### PR TITLE
fix(security): address first-pass CodeQL alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
 
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   tsc:
     name: TypeScript Check

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -31,6 +31,10 @@ import {
 	resolveDbOpt,
 } from "../shared-options.js";
 
+function escapeSqlLikePattern(value: string): string {
+	return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
+}
+
 function formatBytes(bytes: number): string {
 	if (bytes < 1024) return `${bytes} B`;
 	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -308,7 +312,7 @@ renameProjectCmd.action((oldName: string, newName: string, opts: DbOpts & { appl
 	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
 	try {
 		const dryRun = !opts.apply;
-		const escapedOld = oldName.replace(/%/g, "\\%").replace(/_/g, "\\_");
+		const escapedOld = escapeSqlLikePattern(oldName);
 		const suffixPattern = `%/${escapedOld}`;
 		const tables = ["sessions", "raw_event_sessions"] as const;
 		const counts: Record<string, number> = {};

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -33,6 +33,7 @@ export const statsCommand = statsCmd.action((opts: DbOpts & JsonOpts) => {
 	try {
 		const result = store.stats();
 		if (opts.json) {
+			// lgtm[js/clear-text-logging] This is intentional CLI stdout for `--json`, not an application log.
 			console.log(JSON.stringify(result, null, 2));
 			return;
 		}

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -31,6 +31,12 @@ import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
 const VALID_INVITE_POLICIES = new Set(["auto_admit", "approval_required"]);
 const INVITE_IMPORT_TIMEOUT_S = 10;
 
+function stripTrailingSlashes(value: string): string {
+	let end = value.length;
+	while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+	return end === value.length ? value : value.slice(0, end);
+}
+
 function coordinatorRemoteTarget(config = readCodememConfigFile()): {
 	remoteUrl: string | null;
 	adminSecret: string | null;
@@ -201,7 +207,7 @@ export async function coordinatorCreateGroupAction(opts: {
 		if (!adminSecret) throw new Error("Admin secret required.");
 		const payload = await remoteRequest(
 			"POST",
-			`${remote.replace(/\/+$/, "")}/v1/admin/groups`,
+			`${stripTrailingSlashes(remote)}/v1/admin/groups`,
 			adminSecret,
 			{ group_id: groupId, display_name: opts.displayName ?? null },
 		);
@@ -239,7 +245,7 @@ export async function coordinatorRenameGroupAction(opts: {
 		try {
 			payload = await remoteRequest(
 				"POST",
-				`${remote.replace(/\/+$/, "")}/v1/admin/groups/rename`,
+				`${stripTrailingSlashes(remote)}/v1/admin/groups/rename`,
 				adminSecret,
 				{ group_id: groupId, display_name: displayName },
 			);
@@ -276,7 +282,7 @@ export async function coordinatorArchiveGroupAction(opts: {
 		try {
 			payload = await remoteRequest(
 				"POST",
-				`${remote.replace(/\/+$/, "")}/v1/admin/groups/archive`,
+				`${stripTrailingSlashes(remote)}/v1/admin/groups/archive`,
 				adminSecret,
 				{ group_id: groupId },
 			);
@@ -314,7 +320,7 @@ export async function coordinatorUnarchiveGroupAction(opts: {
 		try {
 			payload = await remoteRequest(
 				"POST",
-				`${remote.replace(/\/+$/, "")}/v1/admin/groups/unarchive`,
+				`${stripTrailingSlashes(remote)}/v1/admin/groups/unarchive`,
 				adminSecret,
 				{ group_id: groupId },
 			);
@@ -349,7 +355,7 @@ export async function coordinatorListGroupsAction(opts?: {
 		if (!adminSecret) throw new Error("Admin secret required.");
 		const payload = await remoteRequest(
 			"GET",
-			`${remote.replace(/\/+$/, "")}/v1/admin/groups${includeArchived ? "?include_archived=1" : ""}`,
+			`${stripTrailingSlashes(remote)}/v1/admin/groups${includeArchived ? "?include_archived=1" : ""}`,
 			adminSecret,
 		);
 		return Array.isArray(payload?.items)
@@ -382,7 +388,7 @@ export async function coordinatorListScopesAction(opts: {
 		if (!adminSecret) throw new Error("Admin secret required.");
 		const payload = await remoteRequest(
 			"GET",
-			`${remote.replace(/\/+$/, "")}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes${opts.includeInactive ? "?include_inactive=1" : ""}`,
+			`${stripTrailingSlashes(remote)}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes${opts.includeInactive ? "?include_inactive=1" : ""}`,
 			adminSecret,
 		);
 		return Array.isArray(payload?.items)
@@ -427,7 +433,7 @@ export async function coordinatorCreateScopeAction(opts: {
 		if (!adminSecret) throw new Error("Admin secret required.");
 		const payload = await remoteRequest(
 			"POST",
-			`${remote.replace(/\/+$/, "")}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes`,
+			`${stripTrailingSlashes(remote)}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes`,
 			adminSecret,
 			{
 				scope_id: scopeId,
@@ -494,7 +500,7 @@ export async function coordinatorUpdateScopeAction(opts: {
 		try {
 			payload = await remoteRequest(
 				"PATCH",
-				`${remote.replace(/\/+$/, "")}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes/${encodeURIComponent(scopeId)}`,
+				`${stripTrailingSlashes(remote)}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes/${encodeURIComponent(scopeId)}`,
 				adminSecret,
 				{
 					label: opts.label ?? undefined,
@@ -553,7 +559,7 @@ export async function coordinatorListScopeMembershipsAction(opts: {
 		if (!adminSecret) throw new Error("Admin secret required.");
 		const payload = await remoteRequest(
 			"GET",
-			`${remote.replace(/\/+$/, "")}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes/${encodeURIComponent(scopeId)}/members${opts.includeRevoked ? "?include_revoked=1" : ""}`,
+			`${stripTrailingSlashes(remote)}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes/${encodeURIComponent(scopeId)}/members${opts.includeRevoked ? "?include_revoked=1" : ""}`,
 			adminSecret,
 		);
 		return Array.isArray(payload?.items)
@@ -594,7 +600,7 @@ export async function coordinatorGrantScopeMembershipAction(
 		if (!adminSecret) throw new Error("Admin secret required.");
 		const payload = await remoteRequest(
 			"POST",
-			`${remote.replace(/\/+$/, "")}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes/${encodeURIComponent(scopeId)}/members`,
+			`${stripTrailingSlashes(remote)}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes/${encodeURIComponent(scopeId)}/members`,
 			adminSecret,
 			{
 				device_id: deviceId,
@@ -658,7 +664,7 @@ export async function coordinatorRevokeScopeMembershipAction(
 		try {
 			await remoteRequest(
 				"POST",
-				`${remote.replace(/\/+$/, "")}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes/${encodeURIComponent(scopeId)}/members/${encodeURIComponent(deviceId)}/revoke`,
+				`${stripTrailingSlashes(remote)}/v1/admin/groups/${encodeURIComponent(groupId)}/scopes/${encodeURIComponent(scopeId)}/members/${encodeURIComponent(deviceId)}/revoke`,
 				adminSecret,
 				{
 					membership_epoch: opts.membershipEpoch ?? null,
@@ -737,7 +743,7 @@ export async function coordinatorListDevicesAction(opts: {
 		if (!adminSecret) throw new Error("Admin secret required.");
 		const payload = await remoteRequest(
 			"GET",
-			`${remote.replace(/\/+$/, "")}/v1/admin/devices?group_id=${encodeURIComponent(groupId)}&include_disabled=${opts.includeDisabled ? "1" : "0"}`,
+			`${stripTrailingSlashes(remote)}/v1/admin/devices?group_id=${encodeURIComponent(groupId)}&include_disabled=${opts.includeDisabled ? "1" : "0"}`,
 			adminSecret,
 		);
 		return Array.isArray(payload?.items)
@@ -776,7 +782,7 @@ export async function coordinatorRenameDeviceAction(opts: {
 		try {
 			payload = await remoteRequest(
 				"POST",
-				`${remote.replace(/\/+$/, "")}/v1/admin/devices/rename`,
+				`${stripTrailingSlashes(remote)}/v1/admin/devices/rename`,
 				adminSecret,
 				{ group_id: groupId, device_id: deviceId, display_name: displayName },
 			);
@@ -823,7 +829,7 @@ export async function coordinatorDisableDeviceAction(opts: {
 		try {
 			await remoteRequest(
 				"POST",
-				`${remote.replace(/\/+$/, "")}/v1/admin/devices/disable`,
+				`${stripTrailingSlashes(remote)}/v1/admin/devices/disable`,
 				adminSecret,
 				{ group_id: groupId, device_id: deviceId },
 			);
@@ -864,7 +870,7 @@ export async function coordinatorEnableDeviceAction(opts: {
 		try {
 			await remoteRequest(
 				"POST",
-				`${remote.replace(/\/+$/, "")}/v1/admin/devices/enable`,
+				`${stripTrailingSlashes(remote)}/v1/admin/devices/enable`,
 				adminSecret,
 				{ group_id: groupId, device_id: deviceId },
 			);
@@ -905,7 +911,7 @@ export async function coordinatorRemoveDeviceAction(opts: {
 		try {
 			await remoteRequest(
 				"POST",
-				`${remote.replace(/\/+$/, "")}/v1/admin/devices/remove`,
+				`${stripTrailingSlashes(remote)}/v1/admin/devices/remove`,
 				adminSecret,
 				{ group_id: groupId, device_id: deviceId },
 			);
@@ -948,7 +954,7 @@ export async function coordinatorCreateInviteAction(opts: {
 			throw new Error("Admin secret required to create invites via the coordinator API.");
 		const payload = await remoteRequest(
 			"POST",
-			`${remote.replace(/\/+$/, "")}/v1/admin/invites`,
+			`${stripTrailingSlashes(remote)}/v1/admin/invites`,
 			adminSecret,
 			{
 				group_id: opts.groupId,
@@ -1035,7 +1041,7 @@ export async function coordinatorImportInviteAction(opts: {
 	// trailing slashes before comparing so harmless formatting differences
 	// (e.g. `https://coord.example.com` vs. `…/`) don't reject valid same-
 	// coordinator invites.
-	const normalizeCoordinatorUrl = (value: string): string => value.trim().replace(/\/+$/, "");
+	const normalizeCoordinatorUrl = (value: string): string => stripTrailingSlashes(value.trim());
 	const existingCoordinator = normalizeCoordinatorUrl(String(config.sync_coordinator_url ?? ""));
 	const incomingCoordinator = normalizeCoordinatorUrl(coordinatorUrl);
 	if (existingCoordinator && existingCoordinator !== incomingCoordinator) {
@@ -1048,7 +1054,7 @@ export async function coordinatorImportInviteAction(opts: {
 	try {
 		[status, response] = await requestJson(
 			"POST",
-			`${coordinatorUrl.replace(/\/+$/, "")}/v1/join`,
+			`${stripTrailingSlashes(coordinatorUrl)}/v1/join`,
 			{
 				body: {
 					token: String(payload.token),
@@ -1111,7 +1117,7 @@ export async function coordinatorListJoinRequestsAction(opts: {
 		if (!adminSecret) throw new Error("Admin secret required.");
 		const payload = await remoteRequest(
 			"GET",
-			`${remote.replace(/\/+$/, "")}/v1/admin/join-requests?group_id=${encodeURIComponent(opts.groupId)}`,
+			`${stripTrailingSlashes(remote)}/v1/admin/join-requests?group_id=${encodeURIComponent(opts.groupId)}`,
 			adminSecret,
 		);
 		return Array.isArray(payload?.items)
@@ -1145,7 +1151,7 @@ export async function coordinatorReviewJoinRequestAction(opts: {
 			: "/v1/admin/join-requests/deny";
 		const payload = await remoteRequest(
 			"POST",
-			`${remote.replace(/\/+$/, "")}${endpoint}`,
+			`${stripTrailingSlashes(remote)}${endpoint}`,
 			adminSecret,
 			{
 				request_id: opts.requestId,
@@ -1181,7 +1187,7 @@ export async function coordinatorListBootstrapGrantsAction(opts: {
 		if (!adminSecret) throw new Error("Admin secret required.");
 		const payload = await remoteRequest(
 			"GET",
-			`${remote.replace(/\/+$/, "")}/v1/admin/bootstrap-grants?group_id=${encodeURIComponent(opts.groupId)}`,
+			`${stripTrailingSlashes(remote)}/v1/admin/bootstrap-grants?group_id=${encodeURIComponent(opts.groupId)}`,
 			adminSecret,
 		);
 		return Array.isArray(payload?.items)
@@ -1211,7 +1217,7 @@ export async function coordinatorRevokeBootstrapGrantAction(opts: {
 		try {
 			await remoteRequest(
 				"POST",
-				`${remote.replace(/\/+$/, "")}/v1/admin/bootstrap-grants/revoke`,
+				`${stripTrailingSlashes(remote)}/v1/admin/bootstrap-grants/revoke`,
 				adminSecret,
 				{ grant_id: opts.grantId },
 			);

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -17,7 +17,7 @@ import {
 } from "./ingest-events.js";
 import { isLowSignalObservation, normalizeObservation } from "./ingest-filters.js";
 import { type IngestOptions, ingest } from "./ingest-pipeline.js";
-import { stripPrivate } from "./ingest-sanitize.js";
+import { isSensitiveFieldName, stripPrivate } from "./ingest-sanitize.js";
 import {
 	buildTranscript,
 	deriveRequest,
@@ -427,6 +427,17 @@ describe("ingest-sanitize", () => {
 
 		it("is case-insensitive", () => {
 			expect(stripPrivate("a <PRIVATE>b</PRIVATE> c")).toBe("a  c");
+		});
+
+		it("removes stray closing tags before later private blocks", () => {
+			expect(stripPrivate("a </private> b <private>secret</private> c")).toBe("a  b  c");
+		});
+	});
+
+	describe("isSensitiveFieldName", () => {
+		it("detects camelCase API and private key names", () => {
+			expect(isSensitiveFieldName("apiKey")).toBe(true);
+			expect(isSensitiveFieldName("privateKey")).toBe(true);
 		});
 	});
 });

--- a/packages/core/src/ingest-sanitize.ts
+++ b/packages/core/src/ingest-sanitize.ts
@@ -9,9 +9,8 @@
 // Private content stripping
 // ---------------------------------------------------------------------------
 
-const PRIVATE_BLOCK_RE = /<private>.*?<\/private>/gis;
-const PRIVATE_OPEN_RE = /<private>/i;
-const PRIVATE_CLOSE_RE = /<\/private>/gi;
+const PRIVATE_OPEN = "<private>";
+const PRIVATE_CLOSE = "</private>";
 
 /**
  * Remove `<private>…</private>` blocks from text.
@@ -21,31 +20,74 @@ const PRIVATE_CLOSE_RE = /<\/private>/gi;
  */
 export function stripPrivate(text: string): string {
 	if (!text) return "";
-	// Remove matched pairs
-	let redacted = text.replace(PRIVATE_BLOCK_RE, "");
-	// Orphaned opening tag — truncate everything after it
-	const openMatch = PRIVATE_OPEN_RE.exec(redacted);
-	if (openMatch) {
-		redacted = redacted.slice(0, openMatch.index);
+	let remaining = text;
+	let lowered = remaining.toLowerCase();
+	let output = "";
+	while (remaining) {
+		const openIndex = lowered.indexOf(PRIVATE_OPEN);
+		const closeIndex = lowered.indexOf(PRIVATE_CLOSE);
+		if (openIndex < 0) {
+			if (closeIndex < 0) return output + remaining;
+			output += remaining.slice(0, closeIndex);
+			remaining = remaining.slice(closeIndex + PRIVATE_CLOSE.length);
+			lowered = remaining.toLowerCase();
+			continue;
+		}
+		if (closeIndex >= 0 && closeIndex < openIndex) {
+			output += remaining.slice(0, closeIndex);
+			remaining = remaining.slice(closeIndex + PRIVATE_CLOSE.length);
+			lowered = remaining.toLowerCase();
+			continue;
+		}
+		output += remaining.slice(0, openIndex);
+		const blockCloseIndex = lowered.indexOf(PRIVATE_CLOSE, openIndex + PRIVATE_OPEN.length);
+		if (blockCloseIndex < 0) return output;
+		remaining = remaining.slice(blockCloseIndex + PRIVATE_CLOSE.length);
+		lowered = remaining.toLowerCase();
 	}
-	// Stray closing tags
-	redacted = redacted.replace(PRIVATE_CLOSE_RE, "");
-	return redacted;
+	return output;
 }
 
 // ---------------------------------------------------------------------------
 // Sensitive field detection
 // ---------------------------------------------------------------------------
 
-const SENSITIVE_FIELD_RE =
-	/(?:^|_|-)(?:token|secret|password|passwd|api[_-]?key|authorization|private[_-]?key|cookie)(?:$|_|-)/i;
-
 const REDACTED_VALUE = "[REDACTED]";
+
+function fieldSegments(value: string): string[] {
+	const segments: string[] = [];
+	let current = "";
+	for (const ch of value) {
+		if (ch === "_" || ch === "-") {
+			const trimmed = current.trim();
+			if (trimmed) segments.push(trimmed);
+			current = "";
+		} else {
+			current += ch;
+		}
+	}
+	const trimmed = current.trim();
+	if (trimmed) segments.push(trimmed);
+	return segments;
+}
 
 export function isSensitiveFieldName(fieldName: string): boolean {
 	const normalized = fieldName.trim().toLowerCase();
 	if (!normalized) return false;
-	return SENSITIVE_FIELD_RE.test(normalized);
+	if (normalized.includes("apikey") || normalized.includes("privatekey")) return true;
+	const segments = fieldSegments(normalized);
+	if (
+		segments.some((part) =>
+			["token", "secret", "password", "passwd", "authorization", "cookie"].includes(part),
+		)
+	) {
+		return true;
+	}
+	return (
+		segments.length >= 2 &&
+		((segments.includes("api") && segments.includes("key")) ||
+			(segments.includes("private") && segments.includes("key")))
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/ingest-transcript.ts
+++ b/packages/core/src/ingest-transcript.ts
@@ -29,14 +29,60 @@ export const TRIVIAL_REQUESTS = new Set([
 	"proceed",
 ]);
 
+function stripEdgeQuotes(value: string): string {
+	let start = 0;
+	let end = value.length;
+	while (start < end && (value[start] === '"' || value[start] === "'")) start++;
+	while (end > start && (value[end - 1] === '"' || value[end - 1] === "'")) end--;
+	return value.slice(start, end);
+}
+
+function collapseWhitespace(value: string): string {
+	const parts: string[] = [];
+	let current = "";
+	for (const ch of value) {
+		if (ch === " " || ch === "\n" || ch === "\r" || ch === "\t") {
+			if (current) {
+				parts.push(current);
+				current = "";
+			}
+		} else {
+			current += ch;
+		}
+	}
+	if (current) parts.push(current);
+	return parts.join(" ");
+}
+
+function stripMarkdownSentencePrefix(value: string): string {
+	let index = 0;
+	while (index < value.length) {
+		const ch = value[index];
+		if (ch !== "#" && ch !== "*" && ch !== "-" && ch !== "." && ch !== " " && ch !== "\t") {
+			const code = value.charCodeAt(index);
+			if (code < 48 || code > 57) break;
+		}
+		index++;
+	}
+	return value.slice(index);
+}
+
+function splitFirstSentence(value: string): string {
+	for (let i = 0; i < value.length - 1; i++) {
+		const ch = value[i];
+		const next = value[i + 1];
+		if ((ch === "." || ch === "!" || ch === "?") && (next === " " || next === "\t")) {
+			return value.slice(0, i + 1);
+		}
+	}
+	return value;
+}
+
 /** Normalize request text for comparison: trim, strip quotes, collapse whitespace, lowercase. */
 export function normalizeRequestText(text: string | null): string {
 	if (!text) return "";
-	let cleaned = text
-		.trim()
-		.replace(/^["']+|["']+$/g, "")
-		.trim();
-	cleaned = cleaned.replace(/\s+/g, " ");
+	let cleaned = stripEdgeQuotes(text.trim()).trim();
+	cleaned = collapseWhitespace(cleaned);
 	return cleaned.toLowerCase();
 }
 
@@ -58,9 +104,8 @@ export function firstSentence(text: string): string {
 		.map((l) => l.trim())
 		.filter(Boolean)
 		.join(" ");
-	cleaned = cleaned.replace(/^[#*\-\d.\s]+/, "");
-	const parts = cleaned.split(/(?<=[.!?])\s+/);
-	return (parts[0] ?? cleaned).trim();
+	cleaned = stripMarkdownSentencePrefix(cleaned);
+	return splitFirstSentence(cleaned).trim();
 }
 
 /** Derive a meaningful request from summary fields when the original is trivial. */

--- a/packages/core/src/maintenance/narrative-extract.ts
+++ b/packages/core/src/maintenance/narrative-extract.ts
@@ -3,15 +3,28 @@
 export function extractNarrativeFromBody(bodyText: string): string | null {
 	// Match sections like "## Completed\n...\n\n## Learned\n..."
 	const sections: string[] = [];
+	const lines = bodyText.split("\n");
 
-	const completedMatch = bodyText.match(/##\s*Completed\s*\n([\s\S]*?)(?=\n##\s|\n*$)/);
-	if (completedMatch?.[1]?.trim()) {
-		sections.push(completedMatch[1].trim());
+	const readSection = (heading: string): string | null => {
+		const start = lines.findIndex((line) => line.trim().toLowerCase() === `## ${heading}`);
+		if (start < 0) return null;
+		const body: string[] = [];
+		for (const line of lines.slice(start + 1)) {
+			if (line.trim().startsWith("## ")) break;
+			body.push(line);
+		}
+		const value = body.join("\n").trim();
+		return value || null;
+	};
+
+	const completed = readSection("completed");
+	if (completed) {
+		sections.push(completed);
 	}
 
-	const learnedMatch = bodyText.match(/##\s*Learned\s*\n([\s\S]*?)(?=\n##\s|\n*$)/);
-	if (learnedMatch?.[1]?.trim()) {
-		sections.push(learnedMatch[1].trim());
+	const learned = readSection("learned");
+	if (learned) {
+		sections.push(learned);
 	}
 
 	if (sections.length === 0) return null;

--- a/packages/core/src/observer-auth.ts
+++ b/packages/core/src/observer-auth.ts
@@ -205,18 +205,48 @@ export function runAuthCommand(command: string[], timeoutMs: number): string | n
 	}
 }
 
+function expandEnvVars(value: string): string {
+	let result = "";
+	for (let i = 0; i < value.length; i++) {
+		if (value[i] !== "$" || i === value.length - 1) {
+			result += value[i];
+			continue;
+		}
+		if (value[i + 1] === "{") {
+			const end = value.indexOf("}", i + 2);
+			if (end > i + 2) {
+				const name = value.slice(i + 2, end);
+				result += process.env[name] ?? value.slice(i, end + 1);
+				i = end;
+				continue;
+			}
+		}
+		const start = i + 1;
+		let end = start;
+		while (end < value.length) {
+			const code = value.charCodeAt(end);
+			const isLetter = (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+			const isDigit = code >= 48 && code <= 57;
+			if (!isLetter && !isDigit && code !== 95) break;
+			end++;
+		}
+		const name = value.slice(start, end);
+		if (!name || !Number.isNaN(Number(name[0]))) {
+			result += "$";
+			continue;
+		}
+		result += process.env[name] ?? value.slice(i, end);
+		i = end - 1;
+	}
+	return result;
+}
+
 /** Read a token from a file path (supports `~` and `$ENV_VAR` expansion). */
 export function readAuthFile(filePath: string | null): string | null {
 	if (!filePath) return null;
 	// Expand ~ and $ENV_VAR
-	let resolved = filePath.replace(/^~/, codememHomeDir());
-	resolved = resolved.replace(
-		/\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
-		(match, braced, bare) => {
-			const name = braced ?? bare;
-			return process.env[name] ?? match;
-		},
-	);
+	let resolved = filePath.startsWith("~") ? `${codememHomeDir()}${filePath.slice(1)}` : filePath;
+	resolved = expandEnvVars(resolved);
 	try {
 		if (!existsSync(resolved) || !statSync(resolved).isFile()) return null;
 		const token = readFileSync(resolved, "utf-8").trim();

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -11,7 +11,7 @@
 
 import { execFile } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
 import { codememHomeDir } from "./home.js";
 
@@ -57,6 +57,30 @@ const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
 const FETCH_TIMEOUT_MS = 60_000;
 
 const CLAUDE_SIDECAR_TIMEOUT_MS = 120_000;
+
+function stripTrailingSlashes(value: string): string {
+	let end = value.length;
+	while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+	return end === value.length ? value : value.slice(0, end);
+}
+
+function isSafeCommandName(value: string): boolean {
+	if (!value || value === "." || value === "..") return false;
+	for (let i = 0; i < value.length; i++) {
+		const code = value.charCodeAt(i);
+		const isLetter = (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+		const isDigit = code >= 48 && code <= 57;
+		if (!isLetter && !isDigit && code !== 45 && code !== 46 && code !== 95) return false;
+	}
+	return true;
+}
+
+function validateSidecarExecutable(value: string): string | null {
+	const executable = value.trim();
+	if (!executable) return null;
+	if (isAbsolute(executable)) return executable;
+	return isSafeCommandName(executable) ? executable : null;
+}
 
 // Anthropic model name aliases (friendly → API id)
 const ANTHROPIC_MODEL_ALIASES: Record<string, string> = {
@@ -1399,7 +1423,7 @@ export class ObserverClient {
 
 			let url: string;
 			if (this._customBaseUrl) {
-				url = `${this._customBaseUrl.replace(/\/+$/, "")}/responses`;
+				url = `${stripTrailingSlashes(this._customBaseUrl)}/responses`;
 			} else {
 				url = "https://api.openai.com/v1/responses";
 			}
@@ -1629,7 +1653,7 @@ export class ObserverClient {
 	): Promise<string | null> {
 		let url: string;
 		if (this._customBaseUrl) {
-			url = `${this._customBaseUrl.replace(/\/+$/, "")}/${this.openaiUseResponses ? "responses" : "chat/completions"}`;
+			url = `${stripTrailingSlashes(this._customBaseUrl)}/${this.openaiUseResponses ? "responses" : "chat/completions"}`;
 		} else {
 			url = this.openaiUseResponses
 				? "https://api.openai.com/v1/responses"
@@ -1760,7 +1784,14 @@ export class ObserverClient {
 		useModel: boolean,
 	): Promise<{ output: string | null; error: string | null; reportedModel: string | null }> {
 		const cmd = this._buildSidecarCommand(prompt, useModel);
-		const executable = cmd[0] ?? "claude";
+		const executable = validateSidecarExecutable(cmd[0] ?? "claude");
+		if (!executable) {
+			return {
+				output: null,
+				error: "configured claude command is invalid",
+				reportedModel: null,
+			};
+		}
 		const args = cmd.slice(1);
 		// Clear Claude-Code session markers so the spawned `claude` process starts
 		// fresh rather than inheriting the parent harness's session identity.
@@ -1777,6 +1808,7 @@ export class ObserverClient {
 
 		const execFileAsync = promisify(execFile);
 		try {
+			// lgtm[js/command-line-injection] execFile receives a constrained executable and argv vector; no shell is used.
 			const { stdout } = await execFileAsync(executable, args, {
 				env,
 				timeout: CLAUDE_SIDECAR_TIMEOUT_MS,

--- a/packages/core/src/observer-config.ts
+++ b/packages/core/src/observer-config.ts
@@ -573,25 +573,78 @@ export function resolvePlaceholder(value: string): string {
 
 /** Expand `$VAR` and `${VAR}` environment variable references. */
 function expandEnvVars(value: string): string {
-	return value.replace(/\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (match, braced, bare) => {
-		const name = braced ?? bare;
-		return process.env[name] ?? match;
-	});
+	let result = "";
+	for (let i = 0; i < value.length; i++) {
+		if (value[i] !== "$" || i === value.length - 1) {
+			result += value[i];
+			continue;
+		}
+		if (value[i + 1] === "{") {
+			const end = value.indexOf("}", i + 2);
+			if (end > i + 2) {
+				const name = value.slice(i + 2, end);
+				result += process.env[name] ?? value.slice(i, end + 1);
+				i = end;
+				continue;
+			}
+		}
+		const start = i + 1;
+		let end = start;
+		while (end < value.length) {
+			const code = value.charCodeAt(end);
+			const isLetter = (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+			const isDigit = code >= 48 && code <= 57;
+			if (!isLetter && !isDigit && code !== 95) break;
+			end++;
+		}
+		const name = value.slice(start, end);
+		if (!name || !Number.isNaN(Number(name[0]))) {
+			result += "$";
+			continue;
+		}
+		result += process.env[name] ?? value.slice(i, end);
+		i = end - 1;
+	}
+	return result;
 }
 
 /** Expand `{file:path}` placeholders by reading the referenced file. */
 function resolveFilePlaceholder(value: string): string {
 	if (!value.includes("{file:")) return value;
-	return value.replace(/\{file:([^}]+)\}/g, (match, rawPath: string) => {
-		const trimmed = rawPath.trim();
-		if (!trimmed) return match;
-		const resolved = expandEnvVars(trimmed).replace(/^~/, codememHomeDir());
-		try {
-			return readFileSync(resolved, "utf-8").trim();
-		} catch {
-			return match;
+	let result = "";
+	let index = 0;
+	while (index < value.length) {
+		const start = value.indexOf("{file:", index);
+		if (start < 0) {
+			result += value.slice(index);
+			break;
 		}
-	});
+		const end = value.indexOf("}", start + 6);
+		if (end < 0) {
+			result += value.slice(index);
+			break;
+		}
+		result += value.slice(index, start);
+		const match = value.slice(start, end + 1);
+		const rawPath = value.slice(start + 6, end);
+		const trimmed = rawPath.trim();
+		if (!trimmed) {
+			result += match;
+			index = end + 1;
+			continue;
+		}
+		const expanded = expandEnvVars(trimmed);
+		const resolved = expanded.startsWith("~")
+			? `${codememHomeDir()}${expanded.slice(1)}`
+			: expanded;
+		try {
+			result += readFileSync(resolved, "utf-8").trim();
+		} catch {
+			result += match;
+		}
+		index = end + 1;
+	}
+	return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/project.test.ts
+++ b/packages/core/src/project.test.ts
@@ -16,8 +16,17 @@ describe("project helpers", () => {
 
 	it("uses basename-aware SQL matching for project filters", () => {
 		expect(projectClause("/Users/adam/workspace/codemem")).toEqual({
-			clause: "(sessions.project = ? OR sessions.project LIKE ? OR sessions.project LIKE ?)",
+			clause:
+				"(sessions.project = ? OR sessions.project LIKE ? ESCAPE '\\' OR sessions.project LIKE ? ESCAPE '\\')",
 			params: ["codemem", "%/codemem", "%\\codemem"],
+		});
+	});
+
+	it("escapes SQL LIKE wildcards in project filters", () => {
+		expect(projectClause("weird_%project")).toEqual({
+			clause:
+				"(sessions.project = ? OR sessions.project LIKE ? ESCAPE '\\' OR sessions.project LIKE ? ESCAPE '\\')",
+			params: ["weird_%project", "%/weird\\_\\%project", "%\\weird\\_\\%project"],
 		});
 	});
 

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -2,10 +2,15 @@ import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
 
 export function projectBasename(value: string): string {
-	const normalized = value.replaceAll("\\", "/").replace(/\/+$/, "");
+	let normalized = value.replaceAll("\\", "/");
+	while (normalized.endsWith("/")) normalized = normalized.slice(0, -1);
 	if (!normalized) return "";
 	const parts = normalized.split("/");
 	return parts[parts.length - 1] ?? "";
+}
+
+function escapeSqlLikePattern(value: string): string {
+	return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
 }
 
 export function projectColumnClause(
@@ -16,9 +21,10 @@ export function projectColumnClause(
 	if (!trimmed) return { clause: "", params: [] };
 	const value = /[\\/]/.test(trimmed) ? projectBasename(trimmed) : trimmed;
 	if (!value) return { clause: "", params: [] };
+	const escaped = escapeSqlLikePattern(value);
 	return {
-		clause: `(${columnExpr} = ? OR ${columnExpr} LIKE ? OR ${columnExpr} LIKE ?)`,
-		params: [value, `%/${value}`, `%\\${value}`],
+		clause: `(${columnExpr} = ? OR ${columnExpr} LIKE ? ESCAPE '\\' OR ${columnExpr} LIKE ? ESCAPE '\\')`,
+		params: [value, `%/${escaped}`, `%\\${escaped}`],
 	};
 }
 

--- a/packages/core/src/query-sanitizer.ts
+++ b/packages/core/src/query-sanitizer.ts
@@ -3,7 +3,6 @@ const MIN_QUERY_LENGTH = 10;
 const QUOTE_CHARS = new Set(["'", '"']);
 
 const SENTENCE_SPLIT_RE = /[.!?。！？\n]+/;
-const TRAILING_QUESTION_RE = /[?？]\s*["']?\s*$/;
 const INSTRUCTION_PREFIX_PATTERNS = [
 	/^you are\b/i,
 	/^output only\b/i,
@@ -69,6 +68,22 @@ function looksInstructionLike(segment: string): boolean {
 	return INSTRUCTION_PREFIX_PATTERNS.some((pattern) => pattern.test(trimmed));
 }
 
+function hasTrailingQuestion(segment: string): boolean {
+	let index = segment.length - 1;
+	while (index >= 0) {
+		const ch = segment[index];
+		if (ch !== " " && ch !== "\t" && ch !== "\n" && ch !== "\r") break;
+		index--;
+	}
+	if (segment[index] === "'" || segment[index] === '"') index--;
+	while (index >= 0) {
+		const ch = segment[index];
+		if (ch !== " " && ch !== "\t" && ch !== "\n" && ch !== "\r") break;
+		index--;
+	}
+	return segment[index] === "?" || segment[index] === "？";
+}
+
 function looksContaminated(raw: string, segments: string[]): boolean {
 	if (raw.includes("<") || raw.includes(">")) return true;
 	if (looksInstructionLike(raw)) return true;
@@ -84,7 +99,24 @@ function looksContaminated(raw: string, segments: string[]): boolean {
 }
 
 function extractQuestionSentence(raw: string): string | null {
-	const fragments = raw.match(/[^.!?。！？\n]+[.!?。！？]?/g) ?? [];
+	const fragments: string[] = [];
+	let current = "";
+	for (const ch of raw) {
+		current += ch;
+		if (
+			ch === "." ||
+			ch === "!" ||
+			ch === "?" ||
+			ch === "。" ||
+			ch === "！" ||
+			ch === "？" ||
+			ch === "\n"
+		) {
+			if (current.trim()) fragments.push(current);
+			current = "";
+		}
+	}
+	if (current.trim()) fragments.push(current);
 	for (const fragment of [...fragments].reverse()) {
 		if (!fragment.includes("?") && !fragment.includes("？")) continue;
 		const candidate = trimCandidate(fragment);
@@ -136,7 +168,7 @@ export function sanitizeSearchQuery(rawQuery: string): SanitizedQuery {
 	}
 
 	for (const segment of [...segments].reverse()) {
-		if (!TRAILING_QUESTION_RE.test(segment)) continue;
+		if (!hasTrailingQuestion(segment)) continue;
 		const candidate = trimCandidate(segment);
 		if (candidate.length >= MIN_QUERY_LENGTH) {
 			reasons.push("question_segment");

--- a/packages/core/src/ref-queries.ts
+++ b/packages/core/src/ref-queries.ts
@@ -44,6 +44,10 @@ export interface RefQueryResult {
 	metadata_json: string | null;
 }
 
+function escapeSqlLikePattern(value: string): string {
+	return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
+}
+
 /**
  * Find memories associated with a file path via the `memory_file_refs` index.
  *
@@ -65,7 +69,7 @@ export function findByFile(
 	const refParams: unknown[] = [];
 
 	if (isDir) {
-		const escaped = trimmed.replace(/%/g, "\\%").replace(/_/g, "\\_");
+		const escaped = escapeSqlLikePattern(trimmed);
 		refClauses.push("mfr.file_path LIKE ? ESCAPE '\\'");
 		refParams.push(`${escaped}%`);
 	} else {

--- a/packages/core/src/sync-http-client.ts
+++ b/packages/core/src/sync-http-client.ts
@@ -9,16 +9,36 @@
 // URL helpers
 // ---------------------------------------------------------------------------
 
+function stripTrailingSlashes(value: string): string {
+	let end = value.length;
+	while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+	return end === value.length ? value : value.slice(0, end);
+}
+
+function hasUrlScheme(value: string): boolean {
+	const separator = value.indexOf("://");
+	if (separator <= 0) return false;
+	const first = value.charCodeAt(0);
+	if (!((first >= 65 && first <= 90) || (first >= 97 && first <= 122))) return false;
+	for (let i = 1; i < separator; i++) {
+		const code = value.charCodeAt(i);
+		const isLetter = (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+		const isDigit = code >= 48 && code <= 57;
+		if (!isLetter && !isDigit && code !== 43 && code !== 45 && code !== 46) return false;
+	}
+	return true;
+}
+
 /**
  * Normalize a peer address into a base URL.
  *
  * Adds `http://` when no scheme is present, trims whitespace and trailing slashes.
  */
 export function buildBaseUrl(address: string): string {
-	const trimmed = address.trim().replace(/\/+$/, "");
+	const trimmed = stripTrailingSlashes(address.trim());
 	if (!trimmed) return "";
 	// Check for an existing scheme (e.g. http://, https://)
-	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return trimmed;
+	if (hasUrlScheme(trimmed)) return trimmed;
 	return `http://${trimmed}`;
 }
 

--- a/packages/core/src/sync-identity.ts
+++ b/packages/core/src/sync-identity.ts
@@ -8,7 +8,7 @@
 import { execFileSync } from "node:child_process";
 import { createPrivateKey, createPublicKey, generateKeyPairSync, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
@@ -209,7 +209,7 @@ function publicKeyLooksValid(publicKey: string): boolean {
 
 function backupInvalidKeyFile(path: string, stamp: string): void {
 	if (!existsSync(path)) return;
-	const backupPath = path.replace(/([^/]+)$/, `$1.invalid-${stamp}`);
+	const backupPath = join(dirname(path), `${basename(path)}.invalid-${stamp}`);
 	renameSync(path, backupPath);
 }
 


### PR DESCRIPTION
## Description
Addresses the first pass of GitHub CodeQL/code scanning alerts on top of the dependency remediation PR. Changes include:

- Add least-privilege `contents: read` workflow permissions for CI.
- Escape SQL LIKE wildcards/backslashes in project and file matching helpers.
- Replace CodeQL-flagged regex patterns in high-risk ingest, query, observer, sync, and coordinator paths with bounded string scanning helpers.
- Constrain the Claude sidecar executable before `execFile` and document the remaining no-shell safety boundary.
- Suppress the `stats --json` clear-text logging alert as intentional CLI stdout, not application logging.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- Targeted Vitest files for touched core/CLI helpers
- `pnpm run lint`
- `pnpm run check`
- CodeReviewer review + follow-up re-review: no blockers

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

Compatibility note: `claude_command` executable validation now allows safe PATH command names and absolute paths, but rejects relative executable paths containing `/` such as `./wrapper`.