### PR TITLE
fix(ui): show blocking identities for project bulk assignment

### DIFF
--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -619,7 +619,59 @@ describe("Projects tab", () => {
 		expect(save?.disabled).toBe(true);
 		expect(api.saveSharingDomainProjectMappings).not.toHaveBeenCalled();
 		expect(document.body.textContent).toContain("need individual review");
+		expect(document.body.textContent).toContain(
+			"Blocked identity: https://git.example.invalid/exampleco/api.git:worktree",
+		);
+		expect(document.body.textContent).toContain("Another project is also named api.");
 		expect(document.body.textContent).toContain("Show identities in this project");
+	});
+
+	it("does not block cluster bulk assignment for informational guardrail warnings", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [
+				project(),
+				project({
+					guardrail_warnings: [
+						{
+							code: "unknown_project_local_only",
+							message: "This identity currently stays Local only.",
+							requires_confirmation: false,
+							severity: "warning",
+						},
+					],
+					workspace_identity: "https://git.example.invalid/exampleco/api.git:worktree",
+				}),
+			],
+			total: 2,
+		});
+
+		await loadProjectsData();
+		const select = document.querySelector(
+			".project-inventory-cluster select",
+		) as HTMLSelectElement | null;
+		if (!select) throw new Error("cluster select missing");
+		select.value = "exampleco-work";
+		select.dispatchEvent(new Event("change", { bubbles: true }));
+		const save = Array.from(document.querySelectorAll("button")).find(
+			(button) => button.textContent === "Save Space for 2 identities",
+		) as HTMLButtonElement | undefined;
+		expect(save?.disabled).toBe(false);
+		expect(document.body.textContent).not.toContain("Blocked identity:");
+
+		save?.click();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(api.saveSharingDomainProjectMappings).toHaveBeenCalledWith({
+			mappings: expect.arrayContaining([
+				expect.objectContaining({
+					scope_id: "exampleco-work",
+					workspace_identity: "https://git.example.invalid/exampleco/api.git:worktree",
+				}),
+			]),
+		});
 	});
 
 	it("requires explicit cluster domain choice for mixed suggestions", async () => {

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -761,8 +761,14 @@ function renderProjectCluster(projects: ProjectScopeInventoryProject[]): HTMLEle
 		actions.appendChild(note);
 		row.appendChild(actions);
 	} else {
-		const hasGuardrailWarnings = assignableProjects.some(
-			(project) => (project.guardrail_warnings ?? []).length > 0,
+		const projectsWithBlockingWarnings = assignableProjects.map((project) => ({
+			project,
+			warnings: (project.guardrail_warnings ?? []).filter(
+				(warning) => warning.requires_confirmation,
+			),
+		}));
+		const hasBlockingGuardrailWarnings = projectsWithBlockingWarnings.some(
+			({ warnings }) => warnings.length > 0,
 		);
 		const suggestedScopes = new Set(
 			assignableProjects
@@ -783,7 +789,7 @@ function renderProjectCluster(projects: ProjectScopeInventoryProject[]): HTMLEle
 		save.className = "settings-button";
 		save.type = "button";
 		save.textContent = `Save Space for ${assignableProjects.length} identit${assignableProjects.length === 1 ? "y" : "ies"}`;
-		save.disabled = !select.value || hasGuardrailWarnings;
+		save.disabled = !select.value || hasBlockingGuardrailWarnings;
 		save.addEventListener(
 			"click",
 			() => void saveProjectClusterMapping(assignableProjects, select.value),
@@ -791,16 +797,30 @@ function renderProjectCluster(projects: ProjectScopeInventoryProject[]): HTMLEle
 		select.addEventListener("change", () => {
 			if (select.value) draftClusterDomainSelections.set(clusterKey, select.value);
 			else draftClusterDomainSelections.delete(clusterKey);
-			save.disabled = !select.value || hasGuardrailWarnings;
+			save.disabled = !select.value || hasBlockingGuardrailWarnings;
 		});
 		select.addEventListener("blur", refreshSkippedProjectDataAfterSelectBlur);
 		actions.append(select, save);
-		if (suggestedScopes.size > 1 || resolvedScopes.size > 1 || hasGuardrailWarnings) {
+		if (suggestedScopes.size > 1 || resolvedScopes.size > 1 || hasBlockingGuardrailWarnings) {
 			const note = document.createElement("div");
 			note.className = "settings-note project-attention-note";
-			note.textContent = hasGuardrailWarnings
+			note.textContent = hasBlockingGuardrailWarnings
 				? "One or more identities in this group need individual review before bulk assignment."
 				: "This group has mixed suggestions or current Spaces. Choose a Space explicitly before bulk assignment.";
+			if (hasBlockingGuardrailWarnings) {
+				const blockers = document.createElement("ul");
+				for (const { project, warnings } of projectsWithBlockingWarnings) {
+					if (warnings.length === 0) continue;
+					const item = document.createElement("li");
+					const label = document.createElement("strong");
+					label.textContent = `Blocked identity: ${project.workspace_identity}`;
+					const detail = document.createElement("span");
+					detail.textContent = ` — ${warnings.map((warning) => warning.message).join(" ")}`;
+					item.append(label, detail);
+					blockers.appendChild(item);
+				}
+				note.appendChild(blockers);
+			}
 			actions.appendChild(note);
 		}
 		row.appendChild(actions);


### PR DESCRIPTION
## Description
Fixes `codemem-vo49`: Projects cluster bulk assignment warnings now show which workspace identity blocks bulk save and the guardrail reason. The UI only treats `requires_confirmation` guardrails as blockers, so informational warnings do not disable bulk assignment.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted tests)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected by reproducing the failing blocker-detail regression before the fix

Targeted tests:
- `pnpm exec vitest run packages/ui/src/tabs/projects.test.ts`
- `pnpm exec vitest run packages/ui/src/tabs/coordinator-admin/components/devices-panel.test.tsx packages/ui/src/tabs/coordinator-admin/data/target-group.test.ts packages/ui/src/tabs/coordinator-admin/data/actions.test.ts packages/ui/src/tabs/projects.test.ts`
- `pnpm run tsc`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced