### PR TITLE
perf(core): add cache_size/mmap_size/temp_store pragmas in connect()

### DIFF
--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -77,6 +77,16 @@ describe("connect", () => {
 		expect(sync).toBe(1);
 	});
 
+	it("applies read-tuning pragmas (cache_size, mmap_size, temp_store)", () => {
+		db = connect(join(tmpDir, "test.sqlite"));
+		expect(db.pragma("cache_size", { simple: true })).toBe(-65536);
+		// mmap_size readback is clamped to the build's SQLITE_MAX_MMAP_SIZE, so
+		// assert it's enabled (>0) rather than an exact, build-dependent value.
+		expect(db.pragma("mmap_size", { simple: true })).toBeGreaterThan(0);
+		// temp_store: 2 = MEMORY
+		expect(db.pragma("temp_store", { simple: true })).toBe(2);
+	});
+
 	it("creates parent directories if they don't exist", () => {
 		const nested = join(tmpDir, "deep", "nested", "dir", "test.sqlite");
 		db = connect(nested);

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -218,6 +218,15 @@ export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 
 		db.pragma("synchronous = NORMAL");
 
+		// Read tuning for large (multi-GB) databases. The SQLite defaults — a
+		// ~2 MiB page cache and no mmap — force repeated disk/page-cache reads of
+		// B-tree interior pages on every non-trivial query. A 64 MiB cache, 1 GiB
+		// memory-mapped I/O, and in-memory temp B-trees cut that cost. These are
+		// per-connection and must be set here (they do not persist in the file).
+		db.pragma("cache_size = -65536");
+		db.pragma("mmap_size = 1073741824");
+		db.pragma("temp_store = MEMORY");
+
 		return db;
 	} catch (error) {
 		db.close();


### PR DESCRIPTION
## Description

Sets read-tuning pragmas in `connect()` (on the WAL-configured codemem path) for multi-GB databases: `cache_size = -65536` (64 MiB), `mmap_size = 1073741824` (1 GiB), `temp_store = MEMORY`. The SQLite defaults (~2 MiB cache, no mmap) force repeated B-tree page reads on every non-trivial query. Per-connection, so set in `connect()`.

Profiled against a real 3.5GB DB: this is primarily cold-start insurance (~38% on the one genuinely I/O-bound query; ~0 on warm CPU-bound queries) that compounds once the log tables are pruned. First of the "safe wins" from the performance audit.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (asserts the pragmas are applied)
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
