### PR TITLE
fix(mcp): externalize Express in HTTP bundle

### DIFF
--- a/packages/mcp-server/vite.config.ts
+++ b/packages/mcp-server/vite.config.ts
@@ -19,7 +19,14 @@ export default defineConfig({
 			fileName: (_format, entryName) => `${entryName}.js`,
 		},
 		rollupOptions: {
-			external: [/^@codemem\//, /^node:/, /^@modelcontextprotocol\//, "zod", "better-sqlite3"],
+			external: [
+				/^@codemem\//,
+				/^node:/,
+				/^@modelcontextprotocol\//,
+				/^express(?:\/.*)?$/,
+				"zod",
+				"better-sqlite3",
+			],
 		},
 		outDir: "dist",
 		sourcemap: true,


### PR DESCRIPTION
## Description
Externalizes Express from the MCP HTTP build so published/built artifacts do not bundle Express CommonJS internals into the ESM HTTP entrypoint.

This fixes installed `codemem mcp http --public-url ...` startup failures caused by Rolldown emitting a runtime `require("node:events")` shim inside `@codemem/mcp/http`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm --filter @codemem/mcp typecheck`, `pnpm run lint`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation:
- `pnpm --filter @codemem/mcp build`
- `pnpm --filter codemem build`
- `pnpm exec vitest run packages/mcp-server/src/http.test.ts` — 22 passed
- Built CLI smoke: `node packages/cli/dist/index.js mcp http --port 0 --public-url ...`
- Temp packed-install smoke: packed core/mcp/server/cli artifacts, installed them, and verified installed `codemem mcp http --public-url ...` starts successfully

Note: `pnpm --filter codemem test:packed-artifact` currently fails on an unrelated existing assertion that the CLI tarball is missing `.opencode/plugins/codemem.js`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
