### PR TITLE
fix(codex): remove unsupported hook config field

### DIFF
--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "codemem hook-first Codex integration",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Description
Remove the unsupported top-level `description` field from the packaged Codex plugin `hooks/hooks.json`.

Latest Codex strict-parses plugin hook configs and expects the file to contain the top-level `hooks` object only. Keeping `description` causes Codex to reject the codemem plugin during startup.

Fixes codemem-96w8.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `node -e ...` parsed `plugins/codex/hooks/hooks.json` and asserted the only top-level key is `hooks`
- `pnpm exec biome check --files-ignore-unknown=true plugins/codex/hooks/hooks.json` was attempted, but Biome ignores `plugins/` in this repo and processed 0 files

## Checklist

- [ ] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed; not needed for a packaging schema-only fix)
- [x] No new warnings introduced
