### PR TITLE
feat(mcp): gate OAuth codes with OIDC identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This updates your OpenCode config to install the plugin and register the MCP ser
 
 The standalone `codemem-mcp-ts` binary runs the same stdio server used by `codemem mcp`. Viewer autostart is on by default for both invocation paths; set `CODEMEM_VIEWER=0` or `CODEMEM_VIEWER_AUTO=0` to disable.
 
-For local HTTP transport testing, run `codemem mcp http`. It listens on `127.0.0.1:38889` by default and exposes Streamable HTTP at `POST /mcp`; use `--host`, `--port`, and `--db-path` to override those values. OAuth discovery metadata and Dynamic Client Registration are available at `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource/mcp`, and `/register`; set `--public-url` or `CODEMEM_MCP_HTTP_PUBLIC_URL` to the externally reachable `/mcp` URL so advertised endpoints use the public origin. `/authorize` and `/token` support public-client authorization-code flow with PKCE S256; upstream identity allowlisting and `/mcp` bearer enforcement land in later slices. Non-loopback binds are rejected unless you explicitly pass `--unsafe-public` or set `CODEMEM_MCP_HTTP_UNSAFE_PUBLIC=1`; `/mcp` remains unauthenticated until the OAuth bearer-enforcement slice lands, still applies loopback Host/Origin checks, and should not be exposed directly to untrusted networks.
+For local HTTP transport testing, run `codemem mcp http`. It listens on `127.0.0.1:38889` by default and exposes Streamable HTTP at `POST /mcp`; use `--host`, `--port`, and `--db-path` to override those values. OAuth discovery metadata and Dynamic Client Registration are available at `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource/mcp`, and `/register`; set `--public-url` or `CODEMEM_MCP_HTTP_PUBLIC_URL` to the externally reachable `/mcp` URL so advertised endpoints use the public origin. `/authorize` redirects through a configured upstream OIDC provider before issuing public-client authorization codes, and `/token` supports PKCE S256 exchange. `/mcp` bearer enforcement lands in a later slice, so do not expose this transport as protected until that is enabled. Non-loopback binds are rejected unless you explicitly pass `--unsafe-public` or set `CODEMEM_MCP_HTTP_UNSAFE_PUBLIC=1`; `/mcp` remains unauthenticated until the OAuth bearer-enforcement slice lands, still applies loopback Host/Origin checks, and should not be exposed directly to untrusted networks.
 
 ## Configuration
 
@@ -179,6 +179,8 @@ Common overrides:
 | `CODEMEM_VIEWER_AUTO` | `0` to disable auto-starting the viewer |
 | `CODEMEM_MCP_HTTP_HOST`, `CODEMEM_MCP_HTTP_PORT` | Host/port for `codemem mcp http` |
 | `CODEMEM_MCP_HTTP_PUBLIC_URL` | Public `/mcp` URL advertised in MCP OAuth metadata |
+| `CODEMEM_MCP_OIDC_ISSUER_URL`, `CODEMEM_MCP_OIDC_CLIENT_ID`, `CODEMEM_MCP_OIDC_CLIENT_SECRET` | Upstream OIDC provider used before MCP OAuth code issuance |
+| `CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT`, `CODEMEM_MCP_OAUTH_ALLOWED_EMAIL` | Single-user allowlist for upstream OIDC identity; at least one is required when OIDC is configured |
 | `CODEMEM_MCP_HTTP_UNSAFE_PUBLIC` | `1`, `true`, or `yes` to allow non-loopback MCP HTTP binds |
 
 Viewer note:

--- a/packages/mcp-server/src/http.test.ts
+++ b/packages/mcp-server/src/http.test.ts
@@ -232,7 +232,7 @@ describe("MCP HTTP transport", () => {
 		expect(await response.json()).toMatchObject({ error: "invalid_client_metadata" });
 	});
 
-	it("runs OAuth authorize and token exchange with PKCE", async () => {
+	it("fails closed at authorize when OIDC is not configured", async () => {
 		const server = await startCodememMcpHttpServer({
 			dbPath: tempDbPath(),
 			port: 0,
@@ -240,7 +240,6 @@ describe("MCP HTTP transport", () => {
 		});
 		servers.push(server);
 		const baseUrl = server.url.replace("/mcp", "");
-		const verifier = "d".repeat(43);
 
 		const registration = await fetch(`${baseUrl}/register`, {
 			method: "POST",
@@ -256,28 +255,13 @@ describe("MCP HTTP transport", () => {
 		authorizeUrl.searchParams.set("redirect_uri", "https://claude.ai/api/mcp/auth_callback");
 		authorizeUrl.searchParams.set("response_type", "code");
 		authorizeUrl.searchParams.set("code_challenge_method", "S256");
-		authorizeUrl.searchParams.set("code_challenge", pkceS256(verifier));
+		authorizeUrl.searchParams.set("code_challenge", pkceS256("d".repeat(43)));
 		authorizeUrl.searchParams.set("state", "state-123");
 
-		const authorize = await fetch(authorizeUrl, { redirect: "manual" });
-		const redirect = new URL(authorize.headers.get("location") ?? "");
-		const token = await fetch(`${baseUrl}/token`, {
-			method: "POST",
-			headers: { "content-type": "application/x-www-form-urlencoded" },
-			body: new URLSearchParams({
-				grant_type: "authorization_code",
-				client_id: client.client_id,
-				redirect_uri: "https://claude.ai/api/mcp/auth_callback",
-				code: redirect.searchParams.get("code") ?? "",
-				code_verifier: verifier,
-			}),
-		});
+		const authorize = await fetch(authorizeUrl);
 
-		expect(authorize.status).toBe(302);
-		expect(redirect.origin + redirect.pathname).toBe("https://claude.ai/api/mcp/auth_callback");
-		expect(redirect.searchParams.get("state")).toBe("state-123");
-		expect(token.status).toBe(200);
-		expect(await token.json()).toMatchObject({ token_type: "Bearer", expires_in: 3600 });
+		expect(authorize.status).toBe(400);
+		expect(await authorize.json()).toMatchObject({ error: "temporarily_unavailable" });
 	});
 
 	it("handles repeated MCP initialize requests over POST", async () => {

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -25,6 +25,12 @@ import {
 	normalizeMcpPublicUrl,
 	registerMcpOAuthClient,
 } from "./oauth.js";
+import {
+	beginOidcAuthorization,
+	completeOidcAuthorization,
+	createInMemoryOidcPendingAuthorizationStore,
+	resolveOidcConfig,
+} from "./oidc.js";
 import { createCodememMcpServer } from "./server.js";
 
 export const DEFAULT_MCP_HTTP_HOST = "127.0.0.1";
@@ -171,6 +177,8 @@ export async function startCodememMcpHttpServer(
 	const store = new MemoryStore(options.dbPath ?? resolveDbPath());
 	const clientsStore = createInMemoryOAuthClientsStore();
 	const codeStore = createInMemoryOAuthAuthorizationCodeStore();
+	const oidcConfig = resolveOidcConfig();
+	const oidcPendingStore = createInMemoryOidcPendingAuthorizationStore();
 	const activeRequests = new Set<ActiveRequest>();
 	let closePromise: Promise<void> | null = null;
 
@@ -214,7 +222,45 @@ export async function startCodememMcpHttpServer(
 				if (!prepareOAuthRoute(req, res, ["GET", "OPTIONS"], boundPort, configuredPublicMcpUrl))
 					return;
 				const url = new URL(req.url ?? "/authorize", "http://codemem.local");
-				const result = authorizeMcpOAuthClient(url.searchParams, clientsStore, codeStore);
+				const result = await beginOidcAuthorization(
+					url.searchParams,
+					clientsStore,
+					oidcPendingStore,
+					oidcConfig,
+					publicMcpUrl,
+				);
+				if (result.status === 302) {
+					res.statusCode = result.status;
+					res.setHeader("location", result.location);
+					res.end();
+					return;
+				}
+				writeJson(res, result.status, result.body);
+				return;
+			}
+
+			if (pathname === "/oauth/callback") {
+				if (!prepareOAuthRoute(req, res, ["GET", "OPTIONS"], boundPort, configuredPublicMcpUrl))
+					return;
+				if (!oidcConfig) {
+					writeJson(res, 400, {
+						error: "temporarily_unavailable",
+						error_description: "OIDC is not configured",
+					});
+					return;
+				}
+				const url = new URL(req.url ?? "/oauth/callback", "http://codemem.local");
+				const completed = await completeOidcAuthorization(
+					url.searchParams,
+					oidcPendingStore,
+					oidcConfig,
+					publicMcpUrl,
+				);
+				if ("status" in completed) {
+					writeJson(res, completed.status, completed.body);
+					return;
+				}
+				const result = authorizeMcpOAuthClient(completed.oauthParams, clientsStore, codeStore);
 				if (result.status === 302) {
 					res.statusCode = result.status;
 					res.setHeader("location", result.location);

--- a/packages/mcp-server/src/oauth.ts
+++ b/packages/mcp-server/src/oauth.ts
@@ -70,6 +70,13 @@ export interface McpOAuthTokenResult {
 	body: OAuthTokens;
 }
 
+export interface PreparedMcpOAuthAuthorizationRequest {
+	clientId: string;
+	redirectUri: string;
+	codeChallenge: string;
+	state: string | null;
+}
+
 export class InMemoryOAuthClientsStore implements OAuthRegisteredClientsStore {
 	readonly #clients = new Map<string, OAuthClientInformationFull>();
 
@@ -215,6 +222,30 @@ export function authorizeMcpOAuthClient(
 	codeStore: OAuthAuthorizationCodeStore,
 	now = Date.now(),
 ): McpOAuthRedirectResult | McpOAuthErrorResult {
+	const prepared = prepareMcpOAuthAuthorizationRequest(params, clientsStore);
+	if ("status" in prepared) return prepared;
+
+	const code = codeStore.issueCode(
+		{
+			clientId: prepared.clientId,
+			redirectUri: prepared.redirectUri,
+			codeChallenge: prepared.codeChallenge,
+			expiresAt: now + AUTHORIZATION_CODE_TTL_MS,
+		},
+		now,
+	);
+	if (!code)
+		return invalidOAuthRequest("temporarily_unavailable", "Too many active authorization codes");
+	const redirect = new URL(prepared.redirectUri);
+	redirect.searchParams.set("code", code);
+	if (prepared.state !== null) redirect.searchParams.set("state", prepared.state);
+	return { status: 302, location: redirect.href };
+}
+
+export function prepareMcpOAuthAuthorizationRequest(
+	params: URLSearchParams,
+	clientsStore: OAuthRegisteredClientsStore,
+): PreparedMcpOAuthAuthorizationRequest | McpOAuthErrorResult {
 	const clientId = params.get("client_id") ?? "";
 	const redirectUri = params.get("redirect_uri") ?? "";
 	const responseType = params.get("response_type") ?? "";
@@ -236,21 +267,7 @@ export function authorizeMcpOAuthClient(
 		return invalidOAuthRequest("invalid_request", "redirect_uri is not registered for this client");
 	}
 
-	const code = codeStore.issueCode(
-		{
-			clientId,
-			redirectUri,
-			codeChallenge,
-			expiresAt: now + AUTHORIZATION_CODE_TTL_MS,
-		},
-		now,
-	);
-	if (!code)
-		return invalidOAuthRequest("temporarily_unavailable", "Too many active authorization codes");
-	const redirect = new URL(redirectUri);
-	redirect.searchParams.set("code", code);
-	if (state !== null) redirect.searchParams.set("state", state);
-	return { status: 302, location: redirect.href };
+	return { clientId, redirectUri, codeChallenge, state };
 }
 
 export function exchangeMcpOAuthAuthorizationCode(

--- a/packages/mcp-server/src/oidc.test.ts
+++ b/packages/mcp-server/src/oidc.test.ts
@@ -1,0 +1,619 @@
+import { generateKeyPairSync, type KeyObject, sign } from "node:crypto";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createInMemoryOAuthClientsStore, registerMcpOAuthClient } from "./oauth.js";
+import {
+	beginOidcAuthorization,
+	completeOidcAuthorization,
+	createInMemoryOidcPendingAuthorizationStore,
+	type OidcConfig,
+	resolveOidcConfig,
+} from "./oidc.js";
+
+const servers: { close: () => Promise<void> }[] = [];
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(servers.splice(0).map((server) => server.close()));
+});
+
+describe("OIDC-backed MCP OAuth authorization", () => {
+	it("resolves explicit OIDC configuration and requires an allowlist", () => {
+		expect(resolveOidcConfig({})).toBeUndefined();
+		expect(() =>
+			resolveOidcConfig({
+				CODEMEM_MCP_OIDC_ISSUER_URL: "http://accounts.example.test/",
+				CODEMEM_MCP_OIDC_CLIENT_ID: "client",
+				CODEMEM_MCP_OIDC_CLIENT_SECRET: "secret",
+				CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT: "owner-sub",
+			}),
+		).toThrow(/HTTPS/);
+		expect(() =>
+			resolveOidcConfig({
+				CODEMEM_MCP_OIDC_ISSUER_URL: "https://user:pass@accounts.example.test/",
+				CODEMEM_MCP_OIDC_CLIENT_ID: "client",
+				CODEMEM_MCP_OIDC_CLIENT_SECRET: "secret",
+				CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT: "owner-sub",
+			}),
+		).toThrow(/credentials/);
+		expect(() =>
+			resolveOidcConfig({
+				CODEMEM_MCP_OIDC_ISSUER_URL: "https://accounts.example.test/",
+				CODEMEM_MCP_OIDC_CLIENT_ID: "client",
+				CODEMEM_MCP_OIDC_CLIENT_SECRET: "secret",
+			}),
+		).toThrow(/requires/);
+		expect(
+			resolveOidcConfig({
+				CODEMEM_MCP_OIDC_ISSUER_URL: "https://accounts.example.test/",
+				CODEMEM_MCP_OIDC_CLIENT_ID: "client",
+				CODEMEM_MCP_OIDC_CLIENT_SECRET: "secret",
+				CODEMEM_MCP_OAUTH_ALLOWED_EMAIL: "ME@EXAMPLE.TEST",
+			}),
+		).toMatchObject({ allowedEmail: "me@example.test" });
+	});
+
+	it("preserves path-based issuer URLs during discovery", async () => {
+		const oidc = await startFakeOidc(
+			{ sub: "owner-sub", email: "owner@example.test" },
+			"/realms/test",
+		);
+		servers.push(oidc);
+		const config: OidcConfig = {
+			issuerUrl: oidc.issuer,
+			clientId: "codemem-client",
+			clientSecret: "secret",
+			allowedSubject: "owner-sub",
+		};
+		const clientsStore = createInMemoryOAuthClientsStore();
+		const pendingStore = createInMemoryOidcPendingAuthorizationStore();
+		const registered = registerMcpOAuthClient(
+			{ redirect_uris: ["https://claude.ai/api/mcp/auth_callback"] },
+			clientsStore,
+		);
+		if (registered.status !== 201) throw new Error("expected client registration");
+
+		const begin = await beginOidcAuthorization(
+			new URLSearchParams({
+				client_id: registered.body.client_id,
+				redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+				response_type: "code",
+				code_challenge_method: "S256",
+				code_challenge: "a".repeat(43),
+			}),
+			clientsStore,
+			pendingStore,
+			config,
+			"http://127.0.0.1:38889/mcp",
+		);
+
+		expect(begin.status).toBe(302);
+		expect(oidc.requests).toContain("/realms/test/.well-known/openid-configuration");
+	});
+
+	it("rejects non-HTTPS discovered endpoints outside loopback", async () => {
+		const oidc = await startFakeOidc({ sub: "owner-sub", email: "owner@example.test" }, "", {
+			authorizationEndpoint: "http://evil.example.test/authorize",
+		});
+		servers.push(oidc);
+		const config: OidcConfig = {
+			issuerUrl: oidc.issuer,
+			clientId: "codemem-client",
+			clientSecret: "secret",
+			allowedSubject: "owner-sub",
+		};
+		const clientsStore = createInMemoryOAuthClientsStore();
+		const pendingStore = createInMemoryOidcPendingAuthorizationStore();
+		const registered = registerMcpOAuthClient(
+			{ redirect_uris: ["https://claude.ai/api/mcp/auth_callback"] },
+			clientsStore,
+		);
+		if (registered.status !== 201) throw new Error("expected client registration");
+
+		await expect(
+			beginOidcAuthorization(
+				new URLSearchParams({
+					client_id: registered.body.client_id,
+					redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+					response_type: "code",
+					code_challenge_method: "S256",
+					code_challenge: "a".repeat(43),
+				}),
+				clientsStore,
+				pendingStore,
+				config,
+				"http://127.0.0.1:38889/mcp",
+			),
+		).rejects.toThrow(/HTTPS/);
+	});
+
+	it("rejects discovered loopback HTTP endpoints for HTTPS issuers", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					issuer: "https://accounts.example.test/",
+					authorization_endpoint: "https://accounts.example.test/authorize",
+					token_endpoint: "https://accounts.example.test/token",
+					jwks_uri: "http://127.0.0.1:9999/jwks",
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+		const config: OidcConfig = {
+			issuerUrl: "https://accounts.example.test/",
+			clientId: "codemem-client",
+			clientSecret: "secret",
+			allowedSubject: "owner-sub",
+		};
+		const clientsStore = createInMemoryOAuthClientsStore();
+		const pendingStore = createInMemoryOidcPendingAuthorizationStore();
+		const registered = registerMcpOAuthClient(
+			{ redirect_uris: ["https://claude.ai/api/mcp/auth_callback"] },
+			clientsStore,
+		);
+		if (registered.status !== 201) throw new Error("expected client registration");
+
+		await expect(
+			beginOidcAuthorization(
+				new URLSearchParams({
+					client_id: registered.body.client_id,
+					redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+					response_type: "code",
+					code_challenge_method: "S256",
+					code_challenge: "a".repeat(43),
+				}),
+				clientsStore,
+				pendingStore,
+				config,
+				"https://mcp.example.test/mcp",
+			),
+		).rejects.toThrow(/HTTPS/);
+	});
+
+	it("rejects discovered endpoints containing credentials", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					issuer: "https://accounts.example.test/",
+					authorization_endpoint: "https://accounts.example.test/authorize",
+					token_endpoint: "https://client:secret@accounts.example.test/token",
+					jwks_uri: "https://accounts.example.test/jwks",
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+		const config: OidcConfig = {
+			issuerUrl: "https://accounts.example.test/",
+			clientId: "codemem-client",
+			clientSecret: "secret",
+			allowedSubject: "owner-sub",
+		};
+		const clientsStore = createInMemoryOAuthClientsStore();
+		const pendingStore = createInMemoryOidcPendingAuthorizationStore();
+		const registered = registerMcpOAuthClient(
+			{ redirect_uris: ["https://claude.ai/api/mcp/auth_callback"] },
+			clientsStore,
+		);
+		if (registered.status !== 201) throw new Error("expected client registration");
+
+		await expect(
+			beginOidcAuthorization(
+				new URLSearchParams({
+					client_id: registered.body.client_id,
+					redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+					response_type: "code",
+					code_challenge_method: "S256",
+					code_challenge: "a".repeat(43),
+				}),
+				clientsStore,
+				pendingStore,
+				config,
+				"https://mcp.example.test/mcp",
+			),
+		).rejects.toThrow(/credentials/);
+	});
+
+	it("redirects to upstream OIDC and accepts an allowed identity", async () => {
+		const oidc = await startFakeOidc({ sub: "owner-sub", email: "owner@example.test" });
+		servers.push(oidc);
+		const config: OidcConfig = {
+			issuerUrl: oidc.issuer,
+			clientId: "codemem-client",
+			clientSecret: "secret",
+			allowedSubject: "owner-sub",
+		};
+		const clientsStore = createInMemoryOAuthClientsStore();
+		const pendingStore = createInMemoryOidcPendingAuthorizationStore();
+		const registered = registerMcpOAuthClient(
+			{ redirect_uris: ["https://claude.ai/api/mcp/auth_callback"] },
+			clientsStore,
+		);
+		if (registered.status !== 201) throw new Error("expected client registration");
+
+		const begin = await beginOidcAuthorization(
+			new URLSearchParams({
+				client_id: registered.body.client_id,
+				redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+				response_type: "code",
+				code_challenge_method: "S256",
+				code_challenge: "a".repeat(43),
+				state: "claude-state",
+			}),
+			clientsStore,
+			pendingStore,
+			config,
+			"http://127.0.0.1:38889/mcp",
+		);
+
+		expect(begin.status).toBe(302);
+		if (begin.status !== 302) throw new Error("expected OIDC redirect");
+		const upstream = new URL(begin.location);
+		await fetch(upstream);
+		expect(upstream.pathname).toBe("/authorize");
+		expect(upstream.searchParams.get("scope")).toBe("openid email");
+		const completed = await completeOidcAuthorization(
+			new URLSearchParams({
+				code: "upstream-code",
+				state: upstream.searchParams.get("state") ?? "",
+			}),
+			pendingStore,
+			config,
+			"http://127.0.0.1:38889/mcp",
+		);
+
+		expect("oauthParams" in completed).toBe(true);
+		if (!("oauthParams" in completed)) throw new Error("expected completed OIDC auth");
+		expect(completed.oauthParams.get("state")).toBe("claude-state");
+	});
+
+	it("denies identities outside the configured allowlist", async () => {
+		const oidc = await startFakeOidc({ sub: "other-sub", email: "other@example.test" });
+		servers.push(oidc);
+		const config: OidcConfig = {
+			issuerUrl: oidc.issuer,
+			clientId: "codemem-client",
+			clientSecret: "secret",
+			allowedSubject: "owner-sub",
+		};
+		const clientsStore = createInMemoryOAuthClientsStore();
+		const pendingStore = createInMemoryOidcPendingAuthorizationStore();
+		const registered = registerMcpOAuthClient(
+			{ redirect_uris: ["https://claude.ai/api/mcp/auth_callback"] },
+			clientsStore,
+		);
+		if (registered.status !== 201) throw new Error("expected client registration");
+		const begin = await beginOidcAuthorization(
+			new URLSearchParams({
+				client_id: registered.body.client_id,
+				redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+				response_type: "code",
+				code_challenge_method: "S256",
+				code_challenge: "a".repeat(43),
+			}),
+			clientsStore,
+			pendingStore,
+			config,
+			"http://127.0.0.1:38889/mcp",
+		);
+		if (begin.status !== 302) throw new Error("expected OIDC redirect");
+		await fetch(begin.location);
+
+		const denied = await completeOidcAuthorization(
+			new URLSearchParams({
+				code: "upstream-code",
+				state: new URL(begin.location).searchParams.get("state") ?? "",
+			}),
+			pendingStore,
+			config,
+			"http://127.0.0.1:38889/mcp",
+		);
+
+		expect(denied).toMatchObject({ status: 400, body: { error: "access_denied" } });
+	});
+
+	it("consumes pending state when upstream OIDC returns an error callback", async () => {
+		const oidc = await startFakeOidc({ sub: "owner-sub", email: "owner@example.test" });
+		servers.push(oidc);
+		const config: OidcConfig = {
+			issuerUrl: oidc.issuer,
+			clientId: "codemem-client",
+			clientSecret: "secret",
+			allowedSubject: "owner-sub",
+		};
+		const clientsStore = createInMemoryOAuthClientsStore();
+		const pendingStore = createInMemoryOidcPendingAuthorizationStore();
+		const registered = registerMcpOAuthClient(
+			{ redirect_uris: ["https://claude.ai/api/mcp/auth_callback"] },
+			clientsStore,
+		);
+		if (registered.status !== 201) throw new Error("expected client registration");
+		const begin = await beginOidcAuthorization(
+			new URLSearchParams({
+				client_id: registered.body.client_id,
+				redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+				response_type: "code",
+				code_challenge_method: "S256",
+				code_challenge: "a".repeat(43),
+			}),
+			clientsStore,
+			pendingStore,
+			config,
+			"http://127.0.0.1:38889/mcp",
+		);
+		if (begin.status !== 302) throw new Error("expected OIDC redirect");
+		const state = new URL(begin.location).searchParams.get("state") ?? "";
+
+		const denied = await completeOidcAuthorization(
+			new URLSearchParams({ error: "access_denied", state }),
+			pendingStore,
+			config,
+			"http://127.0.0.1:38889/mcp",
+		);
+		const replayed = await completeOidcAuthorization(
+			new URLSearchParams({ code: "upstream-code", state }),
+			pendingStore,
+			config,
+			"http://127.0.0.1:38889/mcp",
+		);
+
+		expect(denied).toMatchObject({ status: 400, body: { error: "invalid_request" } });
+		expect(replayed).toMatchObject({ status: 400, body: { error: "invalid_request" } });
+		if ("oauthParams" in replayed) throw new Error("expected replay to be rejected");
+		expect(replayed.body.error_description).toMatch(/Expired or unknown/);
+	});
+
+	it("rejects ID tokens missing a subject", async () => {
+		const oidc = await startFakeOidc({ email: "owner@example.test" });
+		servers.push(oidc);
+		const config: OidcConfig = {
+			issuerUrl: oidc.issuer,
+			clientId: "codemem-client",
+			clientSecret: "secret",
+			allowedEmail: "owner@example.test",
+		};
+		const clientsStore = createInMemoryOAuthClientsStore();
+		const pendingStore = createInMemoryOidcPendingAuthorizationStore();
+		const registered = registerMcpOAuthClient(
+			{ redirect_uris: ["https://claude.ai/api/mcp/auth_callback"] },
+			clientsStore,
+		);
+		if (registered.status !== 201) throw new Error("expected client registration");
+		const begin = await beginOidcAuthorization(
+			new URLSearchParams({
+				client_id: registered.body.client_id,
+				redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+				response_type: "code",
+				code_challenge_method: "S256",
+				code_challenge: "a".repeat(43),
+			}),
+			clientsStore,
+			pendingStore,
+			config,
+			"http://127.0.0.1:38889/mcp",
+		);
+		if (begin.status !== 302) throw new Error("expected OIDC redirect");
+		await fetch(begin.location);
+
+		const denied = await completeOidcAuthorization(
+			new URLSearchParams({
+				code: "upstream-code",
+				state: new URL(begin.location).searchParams.get("state") ?? "",
+			}),
+			pendingStore,
+			config,
+			"http://127.0.0.1:38889/mcp",
+		);
+
+		expect(denied).toMatchObject({ status: 400, body: { error: "access_denied" } });
+	});
+
+	it("rejects ID tokens missing issued-at time", async () => {
+		const oidc = await startFakeOidc({ sub: "owner-sub", email: "owner@example.test" }, "", {
+			idTokenClaims: { iat: undefined },
+		});
+		servers.push(oidc);
+		const denied = await completeSuccessfulRedirect(oidc.issuer, "owner-sub");
+
+		expect(denied).toMatchObject({ status: 400, body: { error: "access_denied" } });
+	});
+
+	it("rejects ID tokens issued too far in the future", async () => {
+		const oidc = await startFakeOidc({ sub: "owner-sub", email: "owner@example.test" }, "", {
+			idTokenClaims: { iat: Math.floor(Date.now() / 1000) + 3600 },
+		});
+		servers.push(oidc);
+		const denied = await completeSuccessfulRedirect(oidc.issuer, "owner-sub");
+
+		expect(denied).toMatchObject({ status: 400, body: { error: "access_denied" } });
+	});
+
+	it("rejects multi-audience ID tokens without a matching authorized party", async () => {
+		const oidc = await startFakeOidc({ sub: "owner-sub", email: "owner@example.test" }, "", {
+			idTokenClaims: { aud: ["codemem-client", "other-client"] },
+		});
+		servers.push(oidc);
+		const denied = await completeSuccessfulRedirect(oidc.issuer, "owner-sub");
+
+		expect(denied).toMatchObject({ status: 400, body: { error: "access_denied" } });
+	});
+
+	it("rejects ID tokens with a mismatched authorized party", async () => {
+		const oidc = await startFakeOidc({ sub: "owner-sub", email: "owner@example.test" }, "", {
+			idTokenClaims: { aud: ["codemem-client", "other-client"], azp: "other-client" },
+		});
+		servers.push(oidc);
+		const denied = await completeSuccessfulRedirect(oidc.issuer, "owner-sub");
+
+		expect(denied).toMatchObject({ status: 400, body: { error: "access_denied" } });
+	});
+
+	it("rejects non-2xx token responses even when they include an ID token", async () => {
+		const oidc = await startFakeOidc({ sub: "owner-sub", email: "owner@example.test" }, "", {
+			tokenStatus: 500,
+		});
+		servers.push(oidc);
+		const denied = await completeSuccessfulRedirect(oidc.issuer, "owner-sub");
+
+		expect(denied).toMatchObject({ status: 400, body: { error: "access_denied" } });
+	});
+});
+
+async function completeSuccessfulRedirect(issuerUrl: string, allowedSubject: string) {
+	const config: OidcConfig = {
+		issuerUrl,
+		clientId: "codemem-client",
+		clientSecret: "secret",
+		allowedSubject,
+	};
+	const clientsStore = createInMemoryOAuthClientsStore();
+	const pendingStore = createInMemoryOidcPendingAuthorizationStore();
+	const registered = registerMcpOAuthClient(
+		{ redirect_uris: ["https://claude.ai/api/mcp/auth_callback"] },
+		clientsStore,
+	);
+	if (registered.status !== 201) throw new Error("expected client registration");
+	const begin = await beginOidcAuthorization(
+		new URLSearchParams({
+			client_id: registered.body.client_id,
+			redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+			response_type: "code",
+			code_challenge_method: "S256",
+			code_challenge: "a".repeat(43),
+		}),
+		clientsStore,
+		pendingStore,
+		config,
+		"http://127.0.0.1:38889/mcp",
+	);
+	if (begin.status !== 302) throw new Error("expected OIDC redirect");
+	await fetch(begin.location);
+	return completeOidcAuthorization(
+		new URLSearchParams({
+			code: "upstream-code",
+			state: new URL(begin.location).searchParams.get("state") ?? "",
+		}),
+		pendingStore,
+		config,
+		"http://127.0.0.1:38889/mcp",
+	);
+}
+
+async function startFakeOidc(
+	identity: { sub?: string; email: string },
+	issuerPath = "",
+	overrides: {
+		authorizationEndpoint?: string;
+		tokenEndpoint?: string;
+		jwksUri?: string;
+		tokenStatus?: number;
+		idTokenClaims?: Partial<{ aud: string | string[]; azp: string; iat: number }>;
+	} = {},
+) {
+	const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+	const kid = "test-key";
+	const publicJwk = publicKey.export({ format: "jwk" });
+	let issuer = "";
+	const requests: string[] = [];
+	const server = createServer(async (req, res) => {
+		const url = new URL(req.url ?? "/", issuer);
+		requests.push(url.pathname);
+		if (url.pathname === `${issuerPath}/.well-known/openid-configuration`) {
+			writeJson(res, {
+				issuer,
+				authorization_endpoint: overrides.authorizationEndpoint ?? `${issuer}authorize`,
+				token_endpoint: overrides.tokenEndpoint ?? `${issuer}token`,
+				jwks_uri: overrides.jwksUri ?? `${issuer}jwks`,
+			});
+			return;
+		}
+		if (url.pathname === "/jwks") {
+			writeJson(res, { keys: [{ ...publicJwk, kid, alg: "RS256", use: "sig" }] });
+			return;
+		}
+		if (url.pathname === "/token") {
+			const body = await readBody(req);
+			const params = new URLSearchParams(body);
+			res.statusCode = overrides.tokenStatus ?? 200;
+			writeJson(res, {
+				id_token: createIdToken({
+					issuer,
+					clientId: params.get("client_id") ?? "codemem-client",
+					nonce: lastNonce ?? "missing-nonce",
+					kid,
+					privateKey,
+					sub: identity.sub,
+					email: identity.email,
+					claims: overrides.idTokenClaims,
+				}),
+			});
+			return;
+		}
+		if (url.pathname === "/authorize") {
+			lastNonce = url.searchParams.get("nonce");
+			writeJson(res, { ok: true });
+			return;
+		}
+		res.statusCode = 404;
+		res.end();
+	});
+	let lastNonce: string | null = null;
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen({ host: "127.0.0.1", port: 0 }, () => {
+			server.off("error", reject);
+			const address = server.address();
+			if (!address || typeof address === "string") throw new Error("missing fake OIDC port");
+			issuer = `http://127.0.0.1:${address.port}${issuerPath}/`;
+			resolve();
+		});
+	});
+	return {
+		issuer,
+		requests,
+		close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+	};
+}
+
+function createIdToken(input: {
+	issuer: string;
+	clientId: string;
+	nonce: string;
+	kid: string;
+	privateKey: KeyObject;
+	sub?: string;
+	email: string;
+	claims?: Partial<{ aud: string | string[]; azp: string; iat: number }>;
+}): string {
+	const header = encodeJwtPart({ alg: "RS256", kid: input.kid, typ: "JWT" });
+	const claims = encodeJwtPart({
+		iss: input.issuer,
+		aud: input.claims?.aud ?? input.clientId,
+		azp: input.claims?.azp,
+		exp: Math.floor(Date.now() / 1000) + 300,
+		iat: input.claims && "iat" in input.claims ? input.claims.iat : Math.floor(Date.now() / 1000),
+		nonce: input.nonce,
+		sub: input.sub,
+		email: input.email,
+		email_verified: true,
+	});
+	const payload = `${header}.${claims}`;
+	const signature = sign("RSA-SHA256", Buffer.from(payload), input.privateKey).toString(
+		"base64url",
+	);
+	return `${payload}.${signature}`;
+}
+
+function encodeJwtPart(value: unknown): string {
+	return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+	let body = "";
+	for await (const chunk of req) body += chunk;
+	return body;
+}
+
+function writeJson(res: ServerResponse, body: unknown): void {
+	res.setHeader("content-type", "application/json");
+	res.end(JSON.stringify(body));
+}

--- a/packages/mcp-server/src/oidc.ts
+++ b/packages/mcp-server/src/oidc.ts
@@ -1,0 +1,328 @@
+import { createPublicKey, randomUUID, verify } from "node:crypto";
+import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import {
+	type McpOAuthErrorResult,
+	type McpOAuthRedirectResult,
+	prepareMcpOAuthAuthorizationRequest,
+} from "./oauth.js";
+
+export const MCP_OIDC_ISSUER_URL_ENV = "CODEMEM_MCP_OIDC_ISSUER_URL";
+export const MCP_OIDC_CLIENT_ID_ENV = "CODEMEM_MCP_OIDC_CLIENT_ID";
+export const MCP_OIDC_CLIENT_SECRET_ENV = "CODEMEM_MCP_OIDC_CLIENT_SECRET";
+export const MCP_OAUTH_ALLOWED_SUBJECT_ENV = "CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT";
+export const MCP_OAUTH_ALLOWED_EMAIL_ENV = "CODEMEM_MCP_OAUTH_ALLOWED_EMAIL";
+
+const PENDING_AUTH_TTL_MS = 5 * 60 * 1000;
+const MAX_PENDING_AUTH = 100;
+const ID_TOKEN_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+type JsonWebKey = Record<string, unknown>;
+
+export interface OidcConfig {
+	issuerUrl: string;
+	clientId: string;
+	clientSecret: string;
+	allowedSubject?: string;
+	allowedEmail?: string;
+}
+
+export interface PendingOidcAuthorization {
+	oauthParams: string;
+	nonce: string;
+	expiresAt: number;
+}
+
+export interface OidcPendingAuthorizationStore {
+	issue(record: Omit<PendingOidcAuthorization, "expiresAt">, now?: number): string | undefined;
+	consume(state: string): PendingOidcAuthorization | undefined;
+}
+
+interface OidcDiscoveryMetadata {
+	issuer: string;
+	authorization_endpoint: string;
+	token_endpoint: string;
+	jwks_uri: string;
+}
+
+interface OidcTokensResponse {
+	id_token?: string;
+	error?: string;
+	error_description?: string;
+}
+
+interface JwtHeader {
+	alg?: string;
+	kid?: string;
+}
+
+interface JwtClaims {
+	iss?: string;
+	aud?: string | string[];
+	azp?: string;
+	exp?: number;
+	iat?: number;
+	nonce?: string;
+	sub?: string;
+	email?: string;
+	email_verified?: boolean;
+}
+
+interface JsonWebKeySet {
+	keys?: JsonWebKey[];
+}
+
+export class InMemoryOidcPendingAuthorizationStore implements OidcPendingAuthorizationStore {
+	readonly #records = new Map<string, PendingOidcAuthorization>();
+
+	issue(record: Omit<PendingOidcAuthorization, "expiresAt">, now = Date.now()): string | undefined {
+		this.#deleteExpired(now);
+		if (this.#records.size >= MAX_PENDING_AUTH) return undefined;
+		const state = randomUUID();
+		this.#records.set(state, { ...record, expiresAt: now + PENDING_AUTH_TTL_MS });
+		return state;
+	}
+
+	consume(state: string): PendingOidcAuthorization | undefined {
+		const record = this.#records.get(state);
+		this.#records.delete(state);
+		return record;
+	}
+
+	#deleteExpired(now: number): void {
+		for (const [state, record] of this.#records) {
+			if (record.expiresAt <= now) this.#records.delete(state);
+		}
+	}
+}
+
+export function createInMemoryOidcPendingAuthorizationStore(): OidcPendingAuthorizationStore {
+	return new InMemoryOidcPendingAuthorizationStore();
+}
+
+export function resolveOidcConfig(env: NodeJS.ProcessEnv = process.env): OidcConfig | undefined {
+	const issuerUrl = env[MCP_OIDC_ISSUER_URL_ENV]?.trim();
+	const clientId = env[MCP_OIDC_CLIENT_ID_ENV]?.trim();
+	const clientSecret = env[MCP_OIDC_CLIENT_SECRET_ENV]?.trim();
+	const allowedSubject = env[MCP_OAUTH_ALLOWED_SUBJECT_ENV]?.trim();
+	const allowedEmail = env[MCP_OAUTH_ALLOWED_EMAIL_ENV]?.trim().toLowerCase();
+	if (!issuerUrl && !clientId && !clientSecret && !allowedSubject && !allowedEmail)
+		return undefined;
+	if (!issuerUrl || !clientId || !clientSecret) {
+		throw new Error("Incomplete MCP OIDC configuration");
+	}
+	validateOidcUrl(issuerUrl, "issuer", { allowLoopbackHttp: true });
+	if (!allowedSubject && !allowedEmail) {
+		throw new Error(
+			"MCP OIDC requires CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT or CODEMEM_MCP_OAUTH_ALLOWED_EMAIL",
+		);
+	}
+	return { issuerUrl, clientId, clientSecret, allowedSubject, allowedEmail };
+}
+
+export async function beginOidcAuthorization(
+	params: URLSearchParams,
+	clientsStore: OAuthRegisteredClientsStore,
+	pendingStore: OidcPendingAuthorizationStore,
+	config: OidcConfig | undefined,
+	publicMcpUrl: string,
+	now = Date.now(),
+): Promise<McpOAuthRedirectResult | McpOAuthErrorResult> {
+	if (!config) return invalidOAuthRequest("temporarily_unavailable", "OIDC is not configured");
+	const prepared = prepareMcpOAuthAuthorizationRequest(params, clientsStore);
+	if ("status" in prepared) return prepared;
+
+	const discovery = await fetchOidcDiscovery(config.issuerUrl);
+	const nonce = randomUUID();
+	const upstreamState = pendingStore.issue({ oauthParams: params.toString(), nonce }, now);
+	if (!upstreamState)
+		return invalidOAuthRequest("temporarily_unavailable", "Too many pending OIDC authorizations");
+
+	const redirectUri = getCallbackUrl(publicMcpUrl);
+	const upstream = new URL(discovery.authorization_endpoint);
+	upstream.searchParams.set("response_type", "code");
+	upstream.searchParams.set("client_id", config.clientId);
+	upstream.searchParams.set("redirect_uri", redirectUri);
+	upstream.searchParams.set("scope", "openid email");
+	upstream.searchParams.set("state", upstreamState);
+	upstream.searchParams.set("nonce", nonce);
+	return { status: 302, location: upstream.href };
+}
+
+export async function completeOidcAuthorization(
+	callbackParams: URLSearchParams,
+	pendingStore: OidcPendingAuthorizationStore,
+	config: OidcConfig,
+	publicMcpUrl: string,
+	now = Date.now(),
+): Promise<{ oauthParams: URLSearchParams } | McpOAuthErrorResult> {
+	try {
+		const code = callbackParams.get("code") ?? "";
+		const state = callbackParams.get("state") ?? "";
+		if (!state) return invalidOAuthRequest("invalid_request", "Missing OIDC state");
+		const pending = pendingStore.consume(state);
+		if (!pending || pending.expiresAt <= now)
+			return invalidOAuthRequest("invalid_request", "Expired or unknown OIDC state");
+		if (!code) return invalidOAuthRequest("invalid_request", "Missing OIDC code");
+
+		const discovery = await fetchOidcDiscovery(config.issuerUrl);
+		const tokens = await exchangeOidcCode(
+			discovery.token_endpoint,
+			config,
+			getCallbackUrl(publicMcpUrl),
+			code,
+		);
+		if (!tokens.id_token)
+			return invalidOAuthRequest("invalid_request", "OIDC token exchange failed");
+		const claims = await validateIdToken(
+			tokens.id_token,
+			discovery,
+			config.clientId,
+			pending.nonce,
+			now,
+		);
+		if (!isAllowedIdentity(claims, config))
+			return invalidOAuthRequest("access_denied", "OIDC identity is not allowed");
+
+		return { oauthParams: new URLSearchParams(pending.oauthParams) };
+	} catch {
+		return invalidOAuthRequest("access_denied", "OIDC identity verification failed");
+	}
+}
+
+function getCallbackUrl(publicMcpUrl: string): string {
+	const url = new URL(publicMcpUrl);
+	return new URL("/oauth/callback", url.origin).href;
+}
+
+async function fetchOidcDiscovery(issuerUrl: string): Promise<OidcDiscoveryMetadata> {
+	const issuer = new URL(issuerUrl);
+	if (issuer.search || issuer.hash)
+		throw new Error("OIDC issuer must not include query or fragment");
+	if (issuer.username || issuer.password)
+		throw new Error("OIDC issuer must not include credentials");
+	const discoveryUrl = new URL(
+		`${issuer.pathname.replace(/\/$/, "")}/.well-known/openid-configuration`,
+		issuer.origin,
+	);
+	const response = await fetch(discoveryUrl);
+	if (!response.ok) throw new Error("OIDC discovery request failed");
+	const metadata = (await response.json()) as Partial<OidcDiscoveryMetadata>;
+	if (metadata.issuer !== issuer.href && metadata.issuer !== issuer.href.replace(/\/$/, "")) {
+		throw new Error("OIDC discovery issuer mismatch");
+	}
+	if (!metadata.authorization_endpoint || !metadata.token_endpoint || !metadata.jwks_uri) {
+		throw new Error("OIDC discovery metadata is incomplete");
+	}
+	const allowLoopbackHttp = issuer.protocol === "http:" && isLoopbackHostname(issuer.hostname);
+	validateOidcUrl(metadata.authorization_endpoint, "authorization endpoint", { allowLoopbackHttp });
+	validateOidcUrl(metadata.token_endpoint, "token endpoint", { allowLoopbackHttp });
+	validateOidcUrl(metadata.jwks_uri, "JWKS URI", { allowLoopbackHttp });
+	return metadata as OidcDiscoveryMetadata;
+}
+
+async function exchangeOidcCode(
+	tokenEndpoint: string,
+	config: OidcConfig,
+	redirectUri: string,
+	code: string,
+): Promise<OidcTokensResponse> {
+	const body = new URLSearchParams({
+		grant_type: "authorization_code",
+		code,
+		redirect_uri: redirectUri,
+		client_id: config.clientId,
+		client_secret: config.clientSecret,
+	});
+	const response = await fetch(tokenEndpoint, {
+		method: "POST",
+		headers: { "content-type": "application/x-www-form-urlencoded" },
+		body,
+	});
+	if (!response.ok) throw new Error("OIDC token request failed");
+	return (await response.json()) as OidcTokensResponse;
+}
+
+async function validateIdToken(
+	idToken: string,
+	discovery: OidcDiscoveryMetadata,
+	clientId: string,
+	nonce: string,
+	now: number,
+): Promise<JwtClaims> {
+	const [encodedHeader, encodedClaims, signature] = idToken.split(".");
+	if (!encodedHeader || !encodedClaims || !signature) throw new Error("Invalid OIDC id_token");
+	const header = parseJwtPart<JwtHeader>(encodedHeader);
+	const claims = parseJwtPart<JwtClaims>(encodedClaims);
+	if (header.alg !== "RS256" || !header.kid) throw new Error("Unsupported OIDC id_token signature");
+	if (claims.iss !== discovery.issuer) throw new Error("OIDC id_token issuer mismatch");
+	if (!audienceIncludes(claims.aud, clientId)) throw new Error("OIDC id_token audience mismatch");
+	if (!isValidAuthorizedParty(claims.aud, claims.azp, clientId))
+		throw new Error("OIDC id_token authorized party mismatch");
+	if (typeof claims.exp !== "number" || !Number.isFinite(claims.exp) || claims.exp * 1000 <= now)
+		throw new Error("OIDC id_token is expired");
+	if (typeof claims.iat !== "number" || !Number.isFinite(claims.iat))
+		throw new Error("OIDC id_token issued-at time is missing");
+	if (claims.iat * 1000 > now + ID_TOKEN_CLOCK_SKEW_MS)
+		throw new Error("OIDC id_token issued-at time is in the future");
+	if (claims.nonce !== nonce) throw new Error("OIDC id_token nonce mismatch");
+	if (!claims.sub) throw new Error("OIDC id_token subject is missing");
+
+	const jwksResponse = await fetch(discovery.jwks_uri);
+	if (!jwksResponse.ok) throw new Error("OIDC JWKS request failed");
+	const jwks = (await jwksResponse.json()) as JsonWebKeySet;
+	const jwk = jwks.keys?.find((key) => key.kid === header.kid && key.kty === "RSA");
+	if (!jwk) throw new Error("OIDC signing key not found");
+	const key = createPublicKey({ key: jwk, format: "jwk" });
+	const signed = `${encodedHeader}.${encodedClaims}`;
+	const ok = verify("RSA-SHA256", Buffer.from(signed), key, Buffer.from(signature, "base64url"));
+	if (!ok) throw new Error("OIDC id_token signature verification failed");
+	return claims;
+}
+
+function parseJwtPart<T>(encoded: string): T {
+	return JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as T;
+}
+
+function audienceIncludes(audience: string | string[] | undefined, clientId: string): boolean {
+	return Array.isArray(audience) ? audience.includes(clientId) : audience === clientId;
+}
+
+function isValidAuthorizedParty(
+	audience: string | string[] | undefined,
+	authorizedParty: string | undefined,
+	clientId: string,
+): boolean {
+	if (authorizedParty && authorizedParty !== clientId) return false;
+	return !Array.isArray(audience) || audience.length <= 1 || authorizedParty === clientId;
+}
+
+function isAllowedIdentity(claims: JwtClaims, config: OidcConfig): boolean {
+	if (config.allowedSubject && claims.sub === config.allowedSubject) return true;
+	if (!config.allowedEmail) return false;
+	return claims.email_verified === true && claims.email?.toLowerCase() === config.allowedEmail;
+}
+
+function validateOidcUrl(
+	value: string,
+	label: string,
+	options: { allowLoopbackHttp?: boolean } = {},
+): void {
+	const url = new URL(value);
+	if (url.username || url.password) throw new Error(`OIDC ${label} must not include credentials`);
+	if (url.protocol === "https:") return;
+	if (options.allowLoopbackHttp && url.protocol === "http:" && isLoopbackHostname(url.hostname))
+		return;
+	throw new Error(`OIDC ${label} must use HTTPS`);
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+	const normalized = hostname.replace(/^\[(.*)]$/, "$1").toLowerCase();
+	return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
+}
+
+function invalidOAuthRequest(error: string, description?: string): McpOAuthErrorResult {
+	return {
+		status: 400,
+		body: description ? { error, error_description: description } : { error },
+	};
+}


### PR DESCRIPTION
## Description
Adds upstream OIDC identity gating before MCP OAuth authorization codes are issued. `/authorize` now redirects through a configured OIDC provider, stores pending state/nonce, and `/oauth/callback` exchanges the upstream code, verifies the ID token, enforces a single allowed subject/email, then resumes the existing MCP OAuth code issuance flow.

This is authn plus a single-user allowlist gate only. `/mcp` bearer enforcement and token revocation remain the next stack slice.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run locally:
- `pnpm run tsc && pnpm run lint && pnpm exec vitest run packages/mcp-server/src/http.test.ts packages/mcp-server/src/oauth.test.ts packages/mcp-server/src/oidc.test.ts`
- `pnpm run tsc && pnpm run lint && pnpm run test`
- CodeReviewer review + re-reviews: no remaining blockers
- Snyk Code scan on `packages/mcp-server/src` (remaining HTTP finding is expected for local raw HTTP transport)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
