### PR TITLE
chore: upgrade pnpm to 11.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912",
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
   "pnpm": {
     "strictPeerDependencies": false
   }


### PR DESCRIPTION
## Description

Bumps the `pnpm` package manager from version `11.0.8` to `11.5.0` with its updated integrity hash.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [ ] Code follows project style (`pnpm run lint` passes for touched files)
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No new warnings introduced