### PR TITLE
chore(release): bump version to 0.35.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.35.0"
+    "version": "0.35.1"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.35.0",
+      "version": "0.35.1",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.35.0";
+const PINNED_BACKEND_VERSION = "0.35.1";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.35.0",
+	"version": "0.35.1",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.35.0",
+	"version": "0.35.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.35.0");
+		expect(VERSION).toBe("0.35.1");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.35.0";
+export const VERSION = "0.35.1";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.35.0",
+	"version": "0.35.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.35.0";
+const PINNED_BACKEND_VERSION = "0.35.1";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.35.0",
+	"version": "0.35.1",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.35.0",
+	"version": "0.35.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "author": {
     "name": "Adam Kunicki"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codemem",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Persistent memory for Codex. Capture work across sessions and recall relevant context.",
   "author": {
     "name": "Adam Kunicki"


### PR DESCRIPTION
## Description
Release **0.35.1**. Patch bumping all workspace packages, plugin manifests, and pinned backend versions `0.35.0 → 0.35.1` via `release:version` (12 files, incl. `plugins/codex/.codex-plugin/plugin.json`).

Headline: **`codemem setup --codex`** (#1227) — a plugin-free way to configure Codex MCP + hooks by writing `~/.codex/config.toml` (`[mcp_servers.codemem]`) and `~/.codex/hooks.json`. This unblocks **API-key / non-subscription Codex Desktop**, where the plugin marketplace is greyed out. Hooks resolve direct `codemem` when on PATH (ignoring transient npx bins), else `npx -y codemem`.

## Type of Change
- [ ] 🚀 Feature
- [ ] 🐛 Bug fix
- [ ] 📚 Documentation
- [x] 🔧 Maintenance (release / version bump)
- [ ] 🧪 Testing

## Testing
- [x] `pnpm run tsc`, `pnpm run lint` (469 files), `pnpm run test` (2268 pass)
- [x] `pnpm build` clean; `pnpm run release:version -- check` → aligned at 0.35.1

## Checklist
- [x] Self-review completed
- [x] Documentation updated (Codex docs landed in #1227)
- [x] No new warnings introduced
- [ ] Tag `v0.35.1` pushed on merged `main` (triggers publish) — after merge
