### PR TITLE
feat(sync): group legacy shared review

### DIFF
--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -122,6 +122,7 @@ export interface CachedLegacySharedReview {
 	memory_count?: number;
 	has_data?: boolean;
 	last_updated_at?: string | null;
+	groups?: unknown[];
 }
 
 export interface DiscoveredDevice {

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
@@ -1,0 +1,69 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SyncSharingReview } from "./sync-sharing-review";
+
+let mount: HTMLDivElement | null = null;
+
+function renderReview(element: Parameters<typeof render>[0]) {
+	mount = document.createElement("div");
+	document.body.appendChild(mount);
+	act(() => {
+		render(element, mount as HTMLDivElement);
+	});
+	return mount;
+}
+
+afterEach(() => {
+	if (mount) {
+		act(() => {
+			render(null, mount as HTMLDivElement);
+		});
+		mount.remove();
+		mount = null;
+	}
+	document.body.innerHTML = "";
+	vi.clearAllMocks();
+});
+
+describe("SyncSharingReview", () => {
+	it("renders grouped legacy shared review without automatic promotion", () => {
+		const onLegacyReview = vi.fn();
+		const root = renderReview(
+			<SyncSharingReview
+				items={[]}
+				legacyReview={{
+					groups: [
+						{
+							displayProject: "oss-dev",
+							identitySource: "git_remote",
+							lastUpdatedAt: "2026-05-12T00:00:00Z",
+							memoryCount: 3,
+							suggestedScopeId: "oss",
+							suggestionReason:
+								"Existing project mapping can be reviewed as a destination, but legacy data is not promoted automatically.",
+							workspaceIdentity: "https://git.example.invalid/oss/dev.git",
+						},
+					],
+					memoryCount: 3,
+					scopeId: "legacy-shared-review",
+				}}
+				onLegacyReview={onLegacyReview}
+				onReview={() => {}}
+			/>,
+		);
+
+		expect(root.textContent).toContain("Legacy shared review");
+		expect(root.textContent).toContain("3 historical shared memories");
+		expect(root.textContent).toContain("oss-dev · git_remote · suggested oss");
+		expect(root.textContent).toContain("legacy data is not promoted automatically");
+		expect(root.textContent).toContain(
+			"Remapping or revocation does not erase data already copied",
+		);
+
+		const button = root.querySelector("button");
+		expect(button?.textContent).toBe("Review projects");
+		button?.click();
+		expect(onLegacyReview).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
@@ -8,13 +8,25 @@ export interface SyncSharingReviewItem {
 }
 
 export interface SyncLegacySharedReviewItem {
+	groups?: SyncLegacySharedReviewGroup[];
 	memoryCount: number;
 	scopeId: string;
+}
+
+export interface SyncLegacySharedReviewGroup {
+	displayProject: string;
+	identitySource: string;
+	lastUpdatedAt: string | null;
+	memoryCount: number;
+	suggestedScopeId: string | null;
+	suggestionReason: string | null;
+	workspaceIdentity: string;
 }
 
 type SyncSharingReviewProps = {
 	items: SyncSharingReviewItem[];
 	legacyReview?: SyncLegacySharedReviewItem | null;
+	onLegacyReview?: () => void;
 	onReview: () => void;
 };
 
@@ -46,7 +58,14 @@ function SharingReviewRow({
 	);
 }
 
-function LegacySharedReviewRow({ item }: { item: SyncLegacySharedReviewItem }) {
+function LegacySharedReviewRow({
+	item,
+	onReview,
+}: {
+	item: SyncLegacySharedReviewItem;
+	onReview: () => void;
+}) {
+	const groups = item.groups ?? [];
 	return (
 		<div className="actor-row">
 			<div className="actor-details">
@@ -59,15 +78,45 @@ function LegacySharedReviewRow({ item }: { item: SyncLegacySharedReviewItem }) {
 					placed ambiguous older shared data there conservatively; review mappings before promoting
 					it. Remapping or revocation does not erase data already copied to peers.
 				</div>
+				{groups.length > 0 ? (
+					<ul className="peer-scope-rejections-list" aria-label="Legacy shared review groups">
+						{groups.map((group) => (
+							<li key={group.workspaceIdentity}>
+								<span className="peer-scope-rejection-label">
+									{group.displayProject} · {group.identitySource}
+									{group.suggestedScopeId ? ` · suggested ${group.suggestedScopeId}` : ""}
+								</span>
+								<span className="peer-scope-rejection-count">
+									{group.memoryCount.toLocaleString()}
+								</span>
+								{group.suggestionReason ? (
+									<span className="peer-meta">{group.suggestionReason}</span>
+								) : null}
+							</li>
+						))}
+					</ul>
+				) : null}
+			</div>
+			<div className="actor-actions">
+				<button type="button" className="settings-button" onClick={onReview}>
+					Review projects
+				</button>
 			</div>
 		</div>
 	);
 }
 
-export function SyncSharingReview({ items, legacyReview, onReview }: SyncSharingReviewProps) {
+export function SyncSharingReview({
+	items,
+	legacyReview,
+	onLegacyReview,
+	onReview,
+}: SyncSharingReviewProps) {
 	return (
 		<>
-			{legacyReview ? <LegacySharedReviewRow item={legacyReview} /> : null}
+			{legacyReview ? (
+				<LegacySharedReviewRow item={legacyReview} onReview={onLegacyReview ?? onReview} />
+			) : null}
 			{items.map((item) => (
 				<SharingReviewRow
 					key={`${item.peerName}:${item.actorId}:${item.scopeLabel}`}

--- a/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
@@ -16,6 +16,10 @@ function openFeedSharingReview() {
 	window.location.hash = "feed";
 }
 
+function openProjectsReview() {
+	window.location.hash = "projects";
+}
+
 export function renderSyncSharingReview() {
 	const panel = document.getElementById("syncSharingReview");
 	const meta = document.getElementById("syncSharingReviewMeta");
@@ -26,7 +30,28 @@ export function renderSyncSharingReview() {
 	const legacyRaw = state.lastSyncLegacySharedReview;
 	const legacyCount = Math.max(0, Number(legacyRaw?.memory_count ?? 0));
 	const legacyReview = legacyRaw?.has_data
-		? { memoryCount: legacyCount, scopeId: String(legacyRaw.scope_id || "legacy-shared-review") }
+		? {
+				groups: Array.isArray(legacyRaw.groups)
+					? legacyRaw.groups.map((group) => {
+							const raw = group as Record<string, unknown>;
+							return {
+								displayProject: String(raw.display_project || raw.project || "Unknown project"),
+								identitySource: String(raw.identity_source || "unknown"),
+								lastUpdatedAt: typeof raw.last_updated_at === "string" ? raw.last_updated_at : null,
+								memoryCount: Number(raw.memory_count || 0),
+								suggestedScopeId:
+									typeof raw.suggested_scope_id === "string" ? raw.suggested_scope_id : null,
+								suggestionReason:
+									typeof raw.suggestion_reason === "string" ? raw.suggestion_reason : null,
+								workspaceIdentity: String(
+									raw.workspace_identity || raw.display_project || "unknown",
+								),
+							};
+						})
+					: [],
+				memoryCount: legacyCount,
+				scopeId: String(legacyRaw.scope_id || "legacy-shared-review"),
+			}
 		: null;
 	if (!items.length && !legacyReview) {
 		clearSyncMount(list);
@@ -51,6 +76,11 @@ export function renderSyncSharingReview() {
 	}));
 	renderIntoSyncMount(
 		list,
-		h(SyncSharingReview, { items: reviewItems, legacyReview, onReview: openFeedSharingReview }),
+		h(SyncSharingReview, {
+			items: reviewItems,
+			legacyReview,
+			onLegacyReview: openProjectsReview,
+			onReview: openFeedSharingReview,
+		}),
 	);
 }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2488,7 +2488,7 @@ describe("viewer-server", () => {
 			}
 		});
 
-		it("surfaces legacy shared review summary in sync status", async () => {
+		it("surfaces grouped legacy shared review summary in sync status", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {
 				const _warmup = await app.request("/api/stats");
@@ -2497,10 +2497,43 @@ describe("viewer-server", () => {
 				const now = new Date().toISOString();
 				const session = store.db
 					.prepare(
-						`INSERT INTO sessions(started_at, cwd, project, user, tool_version)
-						 VALUES (?, ?, ?, ?, ?)`,
+						`INSERT INTO sessions(started_at, cwd, project, git_remote, user, tool_version)
+						 VALUES (?, ?, ?, ?, ?, ?)`,
 					)
-					.run(now, "/tmp/codemem-test", "codemem-test", "test", "test");
+					.run(
+						now,
+						"/tmp/codemem-test",
+						"codemem-test",
+						"https://git.example.invalid/oss/codemem-test.git",
+						"test",
+						"test",
+					);
+				const workSession = store.db
+					.prepare(
+						`INSERT INTO sessions(started_at, cwd, project, git_remote, user, tool_version)
+						 VALUES (?, ?, ?, ?, ?, ?)`,
+					)
+					.run(
+						now,
+						"/tmp/work-client-api",
+						"work-client-api",
+						"https://git.example.invalid/exampleco/api.git",
+						"test",
+						"test",
+					);
+				const sameRepoSession = store.db
+					.prepare(
+						`INSERT INTO sessions(started_at, cwd, project, git_remote, user, tool_version)
+						 VALUES (?, ?, ?, ?, ?, ?)`,
+					)
+					.run(
+						now,
+						"/tmp/alternate-worktree",
+						"codemem-test-worktree",
+						"https://git.example.invalid/oss/codemem-test.git",
+						"test",
+						"test",
+					);
 				store.db
 					.prepare(
 						`INSERT INTO memory_items(
@@ -2516,11 +2549,90 @@ describe("viewer-server", () => {
 						now,
 						"legacy-shared-review",
 					);
+				const insertSession = store.db.prepare(
+					`INSERT INTO sessions(started_at, cwd, project, git_remote, user, tool_version)
+					 VALUES (?, ?, ?, ?, ?, ?)`,
+				);
+				const insertLegacyMemory = store.db.prepare(
+					`INSERT INTO memory_items(
+						session_id, kind, title, body_text, created_at, updated_at,
+						visibility, workspace_id, workspace_kind, active, scope_id, metadata_json
+					 ) VALUES (?, 'discovery', ?, ?, ?, ?, 'shared', 'shared:default', 'shared', 1, ?, '{}')`,
+				);
+				for (let index = 0; index < 21; index += 1) {
+					const splitSession = insertSession.run(
+						now,
+						`/tmp/codemem-test-split-${index}`,
+						`codemem-test-split-${index}`,
+						"https://git.example.invalid/oss/codemem-test.git",
+						"test",
+						"test",
+					);
+					insertLegacyMemory.run(
+						Number(splitSession.lastInsertRowid),
+						`Legacy shared split ${index}`,
+						`Legacy shared split body ${index}`,
+						now,
+						now,
+						"legacy-shared-review",
+					);
+				}
+				store.db
+					.prepare(
+						`INSERT INTO memory_items(
+							session_id, kind, title, body_text, created_at, updated_at,
+							visibility, workspace_id, workspace_kind, active, scope_id, metadata_json
+						 ) VALUES (?, 'discovery', ?, ?, ?, ?, 'shared', 'shared:default', 'shared', 1, ?, '{}')`,
+					)
+					.run(
+						Number(sameRepoSession.lastInsertRowid),
+						"Legacy shared same repo",
+						"Legacy shared same repo body",
+						now,
+						now,
+						"legacy-shared-review",
+					);
+				store.db
+					.prepare(
+						`INSERT INTO memory_items(
+							session_id, kind, title, body_text, created_at, updated_at,
+							visibility, workspace_id, workspace_kind, active, deleted_at, scope_id, metadata_json
+						 ) VALUES (?, 'discovery', ?, ?, ?, ?, 'shared', 'shared:default', 'shared', 1, ?, ?, '{}')`,
+					)
+					.run(
+						Number(session.lastInsertRowid),
+						"Deleted legacy shared",
+						"Deleted legacy shared body",
+						now,
+						now,
+						now,
+						"legacy-shared-review",
+					);
+				store.db
+					.prepare(
+						`INSERT INTO memory_items(
+							session_id, kind, title, body_text, created_at, updated_at,
+							visibility, workspace_id, workspace_kind, active, scope_id, metadata_json
+						 ) VALUES (?, 'discovery', ?, ?, ?, ?, 'shared', 'shared:default', 'shared', 1, ?, '{}')`,
+					)
+					.run(
+						Number(workSession.lastInsertRowid),
+						"Legacy shared work",
+						"Legacy shared work body",
+						now,
+						now,
+						"legacy-shared-review",
+					);
 
 				const res = await app.request("/api/sync/status");
 				expect(res.status).toBe(200);
 				const body = (await res.json()) as {
 					legacy_shared_review: {
+						groups: Array<{
+							display_project: string;
+							memory_count: number;
+							workspace_identity: string;
+						}>;
 						has_data: boolean;
 						memory_count: number;
 						scope_id: string;
@@ -2528,9 +2640,23 @@ describe("viewer-server", () => {
 				};
 				expect(body.legacy_shared_review).toMatchObject({
 					has_data: true,
-					memory_count: 1,
+					memory_count: 24,
 					scope_id: "legacy-shared-review",
 				});
+				expect(body.legacy_shared_review.groups).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({
+							display_project: "codemem-test",
+							memory_count: 23,
+							workspace_identity: "https://git.example.invalid/oss/codemem-test.git",
+						}),
+						expect.objectContaining({
+							display_project: "work-client-api",
+							memory_count: 1,
+							workspace_identity: "https://git.example.invalid/exampleco/api.git",
+						}),
+					]),
+				);
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -19,6 +19,7 @@ import {
 	analyzeProjectScopeMappingChangeGuardrails,
 	applyReplicationOps,
 	buildBaseUrl,
+	canonicalWorkspaceIdentity,
 	cleanupNonces,
 	coordinatorArchiveGroupAction,
 	coordinatorCreateGroupAction,
@@ -1255,11 +1256,106 @@ function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> 
 		| { memory_count: number | null; last_updated_at: string | null }
 		| undefined;
 	const memoryCount = Number(row?.memory_count ?? 0);
+	const candidatesByIdentity = new Map(
+		listProjectScopeCandidates(store.db, { limit: null }).map((candidate) => [
+			candidate.workspace_identity,
+			candidate,
+		]),
+	);
+	const groupRows = store.db
+		.prepare(
+			`SELECT s.project,
+			        s.cwd,
+			        s.git_remote,
+			        s.git_branch,
+			        m.workspace_id,
+			        COUNT(*) AS memory_count,
+			        MAX(m.updated_at) AS last_updated_at
+			 FROM memory_items m
+			 LEFT JOIN sessions s ON s.id = m.session_id
+			 WHERE m.scope_id = ?
+			   AND m.active = 1
+			   AND m.deleted_at IS NULL
+			 GROUP BY s.project, s.cwd, s.git_remote, s.git_branch, m.workspace_id
+			 ORDER BY memory_count DESC, last_updated_at DESC`,
+		)
+		.all(LEGACY_SHARED_REVIEW_SCOPE_ID) as Array<{
+		project: string | null;
+		cwd: string | null;
+		git_remote: string | null;
+		git_branch: string | null;
+		workspace_id: string | null;
+		memory_count: number | null;
+		last_updated_at: string | null;
+	}>;
+	const groupsByIdentity = new Map<
+		string,
+		{
+			workspace_identity: string;
+			identity_source: string;
+			display_project: string;
+			memory_count: number;
+			last_updated_at: string | null;
+			suggested_scope_id: string | null;
+			suggestion_reason: string | null;
+		}
+	>();
+	for (const group of groupRows) {
+		const identity = canonicalWorkspaceIdentity({
+			cwd: group.cwd,
+			gitBranch: group.git_branch,
+			gitRemote: group.git_remote,
+			project: group.project,
+			workspaceId: group.workspace_id,
+		});
+		const candidate = candidatesByIdentity.get(identity.value);
+		const resolvedScope = candidate?.resolved_scope_id ?? null;
+		const suggestedScope =
+			resolvedScope &&
+			resolvedScope !== LOCAL_DEFAULT_SCOPE_ID &&
+			resolvedScope !== LEGACY_SHARED_REVIEW_SCOPE_ID
+				? resolvedScope
+				: candidate?.suggested_scope_id;
+		const existing = groupsByIdentity.get(identity.value);
+		const memoryCount = Number(group.memory_count ?? 0);
+		const lastUpdatedAt = group.last_updated_at ?? null;
+		if (existing) {
+			existing.memory_count += memoryCount;
+			if (
+				lastUpdatedAt &&
+				(!existing.last_updated_at || lastUpdatedAt > existing.last_updated_at)
+			) {
+				existing.last_updated_at = lastUpdatedAt;
+			}
+			continue;
+		}
+		groupsByIdentity.set(identity.value, {
+			workspace_identity: identity.value,
+			identity_source: identity.source,
+			display_project: identity.displayProject ?? group.project ?? group.cwd ?? identity.value,
+			memory_count: memoryCount,
+			last_updated_at: lastUpdatedAt,
+			suggested_scope_id: suggestedScope ?? null,
+			suggestion_reason: suggestedScope
+				? (candidate?.suggestion_reason ??
+					"Existing project mapping can be reviewed as a destination, but legacy data is not promoted automatically.")
+				: null,
+		});
+	}
+	const groups = [...groupsByIdentity.values()]
+		.sort(
+			(left, right) =>
+				right.memory_count - left.memory_count ||
+				(right.last_updated_at ?? "").localeCompare(left.last_updated_at ?? "") ||
+				left.workspace_identity.localeCompare(right.workspace_identity),
+		)
+		.slice(0, 20);
 	return {
 		scope_id: LEGACY_SHARED_REVIEW_SCOPE_ID,
 		memory_count: memoryCount,
 		has_data: memoryCount > 0,
 		last_updated_at: row?.last_updated_at ?? null,
+		groups,
 	};
 }
 


### PR DESCRIPTION
## Description
Adds a read-only grouped legacy-shared-review workflow in Sync. The status API now summarizes legacy data by canonical workspace identity with counts and safe suggestions, and the Sync review panel shows grouped rows plus Projects navigation without automatically promoting historical shared data.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
  - `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "legacy shared review" packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx`
  - `pnpm run tsc`
  - `pnpm run lint` (only pre-existing info-level `noExtraBooleanCast` warnings in `FeedItemCard.tsx`)
  - `pnpm --filter @codemem/ui build`
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
