### PR TITLE
fix(sync): gate discovered-device pairing setup states

### DIFF
--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -491,6 +491,7 @@ export interface ApiCoordinatorDiscoveredDevice {
 export interface ApiCoordinatorStatus {
 	enabled: boolean;
 	configured: boolean;
+	sync_enabled?: boolean;
 	coordinator_url?: string | null;
 	groups?: string[];
 	group_id?: string | null;

--- a/packages/core/src/coordinator-runtime.test.ts
+++ b/packages/core/src/coordinator-runtime.test.ts
@@ -243,6 +243,13 @@ describe("coordinatorStatusSnapshot", () => {
 			const second = await coordinatorStatusSnapshot(store, config);
 			const secondFetchCount = fetchCount;
 			const secondPresenceFetchCount = presenceFetchCount;
+			const disabledSyncConfig = readCoordinatorSyncConfig({
+				sync_enabled: false,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+			});
+			const disabledSync = await coordinatorStatusSnapshot(store, disabledSyncConfig);
+			const disabledSyncFetchCount = fetchCount;
 			const changedAdvertiseConfig = readCoordinatorSyncConfig({
 				sync_enabled: true,
 				sync_coordinator_url: "https://coord.example.test",
@@ -254,11 +261,14 @@ describe("coordinatorStatusSnapshot", () => {
 			process.env.CODEMEM_KEYS_DIR = alternateKeysDir;
 			await coordinatorStatusSnapshot(store, changedAdvertiseConfig);
 
+			expect(first.sync_enabled).toBe(true);
 			expect(first.discovered_peer_count).toBe(1);
 			expect(second.discovered_peer_count).toBe(1);
 			expect(second.paired_peer_count).toBe(1);
+			expect(disabledSync.sync_enabled).toBe(false);
 			expect(firstFetchCount).toBeGreaterThan(0);
 			expect(secondFetchCount).toBe(firstFetchCount);
+			expect(disabledSyncFetchCount).toBeGreaterThan(secondFetchCount);
 			expect(secondPresenceFetchCount).toBe(1);
 			expect(changedAdvertisePresenceFetchCount).toBeGreaterThan(secondPresenceFetchCount);
 			expect(lastPresenceAddresses).toEqual(["http://new.example.test:7337"]);

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -139,6 +139,7 @@ function coordinatorStatusCacheKey(
 ): string {
 	return [
 		presenceCacheKey(store, config),
+		config.syncEnabled ? "sync-enabled" : "sync-disabled",
 		config.syncHost,
 		config.syncPort,
 		config.syncAdvertise,
@@ -575,6 +576,8 @@ export async function coordinatorStatusSnapshot(
 		return {
 			enabled: false,
 			configured: false,
+			sync_enabled: config.syncEnabled,
+			coordinator_url: config.syncCoordinatorUrl || null,
 			groups: config.syncCoordinatorGroups,
 			paired_peer_count: currentPairedPeerCount,
 		};
@@ -593,6 +596,7 @@ export async function coordinatorStatusSnapshot(
 	const snapshot: Record<string, unknown> = {
 		enabled: true,
 		configured: true,
+		sync_enabled: config.syncEnabled,
 		coordinator_url: config.syncCoordinatorUrl,
 		groups: config.syncCoordinatorGroups,
 		paired_peer_count: currentPairedPeerCount,

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -141,8 +141,9 @@ export interface DiscoveredDevice {
 
 export interface CachedSyncCoordinator {
 	configured?: boolean;
+	sync_enabled?: boolean;
 	groups?: unknown[];
-	coordinator_url?: string;
+	coordinator_url?: string | null;
 	discovered_devices?: DiscoveredDevice[];
 	presence_status?: string;
 	paired_peer_count?: number;

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -15,7 +15,15 @@ export interface TeamSyncDiscoveredRow {
 	displayName: string;
 	displayTitle: string | null;
 	fingerprint: string;
-	mode: "accept" | "ambiguous" | "conflict" | "none" | "paired" | "scope-pending" | "stale";
+	mode:
+		| "accept"
+		| "ambiguous"
+		| "conflict"
+		| "none"
+		| "paired"
+		| "scope-pending"
+		| "setup-blocked"
+		| "stale";
 	note: string;
 	pairedMessage: string | null;
 	connectionLabel: string;
@@ -219,7 +227,10 @@ function DiscoveredDeviceRow({
 						{reviewLabel}
 					</button>
 				) : null}
-				{(row.mode === "stale" || row.mode === "ambiguous" || row.mode === "scope-pending") &&
+				{(row.mode === "stale" ||
+					row.mode === "ambiguous" ||
+					row.mode === "scope-pending" ||
+					row.mode === "setup-blocked") &&
 				row.actionMessage ? (
 					<div className="peer-meta">{row.actionMessage}</div>
 				) : null}

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -36,6 +36,7 @@ import {
 } from "../../sync-dialogs";
 import {
 	deriveCoordinatorApprovalSummary,
+	deriveCoordinatorSetupBlocker,
 	resolveFriendlyDeviceName,
 	SYNC_TERMINOLOGY,
 	shouldShowCoordinatorReviewAction,
@@ -227,9 +228,11 @@ export function renderTeamSync() {
 	};
 
 	const configured = Boolean(coordinator?.configured);
+	const setupBlocker = deriveCoordinatorSetupBlocker(coordinator);
 	meta.textContent = configured
 		? `Team: ${(coordinator.groups || []).join(", ") || "none"}`
-		: "Start by joining an existing team or creating one, then connect people and devices.";
+		: setupBlocker?.message ||
+			"Start by joining an existing team or creating one, then connect people and devices.";
 	meta.title = configured ? String(coordinator.coordinator_url || "").trim() : "";
 
 	const onlineBadge = document.getElementById("syncOnlineBadge");
@@ -279,11 +282,13 @@ export function renderTeamSync() {
 			Boolean(fingerprint) &&
 			Boolean(pairedFingerprint) &&
 			pairedFingerprint !== fingerprint;
-		const canAccept = shouldShowCoordinatorReviewAction({
-			device,
-			hasAmbiguousCoordinatorGroup,
-			pairedLocally: Boolean(pairedPeer),
-		});
+		const canAccept =
+			!setupBlocker &&
+			shouldShowCoordinatorReviewAction({
+				device,
+				hasAmbiguousCoordinatorGroup,
+				pairedLocally: Boolean(pairedPeer),
+			});
 		const addresses = Array.isArray(device.addresses) ? device.addresses : [];
 		const rawHiddenAddressCount = Number(device.address_count ?? 0);
 		const hiddenAddressCount =
@@ -308,6 +313,9 @@ export function renderTeamSync() {
 
 		if (hasConflict) {
 			mode = "conflict";
+		} else if (setupBlocker && (!pairedPeer || approvalSummary.state === "needs-your-approval")) {
+			actionMessage = setupBlocker.message;
+			mode = "setup-blocked";
 		} else if (hasAmbiguousCoordinatorGroup) {
 			actionMessage =
 				"This device appears in multiple coordinator groups. Review team setup first or ask an admin to clean up the duplicate enrollment before approving it here.";

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	deriveCoordinatorApprovalSummary,
+	deriveCoordinatorSetupBlocker,
 	deriveDuplicatePeople,
 	derivePeerAuthorizedDomainsView,
 	derivePeerGrantRoleMismatchView,
@@ -62,6 +63,51 @@ describe("deviceNeedsFriendlyName", () => {
 				deviceId: "12345678-1234-1234-1234-123456789abc",
 			}),
 		).toBe(false);
+	});
+});
+
+describe("deriveCoordinatorSetupBlocker", () => {
+	it("asks users to configure a coordinator URL first", () => {
+		expect(deriveCoordinatorSetupBlocker({ groups: ["team-a"], sync_enabled: true })).toEqual({
+			reason: "coordinator_url_missing",
+			message: "Configure a coordinator URL before pairing team devices.",
+		});
+	});
+
+	it("asks users to join or configure a team before pairing", () => {
+		expect(
+			deriveCoordinatorSetupBlocker({
+				coordinator_url: "https://coord.example.test",
+				groups: [],
+				sync_enabled: true,
+			}),
+		).toEqual({
+			reason: "coordinator_groups_empty",
+			message: "Join or configure a team before pairing team devices.",
+		});
+	});
+
+	it("asks users to enable sync before pairing when coordinator setup exists", () => {
+		expect(
+			deriveCoordinatorSetupBlocker({
+				coordinator_url: "https://coord.example.test",
+				groups: ["team-a"],
+				sync_enabled: false,
+			}),
+		).toEqual({
+			reason: "sync_disabled",
+			message: "Enable sync before pairing team devices.",
+		});
+	});
+
+	it("returns no blocker when coordinator setup and sync are ready", () => {
+		expect(
+			deriveCoordinatorSetupBlocker({
+				coordinator_url: "https://coord.example.test",
+				groups: ["team-a"],
+				sync_enabled: true,
+			}),
+		).toBeNull();
 	});
 });
 

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -33,9 +33,14 @@ export {
 	deriveDuplicatePeople,
 	deriveVisiblePeopleActors,
 } from "./view-model/people-derivations";
-export { deriveSyncViewModel } from "./view-model/sync-view-model";
+export {
+	deriveCoordinatorSetupBlocker,
+	deriveSyncViewModel,
+} from "./view-model/sync-view-model";
 export {
 	type ActorLike,
+	type CoordinatorSetupBlocker,
+	type CoordinatorSetupBlockerReason,
 	type DiscoveredDeviceLike,
 	type PeerAuthorizedScopeLike,
 	type PeerClaimedLocalActorScopeLike,

--- a/packages/ui/src/tabs/sync/view-model/sync-view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model/sync-view-model.ts
@@ -10,6 +10,7 @@ import { derivePeerTrustSummary, derivePeerUiStatus } from "./peer-status";
 import { deriveDuplicatePeople } from "./people-derivations";
 import type {
 	ActorLike,
+	CoordinatorSetupBlocker,
 	DiscoveredDeviceLike,
 	PeerLike,
 	UiSyncAttentionItem,
@@ -77,6 +78,40 @@ function createNamingItem(device: {
 		actionLabel: "Go to name field",
 		deviceId: device.id,
 	};
+}
+
+export function deriveCoordinatorSetupBlocker(
+	coordinator:
+		| {
+				configured?: boolean;
+				coordinator_url?: string | null;
+				groups?: unknown[];
+				sync_enabled?: boolean;
+		  }
+		| null
+		| undefined,
+): CoordinatorSetupBlocker | null {
+	const coordinatorUrl = cleanText(coordinator?.coordinator_url);
+	const groups = Array.isArray(coordinator?.groups) ? coordinator.groups : [];
+	if (!coordinatorUrl) {
+		return {
+			reason: "coordinator_url_missing",
+			message: "Configure a coordinator URL before pairing team devices.",
+		};
+	}
+	if (!groups.some((group) => cleanText(group))) {
+		return {
+			reason: "coordinator_groups_empty",
+			message: "Join or configure a team before pairing team devices.",
+		};
+	}
+	if (coordinator?.sync_enabled === false) {
+		return {
+			reason: "sync_disabled",
+			message: "Enable sync before pairing team devices.",
+		};
+	}
+	return null;
 }
 
 function mergeDevices(

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -98,6 +98,16 @@ export interface UiSyncViewModel {
 	attentionItems: UiSyncAttentionItem[];
 }
 
+export type CoordinatorSetupBlockerReason =
+	| "coordinator_groups_empty"
+	| "coordinator_url_missing"
+	| "sync_disabled";
+
+export interface CoordinatorSetupBlocker {
+	reason: CoordinatorSetupBlockerReason;
+	message: string;
+}
+
 export interface UiPeerTrustSummary {
 	state: UiTrustState;
 	badgeLabel: string;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -5433,6 +5433,13 @@ describe("viewer-server", () => {
 					interval_s: number;
 					project_filter_active: boolean;
 					project_filter: { include: string[]; exclude: string[] };
+					coordinator: {
+						enabled: boolean;
+						configured: boolean;
+						sync_enabled: boolean;
+						groups: string[];
+					};
+					join_requests: Array<{ request_id: string }>;
 				};
 				expect(body.enabled).toBe(true);
 				expect(body.interval_s).toBe(45);
@@ -5440,6 +5447,7 @@ describe("viewer-server", () => {
 				expect(body.project_filter).toEqual({ include: ["codemem"], exclude: ["junk"] });
 				expect(body.coordinator.enabled).toBe(true);
 				expect(body.coordinator.configured).toBe(true);
+				expect(body.coordinator.sync_enabled).toBe(true);
 				expect(body.coordinator.groups).toEqual(["team-a"]);
 				expect(body.join_requests).toHaveLength(1);
 				expect(body.join_requests[0].request_id).toBe("req-1");


### PR DESCRIPTION
## Description
Blocks discovered-device direct pairing when coordinator setup is incomplete, using the same setup reasons exposed by the server. The Sync UI now shows actionable setup guidance instead of offering an accept button that cannot succeed.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run before stack submission:
- `pnpm exec vitest run packages/ui/src/tabs/sync/view-model.test.ts -t "deriveCoordinatorSetupBlocker"`
- `pnpm exec vitest run packages/core/src/coordinator-runtime.test.ts -t "coordinatorStatusSnapshot"`
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts -t "returns real sync config and coordinator status details"`
- `pnpm build`
- `pnpm run check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

Fixes codemem-93kx.