### PR TITLE
chore(beads): disable jsonl auto sync

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -16,11 +16,13 @@
 # Disable daemon for RPC communication (forces direct database access)
 # no-daemon: false
 
-# Disable auto-flush of database to JSONL after mutations
-# no-auto-flush: false
+# Disable auto-flush of database to JSONL after mutations.
+# codemem uses Dolt as the Beads collaboration source of truth; issues.jsonl
+# is treated as a local backup/export artifact and is intentionally gitignored.
+no-auto-flush: true
 
-# Disable auto-import from JSONL when it's newer than database
-# no-auto-import: false
+# Disable auto-import from JSONL when it's newer than database.
+no-auto-import: true
 
 # Enable JSON output by default
 # json: false


### PR DESCRIPTION
## Description

Disables auto-flush and auto-import in the Beads config. Since codemem uses Dolt as the Beads collaboration source of truth, `issues.jsonl` is treated as a local backup/export artifact and is intentionally gitignored, making automatic JSONL syncing unnecessary.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced