### PR TITLE
fix(ui): avoid serving stale precompressed bundles in build:watch

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"clean": "rm -rf ../viewer-server/static",
 		"dev": "node ./scripts/make-dev-html.mjs && vite",
-		"build": "vite build --mode production && node ./scripts/stage-viewer-static.mjs",
+		"build": "vite build --mode production && node ./scripts/stage-viewer-static.mjs --precompress",
 		"build:watch": "node ./scripts/stage-viewer-static.mjs && vite build --watch --mode development",
 		"test": "pnpm exec vitest run",
 		"typecheck": "tsc -p tsconfig.json --noEmit"

--- a/packages/ui/scripts/stage-viewer-static.mjs
+++ b/packages/ui/scripts/stage-viewer-static.mjs
@@ -1,4 +1,12 @@
-import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { brotliCompressSync, constants as zlibConstants, gzipSync } from "node:zlib";
@@ -22,17 +30,29 @@ for (const entry of readdirSync(sourceStaticDir, { withFileTypes: true })) {
 }
 
 // Precompress text assets so the viewer server (serveStatic precompressed:true)
-// serves .br/.gz. Done HERE, as the final build step, so every asset is the
-// freshly-staged content: app.js was written into viewerStaticDir by vite, and
-// the CSS above was just copied. Compressing in vite's writeBundle instead would
-// race the CSS staging and emit stale/missing CSS siblings.
+// serves .br/.gz — but ONLY for production builds, gated behind --precompress.
+//
+// The production `build` runs this AFTER vite, so the staged assets are final
+// and we emit fresh sidecars. `build:watch` runs this BEFORE vite (and vite
+// then rebuilds app.js on every change without re-staging), so emitting
+// sidecars there would leave stale .gz/.br that serveStatic would serve instead
+// of the freshly rebuilt bundle. In that mode we instead STRIP any existing
+// sidecars so the server falls back to the live raw asset.
+const precompress = process.argv.includes("--precompress");
 for (const name of ["app.js", "themes.css", "tokens.css"]) {
 	const filePath = join(viewerStaticDir, name);
+	const gzPath = `${filePath}.gz`;
+	const brPath = `${filePath}.br`;
+	if (!precompress) {
+		rmSync(gzPath, { force: true });
+		rmSync(brPath, { force: true });
+		continue;
+	}
 	if (!existsSync(filePath)) continue;
 	const raw = readFileSync(filePath);
-	writeFileSync(`${filePath}.gz`, gzipSync(raw, { level: 9 }));
+	writeFileSync(gzPath, gzipSync(raw, { level: 9 }));
 	writeFileSync(
-		`${filePath}.br`,
+		brPath,
 		brotliCompressSync(raw, { params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 11 } }),
 	);
 }


### PR DESCRIPTION
## Description

Follow-up to the viewer-bundle precompression in #1273 (the precompression sidecars were added to `stage-viewer-static.mjs`).

That precompression ran unconditionally. In the production `build` the staging script runs **after** vite, so the `.gz`/`.br` sidecars are fresh — correct. But `build:watch` runs the staging script **before** `vite build --watch`, which then rebuilds `app.js` on every change without re-staging. With `serveStatic({ precompressed: true })`, a browser advertising gzip/brotli was served the **stale** `app.js.gz`/`.br` instead of the freshly rebuilt bundle.

Fix:
- Gate compression behind a `--precompress` flag, passed only by the production `build` script.
- In dev/watch (no flag), **strip** any existing `.gz`/`.br` sidecars so `serveStatic` falls back to the live raw asset.

Verified: the production build emits fresh sidecars (the `.br` decompresses byte-for-byte to the current `app.js`); a bare staging run (dev/watch) removes them.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Verified both modes: `pnpm --filter @codemem/ui build` (`--precompress`) emits fresh sidecars; a bare `node ./scripts/stage-viewer-static.mjs` strips them. tsc + lint clean. (No unit test added — it's a build-staging script, validated by exercising both paths.)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
