### PR TITLE
feat(mcp): structured OAuth audit events

### DIFF
--- a/packages/mcp-server/src/audit.test.ts
+++ b/packages/mcp-server/src/audit.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildOAuthAuditEvent,
+	createDefaultOAuthAuditEmitter,
+	createSilentOAuthAuditEmitter,
+	resolveOAuthAuditEmitterFromEnv,
+	wrapAuditEmitterBestEffort,
+} from "./audit.js";
+
+type WriteCapture = {
+	write: (chunk: string) => boolean;
+};
+
+function captureWrites(): { stream: WriteCapture; chunks: string[] } {
+	const chunks: string[] = [];
+	const stream: WriteCapture = {
+		write(chunk: string) {
+			chunks.push(chunk);
+			return true;
+		},
+	};
+	return { stream, chunks };
+}
+
+describe("OAuth audit events", () => {
+	it("builds events with ISO timestamps and metadata", () => {
+		const event = buildOAuthAuditEvent("bearer", {
+			outcome: "denied",
+			reason: "expired_token",
+			clientId: "client-123",
+			remoteAddress: "203.0.113.10",
+			now: 1_700_000_000_000,
+		});
+
+		expect(event).toEqual({
+			kind: "bearer",
+			outcome: "denied",
+			reason: "expired_token",
+			clientId: "client-123",
+			remoteAddress: "203.0.113.10",
+			timestamp: new Date(1_700_000_000_000).toISOString(),
+		});
+	});
+
+	it("refuses to attach secret-bearing fields in any casing or separator style", () => {
+		const forbidden = [
+			"access_token",
+			"refresh_token",
+			"id_token",
+			"code",
+			"code_verifier",
+			"code_challenge",
+			"client_secret",
+			"authorization",
+			"password",
+			"secret",
+			"token",
+			// camelCase forms that bypassed the snake_case-only denylist before
+			// Codex P2 feedback on PR #1136.
+			"accessToken",
+			"refreshToken",
+			"idToken",
+			"codeVerifier",
+			"codeChallenge",
+			"clientSecret",
+			// UPPER_SNAKE_CASE and kebab-case round out the canonicalization
+			// coverage so future callers cannot smuggle secrets by reshaping.
+			"ACCESS_TOKEN",
+			"client-secret",
+		];
+		for (const key of forbidden) {
+			expect(() =>
+				buildOAuthAuditEvent("token", {
+					outcome: "success",
+					[key]: "leak",
+				} as Parameters<typeof buildOAuthAuditEvent>[1]),
+			).toThrow(/forbidden field/i);
+		}
+	});
+
+	it("default emitter writes one JSON line per event to the supplied stream", () => {
+		const { stream, chunks } = captureWrites();
+		const emit = createDefaultOAuthAuditEmitter(
+			stream as unknown as Parameters<typeof createDefaultOAuthAuditEmitter>[0],
+		);
+
+		emit(
+			buildOAuthAuditEvent("registration", {
+				outcome: "success",
+				clientId: "client-abc",
+				now: 1_700_000_000_000,
+			}),
+		);
+		emit(
+			buildOAuthAuditEvent("bearer", {
+				outcome: "denied",
+				reason: "missing_authorization_header",
+				now: 1_700_000_001_000,
+			}),
+		);
+
+		expect(chunks).toHaveLength(2);
+		const first = chunks[0] ?? "";
+		const second = chunks[1] ?? "";
+		expect(first.endsWith("\n")).toBe(true);
+		expect(JSON.parse(first.trimEnd())).toEqual({
+			source: "codemem-mcp-oauth-audit",
+			kind: "registration",
+			outcome: "success",
+			clientId: "client-abc",
+			timestamp: new Date(1_700_000_000_000).toISOString(),
+		});
+		expect(JSON.parse(second.trimEnd())).toMatchObject({
+			kind: "bearer",
+			outcome: "denied",
+			reason: "missing_authorization_header",
+		});
+	});
+
+	it("silent emitter writes nothing", () => {
+		const emit = createSilentOAuthAuditEmitter();
+		expect(() =>
+			emit(buildOAuthAuditEvent("revocation", { outcome: "success", now: 0 })),
+		).not.toThrow();
+	});
+
+	it("env resolver returns a silent emitter for falsy values", () => {
+		for (const value of ["0", "false", "FALSE", "no", " No "]) {
+			const { stream, chunks } = captureWrites();
+			const emit = resolveOAuthAuditEmitterFromEnv(value);
+			emit(buildOAuthAuditEvent("bearer", { outcome: "denied", now: 0 }));
+			const probe = createDefaultOAuthAuditEmitter(
+				stream as unknown as Parameters<typeof createDefaultOAuthAuditEmitter>[0],
+			);
+			probe(buildOAuthAuditEvent("bearer", { outcome: "denied", now: 0 }));
+			expect(chunks).toHaveLength(1);
+		}
+	});
+
+	it("env resolver returns a default-shaped emitter when unset or unknown", () => {
+		expect(typeof resolveOAuthAuditEmitterFromEnv(undefined)).toBe("function");
+		expect(typeof resolveOAuthAuditEmitterFromEnv("anything-else")).toBe("function");
+	});
+
+	it("wraps emitters so emitter failures never throw into the caller", () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const throwingEmitter = () => {
+				throw new Error("stream write failed");
+			};
+			const safe = wrapAuditEmitterBestEffort(throwingEmitter);
+			const event = buildOAuthAuditEvent("bearer", { outcome: "denied", now: 0 });
+			expect(() => safe(event)).not.toThrow();
+			expect(() => safe(event)).not.toThrow();
+			// First failure surfaces, subsequent ones are suppressed to avoid log floods.
+			expect(consoleError).toHaveBeenCalledTimes(1);
+		} finally {
+			consoleError.mockRestore();
+		}
+	});
+});

--- a/packages/mcp-server/src/audit.ts
+++ b/packages/mcp-server/src/audit.ts
@@ -1,0 +1,137 @@
+/**
+ * @codemem/mcp — privacy-safe OAuth audit events.
+ *
+ * Phase 1 single-user remote MCP needs operator-visible security events
+ * (registration, authorize, OIDC callback, token issuance, revocation, bearer
+ * verification) without ever logging bearer tokens, authorization codes,
+ * client secrets, OIDC ID tokens, or private memory contents.
+ */
+
+export type OAuthAuditKind =
+	| "registration"
+	| "authorize"
+	| "oidc_callback"
+	| "token"
+	| "revocation"
+	| "bearer";
+
+export type OAuthAuditOutcome = "success" | "denied" | "error";
+
+export type BearerDenyReason =
+	| "missing_authorization_header"
+	| "malformed_authorization_header"
+	| "unknown_token"
+	| "expired_token"
+	| "revoked_token";
+
+export interface OAuthAuditEventBase {
+	timestamp: string;
+	outcome: OAuthAuditOutcome;
+	reason?: string;
+	clientId?: string;
+	remoteAddress?: string;
+}
+
+export type OAuthAuditEvent = OAuthAuditEventBase & { kind: OAuthAuditKind };
+
+export type OAuthAuditEmitter = (event: OAuthAuditEvent) => void;
+
+// Canonicalized denylist — keys are compared after lowercasing and stripping
+// non-alphanumeric separators, so `access_token`, `accessToken`, `ACCESS-TOKEN`
+// and `access token` all reduce to `accesstoken` and are blocked uniformly.
+// This codebase commonly uses camelCase identifiers, so a snake_case-only
+// denylist would miss real leak vectors.
+const FORBIDDEN_KEY_TOKENS = new Set([
+	"token",
+	"accesstoken",
+	"refreshtoken",
+	"idtoken",
+	"code",
+	"codeverifier",
+	"codechallenge",
+	"clientsecret",
+	"authorization",
+	"password",
+	"secret",
+]);
+
+function canonicalizeAuditKey(key: string): string {
+	return key.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Build an audit event with redaction safety. Throws if a forbidden field
+ * leaks in; callers should never need to pass token/code material here.
+ */
+export function buildOAuthAuditEvent(
+	kind: OAuthAuditKind,
+	fields: Omit<OAuthAuditEventBase, "timestamp"> & { now?: number },
+): OAuthAuditEvent {
+	for (const key of Object.keys(fields)) {
+		if (FORBIDDEN_KEY_TOKENS.has(canonicalizeAuditKey(key))) {
+			throw new Error(`OAuth audit event must not carry forbidden field: ${key}`);
+		}
+	}
+	const { now, ...rest } = fields;
+	return {
+		kind,
+		timestamp: new Date(now ?? Date.now()).toISOString(),
+		...rest,
+	};
+}
+
+/**
+ * Wrap an audit emitter so any synchronous throw or stream-write failure stays
+ * contained. Audit logging is best-effort observability and must never break
+ * the OAuth/MCP request flow it observes. Failures are reported once per
+ * process to `console.error` so they remain visible without flooding output.
+ */
+export function wrapAuditEmitterBestEffort(emit: OAuthAuditEmitter): OAuthAuditEmitter {
+	let reportedFailure = false;
+	return (event) => {
+		try {
+			emit(event);
+		} catch (err) {
+			if (!reportedFailure) {
+				reportedFailure = true;
+				console.error("codemem MCP OAuth audit emitter failed (further failures suppressed):", err);
+			}
+		}
+	};
+}
+
+/**
+ * Default audit emitter writes one JSON object per line to stderr. This keeps
+ * MCP HTTP stdout reserved for protocol traffic and is greppable by operators
+ * via `journalctl` or a redirected log file.
+ */
+export function createDefaultOAuthAuditEmitter(
+	stream: NodeJS.WriteStream = process.stderr,
+): OAuthAuditEmitter {
+	return (event) => {
+		stream.write(`${JSON.stringify({ source: "codemem-mcp-oauth-audit", ...event })}\n`);
+	};
+}
+
+/**
+ * No-op emitter, used when CODEMEM_MCP_AUDIT=0 or when callers explicitly
+ * want to suppress audit output (for example, embedded tests).
+ */
+export function createSilentOAuthAuditEmitter(): OAuthAuditEmitter {
+	return () => {};
+}
+
+/**
+ * Resolve an emitter from environment configuration. `CODEMEM_MCP_AUDIT=0`,
+ * `false`, or `no` disables audit logging; anything else (including unset)
+ * uses the default stderr emitter.
+ */
+export function resolveOAuthAuditEmitterFromEnv(
+	value = process.env.CODEMEM_MCP_AUDIT,
+): OAuthAuditEmitter {
+	const normalized = value?.trim().toLowerCase();
+	if (normalized === "0" || normalized === "false" || normalized === "no") {
+		return createSilentOAuthAuditEmitter();
+	}
+	return createDefaultOAuthAuditEmitter();
+}

--- a/packages/mcp-server/src/http.test.ts
+++ b/packages/mcp-server/src/http.test.ts
@@ -4,6 +4,7 @@ import { request } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import type { OAuthAuditEvent } from "./audit.js";
 import {
 	type CodememMcpHttpServer,
 	DEFAULT_MCP_HTTP_HOST,
@@ -19,6 +20,45 @@ import {
 import { createInMemoryOAuthAccessTokenStore } from "./oauth.js";
 
 const servers: CodememMcpHttpServer[] = [];
+
+const FORBIDDEN_AUDIT_FIELDS = new Set([
+	"access_token",
+	"refresh_token",
+	"id_token",
+	"code",
+	"code_verifier",
+	"code_challenge",
+	"client_secret",
+	"authorization",
+	"password",
+	"secret",
+	"token",
+]);
+
+function captureAuditEmitter(): {
+	emit: (event: OAuthAuditEvent) => void;
+	events: OAuthAuditEvent[];
+} {
+	const events: OAuthAuditEvent[] = [];
+	return {
+		emit: (event) => {
+			events.push(event);
+		},
+		events,
+	};
+}
+
+function assertAuditEventsAreRedacted(events: OAuthAuditEvent[]): void {
+	for (const event of events) {
+		for (const key of Object.keys(event)) {
+			expect(FORBIDDEN_AUDIT_FIELDS.has(key.toLowerCase())).toBe(false);
+		}
+		const serialized = JSON.stringify(event);
+		for (const forbidden of FORBIDDEN_AUDIT_FIELDS) {
+			expect(serialized.toLowerCase()).not.toContain(`"${forbidden}":`);
+		}
+	}
+}
 
 afterEach(async () => {
 	await Promise.all(servers.splice(0).map((server) => server.close()));
@@ -324,6 +364,67 @@ describe("MCP HTTP transport", () => {
 		});
 
 		expect(response.statusCode).toBe(200);
+	});
+
+	it("emits redacted audit events for the full OAuth + bearer flow", async () => {
+		const tokenStore = createInMemoryOAuthAccessTokenStore();
+		const issued = tokenStore.issueToken("client-audit");
+		if (!issued) throw new Error("expected access token");
+		const { emit, events } = captureAuditEmitter();
+		const server = await startCodememMcpHttpServer({
+			dbPath: tempDbPath(),
+			port: 0,
+			publicUrl: "https://codemem.example.test/mcp",
+			oauthAccessTokenStore: tokenStore,
+			auditEmitter: emit,
+		});
+		servers.push(server);
+		const baseUrl = server.url.replace("/mcp", "");
+
+		const register = await fetch(`${baseUrl}/register`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+				token_endpoint_auth_method: "none",
+			}),
+		});
+		expect(register.status).toBe(201);
+		await fetch(`${baseUrl}/oauth/revoke`, {
+			method: "POST",
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({ token: "ignored-since-unknown" }),
+		});
+		const missingBearer = await fetch(server.url, {
+			method: "POST",
+			headers: {
+				accept: "application/json, text/event-stream",
+				"content-type": "application/json",
+			},
+			body: initializeBody(1),
+		});
+		expect(missingBearer.status).toBe(401);
+		const validBearer = await initialize(server.url, 2, {
+			authorization: `Bearer ${issued.token}`,
+		});
+		expect(validBearer.result?.serverInfo?.name).toBe("codemem");
+
+		const kinds = events.map((e) => e.kind);
+		expect(kinds).toContain("registration");
+		expect(kinds).toContain("revocation");
+		expect(kinds).toContain("bearer");
+
+		const registration = events.find((e) => e.kind === "registration");
+		expect(registration?.outcome).toBe("success");
+		expect(registration?.clientId).toMatch(/[0-9a-f-]{36}/);
+
+		const denied = events.find((e) => e.kind === "bearer" && e.outcome === "denied");
+		expect(denied?.reason).toBe("missing_authorization_header");
+
+		const accepted = events.find((e) => e.kind === "bearer" && e.outcome === "success");
+		expect(accepted?.clientId).toBe("client-audit");
+
+		assertAuditEventsAreRedacted(events);
 	});
 
 	it("rejects expired and revoked bearer tokens", async () => {

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -15,6 +15,13 @@ import { MemoryStore, resolveDbPath } from "@codemem/core";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import {
+	type BearerDenyReason,
+	buildOAuthAuditEvent,
+	type OAuthAuditEmitter,
+	resolveOAuthAuditEmitterFromEnv,
+	wrapAuditEmitterBestEffort,
+} from "./audit.js";
+import {
 	authorizeMcpOAuthClient,
 	createInMemoryOAuthAccessTokenStore,
 	createInMemoryOAuthAuthorizationCodeStore,
@@ -54,6 +61,7 @@ export interface CodememMcpHttpOptions {
 	allowUnsafePublic?: boolean;
 	publicUrl?: string;
 	oauthAccessTokenStore?: OAuthAccessTokenStore;
+	auditEmitter?: OAuthAuditEmitter;
 }
 
 export interface CodememMcpHttpServer {
@@ -190,6 +198,9 @@ export async function startCodememMcpHttpServer(
 	const oidcConfig = resolveOidcConfig();
 	const oidcPendingStore = createInMemoryOidcPendingAuthorizationStore();
 	const shouldRequireMcpBearer = configuredPublicMcpUrl !== undefined || oidcConfig !== undefined;
+	const auditEmit = wrapAuditEmitterBestEffort(
+		options.auditEmitter ?? resolveOAuthAuditEmitterFromEnv(),
+	);
 	const activeRequests = new Set<ActiveRequest>();
 	let closePromise: Promise<void> | null = null;
 
@@ -198,6 +209,7 @@ export async function startCodememMcpHttpServer(
 			const pathname = getRequestPathname(req);
 			const publicMcpUrl = configuredPublicMcpUrl?.href ?? getServerUrl(server, host);
 			const boundPort = getBoundPort(server);
+			const remoteAddress = req.socket.remoteAddress ?? undefined;
 
 			if (pathname === "/.well-known/oauth-authorization-server") {
 				if (!prepareHttpRoute(req, res, ["GET", "OPTIONS"])) return;
@@ -218,6 +230,13 @@ export async function startCodememMcpHttpServer(
 					__codememInvalidJson: "Invalid JSON request body",
 				}));
 				if (isInvalidJsonBody(requestBody)) {
+					auditEmit(
+						buildOAuthAuditEvent("registration", {
+							outcome: "denied",
+							reason: "invalid_json_body",
+							remoteAddress,
+						}),
+					);
 					writeJson(res, 400, {
 						error: "invalid_client_metadata",
 						error_description: requestBody.__codememInvalidJson,
@@ -225,6 +244,23 @@ export async function startCodememMcpHttpServer(
 					return;
 				}
 				const result = registerMcpOAuthClient(requestBody, clientsStore);
+				if (result.status === 201) {
+					auditEmit(
+						buildOAuthAuditEvent("registration", {
+							outcome: "success",
+							clientId: result.body.client_id,
+							remoteAddress,
+						}),
+					);
+				} else {
+					auditEmit(
+						buildOAuthAuditEvent("registration", {
+							outcome: "denied",
+							reason: result.body.error,
+							remoteAddress,
+						}),
+					);
+				}
 				writeJson(res, result.status, result.body);
 				return;
 			}
@@ -233,6 +269,7 @@ export async function startCodememMcpHttpServer(
 				if (!prepareOAuthRoute(req, res, ["GET", "OPTIONS"], boundPort, configuredPublicMcpUrl))
 					return;
 				const url = new URL(req.url ?? "/authorize", "http://codemem.local");
+				const clientIdParam = url.searchParams.get("client_id") ?? undefined;
 				const result = await beginOidcAuthorization(
 					url.searchParams,
 					clientsStore,
@@ -241,11 +278,27 @@ export async function startCodememMcpHttpServer(
 					publicMcpUrl,
 				);
 				if (result.status === 302) {
+					auditEmit(
+						buildOAuthAuditEvent("authorize", {
+							outcome: "success",
+							reason: oidcConfig ? "oidc_redirect_issued" : "code_issued",
+							clientId: clientIdParam,
+							remoteAddress,
+						}),
+					);
 					res.statusCode = result.status;
 					res.setHeader("location", result.location);
 					res.end();
 					return;
 				}
+				auditEmit(
+					buildOAuthAuditEvent("authorize", {
+						outcome: "denied",
+						reason: result.body.error,
+						clientId: clientIdParam,
+						remoteAddress,
+					}),
+				);
 				writeJson(res, result.status, result.body);
 				return;
 			}
@@ -254,6 +307,13 @@ export async function startCodememMcpHttpServer(
 				if (!prepareOAuthRoute(req, res, ["GET", "OPTIONS"], boundPort, configuredPublicMcpUrl))
 					return;
 				if (!oidcConfig) {
+					auditEmit(
+						buildOAuthAuditEvent("oidc_callback", {
+							outcome: "denied",
+							reason: "oidc_not_configured",
+							remoteAddress,
+						}),
+					);
 					writeJson(res, 400, {
 						error: "temporarily_unavailable",
 						error_description: "OIDC is not configured",
@@ -268,16 +328,40 @@ export async function startCodememMcpHttpServer(
 					publicMcpUrl,
 				);
 				if ("status" in completed) {
+					auditEmit(
+						buildOAuthAuditEvent("oidc_callback", {
+							outcome: "denied",
+							reason: completed.body.error,
+							remoteAddress,
+						}),
+					);
 					writeJson(res, completed.status, completed.body);
 					return;
 				}
+				const oauthClientId = completed.oauthParams.get("client_id") ?? undefined;
 				const result = authorizeMcpOAuthClient(completed.oauthParams, clientsStore, codeStore);
 				if (result.status === 302) {
+					auditEmit(
+						buildOAuthAuditEvent("oidc_callback", {
+							outcome: "success",
+							reason: "code_issued",
+							clientId: oauthClientId,
+							remoteAddress,
+						}),
+					);
 					res.statusCode = result.status;
 					res.setHeader("location", result.location);
 					res.end();
 					return;
 				}
+				auditEmit(
+					buildOAuthAuditEvent("oidc_callback", {
+						outcome: "denied",
+						reason: result.body.error,
+						clientId: oauthClientId,
+						remoteAddress,
+					}),
+				);
 				writeJson(res, result.status, result.body);
 				return;
 			}
@@ -286,12 +370,31 @@ export async function startCodememMcpHttpServer(
 				if (!prepareOAuthRoute(req, res, ["POST", "OPTIONS"], boundPort, configuredPublicMcpUrl))
 					return;
 				const params = await readFormBody(req).catch(() => new URLSearchParams());
+				const tokenClientId = params.get("client_id") ?? undefined;
 				const result = exchangeMcpOAuthAuthorizationCode(
 					params,
 					clientsStore,
 					codeStore,
 					tokenStore,
 				);
+				if (result.status === 200) {
+					auditEmit(
+						buildOAuthAuditEvent("token", {
+							outcome: "success",
+							clientId: tokenClientId,
+							remoteAddress,
+						}),
+					);
+				} else {
+					auditEmit(
+						buildOAuthAuditEvent("token", {
+							outcome: "denied",
+							reason: result.body.error,
+							clientId: tokenClientId,
+							remoteAddress,
+						}),
+					);
+				}
 				writeJson(res, result.status, result.body);
 				return;
 			}
@@ -301,6 +404,12 @@ export async function startCodememMcpHttpServer(
 					return;
 				const params = await readFormBody(req).catch(() => new URLSearchParams());
 				const result = revokeMcpOAuthAccessToken(params, tokenStore);
+				auditEmit(
+					buildOAuthAuditEvent("revocation", {
+						outcome: "success",
+						remoteAddress,
+					}),
+				);
 				writeJson(res, result.status, result.body);
 				return;
 			}
@@ -314,12 +423,26 @@ export async function startCodememMcpHttpServer(
 				writeText(res, 403, "Forbidden");
 				return;
 			}
-			if (
-				shouldRequireMcpBearer &&
-				!verifyMcpBearerAuthorization(req.headers.authorization, tokenStore)
-			) {
-				writeBearerUnauthorized(res);
-				return;
+			if (shouldRequireMcpBearer) {
+				const verification = verifyMcpBearerAuthorization(req.headers.authorization, tokenStore);
+				if (!verification.ok) {
+					auditEmit(
+						buildOAuthAuditEvent("bearer", {
+							outcome: "denied",
+							reason: verification.reason,
+							remoteAddress,
+						}),
+					);
+					writeBearerUnauthorized(res);
+					return;
+				}
+				auditEmit(
+					buildOAuthAuditEvent("bearer", {
+						outcome: "success",
+						clientId: verification.clientId,
+						remoteAddress,
+					}),
+				);
 			}
 
 			const mcpServer = createCodememMcpServer(store);
@@ -512,11 +635,15 @@ function isAllowedPublicRequestHost(header: string | undefined, publicMcpUrl: UR
 function verifyMcpBearerAuthorization(
 	header: string | undefined,
 	tokenStore: OAuthAccessTokenStore,
-): boolean {
-	if (!header) return false;
+): { ok: true; clientId: string } | { ok: false; reason: BearerDenyReason } {
+	if (!header) return { ok: false, reason: "missing_authorization_header" };
 	const [scheme, token, extra] = header.trim().split(/\s+/);
-	if (!scheme || !token || extra || scheme.toLowerCase() !== "bearer") return false;
-	return tokenStore.verifyToken(token) !== undefined;
+	if (!scheme || !token || extra || scheme.toLowerCase() !== "bearer") {
+		return { ok: false, reason: "malformed_authorization_header" };
+	}
+	const result = tokenStore.verifyToken(token);
+	if (!result.ok) return { ok: false, reason: result.reason };
+	return { ok: true, clientId: result.record.clientId };
 }
 
 function writeBearerUnauthorized(res: ServerResponse): void {

--- a/packages/mcp-server/src/oauth.test.ts
+++ b/packages/mcp-server/src/oauth.test.ts
@@ -174,8 +174,10 @@ describe("MCP OAuth metadata and dynamic client registration", () => {
 		if (token.status !== 200) throw new Error("expected token response");
 		expect(token.body).toMatchObject({ token_type: "Bearer", expires_in: 3600 });
 		expect(token.body.access_token).toMatch(/^[A-Za-z0-9_-]{43}$/);
-		expect(tokenStore.verifyToken(token.body.access_token)).toMatchObject({
-			clientId: registered.body.client_id,
+		const verification = tokenStore.verifyToken(token.body.access_token);
+		expect(verification).toMatchObject({
+			ok: true,
+			record: { clientId: registered.body.client_id },
 		});
 	});
 
@@ -558,14 +560,19 @@ describe("MCP OAuth metadata and dynamic client registration", () => {
 
 		expect(issued).toBeDefined();
 		if (!issued) throw new Error("expected access token");
-		expect(tokenStore.verifyToken(issued.token, 1_000)).toMatchObject({
-			clientId: "client-123",
-			lastUsedAt: 1_000,
-			revokedAt: null,
+		const firstVerify = tokenStore.verifyToken(issued.token, 1_000);
+		expect(firstVerify).toMatchObject({
+			ok: true,
+			record: { clientId: "client-123", lastUsedAt: 1_000, revokedAt: null },
 		});
-		expect(tokenStore.verifyToken(issued.token, 1_000)?.tokenHash).toMatch(/^[A-Za-z0-9_-]{43}$/);
-		expect(tokenStore.verifyToken(issued.token, 1_000)?.tokenHash).not.toBe(issued.token);
-		expect(tokenStore.verifyToken(issued.token, 1_000 + 60 * 60 * 1000 + 1)).toBeUndefined();
+		if (firstVerify.ok) {
+			expect(firstVerify.record.tokenHash).toMatch(/^[A-Za-z0-9_-]{43}$/);
+			expect(firstVerify.record.tokenHash).not.toBe(issued.token);
+		}
+		expect(tokenStore.verifyToken(issued.token, 1_000 + 60 * 60 * 1000 + 1)).toEqual({
+			ok: false,
+			reason: "expired_token",
+		});
 
 		const revocable = tokenStore.issueToken("client-456", 2_000);
 		if (!revocable) throw new Error("expected revocable access token");
@@ -575,7 +582,14 @@ describe("MCP OAuth metadata and dynamic client registration", () => {
 			status: 200,
 			body: {},
 		});
-		expect(tokenStore.verifyToken(revocable.token, 2_001)).toBeUndefined();
+		expect(tokenStore.verifyToken(revocable.token, 2_001)).toEqual({
+			ok: false,
+			reason: "revoked_token",
+		});
+		expect(tokenStore.verifyToken("entirely-bogus-token", 2_001)).toEqual({
+			ok: false,
+			reason: "unknown_token",
+		});
 	});
 });
 

--- a/packages/mcp-server/src/oauth.ts
+++ b/packages/mcp-server/src/oauth.ts
@@ -69,9 +69,13 @@ export interface AccessTokenRecord {
 	revokedAt: number | null;
 }
 
+export type AccessTokenVerificationResult =
+	| { ok: true; record: AccessTokenRecord }
+	| { ok: false; reason: "unknown_token" | "expired_token" | "revoked_token" };
+
 export interface OAuthAccessTokenStore {
 	issueToken(clientId: string, now?: number): { token: string; expiresIn: number } | undefined;
-	verifyToken(token: string, now?: number): AccessTokenRecord | undefined;
+	verifyToken(token: string, now?: number): AccessTokenVerificationResult;
 	revokeToken(token: string, now?: number): boolean;
 }
 
@@ -175,15 +179,18 @@ export class InMemoryOAuthAccessTokenStore implements OAuthAccessTokenStore {
 		};
 	}
 
-	verifyToken(token: string, now = Date.now()): AccessTokenRecord | undefined {
+	verifyToken(token: string, now = Date.now()): AccessTokenVerificationResult {
 		const tokenBytes = decodeOAuthAccessToken(token);
-		if (!tokenBytes) return undefined;
+		if (!tokenBytes) return { ok: false, reason: "unknown_token" };
 		const tokenHash = signOAuthAccessTokenBytes(tokenBytes, this.#tokenHashKey);
 		const record = this.#tokensByHash.get(tokenHash);
-		if (!record || !isSameTokenHash(record.tokenHash, tokenHash)) return undefined;
-		if (record.revokedAt !== null || record.expiresAt <= now) return undefined;
+		if (!record || !isSameTokenHash(record.tokenHash, tokenHash)) {
+			return { ok: false, reason: "unknown_token" };
+		}
+		if (record.revokedAt !== null) return { ok: false, reason: "revoked_token" };
+		if (record.expiresAt <= now) return { ok: false, reason: "expired_token" };
 		record.lastUsedAt = now;
-		return { ...record };
+		return { ok: true, record: { ...record } };
 	}
 
 	revokeToken(token: string, now = Date.now()): boolean {


### PR DESCRIPTION
## Description
Implements codemem-986p.16: structured OAuth audit events for the Phase 1 single-user remote MCP endpoint.

- New `packages/mcp-server/src/audit.ts`:
  - Discriminated `OAuthAuditEvent` (registration, authorize, oidc_callback, token, revocation, bearer)
  - `BearerDenyReason` enum for missing/malformed/unknown/expired/revoked headers
  - `buildOAuthAuditEvent` throws if any caller passes a forbidden field (`access_token`, `code`, `id_token`, `client_secret`, etc.) — defense against future regressions
  - `createDefaultOAuthAuditEmitter` writes one redacted JSON line per event to stderr; `CODEMEM_MCP_AUDIT=0|false|no` disables
- `OAuthAccessTokenStore.verifyToken` now returns a discriminated result with a bearer reason category instead of `undefined`
- `http.ts` wires audit emit calls into every OAuth code path and the bearer gate, including `clientId` and `remoteAddress` (never tokens/codes/secrets)
- `http.test.ts` adds an end-to-end audit-redaction test that exercises register / revoke / missing bearer / valid bearer and asserts no forbidden material appears in any serialized event

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:

- `pnpm exec vitest run packages/mcp-server/src` → 78 passed
- `pnpm run tsc`, `pnpm run lint`, `pnpm run test` → 109 files, 2016 tests passing

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
