### PR TITLE
chore(release): bump version to 0.35.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.35.1"
+    "version": "0.35.2"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.35.1",
+      "version": "0.35.2",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.35.1";
+const PINNED_BACKEND_VERSION = "0.35.2";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.35.1",
+	"version": "0.35.2",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.35.1",
+	"version": "0.35.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.35.1");
+		expect(VERSION).toBe("0.35.2");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.35.1";
+export const VERSION = "0.35.2";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.35.1",
+	"version": "0.35.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.35.1";
+const PINNED_BACKEND_VERSION = "0.35.2";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.35.1",
+	"version": "0.35.2",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.35.1",
+	"version": "0.35.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "author": {
     "name": "Adam Kunicki"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codemem",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "Persistent memory for Codex. Capture work across sessions and recall relevant context.",
   "author": {
     "name": "Adam Kunicki"


### PR DESCRIPTION
## Description
Bumps codemem release version surfaces from `0.35.1` to `0.35.2` after the Codex hook-output and injection-framing fixes landed in #1229.

This prepares the patch release but does not tag or publish by itself. After merge, run the normal release tag preflight on merged `main` before creating `v0.35.2`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (covered downstack in #1229)
- [x] Manually verified changes work as expected (`pnpm run release:version -- check` reports 0.35.2)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
