### PR TITLE
fix(sync): guard coordinator pairing trust repair

### DIFF
--- a/packages/cli/src/commands/sync-helpers.ts
+++ b/packages/cli/src/commands/sync-helpers.ts
@@ -1,3 +1,4 @@
+import { formatHostPort } from "@codemem/core";
 import { resolveDbOpt } from "../shared-options.js";
 
 export interface SyncAttemptRow {
@@ -81,13 +82,13 @@ export function collectAdvertiseAddresses(
 		return [explicitAddress];
 	}
 	if (configuredHost && configuredHost !== "0.0.0.0") {
-		return [`${configuredHost}:${port}`];
+		return [formatHostPort(configuredHost, port)];
 	}
 	const addresses = Object.values(interfaces)
 		.flatMap((entries) => entries ?? [])
 		.filter((entry) => !entry.internal)
 		.map((entry) => entry.address)
 		.filter((address) => address && address !== "127.0.0.1" && address !== "::1")
-		.map((address) => `${address}:${port}`);
+		.map((address) => formatHostPort(address, port));
 	return [...new Set(addresses)];
 }

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -152,6 +152,18 @@ describe("formatSyncAttempt", () => {
 		).toEqual(["192.168.1.10:7337"]);
 	});
 
+	it("brackets configured IPv6 advertise hosts", () => {
+		expect(collectAdvertiseAddresses(null, "fd00::1", 7337, {})).toEqual(["[fd00::1]:7337"]);
+	});
+
+	it("brackets IPv6 interface advertise addresses", () => {
+		expect(
+			collectAdvertiseAddresses(null, "0.0.0.0", 7337, {
+				utun0: [{ address: "fd00::2", internal: false, family: "IPv6" }],
+			}),
+		).toEqual(["[fd00::2]:7337"]);
+	});
+
 	it("registers coordinator parity subcommands", () => {
 		const coordinator = syncCommand.commands.find((command) => command.name() === "coordinator");
 		expect(coordinator).toBeDefined();

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -528,11 +528,29 @@ pairCmd.action(async (opts: SyncPairOptions) => {
 				process.exitCode = 1;
 				return;
 			}
+			const existingPeer = drizzle(store.db, { schema })
+				.select({ pinned_fingerprint: schema.syncPeers.pinned_fingerprint })
+				.from(schema.syncPeers)
+				.where(eq(schema.syncPeers.peer_device_id, deviceId))
+				.get();
+			const existingFingerprint = String(existingPeer?.pinned_fingerprint ?? "").trim();
+			if (existingFingerprint && existingFingerprint !== fingerprint) {
+				const msg =
+					"Pairing payload conflicts with the existing trusted fingerprint for this device. Remove or repair the old peer before accepting this pairing payload.";
+				if (opts.json) {
+					emitJsonError("peer_conflict", msg);
+					return;
+				}
+				p.log.error(msg);
+				process.exitCode = 1;
+				return;
+			}
 
 			updatePeerAddresses(store.db, deviceId, resolvedAddresses, {
 				name: opts.name,
 				pinnedFingerprint: fingerprint,
 				publicKey,
+				replaceTrust: true,
 			});
 
 			if (opts.default) {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -51,6 +51,11 @@ function createTestStore(): { store: MemoryStore; cleanup: () => void } {
 	};
 }
 
+const FRESH_PEER_PUBLIC_KEY = "peer-public-key";
+const FRESH_PEER_FINGERPRINT = core.fingerprintPublicKey(FRESH_PEER_PUBLIC_KEY);
+const REKEYED_PEER_PUBLIC_KEY = "peer-rekeyed-public-key";
+const REKEYED_PEER_FINGERPRINT = core.fingerprintPublicKey(REKEYED_PEER_PUBLIC_KEY);
+
 function insertTestMemory(
 	store: MemoryStore,
 	options: {
@@ -3252,7 +3257,24 @@ describe("viewer-server", () => {
 				expect(res.status).toBe(401);
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body.error).toBe("unauthorized");
+				expect(body.reason).toBeUndefined();
 			} finally {
+				cleanup();
+			}
+		});
+
+		it("exposes sync auth failure reasons only when diagnostics are explicitly enabled", async () => {
+			const previous = process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS;
+			process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS = "1";
+			const { syncApp, cleanup } = createTestApp();
+			try {
+				const res = await syncApp.request("/v1/status");
+				expect(res.status).toBe(401);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({ error: "unauthorized", reason: "bootstrap_grant_invalid" });
+			} finally {
+				if (previous === undefined) delete process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS;
+				else process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS = previous;
 				cleanup();
 			}
 		});
@@ -5154,7 +5176,7 @@ describe("viewer-server", () => {
 				expect(body.device_id).toBeTruthy();
 				expect(body.fingerprint).toBeTruthy();
 				expect(body.public_key).toBeTruthy();
-				expect(body.addresses).toEqual(["127.0.0.1:7337"]);
+				expect(body.addresses).toEqual(["http://127.0.0.1:7337"]);
 			} finally {
 				cleanup();
 				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
@@ -5667,8 +5689,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -5762,8 +5784,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									groups: ["team-a"],
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
@@ -5961,8 +5983,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -6020,7 +6042,9 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+					}),
 				});
 				expect(res.status).toBe(200);
 				expect(await res.json()).toEqual({
@@ -6040,14 +6064,93 @@ describe("viewer-server", () => {
 					expect.objectContaining({
 						peer_device_id: "peer-fresh",
 						name: "Fresh Device",
-						pinned_fingerprint: "fp-fresh",
-						public_key: "peer-public-key",
+						pinned_fingerprint: FRESH_PEER_FINGERPRINT,
+						public_key: FRESH_PEER_PUBLIC_KEY,
 						last_error: null,
 					}),
 				);
 				expect(JSON.parse(String(peerRow?.addresses_json ?? "[]"))).toEqual([
 					"http://10.0.0.5:7337",
 				]);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("rejects stale discovered coordinator devices before publishing reciprocal approval", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/peers")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-fresh",
+									display_name: "Stale Device",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
+									addresses: ["http://10.0.0.5:7337"],
+									expires_at: new Date(Date.now() - 60_000).toISOString(),
+									stale: true,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
+				});
+				expect(res.status).toBe(409);
+				expect(await res.json()).toEqual({
+					error: "discovered_peer_stale",
+					detail:
+						"This discovered device's coordinator presence is stale. Wait for it to come online and refresh sync status before trusting it.",
+				});
+				expect(
+					fetchMock.mock.calls.some(([input]) =>
+						String(input).includes("/v1/reciprocal-approvals"),
+					),
+				).toBe(false);
+				expect(
+					store.db
+						.prepare("SELECT peer_device_id FROM sync_peers WHERE peer_device_id = ?")
+						.get("peer-fresh"),
+				).toBeUndefined();
 			} finally {
 				cleanup();
 				globalThis.fetch = prevFetch;
@@ -6072,8 +6175,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									groups: ["team-a"],
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
@@ -6111,7 +6214,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(502);
 				expect(await res.json()).toEqual({
@@ -6146,8 +6252,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -6165,8 +6271,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.6:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -6200,7 +6306,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(409);
 				expect(await res.json()).toEqual({
@@ -7346,6 +7455,49 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("redacts sync attempt errors unless diagnostics are requested", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const now = new Date().toISOString();
+				store.db
+					.prepare(
+						"INSERT INTO sync_attempts(peer_device_id, started_at, finished_at, ok, ops_in, ops_out, error) VALUES (?, ?, ?, 0, 0, 0, ?)",
+					)
+					.run(
+						"peer-1",
+						now,
+						now,
+						"all addresses failed | http://10.0.0.5:7337: unauthorized:fingerprint_mismatch",
+					);
+
+				const redactedRes = await app.request("/api/sync/attempts");
+				expect(redactedRes.status).toBe(200);
+				const redactedBody = (await redactedRes.json()) as {
+					items: Array<{ error: string | null; address: string | null }>;
+					redacted: boolean;
+				};
+				expect(redactedBody.redacted).toBe(true);
+				expect(redactedBody.items[0]?.error).toBe(
+					"sync attempt failed; enable diagnostics for details",
+				);
+				expect(redactedBody.items[0]?.address).toBeNull();
+
+				const diagnosticRes = await app.request("/api/sync/attempts?includeDiagnostics=1");
+				expect(diagnosticRes.status).toBe(200);
+				const diagnosticBody = (await diagnosticRes.json()) as {
+					items: Array<{ error: string | null }>;
+					redacted: boolean;
+				};
+				expect(diagnosticBody.redacted).toBe(false);
+				expect(diagnosticBody.items[0]?.error).toContain("fingerprint_mismatch");
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("creates, renames, and merges actors through viewer routes", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {
@@ -7476,8 +7628,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -7539,7 +7691,7 @@ describe("viewer-server", () => {
 					.run(
 						"peer-fresh",
 						"Old Name",
-						"fp-fresh",
+						FRESH_PEER_FINGERPRINT,
 						JSON.stringify(["http://old.example:7337"]),
 						"offline",
 						new Date().toISOString(),
@@ -7547,7 +7699,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(200);
 				expect(await res.json()).toEqual({
@@ -7566,13 +7721,13 @@ describe("viewer-server", () => {
 				expect(peerRow).toEqual(
 					expect.objectContaining({
 						name: "Fresh Device",
-						pinned_fingerprint: "fp-fresh",
+						pinned_fingerprint: FRESH_PEER_FINGERPRINT,
 						last_error: "offline",
 					}),
 				);
 				expect(JSON.parse(String(peerRow?.addresses_json ?? "[]"))).toEqual([
-					"http://old.example:7337",
 					"http://10.0.0.5:7337",
+					"http://old.example:7337",
 				]);
 			} finally {
 				cleanup();
@@ -7603,8 +7758,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -7622,8 +7777,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["10.0.0.6:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -7664,7 +7819,7 @@ describe("viewer-server", () => {
 					.run(
 						"peer-fresh",
 						"Old Name",
-						"fp-fresh",
+						FRESH_PEER_FINGERPRINT,
 						JSON.stringify(["http://old.example:7337"]),
 						"all addresses failed",
 						new Date().toISOString(),
@@ -7719,8 +7874,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-new",
-									public_key: "peer-public-key",
+									fingerprint: REKEYED_PEER_FINGERPRINT,
+									public_key: REKEYED_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -7759,7 +7914,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-new" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: REKEYED_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(409);
 				expect(await res.json()).toEqual({
@@ -7810,7 +7968,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(404);
 				expect(await res.json()).toEqual({
@@ -7838,7 +7999,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(400);
 				expect(await res.json()).toEqual({
@@ -7866,8 +8030,8 @@ describe("viewer-server", () => {
 								{
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
-									fingerprint: "fp-fresh",
-									public_key: "peer-public-key",
+									fingerprint: FRESH_PEER_FINGERPRINT,
+									public_key: FRESH_PEER_PUBLIC_KEY,
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -7925,7 +8089,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(200);
 				expect(await res.json()).toEqual(
@@ -7977,7 +8144,10 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/accept-discovered", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
 				});
 				expect(res.status).toBe(502);
 				expect(await res.json()).toEqual({
@@ -8422,6 +8592,57 @@ describe("viewer-server", () => {
 				expect(row?.pinned_fingerprint).toBe(peerFingerprint);
 			} finally {
 				cleanup();
+			}
+		});
+
+		it("rejects a device pairing payload that conflicts with an existing trusted fingerprint", async () => {
+			const peerKeysDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-keys-"));
+			const peerDbDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-db-"));
+			const peerDbPath = join(peerDbDir, "peer.sqlite");
+			const peerDb = new Database(peerDbPath);
+			initTestSchema(peerDb);
+			const [peerDeviceId, peerFingerprint] = ensureDeviceIdentity(peerDb, {
+				keysDir: peerKeysDir,
+			});
+			const peerPublicKey = loadPublicKey(peerKeysDir) ?? "";
+			peerDb.close();
+			const pairingPayload = {
+				device_id: peerDeviceId,
+				fingerprint: peerFingerprint,
+				public_key: peerPublicKey,
+				addresses: ["http://10.10.10.10:7337"],
+			};
+			const invite = Buffer.from(JSON.stringify(pairingPayload), "utf8").toString("base64");
+
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, public_key, addresses_json, created_at) VALUES (?, ?, ?, ?, ?)",
+					)
+					.run(peerDeviceId, "old-fingerprint", "old-public-key", "[]", new Date().toISOString());
+
+				const res = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite }),
+				});
+				expect(res.status).toBe(409);
+				expect(await res.json()).toMatchObject({ error: "peer_conflict" });
+				const row = store.db
+					.prepare("SELECT pinned_fingerprint, public_key FROM sync_peers WHERE peer_device_id = ?")
+					.get(peerDeviceId) as { pinned_fingerprint?: string; public_key?: string } | undefined;
+				expect(row).toMatchObject({
+					pinned_fingerprint: "old-fingerprint",
+					public_key: "old-public-key",
+				});
+			} finally {
+				cleanup();
+				rmSync(peerKeysDir, { recursive: true, force: true });
+				rmSync(peerDbDir, { recursive: true, force: true });
 			}
 		});
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -55,6 +55,7 @@ import {
 	type FilterReplicationSkipped,
 	filterReplicationOpsForSyncWithStatus,
 	fingerprintPublicKey,
+	formatHostPort,
 	getCoordinatorGroupPreference,
 	getSemanticIndexDiagnostics,
 	getSyncResetState,
@@ -74,6 +75,7 @@ import {
 	lookupCoordinatorPeers,
 	mergeAddresses,
 	negotiateSyncCapability,
+	normalizeAddress,
 	normalizeSyncCapability,
 	parseSyncScopeRequest,
 	personalScopeGrantStatusForPeer,
@@ -278,7 +280,7 @@ async function ensureDefaultSpaceForTeam(opts: {
 			remoteUrl: opts.config.syncCoordinatorUrl || null,
 			adminSecret: opts.config.syncCoordinatorAdminSecret || null,
 		}));
-	const [deviceId] = ensureDeviceIdentity(opts.store.db);
+	const [deviceId] = ensureDeviceIdentity(opts.store.db, { keysDir: syncKeysDir() });
 	const membership = await coordinatorGrantScopeMembershipAction({
 		groupId: opts.groupId,
 		scopeId,
@@ -495,17 +497,19 @@ function pairingAdvertiseAddresses(config = readCoordinatorSyncConfig()): string
 				.split(",")
 				.map((item) => item.trim())
 				.filter(Boolean),
+			{ defaultHttpPort: config.syncPort },
 		);
 	}
 	if (config.syncHost && config.syncHost !== "0.0.0.0") {
-		return [`${config.syncHost}:${config.syncPort}`];
+		return [normalizeAddress(formatHostPort(config.syncHost, config.syncPort))].filter(Boolean);
 	}
 	const addresses = Object.values(networkInterfaces())
 		.flatMap((entries) => entries ?? [])
 		.filter((entry) => !entry.internal)
 		.map((entry) => entry.address)
 		.filter((address) => address && address !== "127.0.0.1" && address !== "::1")
-		.map((address) => `${address}:${config.syncPort}`);
+		.map((address) => normalizeAddress(formatHostPort(address, config.syncPort)))
+		.filter(Boolean);
 	return [...new Set(addresses)];
 }
 
@@ -1024,6 +1028,7 @@ function redactCoordinatorStatus(
 		? coordinator.discovered_devices.map((item) => {
 				if (!item || typeof item !== "object") return item;
 				const record = item as Record<string, unknown>;
+				const addressCount = Array.isArray(record.addresses) ? record.addresses.length : 0;
 				return {
 					device_id: record.device_id,
 					display_name: record.display_name ?? null,
@@ -1037,6 +1042,7 @@ function redactCoordinatorStatus(
 					outgoing_reciprocal_request_id: record.outgoing_reciprocal_request_id ?? null,
 					fingerprint: null,
 					addresses: [],
+					address_count: addressCount,
 				};
 			})
 		: [];
@@ -1048,7 +1054,7 @@ function redactCoordinatorStatus(
 
 interface AcceptDiscoveredPeerOptions {
 	peerDeviceId: string;
-	fingerprint: string;
+	fingerprint?: string;
 	// Optional per-peer scope override. When undefined the group's scope
 	// template is applied if auto_seed_scope is enabled; otherwise the peer
 	// is enrolled with no scope filters.
@@ -1094,17 +1100,43 @@ async function acceptDiscoveredPeer(
 		};
 	}
 	const discovered = await lookupCoordinatorPeers(store, config);
-	const match = discovered.find(
-		(peer) =>
-			String(peer.device_id ?? "").trim() === input.peerDeviceId &&
-			String(peer.fingerprint ?? "").trim() === input.fingerprint,
+	const inputFingerprint = String(input.fingerprint ?? "").trim();
+	const candidates = discovered.filter(
+		(peer) => String(peer.device_id ?? "").trim() === input.peerDeviceId,
 	);
+	const matchingCandidates = inputFingerprint
+		? candidates.filter((peer) => String(peer.fingerprint ?? "").trim() === inputFingerprint)
+		: candidates;
+	const uniqueFingerprints = new Set(
+		matchingCandidates.map((peer) => String(peer.fingerprint ?? "").trim()).filter(Boolean),
+	);
+	if (!inputFingerprint && uniqueFingerprints.size > 1) {
+		return {
+			ok: false,
+			status: 409,
+			error: "ambiguous_discovered_peer",
+			detail:
+				"That discovered device has multiple coordinator fingerprints. Enable diagnostics, refresh sync status, and choose the intended device before trusting it.",
+		};
+	}
+	const match = matchingCandidates[0];
 	if (!match) {
 		return {
 			ok: false,
 			status: 404,
 			error: "discovered_peer_not_found",
 			detail: "That discovered device is no longer available. Refresh sync status and try again.",
+		};
+	}
+	const expiresAt = String(match.expires_at ?? "").trim();
+	const expired = expiresAt ? Date.parse(expiresAt) <= Date.now() : false;
+	if (match.stale || expired) {
+		return {
+			ok: false,
+			status: 409,
+			error: "discovered_peer_stale",
+			detail:
+				"This discovered device's coordinator presence is stale. Wait for it to come online and refresh sync status before trusting it.",
 		};
 	}
 	const nextFingerprint = String(match.fingerprint ?? "").trim();
@@ -1122,9 +1154,21 @@ async function acceptDiscoveredPeer(
 				"This discovered device is missing its coordinator public key. Refresh sync status and try again.",
 		};
 	}
+	if (!nextFingerprint || fingerprintPublicKey(nextPublicKey) !== nextFingerprint) {
+		return {
+			ok: false,
+			status: 409,
+			error: "discovered_peer_fingerprint_mismatch",
+			detail:
+				"This discovered device's coordinator public key does not match its fingerprint. Refresh sync status or re-enroll the device before trusting it.",
+		};
+	}
 
 	const groupIds = Array.isArray(match.groups)
 		? match.groups.map((value) => String(value ?? "").trim()).filter(Boolean)
+		: [];
+	const freshGroupIds = Array.isArray(match.fresh_groups)
+		? match.fresh_groups.map((value) => String(value ?? "").trim()).filter(Boolean)
 		: [];
 	let groupId: string;
 	if (input.expectedGroupId) {
@@ -1135,6 +1179,15 @@ async function acceptDiscoveredPeer(
 				error: "peer_not_in_group",
 				detail:
 					"This discovered device is not visible through the specified coordinator group. Refresh sync status and try again.",
+			};
+		}
+		if (!freshGroupIds.includes(input.expectedGroupId)) {
+			return {
+				ok: false,
+				status: 409,
+				error: "discovered_peer_stale",
+				detail:
+					"This discovered device's coordinator presence is stale for the specified group. Wait for it to come online and refresh sync status before trusting it.",
 			};
 		}
 		groupId = input.expectedGroupId;
@@ -1184,7 +1237,7 @@ async function acceptDiscoveredPeer(
 			return [];
 		}
 	})();
-	const addressesJson = JSON.stringify(mergeAddresses(existingAddresses, nextAddresses));
+	const addressesJson = JSON.stringify(mergeAddresses(nextAddresses, existingAddresses));
 	await createCoordinatorReciprocalApproval(store, config, {
 		groupId,
 		requestedDeviceId: input.peerDeviceId,
@@ -1325,12 +1378,14 @@ function mapPeerRow(
 	const peerId = String(row.peer_device_id ?? "");
 	const recentOps = recentOpsByPeer?.get(peerId) ?? { in: 0, out: 0 };
 	const scopeRejections = scopeRejectionsByPeer?.get(peerId);
+	const addresses = safeJsonList(row.addresses_json as string | null);
 	return {
 		peer_device_id: row.peer_device_id,
 		name: row.name,
 		fingerprint: showDiag ? row.pinned_fingerprint : null,
 		pinned: Boolean(row.pinned_fingerprint),
-		addresses: showDiag ? safeJsonList(row.addresses_json as string | null) : [],
+		addresses: showDiag ? addresses : [],
+		address_count: addresses.length,
 		last_seen_at: row.last_seen_at,
 		last_sync_at: row.last_sync_at,
 		last_error: showDiag ? row.last_error : null,
@@ -1355,6 +1410,25 @@ function mapPeerRow(
 				: null,
 		discovered_via_group_id:
 			typeof row.discovered_via_group_id === "string" ? row.discovered_via_group_id : null,
+	};
+}
+
+function redactSyncAttemptError(error: unknown): string | null {
+	const text = String(error ?? "").trim();
+	if (!text) return null;
+	return "sync attempt failed; enable diagnostics for details";
+}
+
+function mapSyncAttemptRow(
+	row: Record<string, unknown>,
+	showDiag: boolean,
+	addresses?: string[],
+): Record<string, unknown> {
+	return {
+		...row,
+		error: showDiag ? row.error : redactSyncAttemptError(row.error),
+		status: attemptStatus(row),
+		address: showDiag && addresses?.length ? addresses[0] : null,
 	};
 }
 
@@ -1955,14 +2029,15 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				// Specific reasons are logged server-side; wire responses use a generic
 				// reason to prevent info-disclosure.
 				if (bootstrapAttempted) {
+					const grantPresent = Boolean((c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim());
 					console.warn(
-						`[sync] bootstrap grant auth failed: reason=${auth.reason} grant=${(c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim()} path=${c.req.path}`,
+						`[sync] bootstrap grant auth failed: reason=${auth.reason} grant_present=${grantPresent} path=${c.req.path}`,
 					);
 				}
 				const wireReason = bootstrapAttempted ? "bootstrap_grant_invalid" : auth.reason;
 				return (
 					(preauthChecked ? null : rateLimitedResponse(c, c.req.path, false)) ??
-					c.json(unauthorizedPayload(wireReason), 401)
+					c.json(unauthorizedPayload(wireReason, true), 401)
 				);
 			}
 			const limited = rateLimitedResponse(c, auth.deviceId, true);
@@ -1993,7 +2068,8 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 		if (!auth.ok)
 			return (
-				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)
+				rateLimitedResponse(c, c.req.path, false) ??
+				c.json(unauthorizedPayload(auth.reason, true), 401)
 			);
 		const limited = rateLimitedResponse(c, auth.deviceId, true);
 		if (limited) return limited;
@@ -2090,14 +2166,15 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				// Specific reasons are logged server-side; wire responses use a generic
 				// reason to prevent info-disclosure.
 				if (bootstrapAttempted) {
+					const grantPresent = Boolean((c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim());
 					console.warn(
-						`[sync] bootstrap grant auth failed: reason=${auth.reason} grant=${(c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim()} path=${c.req.path}`,
+						`[sync] bootstrap grant auth failed: reason=${auth.reason} grant_present=${grantPresent} path=${c.req.path}`,
 					);
 				}
 				const wireReason = bootstrapAttempted ? "bootstrap_grant_invalid" : auth.reason;
 				return (
 					(preauthChecked ? null : rateLimitedResponse(c, c.req.path, false)) ??
-					c.json(unauthorizedPayload(wireReason), 401)
+					c.json(unauthorizedPayload(wireReason, true), 401)
 				);
 			}
 			const limited = rateLimitedResponse(c, auth.deviceId, true);
@@ -2177,7 +2254,8 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 		if (!auth.ok)
 			return (
-				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)
+				rateLimitedResponse(c, c.req.path, false) ??
+				c.json(unauthorizedPayload(auth.reason, true), 401)
 			);
 		const limited = rateLimitedResponse(c, auth.deviceId, true);
 		if (limited) return limited;
@@ -2509,13 +2587,9 @@ export function syncRoutes(
 			});
 			const attemptsItems = attemptRows.map((row) => {
 				const addrs = showDiag ? peerAddressMap.get(String(row.peer_device_id ?? "")) : undefined;
-				return {
-					...row,
-					status: attemptStatus(row),
-					address: addrs?.length ? addrs[0] : null,
-				};
+				return mapSyncAttemptRow(row, showDiag, addrs);
 			});
-			const latestAttemptError = String(attemptsItems[0]?.error || "").trim();
+			const latestAttemptError = String(attemptRows[0]?.error || "").trim();
 
 			const statusBlock: Record<string, unknown> = {
 				...statusPayload,
@@ -2696,7 +2770,9 @@ export function syncRoutes(
 				.orderBy(desc(schema.syncAttempts.finished_at))
 				.limit(limit)
 				.all();
-			return c.json({ items: rows });
+			const showDiag = queryBool(c.req.query("includeDiagnostics"));
+			const items = rows.map((row) => mapSyncAttemptRow(row, showDiag));
+			return c.json({ items, redacted: !showDiag });
 		}
 	});
 
@@ -2713,39 +2789,22 @@ export function syncRoutes(
 		{
 			const config = readCoordinatorSyncConfig();
 			const d = drizzle(store.db, { schema });
-			const deviceRow = d
-				.select({
-					device_id: schema.syncDevice.device_id,
-					public_key: schema.syncDevice.public_key,
-					fingerprint: schema.syncDevice.fingerprint,
-				})
-				.from(schema.syncDevice)
-				.limit(1)
-				.get();
-
 			let deviceId: string | undefined;
 			let publicKey: string | undefined;
 			let fingerprint: string | undefined;
 
-			if (deviceRow) {
-				deviceId = String(deviceRow.device_id);
-				publicKey = String(deviceRow.public_key);
-				fingerprint = String(deviceRow.fingerprint);
-			} else {
-				// Fall back to ensureDeviceIdentity if no row exists
-				try {
-					const [id, fp] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
-					deviceId = id;
-					fingerprint = fp;
-					const newRow = d
-						.select({ public_key: schema.syncDevice.public_key })
-						.from(schema.syncDevice)
-						.where(eq(schema.syncDevice.device_id, id))
-						.get();
-					publicKey = newRow?.public_key ?? "";
-				} catch {
-					return c.json({ error: "device identity unavailable" }, 500);
-				}
+			try {
+				const [id, fp] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
+				deviceId = id;
+				fingerprint = fp;
+				const row = d
+					.select({ public_key: schema.syncDevice.public_key })
+					.from(schema.syncDevice)
+					.where(eq(schema.syncDevice.device_id, id))
+					.get();
+				publicKey = row?.public_key ?? "";
+			} catch {
+				return c.json({ error: "device identity unavailable" }, 500);
 			}
 
 			if (!deviceId || !fingerprint) {
@@ -3348,9 +3407,11 @@ export function syncRoutes(
 		const peerDeviceId = String(body.peer_device_id ?? "").trim();
 		const fingerprint = String(body.fingerprint ?? "").trim();
 		if (!peerDeviceId) return c.json({ error: "peer_device_id required" }, 400);
-		if (!fingerprint) return c.json({ error: "fingerprint required" }, 400);
 		try {
-			const result = await acceptDiscoveredPeer(store, { peerDeviceId, fingerprint });
+			const result = await acceptDiscoveredPeer(store, {
+				peerDeviceId,
+				fingerprint: fingerprint || undefined,
+			});
 			if (!result.ok) {
 				return c.json(
 					{ error: result.error, detail: result.detail },
@@ -3443,9 +3504,27 @@ export function syncRoutes(
 		}
 		if (pairingResult?.kind === "pair") {
 			try {
+				const d = drizzle(store.db, { schema });
+				const existing = d
+					.select({ pinned_fingerprint: schema.syncPeers.pinned_fingerprint })
+					.from(schema.syncPeers)
+					.where(eq(schema.syncPeers.peer_device_id, pairingResult.device_id))
+					.get();
+				const existingFingerprint = String(existing?.pinned_fingerprint ?? "").trim();
+				if (existingFingerprint && existingFingerprint !== pairingResult.fingerprint) {
+					return c.json(
+						{
+							error: "peer_conflict",
+							detail:
+								"Pairing payload conflicts with the existing trusted fingerprint for this device. Remove or repair the old peer before accepting this pairing payload.",
+						},
+						409,
+					);
+				}
 				updatePeerAddresses(store.db, pairingResult.device_id, pairingResult.addresses, {
 					pinnedFingerprint: pairingResult.fingerprint,
 					publicKey: pairingResult.public_key,
+					replaceTrust: true,
 				});
 				return c.json({
 					ok: true,
@@ -4177,13 +4256,18 @@ export function syncRoutes(
 			const peerDeviceId = String(body.peer_device_id ?? "").trim();
 			const publicKey = String(body.peer_public_key ?? "").trim();
 			const name = String(body.name ?? "").trim() || null;
-			const fingerprint = String(body.fingerprint ?? "").trim() || null;
+			const requestedFingerprint = String(body.fingerprint ?? "").trim();
 			const addressesInput = Array.isArray(body.peer_addresses) ? body.peer_addresses : [];
-			const addresses = addressesInput
-				.map((item) => String(item ?? "").trim())
-				.filter((item) => item.length > 0);
+			const addresses = mergeAddresses(
+				[],
+				addressesInput.map((item) => String(item ?? "").trim()).filter((item) => item.length > 0),
+			);
 			if (!peerDeviceId || !publicKey) {
 				return c.json({ error: "peer_device_id_and_public_key_required" }, 400);
+			}
+			const fingerprint = requestedFingerprint || fingerprintPublicKey(publicKey);
+			if (fingerprintPublicKey(publicKey) !== fingerprint) {
+				return c.json({ error: "fingerprint_mismatch" }, 400);
 			}
 			const manualInclude =
 				overrideInclude && overrideInclude.length > 0 ? JSON.stringify(overrideInclude) : null;


### PR DESCRIPTION
## Description
Guard coordinator/device pairing trust repair paths.

This prevents stale or mismatched coordinator discovery from creating trust, rejects conflicting pairing payloads, repairs matching incomplete trust material, redacts persisted attempt diagnostics by default, and keeps auth failure detail behind explicit diagnostics.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted Vitest suite)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation run on the full stack:

- `pnpm exec vitest run packages/core/src/sync-daemon.test.ts packages/core/src/sync-discovery.test.ts packages/core/src/coordinator-runtime.test.ts packages/cli/src/commands/sync.test.ts packages/viewer-server/src/index.test.ts packages/ui/src/tabs/sync/view-model.test.ts packages/ui/src/tabs/sync/index.test.ts`
- `pnpm run tsc`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced