### PR TITLE
feat(ui): add guided team setup callout

### DIFF
--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -21,6 +21,7 @@ import {
 	currentAdminTargetGroup,
 	setAdminTargetGroup,
 } from "../data/target-group";
+import { teamCardOverview } from "../data/team-card";
 import {
 	closeGroupScopeManagement,
 	openGroupScopeManagement,
@@ -285,6 +286,117 @@ function renderGroupPreferencesEditor(
 	);
 }
 
+function renderTeamSetupGuide(renderShell: () => void): ReturnType<typeof h> {
+	const guide = coordinatorAdminState.teamSetupGuide;
+	if (!guide) return null;
+	const title = guide.displayName || guide.groupId;
+	const warningStepById: Record<string, string> = {
+		default_space: "default Space setup",
+		default_space_grant: "default Space access grant",
+	};
+	const warningStep = warningStepById[guide.setupWarning?.step || ""] || "default Space setup";
+	return h(
+		"div",
+		{ class: "peer-meta coordinator-admin-empty-state" },
+		h("h4", { class: "coordinator-admin-drawer-title" }, `Set up ${title}`),
+		h(
+			"div",
+			{ class: "peer-submeta" },
+			"A Team organizes people and devices. The default Space is the memory boundary; Team membership only grants data access when default Space auto-grant is enabled.",
+		),
+		guide.setupWarning
+			? h(
+					"div",
+					{ class: "peer-meta coordinator-admin-inline-warning" },
+					`Team created, but ${warningStep} failed. Automatic repair is not available yet; use Spaces to inspect or create access manually before inviting teammates.`,
+				)
+			: h(
+					"div",
+					{ class: "peer-submeta" },
+					guide.defaultSpaceScopeId
+						? guide.defaultSpaceLabel
+							? `Default Space ready: ${guide.defaultSpaceLabel}. New devices can receive this Space when auto-grant is enabled.`
+							: "Default Space ready. New devices can receive this Space when auto-grant is enabled."
+						: "Default Space status is unknown. Check Spaces before inviting teammates.",
+				),
+		h(
+			"ol",
+			{ class: "peer-submeta" },
+			h("li", null, "Review Team defaults and the auto-grant default Space setting."),
+			h("li", null, "Invite teammates or other devices."),
+			h("li", null, "Assign projects to Spaces from the Projects tab."),
+		),
+		h(
+			"div",
+			{ class: "peer-actions" },
+			h(
+				"button",
+				{
+					class: "settings-button",
+					onClick: () => {
+						coordinatorAdminState.groupPreferencesOpen.add(guide.groupId);
+						void openGroupPreferences(guide.groupId, renderShell);
+					},
+					type: "button",
+				},
+				"Review Team defaults",
+			),
+			h(
+				"button",
+				{
+					class: "settings-button",
+					onClick: () => {
+						openGroupScopeManagement(guide.groupId, renderShell);
+					},
+					type: "button",
+				},
+				"Check Spaces",
+			),
+			h(
+				"button",
+				{
+					class: "settings-button",
+					onClick: () => {
+						coordinatorAdminState.inviteGroup = guide.groupId;
+						coordinatorAdminState.activeSection = "invites";
+						renderShell();
+					},
+					type: "button",
+				},
+				"Invite devices",
+			),
+			h(
+				"button",
+				{
+					class: "settings-button",
+					onClick: () => {
+						window.location.hash = "projects";
+					},
+					type: "button",
+				},
+				"Assign projects",
+			),
+			h(
+				"button",
+				{
+					class: "settings-button",
+					onClick: () => {
+						coordinatorAdminState.teamSetupGuide = null;
+						renderShell();
+					},
+					type: "button",
+				},
+				"Dismiss",
+			),
+		),
+	);
+}
+
+function archiveButtonLabel(archived: boolean, pending: boolean): string {
+	if (pending) return archived ? "Restoring…" : "Archiving…";
+	return archived ? "Unarchive" : "Archive";
+}
+
 export interface GroupsPanelDeps {
 	summary: CoordinatorAdminSummary;
 	createGroup: () => void;
@@ -331,6 +443,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 					`The selected Team (${selectedGroup}) is configured locally but does not exist in the coordinator yet. Create it below or switch to another Team once one exists.`,
 				)
 			: null,
+		renderTeamSetupGuide(renderShell),
 		h(
 			"div",
 			{ class: "coordinator-admin-form-grid" },
@@ -440,17 +553,49 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 							group.group_id;
 						const scopeOpen = coordinatorAdminState.groupPreferencesOpen.has(group.group_id);
 						const domainsOpen = coordinatorAdminState.groupScopeManagementOpen.has(group.group_id);
+						const archiveActionKind = archived ? "unarchive" : "archive";
+						const archivePending =
+							pending && coordinatorAdminState.groupActionPendingKind === archiveActionKind;
+						const archiveActionLabel = archiveButtonLabel(archived, archivePending);
+						const overview = teamCardOverview({
+							groupId: group.group_id,
+							preferences: coordinatorAdminState.groupPreferencesDrafts.get(group.group_id),
+							scopeManagement: coordinatorAdminState.groupScopeManagementDrafts.get(group.group_id),
+							setupGuide: coordinatorAdminState.teamSetupGuide,
+						});
 						return h(
 							"div",
 							{ class: "peer-card peer-card--padded", key: group.group_id },
 							h("div", { class: "peer-title" }, h("strong", null, draftName)),
 							h("div", { class: "peer-meta" }, `Team ID: ${group.group_id}`),
 							h("div", { class: "peer-submeta" }, archived ? "Archived" : "Active"),
+							h(
+								"div",
+								{ class: "coordinator-admin-summary-grid" },
+								h(
+									"div",
+									{ class: "coordinator-admin-summary-card" },
+									h("span", { class: "section-meta" }, "Default Space"),
+									h("strong", null, overview.defaultSpace),
+								),
+								h(
+									"div",
+									{ class: "coordinator-admin-summary-card" },
+									h("span", { class: "section-meta" }, "Auto-grant"),
+									h("strong", null, overview.autoGrant),
+								),
+								h(
+									"div",
+									{ class: "coordinator-admin-summary-card" },
+									h("span", { class: "section-meta" }, "Spaces"),
+									h("strong", null, overview.spaces),
+								),
+							),
 							configuredGroup === group.group_id
 								? h(
 										"div",
 										{ class: "peer-submeta" },
-										"This node is configured to use this Team for coordinator-backed discovery.",
+										"This node uses this Team for coordinator-backed discovery.",
 									)
 								: null,
 							h(
@@ -539,7 +684,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 										},
 										type: "button",
 									},
-									h("span", null, "Spaces"),
+									h("span", null, "Spaces & access"),
 									h(
 										"span",
 										{ "aria-hidden": "true", class: "device-row-chevron" },
@@ -555,19 +700,11 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 											runGroup(
 												group.group_id,
 												group.display_name || group.group_id,
-												archived ? "unarchive" : "archive",
+												archiveActionKind,
 											),
 										type: "button",
 									},
-									pending &&
-										coordinatorAdminState.groupActionPendingKind ===
-											(archived ? "unarchive" : "archive")
-										? archived
-											? "Restoring…"
-											: "Archiving…"
-										: archived
-											? "Unarchive"
-											: "Archive",
+									archiveActionLabel,
 								),
 							),
 							h(

--- a/packages/ui/src/tabs/coordinator-admin/components/invites-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/invites-panel.ts
@@ -38,7 +38,7 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 			"p",
 			{ class: "peer-submeta" },
 			summary.readiness === "ready"
-				? "Generate a coordinator-backed invite from the same operator surface that will later handle join requests and device administration."
+				? "Generate an invite for the selected Team. Default Space access is controlled by that Team's auto-grant setting."
 				: "Finish setup first. Invite creation stays disabled until the local coordinator admin configuration is ready.",
 		),
 		h(
@@ -47,7 +47,7 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 			h(
 				"label",
 				{ class: "coordinator-admin-field" },
-				h("span", null, "Group"),
+				h("span", null, "Team"),
 				h(TextInput, {
 					class: "peer-scope-input",
 					disabled: summary.readiness !== "ready",
@@ -55,6 +55,7 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 						coordinatorAdminState.inviteGroup = String(
 							(event.currentTarget as HTMLInputElement).value || "",
 						);
+						renderShell();
 					},
 					placeholder: activeGroup || "team-alpha",
 					type: "text",
@@ -77,8 +78,8 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 						renderShell();
 					},
 					options: [
-						{ value: "auto_admit", label: "Auto-admit" },
-						{ value: "approval_required", label: "Approval required" },
+						{ value: "auto_admit", label: "Auto-admit to Team" },
+						{ value: "approval_required", label: "Require approval to join Team" },
 					],
 					triggerClassName: "sync-radix-select-trigger sync-actor-select",
 					value: coordinatorAdminState.invitePolicy,
@@ -118,7 +119,7 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 				},
 				coordinatorAdminState.invitePending ? "Creating…" : "Create invite",
 			),
-			effectiveGroup ? h("span", { class: "peer-submeta" }, `Using group ${effectiveGroup}`) : null,
+			effectiveGroup ? h("span", { class: "peer-submeta" }, `Using Team ${effectiveGroup}`) : null,
 		),
 		output
 			? h(

--- a/packages/ui/src/tabs/coordinator-admin/data/actions.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/actions.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { state } from "../../../lib/state";
+import { createCoordinatorAdminActions } from "./actions";
+import { coordinatorAdminState } from "./state";
+
+const mocks = vi.hoisted(() => ({
+	createCoordinatorAdminGroup: vi.fn(),
+	reviewCoordinatorAdminJoinRequest: vi.fn(),
+	showGlobalNotice: vi.fn(),
+}));
+
+vi.mock("../../../lib/api", () => ({
+	createCoordinatorAdminGroup: mocks.createCoordinatorAdminGroup,
+	reviewCoordinatorAdminJoinRequest: mocks.reviewCoordinatorAdminJoinRequest,
+}));
+
+vi.mock("../../../lib/notice", () => ({
+	showGlobalNotice: mocks.showGlobalNotice,
+}));
+
+vi.mock("../../sync/sync-dialogs", () => ({
+	openSyncConfirmDialog: vi.fn(),
+}));
+
+describe("coordinator admin actions", () => {
+	beforeEach(() => {
+		mocks.createCoordinatorAdminGroup.mockReset();
+		mocks.reviewCoordinatorAdminJoinRequest.mockReset();
+		mocks.showGlobalNotice.mockReset();
+		state.coordinatorAdminTargetGroup = "";
+		state.lastCoordinatorAdminStatus = {
+			coordinator_url: "https://coordinator.example",
+			readiness: "ready",
+		};
+		coordinatorAdminState.createGroupId = "";
+		coordinatorAdminState.createGroupDisplayName = "";
+		coordinatorAdminState.groupActionPendingKind = "";
+		coordinatorAdminState.teamSetupGuide = null;
+		localStorage.clear();
+	});
+
+	it("opens the guided setup callout after creating a Team with a default Space", async () => {
+		mocks.createCoordinatorAdminGroup.mockResolvedValue({
+			group: { group_id: "team-alpha", display_name: "Team Alpha" },
+			default_space: {
+				scope: { scope_id: "team:team-alpha:default", label: "Team Alpha" },
+				membership: { device_id: "dev-a" },
+				preferences: { auto_grant_default_space_on_join: true },
+			},
+		});
+		coordinatorAdminState.createGroupId = "team-alpha";
+		coordinatorAdminState.createGroupDisplayName = "Team Alpha";
+		const reloadData = vi.fn().mockResolvedValue(undefined);
+		const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
+
+		await actions.createGroupFromAdminPanel();
+
+		expect(state.coordinatorAdminTargetGroup).toBe("team-alpha");
+		expect(coordinatorAdminState.teamSetupGuide).toEqual({
+			groupId: "team-alpha",
+			displayName: "Team Alpha",
+			defaultSpaceScopeId: "team:team-alpha:default",
+			defaultSpaceLabel: "Team Alpha",
+			autoGrantDefaultSpaceOnJoin: true,
+			setupWarning: null,
+		});
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+			"Team created with a default Space.",
+			"success",
+		);
+		expect(reloadData).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps setup warnings visible when default Space creation needs repair", async () => {
+		mocks.createCoordinatorAdminGroup.mockResolvedValue({
+			group: { group_id: "team-beta", display_name: "Team Beta" },
+			default_space: null,
+			setup_warning: { step: "default_space", error: "coordinator unavailable" },
+		});
+		coordinatorAdminState.createGroupId = "team-beta";
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await actions.createGroupFromAdminPanel();
+
+		expect(coordinatorAdminState.teamSetupGuide?.setupWarning).toEqual({
+			step: "default_space",
+			error: "coordinator unavailable",
+		});
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+			"Team created, but default Space setup needs repair.",
+			"warning",
+		);
+	});
+
+	it("selects the created Team after refreshing stale group data", async () => {
+		mocks.createCoordinatorAdminGroup.mockResolvedValue({
+			group: { group_id: "team-new", display_name: "Team New" },
+			default_space: {
+				scope: { scope_id: "team:team-new:default", label: "Team New" },
+				preferences: { auto_grant_default_space_on_join: true },
+			},
+		});
+		state.coordinatorAdminTargetGroup = "team-old";
+		coordinatorAdminState.createGroupId = "team-new";
+		const reloadData = vi
+			.fn()
+			.mockImplementationOnce(async () => {
+				state.coordinatorAdminTargetGroup = "team-old";
+			})
+			.mockResolvedValue(undefined);
+		const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
+
+		await actions.createGroupFromAdminPanel();
+
+		expect(reloadData).toHaveBeenCalledTimes(2);
+		expect(state.coordinatorAdminTargetGroup).toBe("team-new");
+	});
+
+	it("keeps default Space grant warnings visible after approving a join request", async () => {
+		mocks.reviewCoordinatorAdminJoinRequest.mockResolvedValue({
+			setup_warning: { step: "default_space_grant", error: "grant failed" },
+		});
+		const reloadData = vi.fn().mockResolvedValue(undefined);
+		const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
+
+		await actions.reviewJoinRequestFromAdminPanel("join-1", "approve");
+
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+			"Join request approved, but default Space access needs repair.",
+			"warning",
+		);
+		expect(reloadData).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/ui/src/tabs/coordinator-admin/data/actions.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/actions.ts
@@ -11,7 +11,7 @@ import { showGlobalNotice } from "../../../lib/notice";
 import { state } from "../../../lib/state";
 import { openSyncConfirmDialog } from "../../sync/sync-dialogs";
 import { coordinatorAdminState } from "./state";
-import { currentAdminTargetGroup } from "./target-group";
+import { currentAdminTargetGroup, setAdminTargetGroup } from "./target-group";
 
 export interface CoordinatorAdminActionDeps {
 	renderShell: () => void;
@@ -47,17 +47,61 @@ export function createCoordinatorAdminActions(
 			showGlobalNotice("Enter a Team id before creating a Team.", "warning");
 			return;
 		}
+		const requestedDisplayName = coordinatorAdminState.createGroupDisplayName.trim();
 		coordinatorAdminState.groupActionPendingKind = "create";
 		renderShell();
 		try {
-			await api.createCoordinatorAdminGroup({
+			const result = (await api.createCoordinatorAdminGroup({
 				group_id: groupId,
-				display_name: coordinatorAdminState.createGroupDisplayName.trim() || null,
-			});
+				display_name: requestedDisplayName || null,
+			})) as {
+				default_space?:
+					| {
+							scope?: { scope_id?: string; label?: string | null } | null;
+							preferences?: { auto_grant_default_space_on_join?: boolean } | null;
+					  }
+					| { scope_id?: string; label?: string | null }
+					| null;
+				group?: { group_id?: string; display_name?: string | null } | null;
+				setup_warning?: { step?: string; error?: string } | null;
+			};
+			const defaultSpaceContainer = result.default_space as
+				| { scope?: { scope_id?: string; label?: string | null } | null }
+				| { scope_id?: string; label?: string | null }
+				| null
+				| undefined;
+			const defaultSpace = ((defaultSpaceContainer && "scope" in defaultSpaceContainer
+				? defaultSpaceContainer.scope
+				: defaultSpaceContainer) ?? {}) as { scope_id?: string; label?: string | null };
+			const defaultSpacePreferences = (
+				defaultSpaceContainer && "preferences" in defaultSpaceContainer
+					? defaultSpaceContainer.preferences
+					: null
+			) as { auto_grant_default_space_on_join?: boolean } | null;
+			const defaultSpaceScopeId = String(defaultSpace?.scope_id || "");
 			coordinatorAdminState.createGroupId = "";
 			coordinatorAdminState.createGroupDisplayName = "";
-			showGlobalNotice("Team created.", "success");
+			coordinatorAdminState.teamSetupGuide = {
+				groupId,
+				displayName: String(result.group?.display_name || requestedDisplayName || groupId),
+				defaultSpaceScopeId,
+				defaultSpaceLabel: String(defaultSpace?.label || ""),
+				autoGrantDefaultSpaceOnJoin:
+					typeof defaultSpacePreferences?.auto_grant_default_space_on_join === "boolean"
+						? defaultSpacePreferences.auto_grant_default_space_on_join
+						: null,
+				setupWarning: result.setup_warning || null,
+			};
 			await reloadData();
+			setAdminTargetGroup(groupId);
+			await reloadData();
+			if (result.setup_warning) {
+				showGlobalNotice("Team created, but default Space setup needs repair.", "warning");
+			} else if (defaultSpaceScopeId) {
+				showGlobalNotice("Team created with a default Space.", "success");
+			} else {
+				showGlobalNotice("Team created, but default Space status is unknown.", "warning");
+			}
 		} catch (error) {
 			showGlobalNotice(
 				error instanceof Error ? error.message : "Failed to create Team.",

--- a/packages/ui/src/tabs/coordinator-admin/data/state.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/state.ts
@@ -44,6 +44,15 @@ export interface GroupScopeManagementDraft {
 	actionPendingKind: ScopeManagementActionKind;
 }
 
+export interface TeamSetupGuideState {
+	groupId: string;
+	displayName: string;
+	defaultSpaceScopeId: string;
+	defaultSpaceLabel: string;
+	autoGrantDefaultSpaceOnJoin: boolean | null;
+	setupWarning: { step?: string; error?: string } | null;
+}
+
 export interface CoordinatorAdminState {
 	activeSection: AdminSection;
 	inviteGroup: string;
@@ -65,6 +74,7 @@ export interface CoordinatorAdminState {
 	groupPreferencesDrafts: Map<string, GroupPreferencesDraft>;
 	groupScopeManagementOpen: Set<string>;
 	groupScopeManagementDrafts: Map<string, GroupScopeManagementDraft>;
+	teamSetupGuide: TeamSetupGuideState | null;
 	/**
 	 * Cached list of project names from /api/projects so the scope-defaults
 	 * ProjectScopePicker can render them as clickable chips without
@@ -96,5 +106,6 @@ export const coordinatorAdminState: CoordinatorAdminState = {
 	groupPreferencesDrafts: new Map<string, GroupPreferencesDraft>(),
 	groupScopeManagementOpen: new Set<string>(),
 	groupScopeManagementDrafts: new Map<string, GroupScopeManagementDraft>(),
+	teamSetupGuide: null,
 	availableProjects: [],
 };

--- a/packages/ui/src/tabs/coordinator-admin/data/team-card.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/team-card.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { teamCardOverview } from "./team-card";
+
+describe("coordinator admin Team card helpers", () => {
+	it("summarizes a newly created default Space without exposing raw IDs", () => {
+		expect(
+			teamCardOverview({
+				groupId: "team-alpha",
+				setupGuide: {
+					groupId: "team-alpha",
+					displayName: "Team Alpha",
+					defaultSpaceScopeId: "team:team-alpha:default",
+					defaultSpaceLabel: "Team Alpha",
+					autoGrantDefaultSpaceOnJoin: true,
+					setupWarning: null,
+				},
+			}),
+		).toMatchObject({
+			autoGrant: "On for the default Space",
+			defaultSpace: "Team Alpha",
+		});
+	});
+
+	it("ignores setup guide state for a different Team", () => {
+		expect(
+			teamCardOverview({
+				groupId: "team-beta",
+				setupGuide: {
+					groupId: "team-alpha",
+					displayName: "Team Alpha",
+					defaultSpaceScopeId: "team:team-alpha:default",
+					defaultSpaceLabel: "Team Alpha",
+					autoGrantDefaultSpaceOnJoin: true,
+					setupWarning: null,
+				},
+			}),
+		).toMatchObject({
+			autoGrant: "Open Team defaults to inspect",
+			defaultSpace: "Open Team defaults to inspect",
+		});
+	});
+
+	it("shows conservative migrated Team defaults when preferences are loaded", () => {
+		expect(
+			teamCardOverview({
+				groupId: "team-beta",
+				preferences: {
+					projects_include: [],
+					projects_exclude: [],
+					auto_seed_scope: true,
+					default_space_scope_id: "",
+					auto_grant_default_space_on_join: false,
+					loaded: true,
+					saving: false,
+					error: "",
+				},
+			}),
+		).toMatchObject({
+			autoGrant: "Off — Space access stays explicit",
+			defaultSpace: "Not configured",
+		});
+	});
+
+	it("trusts loaded preferences over stale setup guide state", () => {
+		expect(
+			teamCardOverview({
+				groupId: "team-alpha",
+				preferences: {
+					projects_include: [],
+					projects_exclude: [],
+					auto_seed_scope: true,
+					default_space_scope_id: "",
+					auto_grant_default_space_on_join: false,
+					loaded: true,
+					saving: false,
+					error: "",
+				},
+				setupGuide: {
+					groupId: "team-alpha",
+					displayName: "Team Alpha",
+					defaultSpaceScopeId: "team:team-alpha:default",
+					defaultSpaceLabel: "Team Alpha",
+					autoGrantDefaultSpaceOnJoin: true,
+					setupWarning: null,
+				},
+			}),
+		).toMatchObject({
+			autoGrant: "Off — Space access stays explicit",
+			defaultSpace: "Not configured",
+		});
+	});
+
+	it("counts active Spaces when the Spaces drawer has loaded", () => {
+		expect(
+			teamCardOverview({
+				groupId: "team-gamma",
+				scopeManagement: {
+					loaded: true,
+					loading: false,
+					error: "",
+					includeInactive: false,
+					devicesLoaded: false,
+					scopes: [{ status: "active" }, { status: "archived" }, {}],
+					membersByScope: new Map(),
+					devices: [],
+					createScopeId: "",
+					createLabel: "",
+					createKind: "",
+					actionPendingKey: "",
+					actionPendingKind: "",
+				},
+			}),
+		).toMatchObject({ spaces: "2 active Spaces" });
+	});
+});

--- a/packages/ui/src/tabs/coordinator-admin/data/team-card.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/team-card.ts
@@ -1,0 +1,70 @@
+import type {
+	GroupPreferencesDraft,
+	GroupScopeManagementDraft,
+	TeamSetupGuideState,
+} from "./state";
+
+export interface TeamCardOverview {
+	defaultSpace: string;
+	autoGrant: string;
+	spaces: string;
+}
+
+function matchingSetupGuide(
+	groupId: string,
+	setupGuide: TeamSetupGuideState | null | undefined,
+): TeamSetupGuideState | null {
+	if (!setupGuide) return null;
+	return setupGuide.groupId === groupId ? setupGuide : null;
+}
+
+function defaultSpaceSummary(
+	preferences: GroupPreferencesDraft | undefined,
+	setupGuide: TeamSetupGuideState | null,
+): string {
+	if (preferences?.loaded && preferences.default_space_scope_id) return "Configured";
+	if (preferences?.loaded) return "Not configured";
+	if (setupGuide?.defaultSpaceLabel) return setupGuide.defaultSpaceLabel;
+	if (setupGuide?.defaultSpaceScopeId) return "Configured";
+	return "Open Team defaults to inspect";
+}
+
+function autoGrantSummary(
+	preferences: GroupPreferencesDraft | undefined,
+	setupGuide: TeamSetupGuideState | null,
+): string {
+	if (preferences?.loaded) {
+		return preferences.auto_grant_default_space_on_join
+			? "On for the default Space"
+			: "Off — Space access stays explicit";
+	}
+	if (setupGuide?.autoGrantDefaultSpaceOnJoin === true) return "On for the default Space";
+	if (setupGuide?.autoGrantDefaultSpaceOnJoin === false) return "Off — Space access stays explicit";
+	return "Open Team defaults to inspect";
+}
+
+function activeSpaceCount(scopeManagement: GroupScopeManagementDraft | undefined): number | null {
+	if (!scopeManagement?.loaded) return null;
+	return scopeManagement.scopes.filter((scope) => String(scope.status || "active") === "active")
+		.length;
+}
+
+function spacesSummary(scopeManagement: GroupScopeManagementDraft | undefined): string {
+	const count = activeSpaceCount(scopeManagement);
+	if (count === null) return "Open Spaces to inspect access grants";
+	return `${count} active ${count === 1 ? "Space" : "Spaces"}`;
+}
+
+export function teamCardOverview(opts: {
+	groupId: string;
+	preferences?: GroupPreferencesDraft;
+	scopeManagement?: GroupScopeManagementDraft;
+	setupGuide?: TeamSetupGuideState | null;
+}): TeamCardOverview {
+	const setupGuide = matchingSetupGuide(opts.groupId, opts.setupGuide);
+	return {
+		autoGrant: autoGrantSummary(opts.preferences, setupGuide),
+		defaultSpace: defaultSpaceSummary(opts.preferences, setupGuide),
+		spaces: spacesSummary(opts.scopeManagement),
+	};
+}

--- a/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
+++ b/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
@@ -65,7 +65,7 @@ function renderShell() {
 		summary.readiness !== "ready"
 			? summary.detail
 			: targetArchived
-				? "The selected admin target group is archived. Restore it or switch groups before creating invites."
+				? "The selected Team is archived. Restore it or switch Teams before creating invites."
 				: "";
 	if (
 		(coordinatorAdminState.activeSection === "invites" && !invitesEnabled) ||
@@ -83,26 +83,26 @@ function renderShell() {
 			h(
 				"div",
 				{ class: "card coordinator-admin-header" },
-				h("div", { class: "section-header" }, h("h2", null, "Coordinator Admin")),
+				h("div", { class: "section-header" }, h("h2", null, "Teams")),
 				h(
 					"div",
 					{ class: "coordinator-admin-summary-grid" },
 					h(
 						"div",
 						{ class: "coordinator-admin-summary-card" },
-						h("span", { class: "section-meta" }, "Admin target"),
+						h("span", { class: "section-meta" }, "Team admin target"),
 						h("strong", null, targetGroup || "None selected"),
 					),
 					h(
 						"div",
 						{ class: "coordinator-admin-summary-card" },
-						h("span", { class: "section-meta" }, "Node discovery group"),
+						h("span", { class: "section-meta" }, "Node discovery Team"),
 						h("strong", null, activeGroup || "None"),
 					),
 					h(
 						"div",
 						{ class: "coordinator-admin-summary-card" },
-						h("span", { class: "section-meta" }, "Groups"),
+						h("span", { class: "section-meta" }, "Teams"),
 						h(
 							"strong",
 							null,
@@ -112,7 +112,7 @@ function renderShell() {
 					h(
 						"div",
 						{ class: "coordinator-admin-summary-card" },
-						h("span", { class: "section-meta" }, "Selected group activity"),
+						h("span", { class: "section-meta" }, "Selected Team activity"),
 						h("strong", null, `${joinRequestCount} join requests · ${deviceCount} devices`),
 					),
 				),
@@ -140,7 +140,7 @@ function renderShell() {
 							renderShell();
 						},
 						tabs: [
-							{ value: "groups", label: "Groups", disabled: !groupsEnabled },
+							{ value: "groups", label: "Teams", disabled: !groupsEnabled },
 							{ value: "invites", label: "Invites", disabled: !invitesEnabled },
 							{ value: "join-requests", label: "Join requests", disabled: !joinRequestsEnabled },
 							{ value: "devices", label: "Devices", disabled: !devicesEnabled },
@@ -176,10 +176,10 @@ function renderShell() {
 					"div",
 					{ class: "section-meta coordinator-admin-context-line" },
 					targetArchived
-						? `Selected group ${targetGroup || "—"} is archived. Switch or restore it to enable invite operations.`
+						? `Selected Team ${targetGroup || "—"} is archived. Switch or restore it to enable invite operations.`
 						: targetGroup
 							? `Actions below apply to ${targetGroup}.`
-							: "Select a group to start managing coordinator state.",
+							: "Select a Team to start managing people, Spaces, and access.",
 				),
 			),
 		),

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -9132,6 +9132,142 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("does not auto-grant a stale non-default Space preference on join approval", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/join-requests/approve")) {
+					return new Response(
+						JSON.stringify({
+							request: {
+								request_id: "req-1",
+								status: "approved",
+								group_id: "team-a",
+								device_id: "dev-b",
+							},
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "team-a",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				const { app, cleanup } = createTestApp();
+				try {
+					const saved = await app.request("/api/coordinator/admin/groups/team-a/preferences", {
+						method: "PUT",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({
+							default_space_scope_id: "scope-private",
+							auto_grant_default_space_on_join: true,
+						}),
+					});
+					expect(saved.status).toBe(200);
+
+					const res = await app.request("/api/coordinator/admin/join-requests/req-1/approve", {
+						method: "POST",
+					});
+
+					expect(res.status).toBe(200);
+					expect(await res.json()).toMatchObject({
+						default_space_membership: null,
+						setup_warning: null,
+					});
+					expect(fetchMock).toHaveBeenCalledTimes(1);
+				} finally {
+					cleanup();
+				}
+			} finally {
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
+			}
+		});
+
+		it("does not auto-grant when the canonical default Space is missing or wrong kind", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/join-requests/approve")) {
+					return new Response(
+						JSON.stringify({
+							request: {
+								request_id: "req-1",
+								status: "approved",
+								group_id: "team-a",
+								device_id: "dev-b",
+							},
+						}),
+						{ status: 200 },
+					);
+				}
+				if (url.includes("/v1/admin/groups/team-a/scopes")) {
+					return new Response(
+						JSON.stringify({
+							items: [{ scope_id: "team:team-a:default", kind: "project", status: "active" }],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "team-a",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				const { app, cleanup } = createTestApp();
+				try {
+					const saved = await app.request("/api/coordinator/admin/groups/team-a/preferences", {
+						method: "PUT",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({
+							default_space_scope_id: "team:team-a:default",
+							auto_grant_default_space_on_join: true,
+						}),
+					});
+					expect(saved.status).toBe(200);
+
+					const res = await app.request("/api/coordinator/admin/join-requests/req-1/approve", {
+						method: "POST",
+					});
+
+					expect(res.status).toBe(200);
+					expect(await res.json()).toMatchObject({
+						default_space_membership: null,
+						setup_warning: null,
+					});
+					expect(fetchMock).toHaveBeenCalledTimes(2);
+				} finally {
+					cleanup();
+				}
+			} finally {
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
+			}
+		});
+
 		it("lists coordinator devices through the admin route", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -310,6 +310,15 @@ async function maybeGrantDefaultSpaceOnJoin(opts: {
 	if (!preferences?.auto_grant_default_space_on_join) return null;
 	const scopeId = preferences.default_space_scope_id?.trim();
 	if (!scopeId) return null;
+	if (scopeId !== defaultSpaceScopeIdForGroup(opts.groupId)) return null;
+	const scopes = await coordinatorListScopesAction({
+		groupId: opts.groupId,
+		includeInactive: false,
+		remoteUrl: opts.config.syncCoordinatorUrl || null,
+		adminSecret: opts.config.syncCoordinatorAdminSecret || null,
+	});
+	const defaultScope = scopes.find((scope) => scope.scope_id === scopeId) ?? null;
+	if (!defaultScope || defaultScope.kind !== "team_default") return null;
 	return await coordinatorGrantScopeMembershipAction({
 		groupId: opts.groupId,
 		scopeId,


### PR DESCRIPTION
## Description
Adds a lightweight guided setup callout after creating a Team from Coordinator Admin. The callout preserves the Team/Space model, shows default Space setup status or partial setup warnings, and links users to Team defaults, Spaces, invites, and Projects for next steps.

Also tightens the follow-up flow from review feedback:

- selects the newly created Team after refreshing stale group data;
- avoids implying auto-grant is on unless the API/preferences say so;
- avoids raw Space IDs in primary setup copy;
- validates join auto-grant only applies to the canonical active `team_default` Space.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run:

- `pnpm exec vitest run packages/ui/src/tabs/coordinator-admin/data/actions.test.ts packages/ui/src/tabs/coordinator-admin/data/team-card.test.ts packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts`
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern 'reviews coordinator join requests|stale non-default Space preference|canonical default Space is missing|local coordinator group preferences'`
- `pnpm exec tsc --build packages/ui/tsconfig.json packages/viewer-server/tsconfig.json --pretty false`
- `pnpm exec biome check packages/ui/src/tabs/coordinator-admin/lifecycle.ts packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts packages/ui/src/tabs/coordinator-admin/components/invites-panel.ts packages/ui/src/tabs/coordinator-admin/data/actions.ts packages/ui/src/tabs/coordinator-admin/data/actions.test.ts packages/ui/src/tabs/coordinator-admin/data/state.ts packages/ui/src/tabs/coordinator-admin/data/team-card.ts packages/ui/src/tabs/coordinator-admin/data/team-card.test.ts packages/viewer-server/src/routes/sync.ts packages/viewer-server/src/index.test.ts`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced