### PR TITLE
fix(ui): gate Sync Space management affordance

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-peers.test.ts
+++ b/packages/ui/src/tabs/sync/components/sync-peers.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { canManageSpacesInTeams } from "./sync-peers";
+
+describe("canManageSpacesInTeams", () => {
+	it("allows the Teams management action only for ready coordinator admin devices", () => {
+		expect(canManageSpacesInTeams({ has_admin_secret: true, readiness: "ready" })).toBe(true);
+	});
+
+	it("blocks the Teams management action when admin capability is absent", () => {
+		expect(canManageSpacesInTeams({ has_admin_secret: false, readiness: "ready" })).toBe(false);
+		expect(canManageSpacesInTeams({ has_admin_secret: true, readiness: "partial" })).toBe(false);
+		expect(canManageSpacesInTeams(null)).toBe(false);
+	});
+});

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -149,6 +149,10 @@ function openTeamsAccessManagement(): void {
 	window.location.hash = "coordinator-admin";
 }
 
+export function canManageSpacesInTeams(status = state.lastCoordinatorAdminStatus): boolean {
+	return status?.readiness === "ready" && status.has_admin_secret === true;
+}
+
 function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncPeerCardProps) {
 	const peerId = String(peer.peer_device_id || "");
 	const displayName = peer.name || (peerId ? peerId.slice(0, 8) : "unknown");
@@ -282,12 +286,14 @@ function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncP
 
 	async function sync() {
 		if (pendingScopeReview) {
+			const canReviewInTeams = canManageSpacesInTeams();
 			const proceed = await openSyncConfirmDialog({
 				title: `Sync ${displayName} before advanced rule review?`,
-				description:
-					"This manual sync will use the current Space access and advanced filters until you review them in Teams.",
+				description: canReviewInTeams
+					? "This manual sync will use the current Space access and advanced filters until you review them in Teams."
+					: "This manual sync will use the current Space access and advanced filters until a coordinator or manager reviews them in Teams.",
 				confirmLabel: "Sync anyway",
-				cancelLabel: "Review in Teams first",
+				cancelLabel: canReviewInTeams ? "Review in Teams first" : "Cancel",
 			});
 			if (!proceed) return;
 		}
@@ -352,6 +358,7 @@ function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncP
 	// in SyncPeerStatusLike.
 	const presenceState: PresenceState = presenceForPeer(peer);
 	const syncMetaText = lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : "Sync: never";
+	const canManageSpaces = canManageSpacesInTeams();
 
 	const toggleLabel = `${isExpanded ? "Collapse" : "Expand"} device ${displayName}`;
 	// Read module-level state directly (not the stale closure value of
@@ -498,8 +505,9 @@ function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncP
 					<div className="peer-scope">
 						{scopeReviewRequested ? (
 							<div className="peer-meta">
-								Review this device&apos;s Space access and advanced rules in Teams if the defaults
-								are too broad.
+								{canManageSpaces
+									? "Review this device's Space access and advanced rules in Teams if the defaults are too broad."
+									: "A coordinator or manager can review this device's Space access and advanced rules in Teams if the defaults are too broad."}
 							</div>
 						) : pendingScopeReview ? (
 							<div className="peer-meta">
@@ -605,11 +613,21 @@ function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncP
 						<div className="peer-meta">
 							{projectNarrowing.statusLabel}. {projectNarrowing.summary} {projectNarrowing.note}
 						</div>
-						<div className="peer-actions">
-							<button type="button" className="settings-button" onClick={openTeamsAccessManagement}>
-								Manage Spaces in Teams
-							</button>
-						</div>
+						{canManageSpaces ? (
+							<div className="peer-actions">
+								<button
+									type="button"
+									className="settings-button"
+									onClick={openTeamsAccessManagement}
+								>
+									Manage Spaces in Teams
+								</button>
+							</div>
+						) : (
+							<div className="peer-meta">
+								Space access is managed in Teams by a coordinator or manager.
+							</div>
+						)}
 						<SyncInlineFeedback feedback={feedback} />
 					</div>
 				</Collapsible.Content>

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -8,7 +8,7 @@ import { renderSyncActorsList } from "./components/sync-actors";
 import { renderSyncEmptyState } from "./components/sync-diagnostics";
 import type { SyncActionFeedback } from "./components/sync-inline-feedback";
 import { renderLegacyClaimsSlice } from "./components/sync-legacy-claims";
-import { renderSyncPeersList } from "./components/sync-peers";
+import { canManageSpacesInTeams, renderSyncPeersList } from "./components/sync-peers";
 import { hideSkeleton, isPeerScopeReviewPending, shouldClearStalePeersFeedback } from "./helpers";
 import { openSyncConfirmDialog } from "./sync-dialogs";
 import {
@@ -143,8 +143,11 @@ export function renderSyncPeers() {
 					feedback = { message: summary.message, tone: "warning" };
 				} else if (peerId && isPeerScopeReviewPending(peerId)) {
 					const displayName = peer?.name || (peerId ? peerId.slice(0, 8) : "unknown");
+					const reviewGuidance = canManageSpacesInTeams()
+						? "Review Space access and advanced rules in Teams if this device needs tighter sharing."
+						: "A coordinator or manager can review Space access and advanced rules in Teams if this device needs tighter sharing.";
 					feedback = {
-						message: `Triggered sync for ${displayName}. Review Space access and advanced rules in Teams if this device needs tighter sharing.`,
+						message: `Triggered sync for ${displayName}. ${reviewGuidance}`,
 						tone: "warning",
 					};
 				} else {


### PR DESCRIPTION
## Description
Gate the Sync peer drawer’s `Manage Spaces in Teams` affordance behind coordinator management capability. Devices that cannot manage Spaces now see non-actionable coordinator/manager guidance instead, including pending-review dialog and post-sync feedback copy.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced