### PR TITLE
fix(sync): gate diagnostics redaction hint on explicit flag

### DIFF
--- a/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.test.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowSyncAttemptRedactionHint } from "./sync-attempts";
+
+describe("shouldShowSyncAttemptRedactionHint", () => {
+	it("shows the reveal hint only for explicitly redacted attempt errors", () => {
+		expect(
+			shouldShowSyncAttemptRedactionHint(
+				{
+					error_redacted: true,
+				},
+				true,
+			),
+		).toBe(true);
+	});
+
+	it("does not show the reveal hint for unredacted generic-looking errors", () => {
+		expect(
+			shouldShowSyncAttemptRedactionHint(
+				{
+					error_redacted: false,
+				},
+				true,
+			),
+		).toBe(false);
+		expect(
+			shouldShowSyncAttemptRedactionHint(
+				{
+					error_redacted: true,
+				},
+				false,
+			),
+		).toBe(false);
+	});
+});

--- a/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.ts
@@ -20,6 +20,13 @@ import {
 } from "../helpers";
 import type { SyncAttemptState } from "../types";
 
+export function shouldShowSyncAttemptRedactionHint(
+	attempt: Pick<SyncAttemptState, "error_redacted">,
+	redact: boolean,
+): boolean {
+	return redact && attempt.error_redacted === true;
+}
+
 export function renderSyncAttempts() {
 	const syncAttempts = document.getElementById("syncAttempts");
 	if (!syncAttempts) return;
@@ -55,7 +62,7 @@ export function renderSyncAttempts() {
 			// doesn't leak private addresses.
 			const errText = String(attempt.error);
 			detailParts.push(redact ? redactIpOctets(errText) : errText);
-			if (redact && /enable diagnostics for details/i.test(errText)) {
+			if (shouldShowSyncAttemptRedactionHint(attempt, redact)) {
 				detailParts.push("Turn off Redact in Advanced diagnostics to reveal the full error.");
 			}
 		}

--- a/packages/ui/src/tabs/sync/diagnostics/types.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/types.ts
@@ -36,6 +36,7 @@ export type SyncStatusState = {
 export type SyncAttemptState = {
 	address?: string;
 	error?: string;
+	error_redacted?: boolean;
 	finished_at?: string;
 	ops_in?: number;
 	ops_out?: number;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -7479,23 +7479,43 @@ describe("viewer-server", () => {
 				const redactedRes = await app.request("/api/sync/attempts");
 				expect(redactedRes.status).toBe(200);
 				const redactedBody = (await redactedRes.json()) as {
-					items: Array<{ error: string | null; address: string | null }>;
+					items: Array<{ error: string | null; error_redacted?: boolean; address: string | null }>;
 					redacted: boolean;
 				};
 				expect(redactedBody.redacted).toBe(true);
 				expect(redactedBody.items[0]?.error).toBe(
 					"sync attempt failed; enable diagnostics for details",
 				);
+				expect(redactedBody.items[0]?.error_redacted).toBe(true);
 				expect(redactedBody.items[0]?.address).toBeNull();
+
+				const redactedStatusRes = await app.request("/api/sync/status");
+				expect(redactedStatusRes.status).toBe(200);
+				const redactedStatusBody = (await redactedStatusRes.json()) as {
+					attempts: Array<{ error: string | null; error_redacted?: boolean }>;
+				};
+				expect(redactedStatusBody.attempts[0]?.error).toBe(
+					"sync attempt failed; enable diagnostics for details",
+				);
+				expect(redactedStatusBody.attempts[0]?.error_redacted).toBe(true);
 
 				const diagnosticRes = await app.request("/api/sync/attempts?includeDiagnostics=1");
 				expect(diagnosticRes.status).toBe(200);
 				const diagnosticBody = (await diagnosticRes.json()) as {
-					items: Array<{ error: string | null }>;
+					items: Array<{ error: string | null; error_redacted?: boolean }>;
 					redacted: boolean;
 				};
 				expect(diagnosticBody.redacted).toBe(false);
 				expect(diagnosticBody.items[0]?.error).toContain("fingerprint_mismatch");
+				expect(diagnosticBody.items[0]?.error_redacted).toBe(false);
+
+				const diagnosticStatusRes = await app.request("/api/sync/status?includeDiagnostics=1");
+				expect(diagnosticStatusRes.status).toBe(200);
+				const diagnosticStatusBody = (await diagnosticStatusRes.json()) as {
+					attempts: Array<{ error: string | null; error_redacted?: boolean }>;
+				};
+				expect(diagnosticStatusBody.attempts[0]?.error).toContain("fingerprint_mismatch");
+				expect(diagnosticStatusBody.attempts[0]?.error_redacted).toBe(false);
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1486,9 +1486,11 @@ function mapSyncAttemptRow(
 	showDiag: boolean,
 	addresses?: string[],
 ): Record<string, unknown> {
+	const redactedError = redactSyncAttemptError(row.error);
 	return {
 		...row,
-		error: showDiag ? row.error : redactSyncAttemptError(row.error),
+		error: showDiag ? row.error : redactedError,
+		error_redacted: !showDiag && redactedError != null,
 		status: attemptStatus(row),
 		address: showDiag && addresses?.length ? addresses[0] : null,
 	};


### PR DESCRIPTION
## Description
Add explicit per-attempt error redaction metadata to sync diagnostics responses and use that flag as the UI source of truth for the Redact reveal hint. Unredacted attempts no longer show generic "turn off Redact" guidance just because the error text looks like a redaction placeholder.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced