### PR TITLE
fix(sync): add structured failure categories

### DIFF
--- a/packages/cli/src/commands/stats.test.ts
+++ b/packages/cli/src/commands/stats.test.ts
@@ -66,15 +66,18 @@ describe("stats command", () => {
 				.run(store.deviceId, now);
 
 			const sessionId = store.startSession({ cwd: process.cwd(), project: "scope-test" });
-			const visibleId = store.remember(sessionId, "discovery", "Visible stats", "Visible body");
-			const hiddenId = store.remember(sessionId, "discovery", "Hidden stats", "Hidden body");
 			store.db
-				.prepare("UPDATE memory_items SET scope_id = ? WHERE id = ?")
-				.run("authorized-team", visibleId);
+				.prepare(
+					`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, scope_id)
+					 VALUES (?, 'discovery', 'Visible stats', 'Visible body', ?, ?, ?)`,
+				)
+				.run(sessionId, now, now, "authorized-team");
 			store.db
-				.prepare("UPDATE memory_items SET scope_id = ? WHERE id = ?")
-				.run("unauthorized-team", hiddenId);
-			await store.flushPendingVectorWrites();
+				.prepare(
+					`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, scope_id)
+					 VALUES (?, 'discovery', 'Hidden stats', 'Hidden body', ?, ?, ?)`,
+				)
+				.run(sessionId, now, now, "unauthorized-team");
 		} finally {
 			store.close();
 		}

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -858,6 +858,8 @@ export interface ApiSyncOpsResetRequiredResponse extends ApiSyncResetBoundary {
 		| "generation_mismatch"
 		| "boundary_mismatch"
 		| "missing_scope"
+		| "scope_inactive"
+		| "stale_epoch"
 		| "unsupported_scope";
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -575,7 +575,7 @@ export {
 	storePrivateKeyKeychain,
 	validateExistingKeypair,
 } from "./sync-identity.js";
-export type { SyncPassOptions, SyncResult } from "./sync-pass.js";
+export type { SyncFailureCategory, SyncPassOptions, SyncResult } from "./sync-pass.js";
 export {
 	consecutiveConnectivityFailures,
 	cursorAdvances,

--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -130,7 +130,9 @@ export async function fetchAllSnapshotPages(
 
 		const [status, payload] = await requestJson("GET", url, { headers, timeoutS });
 		if (status !== 200 || !payload) {
-			const detail = payload?.error ? String(payload.error) : `status ${status}`;
+			const error = payload?.error ? String(payload.error) : "";
+			const reason = payload?.reason ? String(payload.reason) : "";
+			const detail = error ? (reason ? `${error}:${reason}` : error) : `status ${status}`;
 			throw new Error(`snapshot fetch failed: ${detail}`);
 		}
 

--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -508,11 +508,11 @@ describe("syncOnce", () => {
 			next_cursor: null,
 			skipped: 0,
 		};
-		// Server rejects the snapshot fetch for the scope.
+		// Server rejects the snapshot fetch for the scope with a structured reset reason.
 		vi.spyOn(syncHttpClient, "requestJson")
 			.mockResolvedValueOnce([200, statusResponse])
 			.mockResolvedValueOnce([200, defaultOpsResponse])
-			.mockResolvedValueOnce([403, { error: "scope_rejected" }]);
+			.mockResolvedValueOnce([409, { error: "reset_required", reason: "missing_scope" }]);
 
 		const result = await syncOnce(db, "peer-mixed", ["http://127.0.0.1:9090"]);
 
@@ -524,9 +524,99 @@ describe("syncOnce", () => {
 		expect(result.perScopeResults?.[0]).toMatchObject({
 			scope_id: "broken-scope",
 			ok: false,
+			failureCategory: "scope",
 			bootstrapped: true,
 		});
-		expect(result.perScopeResults?.[0]?.error).toContain("snapshot fetch failed");
+		expect(result.perScopeResults?.[0]?.error).toContain(
+			"snapshot fetch failed: reset_required:missing_scope",
+		);
+		expect(result.failureCategory).toBe("scope");
+	});
+
+	it("classifies peer trust failures structurally", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-trust", "fp-trust", new Date().toISOString());
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		vi.spyOn(syncHttpClient, "requestJson").mockResolvedValueOnce([401, { error: "unauthorized" }]);
+
+		const result = await syncOnce(db, "peer-trust", ["http://127.0.0.1:9090"]);
+
+		expect(result.ok).toBe(false);
+		expect(result.failureCategory).toBe("trust");
+		expect(result.error).toContain("401: unauthorized");
+	});
+
+	it("classifies scoped transport failures structurally", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-connectivity", "fp-connectivity", new Date().toISOString());
+		db.prepare(
+			"INSERT INTO replication_cursors (peer_device_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?)",
+		).run("peer-connectivity", "2025-12-31T00:00:00Z|local-op-0", null, new Date().toISOString());
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		vi.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: "fp-connectivity",
+					protocol_version: "2",
+					sync_capability: "scoped",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-default",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+					authorized_scopes: [
+						{
+							scope_id: "oss",
+							label: "OSS",
+							authority_type: "coordinator",
+							membership_epoch: 1,
+							sync_reset: {
+								scope_id: "oss",
+								generation: 1,
+								snapshot_id: "snap-oss",
+								baseline_cursor: null,
+								retained_floor_cursor: null,
+							},
+						},
+					],
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-default",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [],
+					next_cursor: null,
+					skipped: 0,
+				},
+			])
+			.mockRejectedValueOnce(new Error("fetch failed"));
+
+		const result = await syncOnce(db, "peer-connectivity", ["http://127.0.0.1:9090"]);
+
+		expect(result.ok).toBe(false);
+		expect(result.failureCategory).toBe("connectivity");
+		expect(result.perScopeResults?.[0]).toMatchObject({
+			scope_id: "oss",
+			ok: false,
+			failureCategory: "connectivity",
+		});
 	});
 
 	it("replicates a multi-Space corpus from a scoped peer to a fresh receiver (ruu6.7)", async () => {
@@ -997,11 +1087,268 @@ describe("syncOnce", () => {
 			scope_id: "acme-work",
 			ok: false,
 			error: "reset_required:stale_cursor",
+			failureCategory: "other",
 		});
+		expect(result.failureCategory).toBe("other");
 		expect(syncReplication.getReplicationCursor(db, "peer-reset", "acme-work")).toEqual([
 			null,
 			null,
 		]);
+	});
+
+	it.each([
+		"missing_scope",
+		"stale_epoch",
+		"scope_inactive",
+	] as const)("keeps %s reset_required failures categorized as scope access", async (reason) => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run(`peer-${reason}`, `fp-${reason}`, new Date().toISOString());
+		syncReplication.setReplicationCursor(db, `peer-${reason}`, {
+			lastApplied: "2025-12-31T00:00:00Z|default-baseline",
+		});
+		syncReplication.setReplicationCursor(
+			db,
+			`peer-${reason}`,
+			{ lastApplied: "2025-12-31T00:00:00Z|stale-acme" },
+			"acme-work",
+		);
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		grantScopeForSyncPass(db, "acme-work", [`peer-${reason}`, "local-device-id"]);
+
+		vi.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: `fp-${reason}`,
+					protocol_version: "2",
+					sync_capability: "scoped",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-default",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+					authorized_scopes: [
+						{
+							scope_id: "acme-work",
+							label: "acme-work",
+							authority_type: "coordinator",
+							membership_epoch: 1,
+							sync_reset: {
+								scope_id: "acme-work",
+								generation: 2,
+								snapshot_id: "snap-acme-2",
+								baseline_cursor: null,
+								retained_floor_cursor: null,
+							},
+						},
+					],
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-default",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [],
+					next_cursor: null,
+					skipped: 0,
+				},
+			])
+			.mockResolvedValueOnce([
+				409,
+				{
+					reset_required: true,
+					reason,
+					scope_id: "acme-work",
+					generation: 2,
+					snapshot_id: "snap-acme-2",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+				},
+			]);
+
+		const result = await syncOnce(db, `peer-${reason}`, ["http://127.0.0.1:9090"]);
+
+		expect(result.ok).toBe(false);
+		expect(result.perScopeResults?.[0]).toMatchObject({
+			scope_id: "acme-work",
+			ok: false,
+			error: `reset_required:${reason}`,
+			failureCategory: "scope",
+		});
+		expect(result.failureCategory).toBe("scope");
+	});
+
+	it("keeps unsupported-scope reset_required failures categorized as protocol drift", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-unsupported-scope", "fp-unsupported-scope", new Date().toISOString());
+		syncReplication.setReplicationCursor(db, "peer-unsupported-scope", {
+			lastApplied: "2025-12-31T00:00:00Z|default-baseline",
+		});
+		syncReplication.setReplicationCursor(
+			db,
+			"peer-unsupported-scope",
+			{ lastApplied: "2025-12-31T00:00:00Z|stale-acme" },
+			"acme-work",
+		);
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		grantScopeForSyncPass(db, "acme-work", ["peer-unsupported-scope", "local-device-id"]);
+
+		vi.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: "fp-unsupported-scope",
+					protocol_version: "2",
+					sync_capability: "scoped",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-default",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+					authorized_scopes: [
+						{
+							scope_id: "acme-work",
+							label: "acme-work",
+							authority_type: "coordinator",
+							membership_epoch: 1,
+							sync_reset: {
+								scope_id: "acme-work",
+								generation: 2,
+								snapshot_id: "snap-acme-2",
+								baseline_cursor: null,
+								retained_floor_cursor: null,
+							},
+						},
+					],
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-default",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [],
+					next_cursor: null,
+					skipped: 0,
+				},
+			])
+			.mockResolvedValueOnce([
+				409,
+				{
+					reset_required: true,
+					reason: "unsupported_scope",
+					scope_id: "acme-work",
+					generation: 2,
+					snapshot_id: "snap-acme-2",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+				},
+			]);
+
+		const result = await syncOnce(db, "peer-unsupported-scope", ["http://127.0.0.1:9090"]);
+
+		expect(result.ok).toBe(false);
+		expect(result.perScopeResults?.[0]).toMatchObject({
+			scope_id: "acme-work",
+			ok: false,
+			error: "reset_required:unsupported_scope",
+			failureCategory: "other",
+		});
+		expect(result.failureCategory).toBe("other");
+	});
+
+	it("classifies inbound membership rejections as scope failures", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-rejected-scope", "fp-rejected-scope", new Date().toISOString());
+		db.prepare(
+			"INSERT INTO replication_cursors (peer_device_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?)",
+		).run("peer-rejected-scope", "2025-12-31T00:00:00Z|local-op-0", null, new Date().toISOString());
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+
+		vi.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: "fp-rejected-scope",
+					protocol_version: "2",
+					sync_capability: "scoped",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-default",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+					authorized_scopes: [],
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-default",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [
+						{
+							op_id: "rejected-scope-op",
+							entity_type: "memory_item",
+							entity_id: "key:rejected-scope",
+							op_type: "upsert",
+							payload_json: JSON.stringify({
+								kind: "discovery",
+								title: "Rejected scoped title",
+								body_text: "Rejected scoped body",
+								active: 1,
+								created_at: "2026-01-01T00:00:00Z",
+								updated_at: "2026-01-01T00:00:00Z",
+								scope_id: "ungranted-scope",
+							}),
+							clock_rev: 1,
+							clock_updated_at: "2026-01-01T00:00:00Z",
+							clock_device_id: "peer-rejected-scope",
+							device_id: "peer-rejected-scope",
+							created_at: "2026-01-01T00:00:00Z",
+							scope_id: "ungranted-scope",
+						},
+					],
+					next_cursor: "2026-01-01T00:00:00Z|rejected-scope-op",
+					skipped: 0,
+				},
+			]);
+
+		const result = await syncOnce(db, "peer-rejected-scope", ["http://127.0.0.1:9090"]);
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("inbound scope rejected");
+		expect(result.failureCategory).toBe("scope");
+		expect(syncReplication.getReplicationCursor(db, "peer-rejected-scope")[0]).toBe(
+			"2025-12-31T00:00:00Z|local-op-0",
+		);
 	});
 
 	it("rejects pulled ops that spoof the local device without advancing cursor", async () => {

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -75,9 +75,12 @@ const EXPECTED_SYNC_PROTOCOL_VERSION = "2";
 // Types
 // ---------------------------------------------------------------------------
 
+export type SyncFailureCategory = "trust" | "scope" | "connectivity" | "other";
+
 export interface SyncResult {
 	ok: boolean;
 	error?: string;
+	failureCategory?: SyncFailureCategory;
 	address?: string;
 	opsIn: number;
 	opsOut: number;
@@ -114,6 +117,7 @@ export interface SyncScopeResult {
 	scope_id: string;
 	label?: string;
 	ok: boolean;
+	failureCategory?: SyncFailureCategory;
 	opsIn: number;
 	opsOut: number;
 	error?: string;
@@ -480,6 +484,60 @@ function hasLocalRowsInScope(db: Database, scopeId: string): boolean {
 	return row !== undefined;
 }
 
+function categorizeSyncFailure(error: string | undefined): SyncFailureCategory {
+	const lower = String(error ?? "").toLowerCase();
+	if (!lower) return "other";
+	if (lower.includes("401") && lower.includes("unauthorized")) return "trust";
+	if (lower.includes("fingerprint mismatch")) return "trust";
+	if (lower.includes("peer not pinned")) return "trust";
+	if (lower.includes("scope_rejected") || lower.includes("scope rejected")) return "scope";
+	if (lower.includes("missing_scope")) return "scope";
+	if (lower.includes("stale_epoch")) return "scope";
+	if (lower.includes("scope_inactive")) return "scope";
+	if (lower.includes("no dialable peer addresses")) return "connectivity";
+	if (lower.includes("fetch failed")) return "connectivity";
+	if (lower.includes("connection refused")) return "connectivity";
+	if (lower.includes("network")) return "connectivity";
+	if (lower.includes("timeout")) return "connectivity";
+	if (lower.includes("503") || lower.includes("502") || lower.includes("504"))
+		return "connectivity";
+	if (lower.includes("peer status failed")) return "connectivity";
+	if (lower.includes("peer ops fetch failed")) return "connectivity";
+	if (lower.includes("snapshot fetch failed")) return "connectivity";
+	return "other";
+}
+
+function scopeFailureCategory(error: string | undefined): SyncFailureCategory {
+	return categorizeSyncFailure(error);
+}
+
+function scopeResetFailureCategory(reason: SyncResetRequired["reason"]): SyncFailureCategory {
+	switch (reason) {
+		case "missing_scope":
+		case "scope_inactive":
+		case "stale_epoch":
+			return "scope";
+		case "boundary_mismatch":
+		case "generation_mismatch":
+		case "initial_bootstrap":
+		case "stale_cursor":
+		case "unsupported_scope":
+			return "other";
+	}
+	return "other";
+}
+
+function aggregateScopeFailureCategory(
+	results: SyncScopeResult[],
+): SyncFailureCategory | undefined {
+	const failed = results.filter((result) => !result.ok);
+	if (failed.length === 0) return undefined;
+	const categories = new Set(
+		failed.map((result) => result.failureCategory ?? scopeFailureCategory(result.error)),
+	);
+	return categories.size === 1 ? Array.from(categories)[0] : "other";
+}
+
 /**
  * Run the per-Space iteration after a successful default-scope sync.
  *
@@ -585,25 +643,29 @@ async function syncOneScope(
 			// default-scope auto-bootstrap path already enforces in syncOnce
 			// (see "needs_attention:shared_memories_appeared_during_bootstrap").
 			if (hasLocalRowsInScope(db, scopeId)) {
+				const error = "needs_attention:shared_memories_appeared_during_bootstrap";
 				return {
 					scope_id: scopeId,
 					label: scope.label,
 					ok: false,
+					failureCategory: "other",
 					opsIn: 0,
 					opsOut: 0,
-					error: "needs_attention:shared_memories_appeared_during_bootstrap",
+					error,
 					bootstrapped: true,
 				};
 			}
 			const bootstrapResult = applyBootstrapSnapshot(db, peerDeviceId, items, resetInfo, scanner);
 			if (!bootstrapResult.ok) {
+				const error = "bootstrap apply failed";
 				return {
 					scope_id: scopeId,
 					label: scope.label,
 					ok: false,
+					failureCategory: "other",
 					opsIn: 0,
 					opsOut: 0,
-					error: "bootstrap apply failed",
+					error,
 					bootstrapped: true,
 				};
 			}
@@ -617,13 +679,15 @@ async function syncOneScope(
 			};
 		} catch (err) {
 			const detail = err instanceof Error ? err.message.trim() || err.constructor.name : "unknown";
+			const error = `scoped bootstrap failed: ${detail}`;
 			return {
 				scope_id: scopeId,
 				label: scope.label,
 				ok: false,
+				failureCategory: scopeFailureCategory(error),
 				opsIn: 0,
 				opsOut: 0,
-				error: `scoped bootstrap failed: ${detail}`,
+				error,
 				bootstrapped: true,
 			};
 		}
@@ -666,19 +730,23 @@ async function syncOneScope(
 					case "generation_mismatch":
 					case "boundary_mismatch":
 					case "missing_scope":
+					case "scope_inactive":
+					case "stale_epoch":
 					case "unsupported_scope":
 						return payload.reason;
 					default:
 						return "stale_cursor";
 				}
 			})();
+			const error = `reset_required:${reason}`;
 			return {
 				scope_id: scopeId,
 				label: scope.label,
 				ok: false,
+				failureCategory: scopeResetFailureCategory(reason),
 				opsIn: 0,
 				opsOut: 0,
-				error: `reset_required:${reason}`,
+				error,
 				resetRequired: {
 					reset_required: true,
 					reason,
@@ -699,25 +767,29 @@ async function syncOneScope(
 		if (status !== 200 || payload == null) {
 			const detail = errorDetail(payload);
 			const suffix = detail ? ` (${status}: ${detail})` : ` (${status})`;
+			const error = `peer scoped ops fetch failed${suffix}`;
 			return {
 				scope_id: scopeId,
 				label: scope.label,
 				ok: false,
+				failureCategory: scopeFailureCategory(error),
 				opsIn: 0,
 				opsOut: 0,
-				error: `peer scoped ops fetch failed${suffix}`,
+				error,
 				bootstrapped: false,
 			};
 		}
 
 		if (!isValidIncrementalOpsResponse(payload)) {
+			const error = "invalid scoped ops response";
 			return {
 				scope_id: scopeId,
 				label: scope.label,
 				ok: false,
+				failureCategory: "other",
 				opsIn: 0,
 				opsOut: 0,
-				error: "invalid scoped ops response",
+				error,
 				bootstrapped: false,
 			};
 		}
@@ -727,13 +799,15 @@ async function syncOneScope(
 			(op) => op.device_id !== peerDeviceId || op.clock_device_id !== peerDeviceId,
 		);
 		if (mismatched) {
+			const error = `inbound op device mismatch:${mismatched.op_id}`;
 			return {
 				scope_id: scopeId,
 				label: scope.label,
 				ok: false,
+				failureCategory: "other",
 				opsIn: 0,
 				opsOut: 0,
-				error: `inbound op device mismatch:${mismatched.op_id}`,
+				error,
 				bootstrapped: false,
 			};
 		}
@@ -743,13 +817,15 @@ async function syncOneScope(
 		});
 		if (applied.rejected > 0) {
 			const reason = applied.rejections[0]?.reason ?? "scope_rejected";
+			const error = `inbound scope rejected:${reason}`;
 			return {
 				scope_id: scopeId,
 				label: scope.label,
 				ok: false,
+				failureCategory: "scope",
 				opsIn: 0,
 				opsOut: 0,
-				error: `inbound scope rejected:${reason}`,
+				error,
 				bootstrapped: false,
 			};
 		}
@@ -770,13 +846,15 @@ async function syncOneScope(
 		} catch (queueErr) {
 			const fallback = await bestEffortMaintainVectorsForSyncFallback(db, vectorWork);
 			if (fallback.errors.length > 0) {
+				const error = `vector catch-up failed: ${queueErr instanceof Error ? queueErr.message : String(queueErr)}; fallback failed: ${fallback.errors.join("; ")}`;
 				return {
 					scope_id: scopeId,
 					label: scope.label,
 					ok: false,
+					failureCategory: "other",
 					opsIn: 0,
 					opsOut: 0,
-					error: `vector catch-up failed: ${queueErr instanceof Error ? queueErr.message : String(queueErr)}; fallback failed: ${fallback.errors.join("; ")}`,
+					error,
 					bootstrapped: false,
 				};
 			}
@@ -797,13 +875,15 @@ async function syncOneScope(
 		};
 	} catch (err) {
 		const detail = err instanceof Error ? err.message.trim() || err.constructor.name : "unknown";
+		const error = `scoped incremental failed: ${detail}`;
 		return {
 			scope_id: scopeId,
 			label: scope.label,
 			ok: false,
+			failureCategory: scopeFailureCategory(error),
 			opsIn: 0,
 			opsOut: 0,
-			error: `scoped incremental failed: ${detail}`,
+			error,
 			bootstrapped: false,
 		};
 	}
@@ -856,7 +936,14 @@ export async function syncOnce(
 		.get();
 	const pinnedFingerprint = pinRow?.pinned_fingerprint ?? "";
 	if (!pinnedFingerprint) {
-		return { ok: false, error: "peer not pinned", opsIn: 0, opsOut: 0, addressErrors: [] };
+		return {
+			ok: false,
+			error: "peer not pinned",
+			failureCategory: "trust",
+			opsIn: 0,
+			opsOut: 0,
+			addressErrors: [],
+		};
 	}
 
 	// Read cursors
@@ -870,7 +957,7 @@ export async function syncOnce(
 		const detail = err instanceof Error ? err.message.trim() || err.constructor.name : "unknown";
 		const error = `device identity unavailable: ${detail}`;
 		recordSyncAttempt(db, peerDeviceId, { ok: false, error });
-		return { ok: false, error, opsIn: 0, opsOut: 0, addressErrors: [] };
+		return { ok: false, error, failureCategory: "other", opsIn: 0, opsOut: 0, addressErrors: [] };
 	}
 
 	const addressErrors: Array<{ address: string; error: string }> = [];
@@ -966,6 +1053,7 @@ export async function syncOnce(
 								ok: false,
 								address: baseUrl,
 								error: `needs attention: ${postFetchSharedCount} shared memory change(s) appeared during initial bootstrap fetch`,
+								failureCategory: "other",
 								opsIn: 0,
 								opsOut: 0,
 								addressErrors: [],
@@ -1015,6 +1103,7 @@ export async function syncOnce(
 						return {
 							ok: bootstrapAllOk,
 							address: baseUrl,
+							failureCategory: aggregateScopeFailureCategory(scopedAfterBootstrap.results),
 							opsIn: bootstrapResult.applied + scopedAfterBootstrap.totalOpsIn,
 							opsOut: 0,
 							addressErrors: [],
@@ -1092,6 +1181,7 @@ export async function syncOnce(
 						ok: false,
 						address: baseUrl,
 						error: `needs attention: ${dirtyLocal.count} unsynced shared memory change(s) block automatic reset`,
+						failureCategory: "other",
 						opsIn: 0,
 						opsOut: 0,
 						addressErrors: [],
@@ -1118,6 +1208,7 @@ export async function syncOnce(
 							ok: false,
 							address: baseUrl,
 							error: `needs attention: ${dirtyAfterFetch.count} unsynced shared memory change(s) appeared during bootstrap fetch`,
+							failureCategory: "other",
 							opsIn: 0,
 							opsOut: 0,
 							addressErrors: [],
@@ -1160,6 +1251,7 @@ export async function syncOnce(
 						ok: false,
 						address: baseUrl,
 						error: `bootstrap failed: ${msg}`,
+						failureCategory: "other",
 						opsIn: 0,
 						opsOut: 0,
 						addressErrors: [],
@@ -1283,6 +1375,7 @@ export async function syncOnce(
 			return {
 				ok: allScopesOk,
 				address: baseUrl,
+				failureCategory: aggregateScopeFailureCategory(scopedAfterIncremental.results),
 				opsIn: applied.applied + scopedAfterIncremental.totalOpsIn,
 				opsOut: outboundOps.length,
 				opsSkipped,
@@ -1310,7 +1403,14 @@ export async function syncOnce(
 		error,
 		capabilities: lastCapabilityDiagnostics,
 	});
-	return { ok: false, error, opsIn: 0, opsOut: 0, addressErrors };
+	return {
+		ok: false,
+		error,
+		failureCategory: categorizeSyncFailure(error),
+		opsIn: 0,
+		opsOut: 0,
+		addressErrors,
+	};
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -47,6 +47,8 @@ export interface SyncResetRequired extends SyncResetBoundary {
 		| "generation_mismatch"
 		| "boundary_mismatch"
 		| "missing_scope"
+		| "scope_inactive"
+		| "stale_epoch"
 		| "unsupported_scope";
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -423,6 +423,8 @@ export interface SyncResetRequired extends SyncResetBoundary {
 		| "boundary_mismatch"
 		| "initial_bootstrap"
 		| "missing_scope"
+		| "scope_inactive"
+		| "stale_epoch"
 		| "unsupported_scope";
 }
 

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -467,6 +467,29 @@ describe("summarizeSyncRunResult", () => {
 		});
 	});
 
+	it("prefers structured trust failure categories over error text", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-a",
+						ok: false,
+						failureCategory: "trust",
+						error: "status request failed",
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+					},
+				],
+			}),
+		).toEqual({
+			ok: false,
+			message:
+				"This device no longer has two-way trust with the peer. Pair it again from the other device, or remove the stale local record if it should be gone.",
+			warning: true,
+		});
+	});
+
 	it("routes scope_rejected failures to the Teams Space-access message", () => {
 		expect(
 			summarizeSyncRunResult({
@@ -512,6 +535,52 @@ describe("summarizeSyncRunResult", () => {
 		});
 	});
 
+	it("prefers structured scope failure categories over generic text", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-a",
+						ok: false,
+						failureCategory: "scope",
+						error: "sync failed",
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+					},
+				],
+			}),
+		).toEqual({
+			ok: false,
+			message:
+				"Sync ran, but the peer is not authorized for one or more Spaces. Review Space access for this device in Teams, then sync again.",
+			warning: true,
+		});
+	});
+
+	it("uses structured per-scope categories when the top-level item lacks one", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-a",
+						ok: false,
+						error: "scoped sync incomplete",
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+						perScopeResults: [{ scope_id: "oss", ok: false, failureCategory: "scope" }],
+					},
+				],
+			}),
+		).toEqual({
+			ok: false,
+			message:
+				"Sync ran, but the peer is not authorized for one or more Spaces. Review Space access for this device in Teams, then sync again.",
+			warning: true,
+		});
+	});
+
 	it("keeps non-membership scoped sync incomplete failures generic", () => {
 		expect(
 			summarizeSyncRunResult({
@@ -529,6 +598,47 @@ describe("summarizeSyncRunResult", () => {
 		).toEqual({
 			ok: false,
 			message: "scoped sync incomplete: oss=peer scoped ops fetch failed (503: unavailable)",
+			warning: true,
+		});
+	});
+
+	it("keeps structured connectivity and other failures generic", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-a",
+						ok: false,
+						failureCategory: "connectivity",
+						error: "peer scoped ops fetch failed (503: unavailable)",
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+					},
+				],
+			}),
+		).toEqual({
+			ok: false,
+			message: "peer scoped ops fetch failed (503: unavailable)",
+			warning: true,
+		});
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-b",
+						ok: false,
+						failureCategory: "other",
+						error: "invalid scoped ops response",
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+					},
+				],
+			}),
+		).toEqual({
+			ok: false,
+			message: "invalid scoped ops response",
 			warning: true,
 		});
 	});

--- a/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
+++ b/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
@@ -9,6 +9,8 @@ import { cleanText } from "./internal";
 import type {
 	DiscoveredDeviceLike,
 	UiCoordinatorApprovalSummary,
+	UiSyncFailureCategory,
+	UiSyncRunItem,
 	UiSyncRunResponse,
 	UiSyncSkippedOutDetail,
 } from "./types";
@@ -94,8 +96,8 @@ export function summarizeSyncRunResult(payload: UiSyncRunResponse): {
 			warning: false,
 		};
 	}
-	const unauthorizedFailures = failedItems.filter((item) =>
-		isTrustFailureError(cleanText(item.error)),
+	const unauthorizedFailures = failedItems.filter(
+		(item) => failureCategoryForItem(item) === "trust",
 	);
 	if (unauthorizedFailures.length === failedItems.length) {
 		return {
@@ -105,9 +107,7 @@ export function summarizeSyncRunResult(payload: UiSyncRunResponse): {
 			warning: true,
 		};
 	}
-	const scopeFailures = failedItems.filter((item) =>
-		isScopeMembershipFailureError(cleanText(item.error)),
-	);
+	const scopeFailures = failedItems.filter((item) => failureCategoryForItem(item) === "scope");
 	if (scopeFailures.length === failedItems.length) {
 		return {
 			ok: false,
@@ -129,6 +129,24 @@ export function summarizeSyncRunResult(payload: UiSyncRunResponse): {
 		message: error || "Sync failed for at least one device.",
 		warning: true,
 	};
+}
+
+function failureCategoryForItem(item: UiSyncRunItem): UiSyncFailureCategory | null {
+	if (item.failureCategory) return item.failureCategory;
+	const scopeCategories = Array.isArray(item.perScopeResults)
+		? item.perScopeResults
+				.filter((scope) => scope && scope.ok === false)
+				.map((scope) => scope.failureCategory)
+				.filter((category): category is UiSyncFailureCategory => Boolean(category))
+		: [];
+	if (scopeCategories.length) {
+		const unique = new Set(scopeCategories);
+		return unique.size === 1 ? scopeCategories[0] : "other";
+	}
+	const error = cleanText(item.error);
+	if (isTrustFailureError(error)) return "trust";
+	if (isScopeMembershipFailureError(error)) return "scope";
+	return null;
 }
 
 /**

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -38,12 +38,23 @@ export interface UiSyncRunItem {
 	peer_device_id: string;
 	ok: boolean;
 	error?: string;
+	failureCategory?: UiSyncFailureCategory;
 	address?: string;
 	opsIn: number;
 	opsOut: number;
 	opsSkipped?: number;
 	skipped_out?: UiSyncSkippedOutDetail | null;
 	addressErrors: Array<{ address: string; error: string }>;
+	perScopeResults?: UiSyncScopeResult[];
+}
+
+export type UiSyncFailureCategory = "trust" | "scope" | "connectivity" | "other";
+
+export interface UiSyncScopeResult {
+	scope_id?: string;
+	ok?: boolean;
+	error?: string;
+	failureCategory?: UiSyncFailureCategory;
 }
 
 export type UiSyncSkippedOutReason = "scope_filter" | "visibility_filter" | "project_filter";


### PR DESCRIPTION
## Description
Adds structured sync failure categories (`trust`, `scope`, `connectivity`, `other`) to sync result payloads so the UI no longer has to classify new failures by substring matching alone.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
