### PR TITLE
test(plugin): stabilize transform hook timers

### DIFF
--- a/packages/cli/.opencode/tests/plugin-transform-hook.test.js
+++ b/packages/cli/.opencode/tests/plugin-transform-hook.test.js
@@ -124,6 +124,10 @@ describe("experimental.chat.system.transform", () => {
 	const tmpDirs = [];
 
 	beforeEach(() => {
+		// The plugin schedules a delayed compatibility check that can emit its own
+		// toast if a slow pack command crosses the timer boundary. These tests only
+		// cover transform-time injection, so keep that background timer inert.
+		vi.useFakeTimers();
 		vi.resetModules();
 		spawnMock.mockReset();
 		execSyncMock.mockClear();
@@ -137,6 +141,8 @@ describe("experimental.chat.system.transform", () => {
 	});
 
 	afterEach(() => {
+		vi.clearAllTimers();
+		vi.useRealTimers();
 		for (const tmpDir of tmpDirs.splice(0)) {
 			rmSync(tmpDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Description
Stabilizes the OpenCode plugin transform-hook tests by enabling fake timers around the test case setup. The plugin schedules a delayed compatibility check that can emit an unrelated toast if a slow pack command crosses the timer boundary; these tests only cover transform-time injection, so the background timer should stay inert.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected: `pnpm --filter codemem test:plugin -- plugin-transform-hook.test.js` (69 passed)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed; not needed for test-only change)
- [x] No new warnings introduced
