### PR TITLE
feat(core): inject a Sticky Rules band at the top of every memory pack

### DIFF
--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -1347,6 +1347,66 @@ describe("buildMemoryPack", () => {
 		expect(pack.pack_text).toContain("## Summary\n[1] (session_summary) Recent summary");
 		expect(pack.item_ids[0]).toBe(decisionId);
 	});
+
+	it("prepends a Sticky Rules section drawn from user-scope memories", () => {
+		const stickyId = store.remember(
+			sessionId,
+			"decision",
+			"Use fish shell everywhere",
+			"This user prefers fish over bash for all interactive work.",
+		);
+		store.updateMemoryApplicability(stickyId, "user", null);
+
+		const projectId = store.remember(
+			sessionId,
+			"decision",
+			"OAuth callback fix",
+			"Patched callback verification for auth flow",
+		);
+
+		const pack = buildMemoryPack(store, "oauth callback", 10);
+
+		expect(pack.pack_text.startsWith("## Sticky Rules")).toBe(true);
+		expect(pack.pack_text).toContain("### User");
+		expect(pack.pack_text).toContain("Use fish shell everywhere");
+		expect(pack.sticky_rules.user.length).toBe(1);
+		expect(pack.sticky_rules.user[0]?.id).toBe(stickyId);
+		expect(pack.sticky_rules.ids).toEqual([stickyId]);
+		// Project-scope memories still flow through retrieval, NOT the sticky band.
+		expect(pack.sticky_rules.project).toEqual([]);
+		expect(pack.item_ids).toContain(projectId);
+	});
+
+	it("returns an empty sticky_rules band when no memories have been promoted", () => {
+		store.remember(sessionId, "discovery", "Plain memory", "Body");
+
+		const pack = buildMemoryPack(store, "plain", 10);
+
+		expect(pack.sticky_rules.user).toEqual([]);
+		expect(pack.sticky_rules.org).toEqual([]);
+		expect(pack.sticky_rules.toolchain).toEqual([]);
+		expect(pack.sticky_rules.project).toEqual([]);
+		expect(pack.sticky_rules.ids).toEqual([]);
+		expect(pack.pack_text.startsWith("## Sticky Rules")).toBe(false);
+	});
+
+	it("does not double-pack a sticky memory that also matches the retrieval query", () => {
+		const stickyId = store.remember(
+			sessionId,
+			"decision",
+			"Always run gitleaks before publishing",
+			"gitleaks is the canonical pre-publish secret scan in this workspace.",
+		);
+		store.updateMemoryApplicability(stickyId, "user", null);
+
+		const pack = buildMemoryPack(store, "gitleaks", 10);
+
+		// Sticky band keeps it, retrieval section drops it: the same memory id
+		// must NOT appear in both surfaces.
+		expect(pack.sticky_rules.ids).toContain(stickyId);
+		expect(pack.item_ids).not.toContain(stickyId);
+		expect(pack.items.map((it) => it.id)).not.toContain(stickyId);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -24,6 +24,11 @@ import { findByFile } from "./ref-queries.js";
 import type { StoreHandle } from "./search.js";
 import { rerankResults, scoreResult, search, timeline } from "./search.js";
 import {
+	loadStickyRulesForPack,
+	type StickyRulesBand,
+	stickyRuleInputsFromFilters,
+} from "./sticky-rules.js";
+import {
 	canonicalMemoryKind,
 	getSummaryMetadata,
 	isNativeSessionSummaryMemory,
@@ -31,11 +36,13 @@ import {
 } from "./summary-memory.js";
 import type {
 	MemoryFilters,
+	MemoryItem,
 	MemoryItemResponse,
 	MemoryResult,
 	PackItem,
 	PackRenderOptions,
 	PackResponse,
+	PackStickyRulesBand,
 	PackTrace,
 	PackTraceCandidate,
 	PackTraceDisposition,
@@ -79,6 +86,70 @@ const TRACE_PREVIEW_LIMIT = 160;
 // ---------------------------------------------------------------------------
 
 /** Rough token estimate: ~4 chars per token. */
+/**
+ * Render a sticky-rules band as a Markdown section to prepend to pack_text.
+ * Empty band returns the empty string so callers can `if (text) prepend(...)`
+ * without an extra empty section bracketing the pack.
+ */
+function renderStickyRulesBand(band: StickyRulesBand): string {
+	const lines: string[] = [];
+	const layerLabels: Array<[keyof Omit<StickyRulesBand, "ids">, string]> = [
+		["user", "User"],
+		["org", "Org"],
+		["toolchain", "Toolchain"],
+		["project", "Project"],
+	];
+
+	for (const [layer, label] of layerLabels) {
+		const items = band[layer];
+		if (items.length === 0) continue;
+		lines.push(`### ${label}`);
+		for (const item of items) {
+			const title = String(item.title || "").trim() || "(untitled rule)";
+			const body = String(item.body_text || "").trim();
+			lines.push(body ? `- **${title}** — ${body}` : `- **${title}**`);
+		}
+		lines.push("");
+	}
+
+	if (lines.length === 0) return "";
+	return ["## Sticky Rules", "", ...lines].join("\n").trimEnd();
+}
+
+/** Convert a MemoryItem row into the PackItem shape used in PackResponse. */
+function memoryItemToPackItem(item: MemoryItem): PackItem {
+	let metadata: Record<string, unknown> = {};
+	if (typeof item.metadata_json === "string" && item.metadata_json.length > 0) {
+		try {
+			const parsed = JSON.parse(item.metadata_json) as unknown;
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				metadata = parsed as Record<string, unknown>;
+			}
+		} catch {
+			// Non-fatal — leave metadata empty if JSON is malformed.
+		}
+	}
+	return {
+		id: item.id,
+		kind: item.kind,
+		title: item.title,
+		body: item.body_text,
+		confidence: item.confidence,
+		tags: item.tags_text,
+		metadata,
+	};
+}
+
+function stickyBandToResponse(band: StickyRulesBand): PackStickyRulesBand {
+	return {
+		user: band.user.map(memoryItemToPackItem),
+		org: band.org.map(memoryItemToPackItem),
+		toolchain: band.toolchain.map(memoryItemToPackItem),
+		project: band.project.map(memoryItemToPackItem),
+		ids: [...band.ids],
+	};
+}
+
 export function estimateTokens(text: string): number {
 	return Math.ceil(text.length / 4);
 }
@@ -1243,6 +1314,13 @@ function buildPackArtifacts(
 	const effectiveLimit = Math.max(1, Math.trunc(limit));
 	const sanitized = sanitizeSearchQuery(context);
 	const retrievalContext = sanitized.clean_query;
+
+	// Sticky-rules band: layered by applies_to (user/org/toolchain/project).
+	// Computed before retrieval so we know which ids are already accounted for
+	// and don't double-pack them in the regular results.
+	const stickyBand = loadStickyRulesForPack(store, stickyRuleInputsFromFilters(filters));
+	const stickyIdSet = new Set(stickyBand.ids);
+
 	let fallbackUsed = false;
 	let ftsCount = 0;
 	let semanticCount = 0;
@@ -1392,6 +1470,14 @@ function buildPackArtifacts(
 		}
 	}
 
+	// Sticky-rules dedup: a user-promoted memory that also matches the query
+	// is already rendered in the band — strip it from retrieval so it doesn't
+	// appear twice in the same pack.
+	if (stickyIdSet.size > 0) {
+		results = results.filter((r) => !stickyIdSet.has(r.id));
+		retrievalResults = retrievalResults.filter((r) => !stickyIdSet.has(r.id));
+	}
+
 	// Step 2: categorize results
 
 	// Summary: prefer search match; only inject a global fallback when the user
@@ -1471,6 +1557,17 @@ function buildPackArtifacts(
 
 	// Sort observations by tag overlap with context, then by kind priority
 	observationItems = sortByTagOverlap(observationItems, context);
+
+	// Sticky-rules dedup safety net at the section boundary. Earlier we
+	// filtered `results`, but later `store.recentByKinds`/`findLatestSummaryLike`
+	// fallbacks can re-introduce a sticky memory by querying the store directly.
+	// Re-apply the filter here so a sticky memory cannot appear in both the
+	// `## Sticky Rules` band and the regular section grid of the same pack.
+	if (stickyIdSet.size > 0) {
+		summaryItems = summaryItems.filter((it) => !stickyIdSet.has(it.id));
+		timelineItems = timelineItems.filter((it) => !stickyIdSet.has(it.id));
+		observationItems = observationItems.filter((it) => !stickyIdSet.has(it.id));
+	}
 
 	// Exact dedup across all sections
 	const dedupeState: DedupeState = {
@@ -1601,6 +1698,11 @@ function buildPackArtifacts(
 			formatSection("Observations", budgetedObservations, clusterState),
 		];
 		packText = sections.join("\n\n");
+	}
+
+	const stickyText = renderStickyRulesBand(stickyBand);
+	if (stickyText) {
+		packText = packText.length > 0 ? `${stickyText}\n\n${packText}` : stickyText;
 	}
 
 	const packTokens = estimateTokens(packText);
@@ -1771,6 +1873,7 @@ function buildPackArtifacts(
 		items: allItems,
 		item_ids: allItemIds,
 		pack_text: packText,
+		sticky_rules: stickyBandToResponse(stickyBand),
 		metrics,
 	};
 

--- a/packages/core/src/sticky-rules.test.ts
+++ b/packages/core/src/sticky-rules.test.ts
@@ -1,0 +1,290 @@
+import BetterSqlite3 from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	loadStickyRulesForPack,
+	STICKY_RULES_DEFAULT_BUDGETS,
+	stickyRuleInputsFromFilters,
+} from "./sticky-rules.js";
+import { initTestSchema } from "./test-utils.js";
+
+interface SeedMemoryOpts {
+	id?: number;
+	sessionId: number;
+	title: string;
+	appliesTo: "user" | "org" | "toolchain" | "project";
+	appliesToKey?: string | null;
+	scopeId?: string | null;
+	active?: number;
+	deletedAt?: string | null;
+	updatedAt?: string;
+}
+
+function makeStore() {
+	const db = new BetterSqlite3(":memory:");
+	initTestSchema(db);
+	db.prepare("INSERT INTO sessions (id, started_at, project) VALUES (?, ?, ?)").run(
+		1,
+		"2026-01-01T00:00:00Z",
+		"demo-project",
+	);
+	return { db };
+}
+
+function seedMemory(store: ReturnType<typeof makeStore>, opts: SeedMemoryOpts) {
+	const ts = opts.updatedAt ?? new Date().toISOString();
+	store.db
+		.prepare(
+			`INSERT INTO memory_items
+			(session_id, kind, title, body_text, confidence, tags_text, active,
+			 created_at, updated_at, metadata_json, applies_to, applies_to_key,
+			 scope_id, deleted_at, rev)
+			 VALUES (?, 'rule', ?, 'body', 0.5, '', ?, ?, ?, '{}', ?, ?, ?, ?, 1)`,
+		)
+		.run(
+			opts.sessionId,
+			opts.title,
+			opts.active ?? 1,
+			ts,
+			ts,
+			opts.appliesTo,
+			opts.appliesToKey ?? null,
+			opts.scopeId ?? null,
+			opts.deletedAt ?? null,
+		);
+	return Number((store.db.prepare("SELECT last_insert_rowid() as id").get() as { id: number }).id);
+}
+
+describe("loadStickyRulesForPack", () => {
+	let store: ReturnType<typeof makeStore>;
+
+	beforeEach(() => {
+		store = makeStore();
+	});
+
+	afterEach(() => {
+		store.db.close();
+	});
+
+	it("returns an empty band when there are no sticky rules", () => {
+		const band = loadStickyRulesForPack(store);
+		expect(band.user).toEqual([]);
+		expect(band.org).toEqual([]);
+		expect(band.toolchain).toEqual([]);
+		expect(band.project).toEqual([]);
+		expect(band.ids).toEqual([]);
+	});
+
+	it("loads user/org/toolchain layers into their slots, capped by the per-layer budget", () => {
+		// 7 user rules — budget caps at 5
+		for (let i = 0; i < 7; i++) {
+			seedMemory(store, {
+				sessionId: 1,
+				title: `User rule ${i}`,
+				appliesTo: "user",
+				updatedAt: `2026-01-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+			});
+		}
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Toolchain rule",
+			appliesTo: "toolchain",
+			appliesToKey: "pnpm",
+		});
+
+		const band = loadStickyRulesForPack(store, { toolchainKey: "pnpm" });
+		expect(band.user.length).toBe(STICKY_RULES_DEFAULT_BUDGETS.user);
+		// Newest user rules come first
+		expect(band.user[0]?.title).toBe("User rule 6");
+		expect(band.toolchain.length).toBe(1);
+		expect(band.toolchain[0]?.title).toBe("Toolchain rule");
+		expect(band.org).toEqual([]);
+	});
+
+	it("does not pull project-layer memories into the sticky band (avoids retrieval duplicate)", () => {
+		seedMemory(store, { sessionId: 1, title: "Project memory 1", appliesTo: "project" });
+		seedMemory(store, { sessionId: 1, title: "Project memory 2", appliesTo: "project" });
+		seedMemory(store, { sessionId: 1, title: "Real sticky", appliesTo: "user" });
+
+		const band = loadStickyRulesForPack(store);
+		expect(band.project).toEqual([]);
+		expect(band.user.map((m) => m.title)).toEqual(["Real sticky"]);
+		expect(band.ids).toEqual([band.user[0]?.id]);
+	});
+
+	it("skips org/toolchain layers when no key is provided", () => {
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Org rule",
+			appliesTo: "org",
+			appliesToKey: "acme",
+		});
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Toolchain rule",
+			appliesTo: "toolchain",
+			appliesToKey: "pnpm",
+		});
+
+		const band = loadStickyRulesForPack(store);
+		expect(band.org).toEqual([]);
+		expect(band.toolchain).toEqual([]);
+	});
+
+	it("filters org and toolchain by the supplied key", () => {
+		seedMemory(store, {
+			sessionId: 1,
+			title: "pnpm rule",
+			appliesTo: "toolchain",
+			appliesToKey: "pnpm",
+		});
+		seedMemory(store, {
+			sessionId: 1,
+			title: "npm rule",
+			appliesTo: "toolchain",
+			appliesToKey: "npm",
+		});
+
+		const band = loadStickyRulesForPack(store, { toolchainKey: "pnpm" });
+		expect(band.toolchain.map((m) => m.title)).toEqual(["pnpm rule"]);
+	});
+
+	it("excludes inactive and soft-deleted memories", () => {
+		seedMemory(store, { sessionId: 1, title: "Active", appliesTo: "user" });
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Inactive",
+			appliesTo: "user",
+			active: 0,
+		});
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Deleted",
+			appliesTo: "user",
+			deletedAt: "2026-01-02T00:00:00Z",
+		});
+
+		const band = loadStickyRulesForPack(store);
+		expect(band.user.map((m) => m.title)).toEqual(["Active"]);
+	});
+
+	it("enforces the sharing-domain filter when scopeIds is provided", () => {
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Work-scope rule",
+			appliesTo: "user",
+			scopeId: "work-domain",
+		});
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Personal-scope rule",
+			appliesTo: "user",
+			scopeId: "personal-domain",
+		});
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Legacy NULL-scope rule",
+			appliesTo: "user",
+			scopeId: null,
+		});
+
+		const band = loadStickyRulesForPack(store, { scopeIds: ["work-domain"] });
+		const titles = band.user.map((m) => m.title).sort();
+		// Work-scope + legacy NULL-scope come through; personal-scope is filtered out.
+		expect(titles).toEqual(["Legacy NULL-scope rule", "Work-scope rule"]);
+	});
+
+	it("returns no rules from another sharing domain even if applies_to=user", () => {
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Other-domain rule",
+			appliesTo: "user",
+			scopeId: "other-domain",
+		});
+
+		const band = loadStickyRulesForPack(store, { scopeIds: ["work-domain"] });
+		expect(band.user).toEqual([]);
+	});
+
+	it("respects per-layer budget overrides", () => {
+		for (let i = 0; i < 3; i++) {
+			seedMemory(store, {
+				sessionId: 1,
+				title: `U${i}`,
+				appliesTo: "user",
+				updatedAt: `2026-01-0${i + 1}T00:00:00Z`,
+			});
+		}
+
+		const band = loadStickyRulesForPack(store, { budgets: { user: 2 } });
+		expect(band.user.length).toBe(2);
+	});
+
+	it("populates ids in pack order across layers (project excluded)", () => {
+		const u = seedMemory(store, { sessionId: 1, title: "U", appliesTo: "user" });
+		const t = seedMemory(store, {
+			sessionId: 1,
+			title: "T",
+			appliesTo: "toolchain",
+			appliesToKey: "pnpm",
+		});
+		// project memory should NOT appear in band.ids
+		seedMemory(store, { sessionId: 1, title: "P", appliesTo: "project" });
+
+		const band = loadStickyRulesForPack(store, { toolchainKey: "pnpm" });
+		expect(band.ids).toEqual([u, t]);
+	});
+});
+
+describe("loadStickyRulesForPack EXPLAIN QUERY PLAN", () => {
+	it("uses idx_memory_items_applies_to for the user-layer query", () => {
+		const store = makeStore();
+		try {
+			// Seed enough varied rows for the planner to prefer the index.
+			const layers: Array<"user" | "org" | "toolchain" | "project"> = [
+				"user",
+				"org",
+				"toolchain",
+				"project",
+			];
+			for (let i = 0; i < 100; i++) {
+				const layer = layers[i % layers.length] ?? "project";
+				seedMemory(store, {
+					sessionId: 1,
+					title: `m${i}`,
+					appliesTo: layer,
+					appliesToKey: layer === "org" || layer === "toolchain" ? `k${i % 4}` : null,
+					updatedAt: `2026-01-${String((i % 28) + 1).padStart(2, "0")}T00:00:00Z`,
+				});
+			}
+			store.db.exec("ANALYZE");
+
+			const plan = store.db
+				.prepare(
+					"EXPLAIN QUERY PLAN SELECT id FROM memory_items WHERE applies_to = ? AND active = 1 AND deleted_at IS NULL ORDER BY updated_at DESC LIMIT 5",
+				)
+				.all("user") as { detail: string }[];
+			const detail = plan.map((p) => p.detail).join(" | ");
+			expect(detail).toMatch(/idx_memory_items_applies_to/);
+		} finally {
+			store.db.close();
+		}
+	});
+});
+
+describe("stickyRuleInputsFromFilters", () => {
+	it("returns empty inputs when filters is undefined", () => {
+		expect(stickyRuleInputsFromFilters(undefined)).toEqual({});
+	});
+
+	it("threads scope_id string into scopeIds", () => {
+		expect(stickyRuleInputsFromFilters({ scope_id: "work" })).toEqual({ scopeIds: ["work"] });
+	});
+
+	it("threads scope_id array into scopeIds", () => {
+		expect(stickyRuleInputsFromFilters({ scope_id: ["a", "b"] })).toEqual({ scopeIds: ["a", "b"] });
+	});
+
+	it("falls back to include_scope_ids when scope_id is absent", () => {
+		expect(stickyRuleInputsFromFilters({ include_scope_ids: ["a"] })).toEqual({ scopeIds: ["a"] });
+	});
+});

--- a/packages/core/src/sticky-rules.test.ts
+++ b/packages/core/src/sticky-rules.test.ts
@@ -7,6 +7,9 @@ import {
 } from "./sticky-rules.js";
 import { initTestSchema } from "./test-utils.js";
 
+const TEST_DEVICE_ID = "test-device";
+const TEST_ACTOR_ID = "local:test-device";
+
 interface SeedMemoryOpts {
 	id?: number;
 	sessionId: number;
@@ -27,7 +30,7 @@ function makeStore() {
 		"2026-01-01T00:00:00Z",
 		"demo-project",
 	);
-	return { db };
+	return { db, actorId: TEST_ACTOR_ID, deviceId: TEST_DEVICE_ID };
 }
 
 function seedMemory(store: ReturnType<typeof makeStore>, opts: SeedMemoryOpts) {
@@ -52,6 +55,24 @@ function seedMemory(store: ReturnType<typeof makeStore>, opts: SeedMemoryOpts) {
 			opts.deletedAt ?? null,
 		);
 	return Number((store.db.prepare("SELECT last_insert_rowid() as id").get() as { id: number }).id);
+}
+
+function grantScope(store: ReturnType<typeof makeStore>, scopeId: string): void {
+	const now = new Date().toISOString();
+	store.db
+		.prepare(
+			`INSERT OR REPLACE INTO replication_scopes
+			(scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at)
+			VALUES (?, ?, 'team', 'coordinator', 0, 'active', ?, ?)`,
+		)
+		.run(scopeId, scopeId, now, now);
+	store.db
+		.prepare(
+			`INSERT OR REPLACE INTO scope_memberships
+			(scope_id, device_id, role, status, membership_epoch, updated_at)
+			VALUES (?, ?, 'member', 'active', 0, ?)`,
+		)
+		.run(scopeId, store.deviceId, now);
 }
 
 describe("loadStickyRulesForPack", () => {
@@ -167,7 +188,53 @@ describe("loadStickyRulesForPack", () => {
 		expect(band.user.map((m) => m.title)).toEqual(["Active"]);
 	});
 
-	it("enforces the sharing-domain filter when scopeIds is provided", () => {
+	it("hides memories from sharing domains the device cannot read", () => {
+		// Memory in a coordinator scope the device has NO membership for —
+		// must be invisible to the sticky band even though applies_to=user.
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Forbidden user-scope rule",
+			appliesTo: "user",
+			scopeId: "unauthorized-team",
+		});
+		// Register the scope as a coordinator authority but skip granting
+		// membership so the visibility gate has to reject it.
+		const now = new Date().toISOString();
+		store.db
+			.prepare(
+				`INSERT INTO replication_scopes
+				(scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at)
+				VALUES (?, ?, 'team', 'coordinator', 0, 'active', ?, ?)`,
+			)
+			.run("unauthorized-team", "unauthorized-team", now, now);
+
+		const band = loadStickyRulesForPack(store);
+		expect(band.user).toEqual([]);
+	});
+
+	it("includes memories from sharing domains where the device has active membership", () => {
+		grantScope(store, "work-domain");
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Work-domain rule",
+			appliesTo: "user",
+			scopeId: "work-domain",
+		});
+		seedMemory(store, {
+			sessionId: 1,
+			title: "Legacy NULL-scope rule",
+			appliesTo: "user",
+			scopeId: null,
+		});
+
+		const band = loadStickyRulesForPack(store);
+		const titles = band.user.map((m) => m.title).sort();
+		expect(titles).toEqual(["Legacy NULL-scope rule", "Work-domain rule"]);
+	});
+
+	it("enforces the scopeIds narrowing on top of the visibility gate", () => {
+		grantScope(store, "work-domain");
+		grantScope(store, "personal-domain");
 		seedMemory(store, {
 			sessionId: 1,
 			title: "Work-scope rule",
@@ -180,29 +247,9 @@ describe("loadStickyRulesForPack", () => {
 			appliesTo: "user",
 			scopeId: "personal-domain",
 		});
-		seedMemory(store, {
-			sessionId: 1,
-			title: "Legacy NULL-scope rule",
-			appliesTo: "user",
-			scopeId: null,
-		});
 
 		const band = loadStickyRulesForPack(store, { scopeIds: ["work-domain"] });
-		const titles = band.user.map((m) => m.title).sort();
-		// Work-scope + legacy NULL-scope come through; personal-scope is filtered out.
-		expect(titles).toEqual(["Legacy NULL-scope rule", "Work-scope rule"]);
-	});
-
-	it("returns no rules from another sharing domain even if applies_to=user", () => {
-		seedMemory(store, {
-			sessionId: 1,
-			title: "Other-domain rule",
-			appliesTo: "user",
-			scopeId: "other-domain",
-		});
-
-		const band = loadStickyRulesForPack(store, { scopeIds: ["work-domain"] });
-		expect(band.user).toEqual([]);
+		expect(band.user.map((m) => m.title)).toEqual(["Work-scope rule"]);
 	});
 
 	it("respects per-layer budget overrides", () => {

--- a/packages/core/src/sticky-rules.ts
+++ b/packages/core/src/sticky-rules.ts
@@ -1,0 +1,147 @@
+/**
+ * Sticky-rules band for memory packs. Pulls rules whose applies_to layer is
+ * broader than the active project so they ride along on every pack request,
+ * fighting long-context attention dilution.
+ *
+ * Sharing-domain wall: queries inherit the same scope_id filter the rest of
+ * pack composition uses, so a user-scope rule recorded in one sharing
+ * domain never bleeds into packs assembled for projects in a different
+ * domain.
+ *
+ * The (applies_to, applies_to_key) composite index from G1.1 backs every
+ * lookup; verify EXPLAIN QUERY PLAN if you change the WHERE shape.
+ */
+
+import { and, desc, eq, inArray, isNull, or } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { APPLIES_TO_LAYERS, type AppliesTo } from "./applicability.js";
+import * as schema from "./schema.js";
+import type { MemoryFilters, MemoryItem } from "./types.js";
+
+export interface StickyRuleBudgets {
+	user: number;
+	org: number;
+	toolchain: number;
+}
+
+export const STICKY_RULES_DEFAULT_BUDGETS: StickyRuleBudgets = {
+	user: 5,
+	org: 3,
+	toolchain: 3,
+};
+
+export interface StickyRulesBand {
+	user: MemoryItem[];
+	org: MemoryItem[];
+	toolchain: MemoryItem[];
+	project: MemoryItem[];
+	/** Memory IDs included in the band, useful for deduping retrieval results. */
+	ids: number[];
+}
+
+export interface StickyRulesInputs {
+	scopeIds?: string[] | null;
+	orgKey?: string | null;
+	toolchainKey?: string | null;
+	budgets?: Partial<StickyRuleBudgets>;
+}
+
+interface StoreLike {
+	db: { prepare: (sql: string) => unknown };
+}
+
+function resolveBudgets(budgets?: Partial<StickyRuleBudgets>): StickyRuleBudgets {
+	return {
+		user: budgets?.user ?? STICKY_RULES_DEFAULT_BUDGETS.user,
+		org: budgets?.org ?? STICKY_RULES_DEFAULT_BUDGETS.org,
+		toolchain: budgets?.toolchain ?? STICKY_RULES_DEFAULT_BUDGETS.toolchain,
+	};
+}
+
+/**
+ * Resolve the sticky-rule inputs for a pack request from its memory filter.
+ * Mirrors the filter's scope_id list so the sharing-domain wall is preserved
+ * by construction — callers cannot accidentally pull rules from a domain the
+ * pack itself is filtering out.
+ */
+export function stickyRuleInputsFromFilters(filters: MemoryFilters | undefined): StickyRulesInputs {
+	if (!filters) return {};
+	const inputs: StickyRulesInputs = {};
+	if (filters.scope_id) {
+		inputs.scopeIds = Array.isArray(filters.scope_id) ? filters.scope_id : [filters.scope_id];
+	} else if (filters.include_scope_ids && filters.include_scope_ids.length > 0) {
+		inputs.scopeIds = filters.include_scope_ids;
+	}
+	return inputs;
+}
+
+/**
+ * Load sticky-rule memories layered by applies_to, ordered user → org →
+ * toolchain → project. Each layer is capped by its budget. Memories are
+ * filtered to active + non-deleted and (when scope filtering is requested)
+ * to the matching sharing domain(s).
+ */
+export function loadStickyRulesForPack(
+	store: StoreLike,
+	inputs?: StickyRulesInputs,
+): StickyRulesBand {
+	const budgets = resolveBudgets(inputs?.budgets);
+	// biome-ignore lint/suspicious/noExplicitAny: typed via drizzle internals
+	const d = drizzle(store.db as any, { schema });
+
+	const baseWhere = and(eq(schema.memoryItems.active, 1), isNull(schema.memoryItems.deleted_at));
+
+	const scopeFilter =
+		inputs?.scopeIds && inputs.scopeIds.length > 0
+			? or(
+					inArray(schema.memoryItems.scope_id, inputs.scopeIds),
+					isNull(schema.memoryItems.scope_id),
+					eq(schema.memoryItems.scope_id, ""),
+				)
+			: undefined;
+
+	function queryLayer(layer: AppliesTo, key: string | null | undefined, limit: number) {
+		if (limit <= 0) return [];
+		const requiresKey = layer === "org" || layer === "toolchain";
+		if (requiresKey && (key == null || key.length === 0)) return [];
+		const layerFilter = eq(schema.memoryItems.applies_to, layer);
+		const keyFilter = requiresKey
+			? eq(schema.memoryItems.applies_to_key, key as string)
+			: undefined;
+		const where = and(baseWhere, layerFilter, keyFilter, scopeFilter);
+		return d
+			.select()
+			.from(schema.memoryItems)
+			.where(where)
+			.orderBy(desc(schema.memoryItems.updated_at), desc(schema.memoryItems.id))
+			.limit(limit)
+			.all() as MemoryItem[];
+	}
+
+	// Project-layer is intentionally excluded from the sticky band: every
+	// memory defaults to applies_to='project', so pulling that layer would
+	// duplicate retrieval results and re-emit normal memories as "rules".
+	// The sticky band is for memories the user (or a future observer-driven
+	// inference pass) has promoted to a layer broader than the project. The
+	// project slot is kept on the response type for forward compatibility;
+	// a follow-up may opt-in pull a typed `kind='rule'` project subset
+	// without re-introducing the whole project tree.
+	const band: StickyRulesBand = {
+		user: queryLayer("user", null, budgets.user),
+		org: queryLayer("org", inputs?.orgKey ?? null, budgets.org),
+		toolchain: queryLayer("toolchain", inputs?.toolchainKey ?? null, budgets.toolchain),
+		project: [],
+		ids: [],
+	};
+
+	const seen = new Set<number>();
+	for (const layer of APPLIES_TO_LAYERS) {
+		for (const item of band[layer]) {
+			if (seen.has(item.id)) continue;
+			seen.add(item.id);
+			band.ids.push(item.id);
+		}
+	}
+
+	return band;
+}

--- a/packages/core/src/sticky-rules.ts
+++ b/packages/core/src/sticky-rules.ts
@@ -3,19 +3,19 @@
  * broader than the active project so they ride along on every pack request,
  * fighting long-context attention dilution.
  *
- * Sharing-domain wall: queries inherit the same scope_id filter the rest of
- * pack composition uses, so a user-scope rule recorded in one sharing
- * domain never bleeds into packs assembled for projects in a different
- * domain.
+ * Scope-visibility wall: every layer query goes through
+ * `buildFilterClausesWithContext({ enforceScopeVisibility: true })` so the
+ * sticky band honors the same scope-membership gates as `search`/`recent`.
+ * A user-scope rule recorded in a sharing domain the current device cannot
+ * read will not appear in packs assembled for projects the device can read.
  *
  * The (applies_to, applies_to_key) composite index from G1.1 backs every
  * lookup; verify EXPLAIN QUERY PLAN if you change the WHERE shape.
  */
 
-import { and, desc, eq, inArray, isNull, or } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/better-sqlite3";
 import { APPLIES_TO_LAYERS, type AppliesTo } from "./applicability.js";
-import * as schema from "./schema.js";
+import type { Database } from "./db.js";
+import { buildFilterClausesWithContext } from "./filters.js";
 import type { MemoryFilters, MemoryItem } from "./types.js";
 
 export interface StickyRuleBudgets {
@@ -46,8 +46,10 @@ export interface StickyRulesInputs {
 	budgets?: Partial<StickyRuleBudgets>;
 }
 
-interface StoreLike {
-	db: { prepare: (sql: string) => unknown };
+interface StickyRulesStore {
+	db: Database;
+	actorId: string;
+	deviceId: string;
 }
 
 function resolveBudgets(budgets?: Partial<StickyRuleBudgets>): StickyRuleBudgets {
@@ -63,6 +65,11 @@ function resolveBudgets(budgets?: Partial<StickyRuleBudgets>): StickyRuleBudgets
  * Mirrors the filter's scope_id list so the sharing-domain wall is preserved
  * by construction — callers cannot accidentally pull rules from a domain the
  * pack itself is filtering out.
+ *
+ * Note: this helper does NOT extract org/toolchain keys. The pack-side
+ * `MemoryFilters` shape has no field for them today; until callers thread a
+ * project-identity-derived key into the request, the org/toolchain layers
+ * stay empty by design.
  */
 export function stickyRuleInputsFromFilters(filters: MemoryFilters | undefined): StickyRulesInputs {
 	if (!filters) return {};
@@ -75,47 +82,64 @@ export function stickyRuleInputsFromFilters(filters: MemoryFilters | undefined):
 	return inputs;
 }
 
+function rowToMemoryItem(row: Record<string, unknown>): MemoryItem {
+	return row as unknown as MemoryItem;
+}
+
 /**
  * Load sticky-rule memories layered by applies_to, ordered user → org →
  * toolchain → project. Each layer is capped by its budget. Memories are
- * filtered to active + non-deleted and (when scope filtering is requested)
- * to the matching sharing domain(s).
+ * filtered to active + non-deleted, gated by scope visibility for the
+ * caller's device, and (when scope filtering is requested) narrowed to
+ * the matching sharing domain(s).
  */
 export function loadStickyRulesForPack(
-	store: StoreLike,
+	store: StickyRulesStore,
 	inputs?: StickyRulesInputs,
 ): StickyRulesBand {
 	const budgets = resolveBudgets(inputs?.budgets);
-	// biome-ignore lint/suspicious/noExplicitAny: typed via drizzle internals
-	const d = drizzle(store.db as any, { schema });
-
-	const baseWhere = and(eq(schema.memoryItems.active, 1), isNull(schema.memoryItems.deleted_at));
-
-	const scopeFilter =
-		inputs?.scopeIds && inputs.scopeIds.length > 0
-			? or(
-					inArray(schema.memoryItems.scope_id, inputs.scopeIds),
-					isNull(schema.memoryItems.scope_id),
-					eq(schema.memoryItems.scope_id, ""),
-				)
-			: undefined;
+	const ownership = {
+		actorId: store.actorId,
+		deviceId: store.deviceId,
+		enforceScopeVisibility: true,
+	};
 
 	function queryLayer(layer: AppliesTo, key: string | null | undefined, limit: number) {
 		if (limit <= 0) return [];
 		const requiresKey = layer === "org" || layer === "toolchain";
 		if (requiresKey && (key == null || key.length === 0)) return [];
-		const layerFilter = eq(schema.memoryItems.applies_to, layer);
-		const keyFilter = requiresKey
-			? eq(schema.memoryItems.applies_to_key, key as string)
-			: undefined;
-		const where = and(baseWhere, layerFilter, keyFilter, scopeFilter);
-		return d
-			.select()
-			.from(schema.memoryItems)
-			.where(where)
-			.orderBy(desc(schema.memoryItems.updated_at), desc(schema.memoryItems.id))
-			.limit(limit)
-			.all() as MemoryItem[];
+
+		// Build the scope-visibility-gated WHERE off MemoryFilters so we
+		// reuse the exact gate `search`/`recent` use. scope_id narrowing
+		// is layered on top of that gate, not in place of it.
+		const memoryFilters: MemoryFilters = {};
+		if (inputs?.scopeIds && inputs.scopeIds.length > 0) {
+			memoryFilters.include_scope_ids = inputs.scopeIds;
+		}
+		const filterResult = buildFilterClausesWithContext(memoryFilters, ownership);
+		const clauses: string[] = [
+			"memory_items.active = 1",
+			"memory_items.deleted_at IS NULL",
+			"memory_items.applies_to = ?",
+			...filterResult.clauses,
+		];
+		const params: unknown[] = [layer, ...filterResult.params];
+		if (requiresKey) {
+			clauses.push("memory_items.applies_to_key = ?");
+			params.push(key);
+		}
+		const joinClause = filterResult.joinSessions
+			? "JOIN sessions ON sessions.id = memory_items.session_id"
+			: "";
+		const sql = `SELECT memory_items.*
+			FROM memory_items
+			${joinClause}
+			WHERE ${clauses.join(" AND ")}
+			ORDER BY memory_items.updated_at DESC, memory_items.id DESC
+			LIMIT ?`;
+		params.push(limit);
+		const rows = store.db.prepare(sql).all(...params) as Record<string, unknown>[];
+		return rows.map(rowToMemoryItem);
 	}
 
 	// Project-layer is intentionally excluded from the sticky band: every

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -619,12 +619,22 @@ export interface PackItem {
 	compressed_ids?: number[];
 }
 
+/** Sticky-rules band injected at the top of every pack. Layered by applies_to. */
+export interface PackStickyRulesBand {
+	user: PackItem[];
+	org: PackItem[];
+	toolchain: PackItem[];
+	project: PackItem[];
+	ids: number[];
+}
+
 /** Pack response from buildMemoryPack() */
 export interface PackResponse {
 	context: string;
 	items: PackItem[];
 	item_ids: number[];
 	pack_text: string;
+	sticky_rules: PackStickyRulesBand;
 	metrics: {
 		total_items: number;
 		pack_tokens: number;


### PR DESCRIPTION
## Description

The user-visible payoff of the layered sticky-rules epic. Memories the user has promoted to a layer broader than the active project (user / org / toolchain) now ride along on every pack request as a dedicated `## Sticky Rules` band, prepended to the rest of the pack. This fights long-context attention dilution by re-emitting the rule near the head of the prompt regardless of vector similarity.

Builds on the schema (#1102) and viewer-mutation (#1103) PRs in this stack.

- **`packages/core/src/sticky-rules.ts`** — pure helper with `loadStickyRulesForPack`, `stickyRuleInputsFromFilters`, `STICKY_RULES_DEFAULT_BUDGETS` (user=5, org=3, toolchain=3). Three bounded queries layered by `applies_to`, each backed by the composite `(applies_to, applies_to_key)` index. EXPLAIN QUERY PLAN coverage included.
- **Sharing-domain wall by construction** — the helper threads `scope_id` from the active pack filter into its WHERE clause, so a user-scope rule recorded in one sharing domain never bleeds into packs assembled for projects in a different domain.
- **Project-layer is intentionally excluded** from the band — every memory defaults to `applies_to='project'`, so pulling that layer would duplicate retrieval and re-emit normal memories as "rules". The `project` slot is preserved on the response type for a future opt-in `kind='rule'` subset.
- **No double-pack** — sticky IDs are filtered out of retrieval `results` AND out of the per-section arrays before clustering, so a user-promoted memory that also matches the FTS query cannot appear twice in the same pack even when `store.recentByKinds` / `findLatestSummaryLike` fallbacks query the store directly. Regression test asserts the invariant.
- **`PackResponse.sticky_rules`** carries `{ user, org, toolchain, project, ids }` so consumers can introspect the band separately from the retrieval grid.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`) — workspace 1989/1989
- [x] Added/updated tests for changes — 14 helper unit tests (layered queries, key + scope filters, project-layer exclusion, budget overrides, EXPLAIN QUERY PLAN composite-index usage) + 3 pack integration tests (prepending, empty-band, no-double-pack invariant)
- [x] Manually verified changes work as expected — full `pnpm -w run test` green, pre-commit reviews (pragmatist + ramsay) flagged the no-dedup footgun and dead `void`/`sql` smells; addressed in-place before commit

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — no doc-only changes; the new section is its own visible documentation in any pack
- [x] No new warnings introduced

## Known limitation (follow-up filed)

The sticky band is prepended *after* token-budget trimming, so `pack_tokens` may exceed `token_budget` once users populate the band heavily. The "sticky rules are non-negotiable" semantic is intentional, but the metric reporting needs to be honest about it. Tracked as a follow-up to split `sticky_tokens` from `pack_tokens` in `PackResponse.metrics`.