### PR TITLE
fix(ui): clarify sync pairing and diagnostics feedback

### DIFF
--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -198,10 +198,18 @@ function DiscoveredDeviceRow({
 						onClick={async () => {
 							setBusy("review");
 							setReviewLabel("Pairing…");
+							setFeedback({
+								message: `Pairing ${row.displayName}. Keep this page open while the device is approved and refreshed.`,
+								tone: "success",
+							});
 							try {
 								setFeedback((await onReview(row)) || null);
 								setReviewLabel(row.actionLabel || defaultReviewLabel);
 							} catch {
+								setFeedback({
+									message: `Pairing ${row.displayName} failed. Try again.`,
+									tone: "warning",
+								});
 								setReviewLabel("Retry");
 							} finally {
 								setBusy(null);

--- a/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.ts
@@ -55,6 +55,9 @@ export function renderSyncAttempts() {
 			// doesn't leak private addresses.
 			const errText = String(attempt.error);
 			detailParts.push(redact ? redactIpOctets(errText) : errText);
+			if (redact && /enable diagnostics for details/i.test(errText)) {
+				detailParts.push("Turn off Redact in Advanced diagnostics to reveal the full error.");
+			}
 		}
 		if (!isError && (attempt.ops_in || attempt.ops_out)) {
 			detailParts.push(`${attempt.ops_in ?? 0} in · ${attempt.ops_out ?? 0} out`);


### PR DESCRIPTION
## Description
Improves two dogfood feedback loops in the Sync UI:

- pairing a discovered device now immediately shows an inline pending message while approval/refresh is underway
- redacted recent sync-attempt errors now tell users to turn off Redact in Advanced diagnostics to reveal full details

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Checks run:
- `pnpm --filter @codemem/ui build`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
