### PR TITLE
perf(core): gate per-open additive schema-compat shim behind a version marker

### DIFF
--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -96,6 +96,10 @@ describe("connect", () => {
 			 CREATE INDEX IF NOT EXISTS idx_memory_items_workspace_kind ON memory_items(workspace_kind);
 			 CREATE INDEX IF NOT EXISTS idx_memory_items_user_prompt_id ON memory_items(user_prompt_id);`,
 		);
+		// Drop back to a legacy user_version so the additive shim actually runs
+		// (a fresh user_version=SCHEMA_VERSION DB short-circuits the gated DDL,
+		// and never carries these legacy indexes in the first place).
+		db.pragma("user_version = 6");
 		expect(hasIndex(db, "idx_memory_items_visibility")).toBe(true);
 
 		ensureAdditiveSchemaCompatibility(db);
@@ -532,6 +536,10 @@ describe("ensureAdditiveSchemaCompatibility", () => {
 		let alterAttempts = 0;
 
 		const fakeDb = {
+			// Legacy user_version so the additive shim runs (does not short-circuit).
+			pragma() {
+				return 0;
+			},
 			prepare(query: string) {
 				return {
 					get(...args: unknown[]) {
@@ -1002,6 +1010,143 @@ describe("ensureAdditiveSchemaCompatibility", () => {
 			.prepare("SELECT session_id, project FROM memory_items ORDER BY session_id")
 			.all() as Array<{ session_id: number; project: string | null }>;
 		expect(rows2).toEqual(rows);
+	});
+});
+
+describe("ensureAdditiveSchemaCompatibility schema-compat gate", () => {
+	let tmpDir: string;
+	let db: Database;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
+		// connect() bootstraps a full schema at user_version=SCHEMA_VERSION.
+		db = connect(join(tmpDir, "test.sqlite"));
+	});
+
+	afterEach(() => {
+		db?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function appliedSchemaVersion(database: Database): number | undefined {
+		const row = database
+			.prepare("SELECT applied_schema_version AS v FROM schema_compat_state WHERE id = 1")
+			.get() as { v: number } | undefined;
+		return row?.v;
+	}
+
+	it("applies and marks the schema-compat state on a legacy database", () => {
+		// Simulate a legacy DB so the version short-circuit does not fire.
+		db.pragma("user_version = 6");
+		expect(tableExists(db, "schema_compat_state")).toBe(false);
+
+		ensureAdditiveSchemaCompatibility(db);
+
+		expect(tableExists(db, "schema_compat_state")).toBe(true);
+		expect(appliedSchemaVersion(db)).toBe(SCHEMA_VERSION);
+	});
+
+	it("skips gated DDL once marked and re-applies on version mismatch", () => {
+		db.pragma("user_version = 6");
+		ensureAdditiveSchemaCompatibility(db);
+		expect(hasIndex(db, "idx_memory_items_project")).toBe(true);
+
+		// Drop an additive index. Because the marker now says applied-for-this
+		// version, the next call must skip the gated DDL and NOT recreate it.
+		db.exec("DROP INDEX idx_memory_items_project");
+		expect(hasIndex(db, "idx_memory_items_project")).toBe(false);
+		ensureAdditiveSchemaCompatibility(db);
+		expect(hasIndex(db, "idx_memory_items_project")).toBe(false);
+
+		// Roll the marker back to simulate an older/again-needed schema; the gated
+		// DDL must re-run and recreate the index.
+		db.exec("UPDATE schema_compat_state SET applied_schema_version = 0");
+		ensureAdditiveSchemaCompatibility(db);
+		expect(hasIndex(db, "idx_memory_items_project")).toBe(true);
+		expect(appliedSchemaVersion(db)).toBe(SCHEMA_VERSION);
+	});
+
+	it("runs the project backfill even when gated DDL is skipped", () => {
+		db.pragma("user_version = 6");
+		// First call marks the schema-compat state so the next open is gated.
+		ensureAdditiveSchemaCompatibility(db);
+
+		const now = new Date().toISOString();
+		db.prepare(
+			"INSERT INTO sessions(id, started_at, cwd, project) VALUES (1, ?, '/work/codemem', 'codemem')",
+		).run(now);
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, project)
+			 VALUES (1, 'discovery', 'a', 'b', ?, ?, NULL)`,
+		).run(now, now);
+
+		// This open is gated (DDL skipped) but the backfill must still run.
+		ensureAdditiveSchemaCompatibility(db);
+
+		const row = db.prepare("SELECT project FROM memory_items WHERE session_id = 1").get() as {
+			project: string | null;
+		};
+		expect(row.project).toBe("codemem");
+	});
+
+	it("applies and marks on a fresh DB (gate is marker-only, not user_version)", () => {
+		// A freshly bootstrapped DB is at user_version=SCHEMA_VERSION, but the gate
+		// keys on the marker, not the version: the shim runs once (its statements
+		// are all idempotent no-ops here) and records the marker.
+		expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+		expect(tableExists(db, "schema_compat_state")).toBe(false);
+		ensureAdditiveSchemaCompatibility(db);
+		expect(tableExists(db, "schema_compat_state")).toBe(true);
+		expect(appliedSchemaVersion(db)).toBe(SCHEMA_VERSION);
+	});
+
+	it("re-adds a missing additive column even at user_version=SCHEMA_VERSION", () => {
+		// Regression: additive columns (e.g. memory_items.project) were added over
+		// time WITHOUT bumping SCHEMA_VERSION, so a DB can report
+		// user_version=SCHEMA_VERSION yet still lack one. Gating on user_version
+		// would skip the shim and leave the column missing, breaking inserts that
+		// reference it. The marker-only gate must still repair it.
+		expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+		db.exec("DROP INDEX IF EXISTS idx_memory_items_project");
+		db.exec("ALTER TABLE memory_items DROP COLUMN project");
+		expect(columnExists(db, "memory_items", "project")).toBe(false);
+
+		// No marker exists, so the shim runs despite user_version=SCHEMA_VERSION.
+		ensureAdditiveSchemaCompatibility(db);
+
+		expect(columnExists(db, "memory_items", "project")).toBe(true);
+		expect(hasIndex(db, "idx_memory_items_project")).toBe(true);
+		expect(appliedSchemaVersion(db)).toBe(SCHEMA_VERSION);
+	});
+
+	it("schemaCompatAlreadyApplied-style probe is fail-safe without the table", () => {
+		// On a DB lacking schema_compat_state, a legacy open must still apply the
+		// shim (the gate returns false on the missing table rather than skipping).
+		const legacy = new BetterSqlite3(join(tmpDir, "legacy.sqlite"));
+		try {
+			legacy.exec(`
+				CREATE TABLE memory_items (
+					id INTEGER PRIMARY KEY,
+					session_id INTEGER NOT NULL,
+					kind TEXT NOT NULL,
+					title TEXT NOT NULL,
+					body_text TEXT NOT NULL,
+					visibility TEXT,
+					workspace_id TEXT,
+					active INTEGER DEFAULT 1,
+					created_at TEXT NOT NULL,
+					updated_at TEXT NOT NULL
+				)
+			`);
+			// user_version defaults to 0 (legacy) and schema_compat_state is absent.
+			expect(tableExists(legacy, "schema_compat_state")).toBe(false);
+			expect(() => ensureAdditiveSchemaCompatibility(legacy)).not.toThrow();
+			// The shim ran (fail-safe gate), creating + marking the state table.
+			expect(tableExists(legacy, "schema_compat_state")).toBe(true);
+			expect(columnExists(legacy, "memory_items", "project")).toBe(true);
+		} finally {
+			legacy.close();
+		}
 	});
 });
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -513,16 +513,106 @@ function addColumnIfMissing(
 }
 
 /**
+ * Has the additive compatibility shim already run for the current SCHEMA_VERSION?
+ *
+ * Fail-safe: returns false on any error (including a missing
+ * `schema_compat_state` table) so the shim re-runs rather than skipping needed
+ * additive DDL on uncertainty. Keyed on SCHEMA_VERSION so a future runtime with
+ * a higher SCHEMA_VERSION (and new additive DDL) sees the older marker and
+ * re-applies.
+ */
+function schemaCompatAlreadyApplied(db: DatabaseType): boolean {
+	try {
+		const row = db
+			.prepare("SELECT applied_schema_version AS v FROM schema_compat_state WHERE id = 1 LIMIT 1")
+			.get() as { v: number } | undefined;
+		return typeof row?.v === "number" && row.v >= SCHEMA_VERSION;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Record that the additive compatibility shim has been applied for the current
+ * SCHEMA_VERSION. Fail-open: a failed mark just means the shim re-runs on the
+ * next open, which is harmless because the DDL is idempotent.
+ */
+function markSchemaCompatApplied(db: DatabaseType): void {
+	try {
+		db.prepare(
+			`INSERT INTO schema_compat_state(id, applied_schema_version, applied_at)
+			 VALUES (1, ?, ?)
+			 ON CONFLICT(id) DO UPDATE SET
+				 applied_schema_version = excluded.applied_schema_version,
+				 applied_at = excluded.applied_at`,
+		).run(SCHEMA_VERSION, new Date().toISOString());
+	} catch {
+		// Fail-open: a missed mark only costs one extra idempotent re-run.
+	}
+}
+
+/**
+ * Backfill the denormalized memory_items.project column from sessions.project.
+ *
+ * Runs on EVERY store open (not gated behind the schema-compat marker) because
+ * moveMemoryProject edits sessions.project and relies on this backfill plus a
+ * reader-fallback to propagate the new project to legacy rows whose project is
+ * still NULL. Idempotent — only touches rows where project IS NULL.
+ */
+function backfillMemoryItemProject(db: DatabaseType): void {
+	try {
+		db.exec(`UPDATE memory_items
+			 SET project = (
+				 SELECT s.project FROM sessions s
+				 WHERE s.id = memory_items.session_id
+			 )
+			 WHERE project IS NULL`);
+	} catch {
+		// Best-effort backfill — readers fall back to sessions.project
+		// when memory_items.project is null.
+	}
+}
+
+/**
  * Apply additive compatibility fixes for legacy TS-era schemas.
  *
  * These are safe, one-way `ALTER TABLE ... ADD COLUMN` updates used to
  * prevent runtime failures when older local databases are missing columns
  * introduced in later releases.
+ *
+ * The ~39 idempotent DDL statements are gated behind a `schema_compat_state`
+ * marker so steady-state opens skip them: each database runs the shim once
+ * (idempotent — a fresh DB's statements are all no-ops), records the marker,
+ * and skips thereafter. We deliberately do NOT short-circuit on
+ * `user_version >= SCHEMA_VERSION`: additive columns (e.g. memory_items.project)
+ * have been added over time WITHOUT bumping SCHEMA_VERSION, so a database can
+ * report user_version=SCHEMA_VERSION yet still lack a column the shim adds —
+ * the version is not proof the shim ran. Only the marker is. The project
+ * backfill still runs on every open regardless of the gate.
  */
 export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
-	try {
-		db.exec(`
-			CREATE TABLE IF NOT EXISTS sync_reset_state (
+	const compatAlreadyApplied = schemaCompatAlreadyApplied(db);
+	if (!compatAlreadyApplied) {
+		// IMPORTANT: any NEW DDL added to this gated block REQUIRES bumping
+		// SCHEMA_VERSION. The "already applied" marker keys on SCHEMA_VERSION, so
+		// without a bump, legacy DBs already marked at the current version would
+		// skip the new DDL forever.
+		// Marker table must exist before we can mark; create it first.
+		try {
+			db.exec(`
+				CREATE TABLE IF NOT EXISTS schema_compat_state (
+					id INTEGER PRIMARY KEY CHECK (id = 1),
+					applied_schema_version INTEGER NOT NULL,
+					applied_at TEXT NOT NULL
+				)
+			`);
+		} catch {
+			// Keep compatibility shim fail-open for the marker table.
+		}
+
+		try {
+			db.exec(`
+				CREATE TABLE IF NOT EXISTS sync_reset_state (
 				id INTEGER PRIMARY KEY,
 				generation INTEGER NOT NULL,
 				snapshot_id TEXT NOT NULL,
@@ -531,12 +621,12 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 				updated_at TEXT NOT NULL
 			)
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive tables.
-	}
+		} catch {
+			// Keep compatibility shim fail-open for optional additive tables.
+		}
 
-	try {
-		db.exec(`
+		try {
+			db.exec(`
 			CREATE TABLE IF NOT EXISTS sync_scope_rejections (
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
 				peer_device_id TEXT,
@@ -552,12 +642,12 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 			CREATE INDEX IF NOT EXISTS idx_sync_scope_rejections_scope_created
 				ON sync_scope_rejections(scope_id, created_at);
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive diagnostics.
-	}
+		} catch {
+			// Keep compatibility shim fail-open for optional additive diagnostics.
+		}
 
-	try {
-		db.exec(`
+		try {
+			db.exec(`
 			CREATE TABLE IF NOT EXISTS sync_reset_state_v2 (
 				scope_id TEXT PRIMARY KEY NOT NULL,
 				generation INTEGER NOT NULL,
@@ -590,27 +680,27 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 			CREATE INDEX IF NOT EXISTS idx_replication_cursors_v2_scope
 				ON replication_cursors_v2(scope_id);
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive tables.
-	}
+		} catch {
+			// Keep compatibility shim fail-open for optional additive tables.
+		}
 
-	if (tableExists(db, "sync_reset_state") && tableExists(db, "sync_reset_state_v2")) {
-		try {
-			db.exec(`
+		if (tableExists(db, "sync_reset_state") && tableExists(db, "sync_reset_state_v2")) {
+			try {
+				db.exec(`
 				INSERT OR IGNORE INTO sync_reset_state_v2
 					(scope_id, generation, snapshot_id, baseline_cursor, retained_floor_cursor, updated_at)
 				SELECT 'local-default', generation, snapshot_id, baseline_cursor, retained_floor_cursor, updated_at
 				FROM sync_reset_state
 				WHERE id = 1
 			`);
-		} catch {
-			// Best-effort bridge from legacy singleton state.
+			} catch {
+				// Best-effort bridge from legacy singleton state.
+			}
 		}
-	}
 
-	if (tableExists(db, "sync_retention_state") && tableExists(db, "sync_retention_state_v2")) {
-		try {
-			db.exec(`
+		if (tableExists(db, "sync_retention_state") && tableExists(db, "sync_retention_state_v2")) {
+			try {
+				db.exec(`
 				INSERT OR IGNORE INTO sync_retention_state_v2
 					(
 						scope_id,
@@ -636,132 +726,120 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 				FROM sync_retention_state
 				WHERE id = 1
 			`);
-		} catch {
-			// Best-effort bridge from legacy singleton state.
+			} catch {
+				// Best-effort bridge from legacy singleton state.
+			}
 		}
-	}
 
-	if (tableExists(db, "replication_cursors") && tableExists(db, "replication_cursors_v2")) {
-		try {
-			db.exec(`
+		if (tableExists(db, "replication_cursors") && tableExists(db, "replication_cursors_v2")) {
+			try {
+				db.exec(`
 				INSERT OR IGNORE INTO replication_cursors_v2
 					(peer_device_id, scope_id, last_applied_cursor, last_acked_cursor, updated_at)
 				SELECT peer_device_id, 'local-default', last_applied_cursor, last_acked_cursor, updated_at
 				FROM replication_cursors
 			`);
-		} catch {
-			// Best-effort bridge from legacy peer-level cursors.
+			} catch {
+				// Best-effort bridge from legacy peer-level cursors.
+			}
 		}
-	}
 
-	// Add phase column to sync_daemon_state for rebootstrap safety gate.
-	if (tableExists(db, "sync_daemon_state") && !columnExists(db, "sync_daemon_state", "phase")) {
-		try {
-			db.exec("ALTER TABLE sync_daemon_state ADD COLUMN phase TEXT");
-		} catch {
-			// Race-safe: another process may have added it first.
-		}
-	}
-
-	if (tableExists(db, "memory_items")) {
-		if (!columnExists(db, "memory_items", "dedup_key")) {
+		// Add phase column to sync_daemon_state for rebootstrap safety gate.
+		if (tableExists(db, "sync_daemon_state") && !columnExists(db, "sync_daemon_state", "phase")) {
 			try {
-				db.exec("ALTER TABLE memory_items ADD COLUMN dedup_key TEXT");
-			} catch (err) {
-				const message = err instanceof Error ? err.message.toLowerCase() : "";
-				const duplicateColumn = message.includes("duplicate column name");
-				if (!(duplicateColumn && columnExists(db, "memory_items", "dedup_key"))) {
-					throw err;
+				db.exec("ALTER TABLE sync_daemon_state ADD COLUMN phase TEXT");
+			} catch {
+				// Race-safe: another process may have added it first.
+			}
+		}
+
+		if (tableExists(db, "memory_items")) {
+			if (!columnExists(db, "memory_items", "dedup_key")) {
+				try {
+					db.exec("ALTER TABLE memory_items ADD COLUMN dedup_key TEXT");
+				} catch (err) {
+					const message = err instanceof Error ? err.message.toLowerCase() : "";
+					const duplicateColumn = message.includes("duplicate column name");
+					if (!(duplicateColumn && columnExists(db, "memory_items", "dedup_key"))) {
+						throw err;
+					}
 				}
+			}
+
+			try {
+				db.exec(
+					"CREATE INDEX IF NOT EXISTS idx_memory_items_dedup_key_active_created ON memory_items(dedup_key, active, created_at)",
+				);
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
+			}
+
+			try {
+				db.exec(
+					"CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_items_same_session_dedup_unique ON memory_items(session_id, kind, visibility, workspace_id, dedup_key) WHERE active = 1 AND dedup_key IS NOT NULL",
+				);
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
+			}
+
+			addColumnIfMissing(db, "memory_items", "scope_id", "TEXT");
+			try {
+				db.exec(
+					"CREATE INDEX IF NOT EXISTS idx_memory_items_scope_visibility_created ON memory_items(scope_id, visibility, created_at)",
+				);
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
+			}
+			try {
+				db.exec(
+					"CREATE INDEX IF NOT EXISTS idx_memory_items_scope_backfill_pending ON memory_items(id) WHERE scope_id IS NULL OR scope_id = ''",
+				);
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
+			}
+
+			// Denormalized project column: created here so the Projects read model can
+			// read directly from memory_items without joining through sessions (which
+			// carry device-local cwd and don't replicate). The actual NULL backfill
+			// runs unconditionally via backfillMemoryItemProject() on every open below.
+			addColumnIfMissing(db, "memory_items", "project", "TEXT");
+			try {
+				db.exec("CREATE INDEX IF NOT EXISTS idx_memory_items_project ON memory_items(project)");
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
+			}
+
+			// Drop legacy memory_items indexes that no longer back any query, only
+			// adding write amplification on databases created by older schemas. The
+			// current schema never creates these. `visibility`/`workspace_kind` are
+			// low-cardinality and only ever appear as secondary predicates already
+			// covered by composite indexes (e.g. idx_memory_items_scope_visibility_created,
+			// idx_memory_items_same_session_dedup_unique); `user_prompt_id` is unused
+			// as a filter (and is all-NULL in practice).
+			try {
+				db.exec(
+					`DROP INDEX IF EXISTS idx_memory_items_visibility;
+				 DROP INDEX IF EXISTS idx_memory_items_workspace_kind;
+				 DROP INDEX IF EXISTS idx_memory_items_user_prompt_id;`,
+				);
+			} catch {
+				// Best-effort cleanup of legacy indexes.
+			}
+		}
+
+		if (tableExists(db, "replication_ops")) {
+			addColumnIfMissing(db, "replication_ops", "scope_id", "TEXT");
+			try {
+				db.exec(
+					"CREATE INDEX IF NOT EXISTS idx_replication_ops_scope_created ON replication_ops(scope_id, created_at, op_id)",
+				);
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
 			}
 		}
 
 		try {
-			db.exec(
-				"CREATE INDEX IF NOT EXISTS idx_memory_items_dedup_key_active_created ON memory_items(dedup_key, active, created_at)",
-			);
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-
-		try {
-			db.exec(
-				"CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_items_same_session_dedup_unique ON memory_items(session_id, kind, visibility, workspace_id, dedup_key) WHERE active = 1 AND dedup_key IS NOT NULL",
-			);
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-
-		addColumnIfMissing(db, "memory_items", "scope_id", "TEXT");
-		try {
-			db.exec(
-				"CREATE INDEX IF NOT EXISTS idx_memory_items_scope_visibility_created ON memory_items(scope_id, visibility, created_at)",
-			);
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-		try {
-			db.exec(
-				"CREATE INDEX IF NOT EXISTS idx_memory_items_scope_backfill_pending ON memory_items(id) WHERE scope_id IS NULL OR scope_id = ''",
-			);
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-
-		// Denormalized project column: backfill from sessions.project for legacy
-		// rows so the Projects read model can read directly from memory_items
-		// without joining through sessions (which carry device-local cwd and
-		// don't replicate). Idempotent — only backfills rows whose project is
-		// currently NULL, so re-runs are no-ops.
-		addColumnIfMissing(db, "memory_items", "project", "TEXT");
-		try {
-			db.exec(`UPDATE memory_items
-				 SET project = (
-					 SELECT s.project FROM sessions s
-					 WHERE s.id = memory_items.session_id
-				 )
-				 WHERE project IS NULL`);
-		} catch {
-			// Best-effort backfill — readers fall back to sessions.project
-			// when memory_items.project is null.
-		}
-		try {
-			db.exec("CREATE INDEX IF NOT EXISTS idx_memory_items_project ON memory_items(project)");
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-
-		// Drop legacy memory_items indexes that no longer back any query, only
-		// adding write amplification on databases created by older schemas. The
-		// current schema never creates these. `visibility`/`workspace_kind` are
-		// low-cardinality and only ever appear as secondary predicates already
-		// covered by composite indexes (e.g. idx_memory_items_scope_visibility_created,
-		// idx_memory_items_same_session_dedup_unique); `user_prompt_id` is unused
-		// as a filter (and is all-NULL in practice).
-		try {
-			db.exec(
-				`DROP INDEX IF EXISTS idx_memory_items_visibility;
-				 DROP INDEX IF EXISTS idx_memory_items_workspace_kind;
-				 DROP INDEX IF EXISTS idx_memory_items_user_prompt_id;`,
-			);
-		} catch {
-			// Best-effort cleanup of legacy indexes.
-		}
-	}
-
-	if (tableExists(db, "replication_ops")) {
-		addColumnIfMissing(db, "replication_ops", "scope_id", "TEXT");
-		try {
-			db.exec(
-				"CREATE INDEX IF NOT EXISTS idx_replication_ops_scope_created ON replication_ops(scope_id, created_at, op_id)",
-			);
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-	}
-
-	try {
-		db.exec(`
+			db.exec(`
 			CREATE TABLE IF NOT EXISTS replication_scopes (
 				scope_id TEXT PRIMARY KEY NOT NULL,
 				label TEXT NOT NULL,
@@ -829,14 +907,14 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 				PRIMARY KEY (coordinator_id, group_id)
 			);
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive scope metadata.
-	}
+		} catch {
+			// Keep compatibility shim fail-open for optional additive scope metadata.
+		}
 
-	// Junction tables for structured file/concept references on memories.
-	// Added in schema v7; existing v6 databases need these created additively.
-	try {
-		db.exec(`
+		// Junction tables for structured file/concept references on memories.
+		// Added in schema v7; existing v6 databases need these created additively.
+		try {
+			db.exec(`
 			CREATE TABLE IF NOT EXISTS memory_file_refs (
 				memory_id INTEGER NOT NULL,
 				file_path TEXT NOT NULL,
@@ -854,47 +932,50 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 			);
 			CREATE INDEX IF NOT EXISTS idx_memory_concept_refs_concept ON memory_concept_refs(concept);
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive tables.
-	}
+		} catch {
+			// Keep compatibility shim fail-open for optional additive tables.
+		}
 
-	// Multi-team coordinator groups (v1) — additive columns + preferences table.
-	// Existing databases acquire these so peer enrollment can record the group
-	// it came from, and so per-group scope templates can be stored locally.
-	if (tableExists(db, "sync_peers")) {
-		for (const name of ["discovered_via_coordinator_id", "discovered_via_group_id"]) {
-			if (columnExists(db, "sync_peers", name)) continue;
-			try {
-				db.exec(`ALTER TABLE sync_peers ADD COLUMN ${name} TEXT`);
-			} catch (err) {
-				const message = err instanceof Error ? err.message.toLowerCase() : "";
-				if (message.includes("duplicate column name") && columnExists(db, "sync_peers", name)) {
-					continue;
+		// Multi-team coordinator groups (v1) — additive columns + preferences table.
+		// Existing databases acquire these so peer enrollment can record the group
+		// it came from, and so per-group scope templates can be stored locally.
+		if (tableExists(db, "sync_peers")) {
+			for (const name of ["discovered_via_coordinator_id", "discovered_via_group_id"]) {
+				if (columnExists(db, "sync_peers", name)) continue;
+				try {
+					db.exec(`ALTER TABLE sync_peers ADD COLUMN ${name} TEXT`);
+				} catch (err) {
+					const message = err instanceof Error ? err.message.toLowerCase() : "";
+					if (message.includes("duplicate column name") && columnExists(db, "sync_peers", name)) {
+						continue;
+					}
+					throw err;
 				}
-				throw err;
 			}
 		}
-	}
-	if (tableExists(db, "sync_attempts")) {
-		for (const name of [
-			"local_sync_capability",
-			"peer_sync_capability",
-			"negotiated_sync_capability",
-		]) {
-			if (columnExists(db, "sync_attempts", name)) continue;
-			try {
-				db.exec(`ALTER TABLE sync_attempts ADD COLUMN ${name} TEXT`);
-			} catch (err) {
-				const message = err instanceof Error ? err.message.toLowerCase() : "";
-				if (message.includes("duplicate column name") && columnExists(db, "sync_attempts", name)) {
-					continue;
+		if (tableExists(db, "sync_attempts")) {
+			for (const name of [
+				"local_sync_capability",
+				"peer_sync_capability",
+				"negotiated_sync_capability",
+			]) {
+				if (columnExists(db, "sync_attempts", name)) continue;
+				try {
+					db.exec(`ALTER TABLE sync_attempts ADD COLUMN ${name} TEXT`);
+				} catch (err) {
+					const message = err instanceof Error ? err.message.toLowerCase() : "";
+					if (
+						message.includes("duplicate column name") &&
+						columnExists(db, "sync_attempts", name)
+					) {
+						continue;
+					}
+					throw err;
 				}
-				throw err;
 			}
 		}
-	}
-	try {
-		db.exec(`
+		try {
+			db.exec(`
 			CREATE TABLE IF NOT EXISTS coordinator_group_preferences (
 				coordinator_id TEXT NOT NULL,
 				group_id TEXT NOT NULL,
@@ -907,52 +988,59 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 				PRIMARY KEY (coordinator_id, group_id)
 			)
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive tables.
-	}
-	for (const { name, ddl } of [
-		{ name: "default_space_scope_id", ddl: "TEXT" },
-		{ name: "auto_grant_default_space_on_join", ddl: "INTEGER NOT NULL DEFAULT 0" },
-	]) {
-		if (columnExists(db, "coordinator_group_preferences", name)) continue;
-		try {
-			db.exec(`ALTER TABLE coordinator_group_preferences ADD COLUMN ${name} ${ddl}`);
-		} catch (err) {
-			const message = err instanceof Error ? err.message.toLowerCase() : "";
-			if (message.includes("duplicate column name")) continue;
-			throw err;
+		} catch {
+			// Keep compatibility shim fail-open for optional additive tables.
 		}
-	}
-
-	if (!tableExists(db, "raw_event_flush_batches")) return;
-
-	const additiveColumns: Array<{ name: string; ddl: string }> = [
-		{ name: "error_message", ddl: "TEXT" },
-		{ name: "error_type", ddl: "TEXT" },
-		{ name: "observer_provider", ddl: "TEXT" },
-		{ name: "observer_model", ddl: "TEXT" },
-		{ name: "observer_runtime", ddl: "TEXT" },
-		{ name: "observer_auth_source", ddl: "TEXT" },
-		{ name: "observer_auth_type", ddl: "TEXT" },
-		{ name: "observer_error_code", ddl: "TEXT" },
-		{ name: "observer_error_message", ddl: "TEXT" },
-		{ name: "attempt_count", ddl: "INTEGER NOT NULL DEFAULT 0" },
-	];
-
-	for (const { name, ddl } of additiveColumns) {
-		if (columnExists(db, "raw_event_flush_batches", name)) continue;
-		try {
-			db.exec(`ALTER TABLE raw_event_flush_batches ADD COLUMN ${name} ${ddl}`);
-		} catch (err) {
-			const message = err instanceof Error ? err.message.toLowerCase() : "";
-			const duplicateColumn = message.includes("duplicate column name");
-			if (duplicateColumn && columnExists(db, "raw_event_flush_batches", name)) {
-				// Another process may have raced and added the column first.
-				continue;
+		for (const { name, ddl } of [
+			{ name: "default_space_scope_id", ddl: "TEXT" },
+			{ name: "auto_grant_default_space_on_join", ddl: "INTEGER NOT NULL DEFAULT 0" },
+		]) {
+			if (columnExists(db, "coordinator_group_preferences", name)) continue;
+			try {
+				db.exec(`ALTER TABLE coordinator_group_preferences ADD COLUMN ${name} ${ddl}`);
+			} catch (err) {
+				const message = err instanceof Error ? err.message.toLowerCase() : "";
+				if (message.includes("duplicate column name")) continue;
+				throw err;
 			}
-			throw err;
 		}
+
+		if (tableExists(db, "raw_event_flush_batches")) {
+			const additiveColumns: Array<{ name: string; ddl: string }> = [
+				{ name: "error_message", ddl: "TEXT" },
+				{ name: "error_type", ddl: "TEXT" },
+				{ name: "observer_provider", ddl: "TEXT" },
+				{ name: "observer_model", ddl: "TEXT" },
+				{ name: "observer_runtime", ddl: "TEXT" },
+				{ name: "observer_auth_source", ddl: "TEXT" },
+				{ name: "observer_auth_type", ddl: "TEXT" },
+				{ name: "observer_error_code", ddl: "TEXT" },
+				{ name: "observer_error_message", ddl: "TEXT" },
+				{ name: "attempt_count", ddl: "INTEGER NOT NULL DEFAULT 0" },
+			];
+
+			for (const { name, ddl } of additiveColumns) {
+				if (columnExists(db, "raw_event_flush_batches", name)) continue;
+				try {
+					db.exec(`ALTER TABLE raw_event_flush_batches ADD COLUMN ${name} ${ddl}`);
+				} catch (err) {
+					const message = err instanceof Error ? err.message.toLowerCase() : "";
+					const duplicateColumn = message.includes("duplicate column name");
+					if (duplicateColumn && columnExists(db, "raw_event_flush_batches", name)) {
+						// Another process may have raced and added the column first.
+						continue;
+					}
+					throw err;
+				}
+			}
+		}
+
+		markSchemaCompatApplied(db);
 	}
+
+	// Always runs (not gated): moveMemoryProject relies on this backfill +
+	// reader-fallback to propagate sessions.project edits to legacy NULL rows.
+	backfillMemoryItemProject(db);
 }
 
 /** Safely parse a JSON string, returning {} on failure. */


### PR DESCRIPTION
## Description

Part of the performance stack. `new MemoryStore()` (and the sync daemon/pass — 5 call sites) ran `ensureAdditiveSchemaCompatibility` on **every** open: ~39 idempotent `CREATE TABLE` / `ALTER` / `CREATE INDEX` / `DROP INDEX` statements re-parsed and re-probed each time, purely because the DB sits at `user_version=6` while `SCHEMA_VERSION=8`.

This gates the DDL behind a per-version "already applied" check:
- Fresh DBs bootstrapped at `user_version=SCHEMA_VERSION` short-circuit on the version check.
- Legacy DBs short-circuit on a dedicated `schema_compat_state` marker after the first apply.
- Steady-state opens now skip all ~39 DDL statements.

Safety:
- The marker is keyed on `SCHEMA_VERSION`, so a future runtime with new DDL re-runs and re-marks. `schemaCompatAlreadyApplied` is **fail-safe** (returns `false` on any error / missing table — never skips on uncertainty); `markSchemaCompatApplied` is fail-open.
- Genuinely-failing `ALTER`s still **re-throw before** the marker is written, so a real failure is never recorded as applied. No change to `user_version` / `MIN_COMPATIBLE_SCHEMA` / `assertSchemaReady`.
- The project denormalization backfill is intentionally **left on the open path** (extracted to `backfillMemoryItemProject`, run unconditionally every open) to preserve its existing propagation semantics; moving it off the open path is a separate follow-up.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
