### PR TITLE
fix(sync): enforce single is_local=1 row in actors table

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -7558,6 +7558,39 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("demotes stale is_local=1 rows so only the canonical local actor stays marked local", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+
+				const now = new Date().toISOString();
+				store.db
+					.prepare(
+						`INSERT INTO actors (actor_id, display_name, is_local, status, created_at, updated_at)
+						 VALUES (?, ?, 1, 'active', ?, ?)`,
+					)
+					.run("local:stale-device-uuid", "Stale Local", now, now);
+
+				const res = await app.request("/api/sync/actors");
+				expect(res.status).toBe(200);
+
+				const localActorRows = store.db
+					.prepare("SELECT actor_id, is_local FROM actors WHERE is_local = 1")
+					.all() as Array<{ actor_id: string; is_local: number }>;
+				expect(localActorRows).toHaveLength(1);
+				expect(localActorRows[0]?.actor_id).toBe(store.actorId);
+
+				const staleRow = store.db
+					.prepare("SELECT is_local FROM actors WHERE actor_id = ?")
+					.get("local:stale-device-uuid") as { is_local: number } | undefined;
+				expect(staleRow?.is_local).toBe(0);
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("maps claimed_local_actor=true to the local actor id when no actor id is provided", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -942,13 +942,32 @@ function peerAuthorizedScopes(store: MemoryStore, peerDeviceId: string): Record<
 
 function ensureLocalActorRecord(store: MemoryStore): void {
 	const d = drizzle(store.db, { schema });
+	const now = new Date().toISOString();
+	// Invariant: exactly one row in `actors` has is_local=1, and it is the
+	// row whose actor_id matches store.actorId. Stale is_local=1 rows can
+	// appear when a device's actor_id changes (config edit, regenerated
+	// device keys, DB copied from another machine). Demote any such rows
+	// before ensuring the canonical local row exists.
+	d.update(schema.actors)
+		.set({ is_local: 0, updated_at: now })
+		.where(and(eq(schema.actors.is_local, 1), ne(schema.actors.actor_id, store.actorId)))
+		.run();
 	const existing = d
 		.select({ actor_id: schema.actors.actor_id })
 		.from(schema.actors)
 		.where(eq(schema.actors.actor_id, store.actorId))
 		.get();
-	if (existing) return;
-	const now = new Date().toISOString();
+	if (existing) {
+		// Row already exists for the canonical local actor id; the demotion
+		// above guarantees it is the only is_local=1 row, but the row itself
+		// may have been previously set to is_local=0 (e.g. via a stale demote
+		// from an even earlier identity). Re-mark it as local idempotently.
+		d.update(schema.actors)
+			.set({ is_local: 1, updated_at: now })
+			.where(eq(schema.actors.actor_id, store.actorId))
+			.run();
+		return;
+	}
 	d.insert(schema.actors)
 		.values({
 			actor_id: store.actorId,


### PR DESCRIPTION
## Description

`ensureLocalActorRecord` (the only insertion site for `actors.is_local = 1`) previously checked only whether a row matching the current `store.actorId` existed; it did not guard against stale `is_local = 1` rows that originated from a prior actor identity. After a config edit, regenerated device keys, or a database copied from another machine, the `actors` table could end up with multiple rows marked `is_local = 1`. The UI helper `actorDisplayLabel` (`packages/ui/src/tabs/sync/helpers.ts:147`) returns the literal string `"You"` for any `is_local` row, so the bug surfaces as two identical-looking "You" entries in the People & devices view with no way to tell them apart.

The fix demotes any stale `is_local = 1` rows whose `actor_id` does not match `store.actorId` before ensuring the canonical local row, then re-marks the canonical row idempotently. The function is now self-healing on every call.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

New regression test in `packages/viewer-server/src/index.test.ts` ("demotes stale is_local=1 rows so only the canonical local actor stays marked local"): seeds the `actors` table with a stale `is_local = 1` row that does not match the device's canonical actor id, hits `GET /api/sync/actors`, and asserts there is exactly one `is_local = 1` row and that its `actor_id` is `store.actorId`. Test was confirmed to fail without the fix and pass with it. Full viewer-server vitest suite (188 tests) passes. `pnpm run tsc` and `pnpm run lint` clean.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced