### PR TITLE
fix(core): allow no-auth custom observer endpoints

### DIFF
--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -961,6 +961,226 @@ describe("ObserverClient.observe()", () => {
 		expect(result.provider).toBe("openai");
 	});
 
+	it("allows no-auth calls to explicit OpenAI-compatible base URLs", async () => {
+		let capturedUrl: string | undefined;
+		let capturedHeaders: Record<string, string> | undefined;
+
+		globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			capturedUrl = String(input);
+			capturedHeaders = Object.fromEntries(
+				Object.entries((init?.headers as Record<string, string>) ?? {}),
+			);
+			return new Response(
+				JSON.stringify({
+					choices: [{ message: { content: "local model response" } }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof globalThis.fetch;
+
+		const client = new ObserverClient({
+			observerProvider: "lms-200",
+			observerModel: "qwopus-glm-18b-merged",
+			observerRuntime: "api_http",
+			observerApiKey: null,
+			observerBaseUrl: "http://127.0.0.1:1234/v1",
+			observerMaxChars: 12_000,
+			observerMaxTokens: 4_000,
+			observerHeaders: {},
+			observerAuthSource: "none",
+			observerAuthFile: null,
+			observerAuthCommand: [],
+			observerAuthTimeoutMs: 1500,
+			observerAuthCacheTtlS: 300,
+		});
+
+		const result = await client.observe("system", "user");
+
+		expect(capturedUrl).toBe("http://127.0.0.1:1234/v1/chat/completions");
+		expect(capturedHeaders?.authorization).toBeUndefined();
+		expect(result.raw).toBe("local model response");
+	});
+
+	it("parses OpenAI-compatible chat content blocks", async () => {
+		const observerApiKey = fixtureToken("openai-content-blocks");
+		globalThis.fetch = (async () => {
+			return new Response(
+				JSON.stringify({
+					choices: [
+						{
+							message: {
+								content: [
+									{ type: "text", text: "first" },
+									{ type: "output_text", text: " second" },
+								],
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof globalThis.fetch;
+
+		const client = new ObserverClient({
+			observerProvider: "openai",
+			observerModel: "gpt-5.4-mini",
+			observerRuntime: "api_http",
+			observerApiKey,
+			observerBaseUrl: null,
+			observerOpenAIUseResponses: false,
+			observerMaxChars: 12_000,
+			observerMaxTokens: 4_000,
+			observerHeaders: {},
+			observerAuthSource: "auto",
+			observerAuthFile: null,
+			observerAuthCommand: [],
+			observerAuthTimeoutMs: 1500,
+			observerAuthCacheTtlS: 300,
+			observerExplicitConfigKeys: ["observerOpenAIUseResponses"],
+		});
+
+		const result = await client.observe("system", "user");
+
+		expect(result.raw).toBe("first second");
+	});
+
+	it("allows no-auth calls to custom OpenCode provider base URLs", async () => {
+		const prevHome = process.env.HOME;
+		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-custom-no-auth-provider-test-"));
+		const configDir = join(tmpDir, ".config", "opencode");
+		mkdirSync(configDir, { recursive: true });
+		let capturedUrl: string | undefined;
+		let capturedHeaders: Record<string, string> | undefined;
+
+		writeFileSync(
+			join(configDir, "opencode.jsonc"),
+			JSON.stringify({
+				provider: {
+					work: {
+						options: {
+							baseURL: "https://gateway.example.test/v1",
+						},
+						models: {
+							fast: { id: "gateway-fast" },
+						},
+					},
+				},
+			}),
+		);
+
+		globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			capturedUrl = String(input);
+			capturedHeaders = Object.fromEntries(
+				Object.entries((init?.headers as Record<string, string>) ?? {}),
+			);
+			return new Response(
+				JSON.stringify({
+					choices: [{ message: { content: "gateway response" } }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof globalThis.fetch;
+
+		try {
+			process.env.HOME = tmpDir;
+			const client = new ObserverClient({
+				observerProvider: "work",
+				observerModel: "work/fast",
+				observerRuntime: null,
+				observerApiKey: null,
+				observerBaseUrl: null,
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "none",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+
+			const result = await client.observe("system", "user");
+
+			expect(capturedUrl).toBe("https://gateway.example.test/v1/chat/completions");
+			expect(capturedHeaders?.authorization).toBeUndefined();
+			expect(result.model).toBe("gateway-fast");
+			expect(result.raw).toBe("gateway response");
+		} finally {
+			if (prevHome == null) delete process.env.HOME;
+			else process.env.HOME = prevHome;
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it("still requires auth for the built-in opencode provider", async () => {
+		let fetchCalls = 0;
+		globalThis.fetch = (async () => {
+			fetchCalls += 1;
+			return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+		}) as typeof globalThis.fetch;
+
+		const client = new ObserverClient({
+			observerProvider: "opencode",
+			observerModel: "opencode/gpt-5.4-mini",
+			observerRuntime: "api_http",
+			observerApiKey: null,
+			observerBaseUrl: null,
+			observerMaxChars: 12_000,
+			observerMaxTokens: 4_000,
+			observerHeaders: {},
+			observerAuthSource: "none",
+			observerAuthFile: null,
+			observerAuthCommand: [],
+			observerAuthTimeoutMs: 1500,
+			observerAuthCacheTtlS: 300,
+		});
+
+		const result = await client.observe("system", "user");
+
+		expect(result.raw).toBeNull();
+		expect(fetchCalls).toBe(0);
+	});
+
+	it("allows no-auth calls for opencode when observer_base_url is explicit", async () => {
+		let capturedUrl: string | undefined;
+		let capturedHeaders: Record<string, string> | undefined;
+
+		globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			capturedUrl = String(input);
+			capturedHeaders = Object.fromEntries(
+				Object.entries((init?.headers as Record<string, string>) ?? {}),
+			);
+			return new Response(
+				JSON.stringify({
+					choices: [{ message: { content: "explicit opencode gateway response" } }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof globalThis.fetch;
+
+		const client = new ObserverClient({
+			observerProvider: "opencode",
+			observerModel: "opencode/gpt-5.4-mini",
+			observerRuntime: "api_http",
+			observerApiKey: null,
+			observerBaseUrl: "http://127.0.0.1:1234/v1",
+			observerMaxChars: 12_000,
+			observerMaxTokens: 4_000,
+			observerHeaders: {},
+			observerAuthSource: "none",
+			observerAuthFile: null,
+			observerAuthCommand: [],
+			observerAuthTimeoutMs: 1500,
+			observerAuthCacheTtlS: 300,
+		});
+
+		const result = await client.observe("system", "user");
+
+		expect(capturedUrl).toBe("http://127.0.0.1:1234/v1/chat/completions");
+		expect(capturedHeaders?.authorization).toBeUndefined();
+		expect(result.raw).toBe("explicit opencode gateway response");
+	});
+
 	it("dedupes authorization headers case-insensitively for custom providers", async () => {
 		const prevHome = process.env.HOME;
 		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-custom-auth-header-test-"));

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -787,11 +787,13 @@ function parseAnthropicResponse(body: Record<string, unknown>): string | null {
 // OpenAI helpers
 // ---------------------------------------------------------------------------
 
-function buildOpenAIHeaders(token: string): Record<string, string> {
-	return {
-		authorization: `Bearer ${token}`,
-		"content-type": "application/json",
-	};
+function buildOpenAIHeaders(token: string | null): Record<string, string> {
+	return token
+		? {
+				authorization: `Bearer ${token}`,
+				"content-type": "application/json",
+			}
+		: { "content-type": "application/json" };
 }
 
 function mergeHeadersCaseInsensitive(
@@ -917,7 +919,20 @@ function parseOpenAIResponse(body: Record<string, unknown>): string | null {
 	const message = first.message as Record<string, unknown> | undefined;
 	if (!message) return null;
 	const content = message.content;
-	return typeof content === "string" ? content : null;
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return null;
+	const parts: string[] = [];
+	for (const block of content) {
+		if (typeof block !== "object" || block == null) continue;
+		const record = block as Record<string, unknown>;
+		if (
+			(record.type === "text" || record.type === "output_text") &&
+			typeof record.text === "string"
+		) {
+			parts.push(record.text);
+		}
+	}
+	return parts.length > 0 ? parts.join("") : null;
 }
 
 function parseOpenAIResponsesResponse(body: Record<string, unknown>): string | null {
@@ -1063,6 +1078,7 @@ export class ObserverClient {
 
 	private _observerHeaders: Record<string, string>;
 	private _customBaseUrl: string | null;
+	private _customBaseUrlAllowsNoAuth: boolean;
 	private readonly _apiKey: string | null;
 
 	// Claude sidecar state
@@ -1226,6 +1242,7 @@ export class ObserverClient {
 
 		const baseUrl = cfg.observerBaseUrl;
 		this._customBaseUrl = typeof baseUrl === "string" && baseUrl.trim() ? baseUrl.trim() : null;
+		this._customBaseUrlAllowsNoAuth = this._customBaseUrl != null;
 
 		// Set up auth adapter
 		this.authAdapter = new ObserverAuthAdapter({
@@ -1341,6 +1358,10 @@ export class ObserverClient {
 		this._initProvider(force);
 	}
 
+	private canCallOpenAIDirectWithoutAuth(): boolean {
+		return this._customBaseUrlAllowsNoAuth && !this._codexAccess && this.provider !== "anthropic";
+	}
+
 	/**
 	 * Call the LLM with a system prompt and user prompt, return the response.
 	 *
@@ -1408,9 +1429,9 @@ export class ObserverClient {
 		schema: Record<string, unknown>,
 	): Promise<ObserverStructuredJsonResponse> {
 		if (this.provider === "openai" && this.openaiUseResponses && !this._codexAccess) {
-			if (!this.auth.token) {
+			if (!this.auth.token && !this.canCallOpenAIDirectWithoutAuth()) {
 				this._initProvider(true);
-				if (!this.auth.token) {
+				if (!this.auth.token && !this.canCallOpenAIDirectWithoutAuth()) {
 					return {
 						raw: null,
 						parsed: null,
@@ -1427,7 +1448,7 @@ export class ObserverClient {
 			} else {
 				url = "https://api.openai.com/v1/responses";
 			}
-			const headers = buildOpenAIHeaders(this.auth.token ?? "");
+			const headers = buildOpenAIHeaders(this.auth.token);
 			const mergedHeaders = mergeHeadersCaseInsensitive(
 				headers,
 				renderObserverHeaders(this._observerHeaders, this.auth),
@@ -1535,7 +1556,10 @@ export class ObserverClient {
 				: resolveBuiltInProviderModel(this.provider, this.model);
 
 			// Persist resolved values for use in _callOpenAIDirect
-			if (baseUrl && !this._customBaseUrl) this._customBaseUrl = baseUrl;
+			if (baseUrl && !this._customBaseUrl) {
+				this._customBaseUrl = baseUrl;
+				this._customBaseUrlAllowsNoAuth = hasExplicitProviderConfig;
+			}
 			if (modelId) this.model = modelId;
 			if (providerHeaders && Object.keys(providerHeaders).length > 0) {
 				this._observerHeaders = { ...this._observerHeaders, ...providerHeaders };
@@ -1603,11 +1627,11 @@ export class ObserverClient {
 		}
 
 		// Refresh if we have no token
-		if (!this.auth.token) {
+		if (!this.auth.token && !this.canCallOpenAIDirectWithoutAuth()) {
 			this._initProvider(true);
 			if (this._codexAccess) return this._callCodexConsumer(systemPrompt, userPrompt);
 			if (this._anthropicOAuthAccess) return this._callAnthropicConsumer(systemPrompt, userPrompt);
-			if (!this.auth.token) {
+			if (!this.auth.token && !this.canCallOpenAIDirectWithoutAuth()) {
 				this._setLastError(`${capitalize(this.provider)} credentials are missing.`, "auth_missing");
 				return null;
 			}
@@ -1660,7 +1684,7 @@ export class ObserverClient {
 				: "https://api.openai.com/v1/chat/completions";
 		}
 
-		const headers = buildOpenAIHeaders(this.auth.token ?? "");
+		const headers = buildOpenAIHeaders(this.auth.token);
 		const mergedHeaders = mergeHeadersCaseInsensitive(
 			headers,
 			renderObserverHeaders(this._observerHeaders, this.auth),


### PR DESCRIPTION
## Description
Fixes #954 by allowing observer calls without credentials when the target is an explicitly custom OpenAI-compatible endpoint.

This keeps hosted defaults protected while supporting local/custom gateways:
- omit empty `Authorization: Bearer ` headers when no token is available
- allow no-auth direct OpenAI-compatible calls only with a custom/resolved base URL
- keep built-in `opencode` and `anthropic` requiring auth
- parse OpenAI-compatible chat responses that return text content blocks

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
  - `pnpm exec vitest run packages/core/src/observer-client.test.ts`
  - `pnpm run tsc`
  - `pnpm run lint`
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced