### PR TITLE
fix(mcp): allow Claude browser CORS preflights

### DIFF
--- a/docs/remote-mcp-oauth.md
+++ b/docs/remote-mcp-oauth.md
@@ -30,7 +30,7 @@ The Phase 1 endpoint is **single-user**. One self-hosted codemem instance, one a
        │ /authorize → redirect to upstream OIDC
        │ /oauth/callback → verify OIDC ID token, gate on allowlist
        │ /token → PKCE S256 + issue bearer token
-       │ /oauth/revoke → revoke bearer token
+       │ /revoke → revoke bearer token
        │ /mcp → require valid Bearer, run MCP tools
        │
        └► reads local SQLite via @codemem/core
@@ -62,6 +62,8 @@ The viewer process and `codemem mcp http` process must run on different ports. O
 | `CODEMEM_DB` | no | SQLite database path. |
 
 When OIDC env vars or `--public-url` are present the server requires bearer tokens on `POST /mcp`. Without both, the server runs in loopback-only development mode (`localhost`/`127.0.0.1`/`::1` only, no bearer).
+
+Public mode accepts browser CORS preflight requests from `https://claude.ai` on the OAuth and MCP routes while still requiring the request `Host` header to match `CODEMEM_MCP_HTTP_PUBLIC_URL`. Other browser origins remain blocked before OAuth processing.
 
 ## Running the server
 
@@ -111,7 +113,7 @@ Plan tier note: claude.ai custom connectors require Pro / Max / Team / Enterpris
 The bearer token expires after one hour. Revoke at any time with:
 
 ```sh
-curl -X POST "https://codemem-mcp.example.net/oauth/revoke" \
+curl -X POST "https://codemem-mcp.example.net/revoke" \
   -H "content-type: application/x-www-form-urlencoded" \
   --data-urlencode "token=<bearer>"
 ```
@@ -143,6 +145,12 @@ Bearer/access-token values, authorization codes, OIDC ID tokens, and client secr
 
 To disable audit output set `CODEMEM_MCP_AUDIT=0`.
 
+Early Host/Origin guard denials happen before OAuth audit events and are always written as one JSON line to stderr so operator logs show browser preflight or proxy-host failures without logging tokens, codes, or request bodies:
+
+```json
+{"source":"codemem-mcp-http-guard","outcome":"denied","reason":"host_or_origin_mismatch","method":"OPTIONS","path":"/register","host":"codemem-mcp.example.net","origin":"https://evil.test","expectedOrigin":"https://codemem-mcp.example.net"}
+```
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Where to look |
@@ -151,7 +159,7 @@ To disable audit output set `CODEMEM_MCP_AUDIT=0`.
 | `/authorize` returns `temporarily_unavailable` | OIDC env vars not set | Audit log shows `kind=authorize outcome=denied reason=temporarily_unavailable`. Verify `CODEMEM_MCP_OIDC_*` env vars. |
 | `/oauth/callback` returns `subject_not_allowed` | OIDC identity not allowlisted | Audit log shows `kind=oidc_callback outcome=denied reason=subject_not_allowed`. Update `CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT` or `CODEMEM_MCP_OAUTH_ALLOWED_EMAIL`. |
 | `POST /mcp` returns 401 | No / wrong bearer | Audit log shows `kind=bearer outcome=denied reason=...`. Re-run connector setup or check expired/revoked tokens. |
-| `POST /mcp` returns 403 with valid bearer | Host/Origin mismatch with `CODEMEM_MCP_HTTP_PUBLIC_URL` | Confirm the ingress preserves the configured public hostname. Audit log will not record this; the request is rejected before bearer verification. |
+| `POST /mcp` returns 403 with valid bearer | Host/Origin mismatch with `CODEMEM_MCP_HTTP_PUBLIC_URL` | Confirm the ingress preserves the configured public hostname. Check `codemem-mcp-http-guard` log lines; OAuth audit will not record this because the request is rejected before bearer verification. |
 | Connector hangs on registration | DCR rejected | Audit log shows `kind=registration outcome=denied reason=invalid_client_metadata`. Confirm Claude's DCR payload uses one of: `https://claude.ai/api/mcp/auth_callback` or a loopback `http://[127.0.0.1|localhost|::1]:<port>/callback` URI. |
 
 ## Validation checklist
@@ -166,7 +174,7 @@ Before announcing the connector ready, run the steps below against the live host
 - [ ] `/token` exchange with PKCE S256 returns a 43-character base64url bearer token, `token_type: "Bearer"`, `expires_in: 3600`.
 - [ ] `POST /mcp` with that bearer + `Authorization: Bearer …` returns `serverInfo.name === "codemem"` on initialize, and at least one of `memory_schema`/`memory_search` returns a successful result.
 - [ ] `POST /mcp` without the bearer returns 401 with `WWW-Authenticate: Bearer realm="codemem-mcp"`.
-- [ ] `POST /oauth/revoke` with the bearer returns 200; subsequent `/mcp` returns 401 with `reason=revoked_token` in the audit log.
+- [ ] `POST /revoke` with the bearer returns 200; subsequent `/mcp` returns 401 with `reason=revoked_token` in the audit log.
 - [ ] Audit log shows the expected `kind`/`outcome`/`reason` for each step and contains no token/code/secret material.
 
 Non-goals checked off:

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -35,6 +35,7 @@
 		"@codemem/core": "workspace:^",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"express": "^5.2.1",
+		"express-rate-limit": "^8.5.2",
 		"zod": "^4.4.2"
 	},
 	"devDependencies": {

--- a/packages/mcp-server/src/http.test.ts
+++ b/packages/mcp-server/src/http.test.ts
@@ -267,6 +267,81 @@ describe("MCP HTTP transport", () => {
 		expect(token.status).toBe(403);
 	});
 
+	it("allows Claude browser preflight requests on public OAuth and MCP routes", async () => {
+		const server = await startCodememMcpHttpServer({
+			dbPath: tempDbPath(),
+			port: 0,
+			publicUrl: "https://codemem.example.test/mcp",
+		});
+		servers.push(server);
+		const baseUrl = server.url.replace("/mcp", "");
+
+		const register = await requestWithHost(`${baseUrl}/register`, {
+			method: "OPTIONS",
+			host: "codemem.example.test",
+			headers: {
+				origin: "https://claude.ai",
+				"access-control-request-method": "POST",
+				"access-control-request-headers": "content-type",
+			},
+		});
+		const mcp = await requestWithHost(server.url, {
+			method: "OPTIONS",
+			host: "codemem.example.test",
+			headers: {
+				origin: "https://claude.ai",
+				"access-control-request-method": "POST",
+				"access-control-request-headers": "authorization,content-type,mcp-session-id",
+			},
+		});
+
+		expect(register.statusCode).toBe(204);
+		expect(register.headers["access-control-allow-origin"]).toBe("https://claude.ai");
+		expect(register.headers["access-control-allow-headers"]).toBe("content-type");
+		expect(mcp.statusCode).toBe(204);
+		expect(mcp.headers["access-control-allow-origin"]).toBe("https://claude.ai");
+		expect(mcp.headers["access-control-allow-headers"]).toBe(
+			"authorization,content-type,mcp-session-id",
+		);
+	});
+
+	it("logs early public Host and Origin guard denials", async () => {
+		const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const server = await startCodememMcpHttpServer({
+				dbPath: tempDbPath(),
+				port: 0,
+				publicUrl: "https://codemem.example.test/mcp",
+			});
+			servers.push(server);
+
+			const response = await requestWithHost(server.url.replace("/mcp", "/register"), {
+				method: "OPTIONS",
+				host: "codemem.example.test",
+				headers: {
+					origin: "https://evil.test",
+					"access-control-request-method": "POST",
+				},
+			});
+
+			expect(response.statusCode).toBe(403);
+			expect(consoleWarn).toHaveBeenCalledTimes(1);
+			const event = JSON.parse(String(consoleWarn.mock.calls[0]?.[0])) as Record<string, unknown>;
+			expect(event).toMatchObject({
+				source: "codemem-mcp-http-guard",
+				outcome: "denied",
+				reason: "host_or_origin_mismatch",
+				method: "OPTIONS",
+				path: "/register",
+				host: "codemem.example.test",
+				origin: "https://evil.test",
+				expectedOrigin: "https://codemem.example.test",
+			});
+		} finally {
+			consoleWarn.mockRestore();
+		}
+	});
+
 	it("accepts proxied OAuth token requests without rate-limit trust-proxy warnings", async () => {
 		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 		try {
@@ -315,6 +390,27 @@ describe("MCP HTTP transport", () => {
 		expect(response.statusCode).toBe(403);
 		expect(trailingSlash.statusCode).toBe(403);
 		expect(mcpTrailingSlash.statusCode).toBe(403);
+	});
+
+	it("rejects bare public Host headers when the configured public URL uses a non-default port", async () => {
+		const server = await startCodememMcpHttpServer({
+			dbPath: tempDbPath(),
+			port: 0,
+			publicUrl: "https://codemem.example.test:10000/mcp",
+		});
+		servers.push(server);
+
+		const bareHost = await postWithHost(
+			server.url.replace("/mcp", "/register"),
+			"codemem.example.test",
+		);
+		const explicitHost = await postWithHost(
+			server.url.replace("/mcp", "/register"),
+			"codemem.example.test:10000",
+		);
+
+		expect(bareHost.statusCode).toBe(403);
+		expect(explicitHost.statusCode).toBe(400);
 	});
 
 	it("rejects unsupported OAuth redirect URIs", async () => {
@@ -641,6 +737,27 @@ async function postWithHost(
 	host: string,
 	extraHeaders: Record<string, string> = {},
 ): Promise<{ statusCode: number | undefined }> {
+	const response = await requestWithHost(url, {
+		method: "POST",
+		host,
+		headers: extraHeaders,
+		body: initializeBody(1),
+	});
+	return { statusCode: response.statusCode };
+}
+
+async function requestWithHost(
+	url: string,
+	options: {
+		method: string;
+		host: string;
+		headers?: Record<string, string>;
+		body?: string;
+	},
+): Promise<{
+	statusCode: number | undefined;
+	headers: Record<string, string | string[] | undefined>;
+}> {
 	const target = new URL(url);
 	return await new Promise((resolve, reject) => {
 		const req = request(
@@ -648,21 +765,26 @@ async function postWithHost(
 				hostname: target.hostname,
 				port: target.port,
 				path: target.pathname,
-				method: "POST",
+				method: options.method,
 				headers: {
 					accept: "application/json, text/event-stream",
 					"content-type": "application/json",
-					host,
-					...extraHeaders,
+					host: options.host,
+					...options.headers,
 				},
 			},
 			(res) => {
 				res.resume();
-				res.on("end", () => resolve({ statusCode: res.statusCode }));
+				res.on("end", () =>
+					resolve({
+						statusCode: res.statusCode,
+						headers: res.headers,
+					}),
+				);
 			},
 		);
 		req.on("error", reject);
-		req.end(initializeBody(1));
+		req.end(options.body);
 	});
 }
 

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -20,6 +20,7 @@ import {
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import express, { type NextFunction, type Request, type Response } from "express";
+import { rateLimit } from "express-rate-limit";
 import {
 	type BearerDenyReason,
 	buildOAuthAuditEvent,
@@ -51,6 +52,12 @@ import { createCodememMcpServer } from "./server.js";
 export const DEFAULT_MCP_HTTP_HOST = "127.0.0.1";
 export const DEFAULT_MCP_HTTP_PORT = 38889;
 const HTTP_DEFAULT_PORT = 80;
+const TRUSTED_PUBLIC_BROWSER_ORIGINS = new Set(["https://claude.ai"]);
+const CORS_ALLOW_HEADERS = "authorization,content-type,mcp-session-id";
+const CORS_MAX_AGE_SECONDS = "600";
+const MAX_GUARD_LOG_FIELD_LENGTH = 256;
+const PUBLIC_MCP_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const PUBLIC_MCP_RATE_LIMIT_REQUESTS = 600;
 
 const VALID_HOSTNAME = /^[a-zA-Z0-9.-]+$/;
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
@@ -237,16 +244,45 @@ export async function startCodememMcpHttpServer(
 	});
 	const resourceMetadataUrl = getOAuthProtectedResourceMetadataUrl(publicMcpUrlObject);
 
+	app.use(
+		rateLimit({
+			windowMs: PUBLIC_MCP_RATE_LIMIT_WINDOW_MS,
+			limit: PUBLIC_MCP_RATE_LIMIT_REQUESTS,
+			standardHeaders: "draft-8",
+			legacyHeaders: false,
+			// Avoid express-rate-limit's default IPv6 subnet helper here: its current
+			// transitive ip-address API throws on IPv6 loopback in our Node 24 test path.
+			// This coarse limiter is defense-in-depth before the SDK OAuth limiters and
+			// the Host/Origin guard; it must never break local IPv6 metadata requests.
+			ipv6Subnet: false,
+		}),
+	);
 	app.use((req, res, next) => {
 		const boundPort = getBoundPort(server);
 		const pathname = normalizeRoutePath(req.path);
 		if (pathname === "/mcp") {
-			if (isAllowedMcpHttpRequest(req, boundPort, configuredPublicMcpUrl)) return next();
+			if (isAllowedMcpHttpRequest(req, boundPort, configuredPublicMcpUrl)) {
+				applyPublicCorsHeaders(req, res, configuredPublicMcpUrl);
+				if (req.method === "OPTIONS") {
+					res.status(204).send("");
+					return;
+				}
+				return next();
+			}
+			emitHttpGuardDeny(req, pathname, configuredPublicMcpUrl);
 			res.status(403).type("text/plain").send("Forbidden");
 			return;
 		}
 		if (isOAuthOrMetadataPath(pathname)) {
-			if (isAllowedOAuthHttpRequest(req, boundPort, configuredPublicMcpUrl)) return next();
+			if (isAllowedOAuthHttpRequest(req, boundPort, configuredPublicMcpUrl)) {
+				applyPublicCorsHeaders(req, res, configuredPublicMcpUrl);
+				if (req.method === "OPTIONS") {
+					res.status(204).send("");
+					return;
+				}
+				return next();
+			}
+			emitHttpGuardDeny(req, pathname, configuredPublicMcpUrl);
 			res.status(403).type("text/plain").send("Forbidden");
 			return;
 		}
@@ -449,10 +485,72 @@ function isAllowedPublicOrigin(header: string | undefined, publicMcpUrl: URL): b
 	if (!header) return true;
 	try {
 		const origin = new URL(header);
-		return origin.origin === publicMcpUrl.origin;
+		return (
+			origin.origin === publicMcpUrl.origin || TRUSTED_PUBLIC_BROWSER_ORIGINS.has(origin.origin)
+		);
 	} catch {
 		return false;
 	}
+}
+
+function applyPublicCorsHeaders(
+	req: IncomingMessage,
+	res: Response,
+	publicMcpUrl: URL | undefined,
+): void {
+	if (!publicMcpUrl) return;
+	const origin = getAllowedPublicCorsOrigin(req.headers.origin, publicMcpUrl);
+	if (!origin) return;
+	res.setHeader("Access-Control-Allow-Origin", origin);
+	res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+	res.setHeader(
+		"Access-Control-Allow-Headers",
+		req.headers["access-control-request-headers"] ?? CORS_ALLOW_HEADERS,
+	);
+	res.setHeader("Access-Control-Max-Age", CORS_MAX_AGE_SECONDS);
+	res.setHeader("Vary", "Origin");
+}
+
+function getAllowedPublicCorsOrigin(
+	header: string | undefined,
+	publicMcpUrl: URL,
+): string | undefined {
+	if (!header) return undefined;
+	try {
+		const origin = new URL(header).origin;
+		if (origin === publicMcpUrl.origin || TRUSTED_PUBLIC_BROWSER_ORIGINS.has(origin)) {
+			return origin;
+		}
+	} catch {
+		return undefined;
+	}
+	return undefined;
+}
+
+function emitHttpGuardDeny(
+	req: IncomingMessage,
+	pathname: string,
+	publicMcpUrl: URL | undefined,
+): void {
+	console.warn(
+		JSON.stringify({
+			source: "codemem-mcp-http-guard",
+			timestamp: new Date().toISOString(),
+			outcome: "denied",
+			reason: "host_or_origin_mismatch",
+			method: req.method,
+			path: pathname,
+			host: truncateGuardLogField(req.headers.host),
+			origin: truncateGuardLogField(req.headers.origin),
+			expectedOrigin: publicMcpUrl?.origin,
+			remoteAddress: req.socket.remoteAddress ?? undefined,
+		}),
+	);
+}
+
+function truncateGuardLogField(value: string | undefined): string | undefined {
+	if (!value || value.length <= MAX_GUARD_LOG_FIELD_LENGTH) return value;
+	return `${value.slice(0, MAX_GUARD_LOG_FIELD_LENGTH)}…`;
 }
 
 function isAllowedPublicRequestHost(header: string | undefined, publicMcpUrl: URL): boolean {
@@ -463,7 +561,8 @@ function isAllowedPublicRequestHost(header: string | undefined, publicMcpUrl: UR
 		: publicMcpUrl.protocol === "https:"
 			? 443
 			: 80;
-	const actualPort = parsed.port ?? expectedPort;
+	const impliedPort = publicMcpUrl.protocol === "https:" ? 443 : 80;
+	const actualPort = parsed.port ?? impliedPort;
 	return (
 		normalizeHost(parsed.host) === normalizeHost(publicMcpUrl.hostname) &&
 		actualPort === expectedPort

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.5.2
+        version: 8.5.2(express@5.2.1)
       zod:
         specifier: ^4.4.2
         version: 4.4.2
@@ -2706,6 +2709,12 @@ packages:
 
   express-rate-limit@8.3.1:
     resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -5744,6 +5753,11 @@ snapshots:
   expect-type@1.3.0: {}
 
   express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.1
+
+  express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.1.1


### PR DESCRIPTION
## Description
Allow Claude browser-origin CORS preflight on public MCP/OAuth routes while preserving the public Host check. Add early Host/Origin guard denial logs so proxy/CORS failures show up even when OAuth audit middleware is not reached.

Also tightens public Host validation for non-default public ports so a bare Host header is not treated as matching an explicit `:10000` public URL.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Local checks run:
- `pnpm exec vitest run packages/mcp-server/src/http.test.ts`
- `pnpm run lint`
- `pnpm run tsc`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced