### PR TITLE
fix(ui): sanitize feed markdown with DOMPurify and bundle marked

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,8 @@
 		"@radix-ui/react-toast": "^1.2.15",
 		"@radix-ui/react-toggle-group": "^1.1.11",
 		"@radix-ui/react-tooltip": "^1.2.8",
+		"dompurify": "^3.4.11",
+		"marked": "^18.0.5",
 		"preact": "^10.29.2",
 		"tslib": "^2.8.1"
 	},

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -5,7 +5,7 @@
  * Orchestrates tab routing, polling, and delegates rendering to tab modules.
  */
 
-/* global marked, lucide */
+/* global lucide */
 
 declare const __CODEMEM_GIT_COMMIT__: string;
 

--- a/packages/ui/src/tabs/feed/data/sanitize.test.ts
+++ b/packages/ui/src/tabs/feed/data/sanitize.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import { isSafeHref, renderMarkdownSafe, sanitizeHtml } from "./sanitize";
+
+describe("isSafeHref", () => {
+	it("allows fragment, absolute path, http(s), and mailto", () => {
+		expect(isSafeHref("#anchor")).toBe(true);
+		expect(isSafeHref("/projects")).toBe(true);
+		expect(isSafeHref("http://example.com")).toBe(true);
+		expect(isSafeHref("https://example.com")).toBe(true);
+		expect(isSafeHref("mailto:a@b.com")).toBe(true);
+	});
+
+	it("rejects empty, javascript:, and other schemes", () => {
+		expect(isSafeHref("")).toBe(false);
+		expect(isSafeHref("   ")).toBe(false);
+		expect(isSafeHref("javascript:alert(1)")).toBe(false);
+		expect(isSafeHref("data:text/html,<script>")).toBe(false);
+		expect(isSafeHref("vbscript:msgbox(1)")).toBe(false);
+	});
+});
+
+describe("renderMarkdownSafe — XSS vectors neutralized", () => {
+	it("strips an <img onerror> payload (img not allowed)", () => {
+		const out = renderMarkdownSafe("<img src=x onerror=alert(1)>");
+		expect(out).not.toContain("<img");
+		expect(out).not.toContain("onerror");
+		expect(out).not.toContain("alert(1)");
+	});
+
+	it("strips a <script> tag", () => {
+		const out = renderMarkdownSafe("<script>alert(1)</script>");
+		expect(out).not.toContain("<script");
+		expect(out.toLowerCase()).not.toContain("alert(1)");
+	});
+
+	it("drops a javascript: href but keeps the anchor text", () => {
+		const out = renderMarkdownSafe('<a href="javascript:alert(1)">x</a>');
+		expect(out).not.toContain("javascript:");
+		expect(out).not.toContain("href=");
+		expect(out).toContain("x");
+	});
+
+	it("strips an <svg onload> payload (svg not allowed)", () => {
+		const out = renderMarkdownSafe("<svg onload=alert(1)>");
+		expect(out).not.toContain("<svg");
+		expect(out).not.toContain("onload");
+	});
+
+	it("strips inline event-handler attributes", () => {
+		const out = renderMarkdownSafe('<p onclick="alert(1)">hi</p>');
+		expect(out).not.toContain("onclick");
+		expect(out).not.toContain("alert(1)");
+		expect(out).toContain("hi");
+	});
+});
+
+describe("renderMarkdownSafe — mXSS and obfuscated vectors", () => {
+	// Assert no executable form survives. Inert text (e.g. a literal "alert(1)"
+	// rendered as visible text) is harmless, so we check the dangerous tags,
+	// event-handler attributes, and js scheme rather than the bare payload text.
+	const assertInert = (out: string): void => {
+		const lower = out.toLowerCase();
+		expect(lower).not.toContain("onerror");
+		expect(lower).not.toContain("onload");
+		expect(lower).not.toContain("<img");
+		expect(lower).not.toContain("<script");
+		expect(lower).not.toContain("<svg");
+		expect(lower).not.toContain("javascript:");
+	};
+
+	it("neutralizes a noscript-breakout mXSS payload", () => {
+		assertInert(
+			renderMarkdownSafe('<noscript><p title="</noscript><img src=x onerror=alert(1)>">'),
+		);
+	});
+
+	it("neutralizes an svg/style-wrapped mXSS payload", () => {
+		assertInert(renderMarkdownSafe("<svg><style><img src=x onerror=alert(1)></style></svg>"));
+	});
+
+	it("neutralizes a form/math/mglyph mXSS breakout", () => {
+		assertInert(
+			renderMarkdownSafe(
+				"<form><math><mtext></form><form><mglyph><style></math><img src onerror=alert(1)>",
+			),
+		);
+	});
+
+	it("drops an href with an HTML-entity-encoded javascript scheme", () => {
+		const out = renderMarkdownSafe('<a href="&#74;avascript:alert(1)">x</a>');
+		expect(out).not.toContain("href=");
+		expect(out.toLowerCase()).not.toContain("javascript:");
+		expect(out).toContain("x");
+	});
+
+	it("drops an href with a tab-obfuscated javascript scheme", () => {
+		const out = renderMarkdownSafe('<a href="java\tscript:alert(1)">x</a>');
+		expect(out).not.toContain("href=");
+		expect(out.toLowerCase()).not.toContain("javascript:");
+	});
+
+	it("drops an href with a leading-whitespace javascript scheme", () => {
+		const out = renderMarkdownSafe('<a href="  javascript:alert(1)">x</a>');
+		expect(out).not.toContain("href=");
+		expect(out.toLowerCase()).not.toContain("javascript:");
+	});
+});
+
+describe("renderMarkdownSafe — safe content survives", () => {
+	it("renders bold as <strong>", () => {
+		const out = renderMarkdownSafe("**bold**");
+		expect(out).toContain("<strong>bold</strong>");
+	});
+
+	it("renders a markdown link with href + rel + target", () => {
+		const out = renderMarkdownSafe("[x](https://example.com)");
+		expect(out).toContain('href="https://example.com"');
+		expect(out).toContain('rel="noopener noreferrer"');
+		expect(out).toContain('target="_blank"');
+		expect(out).toContain(">x</a>");
+	});
+
+	it("renders headings", () => {
+		const out = renderMarkdownSafe("# Title\n\n## Subtitle");
+		expect(out).toContain("<h1>Title</h1>");
+		expect(out).toContain("<h2>Subtitle</h2>");
+	});
+
+	it("renders unordered lists", () => {
+		const out = renderMarkdownSafe("- one\n- two");
+		expect(out).toContain("<ul>");
+		expect(out).toContain("<li>one</li>");
+		expect(out).toContain("<li>two</li>");
+	});
+});
+
+describe("sanitizeHtml", () => {
+	it("applies the same allowlist + anchor policy to raw HTML", () => {
+		expect(sanitizeHtml("<script>alert(1)</script>")).not.toContain("<script");
+		const link = sanitizeHtml('<a href="https://example.com" title="t">x</a>');
+		expect(link).toContain('href="https://example.com"');
+		expect(link).toContain('title="t"');
+		expect(link).toContain('rel="noopener noreferrer"');
+		expect(link).toContain('target="_blank"');
+		expect(sanitizeHtml('<a href="javascript:alert(1)">x</a>')).not.toContain("javascript:");
+	});
+
+	it("strips disallowed tags but preserves their text content", () => {
+		const out = sanitizeHtml("<div>kept text</div>");
+		expect(out).not.toContain("<div");
+		expect(out).toContain("kept text");
+	});
+
+	it("strips data-* attributes (e.g. data-lucide) so post-render processors can't act on them", () => {
+		const out = sanitizeHtml('<p data-lucide="x" data-foo="y">text</p>');
+		expect(out).not.toContain("data-lucide");
+		expect(out).not.toContain("data-foo");
+		expect(out).toContain("text");
+		expect(renderMarkdownSafe("<p data-lucide=skull>m</p>")).not.toContain("data-lucide");
+	});
+});

--- a/packages/ui/src/tabs/feed/data/sanitize.ts
+++ b/packages/ui/src/tabs/feed/data/sanitize.ts
@@ -1,4 +1,57 @@
-/* Feed sanitize — HTML/Markdown sanitizer + safe-href check. */
+/* Feed sanitize — Markdown rendering + HTML sanitization.
+ *
+ * Untrusted (including peer-synced) memory content is rendered with marked
+ * and then sanitized with DOMPurify. We never round-trip through a bespoke
+ * allowlist + template.innerHTML re-serialize pass, which is the classic
+ * mXSS-bypassable pattern; DOMPurify is the sanitizer marked's own docs
+ * mandate.
+ *
+ * BROWSER-ONLY: DOMPurify needs a real `window`/DOM. In a no-DOM context
+ * (e.g. SSR) DOMPurify.sanitize is a no-op and would fail open on untrusted
+ * input. This module is only ever called client-side (the viewer bundle runs
+ * in the browser; tests run under jsdom). Do not call it server-side without
+ * providing a DOM (e.g. via a jsdom window) first.
+ */
+
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+
+/* Allowlist preserved verbatim from the previous hand-rolled sanitizer. */
+const ALLOWED_TAGS = [
+	"p",
+	"br",
+	"strong",
+	"em",
+	"code",
+	"pre",
+	"ul",
+	"ol",
+	"li",
+	"blockquote",
+	"a",
+	"h1",
+	"h2",
+	"h3",
+	"h4",
+	"h5",
+	"h6",
+	"hr",
+];
+
+/* ALLOWED_ATTR is global (DOMPurify does not scope attributes per tag). That
+ * is safe here: `title` is inert text, and `href` is only meaningful on URL
+ * elements and is independently scheme-filtered by DOMPurify's IS_ALLOWED_URI
+ * (blocking javascript:/data:/etc.). The dangerous href carriers (svg/use)
+ * are excluded by ALLOWED_TAGS. The anchor hook below adds the rel/target
+ * hardening and our stricter isSafeHref check on top. */
+const ALLOWED_ATTR = ["href", "title"];
+
+/* Shared DOMPurify options for both sanitize paths (kept in one place so they
+ * can't drift). ALLOW_DATA_ATTR must be false: DOMPurify keeps data-* attributes
+ * by default even with ALLOWED_ATTR set, and the feed runs lucide.createIcons()
+ * after rendering, which would turn a peer-supplied `data-lucide="..."` into an
+ * SVG — mutating sanitized content and bypassing this allowlist. */
+const SANITIZE_OPTIONS = { ALLOWED_TAGS, ALLOWED_ATTR, ALLOW_DATA_ATTR: false };
 
 export function isSafeHref(value: string): boolean {
 	const href = String(value || "").trim();
@@ -8,74 +61,26 @@ export function isSafeHref(value: string): boolean {
 	return lower.startsWith("http://") || lower.startsWith("https://") || lower.startsWith("mailto:");
 }
 
+/* Enforce anchor policy: drop unsafe hrefs, and harden safe ones with
+ * rel="noopener noreferrer" + target="_blank". Registered once at module
+ * load so it applies to every DOMPurify.sanitize call in this module. */
+DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+	if (node.tagName === "A") {
+		const href = node.getAttribute("href") || "";
+		if (!isSafeHref(href)) {
+			node.removeAttribute("href");
+		} else {
+			node.setAttribute("rel", "noopener noreferrer");
+			node.setAttribute("target", "_blank");
+		}
+	}
+});
+
 export function sanitizeHtml(html: string): string {
-	const template = document.createElement("template");
-	template.innerHTML = String(html || "");
-	const allowedTags = new Set([
-		"p",
-		"br",
-		"strong",
-		"em",
-		"code",
-		"pre",
-		"ul",
-		"ol",
-		"li",
-		"blockquote",
-		"a",
-		"h1",
-		"h2",
-		"h3",
-		"h4",
-		"h5",
-		"h6",
-		"hr",
-	]);
-
-	template.content
-		.querySelectorAll("script, iframe, object, embed, link, style")
-		.forEach((node) => {
-			node.remove();
-		});
-
-	template.content.querySelectorAll("*").forEach((node) => {
-		const tag = node.tagName.toLowerCase();
-		if (!allowedTags.has(tag)) {
-			node.replaceWith(document.createTextNode(node.textContent || ""));
-			return;
-		}
-
-		const allowedAttrs = tag === "a" ? new Set(["href", "title"]) : new Set<string>();
-		for (const attr of Array.from(node.attributes)) {
-			const name = attr.name.toLowerCase();
-			if (!allowedAttrs.has(name)) {
-				node.removeAttribute(attr.name);
-			}
-		}
-
-		if (tag === "a") {
-			const href = node.getAttribute("href") || "";
-			if (!isSafeHref(href)) {
-				node.removeAttribute("href");
-			} else {
-				node.setAttribute("rel", "noopener noreferrer");
-				node.setAttribute("target", "_blank");
-			}
-		}
-	});
-
-	return template.innerHTML;
+	return DOMPurify.sanitize(String(html || ""), SANITIZE_OPTIONS);
 }
 
 export function renderMarkdownSafe(value: string): string {
-	const source = String(value || "");
-	try {
-		const globalMarked = (globalThis as { marked?: { parse: (src: string) => string } }).marked;
-		if (!globalMarked) throw new Error("marked is not available");
-		const rawHtml = globalMarked.parse(source);
-		return sanitizeHtml(rawHtml);
-	} catch {
-		const escaped = source.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-		return escaped;
-	}
+	const rawHtml = marked.parse(String(value || ""), { async: false });
+	return DOMPurify.sanitize(rawHtml, SANITIZE_OPTIONS);
 }

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -8,7 +8,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
-    <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
     <script src="https://unpkg.com/lucide@latest"></script>
     <script>
       (function() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,12 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      dompurify:
+        specifier: ^3.4.11
+        version: 3.4.11
+      marked:
+        specifier: ^18.0.5
+        version: 18.0.5
       preact:
         specifier: ^10.29.2
         version: 10.29.2
@@ -2214,6 +2220,9 @@ packages:
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@vitest/expect@4.1.7':
     resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
 
@@ -2536,6 +2545,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3078,6 +3090,11 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -5320,6 +5337,9 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 24.12.4
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@vitest/expect@4.1.7':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -5646,6 +5666,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -6185,6 +6209,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
 


### PR DESCRIPTION
## Description

The feed rendered untrusted (including peer-synced) memory content with `marked@11` loaded as a CDN global, then a hand-rolled allowlist sanitizer that round-trips through `template.innerHTML` — the classic mXSS-bypassable pattern. This replaces it with DOMPurify (the sanitizer marked's own docs mandate) and bundles `marked` + `dompurify` so there is no CDN dependency or fail-open-on-CDN-miss path.

- `sanitize.ts`: render via bundled marked, sanitize via DOMPurify with the same tag allowlist and `href`/`title` attrs; an `afterSanitizeAttributes` hook keeps the `isSafeHref` check and `rel="noopener noreferrer"`/`target="_blank"` hardening on anchors.
- `static/index.html`: drop the marked CDN `<script>` (now bundled).
- Adds sanitize tests covering mXSS breakout payloads and obfuscated (entity/tab/whitespace) `javascript:` hrefs, and documents the browser-only (DOM-required) assumption.

Found by a full-repo bug audit. The matching Content-Security-Policy backstop is deferred (it needs the inline bootstrap script externalized first to allow a meaningful strict policy).

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (mXSS + obfuscated-href vectors, safe-content survival)
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
