### PR TITLE
feat(cli,mcp): expose distill candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | | `codemem search <query>` | Search memories |
 | | `codemem pack <context>` | Build a context-aware memory pack |
 | | `codemem pack trace <context>` | Inspect retrieval and pack assembly for a manual query |
+| | `codemem distill` | Mine recurring memories into reviewable context candidates |
 | | `codemem embed` | Backfill semantic embeddings |
 | **Memory** | `codemem memory show <id>` | Print a memory item as JSON |
 | | `codemem memory forget <id>` | Deactivate a memory item |
@@ -172,9 +173,21 @@ Run `codemem --help` for the full list. Legacy top-level aliases (`export-memori
 
 Pack rendering defaults to self-contained context. For token-constrained experiments, `codemem pack <context> --compact` renders an index plus top details. Near-related compression is controlled by `--compression-mode off|compact|ids` (or `CODEMEM_PACK_COMPRESSION`); MCP `memory_pack` exposes the same setting as `compression_mode`. Use `ids` only when the agent can follow up with `memory_get_observations`.
 
+### Distill recurring lessons
+
+`codemem distill` finds repeated discoveries and decisions that may be worth promoting into project or user context.
+
+```text
+codemem distill --project codemem --limit 10
+codemem distill --all-projects --json
+codemem distill --explain
+```
+
+Distill is review-only: it emits ranked candidates and evidence, but it does not edit `AGENTS.md` or user context files.
+
 ## MCP tools
 
-To give the LLM direct access to memory tools (search, timeline, pack, remember, forget):
+To give the LLM direct access to memory tools (search, timeline, pack, distill candidates, remember, forget):
 
 ```text
 codemem setup --opencode-only

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -180,6 +180,19 @@ If compatibility toasts appear after restart, follow the runner-specific guidanc
 These are plugin tools callable by the agent/runtime. They are not user-facing
 slash commands in the OpenCode chat input.
 
+## MCP tools exposed to agents
+
+The MCP server exposes memory retrieval and write tools such as `memory_search`,
+`memory_pack`, `memory_recent`, `memory_remember`, and `memory_forget`.
+
+`memory_distill_candidates` mines recurring lessons into reviewable context
+candidates. It is read-only and does not modify documentation files.
+
+Example agent requests:
+
+- "Find recurring project lessons worth adding to AGENTS.md."
+- "Run distill for all projects and show top candidates."
+
 ## Observer model defaults
 
 - OpenAI: `gpt-5.1-codex-mini`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -110,6 +110,23 @@ Command/file token caching notes:
 - Backfill existing memories with: `codemem embed --dry-run` then `codemem embed`.
 - If sqlite-vec fails to load, semantic recall is skipped and keyword search remains.
 
+## Distill recurring lessons
+
+Use `codemem distill` to find lessons that keep showing up in memory history.
+
+```fish
+codemem distill --project codemem --limit 10
+codemem distill --all-projects --explain
+codemem distill --json
+```
+
+Output is review-only:
+
+- `project` candidates usually belong in that repo's `AGENTS.md`.
+- `user` candidates usually belong in global/user context.
+- `draft_text` is intentionally empty until a human or agent writes the final wording.
+- The command does not edit context files automatically.
+
 ## Sync
 
 ### Enable + run

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,6 +24,7 @@ codemem --help
 codemem setup --opencode-only
 codemem stats
 codemem search "query"
+codemem distill --limit 10
 codemem serve start
 codemem mcp
 ```

--- a/packages/cli/src/commands/distill.test.ts
+++ b/packages/cli/src/commands/distill.test.ts
@@ -1,0 +1,167 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	buildDistillReport: vi.fn(),
+	closeStore: vi.fn(),
+	storePaths: [] as Array<string | undefined>,
+}));
+
+vi.mock("@codemem/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@codemem/core")>();
+	return {
+		...actual,
+		buildDistillReport: mocks.buildDistillReport,
+		MemoryStore: class {
+			constructor(dbPath?: string) {
+				mocks.storePaths.push(dbPath);
+			}
+			close = mocks.closeStore;
+		},
+		resolveDbPath: (value?: string) => value,
+	};
+});
+
+import { distillCommand, renderDistillReport } from "./distill.js";
+
+afterEach(() => {
+	mocks.buildDistillReport.mockReset();
+	mocks.closeStore.mockReset();
+	mocks.storePaths.length = 0;
+	process.exitCode = 0;
+	vi.restoreAllMocks();
+});
+
+async function parseDistillCommand(args: string[]): Promise<void> {
+	const root = new Command("codemem");
+	root.addCommand(distillCommand);
+	await root.parseAsync(["distill", ...args], { from: "user" });
+}
+
+describe("distill command", () => {
+	it("registers shared and distill-specific options", () => {
+		const longs = distillCommand.options.map((option) => option.long);
+
+		expect(longs).toContain("--db-path");
+		expect(longs).toContain("--json");
+		expect(longs).toContain("--project");
+		expect(longs).toContain("--all-projects");
+		expect(longs).toContain("--kind");
+		expect(longs).toContain("--min-recurrence");
+		expect(longs).toContain("--limit");
+		expect(longs).toContain("--explain");
+		expect(longs).toContain("--include-documented");
+	});
+
+	it("emits JSON candidates and passes parsed options to core", async () => {
+		mocks.buildDistillReport.mockResolvedValue({
+			version: 1,
+			candidates: [
+				{
+					scope: "project",
+					suggested_target: "AGENTS.md",
+					score: 0.4,
+					recurrence: 2,
+					projects: ["codemem"],
+					member_ids: [1, 2],
+					representative_id: 1,
+					concepts: ["distill"],
+					artifact_kind: "context_fact",
+					evidence: ["Remember this."],
+					draft_text: null,
+				},
+			],
+			metadata: {
+				candidate_count: 1,
+				cluster_count: 1,
+				context_document_count: 0,
+				corpus_count: 2,
+				documented_cluster_count: 0,
+				include_documented: false,
+				min_recurrence: 2,
+			},
+		});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseDistillCommand([
+			"--json",
+			"--db-path",
+			"memory.sqlite",
+			"--project",
+			"codemem",
+			"--kind",
+			"decision,discovery",
+			"--limit",
+			"3",
+			"--min-recurrence",
+			"2",
+		]);
+
+		expect(mocks.storePaths).toEqual(["memory.sqlite"]);
+		expect(mocks.buildDistillReport).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({
+				corpus: expect.objectContaining({
+					filters: { project: "codemem" },
+					kinds: ["decision", "discovery"],
+				}),
+				limit: 3,
+				minRecurrence: 2,
+			}),
+		);
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({
+			version: 1,
+			candidates: [{ representative_id: 1, draft_text: null }],
+		});
+		expect(mocks.closeStore).toHaveBeenCalledTimes(1);
+	});
+
+	it("emits JSON usage errors without throwing", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await parseDistillCommand(["--json", "--project", "codemem", "--all-projects"]);
+
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toEqual({
+			error: "usage_error",
+			message: "--project cannot be combined with --all-projects",
+		});
+		expect(process.exitCode).toBe(2);
+		expect(errorSpy).not.toHaveBeenCalled();
+		expect(mocks.buildDistillReport).not.toHaveBeenCalled();
+	});
+
+	it("renders evidence only when explain is enabled", () => {
+		const report = {
+			version: 1 as const,
+			candidates: [
+				{
+					scope: "user" as const,
+					suggested_target: "~/.config/opencode/AGENTS.md",
+					score: 0.5,
+					recurrence: 3,
+					projects: ["codemem", "memorybench"],
+					member_ids: [1, 2, 3],
+					representative_id: 1,
+					concepts: ["graphite"],
+					artifact_kind: "context_fact" as const,
+					evidence: ["Use HTTPS rewrite for Graphite submit."],
+					draft_text: null,
+				},
+			],
+			metadata: {
+				candidate_count: 1,
+				cluster_count: 1,
+				context_document_count: 0,
+				corpus_count: 3,
+				corpus_limit: 2000,
+				documented_cluster_count: 0,
+				include_documented: false,
+				min_recurrence: 2,
+			},
+		};
+
+		expect(renderDistillReport(report, false)).not.toContain("HTTPS rewrite");
+		expect(renderDistillReport(report, true)).toContain("Use HTTPS rewrite");
+	});
+});

--- a/packages/cli/src/commands/distill.ts
+++ b/packages/cli/src/commands/distill.ts
@@ -1,0 +1,189 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import * as p from "@clack/prompts";
+import {
+	buildDistillReport,
+	type DistillContextDocument,
+	type DistillReport,
+	type MemoryFilters,
+	MemoryStore,
+	projectMatchesFilter,
+	resolveDbPath,
+	resolveProject,
+	resolveProjectRoot,
+} from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+import {
+	addDbOption,
+	addJsonOption,
+	type DbOpts,
+	emitJsonError,
+	type JsonOpts,
+	resolveDbOpt,
+} from "../shared-options.js";
+
+type DistillCommandOptions = DbOpts &
+	JsonOpts & {
+		allProjects?: boolean;
+		explain?: boolean;
+		includeDocumented?: boolean;
+		kind: string[];
+		limit: string;
+		minRecurrence: string;
+		project?: string;
+	};
+
+class DistillUsageError extends Error {}
+
+function collectKind(value: string, previous: string[]): string[] {
+	return [...previous, ...value.split(",")].map((kind) => kind.trim()).filter(Boolean);
+}
+
+function parsePositiveInteger(value: string, name: string): number {
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed < 1 || String(parsed) !== value.trim()) {
+		throw new DistillUsageError(`${name} must be a positive integer`);
+	}
+	return parsed;
+}
+
+function readContextFile(
+	path: string,
+	displayPath: string,
+	scope: DistillContextDocument["scope"],
+): DistillContextDocument | null {
+	if (!existsSync(path)) return null;
+	const text = readFileSync(path, "utf8");
+	return text.trim() ? { path: displayPath, text, scope } : null;
+}
+
+function loadDefaultContextDocuments(
+	includeProjectContext: boolean,
+	cwd = process.cwd(),
+): DistillContextDocument[] {
+	// The repo-root AGENTS.md describes the current repo (scope "project") and is
+	// gated to current-project runs; the user-global context (scope "user")
+	// always applies and never suppresses other projects' candidates. Resolve the
+	// repo root so running from a subdirectory still finds the project context.
+	const projectRoot = resolveProjectRoot(cwd) ?? cwd;
+	const documents = [
+		includeProjectContext
+			? readContextFile(join(projectRoot, "AGENTS.md"), "AGENTS.md", "project")
+			: null,
+		readContextFile(
+			join(homedir(), ".config", "opencode", "AGENTS.md"),
+			"~/.config/opencode/AGENTS.md",
+			"user",
+		),
+	];
+	return documents.filter((document): document is DistillContextDocument => document != null);
+}
+
+function shouldIncludeProjectContext(opts: DistillCommandOptions): boolean {
+	if (opts.allProjects) return false;
+	const currentProject = resolveProject(process.cwd());
+	if (!currentProject) return false;
+	const targetProject = opts.project
+		? resolveProject(process.cwd(), opts.project)
+		: process.env.CODEMEM_PROJECT?.trim() || currentProject;
+	if (!targetProject) return false;
+	// Only reuse the cwd AGENTS.md when the run actually targets this repo.
+	return projectMatchesFilter(targetProject, currentProject);
+}
+
+function buildFilters(opts: DistillCommandOptions): MemoryFilters | undefined {
+	if (opts.allProjects && opts.project) {
+		throw new DistillUsageError("--project cannot be combined with --all-projects");
+	}
+	if (opts.allProjects) return undefined;
+
+	const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
+	const project = opts.project
+		? resolveProject(process.cwd(), opts.project)
+		: (defaultProject ?? resolveProject(process.cwd()));
+	return project ? { project } : undefined;
+}
+
+async function runDistill(store: MemoryStore, opts: DistillCommandOptions): Promise<DistillReport> {
+	const limit = parsePositiveInteger(opts.limit, "limit");
+	const minRecurrence = parsePositiveInteger(opts.minRecurrence, "min recurrence");
+	return buildDistillReport(store, {
+		candidate: {
+			includeDocumented: opts.includeDocumented ?? false,
+			maxEvidenceItems: opts.explain ? 10 : 5,
+		},
+		contextDocuments: loadDefaultContextDocuments(shouldIncludeProjectContext(opts)),
+		corpus: {
+			filters: buildFilters(opts) ?? null,
+			kinds: opts.kind.length > 0 ? opts.kind : undefined,
+		},
+		limit,
+		minRecurrence,
+	});
+}
+
+export function renderDistillReport(report: DistillReport, explain = false): string {
+	if (report.candidates.length === 0) {
+		return "No distill candidates found.";
+	}
+
+	const lines = [`Distill candidates (${report.candidates.length})`, ""];
+	for (const [index, candidate] of report.candidates.entries()) {
+		lines.push(
+			`${index + 1}. [${candidate.scope}] score=${candidate.score.toFixed(3)} recurrence=${candidate.recurrence} target=${candidate.suggested_target}`,
+		);
+		lines.push(`   projects: ${candidate.projects.join(", ") || "(none)"}`);
+		lines.push(`   concepts: ${candidate.concepts.join(", ") || "(none)"}`);
+		lines.push(`   members: ${candidate.member_ids.join(", ")}`);
+		if (explain) {
+			for (const evidence of candidate.evidence) lines.push(`   - ${evidence}`);
+		}
+		lines.push("");
+	}
+	return lines.join("\n").trimEnd();
+}
+
+async function distillAction(opts: DistillCommandOptions): Promise<void> {
+	let store: MemoryStore | null = null;
+	try {
+		store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		const result = await runDistill(store, opts);
+		if (opts.json) {
+			console.log(JSON.stringify(result, null, 2));
+			return;
+		}
+		p.intro("codemem distill");
+		console.log(renderDistillReport(result, opts.explain ?? false));
+		p.outro("review candidates before editing context files");
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const usageError = error instanceof DistillUsageError;
+		if (opts.json) {
+			emitJsonError(usageError ? "usage_error" : "distill_failed", message, usageError ? 2 : 1);
+			return;
+		}
+		p.log.error(message);
+		process.exitCode = usageError ? 2 : 1;
+	} finally {
+		store?.close();
+	}
+}
+
+const cmd = new Command("distill")
+	.configureHelp(helpStyle)
+	.description("Mine recurring memories into reviewable context candidates")
+	.option("-p, --project <project>", "project identifier (defaults to git repo root)")
+	.option("-A, --all-projects", "mine memories across all projects")
+	.option("-k, --kind <kind>", "memory kind to mine (repeat or comma-separate)", collectKind, [])
+	.option("-m, --min-recurrence <n>", "minimum member count per candidate", "2")
+	.option("-l, --limit <n>", "max candidates", "10")
+	.option("-e, --explain", "include evidence snippets in human output")
+	.option("--include-documented", "include candidates already represented in context files");
+
+addDbOption(cmd);
+addJsonOption(cmd);
+cmd.action(distillAction);
+
+export const distillCommand = cmd;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,7 @@ import { codexHookInjectCommand } from "./commands/codex-hook-inject.js";
 import { configCommand } from "./commands/config.js";
 import { coordinatorCommand } from "./commands/coordinator.js";
 import { dbCommand } from "./commands/db.js";
+import { distillCommand } from "./commands/distill.js";
 import { embedCommand } from "./commands/embed.js";
 import { enqueueRawEventCommand } from "./commands/enqueue-raw-event.js";
 import { exportMemoriesCommand } from "./commands/export-memories.js";
@@ -61,6 +62,7 @@ completion.on("command", ({ reply }) => {
 		"config",
 		"coordinator",
 		"db",
+		"distill",
 		"embed",
 		"enqueue-raw-event",
 		"export-memories",
@@ -201,6 +203,7 @@ program.addCommand(claudeHookFileContextCommand);
 program.addCommand(codexHookInjectCommand);
 program.addCommand(codexHookIngestCommand);
 program.addCommand(dbCommand);
+program.addCommand(distillCommand);
 program.addCommand(exportMemoriesCommand);
 program.addCommand(importMemoriesCommand);
 program.addCommand(statsCommand);

--- a/packages/core/src/distill.ts
+++ b/packages/core/src/distill.ts
@@ -145,6 +145,34 @@ export interface DistillCandidateEmitOptions {
 	userTarget?: string;
 }
 
+export interface DistillReportOptions {
+	candidate?: DistillCandidateEmitOptions;
+	cluster?: DistillClusterOptions;
+	contextChunk?: DistillContextChunkOptions;
+	contextDedupe?: DistillContextDedupeOptions;
+	contextDocuments?: DistillContextDocument[];
+	corpus?: DistillCorpusOptions;
+	limit?: number;
+	maxCorpus?: number;
+	minRecurrence?: number;
+	scoring?: DistillScoringOptions;
+}
+
+export interface DistillReport {
+	version: 1;
+	candidates: DistillCandidate[];
+	metadata: {
+		candidate_count: number;
+		cluster_count: number;
+		context_document_count: number;
+		corpus_count: number;
+		corpus_limit: number;
+		documented_cluster_count: number;
+		include_documented: boolean;
+		min_recurrence: number;
+	};
+}
+
 export const DEFAULT_CONTEXT_FACT_KINDS = ["discovery", "decision"] as const;
 
 const DEFAULT_BATCH_SIZE = 500;
@@ -162,6 +190,10 @@ const DEFAULT_USER_CONTEXT_TARGET = "~/.config/opencode/AGENTS.md";
 // Bodies can be very large (ingest allows ~2MB), so cap each evidence string.
 // maxEvidenceItems caps how many entries; this caps the size of each entry.
 const DEFAULT_EVIDENCE_CHAR_LIMIT = 600;
+// Cap the clustering input: clusterDistillFeatures is O(n^2), so an unbounded
+// corpus on a long-lived DB can block the CLI/MCP server even when the caller
+// only wants a few candidates. Bound the corpus before the pairwise step.
+const DEFAULT_DISTILL_CORPUS_LIMIT = 2000;
 const MS_PER_DAY = 86_400_000;
 
 const CLUSTER_STOP_WORDS = new Set([
@@ -950,6 +982,68 @@ export function emitDistillCandidates(
 			];
 		})
 		.toSorted(compareDistillCandidates);
+}
+
+export async function buildDistillReport(
+	store: MemoryStore,
+	options: DistillReportOptions = {},
+): Promise<DistillReport> {
+	const minRecurrence = Math.max(1, Math.floor(options.minRecurrence ?? 2));
+	const limit = Math.max(1, Math.floor(options.limit ?? 10));
+	// Bound the corpus that feeds the O(n^2) clustering step. An explicit
+	// corpus.limit wins; otherwise fall back to maxCorpus or the default cap.
+	const corpusLimit = Math.max(
+		1,
+		Math.floor(options.corpus?.limit ?? options.maxCorpus ?? DEFAULT_DISTILL_CORPUS_LIMIT),
+	);
+	const corpus = selectDistillCorpus(store, { ...options.corpus, limit: corpusLimit });
+	const features = loadDistillVectorFeatures(store, corpus);
+	const clusters = clusterDistillFeatures(features, options.cluster);
+	const scored = scoreDistillClusters(clusters, features, options.scoring);
+	const contextDocuments = options.contextDocuments ?? [];
+
+	// Scope-aware dedupe: route each cluster first, then suppress only against
+	// documents valid for its target scope. A user/global candidate must not be
+	// dropped because one project's AGENTS.md already documents it; project docs
+	// only suppress project-scoped candidates. The routed scope here matches the
+	// scope emitDistillCandidates computes from the same features.
+	const featureById = new Map(features.map((feature) => [feature.memory_id, feature]));
+	const clusterScopeByRepresentative = new Map<number, DistillContextScope>();
+	for (const cluster of scored) {
+		const { scope } = routeDistillScope(
+			cluster.member_ids.map((id) => {
+				const feature = featureById.get(id);
+				return feature ? clean(feature.project) : null;
+			}),
+		);
+		clusterScopeByRepresentative.set(cluster.representative_id, scope);
+	}
+	const contextChunks = chunkDistillContextDocuments(contextDocuments, options.contextChunk);
+	const documented = markDistillClustersDocumented(
+		scored,
+		features,
+		contextChunks,
+		options.contextDedupe,
+		clusterScopeByRepresentative,
+	);
+	const candidates = emitDistillCandidates(documented, features, options.candidate)
+		.filter((candidate) => candidate.recurrence >= minRecurrence)
+		.slice(0, limit);
+
+	return {
+		version: 1,
+		candidates,
+		metadata: {
+			candidate_count: candidates.length,
+			cluster_count: clusters.length,
+			context_document_count: contextDocuments.length,
+			corpus_count: corpus.length,
+			corpus_limit: corpusLimit,
+			documented_cluster_count: documented.filter((cluster) => cluster.already_documented).length,
+			include_documented: options.candidate?.includeDocumented ?? false,
+			min_recurrence: minRecurrence,
+		},
+	};
 }
 
 export function createContextFactDetector(): DistillDetector<ContextFactFeature> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,12 +165,15 @@ export type {
 	DistillDocumentationSignal,
 	DistillDocumentedCluster,
 	DistillPromotabilityScores,
+	DistillReport,
+	DistillReportOptions,
 	DistillScope,
 	DistillScoredCluster,
 	DistillScoringOptions,
 	DistillVectorFeature,
 } from "./distill.js";
 export {
+	buildDistillReport,
 	chunkDistillContextDocuments,
 	clusterDistillFeatures,
 	createContextFactDetector,
@@ -433,6 +436,7 @@ export {
 	projectColumnClause,
 	projectMatchesFilter,
 	resolveProject,
+	resolveProjectRoot,
 } from "./project.js";
 export type {
 	ProjectScopeCandidate,

--- a/packages/core/src/project.test.ts
+++ b/packages/core/src/project.test.ts
@@ -2,7 +2,13 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { projectBasename, projectClause, projectMatchesFilter, resolveProject } from "./project.js";
+import {
+	projectBasename,
+	projectClause,
+	projectMatchesFilter,
+	resolveProject,
+	resolveProjectRoot,
+} from "./project.js";
 
 describe("project helpers", () => {
 	let tmpDir: string | null = null;
@@ -60,6 +66,33 @@ describe("project helpers", () => {
 		);
 
 		expect(resolveProject(worktree)).toBe("main-repo");
+	});
+
+	it("resolves the working-tree root from a subdirectory", () => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-project-test-"));
+		const repoRoot = join(tmpDir, "my-repo");
+		const nested = join(repoRoot, "packages", "core");
+		mkdirSync(join(repoRoot, ".git"), { recursive: true });
+		mkdirSync(nested, { recursive: true });
+
+		expect(resolveProjectRoot(nested)).toBe(repoRoot);
+	});
+
+	it("resolves the linked worktree root, not the primary checkout", () => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-project-test-"));
+		const mainRepo = join(tmpDir, "main-repo");
+		const worktree = join(tmpDir, "feature-worktree");
+		mkdirSync(join(mainRepo, ".git", "worktrees", "feature-worktree"), { recursive: true });
+		mkdirSync(join(worktree, "packages"), { recursive: true });
+		writeFileSync(
+			join(worktree, ".git"),
+			`gitdir: ${join(mainRepo, ".git", "worktrees", "feature-worktree")}`,
+		);
+
+		// resolveProject keeps the primary repo name, but the file root must be the
+		// worktree itself so AGENTS.md is read from the worktree being mined.
+		expect(resolveProject(worktree)).toBe("main-repo");
+		expect(resolveProjectRoot(join(worktree, "packages"))).toBe(worktree);
 	});
 
 	it("honors explicit override before cwd resolution", () => {

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -90,3 +90,23 @@ export function resolveProject(cwd: string, override?: string | null): string | 
 	}
 	return basename(resolve(cwd));
 }
+
+/**
+ * Resolve the working-tree root for a directory by walking up to the nearest
+ * `.git` marker and returning the directory that contains it. Returns null when
+ * no repository is found.
+ *
+ * Unlike `resolveProject` (which follows a linked worktree's gitdir back to the
+ * primary checkout for a stable project name), this returns the *current*
+ * worktree root so repo-root files like AGENTS.md are read from the worktree
+ * actually being used, not another checkout.
+ */
+export function resolveProjectRoot(cwd: string): string | null {
+	let current = resolve(cwd);
+	while (true) {
+		if (existsSync(resolve(current, ".git"))) return current;
+		const parent = dirname(current);
+		if (parent === current) return null;
+		current = parent;
+	}
+}

--- a/packages/mcp-server/src/distill.test.ts
+++ b/packages/mcp-server/src/distill.test.ts
@@ -1,0 +1,131 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, initTestSchema, MemoryStore } from "@codemem/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCodememMcpServer } from "./index.js";
+
+type RegisteredTool = {
+	handler: (args: Record<string, unknown>) => Promise<{
+		content: Array<{ type: string; text: string }>;
+	}>;
+};
+
+function getTool(server: ReturnType<typeof createCodememMcpServer>, name: string): RegisteredTool {
+	const registry = (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+		._registeredTools;
+	const tool = registry[name];
+	if (!tool) throw new Error(`MCP tool not registered: ${name}`);
+	return tool;
+}
+
+function parseToolJson(result: { content: Array<{ type: string; text: string }> }): unknown {
+	const text = result.content[0]?.text;
+	if (typeof text !== "string") throw new Error("tool result missing text content");
+	return JSON.parse(text);
+}
+
+describe("memory_distill_candidates MCP tool", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+	let prevCodememConfig: string | undefined;
+	let prevEmbeddingDisabled: string | undefined;
+
+	beforeEach(() => {
+		prevCodememConfig = process.env.CODEMEM_CONFIG;
+		prevEmbeddingDisabled = process.env.CODEMEM_EMBEDDING_DISABLED;
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-mcp-distill-"));
+		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
+		process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+		dbPath = join(tmpDir, "mem.sqlite");
+
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+		if (prevCodememConfig === undefined) delete process.env.CODEMEM_CONFIG;
+		else process.env.CODEMEM_CONFIG = prevCodememConfig;
+		if (prevEmbeddingDisabled === undefined) delete process.env.CODEMEM_EMBEDDING_DISABLED;
+		else process.env.CODEMEM_EMBEDDING_DISABLED = prevEmbeddingDisabled;
+	});
+
+	function remember(project: string, title: string): number {
+		const sessionId = store.startSession({ cwd: join(tmpDir, project), project });
+		return store.remember(sessionId, "discovery", title, `${title} body`, 0.9);
+	}
+
+	it("mines candidates within the server default project", async () => {
+		remember("greenroom", "mcp distill greenroom recurring lesson");
+		remember("greenroom", "mcp distill greenroom recurring lesson again");
+		remember("other", "mcp distill other recurring lesson");
+		remember("other", "mcp distill other recurring lesson again");
+		const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+		const distill = getTool(server, "memory_distill_candidates");
+
+		const result = parseToolJson(
+			await distill.handler({
+				all_projects: false,
+				include_documented: false,
+				limit: 10,
+				max_evidence_items: 5,
+				min_recurrence: 2,
+			}),
+		) as { candidates: Array<{ projects: string[]; scope: string }>; version: number };
+
+		expect(result.version).toBe(1);
+		expect(result.candidates).toHaveLength(1);
+		expect(result.candidates[0]).toMatchObject({
+			projects: ["greenroom"],
+			scope: "project",
+		});
+	});
+
+	it("supports all-project mining for user-scoped candidates", async () => {
+		remember("greenroom", "purple otter lantern protocol recurring lesson");
+		remember("other", "purple otter lantern protocol lesson again");
+		const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+		const distill = getTool(server, "memory_distill_candidates");
+
+		const result = parseToolJson(
+			await distill.handler({
+				all_projects: true,
+				include_documented: false,
+				limit: 10,
+				max_evidence_items: 5,
+				min_recurrence: 2,
+			}),
+		) as { candidates: Array<{ projects: string[]; scope: string; suggested_target: string }> };
+
+		expect(result.candidates[0]).toMatchObject({
+			projects: ["greenroom", "other"],
+			scope: "user",
+			suggested_target: "~/.config/opencode/AGENTS.md",
+		});
+	});
+
+	it("rejects project filters when all-project mining is requested", async () => {
+		remember("greenroom", "project filter conflict recurring lesson");
+		remember("other", "project filter conflict recurring lesson again");
+		const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+		const distill = getTool(server, "memory_distill_candidates");
+
+		const result = parseToolJson(
+			await distill.handler({
+				all_projects: true,
+				include_documented: false,
+				limit: 10,
+				max_evidence_items: 5,
+				min_recurrence: 2,
+				project: "greenroom",
+			}),
+		) as { error?: string };
+
+		expect(result.error).toBe("project cannot be combined with all_projects");
+	});
+});

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -14,6 +14,7 @@ describe("createCodememMcpServer", () => {
 		).toSorted();
 
 		expect(tools).toEqual([
+			"memory_distill_candidates",
 			"memory_expand",
 			"memory_explain",
 			"memory_forget",

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -2,6 +2,7 @@ import { type MemoryStore, VERSION } from "@codemem/core";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { resolveDefaultProject } from "./project-scope.js";
 import type { CodememMcpServerOptions, ToolRegistrationContext } from "./tool-context.js";
+import { registerDistillTools } from "./tools/distill.js";
 import { registerItemTools } from "./tools/items.js";
 import { registerLearnTools } from "./tools/learn.js";
 import { registerSchemaTools } from "./tools/schema.js";
@@ -28,6 +29,7 @@ export function createCodememMcpServer(
 
 	registerSearchTools(server, context);
 	registerTimelineTools(server, context);
+	registerDistillTools(server, context);
 	registerItemTools(server, context);
 	registerSchemaTools(server);
 	registerLearnTools(server);

--- a/packages/mcp-server/src/tools/distill.ts
+++ b/packages/mcp-server/src/tools/distill.ts
@@ -1,0 +1,130 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+	buildDistillReport,
+	type DistillContextDocument,
+	type MemoryFilters,
+	projectMatchesFilter,
+	resolveProject,
+	resolveProjectRoot,
+} from "@codemem/core";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { errorContent, jsonContent } from "../content.js";
+import { buildFilters } from "../project-scope.js";
+import { filterSchema } from "../schemas.js";
+import type { ToolRegistrationContext } from "../tool-context.js";
+
+function readContextFile(
+	path: string,
+	displayPath: string,
+	scope: DistillContextDocument["scope"],
+): DistillContextDocument | null {
+	if (!existsSync(path)) return null;
+	const text = readFileSync(path, "utf8");
+	return text.trim() ? { path: displayPath, text, scope } : null;
+}
+
+function loadDefaultContextDocuments(
+	includeProjectContext: boolean,
+	cwd = process.cwd(),
+): DistillContextDocument[] {
+	// The repo-root AGENTS.md describes the current repo (scope "project") and is
+	// gated to current-project runs; the user-global context (scope "user")
+	// always applies and never suppresses other projects' candidates. Resolve the
+	// repo root so running from a subdirectory still finds the project context.
+	const projectRoot = resolveProjectRoot(cwd) ?? cwd;
+	const documents = [
+		includeProjectContext
+			? readContextFile(join(projectRoot, "AGENTS.md"), "AGENTS.md", "project")
+			: null,
+		readContextFile(
+			join(homedir(), ".config", "opencode", "AGENTS.md"),
+			"~/.config/opencode/AGENTS.md",
+			"user",
+		),
+	];
+	return documents.filter((document): document is DistillContextDocument => document != null);
+}
+
+function shouldIncludeProjectContext(
+	args: { all_projects?: boolean; project?: unknown },
+	defaultProject: string | null,
+): boolean {
+	if (args.all_projects) return false;
+	const currentProject = resolveProject(process.cwd());
+	if (!currentProject) return false;
+	const explicitProject = typeof args.project === "string" ? args.project.trim() : "";
+	// Match the corpus filter: the cwd AGENTS.md is only valid when the mined
+	// project (explicit arg or the server default project) is this repo.
+	const targetProject = explicitProject
+		? resolveProject(process.cwd(), explicitProject)
+		: defaultProject;
+	if (!targetProject) return false;
+	return projectMatchesFilter(targetProject, currentProject);
+}
+
+function buildDistillFilters(
+	args: { all_projects?: boolean } & Record<string, unknown>,
+	defaultProject: string | null,
+): MemoryFilters | undefined {
+	if (args.all_projects && typeof args.project === "string" && args.project.trim()) {
+		throw new Error("project cannot be combined with all_projects");
+	}
+	return buildFilters(args, args.all_projects ? null : defaultProject);
+}
+
+export function registerDistillTools(server: McpServer, context: ToolRegistrationContext): void {
+	const { defaultProject, store } = context;
+
+	server.tool(
+		"memory_distill_candidates",
+		"Mine recurring memories into reviewable context candidates. Read-only; does not modify context files.",
+		{
+			limit: z.number().int().min(1).max(50).default(10).describe("Max candidates"),
+			min_recurrence: z
+				.number()
+				.int()
+				.min(1)
+				.max(50)
+				.default(2)
+				.describe("Minimum member count per candidate"),
+			all_projects: z.boolean().default(false).describe("Mine memories across all projects"),
+			include_documented: z
+				.boolean()
+				.default(false)
+				.describe("Include candidates already represented in context files"),
+			max_evidence_items: z
+				.number()
+				.int()
+				.min(1)
+				.max(20)
+				.default(5)
+				.describe("Evidence snippets per candidate"),
+			...filterSchema,
+		},
+		async (args) => {
+			try {
+				const resolvedDefaultProject = defaultProject();
+				const filters = buildDistillFilters(args, resolvedDefaultProject);
+				const kinds = args.kind ? [args.kind] : undefined;
+				const result = await buildDistillReport(store, {
+					candidate: {
+						includeDocumented: args.include_documented,
+						maxEvidenceItems: args.max_evidence_items,
+					},
+					contextDocuments: loadDefaultContextDocuments(
+						shouldIncludeProjectContext(args, resolvedDefaultProject),
+					),
+					corpus: { filters: filters ?? null, kinds },
+					limit: args.limit,
+					minRecurrence: args.min_recurrence,
+				});
+				return jsonContent(result);
+			} catch (err) {
+				return errorContent(err instanceof Error ? err.message : String(err));
+			}
+		},
+	);
+}


### PR DESCRIPTION
## Description
Exposes Distill v1 candidates to both humans and agents. Adds a shared core `buildDistillReport` pipeline, a `codemem distill` CLI command with JSON and `--explain` output, and an MCP `memory_distill_candidates` tool. Updates docs to frame Distill as review-only: it emits ranked candidates and evidence but does not edit context files.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm exec vitest run packages/core/src/distill.test.ts packages/core/src/store.test.ts packages/cli/src/commands/distill.test.ts packages/mcp-server/src/distill.test.ts packages/mcp-server/src/server.test.ts`
- [x] `pnpm run tsc`
- [x] `pnpm run lint`
- [x] Added/updated CLI and MCP tests for command/tool registration, JSON contracts, default project scoping, all-project routing, and usage errors
- [ ] Full `pnpm run test` not run; targeted core/CLI/MCP tests were run for this stack slice

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced
