### PR TITLE
feat(core): score distill candidate promotability

### DIFF
--- a/packages/core/src/distill.test.ts
+++ b/packages/core/src/distill.test.ts
@@ -8,6 +8,7 @@ import {
 	createContextFactDetector,
 	loadDistillVectorFeatures,
 	projectContextFactFeatures,
+	scoreDistillClusters,
 	selectDistillCorpus,
 } from "./distill.js";
 import { resolveEmbeddingModel, serializeFloat32 } from "./embeddings.js";
@@ -60,6 +61,7 @@ describe("distill", () => {
 		kind: string;
 		title: string;
 		bodyText?: string;
+		confidence?: number;
 		createdAt: string;
 		metadata?: Record<string, unknown>;
 	}): number {
@@ -68,7 +70,7 @@ describe("distill", () => {
 			input.kind,
 			input.title,
 			input.bodyText ?? `${input.title} body`,
-			0.8,
+			input.confidence ?? 0.8,
 			undefined,
 			input.metadata,
 		);
@@ -153,6 +155,9 @@ describe("distill", () => {
 				text: "Release preflight requires main\n\nRelease preflight rejects detached HEADs.",
 				concepts: ["release", "preflight"],
 				project: "codemem",
+				session_id: sessionId,
+				created_at: "2026-06-01T00:00:01.000Z",
+				confidence: 0.8,
 			},
 		]);
 	});
@@ -429,6 +434,9 @@ describe("distill", () => {
 				text: "Keep distill deterministic\n\nKeep distill deterministic body",
 				concepts: ["distill"],
 				project: "codemem",
+				session_id: sessionId,
+				created_at: "2026-06-01T00:00:01.000Z",
+				confidence: 0.8,
 			},
 		]);
 	});
@@ -467,6 +475,335 @@ describe("distill", () => {
 		const [feature] = loadDistillVectorFeatures(store, [item]);
 
 		expect(feature?.project).toBe("denormalized");
+	});
+
+	it("ranks cross-session weekly recurrence above a larger same-session burst", () => {
+		const features = [
+			...Array.from({ length: 8 }, (_, index) => ({
+				memory_id: index + 1,
+				title: `Burst ${index}`,
+				text: `Burst ${index}`,
+				concepts: [],
+				project: "codemem",
+				session_id: 1,
+				created_at: "2026-06-22T00:00:00.000Z",
+				confidence: 0.9,
+			})),
+			...Array.from({ length: 4 }, (_, index) => ({
+				memory_id: index + 101,
+				title: `Spread ${index}`,
+				text: `Spread ${index}`,
+				concepts: [],
+				project: "codemem",
+				session_id: index + 10,
+				created_at: `2026-06-${String(1 + index * 7).padStart(2, "0")}T00:00:00.000Z`,
+				confidence: 0.9,
+			})),
+		];
+		const scored = scoreDistillClusters(
+			[
+				{
+					representative_id: 1,
+					member_ids: [1, 2, 3, 4, 5, 6, 7, 8],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "title",
+				},
+				{
+					representative_id: 101,
+					member_ids: [101, 102, 103, 104],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "semantic",
+				},
+			],
+			features,
+			{ referenceNow: "2026-06-28T00:00:00.000Z" },
+		);
+
+		expect(scored.map((cluster) => cluster.representative_id)).toEqual([101, 1]);
+		expect(scored[0]?.scores.member_count).toBe(4);
+		expect(scored[0]?.scores.session_count).toBe(4);
+		expect(scored[0]?.scores.time_span_days).toBe(21);
+		expect(scored[0]?.scores.mean_confidence).toBeCloseTo(0.9);
+		expect(scored[0]?.scores.combined_score).toBeGreaterThan(scored[1]?.scores.combined_score ?? 0);
+	});
+
+	it("uses recency as a light weighting rather than overpowering spread", () => {
+		const features = [
+			{
+				memory_id: 1,
+				title: "recent burst one",
+				text: "recent burst one",
+				concepts: [],
+				project: "codemem",
+				session_id: 1,
+				created_at: "2026-06-28T00:00:00.000Z",
+				confidence: 0.9,
+			},
+			{
+				memory_id: 2,
+				title: "recent burst two",
+				text: "recent burst two",
+				concepts: [],
+				project: "codemem",
+				session_id: 1,
+				created_at: "2026-06-28T00:00:00.000Z",
+				confidence: 0.9,
+			},
+			{
+				memory_id: 3,
+				title: "old burst one",
+				text: "old burst one",
+				concepts: [],
+				project: "codemem",
+				session_id: 2,
+				created_at: "2026-03-01T00:00:00.000Z",
+				confidence: 0.9,
+			},
+			{
+				memory_id: 4,
+				title: "old burst two",
+				text: "old burst two",
+				concepts: [],
+				project: "codemem",
+				session_id: 2,
+				created_at: "2026-03-01T00:00:00.000Z",
+				confidence: 0.9,
+			},
+			...Array.from({ length: 4 }, (_, index) => ({
+				memory_id: index + 10,
+				title: `older spread ${index}`,
+				text: `older spread ${index}`,
+				concepts: [],
+				project: "codemem",
+				session_id: index + 10,
+				created_at: `2026-03-${String(1 + index * 7).padStart(2, "0")}T00:00:00.000Z`,
+				confidence: 0.9,
+			})),
+		];
+		const scored = scoreDistillClusters(
+			[
+				{
+					representative_id: 1,
+					member_ids: [1, 2],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "title",
+				},
+				{
+					representative_id: 3,
+					member_ids: [3, 4],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "title",
+				},
+				{
+					representative_id: 10,
+					member_ids: [10, 11, 12, 13],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "semantic",
+				},
+			],
+			features,
+			{ referenceNow: "2026-06-28T00:00:00.000Z" },
+		);
+
+		const recentBurst = scored.find((cluster) => cluster.representative_id === 1);
+		const oldBurst = scored.find((cluster) => cluster.representative_id === 3);
+		const olderSpread = scored.find((cluster) => cluster.representative_id === 10);
+		expect(recentBurst?.scores.combined_score).toBeGreaterThan(
+			oldBurst?.scores.combined_score ?? 0,
+		);
+		expect(olderSpread?.scores.combined_score).toBeGreaterThan(
+			recentBurst?.scores.combined_score ?? 0,
+		);
+	});
+
+	it("scores singleton and missing timestamp clusters deterministically", () => {
+		const scored = scoreDistillClusters(
+			[
+				{
+					representative_id: 2,
+					member_ids: [2],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "title",
+				},
+				{
+					representative_id: 1,
+					member_ids: [1],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "title",
+				},
+			],
+			[
+				{
+					memory_id: 1,
+					title: "missing one",
+					text: "missing one",
+					concepts: [],
+					project: "codemem",
+					session_id: 1,
+					created_at: "not-a-date",
+					confidence: 0.7,
+				},
+				{
+					memory_id: 2,
+					title: "missing two",
+					text: "missing two",
+					concepts: [],
+					project: "codemem",
+					session_id: 2,
+					created_at: null,
+					confidence: 0.7,
+				},
+			],
+			{ referenceNow: "2026-06-28T00:00:00.000Z" },
+		);
+
+		expect(scored.map((cluster) => cluster.representative_id)).toEqual([1, 2]);
+		expect(scored[0]?.scores.member_count).toBe(1);
+		expect(scored[0]?.scores.time_span_days).toBe(0);
+		expect(scored[0]?.scores.recency_score).toBe(0);
+		expect(Number.isFinite(scored[0]?.scores.combined_score)).toBe(true);
+	});
+
+	it("treats absent confidence as neutral instead of zeroing promotability", () => {
+		const scored = scoreDistillClusters(
+			[
+				{
+					representative_id: 1,
+					member_ids: [1, 2],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "semantic",
+				},
+			],
+			[
+				{
+					memory_id: 1,
+					title: "missing confidence one",
+					text: "missing confidence one",
+					concepts: [],
+					project: "codemem",
+					session_id: 1,
+					created_at: "2026-06-01T00:00:00.000Z",
+				},
+				{
+					memory_id: 2,
+					title: "missing confidence two",
+					text: "missing confidence two",
+					concepts: [],
+					project: "codemem",
+					session_id: 2,
+					created_at: "2026-06-08T00:00:00.000Z",
+				},
+			],
+			{ referenceNow: "2026-06-28T00:00:00.000Z" },
+		);
+
+		expect(scored[0]?.scores.mean_confidence).toBe(1);
+		expect(scored[0]?.scores.combined_score).toBeGreaterThan(0);
+	});
+
+	it("uses one reference clock per batch for deterministic tie-breaking", () => {
+		const features = [
+			{
+				memory_id: 1,
+				title: "alpha",
+				text: "alpha",
+				concepts: [],
+				project: "codemem",
+				session_id: 1,
+				created_at: "2026-06-01T00:00:00.000Z",
+				confidence: 0.9,
+			},
+			{
+				memory_id: 2,
+				title: "beta",
+				text: "beta",
+				concepts: [],
+				project: "codemem",
+				session_id: 2,
+				created_at: "2026-06-01T00:00:00.000Z",
+				confidence: 0.9,
+			},
+		];
+		// No referenceNow: scoreDistillClusters must capture a single clock so the
+		// two equal clusters tie and fall through to the representative-id ordering.
+		const scored = scoreDistillClusters(
+			[
+				{
+					representative_id: 2,
+					member_ids: [2],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "title",
+				},
+				{
+					representative_id: 1,
+					member_ids: [1],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "title",
+				},
+			],
+			features,
+		);
+
+		expect(scored[0]?.scores.combined_score).toBe(scored[1]?.scores.combined_score);
+		expect(scored.map((cluster) => cluster.representative_id)).toEqual([1, 2]);
+	});
+
+	it("penalizes low mean confidence even with higher recurrence", () => {
+		const lowConfidenceFeatures = Array.from({ length: 6 }, (_, index) => ({
+			memory_id: index + 1,
+			title: `low confidence ${index}`,
+			text: `low confidence ${index}`,
+			concepts: [],
+			project: "codemem",
+			session_id: index + 1,
+			created_at: `2026-06-${String(1 + index).padStart(2, "0")}T00:00:00.000Z`,
+			confidence: 0.2,
+		}));
+		const highConfidenceFeatures = Array.from({ length: 3 }, (_, index) => ({
+			memory_id: index + 101,
+			title: `high confidence ${index}`,
+			text: `high confidence ${index}`,
+			concepts: [],
+			project: "codemem",
+			session_id: index + 101,
+			created_at: `2026-06-${String(1 + index * 3).padStart(2, "0")}T00:00:00.000Z`,
+			confidence: 0.9,
+		}));
+
+		const scored = scoreDistillClusters(
+			[
+				{
+					representative_id: 1,
+					member_ids: [1, 2, 3, 4, 5, 6],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "semantic",
+				},
+				{
+					representative_id: 101,
+					member_ids: [101, 102, 103],
+					overlap_concepts: [],
+					overlap_words: [],
+					signal: "semantic",
+				},
+			],
+			[...lowConfidenceFeatures, ...highConfidenceFeatures],
+			{ referenceNow: "2026-06-28T00:00:00.000Z" },
+		);
+
+		expect(scored.map((cluster) => cluster.representative_id)).toEqual([101, 1]);
+		expect(scored[0]?.scores.mean_confidence).toBeCloseTo(0.9);
+		expect(scored[1]?.scores.mean_confidence).toBeCloseTo(0.2);
 	});
 
 	it("loads only active-model vectors and averages current-model chunks", () => {

--- a/packages/core/src/distill.ts
+++ b/packages/core/src/distill.ts
@@ -39,6 +39,9 @@ export interface ContextFactFeature {
 	text: string;
 	concepts: string[];
 	project: string | null;
+	session_id?: number | null;
+	created_at?: string | null;
+	confidence?: number | null;
 }
 
 export interface DistillVectorFeature extends ContextFactFeature {
@@ -60,11 +63,41 @@ export interface DistillClusterOptions {
 	minTitleWordOverlap?: number;
 }
 
+export interface DistillPromotabilityScores {
+	combined_score: number;
+	member_count: number;
+	session_count: number;
+	time_span_days: number;
+	mean_confidence: number;
+	recurrence_score: number;
+	session_spread_score: number;
+	time_spread_score: number;
+	recency_score: number;
+}
+
+export interface DistillScoredCluster extends DistillCluster {
+	scores: DistillPromotabilityScores;
+}
+
+export interface DistillScoringOptions {
+	referenceNow?: Date | string;
+	maxRecurrenceCount?: number;
+	maxSessionCount?: number;
+	maxTimeSpreadDays?: number;
+	recencyHalfLifeDays?: number;
+}
+
 export const DEFAULT_CONTEXT_FACT_KINDS = ["discovery", "decision"] as const;
 
 const DEFAULT_BATCH_SIZE = 500;
 const VECTOR_LOOKUP_BATCH_SIZE = 500;
 const SESSION_LOOKUP_BATCH_SIZE = 500;
+const DEFAULT_MAX_RECURRENCE_COUNT = 8;
+const DEFAULT_MAX_SESSION_COUNT = 4;
+const DEFAULT_MAX_TIME_SPREAD_DAYS = 21;
+const DEFAULT_RECENCY_HALF_LIFE_DAYS = 60;
+const DEFAULT_UNKNOWN_CONFIDENCE = 1;
+const MS_PER_DAY = 86_400_000;
 
 const CLUSTER_STOP_WORDS = new Set([
 	"the",
@@ -188,6 +221,22 @@ function strongerSignal(
 	return signals.toSorted((a, b) => signalRank(b) - signalRank(a))[0] ?? "title";
 }
 
+function clamp01(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return Math.min(Math.max(value, 0), 1);
+}
+
+function parseTime(value: string | null | undefined): number | null {
+	if (!value) return null;
+	const time = Date.parse(value);
+	return Number.isFinite(time) ? time : null;
+}
+
+function mean(values: number[]): number {
+	if (values.length === 0) return 0;
+	return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
 export function selectDistillCorpus(
 	store: MemoryStore,
 	options: DistillCorpusOptions = {},
@@ -223,6 +272,9 @@ export function projectContextFactFeatures(items: MemoryItemResponse[]): Context
 			text: [item.title, narrative ?? body ?? ""].filter(Boolean).join("\n\n"),
 			concepts: parseJsonList(item.concepts),
 			project: clean(item.project),
+			session_id: item.session_id,
+			created_at: item.created_at,
+			confidence: item.confidence,
 		};
 	});
 }
@@ -440,6 +492,108 @@ export function clusterDistillFeatures(
 		})
 		.filter((cluster): cluster is DistillCluster => cluster != null)
 		.toSorted((a, b) => a.representative_id - b.representative_id);
+}
+
+export function scoreDistillCluster(
+	cluster: DistillCluster,
+	features: DistillVectorFeature[],
+	options: DistillScoringOptions = {},
+): DistillScoredCluster {
+	const featureById = new Map(features.map((feature) => [feature.memory_id, feature]));
+	const members = cluster.member_ids.flatMap((id) => {
+		const feature = featureById.get(id);
+		return feature ? [feature] : [];
+	});
+	const memberCount = members.length;
+	const sessionCount = new Set(
+		members
+			.map((feature) => feature.session_id)
+			.filter((sessionId): sessionId is number => typeof sessionId === "number"),
+	).size;
+	const times = members
+		.map((feature) => parseTime(feature.created_at))
+		.filter((time): time is number => time != null)
+		.toSorted((a, b) => a - b);
+	const firstTime = times[0] ?? null;
+	const lastTime = times.at(-1) ?? null;
+	const timeSpanDays =
+		firstTime != null && lastTime != null ? (lastTime - firstTime) / MS_PER_DAY : 0;
+	const confidences = members
+		.map((feature) => feature.confidence)
+		.filter(
+			(confidence): confidence is number => confidence != null && Number.isFinite(confidence),
+		);
+	const meanConfidence = clamp01(
+		confidences.length > 0 ? mean(confidences) : DEFAULT_UNKNOWN_CONFIDENCE,
+	);
+
+	const maxRecurrenceCount = Math.max(
+		1,
+		options.maxRecurrenceCount ?? DEFAULT_MAX_RECURRENCE_COUNT,
+	);
+	const maxSessionCount = Math.max(1, options.maxSessionCount ?? DEFAULT_MAX_SESSION_COUNT);
+	const maxTimeSpreadDays = Math.max(1, options.maxTimeSpreadDays ?? DEFAULT_MAX_TIME_SPREAD_DAYS);
+	const recencyHalfLifeDays = Math.max(
+		1,
+		options.recencyHalfLifeDays ?? DEFAULT_RECENCY_HALF_LIFE_DAYS,
+	);
+	const referenceNow =
+		options.referenceNow instanceof Date
+			? options.referenceNow.getTime()
+			: (parseTime(options.referenceNow) ?? Date.now());
+
+	const recurrenceScore = clamp01(Math.log2(memberCount + 1) / Math.log2(maxRecurrenceCount + 1));
+	const sessionSpreadScore = 0.4 + 0.6 * clamp01(sessionCount / maxSessionCount);
+	const timeSpreadScore = 0.4 + 0.6 * clamp01(timeSpanDays / maxTimeSpreadDays);
+	const ageDays =
+		lastTime == null
+			? Number.POSITIVE_INFINITY
+			: Math.max(0, (referenceNow - lastTime) / MS_PER_DAY);
+	const recencyScore = lastTime == null ? 0 : 1 / (1 + ageDays / recencyHalfLifeDays);
+	const recencyMultiplier = 0.95 + 0.1 * recencyScore;
+	const combinedScore =
+		recurrenceScore * sessionSpreadScore * timeSpreadScore * meanConfidence * recencyMultiplier;
+
+	return {
+		...cluster,
+		scores: {
+			combined_score: combinedScore,
+			member_count: memberCount,
+			session_count: sessionCount,
+			time_span_days: timeSpanDays,
+			mean_confidence: meanConfidence,
+			recurrence_score: recurrenceScore,
+			session_spread_score: sessionSpreadScore,
+			time_spread_score: timeSpreadScore,
+			recency_score: recencyScore,
+		},
+	};
+}
+
+export function scoreDistillClusters(
+	clusters: DistillCluster[],
+	features: DistillVectorFeature[],
+	options: DistillScoringOptions = {},
+): DistillScoredCluster[] {
+	// Resolve the scoring clock once so every cluster in the batch shares the
+	// same reference time. Otherwise Date.now() ticks between clusters and equal
+	// clusters get different recency multipliers, making rank depend on timing.
+	const scoringOptions: DistillScoringOptions =
+		options.referenceNow == null ? { ...options, referenceNow: new Date() } : options;
+	return clusters
+		.map((cluster) => scoreDistillCluster(cluster, features, scoringOptions))
+		.toSorted((a, b) => {
+			if (b.scores.combined_score !== a.scores.combined_score) {
+				return b.scores.combined_score - a.scores.combined_score;
+			}
+			if (b.scores.member_count !== a.scores.member_count) {
+				return b.scores.member_count - a.scores.member_count;
+			}
+			if (b.scores.mean_confidence !== a.scores.mean_confidence) {
+				return b.scores.mean_confidence - a.scores.mean_confidence;
+			}
+			return a.representative_id - b.representative_id;
+		});
 }
 
 export function createContextFactDetector(): DistillDetector<ContextFactFeature> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -156,7 +156,10 @@ export type {
 	DistillClusterOptions,
 	DistillCorpusOptions,
 	DistillDetector,
+	DistillPromotabilityScores,
 	DistillScope,
+	DistillScoredCluster,
+	DistillScoringOptions,
 	DistillVectorFeature,
 } from "./distill.js";
 export {
@@ -165,6 +168,8 @@ export {
 	DEFAULT_CONTEXT_FACT_KINDS,
 	loadDistillVectorFeatures,
 	projectContextFactFeatures,
+	scoreDistillCluster,
+	scoreDistillClusters,
 	selectDistillCorpus,
 } from "./distill.js";
 export type { EmbeddingClient } from "./embeddings.js";


### PR DESCRIPTION
## Description

Adds deterministic promotability scoring for Distill clusters. The scoring layer computes an explainable flat breakdown covering recurrence, session spread, time spread, mean confidence, and light recency weighting, then ranks clusters deterministically.

This PR builds on the core scaffold and semantic clustering PRs. It still does not emit final candidates or expose CLI/MCP surfaces; those remain upstack.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm exec vitest run packages/core/src/distill.test.ts packages/core/src/store.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
