### PR TITLE
feat(ui): clarify Teams Space access management

### DIFF
--- a/packages/ui/src/tabs/coordinator-admin/components/devices-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/devices-panel.ts
@@ -8,6 +8,7 @@ import { h } from "preact";
 import { RadixTabsContent } from "../../../components/primitives/radix-tabs";
 import { TextInput } from "../../../components/primitives/text-input";
 import { state } from "../../../lib/state";
+import { coordinatorAdminDeviceCardCopy } from "../data/device-card";
 import { coordinatorAdminState } from "../data/state";
 import type { CoordinatorAdminSummary } from "../data/summary";
 
@@ -34,7 +35,7 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 			"p",
 			{ class: "peer-submeta" },
 			summary.readiness === "ready"
-				? "Rename, disable, re-enable, or remove enrolled devices from the operator surface without confusing this with direct sync state."
+				? "Rename, disable, re-enable, or remove Team devices here. Space access is granted from Spaces below; Team membership alone does not share memories."
 				: "Finish setup first. Device administration stays disabled until coordinator admin is ready.",
 		),
 		!items.length
@@ -49,11 +50,11 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 					"div",
 					{ class: "peer-list" },
 					items.map((item) => {
-						const deviceId = String(item.device_id || "").trim();
-						const groupId = String(
-							item.group_id || state.lastCoordinatorAdminStatus?.active_group || "",
-						).trim();
-						const displayName = String(item.display_name || deviceId || "Unnamed device");
+						const copy = coordinatorAdminDeviceCardCopy(
+							item,
+							String(state.lastCoordinatorAdminStatus?.active_group || ""),
+						);
+						const { deviceId, displayName, teamId } = copy;
 						const pending = coordinatorAdminState.deviceActionPendingId === deviceId;
 						const draft =
 							coordinatorAdminState.deviceRenameDrafts.get(deviceId) ??
@@ -66,9 +67,8 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 								key: deviceId || String(item.fingerprint || "unknown"),
 							},
 							h("div", { class: "peer-title" }, h("strong", null, draft || displayName)),
-							h("div", { class: "peer-meta" }, `Device: ${deviceId || "unknown"}`),
-							groupId ? h("div", { class: "peer-submeta" }, `Group: ${groupId}`) : null,
-							h("div", { class: "peer-submeta" }, enabled ? "Enabled" : "Disabled"),
+							h("div", { class: "peer-submeta" }, copy.statusLabel),
+							h("div", { class: "peer-meta" }, copy.advancedDetail),
 							h(
 								"div",
 								{ class: "coordinator-admin-form-grid" },
@@ -98,7 +98,7 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 									{
 										class: "settings-button",
 										disabled: !deviceId || pending || summary.readiness !== "ready",
-										onClick: () => runDevice(deviceId, groupId, displayName, "rename"),
+										onClick: () => runDevice(deviceId, teamId, displayName, "rename"),
 										type: "button",
 									},
 									pending && coordinatorAdminState.deviceActionPendingKind === "rename"
@@ -111,7 +111,7 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 											{
 												class: "settings-button danger",
 												disabled: !deviceId || pending || summary.readiness !== "ready",
-												onClick: () => runDevice(deviceId, groupId, displayName, "disable"),
+												onClick: () => runDevice(deviceId, teamId, displayName, "disable"),
 												type: "button",
 											},
 											pending && coordinatorAdminState.deviceActionPendingKind === "disable"
@@ -123,7 +123,7 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 											{
 												class: "settings-button",
 												disabled: !deviceId || pending || summary.readiness !== "ready",
-												onClick: () => runDevice(deviceId, groupId, displayName, "enable"),
+												onClick: () => runDevice(deviceId, teamId, displayName, "enable"),
 												type: "button",
 											},
 											pending && coordinatorAdminState.deviceActionPendingKind === "enable"
@@ -135,7 +135,7 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 									{
 										class: "settings-button danger",
 										disabled: !deviceId || pending || summary.readiness !== "ready",
-										onClick: () => runDevice(deviceId, groupId, displayName, "remove"),
+										onClick: () => runDevice(deviceId, teamId, displayName, "remove"),
 										type: "button",
 									},
 									pending && coordinatorAdminState.deviceActionPendingKind === "remove"

--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -159,7 +159,7 @@ function renderGroupPreferencesEditor(
 		h(
 			"div",
 			{ class: "peer-submeta" },
-			"Project filters only narrow what future writes sync; they never grant Space access by themselves. Use the default Space toggle to control whether newly joined devices receive the Team's default Space.",
+			"Space access grants decide what new devices can sync. Advanced sharing rules only narrow future writes after Space access already exists.",
 		),
 		// Master toggle first — the include/exclude chips are only meaningful
 		// when auto-seed is on, so the form reads top-down from decision
@@ -167,7 +167,11 @@ function renderGroupPreferencesEditor(
 		h(
 			"label",
 			{ class: "coordinator-admin-inline-filter" },
-			h("span", { class: "section-meta", id: autoSeedLabelId }, "Auto-seed project filters"),
+			h(
+				"span",
+				{ class: "section-meta", id: autoSeedLabelId },
+				"Auto-apply advanced rules to new devices",
+			),
 			h(RadixSwitch, {
 				"aria-labelledby": autoSeedLabelId,
 				checked: draft.auto_seed_scope,
@@ -214,7 +218,7 @@ function renderGroupPreferencesEditor(
 		h(
 			"div",
 			{ class: "coordinator-admin-field" },
-			h("span", { id: includeLabelId }, "Include projects"),
+			h("span", { id: includeLabelId }, "Include template"),
 			h(ProjectScopePicker, {
 				"aria-labelledby": includeLabelId,
 				availableProjects: coordinatorAdminState.availableProjects,
@@ -234,13 +238,13 @@ function renderGroupPreferencesEditor(
 			h(
 				"span",
 				{ class: "peer-submeta" },
-				"Leave empty to allow every project. Type to search or create a new name.",
+				"Leave empty to allow every project inside the granted Space. Type to search or create a new name.",
 			),
 		),
 		h(
 			"div",
 			{ class: "coordinator-admin-field" },
-			h("span", { id: excludeLabelId }, "Exclude projects"),
+			h("span", { id: excludeLabelId }, "Exclude template"),
 			h(ProjectScopePicker, {
 				"aria-labelledby": excludeLabelId,
 				availableProjects: coordinatorAdminState.availableProjects,

--- a/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
@@ -27,7 +27,7 @@ export function renderJoinRequestsPanel(deps: JoinRequestsPanelDeps) {
 			"p",
 			{ class: "peer-submeta" },
 			summary.readiness === "ready"
-				? "Approve or deny teammate join requests from the dedicated operator surface instead of burying them in Sync."
+				? "Approve or deny devices that want to join this Team. Default Space access is handled by Team defaults and can be reviewed in Spaces."
 				: "Finish setup first. Join request review stays disabled until coordinator admin is ready.",
 		),
 		!items.length
@@ -50,7 +50,7 @@ export function renderJoinRequestsPanel(deps: JoinRequestsPanelDeps) {
 							"div",
 							{ class: "peer-card peer-card--padded", key: requestId || deviceId },
 							h("div", { class: "peer-title" }, h("strong", null, displayName)),
-							h("div", { class: "peer-meta" }, `Device: ${deviceId}`),
+							h("div", { class: "peer-meta" }, `Advanced: Device ID ${deviceId}`),
 							h(
 								"div",
 								{ class: "peer-actions" },

--- a/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
@@ -12,7 +12,9 @@ import {
 	coordinatorAdminDevicesForGroup,
 	deriveScopeMembershipDeviceRows,
 	scopeManagementReadinessMessage,
-	scopeStatusLabel,
+	spaceAccessDeviceCopy,
+	spaceCardCopy,
+	spaceRevokeMemberTitle,
 } from "../data/scope-management";
 import { coordinatorAdminState, type GroupScopeManagementDraft } from "../data/state";
 import type { CoordinatorAdminSummary } from "../data/summary";
@@ -205,7 +207,7 @@ async function revokeMember(
 	const scopeId = String(scope.scope_id || "").trim();
 	if (!scopeId) return;
 	const confirmed = await openSyncConfirmDialog({
-		title: `Revoke ${displayName || deviceId} from ${scope.label || scopeId}?`,
+		title: spaceRevokeMemberTitle(scope, displayName, deviceId),
 		description:
 			"Revocation only blocks future sync for this Space. Data already copied to that device can remain there.",
 		confirmLabel: "Revoke membership",
@@ -263,13 +265,7 @@ function renderMembershipRows(
 			const pending = draft.actionPendingKey === pendingKey;
 			const canGrant = row.enabled && row.status !== "active";
 			const canRevoke = row.status === "active";
-			const statusCopy =
-				row.status === "not_member"
-					? "Not a member"
-					: row.status === "revoked"
-						? "Revoked"
-						: "Active member";
-			const epochCopy = row.membershipEpoch == null ? "epoch —" : `epoch ${row.membershipEpoch}`;
+			const copy = spaceAccessDeviceCopy(row);
 			return h(
 				"div",
 				{ class: "coordinator-admin-scope-member-row", key: row.deviceId },
@@ -277,7 +273,8 @@ function renderMembershipRows(
 					"div",
 					{ class: "coordinator-admin-scope-member-copy" },
 					h("strong", null, row.displayName),
-					h("span", null, `${statusCopy} · ${row.role} · ${epochCopy}`),
+					h("span", null, copy.detail),
+					h("span", { class: "peer-meta" }, copy.advancedDetail),
 					row.enabled ? null : h("span", null, "Device is disabled in this Team."),
 				),
 				h(
@@ -292,7 +289,7 @@ function renderMembershipRows(
 									onClick: () => void grantMember(groupId, scopeId, row.deviceId, renderShell),
 									type: "button",
 								},
-								pending && draft.actionPendingKind === "grant" ? "Granting…" : "Grant",
+								pending && draft.actionPendingKind === "grant" ? "Granting…" : "Grant access",
 							)
 						: null,
 					canRevoke
@@ -305,7 +302,7 @@ function renderMembershipRows(
 										void revokeMember(groupId, scope, row.deviceId, row.displayName, renderShell),
 									type: "button",
 								},
-								pending && draft.actionPendingKind === "revoke" ? "Revoking…" : "Revoke",
+								pending && draft.actionPendingKind === "revoke" ? "Revoking…" : "Revoke access",
 							)
 						: null,
 				),
@@ -322,21 +319,16 @@ function renderScopeCard(
 	renderShell: () => void,
 ) {
 	const scopeId = String(scope.scope_id || "").trim();
-	const label = String(scope.label || scopeId || "Untitled Space");
+	const copy = spaceCardCopy(scope);
 	return h(
 		"div",
-		{ class: "peer-card peer-card--padded coordinator-admin-scope-card", key: scopeId || label },
-		h("div", { class: "peer-title" }, h("strong", null, label)),
-		h(
-			"div",
-			{ class: "peer-submeta" },
-			`Status: ${scopeStatusLabel(scope.status)} · Kind: ${scope.kind || "user"}`,
-		),
-		h(
-			"div",
-			{ class: "peer-meta" },
-			`Advanced: Space ID ${scopeId || "unknown"} · Membership epoch ${scope.membership_epoch ?? 0}`,
-		),
+		{
+			class: "peer-card peer-card--padded coordinator-admin-scope-card",
+			key: scopeId || copy.title,
+		},
+		h("div", { class: "peer-title" }, h("strong", null, copy.title)),
+		h("div", { class: "peer-submeta" }, copy.summary),
+		h("div", { class: "peer-meta" }, copy.advancedDetail),
 		h(
 			"div",
 			{ class: "peer-submeta" },

--- a/packages/ui/src/tabs/coordinator-admin/data/actions.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/actions.test.ts
@@ -6,12 +6,14 @@ import { coordinatorAdminState } from "./state";
 
 const mocks = vi.hoisted(() => ({
 	createCoordinatorAdminGroup: vi.fn(),
+	createCoordinatorInvite: vi.fn(),
 	reviewCoordinatorAdminJoinRequest: vi.fn(),
 	showGlobalNotice: vi.fn(),
 }));
 
 vi.mock("../../../lib/api", () => ({
 	createCoordinatorAdminGroup: mocks.createCoordinatorAdminGroup,
+	createCoordinatorInvite: mocks.createCoordinatorInvite,
 	reviewCoordinatorAdminJoinRequest: mocks.reviewCoordinatorAdminJoinRequest,
 }));
 
@@ -26,6 +28,7 @@ vi.mock("../../sync/sync-dialogs", () => ({
 describe("coordinator admin actions", () => {
 	beforeEach(() => {
 		mocks.createCoordinatorAdminGroup.mockReset();
+		mocks.createCoordinatorInvite.mockReset();
 		mocks.reviewCoordinatorAdminJoinRequest.mockReset();
 		mocks.showGlobalNotice.mockReset();
 		state.coordinatorAdminTargetGroup = "";
@@ -36,6 +39,10 @@ describe("coordinator admin actions", () => {
 		coordinatorAdminState.createGroupId = "";
 		coordinatorAdminState.createGroupDisplayName = "";
 		coordinatorAdminState.groupActionPendingKind = "";
+		coordinatorAdminState.inviteGroup = "";
+		coordinatorAdminState.invitePending = false;
+		coordinatorAdminState.invitePolicy = "auto_admit";
+		coordinatorAdminState.inviteTtlHours = "24";
 		coordinatorAdminState.teamSetupGuide = null;
 		localStorage.clear();
 	});
@@ -118,6 +125,27 @@ describe("coordinator admin actions", () => {
 
 		expect(reloadData).toHaveBeenCalledTimes(2);
 		expect(state.coordinatorAdminTargetGroup).toBe("team-new");
+	});
+
+	it("points successful invite sharing copy at Teams", async () => {
+		mocks.createCoordinatorInvite.mockResolvedValue({ token: "invite-token", warnings: [] });
+		coordinatorAdminState.inviteGroup = "team-alpha";
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await actions.createInviteFromAdminPanel();
+
+		expect(mocks.createCoordinatorInvite).toHaveBeenCalledWith({
+			group_id: "team-alpha",
+			policy: "auto_admit",
+			ttl_hours: 24,
+		});
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+			"Invite created. Copy it from Teams and share it with your teammate.",
+			"success",
+		);
 	});
 
 	it("keeps default Space grant warnings visible after approving a join request", async () => {

--- a/packages/ui/src/tabs/coordinator-admin/data/actions.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/actions.ts
@@ -191,7 +191,7 @@ export function createCoordinatorAdminActions(
 			showGlobalNotice(
 				warnings.length
 					? `Invite created. Review ${warnings.length === 1 ? "the warning" : `${warnings.length} warnings`} before sharing it.`
-					: "Invite created. Copy it from Coordinator Admin and share it with your teammate.",
+					: "Invite created. Copy it from Teams and share it with your teammate.",
 				warnings.length ? "warning" : "success",
 			);
 		} catch (error) {

--- a/packages/ui/src/tabs/coordinator-admin/data/device-card.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/device-card.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { coordinatorAdminDeviceCardCopy } from "./device-card";
+
+describe("coordinator admin device card copy", () => {
+	it("demotes raw device and Team ids to advanced copy", () => {
+		const copy = coordinatorAdminDeviceCardCopy(
+			{ device_id: "dev-a", display_name: "Alice laptop", enabled: true, group_id: "team-a" },
+			"fallback-team",
+		);
+
+		expect(copy.displayName).toBe("Alice laptop");
+		expect(copy.statusLabel).toBe("Enabled in this Team");
+		expect(copy.statusLabel).not.toContain("dev-a");
+		expect(copy.advancedDetail).toBe("Advanced: Device ID dev-a · Team ID team-a");
+	});
+
+	it("uses the active Team as a fallback for older device payloads", () => {
+		const copy = coordinatorAdminDeviceCardCopy(
+			{ device_id: "dev-b", display_name: "", enabled: false },
+			"active-team",
+		);
+
+		expect(copy.displayName).toBe("dev-b");
+		expect(copy.statusLabel).toBe("Disabled in this Team");
+		expect(copy.teamId).toBe("active-team");
+		expect(copy.advancedDetail).toContain("Team ID active-team");
+	});
+});

--- a/packages/ui/src/tabs/coordinator-admin/data/device-card.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/device-card.ts
@@ -1,0 +1,28 @@
+import type { CachedCoordinatorAdminDevice } from "../../../lib/state";
+
+export interface CoordinatorAdminDeviceCardCopy {
+	deviceId: string;
+	displayName: string;
+	teamId: string;
+	statusLabel: string;
+	advancedDetail: string;
+}
+
+export function coordinatorAdminDeviceCardCopy(
+	device: CachedCoordinatorAdminDevice,
+	fallbackTeamId: string,
+): CoordinatorAdminDeviceCardCopy {
+	const deviceId = String(device.device_id || "").trim();
+	const teamId = String(device.group_id || fallbackTeamId || "").trim();
+	const displayName = String(device.display_name || deviceId || "Unnamed device");
+	const enabled = device.enabled !== false && device.enabled !== 0;
+	const advancedParts = [`Device ID ${deviceId || "unknown"}`];
+	if (teamId) advancedParts.push(`Team ID ${teamId}`);
+	return {
+		advancedDetail: `Advanced: ${advancedParts.join(" · ")}`,
+		deviceId,
+		displayName,
+		statusLabel: enabled ? "Enabled in this Team" : "Disabled in this Team",
+		teamId,
+	};
+}

--- a/packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts
@@ -5,6 +5,9 @@ import {
 	deriveScopeMembershipDeviceRows,
 	scopeManagementReadinessMessage,
 	scopeStatusLabel,
+	spaceAccessDeviceCopy,
+	spaceCardCopy,
+	spaceRevokeMemberTitle,
 } from "./scope-management";
 
 describe("coordinator admin scope management view helpers", () => {
@@ -55,6 +58,54 @@ describe("coordinator admin scope management view helpers", () => {
 	it("formats empty or underscored scope statuses for operator copy", () => {
 		expect(scopeStatusLabel(null)).toBe("active");
 		expect(scopeStatusLabel("needs_review")).toBe("needs review");
+	});
+
+	it("keeps raw Space ids in advanced Space card copy", () => {
+		const copy = spaceCardCopy({
+			kind: "team_default",
+			membership_epoch: 7,
+			scope_id: "team-alpha-default",
+			status: "active",
+		});
+
+		expect(copy.summary).toBe("active Space · team default");
+		expect(copy.title).toBe("Untitled Space");
+		expect(copy.title).not.toContain("team-alpha-default");
+		expect(copy.summary).not.toContain("team-alpha-default");
+		expect(copy.advancedDetail).toBe("Advanced: Space ID team-alpha-default · Membership epoch 7");
+	});
+
+	it("formats missing Space membership epochs as unknown in advanced copy", () => {
+		const copy = spaceCardCopy({ label: "Household", scope_id: "household", status: "active" });
+
+		expect(copy.title).toBe("Household");
+		expect(copy.advancedDetail).toBe("Advanced: Space ID household · Membership epoch —");
+	});
+
+	it("labels device Space access without making membership epochs primary copy", () => {
+		const copy = spaceAccessDeviceCopy({
+			deviceId: "dev-a",
+			displayName: "Alice laptop",
+			enabled: true,
+			membershipEpoch: 4,
+			role: "admin_member",
+			status: "active",
+			updatedAt: null,
+		});
+
+		expect(copy.detail).toBe("Space access active · admin member");
+		expect(copy.detail).not.toContain("epoch");
+		expect(copy.advancedDetail).toBe("Advanced: membership epoch 4");
+	});
+
+	it("uses Space card copy in revoke prompts instead of raw ids", () => {
+		expect(
+			spaceRevokeMemberTitle(
+				{ membership_epoch: 7, scope_id: "team-alpha-default", status: "active" },
+				"Alice laptop",
+				"dev-a",
+			),
+		).toBe("Revoke Alice laptop from Untitled Space?");
 	});
 
 	it("falls back to cached enrolled devices for the selected group", () => {

--- a/packages/ui/src/tabs/coordinator-admin/data/scope-management.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/scope-management.ts
@@ -30,6 +30,18 @@ export interface ScopeMembershipDeviceRow {
 	updatedAt: string | null;
 }
 
+export interface SpaceCardCopy {
+	title: string;
+	summary: string;
+	advancedDetail: string;
+}
+
+export interface SpaceAccessDeviceCopy {
+	statusLabel: string;
+	detail: string;
+	advancedDetail: string;
+}
+
 export function scopeManagementReadinessMessage(summary: CoordinatorAdminSummary): string | null {
 	if (summary.readiness === "ready") return null;
 	return "Space management needs the coordinator URL, target Team, and admin secret before it can list Spaces or change memberships.";
@@ -38,6 +50,45 @@ export function scopeManagementReadinessMessage(summary: CoordinatorAdminSummary
 export function scopeStatusLabel(status: string | null | undefined): string {
 	const value = String(status || "active").trim();
 	return value ? value.replaceAll("_", " ") : "active";
+}
+
+export function spaceCardCopy(scope: CoordinatorAdminScopeView): SpaceCardCopy {
+	const title = String(scope.label || "").trim() || "Untitled Space";
+	const status = scopeStatusLabel(scope.status);
+	const kind = String(scope.kind || "user").replaceAll("_", " ");
+	const scopeId = String(scope.scope_id || "").trim() || "unknown";
+	const epoch = scope.membership_epoch == null ? "—" : String(scope.membership_epoch);
+	return {
+		title,
+		summary: `${status} Space · ${kind}`,
+		advancedDetail: `Advanced: Space ID ${scopeId} · Membership epoch ${epoch}`,
+	};
+}
+
+export function spaceAccessDeviceCopy(row: ScopeMembershipDeviceRow): SpaceAccessDeviceCopy {
+	const statusLabel: Record<ScopeMembershipStatus, string> = {
+		active: "Space access active",
+		revoked: "Space access revoked",
+		not_member: "No Space access",
+	};
+	const role = row.role.replaceAll("_", " ");
+	const detail =
+		row.status === "not_member" ? statusLabel[row.status] : `${statusLabel[row.status]} · ${role}`;
+	const epoch = row.membershipEpoch == null ? "—" : String(row.membershipEpoch);
+	return {
+		statusLabel: statusLabel[row.status],
+		detail,
+		advancedDetail: `Advanced: membership epoch ${epoch}`,
+	};
+}
+
+export function spaceRevokeMemberTitle(
+	scope: CoordinatorAdminScopeView,
+	displayName: string,
+	deviceId: string,
+): string {
+	const deviceLabel = displayName || deviceId || "this device";
+	return `Revoke ${deviceLabel} from ${spaceCardCopy(scope).title}?`;
 }
 
 export function deriveScopeMembershipDeviceRows(


### PR DESCRIPTION
## Description
Clarifies the Teams Space access management surface so device administration, Space grants, advanced details, and revoke prompts use product-facing Team/Space language instead of exposing raw IDs as primary copy.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated with targeted coordinator-admin tests, final targeted stack tests, `pnpm run tsc`, and `pnpm run lint`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
