### PR TITLE
feat(codex): add `codemem setup --codex` for plugin-free install

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ local pack generation by default, with optional HTTP `/api/pack` fallback.
 
 ### Codex (early beta)
 
-Codex support is **early beta** — functional and dogfooded, but not yet promoted to a stable support tier. It installs through Codex's own plugin marketplace; there is no `codemem setup` step.
+Codex support is **early beta** — functional and dogfooded, but not yet promoted to a stable support tier. It installs through Codex's own plugin marketplace:
 
 1. Add the codemem marketplace and install the plugin:
 
@@ -90,6 +90,14 @@ codex plugin add codemem@codemem
 2. Restart Codex.
 
 The Codex plugin bundles its MCP config (`codemem mcp`) and hooks. Hooks call `codemem` from your `PATH` and fall back to `npx -y codemem@<version>`, so a global install is optional (installing `codemem` globally reduces hook latency). Validated targets are Codex CLI 0.135+ and current Desktop builds.
+
+**API-key Codex Desktop (marketplace unavailable):** When plugin installation is greyed out (non-subscription / API-key Desktop), configure codemem without the plugin surface:
+
+```text
+npx -y codemem setup --codex
+```
+
+This merges `[mcp_servers.codemem]` into `~/.codex/config.toml` and writes `~/.codex/hooks.json` (SessionStart, UserPromptSubmit, PostToolUse, Stop) — backing up existing files and preserving unrelated entries. Restart Codex and approve the one-time prompt to trust the codemem hooks. MCP recall works immediately. If `codemem` is on your `PATH` the hooks call it directly; otherwise they fall back to `npx -y codemem`. Honors `CODEX_HOME`; re-runnable (use `--force` to refresh).
 
 Codex hook ingestion shares the same raw-event pipeline as Claude and OpenCode: HTTP enqueue-first (`POST /api/codex-hooks`), then `codemem codex-hook-ingest` direct enqueue, with a Codex-specific spool fallback. `UserPromptSubmit` runs capture ingest in the background and injects memory context via `additionalContext`; disable injection with `CODEMEM_INJECT_CONTEXT=0`. See [docs/plugin-reference.md](docs/plugin-reference.md) for details and troubleshooting.
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -121,6 +121,21 @@ codex plugin remove codemem@codemem
 
 The plugin bundles `.mcp.json` (`npx -y codemem mcp`) and `hooks/hooks.json`. Hook scripts call `codemem` from `PATH` and fall back to `npx -y codemem@<plugin version>`, so a global CLI is optional but reduces hook latency. Validated targets: Codex CLI 0.135+ and current Desktop builds.
 
+### Plugin-free install (`codemem setup --codex`)
+
+API-key / non-subscription Codex Desktop greys out plugin installation. For that case, configure Codex directly — no marketplace, no plugin:
+
+```bash
+npx -y codemem setup --codex   # or: codemem setup --codex (or --codex-only)
+```
+
+What it does (idempotent; honors `CODEX_HOME`; backs up existing files; `--force` to refresh):
+
+- **MCP:** appends `[mcp_servers.codemem]` (`command = "npx"`, `args = ["-y", "codemem", "mcp"]`) to `<CODEX_HOME>/config.toml` if not already present. The file is never reparsed or reformatted — only appended — so comments and unrelated servers (including secrets) are preserved.
+- **Hooks:** merges `SessionStart`, `UserPromptSubmit` (ingest + inject), `PostToolUse`, and `Stop` into `<CODEX_HOME>/hooks.json`, preserving any unrelated user hooks. Hook commands resolve to a direct `codemem codex-hook-*` call when `codemem` is on `PATH`, otherwise `npx -y codemem codex-hook-*`.
+
+Hooks loaded from the user config layer require a one-time trust approval in Codex (you'll be prompted on first run; MCP recall needs no trust). `setup --codex` also runs automatically in a plain `codemem setup` when a Codex home (`~/.codex` or `$CODEX_HOME`) is detected.
+
 ### Troubleshooting
 
 - **No memories and no raw events captured.** Confirm the `codemem` the hooks resolve actually has the Codex commands: `codemem codex-hook-ingest </dev/null` should print a structured `{"error":"read_error",...}`, not `unknown command`. The Codex commands are first published in codemem 0.35.0; the `0.34.0` release on npm predates them, so an older global install (or the `npx -y codemem@<plugin version>` fallback while the plugin manifest still pins a pre-0.35 version) silently fails and spools. Inspect the backlog at `~/.codemem/codex-hook-spool/` and the plugin log at `~/.codemem/plugin.log`.

--- a/packages/cli/src/commands/setup-codex.test.ts
+++ b/packages/cli/src/commands/setup-codex.test.ts
@@ -1,0 +1,387 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	buildCodememCodexHookGroups,
+	codememCodexHookBase,
+	codexConfigDir,
+	installCodex,
+	isTransientNpxBinPath,
+	setupCommand,
+} from "./setup.js";
+
+// Resolve the same command base the implementation will use in this environment
+// (direct `codemem` when on PATH, else `npx -y codemem`) so integration
+// assertions are deterministic across dev and CI.
+const HOOK_BASE = codememCodexHookBase();
+const INGEST_CMD = `${HOOK_BASE} codex-hook-ingest`;
+const INJECT_CMD = `${HOOK_BASE} codex-hook-inject`;
+const INGEST_TIMEOUT = HOOK_BASE === "codemem" ? 10 : 30;
+const INJECT_TIMEOUT = HOOK_BASE === "codemem" ? 10 : 20;
+
+const savedCodexHome = process.env.CODEX_HOME;
+let codexHome: string;
+
+beforeEach(() => {
+	codexHome = mkdtempSync(join(tmpdir(), "codemem-setup-codex-"));
+	process.env.CODEX_HOME = codexHome;
+});
+
+afterEach(() => {
+	if (savedCodexHome === undefined) delete process.env.CODEX_HOME;
+	else process.env.CODEX_HOME = savedCodexHome;
+	rmSync(codexHome, { recursive: true, force: true });
+});
+
+interface CodexHookCommand {
+	type: string;
+	command: string;
+	timeout: number;
+	statusMessage: string;
+}
+
+interface CodexHookGroup {
+	hooks: CodexHookCommand[];
+}
+
+function readHooks(): Record<string, CodexHookGroup[]> {
+	const raw = readFileSync(join(codexHome, "hooks.json"), "utf-8");
+	return (JSON.parse(raw) as { hooks: Record<string, CodexHookGroup[]> }).hooks;
+}
+
+function groupsFor(hooks: Record<string, CodexHookGroup[]>, event: string): CodexHookGroup[] {
+	const groups = hooks[event];
+	if (!groups) throw new Error(`expected hook groups for ${event}`);
+	return groups;
+}
+
+function readConfigToml(): string {
+	return readFileSync(join(codexHome, "config.toml"), "utf-8");
+}
+
+describe("codexConfigDir", () => {
+	it("honors CODEX_HOME", () => {
+		expect(codexConfigDir()).toBe(codexHome);
+	});
+});
+
+describe("installCodex — fresh CODEX_HOME", () => {
+	it("writes the MCP block and all four hook events with correct schema", () => {
+		expect(installCodex(false)).toBe(true);
+
+		const toml = readConfigToml();
+		expect(toml).toContain("[mcp_servers.codemem]");
+		expect(toml).toContain('command = "npx"');
+		expect(toml).toContain('args = ["-y", "codemem", "mcp"]');
+		expect(toml).toContain("startup_timeout_sec = 30");
+		expect(toml).toContain("tool_timeout_sec = 60");
+
+		const hooks = readHooks();
+		expect(Object.keys(hooks).sort()).toEqual([
+			"PostToolUse",
+			"SessionStart",
+			"Stop",
+			"UserPromptSubmit",
+		]);
+
+		// Single-ingest events.
+		for (const event of ["SessionStart", "PostToolUse", "Stop"]) {
+			const groups = groupsFor(hooks, event);
+			expect(groups).toHaveLength(1);
+			const group = groups[0];
+			if (!group) throw new Error(`missing group for ${event}`);
+			expect(group.hooks).toHaveLength(1);
+			expect(group.hooks[0]).toEqual({
+				type: "command",
+				command: INGEST_CMD,
+				timeout: INGEST_TIMEOUT,
+				statusMessage: "codemem",
+			});
+		}
+
+		// UserPromptSubmit has BOTH ingest then inject, in order.
+		const ups = groupsFor(hooks, "UserPromptSubmit");
+		expect(ups).toHaveLength(1);
+		const upsGroup = ups[0];
+		if (!upsGroup) throw new Error("missing UserPromptSubmit group");
+		expect(upsGroup.hooks).toHaveLength(2);
+		expect(upsGroup.hooks[0]).toEqual({
+			type: "command",
+			command: INGEST_CMD,
+			timeout: INGEST_TIMEOUT,
+			statusMessage: "codemem capture",
+		});
+		expect(upsGroup.hooks[1]).toEqual({
+			type: "command",
+			command: INJECT_CMD,
+			timeout: INJECT_TIMEOUT,
+			statusMessage: "codemem recall",
+		});
+	});
+
+	it("creates CODEX_HOME if it does not yet exist", () => {
+		const nested = join(codexHome, "nested", "codex");
+		process.env.CODEX_HOME = nested;
+		expect(existsSync(nested)).toBe(false);
+
+		expect(installCodex(false)).toBe(true);
+
+		expect(existsSync(join(nested, "config.toml"))).toBe(true);
+		expect(existsSync(join(nested, "hooks.json"))).toBe(true);
+	});
+});
+
+describe("installCodex — idempotency", () => {
+	it("does not duplicate the MCP block or hook entries on re-run", () => {
+		expect(installCodex(false)).toBe(true);
+		expect(installCodex(false)).toBe(true);
+
+		const toml = readConfigToml();
+		const mcpOccurrences = toml.split("[mcp_servers.codemem]").length - 1;
+		expect(mcpOccurrences).toBe(1);
+
+		const hooks = readHooks();
+		expect(groupsFor(hooks, "SessionStart")).toHaveLength(1);
+		expect(groupsFor(hooks, "PostToolUse")).toHaveLength(1);
+		expect(groupsFor(hooks, "Stop")).toHaveLength(1);
+		const ups = groupsFor(hooks, "UserPromptSubmit");
+		expect(ups).toHaveLength(1);
+		expect(ups[0]?.hooks).toHaveLength(2);
+	});
+
+	it("does not duplicate codemem hooks when run again with --force", () => {
+		expect(installCodex(false)).toBe(true);
+		expect(installCodex(true)).toBe(true);
+
+		const hooks = readHooks();
+		expect(groupsFor(hooks, "SessionStart")).toHaveLength(1);
+		const ups = groupsFor(hooks, "UserPromptSubmit");
+		expect(ups).toHaveLength(1);
+		expect(ups[0]?.hooks).toHaveLength(2);
+	});
+});
+
+describe("installCodex — non-destructive merge", () => {
+	it("preserves unrelated config.toml content (comments + other MCP servers)", () => {
+		const original = [
+			"# my codex config",
+			"",
+			"[mcp_servers.other]",
+			'command = "other-cmd"',
+			"",
+		].join("\n");
+		writeFileSync(join(codexHome, "config.toml"), original, "utf-8");
+
+		expect(installCodex(false)).toBe(true);
+
+		const toml = readConfigToml();
+		expect(toml).toContain("# my codex config");
+		expect(toml).toContain("[mcp_servers.other]");
+		expect(toml).toContain('command = "other-cmd"');
+		expect(toml).toContain("[mcp_servers.codemem]");
+	});
+
+	it("preserves an unrelated user SessionStart hook and adds the codemem hook", () => {
+		const existing = {
+			hooks: {
+				SessionStart: [
+					{
+						hooks: [
+							{
+								type: "command",
+								command: "echo user-hook",
+								timeout: 10,
+								statusMessage: "user",
+							},
+						],
+					},
+				],
+			},
+		};
+		writeFileSync(join(codexHome, "hooks.json"), `${JSON.stringify(existing, null, 2)}\n`, "utf-8");
+
+		expect(installCodex(false)).toBe(true);
+
+		const hooks = readHooks();
+		const sessionStart = groupsFor(hooks, "SessionStart");
+		expect(sessionStart).toHaveLength(2);
+		const commands = sessionStart.flatMap((g) => g.hooks.map((h) => h.command));
+		expect(commands).toContain("echo user-hook");
+		expect(commands).toContain(INGEST_CMD);
+	});
+
+	it("--force preserves an unrelated user hook on the same event", () => {
+		const existing = {
+			hooks: {
+				UserPromptSubmit: [
+					{
+						hooks: [
+							{ type: "command", command: "echo user-ups", timeout: 10, statusMessage: "user" },
+						],
+					},
+				],
+			},
+		};
+		writeFileSync(join(codexHome, "hooks.json"), `${JSON.stringify(existing, null, 2)}\n`, "utf-8");
+
+		// Seed codemem hooks, then re-run with --force.
+		expect(installCodex(false)).toBe(true);
+		expect(installCodex(true)).toBe(true);
+
+		const hooks = readHooks();
+		const ups = groupsFor(hooks, "UserPromptSubmit");
+		const commands = ups.flatMap((g) => g.hooks.map((h) => h.command));
+		// Unrelated user hook survives; codemem hooks present exactly once.
+		expect(commands).toContain("echo user-ups");
+		expect(commands.filter((c) => c === INGEST_CMD)).toHaveLength(1);
+		expect(commands.filter((c) => c === INJECT_CMD)).toHaveLength(1);
+	});
+});
+
+describe("isTransientNpxBinPath", () => {
+	it("flags npx/dlx cache bins so they are not baked into hooks", () => {
+		expect(isTransientNpxBinPath("/Users/x/.npm/_npx/abc123/node_modules/.bin/codemem")).toBe(true);
+		expect(isTransientNpxBinPath("/tmp/.pnpm/dlx/abc/node_modules/.bin/codemem")).toBe(true);
+	});
+
+	it("treats durable global/managed bins as on-PATH", () => {
+		expect(isTransientNpxBinPath("/usr/local/bin/codemem")).toBe(false);
+		expect(isTransientNpxBinPath("/Users/x/.local/share/mise/installs/node/lts/bin/codemem")).toBe(
+			false,
+		);
+		expect(isTransientNpxBinPath("C\\\\Program Files\\\\nodejs\\\\codemem.cmd")).toBe(false);
+	});
+});
+
+describe("setup command options", () => {
+	it("declares both --codex and --codex-only", () => {
+		const longs = setupCommand.options.map((o) => o.long);
+		expect(longs).toContain("--codex");
+		expect(longs).toContain("--codex-only");
+	});
+});
+
+describe("buildCodememCodexHookGroups — command base", () => {
+	it("uses a direct `codemem` call with short timeouts when on PATH", () => {
+		const groups = buildCodememCodexHookGroups("codemem");
+		const ups = groups.UserPromptSubmit?.[0]?.hooks ?? [];
+		expect(ups[0]).toEqual({
+			type: "command",
+			command: "codemem codex-hook-ingest",
+			timeout: 10,
+			statusMessage: "codemem capture",
+		});
+		expect(ups[1]).toEqual({
+			type: "command",
+			command: "codemem codex-hook-inject",
+			timeout: 10,
+			statusMessage: "codemem recall",
+		});
+		expect(groups.SessionStart?.[0]?.hooks?.[0]?.command).toBe("codemem codex-hook-ingest");
+	});
+
+	it("uses `npx -y codemem` with generous timeouts as the fallback", () => {
+		const groups = buildCodememCodexHookGroups("npx -y codemem");
+		const ups = groups.UserPromptSubmit?.[0]?.hooks ?? [];
+		expect(ups[0]).toEqual({
+			type: "command",
+			command: "npx -y codemem codex-hook-ingest",
+			timeout: 30,
+			statusMessage: "codemem capture",
+		});
+		expect(ups[1]).toEqual({
+			type: "command",
+			command: "npx -y codemem codex-hook-inject",
+			timeout: 20,
+			statusMessage: "codemem recall",
+		});
+		expect(groups.Stop?.[0]?.hooks?.[0]?.command).toBe("npx -y codemem codex-hook-ingest");
+	});
+});
+
+describe("installCodex — config.toml MCP detection edge cases", () => {
+	it("does not treat a sibling [mcp_servers.codemem-foo] table as ours (appends our block)", () => {
+		writeFileSync(
+			join(codexHome, "config.toml"),
+			'[mcp_servers.codemem-foo]\ncommand = "x"\n',
+			"utf-8",
+		);
+
+		expect(installCodex(false)).toBe(true);
+
+		const toml = readConfigToml();
+		expect(toml).toContain("[mcp_servers.codemem-foo]");
+		// Our real block was appended (distinct from the sibling).
+		expect(toml.split("[mcp_servers.codemem]").length - 1).toBe(1);
+	});
+
+	it('detects a quoted [mcp_servers."codemem"] table and does not append a duplicate', () => {
+		writeFileSync(
+			join(codexHome, "config.toml"),
+			'[mcp_servers."codemem"]\ncommand = "npx"\n',
+			"utf-8",
+		);
+
+		expect(installCodex(false)).toBe(true);
+
+		const toml = readConfigToml();
+		// No unquoted duplicate appended.
+		expect(toml).not.toContain("[mcp_servers.codemem]\n");
+	});
+
+	it("tolerates whitespace inside the table header", () => {
+		writeFileSync(
+			join(codexHome, "config.toml"),
+			'[ mcp_servers . codemem ]\ncommand = "npx"\n',
+			"utf-8",
+		);
+
+		expect(installCodex(false)).toBe(true);
+
+		const toml = readConfigToml();
+		expect(toml.split("[mcp_servers.codemem]").length - 1).toBe(0);
+	});
+});
+
+describe("installCodex — malformed hooks.json", () => {
+	it("returns false and does not clobber an unparseable hooks.json", () => {
+		const broken = "{ this is not valid json ";
+		writeFileSync(join(codexHome, "hooks.json"), broken, "utf-8");
+
+		expect(installCodex(false)).toBe(false);
+		// File left untouched (no overwrite, no backup-then-replace).
+		expect(readFileSync(join(codexHome, "hooks.json"), "utf-8")).toBe(broken);
+	});
+});
+
+describe("installCodex — backups", () => {
+	it("backs up an existing config.toml before appending", () => {
+		const original = '[mcp_servers.other]\ncommand = "x"\n';
+		writeFileSync(join(codexHome, "config.toml"), original, "utf-8");
+
+		expect(installCodex(false)).toBe(true);
+
+		const backup = join(codexHome, "config.toml.codemem.bak");
+		expect(existsSync(backup)).toBe(true);
+		expect(readFileSync(backup, "utf-8")).toBe(original);
+	});
+
+	it("backs up an existing hooks.json before overwriting", () => {
+		const existing = {
+			hooks: {
+				SessionStart: [
+					{ hooks: [{ type: "command", command: "echo x", timeout: 1, statusMessage: "x" }] },
+				],
+			},
+		};
+		const serialized = `${JSON.stringify(existing, null, 2)}\n`;
+		writeFileSync(join(codexHome, "hooks.json"), serialized, "utf-8");
+
+		expect(installCodex(false)).toBe(true);
+
+		const backup = join(codexHome, "hooks.json.codemem.bak");
+		expect(existsSync(backup)).toBe(true);
+		expect(readFileSync(backup, "utf-8")).toBe(serialized);
+	});
+});

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -11,7 +11,8 @@
  * Designed to be safe to run repeatedly (idempotent unless --force).
  */
 
-import { existsSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
@@ -26,6 +27,11 @@ function opencodeConfigDir(): string {
 
 function claudeConfigDir(): string {
 	return join(homedir(), ".claude");
+}
+
+/** Resolve the Codex home directory, honoring CODEX_HOME. */
+export function codexConfigDir(): string {
+	return process.env.CODEX_HOME?.trim() || join(homedir(), ".codex");
 }
 
 /** The npm package name used in the OpenCode plugin array. */
@@ -289,33 +295,344 @@ function installClaudeMcp(force: boolean): boolean {
 	return true;
 }
 
+// ---------------------------------------------------------------------------
+// Codex install (direct config files — no marketplace plugin required)
+// ---------------------------------------------------------------------------
+
+/** The MCP server table appended to Codex config.toml. */
+const CODEX_MCP_BLOCK = [
+	"[mcp_servers.codemem]",
+	'command = "npx"',
+	'args = ["-y", "codemem", "mcp"]',
+	"startup_timeout_sec = 30",
+	"tool_timeout_sec = 60",
+].join("\n");
+
+// Detect an existing codemem MCP table in config.toml text. Tolerates TOML
+// whitespace around brackets/dots and a quoted key, and avoids false-matching
+// sibling tables like `[mcp_servers.codemem-foo]` (the optional quote is matched
+// symmetrically via the backreference, so `codemem` must be followed by `]`).
+const CODEX_MCP_TABLE_RE = /^[ \t]*\[[ \t]*mcp_servers[ \t]*\.[ \t]*("?)codemem\1[ \t]*\]/m;
+
+/** A single Codex command-hook entry. */
+interface CodexHookCommand {
+	type: "command";
+	command: string;
+	timeout: number;
+	statusMessage: string;
+}
+
+/** A matcher group containing an ordered list of command hooks. */
+interface CodexHookGroup {
+	hooks: CodexHookCommand[];
+}
+
+/** Marker substring identifying codemem-owned hook commands. */
+const CODEMEM_HOOK_MARKER = "codemem codex-hook-";
+
+/**
+ * Resolve how Codex hooks should invoke codemem. Prefer a direct `codemem` call
+ * when it's on PATH (fast — no per-hook resolution); fall back to `npx -y codemem`
+ * only when codemem isn't installed (e.g. setup was run via `npx codemem setup`),
+ * so capture/recall still work without a global install. Mirrors the plugin
+ * wrapper's `codemem`-first / `npx` fallback model.
+ */
+export function codememCodexHookBase(): string {
+	return codememOnPath() ? "codemem" : "npx -y codemem";
+}
+
+/**
+ * Build the codemem-owned hook groups keyed by Codex event name, given the
+ * resolved command base (`codemem` or `npx -y codemem`). Timeouts are ceilings,
+ * not expected runtimes; npx gets more headroom to absorb a cold resolve.
+ */
+export function buildCodememCodexHookGroups(base: string): Record<string, CodexHookGroup[]> {
+	const isNpx = base !== "codemem";
+	const ingestTimeout = isNpx ? 30 : 10;
+	const injectTimeout = isNpx ? 20 : 10;
+	const ingest: CodexHookCommand = {
+		type: "command",
+		command: `${base} codex-hook-ingest`,
+		timeout: ingestTimeout,
+		statusMessage: "codemem",
+	};
+	return {
+		SessionStart: [{ hooks: [{ ...ingest }] }],
+		UserPromptSubmit: [
+			{
+				hooks: [
+					{
+						type: "command",
+						command: `${base} codex-hook-ingest`,
+						timeout: ingestTimeout,
+						statusMessage: "codemem capture",
+					},
+					{
+						type: "command",
+						command: `${base} codex-hook-inject`,
+						timeout: injectTimeout,
+						statusMessage: "codemem recall",
+					},
+				],
+			},
+		],
+		PostToolUse: [{ hooks: [{ ...ingest }] }],
+		Stop: [{ hooks: [{ ...ingest }] }],
+	};
+}
+
+/** True if a matcher group contains a codemem-owned hook command. */
+function isCodememHookGroup(group: unknown): boolean {
+	if (group == null || typeof group !== "object") return false;
+	const hooks = (group as { hooks?: unknown }).hooks;
+	if (!Array.isArray(hooks)) return false;
+	return hooks.some(
+		(h) =>
+			h != null &&
+			typeof h === "object" &&
+			typeof (h as { command?: unknown }).command === "string" &&
+			(h as { command: string }).command.includes(CODEMEM_HOOK_MARKER),
+	);
+}
+
+/**
+ * True if a resolved bin path is a transient npx/dlx cache bin. When setup runs
+ * via `npx -y codemem setup --codex`, npx exposes this package's bin on PATH for
+ * the duration of the run, then removes it — so Codex would later fail to find a
+ * bare `codemem`. Such paths must NOT count as "on PATH" for hook command baking.
+ */
+export function isTransientNpxBinPath(resolved: string): boolean {
+	return /[/\\]_npx[/\\]/.test(resolved) || /[/\\]\.pnpm[/\\]dlx[/\\]/.test(resolved);
+}
+
+/**
+ * Detect whether a durable `codemem` resolves on PATH (excluding a transient
+ * npx/dlx bin that vanishes after this process exits).
+ */
+function codememOnPath(): boolean {
+	try {
+		const out = execFileSync(process.platform === "win32" ? "where" : "which", ["codemem"], {
+			encoding: "utf-8",
+		});
+		const resolved = out
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.find(Boolean);
+		if (!resolved) return false;
+		return !isTransientNpxBinPath(resolved);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Append the codemem MCP server table to Codex config.toml without rewriting
+ * unrelated content. Returns true on success.
+ */
+function installCodexMcp(codexHome: string, force: boolean): boolean {
+	const configPath = join(codexHome, "config.toml");
+	const existing = existsSync(configPath) ? readFileSync(configPath, "utf-8") : "";
+
+	if (CODEX_MCP_TABLE_RE.test(existing)) {
+		if (force) {
+			p.log.info(
+				`Codex MCP entry already exists in ${configPath} — left as-is (TOML is not rewritten in place)`,
+			);
+		} else {
+			p.log.info(`Codex MCP entry already exists in ${configPath}`);
+		}
+		return true;
+	}
+
+	// Back up an existing file before appending.
+	if (existsSync(configPath)) {
+		try {
+			copyFileSync(configPath, `${configPath}.codemem.bak`);
+		} catch {
+			// Non-fatal: continue without a backup rather than blocking install.
+		}
+	}
+
+	let next = existing;
+	if (next.length > 0 && !next.endsWith("\n\n")) {
+		next += next.endsWith("\n") ? "\n" : "\n\n";
+	}
+	next += `${CODEX_MCP_BLOCK}\n`;
+
+	try {
+		writeFileSync(configPath, next, "utf-8");
+		p.log.success(`Codex MCP entry installed: ${configPath}`);
+	} catch (err) {
+		p.log.error(
+			`Failed to write ${configPath}: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Write/merge codemem hook registrations into Codex hooks.json, preserving any
+ * unrelated user hooks. Returns true on success.
+ */
+function installCodexHooks(codexHome: string, force: boolean): boolean {
+	const hooksPath = join(codexHome, "hooks.json");
+
+	let config: Record<string, unknown> = {};
+	if (existsSync(hooksPath)) {
+		try {
+			config = JSON.parse(readFileSync(hooksPath, "utf-8")) as Record<string, unknown>;
+		} catch (err) {
+			p.log.error(
+				`Failed to parse ${hooksPath}: ${err instanceof Error ? err.message : String(err)}`,
+			);
+			p.log.info(
+				`Leaving ${hooksPath} untouched. Fix or remove the file, then re-run \`codemem setup --codex-only\`.`,
+			);
+			return false;
+		}
+	}
+
+	let hooks = config.hooks as Record<string, unknown> | undefined;
+	if (hooks == null || typeof hooks !== "object" || Array.isArray(hooks)) {
+		hooks = {};
+	}
+
+	const ours = buildCodememCodexHookGroups(codememCodexHookBase());
+	let changed = false;
+
+	for (const [event, ourGroups] of Object.entries(ours)) {
+		const current = hooks[event];
+		const existingGroups: unknown[] = Array.isArray(current) ? [...current] : [];
+		const hasCodemem = existingGroups.some(isCodememHookGroup);
+
+		if (hasCodemem && !force) {
+			// Already present — leave as-is (idempotent).
+			continue;
+		}
+
+		// Drop only codemem-owned groups; preserve unrelated user hooks.
+		const preserved = existingGroups.filter((g) => !isCodememHookGroup(g));
+		hooks[event] = [...preserved, ...ourGroups];
+		changed = true;
+	}
+
+	if (!changed && !force) {
+		p.log.info(`Codex hooks already configured in ${hooksPath}`);
+		config.hooks = hooks;
+		return true;
+	}
+
+	config.hooks = hooks;
+
+	// Back up an existing hooks.json before overwriting.
+	if (existsSync(hooksPath)) {
+		try {
+			copyFileSync(hooksPath, `${hooksPath}.codemem.bak`);
+		} catch {
+			// Non-fatal.
+		}
+	}
+
+	try {
+		mkdirSync(codexHome, { recursive: true });
+		writeFileSync(hooksPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+		p.log.success(`Codex hooks installed: ${hooksPath}`);
+	} catch (err) {
+		p.log.error(
+			`Failed to write ${hooksPath}: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Configure Codex via direct config files (MCP in config.toml + hooks in
+ * hooks.json) without relying on the Codex plugin marketplace. Idempotent;
+ * honors CODEX_HOME. Returns true on success.
+ */
+export function installCodex(force: boolean): boolean {
+	const codexHome = codexConfigDir();
+	try {
+		mkdirSync(codexHome, { recursive: true });
+	} catch (err) {
+		p.log.error(
+			`Failed to create Codex home ${codexHome}: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return false;
+	}
+
+	if (codememOnPath()) {
+		p.log.info("Codex hooks will call `codemem` directly (found on PATH).");
+	} else {
+		p.log.info(
+			"`codemem` is not on PATH, so Codex hooks will run via `npx -y codemem` (works without a global install). For lower hook latency: npm i -g codemem",
+		);
+	}
+
+	let ok = true;
+	ok = installCodexMcp(codexHome, force) && ok;
+	ok = installCodexHooks(codexHome, force) && ok;
+	return ok;
+}
+
 export const setupCommand = new Command("setup")
 	.configureHelp(helpStyle)
 	.description("Install codemem plugin + MCP config for OpenCode and Claude Code")
 	.option("--force", "overwrite existing installations")
 	.option("--opencode-only", "only install for OpenCode")
 	.option("--claude-only", "only install for Claude Code")
-	.action((opts: { force?: boolean; opencodeOnly?: boolean; claudeOnly?: boolean }) => {
-		p.intro(`codemem setup v${VERSION}`);
-		const force = opts.force ?? false;
-		let ok = true;
+	.option("--codex-only", "only install for Codex")
+	.option("--codex", "configure Codex only (alias for --codex-only)")
+	.action(
+		(opts: {
+			force?: boolean;
+			opencodeOnly?: boolean;
+			claudeOnly?: boolean;
+			codexOnly?: boolean;
+			codex?: boolean;
+		}) => {
+			p.intro(`codemem setup v${VERSION}`);
+			const force = opts.force ?? false;
+			let ok = true;
 
-		if (!opts.claudeOnly) {
-			p.log.step("Installing OpenCode plugin...");
-			ok = installPlugin(force) && ok;
-			p.log.step("Installing OpenCode MCP config...");
-			ok = installMcp(force) && ok;
-		}
+			// `--codex` is a documented alias for `--codex-only`.
+			const codexOnly = Boolean(opts.codexOnly || opts.codex);
+			const onlyFlag = Boolean(opts.opencodeOnly || opts.claudeOnly || codexOnly);
 
-		if (!opts.opencodeOnly) {
-			p.log.step("Installing Claude Code MCP config...");
-			ok = installClaudeMcp(force) && ok;
-		}
+			const doOpencode = opts.opencodeOnly || !onlyFlag;
+			const doClaude = opts.claudeOnly || !onlyFlag;
+			// With no only-flag, Codex runs only when a Codex home is detected.
+			const doCodex = codexOnly || (!onlyFlag && existsSync(codexConfigDir()));
 
-		if (ok) {
-			p.outro("Setup complete — restart your editor to load the plugin");
-		} else {
-			p.outro("Setup completed with warnings");
-			process.exitCode = 1;
-		}
-	});
+			if (doOpencode) {
+				p.log.step("Installing OpenCode plugin...");
+				ok = installPlugin(force) && ok;
+				p.log.step("Installing OpenCode MCP config...");
+				ok = installMcp(force) && ok;
+			}
+
+			if (doClaude) {
+				p.log.step("Installing Claude Code MCP config...");
+				ok = installClaudeMcp(force) && ok;
+			}
+
+			if (doCodex) {
+				p.log.step("Configuring Codex (MCP + hooks)...");
+				ok = installCodex(force) && ok;
+				p.log.info("Codex next steps:");
+				p.log.info("  - Restart Codex to load the new configuration");
+				p.log.info("  - On first run, approve the one-time prompt to trust the codemem hooks");
+				p.log.info("  - MCP recall works immediately (no trust prompt required)");
+				p.log.info("  - Disable prompt-time injection with CODEMEM_INJECT_CONTEXT=0");
+			}
+
+			if (ok) {
+				p.outro("Setup complete — restart your editor to load the plugin");
+			} else {
+				p.outro("Setup completed with warnings");
+				process.exitCode = 1;
+			}
+		},
+	);


### PR DESCRIPTION
## Description
Adds `codemem setup --codex` — a plugin-free way to configure Codex MCP + hooks by writing Codex's own config files. This unblocks **API-key / non-subscription Codex Desktop**, where the plugin marketplace (the normal install path) is greyed out.

What it does (idempotent; honors `CODEX_HOME`; backs up before changing; `--force` refreshes codemem-owned entries):
- **MCP:** appends `[mcp_servers.codemem]` (`command = "npx"`, `args = ["-y", "codemem", "mcp"]`) to `<CODEX_HOME>/config.toml` only when absent. The file is **never reparsed or reformatted** — only appended — so comments and unrelated servers (including secrets) are preserved. Detection uses a whitespace/quote-tolerant regex that won't false-match siblings like `[mcp_servers.codemem-foo]`.
- **Hooks:** merges `SessionStart`, `UserPromptSubmit` (ingest **and** inject), `PostToolUse`, `Stop` into `<CODEX_HOME>/hooks.json` (Codex's User-layer hooks file), preserving any unrelated user hooks.
- **Command resolution:** hooks call `codemem codex-hook-*` directly when `codemem` is on `PATH` (fast; timeouts 10s), else fall back to `npx -y codemem codex-hook-*` (timeouts 30/20 to absorb a cold npx). Mirrors the plugin wrapper's direct-first / npx-fallback model.
- Wiring: new `--codex-only`; a plain `codemem setup` also configures Codex when `~/.codex` (or `$CODEX_HOME`) is detected. OpenCode/Claude paths unchanged.

Hooks from the user config layer require a one-time trust approval in Codex (prompted on first run); MCP recall needs no trust.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm run tsc`, `pnpm run lint` (469 files), `pnpm run test` (2265 pass)
- [x] 16 unit tests in `setup-codex.test.ts`: fresh install schema, idempotency, non-destructive merge (config.toml comments/other servers + unrelated hooks), `--force` preserve-unrelated, backups, regex edge cases (`codemem-foo` not matched, quoted/whitespace matched), malformed-json no-clobber, direct vs npx command base
- [x] Real smoke against a temp `CODEX_HOME`: preserves existing config + appends MCP; writes hooks.json (UserPromptSubmit ingest+inject in order); resolves **direct** `codemem` commands when on PATH; idempotent re-run; backup created

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed + CodeReviewer pass (ship-blocker on command resolution addressed: direct-when-on-PATH + npx fallback)
- [x] Documentation updated (README + docs/plugin-reference.md plugin-free path)
- [x] No new warnings introduced
