### PR TITLE
feat(codex): add durable hook ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ npx -y codemem setup --claude-only
 
 The Claude plugin starts MCP with the TS CLI (`codemem mcp`).
 
-Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks`) and falls back to direct local DB enqueue via `codemem claude-hook-ingest` when the local server path is unavailable.
+Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks`) and falls back to direct local DB enqueue via `codemem claude-hook-ingest` when the local server path is unavailable. Experimental Codex hook ingestion follows the same shared raw-event pipeline through `POST /api/codex-hooks`, `codemem codex-hook-ingest`, and a Codex-specific fallback spool.
 
 Claude hook events share the same raw-event queue pipeline used by OpenCode. `UserPromptSubmit` runs
 capture ingest in the background and injects memory context via Claude `additionalContext` using
@@ -140,6 +140,7 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | **Plumbing** | `codemem mcp` | MCP stdio server; best-effort starts the local viewer unless `CODEMEM_VIEWER=0` or `CODEMEM_VIEWER_AUTO=0` is set |
 | | `codemem mcp http` | Local Streamable HTTP MCP server (`POST /mcp`, loopback-only by default) |
 | | `codemem claude-hook-ingest` | Claude hook event ingestion (stdin) |
+| | `codemem codex-hook-ingest` | Codex hook event ingestion (stdin, experimental) |
 
 Run `codemem --help` for the full list. Legacy top-level aliases (`export-memories`, `import-memories`, `show`, `forget`, `remember`) still work but are hidden from help.
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -250,6 +250,10 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_PLUGIN_LOG_PATH` | Explicit log file path for Claude hook script logging (overrides `CODEMEM_PLUGIN_LOG` for that script). |
 | `CODEMEM_CLAUDE_HOOK_HTTP_CONNECT_TIMEOUT_S` | Claude hook HTTP enqueue connect timeout in seconds (default `1`). |
 | `CODEMEM_CLAUDE_HOOK_HTTP_MAX_TIME_S` | Claude hook HTTP enqueue total timeout in seconds (default `2`). |
+| `CODEMEM_CODEX_HOOK_HTTP_TIMEOUT_MS` | Codex hook HTTP enqueue timeout in milliseconds (default `1000`). |
+| `CODEMEM_CODEX_HOOK_LOCK_DIR` | Codex hook fallback lock path (default `~/.codemem/codex-hook-ingest.lock`). |
+| `CODEMEM_CODEX_HOOK_LOCK_TTL_S` | Seconds before a Codex hook fallback lock is treated as stale (default `120`). |
+| `CODEMEM_CODEX_HOOK_SPOOL_DIR` | Codex hook fallback spool directory (default `~/.codemem/codex-hook-spool`). |
 | `CODEMEM_INJECT_HTTP_CONNECT_TIMEOUT_S` | `UserPromptSubmit` pack injection connect timeout in seconds (default `1`). |
 | `CODEMEM_INJECT_HTTP_MAX_TIME_S` | `UserPromptSubmit` pack injection total timeout in seconds (default `2`). |
 | `CODEMEM_INJECT_HTTP_FALLBACK` | Set to `0` to disable HTTP `/api/pack` fallback for Claude prompt-time injection (default `1`). |

--- a/packages/cli/src/commands/codex-hook-ingest-spool.ts
+++ b/packages/cli/src/commands/codex-hook-ingest-spool.ts
@@ -1,0 +1,342 @@
+import { randomInt } from "node:crypto";
+import {
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmdirSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { logHookEvent } from "./claude-hook-plugin-log.js";
+
+const DEFAULT_LOCK_TTL_S = 120;
+const DEFAULT_LOCK_GRACE_S = 2;
+const LOCK_ACQUIRE_ATTEMPTS = 20;
+const LOCK_ACQUIRE_BACKOFF_MS = 50;
+
+type LockSnapshot = { pid: string; ts: number | null; owner: string };
+type LockConfig = { lockDir: string; ttlSeconds: number; graceSeconds: number };
+
+export class CodexHookLockBusyError extends Error {
+	constructor() {
+		super("codex-hook-ingest lock busy");
+		this.name = "CodexHookLockBusyError";
+	}
+}
+
+function expandHome(value: string): string {
+	if (value === "~") return homedir();
+	if (value.startsWith("~/")) return join(homedir(), value.slice(2));
+	return value;
+}
+
+function envInt(name: string, fallback: number): number {
+	const parsed = Number.parseInt(process.env[name] ?? "", 10);
+	return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function lockConfig(): LockConfig {
+	return {
+		lockDir: expandHome(
+			process.env.CODEMEM_CODEX_HOOK_LOCK_DIR?.trim() || "~/.codemem/codex-hook-ingest.lock",
+		),
+		ttlSeconds: Math.max(1, envInt("CODEMEM_CODEX_HOOK_LOCK_TTL_S", DEFAULT_LOCK_TTL_S)),
+		graceSeconds: Math.max(1, envInt("CODEMEM_CODEX_HOOK_LOCK_GRACE_S", DEFAULT_LOCK_GRACE_S)),
+	};
+}
+
+export function codexHookSpoolDir(): string {
+	return expandHome(
+		process.env.CODEMEM_CODEX_HOOK_SPOOL_DIR?.trim() || "~/.codemem/codex-hook-spool",
+	);
+}
+
+export function codexHookLockTtlSeconds(): number {
+	return lockConfig().ttlSeconds;
+}
+
+export function hasCodexHookSpooledEntries(): boolean {
+	let entries: string[];
+	try {
+		entries = readdirSync(codexHookSpoolDir());
+	} catch {
+		return false;
+	}
+	return entries.some(
+		(name) => name.endsWith(".json") && !name.startsWith(".hook-tmp-") && !name.startsWith(".bad-"),
+	);
+}
+
+function readTrimmed(path: string): string {
+	try {
+		return readFileSync(path, "utf8").trim();
+	} catch {
+		return "";
+	}
+}
+
+function readLockMetadata(lockDir: string): LockSnapshot {
+	const rawTs = readTrimmed(join(lockDir, "ts"));
+	const ts = rawTs === "" ? null : Number.parseInt(rawTs, 10);
+	return {
+		pid: readTrimmed(join(lockDir, "pid")),
+		ts: ts === null || !Number.isFinite(ts) ? null : ts,
+		owner: readTrimmed(join(lockDir, "owner")),
+	};
+}
+
+function isPidAlive(pidText: string): boolean {
+	const pid = Number.parseInt(pidText, 10);
+	if (!Number.isFinite(pid) || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function lockIsStale(cfg: LockConfig): { stale: boolean; snapshot: LockSnapshot } {
+	const snapshot = readLockMetadata(cfg.lockDir);
+	const nowS = Math.floor(Date.now() / 1000);
+	if (snapshot.pid) {
+		if (isPidAlive(snapshot.pid)) {
+			return { stale: snapshot.ts !== null && nowS - snapshot.ts > cfg.ttlSeconds, snapshot };
+		}
+		return { stale: true, snapshot };
+	}
+	if (snapshot.ts !== null) return { stale: nowS - snapshot.ts > cfg.graceSeconds, snapshot };
+	try {
+		return {
+			stale: nowS - Math.floor(statSync(cfg.lockDir).mtimeMs / 1000) > cfg.graceSeconds,
+			snapshot,
+		};
+	} catch {
+		return { stale: true, snapshot };
+	}
+}
+
+function cleanupLockDir(lockDir: string): void {
+	for (const name of ["pid", "ts", "owner"]) {
+		try {
+			unlinkSync(join(lockDir, name));
+		} catch {
+			// best-effort
+		}
+	}
+	try {
+		rmdirSync(lockDir);
+	} catch {
+		// best-effort
+	}
+}
+
+function cleanupLockDirIfUnchanged(lockDir: string, snapshot: LockSnapshot): void {
+	const current = readLockMetadata(lockDir);
+	if (
+		current.pid === snapshot.pid &&
+		current.ts === snapshot.ts &&
+		current.owner === snapshot.owner
+	) {
+		cleanupLockDir(lockDir);
+	}
+}
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+	return typeof err === "object" && err !== null && "code" in err;
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withCodexHookIngestLock<T>(fn: () => Promise<T> | T): Promise<T> {
+	const cfg = lockConfig();
+	mkdirSync(dirname(cfg.lockDir), { recursive: true });
+	const ownerToken = `${process.pid}-${Math.floor(Date.now() / 1000)}-${randomInt(1000, 10000)}`;
+
+	let acquired = false;
+	for (let attempt = 0; attempt < LOCK_ACQUIRE_ATTEMPTS; attempt++) {
+		try {
+			mkdirSync(cfg.lockDir);
+		} catch (err) {
+			if (isErrnoException(err) && err.code === "EEXIST") {
+				const { stale, snapshot } = lockIsStale(cfg);
+				if (stale) cleanupLockDirIfUnchanged(cfg.lockDir, snapshot);
+			}
+			await sleep(LOCK_ACQUIRE_BACKOFF_MS);
+			continue;
+		}
+
+		try {
+			writeFileSync(join(cfg.lockDir, "ts"), String(Math.floor(Date.now() / 1000)), "utf8");
+			writeFileSync(join(cfg.lockDir, "pid"), String(process.pid), "utf8");
+			writeFileSync(join(cfg.lockDir, "owner"), ownerToken, "utf8");
+			acquired = true;
+			break;
+		} catch {
+			cleanupLockDir(cfg.lockDir);
+			await sleep(LOCK_ACQUIRE_BACKOFF_MS);
+		}
+	}
+
+	if (!acquired) throw new CodexHookLockBusyError();
+	try {
+		return await fn();
+	} finally {
+		if (readTrimmed(join(cfg.lockDir, "owner")) === ownerToken) cleanupLockDir(cfg.lockDir);
+	}
+}
+
+export function spoolCodexHookPayload(payload: Record<string, unknown>): boolean {
+	const dir = codexHookSpoolDir();
+	try {
+		mkdirSync(dir, { recursive: true });
+	} catch {
+		logHookEvent("codemem codex-hook-ingest failed to create spool dir");
+		return false;
+	}
+
+	const tmpPath = join(
+		dir,
+		`.hook-tmp-${process.pid}-${Date.now()}-${randomInt(1000, 10000)}.json`,
+	);
+	try {
+		writeFileSync(tmpPath, JSON.stringify(payload), "utf8");
+	} catch {
+		logHookEvent("codemem codex-hook-ingest failed to allocate spool temp file");
+		return false;
+	}
+
+	const finalPath = join(
+		dir,
+		`hook-${Math.floor(Date.now() / 1000)}-${process.pid}-${randomInt(1000, 10000)}.json`,
+	);
+	try {
+		renameSync(tmpPath, finalPath);
+	} catch {
+		try {
+			unlinkSync(tmpPath);
+		} catch {
+			// best-effort
+		}
+		logHookEvent("codemem codex-hook-ingest failed to spool payload");
+		return false;
+	}
+	logHookEvent(`codemem codex-hook-ingest spooled payload: ${finalPath}`);
+	return true;
+}
+
+export function recoverStaleCodexHookTmpSpool(ttlSeconds: number): void {
+	const dir = codexHookSpoolDir();
+	try {
+		mkdirSync(dir, { recursive: true });
+	} catch {
+		return;
+	}
+
+	let entries: string[];
+	try {
+		entries = readdirSync(dir);
+	} catch {
+		return;
+	}
+
+	const nowS = Date.now() / 1000;
+	for (const name of entries) {
+		if (!name.startsWith(".hook-tmp-") || !name.endsWith(".json")) continue;
+		const tmpPath = join(dir, name);
+		try {
+			if (nowS - statSync(tmpPath).mtimeMs / 1000 <= ttlSeconds) continue;
+			renameSync(
+				tmpPath,
+				join(
+					dir,
+					`hook-recovered-${Math.floor(nowS)}-${process.pid}-${randomInt(1000, 10000)}.json`,
+				),
+			);
+		} catch {
+			// best-effort
+		}
+	}
+}
+
+function quarantineSpoolEntry(dir: string, name: string, reason: string): void {
+	try {
+		renameSync(
+			join(dir, name),
+			join(dir, `.bad-${reason}-${Date.now()}-${randomInt(1000, 10000)}-${name}`),
+		);
+	} catch {
+		try {
+			unlinkSync(join(dir, name));
+		} catch {
+			// best-effort
+		}
+	}
+}
+
+export type CodexSpoolHandler = (payload: Record<string, unknown>) => Promise<boolean> | boolean;
+
+export async function drainCodexHookSpool(
+	handler: CodexSpoolHandler,
+): Promise<{ processed: number; failed: number }> {
+	const dir = codexHookSpoolDir();
+	try {
+		mkdirSync(dir, { recursive: true });
+	} catch {
+		return { processed: 0, failed: 0 };
+	}
+
+	let entries: string[];
+	try {
+		entries = readdirSync(dir);
+	} catch {
+		return { processed: 0, failed: 0 };
+	}
+
+	const result = { processed: 0, failed: 0 };
+	for (const name of entries
+		.filter(
+			(entry) =>
+				entry.endsWith(".json") && !entry.startsWith(".hook-tmp-") && !entry.startsWith(".bad-"),
+		)
+		.sort()) {
+		const path = join(dir, name);
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(readFileSync(path, "utf8"));
+		} catch {
+			quarantineSpoolEntry(dir, name, "parse-error");
+			result.failed++;
+			continue;
+		}
+		if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			quarantineSpoolEntry(dir, name, "wrong-shape");
+			result.failed++;
+			continue;
+		}
+
+		let ok = false;
+		try {
+			ok = await handler(parsed as Record<string, unknown>);
+		} catch {
+			ok = false;
+		}
+		if (!ok) {
+			result.failed++;
+			continue;
+		}
+		try {
+			unlinkSync(path);
+			result.processed++;
+		} catch {
+			// best-effort
+		}
+	}
+	return result;
+}

--- a/packages/cli/src/commands/codex-hook-ingest.test.ts
+++ b/packages/cli/src/commands/codex-hook-ingest.test.ts
@@ -1,0 +1,330 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, initTestSchema } from "@codemem/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	codexHookIngestCommand,
+	directEnqueueCodexHook,
+	ingestCodexHookPayload,
+} from "./codex-hook-ingest.js";
+import { spoolCodexHookPayload } from "./codex-hook-ingest-spool.js";
+
+const savedEnv: Record<string, string | undefined> = {};
+let hermeticDir: string;
+
+function setEnv(key: string, value: string | undefined): void {
+	if (!(key in savedEnv)) savedEnv[key] = process.env[key];
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}
+
+function createTempDbPath(): { dbPath: string; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), "codemem-cli-codex-hook-"));
+	const dbPath = join(dir, "test.sqlite");
+	const db = connect(dbPath);
+	initTestSchema(db);
+	db.close();
+	return {
+		dbPath,
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+describe("codex-hook-ingest command", () => {
+	beforeEach(() => {
+		// Keep lock/spool I/O hermetic so direct-fallback drains never touch
+		// the developer's real ~/.codemem spool directory.
+		hermeticDir = mkdtempSync(join(tmpdir(), "codemem-cli-codex-hermetic-"));
+		setEnv("CODEMEM_CODEX_HOOK_LOCK_DIR", join(hermeticDir, "lock"));
+		setEnv("CODEMEM_CODEX_HOOK_SPOOL_DIR", join(hermeticDir, "spool"));
+	});
+
+	afterEach(() => {
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+			delete savedEnv[key];
+		}
+		rmSync(hermeticDir, { recursive: true, force: true });
+	});
+
+	it("registers expected options and help text", () => {
+		const longs = codexHookIngestCommand.options.map((option) => option.long);
+		expect(longs).toContain("--db");
+		expect(longs).toContain("--db-path");
+		expect(longs).toContain("--host");
+		expect(longs).toContain("--port");
+
+		const help = codexHookIngestCommand.helpInformation();
+		expect(help).toContain("HTTP first");
+		expect(help).toContain("direct DB fallback");
+	});
+
+	it("returns HTTP result when viewer ingest succeeds", async () => {
+		const result = await ingestCodexHookPayload(
+			{ hook_event_name: "SessionStart", session_id: "sess-http", cwd: "/tmp/demo" },
+			{ host: "127.0.0.1", port: 38888 },
+			{
+				httpIngest: async () => ({ ok: true, inserted: 2, skipped: 1 }),
+				directIngest: () => {
+					throw new Error("direct ingest should not be called");
+				},
+				resolveDb: () => {
+					throw new Error("resolveDb should not be called");
+				},
+			},
+		);
+
+		expect(result).toEqual({ inserted: 2, skipped: 1, via: "http" });
+	});
+
+	it("falls back to direct ingest when HTTP path fails", async () => {
+		const result = await ingestCodexHookPayload(
+			{ hook_event_name: "SessionStart", session_id: "sess-direct", cwd: "/tmp/demo" },
+			{ host: "127.0.0.1", port: 38888, db: "/tmp/custom.sqlite" },
+			{
+				httpIngest: async () => ({ ok: false, inserted: 0, skipped: 0 }),
+				directIngest: () => ({ inserted: 1, skipped: 0 }),
+				resolveDb: () => "/tmp/resolved.sqlite",
+			},
+		);
+
+		expect(result).toEqual({ inserted: 1, skipped: 0, via: "direct" });
+	});
+
+	it("spools payloads when HTTP and direct ingest fail", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "codemem-cli-codex-spool-"));
+		try {
+			setEnv("CODEMEM_CODEX_HOOK_LOCK_DIR", join(dir, "lock"));
+			setEnv("CODEMEM_CODEX_HOOK_SPOOL_DIR", join(dir, "spool"));
+			const result = await ingestCodexHookPayload(
+				{ hook_event_name: "SessionStart", session_id: "sess-spool", cwd: "/tmp/demo" },
+				{ host: "127.0.0.1", port: 38888, db: join(dir, "fallback.sqlite") },
+				{
+					httpIngest: async () => ({ ok: false, inserted: 0, skipped: 0 }),
+					directIngest: () => {
+						throw new Error("database locked");
+					},
+				},
+			);
+
+			expect(result).toEqual({ inserted: 0, skipped: 0, via: "spool" });
+			const queued = readdirSync(join(dir, "spool")).filter((name) => name.endsWith(".json"));
+			expect(queued).toHaveLength(1);
+			const spooled = JSON.parse(readFileSync(join(dir, "spool", queued[0] ?? ""), "utf8")) as {
+				timestamp?: unknown;
+			};
+			expect(typeof spooled.timestamp).toBe("string");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not collide repeated timestamp-less payloads", async () => {
+		const { dbPath, cleanup } = createTempDbPath();
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date("2026-05-29T01:00:00Z"));
+			const first = await ingestCodexHookPayload(
+				{ hook_event_name: "UserPromptSubmit", session_id: "sess-repeat", prompt: "continue" },
+				{ host: "127.0.0.1", port: 38888, db: dbPath },
+				{ httpIngest: async () => ({ ok: false, inserted: 0, skipped: 0 }) },
+			);
+			const second = await ingestCodexHookPayload(
+				{ hook_event_name: "UserPromptSubmit", session_id: "sess-repeat", prompt: "continue" },
+				{ host: "127.0.0.1", port: 38888, db: dbPath },
+				{ httpIngest: async () => ({ ok: false, inserted: 0, skipped: 0 }) },
+			);
+
+			expect(first).toEqual({ inserted: 1, skipped: 0, via: "direct" });
+			expect(second).toEqual({ inserted: 1, skipped: 0, via: "direct" });
+			const db = connect(dbPath);
+			try {
+				const count = db.prepare("SELECT COUNT(*) AS count FROM raw_events").get() as {
+					count: number;
+				};
+				expect(count.count).toBe(2);
+			} finally {
+				db.close();
+			}
+		} finally {
+			vi.useRealTimers();
+			cleanup();
+		}
+	});
+
+	it("drains queued spool entries after HTTP recovers", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "codemem-cli-codex-drain-"));
+		try {
+			setEnv("CODEMEM_CODEX_HOOK_LOCK_DIR", join(dir, "lock"));
+			setEnv("CODEMEM_CODEX_HOOK_SPOOL_DIR", join(dir, "spool"));
+			expect(spoolCodexHookPayload({ hook_event_name: "SessionStart", session_id: "queued" })).toBe(
+				true,
+			);
+			const seen: string[] = [];
+			const result = await ingestCodexHookPayload(
+				{ hook_event_name: "SessionStart", session_id: "current" },
+				{ host: "127.0.0.1", port: 38888, db: join(dir, "fallback.sqlite") },
+				{
+					httpIngest: async (payload) => {
+						seen.push(String(payload.session_id));
+						return { ok: true, inserted: 1, skipped: 0 };
+					},
+					directIngest: () => {
+						throw new Error("direct ingest should not be called");
+					},
+				},
+			);
+
+			expect(result).toEqual({ inserted: 1, skipped: 0, via: "http" });
+			expect(seen).toEqual(["current", "queued"]);
+			expect(readdirSync(join(dir, "spool"))).toHaveLength(0);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("drains queued spool entries via direct fallback when the viewer stays down", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "codemem-cli-codex-direct-drain-"));
+		const dbPath = join(dir, "fallback.sqlite");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		try {
+			setEnv("CODEMEM_CODEX_HOOK_LOCK_DIR", join(dir, "lock"));
+			setEnv("CODEMEM_CODEX_HOOK_SPOOL_DIR", join(dir, "spool"));
+			expect(
+				spoolCodexHookPayload({
+					hook_event_name: "SessionStart",
+					session_id: "queued-stream",
+					timestamp: "2026-05-29T01:00:00Z",
+				}),
+			).toBe(true);
+
+			const result = await ingestCodexHookPayload(
+				{ hook_event_name: "UserPromptSubmit", session_id: "current-stream", prompt: "hello" },
+				{ host: "127.0.0.1", port: 38888, db: dbPath },
+				{ httpIngest: async () => ({ ok: false, inserted: 0, skipped: 0 }) },
+			);
+
+			expect(result).toEqual({ inserted: 1, skipped: 0, via: "direct" });
+			expect(readdirSync(join(dir, "spool")).filter((name) => name.endsWith(".json"))).toHaveLength(
+				0,
+			);
+			const verify = connect(dbPath);
+			try {
+				const count = verify.prepare("SELECT COUNT(*) AS count FROM raw_events").get() as {
+					count: number;
+				};
+				expect(count.count).toBe(2);
+			} finally {
+				verify.close();
+			}
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("direct enqueue starts a new stream sequence at zero to match the store path", () => {
+		const { dbPath, cleanup } = createTempDbPath();
+		try {
+			directEnqueueCodexHook(
+				{
+					hook_event_name: "SessionStart",
+					session_id: "sess-seq",
+					timestamp: "2026-05-29T01:00:00Z",
+					cwd: "/tmp/demo",
+				},
+				dbPath,
+			);
+			const db = connect(dbPath);
+			try {
+				const row = db
+					.prepare("SELECT event_seq FROM raw_events WHERE stream_id = ?")
+					.get("sess-seq") as { event_seq: number };
+				expect(row.event_seq).toBe(0);
+				const session = db
+					.prepare(
+						"SELECT last_received_event_seq, last_flushed_event_seq FROM raw_event_sessions WHERE stream_id = ?",
+					)
+					.get("sess-seq") as {
+					last_received_event_seq: number;
+					last_flushed_event_seq: number;
+				};
+				expect(session.last_received_event_seq).toBe(0);
+				expect(session.last_flushed_event_seq).toBe(-1);
+			} finally {
+				db.close();
+			}
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("direct enqueue inserts once and deduplicates event_id", () => {
+		const { dbPath, cleanup } = createTempDbPath();
+		try {
+			const payload = {
+				hook_event_name: "SessionStart",
+				session_id: "sess-dedup",
+				timestamp: "2026-05-29T01:00:00Z",
+				cwd: "/tmp/demo",
+			};
+
+			const first = directEnqueueCodexHook(payload, dbPath);
+			const second = directEnqueueCodexHook(payload, dbPath);
+
+			expect(first).toEqual({ inserted: 1, skipped: 0 });
+			expect(second).toEqual({ inserted: 0, skipped: 0 });
+
+			const db = connect(dbPath);
+			try {
+				const raw = db.prepare("SELECT source, event_type, payload_json FROM raw_events").get() as {
+					source: string;
+					event_type: string;
+					payload_json: string;
+				};
+				expect(raw.source).toBe("codex");
+				expect(raw.event_type).toBe("codex.hook");
+				expect(JSON.parse(raw.payload_json)._adapter.source).toBe("codex");
+			} finally {
+				db.close();
+			}
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("direct enqueue skips unsupported hook payloads gracefully", () => {
+		const { dbPath, cleanup } = createTempDbPath();
+		try {
+			const result = directEnqueueCodexHook(
+				{ hook_event_name: "PermissionRequest", session_id: "sess-x" },
+				dbPath,
+			);
+			expect(result).toEqual({ inserted: 0, skipped: 1 });
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("direct enqueue bootstraps fresh databases on demand", () => {
+		const dir = mkdtempSync(join(tmpdir(), "codemem-cli-codex-direct-bootstrap-"));
+		const dbPath = join(dir, "fresh.sqlite");
+		try {
+			const result = directEnqueueCodexHook(
+				{
+					hook_event_name: "SessionStart",
+					session_id: "sess-fresh-bootstrap",
+					timestamp: "2026-05-29T01:00:00Z",
+					cwd: "/tmp/demo",
+				},
+				dbPath,
+			);
+			expect(result).toEqual({ inserted: 1, skipped: 0 });
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/cli/src/commands/codex-hook-ingest.ts
+++ b/packages/cli/src/commands/codex-hook-ingest.ts
@@ -1,0 +1,337 @@
+/**
+ * codemem codex-hook-ingest — read a single Codex hook payload from stdin and
+ * enqueue it for raw-event processing.
+ */
+
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import {
+	buildRawEventEnvelopeFromCodexHook,
+	connect,
+	ensureSchemaBootstrapped,
+	loadSqliteVec,
+	resolveDbPath,
+	stripPrivateObj,
+} from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+import { addDbOption, addViewerHostOptions, type DbOpts, resolveDbOpt } from "../shared-options.js";
+import { logHookEvent } from "./claude-hook-plugin-log.js";
+import {
+	CodexHookLockBusyError,
+	codexHookLockTtlSeconds,
+	drainCodexHookSpool,
+	hasCodexHookSpooledEntries,
+	recoverStaleCodexHookTmpSpool,
+	spoolCodexHookPayload,
+	withCodexHookIngestLock,
+} from "./codex-hook-ingest-spool.js";
+
+type IngestVia = "http" | "direct" | "spool" | "spool_lock_busy";
+type IngestResult = { inserted: number; skipped: number; via: IngestVia };
+type IngestOpts = { host: string; port: string | number } & DbOpts;
+
+type IngestDeps = {
+	httpIngest?: typeof tryHttpIngest;
+	directIngest?: typeof directEnqueueCodexHook;
+	resolveDb?: typeof resolveDbPath;
+};
+
+// Codex hooks run under a tight wrapper budget (see plugins/codex/scripts/
+// ingest-hook.mjs, which kills the CLI after ~2s), so the HTTP enqueue attempt
+// uses a short 1s default rather than Claude's 5s. Override with
+// CODEMEM_CODEX_HOOK_HTTP_TIMEOUT_MS if a slower viewer needs more headroom.
+const DEFAULT_HTTP_TIMEOUT_MS = 1000;
+
+function httpTimeoutMs(): number {
+	const parsed = Number.parseInt(process.env.CODEMEM_CODEX_HOOK_HTTP_TIMEOUT_MS ?? "", 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_HTTP_TIMEOUT_MS;
+}
+
+function emitStructuredError(errorCode: string, message: string): void {
+	console.log(JSON.stringify({ error: errorCode, message }));
+	process.exitCode = 1;
+}
+
+function envTruthyValue(value: string | undefined): boolean {
+	const normalized = String(value ?? "")
+		.trim()
+		.toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function hasPayloadTimestamp(payload: Record<string, unknown>): boolean {
+	return (
+		(typeof payload.timestamp === "string" && payload.timestamp.trim() !== "") ||
+		(typeof payload.ts === "string" && payload.ts.trim() !== "")
+	);
+}
+
+function normalizePayloadForIngest(payload: Record<string, unknown>): Record<string, unknown> {
+	if (hasPayloadTimestamp(payload)) return payload;
+	return {
+		...payload,
+		timestamp: new Date().toISOString(),
+		codemem_generated_event_nonce: randomUUID(),
+	};
+}
+
+async function tryHttpIngest(
+	payload: Record<string, unknown>,
+	host: string,
+	port: number,
+): Promise<{ ok: boolean; inserted: number; skipped: number }> {
+	const url = `http://${host}:${port}/api/codex-hooks`;
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), httpTimeoutMs());
+	try {
+		const res = await fetch(url, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(payload),
+			signal: controller.signal,
+		});
+		if (!res.ok) return { ok: false, inserted: 0, skipped: 0 };
+
+		const body = (await res.json()) as unknown;
+		if (body == null || typeof body !== "object" || Array.isArray(body)) {
+			logHookEvent("codemem codex-hook-ingest HTTP accepted with invalid response type");
+			return { ok: false, inserted: 0, skipped: 0 };
+		}
+		const obj = body as Record<string, unknown>;
+		if (typeof obj.inserted !== "number" || typeof obj.skipped !== "number") {
+			logHookEvent("codemem codex-hook-ingest HTTP accepted with unexpected response body");
+			return { ok: false, inserted: 0, skipped: 0 };
+		}
+		return { ok: true, inserted: obj.inserted, skipped: obj.skipped };
+	} catch {
+		return { ok: false, inserted: 0, skipped: 0 };
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+export function directEnqueueCodexHook(
+	payload: Record<string, unknown>,
+	dbPath: string,
+): { inserted: number; skipped: number } {
+	const envelope = buildRawEventEnvelopeFromCodexHook(payload);
+	if (!envelope) return { inserted: 0, skipped: 1 };
+
+	const db = connect(dbPath);
+	try {
+		try {
+			loadSqliteVec(db);
+		} catch {
+			// sqlite-vec is not required for raw-event enqueue.
+		}
+		ensureSchemaBootstrapped(db);
+		const strippedPayload = stripPrivateObj(envelope.payload) as Record<string, unknown>;
+		const existing = db
+			.prepare(
+				"SELECT 1 FROM raw_events WHERE source = ? AND stream_id = ? AND event_id = ? LIMIT 1",
+			)
+			.get(envelope.source, envelope.session_stream_id, envelope.event_id);
+		if (existing) return { inserted: 0, skipped: 0 };
+
+		// Seed event_seq from a -1 base so a fresh stream's first event is 0,
+		// matching store.recordRawEvent (which increments the session's
+		// last_received_event_seq default of -1). This keeps the direct-fallback
+		// path and the /api/codex-hooks HTTP path on the same sequence base so
+		// maintenance status math does not over/under-count for new streams.
+		db.prepare(
+			`INSERT INTO raw_events(
+				source, stream_id, opencode_session_id, event_id, event_seq,
+				event_type, ts_wall_ms, payload_json, created_at
+			) VALUES (?, ?, ?, ?, (
+				SELECT COALESCE(MAX(event_seq), -1) + 1
+				FROM raw_events WHERE source = ? AND stream_id = ?
+			), ?, ?, ?, datetime('now'))`,
+		).run(
+			envelope.source,
+			envelope.session_stream_id,
+			envelope.opencode_session_id,
+			envelope.event_id,
+			envelope.source,
+			envelope.session_stream_id,
+			envelope.event_type,
+			envelope.ts_wall_ms,
+			JSON.stringify(strippedPayload),
+		);
+
+		const maxSeqRow = db
+			.prepare(
+				"SELECT COALESCE(MAX(event_seq), 0) AS max_seq FROM raw_events WHERE source = ? AND stream_id = ?",
+			)
+			.get(envelope.source, envelope.session_stream_id) as { max_seq: number };
+
+		db.prepare(
+			`INSERT INTO raw_event_sessions(
+				source, stream_id, opencode_session_id, cwd, project, started_at,
+				last_seen_ts_wall_ms, last_received_event_seq, last_flushed_event_seq, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, -1, datetime('now'))
+			ON CONFLICT(source, stream_id) DO UPDATE SET
+				cwd = COALESCE(excluded.cwd, cwd),
+				project = COALESCE(excluded.project, project),
+				started_at = COALESCE(excluded.started_at, started_at),
+				last_seen_ts_wall_ms = MAX(COALESCE(excluded.last_seen_ts_wall_ms, 0), COALESCE(last_seen_ts_wall_ms, 0)),
+				last_received_event_seq = MAX(excluded.last_received_event_seq, last_received_event_seq),
+				updated_at = datetime('now')`,
+		).run(
+			envelope.source,
+			envelope.session_stream_id,
+			envelope.opencode_session_id,
+			envelope.cwd,
+			envelope.project,
+			envelope.started_at,
+			envelope.ts_wall_ms,
+			maxSeqRow.max_seq,
+		);
+
+		return { inserted: 1, skipped: 0 };
+	} finally {
+		db.close();
+	}
+}
+
+export async function ingestCodexHookPayload(
+	payload: Record<string, unknown>,
+	opts: IngestOpts,
+	deps: IngestDeps = {},
+): Promise<IngestResult> {
+	const httpIngest = deps.httpIngest ?? tryHttpIngest;
+	const directIngest = deps.directIngest ?? directEnqueueCodexHook;
+	const resolveDb = deps.resolveDb ?? resolveDbPath;
+	const port = typeof opts.port === "number" ? opts.port : Number.parseInt(opts.port, 10);
+	const ingestPayload = normalizePayloadForIngest(payload);
+	let cachedDbPath: string | null = null;
+	const getDbPath = (): string => {
+		if (cachedDbPath === null) cachedDbPath = resolveDb(resolveDbOpt(opts));
+		return cachedDbPath;
+	};
+	const tryDirectFallback = (queuedPayload: Record<string, unknown>): boolean => {
+		try {
+			directIngest(queuedPayload, getDbPath());
+			return true;
+		} catch (err) {
+			logHookEvent(
+				`codemem codex-hook-ingest direct fallback failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
+			return false;
+		}
+	};
+	const drainBacklogIfPresent = async (): Promise<void> => {
+		if (!hasCodexHookSpooledEntries()) return;
+		try {
+			await withCodexHookIngestLock(async () => {
+				recoverStaleCodexHookTmpSpool(codexHookLockTtlSeconds());
+				await drainCodexHookSpool(async (queuedPayload) => {
+					const queuedHttp = await httpIngest(queuedPayload, opts.host, port);
+					return queuedHttp.ok || tryDirectFallback(queuedPayload);
+				});
+			});
+		} catch (err) {
+			if (err instanceof CodexHookLockBusyError) return;
+			logHookEvent(
+				`codemem codex-hook-ingest backlog drain failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	};
+
+	const httpResult = await httpIngest(ingestPayload, opts.host, port);
+	if (httpResult.ok) {
+		await drainBacklogIfPresent();
+		return { inserted: httpResult.inserted, skipped: httpResult.skipped, via: "http" };
+	}
+
+	try {
+		return await withCodexHookIngestLock(async () => {
+			recoverStaleCodexHookTmpSpool(codexHookLockTtlSeconds());
+
+			// Make the current payload durable first so a slow backlog drain
+			// can never strand the live event under the hook timeout budget.
+			let currentResult: IngestResult;
+			try {
+				const result = directIngest(ingestPayload, getDbPath());
+				currentResult = { ...result, via: "direct" as const };
+			} catch (err) {
+				logHookEvent(
+					`codemem codex-hook-ingest direct fallback failed: ${err instanceof Error ? err.message : String(err)}`,
+				);
+				if (!spoolCodexHookPayload(ingestPayload)) {
+					throw new Error("codex-hook-ingest: fallback and spool both failed");
+				}
+				currentResult = { inserted: 0, skipped: 0, via: "spool" as const };
+			}
+
+			// Now drain any previously spooled payloads under the lock. Use the
+			// local direct path only: the live HTTP attempt just failed, so a
+			// downed viewer must not consume the hook budget on repeated HTTP
+			// timeouts. The HTTP-success path drains via HTTP when the viewer is
+			// reachable again.
+			await drainCodexHookSpool((queuedPayload) => tryDirectFallback(queuedPayload));
+
+			return currentResult;
+		});
+	} catch (err) {
+		if (!(err instanceof CodexHookLockBusyError)) throw err;
+		logHookEvent("codemem codex-hook-ingest lock busy; trying unlocked fallback");
+		try {
+			const result = directIngest(ingestPayload, getDbPath());
+			return { ...result, via: "direct" };
+		} catch (directErr) {
+			logHookEvent(
+				`codemem codex-hook-ingest unlocked direct fallback failed: ${directErr instanceof Error ? directErr.message : String(directErr)}`,
+			);
+		}
+		if (spoolCodexHookPayload(ingestPayload)) {
+			return { inserted: 0, skipped: 0, via: "spool_lock_busy" };
+		}
+		throw err;
+	}
+}
+
+const codexHookCmd = new Command("codex-hook-ingest")
+	.configureHelp(helpStyle)
+	.description("Ingest Codex hook payload: HTTP first, direct DB fallback");
+
+addDbOption(codexHookCmd);
+addViewerHostOptions(codexHookCmd);
+
+export const codexHookIngestCommand = codexHookCmd.action(
+	async (opts: DbOpts & { host: string; port: string }) => {
+		if (envTruthyValue(process.env.CODEMEM_PLUGIN_IGNORE)) return;
+
+		let raw: string;
+		try {
+			raw = readFileSync(0, "utf8").trim();
+		} catch {
+			emitStructuredError("read_error", "failed to read stdin");
+			return;
+		}
+		if (!raw) {
+			emitStructuredError("read_error", "empty stdin");
+			return;
+		}
+
+		let payload: Record<string, unknown>;
+		try {
+			const parsed = JSON.parse(raw) as unknown;
+			if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+				emitStructuredError("parse_error", "payload must be a JSON object");
+				return;
+			}
+			payload = parsed as Record<string, unknown>;
+		} catch {
+			emitStructuredError("parse_error", "invalid JSON");
+			return;
+		}
+
+		try {
+			const result = await ingestCodexHookPayload(payload, opts);
+			console.log(JSON.stringify(result));
+		} catch (err) {
+			emitStructuredError("ingest_error", err instanceof Error ? err.message : String(err));
+		}
+	},
+);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import omelette from "omelette";
 import { claudeHookFileContextCommand } from "./commands/claude-hook-file-context.js";
 import { claudeHookIngestCommand } from "./commands/claude-hook-ingest.js";
 import { claudeHookInjectCommand } from "./commands/claude-hook-inject.js";
+import { codexHookIngestCommand } from "./commands/codex-hook-ingest.js";
 import { configCommand } from "./commands/config.js";
 import { coordinatorCommand } from "./commands/coordinator.js";
 import { dbCommand } from "./commands/db.js";
@@ -54,6 +55,7 @@ completion.on("command", ({ reply }) => {
 		"claude-hook-file-context",
 		"claude-hook-inject",
 		"claude-hook-ingest",
+		"codex-hook-ingest",
 		"config",
 		"coordinator",
 		"db",
@@ -177,6 +179,7 @@ program.addCommand(mcpCommand);
 program.addCommand(claudeHookInjectCommand);
 program.addCommand(claudeHookIngestCommand);
 program.addCommand(claudeHookFileContextCommand);
+program.addCommand(codexHookIngestCommand);
 program.addCommand(dbCommand);
 program.addCommand(exportMemoriesCommand);
 program.addCommand(importMemoriesCommand);

--- a/plugins/codex/scripts/ingest-hook.mjs
+++ b/plugins/codex/scripts/ingest-hook.mjs
@@ -1,10 +1,106 @@
 import process from "node:process";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { randomInt, randomUUID } from "node:crypto";
 
 async function readStdin() {
+  const chunks = [];
   for await (const chunk of process.stdin) {
-    // Drain stdin so Codex can close the hook process cleanly.
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+let payload = await readStdin();
+if (!payload.trim()) {
+  process.exit(0);
+}
+
+function normalizePayloadText(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return raw;
+    const hasTimestamp =
+      (typeof parsed.timestamp === "string" && parsed.timestamp.trim() !== "") ||
+      (typeof parsed.ts === "string" && parsed.ts.trim() !== "");
+    if (hasTimestamp) return raw;
+    return JSON.stringify({
+      ...parsed,
+      timestamp: new Date().toISOString(),
+      codemem_generated_event_nonce: randomUUID()
+    });
+  } catch {
+    return raw;
   }
 }
 
-await readStdin();
+payload = normalizePayloadText(payload);
+let spooled = false;
+
+if (["1", "true", "yes", "on"].includes((process.env.CODEMEM_PLUGIN_IGNORE ?? "").toLowerCase())) {
+  process.exit(0);
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const pluginRoot = process.env.PLUGIN_ROOT || process.env.CLAUDE_PLUGIN_ROOT || dirname(scriptDir);
+
+function resolvePinnedVersion() {
+  try {
+    const manifest = JSON.parse(readFileSync(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"));
+    return typeof manifest.version === "string" && manifest.version.trim() ? manifest.version.trim() : "latest";
+  } catch {
+    return "latest";
+  }
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    input: payload,
+    encoding: "utf8",
+    stdio: ["pipe", "ignore", "ignore"],
+    timeout: 2000
+  });
+  return result.status === 0;
+}
+
+function expandHome(value) {
+  if (value === "~") return homedir();
+  if (value.startsWith("~/")) return join(homedir(), value.slice(2));
+  return value;
+}
+
+function spoolPayload() {
+  if (spooled) return;
+  try {
+    const dir = expandHome(process.env.CODEMEM_CODEX_HOOK_SPOOL_DIR?.trim() || "~/.codemem/codex-hook-spool");
+    mkdirSync(dir, { recursive: true });
+    const tmpPath = join(dir, `.hook-tmp-${process.pid}-${Date.now()}-${randomInt(1000, 10000)}.json`);
+    const finalPath = join(dir, `hook-${Math.floor(Date.now() / 1000)}-${process.pid}-${randomInt(1000, 10000)}.json`);
+    writeFileSync(tmpPath, payload, "utf8");
+    renameSync(tmpPath, finalPath);
+    spooled = true;
+  } catch {
+    // Best-effort last resort only.
+  }
+}
+
+if (run("codemem", ["codex-hook-ingest"])) {
+  process.exit(0);
+}
+
+// If the package-manager fallback cold-starts or gets killed by Codex's hook
+// timeout, this payload is already durable. A later drain deduplicates it if
+// the fallback succeeds too.
+spoolPayload();
+
+if (run("npx", ["-y", `codemem@${resolvePinnedVersion()}`, "codex-hook-ingest"])) {
+  process.exit(0);
+}
+
+// Hook ingestion is best-effort. Never fail the active Codex session because
+// the local CLI or npm fallback is unavailable.
+spoolPayload();
 process.exit(0);

--- a/plugins/codex/scripts/user-prompt-hook.mjs
+++ b/plugins/codex/scripts/user-prompt-hook.mjs
@@ -1,4 +1,10 @@
 import process from "node:process";
+import { spawn } from "node:child_process";
+import { randomInt, randomUUID } from "node:crypto";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 async function readStdin() {
   const chunks = [];
@@ -10,6 +16,43 @@ async function readStdin() {
 
 function printContinue(extra = {}) {
   process.stdout.write(JSON.stringify({ continue: true, ...extra }));
+}
+
+function normalizePayloadText(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return raw;
+    const hasTimestamp =
+      (typeof parsed.timestamp === "string" && parsed.timestamp.trim() !== "") ||
+      (typeof parsed.ts === "string" && parsed.ts.trim() !== "");
+    if (hasTimestamp) return raw;
+    return JSON.stringify({
+      ...parsed,
+      timestamp: new Date().toISOString(),
+      codemem_generated_event_nonce: randomUUID()
+    });
+  } catch {
+    return raw;
+  }
+}
+
+function expandHome(value) {
+  if (value === "~") return homedir();
+  if (value.startsWith("~/")) return join(homedir(), value.slice(2));
+  return value;
+}
+
+function spoolPayload(raw) {
+  try {
+    const dir = expandHome(process.env.CODEMEM_CODEX_HOOK_SPOOL_DIR?.trim() || "~/.codemem/codex-hook-spool");
+    mkdirSync(dir, { recursive: true });
+    const tmpPath = join(dir, `.hook-tmp-${process.pid}-${Date.now()}-${randomInt(1000, 10000)}.json`);
+    const finalPath = join(dir, `hook-${Math.floor(Date.now() / 1000)}-${process.pid}-${randomInt(1000, 10000)}.json`);
+    writeFileSync(tmpPath, normalizePayloadText(raw), "utf8");
+    renameSync(tmpPath, finalPath);
+  } catch {
+    // Best-effort last resort only.
+  }
 }
 
 const payload = await readStdin();
@@ -33,4 +76,19 @@ if (["1", "true", "yes", "on"].includes((process.env.CODEMEM_CODEX_PLUGIN_SMOKE 
   process.exit(0);
 }
 
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+try {
+  const child = spawn(process.execPath, [join(scriptDir, "ingest-hook.mjs")], {
+    detached: true,
+    stdio: ["pipe", "ignore", "ignore"],
+    env: process.env
+  });
+  child.stdin.end(payload);
+  child.unref();
+} catch {
+  spoolPayload(payload);
+}
+
+// Context injection lands in codemem codex-hook-inject; until then, keep the
+// prompt path non-blocking and stdout-clean.
 printContinue();


### PR DESCRIPTION
## Description
Adds `codemem codex-hook-ingest` plus the durable fallback path for Codex hooks: HTTP first, direct DB enqueue, Codex-specific lock/spool fallback, timestamp/nonce normalization, and wrapper-level last-resort spooling. Also documents the Codex ingest env controls.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, targeted Vitest)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run: `pnpm exec vitest run packages/core/src/codex-hooks.test.ts packages/cli/src/commands/codex-hook-ingest.test.ts`; `pnpm run tsc`; `node --check plugins/codex/scripts/*.mjs`; CLI fallback smoke returned `{ "inserted": 1, "skipped": 0, "via": "direct" }`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced