### PR TITLE
fix(projects): show received bootstrap inventory read-only

### DIFF
--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -45,20 +45,26 @@ function insertSession(
 function insertMemory(
 	db: InstanceType<typeof Database>,
 	sessionId: number,
-	input: { workspaceId?: string | null } = {},
+	input: {
+		originDeviceId?: string | null;
+		project?: string | null;
+		workspaceId?: string | null;
+	} = {},
 ) {
 	const now = "2026-05-06T00:00:00Z";
 	db.prepare(
 		`INSERT INTO memory_items(
 			session_id, kind, title, body_text, created_at, updated_at,
-			visibility, workspace_id, active, metadata_json
-		 ) VALUES (?, 'discovery', 'Scoped project', 'Body', ?, ?, 'shared', ?, 1, ?)`,
+			visibility, workspace_id, origin_device_id, active, metadata_json, project
+		 ) VALUES (?, 'discovery', 'Scoped project', 'Body', ?, ?, 'shared', ?, ?, 1, ?, ?)`,
 	).run(
 		sessionId,
 		now,
 		now,
 		input.workspaceId === undefined ? "shared:acme" : input.workspaceId,
+		input.originDeviceId === undefined ? null : input.originDeviceId,
 		toJson({}),
+		input.project === undefined ? null : input.project,
 	);
 }
 
@@ -693,7 +699,7 @@ describe("project scope settings", () => {
 		).toThrow(/not an active Sharing domain/);
 	});
 
-	it("excludes synthetic sync-bootstrap sessions from the project inventory", () => {
+	it("surfaces bootstrap memory projects without exposing synthetic session cwd", () => {
 		// Real session — should appear in the inventory.
 		const realSession = insertSession(db, {
 			cwd: "/workspace/work/exampleco/api",
@@ -710,7 +716,11 @@ describe("project scope settings", () => {
 			gitRemote: null,
 			project: "codemem",
 		});
-		insertMemory(db, bootstrapSession, { workspaceId: "shared:default" });
+		insertMemory(db, bootstrapSession, {
+			originDeviceId: "peer-a",
+			project: "codemem",
+			workspaceId: "shared:default",
+		});
 
 		const bareBootstrapSession = insertSession(db, {
 			cwd: "__sync_bootstrap__",
@@ -723,12 +733,283 @@ describe("project scope settings", () => {
 		const cwds = inventory.projects.map((project) => project.cwd ?? "");
 		expect(cwds).not.toContain("__sync_bootstrap__:codemem");
 		expect(cwds).not.toContain("__sync_bootstrap__");
+		expect(inventory.projects).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					cwd: null,
+					display_project: "codemem",
+					memory_count: 1,
+					project: "codemem",
+					read_only: true,
+					read_only_reason: "peer_received",
+					statuses: ["received"],
+					workspace_identity: "peer-received:peer-a:project:codemem",
+				}),
+			]),
+		);
 		// Real session is still surfaced.
 		expect(
 			inventory.projects.some(
 				(project) => project.workspace_identity === "https://git.example.invalid/exampleco/api.git",
 			),
 		).toBe(true);
+	});
+
+	it("lists project inventory when every memory arrived from sync bootstrap", () => {
+		const codememSession = insertSession(db, {
+			cwd: "__sync_bootstrap__:codemem",
+			gitRemote: null,
+			project: "codemem",
+		});
+		insertMemory(db, codememSession, {
+			originDeviceId: "peer-a",
+			project: "codemem",
+			workspaceId: "shared:default",
+		});
+
+		const backstageSession = insertSession(db, {
+			cwd: "__sync_bootstrap__:backstage",
+			gitRemote: null,
+			project: "backstage",
+		});
+		insertMemory(db, backstageSession, {
+			originDeviceId: "peer-a",
+			project: "backstage",
+			workspaceId: "shared:default",
+		});
+
+		const inventory = listProjectScopeInventory(db);
+		expect(inventory.total).toBe(2);
+		expect(inventory.projects.map((project) => project.display_project).sort()).toEqual([
+			"backstage",
+			"codemem",
+		]);
+		expect(inventory.projects.every((project) => project.cwd === null)).toBe(true);
+		expect(inventory.projects.every((project) => project.read_only)).toBe(true);
+		expect(inventory.projects.every((project) => project.session_count === 0)).toBe(true);
+		expect(inventory.projects.every((project) => project.statuses.includes("received"))).toBe(true);
+	});
+
+	it("keeps peer-received identities separate from local project-like identities", () => {
+		const localSession = insertSession(db, {
+			cwd: null,
+			gitRemote: null,
+			project: "codemem",
+		});
+		insertMemory(db, localSession, { project: "codemem", workspaceId: "project:codemem" });
+
+		const bootstrapSession = insertSession(db, {
+			cwd: "__sync_bootstrap__:codemem",
+			gitRemote: null,
+			project: "codemem",
+		});
+		insertMemory(db, bootstrapSession, {
+			originDeviceId: "peer-a",
+			project: "codemem",
+			workspaceId: "shared:default",
+		});
+
+		const inventory = listProjectScopeInventory(db);
+		const local = inventory.projects.find(
+			(project) => project.workspace_identity === "project:codemem",
+		);
+		const received = inventory.projects.find(
+			(project) => project.workspace_identity === "peer-received:peer-a:project:codemem",
+		);
+
+		expect(local).toEqual(
+			expect.objectContaining({
+				memory_count: 1,
+				read_only: false,
+				read_only_reason: null,
+				session_count: 1,
+			}),
+		);
+		expect(received).toEqual(
+			expect.objectContaining({
+				memory_count: 1,
+				read_only: true,
+				read_only_reason: "peer_received",
+				session_count: 0,
+				statuses: ["received"],
+			}),
+		);
+	});
+
+	it("keeps peer-received rows separate when local workspace ids use the reserved prefix", () => {
+		const localSession = insertSession(db, {
+			cwd: null,
+			gitRemote: null,
+			project: "codemem",
+		});
+		insertMemory(db, localSession, {
+			project: "codemem",
+			workspaceId: "peer-received:peer-a:project:codemem",
+		});
+
+		const bootstrapSession = insertSession(db, {
+			cwd: "__sync_bootstrap__:codemem",
+			gitRemote: null,
+			project: "codemem",
+		});
+		insertMemory(db, bootstrapSession, {
+			originDeviceId: "peer-a",
+			project: "codemem",
+			workspaceId: "shared:default",
+		});
+
+		const matches = listProjectScopeInventory(db).projects.filter(
+			(project) => project.workspace_identity === "peer-received:peer-a:project:codemem",
+		);
+
+		expect(matches).toHaveLength(2);
+		expect(matches).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					memory_count: 1,
+					read_only: false,
+					read_only_reason: null,
+					session_count: 1,
+				}),
+				expect.objectContaining({
+					memory_count: 1,
+					read_only: true,
+					read_only_reason: "peer_received",
+					session_count: 0,
+					statuses: ["received"],
+				}),
+			]),
+		);
+	});
+
+	it("keeps mapping-only project identities editable when received projects share a name", () => {
+		insertScope(db, { scopeId: "exampleco-work", label: "ExampleCo Work" });
+		upsertProjectScopeSettingsMapping(db, {
+			project_pattern: "codemem",
+			scope_id: "exampleco-work",
+			workspace_identity: "project:codemem",
+		});
+
+		const bootstrapSession = insertSession(db, {
+			cwd: "__sync_bootstrap__:codemem",
+			gitRemote: null,
+			project: "codemem",
+		});
+		insertMemory(db, bootstrapSession, {
+			originDeviceId: "peer-a",
+			project: "codemem",
+			workspaceId: "shared:default",
+		});
+
+		const inventory = listProjectScopeInventory(db);
+		const mappingOnly = inventory.projects.find(
+			(project) => project.workspace_identity === "project:codemem",
+		);
+		const received = inventory.projects.find(
+			(project) => project.workspace_identity === "peer-received:peer-a:project:codemem",
+		);
+
+		expect(mappingOnly).toEqual(
+			expect.objectContaining({
+				memory_count: 0,
+				read_only: false,
+				resolved_scope_id: "exampleco-work",
+				statuses: expect.arrayContaining(["explicitly_mapped"]),
+			}),
+		);
+		expect(received).toEqual(
+			expect.objectContaining({
+				memory_count: 1,
+				read_only: true,
+				statuses: ["received"],
+			}),
+		);
+	});
+
+	it("rejects direct assignment of peer-received project identities without local rows", () => {
+		insertScope(db, { scopeId: "exampleco-work", label: "ExampleCo Work" });
+
+		expect(() =>
+			upsertProjectScopeSettingsMapping(db, {
+				project_pattern: "codemem",
+				scope_id: "exampleco-work",
+				workspace_identity: "peer-received:peer-a:project:codemem",
+			}),
+		).toThrow(/peer-received projects cannot be assigned/);
+	});
+
+	it("allows assignment of reserved-prefix identities when a real local row owns them", () => {
+		insertScope(db, { scopeId: "exampleco-work", label: "ExampleCo Work" });
+		const localSession = insertSession(db, {
+			cwd: null,
+			gitRemote: null,
+			project: "codemem",
+		});
+		insertMemory(db, localSession, {
+			project: "codemem",
+			workspaceId: "peer-received:peer-a:project:codemem",
+		});
+
+		const mapping = upsertProjectScopeSettingsMapping(db, {
+			project_pattern: "codemem",
+			scope_id: "exampleco-work",
+			workspace_identity: "peer-received:peer-a:project:codemem",
+		});
+
+		expect(mapping.scope_id).toBe("exampleco-work");
+	});
+
+	it("does not let peer-received duplicates inherit local mapping semantics", () => {
+		insertScope(db, { scopeId: "exampleco-work", label: "ExampleCo Work" });
+		const localSession = insertSession(db, {
+			cwd: null,
+			gitRemote: null,
+			project: "codemem",
+		});
+		insertMemory(db, localSession, {
+			project: "codemem",
+			workspaceId: "peer-received:peer-a:project:codemem",
+		});
+		upsertProjectScopeSettingsMapping(db, {
+			project_pattern: "codemem",
+			scope_id: "exampleco-work",
+			workspace_identity: "peer-received:peer-a:project:codemem",
+		});
+
+		const bootstrapSession = insertSession(db, {
+			cwd: "__sync_bootstrap__:codemem",
+			gitRemote: null,
+			project: "codemem",
+		});
+		insertMemory(db, bootstrapSession, {
+			originDeviceId: "peer-a",
+			project: "codemem",
+			workspaceId: "shared:default",
+		});
+
+		const matches = listProjectScopeInventory(db).projects.filter(
+			(project) => project.workspace_identity === "peer-received:peer-a:project:codemem",
+		);
+		const received = matches.find((project) => project.read_only === true);
+		const mapped = listProjectScopeInventory(db, { scopeId: "exampleco-work" }).projects;
+
+		expect(received).toEqual(
+			expect.objectContaining({
+				mapping_id: null,
+				matched_pattern: null,
+				read_only: true,
+				resolution_reason: "local_default",
+				resolved_scope_id: LOCAL_DEFAULT_SCOPE_ID,
+				statuses: ["received"],
+			}),
+		);
+		expect(mapped).toHaveLength(1);
+		expect(mapped[0]).toEqual(
+			expect.objectContaining({
+				read_only: false,
+				resolved_scope_id: "exampleco-work",
+			}),
+		);
 	});
 
 	it("keeps cwds that only coincidentally match the bootstrap LIKE-wildcard shape", () => {

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -76,6 +76,8 @@ export interface ProjectScopeCandidate {
 	suggestion_reason: string | null;
 	suggestion_signal: WorkspaceIdentitySource | null;
 	guardrail_warnings: ProjectScopeGuardrailWarning[];
+	read_only: boolean;
+	read_only_reason: "peer_received" | null;
 }
 
 export type ProjectScopeInventoryStatus =
@@ -83,6 +85,7 @@ export type ProjectScopeInventoryStatus =
 	| "legacy_review"
 	| "local_only"
 	| "needs_attention"
+	| "received"
 	| "suggested"
 	| "unmapped";
 
@@ -132,6 +135,8 @@ export interface ProjectScopeMappingChangeGuardrailAnalysis {
 	warnings: ProjectScopeGuardrailWarning[];
 }
 
+const PEER_RECEIVED_WORKSPACE_IDENTITY_PREFIX = "peer-received:";
+
 export interface ReassignProjectScopeInventoryProjectResult {
 	workspace_identity: string;
 	project: string;
@@ -142,6 +147,7 @@ export interface ReassignProjectScopeInventoryProjectResult {
 
 interface ProjectScopeCandidateRow {
 	id: number;
+	inventory_source?: "local" | "peer_received" | null;
 	started_at: string | null;
 	cwd: string | null;
 	project: string | null;
@@ -155,6 +161,31 @@ interface ProjectScopeCandidateRow {
 function clean(value: string | null | undefined): string | null {
 	const trimmed = value?.trim();
 	return trimmed ? trimmed : null;
+}
+
+function inventoryMergeKey(
+	row: ProjectScopeCandidateRow,
+	candidate: ProjectScopeCandidate,
+): string {
+	return `${row.inventory_source === "peer_received" ? "peer_received" : "local"}:${candidate.workspace_identity}`;
+}
+
+function hasLocalInventoryIdentity(db: Database, workspaceIdentity: string): boolean {
+	const row = db
+		.prepare(
+			`SELECT 1 AS one
+			 FROM sessions s
+			 JOIN memory_items mi ON mi.session_id = s.id
+			 WHERE (s.cwd IS NULL OR substr(s.cwd, 1, length(?)) <> ?)
+			   AND COALESCE(TRIM(s.git_remote), TRIM(s.cwd), '') = ''
+			   AND mi.workspace_id IS NOT NULL
+			   AND TRIM(mi.workspace_id) = ?
+			 LIMIT 1`,
+		)
+		.get(SYNC_BOOTSTRAP_CWD_PREFIX, SYNC_BOOTSTRAP_CWD_PREFIX, workspaceIdentity) as
+		| { one: number }
+		| undefined;
+	return Boolean(row);
 }
 
 function normalizeWorkspaceIdentity(value: string | null | undefined): string | null {
@@ -362,6 +393,7 @@ function projectScopeCandidateGuardrailWarnings(
 	collisions: Map<string, ProjectScopeCandidate[]>,
 ): ProjectScopeGuardrailWarning[] {
 	const warnings: ProjectScopeGuardrailWarning[] = [];
+	if (project.read_only) return warnings;
 	if (project.resolution_reason === "local_default") {
 		warnings.push({
 			code: "unknown_project_local_only",
@@ -400,7 +432,10 @@ function withCandidateGuardrails(candidates: ProjectScopeCandidate[]): ProjectSc
 
 function inventoryStatuses(project: ProjectScopeCandidate): ProjectScopeInventoryStatus[] {
 	const statuses = new Set<ProjectScopeInventoryStatus>();
-	if (project.resolved_scope_id === LOCAL_DEFAULT_SCOPE_ID) statuses.add("local_only");
+	if (project.read_only) return ["received"];
+	if (!project.read_only && project.resolved_scope_id === LOCAL_DEFAULT_SCOPE_ID) {
+		statuses.add("local_only");
+	}
 	if (project.resolved_scope_id === LEGACY_SHARED_REVIEW_SCOPE_ID) statuses.add("legacy_review");
 	if (project.identity_source === "unmapped") statuses.add("unmapped");
 	if (project.suggested_scope_id && project.suggested_scope_id !== project.resolved_scope_id) {
@@ -467,6 +502,8 @@ function buildProjectScopeCandidate(
 		resolution_reason: resolution.reason,
 		mapping_id: resolution.mapping?.id ?? null,
 		matched_pattern: resolution.matchedPattern,
+		read_only: false,
+		read_only_reason: null,
 		suggested_scope_id: null,
 		suggestion_reason: null,
 		suggestion_signal: null,
@@ -783,6 +820,7 @@ export function listProjectScopeInventory(
 		.prepare(
 			`SELECT
 				s.id,
+				'local' AS inventory_source,
 				MAX(s.started_at) AS started_at,
 				s.cwd,
 				s.project,
@@ -810,15 +848,60 @@ export function listProjectScopeInventory(
 			 ORDER BY MAX(s.started_at) DESC, s.id DESC`,
 		)
 		.all(SYNC_BOOTSTRAP_CWD_PREFIX, SYNC_BOOTSTRAP_CWD_PREFIX) as ProjectScopeCandidateRow[];
+	const bootstrapRows = db
+		.prepare(
+			`SELECT
+				MIN(s.id) AS id,
+				'peer_received' AS inventory_source,
+				MAX(COALESCE(mi.updated_at, s.started_at)) AS started_at,
+				NULL AS cwd,
+				TRIM(mi.project) AS project,
+				NULL AS git_remote,
+				NULL AS git_branch,
+				'peer-received:' || COALESCE(NULLIF(TRIM(mi.origin_device_id), ''), 'unknown') || ':project:' || TRIM(mi.project) AS workspace_id,
+				0 AS session_count,
+				COUNT(mi.id) AS memory_count
+			 FROM memory_items mi
+			 JOIN sessions s ON s.id = mi.session_id
+			 WHERE mi.active = 1
+			   AND mi.project IS NOT NULL
+			   AND TRIM(mi.project) <> ''
+			   AND s.cwd IS NOT NULL
+			   AND substr(s.cwd, 1, length(?)) = ?
+			 GROUP BY TRIM(mi.project), workspace_id
+			 ORDER BY MAX(COALESCE(mi.updated_at, s.started_at)) DESC, TRIM(mi.project) ASC`,
+		)
+		.all(SYNC_BOOTSTRAP_CWD_PREFIX, SYNC_BOOTSTRAP_CWD_PREFIX) as ProjectScopeCandidateRow[];
 
 	const byIdentity = new Map<string, ProjectScopeInventoryProject>();
 	const inventory: ProjectScopeInventoryProject[] = [];
-	for (const row of rows) {
-		const candidate = buildProjectScopeCandidate(row, mappings, scopes);
-		const existing = byIdentity.get(candidate.workspace_identity);
+	for (const row of [...rows, ...bootstrapRows]) {
+		const readOnly = row.inventory_source === "peer_received";
+		const candidate = {
+			...buildProjectScopeCandidate(row, mappings, scopes),
+			read_only: readOnly,
+			read_only_reason: readOnly ? "peer_received" : null,
+			...(readOnly
+				? {
+						mapping_id: null,
+						matched_pattern: null,
+						resolution_reason: "local_default" as const,
+						resolved_scope_id: LOCAL_DEFAULT_SCOPE_ID,
+						suggested_scope_id: null,
+						suggestion_reason: null,
+						suggestion_signal: null,
+					}
+				: {}),
+		} satisfies ProjectScopeCandidate;
+		const key = inventoryMergeKey(row, candidate);
+		const existing = byIdentity.get(key);
 		if (existing) {
 			existing.memory_count = (existing.memory_count ?? 0) + Number(row.memory_count ?? 0);
 			existing.session_count += Number(row.session_count ?? 1);
+			if (!readOnly) {
+				existing.read_only = false;
+				existing.read_only_reason = null;
+			}
 			continue;
 		}
 		const project = {
@@ -827,12 +910,13 @@ export function listProjectScopeInventory(
 			session_count: Number(row.session_count ?? 1),
 			statuses: [],
 		};
-		byIdentity.set(candidate.workspace_identity, project);
+		byIdentity.set(key, project);
 		inventory.push(project);
 	}
 
 	for (const mapping of mappings) {
-		if (!mapping.workspace_identity || byIdentity.has(mapping.workspace_identity)) continue;
+		if (!mapping.workspace_identity || byIdentity.has(`local:${mapping.workspace_identity}`))
+			continue;
 		const candidate: ProjectScopeCandidate = {
 			workspace_identity: mapping.workspace_identity,
 			identity_source: "workspace_id",
@@ -846,20 +930,20 @@ export function listProjectScopeInventory(
 			resolution_reason: "exact_mapping",
 			mapping_id: mapping.id,
 			matched_pattern: null,
+			read_only: false,
+			read_only_reason: null,
 			suggested_scope_id: null,
 			suggestion_reason: null,
 			suggestion_signal: null,
 			guardrail_warnings: [],
 		};
 		const project = { ...candidate, memory_count: 0, session_count: 0, statuses: [] };
-		byIdentity.set(mapping.workspace_identity, project);
+		byIdentity.set(`local:${mapping.workspace_identity}`, project);
 		inventory.push(project);
 	}
 
-	const withGuardrails = withCandidateGuardrails(inventory).map((project) => {
-		const original = inventory.find(
-			(item) => item.workspace_identity === project.workspace_identity,
-		);
+	const withGuardrails = withCandidateGuardrails(inventory).map((project, index) => {
+		const original = inventory[index];
 		return {
 			...project,
 			memory_count: original?.memory_count ?? null,
@@ -973,6 +1057,12 @@ export function upsertProjectScopeSettingsMapping(
 	const { existing, workspaceIdentity } = draft;
 	if (workspaceIdentity?.startsWith("unmapped:")) {
 		throw new Error("unmapped projects cannot be assigned to a Sharing domain");
+	}
+	if (
+		workspaceIdentity?.startsWith(PEER_RECEIVED_WORKSPACE_IDENTITY_PREFIX) &&
+		!hasLocalInventoryIdentity(db, workspaceIdentity)
+	) {
+		throw new Error("peer-received projects cannot be assigned on this device");
 	}
 	const projectPattern = draft.projectPattern;
 	if (!projectPattern) throw new Error("project_pattern or workspace_identity is required");

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -211,6 +211,8 @@ export interface ProjectScopeCandidate {
 	git_remote: string | null;
 	git_branch: string | null;
 	latest_session_at: string | null;
+	read_only?: boolean;
+	read_only_reason?: "peer_received" | null;
 	resolved_scope_id: string;
 	resolution_reason: string;
 	mapping_id: number | null;
@@ -226,6 +228,7 @@ export type ProjectScopeInventoryStatus =
 	| "legacy_review"
 	| "local_only"
 	| "needs_attention"
+	| "received"
 	| "suggested"
 	| "unmapped";
 

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -184,6 +184,39 @@ describe("Projects tab", () => {
 		);
 	});
 
+	it("renders peer-received project identities read-only", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [
+				project({
+					cwd: null,
+					display_project: "codemem",
+					git_branch: null,
+					git_remote: null,
+					identity_source: "workspace_id",
+					memory_count: 18111,
+					project: "codemem",
+					read_only: true,
+					read_only_reason: "peer_received",
+					session_count: 0,
+					statuses: ["received"],
+					workspace_identity: "peer-received:peer-a:project:codemem",
+				}),
+			],
+			total: 1,
+		});
+
+		initProjectsTab(() => {});
+		await loadProjectsData();
+
+		expect(document.body.textContent).toContain("Received from peers");
+		expect(document.body.textContent).toContain("Change its project or Space on the source device");
+		expect(document.querySelector(".project-domain-select")).toBeNull();
+		expect(document.body.textContent).not.toContain("Change project…");
+	});
+
 	it("does not reload inventory while a Space select is active", async () => {
 		const refresh = vi.fn();
 		initProjectsTab(refresh);
@@ -388,6 +421,99 @@ describe("Projects tab", () => {
 				}),
 			]),
 		});
+	});
+
+	it("excludes peer-received identities from cluster bulk assignment", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [
+				project({
+					cwd: "/workspace/a",
+					git_remote: null,
+					identity_source: "cwd",
+					memory_count: 2,
+					session_count: 1,
+					workspace_identity: "/workspace/a",
+				}),
+				project({
+					cwd: null,
+					git_branch: null,
+					git_remote: null,
+					guardrail_warnings: [
+						{
+							code: "basename_collision_review",
+							message: "Peer-received rows should not block local bulk assignment.",
+							requires_confirmation: true,
+							severity: "warning",
+						},
+					],
+					identity_source: "workspace_id",
+					memory_count: 4,
+					read_only: true,
+					read_only_reason: "peer_received",
+					session_count: 0,
+					statuses: ["received"],
+					workspace_identity: "peer-received:peer-a:project:api",
+				}),
+			],
+			total: 2,
+		});
+
+		await loadProjectsData();
+
+		expect(document.body.textContent).toContain("2 identities · 1 sessions · 6 memories");
+		expect(document.body.textContent).toContain("Save Space for 1 identity");
+		const select = document.querySelector(
+			".project-inventory-cluster select",
+		) as HTMLSelectElement | null;
+		if (!select) throw new Error("cluster select missing");
+		select.value = "exampleco-work";
+		select.dispatchEvent(new Event("change", { bubbles: true }));
+		const save = Array.from(document.querySelectorAll("button")).find(
+			(button) => button.textContent === "Save Space for 1 identity",
+		) as HTMLButtonElement | undefined;
+		expect(save?.disabled).toBe(false);
+		save?.click();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(api.saveSharingDomainProjectMappings).toHaveBeenCalledWith({
+			mappings: [
+				expect.objectContaining({
+					scope_id: "exampleco-work",
+					workspace_identity: "/workspace/a",
+				}),
+			],
+		});
+	});
+
+	it("does not show bulk Space controls for unmapped-only clusters", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [
+				project({
+					cwd: null,
+					git_remote: null,
+					identity_source: "unmapped",
+					workspace_identity: "unmapped:one",
+				}),
+				project({
+					cwd: null,
+					git_remote: null,
+					identity_source: "unmapped",
+					workspace_identity: "unmapped:two",
+				}),
+			],
+			total: 2,
+		});
+
+		await loadProjectsData();
+
+		expect(document.body.textContent).not.toContain("Save Space for");
+		expect(document.querySelector(".project-inventory-cluster select")).toBeNull();
 	});
 
 	it("blocks cluster bulk assignment when an identity needs guardrail review", async () => {

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -15,6 +15,7 @@ const STATUS_OPTIONS = [
 	["needs_attention", "Needs review"],
 	["suggested", "Has suggestion"],
 	["local_only", "Stays on this device"],
+	["received", "Received from peers"],
 	["explicitly_mapped", "Already assigned"],
 	["legacy_review", "Older shared data"],
 	["unmapped", "Missing project identity"],
@@ -57,6 +58,26 @@ function formatResolution(reason: string): string {
 		default:
 			return "stays on this device";
 	}
+}
+
+function isPeerReceivedProject(project: ProjectScopeInventoryProject): boolean {
+	return project.read_only === true && project.read_only_reason === "peer_received";
+}
+
+function isLocallyAssignableProject(project: ProjectScopeInventoryProject): boolean {
+	return project.identity_source !== "unmapped" && !isPeerReceivedProject(project);
+}
+
+function projectDomainLabel(project: ProjectScopeInventoryProject): string {
+	return isPeerReceivedProject(project)
+		? "Received from peers"
+		: scopeSummary(project.resolved_scope_id);
+}
+
+function projectResolutionLabel(project: ProjectScopeInventoryProject): string {
+	return isPeerReceivedProject(project)
+		? "source-owned project"
+		: formatResolution(project.resolution_reason);
 }
 
 function formatLatest(value: string | null): string {
@@ -301,7 +322,7 @@ async function saveProjectClusterMapping(
 	projects: ProjectScopeInventoryProject[],
 	scopeId: string,
 ) {
-	const assignable = projects.filter((project) => project.identity_source !== "unmapped");
+	const assignable = projects.filter(isLocallyAssignableProject);
 	if (assignable.length === 0) return;
 	try {
 		await api.saveSharingDomainProjectMappings({
@@ -421,6 +442,14 @@ async function reassignProject(project: ProjectScopeInventoryProject) {
 function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElement {
 	const actions = document.createElement("div");
 	actions.className = "project-inventory-actions";
+	if (isPeerReceivedProject(project)) {
+		const note = document.createElement("div");
+		note.className = "settings-note";
+		note.textContent =
+			"This project was received from a peer. Change its project or Space on the source device; this node keeps the received identity read-only.";
+		actions.appendChild(note);
+		return actions;
+	}
 	if (project.identity_source === "unmapped") {
 		const note = document.createElement("div");
 		note.className = "settings-note";
@@ -593,14 +622,22 @@ function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 
 	const domain = document.createElement("div");
 	domain.className = "project-inventory-domain";
-	domain.textContent = scopeSummary(project.resolved_scope_id);
+	domain.textContent = projectDomainLabel(project);
 	header.appendChild(domain);
 	row.appendChild(header);
 
 	const meta = document.createElement("div");
 	meta.className = "project-inventory-meta";
-	meta.textContent = `${formatResolution(project.resolution_reason)} · ${project.identity_source} · ${formatLatest(project.latest_session_at)}`;
+	meta.textContent = `${projectResolutionLabel(project)} · ${project.identity_source} · ${formatLatest(project.latest_session_at)}`;
 	row.appendChild(meta);
+
+	if (isPeerReceivedProject(project)) {
+		const receivedNote = document.createElement("div");
+		receivedNote.className = "settings-note";
+		receivedNote.textContent =
+			"Received memories keep the source device's project and Space assignment. Local reassignment controls are disabled here to avoid split-brain sync state.";
+		row.appendChild(receivedNote);
+	}
 
 	const signal = document.createElement("div");
 	signal.className = "project-inventory-signal mono";
@@ -616,7 +653,9 @@ function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 		row.appendChild(suggestion);
 	}
 
-	const warnings = project.guardrail_warnings.filter((warning) => warning.severity === "warning");
+	const warnings = (project.guardrail_warnings ?? []).filter(
+		(warning) => warning.severity === "warning",
+	);
 	if (warnings.length > 0) {
 		const warningBox = document.createElement("div");
 		warningBox.className = "settings-note project-attention-note";
@@ -654,7 +693,7 @@ function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 		["CWD", project.cwd],
 		["Git remote", project.git_remote],
 		["Git branch", project.git_branch],
-		["Current Space", scopeSummary(project.resolved_scope_id)],
+		["Current Space", projectDomainLabel(project)],
 		[
 			"Suggested Space",
 			project.suggested_scope_id ? scopeSummary(project.suggested_scope_id) : null,
@@ -679,8 +718,8 @@ function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 }
 
 function clusterDomainLabel(projects: ProjectScopeInventoryProject[]): string {
-	const uniqueScopes = [...new Set(projects.map((project) => project.resolved_scope_id))];
-	return uniqueScopes.length === 1 ? scopeSummary(uniqueScopes[0]) : "Mixed Spaces";
+	const uniqueLabels = [...new Set(projects.map((project) => projectDomainLabel(project)))];
+	return uniqueLabels.length === 1 ? uniqueLabels[0] : "Mixed Spaces";
 }
 
 function renderProjectCluster(projects: ProjectScopeInventoryProject[]): HTMLElement {
@@ -710,42 +749,58 @@ function renderProjectCluster(projects: ProjectScopeInventoryProject[]): HTMLEle
 
 	const actions = document.createElement("div");
 	actions.className = "project-inventory-actions";
-	const hasGuardrailWarnings = projects.some((project) => project.guardrail_warnings.length > 0);
-	const suggestedScopes = new Set(
-		projects
-			.map((project) => project.suggested_scope_id)
-			.filter((scopeId): scopeId is string => Boolean(scopeId)),
-	);
-	const resolvedScopes = new Set(projects.map((project) => project.resolved_scope_id));
-	const select = document.createElement("select");
-	select.className = "project-domain-select";
-	select.setAttribute("aria-label", `Space for ${projectClusterLabel(projects[0])} group`);
-	const placeholder = document.createElement("option");
-	placeholder.value = "";
-	placeholder.textContent = "Choose Space…";
-	select.appendChild(placeholder);
-	appendAssignableScopeOptions(select);
-	select.value = "";
-	const save = document.createElement("button");
-	save.className = "settings-button";
-	save.type = "button";
-	save.textContent = `Save Space for ${projects.length} identities`;
-	save.disabled = true;
-	save.addEventListener("click", () => void saveProjectClusterMapping(projects, select.value));
-	select.addEventListener("change", () => {
-		save.disabled = !select.value || hasGuardrailWarnings;
-	});
-	select.addEventListener("blur", refreshSkippedProjectDataAfterSelectBlur);
-	actions.append(select, save);
-	if (suggestedScopes.size > 1 || resolvedScopes.size > 1 || hasGuardrailWarnings) {
+	const assignableProjects = projects.filter(isLocallyAssignableProject);
+	if (assignableProjects.length === 0) {
 		const note = document.createElement("div");
-		note.className = "settings-note project-attention-note";
-		note.textContent = hasGuardrailWarnings
-			? "One or more identities in this group need individual review before bulk assignment."
-			: "This group has mixed suggestions or current Spaces. Choose a Space explicitly before bulk assignment.";
+		note.className = "settings-note";
+		note.textContent = projects.every(isPeerReceivedProject)
+			? "These project identities were received from peers. Change project or Space assignments on their source devices."
+			: "These project identities cannot be bulk assigned until they have stable local identities. Expand each identity for details.";
 		actions.appendChild(note);
+		row.appendChild(actions);
+	} else {
+		const hasGuardrailWarnings = assignableProjects.some(
+			(project) => (project.guardrail_warnings ?? []).length > 0,
+		);
+		const suggestedScopes = new Set(
+			assignableProjects
+				.map((project) => project.suggested_scope_id)
+				.filter((scopeId): scopeId is string => Boolean(scopeId)),
+		);
+		const resolvedScopes = new Set(assignableProjects.map((project) => project.resolved_scope_id));
+		const select = document.createElement("select");
+		select.className = "project-domain-select";
+		select.setAttribute("aria-label", `Space for ${projectClusterLabel(projects[0])} group`);
+		const placeholder = document.createElement("option");
+		placeholder.value = "";
+		placeholder.textContent = "Choose Space…";
+		select.appendChild(placeholder);
+		appendAssignableScopeOptions(select);
+		select.value = "";
+		const save = document.createElement("button");
+		save.className = "settings-button";
+		save.type = "button";
+		save.textContent = `Save Space for ${assignableProjects.length} identit${assignableProjects.length === 1 ? "y" : "ies"}`;
+		save.disabled = true;
+		save.addEventListener(
+			"click",
+			() => void saveProjectClusterMapping(assignableProjects, select.value),
+		);
+		select.addEventListener("change", () => {
+			save.disabled = !select.value || hasGuardrailWarnings;
+		});
+		select.addEventListener("blur", refreshSkippedProjectDataAfterSelectBlur);
+		actions.append(select, save);
+		if (suggestedScopes.size > 1 || resolvedScopes.size > 1 || hasGuardrailWarnings) {
+			const note = document.createElement("div");
+			note.className = "settings-note project-attention-note";
+			note.textContent = hasGuardrailWarnings
+				? "One or more identities in this group need individual review before bulk assignment."
+				: "This group has mixed suggestions or current Spaces. Choose a Space explicitly before bulk assignment.";
+			actions.appendChild(note);
+		}
+		row.appendChild(actions);
 	}
-	row.appendChild(actions);
 
 	const details = document.createElement("details");
 	details.className = "project-inventory-details";


### PR DESCRIPTION
## Description
Show project identities learned only from sync bootstrap/peer-received memories in the Projects inventory as read-only rows. This keeps received projects visible without allowing local reassignment or mapping actions to mutate peer-owned data.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced