### PR TITLE
fix(mcp): support hosted connector OAuth redirects

### DIFF
--- a/docs/remote-mcp-oauth.md
+++ b/docs/remote-mcp-oauth.md
@@ -1,6 +1,6 @@
 # Remote MCP OAuth (Phase 1)
 
-This document covers deploying the `codemem mcp http` Streamable HTTP MCP server publicly with OAuth 2.1 protection, registering it as a claude.ai custom connector, and validating the handshake end-to-end.
+This document covers deploying the `codemem mcp http` Streamable HTTP MCP server publicly with OAuth 2.1 protection, registering it as a hosted MCP connector such as Claude or ChatGPT, and validating the handshake end-to-end.
 
 The Phase 1 endpoint is **single-user**. One self-hosted codemem instance, one allowed human identity. Partner access and native multi-tenant MCP authorization are out of scope.
 
@@ -63,7 +63,7 @@ The viewer process and `codemem mcp http` process must run on different ports. O
 
 When OIDC env vars or `--public-url` are present the server requires bearer tokens on `POST /mcp`. Without both, the server runs in loopback-only development mode (`localhost`/`127.0.0.1`/`::1` only, no bearer).
 
-Public mode accepts browser CORS preflight requests from `https://claude.ai` on the OAuth and MCP routes while still requiring the request `Host` header to match `CODEMEM_MCP_HTTP_PUBLIC_URL`. Other browser origins remain blocked before OAuth processing.
+Public mode accepts browser CORS preflight requests from trusted hosted connector origins (`https://claude.ai` and `https://chatgpt.com`) on the OAuth and MCP routes while still requiring the request `Host` header to match `CODEMEM_MCP_HTTP_PUBLIC_URL`. Other browser origins remain blocked before OAuth processing.
 
 ## Running the server
 
@@ -109,17 +109,19 @@ The provider must support OIDC Discovery (`/.well-known/openid-configuration`) o
 3. Note the client ID and secret; set them as env vars above.
 4. Set the allowed identity. For Google use the verified Gmail address in `CODEMEM_MCP_OAUTH_ALLOWED_EMAIL` and/or the numeric `sub` in `CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT`.
 
-## claude.ai custom connector registration
+## Hosted connector registration
 
 Plan tier note: claude.ai custom connectors require Pro / Max / Team / Enterprise.
 
-1. Open Claude (web or mobile) → Customize → Connectors → Add custom connector.
+1. Open the hosted client connector setup flow, such as Claude (web or mobile) → Customize → Connectors → Add custom connector, or ChatGPT connector setup.
 2. Paste the MCP URL: `https://codemem-mcp.example.net/mcp`.
-3. Claude fetches `/.well-known/oauth-protected-resource/mcp`, discovers the authorization server, and posts a DCR registration to `/register`.
-4. Claude redirects you to `/authorize`. The codemem server bounces you to your OIDC provider; you sign in there.
-5. The OIDC provider redirects back to `/oauth/callback`. codemem validates the ID token (signature, issuer, audience, expiry, nonce, allowed subject/email) and issues an authorization code to Claude's callback.
-6. Claude exchanges the code at `/token` with PKCE S256 and stores the resulting bearer token.
-7. Claude calls `POST /mcp` with `Authorization: Bearer <token>`; codemem verifies, runs the MCP tool, and returns the result.
+3. The hosted client fetches `/.well-known/oauth-protected-resource/mcp`, discovers the authorization server, and posts a DCR registration to `/register`.
+4. The hosted client redirects you to `/authorize`. The codemem server bounces you to your OIDC provider; you sign in there.
+5. The OIDC provider redirects back to `/oauth/callback`. codemem validates the ID token (signature, issuer, audience, expiry, nonce, allowed subject/email) and issues an authorization code to the registered hosted-client callback.
+6. The hosted client exchanges the code at `/token` with PKCE S256 and stores the resulting bearer token.
+7. The hosted client calls `POST /mcp` with `Authorization: Bearer <token>`; codemem verifies, runs the MCP tool, and returns the result.
+
+Supported hosted redirect callbacks are currently Claude's fixed MCP callback (`https://claude.ai/api/mcp/auth_callback`) and ChatGPT connector callbacks matching `https://chatgpt.com/connector/oauth/<connector-id>`. Native loopback callbacks remain supported for local MCP clients, including Gemini CLI-style `http://localhost:<port>/oauth/callback` redirects.
 
 The bearer token expires after one hour. Revoke at any time with:
 
@@ -171,7 +173,7 @@ Early Host/Origin guard denials happen before OAuth audit events and are always 
 | `/oauth/callback` returns `subject_not_allowed` | OIDC identity not allowlisted | Audit log shows `kind=oidc_callback outcome=denied reason=subject_not_allowed`. Update `CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT` or `CODEMEM_MCP_OAUTH_ALLOWED_EMAIL`. |
 | `POST /mcp` returns 401 | No / wrong bearer | Audit log shows `kind=bearer outcome=denied reason=...`. Re-run connector setup or check expired/revoked tokens. |
 | `POST /mcp` returns 403 with valid bearer | Host/Origin mismatch with `CODEMEM_MCP_HTTP_PUBLIC_URL` | Confirm the ingress preserves the configured public hostname. Check `codemem-mcp-http-guard` log lines; OAuth audit will not record this because the request is rejected before bearer verification. |
-| Connector hangs on registration | DCR rejected | Audit log shows `kind=registration outcome=denied reason=invalid_client_metadata`. Confirm Claude's DCR payload uses one of: `https://claude.ai/api/mcp/auth_callback` or a loopback `http://[127.0.0.1|localhost|::1]:<port>/callback` URI. |
+| Connector hangs on registration | DCR rejected | Audit log shows `kind=registration outcome=denied reason=invalid_client_metadata`. Confirm the DCR payload uses one of: `https://claude.ai/api/mcp/auth_callback`, `https://chatgpt.com/connector/oauth/<connector-id>`, or a loopback `http://[127.0.0.1|localhost|::1]:<port>/callback` / `/oauth/callback` URI. |
 | Claude loses tools / re-prompts for auth after an upgrade or restart | OAuth state not persisted (older builds) or state file removed | Audit log shows `kind=refresh outcome=denied reason=invalid_client`/`invalid_grant`. Confirm `~/.codemem/mcp-oauth-state.json` exists and is writable by the server process; if it was deleted, re-run connector setup once to re-register. |
 
 ## Validation checklist
@@ -180,7 +182,7 @@ Before announcing the connector ready, run the steps below against the live host
 
 - [ ] `/.well-known/oauth-authorization-server` returns metadata pointing at the configured public URL.
 - [ ] `/.well-known/oauth-protected-resource/mcp` returns the protected resource document.
-- [ ] `POST /register` accepts the claude.ai callback URI and returns a public-client registration.
+- [ ] `POST /register` accepts the hosted connector callback URI and returns a public-client registration.
 - [ ] `/authorize` for the registered client redirects to the OIDC provider (302 with location matching `CODEMEM_MCP_OIDC_ISSUER_URL`).
 - [ ] OIDC callback with an allowed identity issues an authorization code redirecting back to the registered callback.
 - [ ] `/token` exchange with PKCE S256 returns a 43-character base64url bearer token, `token_type: "Bearer"`, `expires_in: 3600`.

--- a/docs/remote-mcp-oauth.md
+++ b/docs/remote-mcp-oauth.md
@@ -121,7 +121,7 @@ Plan tier note: claude.ai custom connectors require Pro / Max / Team / Enterpris
 6. The hosted client exchanges the code at `/token` with PKCE S256 and stores the resulting bearer token.
 7. The hosted client calls `POST /mcp` with `Authorization: Bearer <token>`; codemem verifies, runs the MCP tool, and returns the result.
 
-Supported hosted redirect callbacks are currently Claude's fixed MCP callback (`https://claude.ai/api/mcp/auth_callback`) and ChatGPT connector callbacks matching `https://chatgpt.com/connector/oauth/<connector-id>`. Native loopback callbacks remain supported for local MCP clients, including Gemini CLI-style `http://localhost:<port>/oauth/callback` redirects.
+Supported hosted redirect callbacks are currently Claude's fixed MCP callback (`https://claude.ai/api/mcp/auth_callback`), ChatGPT connector callbacks matching `https://chatgpt.com/connector/oauth/<connector-id>`, and ChatGPT's legacy published-app callback (`https://chatgpt.com/connector_platform_oauth_redirect`). Native loopback callbacks remain supported for local MCP clients, including Gemini CLI-style `http://localhost:<port>/oauth/callback` redirects.
 
 The bearer token expires after one hour. Revoke at any time with:
 
@@ -173,7 +173,7 @@ Early Host/Origin guard denials happen before OAuth audit events and are always 
 | `/oauth/callback` returns `subject_not_allowed` | OIDC identity not allowlisted | Audit log shows `kind=oidc_callback outcome=denied reason=subject_not_allowed`. Update `CODEMEM_MCP_OAUTH_ALLOWED_SUBJECT` or `CODEMEM_MCP_OAUTH_ALLOWED_EMAIL`. |
 | `POST /mcp` returns 401 | No / wrong bearer | Audit log shows `kind=bearer outcome=denied reason=...`. Re-run connector setup or check expired/revoked tokens. |
 | `POST /mcp` returns 403 with valid bearer | Host/Origin mismatch with `CODEMEM_MCP_HTTP_PUBLIC_URL` | Confirm the ingress preserves the configured public hostname. Check `codemem-mcp-http-guard` log lines; OAuth audit will not record this because the request is rejected before bearer verification. |
-| Connector hangs on registration | DCR rejected | Audit log shows `kind=registration outcome=denied reason=invalid_client_metadata`. Confirm the DCR payload uses one of: `https://claude.ai/api/mcp/auth_callback`, `https://chatgpt.com/connector/oauth/<connector-id>`, or a loopback `http://[127.0.0.1|localhost|::1]:<port>/callback` / `/oauth/callback` URI. |
+| Connector hangs on registration | DCR rejected | Audit log shows `kind=registration outcome=denied reason=invalid_client_metadata`. Confirm the DCR payload uses one of: `https://claude.ai/api/mcp/auth_callback`, `https://chatgpt.com/connector/oauth/<connector-id>`, `https://chatgpt.com/connector_platform_oauth_redirect`, or a loopback `http://[127.0.0.1|localhost|::1]:<port>/callback` / `/oauth/callback` URI. |
 | Claude loses tools / re-prompts for auth after an upgrade or restart | OAuth state not persisted (older builds) or state file removed | Audit log shows `kind=refresh outcome=denied reason=invalid_client`/`invalid_grant`. Confirm `~/.codemem/mcp-oauth-state.json` exists and is writable by the server process; if it was deleted, re-run connector setup once to re-register. |
 
 ## Validation checklist

--- a/packages/mcp-server/src/http.test.ts
+++ b/packages/mcp-server/src/http.test.ts
@@ -313,7 +313,7 @@ describe("MCP HTTP transport", () => {
 		expect(token.status).toBe(403);
 	});
 
-	it("allows Claude browser preflight requests on public OAuth and MCP routes", async () => {
+	it("allows trusted hosted connector browser preflight requests on public OAuth and MCP routes", async () => {
 		const server = await startCodememMcpHttpServer({
 			dbPath: tempDbPath(),
 			port: 0,
@@ -349,6 +349,32 @@ describe("MCP HTTP transport", () => {
 		expect(mcp.headers["access-control-allow-headers"]).toBe(
 			"authorization,content-type,mcp-session-id",
 		);
+
+		const chatGpt = await requestWithHost(`${baseUrl}/register`, {
+			method: "OPTIONS",
+			host: "codemem.example.test",
+			headers: {
+				origin: "https://chatgpt.com",
+				"access-control-request-method": "POST",
+				"access-control-request-headers": "content-type",
+			},
+		});
+
+		expect(chatGpt.statusCode).toBe(204);
+		expect(chatGpt.headers["access-control-allow-origin"]).toBe("https://chatgpt.com");
+		expect(chatGpt.headers["access-control-allow-headers"]).toBe("content-type");
+
+		const registration = await requestWithHost(`${baseUrl}/register`, {
+			method: "POST",
+			host: "codemem.example.test",
+			headers: { origin: "https://chatgpt.com" },
+			body: JSON.stringify({
+				redirect_uris: ["https://chatgpt.com/connector/oauth/QvWoF4AUziOy"],
+				token_endpoint_auth_method: "none",
+			}),
+		});
+
+		expect(registration.statusCode).toBe(201);
 	});
 
 	it("logs early public Host and Origin guard denials", async () => {

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -53,7 +53,7 @@ import { createCodememMcpServer } from "./server.js";
 export const DEFAULT_MCP_HTTP_HOST = "127.0.0.1";
 export const DEFAULT_MCP_HTTP_PORT = 38889;
 const HTTP_DEFAULT_PORT = 80;
-const TRUSTED_PUBLIC_BROWSER_ORIGINS = new Set(["https://claude.ai"]);
+const TRUSTED_PUBLIC_BROWSER_ORIGINS = new Set(["https://chatgpt.com", "https://claude.ai"]);
 const CORS_ALLOW_HEADERS = "authorization,content-type,mcp-session-id";
 const CORS_MAX_AGE_SECONDS = "600";
 const MAX_GUARD_LOG_FIELD_LENGTH = 256;

--- a/packages/mcp-server/src/oauth.test.ts
+++ b/packages/mcp-server/src/oauth.test.ts
@@ -93,7 +93,24 @@ describe("MCP OAuth metadata and dynamic client registration", () => {
 	it("accepts native loopback callback redirects", () => {
 		const result = registerMcpOAuthClient(
 			{
-				redirect_uris: ["http://localhost:42713/callback", "http://[::1]:42713/callback"],
+				redirect_uris: [
+					"http://localhost:42713/callback",
+					"http://[::1]:42713/callback",
+					"http://localhost:42713/oauth/callback",
+				],
+				token_endpoint_auth_method: "none",
+			},
+			createInMemoryOAuthClientsStore(),
+		);
+
+		expect(result.status).toBe(201);
+	});
+
+	it("accepts ChatGPT hosted connector redirects", () => {
+		const result = registerMcpOAuthClient(
+			{
+				redirect_uris: ["https://chatgpt.com/connector/oauth/QvWoF4AUziOy"],
+				client_name: "ChatGPT",
 				token_endpoint_auth_method: "none",
 			},
 			createInMemoryOAuthClientsStore(),
@@ -107,6 +124,40 @@ describe("MCP OAuth metadata and dynamic client registration", () => {
 
 		expect(
 			registerMcpOAuthClient({ redirect_uris: ["https://evil.test/callback"] }, clientsStore),
+		).toMatchObject({ status: 400, body: { error: "invalid_client_metadata" } });
+		expect(
+			registerMcpOAuthClient(
+				{ redirect_uris: ["https://user:secret@evil.test/callback"] },
+				clientsStore,
+			),
+		).toMatchObject({
+			status: 400,
+			body: { error: "invalid_client_metadata", error_description: "Invalid redirect URI" },
+		});
+
+		expect(
+			registerMcpOAuthClient(
+				{ redirect_uris: ["https://chatgpt.com/connector/not-oauth/QvWoF4AUziOy"] },
+				clientsStore,
+			),
+		).toMatchObject({ status: 400, body: { error: "invalid_client_metadata" } });
+		expect(
+			registerMcpOAuthClient(
+				{ redirect_uris: ["https://chatgpt.com/connector/oauth/bad%2Fid"] },
+				clientsStore,
+			),
+		).toMatchObject({ status: 400, body: { error: "invalid_client_metadata" } });
+		expect(
+			registerMcpOAuthClient(
+				{ redirect_uris: ["https://chatgpt.com/connector/oauth/QvWoF4AUziOy?code=secret"] },
+				clientsStore,
+			),
+		).toMatchObject({ status: 400, body: { error: "invalid_client_metadata" } });
+		expect(
+			registerMcpOAuthClient(
+				{ redirect_uris: ["https://chatgpt.com.evil.test/connector/oauth/QvWoF4AUziOy"] },
+				clientsStore,
+			),
 		).toMatchObject({ status: 400, body: { error: "invalid_client_metadata" } });
 
 		expect(

--- a/packages/mcp-server/src/oauth.test.ts
+++ b/packages/mcp-server/src/oauth.test.ts
@@ -109,7 +109,10 @@ describe("MCP OAuth metadata and dynamic client registration", () => {
 	it("accepts ChatGPT hosted connector redirects", () => {
 		const result = registerMcpOAuthClient(
 			{
-				redirect_uris: ["https://chatgpt.com/connector/oauth/QvWoF4AUziOy"],
+				redirect_uris: [
+					"https://chatgpt.com/connector/oauth/QvWoF4AUziOy",
+					"https://chatgpt.com/connector_platform_oauth_redirect",
+				],
 				client_name: "ChatGPT",
 				token_endpoint_auth_method: "none",
 			},

--- a/packages/mcp-server/src/oauth.ts
+++ b/packages/mcp-server/src/oauth.ts
@@ -25,6 +25,7 @@ export const MCP_OAUTH_SCOPES_SUPPORTED = ["memory:read", "memory:write"];
 export const MCP_OAUTH_SERVICE_DOCUMENTATION_URL = "https://github.com/kunickiaj/codemem#readme";
 
 const CLAUDE_HOSTED_CALLBACK = "https://claude.ai/api/mcp/auth_callback";
+const CHATGPT_LEGACY_HOSTED_CALLBACK = "https://chatgpt.com/connector_platform_oauth_redirect";
 const LOCAL_CALLBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 const SUPPORTED_GRANT_TYPES = new Set(["authorization_code", "refresh_token"]);
 const SUPPORTED_RESPONSE_TYPES = new Set(["code"]);
@@ -1082,6 +1083,7 @@ function validateRedirectUris(redirectUris: OAuthClientMetadata["redirect_uris"]
 function isSupportedHostedConnectorRedirectUrl(url: URL): boolean {
 	if (url.search !== "") return false;
 	if (url.href === CLAUDE_HOSTED_CALLBACK) return true;
+	if (url.href === CHATGPT_LEGACY_HOSTED_CALLBACK) return true;
 	return url.protocol === "https:" && url.hostname === "chatgpt.com" && isChatGptConnectorPath(url);
 }
 

--- a/packages/mcp-server/src/oauth.ts
+++ b/packages/mcp-server/src/oauth.ts
@@ -39,6 +39,7 @@ const ACCESS_TOKEN_BASE64URL_LENGTH = 43;
 const ACCESS_TOKEN_BASE64URL = /^[A-Za-z0-9_-]{43}$/;
 const PKCE_S256_CHALLENGE = /^[A-Za-z0-9_-]{43}$/;
 const PKCE_VERIFIER = /^[A-Za-z0-9._~-]{43,128}$/;
+const CHATGPT_CONNECTOR_ID = /^[A-Za-z0-9_-]{1,128}$/;
 
 export interface McpOAuthMetadataOptions {
 	mcpUrl: string;
@@ -1070,12 +1071,28 @@ function getOriginUrl(url: URL): URL {
 function validateRedirectUris(redirectUris: OAuthClientMetadata["redirect_uris"]): string | null {
 	for (const redirectUri of redirectUris) {
 		const url = new URL(redirectUri);
-		if (url.username || url.password || url.hash) return `Invalid redirect URI: ${redirectUri}`;
-		if (url.href === CLAUDE_HOSTED_CALLBACK) continue;
+		if (url.username || url.password || url.hash) return "Invalid redirect URI";
+		if (isSupportedHostedConnectorRedirectUrl(url)) continue;
 		if (isLoopbackCallbackUrl(url)) continue;
-		return `Unsupported redirect URI: ${redirectUri}`;
+		return "Unsupported redirect URI";
 	}
 	return null;
+}
+
+function isSupportedHostedConnectorRedirectUrl(url: URL): boolean {
+	if (url.search !== "") return false;
+	if (url.href === CLAUDE_HOSTED_CALLBACK) return true;
+	return url.protocol === "https:" && url.hostname === "chatgpt.com" && isChatGptConnectorPath(url);
+}
+
+function isChatGptConnectorPath(url: URL): boolean {
+	const pathParts = url.pathname.split("/").filter(Boolean);
+	return (
+		pathParts.length === 3 &&
+		pathParts[0] === "connector" &&
+		pathParts[1] === "oauth" &&
+		CHATGPT_CONNECTOR_ID.test(pathParts[2] ?? "")
+	);
 }
 
 function isSupportedTokenEndpointAuthMethod(method: string | undefined): boolean {
@@ -1090,7 +1107,7 @@ function isLoopbackCallbackUrl(url: URL): boolean {
 	return (
 		url.protocol === "http:" &&
 		LOCAL_CALLBACK_HOSTS.has(normalizeHostname(url.hostname)) &&
-		url.pathname === "/callback" &&
+		(url.pathname === "/callback" || url.pathname === "/oauth/callback") &&
 		url.search === ""
 	);
 }


### PR DESCRIPTION
## Description
Fixes remote MCP OAuth dynamic client registration for non-Claude clients by supporting trusted hosted connector redirects and browser origins.

- Accept ChatGPT connector redirect URIs matching `https://chatgpt.com/connector/oauth/<connector-id>`
- Accept ChatGPT's legacy published-app callback `https://chatgpt.com/connector_platform_oauth_redirect`
- Keep Claude and loopback support, including Gemini CLI-style `/oauth/callback` loopback redirects
- Stop reflecting raw rejected redirect URIs in registration error descriptions
- Trust `https://chatgpt.com` for public-mode OAuth/MCP CORS preflights
- Update remote MCP OAuth docs for hosted connector behavior

Release note: patch bugfix candidate for `0.37.1`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran:
- `pnpm exec vitest run packages/mcp-server/src/oauth.test.ts packages/mcp-server/src/http.test.ts`
- `pnpm run tsc`
- `pnpm run lint`

Full `pnpm run test` was not run locally.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced