### PR TITLE
fix(sync): harden coordinator pairing reliability

### DIFF
--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -187,6 +187,10 @@ not accumulate as mixed `host:port` and `http://host:port` variants in local pee
 - enrollment is explicit per device/group
 - there is no username/password or codemem-operated account layer in this model
 
+For local debugging only, `CODEMEM_SYNC_AUTH_DIAGNOSTICS=1` makes direct sync `401` responses include the auth failure
+reason, such as `unknown_peer`, `peer_record_incomplete`, `fingerprint_mismatch`, or `invalid_signature`. Do not enable
+this on publicly reachable sync listeners; it is intended for trusted development or private Tailnet troubleshooting.
+
 ## Remote admin flow
 
 Built-in local coordinator management commands operate directly on the local SQLite store.

--- a/packages/cli/src/commands/sync-helpers.ts
+++ b/packages/cli/src/commands/sync-helpers.ts
@@ -1,3 +1,4 @@
+import { formatHostPort } from "@codemem/core";
 import { resolveDbOpt } from "../shared-options.js";
 
 export interface SyncAttemptRow {
@@ -81,13 +82,13 @@ export function collectAdvertiseAddresses(
 		return [explicitAddress];
 	}
 	if (configuredHost && configuredHost !== "0.0.0.0") {
-		return [`${configuredHost}:${port}`];
+		return [formatHostPort(configuredHost, port)];
 	}
 	const addresses = Object.values(interfaces)
 		.flatMap((entries) => entries ?? [])
 		.filter((entry) => !entry.internal)
 		.map((entry) => entry.address)
 		.filter((address) => address && address !== "127.0.0.1" && address !== "::1")
-		.map((address) => `${address}:${port}`);
+		.map((address) => formatHostPort(address, port));
 	return [...new Set(addresses)];
 }

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -152,6 +152,18 @@ describe("formatSyncAttempt", () => {
 		).toEqual(["192.168.1.10:7337"]);
 	});
 
+	it("brackets configured IPv6 advertise hosts", () => {
+		expect(collectAdvertiseAddresses(null, "fd00::1", 7337, {})).toEqual(["[fd00::1]:7337"]);
+	});
+
+	it("brackets IPv6 interface advertise addresses", () => {
+		expect(
+			collectAdvertiseAddresses(null, "0.0.0.0", 7337, {
+				utun0: [{ address: "fd00::2", internal: false, family: "IPv6" }],
+			}),
+		).toEqual(["[fd00::2]:7337"]);
+	});
+
 	it("registers coordinator parity subcommands", () => {
 		const coordinator = syncCommand.commands.find((command) => command.name() === "coordinator");
 		expect(coordinator).toBeDefined();

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -528,11 +528,29 @@ pairCmd.action(async (opts: SyncPairOptions) => {
 				process.exitCode = 1;
 				return;
 			}
+			const existingPeer = drizzle(store.db, { schema })
+				.select({ pinned_fingerprint: schema.syncPeers.pinned_fingerprint })
+				.from(schema.syncPeers)
+				.where(eq(schema.syncPeers.peer_device_id, deviceId))
+				.get();
+			const existingFingerprint = String(existingPeer?.pinned_fingerprint ?? "").trim();
+			if (existingFingerprint && existingFingerprint !== fingerprint) {
+				const msg =
+					"Pairing payload conflicts with the existing trusted fingerprint for this device. Remove or repair the old peer before accepting this pairing payload.";
+				if (opts.json) {
+					emitJsonError("peer_conflict", msg);
+					return;
+				}
+				p.log.error(msg);
+				process.exitCode = 1;
+				return;
+			}
 
 			updatePeerAddresses(store.db, deviceId, resolvedAddresses, {
 				name: opts.name,
 				pinnedFingerprint: fingerprint,
 				publicKey,
+				replaceTrust: true,
 			});
 
 			if (opts.default) {

--- a/packages/core/src/address-utils.ts
+++ b/packages/core/src/address-utils.ts
@@ -12,32 +12,57 @@
  * lowercases host, strips default ports (80/443), trims trailing slashes.
  * Returns empty string for invalid/empty input.
  */
-export function normalizeAddress(address: string): string {
+export function normalizeAddress(address: string, options?: { defaultHttpPort?: number }): string {
 	const value = address.trim();
 	if (!value) return "";
 
-	const withScheme = value.includes("://") ? value : `http://${value}`;
+	const hasScheme = value.includes("://");
+	const withScheme = hasScheme ? value : `http://${value}`;
+	const hasExplicitDefaultHttpPort = /^http:\/\/(?:\[[^\]]+\]|[^/?#:]+):80(?:[/?#]|$)/i.test(
+		withScheme,
+	);
 
 	try {
 		const url = new URL(withScheme);
 		if (!url.hostname) return "";
 		if (url.port && (Number(url.port) <= 0 || Number(url.port) > 65535)) return "";
+		if (
+			!url.port &&
+			!hasExplicitDefaultHttpPort &&
+			url.protocol === "http:" &&
+			options?.defaultHttpPort
+		) {
+			const port = Math.trunc(options.defaultHttpPort);
+			if (port <= 0 || port > 65535) return "";
+			if (port !== 80 && (!hasScheme || /^http:\/\//i.test(value))) {
+				url.port = String(port);
+			}
+		}
 		return url.origin + url.pathname.replace(/\/+$/, "");
 	} catch {
 		return "";
 	}
 }
 
+export function formatHostPort(host: string, port: number): string {
+	const value = host.trim();
+	if (!value) return "";
+	const normalizedPort = Math.trunc(port);
+	if (normalizedPort <= 0 || normalizedPort > 65535) return "";
+	const authorityHost = value.includes(":") && !value.startsWith("[") ? `[${value}]` : value;
+	return `${authorityHost}:${normalizedPort}`;
+}
+
 /**
- * Produce a dedup key for an address (strips http scheme for comparison).
+ * Produce a dedupe key for an address while preserving scheme and path.
  */
 export function addressDedupeKey(address: string): string {
 	if (!address) return "";
 	try {
 		const url = new URL(address);
 		const host = url.hostname.toLowerCase();
-		if (host && url.port) return `${host}:${url.port}`;
-		if (host) return host;
+		if (host && url.port) return `${url.protocol}//${host}:${url.port}${url.pathname}`;
+		if (host) return `${url.protocol}//${host}${url.pathname}`;
 	} catch {
 		// Not parseable
 	}
@@ -48,15 +73,32 @@ export function addressDedupeKey(address: string): string {
  * Merge two address lists, normalizing and deduplicating.
  * Existing addresses come first, then new candidates.
  */
-export function mergeAddresses(existing: string[], candidates: string[]): string[] {
+export function mergeAddresses(
+	existing: string[],
+	candidates: string[],
+	options?: { defaultHttpPort?: number },
+): string[] {
 	const normalized: string[] = [];
 	const seen = new Set<string>();
 	for (const address of [...existing, ...candidates]) {
-		const cleaned = normalizeAddress(address);
+		const cleaned = normalizeAddress(address, options);
 		const key = addressDedupeKey(cleaned);
 		if (!cleaned || seen.has(key)) continue;
 		seen.add(key);
 		normalized.push(cleaned);
 	}
 	return normalized;
+}
+
+/**
+ * Merge address lists while preferring newly discovered candidates first.
+ * Useful for coordinator presence refreshes where fresh addresses should beat
+ * stale cached LAN/Docker addresses without dropping still-useful fallbacks.
+ */
+export function mergeAddressesPreferCandidates(
+	existing: string[],
+	candidates: string[],
+	options?: { defaultHttpPort?: number },
+): string[] {
+	return mergeAddresses(candidates, existing, options);
 }

--- a/packages/core/src/coordinator-runtime.test.ts
+++ b/packages/core/src/coordinator-runtime.test.ts
@@ -1,6 +1,12 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+	advertisedSyncAddresses,
+	fetchCoordinatorStalePeers,
+	lookupCoordinatorPeers,
 	readCoordinatorSyncConfig,
 	refreshStoredCoordinatorPeerAddresses,
 } from "./coordinator-runtime.js";
@@ -40,6 +46,180 @@ describe("readCoordinatorSyncConfig.syncOpsLimit", () => {
 	it("falls back to the default when the config value is not an integer", () => {
 		const config = readCoordinatorSyncConfig({ sync_ops_limit: "not-a-number" });
 		expect(config.syncOpsLimit).toBe(500);
+	});
+});
+
+describe("advertisedSyncAddresses", () => {
+	it("infers the configured sync port for bare advertised hostnames", () => {
+		const config = readCoordinatorSyncConfig({
+			sync_advertise: "nas.example.test",
+			sync_port: "7337",
+		});
+
+		expect(advertisedSyncAddresses(config)).toEqual(["http://nas.example.test:7337"]);
+	});
+
+	it("preserves explicit ports in advertised URLs", () => {
+		const config = readCoordinatorSyncConfig({
+			sync_advertise: "http://nas.example.test:7444",
+			sync_port: "7337",
+		});
+
+		expect(advertisedSyncAddresses(config)).toEqual(["http://nas.example.test:7444"]);
+	});
+
+	it("deduplicates bare host and explicit sync port after port inference", () => {
+		const config = readCoordinatorSyncConfig({
+			sync_advertise: "nas.example.test,http://nas.example.test:7337",
+			sync_port: "7337",
+		});
+
+		expect(advertisedSyncAddresses(config)).toEqual(["http://nas.example.test:7337"]);
+	});
+});
+
+describe("lookupCoordinatorPeers", () => {
+	it("merges multi-group device groups as plain strings", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		try {
+			initTestSchema(db);
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const url = new URL(String(input));
+				const groupId = url.searchParams.get("group_id") || "";
+				return new Response(
+					JSON.stringify({
+						items: [
+							{
+								device_id: "peer-1",
+								fingerprint: "fp-1",
+								public_key: "pk-1",
+								addresses: [`${groupId}.example.test:7337`],
+								stale: false,
+							},
+						],
+					}),
+					{ status: 200 },
+				);
+			}) as typeof fetch;
+
+			const peers = await lookupCoordinatorPeers(
+				{ db, dbPath: ":memory:" },
+				readCoordinatorSyncConfig({
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_groups: ["team-a", "team-b"],
+				}),
+				{ keysDir },
+			);
+
+			expect(peers).toHaveLength(1);
+			expect(peers[0]?.groups).toEqual(["team-a", "team-b"]);
+			expect(peers[0]?.fresh_groups).toEqual(["team-a", "team-b"]);
+		} finally {
+			globalThis.fetch = prevFetch;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
+	it("tracks freshness per group when merged device sightings disagree", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		try {
+			initTestSchema(db);
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const groupId = new URL(String(input)).searchParams.get("group_id") || "";
+				const stale = groupId === "team-b";
+				const now = Date.now();
+				return new Response(
+					JSON.stringify({
+						items: [
+							{
+								device_id: "peer-1",
+								fingerprint: "fp-1",
+								public_key: "pk-1",
+								addresses: [`${groupId}.example.test:7337`],
+								last_seen_at: new Date(now + (stale ? 1_000 : 0)).toISOString(),
+								expires_at: new Date(now + (stale ? -60_000 : 60_000)).toISOString(),
+								stale,
+							},
+						],
+					}),
+					{ status: 200 },
+				);
+			}) as typeof fetch;
+
+			const peers = await lookupCoordinatorPeers(
+				{ db, dbPath: ":memory:" },
+				readCoordinatorSyncConfig({
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_groups: ["team-a", "team-b"],
+				}),
+				{ keysDir },
+			);
+
+			expect(peers[0]?.groups).toEqual(["team-a", "team-b"]);
+			expect(peers[0]?.fresh_groups).toEqual(["team-a"]);
+			expect(peers[0]?.addresses).toEqual(["http://team-a.example.test:7337"]);
+			expect(Date.parse(String(peers[0]?.expires_at))).toBeGreaterThan(Date.now());
+			expect(peers[0]?.stale).toBe(false);
+		} finally {
+			globalThis.fetch = prevFetch;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("fetchCoordinatorStalePeers", () => {
+	it("returns a stale pinned peer key when the same device has a fresh replacement fingerprint", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const configPath = join(
+			mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-config-")),
+			"config.json",
+		);
+		const prevFetch = globalThis.fetch;
+		const prevConfig = process.env.CODEMEM_CONFIG;
+		try {
+			initTestSchema(db);
+			db.prepare(
+				"INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, addresses_json, created_at) VALUES (?, ?, ?, ?)",
+			).run("peer-1", "old-fp", "[]", new Date().toISOString());
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			process.env.CODEMEM_CONFIG = configPath;
+			globalThis.fetch = (async () =>
+				new Response(
+					JSON.stringify({
+						items: [
+							{ device_id: "peer-1", fingerprint: "old-fp", stale: true },
+							{ device_id: "peer-1", fingerprint: "new-fp", stale: false },
+						],
+					}),
+					{ status: 200 },
+				)) as typeof fetch;
+
+			const stalePeers = await fetchCoordinatorStalePeers(db, ":memory:", keysDir);
+
+			expect(stalePeers.has("peer-1")).toBe(false);
+			expect(stalePeers.has("peer-1:old-fp")).toBe(true);
+		} finally {
+			globalThis.fetch = prevFetch;
+			if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+			else process.env.CODEMEM_CONFIG = prevConfig;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+			rmSync(configPath, { force: true });
+		}
 	});
 });
 
@@ -105,9 +285,9 @@ describe("refreshStoredCoordinatorPeerAddresses", () => {
 		expect(JSON.parse(row.projects_include_json ?? "[]")).toEqual(["work/*"]);
 		expect(JSON.parse(row.projects_exclude_json ?? "[]")).toEqual(["personal/*"]);
 		expect(JSON.parse(row.addresses_json)).toEqual([
-			"http://old.example:7337",
 			"http://10.0.0.5:7337",
 			"http://10.0.0.6:7337",
+			"http://old.example:7337",
 		]);
 		expect(row.last_error).toBe("offline");
 	});
@@ -129,6 +309,33 @@ describe("refreshStoredCoordinatorPeerAddresses", () => {
 				fingerprint: "fp-other",
 				addresses: ["http://10.0.0.5:7337"],
 				groups: ["team-a"],
+			},
+		]);
+
+		expect(updated).toBe(0);
+		const row = db
+			.prepare("SELECT addresses_json FROM sync_peers WHERE peer_device_id = ?")
+			.get("peer-1") as { addresses_json: string };
+		expect(JSON.parse(row.addresses_json)).toEqual(["http://old.example:7337"]);
+	});
+
+	it("does not refresh addresses from stale coordinator input", () => {
+		db.prepare(
+			"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, addresses_json, created_at) VALUES (?, ?, ?, ?, ?)",
+		).run(
+			"peer-1",
+			"Peer One",
+			"fp-1",
+			JSON.stringify(["http://old.example:7337"]),
+			new Date().toISOString(),
+		);
+
+		const updated = refreshStoredCoordinatorPeerAddresses(db, [
+			{
+				device_id: "peer-1",
+				fingerprint: "fp-1",
+				addresses: ["http://stale.example:7337"],
+				stale: true,
 			},
 		]);
 

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -1,5 +1,10 @@
 import { networkInterfaces } from "node:os";
-import { mergeAddresses } from "./address-utils.js";
+import {
+	formatHostPort,
+	mergeAddresses,
+	mergeAddressesPreferCandidates,
+	normalizeAddress,
+} from "./address-utils.js";
 import type { CoordinatorReciprocalApproval } from "./coordinator-store-contract.js";
 import type { Database } from "./db.js";
 import { getCodememEnvOverrides, readCodememConfigFile } from "./observer-config.js";
@@ -46,6 +51,18 @@ function parseStringList(value: unknown): string[] {
 			.filter(Boolean);
 	}
 	return [];
+}
+
+function mergeStringLists(existing: string[], candidates: string[]): string[] {
+	const merged: string[] = [];
+	const seen = new Set<string>();
+	for (const value of [...existing, ...candidates]) {
+		const cleanValue = value.trim();
+		if (!cleanValue || seen.has(cleanValue)) continue;
+		seen.add(cleanValue);
+		merged.push(cleanValue);
+	}
+	return merged;
 }
 
 export interface CoordinatorSyncConfig {
@@ -142,7 +159,7 @@ export function coordinatorEnabled(config: CoordinatorSyncConfig): boolean {
 	return Boolean(config.syncCoordinatorUrl && config.syncCoordinatorGroups.length > 0);
 }
 
-function advertisedSyncAddresses(config: CoordinatorSyncConfig): string[] {
+export function advertisedSyncAddresses(config: CoordinatorSyncConfig): string[] {
 	const advertise = config.syncAdvertise.toLowerCase();
 	if (advertise && advertise !== "auto" && advertise !== "default") {
 		return mergeAddresses(
@@ -151,17 +168,19 @@ function advertisedSyncAddresses(config: CoordinatorSyncConfig): string[] {
 				.split(",")
 				.map((item) => item.trim())
 				.filter(Boolean),
+			{ defaultHttpPort: config.syncPort },
 		);
 	}
 	if (config.syncHost && config.syncHost !== "0.0.0.0") {
-		return [`${config.syncHost}:${config.syncPort}`];
+		return [normalizeAddress(formatHostPort(config.syncHost, config.syncPort))].filter(Boolean);
 	}
 	const addresses = Object.values(networkInterfaces())
 		.flatMap((entries) => entries ?? [])
 		.filter((entry) => !entry.internal)
 		.map((entry) => entry.address)
 		.filter((address) => address && address !== "127.0.0.1" && address !== "::1")
-		.map((address) => `${address}:${config.syncPort}`);
+		.map((address) => normalizeAddress(formatHostPort(address, config.syncPort)))
+		.filter(Boolean);
 	return [...new Set(addresses)];
 }
 
@@ -237,33 +256,41 @@ export async function lookupCoordinatorPeers(
 			const device = clean(record.device_id);
 			const fingerprint = clean(record.fingerprint);
 			if (!device) continue;
+			const freshAddresses = record.stale
+				? []
+				: Array.isArray(record.addresses)
+					? record.addresses.filter((x): x is string => typeof x === "string")
+					: [];
 			const key = `${device}:${fingerprint}`;
 			const existing = merged.get(key);
 			if (!existing) {
 				merged.set(key, {
 					...record,
-					addresses: mergeAddresses(
-						[],
-						Array.isArray(record.addresses)
-							? record.addresses.filter((x): x is string => typeof x === "string")
-							: [],
-					),
+					addresses: mergeAddresses([], freshAddresses),
 					groups: [groupId],
+					fresh_groups: record.stale ? [] : [groupId],
 				});
 				continue;
 			}
 			existing.addresses = mergeAddresses(
 				(Array.isArray(existing.addresses) ? existing.addresses : []) as string[],
-				Array.isArray(record.addresses)
-					? record.addresses.filter((x): x is string => typeof x === "string")
-					: [],
+				freshAddresses,
 			);
-			existing.groups = mergeAddresses(
+			existing.groups = mergeStringLists(
 				(Array.isArray(existing.groups) ? existing.groups : []) as string[],
 				[groupId],
 			);
-			existing.stale = Boolean(existing.stale) && Boolean(record.stale);
-			if (clean(record.last_seen_at) > clean(existing.last_seen_at)) {
+			existing.fresh_groups = mergeStringLists(
+				(Array.isArray(existing.fresh_groups) ? existing.fresh_groups : []) as string[],
+				record.stale ? [] : [groupId],
+			);
+			const wasStale = Boolean(existing.stale);
+			const isStale = Boolean(record.stale);
+			existing.stale = wasStale && isStale;
+			const shouldUpdateFreshnessMetadata =
+				(!isStale && (wasStale || clean(record.last_seen_at) > clean(existing.last_seen_at))) ||
+				(isStale && wasStale && clean(record.last_seen_at) > clean(existing.last_seen_at));
+			if (shouldUpdateFreshnessMetadata) {
 				existing.last_seen_at = record.last_seen_at;
 				existing.expires_at = record.expires_at;
 			}
@@ -301,6 +328,7 @@ export function refreshStoredCoordinatorPeerAddresses(
 ): number {
 	const discoveredAddressesByPinnedPeer = new Map<string, string[]>();
 	for (const peer of peers) {
+		if (peer.stale) continue;
 		const deviceId = clean(peer.device_id);
 		const fingerprint = clean(peer.fingerprint);
 		if (!deviceId || !fingerprint) continue;
@@ -334,7 +362,10 @@ export function refreshStoredCoordinatorPeerAddresses(
 			if (!discoveredAddresses?.length) continue;
 
 			const existingAddresses = mergeAddresses(parseAddressCache(row.addresses_json), []);
-			const mergedAddresses = mergeAddresses(existingAddresses, discoveredAddresses);
+			const mergedAddresses = mergeAddressesPreferCandidates(
+				existingAddresses,
+				discoveredAddresses,
+			);
 			if (JSON.stringify(mergedAddresses) === JSON.stringify(existingAddresses)) continue;
 			update.run(JSON.stringify(mergedAddresses), deviceId, fingerprint);
 			updated += 1;
@@ -362,23 +393,34 @@ export async function fetchCoordinatorStalePeers(
 		const peers = await lookupCoordinatorPeers({ db, dbPath }, config, { keysDir });
 		refreshStoredCoordinatorPeerAddresses(db, peers);
 		// A device may appear under multiple fingerprints (key rotation, multi-group).
-		// Only mark a device stale if ALL its entries are stale.
+		// Skip device-wide only when all entries are stale, but also return pinned
+		// peer keys so an old trusted fingerprint stays fail-closed even when the
+		// same device id has a fresh replacement fingerprint.
 		const freshDevices = new Set<string>();
 		const staleDevices = new Set<string>();
+		const freshPinnedPeers = new Set<string>();
+		const stalePinnedPeers = new Set<string>();
 		for (const peer of peers) {
 			const deviceId = clean(peer.device_id);
 			if (!deviceId) continue;
+			const fingerprint = clean(peer.fingerprint);
+			const pinnedPeerKey = fingerprint ? `${deviceId}:${fingerprint}` : "";
 			if (peer.stale) {
 				staleDevices.add(deviceId);
+				if (pinnedPeerKey) stalePinnedPeers.add(pinnedPeerKey);
 			} else {
 				freshDevices.add(deviceId);
+				if (pinnedPeerKey) freshPinnedPeers.add(pinnedPeerKey);
 			}
 		}
 		// Remove any device that has at least one fresh entry
 		for (const deviceId of freshDevices) {
 			staleDevices.delete(deviceId);
 		}
-		return staleDevices;
+		for (const pinnedPeerKey of freshPinnedPeers) {
+			stalePinnedPeers.delete(pinnedPeerKey);
+		}
+		return new Set([...staleDevices, ...stalePinnedPeers]);
 	} catch {
 		// Best-effort: if coordinator lookup fails, skip the optimization.
 		return new Set();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -540,6 +540,7 @@ export {
 	advertiseMdns,
 	DEFAULT_SERVICE_TYPE,
 	discoverPeersViaMdns,
+	formatHostPort,
 	loadPeerAddresses,
 	mdnsAddressesForPeer,
 	mdnsEnabled,

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -7,6 +7,7 @@ import { columnExists } from "./db.js";
 import {
 	getSyncDaemonPhase,
 	refreshCoordinatorPresenceForDaemon,
+	resolveSyncDaemonKeysDir,
 	runTickOnce,
 	setSyncDaemonError,
 	setSyncDaemonOk,
@@ -15,6 +16,16 @@ import {
 } from "./sync-daemon.js";
 
 import { initTestSchema } from "./test-utils.js";
+
+const ORIGINAL_KEYS_DIR = process.env.CODEMEM_KEYS_DIR;
+
+afterEach(() => {
+	if (ORIGINAL_KEYS_DIR === undefined) {
+		delete process.env.CODEMEM_KEYS_DIR;
+	} else {
+		process.env.CODEMEM_KEYS_DIR = ORIGINAL_KEYS_DIR;
+	}
+});
 
 vi.mock("./coordinator-runtime.js", () => ({
 	coordinatorEnabled: vi.fn().mockReturnValue(false),
@@ -122,6 +133,27 @@ describe("syncDaemonTick", () => {
 		expect(runSyncPass).toHaveBeenCalledWith(db, "peer-2", expect.anything());
 	});
 
+	it("skips only the matching stale pinned coordinator identity", async () => {
+		const { runSyncPass, shouldSkipOfflinePeer } = await import("./sync-pass.js");
+		vi.mocked(shouldSkipOfflinePeer).mockReturnValue(false);
+		const now = new Date().toISOString();
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-1", "old-fp", now);
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-2", "fp2", now);
+
+		const results = await syncDaemonTick(db, undefined, new Set(["peer-1:old-fp"]));
+
+		expect(results).toHaveLength(2);
+		expect(results[0].skipped).toBe(true);
+		expect(results[0].reason).toContain("coordinator presence expired");
+		expect(results[1].ok).toBe(true);
+		expect(runSyncPass).toHaveBeenCalledTimes(1);
+		expect(runSyncPass).toHaveBeenCalledWith(db, "peer-2", expect.anything());
+	});
+
 	it("syncs all peers when stalePeers set is empty", async () => {
 		const { runSyncPass, shouldSkipOfflinePeer } = await import("./sync-pass.js");
 		vi.mocked(shouldSkipOfflinePeer).mockReturnValue(false);
@@ -179,6 +211,18 @@ describe("syncDaemonTick", () => {
 			"peer-1",
 			expect.objectContaining({ scanner: fakeScanner }),
 		);
+	});
+});
+
+describe("resolveSyncDaemonKeysDir", () => {
+	it("falls back to CODEMEM_KEYS_DIR when the caller omits keysDir", () => {
+		process.env.CODEMEM_KEYS_DIR = "/container/keys";
+		expect(resolveSyncDaemonKeysDir()).toBe("/container/keys");
+	});
+
+	it("prefers the explicit daemon keysDir over CODEMEM_KEYS_DIR", () => {
+		process.env.CODEMEM_KEYS_DIR = "/container/keys";
+		expect(resolveSyncDaemonKeysDir("/explicit/keys")).toBe("/explicit/keys");
 	});
 });
 
@@ -260,6 +304,31 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 
 			await runTickOnce(dbPath);
 			expect(syncPassPreflight).toHaveBeenCalledTimes(1);
+		} finally {
+			fileDb.close();
+			rmSync(dbPath, { force: true });
+		}
+	});
+
+	it("threads CODEMEM_KEYS_DIR through one-off ticks when keysDir is omitted", async () => {
+		const { runSyncPass } = await import("./sync-pass.js");
+		process.env.CODEMEM_KEYS_DIR = "/container/keys";
+		const dbPath = join(tmpdir(), `codemem-sync-daemon-env-keys-${Date.now()}.sqlite`);
+		const fileDb = new Database(dbPath);
+		try {
+			initTestSchema(fileDb);
+			fileDb
+				.prepare(
+					"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+				)
+				.run("peer-1", "fp1", new Date().toISOString());
+
+			await runTickOnce(dbPath);
+			expect(runSyncPass).toHaveBeenCalledWith(
+				expect.any(Database),
+				"peer-1",
+				expect.objectContaining({ keysDir: "/container/keys" }),
+			);
 		} finally {
 			fileDb.close();
 			rmSync(dbPath, { force: true });

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -58,6 +58,17 @@ export interface SyncTickResult {
 	opsOut?: number;
 }
 
+export function resolveSyncDaemonKeysDir(keysDir?: string): string | undefined {
+	const explicit = keysDir?.trim();
+	if (explicit) return explicit;
+	return process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
+}
+
+function tableColumnExists(db: Database, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string }>;
+	return rows.some((row) => row.name === column);
+}
+
 // ---------------------------------------------------------------------------
 // Daemon state helpers
 // ---------------------------------------------------------------------------
@@ -162,11 +173,14 @@ export async function syncDaemonTick(
 	stalePeers?: Set<string>,
 	scanner?: SecretScanner,
 ): Promise<SyncTickResult[]> {
-	const d = drizzle(db, { schema });
-	const rows = d
-		.select({ peer_device_id: schema.syncPeers.peer_device_id })
-		.from(schema.syncPeers)
-		.all();
+	const hasPinnedFingerprint = tableColumnExists(db, "sync_peers", "pinned_fingerprint");
+	const rows = db
+		.prepare(
+			hasPinnedFingerprint
+				? "SELECT peer_device_id, pinned_fingerprint FROM sync_peers"
+				: "SELECT peer_device_id, NULL AS pinned_fingerprint FROM sync_peers",
+		)
+		.all() as Array<{ peer_device_id: string; pinned_fingerprint: string | null }>;
 
 	// Skip heavy preflight work when there are no peers configured.
 	// This keeps startup and idle daemon ticks responsive on large local stores.
@@ -181,8 +195,10 @@ export async function syncDaemonTick(
 	const results: SyncTickResult[] = [];
 	for (const row of rows) {
 		const peerDeviceId = row.peer_device_id;
+		const pinnedFingerprint = String(row.pinned_fingerprint ?? "").trim();
+		const stalePeerKey = pinnedFingerprint ? `${peerDeviceId}:${pinnedFingerprint}` : "";
 
-		if (stalePeers?.has(peerDeviceId)) {
+		if (stalePeers?.has(peerDeviceId) || (stalePeerKey && stalePeers?.has(stalePeerKey))) {
 			results.push({
 				ok: false,
 				skipped: true,
@@ -229,7 +245,7 @@ export async function syncDaemonTick(
 export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> {
 	const intervalS = options?.intervalS ?? 120;
 	const dbPath = resolveDbPath(options?.dbPath);
-	const keysDir = options?.keysDir;
+	const keysDir = resolveSyncDaemonKeysDir(options?.keysDir);
 	const signal = options?.signal;
 	const onPhaseChange = options?.onPhaseChange;
 	const scanner = options?.scanner;
@@ -303,19 +319,20 @@ export async function runTickOnce(
 	keysDir?: string,
 	scanner?: SecretScanner,
 ): Promise<void> {
+	const resolvedKeysDir = resolveSyncDaemonKeysDir(keysDir);
 	const db = connectDb(dbPath);
 	try {
 		ensureAdditiveSchemaCompatibility(db);
 		try {
-			await refreshCoordinatorPresenceForDaemon(db, dbPath, keysDir);
+			await refreshCoordinatorPresenceForDaemon(db, dbPath, resolvedKeysDir);
 		} catch {
 			// Coordinator discovery is a supplemental surface. Keep direct peer sync running
 			// even when heartbeat posting fails for this tick.
 		}
 		// Best-effort: skip peers the coordinator reports as offline.
 		// Returns empty set when coordinator is disabled or lookup fails.
-		const stalePeers = await fetchCoordinatorStalePeers(db, dbPath, keysDir);
-		const results = await syncDaemonTick(db, keysDir, stalePeers, scanner);
+		const stalePeers = await fetchCoordinatorStalePeers(db, dbPath, resolvedKeysDir);
+		const results = await syncDaemonTick(db, resolvedKeysDir, stalePeers, scanner);
 		const needsAttention = results.some((r) => !r.ok && r.error?.includes("needs_attention"));
 		if (needsAttention) {
 			setSyncDaemonPhase(db, "needs_attention");

--- a/packages/core/src/sync-discovery.test.ts
+++ b/packages/core/src/sync-discovery.test.ts
@@ -7,11 +7,13 @@ import {
 	addressDedupeKey,
 	advertiseMdns,
 	discoverPeersViaMdns,
+	formatHostPort,
 	loadPeerAddresses,
 	mdnsAddressesForPeer,
 	mdnsEnabled,
 	mergeAddresses,
 	normalizeAddress,
+	normalizeMdnsTxtProperties,
 	recordPeerSuccess,
 	recordSyncAttempt,
 	selectDialAddresses,
@@ -58,6 +60,31 @@ describe("normalizeAddress", () => {
 	it("handles http:// prefix without port", () => {
 		expect(normalizeAddress("http://example.com")).toBe("http://example.com");
 	});
+
+	it("can infer the configured sync port for http advertised hosts", () => {
+		expect(normalizeAddress("nas.example.test", { defaultHttpPort: 7337 })).toBe(
+			"http://nas.example.test:7337",
+		);
+		expect(normalizeAddress("http://nas.example.test", { defaultHttpPort: 7337 })).toBe(
+			"http://nas.example.test:7337",
+		);
+	});
+
+	it("does not infer the sync port over an explicit default http port", () => {
+		expect(normalizeAddress("http://nas.example.test:80", { defaultHttpPort: 7337 })).toBe(
+			"http://nas.example.test",
+		);
+		expect(normalizeAddress("nas.example.test:80", { defaultHttpPort: 7337 })).toBe(
+			"http://nas.example.test",
+		);
+	});
+});
+
+describe("formatHostPort", () => {
+	it("brackets IPv6 literals before appending the port", () => {
+		expect(formatHostPort("fd00::1", 7337)).toBe("[fd00::1]:7337");
+		expect(normalizeAddress(formatHostPort("fd00::1", 7337))).toBe("http://[fd00::1]:7337");
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -65,8 +92,8 @@ describe("normalizeAddress", () => {
 // ---------------------------------------------------------------------------
 
 describe("addressDedupeKey", () => {
-	it("strips http scheme for host:port", () => {
-		expect(addressDedupeKey("http://192.168.1.1:9090")).toBe("192.168.1.1:9090");
+	it("keeps scheme for host:port", () => {
+		expect(addressDedupeKey("http://192.168.1.1:9090")).toBe("http://192.168.1.1:9090/");
 	});
 
 	it("returns as-is for non-URL input", () => {
@@ -77,11 +104,10 @@ describe("addressDedupeKey", () => {
 		expect(addressDedupeKey("")).toBe("");
 	});
 
-	it("returns full URL for addresses with paths", () => {
-		// Port 80 is default for http, so dedup key is just the host
-		expect(addressDedupeKey("http://host:80/path")).toBe("host");
-		// Non-default port preserves host:port
-		expect(addressDedupeKey("http://host:8080/path")).toBe("host:8080");
+	it("keeps scheme and path in the dedupe key", () => {
+		expect(addressDedupeKey("http://host:80/path")).toBe("http://host/path");
+		expect(addressDedupeKey("http://host:8080/path")).toBe("http://host:8080/path");
+		expect(addressDedupeKey("https://host:8080/path")).toBe("https://host:8080/path");
 	});
 });
 
@@ -170,6 +196,39 @@ describe("peer address storage", () => {
 		updatePeerAddresses(db, "peer-1", ["http://host:8080"]);
 		const loaded = loadPeerAddresses(db, "peer-1");
 		expect(loaded).toEqual(["http://host:8080"]);
+	});
+
+	it("fills missing trust material without replacing existing trust by default", () => {
+		updatePeerAddresses(db, "peer-1", ["host:8080"], {
+			pinnedFingerprint: "old-fp",
+			publicKey: "old-key",
+		});
+		updatePeerAddresses(db, "peer-1", ["host:8080"], {
+			pinnedFingerprint: "new-fp",
+			publicKey: "new-key",
+		});
+
+		const row = db
+			.prepare("SELECT pinned_fingerprint, public_key FROM sync_peers WHERE peer_device_id = ?")
+			.get("peer-1") as { pinned_fingerprint: string; public_key: string };
+		expect(row).toMatchObject({ pinned_fingerprint: "old-fp", public_key: "old-key" });
+	});
+
+	it("replaces stale trust material when accepting a fresh pairing payload", () => {
+		updatePeerAddresses(db, "peer-1", ["host:8080"], {
+			pinnedFingerprint: "old-fp",
+			publicKey: "old-key",
+		});
+		updatePeerAddresses(db, "peer-1", ["host:8080"], {
+			pinnedFingerprint: "new-fp",
+			publicKey: "new-key",
+			replaceTrust: true,
+		});
+
+		const row = db
+			.prepare("SELECT pinned_fingerprint, public_key FROM sync_peers WHERE peer_device_id = ?")
+			.get("peer-1") as { pinned_fingerprint: string; public_key: string };
+		expect(row).toMatchObject({ pinned_fingerprint: "new-fp", public_key: "new-key" });
 	});
 });
 
@@ -329,7 +388,7 @@ describe("mdnsAddressesForPeer", () => {
 			},
 		];
 		const addresses = mdnsAddressesForPeer("peer-1", entries);
-		expect(addresses).toEqual(["peer-host.local:9090"]);
+		expect(addresses).toEqual(["http://peer-host.local:9090"]);
 	});
 
 	it("returns empty for no matching peer", () => {
@@ -356,7 +415,28 @@ describe("mdnsAddressesForPeer", () => {
 				properties: { device_id: new TextEncoder().encode("peer-1") },
 			},
 		];
-		expect(mdnsAddressesForPeer("peer-1", entries)).toEqual(["host.local:9090"]);
+		expect(mdnsAddressesForPeer("peer-1", entries)).toEqual(["http://host.local:9090"]);
+	});
+
+	it("brackets IPv6 resolved addresses", () => {
+		const entries = [
+			{
+				host: "peer-host.local",
+				address: "fd00::1",
+				port: 9090,
+				properties: { device_id: "peer-1" },
+			},
+		];
+		expect(mdnsAddressesForPeer("peer-1", entries)).toEqual(["http://[fd00::1]:9090"]);
+	});
+
+	it("preserves binary TXT device IDs for matching", () => {
+		const deviceId = new TextEncoder().encode("peer-1");
+		const properties = normalizeMdnsTxtProperties({ device_id: deviceId });
+		expect(properties.device_id).toBe(deviceId);
+		expect(
+			mdnsAddressesForPeer("peer-1", [{ host: "host.local", port: 9090, properties }]),
+		).toEqual(["http://host.local:9090"]);
 	});
 });
 

--- a/packages/core/src/sync-discovery.ts
+++ b/packages/core/src/sync-discovery.ts
@@ -8,7 +8,7 @@
 import { createRequire } from "node:module";
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
-import { mergeAddresses, normalizeAddress } from "./address-utils.js";
+import { formatHostPort, mergeAddresses, normalizeAddress } from "./address-utils.js";
 import { readCoordinatorSyncConfig } from "./coordinator-runtime.js";
 import type { Database } from "./db.js";
 import * as schema from "./schema.js";
@@ -16,7 +16,12 @@ import * as schema from "./schema.js";
 const requireFromHere = createRequire(import.meta.url);
 
 // Re-export for consumers that import from sync-discovery
-export { addressDedupeKey, mergeAddresses, normalizeAddress } from "./address-utils.js";
+export {
+	addressDedupeKey,
+	formatHostPort,
+	mergeAddresses,
+	normalizeAddress,
+} from "./address-utils.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -78,6 +83,7 @@ export function updatePeerAddresses(
 		name?: string;
 		pinnedFingerprint?: string;
 		publicKey?: string;
+		replaceTrust?: boolean;
 	},
 ): string[] {
 	const merged = mergeAddresses(loadPeerAddresses(db, peerDeviceId), addresses);
@@ -100,8 +106,12 @@ export function updatePeerAddresses(
 			target: schema.syncPeers.peer_device_id,
 			set: {
 				name: sql`COALESCE(excluded.name, ${schema.syncPeers.name})`,
-				pinned_fingerprint: sql`COALESCE(excluded.pinned_fingerprint, ${schema.syncPeers.pinned_fingerprint})`,
-				public_key: sql`COALESCE(excluded.public_key, ${schema.syncPeers.public_key})`,
+				pinned_fingerprint: options?.replaceTrust
+					? sql`COALESCE(excluded.pinned_fingerprint, ${schema.syncPeers.pinned_fingerprint})`
+					: sql`COALESCE(${schema.syncPeers.pinned_fingerprint}, excluded.pinned_fingerprint)`,
+				public_key: options?.replaceTrust
+					? sql`COALESCE(excluded.public_key, ${schema.syncPeers.public_key})`
+					: sql`COALESCE(${schema.syncPeers.public_key}, excluded.public_key)`,
 				addresses_json: sql`excluded.addresses_json`,
 				last_seen_at: sql`excluded.last_seen_at`,
 			},
@@ -231,6 +241,16 @@ export interface MdnsEntry {
 	port?: number;
 	address?: Uint8Array | string;
 	properties?: Record<string, string | Uint8Array>;
+}
+
+export function normalizeMdnsTxtProperties(
+	txt: Record<string, unknown>,
+): Record<string, string | Uint8Array> {
+	const properties: Record<string, string | Uint8Array> = {};
+	for (const [key, value] of Object.entries(txt)) {
+		properties[key] = value instanceof Uint8Array ? value : String(value);
+	}
+	return properties;
 }
 
 const MDNS_SERVICE_TYPE = "codemem"; // advertises as _codemem._tcp.local.
@@ -416,18 +436,16 @@ export async function discoverPeersViaMdns(timeoutMs = 1500): Promise<MdnsEntry[
 			if (seen.has(key)) return;
 			seen.add(key);
 			const addresses = Array.isArray(svc.addresses) ? svc.addresses : [];
-			const ipv4 = addresses.find((addr) => addr && /^[\d.]+$/.test(addr));
-			const properties: Record<string, string> = {};
+			const resolvedAddress =
+				addresses.find((addr) => addr && /^[\d.]+$/.test(addr)) ??
+				addresses.find((addr) => typeof addr === "string" && addr.trim().length > 0);
 			const rawTxt = svc.txt ?? {};
-			for (const [key, value] of Object.entries(rawTxt)) {
-				properties[key] = String(value);
-			}
 			found.push({
 				name: svc.name,
 				host: (svc.host || svc.fqdn || "").replace(/\.$/, ""),
 				port: svc.port,
-				address: ipv4,
-				properties,
+				address: resolvedAddress,
+				properties: normalizeMdnsTxtProperties(rawTxt),
 			});
 		});
 		await new Promise<void>((resolve) => setTimeout(resolve, Math.max(100, timeoutMs)));
@@ -469,7 +487,8 @@ export function mdnsAddressesForPeer(peerDeviceId: string, entries: MdnsEntry[])
 		const host = entry.host ?? "";
 		const dialHost = address && !address.includes(".local") ? address : host;
 		if (dialHost && !dialHost.includes("_tcp.local") && !dialHost.includes("_udp.local")) {
-			addresses.push(`${dialHost}:${port}`);
+			const normalized = normalizeAddress(formatHostPort(dialHost, port));
+			if (normalized) addresses.push(normalized);
 		}
 	}
 	return addresses;

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -121,15 +121,14 @@ export async function renamePeer(peerDeviceId: string, name: string): Promise<un
 
 export async function acceptDiscoveredPeer(
 	peerDeviceId: string,
-	fingerprint: string,
+	fingerprint?: string,
 ): Promise<AcceptDiscoveredPeerResult> {
+	const body: Record<string, string> = { peer_device_id: peerDeviceId };
+	if (fingerprint) body.fingerprint = fingerprint;
 	const resp = await fetch("/api/sync/peers/accept-discovered", {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			peer_device_id: peerDeviceId,
-			fingerprint,
-		}),
+		body: JSON.stringify(body),
 	});
 	const text = await resp.text();
 	let payload: AcceptDiscoveredPeerResult = {};

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -133,6 +133,7 @@ export interface DiscoveredDevice {
 	fingerprint?: string;
 	groups?: string[];
 	stale?: boolean;
+	address_count?: number;
 	addresses?: string[];
 	needs_local_approval?: boolean;
 	waiting_for_peer_approval?: boolean;

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -106,6 +106,7 @@ const DIRECTION_GLYPH: Record<PeerDirection, { glyph: string; label: string } | 
 
 type SyncPeer = PeerLike & {
 	actor_display_name?: string;
+	address_count?: number;
 	addresses?: unknown[];
 	claimed_local_actor?: boolean;
 	claimed_local_actor_scope?: PeerClaimedLocalActorScopeLike | null;
@@ -201,11 +202,16 @@ function SyncPeerCard({
 	const peerAddresses = Array.isArray(peer.addresses)
 		? Array.from(new Set(peer.addresses.filter(Boolean).map((value) => String(value))))
 		: [];
+	const rawHiddenAddressCount = Number(peer.address_count ?? 0);
+	const hiddenAddressCount =
+		Number.isFinite(rawHiddenAddressCount) && rawHiddenAddressCount > 0 ? rawHiddenAddressCount : 0;
 	const addressLine = peerAddresses.length
 		? peerAddresses
 				.map((address) => (isSyncRedactionEnabled() ? redactAddress(address) : address))
 				.join(" · ")
-		: "No addresses";
+		: hiddenAddressCount > 0
+			? `${hiddenAddressCount} ${hiddenAddressCount === 1 ? "address" : "addresses"} hidden`
+			: "No addresses";
 	const assignmentSummary = peer.actor_display_name
 		? `This device belongs to ${peer.claimed_local_actor ? "you" : String(peer.actor_display_name)}.`
 		: "This device is not assigned to anyone yet.";
@@ -325,7 +331,6 @@ function SyncPeerCard({
 	}
 
 	async function sync() {
-		if (!primaryAddress) return;
 		if (pendingScopeReview) {
 			const proceed = await openSyncConfirmDialog({
 				title: `Sync ${displayName} before scope review?`,
@@ -527,8 +532,13 @@ function SyncPeerCard({
 						<button
 							type="button"
 							className="settings-button"
-							disabled={!primaryAddress || syncBusy}
+							disabled={syncBusy}
 							onClick={() => void sync()}
+							title={
+								primaryAddress
+									? undefined
+									: "Address details are hidden; sync will use the server's eligible peer list."
+							}
 						>
 							{syncBusy ? "Syncing…" : "Sync now"}
 						</button>

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -285,6 +285,11 @@ export function renderTeamSync() {
 			pairedLocally: Boolean(pairedPeer),
 		});
 		const addresses = Array.isArray(device.addresses) ? device.addresses : [];
+		const rawHiddenAddressCount = Number(device.address_count ?? 0);
+		const hiddenAddressCount =
+			Number.isFinite(rawHiddenAddressCount) && rawHiddenAddressCount > 0
+				? rawHiddenAddressCount
+				: 0;
 		const addressLabel = addresses.length
 			? addresses
 					.map((address) =>
@@ -292,7 +297,9 @@ export function renderTeamSync() {
 					)
 					.filter(Boolean)
 					.join(" · ")
-			: "No fresh addresses";
+			: hiddenAddressCount > 0
+				? `${hiddenAddressCount} ${device.stale ? "last-known" : "fresh"} ${hiddenAddressCount === 1 ? "address" : "addresses"} hidden`
+				: "No fresh addresses";
 		const noteParts = [addressLabel];
 		if (!addresses.length && displayTitle) noteParts.push(`device id: ${deviceId}`);
 		let actionMessage: string | null = null;

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -659,3 +659,14 @@ describe("deriveSyncViewModel", () => {
 		});
 	});
 });
+
+describe("shouldShowCoordinatorReviewAction", () => {
+	it("allows fresh unpaired discovered devices without a visible fingerprint", () => {
+		expect(
+			shouldShowCoordinatorReviewAction({
+				device: { device_id: "peer-1", stale: false },
+				pairedLocally: false,
+			}),
+		).toBe(true);
+	});
+});

--- a/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
+++ b/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
@@ -56,8 +56,7 @@ export function shouldShowCoordinatorReviewAction(input: {
 }): boolean {
 	const approvalSummary = deriveCoordinatorApprovalSummary(input);
 	const deviceId = cleanText(input.device?.device_id);
-	const fingerprint = cleanText(input.device?.fingerprint);
-	if (!deviceId || !fingerprint) return false;
+	if (!deviceId) return false;
 	if (input.device?.stale || input.hasAmbiguousCoordinatorGroup) return false;
 	if (!input.pairedLocally) return true;
 	return approvalSummary.state === "needs-your-approval";

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -178,6 +178,8 @@ export interface DiscoveredDeviceLike {
 	stale?: boolean;
 	fingerprint?: string;
 	groups?: string[];
+	address_count?: number;
+	addresses?: unknown[];
 	needs_local_approval?: boolean;
 	waiting_for_peer_approval?: boolean;
 }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -51,6 +51,11 @@ function createTestStore(): { store: MemoryStore; cleanup: () => void } {
 	};
 }
 
+const FRESH_PEER_PUBLIC_KEY = "peer-public-key";
+const FRESH_PEER_FINGERPRINT = core.fingerprintPublicKey(FRESH_PEER_PUBLIC_KEY);
+const REKEYED_PEER_PUBLIC_KEY = "peer-rekeyed-public-key";
+const REKEYED_PEER_FINGERPRINT = core.fingerprintPublicKey(REKEYED_PEER_PUBLIC_KEY);
+
 function insertTestMemory(
 	store: MemoryStore,
 	options: {
@@ -3252,7 +3257,24 @@ describe("viewer-server", () => {
 				expect(res.status).toBe(401);
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body.error).toBe("unauthorized");
+				expect(body.reason).toBeUndefined();
 			} finally {
+				cleanup();
+			}
+		});
+
+		it("exposes sync auth failure reasons only when diagnostics are explicitly enabled", async () => {
+			const previous = process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS;
+			process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS = "1";
+			const { syncApp, cleanup } = createTestApp();
+			try {
+				const res = await syncApp.request("/v1/status");
+				expect(res.status).toBe(401);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({ error: "unauthorized", reason: "bootstrap_grant_invalid" });
+			} finally {
+				if (previous === undefined) delete process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS;
+				else process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS = previous;
 				cleanup();
 			}
 		});
@@ -5154,7 +5176,7 @@ describe("viewer-server", () => {
 				expect(body.device_id).toBeTruthy();
 				expect(body.fingerprint).toBeTruthy();
 				expect(body.public_key).toBeTruthy();
-				expect(body.addresses).toEqual(["127.0.0.1:7337"]);
+				expect(body.addresses).toEqual(["http://127.0.0.1:7337"]);
 			} finally {
 				cleanup();
 				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
@@ -5667,8 +5689,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -5762,8 +5784,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									groups: ["team-a"],
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
@@ -5961,8 +5983,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -6020,7 +6042,9 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+					}),
 				});
 				expect(res.status).toBe(200);
 				expect(await res.json()).toEqual({
@@ -6040,14 +6064,93 @@ describe("viewer-server", () => {
 					expect.objectContaining({
 						peer_device_id: "peer-fresh",
 						name: "Fresh Device",
-						pinned_fingerprint: "fp-fresh",
-						public_key: "peer-public-key",
+						pinned_fingerprint: FRESH_PEER_FINGERPRINT,
+						public_key: FRESH_PEER_PUBLIC_KEY,
 						last_error: null,
 					}),
 				);
 				expect(JSON.parse(String(peerRow?.addresses_json ?? "[]"))).toEqual([
 					"http://10.0.0.5:7337",
 				]);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("rejects stale discovered coordinator devices before publishing reciprocal approval", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/peers")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-fresh",
+									display_name: "Stale Device",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
+									addresses: ["http://10.0.0.5:7337"],
+									expires_at: new Date(Date.now() - 60_000).toISOString(),
+									stale: true,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
+				});
+				expect(res.status).toBe(409);
+				expect(await res.json()).toEqual({
+					error: "discovered_peer_stale",
+					detail:
+						"This discovered device's coordinator presence is stale. Wait for it to come online and refresh sync status before trusting it.",
+				});
+				expect(
+					fetchMock.mock.calls.some(([input]) =>
+						String(input).includes("/v1/reciprocal-approvals"),
+					),
+				).toBe(false);
+				expect(
+					store.db
+						.prepare("SELECT peer_device_id FROM sync_peers WHERE peer_device_id = ?")
+						.get("peer-fresh"),
+				).toBeUndefined();
 			} finally {
 				cleanup();
 				globalThis.fetch = prevFetch;
@@ -6072,8 +6175,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									groups: ["team-a"],
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
@@ -6111,7 +6214,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(502);
 				expect(await res.json()).toEqual({
@@ -6146,8 +6252,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -6165,8 +6271,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.6:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -6200,7 +6306,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(409);
 				expect(await res.json()).toEqual({
@@ -7346,6 +7455,49 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("redacts sync attempt errors unless diagnostics are requested", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const now = new Date().toISOString();
+				store.db
+					.prepare(
+						"INSERT INTO sync_attempts(peer_device_id, started_at, finished_at, ok, ops_in, ops_out, error) VALUES (?, ?, ?, 0, 0, 0, ?)",
+					)
+					.run(
+						"peer-1",
+						now,
+						now,
+						"all addresses failed | http://10.0.0.5:7337: unauthorized:fingerprint_mismatch",
+					);
+
+				const redactedRes = await app.request("/api/sync/attempts");
+				expect(redactedRes.status).toBe(200);
+				const redactedBody = (await redactedRes.json()) as {
+					items: Array<{ error: string | null; address: string | null }>;
+					redacted: boolean;
+				};
+				expect(redactedBody.redacted).toBe(true);
+				expect(redactedBody.items[0]?.error).toBe(
+					"sync attempt failed; enable diagnostics for details",
+				);
+				expect(redactedBody.items[0]?.address).toBeNull();
+
+				const diagnosticRes = await app.request("/api/sync/attempts?includeDiagnostics=1");
+				expect(diagnosticRes.status).toBe(200);
+				const diagnosticBody = (await diagnosticRes.json()) as {
+					items: Array<{ error: string | null }>;
+					redacted: boolean;
+				};
+				expect(diagnosticBody.redacted).toBe(false);
+				expect(diagnosticBody.items[0]?.error).toContain("fingerprint_mismatch");
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("creates, renames, and merges actors through viewer routes", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {
@@ -7476,8 +7628,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -7539,7 +7691,7 @@ describe("viewer-server", () => {
 					.run(
 						"peer-fresh",
 						"Old Name",
-						"fp-fresh",
+						FRESH_PEER_FINGERPRINT,
 						JSON.stringify(["http://old.example:7337"]),
 						"offline",
 						new Date().toISOString(),
@@ -7547,7 +7699,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(200);
 				expect(await res.json()).toEqual({
@@ -7566,13 +7721,13 @@ describe("viewer-server", () => {
 				expect(peerRow).toEqual(
 					expect.objectContaining({
 						name: "Fresh Device",
-						pinned_fingerprint: "fp-fresh",
+						pinned_fingerprint: FRESH_PEER_FINGERPRINT,
 						last_error: "offline",
 					}),
 				);
 				expect(JSON.parse(String(peerRow?.addresses_json ?? "[]"))).toEqual([
-					"http://old.example:7337",
 					"http://10.0.0.5:7337",
+					"http://old.example:7337",
 				]);
 			} finally {
 				cleanup();
@@ -7603,8 +7758,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -7622,8 +7777,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["10.0.0.6:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -7664,7 +7819,7 @@ describe("viewer-server", () => {
 					.run(
 						"peer-fresh",
 						"Old Name",
-						"fp-fresh",
+						FRESH_PEER_FINGERPRINT,
 						JSON.stringify(["http://old.example:7337"]),
 						"all addresses failed",
 						new Date().toISOString(),
@@ -7676,17 +7831,17 @@ describe("viewer-server", () => {
 				const body = (await res.json()) as { peers?: Array<Record<string, unknown>> };
 				const peerPayload = body.peers?.find((peer) => peer.peer_device_id === "peer-fresh");
 				expect(peerPayload?.addresses).toEqual([
-					"http://old.example:7337",
 					"http://10.0.0.5:7337",
 					"http://10.0.0.6:7337",
+					"http://old.example:7337",
 				]);
 				const peerRow = store.db
 					.prepare("SELECT addresses_json, last_error FROM sync_peers WHERE peer_device_id = ?")
 					.get("peer-fresh") as Record<string, unknown> | undefined;
 				expect(JSON.parse(String(peerRow?.addresses_json ?? "[]"))).toEqual([
-					"http://old.example:7337",
 					"http://10.0.0.5:7337",
 					"http://10.0.0.6:7337",
+					"http://old.example:7337",
 				]);
 				expect(peerRow?.last_error).toBe("all addresses failed");
 				expect(
@@ -7719,8 +7874,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-new",
-									public_key: "peer-public-key",
+									fingerprint: REKEYED_PEER_FINGERPRINT,
+									public_key: REKEYED_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -7759,7 +7914,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-new" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: REKEYED_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(409);
 				expect(await res.json()).toEqual({
@@ -7810,7 +7968,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(404);
 				expect(await res.json()).toEqual({
@@ -7838,7 +7999,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(400);
 				expect(await res.json()).toEqual({
@@ -7866,8 +8030,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -7925,7 +8089,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(200);
 				expect(await res.json()).toEqual(
@@ -7977,7 +8144,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(502);
 				expect(await res.json()).toEqual({
@@ -8422,6 +8592,57 @@ describe("viewer-server", () => {
 				expect(row?.pinned_fingerprint).toBe(peerFingerprint);
 			} finally {
 				cleanup();
+			}
+		});
+
+		it("rejects a device pairing payload that conflicts with an existing trusted fingerprint", async () => {
+			const peerKeysDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-keys-"));
+			const peerDbDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-db-"));
+			const peerDbPath = join(peerDbDir, "peer.sqlite");
+			const peerDb = new Database(peerDbPath);
+			initTestSchema(peerDb);
+			const [peerDeviceId, peerFingerprint] = ensureDeviceIdentity(peerDb, {
+				keysDir: peerKeysDir,
+			});
+			const peerPublicKey = loadPublicKey(peerKeysDir) ?? "";
+			peerDb.close();
+			const pairingPayload = {
+				device_id: peerDeviceId,
+				fingerprint: peerFingerprint,
+				public_key: peerPublicKey,
+				addresses: ["http://10.10.10.10:7337"],
+			};
+			const invite = Buffer.from(JSON.stringify(pairingPayload), "utf8").toString("base64");
+
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, public_key, addresses_json, created_at) VALUES (?, ?, ?, ?, ?)",
+					)
+					.run(peerDeviceId, "old-fingerprint", "old-public-key", "[]", new Date().toISOString());
+
+				const res = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite }),
+				});
+				expect(res.status).toBe(409);
+				expect(await res.json()).toMatchObject({ error: "peer_conflict" });
+				const row = store.db
+					.prepare("SELECT pinned_fingerprint, public_key FROM sync_peers WHERE peer_device_id = ?")
+					.get(peerDeviceId) as { pinned_fingerprint?: string; public_key?: string } | undefined;
+				expect(row).toMatchObject({
+					pinned_fingerprint: "old-fingerprint",
+					public_key: "old-public-key",
+				});
+			} finally {
+				cleanup();
+				rmSync(peerKeysDir, { recursive: true, force: true });
+				rmSync(peerDbDir, { recursive: true, force: true });
 			}
 		});
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -55,6 +55,7 @@ import {
 	type FilterReplicationSkipped,
 	filterReplicationOpsForSyncWithStatus,
 	fingerprintPublicKey,
+	formatHostPort,
 	getCoordinatorGroupPreference,
 	getSemanticIndexDiagnostics,
 	getSyncResetState,
@@ -74,6 +75,7 @@ import {
 	lookupCoordinatorPeers,
 	mergeAddresses,
 	negotiateSyncCapability,
+	normalizeAddress,
 	normalizeSyncCapability,
 	parseSyncScopeRequest,
 	personalScopeGrantStatusForPeer,
@@ -278,7 +280,7 @@ async function ensureDefaultSpaceForTeam(opts: {
 			remoteUrl: opts.config.syncCoordinatorUrl || null,
 			adminSecret: opts.config.syncCoordinatorAdminSecret || null,
 		}));
-	const [deviceId] = ensureDeviceIdentity(opts.store.db);
+	const [deviceId] = ensureDeviceIdentity(opts.store.db, { keysDir: syncKeysDir() });
 	const membership = await coordinatorGrantScopeMembershipAction({
 		groupId: opts.groupId,
 		scopeId,
@@ -495,17 +497,19 @@ function pairingAdvertiseAddresses(config = readCoordinatorSyncConfig()): string
 				.split(",")
 				.map((item) => item.trim())
 				.filter(Boolean),
+			{ defaultHttpPort: config.syncPort },
 		);
 	}
 	if (config.syncHost && config.syncHost !== "0.0.0.0") {
-		return [`${config.syncHost}:${config.syncPort}`];
+		return [normalizeAddress(formatHostPort(config.syncHost, config.syncPort))].filter(Boolean);
 	}
 	const addresses = Object.values(networkInterfaces())
 		.flatMap((entries) => entries ?? [])
 		.filter((entry) => !entry.internal)
 		.map((entry) => entry.address)
 		.filter((address) => address && address !== "127.0.0.1" && address !== "::1")
-		.map((address) => `${address}:${config.syncPort}`);
+		.map((address) => normalizeAddress(formatHostPort(address, config.syncPort)))
+		.filter(Boolean);
 	return [...new Set(addresses)];
 }
 
@@ -1024,6 +1028,7 @@ function redactCoordinatorStatus(
 		? coordinator.discovered_devices.map((item) => {
 				if (!item || typeof item !== "object") return item;
 				const record = item as Record<string, unknown>;
+				const addressCount = Array.isArray(record.addresses) ? record.addresses.length : 0;
 				return {
 					device_id: record.device_id,
 					display_name: record.display_name ?? null,
@@ -1037,6 +1042,7 @@ function redactCoordinatorStatus(
 					outgoing_reciprocal_request_id: record.outgoing_reciprocal_request_id ?? null,
 					fingerprint: null,
 					addresses: [],
+					address_count: addressCount,
 				};
 			})
 		: [];
@@ -1048,7 +1054,7 @@ function redactCoordinatorStatus(
 
 interface AcceptDiscoveredPeerOptions {
 	peerDeviceId: string;
-	fingerprint: string;
+	fingerprint?: string;
 	// Optional per-peer scope override. When undefined the group's scope
 	// template is applied if auto_seed_scope is enabled; otherwise the peer
 	// is enrolled with no scope filters.
@@ -1094,17 +1100,43 @@ async function acceptDiscoveredPeer(
 		};
 	}
 	const discovered = await lookupCoordinatorPeers(store, config);
-	const match = discovered.find(
-		(peer) =>
-			String(peer.device_id ?? "").trim() === input.peerDeviceId &&
-			String(peer.fingerprint ?? "").trim() === input.fingerprint,
+	const inputFingerprint = String(input.fingerprint ?? "").trim();
+	const candidates = discovered.filter(
+		(peer) => String(peer.device_id ?? "").trim() === input.peerDeviceId,
 	);
+	const matchingCandidates = inputFingerprint
+		? candidates.filter((peer) => String(peer.fingerprint ?? "").trim() === inputFingerprint)
+		: candidates;
+	const uniqueFingerprints = new Set(
+		matchingCandidates.map((peer) => String(peer.fingerprint ?? "").trim()).filter(Boolean),
+	);
+	if (!inputFingerprint && uniqueFingerprints.size > 1) {
+		return {
+			ok: false,
+			status: 409,
+			error: "ambiguous_discovered_peer",
+			detail:
+				"That discovered device has multiple coordinator fingerprints. Enable diagnostics, refresh sync status, and choose the intended device before trusting it.",
+		};
+	}
+	const match = matchingCandidates[0];
 	if (!match) {
 		return {
 			ok: false,
 			status: 404,
 			error: "discovered_peer_not_found",
 			detail: "That discovered device is no longer available. Refresh sync status and try again.",
+		};
+	}
+	const expiresAt = String(match.expires_at ?? "").trim();
+	const expired = expiresAt ? Date.parse(expiresAt) <= Date.now() : false;
+	if (match.stale || expired) {
+		return {
+			ok: false,
+			status: 409,
+			error: "discovered_peer_stale",
+			detail:
+				"This discovered device's coordinator presence is stale. Wait for it to come online and refresh sync status before trusting it.",
 		};
 	}
 	const nextFingerprint = String(match.fingerprint ?? "").trim();
@@ -1122,9 +1154,21 @@ async function acceptDiscoveredPeer(
 				"This discovered device is missing its coordinator public key. Refresh sync status and try again.",
 		};
 	}
+	if (!nextFingerprint || fingerprintPublicKey(nextPublicKey) !== nextFingerprint) {
+		return {
+			ok: false,
+			status: 409,
+			error: "discovered_peer_fingerprint_mismatch",
+			detail:
+				"This discovered device's coordinator public key does not match its fingerprint. Refresh sync status or re-enroll the device before trusting it.",
+		};
+	}
 
 	const groupIds = Array.isArray(match.groups)
 		? match.groups.map((value) => String(value ?? "").trim()).filter(Boolean)
+		: [];
+	const freshGroupIds = Array.isArray(match.fresh_groups)
+		? match.fresh_groups.map((value) => String(value ?? "").trim()).filter(Boolean)
 		: [];
 	let groupId: string;
 	if (input.expectedGroupId) {
@@ -1135,6 +1179,15 @@ async function acceptDiscoveredPeer(
 				error: "peer_not_in_group",
 				detail:
 					"This discovered device is not visible through the specified coordinator group. Refresh sync status and try again.",
+			};
+		}
+		if (!freshGroupIds.includes(input.expectedGroupId)) {
+			return {
+				ok: false,
+				status: 409,
+				error: "discovered_peer_stale",
+				detail:
+					"This discovered device's coordinator presence is stale for the specified group. Wait for it to come online and refresh sync status before trusting it.",
 			};
 		}
 		groupId = input.expectedGroupId;
@@ -1184,7 +1237,7 @@ async function acceptDiscoveredPeer(
 			return [];
 		}
 	})();
-	const addressesJson = JSON.stringify(mergeAddresses(existingAddresses, nextAddresses));
+	const addressesJson = JSON.stringify(mergeAddresses(nextAddresses, existingAddresses));
 	await createCoordinatorReciprocalApproval(store, config, {
 		groupId,
 		requestedDeviceId: input.peerDeviceId,
@@ -1325,12 +1378,14 @@ function mapPeerRow(
 	const peerId = String(row.peer_device_id ?? "");
 	const recentOps = recentOpsByPeer?.get(peerId) ?? { in: 0, out: 0 };
 	const scopeRejections = scopeRejectionsByPeer?.get(peerId);
+	const addresses = safeJsonList(row.addresses_json as string | null);
 	return {
 		peer_device_id: row.peer_device_id,
 		name: row.name,
 		fingerprint: showDiag ? row.pinned_fingerprint : null,
 		pinned: Boolean(row.pinned_fingerprint),
-		addresses: showDiag ? safeJsonList(row.addresses_json as string | null) : [],
+		addresses: showDiag ? addresses : [],
+		address_count: addresses.length,
 		last_seen_at: row.last_seen_at,
 		last_sync_at: row.last_sync_at,
 		last_error: showDiag ? row.last_error : null,
@@ -1355,6 +1410,25 @@ function mapPeerRow(
 				: null,
 		discovered_via_group_id:
 			typeof row.discovered_via_group_id === "string" ? row.discovered_via_group_id : null,
+	};
+}
+
+function redactSyncAttemptError(error: unknown): string | null {
+	const text = String(error ?? "").trim();
+	if (!text) return null;
+	return "sync attempt failed; enable diagnostics for details";
+}
+
+function mapSyncAttemptRow(
+	row: Record<string, unknown>,
+	showDiag: boolean,
+	addresses?: string[],
+): Record<string, unknown> {
+	return {
+		...row,
+		error: showDiag ? row.error : redactSyncAttemptError(row.error),
+		status: attemptStatus(row),
+		address: showDiag && addresses?.length ? addresses[0] : null,
 	};
 }
 
@@ -1955,14 +2029,15 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				// Specific reasons are logged server-side; wire responses use a generic
 				// reason to prevent info-disclosure.
 				if (bootstrapAttempted) {
+					const grantPresent = Boolean((c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim());
 					console.warn(
-						`[sync] bootstrap grant auth failed: reason=${auth.reason} grant=${(c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim()} path=${c.req.path}`,
+						`[sync] bootstrap grant auth failed: reason=${auth.reason} grant_present=${grantPresent} path=${c.req.path}`,
 					);
 				}
 				const wireReason = bootstrapAttempted ? "bootstrap_grant_invalid" : auth.reason;
 				return (
 					(preauthChecked ? null : rateLimitedResponse(c, c.req.path, false)) ??
-					c.json(unauthorizedPayload(wireReason), 401)
+					c.json(unauthorizedPayload(wireReason, true), 401)
 				);
 			}
 			const limited = rateLimitedResponse(c, auth.deviceId, true);
@@ -1993,7 +2068,8 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 		if (!auth.ok)
 			return (
-				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)
+				rateLimitedResponse(c, c.req.path, false) ??
+				c.json(unauthorizedPayload(auth.reason, true), 401)
 			);
 		const limited = rateLimitedResponse(c, auth.deviceId, true);
 		if (limited) return limited;
@@ -2090,14 +2166,15 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				// Specific reasons are logged server-side; wire responses use a generic
 				// reason to prevent info-disclosure.
 				if (bootstrapAttempted) {
+					const grantPresent = Boolean((c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim());
 					console.warn(
-						`[sync] bootstrap grant auth failed: reason=${auth.reason} grant=${(c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim()} path=${c.req.path}`,
+						`[sync] bootstrap grant auth failed: reason=${auth.reason} grant_present=${grantPresent} path=${c.req.path}`,
 					);
 				}
 				const wireReason = bootstrapAttempted ? "bootstrap_grant_invalid" : auth.reason;
 				return (
 					(preauthChecked ? null : rateLimitedResponse(c, c.req.path, false)) ??
-					c.json(unauthorizedPayload(wireReason), 401)
+					c.json(unauthorizedPayload(wireReason, true), 401)
 				);
 			}
 			const limited = rateLimitedResponse(c, auth.deviceId, true);
@@ -2177,7 +2254,8 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 		if (!auth.ok)
 			return (
-				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)
+				rateLimitedResponse(c, c.req.path, false) ??
+				c.json(unauthorizedPayload(auth.reason, true), 401)
 			);
 		const limited = rateLimitedResponse(c, auth.deviceId, true);
 		if (limited) return limited;
@@ -2509,13 +2587,9 @@ export function syncRoutes(
 			});
 			const attemptsItems = attemptRows.map((row) => {
 				const addrs = showDiag ? peerAddressMap.get(String(row.peer_device_id ?? "")) : undefined;
-				return {
-					...row,
-					status: attemptStatus(row),
-					address: addrs?.length ? addrs[0] : null,
-				};
+				return mapSyncAttemptRow(row, showDiag, addrs);
 			});
-			const latestAttemptError = String(attemptsItems[0]?.error || "").trim();
+			const latestAttemptError = String(attemptRows[0]?.error || "").trim();
 
 			const statusBlock: Record<string, unknown> = {
 				...statusPayload,
@@ -2696,7 +2770,9 @@ export function syncRoutes(
 				.orderBy(desc(schema.syncAttempts.finished_at))
 				.limit(limit)
 				.all();
-			return c.json({ items: rows });
+			const showDiag = queryBool(c.req.query("includeDiagnostics"));
+			const items = rows.map((row) => mapSyncAttemptRow(row, showDiag));
+			return c.json({ items, redacted: !showDiag });
 		}
 	});
 
@@ -2713,39 +2789,22 @@ export function syncRoutes(
 		{
 			const config = readCoordinatorSyncConfig();
 			const d = drizzle(store.db, { schema });
-			const deviceRow = d
-				.select({
-					device_id: schema.syncDevice.device_id,
-					public_key: schema.syncDevice.public_key,
-					fingerprint: schema.syncDevice.fingerprint,
-				})
-				.from(schema.syncDevice)
-				.limit(1)
-				.get();
-
 			let deviceId: string | undefined;
 			let publicKey: string | undefined;
 			let fingerprint: string | undefined;
 
-			if (deviceRow) {
-				deviceId = String(deviceRow.device_id);
-				publicKey = String(deviceRow.public_key);
-				fingerprint = String(deviceRow.fingerprint);
-			} else {
-				// Fall back to ensureDeviceIdentity if no row exists
-				try {
-					const [id, fp] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
-					deviceId = id;
-					fingerprint = fp;
-					const newRow = d
-						.select({ public_key: schema.syncDevice.public_key })
-						.from(schema.syncDevice)
-						.where(eq(schema.syncDevice.device_id, id))
-						.get();
-					publicKey = newRow?.public_key ?? "";
-				} catch {
-					return c.json({ error: "device identity unavailable" }, 500);
-				}
+			try {
+				const [id, fp] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
+				deviceId = id;
+				fingerprint = fp;
+				const row = d
+					.select({ public_key: schema.syncDevice.public_key })
+					.from(schema.syncDevice)
+					.where(eq(schema.syncDevice.device_id, id))
+					.get();
+				publicKey = row?.public_key ?? "";
+			} catch {
+				return c.json({ error: "device identity unavailable" }, 500);
 			}
 
 			if (!deviceId || !fingerprint) {
@@ -3348,9 +3407,11 @@ export function syncRoutes(
 		const peerDeviceId = String(body.peer_device_id ?? "").trim();
 		const fingerprint = String(body.fingerprint ?? "").trim();
 		if (!peerDeviceId) return c.json({ error: "peer_device_id required" }, 400);
-		if (!fingerprint) return c.json({ error: "fingerprint required" }, 400);
 		try {
-			const result = await acceptDiscoveredPeer(store, { peerDeviceId, fingerprint });
+			const result = await acceptDiscoveredPeer(store, {
+				peerDeviceId,
+				fingerprint: fingerprint || undefined,
+			});
 			if (!result.ok) {
 				return c.json(
 					{ error: result.error, detail: result.detail },
@@ -3443,9 +3504,27 @@ export function syncRoutes(
 		}
 		if (pairingResult?.kind === "pair") {
 			try {
+				const d = drizzle(store.db, { schema });
+				const existing = d
+					.select({ pinned_fingerprint: schema.syncPeers.pinned_fingerprint })
+					.from(schema.syncPeers)
+					.where(eq(schema.syncPeers.peer_device_id, pairingResult.device_id))
+					.get();
+				const existingFingerprint = String(existing?.pinned_fingerprint ?? "").trim();
+				if (existingFingerprint && existingFingerprint !== pairingResult.fingerprint) {
+					return c.json(
+						{
+							error: "peer_conflict",
+							detail:
+								"Pairing payload conflicts with the existing trusted fingerprint for this device. Remove or repair the old peer before accepting this pairing payload.",
+						},
+						409,
+					);
+				}
 				updatePeerAddresses(store.db, pairingResult.device_id, pairingResult.addresses, {
 					pinnedFingerprint: pairingResult.fingerprint,
 					publicKey: pairingResult.public_key,
+					replaceTrust: true,
 				});
 				return c.json({
 					ok: true,
@@ -4177,13 +4256,18 @@ export function syncRoutes(
 			const peerDeviceId = String(body.peer_device_id ?? "").trim();
 			const publicKey = String(body.peer_public_key ?? "").trim();
 			const name = String(body.name ?? "").trim() || null;
-			const fingerprint = String(body.fingerprint ?? "").trim() || null;
+			const requestedFingerprint = String(body.fingerprint ?? "").trim();
 			const addressesInput = Array.isArray(body.peer_addresses) ? body.peer_addresses : [];
-			const addresses = addressesInput
-				.map((item) => String(item ?? "").trim())
-				.filter((item) => item.length > 0);
+			const addresses = mergeAddresses(
+				[],
+				addressesInput.map((item) => String(item ?? "").trim()).filter((item) => item.length > 0),
+			);
 			if (!peerDeviceId || !publicKey) {
 				return c.json({ error: "peer_device_id_and_public_key_required" }, 400);
+			}
+			const fingerprint = requestedFingerprint || fingerprintPublicKey(publicKey);
+			if (fingerprintPublicKey(publicKey) !== fingerprint) {
+				return c.json({ error: "fingerprint_mismatch" }, 400);
 			}
 			const manualInclude =
 				overrideInclude && overrideInclude.length > 0 ? JSON.stringify(overrideInclude) : null;


### PR DESCRIPTION
## Description
Harden coordinator-backed sync and pairing reliability for Docker/NAS and redacted UI flows.

This fixes stale coordinator address handling, guarded trust repair for pairing, IPv6-safe address formatting, mDNS TXT handling, and diagnostics redaction so pairing/discovery failures are safer and easier to recover from without exposing private details by default.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted Vitest suite)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation run:

- `pnpm exec vitest run packages/core/src/sync-daemon.test.ts packages/core/src/sync-discovery.test.ts packages/core/src/coordinator-runtime.test.ts packages/cli/src/commands/sync.test.ts packages/viewer-server/src/index.test.ts packages/ui/src/tabs/sync/view-model.test.ts packages/ui/src/tabs/sync/index.test.ts`
- `pnpm run tsc`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
