### PR TITLE
chore(release): bump version to 0.35.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.34.0"
+    "version": "0.35.0"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.34.0";
+const PINNED_BACKEND_VERSION = "0.35.0";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.34.0",
+	"version": "0.35.0",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.34.0",
+	"version": "0.35.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.34.0");
+		expect(VERSION).toBe("0.35.0");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.34.0";
+export const VERSION = "0.35.0";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.34.0",
+	"version": "0.35.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.34.0";
+const PINNED_BACKEND_VERSION = "0.35.0";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.34.0",
+	"version": "0.35.0",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.34.0",
+	"version": "0.35.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "author": {
     "name": "Adam Kunicki"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codemem",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Persistent memory for Codex. Capture work across sessions and recall relevant context.",
   "author": {
     "name": "Adam Kunicki"
@@ -8,7 +8,12 @@
   "repository": "https://github.com/kunickiaj/codemem",
   "homepage": "https://github.com/kunickiaj/codemem",
   "license": "MIT",
-  "keywords": ["codemem", "memory", "codex", "mcp"],
+  "keywords": [
+    "codemem",
+    "memory",
+    "codex",
+    "mcp"
+  ],
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",
   "interface": {
@@ -17,9 +22,13 @@
     "longDescription": "Capture Codex session context across projects and recall relevant memories through hooks and MCP tools.",
     "developerName": "Adam Kunicki",
     "category": "Engineering",
-    "capabilities": ["Read"],
+    "capabilities": [
+      "Read"
+    ],
     "websiteURL": "https://github.com/kunickiaj/codemem",
-    "defaultPrompt": ["Recall relevant codemem context for this repo."],
+    "defaultPrompt": [
+      "Recall relevant codemem context for this repo."
+    ],
     "brandColor": "#4F46E5",
     "screenshots": []
   }


### PR DESCRIPTION
## Description
Release **0.35.0**. Bumps all workspace packages, plugin manifests, and pinned backend versions from `0.34.0` to `0.35.0` via `pnpm run release:version -- set 0.35.0` (12 files, including `plugins/codex/.codex-plugin/plugin.json`, which pins the Codex hook `npx -y codemem@<version>` fallback).

Headline: **first-class (early-beta) Codex support.**
- Codex plugin (hooks + bundled MCP) for capture and prompt-time injection via `UserPromptSubmit` (#1218–#1221).
- `codex_sidecar` observer runtime (#1225): Codex / ChatGPT Pro users get memory extraction with **no API key** — auth delegated to the local `codex` CLI; tier routing via `-m`; recursion-safe; respects configured file/command auth before auto-selecting.
- Docs: early-beta Codex install/troubleshooting + observer auth modes (#1224); dead skill removed + lowercased branding (#1223).

Publishing the codex commands in 0.35.0 is what makes `npx -y codemem@0.35.0 codex-hook-*` resolve for everyone (the published 0.34.0 predates them).

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (release / version bump)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm run tsc` clean
- [x] `pnpm run lint` clean (468 files)
- [x] `pnpm run test` — 2249/2249 pass
- [x] `pnpm build` clean; `pnpm run release:version -- check` → aligned at 0.35.0

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (Codex docs landed in #1224)
- [x] No new warnings introduced
- [ ] Tag `v0.35.0` to be pushed on the merged `main` commit (triggers publish) — pending explicit go-ahead
