### PR TITLE
perf(viewer/ui): minify production bundle + precompress assets (brotli/gzip)

### DIFF
--- a/packages/ui/scripts/stage-viewer-static.mjs
+++ b/packages/ui/scripts/stage-viewer-static.mjs
@@ -1,6 +1,7 @@
-import { cpSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { brotliCompressSync, constants as zlibConstants, gzipSync } from "node:zlib";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "../../..");
@@ -18,4 +19,20 @@ for (const entry of readdirSync(sourceStaticDir, { withFileTypes: true })) {
 	if (entry.name === "app.js") continue;
 	if (extname(entry.name) === ".map") continue;
 	cpSync(join(sourceStaticDir, entry.name), join(viewerStaticDir, entry.name));
+}
+
+// Precompress text assets so the viewer server (serveStatic precompressed:true)
+// serves .br/.gz. Done HERE, as the final build step, so every asset is the
+// freshly-staged content: app.js was written into viewerStaticDir by vite, and
+// the CSS above was just copied. Compressing in vite's writeBundle instead would
+// race the CSS staging and emit stale/missing CSS siblings.
+for (const name of ["app.js", "themes.css", "tokens.css"]) {
+	const filePath = join(viewerStaticDir, name);
+	if (!existsSync(filePath)) continue;
+	const raw = readFileSync(filePath);
+	writeFileSync(`${filePath}.gz`, gzipSync(raw, { level: 9 }));
+	writeFileSync(
+		`${filePath}.br`,
+		brotliCompressSync(raw, { params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 11 } }),
+	);
 }

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -75,7 +75,7 @@ export default defineConfig(({ command, mode }) => {
 						fileName: () => "app.js",
 					},
 					sourcemap: mode === "development",
-					minify: false,
+					minify: "esbuild",
 				},
 		plugins: [
 			preact(),

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -8,6 +8,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { brotliCompressSync } from "node:zlib";
 import * as core from "@codemem/core";
 import {
 	buildAuthHeaders,
@@ -291,6 +292,41 @@ describe("viewer-server", () => {
 			const bundle = await app.request("/assets/app.js");
 			expect(bundle.status).toBe(200);
 			expect(bundle.headers.get("cache-control")).toBe("no-cache");
+		} finally {
+			if (previousStaticDir == null) delete process.env.CODEMEM_VIEWER_STATIC_DIR;
+			else process.env.CODEMEM_VIEWER_STATIC_DIR = previousStaticDir;
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it("serves the brotli-precompressed app bundle when the client accepts it", async () => {
+		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-viewer-static-br-"));
+		const previousStaticDir = process.env.CODEMEM_VIEWER_STATIC_DIR;
+		process.env.CODEMEM_VIEWER_STATIC_DIR = tmpDir;
+		try {
+			writeFileSync(
+				join(tmpDir, "index.html"),
+				'<!doctype html><script src="/assets/app.js"></script>',
+			);
+			const rawBundle = "globalThis.__codememTestApp = true;";
+			writeFileSync(join(tmpDir, "app.js"), rawBundle);
+			writeFileSync(join(tmpDir, "app.js.br"), brotliCompressSync(Buffer.from(rawBundle)));
+			const app = createApp({
+				storeFactory: () => createTestStore().store,
+			});
+
+			const compressed = await app.request("/assets/app.js", {
+				headers: { "Accept-Encoding": "br" },
+			});
+			expect(compressed.status).toBe(200);
+			expect(compressed.headers.get("content-encoding")).toBe("br");
+
+			// No matching encoding -> raw file, no Content-Encoding header.
+			const identity = await app.request("/assets/app.js", {
+				headers: { "Accept-Encoding": "identity" },
+			});
+			expect(identity.status).toBe(200);
+			expect(identity.headers.get("content-encoding")).toBeNull();
 		} finally {
 			if (previousStaticDir == null) delete process.env.CODEMEM_VIEWER_STATIC_DIR;
 			else process.env.CODEMEM_VIEWER_STATIC_DIR = previousStaticDir;

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -115,6 +115,7 @@ export function createApp(opts?: AppOptions) {
 		serveStatic({
 			root: staticRoot,
 			rewriteRequestPath: (path) => path.replace(/^\/assets/, ""),
+			precompressed: true,
 		}),
 	);
 


### PR DESCRIPTION
## Description

Part of the performance stack. The production vite build shipped `app.js` **un-minified** (`minify: false`, carried over from the workspace migration with no rationale) — a 979 KB bundle parsed on the main thread before first interactive paint, served with no compression.

- **Enable esbuild minify** in the production build: 979 KB → 508 KB (~48% on disk).
- **Precompress emitted assets at build time** via an inline `node:zlib` vite plugin (no new dependency): writes `.gz` (gzip 9) and `.br` (brotli 11) siblings for `app.js` + `themes.css` + `tokens.css`.
- **Serve them with `serveStatic({ precompressed: true })`**, so brotli/gzip-capable clients get `app.js.br` (~131 KB, **~87% smaller over the wire**) with the correct `Content-Encoding`, falling back to the raw file otherwise.

IIFE format + global name unchanged; dev-server config untouched; the `.br`/`.gz` live in the gitignored static dir. The minified bundle was verified to bootstrap cleanly (renders, no runtime errors). Code-splitting non-initial surfaces (needs an IIFE→ESM change) is deferred to a follow-up.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
