### PR TITLE
feat(mcp): expose OAuth metadata and registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This updates your OpenCode config to install the plugin and register the MCP ser
 
 The standalone `codemem-mcp-ts` binary runs the same stdio server used by `codemem mcp`. Viewer autostart is on by default for both invocation paths; set `CODEMEM_VIEWER=0` or `CODEMEM_VIEWER_AUTO=0` to disable.
 
-For local HTTP transport testing, run `codemem mcp http`. It listens on `127.0.0.1:38889` by default and exposes Streamable HTTP at `POST /mcp`; use `--host`, `--port`, and `--db-path` to override those values. Non-loopback binds are rejected unless you explicitly pass `--unsafe-public` or set `CODEMEM_MCP_HTTP_UNSAFE_PUBLIC=1`; this mode is unauthenticated, still applies loopback Host/Origin checks, and should not be exposed directly to untrusted networks.
+For local HTTP transport testing, run `codemem mcp http`. It listens on `127.0.0.1:38889` by default and exposes Streamable HTTP at `POST /mcp`; use `--host`, `--port`, and `--db-path` to override those values. OAuth discovery metadata and Dynamic Client Registration are available at `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource/mcp`, and `/register`; set `--public-url` or `CODEMEM_MCP_HTTP_PUBLIC_URL` to the externally reachable `/mcp` URL so advertised endpoints use the public origin. This slice exposes discovery and registration only: `/authorize` and `/token` intentionally return `501` until the PKCE/token slice lands. Non-loopback binds are rejected unless you explicitly pass `--unsafe-public` or set `CODEMEM_MCP_HTTP_UNSAFE_PUBLIC=1`; `/mcp` remains unauthenticated until the OAuth bearer-enforcement slice lands, still applies loopback Host/Origin checks, and should not be exposed directly to untrusted networks.
 
 ## Configuration
 
@@ -178,6 +178,7 @@ Common overrides:
 | `CODEMEM_VIEWER_HOST`, `CODEMEM_VIEWER_PORT` | Host/port the plugin-managed viewer should start, probe, and restart |
 | `CODEMEM_VIEWER_AUTO` | `0` to disable auto-starting the viewer |
 | `CODEMEM_MCP_HTTP_HOST`, `CODEMEM_MCP_HTTP_PORT` | Host/port for `codemem mcp http` |
+| `CODEMEM_MCP_HTTP_PUBLIC_URL` | Public `/mcp` URL advertised in MCP OAuth metadata |
 | `CODEMEM_MCP_HTTP_UNSAFE_PUBLIC` | `1`, `true`, or `yes` to allow non-loopback MCP HTTP binds |
 
 Viewer note:

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -39,6 +39,7 @@ describe("mcp command", () => {
 			"--db-path",
 			"--host",
 			"--port",
+			"--public-url",
 			"--unsafe-public",
 		]);
 	});
@@ -55,6 +56,8 @@ describe("mcp command", () => {
 					"localhost",
 					"--port",
 					"39999",
+					"--public-url",
+					"https://codemem.example.test/mcp",
 					"--unsafe-public",
 				],
 				{ from: "user" },
@@ -65,6 +68,7 @@ describe("mcp command", () => {
 				dbPath: "/tmp/codemem-test.sqlite",
 				host: "localhost",
 				port: "39999",
+				publicUrl: "https://codemem.example.test/mcp",
 			});
 		} finally {
 			stderr.mockRestore();
@@ -81,6 +85,7 @@ describe("mcp command", () => {
 				dbPath: "/tmp/parent.sqlite",
 				host: undefined,
 				port: undefined,
+				publicUrl: undefined,
 			});
 		} finally {
 			stderr.mockRestore();
@@ -97,6 +102,7 @@ describe("mcp command", () => {
 				dbPath: undefined,
 				host: undefined,
 				port: undefined,
+				publicUrl: undefined,
 			});
 		} finally {
 			stderr.mockRestore();

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -13,6 +13,7 @@ interface McpHttpOpts extends DbOpts {
 	host?: string;
 	port?: string;
 	unsafePublic?: boolean;
+	publicUrl?: string;
 }
 
 const mcpHttpCmd = new Command("http")
@@ -20,6 +21,7 @@ const mcpHttpCmd = new Command("http")
 	.description("Start the MCP Streamable HTTP server")
 	.option("--host <host>", "HTTP host")
 	.option("--port <port>", "HTTP port")
+	.option("--public-url <url>", "public MCP URL used in OAuth metadata")
 	.option("--unsafe-public", "allow non-loopback bind without auth");
 
 addDbOption(mcpHttpCmd);
@@ -33,6 +35,7 @@ mcpHttpCmd.action(async () => {
 			host: opts.host,
 			port: opts.port,
 			allowUnsafePublic: opts.unsafePublic,
+			publicUrl: opts.publicUrl,
 		});
 		console.error(`codemem MCP HTTP server listening at ${server.url}`);
 
@@ -73,6 +76,7 @@ function isMcpHttpUsageError(message: string): boolean {
 	return (
 		message.includes("Invalid MCP HTTP host") ||
 		message.includes("Invalid MCP HTTP port") ||
+		message.includes("Invalid MCP HTTP public URL") ||
 		message.includes("Refusing unsafe MCP HTTP host")
 	);
 }

--- a/packages/mcp-server/src/http.test.ts
+++ b/packages/mcp-server/src/http.test.ts
@@ -86,6 +86,122 @@ describe("MCP HTTP transport", () => {
 		expect(missingResponse.status).toBe(404);
 	});
 
+	it("serves OAuth authorization server and protected resource metadata", async () => {
+		const server = await startCodememMcpHttpServer({
+			dbPath: tempDbPath(),
+			port: 0,
+			publicUrl: "https://codemem.example.test/mcp",
+		});
+		servers.push(server);
+
+		const baseUrl = server.url.replace("/mcp", "");
+		const authorizationMetadata = await fetch(`${baseUrl}/.well-known/oauth-authorization-server`);
+		const protectedResourceMetadata = await fetch(
+			`${baseUrl}/.well-known/oauth-protected-resource/mcp`,
+		);
+
+		expect(authorizationMetadata.status).toBe(200);
+		expect(await authorizationMetadata.json()).toMatchObject({
+			issuer: "https://codemem.example.test/",
+			registration_endpoint: "https://codemem.example.test/register",
+			code_challenge_methods_supported: ["S256"],
+			token_endpoint_auth_methods_supported: ["none"],
+		});
+		expect(protectedResourceMetadata.status).toBe(200);
+		expect(await protectedResourceMetadata.json()).toEqual({
+			resource: "https://codemem.example.test/mcp",
+			authorization_servers: ["https://codemem.example.test/"],
+			bearer_methods_supported: ["header"],
+			resource_name: "codemem MCP",
+		});
+	});
+
+	it("derives default OAuth metadata from the bound HTTP host", async () => {
+		const server = await startCodememMcpHttpServer({
+			dbPath: tempDbPath(),
+			host: "::1",
+			port: 0,
+		});
+		servers.push(server);
+
+		const response = await fetch(
+			`${server.url.replace("/mcp", "")}/.well-known/oauth-protected-resource/mcp`,
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({ resource: server.url });
+	});
+
+	it("registers OAuth clients through Dynamic Client Registration", async () => {
+		const server = await startCodememMcpHttpServer({
+			dbPath: tempDbPath(),
+			port: 0,
+			publicUrl: "https://codemem.example.test/mcp",
+		});
+		servers.push(server);
+
+		const response = await fetch(server.url.replace("/mcp", "/register"), {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+				client_name: "Claude",
+				token_endpoint_auth_method: "none",
+			}),
+		});
+		const registered = await response.json();
+
+		expect(response.status).toBe(201);
+		expect(registered).toMatchObject({
+			redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+			client_name: "Claude",
+			token_endpoint_auth_method: "none",
+			grant_types: ["authorization_code"],
+		});
+		expect(registered.client_id).toMatch(/[0-9a-f-]{36}/);
+		expect(registered.client_secret).toBeUndefined();
+	});
+
+	it("rejects local Dynamic Client Registration from non-loopback origins", async () => {
+		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
+		servers.push(server);
+
+		const response = await fetch(server.url.replace("/mcp", "/register"), {
+			method: "POST",
+			headers: { "content-type": "application/json", origin: "http://evil.test" },
+			body: JSON.stringify({ redirect_uris: ["https://claude.ai/api/mcp/auth_callback"] }),
+		});
+
+		expect(response.status).toBe(403);
+	});
+
+	it("rejects unsupported OAuth redirect URIs", async () => {
+		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
+		servers.push(server);
+
+		const response = await fetch(server.url.replace("/mcp", "/register"), {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ redirect_uris: ["https://evil.test/callback"] }),
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({ error: "invalid_client_metadata" });
+	});
+
+	it("returns temporary OAuth flow errors for unimplemented authorize/token endpoints", async () => {
+		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
+		servers.push(server);
+
+		const authorize = await fetch(server.url.replace("/mcp", "/authorize"));
+		const token = await fetch(server.url.replace("/mcp", "/token"), { method: "POST" });
+
+		expect(authorize.status).toBe(501);
+		expect(await authorize.json()).toMatchObject({ error: "temporarily_unavailable" });
+		expect(token.status).toBe(501);
+		expect(await token.json()).toMatchObject({ error: "temporarily_unavailable" });
+	});
+
 	it("handles repeated MCP initialize requests over POST", async () => {
 		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
 		servers.push(server);

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -3,8 +3,9 @@
 /**
  * @codemem/mcp — MCP Streamable HTTP server bootstrap.
  *
- * Local-first HTTP transport for MCP clients. This intentionally exposes only
- * POST /mcp and does not implement OAuth or any other auth layer yet.
+ * Local-first HTTP transport for MCP clients. OAuth metadata and Dynamic Client
+ * Registration are exposed for remote MCP setup; bearer enforcement is added in
+ * a later slice.
  */
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
@@ -13,6 +14,14 @@ import { pathToFileURL } from "node:url";
 import { MemoryStore, resolveDbPath } from "@codemem/core";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+	createInMemoryOAuthClientsStore,
+	createMcpOAuthMetadata,
+	createMcpProtectedResourceMetadata,
+	MCP_OAUTH_PUBLIC_URL_ENV,
+	normalizeMcpPublicUrl,
+	registerMcpOAuthClient,
+} from "./oauth.js";
 import { createCodememMcpServer } from "./server.js";
 
 export const DEFAULT_MCP_HTTP_HOST = "127.0.0.1";
@@ -31,6 +40,7 @@ export interface CodememMcpHttpOptions {
 	port?: number | string;
 	dbPath?: string;
 	allowUnsafePublic?: boolean;
+	publicUrl?: string;
 }
 
 export interface CodememMcpHttpServer {
@@ -151,21 +161,76 @@ export async function startCodememMcpHttpServer(
 		options.allowUnsafePublic ?? isUnsafePublicBindAllowed(),
 	);
 	const port = parseMcpHttpPort(options.port ?? process.env.CODEMEM_MCP_HTTP_PORT);
+	const configuredPublicUrl = options.publicUrl ?? process.env[MCP_OAUTH_PUBLIC_URL_ENV];
+	if (configuredPublicUrl) normalizeMcpPublicUrl(configuredPublicUrl);
 	const store = new MemoryStore(options.dbPath ?? resolveDbPath());
+	const clientsStore = createInMemoryOAuthClientsStore();
 	const activeRequests = new Set<ActiveRequest>();
 	let closePromise: Promise<void> | null = null;
 
 	const server = createServer(async (req, res) => {
 		try {
-			if (req.url !== "/mcp") {
+			const pathname = getRequestPathname(req);
+			const publicMcpUrl = configuredPublicUrl ?? getServerUrl(server, host);
+
+			if (pathname === "/.well-known/oauth-authorization-server") {
+				if (!allowMethod(req, res, ["GET", "OPTIONS"])) return;
+				if (req.method === "OPTIONS") {
+					writeCorsNoContent(res);
+					return;
+				}
+				writeJson(res, 200, createMcpOAuthMetadata({ mcpUrl: publicMcpUrl, clientsStore }));
+				return;
+			}
+
+			if (pathname === "/.well-known/oauth-protected-resource/mcp") {
+				if (!allowMethod(req, res, ["GET", "OPTIONS"])) return;
+				if (req.method === "OPTIONS") {
+					writeCorsNoContent(res);
+					return;
+				}
+				writeJson(res, 200, createMcpProtectedResourceMetadata(publicMcpUrl));
+				return;
+			}
+
+			if (pathname === "/register") {
+				if (!allowMethod(req, res, ["POST", "OPTIONS"])) return;
+				if (req.method === "OPTIONS") {
+					writeCorsNoContent(res);
+					return;
+				}
+				if (!configuredPublicUrl && !isAllowedMcpHttpRequest(req, getBoundPort(server))) {
+					writeText(res, 403, "Forbidden");
+					return;
+				}
+				const requestBody = await readJsonBody(req).catch(() => ({
+					__codememInvalidJson: "Invalid JSON request body",
+				}));
+				if (isInvalidJsonBody(requestBody)) {
+					writeJson(res, 400, {
+						error: "invalid_client_metadata",
+						error_description: requestBody.__codememInvalidJson,
+					});
+					return;
+				}
+				const result = registerMcpOAuthClient(requestBody, clientsStore);
+				writeJson(res, result.status, result.body);
+				return;
+			}
+
+			if (pathname === "/authorize" || pathname === "/token") {
+				writeJson(res, 501, {
+					error: "temporarily_unavailable",
+					error_description: "OAuth authorize/token flow is not implemented in this slice",
+				});
+				return;
+			}
+
+			if (pathname !== "/mcp") {
 				writeText(res, 404, "Not found");
 				return;
 			}
-			if (req.method !== "POST") {
-				res.setHeader("Allow", "POST");
-				writeText(res, 405, "Method not allowed");
-				return;
-			}
+			if (!allowMethod(req, res, ["POST"])) return;
 			if (!isAllowedMcpHttpRequest(req, getBoundPort(server))) {
 				writeText(res, 403, "Forbidden");
 				return;
@@ -222,6 +287,52 @@ export async function startCodememMcpHttpServer(
 	};
 }
 
+function getRequestPathname(req: IncomingMessage): string {
+	return new URL(req.url ?? "/", "http://codemem.local").pathname;
+}
+
+function allowMethod(req: IncomingMessage, res: ServerResponse, methods: string[]): boolean {
+	if (req.method && methods.includes(req.method)) return true;
+	res.setHeader("Allow", methods.join(", "));
+	writeText(res, 405, "Method not allowed");
+	return false;
+}
+
+function writeJson(res: ServerResponse, statusCode: number, body: unknown): void {
+	res.statusCode = statusCode;
+	res.setHeader("access-control-allow-origin", "*");
+	res.setHeader("cache-control", "no-store");
+	res.setHeader("content-type", "application/json; charset=utf-8");
+	res.end(JSON.stringify(body));
+}
+
+function writeCorsNoContent(res: ServerResponse): void {
+	res.statusCode = 204;
+	res.setHeader("access-control-allow-origin", "*");
+	res.setHeader("access-control-allow-headers", "content-type");
+	res.setHeader("access-control-allow-methods", "GET, POST, OPTIONS");
+	res.end();
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+	let body = "";
+	for await (const chunk of req) {
+		body += chunk;
+		if (body.length > 64 * 1024) throw new Error("OAuth registration request body is too large");
+	}
+	if (!body) return {};
+	return JSON.parse(body) as unknown;
+}
+
+function isInvalidJsonBody(body: unknown): body is { __codememInvalidJson: string } {
+	return (
+		typeof body === "object" &&
+		body !== null &&
+		"__codememInvalidJson" in body &&
+		typeof body.__codememInvalidJson === "string"
+	);
+}
+
 function isAllowedMcpHttpRequest(req: IncomingMessage, expectedPort: number): boolean {
 	return (
 		isAllowedMcpHttpRequestHost(req.headers.host, expectedPort) &&
@@ -243,6 +354,10 @@ function getBoundPort(server: Server): number {
 
 function formatHostForUrl(host: string): string {
 	return isIP(host) === 6 ? `[${host}]` : host;
+}
+
+function getServerUrl(server: Server, host: string): string {
+	return `http://${formatHostForUrl(host)}:${getBoundPort(server)}/mcp`;
 }
 
 function isEntrypoint(): boolean {

--- a/packages/mcp-server/src/oauth.test.ts
+++ b/packages/mcp-server/src/oauth.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+	createInMemoryOAuthClientsStore,
+	createMcpOAuthMetadata,
+	createMcpProtectedResourceMetadata,
+	normalizeMcpPublicUrl,
+	registerMcpOAuthClient,
+} from "./oauth.js";
+
+describe("MCP OAuth metadata and dynamic client registration", () => {
+	it("builds authorization server metadata from the MCP public URL", () => {
+		const clientsStore = createInMemoryOAuthClientsStore();
+
+		const metadata = createMcpOAuthMetadata({
+			mcpUrl: "https://codemem.example.test/mcp",
+			clientsStore,
+		});
+
+		expect(metadata).toMatchObject({
+			issuer: "https://codemem.example.test/",
+			authorization_endpoint: "https://codemem.example.test/authorize",
+			token_endpoint: "https://codemem.example.test/token",
+			registration_endpoint: "https://codemem.example.test/register",
+			response_types_supported: ["code"],
+			grant_types_supported: ["authorization_code"],
+			code_challenge_methods_supported: ["S256"],
+			token_endpoint_auth_methods_supported: ["none"],
+			client_id_metadata_document_supported: false,
+		});
+	});
+
+	it("builds protected resource metadata for /mcp", () => {
+		expect(createMcpProtectedResourceMetadata("https://codemem.example.test/mcp")).toEqual({
+			resource: "https://codemem.example.test/mcp",
+			authorization_servers: ["https://codemem.example.test/"],
+			bearer_methods_supported: ["header"],
+			resource_name: "codemem MCP",
+		});
+	});
+
+	it("normalizes and validates MCP public URLs", () => {
+		expect(normalizeMcpPublicUrl("https://codemem.example.test").href).toBe(
+			"https://codemem.example.test/mcp",
+		);
+		expect(normalizeMcpPublicUrl("http://127.0.0.1:38889/mcp").href).toBe(
+			"http://127.0.0.1:38889/mcp",
+		);
+		expect(normalizeMcpPublicUrl("http://[::1]:38889/mcp").href).toBe("http://[::1]:38889/mcp");
+		expect(() => normalizeMcpPublicUrl("http://codemem.example.test/mcp")).toThrow(/use HTTPS/);
+		expect(() => normalizeMcpPublicUrl("https://user:secret@codemem.example.test/mcp")).toThrow(
+			/credentials/,
+		);
+		expect(() => normalizeMcpPublicUrl("https://codemem.example.test/other")).toThrow(
+			/expected \/mcp path/,
+		);
+	});
+
+	it("registers public clients and stores them by client id", () => {
+		const clientsStore = createInMemoryOAuthClientsStore();
+
+		const result = registerMcpOAuthClient(
+			{
+				redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+				client_name: "Claude",
+				token_endpoint_auth_method: "none",
+			},
+			clientsStore,
+		);
+
+		expect(result.status).toBe(201);
+		if (result.status !== 201) throw new Error("expected successful registration");
+		expect(result.body.client_id).toMatch(/[0-9a-f-]{36}/);
+		expect(result.body.client_secret).toBeUndefined();
+		expect(result.body.token_endpoint_auth_method).toBe("none");
+		expect(result.body.grant_types).toEqual(["authorization_code"]);
+		expect(result.body.response_types).toEqual(["code"]);
+		expect(clientsStore.getClient(result.body.client_id)).toEqual(result.body);
+	});
+
+	it("accepts native loopback callback redirects", () => {
+		const result = registerMcpOAuthClient(
+			{
+				redirect_uris: ["http://localhost:42713/callback", "http://[::1]:42713/callback"],
+				token_endpoint_auth_method: "none",
+			},
+			createInMemoryOAuthClientsStore(),
+		);
+
+		expect(result.status).toBe(201);
+	});
+
+	it("rejects unsupported redirect URIs and confidential-client registration", () => {
+		const clientsStore = createInMemoryOAuthClientsStore();
+
+		expect(
+			registerMcpOAuthClient({ redirect_uris: ["https://evil.test/callback"] }, clientsStore),
+		).toMatchObject({ status: 400, body: { error: "invalid_client_metadata" } });
+
+		expect(
+			registerMcpOAuthClient(
+				{
+					redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+					token_endpoint_auth_method: "client_secret_post",
+				},
+				clientsStore,
+			),
+		).toMatchObject({ status: 400, body: { error: "invalid_client_metadata" } });
+
+		expect(
+			registerMcpOAuthClient(
+				{
+					redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+					grant_types: ["authorization_code", "refresh_token"],
+				},
+				clientsStore,
+			),
+		).toMatchObject({ status: 400, body: { error: "invalid_client_metadata" } });
+	});
+});

--- a/packages/mcp-server/src/oauth.ts
+++ b/packages/mcp-server/src/oauth.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from "node:crypto";
+import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import type { OAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import { createOAuthMetadata } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import {
+	type OAuthClientInformationFull,
+	type OAuthClientMetadata,
+	OAuthClientMetadataSchema,
+	type OAuthMetadata,
+	type OAuthProtectedResourceMetadata,
+	OAuthProtectedResourceMetadataSchema,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+
+export const MCP_OAUTH_PUBLIC_URL_ENV = "CODEMEM_MCP_HTTP_PUBLIC_URL";
+export const MCP_OAUTH_RESOURCE_NAME = "codemem MCP";
+
+const CLAUDE_HOSTED_CALLBACK = "https://claude.ai/api/mcp/auth_callback";
+const LOCAL_CALLBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+const SUPPORTED_GRANT_TYPES = new Set(["authorization_code"]);
+const SUPPORTED_RESPONSE_TYPES = new Set(["code"]);
+
+export interface McpOAuthMetadataOptions {
+	mcpUrl: string;
+	clientsStore: OAuthRegisteredClientsStore;
+}
+
+export interface RegisteredMcpOAuthClient {
+	status: 201;
+	body: OAuthClientInformationFull;
+}
+
+export interface McpOAuthRegistrationError {
+	status: 400;
+	body: { error: "invalid_client_metadata"; error_description: string };
+}
+
+export class InMemoryOAuthClientsStore implements OAuthRegisteredClientsStore {
+	readonly #clients = new Map<string, OAuthClientInformationFull>();
+
+	getClient(clientId: string): OAuthClientInformationFull | undefined {
+		return this.#clients.get(clientId);
+	}
+
+	registerClient(
+		client: Omit<OAuthClientInformationFull, "client_id" | "client_id_issued_at">,
+	): OAuthClientInformationFull {
+		if (this.#clients.size >= 100) {
+			const oldestClientId = this.#clients.keys().next().value;
+			if (oldestClientId) this.#clients.delete(oldestClientId);
+		}
+		const registered = {
+			...client,
+			client_id: randomUUID(),
+			client_id_issued_at: Math.floor(Date.now() / 1000),
+		};
+		this.#clients.set(registered.client_id, registered);
+		return registered;
+	}
+}
+
+export function createInMemoryOAuthClientsStore(): OAuthRegisteredClientsStore {
+	return new InMemoryOAuthClientsStore();
+}
+
+export function createMcpOAuthMetadata(options: McpOAuthMetadataOptions): OAuthMetadata {
+	const mcpUrl = normalizeMcpPublicUrl(options.mcpUrl);
+	const issuerUrl = getOriginUrl(mcpUrl);
+	const provider = createMetadataOnlyProvider(options.clientsStore);
+	return {
+		...createOAuthMetadata({
+			provider,
+			issuerUrl,
+			baseUrl: issuerUrl,
+		}),
+		// Phase 1 treats claude.ai and local callback clients as public clients.
+		// Do not issue or advertise client secrets until we have a concrete need.
+		grant_types_supported: ["authorization_code"],
+		token_endpoint_auth_methods_supported: ["none"],
+		client_id_metadata_document_supported: false,
+	};
+}
+
+export function createMcpProtectedResourceMetadata(mcpUrl: string): OAuthProtectedResourceMetadata {
+	const normalizedMcpUrl = normalizeMcpPublicUrl(mcpUrl);
+	const metadata = {
+		resource: normalizedMcpUrl.href,
+		authorization_servers: [getOriginUrl(normalizedMcpUrl).href],
+		bearer_methods_supported: ["header"],
+		resource_name: MCP_OAUTH_RESOURCE_NAME,
+	};
+	return OAuthProtectedResourceMetadataSchema.parse(metadata);
+}
+
+export function registerMcpOAuthClient(
+	requestBody: unknown,
+	clientsStore: OAuthRegisteredClientsStore,
+): RegisteredMcpOAuthClient | McpOAuthRegistrationError {
+	if (!clientsStore.registerClient) {
+		return invalidClientMetadata("Dynamic client registration is not enabled");
+	}
+
+	const parseResult = OAuthClientMetadataSchema.safeParse(requestBody);
+	if (!parseResult.success) {
+		return invalidClientMetadata(parseResult.error.message);
+	}
+
+	const clientMetadata = parseResult.data;
+	const redirectError = validateRedirectUris(clientMetadata.redirect_uris);
+	if (redirectError) return invalidClientMetadata(redirectError);
+
+	if (!isSupportedTokenEndpointAuthMethod(clientMetadata.token_endpoint_auth_method)) {
+		return invalidClientMetadata(
+			"Only public clients with token_endpoint_auth_method=none are supported",
+		);
+	}
+
+	if (
+		clientMetadata.grant_types &&
+		!isSupportedList(clientMetadata.grant_types, SUPPORTED_GRANT_TYPES)
+	) {
+		return invalidClientMetadata("Only authorization_code grant_type is supported in this slice");
+	}
+
+	if (
+		clientMetadata.response_types &&
+		!isSupportedList(clientMetadata.response_types, SUPPORTED_RESPONSE_TYPES)
+	) {
+		return invalidClientMetadata("Only code response_type is supported");
+	}
+
+	const registered = clientsStore.registerClient({
+		...clientMetadata,
+		token_endpoint_auth_method: "none",
+		grant_types: clientMetadata.grant_types ?? ["authorization_code"],
+		response_types: clientMetadata.response_types ?? ["code"],
+	});
+
+	if (registered instanceof Promise) {
+		throw new Error(
+			"Asynchronous OAuth client stores are not supported by this HTTP bootstrap yet",
+		);
+	}
+
+	return { status: 201, body: registered };
+}
+
+export function normalizeMcpPublicUrl(value: string): URL {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new Error("Invalid MCP HTTP public URL; expected an HTTPS /mcp URL");
+	}
+	if (url.protocol !== "https:" && !isLoopbackUrl(url)) {
+		throw new Error("Invalid MCP HTTP public URL; use HTTPS for non-loopback URLs");
+	}
+	if (url.username || url.password || url.search || url.hash) {
+		throw new Error(
+			"Invalid MCP HTTP public URL; credentials, query strings, and fragments are not allowed",
+		);
+	}
+	if (url.pathname === "/") url.pathname = "/mcp";
+	if (url.pathname !== "/mcp") {
+		throw new Error("Invalid MCP HTTP public URL; expected /mcp path");
+	}
+	return url;
+}
+
+function getOriginUrl(url: URL): URL {
+	return new URL(url.origin);
+}
+
+function validateRedirectUris(redirectUris: OAuthClientMetadata["redirect_uris"]): string | null {
+	for (const redirectUri of redirectUris) {
+		const url = new URL(redirectUri);
+		if (url.username || url.password || url.hash) return `Invalid redirect URI: ${redirectUri}`;
+		if (url.href === CLAUDE_HOSTED_CALLBACK) continue;
+		if (isLoopbackCallbackUrl(url)) continue;
+		return `Unsupported redirect URI: ${redirectUri}`;
+	}
+	return null;
+}
+
+function isSupportedTokenEndpointAuthMethod(method: string | undefined): boolean {
+	return method === undefined || method === "none";
+}
+
+function isSupportedList(values: string[], supported: Set<string>): boolean {
+	return values.length > 0 && values.every((value) => supported.has(value));
+}
+
+function isLoopbackCallbackUrl(url: URL): boolean {
+	return (
+		url.protocol === "http:" &&
+		LOCAL_CALLBACK_HOSTS.has(normalizeHostname(url.hostname)) &&
+		url.pathname === "/callback" &&
+		url.search === ""
+	);
+}
+
+function isLoopbackUrl(url: URL): boolean {
+	const hostname = normalizeHostname(url.hostname);
+	return url.protocol === "http:" && LOCAL_CALLBACK_HOSTS.has(hostname);
+}
+
+function normalizeHostname(hostname: string): string {
+	return hostname.replace(/^\[(.*)]$/, "$1").toLowerCase();
+}
+
+function invalidClientMetadata(description: string): McpOAuthRegistrationError {
+	return {
+		status: 400,
+		body: { error: "invalid_client_metadata", error_description: description },
+	};
+}
+
+function createMetadataOnlyProvider(
+	clientsStore: OAuthRegisteredClientsStore,
+): OAuthServerProvider {
+	return {
+		clientsStore,
+		async authorize() {
+			throw new Error("OAuth authorize is not implemented yet");
+		},
+		async challengeForAuthorizationCode() {
+			throw new Error("OAuth token exchange is not implemented yet");
+		},
+		async exchangeAuthorizationCode() {
+			throw new Error("OAuth token exchange is not implemented yet");
+		},
+		async exchangeRefreshToken() {
+			throw new Error("OAuth refresh is not implemented yet");
+		},
+		async verifyAccessToken() {
+			throw new Error("OAuth bearer verification is not implemented yet");
+		},
+	};
+}


### PR DESCRIPTION
## Description
Adds the Phase 1 remote MCP OAuth discovery slice: authorization-server metadata, protected-resource metadata, and Dynamic Client Registration for public clients. This keeps /authorize, /token, and /mcp bearer enforcement explicitly out of scope for this PR while documenting the temporary unauthenticated transport behavior.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run locally:
- `pnpm run tsc && pnpm run lint`
- `pnpm exec vitest run packages/mcp-server/src/oauth.test.ts packages/mcp-server/src/http.test.ts packages/cli/src/commands/mcp.test.ts`
- `pnpm run test`
- Snyk Code scan on `packages/mcp-server/src` (remaining HTTP finding is expected for the local raw HTTP transport)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
