### PR TITLE
fix(ui): hide sync-bootstrap placeholder sessions from Projects tab

### DIFF
--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -692,4 +692,42 @@ describe("project scope settings", () => {
 			}),
 		).toThrow(/not an active Sharing domain/);
 	});
+
+	it("excludes synthetic sync-bootstrap sessions from the project inventory", () => {
+		// Real session — should appear in the inventory.
+		const realSession = insertSession(db, {
+			cwd: "/workspace/work/exampleco/api",
+			gitRemote: "https://git.example.invalid/exampleco/api.git",
+			project: "api",
+		});
+		insertMemory(db, realSession);
+
+		// Synthetic placeholder session created by sync-bootstrap.ts when
+		// inbound memories arrive from a peer. Must be hidden from the
+		// Projects tab read model.
+		const bootstrapSession = insertSession(db, {
+			cwd: "__sync_bootstrap__:codemem",
+			gitRemote: null,
+			project: "codemem",
+		});
+		insertMemory(db, bootstrapSession, { workspaceId: "shared:default" });
+
+		const bareBootstrapSession = insertSession(db, {
+			cwd: "__sync_bootstrap__",
+			gitRemote: null,
+			project: null,
+		});
+		insertMemory(db, bareBootstrapSession, { workspaceId: "shared:default" });
+
+		const inventory = listProjectScopeInventory(db);
+		const cwds = inventory.projects.map((project) => project.cwd ?? "");
+		expect(cwds).not.toContain("__sync_bootstrap__:codemem");
+		expect(cwds).not.toContain("__sync_bootstrap__");
+		// Real session is still surfaced.
+		expect(
+			inventory.projects.some(
+				(project) => project.workspace_identity === "https://git.example.invalid/exampleco/api.git",
+			),
+		).toBe(true);
+	});
 });

--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -730,4 +730,23 @@ describe("project scope settings", () => {
 			),
 		).toBe(true);
 	});
+
+	it("keeps cwds that only coincidentally match the bootstrap LIKE-wildcard shape", () => {
+		// Regression: a naive `LIKE '__sync_bootstrap__%'` predicate treats
+		// each `_` as a single-character wildcard, so any 18-char cwd whose
+		// position 3-15 spell "sync" + 13 chars matching "_bootstrap" pattern
+		// would be silently dropped. Use a cwd that LIKE would wrongly
+		// exclude but a literal-prefix comparison must keep.
+		const trickySession = insertSession(db, {
+			// 18 chars total, matching the wildcard count of "__sync_bootstrap__"
+			// but with characters that don't form the literal prefix.
+			cwd: "xxsyncXbootstrapYY",
+			gitRemote: "https://git.example.invalid/team/tricky.git",
+			project: "tricky",
+		});
+		insertMemory(db, trickySession);
+
+		const inventory = listProjectScopeInventory(db);
+		expect(inventory.projects.map((project) => project.cwd ?? "")).toContain("xxsyncXbootstrapYY");
+	});
 });

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -9,6 +9,7 @@ import {
 	type ScopeResolutionReason,
 	type WorkspaceIdentitySource,
 } from "./scope-resolution.js";
+import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap.js";
 
 export interface SharingDomainSettingsScope {
 	scope_id: string;
@@ -772,6 +773,10 @@ export function listProjectScopeInventory(
 	const offset = Math.max(0, options.offset ?? 0);
 	const mappings = listProjectScopeSettingsMappings(db);
 	const scopes = listSharingDomainSettingsScopes(db);
+	// Bootstrap sessions get a placeholder cwd (see SYNC_BOOTSTRAP_CWD_PREFIX
+	// in sync-bootstrap.ts) to satisfy the NOT NULL FK on memory_items.
+	// They represent inbound memories from peers and should not surface as
+	// distinct projects in the inventory.
 	const rows = db
 		.prepare(
 			`SELECT
@@ -794,12 +799,15 @@ export function listProjectScopeInventory(
 				COUNT(mi_count.id) AS memory_count
 			 FROM sessions s
 			 LEFT JOIN memory_items mi_count ON mi_count.session_id = s.id
-			 WHERE COALESCE(TRIM(s.git_remote), TRIM(s.cwd), TRIM(s.project), '') <> ''
-			    OR mi_count.id IS NOT NULL
+			 WHERE (
+			           COALESCE(TRIM(s.git_remote), TRIM(s.cwd), TRIM(s.project), '') <> ''
+			        OR mi_count.id IS NOT NULL
+			       )
+			   AND (s.cwd IS NULL OR s.cwd NOT LIKE ? || '%')
 			 GROUP BY s.id
 			 ORDER BY MAX(s.started_at) DESC, s.id DESC`,
 		)
-		.all() as ProjectScopeCandidateRow[];
+		.all(SYNC_BOOTSTRAP_CWD_PREFIX) as ProjectScopeCandidateRow[];
 
 	const byIdentity = new Map<string, ProjectScopeInventoryProject>();
 	const inventory: ProjectScopeInventoryProject[] = [];

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -776,7 +776,9 @@ export function listProjectScopeInventory(
 	// Bootstrap sessions get a placeholder cwd (see SYNC_BOOTSTRAP_CWD_PREFIX
 	// in sync-bootstrap.ts) to satisfy the NOT NULL FK on memory_items.
 	// They represent inbound memories from peers and should not surface as
-	// distinct projects in the inventory.
+	// distinct projects in the inventory. Match the prefix literally with
+	// substr — SQLite LIKE would treat the underscores in `__sync_bootstrap__`
+	// as wildcards and exclude unrelated cwds.
 	const rows = db
 		.prepare(
 			`SELECT
@@ -803,11 +805,11 @@ export function listProjectScopeInventory(
 			           COALESCE(TRIM(s.git_remote), TRIM(s.cwd), TRIM(s.project), '') <> ''
 			        OR mi_count.id IS NOT NULL
 			       )
-			   AND (s.cwd IS NULL OR s.cwd NOT LIKE ? || '%')
+			   AND (s.cwd IS NULL OR substr(s.cwd, 1, length(?)) <> ?)
 			 GROUP BY s.id
 			 ORDER BY MAX(s.started_at) DESC, s.id DESC`,
 		)
-		.all(SYNC_BOOTSTRAP_CWD_PREFIX) as ProjectScopeCandidateRow[];
+		.all(SYNC_BOOTSTRAP_CWD_PREFIX, SYNC_BOOTSTRAP_CWD_PREFIX) as ProjectScopeCandidateRow[];
 
 	const byIdentity = new Map<string, ProjectScopeInventoryProject>();
 	const inventory: ProjectScopeInventoryProject[] = [];

--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -30,6 +30,22 @@ import type { SyncMemorySnapshotItem, SyncResetRequired } from "./types.js";
 import { queueVectorBackfillForSyncBootstrap } from "./vector-migration.js";
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthetic placeholder cwd written for sessions created during bootstrap
+ * snapshot apply. These sessions exist only to satisfy the NOT NULL FK on
+ * memory_items.session_id for inbound memories that did not originate on
+ * this device. They are not user-facing and should be filtered out of any
+ * UI that lists projects or sessions by cwd.
+ *
+ * Format: `__sync_bootstrap__:<project>` or `__sync_bootstrap__` if no
+ * project is associated.
+ */
+export const SYNC_BOOTSTRAP_CWD_PREFIX = "__sync_bootstrap__";
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -199,7 +215,7 @@ function ensureSessionForBootstrap(
 	const cached = bootstrapSessionCache.get(projectKey);
 	if (cached != null) return cached;
 
-	const cwd = project ? `__sync_bootstrap__:${project}` : "__sync_bootstrap__";
+	const cwd = project ? `${SYNC_BOOTSTRAP_CWD_PREFIX}:${project}` : SYNC_BOOTSTRAP_CWD_PREFIX;
 	const existing = d
 		.select({ id: schema.sessions.id })
 		.from(schema.sessions)


### PR DESCRIPTION
## Description

When inbound memories arrive from a peer, `ensureSessionForBootstrap` (`packages/core/src/sync-bootstrap.ts`) creates a synthetic session with `cwd = "__sync_bootstrap__:<project>"` (or just `"__sync_bootstrap__"` when no project is associated) so that incoming `memory_items` rows have a valid `session_id` to point at. These placeholders are pure scaffolding — they exist to satisfy the NOT NULL foreign key, not to represent any project the user worked in.

The Projects tab read model groups by `sessions.id`, so those placeholder sessions surfaced as user-facing project identities: with the raw internal `__sync_bootstrap__:` prefix exposed in the row, a misleading "Local only · Local device" label, and inclusion in the visible "N project identities found" counter.

Filter them at the read model in `listProjectScopeInventory` by excluding any session whose `cwd` starts with the bootstrap prefix. The constant `SYNC_BOOTSTRAP_CWD_PREFIX` is now exported from `sync-bootstrap.ts` so writer and reader share a single source of truth.

This is the cosmetic fix. Full session-level provenance (so cross-device memories surface under their real originating project with correct Space attribution) requires session metadata to replicate, which is out of scope.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

New regression test `excludes synthetic sync-bootstrap sessions from the project inventory` in `packages/core/src/project-scope-settings.test.ts`: seeds a real session and two bootstrap placeholder sessions (one with project, one without), asserts the placeholders are absent from `listProjectScopeInventory().projects` and the real session is preserved. Full project-scope-settings + sync-bootstrap suites (34 tests) pass. `pnpm run tsc` and `pnpm run lint` clean.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced