### PR TITLE
feat(mcp): add local streamable HTTP transport

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -13,6 +13,11 @@
 			"types": "./dist/stdio.d.ts",
 			"source": "./src/stdio.ts",
 			"import": "./dist/stdio.js"
+		},
+		"./http": {
+			"types": "./dist/http.d.ts",
+			"source": "./src/http.ts",
+			"import": "./dist/http.js"
 		}
 	},
 	"bin": {

--- a/packages/mcp-server/src/http.test.ts
+++ b/packages/mcp-server/src/http.test.ts
@@ -1,0 +1,198 @@
+import { mkdtempSync } from "node:fs";
+import { request } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	type CodememMcpHttpServer,
+	DEFAULT_MCP_HTTP_HOST,
+	DEFAULT_MCP_HTTP_PORT,
+	isAllowedMcpHttpRequestHost,
+	isAllowedMcpHttpRequestOrigin,
+	isUnsafePublicBindAllowed,
+	parseMcpHttpPort,
+	startCodememMcpHttpServer,
+	validateMcpHttpHost,
+} from "./http.js";
+
+const servers: CodememMcpHttpServer[] = [];
+
+afterEach(async () => {
+	await Promise.all(servers.splice(0).map((server) => server.close()));
+});
+
+describe("MCP HTTP transport", () => {
+	it("defaults to loopback host and validates host values", () => {
+		expect(validateMcpHttpHost(undefined)).toBe(DEFAULT_MCP_HTTP_HOST);
+		expect(validateMcpHttpHost("localhost")).toBe("localhost");
+		expect(validateMcpHttpHost("::1")).toBe("::1");
+		expect(() => validateMcpHttpHost("http://127.0.0.1")).toThrow(/Invalid MCP HTTP host/);
+		expect(() => validateMcpHttpHost("127.0.0.1/mcp")).toThrow(/Invalid MCP HTTP host/);
+		expect(() => validateMcpHttpHost("0.0.0.0")).toThrow(/Refusing unsafe MCP HTTP host/);
+		expect(() => validateMcpHttpHost("192.168.1.10")).toThrow(/Refusing unsafe MCP HTTP host/);
+		expect(validateMcpHttpHost("0.0.0.0", true)).toBe("0.0.0.0");
+	});
+
+	it("parses the explicit unsafe public bind switch", () => {
+		expect(isUnsafePublicBindAllowed("1")).toBe(true);
+		expect(isUnsafePublicBindAllowed("true")).toBe(true);
+		expect(isUnsafePublicBindAllowed("yes")).toBe(true);
+		expect(isUnsafePublicBindAllowed("0")).toBe(false);
+	});
+
+	it("allows only loopback Host and Origin headers for the selected port", () => {
+		expect(isAllowedMcpHttpRequestHost("127.0.0.1:38889", 38889)).toBe(true);
+		expect(isAllowedMcpHttpRequestHost("localhost:38889", 38889)).toBe(true);
+		expect(isAllowedMcpHttpRequestHost("[::1]:38889", 38889)).toBe(true);
+		expect(isAllowedMcpHttpRequestHost("evil.test:38889", 38889)).toBe(false);
+		expect(isAllowedMcpHttpRequestHost("127.0.0.1:38888", 38889)).toBe(false);
+
+		expect(isAllowedMcpHttpRequestOrigin(undefined, 38889)).toBe(true);
+		expect(isAllowedMcpHttpRequestOrigin("http://localhost:38889", 38889)).toBe(true);
+		expect(isAllowedMcpHttpRequestOrigin("http://[::1]:38889", 38889)).toBe(true);
+		expect(isAllowedMcpHttpRequestOrigin("http://evil.test:38889", 38889)).toBe(false);
+		expect(isAllowedMcpHttpRequestOrigin("http://localhost:38888", 38889)).toBe(false);
+		expect(isAllowedMcpHttpRequestOrigin("http://localhost:38889/path", 38889)).toBe(false);
+	});
+
+	it("accepts loopback Host headers without an explicit port when bound to HTTP default (PR 1120 P2 regression)", () => {
+		// RFC-compliant clients may send `Host: localhost` (no `:port`) when the
+		// server listens on port 80. Reject anything that is not loopback or that
+		// would inherit a default port other than the bound one.
+		expect(isAllowedMcpHttpRequestHost("localhost", 80)).toBe(true);
+		expect(isAllowedMcpHttpRequestHost("127.0.0.1", 80)).toBe(true);
+		expect(isAllowedMcpHttpRequestHost("[::1]", 80)).toBe(true);
+		expect(isAllowedMcpHttpRequestHost("evil.test", 80)).toBe(false);
+		expect(isAllowedMcpHttpRequestHost("localhost", 38889)).toBe(false);
+	});
+
+	it("defaults and validates port values", () => {
+		expect(parseMcpHttpPort(undefined)).toBe(DEFAULT_MCP_HTTP_PORT);
+		expect(parseMcpHttpPort("0")).toBe(0);
+		expect(parseMcpHttpPort(38889)).toBe(38889);
+		expect(() => parseMcpHttpPort("abc")).toThrow(/Invalid MCP HTTP port/);
+		expect(() => parseMcpHttpPort(65_536)).toThrow(/Invalid MCP HTTP port/);
+	});
+
+	it("exposes only POST /mcp", async () => {
+		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
+		servers.push(server);
+
+		const getResponse = await fetch(server.url);
+		expect(getResponse.status).toBe(405);
+		expect(getResponse.headers.get("allow")).toBe("POST");
+
+		const missingResponse = await fetch(server.url.replace("/mcp", "/health"), { method: "POST" });
+		expect(missingResponse.status).toBe(404);
+	});
+
+	it("handles repeated MCP initialize requests over POST", async () => {
+		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
+		servers.push(server);
+
+		const first = await initialize(server.url, 1);
+		const second = await initialize(server.url, 2);
+
+		expect(first.result?.serverInfo?.name).toBe("codemem");
+		expect(second.result?.serverInfo?.name).toBe("codemem");
+	});
+
+	it("rejects browser requests from non-loopback origins", async () => {
+		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
+		servers.push(server);
+
+		const response = await fetch(server.url, {
+			method: "POST",
+			headers: {
+				accept: "application/json, text/event-stream",
+				"content-type": "application/json",
+				origin: "http://evil.test",
+			},
+			body: initializeBody(1),
+		});
+
+		expect(response.status).toBe(403);
+	});
+
+	it("rejects requests with non-loopback Host headers", async () => {
+		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
+		servers.push(server);
+
+		const response = await postWithHost(server.url, "evil.test:38889");
+		expect(response.statusCode).toBe(403);
+	});
+
+	it("closes idempotently", async () => {
+		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
+		await Promise.all([server.close(), server.close()]);
+	});
+});
+
+async function initialize(
+	url: string,
+	id: number,
+): Promise<{ result?: { serverInfo?: { name?: string } } }> {
+	const response = await fetch(url, {
+		method: "POST",
+		headers: {
+			accept: "application/json, text/event-stream",
+			"content-type": "application/json",
+		},
+		body: initializeBody(id),
+	});
+
+	expect(response.status).toBe(200);
+	expect(response.headers.get("content-type")).toContain("text/event-stream");
+	return parseSseJson(await response.text()) as { result?: { serverInfo?: { name?: string } } };
+}
+
+function initializeBody(id: number): string {
+	return JSON.stringify({
+		jsonrpc: "2.0",
+		id,
+		method: "initialize",
+		params: {
+			protocolVersion: "2024-11-05",
+			capabilities: {},
+			clientInfo: { name: "codemem-test", version: "0.0.0" },
+		},
+	});
+}
+
+function parseSseJson(body: string): unknown {
+	const dataLine = body.split("\n").find((line) => line.startsWith("data: "));
+	if (!dataLine) throw new Error(`Missing SSE data line: ${body}`);
+	return JSON.parse(dataLine.slice("data: ".length));
+}
+
+async function postWithHost(
+	url: string,
+	host: string,
+): Promise<{ statusCode: number | undefined }> {
+	const target = new URL(url);
+	return await new Promise((resolve, reject) => {
+		const req = request(
+			{
+				hostname: target.hostname,
+				port: target.port,
+				path: target.pathname,
+				method: "POST",
+				headers: {
+					accept: "application/json, text/event-stream",
+					"content-type": "application/json",
+					host,
+				},
+			},
+			(res) => {
+				res.resume();
+				res.on("end", () => resolve({ statusCode: res.statusCode }));
+			},
+		);
+		req.on("error", reject);
+		req.end(initializeBody(1));
+	});
+}
+
+function tempDbPath(): string {
+	return join(mkdtempSync(join(tmpdir(), "codemem-mcp-http-")), "mem.sqlite");
+}

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+/**
+ * @codemem/mcp — MCP Streamable HTTP server bootstrap.
+ *
+ * Local-first HTTP transport for MCP clients. This intentionally exposes only
+ * POST /mcp and does not implement OAuth or any other auth layer yet.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { isIP } from "node:net";
+import { pathToFileURL } from "node:url";
+import { MemoryStore, resolveDbPath } from "@codemem/core";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createCodememMcpServer } from "./server.js";
+
+export const DEFAULT_MCP_HTTP_HOST = "127.0.0.1";
+export const DEFAULT_MCP_HTTP_PORT = 38889;
+const HTTP_DEFAULT_PORT = 80;
+
+const VALID_HOSTNAME = /^[a-zA-Z0-9.-]+$/;
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+
+interface ActiveRequest {
+	mcpServer: McpServer;
+}
+
+export interface CodememMcpHttpOptions {
+	host?: string;
+	port?: number | string;
+	dbPath?: string;
+	allowUnsafePublic?: boolean;
+}
+
+export interface CodememMcpHttpServer {
+	server: Server;
+	store: MemoryStore;
+	url: string;
+	close: () => Promise<void>;
+}
+
+export function validateMcpHttpHost(host: string | undefined, allowUnsafePublic = false): string {
+	const value = host?.trim() || DEFAULT_MCP_HTTP_HOST;
+	if (value.includes("://") || value.includes("/") || value.includes("\\")) {
+		throw new Error(`Invalid MCP HTTP host: ${host}`);
+	}
+	if (!(isIP(value) || value === "localhost" || VALID_HOSTNAME.test(value))) {
+		throw new Error(`Invalid MCP HTTP host: ${host}`);
+	}
+	if (!allowUnsafePublic && !isLoopbackHost(value)) {
+		throw new Error(
+			`Refusing unsafe MCP HTTP host ${value}; set CODEMEM_MCP_HTTP_UNSAFE_PUBLIC=1 to allow non-loopback binding`,
+		);
+	}
+	return value;
+}
+
+export function isLoopbackHost(host: string): boolean {
+	return LOOPBACK_HOSTS.has(normalizeHost(host));
+}
+
+export function isUnsafePublicBindAllowed(
+	value = process.env.CODEMEM_MCP_HTTP_UNSAFE_PUBLIC,
+): boolean {
+	return value === "1" || value?.toLowerCase() === "true" || value?.toLowerCase() === "yes";
+}
+
+export function isAllowedMcpHttpRequestHost(
+	header: string | undefined,
+	expectedPort: number,
+): boolean {
+	const parsed = parseHostHeader(header);
+	if (!parsed) return false;
+	if (!isLoopbackHost(parsed.host)) return false;
+	if (parsed.port === null) {
+		// No `:port` in the Host header means the client is using the protocol
+		// default. This server is plain HTTP, so the implied port is 80. Only
+		// accept the bare-host form when the bound port is also 80.
+		return expectedPort === HTTP_DEFAULT_PORT;
+	}
+	return parsed.port === expectedPort;
+}
+
+export function isAllowedMcpHttpRequestOrigin(
+	header: string | undefined,
+	expectedPort: number,
+): boolean {
+	if (!header) return true;
+	try {
+		const url = new URL(header);
+		const port = url.port ? Number(url.port) : url.protocol === "https:" ? 443 : 80;
+		return (
+			(url.protocol === "http:" || url.protocol === "https:") &&
+			url.username === "" &&
+			url.password === "" &&
+			url.pathname === "/" &&
+			url.search === "" &&
+			url.hash === "" &&
+			isLoopbackHost(url.hostname) &&
+			port === expectedPort
+		);
+	} catch {
+		return false;
+	}
+}
+
+function normalizeHost(host: string): string {
+	return host.replace(/^\[(.*)]$/, "$1").toLowerCase();
+}
+
+function parseHostHeader(header: string | undefined): { host: string; port: number | null } | null {
+	if (!header) return null;
+	if (header.startsWith("[")) {
+		// Bracketed IPv6: `[::1]` or `[::1]:8080`.
+		const withPort = /^\[([^\]]+)]:(\d+)$/.exec(header);
+		if (withPort?.[1] && withPort[2]) {
+			return { host: withPort[1], port: Number(withPort[2]) };
+		}
+		const bareIpv6 = /^\[([^\]]+)]$/.exec(header);
+		if (bareIpv6?.[1]) return { host: bareIpv6[1], port: null };
+		return null;
+	}
+	const lastColon = header.lastIndexOf(":");
+	if (lastColon < 0) {
+		// RFC-compliant clients may omit `:port` on default-port requests. Treat
+		// the implied port as "use the protocol default" and let the caller
+		// reconcile against the actually bound port.
+		return { host: header, port: null };
+	}
+	const host = header.slice(0, lastColon);
+	const port = Number(header.slice(lastColon + 1));
+	if (!Number.isInteger(port)) return null;
+	return { host, port };
+}
+
+export function parseMcpHttpPort(port: number | string | undefined): number {
+	if (port === undefined || port === "") return DEFAULT_MCP_HTTP_PORT;
+	const value = typeof port === "number" ? port : Number(port);
+	if (!Number.isInteger(value) || value < 0 || value > 65_535) {
+		throw new Error(`Invalid MCP HTTP port: ${port}`);
+	}
+	return value;
+}
+
+export async function startCodememMcpHttpServer(
+	options: CodememMcpHttpOptions = {},
+): Promise<CodememMcpHttpServer> {
+	const host = validateMcpHttpHost(
+		options.host ?? process.env.CODEMEM_MCP_HTTP_HOST,
+		options.allowUnsafePublic ?? isUnsafePublicBindAllowed(),
+	);
+	const port = parseMcpHttpPort(options.port ?? process.env.CODEMEM_MCP_HTTP_PORT);
+	const store = new MemoryStore(options.dbPath ?? resolveDbPath());
+	const activeRequests = new Set<ActiveRequest>();
+	let closePromise: Promise<void> | null = null;
+
+	const server = createServer(async (req, res) => {
+		try {
+			if (req.url !== "/mcp") {
+				writeText(res, 404, "Not found");
+				return;
+			}
+			if (req.method !== "POST") {
+				res.setHeader("Allow", "POST");
+				writeText(res, 405, "Method not allowed");
+				return;
+			}
+			if (!isAllowedMcpHttpRequest(req, getBoundPort(server))) {
+				writeText(res, 403, "Forbidden");
+				return;
+			}
+
+			const mcpServer = createCodememMcpServer(store);
+			const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+			const activeRequest = { mcpServer };
+			activeRequests.add(activeRequest);
+			try {
+				await mcpServer.connect(transport);
+				await transport.handleRequest(req, res);
+			} finally {
+				activeRequests.delete(activeRequest);
+				await mcpServer.close();
+			}
+		} catch (err) {
+			if (!res.headersSent) writeText(res, 500, "MCP request failed");
+			console.error("codemem MCP HTTP request failed:", err);
+		}
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen({ host, port }, () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+
+	const close = () => {
+		closePromise ??= (async () => {
+			await Promise.allSettled([...activeRequests].map(({ mcpServer }) => mcpServer.close()));
+			await new Promise<void>((resolve, reject) => {
+				server.close((err) => {
+					if (!err || (err as NodeJS.ErrnoException).code === "ERR_SERVER_NOT_RUNNING") {
+						resolve();
+						return;
+					}
+					reject(err);
+				});
+				server.closeAllConnections();
+			});
+			store.close();
+		})();
+		return closePromise;
+	};
+
+	return {
+		server,
+		store,
+		url: `http://${formatHostForUrl(host)}:${getBoundPort(server)}/mcp`,
+		close,
+	};
+}
+
+function isAllowedMcpHttpRequest(req: IncomingMessage, expectedPort: number): boolean {
+	return (
+		isAllowedMcpHttpRequestHost(req.headers.host, expectedPort) &&
+		isAllowedMcpHttpRequestOrigin(req.headers.origin, expectedPort)
+	);
+}
+
+function writeText(res: ServerResponse, statusCode: number, body: string): void {
+	res.statusCode = statusCode;
+	res.setHeader("content-type", "text/plain; charset=utf-8");
+	res.end(body);
+}
+
+function getBoundPort(server: Server): number {
+	const address = server.address();
+	if (!address || typeof address === "string") return DEFAULT_MCP_HTTP_PORT;
+	return address.port;
+}
+
+function formatHostForUrl(host: string): string {
+	return isIP(host) === 6 ? `[${host}]` : host;
+}
+
+function isEntrypoint(): boolean {
+	const script = process.argv[1];
+	return script ? import.meta.url === pathToFileURL(script).href : false;
+}
+
+async function main() {
+	const httpServer = await startCodememMcpHttpServer();
+	console.error(`codemem MCP HTTP server listening at ${httpServer.url}`);
+
+	const shutdown = async () => {
+		try {
+			await httpServer.close();
+		} catch {
+			// Best effort — process is exiting.
+		}
+		process.exit(0);
+	};
+
+	process.on("SIGINT", shutdown);
+	process.on("SIGTERM", shutdown);
+}
+
+if (isEntrypoint()) {
+	main().catch((err) => {
+		console.error("codemem MCP HTTP server failed to start:", err);
+		process.exit(1);
+	});
+}

--- a/packages/mcp-server/vite.config.ts
+++ b/packages/mcp-server/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
 	build: {
 		lib: {
 			entry: {
+				http: "src/http.ts",
 				index: "src/index.ts",
 				stdio: "src/stdio.ts",
 			},


### PR DESCRIPTION
## Description
Adds a local-first Streamable HTTP MCP entrypoint at `@codemem/mcp/http` exposing `POST /mcp` using the shared MCP server factory from the previous PR.

The transport defaults to loopback, rejects unsafe non-loopback binds unless explicitly opted in, validates Host/Origin against loopback and the bound port, creates a fresh stateless MCP server/transport per request, and shuts down idempotently. OAuth is intentionally not included in this slice.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
  - `pnpm --filter @codemem/mcp typecheck`
  - `pnpm --filter codemem typecheck`
  - `pnpm exec vitest run packages/mcp-server/src/server.test.ts packages/mcp-server/src/memory-access.test.ts packages/mcp-server/src/project-scope.test.ts packages/mcp-server/src/http.test.ts`
  - `pnpm --filter @codemem/mcp build` plus `./http` output/shebang/export verification
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
