### PR TITLE
fix(ui): clear stale Removed peer banner when peer rejoins

### DIFF
--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -260,7 +260,15 @@ export const state = {
 	lastTeamJoin: null as CachedTeamJoin | null,
 	syncJoinFlowFeedback: null as { message: string; tone: "success" | "warning" } | null,
 	syncPeerFeedbackById: new Map<string, { message: string; tone: "success" | "warning" }>(),
-	syncPeersSectionFeedback: null as { message: string; tone: "success" | "warning" } | null,
+	syncPeersSectionFeedback: null as {
+		message: string;
+		tone: "success" | "warning";
+		// Optional peer_device_id this feedback is about (e.g. a peer just
+		// removed). When that peer reappears in state.lastSyncPeers (e.g.
+		// because the user re-paired it), the feedback is stale and should
+		// be cleared on the next render — see shouldClearStalePeersFeedback.
+		relatedPeerDeviceId?: string;
+	} | null,
 	syncJoinRequestsFeedback: null as { message: string; tone: "success" | "warning" } | null,
 	syncDiscoveredFeedback: null as { message: string; tone: "success" | "warning" } | null,
 	lastSyncAttempts: [] as unknown[],

--- a/packages/ui/src/tabs/sync/helpers.test.ts
+++ b/packages/ui/src/tabs/sync/helpers.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { state } from "../../lib/state";
-import { actorDisplayLabel, assignmentNote, buildActorSelectOptions } from "./helpers";
+import {
+	actorDisplayLabel,
+	assignmentNote,
+	buildActorSelectOptions,
+	shouldClearStalePeersFeedback,
+} from "./helpers";
 
 const originalActors = state.lastSyncActors;
 const originalPeers = state.lastSyncPeers;
@@ -94,5 +99,39 @@ describe("buildActorSelectOptions", () => {
 			{ value: "", label: "No person assigned" },
 			{ value: "actor-local", label: "You" },
 		]);
+	});
+});
+
+describe("shouldClearStalePeersFeedback", () => {
+	it("clears when the related peer reappears in the loaded list", () => {
+		expect(
+			shouldClearStalePeersFeedback({ relatedPeerDeviceId: "peer-rejoined" }, [
+				{ peer_device_id: "peer-rejoined" },
+			]),
+		).toBe(true);
+	});
+
+	it("does not clear when no peers match", () => {
+		expect(
+			shouldClearStalePeersFeedback({ relatedPeerDeviceId: "peer-removed" }, [
+				{ peer_device_id: "peer-other" },
+			]),
+		).toBe(false);
+	});
+
+	it("does not clear when feedback has no relatedPeerDeviceId", () => {
+		expect(shouldClearStalePeersFeedback({}, [{ peer_device_id: "peer-any" }])).toBe(false);
+	});
+
+	it("does not clear when feedback is null", () => {
+		expect(shouldClearStalePeersFeedback(null, [{ peer_device_id: "peer-any" }])).toBe(false);
+	});
+
+	it("trims whitespace before comparing peer ids", () => {
+		expect(
+			shouldClearStalePeersFeedback({ relatedPeerDeviceId: "  peer-id  " }, [
+				{ peer_device_id: "peer-id" },
+			]),
+		).toBe(true);
 	});
 });

--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -133,6 +133,24 @@ export function parseScopeList(value: string): string[] {
 		.filter(Boolean);
 }
 
+/* ── Peers section feedback helpers ──────────────────────── */
+
+/**
+ * Returns true when a "Removed peer X" style feedback message is stale
+ * because the related peer has reappeared in the loaded peers list (e.g.
+ * the user re-paired the same device they just removed). Used by
+ * renderSyncPeers to clear the persistent banner once the user's view
+ * of reality contradicts it.
+ */
+export function shouldClearStalePeersFeedback(
+	feedback: { relatedPeerDeviceId?: string | null } | null | undefined,
+	peers: ReadonlyArray<{ peer_device_id?: string | null } | null | undefined>,
+): boolean {
+	const id = String(feedback?.relatedPeerDeviceId ?? "").trim();
+	if (!id) return false;
+	return peers.some((peer) => String(peer?.peer_device_id ?? "").trim() === id);
+}
+
 /* ── Actor helpers ───────────────────────────────────────── */
 
 export function actorLabel(actor: SyncActor | null | undefined): string {

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -9,7 +9,12 @@ import { renderSyncEmptyState } from "./components/sync-diagnostics";
 import type { SyncActionFeedback } from "./components/sync-inline-feedback";
 import { renderLegacyClaimsSlice } from "./components/sync-legacy-claims";
 import { renderSyncPeersList } from "./components/sync-peers";
-import { clearPeerScopeReview, hideSkeleton, isPeerScopeReviewPending } from "./helpers";
+import {
+	clearPeerScopeReview,
+	hideSkeleton,
+	isPeerScopeReviewPending,
+	shouldClearStalePeersFeedback,
+} from "./helpers";
 import { openSyncConfirmDialog } from "./sync-dialogs";
 import {
 	deriveVisiblePeopleActors,
@@ -111,8 +116,16 @@ export function renderSyncPeers() {
 	if (!syncPeers) return;
 	hideSkeleton("syncPeersSkeleton");
 	const peers = state.lastSyncPeers;
+	const peersArray = Array.isArray(peers) ? peers : [];
+	// "Removed peer X" feedback survives in module state until the page
+	// reloads. Clear it once the same peer reappears in the loaded list
+	// (e.g. because the user re-paired the device they just removed) so
+	// the banner does not contradict the live device row beneath it.
+	if (shouldClearStalePeersFeedback(state.syncPeersSectionFeedback, peersArray)) {
+		state.syncPeersSectionFeedback = null;
+	}
 	renderSyncPeersList(syncPeers, {
-		peers: Array.isArray(peers) ? peers : [],
+		peers: peersArray,
 		onRename: async (peerId, nextName) => {
 			try {
 				await api.renamePeer(peerId, nextName);
@@ -164,10 +177,13 @@ export function renderSyncPeers() {
 				await api.deletePeer(peerId);
 				const feedback = {
 					message: `Removed peer ${label}.`,
-					tone: "success",
+					tone: "success" as const,
 				} satisfies SyncActionFeedback;
 				state.syncPeerFeedbackById.delete(peerId);
-				state.syncPeersSectionFeedback = feedback;
+				// Tag the section feedback with the removed peer id so a
+				// subsequent re-pair of the same device can detect and clear
+				// the stale "Removed peer X" banner on the next render.
+				state.syncPeersSectionFeedback = { ...feedback, relatedPeerDeviceId: peerId };
 				await _loadSyncData();
 				return feedback;
 			} catch (error) {


### PR DESCRIPTION
## Description

The `Removed peer X.` confirmation in the Devices view lives in module state (`state.syncPeersSectionFeedback`) and previously had no clear path until the page reloaded. If the user removed a peer and then re-paired the same device in the same page lifetime, the green banner persisted alongside the live device row beneath it — directly contradicting what the user saw.

Tag the section feedback with the removed peer's `device_id` at write time (in `onRemove`), and clear it during the next `renderSyncPeers` pass when the same id reappears in the loaded peers list. A small pure helper `shouldClearStalePeersFeedback` keeps the matching logic out of the renderer so the behavior is unit-testable without a DOM.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

New `shouldClearStalePeersFeedback` tests in `packages/ui/src/tabs/sync/helpers.test.ts` cover: match (clears), no-match (does not clear), missing related id (does not clear), null feedback (does not clear), and whitespace-trim before comparison. Full UI vitest suite (149 tests) passes. `pnpm run tsc` and `pnpm run lint` clean.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced