### PR TITLE
feat(projects): cluster identities for domain assignment

### DIFF
--- a/packages/core/src/dedup-key-backfill.ts
+++ b/packages/core/src/dedup-key-backfill.ts
@@ -127,7 +127,7 @@ export async function runDedupKeyBackfillPass(
 				cumulativeSkipped > 0
 					? `Dedup-key backfill complete (${cumulativeSkipped} skipped)`
 					: "Dedup-key backfill complete",
-			progressCurrent: processedAfter,
+			progressCurrent: finalProgressTotal,
 			progressTotal: finalProgressTotal,
 			metadata: {
 				total_backfillable: finalProgressTotal,

--- a/packages/core/src/maintenance-jobs.test.ts
+++ b/packages/core/src/maintenance-jobs.test.ts
@@ -80,6 +80,39 @@ describe("maintenance jobs", () => {
 		}
 	});
 
+	it("reports completed jobs as full progress even when diagnostic counters are partial", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			startMaintenanceJob(db, {
+				kind: "memory_dedup_key_backfill",
+				title: "Backfilling dedup keys",
+				progressTotal: 5147,
+				metadata: { processed_updates: 592, skipped_rows: 263, total_backfillable: 5147 },
+			});
+
+			const done = completeMaintenanceJob(db, "memory_dedup_key_backfill", {
+				message: "Dedup-key backfill complete (263 skipped)",
+				progressCurrent: 592,
+				progressTotal: 5147,
+				metadata: { processed_updates: 592, skipped_rows: 263, total_backfillable: 5147 },
+			});
+
+			expect(done).toMatchObject({
+				status: "completed",
+				progress: { current: 5147, total: 5147, unit: "items" },
+				metadata: { processed_updates: 592, skipped_rows: 263 },
+			});
+			expect(getMaintenanceJob(db, "memory_dedup_key_backfill")?.progress).toEqual({
+				current: 5147,
+				total: 5147,
+				unit: "items",
+			});
+		} finally {
+			db.close();
+		}
+	});
+
 	it("records failure state and error text", () => {
 		const db = new Database(":memory:");
 		try {

--- a/packages/core/src/maintenance-jobs.ts
+++ b/packages/core/src/maintenance-jobs.ts
@@ -113,13 +113,17 @@ function resolveMetadataJson(
 
 function toSnapshot(row: MaintenanceJobRecord | undefined): MaintenanceJobSnapshot | null {
 	if (!row) return null;
+	const progressCurrent =
+		row.status === "completed" && row.progress_total != null
+			? row.progress_total
+			: row.progress_current;
 	return {
 		kind: row.kind,
 		title: row.title,
 		status: row.status,
 		message: row.message,
 		progress: {
-			current: row.progress_current,
+			current: progressCurrent,
 			total: row.progress_total,
 			unit: row.progress_unit,
 		},

--- a/packages/core/src/ref-backfill.ts
+++ b/packages/core/src/ref-backfill.ts
@@ -100,7 +100,9 @@ export async function runRefBackfillPass(
 	const existingJob = getMaintenanceJob(db, REF_BACKFILL_JOB);
 	const existingMetadata = getExistingMetadata(db);
 	const batchSize = Math.max(1, options.batchSize ?? 50);
-	const lastCursorId = Number(existingMetadata.last_cursor_id ?? 0);
+	const startingFresh =
+		!existingJob || existingJob.status === "completed" || existingJob.status === "failed";
+	const lastCursorId = startingFresh ? 0 : Number(existingMetadata.last_cursor_id ?? 0);
 
 	const rows = db
 		.prepare(
@@ -130,10 +132,10 @@ export async function runRefBackfillPass(
 		return false;
 	}
 
-	const processedBefore = Number(existingMetadata.processed ?? 0);
+	const processedBefore = startingFresh ? 0 : Number(existingMetadata.processed ?? 0);
 	let progressTotal = Number(existingMetadata.total_backfillable ?? 0);
 
-	if (!existingJob || existingJob.status === "completed" || existingJob.status === "failed") {
+	if (startingFresh) {
 		const countRow = db
 			.prepare(
 				`SELECT COUNT(*) AS cnt FROM memory_items mi
@@ -203,7 +205,7 @@ export async function runRefBackfillPass(
 		);
 		completeMaintenanceJob(db, REF_BACKFILL_JOB, {
 			message: "Ref backfill complete",
-			progressCurrent: processedAfter,
+			progressCurrent: finalProgressTotal,
 			progressTotal: finalProgressTotal,
 			metadata: {
 				total_backfillable: finalProgressTotal,

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -66,6 +66,7 @@ export {
 	SharingDomainGuardrailConfirmationError,
 	saveCoordinatorGroupPreferences,
 	saveSharingDomainProjectMapping,
+	saveSharingDomainProjectMappings,
 	triggerSync,
 	updatePeerIdentity,
 	updatePeerScope,

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -356,6 +356,37 @@ export async function saveSharingDomainProjectMapping(input: {
 	};
 }
 
+export async function saveSharingDomainProjectMappings(input: {
+	mappings: Array<{
+		id?: number | null;
+		workspace_identity?: string | null;
+		project_pattern?: string | null;
+		scope_id: string;
+		priority?: number | null;
+	}>;
+}): Promise<ProjectScopeMapping[]> {
+	const resp = await fetch("/api/sync/sharing-domains/project-mappings/bulk", {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(input),
+	});
+	const { text, payload } = await readJsonPayload<{
+		error?: string;
+		mappings?: ProjectScopeMapping[];
+		required_guardrails?: string[];
+		required_guardrail_tokens?: string[];
+		guardrail_warnings?: ProjectScopeGuardrailWarning[];
+	}>(resp);
+	if (!resp.ok) {
+		if (payload?.error === "guardrail_confirmation_required") {
+			throw new SharingDomainGuardrailConfirmationError(payload);
+		}
+		throw new Error(payloadError(payload) || text || "request failed");
+	}
+	if (!Array.isArray(payload?.mappings)) throw new Error("response missing mappings");
+	return payload.mappings;
+}
+
 export async function deleteSharingDomainProjectMapping(id: number): Promise<boolean> {
 	const resp = await fetch(`/api/sync/sharing-domains/project-mappings/${encodeURIComponent(id)}`, {
 		method: "DELETE",

--- a/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
@@ -327,7 +327,7 @@ export function FeedItemCard({
 						{ label: formatDate(createdAtRaw), side: "left" },
 						h("div", { className: "small feed-age" }, relative),
 					),
-					Boolean(item.owned_by_self) && memoryId > 0
+					item.owned_by_self && memoryId > 0
 						? h(FeedItemMenu, {
 								assignProjectDisabled: movingProject,
 								disabled: deletingMemory,
@@ -363,7 +363,7 @@ export function FeedItemCard({
 								tags.map((tag, index) => h(TagChip, { key: `${String(tag)}-${index}`, tag })),
 							)
 						: null,
-					Boolean(item.owned_by_self) && memoryId > 0
+					item.owned_by_self && memoryId > 0
 						? h(
 								"div",
 								{ className: "feed-visibility-controls" },

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -7,6 +7,7 @@ vi.mock("../lib/api", () => ({
 	loadSharingDomainSettings: vi.fn(),
 	reassignProjectInventoryProject: vi.fn(),
 	saveSharingDomainProjectMapping: vi.fn(),
+	saveSharingDomainProjectMappings: vi.fn(),
 	SharingDomainGuardrailConfirmationError: class SharingDomainGuardrailConfirmationError extends Error {
 		requiredGuardrailTokens: string[];
 		guardrailWarnings: Array<{ code?: string; message: string }>;
@@ -167,19 +168,56 @@ describe("Projects tab", () => {
 		save?.click();
 		await new Promise((resolve) => setTimeout(resolve, 0));
 
-		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledTimes(2);
-		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledWith(
-			expect.objectContaining({
-				scope_id: "exampleco-work",
-				workspace_identity: "https://git.example.invalid/exampleco/api.git",
+		expect(api.saveSharingDomainProjectMappings).toHaveBeenCalledTimes(1);
+		expect(api.saveSharingDomainProjectMappings).toHaveBeenCalledWith({
+			mappings: [
+				expect.objectContaining({
+					scope_id: "exampleco-work",
+					workspace_identity: "https://git.example.invalid/exampleco/api.git",
+				}),
+				expect.objectContaining({
+					scope_id: "exampleco-work",
+					workspace_identity: "https://git.example.invalid/exampleco/api.git:worktree",
+				}),
+			],
+		});
+	});
+
+	it("does not partially update cluster identities when bulk assignment fails", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [
+				project({ cwd: "/workspace/a" }),
+				project({
+					cwd: "/tmp/worktree-a",
+					workspace_identity: "https://git.example.invalid/exampleco/api.git:worktree",
+				}),
+			],
+			total: 2,
+		});
+		vi.mocked(api.saveSharingDomainProjectMappings).mockRejectedValueOnce(
+			new api.SharingDomainGuardrailConfirmationError({
+				guardrail_warnings: [],
+				required_guardrail_tokens: ["token-1"],
 			}),
 		);
-		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledWith(
-			expect.objectContaining({
-				scope_id: "exampleco-work",
-				workspace_identity: "https://git.example.invalid/exampleco/api.git:worktree",
-			}),
-		);
+
+		await loadProjectsData();
+		const select = document.querySelector(
+			".project-inventory-cluster select",
+		) as HTMLSelectElement | null;
+		if (!select) throw new Error("cluster select missing");
+		select.value = "exampleco-work";
+		const save = Array.from(document.querySelectorAll("button")).find(
+			(button) => button.textContent === "Save domain for 2 identities",
+		) as HTMLButtonElement | undefined;
+		save?.click();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(api.saveSharingDomainProjectMappings).toHaveBeenCalledTimes(1);
+		expect(api.saveSharingDomainProjectMapping).not.toHaveBeenCalled();
 	});
 
 	it("does not render assignment controls for unmapped projects", async () => {

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -126,10 +126,59 @@ describe("Projects tab", () => {
 		initProjectsTab(() => {});
 		await loadProjectsData();
 
-		expect(document.getElementById("projectsInventoryMeta")?.textContent).toBe("0 projects found");
+		expect(document.getElementById("projectsInventoryMeta")?.textContent).toBe(
+			"0 project identities found",
+		);
 		expect(document.body.textContent).not.toContain("showing 1-0");
 		expect(api.loadProjectScopeInventory).toHaveBeenCalledWith(
-			expect.objectContaining({ limit: 25 }),
+			expect.objectContaining({ limit: 250 }),
+		);
+	});
+
+	it("clusters related project identities and bulk assigns the group", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [
+				project({ cwd: "/workspace/a", memory_count: 2, session_count: 1 }),
+				project({
+					cwd: "/tmp/worktree-a",
+					memory_count: 3,
+					session_count: 2,
+					workspace_identity: "https://git.example.invalid/exampleco/api.git:worktree",
+				}),
+			],
+			total: 2,
+		});
+
+		await loadProjectsData();
+
+		expect(document.body.textContent).toContain("2 identities · 3 sessions · 5 memories");
+		expect(document.body.textContent).toContain("Save domain for 2 identities");
+		const select = document.querySelector(
+			".project-inventory-cluster select",
+		) as HTMLSelectElement | null;
+		if (!select) throw new Error("cluster select missing");
+		select.value = "exampleco-work";
+		const save = Array.from(document.querySelectorAll("button")).find(
+			(button) => button.textContent === "Save domain for 2 identities",
+		) as HTMLButtonElement | undefined;
+		save?.click();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledTimes(2);
+		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledWith(
+			expect.objectContaining({
+				scope_id: "exampleco-work",
+				workspace_identity: "https://git.example.invalid/exampleco/api.git",
+			}),
+		);
+		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledWith(
+			expect.objectContaining({
+				scope_id: "exampleco-work",
+				workspace_identity: "https://git.example.invalid/exampleco/api.git:worktree",
+			}),
 		);
 	});
 

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -146,16 +146,16 @@ async function saveProjectClusterMapping(
 	const assignable = projects.filter((project) => project.identity_source !== "unmapped");
 	if (assignable.length === 0) return;
 	try {
-		for (const project of assignable) {
-			await api.saveSharingDomainProjectMapping({
+		await api.saveSharingDomainProjectMappings({
+			mappings: assignable.map((project) => ({
 				...(project.mapping_id && project.resolution_reason === "exact_mapping"
 					? { id: project.mapping_id }
 					: {}),
 				project_pattern: project.display_project,
 				scope_id: scopeId,
 				workspace_identity: project.workspace_identity,
-			});
-		}
+			})),
+		});
 		showGlobalNotice(
 			`Updated ${assignable.length} project identit${assignable.length === 1 ? "y" : "ies"}. Device access grants are unchanged.`,
 		);

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -21,9 +21,10 @@ const STATUS_OPTIONS = [
 
 let refreshProjects: RefreshFn | null = null;
 let currentOffset = 0;
-const lastLimit = 25;
+const lastLimit = 250;
 let scopes: SharingDomainScope[] = [];
 const openProjectDetails = new Set<string>();
+const openProjectClusters = new Set<string>();
 const draftDomainSelections = new Map<string, string>();
 const pendingConfirmations = new Map<
 	string,
@@ -62,6 +63,16 @@ function strongestSignal(project: ProjectScopeInventoryProject): string {
 	if (project.git_remote) return project.git_remote;
 	if (project.cwd) return project.cwd;
 	return project.workspace_identity;
+}
+
+function projectClusterKey(project: ProjectScopeInventoryProject): string {
+	if (project.git_remote) return `git:${project.git_remote}`;
+	if (project.project) return `project:${project.project}`;
+	return `identity:${project.workspace_identity}`;
+}
+
+function projectClusterLabel(project: ProjectScopeInventoryProject): string {
+	return project.project || project.display_project || strongestSignal(project);
 }
 
 function scopeLabel(scopeId: string | null | undefined): string {
@@ -123,6 +134,39 @@ async function saveProjectMapping(
 		}
 		showGlobalNotice(
 			error instanceof Error ? error.message : "Unable to update project Sharing domain.",
+			"warning",
+		);
+	}
+}
+
+async function saveProjectClusterMapping(
+	projects: ProjectScopeInventoryProject[],
+	scopeId: string,
+) {
+	const assignable = projects.filter((project) => project.identity_source !== "unmapped");
+	if (assignable.length === 0) return;
+	try {
+		for (const project of assignable) {
+			await api.saveSharingDomainProjectMapping({
+				...(project.mapping_id && project.resolution_reason === "exact_mapping"
+					? { id: project.mapping_id }
+					: {}),
+				project_pattern: project.display_project,
+				scope_id: scopeId,
+				workspace_identity: project.workspace_identity,
+			});
+		}
+		showGlobalNotice(
+			`Updated ${assignable.length} project identit${assignable.length === 1 ? "y" : "ies"}. Device access grants are unchanged.`,
+		);
+		refreshProjects?.();
+	} catch (error) {
+		showGlobalNotice(
+			error instanceof api.SharingDomainGuardrailConfirmationError
+				? "One identity needs review before bulk assignment. Expand the group and save that identity directly."
+				: error instanceof Error
+					? error.message
+					: "Unable to update project Sharing domains.",
 			"warning",
 		);
 	}
@@ -406,6 +450,84 @@ function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 	return row;
 }
 
+function clusterDomainLabel(projects: ProjectScopeInventoryProject[]): string {
+	const uniqueScopes = [...new Set(projects.map((project) => project.resolved_scope_id))];
+	return uniqueScopes.length === 1 ? scopeLabel(uniqueScopes[0]) : "Mixed Sharing domains";
+}
+
+function renderProjectCluster(projects: ProjectScopeInventoryProject[]): HTMLElement {
+	if (projects.length === 1) return renderProjectRow(projects[0]);
+	const clusterKey = projectClusterKey(projects[0]);
+	const row = document.createElement("article");
+	row.className = "project-inventory-row project-inventory-cluster";
+
+	const header = document.createElement("div");
+	header.className = "project-inventory-row-header";
+	const title = document.createElement("div");
+	title.className = "project-inventory-title";
+	title.textContent = projectClusterLabel(projects[0]);
+	header.appendChild(title);
+	const domain = document.createElement("div");
+	domain.className = "project-inventory-domain";
+	domain.textContent = clusterDomainLabel(projects);
+	header.appendChild(domain);
+	row.appendChild(header);
+
+	const memoryCount = projects.reduce((total, project) => total + (project.memory_count ?? 0), 0);
+	const sessionCount = projects.reduce((total, project) => total + project.session_count, 0);
+	const meta = document.createElement("div");
+	meta.className = "project-inventory-meta";
+	meta.textContent = `${projects.length} identities · ${sessionCount.toLocaleString()} sessions · ${memoryCount.toLocaleString()} memories`;
+	row.appendChild(meta);
+
+	const actions = document.createElement("div");
+	actions.className = "project-inventory-actions";
+	const select = document.createElement("select");
+	select.className = "project-domain-select";
+	select.setAttribute("aria-label", `Sharing domain for ${projectClusterLabel(projects[0])} group`);
+	for (const scope of assignableScopes()) {
+		const option = document.createElement("option");
+		option.value = scope.scope_id;
+		option.textContent = scope.label ? `${scope.label} · ${scope.scope_id}` : scope.scope_id;
+		select.appendChild(option);
+	}
+	select.value =
+		projects.find((project) => project.suggested_scope_id)?.suggested_scope_id ??
+		projects[0].resolved_scope_id;
+	const save = document.createElement("button");
+	save.className = "settings-button";
+	save.type = "button";
+	save.textContent = `Save domain for ${projects.length} identities`;
+	save.addEventListener("click", () => void saveProjectClusterMapping(projects, select.value));
+	actions.append(select, save);
+	row.appendChild(actions);
+
+	const details = document.createElement("details");
+	details.className = "project-inventory-details";
+	details.open = openProjectClusters.has(clusterKey);
+	details.addEventListener("toggle", () => {
+		if (details.open) openProjectClusters.add(clusterKey);
+		else openProjectClusters.delete(clusterKey);
+	});
+	const summary = document.createElement("summary");
+	summary.textContent = "Show identities in this project";
+	details.appendChild(summary);
+	for (const project of projects) details.appendChild(renderProjectRow(project));
+	row.appendChild(details);
+	return row;
+}
+
+function projectClusters(
+	projects: ProjectScopeInventoryProject[],
+): ProjectScopeInventoryProject[][] {
+	const byKey = new Map<string, ProjectScopeInventoryProject[]>();
+	for (const project of projects) {
+		const key = projectClusterKey(project);
+		byKey.set(key, [...(byKey.get(key) ?? []), project]);
+	}
+	return [...byKey.values()];
+}
+
 function renderEmpty(message: string) {
 	const list = el<HTMLDivElement>("projectsInventoryList");
 	if (!list) return;
@@ -436,12 +558,13 @@ export async function loadProjectsData() {
 		if (result.projects.length === 0) {
 			renderEmpty("No projects match those filters.");
 		} else {
-			for (const project of result.projects) list.appendChild(renderProjectRow(project));
+			for (const cluster of projectClusters(result.projects))
+				list.appendChild(renderProjectCluster(cluster));
 		}
 		meta.textContent =
 			result.total === 0
-				? "0 projects found"
-				: `${result.total} project${result.total === 1 ? "" : "s"} found · showing ${result.offset + 1}-${Math.min(result.offset + result.projects.length, result.total)}`;
+				? "0 project identities found"
+				: `${result.total} project identit${result.total === 1 ? "y" : "ies"} found · showing ${result.offset + 1}-${Math.min(result.offset + result.projects.length, result.total)}`;
 		const prev = el<HTMLButtonElement>("projectsPrevPage");
 		const next = el<HTMLButtonElement>("projectsNextPage");
 		if (prev) prev.disabled = result.offset === 0;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -6607,6 +6607,50 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("rejects bulk project mappings before writing any partial updates", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const now = new Date().toISOString();
+				store.db
+					.prepare(
+						`INSERT INTO replication_scopes(
+							scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+						 ) VALUES ('acme-work', 'Acme Work', 'team', 'coordinator', 1, 'active', ?, ?)`,
+					)
+					.run(now, now);
+
+				const res = await app.request("/api/sync/sharing-domains/project-mappings/bulk", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						mappings: [
+							{
+								project_pattern: "safe-project",
+								scope_id: "acme-work",
+								workspace_identity: "workspace:safe-project",
+							},
+							{
+								project_pattern: "/home/fixture-user/*",
+								scope_id: "acme-work",
+							},
+						],
+					}),
+				});
+
+				expect(res.status).toBe(409);
+				expect(await res.json()).toMatchObject({ error: "guardrail_confirmation_required" });
+				const saved = store.db
+					.prepare("SELECT COUNT(*) AS n FROM project_scope_mappings WHERE scope_id = ?")
+					.get("acme-work") as { n: number };
+				expect(saved.n).toBe(0);
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("blocks unmapped projects from non-local Sharing domain assignment", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -321,6 +321,21 @@ function missingGuardrailConfirmations(
 	);
 }
 
+function parseViewerProjectMappingInput(body: Record<string, unknown>) {
+	const id = optionalViewerInteger(body, "id");
+	const priority = optionalViewerInteger(body, "priority");
+	if (Number.isNaN(id)) throw new Error("id must be an integer");
+	if (Number.isNaN(priority)) throw new Error("priority must be an integer");
+	return {
+		id,
+		workspace_identity: optionalViewerStrictString(body, "workspace_identity"),
+		project_pattern: optionalViewerStrictString(body, "project_pattern"),
+		scope_id: optionalViewerStrictString(body, "scope_id") ?? "",
+		priority,
+		source: optionalViewerStrictString(body, "source") ?? "user",
+	};
+}
+
 function coordinatorAdminMutationStatus(message: string): 400 | 404 | 409 | 502 {
 	if (
 		message.includes("scope_not_found") ||
@@ -2720,23 +2735,8 @@ export function syncRoutes(
 		const body = await parseViewerJsonBody(c);
 		if (!body) return c.json({ error: "invalid json" }, 400);
 		try {
-			const id = optionalViewerInteger(body, "id");
-			const priority = optionalViewerInteger(body, "priority");
-			if (Number.isNaN(id)) return c.json({ error: "id must be an integer" }, 400);
-			if (Number.isNaN(priority)) return c.json({ error: "priority must be an integer" }, 400);
-			const workspaceIdentity = optionalViewerStrictString(body, "workspace_identity");
-			const projectPattern = optionalViewerStrictString(body, "project_pattern");
-			const scopeId = optionalViewerStrictString(body, "scope_id") ?? "";
-			const source = optionalViewerStrictString(body, "source") ?? "user";
 			const confirmedGuardrailTokens = optionalViewerStringList(body, "confirmed_guardrail_tokens");
-			const mappingInput = {
-				id,
-				workspace_identity: workspaceIdentity,
-				project_pattern: projectPattern,
-				scope_id: scopeId,
-				priority,
-				source,
-			};
+			const mappingInput = parseViewerProjectMappingInput(body);
 			const analysis = analyzeProjectScopeMappingChangeGuardrails(store.db, mappingInput);
 			if (analysis.requested_workspace_identity?.startsWith("unmapped:")) {
 				return c.json(
@@ -2772,6 +2772,67 @@ export function syncRoutes(
 				...mappingInput,
 			});
 			return c.json({ ok: true, mapping, guardrail_warnings: analysis.warnings });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+		}
+	});
+
+	app.put("/api/sync/sharing-domains/project-mappings/bulk", async (c) => {
+		const store = getStore();
+		const body = await parseViewerJsonBody(c);
+		if (!body) return c.json({ error: "invalid json" }, 400);
+		try {
+			const rawMappings = body.mappings;
+			if (!Array.isArray(rawMappings) || rawMappings.length === 0) {
+				return c.json({ error: "mappings must be a non-empty array" }, 400);
+			}
+			const mappingInputs = rawMappings.map((raw) => {
+				if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+					throw new Error("each mapping must be an object");
+				}
+				return parseViewerProjectMappingInput(raw as Record<string, unknown>);
+			});
+			const analyses = mappingInputs.map((mappingInput) =>
+				analyzeProjectScopeMappingChangeGuardrails(store.db, mappingInput),
+			);
+			const unmapped = analyses.find((analysis) =>
+				analysis.requested_workspace_identity?.startsWith("unmapped:"),
+			);
+			if (unmapped) {
+				return c.json(
+					{
+						error: "unmapped_project_local_only",
+						message:
+							"Unmapped projects need a stable path, git remote, or workspace id before assigning a Sharing domain.",
+						guardrail_warnings: unmapped.warnings,
+					},
+					400,
+				);
+			}
+			const missingConfirmations = analyses.flatMap((analysis) =>
+				missingGuardrailConfirmations(analysis.warnings, []),
+			);
+			if (missingConfirmations.length > 0) {
+				const missingCodes = [...new Set(missingConfirmations.map((warning) => warning.code))];
+				const missingTokens = [
+					...new Set(missingConfirmations.map((warning) => warning.confirmation_token)),
+				].filter((token): token is string => typeof token === "string" && token.length > 0);
+				return c.json(
+					{
+						error: "guardrail_confirmation_required",
+						required_guardrails: missingCodes,
+						required_guardrail_tokens: missingTokens,
+						guardrail_warnings: analyses.flatMap((analysis) => analysis.warnings),
+					},
+					409,
+				);
+			}
+			const saveMappings = store.db.transaction(() =>
+				mappingInputs.map((mappingInput) =>
+					upsertProjectScopeSettingsMapping(store.db, mappingInput),
+				),
+			);
+			return c.json({ ok: true, mappings: saveMappings() });
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
 		}


### PR DESCRIPTION
## Description
Adds Projects clustering and safer bulk Sharing-domain assignment. Related project identities are grouped for review, but cluster assignment now requires an explicit domain choice, disables bulk save for identities with guardrail warnings, and relies on a server bulk endpoint that preflights the full batch before writing in a transaction.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test coverage included)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "legacy shared review|project memory cleanup|forgets locally owned project memories|bulk project mappings"`
- `pnpm exec vitest run packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx packages/ui/src/tabs/projects.test.ts`

Note: `pnpm run lint` reports only the known pre-existing `FeedItemCard` info warnings.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
