### PR TITLE
fix(core): hold inbound replication cursor when ops fail to apply

### DIFF
--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -343,6 +343,79 @@ describe("syncOnce", () => {
 		});
 	});
 
+	it("does not advance the inbound cursor when an op fails to apply", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-err", "abc123", new Date().toISOString());
+		db.prepare(
+			"INSERT INTO replication_cursors (peer_device_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?)",
+		).run("peer-err", "2025-12-31T00:00:00Z|local-op-0", null, new Date().toISOString());
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		grantScopeForSyncPass(db, "acme-work", ["peer-err", "local-device-id"]);
+
+		vi.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: "abc123",
+					protocol_version: "2",
+					sync_capability: "enforcing",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-1",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-1",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [
+						{
+							op_id: "remote-bad-op",
+							entity_type: "memory_item",
+							entity_id: "key:sync-bad-1",
+							op_type: "upsert",
+							// Structurally-invalid payload: errors during apply but is
+							// not a scope rejection, so it lands in `errors` (not
+							// `rejected`).
+							payload_json: JSON.stringify("not-an-object"),
+							clock_rev: 1,
+							clock_updated_at: "2026-01-01T00:00:00Z",
+							clock_device_id: "peer-err",
+							device_id: "peer-err",
+							created_at: "2026-01-01T00:00:00Z",
+							scope_id: "acme-work",
+						},
+					],
+					next_cursor: "2026-01-01T00:00:00Z|remote-bad-op",
+					skipped: 0,
+				},
+			]);
+
+		const result = await syncOnce(db, "peer-err", ["http://127.0.0.1:9090"]);
+
+		// A held inbound cursor is reported as a failure (incomplete), not a
+		// healthy sync, so a persistent stall surfaces to the daemon/operator.
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("inbound apply incomplete");
+		// The op errored during apply; the inbound cursor must NOT advance past it
+		// so it is retried on the next pass instead of being silently skipped.
+		expect(syncReplication.getReplicationCursor(db, "peer-err")[0]).toBe(
+			"2025-12-31T00:00:00Z|local-op-0",
+		);
+	});
+
 	it("bootstraps every authorized scope advertised by a scoped peer", async () => {
 		db.prepare(
 			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -1021,10 +1021,35 @@ async function syncOneScope(
 		}
 
 		const inboundCursorCandidate = asOptionalCursor(payload.next_cursor);
-		if (cursorAdvances(lastApplied, inboundCursorCandidate)) {
+		// Never advance the inbound cursor past a pass that had apply errors: a
+		// failed op that was not durably recorded would otherwise be skipped
+		// forever (silent data loss). Holding the cursor retries it next pass.
+		// Do NOT "fix" a persistent stall by recording throwing ops — that
+		// reintroduces the silent data loss this guards against.
+		if (applied.errors.length > 0) {
+			process.stderr.write(
+				`[codemem] sync: holding inbound cursor for scope ${scopeId} — ${applied.errors.length} op(s) failed to apply and will be retried\n`,
+			);
+		}
+		if (applied.errors.length === 0 && cursorAdvances(lastApplied, inboundCursorCandidate)) {
 			setReplicationCursor(db, peerDeviceId, { lastApplied: inboundCursorCandidate }, scopeId);
 		}
 
+		if (applied.errors.length > 0) {
+			// Cursor was held (apply errors) — inbound replication for this scope
+			// is incomplete and stalled on this window. Report failure so a
+			// persistent stall surfaces instead of looking like a healthy sync.
+			return {
+				scope_id: scopeId,
+				label: scope.label,
+				ok: false,
+				failureCategory: "other",
+				opsIn: applied.applied,
+				opsOut: 0,
+				error: `inbound apply incomplete: ${applied.errors.length} op(s) failed; cursor held for retry`,
+				bootstrapped: hasNullBaselineBootstrapMarker,
+			};
+		}
 		return {
 			scope_id: scopeId,
 			label: scope.label,
@@ -1501,7 +1526,15 @@ export async function syncOnce(
 			}
 
 			const inboundCursorCandidate = asOptionalCursor(getPayload.next_cursor);
-			if (cursorAdvances(lastApplied, inboundCursorCandidate)) {
+			// Never advance the inbound cursor past a pass that had apply errors
+			// (see syncOneScope): advancing would skip the failed ops permanently.
+			// Do NOT clear a persistent stall by recording throwing ops.
+			if (applied.errors.length > 0) {
+				process.stderr.write(
+					`[codemem] sync: holding inbound cursor for peer ${peerDeviceId} — ${applied.errors.length} op(s) failed to apply and will be retried\n`,
+				);
+			}
+			if (applied.errors.length === 0 && cursorAdvances(lastApplied, inboundCursorCandidate)) {
 				setReplicationCursor(db, peerDeviceId, { lastApplied: inboundCursorCandidate });
 				lastApplied = inboundCursorCandidate;
 			}
@@ -1549,25 +1582,44 @@ export async function syncOnce(
 					: { results: [], totalOpsIn: 0 };
 
 			const allScopesOk = scopedAfterIncremental.results.every((r) => r.ok);
+			// A held inbound cursor (default-scope apply errors) means inbound
+			// replication is incomplete and stalled on this window; report it as a
+			// failure so a persistent stall surfaces instead of masquerading as a
+			// healthy sync (and don't promote the peer as fully successful).
+			const inboundIncomplete = applied.errors.length > 0;
+			const ok = allScopesOk && !inboundIncomplete;
+			const errorParts: string[] = [];
+			if (inboundIncomplete) {
+				errorParts.push(
+					`inbound apply incomplete: ${applied.errors.length} op(s) failed; cursor held for retry`,
+				);
+			}
+			if (!allScopesOk) {
+				errorParts.push(
+					`scoped sync incomplete: ${scopedAfterIncremental.results
+						.filter((r) => !r.ok)
+						.map((r) => `${r.scope_id}=${r.error ?? "unknown"}`)
+						.join("; ")}`,
+				);
+			}
+			const combinedError = errorParts.length > 0 ? errorParts.join("; ") : undefined;
 
-			// -- 7. Record success --
-			recordPeerSuccess(db, peerDeviceId, baseUrl);
+			// -- 7. Record result --
+			if (!inboundIncomplete) recordPeerSuccess(db, peerDeviceId, baseUrl);
 			recordSyncAttempt(db, peerDeviceId, {
-				ok: allScopesOk,
+				ok,
 				opsIn: applied.applied + scopedAfterIncremental.totalOpsIn,
 				opsOut: outboundOps.length,
 				capabilities: lastCapabilityDiagnostics,
-				error: allScopesOk
-					? undefined
-					: `scoped sync incomplete: ${scopedAfterIncremental.results
-							.filter((r) => !r.ok)
-							.map((r) => `${r.scope_id}=${r.error ?? "unknown"}`)
-							.join("; ")}`,
+				error: combinedError,
 			});
 			return {
-				ok: allScopesOk,
+				ok,
 				address: baseUrl,
-				failureCategory: aggregateScopeFailureCategory(scopedAfterIncremental.results),
+				error: combinedError,
+				failureCategory: inboundIncomplete
+					? "other"
+					: aggregateScopeFailureCategory(scopedAfterIncremental.results),
 				opsIn: applied.applied + scopedAfterIncremental.totalOpsIn,
 				opsOut: outboundOps.length,
 				opsSkipped,

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -2462,6 +2462,39 @@ describe("applyReplicationOps", () => {
 		expect(r2.applied).toBe(0);
 	});
 
+	it("records malformed-payload upserts so they are not reprocessed every pass", () => {
+		// A structurally-invalid payload can never be applied. It must still be
+		// recorded so it is acknowledged exactly once instead of being re-parsed
+		// (and re-errored) on every subsequent sync pass. Without recording, the
+		// inbound cursor could never safely advance past it.
+		const op = makeReplicationOp({
+			op_id: "bad-payload",
+			payload_json: JSON.stringify("not-an-object"),
+		});
+		const r1 = applyReplicationOps(db, [op], "dev-local");
+		expect(r1.errors.length).toBe(1);
+		expect(memoryExists("key:test-1")).toBe(false);
+
+		// Second pass: the op is already recorded, so it is idempotently skipped
+		// with no repeated error.
+		const r2 = applyReplicationOps(db, [op], "dev-local");
+		expect(r2.skipped).toBe(1);
+		expect(r2.applied).toBe(0);
+		expect(r2.errors.length).toBe(0);
+	});
+
+	it("does not count a delete for an unknown memory as applied", () => {
+		const deleteOp = makeReplicationOp({
+			op_id: "del-unknown",
+			op_type: "delete",
+			entity_id: "key:missing",
+			payload_json: toJson({}),
+		});
+		const result = applyReplicationOps(db, [deleteOp], "dev-local");
+		expect(result.applied).toBe(0);
+		expect(result.skipped).toBe(1);
+	});
+
 	it("inserts a new memory item on upsert", () => {
 		const op = makeReplicationOp();
 		const result = applyReplicationOps(db, [op], "dev-local");
@@ -3550,6 +3583,55 @@ describe("applyReplicationOps", () => {
 			.get("key:undelete") as { active: number; deleted_at: string | null };
 		expect(mem.active).toBe(1);
 		expect(mem.deleted_at).toBeNull();
+	});
+
+	it("does not resurrect a tombstone when an upsert omits deleted_at but sets active=1", () => {
+		const sessionId = insertTestSession(db);
+		const deletedAt = "2026-01-01T00:00:00Z";
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, active, deleted_at, created_at, updated_at, import_key, rev, metadata_json)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			"Stable title",
+			"stable body",
+			0,
+			deletedAt,
+			deletedAt,
+			deletedAt,
+			"key:no-resurrect",
+			1,
+			toJson({ clock_device_id: "dev-remote" }),
+		);
+
+		// Newer upsert carrying active=1 but OMITTING deleted_at (has_deleted_at
+		// is false). The tombstone must be preserved and the row must stay
+		// inactive — a field-omitting upsert must not resurrect a deleted memory.
+		const op = makeReplicationOp({
+			entity_id: "key:no-resurrect",
+			clock_rev: 2,
+			clock_updated_at: "2026-01-02T00:00:00Z",
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Changed title",
+				body_text: "changed body",
+				active: 1,
+				updated_at: "2026-01-02T00:00:00Z",
+			}),
+		});
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+
+		const mem = db
+			.prepare("SELECT id, active, deleted_at FROM memory_items WHERE import_key = ?")
+			.get("key:no-resurrect") as { id: number; active: number; deleted_at: string | null };
+		expect(mem.active).toBe(0);
+		expect(mem.deleted_at).toBe(deletedAt);
+		// Stays tombstoned → embeddings must be queued for deletion, not upsert.
+		expect(result.vectorWork.deleteMemoryIds).toContain(mem.id);
+		expect(result.vectorWork.upsertMemoryIds).not.toContain(mem.id);
 	});
 });
 

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -3174,7 +3174,15 @@ export function applyReplicationOps(
 
 						// Update existing row from payload — skip if malformed
 						const payload = parseMemoryPayload(op, result.errors);
-						if (!payload) continue;
+						if (!payload) {
+							// A malformed payload can never be applied. Record the op so
+							// it is acknowledged exactly once (not re-parsed and re-errored
+							// every pass) and the inbound cursor can eventually advance
+							// past it instead of stalling forever.
+							insertReplicationOpRow(d, op);
+							result.skipped++;
+							continue;
+						}
 						redactMemoryFields(payload, activeScanner);
 						const metaObj = mergePayloadMetadata(payload.metadata_json, op.clock_device_id);
 						const nextTitle = resolveReplicatedTextUpdate(payload.title, memRow.title);
@@ -3188,9 +3196,17 @@ export function applyReplicationOps(
 							? payload.deleted_at
 							: (memRow.deleted_at ?? null);
 						const becomesActive = nextActive !== 0 && nextDeletedAt == null;
-						const shouldDeleteVectors =
-							payload.deleted_at != null ||
-							(payload.active != null && Number(payload.active) === 0);
+						// Keep `active` consistent with the tombstone: when the row stays
+						// (or becomes) tombstoned, force active=0 so a field-omitting
+						// upsert that carries active=1 cannot resurrect a deleted memory
+						// (read paths filter on active=1).
+						const writtenActive = nextDeletedAt != null ? 0 : nextActive;
+						// Base the vector decision on the FINAL persisted state, not the
+						// raw payload: a row that stays (or becomes) tombstoned — active=0
+						// or deleted_at set — must have its embeddings removed, not
+						// re-upserted (the vector queue lets an upsert cancel a pending
+						// delete, which would leave a deleted memory searchable).
+						const shouldDeleteVectors = nextDeletedAt != null || writtenActive === 0;
 						const shouldQueueVectorUpsert =
 							!shouldDeleteVectors && (contentChanged || (wasInactive && becomesActive));
 
@@ -3202,11 +3218,15 @@ export function applyReplicationOps(
 								body_text: sql`COALESCE(${payload.body_text}, ${schema.memoryItems.body_text})`,
 								confidence: sql`COALESCE(${payload.confidence != null ? Number(payload.confidence) : null}, ${schema.memoryItems.confidence})`,
 								tags_text: sql`COALESCE(NULLIF(TRIM(${payload.tags_text}), ''), ${schema.memoryItems.tags_text})`,
-								active: sql`COALESCE(${payload.active != null ? Number(payload.active) : null}, ${schema.memoryItems.active})`,
+								active: writtenActive,
 								updated_at: op.clock_updated_at,
 								metadata_json: toJson(metaObj),
 								rev: op.clock_rev,
-								deleted_at: payload.deleted_at,
+								// Honor the wire intent flag: only clear/set the tombstone
+								// when the payload actually carried `deleted_at`; otherwise
+								// preserve the existing value (nextDeletedAt). Guards against
+								// a field-omitting upsert resurrecting a tombstoned row.
+								deleted_at: nextDeletedAt,
 								actor_id: sql`COALESCE(${payload.actor_id}, ${schema.memoryItems.actor_id})`,
 								actor_display_name: sql`COALESCE(${payload.actor_display_name}, ${schema.memoryItems.actor_display_name})`,
 								visibility: sql`COALESCE(${payload.visibility}, ${schema.memoryItems.visibility})`,
@@ -3244,7 +3264,13 @@ export function applyReplicationOps(
 					} else {
 						// Insert new memory item — skip if malformed
 						const payload = parseMemoryPayload(op, result.errors);
-						if (!payload) continue;
+						if (!payload) {
+							// See the update branch: record malformed ops so they are
+							// acknowledged once and never block inbound cursor progress.
+							insertReplicationOpRow(d, op);
+							result.skipped++;
+							continue;
+						}
 						redactMemoryFields(payload, activeScanner);
 						const replicatedProject =
 							typeof payload.project === "string" && payload.project.trim()
@@ -3333,7 +3359,9 @@ export function applyReplicationOps(
 					if (existingForDelete) {
 						// Clock-compare: only delete if the incoming op is newer
 						const existingClock = clockTuple(
-							existingForDelete.rev ?? 1,
+							// Match the upsert path's `rev ?? 0` so Lamport tie-breaks are
+							// symmetric when an existing row has a NULL rev.
+							existingForDelete.rev ?? 0,
 							existingForDelete.updated_at ?? "",
 							clockDeviceIdFromMetadataJson(existingForDelete.metadata_json),
 						);
@@ -3358,8 +3386,14 @@ export function applyReplicationOps(
 							.where(eq(schema.memoryItems.id, existingForDelete.id))
 							.run();
 						queueVectorDelete(Number(existingForDelete.id));
+					} else {
+						// import_key not found: record the delete as a tombstone for
+						// future resolution, but it mutated nothing — count it as
+						// skipped rather than applied.
+						insertReplicationOpRow(d, op);
+						result.skipped++;
+						continue;
 					}
-					// If import_key not found, record the op as a tombstone for future resolution
 				} else {
 					result.skipped++;
 					insertReplicationOpRow(d, op);


### PR DESCRIPTION
## Description

Replication sync advanced the inbound cursor gated only on scope rejections (`applied.rejected > 0`). Apply-time op failures land in `applied.errors`, not `rejected`: a malformed payload was skipped via `if (!payload) continue` **without** recording the op, and a thrown error was caught *inside* the transaction (which still committed). The cursor then advanced past unrecorded failed ops, which were never re-pulled or idempotently replayed — **permanent, silent inbound data loss**.

- Hold the inbound cursor when a pass has apply errors (both the default and scoped paths); warn when a pass is held back.
- Record malformed-payload ops so they are acknowledged once and self-heal next pass instead of re-erroring forever.
- Defensive: write the computed `nextDeletedAt` so a field-omitting upsert can't clear a tombstone; symmetric `rev ?? 0` in the delete clock; count an unknown-import-key delete as skipped, not applied.

Found by a full-repo bug audit; the data-loss finding was independently verified by an adversarial skeptic pass.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (cursor-gate regression, malformed-op recording, delete counter)
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
