### PR TITLE
docs(codex): document early-beta Codex plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ Claude hook events share the same raw-event queue pipeline used by OpenCode. `Us
 capture ingest in the background and injects memory context via Claude `additionalContext` using
 local pack generation by default, with optional HTTP `/api/pack` fallback.
 
+### Codex (early beta)
+
+Codex support is **early beta** — functional and dogfooded, but not yet promoted to a stable support tier. It installs through Codex's own plugin marketplace; there is no `codemem setup` step.
+
+1. Add the codemem marketplace and install the plugin:
+
+```text
+codex plugin marketplace add https://github.com/kunickiaj/codemem.git
+codex plugin add codemem@codemem
+```
+
+2. Restart Codex.
+
+The Codex plugin bundles its MCP config (`codemem mcp`) and hooks. Hooks call `codemem` from your `PATH` and fall back to `npx -y codemem@<version>`, so a global install is optional (installing `codemem` globally reduces hook latency). Validated targets are Codex CLI 0.135+ and current Desktop builds.
+
+Codex hook ingestion shares the same raw-event pipeline as Claude and OpenCode: HTTP enqueue-first (`POST /api/codex-hooks`), then `codemem codex-hook-ingest` direct enqueue, with a Codex-specific spool fallback. `UserPromptSubmit` runs capture ingest in the background and injects memory context via `additionalContext`; disable injection with `CODEMEM_INJECT_CONTEXT=0`. See [docs/plugin-reference.md](docs/plugin-reference.md) for details and troubleshooting.
+
 > Migrating from `opencode-mem`? See [docs/rename-migration.md](docs/rename-migration.md).
 
 ## How it works

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,7 @@ Support tiers describe operational expectations for each adapter path:
 |---|---|---|
 | OpenCode plugin | Supported | Primary reference adapter for lifecycle events and injection behavior. |
 | Claude hooks/plugin | Supported | Hook-first queue path with CLI/runtime fallback and parity slices tracked in adapter stack PRs. |
-| Codex shell integration | Experimental | Planned as adapter-native ingestion path; no user-facing support contract yet. |
+| Codex plugin (hooks + MCP) | Experimental (early beta) | Functional capture pipeline (`plugins/codex/`, `packages/core/src/codex-hooks.ts`) dogfooded end-to-end: hooks → `POST /api/codex-hooks` → observer → memories. Prompt-time injection present and env-gated but not fully validated on strict models. Not yet promoted to a stable support tier. |
 | Windsurf integration | Experimental | Planned via shared adapter contract after OpenCode/Claude stabilization. |
 | Cursor integration | Experimental | Planned via shared adapter contract after OpenCode/Claude stabilization. |
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -73,9 +73,9 @@ For Claude hooks, project resolution precedence is:
 
 `PreToolUse` is intentionally deferred in the default template. Current memory extraction uses `PostToolUse` / `PostToolUseFailure` (`tool_result`) as the shipped Claude tool signal.
 
-## Codex integration (experimental)
+## Codex integration (early beta)
 
-The Codex plugin uses the same shared raw-event pipeline as Claude and OpenCode. It is packaged under `plugins/codex/` with `.codex-plugin/plugin.json`, bundled `.mcp.json`, and hook scripts under `plugins/codex/scripts/`.
+Codex support is early beta — functional and dogfooded end-to-end, but not yet promoted to a stable support tier. The Codex plugin uses the same shared raw-event pipeline as Claude and OpenCode. It is packaged under `plugins/codex/` with `.codex-plugin/plugin.json`, bundled `.mcp.json`, and hook scripts under `plugins/codex/scripts/`.
 
 Codex hook ingestion is HTTP enqueue-first (`POST /api/codex-hooks`) with a CLI fallback chain:
 
@@ -104,7 +104,30 @@ For Codex hooks, project resolution precedence matches the Claude hook path:
 
 `Stop` events map the inline `last_assistant_message` when present, and fall back to the last assistant message in `transcript_path` so final responses are captured even when the inline field is omitted.
 
-The packaged Codex template registers `SessionStart`, `UserPromptSubmit`, `PostToolUse`, and `Stop` in `plugins/codex/hooks/hooks.json`. Codex support is experimental; see `docs/plans/2026-05-28-codex-first-class-integration.md` for the rollout plan and validation gates.
+The packaged Codex template registers `SessionStart`, `UserPromptSubmit`, `PostToolUse`, and `Stop` in `plugins/codex/hooks/hooks.json`. Codex support is early beta; see `docs/plans/2026-05-28-codex-first-class-integration.md` for the rollout plan and validation gates.
+
+### Install, update, and uninstall
+
+Install through Codex's own plugin marketplace — there is no `codemem setup` step:
+
+```bash
+codex plugin marketplace add https://github.com/kunickiaj/codemem.git
+codex plugin add codemem@codemem
+# refresh the marketplace snapshot later:
+codex plugin marketplace upgrade
+# remove:
+codex plugin remove codemem@codemem
+```
+
+The plugin bundles `.mcp.json` (`npx -y codemem mcp`) and `hooks/hooks.json`. Hook scripts call `codemem` from `PATH` and fall back to `npx -y codemem@<plugin version>`, so a global CLI is optional but reduces hook latency. Validated targets: Codex CLI 0.135+ and current Desktop builds.
+
+### Troubleshooting
+
+- **No memories and no raw events captured.** Confirm the `codemem` the hooks resolve actually has the Codex commands: `codemem codex-hook-ingest </dev/null` should print a structured `{"error":"read_error",...}`, not `unknown command`. The Codex commands are first published in codemem 0.35.0; the `0.34.0` release on npm predates them, so an older global install (or the `npx -y codemem@<plugin version>` fallback while the plugin manifest still pins a pre-0.35 version) silently fails and spools. Inspect the backlog at `~/.codemem/codex-hook-spool/` and the plugin log at `~/.codemem/plugin.log`.
+- **`database locked` in the plugin log / payloads spooling.** The direct-DB fallback lost the writer lock (the viewer or maintenance worker held it). Keep the viewer running and current — it owns the single writer and serves `POST /api/codex-hooks`, so HTTP enqueue avoids cross-process lock contention.
+- **`POST /api/codex-hooks` returns 404.** The running viewer predates Codex support; restart or upgrade it to a build that serves the route.
+- **Spool backlog drains automatically** on the next successful ingest; force it by piping any spooled payload back through `codemem codex-hook-ingest` while the viewer is up.
+- **A model rejects injected context** (for example "the conversation must end with a user message"): disable prompt-time injection with `CODEMEM_INJECT_CONTEXT=0`. Capture/ingest keeps working and recall is still available through the MCP tools.
 
 ## Post-restart config sanity checklist
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -28,6 +28,7 @@ Version bumps are prepared on a release branch and touch these files:
 - `packages/opencode-plugin/.opencode/plugins/codemem.js` (`PINNED_BACKEND_VERSION`)
 - `.claude-plugin/marketplace.json` (marketplace metadata version and codemem plugin entry version)
 - `plugins/claude/.claude-plugin/plugin.json` (Claude plugin metadata version)
+- `plugins/codex/.codex-plugin/plugin.json` (Codex plugin metadata version; also pins the `npx -y codemem@<version>` fallback used by Codex hook scripts)
 
 Use the release version helper to verify or apply the bump:
 


### PR DESCRIPTION
## Description
User-facing documentation for the Codex integration ahead of the 0.35 release. Codex capture (hooks -> `POST /api/codex-hooks` -> observer -> memories) and automatic prompt-time injection (`UserPromptSubmit` -> `codex-hook-inject` -> `additionalContext`) were dogfooded; this documents Codex as **early beta**. MCP tools are documented as a complementary on-demand recall path, not the primary one. Docs only — no behavior change.

- **README**: new "Codex (early beta)" quick start using the Codex plugin marketplace flow (`codex plugin marketplace add` / `codex plugin add codemem@codemem`); no `codemem setup` step. Notes automatic injection via `additionalContext`, PATH vs `npx` fallback, and `CODEMEM_INJECT_CONTEXT`.
- **docs/architecture.md**: support-matrix row updated to "Codex plugin (hooks + MCP) — Experimental (early beta)".
- **docs/plugin-reference.md**: reframed the Codex section as early beta; added Install/update/uninstall and Troubleshooting subsections (missing CLI command, `database locked`/spooling, 404 route, backlog drain, injection rejection).
- **docs/versioning.md**: list `plugins/codex/.codex-plugin/plugin.json` in the version-sync set.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Docs-only; verified commands/paths against the live install and plugin scripts
- [ ] Added/updated tests for changes
- [x] Manually verified the documented Codex install/ingest/inject flow on this machine

## Checklist

- [x] Code follows project style (docs are outside Biome scope)
- [x] Self-review completed
- [x] Documentation updated (this PR)
- [x] No new warnings introduced
