### PR TITLE
ci(release): add always() to GitHub Release job condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,11 @@ jobs:
   release:
     name: Create GitHub Release
     needs: [publish-npm]
-    if: needs.publish-npm.result == 'success'
+    # Use always() to bypass the implicit success() check, otherwise this job
+    # is skipped on workflow_dispatch reruns where the upstream `ci` job is
+    # skipped — the implicit success() requires all transitive needs to have
+    # succeeded, not just direct ones.
+    if: always() && needs.publish-npm.result == 'success'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

Follow-up to #1095. The v0.31.1 dispatch recovery worked for npm publish but `Create GitHub Release` was skipped despite `publish-npm` succeeding, so the release had to be created manually with `gh release create`.

Cause: GitHub Actions injects an implicit `success()` check into job-level `if:` conditions unless the condition explicitly uses `always()`, `cancelled()`, or `failure()`. The implicit `success()` checks **all transitive `needs:` ancestors**, not just direct ones. On a `workflow_dispatch` rerun the `ci` job is intentionally skipped, so the implicit `success()` evaluates to false and the `release` job is skipped — even though `publish-npm` (the only direct dependency) succeeded.

The `publish-npm` job already works around this with `always()`. Applying the same pattern to `release` so future dispatches create the GitHub Release automatically.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — workflow-only change but verified clean)
- [ ] Added/updated tests for changes — workflow YAML, no test harness; \`bash -n\` and YAML parse clean
- [x] Manually verified changes work as expected — caught by today's v0.31.1 dispatch run; will be re-verified on the next release dispatch

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed) — docs already describe the dispatch behavior; no doc change required
- [x] No new warnings introduced