### PR TITLE
feat(core): cluster distill candidates semantically

### DIFF
--- a/packages/core/src/distill.test.ts
+++ b/packages/core/src/distill.test.ts
@@ -4,10 +4,13 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connect } from "./db.js";
 import {
+	clusterDistillFeatures,
 	createContextFactDetector,
+	loadDistillVectorFeatures,
 	projectContextFactFeatures,
 	selectDistillCorpus,
 } from "./distill.js";
+import { resolveEmbeddingModel, serializeFloat32 } from "./embeddings.js";
 import { MemoryStore } from "./store.js";
 import { initTestSchema } from "./test-utils.js";
 
@@ -56,6 +59,7 @@ describe("distill", () => {
 		sessionId: number;
 		kind: string;
 		title: string;
+		bodyText?: string;
 		createdAt: string;
 		metadata?: Record<string, unknown>;
 	}): number {
@@ -63,7 +67,7 @@ describe("distill", () => {
 			input.sessionId,
 			input.kind,
 			input.title,
-			`${input.title} body`,
+			input.bodyText ?? `${input.title} body`,
 			0.8,
 			undefined,
 			input.metadata,
@@ -145,6 +149,7 @@ describe("distill", () => {
 		expect(projectContextFactFeatures([item])).toEqual([
 			{
 				memory_id: id,
+				title: "Release preflight requires main",
 				text: "Release preflight requires main\n\nRelease preflight rejects detached HEADs.",
 				concepts: ["release", "preflight"],
 				project: "codemem",
@@ -167,5 +172,379 @@ describe("distill", () => {
 		expect(detector.artifactKind).toBe("context_fact");
 		expect(selected.map((item) => item.id)).toEqual([id]);
 		expect(detector.project(selected)).toHaveLength(1);
+	});
+
+	it("clusters semantically similar vector features", () => {
+		const clusters = clusterDistillFeatures(
+			[
+				{
+					memory_id: 1,
+					title: "release preflight requires main",
+					text: "release preflight requires main",
+					concepts: ["release"],
+					project: "codemem",
+					vector: new Float32Array([1, 0]),
+				},
+				{
+					memory_id: 2,
+					title: "tag preflight must run on main branch",
+					text: "tag preflight must run on main branch",
+					concepts: ["release"],
+					project: "codemem",
+					vector: new Float32Array([0.98, 0.2]),
+				},
+				{
+					memory_id: 3,
+					title: "viewer bundle changed",
+					text: "viewer bundle changed",
+					concepts: ["viewer"],
+					project: "codemem",
+					vector: new Float32Array([0, 1]),
+				},
+			],
+			{ semanticThreshold: 0.95 },
+		);
+
+		expect(clusters).toEqual([
+			{
+				representative_id: 1,
+				member_ids: [1, 2],
+				overlap_concepts: ["release"],
+				overlap_words: ["main", "preflight"],
+				signal: "semantic",
+			},
+		]);
+	});
+
+	it("falls back to concept and title overlap when vectors are absent", () => {
+		const clusters = clusterDistillFeatures(
+			[
+				{
+					memory_id: 1,
+					title: "release tag preflight clean main branch",
+					text: "release tag preflight clean main branch",
+					concepts: ["release", "preflight"],
+					project: "codemem",
+				},
+				{
+					memory_id: 2,
+					title: "preflight requires clean main branch before tagging",
+					text: "preflight requires clean main branch before tagging",
+					concepts: ["release", "preflight"],
+					project: "codemem",
+				},
+				{
+					memory_id: 3,
+					title: "sync peer bootstrap",
+					text: "sync peer bootstrap",
+					concepts: ["sync"],
+					project: "codemem",
+				},
+			],
+			{ minConceptOverlap: 2, minTitleWordOverlap: 4 },
+		);
+
+		expect(clusters).toEqual([
+			{
+				representative_id: 1,
+				member_ids: [1, 2],
+				overlap_concepts: ["preflight", "release"],
+				overlap_words: ["branch", "clean", "main", "preflight"],
+				signal: "concept",
+			},
+		]);
+	});
+
+	it("preserves the strongest signal across chained unions", () => {
+		// Concept and title edges can chain among un-embedded members; the
+		// cluster reports the strongest signal seen on any edge.
+		const clusters = clusterDistillFeatures(
+			[
+				{
+					memory_id: 1,
+					title: "release preflight guard rules",
+					text: "release preflight guard rules",
+					concepts: ["release", "preflight"],
+					project: "codemem",
+				},
+				{
+					memory_id: 2,
+					title: "release preflight tag checks",
+					text: "release preflight tag checks",
+					concepts: ["release", "preflight"],
+					project: "codemem",
+				},
+				{
+					// Links to member 2 via shared title words only (single shared
+					// concept stays below minConceptOverlap).
+					memory_id: 3,
+					title: "release preflight tag sync",
+					text: "release preflight tag sync",
+					concepts: ["release"],
+					project: "codemem",
+				},
+			],
+			{ minConceptOverlap: 2, minTitleWordOverlap: 3 },
+		);
+
+		expect(clusters[0]?.member_ids).toEqual([1, 2, 3]);
+		expect(clusters[0]?.signal).toBe("concept");
+	});
+
+	it("does not chain embedded memories through shared generic concepts", () => {
+		// Two memories that are NOT semantically similar but share generic concept
+		// tags must stay separate when both are embedded (regression for the
+		// real-DB mega-cluster).
+		const clusters = clusterDistillFeatures(
+			[
+				{
+					memory_id: 1,
+					title: "kube storage constraints",
+					text: "kube storage constraints",
+					concepts: ["decision", "security", "bugfix"],
+					project: "codemem",
+					vector: new Float32Array([1, 0]),
+				},
+				{
+					memory_id: 2,
+					title: "secret cli surface",
+					text: "secret cli surface",
+					concepts: ["decision", "security", "discovery"],
+					project: "codemem",
+					vector: new Float32Array([0, 1]),
+				},
+			],
+			{ semanticThreshold: 0.82, minConceptOverlap: 2 },
+		);
+
+		expect(clusters).toEqual([]);
+	});
+
+	it("does not let an unembedded memory bridge embedded clusters via concepts", () => {
+		// In a partially indexed store, an unembedded memory sharing generic
+		// concepts with two dissimilar embedded memories must not union with
+		// either — that would transitively merge clusters whose embedded-vs-
+		// embedded comparisons already failed.
+		const clusters = clusterDistillFeatures(
+			[
+				{
+					memory_id: 1,
+					title: "kube storage constraints",
+					text: "kube storage constraints",
+					concepts: ["decision", "security"],
+					project: "codemem",
+					vector: new Float32Array([1, 0]),
+				},
+				{
+					memory_id: 2,
+					title: "secret cli surface",
+					text: "secret cli surface",
+					concepts: ["decision", "security"],
+					project: "codemem",
+					vector: new Float32Array([0, 1]),
+				},
+				{
+					memory_id: 3,
+					title: "unindexed generic memory",
+					text: "unindexed generic memory",
+					concepts: ["decision", "security"],
+					project: "codemem",
+				},
+			],
+			{ semanticThreshold: 0.82, minConceptOverlap: 2 },
+		);
+
+		expect(clusters).toEqual([]);
+	});
+
+	it("does not cluster vectors with mismatched dimensions", () => {
+		const clusters = clusterDistillFeatures(
+			[
+				{
+					memory_id: 1,
+					title: "short vector",
+					text: "short vector",
+					concepts: [],
+					project: "codemem",
+					vector: new Float32Array([1]),
+				},
+				{
+					memory_id: 2,
+					title: "long vector",
+					text: "long vector",
+					concepts: [],
+					project: "codemem",
+					vector: new Float32Array([1, 0]),
+				},
+			],
+			{ semanticThreshold: 0.1, minTitleWordOverlap: 3 },
+		);
+
+		expect(clusters).toEqual([]);
+	});
+
+	it("does not use body words for title fallback clustering", () => {
+		const sessionId = insertSession("codemem");
+		const firstId = rememberAt({
+			sessionId,
+			kind: "discovery",
+			title: "Alpha only",
+			bodyText: "shared fallback body words",
+			createdAt: "2026-06-01T00:00:01.000Z",
+		});
+		const secondId = rememberAt({
+			sessionId,
+			kind: "decision",
+			title: "Beta only",
+			bodyText: "shared fallback body words",
+			createdAt: "2026-06-01T00:00:02.000Z",
+		});
+		const items = [store.get(firstId), store.get(secondId)];
+		if (!items[0] || !items[1]) throw new Error("expected seeded memories");
+
+		const clusters = clusterDistillFeatures(projectContextFactFeatures(items), {
+			minConceptOverlap: 99,
+			minTitleWordOverlap: 3,
+		});
+
+		expect(clusters).toEqual([]);
+	});
+
+	it("loads vector features as text/concept features when vector storage is unavailable", () => {
+		const sessionId = insertSession("codemem");
+		const id = rememberAt({
+			sessionId,
+			kind: "decision",
+			title: "Keep distill deterministic",
+			createdAt: "2026-06-01T00:00:01.000Z",
+			metadata: { concepts: ["distill"] },
+		});
+		const item = store.get(id);
+		if (!item) throw new Error("expected seeded memory");
+
+		expect(loadDistillVectorFeatures(store, [item])).toEqual([
+			{
+				memory_id: id,
+				title: "Keep distill deterministic",
+				text: "Keep distill deterministic\n\nKeep distill deterministic body",
+				concepts: ["distill"],
+				project: "codemem",
+			},
+		]);
+	});
+
+	it("derives feature project from the session after a project move", () => {
+		const sessionId = insertSession("old-project");
+		const id = rememberAt({
+			sessionId,
+			kind: "decision",
+			title: "Memory reassigned to a new project",
+			createdAt: "2026-06-01T00:00:01.000Z",
+		});
+		store.moveMemoryProject(id, "new-project");
+		const item = store.get(id);
+		if (!item) throw new Error("expected seeded memory");
+
+		const [feature] = loadDistillVectorFeatures(store, [item]);
+
+		expect(feature?.project).toBe("new-project");
+	});
+
+	it("keeps the denormalized memory project when the session has none", () => {
+		const sessionId = insertSession("placeholder-project");
+		const id = rememberAt({
+			sessionId,
+			kind: "decision",
+			title: "Replicated memory without a session project",
+			createdAt: "2026-06-01T00:00:01.000Z",
+		});
+		// Simulate a replicated row backfilled only on memory_items.project.
+		store.db.prepare("UPDATE sessions SET project = NULL WHERE id = ?").run(sessionId);
+		store.db.prepare("UPDATE memory_items SET project = ? WHERE id = ?").run("denormalized", id);
+		const item = store.get(id);
+		if (!item) throw new Error("expected seeded memory");
+
+		const [feature] = loadDistillVectorFeatures(store, [item]);
+
+		expect(feature?.project).toBe("denormalized");
+	});
+
+	it("loads only active-model vectors and averages current-model chunks", () => {
+		const sessionId = insertSession("codemem");
+		const id = rememberAt({
+			sessionId,
+			kind: "decision",
+			title: "Current model vectors only",
+			createdAt: "2026-06-01T00:00:01.000Z",
+			metadata: { concepts: ["vectors"] },
+		});
+		const item = store.get(id);
+		if (!item) throw new Error("expected seeded memory");
+
+		store.db.exec("DROP TABLE IF EXISTS memory_vectors");
+		store.db.exec(
+			`CREATE TABLE memory_vectors(
+				embedding BLOB,
+				memory_id INTEGER,
+				chunk_index INTEGER,
+				content_hash TEXT,
+				model TEXT
+			)`,
+		);
+		const currentModel = resolveEmbeddingModel();
+		const insertVector = store.db.prepare(
+			"INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model) VALUES (?, ?, ?, ?, ?)",
+		);
+		insertVector.run(serializeFloat32(new Float32Array([100, 100])), id, 0, "old", "old-model");
+		insertVector.run(serializeFloat32(new Float32Array([1, 0])), id, 0, "current-a", currentModel);
+		insertVector.run(serializeFloat32(new Float32Array([0, 1])), id, 1, "current-b", currentModel);
+
+		const [feature] = loadDistillVectorFeatures(store, [item]);
+
+		expect(feature?.vector).toEqual(new Float32Array([0.5, 0.5]));
+	});
+
+	it("chunks vector lookup for large distill corpora", () => {
+		const sessionId = insertSession("codemem");
+		const now = "2026-06-01T00:00:01.000Z";
+		const insertMemory = store.db.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, project
+			) VALUES (?, 'decision', ?, ?, 1, ?, ?, '{}', 'codemem')`,
+		);
+		const ids: number[] = [];
+		for (let i = 0; i < 501; i++) {
+			const info = insertMemory.run(sessionId, `Chunked vector ${i}`, `Body ${i}`, now, now);
+			ids.push(Number(info.lastInsertRowid));
+		}
+
+		store.db.exec("DROP TABLE IF EXISTS memory_vectors");
+		store.db.exec(
+			`CREATE TABLE memory_vectors(
+				embedding BLOB,
+				memory_id INTEGER,
+				chunk_index INTEGER,
+				content_hash TEXT,
+				model TEXT
+			)`,
+		);
+		const currentModel = resolveEmbeddingModel();
+		const insertVector = store.db.prepare(
+			"INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model) VALUES (?, ?, ?, ?, ?)",
+		);
+		const firstId = ids[0];
+		const lastId = ids.at(-1);
+		if (firstId == null || lastId == null) throw new Error("expected seeded memory ids");
+		insertVector.run(serializeFloat32(new Float32Array([1, 0])), firstId, 0, "first", currentModel);
+		insertVector.run(serializeFloat32(new Float32Array([0, 1])), lastId, 0, "last", currentModel);
+
+		const features = loadDistillVectorFeatures(store, store.recentByKinds(["decision"], 501));
+
+		expect(features.find((feature) => feature.memory_id === firstId)?.vector).toEqual(
+			new Float32Array([1, 0]),
+		);
+		expect(features.find((feature) => feature.memory_id === lastId)?.vector).toEqual(
+			new Float32Array([0, 1]),
+		);
 	});
 });

--- a/packages/core/src/distill.ts
+++ b/packages/core/src/distill.ts
@@ -1,5 +1,6 @@
 import type { MemoryStore } from "./store.js";
 import type { MemoryFilters, MemoryItemResponse } from "./types.js";
+import { resolveSemanticSearchModel } from "./vectors.js";
 
 export type DistillScope = "project" | "user";
 
@@ -34,14 +35,60 @@ export interface DistillDetector<TFeature> {
 
 export interface ContextFactFeature {
 	memory_id: number;
+	title: string;
 	text: string;
 	concepts: string[];
 	project: string | null;
 }
 
+export interface DistillVectorFeature extends ContextFactFeature {
+	vector?: Float32Array;
+}
+
+export interface DistillCluster {
+	representative_id: number;
+	member_ids: number[];
+	overlap_concepts: string[];
+	overlap_words: string[];
+	signal: "semantic" | "concept" | "title";
+}
+
+export interface DistillClusterOptions {
+	semanticThreshold?: number;
+	semanticWithConceptThreshold?: number;
+	minConceptOverlap?: number;
+	minTitleWordOverlap?: number;
+}
+
 export const DEFAULT_CONTEXT_FACT_KINDS = ["discovery", "decision"] as const;
 
 const DEFAULT_BATCH_SIZE = 500;
+const VECTOR_LOOKUP_BATCH_SIZE = 500;
+const SESSION_LOOKUP_BATCH_SIZE = 500;
+
+const CLUSTER_STOP_WORDS = new Set([
+	"the",
+	"a",
+	"an",
+	"and",
+	"or",
+	"to",
+	"in",
+	"for",
+	"of",
+	"on",
+	"with",
+	"is",
+	"was",
+	"are",
+	"were",
+	"from",
+	"this",
+	"that",
+	"it",
+	"not",
+	"no",
+]);
 
 function clean(value: string | null | undefined): string | null {
 	const trimmed = value?.trim();
@@ -76,6 +123,71 @@ function compareCorpusItems(a: MemoryItemResponse, b: MemoryItemResponse): numbe
 	return b.id - a.id;
 }
 
+function significantWords(text: string): Set<string> {
+	return new Set(
+		(text.toLowerCase().match(/\w+/g) ?? []).filter(
+			(word) => word.length > 2 && !CLUSTER_STOP_WORDS.has(word),
+		),
+	);
+}
+
+function overlap(a: Set<string>, b: Set<string>): string[] {
+	return [...a].filter((item) => b.has(item)).sort();
+}
+
+function cosine(a: Float32Array, b: Float32Array): number | null {
+	if (a.length !== b.length) return null;
+	const length = a.length;
+	if (length === 0) return null;
+
+	let dot = 0;
+	let aNorm = 0;
+	let bNorm = 0;
+	for (let i = 0; i < length; i++) {
+		const av = a[i] ?? 0;
+		const bv = b[i] ?? 0;
+		dot += av * bv;
+		aNorm += av * av;
+		bNorm += bv * bv;
+	}
+	if (aNorm === 0 || bNorm === 0) return null;
+	return dot / (Math.sqrt(aNorm) * Math.sqrt(bNorm));
+}
+
+function deserializeFloat32(value: unknown): Float32Array | null {
+	if (!(value instanceof Uint8Array) || value.byteLength === 0 || value.byteLength % 4 !== 0) {
+		return null;
+	}
+	const view = new DataView(value.buffer, value.byteOffset, value.byteLength);
+	const vector = new Float32Array(value.byteLength / 4);
+	for (let i = 0; i < vector.length; i++) vector[i] = view.getFloat32(i * 4, true);
+	return vector;
+}
+
+function average(vectors: Float32Array[]): Float32Array | undefined {
+	const first = vectors[0];
+	if (!first) return undefined;
+	const result = new Float32Array(first.length);
+	for (const vector of vectors) {
+		for (let i = 0; i < first.length; i++) result[i] = (result[i] ?? 0) + (vector[i] ?? 0);
+	}
+	for (let i = 0; i < result.length; i++) result[i] = (result[i] ?? 0) / vectors.length;
+	return result;
+}
+
+function signalRank(signal: DistillCluster["signal"] | undefined): number {
+	if (signal === "semantic") return 3;
+	if (signal === "concept") return 2;
+	if (signal === "title") return 1;
+	return 0;
+}
+
+function strongerSignal(
+	...signals: Array<DistillCluster["signal"] | undefined>
+): DistillCluster["signal"] {
+	return signals.toSorted((a, b) => signalRank(b) - signalRank(a))[0] ?? "title";
+}
+
 export function selectDistillCorpus(
 	store: MemoryStore,
 	options: DistillCorpusOptions = {},
@@ -107,11 +219,227 @@ export function projectContextFactFeatures(items: MemoryItemResponse[]): Context
 		const body = clean(item.body_text);
 		return {
 			memory_id: item.id,
+			title: item.title,
 			text: [item.title, narrative ?? body ?? ""].filter(Boolean).join("\n\n"),
 			concepts: parseJsonList(item.concepts),
 			project: clean(item.project),
 		};
 	});
+}
+
+function loadSessionProjects(store: MemoryStore, sessionIds: number[]): Map<number, string | null> {
+	const result = new Map<number, string | null>();
+	if (sessionIds.length === 0) return result;
+
+	try {
+		for (let start = 0; start < sessionIds.length; start += SESSION_LOOKUP_BATCH_SIZE) {
+			const batch = sessionIds.slice(start, start + SESSION_LOOKUP_BATCH_SIZE);
+			const placeholders = batch.map(() => "?").join(", ");
+			const rows = store.db
+				.prepare(`SELECT id, project FROM sessions WHERE id IN (${placeholders})`)
+				.all(...batch) as Array<Record<string, unknown>>;
+			for (const row of rows) {
+				const id = Number(row.id);
+				if (!Number.isFinite(id)) continue;
+				result.set(id, clean(typeof row.project === "string" ? row.project : null));
+			}
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (!/no such table:\s*sessions/i.test(message)) throw error;
+	}
+
+	return result;
+}
+
+export function loadDistillVectorFeatures(
+	store: MemoryStore,
+	items: MemoryItemResponse[],
+): DistillVectorFeature[] {
+	const projectedFeatures = projectContextFactFeatures(items);
+	if (projectedFeatures.length === 0) return [];
+
+	// Project attribution is canonical on sessions.project; moveMemoryProject()
+	// only updates that column and leaves memory_items.project stale. Resolve the
+	// session project so candidate routing never points at a stale target.
+	const sessionIdByMemory = new Map<number, number | null>(
+		items.map((item) => [item.id, item.session_id]),
+	);
+	const projectBySession = loadSessionProjects(store, [
+		...new Set(
+			items
+				.map((item) => item.session_id)
+				.filter((sessionId): sessionId is number => typeof sessionId === "number"),
+		),
+	]);
+	const baseFeatures = projectedFeatures.map((feature) => {
+		const sessionId = sessionIdByMemory.get(feature.memory_id);
+		const sessionProject =
+			typeof sessionId === "number" ? projectBySession.get(sessionId) : undefined;
+		// Prefer the canonical session project, but keep the denormalized
+		// memory-row project when the session has none (e.g. replicated rows whose
+		// project was backfilled only on memory_items.project).
+		if (sessionProject != null) return { ...feature, project: sessionProject };
+		return feature;
+	});
+
+	const vectorsByMemory = new Map<number, Float32Array[]>();
+	const model = resolveSemanticSearchModel(store.db);
+	if (!model) return baseFeatures;
+
+	try {
+		for (let start = 0; start < baseFeatures.length; start += VECTOR_LOOKUP_BATCH_SIZE) {
+			const batch = baseFeatures.slice(start, start + VECTOR_LOOKUP_BATCH_SIZE);
+			const placeholders = batch.map(() => "?").join(", ");
+			const rows = store.db
+				.prepare(
+					`SELECT memory_id, embedding FROM memory_vectors
+					 WHERE model = ? AND memory_id IN (${placeholders})
+					 ORDER BY memory_id ASC, chunk_index ASC`,
+				)
+				.all(model, ...batch.map((feature) => feature.memory_id)) as Array<Record<string, unknown>>;
+
+			for (const row of rows) {
+				const memoryId = Number(row.memory_id);
+				const vector = deserializeFloat32(row.embedding);
+				if (!Number.isFinite(memoryId) || !vector) continue;
+				const existing = vectorsByMemory.get(memoryId);
+				if (existing) existing.push(vector);
+				else vectorsByMemory.set(memoryId, [vector]);
+			}
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (!/no such (table|module):\s*(memory_vectors|vec0)/i.test(message)) throw error;
+	}
+
+	return baseFeatures.map((feature) => {
+		const vector = average(vectorsByMemory.get(feature.memory_id) ?? []);
+		return vector ? { ...feature, vector } : feature;
+	});
+}
+
+export function clusterDistillFeatures(
+	features: DistillVectorFeature[],
+	options: DistillClusterOptions = {},
+): DistillCluster[] {
+	// BGE-small embeddings have a high baseline cosine, so a low threshold makes
+	// single-linkage union-find collapse the whole corpus into one cluster.
+	// ~0.92 yields coherent "same lesson restated" clusters on a real store; tune
+	// via the CLI/MCP similarity flag.
+	const semanticThreshold = options.semanticThreshold ?? 0.92;
+	const semanticWithConceptThreshold = options.semanticWithConceptThreshold ?? 0.9;
+	const minConceptOverlap = options.minConceptOverlap ?? 2;
+	const minTitleWordOverlap = options.minTitleWordOverlap ?? 3;
+
+	const parent = new Map<number, number>();
+	const signalByRoot = new Map<number, DistillCluster["signal"]>();
+	for (const feature of features) parent.set(feature.memory_id, feature.memory_id);
+
+	const find = (id: number): number => {
+		const current = parent.get(id);
+		if (current == null) throw new Error(`missing cluster parent for ${id}`);
+		if (current === id) return id;
+		const root = find(current);
+		parent.set(id, root);
+		return root;
+	};
+	const union = (a: number, b: number, signal: DistillCluster["signal"]): void => {
+		const aRoot = find(a);
+		const bRoot = find(b);
+		const root = Math.min(aRoot, bRoot);
+		const child = Math.max(aRoot, bRoot);
+		if (root !== child) parent.set(child, root);
+		signalByRoot.set(
+			root,
+			strongerSignal(signalByRoot.get(aRoot), signalByRoot.get(bRoot), signal),
+		);
+	};
+
+	const conceptSets = new Map(
+		features.map((feature) => [
+			feature.memory_id,
+			new Set(feature.concepts.map((item) => item.toLowerCase())),
+		]),
+	);
+	const wordSets = new Map(
+		features.map((feature) => [feature.memory_id, significantWords(feature.title)]),
+	);
+
+	for (let i = 0; i < features.length; i++) {
+		for (let j = i + 1; j < features.length; j++) {
+			const a = features[i];
+			const b = features[j];
+			if (!a || !b) continue;
+
+			const sharedConcepts = overlap(
+				conceptSets.get(a.memory_id) ?? new Set(),
+				conceptSets.get(b.memory_id) ?? new Set(),
+			);
+			const similarity = a.vector && b.vector ? cosine(a.vector, b.vector) : null;
+			// When both memories are embedded, cluster on semantics only. Concept
+			// and title overlap are a fallback for un-embedded memories, NOT an
+			// additional union path: generic concept tags (e.g. "decision",
+			// "security") otherwise chain unrelated memories transitively into one
+			// giant cluster.
+			if (similarity != null) {
+				if (
+					similarity >= semanticThreshold ||
+					(similarity >= semanticWithConceptThreshold && sharedConcepts.length > 0)
+				) {
+					union(a.memory_id, b.memory_id, "semantic");
+				}
+				continue;
+			}
+			// The lexical fallback applies only when NEITHER member is embedded.
+			// In a partially indexed store, letting a mixed pair fall through
+			// would let one unembedded memory with generic concepts bridge
+			// embedded clusters whose semantic comparisons already failed.
+			if (a.vector || b.vector) continue;
+			if (sharedConcepts.length >= minConceptOverlap) {
+				union(a.memory_id, b.memory_id, "concept");
+				continue;
+			}
+			const sharedWords = overlap(
+				wordSets.get(a.memory_id) ?? new Set(),
+				wordSets.get(b.memory_id) ?? new Set(),
+			);
+			if (sharedWords.length >= minTitleWordOverlap) union(a.memory_id, b.memory_id, "title");
+		}
+	}
+
+	const byRoot = new Map<number, DistillVectorFeature[]>();
+	for (const feature of features) {
+		const root = find(feature.memory_id);
+		const existing = byRoot.get(root);
+		if (existing) existing.push(feature);
+		else byRoot.set(root, [feature]);
+	}
+
+	return [...byRoot.entries()]
+		.map(([root, cluster]) => {
+			const sorted = cluster.toSorted((a, b) => a.memory_id - b.memory_id);
+			if (sorted.length < 2) return null;
+			const conceptSetsForCluster = sorted.map(
+				(feature) => conceptSets.get(feature.memory_id) ?? new Set<string>(),
+			);
+			const wordSetsForCluster = sorted.map(
+				(feature) => wordSets.get(feature.memory_id) ?? new Set<string>(),
+			);
+			return {
+				representative_id: sorted[0]?.memory_id ?? root,
+				member_ids: sorted.map((feature) => feature.memory_id),
+				overlap_concepts: [...(conceptSetsForCluster[0] ?? new Set<string>())]
+					.filter((concept) => conceptSetsForCluster.every((set) => set.has(concept)))
+					.sort(),
+				overlap_words: [...(wordSetsForCluster[0] ?? new Set<string>())]
+					.filter((word) => wordSetsForCluster.every((set) => set.has(word)))
+					.sort(),
+				signal: signalByRoot.get(root) ?? "title",
+			};
+		})
+		.filter((cluster): cluster is DistillCluster => cluster != null)
+		.toSorted((a, b) => a.representative_id - b.representative_id);
 }
 
 export function createContextFactDetector(): DistillDetector<ContextFactFeature> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -152,13 +152,18 @@ export type {
 	ArtifactKind,
 	ContextFactFeature,
 	DistillCandidate,
+	DistillCluster,
+	DistillClusterOptions,
 	DistillCorpusOptions,
 	DistillDetector,
 	DistillScope,
+	DistillVectorFeature,
 } from "./distill.js";
 export {
+	clusterDistillFeatures,
 	createContextFactDetector,
 	DEFAULT_CONTEXT_FACT_KINDS,
+	loadDistillVectorFeatures,
 	projectContextFactFeatures,
 	selectDistillCorpus,
 } from "./distill.js";


### PR DESCRIPTION
## Description

Adds semantic clustering for Distill candidates on top of the core scaffold. The clustering layer loads stored vector features when available, clusters candidates with cosine similarity + union-find, preserves the strongest cluster signal, and gracefully falls back to concept/title overlap when vector storage is unavailable.

This PR keeps Distill deterministic and core-only; scoring, dedup-vs-context, scope routing, and CLI surfaces remain upstack work.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm exec vitest run packages/core/src/distill.test.ts packages/core/src/store.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
