### PR TITLE
fix(viewer-server): evict usage cache and fix error/config consistency

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -26,6 +26,7 @@ import { serve } from "@hono/node-server";
 import Database from "better-sqlite3";
 import { describe, expect, it, vi } from "vitest";
 import { createApp, createSyncApp } from "./index.js";
+import { __usageCacheTestHooks } from "./routes/stats.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -725,6 +726,45 @@ describe("viewer-server", () => {
 				};
 				expect(afterRevoke.totals.count).toBe(0);
 			} finally {
+				cleanup();
+			}
+		});
+
+		it("evicts expired usage-cache entries on sweep", () => {
+			const { cache, sweep } = __usageCacheTestHooks;
+			cache.clear();
+			try {
+				const nowMs = 1_000_000;
+				// One already-expired entry and one still-live entry.
+				cache.set("expired-key", { payload: {}, expiresAtMs: nowMs - 1 });
+				cache.set("live-key", { payload: {}, expiresAtMs: nowMs + 10_000 });
+				sweep(cache, nowMs);
+				expect(cache.has("expired-key")).toBe(false);
+				expect(cache.has("live-key")).toBe(true);
+				expect(cache.size).toBe(1);
+			} finally {
+				cache.clear();
+			}
+		});
+
+		it("caps the usage cache under a flood of distinct /api/usage requests", async () => {
+			const { app, cleanup } = createTestApp();
+			const { cache, maxEntries } = __usageCacheTestHooks;
+			cache.clear();
+			try {
+				await app.request("/api/stats");
+				// Each distinct ?project= yields a distinct cache key (see
+				// usageCacheKey), mirroring the per-request-unique key growth the
+				// sweep defends against. Driving the real endpoint guards the
+				// handler's use of the sweep, not just the helper in isolation — if
+				// the sweep call is ever removed from the handler, this fails.
+				for (let i = 0; i < maxEntries + 50; i += 1) {
+					await app.request(`/api/usage?project=flood-${i}`);
+				}
+				expect(cache.size).toBeGreaterThan(1);
+				expect(cache.size).toBeLessThanOrEqual(maxEntries);
+			} finally {
+				cache.clear();
 				cleanup();
 			}
 		});
@@ -1899,6 +1939,39 @@ describe("viewer-server", () => {
 	});
 
 	describe("/api/config", () => {
+		it("GET resolves the same workspace-scoped file as the core resolver POST uses", async () => {
+			// Workspace-scoped override via CODEMEM_RUNTIME_ROOT is honored only by
+			// the core resolver (getCodememConfigPath / readCodememConfigFile). The
+			// legacy local getConfigPath() ignored it, so GET and POST could resolve
+			// different files. GET must now match the core resolver exactly.
+			const runtimeRoot = mkdtempSync(join(tmpdir(), "codemem-runtime-root-"));
+			const scopedConfigPath = join(runtimeRoot, "config", "codemem.json");
+			mkdirSync(join(runtimeRoot, "config"), { recursive: true });
+			writeFileSync(scopedConfigPath, JSON.stringify({ observer_model: "scoped-model" }));
+			const prevRuntimeRoot = process.env.CODEMEM_RUNTIME_ROOT;
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			process.env.CODEMEM_RUNTIME_ROOT = runtimeRoot;
+			delete process.env.CODEMEM_CONFIG;
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				// GET resolves to the workspace-scoped file the core resolver chooses,
+				// which is the same path POST writes to.
+				expect(body.path).toBe(core.getCodememConfigPath());
+				expect(body.path).toBe(scopedConfigPath);
+				expect((body.config as Record<string, unknown>).observer_model).toBe("scoped-model");
+			} finally {
+				cleanup();
+				rmSync(runtimeRoot, { recursive: true, force: true });
+				if (prevRuntimeRoot == null) delete process.env.CODEMEM_RUNTIME_ROOT;
+				else process.env.CODEMEM_RUNTIME_ROOT = prevRuntimeRoot;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+			}
+		});
+
 		it("returns provider options from real opencode config prefixes", async () => {
 			const tmpHome = mkdtempSync(join(tmpdir(), "codemem-home-test-"));
 			const opencodeConfigDir = join(tmpHome, ".config", "opencode");
@@ -2435,6 +2508,23 @@ describe("viewer-server", () => {
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body).toHaveProperty("items");
 				expect(body.redacted).toBe(true);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("returns 400 (not 500) when POST /api/sync/peers/rename gets a malformed body", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const res = await app.request("/api/sync/peers/rename", {
+					method: "POST",
+					headers: { "Content-Type": "application/json", Origin: "http://localhost" },
+					body: "{ not json",
+				});
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as { error?: string };
+				expect(body.error).toBe("invalid json");
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/config.ts
+++ b/packages/viewer-server/src/routes/config.ts
@@ -5,9 +5,6 @@
  * codemem/viewer_routes/config.py, scoped to the TS runtime's current needs.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import {
 	CODEMEM_CONFIG_ENV_OVERRIDES,
 	getCodememConfigPath,
@@ -15,8 +12,6 @@ import {
 	listObserverProviderOptions,
 	type RawEventSweeper,
 	readCodememConfigFile,
-	stripJsonComments,
-	stripTrailingCommas,
 	writeCodememConfigFile,
 } from "@codemem/core";
 import { Hono } from "hono";
@@ -112,30 +107,6 @@ export interface ConfigRouteOptions {
 
 function loadProviderOptions(): string[] {
 	return listObserverProviderOptions();
-}
-
-function getConfigPath(): string {
-	const envPath = process.env.CODEMEM_CONFIG;
-	if (envPath) return envPath.replace(/^~/, homedir());
-	const configDir = join(homedir(), ".config", "codemem");
-	const candidates = [join(configDir, "config.json"), join(configDir, "config.jsonc")];
-	return candidates.find((p) => existsSync(p)) ?? join(configDir, "config.json");
-}
-
-function readConfigFile(configPath: string): ConfigData {
-	if (!existsSync(configPath)) return {};
-	try {
-		let text = readFileSync(configPath, "utf-8").trim();
-		if (!text) return {};
-		try {
-			return JSON.parse(text) as ConfigData;
-		} catch {
-			text = stripTrailingCommas(stripJsonComments(text));
-			return JSON.parse(text) as ConfigData;
-		}
-	} catch {
-		return {};
-	}
 }
 
 function withoutRemovedConfigKeys(configData: ConfigData): ConfigData {
@@ -375,8 +346,12 @@ export function configRoutes(opts: ConfigRouteOptions = {}) {
 	const app = new Hono();
 
 	app.get("/api/config", (c) => {
-		const configPath = getConfigPath();
-		const configData = withoutRemovedConfigKeys(readConfigFile(configPath));
+		// Resolve via the core resolver so GET reflects the same file POST
+		// writes — including workspace-scoped overrides honored through
+		// CODEMEM_RUNTIME_ROOT / CODEMEM_WORKSPACE_ID, which the legacy local
+		// getConfigPath() ignored.
+		const configPath = getCodememConfigPath();
+		const configData = withoutRemovedConfigKeys(readCodememConfigFile());
 		const effective = getEffectiveConfig(configData);
 		return c.json({
 			path: configPath,

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -243,6 +243,44 @@ const usagePayloadCache = new Map<string, UsageCacheEntry>();
 const USAGE_PAYLOAD_CACHE_MS = 10_000;
 
 /**
+ * Hard cap on cached usage payloads. The cache key folds in the arbitrary
+ * `?project=` filter and a scope-visibility fingerprint that becomes
+ * per-request-unique on the error/bypass path, so without a bound the map
+ * would grow without limit in a long-running viewer. The cap is far above the
+ * realistic working set (a handful of projects times one or two scope
+ * generations), so legitimate hits are never evicted under normal load.
+ */
+const USAGE_PAYLOAD_CACHE_MAX_ENTRIES = 256;
+
+/**
+ * Sweep expired entries and enforce the size cap before inserting a new one.
+ *
+ * Mirrors the lazy-sweep approach in request-rate-limit.ts: eviction is
+ * piggybacked on writes rather than run on a timer, so an idle viewer does no
+ * background work. Expired entries (those past `expiresAtMs`) are always
+ * dropped; if the map is still at capacity afterward — e.g. a burst of
+ * distinct, still-live bypass keys — the oldest-expiring entries are evicted
+ * to make room. This never changes hit/miss semantics for a live entry: the
+ * caller still re-checks `expiresAtMs` on read, and only already-expired or
+ * over-cap entries are removed here.
+ */
+function sweepUsagePayloadCache(cache: Map<string, UsageCacheEntry>, nowMs: number): void {
+	for (const [key, entry] of cache) {
+		if (entry.expiresAtMs <= nowMs) cache.delete(key);
+	}
+	if (cache.size < USAGE_PAYLOAD_CACHE_MAX_ENTRIES) return;
+	// Leave room for the entry about to be inserted by evicting down to one
+	// below the cap. Drop the soonest-to-expire entries first.
+	const byExpiry = [...cache.entries()].sort((a, b) => a[1].expiresAtMs - b[1].expiresAtMs);
+	let overflow = cache.size - USAGE_PAYLOAD_CACHE_MAX_ENTRIES + 1;
+	for (const [key] of byExpiry) {
+		if (overflow <= 0) break;
+		cache.delete(key);
+		overflow -= 1;
+	}
+}
+
+/**
  * Cheap fingerprint of the state that drives scope visibility
  * (`scope_memberships` / `replication_scopes`). Folding this into the usage
  * cache key ensures a membership/scope status change — e.g. a revocation —
@@ -416,9 +454,11 @@ export function statsRoutes(getStore: () => MemoryStore) {
 				totals_filtered: totalsFiltered,
 				recent_packs: recentPacks,
 			};
+			const setAtMs = Date.now();
+			sweepUsagePayloadCache(usagePayloadCache, setAtMs);
 			usagePayloadCache.set(cacheKey, {
 				payload,
-				expiresAtMs: Date.now() + USAGE_PAYLOAD_CACHE_MS,
+				expiresAtMs: setAtMs + USAGE_PAYLOAD_CACHE_MS,
 			});
 			return c.json(payload);
 		}
@@ -426,3 +466,14 @@ export function statsRoutes(getStore: () => MemoryStore) {
 
 	return app;
 }
+
+/**
+ * Internals exposed for unit tests of the usage-cache eviction. Not part of the
+ * route's public surface; consumers should go through the HTTP handlers.
+ */
+export const __usageCacheTestHooks = {
+	cache: usagePayloadCache,
+	sweep: sweepUsagePayloadCache,
+	maxEntries: USAGE_PAYLOAD_CACHE_MAX_ENTRIES,
+	ttlMs: USAGE_PAYLOAD_CACHE_MS,
+};

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -3089,7 +3089,12 @@ export function syncRoutes(
 		const store = getStore();
 		{
 			const d = drizzle(store.db, { schema });
-			const body = await c.req.json<Record<string, unknown>>();
+			let body: Record<string, unknown>;
+			try {
+				body = await c.req.json<Record<string, unknown>>();
+			} catch {
+				return c.json({ error: "invalid json" }, 400);
+			}
 			const peerDeviceId = String(body.peer_device_id ?? "").trim();
 			const name = String(body.name ?? "").trim();
 			if (!peerDeviceId) return c.json({ error: "peer_device_id required" }, 400);


### PR DESCRIPTION
## Description

Three viewer-server fixes:

- **stats.ts**: the `usagePayloadCache` Map was never evicted, and its key includes the arbitrary `?project=` filter plus a per-request-unique fingerprint on error paths, so it grew without bound in a long-running viewer. Sweep expired entries and cap the map on write (mirrors the request-rate-limit cleanup pattern); cache hit/miss and TTL semantics are unchanged.
- **sync.ts**: `/api/sync/peers/rename` now returns `400 invalid json` instead of a generic 500 on a malformed body — it was the only mutation handler missing the parse guard its siblings have.
- **config.ts**: `GET /api/config` now resolves via the core `getCodememConfigPath` / `readCodememConfigFile` that POST already uses, so both honor workspace-scoped overrides (`CODEMEM_RUNTIME_ROOT` / `CODEMEM_WORKSPACE_ID`) and read the same file; the dead local resolver is removed.

Found by a full-repo bug audit.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (cache cap holds via the real `/api/usage` handler; 400 on malformed rename; GET/POST config-path parity)
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
