### PR TITLE
fix(sync): address scoped sync review findings

### DIFF
--- a/docs/plans/2026-05-25-scoped-sync-postmortem.md
+++ b/docs/plans/2026-05-25-scoped-sync-postmortem.md
@@ -43,7 +43,7 @@ Several factors combined to mask the regression:
 - **`parseSyncScopeRequest` had a test for `unsupported_scope`.** The very behavior that broke the regression was asserted as the correct behavior, because the test was written when the comment "per-scope cursors land in later ov4g.4 slices" was current. The "later slice" never landed but the test was never revisited.
 - **`codemem sync status` had no per-Space surface.** The aggregate `last_sync=ok` per peer was indistinguishable from "all Spaces synced," so neither dogfood operators nor automated checks could tell the difference between "295 of 295 default rows synced" and "295 of 18,511 expected rows synced."
 - **Health stats counted only visible rows.** The 295 active number on the Docker peer matched the receiver's visible rows exactly, which looked plausible because the user had no expectation of a specific count. The number was correct by its own definition while still being deeply wrong relative to the source's corpus.
-- **The codemem-ov4g epic was closed as complete.** Child beads ov4g.4.1 through ov4g.4.9 were each closed individually with their own tests passing, and the parent epic was closed on that basis without a verification that the user-visible "Spaces replicate when you pair a new device" workflow worked end to end.
+- **codemem-ov4g was closed without an end-to-end verification by the bead owner (@kunickiaj).** Child beads ov4g.4.1 through ov4g.4.9 each landed with their own unit tests green, and the epic was signed off on that basis. There was no "drive `syncOnce` against a real multi-Space source, confirm the receiver gets the data" check on the way to close. The cultural pattern — assume the epic is correct because the children are green — is structurally fragile when a child explicitly leaves wire functionality unimplemented behind a comment.
 
 ## Fix shape (codemem-ruu6)
 
@@ -68,9 +68,9 @@ To prevent the same shape of regression from recurring on future protocol work:
 
 ## Validation
 
-- 2134 automated tests pass on the ruu6 stack tip.
-- `codemem sync status` on a scoped peer now lists per-Space progress with synced/pending state.
-- Manual >=10k-row dogfood verification scheduled before promoting 0.33 from alpha to stable (codemem-ruu6.8).
+- 2135 automated tests pass on the ruu6 stack tip, including a "bulk transfer canary" that asserts the receiver actually gets the source's scoped rows. The original regression had a stark fingerprint — source 24,378 / receiver 295 — and this canary catches that shape at small scale before it hits dogfood.
+- `codemem sync status` on a scoped peer now lists per-Space progress with synced/pending state. The CLI and `/api/sync/*` payloads share one helper (`listPerPeerScopeSyncState`) so the two surfaces cannot drift apart.
+- Manual >=10k-row dogfood verification is a HARD GATE on promoting 0.33 from alpha to stable. The bead codemem-ruu6.8 records that gate; stable does not ship until ruu6.8 reports green with per-scope row counts captured on source and receiver. "Scheduled" is the same hedging that let ov4g close — stable is BLOCKED, not "pending."
 
 ## References
 

--- a/docs/plans/2026-05-25-scoped-sync-protocol.md
+++ b/docs/plans/2026-05-25-scoped-sync-protocol.md
@@ -110,7 +110,7 @@ Server population rule:
   - The caller (peer-authenticated device id) has an active membership.
   - `authority_type` is `coordinator`, or the scope is a personal scope explicitly granted to the caller (`personal_scope_grants`).
 - Exclude scopes where `authority_type = 'local'` and there is no personal grant. Those are never replicated.
-- Include `local-default` only if the caller is in the legacy-default cohort (always-on backward compat).
+- Do not include `local-default` in `authorized_scopes`. Scoped-capable peers still run the legacy no-`scope_id` pass for default-scope data before iterating explicit Spaces, so listing `local-default` here would duplicate the same rows through a second path.
 - Each entry carries the scope's per-scope reset boundary (`sync_reset_state_v2` row for that scope_id).
 
 This is a single round trip. No separate `/v1/scopes` endpoint. A separate endpoint adds an extra signed request without changing behavior; folding the data into `/v1/status` is simpler and matches existing usage.
@@ -149,8 +149,8 @@ Under scoped sync:
 
 `local-default` is the implicit "everyone" bucket for unscoped memories that predate Spaces. Under scoped sync:
 
-- `/v1/status` always lists `local-default` in `authorized_scopes` if both peers are sync-paired.
-- Bootstrap for `local-default` uses the existing default-scope query path (`scope_id IS NULL OR scope_id = 'local-default'`).
+- `/v1/status` does not list `local-default` in `authorized_scopes`.
+- Bootstrap and incremental sync for `local-default` use the existing legacy no-`scope_id` query path (`scope_id IS NULL OR scope_id = 'local-default'`).
 - This preserves backward-compat behavior for the 295 default-scope rows in current dogfood DBs.
 
 ## Client behavior
@@ -161,7 +161,8 @@ Under scoped sync:
 2. If legacy peer (no `scoped_sync_v1`):
    - Same path as today: single default-scope bootstrap or incremental, no scope_id.
 3. If scoped peer:
-   - For each scope in `authorized_scopes`:
+   - Run the legacy default-scope path once with no `scope_id`.
+   - For each explicit Space in `authorized_scopes`:
      - Look up local `(peer_device_id, scope_id)` cursor in `replication_cursors_v2`.
      - If no cursor and no local scoped rows: bootstrap that scope via `/v1/snapshot?scope_id=X`.
      - Else: incremental `/v1/ops?scope_id=X&since=<cursor>&generation=G&snapshot_id=S&baseline_cursor=C`.

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -16,10 +16,9 @@ import {
 	ensureDeviceIdentity,
 	fetchAllSnapshotPages,
 	fingerprintPublicKey,
-	getReplicationCursor,
 	getSemanticIndexDiagnostics,
 	hasUnsyncedSharedMemoryChanges,
-	listAuthorizedScopesForPeer,
+	listPerPeerScopeSyncState,
 	loadPublicKey,
 	MemoryStore,
 	mdnsEnabled,
@@ -813,37 +812,18 @@ statusCmd.action((opts: { db?: string; dbPath?: string; config?: string; json?: 
 			.all();
 		const semanticIndex = getSemanticIndexDiagnostics(store.db);
 
-		// Per-Space sync state per peer. When the local device knows what
-		// scopes both it and the peer are authorized to sync, enumerate them
-		// and pair each with the per-scope replication cursor so users can see
-		// whether each Space has actually started syncing yet. This is the
-		// surface that closes the codemem-ruu6 regression where peers showed
-		// `status=ok` while 99% of scoped data was silently missing.
+		// Per-Space sync state per peer. Uses the shared
+		// `listPerPeerScopeSyncState` helper so this surface stays byte-for-byte
+		// consistent with the viewer's /api/sync/status payload — they are the
+		// two surfaces that close the codemem-ruu6 diagnostic gap where peers
+		// showed `status=ok` while 99% of scoped data was silently missing.
 		const localDeviceId = deviceRow?.device_id ?? null;
 		const peersWithScopes = peers.map((peer) => {
 			const peerDeviceId = String(peer.peer_device_id ?? "").trim();
-			const scopes =
-				localDeviceId && peerDeviceId
-					? listAuthorizedScopesForPeer(store.db, {
-							localDeviceId,
-							peerDeviceId,
-						}).map((scope) => {
-							const [lastApplied, lastAcked] = getReplicationCursor(
-								store.db,
-								peerDeviceId,
-								scope.scope_id,
-							);
-							return {
-								scope_id: scope.scope_id,
-								label: scope.label,
-								authority_type: scope.authority_type,
-								membership_epoch: scope.membership_epoch,
-								last_applied_cursor: lastApplied,
-								last_acked_cursor: lastAcked,
-								bootstrapped: lastApplied != null,
-							};
-						})
-					: [];
+			const scopes = listPerPeerScopeSyncState(store.db, {
+				localDeviceId,
+				peerDeviceId,
+			});
 			return { peer, scopes };
 		});
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -626,6 +626,7 @@ export {
 export { SyncRetentionRunner } from "./sync-retention-runner.js";
 export type {
 	AuthorizedScopeEntry,
+	PerPeerScopeSyncEntry,
 	SyncScopeRequest,
 	SyncScopeRequestMode,
 	SyncScopeResetReason,
@@ -633,6 +634,7 @@ export type {
 export {
 	addSyncScopeToBoundary,
 	listAuthorizedScopesForPeer,
+	listPerPeerScopeSyncState,
 	parseSyncScopeRequest,
 	SYNC_SCOPE_QUERY_PARAM,
 	scopeAuthorizationFailureReason,

--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -666,7 +666,7 @@ describe("syncOnce", () => {
 		// because no default-scope ops were returned.
 		for (const scope_id of scopes) {
 			const [lastApplied] = syncReplication.getReplicationCursor(db, "peer-multi", scope_id);
-			expect(lastApplied).not.toBeNull();
+			expect(lastApplied).toBe(`2026-01-01T00:00:00Z|baseline-${scope_id}`);
 		}
 		expect(syncReplication.getReplicationCursor(db, "peer-multi")).toEqual([
 			"2025-12-31T00:00:00Z|local-op-0",
@@ -910,6 +910,96 @@ describe("syncOnce", () => {
 		// Per-scope cursor advanced to the scoped next_cursor.
 		expect(syncReplication.getReplicationCursor(db, "peer-cursor", "acme-work")).toEqual([
 			"2026-02-01T00:00:00Z|acme-op-1",
+			null,
+		]);
+	});
+
+	it("clears a stale per-scope cursor after scoped reset_required", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-reset", "fp-reset", new Date().toISOString());
+		syncReplication.setReplicationCursor(db, "peer-reset", {
+			lastApplied: "2025-12-31T00:00:00Z|default-baseline",
+		});
+		syncReplication.setReplicationCursor(
+			db,
+			"peer-reset",
+			{ lastApplied: "2025-12-31T00:00:00Z|stale-acme" },
+			"acme-work",
+		);
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		grantScopeForSyncPass(db, "acme-work", ["peer-reset", "local-device-id"]);
+
+		vi.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: "fp-reset",
+					protocol_version: "2",
+					sync_capability: "scoped",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-default",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+					authorized_scopes: [
+						{
+							scope_id: "acme-work",
+							label: "acme-work",
+							authority_type: "coordinator",
+							membership_epoch: 1,
+							sync_reset: {
+								scope_id: "acme-work",
+								generation: 2,
+								snapshot_id: "snap-acme-2",
+								baseline_cursor: "2026-01-01T00:00:00Z|baseline-acme",
+								retained_floor_cursor: null,
+							},
+						},
+					],
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-default",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [],
+					next_cursor: null,
+					skipped: 0,
+				},
+			])
+			.mockResolvedValueOnce([
+				409,
+				{
+					reset_required: true,
+					reason: "stale_cursor",
+					scope_id: "acme-work",
+					generation: 2,
+					snapshot_id: "snap-acme-2",
+					baseline_cursor: "2026-01-01T00:00:00Z|baseline-acme",
+					retained_floor_cursor: null,
+				},
+			]);
+
+		const result = await syncOnce(db, "peer-reset", ["http://127.0.0.1:9090"]);
+
+		expect(result.ok).toBe(false);
+		expect(result.perScopeResults?.[0]).toMatchObject({
+			scope_id: "acme-work",
+			ok: false,
+			error: "reset_required:stale_cursor",
+		});
+		expect(syncReplication.getReplicationCursor(db, "peer-reset", "acme-work")).toEqual([
+			null,
 			null,
 		]);
 	});

--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -674,6 +674,133 @@ describe("syncOnce", () => {
 		]);
 	});
 
+	it("canary: bulk of source rows reach a fresh peer across multiple Spaces (ruu6.7)", async () => {
+		// Cheap regression canary for the codemem-ruu6 bug shape — source has
+		// many rows across multiple Spaces, fresh peer should receive almost
+		// all of them (modulo any in scopes the peer is not a member of). The
+		// original regression had a stark fingerprint: source had ~24k rows,
+		// receiver got exactly 295. A "did the bulk transfer?" assertion
+		// would have caught it. This test enforces that floor at a small
+		// scale so any future protocol drift that silently filters out a
+		// whole class of rows trips here, not in dogfood.
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-canary", "fp-canary", new Date().toISOString());
+		db.prepare(
+			"INSERT INTO replication_cursors (peer_device_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?)",
+		).run("peer-canary", "2025-12-31T00:00:00Z|local-op-0", null, new Date().toISOString());
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		grantScopeForSyncPass(db, "alpha", ["peer-canary", "local-device-id"]);
+		grantScopeForSyncPass(db, "beta", ["peer-canary", "local-device-id"]);
+		grantScopeForSyncPass(db, "gamma", ["peer-canary", "local-device-id"]);
+
+		const scopes = ["alpha", "beta", "gamma"] as const;
+		const itemsPerScope = 12;
+		const expectedTotal = scopes.length * itemsPerScope;
+
+		const statusResponse = {
+			fingerprint: "fp-canary",
+			protocol_version: "2",
+			sync_capability: "scoped",
+			sync_reset: {
+				generation: 1,
+				snapshot_id: "snap-default",
+				baseline_cursor: null,
+				retained_floor_cursor: null,
+			},
+			authorized_scopes: scopes.map((scope_id) => ({
+				scope_id,
+				label: scope_id,
+				authority_type: "coordinator",
+				membership_epoch: 1,
+				sync_reset: {
+					scope_id,
+					generation: 1,
+					snapshot_id: `snap-${scope_id}`,
+					baseline_cursor: `2026-01-01T00:00:00Z|baseline-${scope_id}`,
+					retained_floor_cursor: null,
+				},
+			})),
+		};
+		const defaultOpsResponse = {
+			reset_required: false,
+			generation: 1,
+			snapshot_id: "snap-default",
+			baseline_cursor: null,
+			retained_floor_cursor: null,
+			ops: [],
+			next_cursor: null,
+			skipped: 0,
+		};
+
+		const calls = [statusResponse, defaultOpsResponse] as Record<string, unknown>[];
+		for (const scope_id of scopes) {
+			calls.push({
+				scope_id,
+				generation: 1,
+				snapshot_id: `snap-${scope_id}`,
+				baseline_cursor: `2026-01-01T00:00:00Z|baseline-${scope_id}`,
+				retained_floor_cursor: null,
+				sync_capability: "scoped",
+				items: Array.from({ length: itemsPerScope }, (_, i) => ({
+					entity_id: `key:${scope_id}-${i + 1}`,
+					op_type: "upsert",
+					payload_json: JSON.stringify({
+						kind: "discovery",
+						title: `${scope_id} item ${i + 1}`,
+						body_text: `Body ${scope_id} ${i + 1}`,
+						active: 1,
+						created_at: "2026-01-01T00:00:00Z",
+						updated_at: "2026-01-01T00:00:00Z",
+						scope_id,
+						visibility: "shared",
+					}),
+					clock_rev: 1,
+					clock_updated_at: "2026-01-01T00:00:00Z",
+					clock_device_id: "peer-canary",
+				})),
+				next_page_token: null,
+				has_more: false,
+			});
+		}
+
+		const spy = vi.spyOn(syncHttpClient, "requestJson");
+		for (const call of calls) spy.mockResolvedValueOnce([200, call]);
+
+		const result = await syncOnce(db, "peer-canary", ["http://127.0.0.1:9090"]);
+
+		expect(result.ok).toBe(true);
+		// Bulk-transfer canary: count rows the peer received from the source.
+		// The original codemem-ruu6 regression failed this with a 295-row
+		// receiver against a multi-Space source. Allow zero tolerance because
+		// these are synthetic fixtures; in dogfood the bar is "within
+		// tombstone tolerance" per the protocol doc.
+		const receivedCount = (
+			db
+				.prepare(
+					"SELECT count(*) AS n FROM memory_items WHERE import_key IS NOT NULL AND scope_id IN ('alpha','beta','gamma')",
+				)
+				.get() as { n: number }
+		).n;
+		expect(receivedCount).toBe(expectedTotal);
+		// And the per-Space breakdown matches; no Space accidentally got
+		// short-changed.
+		for (const scope_id of scopes) {
+			const perScope = (
+				db
+					.prepare(
+						"SELECT count(*) AS n FROM memory_items WHERE import_key IS NOT NULL AND scope_id = ?",
+					)
+					.get(scope_id) as { n: number }
+			).n;
+			expect(perScope).toBe(itemsPerScope);
+		}
+	});
+
 	it("keeps default-scope and per-scope cursors independent after scoped incremental sync", async () => {
 		// Seeds an incremental scoped pass and asserts the per-scope cursor is
 		// advanced via `replication_cursors_v2(peer, scope_id)` while the

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -28,6 +28,7 @@ import {
 	applyReplicationOps,
 	backfillReplicationOps,
 	chunkOpsBySize,
+	clearReplicationCursorLastApplied,
 	extractReplicationOps,
 	type FilterReplicationSkipped,
 	filterReplicationOpsForSyncWithStatus,
@@ -653,11 +654,12 @@ async function syncOneScope(
 		const [status, payload] = await requestJson("GET", url, { headers });
 
 		if (status === 409 && payload?.reset_required === true) {
-			// Per-scope reset requested. Report it; the next pass will pick a
-			// fresh bootstrap path because the cursor will be cleared by the
-			// reset boundary. We deliberately do not auto-bootstrap from here
+			// Per-scope reset requested. Clear the stale scoped cursor so the
+			// next pass picks a fresh bootstrap path instead of replaying the
+			// same invalid boundary forever. We deliberately do not auto-bootstrap from here
 			// to avoid surprising state changes mid-loop; the default-scope
 			// auto-bootstrap path remains the canonical recovery mechanism.
+			clearReplicationCursorLastApplied(db, peerDeviceId, scopeId);
 			const reason = ((): SyncResetRequired["reason"] => {
 				switch (payload.reason) {
 					case "generation_mismatch":

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -343,14 +343,6 @@ function loadLocalOpsSince(
 	return [rows, nextCursor];
 }
 
-/**
- * Compute a cursor string from a timestamp and op_id.
- * Currently unused — will be needed when real apply logic advances the cursor.
- */
-export function computeCursor(createdAt: string, opId: string): string {
-	return `${createdAt}|${opId}`;
-}
-
 // ---------------------------------------------------------------------------
 // Push ops
 // ---------------------------------------------------------------------------
@@ -583,6 +575,24 @@ async function syncOneScope(
 				keysDir,
 				pageSize: BOOTSTRAP_PAGE_SIZE,
 			});
+			// TOCTOU re-check: another process (CLI write, plugin, concurrent
+			// sync pass) could have created shared memories in this scope while
+			// the snapshot was downloading. applyBootstrapSnapshot wipes all
+			// shared rows for the scope before inserting the snapshot, so
+			// proceeding would clobber those writes. Mirror the same guard the
+			// default-scope auto-bootstrap path already enforces in syncOnce
+			// (see "needs_attention:shared_memories_appeared_during_bootstrap").
+			if (hasLocalRowsInScope(db, scopeId)) {
+				return {
+					scope_id: scopeId,
+					label: scope.label,
+					ok: false,
+					opsIn: 0,
+					opsOut: 0,
+					error: "needs_attention:shared_memories_appeared_during_bootstrap",
+					bootstrapped: true,
+				};
+			}
 			const bootstrapResult = applyBootstrapSnapshot(db, peerDeviceId, items, resetInfo, scanner);
 			if (!bootstrapResult.ok) {
 				return {

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -642,6 +642,33 @@ export function setReplicationCursor(
 	}
 }
 
+export function clearReplicationCursorLastApplied(
+	db: Database,
+	peerDeviceId: string,
+	scopeId?: string | null,
+): void {
+	ensureReplicationCursorTables(db);
+	const now = new Date().toISOString();
+	const effectiveScopeId = normalizeSyncStateScopeId(scopeId);
+	drizzle(db, { schema })
+		.insert(schema.replicationCursorsV2)
+		.values({
+			peer_device_id: peerDeviceId,
+			scope_id: effectiveScopeId,
+			last_applied_cursor: null,
+			last_acked_cursor: null,
+			updated_at: now,
+		})
+		.onConflictDoUpdate({
+			target: [schema.replicationCursorsV2.peer_device_id, schema.replicationCursorsV2.scope_id],
+			set: {
+				last_applied_cursor: null,
+				updated_at: sql`excluded.updated_at`,
+			},
+		})
+		.run();
+}
+
 // Payload extraction
 
 /**

--- a/packages/core/src/sync-scope-protocol.test.ts
+++ b/packages/core/src/sync-scope-protocol.test.ts
@@ -146,6 +146,7 @@ describe("parseSyncScopeRequest scoped path", () => {
 		grantMembership(SCOPE_ID, PEER_DEVICE);
 		const result = parseSyncScopeRequest(SCOPE_ID, true, {
 			db,
+			localDeviceId: LOCAL_DEVICE,
 			negotiatedCapability: "scoped",
 			peerDeviceId: PEER_DEVICE,
 		});
@@ -155,6 +156,7 @@ describe("parseSyncScopeRequest scoped path", () => {
 	it("rejects with missing_scope when the scope does not exist", () => {
 		const result = parseSyncScopeRequest("does-not-exist", true, {
 			db,
+			localDeviceId: LOCAL_DEVICE,
 			negotiatedCapability: "scoped",
 			peerDeviceId: PEER_DEVICE,
 		});
@@ -167,6 +169,20 @@ describe("parseSyncScopeRequest scoped path", () => {
 		// Peer not granted.
 		const result = parseSyncScopeRequest(SCOPE_ID, true, {
 			db,
+			localDeviceId: LOCAL_DEVICE,
+			negotiatedCapability: "scoped",
+			peerDeviceId: PEER_DEVICE,
+		});
+		expect(result).toEqual({ ok: false, reason: "missing_scope" });
+	});
+
+	it("rejects with missing_scope when local device is not a member", () => {
+		insertScope(SCOPE_ID);
+		grantMembership(SCOPE_ID, PEER_DEVICE);
+		// Local device not granted; peer membership alone is not enough.
+		const result = parseSyncScopeRequest(SCOPE_ID, true, {
+			db,
+			localDeviceId: LOCAL_DEVICE,
 			negotiatedCapability: "scoped",
 			peerDeviceId: PEER_DEVICE,
 		});
@@ -179,6 +195,7 @@ describe("parseSyncScopeRequest scoped path", () => {
 		grantMembership(SCOPE_ID, PEER_DEVICE, { membershipEpoch: 3 });
 		const result = parseSyncScopeRequest(SCOPE_ID, true, {
 			db,
+			localDeviceId: LOCAL_DEVICE,
 			negotiatedCapability: "scoped",
 			peerDeviceId: PEER_DEVICE,
 		});
@@ -191,6 +208,7 @@ describe("parseSyncScopeRequest scoped path", () => {
 		grantMembership(SCOPE_ID, PEER_DEVICE, { status: "revoked" });
 		const result = parseSyncScopeRequest(SCOPE_ID, true, {
 			db,
+			localDeviceId: LOCAL_DEVICE,
 			negotiatedCapability: "scoped",
 			peerDeviceId: PEER_DEVICE,
 		});
@@ -203,6 +221,7 @@ describe("parseSyncScopeRequest scoped path", () => {
 		grantMembership(SCOPE_ID, PEER_DEVICE);
 		const result = parseSyncScopeRequest(SCOPE_ID, true, {
 			db,
+			localDeviceId: LOCAL_DEVICE,
 			negotiatedCapability: "aware",
 			peerDeviceId: PEER_DEVICE,
 		});

--- a/packages/core/src/sync-scope-protocol.ts
+++ b/packages/core/src/sync-scope-protocol.ts
@@ -7,7 +7,11 @@ import {
 	getCachedScopeAuthorization,
 } from "./scope-membership-cache.js";
 import { isScopedSyncCapability, type SyncCapability } from "./sync-capability.js";
-import { DEFAULT_SYNC_SCOPE_ID, getSyncResetState } from "./sync-replication.js";
+import {
+	DEFAULT_SYNC_SCOPE_ID,
+	getReplicationCursor,
+	getSyncResetState,
+} from "./sync-replication.js";
 
 export const SYNC_SCOPE_QUERY_PARAM = "scope_id";
 
@@ -246,4 +250,50 @@ export function listAuthorizedScopesForPeer(
 
 	entries.sort((a, b) => a.scope_id.localeCompare(b.scope_id));
 	return entries;
+}
+
+/**
+ * Per-Space sync state for a given peer, suitable for both the CLI status
+ * display and the `/api/sync/status` / `/api/sync/peers` viewer payload.
+ *
+ * Renders the intersection of local + peer scope memberships against the
+ * per-scope cursor state stored in `replication_cursors_v2`. Consumers use
+ * this surface to show "synced / pending" per Space instead of the legacy
+ * peer-level `last_sync=ok`, which is the diagnostic gap that hid the
+ * codemem-ruu6 regression while ~18k scoped rows silently failed to
+ * replicate.
+ *
+ * Returns an empty array when local device identity has not yet been
+ * initialized or when there is no membership overlap.
+ */
+export interface PerPeerScopeSyncEntry {
+	scope_id: string;
+	label: string;
+	authority_type: string;
+	membership_epoch: number;
+	last_applied_cursor: string | null;
+	last_acked_cursor: string | null;
+	bootstrapped: boolean;
+}
+
+export function listPerPeerScopeSyncState(
+	db: Database,
+	options: { localDeviceId: string | null; peerDeviceId: string },
+): PerPeerScopeSyncEntry[] {
+	const localDeviceId = options.localDeviceId?.trim() ?? "";
+	const peerDeviceId = options.peerDeviceId.trim();
+	if (!localDeviceId || !peerDeviceId) return [];
+	const scopes = listAuthorizedScopesForPeer(db, { localDeviceId, peerDeviceId });
+	return scopes.map((scope) => {
+		const [lastApplied, lastAcked] = getReplicationCursor(db, peerDeviceId, scope.scope_id);
+		return {
+			scope_id: scope.scope_id,
+			label: scope.label,
+			authority_type: scope.authority_type,
+			membership_epoch: scope.membership_epoch,
+			last_applied_cursor: lastApplied,
+			last_acked_cursor: lastAcked,
+			bootstrapped: lastApplied != null,
+		};
+	});
 }

--- a/packages/core/src/sync-scope-protocol.ts
+++ b/packages/core/src/sync-scope-protocol.ts
@@ -51,8 +51,9 @@ export interface SyncResetBoundaryShape {
  * responses anyway.
  *
  * Scoped callers (`negotiatedCapability === "scoped"`) may pass a scope_id.
- * The server verifies the calling peer is an active, current-epoch member of
- * the requested scope before accepting. Failed authorization maps to wire
+ * The server verifies both the local device and the calling peer are active,
+ * current-epoch members of the requested scope before accepting. Failed
+ * authorization maps to wire
  * reasons that the client can act on:
  * - `missing_scope`: scope unknown, inactive, or caller is not a member.
  * - `stale_epoch`: caller membership exists but epoch is behind authority.
@@ -66,6 +67,7 @@ export function parseSyncScopeRequest(
 	provided: boolean,
 	context?: {
 		db?: Database;
+		localDeviceId?: string | null;
 		negotiatedCapability?: SyncCapability;
 		peerDeviceId?: string | null;
 	},
@@ -88,11 +90,21 @@ export function parseSyncScopeRequest(
 	}
 
 	const db = context.db;
+	const localDeviceId = context.localDeviceId?.trim();
 	const peerDeviceId = context.peerDeviceId?.trim();
-	if (!db || !peerDeviceId) {
+	if (!db || !localDeviceId || !peerDeviceId) {
 		// Caller advertised scoped capability but the route did not thread
 		// the authentication context through. Fail closed.
 		return { ok: false, reason: "missing_scope" };
+	}
+
+	const localAuthorization = getCachedScopeAuthorization(db, {
+		deviceId: localDeviceId,
+		scopeId,
+	});
+	const localErrorReason = scopeAuthorizationFailureReason(localAuthorization);
+	if (localErrorReason) {
+		return { ok: false, reason: localErrorReason };
 	}
 
 	const authorization = getCachedScopeAuthorization(db, {
@@ -122,8 +134,6 @@ export function scopeAuthorizationFailureReason(
 		case "revoked":
 		case "scope_inactive":
 			return "scope_inactive";
-		case "scope_unknown":
-		case "not_authorized":
 		default:
 			return "missing_scope";
 	}

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -512,6 +512,27 @@ describe("summarizeSyncRunResult", () => {
 		});
 	});
 
+	it("keeps non-membership scoped sync incomplete failures generic", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-a",
+						ok: false,
+						error: "scoped sync incomplete: oss=peer scoped ops fetch failed (503: unavailable)",
+						opsIn: 2,
+						opsOut: 0,
+						addressErrors: [],
+					},
+				],
+			}),
+		).toEqual({
+			ok: false,
+			message: "scoped sync incomplete: oss=peer scoped ops fetch failed (503: unavailable)",
+			warning: true,
+		});
+	});
+
 	it("falls back to the mixed-failure summary when trust and scope failures coexist", () => {
 		expect(
 			summarizeSyncRunResult({

--- a/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
+++ b/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
@@ -153,7 +153,8 @@ function isTrustFailureError(error: string): boolean {
  * - `403: scope_rejected` from POST /v1/ops outbound scope filter.
  * - `409: reset_required` with `reason=missing_scope` or `stale_epoch`
  *   from GET /v1/ops or GET /v1/snapshot.
- * - syncOneScope's `scoped sync incomplete: ...` aggregate string.
+ * - syncOneScope's aggregate string only when it includes one of those wire
+ *   reasons. Other scoped-sync failures remain generic sync failures.
  *
  * Detection is intentionally substring-based because the wire reason can
  * arrive embedded in a longer error string from the address-fallback loop.
@@ -164,7 +165,6 @@ function isScopeMembershipFailureError(error: string): boolean {
 	if (lower.includes("missing_scope")) return true;
 	if (lower.includes("stale_epoch")) return true;
 	if (lower.includes("scope_inactive")) return true;
-	if (lower.includes("scoped sync incomplete")) return true;
 	return false;
 }
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -3952,8 +3952,11 @@ describe("viewer-server", () => {
 					reset_required: true,
 					sync_capability: "scoped",
 					reason: "unsupported_scope",
-					scope_id: "acme-work",
+					scope_id: null,
 				});
+				expect(
+					store.db.prepare("SELECT 1 FROM sync_reset_state_v2 WHERE scope_id = ?").get("acme-work"),
+				).toBeUndefined();
 			} finally {
 				peer?.cleanup();
 				cleanup();
@@ -3979,7 +3982,7 @@ describe("viewer-server", () => {
 					reset_required: true,
 					sync_capability: "scoped",
 					reason: "unsupported_scope",
-					scope_id: "acme-work",
+					scope_id: null,
 				});
 			} finally {
 				peer?.cleanup();
@@ -4039,7 +4042,7 @@ describe("viewer-server", () => {
 					reset_required: true,
 					sync_capability: "scoped",
 					reason: "unsupported_scope",
-					scope_id: "acme-work",
+					scope_id: null,
 				});
 			} finally {
 				peer?.cleanup();
@@ -4072,7 +4075,7 @@ describe("viewer-server", () => {
 					reset_required: true,
 					sync_capability: "scoped",
 					reason: "unsupported_scope",
-					scope_id: "acme-work",
+					scope_id: null,
 				});
 			} finally {
 				peer?.cleanup();
@@ -4141,7 +4144,7 @@ describe("viewer-server", () => {
 					reset_required: true,
 					sync_capability: "scoped",
 					reason: "unsupported_scope",
-					scope_id: "acme-work",
+					scope_id: null,
 				});
 			} finally {
 				peer?.cleanup();

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -2167,18 +2167,20 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		try {
 			const rawScopeId = c.req.query(SYNC_SCOPE_QUERY_PARAM);
 			const negotiated = negotiatedSyncCapability(c);
+			const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 			const scopeRequest = parseSyncScopeRequest(rawScopeId, rawScopeId !== undefined, {
 				db: store.db,
+				localDeviceId,
 				negotiatedCapability: negotiated,
 				peerDeviceId,
 			});
 			if (!scopeRequest.ok) {
 				return c.json(
 					syncScopeResetRequiredPayload(
-						getSyncResetState(store.db, rawScopeId ?? undefined),
+						getSyncResetState(store.db),
 						scopeRequest.reason,
 						LOCAL_SYNC_CAPABILITY,
-						rawScopeId?.trim() || null,
+						null,
 					),
 					409,
 				);
@@ -2193,7 +2195,6 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			const snapshotId = c.req.query("snapshot_id") ?? null;
 			const baselineCursor = c.req.query("baseline_cursor") ?? null;
 			const limit = Number.isFinite(rawLimit) ? Math.max(1, Math.min(rawLimit, 1000)) : 200;
-			const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 			const result = loadReplicationOpsForPeer(store.db, {
 				since,
 				limit,
@@ -2279,18 +2280,20 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			try {
 				const rawScopeId = c.req.query(SYNC_SCOPE_QUERY_PARAM);
 				const negotiated = negotiatedSyncCapability(c);
+				const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 				const scopeRequest = parseSyncScopeRequest(rawScopeId, rawScopeId !== undefined, {
 					db: store.db,
+					localDeviceId,
 					negotiatedCapability: negotiated,
 					peerDeviceId: auth.deviceId,
 				});
 				if (!scopeRequest.ok) {
 					return c.json(
 						syncScopeResetRequiredPayload(
-							getSyncResetState(store.db, rawScopeId ?? undefined),
+							getSyncResetState(store.db),
 							scopeRequest.reason,
 							LOCAL_SYNC_CAPABILITY,
-							rawScopeId?.trim() || null,
+							null,
 						),
 						409,
 					);
@@ -2379,19 +2382,20 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			LOCAL_SYNC_CAPABILITY,
 			normalizeSyncCapability(body.sync_capability),
 		);
-		const rawBodyScopeId = typeof body.scope_id === "string" ? body.scope_id : undefined;
+		const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 		const scopeRequest = parseSyncScopeRequest(body.scope_id, Object.hasOwn(body, "scope_id"), {
 			db: store.db,
+			localDeviceId,
 			negotiatedCapability: negotiated,
 			peerDeviceId,
 		});
 		if (!scopeRequest.ok) {
 			return c.json(
 				syncScopeResetRequiredPayload(
-					getSyncResetState(store.db, rawBodyScopeId),
+					getSyncResetState(store.db),
 					scopeRequest.reason,
 					LOCAL_SYNC_CAPABILITY,
-					rawBodyScopeId?.trim() || null,
+					null,
 				),
 				409,
 			);
@@ -2416,7 +2420,6 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				);
 			}
 		}
-		const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 		// Inbound POSTs still use legacy visibility/project filters, but must not run
 		// the outbound scope gate. Unsupported peers deliberately bypass strict inbound
 		// scope rejection during rollout, so outbound filtering would silently drop data.

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -57,7 +57,6 @@ import {
 	fingerprintPublicKey,
 	formatHostPort,
 	getCoordinatorGroupPreference,
-	getReplicationCursor,
 	getSemanticIndexDiagnostics,
 	getSyncResetState,
 	type InboundScopeRejectionPeerSummary,
@@ -69,6 +68,7 @@ import {
 	listCoordinatorJoinRequests,
 	listInboundScopeRejections,
 	listMaintenanceJobs,
+	listPerPeerScopeSyncState,
 	listProjectScopeCandidates,
 	listProjectScopeInventory,
 	listProjectScopeSettingsMappings,
@@ -1432,7 +1432,10 @@ function mapPeerRow(
 	const recentOps = recentOpsByPeer?.get(peerId) ?? { in: 0, out: 0 };
 	const scopeRejections = scopeRejectionsByPeer?.get(peerId);
 	const addresses = safeJsonList(row.addresses_json as string | null);
-	const perScopeSync = perPeerScopeSyncState(store, peerId, localDeviceId ?? null);
+	const perScopeSync = listPerPeerScopeSyncState(store.db, {
+		localDeviceId: localDeviceId ?? null,
+		peerDeviceId: peerId,
+	});
 	return {
 		peer_device_id: row.peer_device_id,
 		name: row.name,
@@ -1470,44 +1473,6 @@ function mapPeerRow(
 		discovered_via_group_id:
 			typeof row.discovered_via_group_id === "string" ? row.discovered_via_group_id : null,
 	};
-}
-
-/**
- * Per-peer per-Space sync state for the `/api/sync/status` payload.
- *
- * Returns one entry per scope that both the local device and the peer are
- * active members of, each carrying the scope label, authority type, and the
- * per-scope replication cursor pulled from `replication_cursors_v2`.
- * Callers can render this directly in CLI/UI to show which Spaces have
- * actually synced for a peer versus which are still pending.
- *
- * Returns an empty array when local identity is not yet initialized or when
- * there is no overlap between local and peer memberships.
- */
-function perPeerScopeSyncState(
-	store: MemoryStore,
-	peerDeviceId: string,
-	localDeviceId: string | null,
-): Array<Record<string, unknown>> {
-	const trimmedPeer = peerDeviceId.trim();
-	const trimmedLocal = localDeviceId?.trim() ?? "";
-	if (!trimmedLocal || !trimmedPeer) return [];
-	const scopes = listAuthorizedScopesForPeer(store.db, {
-		localDeviceId: trimmedLocal,
-		peerDeviceId: trimmedPeer,
-	});
-	return scopes.map((scope) => {
-		const [lastApplied, lastAcked] = getReplicationCursor(store.db, trimmedPeer, scope.scope_id);
-		return {
-			scope_id: scope.scope_id,
-			label: scope.label,
-			authority_type: scope.authority_type,
-			membership_epoch: scope.membership_epoch,
-			last_applied_cursor: lastApplied,
-			last_acked_cursor: lastAcked,
-			bootstrapped: lastApplied != null,
-		};
-	});
 }
 
 function redactSyncAttemptError(error: unknown): string | null {


### PR DESCRIPTION
## Description

Targeted review-fix PR for the scoped-sync stack. This patch addresses the latest Codex feedback without changing the public product vocabulary or widening the release scope.

## Applied

1. Makes the `local-default` protocol rule normative: it is excluded from `authorized_scopes`; scoped-capable peers still run the legacy no-`scope_id` path for default-scope data.
2. Requires both local-device and peer-device active scope membership before accepting a scoped `scope_id` request.
3. Avoids creating `sync_reset_state_v2` rows for rejected, unvalidated `scope_id` values by returning the unscoped reset boundary with `scope_id: null`.
4. Clears stale per-scope `last_applied_cursor` after scoped `reset_required` so the next pass can re-bootstrap instead of looping forever.
5. Keeps non-membership `scoped sync incomplete` errors generic in the UI toast classifier.
6. Tightens the multi-Space regression assertion to check exact per-scope baseline cursors.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Testing
- [x] 📚 Documentation

## Testing

- [x] `pnpm run tsc`
- [x] `pnpm run lint`
- [x] `pnpm run test` — 114 files / 2138 tests
- [x] Targeted scoped-sync Vitest run — 4 files / 303 tests

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced

## Stack

PR 9/9 in the scoped-sync stack — tip of the stack. Depends on the postmortem PR.
