### PR TITLE
fix(ui): classify scope failures separately from two-way trust

### DIFF
--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -467,6 +467,82 @@ describe("summarizeSyncRunResult", () => {
 		});
 	});
 
+	it("routes scope_rejected failures to the Teams Space-access message", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-a",
+						ok: false,
+						error:
+							"all addresses failed | http://x: peer ops push failed (403: scope_rejected:stale_epoch)",
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+					},
+				],
+			}),
+		).toEqual({
+			ok: false,
+			message:
+				"Sync ran, but the peer is not authorized for one or more Spaces. Review Space access for this device in Teams, then sync again.",
+			warning: true,
+		});
+	});
+
+	it("routes scoped sync incomplete failures to the Teams Space-access message", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-a",
+						ok: false,
+						error: "scoped sync incomplete: oss=reset_required:missing_scope",
+						opsIn: 2,
+						opsOut: 0,
+						addressErrors: [],
+					},
+				],
+			}),
+		).toEqual({
+			ok: false,
+			message:
+				"Sync ran, but the peer is not authorized for one or more Spaces. Review Space access for this device in Teams, then sync again.",
+			warning: true,
+		});
+	});
+
+	it("falls back to the mixed-failure summary when trust and scope failures coexist", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-a",
+						ok: false,
+						error: "peer status failed (401: unauthorized)",
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+					},
+					{
+						peer_device_id: "peer-b",
+						ok: false,
+						error: "peer ops push failed (403: scope_rejected:stale_epoch)",
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+					},
+					{ peer_device_id: "peer-c", ok: true, opsIn: 1, opsOut: 1, addressErrors: [] },
+				],
+			}),
+		).toEqual({
+			ok: false,
+			message:
+				"2 of 3 device sync attempts failed. Open the affected device cards for the specific errors.",
+			warning: true,
+		});
+	});
+
 	it("surfaces outbound filter diagnostics without treating them as failed sync", () => {
 		expect(
 			summarizeSyncRunResult({

--- a/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
+++ b/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
@@ -94,16 +94,25 @@ export function summarizeSyncRunResult(payload: UiSyncRunResponse): {
 			warning: false,
 		};
 	}
-	const unauthorizedFailures = failedItems.filter(
-		(item) =>
-			cleanText(item.error).toLowerCase().includes("401") &&
-			cleanText(item.error).toLowerCase().includes("unauthorized"),
+	const unauthorizedFailures = failedItems.filter((item) =>
+		isTrustFailureError(cleanText(item.error)),
 	);
 	if (unauthorizedFailures.length === failedItems.length) {
 		return {
 			ok: false,
 			message:
 				"This device no longer has two-way trust with the peer. Pair it again from the other device, or remove the stale local record if it should be gone.",
+			warning: true,
+		};
+	}
+	const scopeFailures = failedItems.filter((item) =>
+		isScopeMembershipFailureError(cleanText(item.error)),
+	);
+	if (scopeFailures.length === failedItems.length) {
+		return {
+			ok: false,
+			message:
+				"Sync ran, but the peer is not authorized for one or more Spaces. Review Space access for this device in Teams, then sync again.",
 			warning: true,
 		};
 	}
@@ -120,6 +129,43 @@ export function summarizeSyncRunResult(payload: UiSyncRunResponse): {
 		message: error || "Sync failed for at least one device.",
 		warning: true,
 	};
+}
+
+/**
+ * True when a sync-failure error string looks like a two-way-trust failure
+ * (401 unauthorized on the peer's /v1/status), which is the only class of
+ * failure that should trigger the "no longer has two-way trust" toast. Any
+ * other class — connectivity, scope/membership, generation mismatch — flows
+ * through the generic mixed-failure or scoped paths so users do not get
+ * pointed at re-pairing for problems that re-pairing will not fix.
+ */
+function isTrustFailureError(error: string): boolean {
+	const lower = error.toLowerCase();
+	return lower.includes("401") && lower.includes("unauthorized");
+}
+
+/**
+ * True when a sync-failure error string indicates the peer is not authorized
+ * for a Space (or is authorized at a stale epoch). These failures map to the
+ * scoped-sync protocol classes documented in
+ * docs/plans/2026-05-25-scoped-sync-protocol.md:
+ *
+ * - `403: scope_rejected` from POST /v1/ops outbound scope filter.
+ * - `409: reset_required` with `reason=missing_scope` or `stale_epoch`
+ *   from GET /v1/ops or GET /v1/snapshot.
+ * - syncOneScope's `scoped sync incomplete: ...` aggregate string.
+ *
+ * Detection is intentionally substring-based because the wire reason can
+ * arrive embedded in a longer error string from the address-fallback loop.
+ */
+function isScopeMembershipFailureError(error: string): boolean {
+	const lower = error.toLowerCase();
+	if (lower.includes("scope_rejected")) return true;
+	if (lower.includes("missing_scope")) return true;
+	if (lower.includes("stale_epoch")) return true;
+	if (lower.includes("scope_inactive")) return true;
+	if (lower.includes("scoped sync incomplete")) return true;
+	return false;
 }
 
 function outboundFilterLabel(detail: UiSyncSkippedOutDetail | null): string {


### PR DESCRIPTION
## Description

Sync toast logic previously treated every "all addresses failed" result as a two-way-trust failure when the underlying errors matched `401 unauthorized`. With the new scoped sync paths shipping earlier in this stack, the same toast was firing on `403: scope_rejected:stale_epoch` and `409: reset_required:missing_scope` paths, telling users to re-pair when the actual problem was Space access in Teams.

`summarizeSyncRunResult` now classifies failures into three groups, ordered by specificity:

1. **Trust** (401 unauthorized for every failed item) — keeps the existing re-pairing copy.
2. **Scope/membership** (`scope_rejected` / `missing_scope` / `stale_epoch` / `scope_inactive` / `scoped sync incomplete`) — surfaces a new toast that points users at "Review Space access for this device in Teams, then sync again." Avoids the destructive suggestion to remove the local peer record for what is actually a recoverable access problem.
3. **Mixed** — falls through to the existing "N of M sync attempts failed" summary that routes users to per-device cards.

Helpers `isTrustFailureError` and `isScopeMembershipFailureError` make the classification explicit and unit-testable. Substring matching is intentional because the wire error often arrives wrapped in the address-fallback loop's aggregate string. A structured-failure follow-up is filed separately.

Tests added in `view-model.test.ts` cover the new scope branch on a single peer, on a `scoped sync incomplete` aggregate, and on a mixed trust+scope batch that must NOT classify as either single class.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (n/a — UI fix)
- [x] No new warnings introduced

## Stack

PR 6/9 in the scoped-sync stack. Depends on the per-Space status PR.
