### PR TITLE
feat(sync): add source-authored access cleanup ops

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -591,6 +591,7 @@ export type {
 	ListInboundScopeRejectionsOptions,
 } from "./sync-replication.js";
 export {
+	ACCESS_CLEANUP_OP_TYPE,
 	applyReplicationOps,
 	backfillReplicationOps,
 	bulkPruneReplicationOpsByAgeCutoff,
@@ -614,6 +615,7 @@ export {
 	planReplicationOpsAgePrune,
 	pruneReplicationOps,
 	pruneReplicationOpsUntilCaughtUp,
+	recordAccessCleanupOp,
 	recordReplicationOp,
 	rejectInboundScopeFailures,
 	replicationOpRequiresPersonalScopeAuthorization,

--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -46,6 +46,7 @@ function insertMemory(
 	db: InstanceType<typeof Database>,
 	sessionId: number,
 	input: {
+		importKey?: string | null;
 		originDeviceId?: string | null;
 		project?: string | null;
 		scopeId?: string | null;
@@ -57,8 +58,8 @@ function insertMemory(
 		.prepare(
 			`INSERT INTO memory_items(
 			session_id, kind, title, body_text, created_at, updated_at,
-			visibility, workspace_id, origin_device_id, active, metadata_json, project, scope_id
-		 ) VALUES (?, 'discovery', 'Scoped project', 'Body', ?, ?, 'shared', ?, ?, 1, ?, ?, ?)`,
+			visibility, workspace_id, origin_device_id, active, metadata_json, project, scope_id, import_key
+		 ) VALUES (?, 'discovery', 'Scoped project', 'Body', ?, ?, 'shared', ?, ?, 1, ?, ?, ?, ?)`,
 		)
 		.run(
 			sessionId,
@@ -69,6 +70,7 @@ function insertMemory(
 			toJson({}),
 			input.project === undefined ? null : input.project,
 			input.scopeId === undefined ? null : input.scopeId,
+			input.importKey === undefined ? null : input.importKey,
 		);
 	return Number(result.lastInsertRowid);
 }
@@ -709,6 +711,7 @@ describe("project scope settings", () => {
 			project: "api",
 		});
 		const localMemoryId = insertMemory(db, localSession, {
+			importKey: "key:source-owned-api",
 			originDeviceId: "source-device",
 			project: "api",
 			scopeId: LOCAL_DEFAULT_SCOPE_ID,
@@ -743,9 +746,9 @@ describe("project scope settings", () => {
 				`SELECT op_type, scope_id, clock_rev, clock_device_id, payload_json
 				 FROM replication_ops
 				 WHERE entity_id = ?
-				 ORDER BY clock_rev`,
+				 ORDER BY clock_rev, op_type`,
 			)
-			.all(String(localMemoryId)) as Array<{
+			.all("key:source-owned-api") as Array<{
 			clock_device_id: string;
 			clock_rev: number;
 			op_type: string;
@@ -753,6 +756,12 @@ describe("project scope settings", () => {
 			scope_id: string;
 		}>;
 		expect(ops).toEqual([
+			expect.objectContaining({
+				clock_device_id: "source-device",
+				clock_rev: 1,
+				op_type: "access_cleanup",
+				scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			}),
 			expect.objectContaining({
 				clock_device_id: "source-device",
 				clock_rev: 1,
@@ -766,7 +775,11 @@ describe("project scope settings", () => {
 				scope_id: "acme-work",
 			}),
 		]);
-		expect(JSON.parse(ops[1]?.payload_json ?? "{}")).toMatchObject({
+		expect(JSON.parse(ops[0]?.payload_json ?? "{}")).toMatchObject({
+			cleanup_scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			reason: "project_scope_reassignment",
+		});
+		expect(JSON.parse(ops[2]?.payload_json ?? "{}")).toMatchObject({
 			project: "api",
 			scope_id: "acme-work",
 		});
@@ -780,6 +793,7 @@ describe("project scope settings", () => {
 			project: "api",
 		});
 		const memoryId = insertMemory(db, sessionId, {
+			importKey: "key:edited-api",
 			originDeviceId: "source-device",
 			project: "api",
 			scopeId: LOCAL_DEFAULT_SCOPE_ID,
@@ -804,18 +818,25 @@ describe("project scope settings", () => {
 		).toMatchObject({ rev: 4, scope_id: LOCAL_DEFAULT_SCOPE_ID });
 		const ops = db
 			.prepare(
-				`SELECT op_type, scope_id, clock_rev, clock_device_id
+				`SELECT op_type, scope_id, clock_rev, clock_device_id, payload_json
 				 FROM replication_ops
 				 WHERE entity_id = ?
-				 ORDER BY clock_rev`,
+				 ORDER BY clock_rev, op_type`,
 			)
-			.all(String(memoryId)) as Array<{
+			.all("key:edited-api") as Array<{
 			clock_device_id: string;
 			clock_rev: number;
 			op_type: string;
+			payload_json: string | null;
 			scope_id: string;
 		}>;
 		expect(ops).toEqual([
+			expect.objectContaining({
+				clock_device_id: "source-device",
+				clock_rev: 1,
+				op_type: "access_cleanup",
+				scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			}),
 			expect.objectContaining({
 				clock_device_id: "source-device",
 				clock_rev: 1,
@@ -831,6 +852,12 @@ describe("project scope settings", () => {
 			expect.objectContaining({
 				clock_device_id: "source-device",
 				clock_rev: 3,
+				op_type: "access_cleanup",
+				scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			}),
+			expect.objectContaining({
+				clock_device_id: "source-device",
+				clock_rev: 3,
 				op_type: "delete",
 				scope_id: "acme-work",
 			}),
@@ -841,6 +868,10 @@ describe("project scope settings", () => {
 				scope_id: LOCAL_DEFAULT_SCOPE_ID,
 			}),
 		]);
+		expect(JSON.parse(ops[3]?.payload_json ?? "{}")).toMatchObject({
+			cleanup_scope_id: "acme-work",
+			reason: "project_scope_reassignment",
+		});
 	});
 
 	it("normalizes incoming workspace identities before matching existing mappings", () => {

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -10,7 +10,7 @@ import {
 	type WorkspaceIdentitySource,
 } from "./scope-resolution.js";
 import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap.js";
-import { recordReplicationOp } from "./sync-replication.js";
+import { recordAccessCleanupOp, recordReplicationOp } from "./sync-replication.js";
 
 export interface SharingDomainSettingsScope {
 	scope_id: string;
@@ -689,6 +689,7 @@ function resolveProjectScopeMappingDraft(
 
 interface SourceOwnedMemoryScopeRow {
 	id: number;
+	import_key: string | null;
 	rev: number | null;
 	scope_id: string | null;
 	metadata_json: string | null;
@@ -707,6 +708,7 @@ function sourceOwnedMemoryRowsForScopePropagation(
 		.prepare(
 			`SELECT
 				mi.id,
+				mi.import_key,
 				mi.rev,
 				mi.scope_id,
 				mi.metadata_json,
@@ -788,6 +790,18 @@ function propagateProjectScopeMappingToSourceOwnedMemories(
 			clockDeviceId: deviceId,
 			createdAt: now,
 		});
+		if (row.import_key) {
+			recordAccessCleanupOp(db, {
+				importKey: row.import_key,
+				deviceId,
+				cleanupScopeId: oldScopeId,
+				clockRev: tombstoneRev,
+				clockUpdatedAt: now,
+				clockDeviceId: deviceId,
+				createdAt: now,
+				reason: "project_scope_reassignment",
+			});
+		}
 		recordReplicationOp(db, {
 			memoryId: row.id,
 			opType: "upsert",

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -24,6 +24,7 @@ import {
 	planReplicationOpsAgePrune,
 	pruneReplicationOps,
 	pruneReplicationOpsUntilCaughtUp,
+	recordAccessCleanupOp,
 	recordReplicationOp,
 	setReplicationCursor,
 	setSyncResetState,
@@ -473,6 +474,37 @@ describe("recordReplicationOp", () => {
 			.prepare("SELECT payload_json FROM replication_ops WHERE op_id = ?")
 			.get(opId) as { payload_json: string | null };
 		expect(row.payload_json).toBeNull();
+	});
+
+	it("records access cleanup ops on the default sync path", () => {
+		const opId = recordAccessCleanupOp(db, {
+			importKey: "key:cleanup",
+			deviceId: "dev-source",
+			cleanupScopeId: "acme-work",
+			clockRev: 7,
+			clockUpdatedAt: "2026-01-01T00:00:07Z",
+			targetPeerDeviceId: "dev-receiver",
+			reason: "scope_revoked",
+			opId: "cleanup-op",
+		});
+
+		expect(opId).toBe("cleanup-op");
+		const row = db.prepare("SELECT * FROM replication_ops WHERE op_id = ?").get(opId) as Record<
+			string,
+			unknown
+		>;
+		expect(row).toMatchObject({
+			clock_rev: 7,
+			device_id: "dev-source",
+			entity_id: "key:cleanup",
+			op_type: "access_cleanup",
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+		});
+		expect(JSON.parse(String(row.payload_json))).toMatchObject({
+			cleanup_scope_id: "acme-work",
+			reason: "scope_revoked",
+			target_peer_device_id: "dev-receiver",
+		});
 	});
 
 	it("falls back to memoryId as entity_id when import_key is null", () => {
@@ -2311,6 +2343,35 @@ describe("applyReplicationOps", () => {
 		return Boolean(db.prepare("SELECT 1 FROM memory_items WHERE import_key = ?").get(importKey));
 	}
 
+	function insertReplicatedMemory(
+		input: {
+			importKey?: string;
+			originDeviceId?: string | null;
+			scopeId?: string | null;
+			title?: string;
+		} = {},
+	): number {
+		const sessionId = insertTestSession(db);
+		const result = db
+			.prepare(
+				`INSERT INTO memory_items(
+					session_id, kind, title, body_text, created_at, updated_at,
+					import_key, rev, active, metadata_json, origin_device_id, scope_id
+				 ) VALUES (?, 'discovery', ?, 'Body', ?, ?, ?, 1, 1, ?, ?, ?)`,
+			)
+			.run(
+				sessionId,
+				input.title ?? "Replicated row",
+				"2026-01-01T00:00:00Z",
+				"2026-01-01T00:00:00Z",
+				input.importKey ?? "key:test-1",
+				toJson({ clock_device_id: input.originDeviceId ?? "dev-remote" }),
+				input.originDeviceId ?? "dev-remote",
+				input.scopeId ?? "acme-work",
+			);
+		return Number(result.lastInsertRowid);
+	}
+
 	it("skips ops from the local device", () => {
 		const op = makeReplicationOp({ device_id: "dev-local" });
 		const result = applyReplicationOps(db, [op], "dev-local");
@@ -2580,6 +2641,71 @@ describe("applyReplicationOps", () => {
 			.prepare("SELECT active, scope_id FROM memory_items WHERE import_key = ?")
 			.get(deleteOp.entity_id) as { active: number; scope_id: string | null };
 		expect(mem).toMatchObject({ active: 0, scope_id: "acme-work" });
+	});
+
+	it("physically deletes matching peer-received rows when access cleanup arrives", () => {
+		const memoryId = insertReplicatedMemory({
+			importKey: "key:cleanup",
+			originDeviceId: "dev-remote",
+			scopeId: "acme-work",
+		});
+		const op = makeReplicationOp({
+			op_id: "cleanup-op",
+			entity_id: "key:cleanup",
+			op_type: "access_cleanup",
+			payload_json: toJson({ cleanup_scope_id: "acme-work", reason: "scope_revoked" }),
+			clock_rev: 2,
+			clock_updated_at: "2026-01-01T00:00:01Z",
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+		});
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+
+		expect(result.applied).toBe(1);
+		expect(db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(memoryId)).toBeUndefined();
+		expect(result.vectorWork.deleteMemoryIds).toEqual([memoryId]);
+		expect(
+			db.prepare("SELECT op_type, scope_id FROM replication_ops WHERE op_id = ?").get(op.op_id),
+		).toMatchObject({ op_type: "access_cleanup", scope_id: DEFAULT_SYNC_SCOPE_ID });
+	});
+
+	it("does not let access cleanup delete local or differently scoped rows", () => {
+		const localMemoryId = insertReplicatedMemory({
+			importKey: "key:local-row",
+			originDeviceId: "dev-local",
+			scopeId: "acme-work",
+			title: "Local row",
+		});
+		const otherScopeMemoryId = insertReplicatedMemory({
+			importKey: "key:other-scope",
+			originDeviceId: "dev-remote",
+			scopeId: "client-work",
+			title: "Other scope row",
+		});
+		const cleanupLocal = makeReplicationOp({
+			op_id: "cleanup-local",
+			entity_id: "key:local-row",
+			op_type: "access_cleanup",
+			payload_json: toJson({ cleanup_scope_id: "acme-work", reason: "scope_revoked" }),
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+		});
+		const cleanupOtherScope = makeReplicationOp({
+			op_id: "cleanup-other-scope",
+			entity_id: "key:other-scope",
+			op_type: "access_cleanup",
+			payload_json: toJson({ cleanup_scope_id: "acme-work", reason: "scope_revoked" }),
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+		});
+
+		const result = applyReplicationOps(db, [cleanupLocal, cleanupOtherScope], "dev-local");
+
+		expect(result.applied).toBe(0);
+		expect(result.skipped).toBe(2);
+		expect(db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(localMemoryId)).toBeDefined();
+		expect(
+			db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(otherScopeMemoryId),
+		).toBeDefined();
+		expect(result.vectorWork.deleteMemoryIds).toEqual([]);
 	});
 
 	it("redacts secrets in inbound peer payloads on insert", () => {
@@ -3286,7 +3412,11 @@ describe("replication payload round-trip parity", () => {
 
 		// Read the op back
 		const op = db.prepare("SELECT * FROM replication_ops WHERE op_id = ?").get(opId) as {
+			clock_rev: number;
+			clock_updated_at: string;
+			created_at: string;
 			payload_json: string;
+			scope_id: string | null;
 		};
 		const payload = JSON.parse(op.payload_json) as Record<string, unknown>;
 

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -30,6 +30,7 @@ import type {
 } from "./types.js";
 
 export const DEFAULT_SYNC_SCOPE_ID = "local-default";
+export const ACCESS_CLEANUP_OP_TYPE = "access_cleanup";
 
 export interface SyncResetBoundary {
 	scope_id?: string | null;
@@ -126,6 +127,26 @@ interface MemoryPayload {
 	rev: number;
 	import_key: string | null;
 	project?: string | null;
+}
+
+interface AccessCleanupPayload {
+	cleanup_scope_id: string | null;
+	reason: string | null;
+	target_peer_device_id: string | null;
+}
+
+function parseAccessCleanupPayload(op: ReplicationOp): AccessCleanupPayload {
+	const payload = parsePayload(op.payload_json);
+	return {
+		cleanup_scope_id: cleanText(payload?.cleanup_scope_id ?? payload?.scope_id),
+		reason: cleanText(payload?.reason),
+		target_peer_device_id: cleanText(payload?.target_peer_device_id),
+	};
+}
+
+function accessCleanupTargetsPeer(op: ReplicationOp, peerDeviceId: string | null): boolean {
+	const targetPeerDeviceId = parseAccessCleanupPayload(op).target_peer_device_id;
+	return !targetPeerDeviceId || targetPeerDeviceId === cleanText(peerDeviceId);
 }
 
 function resolveReplicatedTextUpdate(
@@ -873,6 +894,49 @@ export function recordReplicationOp(
 		})
 		.run();
 
+	return opId;
+}
+
+export function recordAccessCleanupOp(
+	db: Database,
+	opts: {
+		importKey: string;
+		deviceId: string;
+		cleanupScopeId: string;
+		clockRev: number;
+		clockUpdatedAt: string;
+		clockDeviceId?: string;
+		createdAt?: string;
+		targetPeerDeviceId?: string | null;
+		reason?: string | null;
+		opId?: string;
+	},
+): string {
+	const d = drizzle(db, { schema });
+	const opId = opts.opId ?? randomUUID();
+	const now = opts.createdAt ?? new Date().toISOString();
+	const payload = {
+		cleanup_scope_id: opts.cleanupScopeId,
+		reason: cleanText(opts.reason) ?? "scope_access_cleanup",
+		...(cleanText(opts.targetPeerDeviceId)
+			? { target_peer_device_id: cleanText(opts.targetPeerDeviceId) }
+			: {}),
+	};
+	d.insert(schema.replicationOps)
+		.values({
+			op_id: opId,
+			entity_type: "memory_item",
+			entity_id: opts.importKey,
+			op_type: ACCESS_CLEANUP_OP_TYPE,
+			payload_json: toJson(payload),
+			clock_rev: opts.clockRev,
+			clock_updated_at: opts.clockUpdatedAt,
+			clock_device_id: opts.clockDeviceId ?? opts.deviceId,
+			device_id: opts.deviceId,
+			created_at: now,
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+		})
+		.run();
 	return opId;
 }
 
@@ -1937,6 +2001,19 @@ export function filterReplicationOpsForSyncWithStatus(
 	for (const op of ops) {
 		if (op.entity_type === "memory_item") {
 			const payload = parsePayload(op.payload_json);
+			if (op.op_type === ACCESS_CLEANUP_OP_TYPE) {
+				if (!accessCleanupTargetsPeer(op, peerDeviceId)) {
+					addSkipped(skipped, op, {
+						reason: "scope_filter",
+						scope_id: cleanText(payload?.cleanup_scope_id ?? op.scope_id),
+					});
+					nextCursor = computeCursor(op.created_at, op.op_id);
+					continue;
+				}
+				allowed.push(op);
+				nextCursor = computeCursor(op.created_at, op.op_id);
+				continue;
+			}
 			if (
 				applyScopeFilter &&
 				!outboundScopeAllowed(db, op, payload, peerDeviceId, options.localDeviceId ?? null)
@@ -2155,6 +2232,17 @@ function validateInboundScopeOp(
 	options: InboundScopeValidationOptions,
 ): InboundScopeRejection | null {
 	const peerDeviceId = cleanText(options.peerDeviceId) ?? cleanText(op.device_id);
+	if (op.op_type === ACCESS_CLEANUP_OP_TYPE) {
+		const senderDeviceId = peerDeviceId ?? cleanText(op.clock_device_id);
+		if (
+			!senderDeviceId ||
+			cleanText(op.device_id) !== senderDeviceId ||
+			cleanText(op.clock_device_id) !== senderDeviceId
+		) {
+			return inboundScopeRejection(op, "sender_not_member", peerDeviceId, null);
+		}
+		return null;
+	}
 	const senderDeviceId = peerDeviceId ?? cleanText(op.clock_device_id);
 	const receiverDeviceId = cleanText(localDeviceId);
 	const opScopeId = normalizeInboundScopeId(op.scope_id);
@@ -2769,6 +2857,30 @@ export function applyReplicationOps(
 		upsertMemoryIds.delete(memoryId);
 		deleteMemoryIds.add(memoryId);
 	};
+	const applyAccessCleanupOp = (op: ReplicationOp): boolean => {
+		const cleanup = parseAccessCleanupPayload(op);
+		if (!cleanup.cleanup_scope_id) return false;
+		const existingForCleanup = d
+			.select({
+				id: schema.memoryItems.id,
+				origin_device_id: schema.memoryItems.origin_device_id,
+				scope_id: schema.memoryItems.scope_id,
+			})
+			.from(schema.memoryItems)
+			.where(eq(schema.memoryItems.import_key, op.entity_id))
+			.limit(1)
+			.get();
+		if (!existingForCleanup) return true;
+		const sourceDeviceId = cleanText(op.clock_device_id) ?? cleanText(op.device_id);
+		const originDeviceId = cleanText(existingForCleanup.origin_device_id);
+		if (!sourceDeviceId || !originDeviceId || originDeviceId !== sourceDeviceId) return false;
+		if (originDeviceId === localDeviceId) return false;
+		if (cleanText(existingForCleanup.scope_id) !== cleanup.cleanup_scope_id) return false;
+		clearMemoryRefs(db, Number(existingForCleanup.id));
+		d.delete(schema.memoryItems).where(eq(schema.memoryItems.id, existingForCleanup.id)).run();
+		queueVectorDelete(Number(existingForCleanup.id));
+		return true;
+	};
 
 	const applyAll = db.transaction(() => {
 		for (const op of ops) {
@@ -2787,6 +2899,14 @@ export function applyReplicationOps(
 					.get();
 				if (existing) {
 					result.skipped++;
+					continue;
+				}
+
+				if (op.op_type === ACCESS_CLEANUP_OP_TYPE) {
+					const cleaned = applyAccessCleanupOp(op);
+					insertReplicationOpRow(d, op);
+					if (cleaned) result.applied++;
+					else result.skipped++;
 					continue;
 				}
 


### PR DESCRIPTION
## Description
Adds an explicit source-authored `access_cleanup` replication op for 0.34 cleanup protocol work. Cleanup ops travel on the default sync path while carrying the affected cleanup scope in their payload, so they can reach peers that no longer have scoped authorization. Source-side project Space reassignment now emits cleanup ops alongside the old-scope delete and new-scope upsert. Receivers physically delete only matching peer-received rows whose `origin_device_id` matches the cleanup author and whose stored `scope_id` matches the cleanup scope. Local/source-owned rows and differently scoped rows are skipped and retained.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, targeted Vitest/Biome)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional checks:
- `pnpm exec vitest run packages/core/src/sync-replication.test.ts`
- `pnpm exec vitest run packages/core/src/sync-replication.test.ts packages/core/src/sync-pass.test.ts`
- `pnpm exec vitest run packages/core/src/project-scope-settings.test.ts packages/core/src/sync-replication.test.ts`
- `pnpm exec biome check packages/core/src/project-scope-settings.ts packages/core/src/project-scope-settings.test.ts packages/core/src/sync-replication.ts packages/core/src/sync-replication.test.ts packages/core/src/index.ts`
- `pnpm run tsc`

## Checklist

- [x] Code follows project style (`pnpm exec biome check` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed; covered by existing 0.34 plan)
- [x] No new warnings introduced
