### PR TITLE
feat(codex): add prompt injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | | `codemem mcp http` | Local Streamable HTTP MCP server (`POST /mcp`, loopback-only by default) |
 | | `codemem claude-hook-ingest` | Claude hook event ingestion (stdin) |
 | | `codemem codex-hook-ingest` | Codex hook event ingestion (stdin, experimental) |
+| | `codemem codex-hook-inject` | Codex prompt-time memory injection (stdin, experimental) |
 
 Run `codemem --help` for the full list. Legacy top-level aliases (`export-memories`, `import-memories`, `show`, `forget`, `remember`) still work but are hidden from help.
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -73,6 +73,39 @@ For Claude hooks, project resolution precedence is:
 
 `PreToolUse` is intentionally deferred in the default template. Current memory extraction uses `PostToolUse` / `PostToolUseFailure` (`tool_result`) as the shipped Claude tool signal.
 
+## Codex integration (experimental)
+
+The Codex plugin uses the same shared raw-event pipeline as Claude and OpenCode. It is packaged under `plugins/codex/` with `.codex-plugin/plugin.json`, bundled `.mcp.json`, and hook scripts under `plugins/codex/scripts/`.
+
+Codex hook ingestion is HTTP enqueue-first (`POST /api/codex-hooks`) with a CLI fallback chain:
+
+- `codemem codex-hook-ingest` — direct local DB enqueue when the viewer API is unavailable.
+- When both HTTP and direct enqueue fail, the payload is written to a Codex-specific on-disk spool (`~/.codemem/codex-hook-spool`) and drained on a later invocation.
+
+```bash
+printf '%s\n' '{"hook_event_name":"SessionStart","session_id":"codex-1","cwd":"/tmp/demo"}' | codemem codex-hook-ingest
+```
+
+`UserPromptSubmit` runs `scripts/user-prompt-hook.mjs`, which:
+- sends the hook payload into capture ingest (`ingest-hook.mjs`) in the background, and
+- returns `hookSpecificOutput.additionalContext` from `codemem codex-hook-inject` for prompt-time memory injection.
+
+Prompt-time Codex injection uses local pack generation first and falls back to `/api/pack` only when local generation fails and `CODEMEM_INJECT_HTTP_FALLBACK` is enabled. It honors the same injection controls as Claude: `CODEMEM_INJECT_CONTEXT`, `CODEMEM_INJECT_LIMIT`, `CODEMEM_INJECT_TOKEN_BUDGET`, `CODEMEM_INJECT_MAX_CHARS`, and `CODEMEM_INJECT_HTTP_MAX_TIME_S`. Hook failures always emit `{"continue": true}` so Codex sessions are never blocked.
+
+```bash
+printf '%s\n' '{"hook_event_name":"UserPromptSubmit","session_id":"codex-1","prompt":"what did we change","cwd":"/tmp/demo"}' | codemem codex-hook-inject
+```
+
+For Codex hooks, project resolution precedence matches the Claude hook path:
+
+1. `CODEMEM_PROJECT` (if set)
+2. repo/cwd-derived project name
+3. payload `project` fallback (only when cwd is unavailable)
+
+`Stop` events map the inline `last_assistant_message` when present, and fall back to the last assistant message in `transcript_path` so final responses are captured even when the inline field is omitted.
+
+The packaged Codex template registers `SessionStart`, `UserPromptSubmit`, `PostToolUse`, and `Stop` in `plugins/codex/hooks/hooks.json`. Codex support is experimental; see `docs/plans/2026-05-28-codex-first-class-integration.md` for the rollout plan and validation gates.
+
 ## Post-restart config sanity checklist
 
 After restarting OpenCode or the viewer, run this quick check when behavior looks off:

--- a/packages/cli/src/commands/codex-hook-inject.test.ts
+++ b/packages/cli/src/commands/codex-hook-inject.test.ts
@@ -1,0 +1,216 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	buildCodexHookInjection,
+	type CodexPackResult,
+	codexHookInjectCommand,
+} from "./codex-hook-inject.js";
+
+const pack = (packText: string, items = 0, packTokens = 0): CodexPackResult => ({
+	packText,
+	items,
+	packTokens,
+});
+
+describe("codex-hook-inject command", () => {
+	let tempDir: string;
+	let pluginLogPath: string;
+	let originalPluginLogPath: string | undefined;
+
+	beforeEach(() => {
+		originalPluginLogPath = process.env.CODEMEM_PLUGIN_LOG_PATH;
+		tempDir = mkdtempSync(join(tmpdir(), "codemem-cli-codex-inject-"));
+		pluginLogPath = join(tempDir, "plugin.log");
+		process.env.CODEMEM_PLUGIN_LOG_PATH = pluginLogPath;
+	});
+
+	afterEach(() => {
+		if (originalPluginLogPath === undefined) delete process.env.CODEMEM_PLUGIN_LOG_PATH;
+		else process.env.CODEMEM_PLUGIN_LOG_PATH = originalPluginLogPath;
+		for (const key of [
+			"CODEMEM_INJECT_CONTEXT",
+			"CODEMEM_INJECT_MAX_CHARS",
+			"CODEMEM_INJECT_HTTP_FALLBACK",
+			"CODEMEM_INJECT_HTTP_MAX_TIME_S",
+			"CODEMEM_PLUGIN_IGNORE",
+		]) {
+			delete process.env[key];
+		}
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("registers expected options and help text", () => {
+		const longs = codexHookInjectCommand.options.map((option) => option.long);
+		expect(longs).toContain("--db");
+		expect(longs).toContain("--db-path");
+		expect(codexHookInjectCommand.helpInformation()).toContain("additionalContext");
+	});
+
+	it("returns Codex additionalContext when local pack succeeds", async () => {
+		const result = await buildCodexHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "codex-session",
+				prompt: "fix auth callback",
+				cwd: "/tmp/codemem",
+				project: "codemem",
+			},
+			{},
+			{
+				buildLocalPack: async (context, project, dbPath) => {
+					expect(context).toBe("fix auth callback codemem");
+					expect(project).toBe("codemem");
+					expect(dbPath).toBe("/tmp/test.sqlite");
+					return pack("## Summary\n[1] (decision) Auth fix", 1, 42);
+				},
+				httpPack: async () => {
+					throw new Error("http fallback should not run");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				hookEventName: "UserPromptSubmit",
+				additionalContext: "## Summary\n[1] (decision) Auth fix",
+			},
+		});
+	});
+
+	it("falls back to HTTP when local pack fails", async () => {
+		process.env.CODEMEM_INJECT_HTTP_FALLBACK = "1";
+		process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S = "7";
+		const result = await buildCodexHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "codex-session",
+				prompt: "continue sync work",
+				cwd: "/tmp/codemem",
+				project: "codemem",
+			},
+			{},
+			{
+				buildLocalPack: async () => {
+					throw new Error("local failed");
+				},
+				httpPack: async (context, project, maxTimeMs) => {
+					expect(context).toBe("continue sync work codemem");
+					expect(project).toBe("codemem");
+					expect(maxTimeMs).toBe(7000);
+					return pack("## Timeline\n[4] (feature) Sync continuation", 1, 53);
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result.hookSpecificOutput?.additionalContext).toBe(
+			"## Timeline\n[4] (feature) Sync continuation",
+		);
+	});
+
+	it("returns continue without additionalContext for empty prompts", async () => {
+		const result = await buildCodexHookInjection(
+			{ hook_event_name: "UserPromptSubmit", session_id: "codex-session", prompt: "   " },
+			{},
+			{
+				buildLocalPack: async () => {
+					throw new Error("should not build local pack");
+				},
+				httpPack: async () => {
+					throw new Error("should not call http fallback");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result).toEqual({ continue: true });
+	});
+
+	it("respects CODEMEM_INJECT_CONTEXT=0", async () => {
+		process.env.CODEMEM_INJECT_CONTEXT = "0";
+		const result = await buildCodexHookInjection(
+			{ hook_event_name: "UserPromptSubmit", session_id: "codex-session", prompt: "fix auth" },
+			{},
+			{
+				buildLocalPack: async () => {
+					throw new Error("should not build local pack");
+				},
+				httpPack: async () => {
+					throw new Error("should not call http fallback");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result).toEqual({ continue: true });
+	});
+
+	it("truncates additionalContext to CODEMEM_INJECT_MAX_CHARS", async () => {
+		process.env.CODEMEM_INJECT_MAX_CHARS = "12";
+		const result = await buildCodexHookInjection(
+			{ hook_event_name: "UserPromptSubmit", session_id: "codex-session", prompt: "viewer cards" },
+			{},
+			{
+				buildLocalPack: async () => pack("12345678901234567890"),
+				httpPack: async () => pack(""),
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result.hookSpecificOutput?.additionalContext).toBe("123456789012\n\n[pack truncated]");
+	});
+
+	it("continues when all pack generation paths fail", async () => {
+		process.env.CODEMEM_INJECT_HTTP_FALLBACK = "1";
+		const result = await buildCodexHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "codex-session",
+				prompt: "oauth follow-up",
+			},
+			{},
+			{
+				buildLocalPack: async () => {
+					throw new Error("local failed");
+				},
+				httpPack: async () => pack(""),
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result).toEqual({ continue: true });
+	});
+
+	it("logs Codex injection metrics", async () => {
+		await buildCodexHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "codex-session",
+				prompt: "ship the feature",
+				cwd: "/tmp/codemem",
+				project: "codemem",
+			},
+			{},
+			{
+				buildLocalPack: async () => pack("## Summary\nmemory pack body", 4, 137),
+				httpPack: async () => {
+					throw new Error("http fallback should not run");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		const log = readFileSync(pluginLogPath, "utf8");
+		const line = log.trim().split("\n").pop() ?? "";
+		expect(line).toContain("inject.pack.ok");
+		expect(line).toContain("source=codex");
+		expect(line).toContain("origin=local");
+		expect(line).toContain("items=4");
+		expect(line).toContain("pack_tokens=137");
+		expect(line).toContain('project="codemem"');
+	});
+});

--- a/packages/cli/src/commands/codex-hook-inject.ts
+++ b/packages/cli/src/commands/codex-hook-inject.ts
@@ -1,0 +1,253 @@
+import { MemoryStore, resolveDbPath, resolveHookProject } from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
+import { logHookEvent } from "./claude-hook-plugin-log.js";
+import { normalizePromptText } from "./claude-hook-session-state.js";
+
+type InjectResult = {
+	continue: true;
+	hookSpecificOutput?: {
+		hookEventName: "UserPromptSubmit";
+		additionalContext: string;
+	};
+};
+
+export type CodexPackResult = {
+	packText: string;
+	items: number;
+	packTokens: number;
+};
+
+type HttpPackResponse = {
+	pack_text?: string;
+	items?: unknown;
+	metrics?: { pack_tokens?: unknown };
+};
+
+type InjectDeps = {
+	buildLocalPack?: typeof buildLocalPack;
+	httpPack?: typeof tryHttpPack;
+	resolveDb?: typeof resolveDbPath;
+};
+
+const HOOK_EVENT_NAME = "UserPromptSubmit" as const;
+const EMPTY_PACK: CodexPackResult = { packText: "", items: 0, packTokens: 0 };
+const DEFAULT_VIEWER_HOST = "127.0.0.1";
+const DEFAULT_VIEWER_PORT = 38888;
+const DEFAULT_MAX_CHARS = 16000;
+const DEFAULT_HTTP_MAX_TIME_S = 2;
+
+function emitJson(value: InjectResult): void {
+	console.log(JSON.stringify(value));
+}
+
+function emitError(value: { error: string; message: string }): void {
+	process.stderr.write(`${JSON.stringify(value)}\n`);
+}
+
+function envNotDisabled(value: string | undefined): boolean {
+	const normalized = String(value ?? "")
+		.trim()
+		.toLowerCase();
+	return normalized !== "0" && normalized !== "false" && normalized !== "off";
+}
+
+function envTruthy(value: string | undefined): boolean {
+	const normalized = String(value ?? "")
+		.trim()
+		.toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+	const parsed = Number.parseInt(String(value ?? ""), 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function continueResult(additionalContext?: string): InjectResult {
+	if (!additionalContext) return { continue: true };
+	return {
+		continue: true,
+		hookSpecificOutput: {
+			hookEventName: HOOK_EVENT_NAME,
+			additionalContext,
+		},
+	};
+}
+
+function truncateAdditionalContext(text: string, maxChars: number): string {
+	const normalized = text.trim();
+	if (!normalized) return "";
+	if (!Number.isFinite(maxChars) || maxChars <= 0 || normalized.length <= maxChars) {
+		return normalized;
+	}
+	return `${normalized.slice(0, maxChars).trimEnd()}\n\n[pack truncated]`;
+}
+
+function resolveInjectProject(payload: Record<string, unknown>): string | null {
+	const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
+	return resolveHookProject(cwd, payload.project);
+}
+
+// Codex injection intentionally uses a simpler query than the Claude path:
+// just the current prompt plus project. Claude's first/last-prompt and
+// working-set-file enrichment depends on the Claude hook session-state tracker,
+// which Codex does not maintain. Keep this lean unless a Codex session-state
+// store is added; don't copy the Claude working-set machinery back in by reflex.
+function buildCodexInjectQuery(prompt: string, project: string | null): string {
+	const parts = [prompt, project ?? ""].filter((part) => part.trim().length > 0);
+	return parts.join(" ").slice(0, 500) || "recent work";
+}
+
+async function buildLocalPack(
+	context: string,
+	project: string | null,
+	dbPath: string,
+): Promise<CodexPackResult> {
+	const store = new MemoryStore(dbPath);
+	try {
+		const limit = parsePositiveInt(process.env.CODEMEM_INJECT_LIMIT, 8);
+		const budget = parsePositiveInt(process.env.CODEMEM_INJECT_TOKEN_BUDGET, 800);
+		const filters: { project?: string } = {};
+		if (project) filters.project = project;
+		const pack = await store.buildMemoryPackAsync(context, limit, budget, filters);
+		return {
+			packText: String(pack.pack_text ?? "").trim(),
+			items: Array.isArray(pack.items) ? pack.items.length : 0,
+			packTokens: Number.isFinite(Number(pack.metrics?.pack_tokens))
+				? Number(pack.metrics?.pack_tokens)
+				: 0,
+		};
+	} finally {
+		store.close();
+	}
+}
+
+async function tryHttpPack(
+	context: string,
+	project: string | null,
+	maxTimeMs = DEFAULT_HTTP_MAX_TIME_S * 1000,
+): Promise<CodexPackResult> {
+	const host = process.env.CODEMEM_VIEWER_HOST || DEFAULT_VIEWER_HOST;
+	const port = parsePositiveInt(process.env.CODEMEM_VIEWER_PORT, DEFAULT_VIEWER_PORT);
+	const url = new URL(`http://${host}:${port}/api/pack`);
+	url.searchParams.set("context", context);
+	url.searchParams.set("limit", String(parsePositiveInt(process.env.CODEMEM_INJECT_LIMIT, 8)));
+	url.searchParams.set(
+		"token_budget",
+		String(parsePositiveInt(process.env.CODEMEM_INJECT_TOKEN_BUDGET, 800)),
+	);
+	if (project) url.searchParams.set("project", project);
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), maxTimeMs);
+	try {
+		const res = await fetch(url, { signal: controller.signal });
+		if (!res.ok) return EMPTY_PACK;
+		const body = (await res.json()) as HttpPackResponse;
+		return {
+			packText: String(body.pack_text ?? "").trim(),
+			items: Array.isArray(body.items) ? body.items.length : 0,
+			packTokens: Number.isFinite(Number(body.metrics?.pack_tokens))
+				? Number(body.metrics?.pack_tokens)
+				: 0,
+		};
+	} catch {
+		return EMPTY_PACK;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+export async function buildCodexHookInjection(
+	payload: Record<string, unknown>,
+	opts: DbOpts,
+	deps: InjectDeps = {},
+): Promise<InjectResult> {
+	if (envTruthy(process.env.CODEMEM_PLUGIN_IGNORE)) return continueResult();
+	if (!envNotDisabled(process.env.CODEMEM_INJECT_CONTEXT || "1")) return continueResult();
+
+	const promptText = normalizePromptText(payload.prompt);
+	if (!promptText) return continueResult();
+
+	const buildPack = deps.buildLocalPack ?? buildLocalPack;
+	const httpPack = deps.httpPack ?? tryHttpPack;
+	const resolveDb = deps.resolveDb ?? resolveDbPath;
+	const project = resolveInjectProject(payload);
+	const query = buildCodexInjectQuery(promptText, project);
+	const maxChars = parsePositiveInt(process.env.CODEMEM_INJECT_MAX_CHARS, DEFAULT_MAX_CHARS);
+	const httpMaxTimeMs =
+		parsePositiveInt(process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S, DEFAULT_HTTP_MAX_TIME_S) * 1000;
+
+	let pack: CodexPackResult = EMPTY_PACK;
+	let origin: "local" | "http" | "none" = "none";
+	try {
+		pack = await buildPack(query, project, resolveDb(resolveDbOpt(opts)));
+		if (pack.packText) origin = "local";
+	} catch (err) {
+		logHookEvent(
+			`codemem codex-hook-inject local pack failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
+
+	if (!pack.packText && envNotDisabled(process.env.CODEMEM_INJECT_HTTP_FALLBACK || "1")) {
+		pack = await httpPack(query, project, httpMaxTimeMs);
+		if (pack.packText) origin = "http";
+	}
+
+	const fields = [
+		"inject.pack.ok",
+		"source=codex",
+		`origin=${origin}`,
+		`items=${pack.items}`,
+		`pack_tokens=${pack.packTokens}`,
+		`query_len=${query.length}`,
+		`empty=${pack.packText ? "false" : "true"}`,
+	];
+	if (project) fields.push(`project=${JSON.stringify(project)}`);
+	logHookEvent(fields.join(" "));
+
+	return continueResult(truncateAdditionalContext(pack.packText, maxChars));
+}
+
+const codexHookInjectCmd = new Command("codex-hook-inject")
+	.configureHelp(helpStyle)
+	.description("Return Codex hook additionalContext from local pack generation");
+
+addDbOption(codexHookInjectCmd);
+
+export const codexHookInjectCommand = codexHookInjectCmd.action(async (opts: DbOpts) => {
+	let raw = "";
+	for await (const chunk of process.stdin) raw += String(chunk);
+	const trimmed = raw.trim();
+	if (!trimmed) {
+		emitJson(continueResult());
+		return;
+	}
+
+	let payload: Record<string, unknown>;
+	try {
+		const parsed = JSON.parse(trimmed) as unknown;
+		if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			emitError({ error: "parse_error", message: "payload must be a JSON object" });
+			process.exitCode = 1;
+			return;
+		}
+		payload = parsed as Record<string, unknown>;
+	} catch {
+		emitError({ error: "parse_error", message: "invalid JSON" });
+		process.exitCode = 1;
+		return;
+	}
+
+	try {
+		const result = await buildCodexHookInjection(payload, opts);
+		emitJson(result);
+	} catch (err) {
+		logHookEvent(
+			`codemem codex-hook-inject failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		emitJson(continueResult());
+	}
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ import { claudeHookFileContextCommand } from "./commands/claude-hook-file-contex
 import { claudeHookIngestCommand } from "./commands/claude-hook-ingest.js";
 import { claudeHookInjectCommand } from "./commands/claude-hook-inject.js";
 import { codexHookIngestCommand } from "./commands/codex-hook-ingest.js";
+import { codexHookInjectCommand } from "./commands/codex-hook-inject.js";
 import { configCommand } from "./commands/config.js";
 import { coordinatorCommand } from "./commands/coordinator.js";
 import { dbCommand } from "./commands/db.js";
@@ -55,6 +56,7 @@ completion.on("command", ({ reply }) => {
 		"claude-hook-file-context",
 		"claude-hook-inject",
 		"claude-hook-ingest",
+		"codex-hook-inject",
 		"codex-hook-ingest",
 		"config",
 		"coordinator",
@@ -179,6 +181,7 @@ program.addCommand(mcpCommand);
 program.addCommand(claudeHookInjectCommand);
 program.addCommand(claudeHookIngestCommand);
 program.addCommand(claudeHookFileContextCommand);
+program.addCommand(codexHookInjectCommand);
 program.addCommand(codexHookIngestCommand);
 program.addCommand(dbCommand);
 program.addCommand(exportMemoriesCommand);

--- a/plugins/codex/scripts/user-prompt-hook.mjs
+++ b/plugins/codex/scripts/user-prompt-hook.mjs
@@ -1,7 +1,7 @@
 import process from "node:process";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { randomInt, randomUUID } from "node:crypto";
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,6 +16,15 @@ async function readStdin() {
 
 function printContinue(extra = {}) {
   process.stdout.write(JSON.stringify({ continue: true, ...extra }));
+}
+
+function readPinnedVersion(pluginRoot) {
+  try {
+    const manifest = JSON.parse(readFileSync(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"));
+    return typeof manifest.version === "string" && manifest.version.trim() ? manifest.version.trim() : "latest";
+  } catch {
+    return "latest";
+  }
 }
 
 function normalizePayloadText(raw) {
@@ -77,6 +86,7 @@ if (["1", "true", "yes", "on"].includes((process.env.CODEMEM_CODEX_PLUGIN_SMOKE 
 }
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
+const pluginRoot = process.env.PLUGIN_ROOT || process.env.CLAUDE_PLUGIN_ROOT || dirname(scriptDir);
 try {
   const child = spawn(process.execPath, [join(scriptDir, "ingest-hook.mjs")], {
     detached: true,
@@ -89,6 +99,31 @@ try {
   spoolPayload(payload);
 }
 
-// Context injection lands in codemem codex-hook-inject; until then, keep the
-// prompt path non-blocking and stdout-clean.
-printContinue();
+function runInject(command, args, timeout) {
+  const result = spawnSync(command, args, {
+    input: payload,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "ignore"],
+    timeout
+  });
+  if (result.status !== 0) return null;
+  const stdout = String(result.stdout ?? "").trim();
+  if (!stdout) return null;
+  try {
+    const parsed = JSON.parse(stdout);
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+const injected =
+  runInject("codemem", ["codex-hook-inject"], 2500) ??
+  runInject("npx", ["-y", `codemem@${readPinnedVersion(pluginRoot)}`, "codex-hook-inject"], 1500);
+
+if (injected) {
+  process.stdout.write(JSON.stringify(injected));
+} else {
+  printContinue();
+}


### PR DESCRIPTION
## Description
Adds `codemem codex-hook-inject` and wires the Codex `UserPromptSubmit` hook to return `hookSpecificOutput.additionalContext` from local memory-pack generation, with HTTP fallback and failure-safe `continue` behavior.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, targeted Vitest)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run: `pnpm exec vitest run packages/cli/src/commands/codex-hook-inject.test.ts packages/cli/src/commands/codex-hook-ingest.test.ts packages/core/src/codex-hooks.test.ts`; `pnpm run tsc`; `node --check plugins/codex/scripts/*.mjs`; CLI injection smoke returned Codex `continue` JSON with `additionalContext`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced