### PR TITLE
test(core): add dual-artifact eval scenario pack + artifact-share metric

### DIFF
--- a/packages/core/src/eval-scenarios.test.ts
+++ b/packages/core/src/eval-scenarios.test.ts
@@ -10,6 +10,7 @@ describe("injection eval scenarios", () => {
 		expect(INJECTION_EVAL_SCENARIO_PACKS.map((pack) => pack.id)).toEqual([
 			"track3-core",
 			"track3-explicit-recap",
+			"dual-artifact-v1",
 		]);
 	});
 
@@ -18,9 +19,14 @@ describe("injection eval scenarios", () => {
 	});
 
 	it("expands scenario prompts without duplicates", () => {
-		const prompts = getInjectionEvalScenarioPrompts(["track3-core", "track3-explicit-recap"]);
+		const prompts = getInjectionEvalScenarioPrompts([
+			"track3-core",
+			"track3-explicit-recap",
+			"dual-artifact-v1",
+		]);
 		expect(prompts).toContain("memory retrieval issues");
 		expect(prompts).toContain("summary of oauth");
+		expect(prompts).toContain("what must future memory extraction preserve");
 		expect(new Set(prompts).size).toBe(prompts.length);
 	});
 });

--- a/packages/core/src/eval-scenarios.ts
+++ b/packages/core/src/eval-scenarios.ts
@@ -104,6 +104,59 @@ export const INJECTION_EVAL_SCENARIO_PACKS: InjectionEvalScenarioPack[] = [
 			},
 		],
 	},
+	{
+		id: "dual-artifact-v1",
+		title: "Dual-artifact memory model scenarios",
+		description:
+			"Measurable-now probes for summary domination, telemetry intrusion, explicit recap quality, and derived-fact-like precision before first-class derived_fact artifacts exist.",
+		scenarios: [
+			{
+				id: "summary-domination-topic",
+				title: "Topical default retrieval prefers durable facts over summaries",
+				category: "decision",
+				prompt: "dual artifact durable policy",
+				expectedModes: ["default", "recall"],
+				expectedPrimary: ["durable", "decision", "derived fact", "implementation contract"],
+				expectedAntiSignals: ["recap takeover", "generic summary", "administrative chatter"],
+			},
+			{
+				id: "telemetry-task-intrusion",
+				title: "Task retrieval avoids review and validation telemetry",
+				category: "continuation",
+				prompt: "what should we do next about dual artifact memory",
+				expectedModes: ["task", "default"],
+				expectedPrimary: ["next-step context", "durable workstream context", "derived fact"],
+				expectedAntiSignals: ["administrative chatter", "review telemetry", "validation telemetry"],
+			},
+			{
+				id: "telemetry-debug-intrusion",
+				title: "Debug retrieval prefers root-cause facts over telemetry",
+				category: "troubleshooting",
+				prompt: "why did memory extraction miss implementation contracts",
+				expectedModes: ["default", "recall"],
+				expectedPrimary: ["bugfix", "discovery", "root cause", "derived fact"],
+				expectedAntiSignals: ["review telemetry", "validation telemetry", "bootstrap telemetry"],
+			},
+			{
+				id: "explicit-dual-artifact-recap",
+				title: "Explicit recap remains summary-capable",
+				category: "continuation",
+				prompt: "catch me up on dual artifact memory work",
+				expectedModes: ["recall"],
+				expectedPrimary: ["session_summary", "recap", "orientation context"],
+				expectedAntiSignals: ["totally summary-free output", "wrong-thread summary"],
+			},
+			{
+				id: "derived-fact-like-contract",
+				title: "Derived-fact-like precision for embedded implementation contracts",
+				category: "decision",
+				prompt: "what must future memory extraction preserve",
+				expectedModes: ["default", "recall"],
+				expectedPrimary: ["derived fact", "implementation contract", "durable"],
+				expectedAntiSignals: ["recap takeover", "validation telemetry", "bootstrap telemetry"],
+			},
+		],
+	},
 ];
 
 export function getInjectionEvalScenarioPack(id: string): InjectionEvalScenarioPack | null {

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -454,6 +454,49 @@ describe("maintenance", { timeout: 15_000 }, () => {
 		expect(report.summary_disposition_buckets).toEqual({ unknown: 1 });
 	});
 
+	it("reports heuristic dual-artifact shares for probe top results", () => {
+		const dbPath = createDbPath("memory-role-report-artifacts");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version) VALUES
+				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, facts, import_key, scope_id
+				) VALUES
+				  (1, 1, 'decision', 'Future memory extraction preserve contract', 'Future memory extraction must preserve implementation contract language.', 1, '2026-03-01T10:10:01Z', '2026-03-01T10:10:01Z', '{}', '["Future memory extraction must preserve implementation contract language."]', 'k1', 'local-default'),
+				  (2, 1, 'session_summary', 'Memory extraction recap', 'Summary of future memory extraction preserve work.', 1, '2026-03-01T10:10:02Z', '2026-03-01T10:10:02Z', '{}', NULL, 'k2', 'local-default'),
+				  (3, 1, 'change', 'Future memory extraction tsc passed', 'pnpm run tsc passed for future memory extraction preserve work.', 1, '2026-03-01T10:10:03Z', '2026-03-01T10:10:03Z', '{}', NULL, 'k3', 'local-default'),
+				  (4, 1, 'discovery', 'Future memory extraction overview', 'Overview of the future memory extraction preserve work area and its components.', 1, '2026-03-01T10:10:04Z', '2026-03-01T10:10:04Z', '{}', NULL, 'k4', 'local-default');
+			`);
+		} finally {
+			db.close();
+		}
+
+		const report = getMemoryRoleReport(dbPath, {
+			project: "codemem",
+			probes: ["what must future memory extraction preserve"],
+		});
+
+		const probe = report.probe_results[0];
+		expect(probe?.top_artifact_counts).toEqual({
+			session_summary: 1,
+			telemetry: 1,
+			derived_fact_like: 1,
+			durable_memory: 1,
+			ephemeral: 0,
+		});
+		expect(probe?.top_artifact_share).toEqual({
+			session_summary_share: 0.25,
+			telemetry_share: 0.25,
+			derived_fact_like_share: 0.25,
+			durable_memory_share: 0.25,
+			ephemeral_share: 0,
+		});
+		expect(probe?.scenario_score?.primary_match_count).toBeGreaterThan(0);
+	});
+
 	it("reports persisted session policy buckets from session metadata", () => {
 		const dbPath = createDbPath("memory-role-session-policy-buckets");
 		const db = new Database(dbPath);

--- a/packages/core/src/maintenance/memory-role-helpers.test.ts
+++ b/packages/core/src/maintenance/memory-role-helpers.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { classifyProbeArtifactBucket } from "./memory-role-helpers.js";
+
+describe("classifyProbeArtifactBucket", () => {
+	it("buckets session_summary kind as session_summary", () => {
+		expect(
+			classifyProbeArtifactBucket({
+				kind: "session_summary",
+				title: "Recap",
+				body_text: "what happened",
+				role: "recap",
+			}),
+		).toBe("session_summary");
+	});
+
+	// Codex #1297: legacy observer summaries are `change` + metadata.source.
+	it("buckets legacy observer_summary change rows as session_summary", () => {
+		expect(
+			classifyProbeArtifactBucket({
+				kind: "change",
+				title: "Session recap",
+				body_text: "broad progress narration",
+				role: "recap",
+				metadata: { source: "observer_summary" },
+			}),
+		).toBe("session_summary");
+	});
+
+	// Codex #1297: empty facts "[]" must NOT count as a derived-fact signal. With
+	// an ephemeral role and no other signal it buckets as ephemeral, not durable.
+	it("does not treat an empty facts array as derived_fact_like", () => {
+		const bucket = classifyProbeArtifactBucket({
+			kind: "discovery",
+			title: "Generic note",
+			body_text: "nothing durable here",
+			role: "ephemeral",
+			facts: "[]",
+		});
+		expect(bucket).not.toBe("derived_fact_like");
+		expect(bucket).toBe("ephemeral");
+	});
+
+	// Codex #1297: a leftover row with no summary/derived/telemetry signal must
+	// only count as durable_memory when its inferred role is actually durable;
+	// ephemeral/general workstream noise must NOT inflate the durable share.
+	it("buckets a durable-role leftover row as durable_memory", () => {
+		expect(
+			classifyProbeArtifactBucket({
+				kind: "decision",
+				title: "Plain decision",
+				body_text: "chose the modular layout",
+				role: "durable",
+			}),
+		).toBe("durable_memory");
+	});
+
+	it("buckets an ephemeral leftover row as ephemeral, not durable_memory", () => {
+		expect(
+			classifyProbeArtifactBucket({
+				kind: "change",
+				title: "Cleanup",
+				body_text: "Need to continue cleanup",
+				role: "ephemeral",
+			}),
+		).toBe("ephemeral");
+	});
+
+	// Codex #1297: bootstrap telemetry the classifier suppresses (current date,
+	// task tracker available) must also be detected here.
+	it("buckets runtime bootstrap telemetry as telemetry", () => {
+		expect(
+			classifyProbeArtifactBucket({
+				kind: "change",
+				title: "Startup",
+				body_text: "The current date was loaded and the task tracker was available.",
+				role: "ephemeral",
+			}),
+		).toBe("telemetry");
+	});
+
+	it("treats a non-empty facts array as derived_fact_like", () => {
+		expect(
+			classifyProbeArtifactBucket({
+				kind: "discovery",
+				title: "Has facts",
+				body_text: "plain body",
+				role: "durable",
+				facts: JSON.stringify(["a durable extracted fact"]),
+			}),
+		).toBe("derived_fact_like");
+	});
+
+	// Codex #1297: telemetry wording in body_text (not title) must still bucket as telemetry.
+	it("buckets telemetry wording from body_text as telemetry", () => {
+		expect(
+			classifyProbeArtifactBucket({
+				kind: "change",
+				title: "Validation",
+				body_text: "pnpm run tsc passed",
+				role: "ephemeral",
+			}),
+		).toBe("telemetry");
+	});
+
+	// Codex #1297: durable signal embedded in telemetry wording wins (signal balance).
+	it("buckets a durable contract embedded in telemetry as derived_fact_like", () => {
+		expect(
+			classifyProbeArtifactBucket({
+				kind: "discovery",
+				title: "Deployment rule",
+				body_text: "CI is green after confirming deployments require reciprocal approval.",
+				role: "durable",
+			}),
+		).toBe("derived_fact_like");
+	});
+});

--- a/packages/core/src/maintenance/memory-role-helpers.ts
+++ b/packages/core/src/maintenance/memory-role-helpers.ts
@@ -1,8 +1,9 @@
 /* Memory-role probe scoring + helper utilities. */
 
 import { getInjectionEvalScenarioByPrompt } from "../eval-scenarios.js";
-import { getSummaryMetadata } from "../summary-memory.js";
+import { getSummaryMetadata, isSummaryLikeMemory } from "../summary-memory.js";
 import type {
+	MemoryArtifactBucket,
 	MemoryRole,
 	MemoryRoleProbeComparison,
 	MemoryRoleProbeItem,
@@ -25,6 +26,122 @@ export function classifyProjectQuality(project: unknown): "normal" | "empty" | "
 
 export function safeParseMetadata(raw: string | null): Record<string, unknown> {
 	return getSummaryMetadata(raw);
+}
+
+function hasAnyPattern(text: string, patterns: RegExp[]): boolean {
+	return patterns.some((pattern) => pattern.test(text));
+}
+
+const REVIEW_TELEMETRY_PATTERNS: RegExp[] = [
+	/\b(?:reviewer|review|re-reviewed|pull request|pr)\b.*\b(?:no blockers?|no findings?|approved|no remaining issues?)\b/,
+	/\b(?:no blockers?|no findings?|approved|no remaining issues?)\b.*\b(?:reviewer|review|re-reviewed|pull request|pr)\b/,
+];
+const VALIDATION_TELEMETRY_PATTERNS: RegExp[] = [
+	/\b(?:tests?|lint|ci|build|typecheck|tsc)\b.*\b(?:passed|green|succeeded|clean)\b/,
+	/\b(?:passed|green|succeeded|clean)\b.*\b(?:tests?|lint|ci|build|typecheck|tsc)\b/,
+];
+// Keep in sync with the runtime_bootstrap_noise patterns in
+// classifyMemoryWorthiness (memory-quality.ts). The probe-side detector must
+// recognize the same bootstrap telemetry the classifier suppresses, otherwise
+// debug/contract scenarios under-report the telemetry they exist to measure.
+const BOOTSTRAP_TELEMETRY_PATTERNS: RegExp[] = [
+	/\bcontext\s+files?\s+(?:were\s+)?loaded\b/,
+	/\bloaded\s+(?:the\s+)?context\b/,
+	/\bsession\s+started\b/,
+	/\bagent\s+initialized\b/,
+	/\bplugin\s+initialized\b/,
+	/\bworkspace\s+root\b/,
+	/\bcurrent\s+date\b/,
+	/\btask\s+tracker\s+(?:was\s+)?available\b/,
+];
+
+export function isReviewTelemetryText(text: string): boolean {
+	return hasAnyPattern(text.toLowerCase(), REVIEW_TELEMETRY_PATTERNS);
+}
+export function isValidationTelemetryText(text: string): boolean {
+	return hasAnyPattern(text.toLowerCase(), VALIDATION_TELEMETRY_PATTERNS);
+}
+export function isBootstrapTelemetryText(text: string): boolean {
+	return hasAnyPattern(text.toLowerCase(), BOOTSTRAP_TELEMETRY_PATTERNS);
+}
+
+export function isTelemetryLikeText(text: string): boolean {
+	return (
+		isReviewTelemetryText(text) || isValidationTelemetryText(text) || isBootstrapTelemetryText(text)
+	);
+}
+
+export function isDerivedFactLikeText(text: string): boolean {
+	const normalized = text.toLowerCase();
+	// Exclude personal-task phrasing so "I/we must ..." is not a durable signal,
+	// matching classifyMemoryWorthiness in memory-quality.ts.
+	const personalTask = hasAnyPattern(normalized, [
+		/\b(?:i|we|you)\s+(?:must|should|need\s+to|have\s+to)\b/,
+		/\bmust\s+remember\b/,
+	]);
+	const durable = hasAnyPattern(normalized, [
+		/\bderived[-\s]?fact\b/,
+		/\bimplementation\s+contract\b/,
+		/\brequires?\b/,
+		/\bsource\s+of\s+truth\b/,
+		/\bcontract\b/,
+		/\binvariant\b/,
+		/\bwhen\s+changing\b/,
+		/\bfails?\s+when\b/,
+		/\bthrows?\s+if\b/,
+		/\broot\s+cause\b/,
+		/\bgotcha\b/,
+		/\bdepends?\s+on\b/,
+		/\bdependent\s+on\b/,
+		/\brelies\s+on\b/,
+		/\bonly\s+(?:after|works?\s+when|if)\b/,
+	]);
+	const modalContract =
+		!personalTask &&
+		hasAnyPattern(normalized, [
+			/\b(?:must|should|shall)\s+(?:not\s+|always\s+|never\s+)?[a-z]{2,}\b/,
+		]);
+	return durable || modalContract;
+}
+
+/** True when the facts column holds a non-empty array (ignores the common `"[]"`). */
+function hasNonEmptyFacts(facts: string | null | undefined): boolean {
+	if (!facts) return false;
+	try {
+		const parsed = JSON.parse(facts);
+		return Array.isArray(parsed) && parsed.length > 0;
+	} catch {
+		// Non-JSON facts payload: treat any non-whitespace content as present.
+		return facts.trim().length > 0;
+	}
+}
+
+export function classifyProbeArtifactBucket(input: {
+	kind: string;
+	title: string;
+	body_text?: string | null;
+	role: MemoryRole;
+	metadata?: Record<string, unknown> | null;
+	facts?: string | null;
+}): MemoryArtifactBucket {
+	const metadata = input.metadata ?? {};
+	// Use the shared summary detector so legacy `change` rows carrying
+	// `source: "observer_summary"` (or `is_summary`) are bucketed as summaries.
+	if (isSummaryLikeMemory({ kind: input.kind, metadata })) return "session_summary";
+	const text = `${input.title} ${input.body_text ?? ""}`.trim();
+	// Signal-balance: durable signals (non-empty facts / derived-fact wording) win
+	// over telemetry wording, mirroring classifyMemoryWorthiness. A row like
+	// "CI is green after confirming deployments require reciprocal approval"
+	// buckets as derived_fact_like, not telemetry.
+	if (hasNonEmptyFacts(input.facts) || isDerivedFactLikeText(text)) return "derived_fact_like";
+	if (isTelemetryLikeText(text)) return "telemetry";
+	// Leftover rows that match no summary/derived/telemetry signal are only
+	// "durable memory" when their inferred role is actually durable. Ephemeral /
+	// general workstream noise (e.g. a `change` "Need to continue cleanup") must
+	// NOT inflate the durable share, or dual-artifact probes look healthy while
+	// non-durable rows occupy the top slots (Codex). Respect the passed role.
+	if (input.role === "durable") return "durable_memory";
+	return "ephemeral";
 }
 
 export function subtractKeyedCounts<T extends string>(
@@ -152,8 +269,9 @@ export function scoreProbeScenario(
 	const topItems = items.slice(0, 5);
 	const topThree = items.slice(0, 3);
 	const matchToken = (text: string, token: string): boolean => text.includes(token.toLowerCase());
-	const itemMatchesPrimary = (item: MemoryRoleProbeItem): boolean => {
-		const haystack = [
+	// Metadata-only haystack for token/role matching.
+	const metaHaystack = (item: MemoryRoleProbeItem): string =>
+		[
 			item.kind,
 			item.role,
 			item.title,
@@ -163,12 +281,36 @@ export function scoreProbeScenario(
 		]
 			.join(" ")
 			.toLowerCase();
+	// Source-content haystack (title + body + facts) for telemetry/derived-fact
+	// detection, so telemetry wording in body_text is scored, not just titles.
+	const sourceHaystack = (item: MemoryRoleProbeItem): string =>
+		[item.title, item.body_text ?? "", item.facts ?? ""].join(" ").toLowerCase();
+	const itemMatchesPrimary = (item: MemoryRoleProbeItem): boolean => {
+		const haystack = metaHaystack(item);
+		const derivedFactLike =
+			hasNonEmptyFacts(item.facts) || isDerivedFactLikeText(sourceHaystack(item));
+		if (
+			derivedFactLike &&
+			scenario.expectedPrimary.some((token) =>
+				["derived fact", "implementation contract"].includes(token.toLowerCase()),
+			)
+		) {
+			return true;
+		}
 		return scenario.expectedPrimary.some((token) => matchToken(haystack, token));
 	};
 	const itemMatchesAntiSignal = (item: MemoryRoleProbeItem): boolean => {
 		const genericRecap = item.role === "recap" && item.session_class === "micro_low_value";
 		const unmappedRecap = item.role === "recap" && item.mapping === "unmapped";
 		const wrongThreadSummary = item.role === "recap" && item.summary_disposition === "unknown";
+		// Signal balance: a row carrying a durable keep-signal (or structured facts)
+		// is NOT telemetry, even if it also contains telemetry wording. Mirrors
+		// classifyMemoryWorthiness so the anti-signal metric matches classification.
+		const src = sourceHaystack(item);
+		const durableException = hasNonEmptyFacts(item.facts) || isDerivedFactLikeText(src);
+		const reviewTelemetry = !durableException && isReviewTelemetryText(src);
+		const validationTelemetry = !durableException && isValidationTelemetryText(src);
+		const bootstrapTelemetry = !durableException && isBootstrapTelemetryText(src);
 		const administrativeChatter =
 			item.role === "ephemeral" &&
 			item.kind !== "decision" &&
@@ -208,6 +350,11 @@ export function scoreProbeScenario(
 		)
 			return true;
 		if (scenario.expectedAntiSignals.includes("administrative chatter") && administrativeChatter)
+			return true;
+		if (scenario.expectedAntiSignals.includes("review telemetry") && reviewTelemetry) return true;
+		if (scenario.expectedAntiSignals.includes("validation telemetry") && validationTelemetry)
+			return true;
+		if (scenario.expectedAntiSignals.includes("bootstrap telemetry") && bootstrapTelemetry)
 			return true;
 		return false;
 	};

--- a/packages/core/src/maintenance/memory-role-report.ts
+++ b/packages/core/src/maintenance/memory-role-report.ts
@@ -8,6 +8,7 @@ import { buildMemoryPack } from "../pack.js";
 import { MemoryStore } from "../store.js";
 import { canonicalMemoryKind, isSummaryLikeMemory } from "../summary-memory.js";
 import {
+	classifyProbeArtifactBucket,
 	classifyProjectQuality,
 	compareProbeResults,
 	type InferredMemoryRole,
@@ -33,6 +34,7 @@ function inferMemoryRoleForReport(row: {
 	body_text: string;
 	project: string | null;
 	metadata_json: string | null;
+	facts?: string | null;
 	session_minutes: number | null;
 	has_opencode_mapping: number;
 }): InferredMemoryRole {
@@ -67,6 +69,7 @@ export function getMemoryRoleReport(
 					m.body_text,
 					m.active,
 					m.metadata_json,
+					m.facts,
 					s.project,
 					s.metadata_json AS session_metadata_json,
 					CASE
@@ -92,6 +95,7 @@ export function getMemoryRoleReport(
 			body_text: string;
 			active: number;
 			metadata_json: string | null;
+			facts: string | null;
 			project: string | null;
 			session_metadata_json: string | null;
 			session_minutes: number | null;
@@ -243,6 +247,8 @@ export function getMemoryRoleReport(
 							}),
 							kind: canonicalMemoryKind(item.kind, item.metadata),
 							title: item.title,
+							body_text: source?.body_text ?? "",
+							facts: source?.facts ?? null,
 							role: inferred.role,
 							role_reason: inferred.reason,
 							mapping,
@@ -257,10 +263,27 @@ export function getMemoryRoleReport(
 						general: 0,
 					};
 					const topMappingCounts = { mapped: 0, unmapped: 0 };
+					const topArtifactCounts = {
+						session_summary: 0,
+						telemetry: 0,
+						derived_fact_like: 0,
+						durable_memory: 0,
+						ephemeral: 0,
+					};
 					let recapUnmappedCount = 0;
 					for (const item of probeItems.slice(0, 5)) {
 						topRoleCounts[item.role] += 1;
 						topMappingCounts[item.mapping] += 1;
+						const source = rows.find((row) => row.id === item.id);
+						const bucket = classifyProbeArtifactBucket({
+							kind: source?.kind ?? item.kind,
+							title: source?.title ?? item.title,
+							body_text: source?.body_text ?? null,
+							role: item.role,
+							metadata: safeParseMetadata(source?.metadata_json ?? null),
+							facts: source?.facts ?? null,
+						});
+						topArtifactCounts[bucket] += 1;
 						if (item.role === "recap" && item.mapping === "unmapped") {
 							recapUnmappedCount += 1;
 						}
@@ -327,6 +350,14 @@ export function getMemoryRoleReport(
 							recap_share: topRoleCounts.recap / topCount,
 							unmapped_share: topMappingCounts.unmapped / topCount,
 							recap_unmapped_share: recapUnmappedCount / topCount,
+						},
+						top_artifact_counts: topArtifactCounts,
+						top_artifact_share: {
+							session_summary_share: topArtifactCounts.session_summary / topCount,
+							telemetry_share: topArtifactCounts.telemetry / topCount,
+							derived_fact_like_share: topArtifactCounts.derived_fact_like / topCount,
+							durable_memory_share: topArtifactCounts.durable_memory / topCount,
+							ephemeral_share: topArtifactCounts.ephemeral / topCount,
 						},
 						simulated_demoted_unmapped_recap: {
 							item_ids: simulatedItems.map((item) => item.id),

--- a/packages/core/src/maintenance/types.ts
+++ b/packages/core/src/maintenance/types.ts
@@ -24,6 +24,27 @@ export interface RawEventStatusResult {
 
 export type MemoryRole = "recap" | "durable" | "ephemeral" | "general";
 
+export type MemoryArtifactBucket =
+	| "session_summary"
+	| "telemetry"
+	| "derived_fact_like"
+	| "durable_memory"
+	// Leftover non-durable rows (inferred role ephemeral/general): workstream
+	// noise, next-step state, etc. Kept distinct so they are not counted as
+	// durable memory in the artifact-share report.
+	| "ephemeral";
+
+export type MemoryArtifactCounts = Record<MemoryArtifactBucket, number>;
+
+export type MemoryArtifactShare = Record<
+	| "session_summary_share"
+	| "telemetry_share"
+	| "derived_fact_like_share"
+	| "durable_memory_share"
+	| "ephemeral_share",
+	number
+>;
+
 export interface MemoryRoleReportOptions {
 	project?: string | null;
 	allProjects?: boolean;
@@ -36,6 +57,10 @@ export interface MemoryRoleProbeItem {
 	stable_key: string;
 	kind: string;
 	title: string;
+	/** Source body text, used for telemetry/derived-fact signal scoring. Optional for back-compat. */
+	body_text?: string;
+	/** Source facts JSON, used as a derived-fact signal. Optional for back-compat. */
+	facts?: string | null;
 	role: MemoryRole;
 	role_reason: string;
 	mapping: "mapped" | "unmapped";
@@ -58,6 +83,12 @@ export interface MemoryRoleProbeResult {
 		unmapped_share: number;
 		recap_unmapped_share: number;
 	};
+	/**
+	 * Heuristic dual-artifact eval buckets for the top probe results. Additive and
+	 * report-only; does not imply persisted schema or first-class derived facts.
+	 */
+	top_artifact_counts?: MemoryArtifactCounts;
+	top_artifact_share?: MemoryArtifactShare;
 	simulated_demoted_unmapped_recap?: {
 		item_ids: number[];
 		top_role_counts: Record<MemoryRole, number>;

--- a/packages/core/src/pack.eval.test.ts
+++ b/packages/core/src/pack.eval.test.ts
@@ -196,4 +196,17 @@ describe("buildMemoryPack usefulness evals", () => {
 		// appear somewhere in the top N rather than trailing pure distractors.
 		expect(pack.item_ids.slice(0, 5)).toContain(corpus.ids.workingSetPrimaryId);
 	});
+
+	// Target-behavior specs for role-based retrieval routing. Per the refocused
+	// policy (2026-06-29), derived_fact is an in-place classification/role over
+	// durable non-summary observations, NOT a materialized row. These encode the
+	// desired routing — durable observations lead default/task, telemetry is
+	// demoted, summaries lead explicit recap — to be asserted with before/after
+	// evals when role-based ranking calibration lands. They stay pending so this
+	// eval-harness work stays green without asserting unimplemented behavior. The
+	// scenario pack (dual-artifact-v1) and the role-report artifact-share metric
+	// are the shippable deliverables now.
+	it.todo("prefers durable non-summary observations over summaries for topical queries");
+	it.todo("keeps telemetry below durable observations for default/task/debug probes");
+	it.todo("still surfaces a summary for explicit recap requests");
 });


### PR DESCRIPTION
## Description
Builds the dual-artifact eval harness foundation for codemem-ovk2.7. Additive and report-only — no schema changes, no migrations, no coupling to the worthiness classifier (reworked later under ovk2.10).

Adds:
- `dual-artifact-v1` scenario pack in eval-scenarios.ts (summary domination, telemetry intrusion for task + debug, explicit recap quality, derived-fact-like precision).
- Heuristic artifact-share metric on the role report (`top_artifact_counts` / `top_artifact_share`) bucketing top probe results into session_summary / telemetry / derived_fact_like / durable_memory. Optional fields; backward compatible.
- Telemetry + derived-fact-like signal helpers reused by scenario scoring (recognizes ordinary 'must <verb>' contracts per Codex M1).
- Deterministic role-report tests for the new metric.

Deferred (kept green, not asserting unbuilt behavior):
- Three pack-level dual-artifact routing specs are `it.todo` referencing codemem-ovk2.12 (artifact-aware retrieval) and codemem-ovk2.11 (first-class derived_fact artifacts). They become real assertions once routing/derivation land.

Upgrade-safety: reads the existing `facts` column only; no new columns, no migration, no behavior change to capture/retrieval/sync.

Tracking: codemem-ovk2.7.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Ran:
- `pnpm exec vitest run packages/core/src/pack.eval.test.ts packages/core/src/search.test.ts packages/core/src/maintenance.test.ts packages/core/src/eval-scenarios.test.ts` → 173 passed, 3 todo
- `pnpm run tsc`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
