### PR TITLE
fix(sync): hydrate scope memberships without admin secret

### DIFF
--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -42,6 +42,9 @@ function createMockStore(
 		createGroup: vi.fn(async () => undefined),
 		getGroup: vi.fn(async (): Promise<CoordinatorGroup | null> => null),
 		listGroups: vi.fn(async (): Promise<CoordinatorGroup[]> => []),
+		renameGroup: vi.fn(async () => false),
+		archiveGroup: vi.fn(async () => false),
+		unarchiveGroup: vi.fn(async () => false),
 		enrollDevice: vi.fn(async (_: string, __: CoordinatorEnrollDeviceInput) => undefined),
 		listEnrolledDevices: vi.fn(
 			async (_: string, __?: boolean): Promise<CoordinatorEnrollment[]> => [],
@@ -124,6 +127,15 @@ function createMockStore(
 }
 
 const allowRequest: CoordinatorRequestVerifier = async () => true;
+
+function authHeaders(deviceId = "device-a", nonce = "nonce-a") {
+	return {
+		"X-Opencode-Device": deviceId,
+		"X-Opencode-Signature": "sig",
+		"X-Opencode-Timestamp": "2026-03-28T00:00:00Z",
+		"X-Opencode-Nonce": nonce,
+	};
+}
 
 describe("createCoordinatorApp dependency injection", () => {
 	it("uses injected admin secret and store factory for admin routes", async () => {
@@ -969,6 +981,128 @@ describe("createCoordinatorApp dependency injection", () => {
 		expect(invalid.status).toBe(401);
 		expect(await invalid.json()).toEqual({ error: "invalid_admin_secret" });
 		expect(store.listScopeMemberships).not.toHaveBeenCalled();
+	});
+
+	it("lets enrolled devices read non-admin Sharing domain membership snapshots", async () => {
+		const scopes: CoordinatorScope[] = [
+			{
+				scope_id: "scope-acme",
+				label: "Acme Work",
+				kind: "team",
+				authority_type: "coordinator",
+				coordinator_id: "coord-a",
+				group_id: "g1",
+				manifest_issuer_device_id: null,
+				membership_epoch: 3,
+				manifest_hash: null,
+				status: "active",
+				created_at: "2026-03-28T00:00:00Z",
+				updated_at: "2026-03-28T00:00:00Z",
+			},
+			{
+				scope_id: "scope-other",
+				label: "Other Work",
+				kind: "team",
+				authority_type: "coordinator",
+				coordinator_id: "coord-a",
+				group_id: "g1",
+				manifest_issuer_device_id: null,
+				membership_epoch: 1,
+				manifest_hash: null,
+				status: "active",
+				created_at: "2026-03-28T00:00:00Z",
+				updated_at: "2026-03-28T00:00:00Z",
+			},
+		];
+		const memberships: Record<string, CoordinatorScopeMembership[]> = {
+			"scope-acme": [
+				{
+					scope_id: "scope-acme",
+					device_id: "device-a",
+					role: "member",
+					status: "active",
+					membership_epoch: 3,
+					coordinator_id: "coord-a",
+					group_id: "g1",
+					manifest_issuer_device_id: null,
+					manifest_hash: null,
+					signed_manifest_json: null,
+					updated_at: "2026-03-28T00:00:00Z",
+				},
+				{
+					scope_id: "scope-acme",
+					device_id: "device-b",
+					role: "member",
+					status: "active",
+					membership_epoch: 3,
+					coordinator_id: "coord-a",
+					group_id: "g1",
+					manifest_issuer_device_id: null,
+					manifest_hash: null,
+					signed_manifest_json: null,
+					updated_at: "2026-03-28T00:00:00Z",
+				},
+			],
+			"scope-other": [
+				{
+					scope_id: "scope-other",
+					device_id: "device-b",
+					role: "member",
+					status: "active",
+					membership_epoch: 1,
+					coordinator_id: "coord-a",
+					group_id: "g1",
+					manifest_issuer_device_id: null,
+					manifest_hash: null,
+					signed_manifest_json: null,
+					updated_at: "2026-03-28T00:00:00Z",
+				},
+			],
+		};
+		const store = createMockStore({
+			getGroup: vi.fn(async () => ({
+				group_id: "g1",
+				display_name: "Acme",
+				archived_at: null,
+				created_at: "2026-03-28T00:00:00Z",
+			})),
+			getEnrollment: vi.fn(async () => ({
+				group_id: "g1",
+				device_id: "device-a",
+				public_key: "pk-a",
+				fingerprint: "fp-a",
+				display_name: "Device A",
+				enabled: 1,
+				created_at: "2026-03-28T00:00:00Z",
+			})),
+			listScopes: vi.fn(async () => scopes),
+			listScopeMemberships: vi.fn(async (scopeId: string) => memberships[scopeId] ?? []),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: {
+				adminSecret: () => "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+			},
+			requestVerifier: allowRequest,
+		});
+
+		const scopeRes = await app.request("/v1/scopes?group_id=g1", {
+			headers: authHeaders("device-a", "nonce-scopes"),
+		});
+		const memberRes = await app.request("/v1/scopes/scope-acme/members?group_id=g1", {
+			headers: authHeaders("device-a", "nonce-members"),
+		});
+		const otherRes = await app.request("/v1/scopes/scope-other/members?group_id=g1", {
+			headers: authHeaders("device-a", "nonce-other"),
+		});
+
+		expect(scopeRes.status).toBe(200);
+		expect(await scopeRes.json()).toEqual({ items: [scopes[0]] });
+		expect(memberRes.status).toBe(200);
+		expect(await memberRes.json()).toEqual({ items: memberships["scope-acme"] });
+		expect(otherRes.status).toBe(403);
+		expect(await otherRes.json()).toEqual({ error: "scope_not_authorized" });
 	});
 
 	it("grants devices explicitly to a Sharing domain", async () => {

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -327,6 +327,48 @@ export function createCoordinatorApp(
 		return { scope, response: null };
 	}
 
+	async function authorizeGroupMember(store: CoordinatorStore, groupId: string, c: Context) {
+		const auth = await authorizeRequest(store, runtime, requestVerifier, {
+			method: c.req.method,
+			url: c.req.url,
+			groupId,
+			body: new Uint8Array(0),
+			deviceId: c.req.header("X-Opencode-Device") ?? null,
+			signature: c.req.header("X-Opencode-Signature") ?? null,
+			timestamp: c.req.header("X-Opencode-Timestamp") ?? null,
+			nonce: c.req.header("X-Opencode-Nonce") ?? null,
+		});
+		if (!auth.ok || !auth.enrollment) {
+			return {
+				auth,
+				response:
+					rateLimitedResponse(c, c.req.path, false) ??
+					c.json({ error: auth.error }, auth.error === "group_archived" ? 409 : 401),
+			};
+		}
+		const limited = rateLimitedResponse(c, String(auth.enrollment.device_id), true);
+		return { auth, response: limited };
+	}
+
+	function activeCurrentMembership(
+		membership: CoordinatorScopeMembership,
+		scope: CoordinatorScope,
+	): boolean {
+		return membership.status === "active" && membership.membership_epoch >= scope.membership_epoch;
+	}
+
+	async function requesterAuthorizedForScope(
+		store: CoordinatorStore,
+		scope: CoordinatorScope,
+		deviceId: string,
+	): Promise<boolean> {
+		const memberships = await store.listScopeMemberships(scope.scope_id, false);
+		return memberships.some(
+			(membership) =>
+				membership.device_id === deviceId && activeCurrentMembership(membership, scope),
+		);
+	}
+
 	// -----------------------------------------------------------------------
 	// POST /v1/presence — upsert device presence (authenticated)
 	// -----------------------------------------------------------------------
@@ -437,6 +479,64 @@ export function createCoordinatorApp(
 
 			const items = await store.listGroupPeers(groupId, String(auth.enrollment.device_id));
 			return c.json({ items });
+		} finally {
+			await store.close();
+		}
+	});
+
+	// -----------------------------------------------------------------------
+	// GET /v1/scopes — list syncable scopes for the authenticated group member
+	// -----------------------------------------------------------------------
+
+	app.get("/v1/scopes", async (c) => {
+		const groupId = (c.req.query("group_id") ?? "").trim();
+		if (!groupId) return c.json({ error: "group_id_required" }, 400);
+		const store = createStore();
+		try {
+			const { auth, response } = await authorizeGroupMember(store, groupId, c);
+			if (response) return response;
+			if (!auth.enrollment) return c.json({ error: "unknown_device" }, 401);
+			const scopes = await store.listScopes({ groupId, includeInactive: false });
+			const items: CoordinatorScope[] = [];
+			for (const scope of scopes) {
+				if (scope.status !== "active") continue;
+				if (await requesterAuthorizedForScope(store, scope, String(auth.enrollment.device_id))) {
+					items.push(scope);
+				}
+			}
+			return c.json({ items });
+		} finally {
+			await store.close();
+		}
+	});
+
+	// -----------------------------------------------------------------------
+	// GET /v1/scopes/:scope_id/members — list members of an authorized scope
+	// -----------------------------------------------------------------------
+
+	app.get("/v1/scopes/:scope_id/members", async (c) => {
+		const groupId = (c.req.query("group_id") ?? "").trim();
+		const scopeId = String(c.req.param("scope_id") ?? "").trim();
+		if (!groupId) return c.json({ error: "group_id_required" }, 400);
+		if (!scopeId) return c.json({ error: "scope_id_required" }, 400);
+		const store = createStore();
+		try {
+			const { auth, response } = await authorizeGroupMember(store, groupId, c);
+			if (response) return response;
+			if (!auth.enrollment) return c.json({ error: "unknown_device" }, 401);
+			const scopes = await store.listScopes({ groupId, includeInactive: false });
+			const scope = scopes.find((item) => item.scope_id === scopeId) ?? null;
+			if (!scope || scope.status !== "active") return c.json({ error: "scope_not_found" }, 404);
+			const memberships = await store.listScopeMemberships(scopeId, false);
+			const requesterAuthorized = memberships.some(
+				(membership) =>
+					membership.device_id === String(auth.enrollment?.device_id) &&
+					activeCurrentMembership(membership, scope),
+			);
+			if (!requesterAuthorized) return c.json({ error: "scope_not_authorized" }, 403);
+			return c.json({
+				items: memberships.filter((membership) => activeCurrentMembership(membership, scope)),
+			});
 		} finally {
 			await store.close();
 		}

--- a/packages/core/src/scope-membership-cache.test.ts
+++ b/packages/core/src/scope-membership-cache.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import type { CoordinatorScope, CoordinatorScopeMembership } from "./coordinator-store-contract.js";
@@ -91,6 +94,53 @@ describe("scope membership cache", () => {
 				scope: expect.objectContaining({ label: "Acme Work" }),
 			}),
 		]);
+	});
+
+	it("hydrates the cache through enrolled-device coordinator endpoints without an admin secret", async () => {
+		const local = setup();
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-scope-cache-keys-"));
+		const previousFetch = globalThis.fetch;
+		try {
+			const seenUrls: string[] = [];
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = String(input);
+				seenUrls.push(url);
+				expect(init?.body ?? null).toBeNull();
+				const headers = new Headers(init?.headers);
+				expect(headers.get("X-Opencode-Device")).toBeTruthy();
+				expect(headers.get("X-Opencode-Signature")).toBeTruthy();
+				expect(headers.get("X-Opencode-Timestamp")).toBeTruthy();
+				expect(headers.get("X-Opencode-Nonce")).toBeTruthy();
+				if (url.endsWith("/v1/scopes?group_id=team-a")) {
+					return new Response(JSON.stringify({ items: [scope()] }), { status: 200 });
+				}
+				if (url.endsWith("/v1/scopes/scope-acme/members?group_id=team-a")) {
+					return new Response(JSON.stringify({ items: [membership()] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+			}) as typeof fetch;
+
+			const result = await refreshScopeMembershipCache(local, {
+				groupIds: ["team-a"],
+				coordinatorId: "https://coord.example.test",
+				remoteUrl: "https://coord.example.test",
+				adminSecret: null,
+				keysDir,
+				now: new Date(now()),
+			});
+
+			expect(result).toMatchObject({ status: "refreshed" });
+			expect(seenUrls).toEqual([
+				"https://coord.example.test/v1/scopes?group_id=team-a",
+				"https://coord.example.test/v1/scopes/scope-acme/members?group_id=team-a",
+			]);
+			expect(
+				getCachedScopeAuthorization(local, { deviceId: "device-a", scopeId: "scope-acme" }),
+			).toMatchObject({ authorized: true, state: "authorized" });
+		} finally {
+			globalThis.fetch = previousFetch;
+			rmSync(keysDir, { recursive: true, force: true });
+		}
 	});
 
 	it("keeps cached authorization visible as stale when coordinator refresh fails", async () => {

--- a/packages/core/src/scope-membership-cache.ts
+++ b/packages/core/src/scope-membership-cache.ts
@@ -15,7 +15,9 @@ import {
 	type ScopeMembershipRevocationNotice,
 	scopeMembershipEpochStatus,
 } from "./scope-membership-semantics.js";
-import { buildBaseUrl } from "./sync-http-client.js";
+import { buildAuthHeaders } from "./sync-auth.js";
+import { buildBaseUrl, requestJson } from "./sync-http-client.js";
+import { ensureDeviceIdentity } from "./sync-identity.js";
 
 export const DEFAULT_SCOPE_MEMBERSHIP_CACHE_MAX_AGE_MS = 60_000;
 
@@ -75,6 +77,9 @@ export interface RefreshScopeMembershipCacheOptions {
 	coordinatorId?: string | null;
 	remoteUrl?: string | null;
 	adminSecret?: string | null;
+	/** @deprecated The refresh database is taken from refreshScopeMembershipCache(db, opts). */
+	db?: Database;
+	keysDir?: string | null;
 	now?: Date;
 	fetchers?: ScopeMembershipCacheFetchers;
 }
@@ -155,7 +160,67 @@ export function ensureScopeMembershipCacheStateTable(db: Database): void {
 	`);
 }
 
-function defaultFetchers(opts: RefreshScopeMembershipCacheOptions): ScopeMembershipCacheFetchers {
+function coordinatorUrl(opts: RefreshScopeMembershipCacheOptions): string {
+	const remote = clean(opts.remoteUrl);
+	if (!remote) throw new Error("Coordinator URL required.");
+	return buildBaseUrl(remote);
+}
+
+function signedCoordinatorGet(
+	db: Database,
+	url: string,
+	keysDir?: string | null,
+): Promise<Record<string, unknown> | null> {
+	const [deviceId] = ensureDeviceIdentity(db, { keysDir: keysDir ?? undefined });
+	const bodyBytes = Buffer.alloc(0);
+	const headers = buildAuthHeaders({
+		deviceId,
+		method: "GET",
+		url,
+		bodyBytes,
+		keysDir: keysDir ?? undefined,
+	});
+	return requestJson("GET", url, {
+		headers,
+	}).then(([status, payload]) => {
+		if (status < 200 || status >= 300) {
+			const detail = typeof payload?.error === "string" ? payload.error : "unknown";
+			throw new Error(`Coordinator membership snapshot failed (${status}): ${detail}`);
+		}
+		return payload;
+	});
+}
+
+function payloadItems<T>(payload: Record<string, unknown> | null): T[] {
+	return Array.isArray(payload?.items)
+		? payload.items.filter((item): item is T => Boolean(item) && typeof item === "object")
+		: [];
+}
+
+function authenticatedFetchers(
+	db: Database,
+	opts: RefreshScopeMembershipCacheOptions,
+): ScopeMembershipCacheFetchers {
+	const baseUrl = coordinatorUrl(opts);
+	return {
+		listScopes: async (groupId) => {
+			const url = `${baseUrl}/v1/scopes?group_id=${encodeURIComponent(groupId)}`;
+			return payloadItems<CoordinatorScope>(await signedCoordinatorGet(db, url, opts.keysDir));
+		},
+		listMemberships: async (groupId, scopeId) => {
+			const url = `${baseUrl}/v1/scopes/${encodeURIComponent(scopeId)}/members?group_id=${encodeURIComponent(groupId)}`;
+			return payloadItems<CoordinatorScopeMembership>(
+				await signedCoordinatorGet(db, url, opts.keysDir),
+			);
+		},
+	};
+}
+
+function defaultFetchers(
+	db: Database,
+	opts: RefreshScopeMembershipCacheOptions,
+): ScopeMembershipCacheFetchers {
+	if (opts.remoteUrl && !opts.adminSecret) return authenticatedFetchers(db, opts);
 	return {
 		listScopes: (groupId) =>
 			coordinatorListScopesAction({
@@ -536,7 +601,7 @@ export async function refreshScopeMembershipCache(
 		coordinatorId,
 		groupId,
 	});
-	const fetchers = opts.fetchers ?? defaultFetchers(opts);
+	const fetchers = opts.fetchers ?? defaultFetchers(db, opts);
 	const timestamp = nowIso(opts.now);
 	const results: RefreshScopeMembershipCacheGroupResult[] = [];
 
@@ -597,9 +662,10 @@ export async function refreshScopeMembershipCache(
 export async function refreshConfiguredScopeMembershipCache(
 	db: Database,
 	config?: CoordinatorSyncConfig,
+	options?: { keysDir?: string | null },
 ): Promise<RefreshScopeMembershipCacheResult> {
 	const syncConfig = config ?? readCoordinatorSyncConfig();
-	if (!coordinatorEnabled(syncConfig) || !syncConfig.syncCoordinatorAdminSecret) {
+	if (!coordinatorEnabled(syncConfig)) {
 		return { status: "skipped", coordinatorId: null, groups: [] };
 	}
 	return refreshScopeMembershipCache(db, {
@@ -607,6 +673,7 @@ export async function refreshConfiguredScopeMembershipCache(
 		coordinatorId: authorityId(syncConfig.syncCoordinatorUrl),
 		remoteUrl: syncConfig.syncCoordinatorUrl,
 		adminSecret: syncConfig.syncCoordinatorAdminSecret,
+		keysDir: options?.keysDir ?? null,
 	});
 }
 

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -278,6 +278,7 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 				syncCoordinatorGroups: ["team"],
 				syncCoordinatorAdminSecret: "secret",
 			}),
+			{ keysDir: "/tmp/keys" },
 		);
 	});
 

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -153,7 +153,7 @@ export async function refreshCoordinatorPresenceForDaemon(
 	const config = readCoordinatorSyncConfig();
 	if (!coordinatorEnabled(config)) return false;
 	await registerCoordinatorPresence({ db, dbPath }, config, { keysDir });
-	await refreshConfiguredScopeMembershipCache(db, config);
+	await refreshConfiguredScopeMembershipCache(db, config, { keysDir });
 	return true;
 }
 


### PR DESCRIPTION
## Description
Hydrates scoped-sync membership metadata on normal enrolled devices that do not have a coordinator admin secret.

This adds signed, non-admin coordinator reads for active scope/member snapshots and uses them to populate the local scope membership cache. Without this, fresh Docker peers can join a team but still reject scoped sync as stale_epoch because their local DB never learns the team Space memberships.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Targeted checks run:
- `pnpm exec vitest run packages/core/src/coordinator-api.test.ts packages/core/src/scope-membership-cache.test.ts packages/core/src/sync-daemon.test.ts`
- `pnpm run tsc`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
