### PR TITLE
docs(docker): add NAS deployment example

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:24-bookworm-slim
+
+ARG CODEMEM_VERSION=latest
+
+ENV NODE_ENV=production
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates make g++ python3 tini \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g "codemem@${CODEMEM_VERSION}" \
+	&& npm cache clean --force
+
+RUN mkdir -p /data /config /keys /app \
+	&& chown -R node:node /data /config /keys /app
+
+WORKDIR /app
+USER node
+
+ENTRYPOINT ["tini", "--"]
+CMD ["codemem", "--help"]

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,0 +1,154 @@
+# Docker deployment example
+
+This directory runs codemem from the published npm package, not from a source checkout.
+It is intended for a NAS, homelab server, or other Docker host where the viewer and MCP
+HTTP server should share one persistent codemem database.
+
+The default topology is:
+
+```text
+Tailscale Funnel / HTTPS ingress
+  -> 127.0.0.1:38889/mcp  codemem MCP HTTP server
+
+Tailscale private access / local host
+  -> 127.0.0.1:38888      codemem viewer
+
+Peer-to-peer sync
+  -> NAS Tailnet/LAN address:7337  codemem sync protocol
+```
+
+No Caddy container is included because Tailscale Funnel or another ingress is expected
+to terminate TLS before forwarding to the MCP port.
+
+## Files
+
+- `Dockerfile` installs `codemem` from npm using `CODEMEM_VERSION`.
+- `docker-compose.yml` starts two containers from the same image:
+  - `codemem-viewer` on container port `38888`
+  - `codemem-mcp` on container port `38889`
+- `environment.example` lists the required runtime settings.
+
+## Setup
+
+From this directory:
+
+```fish
+cp environment.example .env
+```
+
+Edit `.env` and set:
+
+- `CODEMEM_MCP_HTTP_PUBLIC_URL` to the public MCP URL, including `/mcp`
+- `CODEMEM_MCP_OIDC_ISSUER_URL`
+- `CODEMEM_MCP_OIDC_CLIENT_ID`
+- `CODEMEM_MCP_OIDC_CLIENT_SECRET`
+- `CODEMEM_MCP_OAUTH_ALLOWED_EMAIL` or `CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT`
+
+Build and start:
+
+```fish
+docker compose up -d --build
+```
+
+Check status:
+
+```fish
+docker compose ps
+docker compose logs -f codemem-mcp
+```
+
+The Compose file sets container DNS to `1.1.1.1` and `8.8.8.8`. Some NAS Docker
+setups have working host networking but broken container DNS, especially with VPN or
+Tailscale packages installed. If you create containers through a UI instead of Compose,
+set the same DNS servers there.
+
+## Tailscale Funnel
+
+Expose only the MCP port publicly. For example, from the Docker host:
+
+```fish
+tailscale funnel --bg 38889
+```
+
+Then add the custom connector in Claude with the same URL configured as
+`CODEMEM_MCP_HTTP_PUBLIC_URL`.
+
+The viewer port is intentionally bound to `127.0.0.1` on the Docker host. Do not expose
+the viewer publicly unless you add your own authentication layer.
+
+## Sync address advertisement
+
+When Docker runs in bridge mode, codemem's automatic address discovery sees container
+network interfaces, not the NAS host's Tailscale interface. Set an explicit advertised
+sync address so other peers and the coordinator learn a dialable address:
+
+```text
+CODEMEM_SYNC_PORT=7337
+CODEMEM_SYNC_BIND_IP=0.0.0.0
+CODEMEM_SYNC_ADVERTISE=http://your-nas-tailnet-name:7337
+```
+
+`CODEMEM_SYNC_ADVERTISE` should be reachable from your other peers. With Tailscale on
+the NAS host, use the NAS MagicDNS name or 100.x Tailnet IP. The Compose file publishes
+host port `7337` to the viewer container because `codemem serve` owns the sync listener.
+
+After importing a team invite, enable sync inside the container and restart the services:
+
+```fish
+docker exec -it codemem-viewer codemem coordinator import-invite '<invite>'
+docker exec -it codemem-viewer codemem sync enable
+docker restart codemem-viewer codemem-mcp
+```
+
+The Compose environment sets `CODEMEM_DB`, `CODEMEM_CONFIG`, and `CODEMEM_KEYS_DIR`, so
+commands executed inside `codemem-viewer` use the shared mounted database, config, and
+keys by default.
+
+## Persistent data
+
+Compose creates named volumes:
+
+- `codemem-data` for `/data/mem.sqlite`
+- `codemem-config` for `/config/codemem.json`
+- `codemem-keys` for sync keys and peer identity material
+
+Both services use the same database path:
+
+```text
+/data/mem.sqlite
+```
+
+## Observer credentials
+
+Observer/model credentials are optional for this deployment. If the NAS is only an
+always-on retrieval and sync peer, leave observer settings unset. Search, MCP retrieval,
+viewer browsing, and sync still work as long as the memories are already present in the
+shared database.
+
+Configure an observer only if you want this Docker host to extract new memories from raw
+events or other ingestion backlogs. For example, with OpenCode Zen:
+
+```text
+CODEMEM_OBSERVER_PROVIDER=opencode
+CODEMEM_OBSERVER_MODEL=opencode/gpt-5.4-mini
+CODEMEM_OBSERVER_API_KEY=...
+OPENCODE_API_KEY=...
+```
+
+Do not bake observer API keys into the Dockerfile or committed Compose file. Put them in
+the local `.env`, Docker secrets, or the container manager's private environment settings.
+
+## Current limitation
+
+MCP OAuth state is currently process-local in codemem. If the MCP container restarts,
+Claude may need to re-run the connector authorization flow until durable OAuth storage
+is implemented.
+
+## Useful commands
+
+```fish
+docker compose pull
+docker compose up -d --build
+docker compose restart codemem-mcp
+docker compose logs -f codemem-viewer
+```

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,0 +1,119 @@
+services:
+  codemem-viewer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        CODEMEM_VERSION: ${CODEMEM_VERSION:-latest}
+    image: codemem:${CODEMEM_VERSION:-latest}
+    container_name: codemem-viewer
+    command:
+      [
+        "codemem",
+        "serve",
+        "start",
+        "--foreground",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "38888",
+        "--db-path",
+        "/data/mem.sqlite",
+        "--config",
+        "/config/codemem.json"
+      ]
+    environment:
+      TZ: ${TZ:-Etc/UTC}
+      CODEMEM_DB: /data/mem.sqlite
+      CODEMEM_CONFIG: /config/codemem.json
+      CODEMEM_KEYS_DIR: /keys
+      CODEMEM_SYNC_HOST: 0.0.0.0
+      CODEMEM_SYNC_PORT: ${CODEMEM_SYNC_PORT:-7337}
+      CODEMEM_SYNC_ADVERTISE: ${CODEMEM_SYNC_ADVERTISE:-}
+    ports:
+      - "127.0.0.1:${CODEMEM_VIEWER_PORT:-38888}:38888"
+      - "${CODEMEM_SYNC_BIND_IP:-0.0.0.0}:${CODEMEM_SYNC_PORT:-7337}:${CODEMEM_SYNC_PORT:-7337}"
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
+    volumes:
+      - codemem-data:/data
+      - codemem-config:/config
+      - codemem-keys:/keys
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "--input-type=module",
+          "-e",
+          "const res = await fetch('http://127.0.0.1:38888/'); process.exit(res.ok ? 0 : 1);"
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  codemem-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        CODEMEM_VERSION: ${CODEMEM_VERSION:-latest}
+    image: codemem:${CODEMEM_VERSION:-latest}
+    container_name: codemem-mcp
+    command:
+      [
+        "codemem",
+        "mcp",
+        "http",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "38889",
+        "--db-path",
+        "/data/mem.sqlite",
+        "--public-url",
+        "${CODEMEM_MCP_HTTP_PUBLIC_URL}",
+        "--unsafe-public"
+      ]
+    environment:
+      TZ: ${TZ:-Etc/UTC}
+      CODEMEM_DB: /data/mem.sqlite
+      CODEMEM_CONFIG: /config/codemem.json
+      CODEMEM_KEYS_DIR: /keys
+      CODEMEM_MCP_HTTP_PUBLIC_URL: ${CODEMEM_MCP_HTTP_PUBLIC_URL}
+      CODEMEM_MCP_OIDC_ISSUER_URL: ${CODEMEM_MCP_OIDC_ISSUER_URL}
+      CODEMEM_MCP_OIDC_CLIENT_ID: ${CODEMEM_MCP_OIDC_CLIENT_ID}
+      CODEMEM_MCP_OIDC_CLIENT_SECRET: ${CODEMEM_MCP_OIDC_CLIENT_SECRET}
+      CODEMEM_MCP_OAUTH_ALLOWED_EMAIL: ${CODEMEM_MCP_OAUTH_ALLOWED_EMAIL:-}
+      CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT: ${CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT:-}
+    ports:
+      - "127.0.0.1:${CODEMEM_MCP_PORT:-38889}:38889"
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
+    volumes:
+      - codemem-data:/data
+      - codemem-config:/config
+      - codemem-keys:/keys
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "--input-type=module",
+          "-e",
+          "const res = await fetch('http://127.0.0.1:38889/.well-known/oauth-protected-resource/mcp'); process.exit(res.ok ? 0 : 1);"
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+volumes:
+  codemem-data:
+  codemem-config:
+  codemem-keys:

--- a/deploy/docker/environment.example
+++ b/deploy/docker/environment.example
@@ -1,0 +1,36 @@
+# Image version installed from npm. Use "latest" or pin a published version.
+CODEMEM_VERSION=latest
+
+# Container timezone.
+TZ=Etc/UTC
+
+# Viewer and MCP host ports. Compose binds both to 127.0.0.1 on the Docker host.
+CODEMEM_VIEWER_PORT=38888
+CODEMEM_MCP_PORT=38889
+
+# Peer-to-peer sync protocol. Other peers must be able to reach this address.
+# With Docker bridge mode and Tailscale on the host, advertise the NAS host's
+# Tailnet DNS name or 100.x address, not the container's bridge address.
+CODEMEM_SYNC_PORT=7337
+CODEMEM_SYNC_BIND_IP=0.0.0.0
+CODEMEM_SYNC_ADVERTISE=http://your-nas-tailnet-name:7337
+
+# Public HTTPS URL for the MCP endpoint, usually provided by Tailscale Funnel,
+# Cloudflare Tunnel, or another TLS ingress. Must include /mcp.
+CODEMEM_MCP_HTTP_PUBLIC_URL=https://your-host.example/mcp
+
+# Upstream OIDC provider used for Claude custom connector authorization.
+CODEMEM_MCP_OIDC_ISSUER_URL=https://accounts.google.com
+CODEMEM_MCP_OIDC_CLIENT_ID=replace-me
+CODEMEM_MCP_OIDC_CLIENT_SECRET=replace-me
+
+# Set at least one allowed identity. Email is usually simplest for Google OIDC.
+CODEMEM_MCP_OAUTH_ALLOWED_EMAIL=you@example.com
+# CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT=
+
+# Optional observer credentials. Leave unset for a retrieval-only peer that serves
+# synced memories but does not extract new memories from raw events itself.
+# CODEMEM_OBSERVER_PROVIDER=opencode
+# CODEMEM_OBSERVER_MODEL=opencode/gpt-5.4-mini
+# CODEMEM_OBSERVER_API_KEY=replace-me
+# OPENCODE_API_KEY=replace-me


### PR DESCRIPTION
## Description
Adds a generic Docker deployment example for running codemem viewer and MCP from the published npm package on a NAS/homelab host. The example keeps viewer/MCP bound to loopback, publishes the sync protocol port, documents Tailscale/MagicDNS sync advertisement, and uses shared `/data`, `/config`, and `/keys` volumes.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
  - Ran `docker compose --env-file environment.example config` from `deploy/docker`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
