### PR TITLE
feat(mcp): polish OAuth metadata and refresh audits

### DIFF
--- a/packages/mcp-server/src/audit.ts
+++ b/packages/mcp-server/src/audit.ts
@@ -12,6 +12,8 @@ export type OAuthAuditKind =
 	| "authorize"
 	| "oidc_callback"
 	| "token"
+	| "refresh"
+	| "rotation"
 	| "revocation"
 	| "bearer";
 

--- a/packages/mcp-server/src/http.test.ts
+++ b/packages/mcp-server/src/http.test.ts
@@ -152,13 +152,17 @@ describe("MCP HTTP transport", () => {
 			issuer: "https://codemem.example.test/",
 			registration_endpoint: "https://codemem.example.test/register",
 			code_challenge_methods_supported: ["S256"],
-			token_endpoint_auth_methods_supported: ["client_secret_post", "none"],
+			grant_types_supported: ["authorization_code", "refresh_token"],
+			token_endpoint_auth_methods_supported: ["none"],
+			revocation_endpoint: "https://codemem.example.test/revoke",
+			scopes_supported: ["memory:read", "memory:write"],
 		});
 		expect(protectedResourceMetadata.status).toBe(200);
 		expect(await protectedResourceMetadata.json()).toMatchObject({
 			resource: "https://codemem.example.test/mcp",
 			authorization_servers: ["https://codemem.example.test/"],
 			resource_name: "codemem MCP",
+			scopes_supported: ["memory:read", "memory:write"],
 		});
 	});
 
@@ -202,7 +206,7 @@ describe("MCP HTTP transport", () => {
 			redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
 			client_name: "Claude",
 			token_endpoint_auth_method: "none",
-			grant_types: ["authorization_code"],
+			grant_types: ["authorization_code", "refresh_token"],
 		});
 		expect(registered.client_id).toMatch(/[0-9a-f-]{36}/);
 		expect(registered.client_secret).toBeUndefined();

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -31,8 +31,12 @@ import {
 	createInMemoryOAuthAccessTokenStore,
 	createInMemoryOAuthAuthorizationCodeStore,
 	createInMemoryOAuthClientsStore,
+	createMcpOAuthMetadata,
+	createMcpProtectedResourceMetadata,
 	MCP_OAUTH_PUBLIC_URL_ENV,
 	MCP_OAUTH_RESOURCE_NAME,
+	MCP_OAUTH_SCOPES_SUPPORTED,
+	MCP_OAUTH_SERVICE_DOCUMENTATION_URL,
 	normalizeMcpPublicUrl,
 	type OAuthAccessTokenStore,
 } from "./oauth.js";
@@ -285,6 +289,7 @@ export async function startCodememMcpHttpServer(
 			clientId: completed.oauthParams.get("client_id") ?? "",
 			redirectUri: completed.oauthParams.get("redirect_uri") ?? "",
 			codeChallenge: completed.oauthParams.get("code_challenge") ?? "",
+			scopes: parseScopeList(completed.oauthParams.get("scope")),
 			...(completed.oauthParams.get("resource")
 				? { resource: completed.oauthParams.get("resource") ?? undefined }
 				: {}),
@@ -320,6 +325,13 @@ export async function startCodememMcpHttpServer(
 		res.redirect(302, redirect.href);
 	});
 
+	app.get("/.well-known/oauth-authorization-server", (_req, res) => {
+		res.status(200).json(createMcpOAuthMetadata({ mcpUrl: publicMcpUrl, clientsStore }));
+	});
+	app.get("/.well-known/oauth-protected-resource/mcp", (_req, res) => {
+		res.status(200).json(createMcpProtectedResourceMetadata(publicMcpUrl));
+	});
+
 	app.use(
 		mcpAuthRouter({
 			provider,
@@ -327,9 +339,10 @@ export async function startCodememMcpHttpServer(
 			baseUrl: issuerUrl,
 			resourceServerUrl: publicMcpUrlObject,
 			resourceName: MCP_OAUTH_RESOURCE_NAME,
+			scopesSupported: MCP_OAUTH_SCOPES_SUPPORTED,
+			serviceDocumentationUrl: new URL(MCP_OAUTH_SERVICE_DOCUMENTATION_URL),
 			clientRegistrationOptions: { clientSecretExpirySeconds: 0, rateLimit: false },
 			authorizationOptions: { rateLimit: false },
-			tokenOptions: { rateLimit: false },
 			revocationOptions: { rateLimit: false },
 		}),
 	);
@@ -497,8 +510,8 @@ function auditOAuthRouteResponses(
 	auditEmit: (event: ReturnType<typeof buildOAuthAuditEvent>) => void,
 ) {
 	return (req: Request, res: Response, next: NextFunction) => {
-		const kind = oauthAuditKindForPath(req.path);
-		if (!kind) return next();
+		const pathname = req.path;
+		if (!isAuditedOAuthPath(pathname)) return next();
 		let responseBody: unknown;
 		const originalJson = res.json.bind(res);
 		res.json = ((body: unknown) => {
@@ -506,7 +519,9 @@ function auditOAuthRouteResponses(
 			return originalJson(body);
 		}) as typeof res.json;
 		res.on("finish", () => {
-			if (req.path === "/oauth/callback") return;
+			if (pathname === "/oauth/callback") return;
+			const kind = oauthAuditKindForRequest(pathname, req);
+			if (!kind) return;
 			const error = getOAuthResponseError(res, responseBody);
 			const clientId = getRequestClientId(req, responseBody);
 			auditEmit(
@@ -520,6 +535,18 @@ function auditOAuthRouteResponses(
 		});
 		next();
 	};
+}
+
+function isAuditedOAuthPath(pathname: string): boolean {
+	return oauthAuditKindForPath(pathname) !== null;
+}
+
+function oauthAuditKindForRequest(
+	pathname: string,
+	req: Request,
+): "registration" | "authorize" | "token" | "refresh" | "revocation" | null {
+	if (pathname === "/token" && req.body?.grant_type === "refresh_token") return "refresh";
+	return oauthAuditKindForPath(pathname);
 }
 
 function oauthAuditKindForPath(
@@ -603,6 +630,15 @@ function getBearerPreflightDenyReason(
 	const verification = tokenStore.verifyToken(token);
 	if (!verification.ok) return verification.reason;
 	return null;
+}
+
+function parseScopeList(scope: string | null | undefined): string[] {
+	return (
+		scope
+			?.split(/\s+/)
+			.map((item) => item.trim())
+			.filter(Boolean) ?? []
+	);
 }
 
 function isEntrypoint(): boolean {

--- a/packages/mcp-server/src/oauth.test.ts
+++ b/packages/mcp-server/src/oauth.test.ts
@@ -29,12 +29,13 @@ describe("MCP OAuth metadata and dynamic client registration", () => {
 			issuer: "https://codemem.example.test/",
 			authorization_endpoint: "https://codemem.example.test/authorize",
 			token_endpoint: "https://codemem.example.test/token",
-			revocation_endpoint: "https://codemem.example.test/oauth/revoke",
+			revocation_endpoint: "https://codemem.example.test/revoke",
 			registration_endpoint: "https://codemem.example.test/register",
 			response_types_supported: ["code"],
-			grant_types_supported: ["authorization_code"],
+			grant_types_supported: ["authorization_code", "refresh_token"],
 			code_challenge_methods_supported: ["S256"],
 			token_endpoint_auth_methods_supported: ["none"],
+			scopes_supported: ["memory:read", "memory:write"],
 			client_id_metadata_document_supported: false,
 		});
 	});
@@ -43,8 +44,10 @@ describe("MCP OAuth metadata and dynamic client registration", () => {
 		expect(createMcpProtectedResourceMetadata("https://codemem.example.test/mcp")).toEqual({
 			resource: "https://codemem.example.test/mcp",
 			authorization_servers: ["https://codemem.example.test/"],
+			scopes_supported: ["memory:read", "memory:write"],
 			bearer_methods_supported: ["header"],
 			resource_name: "codemem MCP",
+			resource_documentation: "https://github.com/kunickiaj/codemem#readme",
 		});
 	});
 
@@ -82,7 +85,7 @@ describe("MCP OAuth metadata and dynamic client registration", () => {
 		expect(result.body.client_id).toMatch(/[0-9a-f-]{36}/);
 		expect(result.body.client_secret).toBeUndefined();
 		expect(result.body.token_endpoint_auth_method).toBe("none");
-		expect(result.body.grant_types).toEqual(["authorization_code"]);
+		expect(result.body.grant_types).toEqual(["authorization_code", "refresh_token"]);
 		expect(result.body.response_types).toEqual(["code"]);
 		expect(clientsStore.getClient(result.body.client_id)).toEqual(result.body);
 	});
@@ -589,6 +592,7 @@ describe("MCP OAuth metadata and dynamic client registration", () => {
 				clientId: registered.body.client_id,
 				redirectUri: "https://claude.ai/api/mcp/auth_callback",
 				codeChallenge: pkceS256("s".repeat(43)),
+				scopes: [],
 				expiresAt: Date.now() + 5 * 60 * 1000,
 				used: false,
 			}),

--- a/packages/mcp-server/src/oauth.ts
+++ b/packages/mcp-server/src/oauth.ts
@@ -17,6 +17,8 @@ import {
 
 export const MCP_OAUTH_PUBLIC_URL_ENV = "CODEMEM_MCP_HTTP_PUBLIC_URL";
 export const MCP_OAUTH_RESOURCE_NAME = "codemem MCP";
+export const MCP_OAUTH_SCOPES_SUPPORTED = ["memory:read", "memory:write"];
+export const MCP_OAUTH_SERVICE_DOCUMENTATION_URL = "https://github.com/kunickiaj/codemem#readme";
 
 const CLAUDE_HOSTED_CALLBACK = "https://claude.ai/api/mcp/auth_callback";
 const LOCAL_CALLBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
@@ -53,6 +55,7 @@ export interface AuthorizationCodeRecord {
 	clientId: string;
 	redirectUri: string;
 	codeChallenge: string;
+	scopes: string[];
 	resource?: string;
 	expiresAt: number;
 	used: boolean;
@@ -67,6 +70,7 @@ export interface OAuthAuthorizationCodeStore {
 export interface AccessTokenRecord {
 	clientId: string;
 	grantId?: string;
+	scopes: string[];
 	resource?: string;
 	tokenHash: string;
 	issuedAt: number;
@@ -85,6 +89,7 @@ export interface OAuthAccessTokenStore {
 		now?: number,
 		resource?: string,
 		grantId?: string,
+		scopes?: string[],
 	): { token: string; expiresIn: number } | undefined;
 	verifyToken(token: string, now?: number): AccessTokenVerificationResult;
 	revokeToken(token: string, now?: number): boolean;
@@ -153,6 +158,7 @@ export interface PreparedMcpOAuthAuthorizationRequest {
 	clientId: string;
 	redirectUri: string;
 	codeChallenge: string;
+	scopes: string[];
 	resource: string | null;
 	state: string | null;
 }
@@ -192,7 +198,7 @@ export class InMemoryOAuthClientsStore implements OAuthRegisteredClientsStore {
 		const registered = {
 			...client,
 			token_endpoint_auth_method: "none" as const,
-			grant_types: client.grant_types ?? ["authorization_code"],
+			grant_types: client.grant_types ?? ["authorization_code", "refresh_token"],
 			response_types: client.response_types ?? ["code"],
 			client_id: randomUUID(),
 			client_id_issued_at: Math.floor(Date.now() / 1000),
@@ -242,6 +248,7 @@ export class InMemoryOAuthAccessTokenStore implements OAuthAccessTokenStore {
 		now = Date.now(),
 		resource?: string,
 		grantId?: string,
+		scopes: string[] = [],
 	): { token: string; expiresIn: number } | undefined {
 		this.#deleteInactiveTokens(now);
 		if (this.#tokensByHash.size >= MAX_ACCESS_TOKENS) return undefined;
@@ -250,6 +257,7 @@ export class InMemoryOAuthAccessTokenStore implements OAuthAccessTokenStore {
 		this.#tokensByHash.set(tokenHash, {
 			clientId,
 			grantId,
+			scopes: [...scopes],
 			resource,
 			tokenHash,
 			issuedAt: now,
@@ -461,9 +469,11 @@ export function createMcpOAuthMetadata(options: McpOAuthMetadataOptions): OAuthM
 		}),
 		// Phase 1 treats claude.ai and local callback clients as public clients.
 		// Do not issue or advertise client secrets until we have a concrete need.
-		grant_types_supported: ["authorization_code"],
+		grant_types_supported: ["authorization_code", "refresh_token"],
 		token_endpoint_auth_methods_supported: ["none"],
-		revocation_endpoint: new URL("/oauth/revoke", issuerUrl).href,
+		scopes_supported: MCP_OAUTH_SCOPES_SUPPORTED,
+		service_documentation: MCP_OAUTH_SERVICE_DOCUMENTATION_URL,
+		revocation_endpoint: new URL("/revoke", issuerUrl).href,
 		revocation_endpoint_auth_methods_supported: ["none"],
 		client_id_metadata_document_supported: false,
 	};
@@ -474,8 +484,10 @@ export function createMcpProtectedResourceMetadata(mcpUrl: string): OAuthProtect
 	const metadata = {
 		resource: normalizedMcpUrl.href,
 		authorization_servers: [getOriginUrl(normalizedMcpUrl).href],
+		scopes_supported: MCP_OAUTH_SCOPES_SUPPORTED,
 		bearer_methods_supported: ["header"],
 		resource_name: MCP_OAUTH_RESOURCE_NAME,
+		resource_documentation: MCP_OAUTH_SERVICE_DOCUMENTATION_URL,
 	};
 	return OAuthProtectedResourceMetadataSchema.parse(metadata);
 }
@@ -522,7 +534,7 @@ export function registerMcpOAuthClient(
 	const registered = clientsStore.registerClient({
 		...clientMetadata,
 		token_endpoint_auth_method: "none",
-		grant_types: clientMetadata.grant_types ?? ["authorization_code"],
+		grant_types: clientMetadata.grant_types ?? ["authorization_code", "refresh_token"],
 		response_types: clientMetadata.response_types ?? ["code"],
 	});
 
@@ -549,6 +561,7 @@ export function authorizeMcpOAuthClient(
 			clientId: prepared.clientId,
 			redirectUri: prepared.redirectUri,
 			codeChallenge: prepared.codeChallenge,
+			scopes: prepared.scopes,
 			...(prepared.resource ? { resource: prepared.resource } : {}),
 			expiresAt: now + AUTHORIZATION_CODE_TTL_MS,
 		},
@@ -572,6 +585,7 @@ export function prepareMcpOAuthAuthorizationRequest(
 	const codeChallenge = params.get("code_challenge") ?? "";
 	const codeChallengeMethod = params.get("code_challenge_method") ?? "";
 	const resource = params.get("resource");
+	const scopes = parseScopeList(params.get("scope"));
 	const state = params.get("state");
 
 	if (responseType !== "code") return invalidOAuthRequest("unsupported_response_type");
@@ -588,7 +602,7 @@ export function prepareMcpOAuthAuthorizationRequest(
 		return invalidOAuthRequest("invalid_request", "redirect_uri is not registered for this client");
 	}
 
-	return { clientId, redirectUri, codeChallenge, resource, state };
+	return { clientId, redirectUri, codeChallenge, scopes, resource, state };
 }
 
 export function exchangeMcpOAuthAuthorizationCode(
@@ -636,7 +650,7 @@ export function exchangeMcpOAuthAuthorizationCode(
 		return invalidOAuthRequest("invalid_grant", "Code does not match resource");
 	}
 
-	const issued = tokenStore.issueToken(clientId, now, record.resource);
+	const issued = tokenStore.issueToken(clientId, now, record.resource, undefined, record.scopes);
 	if (!issued) {
 		// Token-store overload is transient: leave the auth code unused so the
 		// client can retry token exchange without restarting the OAuth flow.
@@ -730,6 +744,15 @@ function isLoopbackUrl(url: URL): boolean {
 
 function normalizeHostname(hostname: string): string {
 	return hostname.replace(/^\[(.*)]$/, "$1").toLowerCase();
+}
+
+function parseScopeList(scope: string | null | undefined): string[] {
+	return (
+		scope
+			?.split(/\s+/)
+			.map((item) => item.trim())
+			.filter(Boolean) ?? []
+	);
 }
 
 function invalidClientMetadata(description: string): McpOAuthRegistrationError {

--- a/packages/mcp-server/src/provider.test.ts
+++ b/packages/mcp-server/src/provider.test.ts
@@ -329,7 +329,7 @@ describe("MemoryOAuthServerProvider", () => {
 		const client = registerClient(clientsStore);
 		const initial = await provider.exchangeAuthorizationCode(
 			client,
-			issueCode(codeStore, client.client_id, PUBLIC_MCP_URL),
+			issueCode(codeStore, client.client_id, PUBLIC_MCP_URL, ["memory:read"]),
 			undefined,
 			REDIRECT_URI,
 			new URL(PUBLIC_MCP_URL),
@@ -441,7 +441,7 @@ describe("MemoryOAuthServerProvider", () => {
 		const otherClient = registerClient(clientsStore);
 		const initial = await provider.exchangeAuthorizationCode(
 			client,
-			issueCode(codeStore, client.client_id, PUBLIC_MCP_URL),
+			issueCode(codeStore, client.client_id, PUBLIC_MCP_URL, ["memory:read"]),
 			undefined,
 			REDIRECT_URI,
 			new URL(PUBLIC_MCP_URL),
@@ -477,6 +477,54 @@ describe("MemoryOAuthServerProvider", () => {
 			),
 		).rejects.toThrow(/resource/i);
 	});
+
+	it("treats Claude _access scopes as no-op aliases during refresh", async () => {
+		const clientsStore = createInMemoryOAuthClientsStore();
+		const codeStore = createInMemoryOAuthAuthorizationCodeStore();
+		const provider = new MemoryOAuthServerProvider({
+			clientsStore,
+			codeStore,
+			tokenStore: createInMemoryOAuthAccessTokenStore(),
+			publicMcpUrl: PUBLIC_MCP_URL,
+			now: () => NOW,
+		});
+		const client = registerClient(clientsStore);
+		const initial = await provider.exchangeAuthorizationCode(
+			client,
+			issueCode(codeStore, client.client_id, undefined, ["memory:read"]),
+			undefined,
+			REDIRECT_URI,
+		);
+		if (!initial.refresh_token) throw new Error("expected refresh token");
+
+		await expect(
+			provider.exchangeRefreshToken(client, initial.refresh_token, ["memory:read_access"]),
+		).resolves.toMatchObject({ token_type: "Bearer" });
+	});
+
+	it("normalizes Claude _access aliases before issuing refresh grants", async () => {
+		const clientsStore = createInMemoryOAuthClientsStore();
+		const codeStore = createInMemoryOAuthAuthorizationCodeStore();
+		const provider = new MemoryOAuthServerProvider({
+			clientsStore,
+			codeStore,
+			tokenStore: createInMemoryOAuthAccessTokenStore(),
+			publicMcpUrl: PUBLIC_MCP_URL,
+			now: () => NOW,
+		});
+		const client = registerClient(clientsStore);
+		const initial = await provider.exchangeAuthorizationCode(
+			client,
+			issueCode(codeStore, client.client_id, undefined, ["memory:read_access"]),
+			undefined,
+			REDIRECT_URI,
+		);
+		if (!initial.refresh_token) throw new Error("expected refresh token");
+
+		await expect(
+			provider.exchangeRefreshToken(client, initial.refresh_token, ["memory:read"]),
+		).resolves.toMatchObject({ token_type: "Bearer" });
+	});
 });
 
 function registerClient(clientsStore: ReturnType<typeof createInMemoryOAuthClientsStore>) {
@@ -492,12 +540,14 @@ function issueCode(
 	codeStore: ReturnType<typeof createInMemoryOAuthAuthorizationCodeStore>,
 	clientId: string,
 	resource?: string,
+	scopes: string[] = [],
 ): string {
 	const code = codeStore.issueCode(
 		{
 			clientId,
 			redirectUri: REDIRECT_URI,
 			codeChallenge: CODE_CHALLENGE,
+			scopes,
 			...(resource ? { resource } : {}),
 			expiresAt: NOW + 5 * 60 * 1000,
 		},
@@ -527,6 +577,7 @@ function raceLostCodeStore(clientId: string): OAuthAuthorizationCodeStore {
 			clientId,
 			redirectUri: REDIRECT_URI,
 			codeChallenge: CODE_CHALLENGE,
+			scopes: [],
 			expiresAt: NOW + 5 * 60 * 1000,
 			used: false,
 		}),

--- a/packages/mcp-server/src/provider.ts
+++ b/packages/mcp-server/src/provider.ts
@@ -160,8 +160,9 @@ export class MemoryOAuthServerProvider implements OAuthServerProvider {
 			throw new InvalidGrantError("Code does not match resource");
 		}
 
+		const scopes = normalizeClientScopes(record.scopes) ?? [];
 		const grant = this.#refreshTokenStore.issueGrant(
-			{ clientId: client.client_id, resource: record.resource },
+			{ clientId: client.client_id, scopes, resource: record.resource },
 			now,
 		);
 		if (!grant) {
@@ -172,6 +173,7 @@ export class MemoryOAuthServerProvider implements OAuthServerProvider {
 			now,
 			record.resource,
 			grant.grant.grantId,
+			scopes,
 		);
 		if (!issued) {
 			// Token-store overload is transient: leave the auth code unused so the
@@ -208,7 +210,7 @@ export class MemoryOAuthServerProvider implements OAuthServerProvider {
 		const rotation = this.#refreshTokenStore.rotateRefreshToken(
 			client.client_id,
 			refreshToken,
-			{ scopes, ...(resource ? { resource: resource.href } : {}) },
+			{ scopes: normalizeClientScopes(scopes), ...(resource ? { resource: resource.href } : {}) },
 			now,
 		);
 		if (!rotation.ok) {
@@ -222,6 +224,7 @@ export class MemoryOAuthServerProvider implements OAuthServerProvider {
 			now,
 			rotation.grant.resource,
 			rotation.grant.grantId,
+			rotation.grant.scopes,
 		);
 		if (!issued) throw new TemporarilyUnavailableError("Too many active access tokens");
 		return OAuthTokensSchema.parse({
@@ -246,7 +249,7 @@ export class MemoryOAuthServerProvider implements OAuthServerProvider {
 		const authInfo: AuthInfo = {
 			token,
 			clientId: result.record.clientId,
-			scopes: [],
+			scopes: result.record.scopes,
 			expiresAt: Math.floor(result.record.expiresAt / 1000),
 		};
 		if (result.record.resource) {
@@ -320,4 +323,16 @@ function refreshTokenErrorDescription(reason: string): string {
 		default:
 			return "Invalid refresh token";
 	}
+}
+
+function normalizeClientScopes(scopes: string[] | undefined): string[] | undefined {
+	const normalized = scopes
+		?.map((scope) => scope.trim())
+		.filter(Boolean)
+		.map((scope) => {
+			if (scope === "memory:read_access") return "memory:read";
+			if (scope === "memory:write_access") return "memory:write";
+			return scope;
+		});
+	return normalized && normalized.length > 0 ? normalized : undefined;
 }


### PR DESCRIPTION
## Description
Polishes the SDK OAuth migration metadata, audit, and revocation surfaces.

Key points:
- Overrides SDK-generated metadata so authorization-server discovery advertises public-client auth only (`none`).
- Advertises refresh-token grant support, `/revoke`, memory scopes, and service documentation.
- Adds scopes/docs to protected-resource metadata.
- Restores SDK default `/token` rate limiting by no longer disabling `tokenOptions.rateLimit`.
- Classifies refresh-token grant audits separately from authorization-code token audits.
- Keeps SDK runtime ownership of `/register`, `/authorize`, `/token`, `/revoke`; custom routes only override metadata.
- Defaults dynamic client registration to include `refresh_token`.
- Maps known Claude `_access` scope aliases explicitly (`memory:read_access`, `memory:write_access`).

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation run:
- `pnpm run lint`
- `pnpm run tsc`
- `pnpm exec vitest run packages/mcp-server/src/http.test.ts packages/mcp-server/src/oauth.test.ts packages/mcp-server/src/provider.test.ts packages/mcp-server/src/audit.test.ts`
- `pnpm run test`
- CodeReviewer re-review: no blockers

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced

Docs are deferred to the final remote MCP OAuth docs/release validation slice.