### PR TITLE
fix(ui): clarify legacy Space review copy

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
@@ -59,12 +59,12 @@ describe("SyncSharingReview", () => {
 		);
 
 		expect(root.textContent).toContain("Legacy shared review");
-		expect(root.textContent).toContain("1 older project needs a Sharing domain");
+		expect(root.textContent).toContain("1 older project needs a Space");
 		expect(root.textContent).toContain("3 older shared memories total");
 		expect(root.textContent).toContain("oss-dev");
-		expect(root.textContent).toContain("Matched by git remote · suggested oss");
-		expect(root.textContent).toContain("Destination Sharing domain");
-		expect(root.textContent).toContain("OSS · coordinator · suggested");
+		expect(root.textContent).toContain("Matched by git remote · suggested OSS");
+		expect(root.textContent).toContain("Destination Space");
+		expect(root.textContent).toContain("OSS · Team Space · suggested");
 		expect(root.textContent).toContain("legacy data is not promoted automatically");
 		expect(root.textContent).toContain("Nothing moves automatically");
 
@@ -257,7 +257,7 @@ describe("SyncSharingReview", () => {
 
 		const select = root.querySelector("select");
 		expect(select?.value).toBe("");
-		expect(root.textContent).toContain("Choose domain…");
+		expect(root.textContent).toContain("Choose Space…");
 		let applyButton = [...root.querySelectorAll("button")].find(
 			(button) => button.textContent === "Preview reassignment",
 		) as HTMLButtonElement | undefined;
@@ -320,6 +320,9 @@ describe("SyncSharingReview", () => {
 		});
 
 		expect(root.textContent).toContain("local device is not a member");
+		expect(root.textContent).toContain("local device is not a member of Space OSS");
+		expect(root.textContent).not.toContain("Space oss");
+		expect(root.textContent).not.toContain("Sharing domain");
 		expect(root.textContent).toContain("Preview reassignment");
 	});
 
@@ -374,6 +377,7 @@ describe("SyncSharingReview", () => {
 
 		expect(root.textContent).toContain("Needs cleanup 1");
 		expect(root.textContent).toContain("Unclear project identity");
+		expect(root.textContent).not.toContain("fatal: not a git repository");
 
 		const selectSuggested = [...root.querySelectorAll("button")].find(
 			(button) => button.textContent === "Select suggested",
@@ -401,6 +405,55 @@ describe("SyncSharingReview", () => {
 				(button) => button.textContent === "Preview 1 selected",
 			)?.disabled,
 		).toBe(true);
+	});
+
+	it("filters legacy groups by visible suggested Space labels", () => {
+		const root = renderReview(
+			<SyncSharingReview
+				items={[]}
+				legacyReview={{
+					groups: [
+						{
+							displayProject: "platform-api",
+							identitySource: "git_remote",
+							lastUpdatedAt: null,
+							memoryCount: 10,
+							suggestedScopeId: "team-eng-01",
+							suggestionReason: null,
+							workspaceIdentity: "workspace-id:platform-api",
+						},
+						{
+							displayProject: "docs-site",
+							identitySource: "git_remote",
+							lastUpdatedAt: null,
+							memoryCount: 5,
+							suggestedScopeId: "team-docs-01",
+							suggestionReason: null,
+							workspaceIdentity: "workspace-id:docs-site",
+						},
+					],
+					memoryCount: 15,
+					scopeId: "legacy-shared-review",
+					targetScopes: [
+						{ authorityType: "coordinator", label: "Engineering", scopeId: "team-eng-01" },
+						{ authorityType: "coordinator", label: "Documentation", scopeId: "team-docs-01" },
+					],
+				}}
+				onLegacyReassign={vi.fn()}
+				onReview={() => {}}
+			/>,
+		);
+
+		const search = root.querySelector<HTMLInputElement>(".legacy-review-search");
+		act(() => {
+			if (!search) throw new Error("search missing");
+			search.value = "Engineering";
+			search.dispatchEvent(new InputEvent("input", { bubbles: true }));
+		});
+
+		expect(root.textContent).toContain("platform-api");
+		expect(root.textContent).toContain("suggested Engineering");
+		expect(root.textContent).not.toContain("docs-site");
 	});
 
 	it("does not show bulk preview controls without a reassignment target", () => {
@@ -434,7 +487,7 @@ describe("SyncSharingReview", () => {
 		});
 
 		expect(root.textContent).not.toContain("Preview 1 selected");
-		expect(root.textContent).toContain("Add or join a Sharing domain before bulk reassignment");
+		expect(root.textContent).toContain("Add or join a Space before bulk reassignment");
 	});
 
 	it("explains inbound-only legacy groups instead of offering reassignment", () => {
@@ -467,7 +520,7 @@ describe("SyncSharingReview", () => {
 		const checkbox = root.querySelector<HTMLInputElement>('input[type="checkbox"]');
 		expect(checkbox?.disabled).toBe(true);
 		expect(root.textContent).toContain("Peer-owned only");
-		expect(root.textContent).toContain("cannot reassign them to a Sharing domain");
+		expect(root.textContent).toContain("cannot reassign them to a Space");
 		expect(root.textContent).not.toContain("Preview reassignment");
 	});
 });

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
@@ -77,15 +77,74 @@ function needsProjectCleanup(group: SyncLegacySharedReviewGroup): boolean {
 	);
 }
 
+function displayProjectTitle(group: SyncLegacySharedReviewGroup): string {
+	return needsProjectCleanup(group) ? "Unclear project identity" : group.displayProject;
+}
+
 function canReassignLegacyGroup(group: SyncLegacySharedReviewGroup): boolean {
 	return (group.reassignableMemoryCount ?? group.memoryCount) > 0;
 }
 
-function groupSearchText(group: SyncLegacySharedReviewGroup): string {
+function suggestedScopeText(
+	group: SyncLegacySharedReviewGroup,
+	targetScopes: SyncLegacySharedReviewTargetScope[],
+): string {
+	if (!group.suggestedScopeId) return "";
+	const target = targetScopes.find((scope) => scope.scopeId === group.suggestedScopeId);
+	return ` · suggested ${target?.label || "Space"}`;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function targetScopeLabel(
+	scopeId: string,
+	targetScopes: SyncLegacySharedReviewTargetScope[],
+): string {
+	return targetScopes.find((scope) => scope.scopeId === scopeId)?.label || "selected Space";
+}
+
+function authorityLabel(authorityType: string): string {
+	switch (authorityType) {
+		case "coordinator":
+			return "Team Space";
+		case "local":
+			return "Local Space";
+		default:
+			return "Other Space";
+	}
+}
+
+function formatLegacyReviewError(
+	error: unknown,
+	scopeId: string,
+	targetScopes: SyncLegacySharedReviewTargetScope[],
+): string {
+	const message =
+		error instanceof Error ? error.message : "Unable to reassign legacy review memories.";
+	let result = message.replace(/sharing domain/gi, "Space");
+	if (scopeId) {
+		result = result.replace(
+			new RegExp(`\\b${escapeRegExp(scopeId)}\\b`, "g"),
+			targetScopeLabel(scopeId, targetScopes),
+		);
+	}
+	return result;
+}
+
+function groupSearchText(
+	group: SyncLegacySharedReviewGroup,
+	targetScopes: SyncLegacySharedReviewTargetScope[],
+): string {
+	const suggestedScopeLabel = group.suggestedScopeId
+		? targetScopes.find((scope) => scope.scopeId === group.suggestedScopeId)?.label
+		: "";
 	return [
 		group.displayProject,
 		group.identitySource,
 		group.suggestedScopeId ?? "",
+		suggestedScopeLabel ?? "",
 		group.suggestionReason ?? "",
 		group.workspaceIdentity,
 	]
@@ -169,7 +228,9 @@ function LegacySharedReviewRow({
 		if (filter === "cleanup" && !cleanup) return false;
 		if (filter === "no-suggestion" && (group.suggestedScopeId || cleanup)) return false;
 		if (filter === "selected" && !selectedGroups[group.workspaceIdentity]) return false;
-		return !query.trim() || groupSearchText(group).includes(query.trim().toLowerCase());
+		return (
+			!query.trim() || groupSearchText(group, targetScopes).includes(query.trim().toLowerCase())
+		);
 	});
 	async function applyGroup(group: SyncLegacySharedReviewGroup) {
 		const selectedScopeId = selectedScopes[group.workspaceIdentity] || group.suggestedScopeId || "";
@@ -198,8 +259,7 @@ function LegacySharedReviewRow({
 		} catch (error) {
 			setErrors((current) => ({
 				...current,
-				[group.workspaceIdentity]:
-					error instanceof Error ? error.message : "Unable to reassign legacy review memories.",
+				[group.workspaceIdentity]: formatLegacyReviewError(error, selectedScopeId, targetScopes),
 			}));
 		} finally {
 			setBusyIdentity(null);
@@ -275,8 +335,11 @@ function LegacySharedReviewRow({
 				} catch (error) {
 					setErrors((current) => ({
 						...current,
-						[group.workspaceIdentity]:
-							error instanceof Error ? error.message : "Unable to reassign legacy review memories.",
+						[group.workspaceIdentity]: formatLegacyReviewError(
+							error,
+							selectedScopeId,
+							targetScopes,
+						),
 					}));
 				}
 			}
@@ -294,7 +357,7 @@ function LegacySharedReviewRow({
 					</div>
 					<div className="peer-meta legacy-review-summary">
 						{groupCount.toLocaleString()} older{" "}
-						{groupCount === 1 ? "project needs" : "projects need"} a Sharing domain. They contain{" "}
+						{groupCount === 1 ? "project needs" : "projects need"} a Space. They contain{" "}
 						{item.memoryCount.toLocaleString()} older shared memories total; review the projects,
 						not individual memories.
 						{shownGroupCount < groupCount
@@ -384,7 +447,7 @@ function LegacySharedReviewRow({
 						</button>
 					) : onReassign && selectedReassignableCount > 0 ? (
 						<span className="legacy-review-cleanup-note">
-							Add or join a Sharing domain before bulk reassignment.
+							Add or join a Space before bulk reassignment.
 						</span>
 					) : null}
 					{selectedCount > 0 &&
@@ -410,7 +473,7 @@ function LegacySharedReviewRow({
 							<div className="legacy-review-group-main">
 								<div className="legacy-review-title-wrap">
 									<input
-										aria-label={`Select ${group.displayProject}`}
+										aria-label={`Select ${displayProjectTitle(group)}`}
 										checked={Boolean(selectedGroups[group.workspaceIdentity])}
 										className="cm-checkbox"
 										disabled={!canReassignLegacyGroup(group)}
@@ -418,15 +481,15 @@ function LegacySharedReviewRow({
 										type="checkbox"
 									/>
 									<div>
-										<div className="legacy-review-group-title">{group.displayProject}</div>
+										<div className="legacy-review-group-title">{displayProjectTitle(group)}</div>
 										<div className="legacy-review-group-meta">
 											{formatIdentitySource(group.identitySource)}
-											{group.suggestedScopeId ? ` · suggested ${group.suggestedScopeId}` : ""}
+											{suggestedScopeText(group, targetScopes)}
 										</div>
 										{!canReassignLegacyGroup(group) ? (
 											<div className="legacy-review-cleanup-note">
 												Peer-owned only. These older memories were received from another device, so
-												this device cannot reassign them to a Sharing domain.
+												this device cannot reassign them to a Space.
 											</div>
 										) : group.peerOwnedMemoryCount ? (
 											<div className="legacy-review-cleanup-note">
@@ -440,8 +503,8 @@ function LegacySharedReviewRow({
 										) : null}
 										{needsProjectCleanup(group) ? (
 											<div className="legacy-review-cleanup-note">
-												Unclear project identity. Inspect or correct the project before trusting a
-												domain.
+												Inspect or correct the project identity before assigning old shared data to
+												a Space.
 											</div>
 										) : null}
 									</div>
@@ -471,17 +534,17 @@ function LegacySharedReviewRow({
 							) : null}
 							{targetScopes.length > 0 && onReassign && canReassignLegacyGroup(group) ? (
 								<label className="legacy-review-target">
-									<span>Destination Sharing domain</span>
+									<span>Destination Space</span>
 									<select
 										className="peer-scope-input"
 										disabled={busyIdentity != null}
 										onChange={(event) => updateSelectedScope(group, event.currentTarget.value)}
 										value={selectedScopes[group.workspaceIdentity] || ""}
 									>
-										<option value="">Choose domain…</option>
+										<option value="">Choose Space…</option>
 										{targetScopes.map((scope) => (
 											<option key={scope.scopeId} value={scope.scopeId}>
-												{scope.label} · {scope.authorityType}
+												{scope.label} · {authorityLabel(scope.authorityType)}
 												{scope.scopeId === group.suggestedScopeId ? " · suggested" : ""}
 											</option>
 										))}


### PR DESCRIPTION
## Description
Clarifies legacy shared review copy around Space assignment, avoids promoting git error text as a project title, maps authority wording to user-facing labels, and sanitizes legacy reassignment errors so raw Space IDs do not become primary UI copy.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated with legacy shared review component tests, final targeted stack tests, `pnpm run tsc`, and `pnpm run lint`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
