### PR TITLE
fix(sync): propagate project reassignment to source memories

### DIFF
--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -266,9 +266,11 @@ describe("project scope settings", () => {
 			gitRemote: null,
 			project: "injection",
 		});
-		insertMemory(db, sessionId);
+		insertMemory(db, sessionId, { originDeviceId: "source-device", project: "injection" });
+		insertMemory(db, sessionId, { originDeviceId: "peer-device", project: "injection" });
 
 		const result = reassignProjectScopeInventoryProject(db, {
+			deviceId: "source-device",
 			project: "codemem",
 			workspaceIdentity: "/Users/adam/workspace/codemem/.claude/worktrees/injection",
 		});
@@ -283,6 +285,34 @@ describe("project scope settings", () => {
 			project: string;
 		};
 		expect(row.project).toBe("codemem");
+		const memory = db
+			.prepare(
+				"SELECT id, project, rev FROM memory_items WHERE session_id = ? AND origin_device_id = 'source-device'",
+			)
+			.get(sessionId) as { id: number; project: string; rev: number };
+		expect(memory).toMatchObject({ project: "codemem", rev: 1 });
+		const peerMemory = db
+			.prepare(
+				"SELECT project, rev FROM memory_items WHERE session_id = ? AND origin_device_id = 'peer-device'",
+			)
+			.get(sessionId) as { project: string; rev: number };
+		expect(peerMemory).toMatchObject({ project: "injection", rev: 0 });
+		const op = db
+			.prepare(
+				"SELECT clock_device_id, clock_rev, device_id, payload_json FROM replication_ops WHERE entity_id = ?",
+			)
+			.get(String(memory.id)) as {
+			clock_device_id: string;
+			clock_rev: number;
+			device_id: string;
+			payload_json: string;
+		};
+		expect(op).toMatchObject({
+			clock_device_id: "source-device",
+			clock_rev: 1,
+			device_id: "source-device",
+		});
+		expect(JSON.parse(op.payload_json)).toMatchObject({ project: "codemem" });
 		expect(listProjectScopeInventory(db, { query: "codemem" }).projects).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -291,6 +321,92 @@ describe("project scope settings", () => {
 				}),
 			]),
 		);
+	});
+
+	it("requires a current device id before reassigning a project", () => {
+		const sessionId = insertSession(db, {
+			cwd: "/Users/adam/workspace/codemem/.claude/worktrees/injection",
+			gitBranch: null,
+			gitRemote: null,
+			project: "injection",
+		});
+		insertMemory(db, sessionId, { originDeviceId: "source-device", project: "injection" });
+
+		expect(() =>
+			reassignProjectScopeInventoryProject(db, {
+				deviceId: " ",
+				project: "codemem",
+				workspaceIdentity: "/Users/adam/workspace/codemem/.claude/worktrees/injection",
+			}),
+		).toThrow("device_id must be a non-empty string");
+	});
+
+	it("reassigns local sessions without memory rows", () => {
+		const sessionId = insertSession(db, {
+			cwd: "/Users/adam/workspace/codemem/.claude/worktrees/injection",
+			gitBranch: null,
+			gitRemote: null,
+			project: "injection",
+		});
+
+		const result = reassignProjectScopeInventoryProject(db, {
+			deviceId: "source-device",
+			project: "codemem",
+			workspaceIdentity: "/Users/adam/workspace/codemem/.claude/worktrees/injection",
+		});
+
+		expect(result).toMatchObject({
+			moved_memory_count: 0,
+			moved_session_count: 1,
+			previous_projects: ["injection"],
+			project: "codemem",
+		});
+		expect(
+			(
+				db.prepare("SELECT project FROM sessions WHERE id = ?").get(sessionId) as {
+					project: string;
+				}
+			).project,
+		).toBe("codemem");
+		expect(
+			(db.prepare("SELECT COUNT(*) AS count FROM replication_ops").get() as { count: number })
+				.count,
+		).toBe(0);
+	});
+
+	it("does not reassign peer-owned-only project rows", () => {
+		const sessionId = insertSession(db, {
+			cwd: "/Users/adam/workspace/codemem/.claude/worktrees/injection",
+			gitBranch: null,
+			gitRemote: null,
+			project: "injection",
+		});
+		insertMemory(db, sessionId, { originDeviceId: "peer-device", project: "injection" });
+
+		expect(() =>
+			reassignProjectScopeInventoryProject(db, {
+				deviceId: "source-device",
+				project: "codemem",
+				workspaceIdentity: "/Users/adam/workspace/codemem/.claude/worktrees/injection",
+			}),
+		).toThrow("project identity has no source-owned memories on this device");
+		expect(
+			(
+				db.prepare("SELECT project FROM sessions WHERE id = ?").get(sessionId) as {
+					project: string;
+				}
+			).project,
+		).toBe("injection");
+		expect(
+			db.prepare("SELECT project, rev FROM memory_items WHERE session_id = ?").get(sessionId) as {
+				project: string;
+				rev: number;
+			},
+		).toMatchObject({ project: "injection", rev: 0 });
+		expect(
+			(db.prepare("SELECT COUNT(*) AS count FROM replication_ops").get() as { count: number })
+				.count,
+		).toBe(0);
 	});
 
 	it("suggests mappings from canonical signals without saving them", () => {

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -10,6 +10,7 @@ import {
 	type WorkspaceIdentitySource,
 } from "./scope-resolution.js";
 import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap.js";
+import { recordReplicationOp } from "./sync-replication.js";
 
 export interface SharingDomainSettingsScope {
 	scope_id: string;
@@ -980,9 +981,11 @@ export function listProjectScopeInventory(
 
 export function reassignProjectScopeInventoryProject(
 	db: Database,
-	input: { workspaceIdentity: string; project: string },
+	input: { deviceId: string; workspaceIdentity: string; project: string },
 ): ReassignProjectScopeInventoryProjectResult {
 	ensureScopeBackfillScopes(db);
+	const deviceId = clean(input.deviceId);
+	if (!deviceId) throw new Error("device_id must be a non-empty string");
 	const workspaceIdentity = normalizeWorkspaceIdentity(input.workspaceIdentity);
 	if (!workspaceIdentity) throw new Error("workspace_identity must be a non-empty string");
 	if (workspaceIdentity.startsWith("unmapped:")) {
@@ -1027,17 +1030,61 @@ export function reassignProjectScopeInventoryProject(
 		return identity.value === workspaceIdentity;
 	});
 	if (matched.length === 0) throw new Error("project identity not found");
+	const now = new Date().toISOString();
+	const sessionIds = matched.map((row) => row.id);
+	const sessionPlaceholders = sessionIds.map(() => "?").join(", ");
+	const sourceOwnedMemories = db
+		.prepare(
+			`SELECT id, session_id, project
+			 FROM memory_items
+			 WHERE session_id IN (${sessionPlaceholders})
+			   AND active = 1
+			   AND (origin_device_id IS NULL OR TRIM(origin_device_id) = '' OR origin_device_id = ?)`,
+		)
+		.all(...sessionIds, deviceId) as Array<{
+		id: number;
+		project: string | null;
+		session_id: number;
+	}>;
+	const sourceOwnedSessionIds = new Set(sourceOwnedMemories.map((memory) => memory.session_id));
+	const matchedSourceRows = matched.filter(
+		(row) => sourceOwnedSessionIds.has(row.id) || Number(row.memory_count ?? 0) === 0,
+	);
+	if (matchedSourceRows.length === 0) {
+		throw new Error("project identity has no source-owned memories on this device");
+	}
 	const previousProjects = [
-		...new Set(matched.map((row) => clean(row.project) ?? "").filter(Boolean)),
+		...new Set(matchedSourceRows.map((row) => clean(row.project) ?? "").filter(Boolean)),
 	].sort();
-	const movedMemoryCount = matched.reduce((total, row) => total + Number(row.memory_count ?? 0), 0);
+	const changedMemories = sourceOwnedMemories.filter(
+		(memory) => (clean(memory.project) ?? "") !== project,
+	);
+	const movedMemoryCount = changedMemories.length;
 	const update = db.prepare("UPDATE sessions SET project = ? WHERE id = ?");
 	db.transaction(() => {
-		for (const row of matched) update.run(project, row.id);
+		for (const row of matchedSourceRows) update.run(project, row.id);
+		if (changedMemories.length > 0) {
+			const memoryIds = changedMemories.map((memory) => Number(memory.id));
+			db.prepare(
+				`UPDATE memory_items
+				 SET project = ?, updated_at = ?, rev = COALESCE(rev, 0) + 1
+				 WHERE id IN (${memoryIds.map(() => "?").join(", ")})`,
+			).run(project, now, ...memoryIds);
+			for (const memoryId of memoryIds) {
+				recordReplicationOp(db, {
+					memoryId,
+					opType: "upsert",
+					deviceId,
+					clockDeviceId: deviceId,
+					clockUpdatedAt: now,
+					createdAt: now,
+				});
+			}
+		}
 	})();
 	return {
 		moved_memory_count: movedMemoryCount,
-		moved_session_count: matched.length,
+		moved_session_count: matchedSourceRows.length,
 		previous_projects: previousProjects,
 		project,
 		workspace_identity: workspaceIdentity,

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -3110,7 +3110,9 @@ export function syncRoutes(
 		try {
 			const workspaceIdentity = optionalViewerStrictString(body, "workspace_identity") ?? "";
 			const project = optionalViewerStrictString(body, "project") ?? "";
+			const [deviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 			const result = reassignProjectScopeInventoryProject(store.db, {
+				deviceId,
 				project,
 				workspaceIdentity,
 			});


### PR DESCRIPTION
## Description
Propagate source-side project reassignment into source-owned memory rows so sync payloads carry the corrected project to peers. The reassignment path now requires the current device id, gates session updates by source ownership, increments changed memory revisions/timestamps, and emits upsert replication ops only for source-owned memories.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced