### PR TITLE
feat(viewer): expose org/toolchain layers in the applicability picker

### DIFF
--- a/packages/core/src/applicability.test.ts
+++ b/packages/core/src/applicability.test.ts
@@ -67,6 +67,21 @@ describe("validateApplicability", () => {
 		const tc = validateApplicability({ applies_to: "toolchain", applies_to_key: "pnpm" });
 		expect(tc.applies_to_key).toBe("pnpm");
 	});
+
+	it("lowercases applies_to_key so casing variants converge", () => {
+		expect(
+			validateApplicability({ applies_to: "toolchain", applies_to_key: "PNPM" }).applies_to_key,
+		).toBe("pnpm");
+		expect(
+			validateApplicability({ applies_to: "toolchain", applies_to_key: "Pnpm" }).applies_to_key,
+		).toBe("pnpm");
+	});
+
+	it("collapses internal whitespace in applies_to_key", () => {
+		expect(
+			validateApplicability({ applies_to: "org", applies_to_key: "ACME   inc" }).applies_to_key,
+		).toBe("acme inc");
+	});
 });
 
 describe("normalizeApplicability (row → Applicability)", () => {

--- a/packages/core/src/applicability.ts
+++ b/packages/core/src/applicability.ts
@@ -33,8 +33,13 @@ function normalizeLayer(value: unknown): AppliesTo | null {
 
 function normalizeKey(value: unknown): string | null {
 	if (typeof value !== "string") return null;
-	const trimmed = value.trim();
-	return trimmed.length > 0 ? trimmed : null;
+	// Trim, lowercase, and collapse internal whitespace so peers can't
+	// fragment an org/toolchain by typing "PNPM" / "pnpm" / "pnpm " as
+	// three different keys. Toolchain keys (pnpm, cargo, go, bun) are
+	// lowercase by convention; org keys are treated as identifiers in
+	// the same namespace for simplicity.
+	const normalized = value.trim().toLowerCase().replace(/\s+/g, " ");
+	return normalized.length > 0 ? normalized : null;
 }
 
 /**

--- a/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
@@ -104,7 +104,6 @@ export function FeedItemCard({
 		item.applies_to === "project"
 			? item.applies_to
 			: "project";
-	const appliesToEditable = itemAppliesTo === "user" || itemAppliesTo === "project";
 	const [selectedAppliesTo, setSelectedAppliesTo] = useState<
 		"user" | "org" | "toolchain" | "project"
 	>(itemAppliesTo);
@@ -191,22 +190,59 @@ export function FeedItemCard({
 					) || h("div", { className: bodyClassName })
 			: h("div", { className: "feed-body" });
 
-	async function saveAppliesTo(next: "project" | "user") {
+	async function saveAppliesTo(
+		next: "user" | "org" | "toolchain" | "project",
+		nextKey: string | null = null,
+	) {
 		const previous = selectedAppliesTo;
-		if (next === previous) return;
+		const previousKey = item.applies_to_key ?? null;
+		if (next === previous && nextKey === previousKey) return;
 
-		// Broadening from project → user widens this rule's applicability
-		// to every project this device sees. Narrowing is safe and skips
-		// the prompt.
-		if (next === "user") {
-			const titleText = String(displayTitle || "this memory").trim();
-			const truncatedTitle =
-				titleText.length > 80 ? `${titleText.slice(0, 79).trimEnd()}…` : titleText;
+		const titleText = String(displayTitle || "this memory").trim();
+		const truncatedTitle =
+			titleText.length > 80 ? `${titleText.slice(0, 79).trimEnd()}…` : titleText;
+
+		// org/toolchain require a scope_key. Prompt the user for it (free-text in
+		// v1 — suggestions/picker arrive in a follow-up). Cancellation aborts.
+		let resolvedKey: string | null = nextKey;
+		if (next === "org" || next === "toolchain") {
+			const layerLabel = next === "org" ? "organization" : "toolchain";
+			const placeholder = next === "org" ? "e.g. acme, internal" : "e.g. pnpm, cargo, go";
+			const initialValue = previous === next ? (previousKey ?? "") : "";
+			const entered = await openSyncInputDialog({
+				title: `Apply to which ${layerLabel}?`,
+				description: `Promoting "${truncatedTitle}" to ${layerLabel} scope. Enter the ${layerLabel} key this rule should apply to (every project on this device that matches will see it).`,
+				initialValue,
+				placeholder,
+				confirmLabel: "Apply",
+				cancelLabel: "Cancel",
+				validate: (value) => {
+					const trimmed = value.trim();
+					if (!trimmed) return `Enter a ${layerLabel} key.`;
+					if (trimmed === previousKey && previous === next) return "Already set to this value.";
+					return null;
+				},
+			});
+			if (entered == null) return;
+			resolvedKey = entered.trim();
+			if (!resolvedKey) return;
+		}
+
+		// Broadening past project widens applicability. Confirm for any
+		// transition that crosses out of project-scope; narrowing back to
+		// project is safe.
+		if (next !== "project" && previous === "project") {
+			const layerSummary =
+				next === "user"
+					? "every project on this device"
+					: next === "org"
+						? `every project in the "${resolvedKey}" organization`
+						: `every project using the "${resolvedKey}" toolchain`;
 			const confirmed = await openSyncConfirmDialog({
 				autoFocusAction: "cancel",
-				title: "Apply to all your projects?",
-				description: `Promoting "${truncatedTitle}" to user scope means this rule will be injected into packs for every project on this device. You can scope it back to this project at any time.`,
-				confirmLabel: "Apply user-wide",
+				title: "Broaden this rule's scope?",
+				description: `Promoting "${truncatedTitle}" beyond this project means it will be injected into packs for ${layerSummary}. You can scope it back to this project at any time.`,
+				confirmLabel: "Broaden scope",
 				cancelLabel: "Keep project-only",
 				tone: "default",
 			});
@@ -218,15 +254,19 @@ export function FeedItemCard({
 		setSelectedAppliesTo(next);
 		setSavingAppliesTo(true);
 		try {
-			const payload = await api.updateMemoryApplicability(memoryId, next, null);
+			const payload = await api.updateMemoryApplicability(memoryId, next, resolvedKey);
 			if (payload?.item) {
 				onReplace(payload.item as FeedItem);
 				onViewRefresh();
 			}
 			showGlobalNotice(
-				next === "user"
-					? "Rule now applies across all your projects."
-					: "Rule scoped back to this project.",
+				next === "project"
+					? "Rule scoped back to this project."
+					: next === "user"
+						? "Rule now applies across all your projects."
+						: next === "org"
+							? `Rule now applies across every project in the ${resolvedKey} organization.`
+							: `Rule now applies across every project on the ${resolvedKey} toolchain.`,
 			);
 		} catch (error) {
 			setSelectedAppliesTo(previous);
@@ -462,38 +502,41 @@ export function FeedItemCard({
 									h("option", { value: "shared" }, "Share with peers"),
 								),
 								h("div", { className: "feed-visibility-note" }, visibilityNote),
-								appliesToEditable
-									? h(
-											"select",
-											{
-												"aria-label": `Applicability scope for ${String(item.title || "memory")}`,
-												className: "feed-applies-to-select",
-												disabled: savingAppliesTo,
-												onChange: (event) => {
-													const nextValue =
-														String((event.currentTarget as HTMLSelectElement).value) === "user"
-															? "user"
-															: "project";
-													void saveAppliesTo(nextValue);
-												},
-												title:
-													"Org and toolchain layers are managed in advanced settings (coming soon).",
-												value: selectedAppliesTo,
-											},
-											h("option", { value: "project" }, "Project — this project only"),
-											h("option", { value: "user" }, "User — all your projects"),
-										)
-									: h(
-											"div",
-											{
-												className: "feed-applies-to-readonly",
-												title:
-													"This memory is scoped to an org or toolchain. Manage these in advanced settings (coming soon).",
-											},
-											`${selectedAppliesTo === "org" ? "Org" : "Toolchain"}${
-												item.applies_to_key ? ` (${item.applies_to_key})` : ""
-											}`,
-										),
+								h(
+									"select",
+									{
+										"aria-label": `Applicability scope for ${String(item.title || "memory")}`,
+										className: "feed-applies-to-select",
+										disabled: savingAppliesTo,
+										onChange: (event) => {
+											const raw = String((event.currentTarget as HTMLSelectElement).value);
+											const nextValue: "user" | "org" | "toolchain" | "project" =
+												raw === "user" || raw === "org" || raw === "toolchain" ? raw : "project";
+											void saveAppliesTo(nextValue);
+										},
+										value: selectedAppliesTo,
+									},
+									h("option", { value: "project" }, "Project — this project only"),
+									h("option", { value: "user" }, "User — all your projects"),
+									h(
+										"option",
+										{ value: "toolchain" },
+										selectedAppliesTo === "toolchain"
+											? item.applies_to_key
+												? `Toolchain (${item.applies_to_key}) — projects on this toolchain`
+												: "Toolchain (no key) — needs a toolchain key"
+											: "Toolchain — pick a toolchain…",
+									),
+									h(
+										"option",
+										{ value: "org" },
+										selectedAppliesTo === "org"
+											? item.applies_to_key
+												? `Org (${item.applies_to_key}) — projects in this org`
+												: "Org (no key) — needs an organization key"
+											: "Org — pick an organization…",
+									),
+								),
 							)
 						: null,
 				),

--- a/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
@@ -196,7 +196,17 @@ export function FeedItemCard({
 	) {
 		const previous = selectedAppliesTo;
 		const previousKey = item.applies_to_key ?? null;
-		if (next === previous && nextKey === previousKey) return;
+		// No-op only when the current state is already valid for the chosen
+		// layer. For org/toolchain rows that arrived without a key (malformed
+		// peer payload), re-selecting the same layer should fall through to
+		// the key-input dialog so the user can repair the row in place —
+		// otherwise they'd have to bounce through another layer just to set
+		// the required key.
+		const currentLayerNeedsKey = previous === "org" || previous === "toolchain";
+		const currentKeyMissing = previousKey == null || previousKey.length === 0;
+		const wouldBeNoop =
+			next === previous && nextKey === previousKey && !(currentLayerNeedsKey && currentKeyMissing);
+		if (wouldBeNoop) return;
 
 		const titleText = String(displayTitle || "this memory").trim();
 		const truncatedTitle =


### PR DESCRIPTION
## Description

Extends the applicability picker in `FeedItemCard` to expose all four `applies_to` layers (project / user / org / toolchain). Backend has supported all four since #1102; the v1 viewer dropdown only offered project↔user because org/toolchain need a `scope_key` input. This slice fills the gap and tightens key normalization so the free-text input doesn't fragment.

- **Picker:** dropdown lists all four layers; selecting org or toolchain opens the existing `openSyncInputDialog` for a free-text scope_key. Cancel aborts.
- **Broadening confirmation** triggers on any transition out of project scope (project→user, project→org, project→toolchain) and reuses the sync confirm dialog with layer-specific copy.
- **Key normalization:** `normalizeKey` now lowercases and collapses internal whitespace in addition to trimming. Without this, `"PNPM"` / `"pnpm"` / `"pnpm "` would fragment a single toolchain into three distinct layers. Toolchain keys are lowercase by convention; org keys join the same namespace for simplicity. A smarter org casing story is filed as a follow-up alongside the suggestions picker.
- **Repair-friendly labels:** if an org or toolchain row arrives with a missing key (malformed peer payload), the option renders `Toolchain (no key) — needs a toolchain key` instead of the unset-prompt label.
- **Notice copy:** success notice reads `…across every project on the pnpm toolchain` / `…across every project in the acme organization` rather than leaking the raw enum name.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`) — workspace 1992/1992
- [x] Added/updated tests for changes — 2 new applicability validator tests covering case folding and whitespace collapse; existing 15 untouched and still passing
- [x] Manually verified changes work as expected — UI bundle builds; the dropdown + dialog wiring follows the same patterns as the existing `moveMemoryProject` flow. Pre-commit reviews flagged the normalization gap (would have shipped a fragmentation footgun), the leaky raw-enum notice grammar, and the misleading "pick a…" label for missing-key rows — all addressed before commit.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — no doc changes required
- [x] No new warnings introduced

## Known limitations (follow-ups filed)

- No suggestions list: users type the org/toolchain key from memory. A `GET /api/memories/applies-to-keys?layer=…` endpoint feeding the dialog's `suggestions` field is filed as a follow-up so existing keys can be picked instead of re-typed.