### PR TITLE
feat(core): add dual-artifact memory worthiness classifier

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -311,6 +311,16 @@ export {
 	startMaintenanceJob,
 	updateMaintenanceJob,
 } from "./maintenance-jobs.js";
+export type {
+	DerivedMemoryRole,
+	DerivedMemoryRoleResult,
+	InferMemoryRoleInput,
+	MemoryArtifactClass,
+	MemoryWorthinessAction,
+	MemoryWorthinessReason,
+	MemoryWorthinessResult,
+} from "./memory-quality.js";
+export { classifyMemoryWorthiness, inferMemoryRole } from "./memory-quality.js";
 export type { ObserverAuthMaterial } from "./observer-auth.js";
 export {
 	buildCodexHeaders,

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -446,7 +446,10 @@ describe("ingest-sanitize", () => {
 // ingest() integration (mocked observer)
 // ---------------------------------------------------------------------------
 
-describe("ingest() integration", () => {
+// CI occasionally times out these sqlite-backed ingest integration tests on
+// shared runners. Keep the allowance scoped to this persistence-heavy suite
+// rather than changing Vitest's global timeout.
+describe("ingest() integration", { timeout: 15_000 }, () => {
 	let tmpDir: string;
 	let store: MemoryStore;
 

--- a/packages/core/src/memory-quality.test.ts
+++ b/packages/core/src/memory-quality.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { inferMemoryRole } from "./memory-quality.js";
+import { classifyMemoryWorthiness, inferMemoryRole } from "./memory-quality.js";
 
 describe("inferMemoryRole", () => {
 	it("maps summary-like rows to recap", () => {
@@ -44,5 +44,359 @@ describe("inferMemoryRole", () => {
 				project: "opencode",
 			}),
 		).toEqual({ role: "general", reason: "durable_kind_with_non_normal_project" });
+	});
+});
+
+describe("classifyMemoryWorthiness", () => {
+	it("keeps durable decisions as derived facts", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "decision",
+				title: "Use role-based memory quality",
+				body_text:
+					"Decided to keep memory kinds stable because roles can evolve without a schema rewrite.",
+			}),
+		).toEqual({ artifact: "derived_fact", action: "store", reasons: ["durable_decision"] });
+	});
+
+	it("normalizes kind before classifying durable decisions", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: " Decision ",
+				title: "Use role-based memory quality",
+				body_text:
+					"Decided to keep memory kinds stable because roles can evolve without a schema rewrite.",
+			}),
+		).toEqual({ artifact: "derived_fact", action: "store", reasons: ["durable_decision"] });
+	});
+
+	it("keeps implementation contracts tied to files", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "discovery",
+				title: "Memory kind surfaces move together",
+				body_text:
+					"When changing memory kinds, packages/core/src/store.ts and packages/ui/src/tabs/feed.ts must be updated together.",
+			}),
+		).toEqual({ artifact: "derived_fact", action: "store", reasons: ["implementation_contract"] });
+	});
+
+	// Codex M1: ordinary "must <verb>" contracts must be recognized.
+	it("keeps ordinary must-verb implementation contracts (M1)", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "discovery",
+			title: "CLI error handling",
+			body_text:
+				"packages/cli/src/index.ts command handlers must return structured errors instead of throwing.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.action).toBe("store");
+		expect(result.reasons).toContain("implementation_contract");
+	});
+
+	// Codex M2: validation phrasing with an embedded contract is kept.
+	it("keeps a durable contract embedded in validation telemetry (M2)", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "discovery",
+			title: "Deployment rule",
+			body_text: "CI is green after confirming deployments require reciprocal approval.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.reasons).toContain("modal_contract");
+		expect(result.reasons).not.toContain("validation_telemetry_only");
+	});
+
+	// Codex M3: review phrasing with an embedded contract is kept.
+	it("keeps a durable lesson embedded in review telemetry (M3)", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "discovery",
+			title: "Release tagging",
+			body_text:
+				"Review approved after confirming release tags require tagging the merged main commit.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.reasons).not.toContain("review_telemetry_no_findings");
+	});
+
+	// Codex M4: workspace-root rule with contract language is kept, not bootstrap noise.
+	it("keeps durable workspace-root rules (M4)", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "discovery",
+			title: "Project scope",
+			body_text:
+				"Workspace root resolution requires the git repo root when deriving project scope.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.reasons).not.toContain("runtime_bootstrap_noise");
+	});
+
+	// Codex C5: any modal verb (not a whitelist) with a locator is a contract.
+	it("keeps modal contracts with arbitrary verbs (C5)", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "discovery",
+			title: "Migration rule",
+			body_text:
+				"CI is green after confirming packages/core/src/db.ts migrations must add nullable columns before readers depend on them.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.reasons).toContain("implementation_contract");
+		expect(result.reasons).not.toContain("validation_telemetry_only");
+	});
+
+	// Codex C6: dependency/outcome lessons are durable.
+	it("keeps dependency-lesson outcomes embedded in validation telemetry (C6)", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "discovery",
+			title: "Asset dependency",
+			body_text:
+				"The test passed only after rebuilding UI assets, confirming viewer-server checks depend on generated static files.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.reasons).not.toContain("validation_telemetry_only");
+	});
+
+	// Codex C9: a decision-kind row with telemetry words is still durable.
+	it("keeps decision-kind rows even with telemetry wording (C9)", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "decision",
+			title: "Use SQLite by default",
+			body_text: "Tests passed. We will use SQLite by default for local stores.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.reasons).toContain("durable_decision");
+	});
+
+	// Codex C10: investigation with a confirmed outcome is durable, not demoted.
+	it("keeps investigations with a confirmed outcome (C10)", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "discovery",
+			title: "Reranking behavior",
+			body_text:
+				"Investigated packages/core/src/search.ts and confirmed reranking uses recency decay.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.reasons).not.toContain("investigation_without_durable_conclusion");
+	});
+
+	// Codex: "regression tests passed" is validation telemetry, not a gotcha.
+	it("does not keep regression-test-pass telemetry as a gotcha", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "change",
+			title: "Regression run",
+			body_text: "Regression tests passed and the regression suite is green.",
+		});
+		expect(result.artifact).toBe("telemetry");
+		expect(result.reasons).not.toContain("troubleshooting_gotcha");
+	});
+
+	// Codex: findings phrased without "that" should still count as a conclusion.
+	it("keeps investigations with a finding phrased without 'that'", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "change",
+			title: "Reranking inspection",
+			body_text: "Investigated packages/core/src/search.ts and found the recency-decay weighting.",
+		});
+		expect(result.reasons).not.toContain("investigation_without_durable_conclusion");
+	});
+
+	it("does not treat personal task language as a derived fact", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "change",
+			title: "Pending edit",
+			body_text: "I must update store.ts later.",
+		});
+		expect(result.artifact).not.toBe("derived_fact");
+		expect(result.reasons).not.toContain("implementation_contract");
+		expect(result.reasons).not.toContain("modal_contract");
+	});
+
+	// Codex: the personal-task guard must strip only the personal clause, not
+	// block an embedded impersonal contract elsewhere in the text.
+	it("keeps an embedded impersonal contract even after personal-task phrasing", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "change",
+			title: "Static assets",
+			body_text:
+				"Tests passed. We should remember that viewer-server validation requires generated static files.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		// No file path in the text, so it's a modal_contract rather than a
+		// file-scoped implementation_contract — the point is it is NOT suppressed.
+		expect(result.reasons).toContain("modal_contract");
+	});
+
+	// Codex: next-step/handoff phrasing governing a modal is not a durable
+	// contract; it must fall through to workstream continuity, not modal_contract.
+	it("does not treat next-step task phrasing as a modal contract", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "change",
+			title: "Handoff",
+			body_text: "Next step should run tests after the edit lands.",
+		});
+		expect(result.artifact).not.toBe("derived_fact");
+		expect(result.reasons).not.toContain("modal_contract");
+		expect(result.reasons).not.toContain("implementation_contract");
+	});
+
+	// Codex: a no-finding investigation has no reusable lesson and must be
+	// demoted even though it contains the bare verb "found".
+	it("demotes a no-finding investigation despite the word 'found'", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "change",
+			title: "Audit",
+			body_text: "Investigated the auth flow and found no issues.",
+		});
+		expect(result.reasons).toContain("investigation_without_durable_conclusion");
+		expect(result.artifact).not.toBe("derived_fact");
+	});
+
+	it("still keeps an investigation with a real finding", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "change",
+			title: "Audit",
+			body_text: "Investigated the auth flow and found the token refresh races on expiry.",
+		});
+		expect(result.reasons).not.toContain("investigation_without_durable_conclusion");
+	});
+
+	// Codex: "found no <non-status>" is a durable NEGATIVE finding (absence of a
+	// mechanism), not no-finding telemetry, and must not be demoted.
+	it("keeps a durable negative finding (found no <mechanism>)", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "change",
+			title: "Embeddings",
+			body_text:
+				"Investigated packages/core/src/search.ts and found no fallback for empty embeddings.",
+		});
+		expect(result.reasons).not.toContain("investigation_without_durable_conclusion");
+		expect(result.artifact).toBe("derived_fact");
+	});
+
+	it("keeps troubleshooting gotchas", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "bugfix",
+				title: "Viewer asset gotcha",
+				body_text: "Viewer server throws if static/index.html is missing; build UI assets first.",
+			}),
+		).toEqual({ artifact: "derived_fact", action: "store", reasons: ["troubleshooting_gotcha"] });
+	});
+
+	it("suppresses review telemetry without findings", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "discovery",
+				title: "Review completed",
+				body_text: "CodeReviewer re-reviewed the PR and found no blockers or remaining issues.",
+			}),
+		).toEqual({
+			artifact: "telemetry",
+			action: "suppress",
+			reasons: ["review_telemetry_no_findings"],
+		});
+	});
+
+	it("suppresses validation telemetry without a durable lesson", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "change",
+				title: "Validation passed",
+				body_text: "pnpm run lint passed and CI is green.",
+			}),
+		).toEqual({
+			artifact: "telemetry",
+			action: "suppress",
+			reasons: ["validation_telemetry_only"],
+		});
+	});
+
+	it("stores summaries even when they mention validation telemetry", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "session_summary",
+				title: "Session recap",
+				body_text: "Tests passed, CI is green, and context files were loaded.",
+			}),
+		).toEqual({ artifact: "session_summary", action: "store", reasons: ["session_summary_recap"] });
+	});
+
+	it("keeps validation details that encode a durable gotcha", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "discovery",
+				title: "Lint coverage gotcha",
+				body_text: "Lint only covers files included by biome.json; docs need separate review.",
+			}),
+		).toEqual({ artifact: "derived_fact", action: "store", reasons: ["troubleshooting_gotcha"] });
+	});
+
+	it("suppresses duplicate active policy reminders", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "discovery",
+				title: "Delegation reminder",
+				body_text: "Use the task delegation workflow before delegating multi-file work.",
+			}),
+		).toEqual({ artifact: "telemetry", action: "suppress", reasons: ["duplicate_active_policy"] });
+	});
+
+	it("suppresses session bootstrap noise", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "discovery",
+				title: "Session bootstrap",
+				body_text: "Context files were loaded before the run.",
+			}),
+		).toEqual({ artifact: "telemetry", action: "suppress", reasons: ["runtime_bootstrap_noise"] });
+	});
+
+	it("stores a micro-session summary as demoted recap", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "session_summary",
+				title: "Tiny recap",
+				body_text: "Short note.",
+				metadata: { session_class: "micro_low_value" },
+			}),
+		).toEqual({
+			artifact: "session_summary",
+			action: "store_demoted",
+			reasons: ["session_summary_micro"],
+		});
+	});
+
+	it("demotes workstream continuity notes", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "discovery",
+				title: "Follow-up state",
+				body_text: "Next step is to run tests after the edit lands.",
+			}),
+		).toEqual({ artifact: "unknown", action: "store_demoted", reasons: ["workstream_continuity"] });
+	});
+
+	it("keeps durable facts that use current-state wording", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "discovery",
+				title: "Coordinator behavior",
+				body_text: "The coordinator currently uses reciprocal approvals before peers can sync.",
+			}),
+		).toEqual({ artifact: "derived_fact", action: "store", reasons: ["role_inferred_durable"] });
+	});
+
+	it("demotes investigation notes without a durable conclusion", () => {
+		expect(
+			classifyMemoryWorthiness({
+				kind: "change",
+				title: "Scoped inspection",
+				body_text:
+					"Investigated packages/core/src/search.ts and packages/core/src/pack.ts for later follow-up.",
+			}),
+		).toEqual({
+			artifact: "unknown",
+			action: "store_demoted",
+			reasons: ["investigation_without_durable_conclusion"],
+		});
 	});
 });

--- a/packages/core/src/memory-quality.ts
+++ b/packages/core/src/memory-quality.ts
@@ -2,9 +2,59 @@ import { isSummaryLikeMemory } from "./summary-memory.js";
 
 export type DerivedMemoryRole = "recap" | "durable" | "ephemeral" | "general";
 
+/**
+ * Artifact class for the dual-artifact memory model
+ * (see docs/plans/2026-06-28-memory-worthiness-policy.md).
+ *
+ * - `session_summary`: "what happened" continuity/recap.
+ * - `derived_fact`: "what future work should remember" (durable).
+ * - `telemetry`: "what merely occurred" (process status, not durable memory).
+ * - `unknown`: legacy/ambiguous content judged by inferred role.
+ */
+export type MemoryArtifactClass = "session_summary" | "derived_fact" | "telemetry" | "unknown";
+
+/** Storage/retrieval disposition within an artifact class. */
+export type MemoryWorthinessAction = "store" | "store_demoted" | "suppress";
+
+export type MemoryWorthinessReason =
+	| "durable_decision"
+	| "implementation_contract"
+	| "modal_contract"
+	| "troubleshooting_gotcha"
+	| "future_actionable_location"
+	| "repo_specific_policy_exception"
+	| "session_summary_recap"
+	| "session_summary_micro"
+	| "session_summary_empty"
+	| "workstream_continuity"
+	| "investigation_without_durable_conclusion"
+	| "temporary_workstream_state"
+	| "review_telemetry_no_findings"
+	| "validation_telemetry_only"
+	| "duplicate_active_policy"
+	| "runtime_bootstrap_noise"
+	| "generic_process_narration"
+	| "role_inferred_durable"
+	| "role_inferred_general"
+	| "role_inferred_ephemeral";
+
 export interface DerivedMemoryRoleResult {
 	role: DerivedMemoryRole;
 	reason: string;
+}
+
+/**
+ * Dual-artifact worthiness result.
+ *
+ * Signal-balance contract: a candidate is only classified as `telemetry` /
+ * suppressed when NO durable keep-signal is present. Validation/review/bootstrap
+ * phrasing that also carries a contract, decision, or troubleshooting lesson is
+ * kept as a `derived_fact` (fixes the presence-only false negatives in review).
+ */
+export interface MemoryWorthinessResult {
+	artifact: MemoryArtifactClass;
+	action: MemoryWorthinessAction;
+	reasons: MemoryWorthinessReason[];
 }
 
 export interface InferMemoryRoleInput {
@@ -28,6 +78,14 @@ function classifyProjectQuality(project: unknown): "normal" | "empty" | "garbage
 
 function hasAnyMarker(text: string, markers: string[]): boolean {
 	return markers.some((marker) => text.includes(marker));
+}
+
+function hasAnyPattern(text: string, patterns: RegExp[]): boolean {
+	return patterns.some((pattern) => pattern.test(text));
+}
+
+function memoryText(input: InferMemoryRoleInput): string {
+	return `${input.title} ${input.body_text}`.trim().toLowerCase();
 }
 
 function inferMicroSession(
@@ -116,4 +174,301 @@ export function inferMemoryRole(input: InferMemoryRoleInput): DerivedMemoryRoleR
 	return nonNormalProject
 		? { role: "general", reason: "fallback_non_normal_project" }
 		: { role: "ephemeral", reason: "fallback_ephemeral" };
+}
+
+/**
+ * Detect durable keep-signals in memory text.
+ *
+ * These are evaluated BEFORE any telemetry/bootstrap/validation suppression so a
+ * candidate that embeds a contract, decision, or troubleshooting lesson is never
+ * dropped just because it also mentions "CI passed", "review approved", or
+ * "workspace root". Returns the matched keep reasons (empty = no keep signal).
+ */
+function collectKeepReasons(input: {
+	kind: string;
+	text: string;
+	hasImplementationLocator: boolean;
+}): MemoryWorthinessReason[] {
+	const { kind, text, hasImplementationLocator } = input;
+	const reasons: MemoryWorthinessReason[] = [];
+
+	const hasDecisionValue = hasAnyPattern(text, [
+		/\bdecided\b/,
+		/\bchosen\s+because\b/,
+		/\bnon-goals?\b/,
+		/\bout\s+of\s+scope\b/,
+		/\bpreferred\b/,
+		/\btrade-?off\b/,
+	]);
+
+	// Personal/process task phrasing is NOT a durable contract ("I must finish",
+	// "we should remember", "must remember to ...", "next step should run tests").
+	// These are next-step/handoff state, not reusable rules.
+	const personalOrTaskModal = hasAnyPattern(text, [
+		/\b(?:i|we|you)\s+(?:must|should|shall|need\s+to|have\s+to)\b/,
+		/\bmust\s+remember\b/,
+		// next-step / pending handoff phrasing governing a modal
+		/\b(?:next\s+steps?|todo|follow[\s-]?up|then|afterwards?|later)\b[^.]*\b(?:must|should|shall)\b/,
+		/\b(?:must|should|shall)\b[^.]*\b(?:next|after\s+(?:the\s+)?(?:edit|change|merge|pr)\s+(?:lands?|merges?))\b/,
+	]);
+	// M1 / C5 fix: any modal contract `must|should|shall <verb>` counts, not an
+	// enumerated verb whitelist. Require a following lowercase verb-ish token so
+	// "must" at end-of-clause or before punctuation doesn't over-match.
+	//
+	// The personal/task guard must only strip the PERSONAL/TASK clause, not block
+	// an embedded impersonal contract elsewhere in the text (Codex): e.g. "We
+	// should remember that viewer-server validation requires generated static
+	// files" still has a durable `requires` rule. So `requires?` always qualifies,
+	// and a modal contract qualifies when it is NOT purely personal/task phrasing.
+	const hasRequires = hasAnyPattern(text, [/\brequires?\b/]);
+	const hasImpersonalModal = hasAnyPattern(text, [
+		/\b(?:must|should|shall)\s+(?:not\s+|always\s+|never\s+)?[a-z]{2,}\b/,
+	]);
+	const hasModalContract = hasRequires || (hasImpersonalModal && !personalOrTaskModal);
+	// C6 fix: dependency/outcome phrasing is a durable lesson.
+	const hasDependencyLesson = hasAnyPattern(text, [
+		/\bdepends?\s+on\b/,
+		/\bdependent\s+on\b/,
+		/\bonly\s+(?:after|works?\s+when|if)\b/,
+		/\brelies\s+on\b/,
+	]);
+	const hasContractNoun = hasAnyPattern(text, [
+		/\bsource\s+of\s+truth\b/,
+		/\bcontract\b/,
+		/\binvariant\b/,
+		/\bwhen\s+changing\b/,
+	]);
+
+	// A `decision`-kind row is durable even if it doesn't use an explicit decision
+	// word; otherwise a decision that also mentions "tests passed" would fall
+	// through to telemetry suppression (Codex C9).
+	if (hasDecisionValue || kind === "decision") {
+		reasons.push("durable_decision");
+	}
+	if (hasModalContract || hasContractNoun || hasDependencyLesson) {
+		// A locator (file/module/path) makes it a concrete implementation contract;
+		// otherwise it is still a durable contract/rule (M3/M4: review or workspace
+		// lessons without a file path must be kept).
+		reasons.push(hasImplementationLocator ? "implementation_contract" : "modal_contract");
+	}
+	if (
+		hasAnyPattern(text, [
+			/\bfails?\s+when\b/,
+			/\bthrows?\s+if\b/,
+			/\broot\s+cause\b/,
+			// "regression" only as a durable regression bug/risk — not "regression
+			// tests passed / regression suite is green" validation telemetry.
+			/\bregression\b(?!\s+(?:tests?|suite|run|checks?)\b)/,
+			/\bgotcha\b/,
+		])
+	) {
+		reasons.push("troubleshooting_gotcha");
+	}
+	if (
+		hasImplementationLocator &&
+		hasAnyPattern(text, [/\binspect\b/, /\bcontinue\b/, /\blook\s+in\b/, /\bowned\s+by\b/]) &&
+		hasAnyPattern(text, [/\bbecause\b/, /\bso\b/, /\bto\s+avoid\b/])
+	) {
+		reasons.push("future_actionable_location");
+	}
+	if (
+		(hasModalContract || hasContractNoun) &&
+		hasAnyPattern(text, [
+			/\bexception\b/,
+			/\bexcept\b/,
+			/\brepo-specific\b/,
+			/\bproject-specific\b/,
+		])
+	) {
+		reasons.push("repo_specific_policy_exception");
+	}
+
+	return reasons;
+}
+
+/**
+ * Classify a memory candidate into a dual-artifact class plus a storage action.
+ *
+ * Order of evaluation enforces the signal-balance contract:
+ * 1. session summaries are their own artifact (telemetry words inside a summary
+ *    never turn it into a dropped telemetry row);
+ * 2. durable keep-signals win over telemetry/bootstrap/validation suppression;
+ * 3. only then do telemetry/process patterns suppress;
+ * 4. continuity/ambiguous content falls back to inferred role.
+ */
+export function classifyMemoryWorthiness(input: InferMemoryRoleInput): MemoryWorthinessResult {
+	const metadata = input.metadata ?? {};
+	const kind = String(input.kind ?? "")
+		.trim()
+		.toLowerCase();
+	const normalizedInput = { ...input, kind };
+	const text = memoryText(normalizedInput);
+	const isSummary = isSummaryLikeMemory({ kind, metadata });
+
+	// 1. Session summaries are a first-class artifact, judged on their own terms.
+	if (isSummary) {
+		if (!text) {
+			return {
+				artifact: "session_summary",
+				action: "suppress",
+				reasons: ["session_summary_empty"],
+			};
+		}
+		if (inferMicroSession(input.session_minutes, metadata)) {
+			return {
+				artifact: "session_summary",
+				action: "store_demoted",
+				reasons: ["session_summary_micro"],
+			};
+		}
+		return { artifact: "session_summary", action: "store", reasons: ["session_summary_recap"] };
+	}
+
+	const hasImplementationLocator = hasAnyPattern(text, [
+		/\bpackages\/[\w./-]+/,
+		/\bdocs\/[\w./-]+/,
+		/\bsrc\/[\w./-]+/,
+		/[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|sql|yaml|yml)\b/,
+	]);
+
+	// 2. Keep-signals win over telemetry/bootstrap/validation (fixes M1-M4).
+	const keepReasons = collectKeepReasons({ kind, text, hasImplementationLocator });
+	if (keepReasons.length > 0) {
+		return { artifact: "derived_fact", action: "store", reasons: keepReasons };
+	}
+
+	// 3. Telemetry/process suppression (only when no durable keep-signal exists).
+	if (
+		hasAnyPattern(text, [
+			/\b(?:reviewer|review|re-reviewed|pull request|pr)\b.*\b(?:no blockers?|no findings?|approved|no remaining issues?)\b/,
+			/\b(?:no blockers?|no findings?|approved|no remaining issues?)\b.*\b(?:reviewer|review|re-reviewed|pull request|pr)\b/,
+		])
+	) {
+		return { artifact: "telemetry", action: "suppress", reasons: ["review_telemetry_no_findings"] };
+	}
+	if (
+		hasAnyPattern(text, [
+			/\b(?:tests?|lint|ci|build|typecheck|tsc)\b.*\b(?:passed|green|succeeded|clean)\b/,
+			/\b(?:passed|green|succeeded|clean)\b.*\b(?:tests?|lint|ci|build|typecheck|tsc)\b/,
+		])
+	) {
+		return { artifact: "telemetry", action: "suppress", reasons: ["validation_telemetry_only"] };
+	}
+	if (
+		hasAnyPattern(text, [
+			/\buse\s+(?:the\s+)?(?:task\s+)?delegation\s+workflow\b/,
+			/\bload\s+code-quality\s+standards?\b/,
+			/\buse\s+(?:the\s+)?graphite\s+workflow\b/,
+			/\bdo\s+not\s+modify\s+unrelated\s+(?:user\s+)?changes\b/,
+			/\brun\s+minimal\s+(?:relevant\s+)?checks\b/,
+		])
+	) {
+		return { artifact: "telemetry", action: "suppress", reasons: ["duplicate_active_policy"] };
+	}
+	if (
+		hasAnyPattern(text, [
+			/\bcontext\s+files?\s+(?:were\s+)?loaded\b/,
+			/\bloaded\s+(?:the\s+)?context\b/,
+			/\bsession\s+started\b/,
+			/\bagent\s+initialized\b/,
+			/\bplugin\s+initialized\b/,
+			/\bworkspace\s+root\s+(?:was\s+)?(?:set|detected|loaded|resolved)\b/,
+			/\bcurrent\s+date\b/,
+			/\btask\s+tracker\s+(?:was\s+)?available\b/,
+		])
+	) {
+		return { artifact: "telemetry", action: "suppress", reasons: ["runtime_bootstrap_noise"] };
+	}
+
+	// 4. Continuity / ambiguous content -> inferred role.
+	const inferred = inferMemoryRole(normalizedInput);
+
+	if (
+		(inferred.role === "ephemeral" || kind === "change") &&
+		hasAnyPattern(text, [
+			/\bnext\s+steps?\b/,
+			/\bpending\b/,
+			/\bcurrently\s+(?:blocked|working|paused)\b/,
+			/\bblocked\s+on\b/,
+			/\b(?:task|work|review|migration)\s+is\s+in\s+progress\b/,
+		])
+	) {
+		return { artifact: "unknown", action: "store_demoted", reasons: ["workstream_continuity"] };
+	}
+	if (
+		hasAnyPattern(text, [
+			/\btemporary\b/,
+			/\bcurrent\s+branch\b/,
+			/\breview\s+pass\s+is\s+pending\b/,
+		])
+	) {
+		return {
+			artifact: "unknown",
+			action: "store_demoted",
+			reasons: ["temporary_workstream_state"],
+		};
+	}
+
+	// Demote investigations only when they lack a durable outcome. Confirmation
+	// verbs (confirmed/determined/found/learned/discovered) signal a durable
+	// finding and must not be demoted (Codex C10).
+	const hasDurableOutcome = hasAnyPattern(text, [
+		/\bresolved\b/,
+		/\bfixed\b/,
+		/\bconfirmed\b/,
+		/\bdetermined\b/,
+		// "found" as a finding verb (found that / found the / found a / found
+		// it ...), not only "found that".
+		/\bfound\b/,
+		/\bdiscovered\b/,
+		/\blearned\b/,
+	]);
+	// A NO-finding outcome ("found no issues/blockers", "found nothing",
+	// "confirmed no problems") is not a reusable lesson — it must not exempt the
+	// investigation from demotion (Codex). Treat it as no durable outcome.
+	// Limit "no-finding" to status/no-issue phrasing. A bare "found no <word>"
+	// catch-all wrongly demotes durable NEGATIVE findings like "found no fallback
+	// for empty embeddings" (an absence-of-mechanism discovery, not telemetry).
+	// Only no-status outcomes (no issues/blockers/problems/...) count (Codex).
+	const NO_STATUS =
+		"issues?|blockers?|problems?|findings?|bugs?|regressions?|errors?|remaining\\s+issues?";
+	const hasNoFindingOutcome = hasAnyPattern(text, [
+		// "found nothing" / "found none" (bare) is a no-finding outcome; but
+		// "found no <X>" only counts when <X> is a status noun, so durable negative
+		// findings like "found no fallback for empty embeddings" are NOT demoted.
+		/\b(?:found|confirmed|determined|discovered)\s+(?:that\s+there\s+(?:were|are|was|is)\s+)?(?:nothing|none)\b/,
+		new RegExp(
+			`\\b(?:found|confirmed|determined|discovered)\\s+(?:that\\s+there\\s+(?:were|are|was|is)\\s+)?no\\s+(?:${NO_STATUS})\\b`,
+		),
+		new RegExp(`\\bno\\s+(?:${NO_STATUS})\\b`),
+		/\bnothing\s+(?:to\s+\w+|of\s+note|notable|wrong)\b/,
+	]);
+	const hasInvestigatedWithoutOutcome =
+		hasAnyPattern(text, [/\binvestigated\b/, /\binspected\b/, /\bchecked\b/, /\blooked\s+at\b/]) &&
+		(!hasDurableOutcome || hasNoFindingOutcome);
+	if (hasInvestigatedWithoutOutcome) {
+		return {
+			artifact: "unknown",
+			action: "store_demoted",
+			reasons: ["investigation_without_durable_conclusion"],
+		};
+	}
+
+	if (
+		hasAnyPattern(text, [
+			/\bwork\s+(?:was\s+)?(?:completed|investigated)\b/,
+			/\bcompleted\s+(?:the\s+)?work\b/,
+		]) &&
+		!hasImplementationLocator
+	) {
+		return { artifact: "telemetry", action: "suppress", reasons: ["generic_process_narration"] };
+	}
+
+	if (inferred.role === "durable") {
+		return { artifact: "derived_fact", action: "store", reasons: ["role_inferred_durable"] };
+	}
+	if (inferred.role === "general") {
+		return { artifact: "derived_fact", action: "store", reasons: ["role_inferred_general"] };
+	}
+	return { artifact: "unknown", action: "store_demoted", reasons: ["role_inferred_ephemeral"] };
 }


### PR DESCRIPTION
## Description
Shared pure classifier for the dual-artifact memory model. Returns an artifact class + storage action + reasons:
- artifact: `session_summary | derived_fact | telemetry | unknown`
- action: `store | store_demoted | suppress`
- reasons: stable identifiers

Signal-balance contract (replaces the earlier single-signal keep/demote/drop): durable keep-signals are computed first, so a candidate that embeds a contract/decision/troubleshooting lesson is never suppressed just because it also mentions 'CI passed', 'review approved', or 'workspace root'.

Resolves the four Codex P2 threads on this PR:
- M1: ordinary `must <verb>` / `requires` contracts are recognized (not just `must be|always|never|not`), excluding personal-task phrasing (`I/we/you must`, `must remember`).
- M2: validation phrasing with an embedded contract is kept (e.g. 'CI is green after confirming deployments require reciprocal approval').
- M3: review phrasing with an embedded durable lesson is kept.
- M4: `workspace root … requires …` is kept; bootstrap pattern tightened to startup-narration forms.

Not yet wired into capture/retrieval/Distill — consumers (ovk2.5/.11/.12) remain gated on before/after evals (ovk2.7 harness + captured real-DB baseline).

Tracking: codemem-ovk2.10.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

23 classifier unit tests incl. M1-M4 regressions; full stack regression `memory-quality + pack.eval + search + maintenance + eval-scenarios` = 196 passed / 3 todo; `tsc` + `lint` green.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
