### PR TITLE
feat(sync): render per-space peer progress

### DIFF
--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -22,7 +22,9 @@ import { buildAuthHeaders } from "./sync-auth.js";
 import { LOCAL_SYNC_CAPABILITY, SYNC_CAPABILITY_HEADER } from "./sync-capability.js";
 import { requestJson } from "./sync-http-client.js";
 import {
+	clearReplicationCursorLastApplied,
 	DEFAULT_SYNC_SCOPE_ID,
+	SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
 	setReplicationCursor,
 	setSyncResetState,
 } from "./sync-replication.js";
@@ -378,13 +380,22 @@ export function applyBootstrapSnapshot(
 			result.applied++;
 		}
 
-		// 3. Update replication cursor to baseline_cursor.
-		if (resetInfo.baseline_cursor) {
+		// 3. Update replication cursor to baseline_cursor. For scoped null-baseline
+		// snapshots, baseline_cursor can be null; store a hidden marker in the
+		// scoped cursor row so status can distinguish "this peer/scope bootstrap
+		// completed without a cursor boundary" from "this scope was never attempted".
+		if (resetInfo.baseline_cursor || resetInfo.scope_id) {
+			if (resetInfo.scope_id && !resetInfo.baseline_cursor) {
+				clearReplicationCursorLastApplied(db, peerDeviceId, resetInfo.scope_id);
+			}
 			setReplicationCursor(
 				db,
 				peerDeviceId,
 				{
 					lastApplied: resetInfo.baseline_cursor,
+					lastAcked: resetInfo.baseline_cursor
+						? undefined
+						: SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
 				},
 				resetInfo.scope_id,
 			);

--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -1276,6 +1276,196 @@ describe("syncOnce", () => {
 		expect(result.failureCategory).toBe("other");
 	});
 
+	it("does not re-bootstrap null-baseline scoped bootstraps that already have a marker", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-empty-scope", "fp-empty-scope", new Date().toISOString());
+		syncReplication.setReplicationCursor(db, "peer-empty-scope", {
+			lastApplied: "2025-12-31T00:00:00Z|default",
+		});
+		syncReplication.setReplicationCursor(
+			db,
+			"peer-empty-scope",
+			{ lastAcked: syncReplication.SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER },
+			"empty-work",
+		);
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		grantScopeForSyncPass(db, "empty-work", ["peer-empty-scope", "local-device-id"]);
+
+		const requestSpy = vi
+			.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: "fp-empty-scope",
+					protocol_version: "2",
+					sync_capability: "scoped",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-default",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+					authorized_scopes: [
+						{
+							scope_id: "empty-work",
+							label: "empty-work",
+							authority_type: "coordinator",
+							membership_epoch: 1,
+							sync_reset: {
+								scope_id: "empty-work",
+								generation: 1,
+								snapshot_id: "snap-empty",
+								baseline_cursor: null,
+								retained_floor_cursor: null,
+							},
+						},
+					],
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-default",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [],
+					next_cursor: null,
+					skipped: 0,
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-empty",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [],
+					next_cursor: null,
+					skipped: 0,
+				},
+			]);
+
+		const result = await syncOnce(db, "peer-empty-scope", ["http://127.0.0.1:9090"]);
+
+		expect(result.ok).toBe(true);
+		expect(result.perScopeResults?.[0]).toMatchObject({
+			bootstrapped: true,
+			ok: true,
+			scope_id: "empty-work",
+		});
+		const requestedUrls = requestSpy.mock.calls.map(([method, url]) => `${method} ${url}`);
+		expect(requestedUrls.some((entry) => entry.includes("/v1/snapshot"))).toBe(false);
+		expect(
+			requestedUrls.some(
+				(entry) => entry.includes("/v1/ops?") && entry.includes("scope_id=empty-work"),
+			),
+		).toBe(true);
+	});
+
+	it("re-bootstraps marked empty scopes when the peer advertises a baseline", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-empty-baseline", "fp-empty-baseline", new Date().toISOString());
+		syncReplication.setReplicationCursor(db, "peer-empty-baseline", {
+			lastApplied: "2025-12-31T00:00:00Z|default",
+		});
+		syncReplication.setReplicationCursor(
+			db,
+			"peer-empty-baseline",
+			{ lastAcked: syncReplication.SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER },
+			"empty-work",
+		);
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		grantScopeForSyncPass(db, "empty-work", ["peer-empty-baseline", "local-device-id"]);
+
+		vi.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: "fp-empty-baseline",
+					protocol_version: "2",
+					sync_capability: "scoped",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-default",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+					authorized_scopes: [
+						{
+							scope_id: "empty-work",
+							label: "empty-work",
+							authority_type: "coordinator",
+							membership_epoch: 1,
+							sync_reset: {
+								scope_id: "empty-work",
+								generation: 2,
+								snapshot_id: "snap-empty-2",
+								baseline_cursor: "2026-01-02T00:00:00Z|baseline-empty",
+								retained_floor_cursor: null,
+							},
+						},
+					],
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-default",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [],
+					next_cursor: null,
+					skipped: 0,
+				},
+			]);
+		vi.spyOn(syncBootstrap, "fetchAllSnapshotPages").mockResolvedValue({
+			items: [],
+			generation: 2,
+			snapshot_id: "snap-empty-2",
+			baseline_cursor: "2026-01-02T00:00:00Z|baseline-empty",
+		});
+		vi.spyOn(syncBootstrap, "applyBootstrapSnapshot").mockReturnValue({
+			ok: true,
+			applied: 0,
+			deleted: 0,
+		});
+
+		const result = await syncOnce(db, "peer-empty-baseline", ["http://127.0.0.1:9090"]);
+
+		expect(result.ok).toBe(true);
+		expect(result.perScopeResults?.[0]).toMatchObject({
+			bootstrapped: true,
+			ok: true,
+			scope_id: "empty-work",
+		});
+		expect(syncBootstrap.fetchAllSnapshotPages).toHaveBeenCalledOnce();
+		expect(syncBootstrap.fetchAllSnapshotPages).toHaveBeenCalledWith(
+			"http://127.0.0.1:9090",
+			expect.objectContaining({
+				baseline_cursor: "2026-01-02T00:00:00Z|baseline-empty",
+				scope_id: "empty-work",
+			}),
+			"local-device-id",
+			expect.objectContaining({ pageSize: 2000 }),
+		);
+	});
+
 	it("classifies inbound membership rejections as scope failures", async () => {
 		db.prepare(
 			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -36,6 +36,7 @@ import {
 	hasUnsyncedSharedMemoryChanges,
 	migrateLegacyImportKeys,
 	reconcileStalePeerReceivedRows,
+	SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
 	setReplicationCursor,
 } from "./sync-replication.js";
 import type { ReplicationOp, SyncResetRequired } from "./types.js";
@@ -613,14 +614,17 @@ async function syncOneScope(
 ): Promise<SyncScopeResult> {
 	const { peerDeviceId, baseUrl, deviceId, scope, keysDir, scanner, limit } = options;
 	const scopeId = scope.scope_id;
-	const [lastApplied] = getReplicationCursor(db, peerDeviceId, scopeId);
+	const [lastApplied, lastAcked] = getReplicationCursor(db, peerDeviceId, scopeId);
+	const hasNullBaselineBootstrapMarker = lastAcked === SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER;
+	const nullBaselineBootstrapStillCurrent =
+		hasNullBaselineBootstrapMarker && scope.sync_reset.baseline_cursor == null;
 	const localRowsPresent = hasLocalRowsInScope(db, scopeId);
 
 	// Bootstrap when this device has never pulled the scope and has no local
 	// rows. If there ARE local rows but no cursor, fall through to incremental
 	// so the server's reset_required logic can decide whether a re-bootstrap
 	// is required without clobbering existing data.
-	if (lastApplied == null && !localRowsPresent) {
+	if (lastApplied == null && !localRowsPresent && !nullBaselineBootstrapStillCurrent) {
 		try {
 			const resetInfo: SyncResetRequired = {
 				scope_id: scopeId,
@@ -871,7 +875,7 @@ async function syncOneScope(
 			ok: true,
 			opsIn: applied.applied,
 			opsOut: 0,
-			bootstrapped: false,
+			bootstrapped: hasNullBaselineBootstrapMarker,
 		};
 	} catch (err) {
 		const detail = err instanceof Error ? err.message.trim() || err.constructor.name : "unknown";

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -7,6 +7,7 @@ import {
 	backfillReplicationOps,
 	bulkPruneReplicationOpsByAgeCutoff,
 	chunkOpsBySize,
+	clearReplicationCursorLastApplied,
 	clockTuple,
 	DEFAULT_SYNC_SCOPE_ID,
 	diagnoseStalePeerReceivedRows,
@@ -28,6 +29,7 @@ import {
 	reconcileStalePeerReceivedRows,
 	recordAccessCleanupOp,
 	recordReplicationOp,
+	SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
 	setReplicationCursor,
 	setSyncResetState,
 	summarizeInboundScopeRejections,
@@ -3800,6 +3802,95 @@ describe("bootstrap snapshot round-trip parity", () => {
 		expect(applied.narrative).toBe("Bootstrap narrative");
 		expect(applied.user_prompt_id).toBe(99);
 		expect(applied.prompt_number).toBe(3);
+	});
+
+	it("records a scoped cursor marker for empty scoped bootstrap snapshots", async () => {
+		const { applyBootstrapSnapshot } = await import("./sync-bootstrap.js");
+		const resetInfo = {
+			scope_id: "empty-work",
+			generation: 1,
+			snapshot_id: "snap-empty",
+			baseline_cursor: null,
+			retained_floor_cursor: null,
+			reset_required: true as const,
+			reason: "initial_bootstrap" as const,
+		};
+
+		const result = applyBootstrapSnapshot(db, "target-peer", [], resetInfo);
+
+		expect(result.ok).toBe(true);
+		expect(result.applied).toBe(0);
+		const row = db
+			.prepare(
+				`SELECT last_applied_cursor, last_acked_cursor
+				   FROM replication_cursors_v2
+				  WHERE peer_device_id = ? AND scope_id = ?`,
+			)
+			.get("target-peer", "empty-work") as
+			| { last_applied_cursor: string | null; last_acked_cursor: string | null }
+			| undefined;
+		expect(row).toEqual({
+			last_applied_cursor: null,
+			last_acked_cursor: SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
+		});
+	});
+
+	it("clears stale scoped cursors before writing a null-baseline bootstrap marker", async () => {
+		setReplicationCursor(
+			db,
+			"target-peer",
+			{ lastApplied: "2026-01-01T00:00:00Z|stale-cursor", lastAcked: "old-ack" },
+			"empty-work",
+		);
+		const { applyBootstrapSnapshot } = await import("./sync-bootstrap.js");
+		const resetInfo = {
+			scope_id: "empty-work",
+			generation: 2,
+			snapshot_id: "snap-empty-2",
+			baseline_cursor: null,
+			retained_floor_cursor: null,
+			reset_required: true as const,
+			reason: "initial_bootstrap" as const,
+		};
+
+		const result = applyBootstrapSnapshot(db, "target-peer", [], resetInfo);
+
+		expect(result.ok).toBe(true);
+		const row = db
+			.prepare(
+				`SELECT last_applied_cursor, last_acked_cursor
+				   FROM replication_cursors_v2
+				  WHERE peer_device_id = ? AND scope_id = ?`,
+			)
+			.get("target-peer", "empty-work") as
+			| { last_applied_cursor: string | null; last_acked_cursor: string | null }
+			| undefined;
+		expect(row).toEqual({
+			last_applied_cursor: null,
+			last_acked_cursor: SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
+		});
+	});
+
+	it("clears scoped null-baseline bootstrap markers when a scoped reset is required", () => {
+		setReplicationCursor(
+			db,
+			"target-peer",
+			{ lastAcked: SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER },
+			"empty-work",
+		);
+
+		clearReplicationCursorLastApplied(db, "target-peer", "empty-work");
+
+		const row = db
+			.prepare(
+				`SELECT last_applied_cursor, last_acked_cursor
+				   FROM replication_cursors_v2
+				  WHERE peer_device_id = ? AND scope_id = ?`,
+			)
+			.get("target-peer", "empty-work") as
+			| { last_applied_cursor: string | null; last_acked_cursor: string | null }
+			| undefined;
+		expect(row).toEqual({ last_applied_cursor: null, last_acked_cursor: null });
 	});
 });
 

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -31,6 +31,8 @@ import type {
 
 export const DEFAULT_SYNC_SCOPE_ID = "local-default";
 export const ACCESS_CLEANUP_OP_TYPE = "access_cleanup";
+export const SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER =
+	"__codemem_scoped_null_baseline_bootstrap__";
 
 export interface SyncResetBoundary {
 	scope_id?: string | null;
@@ -682,21 +684,18 @@ export function clearReplicationCursorLastApplied(
 	const now = new Date().toISOString();
 	const effectiveScopeId = normalizeSyncStateScopeId(scopeId);
 	drizzle(db, { schema })
-		.insert(schema.replicationCursorsV2)
-		.values({
-			peer_device_id: peerDeviceId,
-			scope_id: effectiveScopeId,
+		.update(schema.replicationCursorsV2)
+		.set({
 			last_applied_cursor: null,
 			last_acked_cursor: null,
 			updated_at: now,
 		})
-		.onConflictDoUpdate({
-			target: [schema.replicationCursorsV2.peer_device_id, schema.replicationCursorsV2.scope_id],
-			set: {
-				last_applied_cursor: null,
-				updated_at: sql`excluded.updated_at`,
-			},
-		})
+		.where(
+			and(
+				eq(schema.replicationCursorsV2.peer_device_id, peerDeviceId),
+				eq(schema.replicationCursorsV2.scope_id, effectiveScopeId),
+			),
+		)
 		.run();
 }
 

--- a/packages/core/src/sync-scope-protocol.test.ts
+++ b/packages/core/src/sync-scope-protocol.test.ts
@@ -1,8 +1,13 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+	SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
+	setReplicationCursor,
+} from "./sync-replication.js";
+import {
 	addSyncScopeToBoundary,
 	listAuthorizedScopesForPeer,
+	listPerPeerScopeSyncState,
 	parseSyncScopeRequest,
 	syncScopeResetRequiredPayload,
 } from "./sync-scope-protocol.js";
@@ -265,6 +270,24 @@ describe("listAuthorizedScopesForPeer", () => {
 		).run(scopeId, deviceId, status, NOW);
 	}
 
+	function recordSyncAttempt(
+		peerDeviceId: string,
+		completedAt: string,
+		opts: { ok?: boolean; capability?: string } = {},
+	) {
+		db.prepare(
+			`INSERT INTO sync_attempts(
+				peer_device_id, started_at, finished_at, ok, ops_in, ops_out, negotiated_sync_capability
+			) VALUES (?, ?, ?, ?, 0, 0, ?)`,
+		).run(
+			peerDeviceId,
+			completedAt,
+			completedAt,
+			opts.ok === false ? 0 : 1,
+			opts.capability ?? "scoped",
+		);
+	}
+
 	beforeEach(() => {
 		db = new Database(":memory:");
 		initTestSchema(db);
@@ -360,5 +383,109 @@ describe("listAuthorizedScopesForPeer", () => {
 				peerDeviceId: LOCAL_DEVICE,
 			}),
 		).toEqual([]);
+	});
+
+	it("marks empty authorized Spaces current after scoped bootstrap records a cursor marker", () => {
+		insertScope("empty-work");
+		grantMembership("empty-work", LOCAL_DEVICE);
+		grantMembership("empty-work", PEER_DEVICE);
+		setReplicationCursor(
+			db,
+			PEER_DEVICE,
+			{ lastAcked: SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER },
+			"empty-work",
+		);
+
+		const scopes = listPerPeerScopeSyncState(db, {
+			localDeviceId: LOCAL_DEVICE,
+			peerDeviceId: PEER_DEVICE,
+		});
+
+		expect(scopes).toHaveLength(1);
+		expect(scopes[0]).toMatchObject({
+			bootstrapped: true,
+			last_acked_cursor: null,
+			last_applied_cursor: null,
+			scope_id: "empty-work",
+		});
+	});
+
+	it("does not treat peer-wide scoped attempts as per-Space evidence", () => {
+		insertScope("empty-work");
+		grantMembership("empty-work", LOCAL_DEVICE);
+		grantMembership("empty-work", PEER_DEVICE);
+		recordSyncAttempt(PEER_DEVICE, "2026-05-26T00:00:00.000Z");
+
+		const scopes = listPerPeerScopeSyncState(db, {
+			localDeviceId: LOCAL_DEVICE,
+			peerDeviceId: PEER_DEVICE,
+		});
+
+		expect(scopes).toHaveLength(1);
+		expect(scopes[0]).toMatchObject({
+			bootstrapped: false,
+			last_applied_cursor: null,
+			scope_id: "empty-work",
+		});
+	});
+
+	it("keeps newly granted Spaces pending until scoped sync records a cursor marker", () => {
+		insertScope("new-work");
+		grantMembership("new-work", LOCAL_DEVICE);
+		grantMembership("new-work", PEER_DEVICE);
+		recordSyncAttempt(PEER_DEVICE, "2026-05-26T00:00:00.000Z");
+
+		const scopes = listPerPeerScopeSyncState(db, {
+			localDeviceId: LOCAL_DEVICE,
+			peerDeviceId: PEER_DEVICE,
+		});
+
+		expect(scopes).toHaveLength(1);
+		expect(scopes[0]).toMatchObject({
+			bootstrapped: false,
+			last_applied_cursor: null,
+			scope_id: "new-work",
+		});
+	});
+
+	it("keeps empty Spaces pending after failed or non-scoped sync attempts", () => {
+		insertScope("empty-work");
+		grantMembership("empty-work", LOCAL_DEVICE);
+		grantMembership("empty-work", PEER_DEVICE);
+		recordSyncAttempt(PEER_DEVICE, "2026-05-26T00:00:00.000Z", { ok: false });
+		recordSyncAttempt(PEER_DEVICE, "2026-05-27T00:00:00.000Z", { capability: "aware" });
+
+		const scopes = listPerPeerScopeSyncState(db, {
+			localDeviceId: LOCAL_DEVICE,
+			peerDeviceId: PEER_DEVICE,
+		});
+
+		expect(scopes).toHaveLength(1);
+		expect(scopes[0]).toMatchObject({
+			bootstrapped: false,
+			last_applied_cursor: null,
+			scope_id: "empty-work",
+		});
+	});
+
+	it("keeps unadvertised Spaces pending even when newer irrelevant attempts exist", () => {
+		insertScope("empty-work");
+		grantMembership("empty-work", LOCAL_DEVICE);
+		grantMembership("empty-work", PEER_DEVICE);
+		recordSyncAttempt(PEER_DEVICE, "2026-05-26T00:00:00.000Z");
+		recordSyncAttempt(PEER_DEVICE, "2026-05-27T00:00:00.000Z", { ok: false });
+		recordSyncAttempt(PEER_DEVICE, "2026-05-28T00:00:00.000Z", { capability: "aware" });
+
+		const scopes = listPerPeerScopeSyncState(db, {
+			localDeviceId: LOCAL_DEVICE,
+			peerDeviceId: PEER_DEVICE,
+		});
+
+		expect(scopes).toHaveLength(1);
+		expect(scopes[0]).toMatchObject({
+			bootstrapped: false,
+			last_applied_cursor: null,
+			scope_id: "empty-work",
+		});
 	});
 });

--- a/packages/core/src/sync-scope-protocol.ts
+++ b/packages/core/src/sync-scope-protocol.ts
@@ -11,6 +11,7 @@ import {
 	DEFAULT_SYNC_SCOPE_ID,
 	getReplicationCursor,
 	getSyncResetState,
+	SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
 } from "./sync-replication.js";
 
 export const SYNC_SCOPE_QUERY_PARAM = "scope_id";
@@ -296,14 +297,16 @@ export function listPerPeerScopeSyncState(
 	const scopes = listAuthorizedScopesForPeer(db, { localDeviceId, peerDeviceId });
 	return scopes.map((scope) => {
 		const [lastApplied, lastAcked] = getReplicationCursor(db, peerDeviceId, scope.scope_id);
+		const hasNullBaselineBootstrapMarker =
+			lastAcked === SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER;
 		return {
 			scope_id: scope.scope_id,
 			label: scope.label,
 			authority_type: scope.authority_type,
 			membership_epoch: scope.membership_epoch,
 			last_applied_cursor: lastApplied,
-			last_acked_cursor: lastAcked,
-			bootstrapped: lastApplied != null,
+			last_acked_cursor: hasNullBaselineBootstrapMarker ? null : lastAcked,
+			bootstrapped: lastApplied != null || hasNullBaselineBootstrapMarker,
 		};
 	});
 }

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -21,11 +21,13 @@ import {
 	derivePeerGrantRoleMismatchView,
 	derivePeerProjectNarrowingView,
 	derivePeerScopeRejectionsView,
+	derivePeerScopeSyncView,
 	derivePeerTrustSummary,
 	derivePeerUiStatus,
 	type PeerClaimedLocalActorScopeLike,
 	type PeerDirection,
 	type PeerLike,
+	type PeerPerScopeSyncLike,
 	type PeerProjectScopeLike,
 	type PeerScopeRejectionsSummary,
 } from "../view-model";
@@ -108,6 +110,7 @@ type SyncPeer = PeerLike & {
 	addresses?: unknown[];
 	claimed_local_actor?: boolean;
 	claimed_local_actor_scope?: PeerClaimedLocalActorScopeLike | null;
+	per_scope_sync?: PeerPerScopeSyncLike[];
 	project_scope?: PeerProjectScopeLike;
 	scope_rejections?: PeerScopeRejectionsSummary;
 	discovered_via_coordinator_id?: string | null;
@@ -165,6 +168,7 @@ function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncP
 	const pendingScopeReview = rawPendingScopeReview && authorizedDomains.total === 0;
 	const grantRoleMismatch = derivePeerGrantRoleMismatchView(peer);
 	const scopeRejections = derivePeerScopeRejectionsView(peer);
+	const scopeSync = derivePeerScopeSyncView(peer);
 	const scope = peer.project_scope || {};
 	const projectNarrowing = derivePeerProjectNarrowingView(scope);
 	const primaryAddress = pickPrimaryAddress(peer.addresses);
@@ -548,6 +552,27 @@ function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncP
 							</div>
 						) : null}
 						<div className="peer-meta">{projectNarrowing.note}</div>
+
+						<div className="peer-scope-summary">Space sync progress</div>
+						<div className="peer-meta">
+							{scopeSync.total > 0
+								? "Per-Space progress for this device. Open details to see technical identifiers."
+								: scopeSync.emptyMessage}
+						</div>
+						{scopeSync.rows.length > 0 ? (
+							<ul className="peer-scope-rejections-list" aria-label="Per-Space sync progress">
+								{scopeSync.rows.map((row) => (
+									<li key={row.scopeId} title={row.detail}>
+										<span className="peer-scope-rejection-label">{row.label}</span>
+										<span
+											className={`badge ${row.status === "received" ? "badge-online" : "actor-badge"}`}
+										>
+											{row.badgeLabel}
+										</span>
+									</li>
+								))}
+							</ul>
+						) : null}
 
 						{scopeRejections.total > 0 ? (
 							<div

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -7,6 +7,7 @@ import {
 	derivePeerGrantRoleMismatchView,
 	derivePeerProjectNarrowingView,
 	derivePeerScopeRejectionsView,
+	derivePeerScopeSyncView,
 	derivePeerTrustSummary,
 	derivePeerUiStatus,
 	deriveSyncViewModel,
@@ -228,6 +229,65 @@ describe("derivePeerAuthorizedDomainsView", () => {
 		expect(view.domains[0]?.label).toBe("Untitled Space");
 		expect(view.domains[0]?.label).not.toContain("team-alpha-default");
 		expect(view.domains[0]?.detail).not.toContain("team-alpha-default");
+	});
+});
+
+describe("derivePeerScopeSyncView", () => {
+	it("maps per-Space cursor state to received and pending rows", () => {
+		const view = derivePeerScopeSyncView({
+			per_scope_sync: [
+				{
+					authority_type: "coordinator",
+					bootstrapped: true,
+					label: "Acme Work",
+					last_acked_cursor: "2026-01-01T00:00:01Z|ack",
+					last_applied_cursor: "2026-01-01T00:00:02Z|applied",
+					membership_epoch: 3,
+					scope_id: "acme-work",
+				},
+				{
+					authority_type: "local",
+					bootstrapped: false,
+					label: "Personal",
+					last_applied_cursor: null,
+					membership_epoch: 1,
+					scope_id: "personal",
+				},
+				{
+					authority_type: "coordinator",
+					bootstrapped: true,
+					label: "Empty Work",
+					last_applied_cursor: null,
+					membership_epoch: 1,
+					scope_id: "empty-work",
+				},
+			],
+		});
+
+		expect(view.total).toBe(3);
+		expect(view.rows.map((row) => [row.label, row.status, row.badgeLabel])).toEqual([
+			["Acme Work", "received", "Received"],
+			["Personal", "pending", "Pending"],
+			["Empty Work", "received", "Received"],
+		]);
+		expect(view.rows[0]?.detail).toContain("Scope id: acme-work");
+		expect(view.rows[0]?.detail).toContain("membership epoch 3");
+	});
+
+	it("keeps raw Space ids out of primary labels when labels are missing", () => {
+		const view = derivePeerScopeSyncView({
+			per_scope_sync: [
+				{
+					bootstrapped: false,
+					last_applied_cursor: null,
+					scope_id: "team-alpha-default",
+				},
+			],
+		});
+
+		expect(view.rows[0]?.label).toBe("Untitled Space");
+		expect(view.rows[0]?.label).not.toContain("team-alpha-default");
+		expect(view.rows[0]?.detail).toContain("Scope id: team-alpha-default");
 	});
 });
 

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -18,6 +18,7 @@ export {
 	derivePeerGrantRoleMismatchView,
 	derivePeerProjectNarrowingView,
 	derivePeerScopeRejectionsView,
+	derivePeerScopeSyncView,
 	derivePeerTrustSummary,
 	derivePeerUiStatus,
 	type PeerAuthorizedDomainsView,
@@ -25,6 +26,8 @@ export {
 	type PeerGrantRoleMismatchView,
 	type PeerProjectNarrowingView,
 	type PeerScopeRejectionsView,
+	type PeerScopeSyncView,
+	type PeerScopeSyncViewItem,
 } from "./view-model/peer-status";
 export {
 	deriveDuplicatePeople,
@@ -38,6 +41,7 @@ export {
 	type PeerClaimedLocalActorScopeLike,
 	type PeerDirection,
 	type PeerLike,
+	type PeerPerScopeSyncLike,
 	type PeerProjectScopeLike,
 	type PeerRecentOps,
 	type PeerScopeRejectionReason,

--- a/packages/ui/src/tabs/sync/view-model/peer-status.ts
+++ b/packages/ui/src/tabs/sync/view-model/peer-status.ts
@@ -13,6 +13,7 @@ import type {
 	PeerAuthorizedScopeLike,
 	PeerDirection,
 	PeerLike,
+	PeerPerScopeSyncLike,
 	PeerProjectScopeLike,
 	PeerScopeRejectionReason,
 	UiPeerTrustSummary,
@@ -191,6 +192,22 @@ export interface PeerGrantRoleMismatchView {
 	detail: string;
 }
 
+export type PeerScopeSyncStatus = "received" | "pending";
+
+export interface PeerScopeSyncViewItem {
+	scopeId: string;
+	label: string;
+	status: PeerScopeSyncStatus;
+	badgeLabel: string;
+	detail: string;
+}
+
+export interface PeerScopeSyncView {
+	total: number;
+	rows: PeerScopeSyncViewItem[];
+	emptyMessage: string;
+}
+
 export function derivePeerAuthorizedDomainsView(peer: PeerLike): PeerAuthorizedDomainsView {
 	const domains = (Array.isArray(peer.authorized_scopes) ? peer.authorized_scopes : [])
 		.map((scope: PeerAuthorizedScopeLike): PeerAuthorizedDomainViewItem | null => {
@@ -216,6 +233,45 @@ export function derivePeerAuthorizedDomainsView(peer: PeerLike): PeerAuthorizedD
 		domains,
 		emptyMessage:
 			"No Space access grants exist for this device yet. Advanced project filters cannot send data by themselves.",
+	};
+}
+
+export function derivePeerScopeSyncView(peer: PeerLike): PeerScopeSyncView {
+	const rows = (Array.isArray(peer.per_scope_sync) ? peer.per_scope_sync : [])
+		.map((scope: PeerPerScopeSyncLike): PeerScopeSyncViewItem | null => {
+			const scopeId = cleanText(scope.scope_id);
+			const rawLabel = cleanText(scope.label);
+			if (!scopeId && !rawLabel) return null;
+			const label = rawLabel || "Untitled Space";
+			const lastApplied = cleanText(scope.last_applied_cursor);
+			const lastAcked = cleanText(scope.last_acked_cursor);
+			const bootstrapped = scope.bootstrapped === true || Boolean(lastApplied);
+			const status: PeerScopeSyncStatus = bootstrapped ? "received" : "pending";
+			const authority = labelPart(cleanText(scope.authority_type), "local");
+			const epoch = Number(scope.membership_epoch ?? 0);
+			const detail = [
+				`Scope id: ${scopeId || "unknown"}`,
+				`${authority} authority`,
+				Number.isFinite(epoch) ? `membership epoch ${epoch}` : null,
+				lastApplied ? `last applied ${lastApplied}` : null,
+				lastAcked ? `last acknowledged ${lastAcked}` : null,
+			]
+				.filter((value): value is string => Boolean(value))
+				.join(" · ");
+			return {
+				scopeId: scopeId || label,
+				label,
+				status,
+				badgeLabel: status === "received" ? "Received" : "Pending",
+				detail,
+			};
+		})
+		.filter((item): item is PeerScopeSyncViewItem => item != null);
+	return {
+		total: rows.length,
+		rows,
+		emptyMessage:
+			"No per-Space sync progress is available yet. Run sync after both devices have Space access.",
 	};
 }
 

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -158,6 +158,16 @@ export interface PeerAuthorizedScopeLike {
 	updated_at?: string | null;
 }
 
+export interface PeerPerScopeSyncLike {
+	scope_id?: string | null;
+	label?: string | null;
+	authority_type?: string | null;
+	membership_epoch?: number | null;
+	last_applied_cursor?: string | null;
+	last_acked_cursor?: string | null;
+	bootstrapped?: boolean | null;
+}
+
 export interface PeerClaimedLocalActorScopeLike {
 	scope_id?: string | null;
 	authorized?: boolean;
@@ -179,6 +189,7 @@ export interface PeerLike {
 	scope_rejections?: PeerScopeRejectionsSummary;
 	project_scope?: PeerProjectScopeLike;
 	authorized_scopes?: PeerAuthorizedScopeLike[];
+	per_scope_sync?: PeerPerScopeSyncLike[];
 	claimed_local_actor?: boolean;
 	claimed_local_actor_scope?: PeerClaimedLocalActorScopeLike | null;
 }


### PR DESCRIPTION
## Description
Renders per-Space sync progress in the viewer Sync peer drawer from `per_scope_sync`, showing received vs pending Space rows while keeping technical scope ids in expanded details instead of primary labels.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
