### PR TITLE
perf(core): drop legacy unused memory_items indexes

### DIFF
--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -87,6 +87,26 @@ describe("connect", () => {
 		expect(db.pragma("temp_store", { simple: true })).toBe(2);
 	});
 
+	it("drops legacy memory_items indexes via additive compatibility", () => {
+		db = connect(join(tmpDir, "legacy-idx.sqlite"));
+		// Simulate a database created by an older schema that carried the
+		// now-obsolete indexes the current schema never creates.
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_memory_items_visibility ON memory_items(visibility);
+			 CREATE INDEX IF NOT EXISTS idx_memory_items_workspace_kind ON memory_items(workspace_kind);
+			 CREATE INDEX IF NOT EXISTS idx_memory_items_user_prompt_id ON memory_items(user_prompt_id);`,
+		);
+		expect(hasIndex(db, "idx_memory_items_visibility")).toBe(true);
+
+		ensureAdditiveSchemaCompatibility(db);
+
+		expect(hasIndex(db, "idx_memory_items_visibility")).toBe(false);
+		expect(hasIndex(db, "idx_memory_items_workspace_kind")).toBe(false);
+		expect(hasIndex(db, "idx_memory_items_user_prompt_id")).toBe(false);
+		// A composite index that legitimately covers visibility still exists.
+		expect(hasIndex(db, "idx_memory_items_scope_visibility_created")).toBe(true);
+	});
+
 	it("creates parent directories if they don't exist", () => {
 		const nested = join(tmpDir, "deep", "nested", "dir", "test.sqlite");
 		db = connect(nested);

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -730,6 +730,23 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 		} catch {
 			// Keep additive compatibility best-effort for index creation.
 		}
+
+		// Drop legacy memory_items indexes that no longer back any query, only
+		// adding write amplification on databases created by older schemas. The
+		// current schema never creates these. `visibility`/`workspace_kind` are
+		// low-cardinality and only ever appear as secondary predicates already
+		// covered by composite indexes (e.g. idx_memory_items_scope_visibility_created,
+		// idx_memory_items_same_session_dedup_unique); `user_prompt_id` is unused
+		// as a filter (and is all-NULL in practice).
+		try {
+			db.exec(
+				`DROP INDEX IF EXISTS idx_memory_items_visibility;
+				 DROP INDEX IF EXISTS idx_memory_items_workspace_kind;
+				 DROP INDEX IF EXISTS idx_memory_items_user_prompt_id;`,
+			);
+		} catch {
+			// Best-effort cleanup of legacy indexes.
+		}
 	}
 
 	if (tableExists(db, "replication_ops")) {


### PR DESCRIPTION
## Description

Drops three `memory_items` indexes that the current schema no longer creates and that back no query — they only add write amplification on databases created by older schemas:

- `idx_memory_items_visibility`, `idx_memory_items_workspace_kind`: low-cardinality columns only ever filtered as secondary predicates already covered by composite indexes (`idx_memory_items_scope_visibility_created`, `idx_memory_items_same_session_dedup_unique`). Confirmed via `EXPLAIN QUERY PLAN` on the real DB: the planner picks the composites / `idx_memory_items_session`, never the standalone visibility index.
- `idx_memory_items_user_prompt_id`: unused as a filter (all-NULL in practice).

Dropped in the additive-compatibility migration (`DROP INDEX IF EXISTS`), so existing databases shed them on next open; fresh schemas never create them. Second of the audit "safe wins"; stacked on #1268.

## Upgrade safety

- Indexes never affect query **correctness**, only plans — so no reader (including a version-skewed concurrent process) can break or return wrong results when one is dropped.
- No data mutation, no `SCHEMA_VERSION` bump, no `VACUUM`/`REINDEX`/table rebuild. `DROP INDEX IF EXISTS` is idempotent and WAL-concurrent-safe.
- Consistent with existing precedent (`schema-bootstrap.ts` already issues `DROP TRIGGER IF EXISTS`). The DB coexistence contract's additive-only rule covered the now-retired Python↔TS coexistence (Phase 4 complete).

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (recreates the legacy indexes, asserts the migration drops them while a kept composite survives)
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
