### PR TITLE
fix(ui): clarify source-owned sync reassignment copy

### DIFF
--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -1454,7 +1454,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				prevents_future_sync: true,
 				deletes_already_copied_data: false,
 				message:
-					"Revocation prevents future sync only; it does not remove data already copied to the revoked device.",
+					"Revocation blocks future sync for this Space. It does not remove data already copied to the revoked device; offline devices, backups, copied databases, malicious peers, or old versions may retain data.",
 			},
 		});
 		expect(store.revokeScopeMembership).toHaveBeenCalledWith({

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -847,7 +847,7 @@ export function analyzeProjectScopeMappingChangeGuardrails(
 		warnings.push({
 			code: "scope_reassignment_old_copies",
 			severity: "warning",
-			message: `Changing this project from ${oldScope} to ${newScope} does not recall data already copied under the old Sharing domain. Previous recipients may retain it.`,
+			message: `Changing this project from ${oldScope} to ${newScope} updates future sync authorization. Online compatible peers should converge after syncing, but offline devices, backups, copied databases, malicious peers, or old versions may retain old copies.`,
 			requires_confirmation: true,
 			scope_id: draft.scopeId,
 			previous_scope_id: draft.existing.scope_id,

--- a/packages/core/src/scope-membership-cache.test.ts
+++ b/packages/core/src/scope-membership-cache.test.ts
@@ -452,7 +452,7 @@ describe("scope membership cache", () => {
 			prevents_future_sync: true,
 			deletes_already_copied_data: false,
 			message:
-				"Revocation prevents future sync only; it does not remove data already copied to the revoked device.",
+				"Revocation blocks future sync for this Space. It does not remove data already copied to the revoked device; offline devices, backups, copied databases, malicious peers, or old versions may retain data.",
 		});
 	});
 

--- a/packages/core/src/scope-membership-semantics.test.ts
+++ b/packages/core/src/scope-membership-semantics.test.ts
@@ -40,7 +40,7 @@ describe("scope membership semantics", () => {
 			prevents_future_sync: true,
 			deletes_already_copied_data: false,
 			message:
-				"Revocation prevents future sync only; it does not remove data already copied to the revoked device.",
+				"Revocation blocks future sync for this Space. It does not remove data already copied to the revoked device; offline devices, backups, copied databases, malicious peers, or old versions may retain data.",
 		});
 	});
 });

--- a/packages/core/src/scope-membership-semantics.ts
+++ b/packages/core/src/scope-membership-semantics.ts
@@ -1,5 +1,5 @@
 export const SCOPE_MEMBERSHIP_REVOCATION_LIMITATION =
-	"Revocation prevents future sync only; it does not remove data already copied to the revoked device.";
+	"Revocation blocks future sync for this Space. It does not remove data already copied to the revoked device; offline devices, backups, copied databases, malicious peers, or old versions may retain data.";
 
 export interface ScopeMembershipRevocationNotice {
 	scope_id: string;

--- a/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
@@ -209,7 +209,7 @@ async function revokeMember(
 	const confirmed = await openSyncConfirmDialog({
 		title: spaceRevokeMemberTitle(scope, displayName, deviceId),
 		description:
-			"Revocation only blocks future sync for this Space. Data already copied to that device can remain there.",
+			"Revocation blocks future sync for this Space. It does not remove data already copied to the revoked device; offline devices, backups, copied databases, malicious peers, or old versions may retain data.",
 		confirmLabel: "Revoke membership",
 		cancelLabel: "Keep membership",
 		tone: "danger",

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx
@@ -85,7 +85,7 @@ describe("SyncSharingReview", () => {
 		expect(root.textContent).toContain("Evidence from a legacy shared memory.");
 		expect(root.textContent).toContain("local, reassignable");
 		expect(root.textContent).toContain("legacy data is not promoted automatically");
-		expect(root.textContent).toContain("Nothing moves automatically");
+		expect(root.textContent).toContain("Fix peer-owned projects on their source device");
 
 		const buttons = [...root.querySelectorAll("button")];
 		const button = buttons.find((item) => item.textContent === "Manage all projects");
@@ -107,7 +107,7 @@ describe("SyncSharingReview", () => {
 				skipped_memory_count: 1,
 				target_scope_label: "OSS",
 				warning:
-					"This changes future sync authorization but does not erase data already copied to peers.",
+					"This device can reassign only locally owned memories. Peer-owned copies must be fixed on their source device. Online compatible peers should converge after syncing, but offline devices, backups, copied databases, malicious peers, or old versions may retain old copies.",
 				workspace_identity: "https://git.example.invalid/oss/dev.git",
 			})
 			.mockResolvedValueOnce(null);
@@ -154,6 +154,7 @@ describe("SyncSharingReview", () => {
 		);
 		expect(root.textContent).toContain("2 of 3 memories");
 		expect(root.textContent).toContain("1 peer-owned copies will be left unchanged");
+		expect(root.textContent).toContain("Peer-owned copies must be fixed on their source device");
 
 		const confirmButton = [...root.querySelectorAll("button")].find(
 			(button) => button.textContent === "I understand, reassign memories",
@@ -540,6 +541,7 @@ describe("SyncSharingReview", () => {
 		expect(checkbox?.disabled).toBe(true);
 		expect(root.textContent).toContain("Peer-owned only");
 		expect(root.textContent).toContain("cannot reassign them to a Space");
+		expect(root.textContent).toContain("Assign this project to a Space on the source device");
 		expect(root.textContent).not.toContain("Preview reassignment");
 	});
 });

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
@@ -439,8 +439,10 @@ function LegacySharedReviewRow({
 							: ""}
 					</div>
 					<div className="peer-meta legacy-review-warning">
-						Nothing moves automatically. Reassignment changes future sync authorization; it does not
-						erase copies peers already received.
+						Fix peer-owned projects on their source device. Reassignment updates future sync
+						authorization; online compatible peers should converge after syncing, but offline
+						devices, backups, copied databases, malicious peers, or old versions may retain old
+						copies.
 					</div>
 				</div>
 				<div className="actor-actions">
@@ -563,7 +565,8 @@ function LegacySharedReviewRow({
 										{!canReassignLegacyGroup(group) ? (
 											<div className="legacy-review-cleanup-note">
 												Peer-owned only. These older memories were received from another device, so
-												this device cannot reassign them to a Space.
+												this device cannot reassign them to a Space. Assign this project to a Space
+												on the source device; after sync, this review should clear here.
 											</div>
 										) : group.peerOwnedMemoryCount ? (
 											<div className="legacy-review-cleanup-note">

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2806,7 +2806,9 @@ describe("viewer-server", () => {
 					memory_count: 2,
 					reassignable_memory_count: 1,
 				});
-				expect(preview.preview.warning).toContain("does not erase data already copied");
+				expect(preview.preview.warning).toContain(
+					"Peer-owned copies must be fixed on their source device",
+				);
 
 				const applyRes = await app.request("/api/sync/legacy-shared-review/reassign", {
 					method: "POST",

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1954,7 +1954,7 @@ function legacySharedReviewReassignmentPreview(
 		skipped_memory_count: rows.length - reassignableRows.length,
 		target_scope_label: targetScope.label || targetScope.scope_id,
 		warning:
-			"This changes future sync authorization for reassignable local memories. It does not erase data already copied to peers under legacy-shared-review.",
+			"This device can reassign only locally owned memories. Peer-owned copies must be fixed on their source device. Online compatible peers should converge after syncing, but offline devices, backups, copied databases, malicious peers, or old versions may retain old copies.",
 		workspace_identity: input.workspaceIdentity,
 	};
 }


### PR DESCRIPTION
## Description
Clarifies the 0.33.1 user-facing copy around legacy shared review and Space revocation. Legacy shared review now explains that peer-owned rows must be fixed on the source device and that reassignment updates future sync authorization without guaranteeing cleanup everywhere. Revocation copy now avoids promising post-revocation cleanup via sync and states that already-copied data may remain on the revoked device, offline devices, backups, copied databases, malicious peers, or old versions.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional targeted checks:
- `pnpm exec vitest run packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx`
- `pnpm exec vitest run packages/core/src/scope-membership-semantics.test.ts packages/core/src/scope-membership-cache.test.ts packages/core/src/coordinator-api.test.ts`
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "legacy shared review"`
- `pnpm exec biome check packages/core/src/scope-membership-semantics.ts packages/core/src/scope-membership-semantics.test.ts packages/core/src/scope-membership-cache.test.ts packages/core/src/coordinator-api.test.ts packages/core/src/project-scope-settings.ts packages/viewer-server/src/routes/sync.ts packages/viewer-server/src/index.test.ts packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts packages/ui/src/tabs/sync/components/sync-sharing-review.tsx packages/ui/src/tabs/sync/components/sync-sharing-review.test.tsx`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
