### PR TITLE
refactor(ui): tokenize motion durations and easings

### DIFF
--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -139,6 +139,38 @@
         --font-weight-medium:   500;
         --font-weight-semibold: 600;
         --font-weight-bold:     700;
+
+        /* Motion — durations and easings.
+
+           The hover/state transition tier uses a small scale
+           (instant/fast/base/medium). Named keyframe animations get
+           semantic tokens because their duration is coupled to a specific
+           timing curve and cannot be freely reshuffled. The three most
+           common timing functions (ease, ease-in-out, ease-out) are
+           tokenized; rare one-offs (linear, steps()) remain inline.
+
+           A global @media (prefers-reduced-motion: reduce) block at the
+           bottom of this stylesheet already collapses every transition
+           and finite animation to 0.01ms, plus the four reduce blocks
+           that null specific infinite animations. So tokenization here is
+           visually identical to current main. */
+        --duration-instant: 80ms;
+        --duration-fast:    140ms;
+        --duration-toast:   160ms;
+        --duration-base:    200ms;
+        --duration-medium:  250ms;
+        --duration-shake:   300ms;
+        --duration-fade-up: 400ms;
+        --duration-new-pulse: 420ms;
+        --duration-attention: 900ms;
+        --duration-blink:   1100ms;
+        --duration-pip:     1200ms;
+        --duration-shimmer: 1500ms;
+        --duration-pulse:   2400ms;
+
+        --ease-standard: ease;
+        --ease-in-out:   ease-in-out;
+        --ease-out:      ease-out;
       }
 
       /* ── Light variant ─────────────────────────────────────── */
@@ -390,7 +422,7 @@
       }
       .health-dot.status-healthy { background: var(--status-healthy); box-shadow: 0 0 0 3px var(--accent-subtle); }
       .health-dot.status-degraded { background: var(--status-degraded); box-shadow: 0 0 0 3px var(--accent-warm-subtle); }
-      .health-dot.status-attention { background: var(--status-attention); box-shadow: 0 0 0 3px rgba(255, 122, 80, 0.18); animation: pulse 2.4s ease infinite; }
+      .health-dot.status-attention { background: var(--status-attention); box-shadow: 0 0 0 3px rgba(255, 122, 80, 0.18); animation: pulse var(--duration-pulse) var(--ease-standard) infinite; }
 
       .header-right {
         display: flex;
@@ -449,7 +481,7 @@
         font-size: var(--font-size-md);
         font-weight: var(--font-weight-medium);
         cursor: pointer;
-        transition: color 140ms ease;
+        transition: color var(--duration-fast) var(--ease-standard);
       }
 
       .tab-btn:hover {
@@ -523,7 +555,7 @@
         border-radius: var(--radius-xl);
         padding: var(--sp-5);
         box-shadow: var(--shadow-md);
-        animation: fadeUp 0.4s ease both;
+        animation: fadeUp var(--duration-fade-up) var(--ease-standard) both;
       }
 
       .card h2 {
@@ -700,7 +732,7 @@
         cursor: pointer;
         flex-shrink: 0;
         padding: 1px;
-        transition: background 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+        transition: background var(--duration-fast) var(--ease-standard), border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
       }
 
       .coordinator-admin-switch:hover {
@@ -731,7 +763,7 @@
         background: color-mix(in srgb, var(--surface-0) 88%, white);
         border: 1px solid color-mix(in srgb, var(--text-tertiary) 24%, transparent);
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
-        transition: transform 140ms ease, background 140ms ease;
+        transition: transform var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard);
         transform: translateX(0);
       }
 
@@ -768,7 +800,7 @@
         display: inline-flex;
         width: 14px;
         height: 14px;
-        transition: transform 140ms ease;
+        transition: transform var(--duration-fast) var(--ease-standard);
       }
       .coordinator-admin-scope-trigger .device-row-chevron svg {
         width: 100%;
@@ -924,7 +956,7 @@
         text-decoration: none;
         padding: 4px 6px;
         border-radius: var(--radius-sm);
-        transition: color 140ms ease;
+        transition: color var(--duration-fast) var(--ease-standard);
       }
       .sync-subview-link:hover {
         color: var(--accent);
@@ -1037,7 +1069,7 @@
         min-width: 28px;
         min-height: 28px;
         font-size: var(--font-size-sm);
-        transition: background 140ms ease, border-color 140ms ease;
+        transition: background var(--duration-fast) var(--ease-standard), border-color var(--duration-fast) var(--ease-standard);
       }
       .settings-button:hover {
         background: var(--control-hover-bg);
@@ -1095,7 +1127,7 @@
       .device-row-chevron svg {
         width: 18px;
         height: 18px;
-        transition: transform 140ms ease;
+        transition: transform var(--duration-fast) var(--ease-standard);
       }
       button.device-row-head--trigger[data-state="open"] .device-row-chevron svg {
         transform: rotate(90deg);
@@ -1160,7 +1192,7 @@
           color-mix(in srgb, var(--surface-2) 60%, var(--surface-1)) 50%,
           color-mix(in srgb, var(--surface-2) 82%, var(--surface-1)) 75%);
         background-size: 200% 100%;
-        animation: device-skel-shimmer 1.5s ease-in-out infinite;
+        animation: device-skel-shimmer var(--duration-shimmer) var(--ease-in-out) infinite;
       }
       .device-row-skeleton .skel-pip {
         width: 8px;
@@ -1203,7 +1235,7 @@
         cursor: pointer;
         flex-shrink: 0;
         padding: 1px;
-        transition: background 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+        transition: background var(--duration-fast) var(--ease-standard), border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
       }
 
       .sync-redact-switch:hover {
@@ -1229,7 +1261,7 @@
         background: color-mix(in srgb, var(--surface-0) 88%, white);
         border: 1px solid color-mix(in srgb, var(--text-tertiary) 24%, transparent);
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
-        transition: transform 140ms ease, background 140ms ease;
+        transition: transform var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard);
         transform: translateX(0);
       }
 
@@ -1250,7 +1282,7 @@
         font-family: var(--font-sans);
         font-size: var(--font-size-sm);
         cursor: pointer;
-        transition: border-color 140ms ease;
+        transition: border-color var(--duration-fast) var(--ease-standard);
       }
       .project-filter:hover { border-color: var(--border-hover); }
       .project-filter:focus {
@@ -1366,7 +1398,7 @@
         color: var(--control-text);
         cursor: pointer;
         flex-shrink: 0;
-        transition: background-color 140ms ease, border-color 140ms ease, transform 140ms ease;
+        transition: background-color var(--duration-fast) var(--ease-standard), border-color var(--duration-fast) var(--ease-standard), transform var(--duration-fast) var(--ease-standard);
       }
       .icon-button:hover {
         background: var(--control-hover-bg);
@@ -1439,7 +1471,7 @@
         font-family: var(--font-sans);
         font-size: var(--font-size-md);
         outline: none;
-        transition: border-color 140ms ease, box-shadow 140ms ease;
+        transition: border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
       }
       .feed-search::placeholder { color: var(--text-tertiary); }
       .feed-search:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--focus-ring); }
@@ -1458,7 +1490,7 @@
         line-height: 1.45;
         resize: vertical;
         outline: none;
-        transition: border-color 140ms ease, box-shadow 140ms ease;
+        transition: border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
       }
       .feed-inspector-files::placeholder { color: var(--text-tertiary); }
       .feed-inspector-files:focus {
@@ -1487,7 +1519,7 @@
         display: inline-flex;
         align-items: center;
         gap: 5px;
-        transition: background-color 140ms ease, color 140ms ease, box-shadow 140ms ease;
+        transition: background-color var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
       }
       .toggle-button:hover { background: var(--toggle-hover-bg); color: var(--text-primary); }
       .toggle-button.active {
@@ -1529,7 +1561,7 @@
         height: 28px;
         background: linear-gradient(90deg, var(--surface-2) 25%, var(--surface-3) 50%, var(--surface-2) 75%);
         background-size: 400px 100%;
-        animation: sync-shimmer 1.5s ease-in-out infinite;
+        animation: sync-shimmer var(--duration-shimmer) var(--ease-in-out) infinite;
         border-bottom: 1px solid var(--border);
       }
       .feed-skeleton-body {
@@ -1543,7 +1575,7 @@
         border-radius: 6px;
         background: linear-gradient(90deg, var(--surface-2) 25%, var(--surface-3) 50%, var(--surface-2) 75%);
         background-size: 400px 100%;
-        animation: sync-shimmer 1.5s ease-in-out infinite;
+        animation: sync-shimmer var(--duration-shimmer) var(--ease-in-out) infinite;
       }
       .feed-skeleton-line.w-85 { width: 85%; }
       .feed-skeleton-line.w-65 { width: 65%; }
@@ -1559,7 +1591,7 @@
         border-radius: var(--radius-pill);
         background: linear-gradient(90deg, var(--surface-2) 25%, var(--surface-3) 50%, var(--surface-2) 75%);
         background-size: 400px 100%;
-        animation: sync-shimmer 1.5s ease-in-out infinite;
+        animation: sync-shimmer var(--duration-shimmer) var(--ease-in-out) infinite;
       }
       .feed-skeleton-chip.w-36 { width: 36px; }
       .feed-skeleton-chip.w-56 { width: 56px; }
@@ -1578,7 +1610,7 @@
         display: flex;
         flex-direction: column;
         box-shadow: var(--shadow-sm);
-        transition: transform 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+        transition: transform var(--duration-fast) var(--ease-standard), border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
       }
       .feed-item:hover {
         transform: translateY(-1px);
@@ -1651,7 +1683,7 @@
         color: var(--text-tertiary);
         font-size: var(--font-size-2xl);
         line-height: 1;
-        transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
+        transition: background var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard), border-color var(--duration-fast) var(--ease-standard);
       }
       .feed-menu-trigger:hover,
       .feed-menu-trigger[data-state="open"] {
@@ -1741,7 +1773,7 @@
         content: "_";
         display: inline-block;
         color: var(--accent);
-        animation: cursorBlink 1.1s steps(2, end) infinite;
+        animation: cursorBlink var(--duration-blink) steps(2, end) infinite;
       }
       @keyframes cursorBlink {
         0%, 100% { opacity: 1; }
@@ -1854,7 +1886,7 @@
         color: var(--text-tertiary);
         padding: 3px 10px;
         font-size: var(--font-size-xs);
-        transition: background 140ms ease, color 140ms ease;
+        transition: background var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard);
       }
       .feed-expand:hover { background: var(--accent-subtle); color: var(--accent); }
       .feed-expand:focus-visible {
@@ -1928,7 +1960,7 @@
         color: var(--accent);
         font-size: var(--font-size-sm);
         font-weight: var(--font-weight-semibold);
-        transition: background 140ms ease, color 140ms ease;
+        transition: background var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard);
       }
       .pill.alt { background: var(--accent-warm-subtle); color: var(--accent-warm); }
       .pill-success { background: var(--green-bg, #16a34a22); color: var(--green-text, #16a34a); }
@@ -1951,7 +1983,7 @@
         font-size: var(--font-size-sm);
         font-weight: var(--font-weight-semibold);
         letter-spacing: 0.02em;
-        transition: background 140ms ease, color 140ms ease;
+        transition: background var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard);
       }
       .sync-online-badge::before {
         content: "";
@@ -2005,7 +2037,7 @@
         color: var(--accent);
         text-decoration-color: color-mix(in srgb, var(--accent) 52%, transparent);
         text-underline-offset: 3px;
-        transition: color 140ms ease, text-decoration-color 140ms ease;
+        transition: color var(--duration-fast) var(--ease-standard), text-decoration-color var(--duration-fast) var(--ease-standard);
       }
       .settings-link:hover,
       .sync-subview-link:hover {
@@ -2388,8 +2420,8 @@
       .presence-pip--online    { background: var(--accent); }
       .presence-pip--offline   { background: var(--accent-warm, var(--accent)); }
       .presence-pip--degraded  { background: var(--accent-warm, var(--accent)); }
-      .presence-pip--attention { background: var(--accent-warm-strong, var(--accent-warm, var(--accent))); animation: pip-attention 2.4s ease-in-out infinite; }
-      .presence-pip--syncing   { background: var(--accent); animation: pip-syncing 1.2s ease-in-out infinite; }
+      .presence-pip--attention { background: var(--accent-warm-strong, var(--accent-warm, var(--accent))); animation: pip-attention var(--duration-pulse) var(--ease-in-out) infinite; }
+      .presence-pip--syncing   { background: var(--accent); animation: pip-syncing var(--duration-pip) var(--ease-in-out) infinite; }
       .presence-pip--unknown   { background: var(--text-tertiary); opacity: 0.6; }
 
       @keyframes pip-attention {
@@ -2433,7 +2465,7 @@
         display: grid;
         gap: var(--sp-2);
         overflow: hidden;
-        transition: max-height 0.25s ease, opacity 0.2s ease;
+        transition: max-height var(--duration-medium) var(--ease-standard), opacity var(--duration-base) var(--ease-standard);
         max-height: 400px;
         opacity: 1;
       }
@@ -2452,7 +2484,7 @@
         border-radius: 6px;
         background: linear-gradient(90deg, var(--border) 25%, var(--surface-2) 50%, var(--border) 75%);
         background-size: 400px 100%;
-        animation: sync-shimmer 1.5s ease-in-out infinite;
+        animation: sync-shimmer var(--duration-shimmer) var(--ease-in-out) infinite;
         margin: 8px 0;
       }
       .sync-skeleton-line.short { width: 40%; }
@@ -2463,7 +2495,7 @@
         border-radius: 8px;
         background: linear-gradient(90deg, var(--border) 25%, var(--surface-2) 50%, var(--border) 75%);
         background-size: 400px 100%;
-        animation: sync-shimmer 1.5s ease-in-out infinite;
+        animation: sync-shimmer var(--duration-shimmer) var(--ease-in-out) infinite;
         margin: 8px 0;
       }
       .sync-empty-state {
@@ -2508,7 +2540,7 @@
         20%, 60% { transform: translateX(-4px); }
         40%, 80% { transform: translateX(4px); }
       }
-      .sync-shake { animation: sync-shake 0.3s ease-in-out; }
+      .sync-shake { animation: sync-shake var(--duration-shake) var(--ease-in-out); }
       @keyframes sync-attention-target {
         0% {
           transform: translateY(0);
@@ -2524,14 +2556,14 @@
         }
       }
       .sync-attention-target {
-        animation: sync-attention-target 900ms ease-out;
+        animation: sync-attention-target var(--duration-attention) var(--ease-out);
       }
       .settings-button:disabled {
         opacity: 0.55;
         cursor: not-allowed;
       }
       .settings-button {
-        transition: opacity 140ms ease, background 140ms ease, color 140ms ease;
+        transition: opacity var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard);
       }
       .sync-toggle-admin {
         background: none;
@@ -2676,7 +2708,7 @@
         font-family: var(--font-sans);
         font-size: var(--font-size-md);
         cursor: pointer;
-        transition: border-color 140ms ease, box-shadow 140ms ease;
+        transition: border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
       }
       .sync-legacy-select:hover { border-color: var(--border-hover); }
       .sync-legacy-select:focus {
@@ -2691,7 +2723,7 @@
         padding: 8px 14px;
         font-size: var(--font-size-md);
         font-weight: var(--font-weight-semibold);
-        transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+        transition: background var(--duration-fast) var(--ease-standard), border-color var(--duration-fast) var(--ease-standard), transform var(--duration-fast) var(--ease-standard);
       }
       .sync-legacy-button:hover {
         background: var(--control-hover-bg);
@@ -2715,7 +2747,7 @@
         font-family: var(--font-sans);
         font-size: var(--font-size-md);
         cursor: pointer;
-        transition: border-color 140ms ease, box-shadow 140ms ease;
+        transition: border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
       }
       .sync-actor-select:hover { border-color: var(--border-hover); }
       .sync-actor-select:focus {
@@ -2798,7 +2830,7 @@
         max-width: 320px;
         z-index: 60;
         user-select: none;
-        animation: tooltipFade 140ms ease;
+        animation: tooltipFade var(--duration-fast) var(--ease-standard);
       }
       .tooltip-content[data-state="closed"] { animation: none; }
       .tooltip-arrow { fill: var(--surface-1); filter: drop-shadow(0 1px 0 var(--border)); }
@@ -2821,7 +2853,7 @@
         cursor: pointer;
         font-family: var(--font-sans);
         font-size: var(--font-size-sm);
-        transition: border-color 140ms ease, background 140ms ease, color 140ms ease;
+        transition: border-color var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard);
       }
       .modal-close-button:hover {
         border-color: var(--border-hover);
@@ -2884,11 +2916,11 @@
         font-size: var(--font-size-md);
         line-height: 1.5;
       }
-      .toast-root[data-state="open"] { animation: toastSlideIn 160ms ease; }
-      .toast-root[data-state="closed"] { animation: toastFadeOut 140ms ease forwards; }
+      .toast-root[data-state="open"] { animation: toastSlideIn var(--duration-toast) var(--ease-standard); }
+      .toast-root[data-state="closed"] { animation: toastFadeOut var(--duration-fast) var(--ease-standard) forwards; }
       .toast-root[data-swipe="move"] { transform: translateX(var(--radix-toast-swipe-move-x)); }
-      .toast-root[data-swipe="cancel"] { transform: translateX(0); transition: transform 140ms ease; }
-      .toast-root[data-swipe="end"] { animation: toastSwipeOut 140ms ease forwards; }
+      .toast-root[data-swipe="cancel"] { transform: translateX(0); transition: transform var(--duration-fast) var(--ease-standard); }
+      .toast-root[data-swipe="end"] { animation: toastSwipeOut var(--duration-fast) var(--ease-standard) forwards; }
 
       .toast-success { border-left-color: var(--accent); }
       .toast-info    { border-left-color: var(--accent-cool); }
@@ -2910,7 +2942,7 @@
         font-size: var(--font-size-base);
         line-height: 1;
         cursor: pointer;
-        transition: background-color 140ms ease, color 140ms ease;
+        transition: background-color var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard);
         padding: 0;
         flex-shrink: 0;
       }
@@ -2985,7 +3017,7 @@
         border-radius: 50%;
         border: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
         border-top-color: var(--accent);
-        animation: reconnectSpin 0.9s linear infinite;
+        animation: reconnectSpin var(--duration-attention) linear infinite;
       }
       @keyframes reconnectSpin {
         from { transform: rotate(0deg); }
@@ -3139,7 +3171,7 @@
         pointer-events: none;
         opacity: 0;
         transform: translateY(-2px);
-        transition: opacity 0.08s ease, transform 0.08s ease;
+        transition: opacity var(--duration-instant) var(--ease-standard), transform var(--duration-instant) var(--ease-standard);
         z-index: 1000;
       }
 
@@ -3245,7 +3277,7 @@
         cursor: pointer;
         flex-shrink: 0;
         padding: 1px;
-        transition: background 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+        transition: background var(--duration-fast) var(--ease-standard), border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
       }
       .settings-switch:hover {
         border-color: color-mix(in srgb, var(--accent) 38%, var(--control-hover-border));
@@ -3271,7 +3303,7 @@
         background: color-mix(in srgb, var(--surface-0) 88%, white);
         border: 1px solid color-mix(in srgb, var(--text-tertiary) 24%, transparent);
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
-        transition: transform 140ms ease, background 140ms ease;
+        transition: transform var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard);
         transform: translateX(0);
       }
       .settings-switch[data-state="checked"] .settings-switch-thumb {
@@ -3318,7 +3350,7 @@
         font-family: var(--font-sans);
         font-size: var(--font-size-sm);
         cursor: pointer;
-        transition: background 140ms ease;
+        transition: background var(--duration-fast) var(--ease-standard);
       }
       .settings-save:hover { background: var(--control-hover-bg); }
       .sync-dialog-card {
@@ -3408,7 +3440,7 @@
         border-radius: var(--radius-md);
         background: color-mix(in srgb, var(--surface-1) 86%, var(--surface-0));
         cursor: pointer;
-        transition: border-color 140ms ease, background 140ms ease;
+        transition: border-color var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard);
       }
       .sync-dialog-radio-option:hover {
         border-color: var(--border-hover);
@@ -3480,7 +3512,7 @@
           30%  { box-shadow: 0 0 0 6px var(--accent-subtle); }
           100% { box-shadow: 0 0 0 0 transparent; }
         }
-        .feed-item.new-item { animation: newPulse 420ms ease-out 1; }
+        .feed-item.new-item { animation: newPulse var(--duration-new-pulse) var(--ease-out) 1; }
       }
 
       /* ── Responsive ────────────────────────────────────────── */


### PR DESCRIPTION
## Description
Tokenizes every transition/animation duration and easing in `packages/ui/static/index.html`. Adds 13 duration tokens and 3 easing tokens to `:root`, then sweeps the 14 unique duration-easing literal pairs onto token references.

- Hover/state transitions use a small scale: `--duration-instant` (80ms), `--duration-fast` (140ms — the dominant feedback tier with 68 uses), `--duration-toast` (160ms), `--duration-base` (200ms), `--duration-medium` (250ms).
- Named keyframe animations get semantic tokens because each is coupled to a specific timing curve and cannot be freely reshuffled: shake, fade-up, new-pulse, attention, blink, pip, shimmer, pulse.
- The three recurring easings (`ease`, `ease-in-out`, `ease-out`) are tokenized; one-offs (`linear`, `steps(2, end)`) intentionally remain inline.

Reduced-motion behavior is unchanged: the global `@media (prefers-reduced-motion: reduce)` block at the bottom of the stylesheet already collapses transitions and finite animations to 0.01ms, and the four explicit `animation: none` blocks for infinite-iteration animations still apply.

Continues the foundation polish track from #1192 (typography tokens).

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, full UI vitest, UI build)
- [x] Added/updated tests for changes (no test changes needed — purely token sweep)
- [ ] Manually verified changes work as expected

Validated with:
- `pnpm run lint`
- `pnpm run tsc`
- `pnpm --filter @codemem/ui build`
- `pnpm exec vitest run packages/ui` (21 files / 166 tests pass)
- `git diff --check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] Documentation updated (token comment block documents the scale)
- [x] No new warnings introduced
