### PR TITLE
fix(sync): show friendly names in pairing requests

### DIFF
--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -189,6 +189,7 @@ export interface CachedPairingPayload {
 export interface CachedSyncJoinRequest {
 	display_name?: string;
 	device_id?: string;
+	fingerprint?: string;
 	request_id?: string;
 }
 

--- a/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.test.tsx
+++ b/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.test.tsx
@@ -1,0 +1,77 @@
+import { type ComponentChildren, render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { state } from "../../../lib/state";
+import { coordinatorAdminState } from "../data/state";
+import { renderJoinRequestsPanel } from "./join-requests-panel";
+
+vi.mock("../../../components/primitives/radix-tabs", () => ({
+	RadixTabsContent: ({
+		children,
+		className,
+	}: {
+		children?: ComponentChildren;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+}));
+
+let mount: HTMLDivElement | null = null;
+
+function renderPanel() {
+	mount = document.createElement("div");
+	document.body.appendChild(mount);
+	act(() => {
+		render(
+			renderJoinRequestsPanel({
+				reviewJoinRequest: vi.fn(),
+				summary: {
+					detail: "Ready",
+					readiness: "ready",
+					title: "Ready",
+				},
+			}),
+			mount as HTMLDivElement,
+		);
+	});
+	return mount;
+}
+
+describe("JoinRequestsPanel", () => {
+	beforeEach(() => {
+		state.lastCoordinatorAdminJoinRequests = [
+			{
+				device_id: "dev-1",
+				display_name: "Adam laptop",
+				fingerprint: "fp-abc123",
+				request_id: "req-1",
+			},
+		];
+		coordinatorAdminState.joinReviewPendingId = null;
+		coordinatorAdminState.joinReviewPendingAction = null;
+	});
+
+	afterEach(() => {
+		if (mount) {
+			act(() => {
+				render(null, mount as HTMLDivElement);
+			});
+			mount.remove();
+			mount = null;
+		}
+		document.body.innerHTML = "";
+		state.lastCoordinatorAdminJoinRequests = [];
+		coordinatorAdminState.joinReviewPendingId = null;
+		coordinatorAdminState.joinReviewPendingAction = null;
+		vi.clearAllMocks();
+	});
+
+	it("shows friendly names with device identity as secondary diagnostics", () => {
+		const root = renderPanel();
+
+		expect(root.querySelector(".peer-title strong")?.textContent).toBe("Adam laptop");
+		expect(root.querySelector(".peer-meta")?.textContent).toBe(
+			"Advanced: Device ID dev-1 · Fingerprint fp-abc123",
+		);
+	});
+});

--- a/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
@@ -44,13 +44,16 @@ export function renderJoinRequestsPanel(deps: JoinRequestsPanelDeps) {
 					items.map((item) => {
 						const requestId = String(item.request_id || "").trim();
 						const deviceId = String(item.device_id || "unknown-device");
-						const displayName = String(item.display_name || deviceId);
+						const displayName = String(item.display_name || deviceId).trim() || deviceId;
+						const fingerprint = String(item.fingerprint || "").trim();
+						const advancedDetails = [`Device ID ${deviceId}`];
+						if (fingerprint) advancedDetails.push(`Fingerprint ${fingerprint}`);
 						const pending = coordinatorAdminState.joinReviewPendingId === requestId;
 						return h(
 							"div",
 							{ class: "peer-card peer-card--padded", key: requestId || deviceId },
 							h("div", { class: "peer-title" }, h("strong", null, displayName)),
-							h("div", { class: "peer-meta" }, `Advanced: Device ID ${deviceId}`),
+							h("div", { class: "peer-meta" }, `Advanced: ${advancedDetails.join(" · ")}`),
 							h(
 								"div",
 								{ class: "peer-actions" },


### PR DESCRIPTION
## Description
Shows pending pairing/join requests with the friendly device name as the primary label when available, while keeping device ID and fingerprint as secondary diagnostics. This makes it easier to recognize who or what is asking to join without hiding low-level identity data.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run before stack submission:
- `pnpm exec vitest run packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.test.tsx`
- `pnpm build`
- `pnpm run check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

Fixes codemem-hyrf.