### PR TITLE
chore(core): log replication-op emit failures in updateMemoryVisibility

### DIFF
--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1194,8 +1194,14 @@ export class MemoryStore {
 						opType: "upsert",
 						deviceId: this.deviceId,
 					});
-				} catch {
-					// Non-fatal
+				} catch (err) {
+					// Non-fatal for the visibility write itself, but surface
+					// the failure: peers won't learn about this change until
+					// the next reconciliation pass, and a silent swallow
+					// hides whatever broke the replication path.
+					console.warn(
+						`[codemem] updateMemoryVisibility: replication-op emit failed for memory ${memoryId}: ${err instanceof Error ? err.message : String(err)}`,
+					);
 				}
 
 				const updated = this.get(memoryId);


### PR DESCRIPTION
## Description

`updateMemoryVisibility` wraps `recordReplicationOp` in a silent `try/catch` with `\"Non-fatal\"` as the only comment. The intent (don't fail the visibility write on a replication hiccup) is correct, but the silence hides whatever actually broke the replication path — peers stop learning about the change and no signal reaches the operator.

Replace the swallow with a structured `console.warn` using the existing `[codemem]` prefix convention (matches `db.ts`, `observer-client.ts`, `sync-discovery.ts`, etc.). Includes the memory id and the error message so a failure leaves a forensic trail without crashing the caller. Behavior is otherwise unchanged.

This is a standalone re-do of the visibility-side change from the now-closed sticky-rules feature stack; the rest of that feature was scrapped.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`) — workspace 1927/1927
- [x] Added/updated tests for changes — observability-only change, no new tests; the existing replication-op emit tests already exercise the happy path
- [x] Manually verified changes work as expected — log message format matches existing `[codemem]` log lines

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — N/A
- [x] No new warnings introduced