### PR TITLE
chore(ui): rename Coordinator Admin surface to Teams

### DIFF
--- a/docs/design/disclosure-region-anatomy.md
+++ b/docs/design/disclosure-region-anatomy.md
@@ -44,8 +44,8 @@ semantics, use a plain `<button aria-controls aria-expanded>` toggle
 next to a region that conditionally renders. Examples in the codebase:
 
 - "Advanced sharing scope" in the device detail drawer.
-- "Show archived" groups toggle in Coordinator Admin.
-- Coordinator Admin "Scope defaults" drawer inside each group card.
+- "Show archived" Teams toggle in Teams.
+- Teams "Scope defaults" drawer inside each Team card.
 
 Use `var(--sp-3)` gap between the toggle and its revealed region, and
 keep the region inside the same card when possible so proximity

--- a/packages/ui/src/tabs/coordinator-admin/components/devices-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/devices-panel.ts
@@ -36,7 +36,7 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 			{ class: "peer-submeta" },
 			summary.readiness === "ready"
 				? "Rename, disable, re-enable, or remove Team devices here. Space access is granted from Spaces below; Team membership alone does not share memories."
-				: "Finish setup first. Device administration stays disabled until coordinator admin is ready.",
+				: "Finish setup first. Device administration stays disabled until Teams is ready.",
 		),
 		!items.length
 			? h(

--- a/packages/ui/src/tabs/coordinator-admin/components/invites-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/invites-panel.ts
@@ -40,7 +40,7 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 			{ class: "peer-submeta" },
 			summary.readiness === "ready"
 				? "Generate an invite for the selected Team. Default Space access is controlled by that Team's auto-grant setting."
-				: "Finish setup first. Invite creation stays disabled until the local coordinator admin configuration is ready.",
+				: "Finish setup first. Invite creation stays disabled until the local Teams configuration is ready.",
 		),
 		h(
 			"form",

--- a/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
@@ -28,7 +28,7 @@ export function renderJoinRequestsPanel(deps: JoinRequestsPanelDeps) {
 			{ class: "peer-submeta" },
 			summary.readiness === "ready"
 				? "Approve or deny devices that want to join this Team. Default Space access is handled by Team defaults and can be reviewed in Spaces."
-				: "Finish setup first. Join request review stays disabled until coordinator admin is ready.",
+				: "Finish setup first. Join request review stays disabled until Teams is ready.",
 		),
 		!items.length
 			? h(

--- a/packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts
@@ -15,7 +15,7 @@ describe("coordinator admin scope management view helpers", () => {
 		expect(
 			scopeManagementReadinessMessage({
 				readiness: "partial",
-				title: "Coordinator admin setup is incomplete",
+				title: "Teams setup is incomplete",
 				detail: "Set a coordinator admin secret.",
 			}),
 		).toContain("admin secret");

--- a/packages/ui/src/tabs/coordinator-admin/data/summary.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/summary.ts
@@ -17,32 +17,32 @@ export function coordinatorAdminSummary(): CoordinatorAdminSummary {
 	if (!status) {
 		return {
 			readiness: "partial",
-			title: "Checking coordinator admin readiness…",
-			detail: "Loading local coordinator admin configuration from the viewer server.",
+			title: "Checking Teams readiness…",
+			detail: "Loading local Teams configuration from the viewer server.",
 		};
 	}
 	if (status.readiness === "ready") {
 		return {
 			readiness: "ready",
-			title: "Coordinator admin is ready",
+			title: "Teams is ready",
 			detail:
-				"This viewer can use the local admin configuration to manage invites, join requests, and enrolled devices without exposing the admin secret to the browser.",
+				"This viewer can use the local Teams admin configuration to manage invites, join requests, and enrolled devices without exposing the admin secret to the browser.",
 		};
 	}
 	if (status.readiness === "partial") {
 		return {
 			readiness: "partial",
-			title: "Coordinator admin setup is incomplete",
+			title: "Teams setup is incomplete",
 			detail:
 				status.has_admin_secret === false
-					? "Set a coordinator admin secret for the viewer server before using invite and device admin actions."
-					: "Finish configuring the coordinator target and group before using admin actions.",
+					? "Set a coordinator admin secret for the viewer server before using Teams invite and device actions."
+					: "Finish configuring the coordinator target and Team before using Teams actions.",
 		};
 	}
 	return {
 		readiness: "not_configured",
-		title: "Coordinator admin is not configured",
+		title: "Teams is not configured",
 		detail:
-			"Set a coordinator URL, group, and admin secret locally to enable remote coordinator administration from this viewer.",
+			"Set a coordinator URL, Team, and admin secret locally to enable remote Teams administration from this viewer.",
 	};
 }

--- a/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
+++ b/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
@@ -133,7 +133,7 @@ function renderShell() {
 				h(
 					RadixTabs,
 					{
-						ariaLabel: "Coordinator admin sections",
+						ariaLabel: "Teams sections",
 						listClassName: "coordinator-admin-tabs-list",
 						onValueChange: (value) => {
 							coordinatorAdminState.activeSection = (value as AdminSection) || "groups";

--- a/packages/ui/src/tabs/sync/team-sync/helpers/invite-panel-dom.ts
+++ b/packages/ui/src/tabs/sync/team-sync/helpers/invite-panel-dom.ts
@@ -32,14 +32,14 @@ export function applySyncInviteReadinessState() {
 		syncCreateInviteButton.disabled = false;
 		hint.hidden = false;
 		hint.textContent = activeGroup
-			? `Remote coordinator admin is ready for ${activeGroup}. Advanced admin tools now live in Coordinator Admin.`
-			: "Remote coordinator admin is ready. Advanced admin tools now live in Coordinator Admin.";
+			? `Teams is ready for ${activeGroup}. Advanced admin tools now live in Teams.`
+			: "Teams is ready. Advanced admin tools now live in Teams.";
 		return;
 	}
 	const message =
 		readiness === "partial"
-			? "Finish coordinator admin setup before creating remote invites. Use Coordinator Admin to check what is missing."
-			: "Configure a coordinator URL, group, and admin secret before creating remote invites. Use Coordinator Admin to finish setup.";
+			? "Finish Teams setup before creating remote invites. Use Teams to check what is missing."
+			: "Configure a coordinator URL, Team, and admin secret before creating remote invites. Use Teams to finish setup.";
 	syncCreateInviteButton.disabled = true;
 	hint.hidden = false;
 	hint.textContent = message;

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -3418,7 +3418,7 @@
       <button class="tab-btn" id="tabBtn-projects">Projects</button>
       <button class="tab-btn" id="tabBtn-sync">Sync</button>
       <button class="tab-btn" id="tabBtn-health">Health</button>
-      <button class="tab-btn" id="tabBtn-coordinator-admin">Coordinator Admin</button>
+      <button class="tab-btn" id="tabBtn-coordinator-admin">Teams</button>
     </nav>
     <div id="toastRoot"></div>
     <div class="viewer-reconnect-overlay" id="viewerReconnectOverlay" hidden>


### PR DESCRIPTION
## Description
Renames the primary Coordinator Admin product surface to Teams in viewer navigation, readiness copy, Sync handoff text, and live design docs while keeping internal routes/modules/class names stable.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run before stack submission:
- `pnpm exec vitest run packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.test.tsx packages/ui/src/tabs/coordinator-admin/components/devices-panel.test.tsx`
- `pnpm build`
- `pnpm run check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

Fixes codemem-00dc.12.