### PR TITLE
feat(sync): show legacy shared-review memory samples

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
@@ -39,6 +39,20 @@ describe("SyncSharingReview", () => {
 							identitySource: "git_remote",
 							lastUpdatedAt: "2026-05-12T00:00:00Z",
 							memoryCount: 3,
+							memorySamples: [
+								{
+									bodyPreview: "Evidence from a legacy shared memory.",
+									createdAt: "2026-05-10T00:00:00Z",
+									cwd: "/workspace/oss/dev",
+									gitRemote: "https://git.example.invalid/oss/dev.git",
+									id: 101,
+									kind: "discovery",
+									ownership: "local",
+									project: "oss-dev",
+									title: "Legacy memory sample",
+									updatedAt: "2026-05-12T00:00:00Z",
+								},
+							],
 							suggestedScopeId: "oss",
 							suggestionReason:
 								"Existing project mapping can be reviewed as a destination, but legacy data is not promoted automatically.",
@@ -65,6 +79,11 @@ describe("SyncSharingReview", () => {
 		expect(root.textContent).toContain("Matched by git remote · suggested OSS");
 		expect(root.textContent).toContain("Destination Space");
 		expect(root.textContent).toContain("OSS · Team Space · suggested");
+		expect(root.textContent).toContain("Inspect affected memories (1 sample)");
+		expect(root.textContent).toContain("Legacy memory sample");
+		expect(root.textContent).toContain("May 12, 2026");
+		expect(root.textContent).toContain("Evidence from a legacy shared memory.");
+		expect(root.textContent).toContain("local, reassignable");
 		expect(root.textContent).toContain("legacy data is not promoted automatically");
 		expect(root.textContent).toContain("Nothing moves automatically");
 

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
@@ -30,11 +30,25 @@ export interface SyncLegacySharedReviewGroup {
 	identitySource: string;
 	lastUpdatedAt: string | null;
 	memoryCount: number;
+	memorySamples?: SyncLegacySharedReviewMemorySample[];
 	peerOwnedMemoryCount?: number;
 	reassignableMemoryCount?: number;
 	suggestedScopeId: string | null;
 	suggestionReason: string | null;
 	workspaceIdentity: string;
+}
+
+export interface SyncLegacySharedReviewMemorySample {
+	bodyPreview: string | null;
+	createdAt: string | null;
+	cwd: string | null;
+	gitRemote: string | null;
+	id: number;
+	kind: string | null;
+	ownership: "local" | "peer";
+	project: string | null;
+	title: string;
+	updatedAt: string | null;
 }
 
 type SyncSharingReviewProps = {
@@ -114,6 +128,66 @@ function authorityLabel(authorityType: string): string {
 		default:
 			return "Other Space";
 	}
+}
+
+function formatSampleDate(value: string | null): string {
+	if (!value) return "date unavailable";
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) return value;
+	return new Intl.DateTimeFormat("en-US", {
+		day: "numeric",
+		month: "short",
+		timeZone: "UTC",
+		year: "numeric",
+	}).format(date);
+}
+
+function sampleOrigin(sample: SyncLegacySharedReviewMemorySample): string {
+	if (sample.gitRemote) return sample.gitRemote;
+	if (sample.cwd) return sample.cwd;
+	if (sample.project) return sample.project;
+	return "source identity unavailable";
+}
+
+function LegacyMemorySamples({ group }: { group: SyncLegacySharedReviewGroup }) {
+	const samples = group.memorySamples ?? [];
+	const shownCount = samples.length;
+	return (
+		<details className="legacy-review-samples">
+			<summary>
+				Inspect affected memories
+				{shownCount ? ` (${shownCount} sample${shownCount === 1 ? "" : "s"})` : ""}
+			</summary>
+			<div className="legacy-review-cleanup-note">
+				Showing representative memories from this project group before reassignment. Local memories
+				can be reassigned; peer-owned memories stay in review on this device.
+			</div>
+			{samples.length > 0 ? (
+				<ul className="legacy-review-sample-list">
+					{samples.map((sample) => (
+						<li className="legacy-review-sample" key={sample.id}>
+							<div className="legacy-review-sample-title">{sample.title}</div>
+							<div className="legacy-review-group-meta">
+								{sample.kind || "memory"} · {formatSampleDate(sample.updatedAt ?? sample.createdAt)}{" "}
+								·{" "}
+								{sample.ownership === "local"
+									? "local, reassignable"
+									: "peer-owned, stays in review"}
+							</div>
+							{sample.bodyPreview ? (
+								<div className="legacy-review-sample-body">{sample.bodyPreview}</div>
+							) : null}
+							<div className="legacy-review-group-meta mono">{sampleOrigin(sample)}</div>
+						</li>
+					))}
+				</ul>
+			) : (
+				<div className="legacy-review-cleanup-note">
+					No samples are available for this group. Refresh Sync and try again before reassigning.
+				</div>
+			)}
+		</details>
+	);
 }
 
 function formatLegacyReviewError(
@@ -532,6 +606,7 @@ function LegacySharedReviewRow({
 									.
 								</div>
 							) : null}
+							<LegacyMemorySamples group={group} />
 							{targetScopes.length > 0 && onReassign && canReassignLegacyGroup(group) ? (
 								<label className="legacy-review-target">
 									<span>Destination Space</span>

--- a/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
@@ -74,6 +74,31 @@ export function renderSyncSharingReview() {
 								identitySource: String(raw.identity_source || "unknown"),
 								lastUpdatedAt: typeof raw.last_updated_at === "string" ? raw.last_updated_at : null,
 								memoryCount: Number(raw.memory_count || 0),
+								memorySamples: Array.isArray(raw.memory_samples)
+									? raw.memory_samples.map((sample) => {
+											const sampleRaw = sample as Record<string, unknown>;
+											const ownership: "local" | "peer" =
+												sampleRaw.ownership === "peer" ? "peer" : "local";
+											return {
+												bodyPreview:
+													typeof sampleRaw.body_preview === "string"
+														? sampleRaw.body_preview
+														: null,
+												createdAt:
+													typeof sampleRaw.created_at === "string" ? sampleRaw.created_at : null,
+												cwd: typeof sampleRaw.cwd === "string" ? sampleRaw.cwd : null,
+												gitRemote:
+													typeof sampleRaw.git_remote === "string" ? sampleRaw.git_remote : null,
+												id: Number(sampleRaw.id || 0),
+												kind: typeof sampleRaw.kind === "string" ? sampleRaw.kind : null,
+												ownership,
+												project: typeof sampleRaw.project === "string" ? sampleRaw.project : null,
+												title: String(sampleRaw.title || `Memory ${Number(sampleRaw.id || 0)}`),
+												updatedAt:
+													typeof sampleRaw.updated_at === "string" ? sampleRaw.updated_at : null,
+											};
+										})
+									: [],
 								peerOwnedMemoryCount: Number(raw.peer_owned_memory_count || 0),
 								reassignableMemoryCount: Number(raw.reassignable_memory_count || 0),
 								suggestedScopeId:

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1978,6 +1978,34 @@
         font-size: var(--font-size-md);
         line-height: 1.45;
       }
+      .legacy-review-samples {
+        padding: var(--sp-2) var(--sp-3);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--surface-1) 72%, transparent);
+      }
+      .legacy-review-samples summary {
+        cursor: pointer;
+        color: var(--text-primary);
+        font-weight: var(--font-weight-semibold);
+      }
+      .legacy-review-sample-list {
+        display: grid;
+        gap: var(--sp-2);
+        margin: var(--sp-2) 0 0;
+        padding: 0;
+        list-style: none;
+      }
+      .legacy-review-sample {
+        display: grid;
+        gap: 3px;
+        padding: var(--sp-2);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface-1);
+      }
+      .legacy-review-sample-title { color: var(--text-primary); font-weight: var(--font-weight-semibold); }
+      .legacy-review-sample-body { color: var(--text-secondary); font-size: var(--font-size-sm); line-height: 1.45; }
       .legacy-review-target {
         display: grid;
         gap: 5px;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2586,8 +2586,8 @@ describe("viewer-server", () => {
 					.prepare(
 						`INSERT INTO memory_items(
 							session_id, kind, title, body_text, created_at, updated_at,
-							visibility, workspace_id, workspace_kind, active, scope_id, metadata_json
-						 ) VALUES (?, 'discovery', ?, ?, ?, ?, 'shared', 'shared:default', 'shared', 1, ?, '{}')`,
+							visibility, workspace_id, workspace_kind, active, origin_device_id, scope_id, metadata_json
+						 ) VALUES (?, 'discovery', ?, ?, ?, ?, 'shared', 'shared:default', 'shared', 1, ?, ?, '{}')`,
 					)
 					.run(
 						Number(sameRepoSession.lastInsertRowid),
@@ -2595,6 +2595,7 @@ describe("viewer-server", () => {
 						"Legacy shared same repo body",
 						now,
 						now,
+						store.deviceId,
 						"legacy-shared-review",
 					);
 				store.db
@@ -2635,6 +2636,11 @@ describe("viewer-server", () => {
 					legacy_shared_review: {
 						groups: Array<{
 							display_project: string;
+							memory_samples: Array<{
+								body_preview: string | null;
+								ownership: "local" | "peer";
+								title: string;
+							}>;
 							memory_count: number;
 							workspace_identity: string;
 						}>;
@@ -2648,10 +2654,33 @@ describe("viewer-server", () => {
 					memory_count: 24,
 					scope_id: "legacy-shared-review",
 				});
+				const codememGroup = body.legacy_shared_review.groups.find(
+					(group) =>
+						group.workspace_identity === "https://git.example.invalid/oss/codemem-test.git",
+				);
+				expect(codememGroup?.memory_samples).toHaveLength(3);
+				expect(
+					codememGroup?.memory_samples.every(
+						(sample) => !sample.body_preview || sample.body_preview.length <= 180,
+					),
+				).toBe(true);
+				expect(codememGroup?.memory_samples).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({ ownership: "local" }),
+						expect.objectContaining({ ownership: "peer" }),
+					]),
+				);
 				expect(body.legacy_shared_review.groups).toEqual(
 					expect.arrayContaining([
 						expect.objectContaining({
-							display_project: "codemem-test",
+							display_project: "codemem-test-worktree",
+							memory_samples: expect.arrayContaining([
+								expect.objectContaining({
+									body_preview: expect.stringContaining("Legacy shared"),
+									ownership: expect.stringMatching(/^(local|peer)$/),
+									title: expect.stringContaining("Legacy shared"),
+								}),
+							]),
 							memory_count: 23,
 							workspace_identity: "https://git.example.invalid/oss/codemem-test.git",
 						}),

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1537,6 +1537,7 @@ function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> 
 			reassignable_memory_count: number;
 			peer_owned_memory_count: number;
 			last_updated_at: string | null;
+			memory_samples: LegacySharedReviewMemorySample[];
 			suggested_scope_id: string | null;
 			suggestion_reason: string | null;
 		}
@@ -1567,6 +1568,9 @@ function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> 
 			if (rowUpdatedAt && (!existing.last_updated_at || rowUpdatedAt > existing.last_updated_at)) {
 				existing.last_updated_at = rowUpdatedAt;
 			}
+			if (existing.memory_samples.length < LEGACY_SHARED_REVIEW_SAMPLE_LIMIT) {
+				existing.memory_samples.push(legacySharedReviewMemorySample(row, isOwnedBySelf));
+			}
 			continue;
 		}
 		groupsByIdentity.set(identity.value, {
@@ -1577,6 +1581,7 @@ function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> 
 			reassignable_memory_count: isOwnedBySelf ? 1 : 0,
 			peer_owned_memory_count: isOwnedBySelf ? 0 : 1,
 			last_updated_at: rowUpdatedAt,
+			memory_samples: [legacySharedReviewMemorySample(row, isOwnedBySelf)],
 			suggested_scope_id: suggestedScope ?? null,
 			suggestion_reason: suggestedScope
 				? (candidate?.suggestion_reason ??
@@ -1618,8 +1623,12 @@ interface LegacySharedReviewReassignmentMemoryRow {
 	rev: number | null;
 	active: number | null;
 	deleted_at: string | null;
+	created_at: string | null;
 	updated_at: string | null;
 	scope_id: string | null;
+	kind: string | null;
+	title: string | null;
+	body_text: string | null;
 	project: string | null;
 	cwd: string | null;
 	git_remote: string | null;
@@ -1630,6 +1639,46 @@ interface LegacySharedReviewReassignmentMemoryRow {
 	metadata_json: string | null;
 }
 
+const LEGACY_SHARED_REVIEW_SAMPLE_LIMIT = 3;
+const LEGACY_SHARED_REVIEW_BODY_PREVIEW_SQL_LIMIT = 360;
+
+interface LegacySharedReviewMemorySample {
+	id: number;
+	kind: string | null;
+	title: string;
+	body_preview: string | null;
+	created_at: string | null;
+	updated_at: string | null;
+	ownership: "local" | "peer";
+	project: string | null;
+	cwd: string | null;
+	git_remote: string | null;
+}
+
+function previewText(value: string | null | undefined, limit = 180): string | null {
+	const normalized = value?.replace(/\s+/g, " ").trim();
+	if (!normalized) return null;
+	return normalized.length > limit ? `${normalized.slice(0, limit - 1)}…` : normalized;
+}
+
+function legacySharedReviewMemorySample(
+	row: LegacySharedReviewReassignmentMemoryRow,
+	isOwnedBySelf: boolean,
+): LegacySharedReviewMemorySample {
+	return {
+		id: row.id,
+		kind: row.kind,
+		title: previewText(row.title, 120) ?? `Memory ${row.id}`,
+		body_preview: previewText(row.body_text),
+		created_at: row.created_at ?? null,
+		updated_at: row.updated_at ?? null,
+		ownership: isOwnedBySelf ? "local" : "peer",
+		project: row.project ?? null,
+		cwd: row.cwd ?? null,
+		git_remote: row.git_remote ?? null,
+	};
+}
+
 function legacySharedReviewRows(store: MemoryStore): LegacySharedReviewReassignmentMemoryRow[] {
 	return store.db
 		.prepare(
@@ -1637,8 +1686,12 @@ function legacySharedReviewRows(store: MemoryStore): LegacySharedReviewReassignm
 			        m.rev,
 			        m.active,
 			        m.deleted_at,
+			        m.created_at,
 			        m.updated_at,
 			        m.scope_id,
+			        m.kind,
+			        m.title,
+				        substr(m.body_text, 1, ?) AS body_text,
 			        s.project,
 			        s.cwd,
 			        s.git_remote,
@@ -1651,9 +1704,13 @@ function legacySharedReviewRows(store: MemoryStore): LegacySharedReviewReassignm
 			 LEFT JOIN sessions s ON s.id = m.session_id
 			 WHERE m.scope_id = ?
 			   AND m.active = 1
-			   AND m.deleted_at IS NULL`,
+			   AND m.deleted_at IS NULL
+			 ORDER BY COALESCE(m.updated_at, m.created_at, '') DESC, m.id DESC`,
 		)
-		.all(LEGACY_SHARED_REVIEW_SCOPE_ID) as LegacySharedReviewReassignmentMemoryRow[];
+		.all(
+			LEGACY_SHARED_REVIEW_BODY_PREVIEW_SQL_LIMIT,
+			LEGACY_SHARED_REVIEW_SCOPE_ID,
+		) as LegacySharedReviewReassignmentMemoryRow[];
 }
 
 function legacySharedReviewConfirmationToken(input: {


### PR DESCRIPTION
## Description
Adds representative memory samples to the legacy shared-review reassignment flow so users can inspect affected memories before choosing a destination Space.

- includes up to three bounded samples per legacy project group in sync status
- maps those samples into the Sync review UI
- renders an “Inspect affected memories” details panel that distinguishes local, reassignable memories from peer-owned memories that stay in review

Projects inventory behavior is unchanged.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Checks run:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts -t "legacy shared review"`
- `pnpm exec vitest run packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx`
- `pnpm run tsc`
- `pnpm run lint`
- `pnpm --filter @codemem/ui build`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
