### PR TITLE
fix(ui): preserve Projects Space interactions

### DIFF
--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -4,6 +4,8 @@ vi.mock("../lib/api", () => ({
 	deleteSharingDomainProjectMapping: vi.fn(),
 	forgetProjectInventoryMemories: vi.fn(),
 	loadProjects: vi.fn(),
+	loadCoordinatorAdminGroupsFiltered: vi.fn(),
+	loadCoordinatorAdminStatus: vi.fn(),
 	loadProjectScopeInventory: vi.fn(),
 	loadSharingDomainSettings: vi.fn(),
 	reassignProjectInventoryProject: vi.fn(),
@@ -89,12 +91,25 @@ function mountProjectsDom() {
 	`;
 }
 
+async function flushAsyncWork() {
+	for (let i = 0; i < 5; i += 1) {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+}
+
 describe("Projects tab", () => {
 	beforeEach(() => {
 		mountProjectsDom();
 		state.lastCoordinatorAdminGroups = [
 			{ archived_at: null, display_name: "ExampleCo Team", group_id: "exampleco" },
 		];
+		vi.mocked(api.loadCoordinatorAdminStatus).mockResolvedValue({
+			has_admin_secret: true,
+			readiness: "ready",
+		});
+		vi.mocked(api.loadCoordinatorAdminGroupsFiltered).mockResolvedValue({
+			items: [{ archived_at: null, display_name: "ExampleCo Team", group_id: "exampleco" }],
+		});
 		vi.mocked(api.loadSharingDomainSettings).mockResolvedValue({
 			local_default_scope_id: "local-default",
 			mappings: [],
@@ -167,6 +182,163 @@ describe("Projects tab", () => {
 		expect(api.loadProjectScopeInventory).toHaveBeenCalledWith(
 			expect.objectContaining({ limit: 250 }),
 		);
+	});
+
+	it("does not reload inventory while a Space select is active", async () => {
+		const refresh = vi.fn();
+		initProjectsTab(refresh);
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		});
+		await loadProjectsData();
+		await flushAsyncWork();
+		const select = document.querySelector(".project-domain-select") as HTMLSelectElement | null;
+		if (!select) throw new Error("project Space select missing");
+		select.focus();
+		vi.clearAllMocks();
+
+		await loadProjectsData();
+
+		expect(api.loadProjectScopeInventory).not.toHaveBeenCalled();
+		expect(api.loadSharingDomainSettings).not.toHaveBeenCalled();
+		expect(api.loadCoordinatorAdminGroupsFiltered).not.toHaveBeenCalled();
+		expect(document.activeElement).toBe(select);
+
+		select.blur();
+		expect(refresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("replays skipped refresh when a focused cluster Space select blurs", async () => {
+		const refresh = vi.fn();
+		initProjectsTab(refresh);
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [
+				project({ cwd: "/workspace/a", memory_count: 2, session_count: 1 }),
+				project({
+					cwd: "/tmp/worktree-a",
+					memory_count: 3,
+					session_count: 2,
+					workspace_identity: "https://git.example.invalid/exampleco/api.git:worktree",
+				}),
+			],
+			total: 2,
+		});
+		await loadProjectsData();
+		await flushAsyncWork();
+		const select = document.querySelector(
+			".project-inventory-cluster > .project-inventory-actions .project-domain-select",
+		) as HTMLSelectElement | null;
+		if (!select) throw new Error("cluster Space select missing");
+		select.focus();
+		vi.clearAllMocks();
+
+		await loadProjectsData();
+		expect(document.body.textContent).not.toContain("Team: ExampleCo Team");
+		await flushAsyncWork();
+		expect(api.loadProjectScopeInventory).not.toHaveBeenCalled();
+
+		select.blur();
+		expect(refresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("refreshes active Team names and ignores archived Teams for Space labels", async () => {
+		state.lastCoordinatorAdminGroups = [
+			{ archived_at: "2026-05-01T00:00:00Z", display_name: "Old Team", group_id: "old" },
+		];
+		vi.mocked(api.loadCoordinatorAdminGroupsFiltered).mockResolvedValue({
+			items: [
+				{ archived_at: null, display_name: "ExampleCo Team", group_id: "exampleco" },
+				{ archived_at: "2026-05-01T00:00:00Z", display_name: "Old Team", group_id: "old" },
+			],
+		});
+		vi.mocked(api.loadSharingDomainSettings).mockResolvedValue({
+			local_default_scope_id: "local-default",
+			mappings: [],
+			projects: [],
+			scopes: [
+				{
+					authority_type: "coordinator",
+					group_id: "exampleco",
+					kind: "team",
+					label: "ExampleCo Work",
+					scope_id: "exampleco-work",
+					status: "active",
+				},
+				{
+					authority_type: "coordinator",
+					group_id: "old",
+					kind: "team",
+					label: "Old Work",
+					scope_id: "old-work",
+					status: "active",
+				},
+			],
+		});
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [
+				project({ resolved_scope_id: "exampleco-work" }),
+				project({
+					display_project: "old-api",
+					git_remote: "https://git.example.invalid/old/api.git",
+					project: "old-api",
+					resolved_scope_id: "old-work",
+					workspace_identity: "https://git.example.invalid/old/api.git",
+				}),
+			],
+			total: 2,
+		});
+
+		await loadProjectsData();
+		expect(document.body.textContent).not.toContain("Team: ExampleCo Team");
+		await flushAsyncWork();
+
+		expect(api.loadCoordinatorAdminGroupsFiltered).toHaveBeenCalledWith(false);
+		expect(document.body.textContent).toContain("Team: ExampleCo Team");
+		expect(document.body.textContent).not.toContain("Team: Old Team");
+		expect(document.body.textContent).toContain("Team details unavailable");
+		const enabledOptionLabels = Array.from(document.querySelectorAll("option:not(:disabled)")).map(
+			(option) => option.textContent,
+		);
+		expect(enabledOptionLabels).toContain("ExampleCo Work");
+		expect(enabledOptionLabels).not.toContain("Old Work");
+	});
+
+	it("renders inventory before coordinator Team name refresh finishes", async () => {
+		let resolveStatus: (value: unknown) => void = () => {};
+		vi.mocked(api.loadCoordinatorAdminStatus).mockReturnValue(
+			new Promise((resolve) => {
+				resolveStatus = resolve;
+			}),
+		);
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [project({ resolved_scope_id: "exampleco-work" })],
+			total: 1,
+		});
+
+		await loadProjectsData();
+
+		expect(document.getElementById("projectsInventoryMeta")?.textContent).toContain(
+			"1 project identity found",
+		);
+		expect(api.loadCoordinatorAdminGroupsFiltered).not.toHaveBeenCalled();
+
+		resolveStatus({ has_admin_secret: true, readiness: "ready" });
+		await flushAsyncWork();
+
+		expect(api.loadCoordinatorAdminGroupsFiltered).toHaveBeenCalledWith(false);
 	});
 
 	it("clusters related project identities and bulk assigns the group", async () => {
@@ -600,8 +772,10 @@ describe("Projects tab", () => {
 
 		const nextSelect = document.querySelector(".project-domain-select") as HTMLSelectElement | null;
 		if (!nextSelect) throw new Error("select missing after refresh");
+		nextSelect.focus();
 		nextSelect.value = "local-default";
 		nextSelect.dispatchEvent(new Event("change"));
+		expect(document.body.textContent).not.toContain("I understand, save Space");
 		staleConfirm?.click();
 		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledTimes(1);
 		await loadProjectsData();

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -35,6 +35,8 @@ const pendingForgetConfirmations = new Map<
 	string,
 	{ confirmationToken: string; localOwnedMemoryCount: number; peerOwnedMemoryCount: number }
 >();
+let skippedProjectRefreshForActiveSelect = false;
+let coordinatorGroupNamesCurrent = false;
 
 function el<T extends HTMLElement>(id: string): T | null {
 	return document.getElementById(id) as T | null;
@@ -84,9 +86,69 @@ function teamName(groupId: string | null | undefined): string | null {
 	const normalized = String(groupId || "").trim();
 	if (!normalized) return null;
 	const group = state.lastCoordinatorAdminGroups.find(
-		(item) => String(item.group_id || "").trim() === normalized,
+		(item) => String(item.group_id || "").trim() === normalized && !item.archived_at,
 	);
 	return group?.display_name || "Team details unavailable";
+}
+
+function knownActiveCoordinatorGroupIds(): Set<string> {
+	return new Set(
+		state.lastCoordinatorAdminGroups
+			.filter((item) => !item.archived_at)
+			.map((item) => String(item.group_id || "").trim())
+			.filter(Boolean),
+	);
+}
+
+function isFromKnownInactiveCoordinatorGroup(scope: SharingDomainScope): boolean {
+	if (!coordinatorGroupNamesCurrent || scope.authority_type !== "coordinator" || !scope.group_id) {
+		return false;
+	}
+	return !knownActiveCoordinatorGroupIds().has(String(scope.group_id).trim());
+}
+
+function isProjectSpaceSelectActive(): boolean {
+	const active = document.activeElement;
+	return active instanceof HTMLSelectElement && active.classList.contains("project-domain-select");
+}
+
+function refreshSkippedProjectDataAfterSelectBlur() {
+	if (!skippedProjectRefreshForActiveSelect) return;
+	skippedProjectRefreshForActiveSelect = false;
+	refreshProjects?.();
+}
+
+async function refreshProjectCoordinatorGroupNames(): Promise<void> {
+	try {
+		const status = await api.loadCoordinatorAdminStatus();
+		state.lastCoordinatorAdminStatus =
+			status && typeof status === "object"
+				? (status as typeof state.lastCoordinatorAdminStatus)
+				: null;
+	} catch {
+		state.lastCoordinatorAdminStatus = null;
+		state.lastCoordinatorAdminGroups = [];
+		coordinatorGroupNamesCurrent = false;
+		return;
+	}
+	if (
+		state.lastCoordinatorAdminStatus?.readiness !== "ready" ||
+		!state.lastCoordinatorAdminStatus.has_admin_secret
+	) {
+		state.lastCoordinatorAdminGroups = [];
+		coordinatorGroupNamesCurrent = false;
+		return;
+	}
+	try {
+		const payload = (await api.loadCoordinatorAdminGroupsFiltered(false)) as {
+			items?: typeof state.lastCoordinatorAdminGroups;
+		};
+		state.lastCoordinatorAdminGroups = Array.isArray(payload?.items) ? payload.items : [];
+		coordinatorGroupNamesCurrent = true;
+	} catch {
+		state.lastCoordinatorAdminGroups = [];
+		coordinatorGroupNamesCurrent = false;
+	}
 }
 
 function isDefaultTeamSpace(scope: SharingDomainScope): boolean {
@@ -126,7 +188,10 @@ function scopeSummary(scopeId: string | null | undefined): string {
 }
 
 function assignableScopes(): SharingDomainScope[] {
-	return scopes.filter((scope) => scope.scope_id !== "legacy-shared-review");
+	return scopes.filter(
+		(scope) =>
+			scope.scope_id !== "legacy-shared-review" && !isFromKnownInactiveCoordinatorGroup(scope),
+	);
 }
 
 function isAssignableScopeId(scopeId: string | null | undefined): boolean {
@@ -402,10 +467,12 @@ function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElemen
 	select.addEventListener("change", () => {
 		draftDomainSelections.set(project.workspace_identity, select.value);
 		pendingConfirmations.delete(project.workspace_identity);
+		actions.querySelector(".project-space-guardrail-confirmation")?.remove();
 		save.textContent = "Save Space";
 		save.disabled = !select.value;
 		refreshProjects?.();
 	});
+	select.addEventListener("blur", refreshSkippedProjectDataAfterSelectBlur);
 
 	const keepLocal = document.createElement("button");
 	keepLocal.className = "settings-button";
@@ -440,7 +507,8 @@ function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElemen
 	const pending = pendingConfirmations.get(project.workspace_identity);
 	if (pending) {
 		const warningBox = document.createElement("div");
-		warningBox.className = "settings-note project-guardrail-confirmation";
+		warningBox.className =
+			"settings-note project-guardrail-confirmation project-space-guardrail-confirmation";
 		warningBox.setAttribute("role", "alert");
 		const title = document.createElement("strong");
 		title.textContent = "Confirmation required before saving this Space.";
@@ -667,6 +735,7 @@ function renderProjectCluster(projects: ProjectScopeInventoryProject[]): HTMLEle
 	select.addEventListener("change", () => {
 		save.disabled = !select.value || hasGuardrailWarnings;
 	});
+	select.addEventListener("blur", refreshSkippedProjectDataAfterSelectBlur);
 	actions.append(select, save);
 	if (suggestedScopes.size > 1 || resolvedScopes.size > 1 || hasGuardrailWarnings) {
 		const note = document.createElement("div");
@@ -714,10 +783,53 @@ function renderEmpty(message: string) {
 	list.appendChild(empty);
 }
 
+function renderProjectInventory(result: {
+	projects: ProjectScopeInventoryProject[];
+	total: number;
+	offset: number;
+	has_more: boolean;
+}) {
+	const meta = el<HTMLDivElement>("projectsInventoryMeta");
+	const list = el<HTMLDivElement>("projectsInventoryList");
+	if (!meta || !list) return;
+	list.textContent = "";
+	if (result.projects.length === 0) {
+		renderEmpty("No projects match those filters.");
+	} else {
+		for (const cluster of projectClusters(result.projects))
+			list.appendChild(renderProjectCluster(cluster));
+	}
+	meta.textContent =
+		result.total === 0
+			? "0 project identities found"
+			: `${result.total} project identit${result.total === 1 ? "y" : "ies"} found · showing ${result.offset + 1}-${Math.min(result.offset + result.projects.length, result.total)}`;
+	const prev = el<HTMLButtonElement>("projectsPrevPage");
+	const next = el<HTMLButtonElement>("projectsNextPage");
+	if (prev) prev.disabled = result.offset === 0;
+	if (next) next.disabled = !result.has_more;
+}
+
+function refreshProjectCoordinatorGroupNamesInBackground(result: {
+	projects: ProjectScopeInventoryProject[];
+	total: number;
+	offset: number;
+	has_more: boolean;
+}) {
+	void refreshProjectCoordinatorGroupNames().then(() => {
+		if (isProjectSpaceSelectActive()) return;
+		renderProjectInventory(result);
+	});
+}
+
 export async function loadProjectsData() {
 	const meta = el<HTMLDivElement>("projectsInventoryMeta");
 	const list = el<HTMLDivElement>("projectsInventoryList");
 	if (!meta || !list) return;
+	if (isProjectSpaceSelectActive()) {
+		skippedProjectRefreshForActiveSelect = true;
+		return;
+	}
+	skippedProjectRefreshForActiveSelect = false;
 	meta.textContent = "Loading project inventory…";
 	try {
 		const [result, settings] = await Promise.all([
@@ -730,21 +842,8 @@ export async function loadProjectsData() {
 			api.loadSharingDomainSettings(),
 		]);
 		scopes = settings.scopes;
-		list.textContent = "";
-		if (result.projects.length === 0) {
-			renderEmpty("No projects match those filters.");
-		} else {
-			for (const cluster of projectClusters(result.projects))
-				list.appendChild(renderProjectCluster(cluster));
-		}
-		meta.textContent =
-			result.total === 0
-				? "0 project identities found"
-				: `${result.total} project identit${result.total === 1 ? "y" : "ies"} found · showing ${result.offset + 1}-${Math.min(result.offset + result.projects.length, result.total)}`;
-		const prev = el<HTMLButtonElement>("projectsPrevPage");
-		const next = el<HTMLButtonElement>("projectsNextPage");
-		if (prev) prev.disabled = result.offset === 0;
-		if (next) next.disabled = !result.has_more;
+		renderProjectInventory(result);
+		refreshProjectCoordinatorGroupNamesInBackground(result);
 	} catch (error) {
 		meta.textContent = "Project inventory failed to load.";
 		renderEmpty(error instanceof Error ? error.message : "Unable to load project inventory.");


### PR DESCRIPTION
## Description
Fixes Projects tab Space assignment interactions so background refreshes do not close focused Space dropdowns. Also refreshes active Team metadata before rendering Space labels and prevents archived Team Spaces from appearing as enabled assignment options when current Team data is available.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated locally with:
- `pnpm exec vitest run packages/ui/src/tabs/projects.test.ts`
- `pnpm exec tsc --build packages/ui/tsconfig.json --pretty false`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced