### PR TITLE
fix(ui): add token-aligned focus rings to remaining inputs and buttons

### DIFF
--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -3509,6 +3509,34 @@
         .modal-card { padding: var(--sp-4); border-radius: var(--radius-lg); }
       }
 
+      /* ──────────────────────────────────────────────────────────────────
+         Token-aligned focus rings.
+
+         The interactive surfaces below previously relied on the browser's
+         default focus outline. They now share the same focus language as
+         the rest of the system:
+           - Buttons get a 2px var(--accent) outline with a 2px offset.
+           - Inputs and selects get an accent border + 3px var(--focus-ring)
+             halo, matching .feed-search / .project-filter / .sync-actor-select.
+         Radix-managed items (with [data-highlighted]) are intentionally not
+         touched here because their highlight state already serves as a
+         keyboard-focus indicator. */
+      .coordinator-admin-tab-trigger:focus-visible,
+      .feed-inspector-button:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      .actor-merge-select:focus,
+      .actor-name-input:focus,
+      .feed-visibility-select:focus,
+      .legacy-review-search:focus,
+      .peer-scope-input:focus,
+      .project-domain-select:focus {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--focus-ring);
+      }
+
       @media (prefers-reduced-motion: reduce) {
         *, *::before, *::after {
           animation-duration: 0.01ms !important;


### PR DESCRIPTION
## Description
Adds explicit `:focus-visible` (or `:focus` on inputs) rings to the nine interactive surfaces that previously fell back to the browser default focus outline. These are all custom Radix/button/input/select surfaces that have token-aligned hover and active states but no token-aligned focus state.

Buttons get the same `outline: 2px solid var(--accent); outline-offset: 2px;` pattern used by `.tab-btn`, `.icon-button`, `.settings-button`, etc. Inputs and selects get the `border-color: var(--accent); box-shadow: 0 0 0 3px var(--focus-ring);` halo used by `.feed-search`, `.project-filter`, `.sync-actor-select`, etc.

Surfaces covered:
- `.coordinator-admin-tab-trigger`
- `.feed-inspector-button`
- `.actor-merge-select`
- `.actor-name-input`
- `.feed-visibility-select`
- `.legacy-review-search`
- `.peer-scope-input`
- `.project-domain-select`

Radix items with `[data-highlighted]` are intentionally untouched — their highlight state already serves as a keyboard-focus indicator.

Context: this PR also confirms that the global `@media (prefers-reduced-motion: reduce)` block already in place at the bottom of the stylesheet means reduced-motion gating is broader than my initial audit claimed; the only remaining motion work is duration/easing tokenization, tracked separately as `codemem-z4m2`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, full UI vitest, UI build)
- [x] Added/updated tests for changes (existing focus-ring tests still pass; new rules are CSS-only)
- [ ] Manually verified changes work as expected

Validated with:
- `pnpm run lint`
- `pnpm run tsc`
- `pnpm --filter @codemem/ui build`
- `pnpm exec vitest run packages/ui` (21 files / 166 tests pass)
- `git diff --check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] Documentation updated (token-aligned focus rings comment block documents the pattern)
- [x] No new warnings introduced
