### PR TITLE
fix(ui): show enrolled devices in sharing domain grants

### DIFF
--- a/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
@@ -4,10 +4,12 @@ import { TextInput } from "../../../components/primitives/text-input";
 import * as api from "../../../lib/api";
 import { showGlobalNotice } from "../../../lib/notice";
 import type { CachedCoordinatorAdminDevice } from "../../../lib/state";
+import { state } from "../../../lib/state";
 import { openSyncConfirmDialog } from "../../sync/sync-dialogs";
 import {
 	type CoordinatorAdminScopeMemberView,
 	type CoordinatorAdminScopeView,
+	coordinatorAdminDevicesForGroup,
 	deriveScopeMembershipDeviceRows,
 	scopeManagementReadinessMessage,
 	scopeStatusLabel,
@@ -28,6 +30,7 @@ function emptyScopeDraft(): GroupScopeManagementDraft {
 		loading: false,
 		error: "",
 		includeInactive: false,
+		devicesLoaded: false,
 		scopes: [],
 		membersByScope: new Map<string, CoordinatorAdminScopeMemberView[]>(),
 		devices: [],
@@ -87,6 +90,7 @@ async function loadGroupScopeManagement(
 			loading: false,
 			error: "",
 			includeInactive,
+			devicesLoaded: true,
 			scopes,
 			devices,
 			membersByScope: new Map(memberEntries.filter(([scopeId]) => scopeId.length > 0)),
@@ -237,10 +241,13 @@ function renderMembershipRows(
 	renderShell: () => void,
 ) {
 	const scopeId = String(scope.scope_id || "").trim();
-	const rows = deriveScopeMembershipDeviceRows(
+	const devices = coordinatorAdminDevicesForGroup(
 		draft.devices,
-		draft.membersByScope.get(scopeId) ?? [],
+		state.lastCoordinatorAdminDevices,
+		groupId,
+		draft.devicesLoaded,
 	);
+	const rows = deriveScopeMembershipDeviceRows(devices, draft.membersByScope.get(scopeId) ?? []);
 	if (!rows.length) {
 		return h(
 			"div",

--- a/packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	coordinatorAdminDevicesForGroup,
 	deriveScopeMembershipDeviceRows,
 	scopeManagementReadinessMessage,
 	scopeStatusLabel,
@@ -54,5 +55,37 @@ describe("coordinator admin scope management view helpers", () => {
 	it("formats empty or underscored scope statuses for operator copy", () => {
 		expect(scopeStatusLabel(null)).toBe("active");
 		expect(scopeStatusLabel("needs_review")).toBe("needs review");
+	});
+
+	it("falls back to cached enrolled devices for the selected group", () => {
+		expect(
+			coordinatorAdminDevicesForGroup(
+				[],
+				[
+					{ group_id: "team-a", device_id: "dev-a", display_name: "Alice", enabled: true },
+					{ group_id: "team-b", device_id: "dev-b", display_name: "Bob", enabled: true },
+				],
+				"team-a",
+				false,
+			),
+		).toEqual([{ group_id: "team-a", device_id: "dev-a", display_name: "Alice", enabled: true }]);
+
+		expect(
+			coordinatorAdminDevicesForGroup(
+				[],
+				[{ group_id: "team-a", device_id: "stale-dev", enabled: true }],
+				"team-a",
+				true,
+			),
+		).toEqual([]);
+
+		expect(
+			coordinatorAdminDevicesForGroup(
+				[{ group_id: "team-a", device_id: "fresh-dev", enabled: true }],
+				[{ group_id: "team-a", device_id: "cached-dev", enabled: true }],
+				"team-a",
+				true,
+			),
+		).toEqual([{ group_id: "team-a", device_id: "fresh-dev", enabled: true }]);
 	});
 });

--- a/packages/ui/src/tabs/coordinator-admin/data/scope-management.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/scope-management.ts
@@ -86,3 +86,14 @@ export function deriveScopeMembershipDeviceRows(
 			);
 		});
 }
+
+export function coordinatorAdminDevicesForGroup(
+	loadedDevices: CachedCoordinatorAdminDevice[],
+	cachedDevices: CachedCoordinatorAdminDevice[],
+	groupId: string,
+	devicesLoaded: boolean,
+): CachedCoordinatorAdminDevice[] {
+	const targetGroupId = String(groupId || "").trim();
+	if (devicesLoaded || loadedDevices.length > 0 || !targetGroupId) return loadedDevices;
+	return cachedDevices.filter((device) => String(device.group_id || "").trim() === targetGroupId);
+}

--- a/packages/ui/src/tabs/coordinator-admin/data/state.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/state.ts
@@ -31,6 +31,7 @@ export interface GroupScopeManagementDraft {
 	loading: boolean;
 	error: string;
 	includeInactive: boolean;
+	devicesLoaded: boolean;
 	scopes: CoordinatorAdminScopeView[];
 	membersByScope: Map<string, CoordinatorAdminScopeMemberView[]>;
 	devices: CachedCoordinatorAdminDevice[];


### PR DESCRIPTION
## Description
Fixes the Coordinator Admin Sharing domains drawer so it can show enrolled devices from the selected group even when the drawer-local device load is empty or stale. This restores the expected Not a member → Grant workflow for assigning sharing-domain access.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (pnpm run tsc, pnpm run lint, pnpm run test)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run:
- pnpm exec vitest run packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts
- pnpm exec tsc --build packages/ui/tsconfig.json --pretty false

## Checklist

- [x] Code follows project style for touched files
- [x] Self-review completed
- [x] Documentation updated (not needed; no user-facing copy/API contract change)
- [x] No new warnings introduced