### PR TITLE
feat(cli): expose MCP HTTP mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | **Config** | `codemem config` | View or update configuration |
 | | `codemem setup` | Interactive first-run setup |
 | **Plumbing** | `codemem mcp` | MCP stdio server; best-effort starts the local viewer unless `CODEMEM_VIEWER=0` or `CODEMEM_VIEWER_AUTO=0` is set |
+| | `codemem mcp http` | Local Streamable HTTP MCP server (`POST /mcp`, loopback-only by default) |
 | | `codemem claude-hook-ingest` | Claude hook event ingestion (stdin) |
 
 Run `codemem --help` for the full list. Legacy top-level aliases (`export-memories`, `import-memories`, `show`, `forget`, `remember`) still work but are hidden from help.
@@ -155,6 +156,8 @@ codemem setup --opencode-only
 This updates your OpenCode config to install the plugin and register the MCP server. Restart OpenCode to activate.
 
 The standalone `codemem-mcp-ts` binary runs the same stdio server used by `codemem mcp`. Viewer autostart is on by default for both invocation paths; set `CODEMEM_VIEWER=0` or `CODEMEM_VIEWER_AUTO=0` to disable.
+
+For local HTTP transport testing, run `codemem mcp http`. It listens on `127.0.0.1:38889` by default and exposes Streamable HTTP at `POST /mcp`; use `--host`, `--port`, and `--db-path` to override those values. Non-loopback binds are rejected unless you explicitly pass `--unsafe-public` or set `CODEMEM_MCP_HTTP_UNSAFE_PUBLIC=1`; this mode is unauthenticated, still applies loopback Host/Origin checks, and should not be exposed directly to untrusted networks.
 
 ## Configuration
 
@@ -174,6 +177,8 @@ Common overrides:
 | `CODEMEM_INJECT_CONTEXT` | `0` to disable automatic context injection |
 | `CODEMEM_VIEWER_HOST`, `CODEMEM_VIEWER_PORT` | Host/port the plugin-managed viewer should start, probe, and restart |
 | `CODEMEM_VIEWER_AUTO` | `0` to disable auto-starting the viewer |
+| `CODEMEM_MCP_HTTP_HOST`, `CODEMEM_MCP_HTTP_PORT` | Host/port for `codemem mcp http` |
+| `CODEMEM_MCP_HTTP_UNSAFE_PUBLIC` | `1`, `true`, or `yes` to allow non-loopback MCP HTTP binds |
 
 Viewer note:
 

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -1,0 +1,124 @@
+import { startCodememMcpHttpServer } from "@codemem/mcp/http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mcpCommand } from "./mcp.js";
+
+const stdioImportMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@codemem/mcp/stdio", () => {
+	stdioImportMock();
+	return {};
+});
+vi.mock("@codemem/mcp/http", () => ({
+	startCodememMcpHttpServer: vi.fn(async () => ({
+		url: "http://127.0.0.1:38889/mcp",
+		close: vi.fn(async () => {}),
+	})),
+}));
+
+const startHttpMock = vi.mocked(startCodememMcpHttpServer);
+
+describe("mcp command", () => {
+	afterEach(() => {
+		startHttpMock.mockClear();
+		stdioImportMock.mockClear();
+		process.exitCode = undefined;
+	});
+
+	it("keeps stdio mode as the default command", () => {
+		expect(mcpCommand.name()).toBe("mcp");
+		expect(mcpCommand.summary()).toBe("Start the MCP stdio server");
+	});
+
+	it("exposes HTTP mode with host, port, and database options", () => {
+		const httpCommand = mcpCommand.commands.find((command) => command.name() === "http");
+
+		expect(httpCommand).toBeDefined();
+		expect(httpCommand?.description()).toBe("Start the MCP Streamable HTTP server");
+		expect(httpCommand?.options.map((option) => option.long).toSorted()).toEqual([
+			"--db",
+			"--db-path",
+			"--host",
+			"--port",
+			"--unsafe-public",
+		]);
+	});
+
+	it("forwards HTTP mode options to the MCP HTTP starter", async () => {
+		const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await mcpCommand.parseAsync(
+				[
+					"http",
+					"--db-path",
+					"/tmp/codemem-test.sqlite",
+					"--host",
+					"localhost",
+					"--port",
+					"39999",
+					"--unsafe-public",
+				],
+				{ from: "user" },
+			);
+
+			expect(startHttpMock).toHaveBeenCalledWith({
+				allowUnsafePublic: true,
+				dbPath: "/tmp/codemem-test.sqlite",
+				host: "localhost",
+				port: "39999",
+			});
+		} finally {
+			stderr.mockRestore();
+		}
+	});
+
+	it("forwards parent-level database options to HTTP mode", async () => {
+		const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await mcpCommand.parseAsync(["--db-path", "/tmp/parent.sqlite", "http"], { from: "user" });
+
+			expect(startHttpMock).toHaveBeenCalledWith({
+				allowUnsafePublic: undefined,
+				dbPath: "/tmp/parent.sqlite",
+				host: undefined,
+				port: undefined,
+			});
+		} finally {
+			stderr.mockRestore();
+		}
+	});
+
+	it("lets the MCP HTTP starter resolve env/default host and port", async () => {
+		const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await mcpCommand.parseAsync(["http"], { from: "user" });
+
+			expect(startHttpMock).toHaveBeenCalledWith({
+				allowUnsafePublic: undefined,
+				dbPath: undefined,
+				host: undefined,
+				port: undefined,
+			});
+		} finally {
+			stderr.mockRestore();
+		}
+	});
+
+	it("classifies MCP HTTP validation failures as usage errors", async () => {
+		startHttpMock.mockRejectedValueOnce(new Error("Invalid MCP HTTP port: nope"));
+		const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await mcpCommand.parseAsync(["http", "--port", "nope"], { from: "user" });
+
+			expect(process.exitCode).toBe(2);
+		} finally {
+			stderr.mockRestore();
+		}
+	});
+
+	it("runs stdio mode by default", async () => {
+		await mcpCommand.parseAsync([], { from: "user" });
+
+		expect(stdioImportMock).toHaveBeenCalledTimes(1);
+		expect(startHttpMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -4,9 +4,57 @@ import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
 
 const mcpCmd = new Command("mcp")
 	.configureHelp(helpStyle)
-	.description("Start the MCP stdio server");
+	.description("Start an MCP server")
+	.summary("Start the MCP stdio server");
 
 addDbOption(mcpCmd);
+
+interface McpHttpOpts extends DbOpts {
+	host?: string;
+	port?: string;
+	unsafePublic?: boolean;
+}
+
+const mcpHttpCmd = new Command("http")
+	.configureHelp(helpStyle)
+	.description("Start the MCP Streamable HTTP server")
+	.option("--host <host>", "HTTP host")
+	.option("--port <port>", "HTTP port")
+	.option("--unsafe-public", "allow non-loopback bind without auth");
+
+addDbOption(mcpHttpCmd);
+
+mcpHttpCmd.action(async () => {
+	const opts = mcpHttpCmd.opts<McpHttpOpts>();
+	try {
+		const { startCodememMcpHttpServer } = await import("@codemem/mcp/http");
+		const server = await startCodememMcpHttpServer({
+			dbPath: resolveDbOpt(opts) ?? resolveDbOpt(mcpCmd.opts<DbOpts>()),
+			host: opts.host,
+			port: opts.port,
+			allowUnsafePublic: opts.unsafePublic,
+		});
+		console.error(`codemem MCP HTTP server listening at ${server.url}`);
+
+		const shutdown = async () => {
+			try {
+				await server.close();
+			} catch {
+				// Best effort — process is exiting.
+			}
+			process.exit(0);
+		};
+
+		process.on("SIGINT", shutdown);
+		process.on("SIGTERM", shutdown);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.error(`Failed to start MCP HTTP server: ${message}`);
+		process.exitCode = isMcpHttpUsageError(message) ? 2 : 1;
+	}
+});
+
+mcpCmd.addCommand(mcpHttpCmd);
 
 export const mcpCommand = mcpCmd.action(async (opts: DbOpts) => {
 	const dbPath = resolveDbOpt(opts);
@@ -20,3 +68,11 @@ export const mcpCommand = mcpCmd.action(async (opts: DbOpts) => {
 		process.exitCode = 1;
 	}
 });
+
+function isMcpHttpUsageError(message: string): boolean {
+	return (
+		message.includes("Invalid MCP HTTP host") ||
+		message.includes("Invalid MCP HTTP port") ||
+		message.includes("Refusing unsafe MCP HTTP host")
+	);
+}


### PR DESCRIPTION
## Description
Adds `codemem mcp http` as the CLI entrypoint for the Streamable HTTP MCP server while preserving `codemem mcp` as the stdio default.

The new subcommand forwards `--db-path`/`--db`, `--host`, `--port`, and `--unsafe-public` to `@codemem/mcp/http`. Host and port are left unset when omitted so environment/default resolution stays in the MCP HTTP package. README documentation covers the command, env vars, loopback default, and unsafe-public caveat.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
  - `pnpm --filter codemem typecheck`
  - `pnpm --filter @codemem/mcp typecheck`
  - `pnpm exec vitest run packages/cli/src/commands/mcp.test.ts packages/mcp-server/src/http.test.ts`
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
