### PR TITLE
fix(cli): align packed artifact smoke with CLI package

### DIFF
--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -2,7 +2,6 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
 
 const packageRoot = process.cwd();
 const workspaceRoot = resolve(packageRoot, "..", "..");
@@ -69,36 +68,17 @@ try {
 	assert(existsSync(packedTarball), `Packed tarball not found: ${packedTarball}`);
 
 	const tarListing = run("tar", ["-tf", packedTarball]).stdout;
-	assert(
-		tarListing.includes("package/.opencode/plugins/codemem.js"),
-		"Packed artifact is missing .opencode/plugins/codemem.js",
-	);
-	assert(
-		tarListing.includes("package/.opencode/lib/compat.js"),
-		"Packed artifact is missing .opencode/lib/compat.js",
-	);
-	assert(
-		tarListing.includes("package/.opencode/package.json"),
-		"Packed artifact is missing .opencode/package.json",
-	);
+	assert(tarListing.includes("package/dist/index.js"), "Packed artifact is missing dist/index.js");
 	assert(tarListing.includes("package/README.md"), "Packed artifact is missing README.md");
 
 	const installDir = join(tempDir, "install");
 	run("npm", ["install", "--prefix", installDir, coreTarball, mcpTarball, serverTarball, packedTarball]);
 
 	const installedPackageRoot = join(installDir, "node_modules", "codemem");
-	const installedPluginRoot = join(installedPackageRoot, ".opencode");
 	const cliBin = join(installDir, "node_modules", ".bin", process.platform === "win32" ? "codemem.cmd" : "codemem");
 
 	assert(existsSync(cliBin), "Installed artifact is missing the codemem binary");
-	assert(
-		existsSync(join(installedPluginRoot, "plugins", "codemem.js")),
-		"Installed artifact is missing .opencode/plugins/codemem.js",
-	);
-	assert(
-		existsSync(join(installedPluginRoot, "package.json")),
-		"Installed artifact is missing .opencode/package.json",
-	);
+	assert(existsSync(join(installedPackageRoot, "dist", "index.js")), "Installed artifact is missing dist/index.js");
 	assert(
 		existsSync(join(installedPackageRoot, "README.md")),
 		"Installed artifact is missing README.md",
@@ -109,22 +89,6 @@ try {
 
 	const versionOutput = run(cliBin, ["version"]).stdout.trim();
 	assert(versionOutput === packageVersion, `Installed CLI reported ${versionOutput}, expected ${packageVersion}`);
-
-	run("npm", ["install", "--prefix", installedPluginRoot, "--no-save"]);
-	const installedPluginPackage = JSON.parse(
-		readFileSync(resolve(installedPluginRoot, "node_modules", "@opencode-ai", "plugin", "package.json"), "utf8"),
-	);
-	assert(
-		installedPluginPackage.version === "1.2.27",
-		`Installed plugin runtime version was ${installedPluginPackage.version}, expected 1.2.27`,
-	);
-	const pluginModuleUrl = pathToFileURL(join(installedPluginRoot, "plugins", "codemem.js")).href;
-	run(process.execPath, [
-		"--input-type=module",
-		"-e",
-		"const mod = await import(process.argv[1]); if (!mod.default) throw new Error('plugin default export missing');",
-		pluginModuleUrl,
-	]);
 } finally {
 	rmSync(tempDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Description
Updates the `codemem` CLI packed-artifact smoke test to match the current package split: the CLI package should validate CLI files and behavior, while `@codemem/opencode-plugin` owns plugin artifact validation.

This removes stale assertions that expected `.opencode/**` plugin files inside the CLI tarball after the plugin moved to a dedicated package in #428.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation:
- `pnpm run build`
- `pnpm --filter codemem test:packed-artifact`
- `pnpm --filter @codemem/opencode-plugin test:packed-artifact`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
