### PR TITLE
fix(cli): prune-replication-ops prunes all scopes + honest whole-table size report

### DIFF
--- a/packages/cli/src/commands/db.test.ts
+++ b/packages/cli/src/commands/db.test.ts
@@ -248,4 +248,102 @@ describe("db command", () => {
 			logErrorSpy.mockRestore();
 		}
 	});
+
+	// `null` scope_id is the DEFAULT scope (matched by scope_id IS NULL OR = local-default).
+	function seedReplicationOp(
+		store: MemoryStore,
+		opId: string,
+		scopeId: string | null,
+		createdAtIso: string,
+	) {
+		store.db
+			.prepare(
+				`INSERT INTO replication_ops
+				 (op_id, entity_type, entity_id, op_type, payload_json, clock_rev,
+				  clock_updated_at, clock_device_id, device_id, created_at, scope_id)
+				 VALUES (?, 'memory_item', ?, 'upsert', '{}', 1, ?, 'dev-a', 'dev-a', ?, ?)`,
+			)
+			.run(opId, `ent-${opId}`, createdAtIso, createdAtIso, scopeId);
+	}
+
+	function countReplicationOpsByScope(dbPath: string): Map<string | null, number> {
+		const store = new MemoryStore(dbPath);
+		try {
+			const rows = store.db
+				.prepare(
+					"SELECT scope_id AS scope_id, COUNT(*) AS cnt FROM replication_ops GROUP BY scope_id",
+				)
+				.all() as Array<{ scope_id: string | null; cnt: number }>;
+			const counts = new Map<string | null, number>();
+			for (const row of rows) counts.set(row.scope_id, Number(row.cnt));
+			return counts;
+		} finally {
+			store.close();
+		}
+	}
+
+	it("prune-replication-ops deletes old ops across ALL scopes, not just the default", async () => {
+		const pruneRepl = dbCommand.commands.find(
+			(command) => command.name() === "prune-replication-ops",
+		);
+		expect(pruneRepl).toBeDefined();
+		if (!pruneRepl) throw new Error("expected prune-replication-ops command");
+
+		const dbPath = join(mkdtempSync(join(tmpdir(), "codemem-db-prune-repl-")), "test.sqlite");
+		initDatabase(dbPath);
+		// All rows are well older than a 30-day cutoff so the age pass removes them.
+		// No replication_cursors are seeded, so no retained floor blocks deletion.
+		const oldIso = new Date(Date.now() - 200 * 86_400_000).toISOString();
+		const store = new MemoryStore(dbPath);
+		seedReplicationOp(store, "op-default-1", null, oldIso);
+		seedReplicationOp(store, "op-default-2", null, oldIso);
+		seedReplicationOp(store, "op-oss-1", "oss", oldIso);
+		seedReplicationOp(store, "op-oss-2", "oss", oldIso);
+		seedReplicationOp(store, "op-legacy-1", "legacy-shared-review", oldIso);
+		seedReplicationOp(store, "op-legacy-2", "legacy-shared-review", oldIso);
+		store.close();
+
+		const before = countReplicationOpsByScope(dbPath);
+		expect(before.get(null)).toBe(2);
+		expect(before.get("oss")).toBe(2);
+		expect(before.get("legacy-shared-review")).toBe(2);
+
+		await pruneRepl.parseAsync(
+			["node", "prune-replication-ops", "--db-path", dbPath, "--max-age-days", "30"],
+			{ from: "node" },
+		);
+
+		// Every scope must be pruned to zero — the regression deletes only the default scope.
+		const after = countReplicationOpsByScope(dbPath);
+		expect(after.get(null) ?? 0).toBe(0);
+		expect(after.get("oss") ?? 0).toBe(0);
+		expect(after.get("legacy-shared-review") ?? 0).toBe(0);
+	});
+
+	it("prune-replication-ops --dry-run deletes nothing across all scopes", async () => {
+		const pruneRepl = dbCommand.commands.find(
+			(command) => command.name() === "prune-replication-ops",
+		);
+		expect(pruneRepl).toBeDefined();
+		if (!pruneRepl) throw new Error("expected prune-replication-ops command");
+
+		const dbPath = join(mkdtempSync(join(tmpdir(), "codemem-db-prune-repl-dry-")), "test.sqlite");
+		initDatabase(dbPath);
+		const oldIso = new Date(Date.now() - 200 * 86_400_000).toISOString();
+		const store = new MemoryStore(dbPath);
+		seedReplicationOp(store, "op-default-1", null, oldIso);
+		seedReplicationOp(store, "op-oss-1", "oss", oldIso);
+		seedReplicationOp(store, "op-legacy-1", "legacy-shared-review", oldIso);
+		store.close();
+
+		await pruneRepl.parseAsync(
+			["node", "prune-replication-ops", "--db-path", dbPath, "--max-age-days", "30", "--dry-run"],
+			{ from: "node" },
+		);
+
+		const after = countReplicationOpsByScope(dbPath);
+		expect(after.get(null)).toBe(1);
+		expect(after.get("oss")).toBe(1);
+		expect(after.get("legacy-shared-review")).toBe(1);
+	});
 });

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -11,6 +11,7 @@ import {
 	dedupNearDuplicateMemories,
 	getRawEventStatus,
 	initDatabase,
+	listRetentionScopeIds,
 	MemoryStore,
 	planReplicationOpsAgePrune,
 	pruneReplicationOpsUntilCaughtUp,
@@ -125,7 +126,7 @@ const pruneReplCmd = new Command("prune-replication-ops")
 	)
 	.option("--dry-run", "show current size/targets without deleting")
 	.option("--max-age-days <days>", "retention age threshold in days", "30")
-	.option("--max-size-mb <mb>", "target replication log budget in MB", "512")
+	.option("--max-size-mb <mb>", "target per-scope replication log budget in MB", "512")
 	.option("--batch-ops <n>", "max ops deleted per batch", "5000")
 	.option("--batch-runtime-ms <ms>", "max runtime per batch in ms", "2000")
 	.option("--vacuum", "run VACUUM explicitly after prune completes");
@@ -153,12 +154,19 @@ pruneReplCmd.action(
 			p.intro("codemem db prune-replication-ops");
 			p.log.info(`Replication ops size: ${formatBytes(beforeBytes)}`);
 			p.log.info(
-				`Policy: approximately prune oldest-first toward <= ${maxSizeMb} MB while removing history older than ${maxAgeDays} day(s), subject to per-pass batch/runtime limits`,
+				`Policy: across all replication scopes, approximately prune oldest-first toward <= ${maxSizeMb} MB PER SCOPE while removing history older than ${maxAgeDays} day(s), subject to per-pass batch/runtime limits (the size budget is applied per scope, matching the background retention runner; total ops across scopes may exceed it)`,
 			);
+			// Enumerate every replication scope present in the DB (DEFAULT first).
+			// The background retention runner prunes all of them; the offline CLI
+			// must too, otherwise scopes like legacy-shared-review/oss are never
+			// reclaimed and the command is useless for a bloated multi-scope DB.
+			const scopeIds = listRetentionScopeIds(db);
+			// planReplicationOpsAgePrune is whole-table (no scope filter), so the
+			// candidate count already reflects every scope the real prune will cover.
 			const agePlan = planReplicationOpsAgePrune(db, maxAgeDays, batchOps);
 			if (agePlan.candidate_ops > 0) {
 				p.log.info(
-					`Age pass plan: ${agePlan.candidate_ops.toLocaleString()} ops, ~${formatBytes(agePlan.estimated_candidate_bytes)} in ~${agePlan.estimated_batches.toLocaleString()} batch(es), cutoff ${agePlan.cutoff_cursor}`,
+					`Age pass plan (all scopes): ${agePlan.candidate_ops.toLocaleString()} ops, ~${formatBytes(agePlan.estimated_candidate_bytes)} in ~${agePlan.estimated_batches.toLocaleString()} batch(es), cutoff ${agePlan.cutoff_cursor}`,
 				);
 			} else {
 				p.log.info("Age pass plan: no ops older than cutoff");
@@ -169,26 +177,42 @@ pruneReplCmd.action(
 				return;
 			}
 
-			const loopResult = pruneReplicationOpsUntilCaughtUp(db, {
-				maxAgeDays,
-				maxSizeBytes: maxSizeMb * 1024 * 1024,
-				maxDeleteOps: batchOps,
-				maxRuntimeMs: batchRuntimeMs,
-				onPass: (pass) => {
-					if (pass.deleted === 0 && !pass.stoppedByBudget) return;
-					const suffix = pass.stoppedByBudget ? " (budget-limited)" : "";
-					p.log.step(
-						`Pass ${pass.passNumber}: deleted ${pass.deleted.toLocaleString()} ops, remaining size ~${formatBytes(pass.afterBytes)}${suffix}`,
-					);
-				},
-			});
+			let totalDeleted = 0;
+			let anyStoppedByBudget = false;
+			let lastFloor: string | null = null;
+			for (const scopeId of scopeIds) {
+				const loopResult = pruneReplicationOpsUntilCaughtUp(db, {
+					maxAgeDays,
+					maxSizeBytes: maxSizeMb * 1024 * 1024,
+					maxDeleteOps: batchOps,
+					maxRuntimeMs: batchRuntimeMs,
+					scopeId,
+					onPass: (pass) => {
+						if (pass.deleted === 0 && !pass.stoppedByBudget) return;
+						const suffix = pass.stoppedByBudget ? " (budget-limited)" : "";
+						p.log.step(
+							`scope ${scopeId} pass ${pass.passNumber}: deleted ${pass.deleted.toLocaleString()} ops${suffix}`,
+						);
+					},
+				});
+				totalDeleted += loopResult.totalDeleted;
+				if (loopResult.totalDeleted > 0) {
+					p.log.info(`scope ${scopeId}: deleted ${loopResult.totalDeleted.toLocaleString()} ops`);
+				}
+				if (loopResult.lastFloor) lastFloor = loopResult.lastFloor;
+				if (loopResult.stoppedByBudget) anyStoppedByBudget = true;
+			}
 
-			p.log.info(`Deleted ops: ${loopResult.totalDeleted.toLocaleString()}`);
+			p.log.info(`Deleted ops (all scopes): ${totalDeleted.toLocaleString()}`);
+			// Recompute the whole-table physical size so before/after are the same
+			// dbstat measure. (Per-scope afterBytes is a logical content estimate and
+			// is not comparable to the whole-table before-size.)
+			const afterBytes = estimateReplicationOpsBytes(db);
 			p.log.info(
-				`Estimated replication ops size after prune: ${formatBytes(loopResult.afterBytes)} (approximate)`,
+				`Estimated replication ops size after prune: ${formatBytes(afterBytes)} (approximate)`,
 			);
-			if (loopResult.lastFloor) p.log.info(`Retained floor: ${loopResult.lastFloor}`);
-			if (loopResult.stoppedByBudget) {
+			if (lastFloor) p.log.info(`Retained floor: ${lastFloor}`);
+			if (anyStoppedByBudget) {
 				p.log.warn(
 					"Prune stopped because the current batch/runtime budget was exhausted before retention caught up. Re-run with higher --batch-ops or --batch-runtime-ms for faster catch-up.",
 				);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -639,7 +639,7 @@ export {
 	syncProjectAllowedByFilters,
 	syncVisibilityAllowed,
 } from "./sync-replication.js";
-export { SyncRetentionRunner } from "./sync-retention-runner.js";
+export { listRetentionScopeIds, SyncRetentionRunner } from "./sync-retention-runner.js";
 export type {
 	AuthorizedScopeEntry,
 	PerPeerScopeSyncEntry,

--- a/packages/core/src/sync-retention-runner.test.ts
+++ b/packages/core/src/sync-retention-runner.test.ts
@@ -1,9 +1,10 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { connect } from "./db.js";
-import { runSyncRetentionPass } from "./sync-retention-runner.js";
+import { listRetentionScopeIds, runSyncRetentionPass } from "./sync-retention-runner.js";
 import { initTestSchema } from "./test-utils.js";
 
 function insertReplicationOp(
@@ -152,5 +153,70 @@ describe("runSyncRetentionPass", () => {
 			.prepare("SELECT op_id FROM replication_ops ORDER BY created_at, op_id")
 			.all() as Array<{ op_id: string }>;
 		expect(remaining.map((row) => row.op_id)).toEqual(["op-fresh"]);
+	});
+});
+
+describe("listRetentionScopeIds", () => {
+	let tmpDir: string;
+	let db: ReturnType<typeof connect>;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-list-scopes-test-"));
+		db = connect(join(tmpDir, "scopes.sqlite"));
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("enumerates scopes from replication_ops when the additive v2 state tables are absent", () => {
+		// Simulate a legacy DB opened via the CLI prune path (raw connect(), no
+		// additive-compat shim): the v2 state tables don't exist yet. Enumeration
+		// must not throw `no such table: sync_retention_state_v2`.
+		db.exec("DROP TABLE IF EXISTS sync_reset_state_v2");
+		db.exec("DROP TABLE IF EXISTS sync_retention_state_v2");
+		insertReplicationOp(db, "op-default", "2026-04-01T00:00:00Z", null);
+		insertReplicationOp(db, "op-oss", "2026-04-01T00:00:01Z", "oss");
+		insertReplicationOp(db, "op-lsr", "2026-04-01T00:00:02Z", "legacy-shared-review");
+
+		const scopes = listRetentionScopeIds(db);
+
+		// local-default is always present (NULL scope normalizes to it); the
+		// explicit scopes are enumerated from replication_ops alone.
+		expect(scopes).toContain("local-default");
+		expect(scopes).toContain("oss");
+		expect(scopes).toContain("legacy-shared-review");
+	});
+
+	it("tolerates a legacy replication_ops table that predates the scope_id column", () => {
+		// scope_id is an additive column. A v6/legacy DB opened via the CLI prune
+		// path (raw connect(), no additive-compat shim) can have replication_ops
+		// without it. Enumeration must fall back to the default scope, not throw
+		// `no such column: scope_id` (which would crash prune-replication-ops,
+		// even --dry-run).
+		const legacy = new Database(":memory:");
+		try {
+			legacy.exec(`CREATE TABLE replication_ops (
+				op_id TEXT PRIMARY KEY,
+				entity_type TEXT,
+				entity_id TEXT,
+				op_type TEXT,
+				payload_json TEXT,
+				clock_rev INTEGER,
+				created_at TEXT
+			)`);
+			legacy
+				.prepare(
+					"INSERT INTO replication_ops(op_id, entity_type, entity_id, op_type, created_at) VALUES (?, 'memory_item', 'e1', 'upsert', ?)",
+				)
+				.run("op-legacy", "2026-04-01T00:00:00Z");
+
+			expect(() => listRetentionScopeIds(legacy)).not.toThrow();
+			expect(listRetentionScopeIds(legacy)).toEqual(["local-default"]);
+		} finally {
+			legacy.close();
+		}
 	});
 });

--- a/packages/core/src/sync-retention-runner.ts
+++ b/packages/core/src/sync-retention-runner.ts
@@ -58,28 +58,42 @@ function ensureSyncRetentionStateTables(db: Database): void {
 	`);
 }
 
-function listRetentionScopeIds(db: Database): string[] {
-	const rows = db
-		.prepare(
-			`SELECT scope_id FROM (
-				SELECT COALESCE(NULLIF(TRIM(scope_id), ''), ?) AS scope_id FROM replication_ops
-				UNION
-				SELECT COALESCE(NULLIF(TRIM(scope_id), ''), ?) AS scope_id FROM sync_reset_state_v2
-				UNION
-				SELECT COALESCE(NULLIF(TRIM(scope_id), ''), ?) AS scope_id FROM sync_retention_state_v2
-			)
-			ORDER BY CASE WHEN scope_id = ? THEN 0 ELSE 1 END, scope_id`,
-		)
-		.all(
-			DEFAULT_SYNC_SCOPE_ID,
-			DEFAULT_SYNC_SCOPE_ID,
-			DEFAULT_SYNC_SCOPE_ID,
-			DEFAULT_SYNC_SCOPE_ID,
-		) as Array<{ scope_id: string | null }>;
+export function listRetentionScopeIds(db: Database): string[] {
+	const tableExists = (name: string): boolean =>
+		db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) !==
+		undefined;
+	const hasScopeIdColumn = (table: string): boolean =>
+		(db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).some(
+			(col) => col.name === "scope_id",
+		);
+	// Only union over tables that exist AND carry a scope_id column. The v2 state
+	// tables are additive and may be absent on a legacy DB opened via the CLI
+	// prune path (raw connect(), which doesn't run the additive-compat shim) —
+	// and scope_id itself is additive, so even `replication_ops` (a core table)
+	// predates it: an old DB can have the table without the column. Skipping a
+	// source can never drop a scope: anything not enumerated is implicitly the
+	// default scope, which is always seeded below. Without this column guard,
+	// `prune-replication-ops --dry-run` on such a DB would throw `no such column:
+	// scope_id`. Table names are a fixed allowlist — never input.
+	const sources = ["replication_ops", "sync_reset_state_v2", "sync_retention_state_v2"].filter(
+		(table) => tableExists(table) && hasScopeIdColumn(table),
+	);
 	const scopeIds = new Set<string>([DEFAULT_SYNC_SCOPE_ID]);
-	for (const row of rows) {
-		const scopeId = normalizeRetentionScopeId(row.scope_id);
-		scopeIds.add(scopeId);
+	if (sources.length > 0) {
+		const union = sources
+			.map((table) => `SELECT COALESCE(NULLIF(TRIM(scope_id), ''), ?) AS scope_id FROM ${table}`)
+			.join(" UNION ");
+		const rows = db
+			.prepare(
+				`SELECT scope_id FROM ( ${union} )
+				ORDER BY CASE WHEN scope_id = ? THEN 0 ELSE 1 END, scope_id`,
+			)
+			.all(...sources.map(() => DEFAULT_SYNC_SCOPE_ID), DEFAULT_SYNC_SCOPE_ID) as Array<{
+			scope_id: string | null;
+		}>;
+		for (const row of rows) {
+			scopeIds.add(normalizeRetentionScopeId(row.scope_id));
+		}
 	}
 	return Array.from(scopeIds);
 }


### PR DESCRIPTION
## Description

The offline `codemem db prune-replication-ops` only pruned the **default** replication scope — it called `pruneReplicationOpsUntilCaughtUp` with no `scopeId`. So `replication_ops` accumulated in other scopes (e.g. `legacy-shared-review`, `oss`) was **never reclaimed**: the command was useless for the exact bloated-DB case it exists for, and is a root cause of unbounded `replication_ops` growth. The background retention runner already prunes every scope; the CLI now does too.

- **Prune all scopes:** export `listRetentionScopeIds` (the runner's scope enumerator) from core; the CLI enumerates every scope present in `replication_ops` + the v2 state tables (DEFAULT first) and runs `pruneReplicationOpsUntilCaughtUp` per scope. Each scope's per-scope retained floor still protects peer-needed ops.
- **Honest size report:** the after-size used a per-scope *logical* content estimate while the before-size was the whole-table *physical* dbstat, producing bogus deltas (e.g. "894 MB → 14 MB"). Both now use the same whole-table dbstat (`estimateReplicationOpsBytes`), honestly showing the pre-vacuum size.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Test: ops seeded in default + `oss` + `legacy-shared-review` (all past the cutoff, no cursors) are all pruned — previously only the default scope cleared. Full `packages/core` + `packages/cli` suites pass (1844).

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
