### PR TITLE
fix(sync): purge replication_cursors_v2 (+ all per-peer state) on peer removal

### DIFF
--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -421,11 +421,27 @@ describe("formatSyncAttempt", () => {
 					"INSERT INTO replication_cursors(peer_device_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?)",
 				)
 				.run("peer-1", "cursor-1", "cursor-1", new Date().toISOString());
+			// The v2 cursor drives the replication retention floor; removal must
+			// clear it or replication_ops can never prune past this peer.
+			store.db
+				.prepare(
+					"INSERT INTO replication_cursors_v2(peer_device_id, scope_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?, ?)",
+				)
+				.run("peer-1", "local-default", "cursor-1", "cursor-1", new Date().toISOString());
 			const peers = syncCommand.commands.find((command) => command.name() === "peers");
 			const remove = peers?.commands.find((command) => command.name() === "remove");
 			await remove?.parseAsync(["work", "--db-path", dbPath, "--json"], { from: "user" });
 			expect(logSpy).toHaveBeenCalledWith(
-				JSON.stringify({ ok: true, peer_device_id: "peer-1", name: "work" }, null, 2),
+				JSON.stringify(
+					{
+						ok: true,
+						peer_device_id: "peer-1",
+						name: "work",
+						removed: { cursors: 1, cursorsV2: 1, peers: 1, attempts: 0, rejections: 0 },
+					},
+					null,
+					2,
+				),
 			);
 			const row = store.db
 				.prepare("SELECT peer_device_id FROM sync_peers WHERE peer_device_id = ?")
@@ -433,8 +449,117 @@ describe("formatSyncAttempt", () => {
 			const cursor = store.db
 				.prepare("SELECT peer_device_id FROM replication_cursors WHERE peer_device_id = ?")
 				.get("peer-1");
+			const cursorV2 = store.db
+				.prepare("SELECT peer_device_id FROM replication_cursors_v2 WHERE peer_device_id = ?")
+				.get("peer-1");
 			expect(row).toBeUndefined();
 			expect(cursor).toBeUndefined();
+			expect(cursorV2).toBeUndefined();
+			expect(process.exitCode).toBeUndefined();
+		} finally {
+			logSpy.mockRestore();
+			store.close();
+			rmSync(tmpDbDir, { recursive: true, force: true });
+			process.exitCode = prevExitCode;
+		}
+	});
+
+	it("removes a stranded orphan device id with only a replication_cursors_v2 row", async () => {
+		const tmpDbDir = mkdtempSync(join(tmpdir(), "sync-peers-remove-orphan-test-"));
+		const dbPath = join(tmpDbDir, "mem.sqlite");
+		const rawDb = connect(dbPath);
+		initTestSchema(rawDb);
+		rawDb.close();
+		const store = new MemoryStore(dbPath);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const prevExitCode = process.exitCode;
+		process.exitCode = undefined;
+		try {
+			// No sync_peers row — only a stranded v2 cursor that pins the
+			// retention floor. Removal by device id must still succeed.
+			store.db
+				.prepare(
+					"INSERT INTO replication_cursors_v2(peer_device_id, scope_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?, ?)",
+				)
+				.run("orphan-device", "local-default", "cursor-1", "cursor-1", new Date().toISOString());
+			const peers = syncCommand.commands.find((command) => command.name() === "peers");
+			const remove = peers?.commands.find((command) => command.name() === "remove");
+			await remove?.parseAsync(["orphan-device", "--db-path", dbPath, "--json"], { from: "user" });
+			expect(logSpy).toHaveBeenCalledWith(
+				JSON.stringify(
+					{
+						ok: true,
+						peer_device_id: "orphan-device",
+						name: null,
+						removed: { cursors: 0, cursorsV2: 1, peers: 0, attempts: 0, rejections: 0 },
+					},
+					null,
+					2,
+				),
+			);
+			const cursorV2 = store.db
+				.prepare("SELECT peer_device_id FROM replication_cursors_v2 WHERE peer_device_id = ?")
+				.get("orphan-device");
+			expect(cursorV2).toBeUndefined();
+			// Did not fail: not-found would set exit code 1.
+			expect(process.exitCode).toBeUndefined();
+		} finally {
+			logSpy.mockRestore();
+			store.close();
+			rmSync(tmpDbDir, { recursive: true, force: true });
+			process.exitCode = prevExitCode;
+		}
+	});
+
+	it("prefers an orphan cursor id over a registered peer whose name collides with it", async () => {
+		const tmpDbDir = mkdtempSync(join(tmpdir(), "sync-peers-remove-collision-test-"));
+		const dbPath = join(tmpDbDir, "mem.sqlite");
+		const rawDb = connect(dbPath);
+		initTestSchema(rawDb);
+		rawDb.close();
+		const store = new MemoryStore(dbPath);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const prevExitCode = process.exitCode;
+		process.exitCode = undefined;
+		try {
+			// A live registered peer whose NAME equals an orphan's device id, plus
+			// the stranded orphan v2 cursor under that same id. Removal by id must
+			// target the orphan cursor (exact id), NOT the name-matched live peer.
+			store.db
+				.prepare("INSERT INTO sync_peers(peer_device_id, name, created_at) VALUES (?, ?, ?)")
+				.run("real-device", "collision-id", new Date().toISOString());
+			store.db
+				.prepare(
+					"INSERT INTO replication_cursors_v2(peer_device_id, scope_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?, ?)",
+				)
+				.run("collision-id", "local-default", "cursor-1", "cursor-1", new Date().toISOString());
+			const peers = syncCommand.commands.find((command) => command.name() === "peers");
+			const remove = peers?.commands.find((command) => command.name() === "remove");
+			await remove?.parseAsync(["collision-id", "--db-path", dbPath, "--json"], { from: "user" });
+			expect(logSpy).toHaveBeenCalledWith(
+				JSON.stringify(
+					{
+						ok: true,
+						peer_device_id: "collision-id",
+						name: null,
+						removed: { cursors: 0, cursorsV2: 1, peers: 0, attempts: 0, rejections: 0 },
+					},
+					null,
+					2,
+				),
+			);
+			// The orphan cursor is gone...
+			expect(
+				store.db
+					.prepare("SELECT peer_device_id FROM replication_cursors_v2 WHERE peer_device_id = ?")
+					.get("collision-id"),
+			).toBeUndefined();
+			// ...and the live peer that merely shares the name is untouched.
+			expect(
+				store.db
+					.prepare("SELECT peer_device_id FROM sync_peers WHERE peer_device_id = ?")
+					.get("real-device"),
+			).toEqual({ peer_device_id: "real-device" });
 			expect(process.exitCode).toBeUndefined();
 		} finally {
 			logSpy.mockRestore();

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -16,6 +16,7 @@ import {
 	ensureDeviceIdentity,
 	fetchAllSnapshotPages,
 	fingerprintPublicKey,
+	forgetSyncPeerState,
 	getSemanticIndexDiagnostics,
 	hasUnsyncedSharedMemoryChanges,
 	listPerPeerScopeSyncState,
@@ -113,6 +114,23 @@ function resolvePeerMatch(
 		.where(eq(schema.syncPeers.peer_device_id, trimmed))
 		.get();
 	if (byId) return byId;
+	// Stranded/orphan cursor rows: a peer whose sync_peers row is already gone but
+	// whose replication_cursors(_v2) rows still linger. Resolved by exact device id
+	// BEFORE the name lookup below, so an exact id always wins over a registered
+	// peer whose *name* happens to equal that id (otherwise `remove <orphan-id>`
+	// could target the wrong peer and leave the orphan still pinning retention).
+	const orphanCursor =
+		db
+			.select({ peer_device_id: schema.replicationCursorsV2.peer_device_id })
+			.from(schema.replicationCursorsV2)
+			.where(eq(schema.replicationCursorsV2.peer_device_id, trimmed))
+			.get() ??
+		db
+			.select({ peer_device_id: schema.replicationCursors.peer_device_id })
+			.from(schema.replicationCursors)
+			.where(eq(schema.replicationCursors.peer_device_id, trimmed))
+			.get();
+	if (orphanCursor) return { peer_device_id: trimmed, name: null };
 	const byName = db
 		.select({ peer_device_id: schema.syncPeers.peer_device_id, name: schema.syncPeers.name })
 		.from(schema.syncPeers)
@@ -1091,23 +1109,24 @@ peersRemoveCmd.action((peerRef: string, opts: { db?: string; dbPath?: string; js
 			process.exitCode = 1;
 			return;
 		}
-		d.delete(schema.replicationCursors)
-			.where(eq(schema.replicationCursors.peer_device_id, match.peer_device_id))
-			.run();
-		d.delete(schema.syncPeers)
-			.where(eq(schema.syncPeers.peer_device_id, match.peer_device_id))
-			.run();
+		// Purge every per-peer table (incl. replication_cursors_v2, which drives
+		// the replication retention floor) so removal can't leave orphan rows
+		// that block replication_ops pruning.
+		const { removed } = forgetSyncPeerState(store.db, match.peer_device_id);
 		const payload = {
 			ok: true,
 			peer_device_id: match.peer_device_id,
 			name: match.name,
+			removed,
 		};
 		if (opts.json) {
 			console.log(JSON.stringify(payload, null, 2));
 			return;
 		}
 		p.intro("codemem sync peers remove");
-		p.log.success(`Removed peer ${match.name || match.peer_device_id}`);
+		p.log.success(
+			`Removed peer ${match.name || match.peer_device_id} (cleared ${removed.cursorsV2} cursor(s))`,
+		);
 		p.outro(match.peer_device_id);
 	} finally {
 		store.close();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -614,6 +614,7 @@ export {
 	extractReplicationOps,
 	filterReplicationOpsForSync,
 	filterReplicationOpsForSyncWithStatus,
+	forgetSyncPeerState,
 	getReplicationCursor,
 	getSyncResetState,
 	hasUnsyncedSharedMemoryChanges,

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -14,6 +14,7 @@ import {
 	extractReplicationOps,
 	filterReplicationOpsForSync,
 	filterReplicationOpsForSyncWithStatus,
+	forgetSyncPeerState,
 	getReplicationCursor,
 	getSyncResetState,
 	hasUnsyncedSharedMemoryChanges,
@@ -165,6 +166,101 @@ describe("replication cursors", () => {
 		setReplicationCursor(db, "peer-legacy", { lastApplied: "new-applied" });
 
 		expect(getReplicationCursor(db, "peer-legacy")).toEqual(["new-applied", "legacy-acked"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// forgetSyncPeerState
+// ---------------------------------------------------------------------------
+
+describe("forgetSyncPeerState", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	function seedPeer(peerDeviceId: string): void {
+		const now = "2026-01-01T00:00:00Z";
+		db.prepare(
+			"INSERT INTO replication_cursors(peer_device_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?)",
+		).run(peerDeviceId, "c1", "c1", now);
+		db.prepare(
+			"INSERT INTO replication_cursors_v2(peer_device_id, scope_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?, ?)",
+		).run(peerDeviceId, DEFAULT_SYNC_SCOPE_ID, "c1", "c1", now);
+		db.prepare("INSERT INTO sync_peers(peer_device_id, name, created_at) VALUES (?, ?, ?)").run(
+			peerDeviceId,
+			`name-${peerDeviceId}`,
+			now,
+		);
+		db.prepare(
+			"INSERT INTO sync_attempts(peer_device_id, started_at, ok, ops_in, ops_out) VALUES (?, ?, ?, ?, ?)",
+		).run(peerDeviceId, now, 1, 0, 0);
+		db.prepare(
+			"INSERT INTO sync_scope_rejections(peer_device_id, op_id, entity_type, entity_id, reason, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+		).run(peerDeviceId, `op-${peerDeviceId}`, "memory_item", `ent-${peerDeviceId}`, "scope", now);
+	}
+
+	const countFor = (table: string, peerDeviceId: string): number =>
+		Number(
+			(
+				db
+					.prepare(`SELECT count(*) AS n FROM ${table} WHERE peer_device_id = ?`)
+					.get(peerDeviceId) as { n: number }
+			).n,
+		);
+
+	it("purges all five per-peer tables for the target peer and leaves others intact", () => {
+		seedPeer("peer-1");
+		seedPeer("peer-2");
+
+		const result = forgetSyncPeerState(db, "peer-1");
+
+		expect(result).toEqual({
+			peer_device_id: "peer-1",
+			removed: { cursors: 1, cursorsV2: 1, peers: 1, attempts: 1, rejections: 1 },
+		});
+
+		// Peer 1 fully purged across every table.
+		expect(countFor("replication_cursors", "peer-1")).toBe(0);
+		expect(countFor("replication_cursors_v2", "peer-1")).toBe(0);
+		expect(countFor("sync_peers", "peer-1")).toBe(0);
+		expect(countFor("sync_attempts", "peer-1")).toBe(0);
+		expect(countFor("sync_scope_rejections", "peer-1")).toBe(0);
+
+		// Peer 2 untouched.
+		expect(countFor("replication_cursors", "peer-2")).toBe(1);
+		expect(countFor("replication_cursors_v2", "peer-2")).toBe(1);
+		expect(countFor("sync_peers", "peer-2")).toBe(1);
+		expect(countFor("sync_attempts", "peer-2")).toBe(1);
+		expect(countFor("sync_scope_rejections", "peer-2")).toBe(1);
+	});
+
+	it("is a no-op with zeroed counts for an empty id", () => {
+		seedPeer("peer-1");
+		const result = forgetSyncPeerState(db, "   ");
+		expect(result).toEqual({
+			peer_device_id: "",
+			removed: { cursors: 0, cursorsV2: 0, peers: 0, attempts: 0, rejections: 0 },
+		});
+		expect(countFor("sync_peers", "peer-1")).toBe(1);
+	});
+
+	it("removes a stranded v2 cursor even when no sync_peers row exists", () => {
+		db.prepare(
+			"INSERT INTO replication_cursors_v2(peer_device_id, scope_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?, ?)",
+		).run("orphan", DEFAULT_SYNC_SCOPE_ID, "c1", "c1", "2026-01-01T00:00:00Z");
+
+		const result = forgetSyncPeerState(db, "orphan");
+
+		expect(result.removed.cursorsV2).toBe(1);
+		expect(result.removed.peers).toBe(0);
+		expect(countFor("replication_cursors_v2", "orphan")).toBe(0);
 	});
 });
 

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -699,6 +699,65 @@ export function clearReplicationCursorLastApplied(
 		.run();
 }
 
+export interface ForgetSyncPeerStateResult {
+	peer_device_id: string;
+	removed: {
+		cursors: number;
+		cursorsV2: number;
+		peers: number;
+		attempts: number;
+		rejections: number;
+	};
+}
+
+/**
+ * Purge all per-peer sync state for a removed peer device, in one transaction.
+ *
+ * Deletes rows keyed on `peer_device_id` from every per-peer table:
+ *   - replication_cursors (v1)
+ *   - replication_cursors_v2 (v2 — drives the replication retention "retained
+ *     floor"; orphaned rows here pin the floor and block replication_ops prune)
+ *   - sync_peers
+ *   - sync_attempts
+ *   - sync_scope_rejections (peer_device_id is nullable; NULL rows never match)
+ *
+ * Returns per-table deleted-row counts. An empty/whitespace id is a no-op.
+ */
+export function forgetSyncPeerState(db: Database, peerDeviceId: string): ForgetSyncPeerStateResult {
+	const id = String(peerDeviceId ?? "").trim();
+	if (!id) {
+		return {
+			peer_device_id: "",
+			removed: { cursors: 0, cursorsV2: 0, peers: 0, attempts: 0, rejections: 0 },
+		};
+	}
+	const d = drizzle(db, { schema });
+	const removed = db.transaction(() => {
+		const cursors = d
+			.delete(schema.replicationCursors)
+			.where(eq(schema.replicationCursors.peer_device_id, id))
+			.run().changes;
+		const cursorsV2 = d
+			.delete(schema.replicationCursorsV2)
+			.where(eq(schema.replicationCursorsV2.peer_device_id, id))
+			.run().changes;
+		const peers = d
+			.delete(schema.syncPeers)
+			.where(eq(schema.syncPeers.peer_device_id, id))
+			.run().changes;
+		const attempts = d
+			.delete(schema.syncAttempts)
+			.where(eq(schema.syncAttempts.peer_device_id, id))
+			.run().changes;
+		const rejections = d
+			.delete(schema.syncScopeRejections)
+			.where(eq(schema.syncScopeRejections.peer_device_id, id))
+			.run().changes;
+		return { cursors, cursorsV2, peers, attempts, rejections };
+	})();
+	return { peer_device_id: id, removed };
+}
+
 // Payload extraction
 
 /**


### PR DESCRIPTION
## Description

`codemem sync peers remove` deleted only `replication_cursors` (v1) and `sync_peers` — but the replication retention **retained floor** is computed from `replication_cursors_v2`. The orphaned v2 row left behind **pinned the floor at the removed peer's position permanently**, so `replication_ops` could never be pruned past it → unbounded DB growth after removing a peer. (This is the root cause behind multi-GB `replication_ops` blowups, and why retention "silently stops working" once a device is removed.)

- **New core helper** `forgetSyncPeerState(db, peerDeviceId)`: in one transaction, deletes every per-peer-keyed table — `replication_cursors`, `replication_cursors_v2`, `sync_peers`, `sync_attempts`, `sync_scope_rejections` — and returns per-table removed counts. Exported from `@codemem/core`.
- `sync peers remove` now calls it (previously left v2 + attempts + rejections behind).
- **`resolvePeerMatch` now resolves stranded orphans:** a peer whose `sync_peers` row is already gone but whose `replication_cursors(_v2)` rows linger can now be targeted by device id (previously unreachable — orphans were un-removable). Name lookup stays `sync_peers`-only.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

`forgetSyncPeerState` purges all 5 per-peer tables and leaves other peers intact; removing a registered peer now clears its `replication_cursors_v2` row; removing a stranded orphan id (only a v2 cursor row) succeeds and clears it. Full `packages/core` + `packages/cli` suites pass (1846 tests).

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
