### PR TITLE
perf(core): resolve scope-visibility set once and filter with indexed IN()

### DIFF
--- a/packages/core/src/filters.ts
+++ b/packages/core/src/filters.ts
@@ -6,7 +6,11 @@
  */
 
 import { projectClause } from "./project.js";
-import { LOCAL_DEFAULT_SCOPE_ID } from "./scope-resolution.js";
+import {
+	LEGACY_SHARED_REVIEW_SCOPE_ID,
+	LOCAL_DEFAULT_SCOPE_ID,
+	MAX_SCOPE_IN_PARAMS,
+} from "./scope-resolution.js";
 import type { MemoryFilters } from "./types.js";
 
 export interface OwnershipFilterContext {
@@ -21,6 +25,15 @@ export interface OwnershipFilterContext {
 	 * invariant.
 	 */
 	enforceScopeVisibility?: boolean;
+	/**
+	 * Pre-resolved set of scope_ids this device may read (see
+	 * `resolveVisibleScopeIds` in scope-resolution.ts). When present, scope visibility is
+	 * enforced with an index-eligible `scope_id IN (...)` predicate instead of
+	 * the per-row EXISTS subqueries. Callers that cannot resolve the set up front
+	 * (e.g. a context built without db access) omit it and fall back to the
+	 * EXISTS predicate, which is semantically identical.
+	 */
+	visibleScopeIds?: readonly string[];
 }
 
 export interface FilterResult {
@@ -93,8 +106,6 @@ function addMultiValueFilter(
 		params.push(...excludeValues);
 	}
 }
-
-const LEGACY_SHARED_REVIEW_SCOPE_ID = "legacy-shared-review";
 
 function cleanUniqueStrings(value: string[] | undefined): string[] {
 	return [...new Set((value ?? []).map((item) => item.trim()).filter(Boolean))];
@@ -170,6 +181,30 @@ function addScopeVisibilityFilter(
 	// Migration backfill promotes legacy rows to explicit scopes asynchronously,
 	// but until that completes those rows must remain visible to their owning
 	// device exactly the way local-default rows are.
+	const visibleScopeIds = context.visibleScopeIds;
+	if (visibleScopeIds !== undefined && visibleScopeIds.length <= MAX_SCOPE_IN_PARAMS) {
+		// Fast path: the visible scope-id set was resolved once per request (see
+		// resolveVisibleScopeIds in scope-resolution.ts). A plain `scope_id IN (...)`
+		// is index-eligible on idx_memory_items_scope_visibility_created, unlike the
+		// EXISTS-based fallback below.
+		//
+		// Guarded by MAX_SCOPE_IN_PARAMS: each id is one bound parameter, so an
+		// unrealistically large visible set would otherwise blow SQLite's variable
+		// limit and throw at prepare time. Beyond the cap we fail safe to the
+		// fixed-param EXISTS fallback, which is semantically identical.
+		//
+		// We deliberately do NOT TRIM memory_items.scope_id here. TRIM defeats the
+		// index, and it is unnecessary: stored scope_ids are always trimmed on
+		// write (op scope_id is .trim()ed), so no whitespace-padded values exist.
+		// NULL scope_id (legacy rows pending backfill) is handled by the explicit
+		// IS NULL branch; the empty string "" is included in the resolved set.
+		const placeholders = visibleScopeIds.map(() => "?").join(", ");
+		clauses.push(`(memory_items.scope_id IS NULL OR memory_items.scope_id IN (${placeholders}))`);
+		params.push(...visibleScopeIds);
+		return;
+	}
+	// Fallback path: no pre-resolved set (e.g. a context built without db access).
+	// Semantically identical to the IN predicate above, but evaluated per row.
 	clauses.push(`(
 		COALESCE(TRIM(memory_items.scope_id), '') IN (?, ?, ?)
 		OR EXISTS (

--- a/packages/core/src/scope-backfill.ts
+++ b/packages/core/src/scope-backfill.ts
@@ -15,9 +15,11 @@ import {
 	startMaintenanceJob,
 	updateMaintenanceJob,
 } from "./maintenance-jobs.js";
-import { LOCAL_DEFAULT_SCOPE_ID } from "./scope-resolution.js";
+import { LEGACY_SHARED_REVIEW_SCOPE_ID, LOCAL_DEFAULT_SCOPE_ID } from "./scope-resolution.js";
 
-export const LEGACY_SHARED_REVIEW_SCOPE_ID = "legacy-shared-review";
+// Re-exported from its single source of truth (scope-resolution.ts) so existing
+// importers of this symbol from scope-backfill keep working.
+export { LEGACY_SHARED_REVIEW_SCOPE_ID };
 export const SCOPE_BACKFILL_JOB = "scope_id_backfill";
 
 export type ScopeBackfillReason =

--- a/packages/core/src/scope-resolution.ts
+++ b/packages/core/src/scope-resolution.ts
@@ -1,7 +1,25 @@
 import { createHash } from "node:crypto";
 import { resolve } from "node:path";
+import type { Database } from "better-sqlite3";
 
 export const LOCAL_DEFAULT_SCOPE_ID = "local-default";
+
+/**
+ * Scope id used by the conservative migration backfill for legacy shared
+ * memories that cannot yet be assigned to a concrete team/org scope. Single
+ * source of truth: filters.ts and scope-backfill.ts re-import this so the
+ * read-visibility predicate and the backfill agree on one literal.
+ */
+export const LEGACY_SHARED_REVIEW_SCOPE_ID = "legacy-shared-review";
+
+/**
+ * Upper bound on how many scope ids we will inline into the index-eligible
+ * `scope_id IN (...)` fast path (one bound parameter each). Kept well under
+ * SQLite's compiled `SQLITE_MAX_VARIABLE_NUMBER` so a device with an
+ * unrealistically large visible set falls back to the fixed-param EXISTS
+ * predicate instead of throwing "too many SQL variables" at prepare time.
+ */
+export const MAX_SCOPE_IN_PARAMS = 500;
 
 export type WorkspaceIdentitySource =
 	| "git_remote"
@@ -247,4 +265,50 @@ export function resolveProjectScope(input: ResolveProjectScopeInput): ScopeResol
 		mapping: null,
 		matchedPattern: null,
 	};
+}
+
+/**
+ * Resolve, once per request, the full set of scope_ids that `deviceId` may read.
+ *
+ * This is the index-eligible equivalent of the per-row EXISTS predicate in
+ * `addScopeVisibilityFilter`'s fallback branch (filters.ts): instead of
+ * evaluating the replication_scopes / scope_memberships subqueries for every
+ * candidate row, we compute the visible set up front and let the SQL filter use
+ * a plain `scope_id IN (...)`. The membership predicate (active membership with
+ * `membership_epoch >= scope.membership_epoch`) is preserved exactly.
+ *
+ * Lives in this leaf module (it imports nothing from filters/search/store/
+ * vectors) so all three OwnershipFilterContext builders can share it without an
+ * import cycle.
+ *
+ * NULL scope_ids are skipped here — a NULL scope_id is handled by the filter's
+ * dedicated `IS NULL` branch, not by membership in this set.
+ */
+export function resolveVisibleScopeIds(db: Database, deviceId: string): string[] {
+	const visible = new Set<string>(["", LOCAL_DEFAULT_SCOPE_ID, LEGACY_SHARED_REVIEW_SCOPE_ID]);
+	const localScopes = db
+		.prepare(
+			`SELECT scope_id
+			 FROM replication_scopes
+			 WHERE status = 'active' AND authority_type = 'local'`,
+		)
+		.all() as Array<{ scope_id: string | null }>;
+	for (const row of localScopes) {
+		if (row.scope_id != null) visible.add(row.scope_id);
+	}
+	const memberScopes = db
+		.prepare(
+			`SELECT sm.scope_id AS scope_id
+			 FROM scope_memberships sm
+			 JOIN replication_scopes rs ON rs.scope_id = sm.scope_id
+			 WHERE sm.device_id = ?
+			   AND sm.status = 'active'
+			   AND rs.status = 'active'
+			   AND sm.membership_epoch >= rs.membership_epoch`,
+		)
+		.all(deviceId) as Array<{ scope_id: string | null }>;
+	for (const row of memberScopes) {
+		if (row.scope_id != null) visible.add(row.scope_id);
+	}
+	return [...visible];
 }

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -3,8 +3,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connect } from "./db.js";
+import { buildFilterClausesWithContext } from "./filters.js";
 import { sanitizeSearchQuery } from "./query-sanitizer.js";
-import { expandQuery, kindBonus, recencyScore, rerankResults } from "./search.js";
+import { resolveVisibleScopeIds } from "./scope-resolution.js";
+import {
+	expandQuery,
+	kindBonus,
+	ownershipFilterContext,
+	recencyScore,
+	rerankResults,
+} from "./search.js";
 import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import type { MemoryResult } from "./types.js";
@@ -995,6 +1003,236 @@ describe("MemoryStore.search", () => {
 		expect(result).toHaveProperty("metadata");
 		expect(typeof result.score).toBe("number");
 		expect(typeof result.metadata).toBe("object");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Scope-visibility filter: resolved IN-set equivalence
+// ---------------------------------------------------------------------------
+
+describe("scope visibility filter (resolved visible set)", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-scope-vis-test-"));
+		dbPath = join(tmpDir, "test.sqlite");
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function insertLocalAuthorityScope(scopeId: string): void {
+		const now = new Date().toISOString();
+		store.db
+			.prepare(
+				`INSERT OR REPLACE INTO replication_scopes(
+					scope_id, label, kind, authority_type, coordinator_id, group_id,
+					membership_epoch, status, created_at, updated_at
+				 ) VALUES (?, ?, 'user', 'local', NULL, NULL, 0, 'active', ?, ?)`,
+			)
+			.run(scopeId, scopeId, now, now);
+	}
+
+	function insertCoordinatorScopeWithEpoch(
+		scopeId: string,
+		membershipEpoch: number,
+		status: "active" | "inactive",
+	): void {
+		const now = new Date().toISOString();
+		store.db
+			.prepare(
+				`INSERT OR REPLACE INTO replication_scopes(
+					scope_id, label, kind, authority_type, coordinator_id, group_id,
+					membership_epoch, status, created_at, updated_at
+				 ) VALUES (?, ?, 'team', 'coordinator', 'coord-test', 'group-test', ?, ?, ?, ?)`,
+			)
+			.run(scopeId, scopeId, membershipEpoch, status, now, now);
+	}
+
+	function grantMembership(scopeId: string, membershipEpoch: number): void {
+		store.db
+			.prepare(
+				`INSERT OR REPLACE INTO scope_memberships(
+					scope_id, device_id, role, status, membership_epoch,
+					coordinator_id, group_id, updated_at
+				 ) VALUES (?, ?, 'member', 'active', ?, 'coord-test', 'group-test', ?)`,
+			)
+			.run(scopeId, store.deviceId, membershipEpoch, new Date().toISOString());
+	}
+
+	it("resolves and filters to exactly the readable scope set", () => {
+		// Visible scopes
+		insertLocalAuthorityScope("local-authority-team");
+		insertCoordinatorScopeWithEpoch("member-team", 3, "active");
+		grantMembership("member-team", 3); // epoch 3 >= scope epoch 3 -> visible
+
+		// Not-visible scopes
+		insertCoordinatorScopeWithEpoch("nonmember-team", 0, "active"); // no membership
+		insertCoordinatorScopeWithEpoch("stale-team", 5, "active");
+		grantMembership("stale-team", 4); // membership epoch 4 < scope epoch 5 -> not visible
+		insertCoordinatorScopeWithEpoch("inactive-team", 0, "inactive"); // scope inactive
+		grantMembership("inactive-team", 0); // membership active but scope inactive -> not visible
+
+		// Resolver output: literals + local-authority + valid-membership only.
+		const resolved = resolveVisibleScopeIds(store.db, store.deviceId);
+		expect([...resolved].sort()).toEqual(
+			["", "local-default", "legacy-shared-review", "local-authority-team", "member-team"].sort(),
+		);
+		expect(resolved).not.toContain("nonmember-team");
+		expect(resolved).not.toContain("stale-team");
+		expect(resolved).not.toContain("inactive-team");
+
+		// Seed one memory row per scope plus NULL-scope and empty-scope rows.
+		const sessionId = insertTestSession(store.db);
+		const insertRow = (scopeId: string | null): number => {
+			const ts = new Date().toISOString();
+			const info = store.db
+				.prepare(
+					`INSERT INTO memory_items(
+						session_id, kind, title, body_text, confidence, tags_text, active,
+						created_at, updated_at, metadata_json, rev, visibility, scope_id
+					 ) VALUES (?, 'discovery', 'scoped row', 'body', 0.5, '', 1, ?, ?, '{}', 1, 'shared', ?)`,
+				)
+				.run(sessionId, ts, ts, scopeId);
+			return Number(info.lastInsertRowid);
+		};
+
+		const nullId = insertRow(null);
+		const emptyId = insertRow("");
+		const localDefaultId = insertRow("local-default");
+		const legacyReviewId = insertRow("legacy-shared-review");
+		const localAuthorityId = insertRow("local-authority-team");
+		const memberId = insertRow("member-team");
+		const nonmemberId = insertRow("nonmember-team");
+		const staleId = insertRow("stale-team");
+		const inactiveId = insertRow("inactive-team");
+
+		// Render the scope-visibility predicate via the resolved-set context
+		// (search.ts ownershipFilterContext sets visibleScopeIds -> fast path).
+		const filterResult = buildFilterClausesWithContext(null, ownershipFilterContext(store));
+		const whereSql = ["memory_items.active = 1", ...filterResult.clauses].join(" AND ");
+		const rows = store.db
+			.prepare(`SELECT id FROM memory_items WHERE ${whereSql}`)
+			.all(...filterResult.params) as Array<{ id: number }>;
+		const visibleIds = new Set(rows.map((row) => row.id));
+
+		// Visible: NULL, "", local-default, legacy-shared-review, local-authority, valid member.
+		expect(visibleIds.has(nullId)).toBe(true);
+		expect(visibleIds.has(emptyId)).toBe(true);
+		expect(visibleIds.has(localDefaultId)).toBe(true);
+		expect(visibleIds.has(legacyReviewId)).toBe(true);
+		expect(visibleIds.has(localAuthorityId)).toBe(true);
+		expect(visibleIds.has(memberId)).toBe(true);
+
+		// Not visible: non-member, stale-epoch member, inactive scope.
+		expect(visibleIds.has(nonmemberId)).toBe(false);
+		expect(visibleIds.has(staleId)).toBe(false);
+		expect(visibleIds.has(inactiveId)).toBe(false);
+	});
+
+	it("matches the EXISTS fallback predicate for the same data", () => {
+		insertLocalAuthorityScope("local-authority-team");
+		insertCoordinatorScopeWithEpoch("member-team", 3, "active");
+		grantMembership("member-team", 3);
+		insertCoordinatorScopeWithEpoch("nonmember-team", 0, "active");
+		insertCoordinatorScopeWithEpoch("stale-team", 5, "active");
+		grantMembership("stale-team", 4);
+		insertCoordinatorScopeWithEpoch("inactive-team", 0, "inactive");
+		grantMembership("inactive-team", 0);
+
+		const sessionId = insertTestSession(store.db);
+		const insertRow = (scopeId: string | null): number => {
+			const ts = new Date().toISOString();
+			const info = store.db
+				.prepare(
+					`INSERT INTO memory_items(
+						session_id, kind, title, body_text, confidence, tags_text, active,
+						created_at, updated_at, metadata_json, rev, visibility, scope_id
+					 ) VALUES (?, 'discovery', 'scoped row', 'body', 0.5, '', 1, ?, ?, '{}', 1, 'shared', ?)`,
+				)
+				.run(sessionId, ts, ts, scopeId);
+			return Number(info.lastInsertRowid);
+		};
+		for (const scopeId of [
+			null,
+			"",
+			"local-default",
+			"legacy-shared-review",
+			"local-authority-team",
+			"member-team",
+			"nonmember-team",
+			"stale-team",
+			"inactive-team",
+		]) {
+			insertRow(scopeId);
+		}
+
+		const runIds = (context: ReturnType<typeof ownershipFilterContext>): Set<number> => {
+			const filterResult = buildFilterClausesWithContext(null, context);
+			const whereSql = ["memory_items.active = 1", ...filterResult.clauses].join(" AND ");
+			const rows = store.db
+				.prepare(`SELECT id FROM memory_items WHERE ${whereSql}`)
+				.all(...filterResult.params) as Array<{ id: number }>;
+			return new Set(rows.map((row) => row.id));
+		};
+
+		// Fast path (resolved IN-set) vs fallback (EXISTS) must select identical rows.
+		const fastContext = ownershipFilterContext(store);
+		const { visibleScopeIds: _omit, ...fallbackContext } = fastContext;
+		expect([...runIds(fastContext)].sort()).toEqual([...runIds(fallbackContext)].sort());
+	});
+
+	it("renders an index-eligible plan with no correlated scope subquery", () => {
+		insertLocalAuthorityScope("local-authority-team");
+		insertCoordinatorScopeWithEpoch("member-team", 3, "active");
+		grantMembership("member-team", 3);
+
+		// Enough rows that a full scan would be a real regression, not a tie.
+		const sessionId = insertTestSession(store.db);
+		const ts = new Date().toISOString();
+		for (let i = 0; i < 50; i++) {
+			store.db
+				.prepare(
+					`INSERT INTO memory_items(
+						session_id, kind, title, body_text, confidence, tags_text, active,
+						created_at, updated_at, metadata_json, rev, visibility, scope_id
+					 ) VALUES (?, 'discovery', 't', 'b', 0.5, '', 1, ?, ?, '{}', 1, 'shared', ?)`,
+				)
+				.run(sessionId, ts, ts, i % 3 === 0 ? null : "member-team");
+		}
+
+		const explainPlan = (context: ReturnType<typeof ownershipFilterContext>): string => {
+			const filterResult = buildFilterClausesWithContext(null, context);
+			const whereSql = ["memory_items.active = 1", ...filterResult.clauses].join(" AND ");
+			const rows = store.db
+				.prepare(`EXPLAIN QUERY PLAN SELECT id FROM memory_items WHERE ${whereSql}`)
+				.all(...filterResult.params) as Array<{ detail: string }>;
+			return rows.map((row) => row.detail).join("\n");
+		};
+
+		// Fast path: the resolved IN-set must produce an index-backed scan with no
+		// correlated subquery and no TRIM (TRIM would defeat the index). This pins
+		// the actual perf goal: a future regression that reintroduces TRIM or the
+		// per-row EXISTS predicate would resurface CORRELATED here and fail.
+		const fastPlan = explainPlan(ownershipFilterContext(store));
+		expect(fastPlan).toMatch(/USING INDEX/);
+		expect(fastPlan).not.toMatch(/CORRELATED/);
+		expect(fastPlan).not.toMatch(/TRIM/);
+
+		// Contrast guard: the EXISTS fallback is exactly the plan shape we are
+		// hoisting away from — it must still contain the correlated subqueries, so
+		// this assertion proves the fast-path check above is meaningful.
+		const { visibleScopeIds: _omit, ...fallbackContext } = ownershipFilterContext(store);
+		const fallbackPlan = explainPlan(fallbackContext);
+		expect(fallbackPlan).toMatch(/CORRELATED/);
 	});
 });
 

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -24,6 +24,7 @@ import { sanitizeSearchQuery } from "./query-sanitizer.js";
 import { memoryLooksRecapLike, queryPrefersRecap, recapPenaltyMultiplier } from "./recap-policy.js";
 import { findByConcept, findByFile } from "./ref-queries.js";
 import * as schema from "./schema.js";
+import { resolveVisibleScopeIds } from "./scope-resolution.js";
 import { canonicalMemoryKind } from "./summary-memory.js";
 import type {
 	ExplainError,
@@ -88,6 +89,7 @@ export function ownershipFilterContext(store: StoreHandle): OwnershipFilterConte
 		claimedDeviceIds,
 		legacyActorIds: claimedDeviceIds.map((peerId) => `legacy-sync:${peerId}`),
 		enforceScopeVisibility: true,
+		visibleScopeIds: resolveVisibleScopeIds(store.db, store.deviceId),
 	};
 }
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -41,6 +41,7 @@ import { populateMemoryRefs } from "./ref-populate.js";
 import type { RefQueryOptions, RefQueryResult } from "./ref-queries.js";
 import { findByConcept as findByConceptFn, findByFile as findByFileFn } from "./ref-queries.js";
 import * as schema from "./schema.js";
+import { resolveVisibleScopeIds } from "./scope-resolution.js";
 import { ensureMemoryScopeId, resolveSessionScopeId } from "./scope-stamping.js";
 import {
 	type ExplainOptions,
@@ -429,6 +430,11 @@ export class MemoryStore {
 			claimedDeviceIds,
 			legacyActorIds: claimedDeviceIds.map((peerId) => `legacy-sync:${peerId}`),
 			enforceScopeVisibility: true,
+			// Resolve the visible scope set once per request so the SQL filter can
+			// use the index-eligible `scope_id IN (...)` fast path instead of the
+			// per-row EXISTS predicate. Fronts get()/recent()/recentByKinds() and
+			// every viewer-server route.
+			visibleScopeIds: resolveVisibleScopeIds(this.db, this.deviceId),
 		};
 	}
 

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -43,6 +43,12 @@ function scopeVisibleFilterContext(context: SemanticSearchScopeContext): Ownersh
 		claimedDeviceIds: context?.claimedDeviceIds ?? [],
 		legacyActorIds: context?.legacyActorIds ?? [],
 		enforceScopeVisibility: true,
+		// Forward the pre-resolved visible scope set so the KNN candidate filter
+		// gets the index-eligible `scope_id IN (...)` fast path. Callers reach
+		// semanticSearch via ownershipFilterContext(store) (search.ts / store.ts),
+		// which already resolves this set; when absent the filter falls back to the
+		// equivalent EXISTS predicate. This function has no db handle of its own.
+		visibleScopeIds: context?.visibleScopeIds,
 	};
 }
 


### PR DESCRIPTION
## Description

Part of the performance stack. The scope-visibility read filter ran a per-row predicate — `COALESCE(TRIM(scope_id),'')` (which defeats `idx_memory_items_scope_visibility_created`) plus two correlated `EXISTS` subqueries (one full-scanning `replication_scopes`) — for every candidate row on every scope-enforced read.

This resolves the device's visible `scope_id` set once per request (`resolveVisibleScopeIds`) and filters with an index-eligible `(scope_id IS NULL OR scope_id IN (...))`, replacing the per-row correlated subquery (confirmed via `EXPLAIN QUERY PLAN`) across search, recent/get, timeline, pack, the vector KNN candidate filter, and every viewer-server route.

- `resolveVisibleScopeIds` lives in `scope-resolution.ts`; wired into all three `OwnershipFilterContext` builders (search, `MemoryStore`, vectors).
- Drops the `TRIM` (stored `scope_id`s are always trimmed on write — verified across all write paths including untrusted inbound sync apply); the `EXISTS` predicate is kept byte-identical as a fallback for contexts built without db access (export/import) and as a fail-safe when the visible set would exceed the SQLite bound-parameter cap.
- **Authorization-equivalent**: a test asserts the `IN` fast path selects the exact same rows as the `EXISTS` fallback on shared data (including `NULL`- and blank-`scope_id` rows), and an `EXPLAIN QUERY PLAN` test pins the index-eligible plan with no correlated subquery.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
