### PR TITLE
feat(core): raw_events retention config keys + db prune-raw-events CLI

### DIFF
--- a/packages/cli/src/commands/db.test.ts
+++ b/packages/cli/src/commands/db.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
-import { initDatabase } from "@codemem/core";
+import { initDatabase, MemoryStore } from "@codemem/core";
 import { describe, expect, it, vi } from "vitest";
 import { dbCommand } from "./db.js";
 
@@ -76,6 +76,156 @@ describe("db command", () => {
 		expect(aiLongs).toContain("--overwrite");
 		expect(aiLongs).toContain("--dry-run");
 		expect(aiLongs).toContain("--json");
+	});
+
+	it("registers prune-raw-events subcommand with age-based options", () => {
+		const pruneRaw = dbCommand.commands.find((command) => command.name() === "prune-raw-events");
+		expect(pruneRaw).toBeDefined();
+		const longs = pruneRaw?.options.map((option) => option.long) ?? [];
+		expect(longs).toContain("--db-path");
+		expect(longs).toContain("--dry-run");
+		expect(longs).toContain("--max-age-days");
+		expect(longs).toContain("--vacuum");
+		// Age-based only: no size-budget/batch options.
+		expect(longs).not.toContain("--max-size-mb");
+		expect(longs).not.toContain("--batch-ops");
+	});
+
+	function seedRawEvent(store: MemoryStore, sessionId: string, eventId: string, tsWallMs: number) {
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId,
+			eventType: "user_prompt",
+			payload: { type: "user_prompt", prompt_text: `seed ${eventId}` },
+			tsWallMs,
+		});
+	}
+
+	function countRawEvents(dbPath: string): number {
+		const store = new MemoryStore(dbPath);
+		try {
+			const row = store.db.prepare("SELECT COUNT(*) AS cnt FROM raw_events").get() as {
+				cnt: number;
+			};
+			return Number(row.cnt);
+		} finally {
+			store.close();
+		}
+	}
+
+	it("prune-raw-events --dry-run deletes nothing", async () => {
+		const pruneRaw = dbCommand.commands.find((command) => command.name() === "prune-raw-events");
+		expect(pruneRaw).toBeDefined();
+		if (!pruneRaw) throw new Error("expected prune-raw-events command");
+
+		const dbPath = join(mkdtempSync(join(tmpdir(), "codemem-db-prune-raw-")), "test.sqlite");
+		initDatabase(dbPath);
+		const oldTs = Date.now() - 200 * 86_400_000; // well past a 1-day cutoff
+		const store = new MemoryStore(dbPath);
+		seedRawEvent(store, "sess-dry", "evt-0", oldTs);
+		seedRawEvent(store, "sess-dry", "evt-1", oldTs + 1000);
+		store.close();
+		expect(countRawEvents(dbPath)).toBe(2);
+
+		await pruneRaw.parseAsync(
+			["node", "prune-raw-events", "--db-path", dbPath, "--max-age-days", "1", "--dry-run"],
+			{ from: "node" },
+		);
+
+		expect(countRawEvents(dbPath)).toBe(2);
+	});
+
+	it("prune-raw-events deletes events older than the cutoff and keeps newer ones", async () => {
+		const pruneRaw = dbCommand.commands.find((command) => command.name() === "prune-raw-events");
+		expect(pruneRaw).toBeDefined();
+		if (!pruneRaw) throw new Error("expected prune-raw-events command");
+
+		const dbPath = join(mkdtempSync(join(tmpdir(), "codemem-db-prune-raw-")), "test.sqlite");
+		initDatabase(dbPath);
+		const now = Date.now();
+		const store = new MemoryStore(dbPath);
+		// Two old events (older than a 1-day cutoff) and one recent event.
+		seedRawEvent(store, "sess-old", "evt-0", now - 10 * 86_400_000);
+		seedRawEvent(store, "sess-old", "evt-1", now - 5 * 86_400_000);
+		seedRawEvent(store, "sess-new", "evt-2", now - 1000);
+		store.close();
+		expect(countRawEvents(dbPath)).toBe(3);
+
+		await pruneRaw.parseAsync(
+			["node", "prune-raw-events", "--db-path", dbPath, "--max-age-days", "1"],
+			{ from: "node" },
+		);
+
+		// Only the recent event survives.
+		expect(countRawEvents(dbPath)).toBe(1);
+		const store2 = new MemoryStore(dbPath);
+		try {
+			const remaining = store2.db.prepare("SELECT event_id FROM raw_events").all() as Array<{
+				event_id: string;
+			}>;
+			expect(remaining.map((r) => r.event_id)).toEqual(["evt-2"]);
+		} finally {
+			store2.close();
+		}
+	});
+
+	it("prune-raw-events rejects invalid --max-age-days and deletes nothing", async () => {
+		const pruneRaw = dbCommand.commands.find((command) => command.name() === "prune-raw-events");
+		expect(pruneRaw).toBeDefined();
+		if (!pruneRaw) throw new Error("expected prune-raw-events command");
+
+		const dbPath = join(mkdtempSync(join(tmpdir(), "codemem-db-prune-raw-bad-")), "test.sqlite");
+		initDatabase(dbPath);
+		const store = new MemoryStore(dbPath);
+		seedRawEvent(store, "sess-x", "evt-0", Date.now() - 10 * 86_400_000);
+		store.close();
+		expect(countRawEvents(dbPath)).toBe(1);
+
+		const logErrorSpy = vi.spyOn(p.log, "error").mockImplementation(() => {});
+		const originalExitCode = process.exitCode;
+		try {
+			// A mistyped age and an explicit 0 must both be rejected — a destructive
+			// prune must never run on invalid input. Includes partially-numeric
+			// values ("1foo"/"1.5") that Number.parseInt would silently accept as 1.
+			for (const bad of ["foo", "0", "1foo", "1.5", "-1", ""]) {
+				process.exitCode = undefined;
+				await pruneRaw.parseAsync(
+					["node", "prune-raw-events", "--db-path", dbPath, "--max-age-days", bad],
+					{ from: "node" },
+				);
+				expect(process.exitCode).toBe(1);
+				expect(countRawEvents(dbPath)).toBe(1);
+			}
+		} finally {
+			process.exitCode = originalExitCode;
+			logErrorSpy.mockRestore();
+		}
+	});
+
+	it("prune-raw-events reports a clean error (no uncaught throw) on an unreadable DB", async () => {
+		const pruneRaw = dbCommand.commands.find((command) => command.name() === "prune-raw-events");
+		expect(pruneRaw).toBeDefined();
+		if (!pruneRaw) throw new Error("expected prune-raw-events command");
+
+		// A non-SQLite file makes MemoryStore construction throw; the handler must
+		// catch it and set exit code 1 rather than let an uncaught error escape.
+		const badDbPath = join(mkdtempSync(join(tmpdir(), "codemem-db-badopen-")), "not-a.sqlite");
+		writeFileSync(badDbPath, "this is definitely not a sqlite database");
+		const logErrorSpy = vi.spyOn(p.log, "error").mockImplementation(() => {});
+		const originalExitCode = process.exitCode;
+		process.exitCode = undefined;
+		try {
+			await expect(
+				pruneRaw.parseAsync(
+					["node", "prune-raw-events", "--db-path", badDbPath, "--max-age-days", "30"],
+					{ from: "node" },
+				),
+			).resolves.toBeDefined();
+			expect(process.exitCode).toBe(1);
+		} finally {
+			process.exitCode = originalExitCode;
+			logErrorSpy.mockRestore();
+		}
 	});
 
 	it("rejects invalid dedup window input", async () => {

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -211,6 +211,87 @@ pruneReplCmd.action(
 );
 dbCommand.addCommand(pruneReplCmd);
 
+// --- db prune-raw-events ---
+const pruneRawEventsCmd = new Command("prune-raw-events")
+	.configureHelp(helpStyle)
+	.description("Delete raw_events older than a cutoff (age-based), with dry-run and VACUUM support")
+	.option("--dry-run", "show current size/targets without deleting")
+	.option("--max-age-days <days>", "retention age threshold in days", "90")
+	.option("--vacuum", "run VACUUM explicitly after prune completes");
+addDbOption(pruneRawEventsCmd);
+pruneRawEventsCmd.action(
+	(
+		opts: DbOpts & {
+			dryRun?: boolean;
+			maxAgeDays: string;
+			vacuum?: boolean;
+		},
+	) => {
+		// Validate before opening the DB. This is a destructive command and
+		// raw_events are the re-extraction source, so a mistyped/zero age must be
+		// rejected rather than silently coerced to a real purge window. Match the
+		// WHOLE string against digits: Number.parseInt would accept "1foo"/"1.5"
+		// as 1 and proceed to delete.
+		const rawAge = opts.maxAgeDays.trim();
+		const maxAgeDays = Number.parseInt(rawAge, 10);
+		if (!/^\d+$/.test(rawAge) || !Number.isInteger(maxAgeDays) || maxAgeDays < 1) {
+			p.log.error(
+				`--max-age-days must be a positive integer (got "${opts.maxAgeDays}"). ` +
+					"Refusing to run a destructive prune on invalid input.",
+			);
+			process.exitCode = 1;
+			return;
+		}
+		const dbPath = resolveDbPath(resolveDbOpt(opts));
+		// Construct the store inside the guarded block so an unreadable or
+		// schema-incompatible DB surfaces a clean error + exit code rather than an
+		// uncaught throw from the command handler.
+		let store: MemoryStore | null = null;
+		try {
+			store = new MemoryStore(dbPath);
+			const maxAgeMs = maxAgeDays * 86_400_000;
+			const status = store.rawEventsRetentionStatus(maxAgeMs);
+			p.intro("codemem db prune-raw-events");
+			p.log.warn(
+				"raw_events is the re-extraction source. Age-based purge is NOT extraction-aware: " +
+					"pruning a window shorter than your extraction lag can delete un-extracted events. " +
+					"The 90-day default mitigates this.",
+			);
+			p.log.info(
+				`raw_events: ${status.total_rows.toLocaleString()} rows, ~${formatBytes(status.estimated_bytes)} on disk`,
+			);
+			p.log.info(
+				`Older than ${maxAgeDays} day(s): ${status.candidate_rows.toLocaleString()} row(s) to delete`,
+			);
+
+			if (opts.dryRun) {
+				p.outro("Dry run only; no changes made");
+				return;
+			}
+
+			const deleted = store.purgeRawEvents(maxAgeMs);
+			p.log.info(`Deleted raw_events: ${deleted.toLocaleString()}`);
+			if (opts.vacuum) {
+				p.log.step("Running VACUUM as requested...");
+				store.close();
+				store = null;
+				const vacuumed = vacuumDatabase(dbPath);
+				p.outro(`Done. VACUUM complete. File size is now ${formatBytes(vacuumed.sizeBytes)}.`);
+				return;
+			}
+			p.outro(
+				"Done. SQLite file size may not shrink until you run `codemem db vacuum` explicitly (or re-run this command with --vacuum).",
+			);
+		} catch (error) {
+			p.log.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		} finally {
+			store?.close();
+		}
+	},
+);
+dbCommand.addCommand(pruneRawEventsCmd);
+
 // --- db raw-events-status ---
 const rawEventsStatusCmd = new Command("raw-events-status")
 	.configureHelp(helpStyle)

--- a/packages/core/src/coordinator-runtime.test.ts
+++ b/packages/core/src/coordinator-runtime.test.ts
@@ -52,6 +52,59 @@ describe("readCoordinatorSyncConfig.syncOpsLimit", () => {
 	});
 });
 
+describe("readCoordinatorSyncConfig raw-events retention", () => {
+	afterEach(() => {
+		delete process.env.CODEMEM_RAW_EVENTS_RETENTION_ENABLED;
+		delete process.env.CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS;
+	});
+
+	it("defaults to disabled with a 90-day max age when nothing is supplied", () => {
+		const config = readCoordinatorSyncConfig({});
+		expect(config.rawEventsRetentionEnabled).toBe(false);
+		expect(config.rawEventsRetentionMaxAgeDays).toBe(90);
+	});
+
+	it("marks retention configured only when the enabled key is explicitly present", () => {
+		// Absent → not configured (legacy env may still apply downstream).
+		expect(readCoordinatorSyncConfig({}).rawEventsRetentionConfigured).toBe(false);
+		// Explicitly present — true OR false — counts as configured, so an explicit
+		// disable can be treated as authoritative.
+		expect(
+			readCoordinatorSyncConfig({ raw_events_retention_enabled: false })
+				.rawEventsRetentionConfigured,
+		).toBe(true);
+		expect(
+			readCoordinatorSyncConfig({ raw_events_retention_enabled: true })
+				.rawEventsRetentionConfigured,
+		).toBe(true);
+	});
+
+	it("reads enabled + max-age from the config object", () => {
+		const config = readCoordinatorSyncConfig({
+			raw_events_retention_enabled: true,
+			raw_events_retention_max_age_days: 30,
+		});
+		expect(config.rawEventsRetentionEnabled).toBe(true);
+		expect(config.rawEventsRetentionMaxAgeDays).toBe(30);
+	});
+
+	it("honors the env vars over config", () => {
+		process.env.CODEMEM_RAW_EVENTS_RETENTION_ENABLED = "1";
+		process.env.CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS = "45";
+		const config = readCoordinatorSyncConfig({
+			raw_events_retention_enabled: false,
+			raw_events_retention_max_age_days: 10,
+		});
+		expect(config.rawEventsRetentionEnabled).toBe(true);
+		expect(config.rawEventsRetentionMaxAgeDays).toBe(45);
+	});
+
+	it("clamps max-age below 1 up to 1", () => {
+		const config = readCoordinatorSyncConfig({ raw_events_retention_max_age_days: 0 });
+		expect(config.rawEventsRetentionMaxAgeDays).toBe(1);
+	});
+});
+
 describe("advertisedSyncAddresses", () => {
 	it("infers the configured sync port for bare advertised hostnames", () => {
 		const config = readCoordinatorSyncConfig({

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -78,6 +78,11 @@ export interface CoordinatorSyncConfig {
 	syncRetentionIntervalS: number;
 	syncRetentionMaxRuntimeMs: number;
 	syncRetentionMaxOpsPerPass: number;
+	rawEventsRetentionEnabled: boolean;
+	/** Whether raw_events_retention_enabled was explicitly set (file or env), so
+	 * callers can treat an explicit `false` as authoritative over legacy knobs. */
+	rawEventsRetentionConfigured: boolean;
+	rawEventsRetentionMaxAgeDays: number;
 	syncProjectsInclude: string[];
 	syncProjectsExclude: string[];
 	syncOpsLimit: number;
@@ -190,6 +195,12 @@ export function readCoordinatorSyncConfig(config?: ConfigRecord): CoordinatorSyn
 		syncRetentionIntervalS: Math.max(5, parseIntOr(raw.sync_retention_interval_s, 300)),
 		syncRetentionMaxRuntimeMs: Math.max(100, parseIntOr(raw.sync_retention_max_runtime_ms, 2000)),
 		syncRetentionMaxOpsPerPass: Math.max(1, parseIntOr(raw.sync_retention_max_ops_per_pass, 5000)),
+		rawEventsRetentionEnabled: parseBoolOr(raw.raw_events_retention_enabled, false),
+		rawEventsRetentionConfigured: raw.raw_events_retention_enabled !== undefined,
+		rawEventsRetentionMaxAgeDays: Math.max(
+			1,
+			parseIntOr(raw.raw_events_retention_max_age_days, 90),
+		),
 		syncProjectsInclude: parseStringList(raw.sync_projects_include),
 		syncProjectsExclude: parseStringList(raw.sync_projects_exclude),
 		syncOpsLimit: Math.max(1, Math.min(1000, parseIntOr(raw.sync_ops_limit, 500))),

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -77,6 +77,16 @@ describe("connect", () => {
 		expect(sync).toBe(1);
 	});
 
+	it("applies read-tuning pragmas (cache_size, mmap_size, temp_store)", () => {
+		db = connect(join(tmpDir, "test.sqlite"));
+		expect(db.pragma("cache_size", { simple: true })).toBe(-65536);
+		// mmap_size readback is clamped to the build's SQLITE_MAX_MMAP_SIZE, so
+		// assert it's enabled (>0) rather than an exact, build-dependent value.
+		expect(db.pragma("mmap_size", { simple: true })).toBeGreaterThan(0);
+		// temp_store: 2 = MEMORY
+		expect(db.pragma("temp_store", { simple: true })).toBe(2);
+	});
+
 	it("creates parent directories if they don't exist", () => {
 		const nested = join(tmpDir, "deep", "nested", "dir", "test.sqlite");
 		db = connect(nested);

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -87,6 +87,26 @@ describe("connect", () => {
 		expect(db.pragma("temp_store", { simple: true })).toBe(2);
 	});
 
+	it("drops legacy memory_items indexes via additive compatibility", () => {
+		db = connect(join(tmpDir, "legacy-idx.sqlite"));
+		// Simulate a database created by an older schema that carried the
+		// now-obsolete indexes the current schema never creates.
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_memory_items_visibility ON memory_items(visibility);
+			 CREATE INDEX IF NOT EXISTS idx_memory_items_workspace_kind ON memory_items(workspace_kind);
+			 CREATE INDEX IF NOT EXISTS idx_memory_items_user_prompt_id ON memory_items(user_prompt_id);`,
+		);
+		expect(hasIndex(db, "idx_memory_items_visibility")).toBe(true);
+
+		ensureAdditiveSchemaCompatibility(db);
+
+		expect(hasIndex(db, "idx_memory_items_visibility")).toBe(false);
+		expect(hasIndex(db, "idx_memory_items_workspace_kind")).toBe(false);
+		expect(hasIndex(db, "idx_memory_items_user_prompt_id")).toBe(false);
+		// A composite index that legitimately covers visibility still exists.
+		expect(hasIndex(db, "idx_memory_items_scope_visibility_created")).toBe(true);
+	});
+
 	it("creates parent directories if they don't exist", () => {
 		const nested = join(tmpDir, "deep", "nested", "dir", "test.sqlite");
 		db = connect(nested);

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -96,6 +96,10 @@ describe("connect", () => {
 			 CREATE INDEX IF NOT EXISTS idx_memory_items_workspace_kind ON memory_items(workspace_kind);
 			 CREATE INDEX IF NOT EXISTS idx_memory_items_user_prompt_id ON memory_items(user_prompt_id);`,
 		);
+		// Drop back to a legacy user_version so the additive shim actually runs
+		// (a fresh user_version=SCHEMA_VERSION DB short-circuits the gated DDL,
+		// and never carries these legacy indexes in the first place).
+		db.pragma("user_version = 6");
 		expect(hasIndex(db, "idx_memory_items_visibility")).toBe(true);
 
 		ensureAdditiveSchemaCompatibility(db);
@@ -532,6 +536,10 @@ describe("ensureAdditiveSchemaCompatibility", () => {
 		let alterAttempts = 0;
 
 		const fakeDb = {
+			// Legacy user_version so the additive shim runs (does not short-circuit).
+			pragma() {
+				return 0;
+			},
 			prepare(query: string) {
 				return {
 					get(...args: unknown[]) {
@@ -1002,6 +1010,143 @@ describe("ensureAdditiveSchemaCompatibility", () => {
 			.prepare("SELECT session_id, project FROM memory_items ORDER BY session_id")
 			.all() as Array<{ session_id: number; project: string | null }>;
 		expect(rows2).toEqual(rows);
+	});
+});
+
+describe("ensureAdditiveSchemaCompatibility schema-compat gate", () => {
+	let tmpDir: string;
+	let db: Database;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
+		// connect() bootstraps a full schema at user_version=SCHEMA_VERSION.
+		db = connect(join(tmpDir, "test.sqlite"));
+	});
+
+	afterEach(() => {
+		db?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function appliedSchemaVersion(database: Database): number | undefined {
+		const row = database
+			.prepare("SELECT applied_schema_version AS v FROM schema_compat_state WHERE id = 1")
+			.get() as { v: number } | undefined;
+		return row?.v;
+	}
+
+	it("applies and marks the schema-compat state on a legacy database", () => {
+		// Simulate a legacy DB so the version short-circuit does not fire.
+		db.pragma("user_version = 6");
+		expect(tableExists(db, "schema_compat_state")).toBe(false);
+
+		ensureAdditiveSchemaCompatibility(db);
+
+		expect(tableExists(db, "schema_compat_state")).toBe(true);
+		expect(appliedSchemaVersion(db)).toBe(SCHEMA_VERSION);
+	});
+
+	it("skips gated DDL once marked and re-applies on version mismatch", () => {
+		db.pragma("user_version = 6");
+		ensureAdditiveSchemaCompatibility(db);
+		expect(hasIndex(db, "idx_memory_items_project")).toBe(true);
+
+		// Drop an additive index. Because the marker now says applied-for-this
+		// version, the next call must skip the gated DDL and NOT recreate it.
+		db.exec("DROP INDEX idx_memory_items_project");
+		expect(hasIndex(db, "idx_memory_items_project")).toBe(false);
+		ensureAdditiveSchemaCompatibility(db);
+		expect(hasIndex(db, "idx_memory_items_project")).toBe(false);
+
+		// Roll the marker back to simulate an older/again-needed schema; the gated
+		// DDL must re-run and recreate the index.
+		db.exec("UPDATE schema_compat_state SET applied_schema_version = 0");
+		ensureAdditiveSchemaCompatibility(db);
+		expect(hasIndex(db, "idx_memory_items_project")).toBe(true);
+		expect(appliedSchemaVersion(db)).toBe(SCHEMA_VERSION);
+	});
+
+	it("runs the project backfill even when gated DDL is skipped", () => {
+		db.pragma("user_version = 6");
+		// First call marks the schema-compat state so the next open is gated.
+		ensureAdditiveSchemaCompatibility(db);
+
+		const now = new Date().toISOString();
+		db.prepare(
+			"INSERT INTO sessions(id, started_at, cwd, project) VALUES (1, ?, '/work/codemem', 'codemem')",
+		).run(now);
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, project)
+			 VALUES (1, 'discovery', 'a', 'b', ?, ?, NULL)`,
+		).run(now, now);
+
+		// This open is gated (DDL skipped) but the backfill must still run.
+		ensureAdditiveSchemaCompatibility(db);
+
+		const row = db.prepare("SELECT project FROM memory_items WHERE session_id = 1").get() as {
+			project: string | null;
+		};
+		expect(row.project).toBe("codemem");
+	});
+
+	it("applies and marks on a fresh DB (gate is marker-only, not user_version)", () => {
+		// A freshly bootstrapped DB is at user_version=SCHEMA_VERSION, but the gate
+		// keys on the marker, not the version: the shim runs once (its statements
+		// are all idempotent no-ops here) and records the marker.
+		expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+		expect(tableExists(db, "schema_compat_state")).toBe(false);
+		ensureAdditiveSchemaCompatibility(db);
+		expect(tableExists(db, "schema_compat_state")).toBe(true);
+		expect(appliedSchemaVersion(db)).toBe(SCHEMA_VERSION);
+	});
+
+	it("re-adds a missing additive column even at user_version=SCHEMA_VERSION", () => {
+		// Regression: additive columns (e.g. memory_items.project) were added over
+		// time WITHOUT bumping SCHEMA_VERSION, so a DB can report
+		// user_version=SCHEMA_VERSION yet still lack one. Gating on user_version
+		// would skip the shim and leave the column missing, breaking inserts that
+		// reference it. The marker-only gate must still repair it.
+		expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+		db.exec("DROP INDEX IF EXISTS idx_memory_items_project");
+		db.exec("ALTER TABLE memory_items DROP COLUMN project");
+		expect(columnExists(db, "memory_items", "project")).toBe(false);
+
+		// No marker exists, so the shim runs despite user_version=SCHEMA_VERSION.
+		ensureAdditiveSchemaCompatibility(db);
+
+		expect(columnExists(db, "memory_items", "project")).toBe(true);
+		expect(hasIndex(db, "idx_memory_items_project")).toBe(true);
+		expect(appliedSchemaVersion(db)).toBe(SCHEMA_VERSION);
+	});
+
+	it("schemaCompatAlreadyApplied-style probe is fail-safe without the table", () => {
+		// On a DB lacking schema_compat_state, a legacy open must still apply the
+		// shim (the gate returns false on the missing table rather than skipping).
+		const legacy = new BetterSqlite3(join(tmpDir, "legacy.sqlite"));
+		try {
+			legacy.exec(`
+				CREATE TABLE memory_items (
+					id INTEGER PRIMARY KEY,
+					session_id INTEGER NOT NULL,
+					kind TEXT NOT NULL,
+					title TEXT NOT NULL,
+					body_text TEXT NOT NULL,
+					visibility TEXT,
+					workspace_id TEXT,
+					active INTEGER DEFAULT 1,
+					created_at TEXT NOT NULL,
+					updated_at TEXT NOT NULL
+				)
+			`);
+			// user_version defaults to 0 (legacy) and schema_compat_state is absent.
+			expect(tableExists(legacy, "schema_compat_state")).toBe(false);
+			expect(() => ensureAdditiveSchemaCompatibility(legacy)).not.toThrow();
+			// The shim ran (fail-safe gate), creating + marking the state table.
+			expect(tableExists(legacy, "schema_compat_state")).toBe(true);
+			expect(columnExists(legacy, "memory_items", "project")).toBe(true);
+		} finally {
+			legacy.close();
+		}
 	});
 });
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -513,16 +513,106 @@ function addColumnIfMissing(
 }
 
 /**
+ * Has the additive compatibility shim already run for the current SCHEMA_VERSION?
+ *
+ * Fail-safe: returns false on any error (including a missing
+ * `schema_compat_state` table) so the shim re-runs rather than skipping needed
+ * additive DDL on uncertainty. Keyed on SCHEMA_VERSION so a future runtime with
+ * a higher SCHEMA_VERSION (and new additive DDL) sees the older marker and
+ * re-applies.
+ */
+function schemaCompatAlreadyApplied(db: DatabaseType): boolean {
+	try {
+		const row = db
+			.prepare("SELECT applied_schema_version AS v FROM schema_compat_state WHERE id = 1 LIMIT 1")
+			.get() as { v: number } | undefined;
+		return typeof row?.v === "number" && row.v >= SCHEMA_VERSION;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Record that the additive compatibility shim has been applied for the current
+ * SCHEMA_VERSION. Fail-open: a failed mark just means the shim re-runs on the
+ * next open, which is harmless because the DDL is idempotent.
+ */
+function markSchemaCompatApplied(db: DatabaseType): void {
+	try {
+		db.prepare(
+			`INSERT INTO schema_compat_state(id, applied_schema_version, applied_at)
+			 VALUES (1, ?, ?)
+			 ON CONFLICT(id) DO UPDATE SET
+				 applied_schema_version = excluded.applied_schema_version,
+				 applied_at = excluded.applied_at`,
+		).run(SCHEMA_VERSION, new Date().toISOString());
+	} catch {
+		// Fail-open: a missed mark only costs one extra idempotent re-run.
+	}
+}
+
+/**
+ * Backfill the denormalized memory_items.project column from sessions.project.
+ *
+ * Runs on EVERY store open (not gated behind the schema-compat marker) because
+ * moveMemoryProject edits sessions.project and relies on this backfill plus a
+ * reader-fallback to propagate the new project to legacy rows whose project is
+ * still NULL. Idempotent — only touches rows where project IS NULL.
+ */
+function backfillMemoryItemProject(db: DatabaseType): void {
+	try {
+		db.exec(`UPDATE memory_items
+			 SET project = (
+				 SELECT s.project FROM sessions s
+				 WHERE s.id = memory_items.session_id
+			 )
+			 WHERE project IS NULL`);
+	} catch {
+		// Best-effort backfill — readers fall back to sessions.project
+		// when memory_items.project is null.
+	}
+}
+
+/**
  * Apply additive compatibility fixes for legacy TS-era schemas.
  *
  * These are safe, one-way `ALTER TABLE ... ADD COLUMN` updates used to
  * prevent runtime failures when older local databases are missing columns
  * introduced in later releases.
+ *
+ * The ~39 idempotent DDL statements are gated behind a `schema_compat_state`
+ * marker so steady-state opens skip them: each database runs the shim once
+ * (idempotent — a fresh DB's statements are all no-ops), records the marker,
+ * and skips thereafter. We deliberately do NOT short-circuit on
+ * `user_version >= SCHEMA_VERSION`: additive columns (e.g. memory_items.project)
+ * have been added over time WITHOUT bumping SCHEMA_VERSION, so a database can
+ * report user_version=SCHEMA_VERSION yet still lack a column the shim adds —
+ * the version is not proof the shim ran. Only the marker is. The project
+ * backfill still runs on every open regardless of the gate.
  */
 export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
-	try {
-		db.exec(`
-			CREATE TABLE IF NOT EXISTS sync_reset_state (
+	const compatAlreadyApplied = schemaCompatAlreadyApplied(db);
+	if (!compatAlreadyApplied) {
+		// IMPORTANT: any NEW DDL added to this gated block REQUIRES bumping
+		// SCHEMA_VERSION. The "already applied" marker keys on SCHEMA_VERSION, so
+		// without a bump, legacy DBs already marked at the current version would
+		// skip the new DDL forever.
+		// Marker table must exist before we can mark; create it first.
+		try {
+			db.exec(`
+				CREATE TABLE IF NOT EXISTS schema_compat_state (
+					id INTEGER PRIMARY KEY CHECK (id = 1),
+					applied_schema_version INTEGER NOT NULL,
+					applied_at TEXT NOT NULL
+				)
+			`);
+		} catch {
+			// Keep compatibility shim fail-open for the marker table.
+		}
+
+		try {
+			db.exec(`
+				CREATE TABLE IF NOT EXISTS sync_reset_state (
 				id INTEGER PRIMARY KEY,
 				generation INTEGER NOT NULL,
 				snapshot_id TEXT NOT NULL,
@@ -531,12 +621,12 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 				updated_at TEXT NOT NULL
 			)
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive tables.
-	}
+		} catch {
+			// Keep compatibility shim fail-open for optional additive tables.
+		}
 
-	try {
-		db.exec(`
+		try {
+			db.exec(`
 			CREATE TABLE IF NOT EXISTS sync_scope_rejections (
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
 				peer_device_id TEXT,
@@ -552,12 +642,12 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 			CREATE INDEX IF NOT EXISTS idx_sync_scope_rejections_scope_created
 				ON sync_scope_rejections(scope_id, created_at);
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive diagnostics.
-	}
+		} catch {
+			// Keep compatibility shim fail-open for optional additive diagnostics.
+		}
 
-	try {
-		db.exec(`
+		try {
+			db.exec(`
 			CREATE TABLE IF NOT EXISTS sync_reset_state_v2 (
 				scope_id TEXT PRIMARY KEY NOT NULL,
 				generation INTEGER NOT NULL,
@@ -590,27 +680,27 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 			CREATE INDEX IF NOT EXISTS idx_replication_cursors_v2_scope
 				ON replication_cursors_v2(scope_id);
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive tables.
-	}
+		} catch {
+			// Keep compatibility shim fail-open for optional additive tables.
+		}
 
-	if (tableExists(db, "sync_reset_state") && tableExists(db, "sync_reset_state_v2")) {
-		try {
-			db.exec(`
+		if (tableExists(db, "sync_reset_state") && tableExists(db, "sync_reset_state_v2")) {
+			try {
+				db.exec(`
 				INSERT OR IGNORE INTO sync_reset_state_v2
 					(scope_id, generation, snapshot_id, baseline_cursor, retained_floor_cursor, updated_at)
 				SELECT 'local-default', generation, snapshot_id, baseline_cursor, retained_floor_cursor, updated_at
 				FROM sync_reset_state
 				WHERE id = 1
 			`);
-		} catch {
-			// Best-effort bridge from legacy singleton state.
+			} catch {
+				// Best-effort bridge from legacy singleton state.
+			}
 		}
-	}
 
-	if (tableExists(db, "sync_retention_state") && tableExists(db, "sync_retention_state_v2")) {
-		try {
-			db.exec(`
+		if (tableExists(db, "sync_retention_state") && tableExists(db, "sync_retention_state_v2")) {
+			try {
+				db.exec(`
 				INSERT OR IGNORE INTO sync_retention_state_v2
 					(
 						scope_id,
@@ -636,132 +726,120 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 				FROM sync_retention_state
 				WHERE id = 1
 			`);
-		} catch {
-			// Best-effort bridge from legacy singleton state.
+			} catch {
+				// Best-effort bridge from legacy singleton state.
+			}
 		}
-	}
 
-	if (tableExists(db, "replication_cursors") && tableExists(db, "replication_cursors_v2")) {
-		try {
-			db.exec(`
+		if (tableExists(db, "replication_cursors") && tableExists(db, "replication_cursors_v2")) {
+			try {
+				db.exec(`
 				INSERT OR IGNORE INTO replication_cursors_v2
 					(peer_device_id, scope_id, last_applied_cursor, last_acked_cursor, updated_at)
 				SELECT peer_device_id, 'local-default', last_applied_cursor, last_acked_cursor, updated_at
 				FROM replication_cursors
 			`);
-		} catch {
-			// Best-effort bridge from legacy peer-level cursors.
+			} catch {
+				// Best-effort bridge from legacy peer-level cursors.
+			}
 		}
-	}
 
-	// Add phase column to sync_daemon_state for rebootstrap safety gate.
-	if (tableExists(db, "sync_daemon_state") && !columnExists(db, "sync_daemon_state", "phase")) {
-		try {
-			db.exec("ALTER TABLE sync_daemon_state ADD COLUMN phase TEXT");
-		} catch {
-			// Race-safe: another process may have added it first.
-		}
-	}
-
-	if (tableExists(db, "memory_items")) {
-		if (!columnExists(db, "memory_items", "dedup_key")) {
+		// Add phase column to sync_daemon_state for rebootstrap safety gate.
+		if (tableExists(db, "sync_daemon_state") && !columnExists(db, "sync_daemon_state", "phase")) {
 			try {
-				db.exec("ALTER TABLE memory_items ADD COLUMN dedup_key TEXT");
-			} catch (err) {
-				const message = err instanceof Error ? err.message.toLowerCase() : "";
-				const duplicateColumn = message.includes("duplicate column name");
-				if (!(duplicateColumn && columnExists(db, "memory_items", "dedup_key"))) {
-					throw err;
+				db.exec("ALTER TABLE sync_daemon_state ADD COLUMN phase TEXT");
+			} catch {
+				// Race-safe: another process may have added it first.
+			}
+		}
+
+		if (tableExists(db, "memory_items")) {
+			if (!columnExists(db, "memory_items", "dedup_key")) {
+				try {
+					db.exec("ALTER TABLE memory_items ADD COLUMN dedup_key TEXT");
+				} catch (err) {
+					const message = err instanceof Error ? err.message.toLowerCase() : "";
+					const duplicateColumn = message.includes("duplicate column name");
+					if (!(duplicateColumn && columnExists(db, "memory_items", "dedup_key"))) {
+						throw err;
+					}
 				}
+			}
+
+			try {
+				db.exec(
+					"CREATE INDEX IF NOT EXISTS idx_memory_items_dedup_key_active_created ON memory_items(dedup_key, active, created_at)",
+				);
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
+			}
+
+			try {
+				db.exec(
+					"CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_items_same_session_dedup_unique ON memory_items(session_id, kind, visibility, workspace_id, dedup_key) WHERE active = 1 AND dedup_key IS NOT NULL",
+				);
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
+			}
+
+			addColumnIfMissing(db, "memory_items", "scope_id", "TEXT");
+			try {
+				db.exec(
+					"CREATE INDEX IF NOT EXISTS idx_memory_items_scope_visibility_created ON memory_items(scope_id, visibility, created_at)",
+				);
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
+			}
+			try {
+				db.exec(
+					"CREATE INDEX IF NOT EXISTS idx_memory_items_scope_backfill_pending ON memory_items(id) WHERE scope_id IS NULL OR scope_id = ''",
+				);
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
+			}
+
+			// Denormalized project column: created here so the Projects read model can
+			// read directly from memory_items without joining through sessions (which
+			// carry device-local cwd and don't replicate). The actual NULL backfill
+			// runs unconditionally via backfillMemoryItemProject() on every open below.
+			addColumnIfMissing(db, "memory_items", "project", "TEXT");
+			try {
+				db.exec("CREATE INDEX IF NOT EXISTS idx_memory_items_project ON memory_items(project)");
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
+			}
+
+			// Drop legacy memory_items indexes that no longer back any query, only
+			// adding write amplification on databases created by older schemas. The
+			// current schema never creates these. `visibility`/`workspace_kind` are
+			// low-cardinality and only ever appear as secondary predicates already
+			// covered by composite indexes (e.g. idx_memory_items_scope_visibility_created,
+			// idx_memory_items_same_session_dedup_unique); `user_prompt_id` is unused
+			// as a filter (and is all-NULL in practice).
+			try {
+				db.exec(
+					`DROP INDEX IF EXISTS idx_memory_items_visibility;
+				 DROP INDEX IF EXISTS idx_memory_items_workspace_kind;
+				 DROP INDEX IF EXISTS idx_memory_items_user_prompt_id;`,
+				);
+			} catch {
+				// Best-effort cleanup of legacy indexes.
+			}
+		}
+
+		if (tableExists(db, "replication_ops")) {
+			addColumnIfMissing(db, "replication_ops", "scope_id", "TEXT");
+			try {
+				db.exec(
+					"CREATE INDEX IF NOT EXISTS idx_replication_ops_scope_created ON replication_ops(scope_id, created_at, op_id)",
+				);
+			} catch {
+				// Keep additive compatibility best-effort for index creation.
 			}
 		}
 
 		try {
-			db.exec(
-				"CREATE INDEX IF NOT EXISTS idx_memory_items_dedup_key_active_created ON memory_items(dedup_key, active, created_at)",
-			);
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-
-		try {
-			db.exec(
-				"CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_items_same_session_dedup_unique ON memory_items(session_id, kind, visibility, workspace_id, dedup_key) WHERE active = 1 AND dedup_key IS NOT NULL",
-			);
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-
-		addColumnIfMissing(db, "memory_items", "scope_id", "TEXT");
-		try {
-			db.exec(
-				"CREATE INDEX IF NOT EXISTS idx_memory_items_scope_visibility_created ON memory_items(scope_id, visibility, created_at)",
-			);
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-		try {
-			db.exec(
-				"CREATE INDEX IF NOT EXISTS idx_memory_items_scope_backfill_pending ON memory_items(id) WHERE scope_id IS NULL OR scope_id = ''",
-			);
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-
-		// Denormalized project column: backfill from sessions.project for legacy
-		// rows so the Projects read model can read directly from memory_items
-		// without joining through sessions (which carry device-local cwd and
-		// don't replicate). Idempotent — only backfills rows whose project is
-		// currently NULL, so re-runs are no-ops.
-		addColumnIfMissing(db, "memory_items", "project", "TEXT");
-		try {
-			db.exec(`UPDATE memory_items
-				 SET project = (
-					 SELECT s.project FROM sessions s
-					 WHERE s.id = memory_items.session_id
-				 )
-				 WHERE project IS NULL`);
-		} catch {
-			// Best-effort backfill — readers fall back to sessions.project
-			// when memory_items.project is null.
-		}
-		try {
-			db.exec("CREATE INDEX IF NOT EXISTS idx_memory_items_project ON memory_items(project)");
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-
-		// Drop legacy memory_items indexes that no longer back any query, only
-		// adding write amplification on databases created by older schemas. The
-		// current schema never creates these. `visibility`/`workspace_kind` are
-		// low-cardinality and only ever appear as secondary predicates already
-		// covered by composite indexes (e.g. idx_memory_items_scope_visibility_created,
-		// idx_memory_items_same_session_dedup_unique); `user_prompt_id` is unused
-		// as a filter (and is all-NULL in practice).
-		try {
-			db.exec(
-				`DROP INDEX IF EXISTS idx_memory_items_visibility;
-				 DROP INDEX IF EXISTS idx_memory_items_workspace_kind;
-				 DROP INDEX IF EXISTS idx_memory_items_user_prompt_id;`,
-			);
-		} catch {
-			// Best-effort cleanup of legacy indexes.
-		}
-	}
-
-	if (tableExists(db, "replication_ops")) {
-		addColumnIfMissing(db, "replication_ops", "scope_id", "TEXT");
-		try {
-			db.exec(
-				"CREATE INDEX IF NOT EXISTS idx_replication_ops_scope_created ON replication_ops(scope_id, created_at, op_id)",
-			);
-		} catch {
-			// Keep additive compatibility best-effort for index creation.
-		}
-	}
-
-	try {
-		db.exec(`
+			db.exec(`
 			CREATE TABLE IF NOT EXISTS replication_scopes (
 				scope_id TEXT PRIMARY KEY NOT NULL,
 				label TEXT NOT NULL,
@@ -829,14 +907,14 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 				PRIMARY KEY (coordinator_id, group_id)
 			);
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive scope metadata.
-	}
+		} catch {
+			// Keep compatibility shim fail-open for optional additive scope metadata.
+		}
 
-	// Junction tables for structured file/concept references on memories.
-	// Added in schema v7; existing v6 databases need these created additively.
-	try {
-		db.exec(`
+		// Junction tables for structured file/concept references on memories.
+		// Added in schema v7; existing v6 databases need these created additively.
+		try {
+			db.exec(`
 			CREATE TABLE IF NOT EXISTS memory_file_refs (
 				memory_id INTEGER NOT NULL,
 				file_path TEXT NOT NULL,
@@ -854,47 +932,50 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 			);
 			CREATE INDEX IF NOT EXISTS idx_memory_concept_refs_concept ON memory_concept_refs(concept);
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive tables.
-	}
+		} catch {
+			// Keep compatibility shim fail-open for optional additive tables.
+		}
 
-	// Multi-team coordinator groups (v1) — additive columns + preferences table.
-	// Existing databases acquire these so peer enrollment can record the group
-	// it came from, and so per-group scope templates can be stored locally.
-	if (tableExists(db, "sync_peers")) {
-		for (const name of ["discovered_via_coordinator_id", "discovered_via_group_id"]) {
-			if (columnExists(db, "sync_peers", name)) continue;
-			try {
-				db.exec(`ALTER TABLE sync_peers ADD COLUMN ${name} TEXT`);
-			} catch (err) {
-				const message = err instanceof Error ? err.message.toLowerCase() : "";
-				if (message.includes("duplicate column name") && columnExists(db, "sync_peers", name)) {
-					continue;
+		// Multi-team coordinator groups (v1) — additive columns + preferences table.
+		// Existing databases acquire these so peer enrollment can record the group
+		// it came from, and so per-group scope templates can be stored locally.
+		if (tableExists(db, "sync_peers")) {
+			for (const name of ["discovered_via_coordinator_id", "discovered_via_group_id"]) {
+				if (columnExists(db, "sync_peers", name)) continue;
+				try {
+					db.exec(`ALTER TABLE sync_peers ADD COLUMN ${name} TEXT`);
+				} catch (err) {
+					const message = err instanceof Error ? err.message.toLowerCase() : "";
+					if (message.includes("duplicate column name") && columnExists(db, "sync_peers", name)) {
+						continue;
+					}
+					throw err;
 				}
-				throw err;
 			}
 		}
-	}
-	if (tableExists(db, "sync_attempts")) {
-		for (const name of [
-			"local_sync_capability",
-			"peer_sync_capability",
-			"negotiated_sync_capability",
-		]) {
-			if (columnExists(db, "sync_attempts", name)) continue;
-			try {
-				db.exec(`ALTER TABLE sync_attempts ADD COLUMN ${name} TEXT`);
-			} catch (err) {
-				const message = err instanceof Error ? err.message.toLowerCase() : "";
-				if (message.includes("duplicate column name") && columnExists(db, "sync_attempts", name)) {
-					continue;
+		if (tableExists(db, "sync_attempts")) {
+			for (const name of [
+				"local_sync_capability",
+				"peer_sync_capability",
+				"negotiated_sync_capability",
+			]) {
+				if (columnExists(db, "sync_attempts", name)) continue;
+				try {
+					db.exec(`ALTER TABLE sync_attempts ADD COLUMN ${name} TEXT`);
+				} catch (err) {
+					const message = err instanceof Error ? err.message.toLowerCase() : "";
+					if (
+						message.includes("duplicate column name") &&
+						columnExists(db, "sync_attempts", name)
+					) {
+						continue;
+					}
+					throw err;
 				}
-				throw err;
 			}
 		}
-	}
-	try {
-		db.exec(`
+		try {
+			db.exec(`
 			CREATE TABLE IF NOT EXISTS coordinator_group_preferences (
 				coordinator_id TEXT NOT NULL,
 				group_id TEXT NOT NULL,
@@ -907,52 +988,59 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 				PRIMARY KEY (coordinator_id, group_id)
 			)
 		`);
-	} catch {
-		// Keep compatibility shim fail-open for optional additive tables.
-	}
-	for (const { name, ddl } of [
-		{ name: "default_space_scope_id", ddl: "TEXT" },
-		{ name: "auto_grant_default_space_on_join", ddl: "INTEGER NOT NULL DEFAULT 0" },
-	]) {
-		if (columnExists(db, "coordinator_group_preferences", name)) continue;
-		try {
-			db.exec(`ALTER TABLE coordinator_group_preferences ADD COLUMN ${name} ${ddl}`);
-		} catch (err) {
-			const message = err instanceof Error ? err.message.toLowerCase() : "";
-			if (message.includes("duplicate column name")) continue;
-			throw err;
+		} catch {
+			// Keep compatibility shim fail-open for optional additive tables.
 		}
-	}
-
-	if (!tableExists(db, "raw_event_flush_batches")) return;
-
-	const additiveColumns: Array<{ name: string; ddl: string }> = [
-		{ name: "error_message", ddl: "TEXT" },
-		{ name: "error_type", ddl: "TEXT" },
-		{ name: "observer_provider", ddl: "TEXT" },
-		{ name: "observer_model", ddl: "TEXT" },
-		{ name: "observer_runtime", ddl: "TEXT" },
-		{ name: "observer_auth_source", ddl: "TEXT" },
-		{ name: "observer_auth_type", ddl: "TEXT" },
-		{ name: "observer_error_code", ddl: "TEXT" },
-		{ name: "observer_error_message", ddl: "TEXT" },
-		{ name: "attempt_count", ddl: "INTEGER NOT NULL DEFAULT 0" },
-	];
-
-	for (const { name, ddl } of additiveColumns) {
-		if (columnExists(db, "raw_event_flush_batches", name)) continue;
-		try {
-			db.exec(`ALTER TABLE raw_event_flush_batches ADD COLUMN ${name} ${ddl}`);
-		} catch (err) {
-			const message = err instanceof Error ? err.message.toLowerCase() : "";
-			const duplicateColumn = message.includes("duplicate column name");
-			if (duplicateColumn && columnExists(db, "raw_event_flush_batches", name)) {
-				// Another process may have raced and added the column first.
-				continue;
+		for (const { name, ddl } of [
+			{ name: "default_space_scope_id", ddl: "TEXT" },
+			{ name: "auto_grant_default_space_on_join", ddl: "INTEGER NOT NULL DEFAULT 0" },
+		]) {
+			if (columnExists(db, "coordinator_group_preferences", name)) continue;
+			try {
+				db.exec(`ALTER TABLE coordinator_group_preferences ADD COLUMN ${name} ${ddl}`);
+			} catch (err) {
+				const message = err instanceof Error ? err.message.toLowerCase() : "";
+				if (message.includes("duplicate column name")) continue;
+				throw err;
 			}
-			throw err;
 		}
+
+		if (tableExists(db, "raw_event_flush_batches")) {
+			const additiveColumns: Array<{ name: string; ddl: string }> = [
+				{ name: "error_message", ddl: "TEXT" },
+				{ name: "error_type", ddl: "TEXT" },
+				{ name: "observer_provider", ddl: "TEXT" },
+				{ name: "observer_model", ddl: "TEXT" },
+				{ name: "observer_runtime", ddl: "TEXT" },
+				{ name: "observer_auth_source", ddl: "TEXT" },
+				{ name: "observer_auth_type", ddl: "TEXT" },
+				{ name: "observer_error_code", ddl: "TEXT" },
+				{ name: "observer_error_message", ddl: "TEXT" },
+				{ name: "attempt_count", ddl: "INTEGER NOT NULL DEFAULT 0" },
+			];
+
+			for (const { name, ddl } of additiveColumns) {
+				if (columnExists(db, "raw_event_flush_batches", name)) continue;
+				try {
+					db.exec(`ALTER TABLE raw_event_flush_batches ADD COLUMN ${name} ${ddl}`);
+				} catch (err) {
+					const message = err instanceof Error ? err.message.toLowerCase() : "";
+					const duplicateColumn = message.includes("duplicate column name");
+					if (duplicateColumn && columnExists(db, "raw_event_flush_batches", name)) {
+						// Another process may have raced and added the column first.
+						continue;
+					}
+					throw err;
+				}
+			}
+		}
+
+		markSchemaCompatApplied(db);
 	}
+
+	// Always runs (not gated): moveMemoryProject relies on this backfill +
+	// reader-fallback to propagate sessions.project edits to legacy NULL rows.
+	backfillMemoryItemProject(db);
 }
 
 /** Safely parse a JSON string, returning {} on failure. */

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -218,6 +218,15 @@ export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 
 		db.pragma("synchronous = NORMAL");
 
+		// Read tuning for large (multi-GB) databases. The SQLite defaults — a
+		// ~2 MiB page cache and no mmap — force repeated disk/page-cache reads of
+		// B-tree interior pages on every non-trivial query. A 64 MiB cache, 1 GiB
+		// memory-mapped I/O, and in-memory temp B-trees cut that cost. These are
+		// per-connection and must be set here (they do not persist in the file).
+		db.pragma("cache_size = -65536");
+		db.pragma("mmap_size = 1073741824");
+		db.pragma("temp_store = MEMORY");
+
 		return db;
 	} catch (error) {
 		db.close();

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -730,6 +730,23 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 		} catch {
 			// Keep additive compatibility best-effort for index creation.
 		}
+
+		// Drop legacy memory_items indexes that no longer back any query, only
+		// adding write amplification on databases created by older schemas. The
+		// current schema never creates these. `visibility`/`workspace_kind` are
+		// low-cardinality and only ever appear as secondary predicates already
+		// covered by composite indexes (e.g. idx_memory_items_scope_visibility_created,
+		// idx_memory_items_same_session_dedup_unique); `user_prompt_id` is unused
+		// as a filter (and is all-NULL in practice).
+		try {
+			db.exec(
+				`DROP INDEX IF EXISTS idx_memory_items_visibility;
+				 DROP INDEX IF EXISTS idx_memory_items_workspace_kind;
+				 DROP INDEX IF EXISTS idx_memory_items_user_prompt_id;`,
+			);
+		} catch {
+			// Best-effort cleanup of legacy indexes.
+		}
 	}
 
 	if (tableExists(db, "replication_ops")) {

--- a/packages/core/src/filters.ts
+++ b/packages/core/src/filters.ts
@@ -6,7 +6,11 @@
  */
 
 import { projectClause } from "./project.js";
-import { LOCAL_DEFAULT_SCOPE_ID } from "./scope-resolution.js";
+import {
+	LEGACY_SHARED_REVIEW_SCOPE_ID,
+	LOCAL_DEFAULT_SCOPE_ID,
+	MAX_SCOPE_IN_PARAMS,
+} from "./scope-resolution.js";
 import type { MemoryFilters } from "./types.js";
 
 export interface OwnershipFilterContext {
@@ -21,6 +25,15 @@ export interface OwnershipFilterContext {
 	 * invariant.
 	 */
 	enforceScopeVisibility?: boolean;
+	/**
+	 * Pre-resolved set of scope_ids this device may read (see
+	 * `resolveVisibleScopeIds` in scope-resolution.ts). When present, scope visibility is
+	 * enforced with an index-eligible `scope_id IN (...)` predicate instead of
+	 * the per-row EXISTS subqueries. Callers that cannot resolve the set up front
+	 * (e.g. a context built without db access) omit it and fall back to the
+	 * EXISTS predicate, which is semantically identical.
+	 */
+	visibleScopeIds?: readonly string[];
 }
 
 export interface FilterResult {
@@ -93,8 +106,6 @@ function addMultiValueFilter(
 		params.push(...excludeValues);
 	}
 }
-
-const LEGACY_SHARED_REVIEW_SCOPE_ID = "legacy-shared-review";
 
 function cleanUniqueStrings(value: string[] | undefined): string[] {
 	return [...new Set((value ?? []).map((item) => item.trim()).filter(Boolean))];
@@ -170,6 +181,30 @@ function addScopeVisibilityFilter(
 	// Migration backfill promotes legacy rows to explicit scopes asynchronously,
 	// but until that completes those rows must remain visible to their owning
 	// device exactly the way local-default rows are.
+	const visibleScopeIds = context.visibleScopeIds;
+	if (visibleScopeIds !== undefined && visibleScopeIds.length <= MAX_SCOPE_IN_PARAMS) {
+		// Fast path: the visible scope-id set was resolved once per request (see
+		// resolveVisibleScopeIds in scope-resolution.ts). A plain `scope_id IN (...)`
+		// is index-eligible on idx_memory_items_scope_visibility_created, unlike the
+		// EXISTS-based fallback below.
+		//
+		// Guarded by MAX_SCOPE_IN_PARAMS: each id is one bound parameter, so an
+		// unrealistically large visible set would otherwise blow SQLite's variable
+		// limit and throw at prepare time. Beyond the cap we fail safe to the
+		// fixed-param EXISTS fallback, which is semantically identical.
+		//
+		// We deliberately do NOT TRIM memory_items.scope_id here. TRIM defeats the
+		// index, and it is unnecessary: stored scope_ids are always trimmed on
+		// write (op scope_id is .trim()ed), so no whitespace-padded values exist.
+		// NULL scope_id (legacy rows pending backfill) is handled by the explicit
+		// IS NULL branch; the empty string "" is included in the resolved set.
+		const placeholders = visibleScopeIds.map(() => "?").join(", ");
+		clauses.push(`(memory_items.scope_id IS NULL OR memory_items.scope_id IN (${placeholders}))`);
+		params.push(...visibleScopeIds);
+		return;
+	}
+	// Fallback path: no pre-resolved set (e.g. a context built without db access).
+	// Semantically identical to the IN predicate above, but evaluated per row.
 	clauses.push(`(
 		COALESCE(TRIM(memory_items.scope_id), '') IN (?, ?, ?)
 		OR EXISTS (

--- a/packages/core/src/observer-config.test.ts
+++ b/packages/core/src/observer-config.test.ts
@@ -288,6 +288,20 @@ describe("getCodememEnvOverrides", () => {
 			delete process.env.CODEMEM_SYNC_RETENTION_MAX_SIZE_MB;
 		}
 	});
+
+	it("includes raw-events retention env overrides when set", () => {
+		process.env.CODEMEM_RAW_EVENTS_RETENTION_ENABLED = "1";
+		process.env.CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS = "45";
+		try {
+			expect(getCodememEnvOverrides()).toMatchObject({
+				raw_events_retention_enabled: "CODEMEM_RAW_EVENTS_RETENTION_ENABLED",
+				raw_events_retention_max_age_days: "CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS",
+			});
+		} finally {
+			delete process.env.CODEMEM_RAW_EVENTS_RETENTION_ENABLED;
+			delete process.env.CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS;
+		}
+	});
 });
 
 describe("resolveCodememConfigPath", () => {

--- a/packages/core/src/observer-config.ts
+++ b/packages/core/src/observer-config.ts
@@ -229,6 +229,8 @@ export const CODEMEM_CONFIG_ENV_OVERRIDES: Record<string, string> = {
 	sync_projects_exclude: "CODEMEM_SYNC_PROJECTS_EXCLUDE",
 	sync_ops_limit: "CODEMEM_SYNC_OPS_LIMIT",
 	raw_events_sweeper_interval_s: "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S",
+	raw_events_retention_enabled: "CODEMEM_RAW_EVENTS_RETENTION_ENABLED",
+	raw_events_retention_max_age_days: "CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/raw-event-sweeper.test.ts
+++ b/packages/core/src/raw-event-sweeper.test.ts
@@ -484,6 +484,51 @@ describe("RawEventSweeper auto flush", () => {
 		expect(store.latestRawEventFlushFailure("opencode")?.stream_id).not.toBe("sess-lifecycle-only");
 	});
 
+	it("resolves retentionMs: explicit config wins, legacy env only as absent-fallback", () => {
+		const prevEnabled = process.env.CODEMEM_RAW_EVENTS_RETENTION_ENABLED;
+		const prevMaxAge = process.env.CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS;
+		const prevLegacy = process.env.CODEMEM_RAW_EVENTS_RETENTION_MS;
+		// Isolate from any developer config file influence.
+		const prevConfig = process.env.CODEMEM_CONFIG;
+		process.env.CODEMEM_CONFIG = join(tmpDir, "no-such-config.json");
+		// Access the private retentionMs() for direct assertion.
+		const retentionMs = (s: RawEventSweeper) =>
+			(s as unknown as { retentionMs(): number }).retentionMs();
+		const sweeper = new RawEventSweeper(store, ingestOpts);
+		try {
+			// 1. New config keys: enabled + max_age_days => days * 86_400_000.
+			delete process.env.CODEMEM_RAW_EVENTS_RETENTION_MS;
+			process.env.CODEMEM_RAW_EVENTS_RETENTION_ENABLED = "1";
+			process.env.CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS = "30";
+			expect(retentionMs(sweeper)).toBe(30 * 86_400_000);
+
+			// 2. New key ABSENT => fall back to the legacy CODEMEM_RAW_EVENTS_RETENTION_MS env var.
+			delete process.env.CODEMEM_RAW_EVENTS_RETENTION_ENABLED;
+			delete process.env.CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS;
+			process.env.CODEMEM_RAW_EVENTS_RETENTION_MS = "123456";
+			expect(retentionMs(sweeper)).toBe(123456);
+
+			// 2b. EXPLICIT disable (enabled=0) is authoritative over a stale legacy
+			// env var: retention stays off rather than silently honoring the legacy value.
+			process.env.CODEMEM_RAW_EVENTS_RETENTION_ENABLED = "0";
+			expect(retentionMs(sweeper)).toBe(0);
+			delete process.env.CODEMEM_RAW_EVENTS_RETENTION_ENABLED;
+
+			// 3. Neither set => 0 (no retention).
+			delete process.env.CODEMEM_RAW_EVENTS_RETENTION_MS;
+			expect(retentionMs(sweeper)).toBe(0);
+		} finally {
+			if (prevEnabled == null) delete process.env.CODEMEM_RAW_EVENTS_RETENTION_ENABLED;
+			else process.env.CODEMEM_RAW_EVENTS_RETENTION_ENABLED = prevEnabled;
+			if (prevMaxAge == null) delete process.env.CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS;
+			else process.env.CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS = prevMaxAge;
+			if (prevLegacy == null) delete process.env.CODEMEM_RAW_EVENTS_RETENTION_MS;
+			else process.env.CODEMEM_RAW_EVENTS_RETENTION_MS = prevLegacy;
+			if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+			else process.env.CODEMEM_CONFIG = prevConfig;
+		}
+	});
+
 	it("does not terminally skip adapter-wrapped prompt sessions", async () => {
 		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
 		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";

--- a/packages/core/src/raw-event-sweeper.ts
+++ b/packages/core/src/raw-event-sweeper.ts
@@ -16,11 +16,14 @@
  * 7. Handle auth errors by setting backoff
  */
 
+import { readCoordinatorSyncConfig } from "./coordinator-runtime.js";
 import type { IngestOptions } from "./ingest-pipeline.js";
 import { ObserverAuthError } from "./observer-client.js";
 import { readCodememConfigFile } from "./observer-config.js";
 import { flushRawEvents } from "./raw-event-flush.js";
 import type { MemoryStore } from "./store.js";
+
+const MS_PER_DAY = 86_400_000;
 
 /** Back off after an auth error. 60s gives OpenCode time to refresh its
  *  OAuth token while staying longer than the default 30s sweep interval. */
@@ -107,6 +110,17 @@ export class RawEventSweeper {
 	}
 
 	private retentionMs(): number {
+		// The new config key (raw_events_retention_enabled / _max_age_days) is the
+		// authoritative control. An EXPLICIT value wins — enabled=true purges by
+		// age in days, and an explicit enabled=false disables retention even if a
+		// stale legacy CODEMEM_RAW_EVENTS_RETENTION_MS is still set. Only when the
+		// new key is absent do we fall back to that legacy env var for back-compat.
+		const config = readCoordinatorSyncConfig();
+		if (config.rawEventsRetentionConfigured) {
+			return config.rawEventsRetentionEnabled
+				? Math.max(1, config.rawEventsRetentionMaxAgeDays) * MS_PER_DAY
+				: 0;
+		}
 		return envInt("CODEMEM_RAW_EVENTS_RETENTION_MS", 0);
 	}
 

--- a/packages/core/src/scope-backfill.ts
+++ b/packages/core/src/scope-backfill.ts
@@ -15,9 +15,11 @@ import {
 	startMaintenanceJob,
 	updateMaintenanceJob,
 } from "./maintenance-jobs.js";
-import { LOCAL_DEFAULT_SCOPE_ID } from "./scope-resolution.js";
+import { LEGACY_SHARED_REVIEW_SCOPE_ID, LOCAL_DEFAULT_SCOPE_ID } from "./scope-resolution.js";
 
-export const LEGACY_SHARED_REVIEW_SCOPE_ID = "legacy-shared-review";
+// Re-exported from its single source of truth (scope-resolution.ts) so existing
+// importers of this symbol from scope-backfill keep working.
+export { LEGACY_SHARED_REVIEW_SCOPE_ID };
 export const SCOPE_BACKFILL_JOB = "scope_id_backfill";
 
 export type ScopeBackfillReason =

--- a/packages/core/src/scope-resolution.ts
+++ b/packages/core/src/scope-resolution.ts
@@ -1,7 +1,25 @@
 import { createHash } from "node:crypto";
 import { resolve } from "node:path";
+import type { Database } from "better-sqlite3";
 
 export const LOCAL_DEFAULT_SCOPE_ID = "local-default";
+
+/**
+ * Scope id used by the conservative migration backfill for legacy shared
+ * memories that cannot yet be assigned to a concrete team/org scope. Single
+ * source of truth: filters.ts and scope-backfill.ts re-import this so the
+ * read-visibility predicate and the backfill agree on one literal.
+ */
+export const LEGACY_SHARED_REVIEW_SCOPE_ID = "legacy-shared-review";
+
+/**
+ * Upper bound on how many scope ids we will inline into the index-eligible
+ * `scope_id IN (...)` fast path (one bound parameter each). Kept well under
+ * SQLite's compiled `SQLITE_MAX_VARIABLE_NUMBER` so a device with an
+ * unrealistically large visible set falls back to the fixed-param EXISTS
+ * predicate instead of throwing "too many SQL variables" at prepare time.
+ */
+export const MAX_SCOPE_IN_PARAMS = 500;
 
 export type WorkspaceIdentitySource =
 	| "git_remote"
@@ -247,4 +265,50 @@ export function resolveProjectScope(input: ResolveProjectScopeInput): ScopeResol
 		mapping: null,
 		matchedPattern: null,
 	};
+}
+
+/**
+ * Resolve, once per request, the full set of scope_ids that `deviceId` may read.
+ *
+ * This is the index-eligible equivalent of the per-row EXISTS predicate in
+ * `addScopeVisibilityFilter`'s fallback branch (filters.ts): instead of
+ * evaluating the replication_scopes / scope_memberships subqueries for every
+ * candidate row, we compute the visible set up front and let the SQL filter use
+ * a plain `scope_id IN (...)`. The membership predicate (active membership with
+ * `membership_epoch >= scope.membership_epoch`) is preserved exactly.
+ *
+ * Lives in this leaf module (it imports nothing from filters/search/store/
+ * vectors) so all three OwnershipFilterContext builders can share it without an
+ * import cycle.
+ *
+ * NULL scope_ids are skipped here — a NULL scope_id is handled by the filter's
+ * dedicated `IS NULL` branch, not by membership in this set.
+ */
+export function resolveVisibleScopeIds(db: Database, deviceId: string): string[] {
+	const visible = new Set<string>(["", LOCAL_DEFAULT_SCOPE_ID, LEGACY_SHARED_REVIEW_SCOPE_ID]);
+	const localScopes = db
+		.prepare(
+			`SELECT scope_id
+			 FROM replication_scopes
+			 WHERE status = 'active' AND authority_type = 'local'`,
+		)
+		.all() as Array<{ scope_id: string | null }>;
+	for (const row of localScopes) {
+		if (row.scope_id != null) visible.add(row.scope_id);
+	}
+	const memberScopes = db
+		.prepare(
+			`SELECT sm.scope_id AS scope_id
+			 FROM scope_memberships sm
+			 JOIN replication_scopes rs ON rs.scope_id = sm.scope_id
+			 WHERE sm.device_id = ?
+			   AND sm.status = 'active'
+			   AND rs.status = 'active'
+			   AND sm.membership_epoch >= rs.membership_epoch`,
+		)
+		.all(deviceId) as Array<{ scope_id: string | null }>;
+	for (const row of memberScopes) {
+		if (row.scope_id != null) visible.add(row.scope_id);
+	}
+	return [...visible];
 }

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -3,8 +3,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connect } from "./db.js";
+import { buildFilterClausesWithContext } from "./filters.js";
 import { sanitizeSearchQuery } from "./query-sanitizer.js";
-import { expandQuery, kindBonus, recencyScore, rerankResults } from "./search.js";
+import { resolveVisibleScopeIds } from "./scope-resolution.js";
+import {
+	expandQuery,
+	kindBonus,
+	ownershipFilterContext,
+	recencyScore,
+	rerankResults,
+} from "./search.js";
 import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import type { MemoryResult } from "./types.js";
@@ -995,6 +1003,236 @@ describe("MemoryStore.search", () => {
 		expect(result).toHaveProperty("metadata");
 		expect(typeof result.score).toBe("number");
 		expect(typeof result.metadata).toBe("object");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Scope-visibility filter: resolved IN-set equivalence
+// ---------------------------------------------------------------------------
+
+describe("scope visibility filter (resolved visible set)", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-scope-vis-test-"));
+		dbPath = join(tmpDir, "test.sqlite");
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function insertLocalAuthorityScope(scopeId: string): void {
+		const now = new Date().toISOString();
+		store.db
+			.prepare(
+				`INSERT OR REPLACE INTO replication_scopes(
+					scope_id, label, kind, authority_type, coordinator_id, group_id,
+					membership_epoch, status, created_at, updated_at
+				 ) VALUES (?, ?, 'user', 'local', NULL, NULL, 0, 'active', ?, ?)`,
+			)
+			.run(scopeId, scopeId, now, now);
+	}
+
+	function insertCoordinatorScopeWithEpoch(
+		scopeId: string,
+		membershipEpoch: number,
+		status: "active" | "inactive",
+	): void {
+		const now = new Date().toISOString();
+		store.db
+			.prepare(
+				`INSERT OR REPLACE INTO replication_scopes(
+					scope_id, label, kind, authority_type, coordinator_id, group_id,
+					membership_epoch, status, created_at, updated_at
+				 ) VALUES (?, ?, 'team', 'coordinator', 'coord-test', 'group-test', ?, ?, ?, ?)`,
+			)
+			.run(scopeId, scopeId, membershipEpoch, status, now, now);
+	}
+
+	function grantMembership(scopeId: string, membershipEpoch: number): void {
+		store.db
+			.prepare(
+				`INSERT OR REPLACE INTO scope_memberships(
+					scope_id, device_id, role, status, membership_epoch,
+					coordinator_id, group_id, updated_at
+				 ) VALUES (?, ?, 'member', 'active', ?, 'coord-test', 'group-test', ?)`,
+			)
+			.run(scopeId, store.deviceId, membershipEpoch, new Date().toISOString());
+	}
+
+	it("resolves and filters to exactly the readable scope set", () => {
+		// Visible scopes
+		insertLocalAuthorityScope("local-authority-team");
+		insertCoordinatorScopeWithEpoch("member-team", 3, "active");
+		grantMembership("member-team", 3); // epoch 3 >= scope epoch 3 -> visible
+
+		// Not-visible scopes
+		insertCoordinatorScopeWithEpoch("nonmember-team", 0, "active"); // no membership
+		insertCoordinatorScopeWithEpoch("stale-team", 5, "active");
+		grantMembership("stale-team", 4); // membership epoch 4 < scope epoch 5 -> not visible
+		insertCoordinatorScopeWithEpoch("inactive-team", 0, "inactive"); // scope inactive
+		grantMembership("inactive-team", 0); // membership active but scope inactive -> not visible
+
+		// Resolver output: literals + local-authority + valid-membership only.
+		const resolved = resolveVisibleScopeIds(store.db, store.deviceId);
+		expect([...resolved].sort()).toEqual(
+			["", "local-default", "legacy-shared-review", "local-authority-team", "member-team"].sort(),
+		);
+		expect(resolved).not.toContain("nonmember-team");
+		expect(resolved).not.toContain("stale-team");
+		expect(resolved).not.toContain("inactive-team");
+
+		// Seed one memory row per scope plus NULL-scope and empty-scope rows.
+		const sessionId = insertTestSession(store.db);
+		const insertRow = (scopeId: string | null): number => {
+			const ts = new Date().toISOString();
+			const info = store.db
+				.prepare(
+					`INSERT INTO memory_items(
+						session_id, kind, title, body_text, confidence, tags_text, active,
+						created_at, updated_at, metadata_json, rev, visibility, scope_id
+					 ) VALUES (?, 'discovery', 'scoped row', 'body', 0.5, '', 1, ?, ?, '{}', 1, 'shared', ?)`,
+				)
+				.run(sessionId, ts, ts, scopeId);
+			return Number(info.lastInsertRowid);
+		};
+
+		const nullId = insertRow(null);
+		const emptyId = insertRow("");
+		const localDefaultId = insertRow("local-default");
+		const legacyReviewId = insertRow("legacy-shared-review");
+		const localAuthorityId = insertRow("local-authority-team");
+		const memberId = insertRow("member-team");
+		const nonmemberId = insertRow("nonmember-team");
+		const staleId = insertRow("stale-team");
+		const inactiveId = insertRow("inactive-team");
+
+		// Render the scope-visibility predicate via the resolved-set context
+		// (search.ts ownershipFilterContext sets visibleScopeIds -> fast path).
+		const filterResult = buildFilterClausesWithContext(null, ownershipFilterContext(store));
+		const whereSql = ["memory_items.active = 1", ...filterResult.clauses].join(" AND ");
+		const rows = store.db
+			.prepare(`SELECT id FROM memory_items WHERE ${whereSql}`)
+			.all(...filterResult.params) as Array<{ id: number }>;
+		const visibleIds = new Set(rows.map((row) => row.id));
+
+		// Visible: NULL, "", local-default, legacy-shared-review, local-authority, valid member.
+		expect(visibleIds.has(nullId)).toBe(true);
+		expect(visibleIds.has(emptyId)).toBe(true);
+		expect(visibleIds.has(localDefaultId)).toBe(true);
+		expect(visibleIds.has(legacyReviewId)).toBe(true);
+		expect(visibleIds.has(localAuthorityId)).toBe(true);
+		expect(visibleIds.has(memberId)).toBe(true);
+
+		// Not visible: non-member, stale-epoch member, inactive scope.
+		expect(visibleIds.has(nonmemberId)).toBe(false);
+		expect(visibleIds.has(staleId)).toBe(false);
+		expect(visibleIds.has(inactiveId)).toBe(false);
+	});
+
+	it("matches the EXISTS fallback predicate for the same data", () => {
+		insertLocalAuthorityScope("local-authority-team");
+		insertCoordinatorScopeWithEpoch("member-team", 3, "active");
+		grantMembership("member-team", 3);
+		insertCoordinatorScopeWithEpoch("nonmember-team", 0, "active");
+		insertCoordinatorScopeWithEpoch("stale-team", 5, "active");
+		grantMembership("stale-team", 4);
+		insertCoordinatorScopeWithEpoch("inactive-team", 0, "inactive");
+		grantMembership("inactive-team", 0);
+
+		const sessionId = insertTestSession(store.db);
+		const insertRow = (scopeId: string | null): number => {
+			const ts = new Date().toISOString();
+			const info = store.db
+				.prepare(
+					`INSERT INTO memory_items(
+						session_id, kind, title, body_text, confidence, tags_text, active,
+						created_at, updated_at, metadata_json, rev, visibility, scope_id
+					 ) VALUES (?, 'discovery', 'scoped row', 'body', 0.5, '', 1, ?, ?, '{}', 1, 'shared', ?)`,
+				)
+				.run(sessionId, ts, ts, scopeId);
+			return Number(info.lastInsertRowid);
+		};
+		for (const scopeId of [
+			null,
+			"",
+			"local-default",
+			"legacy-shared-review",
+			"local-authority-team",
+			"member-team",
+			"nonmember-team",
+			"stale-team",
+			"inactive-team",
+		]) {
+			insertRow(scopeId);
+		}
+
+		const runIds = (context: ReturnType<typeof ownershipFilterContext>): Set<number> => {
+			const filterResult = buildFilterClausesWithContext(null, context);
+			const whereSql = ["memory_items.active = 1", ...filterResult.clauses].join(" AND ");
+			const rows = store.db
+				.prepare(`SELECT id FROM memory_items WHERE ${whereSql}`)
+				.all(...filterResult.params) as Array<{ id: number }>;
+			return new Set(rows.map((row) => row.id));
+		};
+
+		// Fast path (resolved IN-set) vs fallback (EXISTS) must select identical rows.
+		const fastContext = ownershipFilterContext(store);
+		const { visibleScopeIds: _omit, ...fallbackContext } = fastContext;
+		expect([...runIds(fastContext)].sort()).toEqual([...runIds(fallbackContext)].sort());
+	});
+
+	it("renders an index-eligible plan with no correlated scope subquery", () => {
+		insertLocalAuthorityScope("local-authority-team");
+		insertCoordinatorScopeWithEpoch("member-team", 3, "active");
+		grantMembership("member-team", 3);
+
+		// Enough rows that a full scan would be a real regression, not a tie.
+		const sessionId = insertTestSession(store.db);
+		const ts = new Date().toISOString();
+		for (let i = 0; i < 50; i++) {
+			store.db
+				.prepare(
+					`INSERT INTO memory_items(
+						session_id, kind, title, body_text, confidence, tags_text, active,
+						created_at, updated_at, metadata_json, rev, visibility, scope_id
+					 ) VALUES (?, 'discovery', 't', 'b', 0.5, '', 1, ?, ?, '{}', 1, 'shared', ?)`,
+				)
+				.run(sessionId, ts, ts, i % 3 === 0 ? null : "member-team");
+		}
+
+		const explainPlan = (context: ReturnType<typeof ownershipFilterContext>): string => {
+			const filterResult = buildFilterClausesWithContext(null, context);
+			const whereSql = ["memory_items.active = 1", ...filterResult.clauses].join(" AND ");
+			const rows = store.db
+				.prepare(`EXPLAIN QUERY PLAN SELECT id FROM memory_items WHERE ${whereSql}`)
+				.all(...filterResult.params) as Array<{ detail: string }>;
+			return rows.map((row) => row.detail).join("\n");
+		};
+
+		// Fast path: the resolved IN-set must produce an index-backed scan with no
+		// correlated subquery and no TRIM (TRIM would defeat the index). This pins
+		// the actual perf goal: a future regression that reintroduces TRIM or the
+		// per-row EXISTS predicate would resurface CORRELATED here and fail.
+		const fastPlan = explainPlan(ownershipFilterContext(store));
+		expect(fastPlan).toMatch(/USING INDEX/);
+		expect(fastPlan).not.toMatch(/CORRELATED/);
+		expect(fastPlan).not.toMatch(/TRIM/);
+
+		// Contrast guard: the EXISTS fallback is exactly the plan shape we are
+		// hoisting away from — it must still contain the correlated subqueries, so
+		// this assertion proves the fast-path check above is meaningful.
+		const { visibleScopeIds: _omit, ...fallbackContext } = ownershipFilterContext(store);
+		const fallbackPlan = explainPlan(fallbackContext);
+		expect(fallbackPlan).toMatch(/CORRELATED/);
 	});
 });
 

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -24,6 +24,7 @@ import { sanitizeSearchQuery } from "./query-sanitizer.js";
 import { memoryLooksRecapLike, queryPrefersRecap, recapPenaltyMultiplier } from "./recap-policy.js";
 import { findByConcept, findByFile } from "./ref-queries.js";
 import * as schema from "./schema.js";
+import { resolveVisibleScopeIds } from "./scope-resolution.js";
 import { canonicalMemoryKind } from "./summary-memory.js";
 import type {
 	ExplainError,
@@ -88,6 +89,7 @@ export function ownershipFilterContext(store: StoreHandle): OwnershipFilterConte
 		claimedDeviceIds,
 		legacyActorIds: claimedDeviceIds.map((peerId) => `legacy-sync:${peerId}`),
 		enforceScopeVisibility: true,
+		visibleScopeIds: resolveVisibleScopeIds(store.db, store.deviceId),
 	};
 }
 

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -1487,6 +1487,100 @@ describe("MemoryStore", () => {
 		});
 	});
 
+	// -- usageAggregate ------------------------------------------------------
+
+	describe("usageAggregate", () => {
+		function insertUsageEvent(
+			sessionId: number | null,
+			event: string,
+			tokensRead: number,
+			tokensWritten: number,
+			tokensSaved: number | null,
+			createdAt = "2026-03-26T23:30:00Z",
+		): void {
+			store.db
+				.prepare(
+					`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+					 VALUES (?, ?, ?, ?, ?, ?, '{}')`,
+				)
+				.run(sessionId, event, tokensRead, tokensWritten, tokensSaved, createdAt);
+		}
+
+		it("groups by event and sums tokens with tokens_saved NULL coalesced to 0", () => {
+			const sessionId = insertTestSession(store.db);
+			insertUsageEvent(sessionId, "pack", 100, 10, 5);
+			insertUsageEvent(sessionId, "pack", 200, 20, null);
+			insertUsageEvent(sessionId, "search", 30, 3, 7);
+
+			const rows = store.usageAggregate();
+			const byEvent = new Map(rows.map((row) => [row.event, row]));
+			expect(byEvent.get("pack")).toEqual({
+				event: "pack",
+				count: 2,
+				tokens_read: 300,
+				tokens_written: 30,
+				// NULL tokens_saved on the second pack contributes 0.
+				tokens_saved: 5,
+			});
+			expect(byEvent.get("search")).toEqual({
+				event: "search",
+				count: 1,
+				tokens_read: 30,
+				tokens_written: 3,
+				tokens_saved: 7,
+			});
+		});
+
+		it("restricts the aggregate to a project when a non-empty filter is given", () => {
+			const codememSession = insertTestSession(store.db);
+			store.db
+				.prepare("UPDATE sessions SET project = ? WHERE id = ?")
+				.run("codemem", codememSession);
+			const otherSession = insertTestSession(store.db);
+			store.db.prepare("UPDATE sessions SET project = ? WHERE id = ?").run("other", otherSession);
+			insertUsageEvent(codememSession, "pack", 100, 10, 5);
+			insertUsageEvent(otherSession, "pack", 1000, 100, 50);
+
+			const filtered = store.usageAggregate("codemem");
+			expect(filtered).toEqual([
+				{ event: "pack", count: 1, tokens_read: 100, tokens_written: 10, tokens_saved: 5 },
+			]);
+
+			// Empty-string filter behaves like the unfiltered (global) variant.
+			const globalViaEmpty = store.usageAggregate("");
+			const global = store.usageAggregate();
+			expect(globalViaEmpty).toEqual(global);
+			expect(global).toEqual([
+				{ event: "pack", count: 2, tokens_read: 1100, tokens_written: 110, tokens_saved: 55 },
+			]);
+		});
+
+		it("returns an empty array when there are no usage events", () => {
+			expect(store.usageAggregate()).toEqual([]);
+			expect(store.usageAggregate("codemem")).toEqual([]);
+		});
+
+		it("backs store.stats().usage with the same unfiltered values", () => {
+			const sessionId = insertTestSession(store.db);
+			insertUsageEvent(sessionId, "pack", 100, 10, 5);
+			insertUsageEvent(sessionId, "pack", 200, 20, null);
+			insertUsageEvent(sessionId, "search", 30, 3, 7);
+
+			const usage = store.stats().usage;
+			// stats() sorts events by count DESC.
+			expect(usage.events).toEqual([
+				{ event: "pack", count: 2, tokens_read: 300, tokens_written: 30, tokens_saved: 5 },
+				{ event: "search", count: 1, tokens_read: 30, tokens_written: 3, tokens_saved: 7 },
+			]);
+			expect(usage.totals).toEqual({
+				events: 3,
+				tokens_read: 330,
+				tokens_written: 33,
+				tokens_saved: 12,
+			});
+		});
+	});
+
 	// -- updateMemoryVisibility ----------------------------------------------
 
 	describe("updateMemoryVisibility", () => {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1713,6 +1713,66 @@ export class MemoryStore {
 	}
 
 	/**
+	 * Report raw_events storage usage and how many rows fall before an age cutoff.
+	 *
+	 * Age-based only (mirrors planReplicationOpsAgePrune / estimateReplicationOps
+	 * style): counts total rows, estimates the on-disk bytes for the raw_events
+	 * table and its indexes, and counts rows with ts_wall_ms older than the
+	 * cutoff implied by maxAgeMs. Used by the prune-raw-events dry-run report.
+	 */
+	rawEventsRetentionStatus(maxAgeMs: number): {
+		total_rows: number;
+		estimated_bytes: number;
+		candidate_rows: number;
+		cutoff_ts_wall_ms: number | null;
+	} {
+		const totalRow = this.d.select({ total: sql<number>`COUNT(*)` }).from(schema.rawEvents).get();
+		const totalRows = Number(totalRow?.total ?? 0);
+
+		let candidateRows = 0;
+		let cutoffTsWallMs: number | null = null;
+		if (maxAgeMs > 0) {
+			cutoffTsWallMs = Date.now() - maxAgeMs;
+			const candidateRow = this.d
+				.select({ total: sql<number>`COUNT(*)` })
+				.from(schema.rawEvents)
+				.where(
+					and(
+						isNotNull(schema.rawEvents.ts_wall_ms),
+						lt(schema.rawEvents.ts_wall_ms, cutoffTsWallMs),
+					),
+				)
+				.get();
+			candidateRows = Number(candidateRow?.total ?? 0);
+		}
+
+		return {
+			total_rows: totalRows,
+			estimated_bytes: this.estimateRawEventsBytes(),
+			candidate_rows: candidateRows,
+			cutoff_ts_wall_ms: cutoffTsWallMs,
+		};
+	}
+
+	private estimateRawEventsBytes(): number {
+		try {
+			const row = this.db
+				.prepare(
+					`SELECT COALESCE(SUM(pgsize), 0) AS total_bytes
+					 FROM dbstat
+					 WHERE name = 'raw_events'
+					    OR name LIKE 'idx_raw_events_%'
+					    OR name LIKE 'sqlite_autoindex_raw_events_%'`,
+				)
+				.get() as { total_bytes?: number | string | null } | undefined;
+			const total = Number(row?.total_bytes ?? 0);
+			return Number.isFinite(total) && total >= 0 ? total : 0;
+		} catch {
+			return 0;
+		}
+	}
+
+	/**
 	 * Mark stuck flush batches (started/running/pending/claimed) as failed.
 	 * Port of mark_stuck_raw_event_batches_as_error().
 	 */

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -41,6 +41,7 @@ import { populateMemoryRefs } from "./ref-populate.js";
 import type { RefQueryOptions, RefQueryResult } from "./ref-queries.js";
 import { findByConcept as findByConceptFn, findByFile as findByFileFn } from "./ref-queries.js";
 import * as schema from "./schema.js";
+import { resolveVisibleScopeIds } from "./scope-resolution.js";
 import { ensureMemoryScopeId, resolveSessionScopeId } from "./scope-stamping.js";
 import {
 	type ExplainOptions,
@@ -429,6 +430,11 @@ export class MemoryStore {
 			claimedDeviceIds,
 			legacyActorIds: claimedDeviceIds.map((peerId) => `legacy-sync:${peerId}`),
 			enforceScopeVisibility: true,
+			// Resolve the visible scope set once per request so the SQL filter can
+			// use the index-eligible `scope_id IN (...)` fast path instead of the
+			// per-row EXISTS predicate. Fronts get()/recent()/recentByKinds() and
+			// every viewer-server route.
+			visibleScopeIds: resolveVisibleScopeIds(this.db, this.deviceId),
 		};
 	}
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1031,6 +1031,63 @@ export class MemoryStore {
 		return rows.map((row) => parseMetadata(row));
 	}
 
+	// usageAggregate
+
+	/**
+	 * Neutral, unfiltered token/event aggregate over usage_events, grouped by
+	 * event kind. This is the shared SQL aggregate used by both stats() and the
+	 * viewer /api/usage route so neither has to scan the (potentially large)
+	 * usage_events table into JS to sum it. The COALESCE on tokens_saved matches
+	 * the historical stats() semantics (treat NULL saved as 0). When
+	 * projectFilter is a non-empty string, rows are restricted to the given
+	 * project via the sessions join; otherwise every row is aggregated.
+	 * Callers sort the returned rows as needed.
+	 */
+	usageAggregate(projectFilter?: string | null): Array<{
+		event: string;
+		count: number;
+		tokens_read: number;
+		tokens_written: number;
+		tokens_saved: number;
+	}> {
+		// Two near-identical GROUP BYs kept deliberately separate: the global
+		// variant avoids a needless sessions join, and the projections (incl.
+		// the tokens_saved double-COALESCE) must stay byte-identical in both.
+		const hasProject = typeof projectFilter === "string" && projectFilter.length > 0;
+		const rows = hasProject
+			? (this.db
+					.prepare(
+						`SELECT usage_events.event AS event,
+							COUNT(*) AS count,
+							COALESCE(SUM(usage_events.tokens_read), 0) AS tokens_read,
+							COALESCE(SUM(usage_events.tokens_written), 0) AS tokens_written,
+							COALESCE(SUM(COALESCE(usage_events.tokens_saved, 0)), 0) AS tokens_saved
+						 FROM usage_events
+						 JOIN sessions ON sessions.id = usage_events.session_id
+						 WHERE sessions.project = ?
+						 GROUP BY usage_events.event`,
+					)
+					.all(projectFilter) as Record<string, unknown>[])
+			: (this.db
+					.prepare(
+						`SELECT event AS event,
+							COUNT(*) AS count,
+							COALESCE(SUM(tokens_read), 0) AS tokens_read,
+							COALESCE(SUM(tokens_written), 0) AS tokens_written,
+							COALESCE(SUM(COALESCE(tokens_saved, 0)), 0) AS tokens_saved
+						 FROM usage_events
+						 GROUP BY event`,
+					)
+					.all() as Record<string, unknown>[]);
+		return rows.map((row) => ({
+			event: String(row.event),
+			count: Number(row.count ?? 0),
+			tokens_read: Number(row.tokens_read ?? 0),
+			tokens_written: Number(row.tokens_written ?? 0),
+			tokens_saved: Number(row.tokens_saved ?? 0),
+		}));
+	}
+
 	// stats
 
 	/**
@@ -1098,27 +1155,12 @@ export class MemoryStore {
 			// File may not exist yet or be inaccessible
 		}
 
-		// Usage stats
-		const usageRows = this.d
-			.select({
-				event: schema.usageEvents.event,
-				count: sql<number>`COUNT(*)`,
-				tokens_read: sql<number | null>`SUM(tokens_read)`,
-				tokens_written: sql<number | null>`SUM(tokens_written)`,
-				tokens_saved: sql<number | null>`SUM(COALESCE(tokens_saved, 0))`,
-			})
-			.from(schema.usageEvents)
-			.groupBy(schema.usageEvents.event)
-			.orderBy(desc(sql`COUNT(*)`))
-			.all();
-
-		const usageEvents = usageRows.map((r) => ({
-			event: r.event,
-			count: r.count,
-			tokens_read: r.tokens_read ?? 0,
-			tokens_written: r.tokens_written ?? 0,
-			tokens_saved: r.tokens_saved ?? 0,
-		}));
+		// Usage stats. Sort by count DESC to preserve the historical
+		// ORDER BY COUNT(*) DESC ordering of this block, with event name as a
+		// stable tiebreaker so equal-count rows have a deterministic order.
+		const usageEvents = this.usageAggregate().sort(
+			(a, b) => b.count - a.count || a.event.localeCompare(b.event),
+		);
 
 		const totalEvents = usageEvents.reduce((s, e) => s + e.count, 0);
 		const totalTokensRead = usageEvents.reduce((s, e) => s + e.tokens_read, 0);

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -43,6 +43,12 @@ function scopeVisibleFilterContext(context: SemanticSearchScopeContext): Ownersh
 		claimedDeviceIds: context?.claimedDeviceIds ?? [],
 		legacyActorIds: context?.legacyActorIds ?? [],
 		enforceScopeVisibility: true,
+		// Forward the pre-resolved visible scope set so the KNN candidate filter
+		// gets the index-eligible `scope_id IN (...)` fast path. Callers reach
+		// semanticSearch via ownershipFilterContext(store) (search.ts / store.ts),
+		// which already resolves this set; when absent the filter falls back to the
+		// equivalent EXISTS predicate. This function has no db handle of its own.
+		visibleScopeIds: context?.visibleScopeIds,
 	};
 }
 

--- a/packages/ui/scripts/stage-viewer-static.mjs
+++ b/packages/ui/scripts/stage-viewer-static.mjs
@@ -1,6 +1,7 @@
-import { cpSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { brotliCompressSync, constants as zlibConstants, gzipSync } from "node:zlib";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "../../..");
@@ -18,4 +19,20 @@ for (const entry of readdirSync(sourceStaticDir, { withFileTypes: true })) {
 	if (entry.name === "app.js") continue;
 	if (extname(entry.name) === ".map") continue;
 	cpSync(join(sourceStaticDir, entry.name), join(viewerStaticDir, entry.name));
+}
+
+// Precompress text assets so the viewer server (serveStatic precompressed:true)
+// serves .br/.gz. Done HERE, as the final build step, so every asset is the
+// freshly-staged content: app.js was written into viewerStaticDir by vite, and
+// the CSS above was just copied. Compressing in vite's writeBundle instead would
+// race the CSS staging and emit stale/missing CSS siblings.
+for (const name of ["app.js", "themes.css", "tokens.css"]) {
+	const filePath = join(viewerStaticDir, name);
+	if (!existsSync(filePath)) continue;
+	const raw = readFileSync(filePath);
+	writeFileSync(`${filePath}.gz`, gzipSync(raw, { level: 9 }));
+	writeFileSync(
+		`${filePath}.br`,
+		brotliCompressSync(raw, { params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 11 } }),
+	);
 }

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -75,7 +75,7 @@ export default defineConfig(({ command, mode }) => {
 						fileName: () => "app.js",
 					},
 					sourcemap: mode === "development",
-					minify: false,
+					minify: "esbuild",
 				},
 		plugins: [
 			preact(),

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -551,8 +551,12 @@ describe("viewer-server", () => {
 					recent_packs: Array<{ metadata_json: unknown }>;
 					totals: { count: number; tokens_read: number; tokens_saved: number };
 				};
+				// recent_packs stays scope-filtered: only the visible-session pack
+				// survives, with hidden ids stripped from its metadata.
 				expect(body.recent_packs).toHaveLength(1);
-				expect(body.totals).toMatchObject({ count: 1, tokens_read: 123, tokens_saved: 456 });
+				// Aggregate totals are unfiltered SQL sums over every usage row
+				// (both packs), matching store.stats() semantics.
+				expect(body.totals).toMatchObject({ count: 2, tokens_read: 1122, tokens_saved: 1455 });
 				expect(body.recent_packs[0]?.metadata_json).toMatchObject({
 					pack_item_ids: [visibleId],
 					added_ids: [visibleId],
@@ -603,8 +607,11 @@ describe("viewer-server", () => {
 					recent_packs: unknown[];
 					totals: { count: number; tokens_read: number; tokens_saved: number };
 				};
+				// The hidden-session pack is still excluded from recent_packs
+				// (session not visible), but the unfiltered aggregate totals count
+				// it just like store.stats() would.
 				expect(body.recent_packs).toHaveLength(0);
-				expect(body.totals).toMatchObject({ count: 0, tokens_read: 0, tokens_saved: 0 });
+				expect(body.totals).toMatchObject({ count: 1, tokens_read: 999, tokens_saved: 999 });
 			} finally {
 				cleanup();
 			}
@@ -710,21 +717,23 @@ describe("viewer-server", () => {
 					.run(sessionId, "2026-03-26T23:30:00Z");
 
 				const beforeRevoke = (await (await app.request("/api/usage")).json()) as {
-					totals: { count: number };
+					recent_packs: unknown[];
 				};
-				expect(beforeRevoke.totals.count).toBe(1);
+				expect(beforeRevoke.recent_packs).toHaveLength(1);
 
 				// Revoke the device's membership. Even within the TTL window the
 				// next request must recompute and hide the now-invisible scope
-				// instead of serving the cached (visible) payload.
+				// instead of serving the cached (visible) payload. recent_packs is
+				// the scope-sensitive surface here (aggregate totals are now
+				// unfiltered, so they would not reflect a visibility change).
 				store.db
 					.prepare("DELETE FROM scope_memberships WHERE scope_id = ? AND device_id = ?")
 					.run("authorized-team", store.deviceId);
 
 				const afterRevoke = (await (await app.request("/api/usage")).json()) as {
-					totals: { count: number };
+					recent_packs: unknown[];
 				};
-				expect(afterRevoke.totals.count).toBe(0);
+				expect(afterRevoke.recent_packs).toHaveLength(0);
 			} finally {
 				cleanup();
 			}
@@ -765,6 +774,229 @@ describe("viewer-server", () => {
 				expect(cache.size).toBeLessThanOrEqual(maxEntries);
 			} finally {
 				cache.clear();
+				cleanup();
+			}
+		});
+
+		it("aggregates token/event totals in SQL with hand-summed global and project values", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const codememSession = insertTestSession(store.db);
+				store.db
+					.prepare("UPDATE sessions SET project = ? WHERE id = ?")
+					.run("codemem", codememSession);
+				const otherSession = insertTestSession(store.db);
+				store.db.prepare("UPDATE sessions SET project = ? WHERE id = ?").run("other", otherSession);
+
+				const insertUsage = (
+					sessionId: number,
+					event: string,
+					read: number,
+					written: number,
+					saved: number | null,
+					createdAt: string,
+				) =>
+					store.db
+						.prepare(
+							`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+							 VALUES (?, ?, ?, ?, ?, ?, '{}')`,
+						)
+						.run(sessionId, event, read, written, saved, createdAt);
+
+				// codemem project: two packs + one search.
+				insertUsage(codememSession, "pack", 100, 10, 5, "2026-03-26T23:30:00Z");
+				insertUsage(codememSession, "pack", 200, 20, null, "2026-03-26T23:31:00Z");
+				insertUsage(codememSession, "search", 30, 3, 7, "2026-03-26T23:32:00Z");
+				// other project: one pack.
+				insertUsage(otherSession, "pack", 1000, 100, 50, "2026-03-26T23:33:00Z");
+
+				const res = await app.request("/api/usage?project=codemem");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					events_global: Array<{
+						event: string;
+						total_tokens_read: number;
+						total_tokens_written: number;
+						total_tokens_saved: number;
+						count: number;
+					}>;
+					totals_global: {
+						tokens_read: number;
+						tokens_written: number;
+						tokens_saved: number;
+						count: number;
+					};
+					events_filtered: Array<{
+						event: string;
+						total_tokens_read: number;
+						total_tokens_written: number;
+						total_tokens_saved: number;
+						count: number;
+					}> | null;
+					totals_filtered: {
+						tokens_read: number;
+						tokens_written: number;
+						tokens_saved: number;
+						count: number;
+					} | null;
+					totals: {
+						tokens_read: number;
+						tokens_written: number;
+						tokens_saved: number;
+						count: number;
+					};
+				};
+
+				// Global aggregate = all four rows, NULL tokens_saved coalesced to 0.
+				expect(body.totals_global).toEqual({
+					tokens_read: 1330,
+					tokens_written: 133,
+					tokens_saved: 62,
+					count: 4,
+				});
+				// events_global is sorted by event name ASC (pack before search).
+				expect(body.events_global).toEqual([
+					{
+						event: "pack",
+						total_tokens_read: 1300,
+						total_tokens_written: 130,
+						total_tokens_saved: 55,
+						count: 3,
+					},
+					{
+						event: "search",
+						total_tokens_read: 30,
+						total_tokens_written: 3,
+						total_tokens_saved: 7,
+						count: 1,
+					},
+				]);
+
+				// Project-filtered aggregate = only the codemem rows.
+				expect(body.totals_filtered).toEqual({
+					tokens_read: 330,
+					tokens_written: 33,
+					tokens_saved: 12,
+					count: 3,
+				});
+				expect(body.events_filtered).toEqual([
+					{
+						event: "pack",
+						total_tokens_read: 300,
+						total_tokens_written: 30,
+						total_tokens_saved: 5,
+						count: 2,
+					},
+					{
+						event: "search",
+						total_tokens_read: 30,
+						total_tokens_written: 3,
+						total_tokens_saved: 7,
+						count: 1,
+					},
+				]);
+
+				// When a project filter is present, `totals` mirrors the filtered values.
+				expect(body.totals).toEqual(body.totals_filtered);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("orders recent_packs by created_at DESC and caps the surfaced window", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Recent-pack visible memory",
+				});
+				const insertPack = (createdAt: string, tokensRead: number) =>
+					store.db
+						.prepare(
+							`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+							 VALUES (?, 'pack', ?, 0, 0, ?, '{}')`,
+						)
+						.run(sessionId, tokensRead, createdAt);
+
+				// Insert 15 packs in ascending time order; the route should return
+				// the newest first and never surface more than 10.
+				for (let i = 0; i < 15; i += 1) {
+					const minute = String(i).padStart(2, "0");
+					insertPack(`2026-03-26T23:${minute}:00Z`, i);
+				}
+
+				const res = await app.request("/api/usage");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					recent_packs: Array<{ created_at: string }>;
+				};
+				expect(body.recent_packs).toHaveLength(10);
+				const timestamps = body.recent_packs.map((row) => row.created_at);
+				const sortedDesc = [...timestamps].sort((a, b) => b.localeCompare(a));
+				expect(timestamps).toEqual(sortedDesc);
+				// Newest seeded pack (minute 14) is first; oldest surfaced is minute 05.
+				expect(timestamps[0]).toBe("2026-03-26T23:14:00Z");
+				expect(timestamps.at(-1)).toBe("2026-03-26T23:05:00Z");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("does not surface a visible pack older than the bounded recent-pack window", async () => {
+			// Documents the deliberate truncation tradeoff: the recent_packs window
+			// considers only the newest RECENT_PACK_SCAN_LIMIT (200) pack events, so
+			// a visible pack buried under that many newer non-visible packs is not
+			// surfaced — while the unfiltered aggregate still counts every event.
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Starvation-test visible memory",
+				});
+				const insertPack = (sessionRef: number | null, createdAt: string) =>
+					store.db
+						.prepare(
+							`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+							 VALUES (?, 'pack', 1, 0, 0, ?, '{}')`,
+						)
+						.run(sessionRef, createdAt);
+
+				// One visible pack at the OLDEST timestamp (session is visible)...
+				insertPack(sessionId, "2026-03-26T00:00:00Z");
+				// ...buried under 200 NEWER non-visible packs (NULL session => a row
+				// with no pack_item_ids and a null session is never visible). The
+				// newest-200 window is entirely non-visible, so the lone visible pack
+				// sits at position 201 and is never considered.
+				for (let i = 0; i < 200; i += 1) {
+					const minute = String(Math.floor(i / 60)).padStart(2, "0");
+					const second = String(i % 60).padStart(2, "0");
+					insertPack(null, `2026-04-01T00:${minute}:${second}Z`);
+				}
+
+				const res = await app.request("/api/usage");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					recent_packs: unknown[];
+					totals_global: { count: number };
+				};
+				// recent_packs is starved to empty even though a visible pack exists...
+				expect(body.recent_packs).toHaveLength(0);
+				// ...while the unfiltered aggregate still counts every pack event (201).
+				expect(body.totals_global.count).toBe(201);
+			} finally {
 				cleanup();
 			}
 		});

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -8,6 +8,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { brotliCompressSync } from "node:zlib";
 import * as core from "@codemem/core";
 import {
 	buildAuthHeaders,
@@ -291,6 +292,41 @@ describe("viewer-server", () => {
 			const bundle = await app.request("/assets/app.js");
 			expect(bundle.status).toBe(200);
 			expect(bundle.headers.get("cache-control")).toBe("no-cache");
+		} finally {
+			if (previousStaticDir == null) delete process.env.CODEMEM_VIEWER_STATIC_DIR;
+			else process.env.CODEMEM_VIEWER_STATIC_DIR = previousStaticDir;
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it("serves the brotli-precompressed app bundle when the client accepts it", async () => {
+		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-viewer-static-br-"));
+		const previousStaticDir = process.env.CODEMEM_VIEWER_STATIC_DIR;
+		process.env.CODEMEM_VIEWER_STATIC_DIR = tmpDir;
+		try {
+			writeFileSync(
+				join(tmpDir, "index.html"),
+				'<!doctype html><script src="/assets/app.js"></script>',
+			);
+			const rawBundle = "globalThis.__codememTestApp = true;";
+			writeFileSync(join(tmpDir, "app.js"), rawBundle);
+			writeFileSync(join(tmpDir, "app.js.br"), brotliCompressSync(Buffer.from(rawBundle)));
+			const app = createApp({
+				storeFactory: () => createTestStore().store,
+			});
+
+			const compressed = await app.request("/assets/app.js", {
+				headers: { "Accept-Encoding": "br" },
+			});
+			expect(compressed.status).toBe(200);
+			expect(compressed.headers.get("content-encoding")).toBe("br");
+
+			// No matching encoding -> raw file, no Content-Encoding header.
+			const identity = await app.request("/assets/app.js", {
+				headers: { "Accept-Encoding": "identity" },
+			});
+			expect(identity.status).toBe(200);
+			expect(identity.headers.get("content-encoding")).toBeNull();
 		} finally {
 			if (previousStaticDir == null) delete process.env.CODEMEM_VIEWER_STATIC_DIR;
 			else process.env.CODEMEM_VIEWER_STATIC_DIR = previousStaticDir;

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -115,6 +115,7 @@ export function createApp(opts?: AppOptions) {
 		serveStatic({
 			root: staticRoot,
 			rewriteRequestPath: (path) => path.replace(/^\/assets/, ""),
+			precompressed: true,
 		}),
 	);
 

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -181,43 +181,48 @@ function sanitizePackUsageMetadata(
 	return sanitized;
 }
 
-function summarizeUsageEvents(rows: UsageRow[]): Record<string, unknown>[] {
-	const byEvent = new Map<
-		string,
-		{
-			event: string;
-			total_tokens_read: number;
-			total_tokens_written: number;
-			total_tokens_saved: number;
-			count: number;
-		}
-	>();
-	for (const row of rows) {
-		const summary = byEvent.get(row.event) ?? {
+type UsageAggregateRow = {
+	event: string;
+	count: number;
+	tokens_read: number;
+	tokens_written: number;
+	tokens_saved: number;
+};
+
+/**
+ * Convert the neutral core aggregate rows into the wire shape for /api/usage
+ * (ApiUsageEventSummary: total_tokens_* names), sorted by event name ASC to
+ * match the route's historical ordering.
+ */
+function mapAggregateEvents(rows: UsageAggregateRow[]): Record<string, unknown>[] {
+	return rows
+		.map((row) => ({
 			event: row.event,
-			total_tokens_read: 0,
-			total_tokens_written: 0,
-			total_tokens_saved: 0,
-			count: 0,
-		};
-		summary.total_tokens_read += row.tokens_read;
-		summary.total_tokens_written += row.tokens_written;
-		summary.total_tokens_saved += row.tokens_saved;
-		summary.count += 1;
-		byEvent.set(row.event, summary);
-	}
-	return [...byEvent.values()].sort((a, b) => a.event.localeCompare(b.event));
+			total_tokens_read: row.tokens_read,
+			total_tokens_written: row.tokens_written,
+			total_tokens_saved: row.tokens_saved,
+			count: row.count,
+		}))
+		.sort((a, b) => a.event.localeCompare(b.event));
 }
 
-function totalUsageEvents(rows: UsageRow[]): Record<string, unknown> {
+/**
+ * Sum the neutral core aggregate rows into the ApiUsageTotals wire shape.
+ */
+function totalsFromAggregate(rows: UsageAggregateRow[]): {
+	tokens_read: number;
+	tokens_written: number;
+	tokens_saved: number;
+	count: number;
+} {
 	return rows.reduce(
 		(acc, row) => ({
-			tokens_read: Number(acc.tokens_read) + row.tokens_read,
-			tokens_written: Number(acc.tokens_written) + row.tokens_written,
-			tokens_saved: Number(acc.tokens_saved) + row.tokens_saved,
-			count: Number(acc.count) + 1,
+			tokens_read: acc.tokens_read + row.tokens_read,
+			tokens_written: acc.tokens_written + row.tokens_written,
+			tokens_saved: acc.tokens_saved + row.tokens_saved,
+			count: acc.count + row.count,
 		}),
-		{ tokens_read: 0, tokens_written: 0, tokens_saved: 0, count: 0 } as Record<string, unknown>,
+		{ tokens_read: 0, tokens_written: 0, tokens_saved: 0, count: 0 },
 	);
 }
 
@@ -232,12 +237,12 @@ interface UsageCacheEntry {
  * Short-lived cache for the computed /api/usage payload.
  *
  * The health dot polls /api/usage on every 5s refresh regardless of the
- * active tab, and the computation scans the full usage_events table to apply
- * scope visibility before aggregating. The resulting token totals are
- * cumulative dashboard figures, so a few seconds of staleness is acceptable
- * in exchange for collapsing the repeated full-table scan on the polling
- * loop. Keyed by db path + scope identity + project filter so distinct
- * stores/projects never share an entry.
+ * active tab. The token/event totals come from indexed SQL aggregates and the
+ * recent-pack window runs scope-visibility resolution over its bounded set, so
+ * each miss is cheap — but the totals are cumulative dashboard figures where a
+ * few seconds of staleness is acceptable, so caching still collapses the
+ * repeated recompute on the polling loop. Keyed by db path + scope identity +
+ * project filter so distinct stores/projects never share an entry.
  */
 const usagePayloadCache = new Map<string, UsageCacheEntry>();
 const USAGE_PAYLOAD_CACHE_MS = 10_000;
@@ -396,7 +401,30 @@ export function statsRoutes(getStore: () => MemoryStore) {
 			if (cached && nowMs < cached.expiresAtMs) {
 				return c.json(cached.payload);
 			}
-			const loadUsageRows = (project?: string | null): UsageRow[] => {
+
+			// Token/event aggregates are unfiltered SQL GROUP BYs (matching
+			// store.stats()), so they never load the full usage_events table
+			// into JS. Only the small surfaced recent_packs window below keeps
+			// per-row scope visibility + metadata sanitization.
+			const globalAggregate = store.usageAggregate();
+			const eventsGlobal = mapAggregateEvents(globalAggregate);
+			const totalsGlobal = totalsFromAggregate(globalAggregate);
+			const filteredAggregate = projectFilter ? store.usageAggregate(projectFilter) : null;
+			const eventsFiltered = filteredAggregate ? mapAggregateEvents(filteredAggregate) : null;
+			const totalsFiltered = filteredAggregate ? totalsFromAggregate(filteredAggregate) : null;
+
+			// recent_packs candidate window. Over-fetch the most-recent pack
+			// events (20x the 10 we surface) so that, in the common case where a
+			// device sees most of its own packs, 10 *visible* packs survive the
+			// scope filter below without ever scanning the whole table.
+			// Tradeoff vs. the old full-scan-then-slice: if MORE than
+			// (LIMIT - 10) of the newest packs are non-visible, fewer than 10
+			// surface, and a visible pack older than the newest 200 is not
+			// shown at all. That only bites a heavily-shared DB whose recent
+			// activity is dominated by other scopes; for an activity widget the
+			// bounded recompute on a 5s poll is the right call.
+			const RECENT_PACK_SCAN_LIMIT = 200;
+			const loadRecentPackWindow = (project?: string | null): UsageRow[] => {
 				const rows = project
 					? (store.db
 							.prepare(
@@ -405,39 +433,27 @@ export function statsRoutes(getStore: () => MemoryStore) {
 									usage_events.created_at, usage_events.metadata_json
 								 FROM usage_events
 								 JOIN sessions ON sessions.id = usage_events.session_id
-								 WHERE sessions.project = ?
-								 ORDER BY usage_events.created_at DESC`,
+								 WHERE sessions.project = ? AND usage_events.event = 'pack'
+								 ORDER BY usage_events.created_at DESC
+								 LIMIT ?`,
 							)
-							.all(project) as Record<string, unknown>[])
+							.all(project, RECENT_PACK_SCAN_LIMIT) as Record<string, unknown>[])
 					: (store.db
 							.prepare(
 								`SELECT id, session_id, event, tokens_read, tokens_written, tokens_saved,
 									created_at, metadata_json
 								 FROM usage_events
-								 ORDER BY created_at DESC`,
+								 WHERE event = 'pack'
+								 ORDER BY created_at DESC
+								 LIMIT ?`,
 							)
-							.all() as Record<string, unknown>[]);
+							.all(RECENT_PACK_SCAN_LIMIT) as Record<string, unknown>[]);
 				return rows.map((row) => toUsageRow(row, parseMetadataJson(row.metadata_json)));
 			};
-			const loadedGlobalRows = loadUsageRows();
-			const globalVisibility = buildUsageVisibility(store, loadedGlobalRows);
-			const globalRows = loadedGlobalRows.filter((row) => usageRowVisible(row, globalVisibility));
-			const loadedFilteredRows = projectFilter ? loadUsageRows(projectFilter) : null;
-			const filteredVisibility = loadedFilteredRows
-				? buildUsageVisibility(store, loadedFilteredRows)
-				: null;
-			const filteredRows = loadedFilteredRows
-				? loadedFilteredRows.filter((row) =>
-						usageRowVisible(row, filteredVisibility ?? globalVisibility),
-					)
-				: null;
-			const eventsGlobal = summarizeUsageEvents(globalRows);
-			const totalsGlobal = totalUsageEvents(globalRows);
-			const eventsFiltered = filteredRows ? summarizeUsageEvents(filteredRows) : null;
-			const totalsFiltered = filteredRows ? totalUsageEvents(filteredRows) : null;
-			const recentVisibility = filteredVisibility ?? globalVisibility;
-			const recentPacks = (filteredRows ?? globalRows)
-				.filter((row) => row.event === "pack")
+			const recentWindow = loadRecentPackWindow(projectFilter);
+			const recentVisibility = buildUsageVisibility(store, recentWindow);
+			const recentPacks = recentWindow
+				.filter((row) => usageRowVisible(row, recentVisibility))
 				.slice(0, 10)
 				.map((row) => ({
 					...row,


### PR DESCRIPTION
## Description

The code half of the storage-reclaim work (`raw_events` is the largest prunable table). It adds the knobs and a CLI — it does **not** prune any live database on its own; enabling retention or running the prune is an explicit user action.

`raw_events` grows forever by default: the only purge path (`purgeRawEvents`) ran only when the **undocumented** env var `CODEMEM_RAW_EVENTS_RETENTION_MS > 0` (defaults 0).

- **Config keys** mirroring `sync_retention_*`: `raw_events_retention_enabled` (`CODEMEM_RAW_EVENTS_RETENTION_ENABLED`, default `false`) and `raw_events_retention_max_age_days` (`CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS`, default `90` — conservative because `raw_events` is the re-extraction source). The sweeper's `retentionMs()` now resolves from these, falling back to the legacy env var for back-compat.
- **CLI** `codemem db prune-raw-events [--dry-run] [--max-age-days <days>=90] [--vacuum]` mirroring `prune-replication-ops`. Dry-run reports row count + size + candidate count without deleting; real run calls `purgeRawEvents`; `--vacuum` reclaims file size. Warns prominently that age-based purge is **not** extraction-aware.
- New `MemoryStore.rawEventsRetentionStatus(maxAgeMs)` estimator backing the dry-run.

Retention stays **disabled by default**.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
