### PR TITLE
docs(sync): clarify capability header threat model

### DIFF
--- a/docs/plans/2026-05-25-scoped-sync-protocol.md
+++ b/docs/plans/2026-05-25-scoped-sync-protocol.md
@@ -129,6 +129,14 @@ This is a single round trip. No separate `/v1/scopes` endpoint. A separate endpo
 
 No new signing mechanism. The existing `buildAuthHeaders` HMAC covers `(method, full_url_including_query, body_bytes)`. `scope_id` in the query string is therefore already cryptographically bound to the signed request. For POST, `scope_id` is in the signed JSON body.
 
+### Capability header threat model
+
+`X-Codemem-Sync-Capability` is an unsigned advertisement header. The server treats it as a feature-negotiation hint, not an authorization claim. Authentication still happens through the normal signed sync request headers before the server reads capability-dependent behavior. `/v1/status` can also authenticate a not-yet-paired worker through a valid bootstrap grant; that grant path is part of the same bounded metadata-disclosure model.
+
+The bounded disclosure is intentional for this slice: an authenticated paired peer, or a bootstrap worker with a valid grant and matching membership rows, can claim scoped capability and make `/v1/status` include the `authorized_scopes` entries that caller is already a member of. That reveals Space IDs/labels and reset boundaries for scopes inside the paired-peer or bootstrap-grant trust boundary. It does **not** authorize scoped data reads or writes. `/v1/ops` and `/v1/snapshot` still require signed requests and membership checks for each `scope_id`; unauthorized or stale memberships fail closed with scoped reset/error responses.
+
+If future product requirements treat scope membership enumeration itself as too sensitive for an already-paired device or a bootstrap worker with a valid grant, capability negotiation should move into signed request material or `/v1/status` should gate enumeration to pinned peers only. Until then, the header is acceptable only as metadata negotiation inside the authenticated peer/bootstrap trust boundary.
+
 ### Per-scope boundary
 
 `sync_reset_state_v2` is already keyed by `scope_id`. No schema change. `getSyncResetState(db, scope_id)` returns the per-scope row, or a synthesized default if missing.

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -256,9 +256,9 @@ function capabilityDiagnostics(peerCapability: unknown): SyncCapabilityDiagnosti
 }
 
 function capabilityHeader(): Record<string, string> {
-	// Diagnostic advertisement only. The receiver must never use this unsigned
-	// GET header for authorization; behavioral negotiation comes from response
-	// payloads and signed POST bodies.
+	// Diagnostic advertisement only. This unsigned GET header can opt an
+	// authenticated paired peer into scoped metadata enumeration, but never into
+	// scoped data access; receivers must still authorize every scoped request.
 	return { [SYNC_CAPABILITY_HEADER]: LOCAL_SYNC_CAPABILITY };
 }
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -2163,9 +2163,14 @@ const PEERS_QUERY = `
  * honor scoped-sync wire features such as explicit `scope_id` parameters
  * and `/v1/status` `authorized_scopes` enumeration.
  *
- * Unsigned headers are fine here: the server is computing what it is
- * willing to do, not granting access. Per-scope authorization is enforced
- * separately via the membership cache when a scope_id is actually used.
+ * Threat model: this header is intentionally only a best-effort capability
+ * advertisement. It is not signed, so an authenticated paired peer — or a
+ * bootstrap worker presenting a valid grant on `/v1/status` — can claim
+ * `scoped` support and cause status to enumerate the scopes that caller is
+ * already authorized to see. That is metadata disclosure inside the paired-peer
+ * or bootstrap-grant trust boundary, not data authorization. Every scoped data
+ * path still requires signed requests and checks membership before returning
+ * scope contents.
  */
 function negotiatedSyncCapability(c: Context) {
 	const header = c.req.header(SYNC_CAPABILITY_HEADER) ?? null;


### PR DESCRIPTION
## Description
Clarifies the threat model for the unsigned `X-Codemem-Sync-Capability` header in code and the scoped sync protocol doc: authenticated paired peers and valid bootstrap-grant `/v1/status` callers may enumerate their own authorized scopes, while scoped data access still requires signed requests and membership checks.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
