### PR TITLE
fix(ui): improve header density at narrow widths

### DIFF
--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -144,6 +144,17 @@
         gap: var(--sp-2);
       }
 
+      /* Diagnostic metadata cluster: runtime version + database path. Grouped
+         under one container so the responsive treatment can hide both together
+         on narrow viewports without disturbing the surrounding primary
+         controls (project filter, theme toggle, settings). */
+      .header-tertiary {
+        display: flex;
+        align-items: center;
+        gap: var(--sp-2);
+        min-width: 0;
+      }
+
       .refresh-status {
         display: inline-flex;
         align-items: center;
@@ -3248,6 +3259,22 @@
         .legacy-review-bulk-row .settings-save { width: 100%; }
       }
 
+      @media (max-width: 720px) {
+        /* Hide diagnostic metadata (runtime version + database path) when the
+           header would otherwise wrap. Keeps brand + project filter + theme
+           + settings on a single row at common split-window widths. */
+        .header-tertiary { display: none; }
+        /* Allow the tab bar to scroll horizontally rather than wrap into two
+           rows. Scrollbar is hidden to keep the sticky chrome compact. */
+        .tab-bar {
+          overflow-x: auto;
+          -webkit-overflow-scrolling: touch;
+          scrollbar-width: none;
+        }
+        .tab-bar::-webkit-scrollbar { display: none; }
+        .tab-btn { flex-shrink: 0; }
+      }
+
       @media (max-width: 520px) {
         header { padding: var(--sp-3) var(--sp-4); }
         .tab-bar { padding: 0 var(--sp-4); }
@@ -3312,8 +3339,10 @@
           <span class="sr-only" id="refreshAnnouncer" aria-live="polite"></span>
         </div>
         <div class="header-right">
-          <span class="runtime-label" id="runtimeLabel" hidden></span>
-          <span class="meta-line" id="metaLine"></span>
+          <div class="header-tertiary">
+            <span class="runtime-label" id="runtimeLabel" hidden></span>
+            <span class="meta-line" id="metaLine"></span>
+          </div>
           <select class="project-filter" id="projectFilter" aria-label="Project filter">
             <option value="">All Projects</option>
           </select>


### PR DESCRIPTION
## Description
Tightens the viewer header at narrow widths by grouping diagnostic metadata and hiding that cluster before it forces the primary controls to wrap. The tab bar now scrolls horizontally at narrow widths instead of splitting into a taller two-row sticky header.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran targeted UI build during this stack:
- `pnpm --filter @codemem/ui build`
- `pnpm exec vitest run packages/ui/src/tabs/projects.test.ts packages/ui/src/tabs/sync/index.test.ts`
- `pnpm run tsc`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced