### PR TITLE
fix(core): refresh churned replication ops in place to bound op-log growth

### DIFF
--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -29,6 +29,7 @@ import {
 	reconcileStalePeerReceivedRows,
 	recordAccessCleanupOp,
 	recordReplicationOp,
+	replicationOpContentEqual,
 	SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER,
 	setReplicationCursor,
 	setSyncResetState,
@@ -534,6 +535,296 @@ describe("recordReplicationOp", () => {
 			unknown
 		>;
 		expect(row.entity_id).toBe(String(memId));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// recordReplicationOp content-idempotency guard
+// ---------------------------------------------------------------------------
+
+describe("recordReplicationOp content-idempotency", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	function insertMemory(importKey: string, title: string, body: string): number {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			title,
+			body,
+			now,
+			now,
+			importKey,
+			1,
+			toJson({ clock_device_id: "dev-a" }),
+		);
+		return (
+			db.prepare("SELECT id FROM memory_items WHERE import_key = ?").get(importKey) as {
+				id: number;
+			}
+		).id;
+	}
+
+	function countOps(entityId: string): number {
+		return (
+			db.prepare("SELECT COUNT(*) AS n FROM replication_ops WHERE entity_id = ?").get(entityId) as {
+				n: number;
+			}
+		).n;
+	}
+
+	it("re-saving identical content N times yields exactly one op (the first)", () => {
+		const memId = insertMemory("key:churn", "Stable title", "stable body");
+
+		// First save emits the op.
+		const firstOpId = recordReplicationOp(db, {
+			memoryId: memId,
+			opType: "upsert",
+			deviceId: "dev-a",
+		});
+		expect(countOps("key:churn")).toBe(1);
+
+		// Simulate the 120s sync cadence bumping rev + updated_at with no content
+		// change. Each call should dedup against the first op and insert nothing.
+		for (let i = 2; i <= 6; i++) {
+			db.prepare("UPDATE memory_items SET rev = ?, updated_at = ? WHERE id = ?").run(
+				i,
+				`2026-06-21T00:00:0${i}Z`,
+				memId,
+			);
+			const opId = recordReplicationOp(db, {
+				memoryId: memId,
+				opType: "upsert",
+				deviceId: "dev-a",
+			});
+			expect(opId).toBe(firstOpId);
+		}
+
+		// Still exactly one op after 5 churn re-saves: amplification is bounded.
+		expect(countOps("key:churn")).toBe(1);
+
+		// ...but the surviving op's clock_rev was refreshed in place to track the
+		// memory's current rev, so the dirty-check invariant (an op exists with
+		// clock_rev == m.rev) still holds — the op is not frozen at rev 1.
+		const op = db
+			.prepare("SELECT clock_rev FROM replication_ops WHERE entity_id = 'key:churn'")
+			.get() as { clock_rev: number };
+		expect(op.clock_rev).toBe(6);
+	});
+
+	it("keeps a churned shared memory out of the dirty-check (clock_rev tracks rev)", () => {
+		const memId = insertMemory("key:dirty", "Stable", "stable body");
+		recordReplicationOp(db, { memoryId: memId, opType: "upsert", deviceId: "dev-a" });
+		// Freshly recorded: an op exists with clock_rev == rev, so not dirty.
+		expect(hasUnsyncedSharedMemoryChanges(db).dirty).toBe(false);
+
+		// Rev churn with no content change. The dedup refreshes the existing op in
+		// place and advances its clock_rev, so the memory must NOT become dirty.
+		// Regression guard: a frozen clock_rev (skip-the-insert) would make this
+		// read dirty forever and abort sync.
+		for (let r = 2; r <= 5; r++) {
+			db.prepare("UPDATE memory_items SET rev = ?, updated_at = ? WHERE id = ?").run(
+				r,
+				`2026-06-21T00:00:0${r}Z`,
+				memId,
+			);
+			recordReplicationOp(db, { memoryId: memId, opType: "upsert", deviceId: "dev-a" });
+			expect(hasUnsyncedSharedMemoryChanges(db).dirty).toBe(false);
+		}
+		expect(countOps("key:dirty")).toBe(1);
+	});
+
+	it("emits a second op when memory content actually changes", () => {
+		const memId = insertMemory("key:real-change", "Original title", "body");
+		recordReplicationOp(db, { memoryId: memId, opType: "upsert", deviceId: "dev-a" });
+		expect(countOps("key:real-change")).toBe(1);
+
+		// A genuine content change (new title) with a rev bump MUST emit.
+		db.prepare("UPDATE memory_items SET title = ?, rev = ?, updated_at = ? WHERE id = ?").run(
+			"New title",
+			2,
+			"2026-06-21T00:00:02Z",
+			memId,
+		);
+		recordReplicationOp(db, { memoryId: memId, opType: "upsert", deviceId: "dev-a" });
+		expect(countOps("key:real-change")).toBe(2);
+	});
+
+	it("does not dedup a delete against a prior upsert", () => {
+		const memId = insertMemory("key:del-after-upsert", "Doomed", "body");
+		recordReplicationOp(db, { memoryId: memId, opType: "upsert", deviceId: "dev-a" });
+		expect(countOps("key:del-after-upsert")).toBe(1);
+
+		// A delete (different op_type) is never deduped against the upsert.
+		recordReplicationOp(db, { memoryId: memId, opType: "delete", deviceId: "dev-a" });
+		expect(countOps("key:del-after-upsert")).toBe(2);
+
+		const ops = db
+			.prepare("SELECT op_type FROM replication_ops WHERE entity_id = ? ORDER BY clock_rev")
+			.all("key:del-after-upsert") as Array<{ op_type: string }>;
+		expect(ops.map((o) => o.op_type).sort()).toEqual(["delete", "upsert"]);
+	});
+
+	it("dedups a repeated delete (delete-vs-delete) for the same entity", () => {
+		const memId = insertMemory("key:double-del", "Doomed", "body");
+		const firstDelete = recordReplicationOp(db, {
+			memoryId: memId,
+			opType: "delete",
+			deviceId: "dev-a",
+		});
+		// Second identical delete (null payload) bumps rev but emits no new op.
+		db.prepare("UPDATE memory_items SET rev = 2 WHERE id = ?").run(memId);
+		const secondDelete = recordReplicationOp(db, {
+			memoryId: memId,
+			opType: "delete",
+			deviceId: "dev-a",
+		});
+		expect(secondDelete).toBe(firstDelete);
+		expect(countOps("key:double-del")).toBe(1);
+	});
+
+	it("does not dedup deletes that target different scopes", () => {
+		const memId = insertMemory("key:scope-del", "Doomed", "body");
+		// A delete's null payload carries no scope, so scope_id (an op-row field
+		// that drives routing) must be part of the dedup key. Two deletes in
+		// different scopes are distinct ops and must both emit.
+		const firstDelete = recordReplicationOp(db, {
+			memoryId: memId,
+			opType: "delete",
+			deviceId: "dev-a",
+			scopeId: "scope-a",
+		});
+		const secondDelete = recordReplicationOp(db, {
+			memoryId: memId,
+			opType: "delete",
+			deviceId: "dev-a",
+			scopeId: "scope-b",
+		});
+		expect(secondDelete).not.toBe(firstDelete);
+		expect(countOps("key:scope-del")).toBe(2);
+	});
+
+	it("emits an upsert after a delete even if content matches the pre-delete upsert", () => {
+		const memId = insertMemory("key:resurrect", "Title", "body");
+		// upsert(C)
+		recordReplicationOp(db, { memoryId: memId, opType: "upsert", deviceId: "dev-a" });
+		expect(countOps("key:resurrect")).toBe(1);
+
+		// delete — the entity is now tombstoned on peers.
+		db.prepare("UPDATE memory_items SET rev = 2 WHERE id = ?").run(memId);
+		recordReplicationOp(db, { memoryId: memId, opType: "delete", deviceId: "dev-a" });
+		expect(countOps("key:resurrect")).toBe(2);
+
+		// upsert(C) again with the SAME content as the first upsert. The dedup
+		// must NOT match against that pre-delete upsert: the most recent op is the
+		// delete, so this resurrecting upsert must emit or peers stay deleted.
+		db.prepare("UPDATE memory_items SET rev = 3 WHERE id = ?").run(memId);
+		recordReplicationOp(db, { memoryId: memId, opType: "upsert", deviceId: "dev-a" });
+		expect(countOps("key:resurrect")).toBe(3);
+
+		// The latest op is the resurrecting upsert, so peers re-create the entity.
+		const latest = db
+			.prepare(
+				"SELECT op_type FROM replication_ops WHERE entity_id = ? ORDER BY clock_rev DESC, created_at DESC LIMIT 1",
+			)
+			.get("key:resurrect") as { op_type: string };
+		expect(latest.op_type).toBe("upsert");
+	});
+});
+
+describe("replicationOpContentEqual", () => {
+	it("treats payloads differing only by rev/updated_at/clock_* as equal", () => {
+		const a = toJson({
+			title: "T",
+			body_text: "B",
+			rev: 1,
+			updated_at: "2026-06-21T00:00:01Z",
+			clock_rev: 1,
+			clock_updated_at: "2026-06-21T00:00:01Z",
+			clock_device_id: "dev-a",
+			metadata_json: { clock_device_id: "dev-a", custom: "x" },
+		});
+		const b = toJson({
+			title: "T",
+			body_text: "B",
+			rev: 9,
+			updated_at: "2026-06-21T09:09:09Z",
+			clock_rev: 9,
+			clock_updated_at: "2026-06-21T09:09:09Z",
+			clock_device_id: "dev-b",
+			metadata_json: { clock_device_id: "dev-b", custom: "x" },
+		});
+		expect(replicationOpContentEqual(a, b)).toBe(true);
+	});
+
+	it("returns false when title differs", () => {
+		const a = toJson({ title: "Old", body_text: "B", rev: 1 });
+		const b = toJson({ title: "New", body_text: "B", rev: 2 });
+		expect(replicationOpContentEqual(a, b)).toBe(false);
+	});
+
+	it("returns true for two null (delete) payloads", () => {
+		expect(replicationOpContentEqual(null, null)).toBe(true);
+	});
+
+	it("returns false for null vs non-null payload", () => {
+		expect(replicationOpContentEqual(null, toJson({ title: "T" }))).toBe(false);
+	});
+
+	it("returns false on unparseable JSON (conservative: emit)", () => {
+		expect(replicationOpContentEqual("{not json", toJson({ title: "T" }))).toBe(false);
+	});
+
+	it("ignores key order in content comparison", () => {
+		const a = toJson({ title: "T", body_text: "B", tags_text: "x y" });
+		const b = toJson({ tags_text: "x y", title: "T", body_text: "B" });
+		expect(replicationOpContentEqual(a, b)).toBe(true);
+	});
+
+	it("does NOT ignore a nested user updated_at/rev (only the top-level clock)", () => {
+		// rev/updated_at are stripped only at the top level (the memory's own
+		// replication clock). The same names nested inside metadata_json are real
+		// user content: a change there must register, or it would silently dedup
+		// away and never reach peers past the op's cursor.
+		const a = toJson({
+			title: "T",
+			updated_at: "2026-06-21T00:00:01Z",
+			metadata_json: { source: { updated_at: "2020-01-01T00:00:00Z", rev: 1 } },
+		});
+		const b = toJson({
+			title: "T",
+			updated_at: "2026-06-21T09:09:09Z", // top-level churn — ignored
+			metadata_json: { source: { updated_at: "2024-12-31T00:00:00Z", rev: 2 } }, // real change
+		});
+		expect(replicationOpContentEqual(a, b)).toBe(false);
+	});
+
+	it("still strips clock_* provenance at any nesting depth", () => {
+		// The clock_ prefix is codemem-internal sync provenance, never user
+		// content, so it is stripped at every level — nested clock_device_id
+		// churn must not defeat dedup.
+		const a = toJson({
+			title: "T",
+			metadata_json: { nested: { clock_device_id: "dev-a", keep: "v" } },
+		});
+		const b = toJson({
+			title: "T",
+			metadata_json: { nested: { clock_device_id: "dev-b", keep: "v" } },
+		});
+		expect(replicationOpContentEqual(a, b)).toBe(true);
 	});
 });
 

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -775,11 +775,106 @@ export function isNewerClock(
 // Record a replication op
 
 /**
+ * Sync-internal clock provenance keys. The `clock_` prefix is codemem's own
+ * namespace for per-write sync metadata, never user content, so these are
+ * stripped at EVERY nesting level — including the copy embedded inside
+ * `metadata_json`. An explicit set, not a `clock_*` wildcard: a wildcard could
+ * silently drop a future content field that happened to be named `clock_*`,
+ * and this comparison must never treat changed content as a duplicate.
+ */
+const REPLICATION_OP_CLOCK_PROVENANCE_KEYS = new Set([
+	"clock_rev",
+	"clock_updated_at",
+	"clock_device_id",
+]);
+
+/**
+ * Top-level payload fields that are the memory's own replication clock and so
+ * churn (bumped rev/updated_at) without any content change. Stripped ONLY at
+ * the top level: a nested `rev`/`updated_at` (e.g. a user value inside
+ * `metadata_json`) is real content, and ignoring it would let a genuine change
+ * dedup away and never reach peers past the op's cursor.
+ */
+const REPLICATION_OP_TOP_LEVEL_VOLATILE_KEYS = new Set([
+	"rev",
+	"updated_at",
+	"clock_rev",
+	"clock_updated_at",
+	"clock_device_id",
+]);
+
+/**
+ * Strip volatile keys and produce a canonical, order-independent value so two
+ * structurally-equal payloads stringify identically. Object keys are sorted.
+ *
+ * Depth matters: at the top level the memory's replication clock
+ * (rev/updated_at/clock_*) is stripped; deeper (e.g. inside `metadata_json`)
+ * only the unambiguous `clock_*` provenance is stripped, leaving any nested
+ * user `rev`/`updated_at` intact as content.
+ */
+function canonicalizeContent(value: unknown, topLevel: boolean): unknown {
+	if (Array.isArray(value)) {
+		return value.map((entry) => canonicalizeContent(entry, false));
+	}
+	if (value && typeof value === "object") {
+		const ignore = topLevel
+			? REPLICATION_OP_TOP_LEVEL_VOLATILE_KEYS
+			: REPLICATION_OP_CLOCK_PROVENANCE_KEYS;
+		const out: Record<string, unknown> = {};
+		for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+			if (ignore.has(key)) continue;
+			out[key] = canonicalizeContent((value as Record<string, unknown>)[key], false);
+		}
+		return out;
+	}
+	return value;
+}
+
+/**
+ * Compare a previously-recorded op's stored payload JSON against the payload
+ * about to be written, ignoring volatile fields (rev/updated_at/clock_*).
+ *
+ * Returns true only when the remaining memory content (title, body, kind,
+ * tags, concepts, files, visibility, scope, metadata sans clock fields, etc.)
+ * is deep-equal. Conservative by construction: any parse failure or shape
+ * mismatch yields false so a real change always emits a fresh op.
+ *
+ * Handles delete ops too: both null payloads canonicalize to `null` and
+ * compare equal, while a null-vs-object pair does not.
+ */
+export function replicationOpContentEqual(
+	prevPayloadJson: string | null | undefined,
+	nextPayloadJson: string | null | undefined,
+): boolean {
+	const parse = (raw: string | null | undefined): { ok: boolean; value: unknown } => {
+		if (raw === null || raw === undefined) return { ok: true, value: null };
+		try {
+			return { ok: true, value: JSON.parse(raw) };
+		} catch {
+			return { ok: false, value: null };
+		}
+	};
+	const prev = parse(prevPayloadJson);
+	const next = parse(nextPayloadJson);
+	if (!prev.ok || !next.ok) return false;
+	return (
+		JSON.stringify(canonicalizeContent(prev.value, true)) ===
+		JSON.stringify(canonicalizeContent(next.value, true))
+	);
+}
+
+/**
  * Generate and INSERT a single replication op for a memory item.
  *
  * Reads the memory item's clock fields (rev, updated_at, metadata_json)
  * from the DB, builds the op row, and inserts into `replication_ops`.
  * Returns the generated op_id (UUID).
+ *
+ * Idempotent against churn: if the op about to be written is content-identical
+ * (volatile fields ignored) to the most recent existing op for the same entity
+ * and op_type, the insert is skipped and the existing op_id is returned. This
+ * bounds `replication_ops` growth when something keeps bumping rev/updated_at
+ * with no real content change.
  *
  * Uses Drizzle's typed select so all memory_items columns are captured
  * automatically — no hand-maintained column list to go out of sync.
@@ -885,6 +980,66 @@ export function recordReplicationOp(
 		});
 	} else {
 		payloadJson = null;
+	}
+
+	// Content-idempotency guard: when the MOST RECENT op (of ANY type) for this
+	// entity+scope is the same op_type AND carries identical memory content
+	// (volatile rev/timestamp/clock fields ignored), refresh that op IN PLACE
+	// instead of inserting a duplicate row. This bounds replication_ops growth
+	// under rev churn (something bumping rev/updated_at with no content change).
+	//
+	// We must NOT filter the lookup by op_type: doing so could skip past an
+	// intervening delete. e.g. upsert(C) → delete → upsert(C): the trailing
+	// upsert's content matches the pre-delete upsert, but the latest op is the
+	// delete, so this upsert must still emit to resurrect the entity on peers.
+	// scope_id IS part of the lookup — it drives replication routing and is
+	// absent from a delete's (null) payload, so two deletes for the same entity
+	// in different scopes are distinct ops that must both emit.
+	const scopeMatch =
+		scopeId === null
+			? isNull(schema.replicationOps.scope_id)
+			: eq(schema.replicationOps.scope_id, scopeId);
+	const lastOp = d
+		.select({
+			op_id: schema.replicationOps.op_id,
+			op_type: schema.replicationOps.op_type,
+			payload_json: schema.replicationOps.payload_json,
+		})
+		.from(schema.replicationOps)
+		.where(
+			and(
+				eq(schema.replicationOps.entity_type, "memory_item"),
+				eq(schema.replicationOps.entity_id, entityId),
+				scopeMatch,
+			),
+		)
+		.orderBy(desc(schema.replicationOps.clock_rev), desc(schema.replicationOps.created_at))
+		.limit(1)
+		.get();
+
+	if (
+		lastOp &&
+		lastOp.op_type === opts.opType &&
+		replicationOpContentEqual(lastOp.payload_json, payloadJson)
+	) {
+		// Reuse the existing op_id and created_at so the op's outbound cursor
+		// position is unchanged and already-synced peers do not re-pull it. But
+		// still advance clock_rev to the memory's current rev: the dirty-check
+		// (hasUnsyncedSharedMemoryChanges) and backfillReplicationOps both treat a
+		// shared memory as needing an op whenever no op has clock_rev == m.rev, so
+		// a frozen clock_rev would make a content-stable memory read dirty forever
+		// and abort sync. Refreshing payload_json keeps the row's embedded
+		// updated_at current for a future full bootstrap (content is unchanged).
+		d.update(schema.replicationOps)
+			.set({
+				clock_rev: rev,
+				clock_updated_at: updatedAt,
+				clock_device_id: clockDeviceId,
+				payload_json: payloadJson,
+			})
+			.where(eq(schema.replicationOps.op_id, lastOp.op_id))
+			.run();
+		return lastOp.op_id;
 	}
 
 	d.insert(schema.replicationOps)


### PR DESCRIPTION
## Description

`recordReplicationOp` inserted a row into `replication_ops` for every memory save. Anything that re-saved a shared memory on a fixed cadence — bumping `rev`/`updated_at` with no content change — amplified the op log; one memory accumulated 245 byte-identical ops differing only in `rev`/`updated_at`. That bloat is what kept the op log from shrinking after retention pruning.

This adds a content-idempotency guard. When the most recent op for the same `entity_id` + `scope_id` is the same `op_type` and carries identical memory content (volatile `rev`/`updated_at`/`clock_*` fields ignored), the existing op is **refreshed in place** instead of inserting a duplicate row.

Key invariants preserved:

- **Cursor-stable.** The refresh reuses the existing `op_id` and `created_at`, so the op's position in the outbound feed (`loadReplicationOpsSince`, cursored on `created_at|op_id`) is unchanged — already-synced peers don't re-pull.
- **`clock_rev == rev` holds.** The refresh still advances `clock_rev` to the memory's current `rev`. `hasUnsyncedSharedMemoryChanges` and `backfillReplicationOps` both treat a shared memory as needing an op whenever no op has `clock_rev == rev`; a frozen `clock_rev` would make a content-stable memory read dirty forever and abort sync.
- **Resurrection still emits.** The lookup is not filtered by `op_type`, so an `upsert` after a `delete` still emits even when its content matches a pre-delete `upsert`.
- **No content-eater.** Volatile fields are matched against an explicit allow-set at every nesting level — no `clock_*` prefix wildcard that could silently drop a future content field.

Out of scope: whatever upstream save path bumps `rev` on a no-op write (the churn trigger itself) — this bounds the op-log symptom regardless.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `pnpm run tsc` — clean
- `pnpm run lint` — clean
- `pnpm exec vitest run packages/core` — 1577 passing (incl. new churn-dedup, dirty-check, resurrection, cross-scope-delete, and `replicationOpContentEqual` cases)
- `pnpm exec vitest run packages/cli` — 278 passing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes