### PR TITLE
fix(ui): link redacted sync attempts to diagnostics

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
@@ -11,6 +11,8 @@ export type SyncAttemptItem = {
 	peerLabel: string;
 	detail: string;
 	startedAt: string;
+	actionHref?: string;
+	actionLabel?: string;
 };
 
 export type PairingView = {
@@ -49,6 +51,11 @@ function AttemptsList({ attempts, note }: { attempts: SyncAttemptItem[]; note?: 
 							{attempt.peerLabel} — {attempt.status}
 						</div>
 						{attempt.detail ? <div class="small">{attempt.detail}</div> : null}
+						{attempt.actionHref && attempt.actionLabel ? (
+							<a class="small" href={attempt.actionHref}>
+								{attempt.actionLabel}
+							</a>
+						) : null}
 					</div>
 					<div class="right">{attempt.startedAt}</div>
 				</div>

--- a/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.test.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { shouldShowSyncAttemptRedactionHint } from "./sync-attempts";
+import { afterEach, describe, expect, it } from "vitest";
+import { state } from "../../../../lib/state";
+import { renderSyncAttempts, shouldShowSyncAttemptRedactionHint } from "./sync-attempts";
+
+afterEach(() => {
+	document.body.innerHTML = "";
+	localStorage.clear();
+	state.lastSyncAttempts = [];
+	state.lastSyncPeers = [];
+	state.lastSyncStatus = null;
+});
 
 describe("shouldShowSyncAttemptRedactionHint", () => {
 	it("shows the reveal hint only for explicitly redacted attempt errors", () => {
@@ -30,5 +39,28 @@ describe("shouldShowSyncAttemptRedactionHint", () => {
 				false,
 			),
 		).toBe(false);
+	});
+});
+
+describe("renderSyncAttempts", () => {
+	it("links redacted failed attempts to the Advanced diagnostics redaction setting", () => {
+		document.body.innerHTML = `<div id="syncAttempts"></div>`;
+		state.lastSyncAttempts = [
+			{
+				status: "error",
+				peer_device_id: "peer-device-123456",
+				error: "sync attempt failed; enable diagnostics for details",
+				error_redacted: true,
+				started_at: "2026-06-11T17:00:00.000Z",
+			},
+		];
+
+		renderSyncAttempts();
+
+		const link = document.querySelector<HTMLAnchorElement>('a[href="#sync/diagnostics"]');
+		expect(document.body.textContent).toContain(
+			"Turn off Redact in Advanced diagnostics to reveal the full error.",
+		);
+		expect(link?.textContent).toBe("Open Advanced diagnostics Redact setting");
 	});
 });

--- a/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.ts
@@ -78,6 +78,12 @@ export function renderSyncAttempts() {
 			peerLabel,
 			detail: detailParts.join(" · "),
 			startedAt: time ? formatTimestamp(time) : "",
+			...(shouldShowSyncAttemptRedactionHint(attempt, redact)
+				? {
+						actionHref: "#sync/diagnostics",
+						actionLabel: "Open Advanced diagnostics Redact setting",
+					}
+				: {}),
 		};
 	});
 


### PR DESCRIPTION
## Description
Redacted failed entries in Recent sync attempts could only tell users to turn off Redact in Advanced diagnostics, with no direct way to get there. This adds a small inline action link on redacted failed attempts that navigates to `#sync/diagnostics`, where the Redact control lives.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted Vitest)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
