### PR TITLE
feat(ui): wrap coordinator admin panels in forms for Enter-to-submit

### DIFF
--- a/packages/ui/src/tabs/coordinator-admin/components/devices-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/devices-panel.ts
@@ -60,6 +60,7 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 							coordinatorAdminState.deviceRenameDrafts.get(deviceId) ??
 							String(item.display_name || "");
 						const enabled = item.enabled !== false && item.enabled !== 0;
+						const actionDisabled = !deviceId || pending || summary.readiness !== "ready";
 						return h(
 							"div",
 							{
@@ -70,77 +71,87 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 							h("div", { class: "peer-submeta" }, copy.statusLabel),
 							h("div", { class: "peer-meta" }, copy.advancedDetail),
 							h(
-								"div",
-								{ class: "coordinator-admin-form-grid" },
+								"form",
+								{
+									class: "coordinator-admin-form",
+									onSubmit: (event: Event) => {
+										event.preventDefault();
+										if (actionDisabled) return;
+										runDevice(deviceId, teamId, displayName, "rename");
+									},
+								},
 								h(
-									"label",
-									{ class: "coordinator-admin-field" },
-									h("span", null, "Display name"),
-									h(TextInput, {
-										class: "peer-scope-input",
-										disabled: summary.readiness !== "ready" || pending,
-										onInput: (event) => {
-											coordinatorAdminState.deviceRenameDrafts.set(
-												deviceId,
-												String((event.currentTarget as HTMLInputElement).value || ""),
-											);
+									"div",
+									{ class: "coordinator-admin-form-grid" },
+									h(
+										"label",
+										{ class: "coordinator-admin-field" },
+										h("span", null, "Display name"),
+										h(TextInput, {
+											class: "peer-scope-input",
+											disabled: summary.readiness !== "ready" || pending,
+											onInput: (event) => {
+												coordinatorAdminState.deviceRenameDrafts.set(
+													deviceId,
+													String((event.currentTarget as HTMLInputElement).value || ""),
+												);
+											},
+											type: "text",
+											value: draft,
+										}),
+									),
+								),
+								h(
+									"div",
+									{ class: "peer-actions" },
+									h(
+										"button",
+										{
+											class: "settings-button",
+											disabled: actionDisabled,
+											type: "submit",
 										},
-										type: "text",
-										value: draft,
-									}),
-								),
-							),
-							h(
-								"div",
-								{ class: "peer-actions" },
-								h(
-									"button",
-									{
-										class: "settings-button",
-										disabled: !deviceId || pending || summary.readiness !== "ready",
-										onClick: () => runDevice(deviceId, teamId, displayName, "rename"),
-										type: "button",
-									},
-									pending && coordinatorAdminState.deviceActionPendingKind === "rename"
-										? "Renaming…"
-										: "Rename",
-								),
-								enabled
-									? h(
-											"button",
-											{
-												class: "settings-button danger",
-												disabled: !deviceId || pending || summary.readiness !== "ready",
-												onClick: () => runDevice(deviceId, teamId, displayName, "disable"),
-												type: "button",
-											},
-											pending && coordinatorAdminState.deviceActionPendingKind === "disable"
-												? "Disabling…"
-												: "Disable",
-										)
-									: h(
-											"button",
-											{
-												class: "settings-button",
-												disabled: !deviceId || pending || summary.readiness !== "ready",
-												onClick: () => runDevice(deviceId, teamId, displayName, "enable"),
-												type: "button",
-											},
-											pending && coordinatorAdminState.deviceActionPendingKind === "enable"
-												? "Enabling…"
-												: "Enable",
-										),
-								h(
-									"button",
-									{
-										class: "settings-button danger",
-										disabled: !deviceId || pending || summary.readiness !== "ready",
-										onClick: () => runDevice(deviceId, teamId, displayName, "remove"),
-										type: "button",
-									},
-									pending && coordinatorAdminState.deviceActionPendingKind === "remove"
-										? "Removing…"
-										: "Remove",
+										pending && coordinatorAdminState.deviceActionPendingKind === "rename"
+											? "Renaming…"
+											: "Rename",
+									),
+									enabled
+										? h(
+												"button",
+												{
+													class: "settings-button danger",
+													disabled: actionDisabled,
+													onClick: () => runDevice(deviceId, teamId, displayName, "disable"),
+													type: "button",
+												},
+												pending && coordinatorAdminState.deviceActionPendingKind === "disable"
+													? "Disabling…"
+													: "Disable",
+											)
+										: h(
+												"button",
+												{
+													class: "settings-button",
+													disabled: actionDisabled,
+													onClick: () => runDevice(deviceId, teamId, displayName, "enable"),
+													type: "button",
+												},
+												pending && coordinatorAdminState.deviceActionPendingKind === "enable"
+													? "Enabling…"
+													: "Enable",
+											),
+									h(
+										"button",
+										{
+											class: "settings-button danger",
+											disabled: actionDisabled,
+											onClick: () => runDevice(deviceId, teamId, displayName, "remove"),
+											type: "button",
+										},
+										pending && coordinatorAdminState.deviceActionPendingKind === "remove"
+											? "Removing…"
+											: "Remove",
+									),
 								),
 							),
 						);

--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -448,92 +448,102 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 				)
 			: null,
 		renderTeamSetupGuide(renderShell),
-		h(
-			"div",
-			{ class: "coordinator-admin-form-grid" },
-			h(
-				"label",
-				{ class: "coordinator-admin-field" },
-				h("span", null, "New Team id"),
-				h(TextInput, {
-					class: "peer-scope-input",
-					disabled:
-						summary.readiness !== "ready" ||
-						coordinatorAdminState.groupActionPendingKind === "create",
-					onInput: (event) => {
-						coordinatorAdminState.createGroupId = String(
-							(event.currentTarget as HTMLInputElement).value || "",
-						);
+		(() => {
+			const createGroupDisabled =
+				summary.readiness !== "ready" || coordinatorAdminState.groupActionPendingKind === "create";
+			return h(
+				"form",
+				{
+					class: "coordinator-admin-form",
+					onSubmit: (event: Event) => {
+						event.preventDefault();
+						if (createGroupDisabled) return;
+						createGroup();
 					},
-					placeholder: "team-alpha",
-					type: "text",
-					value: coordinatorAdminState.createGroupId,
-				}),
-			),
-			h(
-				"label",
-				{ class: "coordinator-admin-field" },
-				h("span", null, "Display name"),
-				h(TextInput, {
-					class: "peer-scope-input",
-					disabled:
-						summary.readiness !== "ready" ||
-						coordinatorAdminState.groupActionPendingKind === "create",
-					onInput: (event) => {
-						coordinatorAdminState.createGroupDisplayName = String(
-							(event.currentTarget as HTMLInputElement).value || "",
-						);
-					},
-					placeholder: "Team Alpha",
-					type: "text",
-					value: coordinatorAdminState.createGroupDisplayName,
-				}),
-			),
-		),
-		h(
-			"div",
-			{ class: "section-actions coordinator-admin-groups-toolbar" },
-			h(
-				"div",
-				{ class: "coordinator-admin-primary-actions" },
+				},
 				h(
-					"button",
-					{
-						class: "settings-button",
-						disabled:
-							summary.readiness !== "ready" ||
-							coordinatorAdminState.groupActionPendingKind === "create",
-						onClick: () => createGroup(),
-						type: "button",
-					},
-					coordinatorAdminState.groupActionPendingKind === "create" ? "Creating…" : "Create Team",
-				),
-			),
-			h(
-				"div",
-				{ class: "coordinator-admin-secondary-actions" },
-				h(
-					"label",
-					{ class: "coordinator-admin-inline-filter" },
+					"div",
+					{ class: "coordinator-admin-form-grid" },
 					h(
-						"span",
-						{ class: "section-meta", id: "coordinatorAdminShowArchivedLabel" },
-						"Show archived",
+						"label",
+						{ class: "coordinator-admin-field" },
+						h("span", null, "New Team id"),
+						h(TextInput, {
+							class: "peer-scope-input",
+							disabled: createGroupDisabled,
+							onInput: (event) => {
+								coordinatorAdminState.createGroupId = String(
+									(event.currentTarget as HTMLInputElement).value || "",
+								);
+							},
+							placeholder: "team-alpha",
+							type: "text",
+							value: coordinatorAdminState.createGroupId,
+						}),
 					),
-					h(RadixSwitch, {
-						"aria-labelledby": "coordinatorAdminShowArchivedLabel",
-						checked: coordinatorAdminState.showArchivedGroups,
-						className: "coordinator-admin-switch",
-						disabled: summary.readiness !== "ready",
-						onCheckedChange: (checked) => {
-							coordinatorAdminState.showArchivedGroups = checked;
-							renderShell();
-						},
-						thumbClassName: "coordinator-admin-switch-thumb",
-					}),
+					h(
+						"label",
+						{ class: "coordinator-admin-field" },
+						h("span", null, "Display name"),
+						h(TextInput, {
+							class: "peer-scope-input",
+							disabled: createGroupDisabled,
+							onInput: (event) => {
+								coordinatorAdminState.createGroupDisplayName = String(
+									(event.currentTarget as HTMLInputElement).value || "",
+								);
+							},
+							placeholder: "Team Alpha",
+							type: "text",
+							value: coordinatorAdminState.createGroupDisplayName,
+						}),
+					),
 				),
-			),
-		),
+				h(
+					"div",
+					{ class: "section-actions coordinator-admin-groups-toolbar" },
+					h(
+						"div",
+						{ class: "coordinator-admin-primary-actions" },
+						h(
+							"button",
+							{
+								class: "settings-button",
+								disabled: createGroupDisabled,
+								type: "submit",
+							},
+							coordinatorAdminState.groupActionPendingKind === "create"
+								? "Creating…"
+								: "Create Team",
+						),
+					),
+					h(
+						"div",
+						{ class: "coordinator-admin-secondary-actions" },
+						h(
+							"label",
+							{ class: "coordinator-admin-inline-filter" },
+							h(
+								"span",
+								{ class: "section-meta", id: "coordinatorAdminShowArchivedLabel" },
+								"Show archived",
+							),
+							h(RadixSwitch, {
+								"aria-labelledby": "coordinatorAdminShowArchivedLabel",
+								checked: coordinatorAdminState.showArchivedGroups,
+								className: "coordinator-admin-switch",
+								disabled: summary.readiness !== "ready",
+								onCheckedChange: (checked) => {
+									coordinatorAdminState.showArchivedGroups = checked;
+									renderShell();
+								},
+								thumbClassName: "coordinator-admin-switch-thumb",
+							}),
+						),
+					),
+				),
+			);
+		})(),
 		!visibleGroups.length
 			? h(
 					"div",

--- a/packages/ui/src/tabs/coordinator-admin/components/invites-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/invites-panel.ts
@@ -30,6 +30,7 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 	const warnings = Array.isArray(state.lastTeamInvite?.warnings)
 		? state.lastTeamInvite?.warnings
 		: [];
+	const inviteDisabled = summary.readiness !== "ready" || coordinatorAdminState.invitePending;
 	return h(
 		RadixTabsContent,
 		{ className: "coordinator-admin-panel", value: "invites" },
@@ -42,84 +43,94 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 				: "Finish setup first. Invite creation stays disabled until the local coordinator admin configuration is ready.",
 		),
 		h(
-			"div",
-			{ class: "coordinator-admin-form-grid" },
-			h(
-				"label",
-				{ class: "coordinator-admin-field" },
-				h("span", null, "Team"),
-				h(TextInput, {
-					class: "peer-scope-input",
-					disabled: summary.readiness !== "ready",
-					onInput: (event) => {
-						coordinatorAdminState.inviteGroup = String(
-							(event.currentTarget as HTMLInputElement).value || "",
-						);
-						renderShell();
-					},
-					placeholder: activeGroup || "team-alpha",
-					type: "text",
-					value: coordinatorAdminState.inviteGroup,
-				}),
-			),
-			h(
-				"label",
-				{ class: "coordinator-admin-field" },
-				h("span", null, "Join policy"),
-				h(RadixSelect, {
-					ariaLabel: "Invite join policy",
-					contentClassName: "sync-radix-select-content sync-actor-select-content",
-					disabled: summary.readiness !== "ready",
-					id: "coordinatorAdminInvitePolicy",
-					itemClassName: "sync-radix-select-item",
-					onValueChange: (value) => {
-						coordinatorAdminState.invitePolicy =
-							value === "approval_required" ? "approval_required" : "auto_admit";
-						renderShell();
-					},
-					options: [
-						{ value: "auto_admit", label: "Auto-admit to Team" },
-						{ value: "approval_required", label: "Require approval to join Team" },
-					],
-					triggerClassName: "sync-radix-select-trigger sync-actor-select",
-					value: coordinatorAdminState.invitePolicy,
-					viewportClassName: "sync-radix-select-viewport",
-				}),
-			),
-			h(
-				"label",
-				{ class: "coordinator-admin-field" },
-				h("span", null, "Expires in (hours)"),
-				h(TextInput, {
-					class: "peer-scope-input",
-					disabled: summary.readiness !== "ready",
-					min: "1",
-					onInput: (event) => {
-						coordinatorAdminState.inviteTtlHours = String(
-							(event.currentTarget as HTMLInputElement).value || "",
-						);
-					},
-					type: "number",
-					value: coordinatorAdminState.inviteTtlHours,
-				}),
-			),
-		),
-		h(
-			"div",
-			{ class: "section-actions" },
-			h(
-				"button",
-				{
-					class: "settings-button",
-					disabled: summary.readiness !== "ready" || coordinatorAdminState.invitePending,
-					onClick: () => {
-						createInvite();
-					},
-					type: "button",
+			"form",
+			{
+				class: "coordinator-admin-form",
+				onSubmit: (event: Event) => {
+					event.preventDefault();
+					if (inviteDisabled) return;
+					createInvite();
 				},
-				coordinatorAdminState.invitePending ? "Creating…" : "Create invite",
+			},
+			h(
+				"div",
+				{ class: "coordinator-admin-form-grid" },
+				h(
+					"label",
+					{ class: "coordinator-admin-field" },
+					h("span", null, "Team"),
+					h(TextInput, {
+						class: "peer-scope-input",
+						disabled: summary.readiness !== "ready",
+						onInput: (event) => {
+							coordinatorAdminState.inviteGroup = String(
+								(event.currentTarget as HTMLInputElement).value || "",
+							);
+							renderShell();
+						},
+						placeholder: activeGroup || "team-alpha",
+						type: "text",
+						value: coordinatorAdminState.inviteGroup,
+					}),
+				),
+				h(
+					"label",
+					{ class: "coordinator-admin-field" },
+					h("span", null, "Join policy"),
+					h(RadixSelect, {
+						ariaLabel: "Invite join policy",
+						contentClassName: "sync-radix-select-content sync-actor-select-content",
+						disabled: summary.readiness !== "ready",
+						id: "coordinatorAdminInvitePolicy",
+						itemClassName: "sync-radix-select-item",
+						onValueChange: (value) => {
+							coordinatorAdminState.invitePolicy =
+								value === "approval_required" ? "approval_required" : "auto_admit";
+							renderShell();
+						},
+						options: [
+							{ value: "auto_admit", label: "Auto-admit to Team" },
+							{ value: "approval_required", label: "Require approval to join Team" },
+						],
+						triggerClassName: "sync-radix-select-trigger sync-actor-select",
+						value: coordinatorAdminState.invitePolicy,
+						viewportClassName: "sync-radix-select-viewport",
+					}),
+				),
+				h(
+					"label",
+					{ class: "coordinator-admin-field" },
+					h("span", null, "Expires in (hours)"),
+					h(TextInput, {
+						class: "peer-scope-input",
+						disabled: summary.readiness !== "ready",
+						min: "1",
+						onInput: (event) => {
+							coordinatorAdminState.inviteTtlHours = String(
+								(event.currentTarget as HTMLInputElement).value || "",
+							);
+						},
+						type: "number",
+						value: coordinatorAdminState.inviteTtlHours,
+					}),
+				),
 			),
-			effectiveGroup ? h("span", { class: "peer-submeta" }, `Using Team ${effectiveGroup}`) : null,
+			h(
+				"div",
+				{ class: "section-actions" },
+				h(
+					"button",
+					{
+						class: "settings-button",
+						disabled: inviteDisabled,
+						type: "submit",
+					},
+					coordinatorAdminState.invitePending ? "Creating…" : "Create invite",
+				),
+				effectiveGroup
+					? h("span", { class: "peer-submeta" }, `Using Team ${effectiveGroup}`)
+					: null,
+			),
 		),
 		output
 			? h(

--- a/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
@@ -379,88 +379,99 @@ export function renderGroupScopeManagementPanel(deps: ScopeManagementPanelDeps) 
 			}),
 		),
 		h(
-			"div",
-			{ class: "coordinator-admin-form-grid" },
-			h(
-				"label",
-				{ class: "coordinator-admin-field" },
-				h("span", null, "New Space id"),
-				h(TextInput, {
-					class: "peer-scope-input",
-					disabled,
-					onInput: (event) => {
-						const current = draftFor(groupId);
-						setDraft(groupId, {
-							...current,
-							createScopeId: String((event.currentTarget as HTMLInputElement).value || ""),
-						});
-					},
-					placeholder: "acme-work",
-					type: "text",
-					value: draft.createScopeId,
-				}),
-			),
-			h(
-				"label",
-				{ class: "coordinator-admin-field" },
-				h("span", null, "Label"),
-				h(TextInput, {
-					class: "peer-scope-input",
-					disabled,
-					onInput: (event) => {
-						const current = draftFor(groupId);
-						setDraft(groupId, {
-							...current,
-							createLabel: String((event.currentTarget as HTMLInputElement).value || ""),
-						});
-					},
-					placeholder: "Acme Work",
-					type: "text",
-					value: draft.createLabel,
-				}),
-			),
-			h(
-				"label",
-				{ class: "coordinator-admin-field" },
-				h("span", null, "Kind"),
-				h(TextInput, {
-					class: "peer-scope-input",
-					disabled,
-					onInput: (event) => {
-						const current = draftFor(groupId);
-						setDraft(groupId, {
-							...current,
-							createKind: String((event.currentTarget as HTMLInputElement).value || ""),
-						});
-					},
-					placeholder: "team",
-					type: "text",
-					value: draft.createKind,
-				}),
-			),
-		),
-		h(
-			"div",
-			{ class: "peer-actions" },
-			h(
-				"button",
-				{
-					class: "settings-button",
-					disabled,
-					onClick: () => void createScope(groupId, renderShell),
-					type: "button",
+			"form",
+			{
+				class: "coordinator-admin-form",
+				onSubmit: (event: Event) => {
+					event.preventDefault();
+					if (disabled) return;
+					void createScope(groupId, renderShell);
 				},
-				draft.actionPendingKind === "create" ? "Creating…" : "Create Space",
+			},
+			h(
+				"div",
+				{ class: "coordinator-admin-form-grid" },
+				h(
+					"label",
+					{ class: "coordinator-admin-field" },
+					h("span", null, "New Space id"),
+					h(TextInput, {
+						class: "peer-scope-input",
+						disabled,
+						onInput: (event) => {
+							const current = draftFor(groupId);
+							setDraft(groupId, {
+								...current,
+								createScopeId: String((event.currentTarget as HTMLInputElement).value || ""),
+							});
+						},
+						placeholder: "acme-work",
+						type: "text",
+						value: draft.createScopeId,
+					}),
+				),
+				h(
+					"label",
+					{ class: "coordinator-admin-field" },
+					h("span", null, "Label"),
+					h(TextInput, {
+						class: "peer-scope-input",
+						disabled,
+						onInput: (event) => {
+							const current = draftFor(groupId);
+							setDraft(groupId, {
+								...current,
+								createLabel: String((event.currentTarget as HTMLInputElement).value || ""),
+							});
+						},
+						placeholder: "Acme Work",
+						type: "text",
+						value: draft.createLabel,
+					}),
+				),
+				h(
+					"label",
+					{ class: "coordinator-admin-field" },
+					h("span", null, "Kind"),
+					h(TextInput, {
+						class: "peer-scope-input",
+						disabled,
+						onInput: (event) => {
+							const current = draftFor(groupId);
+							setDraft(groupId, {
+								...current,
+								createKind: String((event.currentTarget as HTMLInputElement).value || ""),
+							});
+						},
+						placeholder: "team",
+						type: "text",
+						value: draft.createKind,
+					}),
+				),
 			),
 			h(
-				"button",
-				{
-					class: "settings-button",
-					disabled,
-					onClick: () => void loadGroupScopeManagement(groupId, renderShell, draft.includeInactive),
-					type: "button",
-				},
-				draft.loading ? "Refreshing…" : "Refresh",
+				"div",
+				{ class: "peer-actions" },
+				h(
+					"button",
+					{
+						class: "settings-button",
+						disabled,
+						type: "submit",
+					},
+					draft.actionPendingKind === "create" ? "Creating…" : "Create Space",
+				),
+				h(
+					"button",
+					{
+						class: "settings-button",
+						disabled,
+						onClick: () =>
+							void loadGroupScopeManagement(groupId, renderShell, draft.includeInactive),
+						type: "button",
+					},
+					draft.loading ? "Refreshing…" : "Refresh",
+				),
 			),
 		),
 		draft.error ? h("div", { class: "peer-submeta coordinator-admin-error" }, draft.error) : null,


### PR DESCRIPTION
## Description
Wraps the four Coordinator Admin inline forms (invites, scope management, groups, devices) in `<form onSubmit>` so Enter inside any single-line input submits the form natively. Primary action buttons get `type="submit"`; secondary actions (Refresh, Show archived toggle, Disable, Remove) keep `type="button"` so they do not fire on Enter.

The devices panel is the most layout-sensitive change: each per-device row now has its own `<form>` wrapping the Display name input + the Rename / Disable / Remove buttons. Only Rename is `type="submit"`. This is intentionally narrower than the Settings modal approach because each device row has its own primary action.

Second PR in the Phase 1 keyboard-parity stack (bd codemem-etak).

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, full UI vitest, UI build)
- [ ] Added/updated tests for changes (coordinator admin panels are not unit-tested at the render level today)
- [ ] Manually verified changes work as expected

Validated with `pnpm run lint`, `pnpm run tsc`, `pnpm exec vitest run packages/ui`, `pnpm --filter @codemem/ui build`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] Documentation updated (n/a)
- [x] No new warnings introduced
