### PR TITLE
fix(core): harden coordinator address discovery

### DIFF
--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -187,6 +187,10 @@ not accumulate as mixed `host:port` and `http://host:port` variants in local pee
 - enrollment is explicit per device/group
 - there is no username/password or codemem-operated account layer in this model
 
+For local debugging only, `CODEMEM_SYNC_AUTH_DIAGNOSTICS=1` makes direct sync `401` responses include the auth failure
+reason, such as `unknown_peer`, `peer_record_incomplete`, `fingerprint_mismatch`, or `invalid_signature`. Do not enable
+this on publicly reachable sync listeners; it is intended for trusted development or private Tailnet troubleshooting.
+
 ## Remote admin flow
 
 Built-in local coordinator management commands operate directly on the local SQLite store.

--- a/packages/core/src/address-utils.ts
+++ b/packages/core/src/address-utils.ts
@@ -12,32 +12,57 @@
  * lowercases host, strips default ports (80/443), trims trailing slashes.
  * Returns empty string for invalid/empty input.
  */
-export function normalizeAddress(address: string): string {
+export function normalizeAddress(address: string, options?: { defaultHttpPort?: number }): string {
 	const value = address.trim();
 	if (!value) return "";
 
-	const withScheme = value.includes("://") ? value : `http://${value}`;
+	const hasScheme = value.includes("://");
+	const withScheme = hasScheme ? value : `http://${value}`;
+	const hasExplicitDefaultHttpPort = /^http:\/\/(?:\[[^\]]+\]|[^/?#:]+):0*80(?:[/?#]|$)/i.test(
+		withScheme,
+	);
 
 	try {
 		const url = new URL(withScheme);
 		if (!url.hostname) return "";
 		if (url.port && (Number(url.port) <= 0 || Number(url.port) > 65535)) return "";
+		if (
+			!url.port &&
+			!hasExplicitDefaultHttpPort &&
+			url.protocol === "http:" &&
+			options?.defaultHttpPort
+		) {
+			const port = Math.trunc(options.defaultHttpPort);
+			if (port <= 0 || port > 65535) return "";
+			if (port !== 80 && (!hasScheme || /^http:\/\//i.test(value))) {
+				url.port = String(port);
+			}
+		}
 		return url.origin + url.pathname.replace(/\/+$/, "");
 	} catch {
 		return "";
 	}
 }
 
+export function formatHostPort(host: string, port: number): string {
+	const value = host.trim();
+	if (!value) return "";
+	const normalizedPort = Math.trunc(port);
+	if (normalizedPort <= 0 || normalizedPort > 65535) return "";
+	const authorityHost = value.includes(":") && !value.startsWith("[") ? `[${value}]` : value;
+	return `${authorityHost}:${normalizedPort}`;
+}
+
 /**
- * Produce a dedup key for an address (strips http scheme for comparison).
+ * Produce a dedupe key for an address while preserving scheme and path.
  */
 export function addressDedupeKey(address: string): string {
 	if (!address) return "";
 	try {
 		const url = new URL(address);
 		const host = url.hostname.toLowerCase();
-		if (host && url.port) return `${host}:${url.port}`;
-		if (host) return host;
+		if (host && url.port) return `${url.protocol}//${host}:${url.port}${url.pathname}`;
+		if (host) return `${url.protocol}//${host}${url.pathname}`;
 	} catch {
 		// Not parseable
 	}
@@ -48,15 +73,32 @@ export function addressDedupeKey(address: string): string {
  * Merge two address lists, normalizing and deduplicating.
  * Existing addresses come first, then new candidates.
  */
-export function mergeAddresses(existing: string[], candidates: string[]): string[] {
+export function mergeAddresses(
+	existing: string[],
+	candidates: string[],
+	options?: { defaultHttpPort?: number },
+): string[] {
 	const normalized: string[] = [];
 	const seen = new Set<string>();
 	for (const address of [...existing, ...candidates]) {
-		const cleaned = normalizeAddress(address);
+		const cleaned = normalizeAddress(address, options);
 		const key = addressDedupeKey(cleaned);
 		if (!cleaned || seen.has(key)) continue;
 		seen.add(key);
 		normalized.push(cleaned);
 	}
 	return normalized;
+}
+
+/**
+ * Merge address lists while preferring newly discovered candidates first.
+ * Useful for coordinator presence refreshes where fresh addresses should beat
+ * stale cached LAN/Docker addresses without dropping still-useful fallbacks.
+ */
+export function mergeAddressesPreferCandidates(
+	existing: string[],
+	candidates: string[],
+	options?: { defaultHttpPort?: number },
+): string[] {
+	return mergeAddresses(candidates, existing, options);
 }

--- a/packages/core/src/coordinator-runtime.test.ts
+++ b/packages/core/src/coordinator-runtime.test.ts
@@ -1,6 +1,12 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+	advertisedSyncAddresses,
+	fetchCoordinatorStalePeers,
+	lookupCoordinatorPeers,
 	readCoordinatorSyncConfig,
 	refreshStoredCoordinatorPeerAddresses,
 } from "./coordinator-runtime.js";
@@ -40,6 +46,180 @@ describe("readCoordinatorSyncConfig.syncOpsLimit", () => {
 	it("falls back to the default when the config value is not an integer", () => {
 		const config = readCoordinatorSyncConfig({ sync_ops_limit: "not-a-number" });
 		expect(config.syncOpsLimit).toBe(500);
+	});
+});
+
+describe("advertisedSyncAddresses", () => {
+	it("infers the configured sync port for bare advertised hostnames", () => {
+		const config = readCoordinatorSyncConfig({
+			sync_advertise: "nas.example.test",
+			sync_port: "7337",
+		});
+
+		expect(advertisedSyncAddresses(config)).toEqual(["http://nas.example.test:7337"]);
+	});
+
+	it("preserves explicit ports in advertised URLs", () => {
+		const config = readCoordinatorSyncConfig({
+			sync_advertise: "http://nas.example.test:7444",
+			sync_port: "7337",
+		});
+
+		expect(advertisedSyncAddresses(config)).toEqual(["http://nas.example.test:7444"]);
+	});
+
+	it("deduplicates bare host and explicit sync port after port inference", () => {
+		const config = readCoordinatorSyncConfig({
+			sync_advertise: "nas.example.test,http://nas.example.test:7337",
+			sync_port: "7337",
+		});
+
+		expect(advertisedSyncAddresses(config)).toEqual(["http://nas.example.test:7337"]);
+	});
+});
+
+describe("lookupCoordinatorPeers", () => {
+	it("merges multi-group device groups as plain strings", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		try {
+			initTestSchema(db);
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const url = new URL(String(input));
+				const groupId = url.searchParams.get("group_id") || "";
+				return new Response(
+					JSON.stringify({
+						items: [
+							{
+								device_id: "peer-1",
+								fingerprint: "fp-1",
+								public_key: "pk-1",
+								addresses: [`${groupId}.example.test:7337`],
+								stale: false,
+							},
+						],
+					}),
+					{ status: 200 },
+				);
+			}) as typeof fetch;
+
+			const peers = await lookupCoordinatorPeers(
+				{ db, dbPath: ":memory:" },
+				readCoordinatorSyncConfig({
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_groups: ["team-a", "team-b"],
+				}),
+				{ keysDir },
+			);
+
+			expect(peers).toHaveLength(1);
+			expect(peers[0]?.groups).toEqual(["team-a", "team-b"]);
+			expect(peers[0]?.fresh_groups).toEqual(["team-a", "team-b"]);
+		} finally {
+			globalThis.fetch = prevFetch;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
+	it("tracks freshness per group when merged device sightings disagree", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		try {
+			initTestSchema(db);
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const groupId = new URL(String(input)).searchParams.get("group_id") || "";
+				const stale = groupId === "team-b";
+				const now = Date.now();
+				return new Response(
+					JSON.stringify({
+						items: [
+							{
+								device_id: "peer-1",
+								fingerprint: "fp-1",
+								public_key: "pk-1",
+								addresses: [`${groupId}.example.test:7337`],
+								last_seen_at: new Date(now + (stale ? 1_000 : 0)).toISOString(),
+								expires_at: new Date(now + (stale ? -60_000 : 60_000)).toISOString(),
+								stale,
+							},
+						],
+					}),
+					{ status: 200 },
+				);
+			}) as typeof fetch;
+
+			const peers = await lookupCoordinatorPeers(
+				{ db, dbPath: ":memory:" },
+				readCoordinatorSyncConfig({
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_groups: ["team-a", "team-b"],
+				}),
+				{ keysDir },
+			);
+
+			expect(peers[0]?.groups).toEqual(["team-a", "team-b"]);
+			expect(peers[0]?.fresh_groups).toEqual(["team-a"]);
+			expect(peers[0]?.addresses).toEqual(["http://team-a.example.test:7337"]);
+			expect(Date.parse(String(peers[0]?.expires_at))).toBeGreaterThan(Date.now());
+			expect(peers[0]?.stale).toBe(false);
+		} finally {
+			globalThis.fetch = prevFetch;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("fetchCoordinatorStalePeers", () => {
+	it("returns a stale pinned peer key when the same device has a fresh replacement fingerprint", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const configPath = join(
+			mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-config-")),
+			"config.json",
+		);
+		const prevFetch = globalThis.fetch;
+		const prevConfig = process.env.CODEMEM_CONFIG;
+		try {
+			initTestSchema(db);
+			db.prepare(
+				"INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, addresses_json, created_at) VALUES (?, ?, ?, ?)",
+			).run("peer-1", "old-fp", "[]", new Date().toISOString());
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			process.env.CODEMEM_CONFIG = configPath;
+			globalThis.fetch = (async () =>
+				new Response(
+					JSON.stringify({
+						items: [
+							{ device_id: "peer-1", fingerprint: "old-fp", stale: true },
+							{ device_id: "peer-1", fingerprint: "new-fp", stale: false },
+						],
+					}),
+					{ status: 200 },
+				)) as typeof fetch;
+
+			const stalePeers = await fetchCoordinatorStalePeers(db, ":memory:", keysDir);
+
+			expect(stalePeers.has("peer-1")).toBe(false);
+			expect(stalePeers.has("peer-1:old-fp")).toBe(true);
+		} finally {
+			globalThis.fetch = prevFetch;
+			if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+			else process.env.CODEMEM_CONFIG = prevConfig;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+			rmSync(configPath, { force: true });
+		}
 	});
 });
 
@@ -105,9 +285,9 @@ describe("refreshStoredCoordinatorPeerAddresses", () => {
 		expect(JSON.parse(row.projects_include_json ?? "[]")).toEqual(["work/*"]);
 		expect(JSON.parse(row.projects_exclude_json ?? "[]")).toEqual(["personal/*"]);
 		expect(JSON.parse(row.addresses_json)).toEqual([
-			"http://old.example:7337",
 			"http://10.0.0.5:7337",
 			"http://10.0.0.6:7337",
+			"http://old.example:7337",
 		]);
 		expect(row.last_error).toBe("offline");
 	});
@@ -129,6 +309,33 @@ describe("refreshStoredCoordinatorPeerAddresses", () => {
 				fingerprint: "fp-other",
 				addresses: ["http://10.0.0.5:7337"],
 				groups: ["team-a"],
+			},
+		]);
+
+		expect(updated).toBe(0);
+		const row = db
+			.prepare("SELECT addresses_json FROM sync_peers WHERE peer_device_id = ?")
+			.get("peer-1") as { addresses_json: string };
+		expect(JSON.parse(row.addresses_json)).toEqual(["http://old.example:7337"]);
+	});
+
+	it("does not refresh addresses from stale coordinator input", () => {
+		db.prepare(
+			"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, addresses_json, created_at) VALUES (?, ?, ?, ?, ?)",
+		).run(
+			"peer-1",
+			"Peer One",
+			"fp-1",
+			JSON.stringify(["http://old.example:7337"]),
+			new Date().toISOString(),
+		);
+
+		const updated = refreshStoredCoordinatorPeerAddresses(db, [
+			{
+				device_id: "peer-1",
+				fingerprint: "fp-1",
+				addresses: ["http://stale.example:7337"],
+				stale: true,
 			},
 		]);
 

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -1,5 +1,10 @@
 import { networkInterfaces } from "node:os";
-import { mergeAddresses } from "./address-utils.js";
+import {
+	formatHostPort,
+	mergeAddresses,
+	mergeAddressesPreferCandidates,
+	normalizeAddress,
+} from "./address-utils.js";
 import type { CoordinatorReciprocalApproval } from "./coordinator-store-contract.js";
 import type { Database } from "./db.js";
 import { getCodememEnvOverrides, readCodememConfigFile } from "./observer-config.js";
@@ -46,6 +51,18 @@ function parseStringList(value: unknown): string[] {
 			.filter(Boolean);
 	}
 	return [];
+}
+
+function mergeStringLists(existing: string[], candidates: string[]): string[] {
+	const merged: string[] = [];
+	const seen = new Set<string>();
+	for (const value of [...existing, ...candidates]) {
+		const cleanValue = value.trim();
+		if (!cleanValue || seen.has(cleanValue)) continue;
+		seen.add(cleanValue);
+		merged.push(cleanValue);
+	}
+	return merged;
 }
 
 export interface CoordinatorSyncConfig {
@@ -142,7 +159,7 @@ export function coordinatorEnabled(config: CoordinatorSyncConfig): boolean {
 	return Boolean(config.syncCoordinatorUrl && config.syncCoordinatorGroups.length > 0);
 }
 
-function advertisedSyncAddresses(config: CoordinatorSyncConfig): string[] {
+export function advertisedSyncAddresses(config: CoordinatorSyncConfig): string[] {
 	const advertise = config.syncAdvertise.toLowerCase();
 	if (advertise && advertise !== "auto" && advertise !== "default") {
 		return mergeAddresses(
@@ -151,17 +168,19 @@ function advertisedSyncAddresses(config: CoordinatorSyncConfig): string[] {
 				.split(",")
 				.map((item) => item.trim())
 				.filter(Boolean),
+			{ defaultHttpPort: config.syncPort },
 		);
 	}
 	if (config.syncHost && config.syncHost !== "0.0.0.0") {
-		return [`${config.syncHost}:${config.syncPort}`];
+		return [normalizeAddress(formatHostPort(config.syncHost, config.syncPort))].filter(Boolean);
 	}
 	const addresses = Object.values(networkInterfaces())
 		.flatMap((entries) => entries ?? [])
 		.filter((entry) => !entry.internal)
 		.map((entry) => entry.address)
 		.filter((address) => address && address !== "127.0.0.1" && address !== "::1")
-		.map((address) => `${address}:${config.syncPort}`);
+		.map((address) => normalizeAddress(formatHostPort(address, config.syncPort)))
+		.filter(Boolean);
 	return [...new Set(addresses)];
 }
 
@@ -237,33 +256,41 @@ export async function lookupCoordinatorPeers(
 			const device = clean(record.device_id);
 			const fingerprint = clean(record.fingerprint);
 			if (!device) continue;
+			const freshAddresses = record.stale
+				? []
+				: Array.isArray(record.addresses)
+					? record.addresses.filter((x): x is string => typeof x === "string")
+					: [];
 			const key = `${device}:${fingerprint}`;
 			const existing = merged.get(key);
 			if (!existing) {
 				merged.set(key, {
 					...record,
-					addresses: mergeAddresses(
-						[],
-						Array.isArray(record.addresses)
-							? record.addresses.filter((x): x is string => typeof x === "string")
-							: [],
-					),
+					addresses: mergeAddresses([], freshAddresses),
 					groups: [groupId],
+					fresh_groups: record.stale ? [] : [groupId],
 				});
 				continue;
 			}
 			existing.addresses = mergeAddresses(
 				(Array.isArray(existing.addresses) ? existing.addresses : []) as string[],
-				Array.isArray(record.addresses)
-					? record.addresses.filter((x): x is string => typeof x === "string")
-					: [],
+				freshAddresses,
 			);
-			existing.groups = mergeAddresses(
+			existing.groups = mergeStringLists(
 				(Array.isArray(existing.groups) ? existing.groups : []) as string[],
 				[groupId],
 			);
-			existing.stale = Boolean(existing.stale) && Boolean(record.stale);
-			if (clean(record.last_seen_at) > clean(existing.last_seen_at)) {
+			existing.fresh_groups = mergeStringLists(
+				(Array.isArray(existing.fresh_groups) ? existing.fresh_groups : []) as string[],
+				record.stale ? [] : [groupId],
+			);
+			const wasStale = Boolean(existing.stale);
+			const isStale = Boolean(record.stale);
+			existing.stale = wasStale && isStale;
+			const shouldUpdateFreshnessMetadata =
+				(!isStale && (wasStale || clean(record.last_seen_at) > clean(existing.last_seen_at))) ||
+				(isStale && wasStale && clean(record.last_seen_at) > clean(existing.last_seen_at));
+			if (shouldUpdateFreshnessMetadata) {
 				existing.last_seen_at = record.last_seen_at;
 				existing.expires_at = record.expires_at;
 			}
@@ -301,6 +328,7 @@ export function refreshStoredCoordinatorPeerAddresses(
 ): number {
 	const discoveredAddressesByPinnedPeer = new Map<string, string[]>();
 	for (const peer of peers) {
+		if (peer.stale) continue;
 		const deviceId = clean(peer.device_id);
 		const fingerprint = clean(peer.fingerprint);
 		if (!deviceId || !fingerprint) continue;
@@ -334,7 +362,10 @@ export function refreshStoredCoordinatorPeerAddresses(
 			if (!discoveredAddresses?.length) continue;
 
 			const existingAddresses = mergeAddresses(parseAddressCache(row.addresses_json), []);
-			const mergedAddresses = mergeAddresses(existingAddresses, discoveredAddresses);
+			const mergedAddresses = mergeAddressesPreferCandidates(
+				existingAddresses,
+				discoveredAddresses,
+			);
 			if (JSON.stringify(mergedAddresses) === JSON.stringify(existingAddresses)) continue;
 			update.run(JSON.stringify(mergedAddresses), deviceId, fingerprint);
 			updated += 1;
@@ -362,23 +393,34 @@ export async function fetchCoordinatorStalePeers(
 		const peers = await lookupCoordinatorPeers({ db, dbPath }, config, { keysDir });
 		refreshStoredCoordinatorPeerAddresses(db, peers);
 		// A device may appear under multiple fingerprints (key rotation, multi-group).
-		// Only mark a device stale if ALL its entries are stale.
+		// Skip device-wide only when all entries are stale, but also return pinned
+		// peer keys so an old trusted fingerprint stays fail-closed even when the
+		// same device id has a fresh replacement fingerprint.
 		const freshDevices = new Set<string>();
 		const staleDevices = new Set<string>();
+		const freshPinnedPeers = new Set<string>();
+		const stalePinnedPeers = new Set<string>();
 		for (const peer of peers) {
 			const deviceId = clean(peer.device_id);
 			if (!deviceId) continue;
+			const fingerprint = clean(peer.fingerprint);
+			const pinnedPeerKey = fingerprint ? `${deviceId}:${fingerprint}` : "";
 			if (peer.stale) {
 				staleDevices.add(deviceId);
+				if (pinnedPeerKey) stalePinnedPeers.add(pinnedPeerKey);
 			} else {
 				freshDevices.add(deviceId);
+				if (pinnedPeerKey) freshPinnedPeers.add(pinnedPeerKey);
 			}
 		}
 		// Remove any device that has at least one fresh entry
 		for (const deviceId of freshDevices) {
 			staleDevices.delete(deviceId);
 		}
-		return staleDevices;
+		for (const pinnedPeerKey of freshPinnedPeers) {
+			stalePinnedPeers.delete(pinnedPeerKey);
+		}
+		return new Set([...staleDevices, ...stalePinnedPeers]);
 	} catch {
 		// Best-effort: if coordinator lookup fails, skip the optimization.
 		return new Set();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -540,6 +540,7 @@ export {
 	advertiseMdns,
 	DEFAULT_SERVICE_TYPE,
 	discoverPeersViaMdns,
+	formatHostPort,
 	loadPeerAddresses,
 	mdnsAddressesForPeer,
 	mdnsEnabled,

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -7,6 +7,7 @@ import { columnExists } from "./db.js";
 import {
 	getSyncDaemonPhase,
 	refreshCoordinatorPresenceForDaemon,
+	resolveSyncDaemonKeysDir,
 	runTickOnce,
 	setSyncDaemonError,
 	setSyncDaemonOk,
@@ -15,6 +16,16 @@ import {
 } from "./sync-daemon.js";
 
 import { initTestSchema } from "./test-utils.js";
+
+const ORIGINAL_KEYS_DIR = process.env.CODEMEM_KEYS_DIR;
+
+afterEach(() => {
+	if (ORIGINAL_KEYS_DIR === undefined) {
+		delete process.env.CODEMEM_KEYS_DIR;
+	} else {
+		process.env.CODEMEM_KEYS_DIR = ORIGINAL_KEYS_DIR;
+	}
+});
 
 vi.mock("./coordinator-runtime.js", () => ({
 	coordinatorEnabled: vi.fn().mockReturnValue(false),
@@ -122,6 +133,27 @@ describe("syncDaemonTick", () => {
 		expect(runSyncPass).toHaveBeenCalledWith(db, "peer-2", expect.anything());
 	});
 
+	it("skips only the matching stale pinned coordinator identity", async () => {
+		const { runSyncPass, shouldSkipOfflinePeer } = await import("./sync-pass.js");
+		vi.mocked(shouldSkipOfflinePeer).mockReturnValue(false);
+		const now = new Date().toISOString();
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-1", "old-fp", now);
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-2", "fp2", now);
+
+		const results = await syncDaemonTick(db, undefined, new Set(["peer-1:old-fp"]));
+
+		expect(results).toHaveLength(2);
+		expect(results[0].skipped).toBe(true);
+		expect(results[0].reason).toContain("coordinator presence expired");
+		expect(results[1].ok).toBe(true);
+		expect(runSyncPass).toHaveBeenCalledTimes(1);
+		expect(runSyncPass).toHaveBeenCalledWith(db, "peer-2", expect.anything());
+	});
+
 	it("syncs all peers when stalePeers set is empty", async () => {
 		const { runSyncPass, shouldSkipOfflinePeer } = await import("./sync-pass.js");
 		vi.mocked(shouldSkipOfflinePeer).mockReturnValue(false);
@@ -179,6 +211,18 @@ describe("syncDaemonTick", () => {
 			"peer-1",
 			expect.objectContaining({ scanner: fakeScanner }),
 		);
+	});
+});
+
+describe("resolveSyncDaemonKeysDir", () => {
+	it("falls back to CODEMEM_KEYS_DIR when the caller omits keysDir", () => {
+		process.env.CODEMEM_KEYS_DIR = "/container/keys";
+		expect(resolveSyncDaemonKeysDir()).toBe("/container/keys");
+	});
+
+	it("prefers the explicit daemon keysDir over CODEMEM_KEYS_DIR", () => {
+		process.env.CODEMEM_KEYS_DIR = "/container/keys";
+		expect(resolveSyncDaemonKeysDir("/explicit/keys")).toBe("/explicit/keys");
 	});
 });
 
@@ -260,6 +304,31 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 
 			await runTickOnce(dbPath);
 			expect(syncPassPreflight).toHaveBeenCalledTimes(1);
+		} finally {
+			fileDb.close();
+			rmSync(dbPath, { force: true });
+		}
+	});
+
+	it("threads CODEMEM_KEYS_DIR through one-off ticks when keysDir is omitted", async () => {
+		const { runSyncPass } = await import("./sync-pass.js");
+		process.env.CODEMEM_KEYS_DIR = "/container/keys";
+		const dbPath = join(tmpdir(), `codemem-sync-daemon-env-keys-${Date.now()}.sqlite`);
+		const fileDb = new Database(dbPath);
+		try {
+			initTestSchema(fileDb);
+			fileDb
+				.prepare(
+					"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+				)
+				.run("peer-1", "fp1", new Date().toISOString());
+
+			await runTickOnce(dbPath);
+			expect(runSyncPass).toHaveBeenCalledWith(
+				expect.any(Database),
+				"peer-1",
+				expect.objectContaining({ keysDir: "/container/keys" }),
+			);
 		} finally {
 			fileDb.close();
 			rmSync(dbPath, { force: true });

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -58,6 +58,17 @@ export interface SyncTickResult {
 	opsOut?: number;
 }
 
+export function resolveSyncDaemonKeysDir(keysDir?: string): string | undefined {
+	const explicit = keysDir?.trim();
+	if (explicit) return explicit;
+	return process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
+}
+
+function tableColumnExists(db: Database, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string }>;
+	return rows.some((row) => row.name === column);
+}
+
 // ---------------------------------------------------------------------------
 // Daemon state helpers
 // ---------------------------------------------------------------------------
@@ -162,11 +173,14 @@ export async function syncDaemonTick(
 	stalePeers?: Set<string>,
 	scanner?: SecretScanner,
 ): Promise<SyncTickResult[]> {
-	const d = drizzle(db, { schema });
-	const rows = d
-		.select({ peer_device_id: schema.syncPeers.peer_device_id })
-		.from(schema.syncPeers)
-		.all();
+	const hasPinnedFingerprint = tableColumnExists(db, "sync_peers", "pinned_fingerprint");
+	const rows = db
+		.prepare(
+			hasPinnedFingerprint
+				? "SELECT peer_device_id, pinned_fingerprint FROM sync_peers"
+				: "SELECT peer_device_id, NULL AS pinned_fingerprint FROM sync_peers",
+		)
+		.all() as Array<{ peer_device_id: string; pinned_fingerprint: string | null }>;
 
 	// Skip heavy preflight work when there are no peers configured.
 	// This keeps startup and idle daemon ticks responsive on large local stores.
@@ -181,8 +195,10 @@ export async function syncDaemonTick(
 	const results: SyncTickResult[] = [];
 	for (const row of rows) {
 		const peerDeviceId = row.peer_device_id;
+		const pinnedFingerprint = String(row.pinned_fingerprint ?? "").trim();
+		const stalePeerKey = pinnedFingerprint ? `${peerDeviceId}:${pinnedFingerprint}` : "";
 
-		if (stalePeers?.has(peerDeviceId)) {
+		if (stalePeers?.has(peerDeviceId) || (stalePeerKey && stalePeers?.has(stalePeerKey))) {
 			results.push({
 				ok: false,
 				skipped: true,
@@ -229,7 +245,7 @@ export async function syncDaemonTick(
 export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> {
 	const intervalS = options?.intervalS ?? 120;
 	const dbPath = resolveDbPath(options?.dbPath);
-	const keysDir = options?.keysDir;
+	const keysDir = resolveSyncDaemonKeysDir(options?.keysDir);
 	const signal = options?.signal;
 	const onPhaseChange = options?.onPhaseChange;
 	const scanner = options?.scanner;
@@ -303,19 +319,20 @@ export async function runTickOnce(
 	keysDir?: string,
 	scanner?: SecretScanner,
 ): Promise<void> {
+	const resolvedKeysDir = resolveSyncDaemonKeysDir(keysDir);
 	const db = connectDb(dbPath);
 	try {
 		ensureAdditiveSchemaCompatibility(db);
 		try {
-			await refreshCoordinatorPresenceForDaemon(db, dbPath, keysDir);
+			await refreshCoordinatorPresenceForDaemon(db, dbPath, resolvedKeysDir);
 		} catch {
 			// Coordinator discovery is a supplemental surface. Keep direct peer sync running
 			// even when heartbeat posting fails for this tick.
 		}
 		// Best-effort: skip peers the coordinator reports as offline.
 		// Returns empty set when coordinator is disabled or lookup fails.
-		const stalePeers = await fetchCoordinatorStalePeers(db, dbPath, keysDir);
-		const results = await syncDaemonTick(db, keysDir, stalePeers, scanner);
+		const stalePeers = await fetchCoordinatorStalePeers(db, dbPath, resolvedKeysDir);
+		const results = await syncDaemonTick(db, resolvedKeysDir, stalePeers, scanner);
 		const needsAttention = results.some((r) => !r.ok && r.error?.includes("needs_attention"));
 		if (needsAttention) {
 			setSyncDaemonPhase(db, "needs_attention");

--- a/packages/core/src/sync-discovery.test.ts
+++ b/packages/core/src/sync-discovery.test.ts
@@ -7,11 +7,13 @@ import {
 	addressDedupeKey,
 	advertiseMdns,
 	discoverPeersViaMdns,
+	formatHostPort,
 	loadPeerAddresses,
 	mdnsAddressesForPeer,
 	mdnsEnabled,
 	mergeAddresses,
 	normalizeAddress,
+	normalizeMdnsTxtProperties,
 	recordPeerSuccess,
 	recordSyncAttempt,
 	selectDialAddresses,
@@ -58,6 +60,34 @@ describe("normalizeAddress", () => {
 	it("handles http:// prefix without port", () => {
 		expect(normalizeAddress("http://example.com")).toBe("http://example.com");
 	});
+
+	it("can infer the configured sync port for http advertised hosts", () => {
+		expect(normalizeAddress("nas.example.test", { defaultHttpPort: 7337 })).toBe(
+			"http://nas.example.test:7337",
+		);
+		expect(normalizeAddress("http://nas.example.test", { defaultHttpPort: 7337 })).toBe(
+			"http://nas.example.test:7337",
+		);
+	});
+
+	it("does not infer the sync port over an explicit default http port", () => {
+		expect(normalizeAddress("http://nas.example.test:80", { defaultHttpPort: 7337 })).toBe(
+			"http://nas.example.test",
+		);
+		expect(normalizeAddress("http://nas.example.test:080", { defaultHttpPort: 7337 })).toBe(
+			"http://nas.example.test",
+		);
+		expect(normalizeAddress("nas.example.test:80", { defaultHttpPort: 7337 })).toBe(
+			"http://nas.example.test",
+		);
+	});
+});
+
+describe("formatHostPort", () => {
+	it("brackets IPv6 literals before appending the port", () => {
+		expect(formatHostPort("fd00::1", 7337)).toBe("[fd00::1]:7337");
+		expect(normalizeAddress(formatHostPort("fd00::1", 7337))).toBe("http://[fd00::1]:7337");
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -65,8 +95,8 @@ describe("normalizeAddress", () => {
 // ---------------------------------------------------------------------------
 
 describe("addressDedupeKey", () => {
-	it("strips http scheme for host:port", () => {
-		expect(addressDedupeKey("http://192.168.1.1:9090")).toBe("192.168.1.1:9090");
+	it("keeps scheme for host:port", () => {
+		expect(addressDedupeKey("http://192.168.1.1:9090")).toBe("http://192.168.1.1:9090/");
 	});
 
 	it("returns as-is for non-URL input", () => {
@@ -77,11 +107,10 @@ describe("addressDedupeKey", () => {
 		expect(addressDedupeKey("")).toBe("");
 	});
 
-	it("returns full URL for addresses with paths", () => {
-		// Port 80 is default for http, so dedup key is just the host
-		expect(addressDedupeKey("http://host:80/path")).toBe("host");
-		// Non-default port preserves host:port
-		expect(addressDedupeKey("http://host:8080/path")).toBe("host:8080");
+	it("keeps scheme and path in the dedupe key", () => {
+		expect(addressDedupeKey("http://host:80/path")).toBe("http://host/path");
+		expect(addressDedupeKey("http://host:8080/path")).toBe("http://host:8080/path");
+		expect(addressDedupeKey("https://host:8080/path")).toBe("https://host:8080/path");
 	});
 });
 
@@ -170,6 +199,39 @@ describe("peer address storage", () => {
 		updatePeerAddresses(db, "peer-1", ["http://host:8080"]);
 		const loaded = loadPeerAddresses(db, "peer-1");
 		expect(loaded).toEqual(["http://host:8080"]);
+	});
+
+	it("fills missing trust material without replacing existing trust by default", () => {
+		updatePeerAddresses(db, "peer-1", ["host:8080"], {
+			pinnedFingerprint: "old-fp",
+			publicKey: "old-key",
+		});
+		updatePeerAddresses(db, "peer-1", ["host:8080"], {
+			pinnedFingerprint: "new-fp",
+			publicKey: "new-key",
+		});
+
+		const row = db
+			.prepare("SELECT pinned_fingerprint, public_key FROM sync_peers WHERE peer_device_id = ?")
+			.get("peer-1") as { pinned_fingerprint: string; public_key: string };
+		expect(row).toMatchObject({ pinned_fingerprint: "old-fp", public_key: "old-key" });
+	});
+
+	it("replaces stale trust material when accepting a fresh pairing payload", () => {
+		updatePeerAddresses(db, "peer-1", ["host:8080"], {
+			pinnedFingerprint: "old-fp",
+			publicKey: "old-key",
+		});
+		updatePeerAddresses(db, "peer-1", ["host:8080"], {
+			pinnedFingerprint: "new-fp",
+			publicKey: "new-key",
+			replaceTrust: true,
+		});
+
+		const row = db
+			.prepare("SELECT pinned_fingerprint, public_key FROM sync_peers WHERE peer_device_id = ?")
+			.get("peer-1") as { pinned_fingerprint: string; public_key: string };
+		expect(row).toMatchObject({ pinned_fingerprint: "new-fp", public_key: "new-key" });
 	});
 });
 
@@ -329,7 +391,7 @@ describe("mdnsAddressesForPeer", () => {
 			},
 		];
 		const addresses = mdnsAddressesForPeer("peer-1", entries);
-		expect(addresses).toEqual(["peer-host.local:9090"]);
+		expect(addresses).toEqual(["http://peer-host.local:9090"]);
 	});
 
 	it("returns empty for no matching peer", () => {
@@ -356,7 +418,28 @@ describe("mdnsAddressesForPeer", () => {
 				properties: { device_id: new TextEncoder().encode("peer-1") },
 			},
 		];
-		expect(mdnsAddressesForPeer("peer-1", entries)).toEqual(["host.local:9090"]);
+		expect(mdnsAddressesForPeer("peer-1", entries)).toEqual(["http://host.local:9090"]);
+	});
+
+	it("brackets IPv6 resolved addresses", () => {
+		const entries = [
+			{
+				host: "peer-host.local",
+				address: "fd00::1",
+				port: 9090,
+				properties: { device_id: "peer-1" },
+			},
+		];
+		expect(mdnsAddressesForPeer("peer-1", entries)).toEqual(["http://[fd00::1]:9090"]);
+	});
+
+	it("preserves binary TXT device IDs for matching", () => {
+		const deviceId = new TextEncoder().encode("peer-1");
+		const properties = normalizeMdnsTxtProperties({ device_id: deviceId });
+		expect(properties.device_id).toBe(deviceId);
+		expect(
+			mdnsAddressesForPeer("peer-1", [{ host: "host.local", port: 9090, properties }]),
+		).toEqual(["http://host.local:9090"]);
 	});
 });
 

--- a/packages/core/src/sync-discovery.ts
+++ b/packages/core/src/sync-discovery.ts
@@ -8,7 +8,7 @@
 import { createRequire } from "node:module";
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
-import { mergeAddresses, normalizeAddress } from "./address-utils.js";
+import { formatHostPort, mergeAddresses, normalizeAddress } from "./address-utils.js";
 import { readCoordinatorSyncConfig } from "./coordinator-runtime.js";
 import type { Database } from "./db.js";
 import * as schema from "./schema.js";
@@ -16,7 +16,12 @@ import * as schema from "./schema.js";
 const requireFromHere = createRequire(import.meta.url);
 
 // Re-export for consumers that import from sync-discovery
-export { addressDedupeKey, mergeAddresses, normalizeAddress } from "./address-utils.js";
+export {
+	addressDedupeKey,
+	formatHostPort,
+	mergeAddresses,
+	normalizeAddress,
+} from "./address-utils.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -78,6 +83,7 @@ export function updatePeerAddresses(
 		name?: string;
 		pinnedFingerprint?: string;
 		publicKey?: string;
+		replaceTrust?: boolean;
 	},
 ): string[] {
 	const merged = mergeAddresses(loadPeerAddresses(db, peerDeviceId), addresses);
@@ -100,8 +106,12 @@ export function updatePeerAddresses(
 			target: schema.syncPeers.peer_device_id,
 			set: {
 				name: sql`COALESCE(excluded.name, ${schema.syncPeers.name})`,
-				pinned_fingerprint: sql`COALESCE(excluded.pinned_fingerprint, ${schema.syncPeers.pinned_fingerprint})`,
-				public_key: sql`COALESCE(excluded.public_key, ${schema.syncPeers.public_key})`,
+				pinned_fingerprint: options?.replaceTrust
+					? sql`COALESCE(excluded.pinned_fingerprint, ${schema.syncPeers.pinned_fingerprint})`
+					: sql`COALESCE(${schema.syncPeers.pinned_fingerprint}, excluded.pinned_fingerprint)`,
+				public_key: options?.replaceTrust
+					? sql`COALESCE(excluded.public_key, ${schema.syncPeers.public_key})`
+					: sql`COALESCE(${schema.syncPeers.public_key}, excluded.public_key)`,
 				addresses_json: sql`excluded.addresses_json`,
 				last_seen_at: sql`excluded.last_seen_at`,
 			},
@@ -231,6 +241,16 @@ export interface MdnsEntry {
 	port?: number;
 	address?: Uint8Array | string;
 	properties?: Record<string, string | Uint8Array>;
+}
+
+export function normalizeMdnsTxtProperties(
+	txt: Record<string, unknown>,
+): Record<string, string | Uint8Array> {
+	const properties: Record<string, string | Uint8Array> = {};
+	for (const [key, value] of Object.entries(txt)) {
+		properties[key] = value instanceof Uint8Array ? value : String(value);
+	}
+	return properties;
 }
 
 const MDNS_SERVICE_TYPE = "codemem"; // advertises as _codemem._tcp.local.
@@ -416,18 +436,16 @@ export async function discoverPeersViaMdns(timeoutMs = 1500): Promise<MdnsEntry[
 			if (seen.has(key)) return;
 			seen.add(key);
 			const addresses = Array.isArray(svc.addresses) ? svc.addresses : [];
-			const ipv4 = addresses.find((addr) => addr && /^[\d.]+$/.test(addr));
-			const properties: Record<string, string> = {};
+			const resolvedAddress =
+				addresses.find((addr) => addr && /^[\d.]+$/.test(addr)) ??
+				addresses.find((addr) => typeof addr === "string" && addr.trim().length > 0);
 			const rawTxt = svc.txt ?? {};
-			for (const [key, value] of Object.entries(rawTxt)) {
-				properties[key] = String(value);
-			}
 			found.push({
 				name: svc.name,
 				host: (svc.host || svc.fqdn || "").replace(/\.$/, ""),
 				port: svc.port,
-				address: ipv4,
-				properties,
+				address: resolvedAddress,
+				properties: normalizeMdnsTxtProperties(rawTxt),
 			});
 		});
 		await new Promise<void>((resolve) => setTimeout(resolve, Math.max(100, timeoutMs)));
@@ -469,7 +487,8 @@ export function mdnsAddressesForPeer(peerDeviceId: string, entries: MdnsEntry[])
 		const host = entry.host ?? "";
 		const dialHost = address && !address.includes(".local") ? address : host;
 		if (dialHost && !dialHost.includes("_tcp.local") && !dialHost.includes("_udp.local")) {
-			addresses.push(`${dialHost}:${port}`);
+			const normalized = normalizeAddress(formatHostPort(dialHost, port));
+			if (normalized) addresses.push(normalized);
 		}
 	}
 	return addresses;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -7676,17 +7676,17 @@ describe("viewer-server", () => {
 				const body = (await res.json()) as { peers?: Array<Record<string, unknown>> };
 				const peerPayload = body.peers?.find((peer) => peer.peer_device_id === "peer-fresh");
 				expect(peerPayload?.addresses).toEqual([
-					"http://old.example:7337",
 					"http://10.0.0.5:7337",
 					"http://10.0.0.6:7337",
+					"http://old.example:7337",
 				]);
 				const peerRow = store.db
 					.prepare("SELECT addresses_json, last_error FROM sync_peers WHERE peer_device_id = ?")
 					.get("peer-fresh") as Record<string, unknown> | undefined;
 				expect(JSON.parse(String(peerRow?.addresses_json ?? "[]"))).toEqual([
-					"http://old.example:7337",
 					"http://10.0.0.5:7337",
 					"http://10.0.0.6:7337",
+					"http://old.example:7337",
 				]);
 				expect(peerRow?.last_error).toBe("all addresses failed");
 				expect(


### PR DESCRIPTION
## Description
Harden coordinator address discovery and sync-daemon freshness handling.

This normalizes discovered/advertised addresses, preserves IPv6 and mDNS TXT edge cases, prefers fresh coordinator addresses over stale cached ones, and lets daemon stale checks target a specific pinned device identity.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted Vitest suite)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation run on the full stack:

- `pnpm exec vitest run packages/core/src/sync-daemon.test.ts packages/core/src/sync-discovery.test.ts packages/core/src/coordinator-runtime.test.ts packages/cli/src/commands/sync.test.ts packages/viewer-server/src/index.test.ts packages/ui/src/tabs/sync/view-model.test.ts packages/ui/src/tabs/sync/index.test.ts`
- `pnpm run tsc`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced