### PR TITLE
fix(sync): cache coordinator status snapshot

### DIFF
--- a/packages/core/src/coordinator-runtime.test.ts
+++ b/packages/core/src/coordinator-runtime.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -5,11 +6,13 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	advertisedSyncAddresses,
+	coordinatorStatusSnapshot,
 	fetchCoordinatorStalePeers,
 	lookupCoordinatorPeers,
 	readCoordinatorSyncConfig,
 	refreshStoredCoordinatorPeerAddresses,
 } from "./coordinator-runtime.js";
+import type { MemoryStore } from "./store.js";
 import { initTestSchema } from "./test-utils.js";
 
 describe("readCoordinatorSyncConfig.syncOpsLimit", () => {
@@ -169,6 +172,105 @@ describe("lookupCoordinatorPeers", () => {
 			globalThis.fetch = prevFetch;
 			db.close();
 			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("coordinatorStatusSnapshot", () => {
+	it("reuses a short-lived coordinator snapshot instead of polling remote status on every viewer refresh", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const alternateKeysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		let fetchCount = 0;
+		let presenceFetchCount = 0;
+		let lastPresenceAddresses: unknown = null;
+		try {
+			initTestSchema(db);
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				fetchCount += 1;
+				const url = new URL(String(input));
+				if (url.pathname === "/v1/presence") {
+					presenceFetchCount += 1;
+					const rawBody = init?.body;
+					const body = rawBody
+						? JSON.parse(Buffer.from(rawBody as ArrayBuffer).toString("utf8"))
+						: {};
+					lastPresenceAddresses = body.addresses;
+					return new Response(JSON.stringify({ addresses: ["http://local.test:7337"] }), {
+						status: 200,
+					});
+				}
+				if (url.pathname === "/v1/peers") {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-1",
+									fingerprint: "fp-1",
+									addresses: ["http://peer.test:7337"],
+									stale: false,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				if (url.pathname === "/v1/reciprocal-approvals") {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as typeof fetch;
+
+			const config = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+			});
+			const store = {
+				db,
+				dbPath: `:memory:-${randomUUID()}`,
+			} as unknown as MemoryStore;
+
+			const first = await coordinatorStatusSnapshot(store, config);
+			const firstFetchCount = fetchCount;
+			db.prepare("INSERT INTO sync_peers(peer_device_id, created_at) VALUES (?, ?)").run(
+				"peer-1",
+				new Date().toISOString(),
+			);
+			const second = await coordinatorStatusSnapshot(store, config);
+			const secondFetchCount = fetchCount;
+			const secondPresenceFetchCount = presenceFetchCount;
+			const changedAdvertiseConfig = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+				sync_advertise: "new.example.test",
+			});
+			await coordinatorStatusSnapshot(store, changedAdvertiseConfig);
+			const changedAdvertisePresenceFetchCount = presenceFetchCount;
+			process.env.CODEMEM_KEYS_DIR = alternateKeysDir;
+			await coordinatorStatusSnapshot(store, changedAdvertiseConfig);
+
+			expect(first.discovered_peer_count).toBe(1);
+			expect(second.discovered_peer_count).toBe(1);
+			expect(second.paired_peer_count).toBe(1);
+			expect(firstFetchCount).toBeGreaterThan(0);
+			expect(secondFetchCount).toBe(firstFetchCount);
+			expect(secondPresenceFetchCount).toBe(1);
+			expect(changedAdvertisePresenceFetchCount).toBeGreaterThan(secondPresenceFetchCount);
+			expect(lastPresenceAddresses).toEqual(["http://new.example.test:7337"]);
+			expect(fetchCount).toBeGreaterThan(secondFetchCount);
+			expect(presenceFetchCount).toBeGreaterThan(changedAdvertisePresenceFetchCount);
+		} finally {
+			globalThis.fetch = prevFetch;
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+			rmSync(alternateKeysDir, { recursive: true, force: true });
 		}
 	});
 });

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -98,11 +98,62 @@ interface PresenceSnapshot {
 	nextRefreshAtMs: number;
 }
 
+interface CoordinatorStatusCacheEntry {
+	snapshot: Record<string, unknown>;
+	nextRefreshAtMs: number;
+}
+
 const coordinatorPresenceCache = new Map<string, PresenceSnapshot>();
+const coordinatorStatusCache = new Map<string, CoordinatorStatusCacheEntry>();
+const COORDINATOR_STATUS_SNAPSHOT_CACHE_MS = 5_000;
 
 function presenceCacheKey(store: PresenceStoreLike, config: CoordinatorSyncConfig): string {
 	const groups = [...config.syncCoordinatorGroups].sort().join(",");
-	return `${store.dbPath}|${config.syncCoordinatorUrl}|${groups}`;
+	return [
+		store.dbPath,
+		config.syncCoordinatorUrl,
+		groups,
+		coordinatorStatusIdentityCacheSegment(store),
+		config.syncHost,
+		config.syncPort,
+		config.syncAdvertise,
+		config.syncCoordinatorPresenceTtlS,
+	].join("|");
+}
+
+function coordinatorStatusIdentityCacheSegment(store: PresenceStoreLike): string {
+	const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || "";
+	try {
+		const row = store.db.prepare("SELECT device_id, fingerprint FROM sync_device LIMIT 1").get() as
+			| { device_id?: string | null; fingerprint?: string | null }
+			| undefined;
+		return `${keysDir}|${row?.device_id ?? ""}|${row?.fingerprint ?? ""}`;
+	} catch {
+		return keysDir;
+	}
+}
+
+function coordinatorStatusCacheKey(
+	store: PresenceStoreLike,
+	config: CoordinatorSyncConfig,
+): string {
+	return [
+		presenceCacheKey(store, config),
+		config.syncHost,
+		config.syncPort,
+		config.syncAdvertise,
+		config.syncCoordinatorPresenceTtlS,
+	].join("|");
+}
+
+function pairedPeerCount(store: PresenceStoreLike): number {
+	return Number(
+		(
+			store.db.prepare("SELECT COUNT(1) AS total FROM sync_peers").get() as
+				| { total?: number }
+				| undefined
+		)?.total ?? 0,
+	);
 }
 
 function presenceRefreshIntervalMs(config: CoordinatorSyncConfig): number {
@@ -519,19 +570,24 @@ export async function coordinatorStatusSnapshot(
 	store: MemoryStore,
 	config: CoordinatorSyncConfig,
 ): Promise<Record<string, unknown>> {
-	const pairedPeerCount = Number(
-		(
-			store.db.prepare("SELECT COUNT(1) AS total FROM sync_peers").get() as
-				| { total?: number }
-				| undefined
-		)?.total ?? 0,
-	);
+	const currentPairedPeerCount = pairedPeerCount(store);
 	if (!coordinatorEnabled(config)) {
 		return {
 			enabled: false,
 			configured: false,
 			groups: config.syncCoordinatorGroups,
-			paired_peer_count: pairedPeerCount,
+			paired_peer_count: currentPairedPeerCount,
+		};
+	}
+	const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
+	ensureDeviceIdentity(store.db, { keysDir });
+	const cacheKey = coordinatorStatusCacheKey(store, config);
+	const now = Date.now();
+	const cachedSnapshot = coordinatorStatusCache.get(cacheKey);
+	if (cachedSnapshot && now < cachedSnapshot.nextRefreshAtMs) {
+		return {
+			...structuredClone(cachedSnapshot.snapshot),
+			paired_peer_count: pairedPeerCount(store),
 		};
 	}
 	const snapshot: Record<string, unknown> = {
@@ -539,7 +595,7 @@ export async function coordinatorStatusSnapshot(
 		configured: true,
 		coordinator_url: config.syncCoordinatorUrl,
 		groups: config.syncCoordinatorGroups,
-		paired_peer_count: pairedPeerCount,
+		paired_peer_count: currentPairedPeerCount,
 		presence_status: "unknown",
 		presence_error: null,
 		advertised_addresses: [],
@@ -548,9 +604,8 @@ export async function coordinatorStatusSnapshot(
 		discovered_peer_count: 0,
 		discovered_devices: [],
 	};
-	const cacheKey = presenceCacheKey(store, config);
-	const now = Date.now();
-	const cachedPresence = coordinatorPresenceCache.get(cacheKey);
+	const presenceKey = presenceCacheKey(store, config);
+	const cachedPresence = coordinatorPresenceCache.get(presenceKey);
 	if (cachedPresence && now < cachedPresence.nextRefreshAtMs) {
 		snapshot.presence_status = cachedPresence.status;
 		snapshot.presence_error = cachedPresence.error;
@@ -565,7 +620,7 @@ export async function coordinatorStatusSnapshot(
 					: [];
 			snapshot.presence_status = "posted";
 			snapshot.advertised_addresses = advertisedAddresses;
-			coordinatorPresenceCache.set(cacheKey, {
+			coordinatorPresenceCache.set(presenceKey, {
 				status: "posted",
 				error: null,
 				advertisedAddresses,
@@ -577,7 +632,7 @@ export async function coordinatorStatusSnapshot(
 			const nextRefreshAtMs = status === "not_enrolled" ? now : now + presenceRetryIntervalMs();
 			snapshot.presence_status = status;
 			snapshot.presence_error = message;
-			coordinatorPresenceCache.set(cacheKey, {
+			coordinatorPresenceCache.set(presenceKey, {
 				status,
 				error: message,
 				advertisedAddresses: [],
@@ -628,6 +683,12 @@ export async function coordinatorStatusSnapshot(
 		}));
 	} catch (error) {
 		snapshot.lookup_error = error instanceof Error ? error.message : String(error);
+	}
+	if (snapshot.presence_status !== "not_enrolled") {
+		coordinatorStatusCache.set(cacheKey, {
+			snapshot: structuredClone(snapshot),
+			nextRefreshAtMs: Date.now() + COORDINATOR_STATUS_SNAPSHOT_CACHE_MS,
+		});
 	}
 	return snapshot;
 }


### PR DESCRIPTION
## Description
Caches the viewer-facing coordinator status snapshot for a short 5s window so rapid `/api/sync/status` refreshes do not repeatedly perform sequential remote coordinator calls.

The cache is keyed by coordinator config, local identity, keys dir, and presence-affecting advertised endpoint settings. Cache hits still recompute the cheap local `paired_peer_count` so local peer changes show up promptly.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, targeted Biome check)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Checks run:
- `pnpm exec vitest run packages/core/src/coordinator-runtime.test.ts`
- `pnpm exec biome check packages/core/src/coordinator-runtime.ts packages/core/src/coordinator-runtime.test.ts`
- `pnpm run tsc`

Manual measurement: repeated source `coordinatorStatusSnapshot()` calls dropped from roughly 600–1900ms to 0–1ms inside the cache window.

## Checklist

- [x] Code follows project style (`pnpm exec biome check` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
