### PR TITLE
fix(sync): return structured reason for coordinator_not_configured

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -8022,7 +8022,7 @@ describe("viewer-server", () => {
 			}
 		});
 
-		it("returns 400 when coordinator sync is not configured", async () => {
+		it("returns 400 with coordinator_url_missing when no coordinator URL is configured", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;
 			process.env.CODEMEM_CONFIG = configPath;
@@ -8040,7 +8040,77 @@ describe("viewer-server", () => {
 				expect(res.status).toBe(400);
 				expect(await res.json()).toEqual({
 					error: "coordinator_not_configured",
-					detail: "Coordinator must be configured before accepting discovered peers.",
+					reason: "coordinator_url_missing",
+					detail: "Configure a coordinator URL before pairing with discovered peers.",
+				});
+			} finally {
+				cleanup();
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+			}
+		});
+
+		it("returns 400 with coordinator_groups_empty when URL is set but no groups", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: false,
+					sync_coordinator_url: "http://localhost:7347",
+				}),
+			);
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
+				});
+				expect(res.status).toBe(400);
+				expect(await res.json()).toEqual({
+					error: "coordinator_not_configured",
+					reason: "coordinator_groups_empty",
+					detail: "Join a coordinator team before pairing with discovered peers.",
+				});
+			} finally {
+				cleanup();
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+			}
+		});
+
+		it("returns 400 with sync_disabled when coordinator is fully set up but sync is off", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: false,
+					sync_coordinator_url: "http://localhost:7347",
+					sync_coordinator_groups: ["test-team"],
+				}),
+			);
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						fingerprint: FRESH_PEER_FINGERPRINT,
+					}),
+				});
+				expect(res.status).toBe(400);
+				expect(await res.json()).toEqual({
+					error: "coordinator_not_configured",
+					reason: "sync_disabled",
+					detail: "Enable sync on this device before pairing with discovered peers.",
 				});
 			} finally {
 				cleanup();

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1091,6 +1091,22 @@ interface AcceptDiscoveredPeerOptions {
 	expectedGroupId?: string;
 }
 
+type AcceptDiscoveredPeerNotConfiguredReason =
+	| "coordinator_url_missing"
+	| "coordinator_groups_empty"
+	| "sync_disabled";
+
+function detailForNotConfiguredReason(reason: AcceptDiscoveredPeerNotConfiguredReason): string {
+	switch (reason) {
+		case "coordinator_url_missing":
+			return "Configure a coordinator URL before pairing with discovered peers.";
+		case "coordinator_groups_empty":
+			return "Join a coordinator team before pairing with discovered peers.";
+		case "sync_disabled":
+			return "Enable sync on this device before pairing with discovered peers.";
+	}
+}
+
 async function acceptDiscoveredPeer(
 	store: MemoryStore,
 	input: AcceptDiscoveredPeerOptions,
@@ -1103,19 +1119,32 @@ async function acceptDiscoveredPeer(
 			name: string | null;
 			group_id: string;
 	  }
-	| { ok: false; status: number; error: string; detail: string }
+	| {
+			ok: false;
+			status: number;
+			error: string;
+			detail: string;
+			reason?: AcceptDiscoveredPeerNotConfiguredReason;
+	  }
 > {
 	const config = readCoordinatorSyncConfig();
-	if (
-		!config.syncEnabled ||
-		!config.syncCoordinatorUrl ||
-		config.syncCoordinatorGroups.length === 0
-	) {
+	// Order: address the most foundational gap first so the detail string
+	// guides the user through setup in the correct sequence.
+	let notConfiguredReason: AcceptDiscoveredPeerNotConfiguredReason | null = null;
+	if (!config.syncCoordinatorUrl) {
+		notConfiguredReason = "coordinator_url_missing";
+	} else if (config.syncCoordinatorGroups.length === 0) {
+		notConfiguredReason = "coordinator_groups_empty";
+	} else if (!config.syncEnabled) {
+		notConfiguredReason = "sync_disabled";
+	}
+	if (notConfiguredReason) {
 		return {
 			ok: false,
 			status: 400,
 			error: "coordinator_not_configured",
-			detail: "Coordinator must be configured before accepting discovered peers.",
+			reason: notConfiguredReason,
+			detail: detailForNotConfiguredReason(notConfiguredReason),
 		};
 	}
 	const discovered = await lookupCoordinatorPeers(store, config);
@@ -3433,7 +3462,11 @@ export function syncRoutes(
 			});
 			if (!result.ok) {
 				return c.json(
-					{ error: result.error, detail: result.detail },
+					{
+						error: result.error,
+						detail: result.detail,
+						...(result.reason ? { reason: result.reason } : {}),
+					},
 					{ status: result.status as 400 | 404 | 409 },
 				);
 			}
@@ -4366,7 +4399,11 @@ export function syncRoutes(
 				return c.json(result);
 			}
 			return c.json(
-				{ error: result.error, detail: result.detail },
+				{
+					error: result.error,
+					detail: result.detail,
+					...(result.reason ? { reason: result.reason } : {}),
+				},
 				result.status as 400 | 404 | 409,
 			);
 		} catch (error) {


### PR DESCRIPTION
## Description

`acceptDiscoveredPeer` previously collapsed three distinct user-fixable states into a single generic 400 with the same `detail` string ("Coordinator must be configured before accepting discovered peers."). The user has no way to tell which step they need to take. Three different setup paths converged on the same opaque message:

- No `sync_coordinator_url` configured (foundational — coordinator not joined yet)
- Coordinator URL set but `sync_coordinator_groups` is empty (URL set but no team joined)
- Coordinator fully set up but `sync_enabled` is `false` (joined team, sync explicitly disabled)

Return a structured `reason` field on the 400 response (alongside the existing `detail`), set to `coordinator_url_missing`, `coordinator_groups_empty`, or `sync_disabled`. The `detail` string is now specific to which check failed, guiding the user through setup in foundational order.

The forwarding through both call sites of `acceptDiscoveredPeer` (`/api/sync/peers/accept-discovered` and the coordinator-admin equivalent at line 4369) is preserved — both pass the new `reason` through to the wire response.

This is the server-side slice. UI gating on the Pair button (rendering a disabled state with the reason inline instead of letting users click into a guaranteed 400) is deferred to a follow-up that consumes this new field.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Updated the existing "returns 400 when coordinator sync is not configured" test to match the new `coordinator_url_missing` shape, and added two new tests covering `coordinator_groups_empty` (URL set, no groups) and `sync_disabled` (URL + groups set, sync off). All three pass; full viewer-server vitest suite (189 tests) passes. `pnpm run tsc` and `pnpm run lint` clean.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced