### PR TITLE
fix(viewer): clarify dogfood UX cleanup

### DIFF
--- a/docs/plans/2026-05-12-mixed-sharing-domain-dogfood-validation.md
+++ b/docs/plans/2026-05-12-mixed-sharing-domain-dogfood-validation.md
@@ -1,0 +1,121 @@
+# Mixed Sharing-domain dogfood validation
+
+**Date:** 2026-05-12  
+**Status:** completed with follow-ups  
+**Related:** `codemem-vsn0.5`, `2026-05-06-sharing-domain-release-readiness-ux-design.md`, `2026-05-08-sharing-domain-guided-setup-flow.md`
+
+## Scope
+
+Validate the 0.31 Projects and Sharing-domain workflow against a realistic mixed setup:
+
+- personal projects and memories;
+- work/client projects and memories;
+- OSS/dev projects and memories;
+- at least one always-on peer or always-on-peer stand-in;
+- project/worktree rows with imperfect metadata.
+
+The purpose is product validation, not release automation. File confusing states as follow-up Beads instead of expanding this slice.
+
+## Invariants to verify
+
+- Sharing domain (`scope_id`) remains the hard access boundary.
+- Project, folder, git remote, branch, and workspace identity are hints or retrieval labels, not access grants.
+- Changing a project row's Sharing domain affects future scope resolution only; it does not recall already-copied data.
+- Changing a row's project updates project retrieval/grouping only; it does not change Sharing-domain grants.
+- Coordinator/group context and project filters only narrow or organize already-authorized sync.
+
+## Current dogfood findings already addressed
+
+- Projects tab could show fresh HTML with stale JavaScript, making the new tab appear but not route. Fixed in PR `#1081` with cache-safe viewer shell and bundle headers.
+- Projects auto-refresh collapsed expanded rows. Fixed in PR `#1082` by preserving expanded row state by workspace identity.
+- Projects auto-refresh reset an in-progress Sharing-domain dropdown selection. Fixed in PR `#1082` by preserving draft domain selections by workspace identity until save/remove succeeds.
+- Duplicate display names (common for worktrees) were treated as persistent attention states. Fixed in PR `#1082`; duplicate-name collisions are informational in inventory and still require confirmation before non-local assignment.
+- Projects cards were too dense at 50/page. Fixed in PR `#1082`; Projects requests 25/page.
+- Rows with correct workspace identity but wrong stored project were hard to fix from Feed. Fixed in PR `#1083`; Projects rows can now use **Change project…** to update `sessions.project` while leaving Sharing-domain assignment unchanged.
+- Mapping-only rows with no sessions exposed a guaranteed-failing **Change project…** action. Fixed in PR `#1083`; the action is disabled with explanatory title text.
+
+## Follow-up Beads filed during validation
+
+- `codemem-m1wy` — Clarify the two-step Sharing-domain guardrail confirmation copy (`Save domain` vs `Confirm and save`).
+- `codemem-vsn0.7` — Flag peer/domain grant role mismatches before treating sync as validated.
+- `codemem-vsn0.8` — Reorder viewer tabs to follow the primary workflow: Feed, Projects, Sync, Health, Coordinator Admin.
+
+## 2026-05-12 local validation pass
+
+The local viewer was restarted from the current `main` checkout so the Projects API reflected the merged Projects implementation rather than a stale background server. Evidence below is intentionally anonymized.
+
+Observed setup:
+
+- Sync is enabled with two known peers.
+- Both peers were syncing successfully in the later validation pass.
+- Sharing-domain settings exposed four domains: local-only, legacy-review, personal, and OSS.
+- No work/client Sharing domain was configured in this local pass, so work/client grant-boundary acceptance criteria remain unverified.
+- Projects inventory returned 39 rows in the first pass and 39 rows in the later pass; the later pass resolved 33 local-only, 3 personal, and 3 OSS rows.
+- Inventory identity sources included cwd, git remote, workspace id, and one unmapped row.
+- Five duplicate display-name groups were present; duplicates did not appear as a persistent review status in the inventory counts.
+- Five explicit mappings were present in the first pass and six in the later pass; no mapping-only zero-session row was present in this database snapshot.
+- Peer grants showed one peer with no domain grants and one peer with two explicit domain grants plus project filters. This confirmed the UI/API model can represent "filters narrow authorized domains" separately from domain grants.
+- The peer intended to represent the work/client side did not have a work/client-only grant in this setup. Instead, the available grants were personal and OSS. That is not a safe pass for the personal/work boundary acceptance criteria; it is a dogfood setup/product-follow-up finding.
+- The assignment confirmation flow is behaviorally correct: selecting a Sharing domain and clicking **Save domain** performs the initial save attempt, then backend guardrails require the user to acknowledge warnings with **Confirm and save**. The copy is the problem. It stacks an unmapped/local-only explanation with a duplicate-display-name collision warning, without making it clear that the second action is the required guardrail acknowledgement before saving. This belongs under `codemem-m1wy`.
+- Aside from confirmation-copy clarity, the Projects workflow behaved as expected in dogfood. The initial top-level order was Feed, Health, Projects, Sync, Coordinator Admin; Projects belonged closer to Sync because it explains what data can sync, while Health is diagnostic. The cleanup changed the order to Feed, Projects, Sync, Health, Coordinator Admin.
+
+Validation outcome for this pass: useful evidence plus concrete follow-ups. The active setup did not provide a clean work/client-domain boundary check, so the peer-role mismatch is tracked separately instead of expanding this validation slice.
+
+## 2026-05-12 cleanup fixes
+
+Follow-up fixes landed from the dogfood findings:
+
+- The guardrail confirmation panel now states that confirmation is required before saving, explains that codemem can save after the warnings are acknowledged, separates warning categories, and labels the final action **I understand, save domain**.
+- Viewer tabs now follow the primary workflow order: Feed, Projects, Sync, Health, Coordinator Admin.
+
+These fixes close the actionable UI findings from this validation pass. The remaining peer-role mismatch is tracked separately by `codemem-vsn0.7` as guided-setup/review work rather than a blocker for this dogfood validation record.
+
+## Manual validation checklist
+
+### 1. Project inventory sanity
+
+- [ ] Search finds known personal, work/client, and OSS projects by project name. _(partial: personal and OSS inventory present; work/client domain not configured in this pass)_
+- [x] Search finds worktrees by cwd, git remote, branch, or workspace identity without exposing private path details in committed notes.
+- [x] Duplicate display names no longer produce persistent **Review before mapping** noise.
+- [x] Duplicate display names still produce a confirmation panel when assigning a non-local Sharing domain. _(copy clarified by `codemem-m1wy`)_
+- [ ] Saved mappings with no sessions are visible but cannot invoke **Change project…**. _(not observed in this database snapshot)_
+
+### 2. Project correction
+
+- [ ] A row with wrong stored project but correct workspace identity can be changed with **Change project…**.
+- [ ] The prompt previews affected session and memory counts.
+- [ ] After correction, project-filtered retrieval finds those memories under the corrected project.
+- [ ] Sharing-domain assignment remains unchanged after project correction.
+
+### 3. Sharing-domain assignment
+
+- [ ] Personal project rows resolve to a personal/local domain only after explicit confirmation.
+- [ ] Work/client project rows resolve to work/client domains only after explicit confirmation.
+- [ ] OSS/dev project rows can map to an OSS domain independently of personal/work domains.
+- [ ] **Keep local-only** leaves the row local-only and does not grant peers access.
+- [ ] **Remove mapping** falls back to the next resolution rule and explains that future writes change only by resolution.
+- [x] Guardrail confirmation copy is understandable enough to proceed safely; confusing copy should reference `codemem-m1wy`. _(fixed: the panel now explains the required acknowledgement step and uses **I understand, save domain**)_
+
+### 4. Peer grant boundaries
+
+- [ ] Work peer is granted only work/client domains. _(blocked: no work/client Sharing domain configured in this pass)_
+- [ ] Personal peer is granted only personal domains.
+- [ ] OSS peer is granted only OSS domains.
+- [ ] Always-on peer receives only explicitly selected domains. _(partial: one peer had no grants; one peer had explicit grants)_
+- [ ] Project include/exclude filters are shown as narrowing rules only.
+- [ ] A peer without a domain grant cannot receive that domain even if its project filter would match.
+
+### 5. Retrieval/sync spot checks
+
+- [ ] Memory pack/search for a project includes all sessions whose stored `sessions.project` matches that project label, across workspace identities.
+- [ ] Correcting `sessions.project` moves retrieval to the corrected project.
+- [ ] Sync/retrieval behavior respects `scope_id` visibility before project filters.
+- [ ] Personal data is not visible to work peers. _(blocked: no work/client Sharing domain configured in this pass)_
+- [ ] Work/client data is not visible to personal peers. _(blocked: no work/client Sharing domain configured in this pass)_
+- [ ] OSS data can be shared independently. _(partial: OSS domain and explicit grants are present; peer-side visibility still needs spot check)_
+
+## Notes for recording evidence
+
+Use anonymized labels in committed docs: `personal`, `work-client`, `oss-dev`, `anchor-peer`. Do not commit local absolute paths, internal hostnames, private repo names, device IDs, or screenshots containing them.
+
+If a screenshot is useful, redact it before committing or keep it outside the repo and summarize the finding here.

--- a/packages/ui/src/lib/state.test.ts
+++ b/packages/ui/src/lib/state.test.ts
@@ -10,6 +10,10 @@ import {
 } from "./state";
 
 describe("Viewer tab routing", () => {
+	it("orders tabs around the primary review and sync workflow", () => {
+		expect(ALL_TAB_IDS).toEqual(["feed", "projects", "sync", "health", "coordinator-admin"]);
+	});
+
 	it("recognizes Projects as a routable top-level tab", () => {
 		expect(ALL_TAB_IDS).toContain("projects");
 		expect(parseTabFromHash("#projects")).toBe("projects");

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -3,8 +3,8 @@
 import type { UiSyncViewModel } from "../tabs/sync/view-model";
 
 export type RefreshState = "idle" | "refreshing" | "paused" | "error";
-export type TabId = "feed" | "health" | "projects" | "sync" | "coordinator-admin";
-export const ALL_TAB_IDS: TabId[] = ["feed", "health", "projects", "sync", "coordinator-admin"];
+export type TabId = "feed" | "projects" | "sync" | "health" | "coordinator-admin";
+export const ALL_TAB_IDS: TabId[] = ["feed", "projects", "sync", "health", "coordinator-admin"];
 
 /* ── Cached server payload shapes ─────────────────────────── */
 

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -9,11 +9,11 @@ vi.mock("../lib/api", () => ({
 	saveSharingDomainProjectMapping: vi.fn(),
 	SharingDomainGuardrailConfirmationError: class SharingDomainGuardrailConfirmationError extends Error {
 		requiredGuardrailTokens: string[];
-		guardrailWarnings: Array<{ message: string }>;
+		guardrailWarnings: Array<{ code?: string; message: string }>;
 
 		constructor(input: {
 			required_guardrail_tokens?: string[];
-			guardrail_warnings?: Array<{ message: string }>;
+			guardrail_warnings?: Array<{ code?: string; message: string }>;
 		}) {
 			super("Sharing domain guardrail confirmation required");
 			this.requiredGuardrailTokens = input.required_guardrail_tokens ?? [];
@@ -214,6 +214,119 @@ describe("Projects tab", () => {
 		expect(
 			(document.querySelector(".project-domain-select") as HTMLSelectElement | null)?.value,
 		).toBe("exampleco-work");
+	});
+
+	it("explains backend guardrail confirmation as a required acknowledgement", async () => {
+		const refresh = vi.fn();
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 25,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		});
+		vi.mocked(api.saveSharingDomainProjectMapping).mockRejectedValueOnce(
+			new api.SharingDomainGuardrailConfirmationError({
+				guardrail_warnings: [
+					{
+						code: "unknown_project_local_only",
+						message:
+							"No Sharing domain mapping matches this project, so future memories stay Local only until you assign one.",
+						requires_confirmation: true,
+						severity: "warning",
+					},
+					{
+						code: "basename_collision_review",
+						message:
+							"Another workspace is also named api. Review the git remote or path before assigning a non-local Sharing domain.",
+						requires_confirmation: true,
+						severity: "warning",
+					},
+				],
+				required_guardrail_tokens: ["token-1", "token-2"],
+			}),
+		);
+
+		initProjectsTab(refresh);
+		await loadProjectsData();
+		const select = document.querySelector(".project-domain-select") as HTMLSelectElement | null;
+		if (!select) throw new Error("select missing");
+		select.value = "exampleco-work";
+		select.dispatchEvent(new Event("change"));
+		const save = Array.from(document.querySelectorAll("button")).find(
+			(button) => button.textContent === "Save domain",
+		) as HTMLButtonElement | undefined;
+		save?.click();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await loadProjectsData();
+
+		expect(document.body.textContent).toContain(
+			"Confirmation required before saving this Sharing domain.",
+		);
+		expect(document.body.textContent).toContain(
+			"Codemem can save this change after you acknowledge the checks below.",
+		);
+		expect(document.body.textContent).toContain("Current behavior:");
+		expect(document.body.textContent).toContain("Name collision:");
+		expect(document.body.textContent).toContain("I understand, save domain");
+		expect(document.body.textContent).not.toContain("Confirm and save");
+	});
+
+	it("clears stale guardrail confirmation when the draft domain changes", async () => {
+		const refresh = vi.fn();
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 25,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		});
+		vi.mocked(api.saveSharingDomainProjectMapping).mockRejectedValueOnce(
+			new api.SharingDomainGuardrailConfirmationError({
+				guardrail_warnings: [
+					{
+						code: "basename_collision_review",
+						message:
+							"Another workspace is also named api. Review the git remote or path before assigning a non-local Sharing domain.",
+						requires_confirmation: true,
+						severity: "warning",
+					},
+				],
+				required_guardrail_tokens: ["token-1"],
+			}),
+		);
+
+		initProjectsTab(refresh);
+		await loadProjectsData();
+		const select = document.querySelector(".project-domain-select") as HTMLSelectElement | null;
+		if (!select) throw new Error("select missing");
+		select.value = "exampleco-work";
+		select.dispatchEvent(new Event("change"));
+		const save = Array.from(document.querySelectorAll("button")).find(
+			(button) => button.textContent === "Save domain",
+		) as HTMLButtonElement | undefined;
+		save?.click();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await loadProjectsData();
+		expect(document.body.textContent).toContain("I understand, save domain");
+		const staleConfirm = Array.from(document.querySelectorAll("button")).find(
+			(button) => button.textContent === "I understand, save domain",
+		) as HTMLButtonElement | undefined;
+		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledTimes(1);
+
+		const nextSelect = document.querySelector(".project-domain-select") as HTMLSelectElement | null;
+		if (!nextSelect) throw new Error("select missing after refresh");
+		nextSelect.value = "local-default";
+		nextSelect.dispatchEvent(new Event("change"));
+		staleConfirm?.click();
+		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledTimes(1);
+		await loadProjectsData();
+
+		expect(document.body.textContent).not.toContain("I understand, save domain");
+		expect(document.body.textContent).not.toContain(
+			"Confirmation required before saving this Sharing domain.",
+		);
+		expect(refresh).toHaveBeenCalled();
 	});
 
 	it("surfaces suggestions and attention warnings on the collapsed card", async () => {

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -74,6 +74,22 @@ function assignableScopes(): SharingDomainScope[] {
 	return scopes.filter((scope) => scope.scope_id !== "legacy-shared-review");
 }
 
+function guardrailHeading(warning: ProjectScopeGuardrailWarning): string {
+	switch (warning.code) {
+		case "unknown_project_local_only":
+			return "Current behavior";
+		case "basename_collision_review":
+			return "Name collision";
+		case "scope_reassignment_old_copies":
+			return "Previous copies";
+		case "broad_org_domain_pattern":
+		case "home_directory_org_domain_pattern":
+			return "Broad mapping";
+		default:
+			return "Review item";
+	}
+}
+
 async function saveProjectMapping(
 	project: ProjectScopeInventoryProject,
 	scopeId: string,
@@ -221,8 +237,10 @@ function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElemen
 	save.addEventListener("click", () => void saveProjectMapping(project, select.value));
 	select.addEventListener("change", () => {
 		draftDomainSelections.set(project.workspace_identity, select.value);
+		pendingConfirmations.delete(project.workspace_identity);
 		save.textContent = "Save domain";
 		save.disabled = false;
+		refreshProjects?.();
 	});
 
 	const keepLocal = document.createElement("button");
@@ -255,21 +273,33 @@ function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElemen
 		warningBox.className = "settings-note project-guardrail-confirmation";
 		warningBox.setAttribute("role", "alert");
 		const title = document.createElement("strong");
-		title.textContent = "Review before saving this Sharing domain.";
+		title.textContent = "Confirmation required before saving this Sharing domain.";
+		const intro = document.createElement("p");
+		intro.textContent =
+			"Codemem can save this change after you acknowledge the checks below. Verify the workspace details, then confirm to complete the save.";
 		const list = document.createElement("ul");
 		for (const warning of pending.warnings) {
 			const item = document.createElement("li");
-			item.textContent = warning.message;
+			const itemTitle = document.createElement("strong");
+			itemTitle.textContent = `${guardrailHeading(warning)}: `;
+			const message = document.createElement("span");
+			message.textContent = warning.message;
+			item.append(itemTitle, message);
 			list.appendChild(item);
 		}
 		const confirm = document.createElement("button");
 		confirm.className = "settings-button";
 		confirm.type = "button";
-		confirm.textContent = "Confirm and save";
-		confirm.addEventListener(
-			"click",
-			() => void saveProjectMapping(project, pending.scopeId, pending.requiredGuardrailTokens),
-		);
+		confirm.textContent = "I understand, save domain";
+		confirm.addEventListener("click", () => {
+			const currentPending = pendingConfirmations.get(project.workspace_identity);
+			if (!currentPending || currentPending.scopeId !== select.value) return;
+			void saveProjectMapping(
+				project,
+				currentPending.scopeId,
+				currentPending.requiredGuardrailTokens,
+			);
+		});
 		const cancel = document.createElement("button");
 		cancel.className = "settings-button";
 		cancel.type = "button";
@@ -278,7 +308,7 @@ function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElemen
 			pendingConfirmations.delete(project.workspace_identity);
 			refreshProjects?.();
 		});
-		warningBox.append(title, list, confirm, cancel);
+		warningBox.append(title, intro, list, confirm, cancel);
 		actions.appendChild(warningBox);
 	}
 	return actions;

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -3399,9 +3399,9 @@
     <!-- ── Tab bar ─────────────────────────────────────────── -->
     <nav class="tab-bar" aria-label="Main navigation">
       <button class="tab-btn active" id="tabBtn-feed">Feed</button>
-      <button class="tab-btn" id="tabBtn-health">Health</button>
       <button class="tab-btn" id="tabBtn-projects">Projects</button>
       <button class="tab-btn" id="tabBtn-sync">Sync</button>
+      <button class="tab-btn" id="tabBtn-health">Health</button>
       <button class="tab-btn" id="tabBtn-coordinator-admin">Coordinator Admin</button>
     </nav>
     <div id="toastRoot"></div>


### PR DESCRIPTION
## Description
Clarifies the Projects Sharing-domain confirmation flow from dogfood and reorders the viewer tabs around the primary review/sync workflow. Also records the mixed Sharing-domain validation pass and follow-up findings.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
  - `pnpm run tsc`
  - `pnpm run lint` (only pre-existing info-level `noExtraBooleanCast` warnings in `FeedItemCard.tsx`)
  - `pnpm exec vitest run packages/ui/src/lib/state.test.ts packages/ui/src/tabs/projects.test.ts`
  - `pnpm --filter @codemem/ui build`
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
