### PR TITLE
feat(ui): add primary-action keyboard helper and wire Settings modal

### DIFF
--- a/packages/ui/src/lib/keyboard.test.ts
+++ b/packages/ui/src/lib/keyboard.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { handlePrimaryActionKeyboard } from "./keyboard";
+
+function keydown(
+	target: HTMLElement,
+	key: string,
+	modifiers: { metaKey?: boolean; ctrlKey?: boolean; isComposing?: boolean } = {},
+): KeyboardEvent {
+	const event = new KeyboardEvent("keydown", {
+		bubbles: true,
+		cancelable: true,
+		key,
+		metaKey: modifiers.metaKey ?? false,
+		ctrlKey: modifiers.ctrlKey ?? false,
+		isComposing: modifiers.isComposing ?? false,
+	});
+	Object.defineProperty(event, "target", { value: target, configurable: true });
+	return event;
+}
+
+function appendInput(): HTMLInputElement {
+	const input = document.createElement("input");
+	input.type = "text";
+	document.body.appendChild(input);
+	return input;
+}
+
+function appendInputWithType(type: string): HTMLInputElement {
+	const input = document.createElement("input");
+	input.type = type;
+	document.body.appendChild(input);
+	return input;
+}
+
+function appendTextarea(): HTMLTextAreaElement {
+	const textarea = document.createElement("textarea");
+	document.body.appendChild(textarea);
+	return textarea;
+}
+
+function appendButton(): HTMLButtonElement {
+	const button = document.createElement("button");
+	button.type = "button";
+	document.body.appendChild(button);
+	return button;
+}
+
+function appendSelect(): HTMLSelectElement {
+	const select = document.createElement("select");
+	document.body.appendChild(select);
+	return select;
+}
+
+function appendAnchor(): HTMLAnchorElement {
+	const anchor = document.createElement("a");
+	anchor.href = "#test";
+	document.body.appendChild(anchor);
+	return anchor;
+}
+
+afterEach(() => {
+	document.body.innerHTML = "";
+});
+
+describe("handlePrimaryActionKeyboard", () => {
+	it("fires onSubmit and preventDefaults Enter on a single-line input", () => {
+		const input = appendInput();
+		const onSubmit = vi.fn();
+
+		const event = keydown(input, "Enter");
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it("does not fire onSubmit on bare Enter inside a textarea", () => {
+		const textarea = appendTextarea();
+		const onSubmit = vi.fn();
+
+		const event = keydown(textarea, "Enter");
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it("fires onSubmit on Cmd+Enter inside a textarea", () => {
+		const textarea = appendTextarea();
+		const onSubmit = vi.fn();
+
+		const event = keydown(textarea, "Enter", { metaKey: true });
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it("fires onSubmit on Ctrl+Enter inside a textarea", () => {
+		const textarea = appendTextarea();
+		const onSubmit = vi.fn();
+
+		const event = keydown(textarea, "Enter", { ctrlKey: true });
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it("fires onSubmit on Cmd+Enter inside a contentEditable region", () => {
+		const region = document.createElement("div");
+		region.contentEditable = "true";
+		document.body.appendChild(region);
+		const onSubmit = vi.fn();
+
+		const event = keydown(region, "Enter", { metaKey: true });
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not intercept Enter on a button", () => {
+		const button = appendButton();
+		const onSubmit = vi.fn();
+
+		const event = keydown(button, "Enter");
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it("does not intercept Enter on input types with native Enter behavior", () => {
+		for (const type of ["button", "file", "image", "reset", "submit"]) {
+			const input = appendInputWithType(type);
+			const onSubmit = vi.fn();
+
+			const event = keydown(input, "Enter");
+			handlePrimaryActionKeyboard(event, { onSubmit });
+
+			expect(onSubmit, type).not.toHaveBeenCalled();
+			expect(event.defaultPrevented, type).toBe(false);
+		}
+	});
+
+	it("does not intercept Enter on a select", () => {
+		const select = appendSelect();
+		const onSubmit = vi.fn();
+
+		const event = keydown(select, "Enter");
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it("does not intercept Enter on an anchor", () => {
+		const anchor = appendAnchor();
+		const onSubmit = vi.fn();
+
+		const event = keydown(anchor, "Enter");
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it("ignores Enter when the focused element opts out via data-primary-action-ignore", () => {
+		const wrapper = document.createElement("div");
+		wrapper.dataset.primaryActionIgnore = "true";
+		const input = document.createElement("input");
+		wrapper.appendChild(input);
+		document.body.appendChild(wrapper);
+
+		const onSubmit = vi.fn();
+		const event = keydown(input, "Enter");
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it("does not fire onSubmit when isComposing is true", () => {
+		const input = appendInput();
+		const onSubmit = vi.fn();
+
+		const event = keydown(input, "Enter", { isComposing: true });
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("does not fire onSubmit when the event was already preventDefaulted", () => {
+		const input = appendInput();
+		const onSubmit = vi.fn();
+
+		const event = keydown(input, "Enter");
+		event.preventDefault();
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("does not fire onSubmit when disabled is true", () => {
+		const input = appendInput();
+		const onSubmit = vi.fn();
+
+		const event = keydown(input, "Enter");
+		handlePrimaryActionKeyboard(event, { onSubmit, disabled: true });
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it("fires onCancel and preventDefaults Escape when onCancel is provided", () => {
+		const input = appendInput();
+		const onSubmit = vi.fn();
+		const onCancel = vi.fn();
+
+		const event = keydown(input, "Escape");
+		handlePrimaryActionKeyboard(event, { onSubmit, onCancel });
+
+		expect(onCancel).toHaveBeenCalledTimes(1);
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it("ignores Escape when no onCancel handler is provided", () => {
+		const input = appendInput();
+		const onSubmit = vi.fn();
+
+		const event = keydown(input, "Escape");
+		handlePrimaryActionKeyboard(event, { onSubmit });
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it("ignores keys other than Enter and Escape", () => {
+		const input = appendInput();
+		const onSubmit = vi.fn();
+		const onCancel = vi.fn();
+
+		for (const key of ["a", "Tab", "ArrowDown", " "]) {
+			const event = keydown(input, key);
+			handlePrimaryActionKeyboard(event, { onSubmit, onCancel });
+		}
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(onCancel).not.toHaveBeenCalled();
+	});
+});

--- a/packages/ui/src/lib/keyboard.ts
+++ b/packages/ui/src/lib/keyboard.ts
@@ -1,0 +1,128 @@
+/**
+ * Keyboard activation helpers.
+ *
+ * The viewer UI has very few <form> elements, so the browser default of
+ * "Enter inside an input submits the surrounding form" does not apply across
+ * most modals, inline forms, and inline editors. This module supplies a
+ * single, well-tested keydown handler that surfaces the same behavior in a
+ * framework-agnostic way: attach it via Preact's `onKeyDown`, an imperative
+ * `addEventListener("keydown", ...)`, or a `<form>` `onSubmit` shim.
+ *
+ * Conventions, derived from VS Code / Linear / GitHub:
+ *
+ *   - Enter, when focus is on a single-line input (HTMLInputElement that is
+ *     not type="button"/"submit"/etc, or any other non-button/non-link/
+ *     non-select control), fires the scope's primary action.
+ *   - Cmd+Enter (macOS) or Ctrl+Enter (other platforms) fires the primary
+ *     action from anywhere inside the scope, including textareas and
+ *     contenteditable regions.
+ *   - Escape fires the scope's cancel handler if provided. Radix Dialog
+ *     already handles Escape for modal close, so this is opt-in for
+ *     non-Radix surfaces (inline editors, custom popovers, etc.).
+ *   - The handler ignores composition events (IME candidate selection) and
+ *     events that have already been prevented by a deeper listener.
+ *   - The handler skips elements that opt out via the
+ *     `data-primary-action-ignore="true"` attribute, anywhere on or above
+ *     the focused element. Useful for multi-line composers or Radix
+ *     listbox options that need their own Enter semantics.
+ *
+ * The helper does NOT intercept Enter on buttons, anchors, or selects: those
+ * controls have well-defined native Enter behavior (click self, navigate,
+ * open picker) and stealing it would be surprising.
+ */
+
+export interface PrimaryActionKeyboardOptions {
+	/**
+	 * Called when Enter (on a single-line control) or Cmd/Ctrl+Enter (anywhere
+	 * including textareas) is pressed inside the scope.
+	 */
+	onSubmit: () => void;
+	/**
+	 * Optional: called when Escape is pressed inside the scope. Most modals
+	 * delegate Escape to Radix and should leave this undefined.
+	 */
+	onCancel?: () => void;
+	/**
+	 * When true, the helper does nothing. Use this to honor a disabled or
+	 * saving state on the primary action, so Enter does not fire while Save
+	 * is grayed out.
+	 */
+	disabled?: boolean;
+}
+
+const FORM_CONTROL_TAGS = new Set(["BUTTON", "A", "SELECT"]);
+const INPUT_TYPES_WITH_NATIVE_ENTER = new Set([
+	"button",
+	"checkbox",
+	"color",
+	"file",
+	"image",
+	"radio",
+	"range",
+	"reset",
+	"submit",
+]);
+
+function shouldIgnoreTarget(target: HTMLElement | null): boolean {
+	if (!target) return false;
+	if (typeof target.closest !== "function") return false;
+	return target.closest('[data-primary-action-ignore="true"]') !== null;
+}
+
+function isTextareaOrEditable(target: HTMLElement | null): boolean {
+	if (!target) return false;
+	if (target instanceof HTMLTextAreaElement) return true;
+	if ("isContentEditable" in target && target.isContentEditable) return true;
+	return false;
+}
+
+function hasNativeEnterBehavior(target: HTMLElement | null): boolean {
+	if (!target) return false;
+	if (FORM_CONTROL_TAGS.has(target.tagName)) return true;
+	return target instanceof HTMLInputElement && INPUT_TYPES_WITH_NATIVE_ENTER.has(target.type);
+}
+
+function hasPrimaryModifier(event: KeyboardEvent): boolean {
+	return event.metaKey || event.ctrlKey;
+}
+
+/**
+ * Handle a keydown event according to the primary-action conventions
+ * documented at the top of this module.
+ *
+ * This function is a pure helper: it inspects the event, decides whether to
+ * fire `onSubmit` or `onCancel`, and calls `event.preventDefault()` when it
+ * acts. It never mutates DOM state directly. Callers should attach it to the
+ * scope that owns the primary action (modal card, form element, inline
+ * editor row).
+ */
+export function handlePrimaryActionKeyboard(
+	event: KeyboardEvent,
+	options: PrimaryActionKeyboardOptions,
+): void {
+	if (options.disabled) return;
+	if (event.defaultPrevented) return;
+	if (event.isComposing) return;
+	if (event.key !== "Enter" && event.key !== "Escape") return;
+
+	const target = event.target instanceof HTMLElement ? event.target : null;
+	if (shouldIgnoreTarget(target)) return;
+
+	if (event.key === "Escape") {
+		if (!options.onCancel) return;
+		event.preventDefault();
+		options.onCancel();
+		return;
+	}
+
+	// Enter — skip when focus is on a control with its own native Enter
+	// semantics. Buttons/links/selects all do something useful on Enter
+	// already and intercepting would be surprising.
+	if (hasNativeEnterBehavior(target)) return;
+
+	const requiresModifier = isTextareaOrEditable(target);
+	if (requiresModifier && !hasPrimaryModifier(event)) return;
+
+	event.preventDefault();
+	options.onSubmit();
+}

--- a/packages/ui/src/tabs/settings/components/SettingsModalContent.tsx
+++ b/packages/ui/src/tabs/settings/components/SettingsModalContent.tsx
@@ -1,6 +1,7 @@
 import type { ComponentChildren } from "preact";
 import { DialogCloseButton } from "../../../components/primitives/dialog-close-button";
 import { RadixTabs, RadixTabsContent } from "../../../components/primitives/radix-tabs";
+import { handlePrimaryActionKeyboard } from "../../../lib/keyboard";
 import { SETTINGS_TABS } from "../data/constants";
 import type { SettingsPanelProps, SettingsRenderState } from "../data/types";
 import { ObserverPanel } from "./ObserverPanel";
@@ -34,8 +35,18 @@ export function SettingsModalContent({
 	onAdvancedToggle,
 	observerStatusBannerSlot,
 }: SettingsModalContentProps) {
+	const saveDisabled = !settingsDirty || renderState.isSaving;
 	return (
-		<div className="modal-card">
+		// biome-ignore lint/a11y/noStaticElementInteractions: delegated keydown for primary-action handling; the actual interactive element is the Save button below, which is announced semantically. Radix Dialog handles Escape itself.
+		<div
+			className="modal-card"
+			onKeyDown={(event) =>
+				handlePrimaryActionKeyboard(event, {
+					onSubmit: onSave,
+					disabled: saveDisabled,
+				})
+			}
+		>
 			<div className="modal-header">
 				<h2 id="settingsTitle">Settings</h2>
 				<DialogCloseButton
@@ -113,7 +124,8 @@ export function SettingsModalContent({
 				</div>
 				<button
 					className="settings-save"
-					disabled={!settingsDirty || renderState.isSaving}
+					data-primary-action="true"
+					disabled={saveDisabled}
 					id="settingsSave"
 					onClick={onSave}
 					type="button"


### PR DESCRIPTION
## Description
Adds a shared `handlePrimaryActionKeyboard` helper (`packages/ui/src/lib/keyboard.ts`) for Enter / Cmd+Enter / Escape activation on modals, forms, and inline editors, and wires it to the Settings modal so typing Enter (or Cmd/Ctrl+Enter inside a textarea) saves changes.

The helper conventions: Enter on single-line inputs fires the scope primary action; Cmd/Ctrl+Enter fires it from textareas and contenteditable; Escape opt-in; skips buttons / anchors / selects and button-like input types (which have native Enter semantics); honors `data-primary-action-ignore` and IME composition. 16 unit tests cover the matrix.

Settings modal: a delegated `onKeyDown` on the modal-card uses the helper with `onSubmit = onSave` and `disabled = !settingsDirty || isSaving`. The Save button gets `data-primary-action="true"` so future readers see the convention.

First PR in the Phase 1 keyboard-parity stack.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, full UI vitest, UI build)
- [x] Added/updated tests for changes (16 unit tests for the helper)
- [ ] Manually verified changes work as expected

Validated with `pnpm exec vitest run packages/ui/src/lib/keyboard.test.ts packages/ui/src/tabs/sync/sync-dialogs/components/duplicate-person-content.test.tsx packages/ui/src/tabs/projects.test.ts packages/ui/src/tabs/sync/index.test.ts`, `pnpm run tsc`, `pnpm run lint`, and `pnpm --filter @codemem/ui build`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] Documentation updated (helper has full convention doc-comment)
- [x] No new warnings introduced