### PR TITLE
fix(core): treat claimed same-actor peers as mine in ownership_scope SQL

### DIFF
--- a/packages/core/src/filters.ts
+++ b/packages/core/src/filters.ts
@@ -12,6 +12,8 @@ import type { MemoryFilters } from "./types.js";
 export interface OwnershipFilterContext {
 	actorId: string;
 	deviceId: string;
+	claimedDeviceIds?: string[];
+	legacyActorIds?: string[];
 	/**
 	 * Apply the local read boundary for replication scopes. This is opt-in so
 	 * low-level filter unit tests and non-memory callers can keep using the pure
@@ -94,6 +96,65 @@ function addMultiValueFilter(
 
 const LEGACY_SHARED_REVIEW_SCOPE_ID = "legacy-shared-review";
 
+function cleanUniqueStrings(value: string[] | undefined): string[] {
+	return [...new Set((value ?? []).map((item) => item.trim()).filter(Boolean))];
+}
+
+// Mirror MemoryStore.buildOwnershipPredicate(): prefer the top-level column,
+// then fall back to the metadata_json copy, and finally normalize a missing
+// owner to '' (never NULL) so the `theirs` (NOT ...) comparison stays null-safe.
+function ownershipColumnSql(column: string, jsonPath: string): string {
+	return `COALESCE(
+	NULLIF(TRIM(memory_items.${column}), ''),
+	NULLIF(TRIM(CASE
+		WHEN json_valid(COALESCE(memory_items.metadata_json, ''))
+		THEN COALESCE(json_extract(memory_items.metadata_json, '${jsonPath}'), '')
+		ELSE ''
+	END), ''),
+	''
+)`;
+}
+
+const OWNERSHIP_ACTOR_SQL = ownershipColumnSql("actor_id", "$.actor_id");
+const OWNERSHIP_ORIGIN_DEVICE_SQL = ownershipColumnSql("origin_device_id", "$.origin_device_id");
+
+function ownershipPredicateSql(context: OwnershipFilterContext): {
+	clause: string;
+	params: string[];
+} {
+	const alternatives: string[] = [];
+	const params: string[] = [];
+	// Guard blank identity: an empty actorId/deviceId must NOT match every
+	// ownerless row (mirrors the falsy checks in
+	// MemoryStore.buildOwnershipPredicate()). Skip the equality alternative
+	// when the value is empty rather than emitting `<expr> = ''`.
+	const actorId = context.actorId.trim();
+	if (actorId) {
+		alternatives.push(`${OWNERSHIP_ACTOR_SQL} = ?`);
+		params.push(actorId);
+	}
+	const deviceId = context.deviceId.trim();
+	if (deviceId) {
+		alternatives.push(`${OWNERSHIP_ORIGIN_DEVICE_SQL} = ?`);
+		params.push(deviceId);
+	}
+	const claimedDeviceIds = cleanUniqueStrings(context.claimedDeviceIds);
+	if (claimedDeviceIds.length > 0) {
+		alternatives.push(
+			`${OWNERSHIP_ORIGIN_DEVICE_SQL} IN (${claimedDeviceIds.map(() => "?").join(", ")})`,
+		);
+		params.push(...claimedDeviceIds);
+	}
+	const legacyActorIds = cleanUniqueStrings(context.legacyActorIds);
+	if (legacyActorIds.length > 0) {
+		alternatives.push(`${OWNERSHIP_ACTOR_SQL} IN (${legacyActorIds.map(() => "?").join(", ")})`);
+		params.push(...legacyActorIds);
+	}
+	// No usable owner identity → nothing is "mine" (and `theirs` = everything).
+	if (alternatives.length === 0) return { clause: "(0 = 1)", params };
+	return { clause: `(${alternatives.join(" OR ")})`, params };
+}
+
 function addScopeVisibilityFilter(
 	clauses: string[],
 	params: unknown[],
@@ -170,16 +231,13 @@ export function buildFilterClausesWithContext(
 		.trim()
 		.toLowerCase();
 	if (ownership && (ownershipScope === "mine" || ownershipScope === "theirs")) {
-		const ownedClause =
-			"(COALESCE(memory_items.actor_id, '') = ? OR COALESCE(memory_items.origin_device_id, '') = ?)";
+		const ownedPredicate = ownershipPredicateSql(ownership);
 		if (ownershipScope === "mine") {
-			clauses.push(ownedClause);
+			clauses.push(ownedPredicate.clause);
 		} else {
-			clauses.push(
-				"(COALESCE(memory_items.actor_id, '') != ? AND COALESCE(memory_items.origin_device_id, '') != ?)",
-			);
+			clauses.push(`NOT ${ownedPredicate.clause}`);
 		}
-		params.push(ownership.actorId, ownership.deviceId);
+		params.push(...ownedPredicate.params);
 	}
 
 	// Project scoping — requires sessions JOIN

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -22,7 +22,7 @@ import { sanitizeSearchQuery } from "./query-sanitizer.js";
 import { memoryLooksRecapLike, queryPrefersRecap } from "./recap-policy.js";
 import { findByFile } from "./ref-queries.js";
 import type { StoreHandle } from "./search.js";
-import { rerankResults, scoreResult, search, timeline } from "./search.js";
+import { ownershipFilterContext, rerankResults, scoreResult, search, timeline } from "./search.js";
 import {
 	canonicalMemoryKind,
 	getSummaryMetadata,
@@ -943,11 +943,7 @@ function validatePackDeltaBaselineIds(
 	filters: MemoryFilters | null,
 ): number[] | null {
 	if (ids.length === 0) return null;
-	const filterResult = buildFilterClausesWithContext(filters, {
-		actorId: store.actorId,
-		deviceId: store.deviceId,
-		enforceScopeVisibility: true,
-	});
+	const filterResult = buildFilterClausesWithContext(filters, ownershipFilterContext(store));
 	const placeholders = ids.map(() => "?").join(", ");
 	const joinClause = filterResult.joinSessions
 		? "JOIN sessions ON sessions.id = memory_items.session_id"
@@ -970,11 +966,10 @@ function isSummaryLike(item: Pick<MemoryResult, "kind" | "metadata">): boolean {
 }
 
 function findLatestSummaryLike(store: StoreHandle, filters?: MemoryFilters): MemoryResult | null {
-	const filterResult = buildFilterClausesWithContext(filters ?? null, {
-		actorId: store.actorId,
-		deviceId: store.deviceId,
-		enforceScopeVisibility: true,
-	});
+	const filterResult = buildFilterClausesWithContext(
+		filters ?? null,
+		ownershipFilterContext(store),
+	);
 	const whereParts = [
 		"memory_items.active = 1",
 		"(memory_items.kind = 'session_summary' OR json_extract(memory_items.metadata_json, '$.is_summary') = 1)",
@@ -1176,11 +1171,10 @@ function rehydrateScopedCandidateResults(
 	const ids = [...originalById.keys()];
 	if (ids.length === 0) return [];
 
-	const filterResult = buildFilterClausesWithContext(filters ?? null, {
-		actorId: store.actorId,
-		deviceId: store.deviceId,
-		enforceScopeVisibility: true,
-	});
+	const filterResult = buildFilterClausesWithContext(
+		filters ?? null,
+		ownershipFilterContext(store),
+	);
 	const joinClause = filterResult.joinSessions
 		? "JOIN sessions ON sessions.id = memory_items.session_id"
 		: "";
@@ -2000,10 +1994,13 @@ export async function buildMemoryPackAsync(
 	let semResults: MemoryResult[] = [];
 	const semanticQuery = sanitizeSearchQuery(context).clean_query;
 	try {
-		const raw = await semanticSearch(store.db, semanticQuery, limit, filters ?? null, {
-			actorId: store.actorId,
-			deviceId: store.deviceId,
-		});
+		const raw = await semanticSearch(
+			store.db,
+			semanticQuery,
+			limit,
+			filters ?? null,
+			ownershipFilterContext(store),
+		);
 		semResults = semanticMemoryResults(raw);
 	} catch {
 		// Semantic search failure is non-fatal — fall through to FTS-only
@@ -2028,10 +2025,13 @@ export async function buildMemoryPackTraceAsync(
 	let semResults: MemoryResult[] = [];
 	const semanticQuery = sanitizeSearchQuery(context).clean_query;
 	try {
-		const raw = await semanticSearch(store.db, semanticQuery, limit, filters ?? null, {
-			actorId: store.actorId,
-			deviceId: store.deviceId,
-		});
+		const raw = await semanticSearch(
+			store.db,
+			semanticQuery,
+			limit,
+			filters ?? null,
+			ownershipFilterContext(store),
+		);
 		semResults = semanticMemoryResults(raw);
 	} catch {
 		// Semantic search failure is non-fatal — fall through to FTS-only

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -15,6 +15,7 @@ import {
 	normalizeFilterStrings,
 	normalizeVisibilityValues,
 	normalizeWorkspaceKinds,
+	type OwnershipFilterContext,
 } from "./filters.js";
 import { parsePositiveMemoryId } from "./integers.js";
 import { inferMemoryRole } from "./memory-quality.js";
@@ -52,6 +53,7 @@ export interface StoreHandle {
 	readonly deviceId: string;
 	get(memoryId: number): MemoryItemResponse | null;
 	memoryOwnedBySelf(item: MemoryItem | MemoryResult | Record<string, unknown>): boolean;
+	sameActorPeerIds?(): string[];
 	buildOwnershipPredicate?(): (
 		item: MemoryItem | MemoryResult | Record<string, unknown>,
 	) => boolean;
@@ -77,6 +79,17 @@ const MEMORY_KIND_BONUS: Record<string, number> = {
 	exploration: 0.1,
 	entities: 0.05,
 };
+
+export function ownershipFilterContext(store: StoreHandle): OwnershipFilterContext {
+	const claimedDeviceIds = store.sameActorPeerIds?.() ?? [];
+	return {
+		actorId: store.actorId,
+		deviceId: store.deviceId,
+		claimedDeviceIds,
+		legacyActorIds: claimedDeviceIds.map((peerId) => `legacy-sync:${peerId}`),
+		enforceScopeVisibility: true,
+	};
+}
 
 const PERSONAL_FIRST_BONUS = 0.45;
 const TRUST_BIAS_LEGACY_UNKNOWN_PENALTY = 0.18;
@@ -702,11 +715,7 @@ function fetchResultsByIds(
 	const placeholders = ids.map(() => "?").join(", ");
 	const params: unknown[] = [...ids];
 	const whereClauses = [`memory_items.id IN (${placeholders})`, "memory_items.active = 1"];
-	const filterResult = buildFilterClausesWithContext(filters, {
-		actorId: store.actorId,
-		deviceId: store.deviceId,
-		enforceScopeVisibility: true,
-	});
+	const filterResult = buildFilterClausesWithContext(filters, ownershipFilterContext(store));
 	whereClauses.push(...filterResult.clauses);
 	params.push(...filterResult.params);
 	const joinClause = filterResult.joinSessions
@@ -1000,11 +1009,7 @@ function searchOnce(
 	const params: unknown[] = [expanded];
 	const whereClauses = ["memory_items.active = 1", "memory_fts MATCH ?"];
 
-	const filterResult = buildFilterClausesWithContext(filters, {
-		actorId: store.actorId,
-		deviceId: store.deviceId,
-		enforceScopeVisibility: true,
-	});
+	const filterResult = buildFilterClausesWithContext(filters, ownershipFilterContext(store));
 	whereClauses.push(...filterResult.clauses);
 	params.push(...filterResult.params);
 
@@ -1118,11 +1123,7 @@ function timelineAround(
 		return [];
 	}
 
-	const filterResult = buildFilterClausesWithContext(filters, {
-		actorId: store.actorId,
-		deviceId: store.deviceId,
-		enforceScopeVisibility: true,
-	});
+	const filterResult = buildFilterClausesWithContext(filters, ownershipFilterContext(store));
 	const whereParts = ["memory_items.active = 1", ...filterResult.clauses];
 	const baseParams = [...filterResult.params];
 
@@ -1316,11 +1317,7 @@ function loadItemsByIdsForExplain(
 
 	// Placeholders for the dynamic-filter raw SQL queries below
 	const placeholders = ids.map(() => "?").join(", ");
-	const scopeContext = {
-		actorId: store.actorId,
-		deviceId: store.deviceId,
-		enforceScopeVisibility: true,
-	};
+	const scopeContext = ownershipFilterContext(store);
 	const visibilityFilter = buildFilterClausesWithContext(null, scopeContext);
 	const visibleRows = store.db
 		.prepare(

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -1276,6 +1276,61 @@ describe("MemoryStore", () => {
 			}
 		});
 
+		it("treats claimed same-actor peer rows as mine for SQL ownership filters", () => {
+			const sessionId = insertTestSession(store.db);
+			const now = "2026-01-01T00:00:00Z";
+			store.db
+				.prepare(
+					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+				)
+				.run("peer-claimed", store.actorId, 1, now);
+
+			const insertMemory = (
+				title: string,
+				actorId: string | null,
+				originDeviceId: string | null,
+				metadata: Record<string, unknown> = {},
+			) => {
+				const info = store.db
+					.prepare(
+						`INSERT INTO memory_items(
+							session_id, kind, title, body_text, confidence, tags_text, active,
+							created_at, updated_at, metadata_json, rev, scope_id, actor_id, origin_device_id
+						 ) VALUES (?, 'discovery', ?, 'Body', 0.5, '', 1, ?, ?, ?, 1, 'local-default', ?, ?)`,
+					)
+					.run(sessionId, title, now, now, JSON.stringify(metadata), actorId, originDeviceId);
+				return Number(info.lastInsertRowid);
+			};
+
+			const claimedDeviceId = insertMemory("Claimed peer device", null, "peer-claimed");
+			const legacyActorId = insertMemory(
+				"Claimed peer legacy actor",
+				"legacy-sync:peer-claimed",
+				"unknown-origin",
+			);
+			const metadataDeviceId = insertMemory("Claimed metadata peer device", null, null, {
+				origin_device_id: "peer-claimed",
+			});
+			const metadataLegacyActorId = insertMemory("Claimed metadata legacy actor", null, null, {
+				actor_id: "legacy-sync:peer-claimed",
+			});
+			const otherId = insertMemory("Other peer", "local:other-peer", "other-peer");
+
+			const mineIds = store.recent(10, { ownership_scope: "mine" }).map((item) => item.id);
+			expect(mineIds).toContain(claimedDeviceId);
+			expect(mineIds).toContain(legacyActorId);
+			expect(mineIds).toContain(metadataDeviceId);
+			expect(mineIds).toContain(metadataLegacyActorId);
+			expect(mineIds).not.toContain(otherId);
+
+			const theirsIds = store.recent(10, { ownership_scope: "theirs" }).map((item) => item.id);
+			expect(theirsIds).not.toContain(claimedDeviceId);
+			expect(theirsIds).not.toContain(legacyActorId);
+			expect(theirsIds).not.toContain(metadataDeviceId);
+			expect(theirsIds).not.toContain(metadataLegacyActorId);
+			expect(theirsIds).toContain(otherId);
+		});
+
 		it("intersects explicit scope filters with local authorization", () => {
 			grantScopeToLocalDevice("authorized-team");
 			insertCoordinatorScope("unauthorized-team");
@@ -1675,10 +1730,36 @@ describe("buildFilterClauses", () => {
 			{ ownership_scope: "mine" },
 			{ actorId: "local:device-1", deviceId: "device-1" },
 		);
-		expect(result.clauses).toEqual([
-			"(COALESCE(memory_items.actor_id, '') = ? OR COALESCE(memory_items.origin_device_id, '') = ?)",
-		]);
+		expect(result.clauses).toHaveLength(1);
+		expect(result.clauses[0]).toContain("memory_items.actor_id");
+		expect(result.clauses[0]).toContain("$.actor_id");
+		expect(result.clauses[0]).toContain("memory_items.origin_device_id");
+		expect(result.clauses[0]).toContain("$.origin_device_id");
 		expect(result.params).toEqual(["local:device-1", "device-1"]);
+	});
+
+	it("builds ownership_scope mine clause with claimed same-actor peers", () => {
+		const result = buildFilterClausesWithContext(
+			{ ownership_scope: "mine" },
+			{
+				actorId: "local:device-1",
+				deviceId: "device-1",
+				claimedDeviceIds: ["peer-a", " peer-a ", "peer-b"],
+				legacyActorIds: ["legacy-sync:peer-a"],
+			},
+		);
+		expect(result.clauses).toHaveLength(1);
+		expect(result.clauses[0]).toContain("IN (?, ?)");
+		expect(result.clauses[0]).toContain("IN (?)");
+		expect(result.clauses[0]).toContain("$.actor_id");
+		expect(result.clauses[0]).toContain("$.origin_device_id");
+		expect(result.params).toEqual([
+			"local:device-1",
+			"device-1",
+			"peer-a",
+			"peer-b",
+			"legacy-sync:peer-a",
+		]);
 	});
 
 	it("builds ownership_scope theirs clause with null-safe comparisons", () => {
@@ -1686,10 +1767,41 @@ describe("buildFilterClauses", () => {
 			{ ownership_scope: "theirs" },
 			{ actorId: "local:device-1", deviceId: "device-1" },
 		);
-		expect(result.clauses).toEqual([
-			"(COALESCE(memory_items.actor_id, '') != ? AND COALESCE(memory_items.origin_device_id, '') != ?)",
-		]);
+		expect(result.clauses).toHaveLength(1);
+		expect(result.clauses[0]).toMatch(/^NOT \(/);
+		expect(result.clauses[0]).toContain("$.actor_id");
+		expect(result.clauses[0]).toContain("$.origin_device_id");
 		expect(result.params).toEqual(["local:device-1", "device-1"]);
+	});
+
+	it("builds ownership_scope theirs as inverse of claimed same-actor ownership", () => {
+		const result = buildFilterClausesWithContext(
+			{ ownership_scope: "theirs" },
+			{
+				actorId: "local:device-1",
+				deviceId: "device-1",
+				claimedDeviceIds: ["peer-a"],
+				legacyActorIds: ["legacy-sync:peer-a"],
+			},
+		);
+		expect(result.clauses).toHaveLength(1);
+		expect(result.clauses[0]).toMatch(/^NOT \(/);
+		expect(result.clauses[0]).toContain("IN (?)");
+		expect(result.clauses[0]).toContain("$.actor_id");
+		expect(result.clauses[0]).toContain("$.origin_device_id");
+		expect(result.params).toEqual(["local:device-1", "device-1", "peer-a", "legacy-sync:peer-a"]);
+	});
+
+	it("does not treat ownerless rows as mine when identity context is blank", () => {
+		const result = buildFilterClausesWithContext(
+			{ ownership_scope: "mine" },
+			{ actorId: "", deviceId: "  " },
+		);
+		// Blank actor/device must match nothing rather than emitting `<expr> = ''`,
+		// which would otherwise own every anonymous row and diverge from
+		// MemoryStore.buildOwnershipPredicate().
+		expect(result.clauses).toEqual(["(0 = 1)"]);
+		expect(result.params).toEqual([]);
 	});
 });
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -414,12 +414,26 @@ export class MemoryStore {
 		await Promise.allSettled([...this.pendingVectorWrites]);
 	}
 
-	private scopeVisibleFilterContext(): OwnershipFilterContext {
+	/**
+	 * Build the ownership/scope-visibility filter context for SQL filter
+	 * builders. Snapshots claimed same-actor peers (and their legacy-sync actor
+	 * ids) once so `ownership_scope=mine/theirs` SQL matches
+	 * {@link buildOwnershipPredicate}. Shared by core read paths and viewer
+	 * routes to keep a single source of truth for "is this mine?".
+	 */
+	ownershipFilterContext(): OwnershipFilterContext {
+		const claimedDeviceIds = this.sameActorPeerIds();
 		return {
 			actorId: this.actorId,
 			deviceId: this.deviceId,
+			claimedDeviceIds,
+			legacyActorIds: claimedDeviceIds.map((peerId) => `legacy-sync:${peerId}`),
 			enforceScopeVisibility: true,
 		};
+	}
+
+	private scopeVisibleFilterContext(): OwnershipFilterContext {
+		return this.ownershipFilterContext();
 	}
 
 	// get

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -31,15 +31,17 @@ type VectorModelCount = { model: string; rows: number };
 
 type MemoryTextRow = { id: number; title: string | null; body_text: string | null };
 
-export interface SemanticSearchScopeContext {
-	actorId: string;
-	deviceId: string;
-}
+// Deliberately omits `enforceScopeVisibility` so semantic callers can never
+// disable the local read boundary — scopeVisibleFilterContext() always forces
+// it on below. Field list otherwise mirrors OwnershipFilterContext.
+export type SemanticSearchScopeContext = Omit<OwnershipFilterContext, "enforceScopeVisibility">;
 
 function scopeVisibleFilterContext(context: SemanticSearchScopeContext): OwnershipFilterContext {
 	return {
 		actorId: context?.actorId ?? "",
 		deviceId: context?.deviceId ?? "",
+		claimedDeviceIds: context?.claimedDeviceIds ?? [],
+		legacyActorIds: context?.legacyActorIds ?? [],
 		enforceScopeVisibility: true,
 	};
 }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -940,6 +940,26 @@ describe("viewer-server", () => {
 					actorId: "peer:other",
 					originDeviceId: "peer-device-002",
 				});
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+					)
+					.run("peer-claimed", store.actorId, 1, "2026-01-01T00:00:00Z");
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Claimed peer mine",
+					actorId: "local:peer-claimed",
+					originDeviceId: "peer-claimed",
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Claimed peer metadata mine",
+					actorId: null,
+					originDeviceId: null,
+					metadata: { origin_device_id: "peer-claimed" },
+				});
 				insertTestMemory(store, {
 					sessionId,
 					kind: "discovery",
@@ -954,8 +974,12 @@ describe("viewer-server", () => {
 				const mineItems = (
 					(await mineRes.json()) as { items: Array<{ title: string; owned_by_self?: boolean }> }
 				).items;
-				expect(mineItems.map((item) => item.title)).toEqual(["Mine"]);
-				expect(mineItems[0]?.owned_by_self).toBe(true);
+				expect(mineItems.map((item) => item.title).sort()).toEqual([
+					"Claimed peer metadata mine",
+					"Claimed peer mine",
+					"Mine",
+				]);
+				expect(mineItems.every((item) => item.owned_by_self === true)).toBe(true);
 
 				const theirsRes = await app.request("/api/observations?scope=theirs");
 				expect(theirsRes.status).toBe(200);

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -18,60 +18,21 @@ import { queryInt } from "../helpers.js";
 
 type StoreFactory = () => MemoryStore;
 
-type OwnershipContext = {
-	actorId: string;
-	claimedPeerIds: Set<string>;
-	deviceId: string;
-	legacyActorIds: Set<string>;
-};
-
-function cleanOwnershipValue(value: unknown): string | null {
-	if (typeof value !== "string") return null;
-	const trimmed = value.trim();
-	return trimmed ? trimmed : null;
-}
-
-function buildOwnershipContext(store: MemoryStore): OwnershipContext {
-	const claimedPeerIds = new Set(store.sameActorPeerIds());
-	return {
-		actorId: store.actorId,
-		claimedPeerIds,
-		deviceId: store.deviceId,
-		legacyActorIds: new Set(Array.from(claimedPeerIds, (peerId) => `legacy-sync:${peerId}`)),
-	};
-}
-
-function memoryOwnedBySelf(
-	row: Record<string, unknown>,
-	ownership: OwnershipContext,
-	metadata = fromJson((row.metadata_json as string) ?? null),
-): boolean {
-	const meta = metadata as Record<string, unknown>;
-	const actorId = cleanOwnershipValue(row.actor_id) ?? cleanOwnershipValue(meta.actor_id);
-	if (actorId === ownership.actorId) return true;
-
-	const deviceId =
-		cleanOwnershipValue(row.origin_device_id) ?? cleanOwnershipValue(meta.origin_device_id);
-	if (deviceId === ownership.deviceId) return true;
-	if (deviceId && ownership.claimedPeerIds.has(deviceId)) return true;
-	if (actorId && ownership.legacyActorIds.has(actorId)) return true;
-
-	return false;
-}
+type OwnershipPredicate = (item: Record<string, unknown>) => boolean;
 
 function serializeMemoryRow(
-	ownership: OwnershipContext,
+	ownedBySelf: OwnershipPredicate,
 	row: Record<string, unknown>,
 ): Record<string, unknown> {
 	const metadata = fromJson((row.metadata_json as string) ?? null);
-	const item = {
+	// Evaluate ownership against the raw row (top-level columns + metadata_json
+	// fallback) before we overwrite metadata_json with the parsed object.
+	const owned_by_self = ownedBySelf(row);
+	return {
 		...row,
 		kind: canonicalMemoryKind((row.kind as string | null | undefined) ?? null, row.metadata_json),
 		metadata_json: metadata,
-	};
-	return {
-		...item,
-		owned_by_self: memoryOwnedBySelf(row, ownership, metadata),
+		owned_by_self,
 	};
 }
 
@@ -139,11 +100,7 @@ function normalizeScope(raw: string | undefined): "mine" | "theirs" | undefined 
 }
 
 function buildViewerMemoryFilters(store: MemoryStore, filters?: MemoryFilters | null) {
-	return buildFilterClausesWithContext(filters, {
-		actorId: store.actorId,
-		deviceId: store.deviceId,
-		enforceScopeVisibility: true,
-	});
+	return buildFilterClausesWithContext(filters, store.ownershipFilterContext());
 }
 
 function countVisibleMemoryRows(store: MemoryStore, filters?: MemoryFilters | null): number {
@@ -274,8 +231,8 @@ function queryMemoryPage(
 		)
 		.all(...filterResult.params, options.limit + 1, options.offset) as Record<string, unknown>[];
 
-	const ownership = buildOwnershipContext(store);
-	return rows.map((row) => serializeMemoryRow(ownership, row));
+	const ownedBySelf = store.buildOwnershipPredicate();
+	return rows.map((row) => serializeMemoryRow(ownedBySelf, row));
 }
 
 function isSummaryLikeMemory(item: Record<string, unknown>): boolean {
@@ -683,8 +640,7 @@ export function memoryRoutes(getStore: StoreFactory) {
 		if (!row) {
 			return c.json({ error: "memory not found" }, 404);
 		}
-		const ownership = buildOwnershipContext(store);
-		if (!memoryOwnedBySelf(row, ownership)) {
+		if (!store.memoryOwnedBySelf(row as Record<string, unknown>)) {
 			return c.json({ error: "memory not owned by this device" }, 403);
 		}
 		if (Number(row.active ?? 1) === 0 || row.deleted_at != null) {


### PR DESCRIPTION
## Description

`ownership_scope=mine`/`theirs` filtering only matched the local `actor_id`/`origin_device_id`, so memories owned by **claimed same-actor peer devices** (and their `legacy-sync:` actor ids) were wrongly excluded from "My memories" and leaked into "Theirs". This diverged from `MemoryStore.buildOwnershipPredicate()`, which already counts claimed peers — the exact cross-surface drift that produces "my own device's memories aren't showing as mine".

This makes the SQL ownership predicate mirror the JS predicate:

- Include claimed peer device ids and their `legacy-sync:` actor ids in `mine`.
- Fall back to `metadata_json` for `actor_id`/`origin_device_id` when the top-level columns are blank (matches the JS metadata fallback).
- Normalize a missing owner to `''` so the `theirs` (`NOT ...`) comparison stays null-safe.
- Guard blank identity: an empty actor/device context matches **nothing** (`0 = 1`) instead of every ownerless row.

Consolidates the ownership filter context behind a single `MemoryStore.ownershipFilterContext()` and reuses it across store, search, pack, semantic search, and the viewer route. The viewer now reuses `store.buildOwnershipPredicate()` instead of a hand-rolled copy, collapsing three near-duplicate "is this mine?" implementations toward one source of truth.

> Stacked on top of #1259 (scoped sync recovery). Review/merge that first.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

New regression coverage:
- Filter-builder unit tests for claimed-peer device, legacy-sync actor, `metadata_json` fallback, and blank-identity (`0 = 1`) cases.
- `store.recent` ownership tests asserting claimed-peer rows are `mine` and excluded from `theirs`.
- Viewer `/api/observations?scope=mine|theirs` test extended with claimed-peer + metadata-fallback rows.
- Full `pnpm run check` green: tsc, lint, and the whole vitest workspace (2314 tests).
- Reviewed by CodeReviewer, gordon-ramsay, and code-quality-pragmatist; findings (blank-identity SQL/JS parity, null-safety, predicate de-duplication) addressed.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
