### PR TITLE
feat(distill): draft AGENTS.md rules from candidates with diff/apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,13 @@ Pack rendering defaults to self-contained context. For token-constrained experim
 `codemem distill` finds repeated discoveries and decisions that may be worth promoting into project or user context.
 
 ```text
-codemem distill --project codemem --limit 10
-codemem distill --all-projects --json
-codemem distill --explain
+codemem distill --explain               # ranked candidates + evidence
+codemem distill --all-projects --json   # machine-readable
+codemem distill --draft                 # draft an AGENTS.md rule for the top candidate and show a diff
+codemem distill --draft --apply         # write it after confirmation
 ```
 
-Distill is review-only: it emits ranked candidates and evidence, but it does not edit `AGENTS.md` or user context files.
+Candidate mining is deterministic. `--draft` uses your configured observer model to turn the top candidate into a single `AGENTS.md` rule and renders a unified diff; nothing is written. `--apply` writes that rule into a codemem-managed `## Distilled lessons` block (delimited by `<!-- codemem:distilled:begin/end -->` markers, so all distilled edits stay in one place) after prompting for confirmation.
 
 ## MCP tools
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -115,17 +115,18 @@ Command/file token caching notes:
 Use `codemem distill` to find lessons that keep showing up in memory history.
 
 ```fish
-codemem distill --project codemem --limit 10
-codemem distill --all-projects --explain
-codemem distill --json
+codemem distill --explain
+codemem distill --all-projects --json
+codemem distill --draft          # draft an AGENTS.md rule for the top candidate + diff
+codemem distill --draft --apply  # write it after confirmation
 ```
 
-Output is review-only:
+Candidate mining is deterministic and review-first:
 
-- `project` candidates usually belong in that repo's `AGENTS.md`.
-- `user` candidates usually belong in global/user context.
-- `draft_text` is intentionally empty until a human or agent writes the final wording.
-- The command does not edit context files automatically.
+- `project` candidates target that repo's `AGENTS.md`; `user` candidates target global/user context.
+- Without `--draft`, the command only emits ranked candidates and evidence (`draft_text` is null).
+- `--draft` uses your configured observer model to write one concise rule for the top candidate and prints a unified diff; it does not write anything.
+- `--apply` (implies `--draft`) writes the rule into a codemem-managed `## Distilled lessons` block, delimited by `<!-- codemem:distilled:begin/end -->` markers so every distilled edit stays in one place. It prompts before writing (except with `--json`, which is non-interactive — there `--apply` itself is the explicit consent and the write happens immediately) and appends only (never deletes your existing notes).
 
 ## Sync
 

--- a/packages/cli/src/commands/distill.test.ts
+++ b/packages/cli/src/commands/distill.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
 	buildDistillReport: vi.fn(),
 	closeStore: vi.fn(),
+	observe: vi.fn(),
 	storePaths: [] as Array<string | undefined>,
 }));
 
@@ -18,6 +19,9 @@ vi.mock("@codemem/core", async (importOriginal) => {
 			}
 			close = mocks.closeStore;
 		},
+		ObserverClient: class {
+			observe = mocks.observe;
+		},
 		resolveDbPath: (value?: string) => value,
 	};
 });
@@ -27,10 +31,42 @@ import { distillCommand, renderDistillReport } from "./distill.js";
 afterEach(() => {
 	mocks.buildDistillReport.mockReset();
 	mocks.closeStore.mockReset();
+	mocks.observe.mockReset();
 	mocks.storePaths.length = 0;
 	process.exitCode = 0;
 	vi.restoreAllMocks();
 });
+
+function userScopeReport() {
+	return {
+		version: 1,
+		candidates: [
+			{
+				scope: "user",
+				suggested_target: "~/.config/opencode/AGENTS.md",
+				score: 0.5,
+				recurrence: 4,
+				projects: ["codemem", "memorybench"],
+				member_ids: [1, 2, 3, 4],
+				representative_id: 1,
+				concepts: ["graphite"],
+				artifact_kind: "context_fact",
+				evidence: ["Use the HTTPS rewrite when Graphite SSH auth stalls."],
+				draft_text: null,
+			},
+		],
+		metadata: {
+			candidate_count: 1,
+			cluster_count: 1,
+			context_document_count: 0,
+			corpus_count: 4,
+			corpus_limit: 2000,
+			documented_cluster_count: 0,
+			include_documented: false,
+			min_recurrence: 2,
+		},
+	};
+}
 
 async function parseDistillCommand(args: string[]): Promise<void> {
 	const root = new Command("codemem");
@@ -51,6 +87,8 @@ describe("distill command", () => {
 		expect(longs).toContain("--limit");
 		expect(longs).toContain("--explain");
 		expect(longs).toContain("--include-documented");
+		expect(longs).toContain("--draft");
+		expect(longs).toContain("--apply");
 	});
 
 	it("emits JSON candidates and passes parsed options to core", async () => {
@@ -163,5 +201,75 @@ describe("distill command", () => {
 
 		expect(renderDistillReport(report, false)).not.toContain("HTTPS rewrite");
 		expect(renderDistillReport(report, true)).toContain("Use HTTPS rewrite");
+	});
+
+	it("drafts a rule for the top candidate and prints a diff without writing", async () => {
+		mocks.buildDistillReport.mockResolvedValue(userScopeReport());
+		mocks.observe.mockResolvedValue({
+			raw: "- Use the HTTPS rewrite when Graphite SSH auth stalls.",
+		});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseDistillCommand(["--draft", "--json"]);
+
+		expect(mocks.observe).toHaveBeenCalledTimes(1);
+		const out = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(out.draft.rule).toBe("Use the HTTPS rewrite when Graphite SSH auth stalls.");
+		expect(out.draft.applied).toBe(false);
+		expect(typeof out.draft.diff).toBe("string");
+		expect(out.draft.diff).toContain("codemem:distilled:begin");
+	});
+
+	it("reports a structured error when drafting has no observer", async () => {
+		mocks.buildDistillReport.mockResolvedValue(userScopeReport());
+		mocks.observe.mockRejectedValue(new Error("no observer auth configured"));
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseDistillCommand(["--draft", "--json"]);
+
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({
+			error: "draft_failed",
+		});
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("does not write when the model declines to draft a rule", async () => {
+		mocks.buildDistillReport.mockResolvedValue(userScopeReport());
+		mocks.observe.mockResolvedValue({ raw: "SKIP" });
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseDistillCommand(["--draft", "--json"]);
+
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({
+			draft: null,
+			reason: "model_declined",
+		});
+	});
+
+	it("refuses to draft a project-scoped candidate from another repo", async () => {
+		const report = userScopeReport();
+		const [first] = report.candidates;
+		if (!first) throw new Error("expected a seeded candidate");
+		report.candidates = [
+			{
+				...first,
+				scope: "project",
+				suggested_target: "AGENTS.md",
+				projects: ["another-unrelated-repo"],
+			},
+		];
+		mocks.buildDistillReport.mockResolvedValue(report);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseDistillCommand(["--draft", "--json"]);
+
+		// The cwd checkout is not "another-unrelated-repo": drafting must refuse
+		// before any model call so the wrong repo's AGENTS.md is never targeted.
+		expect(mocks.observe).not.toHaveBeenCalled();
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({
+			draft: null,
+			reason: "project_mismatch",
+			projects: ["another-unrelated-repo"],
+		});
 	});
 });

--- a/packages/cli/src/commands/distill.ts
+++ b/packages/cli/src/commands/distill.ts
@@ -1,14 +1,19 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import * as p from "@clack/prompts";
 import {
+	applyDistillRule,
 	buildDistillReport,
+	type DistillCandidate,
 	type DistillContextDocument,
 	type DistillReport,
+	draftDistillRule,
 	type MemoryFilters,
 	MemoryStore,
+	ObserverClient,
 	projectMatchesFilter,
+	renderUnifiedDiff,
 	resolveDbPath,
 	resolveProject,
 	resolveProjectRoot,
@@ -27,6 +32,8 @@ import {
 type DistillCommandOptions = DbOpts &
 	JsonOpts & {
 		allProjects?: boolean;
+		apply?: boolean;
+		draft?: boolean;
 		explain?: boolean;
 		includeDocumented?: boolean;
 		kind: string[];
@@ -145,11 +152,181 @@ export function renderDistillReport(report: DistillReport, explain = false): str
 	return lines.join("\n").trimEnd();
 }
 
+function resolveCandidateTarget(candidate: DistillCandidate): { path: string; display: string } {
+	if (candidate.scope === "user") {
+		return {
+			path: join(homedir(), ".config", "opencode", "AGENTS.md"),
+			display: "~/.config/opencode/AGENTS.md",
+		};
+	}
+	const root = resolveProjectRoot(process.cwd()) ?? process.cwd();
+	return { path: join(root, "AGENTS.md"), display: "AGENTS.md" };
+}
+
+async function draftTopCandidate(
+	report: DistillReport,
+	opts: DistillCommandOptions,
+): Promise<void> {
+	const candidate = report.candidates[0];
+	if (!candidate) {
+		if (opts.json) {
+			console.log(JSON.stringify({ draft: null, reason: "no_candidates" }, null, 2));
+		} else {
+			p.intro("codemem distill");
+			p.log.warn("No distill candidates to draft.");
+			p.outro("done");
+		}
+		return;
+	}
+
+	// A project-scoped candidate targets ITS repo's AGENTS.md. When the run was
+	// filtered to another project (or --all-projects surfaced a different repo),
+	// writing the cwd checkout's AGENTS.md would put the rule in the wrong repo.
+	if (candidate.scope === "project") {
+		const currentProject = resolveProject(process.cwd());
+		const matchesCwd =
+			currentProject != null &&
+			candidate.projects.every((project) => projectMatchesFilter(project, currentProject));
+		if (!matchesCwd) {
+			const projects = candidate.projects.join(", ") || "(unknown)";
+			if (opts.json) {
+				console.log(
+					JSON.stringify(
+						{
+							draft: null,
+							reason: "project_mismatch",
+							representative_id: candidate.representative_id,
+							projects: candidate.projects,
+						},
+						null,
+						2,
+					),
+				);
+			} else {
+				p.intro("codemem distill draft");
+				p.log.warn(
+					`The top candidate belongs to project "${projects}", not this checkout. Run distill from that repo to draft its AGENTS.md rule.`,
+				);
+				p.outro("nothing written");
+			}
+			return;
+		}
+	}
+
+	const target = resolveCandidateTarget(candidate);
+	const current = existsSync(target.path) ? readFileSync(target.path, "utf8") : "";
+
+	let rule: string | null;
+	let raw: string | null;
+	try {
+		const client = new ObserverClient();
+		const drafted = await draftDistillRule(candidate, async (system, user) => {
+			const response = await client.observe(system, user);
+			return response.raw;
+		});
+		rule = drafted.rule;
+		raw = drafted.raw;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const guidance = `drafting needs a configured observer model: ${message}`;
+		if (opts.json) {
+			emitJsonError("draft_failed", guidance, 1);
+		} else {
+			p.log.error(guidance);
+			process.exitCode = 1;
+		}
+		return;
+	}
+
+	if (!rule) {
+		if (opts.json) {
+			console.log(
+				JSON.stringify(
+					{
+						draft: null,
+						reason: "model_declined",
+						representative_id: candidate.representative_id,
+						raw,
+					},
+					null,
+					2,
+				),
+			);
+		} else {
+			p.intro("codemem distill draft");
+			p.log.warn("The model declined to draft a rule for the top candidate (too vague).");
+			p.outro("done");
+		}
+		return;
+	}
+
+	const applied = applyDistillRule(current, rule);
+	const diff = renderUnifiedDiff(target.display, current, applied.text);
+
+	if (opts.json) {
+		const wrote = Boolean(opts.apply && applied.changed);
+		if (wrote) {
+			mkdirSync(dirname(target.path), { recursive: true });
+			writeFileSync(target.path, applied.text);
+		}
+		console.log(
+			JSON.stringify(
+				{
+					draft: {
+						target: target.display,
+						scope: candidate.scope,
+						representative_id: candidate.representative_id,
+						recurrence: candidate.recurrence,
+						score: candidate.score,
+						rule,
+						diff,
+						already_present: !applied.changed,
+						applied: wrote,
+					},
+				},
+				null,
+				2,
+			),
+		);
+		return;
+	}
+
+	p.intro("codemem distill draft");
+	p.log.info(
+		`Top candidate [${candidate.scope}] recurrence=${candidate.recurrence} → ${target.display}`,
+	);
+	p.log.step(`Proposed rule:\n  ${rule}`);
+	if (!applied.changed) {
+		p.log.warn("This rule is already present in the target file.");
+		p.outro("nothing to apply");
+		return;
+	}
+	console.log(diff);
+
+	if (!opts.apply) {
+		p.outro(`dry run — re-run with --apply to write ${target.display}`);
+		return;
+	}
+
+	const confirmed = await p.confirm({ message: `Apply this change to ${target.display}?` });
+	if (p.isCancel(confirmed) || !confirmed) {
+		p.outro("aborted — nothing written");
+		return;
+	}
+	mkdirSync(dirname(target.path), { recursive: true });
+	writeFileSync(target.path, applied.text);
+	p.outro(`wrote ${target.display}`);
+}
+
 async function distillAction(opts: DistillCommandOptions): Promise<void> {
 	let store: MemoryStore | null = null;
 	try {
 		store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
 		const result = await runDistill(store, opts);
+		if (opts.draft || opts.apply) {
+			await draftTopCandidate(result, opts);
+			return;
+		}
 		if (opts.json) {
 			console.log(JSON.stringify(result, null, 2));
 			return;
@@ -180,7 +357,12 @@ const cmd = new Command("distill")
 	.option("-m, --min-recurrence <n>", "minimum member count per candidate", "2")
 	.option("-l, --limit <n>", "max candidates", "10")
 	.option("-e, --explain", "include evidence snippets in human output")
-	.option("--include-documented", "include candidates already represented in context files");
+	.option("--include-documented", "include candidates already represented in context files")
+	.option("-D, --draft", "draft an AGENTS.md rule for the top candidate and show the diff")
+	.option(
+		"--apply",
+		"write the drafted rule to the target file (implies --draft; prompts to confirm; with --json applies immediately without prompting)",
+	);
 
 addDbOption(cmd);
 addJsonOption(cmd);

--- a/packages/core/src/distill-draft.test.ts
+++ b/packages/core/src/distill-draft.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { DistillCandidate } from "./distill.js";
+import {
+	applyDistillRule,
+	buildDistillDraftPrompt,
+	DISTILL_BLOCK_BEGIN,
+	DISTILL_BLOCK_END,
+	draftDistillRule,
+	renderUnifiedDiff,
+	sanitizeRuleLine,
+} from "./distill-draft.js";
+
+function candidate(overrides: Partial<DistillCandidate> = {}): DistillCandidate {
+	return {
+		scope: "project",
+		suggested_target: "AGENTS.md",
+		score: 0.5,
+		recurrence: 4,
+		projects: ["codemem"],
+		member_ids: [1, 2, 3, 4],
+		representative_id: 1,
+		concepts: ["release", "preflight"],
+		artifact_kind: "context_fact",
+		evidence: ["Release preflight must run on main.", "Tags require a clean main branch."],
+		draft_text: null,
+		...overrides,
+	};
+}
+
+describe("distill draft", () => {
+	it("builds a prompt that carries scope, concepts, and evidence", () => {
+		const { system, user } = buildDistillDraftPrompt(candidate());
+		expect(system).toContain("AGENTS.md");
+		expect(system).toContain("SKIP");
+		expect(user).toContain("Scope: project");
+		expect(user).toContain("release, preflight");
+		expect(user).toContain("- Release preflight must run on main.");
+	});
+
+	it("sanitizes model output into a single clean rule line", () => {
+		expect(sanitizeRuleLine("- Run release preflight on main.")).toBe(
+			"Run release preflight on main.",
+		);
+		expect(sanitizeRuleLine('1. "Keep tags on a clean main branch."')).toBe(
+			"Keep tags on a clean main branch.",
+		);
+		expect(sanitizeRuleLine("First useful line\nsecond line")).toBe("First useful line");
+		expect(sanitizeRuleLine("SKIP")).toBeNull();
+		expect(sanitizeRuleLine("   ")).toBeNull();
+		expect(sanitizeRuleLine(null)).toBeNull();
+	});
+
+	it("caps very long rules", () => {
+		const rule = sanitizeRuleLine("x".repeat(500));
+		expect(rule).not.toBeNull();
+		expect((rule ?? "").length).toBeLessThanOrEqual(200);
+		expect((rule ?? "").endsWith("…")).toBe(true);
+	});
+
+	it("drafts a rule via the injected drafter and honors SKIP", async () => {
+		const ok = await draftDistillRule(candidate(), async () => "- Always run preflight on main.");
+		expect(ok.rule).toBe("Always run preflight on main.");
+
+		const skipped = await draftDistillRule(candidate(), async () => "SKIP");
+		expect(skipped.rule).toBeNull();
+		expect(skipped.raw).toBe("SKIP");
+	});
+
+	it("creates a managed block in an empty file", () => {
+		const result = applyDistillRule("", "Run preflight on main");
+		expect(result.changed).toBe(true);
+		expect(result.text).toContain("## Distilled lessons");
+		expect(result.text).toContain(DISTILL_BLOCK_BEGIN);
+		expect(result.text).toContain("- Run preflight on main");
+		expect(result.text).toContain(DISTILL_BLOCK_END);
+	});
+
+	it("appends a managed block to an existing file without clobbering content", () => {
+		const original = "# Project\n\nSome existing guidance.\n";
+		const result = applyDistillRule(original, "Run preflight on main");
+		expect(result.changed).toBe(true);
+		expect(result.text.startsWith(original.replace(/\s+$/, ""))).toBe(true);
+		expect(result.text).toContain(DISTILL_BLOCK_BEGIN);
+		expect(result.text).toContain("- Run preflight on main");
+	});
+
+	it("inserts into an existing managed block and dedupes", () => {
+		const first = applyDistillRule("", "Rule one").text;
+		const second = applyDistillRule(first, "Rule two");
+		expect(second.changed).toBe(true);
+		expect(second.text).toContain("- Rule one");
+		expect(second.text).toContain("- Rule two");
+		// Only one managed block.
+		expect(second.text.split(DISTILL_BLOCK_BEGIN).length).toBe(2);
+
+		const dupe = applyDistillRule(second.text, "Rule two");
+		expect(dupe.changed).toBe(false);
+		expect(dupe.text).toBe(second.text);
+	});
+
+	it("renders a unified diff for the proposed change", () => {
+		const before = "# Project\n\nSome existing guidance.\n";
+		const after = applyDistillRule(before, "Run preflight on main").text;
+		const diff = renderUnifiedDiff("AGENTS.md", before, after);
+		expect(diff).toContain("--- a/AGENTS.md");
+		expect(diff).toContain("+++ b/AGENTS.md");
+		expect(diff).toContain("+- Run preflight on main");
+		expect(diff).toContain(`+${DISTILL_BLOCK_BEGIN}`);
+	});
+
+	it("uses /dev/null as the original for a new file diff", () => {
+		const after = applyDistillRule("", "Run preflight on main").text;
+		const diff = renderUnifiedDiff("AGENTS.md", "", after);
+		expect(diff).toContain("--- /dev/null");
+		expect(diff).toContain("+## Distilled lessons");
+	});
+});

--- a/packages/core/src/distill-draft.ts
+++ b/packages/core/src/distill-draft.ts
@@ -1,0 +1,184 @@
+import type { DistillCandidate } from "./distill.js";
+
+/**
+ * Injected LLM call. Returns the model's raw text, or null when unavailable.
+ * Kept abstract so core stays pure and testable; the CLI wires this to the
+ * configured observer runtime (api_http / claude_sidecar / codex_sidecar).
+ */
+export type DistillRuleDrafter = (system: string, user: string) => Promise<string | null>;
+
+export interface DistillDraftPrompt {
+	system: string;
+	user: string;
+}
+
+export interface DistillDraftResult {
+	/** The drafted one-line rule, or null when the model declined (SKIP) or failed. */
+	rule: string | null;
+	/** Raw model output, for debugging/--json. */
+	raw: string | null;
+}
+
+export interface DistillApplyResult {
+	/** The new full file text after inserting the rule. */
+	text: string;
+	/** False when the rule was already present (no-op). */
+	changed: boolean;
+}
+
+export const DISTILL_LESSONS_HEADING = "## Distilled lessons";
+// codemem-owned markers so every distilled edit lives in one delimited block
+// that is trivial to find, update, or rewrite (matches the repo's existing
+// <!-- ...:begin/end --> convention).
+export const DISTILL_BLOCK_BEGIN = "<!-- codemem:distilled:begin -->";
+export const DISTILL_BLOCK_END = "<!-- codemem:distilled:end -->";
+const MAX_RULE_CHARS = 200;
+const MAX_EVIDENCE_FOR_PROMPT = 8;
+const SKIP_TOKEN = "SKIP";
+
+export function buildDistillDraftPrompt(candidate: DistillCandidate): DistillDraftPrompt {
+	const system = [
+		"You convert a recurring engineering lesson into a single durable rule for an AGENTS.md context file.",
+		"Output exactly one line: an imperative rule with no preamble and no markdown bullet, at most 200 characters.",
+		"It must be specific and actionable so an AI coding agent can follow it without the original evidence.",
+		`If the evidence is too vague or generic to form a useful rule, output the single word: ${SKIP_TOKEN}.`,
+	].join("\n");
+
+	const evidence = candidate.evidence
+		.slice(0, MAX_EVIDENCE_FOR_PROMPT)
+		.map((item) => `- ${item}`)
+		.join("\n");
+
+	const user = [
+		`Scope: ${candidate.scope}`,
+		`Projects: ${candidate.projects.join(", ") || "(unknown)"}`,
+		`Concepts: ${candidate.concepts.join(", ") || "(none)"}`,
+		`Times observed: ${candidate.recurrence}`,
+		"",
+		"Recurring observations:",
+		evidence || "(no evidence)",
+	].join("\n");
+
+	return { system, user };
+}
+
+/** Normalize a model response into a single clean rule line, or null. */
+export function sanitizeRuleLine(text: string | null | undefined): string | null {
+	if (!text) return null;
+	const firstLine = text
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.find((line) => line.length > 0);
+	if (!firstLine) return null;
+
+	let rule = firstLine
+		.replace(/^[-*+]\s+/, "") // strip markdown bullet
+		.replace(/^\d+[.)]\s+/, "") // strip numbered list marker
+		.replace(/^["'`]+|["'`]+$/g, "") // strip surrounding quotes/backticks
+		.replace(/\s+/g, " ")
+		.trim();
+
+	if (!rule || rule.toUpperCase() === SKIP_TOKEN) return null;
+	if (rule.length > MAX_RULE_CHARS) rule = `${rule.slice(0, MAX_RULE_CHARS - 1).trimEnd()}…`;
+	return rule;
+}
+
+export async function draftDistillRule(
+	candidate: DistillCandidate,
+	drafter: DistillRuleDrafter,
+): Promise<DistillDraftResult> {
+	const { system, user } = buildDistillDraftPrompt(candidate);
+	const raw = await drafter(system, user);
+	return { rule: sanitizeRuleLine(raw), raw: raw ?? null };
+}
+
+/**
+ * Insert a rule bullet into the codemem-managed block of a context file.
+ * Append-only and idempotent: if the rule already exists the file is unchanged.
+ * All distilled edits stay inside the begin/end markers so the block is easy to
+ * locate and rewrite later.
+ */
+export function applyDistillRule(currentText: string, rule: string): DistillApplyResult {
+	const bullet = `- ${rule}`;
+	const existing = currentText ?? "";
+
+	const beginIdx = existing.indexOf(DISTILL_BLOCK_BEGIN);
+	const endIdx = existing.indexOf(DISTILL_BLOCK_END);
+
+	if (beginIdx !== -1 && endIdx !== -1 && endIdx > beginIdx) {
+		// Rebuild the managed block from its existing bullets plus the new one.
+		const before = existing.slice(0, beginIdx + DISTILL_BLOCK_BEGIN.length);
+		const inner = existing.slice(beginIdx + DISTILL_BLOCK_BEGIN.length, endIdx);
+		const after = existing.slice(endIdx);
+		const bullets = inner
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0);
+		if (bullets.includes(bullet)) return { text: existing, changed: false };
+		const rebuilt = `\n${[...bullets, bullet].join("\n")}\n`;
+		return { text: `${before}${rebuilt}${after}`, changed: true };
+	}
+
+	const managedBlock = `${DISTILL_LESSONS_HEADING}\n\n${DISTILL_BLOCK_BEGIN}\n${bullet}\n${DISTILL_BLOCK_END}\n`;
+	const trimmed = existing.replace(/\s+$/, "");
+	if (trimmed.length === 0) return { text: managedBlock, changed: true };
+	return { text: `${trimmed}\n\n${managedBlock}`, changed: true };
+}
+
+function commonPrefix(a: string[], b: string[]): number {
+	const max = Math.min(a.length, b.length);
+	let i = 0;
+	while (i < max && a[i] === b[i]) i += 1;
+	return i;
+}
+
+function commonSuffix(a: string[], b: string[], used: number): number {
+	const max = Math.min(a.length, b.length) - used;
+	let i = 0;
+	while (i < max && a[a.length - 1 - i] === b[b.length - 1 - i]) i += 1;
+	return i;
+}
+
+/**
+ * Render a minimal single-hunk unified diff for a localized change (our edits
+ * only insert lines, so one hunk is exact). Uses /dev/null for empty originals.
+ */
+export function renderUnifiedDiff(
+	displayPath: string,
+	oldText: string,
+	newText: string,
+	context = 3,
+): string {
+	if (oldText === newText) return "";
+
+	const oldLines = oldText === "" ? [] : oldText.replace(/\n$/, "").split("\n");
+	const newLines = newText === "" ? [] : newText.replace(/\n$/, "").split("\n");
+
+	const prefix = commonPrefix(oldLines, newLines);
+	const suffix = commonSuffix(oldLines, newLines, prefix);
+
+	const preStart = Math.max(0, prefix - context);
+	const pre = oldLines.slice(preStart, prefix);
+	const removed = oldLines.slice(prefix, oldLines.length - suffix);
+	const added = newLines.slice(prefix, newLines.length - suffix);
+	const postEnd = Math.min(oldLines.length, oldLines.length - suffix + context);
+	const post = oldLines.slice(oldLines.length - suffix, postEnd);
+
+	const oldStart = oldLines.length === 0 ? 0 : preStart + 1;
+	const newStart = newLines.length === 0 ? 0 : preStart + 1;
+	const oldCount = pre.length + removed.length + post.length;
+	const newCount = pre.length + added.length + post.length;
+
+	const header = [
+		`--- ${oldText === "" ? "/dev/null" : `a/${displayPath}`}`,
+		`+++ b/${displayPath}`,
+		`@@ -${oldStart},${oldCount} +${newStart},${newCount} @@`,
+	];
+	const body = [
+		...pre.map((line) => ` ${line}`),
+		...removed.map((line) => `-${line}`),
+		...added.map((line) => `+${line}`),
+		...post.map((line) => ` ${line}`),
+	];
+	return [...header, ...body].join("\n");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -187,6 +187,22 @@ export {
 	scoreDistillClusters,
 	selectDistillCorpus,
 } from "./distill.js";
+export type {
+	DistillApplyResult,
+	DistillDraftPrompt,
+	DistillDraftResult,
+	DistillRuleDrafter,
+} from "./distill-draft.js";
+export {
+	applyDistillRule,
+	buildDistillDraftPrompt,
+	DISTILL_BLOCK_BEGIN,
+	DISTILL_BLOCK_END,
+	DISTILL_LESSONS_HEADING,
+	draftDistillRule,
+	renderUnifiedDiff,
+	sanitizeRuleLine,
+} from "./distill-draft.js";
 export type { EmbeddingClient } from "./embeddings.js";
 export {
 	_resetEmbeddingClient,


### PR DESCRIPTION
## Description
Adds the B-side of Distill: turn a candidate into an actual `AGENTS.md` change.

- Core (`distill-draft.ts`, pure + injected LLM): `buildDistillDraftPrompt`, `sanitizeRuleLine`, `draftDistillRule(candidate, drafter)` produce one concise imperative rule; `applyDistillRule` inserts it (append-only, idempotent) into a codemem-managed block delimited by `<!-- codemem:distilled:begin/end -->` under a `## Distilled lessons` heading; `renderUnifiedDiff` renders a minimal single-hunk diff.
- CLI: `codemem distill --draft` drafts the top candidate via the configured observer (`ObserverClient.observe`) and prints a unified diff (no write); `--apply` writes it after a confirmation prompt. Graceful error when no observer is configured.
- Also recalibrates clustering (in the clustering PR) so candidates are coherent on a real store, and gates concept/title unions to un-embedded pairs.

Validated end-to-end against a real ~2000-memory store: produces coherent ranked candidates and a clean proposed `AGENTS.md` diff.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm run tsc`
- [x] `pnpm run lint`
- [x] `pnpm run test` (full workspace, 2448 tests)
- [x] Core draft/diff tests (prompt, sanitize, draft+SKIP, apply create/append/dedupe, unified diff)
- [x] CLI tests (flag registration, `--draft --json` diff, observer-missing error, model-declined)
- [x] Manual: `codemem distill --draft` against a real store renders a proposed AGENTS.md diff

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] Documentation updated (README + user-guide cover `--draft`/`--apply`)
- [x] No new warnings introduced
