### PR TITLE
feat(ui): rename coordinator groups to teams

### DIFF
--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -513,6 +513,8 @@ export async function saveCoordinatorGroupPreferences(
 		projects_include?: string[] | null;
 		projects_exclude?: string[] | null;
 		auto_seed_scope?: boolean;
+		default_space_scope_id?: string | null;
+		auto_grant_default_space_on_join?: boolean;
 	},
 ): Promise<CoordinatorGroupPreferences> {
 	const resp = await fetch(

--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -55,7 +55,7 @@ function emptyDraft(): GroupPreferencesDraft {
 		projects_exclude: [],
 		auto_seed_scope: true,
 		default_space_scope_id: "",
-		auto_grant_default_space_on_join: true,
+		auto_grant_default_space_on_join: false,
 		loaded: false,
 		saving: false,
 		error: "",
@@ -74,7 +74,7 @@ async function openGroupPreferences(groupId: string, renderShell: () => void): P
 			projects_exclude: Array.isArray(prefs.projects_exclude) ? [...prefs.projects_exclude] : [],
 			auto_seed_scope: prefs.auto_seed_scope,
 			default_space_scope_id: prefs.default_space_scope_id || "",
-			auto_grant_default_space_on_join: prefs.auto_grant_default_space_on_join !== false,
+			auto_grant_default_space_on_join: prefs.auto_grant_default_space_on_join === true,
 			loaded: true,
 			saving: false,
 			error: "",
@@ -120,9 +120,7 @@ async function saveGroupPreferences(groupId: string, renderShell: () => void): P
 	renderShell();
 	try {
 		await api.saveCoordinatorGroupPreferences(groupId, payload);
-		showGlobalNotice(
-			"Group project defaults saved. New peers enrolled through this team will use these filters.",
-		);
+		showGlobalNotice("Team defaults saved. New devices use these filters and Space settings.");
 		closeGroupPreferences(groupId, renderShell);
 	} catch (error) {
 		// Re-read the latest draft so any keystrokes landed during the save are
@@ -156,11 +154,11 @@ function renderGroupPreferencesEditor(
 	return h(
 		Fragment,
 		null,
-		h("h4", { class: "coordinator-admin-drawer-title" }, "Project defaults"),
+		h("h4", { class: "coordinator-admin-drawer-title" }, "Team defaults"),
 		h(
 			"div",
 			{ class: "peer-submeta" },
-			"When enabled, new peers enrolled through this coordinator group start with the project filters below. Existing peers are unchanged, and these filters never grant sharing-domain access.",
+			"Project filters only narrow what future writes sync; they never grant Space access by themselves. Use the default Space toggle to control whether newly joined devices receive the Team's default Space.",
 		),
 		// Master toggle first — the include/exclude chips are only meaningful
 		// when auto-seed is on, so the form reads top-down from decision
@@ -210,7 +208,7 @@ function renderGroupPreferencesEditor(
 			}),
 		),
 		draft.default_space_scope_id
-			? h("div", { class: "peer-submeta" }, `Default Space: ${draft.default_space_scope_id}`)
+			? h("div", { class: "peer-submeta" }, "Default Space configured.")
 			: h("div", { class: "peer-submeta" }, "No default Space has been created yet."),
 		h(
 			"div",
@@ -315,22 +313,22 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 	return h(
 		RadixTabsContent,
 		{ className: "coordinator-admin-panel", value: "groups" },
-		h("h3", null, "Groups"),
+		h("h3", null, "Teams"),
 		h(
 			"p",
 			{ class: "peer-submeta" },
 			selectedGroup
 				? `Managing ${selectedGroup}${configuredGroup && configuredGroup !== selectedGroup ? ` · this node uses ${configuredGroup} for discovery` : ""}`
 				: configuredGroup
-					? `This node uses ${configuredGroup} for discovery. Select a group below to manage it.`
-					: "No group selected yet. Create one or select an existing group to manage.",
+					? `This node uses ${configuredGroup} for discovery. Select a Team below to manage it.`
+					: "No Team selected yet. Create one or select an existing Team to manage.",
 		),
 		groups.length ? h("p", { class: "peer-submeta" }, countParts.join(" · ")) : null,
 		!targetExists && selectedGroup
 			? h(
 					"div",
 					{ class: "peer-meta coordinator-admin-inline-warning" },
-					`The selected admin target group (${selectedGroup}) is configured locally but does not exist in the coordinator yet. Create it below or switch to another group once one exists.`,
+					`The selected Team (${selectedGroup}) is configured locally but does not exist in the coordinator yet. Create it below or switch to another Team once one exists.`,
 				)
 			: null,
 		h(
@@ -339,7 +337,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 			h(
 				"label",
 				{ class: "coordinator-admin-field" },
-				h("span", null, "New group id"),
+				h("span", null, "New Team id"),
 				h(TextInput, {
 					class: "peer-scope-input",
 					disabled:
@@ -391,7 +389,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 						onClick: () => createGroup(),
 						type: "button",
 					},
-					coordinatorAdminState.groupActionPendingKind === "create" ? "Creating…" : "Create group",
+					coordinatorAdminState.groupActionPendingKind === "create" ? "Creating…" : "Create Team",
 				),
 			),
 			h(
@@ -425,9 +423,9 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 					{ class: "peer-meta coordinator-admin-empty-state" },
 					summary.readiness === "ready"
 						? coordinatorAdminState.showArchivedGroups
-							? "No coordinator groups are available yet."
-							: "No active groups yet. Create one to get started."
-						: "Group browsing will appear here once setup is complete.",
+							? "No Teams are available yet."
+							: "No active Teams yet. Create one to get started."
+						: "Team browsing will appear here once setup is complete.",
 				)
 			: h(
 					"div",
@@ -446,13 +444,13 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 							"div",
 							{ class: "peer-card peer-card--padded", key: group.group_id },
 							h("div", { class: "peer-title" }, h("strong", null, draftName)),
-							h("div", { class: "peer-meta" }, `Group ID: ${group.group_id}`),
+							h("div", { class: "peer-meta" }, `Team ID: ${group.group_id}`),
 							h("div", { class: "peer-submeta" }, archived ? "Archived" : "Active"),
 							configuredGroup === group.group_id
 								? h(
 										"div",
 										{ class: "peer-submeta" },
-										"This node is configured to use this group for coordinator-backed discovery.",
+										"This node is configured to use this Team for coordinator-backed discovery.",
 									)
 								: null,
 							h(
@@ -517,7 +515,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 										},
 										type: "button",
 									},
-									h("span", null, "Project defaults"),
+									h("span", null, "Team defaults"),
 									h(
 										"span",
 										{ "aria-hidden": "true", class: "device-row-chevron" },
@@ -528,7 +526,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 									"button",
 									{
 										"aria-expanded": domainsOpen,
-										"aria-controls": `coord-admin-domains-drawer-${group.group_id}`,
+										"aria-controls": `coord-admin-spaces-drawer-${group.group_id}`,
 										class: "settings-button coordinator-admin-scope-trigger",
 										"data-state": domainsOpen ? "open" : "closed",
 										disabled: summary.readiness !== "ready" || pending,
@@ -541,7 +539,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 										},
 										type: "button",
 									},
-									h("span", null, "Sharing domains"),
+									h("span", null, "Spaces"),
 									h(
 										"span",
 										{ "aria-hidden": "true", class: "device-row-chevron" },
@@ -609,10 +607,10 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 								h(
 									Collapsible.Content,
 									{
-										"aria-label": `Sharing domains for ${draftName}`,
+										"aria-label": `Spaces for ${draftName}`,
 										class:
 											"coordinator-admin-group-preferences coordinator-admin-domain-management",
-										id: `coord-admin-domains-drawer-${group.group_id}`,
+										id: `coord-admin-spaces-drawer-${group.group_id}`,
 									},
 									domainsOpen
 										? renderGroupScopeManagementPanel({

--- a/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
@@ -102,7 +102,7 @@ async function loadGroupScopeManagement(
 			...draftFor(groupId),
 			loaded: true,
 			loading: false,
-			error: error instanceof Error ? error.message : "Failed to load sharing domains.",
+			error: error instanceof Error ? error.message : "Failed to load Spaces.",
 		});
 	}
 	renderShell();
@@ -128,7 +128,7 @@ async function createScope(groupId: string, renderShell: () => void): Promise<vo
 	const label = draft.createLabel.trim();
 	const kind = draft.createKind.trim() || "team";
 	if (!scopeId || !label) {
-		showGlobalNotice("Enter a scope id and label before creating a sharing domain.", "warning");
+		showGlobalNotice("Enter a Space id and label before creating a Space.", "warning");
 		return;
 	}
 	setDraft(groupId, {
@@ -153,14 +153,14 @@ async function createScope(groupId: string, renderShell: () => void): Promise<vo
 			actionPendingKey: "",
 			actionPendingKind: "",
 		});
-		showGlobalNotice("Sharing domain created. Grant devices explicitly before data can sync.");
+		showGlobalNotice("Space created. Grant devices explicitly before data can sync.");
 		await loadGroupScopeManagement(groupId, renderShell, latest.includeInactive);
 	} catch (error) {
 		setDraft(groupId, {
 			...draftFor(groupId),
 			actionPendingKey: "",
 			actionPendingKind: "",
-			error: error instanceof Error ? error.message : "Failed to create sharing domain.",
+			error: error instanceof Error ? error.message : "Failed to create Space.",
 		});
 		renderShell();
 	}
@@ -182,14 +182,14 @@ async function grantMember(
 			device_id: deviceId,
 			role: "member",
 		});
-		showGlobalNotice("Device granted access to the sharing domain.");
+		showGlobalNotice("Device granted access to the Space.");
 		await loadGroupScopeManagement(groupId, renderShell, draft.includeInactive);
 	} catch (error) {
 		setDraft(groupId, {
 			...draftFor(groupId),
 			actionPendingKey: "",
 			actionPendingKind: "",
-			error: error instanceof Error ? error.message : "Failed to grant scope membership.",
+			error: error instanceof Error ? error.message : "Failed to grant Space access.",
 		});
 		renderShell();
 	}
@@ -207,7 +207,7 @@ async function revokeMember(
 	const confirmed = await openSyncConfirmDialog({
 		title: `Revoke ${displayName || deviceId} from ${scope.label || scopeId}?`,
 		description:
-			"Revocation only blocks future sync for this sharing domain. Data already copied to that device can remain there.",
+			"Revocation only blocks future sync for this Space. Data already copied to that device can remain there.",
 		confirmLabel: "Revoke membership",
 		cancelLabel: "Keep membership",
 		tone: "danger",
@@ -220,14 +220,14 @@ async function revokeMember(
 	renderShell();
 	try {
 		await api.revokeCoordinatorAdminScopeMember(groupId, scopeId, deviceId);
-		showGlobalNotice("Scope membership revoked. Future sync is blocked for that device.");
+		showGlobalNotice("Space access revoked. Future sync is blocked for that device.");
 		await loadGroupScopeManagement(groupId, renderShell, draft.includeInactive);
 	} catch (error) {
 		setDraft(groupId, {
 			...draftFor(groupId),
 			actionPendingKey: "",
 			actionPendingKind: "",
-			error: error instanceof Error ? error.message : "Failed to revoke scope membership.",
+			error: error instanceof Error ? error.message : "Failed to revoke Space access.",
 		});
 		renderShell();
 	}
@@ -252,7 +252,7 @@ function renderMembershipRows(
 		return h(
 			"div",
 			{ class: "peer-submeta coordinator-admin-empty-state" },
-			"No enrolled devices in this group yet. Enroll a device before granting this sharing domain.",
+			"No enrolled devices in this Team yet. Enroll a device before granting this Space.",
 		);
 	}
 	return h(
@@ -278,7 +278,7 @@ function renderMembershipRows(
 					{ class: "coordinator-admin-scope-member-copy" },
 					h("strong", null, row.displayName),
 					h("span", null, `${statusCopy} · ${row.role} · ${epochCopy}`),
-					row.enabled ? null : h("span", null, "Device is disabled in this coordinator group."),
+					row.enabled ? null : h("span", null, "Device is disabled in this Team."),
 				),
 				h(
 					"div",
@@ -322,12 +322,12 @@ function renderScopeCard(
 	renderShell: () => void,
 ) {
 	const scopeId = String(scope.scope_id || "").trim();
-	const label = String(scope.label || scopeId || "Untitled sharing domain");
+	const label = String(scope.label || scopeId || "Untitled Space");
 	return h(
 		"div",
 		{ class: "peer-card peer-card--padded coordinator-admin-scope-card", key: scopeId || label },
 		h("div", { class: "peer-title" }, h("strong", null, label)),
-		h("div", { class: "peer-meta" }, `Scope ID: ${scopeId || "unknown"}`),
+		h("div", { class: "peer-meta" }, `Space ID: ${scopeId || "unknown"}`),
 		h(
 			"div",
 			{ class: "peer-submeta" },
@@ -336,7 +336,7 @@ function renderScopeCard(
 		h(
 			"div",
 			{ class: "peer-submeta" },
-			"Devices below are enrolled in the coordinator group; only active members can sync this sharing domain.",
+			"Devices below are enrolled in the Team; only active Space members can sync this data boundary.",
 		),
 		renderMembershipRows(groupId, scope, draft, ready, renderShell),
 	);
@@ -351,17 +351,17 @@ export function renderGroupScopeManagementPanel(deps: ScopeManagementPanelDeps) 
 		return h("div", { class: "peer-meta coordinator-admin-inline-warning" }, readinessMessage);
 	}
 	if (!draft.loaded) {
-		return h("div", { class: "peer-submeta" }, "Loading sharing domains…");
+		return h("div", { class: "peer-submeta" }, "Loading Spaces…");
 	}
 	const disabled = !ready || Boolean(draft.actionPendingKey) || draft.loading;
 	return h(
 		Fragment,
 		null,
-		h("h4", { class: "coordinator-admin-drawer-title" }, "Sharing domains"),
+		h("h4", { class: "coordinator-admin-drawer-title" }, "Spaces"),
 		h(
 			"div",
 			{ class: "peer-submeta" },
-			"Coordinator groups discover and enroll devices. Sharing domains grant data access. Granting a device here is explicit; group membership alone does not share memories.",
+			"Teams discover and enroll devices. Spaces grant data access. Granting a device here is explicit; Team membership alone does not share memories.",
 		),
 		h(
 			"label",
@@ -369,7 +369,7 @@ export function renderGroupScopeManagementPanel(deps: ScopeManagementPanelDeps) 
 			h(
 				"span",
 				{ class: "section-meta", id: `coord-admin-domain-inactive-${groupId}` },
-				"Show inactive domains",
+				"Show inactive Spaces",
 			),
 			h(RadixSwitch, {
 				"aria-labelledby": `coord-admin-domain-inactive-${groupId}`,
@@ -388,7 +388,7 @@ export function renderGroupScopeManagementPanel(deps: ScopeManagementPanelDeps) 
 			h(
 				"label",
 				{ class: "coordinator-admin-field" },
-				h("span", null, "New domain id"),
+				h("span", null, "New Space id"),
 				h(TextInput, {
 					class: "peer-scope-input",
 					disabled,
@@ -454,7 +454,7 @@ export function renderGroupScopeManagementPanel(deps: ScopeManagementPanelDeps) 
 					onClick: () => void createScope(groupId, renderShell),
 					type: "button",
 				},
-				draft.actionPendingKind === "create" ? "Creating…" : "Create sharing domain",
+				draft.actionPendingKind === "create" ? "Creating…" : "Create Space",
 			),
 			h(
 				"button",
@@ -477,7 +477,7 @@ export function renderGroupScopeManagementPanel(deps: ScopeManagementPanelDeps) 
 			: h(
 					"div",
 					{ class: "peer-meta coordinator-admin-empty-state" },
-					"No sharing domains are defined for this group yet. Create one, then grant specific devices.",
+					"No Spaces are defined for this Team yet. Create one, then grant specific devices.",
 				),
 	);
 }

--- a/packages/ui/src/tabs/coordinator-admin/data/actions.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/actions.ts
@@ -44,7 +44,7 @@ export function createCoordinatorAdminActions(
 		if (coordinatorAdminState.groupActionPendingKind) return;
 		const groupId = coordinatorAdminState.createGroupId.trim();
 		if (!groupId) {
-			showGlobalNotice("Enter a group id before creating a group.", "warning");
+			showGlobalNotice("Enter a Team id before creating a Team.", "warning");
 			return;
 		}
 		coordinatorAdminState.groupActionPendingKind = "create";
@@ -56,11 +56,11 @@ export function createCoordinatorAdminActions(
 			});
 			coordinatorAdminState.createGroupId = "";
 			coordinatorAdminState.createGroupDisplayName = "";
-			showGlobalNotice("Group created.", "success");
+			showGlobalNotice("Team created.", "success");
 			await reloadData();
 		} catch (error) {
 			showGlobalNotice(
-				error instanceof Error ? error.message : "Failed to create group.",
+				error instanceof Error ? error.message : "Failed to create Team.",
 				"warning",
 			);
 		} finally {
@@ -81,10 +81,10 @@ export function createCoordinatorAdminActions(
 				title: `${kind === "archive" ? "Archive" : "Unarchive"} ${displayName || groupId}?`,
 				description:
 					kind === "archive"
-						? "Archived groups stay visible and restorable, but they stop being operational for new invites and joins."
-						: "This group will become operational again for invites and coordinator-backed joins.",
-				confirmLabel: kind === "archive" ? "Archive group" : "Unarchive group",
-				cancelLabel: kind === "archive" ? "Keep group active" : "Keep group archived",
+						? "Archived Teams stay visible and restorable, but they stop being operational for new invites and joins."
+						: "This Team will become operational again for invites and coordinator-backed joins.",
+				confirmLabel: kind === "archive" ? "Archive Team" : "Unarchive Team",
+				cancelLabel: kind === "archive" ? "Keep Team active" : "Keep Team archived",
 				tone: "danger",
 			}))
 		) {
@@ -96,20 +96,20 @@ export function createCoordinatorAdminActions(
 		try {
 			if (kind === "rename") {
 				await api.renameCoordinatorAdminGroup(groupId, displayName);
-				showGlobalNotice("Group renamed.", "success");
+				showGlobalNotice("Team renamed.", "success");
 			}
 			if (kind === "archive") {
 				await api.archiveCoordinatorAdminGroup(groupId);
-				showGlobalNotice("Group archived.", "success");
+				showGlobalNotice("Team archived.", "success");
 			}
 			if (kind === "unarchive") {
 				await api.unarchiveCoordinatorAdminGroup(groupId);
-				showGlobalNotice("Group unarchived.", "success");
+				showGlobalNotice("Team unarchived.", "success");
 			}
 			await reloadData();
 		} catch (error) {
 			showGlobalNotice(
-				error instanceof Error ? error.message : `Failed to ${kind} group.`,
+				error instanceof Error ? error.message : `Failed to ${kind} Team.`,
 				"warning",
 			);
 		} finally {
@@ -126,7 +126,7 @@ export function createCoordinatorAdminActions(
 		const groupId = coordinatorAdminState.inviteGroup.trim() || defaultGroup;
 		const ttlHours = Number(coordinatorAdminState.inviteTtlHours);
 		if (!groupId) {
-			showGlobalNotice("Choose a coordinator group before creating an invite.", "warning");
+			showGlobalNotice("Choose a Team before creating an invite.", "warning");
 			return;
 		}
 		if (!Number.isFinite(ttlHours) || ttlHours < 1) {
@@ -165,11 +165,20 @@ export function createCoordinatorAdminActions(
 		coordinatorAdminState.joinReviewPendingAction = action;
 		renderShell();
 		try {
-			await api.reviewCoordinatorAdminJoinRequest(requestId, action);
-			showGlobalNotice(
-				action === "approve" ? "Join request approved." : "Join request denied.",
-				"success",
-			);
+			const result = (await api.reviewCoordinatorAdminJoinRequest(requestId, action)) as {
+				setup_warning?: { step?: string; error?: string } | null;
+			};
+			if (action === "approve" && result.setup_warning) {
+				showGlobalNotice(
+					"Join request approved, but default Space access needs repair.",
+					"warning",
+				);
+			} else {
+				showGlobalNotice(
+					action === "approve" ? "Join request approved." : "Join request denied.",
+					"success",
+				);
+			}
 			await reloadData();
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to review join request.";

--- a/packages/ui/src/tabs/coordinator-admin/data/scope-management.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/scope-management.ts
@@ -32,7 +32,7 @@ export interface ScopeMembershipDeviceRow {
 
 export function scopeManagementReadinessMessage(summary: CoordinatorAdminSummary): string | null {
 	if (summary.readiness === "ready") return null;
-	return "Sharing domain management needs the coordinator URL, target group, and admin secret before it can list scopes or change memberships.";
+	return "Space management needs the coordinator URL, target Team, and admin secret before it can list Spaces or change memberships.";
 }
 
 export function scopeStatusLabel(status: string | null | undefined): string {


### PR DESCRIPTION
## Description
Updates the primary Coordinator Admin UI copy to the 0.32 Team/Space vocabulary. The main admin surface now presents coordinator groups as Teams and sharing-domain data boundaries as Spaces, while preserving underlying API/internal names.

The Team defaults panel also surfaces default Space auto-grant behavior and warns admins when join approval succeeds but default Space access needs repair.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm exec tsc --build packages/core/tsconfig.json packages/viewer-server/tsconfig.json packages/ui/tsconfig.json --pretty false`
- `pnpm exec biome check` on touched files
- Stack reviewed with CodeReviewer; blockers addressed

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
