### PR TITLE
fix(ui): keep redacted sync devices actionable

### DIFF
--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { triggerSync } from "./sync";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("triggerSync", () => {
+	it("can scope a manual sync by peer device id when addresses are hidden", async () => {
+		const fetchMock = vi.fn(
+			async () => new Response(JSON.stringify({ items: [] }), { status: 200 }),
+		);
+		globalThis.fetch = fetchMock as typeof fetch;
+
+		await triggerSync({ peerDeviceId: "peer-redacted" });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/sync/run",
+			expect.objectContaining({
+				body: JSON.stringify({ peer_device_id: "peer-redacted" }),
+				method: "POST",
+			}),
+		);
+	});
+});

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -6,6 +6,11 @@
 import { fetchJson, payloadError, readJsonPayload } from "./internal";
 import type { AcceptDiscoveredPeerResult, ImportInviteResult, SyncRunResponse } from "./types";
 
+type TriggerSyncTarget = {
+	address?: string;
+	peerDeviceId?: string;
+};
+
 export async function loadSyncStatus(
 	includeDiagnostics: boolean,
 	project = "",
@@ -121,15 +126,14 @@ export async function renamePeer(peerDeviceId: string, name: string): Promise<un
 
 export async function acceptDiscoveredPeer(
 	peerDeviceId: string,
-	fingerprint: string,
+	fingerprint?: string,
 ): Promise<AcceptDiscoveredPeerResult> {
+	const body: Record<string, string> = { peer_device_id: peerDeviceId };
+	if (fingerprint) body.fingerprint = fingerprint;
 	const resp = await fetch("/api/sync/peers/accept-discovered", {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			peer_device_id: peerDeviceId,
-			fingerprint,
-		}),
+		body: JSON.stringify(body),
 	});
 	const text = await resp.text();
 	let payload: AcceptDiscoveredPeerResult = {};
@@ -657,8 +661,12 @@ export async function claimLegacyDeviceIdentity(originDeviceId: string): Promise
 	return payload;
 }
 
-export async function triggerSync(address?: string): Promise<SyncRunResponse> {
-	const payload = address ? { address } : {};
+export async function triggerSync(target?: string | TriggerSyncTarget): Promise<SyncRunResponse> {
+	const address = typeof target === "string" ? target.trim() : target?.address?.trim();
+	const peerDeviceId = typeof target === "string" ? "" : target?.peerDeviceId?.trim();
+	const payload: Record<string, string> = {};
+	if (address) payload.address = address;
+	if (peerDeviceId) payload.peer_device_id = peerDeviceId;
 	const resp = await fetch("/api/sync/run", {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -133,6 +133,7 @@ export interface DiscoveredDevice {
 	fingerprint?: string;
 	groups?: string[];
 	stale?: boolean;
+	address_count?: number;
 	addresses?: string[];
 	needs_local_approval?: boolean;
 	waiting_for_peer_approval?: boolean;

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -106,6 +106,7 @@ const DIRECTION_GLYPH: Record<PeerDirection, { glyph: string; label: string } | 
 
 type SyncPeer = PeerLike & {
 	actor_display_name?: string;
+	address_count?: number;
 	addresses?: unknown[];
 	claimed_local_actor?: boolean;
 	claimed_local_actor_scope?: PeerClaimedLocalActorScopeLike | null;
@@ -201,11 +202,16 @@ function SyncPeerCard({
 	const peerAddresses = Array.isArray(peer.addresses)
 		? Array.from(new Set(peer.addresses.filter(Boolean).map((value) => String(value))))
 		: [];
+	const rawHiddenAddressCount = Number(peer.address_count ?? 0);
+	const hiddenAddressCount =
+		Number.isFinite(rawHiddenAddressCount) && rawHiddenAddressCount > 0 ? rawHiddenAddressCount : 0;
 	const addressLine = peerAddresses.length
 		? peerAddresses
 				.map((address) => (isSyncRedactionEnabled() ? redactAddress(address) : address))
 				.join(" · ")
-		: "No addresses";
+		: hiddenAddressCount > 0
+			? `${hiddenAddressCount} ${hiddenAddressCount === 1 ? "address" : "addresses"} hidden`
+			: "No addresses";
 	const assignmentSummary = peer.actor_display_name
 		? `This device belongs to ${peer.claimed_local_actor ? "you" : String(peer.actor_display_name)}.`
 		: "This device is not assigned to anyone yet.";
@@ -325,7 +331,6 @@ function SyncPeerCard({
 	}
 
 	async function sync() {
-		if (!primaryAddress) return;
 		if (pendingScopeReview) {
 			const proceed = await openSyncConfirmDialog({
 				title: `Sync ${displayName} before scope review?`,
@@ -527,8 +532,13 @@ function SyncPeerCard({
 						<button
 							type="button"
 							className="settings-button"
-							disabled={!primaryAddress || syncBusy}
+							disabled={syncBusy}
 							onClick={() => void sync()}
+							title={
+								primaryAddress
+									? undefined
+									: "Address details are hidden; sync will target this device by ID."
+							}
 						>
 							{syncBusy ? "Syncing…" : "Sync now"}
 						</button>

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -127,9 +127,9 @@ export function renderSyncPeers() {
 		},
 		onSync: async (peer, address) => {
 			try {
-				const result = await api.triggerSync(address);
-				const summary = summarizeSyncRunResult(result);
 				const peerId = String(peer?.peer_device_id || "");
+				const result = await api.triggerSync({ address, peerDeviceId: peerId || undefined });
+				const summary = summarizeSyncRunResult(result);
 				let feedback: SyncActionFeedback | null;
 				if (!summary.ok) {
 					feedback = { message: summary.message, tone: "warning" };

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -285,6 +285,11 @@ export function renderTeamSync() {
 			pairedLocally: Boolean(pairedPeer),
 		});
 		const addresses = Array.isArray(device.addresses) ? device.addresses : [];
+		const rawHiddenAddressCount = Number(device.address_count ?? 0);
+		const hiddenAddressCount =
+			Number.isFinite(rawHiddenAddressCount) && rawHiddenAddressCount > 0
+				? rawHiddenAddressCount
+				: 0;
 		const addressLabel = addresses.length
 			? addresses
 					.map((address) =>
@@ -292,7 +297,9 @@ export function renderTeamSync() {
 					)
 					.filter(Boolean)
 					.join(" · ")
-			: "No fresh addresses";
+			: hiddenAddressCount > 0
+				? `${hiddenAddressCount} ${device.stale ? "last-known" : "fresh"} ${hiddenAddressCount === 1 ? "address" : "addresses"} hidden`
+				: "No fresh addresses";
 		const noteParts = [addressLabel];
 		if (!addresses.length && displayTitle) noteParts.push(`device id: ${deviceId}`);
 		let actionMessage: string | null = null;

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -659,3 +659,14 @@ describe("deriveSyncViewModel", () => {
 		});
 	});
 });
+
+describe("shouldShowCoordinatorReviewAction", () => {
+	it("allows fresh unpaired discovered devices without a visible fingerprint", () => {
+		expect(
+			shouldShowCoordinatorReviewAction({
+				device: { device_id: "peer-1", stale: false },
+				pairedLocally: false,
+			}),
+		).toBe(true);
+	});
+});

--- a/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
+++ b/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
@@ -56,8 +56,7 @@ export function shouldShowCoordinatorReviewAction(input: {
 }): boolean {
 	const approvalSummary = deriveCoordinatorApprovalSummary(input);
 	const deviceId = cleanText(input.device?.device_id);
-	const fingerprint = cleanText(input.device?.fingerprint);
-	if (!deviceId || !fingerprint) return false;
+	if (!deviceId) return false;
 	if (input.device?.stale || input.hasAmbiguousCoordinatorGroup) return false;
 	if (!input.pairedLocally) return true;
 	return approvalSummary.state === "needs-your-approval";

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -178,6 +178,8 @@ export interface DiscoveredDeviceLike {
 	stale?: boolean;
 	fingerprint?: string;
 	groups?: string[];
+	address_count?: number;
+	addresses?: unknown[];
 	needs_local_approval?: boolean;
 	waiting_for_peer_approval?: boolean;
 }


### PR DESCRIPTION
## Description
Keep redacted sync devices actionable in the UI.

This lets fresh coordinator-discovered devices remain reviewable when fingerprints/addresses are hidden, shows hidden address counts instead of false empty states, and keeps manual sync usable when address details are redacted.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted Vitest suite)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation run on the full stack:

- `pnpm exec vitest run packages/core/src/sync-daemon.test.ts packages/core/src/sync-discovery.test.ts packages/core/src/coordinator-runtime.test.ts packages/cli/src/commands/sync.test.ts packages/viewer-server/src/index.test.ts packages/ui/src/tabs/sync/view-model.test.ts packages/ui/src/tabs/sync/index.test.ts`
- `pnpm run tsc`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced