### PR TITLE
feat(ui): handle Enter on sync pairing inputs and actor rename

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -2,6 +2,7 @@ import type { TargetedInputEvent } from "preact";
 import { useEffect, useState } from "preact/hooks";
 import { RadixSelect } from "../../../components/primitives/radix-select";
 import { TextInput } from "../../../components/primitives/text-input";
+import { handlePrimaryActionKeyboard } from "../../../lib/keyboard";
 import {
 	actorDisplayLabel,
 	actorLabel,
@@ -162,10 +163,17 @@ function SyncActorRow({
 							onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
 								setName(event.currentTarget.value)
 							}
+							onKeyDown={(event: KeyboardEvent) =>
+								handlePrimaryActionKeyboard(event, {
+									onSubmit: () => void rename(),
+									disabled: renameBusy || mergeBusy || !name.trim(),
+								})
+							}
 						/>
 						<button
 							type="button"
 							className="settings-button"
+							data-primary-action="true"
 							disabled={renameBusy || mergeBusy}
 							onClick={() => void rename()}
 						>

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -2,6 +2,7 @@
 
 import * as api from "../../lib/api";
 import { clearFieldError, friendlyError, markFieldError } from "../../lib/form";
+import { handlePrimaryActionKeyboard } from "../../lib/keyboard";
 import { showGlobalNotice } from "../../lib/notice";
 import { state } from "../../lib/state";
 import { renderSyncActorsList } from "./components/sync-actors";
@@ -275,6 +276,15 @@ export function initPeopleEvents(loadSyncData: () => Promise<void>) {
 	const syncLegacyClaimButton = document.getElementById(
 		"syncLegacyClaimButton",
 	) as HTMLButtonElement | null;
+
+	// Enter inside the create-person input triggers Create person so the
+	// user does not need to chase the button after typing the name.
+	syncActorCreateInput?.addEventListener("keydown", (event) => {
+		handlePrimaryActionKeyboard(event, {
+			onSubmit: () => syncActorCreateButton?.click(),
+			disabled: !syncActorCreateButton || syncActorCreateButton.disabled,
+		});
+	});
 
 	syncActorCreateButton?.addEventListener("click", async () => {
 		if (!syncActorCreateButton || !syncActorCreateInput) return;

--- a/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
+++ b/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
@@ -6,6 +6,7 @@
 
 import * as api from "../../../../lib/api";
 import { clearFieldError, friendlyError, markFieldError } from "../../../../lib/form";
+import { handlePrimaryActionKeyboard } from "../../../../lib/keyboard";
 import { showGlobalNotice } from "../../../../lib/notice";
 import { state } from "../../../../lib/state";
 import type { SyncActionFeedback } from "../../components/sync-inline-feedback";
@@ -89,6 +90,16 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 				syncCreateInviteButton.textContent = "Create invite";
 			}
 		}
+	});
+
+	// Cmd/Ctrl+Enter inside the invite textarea triggers Accept. Bare Enter
+	// is intentionally left alone so users can keep the textarea's native
+	// newline behavior while pasting multi-line payloads.
+	syncJoinInvite?.addEventListener("keydown", (event) => {
+		handlePrimaryActionKeyboard(event, {
+			onSubmit: () => syncJoinButton?.click(),
+			disabled: !syncJoinButton || syncJoinButton.disabled,
+		});
 	});
 
 	syncJoinButton?.addEventListener("click", async () => {


### PR DESCRIPTION
## Description
Adds Enter handling to three more inline primary actions in the Sync card:

- `syncJoinInvite` textarea: Cmd/Ctrl+Enter triggers `syncJoinButton.click()` so pasting a team invite or pairing payload and hitting Cmd+Enter immediately accepts. Bare Enter is intentionally left alone so the textarea keeps its native newline behavior for multi-line payloads.
- `syncActorCreateInput`: bare Enter triggers `syncActorCreateButton.click()` so typing a person name and hitting Enter creates the person.
- Actor rename row in `sync-actors.tsx`: Enter inside the rename input fires the row\u2019s `rename()` so you can rename a person without reaching for the mouse.

Each uses the shared `handlePrimaryActionKeyboard` helper from PR #1196 with `disabled` wired to the corresponding button\u2019s disabled state, so Enter does not fire mid-save.

Fourth and final PR in the Phase 1 keyboard-parity stack (bd codemem-etak).

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, full UI vitest, UI build)
- [ ] Added/updated tests for changes (covered by shared helper tests in PR #1196)
- [ ] Manually verified changes work as expected

Validated with `pnpm run lint`, `pnpm run tsc`, `pnpm exec vitest run packages/ui`, `pnpm --filter @codemem/ui build`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] Documentation updated (n/a)
- [x] No new warnings introduced
