### PR TITLE
fix(sync): flag peer grant role mismatches

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -20,6 +20,7 @@ import { openSyncConfirmDialog } from "../sync-dialogs";
 import {
 	derivePeerAuthorizedDomainsView,
 	derivePeerDirection,
+	derivePeerGrantRoleMismatchView,
 	derivePeerProjectNarrowingView,
 	derivePeerScopeRejectionsView,
 	derivePeerTrustSummary,
@@ -190,6 +191,7 @@ function SyncPeerCard({
 	const directionHint = DIRECTION_GLYPH[derivePeerDirection(peer)];
 	const peerStatus: SyncPeerStatus = peer.status || {};
 	const authorizedDomains = derivePeerAuthorizedDomainsView(peer);
+	const grantRoleMismatch = derivePeerGrantRoleMismatchView(peer);
 	const scopeRejections = derivePeerScopeRejectionsView(peer);
 	const scope = peer.project_scope || {};
 	const projectNarrowing = derivePeerProjectNarrowingView(scope);
@@ -492,6 +494,14 @@ function SyncPeerCard({
 									{scopeRejections.badgeLabel}
 								</span>
 							) : null}
+							{grantRoleMismatch.badgeLabel ? (
+								<span
+									className="badge badge-offline"
+									title="Review whether explicit Sharing-domain grants match this device's intended role."
+								>
+									{grantRoleMismatch.badgeLabel}
+								</span>
+							) : null}
 							{peer.discovered_via_group_id ? (
 								<span
 									className="badge actor-badge"
@@ -594,6 +604,13 @@ function SyncPeerCard({
 									</li>
 								))}
 							</ul>
+						) : null}
+						{grantRoleMismatch.isVisible ? (
+							<div className="settings-note" role="status">
+								<strong>{grantRoleMismatch.title}</strong>
+								<div>{grantRoleMismatch.message}</div>
+								<div>{grantRoleMismatch.detail}</div>
+							</div>
 						) : null}
 						<div className="peer-meta">{projectNarrowing.note}</div>
 

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -4,6 +4,7 @@ import {
 	deriveCoordinatorApprovalSummary,
 	deriveDuplicatePeople,
 	derivePeerAuthorizedDomainsView,
+	derivePeerGrantRoleMismatchView,
 	derivePeerProjectNarrowingView,
 	derivePeerScopeRejectionsView,
 	derivePeerTrustSummary,
@@ -214,6 +215,86 @@ describe("derivePeerAuthorizedDomainsView", () => {
 		expect(view.isWarning).toBe(false);
 		expect(view.domains.map((domain) => domain.label)).toEqual(["Acme Work", "Personal Devices"]);
 		expect(view.domains[0]?.detail).toBe("team · coordinator · member role");
+	});
+});
+
+describe("derivePeerGrantRoleMismatchView", () => {
+	it("flags coordinator-discovered peers with personal or OSS grants but no work/client-like grant", () => {
+		const view = derivePeerGrantRoleMismatchView({
+			authorized_scopes: [
+				{ label: "Personal", scope_id: "personal" },
+				{ label: "OSS", scope_id: "oss" },
+			],
+			discovered_via_group_id: "team-alpha",
+		});
+
+		expect(view.isVisible).toBe(true);
+		expect(view.badgeLabel).toBe("Review domain fit");
+		expect(view.message).toContain("personal or OSS Sharing-domain grants");
+		expect(view.message).toContain("no separate work/client-like domain grant");
+		expect(view.detail).toContain("project filters only narrow already-authorized domains");
+	});
+
+	it("does not flag peers once a separate work/client-like grant is present", () => {
+		const view = derivePeerGrantRoleMismatchView({
+			authorized_scopes: [
+				{ label: "Personal", scope_id: "personal" },
+				{ label: "Work Client", scope_id: "client-work" },
+			],
+			discovered_via_group_id: "team-alpha",
+		});
+
+		expect(view.isVisible).toBe(false);
+	});
+
+	it("counts local work scopes as valid work/client-like grants", () => {
+		const view = derivePeerGrantRoleMismatchView({
+			authorized_scopes: [
+				{ authority_type: "local", label: "Personal", scope_id: "personal" },
+				{ authority_type: "local", label: "Work Client", scope_id: "client-work" },
+			],
+			discovered_via_group_id: "team-alpha",
+		});
+
+		expect(view.isVisible).toBe(false);
+	});
+
+	it("counts explicitly work-like local scope names as valid grants", () => {
+		const view = derivePeerGrantRoleMismatchView({
+			authorized_scopes: [
+				{ authority_type: "local", label: "Personal", scope_id: "personal" },
+				{ authority_type: "local", label: "Local Work", scope_id: "local-client" },
+			],
+			discovered_via_group_id: "team-alpha",
+		});
+
+		expect(view.isVisible).toBe(false);
+	});
+
+	it("does not treat substring matches inside work domain names as personal grants", () => {
+		const view = derivePeerGrantRoleMismatchView({
+			authorized_scopes: [{ label: "Acme Work", scope_id: "acme-work" }],
+			discovered_via_group_id: "team-alpha",
+		});
+
+		expect(view.isVisible).toBe(false);
+	});
+
+	it("does not treat substring matches inside public-looking names as OSS grants", () => {
+		const view = derivePeerGrantRoleMismatchView({
+			authorized_scopes: [{ label: "Publicis Client", scope_id: "publicis-client" }],
+			discovered_via_group_id: "team-alpha",
+		});
+
+		expect(view.isVisible).toBe(false);
+	});
+
+	it("does not infer role mismatches without coordinator or group context", () => {
+		const view = derivePeerGrantRoleMismatchView({
+			authorized_scopes: [{ label: "Personal", scope_id: "personal" }],
+		});
+
+		expect(view.isVisible).toBe(false);
 	});
 });
 

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -15,12 +15,14 @@ export { deviceNeedsFriendlyName, resolveFriendlyDeviceName } from "./view-model
 export {
 	derivePeerAuthorizedDomainsView,
 	derivePeerDirection,
+	derivePeerGrantRoleMismatchView,
 	derivePeerProjectNarrowingView,
 	derivePeerScopeRejectionsView,
 	derivePeerTrustSummary,
 	derivePeerUiStatus,
 	type PeerAuthorizedDomainsView,
 	type PeerAuthorizedDomainViewItem,
+	type PeerGrantRoleMismatchView,
 	type PeerProjectNarrowingView,
 	type PeerScopeRejectionsView,
 } from "./view-model/peer-status";

--- a/packages/ui/src/tabs/sync/view-model/peer-status.ts
+++ b/packages/ui/src/tabs/sync/view-model/peer-status.ts
@@ -183,6 +183,14 @@ export interface PeerAuthorizedDomainsView {
 	emptyMessage: string;
 }
 
+export interface PeerGrantRoleMismatchView {
+	isVisible: boolean;
+	badgeLabel: string | null;
+	title: string;
+	message: string;
+	detail: string;
+}
+
 export function derivePeerAuthorizedDomainsView(peer: PeerLike): PeerAuthorizedDomainsView {
 	const domains = (Array.isArray(peer.authorized_scopes) ? peer.authorized_scopes : [])
 		.map((scope: PeerAuthorizedScopeLike): PeerAuthorizedDomainViewItem | null => {
@@ -212,6 +220,80 @@ export function derivePeerAuthorizedDomainsView(peer: PeerLike): PeerAuthorizedD
 		domains,
 		emptyMessage:
 			"No Sharing-domain grants exist for this device yet. Project filters below cannot send data by themselves.",
+	};
+}
+
+const PERSONAL_SCOPE_WORDS = ["personal", "private", "home", "mine", "me"];
+const OSS_SCOPE_WORDS = ["oss", "open source", "opensource", "community", "public"];
+const WORK_LIKE_SCOPE_WORDS = ["work", "client"];
+const LOCAL_SCOPE_WORDS = ["local", "legacy", "review"];
+
+function scopeSearchText(scope: PeerAuthorizedScopeLike): string {
+	return [scope.scope_id, scope.label, scope.kind, scope.authority_type]
+		.map((value) => cleanText(value) ?? "")
+		.join(" ")
+		.toLowerCase();
+}
+
+function scopeIdentitySearchText(scope: PeerAuthorizedScopeLike): string {
+	return [scope.scope_id, scope.label, scope.kind]
+		.map((value) => cleanText(value) ?? "")
+		.join(" ")
+		.toLowerCase();
+}
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function hasScopeWord(scope: PeerAuthorizedScopeLike, words: string[]): boolean {
+	const text = scopeSearchText(scope);
+	return words.some((word) => {
+		const escaped = escapeRegex(word.toLowerCase());
+		return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`).test(text);
+	});
+}
+
+function isPersonalOrOssScope(scope: PeerAuthorizedScopeLike): boolean {
+	return hasScopeWord(scope, PERSONAL_SCOPE_WORDS) || hasScopeWord(scope, OSS_SCOPE_WORDS);
+}
+
+function isLocalOrLegacyScope(scope: PeerAuthorizedScopeLike): boolean {
+	const text = scopeIdentitySearchText(scope);
+	return LOCAL_SCOPE_WORDS.some((word) => {
+		const escaped = escapeRegex(word.toLowerCase());
+		return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`).test(text);
+	});
+}
+
+function isWorkLikeScope(scope: PeerAuthorizedScopeLike): boolean {
+	return (
+		!isPersonalOrOssScope(scope) &&
+		(!isLocalOrLegacyScope(scope) || hasScopeWord(scope, WORK_LIKE_SCOPE_WORDS))
+	);
+}
+
+export function derivePeerGrantRoleMismatchView(peer: PeerLike): PeerGrantRoleMismatchView {
+	const scopes = Array.isArray(peer.authorized_scopes) ? peer.authorized_scopes : [];
+	const hasCoordinatorContext = Boolean(
+		cleanText(peer.discovered_via_group_id) || cleanText(peer.discovered_via_coordinator_id),
+	);
+	if (!hasCoordinatorContext || scopes.length === 0) {
+		return { badgeLabel: null, detail: "", isVisible: false, message: "", title: "" };
+	}
+	const hasPersonalOrOssGrant = scopes.some(isPersonalOrOssScope);
+	const hasWorkLikeGrant = scopes.some(isWorkLikeScope);
+	if (!hasPersonalOrOssGrant || hasWorkLikeGrant) {
+		return { badgeLabel: null, detail: "", isVisible: false, message: "", title: "" };
+	}
+	return {
+		badgeLabel: "Review domain fit",
+		detail:
+			"Coordinator/group context helps find the device, and project filters only narrow already-authorized domains. Neither one grants a missing work/client domain.",
+		isVisible: true,
+		message:
+			"This coordinator-discovered device has personal or OSS Sharing-domain grants, but no separate work/client-like domain grant. If this device is meant for work/client sync, add that Sharing domain explicitly before treating sync as validated.",
+		title: "Check this device's Sharing-domain role",
 	};
 }
 

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -157,6 +157,8 @@ export interface PeerClaimedLocalActorScopeLike {
 export interface PeerLike {
 	peer_device_id?: string;
 	name?: string;
+	discovered_via_coordinator_id?: string | null;
+	discovered_via_group_id?: string | null;
 	has_error?: boolean;
 	last_error?: string;
 	fingerprint?: string;


### PR DESCRIPTION
## Description
Flags coordinator-discovered devices whose explicit Sharing-domain grants look like personal/OSS-only access without a separate work/client-like grant. This makes the dogfood mismatch visible without relying on peer names and reinforces that coordinator context and project filters do not grant missing domains.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
  - `pnpm exec vitest run packages/ui/src/tabs/sync/view-model.test.ts`
  - `pnpm run tsc`
  - `pnpm run lint` (only pre-existing info-level `noExtraBooleanCast` warnings in `FeedItemCard.tsx`)
  - `pnpm --filter @codemem/ui build`
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
