### PR TITLE
feat(sync): surface cleanup diagnostics

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -582,6 +582,7 @@ export {
 export type {
 	ApplyReplicationOpsOptions,
 	ApplyResult,
+	DiagnoseStalePeerReceivedRowsResult,
 	FilterReplicationSkipped,
 	InboundScopeRejection,
 	InboundScopeRejectionPeerSummary,
@@ -602,6 +603,7 @@ export {
 	chunkOpsBySize,
 	clockTuple,
 	DEFAULT_SYNC_SCOPE_ID,
+	diagnoseStalePeerReceivedRows,
 	extractReplicationOps,
 	filterReplicationOpsForSync,
 	filterReplicationOpsForSyncWithStatus,

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -9,6 +9,7 @@ import {
 	chunkOpsBySize,
 	clockTuple,
 	DEFAULT_SYNC_SCOPE_ID,
+	diagnoseStalePeerReceivedRows,
 	extractReplicationOps,
 	filterReplicationOpsForSync,
 	filterReplicationOpsForSyncWithStatus,
@@ -2828,6 +2829,42 @@ describe("applyReplicationOps", () => {
 		expect(
 			db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(pendingPeerMemoryId),
 		).toBeDefined();
+	});
+
+	it("diagnoses stale peer-received rows without deleting them", () => {
+		grantScope("acme-work", ["dev-remote"]);
+		const stalePeerMemoryId = insertReplicatedMemory({
+			importKey: "key:diagnose-stale-peer",
+			originDeviceId: "dev-remote",
+			scopeId: "acme-work",
+		});
+
+		const result = diagnoseStalePeerReceivedRows(db, { localDeviceId: "dev-local" });
+
+		expect(result.would_delete).toBe(1);
+		expect(result.would_delete_memory_ids).toEqual([stalePeerMemoryId]);
+		expect(
+			db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(stalePeerMemoryId),
+		).toBeDefined();
+	});
+
+	it("bounds stale peer diagnostic scans", () => {
+		grantScope("acme-work", ["dev-remote"]);
+		insertReplicatedMemory({
+			importKey: "key:diagnose-stale-peer-1",
+			originDeviceId: "dev-remote",
+			scopeId: "acme-work",
+		});
+		insertReplicatedMemory({
+			importKey: "key:diagnose-stale-peer-2",
+			originDeviceId: "dev-remote",
+			scopeId: "acme-work",
+		});
+
+		const result = diagnoseStalePeerReceivedRows(db, { localDeviceId: "dev-local", maxRows: 1 });
+
+		expect(result.checked).toBe(1);
+		expect(result.would_delete).toBe(1);
 	});
 
 	it("redacts secrets in inbound peer payloads on insert", () => {

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -2157,8 +2157,17 @@ export interface ReconcileStalePeerReceivedRowsResult {
 
 export interface ReconcileStalePeerReceivedRowsOptions {
 	localDeviceId: string;
+	maxRows?: number | null;
 	peerDeviceId?: string | null;
 }
+
+export type DiagnoseStalePeerReceivedRowsResult = Omit<
+	ReconcileStalePeerReceivedRowsResult,
+	"deleted" | "deleted_memory_ids"
+> & {
+	would_delete: number;
+	would_delete_memory_ids: number[];
+};
 
 type StalePeerCandidateAuthState = ReturnType<typeof getCachedScopeAuthorization>["state"];
 
@@ -2186,18 +2195,45 @@ export function reconcileStalePeerReceivedRows(
 	db: Database,
 	options: ReconcileStalePeerReceivedRowsOptions,
 ): ReconcileStalePeerReceivedRowsResult {
+	return reconcileStalePeerReceivedRowsInternal(db, options, true);
+}
+
+export function diagnoseStalePeerReceivedRows(
+	db: Database,
+	options: ReconcileStalePeerReceivedRowsOptions,
+): DiagnoseStalePeerReceivedRowsResult {
+	const result = reconcileStalePeerReceivedRowsInternal(db, options, false);
+	return {
+		checked: result.checked,
+		would_delete: result.deleted,
+		would_delete_memory_ids: result.deleted_memory_ids,
+		retained: result.retained,
+		ambiguous: result.ambiguous,
+	};
+}
+
+function reconcileStalePeerReceivedRowsInternal(
+	db: Database,
+	options: ReconcileStalePeerReceivedRowsOptions,
+	deleteRows: boolean,
+): ReconcileStalePeerReceivedRowsResult {
 	const localDeviceId = cleanText(options.localDeviceId);
 	if (!localDeviceId) throw new Error("localDeviceId must be a non-empty string");
 	const peerDeviceId = cleanText(options.peerDeviceId);
+	const maxRows =
+		typeof options.maxRows === "number" && Number.isFinite(options.maxRows)
+			? Math.max(0, Math.trunc(options.maxRows))
+			: -1;
 	const rows = db
 		.prepare(
 			`SELECT id, import_key, origin_device_id, scope_id
 			 FROM memory_items
 			 WHERE active = 1
 			   AND (? IS NULL OR origin_device_id = ?)
-			 ORDER BY id`,
+			 ORDER BY id
+			 LIMIT ?`,
 		)
-		.all(peerDeviceId, peerDeviceId) as Array<{
+		.all(peerDeviceId, peerDeviceId, maxRows) as Array<{
 		id: number;
 		import_key: string | null;
 		origin_device_id: string | null;
@@ -2210,7 +2246,7 @@ export function reconcileStalePeerReceivedRows(
 		retained: 0,
 		ambiguous: [],
 	};
-	const deleteMemory = db.prepare("DELETE FROM memory_items WHERE id = ?");
+	const deleteMemory = deleteRows ? db.prepare("DELETE FROM memory_items WHERE id = ?") : null;
 	db.transaction(() => {
 		for (const row of rows) {
 			const memoryId = Number(row.id);
@@ -2275,8 +2311,10 @@ export function reconcileStalePeerReceivedRows(
 				continue;
 			}
 			if (!auth.membership) {
-				clearMemoryRefs(db, memoryId);
-				deleteMemory.run(memoryId);
+				if (deleteRows) {
+					clearMemoryRefs(db, memoryId);
+					deleteMemory?.run(memoryId);
+				}
 				result.deleted += 1;
 				result.deleted_memory_ids.push(memoryId);
 				continue;
@@ -2293,8 +2331,10 @@ export function reconcileStalePeerReceivedRows(
 				);
 				continue;
 			}
-			clearMemoryRefs(db, memoryId);
-			deleteMemory.run(memoryId);
+			if (deleteRows) {
+				clearMemoryRefs(db, memoryId);
+				deleteMemory?.run(memoryId);
+			}
 			result.deleted += 1;
 			result.deleted_memory_ids.push(memoryId);
 		}

--- a/packages/ui/src/tabs/sync/diagnostics.test.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { syncAttemptsHistoryNote } from "./diagnostics";
+import { cleanupDiagnosticLabel } from "./diagnostics/render/sync-status";
 
 describe("syncAttemptsHistoryNote", () => {
 	it("explains that offline-peer attempts may be historical", () => {
@@ -16,5 +17,23 @@ describe("syncAttemptsHistoryNote", () => {
 	it("stays empty for other daemon states", () => {
 		expect(syncAttemptsHistoryNote("ok", true)).toBe("");
 		expect(syncAttemptsHistoryNote("stale", true)).toBe("");
+	});
+});
+
+describe("cleanupDiagnosticLabel", () => {
+	it("labels cleanup-specific sync states without raw ids", () => {
+		expect(
+			cleanupDiagnosticLabel({
+				state: "cleanup_pending",
+				stale_peer_rows: { would_remove: 3 },
+			}),
+		).toBe("3 pending removal");
+		expect(
+			cleanupDiagnosticLabel({ state: "needs_review", stale_peer_rows: { ambiguous: 2 } }),
+		).toBe("2 needs review");
+		expect(
+			cleanupDiagnosticLabel({ state: "cleanup_applied", access_cleanup_ops: { applied: 4 } }),
+		).toBe("4 applied");
+		expect(cleanupDiagnosticLabel({ state: "clear" })).toBe("Clear");
 	});
 });

--- a/packages/ui/src/tabs/sync/diagnostics/render/sync-status.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/render/sync-status.ts
@@ -13,7 +13,27 @@ import {
 } from "../../components/sync-diagnostics";
 import { hideSkeleton, renderActionList } from "../../helpers";
 import { diagnosticsLoadingState, newestPeerPing } from "../helpers";
-import type { SyncStatusState } from "../types";
+import type { SyncCleanupDiagnostics, SyncStatusState } from "../types";
+
+function numeric(value: unknown): number {
+	const parsed = Number(value ?? 0);
+	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function cleanupDiagnosticLabel(cleanup: SyncCleanupDiagnostics | undefined): string {
+	const state = String(cleanup?.state ?? "clear");
+	const stale = cleanup?.stale_peer_rows ?? {};
+	const ops = cleanup?.access_cleanup_ops ?? {};
+	const wouldRemove = numeric(stale.would_remove);
+	const ambiguous = numeric(stale.ambiguous);
+	const applied = numeric(ops.applied);
+	const sourceAuthored = numeric(ops.source_authored);
+	if (state === "cleanup_pending" || wouldRemove > 0) return `${wouldRemove} pending removal`;
+	if (state === "needs_review" || ambiguous > 0) return `${ambiguous} needs review`;
+	if (state === "cleanup_applied" || applied > 0) return `${applied} applied`;
+	if (state === "cleanup_announced" || sourceAuthored > 0) return `${sourceAuthored} announced`;
+	return "Clear";
+}
 
 export function renderSyncStatus() {
 	const syncStatusGrid = document.getElementById("syncStatusGrid");
@@ -42,6 +62,10 @@ export function renderSyncStatus() {
 	const daemonDetail = String(status.daemon_detail || "");
 	const daemonState = String(status.daemon_state || "unknown");
 	const retention = status.retention || {};
+	const cleanup = status.cleanup_diagnostics;
+	const cleanupStale = cleanup?.stale_peer_rows ?? {};
+	const cleanupWouldRemove = numeric(cleanupStale.would_remove);
+	const cleanupAmbiguous = numeric(cleanupStale.ambiguous);
 	const retentionEnabled = retention.enabled === true;
 	const retentionDeleted = Number(retention.last_deleted_ops || 0);
 	const retentionLastRunAt = retention.last_run_at || null;
@@ -90,6 +114,13 @@ export function renderSyncStatus() {
 				retentionLastRunAt
 					? `Retention last ran ${formatAgeShort(secondsSince(retentionLastRunAt))} ago (approx oldest-first)`
 					: "Retention enabled",
+			);
+		}
+		if (cleanupWouldRemove > 0) {
+			parts.push(`${cleanupWouldRemove.toLocaleString()} stale peer rows pending cleanup`);
+		} else if (cleanupAmbiguous > 0) {
+			parts.push(
+				`${cleanupAmbiguous.toLocaleString()} stale peer rows retained because safe cleanup could not be proven`,
 			);
 		}
 
@@ -159,6 +190,10 @@ export function renderSyncStatus() {
 		});
 	}
 
+	if (!syncDisabled && !syncNoPeers && cleanup) {
+		items.push({ label: "Cleanup", value: cleanupDiagnosticLabel(cleanup) });
+	}
+
 	renderDiagnosticsGrid(syncStatusGrid, items);
 
 	const actions: Array<{ label: string; command: string }> = [];
@@ -191,6 +226,17 @@ export function renderSyncStatus() {
 	} else if (!syncDisabled && !syncNoPeers && pending > 0) {
 		actions.push({
 			label: "Pending sync work detected. Run one pass now.",
+			command: "codemem sync once",
+		});
+	}
+	if (!syncDisabled && cleanupAmbiguous > 0) {
+		actions.push({
+			label: "Some stale peer rows were retained because cleanup was ambiguous.",
+			command: "codemem sync doctor",
+		});
+	} else if (!syncDisabled && cleanupWouldRemove > 0) {
+		actions.push({
+			label: "Stale peer rows are eligible for cleanup. Run one sync pass now.",
 			command: "codemem sync once",
 		});
 	}

--- a/packages/ui/src/tabs/sync/diagnostics/types.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/types.ts
@@ -17,7 +17,26 @@ export type PingPayloadState = SyncPayloadState & {
 	last_ping_at?: string | null;
 };
 
+export type SyncCleanupDiagnostics = {
+	state?: string;
+	access_cleanup_ops?: {
+		source_authored?: number | string;
+		applied?: number | string;
+		latest_at?: string | null;
+	};
+	stale_peer_rows?: {
+		checked?: number | string;
+		diagnostic_limit?: number | string;
+		scan_skipped?: boolean;
+		would_remove?: number | string;
+		ambiguous?: number | string;
+		retained?: number | string;
+	};
+	redacted?: boolean;
+};
+
 export type SyncStatusState = {
+	cleanup_diagnostics?: SyncCleanupDiagnostics;
 	daemon_detail?: string;
 	daemon_state?: string;
 	enabled?: boolean;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -17,6 +17,7 @@ import type {
 	SemanticIndexDiagnostics,
 } from "@codemem/core";
 import {
+	ACCESS_CLEANUP_OP_TYPE,
 	addSyncScopeToBoundary,
 	analyzeProjectScopeMappingChangeGuardrails,
 	applyReplicationOps,
@@ -50,6 +51,7 @@ import {
 	DEFAULT_TIME_WINDOW_S,
 	defaultSpaceScopeIdForGroup,
 	deleteProjectScopeSettingsMapping,
+	diagnoseStalePeerReceivedRows,
 	ensureDeviceIdentity,
 	extractReplicationOps,
 	type FilterReplicationSkipped,
@@ -1497,6 +1499,7 @@ function mapSyncAttemptRow(
 }
 
 const SYNC_SCOPE_REJECTION_WINDOW_SECONDS = 24 * 60 * 60;
+const CLEANUP_DIAGNOSTICS_MAX_ROWS = 250;
 
 function recentScopeRejectionsByPeer(
 	store: MemoryStore,
@@ -1510,6 +1513,67 @@ function recentScopeRejectionsByPeer(
 		map.set(id, summary);
 	}
 	return map;
+}
+
+function cleanupDiagnostics(
+	store: MemoryStore,
+	localDeviceId: string | null,
+	showDiag: boolean,
+): Record<string, unknown> {
+	const opRows = store.db
+		.prepare(
+			`SELECT
+				SUM(CASE WHEN device_id = ? THEN 1 ELSE 0 END) AS source_authored,
+				SUM(CASE WHEN device_id != ? THEN 1 ELSE 0 END) AS applied,
+				MAX(created_at) AS latest_at
+			 FROM replication_ops
+			 WHERE op_type = ?`,
+		)
+		.get(localDeviceId ?? "", localDeviceId ?? "", ACCESS_CLEANUP_OP_TYPE) as
+		| { applied: number | null; latest_at: string | null; source_authored: number | null }
+		| undefined;
+	const stale =
+		localDeviceId && showDiag
+			? diagnoseStalePeerReceivedRows(store.db, {
+					localDeviceId,
+					maxRows: CLEANUP_DIAGNOSTICS_MAX_ROWS,
+				})
+			: { ambiguous: [], checked: 0, retained: 0, would_delete: 0, would_delete_memory_ids: [] };
+	const ambiguousByReason: Record<string, number> = {};
+	for (const item of stale.ambiguous) {
+		ambiguousByReason[item.reason] = (ambiguousByReason[item.reason] ?? 0) + 1;
+	}
+	const sourceAuthored = Number(opRows?.source_authored ?? 0);
+	const applied = Number(opRows?.applied ?? 0);
+	const ambiguous = stale.ambiguous.length;
+	const state = stale.would_delete
+		? "cleanup_pending"
+		: ambiguous
+			? "needs_review"
+			: applied
+				? "cleanup_applied"
+				: sourceAuthored
+					? "cleanup_announced"
+					: "clear";
+	return {
+		state,
+		access_cleanup_ops: {
+			source_authored: sourceAuthored,
+			applied,
+			latest_at: opRows?.latest_at ?? null,
+		},
+		stale_peer_rows: {
+			checked: stale.checked,
+			diagnostic_limit: showDiag ? CLEANUP_DIAGNOSTICS_MAX_ROWS : 0,
+			scan_skipped: !showDiag || !localDeviceId,
+			would_remove: stale.would_delete,
+			ambiguous,
+			ambiguous_by_reason: ambiguousByReason,
+			retained: stale.retained,
+			items: showDiag ? stale.ambiguous.slice(0, 25) : undefined,
+		},
+		redacted: !showDiag,
+	};
 }
 
 function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> {
@@ -2678,6 +2742,11 @@ export function syncRoutes(
 					include: config.syncProjectsInclude,
 					exclude: config.syncProjectsExclude,
 				},
+				cleanup_diagnostics: cleanupDiagnostics(
+					store,
+					(deviceRow?.device_id as string | null | undefined) ?? null,
+					showDiag,
+				),
 				redacted: !showDiag,
 			};
 


### PR DESCRIPTION
## Description
Adds cleanup-specific diagnostics for the 0.34 cleanup protocol. The status API now reports access cleanup op counts and a non-mutating stale peer row diagnostic preview. The Sync diagnostics UI surfaces cleanup states such as pending removal, ambiguous retained rows, cleanup applied, and cleanup announced without exposing raw row identifiers in the primary UI.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional checks:
- `pnpm exec vitest run packages/core/src/sync-replication.test.ts packages/core/src/sync-pass.test.ts packages/ui/src/tabs/sync/diagnostics.test.ts`
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "sync/status|status"`
- `pnpm run check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed beyond existing plan)
- [x] No new warnings introduced
