### PR TITLE
feat(sync): guide anchor peer setup

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.test.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.test.tsx
@@ -1,0 +1,61 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SyncInviteJoinPanels } from "./sync-invite-join-panels";
+
+let mount: HTMLDivElement | null = null;
+
+function renderPanels(overrides: Partial<Parameters<typeof SyncInviteJoinPanels>[0]> = {}) {
+	mount = document.createElement("div");
+	document.body.appendChild(mount);
+	act(() => {
+		render(
+			<SyncInviteJoinPanels
+				invitePanel={null}
+				invitePanelOpen={false}
+				inviteRestoreParent={null}
+				joinPanel={null}
+				joinPanelOpen={false}
+				joinRestoreParent={null}
+				pairedPeerCount={1}
+				presenceStatus="posted"
+				onToggleInvitePanel={() => {}}
+				onToggleJoinPanel={() => {}}
+				{...overrides}
+			/>,
+			mount as HTMLDivElement,
+		);
+	});
+	return mount;
+}
+
+afterEach(() => {
+	if (mount) {
+		act(() => {
+			render(null, mount as HTMLDivElement);
+		});
+		mount.remove();
+		mount = null;
+	}
+	document.body.innerHTML = "";
+	vi.clearAllMocks();
+});
+
+describe("SyncInviteJoinPanels", () => {
+	it("guides always-on peer setup without implying special access", () => {
+		const root = renderPanels();
+
+		expect(root.textContent).toContain("Set up an always-on peer");
+		expect(root.textContent).toContain("normal paired device that stays online");
+		expect(root.textContent).toContain("not a coordinator, relay, or special protocol role");
+		expect(root.textContent).toContain("Grant only the explicit Sharing domains");
+		expect(root.textContent).toContain("domains absent from its Authorized Sharing domains list");
+		expect(root.textContent).toContain("project filters only to narrow those authorized domains");
+		expect(root.textContent).toContain("Coordinator discovery only helps devices find each other");
+		expect(root.textContent).toContain("codemem sync enable");
+		expect(root.textContent).toContain("codemem sync pair --payload-only");
+		expect(root.textContent).toContain("codemem coordinator grant-scope-member");
+		expect(root.textContent).toContain("codemem coordinator list-scope-members");
+		expect(root.textContent).toContain("Open anchor-peer deployment guide");
+	});
+});

--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
@@ -92,6 +92,53 @@ function PairingCopyRow() {
 	);
 }
 
+function AnchorPeerGuide({ pairedPeerCount }: { pairedPeerCount: number }) {
+	return (
+		<section className="sync-action" aria-labelledby="anchor-peer-guide-title">
+			<div className="sync-action-text">
+				<span id="anchor-peer-guide-title">Set up an always-on peer.</span>
+				<span className="sync-action-command">
+					An anchor peer is a normal paired device that stays online. It is not a coordinator,
+					relay, or special protocol role.
+				</span>
+				<ol className="sync-action-command">
+					<li>Pair or select the server, desktop, Pi, or VPS you expect to stay online.</li>
+					<li>
+						Grant only the explicit Sharing domains it should carry; domains absent from its
+						Authorized Sharing domains list will not sync to it.
+					</li>
+					<li>
+						Use project filters only to narrow those authorized domains. Coordinator discovery only
+						helps devices find each other.
+					</li>
+					<li>
+						Headless setup: run <code>codemem sync enable</code>, copy a pairing payload with{" "}
+						<code>codemem sync pair --payload-only</code>, then grant only the intended domains with{" "}
+						<code>
+							codemem coordinator grant-scope-member &lt;group&gt; &lt;scope-id&gt;
+							&lt;anchor-device-id&gt;
+						</code>
+						. Verify with <code>codemem coordinator list-scope-members</code>.
+					</li>
+				</ol>
+				<a
+					className="settings-link"
+					href="https://github.com/kunickiaj/codemem/blob/main/docs/anchor-peer-deployment.md"
+					rel="noreferrer"
+					target="_blank"
+				>
+					Open anchor-peer deployment guide
+				</a>
+				<span className="sync-action-command">
+					{pairedPeerCount > 0
+						? "Expand a device below to review what it can and cannot receive before treating it as your always-on peer."
+						: "No paired devices are available yet. Pair the always-on device first, then review its Sharing-domain grants here."}
+				</span>
+			</div>
+		</section>
+	);
+}
+
 function JoinToggleRow({
 	joinPanel,
 	joinPanelOpen,
@@ -212,6 +259,8 @@ export function SyncInviteJoinPanels({
 					onToggle={onToggleInvitePanel}
 				/>
 			) : null}
+
+			{showInviteActions ? <AnchorPeerGuide pairedPeerCount={pairedPeerCount} /> : null}
 
 			{!pairedPeerCount && presenceStatus === "posted" ? <PairingCopyRow /> : null}
 		</>


### PR DESCRIPTION
## Description
Adds an always-on peer setup guide to the Sync onboarding surface. The guide keeps anchor peers framed as ordinary paired devices, points users to explicit Sharing-domain grants, shows that absent domains will not sync, and includes installed CLI/headless steps plus the deployment guide link.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
  - `pnpm exec vitest run packages/ui/src/tabs/sync/components/sync-invite-join-panels.test.tsx`
  - `pnpm run tsc`
  - `pnpm run lint` (only pre-existing info-level `noExtraBooleanCast` warnings in `FeedItemCard.tsx`)
  - `pnpm --filter @codemem/ui build`
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
