### PR TITLE
fix(ui): keep coordinator rename drafts out of device titles

### DIFF
--- a/packages/ui/src/tabs/coordinator-admin/components/devices-panel.test.tsx
+++ b/packages/ui/src/tabs/coordinator-admin/components/devices-panel.test.tsx
@@ -1,0 +1,93 @@
+import { type ComponentChildren, render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { state } from "../../../lib/state";
+import { coordinatorAdminState } from "../data/state";
+import { renderDevicesPanel } from "./devices-panel";
+
+vi.mock("../../../components/primitives/radix-tabs", () => ({
+	RadixTabsContent: ({
+		children,
+		className,
+	}: {
+		children?: ComponentChildren;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+}));
+
+let mount: HTMLDivElement | null = null;
+
+function renderPanel() {
+	mount = document.createElement("div");
+	document.body.appendChild(mount);
+	act(() => {
+		render(
+			renderDevicesPanel({
+				runDevice: vi.fn(),
+				summary: {
+					detail: "Ready",
+					readiness: "ready",
+					title: "Ready",
+				},
+			}),
+			mount as HTMLDivElement,
+		);
+	});
+	return mount;
+}
+
+describe("DevicesPanel", () => {
+	beforeEach(() => {
+		state.lastCoordinatorAdminStatus = { active_group: "team-a", readiness: "ready" };
+		state.lastCoordinatorAdminDevices = [
+			{ device_id: "dev-1", display_name: "NAS", enabled: true, group_id: "team-a" },
+		];
+		coordinatorAdminState.deviceRenameDrafts.clear();
+		coordinatorAdminState.deviceRenameServerNames.clear();
+	});
+
+	afterEach(() => {
+		if (mount) {
+			act(() => {
+				render(null, mount as HTMLDivElement);
+			});
+			mount.remove();
+			mount = null;
+		}
+		document.body.innerHTML = "";
+		state.lastCoordinatorAdminStatus = null;
+		state.lastCoordinatorAdminDevices = [];
+		coordinatorAdminState.deviceRenameDrafts.clear();
+		coordinatorAdminState.deviceRenameServerNames.clear();
+		vi.clearAllMocks();
+	});
+
+	it("keeps the device title on the saved display name while editing a rename draft", () => {
+		const root = renderPanel();
+		const title = root.querySelector(".peer-title strong");
+		const input = root.querySelector("input") as HTMLInputElement | null;
+		if (!title || !input) throw new Error("device row did not render");
+
+		expect(title.textContent).toBe("NAS");
+
+		act(() => {
+			input.value = "NAS storage box";
+			input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+			render(
+				renderDevicesPanel({
+					runDevice: vi.fn(),
+					summary: {
+						detail: "Ready",
+						readiness: "ready",
+						title: "Ready",
+					},
+				}),
+				root,
+			);
+		});
+
+		expect(root.querySelector("input")?.value).toBe("NAS storage box");
+		expect(root.querySelector(".peer-title strong")?.textContent).toBe("NAS");
+	});
+});

--- a/packages/ui/src/tabs/coordinator-admin/components/devices-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/devices-panel.ts
@@ -67,7 +67,7 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 								class: "peer-card peer-card--padded",
 								key: deviceId || String(item.fingerprint || "unknown"),
 							},
-							h("div", { class: "peer-title" }, h("strong", null, draft || displayName)),
+							h("div", { class: "peer-title" }, h("strong", null, displayName)),
 							h("div", { class: "peer-submeta" }, copy.statusLabel),
 							h("div", { class: "peer-meta" }, copy.advancedDetail),
 							h(


### PR DESCRIPTION
## Description
Fixes `codemem-2pqn`: coordinator admin device cards now keep the title on the saved display name while rename edits are still local drafts. The rename input continues to show the draft until the user submits it.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted tests)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected by reproducing the failing regression before the fix

Targeted tests:
- `pnpm exec vitest run packages/ui/src/tabs/coordinator-admin/components/devices-panel.test.tsx packages/ui/src/tabs/coordinator-admin/data/target-group.test.ts packages/ui/src/tabs/coordinator-admin/data/actions.test.ts packages/ui/src/tabs/projects.test.ts`
- `pnpm run tsc`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced