### PR TITLE
fix(ui): improve projects first paint

### DIFF
--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -85,6 +85,7 @@ function mountProjectsDom() {
 		<input id="projectsSearch" />
 		<select id="projectsStatusFilter"></select>
 		<div id="projectsInventoryMeta"></div>
+		<div id="projectsInventorySkeleton"></div>
 		<div id="projectsInventoryList"></div>
 		<button id="projectsPrevPage"></button>
 		<button id="projectsNextPage"></button>
@@ -182,6 +183,20 @@ describe("Projects tab", () => {
 		expect(api.loadProjectScopeInventory).toHaveBeenCalledWith(
 			expect.objectContaining({ limit: 250 }),
 		);
+		expect(document.getElementById("projectsInventorySkeleton")).toBeNull();
+	});
+
+	it("removes the project inventory skeleton when loading fails", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockRejectedValue(new Error("inventory unavailable"));
+
+		initProjectsTab(() => {});
+		await loadProjectsData();
+
+		expect(document.getElementById("projectsInventorySkeleton")).toBeNull();
+		expect(document.getElementById("projectsInventoryMeta")?.textContent).toBe(
+			"Project inventory failed to load.",
+		);
+		expect(document.body.textContent).toContain("inventory unavailable");
 	});
 
 	it("renders peer-received project identities read-only", async () => {

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -842,6 +842,10 @@ function renderEmpty(message: string) {
 	list.appendChild(empty);
 }
 
+function hideProjectInventorySkeleton() {
+	document.getElementById("projectsInventorySkeleton")?.remove();
+}
+
 function renderProjectInventory(result: {
 	projects: ProjectScopeInventoryProject[];
 	total: number;
@@ -851,6 +855,7 @@ function renderProjectInventory(result: {
 	const meta = el<HTMLDivElement>("projectsInventoryMeta");
 	const list = el<HTMLDivElement>("projectsInventoryList");
 	if (!meta || !list) return;
+	hideProjectInventorySkeleton();
 	list.textContent = "";
 	if (result.projects.length === 0) {
 		renderEmpty("No projects match those filters.");
@@ -904,6 +909,7 @@ export async function loadProjectsData() {
 		renderProjectInventory(result);
 		refreshProjectCoordinatorGroupNamesInBackground(result);
 	} catch (error) {
+		hideProjectInventorySkeleton();
 		meta.textContent = "Project inventory failed to load.";
 		renderEmpty(error instanceof Error ? error.message : "Unable to load project inventory.");
 	}

--- a/packages/ui/src/tabs/sync/index.test.ts
+++ b/packages/ui/src/tabs/sync/index.test.ts
@@ -9,6 +9,7 @@ vi.mock("../health", () => ({ renderHealthOverview: vi.fn() }));
 vi.mock("./diagnostics", () => ({
 	renderSyncStatus: vi.fn(),
 	renderSyncAttempts: vi.fn(),
+	renderSyncDiagnosticsUnavailable: vi.fn(),
 	renderPairing: vi.fn(),
 	initDiagnosticsEvents: vi.fn(),
 	setRenderSyncPeers: vi.fn(),
@@ -22,6 +23,7 @@ vi.mock("./team-sync", () => ({
 vi.mock("./people", () => ({
 	renderSyncActors: vi.fn(),
 	renderSyncPeers: vi.fn(),
+	renderSyncPeopleUnavailable: vi.fn(),
 	renderLegacyDeviceClaims: vi.fn(),
 	initPeopleEvents: vi.fn(),
 	setLoadSyncData: vi.fn(),
@@ -86,7 +88,6 @@ describe("loadSyncData", () => {
 			.mockReturnValueOnce(first.promise as never)
 			.mockReturnValueOnce(second.promise as never);
 		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
-
 		const firstLoad = loadSyncData();
 		const secondLoad = loadSyncData();
 
@@ -129,7 +130,6 @@ describe("loadSyncData", () => {
 			legacy_devices: [],
 		} as never);
 		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
-
 		await loadSyncData();
 		await loadSyncData();
 
@@ -137,5 +137,17 @@ describe("loadSyncData", () => {
 		expect(api.loadSyncStatus).toHaveBeenCalledWith(false, "", {
 			includeJoinRequests: false,
 		});
+	});
+
+	it("does not request secondary sync data when status fails", async () => {
+		const api = await import("../../lib/api");
+		const { loadSyncData } = await import("./index");
+
+		vi.mocked(api.loadSyncStatus).mockRejectedValue(new Error("status unavailable"));
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+
+		await loadSyncData();
+
+		expect(api.loadSyncActors).not.toHaveBeenCalled();
 	});
 });

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1038,6 +1038,28 @@
         gap: var(--sp-3);
         margin-top: var(--sp-4);
       }
+      .project-inventory-skeleton {
+        display: grid;
+        gap: var(--sp-3);
+        margin-top: var(--sp-4);
+      }
+      .project-inventory-skeleton-row {
+        padding: var(--sp-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-1);
+      }
+      .project-inventory-skeleton-line {
+        height: 12px;
+        border-radius: var(--radius-pill);
+        background: linear-gradient(90deg, var(--border) 25%, var(--surface-2) 50%, var(--border) 75%);
+        background-size: 400px 100%;
+        animation: sync-shimmer var(--duration-shimmer) var(--ease-in-out) infinite;
+        margin: var(--sp-2) 0;
+      }
+      .project-inventory-skeleton-line.title { width: 42%; height: 16px; }
+      .project-inventory-skeleton-line.meta { width: 68%; }
+      .project-inventory-skeleton-line.signal { width: 86%; }
       .project-inventory-row {
         padding: var(--sp-4);
         border: 1px solid var(--border);
@@ -3670,6 +3692,18 @@
           <select id="projectsStatusFilter" aria-label="Project status filter"></select>
         </div>
         <div class="section-meta" id="projectsInventoryMeta">Loading project inventory…</div>
+        <div class="project-inventory-skeleton" id="projectsInventorySkeleton" role="status" aria-label="Loading project inventory" aria-busy="true">
+          <div class="project-inventory-skeleton-row">
+            <div class="project-inventory-skeleton-line title"></div>
+            <div class="project-inventory-skeleton-line meta"></div>
+            <div class="project-inventory-skeleton-line signal"></div>
+          </div>
+          <div class="project-inventory-skeleton-row">
+            <div class="project-inventory-skeleton-line title"></div>
+            <div class="project-inventory-skeleton-line meta"></div>
+            <div class="project-inventory-skeleton-line signal"></div>
+          </div>
+        </div>
         <div class="project-inventory-list" id="projectsInventoryList" aria-live="polite"></div>
         <div class="section-actions projects-pagination">
           <button class="settings-button" id="projectsPrevPage" type="button">Previous</button>


### PR DESCRIPTION
## Description
Improves perceived latency on the Projects surface. Projects now shows an inventory-shaped loading skeleton until inventory data resolves or fails, so first paint is not just an empty list under “Loading project inventory…”.

This also adds a Sync regression test for degraded startup behavior: if `/api/sync/status` fails, the UI should not fire secondary Sync actor requests on that refresh cycle. That preserves the existing quieter failure path after the initial parallelization idea was rejected in review.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran:
- `pnpm exec vitest run packages/ui/src/tabs/sync/index.test.ts packages/ui/src/tabs/projects.test.ts`
- `pnpm run tsc`
- `pnpm run lint`
- `pnpm --filter @codemem/ui build`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced