### PR TITLE
feat(codex): map hook events

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,8 @@ flowchart LR
     OCA -->|fallback: enqueue-raw-event CLI| DB
     CH["Claude hooks"] -->|POST /api/claude-hooks| VW
     CH -->|fallback: claude-hook-ingest direct enqueue| DB
+    CX["Codex hooks"] -->|POST /api/codex-hooks| VW
+    CX -->|fallback: codex-hook-ingest direct enqueue/spool| DB
     VW --> DB["SQLite"]
     DB -->|flush batch claimed| IN["Ingest pipeline"]
     IN --> OB["Observer"]
@@ -38,7 +40,7 @@ flowchart LR
 
 1. Adapters capture tool/conversation lifecycle events and normalize them into raw events with optional `_adapter` envelopes.
 2. OpenCode streams raw events to the viewer ingest API (`POST /api/raw-events`) with preflight checks (`GET /api/raw-events/status`) and can fall back to CLI queue enqueue when stream writes fail.
-3. Claude hook ingestion posts to `POST /api/claude-hooks` first and falls back to `codemem claude-hook-ingest` direct enqueue when the local viewer API is unavailable.
+3. Claude hook ingestion posts to `POST /api/claude-hooks` first and falls back to `codemem claude-hook-ingest` direct enqueue when the local viewer API is unavailable. Codex hook ingestion follows the same HTTP-first shape through `POST /api/codex-hooks`, then `codemem codex-hook-ingest` direct enqueue, with a Codex-specific on-disk spool as the last-resort fallback.
 4. The viewer/store persists raw events and queues durable flush batches.
 5. Idle and sweeper workers claim batches and run them through ingest.
 6. Before building session context, raw events are passed through `normalizeEventsForSessionContext` (in `ingest-transcript.ts`) which projects adapter-enveloped events (`_adapter` schema v1.0) into the flat `user_prompt` / `tool.execute.after` shapes that `buildSessionContext` scans. This is critical for Claude Code hook events which always arrive wrapped in the adapter envelope.

--- a/packages/core/src/claude-hooks.ts
+++ b/packages/core/src/claude-hooks.ts
@@ -116,7 +116,18 @@ function stableEventId(...parts: string[]): string {
 /** Normalize a raw label value to a plain project name (basename if path). */
 export function normalizeProjectLabel(value: unknown): string | null {
 	if (typeof value !== "string") return null;
-	const cleaned = value.trim().replace(/[\\/]+$/, "");
+	// Strip trailing path separators with a linear scan rather than a regex.
+	// The previous `/[\\/]+$/` pattern backtracks quadratically on adversarial
+	// inputs (a long run of separators followed by a non-separator), and this
+	// value can originate from uncontrolled hook payloads.
+	const trimmed = value.trim();
+	let end = trimmed.length;
+	while (end > 0) {
+		const code = trimmed.charCodeAt(end - 1);
+		if (code === 47 /* / */ || code === 92 /* \\ */) end -= 1;
+		else break;
+	}
+	const cleaned = trimmed.slice(0, end);
 	if (!cleaned) return null;
 	if (cleaned.includes("/") || cleaned.includes("\\")) {
 		// Windows-style path (drive letter or backslash)
@@ -296,8 +307,11 @@ function textFromContent(value: unknown): string {
 /**
  * Read the transcript JSONL and return the last assistant message text + usage.
  * Returns [null, null] on any read or parse failure.
+ *
+ * Exported so other adapter mappers (e.g. Codex) can reuse the same
+ * transcript fallback for Stop events that omit `last_assistant_message`.
  */
-function extractFromTranscript(
+export function extractFromTranscript(
 	transcriptPath: unknown,
 	cwdHint?: string | null,
 ): [string | null, Record<string, number> | null] {

--- a/packages/core/src/codex-hooks.test.ts
+++ b/packages/core/src/codex-hooks.test.ts
@@ -1,0 +1,225 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	buildIngestPayloadFromCodexHook,
+	buildRawEventEnvelopeFromCodexHook,
+	mapCodexHookPayload,
+} from "./codex-hooks.js";
+
+const tempDirs: string[] = [];
+
+function writeTranscript(lines: Array<Record<string, unknown>>): string {
+	const dir = mkdtempSync(join(tmpdir(), "codemem-codex-transcript-"));
+	tempDirs.push(dir);
+	const path = join(dir, "transcript.jsonl");
+	writeFileSync(path, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+	return path;
+}
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		rmSync(tempDirs.pop() as string, { recursive: true, force: true });
+	}
+});
+
+describe("mapCodexHookPayload", () => {
+	it("maps UserPromptSubmit to prompt", () => {
+		const event = mapCodexHookPayload({
+			hook_event_name: "UserPromptSubmit",
+			session_id: " codex-session ",
+			turn_id: "turn-1",
+			prompt: "Run the tests",
+			cwd: "/tmp/repo",
+			custom_field: "preserve",
+		});
+
+		expect(event).not.toBeNull();
+		expect(event?.source).toBe("codex");
+		expect(event?.event_type).toBe("prompt");
+		expect(event?.session_id).toBe("codex-session");
+		expect(event?.payload.text).toBe("Run the tests");
+		expect(event?.meta.turn_id).toBe("turn-1");
+		expect((event?.meta.hook_fields as Record<string, unknown>).custom_field).toBe("preserve");
+	});
+
+	it("skips empty prompts", () => {
+		expect(
+			mapCodexHookPayload({
+				hook_event_name: "UserPromptSubmit",
+				session_id: "codex-session",
+				prompt: "   ",
+			}),
+		).toBeNull();
+	});
+
+	it("maps SessionStart target metadata", () => {
+		const event = mapCodexHookPayload({
+			hook_event_name: "SessionStart",
+			session_id: "codex-session",
+			target: { source: "startup" },
+		});
+
+		expect(event).not.toBeNull();
+		expect(event?.event_type).toBe("session_start");
+		expect(event?.payload.source).toBe("startup");
+		expect(event?.payload.target).toEqual({ source: "startup" });
+	});
+
+	it("maps PreToolUse to tool_call", () => {
+		const event = mapCodexHookPayload({
+			hook_event_name: "PreToolUse",
+			session_id: "codex-session",
+			turn_id: "turn-1",
+			tool_use_id: "tool-1",
+			tool_name: "Bash",
+			tool_input: { command: "pnpm test" },
+		});
+
+		expect(event).not.toBeNull();
+		expect(event?.event_type).toBe("tool_call");
+		expect(event?.payload.tool_name).toBe("Bash");
+		expect(event?.payload.tool_input).toEqual({ command: "pnpm test" });
+		expect(event?.meta.tool_use_id).toBe("tool-1");
+	});
+
+	it("maps PostToolUse to ok tool_result", () => {
+		const event = mapCodexHookPayload({
+			hook_event_name: "PostToolUse",
+			session_id: "codex-session",
+			tool_name: "Read",
+			tool_input: { filePath: "README.md" },
+			tool_response: { content: "hello" },
+		});
+
+		expect(event).not.toBeNull();
+		expect(event?.event_type).toBe("tool_result");
+		expect(event?.payload.status).toBe("ok");
+		expect(event?.payload.tool_output).toEqual({ content: "hello" });
+		expect(event?.payload.tool_error).toBeNull();
+	});
+
+	it("maps Stop to assistant when assistant text is present", () => {
+		const event = mapCodexHookPayload({
+			hook_event_name: "Stop",
+			session_id: "codex-session",
+			turn_id: "turn-1",
+			last_assistant_message: "Done",
+		});
+
+		expect(event).not.toBeNull();
+		expect(event?.event_type).toBe("assistant");
+		expect(event?.payload.text).toBe("Done");
+	});
+
+	it("maps Stop via transcript fallback when last_assistant_message is missing", () => {
+		const transcriptPath = writeTranscript([
+			{ role: "user", content: "do the thing" },
+			{ role: "assistant", content: "Finished the thing" },
+		]);
+		const event = mapCodexHookPayload({
+			hook_event_name: "Stop",
+			session_id: "codex-session",
+			transcript_path: transcriptPath,
+		});
+
+		expect(event).not.toBeNull();
+		expect(event?.event_type).toBe("assistant");
+		expect(event?.payload.text).toBe("Finished the thing");
+	});
+
+	it("keeps Stop event IDs stable across transcript-fallback retries", () => {
+		const transcriptPath = writeTranscript([{ role: "assistant", content: "Finished the thing" }]);
+		const payload = {
+			hook_event_name: "Stop",
+			session_id: "codex-session",
+			transcript_path: transcriptPath,
+		};
+		expect(mapCodexHookPayload(payload)?.event_id).toBe(mapCodexHookPayload(payload)?.event_id);
+	});
+
+	it("skips Stop when neither assistant text nor transcript text is available", () => {
+		expect(
+			mapCodexHookPayload({ hook_event_name: "Stop", session_id: "codex-session" }),
+		).toBeNull();
+	});
+
+	it("skips unsupported events and missing session IDs", () => {
+		expect(
+			mapCodexHookPayload({ hook_event_name: "PermissionRequest", session_id: "s" }),
+		).toBeNull();
+		expect(mapCodexHookPayload({ hook_event_name: "SessionStart" })).toBeNull();
+		expect(mapCodexHookPayload({ hook_event_name: "SessionStart", session_id: "  " })).toBeNull();
+	});
+
+	it("produces stable event IDs for identical timestamped payloads", () => {
+		const payload = {
+			hook_event_name: "UserPromptSubmit",
+			session_id: "codex-session",
+			turn_id: "turn-1",
+			prompt: "Run tests",
+			timestamp: "2026-05-29T01:00:00Z",
+		};
+		expect(mapCodexHookPayload(payload)?.event_id).toBe(mapCodexHookPayload(payload)?.event_id);
+	});
+
+	it("uses generated timestamps to avoid collisions for repeated timestamp-less payloads", () => {
+		const payload = {
+			hook_event_name: "UserPromptSubmit",
+			session_id: "codex-session",
+			turn_id: "turn-1",
+			prompt: "Run tests",
+		};
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date("2026-05-29T01:00:00Z"));
+			const first = mapCodexHookPayload(payload)?.event_id;
+			vi.setSystemTime(new Date("2026-05-29T01:00:05Z"));
+			const second = mapCodexHookPayload(payload)?.event_id;
+			expect(first).not.toBe(second);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
+describe("buildRawEventEnvelopeFromCodexHook", () => {
+	it("wraps Codex adapter events for raw-event ingestion", () => {
+		const envelope = buildRawEventEnvelopeFromCodexHook({
+			hook_event_name: "SessionStart",
+			session_id: "codex-session",
+			timestamp: "2026-05-29T01:00:00Z",
+			cwd: "/tmp/repo",
+			project: "repo",
+		});
+
+		expect(envelope).not.toBeNull();
+		expect(envelope?.source).toBe("codex");
+		expect(envelope?.event_type).toBe("codex.hook");
+		expect(envelope?.session_stream_id).toBe("codex-session");
+		expect(envelope?.started_at).toBe("2026-05-29T01:00:00Z");
+		expect(envelope?.payload.type).toBe("codex.hook");
+		expect((envelope?.payload._adapter as Record<string, unknown>).source).toBe("codex");
+	});
+});
+
+describe("buildIngestPayloadFromCodexHook", () => {
+	it("builds shared ingest payload shape", () => {
+		const payload = buildIngestPayloadFromCodexHook({
+			hook_event_name: "UserPromptSubmit",
+			session_id: "codex-session",
+			prompt: "Run tests",
+		});
+
+		expect(payload).not.toBeNull();
+		expect(payload?.session_context).toEqual({
+			source: "codex",
+			stream_id: "codex-session",
+			session_stream_id: "codex-session",
+			session_id: "codex-session",
+			opencode_session_id: "codex-session",
+		});
+		expect((payload?.events as Record<string, unknown>[])[0]?.type).toBe("codex.hook");
+	});
+});

--- a/packages/core/src/codex-hooks.ts
+++ b/packages/core/src/codex-hooks.ts
@@ -1,0 +1,323 @@
+/**
+ * Codex hook payload mapping.
+ *
+ * Normalizes Codex plugin hook payloads into AdapterEvent v1 envelopes for
+ * the shared raw-event sweeper pipeline.
+ */
+
+import { createHash } from "node:crypto";
+import {
+	extractFromTranscript,
+	normalizeProjectLabel,
+	resolveHookProject,
+} from "./claude-hooks.js";
+
+export const MAPPABLE_CODEX_HOOK_EVENTS = new Set([
+	"SessionStart",
+	"UserPromptSubmit",
+	"PreToolUse",
+	"PostToolUse",
+	"Stop",
+]);
+
+function nowIso(): string {
+	return new Date().toISOString().replace(/\.(\d{3})\d*Z$/, ".$1Z");
+}
+
+function normalizeIsoTs(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const text = value.trim();
+	if (!text) return null;
+	const hasTimezone =
+		/[Zz]$/.test(text) || /[+-]\d{2}:\d{2}$/.test(text) || /[+-]\d{4}$/.test(text);
+	const parsed = new Date(hasTimezone ? text : `${text}Z`);
+	if (Number.isNaN(parsed.getTime())) return null;
+	const hasFractional = /\.\d+([Zz+-]|$)/.test(text);
+	return hasFractional
+		? parsed.toISOString().replace(/\.(\d{3})Z$/, ".$1000Z")
+		: parsed.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function isoToWallMs(value: string): number {
+	return new Date(value).getTime();
+}
+
+function stableEventId(...parts: string[]): string {
+	const digest = createHash("sha256").update(parts.join("|"), "utf-8").digest("hex").slice(0, 24);
+	return `cdx_evt_${digest}`;
+}
+
+function coerceString(value: unknown): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function coerceSessionId(payload: Record<string, unknown>): string | null {
+	const value = coerceString(payload.session_id);
+	return value || null;
+}
+
+function objectOrEmpty(value: unknown): Record<string, unknown> {
+	return value != null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+function sortKeys(value: unknown): unknown {
+	if (value == null || typeof value !== "object" || Array.isArray(value)) return value;
+	const sorted: Record<string, unknown> = {};
+	for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+		sorted[key] = sortKeys((value as Record<string, unknown>)[key]);
+	}
+	return sorted;
+}
+
+export interface CodexHookAdapterEvent {
+	schema_version: "1.0";
+	source: "codex";
+	session_id: string;
+	event_id: string;
+	event_type: string;
+	ts: string;
+	ordering_confidence: "low";
+	cwd: string | null;
+	payload: Record<string, unknown>;
+	meta: Record<string, unknown>;
+}
+
+export function mapCodexHookPayload(
+	payload: Record<string, unknown>,
+): CodexHookAdapterEvent | null {
+	const hookEvent = coerceString(payload.hook_event_name);
+	if (!MAPPABLE_CODEX_HOOK_EVENTS.has(hookEvent)) return null;
+
+	const sessionId = coerceSessionId(payload);
+	if (!sessionId) return null;
+
+	const normalizedRawTs = normalizeIsoTs(payload.ts ?? payload.timestamp);
+	const ts = normalizedRawTs ?? nowIso();
+	const generatedEventNonce = coerceString(payload.codemem_generated_event_nonce);
+	const toolUseId = coerceString(payload.tool_use_id);
+	const turnId = coerceString(payload.turn_id);
+
+	const consumed = new Set([
+		"hook_event_name",
+		"session_id",
+		"cwd",
+		"ts",
+		"timestamp",
+		"transcript_path",
+		"permission_mode",
+		"codemem_generated_event_nonce",
+		"tool_use_id",
+		"turn_id",
+		"model",
+		"subagent",
+	]);
+
+	let eventType: string;
+	let eventPayload: Record<string, unknown>;
+	let eventIdPayload: Record<string, unknown>;
+	let contentAnchoredEventId = false;
+
+	if (hookEvent === "SessionStart") {
+		const target = objectOrEmpty(payload.target);
+		const source = payload.source ?? target.source ?? null;
+		eventType = "session_start";
+		eventPayload = { source, target: Object.keys(target).length ? target : null };
+		eventIdPayload = { ...eventPayload };
+		consumed.add("source");
+		consumed.add("target");
+	} else if (hookEvent === "UserPromptSubmit") {
+		const text = coerceString(payload.prompt);
+		if (!text) return null;
+		eventType = "prompt";
+		eventPayload = { text };
+		eventIdPayload = { ...eventPayload };
+		consumed.add("prompt");
+	} else if (hookEvent === "PreToolUse") {
+		const toolName = coerceString(payload.tool_name);
+		if (!toolName) return null;
+		const toolInput = objectOrEmpty(payload.tool_input);
+		eventType = "tool_call";
+		eventPayload = { tool_name: toolName, tool_input: toolInput };
+		eventIdPayload = { ...eventPayload };
+		consumed.add("tool_name");
+		consumed.add("tool_input");
+		consumed.add("matcher_aliases");
+	} else if (hookEvent === "PostToolUse") {
+		const toolName = coerceString(payload.tool_name);
+		if (!toolName) return null;
+		const toolInput = objectOrEmpty(payload.tool_input);
+		const toolResponse = payload.tool_response ?? null;
+		eventType = "tool_result";
+		eventPayload = {
+			tool_name: toolName,
+			status: "ok",
+			tool_input: toolInput,
+			tool_output: toolResponse,
+			tool_error: null,
+		};
+		eventIdPayload = { ...eventPayload };
+		consumed.add("tool_name");
+		consumed.add("tool_input");
+		consumed.add("tool_response");
+		consumed.add("matcher_aliases");
+	} else {
+		// Stop: prefer the inline assistant message, then fall back to the
+		// transcript's last assistant text so Codex Stop payloads that only
+		// carry `transcript_path` still reach the observer pipeline.
+		//
+		// Token usage is intentionally not captured for Codex Stop events:
+		// the Codex MVP scope is context injection + ingestion only, so the
+		// transcript usage tuple is discarded here. Mirror the Claude usage
+		// handling if/when Codex usage capture becomes in scope.
+		const rawAssistantText = coerceString(payload.last_assistant_message);
+		let assistantText = rawAssistantText;
+		if (!assistantText) {
+			const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
+			const [transcriptText] = extractFromTranscript(payload.transcript_path, cwd);
+			if (transcriptText) assistantText = transcriptText.trim();
+		}
+		if (!assistantText) return null;
+		eventType = "assistant";
+		eventPayload = { text: assistantText };
+		contentAnchoredEventId = true;
+
+		// Keep the event id stable on the raw inline text when present;
+		// otherwise anchor it to the transcript path so retries dedupe and a
+		// later inline-text payload is still treated as a distinct event.
+		if (rawAssistantText) {
+			eventIdPayload = { text: rawAssistantText };
+		} else {
+			const transcriptPath = coerceString(payload.transcript_path);
+			eventIdPayload = transcriptPath
+				? { transcript_path: transcriptPath }
+				: { text: assistantText };
+		}
+		consumed.add("stop_hook_active");
+		consumed.add("last_assistant_message");
+		consumed.add("target");
+	}
+
+	const meta: Record<string, unknown> = {
+		hook_event_name: hookEvent,
+		ordering_confidence: "low",
+	};
+	if (toolUseId) meta.tool_use_id = toolUseId;
+	if (turnId) meta.turn_id = turnId;
+	if (normalizedRawTs === null) meta.ts_normalized = "generated";
+
+	const unknown: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(payload)) {
+		if (!consumed.has(key)) unknown[key] = value;
+	}
+	if (Object.keys(unknown).length > 0) meta.hook_fields = unknown;
+
+	const payloadHash = createHash("sha256")
+		.update(JSON.stringify(sortKeys(eventIdPayload)), "utf-8")
+		.digest("hex");
+	// Stop events are content-anchored: their identity is the assistant message
+	// (inline text or transcript), so retries of the same completion must dedupe.
+	// Excluding the generated wall-clock ts and per-call nonce keeps the id stable
+	// when Codex omits a timestamp. Other event types keep the generated-time
+	// fallbacks to avoid collisions for repeated timestamp-less payloads.
+	const eventIdTs = normalizedRawTs ?? (contentAnchoredEventId ? "" : ts);
+	const eventIdNonce = contentAnchoredEventId ? "" : generatedEventNonce;
+	const eventId = stableEventId(
+		sessionId,
+		hookEvent,
+		eventIdTs,
+		turnId,
+		toolUseId,
+		eventIdNonce,
+		payloadHash,
+	);
+	const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
+
+	return {
+		schema_version: "1.0",
+		source: "codex",
+		session_id: sessionId,
+		event_id: eventId,
+		event_type: eventType,
+		ts,
+		ordering_confidence: "low",
+		cwd,
+		payload: eventPayload,
+		meta,
+	};
+}
+
+export interface CodexHookRawEventEnvelope {
+	session_stream_id: string;
+	session_id: string;
+	opencode_session_id: string;
+	source: string;
+	event_id: string;
+	event_type: "codex.hook";
+	payload: Record<string, unknown>;
+	ts_wall_ms: number;
+	cwd: string | null;
+	project: string | null;
+	started_at: string | null;
+}
+
+export function buildRawEventEnvelopeFromCodexHook(
+	hookPayload: Record<string, unknown>,
+): CodexHookRawEventEnvelope | null {
+	const adapterEvent = mapCodexHookPayload(hookPayload);
+	if (adapterEvent === null) return null;
+
+	const sessionId = adapterEvent.session_id.trim();
+	if (!sessionId) return null;
+	const ts = adapterEvent.ts.trim();
+	if (!ts) return null;
+
+	const cwd = typeof hookPayload.cwd === "string" ? hookPayload.cwd : null;
+	const project =
+		resolveHookProject(cwd, hookPayload.project) ?? normalizeProjectLabel(hookPayload.project);
+	const hookEventName = coerceString(hookPayload.hook_event_name);
+
+	return {
+		session_stream_id: sessionId,
+		session_id: sessionId,
+		opencode_session_id: sessionId,
+		source: "codex",
+		event_id: adapterEvent.event_id,
+		event_type: "codex.hook",
+		payload: {
+			type: "codex.hook",
+			timestamp: ts,
+			_adapter: adapterEvent,
+		},
+		ts_wall_ms: isoToWallMs(ts),
+		cwd,
+		project,
+		started_at: hookEventName === "SessionStart" ? ts : null,
+	};
+}
+
+export function buildIngestPayloadFromCodexHook(
+	hookPayload: Record<string, unknown>,
+): Record<string, unknown> | null {
+	const adapterEvent = mapCodexHookPayload(hookPayload);
+	if (adapterEvent === null) return null;
+	const sessionId = adapterEvent.session_id;
+	return {
+		cwd: hookPayload.cwd ?? null,
+		events: [
+			{
+				type: "codex.hook",
+				timestamp: adapterEvent.ts,
+				_adapter: adapterEvent,
+			},
+		],
+		session_context: {
+			source: "codex",
+			stream_id: sessionId,
+			session_stream_id: sessionId,
+			session_id: sessionId,
+			opencode_session_id: sessionId,
+		},
+	};
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,13 @@ export {
 	normalizeProjectLabel,
 	resolveHookProject,
 } from "./claude-hooks.js";
+export type { CodexHookAdapterEvent, CodexHookRawEventEnvelope } from "./codex-hooks.js";
+export {
+	buildIngestPayloadFromCodexHook,
+	buildRawEventEnvelopeFromCodexHook,
+	MAPPABLE_CODEX_HOOK_EVENTS,
+	mapCodexHookPayload,
+} from "./codex-hooks.js";
 export {
 	coordinatorArchiveGroupAction,
 	coordinatorCreateGroupAction,

--- a/packages/viewer-server/src/routes/raw-events.ts
+++ b/packages/viewer-server/src/routes/raw-events.ts
@@ -1,11 +1,16 @@
 /**
  * Raw events routes — GET & POST /api/raw-events, GET /api/raw-events/status,
- * POST /api/claude-hooks.
+ * POST /api/claude-hooks, POST /api/codex-hooks.
  */
 
 import { createHash } from "node:crypto";
 import type { MemoryStore, RawEventSweeper } from "@codemem/core";
-import { buildRawEventEnvelopeFromHook, schema, stripPrivateObj } from "@codemem/core";
+import {
+	buildRawEventEnvelopeFromCodexHook,
+	buildRawEventEnvelopeFromHook,
+	schema,
+	stripPrivateObj,
+} from "@codemem/core";
 import { desc } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { Hono } from "hono";
@@ -419,6 +424,53 @@ export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweepe
 			});
 
 			// Note activity for optional debounced auto-flush.
+			nudgeSweeper(sweeper, [opencodeSessionId], source);
+
+			return c.json({ inserted: inserted ? 1 : 0, skipped: 0 });
+		} catch (err) {
+			const response: Record<string, unknown> = { error: "internal server error" };
+			if (process.env.CODEMEM_VIEWER_DEBUG === "1") {
+				response.detail = (err as Error).message;
+			}
+			return c.json(response, 500);
+		}
+	});
+
+	// POST /api/codex-hooks — ingest Codex hook events
+	app.post("/api/codex-hooks", async (c) => {
+		const result = await parseJsonObjectBody(c, MAX_RAW_EVENTS_BODY_BYTES);
+		if (result instanceof Response) return result;
+		const payload = result;
+
+		const envelope = buildRawEventEnvelopeFromCodexHook(payload);
+		if (envelope === null) {
+			return c.json({ inserted: 0, skipped: 1 });
+		}
+
+		const store = getStore();
+		try {
+			const opencodeSessionId = envelope.opencode_session_id;
+			const source = envelope.source;
+			const strippedPayload = stripPrivateObj(envelope.payload) as Record<string, unknown>;
+
+			const inserted = store.recordRawEvent({
+				opencodeSessionId,
+				source,
+				eventId: envelope.event_id,
+				eventType: envelope.event_type,
+				payload: strippedPayload,
+				tsWallMs: envelope.ts_wall_ms,
+			});
+
+			store.updateRawEventSessionMeta({
+				opencodeSessionId,
+				source,
+				cwd: envelope.cwd,
+				project: envelope.project,
+				startedAt: envelope.started_at,
+				lastSeenTsWallMs: envelope.ts_wall_ms,
+			});
+
 			nudgeSweeper(sweeper, [opencodeSessionId], source);
 
 			return c.json({ inserted: inserted ? 1 : 0, skipped: 0 });


### PR DESCRIPTION
## Description
Adds Codex hook payload mapping into AdapterEvent v1 and wires `/api/codex-hooks` into the viewer raw-event route. This slice covers the shared core mapping, raw-event envelope construction, exports, and route enqueue behavior without the CLI fallback layer.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, targeted Vitest)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation run: `pnpm exec vitest run packages/core/src/codex-hooks.test.ts`; `pnpm run tsc`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced