### PR TITLE
fix(ui): use runtime endpoint for reconnect probe

### DIFF
--- a/packages/ui/src/lib/api/runtime.test.ts
+++ b/packages/ui/src/lib/api/runtime.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { pingViewerReady } from "./runtime";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("pingViewerReady", () => {
+	it("uses the lightweight runtime endpoint instead of the stats hot path", async () => {
+		const fetchMock = vi.fn(
+			async () => new Response(JSON.stringify({ version: "test" }), { status: 200 }),
+		);
+		globalThis.fetch = fetchMock as typeof fetch;
+
+		await pingViewerReady();
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/runtime",
+			expect.objectContaining({ cache: "no-store" }),
+		);
+	});
+});

--- a/packages/ui/src/lib/api/runtime.ts
+++ b/packages/ui/src/lib/api/runtime.ts
@@ -9,11 +9,11 @@ export async function pingViewerReady(timeoutMs = 1200): Promise<void> {
 	const controller = new AbortController();
 	const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
 	try {
-		const resp = await fetch("/api/stats", {
+		const resp = await fetch("/api/runtime", {
 			cache: "no-store",
 			signal: controller.signal,
 		});
-		if (!resp.ok) throw new Error(`/api/stats: ${resp.status} ${resp.statusText}`);
+		if (!resp.ok) throw new Error(`/api/runtime: ${resp.status} ${resp.statusText}`);
 	} finally {
 		window.clearTimeout(timeoutId);
 	}


### PR DESCRIPTION
## Description
Switches the viewer reconnect readiness probe from `/api/stats` to the lightweight `/api/runtime` endpoint.

This keeps reconnect polling from repeatedly hitting the expensive stats hot path on large local databases, matching the existing runtime API comment that readiness should not pull in stats payload work.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, targeted Biome check)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Checks run:
- `pnpm exec vitest run packages/ui/src/lib/api/runtime.test.ts`
- `pnpm exec biome check packages/ui/src/lib/api/runtime.ts packages/ui/src/lib/api/runtime.test.ts`
- `pnpm run tsc`

## Checklist

- [x] Code follows project style (`pnpm exec biome check` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
