### PR TITLE
perf(viewer): aggregate /api/usage in SQL, bound recent-packs visibility window

### DIFF
--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -1487,6 +1487,100 @@ describe("MemoryStore", () => {
 		});
 	});
 
+	// -- usageAggregate ------------------------------------------------------
+
+	describe("usageAggregate", () => {
+		function insertUsageEvent(
+			sessionId: number | null,
+			event: string,
+			tokensRead: number,
+			tokensWritten: number,
+			tokensSaved: number | null,
+			createdAt = "2026-03-26T23:30:00Z",
+		): void {
+			store.db
+				.prepare(
+					`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+					 VALUES (?, ?, ?, ?, ?, ?, '{}')`,
+				)
+				.run(sessionId, event, tokensRead, tokensWritten, tokensSaved, createdAt);
+		}
+
+		it("groups by event and sums tokens with tokens_saved NULL coalesced to 0", () => {
+			const sessionId = insertTestSession(store.db);
+			insertUsageEvent(sessionId, "pack", 100, 10, 5);
+			insertUsageEvent(sessionId, "pack", 200, 20, null);
+			insertUsageEvent(sessionId, "search", 30, 3, 7);
+
+			const rows = store.usageAggregate();
+			const byEvent = new Map(rows.map((row) => [row.event, row]));
+			expect(byEvent.get("pack")).toEqual({
+				event: "pack",
+				count: 2,
+				tokens_read: 300,
+				tokens_written: 30,
+				// NULL tokens_saved on the second pack contributes 0.
+				tokens_saved: 5,
+			});
+			expect(byEvent.get("search")).toEqual({
+				event: "search",
+				count: 1,
+				tokens_read: 30,
+				tokens_written: 3,
+				tokens_saved: 7,
+			});
+		});
+
+		it("restricts the aggregate to a project when a non-empty filter is given", () => {
+			const codememSession = insertTestSession(store.db);
+			store.db
+				.prepare("UPDATE sessions SET project = ? WHERE id = ?")
+				.run("codemem", codememSession);
+			const otherSession = insertTestSession(store.db);
+			store.db.prepare("UPDATE sessions SET project = ? WHERE id = ?").run("other", otherSession);
+			insertUsageEvent(codememSession, "pack", 100, 10, 5);
+			insertUsageEvent(otherSession, "pack", 1000, 100, 50);
+
+			const filtered = store.usageAggregate("codemem");
+			expect(filtered).toEqual([
+				{ event: "pack", count: 1, tokens_read: 100, tokens_written: 10, tokens_saved: 5 },
+			]);
+
+			// Empty-string filter behaves like the unfiltered (global) variant.
+			const globalViaEmpty = store.usageAggregate("");
+			const global = store.usageAggregate();
+			expect(globalViaEmpty).toEqual(global);
+			expect(global).toEqual([
+				{ event: "pack", count: 2, tokens_read: 1100, tokens_written: 110, tokens_saved: 55 },
+			]);
+		});
+
+		it("returns an empty array when there are no usage events", () => {
+			expect(store.usageAggregate()).toEqual([]);
+			expect(store.usageAggregate("codemem")).toEqual([]);
+		});
+
+		it("backs store.stats().usage with the same unfiltered values", () => {
+			const sessionId = insertTestSession(store.db);
+			insertUsageEvent(sessionId, "pack", 100, 10, 5);
+			insertUsageEvent(sessionId, "pack", 200, 20, null);
+			insertUsageEvent(sessionId, "search", 30, 3, 7);
+
+			const usage = store.stats().usage;
+			// stats() sorts events by count DESC.
+			expect(usage.events).toEqual([
+				{ event: "pack", count: 2, tokens_read: 300, tokens_written: 30, tokens_saved: 5 },
+				{ event: "search", count: 1, tokens_read: 30, tokens_written: 3, tokens_saved: 7 },
+			]);
+			expect(usage.totals).toEqual({
+				events: 3,
+				tokens_read: 330,
+				tokens_written: 33,
+				tokens_saved: 12,
+			});
+		});
+	});
+
 	// -- updateMemoryVisibility ----------------------------------------------
 
 	describe("updateMemoryVisibility", () => {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1031,6 +1031,63 @@ export class MemoryStore {
 		return rows.map((row) => parseMetadata(row));
 	}
 
+	// usageAggregate
+
+	/**
+	 * Neutral, unfiltered token/event aggregate over usage_events, grouped by
+	 * event kind. This is the shared SQL aggregate used by both stats() and the
+	 * viewer /api/usage route so neither has to scan the (potentially large)
+	 * usage_events table into JS to sum it. The COALESCE on tokens_saved matches
+	 * the historical stats() semantics (treat NULL saved as 0). When
+	 * projectFilter is a non-empty string, rows are restricted to the given
+	 * project via the sessions join; otherwise every row is aggregated.
+	 * Callers sort the returned rows as needed.
+	 */
+	usageAggregate(projectFilter?: string | null): Array<{
+		event: string;
+		count: number;
+		tokens_read: number;
+		tokens_written: number;
+		tokens_saved: number;
+	}> {
+		// Two near-identical GROUP BYs kept deliberately separate: the global
+		// variant avoids a needless sessions join, and the projections (incl.
+		// the tokens_saved double-COALESCE) must stay byte-identical in both.
+		const hasProject = typeof projectFilter === "string" && projectFilter.length > 0;
+		const rows = hasProject
+			? (this.db
+					.prepare(
+						`SELECT usage_events.event AS event,
+							COUNT(*) AS count,
+							COALESCE(SUM(usage_events.tokens_read), 0) AS tokens_read,
+							COALESCE(SUM(usage_events.tokens_written), 0) AS tokens_written,
+							COALESCE(SUM(COALESCE(usage_events.tokens_saved, 0)), 0) AS tokens_saved
+						 FROM usage_events
+						 JOIN sessions ON sessions.id = usage_events.session_id
+						 WHERE sessions.project = ?
+						 GROUP BY usage_events.event`,
+					)
+					.all(projectFilter) as Record<string, unknown>[])
+			: (this.db
+					.prepare(
+						`SELECT event AS event,
+							COUNT(*) AS count,
+							COALESCE(SUM(tokens_read), 0) AS tokens_read,
+							COALESCE(SUM(tokens_written), 0) AS tokens_written,
+							COALESCE(SUM(COALESCE(tokens_saved, 0)), 0) AS tokens_saved
+						 FROM usage_events
+						 GROUP BY event`,
+					)
+					.all() as Record<string, unknown>[]);
+		return rows.map((row) => ({
+			event: String(row.event),
+			count: Number(row.count ?? 0),
+			tokens_read: Number(row.tokens_read ?? 0),
+			tokens_written: Number(row.tokens_written ?? 0),
+			tokens_saved: Number(row.tokens_saved ?? 0),
+		}));
+	}
+
 	// stats
 
 	/**
@@ -1098,27 +1155,12 @@ export class MemoryStore {
 			// File may not exist yet or be inaccessible
 		}
 
-		// Usage stats
-		const usageRows = this.d
-			.select({
-				event: schema.usageEvents.event,
-				count: sql<number>`COUNT(*)`,
-				tokens_read: sql<number | null>`SUM(tokens_read)`,
-				tokens_written: sql<number | null>`SUM(tokens_written)`,
-				tokens_saved: sql<number | null>`SUM(COALESCE(tokens_saved, 0))`,
-			})
-			.from(schema.usageEvents)
-			.groupBy(schema.usageEvents.event)
-			.orderBy(desc(sql`COUNT(*)`))
-			.all();
-
-		const usageEvents = usageRows.map((r) => ({
-			event: r.event,
-			count: r.count,
-			tokens_read: r.tokens_read ?? 0,
-			tokens_written: r.tokens_written ?? 0,
-			tokens_saved: r.tokens_saved ?? 0,
-		}));
+		// Usage stats. Sort by count DESC to preserve the historical
+		// ORDER BY COUNT(*) DESC ordering of this block, with event name as a
+		// stable tiebreaker so equal-count rows have a deterministic order.
+		const usageEvents = this.usageAggregate().sort(
+			(a, b) => b.count - a.count || a.event.localeCompare(b.event),
+		);
 
 		const totalEvents = usageEvents.reduce((s, e) => s + e.count, 0);
 		const totalTokensRead = usageEvents.reduce((s, e) => s + e.tokens_read, 0);

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -551,8 +551,12 @@ describe("viewer-server", () => {
 					recent_packs: Array<{ metadata_json: unknown }>;
 					totals: { count: number; tokens_read: number; tokens_saved: number };
 				};
+				// recent_packs stays scope-filtered: only the visible-session pack
+				// survives, with hidden ids stripped from its metadata.
 				expect(body.recent_packs).toHaveLength(1);
-				expect(body.totals).toMatchObject({ count: 1, tokens_read: 123, tokens_saved: 456 });
+				// Aggregate totals are unfiltered SQL sums over every usage row
+				// (both packs), matching store.stats() semantics.
+				expect(body.totals).toMatchObject({ count: 2, tokens_read: 1122, tokens_saved: 1455 });
 				expect(body.recent_packs[0]?.metadata_json).toMatchObject({
 					pack_item_ids: [visibleId],
 					added_ids: [visibleId],
@@ -603,8 +607,11 @@ describe("viewer-server", () => {
 					recent_packs: unknown[];
 					totals: { count: number; tokens_read: number; tokens_saved: number };
 				};
+				// The hidden-session pack is still excluded from recent_packs
+				// (session not visible), but the unfiltered aggregate totals count
+				// it just like store.stats() would.
 				expect(body.recent_packs).toHaveLength(0);
-				expect(body.totals).toMatchObject({ count: 0, tokens_read: 0, tokens_saved: 0 });
+				expect(body.totals).toMatchObject({ count: 1, tokens_read: 999, tokens_saved: 999 });
 			} finally {
 				cleanup();
 			}
@@ -710,21 +717,23 @@ describe("viewer-server", () => {
 					.run(sessionId, "2026-03-26T23:30:00Z");
 
 				const beforeRevoke = (await (await app.request("/api/usage")).json()) as {
-					totals: { count: number };
+					recent_packs: unknown[];
 				};
-				expect(beforeRevoke.totals.count).toBe(1);
+				expect(beforeRevoke.recent_packs).toHaveLength(1);
 
 				// Revoke the device's membership. Even within the TTL window the
 				// next request must recompute and hide the now-invisible scope
-				// instead of serving the cached (visible) payload.
+				// instead of serving the cached (visible) payload. recent_packs is
+				// the scope-sensitive surface here (aggregate totals are now
+				// unfiltered, so they would not reflect a visibility change).
 				store.db
 					.prepare("DELETE FROM scope_memberships WHERE scope_id = ? AND device_id = ?")
 					.run("authorized-team", store.deviceId);
 
 				const afterRevoke = (await (await app.request("/api/usage")).json()) as {
-					totals: { count: number };
+					recent_packs: unknown[];
 				};
-				expect(afterRevoke.totals.count).toBe(0);
+				expect(afterRevoke.recent_packs).toHaveLength(0);
 			} finally {
 				cleanup();
 			}
@@ -765,6 +774,229 @@ describe("viewer-server", () => {
 				expect(cache.size).toBeLessThanOrEqual(maxEntries);
 			} finally {
 				cache.clear();
+				cleanup();
+			}
+		});
+
+		it("aggregates token/event totals in SQL with hand-summed global and project values", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const codememSession = insertTestSession(store.db);
+				store.db
+					.prepare("UPDATE sessions SET project = ? WHERE id = ?")
+					.run("codemem", codememSession);
+				const otherSession = insertTestSession(store.db);
+				store.db.prepare("UPDATE sessions SET project = ? WHERE id = ?").run("other", otherSession);
+
+				const insertUsage = (
+					sessionId: number,
+					event: string,
+					read: number,
+					written: number,
+					saved: number | null,
+					createdAt: string,
+				) =>
+					store.db
+						.prepare(
+							`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+							 VALUES (?, ?, ?, ?, ?, ?, '{}')`,
+						)
+						.run(sessionId, event, read, written, saved, createdAt);
+
+				// codemem project: two packs + one search.
+				insertUsage(codememSession, "pack", 100, 10, 5, "2026-03-26T23:30:00Z");
+				insertUsage(codememSession, "pack", 200, 20, null, "2026-03-26T23:31:00Z");
+				insertUsage(codememSession, "search", 30, 3, 7, "2026-03-26T23:32:00Z");
+				// other project: one pack.
+				insertUsage(otherSession, "pack", 1000, 100, 50, "2026-03-26T23:33:00Z");
+
+				const res = await app.request("/api/usage?project=codemem");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					events_global: Array<{
+						event: string;
+						total_tokens_read: number;
+						total_tokens_written: number;
+						total_tokens_saved: number;
+						count: number;
+					}>;
+					totals_global: {
+						tokens_read: number;
+						tokens_written: number;
+						tokens_saved: number;
+						count: number;
+					};
+					events_filtered: Array<{
+						event: string;
+						total_tokens_read: number;
+						total_tokens_written: number;
+						total_tokens_saved: number;
+						count: number;
+					}> | null;
+					totals_filtered: {
+						tokens_read: number;
+						tokens_written: number;
+						tokens_saved: number;
+						count: number;
+					} | null;
+					totals: {
+						tokens_read: number;
+						tokens_written: number;
+						tokens_saved: number;
+						count: number;
+					};
+				};
+
+				// Global aggregate = all four rows, NULL tokens_saved coalesced to 0.
+				expect(body.totals_global).toEqual({
+					tokens_read: 1330,
+					tokens_written: 133,
+					tokens_saved: 62,
+					count: 4,
+				});
+				// events_global is sorted by event name ASC (pack before search).
+				expect(body.events_global).toEqual([
+					{
+						event: "pack",
+						total_tokens_read: 1300,
+						total_tokens_written: 130,
+						total_tokens_saved: 55,
+						count: 3,
+					},
+					{
+						event: "search",
+						total_tokens_read: 30,
+						total_tokens_written: 3,
+						total_tokens_saved: 7,
+						count: 1,
+					},
+				]);
+
+				// Project-filtered aggregate = only the codemem rows.
+				expect(body.totals_filtered).toEqual({
+					tokens_read: 330,
+					tokens_written: 33,
+					tokens_saved: 12,
+					count: 3,
+				});
+				expect(body.events_filtered).toEqual([
+					{
+						event: "pack",
+						total_tokens_read: 300,
+						total_tokens_written: 30,
+						total_tokens_saved: 5,
+						count: 2,
+					},
+					{
+						event: "search",
+						total_tokens_read: 30,
+						total_tokens_written: 3,
+						total_tokens_saved: 7,
+						count: 1,
+					},
+				]);
+
+				// When a project filter is present, `totals` mirrors the filtered values.
+				expect(body.totals).toEqual(body.totals_filtered);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("orders recent_packs by created_at DESC and caps the surfaced window", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Recent-pack visible memory",
+				});
+				const insertPack = (createdAt: string, tokensRead: number) =>
+					store.db
+						.prepare(
+							`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+							 VALUES (?, 'pack', ?, 0, 0, ?, '{}')`,
+						)
+						.run(sessionId, tokensRead, createdAt);
+
+				// Insert 15 packs in ascending time order; the route should return
+				// the newest first and never surface more than 10.
+				for (let i = 0; i < 15; i += 1) {
+					const minute = String(i).padStart(2, "0");
+					insertPack(`2026-03-26T23:${minute}:00Z`, i);
+				}
+
+				const res = await app.request("/api/usage");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					recent_packs: Array<{ created_at: string }>;
+				};
+				expect(body.recent_packs).toHaveLength(10);
+				const timestamps = body.recent_packs.map((row) => row.created_at);
+				const sortedDesc = [...timestamps].sort((a, b) => b.localeCompare(a));
+				expect(timestamps).toEqual(sortedDesc);
+				// Newest seeded pack (minute 14) is first; oldest surfaced is minute 05.
+				expect(timestamps[0]).toBe("2026-03-26T23:14:00Z");
+				expect(timestamps.at(-1)).toBe("2026-03-26T23:05:00Z");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("does not surface a visible pack older than the bounded recent-pack window", async () => {
+			// Documents the deliberate truncation tradeoff: the recent_packs window
+			// considers only the newest RECENT_PACK_SCAN_LIMIT (200) pack events, so
+			// a visible pack buried under that many newer non-visible packs is not
+			// surfaced — while the unfiltered aggregate still counts every event.
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Starvation-test visible memory",
+				});
+				const insertPack = (sessionRef: number | null, createdAt: string) =>
+					store.db
+						.prepare(
+							`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+							 VALUES (?, 'pack', 1, 0, 0, ?, '{}')`,
+						)
+						.run(sessionRef, createdAt);
+
+				// One visible pack at the OLDEST timestamp (session is visible)...
+				insertPack(sessionId, "2026-03-26T00:00:00Z");
+				// ...buried under 200 NEWER non-visible packs (NULL session => a row
+				// with no pack_item_ids and a null session is never visible). The
+				// newest-200 window is entirely non-visible, so the lone visible pack
+				// sits at position 201 and is never considered.
+				for (let i = 0; i < 200; i += 1) {
+					const minute = String(Math.floor(i / 60)).padStart(2, "0");
+					const second = String(i % 60).padStart(2, "0");
+					insertPack(null, `2026-04-01T00:${minute}:${second}Z`);
+				}
+
+				const res = await app.request("/api/usage");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					recent_packs: unknown[];
+					totals_global: { count: number };
+				};
+				// recent_packs is starved to empty even though a visible pack exists...
+				expect(body.recent_packs).toHaveLength(0);
+				// ...while the unfiltered aggregate still counts every pack event (201).
+				expect(body.totals_global.count).toBe(201);
+			} finally {
 				cleanup();
 			}
 		});

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -181,43 +181,48 @@ function sanitizePackUsageMetadata(
 	return sanitized;
 }
 
-function summarizeUsageEvents(rows: UsageRow[]): Record<string, unknown>[] {
-	const byEvent = new Map<
-		string,
-		{
-			event: string;
-			total_tokens_read: number;
-			total_tokens_written: number;
-			total_tokens_saved: number;
-			count: number;
-		}
-	>();
-	for (const row of rows) {
-		const summary = byEvent.get(row.event) ?? {
+type UsageAggregateRow = {
+	event: string;
+	count: number;
+	tokens_read: number;
+	tokens_written: number;
+	tokens_saved: number;
+};
+
+/**
+ * Convert the neutral core aggregate rows into the wire shape for /api/usage
+ * (ApiUsageEventSummary: total_tokens_* names), sorted by event name ASC to
+ * match the route's historical ordering.
+ */
+function mapAggregateEvents(rows: UsageAggregateRow[]): Record<string, unknown>[] {
+	return rows
+		.map((row) => ({
 			event: row.event,
-			total_tokens_read: 0,
-			total_tokens_written: 0,
-			total_tokens_saved: 0,
-			count: 0,
-		};
-		summary.total_tokens_read += row.tokens_read;
-		summary.total_tokens_written += row.tokens_written;
-		summary.total_tokens_saved += row.tokens_saved;
-		summary.count += 1;
-		byEvent.set(row.event, summary);
-	}
-	return [...byEvent.values()].sort((a, b) => a.event.localeCompare(b.event));
+			total_tokens_read: row.tokens_read,
+			total_tokens_written: row.tokens_written,
+			total_tokens_saved: row.tokens_saved,
+			count: row.count,
+		}))
+		.sort((a, b) => a.event.localeCompare(b.event));
 }
 
-function totalUsageEvents(rows: UsageRow[]): Record<string, unknown> {
+/**
+ * Sum the neutral core aggregate rows into the ApiUsageTotals wire shape.
+ */
+function totalsFromAggregate(rows: UsageAggregateRow[]): {
+	tokens_read: number;
+	tokens_written: number;
+	tokens_saved: number;
+	count: number;
+} {
 	return rows.reduce(
 		(acc, row) => ({
-			tokens_read: Number(acc.tokens_read) + row.tokens_read,
-			tokens_written: Number(acc.tokens_written) + row.tokens_written,
-			tokens_saved: Number(acc.tokens_saved) + row.tokens_saved,
-			count: Number(acc.count) + 1,
+			tokens_read: acc.tokens_read + row.tokens_read,
+			tokens_written: acc.tokens_written + row.tokens_written,
+			tokens_saved: acc.tokens_saved + row.tokens_saved,
+			count: acc.count + row.count,
 		}),
-		{ tokens_read: 0, tokens_written: 0, tokens_saved: 0, count: 0 } as Record<string, unknown>,
+		{ tokens_read: 0, tokens_written: 0, tokens_saved: 0, count: 0 },
 	);
 }
 
@@ -232,12 +237,12 @@ interface UsageCacheEntry {
  * Short-lived cache for the computed /api/usage payload.
  *
  * The health dot polls /api/usage on every 5s refresh regardless of the
- * active tab, and the computation scans the full usage_events table to apply
- * scope visibility before aggregating. The resulting token totals are
- * cumulative dashboard figures, so a few seconds of staleness is acceptable
- * in exchange for collapsing the repeated full-table scan on the polling
- * loop. Keyed by db path + scope identity + project filter so distinct
- * stores/projects never share an entry.
+ * active tab. The token/event totals come from indexed SQL aggregates and the
+ * recent-pack window runs scope-visibility resolution over its bounded set, so
+ * each miss is cheap — but the totals are cumulative dashboard figures where a
+ * few seconds of staleness is acceptable, so caching still collapses the
+ * repeated recompute on the polling loop. Keyed by db path + scope identity +
+ * project filter so distinct stores/projects never share an entry.
  */
 const usagePayloadCache = new Map<string, UsageCacheEntry>();
 const USAGE_PAYLOAD_CACHE_MS = 10_000;
@@ -396,7 +401,30 @@ export function statsRoutes(getStore: () => MemoryStore) {
 			if (cached && nowMs < cached.expiresAtMs) {
 				return c.json(cached.payload);
 			}
-			const loadUsageRows = (project?: string | null): UsageRow[] => {
+
+			// Token/event aggregates are unfiltered SQL GROUP BYs (matching
+			// store.stats()), so they never load the full usage_events table
+			// into JS. Only the small surfaced recent_packs window below keeps
+			// per-row scope visibility + metadata sanitization.
+			const globalAggregate = store.usageAggregate();
+			const eventsGlobal = mapAggregateEvents(globalAggregate);
+			const totalsGlobal = totalsFromAggregate(globalAggregate);
+			const filteredAggregate = projectFilter ? store.usageAggregate(projectFilter) : null;
+			const eventsFiltered = filteredAggregate ? mapAggregateEvents(filteredAggregate) : null;
+			const totalsFiltered = filteredAggregate ? totalsFromAggregate(filteredAggregate) : null;
+
+			// recent_packs candidate window. Over-fetch the most-recent pack
+			// events (20x the 10 we surface) so that, in the common case where a
+			// device sees most of its own packs, 10 *visible* packs survive the
+			// scope filter below without ever scanning the whole table.
+			// Tradeoff vs. the old full-scan-then-slice: if MORE than
+			// (LIMIT - 10) of the newest packs are non-visible, fewer than 10
+			// surface, and a visible pack older than the newest 200 is not
+			// shown at all. That only bites a heavily-shared DB whose recent
+			// activity is dominated by other scopes; for an activity widget the
+			// bounded recompute on a 5s poll is the right call.
+			const RECENT_PACK_SCAN_LIMIT = 200;
+			const loadRecentPackWindow = (project?: string | null): UsageRow[] => {
 				const rows = project
 					? (store.db
 							.prepare(
@@ -405,39 +433,27 @@ export function statsRoutes(getStore: () => MemoryStore) {
 									usage_events.created_at, usage_events.metadata_json
 								 FROM usage_events
 								 JOIN sessions ON sessions.id = usage_events.session_id
-								 WHERE sessions.project = ?
-								 ORDER BY usage_events.created_at DESC`,
+								 WHERE sessions.project = ? AND usage_events.event = 'pack'
+								 ORDER BY usage_events.created_at DESC
+								 LIMIT ?`,
 							)
-							.all(project) as Record<string, unknown>[])
+							.all(project, RECENT_PACK_SCAN_LIMIT) as Record<string, unknown>[])
 					: (store.db
 							.prepare(
 								`SELECT id, session_id, event, tokens_read, tokens_written, tokens_saved,
 									created_at, metadata_json
 								 FROM usage_events
-								 ORDER BY created_at DESC`,
+								 WHERE event = 'pack'
+								 ORDER BY created_at DESC
+								 LIMIT ?`,
 							)
-							.all() as Record<string, unknown>[]);
+							.all(RECENT_PACK_SCAN_LIMIT) as Record<string, unknown>[]);
 				return rows.map((row) => toUsageRow(row, parseMetadataJson(row.metadata_json)));
 			};
-			const loadedGlobalRows = loadUsageRows();
-			const globalVisibility = buildUsageVisibility(store, loadedGlobalRows);
-			const globalRows = loadedGlobalRows.filter((row) => usageRowVisible(row, globalVisibility));
-			const loadedFilteredRows = projectFilter ? loadUsageRows(projectFilter) : null;
-			const filteredVisibility = loadedFilteredRows
-				? buildUsageVisibility(store, loadedFilteredRows)
-				: null;
-			const filteredRows = loadedFilteredRows
-				? loadedFilteredRows.filter((row) =>
-						usageRowVisible(row, filteredVisibility ?? globalVisibility),
-					)
-				: null;
-			const eventsGlobal = summarizeUsageEvents(globalRows);
-			const totalsGlobal = totalUsageEvents(globalRows);
-			const eventsFiltered = filteredRows ? summarizeUsageEvents(filteredRows) : null;
-			const totalsFiltered = filteredRows ? totalUsageEvents(filteredRows) : null;
-			const recentVisibility = filteredVisibility ?? globalVisibility;
-			const recentPacks = (filteredRows ?? globalRows)
-				.filter((row) => row.event === "pack")
+			const recentWindow = loadRecentPackWindow(projectFilter);
+			const recentVisibility = buildUsageVisibility(store, recentWindow);
+			const recentPacks = recentWindow
+				.filter((row) => usageRowVisible(row, recentVisibility))
 				.slice(0, 10)
 				.map((row) => ({
 					...row,


### PR DESCRIPTION
## Description

Part of the performance stack. `GET /api/usage` loaded the entire `usage_events` table (hundreds of thousands of rows + every `metadata_json` blob) into JS on every call, harvested memory-id refs from all pack metadata, ran a chunked visibility fan-out, then summed token totals by hand — all on the Health tab's 5s poll.

This replaces the scan with SQL aggregation:

- Token/event totals come from a shared `MemoryStore.usageAggregate()` helper (`GROUP BY event` over an indexed scan), used by **both** `/api/usage` and `store.stats()` so the two endpoints can no longer disagree.
- `recent_packs` is sourced from a bounded most-recent window (`idx_usage_events_event_created`, `LIMIT`), and the existing per-pack scope-visibility filter + metadata sanitization run only over that small set — byte-for-byte the same surfaced-pack authorization semantics, without touching the whole table.
- The aggregate totals are now unfiltered, matching what `store.stats()` has always reported: `usage_events` is local-only (never synced from peers), so the totals are a record of this device's own activity; only the surfaced `recent_packs` window (which exposes memory ids) remains scope-sanitized.

The one deliberate tradeoff (a visible pack older than the bounded window isn't surfaced when newer packs are non-visible) is documented in-code and covered by a dedicated test.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
