### PR TITLE
feat(ui): make Sync Space access read-only

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -1,6 +1,6 @@
 import * as Collapsible from "@radix-ui/react-collapsible";
 import type { TargetedInputEvent } from "preact";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
+import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { PresencePip, type PresenceState } from "../../../components/primitives/presence-pip";
 import { RadixSelect } from "../../../components/primitives/radix-select";
 import { TextInput } from "../../../components/primitives/text-input";
@@ -8,14 +8,12 @@ import { formatTimestamp } from "../../../lib/format";
 import { isSyncRedactionEnabled, state } from "../../../lib/state";
 import {
 	buildActorSelectOptions,
+	clearPeerScopeReview,
 	consumePeerScopeReviewRequest,
-	createChipEditor,
 	isPeerScopeReviewPending,
-	openPeerScopeEditors,
 	pickPrimaryAddress,
 	redactAddress,
 } from "../helpers";
-import { PeerScopeCollapsible } from "../peer-scope-collapsible";
 import { openSyncConfirmDialog } from "../sync-dialogs";
 import {
 	derivePeerAuthorizedDomainsView,
@@ -128,12 +126,6 @@ type SyncPeerCardProps = {
 	onAssignActor: (peerId: string, actorId: string | null) => Promise<SyncActionFeedback>;
 	onRemove: (peerId: string, label: string) => Promise<SyncActionFeedback>;
 	onRename: (peerId: string, name: string) => Promise<SyncActionFeedback>;
-	onResetScope: (peerId: string) => Promise<SyncActionFeedback>;
-	onSaveScope: (
-		peerId: string,
-		include: string[],
-		exclude: string[],
-	) => Promise<SyncActionFeedback>;
 	onSync: (peer: SyncPeer, address: string | undefined) => Promise<SyncActionFeedback | null>;
 };
 
@@ -141,63 +133,36 @@ type SyncPeersListProps = Omit<SyncPeerCardProps, "peer"> & {
 	peers: SyncPeer[];
 };
 
-function listText(value: unknown): string[] {
-	return Array.isArray(value) ? value.map((item) => String(item || "").trim()).filter(Boolean) : [];
-}
-
 function claimedLocalActorScopeMessage(
 	scope: PeerClaimedLocalActorScopeLike | null | undefined,
 ): string {
-	const scopeId = String(scope?.scope_id || "").trim();
 	if (!scope) {
-		return "Private same-person sync is limited to an allowed personal Sharing domain; team or org domains do not carry your private memories.";
+		return "Private same-person sync is limited to an allowed personal Space; team or org Spaces do not carry your private memories.";
 	}
 	if (scope.authorized) {
-		return `Private same-person sync is limited to personal Sharing domain ${scopeId || "this device's personal domain"}. Team and org domains do not carry your private memories.`;
+		return "Private same-person sync is limited to your personal Space. Team and org Spaces do not carry your private memories.";
 	}
-	return `Private same-person sync is blocked until this device is granted ${scopeId || "its personal Sharing domain"}.`;
+	return "Private same-person sync is blocked until this device is granted an allowed personal Space.";
 }
 
-function ExistingElementSlot({ element }: { element: HTMLElement }) {
-	const hostRef = useRef<HTMLDivElement | null>(null);
-
-	useLayoutEffect(() => {
-		const host = hostRef.current;
-		if (!host) return;
-		if (element.parentElement !== host) host.appendChild(element);
-		return () => {
-			if (element.parentElement === host) {
-				host.removeChild(element);
-			}
-		};
-	}, [element]);
-
-	return <div ref={hostRef} />;
+function openTeamsAccessManagement(): void {
+	window.location.hash = "coordinator-admin";
 }
 
-function SyncPeerCard({
-	peer,
-	onAssignActor,
-	onRemove,
-	onRename,
-	onResetScope,
-	onSaveScope,
-	onSync,
-}: SyncPeerCardProps) {
+function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncPeerCardProps) {
 	const peerId = String(peer.peer_device_id || "");
 	const displayName = peer.name || (peerId ? peerId.slice(0, 8) : "unknown");
 	const destructiveLabel = peer.name || peerId || displayName;
-	const pendingScopeReview = isPeerScopeReviewPending(peerId);
 	const trustSummary = derivePeerTrustSummary(peer);
 	const directionHint = DIRECTION_GLYPH[derivePeerDirection(peer)];
 	const peerStatus: SyncPeerStatus = peer.status || {};
 	const authorizedDomains = derivePeerAuthorizedDomainsView(peer);
+	const rawPendingScopeReview = isPeerScopeReviewPending(peerId);
+	const pendingScopeReview = rawPendingScopeReview && authorizedDomains.total === 0;
 	const grantRoleMismatch = derivePeerGrantRoleMismatchView(peer);
 	const scopeRejections = derivePeerScopeRejectionsView(peer);
 	const scope = peer.project_scope || {};
 	const projectNarrowing = derivePeerProjectNarrowingView(scope);
-	const includeList = listText(scope.include);
-	const excludeList = listText(scope.exclude);
 	const primaryAddress = pickPrimaryAddress(peer.addresses);
 	const peerAddresses = Array.isArray(peer.addresses)
 		? Array.from(new Set(peer.addresses.filter(Boolean).map((value) => String(value))))
@@ -218,14 +183,12 @@ function SyncPeerCard({
 	const lastSyncAt = String(peerStatus.last_sync_at || peerStatus.last_sync_at_utc || "");
 	const lastPingAt = String(peerStatus.last_ping_at || peerStatus.last_ping_at_utc || "");
 	const discoverySummary = peer.discovered_via_group_id
-		? `Discovery: seen through coordinator group ${peer.discovered_via_group_id}. Discovery helps find devices; Sharing-domain grants above decide data access.`
+		? `Discovery: seen through Team ${peer.discovered_via_group_id}. Discovery helps find devices; Space access above decides data access.`
 		: peer.discovered_via_coordinator_id
-			? `Discovery: seen through coordinator ${peer.discovered_via_coordinator_id}. Discovery helps find devices; Sharing-domain grants above decide data access.`
+			? `Discovery: seen through coordinator ${peer.discovered_via_coordinator_id}. Discovery helps find devices; Space access above decides data access.`
 			: null;
-	const scopeEditorOpen = openPeerScopeEditors.has(peerId);
 	const scopeReviewRequested = consumePeerScopeReviewRequest(peerId);
 	const cardRef = useRef<HTMLDivElement | null>(null);
-	const [scopeHost, setScopeHost] = useState<HTMLDivElement | null>(null);
 
 	const [renameValue, setRenameValue] = useState(displayName);
 	const [feedback, setFeedback] = useState<SyncActionFeedback | null>(
@@ -239,10 +202,6 @@ function SyncPeerCard({
 	const [selectedActorId, setSelectedActorId] = useState(String(peer.actor_id || ""));
 	const [applyActorBusy, setApplyActorBusy] = useState(false);
 	const [applyActorLabel, setApplyActorLabel] = useState("Save assignment");
-	const [saveScopeBusy, setSaveScopeBusy] = useState(false);
-	const [saveScopeLabel, setSaveScopeLabel] = useState("Save scope");
-	const [resetScopeBusy, setResetScopeBusy] = useState(false);
-	const [resetScopeLabel, setResetScopeLabel] = useState("Reset to global scope");
 	const actorSelectOptions = useMemo(() => {
 		const options = buildActorSelectOptions(selectedActorId);
 		const hasSelected = options.some((option) => option.value === selectedActorId);
@@ -264,14 +223,9 @@ function SyncPeerCard({
 		state.lastSyncViewModel,
 	]);
 
-	const includeEditor = useMemo(
-		() => createChipEditor(includeList, "Add project", "All projects", state.knownProjects),
-		[peerId, includeList.join("|"), state.knownProjects.join("|")],
-	);
-	const excludeEditor = useMemo(
-		() => createChipEditor(excludeList, "Add project", "No exclusions", state.knownProjects),
-		[peerId, excludeList.join("|"), state.knownProjects.join("|")],
-	);
+	useEffect(() => {
+		if (rawPendingScopeReview && authorizedDomains.total > 0) clearPeerScopeReview(peerId);
+	}, [authorizedDomains.total, peerId, rawPendingScopeReview]);
 
 	useEffect(() => {
 		setRenameValue(displayName);
@@ -284,11 +238,7 @@ function SyncPeerCard({
 		setSelectedActorId(String(peer.actor_id || ""));
 		setApplyActorBusy(false);
 		setApplyActorLabel("Save assignment");
-		setSaveScopeBusy(false);
-		setSaveScopeLabel("Save scope");
-		setResetScopeBusy(false);
-		setResetScopeLabel("Reset to global scope");
-	}, [displayName, peer.actor_id, peerId, includeList.join("|"), excludeList.join("|")]);
+	}, [displayName, peer.actor_id, peerId]);
 
 	useEffect(() => {
 		if (!scopeReviewRequested || !cardRef.current) return;
@@ -333,11 +283,11 @@ function SyncPeerCard({
 	async function sync() {
 		if (pendingScopeReview) {
 			const proceed = await openSyncConfirmDialog({
-				title: `Sync ${displayName} before scope review?`,
+				title: `Sync ${displayName} before advanced rule review?`,
 				description:
-					"This manual sync will use the current effective scope until you finish reviewing and saving the device scope.",
+					"This manual sync will use the current Space access and advanced filters until you review them in Teams.",
 				confirmLabel: "Sync anyway",
-				cancelLabel: "Review scope first",
+				cancelLabel: "Review in Teams first",
 			});
 			if (!proceed) return;
 		}
@@ -388,42 +338,6 @@ function SyncPeerCard({
 			setApplyActorLabel("Retry");
 		} finally {
 			setApplyActorBusy(false);
-		}
-	}
-
-	async function saveScope() {
-		if (!peerId) return;
-		setSaveScopeBusy(true);
-		setSaveScopeLabel("Saving…");
-		try {
-			const nextFeedback = await onSaveScope(
-				peerId,
-				includeEditor.values(),
-				excludeEditor.values(),
-			);
-			setFeedback(nextFeedback);
-			state.syncPeerFeedbackById.set(peerId, nextFeedback);
-			setSaveScopeLabel("Save scope");
-		} catch {
-			setSaveScopeLabel("Retry");
-		} finally {
-			setSaveScopeBusy(false);
-		}
-	}
-
-	async function resetScope() {
-		if (!peerId) return;
-		setResetScopeBusy(true);
-		setResetScopeLabel("Resetting…");
-		try {
-			const nextFeedback = await onResetScope(peerId);
-			setFeedback(nextFeedback);
-			state.syncPeerFeedbackById.set(peerId, nextFeedback);
-			setResetScopeLabel("Reset to global scope");
-		} catch {
-			setResetScopeLabel("Retry");
-		} finally {
-			setResetScopeBusy(false);
 		}
 	}
 
@@ -483,11 +397,11 @@ function SyncPeerCard({
 								{trustSummary.badgeLabel}
 							</span>
 							{pendingScopeReview ? (
-								<span className="badge actor-badge">Needs scope review</span>
+								<span className="badge actor-badge">Review advanced rules</span>
 							) : null}
 							<span
 								className={`badge ${authorizedDomains.isWarning ? "badge-offline" : "actor-badge"}`}
-								title="Sharing domains are the hard access boundary; project filters only narrow inside them."
+								title="Spaces are the hard access boundary; advanced filters only narrow inside them."
 							>
 								{authorizedDomains.badgeLabel}
 							</span>
@@ -502,7 +416,7 @@ function SyncPeerCard({
 							{grantRoleMismatch.badgeLabel ? (
 								<span
 									className="badge badge-offline"
-									title="Review whether explicit Sharing-domain grants match this device's intended role."
+									title="Review whether explicit Space access matches this device's intended role."
 								>
 									{grantRoleMismatch.badgeLabel}
 								</span>
@@ -584,10 +498,13 @@ function SyncPeerCard({
 					<div className="peer-scope">
 						{scopeReviewRequested ? (
 							<div className="peer-meta">
-								Review this device&apos;s sharing rules now if the defaults are too broad.
+								Review this device&apos;s Space access and advanced rules in Teams if the defaults
+								are too broad.
 							</div>
 						) : pendingScopeReview ? (
-							<div className="peer-meta">Sharing rule review is still pending for this device.</div>
+							<div className="peer-meta">
+								Advanced rule review is still pending for this device.
+							</div>
 						) : null}
 
 						<div className="peer-scope-summary">Device details</div>
@@ -600,14 +517,14 @@ function SyncPeerCard({
 							].join(" · ")}
 						</div>
 
-						<div className="peer-scope-summary">Authorized Sharing domains</div>
+						<div className="peer-scope-summary">Space access</div>
 						<div className="peer-meta">
 							{authorizedDomains.total > 0
-								? "These Sharing domains are the hard access boundary for this device."
+								? "These Spaces are the hard access boundary for this device."
 								: authorizedDomains.emptyMessage}
 						</div>
 						{authorizedDomains.domains.length > 0 ? (
-							<ul className="peer-scope-chips" aria-label="Authorized Sharing domains">
+							<ul className="peer-scope-chips" aria-label="Authorized Spaces">
 								{authorizedDomains.domains.map((domain) => (
 									<li className="peer-scope-chip" key={domain.scopeId} title={domain.detail}>
 										{domain.label}
@@ -684,46 +601,16 @@ function SyncPeerCard({
 							</button>
 						</div>
 
-						<div className="peer-scope-summary">Project filters (narrowing only)</div>
+						<div className="peer-scope-summary">Advanced sharing rules</div>
 						<div className="peer-meta">
-							{projectNarrowing.summary} Review or tighten these filters when this device should
-							receive fewer projects from its authorized Sharing domains.
+							{projectNarrowing.statusLabel}. {projectNarrowing.summary} {projectNarrowing.note}
 						</div>
-						<PeerScopeCollapsible
-							contentHost={scopeHost}
-							initialOpen={scopeEditorOpen}
-							onOpenChange={(open) => {
-								if (open) openPeerScopeEditors.add(peerId);
-								else openPeerScopeEditors.delete(peerId);
-							}}
-						>
-							<div>
-								<div className="peer-scope-row">
-									<ExistingElementSlot element={includeEditor.element} />
-									<ExistingElementSlot element={excludeEditor.element} />
-								</div>
-								<div className="peer-scope-actions">
-									<button
-										type="button"
-										className="settings-button"
-										disabled={saveScopeBusy}
-										onClick={() => void saveScope()}
-									>
-										{saveScopeLabel}
-									</button>
-									<button
-										type="button"
-										className="settings-button"
-										disabled={resetScopeBusy}
-										onClick={() => void resetScope()}
-									>
-										{resetScopeLabel}
-									</button>
-								</div>
-							</div>
-						</PeerScopeCollapsible>
+						<div className="peer-actions">
+							<button type="button" className="settings-button" onClick={openTeamsAccessManagement}>
+								Manage Spaces in Teams
+							</button>
+						</div>
 						<SyncInlineFeedback feedback={feedback} />
-						<div ref={setScopeHost} />
 					</div>
 				</Collapsible.Content>
 			</div>

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -9,12 +9,7 @@ import { renderSyncEmptyState } from "./components/sync-diagnostics";
 import type { SyncActionFeedback } from "./components/sync-inline-feedback";
 import { renderLegacyClaimsSlice } from "./components/sync-legacy-claims";
 import { renderSyncPeersList } from "./components/sync-peers";
-import {
-	clearPeerScopeReview,
-	hideSkeleton,
-	isPeerScopeReviewPending,
-	shouldClearStalePeersFeedback,
-} from "./helpers";
+import { hideSkeleton, isPeerScopeReviewPending, shouldClearStalePeersFeedback } from "./helpers";
 import { openSyncConfirmDialog } from "./sync-dialogs";
 import {
 	deriveVisiblePeopleActors,
@@ -149,7 +144,7 @@ export function renderSyncPeers() {
 				} else if (peerId && isPeerScopeReviewPending(peerId)) {
 					const displayName = peer?.name || (peerId ? peerId.slice(0, 8) : "unknown");
 					feedback = {
-						message: `Triggered sync for ${displayName}. Review scope in this card if you want tighter sharing rules.`,
+						message: `Triggered sync for ${displayName}. Review Space access and advanced rules in Teams if this device needs tighter sharing.`,
 						tone: "warning",
 					};
 				} else {
@@ -209,44 +204,6 @@ export function renderSyncPeers() {
 					message: friendlyError(
 						error,
 						"Failed to update device assignment. The current assignment is unchanged.",
-					),
-					tone: "warning",
-				} satisfies SyncActionFeedback;
-			}
-		},
-		onSaveScope: async (peerId, include, exclude) => {
-			try {
-				await api.updatePeerScope(peerId, include, exclude);
-				clearPeerScopeReview(peerId);
-				await _loadSyncData();
-				return {
-					message: "Device sync scope saved.",
-					tone: "success",
-				} satisfies SyncActionFeedback;
-			} catch (error) {
-				return {
-					message: friendlyError(
-						error,
-						"Failed to save device scope. The current sharing rules are still active.",
-					),
-					tone: "warning",
-				} satisfies SyncActionFeedback;
-			}
-		},
-		onResetScope: async (peerId) => {
-			try {
-				await api.updatePeerScope(peerId, null, null, true);
-				clearPeerScopeReview(peerId);
-				await _loadSyncData();
-				return {
-					message: "Device sync scope reset to global defaults.",
-					tone: "success",
-				} satisfies SyncActionFeedback;
-			} catch (error) {
-				return {
-					message: friendlyError(
-						error,
-						"Failed to reset device scope. The current sharing rules are still active.",
 					),
 					tone: "warning",
 				} satisfies SyncActionFeedback;

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -313,7 +313,8 @@ export function renderTeamSync() {
 				"This device appears in multiple coordinator groups. Review team setup first or ask an admin to clean up the duplicate enrollment before approving it here.";
 			mode = "ambiguous";
 		} else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
-			actionMessage = `Finish this device's scope review in People & devices before you sync it.`;
+			actionMessage =
+				"Review this device's Space access and advanced rules in Teams before you sync it.";
 			mode = "scope-pending";
 		} else if (pairedPeer?.last_error) {
 			noteParts.push(`error: ${String(pairedPeer.last_error)}`);

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -181,17 +181,17 @@ describe("derivePeerScopeRejectionsView", () => {
 });
 
 describe("derivePeerAuthorizedDomainsView", () => {
-	it("labels peers with no cached Sharing domain authorization", () => {
+	it("labels peers with no cached Space access", () => {
 		const view = derivePeerAuthorizedDomainsView({ authorized_scopes: [] });
 
 		expect(view.total).toBe(0);
-		expect(view.badgeLabel).toBe("No Sharing domains");
+		expect(view.badgeLabel).toBe("No Space access");
 		expect(view.isWarning).toBe(true);
-		expect(view.emptyMessage).toContain("No Sharing-domain grants exist");
-		expect(view.emptyMessage).toContain("Project filters below cannot send data by themselves");
+		expect(view.emptyMessage).toContain("No Space access grants exist");
+		expect(view.emptyMessage).toContain("Advanced project filters cannot send data by themselves");
 	});
 
-	it("formats authorized Sharing domains without exposing membership internals", () => {
+	it("formats authorized Spaces without exposing membership internals", () => {
 		const view = derivePeerAuthorizedDomainsView({
 			authorized_scopes: [
 				{
@@ -211,10 +211,23 @@ describe("derivePeerAuthorizedDomainsView", () => {
 			],
 		});
 
-		expect(view.badgeLabel).toBe("2 Sharing domains");
+		expect(view.badgeLabel).toBe("2 Spaces");
 		expect(view.isWarning).toBe(false);
 		expect(view.domains.map((domain) => domain.label)).toEqual(["Acme Work", "Personal Devices"]);
 		expect(view.domains[0]?.detail).toBe("team · coordinator · member role");
+	});
+
+	it("does not promote raw Space ids when authorized Space labels are missing", () => {
+		const view = derivePeerAuthorizedDomainsView({
+			authorized_scopes: [
+				{ authority_type: "coordinator", role: "member", scope_id: "team-alpha-default" },
+			],
+		});
+
+		expect(view.badgeLabel).toBe("1 Space");
+		expect(view.domains[0]?.label).toBe("Untitled Space");
+		expect(view.domains[0]?.label).not.toContain("team-alpha-default");
+		expect(view.domains[0]?.detail).not.toContain("team-alpha-default");
 	});
 });
 
@@ -229,10 +242,10 @@ describe("derivePeerGrantRoleMismatchView", () => {
 		});
 
 		expect(view.isVisible).toBe(true);
-		expect(view.badgeLabel).toBe("Review domain fit");
-		expect(view.message).toContain("personal or OSS Sharing-domain grants");
-		expect(view.message).toContain("no separate work/client-like domain grant");
-		expect(view.detail).toContain("project filters only narrow already-authorized domains");
+		expect(view.badgeLabel).toBe("Review Space fit");
+		expect(view.message).toContain("personal or OSS Space access");
+		expect(view.message).toContain("no separate work/client-like Space access");
+		expect(view.detail).toContain("advanced project filters only narrow already-authorized Spaces");
 	});
 
 	it("does not flag peers once a separate work/client-like grant is present", () => {
@@ -307,8 +320,21 @@ describe("derivePeerProjectNarrowingView", () => {
 		});
 
 		expect(view.summary).toBe("Global defaults. Include filter: *; Exclude filter: personal.");
-		expect(view.note).toContain("only narrow data after Sharing domain authorization");
-		expect(view.note).toContain("never grant access to another domain");
+		expect(view.statusLabel).toBe("Advanced filters active");
+		expect(view.hasAdvancedFilters).toBe(true);
+		expect(view.note).toContain("only narrow data after Space access");
+		expect(view.note).toContain("never grant access to another Space");
+	});
+
+	it("treats all-project/no-exclusion defaults as no advanced filters", () => {
+		const view = derivePeerProjectNarrowingView({
+			effective_exclude: [],
+			effective_include: ["*"],
+			inherits_global: true,
+		});
+
+		expect(view.statusLabel).toBe("No advanced filters");
+		expect(view.hasAdvancedFilters).toBe(false);
 	});
 });
 

--- a/packages/ui/src/tabs/sync/view-model/peer-status.ts
+++ b/packages/ui/src/tabs/sync/view-model/peer-status.ts
@@ -195,8 +195,9 @@ export function derivePeerAuthorizedDomainsView(peer: PeerLike): PeerAuthorizedD
 	const domains = (Array.isArray(peer.authorized_scopes) ? peer.authorized_scopes : [])
 		.map((scope: PeerAuthorizedScopeLike): PeerAuthorizedDomainViewItem | null => {
 			const scopeId = cleanText(scope.scope_id);
-			const label = cleanText(scope.label) ?? scopeId;
-			if (!scopeId && !label) return null;
+			const rawLabel = cleanText(scope.label);
+			if (!scopeId && !rawLabel) return null;
+			const label = rawLabel || "Untitled Space";
 			const detail = [
 				labelPart(cleanText(scope.kind), "user"),
 				labelPart(cleanText(scope.authority_type), "local"),
@@ -204,22 +205,17 @@ export function derivePeerAuthorizedDomainsView(peer: PeerLike): PeerAuthorizedD
 			]
 				.filter(Boolean)
 				.join(" · ");
-			return { scopeId: scopeId || label, label: label || scopeId, detail };
+			return { scopeId: scopeId || label, label, detail };
 		})
 		.filter((item): item is PeerAuthorizedDomainViewItem => item != null);
 	const total = domains.length;
 	return {
 		total,
-		badgeLabel:
-			total === 1
-				? "1 Sharing domain"
-				: total > 1
-					? `${total} Sharing domains`
-					: "No Sharing domains",
+		badgeLabel: total === 1 ? "1 Space" : total > 1 ? `${total} Spaces` : "No Space access",
 		isWarning: total === 0,
 		domains,
 		emptyMessage:
-			"No Sharing-domain grants exist for this device yet. Project filters below cannot send data by themselves.",
+			"No Space access grants exist for this device yet. Advanced project filters cannot send data by themselves.",
 	};
 }
 
@@ -287,22 +283,30 @@ export function derivePeerGrantRoleMismatchView(peer: PeerLike): PeerGrantRoleMi
 		return { badgeLabel: null, detail: "", isVisible: false, message: "", title: "" };
 	}
 	return {
-		badgeLabel: "Review domain fit",
+		badgeLabel: "Review Space fit",
 		detail:
-			"Coordinator/group context helps find the device, and project filters only narrow already-authorized domains. Neither one grants a missing work/client domain.",
+			"Team discovery helps find the device, and advanced project filters only narrow already-authorized Spaces. Neither one grants missing work/client Space access.",
 		isVisible: true,
 		message:
-			"This coordinator-discovered device has personal or OSS Sharing-domain grants, but no separate work/client-like domain grant. If this device is meant for work/client sync, add that Sharing domain explicitly before treating sync as validated.",
-		title: "Check this device's Sharing-domain role",
+			"This Team-discovered device has personal or OSS Space access, but no separate work/client-like Space access. If this device is meant for work/client sync, grant that Space explicitly before treating sync as validated.",
+		title: "Check this device's Space access",
 	};
 }
 
 export interface PeerProjectNarrowingView {
+	hasAdvancedFilters: boolean;
+	statusLabel: string;
 	summary: string;
 	note: string;
 	sourceLabel: string;
 	includeLabel: string;
 	excludeLabel: string;
+}
+
+function hasActiveProjectNarrowing(include: string[], exclude: string[]): boolean {
+	const normalizedInclude = include.map((item) => item.trim()).filter(Boolean);
+	const includeNarrows = normalizedInclude.length > 0 && !normalizedInclude.includes("*");
+	return includeNarrows || exclude.length > 0;
 }
 
 export function derivePeerProjectNarrowingView(
@@ -313,11 +317,14 @@ export function derivePeerProjectNarrowingView(
 	const sourceLabel = scope?.inherits_global ? "Global defaults" : "Device override";
 	const includeLabel = `Include filter: ${shortList(effectiveInclude, "all projects")}`;
 	const excludeLabel = `Exclude filter: ${shortList(effectiveExclude, "no exclusions")}`;
+	const hasAdvancedFilters = hasActiveProjectNarrowing(effectiveInclude, effectiveExclude);
 	return {
+		hasAdvancedFilters,
+		statusLabel: hasAdvancedFilters ? "Advanced filters active" : "No advanced filters",
 		sourceLabel,
 		includeLabel,
 		excludeLabel,
 		summary: `${sourceLabel}. ${includeLabel}; ${excludeLabel}.`,
-		note: "Project filters only narrow data after Sharing domain authorization; they never grant access to another domain.",
+		note: "Advanced filters only narrow data after Space access; they never grant access to another Space.",
 	};
 }


### PR DESCRIPTION
## Description
Makes Sync present Space access as a read-only summary and routes access changes back to Teams. Also removes primary raw Space ID fallbacks from Sync access summaries.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated with Sync view-model/index tests, final targeted stack tests, `pnpm run tsc`, and `pnpm run lint`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
