### PR TITLE
fix(ui): move team space ids to advanced copy

### DIFF
--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -567,8 +567,8 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 							"div",
 							{ class: "peer-card peer-card--padded", key: group.group_id },
 							h("div", { class: "peer-title" }, h("strong", null, draftName)),
-							h("div", { class: "peer-meta" }, `Team ID: ${group.group_id}`),
-							h("div", { class: "peer-submeta" }, archived ? "Archived" : "Active"),
+							h("div", { class: "peer-submeta" }, archived ? "Archived Team" : "Active Team"),
+							h("div", { class: "peer-meta" }, `Advanced: Team ID ${group.group_id}`),
 							h(
 								"div",
 								{ class: "coordinator-admin-summary-grid" },
@@ -629,7 +629,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 										},
 										type: "button",
 									},
-									selected ? "Managing" : "Manage",
+									selected ? "Managing" : "Manage Team",
 								),
 								h(
 									"button",

--- a/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
@@ -327,11 +327,15 @@ function renderScopeCard(
 		"div",
 		{ class: "peer-card peer-card--padded coordinator-admin-scope-card", key: scopeId || label },
 		h("div", { class: "peer-title" }, h("strong", null, label)),
-		h("div", { class: "peer-meta" }, `Space ID: ${scopeId || "unknown"}`),
 		h(
 			"div",
 			{ class: "peer-submeta" },
-			`Kind: ${scope.kind || "user"} · Status: ${scopeStatusLabel(scope.status)} · Membership epoch: ${scope.membership_epoch ?? 0}`,
+			`Status: ${scopeStatusLabel(scope.status)} · Kind: ${scope.kind || "user"}`,
+		),
+		h(
+			"div",
+			{ class: "peer-meta" },
+			`Advanced: Space ID ${scopeId || "unknown"} · Membership epoch ${scope.membership_epoch ?? 0}`,
 		),
 		h(
 			"div",
@@ -477,7 +481,7 @@ export function renderGroupScopeManagementPanel(deps: ScopeManagementPanelDeps) 
 			: h(
 					"div",
 					{ class: "peer-meta coordinator-admin-empty-state" },
-					"No Spaces are defined for this Team yet. Create one, then grant specific devices.",
+					"No Spaces are defined for this Team yet. Create a Space, then grant specific devices. Projects stay local-only until assigned to a Space.",
 				),
 	);
 }


### PR DESCRIPTION
## Description
Moves raw Team and Space identifiers out of primary Coordinator Admin copy and marks them as advanced details. Also tightens the empty state for Teams without Spaces so it reinforces that projects stay local-only until assigned to a Space.

This closes the remaining polish gap for codemem-00dc.2 after the Team card and Spaces/access work in #1131.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run:

- `pnpm exec vitest run packages/ui/src/tabs/coordinator-admin/data/team-card.test.ts packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts packages/ui/src/tabs/coordinator-admin/data/actions.test.ts`
- `pnpm exec tsc --build packages/ui/tsconfig.json --pretty false`
- `pnpm exec biome check packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced