### PR TITLE
fix(sync): refine legacy migration review UX

### DIFF
--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -59,9 +59,147 @@ async function loadRuntimeLabel() {
 type RefreshState = "idle" | "refreshing" | "paused" | "error";
 let lastAnnouncedRefreshState: RefreshState | null = null;
 const RECONNECT_POLL_MS = 1500;
+const LEGACY_UPGRADE_NOTICE_DISMISSED_KEY = "codemem-legacy-upgrade-notice-dismissed";
 
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnecting = false;
+let legacyUpgradeNoticeShown = false;
+let legacyUpgradeNoticePreviousFocus: HTMLElement | null = null;
+
+type LegacyUpgradeReviewSummary = {
+	groupCount: number;
+	memoryCount: number;
+};
+
+function readNonNegativeCount(value: unknown, fallback = 0): number {
+	const count = Number(value);
+	return Number.isFinite(count) ? Math.max(0, count) : fallback;
+}
+
+function readLegacyUpgradeReviewSummary(payload: unknown): LegacyUpgradeReviewSummary | null {
+	if (!payload || typeof payload !== "object") return null;
+	const review = (payload as { legacy_shared_review?: unknown }).legacy_shared_review ?? payload;
+	if (!review || typeof review !== "object") return null;
+	const raw = review as {
+		groups?: unknown;
+		has_data?: unknown;
+		memory_count?: unknown;
+		total_group_count?: unknown;
+	};
+	if (raw.has_data !== true) return null;
+	const groups = Array.isArray(raw.groups) ? raw.groups : [];
+	const groupCount = readNonNegativeCount(raw.total_group_count, groups.length);
+	const memoryCount = readNonNegativeCount(raw.memory_count);
+	if (groupCount <= 0 || memoryCount <= 0) return null;
+	return { groupCount, memoryCount };
+}
+
+function isLegacyUpgradeNoticeDismissed(): boolean {
+	try {
+		return localStorage.getItem(LEGACY_UPGRADE_NOTICE_DISMISSED_KEY) === "1";
+	} catch {
+		return false;
+	}
+}
+
+function dismissLegacyUpgradeNoticeIfRequested() {
+	const checkbox = document.getElementById("legacyUpgradeDontShow") as HTMLInputElement | null;
+	if (!checkbox?.checked) return;
+	try {
+		localStorage.setItem(LEGACY_UPGRADE_NOTICE_DISMISSED_KEY, "1");
+	} catch {}
+}
+
+function legacyUpgradeFocusableElements(): HTMLElement[] {
+	const modal = $("legacyUpgradeModal");
+	if (!modal || modal.hidden) return [];
+	return Array.from(
+		modal.querySelectorAll<HTMLElement>(
+			'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+		),
+	).filter((element) => !element.hidden && element.offsetParent !== null);
+}
+
+function focusLegacyUpgradeModal() {
+	const focusable = legacyUpgradeFocusableElements();
+	const primary = $("legacyUpgradeReviewGroups") as HTMLElement | null;
+	(primary && focusable.includes(primary) ? primary : focusable[0])?.focus();
+}
+
+function handleLegacyUpgradeModalKeydown(event: KeyboardEvent) {
+	const modal = $("legacyUpgradeModal");
+	if (!modal || modal.hidden) return;
+	if (event.key === "Escape") {
+		event.preventDefault();
+		dismissLegacyUpgradeNoticeIfRequested();
+		setLegacyUpgradeNotice(false);
+		return;
+	}
+	if (event.key !== "Tab") return;
+	const focusable = legacyUpgradeFocusableElements();
+	if (focusable.length === 0) return;
+	const first = focusable[0];
+	const last = focusable[focusable.length - 1];
+	if (event.shiftKey && document.activeElement === first) {
+		event.preventDefault();
+		last.focus();
+		return;
+	}
+	if (!event.shiftKey && document.activeElement === last) {
+		event.preventDefault();
+		first.focus();
+	}
+}
+
+function setLegacyUpgradeBackgroundInert(inert: boolean) {
+	for (const element of document.querySelectorAll<HTMLElement>(
+		"header, .tab-bar, .tab-panel, #toastRoot, #viewerReconnectOverlay, #settingsDialogMount",
+	)) {
+		if (element.id === "viewerReconnectOverlay" && element.hidden) continue;
+		element.inert = inert;
+		if (inert) element.setAttribute("aria-hidden", "true");
+		else element.removeAttribute("aria-hidden");
+	}
+}
+
+function setLegacyUpgradeNotice(open: boolean, summary?: LegacyUpgradeReviewSummary) {
+	const overlay = $("legacyUpgradeModalBackdrop");
+	const modal = $("legacyUpgradeModal");
+	const summaryEl = $("legacyUpgradeSummary");
+	if (!overlay || !modal || !summaryEl) return;
+	if (summary) {
+		summaryEl.textContent = `${summary.groupCount.toLocaleString()} older ${summary.groupCount === 1 ? "project needs" : "projects need"} a Sharing domain. They contain ${summary.memoryCount.toLocaleString()} older shared memories total; you will review the projects, not individual memories.`;
+	}
+	overlay.hidden = !open;
+	modal.hidden = !open;
+	if (open) {
+		legacyUpgradeNoticePreviousFocus = document.activeElement as HTMLElement | null;
+		document.addEventListener("keydown", handleLegacyUpgradeModalKeydown);
+		focusLegacyUpgradeModal();
+		setLegacyUpgradeBackgroundInert(true);
+		return;
+	}
+	setLegacyUpgradeBackgroundInert(false);
+	document.removeEventListener("keydown", handleLegacyUpgradeModalKeydown);
+	if (legacyUpgradeNoticePreviousFocus && document.contains(legacyUpgradeNoticePreviousFocus)) {
+		legacyUpgradeNoticePreviousFocus.focus();
+	}
+	legacyUpgradeNoticePreviousFocus = null;
+}
+
+function maybeShowLegacyUpgradeNotice(summary: LegacyUpgradeReviewSummary | null) {
+	if (!summary || legacyUpgradeNoticeShown || isLegacyUpgradeNoticeDismissed()) return;
+	legacyUpgradeNoticeShown = true;
+	setLegacyUpgradeNotice(true, summary);
+}
+
+async function checkLegacyUpgradeNotice() {
+	if (legacyUpgradeNoticeShown || isLegacyUpgradeNoticeDismissed()) return;
+	try {
+		const payload = await api.loadSyncStatus(false, "", { includeJoinRequests: false });
+		maybeShowLegacyUpgradeNotice(readLegacyUpgradeReviewSummary(payload));
+	} catch {}
+}
 
 function setReconnectOverlay(open: boolean, detail?: string) {
 	const overlay = $("viewerReconnectOverlay");
@@ -359,6 +497,7 @@ async function doRefresh() {
 		}
 
 		await Promise.all(promises);
+		maybeShowLegacyUpgradeNotice(readLegacyUpgradeReviewSummary(state.lastSyncLegacySharedReview));
 		const nextTab = resolveAccessibleTab(state.activeTab, state.lastCoordinatorAdminStatus);
 		if (nextTab !== state.activeTab) {
 			setActiveTab(nextTab);
@@ -431,8 +570,32 @@ $("viewerReconnectRetry")?.addEventListener("click", async () => {
 	if (!reconnecting) setReconnectOverlay(false);
 });
 
+$("legacyUpgradeReviewGroups")?.addEventListener("click", () => {
+	dismissLegacyUpgradeNoticeIfRequested();
+	setLegacyUpgradeNotice(false);
+	window.location.hash = "sync";
+	setTimeout(
+		() => document.getElementById("syncSharingReview")?.scrollIntoView({ block: "start" }),
+		120,
+	);
+});
+
+$("legacyUpgradeReviewProjects")?.addEventListener("click", () => {
+	dismissLegacyUpgradeNoticeIfRequested();
+	setLegacyUpgradeNotice(false);
+	window.location.hash = "projects";
+});
+
+$("legacyUpgradeNotNow")?.addEventListener("click", () => {
+	dismissLegacyUpgradeNoticeIfRequested();
+	setLegacyUpgradeNotice(false);
+});
+
 // Version label
 loadRuntimeLabel();
+
+// Upgrade notice
+checkLegacyUpgradeNotice();
 
 // Start
 refresh();

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -123,6 +123,8 @@ export interface CachedLegacySharedReview {
 	has_data?: boolean;
 	last_updated_at?: string | null;
 	groups?: unknown[];
+	total_group_count?: number;
+	target_scopes?: unknown[];
 }
 
 export interface DiscoveredDevice {

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -10,13 +10,13 @@ import { openSyncInputDialog } from "./sync/sync-dialogs";
 type RefreshFn = () => void;
 
 const STATUS_OPTIONS = [
-	["", "All statuses"],
-	["local_only", "Local only"],
-	["unmapped", "Unmapped"],
-	["suggested", "Suggested assignment"],
-	["explicitly_mapped", "Explicitly mapped"],
-	["legacy_review", "Legacy review"],
-	["needs_attention", "Review before mapping"],
+	["", "All projects"],
+	["needs_attention", "Needs review"],
+	["suggested", "Has suggestion"],
+	["local_only", "Stays on this device"],
+	["explicitly_mapped", "Already assigned"],
+	["legacy_review", "Older shared data"],
+	["unmapped", "Missing project identity"],
 ] as const;
 
 let refreshProjects: RefreshFn | null = null;
@@ -41,13 +41,13 @@ function formatStatus(status: string): string {
 function formatResolution(reason: string): string {
 	switch (reason) {
 		case "exact_mapping":
-			return "explicit project mapping";
+			return "assigned to a Sharing domain";
 		case "pattern_mapping":
-			return "pattern mapping";
+			return "assigned by matching rule";
 		case "explicit_override":
-			return "explicit override";
+			return "manually assigned";
 		default:
-			return "local-only fallback";
+			return "stays on this device";
 	}
 }
 

--- a/packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx
+++ b/packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx
@@ -190,7 +190,8 @@ describe("SharingDomainsPanel", () => {
 		const root = renderIntoDocument(<SharingDomainsPanel />);
 		await flushEffects();
 
-		expect(root.textContent).toContain("Unmapped and unknown projects stay on Local only");
+		expect(root.textContent).toContain("Use Projects for day-to-day project/domain review");
+		expect(root.textContent).toContain("Open Projects review");
 		expect(root.textContent).toContain("Current default: Local only · local-only fallback");
 
 		const select = root.querySelector("select");

--- a/packages/ui/src/tabs/settings/components/SharingDomainsPanel.tsx
+++ b/packages/ui/src/tabs/settings/components/SharingDomainsPanel.tsx
@@ -199,15 +199,25 @@ export function SharingDomainsPanel() {
 		}
 	};
 
+	const openProjects = () => {
+		window.location.hash = "projects";
+	};
+
 	return (
 		<div className="settings-group">
-			<h3 className="settings-group-title">Sharing domains</h3>
+			<h3 className="settings-group-title">Advanced Sharing-domain mappings</h3>
 			<div className="small">
-				Map known projects to their default Sharing domain. This changes local scope resolution for
-				future writes; it does not grant any peer or coordinator member access by itself.
+				Use Projects for day-to-day project/domain review. This fallback panel exposes the same
+				mapping controls for troubleshooting and recovery.
 			</div>
 			<div className="small">
-				Unmapped and unknown projects stay on Local only until you assign a domain.
+				Saving a mapping changes local scope resolution for future writes; it does not grant any
+				peer or coordinator member access by itself.
+			</div>
+			<div className="section-actions">
+				<button className="settings-button" onClick={openProjects} type="button">
+					Open Projects review
+				</button>
 			</div>
 			{settings ? (
 				<GuardrailMessages

--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.test.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.test.tsx
@@ -42,20 +42,12 @@ afterEach(() => {
 });
 
 describe("SyncInviteJoinPanels", () => {
-	it("guides always-on peer setup without implying special access", () => {
+	it("keeps anchor-peer setup out of the primary invite/join flow", () => {
 		const root = renderPanels();
 
-		expect(root.textContent).toContain("Set up an always-on peer");
-		expect(root.textContent).toContain("normal paired device that stays online");
-		expect(root.textContent).toContain("not a coordinator, relay, or special protocol role");
-		expect(root.textContent).toContain("Grant only the explicit Sharing domains");
-		expect(root.textContent).toContain("domains absent from its Authorized Sharing domains list");
-		expect(root.textContent).toContain("project filters only to narrow those authorized domains");
-		expect(root.textContent).toContain("Coordinator discovery only helps devices find each other");
-		expect(root.textContent).toContain("codemem sync enable");
-		expect(root.textContent).toContain("codemem sync pair --payload-only");
-		expect(root.textContent).toContain("codemem coordinator grant-scope-member");
-		expect(root.textContent).toContain("codemem coordinator list-scope-members");
-		expect(root.textContent).toContain("Open anchor-peer deployment guide");
+		expect(root.textContent).toContain("Accept an invite or pairing");
+		expect(root.textContent).toContain("Invite a teammate");
+		expect(root.textContent).not.toContain("Set up an always-on peer");
+		expect(root.textContent).not.toContain("Open anchor-peer deployment guide");
 	});
 });

--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
@@ -92,53 +92,6 @@ function PairingCopyRow() {
 	);
 }
 
-function AnchorPeerGuide({ pairedPeerCount }: { pairedPeerCount: number }) {
-	return (
-		<section className="sync-action" aria-labelledby="anchor-peer-guide-title">
-			<div className="sync-action-text">
-				<span id="anchor-peer-guide-title">Set up an always-on peer.</span>
-				<span className="sync-action-command">
-					An anchor peer is a normal paired device that stays online. It is not a coordinator,
-					relay, or special protocol role.
-				</span>
-				<ol className="sync-action-command">
-					<li>Pair or select the server, desktop, Pi, or VPS you expect to stay online.</li>
-					<li>
-						Grant only the explicit Sharing domains it should carry; domains absent from its
-						Authorized Sharing domains list will not sync to it.
-					</li>
-					<li>
-						Use project filters only to narrow those authorized domains. Coordinator discovery only
-						helps devices find each other.
-					</li>
-					<li>
-						Headless setup: run <code>codemem sync enable</code>, copy a pairing payload with{" "}
-						<code>codemem sync pair --payload-only</code>, then grant only the intended domains with{" "}
-						<code>
-							codemem coordinator grant-scope-member &lt;group&gt; &lt;scope-id&gt;
-							&lt;anchor-device-id&gt;
-						</code>
-						. Verify with <code>codemem coordinator list-scope-members</code>.
-					</li>
-				</ol>
-				<a
-					className="settings-link"
-					href="https://github.com/kunickiaj/codemem/blob/main/docs/anchor-peer-deployment.md"
-					rel="noreferrer"
-					target="_blank"
-				>
-					Open anchor-peer deployment guide
-				</a>
-				<span className="sync-action-command">
-					{pairedPeerCount > 0
-						? "Expand a device below to review what it can and cannot receive before treating it as your always-on peer."
-						: "No paired devices are available yet. Pair the always-on device first, then review its Sharing-domain grants here."}
-				</span>
-			</div>
-		</section>
-	);
-}
-
 function JoinToggleRow({
 	joinPanel,
 	joinPanelOpen,
@@ -259,8 +212,6 @@ export function SyncInviteJoinPanels({
 					onToggle={onToggleInvitePanel}
 				/>
 			) : null}
-
-			{showInviteActions ? <AnchorPeerGuide pairedPeerCount={pairedPeerCount} /> : null}
 
 			{!pairedPeerCount && presenceStatus === "posted" ? <PairingCopyRow /> : null}
 		</>

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
@@ -47,22 +47,29 @@ describe("SyncSharingReview", () => {
 					],
 					memoryCount: 3,
 					scopeId: "legacy-shared-review",
+					targetScopes: [
+						{ authorityType: "local", label: "Personal", scopeId: "personal" },
+						{ authorityType: "coordinator", label: "OSS", scopeId: "oss" },
+					],
 				}}
+				onLegacyReassign={vi.fn()}
 				onLegacyReview={onLegacyReview}
 				onReview={() => {}}
 			/>,
 		);
 
 		expect(root.textContent).toContain("Legacy shared review");
-		expect(root.textContent).toContain("3 historical shared memories");
-		expect(root.textContent).toContain("oss-dev · git_remote · suggested oss");
+		expect(root.textContent).toContain("1 older project needs a Sharing domain");
+		expect(root.textContent).toContain("3 older shared memories total");
+		expect(root.textContent).toContain("oss-dev");
+		expect(root.textContent).toContain("Matched by git remote · suggested oss");
+		expect(root.textContent).toContain("Destination Sharing domain");
+		expect(root.textContent).toContain("OSS · coordinator · suggested");
 		expect(root.textContent).toContain("legacy data is not promoted automatically");
-		expect(root.textContent).toContain(
-			"Remapping or revocation does not erase data already copied",
-		);
+		expect(root.textContent).toContain("Nothing moves automatically");
 
 		const buttons = [...root.querySelectorAll("button")];
-		const button = buttons.find((item) => item.textContent === "Review projects");
+		const button = buttons.find((item) => item.textContent === "Manage all projects");
 		expect(button).toBeTruthy();
 		button?.click();
 		expect(onLegacyReview).toHaveBeenCalledTimes(1);
@@ -101,6 +108,10 @@ describe("SyncSharingReview", () => {
 					],
 					memoryCount: 3,
 					scopeId: "legacy-shared-review",
+					targetScopes: [
+						{ authorityType: "local", label: "Personal", scopeId: "personal" },
+						{ authorityType: "coordinator", label: "OSS", scopeId: "oss" },
+					],
 				}}
 				onLegacyReassign={onLegacyReassign}
 				onReview={() => {}}
@@ -108,7 +119,7 @@ describe("SyncSharingReview", () => {
 		);
 
 		const applyButton = [...root.querySelectorAll("button")].find(
-			(button) => button.textContent === "Review suggested reassignment",
+			(button) => button.textContent === "Preview reassignment",
 		);
 		expect(applyButton).toBeTruthy();
 		await act(async () => {
@@ -136,5 +147,173 @@ describe("SyncSharingReview", () => {
 			"oss",
 			true,
 		);
+	});
+
+	it("lets users choose a non-suggested legacy destination before preview", async () => {
+		const onLegacyReassign = vi.fn().mockResolvedValueOnce({
+			affected_peer_device_count: 0,
+			affected_peer_device_ids: [],
+			memory_count: 960,
+			reassignable_memory_count: 960,
+			scope_id: "oss",
+			skipped_memory_count: 0,
+			target_scope_label: "OSS",
+			warning: "This changes future sync authorization.",
+			workspace_identity: "workspace-id:codemem",
+		});
+		const root = renderReview(
+			<SyncSharingReview
+				items={[]}
+				legacyReview={{
+					groups: [
+						{
+							displayProject: "codemem",
+							identitySource: "workspace_id",
+							lastUpdatedAt: null,
+							memoryCount: 960,
+							suggestedScopeId: "personal",
+							suggestionReason: "Existing project mapping can be reviewed.",
+							workspaceIdentity: "workspace-id:codemem",
+						},
+					],
+					memoryCount: 960,
+					scopeId: "legacy-shared-review",
+					targetScopes: [
+						{ authorityType: "local", label: "Personal", scopeId: "personal" },
+						{ authorityType: "coordinator", label: "OSS", scopeId: "oss" },
+					],
+				}}
+				onLegacyReassign={onLegacyReassign}
+				onReview={() => {}}
+			/>,
+		);
+
+		const select = root.querySelector("select");
+		expect(select?.value).toBe("personal");
+		act(() => {
+			if (!select) throw new Error("select missing");
+			select.value = "oss";
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+
+		const applyButton = [...root.querySelectorAll("button")].find(
+			(button) => button.textContent === "Preview reassignment",
+		);
+		await act(async () => {
+			applyButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(onLegacyReassign).toHaveBeenCalledWith(
+			expect.objectContaining({ workspaceIdentity: "workspace-id:codemem" }),
+			"oss",
+			false,
+		);
+	});
+
+	it("filters cleanup groups and previews selected suggested groups in bulk", async () => {
+		const onLegacyReassign = vi.fn().mockResolvedValue({
+			affected_peer_device_count: 0,
+			affected_peer_device_ids: [],
+			memory_count: 10,
+			reassignable_memory_count: 10,
+			scope_id: "oss",
+			skipped_memory_count: 0,
+			target_scope_label: "OSS",
+			warning: "This changes future sync authorization.",
+			workspace_identity: "workspace-id:codemem",
+		});
+		const root = renderReview(
+			<SyncSharingReview
+				items={[]}
+				legacyReview={{
+					groups: [
+						{
+							displayProject: "codemem",
+							identitySource: "git_remote",
+							lastUpdatedAt: null,
+							memoryCount: 10,
+							suggestedScopeId: "oss",
+							suggestionReason: "Existing project mapping can be reviewed.",
+							workspaceIdentity: "workspace-id:codemem",
+						},
+						{
+							displayProject: "fatal: not a git repository (or any parent): .git",
+							identitySource: "cwd",
+							lastUpdatedAt: null,
+							memoryCount: 122,
+							suggestedScopeId: "personal",
+							suggestionReason: "Existing project mapping can be reviewed.",
+							workspaceIdentity: "cwd:fatal",
+						},
+					],
+					memoryCount: 132,
+					scopeId: "legacy-shared-review",
+					targetScopes: [
+						{ authorityType: "local", label: "Personal", scopeId: "personal" },
+						{ authorityType: "coordinator", label: "OSS", scopeId: "oss" },
+					],
+				}}
+				onLegacyReassign={onLegacyReassign}
+				onReview={() => {}}
+			/>,
+		);
+
+		expect(root.textContent).toContain("Needs cleanup 1");
+		expect(root.textContent).toContain("Unclear project identity");
+
+		const selectSuggested = [...root.querySelectorAll("button")].find(
+			(button) => button.textContent === "Select suggested",
+		);
+		act(() => {
+			selectSuggested?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		const bulkPreview = [...root.querySelectorAll("button")].find(
+			(button) => button.textContent === "Preview 1 selected",
+		);
+		await act(async () => {
+			bulkPreview?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(onLegacyReassign).toHaveBeenCalledTimes(1);
+		expect(onLegacyReassign).toHaveBeenCalledWith(
+			expect.objectContaining({ workspaceIdentity: "workspace-id:codemem" }),
+			"oss",
+			false,
+		);
+	});
+
+	it("does not show bulk preview controls without a reassignment target", () => {
+		const root = renderReview(
+			<SyncSharingReview
+				items={[]}
+				legacyReview={{
+					groups: [
+						{
+							displayProject: "codemem",
+							identitySource: "git_remote",
+							lastUpdatedAt: null,
+							memoryCount: 10,
+							suggestedScopeId: null,
+							suggestionReason: null,
+							workspaceIdentity: "workspace-id:codemem",
+						},
+					],
+					memoryCount: 10,
+					scopeId: "legacy-shared-review",
+					targetScopes: [],
+				}}
+				onLegacyReassign={vi.fn()}
+				onReview={() => {}}
+			/>,
+		);
+
+		const checkbox = root.querySelector<HTMLInputElement>('input[type="checkbox"]');
+		act(() => {
+			checkbox?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(root.textContent).not.toContain("Preview 1 selected");
+		expect(root.textContent).toContain("Add or join a Sharing domain before bulk reassignment");
 	});
 });

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
@@ -15,6 +15,14 @@ export interface SyncLegacySharedReviewItem {
 	groups?: SyncLegacySharedReviewGroup[];
 	memoryCount: number;
 	scopeId: string;
+	targetScopes?: SyncLegacySharedReviewTargetScope[];
+	totalGroupCount?: number;
+}
+
+export interface SyncLegacySharedReviewTargetScope {
+	authorityType: string;
+	label: string;
+	scopeId: string;
 }
 
 export interface SyncLegacySharedReviewGroup {
@@ -38,6 +46,45 @@ type SyncSharingReviewProps = {
 	onLegacyReview?: () => void;
 	onReview: () => void;
 };
+
+function formatIdentitySource(source: string): string {
+	switch (source) {
+		case "cwd":
+			return "Matched by folder";
+		case "git_remote":
+			return "Matched by git remote";
+		case "workspace_id":
+			return "Matched by workspace";
+		case "project":
+			return "Matched by project name";
+		case "unmapped":
+			return "Missing project identity";
+		default:
+			return `Matched by ${source.replace(/_/g, " ")}`;
+	}
+}
+
+function needsProjectCleanup(group: SyncLegacySharedReviewGroup): boolean {
+	const label = group.displayProject.toLowerCase();
+	return (
+		label.includes("fatal:") ||
+		label.includes("not a git repository") ||
+		label === "unknown project" ||
+		group.identitySource === "unmapped"
+	);
+}
+
+function groupSearchText(group: SyncLegacySharedReviewGroup): string {
+	return [
+		group.displayProject,
+		group.identitySource,
+		group.suggestedScopeId ?? "",
+		group.suggestionReason ?? "",
+		group.workspaceIdentity,
+	]
+		.join(" ")
+		.toLowerCase();
+}
 
 function SharingReviewRow({
 	item,
@@ -81,15 +128,43 @@ function LegacySharedReviewRow({
 	onReview: () => void;
 }) {
 	const groups = item.groups ?? [];
+	const targetScopes = item.targetScopes ?? [];
+	const firstTargetScopeId = targetScopes[0]?.scopeId ?? null;
+	const initialSelections = Object.fromEntries(
+		groups.map((group) => [
+			group.workspaceIdentity,
+			group.suggestedScopeId ?? firstTargetScopeId ?? "",
+		]),
+	);
 	const [pending, setPending] = useState<Record<string, LegacySharedReviewReassignmentPreview>>({});
+	const [selectedScopes, setSelectedScopes] = useState<Record<string, string>>(initialSelections);
+	const [selectedGroups, setSelectedGroups] = useState<Record<string, boolean>>({});
+	const [filter, setFilter] = useState("all");
+	const [query, setQuery] = useState("");
 	const [busyIdentity, setBusyIdentity] = useState<string | null>(null);
+	const shownGroupCount = groups.length;
+	const groupCount = item.totalGroupCount ?? shownGroupCount;
+	const cleanupCount = groups.filter(needsProjectCleanup).length;
+	const suggestedCount = groups.filter(
+		(group) => group.suggestedScopeId && !needsProjectCleanup(group),
+	).length;
+	const selectedCount = groups.filter((group) => selectedGroups[group.workspaceIdentity]).length;
+	const visibleGroups = groups.filter((group) => {
+		const cleanup = needsProjectCleanup(group);
+		if (filter === "suggested" && (!group.suggestedScopeId || cleanup)) return false;
+		if (filter === "cleanup" && !cleanup) return false;
+		if (filter === "no-suggestion" && (group.suggestedScopeId || cleanup)) return false;
+		if (filter === "selected" && !selectedGroups[group.workspaceIdentity]) return false;
+		return !query.trim() || groupSearchText(group).includes(query.trim().toLowerCase());
+	});
 	async function applyGroup(group: SyncLegacySharedReviewGroup) {
-		if (!group.suggestedScopeId || !onReassign || busyIdentity) return;
+		const selectedScopeId = selectedScopes[group.workspaceIdentity] || group.suggestedScopeId || "";
+		if (!selectedScopeId || !onReassign || busyIdentity) return;
 		setBusyIdentity(group.workspaceIdentity);
 		try {
 			const preview = await onReassign(
 				group,
-				group.suggestedScopeId,
+				selectedScopeId,
 				Boolean(pending[group.workspaceIdentity]),
 			);
 			if (preview) setPending((current) => ({ ...current, [group.workspaceIdentity]: preview }));
@@ -104,44 +179,223 @@ function LegacySharedReviewRow({
 			setBusyIdentity(null);
 		}
 	}
+	function updateSelectedScope(group: SyncLegacySharedReviewGroup, scopeId: string) {
+		setSelectedScopes((current) => ({ ...current, [group.workspaceIdentity]: scopeId }));
+		setPending((current) => {
+			const next = { ...current };
+			delete next[group.workspaceIdentity];
+			return next;
+		});
+	}
+	function toggleGroup(group: SyncLegacySharedReviewGroup, checked: boolean) {
+		setSelectedGroups((current) => ({ ...current, [group.workspaceIdentity]: checked }));
+	}
+	function setVisibleSelected(checked: boolean) {
+		setSelectedGroups((current) => ({
+			...current,
+			...Object.fromEntries(visibleGroups.map((group) => [group.workspaceIdentity, checked])),
+		}));
+	}
+	function selectSuggestedGroups() {
+		setSelectedGroups((current) => ({
+			...current,
+			...Object.fromEntries(
+				groups
+					.filter((group) => group.suggestedScopeId && !needsProjectCleanup(group))
+					.map((group) => [group.workspaceIdentity, true]),
+			),
+		}));
+	}
+	async function applySelectedGroups() {
+		if (!onReassign || busyIdentity || selectedCount === 0) return;
+		const selected = groups.filter((group) => selectedGroups[group.workspaceIdentity]);
+		const allPreviewed = selected.every((group) => pending[group.workspaceIdentity]);
+		setBusyIdentity("bulk");
+		try {
+			for (const group of selected) {
+				const selectedScopeId =
+					selectedScopes[group.workspaceIdentity] || group.suggestedScopeId || "";
+				if (!selectedScopeId) continue;
+				const preview = await onReassign(group, selectedScopeId, allPreviewed);
+				if (preview) {
+					setPending((current) => ({ ...current, [group.workspaceIdentity]: preview }));
+				} else if (allPreviewed) {
+					setPending((current) => {
+						const next = { ...current };
+						delete next[group.workspaceIdentity];
+						return next;
+					});
+					setSelectedGroups((current) => ({ ...current, [group.workspaceIdentity]: false }));
+				}
+			}
+		} finally {
+			setBusyIdentity(null);
+		}
+	}
 	return (
-		<div className="actor-row">
-			<div className="actor-details">
-				<div className="actor-title">
-					<strong>Legacy shared review</strong>
-					<span className="badge badge-offline">Needs review</span>
+		<div className="legacy-review-card">
+			<div className="legacy-review-header">
+				<div>
+					<div className="actor-title">
+						<strong>Legacy shared review</strong>
+						<span className="badge badge-offline">Needs project review</span>
+					</div>
+					<div className="peer-meta legacy-review-summary">
+						{groupCount.toLocaleString()} older{" "}
+						{groupCount === 1 ? "project needs" : "projects need"} a Sharing domain. They contain{" "}
+						{item.memoryCount.toLocaleString()} older shared memories total; review the projects,
+						not individual memories.
+						{shownGroupCount < groupCount
+							? ` Showing the first ${shownGroupCount.toLocaleString()} projects by memory count.`
+							: ""}
+					</div>
+					<div className="peer-meta legacy-review-warning">
+						Nothing moves automatically. Reassignment changes future sync authorization; it does not
+						erase copies peers already received.
+					</div>
 				</div>
-				<div className="peer-meta">
-					{item.memoryCount.toLocaleString()} historical shared memories are in {item.scopeId}. 0.30
-					placed ambiguous older shared data there conservatively; review mappings before promoting
-					it. Remapping or revocation does not erase data already copied to peers.
+				<div className="actor-actions">
+					<button type="button" className="settings-button" onClick={onReview}>
+						Manage all projects
+					</button>
 				</div>
-				{groups.length > 0 ? (
-					<ul className="peer-scope-rejections-list" aria-label="Legacy shared review groups">
-						{groups.map((group) => (
-							<li key={group.workspaceIdentity}>
-								<span className="peer-scope-rejection-label">
-									{group.displayProject} · {group.identitySource}
-									{group.suggestedScopeId ? ` · suggested ${group.suggestedScopeId}` : ""}
+			</div>
+			<div className="legacy-review-toolbar">
+				<div className="legacy-review-filter-row">
+					{[
+						["all", `Showing ${shownGroupCount.toLocaleString()}`],
+						["suggested", `Suggested ${suggestedCount.toLocaleString()}`],
+						["cleanup", `Needs cleanup ${cleanupCount.toLocaleString()}`],
+						["no-suggestion", "No suggestion"],
+						["selected", `Selected ${selectedCount.toLocaleString()}`],
+					].map(([value, label]) => (
+						<button
+							className={
+								filter === value
+									? "settings-button legacy-filter active"
+									: "settings-button legacy-filter"
+							}
+							key={value}
+							onClick={() => setFilter(value)}
+							type="button"
+						>
+							{label}
+						</button>
+					))}
+				</div>
+				<div className="legacy-review-bulk-row">
+					<input
+						aria-label="Search legacy project groups"
+						className="peer-scope-input legacy-review-search"
+						onInput={(event) => setQuery(event.currentTarget.value)}
+						placeholder="Search project, signal, or destination…"
+						value={query}
+					/>
+					<button
+						className="settings-button"
+						onClick={() => setVisibleSelected(true)}
+						type="button"
+					>
+						Select visible
+					</button>
+					<button className="settings-button" onClick={selectSuggestedGroups} type="button">
+						Select suggested
+					</button>
+					<button
+						className="settings-button"
+						onClick={() => setVisibleSelected(false)}
+						type="button"
+					>
+						Clear visible
+					</button>
+					{onReassign && targetScopes.length > 0 ? (
+						<button
+							className="settings-save"
+							disabled={busyIdentity != null || selectedCount === 0}
+							onClick={() => void applySelectedGroups()}
+							type="button"
+						>
+							{busyIdentity === "bulk"
+								? "Working…"
+								: selectedCount > 0 &&
+										groups
+											.filter((group) => selectedGroups[group.workspaceIdentity])
+											.every((group) => pending[group.workspaceIdentity])
+									? `Apply ${selectedCount.toLocaleString()} selected`
+									: `Preview ${selectedCount.toLocaleString()} selected`}
+						</button>
+					) : onReassign && selectedCount > 0 ? (
+						<span className="legacy-review-cleanup-note">
+							Add or join a Sharing domain before bulk reassignment.
+						</span>
+					) : null}
+				</div>
+			</div>
+			{groups.length > 0 ? (
+				<ul className="legacy-review-groups" aria-label="Legacy shared review project groups">
+					{visibleGroups.map((group) => (
+						<li className="legacy-review-group" key={group.workspaceIdentity}>
+							<div className="legacy-review-group-main">
+								<div className="legacy-review-title-wrap">
+									<input
+										aria-label={`Select ${group.displayProject}`}
+										checked={Boolean(selectedGroups[group.workspaceIdentity])}
+										className="cm-checkbox"
+										onChange={(event) => toggleGroup(group, event.currentTarget.checked)}
+										type="checkbox"
+									/>
+									<div>
+										<div className="legacy-review-group-title">{group.displayProject}</div>
+										<div className="legacy-review-group-meta">
+											{formatIdentitySource(group.identitySource)}
+											{group.suggestedScopeId ? ` · suggested ${group.suggestedScopeId}` : ""}
+										</div>
+										{needsProjectCleanup(group) ? (
+											<div className="legacy-review-cleanup-note">
+												Unclear project identity. Inspect or correct the project before trusting a
+												domain.
+											</div>
+										) : null}
+									</div>
+								</div>
+								<span className="legacy-review-count">
+									{group.memoryCount.toLocaleString()} memor{group.memoryCount === 1 ? "y" : "ies"}
 								</span>
-								<span className="peer-scope-rejection-count">
-									{group.memoryCount.toLocaleString()}
-								</span>
-								{group.suggestionReason ? (
-									<span className="peer-meta">{group.suggestionReason}</span>
-								) : null}
-								{pending[group.workspaceIdentity] ? (
-									<span className="peer-meta" role="alert">
-										{pending[group.workspaceIdentity].warning} This will reassign{" "}
-										{pending[group.workspaceIdentity].reassignable_memory_count.toLocaleString()} of{" "}
-										{pending[group.workspaceIdentity].memory_count.toLocaleString()} memories
-										{pending[group.workspaceIdentity].skipped_memory_count
-											? `; ${pending[group.workspaceIdentity].skipped_memory_count.toLocaleString()} peer-owned copies will be left unchanged`
-											: ""}
-										.
-									</span>
-								) : null}
-								{group.suggestedScopeId && onReassign ? (
+							</div>
+							{group.suggestionReason ? (
+								<div className="legacy-review-reason">{group.suggestionReason}</div>
+							) : null}
+							{pending[group.workspaceIdentity] ? (
+								<div className="legacy-review-confirmation" role="alert">
+									{pending[group.workspaceIdentity].warning} This will reassign{" "}
+									{pending[group.workspaceIdentity].reassignable_memory_count.toLocaleString()} of{" "}
+									{pending[group.workspaceIdentity].memory_count.toLocaleString()} memories
+									{pending[group.workspaceIdentity].skipped_memory_count
+										? `; ${pending[group.workspaceIdentity].skipped_memory_count.toLocaleString()} peer-owned copies will be left unchanged`
+										: ""}
+									.
+								</div>
+							) : null}
+							{targetScopes.length > 0 && onReassign ? (
+								<label className="legacy-review-target">
+									<span>Destination Sharing domain</span>
+									<select
+										className="peer-scope-input"
+										disabled={busyIdentity != null}
+										onChange={(event) => updateSelectedScope(group, event.currentTarget.value)}
+										value={selectedScopes[group.workspaceIdentity] || group.suggestedScopeId || ""}
+									>
+										{targetScopes.map((scope) => (
+											<option key={scope.scopeId} value={scope.scopeId}>
+												{scope.label} · {scope.authorityType}
+												{scope.scopeId === group.suggestedScopeId ? " · suggested" : ""}
+											</option>
+										))}
+									</select>
+								</label>
+							) : null}
+							{targetScopes.length > 0 && onReassign ? (
+								<div className="legacy-review-actions">
 									<button
 										type="button"
 										className="settings-button"
@@ -152,19 +406,14 @@ function LegacySharedReviewRow({
 											? "Reassigning…"
 											: pending[group.workspaceIdentity]
 												? "I understand, reassign memories"
-												: "Review suggested reassignment"}
+												: "Preview reassignment"}
 									</button>
-								) : null}
-							</li>
-						))}
-					</ul>
-				) : null}
-			</div>
-			<div className="actor-actions">
-				<button type="button" className="settings-button" onClick={onReview}>
-					Review projects
-				</button>
-			</div>
+								</div>
+							) : null}
+						</li>
+					))}
+				</ul>
+			) : null}
 		</div>
 	);
 }

--- a/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
@@ -85,6 +85,19 @@ export function renderSyncSharingReview() {
 					: [],
 				memoryCount: legacyCount,
 				scopeId: String(legacyRaw.scope_id || "legacy-shared-review"),
+				totalGroupCount: Number(legacyRaw.total_group_count || legacyRaw.groups?.length || 0),
+				targetScopes: Array.isArray(legacyRaw.target_scopes)
+					? legacyRaw.target_scopes
+							.map((scope) => {
+								const raw = scope as Record<string, unknown>;
+								return {
+									authorityType: String(raw.authority_type || "unknown"),
+									label: String(raw.label || raw.scope_id || "Unknown domain"),
+									scopeId: String(raw.scope_id || ""),
+								};
+							})
+							.filter((scope) => scope.scopeId)
+					: [],
 			}
 		: null;
 	if (!items.length && !legacyReview) {

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1978,6 +1978,18 @@
       .sync-action ~ .sync-action { margin-top: var(--sp-2); }
 
       .health-action-text, .sync-action-text { font-size: 13px; color: var(--text-primary); flex: 1; min-width: 0; }
+      .settings-link,
+      .sync-subview-link {
+        color: var(--accent);
+        text-decoration-color: color-mix(in srgb, var(--accent) 52%, transparent);
+        text-underline-offset: 3px;
+        transition: color 140ms ease, text-decoration-color 140ms ease;
+      }
+      .settings-link:hover,
+      .sync-subview-link:hover {
+        color: var(--accent-hover);
+        text-decoration-color: currentColor;
+      }
       .sync-section-heading {
         display: flex;
         align-items: center;
@@ -2073,6 +2085,108 @@
       .actor-details { min-width: 0; display: grid; gap: 6px; }
       .actor-title { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
       .actor-actions { display: flex; align-items: center; gap: var(--sp-2); flex-wrap: wrap; justify-content: flex-end; }
+      .legacy-review-card {
+        display: grid;
+        gap: var(--sp-3);
+        padding: var(--sp-3);
+        border: 1px solid color-mix(in srgb, var(--accent-warm) 24%, var(--border));
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--accent-warm-subtle) 34%, var(--surface-1));
+      }
+      .legacy-review-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--sp-3);
+      }
+      .legacy-review-summary { margin-top: 6px; max-width: 78ch; color: var(--text-secondary); }
+      .legacy-review-warning { margin-top: 4px; max-width: 78ch; }
+      .legacy-review-groups {
+        display: grid;
+        gap: var(--sp-2);
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+      .legacy-review-toolbar {
+        display: grid;
+        gap: var(--sp-2);
+        padding: var(--sp-2);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--surface-2) 72%, transparent);
+      }
+      .legacy-review-filter-row,
+      .legacy-review-bulk-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sp-2);
+        align-items: center;
+      }
+      .legacy-filter.active {
+        background: var(--accent-subtle);
+        border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
+        color: var(--accent);
+      }
+      .legacy-review-search { flex: 1 1 260px; min-width: min(260px, 100%); }
+      .legacy-review-group {
+        display: grid;
+        gap: var(--sp-2);
+        padding: var(--sp-3);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-2);
+      }
+      .legacy-review-group-main {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: var(--sp-3);
+        align-items: start;
+      }
+      .legacy-review-title-wrap { display: flex; align-items: flex-start; gap: var(--sp-2); min-width: 0; }
+      .legacy-review-group-title { color: var(--text-primary); font-weight: 700; overflow-wrap: anywhere; }
+      .legacy-review-group-meta,
+      .legacy-review-reason {
+        margin-top: 2px;
+        color: var(--text-tertiary);
+        font-size: 12px;
+        line-height: 1.45;
+      }
+      .legacy-review-cleanup-note {
+        margin-top: 6px;
+        color: var(--accent-warm);
+        font-size: 12px;
+        line-height: 1.45;
+      }
+      .legacy-review-count {
+        justify-self: end;
+        white-space: nowrap;
+        padding: 3px 9px;
+        border-radius: var(--radius-pill);
+        background: var(--accent-neutral-subtle);
+        color: var(--text-secondary);
+        font-family: var(--font-mono);
+        font-size: 12px;
+      }
+      .legacy-review-confirmation {
+        padding: var(--sp-2) var(--sp-3);
+        border: 1px solid color-mix(in srgb, var(--accent-warm) 35%, var(--border));
+        border-radius: var(--radius-md);
+        background: var(--accent-warm-subtle);
+        color: var(--text-secondary);
+        font-size: 13px;
+        line-height: 1.45;
+      }
+      .legacy-review-target {
+        display: grid;
+        gap: 5px;
+        color: var(--text-tertiary);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .legacy-review-actions { display: flex; justify-content: flex-end; }
       .actor-name-input { min-width: 220px; }
       .actor-merge-controls { display: flex; align-items: center; gap: var(--sp-2); flex-wrap: wrap; }
       .actor-merge-select { min-width: 200px; }
@@ -2614,6 +2728,22 @@
       }
       @media (max-height: 720px) { .modal { align-items: flex-start; } }
       .modal-backdrop[hidden], .modal[hidden] { display: none; }
+
+      .legacy-upgrade-modal .modal-card { width: min(620px, 100%); }
+      .legacy-upgrade-summary {
+        padding: var(--sp-3);
+        border: 1px solid color-mix(in srgb, var(--accent-warm) 28%, var(--border));
+        border-radius: var(--radius-md);
+        background: var(--accent-warm-subtle);
+        color: var(--text-secondary);
+        line-height: 1.5;
+      }
+      .legacy-upgrade-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sp-2);
+        justify-content: flex-end;
+      }
 
       .modal-card {
         width: min(520px, 100%);
@@ -3343,6 +3473,11 @@
         .feed-visibility-controls { align-items: stretch; }
         .feed-visibility-select { width: 100%; }
         .actor-actions { justify-content: flex-start; }
+        .legacy-review-header { flex-direction: column; }
+        .legacy-review-group-main { grid-template-columns: 1fr; }
+        .legacy-review-count { justify-self: start; }
+        .legacy-review-actions { justify-content: flex-start; }
+        .legacy-review-bulk-row .settings-save { width: 100%; }
       }
 
       @media (max-width: 520px) {
@@ -3418,6 +3553,49 @@
         </div>
         <div>
           <button class="settings-button" id="viewerReconnectRetry">Retry now</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal-backdrop" id="legacyUpgradeModalBackdrop" hidden></div>
+    <div
+      aria-describedby="legacyUpgradeDescription legacyUpgradeSummary"
+      aria-labelledby="legacyUpgradeTitle"
+      aria-modal="true"
+      class="modal legacy-upgrade-modal"
+      hidden
+      id="legacyUpgradeModal"
+      role="dialog"
+    >
+      <div class="modal-card">
+        <div class="modal-header">
+          <h2 id="legacyUpgradeTitle">Choose where older shared memories belong</h2>
+        </div>
+        <div class="modal-body">
+          <div class="small" id="legacyUpgradeDescription">
+            Some memories were shared before codemem had clear Sharing domains. We kept them out
+            of normal sync until you choose which project/domain they belong to.
+          </div>
+          <div class="legacy-upgrade-summary" id="legacyUpgradeSummary"></div>
+          <div class="small">
+            You’ll review projects, not individual memories. Nothing moves automatically, and this
+            will not erase copies another device may already have received.
+          </div>
+          <label class="field-checkbox" for="legacyUpgradeDontShow">
+            <input class="cm-checkbox" id="legacyUpgradeDontShow" type="checkbox" />
+            <span>Don’t show this again</span>
+          </label>
+        </div>
+        <div class="modal-footer">
+          <div class="legacy-upgrade-actions">
+            <button class="settings-button" id="legacyUpgradeReviewProjects" type="button">
+              Manage all projects
+            </button>
+            <button class="settings-button" id="legacyUpgradeNotNow" type="button">Not now</button>
+            <button class="settings-save" id="legacyUpgradeReviewGroups" type="button">
+              Start review
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -3659,7 +3837,7 @@
         <div class="section-header">
           <div>
             <h2>Projects & Sharing domains</h2>
-            <div class="section-meta">Review project/worktree identities and choose the Sharing domain future memories use. Metadata correction stays in the Feed for now.</div>
+            <div class="section-meta">Choose which Sharing domain future memories use. “Stays on this device” means no Sharing domain is assigned yet, so it belongs in Projects review rather than Sync triage.</div>
           </div>
         </div>
         <div class="projects-toolbar">

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1342,6 +1342,7 @@ function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> 
 				: null,
 		});
 	}
+	const totalGroupCount = groupsByIdentity.size;
 	const groups = [...groupsByIdentity.values()]
 		.sort(
 			(left, right) =>
@@ -1350,12 +1351,25 @@ function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> 
 				left.workspace_identity.localeCompare(right.workspace_identity),
 		)
 		.slice(0, 20);
+	const targetScopes = listSharingDomainSettingsScopes(store.db)
+		.filter(
+			(scope) =>
+				scope.scope_id !== LOCAL_DEFAULT_SCOPE_ID &&
+				scope.scope_id !== LEGACY_SHARED_REVIEW_SCOPE_ID,
+		)
+		.map((scope) => ({
+			authority_type: scope.authority_type,
+			label: scope.label || scope.scope_id,
+			scope_id: scope.scope_id,
+		}));
 	return {
 		scope_id: LEGACY_SHARED_REVIEW_SCOPE_ID,
 		memory_count: memoryCount,
 		has_data: memoryCount > 0,
 		last_updated_at: row?.last_updated_at ?? null,
 		groups,
+		total_group_count: totalGroupCount,
+		target_scopes: targetScopes,
 	};
 }
 


### PR DESCRIPTION
## Description
Refines the 0.31 legacy Sharing-domain migration review so upgraded users can understand and process older shared data without reviewing individual memories. Adds an upgrade notice, project-oriented legacy triage, editable destination domains, search/filter/selection/bulk preview flow, clearer Projects labels, and removes anchor-peer setup from the primary Sync path.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Checks run:
- `pnpm exec vitest run packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx packages/ui/src/tabs/sync/components/sync-invite-join-panels.test.tsx packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx packages/viewer-server/src/index.test.ts --testNamePattern "legacy shared review"`
- `pnpm exec vitest run packages/ui/src/tabs/projects.test.ts`
- `pnpm run tsc`
- `pnpm --filter @codemem/ui build`
- `pnpm run lint` (only pre-existing FeedItemCard noExtraBooleanCast infos)
- `pnpm run test`
- `git diff --check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced