### PR TITLE
feat(core): capture-time artifact routing + telemetry suppression (gated)

### DIFF
--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -28,6 +28,7 @@ import {
 import type { IngestPayload, ParsedSummary, ToolEvent } from "./ingest-types.js";
 import { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
 import type { ObserverConfig } from "./observer-client.js";
+import { flushRawEvents } from "./raw-event-flush.js";
 import { MemoryStore } from "./store.js";
 import { initTestSchema } from "./test-utils.js";
 
@@ -452,8 +453,14 @@ describe("ingest-sanitize", () => {
 describe("ingest() integration", { timeout: 15_000 }, () => {
 	let tmpDir: string;
 	let store: MemoryStore;
+	let priorCaptureRouting: string | undefined;
+	let priorDebug: string | undefined;
 
 	beforeEach(() => {
+		priorCaptureRouting = process.env.CODEMEM_CAPTURE_ROUTING;
+		priorDebug = process.env.CODEMEM_DEBUG;
+		delete process.env.CODEMEM_CAPTURE_ROUTING;
+		delete process.env.CODEMEM_DEBUG;
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-ingest-test-"));
 		const dbPath = join(tmpDir, "test.sqlite");
 		const setupDb = connect(dbPath);
@@ -463,6 +470,10 @@ describe("ingest() integration", { timeout: 15_000 }, () => {
 	});
 
 	afterEach(() => {
+		if (priorCaptureRouting === undefined) delete process.env.CODEMEM_CAPTURE_ROUTING;
+		else process.env.CODEMEM_CAPTURE_ROUTING = priorCaptureRouting;
+		if (priorDebug === undefined) delete process.env.CODEMEM_DEBUG;
+		else process.env.CODEMEM_DEBUG = priorDebug;
 		store?.close();
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
@@ -532,6 +543,34 @@ describe("ingest() integration", { timeout: 15_000 }, () => {
 		};
 	}
 
+	function observerWithRaw(raw: string) {
+		return {
+			observe: async () => ({ raw, parsed: null, provider: "test", model: "test-model" }),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+	}
+
+	function latestObserverUsageMetadata(targetStore = store): Record<string, unknown> {
+		const row = targetStore.db
+			.prepare(
+				"SELECT metadata_json FROM usage_events WHERE event = 'observer_call' ORDER BY id DESC LIMIT 1",
+			)
+			.get() as { metadata_json: string };
+		return JSON.parse(row.metadata_json) as Record<string, unknown>;
+	}
+
+	function observerMemoryMetadata(title: string, targetStore = store): Record<string, unknown> {
+		const row = targetStore.db
+			.prepare("SELECT metadata_json FROM memory_items WHERE title = ? ORDER BY id DESC LIMIT 1")
+			.get(title) as { metadata_json: string };
+		return JSON.parse(row.metadata_json) as Record<string, unknown>;
+	}
+
 	it("creates memories from observer response", async () => {
 		const payload = buildPayload();
 		await ingest(payload, store, { observer: mockObserver } as unknown as IngestOptions);
@@ -563,6 +602,235 @@ describe("ingest() integration", { timeout: 15_000 }, () => {
 		expect(summaryMetadata.request).toBe("Fix auth timeout");
 		expect(summaryMetadata.completed).toBe("Fixed the timeout");
 		expect(summaryMetadata.learned).toBe("Race condition in handler");
+	});
+
+	it("suppresses telemetry observations with capture routing enabled", async () => {
+		process.env.CODEMEM_CAPTURE_ROUTING = "1";
+		const observer = observerWithRaw(`<observation>
+			<type>change</type>
+			<title>Validation passed</title>
+			<narrative>CI passed and lint was green.</narrative>
+		</observation>`);
+
+		await ingest(buildPayload(), store, { observer } as unknown as IngestOptions);
+
+		expect(store.recent(10)).toHaveLength(0);
+		expect(latestObserverUsageMetadata()).toEqual(
+			expect.objectContaining({
+				capture_suppressed_count: 1,
+				capture_candidate_count: 0,
+				capture_routing_enabled: true,
+			}),
+		);
+	});
+
+	it("keeps durable modal contracts as candidate derived facts", async () => {
+		process.env.CODEMEM_CAPTURE_ROUTING = "1";
+		const observer = observerWithRaw(`<observation>
+			<type>discovery</type>
+			<title>Handlers must return structured errors instead of throwing</title>
+			<narrative>Handlers must return structured errors instead of throwing.</narrative>
+		</observation>`);
+
+		await ingest(buildPayload(), store, { observer } as unknown as IngestOptions);
+
+		const metadata = observerMemoryMetadata(
+			"Handlers must return structured errors instead of throwing",
+		);
+		expect(metadata.derivation).toEqual(
+			expect.objectContaining({
+				candidate: true,
+				evaluated_extractor_version: "v1",
+			}),
+		);
+		expect((metadata.derivation as Record<string, unknown>).candidate_reasons).toContain(
+			"modal_contract",
+		);
+	});
+
+	it("keeps validation text that embeds a durable contract", async () => {
+		process.env.CODEMEM_CAPTURE_ROUTING = "1";
+		const observer = observerWithRaw(`<observation>
+			<type>discovery</type>
+			<title>CI passed after confirming handlers must return structured errors</title>
+			<narrative>CI passed after confirming handlers must return structured errors.</narrative>
+		</observation>`);
+
+		await ingest(buildPayload(), store, { observer } as unknown as IngestOptions);
+
+		const metadata = observerMemoryMetadata(
+			"CI passed after confirming handlers must return structured errors",
+		);
+		expect(metadata.derivation).toEqual(
+			expect.objectContaining({
+				candidate: true,
+				evaluated_extractor_version: "v1",
+			}),
+		);
+	});
+
+	it("stores unknown observations with explicit candidate false", async () => {
+		process.env.CODEMEM_CAPTURE_ROUTING = "1";
+		const observer = observerWithRaw(`<observation>
+			<type>change</type>
+			<title>Review pass is pending</title>
+			<narrative>The review pass is pending.</narrative>
+		</observation>`);
+
+		await ingest(buildPayload(), store, { observer } as unknown as IngestOptions);
+
+		const metadata = observerMemoryMetadata("Review pass is pending");
+		expect(metadata.derivation).toEqual({
+			candidate: false,
+			evaluated_extractor_version: "v1",
+		});
+	});
+
+	it("does not route summaries through capture suppression", async () => {
+		process.env.CODEMEM_CAPTURE_ROUTING = "1";
+		const observer = observerWithRaw(`<observation>
+			<type>change</type>
+			<title>Validation passed</title>
+			<narrative>CI passed and lint was green.</narrative>
+		</observation>
+		<summary>
+			<request>Validate routing</request>
+			<completed>CI passed and lint was green.</completed>
+		</summary>`);
+
+		await ingest(buildPayload(), store, { observer } as unknown as IngestOptions);
+
+		const summaryMemory = store.db
+			.prepare(
+				"SELECT kind, metadata_json FROM memory_items WHERE json_extract(metadata_json, '$.is_summary') = 1 ORDER BY id DESC LIMIT 1",
+			)
+			.get() as { kind: string; metadata_json: string };
+		expect(summaryMemory.kind).toBe("session_summary");
+		expect(JSON.parse(summaryMemory.metadata_json).completed).toBe("CI passed and lint was green.");
+		expect(latestObserverUsageMetadata().capture_suppressed_count).toBe(1);
+	});
+
+	it("does not add derivation metadata to manual memories when routing is enabled", () => {
+		process.env.CODEMEM_CAPTURE_ROUTING = "1";
+		const sessionId = store.startSession({ cwd: tmpDir, project: "codemem" });
+		store.remember(
+			sessionId,
+			"discovery",
+			"Manual contract",
+			"Handlers must return structured errors instead of throwing.",
+		);
+
+		const metadata = observerMemoryMetadata("Manual contract");
+		expect(metadata.derivation).toBeUndefined();
+	});
+
+	it("terminally completes raw-event batches when capture routing suppresses every observation", async () => {
+		process.env.CODEMEM_CAPTURE_ROUTING = "1";
+		store.recordRawEvent({
+			opencodeSessionId: "sess-capture-suppressed",
+			eventId: "evt-1",
+			eventType: "user_prompt",
+			payload: { type: "user_prompt", prompt_text: "run validation" },
+			tsWallMs: 100,
+		});
+		store.recordRawEvent({
+			opencodeSessionId: "sess-capture-suppressed",
+			eventId: "evt-2",
+			eventType: "tool.execute.after",
+			payload: { type: "tool.execute.after", tool: "bash", args: {}, result: "ci passed" },
+			tsWallMs: 200,
+		});
+
+		const observer = observerWithRaw(`<observation>
+			<type>change</type>
+			<title>Validation passed</title>
+			<narrative>CI passed and lint was green.</narrative>
+		</observation>`);
+
+		await expect(
+			flushRawEvents(store, { observer } as unknown as IngestOptions, {
+				opencodeSessionId: "sess-capture-suppressed",
+				cwd: tmpDir,
+				project: "codemem",
+			}),
+		).resolves.toEqual({ flushed: 2, updatedState: 1 });
+
+		expect(store.rawEventFlushState("sess-capture-suppressed")).toBe(1);
+		expect(store.recent(10)).toHaveLength(0);
+		const session = store.db
+			.prepare("SELECT ended_at, metadata_json FROM sessions ORDER BY id DESC LIMIT 1")
+			.get() as { ended_at: string | null; metadata_json: string };
+		expect(session.ended_at).not.toBeNull();
+		expect(JSON.parse(session.metadata_json).post).toEqual(
+			expect.objectContaining({ capture_suppressed_count: 1 }),
+		);
+	});
+
+	it("stores telemetry without derivation metadata when capture routing is off", async () => {
+		const observer = observerWithRaw(`<observation>
+			<type>change</type>
+			<title>Validation passed</title>
+			<narrative>CI passed and lint was green.</narrative>
+		</observation>`);
+
+		await ingest(buildPayload(), store, { observer } as unknown as IngestOptions);
+
+		const metadata = observerMemoryMetadata("Validation passed");
+		expect(metadata.derivation).toBeUndefined();
+		// Default-off must be byte-identical to pre-feature: NO capture keys emitted.
+		const usage = latestObserverUsageMetadata();
+		expect(usage).not.toHaveProperty("capture_suppressed_count");
+		expect(usage).not.toHaveProperty("capture_candidate_count");
+		expect(usage).not.toHaveProperty("capture_routing_enabled");
+	});
+
+	it("stores only durable candidates from mixed batches when capture routing is on", async () => {
+		const raw = `<observation>
+			<type>discovery</type>
+			<title>Handlers must return structured errors</title>
+			<narrative>Handlers must return structured errors instead of throwing.</narrative>
+		</observation>
+		<observation>
+			<type>change</type>
+			<title>CI passed</title>
+			<narrative>CI passed and lint was green.</narrative>
+		</observation>
+		<observation>
+			<type>change</type>
+			<title>Review approved</title>
+			<narrative>The review was approved with no blockers.</narrative>
+		</observation>`;
+
+		await ingest(buildPayload(), store, {
+			observer: observerWithRaw(raw),
+		} as unknown as IngestOptions);
+		expect(store.recent(10).filter((memory) => memory.kind !== "session_summary")).toHaveLength(3);
+
+		const tmpDirOn = mkdtempSync(join(tmpdir(), "codemem-ingest-routing-on-"));
+		const dbPathOn = join(tmpDirOn, "test.sqlite");
+		const setupDbOn = connect(dbPathOn);
+		initTestSchema(setupDbOn);
+		setupDbOn.close();
+		const routingStore = new MemoryStore(dbPathOn);
+		try {
+			process.env.CODEMEM_CAPTURE_ROUTING = "1";
+			await ingest(buildPayload(), routingStore, {
+				observer: observerWithRaw(raw),
+			} as unknown as IngestOptions);
+			expect(
+				routingStore.recent(10).filter((memory) => memory.kind !== "session_summary"),
+			).toHaveLength(1);
+			expect(latestObserverUsageMetadata(routingStore)).toEqual(
+				expect.objectContaining({
+					capture_suppressed_count: 2,
+					capture_candidate_count: 1,
+					capture_routing_enabled: true,
+				}),
+			);
+		} finally {
+			routingStore.close();
+			rmSync(tmpDirOn, { recursive: true, force: true });
+		}
 	});
 
 	it("suppresses summary-only micro-session recap output", async () => {
@@ -834,9 +1102,13 @@ describe("ingest() integration", { timeout: 15_000 }, () => {
 
 		expect(store.recent(10)).toHaveLength(0);
 		const session = store.db
-			.prepare("SELECT ended_at FROM sessions ORDER BY id DESC LIMIT 1")
-			.get() as { ended_at: string | null };
+			.prepare("SELECT ended_at, metadata_json FROM sessions ORDER BY id DESC LIMIT 1")
+			.get() as { ended_at: string | null; metadata_json: string | null };
 		expect(session.ended_at).not.toBeNull();
+		// Default-off: this raw-event zero-output session-end branch must NOT leak
+		// capture-routing metadata into session records (Codex default-off P2).
+		const sessionMeta = JSON.parse(session.metadata_json ?? "{}") as Record<string, unknown>;
+		expect(sessionMeta).not.toHaveProperty("capture_suppressed_count");
 	});
 
 	it("still fails raw-event flush when skip_summary reason is not low-signal", async () => {

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -36,6 +36,7 @@ import {
 } from "./ingest-events.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
 import { buildObserverPrompt, truncateObserverTranscript } from "./ingest-prompts.js";
+import { type CaptureRoutedObservation, routeObservationsForCapture } from "./ingest-routing.js";
 import {
 	buildTranscript,
 	deriveRequest,
@@ -337,6 +338,7 @@ export async function ingest(
 	const storeTyped = options.storeTyped ?? true;
 	const maxChars = options.maxChars ?? 12_000;
 	const observerMaxChars = options.observerMaxChars ?? 12_000;
+	const captureRoutingEnabled = process.env.CODEMEM_CAPTURE_ROUTING === "1";
 
 	const d = drizzle(store.db, { schema });
 	const now = new Date().toISOString();
@@ -546,7 +548,7 @@ export async function ingest(
 		const parsed = response.parsed;
 		const observerStatus = selectedObserver.getStatus();
 
-		const observationsToStore: typeof parsed.observations = [];
+		let observationsToStore: CaptureRoutedObservation[] = [];
 		if (storeTyped && hasMeaningfulObservation(parsed.observations)) {
 			for (const obs of parsed.observations) {
 				const kind = obs.kind.trim().toLowerCase();
@@ -585,6 +587,29 @@ export async function ingest(
 				const body = summaryBody(summary);
 				if (body && !isLowSignalObservation(firstSentence(body))) {
 					summaryToStore = { summary, request, body };
+				}
+			}
+		}
+
+		let captureSuppressedCount = 0;
+		let captureCandidateCount = 0;
+		if (captureRoutingEnabled) {
+			const routed = routeObservationsForCapture(observationsToStore, {
+				project,
+				sessionMinutes:
+					typeof sessionContext.durationMs === "number" ? sessionContext.durationMs / 60000 : null,
+			});
+			observationsToStore = routed.kept;
+			captureSuppressedCount = routed.suppressedTelemetry.count;
+			captureCandidateCount = observationsToStore.filter(
+				(obs) => obs.derivation?.candidate === true,
+			).length;
+			if (captureSuppressedCount > 0 && process.env.CODEMEM_DEBUG === "1") {
+				const reasonText = [...new Set(routed.suppressedTelemetry.reasons)].join(", ") || "unknown";
+				for (let i = 0; i < captureSuppressedCount; i += 1) {
+					console.error(
+						`[codemem] capture routing suppressed telemetry observation (reasons=${reasonText})`,
+					);
 				}
 			}
 		}
@@ -643,10 +668,26 @@ export async function ingest(
 						hasAssistantMessage: Boolean(lastAssistantMessage),
 						skipSummaryReason: parsed.skipSummaryReason,
 					});
-				if (pureLowSignalSkip || locallySuppressedSummaryOnlyMicro) {
+				// Only soft-skip when capture routing suppressed EVERY observation
+				// (and there was no summary). If something else zeroed the batch,
+				// fall through to the throw so a real losslessness bug isn't masked.
+				const captureSuppressedTelemetryOnly =
+					captureRoutingEnabled &&
+					captureSuppressedCount > 0 &&
+					parsed.observations.length > 0 &&
+					captureSuppressedCount === parsed.observations.length &&
+					summaryToStore == null;
+				if (
+					pureLowSignalSkip ||
+					locallySuppressedSummaryOnlyMicro ||
+					captureSuppressedTelemetryOnly
+				) {
 					endSession(store, sessionId, events.length, sessionContext, {
 						session_class: sessionClass,
-						summary_disposition: locallySuppressedSummaryOnlyMicro ? "suppressed" : "none",
+						summary_disposition: summaryDisposition,
+						// Only emit capture-routing telemetry when the gate is on, so
+						// default-off session metadata stays byte-identical to pre-feature.
+						...(captureRoutingEnabled ? { capture_suppressed_count: captureSuppressedCount } : {}),
 					});
 					return;
 				}
@@ -684,6 +725,7 @@ export async function ingest(
 					filesModified: obs.filesModified,
 				});
 				const memoryId = store.remember(sessionId, kind, memoryTitle, bodyText, 0.5, tags, {
+					...(obs.derivation ? { derivation: obs.derivation } : {}),
 					subtitle: obs.subtitle,
 					narrative: obs.narrative,
 					facts: obs.facts,
@@ -786,6 +828,15 @@ export async function ingest(
 						project,
 						observation_count: observationsToStore.length,
 						has_summary: summaryToStore != null,
+						// Only emit capture-routing telemetry when the gate is on, so
+						// default-off output stays byte-identical to pre-feature.
+						...(captureRoutingEnabled
+							? {
+									capture_suppressed_count: captureSuppressedCount,
+									capture_candidate_count: captureCandidateCount,
+									capture_routing_enabled: true,
+								}
+							: {}),
 						session_class: sessionClass,
 						summary_disposition: summaryDisposition,
 						observer_tier: selectedTier,
@@ -820,6 +871,7 @@ export async function ingest(
 		endSession(store, sessionId, events.length, sessionContext, {
 			session_class: sessionClass,
 			summary_disposition: summaryDisposition,
+			...(captureRoutingEnabled ? { capture_suppressed_count: captureSuppressedCount } : {}),
 			observer_tier: selectedTier,
 			observer_tier_reasons: selectedTierReasons,
 			observer_requested_provider: requestedObserverProvider,

--- a/packages/core/src/ingest-routing.ts
+++ b/packages/core/src/ingest-routing.ts
@@ -1,0 +1,84 @@
+/**
+ * Capture-time artifact routing for observer observations.
+ *
+ * This module is deliberately pure: it classifies already-parsed observer
+ * observations and returns kept observations plus telemetry suppression counts.
+ */
+
+import type { ParsedObservation } from "./ingest-types.js";
+import { classifyMemoryWorthiness, type MemoryWorthinessReason } from "./memory-quality.js";
+
+export interface CaptureDerivationMarker {
+	candidate: boolean;
+	candidate_reasons?: MemoryWorthinessReason[];
+	evaluated_extractor_version: "v1";
+}
+
+export type CaptureRoutedObservation = ParsedObservation & {
+	derivation?: CaptureDerivationMarker;
+};
+
+export interface CaptureRoutingContext {
+	project?: string | null;
+	sessionMinutes?: number | null;
+}
+
+export interface CaptureRoutingResult {
+	kept: CaptureRoutedObservation[];
+	suppressedTelemetry: {
+		count: number;
+		reasons: string[];
+	};
+}
+
+function observationBodyText(obs: ParsedObservation): string {
+	const bodyParts: string[] = [];
+	if (obs.narrative) bodyParts.push(obs.narrative);
+	if (obs.facts.length > 0) {
+		bodyParts.push(obs.facts.map((fact) => `- ${fact}`).join("\n"));
+	}
+	return bodyParts.join("\n\n");
+}
+
+export function routeObservationsForCapture(
+	observations: ParsedObservation[],
+	ctx: CaptureRoutingContext,
+): CaptureRoutingResult {
+	const kept: CaptureRoutedObservation[] = [];
+	const reasons: string[] = [];
+
+	for (const obs of observations) {
+		const bodyText = observationBodyText(obs);
+		const result = classifyMemoryWorthiness({
+			kind: obs.kind.trim().toLowerCase(),
+			title: obs.title || obs.narrative,
+			body_text: bodyText,
+			metadata: { source: "observer" },
+			project: ctx.project,
+			session_minutes: ctx.sessionMinutes,
+		});
+
+		if (result.artifact === "telemetry" && result.action === "suppress") {
+			reasons.push(...result.reasons);
+			continue;
+		}
+
+		const candidate = result.artifact === "derived_fact";
+		kept.push({
+			...obs,
+			derivation: {
+				candidate,
+				...(candidate ? { candidate_reasons: result.reasons } : {}),
+				evaluated_extractor_version: "v1",
+			},
+		});
+	}
+
+	return {
+		kept,
+		suppressedTelemetry: {
+			count: observations.length - kept.length,
+			reasons,
+		},
+	};
+}

--- a/packages/core/src/memory-quality.test.ts
+++ b/packages/core/src/memory-quality.test.ts
@@ -310,6 +310,89 @@ describe("classifyMemoryWorthiness", () => {
 		});
 	});
 
+	// Codex: a real bugfix/discovery that also mentions validation must NOT be
+	// suppressed as telemetry — it carries a durable fix/finding.
+	it("keeps a bugfix that records a fix even when it mentions tests passing", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "bugfix",
+			title: "Fixed auth timeout",
+			body_text: "Fixed the race condition in the auth refresh path; tests passed.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.action).toBe("store");
+		expect(result.reasons).not.toContain("validation_telemetry_only");
+		expect(result.reasons).toContain("troubleshooting_gotcha");
+	});
+
+	it("keeps a discovery that records a finding even when CI is green", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "discovery",
+			title: "Cursor drift",
+			body_text: "Determined the cursor drift came from unstable sort; CI is green now.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.action).toBe("store");
+		expect(result.reasons).not.toContain("validation_telemetry_only");
+	});
+
+	it("still suppresses a bare bugfix that only reports tests passing", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "bugfix",
+			title: "CI check",
+			body_text: "Tests passed and CI is green.",
+		});
+		expect(result.artifact).toBe("telemetry");
+		expect(result.reasons).toContain("validation_telemetry_only");
+	});
+
+	// Codex: a weak finding verb (confirmed/determined/...) whose object is just
+	// validation/review status must NOT be rescued as a durable finding.
+	it("suppresses a discovery that only confirms validation telemetry", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "discovery",
+			title: "CI status",
+			body_text: "Confirmed CI passed and lint was green.",
+		});
+		expect(result.artifact).toBe("telemetry");
+		expect(result.reasons).toContain("validation_telemetry_only");
+		expect(result.reasons).not.toContain("durable_decision");
+	});
+
+	it("suppresses a bugfix that only verifies the tests pass", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "bugfix",
+			title: "Verified",
+			body_text: "Verified the tests are green after the change.",
+		});
+		expect(result.artifact).toBe("telemetry");
+		expect(result.reasons).not.toContain("troubleshooting_gotcha");
+	});
+
+	// Codex: a STRONG fix verb must keep even when a no-findings/validation phrase
+	// is present (the no-findings guard must not cancel a real fix).
+	it("keeps a strong fix even when paired with a no-remaining-issues phrase", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "bugfix",
+			title: "Fixed auth timeout",
+			body_text: "Fixed auth timeout; tests passed and no remaining issues.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.reasons).toContain("troubleshooting_gotcha");
+		expect(result.reasons).not.toContain("validation_telemetry_only");
+	});
+
+	// Codex: a substantive weak finding in the same row as a telemetry-governed
+	// weak verb must still keep (the telemetry guard is per-clause, not global).
+	it("keeps a substantive finding even when another clause confirms telemetry", () => {
+		const result = classifyMemoryWorthiness({
+			kind: "discovery",
+			title: "Cursor drift",
+			body_text: "Confirmed CI passed after determining cursor drift came from unstable sort.",
+		});
+		expect(result.artifact).toBe("derived_fact");
+		expect(result.reasons).toContain("durable_decision");
+	});
+
 	it("stores summaries even when they mention validation telemetry", () => {
 		expect(
 			classifyMemoryWorthiness({

--- a/packages/core/src/memory-quality.ts
+++ b/packages/core/src/memory-quality.ts
@@ -245,6 +245,67 @@ function collectKeepReasons(input: {
 	if (hasDecisionValue || kind === "decision") {
 		reasons.push("durable_decision");
 	}
+	// A `bugfix`/`discovery` row that records an actual fix or finding is durable
+	// even if it also mentions validation telemetry. Without this, an observer row
+	// like `kind=bugfix` / "Fixed the race condition; tests passed" is suppressed
+	// by the validation-telemetry regex below, silently dropping a real fix in the
+	// capture-routing path (Codex). Require a resolution/finding verb so bare
+	// "bugfix: tests passed" with no described fix still falls through.
+	//
+	// STRONG fix verbs always indicate a real change and keep regardless of any
+	// validation/review phrasing in the same row ("Fixed auth timeout; tests
+	// passed and no remaining issues" is still a durable fix — Codex).
+	const hasStrongFixVerb = hasAnyPattern(text, [
+		/\bfixed\b/,
+		/\bresolved\b/,
+		/\broot\s+caused?\b/,
+		/\bpatched\b/,
+	]);
+	// WEAK finding verbs (confirmed/determined/found/discovered/identified) are
+	// durable only when at least one occurrence governs a SUBSTANTIVE object, not
+	// a validation/review subject or a no-findings outcome. The check is
+	// per-clause: "Confirmed CI passed after determining cursor drift came from
+	// unstable sort" must keep on the "determining cursor drift" clause even
+	// though "Confirmed CI" governs telemetry (Codex).
+	const WEAK_FINDING_VERBS =
+		"confirmed|determined|determining|verified|verifying|found|finding|discovered|discovering|identified|identifying|confirming";
+	// A weak finding verb is SUBSTANTIVE only when it directly governs a concrete
+	// object that is NOT validation/review status or a no-finding outcome. We match
+	// the verb followed by a content word other than the telemetry/no-finding
+	// nouns; that excludes both "confirmed CI passed" (telemetry object) and a bare
+	// "Verified" with no object (e.g. a terse title), while keeping "determining
+	// cursor drift came from ..." (Codex: per-clause, not whole-text).
+	// Objects that do NOT make a weak finding substantive: validation/review
+	// status, no-finding outcomes, and another weak finding verb (a duplicated
+	// bare verb such as a terse "Verified" title followed by "verified ..." must
+	// not bootstrap itself into a substantive finding).
+	const NON_SUBSTANTIVE_OBJECTS = `${WEAK_FINDING_VERBS}|tests?|lint|ci|build|typecheck|tsc|checks?|review|reviewer|pr|pull\\s+request|no|nothing|none`;
+	// weak verb -> optional "that" -> optional determiner -> a content word that is
+	// not itself a non-substantive object. Determiners are consumed (not allowed to
+	// satisfy the object) so "verified the tests" / a bare "verified verified" do
+	// not bootstrap a substantive finding, while "determined cursor drift" does.
+	const DETERMINERS = "the|a|an|all|our|its|their";
+	const substantiveWeakFinding = new RegExp(
+		`\\b(?:${WEAK_FINDING_VERBS})\\s+(?:that\\s+)?(?:(?:${DETERMINERS})\\s+)?` +
+			`(?!(?:${NON_SUBSTANTIVE_OBJECTS}|${DETERMINERS})\\b)[a-z]{3,}`,
+	);
+	const hasSubstantiveWeakFinding = substantiveWeakFinding.test(text);
+	// Bare "found no blockers / no remaining issues" review telemetry, with no
+	// strong fix and no substantive finding, still suppresses.
+	const isReviewNoFindings = hasAnyPattern(text, [
+		/\bfound\s+(?:no|nothing|none)\b/,
+		/\bno\s+(?:blockers?|findings?|remaining\s+issues?|issues?)\b/,
+	]);
+	const hasUsefulFindingVerb = hasStrongFixVerb || hasSubstantiveWeakFinding;
+	// `isReviewNoFindings` only blocks when there is no strong fix and no
+	// substantive weak finding to stand on.
+	if (
+		(kind === "bugfix" || kind === "discovery") &&
+		hasUsefulFindingVerb &&
+		(hasStrongFixVerb || hasSubstantiveWeakFinding || !isReviewNoFindings)
+	) {
+		reasons.push(kind === "bugfix" ? "troubleshooting_gotcha" : "durable_decision");
+	}
 	if (hasModalContract || hasContractNoun || hasDependencyLesson) {
 		// A locator (file/module/path) makes it a concrete implementation contract;
 		// otherwise it is still a durable contract/rule (M3/M4: review or workspace


### PR DESCRIPTION
## Description
Capture-time artifact routing + telemetry suppression (codemem-ovk2.5, Pass A inline tagging). At observer ingest, suppresses high-confidence telemetry observations before durable storage and tags surviving observations with an inline derivation candidate marker for the future batch derivation pass (ovk2.11).

Gated behind CODEMEM_CAPTURE_ROUTING, DEFAULT OFF — byte-identical behavior when unset.

Adds:
- packages/core/src/ingest-routing.ts: pure routeObservationsForCapture() reusing classifyMemoryWorthiness.
- ingest-pipeline.ts wiring between summary finalization and session-class, replacing observationsToStore with kept rows and merging the marker into remember() metadata.
- Marker is candidate-only (C13: no artifact_class) with explicit candidate=false for evaluated-but-negative (C15) + evaluated_extractor_version.
- Critical raw-events losslessness fix: when routing suppresses all observations on a raw_events flush, soft-skip (endSession + return) instead of throwing, preventing an infinite reprocess loop.
- Observability via usage_events (capture_suppressed_count / capture_candidate_count / capture_routing_enabled) + endSession post; per-suppression stderr only under CODEMEM_DEBUG.

Manual CLI/MCP remember paths are untouched (classifier stays observer-only; a test asserts manual rows get no derivation block).

Upgrade-safe: additive metadata only, no schema change, default-off, reversible.

Tracking: codemem-ovk2.5.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance
- [x] 🧪 Testing

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

vitest ingest-pipeline + memory-quality + raw-event-flush + maintenance (173 pass); tsc; lint green. Tests cover telemetry suppressed, durable kept + candidate marker, M2 signal-balance keep, explicit candidate=false, summary unaffected, manual remember untouched, raw-events all-telemetry soft-skip, gate-off default safety, before/after counts.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
