### PR TITLE
fix(sync): honor Docker env when importing coordinator invites

### DIFF
--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -11,6 +11,7 @@ import {
 	coordinatorEnableDeviceAction,
 	coordinatorEnrollDeviceAction,
 	coordinatorGrantScopeMembershipAction,
+	coordinatorImportInviteAction,
 	coordinatorListDevicesAction,
 	coordinatorListGroupsAction,
 	coordinatorListScopeMembershipsAction,
@@ -20,16 +21,23 @@ import {
 	coordinatorRevokeScopeMembershipAction,
 	coordinatorUpdateScopeAction,
 } from "./coordinator-actions.js";
+import { encodeInvitePayload } from "./coordinator-invites.js";
+import { connect } from "./db.js";
+import { fingerprintPublicKey, loadPublicKey } from "./sync-identity.js";
 
 describe("coordinator local admin actions", () => {
 	let tmpDir: string;
 	let dbPath: string;
 	let prevConfigPath: string | undefined;
+	let prevDbPath: string | undefined;
+	let prevKeysDir: string | undefined;
 
 	beforeEach(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "coord-actions-test-"));
 		dbPath = join(tmpDir, "coordinator.sqlite");
 		prevConfigPath = process.env.CODEMEM_CONFIG;
+		prevDbPath = process.env.CODEMEM_DB;
+		prevKeysDir = process.env.CODEMEM_KEYS_DIR;
 		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
 	});
 
@@ -37,6 +45,10 @@ describe("coordinator local admin actions", () => {
 		vi.unstubAllGlobals();
 		if (prevConfigPath == null) delete process.env.CODEMEM_CONFIG;
 		else process.env.CODEMEM_CONFIG = prevConfigPath;
+		if (prevDbPath == null) delete process.env.CODEMEM_DB;
+		else process.env.CODEMEM_DB = prevDbPath;
+		if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+		else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -450,6 +462,56 @@ describe("coordinator local admin actions", () => {
 			dbPath,
 		});
 		expect(invite.warnings).toEqual([]);
+	});
+
+	it("imports invites using CODEMEM_DB and CODEMEM_KEYS_DIR when flags are omitted", async () => {
+		const envDbPath = join(tmpDir, "env-mem.sqlite");
+		const envKeysDir = join(tmpDir, "env-keys");
+		process.env.CODEMEM_DB = envDbPath;
+		process.env.CODEMEM_KEYS_DIR = envKeysDir;
+		const capturedBodies: Record<string, unknown>[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_url: string, init?: RequestInit) => {
+				const body =
+					init?.body instanceof Uint8Array ? Buffer.from(init.body).toString("utf8") : "{}";
+				capturedBodies.push(JSON.parse(body) as Record<string, unknown>);
+				return new Response(JSON.stringify({ ok: true, status: "enrolled" }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}),
+		);
+
+		const invite = encodeInvitePayload({
+			v: 1,
+			kind: "coordinator_team_invite",
+			coordinator_url: "https://coord.example.test",
+			group_id: "team-a",
+			policy: "auto_admit",
+			token: "invite-token",
+			expires_at: "2099-01-01T00:00:00.000Z",
+			team_name: "Team A",
+		});
+
+		await coordinatorImportInviteAction({ inviteValue: invite });
+
+		const publicKey = loadPublicKey(envKeysDir);
+		expect(publicKey).toBeTruthy();
+		const conn = connect(envDbPath);
+		try {
+			expect(
+				conn.prepare("SELECT COUNT(1) AS total FROM sync_device").get() as { total?: number },
+			).toMatchObject({ total: 1 });
+		} finally {
+			conn.close();
+		}
+		expect(capturedBodies).toEqual([
+			expect.objectContaining({
+				public_key: publicKey,
+				fingerprint: fingerprintPublicKey(String(publicKey)),
+			}),
+		]);
 	});
 
 	it("warns when local invite coordinator URL uses private IPv6 space", async () => {

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -1,5 +1,3 @@
-import { homedir } from "node:os";
-import { join } from "node:path";
 import {
 	BetterSqliteCoordinatorStore,
 	DEFAULT_COORDINATOR_DB_PATH,
@@ -22,9 +20,13 @@ import type {
 	CoordinatorScope,
 	CoordinatorScopeMembership,
 } from "./coordinator-store-contract.js";
-import { connect } from "./db.js";
+import { connect, resolveDbPath } from "./db.js";
 import { initDatabase } from "./maintenance.js";
-import { readCodememConfigFile, writeCodememConfigFile } from "./observer-config.js";
+import {
+	readCodememConfigFile,
+	readCodememConfigFileAtPath,
+	writeCodememConfigFile,
+} from "./observer-config.js";
 import { buildBaseUrl, requestJson } from "./sync-http-client.js";
 import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
 
@@ -1018,21 +1020,24 @@ export async function coordinatorImportInviteAction(opts: {
 	configPath?: string | null;
 }): Promise<Record<string, unknown>> {
 	const payload = decodeInvitePayload(extractInvitePayload(opts.inviteValue));
-	const resolvedDbPath = opts.dbPath ?? join(homedir(), ".codemem", "mem.sqlite");
+	const resolvedDbPath = resolveDbPath(opts.dbPath ?? undefined);
+	const keysDir = opts.keysDir ?? (process.env.CODEMEM_KEYS_DIR?.trim() || undefined);
 	initDatabase(resolvedDbPath);
 	const conn = connect(resolvedDbPath);
 	let deviceId = "";
 	let fingerprint = "";
 	try {
-		[deviceId, fingerprint] = ensureDeviceIdentity(conn, { keysDir: opts.keysDir ?? undefined });
+		[deviceId, fingerprint] = ensureDeviceIdentity(conn, { keysDir });
 	} finally {
 		conn.close();
 	}
-	const publicKey = loadPublicKey(opts.keysDir ?? undefined);
+	const publicKey = loadPublicKey(keysDir);
 	if (!publicKey) throw new Error("public key missing");
 	const coordinatorUrl = String(payload.coordinator_url ?? "").trim();
 	if (!coordinatorUrl) throw new Error("Invite is missing a coordinator URL.");
-	const config = readCodememConfigFile();
+	const config = opts.configPath
+		? readCodememConfigFileAtPath(opts.configPath)
+		: readCodememConfigFile();
 	const displayName = String(config.actor_display_name ?? deviceId).trim() || deviceId;
 	// V1 of multi-team assumes one coordinator hosting multiple groups.
 	// If this device is already enrolled in a different coordinator, surface
@@ -1073,7 +1078,9 @@ export async function coordinatorImportInviteAction(opts: {
 		const detail = typeof response?.error === "string" ? response.error : "unknown";
 		throw new Error(`Invite import failed (${status}): ${detail}`);
 	}
-	const nextConfig = readCodememConfigFile();
+	const nextConfig = opts.configPath
+		? readCodememConfigFileAtPath(opts.configPath)
+		: readCodememConfigFile();
 	nextConfig.sync_coordinator_url = coordinatorUrl;
 	// Append the new group to sync_coordinator_groups (dedup) instead of
 	// overwriting sync_coordinator_group. The runtime reads both the plural

--- a/packages/ui/src/tabs/coordinator-admin/data/state.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/state.ts
@@ -70,6 +70,7 @@ export interface CoordinatorAdminState {
 	deviceActionPendingKind: DeviceActionKind;
 	groupRenameDrafts: Map<string, string>;
 	deviceRenameDrafts: Map<string, string>;
+	deviceRenameServerNames: Map<string, string>;
 	groupPreferencesOpen: Set<string>;
 	groupPreferencesDrafts: Map<string, GroupPreferencesDraft>;
 	groupScopeManagementOpen: Set<string>;
@@ -102,6 +103,7 @@ export const coordinatorAdminState: CoordinatorAdminState = {
 	deviceActionPendingKind: "",
 	groupRenameDrafts: new Map<string, string>(),
 	deviceRenameDrafts: new Map<string, string>(),
+	deviceRenameServerNames: new Map<string, string>(),
 	groupPreferencesOpen: new Set<string>(),
 	groupPreferencesDrafts: new Map<string, GroupPreferencesDraft>(),
 	groupScopeManagementOpen: new Set<string>(),

--- a/packages/ui/src/tabs/coordinator-admin/data/target-group.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/target-group.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { state } from "../../../lib/state";
+import { coordinatorAdminState } from "./state";
+import { reconcileDeviceRenameDrafts } from "./target-group";
+
+describe("coordinator admin target group helpers", () => {
+	beforeEach(() => {
+		state.lastCoordinatorAdminDevices = [];
+		coordinatorAdminState.deviceRenameDrafts.clear();
+		coordinatorAdminState.deviceRenameServerNames.clear();
+	});
+
+	it("preserves dirty device rename drafts across refreshes", () => {
+		state.lastCoordinatorAdminDevices = [
+			{ device_id: "dev-1", display_name: "NAS", group_id: "team-a" },
+		];
+		reconcileDeviceRenameDrafts();
+		coordinatorAdminState.deviceRenameDrafts.set("dev-1", "NAS storage box");
+
+		state.lastCoordinatorAdminDevices = [
+			{ device_id: "dev-1", display_name: "NAS", group_id: "team-a" },
+		];
+		reconcileDeviceRenameDrafts();
+
+		expect(coordinatorAdminState.deviceRenameDrafts.get("dev-1")).toBe("NAS storage box");
+	});
+
+	it("updates clean device rename drafts from refreshed server state", () => {
+		state.lastCoordinatorAdminDevices = [
+			{ device_id: "dev-1", display_name: "NAS", group_id: "team-a" },
+		];
+		reconcileDeviceRenameDrafts();
+
+		state.lastCoordinatorAdminDevices = [
+			{ device_id: "dev-1", display_name: "NAS seed peer", group_id: "team-a" },
+		];
+		reconcileDeviceRenameDrafts();
+
+		expect(coordinatorAdminState.deviceRenameDrafts.get("dev-1")).toBe("NAS seed peer");
+	});
+});

--- a/packages/ui/src/tabs/coordinator-admin/data/target-group.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/target-group.ts
@@ -88,16 +88,28 @@ export function resolveAdminTargetGroup() {
 
 export function reconcileDeviceRenameDrafts() {
 	const next = new Map<string, string>();
+	const nextServerNames = new Map<string, string>();
 	const items = Array.isArray(state.lastCoordinatorAdminDevices)
 		? state.lastCoordinatorAdminDevices
 		: [];
 	for (const item of items) {
 		const deviceId = String(item.device_id || "").trim();
 		if (!deviceId) continue;
-		next.set(deviceId, String(item.display_name || ""));
+		const serverName = String(item.display_name || "");
+		const existingDraft = coordinatorAdminState.deviceRenameDrafts.get(deviceId);
+		const previousServerName = coordinatorAdminState.deviceRenameServerNames.get(deviceId);
+		const hasDirtyDraft =
+			existingDraft !== undefined &&
+			(previousServerName === undefined || existingDraft !== previousServerName);
+		next.set(deviceId, hasDirtyDraft ? existingDraft : serverName);
+		nextServerNames.set(deviceId, serverName);
 	}
 	coordinatorAdminState.deviceRenameDrafts.clear();
 	for (const [deviceId, name] of next.entries()) {
 		coordinatorAdminState.deviceRenameDrafts.set(deviceId, name);
+	}
+	coordinatorAdminState.deviceRenameServerNames.clear();
+	for (const [deviceId, name] of nextServerNames.entries()) {
+		coordinatorAdminState.deviceRenameServerNames.set(deviceId, name);
 	}
 }

--- a/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
+++ b/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
@@ -200,6 +200,7 @@ export async function loadCoordinatorAdminData() {
 		state.lastCoordinatorAdminJoinRequests = [];
 		state.lastCoordinatorAdminDevices = [];
 		coordinatorAdminState.deviceRenameDrafts.clear();
+		coordinatorAdminState.deviceRenameServerNames.clear();
 		renderShell();
 		return;
 	}
@@ -243,7 +244,6 @@ export async function loadCoordinatorAdminData() {
 			reconcileDeviceRenameDrafts();
 		} catch {
 			state.lastCoordinatorAdminDevices = [];
-			coordinatorAdminState.deviceRenameDrafts.clear();
 		}
 		try {
 			coordinatorAdminState.availableProjects = await api.loadProjects();
@@ -257,6 +257,7 @@ export async function loadCoordinatorAdminData() {
 		state.lastCoordinatorAdminJoinRequests = [];
 		state.lastCoordinatorAdminDevices = [];
 		coordinatorAdminState.deviceRenameDrafts.clear();
+		coordinatorAdminState.deviceRenameServerNames.clear();
 	}
 	renderShell();
 }


### PR DESCRIPTION
## Description
Fixes coordinator invite import in containerized deployments by honoring `CODEMEM_DB`, `CODEMEM_KEYS_DIR`, and explicit config-path reads when CLI flags are omitted. This prevents enrolling one sync key while the running viewer signs with another. Also preserves dirty coordinator-admin device rename drafts across refreshes.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
  - Confirmed remote coordinator enrollment fingerprint mismatch was caused by importing with a different key path than runtime signing.
  - Ran targeted coordinator import and coordinator-admin draft regression tests.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
