### PR TITLE
fix(viewer): cache usage payload to avoid full usage_events scan on poll

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -605,6 +605,86 @@ describe("viewer-server", () => {
 				cleanup();
 			}
 		});
+
+		it("serves a cached usage payload within the short TTL window", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Cached usage memory",
+				});
+				const insertPack = (createdAt: string) =>
+					store.db
+						.prepare(
+							`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+							 VALUES (?, 'pack', 100, 0, 200, ?, '{}')`,
+						)
+						.run(sessionId, createdAt);
+
+				insertPack("2026-03-26T23:30:00Z");
+				const first = (await (await app.request("/api/usage")).json()) as {
+					totals: { count: number };
+				};
+				expect(first.totals.count).toBe(1);
+
+				// A second pack inserted immediately should NOT change the cached
+				// response while the TTL window is still open.
+				insertPack("2026-03-26T23:31:00Z");
+				const second = (await (await app.request("/api/usage")).json()) as {
+					totals: { count: number };
+				};
+				expect(second.totals.count).toBe(1);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("busts the usage cache when scope visibility changes within the TTL", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				grantSyncScopeToDevices(store, "authorized-team", [store.deviceId]);
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Scoped usage memory",
+					scopeId: "authorized-team",
+				});
+				store.db
+					.prepare(
+						`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+						 VALUES (?, 'pack', 100, 0, 200, ?, '{}')`,
+					)
+					.run(sessionId, "2026-03-26T23:30:00Z");
+
+				const beforeRevoke = (await (await app.request("/api/usage")).json()) as {
+					totals: { count: number };
+				};
+				expect(beforeRevoke.totals.count).toBe(1);
+
+				// Revoke the device's membership. Even within the TTL window the
+				// next request must recompute and hide the now-invisible scope
+				// instead of serving the cached (visible) payload.
+				store.db
+					.prepare("DELETE FROM scope_memberships WHERE scope_id = ? AND device_id = ?")
+					.run("authorized-team", store.deviceId);
+
+				const afterRevoke = (await (await app.request("/api/usage")).json()) as {
+					totals: { count: number };
+				};
+				expect(afterRevoke.totals.count).toBe(0);
+			} finally {
+				cleanup();
+			}
+		});
 	});
 
 	describe("GET /api/sessions", () => {

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -221,6 +221,73 @@ function totalUsageEvents(rows: UsageRow[]): Record<string, unknown> {
 	);
 }
 
+type UsagePayload = Record<string, unknown>;
+
+interface UsageCacheEntry {
+	payload: UsagePayload;
+	expiresAtMs: number;
+}
+
+/**
+ * Short-lived cache for the computed /api/usage payload.
+ *
+ * The health dot polls /api/usage on every 5s refresh regardless of the
+ * active tab, and the computation scans the full usage_events table to apply
+ * scope visibility before aggregating. The resulting token totals are
+ * cumulative dashboard figures, so a few seconds of staleness is acceptable
+ * in exchange for collapsing the repeated full-table scan on the polling
+ * loop. Keyed by db path + scope identity + project filter so distinct
+ * stores/projects never share an entry.
+ */
+const usagePayloadCache = new Map<string, UsageCacheEntry>();
+const USAGE_PAYLOAD_CACHE_MS = 10_000;
+
+/**
+ * Cheap fingerprint of the state that drives scope visibility
+ * (`scope_memberships` / `replication_scopes`). Folding this into the usage
+ * cache key ensures a membership/scope status change — e.g. a revocation —
+ * invalidates any cached payload immediately instead of letting a device keep
+ * reading a scope it can no longer see for up to the TTL. These tables are
+ * small, so the aggregate is negligible next to the usage_events scan the
+ * cache exists to avoid. Fails safe: any error forces a unique value so the
+ * request bypasses the cache and recomputes visibility from scratch.
+ */
+function scopeVisibilityGeneration(store: MemoryStore): string {
+	try {
+		const row = store.db
+			.prepare(
+				`SELECT
+					(SELECT COUNT(*) FROM scope_memberships) AS m_count,
+					(SELECT COUNT(*) FROM scope_memberships WHERE status = 'active') AS m_active,
+					(SELECT COALESCE(MAX(updated_at), '') FROM scope_memberships) AS m_updated,
+					(SELECT COALESCE(MAX(membership_epoch), 0) FROM scope_memberships) AS m_epoch,
+					(SELECT COUNT(*) FROM replication_scopes) AS s_count,
+					(SELECT COUNT(*) FROM replication_scopes WHERE status = 'active') AS s_active,
+					(SELECT COALESCE(MAX(updated_at), '') FROM replication_scopes) AS s_updated`,
+			)
+			.get() as Record<string, unknown> | undefined;
+		if (!row) return "no-scope-state";
+		return [
+			row.m_count,
+			row.m_active,
+			row.m_updated,
+			row.m_epoch,
+			row.s_count,
+			row.s_active,
+			row.s_updated,
+		].join(":");
+	} catch {
+		// Fail safe: bypass the cache rather than risk serving a payload
+		// computed under stale visibility rules.
+		return `bypass-${Date.now()}-${Math.random()}`;
+	}
+}
+
+function usageCacheKey(store: MemoryStore, projectFilter: string | null): string {
+	const visibilityGeneration = scopeVisibilityGeneration(store);
+	return `${store.dbPath}|${store.actorId}|${store.deviceId}|${projectFilter ?? ""}|${visibilityGeneration}`;
+}
+
 /**
  * Create stats routes. The store factory is called per-request to get a
  * fresh connection (matching the Python viewer pattern).
@@ -285,6 +352,12 @@ export function statsRoutes(getStore: () => MemoryStore) {
 		const store = getStore();
 		{
 			const projectFilter = c.req.query("project") || null;
+			const cacheKey = usageCacheKey(store, projectFilter);
+			const nowMs = Date.now();
+			const cached = usagePayloadCache.get(cacheKey);
+			if (cached && nowMs < cached.expiresAtMs) {
+				return c.json(cached.payload);
+			}
 			const loadUsageRows = (project?: string | null): UsageRow[] => {
 				const rows = project
 					? (store.db
@@ -333,7 +406,7 @@ export function statsRoutes(getStore: () => MemoryStore) {
 					metadata_json: sanitizePackUsageMetadata(row.metadata_json, recentVisibility),
 				}));
 
-			return c.json({
+			const payload: UsagePayload = {
 				project: projectFilter,
 				events: projectFilter ? eventsFiltered : eventsGlobal,
 				totals: projectFilter ? totalsFiltered : totalsGlobal,
@@ -342,7 +415,12 @@ export function statsRoutes(getStore: () => MemoryStore) {
 				events_filtered: eventsFiltered,
 				totals_filtered: totalsFiltered,
 				recent_packs: recentPacks,
+			};
+			usagePayloadCache.set(cacheKey, {
+				payload,
+				expiresAtMs: Date.now() + USAGE_PAYLOAD_CACHE_MS,
 			});
+			return c.json(payload);
 		}
 	});
 


### PR DESCRIPTION
## Description
`/api/usage` is polled on every 5s health refresh regardless of active tab (it powers the header health dot via `loadHealthData()`). On large databases it loads the **entire `usage_events` table** (300k+ rows on a real 3.5GB DB), parses `metadata_json` per row, builds scope-visibility sets, and aggregates in JS — measured at ~2.5s per call, returning only ~11KB.

This adds a short-lived (10s) cache of the computed usage payload, keyed by db path + scope identity + project filter. Repeated polls within the window return the cached payload instead of rescanning. Token totals are cumulative dashboard figures, so a few seconds of staleness is acceptable.

### Measured impact (real route handler against a 3.5GB DB)
- Cold / cache miss: ~2474ms
- Cached hits: 0–1ms
- After 10s TTL expiry: recomputes (~2534ms), then 0ms again

### Known limitation / follow-up
better-sqlite3 is synchronous, so each cache **miss** still blocks the event loop for ~2.5s. This change reduces miss frequency (5s poll vs 10s TTL) but does not eliminate the blocking scan. The complete fix is pushing aggregation + scope visibility into SQL to avoid loading the full table; tracked as a follow-up because the pack-item visibility refinement is on a leak-prevention path and warrants its own change.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, targeted Biome check)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Checks run:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts` (191 passed)
- `pnpm exec biome check packages/viewer-server/src/routes/stats.ts packages/viewer-server/src/index.test.ts`
- `pnpm run tsc`
- Empirical perf verification via `createApp` + `app.request("/api/usage")` against the live DB (numbers above)

## Checklist

- [x] Code follows project style (`pnpm exec biome check` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
