### PR TITLE
feat(sync): reconcile stale peer-received rows

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -589,6 +589,10 @@ export type {
 	InboundScopeRejectionRecord,
 	InboundScopeRejectionSummaryOptions,
 	ListInboundScopeRejectionsOptions,
+	ReconcileStalePeerReceivedRowsOptions,
+	ReconcileStalePeerReceivedRowsResult,
+	StalePeerReceivedRowDiagnostic,
+	StalePeerReceivedRowReason,
 } from "./sync-replication.js";
 export {
 	ACCESS_CLEANUP_OP_TYPE,
@@ -615,6 +619,7 @@ export {
 	planReplicationOpsAgePrune,
 	pruneReplicationOps,
 	pruneReplicationOpsUntilCaughtUp,
+	reconcileStalePeerReceivedRows,
 	recordAccessCleanupOp,
 	recordReplicationOp,
 	rejectInboundScopeFailures,

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -35,6 +35,7 @@ import {
 	getReplicationCursor,
 	hasUnsyncedSharedMemoryChanges,
 	migrateLegacyImportKeys,
+	reconcileStalePeerReceivedRows,
 	setReplicationCursor,
 } from "./sync-replication.js";
 import type { ReplicationOp, SyncResetRequired } from "./types.js";
@@ -753,10 +754,21 @@ async function syncOneScope(
 			};
 		}
 
+		const reconciliation = reconcileStalePeerReceivedRows(db, {
+			localDeviceId: deviceId,
+			peerDeviceId,
+		});
+		const vectorWork = {
+			upsertMemoryIds: applied.vectorWork.upsertMemoryIds,
+			deleteMemoryIds: [
+				...applied.vectorWork.deleteMemoryIds,
+				...reconciliation.deleted_memory_ids,
+			],
+		};
 		try {
-			queueVectorBackfillForIncrementalSync(db, applied.vectorWork);
+			queueVectorBackfillForIncrementalSync(db, vectorWork);
 		} catch (queueErr) {
-			const fallback = await bestEffortMaintainVectorsForSyncFallback(db, applied.vectorWork);
+			const fallback = await bestEffortMaintainVectorsForSyncFallback(db, vectorWork);
 			if (fallback.errors.length > 0) {
 				return {
 					scope_id: scopeId,
@@ -1181,10 +1193,21 @@ export async function syncOnce(
 				const firstReason = applied.rejections[0]?.reason ?? "scope_rejected";
 				throw new Error(`inbound scope rejected:${firstReason}`);
 			}
+			const reconciliation = reconcileStalePeerReceivedRows(db, {
+				localDeviceId: deviceId,
+				peerDeviceId,
+			});
+			const vectorWork = {
+				upsertMemoryIds: applied.vectorWork.upsertMemoryIds,
+				deleteMemoryIds: [
+					...applied.vectorWork.deleteMemoryIds,
+					...reconciliation.deleted_memory_ids,
+				],
+			};
 			try {
-				queueVectorBackfillForIncrementalSync(db, applied.vectorWork);
+				queueVectorBackfillForIncrementalSync(db, vectorWork);
 			} catch (queueError) {
-				const fallback = await bestEffortMaintainVectorsForSyncFallback(db, applied.vectorWork);
+				const fallback = await bestEffortMaintainVectorsForSyncFallback(db, vectorWork);
 				if (fallback.errors.length > 0) {
 					const details = fallback.errors.join("; ");
 					throw new Error(

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -24,6 +24,7 @@ import {
 	planReplicationOpsAgePrune,
 	pruneReplicationOps,
 	pruneReplicationOpsUntilCaughtUp,
+	reconcileStalePeerReceivedRows,
 	recordAccessCleanupOp,
 	recordReplicationOp,
 	setReplicationCursor,
@@ -2345,7 +2346,7 @@ describe("applyReplicationOps", () => {
 
 	function insertReplicatedMemory(
 		input: {
-			importKey?: string;
+			importKey?: string | null;
 			originDeviceId?: string | null;
 			scopeId?: string | null;
 			title?: string;
@@ -2364,9 +2365,11 @@ describe("applyReplicationOps", () => {
 				input.title ?? "Replicated row",
 				"2026-01-01T00:00:00Z",
 				"2026-01-01T00:00:00Z",
-				input.importKey ?? "key:test-1",
-				toJson({ clock_device_id: input.originDeviceId ?? "dev-remote" }),
-				input.originDeviceId ?? "dev-remote",
+				input.importKey === undefined ? "key:test-1" : input.importKey,
+				toJson({
+					clock_device_id: input.originDeviceId === undefined ? "dev-remote" : input.originDeviceId,
+				}),
+				input.originDeviceId === undefined ? "dev-remote" : input.originDeviceId,
 				input.scopeId ?? "acme-work",
 			);
 		return Number(result.lastInsertRowid);
@@ -2706,6 +2709,125 @@ describe("applyReplicationOps", () => {
 			db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(otherScopeMemoryId),
 		).toBeDefined();
 		expect(result.vectorWork.deleteMemoryIds).toEqual([]);
+	});
+
+	it("reconciles provably stale peer-received rows without deleting receiver-owned rows", () => {
+		grantScope("acme-work", ["dev-remote"]);
+		const stalePeerMemoryId = insertReplicatedMemory({
+			importKey: "key:stale-peer",
+			originDeviceId: "dev-remote",
+			scopeId: "acme-work",
+		});
+		const localMemoryId = insertReplicatedMemory({
+			importKey: "key:local-owned",
+			originDeviceId: "dev-local",
+			scopeId: "acme-work",
+		});
+		const missingOriginMemoryId = insertReplicatedMemory({
+			importKey: "key:missing-origin",
+			originDeviceId: null,
+			scopeId: "acme-work",
+		});
+
+		const result = reconcileStalePeerReceivedRows(db, { localDeviceId: "dev-local" });
+
+		expect(result.deleted).toBe(1);
+		expect(result.deleted_memory_ids).toEqual([stalePeerMemoryId]);
+		expect(
+			db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(stalePeerMemoryId),
+		).toBeUndefined();
+		expect(db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(localMemoryId)).toBeDefined();
+		expect(
+			db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(missingOriginMemoryId),
+		).toBeDefined();
+		expect(result.ambiguous).toEqual([
+			expect.objectContaining({
+				memory_id: missingOriginMemoryId,
+				reason: "missing_origin_device",
+			}),
+		]);
+	});
+
+	it("leaves authorized and ambiguous stale-scope candidates intact with diagnostics", () => {
+		grantScope("acme-work", ["dev-local", "dev-remote"]);
+		const authorizedPeerMemoryId = insertReplicatedMemory({
+			importKey: "key:authorized-peer",
+			originDeviceId: "dev-remote",
+			scopeId: "acme-work",
+		});
+		const missingImportKeyMemoryId = insertReplicatedMemory({
+			importKey: null,
+			originDeviceId: "dev-remote",
+			scopeId: "ghost-scope",
+		});
+		const unknownScopeMemoryId = insertReplicatedMemory({
+			importKey: "key:unknown-scope",
+			originDeviceId: "dev-remote",
+			scopeId: "ghost-scope",
+		});
+
+		const result = reconcileStalePeerReceivedRows(db, { localDeviceId: "dev-local" });
+
+		expect(result.deleted).toBe(0);
+		expect(result.retained).toBeGreaterThanOrEqual(1);
+		expect(
+			db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(authorizedPeerMemoryId),
+		).toBeDefined();
+		expect(
+			db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(missingImportKeyMemoryId),
+		).toBeDefined();
+		expect(
+			db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(unknownScopeMemoryId),
+		).toBeDefined();
+		expect(result.ambiguous).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					memory_id: missingImportKeyMemoryId,
+					reason: "missing_import_key",
+				}),
+				expect.objectContaining({
+					memory_id: unknownScopeMemoryId,
+					reason: "authorization_unknown",
+				}),
+			]),
+		);
+	});
+
+	it("reconciles stale-epoch peer rows as stale retention", () => {
+		grantScope("acme-work", ["dev-remote"], { scopeEpoch: 3 });
+		grantScope("acme-work", ["dev-local"], { scopeEpoch: 3, membershipEpoch: 2 });
+		const stalePeerMemoryId = insertReplicatedMemory({
+			importKey: "key:stale-epoch-peer",
+			originDeviceId: "dev-remote",
+			scopeId: "acme-work",
+		});
+
+		const result = reconcileStalePeerReceivedRows(db, { localDeviceId: "dev-local" });
+
+		expect(result.deleted_memory_ids).toEqual([stalePeerMemoryId]);
+		expect(result.deleted).toBe(1);
+	});
+
+	it("retains pending membership peer rows as ambiguous", () => {
+		grantScope("acme-work", ["dev-local", "dev-remote"], { status: "pending" });
+		const pendingPeerMemoryId = insertReplicatedMemory({
+			importKey: "key:pending-peer",
+			originDeviceId: "dev-remote",
+			scopeId: "acme-work",
+		});
+
+		const result = reconcileStalePeerReceivedRows(db, { localDeviceId: "dev-local" });
+
+		expect(result.deleted).toBe(0);
+		expect(result.ambiguous).toEqual([
+			expect.objectContaining({
+				memory_id: pendingPeerMemoryId,
+				reason: "authorization_unknown",
+			}),
+		]);
+		expect(
+			db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(pendingPeerMemoryId),
+		).toBeDefined();
 	});
 
 	it("redacts secrets in inbound peer payloads on insert", () => {

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -2133,6 +2133,175 @@ export interface ReplicationVectorWork {
 	deleteMemoryIds: number[];
 }
 
+export type StalePeerReceivedRowReason =
+	| "authorization_unknown"
+	| "missing_import_key"
+	| "missing_origin_device"
+	| "missing_scope";
+
+export interface StalePeerReceivedRowDiagnostic {
+	memory_id: number;
+	import_key: string | null;
+	origin_device_id: string | null;
+	scope_id: string | null;
+	reason: StalePeerReceivedRowReason;
+}
+
+export interface ReconcileStalePeerReceivedRowsResult {
+	checked: number;
+	deleted: number;
+	deleted_memory_ids: number[];
+	retained: number;
+	ambiguous: StalePeerReceivedRowDiagnostic[];
+}
+
+export interface ReconcileStalePeerReceivedRowsOptions {
+	localDeviceId: string;
+	peerDeviceId?: string | null;
+}
+
+type StalePeerCandidateAuthState = ReturnType<typeof getCachedScopeAuthorization>["state"];
+
+function stalePeerCandidateIsDeletable(state: StalePeerCandidateAuthState): boolean {
+	return state === "revoked" || state === "scope_inactive" || state === "stale_epoch";
+}
+
+function stalePeerCandidateDiagnostic(input: {
+	importKey: string | null;
+	memoryId: number;
+	originDeviceId: string | null;
+	reason: StalePeerReceivedRowReason;
+	scopeId: string | null;
+}): StalePeerReceivedRowDiagnostic {
+	return {
+		memory_id: input.memoryId,
+		import_key: input.importKey,
+		origin_device_id: input.originDeviceId,
+		scope_id: input.scopeId,
+		reason: input.reason,
+	};
+}
+
+export function reconcileStalePeerReceivedRows(
+	db: Database,
+	options: ReconcileStalePeerReceivedRowsOptions,
+): ReconcileStalePeerReceivedRowsResult {
+	const localDeviceId = cleanText(options.localDeviceId);
+	if (!localDeviceId) throw new Error("localDeviceId must be a non-empty string");
+	const peerDeviceId = cleanText(options.peerDeviceId);
+	const rows = db
+		.prepare(
+			`SELECT id, import_key, origin_device_id, scope_id
+			 FROM memory_items
+			 WHERE active = 1
+			   AND (? IS NULL OR origin_device_id = ?)
+			 ORDER BY id`,
+		)
+		.all(peerDeviceId, peerDeviceId) as Array<{
+		id: number;
+		import_key: string | null;
+		origin_device_id: string | null;
+		scope_id: string | null;
+	}>;
+	const result: ReconcileStalePeerReceivedRowsResult = {
+		checked: rows.length,
+		deleted: 0,
+		deleted_memory_ids: [],
+		retained: 0,
+		ambiguous: [],
+	};
+	const deleteMemory = db.prepare("DELETE FROM memory_items WHERE id = ?");
+	db.transaction(() => {
+		for (const row of rows) {
+			const memoryId = Number(row.id);
+			const importKey = cleanText(row.import_key);
+			const originDeviceId = cleanText(row.origin_device_id);
+			const scopeId = cleanText(row.scope_id);
+			if (!originDeviceId) {
+				result.ambiguous.push(
+					stalePeerCandidateDiagnostic({
+						importKey,
+						memoryId,
+						originDeviceId,
+						reason: "missing_origin_device",
+						scopeId,
+					}),
+				);
+				continue;
+			}
+			if (originDeviceId === localDeviceId) {
+				result.retained += 1;
+				continue;
+			}
+			if (!scopeId || scopeId === DEFAULT_SYNC_SCOPE_ID) {
+				result.ambiguous.push(
+					stalePeerCandidateDiagnostic({
+						importKey,
+						memoryId,
+						originDeviceId,
+						reason: "missing_scope",
+						scopeId,
+					}),
+				);
+				continue;
+			}
+			if (!importKey) {
+				result.ambiguous.push(
+					stalePeerCandidateDiagnostic({
+						importKey,
+						memoryId,
+						originDeviceId,
+						reason: "missing_import_key",
+						scopeId,
+					}),
+				);
+				continue;
+			}
+			const auth = getCachedScopeAuthorization(db, { deviceId: localDeviceId, scopeId });
+			if (auth.authorized) {
+				result.retained += 1;
+				continue;
+			}
+			if (!auth.scope) {
+				result.ambiguous.push(
+					stalePeerCandidateDiagnostic({
+						importKey,
+						memoryId,
+						originDeviceId,
+						reason: "authorization_unknown",
+						scopeId,
+					}),
+				);
+				continue;
+			}
+			if (!auth.membership) {
+				clearMemoryRefs(db, memoryId);
+				deleteMemory.run(memoryId);
+				result.deleted += 1;
+				result.deleted_memory_ids.push(memoryId);
+				continue;
+			}
+			if (!stalePeerCandidateIsDeletable(auth.state)) {
+				result.ambiguous.push(
+					stalePeerCandidateDiagnostic({
+						importKey,
+						memoryId,
+						originDeviceId,
+						reason: "authorization_unknown",
+						scopeId,
+					}),
+				);
+				continue;
+			}
+			clearMemoryRefs(db, memoryId);
+			deleteMemory.run(memoryId);
+			result.deleted += 1;
+			result.deleted_memory_ids.push(memoryId);
+		}
+	})();
+	return result;
+}
+
 export type InboundScopeRejectionReason =
 	| "missing_scope"
 	| "sender_not_member"


### PR DESCRIPTION
## Description
Adds receiver-side stale peer row reconciliation for the 0.34 cleanup stack. The reconciler compares peer-received rows against current local Space authorization and deletes only rows that are unambiguously stale. Local/source-owned rows, missing provenance, missing import keys, missing scope metadata, and unknown authorization states are retained with diagnostics instead of being deleted. Sync apply paths now run reconciliation after inbound ops and include reconciled deletes in vector cleanup work.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional checks:
- `pnpm exec vitest run packages/core/src/sync-replication.test.ts packages/core/src/sync-pass.test.ts`
- `pnpm run check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (covered by existing 0.34 cleanup plan)
- [x] No new warnings introduced
