### PR TITLE
chore(release): bump version to 0.34.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.33.0"
+    "version": "0.34.0"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.33.0";
+const PINNED_BACKEND_VERSION = "0.34.0";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.33.0",
+	"version": "0.34.0",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.33.0",
+	"version": "0.34.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.33.0");
+		expect(VERSION).toBe("0.34.0");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.33.0";
+export const VERSION = "0.34.0";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.33.0",
+	"version": "0.34.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.33.0";
+const PINNED_BACKEND_VERSION = "0.34.0";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.33.0",
+	"version": "0.34.0",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.33.0",
+	"version": "0.34.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description
Release version bump to **0.34.0**. Aligns all managed version markers via `scripts/release-version.mjs set 0.34.0`.

Minor bump: changes since `v0.33.0` include new sync features (source-authored access cleanup ops, stale peer-row reconciliation, cleanup diagnostics) alongside fixes (MCP OAuth state persistence, coordinator status cache, runtime reconnect probe, usage payload cache) and docs.

Tag `v0.34.0` will be pushed on the merged `main` commit after this lands (publishing is tag-triggered; per repo policy the tag goes on merged `main`, validated by `pnpm run release:preflight-tag`).

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run test:release-version`, core VERSION assertion)
- [x] `node scripts/release-version.mjs check` → versions aligned at 0.34.0
- [x] Added/updated tests for changes (n/a — managed version markers only)

## Checklist

- [x] Self-review completed
- [x] Documentation updated (if needed) — release notes will accompany the tag
- [x] No new warnings introduced
