### PR TITLE
fix(sync): propagate source project scope mappings

### DIFF
--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -48,24 +48,29 @@ function insertMemory(
 	input: {
 		originDeviceId?: string | null;
 		project?: string | null;
+		scopeId?: string | null;
 		workspaceId?: string | null;
 	} = {},
 ) {
 	const now = "2026-05-06T00:00:00Z";
-	db.prepare(
-		`INSERT INTO memory_items(
+	const result = db
+		.prepare(
+			`INSERT INTO memory_items(
 			session_id, kind, title, body_text, created_at, updated_at,
-			visibility, workspace_id, origin_device_id, active, metadata_json, project
-		 ) VALUES (?, 'discovery', 'Scoped project', 'Body', ?, ?, 'shared', ?, ?, 1, ?, ?)`,
-	).run(
-		sessionId,
-		now,
-		now,
-		input.workspaceId === undefined ? "shared:acme" : input.workspaceId,
-		input.originDeviceId === undefined ? null : input.originDeviceId,
-		toJson({}),
-		input.project === undefined ? null : input.project,
-	);
+			visibility, workspace_id, origin_device_id, active, metadata_json, project, scope_id
+		 ) VALUES (?, 'discovery', 'Scoped project', 'Body', ?, ?, 'shared', ?, ?, 1, ?, ?, ?)`,
+		)
+		.run(
+			sessionId,
+			now,
+			now,
+			input.workspaceId === undefined ? "shared:acme" : input.workspaceId,
+			input.originDeviceId === undefined ? null : input.originDeviceId,
+			toJson({}),
+			input.project === undefined ? null : input.project,
+			input.scopeId === undefined ? null : input.scopeId,
+		);
+	return Number(result.lastInsertRowid);
 }
 
 function insertScope(
@@ -694,6 +699,148 @@ describe("project scope settings", () => {
 			mapping_id: mapping.id,
 		});
 		expect(memberships.n).toBe(0);
+	});
+
+	it("propagates source-owned project Space assignments into syncable memory ops", () => {
+		insertScope(db, { scopeId: "acme-work", label: "Acme Work" });
+		const localSession = insertSession(db, {
+			cwd: "/workspace/work/exampleco/api",
+			gitRemote: "https://git.example.invalid/exampleco/api.git",
+			project: "api",
+		});
+		const localMemoryId = insertMemory(db, localSession, {
+			originDeviceId: "source-device",
+			project: "api",
+			scopeId: LOCAL_DEFAULT_SCOPE_ID,
+		});
+		const peerSession = insertSession(db, {
+			cwd: "/workspace/work/exampleco/api-peer-copy",
+			gitRemote: "https://git.example.invalid/exampleco/api.git",
+			project: "api",
+		});
+		const peerMemoryId = insertMemory(db, peerSession, {
+			originDeviceId: "peer-device",
+			project: "api",
+			scopeId: LOCAL_DEFAULT_SCOPE_ID,
+		});
+
+		const mapping = upsertProjectScopeSettingsMapping(db, {
+			deviceId: "source-device",
+			workspace_identity: "https://git.example.invalid/exampleco/api.git",
+			project_pattern: "api",
+			scope_id: "acme-work",
+		});
+
+		expect(mapping.scope_id).toBe("acme-work");
+		expect(
+			db.prepare("SELECT scope_id, rev FROM memory_items WHERE id = ?").get(localMemoryId),
+		).toMatchObject({ rev: 2, scope_id: "acme-work" });
+		expect(
+			db.prepare("SELECT scope_id, rev FROM memory_items WHERE id = ?").get(peerMemoryId),
+		).toMatchObject({ rev: 0, scope_id: LOCAL_DEFAULT_SCOPE_ID });
+		const ops = db
+			.prepare(
+				`SELECT op_type, scope_id, clock_rev, clock_device_id, payload_json
+				 FROM replication_ops
+				 WHERE entity_id = ?
+				 ORDER BY clock_rev`,
+			)
+			.all(String(localMemoryId)) as Array<{
+			clock_device_id: string;
+			clock_rev: number;
+			op_type: string;
+			payload_json: string | null;
+			scope_id: string;
+		}>;
+		expect(ops).toEqual([
+			expect.objectContaining({
+				clock_device_id: "source-device",
+				clock_rev: 1,
+				op_type: "delete",
+				scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			}),
+			expect.objectContaining({
+				clock_device_id: "source-device",
+				clock_rev: 2,
+				op_type: "upsert",
+				scope_id: "acme-work",
+			}),
+		]);
+		expect(JSON.parse(ops[1]?.payload_json ?? "{}")).toMatchObject({
+			project: "api",
+			scope_id: "acme-work",
+		});
+	});
+
+	it("propagates rows that matched a project Space mapping before it was edited", () => {
+		insertScope(db, { scopeId: "acme-work", label: "Acme Work" });
+		const sessionId = insertSession(db, {
+			cwd: "/workspace/work/exampleco/api",
+			gitRemote: "https://git.example.invalid/exampleco/api.git",
+			project: "api",
+		});
+		const memoryId = insertMemory(db, sessionId, {
+			originDeviceId: "source-device",
+			project: "api",
+			scopeId: LOCAL_DEFAULT_SCOPE_ID,
+		});
+		const mapping = upsertProjectScopeSettingsMapping(db, {
+			deviceId: "source-device",
+			workspace_identity: "https://git.example.invalid/exampleco/api.git",
+			project_pattern: "api",
+			scope_id: "acme-work",
+		});
+
+		upsertProjectScopeSettingsMapping(db, {
+			deviceId: "source-device",
+			id: mapping.id,
+			workspace_identity: "https://git.example.invalid/exampleco/other.git",
+			project_pattern: "other",
+			scope_id: "acme-work",
+		});
+
+		expect(
+			db.prepare("SELECT scope_id, rev FROM memory_items WHERE id = ?").get(memoryId),
+		).toMatchObject({ rev: 4, scope_id: LOCAL_DEFAULT_SCOPE_ID });
+		const ops = db
+			.prepare(
+				`SELECT op_type, scope_id, clock_rev, clock_device_id
+				 FROM replication_ops
+				 WHERE entity_id = ?
+				 ORDER BY clock_rev`,
+			)
+			.all(String(memoryId)) as Array<{
+			clock_device_id: string;
+			clock_rev: number;
+			op_type: string;
+			scope_id: string;
+		}>;
+		expect(ops).toEqual([
+			expect.objectContaining({
+				clock_device_id: "source-device",
+				clock_rev: 1,
+				op_type: "delete",
+				scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			}),
+			expect.objectContaining({
+				clock_device_id: "source-device",
+				clock_rev: 2,
+				op_type: "upsert",
+				scope_id: "acme-work",
+			}),
+			expect.objectContaining({
+				clock_device_id: "source-device",
+				clock_rev: 3,
+				op_type: "delete",
+				scope_id: "acme-work",
+			}),
+			expect.objectContaining({
+				clock_device_id: "source-device",
+				clock_rev: 4,
+				op_type: "upsert",
+				scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			}),
+		]);
 	});
 
 	it("normalizes incoming workspace identities before matching existing mappings", () => {

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { Database } from "./db.js";
+import { type Database, fromJson, toJson } from "./db.js";
 import { ensureScopeBackfillScopes, LEGACY_SHARED_REVIEW_SCOPE_ID } from "./scope-backfill.js";
 import {
 	canonicalWorkspaceIdentity,
@@ -120,6 +120,7 @@ interface ProjectScopeSuggestion {
 }
 
 export interface UpsertProjectScopeMappingInput {
+	deviceId?: string | null;
 	id?: number | null;
 	workspace_identity?: string | null;
 	project_pattern?: string | null;
@@ -651,6 +652,7 @@ function assertActiveScope(db: Database, scopeId: string): void {
 }
 
 interface ProjectScopeMappingDraft {
+	deviceId: string | null;
 	existing: ProjectScopeSettingsMapping | null;
 	workspaceIdentity: string | null;
 	projectPattern: string | null;
@@ -675,6 +677,7 @@ function resolveProjectScopeMappingDraft(
 		clean(input.project_pattern) ?? existing?.project_pattern ?? workspaceIdentity;
 	const priority = input.priority == null ? (existing?.priority ?? 0) : Number(input.priority);
 	return {
+		deviceId: clean(input.deviceId),
 		existing,
 		workspaceIdentity,
 		projectPattern,
@@ -682,6 +685,122 @@ function resolveProjectScopeMappingDraft(
 		priority,
 		source: clean(input.source) ?? "user",
 	};
+}
+
+interface SourceOwnedMemoryScopeRow {
+	id: number;
+	rev: number | null;
+	scope_id: string | null;
+	metadata_json: string | null;
+	workspace_id: string | null;
+	cwd: string | null;
+	git_branch: string | null;
+	git_remote: string | null;
+	project: string | null;
+}
+
+function sourceOwnedMemoryRowsForScopePropagation(
+	db: Database,
+	deviceId: string,
+): SourceOwnedMemoryScopeRow[] {
+	return db
+		.prepare(
+			`SELECT
+				mi.id,
+				mi.rev,
+				mi.scope_id,
+				mi.metadata_json,
+				mi.workspace_id,
+				s.cwd,
+				s.git_branch,
+				s.git_remote,
+				s.project
+			 FROM memory_items mi
+			 JOIN sessions s ON s.id = mi.session_id
+			 WHERE mi.active = 1
+			   AND (mi.origin_device_id IS NULL OR TRIM(mi.origin_device_id) = '' OR mi.origin_device_id = ?)
+			   AND (s.cwd IS NULL OR substr(s.cwd, 1, length(?)) <> ?)`,
+		)
+		.all(
+			deviceId,
+			SYNC_BOOTSTRAP_CWD_PREFIX,
+			SYNC_BOOTSTRAP_CWD_PREFIX,
+		) as SourceOwnedMemoryScopeRow[];
+}
+
+function propagateProjectScopeMappingToSourceOwnedMemories(
+	db: Database,
+	mapping: ProjectScopeSettingsMapping,
+	deviceId: string | null,
+	previousMappings?: ProjectScopeSettingsMapping[],
+): number {
+	if (!deviceId) return 0;
+	const mappings = listProjectScopeSettingsMappings(db);
+	const oldMappings = previousMappings ?? mappings;
+	const now = new Date().toISOString();
+	let moved = 0;
+	for (const row of sourceOwnedMemoryRowsForScopePropagation(db, deviceId)) {
+		const previousResolution = resolveProjectScope({
+			gitBranch: row.git_branch,
+			gitRemote: row.git_remote,
+			cwd: row.cwd,
+			project: row.project,
+			workspaceId: row.workspace_id,
+			mappings: oldMappings,
+		});
+		const resolution = resolveProjectScope({
+			gitBranch: row.git_branch,
+			gitRemote: row.git_remote,
+			cwd: row.cwd,
+			project: row.project,
+			workspaceId: row.workspace_id,
+			mappings,
+		});
+		if (previousResolution.mapping?.id !== mapping.id && resolution.mapping?.id !== mapping.id) {
+			continue;
+		}
+		const oldScopeId = clean(row.scope_id) ?? LOCAL_DEFAULT_SCOPE_ID;
+		const newScopeId = resolution.scopeId;
+		if (oldScopeId === newScopeId) continue;
+		const oldRev = Number(row.rev ?? 0);
+		const tombstoneRev = oldRev + 1;
+		const upsertRev = oldRev + 2;
+		const metadata = fromJson(row.metadata_json);
+		metadata.clock_device_id = deviceId;
+		metadata.last_project_scope_mapping = {
+			mapping_id: mapping.id,
+			old_scope_id: oldScopeId,
+			new_scope_id: newScopeId,
+			updated_at: now,
+		};
+		db.prepare(
+			`UPDATE memory_items
+			 SET scope_id = ?, updated_at = ?, metadata_json = ?, rev = ?
+			 WHERE id = ?`,
+		).run(newScopeId, now, toJson(metadata), upsertRev, row.id);
+		recordReplicationOp(db, {
+			memoryId: row.id,
+			opType: "delete",
+			deviceId,
+			scopeId: oldScopeId,
+			clockRev: tombstoneRev,
+			clockUpdatedAt: now,
+			clockDeviceId: deviceId,
+			createdAt: now,
+		});
+		recordReplicationOp(db, {
+			memoryId: row.id,
+			opType: "upsert",
+			deviceId,
+			scopeId: newScopeId,
+			clockRev: upsertRev,
+			clockUpdatedAt: now,
+			clockDeviceId: deviceId,
+			createdAt: now,
+		});
+		moved += 1;
+	}
+	return moved;
 }
 
 export function analyzeProjectScopeMappingChangeGuardrails(
@@ -1123,6 +1242,7 @@ export function upsertProjectScopeSettingsMapping(
 	const source = draft.source;
 	const now = new Date().toISOString();
 	if (existing) {
+		const previousMappings = listProjectScopeSettingsMappings(db);
 		db.prepare(
 			`UPDATE project_scope_mappings
 			 SET workspace_identity = ?, project_pattern = ?, scope_id = ?, priority = ?, source = ?, updated_at = ?
@@ -1130,6 +1250,7 @@ export function upsertProjectScopeSettingsMapping(
 		).run(workspaceIdentity, projectPattern, scopeId, priority, source, now, existing.id);
 		const saved = getProjectScopeSettingsMappingById(db, existing.id);
 		if (!saved) throw new Error("project_scope_mapping update returned no row");
+		propagateProjectScopeMappingToSourceOwnedMemories(db, saved, draft.deviceId, previousMappings);
 		return saved;
 	}
 
@@ -1142,6 +1263,7 @@ export function upsertProjectScopeSettingsMapping(
 		.run(workspaceIdentity, projectPattern, scopeId, priority, source, now, now);
 	const saved = getProjectScopeSettingsMappingById(db, Number(result.lastInsertRowid));
 	if (!saved) throw new Error("project_scope_mapping insert returned no row");
+	propagateProjectScopeMappingToSourceOwnedMemories(db, saved, draft.deviceId);
 	return saved;
 }
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -3285,7 +3285,9 @@ export function syncRoutes(
 					409,
 				);
 			}
+			const [deviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 			const mapping = upsertProjectScopeSettingsMapping(store.db, {
+				deviceId,
 				...mappingInput,
 			});
 			return c.json({ ok: true, mapping, guardrail_warnings: analysis.warnings });
@@ -3344,9 +3346,10 @@ export function syncRoutes(
 					409,
 				);
 			}
+			const [deviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 			const saveMappings = store.db.transaction(() =>
 				mappingInputs.map((mappingInput) =>
-					upsertProjectScopeSettingsMapping(store.db, mappingInput),
+					upsertProjectScopeSettingsMapping(store.db, { deviceId, ...mappingInput }),
 				),
 			);
 			return c.json({


### PR DESCRIPTION
## Description
Propagates source-owned project Space mapping changes into the memories the source device owns. When a project mapping is saved through the viewer API, matching local/source-owned memories now get their `scope_id` updated, revision bumped, and old-scope delete plus new-scope upsert replication ops emitted so receivers can converge. Edited mappings also rescope rows that matched the previous mapping but no longer match the edited identity/pattern. Peer-owned received rows remain excluded.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional targeted checks:
- `pnpm exec vitest run packages/core/src/project-scope-settings.test.ts`
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "legacy shared review|project-mappings"`
- `pnpm exec biome check packages/core/src/project-scope-settings.ts packages/core/src/project-scope-settings.test.ts packages/viewer-server/src/routes/sync.ts`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
