### PR TITLE
feat(feed): show memory ids on cards

### DIFF
--- a/packages/ui/src/tabs/feed/components/FeedItemCard.test.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.test.tsx
@@ -1,0 +1,54 @@
+import { h, render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FeedItemCard } from "./FeedItemCard";
+
+vi.mock("../../../components/primitives/tooltip", () => ({
+	Tooltip: ({ children }: { children?: unknown }) => children,
+	TooltipProvider: ({ children }: { children?: unknown }) => children,
+}));
+
+let mount: HTMLDivElement;
+
+beforeEach(() => {
+	mount = document.createElement("div");
+	document.body.appendChild(mount);
+});
+
+afterEach(() => {
+	act(() => {
+		render(null, mount);
+	});
+	mount.remove();
+});
+
+describe("FeedItemCard", () => {
+	it("shows the memory database id as quiet provenance", () => {
+		act(() => {
+			render(
+				h(FeedItemCard, {
+					item: {
+						body_text: "A diagnostic memory body.",
+						created_at: "2026-05-26T23:30:00.000Z",
+						id: 1234,
+						kind: "discovery",
+						metadata_json: {},
+						owned_by_self: false,
+						project: "btha",
+						title: "BTHA diagnostic memory",
+						visibility: "shared",
+					},
+					onReload: async () => {},
+					onRemove: () => {},
+					onReplace: () => {},
+					onViewRefresh: () => {},
+				}),
+				mount,
+			);
+		});
+
+		expect(mount.textContent).toContain("ID 1234");
+		const chip = mount.querySelector(".provenance-chip.memory-id");
+		expect(chip?.textContent).toBe("ID 1234");
+	});
+});

--- a/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
@@ -69,6 +69,7 @@ export function FeedItemCard({
 	const tagContent = tags.length ? ` · ${tags.map((t) => formatTagLabel(t)).join(", ")}` : "";
 	const fileContent = files.length ? ` · ${formatFileList(files)}` : "";
 	const memoryId = Number(item.id || 0);
+	const memoryIdLabel = memoryId > 0 ? `ID ${memoryId}` : "";
 	const [isNew, setIsNew] = useState(state.newItemKeys.has(rowKey));
 	const summaryObj = isSessionSummary
 		? getSummaryObject({ ...item, metadata_json: metadata })
@@ -343,6 +344,13 @@ export function FeedItemCard({
 				{ className: "feed-provenance" },
 				h(ProvenanceChip, { label: actor, variant: actor === "You" ? "mine" : "author" }),
 				h(ProvenanceChip, { label: visibility || "private", variant: visibility || "private" }),
+				memoryIdLabel
+					? h(
+							Tooltip,
+							{ label: `Memory database id ${memoryId}`, side: "top" },
+							h(ProvenanceChip, { label: memoryIdLabel, variant: "memory-id" }),
+						)
+					: null,
 			),
 			h(
 				"div",

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1570,6 +1570,12 @@
       .provenance-chip.source { background: rgba(94, 129, 172, 0.12); color: #5e81ac; }
       .provenance-chip.device { background: rgba(128, 110, 74, 0.12); color: #806e4a; }
       .provenance-chip.trust { background: rgba(202, 138, 4, 0.12); color: #a16207; }
+      .provenance-chip.memory-id {
+        background: transparent;
+        border-color: color-mix(in srgb, var(--border) 55%, transparent);
+        color: var(--text-tertiary);
+        font-family: var(--font-mono);
+      }
 
       .feed-body {
         font-size: var(--font-size-md);


### PR DESCRIPTION
## Description
Adds a quiet memory ID chip to Feed cards so copied or unexpected memories can be traced from the UI back to their database row.

- renders `ID <number>` alongside provenance chips when a memory row has a positive database id
- keeps the styling muted and monospace so it stays diagnostic rather than distracting
- adds a component regression test for the visible ID chip

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Checks run:
- `pnpm exec vitest run packages/ui/src/tabs/feed/components/FeedItemCard.test.tsx`
- `pnpm run tsc`
- `pnpm run lint`
- `pnpm --filter @codemem/ui build`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
