### PR TITLE
fix(sync): handle inbound-only legacy review groups

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
@@ -316,4 +316,38 @@ describe("SyncSharingReview", () => {
 		expect(root.textContent).not.toContain("Preview 1 selected");
 		expect(root.textContent).toContain("Add or join a Sharing domain before bulk reassignment");
 	});
+
+	it("explains inbound-only legacy groups instead of offering reassignment", () => {
+		const root = renderReview(
+			<SyncSharingReview
+				items={[]}
+				legacyReview={{
+					groups: [
+						{
+							displayProject: "oss-inbound",
+							identitySource: "git_remote",
+							lastUpdatedAt: null,
+							memoryCount: 2000,
+							peerOwnedMemoryCount: 2000,
+							reassignableMemoryCount: 0,
+							suggestedScopeId: "oss",
+							suggestionReason: "Existing project mapping can be reviewed.",
+							workspaceIdentity: "https://git.example.invalid/oss/inbound.git",
+						},
+					],
+					memoryCount: 2000,
+					scopeId: "legacy-shared-review",
+					targetScopes: [{ authorityType: "coordinator", label: "OSS", scopeId: "oss" }],
+				}}
+				onLegacyReassign={vi.fn()}
+				onReview={() => {}}
+			/>,
+		);
+
+		const checkbox = root.querySelector<HTMLInputElement>('input[type="checkbox"]');
+		expect(checkbox?.disabled).toBe(true);
+		expect(root.textContent).toContain("Peer-owned only");
+		expect(root.textContent).toContain("cannot reassign them to a Sharing domain");
+		expect(root.textContent).not.toContain("Preview reassignment");
+	});
 });

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
@@ -30,6 +30,8 @@ export interface SyncLegacySharedReviewGroup {
 	identitySource: string;
 	lastUpdatedAt: string | null;
 	memoryCount: number;
+	peerOwnedMemoryCount?: number;
+	reassignableMemoryCount?: number;
 	suggestedScopeId: string | null;
 	suggestionReason: string | null;
 	workspaceIdentity: string;
@@ -72,6 +74,10 @@ function needsProjectCleanup(group: SyncLegacySharedReviewGroup): boolean {
 		label === "unknown project" ||
 		group.identitySource === "unmapped"
 	);
+}
+
+function canReassignLegacyGroup(group: SyncLegacySharedReviewGroup): boolean {
+	return (group.reassignableMemoryCount ?? group.memoryCount) > 0;
 }
 
 function groupSearchText(group: SyncLegacySharedReviewGroup): string {
@@ -146,9 +152,12 @@ function LegacySharedReviewRow({
 	const groupCount = item.totalGroupCount ?? shownGroupCount;
 	const cleanupCount = groups.filter(needsProjectCleanup).length;
 	const suggestedCount = groups.filter(
-		(group) => group.suggestedScopeId && !needsProjectCleanup(group),
+		(group) =>
+			group.suggestedScopeId && !needsProjectCleanup(group) && canReassignLegacyGroup(group),
 	).length;
-	const selectedCount = groups.filter((group) => selectedGroups[group.workspaceIdentity]).length;
+	const selectedCount = groups.filter(
+		(group) => selectedGroups[group.workspaceIdentity] && canReassignLegacyGroup(group),
+	).length;
 	const visibleGroups = groups.filter((group) => {
 		const cleanup = needsProjectCleanup(group);
 		if (filter === "suggested" && (!group.suggestedScopeId || cleanup)) return false;
@@ -193,7 +202,11 @@ function LegacySharedReviewRow({
 	function setVisibleSelected(checked: boolean) {
 		setSelectedGroups((current) => ({
 			...current,
-			...Object.fromEntries(visibleGroups.map((group) => [group.workspaceIdentity, checked])),
+			...Object.fromEntries(
+				visibleGroups
+					.filter(canReassignLegacyGroup)
+					.map((group) => [group.workspaceIdentity, checked]),
+			),
 		}));
 	}
 	function selectSuggestedGroups() {
@@ -201,14 +214,21 @@ function LegacySharedReviewRow({
 			...current,
 			...Object.fromEntries(
 				groups
-					.filter((group) => group.suggestedScopeId && !needsProjectCleanup(group))
+					.filter(
+						(group) =>
+							group.suggestedScopeId &&
+							!needsProjectCleanup(group) &&
+							canReassignLegacyGroup(group),
+					)
 					.map((group) => [group.workspaceIdentity, true]),
 			),
 		}));
 	}
 	async function applySelectedGroups() {
 		if (!onReassign || busyIdentity || selectedCount === 0) return;
-		const selected = groups.filter((group) => selectedGroups[group.workspaceIdentity]);
+		const selected = groups.filter(
+			(group) => selectedGroups[group.workspaceIdentity] && canReassignLegacyGroup(group),
+		);
 		const allPreviewed = selected.every((group) => pending[group.workspaceIdentity]);
 		setBusyIdentity("bulk");
 		try {
@@ -319,7 +339,10 @@ function LegacySharedReviewRow({
 								? "Working…"
 								: selectedCount > 0 &&
 										groups
-											.filter((group) => selectedGroups[group.workspaceIdentity])
+											.filter(
+												(group) =>
+													selectedGroups[group.workspaceIdentity] && canReassignLegacyGroup(group),
+											)
 											.every((group) => pending[group.workspaceIdentity])
 									? `Apply ${selectedCount.toLocaleString()} selected`
 									: `Preview ${selectedCount.toLocaleString()} selected`}
@@ -341,6 +364,7 @@ function LegacySharedReviewRow({
 										aria-label={`Select ${group.displayProject}`}
 										checked={Boolean(selectedGroups[group.workspaceIdentity])}
 										className="cm-checkbox"
+										disabled={!canReassignLegacyGroup(group)}
 										onChange={(event) => toggleGroup(group, event.currentTarget.checked)}
 										type="checkbox"
 									/>
@@ -350,6 +374,21 @@ function LegacySharedReviewRow({
 											{formatIdentitySource(group.identitySource)}
 											{group.suggestedScopeId ? ` · suggested ${group.suggestedScopeId}` : ""}
 										</div>
+										{!canReassignLegacyGroup(group) ? (
+											<div className="legacy-review-cleanup-note">
+												Peer-owned only. These older memories were received from another device, so
+												this device cannot reassign them to a Sharing domain.
+											</div>
+										) : group.peerOwnedMemoryCount ? (
+											<div className="legacy-review-cleanup-note">
+												{(group.reassignableMemoryCount ?? group.memoryCount).toLocaleString()}{" "}
+												local memor
+												{(group.reassignableMemoryCount ?? group.memoryCount) === 1 ? "y" : "ies"}{" "}
+												can be reassigned; {group.peerOwnedMemoryCount.toLocaleString()} peer-owned
+												memor
+												{group.peerOwnedMemoryCount === 1 ? "y" : "ies"} will stay in review.
+											</div>
+										) : null}
 										{needsProjectCleanup(group) ? (
 											<div className="legacy-review-cleanup-note">
 												Unclear project identity. Inspect or correct the project before trusting a
@@ -376,7 +415,7 @@ function LegacySharedReviewRow({
 									.
 								</div>
 							) : null}
-							{targetScopes.length > 0 && onReassign ? (
+							{targetScopes.length > 0 && onReassign && canReassignLegacyGroup(group) ? (
 								<label className="legacy-review-target">
 									<span>Destination Sharing domain</span>
 									<select
@@ -394,7 +433,7 @@ function LegacySharedReviewRow({
 									</select>
 								</label>
 							) : null}
-							{targetScopes.length > 0 && onReassign ? (
+							{targetScopes.length > 0 && onReassign && canReassignLegacyGroup(group) ? (
 								<div className="legacy-review-actions">
 									<button
 										type="button"

--- a/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
@@ -73,6 +73,8 @@ export function renderSyncSharingReview() {
 								identitySource: String(raw.identity_source || "unknown"),
 								lastUpdatedAt: typeof raw.last_updated_at === "string" ? raw.last_updated_at : null,
 								memoryCount: Number(raw.memory_count || 0),
+								peerOwnedMemoryCount: Number(raw.peer_owned_memory_count || 0),
+								reassignableMemoryCount: Number(raw.reassignable_memory_count || 0),
 								suggestedScopeId:
 									typeof raw.suggested_scope_id === "string" ? raw.suggested_scope_id : null,
 								suggestionReason:

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2760,6 +2760,70 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("reports inbound-only legacy shared review groups without offering reassignment capacity", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				const _warmup = await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const now = new Date().toISOString();
+				store.db
+					.prepare(
+						`INSERT INTO replication_scopes(
+							scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+						 ) VALUES ('oss', 'OSS', 'team', 'coordinator', 1, 'active', ?, ?)`,
+					)
+					.run(now, now);
+				grantSyncScopeToDevices(store, "oss", [store.deviceId]);
+				const sessionId = insertTestSession(store.db);
+				store.db
+					.prepare("UPDATE sessions SET git_remote = ?, project = ? WHERE id = ?")
+					.run("https://git.example.invalid/oss/inbound.git", "oss-inbound", sessionId);
+				insertTestMemory(store, {
+					actorId: "remote-actor",
+					kind: "discovery",
+					originDeviceId: "peer-device",
+					scopeId: "legacy-shared-review",
+					sessionId,
+					title: "legacy peer shared",
+				});
+
+				const statusRes = await app.request("/api/sync/status");
+				expect(statusRes.status).toBe(200);
+				const status = (await statusRes.json()) as {
+					legacy_shared_review: {
+						groups: Array<{
+							memory_count: number;
+							peer_owned_memory_count: number;
+							reassignable_memory_count: number;
+							workspace_identity: string;
+						}>;
+					};
+				};
+				expect(status.legacy_shared_review.groups[0]).toMatchObject({
+					memory_count: 1,
+					peer_owned_memory_count: 1,
+					reassignable_memory_count: 0,
+					workspace_identity: "https://git.example.invalid/oss/inbound.git",
+				});
+
+				const previewRes = await app.request("/api/sync/legacy-shared-review/reassign", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						scope_id: "oss",
+						workspace_identity: "https://git.example.invalid/oss/inbound.git",
+					}),
+				});
+				expect(previewRes.status).toBe(400);
+				const body = (await previewRes.json()) as { error: string };
+				expect(body.error).toContain("peer-owned memories");
+				expect(body.error).not.toContain("no locally owned memories");
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("rejects legacy shared review reassignment when the local device lacks target membership", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1243,51 +1243,20 @@ function recentScopeRejectionsByPeer(
 }
 
 function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> {
-	const row = store.db
-		.prepare(
-			`SELECT COUNT(*) AS memory_count,
-			        MAX(updated_at) AS last_updated_at
-			 FROM memory_items
-			 WHERE scope_id = ?
-			   AND active = 1
-			   AND deleted_at IS NULL`,
-		)
-		.get(LEGACY_SHARED_REVIEW_SCOPE_ID) as
-		| { memory_count: number | null; last_updated_at: string | null }
-		| undefined;
-	const memoryCount = Number(row?.memory_count ?? 0);
+	const rows = legacySharedReviewRows(store);
+	const memoryCount = rows.length;
+	const lastUpdatedAt = rows.reduce<string | null>(
+		(current, row) =>
+			row.updated_at && (!current || row.updated_at > current) ? row.updated_at : current,
+		null,
+	);
+	const ownedBySelf = store.buildOwnershipPredicate();
 	const candidatesByIdentity = new Map(
 		listProjectScopeCandidates(store.db, { limit: null }).map((candidate) => [
 			candidate.workspace_identity,
 			candidate,
 		]),
 	);
-	const groupRows = store.db
-		.prepare(
-			`SELECT s.project,
-			        s.cwd,
-			        s.git_remote,
-			        s.git_branch,
-			        m.workspace_id,
-			        COUNT(*) AS memory_count,
-			        MAX(m.updated_at) AS last_updated_at
-			 FROM memory_items m
-			 LEFT JOIN sessions s ON s.id = m.session_id
-			 WHERE m.scope_id = ?
-			   AND m.active = 1
-			   AND m.deleted_at IS NULL
-			 GROUP BY s.project, s.cwd, s.git_remote, s.git_branch, m.workspace_id
-			 ORDER BY memory_count DESC, last_updated_at DESC`,
-		)
-		.all(LEGACY_SHARED_REVIEW_SCOPE_ID) as Array<{
-		project: string | null;
-		cwd: string | null;
-		git_remote: string | null;
-		git_branch: string | null;
-		workspace_id: string | null;
-		memory_count: number | null;
-		last_updated_at: string | null;
-	}>;
 	const groupsByIdentity = new Map<
 		string,
 		{
@@ -1295,18 +1264,20 @@ function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> 
 			identity_source: string;
 			display_project: string;
 			memory_count: number;
+			reassignable_memory_count: number;
+			peer_owned_memory_count: number;
 			last_updated_at: string | null;
 			suggested_scope_id: string | null;
 			suggestion_reason: string | null;
 		}
 	>();
-	for (const group of groupRows) {
+	for (const row of rows) {
 		const identity = canonicalWorkspaceIdentity({
-			cwd: group.cwd,
-			gitBranch: group.git_branch,
-			gitRemote: group.git_remote,
-			project: group.project,
-			workspaceId: group.workspace_id,
+			cwd: row.cwd,
+			gitBranch: row.git_branch,
+			gitRemote: row.git_remote,
+			project: row.project,
+			workspaceId: row.workspace_id,
 		});
 		const candidate = candidatesByIdentity.get(identity.value);
 		const resolvedScope = candidate?.resolved_scope_id ?? null;
@@ -1317,24 +1288,25 @@ function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> 
 				? resolvedScope
 				: candidate?.suggested_scope_id;
 		const existing = groupsByIdentity.get(identity.value);
-		const memoryCount = Number(group.memory_count ?? 0);
-		const lastUpdatedAt = group.last_updated_at ?? null;
+		const isOwnedBySelf = ownedBySelf(row as unknown as Record<string, unknown>);
+		const rowUpdatedAt = row.updated_at ?? null;
 		if (existing) {
-			existing.memory_count += memoryCount;
-			if (
-				lastUpdatedAt &&
-				(!existing.last_updated_at || lastUpdatedAt > existing.last_updated_at)
-			) {
-				existing.last_updated_at = lastUpdatedAt;
+			existing.memory_count += 1;
+			if (isOwnedBySelf) existing.reassignable_memory_count += 1;
+			else existing.peer_owned_memory_count += 1;
+			if (rowUpdatedAt && (!existing.last_updated_at || rowUpdatedAt > existing.last_updated_at)) {
+				existing.last_updated_at = rowUpdatedAt;
 			}
 			continue;
 		}
 		groupsByIdentity.set(identity.value, {
 			workspace_identity: identity.value,
 			identity_source: identity.source,
-			display_project: identity.displayProject ?? group.project ?? group.cwd ?? identity.value,
-			memory_count: memoryCount,
-			last_updated_at: lastUpdatedAt,
+			display_project: identity.displayProject ?? row.project ?? row.cwd ?? identity.value,
+			memory_count: 1,
+			reassignable_memory_count: isOwnedBySelf ? 1 : 0,
+			peer_owned_memory_count: isOwnedBySelf ? 0 : 1,
+			last_updated_at: rowUpdatedAt,
 			suggested_scope_id: suggestedScope ?? null,
 			suggestion_reason: suggestedScope
 				? (candidate?.suggestion_reason ??
@@ -1366,7 +1338,7 @@ function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> 
 		scope_id: LEGACY_SHARED_REVIEW_SCOPE_ID,
 		memory_count: memoryCount,
 		has_data: memoryCount > 0,
-		last_updated_at: row?.last_updated_at ?? null,
+		last_updated_at: lastUpdatedAt,
 		groups,
 		total_group_count: totalGroupCount,
 		target_scopes: targetScopes,
@@ -1377,6 +1349,7 @@ interface LegacySharedReviewReassignmentMemoryRow {
 	id: number;
 	active: number | null;
 	deleted_at: string | null;
+	updated_at: string | null;
 	scope_id: string | null;
 	project: string | null;
 	cwd: string | null;
@@ -1386,6 +1359,31 @@ interface LegacySharedReviewReassignmentMemoryRow {
 	actor_id: string | null;
 	origin_device_id: string | null;
 	metadata_json: string | null;
+}
+
+function legacySharedReviewRows(store: MemoryStore): LegacySharedReviewReassignmentMemoryRow[] {
+	return store.db
+		.prepare(
+			`SELECT m.id,
+			        m.active,
+			        m.deleted_at,
+			        m.updated_at,
+			        m.scope_id,
+			        s.project,
+			        s.cwd,
+			        s.git_remote,
+			        s.git_branch,
+			        m.workspace_id,
+			        m.actor_id,
+			        m.origin_device_id,
+			        m.metadata_json
+			 FROM memory_items m
+			 LEFT JOIN sessions s ON s.id = m.session_id
+			 WHERE m.scope_id = ?
+			   AND m.active = 1
+			   AND m.deleted_at IS NULL`,
+		)
+		.all(LEGACY_SHARED_REVIEW_SCOPE_ID) as LegacySharedReviewReassignmentMemoryRow[];
 }
 
 interface LegacySharedReviewReassignmentPreview {
@@ -1422,28 +1420,7 @@ function legacySharedReviewRowsForWorkspace(
 	store: MemoryStore,
 	workspaceIdentity: string,
 ): LegacySharedReviewReassignmentMemoryRow[] {
-	const rows = store.db
-		.prepare(
-			`SELECT m.id,
-			        m.active,
-			        m.deleted_at,
-			        m.scope_id,
-			        s.project,
-			        s.cwd,
-			        s.git_remote,
-			        s.git_branch,
-			        m.workspace_id,
-			        m.actor_id,
-			        m.origin_device_id,
-			        m.metadata_json
-			 FROM memory_items m
-			 LEFT JOIN sessions s ON s.id = m.session_id
-			 WHERE m.scope_id = ?
-			   AND m.active = 1
-			   AND m.deleted_at IS NULL`,
-		)
-		.all(LEGACY_SHARED_REVIEW_SCOPE_ID) as LegacySharedReviewReassignmentMemoryRow[];
-	return rows.filter((row) => {
+	return legacySharedReviewRows(store).filter((row) => {
 		const identity = canonicalWorkspaceIdentity({
 			cwd: row.cwd,
 			gitBranch: row.git_branch,
@@ -1463,7 +1440,9 @@ function reassignableLegacySharedReviewRows(
 		store.memoryOwnedBySelf(row as unknown as Record<string, unknown>),
 	);
 	if (reassignableRows.length === 0) {
-		throw new Error("legacy shared review group has no locally owned memories to reassign");
+		throw new Error(
+			"This legacy review group contains only peer-owned memories; this device cannot reassign them to a Sharing domain.",
+		);
 	}
 	const currentRows = store.db
 		.prepare(


### PR DESCRIPTION
## Description
Fixes the legacy shared-review migration surface for inbound-only groups. The Sync review now reports locally reassignable versus peer-owned memories, explains peer-owned-only groups instead of offering impossible reassignment, returns all legacy groups for review, and requires token-bound confirmation before moving local legacy rows.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test coverage included)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "legacy shared review|project memory cleanup|forgets locally owned project memories|bulk project mappings"`
- `pnpm exec vitest run packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx packages/ui/src/tabs/projects.test.ts`

Note: `pnpm run lint` reports only the known pre-existing `FeedItemCard` info warnings.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
