### PR TITLE
fix(sync): additively merge-recover scoped peers with local rows but no cursor

### DIFF
--- a/packages/core/src/sync-bootstrap.test.ts
+++ b/packages/core/src/sync-bootstrap.test.ts
@@ -5,10 +5,20 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { toJson } from "./db.js";
 import { getMaintenanceJob } from "./maintenance-jobs.js";
-import { applyBootstrapSnapshot, fetchAllSnapshotPages } from "./sync-bootstrap.js";
+import {
+	applyBootstrapSnapshot,
+	fetchAllSnapshotPages,
+	mergeBootstrapSnapshot,
+} from "./sync-bootstrap.js";
 import { SYNC_CAPABILITY_HEADER } from "./sync-capability.js";
 import { ensureDeviceIdentity } from "./sync-identity.js";
-import { getReplicationCursor, getSyncResetState, setSyncResetState } from "./sync-replication.js";
+import {
+	getReplicationCursor,
+	getSyncResetState,
+	SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
+	setReplicationCursor,
+	setSyncResetState,
+} from "./sync-replication.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import type { SyncMemorySnapshotItem, SyncResetRequired } from "./types.js";
 import { VECTOR_MODEL_MIGRATION_JOB } from "./vector-migration.js";
@@ -151,6 +161,12 @@ describe("applyBootstrapSnapshot", () => {
 		);
 
 		const items = [makeSnapshotItem("new-work-key")];
+		setReplicationCursor(
+			db,
+			"peer-1",
+			{ lastAcked: SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER },
+			"acme-work",
+		);
 		const result = applyBootstrapSnapshot(
 			db,
 			"peer-1",
@@ -176,6 +192,89 @@ describe("applyBootstrapSnapshot", () => {
 			"2026-01-01T00:00:05Z|base-op",
 			null,
 		]);
+	});
+
+	it("merge recovery preserves stale rows when a newer snapshot item is malformed", () => {
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, visibility, scope_id, metadata_json)
+			 VALUES (?, 'discovery', 'stale-work', 'body', ?, ?, 'stale-work-key', 1, 'shared', 'acme-work', ?)`,
+		).run(sessionId, now, now, toJson({ clock_device_id: "peer-dev" }));
+
+		const result = mergeBootstrapSnapshot(
+			db,
+			"peer-1",
+			[
+				{
+					entity_id: "stale-work-key",
+					op_type: "upsert",
+					payload_json: "{not-json",
+					clock_rev: 2,
+					clock_updated_at: "2026-01-02T00:00:00Z",
+					clock_device_id: "peer-dev",
+				},
+			],
+			makeResetInfo({ scope_id: "acme-work", baseline_cursor: null }),
+		);
+
+		expect(result.ok).toBe(true);
+		expect(result.applied).toBe(0);
+		expect(result.deleted).toBe(0);
+		expect(
+			db
+				.prepare("SELECT title FROM memory_items WHERE import_key = ? AND scope_id = ?")
+				.get("stale-work-key", "acme-work"),
+		).toMatchObject({ title: "stale-work" });
+	});
+
+	it("merge recovery breaks rev/updated_at ties on clock_device_id", () => {
+		const tied = "2026-01-01T00:00:02Z";
+		const seedRow = (importKey: string, title: string, deviceId: string) => {
+			db.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, visibility, scope_id, metadata_json)
+				 VALUES (?, 'discovery', ?, 'body', ?, ?, ?, 1, 'shared', 'acme-work', ?)`,
+			).run(sessionId, title, tied, tied, importKey, toJson({ clock_device_id: deviceId }));
+		};
+		// Existing local clock device id sorts lower than the snapshot's, so on an
+		// exact rev/updated_at tie the snapshot should win and replace the row.
+		seedRow("tie-loser-key", "stale-loser", "dev-a");
+		// Existing local clock device id sorts higher than the snapshot's, so the
+		// local row should win the tie and be preserved.
+		seedRow("tie-winner-key", "local-winner", "dev-z");
+
+		const result = mergeBootstrapSnapshot(
+			db,
+			"peer-1",
+			[
+				makeSnapshotItem("tie-loser-key", {
+					payload: { title: "snapshot-wins", scope_id: "acme-work" },
+					clock_rev: 1,
+					clock_updated_at: tied,
+					clock_device_id: "dev-m",
+				}),
+				makeSnapshotItem("tie-winner-key", {
+					payload: { title: "snapshot-loses", scope_id: "acme-work" },
+					clock_rev: 1,
+					clock_updated_at: tied,
+					clock_device_id: "dev-m",
+				}),
+			],
+			makeResetInfo({ scope_id: "acme-work", baseline_cursor: null }),
+		);
+
+		expect(result.ok).toBe(true);
+		expect(result.applied).toBe(1);
+		expect(result.deleted).toBe(1);
+		expect(
+			db
+				.prepare("SELECT title FROM memory_items WHERE import_key = ? AND scope_id = ?")
+				.get("tie-loser-key", "acme-work"),
+		).toMatchObject({ title: "snapshot-wins" });
+		expect(
+			db
+				.prepare("SELECT title FROM memory_items WHERE import_key = ? AND scope_id = ?")
+				.get("tie-winner-key", "acme-work"),
+		).toMatchObject({ title: "local-winner" });
 	});
 
 	it("unscoped bootstrap replaces only null and local-default scoped rows", () => {

--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -11,7 +11,7 @@
  *    bump generation
  */
 
-import { and, eq, isNotNull, isNull, ne, or, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, ne, or, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { ApiSyncMemorySnapshotPageResponse } from "./api-types.js";
 import type { Database } from "./db.js";
@@ -23,7 +23,9 @@ import { LOCAL_SYNC_CAPABILITY, SYNC_CAPABILITY_HEADER } from "./sync-capability
 import { requestJson } from "./sync-http-client.js";
 import {
 	clearReplicationCursorLastApplied,
+	clockDeviceIdFromMetadataJson,
 	DEFAULT_SYNC_SCOPE_ID,
+	isNewerClock,
 	SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
 	setReplicationCursor,
 	setSyncResetState,
@@ -56,6 +58,13 @@ export interface BootstrapResult {
 	applied: number;
 	deleted: number;
 	error?: string;
+}
+
+interface ExistingSnapshotRow {
+	id: number;
+	rev: number | null;
+	updated_at: string;
+	metadata_json: string | null;
 }
 
 export interface BootstrapOptions {
@@ -247,6 +256,117 @@ function ensureSessionForBootstrap(
 	return id;
 }
 
+function shouldReplaceExistingSnapshotRows(
+	existingRows: ExistingSnapshotRow[],
+	item: SyncMemorySnapshotItem,
+): boolean {
+	if (existingRows.length === 0) return true;
+	// Mirror the canonical last-writer-wins clock used by incremental
+	// replication: rev → updated_at → clock_device_id. Without the device-id
+	// tie-break, an exact rev+timestamp tie that the snapshot should win would
+	// be skipped here while the scoped cursor/baseline still advances, leaving
+	// the stale local row with no later pull to correct it.
+	const candidate: [number, string, string] = [
+		item.clock_rev,
+		item.clock_updated_at,
+		item.clock_device_id,
+	];
+	return existingRows.every((row) =>
+		isNewerClock(candidate, [
+			typeof row.rev === "number" ? row.rev : 0,
+			row.updated_at,
+			clockDeviceIdFromMetadataJson(row.metadata_json),
+		]),
+	);
+}
+
+function insertSnapshotItem(
+	d: ReturnType<typeof drizzle>,
+	item: SyncMemorySnapshotItem,
+	bootstrapScopeId: string | null,
+	activeScanner: SecretScanner,
+): { applied: boolean; embeddable: boolean } {
+	const payload = parseSnapshotPayload(item);
+	if (!payload) return { applied: false, embeddable: false };
+	redactMemoryFields(payload, activeScanner);
+	const scopeId = snapshotPayloadScopeId(payload, bootstrapScopeId);
+	const project =
+		typeof payload.project === "string" && payload.project.trim() ? payload.project.trim() : null;
+	const sessionId = ensureSessionForBootstrap(d, new Date().toISOString(), project);
+
+	const metaRaw = payload.metadata_json;
+	const meta =
+		metaRaw && typeof metaRaw === "object" && !Array.isArray(metaRaw)
+			? (metaRaw as Record<string, unknown>)
+			: {};
+	meta.clock_device_id = item.clock_device_id;
+
+	const isDeleted = item.op_type === "delete";
+
+	d.insert(schema.memoryItems)
+		.values({
+			session_id: sessionId,
+			kind: typeof payload.kind === "string" ? payload.kind : "discovery",
+			title: typeof payload.title === "string" ? payload.title : "",
+			subtitle: typeof payload.subtitle === "string" ? payload.subtitle : null,
+			body_text: typeof payload.body_text === "string" ? payload.body_text : "",
+			confidence: typeof payload.confidence === "number" ? payload.confidence : 0.5,
+			tags_text: typeof payload.tags_text === "string" ? payload.tags_text : "",
+			active: isDeleted ? 0 : 1,
+			created_at:
+				typeof payload.created_at === "string" ? payload.created_at : item.clock_updated_at,
+			updated_at: item.clock_updated_at,
+			metadata_json: toJson(meta),
+			import_key: item.entity_id,
+			deleted_at: isDeleted ? item.clock_updated_at : null,
+			rev: item.clock_rev,
+			actor_id: typeof payload.actor_id === "string" ? payload.actor_id : null,
+			actor_display_name:
+				typeof payload.actor_display_name === "string" ? payload.actor_display_name : null,
+			visibility: typeof payload.visibility === "string" ? payload.visibility : "shared",
+			workspace_id:
+				typeof payload.workspace_id === "string" ? payload.workspace_id : "shared:default",
+			workspace_kind:
+				typeof payload.workspace_kind === "string" ? payload.workspace_kind : "shared",
+			origin_device_id:
+				typeof payload.origin_device_id === "string"
+					? payload.origin_device_id
+					: item.clock_device_id,
+			origin_source: typeof payload.origin_source === "string" ? payload.origin_source : null,
+			trust_state: typeof payload.trust_state === "string" ? payload.trust_state : "trusted",
+			narrative: typeof payload.narrative === "string" ? payload.narrative : null,
+			facts: Array.isArray(payload.facts) ? JSON.stringify(payload.facts) : null,
+			concepts: Array.isArray(payload.concepts) ? JSON.stringify(payload.concepts) : null,
+			files_read: Array.isArray(payload.files_read) ? JSON.stringify(payload.files_read) : null,
+			files_modified: Array.isArray(payload.files_modified)
+				? JSON.stringify(payload.files_modified)
+				: null,
+			user_prompt_id: typeof payload.user_prompt_id === "number" ? payload.user_prompt_id : null,
+			prompt_number: typeof payload.prompt_number === "number" ? payload.prompt_number : null,
+			scope_id: scopeId,
+			// Persist the originating project name from the snapshot so the
+			// Projects read model can surface this memory under its real
+			// project identity on this receiver.
+			project,
+		})
+		.run();
+
+	return { applied: true, embeddable: !isDeleted && isEmbeddableSnapshotPayload(payload) };
+}
+
+function clearScopedAckedCursor(db: Database, peerDeviceId: string, scopeId: string): void {
+	drizzle(db, { schema })
+		.update(schema.replicationCursorsV2)
+		.set({ last_acked_cursor: null, updated_at: new Date().toISOString() })
+		.where(
+			and(
+				eq(schema.replicationCursorsV2.peer_device_id, peerDeviceId),
+				eq(schema.replicationCursorsV2.scope_id, scopeId),
+			),
+		)
+		.run();
+}
+
 /**
  * Apply a bootstrap snapshot to the local database, atomically replacing
  * synced memories in the requested scope with the snapshot contents.
@@ -307,76 +427,9 @@ export function applyBootstrapSnapshot(
 		bootstrapSessionCache.clear();
 
 		for (const item of items) {
-			const payload = parseSnapshotPayload(item);
-			if (!payload) continue;
-			redactMemoryFields(payload, activeScanner);
-			const scopeId = snapshotPayloadScopeId(payload, bootstrapScopeId);
-			const project =
-				typeof payload.project === "string" && payload.project.trim()
-					? payload.project.trim()
-					: null;
-			const sessionId = ensureSessionForBootstrap(d, new Date().toISOString(), project);
-
-			const metaRaw = payload.metadata_json;
-			const meta =
-				metaRaw && typeof metaRaw === "object" && !Array.isArray(metaRaw)
-					? (metaRaw as Record<string, unknown>)
-					: {};
-			meta.clock_device_id = item.clock_device_id;
-
-			const isDeleted = item.op_type === "delete";
-			if (!isDeleted && isEmbeddableSnapshotPayload(payload)) {
-				embeddableApplied++;
-			}
-
-			d.insert(schema.memoryItems)
-				.values({
-					session_id: sessionId,
-					kind: typeof payload.kind === "string" ? payload.kind : "discovery",
-					title: typeof payload.title === "string" ? payload.title : "",
-					subtitle: typeof payload.subtitle === "string" ? payload.subtitle : null,
-					body_text: typeof payload.body_text === "string" ? payload.body_text : "",
-					confidence: typeof payload.confidence === "number" ? payload.confidence : 0.5,
-					tags_text: typeof payload.tags_text === "string" ? payload.tags_text : "",
-					active: isDeleted ? 0 : 1,
-					created_at:
-						typeof payload.created_at === "string" ? payload.created_at : item.clock_updated_at,
-					updated_at: item.clock_updated_at,
-					metadata_json: toJson(meta),
-					import_key: item.entity_id,
-					deleted_at: isDeleted ? item.clock_updated_at : null,
-					rev: item.clock_rev,
-					actor_id: typeof payload.actor_id === "string" ? payload.actor_id : null,
-					actor_display_name:
-						typeof payload.actor_display_name === "string" ? payload.actor_display_name : null,
-					visibility: typeof payload.visibility === "string" ? payload.visibility : "shared",
-					workspace_id:
-						typeof payload.workspace_id === "string" ? payload.workspace_id : "shared:default",
-					workspace_kind:
-						typeof payload.workspace_kind === "string" ? payload.workspace_kind : "shared",
-					origin_device_id:
-						typeof payload.origin_device_id === "string"
-							? payload.origin_device_id
-							: item.clock_device_id,
-					origin_source: typeof payload.origin_source === "string" ? payload.origin_source : null,
-					trust_state: typeof payload.trust_state === "string" ? payload.trust_state : "trusted",
-					narrative: typeof payload.narrative === "string" ? payload.narrative : null,
-					facts: Array.isArray(payload.facts) ? JSON.stringify(payload.facts) : null,
-					concepts: Array.isArray(payload.concepts) ? JSON.stringify(payload.concepts) : null,
-					files_read: Array.isArray(payload.files_read) ? JSON.stringify(payload.files_read) : null,
-					files_modified: Array.isArray(payload.files_modified)
-						? JSON.stringify(payload.files_modified)
-						: null,
-					user_prompt_id:
-						typeof payload.user_prompt_id === "number" ? payload.user_prompt_id : null,
-					prompt_number: typeof payload.prompt_number === "number" ? payload.prompt_number : null,
-					scope_id: scopeId,
-					// Persist the originating project name from the snapshot so the
-					// Projects read model can surface this memory under its real
-					// project identity on this receiver.
-					project,
-				})
-				.run();
+			const inserted = insertSnapshotItem(d, item, bootstrapScopeId, activeScanner);
+			if (!inserted.applied) continue;
+			if (inserted.embeddable) embeddableApplied++;
 			result.applied++;
 		}
 
@@ -387,6 +440,9 @@ export function applyBootstrapSnapshot(
 		if (resetInfo.baseline_cursor || resetInfo.scope_id) {
 			if (resetInfo.scope_id && !resetInfo.baseline_cursor) {
 				clearReplicationCursorLastApplied(db, peerDeviceId, resetInfo.scope_id);
+			}
+			if (resetInfo.scope_id && resetInfo.baseline_cursor) {
+				clearScopedAckedCursor(db, peerDeviceId, resetInfo.scope_id);
 			}
 			setReplicationCursor(
 				db,
@@ -414,6 +470,110 @@ export function applyBootstrapSnapshot(
 
 		queueVectorBackfillForSyncBootstrap(db, { embeddableTotal: embeddableApplied });
 
+		result.ok = true;
+	}).immediate();
+
+	return result;
+}
+
+/**
+ * Additively merge a peer snapshot into an already-populated scope.
+ *
+ * Unlike `applyBootstrapSnapshot`, this does not delete local imported rows that
+ * are absent from the peer snapshot. It only inserts missing snapshot entities
+ * or replaces stale copies of the same snapshot entity. Use this when a scoped
+ * peer has no cursor yet but the receiver already has rows in that scope from
+ * another source, making destructive bootstrap unsafe.
+ */
+export function mergeBootstrapSnapshot(
+	db: Database,
+	peerDeviceId: string,
+	items: SyncMemorySnapshotItem[],
+	resetInfo: SyncResetRequired,
+	scanner?: SecretScanner,
+): BootstrapResult {
+	const result: BootstrapResult = { ok: false, applied: 0, deleted: 0 };
+	const activeScanner = scanner ?? new SecretScanner();
+	const bootstrapScopeId = normalizeBootstrapScopeId(resetInfo.scope_id);
+	const mergeScopePredicate = bootstrapScopeId
+		? eq(schema.memoryItems.scope_id, bootstrapScopeId)
+		: or(
+				isNull(schema.memoryItems.scope_id),
+				eq(schema.memoryItems.scope_id, DEFAULT_SYNC_SCOPE_ID),
+			);
+
+	db.transaction(() => {
+		const d = drizzle(db, { schema });
+		let embeddableApplied = 0;
+		bootstrapSessionCache.clear();
+
+		for (const item of items) {
+			if (!parseSnapshotPayload(item)) continue;
+			const existingRows = d
+				.select({
+					id: schema.memoryItems.id,
+					rev: schema.memoryItems.rev,
+					updated_at: schema.memoryItems.updated_at,
+					metadata_json: schema.memoryItems.metadata_json,
+				})
+				.from(schema.memoryItems)
+				.where(
+					and(
+						eq(schema.memoryItems.import_key, item.entity_id),
+						mergeScopePredicate,
+						ne(sql`COALESCE(${schema.memoryItems.visibility}, '')`, "private"),
+					),
+				)
+				.all();
+
+			if (!shouldReplaceExistingSnapshotRows(existingRows, item)) continue;
+
+			const existingIds = existingRows.map((row) => row.id);
+			if (existingIds.length > 0) {
+				const deleteResult = d
+					.delete(schema.memoryItems)
+					.where(inArray(schema.memoryItems.id, existingIds))
+					.run();
+				result.deleted += deleteResult.changes;
+			}
+
+			const inserted = insertSnapshotItem(d, item, bootstrapScopeId, activeScanner);
+			if (!inserted.applied) continue;
+			if (inserted.embeddable) embeddableApplied++;
+			result.applied++;
+		}
+
+		if (resetInfo.baseline_cursor || resetInfo.scope_id) {
+			if (resetInfo.scope_id && !resetInfo.baseline_cursor) {
+				clearReplicationCursorLastApplied(db, peerDeviceId, resetInfo.scope_id);
+			}
+			if (resetInfo.scope_id && resetInfo.baseline_cursor) {
+				clearScopedAckedCursor(db, peerDeviceId, resetInfo.scope_id);
+			}
+			setReplicationCursor(
+				db,
+				peerDeviceId,
+				{
+					lastApplied: resetInfo.baseline_cursor,
+					lastAcked: resetInfo.baseline_cursor
+						? undefined
+						: SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
+				},
+				resetInfo.scope_id,
+			);
+		}
+
+		setSyncResetState(
+			db,
+			{
+				generation: resetInfo.generation,
+				snapshot_id: resetInfo.snapshot_id,
+				baseline_cursor: resetInfo.baseline_cursor,
+			},
+			resetInfo.scope_id,
+		);
+
+		queueVectorBackfillForSyncBootstrap(db, { embeddableTotal: embeddableApplied });
 		result.ok = true;
 	}).immediate();
 

--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -457,6 +457,293 @@ describe("syncOnce", () => {
 		});
 	});
 
+	it("merge-recovers scoped snapshots when local rows exist but the peer scope has no cursor", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-scoped-merge", "fp-scoped-merge", new Date().toISOString());
+		syncReplication.setReplicationCursor(db, "peer-scoped-merge", {
+			lastApplied: "2025-12-31T00:00:00Z|default",
+		});
+		const sessionId = Number(
+			(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?) RETURNING id")
+					.get("2026-01-01T00:00:00Z", "codemem") as { id: number }
+			).id,
+		);
+		db.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, body_text, confidence, active, created_at, updated_at,
+				import_key, scope_id, visibility, workspace_id, workspace_kind, origin_device_id, rev, project, metadata_json
+			 ) VALUES (?, 'discovery', ?, ?, 0.8, 1, ?, ?, ?, 'acme-work', 'shared', 'shared:default', 'shared', ?, ?, 'codemem', '{"clock_device_id":"peer-scoped-merge"}')`,
+		).run(
+			sessionId,
+			"Existing scoped memory",
+			"Existing body",
+			"2026-01-01T00:00:00Z",
+			"2026-01-01T00:00:00Z",
+			"existing-key",
+			"peer-scoped-merge",
+			1,
+		);
+		db.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, body_text, confidence, active, created_at, updated_at,
+				import_key, scope_id, visibility, workspace_id, workspace_kind, origin_device_id, rev, project
+			 ) VALUES (?, 'discovery', ?, ?, 0.8, 1, ?, ?, ?, 'acme-work', 'shared', 'shared:default', 'shared', ?, ?, 'codemem')`,
+		).run(
+			sessionId,
+			"M4x-only scoped memory",
+			"This row must survive additive recovery",
+			"2026-01-01T00:00:00Z",
+			"2026-01-01T00:00:00Z",
+			"m4x-only-key",
+			"local-device-id",
+			1,
+		);
+		db.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, body_text, confidence, active, created_at, updated_at,
+				import_key, scope_id, visibility, workspace_id, workspace_kind, origin_device_id, rev, project
+			 ) VALUES (?, 'discovery', ?, ?, 0.8, 1, ?, ?, ?, 'acme-work', 'shared', 'shared:default', 'shared', ?, ?, 'codemem')`,
+		).run(
+			sessionId,
+			"Stale scoped memory",
+			"Old body",
+			"2026-01-01T00:00:00Z",
+			"2026-01-01T00:00:00Z",
+			"stale-key",
+			"peer-scoped-merge",
+			1,
+		);
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		grantScopeForSyncPass(db, "acme-work", ["peer-scoped-merge", "local-device-id"]);
+
+		const statusResponse = {
+			fingerprint: "fp-scoped-merge",
+			protocol_version: "2",
+			sync_capability: "scoped",
+			sync_reset: {
+				generation: 1,
+				snapshot_id: "snap-default",
+				baseline_cursor: null,
+				retained_floor_cursor: null,
+			},
+			authorized_scopes: [
+				{
+					scope_id: "acme-work",
+					label: "Acme Work",
+					authority_type: "coordinator",
+					membership_epoch: 1,
+					sync_reset: {
+						scope_id: "acme-work",
+						generation: 1,
+						snapshot_id: "snap-acme-1",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+				},
+			],
+		};
+		const defaultOpsResponse = {
+			reset_required: false,
+			generation: 1,
+			snapshot_id: "snap-default",
+			baseline_cursor: null,
+			retained_floor_cursor: null,
+			ops: [],
+			next_cursor: null,
+			skipped: 0,
+		};
+		const requestSpy = vi
+			.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([200, statusResponse])
+			.mockResolvedValueOnce([200, defaultOpsResponse]);
+		vi.spyOn(syncBootstrap, "fetchAllSnapshotPages").mockResolvedValue({
+			items: [
+				{
+					entity_id: "existing-key",
+					op_type: "upsert",
+					payload_json: JSON.stringify({
+						kind: "discovery",
+						title: "Existing scoped memory",
+						body_text: "Existing body",
+						created_at: "2026-01-01T00:00:00Z",
+						updated_at: "2026-01-01T00:00:00Z",
+						scope_id: "acme-work",
+						visibility: "shared",
+						project: "codemem",
+					}),
+					clock_rev: 1,
+					clock_updated_at: "2026-01-01T00:00:00Z",
+					clock_device_id: "peer-scoped-merge",
+				},
+				{
+					entity_id: "missing-key",
+					op_type: "upsert",
+					payload_json: JSON.stringify({
+						kind: "discovery",
+						title: "Missing scoped memory",
+						body_text: "Recovered from peer snapshot",
+						created_at: "2026-01-02T00:00:00Z",
+						updated_at: "2026-01-02T00:00:00Z",
+						scope_id: "acme-work",
+						visibility: "shared",
+						project: "codemem",
+					}),
+					clock_rev: 1,
+					clock_updated_at: "2026-01-02T00:00:00Z",
+					clock_device_id: "peer-scoped-merge",
+				},
+				{
+					entity_id: "stale-key",
+					op_type: "upsert",
+					payload_json: JSON.stringify({
+						kind: "discovery",
+						title: "Updated scoped memory",
+						body_text: "New body",
+						created_at: "2026-01-01T00:00:00Z",
+						updated_at: "2026-01-03T00:00:00Z",
+						scope_id: "acme-work",
+						visibility: "shared",
+						project: "codemem",
+					}),
+					clock_rev: 2,
+					clock_updated_at: "2026-01-03T00:00:00Z",
+					clock_device_id: "peer-scoped-merge",
+				},
+			],
+			generation: 1,
+			snapshot_id: "snap-acme-1",
+			baseline_cursor: null,
+		});
+
+		const result = await syncOnce(db, "peer-scoped-merge", ["http://127.0.0.1:9090"]);
+
+		expect(result.ok).toBe(true);
+		expect(result.perScopeResults?.[0]).toMatchObject({
+			scope_id: "acme-work",
+			ok: true,
+			opsIn: 2,
+			bootstrapped: true,
+		});
+		expect(result.opsIn).toBe(2);
+		expect(syncBootstrap.fetchAllSnapshotPages).toHaveBeenCalledWith(
+			"http://127.0.0.1:9090",
+			expect.objectContaining({ scope_id: "acme-work", snapshot_id: "snap-acme-1" }),
+			"local-device-id",
+			expect.objectContaining({ pageSize: 2000 }),
+		);
+		const requestedUrls = requestSpy.mock.calls.map(([method, url]) => `${method} ${url}`);
+		expect(
+			requestedUrls.some(
+				(entry) => entry.includes("/v1/ops?") && entry.includes("scope_id=acme-work"),
+			),
+		).toBe(false);
+		expect(
+			db
+				.prepare("SELECT COUNT(*) AS n FROM memory_items WHERE import_key = ? AND scope_id = ?")
+				.get("existing-key", "acme-work"),
+		).toMatchObject({ n: 1 });
+		expect(
+			db
+				.prepare("SELECT title FROM memory_items WHERE import_key = ? AND scope_id = ?")
+				.get("missing-key", "acme-work"),
+		).toMatchObject({ title: "Missing scoped memory" });
+		expect(
+			db
+				.prepare("SELECT title FROM memory_items WHERE import_key = ? AND scope_id = ?")
+				.get("stale-key", "acme-work"),
+		).toMatchObject({ title: "Updated scoped memory" });
+		expect(
+			db
+				.prepare("SELECT title FROM memory_items WHERE import_key = ? AND scope_id = ?")
+				.get("m4x-only-key", "acme-work"),
+		).toMatchObject({ title: "M4x-only scoped memory" });
+		expect(syncReplication.getReplicationCursor(db, "peer-scoped-merge", "acme-work")).toEqual([
+			null,
+			syncReplication.SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
+		]);
+	});
+
+	it("does not fetch scoped snapshots for local-only advertised scopes", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-local-scope", "fp-local-scope", new Date().toISOString());
+		syncReplication.setReplicationCursor(db, "peer-local-scope", {
+			lastApplied: "2025-12-31T00:00:00Z|default",
+		});
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		grantScopeForSyncPass(db, "local-only-scope", ["peer-local-scope", "local-device-id"]);
+		db.prepare("UPDATE replication_scopes SET authority_type = 'local' WHERE scope_id = ?").run(
+			"local-only-scope",
+		);
+
+		vi.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: "fp-local-scope",
+					protocol_version: "2",
+					sync_capability: "scoped",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-default",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+					authorized_scopes: [
+						{
+							scope_id: "local-only-scope",
+							label: "Local only",
+							authority_type: "local",
+							membership_epoch: 1,
+							sync_reset: {
+								scope_id: "local-only-scope",
+								generation: 1,
+								snapshot_id: "snap-local-only",
+								baseline_cursor: null,
+								retained_floor_cursor: null,
+							},
+						},
+					],
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-default",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [],
+					next_cursor: null,
+					skipped: 0,
+				},
+			]);
+		const fetchSpy = vi.spyOn(syncBootstrap, "fetchAllSnapshotPages");
+
+		const result = await syncOnce(db, "peer-local-scope", ["http://127.0.0.1:9090"]);
+
+		expect(result.ok).toBe(false);
+		expect(result.perScopeResults?.[0]).toMatchObject({
+			scope_id: "local-only-scope",
+			ok: false,
+			error: "reset_required:missing_scope",
+			failureCategory: "scope",
+		});
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
 	it("reports per-scope failure without rolling back default-scope sync", async () => {
 		db.prepare(
 			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
@@ -471,6 +758,7 @@ describe("syncOnce", () => {
 			"ed25519 AAAA",
 		]);
 		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		grantScopeForSyncPass(db, "broken-scope", ["peer-mixed", "local-device-id"]);
 
 		const statusResponse = {
 			fingerprint: "fp-mixed",
@@ -563,6 +851,7 @@ describe("syncOnce", () => {
 			"ed25519 AAAA",
 		]);
 		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		grantScopeForSyncPass(db, "oss", ["peer-connectivity", "local-device-id"]);
 		vi.spyOn(syncHttpClient, "requestJson")
 			.mockResolvedValueOnce([
 				200,
@@ -2206,6 +2495,11 @@ describe("syncOnce auto-bootstrap", () => {
 
 	it("triggers bootstrap for empty local state with no cursor", async () => {
 		seedPeer();
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		grantScopeForSyncPass(db, "acme-work", [peerDeviceId, "local-device-id"]);
 
 		vi.spyOn(syncHttpClient, "requestJson").mockResolvedValue([
 			200,
@@ -2237,6 +2531,26 @@ describe("syncOnce auto-bootstrap", () => {
 		const fetchCall = vi.mocked(syncBootstrap.fetchAllSnapshotPages).mock.calls[0];
 		expect(fetchCall?.[1]).toMatchObject({ scope_id: "acme-work" });
 		expect(fetchCall?.[3]?.pageSize).toBe(2000);
+	});
+
+	it("rejects scoped top-level bootstrap when local membership is missing", async () => {
+		seedPeer();
+
+		vi.spyOn(syncHttpClient, "requestJson").mockResolvedValue([
+			200,
+			{
+				...statusPayload,
+				sync_reset: { ...statusPayload.sync_reset, scope_id: "acme-work" },
+			},
+		]);
+		const fetchSpy = vi.spyOn(syncBootstrap, "fetchAllSnapshotPages");
+
+		const result = await syncOnce(db, peerDeviceId, [address]);
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toBe("reset_required:missing_scope");
+		expect(result.failureCategory).toBe("scope");
+		expect(fetchSpy).not.toHaveBeenCalled();
 	});
 
 	it("falls through to incremental when local shared data exists", async () => {

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -13,7 +13,11 @@ import { ensureAdditiveSchemaCompatibility } from "./db.js";
 import * as schema from "./schema.js";
 import type { SecretScanner } from "./secret-scanner.js";
 import { buildAuthHeaders } from "./sync-auth.js";
-import { applyBootstrapSnapshot, fetchAllSnapshotPages } from "./sync-bootstrap.js";
+import {
+	applyBootstrapSnapshot,
+	fetchAllSnapshotPages,
+	mergeBootstrapSnapshot,
+} from "./sync-bootstrap.js";
 import {
 	LOCAL_SYNC_CAPABILITY,
 	negotiateSyncCapability,
@@ -68,6 +72,13 @@ const DEFAULT_LIMIT = 500;
 
 /** Elevated page size for initial bootstrap of never-synced peers. */
 const BOOTSTRAP_PAGE_SIZE = 2000;
+
+/**
+ * Per-page snapshot fetch timeout for bootstrap / scoped merge recovery.
+ * Larger than the default incremental timeout because snapshot pages can be
+ * substantially bigger and slower to assemble on the serving peer.
+ */
+const BOOTSTRAP_REQUEST_TIMEOUT_S = 60;
 
 /** Current sync protocol version expected from peers. */
 const EXPECTED_SYNC_PROTOCOL_VERSION = "2";
@@ -485,6 +496,59 @@ function hasLocalRowsInScope(db: Database, scopeId: string): boolean {
 	return row !== undefined;
 }
 
+function scopedSnapshotAccessFailure(
+	db: Database,
+	options: { scopeId: string; peerDeviceId: string; localDeviceId: string },
+): SyncResetRequired["reason"] | null {
+	const scope = db
+		.prepare(
+			`SELECT authority_type, status, membership_epoch
+			   FROM replication_scopes
+			  WHERE scope_id = ?`,
+		)
+		.get(options.scopeId) as
+		| { authority_type: string | null; status: string | null; membership_epoch: number | null }
+		| undefined;
+	if (!scope) return "missing_scope";
+	if (scope.status !== "active") return "scope_inactive";
+	if (scope.authority_type === "local") return "missing_scope";
+
+	const requiredEpoch = Number(scope.membership_epoch ?? 0);
+	for (const deviceId of [options.localDeviceId, options.peerDeviceId]) {
+		const membership = db
+			.prepare(
+				`SELECT status, membership_epoch
+				   FROM scope_memberships
+				  WHERE scope_id = ? AND device_id = ?`,
+			)
+			.get(options.scopeId, deviceId) as
+			| { status: string | null; membership_epoch: number | null }
+			| undefined;
+		if (!membership) return "missing_scope";
+		if (membership.status !== "active") return "scope_inactive";
+		if (Number(membership.membership_epoch ?? 0) < requiredEpoch) return "stale_epoch";
+	}
+
+	return null;
+}
+
+function scopedSnapshotAccessDeniedResult(
+	baseUrl: string,
+	resetInfo: SyncResetRequired,
+	reason: SyncResetRequired["reason"],
+): SyncResult {
+	return {
+		ok: false,
+		address: baseUrl,
+		error: `reset_required:${reason}`,
+		failureCategory: scopeResetFailureCategory(reason),
+		opsIn: 0,
+		opsOut: 0,
+		addressErrors: [],
+		resetRequired: { ...resetInfo, reason },
+	};
+}
+
 function categorizeSyncFailure(error: string | undefined): SyncFailureCategory {
 	const lower = String(error ?? "").toLowerCase();
 	if (!lower) return "other";
@@ -619,12 +683,46 @@ async function syncOneScope(
 	const nullBaselineBootstrapStillCurrent =
 		hasNullBaselineBootstrapMarker && scope.sync_reset.baseline_cursor == null;
 	const localRowsPresent = hasLocalRowsInScope(db, scopeId);
+	const shouldMergeRecoverScope =
+		lastApplied == null && localRowsPresent && !nullBaselineBootstrapStillCurrent;
+	const shouldBootstrapEmptyScope =
+		lastApplied == null && !localRowsPresent && !nullBaselineBootstrapStillCurrent;
+	if (shouldMergeRecoverScope || shouldBootstrapEmptyScope) {
+		const accessFailure = scopedSnapshotAccessFailure(db, {
+			scopeId,
+			peerDeviceId,
+			localDeviceId: deviceId,
+		});
+		if (accessFailure) {
+			return {
+				scope_id: scopeId,
+				label: scope.label,
+				ok: false,
+				failureCategory: scopeResetFailureCategory(accessFailure),
+				opsIn: 0,
+				opsOut: 0,
+				error: `reset_required:${accessFailure}`,
+				resetRequired: {
+					reset_required: true,
+					reason: accessFailure,
+					scope_id: scopeId,
+					generation: scope.sync_reset.generation,
+					snapshot_id: scope.sync_reset.snapshot_id,
+					baseline_cursor: scope.sync_reset.baseline_cursor,
+					retained_floor_cursor: scope.sync_reset.retained_floor_cursor,
+				},
+				bootstrapped: false,
+			};
+		}
+	}
 
-	// Bootstrap when this device has never pulled the scope and has no local
-	// rows. If there ARE local rows but no cursor, fall through to incremental
-	// so the server's reset_required logic can decide whether a re-bootstrap
-	// is required without clobbering existing data.
-	if (lastApplied == null && !localRowsPresent && !nullBaselineBootstrapStillCurrent) {
+	// If this peer/scope has no cursor but the receiver already has rows in the
+	// scope, a destructive bootstrap is unsafe and incremental from an empty
+	// cursor can be a permanent no-op on peers that only retain snapshot state.
+	// Recover additively by merging the advertised scoped snapshot: missing or
+	// stale copies of the same snapshot entity are applied, but rows absent from
+	// the peer snapshot are preserved.
+	if (shouldMergeRecoverScope) {
 		try {
 			const resetInfo: SyncResetRequired = {
 				scope_id: scopeId,
@@ -638,6 +736,64 @@ async function syncOneScope(
 			const { items } = await fetchAllSnapshotPages(baseUrl, resetInfo, deviceId, {
 				keysDir,
 				pageSize: BOOTSTRAP_PAGE_SIZE,
+				timeoutS: BOOTSTRAP_REQUEST_TIMEOUT_S,
+			});
+			const mergeResult = mergeBootstrapSnapshot(db, peerDeviceId, items, resetInfo, scanner);
+			if (!mergeResult.ok) {
+				const error = "scoped merge bootstrap apply failed";
+				return {
+					scope_id: scopeId,
+					label: scope.label,
+					ok: false,
+					failureCategory: "other",
+					opsIn: 0,
+					opsOut: 0,
+					error,
+					bootstrapped: true,
+				};
+			}
+			return {
+				scope_id: scopeId,
+				label: scope.label,
+				ok: true,
+				opsIn: mergeResult.applied,
+				opsOut: 0,
+				bootstrapped: true,
+			};
+		} catch (err) {
+			const detail = err instanceof Error ? err.message.trim() || err.constructor.name : "unknown";
+			const error = `scoped merge bootstrap failed: ${detail}`;
+			return {
+				scope_id: scopeId,
+				label: scope.label,
+				ok: false,
+				failureCategory: scopeFailureCategory(error),
+				opsIn: 0,
+				opsOut: 0,
+				error,
+				bootstrapped: true,
+			};
+		}
+	}
+
+	// Bootstrap when this device has never pulled the scope and has no local
+	// rows. Populated scopes without a peer cursor are handled by the additive
+	// merge-recovery branch above so this destructive bootstrap path stays safe.
+	if (shouldBootstrapEmptyScope) {
+		try {
+			const resetInfo: SyncResetRequired = {
+				scope_id: scopeId,
+				generation: scope.sync_reset.generation,
+				snapshot_id: scope.sync_reset.snapshot_id,
+				baseline_cursor: scope.sync_reset.baseline_cursor,
+				retained_floor_cursor: scope.sync_reset.retained_floor_cursor,
+				reset_required: true,
+				reason: "initial_bootstrap" as SyncResetRequired["reason"],
+			};
+			const { items } = await fetchAllSnapshotPages(baseUrl, resetInfo, deviceId, {
+				keysDir,
+				pageSize: BOOTSTRAP_PAGE_SIZE,
+				timeoutS: BOOTSTRAP_REQUEST_TIMEOUT_S,
 			});
 			// TOCTOU re-check: another process (CLI write, plugin, concurrent
 			// sync pass) could have created shared memories in this scope while
@@ -1032,9 +1188,25 @@ export async function syncOnce(
 							reset_required: true as const,
 							reason: "initial_bootstrap" as const,
 						};
+						if (resetInfo.scope_id) {
+							const accessFailure = scopedSnapshotAccessFailure(db, {
+								scopeId: resetInfo.scope_id,
+								peerDeviceId,
+								localDeviceId: deviceId,
+							});
+							if (accessFailure) {
+								recordSyncAttempt(db, peerDeviceId, {
+									ok: false,
+									error: `reset_required:${accessFailure}`,
+									capabilities: lastCapabilityDiagnostics,
+								});
+								return scopedSnapshotAccessDeniedResult(baseUrl, resetInfo, accessFailure);
+							}
+						}
 						const { items } = await fetchAllSnapshotPages(baseUrl, resetInfo, deviceId, {
 							keysDir,
 							pageSize: BOOTSTRAP_PAGE_SIZE,
+							timeoutS: BOOTSTRAP_REQUEST_TIMEOUT_S,
 						});
 
 						// Re-check after network fetch: another process (plugin, CLI, another
@@ -1195,8 +1367,24 @@ export async function syncOnce(
 
 				// No dirty local state — safe to auto-bootstrap from peer snapshot.
 				try {
+					if (resetRequired.scope_id) {
+						const accessFailure = scopedSnapshotAccessFailure(db, {
+							scopeId: resetRequired.scope_id,
+							peerDeviceId,
+							localDeviceId: deviceId,
+						});
+						if (accessFailure) {
+							recordSyncAttempt(db, peerDeviceId, {
+								ok: false,
+								error: `reset_required:${accessFailure}`,
+								capabilities: lastCapabilityDiagnostics,
+							});
+							return scopedSnapshotAccessDeniedResult(baseUrl, resetRequired, accessFailure);
+						}
+					}
 					const { items } = await fetchAllSnapshotPages(baseUrl, resetRequired, deviceId, {
 						keysDir,
+						timeoutS: BOOTSTRAP_REQUEST_TIMEOUT_S,
 					});
 
 					// Re-check dirty state after network fetch to close the TOCTOU window.

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -485,7 +485,7 @@ function mergePayloadMetadata(
 	};
 }
 
-function clockDeviceIdFromMetadataJson(raw: string | null): string {
+export function clockDeviceIdFromMetadataJson(raw: string | null): string {
 	const metadata = fromJson(raw);
 	return typeof metadata.clock_device_id === "string" ? metadata.clock_device_id : "";
 }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -3466,6 +3466,9 @@ describe("viewer-server", () => {
 				const scopes = ["oss", "personal"] as const;
 				for (const scopeId of scopes) {
 					grantSyncScopeToDevices(source.store, scopeId, [sourceDeviceId, receiverDeviceId]);
+					// Receiver must hold local scope membership to bootstrap a scoped
+					// snapshot — scopedSnapshotAccessFailure() fails closed otherwise.
+					grantSyncScopeToDevices(receiver.store, scopeId, [sourceDeviceId, receiverDeviceId]);
 					core.setSyncResetState(
 						source.store.db,
 						{


### PR DESCRIPTION
## Description

When a scoped peer advertises a scope the receiver **already has local rows in** but has **no replication cursor for**, the previous logic was unsafe in both directions:

- Incremental sync from an empty cursor can be a permanent no-op on peers that only retain snapshot state, so the backlog never imports.
- A destructive bootstrap would clobber authoritative local rows in that scope.

This adds an **additive merge-recovery** path (`mergeBootstrapSnapshot`) that inserts missing snapshot entities and replaces stale copies of the same entity, while **preserving** local rows that are absent from the peer snapshot.

It also fails closed on scoped snapshot access: `scopedSnapshotAccessFailure()` validates local + peer scope membership and rejects `authority_type='local'` before fetching a snapshot. Supporting changes:

- Name the bootstrap request timeout constant (`BOOTSTRAP_REQUEST_TIMEOUT_S = 60`, replacing four inline literals).
- Clear the null-baseline marker when a real baseline cursor lands.
- Update the multi-Space sync integration test to grant the **receiver** local scope membership, matching the new fail-closed gating.

> Base of a 2-PR stack. #1260 (ownership_scope SQL fix) is stacked on top.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Coverage:
- `sync-bootstrap.test.ts`: merge recovery preserves stale rows when a newer snapshot item is malformed; null-baseline marker handling.
- `sync-pass.test.ts`: merge-recovers scoped snapshots when local rows exist but the peer scope has no cursor; rejects scoped bootstrap when local membership is missing; skips local-only advertised scopes.
- Viewer multi-Space integration test passes with receiver-side scope grants.
- Validated standalone on this branch: `pnpm run tsc` clean, 73 sync tests pass.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
