### PR TITLE
fix(mcp): trust loopback proxy for OAuth rate limits

### DIFF
--- a/packages/mcp-server/src/http.test.ts
+++ b/packages/mcp-server/src/http.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync } from "node:fs";
 import { request } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OAuthAuditEvent } from "./audit.js";
 import {
 	type CodememMcpHttpServer,
@@ -265,6 +265,39 @@ describe("MCP HTTP transport", () => {
 		expect(register.status).toBe(403);
 		expect(authorize.status).toBe(403);
 		expect(token.status).toBe(403);
+	});
+
+	it("accepts proxied OAuth token requests without rate-limit trust-proxy warnings", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const server = await startCodememMcpHttpServer({
+				dbPath: tempDbPath(),
+				port: 0,
+				publicUrl: "https://codemem.example.test/mcp",
+			});
+			servers.push(server);
+
+			const response = await fetch(server.url.replace("/mcp", "/token"), {
+				method: "POST",
+				headers: {
+					"content-type": "application/x-www-form-urlencoded",
+					"x-forwarded-for": "203.0.113.10",
+				},
+				body: new URLSearchParams({
+					client_id: "missing-client",
+					grant_type: "refresh_token",
+					refresh_token: "missing-refresh-token",
+				}),
+			});
+
+			expect(response.status).toBe(400);
+			expect(await response.json()).toMatchObject({ error: "invalid_client" });
+			expect(consoleError).not.toHaveBeenCalledWith(
+				expect.objectContaining({ code: "ERR_ERL_UNEXPECTED_X_FORWARDED_FOR" }),
+			);
+		} finally {
+			consoleError.mockRestore();
+		}
 	});
 
 	it("rejects public OAuth requests with non-public Host headers", async () => {

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -211,6 +211,10 @@ export async function startCodememMcpHttpServer(
 
 	const app = express();
 	app.disable("x-powered-by");
+	// Tailscale Funnel and similar local ingress proxies forward from loopback and
+	// add X-Forwarded-For. Trust only loopback proxy hops so SDK rate limiters can
+	// key on the real client IP without making public clients spoofable.
+	app.set("trust proxy", "loopback");
 	const server = createServer(app);
 
 	await new Promise<void>((resolve, reject) => {
@@ -341,9 +345,7 @@ export async function startCodememMcpHttpServer(
 			resourceName: MCP_OAUTH_RESOURCE_NAME,
 			scopesSupported: MCP_OAUTH_SCOPES_SUPPORTED,
 			serviceDocumentationUrl: new URL(MCP_OAUTH_SERVICE_DOCUMENTATION_URL),
-			clientRegistrationOptions: { clientSecretExpirySeconds: 0, rateLimit: false },
-			authorizationOptions: { rateLimit: false },
-			revocationOptions: { rateLimit: false },
+			clientRegistrationOptions: { clientSecretExpirySeconds: 0 },
 		}),
 	);
 


### PR DESCRIPTION
## Description
Keeps MCP OAuth SDK rate limiting enabled for public OAuth endpoints while allowing Tailscale Funnel / local reverse-proxy requests that include `X-Forwarded-For`.

Express now trusts only loopback proxy hops (`trust proxy = loopback`), which lets `express-rate-limit` key on the forwarded client IP without making arbitrary public clients spoofable. This removes the `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` stderr warning seen behind Funnel and avoids the unsafe alternative of disabling `/token` rate limits.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm --filter @codemem/mcp typecheck`, `pnpm run lint`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation:
- `pnpm exec vitest run packages/mcp-server/src/http.test.ts` — 23 passed

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
