### PR TITLE
fix(core): make coordinator removeDevice atomic and invite-expiry timezone-safe

### DIFF
--- a/packages/cloudflare-coordinator-worker/src/request-verifier.ts
+++ b/packages/cloudflare-coordinator-worker/src/request-verifier.ts
@@ -86,6 +86,11 @@ export const verifyCloudflareCoordinatorRequest: CoordinatorRequestVerifier = as
 	if (!/^\d+$/.test(request.timestamp)) return false;
 	const timestamp = Number.parseInt(request.timestamp, 10);
 	if (Number.isNaN(timestamp)) return false;
+	// Freshness is checked against real Date.now(), independent of the
+	// coordinator's injected runtime.now() used for nonce cutoffs. This is safe
+	// in production where both are wall-clock, but means a frozen/injected
+	// runtime clock will not move this check. See coordinator-api authorizeRequest
+	// for the matching clock-source note.
 	const now = Math.floor(Date.now() / 1000);
 	if (Math.abs(now - timestamp) > DEFAULT_TIME_WINDOW_S) return false;
 

--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -46,6 +46,7 @@ import type {
 	CoordinatorUpdateScopeInput,
 	CoordinatorUpsertPresenceInput,
 } from "./coordinator-store-contract.js";
+import { normalizeInviteExpiresAt } from "./coordinator-store-contract.js";
 
 export const DEFAULT_COORDINATOR_DB_PATH = join(homedir(), ".codemem", "coordinator.sqlite");
 
@@ -642,18 +643,23 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 	}
 
 	async removeDevice(groupId: string, deviceId: string): Promise<boolean> {
-		this.db
-			.prepare("DELETE FROM presence_records WHERE group_id = ? AND device_id = ?")
-			.run(groupId, deviceId);
-		this.db
-			.prepare(
-				"DELETE FROM coordinator_reciprocal_approvals WHERE group_id = ? AND (requesting_device_id = ? OR requested_device_id = ?)",
-			)
-			.run(groupId, deviceId, deviceId);
-		const result = this.db
-			.prepare("DELETE FROM enrolled_devices WHERE group_id = ? AND device_id = ?")
-			.run(groupId, deviceId);
-		return result.changes > 0;
+		// Atomic: a partial failure must not leave presence/approval rows
+		// orphaned against a still-enrolled device (or vice versa).
+		const removeAll = this.db.transaction(() => {
+			this.db
+				.prepare("DELETE FROM presence_records WHERE group_id = ? AND device_id = ?")
+				.run(groupId, deviceId);
+			this.db
+				.prepare(
+					"DELETE FROM coordinator_reciprocal_approvals WHERE group_id = ? AND (requesting_device_id = ? OR requested_device_id = ?)",
+				)
+				.run(groupId, deviceId, deviceId);
+			const result = this.db
+				.prepare("DELETE FROM enrolled_devices WHERE group_id = ? AND device_id = ?")
+				.run(groupId, deviceId);
+			return result.changes > 0;
+		});
+		return removeAll();
 	}
 
 	async recordNonce(deviceId: string, nonce: string, createdAt: string): Promise<boolean> {
@@ -673,6 +679,9 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 
 	async createInvite(opts: CoordinatorCreateInviteInput): Promise<CoordinatorInvite> {
 		const now = nowISO();
+		// Normalize to canonical UTC ISO so the lexicographic `expires_at > ?`
+		// comparison in getInviteByToken is sound.
+		const expiresAt = normalizeInviteExpiresAt(opts.expiresAt);
 		const inviteId = tokenUrlSafe(12);
 		const token = tokenUrlSafe(24);
 		const group = await this.getGroup(opts.groupId);
@@ -685,7 +694,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				opts.groupId,
 				token,
 				opts.policy,
-				opts.expiresAt,
+				expiresAt,
 				now,
 				opts.createdBy ?? null,
 				group?.display_name ?? null,

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -185,6 +185,31 @@ describe("createCoordinatorApp dependency injection", () => {
 		expect(store.close).toHaveBeenCalledTimes(1);
 	});
 
+	it("rejects an invalid invite expires_at with 400 instead of a 500", async () => {
+		const store = createMockStore({});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: {
+				adminSecret: () => "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+			},
+			requestVerifier: allowRequest,
+		});
+
+		const res = await app.request("/v1/admin/invites", {
+			method: "POST",
+			headers: {
+				"X-Codemem-Coordinator-Admin": "test-secret",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ group_id: "g1", policy: "auto_admit", expires_at: "not-a-date" }),
+		});
+
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "invalid_expires_at" });
+		expect(store.createInvite).not.toHaveBeenCalled();
+	});
+
 	it("rate limits repeated coordinator reads before route handling continues", async () => {
 		const store = createMockStore({
 			listEnrolledDevices: vi.fn(async () => []),

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -167,6 +167,15 @@ async function authorizeRequest(
 		return { ok: false, error: "nonce_replay", enrollment: null };
 	}
 
+	// Clock-source note: the nonce timestamp/cutoff below is driven by the
+	// injected runtime.now(), while the request freshness window is enforced
+	// inside requestVerifier using real Date.now() (see the worker's
+	// request-verifier). In production both are wall-clock so they agree. Under
+	// an injected/frozen clock they can diverge; the freshness check is not
+	// reachable from runtime.now(), so tests that freeze runtime.now() must keep
+	// timestamps within DEFAULT_TIME_WINDOW_S of real time for the verifier to
+	// accept them. Unifying the two would require threading the clock into the
+	// verifier signature across the core/worker boundary.
 	const cutoff = new Date(
 		new Date(createdAt).getTime() - DEFAULT_TIME_WINDOW_S * 2 * 1000,
 	).toISOString();
@@ -1250,6 +1259,11 @@ export function createCoordinatorApp(
 
 		if (!groupId || !["auto_admit", "approval_required"].includes(policy) || !expiresAt) {
 			return c.json({ error: "group_id_policy_and_expires_at_required" }, 400);
+		}
+		// Validate the date at the boundary so store.createInvite's
+		// normalizeInviteExpiresAt throw can't escape as an unhandled 500.
+		if (Number.isNaN(new Date(expiresAt).getTime())) {
+			return c.json({ error: "invalid_expires_at" }, 400);
 		}
 
 		const store = createStore();

--- a/packages/core/src/coordinator-store-contract.ts
+++ b/packages/core/src/coordinator-store-contract.ts
@@ -1,3 +1,19 @@
+/**
+ * Normalize a caller-supplied invite expiry to a canonical UTC ISO-8601
+ * (`...Z`) string. Invite lookups filter with a SQL `expires_at > ?` string
+ * comparison against `new Date().toISOString()`, which is only correct when
+ * stored values share that exact format — a `+00:00` offset or date-only value
+ * would compare wrong. Shared by both coordinator store implementations.
+ */
+export function normalizeInviteExpiresAt(value: string): string {
+	const trimmed = value.trim();
+	const parsed = new Date(trimmed);
+	if (!trimmed || Number.isNaN(parsed.getTime())) {
+		throw new Error("expiresAt must be a valid date.");
+	}
+	return parsed.toISOString();
+}
+
 export interface CoordinatorGroup {
 	group_id: string;
 	display_name: string | null;

--- a/packages/core/src/d1-coordinator-store.test.ts
+++ b/packages/core/src/d1-coordinator-store.test.ts
@@ -140,6 +140,23 @@ class FailingAuditBatchD1Database extends SqliteD1Database {
 	}
 }
 
+class FailingDeviceRemovalBatchD1Database extends SqliteD1Database {
+	override async batch(statements: D1PreparedStatementLike[]): Promise<unknown[]> {
+		return this.db.transaction(() => {
+			// Run every delete except the final enrolled_devices delete, then fail
+			// mid-batch so the rollback restores all three row types.
+			const results: unknown[] = [];
+			for (const statement of statements.slice(0, -1)) {
+				if (!(statement instanceof SqliteD1Statement)) {
+					throw new Error("Unsupported D1 statement test double.");
+				}
+				results.push(statement.executeRunSync());
+			}
+			throw new Error("device removal batch failed");
+		})();
+	}
+}
+
 class RacingRevokeBatchD1Database extends SqliteD1Database {
 	private injected = false;
 
@@ -400,6 +417,177 @@ describe("D1CoordinatorStore", () => {
 			vi.useRealTimers();
 			await racingStore.close();
 			await normalStore.close();
+			await cleanup();
+		}
+	});
+
+	it("removes presence, reciprocal approvals, and enrollment atomically", async () => {
+		const { db, cleanup } = setupStore();
+		const store = new D1CoordinatorStore(new SqliteD1Database(db));
+		try {
+			await store.createGroup("g1");
+			await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
+			await store.enrollDevice("g1", { deviceId: "d2", fingerprint: "fp2", publicKey: "pk2" });
+			await store.upsertPresence({
+				groupId: "g1",
+				deviceId: "d1",
+				addresses: ["http://localhost:9000"],
+				ttlS: 300,
+			});
+			await store.createReciprocalApproval({
+				groupId: "g1",
+				requestingDeviceId: "d1",
+				requestedDeviceId: "d2",
+			});
+
+			expect(await store.removeDevice("g1", "d1")).toBe(true);
+
+			expect(await store.getEnrollment("g1", "d1")).toBeNull();
+			expect(
+				db
+					.prepare(
+						"SELECT COUNT(*) AS n FROM presence_records WHERE group_id = ? AND device_id = ?",
+					)
+					.get("g1", "d1"),
+			).toEqual({ n: 0 });
+			expect(
+				db
+					.prepare(
+						"SELECT COUNT(*) AS n FROM coordinator_reciprocal_approvals WHERE group_id = ? AND (requesting_device_id = ? OR requested_device_id = ?)",
+					)
+					.get("g1", "d1", "d1"),
+			).toEqual({ n: 0 });
+		} finally {
+			await store.close();
+			await cleanup();
+		}
+	});
+
+	it("returns false when removing a non-existent device", async () => {
+		const { db, cleanup } = setupStore();
+		const store = new D1CoordinatorStore(new SqliteD1Database(db));
+		try {
+			await store.createGroup("g1");
+			expect(await store.removeDevice("g1", "ghost")).toBe(false);
+		} finally {
+			await store.close();
+			await cleanup();
+		}
+	});
+
+	it("leaves no partial deletion when the device removal batch fails mid-way", async () => {
+		const { db, cleanup } = setupStore();
+		const normalStore = new D1CoordinatorStore(new SqliteD1Database(db));
+		const failingStore = new D1CoordinatorStore(new FailingDeviceRemovalBatchD1Database(db));
+		try {
+			await normalStore.createGroup("g1");
+			await normalStore.enrollDevice("g1", {
+				deviceId: "d1",
+				fingerprint: "fp1",
+				publicKey: "pk1",
+			});
+			await normalStore.enrollDevice("g1", {
+				deviceId: "d2",
+				fingerprint: "fp2",
+				publicKey: "pk2",
+			});
+			await normalStore.upsertPresence({
+				groupId: "g1",
+				deviceId: "d1",
+				addresses: ["http://localhost:9000"],
+				ttlS: 300,
+			});
+			await normalStore.createReciprocalApproval({
+				groupId: "g1",
+				requestingDeviceId: "d1",
+				requestedDeviceId: "d2",
+			});
+
+			await expect(failingStore.removeDevice("g1", "d1")).rejects.toThrow(
+				"device removal batch failed",
+			);
+
+			// All-or-nothing: the enrollment, presence, and reciprocal approval rows
+			// must all survive the rolled-back batch.
+			expect(await normalStore.getEnrollment("g1", "d1")).not.toBeNull();
+			expect(
+				db
+					.prepare(
+						"SELECT COUNT(*) AS n FROM presence_records WHERE group_id = ? AND device_id = ?",
+					)
+					.get("g1", "d1"),
+			).toEqual({ n: 1 });
+			expect(
+				db
+					.prepare(
+						"SELECT COUNT(*) AS n FROM coordinator_reciprocal_approvals WHERE group_id = ? AND (requesting_device_id = ? OR requested_device_id = ?)",
+					)
+					.get("g1", "d1", "d1"),
+			).toEqual({ n: 1 });
+		} finally {
+			await failingStore.close();
+			await normalStore.close();
+			await cleanup();
+		}
+	});
+
+	it("stores a non-canonical invite expiry in canonical UTC form", async () => {
+		const { store, cleanup } = setupStore();
+		try {
+			await store.createGroup("g1", "Team Alpha");
+			const offsetInvite = await store.createInvite({
+				groupId: "g1",
+				policy: "auto_admit",
+				expiresAt: "2099-07-01T00:00:00+00:00",
+			});
+			expect(offsetInvite.expires_at).toBe("2099-07-01T00:00:00.000Z");
+
+			const dateOnlyInvite = await store.createInvite({
+				groupId: "g1",
+				policy: "auto_admit",
+				expiresAt: "2099-07-01",
+			});
+			expect(dateOnlyInvite.expires_at).toBe("2099-07-01T00:00:00.000Z");
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("rejects an unparseable invite expiry", async () => {
+		const { store, cleanup } = setupStore();
+		try {
+			await store.createGroup("g1");
+			await expect(
+				store.createInvite({ groupId: "g1", policy: "auto_admit", expiresAt: "not-a-date" }),
+			).rejects.toThrow("expiresAt must be a valid date.");
+			await expect(
+				store.createInvite({ groupId: "g1", policy: "auto_admit", expiresAt: "   " }),
+			).rejects.toThrow("expiresAt must be a valid date.");
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("excludes expired invites and includes unexpired ones by token", async () => {
+		const { store, cleanup } = setupStore();
+		try {
+			await store.createGroup("g1");
+			const liveInvite = await store.createInvite({
+				groupId: "g1",
+				policy: "auto_admit",
+				// Future, supplied with a non-canonical offset to confirm the stored
+				// canonical form compares correctly against nowISO().
+				expiresAt: "2099-01-01T00:00:00+00:00",
+			});
+			expect(await store.getInviteByToken(liveInvite.token as string)).not.toBeNull();
+
+			const expiredInvite = await store.createInvite({
+				groupId: "g1",
+				policy: "auto_admit",
+				expiresAt: "2000-01-01T00:00:00+00:00",
+			});
+			expect(await store.getInviteByToken(expiredInvite.token as string)).toBeNull();
+		} finally {
 			await cleanup();
 		}
 	});

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -28,6 +28,7 @@ import type {
 	CoordinatorUpdateScopeInput,
 	CoordinatorUpsertPresenceInput,
 } from "./coordinator-store-contract.js";
+import { normalizeInviteExpiresAt } from "./coordinator-store-contract.js";
 
 interface D1RunResultLike {
 	meta?: {
@@ -534,23 +535,30 @@ export class D1CoordinatorStore implements CoordinatorStore {
 	}
 
 	async removeDevice(_groupId: string, _deviceId: string): Promise<boolean> {
-		await this.db
-			.prepare("DELETE FROM presence_records WHERE group_id = ? AND device_id = ?")
-			.bind(_groupId, _deviceId)
-			.run();
-		await this.db
-			.prepare(
-				"DELETE FROM coordinator_reciprocal_approvals WHERE group_id = ? AND (requesting_device_id = ? OR requested_device_id = ?)",
-			)
-			.bind(_groupId, _deviceId, _deviceId)
-			.run();
-		return (
-			(await runChanges(
-				this.db
-					.prepare("DELETE FROM enrolled_devices WHERE group_id = ? AND device_id = ?")
-					.bind(_groupId, _deviceId),
-			)) > 0
-		);
+		// Presence, reciprocal approvals, and the enrollment row must be removed
+		// all-or-nothing. Running them as independent statements can orphan rows
+		// (an enrolled device with no presence/approvals, or vice versa) if any
+		// one statement fails. D1 batch() is the transaction boundary here, the
+		// same convention used for audited membership changes via runAuditedBatch.
+		if (!this.db.batch) {
+			throw new Error("D1 batch support is required for atomic device removal.");
+		}
+		const results = await this.db.batch([
+			this.db
+				.prepare("DELETE FROM presence_records WHERE group_id = ? AND device_id = ?")
+				.bind(_groupId, _deviceId),
+			this.db
+				.prepare(
+					"DELETE FROM coordinator_reciprocal_approvals WHERE group_id = ? AND (requesting_device_id = ? OR requested_device_id = ?)",
+				)
+				.bind(_groupId, _deviceId, _deviceId),
+			this.db
+				.prepare("DELETE FROM enrolled_devices WHERE group_id = ? AND device_id = ?")
+				.bind(_groupId, _deviceId),
+		]);
+		// The enrolled_devices delete is the last statement; its changes() tells us
+		// whether the device existed, preserving the boolean return contract.
+		return batchResultChanges(results[2]) > 0;
 	}
 
 	async recordNonce(_deviceId: string, _nonce: string, _createdAt: string): Promise<boolean> {
@@ -573,6 +581,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		const now = nowISO();
 		const inviteId = tokenUrlSafe(12);
 		const token = tokenUrlSafe(24);
+		const expiresAt = normalizeInviteExpiresAt(_opts.expiresAt);
 		const group = await this.getGroup(_opts.groupId);
 		await this.db
 			.prepare(`INSERT INTO coordinator_invites(
@@ -583,7 +592,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 				_opts.groupId,
 				token,
 				_opts.policy,
-				_opts.expiresAt,
+				expiresAt,
 				now,
 				_opts.createdBy ?? null,
 				group?.display_name ?? null,

--- a/packages/core/src/request-rate-limit.ts
+++ b/packages/core/src/request-rate-limit.ts
@@ -9,6 +9,17 @@ export interface CreateInMemoryRequestRateLimiterOptions {
 	now?: () => number;
 }
 
+/**
+ * Best-effort, per-isolate request rate limiter.
+ *
+ * Buckets live in a module-local Map, so on Cloudflare Workers the limits are
+ * enforced per isolate, not fleet-wide: the effective ceiling is multiplied by
+ * the number of live isolates and resets whenever an isolate is evicted. This
+ * is acceptable as a coarse abuse brake but is NOT a hard global limit. The
+ * unauthenticated /v1/join surface is the most exposed to this gap. Real
+ * fleet-wide enforcement needs a shared counter backed by a Durable Object or
+ * D1/KV.
+ */
 export function createInMemoryRequestRateLimiter(
 	options: CreateInMemoryRequestRateLimiterOptions = {},
 ): InMemoryRequestRateLimiter {


### PR DESCRIPTION
## Description

Coordinator robustness, applied to **both** store implementations (D1 for Workers, better-sqlite for local `coordinator serve`), which share `coordinator-store-contract.ts`:

- **removeDevice atomicity**: the three deletes (presence, reciprocal approvals, enrollment) ran as independent statements, so a partial failure orphaned rows. They are now atomic — via `db.batch([...])` on D1 and `db.transaction(...)` on better-sqlite; the boolean return contract is preserved.
- **invite expiry**: `createInvite` stored `expires_at` verbatim while `getInviteByToken` filters with a lexicographic `expires_at > ?` compare against `nowISO()` — only correct for identically-formatted UTC `Z` strings. A shared `normalizeInviteExpiresAt()` now canonicalizes `expires_at` to `toISOString()` before storing (and rejects unparseable input) in both stores, so the compare is sound.
- Documents two latent LOW issues without behavior change: the nonce cleanup / freshness clocks diverge only under an injected clock (prod-safe), and the in-memory request rate limiter is best-effort per-isolate on Workers.

Found by a full-repo bug audit.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (removeDevice all-or-nothing rollback on mid-batch failure; invite-expiry normalization; shared harness covers the better-sqlite store)
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
