### PR TITLE
feat(core): scaffold distill fact-miner candidate engine

### DIFF
--- a/docs/plans/2026-06-27-distill-fact-miner-design.md
+++ b/docs/plans/2026-06-27-distill-fact-miner-design.md
@@ -1,0 +1,191 @@
+# Distill: mining history into promotable context and skills
+
+**Status:** Design draft — pending approval
+**Related:**
+- [Phase B: Pack near-duplicate compression](./2026-04-08-phase-b-pack-dedup-design.md) (recurrence detection this builds on)
+- [File/concept index layer](./2026-04-11-file-concept-index-layer.md) (skill-miner input projection)
+- [Cross-project fallback retrieval](./2026-04-17-cross-project-fallback-retrieval.md) (project-spread signal)
+
+## Goal
+
+Turn codemem's accumulated history into two kinds of durable, reusable output:
+
+1. **Context facts** — lessons/constraints that recur often enough that they
+   should be written into project `AGENTS.md` or user/global context, so agents
+   stop re-learning them every session.
+2. **Skills** — multi-step procedures that recur often enough that they should
+   be codified as a `SKILL.md` (e.g. "to change a memory kind, touch `store.ts`
+   + `mcp-server` + `feed.ts`").
+
+The fact miner ships first (v1). The skill miner is a committed v2, not a maybe.
+
+## Core insight
+
+codemem **already** detects recurrence. `packages/core/src/pack.ts` clusters
+near-duplicate memories (union-find over shared title words) and labels each
+cluster with a `pattern`: `recurring_failure`, `operational_rule`,
+`related_work`, `session_echo`, `thematic_overlap`. Today that signal is used
+only to **compress** packs.
+
+This feature reuses the same latent recurrence signal but routes it to a
+different destination: **promotion into context/skills** instead of compression.
+The hand-maintained gotchas list in `AGENTS.md` is the manual version of this
+output — a graveyard of lessons that recurred enough to hurt. Distill spots them
+before they have to be hand-written.
+
+Two enablers already exist in core:
+- **Semantic embeddings** — sqlite-vec, 384-dim BGE-small, KNN search
+  (`packages/core/src/vectors.ts`, `embeddings.ts`). Lets us cluster by meaning,
+  not just shared title words, so "the same lesson re-learned in different words"
+  is detectable.
+- **Structured fields** — `concepts[]`, `files_read[]`, `files_modified[]`,
+  `kind`, `project`, `confidence` per memory
+  (`packages/core/src/ref-queries.ts`).
+
+## Decisions locked in this brainstorm
+
+| Question | Decision |
+|---|---|
+| Product or personal? | Start personal, design so it productizes (CLI/MCP/viewer later). |
+| Emission model | **A → B**: deterministic engine emits ranked candidates (A); LLM + human gate writes the artifact (B). |
+| Invocation | Manual for v1; proactive "hey I noticed…" nudge is a v2 bonus. |
+| First detector | Context-fact miner. Skill miner is detector #2 (v2). |
+| Scope routing | **Route by project spread**: recurs in 1 project → that repo's context; recurs across ≥2 projects → user/global. Human can override at review. |
+| Anti-noise | Candidates are **diffed against existing context files** (`AGENTS.md` etc.) so only net-new lessons surface. |
+| Auto-write? | No. v1 stops at "emit the diff"; applying the write stays a human action. |
+
+A wrong auto-written rule silently steers every future session — the
+agent-behavior equivalent of an insecure default. That is why B is gated.
+
+## Architecture
+
+```
+select → cluster → score → dedup-vs-context → route-scope → emit candidates
+  (A: deterministic core)                                   │
+                                                            ▼
+                                          B: LLM drafts prose → diff → human applies
+```
+
+### Module placement
+
+- **`packages/core/src/distill.ts`** — pure, deterministic, vitest-friendly.
+  All clustering/scoring/dedup/routing. No file writes, no chat-LLM. Returns
+  scored candidates.
+- **CLI** — a thin command that calls `distill.ts` and prints candidates
+  (`--json` + markdown), following `docs/cli-design-conventions.md`. Working
+  name `codemem distill`; final name settled against the noun-group convention
+  before release.
+- **Detector interface** from day one so the skill miner is detector #2 with a
+  different input projection and artifact type.
+
+### Detector interface (the seam for v2)
+
+```ts
+interface Detector<TCandidate> {
+  // Which memories this detector consumes.
+  select(store): MemoryResult[];
+  // Project memories into the feature space this detector clusters on.
+  project(items: MemoryResult[]): FeatureVector[];
+  // Cluster + score, shared across detectors.
+  // (cluster/score/dedup/route are shared utilities)
+  artifactKind: "context_fact" | "skill";
+}
+```
+
+- **Fact detector (v1):** `select` = `discovery` + `decision` (config flag to
+  fold in `bugfix` as guardrail candidates later). `project` = semantic
+  embedding centroid + `concepts[]`.
+- **Skill detector (v2):** `select` = action-bearing memories. `project` =
+  `files_modified[]` co-occurrence + `kind` sequences over time.
+
+### Clustering
+
+1. Semantic KNN over existing embeddings → adjacency at a cosine threshold.
+2. Union-find over the adjacency graph (same shape as `pack.ts`, stronger
+   signal than title-word overlap).
+3. `concepts[]` overlap as a tie-breaker / booster.
+
+### Scoring (promotability)
+
+```
+score = recurrence × session_spread × time_spread × mean_confidence
+        (lightly recency-weighted)
+        − already_documented_penalty
+```
+
+Repetition across **many sessions over weeks** must outrank many hits in one
+afternoon — the former is a durable lesson, the latter is one task. Exact
+weights are tuned empirically against a real DB (see Open questions).
+
+### Dedup vs existing context
+
+Embed the existing `AGENTS.md` / context-file chunks. If a cluster centroid is
+too close (cosine) to something already written, suppress it or mark it
+`already_documented`. This is what keeps run #1 from being 90% noise.
+
+### Scope routing
+
+Count distinct `project` values in the cluster:
+- 1 project → propose for that repo's context (`AGENTS.md`).
+- ≥2 projects → propose for user/global context.
+
+Human can override scope at review time.
+
+### Candidate contract (handoff to B)
+
+```jsonc
+{
+  "scope": "project" | "user",
+  "suggested_target": "AGENTS.md" | "~/.config/.../context",
+  "score": 0.0,
+  "recurrence": 7,
+  "projects": ["codemem", "garf"],
+  "member_ids": [123, 456],
+  "representative_id": 123,
+  "concepts": ["lint", "biome"],
+  "artifact_kind": "context_fact",   // skill detector emits "skill"
+  "evidence": ["...fact lines from members..."],
+  "draft_text": null                  // A leaves null; B fills it
+}
+```
+
+Deterministic core emits everything except `draft_text`.
+
+### B side (gated synthesis)
+
+`distill` prints candidates → the agent (or human) writes the prose rule into
+`draft_text` → produces a **diff against the target file** for human approval.
+v1 stops at "emit the diff." Applying the write is a human action.
+
+## Roadmap
+
+- **v1 — fact miner.** `distill.ts` + CLI + candidate contract + review handoff.
+  Context facts only. Deterministic core, manual invocation, emit-diff only.
+- **v2 — skill miner (detector #2).** Reuse the pipeline; swap input projection
+  to `files_modified[]` co-occurrence + `kind` sequences; emit `SKILL.md` stubs.
+- **v2 — proactive nudge.** A `distill_candidates` table with status
+  (`new`/`accepted`/`dismissed`/`snoozed`) so reruns don't re-surface dismissed
+  items, plus a session hook that says "N new lessons worth writing down." Built
+  on the batch scorer, not pack-time clustering (pack clustering only sees what
+  a query pulled — biased, never whole-corpus).
+
+## Testing
+
+- `distill.test.ts`: deterministic fixtures → assert clustering, scoring order,
+  scope routing, and `already_documented` suppression. No embedding model needed
+  if fixtures inject vectors (same pattern as `scope-regression.test.ts` /
+  `vectors.test.ts`).
+- Validate against the real local DB via `--explain` dry-run before tuning
+  thresholds.
+
+## Open questions (need real data to settle)
+
+- Cosine / min-recurrence / doc-overlap-suppression thresholds — start with
+  defaults + a `--explain` dry-run, tune against a real store.
+- Final command name/placement under CLI conventions.
+- Whether `bugfix` clusters become "guardrail" candidates in v1 or wait for v2.
+
+## Explicitly out of scope for v1
+
+Auto-apply/auto-write; skill miner; proactive nudge; UI/viewer tab. Seams are
+designed in v1; implementations land in v2.

--- a/docs/plans/2026-06-27-distill-fact-miner-implementation-plan.md
+++ b/docs/plans/2026-06-27-distill-fact-miner-implementation-plan.md
@@ -1,0 +1,98 @@
+# Distill fact miner — v1 implementation plan
+
+**Status:** Plan ready — pending build
+**Design:** [Distill: mining history into promotable context and skills](./2026-06-27-distill-fact-miner-design.md)
+**Tracking:** `bd` epic (see "Beads" section)
+
+Scope: the **v1 context-fact miner** only. Deterministic candidate engine in
+core + `codemem distill` CLI + review handoff (emit diff, human applies). Skill
+miner and proactive ledger are v2 (separate epic).
+
+## Build order (each step = one PR / one bead)
+
+Core lands before CLI so the deterministic engine is fully tested in isolation.
+
+### Step 1 — Core scaffolding + corpus read
+**Files:** `packages/core/src/distill.ts` (new), `packages/core/src/store.ts`,
+`packages/core/src/index.ts`, `packages/core/src/distill.test.ts` (new).
+
+- Define types: `DistillCandidate`, `DistillScope = "project" | "user"`,
+  `ArtifactKind = "context_fact" | "skill"`, and the `Detector<T>` seam.
+- Add a corpus-read on `MemoryStore` (the existing `recent`/`search` are
+  query-scoped; we need a deterministic full scan). Either paginate `recent`
+  with `offset` and no project filter, or add `iterateMemories(filters)`.
+  Default selection = `kind in (discovery, decision)`.
+- Export from `core/index.ts`.
+- **Test:** corpus read returns the expected member set deterministically for a
+  seeded fixture DB.
+
+### Step 2 — Semantic clustering
+**Files:** `distill.ts`, `distill.test.ts`.
+
+- Pull stored vectors from `memory_vectors` for the selected members.
+- Build KNN adjacency at a cosine threshold; union-find (reuse the shape in
+  `pack.ts`) to form clusters. `concepts[]` overlap as a booster/tie-breaker.
+- Degrade gracefully when embeddings are unavailable (fall back to the
+  title-word/concept overlap path; never throw — same posture as `vectors.ts`).
+- **Test:** inject fixture vectors (no model needed, mirror
+  `vectors.test.ts`/`scope-regression.test.ts`); assert deterministic cluster
+  membership and the embeddings-disabled fallback.
+
+### Step 3 — Promotability scoring
+**Files:** `distill.ts`, `distill.test.ts`.
+
+- `score = recurrence × session_spread × time_spread × mean_confidence`,
+  lightly recency-weighted. Pure function over a cluster.
+- **Test:** crafted clusters assert ranking — "recurs across many sessions over
+  weeks" outranks "many hits in one session."
+
+### Step 4 — Dedup vs existing context
+**Files:** `distill.ts`, `distill.test.ts`.
+
+- Read target context files (`AGENTS.md`, configured user-context path), chunk +
+  embed (reuse `embeddings.ts` `chunkText`/`embedTexts`).
+- Suppress (or mark `already_documented`) clusters whose centroid is within a
+  cosine threshold of an existing chunk.
+- **Test:** a candidate matching seeded context text is suppressed; a net-new one
+  survives.
+
+### Step 5 — Scope routing + candidate emit
+**Files:** `distill.ts`, `distill.test.ts`.
+
+- Distinct `project` count → `project` (1) vs `user` (≥2) + `suggested_target`.
+- Assemble `DistillCandidate[]`, stable-sorted by score; `draft_text` stays
+  `null` (B fills it).
+- **Test:** snapshot the candidate contract shape; assert scope routing both ways.
+
+### Step 6 — `codemem distill` CLI + docs
+**Files:** `packages/cli/src/commands/distill.ts` (new),
+`packages/cli/src/index.ts`, `packages/cli/src/commands/distill.test.ts` (new),
+`README.md`, `docs/user-guide.md`.
+
+- Mirror `recent.ts`/`stats.ts`: `helpStyle`, `addDbOption`, `addJsonOption`,
+  `resolveDbOpt`, `emitJsonError`. Catch at the handler boundary (no uncaught
+  throws). `--json` is a stable contract.
+- Flags: `--project`, `--all-projects`, `--kind`, `--min-recurrence`,
+  `--limit`, `--explain` (dry-run showing per-candidate evidence + score
+  breakdown).
+- Register via `program.addCommand(distillCommand)`. Update the completion list.
+- **Test:** smoke test (JSON shape, exit codes) + a `--explain` snapshot.
+- **Docs parity:** required by `cli-design-conventions.md` — same PR.
+
+## Test strategy
+
+- Pure functions (cluster/score/dedup/route) are unit-tested with injected
+  vectors and seeded fixtures — **no embedding model required in CI**.
+- One integration-ish test seeds a temp DB and runs the full pipeline.
+- Gate locally with `pnpm run tsc && pnpm run lint && pnpm run test`.
+
+## Tuning (post-merge, against real data)
+
+Thresholds (KNN cosine, `--min-recurrence`, doc-overlap suppression) ship with
+conservative defaults and are tuned via `--explain` against a real store. This
+is expected iteration, not a blocker for v1 merge.
+
+## Out of scope (v2 epic)
+
+Skill miner (detector #2), proactive `distill_candidates` ledger + session
+nudge, auto-apply, viewer tab.

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -102,7 +102,7 @@ export interface ApiUsageResponse {
 
 /** Extended memory item with session + ownership fields attached by the viewer. */
 export interface ApiMemoryItem extends MemoryItemResponse {
-	project?: string;
+	project: string | null;
 	cwd?: string;
 	owned_by_self?: boolean;
 }

--- a/packages/core/src/distill.test.ts
+++ b/packages/core/src/distill.test.ts
@@ -1,0 +1,171 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import {
+	createContextFactDetector,
+	projectContextFactFeatures,
+	selectDistillCorpus,
+} from "./distill.js";
+import { MemoryStore } from "./store.js";
+import { initTestSchema } from "./test-utils.js";
+
+describe("distill", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+	let prevCodememConfig: string | undefined;
+	let prevEmbeddingDisabled: string | undefined;
+
+	beforeEach(() => {
+		prevCodememConfig = process.env.CODEMEM_CONFIG;
+		prevEmbeddingDisabled = process.env.CODEMEM_EMBEDDING_DISABLED;
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-distill-test-"));
+		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
+		process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+		dbPath = join(tmpDir, "test.sqlite");
+
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		if (prevCodememConfig === undefined) delete process.env.CODEMEM_CONFIG;
+		else process.env.CODEMEM_CONFIG = prevCodememConfig;
+		if (prevEmbeddingDisabled === undefined) delete process.env.CODEMEM_EMBEDDING_DISABLED;
+		else process.env.CODEMEM_EMBEDDING_DISABLED = prevEmbeddingDisabled;
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function insertSession(project: string): number {
+		const now = "2026-06-01T00:00:00.000Z";
+		const info = store.db
+			.prepare(
+				`INSERT INTO sessions(started_at, cwd, project, user, tool_version)
+				 VALUES (?, ?, ?, 'test-user', 'test')`,
+			)
+			.run(now, `/tmp/${project}`, project);
+		return Number(info.lastInsertRowid);
+	}
+
+	function rememberAt(input: {
+		sessionId: number;
+		kind: string;
+		title: string;
+		createdAt: string;
+		metadata?: Record<string, unknown>;
+	}): number {
+		const id = store.remember(
+			input.sessionId,
+			input.kind,
+			input.title,
+			`${input.title} body`,
+			0.8,
+			undefined,
+			input.metadata,
+		);
+		store.db
+			.prepare("UPDATE memory_items SET created_at = ?, updated_at = ? WHERE id = ?")
+			.run(input.createdAt, input.createdAt, id);
+		return id;
+	}
+
+	it("selects the default context-fact corpus deterministically across pages", () => {
+		const alpha = insertSession("alpha-project");
+		const beta = insertSession("beta-project");
+
+		const discoveryId = rememberAt({
+			sessionId: alpha,
+			kind: "discovery",
+			title: "Alpha repeated lesson",
+			createdAt: "2026-06-01T00:00:01.000Z",
+		});
+		rememberAt({
+			sessionId: alpha,
+			kind: "feature",
+			title: "Feature should not be selected by default",
+			createdAt: "2026-06-01T00:00:02.000Z",
+		});
+		const decisionId = rememberAt({
+			sessionId: beta,
+			kind: "decision",
+			title: "Beta operational rule",
+			createdAt: "2026-06-01T00:00:03.000Z",
+		});
+
+		const corpus = selectDistillCorpus(store, { batchSize: 1 });
+
+		expect(corpus.map((item) => item.id)).toEqual([decisionId, discoveryId]);
+		expect(corpus.map((item) => item.project)).toEqual(["beta-project", "alpha-project"]);
+	});
+
+	it("normalizes explicit kinds and respects limits", () => {
+		const sessionId = insertSession("codemem");
+		const bugfixId = rememberAt({
+			sessionId,
+			kind: "bugfix",
+			title: "Guardrail candidate",
+			createdAt: "2026-06-01T00:00:02.000Z",
+		});
+		rememberAt({
+			sessionId,
+			kind: "decision",
+			title: "Older operational rule",
+			createdAt: "2026-06-01T00:00:01.000Z",
+		});
+
+		const corpus = selectDistillCorpus(store, {
+			kinds: [" Bugfix ", "bugfix", "decision"],
+			limit: 1,
+		});
+
+		expect(corpus.map((item) => item.id)).toEqual([bugfixId]);
+	});
+
+	it("projects context-fact features from structured memory fields", () => {
+		const sessionId = insertSession("codemem");
+		const id = rememberAt({
+			sessionId,
+			kind: "discovery",
+			title: "Release preflight requires main",
+			createdAt: "2026-06-01T00:00:01.000Z",
+			metadata: {
+				narrative: "Release preflight rejects detached HEADs.",
+				concepts: ["release", " preflight "],
+			},
+		});
+
+		const item = store.get(id);
+		if (!item) throw new Error("expected seeded memory");
+
+		expect(projectContextFactFeatures([item])).toEqual([
+			{
+				memory_id: id,
+				text: "Release preflight requires main\n\nRelease preflight rejects detached HEADs.",
+				concepts: ["release", "preflight"],
+				project: "codemem",
+			},
+		]);
+	});
+
+	it("exposes a context-fact detector seam for the v2 skill miner", () => {
+		const sessionId = insertSession("codemem");
+		const id = rememberAt({
+			sessionId,
+			kind: "decision",
+			title: "Keep distill writes human-gated",
+			createdAt: "2026-06-01T00:00:01.000Z",
+		});
+
+		const detector = createContextFactDetector();
+		const selected = detector.select(store);
+
+		expect(detector.artifactKind).toBe("context_fact");
+		expect(selected.map((item) => item.id)).toEqual([id]);
+		expect(detector.project(selected)).toHaveLength(1);
+	});
+});

--- a/packages/core/src/distill.ts
+++ b/packages/core/src/distill.ts
@@ -1,0 +1,123 @@
+import type { MemoryStore } from "./store.js";
+import type { MemoryFilters, MemoryItemResponse } from "./types.js";
+
+export type DistillScope = "project" | "user";
+
+export type ArtifactKind = "context_fact" | "skill";
+
+export interface DistillCandidate {
+	scope: DistillScope;
+	suggested_target: string | null;
+	score: number;
+	recurrence: number;
+	projects: string[];
+	member_ids: number[];
+	representative_id: number;
+	concepts: string[];
+	artifact_kind: ArtifactKind;
+	evidence: string[];
+	draft_text: string | null;
+}
+
+export interface DistillCorpusOptions {
+	kinds?: string[];
+	filters?: MemoryFilters | null;
+	batchSize?: number;
+	limit?: number;
+}
+
+export interface DistillDetector<TFeature> {
+	artifactKind: ArtifactKind;
+	select(store: MemoryStore, options?: DistillCorpusOptions): MemoryItemResponse[];
+	project(items: MemoryItemResponse[]): TFeature[];
+}
+
+export interface ContextFactFeature {
+	memory_id: number;
+	text: string;
+	concepts: string[];
+	project: string | null;
+}
+
+export const DEFAULT_CONTEXT_FACT_KINDS = ["discovery", "decision"] as const;
+
+const DEFAULT_BATCH_SIZE = 500;
+
+function clean(value: string | null | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function parseJsonList(value: string | null | undefined): string[] {
+	if (!value) return [];
+	try {
+		const parsed = JSON.parse(value);
+		return Array.isArray(parsed)
+			? parsed
+					.filter((item): item is string => typeof item === "string")
+					.map((item) => item.trim())
+					.filter(Boolean)
+			: [];
+	} catch {
+		return [];
+	}
+}
+
+function normalizeKinds(kinds: string[] | undefined): string[] {
+	const normalized = (kinds ?? [...DEFAULT_CONTEXT_FACT_KINDS])
+		.map((kind) => kind.trim().toLowerCase())
+		.filter(Boolean);
+	return [...new Set(normalized)];
+}
+
+function compareCorpusItems(a: MemoryItemResponse, b: MemoryItemResponse): number {
+	const created = b.created_at.localeCompare(a.created_at);
+	if (created !== 0) return created;
+	return b.id - a.id;
+}
+
+export function selectDistillCorpus(
+	store: MemoryStore,
+	options: DistillCorpusOptions = {},
+): MemoryItemResponse[] {
+	const kinds = normalizeKinds(options.kinds);
+	if (kinds.length === 0) return [];
+
+	const batchSize = Math.max(1, Math.floor(options.batchSize ?? DEFAULT_BATCH_SIZE));
+	const limit =
+		options.limit == null ? Number.POSITIVE_INFINITY : Math.max(0, Math.floor(options.limit));
+	if (limit === 0) return [];
+
+	const results: MemoryItemResponse[] = [];
+	let offset = 0;
+	while (results.length < limit) {
+		const remaining = Math.min(batchSize, limit - results.length);
+		const batch = store.recentByKinds(kinds, remaining, options.filters ?? null, offset);
+		results.push(...batch);
+		if (batch.length < remaining) break;
+		offset += batch.length;
+	}
+
+	return results.toSorted(compareCorpusItems);
+}
+
+export function projectContextFactFeatures(items: MemoryItemResponse[]): ContextFactFeature[] {
+	return items.map((item) => {
+		const narrative = clean(item.narrative);
+		const body = clean(item.body_text);
+		return {
+			memory_id: item.id,
+			text: [item.title, narrative ?? body ?? ""].filter(Boolean).join("\n\n"),
+			concepts: parseJsonList(item.concepts),
+			project: clean(item.project),
+		};
+	});
+}
+
+export function createContextFactDetector(): DistillDetector<ContextFactFeature> {
+	return {
+		artifactKind: "context_fact",
+		select: selectDistillCorpus,
+		project: projectContextFactFeatures,
+	};
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -148,6 +148,20 @@ export {
 	hasPendingDedupKeyBackfill,
 	runDedupKeyBackfillPass,
 } from "./dedup-key-backfill.js";
+export type {
+	ArtifactKind,
+	ContextFactFeature,
+	DistillCandidate,
+	DistillCorpusOptions,
+	DistillDetector,
+	DistillScope,
+} from "./distill.js";
+export {
+	createContextFactDetector,
+	DEFAULT_CONTEXT_FACT_KINDS,
+	projectContextFactFeatures,
+	selectDistillCorpus,
+} from "./distill.js";
 export type { EmbeddingClient } from "./embeddings.js";
 export {
 	_resetEmbeddingClient,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -989,7 +989,7 @@ export class MemoryStore {
 		const rows = this.d.all<MemoryItem>(
 			sql`SELECT memory_items.* FROM ${fromSql}
 				WHERE ${whereSql}
-				ORDER BY created_at DESC
+				ORDER BY created_at DESC, id DESC
 				LIMIT ${limit} OFFSET ${Math.max(offset, 0)}`,
 		);
 
@@ -1024,7 +1024,7 @@ export class MemoryStore {
 		const rows = this.d.all<MemoryItem>(
 			sql`SELECT memory_items.* FROM ${fromSql}
 				WHERE ${whereSql}
-				ORDER BY created_at DESC
+				ORDER BY created_at DESC, id DESC
 				LIMIT ${limit} OFFSET ${Math.max(offset, 0)}`,
 		);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,6 +61,7 @@ export interface MemoryItem {
 	deleted_at: string | null;
 	rev: number;
 	scope_id: string | null;
+	project: string | null;
 }
 
 export interface Artifact {


### PR DESCRIPTION
## Description

Adds the first deterministic core scaffold for the Distill fact-miner feature. This PR captures the agreed A→B design/implementation plan, introduces the core candidate/detector types, adds a context-fact detector seam, and provides deterministic corpus selection for `discovery`/`decision` memories.

This is the bottom PR in the Distill stack and intentionally does **not** perform clustering/scoring or write context files yet.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm exec vitest run packages/core/src/distill.test.ts packages/core/src/store.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
