### PR TITLE
fix(sync): disconnect archived coordinator teams

### DIFF
--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -238,6 +238,126 @@ describe("createCoordinatorApp dependency injection", () => {
 		).toHaveProperty("status", 200);
 	});
 
+	it("rejects signed presence and peer reads for archived groups", async () => {
+		const enrollment: CoordinatorEnrollment = {
+			group_id: "g1",
+			device_id: "d1",
+			public_key: "pk1",
+			fingerprint: "fp1",
+			display_name: "Laptop",
+			enabled: 1,
+			created_at: "2026-03-28T00:00:00Z",
+		};
+		const store = createMockStore({
+			getEnrollment: vi.fn(async () => enrollment),
+			getGroup: vi.fn(async () => ({
+				group_id: "g1",
+				display_name: "Group 1",
+				archived_at: "2026-05-22T00:00:00Z",
+				created_at: "2026-03-28T00:00:00Z",
+			})),
+			upsertPresence: vi.fn(async (): Promise<CoordinatorPresenceRecord> => {
+				throw new Error("presence should not update archived groups");
+			}),
+			listGroupPeers: vi.fn(async (): Promise<CoordinatorPeerRecord[]> => {
+				throw new Error("peers should not list archived groups");
+			}),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: {
+				adminSecret: () => "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+			},
+			requestVerifier: allowRequest,
+		});
+
+		const headers = {
+			"Content-Type": "application/json",
+			"X-Opencode-Device": "d1",
+			"X-Opencode-Signature": "sig",
+			"X-Opencode-Timestamp": "2026-03-28T00:00:00Z",
+			"X-Opencode-Nonce": "nonce-1",
+		};
+		const presence = await app.request("/v1/presence", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({ group_id: "g1", fingerprint: "fp1", addresses: [] }),
+		});
+		const peers = await app.request("/v1/peers?group_id=g1", {
+			headers: { ...headers, "X-Opencode-Nonce": "nonce-2" },
+		});
+
+		expect(presence.status).toBe(409);
+		expect(await presence.json()).toEqual({ error: "group_archived" });
+		expect(peers.status).toBe(409);
+		expect(await peers.json()).toEqual({ error: "group_archived" });
+		expect(store.upsertPresence).not.toHaveBeenCalled();
+		expect(store.listGroupPeers).not.toHaveBeenCalled();
+	});
+
+	it("rate limits archived-group authentication failures", async () => {
+		const enrollment: CoordinatorEnrollment = {
+			group_id: "g1",
+			device_id: "d1",
+			public_key: "pk1",
+			fingerprint: "fp1",
+			display_name: "Laptop",
+			enabled: 1,
+			created_at: "2026-03-28T00:00:00Z",
+		};
+		const store = createMockStore({
+			getEnrollment: vi.fn(async () => enrollment),
+			getGroup: vi.fn(async () => ({
+				group_id: "g1",
+				display_name: "Group 1",
+				archived_at: "2026-05-22T00:00:00Z",
+				created_at: "2026-03-28T00:00:00Z",
+			})),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: {
+				adminSecret: () => "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+			},
+			requestVerifier: allowRequest,
+			requestRateLimit: {
+				limiter: createInMemoryRequestRateLimiter(),
+				readLimit: 10,
+				unauthenticatedReadLimit: 1,
+				unauthenticatedMutationLimit: 1,
+			},
+		});
+
+		const headers = {
+			"Content-Type": "application/json",
+			"X-Opencode-Device": "d1",
+			"X-Opencode-Signature": "sig",
+			"X-Opencode-Timestamp": "2026-03-28T00:00:00Z",
+			"X-Opencode-Nonce": "nonce-1",
+		};
+		expect(
+			await app.request("/v1/presence", {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ group_id: "g1", fingerprint: "fp1", addresses: [] }),
+			}),
+		).toHaveProperty("status", 409);
+
+		const limited = await app.request("/v1/presence", {
+			method: "POST",
+			headers: { ...headers, "X-Opencode-Nonce": "nonce-2" },
+			body: JSON.stringify({ group_id: "g1", fingerprint: "fp1", addresses: [] }),
+		});
+
+		expect(limited.status).toBe(429);
+		expect(await limited.json()).toEqual({
+			error: "rate_limited",
+			retry_after_s: expect.any(Number),
+		});
+	});
+
 	it("does not rely on process env when runtime admin secret is unset", async () => {
 		const app = createCoordinatorApp({
 			storeFactory: () => createMockStore(),
@@ -320,6 +440,12 @@ describe("createCoordinatorApp dependency injection", () => {
 
 	it("lists reciprocal approvals for the authenticated device", async () => {
 		const store = createMockStore({
+			getGroup: vi.fn(async () => ({
+				group_id: "g1",
+				display_name: "Group 1",
+				archived_at: null,
+				created_at: "2026-03-28T00:00:00Z",
+			})),
 			getEnrollment: vi.fn(async () => ({
 				group_id: "g1",
 				device_id: "local-device",
@@ -386,6 +512,12 @@ describe("createCoordinatorApp dependency injection", () => {
 
 	it("creates a reciprocal approval for the authenticated device", async () => {
 		const store = createMockStore({
+			getGroup: vi.fn(async () => ({
+				group_id: "g1",
+				display_name: "Group 1",
+				archived_at: null,
+				created_at: "2026-03-28T00:00:00Z",
+			})),
 			getEnrollment: vi.fn(async (groupId: string, deviceId: string) => {
 				if (groupId !== "g1") return null;
 				if (deviceId === "local-device" || deviceId === "peer-a") {

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -134,6 +134,13 @@ async function authorizeRequest(
 	if (!enrollment) {
 		return { ok: false, error: "unknown_device", enrollment: null };
 	}
+	const group = await store.getGroup(opts.groupId);
+	if (!group) {
+		return { ok: false, error: "group_not_found", enrollment: null };
+	}
+	if (group.archived_at) {
+		return { ok: false, error: "group_archived", enrollment: null };
+	}
 
 	let valid: boolean;
 	try {
@@ -353,7 +360,9 @@ export function createCoordinatorApp(
 				nonce: c.req.header("X-Opencode-Nonce") ?? null,
 			});
 			if (!auth.ok || !auth.enrollment) {
-				return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: auth.error }, 401);
+				const limited = rateLimitedResponse(c, c.req.path, false);
+				if (limited) return limited;
+				return c.json({ error: auth.error }, auth.error === "group_archived" ? 409 : 401);
 			}
 			const limited = rateLimitedResponse(c, String(auth.enrollment.device_id), true);
 			if (limited) return limited;
@@ -419,7 +428,9 @@ export function createCoordinatorApp(
 				nonce: c.req.header("X-Opencode-Nonce") ?? null,
 			});
 			if (!auth.ok || !auth.enrollment) {
-				return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: auth.error }, 401);
+				const limited = rateLimitedResponse(c, c.req.path, false);
+				if (limited) return limited;
+				return c.json({ error: auth.error }, auth.error === "group_archived" ? 409 : 401);
 			}
 			const limited = rateLimitedResponse(c, String(auth.enrollment.device_id), true);
 			if (limited) return limited;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -8572,6 +8572,7 @@ describe("viewer-server", () => {
 					JSON.stringify({
 						sync_coordinator_url: "https://coord.example.test",
 						sync_coordinator_group: "team-a",
+						sync_coordinator_groups: ["team-a", "team-b"],
 						sync_coordinator_admin_secret: "secret",
 					}),
 				);
@@ -8620,6 +8621,7 @@ describe("viewer-server", () => {
 					JSON.stringify({
 						sync_coordinator_url: "https://coord.example.test",
 						sync_coordinator_group: "team-a",
+						sync_coordinator_groups: ["team-a", "team-b"],
 						sync_coordinator_admin_secret: "secret",
 					}),
 				);
@@ -8669,6 +8671,7 @@ describe("viewer-server", () => {
 					JSON.stringify({
 						sync_coordinator_url: "https://coord.example.test",
 						sync_coordinator_group: "team-a",
+						sync_coordinator_groups: ["team-a", "team-b"],
 						sync_coordinator_admin_secret: "secret",
 					}),
 				);
@@ -8750,6 +8753,7 @@ describe("viewer-server", () => {
 					JSON.stringify({
 						sync_coordinator_url: "https://coord.example.test",
 						sync_coordinator_group: "team-a",
+						sync_coordinator_groups: ["team-a", "team-b"],
 						sync_coordinator_admin_secret: "secret",
 					}),
 				);
@@ -8772,6 +8776,15 @@ describe("viewer-server", () => {
 						method: "POST",
 					});
 					expect(archived.status).toBe(200);
+					expect(await archived.json()).toMatchObject({
+						disconnected_group_id: "team-a",
+						groups: ["team-b"],
+						status: { groups: ["team-b"], active_group: "team-b" },
+					});
+					expect(JSON.parse(readFileSync(configPath, "utf8"))).toMatchObject({
+						sync_coordinator_group: "team-b",
+						sync_coordinator_groups: ["team-b"],
+					});
 					const unarchived = await app.request("/api/coordinator/admin/groups/team-a/unarchive", {
 						method: "POST",
 					});

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -74,6 +74,7 @@ import {
 	normalizeSyncCapability,
 	parseSyncScopeRequest,
 	personalScopeGrantStatusForPeer,
+	readCodememConfigFile,
 	readCoordinatorSyncConfig,
 	reassignProjectScopeInventoryProject,
 	recordNonce,
@@ -88,6 +89,7 @@ import {
 	upsertCoordinatorGroupPreference,
 	upsertProjectScopeSettingsMapping,
 	verifySignature,
+	writeCodememConfigFile,
 } from "@codemem/core";
 import { and, count, desc, eq, max, ne } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -236,6 +238,30 @@ function coordinatorAdminStatusPayload(config = readCoordinatorSyncConfig()) {
 		has_admin_secret: hasAdminSecret,
 		has_groups: hasGroups,
 	};
+}
+
+function removeConfiguredCoordinatorGroup(groupId: string): string[] {
+	const targetGroup = groupId.trim();
+	if (!targetGroup) return [];
+	const config = readCodememConfigFile();
+	const rawGroups = config.sync_coordinator_groups;
+	const groups = Array.isArray(rawGroups)
+		? rawGroups.map((group) => String(group).trim()).filter(Boolean)
+		: typeof rawGroups === "string"
+			? rawGroups
+					.split(",")
+					.map((group) => group.trim())
+					.filter(Boolean)
+			: typeof config.sync_coordinator_group === "string" && config.sync_coordinator_group.trim()
+				? [config.sync_coordinator_group.trim()]
+				: [];
+	const nextGroups = groups.filter((group) => group !== targetGroup);
+	if (nextGroups.length === groups.length) return groups;
+	config.sync_coordinator_groups = nextGroups;
+	if (nextGroups.length) config.sync_coordinator_group = nextGroups[0];
+	else delete config.sync_coordinator_group;
+	writeCodememConfigFile(config);
+	return nextGroups;
 }
 
 function coordinatorAdminUnavailable(status: ReturnType<typeof coordinatorAdminStatusPayload>): {
@@ -3461,7 +3487,14 @@ export function syncRoutes(
 				adminSecret: config.syncCoordinatorAdminSecret || null,
 			});
 			if (!group) return c.json({ error: "group_not_found_or_already_archived", status }, 404);
-			return c.json({ ok: true, group, status });
+			const groups = removeConfiguredCoordinatorGroup(groupId);
+			return c.json({
+				ok: true,
+				group,
+				status: coordinatorAdminStatusPayload(),
+				disconnected_group_id: groupId,
+				groups,
+			});
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : String(error), status }, 400);
 		}


### PR DESCRIPTION
## Description
Fixes archived Team/coordinator group lifecycle behavior for the 0.31.4 patch line.

Archiving a configured Team now disconnects it from this local node by removing it from the active coordinator group config. The coordinator API also rejects signed presence and peer-list requests for archived groups, so archived Teams stop participating in discovery instead of remaining operational until users manually edit config.json.

Note: the coordinator API change requires redeploying the Cloudflare coordinator Worker after merge.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (pnpm run tsc, pnpm run lint, pnpm run test)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run:
- pnpm exec vitest run packages/core/src/coordinator-api.test.ts
- pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "runs coordinator group lifecycle actions through the admin routes"
- pnpm exec biome check packages/core/src/coordinator-api.ts packages/core/src/coordinator-api.test.ts packages/viewer-server/src/routes/sync.ts packages/viewer-server/src/index.test.ts
- pnpm exec tsc --build packages/core/tsconfig.json packages/viewer-server/tsconfig.json --pretty false

## Checklist

- [x] Code follows project style for touched files
- [x] Self-review completed
- [x] Documentation updated (not needed for patch behavior; PR notes coordinator redeploy requirement)
- [x] No new warnings introduced