### PR TITLE
feat(sync): accept scoped sync_id on server-side protocol routes

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -519,6 +519,7 @@ export type { BootstrapOptions, BootstrapResult } from "./sync-bootstrap.js";
 export { applyBootstrapSnapshot, fetchAllSnapshotPages } from "./sync-bootstrap.js";
 export type { SyncCapability } from "./sync-capability.js";
 export {
+	isScopedSyncCapability,
 	LOCAL_SYNC_CAPABILITY,
 	negotiateSyncCapability,
 	normalizeSyncCapability,
@@ -624,14 +625,17 @@ export {
 } from "./sync-replication.js";
 export { SyncRetentionRunner } from "./sync-retention-runner.js";
 export type {
+	AuthorizedScopeEntry,
 	SyncScopeRequest,
 	SyncScopeRequestMode,
 	SyncScopeResetReason,
 } from "./sync-scope-protocol.js";
 export {
 	addSyncScopeToBoundary,
+	listAuthorizedScopesForPeer,
 	parseSyncScopeRequest,
 	SYNC_SCOPE_QUERY_PARAM,
+	scopeAuthorizationFailureReason,
 	syncScopeResetRequiredPayload,
 } from "./sync-scope-protocol.js";
 export { deriveTags, fileTags, normalizeTag } from "./tags.js";

--- a/packages/core/src/sync-bootstrap.test.ts
+++ b/packages/core/src/sync-bootstrap.test.ts
@@ -371,7 +371,7 @@ describe("fetchAllSnapshotPages", () => {
 				expect(String(_input)).toContain("scope_id=acme-work");
 				expect(init?.headers).toMatchObject({
 					"X-Codemem-Bootstrap-Grant": "grant-1",
-					[SYNC_CAPABILITY_HEADER]: "aware",
+					[SYNC_CAPABILITY_HEADER]: "scoped",
 					"X-Opencode-Device": deviceId,
 				});
 				return new Response(

--- a/packages/core/src/sync-capability.ts
+++ b/packages/core/src/sync-capability.ts
@@ -6,19 +6,45 @@
  * sync contract they understand.
  */
 
-export const SYNC_CAPABILITIES = ["unsupported", "aware", "enforcing"] as const;
+export const SYNC_CAPABILITIES = ["unsupported", "aware", "enforcing", "scoped"] as const;
 
 export const SYNC_CAPABILITY_HEADER = "X-Codemem-Sync-Capability";
 
 export type SyncCapability = (typeof SYNC_CAPABILITIES)[number];
 
-export const LOCAL_SYNC_CAPABILITY: SyncCapability = "aware";
+/**
+ * Local sync capability advertised on every wire response and outbound request.
+ *
+ * `scoped` (rank 3) signals the peer understands the per-Space sync protocol
+ * defined in docs/plans/2026-05-25-scoped-sync-protocol.md:
+ * - GET /v1/status emits `authorized_scopes` when caller is also scoped.
+ * - GET /v1/ops and GET /v1/snapshot accept a signed `scope_id` query param.
+ * - POST /v1/ops accepts a `scope_id` field in the signed body.
+ *
+ * Mixed-version pairs negotiate down to the lower rank (`aware`), so legacy
+ * default-scope behavior is preserved end-to-end for either side that does
+ * not advertise `scoped`.
+ */
+export const LOCAL_SYNC_CAPABILITY: SyncCapability = "scoped";
 
 const CAPABILITY_RANK: Record<SyncCapability, number> = {
 	unsupported: 0,
 	aware: 1,
 	enforcing: 2,
+	scoped: 3,
 };
+
+/**
+ * True when the negotiated capability supports per-Space scoped sync.
+ *
+ * Use this to gate `authorized_scopes` enumeration on /v1/status and to
+ * decide whether to honor an explicit `scope_id` parameter on the other
+ * sync routes. Returns false for `aware` / `enforcing` / `unsupported`,
+ * preserving legacy default-scope behavior.
+ */
+export function isScopedSyncCapability(capability: SyncCapability): boolean {
+	return CAPABILITY_RANK[capability] >= CAPABILITY_RANK.scoped;
+}
 
 export function normalizeSyncCapability(value: unknown): SyncCapability {
 	if (typeof value !== "string") return "unsupported";

--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -151,9 +151,13 @@ describe("sync capability negotiation", () => {
 		expect(negotiateSyncCapability("aware", "enforcing")).toBe("aware");
 	});
 
-	it("does not upgrade a local aware peer from an enforcing advertisement", () => {
-		expect(LOCAL_SYNC_CAPABILITY).toBe("aware");
-		expect(negotiateSyncCapability(LOCAL_SYNC_CAPABILITY, "enforcing")).toBe("aware");
+	it("does not upgrade a local scoped peer from an enforcing advertisement", () => {
+		expect(LOCAL_SYNC_CAPABILITY).toBe("scoped");
+		expect(negotiateSyncCapability(LOCAL_SYNC_CAPABILITY, "enforcing")).toBe("enforcing");
+	});
+
+	it("downgrades scoped-to-aware sessions to aware", () => {
+		expect(negotiateSyncCapability("scoped", "aware")).toBe("aware");
 	});
 });
 
@@ -227,7 +231,7 @@ describe("syncOnce", () => {
 			)
 			.get("peer-identity-fail") as Record<string, unknown>;
 		expect(attempt).toMatchObject({
-			local_sync_capability: "aware",
+			local_sync_capability: "scoped",
 			peer_sync_capability: "unsupported",
 			negotiated_sync_capability: "unsupported",
 		});
@@ -318,10 +322,10 @@ describe("syncOnce", () => {
 			"2026-01-01T00:00:00Z|remote-op-1",
 		);
 		expect(vi.mocked(syncHttpClient.requestJson).mock.calls[0]?.[2]?.headers).toMatchObject({
-			[SYNC_CAPABILITY_HEADER]: "aware",
+			[SYNC_CAPABILITY_HEADER]: "scoped",
 		});
 		expect(vi.mocked(syncHttpClient.requestJson).mock.calls[1]?.[2]?.headers).toMatchObject({
-			[SYNC_CAPABILITY_HEADER]: "aware",
+			[SYNC_CAPABILITY_HEADER]: "scoped",
 		});
 		const attempt = db
 			.prepare(
@@ -333,9 +337,9 @@ describe("syncOnce", () => {
 			)
 			.get("peer-1") as Record<string, unknown>;
 		expect(attempt).toMatchObject({
-			local_sync_capability: "aware",
+			local_sync_capability: "scoped",
 			peer_sync_capability: "enforcing",
-			negotiated_sync_capability: "aware",
+			negotiated_sync_capability: "enforcing",
 		});
 	});
 
@@ -574,7 +578,7 @@ describe("syncOnce", () => {
 			)
 			.get("peer-legacy") as Record<string, unknown>;
 		expect(attempt).toMatchObject({
-			local_sync_capability: "aware",
+			local_sync_capability: "scoped",
 			peer_sync_capability: "unsupported",
 			negotiated_sync_capability: "unsupported",
 		});

--- a/packages/core/src/sync-scope-protocol.test.ts
+++ b/packages/core/src/sync-scope-protocol.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	addSyncScopeToBoundary,
+	listAuthorizedScopesForPeer,
 	parseSyncScopeRequest,
 	syncScopeResetRequiredPayload,
 } from "./sync-scope-protocol.js";
+import { initTestSchema } from "./test-utils.js";
 
 describe("sync scope protocol compatibility", () => {
 	it("treats omitted scope_id as legacy compatibility mode", () => {
@@ -18,8 +21,12 @@ describe("sync scope protocol compatibility", () => {
 		expect(parseSyncScopeRequest("  ", true)).toEqual({ ok: false, reason: "missing_scope" });
 	});
 
-	it("returns unsupported_scope for explicit scoped requests until per-scope sync lands", () => {
+	it("returns unsupported_scope for explicit scoped requests without scoped capability", () => {
 		expect(parseSyncScopeRequest("acme-work", true)).toEqual({
+			ok: false,
+			reason: "unsupported_scope",
+		});
+		expect(parseSyncScopeRequest("acme-work", true, { negotiatedCapability: "aware" })).toEqual({
 			ok: false,
 			reason: "unsupported_scope",
 		});
@@ -68,5 +75,271 @@ describe("sync scope protocol compatibility", () => {
 			retained_floor_cursor: null,
 			scope_id: null,
 		});
+	});
+
+	it("echoes the requested scope_id on reset_required when provided", () => {
+		expect(
+			syncScopeResetRequiredPayload(
+				{
+					generation: 1,
+					snapshot_id: "snap-acme",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+				},
+				"missing_scope",
+				"scoped",
+				"acme-work",
+			),
+		).toMatchObject({ scope_id: "acme-work", reason: "missing_scope" });
+	});
+});
+
+describe("parseSyncScopeRequest scoped path", () => {
+	const LOCAL_DEVICE = "local-device";
+	const PEER_DEVICE = "peer-device";
+	const SCOPE_ID = "acme-work";
+	const NOW = "2026-05-25T00:00:00.000Z";
+	let db: InstanceType<typeof Database>;
+
+	function insertScope(
+		scopeId: string,
+		opts: { membershipEpoch?: number; status?: string; authorityType?: string } = {},
+	) {
+		const membershipEpoch = opts.membershipEpoch ?? 0;
+		const status = opts.status ?? "active";
+		const authorityType = opts.authorityType ?? "coordinator";
+		db.prepare(
+			`INSERT OR REPLACE INTO replication_scopes(
+				scope_id, label, kind, authority_type, coordinator_id, group_id,
+				membership_epoch, status, created_at, updated_at
+			) VALUES (?, ?, 'team', ?, 'coordinator-1', 'group-1', ?, ?, ?, ?)`,
+		).run(scopeId, `Scope ${scopeId}`, authorityType, membershipEpoch, status, NOW, NOW);
+	}
+
+	function grantMembership(
+		scopeId: string,
+		deviceId: string,
+		opts: { membershipEpoch?: number; status?: string } = {},
+	) {
+		const membershipEpoch = opts.membershipEpoch ?? 0;
+		const status = opts.status ?? "active";
+		db.prepare(
+			`INSERT OR REPLACE INTO scope_memberships(
+				scope_id, device_id, role, status, membership_epoch,
+				coordinator_id, group_id, updated_at
+			) VALUES (?, ?, 'member', ?, ?, 'coordinator-1', 'group-1', ?)`,
+		).run(scopeId, deviceId, status, membershipEpoch, NOW);
+	}
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("accepts a scoped request when peer is an authorized active member", () => {
+		insertScope(SCOPE_ID);
+		grantMembership(SCOPE_ID, LOCAL_DEVICE);
+		grantMembership(SCOPE_ID, PEER_DEVICE);
+		const result = parseSyncScopeRequest(SCOPE_ID, true, {
+			db,
+			negotiatedCapability: "scoped",
+			peerDeviceId: PEER_DEVICE,
+		});
+		expect(result).toEqual({ ok: true, mode: "scoped", scope_id: SCOPE_ID });
+	});
+
+	it("rejects with missing_scope when the scope does not exist", () => {
+		const result = parseSyncScopeRequest("does-not-exist", true, {
+			db,
+			negotiatedCapability: "scoped",
+			peerDeviceId: PEER_DEVICE,
+		});
+		expect(result).toEqual({ ok: false, reason: "missing_scope" });
+	});
+
+	it("rejects with missing_scope when peer is not a member", () => {
+		insertScope(SCOPE_ID);
+		grantMembership(SCOPE_ID, LOCAL_DEVICE);
+		// Peer not granted.
+		const result = parseSyncScopeRequest(SCOPE_ID, true, {
+			db,
+			negotiatedCapability: "scoped",
+			peerDeviceId: PEER_DEVICE,
+		});
+		expect(result).toEqual({ ok: false, reason: "missing_scope" });
+	});
+
+	it("rejects with stale_epoch when peer membership epoch is behind authority", () => {
+		insertScope(SCOPE_ID, { membershipEpoch: 5 });
+		grantMembership(SCOPE_ID, LOCAL_DEVICE, { membershipEpoch: 5 });
+		grantMembership(SCOPE_ID, PEER_DEVICE, { membershipEpoch: 3 });
+		const result = parseSyncScopeRequest(SCOPE_ID, true, {
+			db,
+			negotiatedCapability: "scoped",
+			peerDeviceId: PEER_DEVICE,
+		});
+		expect(result).toEqual({ ok: false, reason: "stale_epoch" });
+	});
+
+	it("rejects with scope_inactive when membership was revoked", () => {
+		insertScope(SCOPE_ID);
+		grantMembership(SCOPE_ID, LOCAL_DEVICE);
+		grantMembership(SCOPE_ID, PEER_DEVICE, { status: "revoked" });
+		const result = parseSyncScopeRequest(SCOPE_ID, true, {
+			db,
+			negotiatedCapability: "scoped",
+			peerDeviceId: PEER_DEVICE,
+		});
+		expect(result).toEqual({ ok: false, reason: "scope_inactive" });
+	});
+
+	it("falls back to unsupported_scope when caller advertises a lower capability", () => {
+		insertScope(SCOPE_ID);
+		grantMembership(SCOPE_ID, LOCAL_DEVICE);
+		grantMembership(SCOPE_ID, PEER_DEVICE);
+		const result = parseSyncScopeRequest(SCOPE_ID, true, {
+			db,
+			negotiatedCapability: "aware",
+			peerDeviceId: PEER_DEVICE,
+		});
+		expect(result).toEqual({ ok: false, reason: "unsupported_scope" });
+	});
+});
+
+describe("listAuthorizedScopesForPeer", () => {
+	const LOCAL_DEVICE = "local-device";
+	const PEER_DEVICE = "peer-device";
+	const NOW = "2026-05-25T00:00:00.000Z";
+	let db: InstanceType<typeof Database>;
+
+	function insertScope(
+		scopeId: string,
+		opts: {
+			membershipEpoch?: number;
+			status?: string;
+			authorityType?: string;
+			label?: string;
+		} = {},
+	) {
+		const membershipEpoch = opts.membershipEpoch ?? 0;
+		const status = opts.status ?? "active";
+		const authorityType = opts.authorityType ?? "coordinator";
+		const label = opts.label ?? `Scope ${scopeId}`;
+		db.prepare(
+			`INSERT OR REPLACE INTO replication_scopes(
+				scope_id, label, kind, authority_type, coordinator_id, group_id,
+				membership_epoch, status, created_at, updated_at
+			) VALUES (?, ?, 'team', ?, 'coordinator-1', 'group-1', ?, ?, ?, ?)`,
+		).run(scopeId, label, authorityType, membershipEpoch, status, NOW, NOW);
+	}
+
+	function grantMembership(scopeId: string, deviceId: string, status = "active") {
+		db.prepare(
+			`INSERT OR REPLACE INTO scope_memberships(
+				scope_id, device_id, role, status, membership_epoch,
+				coordinator_id, group_id, updated_at
+			) VALUES (?, ?, 'member', ?, 0, 'coordinator-1', 'group-1', ?)`,
+		).run(scopeId, deviceId, status, NOW);
+	}
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("returns an empty list when the local device has no memberships", () => {
+		expect(
+			listAuthorizedScopesForPeer(db, {
+				localDeviceId: LOCAL_DEVICE,
+				peerDeviceId: PEER_DEVICE,
+			}),
+		).toEqual([]);
+	});
+
+	it("returns scopes both devices are active members of, sorted by scope_id", () => {
+		insertScope("zeta", { label: "Zeta" });
+		insertScope("alpha", { label: "Alpha" });
+		grantMembership("zeta", LOCAL_DEVICE);
+		grantMembership("zeta", PEER_DEVICE);
+		grantMembership("alpha", LOCAL_DEVICE);
+		grantMembership("alpha", PEER_DEVICE);
+
+		const scopes = listAuthorizedScopesForPeer(db, {
+			localDeviceId: LOCAL_DEVICE,
+			peerDeviceId: PEER_DEVICE,
+		});
+
+		expect(scopes.map((s) => s.scope_id)).toEqual(["alpha", "zeta"]);
+		expect(scopes[0]).toMatchObject({
+			scope_id: "alpha",
+			label: "Alpha",
+			authority_type: "coordinator",
+			membership_epoch: 0,
+			sync_reset: expect.objectContaining({
+				scope_id: "alpha",
+				generation: 1,
+			}),
+		});
+	});
+
+	it("excludes scopes where the peer is not a member", () => {
+		insertScope("acme-work");
+		insertScope("oss");
+		grantMembership("acme-work", LOCAL_DEVICE);
+		grantMembership("acme-work", PEER_DEVICE);
+		grantMembership("oss", LOCAL_DEVICE);
+		// Peer not in oss.
+
+		const scopes = listAuthorizedScopesForPeer(db, {
+			localDeviceId: LOCAL_DEVICE,
+			peerDeviceId: PEER_DEVICE,
+		});
+		expect(scopes.map((s) => s.scope_id)).toEqual(["acme-work"]);
+	});
+
+	it("excludes the legacy local-default scope", () => {
+		insertScope("local-default", { authorityType: "local" });
+		insertScope("acme-work");
+		grantMembership("local-default", LOCAL_DEVICE);
+		grantMembership("local-default", PEER_DEVICE);
+		grantMembership("acme-work", LOCAL_DEVICE);
+		grantMembership("acme-work", PEER_DEVICE);
+
+		const scopes = listAuthorizedScopesForPeer(db, {
+			localDeviceId: LOCAL_DEVICE,
+			peerDeviceId: PEER_DEVICE,
+		});
+		expect(scopes.map((s) => s.scope_id)).toEqual(["acme-work"]);
+	});
+
+	it("excludes scopes where the peer membership is revoked", () => {
+		insertScope("acme-work");
+		grantMembership("acme-work", LOCAL_DEVICE);
+		grantMembership("acme-work", PEER_DEVICE, "revoked");
+
+		const scopes = listAuthorizedScopesForPeer(db, {
+			localDeviceId: LOCAL_DEVICE,
+			peerDeviceId: PEER_DEVICE,
+		});
+		expect(scopes).toEqual([]);
+	});
+
+	it("returns an empty list when local and peer device ids are equal", () => {
+		insertScope("acme-work");
+		grantMembership("acme-work", LOCAL_DEVICE);
+		expect(
+			listAuthorizedScopesForPeer(db, {
+				localDeviceId: LOCAL_DEVICE,
+				peerDeviceId: LOCAL_DEVICE,
+			}),
+		).toEqual([]);
 	});
 });

--- a/packages/core/src/sync-scope-protocol.ts
+++ b/packages/core/src/sync-scope-protocol.ts
@@ -1,9 +1,22 @@
-import type { SyncCapability } from "./sync-capability.js";
+import { and, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import type { Database } from "./db.js";
+import * as schema from "./schema.js";
+import {
+	type CachedScopeAuthorization,
+	getCachedScopeAuthorization,
+} from "./scope-membership-cache.js";
+import { isScopedSyncCapability, type SyncCapability } from "./sync-capability.js";
+import { DEFAULT_SYNC_SCOPE_ID, getSyncResetState } from "./sync-replication.js";
 
 export const SYNC_SCOPE_QUERY_PARAM = "scope_id";
 
 export type SyncScopeRequestMode = "legacy" | "scoped";
-export type SyncScopeResetReason = "missing_scope" | "unsupported_scope";
+export type SyncScopeResetReason =
+	| "missing_scope"
+	| "unsupported_scope"
+	| "stale_epoch"
+	| "scope_inactive";
 
 export interface SyncScopeRequestOk {
 	ok: true;
@@ -25,7 +38,34 @@ export interface SyncResetBoundaryShape {
 	retained_floor_cursor: string | null;
 }
 
-export function parseSyncScopeRequest(value: unknown, provided: boolean): SyncScopeRequest {
+/**
+ * Parse a sync scope request and validate it against caller authorization.
+ *
+ * Legacy callers (`negotiatedCapability !== "scoped"`) MUST NOT pass a
+ * scope_id; doing so is rejected as `unsupported_scope` so the wire format
+ * stays predictable when the lower-ranked side cannot interpret per-scope
+ * responses anyway.
+ *
+ * Scoped callers (`negotiatedCapability === "scoped"`) may pass a scope_id.
+ * The server verifies the calling peer is an active, current-epoch member of
+ * the requested scope before accepting. Failed authorization maps to wire
+ * reasons that the client can act on:
+ * - `missing_scope`: scope unknown, inactive, or caller is not a member.
+ * - `stale_epoch`: caller membership exists but epoch is behind authority.
+ * - `scope_inactive`: scope membership was revoked or scope is closed.
+ *
+ * Callers that pass no scope_id continue to be served via the legacy default
+ * scope path regardless of capability.
+ */
+export function parseSyncScopeRequest(
+	value: unknown,
+	provided: boolean,
+	context?: {
+		db?: Database;
+		negotiatedCapability?: SyncCapability;
+		peerDeviceId?: string | null;
+	},
+): SyncScopeRequest {
 	if (!provided) {
 		return { ok: true, mode: "legacy", scope_id: null };
 	}
@@ -35,10 +75,54 @@ export function parseSyncScopeRequest(value: unknown, provided: boolean): SyncSc
 		return { ok: false, reason: "missing_scope" };
 	}
 
-	// ov4g.4.1 reserves the parameter and fails closed for explicit scoped
-	// requests. Per-scope cursors/snapshots land in later ov4g.4 slices; until
-	// then, silently ignoring a requested scope would be worse than refusing it.
-	return { ok: false, reason: "unsupported_scope" };
+	const negotiated = context?.negotiatedCapability;
+	if (!negotiated || !isScopedSyncCapability(negotiated)) {
+		// Caller is on the legacy default-scope wire format. Refuse the
+		// scope_id rather than silently downgrading: the response shape
+		// will not carry the per-scope boundary the caller expects.
+		return { ok: false, reason: "unsupported_scope" };
+	}
+
+	const db = context.db;
+	const peerDeviceId = context.peerDeviceId?.trim();
+	if (!db || !peerDeviceId) {
+		// Caller advertised scoped capability but the route did not thread
+		// the authentication context through. Fail closed.
+		return { ok: false, reason: "missing_scope" };
+	}
+
+	const authorization = getCachedScopeAuthorization(db, {
+		deviceId: peerDeviceId,
+		scopeId,
+	});
+	const errorReason = scopeAuthorizationFailureReason(authorization);
+	if (errorReason) {
+		return { ok: false, reason: errorReason };
+	}
+
+	return { ok: true, mode: "scoped", scope_id: scopeId };
+}
+
+/**
+ * Map a cached scope authorization result to a wire reset reason, or null
+ * when the caller is fully authorized for the scope.
+ */
+export function scopeAuthorizationFailureReason(
+	authorization: CachedScopeAuthorization,
+): SyncScopeResetReason | null {
+	if (authorization.authorized) return null;
+
+	switch (authorization.state) {
+		case "stale_epoch":
+			return "stale_epoch";
+		case "revoked":
+		case "scope_inactive":
+			return "scope_inactive";
+		case "scope_unknown":
+		case "not_authorized":
+		default:
+			return "missing_scope";
+	}
 }
 
 export function addSyncScopeToBoundary<T extends SyncResetBoundaryShape>(
@@ -52,6 +136,7 @@ export function syncScopeResetRequiredPayload(
 	boundary: SyncResetBoundaryShape,
 	reason: SyncScopeResetReason,
 	syncCapability: SyncCapability,
+	scopeId?: string | null,
 ): SyncResetBoundaryShape & {
 	error: "reset_required";
 	reset_required: true;
@@ -64,6 +149,101 @@ export function syncScopeResetRequiredPayload(
 		reset_required: true,
 		sync_capability: syncCapability,
 		reason,
-		...addSyncScopeToBoundary(boundary, null),
+		...addSyncScopeToBoundary(boundary, scopeId ?? null),
 	};
+}
+
+/**
+ * Authorized-scope entry advertised on /v1/status when both peers negotiate
+ * the `scoped` capability. Each entry carries the per-scope reset boundary
+ * (`sync_reset_state_v2` row) so the client can immediately request that
+ * scope's snapshot or incremental ops without an extra round trip.
+ */
+export interface AuthorizedScopeEntry {
+	scope_id: string;
+	label: string;
+	authority_type: string;
+	membership_epoch: number;
+	sync_reset: SyncResetBoundaryShape & { scope_id: string | null };
+}
+
+/**
+ * Enumerate scopes the calling peer is authorized to sync with the local
+ * device, suitable for advertising on /v1/status under scoped capability.
+ *
+ * Inclusion rule: a scope is returned when
+ * - it exists in `replication_scopes` with status `active`, and
+ * - both the local device and the peer device have active membership rows
+ *   in `scope_memberships`, and
+ * - the scope's `authority_type` is either non-`local`, OR the local
+ *   membership exists (which is how personal scope grants are modeled — the
+ *   grant row is the membership).
+ *
+ * The legacy `local-default` scope is intentionally excluded. Scoped peers
+ * still run the legacy default-scope path alongside per-scope sync to handle
+ * pre-Spaces data, so listing it here would duplicate work and require new
+ * code paths in the loaders to emit "explicit" default-scope rows.
+ *
+ * The returned `sync_reset` value is the per-scope boundary; calling
+ * `getSyncResetState(db, scope_id)` lazily creates a row if one does not
+ * exist yet so first-time scopes get a stable generation/snapshot_id.
+ */
+export function listAuthorizedScopesForPeer(
+	db: Database,
+	options: { localDeviceId: string; peerDeviceId: string },
+): AuthorizedScopeEntry[] {
+	const localDeviceId = options.localDeviceId.trim();
+	const peerDeviceId = options.peerDeviceId.trim();
+	if (!localDeviceId || !peerDeviceId || localDeviceId === peerDeviceId) {
+		return [];
+	}
+
+	const d = drizzle(db, { schema });
+	const localMemberships = d
+		.select({
+			scope_id: schema.scopeMemberships.scope_id,
+			membership_epoch: schema.scopeMemberships.membership_epoch,
+		})
+		.from(schema.scopeMemberships)
+		.where(
+			and(
+				eq(schema.scopeMemberships.device_id, localDeviceId),
+				eq(schema.scopeMemberships.status, "active"),
+			),
+		)
+		.all();
+
+	if (localMemberships.length === 0) return [];
+
+	const entries: AuthorizedScopeEntry[] = [];
+	for (const local of localMemberships) {
+		if (!local.scope_id || local.scope_id === DEFAULT_SYNC_SCOPE_ID) continue;
+
+		// Peer must also be an active member of the same scope, at the same
+		// or higher membership_epoch as the local row, before we advertise.
+		const peerAuth = getCachedScopeAuthorization(db, {
+			deviceId: peerDeviceId,
+			scopeId: local.scope_id,
+		});
+		if (!peerAuth.authorized || !peerAuth.scope) continue;
+		if (peerAuth.scope.status !== "active") continue;
+
+		const reset = getSyncResetState(db, local.scope_id);
+		entries.push({
+			scope_id: local.scope_id,
+			label: peerAuth.scope.label,
+			authority_type: peerAuth.scope.authority_type,
+			membership_epoch: Number(peerAuth.scope.membership_epoch ?? local.membership_epoch ?? 0),
+			sync_reset: {
+				scope_id: local.scope_id,
+				generation: reset.generation,
+				snapshot_id: reset.snapshot_id,
+				baseline_cursor: reset.baseline_cursor,
+				retained_floor_cursor: reset.retained_floor_cursor,
+			},
+		});
+	}
+
+	entries.sort((a, b) => a.scope_id.localeCompare(b.scope_id));
+	return entries;
 }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -3504,7 +3504,7 @@ describe("viewer-server", () => {
 					expect(res.status).toBe(200);
 					const body = (await res.json()) as Record<string, unknown>;
 					expect(body.protocol_version).toBe("2");
-					expect(body.sync_capability).toBe("aware");
+					expect(body.sync_capability).toBe("scoped");
 					expect(body.sync_reset).toMatchObject({ scope_id: null });
 				} finally {
 					peerDb.close();
@@ -3818,7 +3818,7 @@ describe("viewer-server", () => {
 					const body = (await res.json()) as Record<string, unknown>;
 					expect(body.error).toBe("reset_required");
 					expect(body.reset_required).toBe(true);
-					expect(body.sync_capability).toBe("aware");
+					expect(body.sync_capability).toBe("scoped");
 					expect(body.reason).toBe("stale_cursor");
 					expect(body.generation).toBe(7);
 					expect(body.snapshot_id).toBe("snapshot-7");
@@ -3892,7 +3892,7 @@ describe("viewer-server", () => {
 					const body = (await res.json()) as Record<string, unknown>;
 					expect(body.error).toBe("reset_required");
 					expect(body.reset_required).toBe(true);
-					expect(body.sync_capability).toBe("aware");
+					expect(body.sync_capability).toBe("scoped");
 					expect(body.reason).toBe("boundary_mismatch");
 					expect(body.generation).toBe(9);
 					expect(body.snapshot_id).toBe("snapshot-9");
@@ -3923,7 +3923,7 @@ describe("viewer-server", () => {
 				expect(body).toMatchObject({
 					error: "reset_required",
 					reset_required: true,
-					sync_capability: "aware",
+					sync_capability: "scoped",
 					reason: "missing_scope",
 					scope_id: null,
 				});
@@ -3950,9 +3950,9 @@ describe("viewer-server", () => {
 				expect(body).toMatchObject({
 					error: "reset_required",
 					reset_required: true,
-					sync_capability: "aware",
+					sync_capability: "scoped",
 					reason: "unsupported_scope",
-					scope_id: null,
+					scope_id: "acme-work",
 				});
 			} finally {
 				peer?.cleanup();
@@ -3977,9 +3977,9 @@ describe("viewer-server", () => {
 				expect(body).toMatchObject({
 					error: "reset_required",
 					reset_required: true,
-					sync_capability: "aware",
+					sync_capability: "scoped",
 					reason: "unsupported_scope",
-					scope_id: null,
+					scope_id: "acme-work",
 				});
 			} finally {
 				peer?.cleanup();
@@ -4004,7 +4004,7 @@ describe("viewer-server", () => {
 				expect(body).toMatchObject({
 					error: "reset_required",
 					reset_required: true,
-					sync_capability: "aware",
+					sync_capability: "scoped",
 					reason: "missing_scope",
 					scope_id: null,
 				});
@@ -4037,9 +4037,9 @@ describe("viewer-server", () => {
 				expect(body).toMatchObject({
 					error: "reset_required",
 					reset_required: true,
-					sync_capability: "aware",
+					sync_capability: "scoped",
 					reason: "unsupported_scope",
-					scope_id: null,
+					scope_id: "acme-work",
 				});
 			} finally {
 				peer?.cleanup();
@@ -4070,9 +4070,9 @@ describe("viewer-server", () => {
 				expect(body).toMatchObject({
 					error: "reset_required",
 					reset_required: true,
-					sync_capability: "aware",
+					sync_capability: "scoped",
 					reason: "unsupported_scope",
-					scope_id: null,
+					scope_id: "acme-work",
 				});
 			} finally {
 				peer?.cleanup();
@@ -4103,7 +4103,7 @@ describe("viewer-server", () => {
 				expect(body).toMatchObject({
 					error: "reset_required",
 					reset_required: true,
-					sync_capability: "aware",
+					sync_capability: "scoped",
 					reason: "missing_scope",
 					scope_id: null,
 				});
@@ -4139,9 +4139,9 @@ describe("viewer-server", () => {
 				expect(body).toMatchObject({
 					error: "reset_required",
 					reset_required: true,
-					sync_capability: "aware",
+					sync_capability: "scoped",
 					reason: "unsupported_scope",
-					scope_id: null,
+					scope_id: "acme-work",
 				});
 			} finally {
 				peer?.cleanup();
@@ -4198,7 +4198,7 @@ describe("viewer-server", () => {
 					expect(res.status).toBe(200);
 					const body = (await res.json()) as Record<string, unknown>;
 					expect(body.reset_required).toBe(false);
-					expect(body.sync_capability).toBe("aware");
+					expect(body.sync_capability).toBe("scoped");
 					expect(body.scope_id).toBeNull();
 					expect(body.ops).toEqual([]);
 				} finally {
@@ -4360,7 +4360,7 @@ describe("viewer-server", () => {
 					const body = (await res.json()) as Record<string, unknown>;
 					expect(body.generation).toBe(11);
 					expect(body.snapshot_id).toBe("snapshot-11");
-					expect(body.sync_capability).toBe("aware");
+					expect(body.sync_capability).toBe("scoped");
 					expect(body.scope_id).toBeNull();
 					const items = body.items as Array<Record<string, unknown>>;
 					expect(items.map((item) => item.entity_id)).toEqual(["key-a", "key-b"]);
@@ -4445,7 +4445,7 @@ describe("viewer-server", () => {
 					});
 					expect(res.status).toBe(200);
 					const body = (await res.json()) as Record<string, unknown>;
-					expect(body.sync_capability).toBe("aware");
+					expect(body.sync_capability).toBe("scoped");
 					expect(body.scope_id).toBeNull();
 				} finally {
 					peerDb.close();
@@ -4697,7 +4697,7 @@ describe("viewer-server", () => {
 
 				const now = "2026-01-01T00:00:00Z";
 				const payload = {
-					sync_capability: "aware",
+					sync_capability: "scoped",
 					ops: [
 						{
 							op_id: "blocked-delete-op",
@@ -4818,7 +4818,7 @@ describe("viewer-server", () => {
 					const url = "http://localhost/v1/ops";
 					const now = "2026-01-01T00:00:00Z";
 					const payload = {
-						sync_capability: "aware",
+						sync_capability: "scoped",
 						ops: [
 							{
 								op_id: "private-op-1",

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -60,9 +60,11 @@ import {
 	getSemanticIndexDiagnostics,
 	getSyncResetState,
 	type InboundScopeRejectionPeerSummary,
+	isScopedSyncCapability,
 	LEGACY_SHARED_REVIEW_SCOPE_ID,
 	LOCAL_DEFAULT_SCOPE_ID,
 	LOCAL_SYNC_CAPABILITY,
+	listAuthorizedScopesForPeer,
 	listCoordinatorJoinRequests,
 	listInboundScopeRejections,
 	listMaintenanceJobs,
@@ -86,6 +88,7 @@ import {
 	rejectInboundScopeFailures,
 	requestJson,
 	runSyncPass,
+	SYNC_CAPABILITY_HEADER,
 	SYNC_SCOPE_QUERY_PARAM,
 	schema,
 	summarizeInboundScopeRejections,
@@ -2020,6 +2023,22 @@ const PEERS_QUERY = `
 // ---------------------------------------------------------------------------
 
 /**
+ * Compute the negotiated sync capability for a request by combining the
+ * server's local capability with the value the caller advertised in the
+ * `X-Codemem-Sync-Capability` header. Routes use this to decide whether to
+ * honor scoped-sync wire features such as explicit `scope_id` parameters
+ * and `/v1/status` `authorized_scopes` enumeration.
+ *
+ * Unsigned headers are fine here: the server is computing what it is
+ * willing to do, not granting access. Per-scope authorization is enforced
+ * separately via the membership cache when a scope_id is actually used.
+ */
+function negotiatedSyncCapability(c: Context) {
+	const header = c.req.header(SYNC_CAPABILITY_HEADER) ?? null;
+	return negotiateSyncCapability(LOCAL_SYNC_CAPABILITY, normalizeSyncCapability(header));
+}
+
+/**
  * Peer-to-peer sync protocol routes (/v1/*).
  *
  * These are mounted on the sync listener (0.0.0.0:7337) and are
@@ -2096,13 +2115,24 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 					keysDir: syncKeysDir(),
 				});
 				const syncReset = getSyncResetState(store.db);
-				return c.json({
+				const negotiated = negotiatedSyncCapability(c);
+				const authorizedScopes = isScopedSyncCapability(negotiated)
+					? listAuthorizedScopesForPeer(store.db, {
+							localDeviceId: deviceId,
+							peerDeviceId: auth.deviceId,
+						})
+					: null;
+				const response: Record<string, unknown> = {
 					device_id: deviceId,
 					protocol_version: SYNC_PROTOCOL_VERSION,
 					fingerprint,
 					sync_reset: addSyncScopeToBoundary(syncReset, null),
 					sync_capability: LOCAL_SYNC_CAPABILITY,
-				});
+				};
+				if (authorizedScopes !== null) {
+					response.authorized_scopes = authorizedScopes;
+				}
+				return c.json(response);
 			} catch {
 				return c.json({ error: "internal_error" }, 500);
 			}
@@ -2125,13 +2155,19 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 
 		try {
 			const rawScopeId = c.req.query(SYNC_SCOPE_QUERY_PARAM);
-			const scopeRequest = parseSyncScopeRequest(rawScopeId, rawScopeId !== undefined);
+			const negotiated = negotiatedSyncCapability(c);
+			const scopeRequest = parseSyncScopeRequest(rawScopeId, rawScopeId !== undefined, {
+				db: store.db,
+				negotiatedCapability: negotiated,
+				peerDeviceId,
+			});
 			if (!scopeRequest.ok) {
 				return c.json(
 					syncScopeResetRequiredPayload(
-						getSyncResetState(store.db),
+						getSyncResetState(store.db, rawScopeId ?? undefined),
 						scopeRequest.reason,
 						LOCAL_SYNC_CAPABILITY,
+						rawScopeId?.trim() || null,
 					),
 					409,
 				);
@@ -2154,6 +2190,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				generation: Number.isFinite(generation) ? generation : null,
 				snapshotId,
 				baselineCursor,
+				scopeId: scopeRequest.mode === "scoped" ? scopeRequest.scope_id : undefined,
 			});
 			if (result.reset_required) {
 				return c.json(
@@ -2230,13 +2267,19 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 
 			try {
 				const rawScopeId = c.req.query(SYNC_SCOPE_QUERY_PARAM);
-				const scopeRequest = parseSyncScopeRequest(rawScopeId, rawScopeId !== undefined);
+				const negotiated = negotiatedSyncCapability(c);
+				const scopeRequest = parseSyncScopeRequest(rawScopeId, rawScopeId !== undefined, {
+					db: store.db,
+					negotiatedCapability: negotiated,
+					peerDeviceId: auth.deviceId,
+				});
 				if (!scopeRequest.ok) {
 					return c.json(
 						syncScopeResetRequiredPayload(
-							getSyncResetState(store.db),
+							getSyncResetState(store.db, rawScopeId ?? undefined),
 							scopeRequest.reason,
 							LOCAL_SYNC_CAPABILITY,
+							rawScopeId?.trim() || null,
 						),
 						409,
 					);
@@ -2267,6 +2310,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 					pageToken,
 					limit,
 					peerDeviceId: auth.deviceId,
+					scopeId: scopeRequest.mode === "scoped" ? scopeRequest.scope_id : undefined,
 				});
 
 				return c.json({
@@ -2320,13 +2364,23 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			return c.json({ error: "invalid_json" }, 400);
 		}
 
-		const scopeRequest = parseSyncScopeRequest(body.scope_id, Object.hasOwn(body, "scope_id"));
+		const negotiated = negotiateSyncCapability(
+			LOCAL_SYNC_CAPABILITY,
+			normalizeSyncCapability(body.sync_capability),
+		);
+		const rawBodyScopeId = typeof body.scope_id === "string" ? body.scope_id : undefined;
+		const scopeRequest = parseSyncScopeRequest(body.scope_id, Object.hasOwn(body, "scope_id"), {
+			db: store.db,
+			negotiatedCapability: negotiated,
+			peerDeviceId,
+		});
 		if (!scopeRequest.ok) {
 			return c.json(
 				syncScopeResetRequiredPayload(
-					getSyncResetState(store.db),
+					getSyncResetState(store.db, rawBodyScopeId),
 					scopeRequest.reason,
 					LOCAL_SYNC_CAPABILITY,
+					rawBodyScopeId?.trim() || null,
 				),
 				409,
 			);
@@ -2352,10 +2406,6 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			}
 		}
 		const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
-		const negotiatedCapability = negotiateSyncCapability(
-			LOCAL_SYNC_CAPABILITY,
-			normalizeSyncCapability(body.sync_capability),
-		);
 		// Inbound POSTs still use legacy visibility/project filters, but must not run
 		// the outbound scope gate. Unsupported peers deliberately bypass strict inbound
 		// scope rejection during rollout, so outbound filtering would silently drop data.
@@ -2365,7 +2415,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		// Scope validation runs against the full signed batch so bad scoped ops cannot
 		// evade fail-closed rejection by also tripping peer project filters.
 		const rejected = rejectInboundScopeFailures(store.db, normalizedOps, localDeviceId, {
-			enabled: negotiatedCapability !== "unsupported",
+			enabled: negotiated !== "unsupported",
 			peerDeviceId,
 		});
 		if (rejected) {


### PR DESCRIPTION
## Description

Server side of the scoped sync protocol. viewer-server now accepts signed `scope_id` requests when both peers negotiate the new `scoped` sync capability, and advertises authorized scopes on `/v1/status` so the client can iterate them.

Core changes:

- `packages/core/src/sync-capability.ts`: add `scoped` capability (rank 3) and bump `LOCAL_SYNC_CAPABILITY`. Mixed-version pairs negotiate down to `aware` and preserve legacy default-scope behavior. Add `isScopedSyncCapability()` helper.
- `packages/core/src/sync-scope-protocol.ts`:
  - `parseSyncScopeRequest` now accepts a `(db, negotiatedCapability, peerDeviceId)` context. Scoped callers with active, current-epoch membership get `scoped` mode; others get `unsupported_scope` / `missing_scope` / `stale_epoch` / `scope_inactive` reasons.
  - Add `listAuthorizedScopesForPeer()` that intersects local and peer `scope_memberships` and returns each entry with its per-scope `sync_reset` boundary. Excludes `local-default` and scopes the peer is not an active member of.
  - `syncScopeResetRequiredPayload` now echoes the requested `scope_id` so clients learn which scope failed.
- `packages/viewer-server/src/routes/sync.ts`:
  - `GET /v1/status` emits `authorized_scopes` when caller negotiates `scoped`.
  - `GET /v1/ops` and `GET /v1/snapshot` thread `scope_id` from query into `loadReplicationOpsForPeer` / `loadMemorySnapshotPageForPeer`.
  - `POST /v1/ops` threads `body.scope_id` through the same validation.

## Wire compatibility

Legacy default-scope sync path is unchanged for peers that do not advertise `scoped` capability.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (13 new tests in sync-scope-protocol.test.ts + existing tests updated for `scoped` capability)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (design doc in PR 1)
- [x] No new warnings introduced

## Stack

PR 2/9 in the scoped-sync stack. Depends on the design doc PR.
