### PR TITLE
ci(release): idempotent npm publish + dispatch recovery path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,12 @@ permissions:
   contents: write
 
 env:
-  RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  # Fully-qualified ref used by actions/checkout. For workflow_dispatch we
+  # always force the ref to a tag so non-tag inputs (branches, SHAs) fail to
+  # check out instead of silently publishing untagged code.
+  RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+  # Bare tag name (e.g. v0.31.1) for dist-tag selection and Release naming.
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
 jobs:
   preflight-tag:
@@ -23,18 +28,47 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Validate dispatch input
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$DISPATCH_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
+            echo "Refusing to dispatch release for '$DISPATCH_TAG'." >&2
+            echo "Tag input must match v<MAJOR>.<MINOR>.<PATCH>[-PRERELEASE], e.g. v0.31.1 or v0.32.0-rc.1." >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.RELEASE_REF }}
 
       - name: Verify tag points at merged main or release branch
+        env:
+          IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+          PUSH_SHA: ${{ github.sha }}
+          EXPECTED_TAG: ${{ env.RELEASE_TAG }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            RELEASE_TAG_COMMIT="$(git rev-parse HEAD)"
+          # Confirm the checked-out HEAD is exactly the named tag's commit.
+          # actions/checkout was given refs/tags/<tag>, but we verify the local
+          # tag ref still resolves and matches HEAD as defense-in-depth.
+          HEAD_SHA="$(git rev-parse HEAD)"
+          TAG_SHA="$(git rev-parse "refs/tags/${EXPECTED_TAG}^{commit}" 2>/dev/null || true)"
+          if [[ -z "$TAG_SHA" ]]; then
+            echo "Refusing to publish: tag '${EXPECTED_TAG}' did not resolve in the checked-out repo." >&2
+            exit 1
+          fi
+          if [[ "$HEAD_SHA" != "$TAG_SHA" ]]; then
+            echo "Refusing to publish: HEAD ($HEAD_SHA) does not match refs/tags/${EXPECTED_TAG} ($TAG_SHA)." >&2
+            exit 1
+          fi
+          if [[ "$IS_DISPATCH" == "true" ]]; then
+            RELEASE_TAG_COMMIT="$HEAD_SHA"
           else
-            RELEASE_TAG_COMMIT="${{ github.sha }}"
+            RELEASE_TAG_COMMIT="$PUSH_SHA"
           fi
           export RELEASE_TAG_COMMIT
           bash scripts/release-tag-preflight.sh
@@ -88,7 +122,7 @@ jobs:
         id: dist-tag
         run: |
           set -euo pipefail
-          TAG="${{ env.RELEASE_REF }}"
+          TAG="${{ env.RELEASE_TAG }}"
           if [[ "$TAG" == *"-alpha"* ]]; then
             echo "tag=alpha" >> "$GITHUB_OUTPUT"
           elif [[ "$TAG" == *"-beta"* ]]; then
@@ -148,7 +182,7 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ env.RELEASE_REF }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
           set -euo pipefail
           PRERELEASE_FLAG=""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,18 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish (e.g. v0.31.1). Use to re-run a failed release; npm publish is idempotent per package version."
+        required: true
+        type: string
 
 permissions:
   contents: write
+
+env:
+  RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
 jobs:
   preflight-tag:
@@ -17,20 +26,32 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Verify tag points at merged main or release branch
-        env:
-          RELEASE_TAG_COMMIT: ${{ github.sha }}
-        run: bash scripts/release-tag-preflight.sh
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            RELEASE_TAG_COMMIT="$(git rev-parse HEAD)"
+          else
+            RELEASE_TAG_COMMIT="${{ github.sha }}"
+          fi
+          export RELEASE_TAG_COMMIT
+          bash scripts/release-tag-preflight.sh
 
   ci:
     name: CI
     needs: preflight-tag
+    if: github.event_name == 'push'
     uses: ./.github/workflows/ci.yml
 
   publish-npm:
     name: Publish to npm
-    needs: ci
+    needs: [preflight-tag, ci]
+    if: |
+      always() &&
+      needs.preflight-tag.result == 'success' &&
+      (github.event_name != 'push' || needs.ci.result == 'success')
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -39,6 +60,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
@@ -64,7 +87,8 @@ jobs:
       - name: Determine npm dist-tag
         id: dist-tag
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          set -euo pipefail
+          TAG="${{ env.RELEASE_REF }}"
           if [[ "$TAG" == *"-alpha"* ]]; then
             echo "tag=alpha" >> "$GITHUB_OUTPUT"
           elif [[ "$TAG" == *"-beta"* ]]; then
@@ -78,39 +102,66 @@ jobs:
       - name: Publish packages
         env:
           NODE_AUTH_TOKEN: ""
+          DIST_TAG: ${{ steps.dist-tag.outputs.tag }}
         run: |
-          DIST_TAG="${{ steps.dist-tag.outputs.tag }}"
+          set -euo pipefail
+          # Idempotent publish: skip any package whose exact version is already on
+          # the npm registry. Lets us safely re-run after a partial failure
+          # (e.g. transient OIDC fluke) without choking on duplicate versions.
+          publish_if_missing() {
+            local filter="$1"
+            local pkg_dir="$2"
+            local name version view
+            name="$(jq -r .name "${pkg_dir}/package.json")"
+            version="$(jq -r .version "${pkg_dir}/package.json")"
+            view="$(npm view "${name}@${version}" version 2>/dev/null || true)"
+            if [[ -z "${view}" ]]; then
+              sleep 2
+              view="$(npm view "${name}@${version}" version 2>/dev/null || true)"
+            fi
+            if [[ "${view}" == "${version}" ]]; then
+              echo "skip: ${name}@${version} already published on npm (dist-tag=${DIST_TAG})"
+              return 0
+            fi
+            echo "publish: ${name}@${version} (dist-tag=${DIST_TAG})"
+            pnpm --filter "${filter}" publish --tag "${DIST_TAG}" --provenance --access public --no-git-checks
+          }
           # pnpm publish resolves workspace:^ to actual version ranges.
-          # Publish in dependency order: core → mcp, server → cli, opencode-plugin
-          pnpm --filter @codemem/core publish --tag "$DIST_TAG" --provenance --access public --no-git-checks
-          pnpm --filter @codemem/mcp publish --tag "$DIST_TAG" --provenance --access public --no-git-checks
-          pnpm --filter @codemem/server publish --tag "$DIST_TAG" --provenance --access public --no-git-checks
-          pnpm --filter codemem publish --tag "$DIST_TAG" --provenance --access public --no-git-checks
-          pnpm --filter @codemem/opencode-plugin publish --tag "$DIST_TAG" --provenance --access public --no-git-checks
+          # Publish in dependency order: core → mcp, server → cli → opencode-plugin.
+          publish_if_missing "@codemem/core" "packages/core"
+          publish_if_missing "@codemem/mcp" "packages/mcp-server"
+          publish_if_missing "@codemem/server" "packages/viewer-server"
+          publish_if_missing "codemem" "packages/cli"
+          publish_if_missing "@codemem/opencode-plugin" "packages/opencode-plugin"
 
   release:
     name: Create GitHub Release
-    needs: [ci, publish-npm]
+    needs: [publish-npm]
+    if: needs.publish-npm.result == 'success'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ env.RELEASE_REF }}
         run: |
+          set -euo pipefail
           PRERELEASE_FLAG=""
-          if [[ "${{ github.ref_name }}" == *"-alpha"* ]] || \
-             [[ "${{ github.ref_name }}" == *"-beta"* ]] || \
-             [[ "${{ github.ref_name }}" == *"-rc"* ]]; then
+          if [[ "$RELEASE_TAG" == *"-alpha"* ]] || \
+             [[ "$RELEASE_TAG" == *"-beta"* ]] || \
+             [[ "$RELEASE_TAG" == *"-rc"* ]]; then
             PRERELEASE_FLAG="--prerelease"
           fi
-          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
-            echo "Release already exists"
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists"
           else
-            gh release create "${{ github.ref_name }}" \
+            gh release create "$RELEASE_TAG" \
               --generate-notes \
-              --title "Release ${{ github.ref_name }}" \
+              --title "Release $RELEASE_TAG" \
               $PRERELEASE_FLAG
           fi

--- a/docs/trusted-publisher.md
+++ b/docs/trusted-publisher.md
@@ -61,9 +61,11 @@ on one package), use the `workflow_dispatch` path instead of retagging:
 1. Confirm the tag (e.g. `v0.31.1`) still points at the merged release commit.
 2. Trigger the workflow on `main` with the tag input:
    - `gh workflow run release.yml --ref main -f tag=v0.31.1`
-3. The workflow checks out the tag, skips the `CI` job (already passed for
-   the original tag push), and reruns `Publish to npm`. Already-published
-   versions are skipped, missing ones are published.
+3. The workflow validates that the input matches `v<MAJOR>.<MINOR>.<PATCH>[-PRERELEASE]`
+   and resolves it as `refs/tags/<tag>` for checkout, so a non-tag ref
+   (branch name, commit SHA, etc.) cannot be published. The `CI` job is
+   skipped (already passed for the original tag push), and `Publish to npm`
+   reruns. Already-published versions are skipped, missing ones are published.
 4. The `Create GitHub Release` job runs after publish and is also idempotent —
    it skips creation if the release already exists.
 

--- a/docs/trusted-publisher.md
+++ b/docs/trusted-publisher.md
@@ -11,31 +11,67 @@ Use npm trusted publishing for this GitHub repo:
 - **Workflow**: `release.yml`
 - **Environment**: `release`
 
+Trusted publishing must be configured for every package the workflow publishes:
+
+- `@codemem/core`
+- `@codemem/mcp`
+- `@codemem/server`
+- `codemem`
+- `@codemem/opencode-plugin`
+
 ## GitHub workflow behavior
 
-`.github/workflows/release.yml` publishes on `v*` tags via the `publish-npm` job.
+`.github/workflows/release.yml` publishes from two triggers:
 
-Published packages (in dependency order):
+- `push` of a `v*` tag — the normal release path.
+- `workflow_dispatch` with a `tag` input — a recovery path for re-running a
+  failed release without retagging.
+
+In both cases the publish job checks out the workspace at the resolved tag,
+builds, and then runs `Publish packages`. Each package is published in
+dependency order:
 
 1. `@codemem/core`
 2. `@codemem/mcp`
 3. `@codemem/server`
 4. `codemem`
+5. `@codemem/opencode-plugin`
 
 Publish command shape:
 
 - `pnpm --filter <package> publish --provenance --access public --tag <dist-tag>`
 
-Dist-tag selection is automatic from the Git tag:
+The publish step is **idempotent per package version**: before publishing it
+checks `npm view <name>@<version>` and skips any package whose exact version is
+already on the registry. A rerun after a partial failure publishes only the
+packages still missing.
+
+Dist-tag selection is automatic from the resolved release tag:
 
 - `*-alpha*` → `alpha`
 - `*-beta*` → `beta`
 - `*-rc*` → `rc`
 - otherwise → `latest`
 
+## Re-running a failed release
+
+If `Publish to npm` fails partway through (for example a transient OIDC error
+on one package), use the `workflow_dispatch` path instead of retagging:
+
+1. Confirm the tag (e.g. `v0.31.1`) still points at the merged release commit.
+2. Trigger the workflow on `main` with the tag input:
+   - `gh workflow run release.yml --ref main -f tag=v0.31.1`
+3. The workflow checks out the tag, skips the `CI` job (already passed for
+   the original tag push), and reruns `Publish to npm`. Already-published
+   versions are skipped, missing ones are published.
+4. The `Create GitHub Release` job runs after publish and is also idempotent —
+   it skips creation if the release already exists.
+
 ## Verification checklist
 
-- Tag push `vX.Y.Z` runs `Release`
-- `publish-npm` job succeeds
-- Package versions on npm match the release tag
+- Tag push `vX.Y.Z` runs `Release` and `publish-npm` succeeds
+- All five package versions on npm match the release tag
 - npm provenance attestation is present for published artifacts
+- For recovery: `workflow_dispatch` rerun completes with `skip:` lines for
+  packages already at the tag's version and `publish:` lines for any that
+  were missing


### PR DESCRIPTION
## Description

Make the release workflow's `Publish to npm` step idempotent per package version, and add a `workflow_dispatch` recovery path so a failed release can be re-run without retagging.

This is a direct response to the v0.31.1 release: trusted publishing succeeded for `@codemem/core`, `@codemem/mcp`, and `@codemem/server`, then the unscoped `codemem` publish hit a transient `OIDC publish authorize: Invalid token` (looks like an npm fluke). With the original workflow, a rerun would re-attempt all five publishes in order and fail immediately on the first already-published package.

### What changes

- `Publish packages` step now wraps each `pnpm publish` in a `publish_if_missing` helper that calls `npm view <name>@<version>` first and skips the publish when the exact version is already on the registry. Single retry on empty results to soak up transient registry hiccups.
- New `workflow_dispatch` trigger with a required `tag` input. All checkouts resolve `RELEASE_REF = inputs.tag || github.ref_name`, so the publish job operates on the tag's tree on dispatch.
- `CI` job is skipped on `workflow_dispatch` (the original tag push already passed CI), and `publish-npm` / `release` use `if:` guards so a skipped CI on dispatch doesn't block them.
- `Determine npm dist-tag` and `Create GitHub Release` read the resolved tag from `RELEASE_REF` so dist-tag and release naming stay correct under both triggers.
- `docs/trusted-publisher.md` updated to list the full five-package publish set (was missing `@codemem/opencode-plugin`) and document the dispatch-based rerun procedure.

### Recovering v0.31.1 after merge

After merging this PR:

```fish
gh workflow run release.yml --ref main -f tag=v0.31.1
```

Expected behavior: the workflow checks out the v0.31.1 tag, the publish job logs `skip:` for `@codemem/core`, `@codemem/mcp`, `@codemem/server`, then `publish:` for `codemem` and `@codemem/opencode-plugin`, then `Create GitHub Release` opens the v0.31.1 release.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes — workflow YAML / shell, no test harness; validated via `python3 -c "yaml.safe_load(...)"` and `bash -n` on every inline `run` block
- [ ] Manually verified changes work as expected — will be verified on merge by running the dispatch against `v0.31.1`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced