### PR TITLE
feat(ui): handle Enter on legacy upgrade and duplicate person dialogs

### DIFF
--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -12,6 +12,7 @@ declare const __CODEMEM_GIT_COMMIT__: string;
 import { mountToastHost } from "./components/primitives/toast";
 import * as api from "./lib/api";
 import { $, $button, $select } from "./lib/dom";
+import { handlePrimaryActionKeyboard } from "./lib/keyboard";
 import {
 	ALL_TAB_IDS,
 	getVisibleTabs,
@@ -133,6 +134,14 @@ function handleLegacyUpgradeModalKeydown(event: KeyboardEvent) {
 		event.preventDefault();
 		dismissLegacyUpgradeNoticeIfRequested();
 		setLegacyUpgradeNotice(false);
+		return;
+	}
+	if (event.key === "Enter") {
+		const primary = $("legacyUpgradeReviewGroups") as HTMLButtonElement | null;
+		handlePrimaryActionKeyboard(event, {
+			onSubmit: () => primary?.click(),
+			disabled: !primary || primary.disabled,
+		});
 		return;
 	}
 	if (event.key !== "Tab") return;

--- a/packages/ui/src/tabs/sync/sync-dialogs/components/duplicate-person-content.test.tsx
+++ b/packages/ui/src/tabs/sync/sync-dialogs/components/duplicate-person-content.test.tsx
@@ -1,0 +1,110 @@
+import { type ComponentChild, render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+let radioOnValueChange: ((value: string) => void) | undefined;
+const mocks = vi.hoisted(() => ({
+	resolveCurrentDialog: vi.fn(),
+}));
+
+type MockChildrenProps = {
+	children?: ComponentChild;
+	[key: string]: unknown;
+};
+
+vi.mock("../../../../components/primitives/radix-radio-group", () => ({
+	RadixRadioGroup: ({ options, onValueChange, rootClassName, value }: MockChildrenProps) => {
+		radioOnValueChange = onValueChange as (value: string) => void;
+		return (
+			<div className={String(rootClassName || "")}>
+				{(options as Array<{ label: ComponentChild; value: string }>).map((option) => (
+					<label key={option.value}>
+						<input
+							aria-label={option.value}
+							checked={option.value === value}
+							onChange={() => radioOnValueChange?.(option.value)}
+							type="radio"
+							value={option.value}
+						/>
+						{option.label}
+					</label>
+				))}
+			</div>
+		);
+	},
+}));
+
+vi.mock("../../../../components/primitives/radix-select", () => ({
+	RadixSelect: ({ ariaLabel }: MockChildrenProps) => (
+		<button aria-label={String(ariaLabel || "Select")} type="button">
+			Select merge target
+		</button>
+	),
+}));
+
+vi.mock("../internal", () => ({ resolveCurrentDialog: mocks.resolveCurrentDialog }));
+
+import { DuplicatePersonDialogContent } from "./duplicate-person-content";
+
+let mount: HTMLDivElement | null = null;
+
+function renderIntoDocument(content: ComponentChild) {
+	mount = document.createElement("div");
+	document.body.appendChild(mount);
+	act(() => {
+		render(content, mount as HTMLDivElement);
+	});
+	return mount;
+}
+
+afterEach(() => {
+	if (mount) {
+		act(() => {
+			render(null, mount as HTMLDivElement);
+		});
+		mount.remove();
+		mount = null;
+	}
+	radioOnValueChange = undefined;
+	mocks.resolveCurrentDialog.mockReset();
+	document.body.innerHTML = "";
+});
+
+describe("DuplicatePersonDialogContent", () => {
+	it("submits the merge decision when Enter is pressed on the focused primary selector", () => {
+		const root = renderIntoDocument(
+			<DuplicatePersonDialogContent
+				descriptionId="duplicate-person-description"
+				request={{
+					actors: [
+						{ actorId: "local", isLocal: true, label: "You" },
+						{ actorId: "duplicate", isLocal: false, label: "You on laptop" },
+					],
+					kind: "duplicate-person",
+					summary: "Two people look duplicated.",
+					title: "Review duplicate people",
+				}}
+			/>,
+		);
+
+		const samePersonButton = Array.from(root.querySelectorAll("button")).find((button) =>
+			button.textContent?.includes("These are both me"),
+		);
+		act(() => {
+			samePersonButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		const primarySelector = root.querySelector('input[type="radio"]');
+		act(() => {
+			primarySelector?.dispatchEvent(
+				new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Enter" }),
+			);
+		});
+
+		expect(mocks.resolveCurrentDialog).toHaveBeenCalledWith({
+			action: "merge",
+			primaryActorId: "local",
+			secondaryActorId: "duplicate",
+		});
+	});
+});

--- a/packages/ui/src/tabs/sync/sync-dialogs/components/duplicate-person-content.tsx
+++ b/packages/ui/src/tabs/sync/sync-dialogs/components/duplicate-person-content.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useState } from "preact/hooks";
 import { RadixRadioGroup } from "../../../../components/primitives/radix-radio-group";
 import { RadixSelect } from "../../../../components/primitives/radix-select";
+import { handlePrimaryActionKeyboard } from "../../../../lib/keyboard";
 import { resolveCurrentDialog } from "../internal";
 import type { DuplicatePersonDialogRequest } from "../types";
 
@@ -53,6 +54,24 @@ export function DuplicatePersonDialogContent({
 		value: actor.actorId,
 	}));
 
+	const mergeReady = Boolean(primary?.actorId && secondary?.actorId);
+	const submitMerge = () => {
+		if (!primary?.actorId || !secondary?.actorId) return;
+		resolveCurrentDialog({
+			action: "merge",
+			primaryActorId: primary.actorId,
+			secondaryActorId: secondary.actorId,
+		});
+	};
+	const submitMergeFromRadioKey = (event: KeyboardEvent) => {
+		const target = event.target instanceof HTMLElement ? event.target : null;
+		if (event.defaultPrevented || event.isComposing || event.key !== "Enter") return;
+		if (!target?.closest(".sync-dialog-radio-list")) return;
+		if (!mergeReady) return;
+		event.preventDefault();
+		submitMerge();
+	};
+
 	return step === "choice" ? (
 		<div className="sync-dialog-stack">
 			<ul className="sync-dialog-choice-list">
@@ -60,6 +79,7 @@ export function DuplicatePersonDialogContent({
 					<button
 						autoFocus
 						className="settings-button"
+						data-primary-action="true"
 						data-sync-primary-action="true"
 						onClick={() => setStep("merge")}
 						type="button"
@@ -88,7 +108,17 @@ export function DuplicatePersonDialogContent({
 			</ul>
 		</div>
 	) : (
-		<div className="sync-dialog-stack">
+		// biome-ignore lint/a11y/noStaticElementInteractions: delegated keydown for primary-action handling; the actual interactive element is the Combine people button below.
+		<div
+			className="sync-dialog-stack"
+			onKeyDown={(event) => {
+				submitMergeFromRadioKey(event);
+				handlePrimaryActionKeyboard(event, {
+					onSubmit: submitMerge,
+					disabled: !mergeReady,
+				});
+			}}
+		>
 			<div className="small" id={descriptionId}>
 				Choose which person should remain after combining these duplicates.
 			</div>
@@ -129,15 +159,9 @@ export function DuplicatePersonDialogContent({
 				</button>
 				<button
 					className="settings-button"
-					disabled={!primary?.actorId || !secondary?.actorId}
-					onClick={() => {
-						if (!primary?.actorId || !secondary?.actorId) return;
-						resolveCurrentDialog({
-							action: "merge",
-							primaryActorId: primary.actorId,
-							secondaryActorId: secondary.actorId,
-						});
-					}}
+					data-primary-action="true"
+					disabled={!mergeReady}
+					onClick={submitMerge}
 					type="button"
 				>
 					Combine people


### PR DESCRIPTION
## Description
Adds Enter handling to two dialogs that previously only acted on Enter when focus already happened to be on a button:

- Legacy upgrade modal: the document-level keydown listener now intercepts Enter (in addition to Escape and Tab trap) and triggers `legacyUpgradeReviewGroups.click()` via the shared `handlePrimaryActionKeyboard` helper. Useful when the user has clicked the "Don’t show this again" checkbox and lost the initial autofocus on Start review.
- Duplicate-person dialog merge step: Enter on the primary selector now submits the selected merge pair, and the step still preserves native button behavior for Back / Combine people.

Third PR in the Phase 1 keyboard-parity stack.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted UI tests, UI build)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated with `pnpm exec vitest run packages/ui/src/lib/keyboard.test.ts packages/ui/src/tabs/sync/sync-dialogs/components/duplicate-person-content.test.tsx packages/ui/src/tabs/projects.test.ts packages/ui/src/tabs/sync/index.test.ts`, `pnpm run tsc`, `pnpm run lint`, and `pnpm --filter @codemem/ui build`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] Documentation updated (n/a)
- [x] No new warnings introduced