### PR TITLE
feat(viewer): expose applies_to mutation via store + endpoint + feed card

### DIFF
--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -1598,6 +1598,191 @@ describe("MemoryStore", () => {
 		});
 	});
 
+	describe("updateMemoryApplicability", () => {
+		it("changes applies_to from default 'project' to 'user' with no key", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Use fish shell", "Body");
+
+			const updated = store.updateMemoryApplicability(memId, "user", null);
+			expect(updated.applies_to).toBe("user");
+			expect(updated.applies_to_key).toBeNull();
+		});
+
+		it("changes applies_to to 'toolchain' with a key", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "pnpm not npm", "Body");
+
+			const updated = store.updateMemoryApplicability(memId, "toolchain", "pnpm");
+			expect(updated.applies_to).toBe("toolchain");
+			expect(updated.applies_to_key).toBe("pnpm");
+		});
+
+		it("bumps rev and updates updated_at on change", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Rule", "Body");
+
+			const before = store.get(memId);
+			const beforeRev = Number(before?.rev ?? 0);
+			const updated = store.updateMemoryApplicability(memId, "user", null);
+			expect(updated.rev).toBe(beforeRev + 1);
+			expect(updated.updated_at).not.toBe(before?.updated_at);
+		});
+
+		it("appends an applies_to_history change-log entry to metadata", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Rule", "Body");
+
+			store.updateMemoryApplicability(memId, "user", null);
+			const after = store.get(memId);
+			const history = (after?.metadata_json as Record<string, unknown>).applies_to_history as Array<
+				Record<string, unknown>
+			>;
+			expect(Array.isArray(history)).toBe(true);
+			expect(history.length).toBe(1);
+			expect(history[0]?.from).toBe("project");
+			expect(history[0]?.from_key).toBeNull();
+			expect(history[0]?.to).toBe("user");
+			expect(history[0]?.key).toBeNull();
+			expect(history[0]?.by).toBe(store.deviceId);
+			expect(typeof history[0]?.at).toBe("string");
+		});
+
+		it("records the previous applies_to_key on layer transitions", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Rule", "Body");
+
+			store.updateMemoryApplicability(memId, "toolchain", "pnpm");
+			store.updateMemoryApplicability(memId, "toolchain", "npm");
+			const after = store.get(memId);
+			const history = (after?.metadata_json as Record<string, unknown>).applies_to_history as Array<
+				Record<string, unknown>
+			>;
+			expect(history[1]?.from).toBe("toolchain");
+			expect(history[1]?.from_key).toBe("pnpm");
+			expect(history[1]?.to).toBe("toolchain");
+			expect(history[1]?.key).toBe("npm");
+		});
+
+		it("caps applies_to_history at 20 entries", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Rule", "Body");
+
+			for (let i = 0; i < 25; i++) {
+				store.updateMemoryApplicability(memId, i % 2 === 0 ? "user" : "project", null);
+			}
+			const after = store.get(memId);
+			const history = (after?.metadata_json as Record<string, unknown>).applies_to_history as Array<
+				Record<string, unknown>
+			>;
+			expect(history.length).toBe(20);
+			// Sequence i=0..24 produces toggles. With cap=20 the first retained
+			// entry is from iteration i=5 (project → 'project'), preceded by
+			// i=4's resulting state (user).
+			expect(history[0]?.from).toBe("user");
+			expect(history[0]?.to).toBe("project");
+		});
+
+		it("does not mutate scope_id (sharing-domain wall preserved by omission)", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Rule", "Body");
+			const before = store.db
+				.prepare("SELECT scope_id FROM memory_items WHERE id = ?")
+				.get(memId) as { scope_id: string | null };
+
+			store.updateMemoryApplicability(memId, "user", null);
+
+			const after = store.db
+				.prepare("SELECT scope_id FROM memory_items WHERE id = ?")
+				.get(memId) as { scope_id: string | null };
+			expect(after.scope_id).toBe(before.scope_id);
+		});
+
+		it("appends additional change-log entries on subsequent changes", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Rule", "Body");
+
+			store.updateMemoryApplicability(memId, "user", null);
+			store.updateMemoryApplicability(memId, "toolchain", "pnpm");
+
+			const after = store.get(memId);
+			const history = (after?.metadata_json as Record<string, unknown>).applies_to_history as Array<
+				Record<string, unknown>
+			>;
+			expect(history.length).toBe(2);
+			expect(history[1]?.from).toBe("user");
+			expect(history[1]?.to).toBe("toolchain");
+			expect(history[1]?.key).toBe("pnpm");
+		});
+
+		it("emits a replication-op on change", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Rule", "Body");
+			const before = (
+				store.db.prepare("SELECT COUNT(*) AS n FROM replication_ops").get() as { n: number }
+			).n;
+
+			store.updateMemoryApplicability(memId, "user", null);
+
+			const after = (
+				store.db.prepare("SELECT COUNT(*) AS n FROM replication_ops").get() as { n: number }
+			).n;
+			expect(after).toBeGreaterThan(before);
+		});
+
+		it("throws on invalid applies_to enum", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Rule", "Body");
+			expect(() => store.updateMemoryApplicability(memId, "team", null)).toThrow(/applies_to/);
+		});
+
+		it("throws when applies_to_key is missing for 'org'", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Rule", "Body");
+			expect(() => store.updateMemoryApplicability(memId, "org", null)).toThrow(/applies_to_key/);
+		});
+
+		it("throws when applies_to_key is provided for 'user'", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Rule", "Body");
+			expect(() => store.updateMemoryApplicability(memId, "user", "leaked")).toThrow(
+				/applies_to_key/,
+			);
+		});
+
+		it("throws for non-existent memory", () => {
+			expect(() => store.updateMemoryApplicability(99999, "user", null)).toThrow(
+				/memory not found/,
+			);
+		});
+
+		it("throws for inactive memory", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "decision", "Rule", "Body");
+			store.forget(memId);
+			expect(() => store.updateMemoryApplicability(memId, "user", null)).toThrow(
+				/memory not found/,
+			);
+		});
+
+		it("throws for memory owned by another device", () => {
+			const sessionId = insertTestSession(store.db);
+			store.db
+				.prepare(
+					`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+					tags_text, active, created_at, updated_at, metadata_json,
+					origin_device_id, rev, scope_id)
+					VALUES (?, 'decision', 'Foreign', 'Body', 0.5, '', 1, ?, ?, '{}', 'other-device', 1, 'local-default')`,
+				)
+				.run(sessionId, new Date().toISOString(), new Date().toISOString());
+			const foreignId = Number(
+				(store.db.prepare("SELECT last_insert_rowid() as id").get() as { id: number }).id,
+			);
+			expect(() => store.updateMemoryApplicability(foreignId, "user", null)).toThrow(
+				/not owned by this device/,
+			);
+		});
+	});
+
 	describe("close", () => {
 		it("closes the database connection", () => {
 			const sessionId = insertTestSession(store.db);

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -13,6 +13,7 @@ import { randomUUID } from "node:crypto";
 import { statSync } from "node:fs";
 import { and, desc, eq, gt, inArray, isNotNull, lt, lte, or, type SQL, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
+import { type Applicability, validateApplicability } from "./applicability.js";
 import type { Database } from "./db.js";
 import {
 	assertSchemaReady,
@@ -1196,6 +1197,97 @@ export class MemoryStore {
 					});
 				} catch {
 					// Non-fatal
+				}
+
+				const updated = this.get(memoryId);
+				if (!updated) {
+					throw new Error("memory not found after update");
+				}
+				return updated;
+			})
+			.immediate();
+	}
+
+	// updateMemoryApplicability
+
+	/**
+	 * Update the applicability of an active, locally-owned memory.
+	 * Applies strict validation: only known layers, key required for
+	 * org/toolchain and forbidden for user/project. Appends a
+	 * `applies_to_history` change-log entry (last-N debugging trail, not
+	 * an immutable audit) to metadata and emits a replication op so peers
+	 * in the same sharing domain learn about the change.
+	 *
+	 * Note: this method intentionally does NOT touch `scope_id`. Applicability
+	 * (where the rule applies) is orthogonal to the sharing domain (who can
+	 * read it). The sharing-domain wall is preserved by leaving scope_id alone;
+	 * pack composition (codemem-68ci / G1.4) filters the sticky-rules band per
+	 * scope_id so a work-domain rule with applies_to=user never bleeds into a
+	 * personal project's pack.
+	 */
+	updateMemoryApplicability(
+		memoryId: number,
+		appliesTo: string | null | undefined,
+		appliesToKey: string | null | undefined,
+	): MemoryItemResponse {
+		const normalized: Applicability = validateApplicability({
+			applies_to: appliesTo,
+			applies_to_key: appliesToKey,
+		});
+
+		return this.db
+			.transaction(() => {
+				const row = this.d
+					.select()
+					.from(schema.memoryItems)
+					.where(and(eq(schema.memoryItems.id, memoryId), eq(schema.memoryItems.active, 1)))
+					.get() as MemoryItem | undefined;
+				if (!row) {
+					throw new Error("memory not found");
+				}
+				if (!this.memoryOwnedBySelf(row)) {
+					throw new Error("memory not owned by this device");
+				}
+
+				const meta = fromJson(row.metadata_json);
+				const priorHistory = Array.isArray(meta.applies_to_history)
+					? (meta.applies_to_history as unknown[])
+					: [];
+				priorHistory.push({
+					from: row.applies_to,
+					from_key: row.applies_to_key,
+					to: normalized.applies_to,
+					key: normalized.applies_to_key,
+					at: nowIso(),
+					by: this.deviceId,
+				});
+				// Cap history to the last 20 entries to keep metadata bounded.
+				meta.applies_to_history = priorHistory.slice(-20);
+				meta.clock_device_id = this.deviceId;
+
+				const now = nowIso();
+				const rev = (row.rev ?? 0) + 1;
+
+				this.d
+					.update(schema.memoryItems)
+					.set({
+						applies_to: normalized.applies_to,
+						applies_to_key: normalized.applies_to_key,
+						updated_at: now,
+						metadata_json: toJson(meta),
+						rev,
+					})
+					.where(eq(schema.memoryItems.id, memoryId))
+					.run();
+
+				try {
+					recordReplicationOp(this.db, {
+						memoryId,
+						opType: "upsert",
+						deviceId: this.deviceId,
+					});
+				} catch {
+					// Non-fatal — same pattern as updateMemoryVisibility.
 				}
 
 				const updated = this.get(memoryId);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,6 +61,10 @@ export interface MemoryItem {
 	deleted_at: string | null;
 	rev: number;
 	scope_id: string | null;
+	// Applicability: WHERE the rule applies (user/org/toolchain/project).
+	// See packages/core/src/applicability.ts for normalization/validation.
+	applies_to: string;
+	applies_to_key: string | null;
 }
 
 export interface Artifact {

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -37,6 +37,7 @@ export {
 	loadSummariesPage,
 	moveMemoryProject,
 	tracePack,
+	updateMemoryApplicability,
 	updateMemoryVisibility,
 } from "./api/memories";
 export { loadProjects, loadRuntimeInfo, pingViewerReady } from "./api/runtime";

--- a/packages/ui/src/lib/api/memories.ts
+++ b/packages/ui/src/lib/api/memories.ts
@@ -50,6 +50,27 @@ export async function moveMemoryProject(
 	return payload;
 }
 
+export async function updateMemoryApplicability(
+	memoryId: number,
+	appliesTo: "user" | "org" | "toolchain" | "project",
+	appliesToKey: string | null,
+): Promise<{ item?: { applies_to: string; applies_to_key: string | null } }> {
+	const resp = await fetch("/api/memories/applies-to", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			memory_id: memoryId,
+			applies_to: appliesTo,
+			applies_to_key: appliesToKey,
+		}),
+	});
+	const { text, payload } = await readJsonPayload<{
+		item?: { applies_to: string; applies_to_key: string | null };
+	}>(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
+}
+
 export async function forgetMemory(memoryId: number): Promise<{ status?: string }> {
 	const resp = await fetch("/api/memories/forget", {
 		method: "POST",

--- a/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
@@ -92,6 +92,11 @@ export function FeedItemCard({
 	const [savingVisibility, setSavingVisibility] = useState(false);
 	const [deletingMemory, setDeletingMemory] = useState(false);
 	const [movingProject, setMovingProject] = useState(false);
+	// applies_to layer: in v1 only project ↔ user is exposed in the UI.
+	// Org/toolchain require a key input and arrive in a follow-up slice.
+	const initialAppliesTo = item.applies_to === "user" ? "user" : "project";
+	const [selectedAppliesTo, setSelectedAppliesTo] = useState<"project" | "user">(initialAppliesTo);
+	const [savingAppliesTo, setSavingAppliesTo] = useState(false);
 	const summarySections = summaryObj ? renderSummarySections(summaryObj) : [];
 
 	useEffect(() => {
@@ -112,6 +117,10 @@ export function FeedItemCard({
 	useEffect(() => {
 		setSelectedVisibility(visibility === "shared" ? "shared" : "private");
 	}, [visibility]);
+
+	useEffect(() => {
+		setSelectedAppliesTo(item.applies_to === "user" ? "user" : "project");
+	}, [item.applies_to]);
 
 	useEffect(() => {
 		if (!isNew) return;
@@ -162,6 +171,54 @@ export function FeedItemCard({
 						bodyClassName,
 					) || h("div", { className: bodyClassName })
 			: h("div", { className: "feed-body" });
+
+	async function saveAppliesTo(next: "project" | "user") {
+		const previous = selectedAppliesTo;
+		if (next === previous) return;
+
+		// Broadening from project → user widens this rule's applicability
+		// to every project this device sees. Narrowing is safe and skips
+		// the prompt.
+		if (next === "user") {
+			const titleText = String(displayTitle || "this memory").trim();
+			const truncatedTitle =
+				titleText.length > 80 ? `${titleText.slice(0, 79).trimEnd()}…` : titleText;
+			const confirmed = await openSyncConfirmDialog({
+				autoFocusAction: "cancel",
+				title: "Apply to all your projects?",
+				description: `Promoting "${truncatedTitle}" to user scope means this rule will be injected into packs for every project on this device. You can scope it back to this project at any time.`,
+				confirmLabel: "Apply user-wide",
+				cancelLabel: "Keep project-only",
+				tone: "default",
+			});
+			if (!confirmed) {
+				return;
+			}
+		}
+
+		setSelectedAppliesTo(next);
+		setSavingAppliesTo(true);
+		try {
+			const payload = await api.updateMemoryApplicability(memoryId, next, null);
+			if (payload?.item) {
+				onReplace(payload.item as FeedItem);
+				onViewRefresh();
+			}
+			showGlobalNotice(
+				next === "user"
+					? "Rule now applies across all your projects."
+					: "Rule scoped back to this project.",
+			);
+		} catch (error) {
+			setSelectedAppliesTo(previous);
+			showGlobalNotice(
+				error instanceof Error ? error.message : "Failed to update scope.",
+				"warning",
+			);
+		} finally {
+			setSavingAppliesTo(false);
+		}
+	}
 
 	async function saveVisibility(nextVisibility: "private" | "shared") {
 		const previousVisibility = currentVisibility;
@@ -386,6 +443,26 @@ export function FeedItemCard({
 									h("option", { value: "shared" }, "Share with peers"),
 								),
 								h("div", { className: "feed-visibility-note" }, visibilityNote),
+								h(
+									"select",
+									{
+										"aria-label": `Applicability scope for ${String(item.title || "memory")}`,
+										className: "feed-applies-to-select",
+										disabled: savingAppliesTo,
+										onChange: (event) => {
+											const nextValue =
+												String((event.currentTarget as HTMLSelectElement).value) === "user"
+													? "user"
+													: "project";
+											void saveAppliesTo(nextValue);
+										},
+										title:
+											"Org and toolchain layers are deferred — only project and user can be picked here.",
+										value: selectedAppliesTo,
+									},
+									h("option", { value: "project" }, "Project — this project only"),
+									h("option", { value: "user" }, "User — all your projects"),
+								),
 							)
 						: null,
 				),

--- a/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
@@ -92,10 +92,22 @@ export function FeedItemCard({
 	const [savingVisibility, setSavingVisibility] = useState(false);
 	const [deletingMemory, setDeletingMemory] = useState(false);
 	const [movingProject, setMovingProject] = useState(false);
-	// applies_to layer: in v1 only project ↔ user is exposed in the UI.
-	// Org/toolchain require a key input and arrive in a follow-up slice.
-	const initialAppliesTo = item.applies_to === "user" ? "user" : "project";
-	const [selectedAppliesTo, setSelectedAppliesTo] = useState<"project" | "user">(initialAppliesTo);
+	// applies_to layer: in v1 only project ↔ user is editable from this UI.
+	// Org/toolchain require a key picker and arrive in a follow-up slice — but
+	// preserve the true value here so existing org/toolchain memories are not
+	// misrepresented as project-scoped, and so picking from the project/user
+	// dropdown can't silently overwrite a non-project/user assignment.
+	const itemAppliesTo: "user" | "org" | "toolchain" | "project" =
+		item.applies_to === "user" ||
+		item.applies_to === "org" ||
+		item.applies_to === "toolchain" ||
+		item.applies_to === "project"
+			? item.applies_to
+			: "project";
+	const appliesToEditable = itemAppliesTo === "user" || itemAppliesTo === "project";
+	const [selectedAppliesTo, setSelectedAppliesTo] = useState<
+		"user" | "org" | "toolchain" | "project"
+	>(itemAppliesTo);
 	const [savingAppliesTo, setSavingAppliesTo] = useState(false);
 	const summarySections = summaryObj ? renderSummarySections(summaryObj) : [];
 
@@ -119,7 +131,14 @@ export function FeedItemCard({
 	}, [visibility]);
 
 	useEffect(() => {
-		setSelectedAppliesTo(item.applies_to === "user" ? "user" : "project");
+		const next: "user" | "org" | "toolchain" | "project" =
+			item.applies_to === "user" ||
+			item.applies_to === "org" ||
+			item.applies_to === "toolchain" ||
+			item.applies_to === "project"
+				? item.applies_to
+				: "project";
+		setSelectedAppliesTo(next);
 	}, [item.applies_to]);
 
 	useEffect(() => {
@@ -443,26 +462,38 @@ export function FeedItemCard({
 									h("option", { value: "shared" }, "Share with peers"),
 								),
 								h("div", { className: "feed-visibility-note" }, visibilityNote),
-								h(
-									"select",
-									{
-										"aria-label": `Applicability scope for ${String(item.title || "memory")}`,
-										className: "feed-applies-to-select",
-										disabled: savingAppliesTo,
-										onChange: (event) => {
-											const nextValue =
-												String((event.currentTarget as HTMLSelectElement).value) === "user"
-													? "user"
-													: "project";
-											void saveAppliesTo(nextValue);
-										},
-										title:
-											"Org and toolchain layers are deferred — only project and user can be picked here.",
-										value: selectedAppliesTo,
-									},
-									h("option", { value: "project" }, "Project — this project only"),
-									h("option", { value: "user" }, "User — all your projects"),
-								),
+								appliesToEditable
+									? h(
+											"select",
+											{
+												"aria-label": `Applicability scope for ${String(item.title || "memory")}`,
+												className: "feed-applies-to-select",
+												disabled: savingAppliesTo,
+												onChange: (event) => {
+													const nextValue =
+														String((event.currentTarget as HTMLSelectElement).value) === "user"
+															? "user"
+															: "project";
+													void saveAppliesTo(nextValue);
+												},
+												title:
+													"Org and toolchain layers are managed in advanced settings (coming soon).",
+												value: selectedAppliesTo,
+											},
+											h("option", { value: "project" }, "Project — this project only"),
+											h("option", { value: "user" }, "User — all your projects"),
+										)
+									: h(
+											"div",
+											{
+												className: "feed-applies-to-readonly",
+												title:
+													"This memory is scoped to an org or toolchain. Manage these in advanced settings (coming soon).",
+											},
+											`${selectedAppliesTo === "org" ? "Org" : "Toolchain"}${
+												item.applies_to_key ? ` (${item.applies_to_key})` : ""
+											}`,
+										),
 							)
 						: null,
 				),

--- a/packages/ui/src/tabs/feed/types.ts
+++ b/packages/ui/src/tabs/feed/types.ts
@@ -46,6 +46,8 @@ export interface FeedItem {
 	origin_source?: string;
 	origin_device_id?: string;
 	trust_state?: string;
+	applies_to?: string;
+	applies_to_key?: string | null;
 	metadata_json?: FeedItemMetadata;
 	summary?: unknown;
 }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -961,6 +961,160 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("updates applies_to via /api/memories/applies-to", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "decision",
+					title: "Use fish shell everywhere",
+				});
+
+				const res = await app.request("/api/memories/applies-to", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: memoryId, applies_to: "user", applies_to_key: null }),
+				});
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					item: { applies_to: string; applies_to_key: string | null };
+				};
+				expect(body.item.applies_to).toBe("user");
+				expect(body.item.applies_to_key).toBeNull();
+
+				const row = store.db
+					.prepare("SELECT applies_to, applies_to_key FROM memory_items WHERE id = ?")
+					.get(memoryId) as { applies_to: string; applies_to_key: string | null };
+				expect(row.applies_to).toBe("user");
+				expect(row.applies_to_key).toBeNull();
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("accepts a toolchain key on /api/memories/applies-to", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "decision",
+					title: "pnpm not npm",
+				});
+
+				const res = await app.request("/api/memories/applies-to", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({
+						memory_id: memoryId,
+						applies_to: "toolchain",
+						applies_to_key: "pnpm",
+					}),
+				});
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					item: { applies_to: string; applies_to_key: string | null };
+				};
+				expect(body.item.applies_to).toBe("toolchain");
+				expect(body.item.applies_to_key).toBe("pnpm");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects /api/memories/applies-to with an unknown applies_to (400)", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "decision",
+					title: "Memory",
+				});
+
+				const res = await app.request("/api/memories/applies-to", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: memoryId, applies_to: "team", applies_to_key: null }),
+				});
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as { error?: string };
+				expect(body.error).toMatch(/applies_to/);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects /api/memories/applies-to without a key for toolchain (400)", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "decision",
+					title: "Memory",
+				});
+
+				const res = await app.request("/api/memories/applies-to", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({
+						memory_id: memoryId,
+						applies_to: "toolchain",
+						applies_to_key: null,
+					}),
+				});
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as { error?: string };
+				expect(body.error).toMatch(/applies_to_key/);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("returns 404 for a non-existent memory on /api/memories/applies-to", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const res = await app.request("/api/memories/applies-to", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: 99999, applies_to: "user", applies_to_key: null }),
+				});
+				expect(res.status).toBe(404);
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("forgets an owned memory via the viewer API", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1097,6 +1097,40 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("rejects /api/memories/applies-to when applies_to is missing (400)", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "decision",
+					title: "Memory",
+				});
+
+				const res = await app.request("/api/memories/applies-to", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: memoryId }),
+				});
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as { error?: string };
+				expect(body.error).toMatch(/applies_to/);
+				// Memory should be untouched.
+				const row = store.db
+					.prepare("SELECT applies_to FROM memory_items WHERE id = ?")
+					.get(memoryId) as { applies_to: string };
+				expect(row.applies_to).toBe("project");
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("returns 404 for a non-existent memory on /api/memories/applies-to", async () => {
 			const { app, cleanup } = createTestApp();
 			try {

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -674,7 +674,16 @@ export function memoryRoutes(getStore: StoreFactory) {
 		if (!store.get(memoryId)) {
 			return c.json({ error: "memory not found" }, 404);
 		}
-		const appliesTo = typeof body.applies_to === "string" ? body.applies_to : null;
+		// applies_to is REQUIRED — treating a missing field as null silently
+		// resets the memory to the 'project' default. That's a destructive
+		// update masquerading as a no-op, so reject malformed payloads.
+		if (typeof body.applies_to !== "string" || body.applies_to.trim().length === 0) {
+			return c.json(
+				{ error: "applies_to is required and must be one of user|org|toolchain|project" },
+				400,
+			);
+		}
+		const appliesTo = body.applies_to;
 		const appliesToKey =
 			body.applies_to_key === null
 				? null

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -656,6 +656,42 @@ export function memoryRoutes(getStore: StoreFactory) {
 		}
 	});
 
+	// POST /api/memories/applies-to
+	app.post("/api/memories/applies-to", async (c) => {
+		const store = getStore();
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid JSON" }, 400);
+		}
+		const memoryId = parseStrictInteger(
+			typeof body.memory_id === "string" ? body.memory_id : String(body.memory_id ?? ""),
+		);
+		if (memoryId == null || memoryId <= 0) {
+			return c.json({ error: "memory_id must be int" }, 400);
+		}
+		if (!store.get(memoryId)) {
+			return c.json({ error: "memory not found" }, 404);
+		}
+		const appliesTo = typeof body.applies_to === "string" ? body.applies_to : null;
+		const appliesToKey =
+			body.applies_to_key === null
+				? null
+				: typeof body.applies_to_key === "string"
+					? body.applies_to_key
+					: undefined;
+		try {
+			const item = store.updateMemoryApplicability(memoryId, appliesTo, appliesToKey);
+			return c.json({ item });
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			if (msg.includes("not found")) return c.json({ error: msg }, 404);
+			if (msg.includes("not owned")) return c.json({ error: msg }, 403);
+			return c.json({ error: msg }, 400);
+		}
+	});
+
 	// POST /api/memories/forget
 	app.post("/api/memories/forget", async (c) => {
 		const store = getStore();


### PR DESCRIPTION
## Description

Adds the user-driven mutation path for memory applicability now that the schema foundation is in place (PR #1102).

- **Store:** `updateMemoryApplicability(memoryId, appliesTo, appliesToKey)` enforces the enum + key contract via the existing validator, requires the memory be active and owned by this device, persists a layered change-log entry in `metadata_json.applies_to_history` (capped at 20 entries, carries both prior and new layer/key), and emits a replication op.
- **Sharing-domain wall by omission:** the store method deliberately does NOT touch `scope_id`. Applicability (where the rule applies) is orthogonal to the sharing domain (who can read it). Pack composition (the next slice) is responsible for per-domain filtering; this layer just records the user's intent without crossing trust boundaries. A regression test asserts `scope_id` is unchanged so a future change can't quietly break the invariant.
- **HTTP:** `POST /api/memories/applies-to` mirrors the existing visibility/project endpoints — same input validation, same 400/403/404 mapping, same response shape.
- **UI:** `FeedItemCard` gains a second `<select>` parallel to the existing visibility control. v1 exposes only project ↔ user; org/toolchain layers require a key picker and arrive in a follow-up. **Promoting project → user prompts via the existing sync confirm dialog** so the broadening direction isn't a one-click footgun; narrowing skips the prompt.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`) — workspace 1971/1971
- [x] Added/updated tests for changes — 15 store tests (defaults, enum, key contracts, ownership, change-log shape + cap + `from_key` carry, `scope_id`-untouched invariant, replication-op emit) + 5 endpoint tests (happy path with `null` key, toolchain key, invalid enum, missing key 400, non-existent 404)
- [x] Manually verified changes work as expected — UI bundle builds, native `<select>` reuses the existing visibility-control pattern, confirm dialog uses the existing `openSyncConfirmDialog`. Pre-commit reviews (pragmatist + ramsay) caught: missing `from_key` in change-log, missing scope_id-invariant test, missing 20-entry cap test, missing broadening confirmation, dishonest dropdown copy. All addressed.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — no doc changes required; the visible UI control is its own documentation. Org/toolchain UI deferral is tracked as follow-up work.
- [x] No new warnings introduced

## Follow-ups filed

- Consolidate hand-rolled `MemoryItem` interface with Drizzle `$inferSelect`
- Replication-op silent-catch observability for `updateMemoryVisibility`/`Applicability`
- Per-card hook proliferation (visibility + applies_to + future) — lift state or render lazily; pairs with the open viewer-perf investigation