### PR TITLE
feat(core): derived-fact derivation pass (upsertDerivedFact + derive + sync dedup_key)

### DIFF
--- a/packages/core/src/derive-eval-fixtures.ts
+++ b/packages/core/src/derive-eval-fixtures.ts
@@ -1,0 +1,31 @@
+export interface DeriveEvalFixture {
+	name: string;
+	kind: string;
+	title: string;
+	bodyText: string;
+	expectDerived: boolean;
+}
+
+export const DERIVE_EVAL_FIXTURES: DeriveEvalFixture[] = [
+	{
+		name: "M1 modal contract",
+		kind: "decision",
+		title: "Handlers must return structured errors",
+		bodyText: "Handlers must return structured errors instead of throwing uncaught exceptions.",
+		expectDerived: true,
+	},
+	{
+		name: "M2 embedded contract with validation telemetry",
+		kind: "change",
+		title: "CI passed after handler contract was confirmed",
+		bodyText: "CI passed after confirming handlers must return structured errors.",
+		expectDerived: true,
+	},
+	{
+		name: "pure validation telemetry",
+		kind: "change",
+		title: "CI passed",
+		bodyText: "pnpm run tsc passed and lint was green.",
+		expectDerived: false,
+	},
+];

--- a/packages/core/src/derive.test.ts
+++ b/packages/core/src/derive.test.ts
@@ -1,0 +1,385 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect, fromJson } from "./db.js";
+import {
+	type CorpusRow,
+	computeClaimKey,
+	computeScopeKey,
+	deriveClaimsFromBundle,
+	groundingTokensPresent,
+	leastTrustedState,
+	reduceProvenance,
+	runDerivePass,
+} from "./derive.js";
+import { DERIVE_EVAL_FIXTURES } from "./derive-eval-fixtures.js";
+import { type DerivedFactInput, MemoryStore } from "./store.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+
+function makeStore(): { store: MemoryStore; tmpDir: string } {
+	const tmpDir = mkdtempSync(join(tmpdir(), "codemem-derive-test-"));
+	const dbPath = join(tmpDir, "test.sqlite");
+	const db = connect(dbPath);
+	initTestSchema(db);
+	db.close();
+	return { store: new MemoryStore(dbPath), tmpDir };
+}
+
+function baseInput(sessionId: number, overrides: Partial<DerivedFactInput> = {}): DerivedFactInput {
+	return {
+		sessionId,
+		kind: "decision",
+		title: "Handlers must return structured errors",
+		bodyText: "Handlers must return structured errors instead of throwing uncaught exceptions.",
+		facts: ["Handlers must return structured errors instead of throwing uncaught exceptions."],
+		concepts: ["handlers"],
+		filesRead: ["packages/core/src/store.ts"],
+		filesModified: [],
+		provenance: {
+			scope_id: "scope-a",
+			visibility: "shared",
+			workspace_id: "shared:default",
+			workspace_kind: "shared",
+			trust_state: "trusted",
+		},
+		derivation: {
+			claim_type: "contract",
+			claim_key: "df:v1:contract:handlers:handlers must return structured errors",
+			extractor_version: "v1",
+			source: { session_ids: [sessionId], memory_ids: [1], memory_import_keys: ["mem:1"] },
+			grounding: { concepts: ["handlers"], files: [], must_appear_tokens: ["Handlers"] },
+		},
+		options: { skipVectorWrite: true },
+		...overrides,
+	};
+}
+
+describe("derive pure helpers", () => {
+	it("computes claim keys without grounding tokens", () => {
+		expect(
+			computeClaimKey({
+				claimType: "contract",
+				scopeKey: "src/a.ts",
+				title: "PR #12 Handlers must return structured errors",
+			}),
+		).toBe("df:v1:contract:src/a.ts:handlers must return structured errors");
+	});
+
+	it("computes sorted normalized scope keys capped at three", () => {
+		expect(
+			computeScopeKey({
+				filesModified: ["SRC/B.ts", "src/a.ts"],
+				filesRead: ["src/a.ts"],
+				concepts: ["Handlers", "Zed"],
+			}),
+		).toBe("handlers,src/a.ts,src/b.ts");
+	});
+
+	it("uses the least trusted source state", () => {
+		expect(leastTrustedState(["trusted", "unreviewed"])).toBe("unreviewed");
+		expect(leastTrustedState(["trusted", "legacy_unknown"])).toBe("legacy_unknown");
+	});
+
+	// Codex: a NULL/blank source trust_state must not be treated as trusted.
+	it("does not treat a missing source trust state as trusted", () => {
+		expect(leastTrustedState(["trusted", null])).toBe("legacy_unknown");
+		expect(leastTrustedState([undefined])).toBe("legacy_unknown");
+		expect(leastTrustedState([""])).toBe("legacy_unknown");
+	});
+
+	it("rejects mixed provenance", () => {
+		const result = reduceProvenance([
+			{
+				scope_id: "a",
+				visibility: "shared",
+				workspace_id: "shared:a",
+				workspace_kind: "shared",
+				trust_state: "trusted",
+			},
+			{
+				scope_id: "b",
+				visibility: "shared",
+				workspace_id: "shared:a",
+				workspace_kind: "shared",
+				trust_state: "trusted",
+			},
+		]);
+		expect(result).toEqual({ ok: false, reason: "mixed_provenance" });
+	});
+
+	it("checks grounding tokens against source and summary bodies", () => {
+		expect(
+			groundingTokensPresent({
+				mustAppearTokens: ["structured errors"],
+				sourceBodies: ["source body", "Summary says structured errors are required"],
+			}),
+		).toBe(true);
+	});
+});
+
+describe("derive pass", () => {
+	let store: MemoryStore;
+	let tmpDir: string;
+	let prevEmbeddingDisabled: string | undefined;
+
+	beforeEach(() => {
+		prevEmbeddingDisabled = process.env.CODEMEM_EMBEDDING_DISABLED;
+		process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+		const setup = makeStore();
+		store = setup.store;
+		tmpDir = setup.tmpDir;
+	});
+
+	afterEach(() => {
+		store.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+		if (prevEmbeddingDisabled === undefined) delete process.env.CODEMEM_EMBEDDING_DISABLED;
+		else process.env.CODEMEM_EMBEDDING_DISABLED = prevEmbeddingDisabled;
+	});
+
+	it("promotes M1/M2 fixtures and suppresses pure telemetry", () => {
+		for (const fixture of DERIVE_EVAL_FIXTURES) {
+			const sessionId = insertTestSession(store.db);
+			store.remember(sessionId, fixture.kind, fixture.title, fixture.bodyText, 0.5, [], {
+				concepts: ["handlers"],
+				visibility: "shared",
+				workspace_id: "shared:default",
+			});
+		}
+
+		const result = runDerivePass(store, {
+			createdAtFrom: "2000-01-01T00:00:00.000Z",
+			skipVectorWrite: true,
+		});
+		expect(result.inserted).toBe(2);
+	});
+
+	it("derives summary-only grounded claims using the summary body", () => {
+		const sessionId = insertTestSession(store.db);
+		const summaryId = store.remember(
+			sessionId,
+			"session_summary",
+			"Summary",
+			"Handlers must return structured errors instead of throwing uncaught exceptions.",
+			0.5,
+			[],
+			{
+				source: "observer_summary",
+				concepts: ["handlers"],
+				visibility: "shared",
+				workspace_id: "shared:default",
+			},
+		);
+		const row = store.db
+			.prepare(
+				"SELECT m.*, s.import_key AS session_import_key FROM memory_items m LEFT JOIN sessions s ON s.id = m.session_id WHERE m.id = ?",
+			)
+			.get(summaryId) as CorpusRow;
+
+		const claims = deriveClaimsFromBundle({
+			sessionId,
+			sessionImportKey: null,
+			sources: [],
+			summary: row,
+		});
+		expect(claims).toHaveLength(1);
+		expect(claims[0]?.derivation.source.summary_memory_id).toBe(summaryId);
+	});
+
+	it("is idempotent across reruns and extractor version bumps", () => {
+		const sessionId = insertTestSession(store.db);
+		store.remember(
+			sessionId,
+			"decision",
+			"Handlers must return structured errors",
+			"Handlers must return structured errors instead of throwing uncaught exceptions.",
+			0.5,
+			[],
+			{
+				concepts: ["handlers"],
+				visibility: "shared",
+				workspace_id: "shared:default",
+			},
+		);
+
+		expect(
+			runDerivePass(store, { createdAtFrom: "2000-01-01T00:00:00.000Z", skipVectorWrite: true })
+				.inserted,
+		).toBe(1);
+		expect(
+			runDerivePass(store, { createdAtFrom: "2000-01-01T00:00:00.000Z", skipVectorWrite: true })
+				.updated,
+		).toBe(1);
+		expect(
+			runDerivePass(store, {
+				createdAtFrom: "2000-01-01T00:00:00.000Z",
+				extractorVersion: "v2",
+				skipVectorWrite: true,
+			}).updated,
+		).toBe(1);
+		const count = store.db
+			.prepare(
+				"SELECT COUNT(*) AS count FROM memory_items WHERE json_extract(metadata_json, '$.derivation.artifact_class') = 'derived_fact'",
+			)
+			.get() as { count: number };
+		expect(count.count).toBe(1);
+	});
+
+	// Codex: trust can only ratchet down when a less-trusted source merges.
+	it("lowers trust_state when a less-trusted source updates an existing fact", () => {
+		const sessionId = insertTestSession(store.db);
+		const inserted = store.upsertDerivedFact(baseInput(sessionId)); // trusted
+		expect(inserted.outcome).toBe("inserted");
+		const updated = store.upsertDerivedFact(
+			baseInput(sessionId, {
+				provenance: {
+					scope_id: "scope-a",
+					visibility: "shared",
+					workspace_id: "shared:default",
+					workspace_kind: "shared",
+					trust_state: "unreviewed",
+				},
+			}),
+		);
+		expect(updated.outcome).toBe("updated");
+		const row = store.db
+			.prepare("SELECT trust_state FROM memory_items WHERE id = ?")
+			.get(inserted.id) as { trust_state: string };
+		expect(row.trust_state).toBe("unreviewed");
+	});
+
+	it("does not upgrade trust_state when a more-trusted source updates", () => {
+		const sessionId = insertTestSession(store.db);
+		const inserted = store.upsertDerivedFact(
+			baseInput(sessionId, {
+				provenance: {
+					scope_id: "scope-a",
+					visibility: "shared",
+					workspace_id: "shared:default",
+					workspace_kind: "shared",
+					trust_state: "unreviewed",
+				},
+			}),
+		);
+		store.upsertDerivedFact(baseInput(sessionId)); // trusted source
+		const row = store.db
+			.prepare("SELECT trust_state FROM memory_items WHERE id = ?")
+			.get(inserted.id) as { trust_state: string };
+		expect(row.trust_state).toBe("unreviewed");
+	});
+
+	it("does not recreate forgotten derived fact tombstones", () => {
+		const sessionId = insertTestSession(store.db);
+		const inserted = store.upsertDerivedFact(baseInput(sessionId));
+		expect(inserted.outcome).toBe("inserted");
+		store.forget(inserted.id);
+
+		const skipped = store.upsertDerivedFact(baseInput(sessionId));
+		expect(skipped.outcome).toBe("skipped_tombstone");
+		const rows = store.db
+			.prepare("SELECT COUNT(*) AS count FROM memory_items WHERE dedup_key = ?")
+			.get(baseInput(sessionId).derivation.claim_key) as { count: number };
+		expect(rows.count).toBe(1);
+	});
+
+	it("bypasses legacy title dedup and never mutates source observations", () => {
+		const sessionId = insertTestSession(store.db);
+		const sourceId = store.remember(
+			sessionId,
+			"decision",
+			"Handlers must return structured errors",
+			"Handlers must return structured errors instead of throwing uncaught exceptions.",
+		);
+		const result = store.upsertDerivedFact(
+			baseInput(sessionId, {
+				derivation: {
+					...baseInput(sessionId).derivation,
+					source: { session_ids: [sessionId], memory_ids: [sourceId] },
+				},
+			}),
+		);
+
+		expect(result.outcome).toBe("inserted");
+		expect(result.id).not.toBe(sourceId);
+		const source = store.db
+			.prepare("SELECT metadata_json FROM memory_items WHERE id = ?")
+			.get(sourceId) as { metadata_json: string | null };
+		expect(fromJson(source.metadata_json).derivation).toBeUndefined();
+	});
+
+	it("preserves private visibility and least trusted state", () => {
+		const sessionId = insertTestSession(store.db);
+		const result = store.upsertDerivedFact(
+			baseInput(sessionId, {
+				provenance: {
+					scope_id: "personal:actor",
+					visibility: "private",
+					workspace_id: "personal:actor",
+					workspace_kind: "personal",
+					trust_state: "unreviewed",
+				},
+			}),
+		);
+		expect(result.outcome).toBe("inserted");
+		const row = store.db
+			.prepare("SELECT visibility, workspace_id, trust_state FROM memory_items WHERE id = ?")
+			.get(result.id) as { visibility: string; workspace_id: string; trust_state: string };
+		expect(row).toMatchObject({
+			visibility: "private",
+			workspace_id: "personal:actor",
+			trust_state: "unreviewed",
+		});
+	});
+
+	it("skips active legacy rows with the same claim key", () => {
+		const sessionId = insertTestSession(store.db);
+		store.db
+			.prepare(
+				"INSERT INTO memory_items(session_id, kind, title, body_text, confidence, tags_text, active, created_at, updated_at, metadata_json, rev, scope_id, dedup_key) VALUES (?, 'decision', 'Legacy', 'Body', 0.5, '', 1, ?, ?, '{}', 1, 'scope-a', ?)",
+			)
+			.run(
+				sessionId,
+				new Date().toISOString(),
+				new Date().toISOString(),
+				baseInput(sessionId).derivation.claim_key,
+			);
+
+		expect(store.upsertDerivedFact(baseInput(sessionId)).outcome).toBe("skipped_legacy_conflict");
+	});
+
+	// Security: provenance must be explicit — never fail open to shared/trusted.
+	it("rejects blank trust_state instead of laundering to trusted", () => {
+		const sessionId = insertTestSession(store.db);
+		expect(() =>
+			store.upsertDerivedFact(
+				baseInput(sessionId, {
+					provenance: {
+						scope_id: "personal:actor",
+						visibility: "private",
+						workspace_id: "personal:actor",
+						workspace_kind: "personal",
+						trust_state: "",
+					},
+				}),
+			),
+		).toThrow(/trust_state is required/);
+	});
+
+	it("rejects blank visibility instead of laundering to shared", () => {
+		const sessionId = insertTestSession(store.db);
+		expect(() =>
+			store.upsertDerivedFact(
+				baseInput(sessionId, {
+					provenance: {
+						scope_id: "personal:actor",
+						visibility: "",
+						workspace_id: "personal:actor",
+						workspace_kind: "personal",
+						trust_state: "unreviewed",
+					},
+				}),
+			),
+		).toThrow(/visibility is required/);
+	});
+});

--- a/packages/core/src/derive.ts
+++ b/packages/core/src/derive.ts
@@ -1,0 +1,432 @@
+import { normalizeMemoryDedupTitle } from "./memory-dedup.js";
+import { classifyMemoryWorthiness, type MemoryWorthinessReason } from "./memory-quality.js";
+import type {
+	DerivedFactInput,
+	DerivedFactProvenance,
+	DerivedFactResult,
+	MemoryStore,
+} from "./store.js";
+
+export const DERIVE_EXTRACTOR_VERSION = "v1";
+
+export type ClaimType =
+	| "contract"
+	| "invariant"
+	| "source-of-truth"
+	| "non-goal"
+	| "preference"
+	| "gotcha"
+	| "failure"
+	| "bugfix"
+	| "locator"
+	| "decision";
+
+export interface ComputeClaimKeyInput {
+	claimType: ClaimType | string;
+	scopeKey: string;
+	title: string;
+}
+
+export function computeClaimKey(input: ComputeClaimKeyInput): string {
+	return `df:v1:${input.claimType}:${input.scopeKey}:${normalizeMemoryDedupTitle(input.title)}`;
+}
+
+export interface ComputeScopeKeyInput {
+	filesModified?: string[] | null;
+	filesRead?: string[] | null;
+	concepts?: string[] | null;
+}
+
+function normalizeScopePart(value: string): string {
+	return value.trim().replace(/\\/g, "/").replace(/\/+/g, "/").toLowerCase();
+}
+
+export function computeScopeKey(input: ComputeScopeKeyInput): string {
+	return [...(input.filesModified ?? []), ...(input.filesRead ?? []), ...(input.concepts ?? [])]
+		.map(normalizeScopePart)
+		.filter(Boolean)
+		.filter((value, index, array) => array.indexOf(value) === index)
+		.sort()
+		.slice(0, 3)
+		.join(",");
+}
+
+export function groundingTokensPresent(input: {
+	mustAppearTokens: string[];
+	sourceBodies: string[];
+}): boolean {
+	if (input.mustAppearTokens.length === 0) return false;
+	const bodies = input.sourceBodies.map((body) => body.toLowerCase());
+	return input.mustAppearTokens.every((token) => {
+		const needle = token.trim().toLowerCase();
+		return needle.length > 0 && bodies.some((body) => body.includes(needle));
+	});
+}
+
+const TRUST_ORDER = ["trusted", "unreviewed", "legacy_unknown", "untrusted"];
+
+export function leastTrustedState(states: Array<string | null | undefined>): string {
+	let least = "trusted";
+	for (const raw of states) {
+		// A missing/blank source trust_state (nullable column on legacy/replicated
+		// rows) must NOT be treated as trusted — degrade to the least-trusted known
+		// tier so derivation never launders untrusted provenance into a trusted fact.
+		const state = raw?.trim() || "legacy_unknown";
+		if (TRUST_ORDER.indexOf(state) > TRUST_ORDER.indexOf(least)) least = state;
+		if (!TRUST_ORDER.includes(state)) least = state;
+	}
+	return least;
+}
+
+export type ProvenanceReductionResult =
+	| { ok: true; provenance: DerivedFactProvenance }
+	| { ok: false; reason: string };
+
+export function reduceProvenance(
+	sources: Array<{
+		scope_id: string | null;
+		visibility: string | null;
+		workspace_id: string | null;
+		workspace_kind: string | null;
+		trust_state: string | null;
+		actor_id?: string | null;
+		actor_display_name?: string | null;
+		origin_device_id?: string | null;
+	}>,
+): ProvenanceReductionResult {
+	if (sources.length === 0) return { ok: false, reason: "no_sources" };
+	const first = sources[0];
+	if (!first) return { ok: false, reason: "no_sources" };
+	if (!first.scope_id || !first.visibility || !first.workspace_id || !first.workspace_kind) {
+		return { ok: false, reason: "missing_provenance" };
+	}
+	for (const source of sources) {
+		if (
+			source.scope_id !== first.scope_id ||
+			source.visibility !== first.visibility ||
+			source.workspace_id !== first.workspace_id ||
+			source.workspace_kind !== first.workspace_kind
+		) {
+			return { ok: false, reason: "mixed_provenance" };
+		}
+	}
+	return {
+		ok: true,
+		provenance: {
+			scope_id: first.scope_id,
+			visibility: first.visibility,
+			workspace_id: first.workspace_id,
+			workspace_kind: first.workspace_kind,
+			trust_state: leastTrustedState(sources.map((source) => source.trust_state)),
+			actor_id: first.actor_id ?? null,
+			actor_display_name: first.actor_display_name ?? null,
+			origin_device_id: first.origin_device_id ?? null,
+		},
+	};
+}
+
+export function kindForClaimType(
+	claimType: ClaimType | string,
+): "decision" | "bugfix" | "discovery" {
+	if (["gotcha", "failure", "failure-mode", "bugfix", "regression"].includes(claimType)) {
+		return "bugfix";
+	}
+	if (claimType === "locator") return "discovery";
+	return "decision";
+}
+
+export interface CorpusRow {
+	id: number;
+	session_id: number;
+	kind: string;
+	title: string;
+	body_text: string;
+	metadata_json: string | null;
+	created_at: string;
+	visibility: string | null;
+	workspace_id: string | null;
+	workspace_kind: string | null;
+	scope_id: string | null;
+	trust_state: string | null;
+	actor_id: string | null;
+	actor_display_name: string | null;
+	origin_device_id: string | null;
+	import_key: string | null;
+	session_import_key: string | null;
+	concepts: string | null;
+	files_read: string | null;
+	files_modified: string | null;
+}
+
+export interface DeriveBundle {
+	sessionId: number;
+	sessionImportKey: string | null;
+	sources: CorpusRow[];
+	summary: CorpusRow | null;
+}
+
+export interface SelectDeriveCorpusOptions {
+	createdAtFrom?: string;
+	createdAtTo?: string;
+	sessionIds?: number[];
+	limit?: number;
+	extractorVersion?: string;
+}
+
+function fromJsonObject(value: string | null): Record<string, unknown> {
+	if (!value) return {};
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>)
+			: {};
+	} catch {
+		return {};
+	}
+}
+
+function jsonList(value: string | null): string[] {
+	if (!value) return [];
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return Array.isArray(parsed)
+			? parsed.filter((item): item is string => typeof item === "string")
+			: [];
+	} catch {
+		return [];
+	}
+}
+
+export function selectDeriveCorpus(
+	store: MemoryStore,
+	opts: SelectDeriveCorpusOptions = {},
+): DeriveBundle[] {
+	const extractorVersion = opts.extractorVersion ?? DERIVE_EXTRACTOR_VERSION;
+	const limit = Math.max(1, Math.min(opts.limit ?? 100, 1000));
+	const createdAtFrom =
+		opts.createdAtFrom ?? new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+	// Exclude already-derived facts in SQL so the LIMIT is spent on candidate
+	// source rows, not previously-created derived facts (which we skip anyway).
+	const clauses = [
+		"m.active = 1",
+		"m.created_at >= ?",
+		"COALESCE(json_extract(m.metadata_json, '$.derivation.artifact_class'), '') != 'derived_fact'",
+	];
+	const params: unknown[] = [createdAtFrom];
+	if (opts.createdAtTo) {
+		clauses.push("m.created_at <= ?");
+		params.push(opts.createdAtTo);
+	}
+	if (opts.sessionIds && opts.sessionIds.length > 0) {
+		clauses.push(`m.session_id IN (${opts.sessionIds.map(() => "?").join(",")})`);
+		params.push(...opts.sessionIds);
+	}
+	const rows = store.db
+		.prepare(
+			`SELECT m.*, s.import_key AS session_import_key
+			 FROM memory_items m
+			 LEFT JOIN sessions s ON s.id = m.session_id
+			 WHERE ${clauses.join(" AND ")}
+			 ORDER BY m.created_at DESC, m.id DESC
+			 LIMIT ${limit}`,
+		)
+		.all(...params) as CorpusRow[];
+	const bySession = new Map<number, DeriveBundle>();
+	for (const row of rows) {
+		const metadata = fromJsonObject(row.metadata_json);
+		const derivation =
+			metadata.derivation && typeof metadata.derivation === "object"
+				? (metadata.derivation as Record<string, unknown>)
+				: {};
+		if (derivation.artifact_class === "derived_fact") continue;
+		if (
+			derivation.candidate === false &&
+			derivation.evaluated_extractor_version === extractorVersion
+		) {
+			continue;
+		}
+		let bundle = bySession.get(row.session_id);
+		if (!bundle) {
+			bundle = {
+				sessionId: row.session_id,
+				sessionImportKey: row.session_import_key,
+				sources: [],
+				summary: null,
+			};
+			bySession.set(row.session_id, bundle);
+		}
+		if (row.kind === "session_summary" || metadata.source === "observer_summary")
+			bundle.summary = row;
+		else bundle.sources.push(row);
+	}
+	return [...bySession.values()];
+}
+
+export interface DeriveClaimsOptions {
+	extractorVersion?: string;
+	fanOutCap?: number;
+}
+
+function durableSentence(text: string): string | null {
+	const sentences = text
+		.split(/(?<=[.!?])\s+/)
+		.map((part) => part.trim())
+		.filter(Boolean);
+	return (
+		sentences.find((sentence) =>
+			/\b(?:must|should|shall|requires?|depends? on|relies on|only after|works when|fails when|throws if|source of truth|non-goals?|preferred|look in)\b/i.test(
+				sentence,
+			),
+		) ??
+		sentences[0] ??
+		null
+	);
+}
+
+function claimTypeFromReasons(reasons: MemoryWorthinessReason[]): ClaimType {
+	if (reasons.includes("troubleshooting_gotcha")) return "gotcha";
+	if (reasons.includes("future_actionable_location")) return "locator";
+	if (reasons.includes("durable_decision")) return "decision";
+	if (reasons.includes("implementation_contract") || reasons.includes("modal_contract"))
+		return "contract";
+	return "decision";
+}
+
+function groundingTokenFor(sentence: string, row: CorpusRow, sourceBodies: string[]): string[] {
+	const files = [...jsonList(row.files_modified), ...jsonList(row.files_read)];
+	const fileToken = files.find((file) =>
+		sourceBodies.some((body) => body.toLowerCase().includes(file.toLowerCase())),
+	);
+	if (fileToken) return [fileToken];
+	const word = sentence.match(/\b[a-z][a-z0-9_-]{4,}\b/i)?.[0];
+	return word ? [word] : [];
+}
+
+export function deriveClaimsFromBundle(
+	bundle: DeriveBundle,
+	opts: DeriveClaimsOptions = {},
+): DerivedFactInput[] {
+	const extractorVersion = opts.extractorVersion ?? DERIVE_EXTRACTOR_VERSION;
+	const fanOutCap = opts.fanOutCap ?? 5;
+	// Grounding corpus includes titles + bodies (durable content is often in the
+	// title, e.g. title "Handlers must return structured errors" / body "Use them").
+	const sourceBodies = [
+		...bundle.sources.flatMap((row) => [row.title, row.body_text]),
+		bundle.summary?.title ?? "",
+		bundle.summary?.body_text ?? "",
+	].filter(Boolean);
+	const candidates = [...bundle.sources, ...(bundle.summary ? [bundle.summary] : [])];
+	const claims: DerivedFactInput[] = [];
+	for (const row of candidates) {
+		if (claims.length >= fanOutCap) break;
+		const text = `${row.title}. ${row.body_text}`;
+		const metadata = fromJsonObject(row.metadata_json);
+		const classifierKind = row.kind === "session_summary" ? "decision" : row.kind;
+		const classification = classifyMemoryWorthiness({
+			kind: classifierKind,
+			title: row.title,
+			body_text: row.body_text,
+			metadata: row.kind === "session_summary" ? {} : metadata,
+		});
+		if (classification.artifact !== "derived_fact") continue;
+		const sentence = durableSentence(text);
+		if (!sentence) continue;
+		const mustAppearTokens = groundingTokenFor(sentence, row, sourceBodies);
+		if (!groundingTokensPresent({ mustAppearTokens, sourceBodies })) continue;
+		const provenanceSources = [
+			row,
+			...(bundle.summary && bundle.summary.id !== row.id ? [bundle.summary] : []),
+		];
+		const provenance = reduceProvenance(provenanceSources);
+		if (!provenance.ok) continue;
+		const concepts = jsonList(row.concepts);
+		const filesRead = jsonList(row.files_read);
+		const filesModified = jsonList(row.files_modified);
+		const claimType = claimTypeFromReasons(classification.reasons);
+		const title = sentence.length > 120 ? `${sentence.slice(0, 117).trim()}...` : sentence;
+		const scopeKey = computeScopeKey({ filesModified, filesRead, concepts });
+		claims.push({
+			sessionId: bundle.sessionId,
+			kind: kindForClaimType(claimType),
+			title,
+			bodyText: sentence,
+			confidence: 0.7,
+			narrative: sentence,
+			facts: [sentence],
+			concepts,
+			filesRead,
+			filesModified,
+			provenance: provenance.provenance,
+			derivation: {
+				claim_type: claimType,
+				claim_key: computeClaimKey({ claimType, scopeKey, title }),
+				extractor_version: extractorVersion,
+				source: {
+					session_ids: [bundle.sessionId],
+					memory_ids: row.kind === "session_summary" ? [] : [row.id],
+					summary_memory_id: bundle.summary?.id ?? null,
+					session_import_keys: bundle.sessionImportKey ? [bundle.sessionImportKey] : [],
+					memory_import_keys:
+						row.kind === "session_summary" || !row.import_key ? [] : [row.import_key],
+					summary_memory_import_key: bundle.summary?.import_key ?? null,
+				},
+				grounding: {
+					concepts,
+					files: [...filesModified, ...filesRead],
+					must_appear_tokens: mustAppearTokens,
+				},
+			},
+		});
+	}
+	return claims;
+}
+
+export interface RunDerivePassOptions extends SelectDeriveCorpusOptions, DeriveClaimsOptions {
+	dryRun?: boolean;
+	skipVectorWrite?: boolean;
+}
+
+export interface DeriveRunResult {
+	consideredBundles: number;
+	consideredClaims: number;
+	inserted: number;
+	updated: number;
+	skipped_tombstone: number;
+	skipped_legacy_conflict: number;
+	dryRun: boolean;
+	results: DerivedFactResult[];
+}
+
+export function runDerivePass(
+	store: MemoryStore,
+	opts: RunDerivePassOptions = {},
+): DeriveRunResult {
+	const bundles = selectDeriveCorpus(store, opts);
+	const result: DeriveRunResult = {
+		consideredBundles: bundles.length,
+		consideredClaims: 0,
+		inserted: 0,
+		updated: 0,
+		skipped_tombstone: 0,
+		skipped_legacy_conflict: 0,
+		dryRun: opts.dryRun === true,
+		results: [],
+	};
+	for (const bundle of bundles) {
+		const claims = deriveClaimsFromBundle(bundle, opts);
+		result.consideredClaims += claims.length;
+		for (const claim of claims) {
+			if (opts.dryRun) continue;
+			const writeResult = store.upsertDerivedFact({
+				...claim,
+				options: { skipVectorWrite: opts.skipVectorWrite },
+			});
+			result.results.push(writeResult);
+			if (writeResult.outcome === "inserted") result.inserted++;
+			else if (writeResult.outcome === "updated") result.updated++;
+			else if (writeResult.outcome === "skipped_tombstone") result.skipped_tombstone++;
+			else result.skipped_legacy_conflict++;
+		}
+	}
+	return result;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -148,6 +148,7 @@ export {
 	hasPendingDedupKeyBackfill,
 	runDedupKeyBackfillPass,
 } from "./dedup-key-backfill.js";
+export * from "./derive.js";
 export type { EmbeddingClient } from "./embeddings.js";
 export {
 	_resetEmbeddingClient,
@@ -513,6 +514,7 @@ export {
 	SESSION_CONTEXT_BACKFILL_JOB,
 	SessionContextBackfillRunner,
 } from "./session-context-backfill.js";
+export type { DerivedFactInput, DerivedFactResult } from "./store.js";
 export { MemoryStore } from "./store.js";
 export {
 	hasPendingSummaryDedupBackfill,

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -1517,6 +1517,46 @@ describe("backfillMemoryDedupKeys", () => {
 		}
 	});
 
+	it("skips derived facts when backfilling dedup keys", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const now = new Date().toISOString();
+			const id = Number(
+				db
+					.prepare(
+						`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+						 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+						 workspace_id, dedup_key)
+						 VALUES (?, 'decision', 'Derived claim', 'Body', 0.7, '', 1, ?, ?, ?, 1, 'shared', 'shared:default', NULL)`,
+					)
+					.run(
+						sessionId,
+						now,
+						now,
+						JSON.stringify({
+							derivation: { artifact_class: "derived_fact", claim_key: "df:v1:x" },
+						}),
+					).lastInsertRowid,
+			);
+
+			const result = backfillMemoryDedupKeys(db);
+
+			expect(result).toMatchObject({ checked: 0, updated: 0, skipped: 0 });
+			const row = db.prepare("SELECT dedup_key FROM memory_items WHERE id = ?").get(id) as {
+				dedup_key: string | null;
+			};
+			expect(row.dedup_key).toBeNull();
+		} finally {
+			db.close();
+		}
+	});
+
 	it("respects dry-run mode", () => {
 		const db = new Database(":memory:");
 		try {

--- a/packages/core/src/maintenance/dedup-keys.ts
+++ b/packages/core/src/maintenance/dedup-keys.ts
@@ -51,6 +51,7 @@ function selectDedupKeyCandidateRows(
 			 FROM memory_items
 			 WHERE dedup_key IS NULL
 			   AND id > ?
+			   AND COALESCE(json_extract(metadata_json, '$.derivation.artifact_class'), '') != 'derived_fact'
 			 ORDER BY created_at ASC, id ASC
 			 ${limitClause}`,
 		)

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -9,7 +9,7 @@
  * `codemem db init` invocation first.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { statSync } from "node:fs";
 import { and, desc, eq, gt, inArray, isNotNull, lt, lte, or, type SQL, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -139,6 +139,22 @@ function cleanStr(value: unknown): string | null {
 	return trimmed.length > 0 ? trimmed : null;
 }
 
+// Trust tiers from most- to least-trusted. A missing/blank/unknown value is
+// treated as the least-trusted tier so derived-fact merges never launder trust.
+const TRUST_TIER_ORDER = ["trusted", "unreviewed", "legacy_unknown", "untrusted"];
+
+/** Return the least-trusted of two trust states (never upgrades). */
+function leastTrustedOf(a: string | null | undefined, b: string | null | undefined): string {
+	const rank = (state: string | null | undefined): number => {
+		const value = state?.trim() || "legacy_unknown";
+		const idx = TRUST_TIER_ORDER.indexOf(value);
+		return idx === -1 ? TRUST_TIER_ORDER.length : idx; // unknown => least trusted
+	};
+	const aClean = a?.trim() || "legacy_unknown";
+	const bClean = b?.trim() || "legacy_unknown";
+	return rank(a) >= rank(b) ? aClean : bClean;
+}
+
 function parseJsonList(value: unknown): string[] {
 	if (typeof value !== "string" || !value.trim()) return [];
 	try {
@@ -152,6 +168,79 @@ function parseJsonList(value: unknown): string[] {
 	} catch {
 		return [];
 	}
+}
+
+function stringArrayFromUnknown(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return [
+		...new Set(
+			value
+				.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+				.map((item) => item.trim()),
+		),
+	];
+}
+
+function numberArrayFromUnknown(value: unknown): number[] {
+	if (!Array.isArray(value)) return [];
+	return [
+		...new Set(
+			value.map((item) => Number(item)).filter((item) => Number.isInteger(item) && item > 0),
+		),
+	];
+}
+
+function normalizeDerivedFactSource(source: DerivedFactSource): Record<string, unknown> {
+	const normalized: Record<string, unknown> = {
+		session_ids: numberArrayFromUnknown(source.session_ids),
+		memory_ids: numberArrayFromUnknown(source.memory_ids),
+		session_import_keys: stringArrayFromUnknown(source.session_import_keys),
+		memory_import_keys: stringArrayFromUnknown(source.memory_import_keys),
+	};
+	const summaryMemoryId = Number(source.summary_memory_id);
+	if (Number.isInteger(summaryMemoryId) && summaryMemoryId > 0) {
+		normalized.summary_memory_id = summaryMemoryId;
+	}
+	const summaryImportKey = cleanStr(source.summary_memory_import_key);
+	if (summaryImportKey) normalized.summary_memory_import_key = summaryImportKey;
+	return normalized;
+}
+
+function unionDerivedFactSource(
+	existing: Record<string, unknown>,
+	incoming: DerivedFactSource,
+): Record<string, unknown> {
+	const incomingNormalized = normalizeDerivedFactSource(incoming);
+	const unionNumbers = (key: string): number[] =>
+		[
+			...new Set([
+				...numberArrayFromUnknown(existing[key]),
+				...numberArrayFromUnknown(incomingNormalized[key]),
+			]),
+		].sort((a, b) => a - b);
+	const unionStrings = (key: string): string[] =>
+		[
+			...new Set([
+				...stringArrayFromUnknown(existing[key]),
+				...stringArrayFromUnknown(incomingNormalized[key]),
+			]),
+		].sort();
+	const next: Record<string, unknown> = {
+		...existing,
+		session_ids: unionNumbers("session_ids"),
+		memory_ids: unionNumbers("memory_ids"),
+		session_import_keys: unionStrings("session_import_keys"),
+		memory_import_keys: unionStrings("memory_import_keys"),
+	};
+	if (incomingNormalized.summary_memory_id != null)
+		next.summary_memory_id = incomingNormalized.summary_memory_id;
+	else if (existing.summary_memory_id != null) next.summary_memory_id = existing.summary_memory_id;
+	if (incomingNormalized.summary_memory_import_key != null) {
+		next.summary_memory_import_key = incomingNormalized.summary_memory_import_key;
+	} else if (existing.summary_memory_import_key != null) {
+		next.summary_memory_import_key = existing.summary_memory_import_key;
+	}
+	return next;
 }
 
 function projectBasename(value: string | null | undefined): string {
@@ -172,6 +261,63 @@ type DedupHit = {
 	id: number;
 	scope: "same_session" | "cross_session";
 };
+
+export interface DerivedFactSource {
+	session_ids?: number[];
+	memory_ids?: number[];
+	summary_memory_id?: number | null;
+	session_import_keys?: string[];
+	memory_import_keys?: string[];
+	summary_memory_import_key?: string | null;
+}
+
+export interface DerivedFactProvenance {
+	scope_id: string;
+	visibility: "private" | "shared" | string;
+	workspace_id: string;
+	workspace_kind: "personal" | "shared" | string;
+	trust_state: string;
+	actor_id?: string | null;
+	actor_display_name?: string | null;
+	origin_device_id?: string | null;
+}
+
+export interface DerivedFactInput {
+	sessionId: number;
+	kind: string;
+	title: string;
+	bodyText: string;
+	confidence?: number;
+	subtitle?: string | null;
+	narrative?: string | null;
+	facts?: string[] | null;
+	concepts?: string[] | null;
+	filesRead?: string[] | null;
+	filesModified?: string[] | null;
+	derivation: {
+		claim_type: string;
+		claim_key: string;
+		extractor_version: string;
+		source: DerivedFactSource;
+		grounding: {
+			concepts?: string[];
+			files?: string[];
+			must_appear_tokens: string[];
+		};
+		confidence?: number;
+		supersedes?: number | string | null;
+	};
+	provenance: DerivedFactProvenance;
+	options?: {
+		skipVectorWrite?: boolean;
+	};
+}
+
+export type DerivedFactResult =
+	| { outcome: "inserted"; id: number }
+	| { outcome: "updated"; id: number }
+	| { outcome: "skipped_tombstone"; id: number }
+	| { outcome: "skipped_legacy_conflict"; id: number };
 
 function getMemoryDedupMatchText(title: string): string | null {
 	const normalized = normalizeMemoryDedupTitle(title);
@@ -776,6 +922,256 @@ export class MemoryStore {
 		}
 
 		return memoryId;
+	}
+
+	upsertDerivedFact(input: DerivedFactInput): DerivedFactResult {
+		const validKind = validateMemoryKind(input.kind);
+		if (validKind === "session_summary") {
+			throw new Error("derived facts must use a non-summary memory kind");
+		}
+		const claimKey = cleanStr(input.derivation.claim_key);
+		if (!claimKey) throw new Error("derived fact claim_key is required");
+		const scopeId = cleanStr(input.provenance.scope_id);
+		if (!scopeId) throw new Error("derived fact scope_id is required");
+		// Provenance must be explicit — do NOT fail open to the most-privileged
+		// values. Defaulting visibility->"shared" or trust_state->"trusted" would
+		// launder a private/unreviewed source into shared/trusted (search trust-bias
+		// + sync exposure). Require them, mirroring scope_id/workspace_id.
+		const visibility = cleanStr(input.provenance.visibility);
+		if (!visibility) throw new Error("derived fact visibility is required");
+		const workspaceId = cleanStr(input.provenance.workspace_id);
+		if (!workspaceId) throw new Error("derived fact workspace_id is required");
+		const workspaceKind = cleanStr(input.provenance.workspace_kind);
+		if (!workspaceKind) throw new Error("derived fact workspace_kind is required");
+		const trustState = cleanStr(input.provenance.trust_state);
+		if (!trustState) throw new Error("derived fact trust_state is required");
+		this.assertSharedMutationAllowed(visibility);
+
+		const now = nowIso();
+		const scanner = this.scanner;
+		const titleScan = scanner.scan(input.title);
+		const bodyScan = scanner.scan(input.bodyText);
+		const safeTitle = titleScan.redacted;
+		const safeBody = bodyScan.redacted;
+		const safeFacts = scanner.redactValue(input.facts ?? null);
+		const safeConcepts = scanner.redactValue(input.concepts ?? null);
+		const safeFilesRead = scanner.redactValue(input.filesRead ?? null);
+		const safeFilesModified = scanner.redactValue(input.filesModified ?? null);
+
+		let result!: DerivedFactResult;
+		let vectorTitle = safeTitle;
+		let vectorBody = safeBody;
+		this.db.transaction(() => {
+			const existingDerived = this.db
+				.prepare(
+					`SELECT id, active, deleted_at, metadata_json, rev, title, body_text, trust_state
+					 FROM memory_items
+					 WHERE scope_id = ?
+					   AND dedup_key = ?
+					   AND json_extract(metadata_json, '$.derivation.artifact_class') = 'derived_fact'
+					 ORDER BY (deleted_at IS NULL) DESC, id DESC
+					 LIMIT 1`,
+				)
+				.get(scopeId, claimKey) as
+				| {
+						id: number;
+						active: number | null;
+						deleted_at: string | null;
+						metadata_json: string | null;
+						rev: number | null;
+						title: string;
+						body_text: string;
+						trust_state: string | null;
+				  }
+				| undefined;
+
+			if (existingDerived) {
+				if (Number(existingDerived.active ?? 1) === 0 || existingDerived.deleted_at != null) {
+					result = { outcome: "skipped_tombstone", id: Number(existingDerived.id) };
+					return;
+				}
+				const existingMeta = fromJson(existingDerived.metadata_json);
+				const existingDerivation =
+					existingMeta.derivation && typeof existingMeta.derivation === "object"
+						? (existingMeta.derivation as Record<string, unknown>)
+						: {};
+				const existingSource =
+					existingDerivation.source && typeof existingDerivation.source === "object"
+						? (existingDerivation.source as Record<string, unknown>)
+						: {};
+				const nextSource = unionDerivedFactSource(existingSource, input.derivation.source);
+				const nextMeta = {
+					...existingMeta,
+					clock_device_id: this.deviceId,
+					derivation: {
+						...existingDerivation,
+						extractor: "derive-batch",
+						extractor_version: input.derivation.extractor_version,
+						claim_key: claimKey,
+						derived_at: now,
+						source: nextSource,
+					},
+				};
+				const metaScan = scanner.redactValue(nextMeta);
+				const safeMeta = metaScan.value as Record<string, unknown>;
+				const rev = Number(existingDerived.rev ?? 0) + 1;
+				// Trust can only ratchet DOWN on merge: if a later, less-trusted
+				// source contributes to an existing derived fact, lower its
+				// trust_state to the least-trusted of the two (never upgrade).
+				const mergedTrust = leastTrustedOf(existingDerived.trust_state, trustState);
+				this.d
+					.update(schema.memoryItems)
+					.set({
+						updated_at: now,
+						metadata_json: toJson(safeMeta),
+						rev,
+						trust_state: mergedTrust,
+					})
+					.where(eq(schema.memoryItems.id, existingDerived.id))
+					.run();
+				recordReplicationOp(this.db, {
+					memoryId: existingDerived.id,
+					opType: "upsert",
+					deviceId: this.deviceId,
+				});
+				const detections = mergeDetections(metaScan.detections);
+				if (detections.length > 0)
+					this.logSecretRedactions(existingDerived.id, validKind, detections);
+				vectorTitle = existingDerived.title;
+				vectorBody = existingDerived.body_text;
+				result = { outcome: "updated", id: Number(existingDerived.id) };
+				return;
+			}
+
+			const legacyConflict = this.db
+				.prepare(
+					`SELECT id
+					 FROM memory_items
+					 WHERE active = 1
+					   AND scope_id = ?
+					   AND dedup_key = ?
+					   AND COALESCE(json_extract(metadata_json, '$.derivation.artifact_class'), '') != 'derived_fact'
+					 ORDER BY id DESC
+					 LIMIT 1`,
+				)
+				.get(scopeId, claimKey) as { id: number } | undefined;
+			if (legacyConflict) {
+				result = { outcome: "skipped_legacy_conflict", id: Number(legacyConflict.id) };
+				return;
+			}
+
+			const sessionProject = (this.d
+				.select({ project: schema.sessions.project })
+				.from(schema.sessions)
+				.where(eq(schema.sessions.id, input.sessionId))
+				.get()?.project ?? null) as string | null;
+			const importKey = `df:${createHash("sha256").update(`${scopeId}\u241f${claimKey}`).digest("hex")}`;
+			const confidence = input.confidence ?? input.derivation.confidence ?? 0.7;
+			const facts = Array.isArray(safeFacts.value) ? (safeFacts.value as string[]) : null;
+			const concepts = Array.isArray(safeConcepts.value) ? (safeConcepts.value as string[]) : null;
+			const filesRead = Array.isArray(safeFilesRead.value)
+				? (safeFilesRead.value as string[])
+				: null;
+			const filesModified = Array.isArray(safeFilesModified.value)
+				? (safeFilesModified.value as string[])
+				: null;
+			const metaPayload = {
+				clock_device_id: this.deviceId,
+				import_key: importKey,
+				subtitle: input.subtitle ?? undefined,
+				narrative: input.narrative ?? undefined,
+				facts: facts ?? undefined,
+				concepts: concepts ?? undefined,
+				files_read: filesRead ?? undefined,
+				files_modified: filesModified ?? undefined,
+				visibility,
+				workspace_id: workspaceId,
+				workspace_kind: workspaceKind,
+				trust_state: trustState,
+				origin_source: "derive-batch",
+				origin_device_id: cleanStr(input.provenance.origin_device_id) ?? this.deviceId,
+				actor_id: cleanStr(input.provenance.actor_id) ?? this.actorId,
+				actor_display_name: cleanStr(input.provenance.actor_display_name) ?? this.actorDisplayName,
+				derivation: {
+					artifact_class: "derived_fact",
+					extractor: "derive-batch",
+					extractor_version: input.derivation.extractor_version,
+					claim_type: input.derivation.claim_type,
+					claim_key: claimKey,
+					source: normalizeDerivedFactSource(input.derivation.source),
+					grounding: input.derivation.grounding,
+					derived_at: now,
+					confidence,
+					...(input.derivation.supersedes != null
+						? { supersedes: input.derivation.supersedes }
+						: {}),
+				},
+			};
+			const metaScan = scanner.redactValue(metaPayload);
+			const safeMeta = metaScan.value as Record<string, unknown>;
+			const insertedRows = this.d
+				.insert(schema.memoryItems)
+				.values({
+					session_id: input.sessionId,
+					kind: validKind,
+					title: safeTitle,
+					subtitle: input.subtitle ?? null,
+					body_text: safeBody,
+					confidence,
+					tags_text: "",
+					active: 1,
+					created_at: now,
+					updated_at: now,
+					metadata_json: toJson(safeMeta),
+					actor_id: cleanStr(input.provenance.actor_id) ?? this.actorId,
+					actor_display_name:
+						cleanStr(input.provenance.actor_display_name) ?? this.actorDisplayName,
+					visibility,
+					workspace_id: workspaceId,
+					workspace_kind: workspaceKind,
+					origin_device_id: cleanStr(input.provenance.origin_device_id) ?? this.deviceId,
+					origin_source: "derive-batch",
+					trust_state: trustState,
+					narrative: input.narrative ?? null,
+					facts: toJsonNullable(facts),
+					concepts: toJsonNullable(concepts),
+					files_read: toJsonNullable(filesRead),
+					files_modified: toJsonNullable(filesModified),
+					prompt_number: null,
+					user_prompt_id: null,
+					deleted_at: null,
+					rev: 1,
+					dedup_key: claimKey,
+					import_key: importKey,
+					scope_id: scopeId,
+					project: sessionProject,
+				})
+				.returning({ id: schema.memoryItems.id })
+				.all();
+			const id = insertedRows[0]?.id;
+			if (id == null) throw new Error("derived fact insert returned no id");
+			populateMemoryRefs(this.db, id, filesRead, filesModified, concepts);
+			recordReplicationOp(this.db, { memoryId: id, opType: "upsert", deviceId: this.deviceId });
+			const detections = mergeDetections(
+				titleScan.detections,
+				bodyScan.detections,
+				safeFacts.detections,
+				safeConcepts.detections,
+				safeFilesRead.detections,
+				safeFilesModified.detections,
+				metaScan.detections,
+			);
+			if (detections.length > 0) this.logSecretRedactions(id, validKind, detections);
+			result = { outcome: "inserted", id };
+		})();
+
+		if (
+			(result.outcome === "inserted" || result.outcome === "updated") &&
+			input.options?.skipVectorWrite !== true
+		) {
+			this.enqueueVectorWrite(result.id, vectorTitle, vectorBody);
+		}
+		return result;
 	}
 
 	/**

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -3666,14 +3666,14 @@ describe("replication payload round-trip parity", () => {
 				actor_id, actor_display_name, visibility, workspace_id,
 				workspace_kind, origin_device_id, origin_source, trust_state,
 				narrative, facts, concepts, files_read, files_modified,
-				user_prompt_id, prompt_number, import_key, rev
+				user_prompt_id, prompt_number, import_key, rev, dedup_key
 			) VALUES (
 				?, 'decision', 'Round Trip Title', 'Sub', 'Body text here', 0.85,
 				'tag-a tag-b', 1, ?, ?, '{"custom_key":"custom_val"}',
 				'actor-rt', 'Actor Name', 'shared', 'ws-1',
 				'shared', 'device-origin', 'test', 'trusted',
 				'A narrative', '["fact-1"]', '["concept-1"]', '["file-a"]', '["file-b"]',
-				42, 7, 'roundtrip-key-1', 1
+				42, 7, 'roundtrip-key-1', 1, 'dedup:roundtrip'
 			)
 		`).run(sessionId, now, now);
 
@@ -3729,6 +3729,7 @@ describe("replication payload round-trip parity", () => {
 		expect(payload.narrative).toBe("A narrative");
 		expect(payload.user_prompt_id).toBe(42);
 		expect(payload.prompt_number).toBe(7);
+		expect(payload.dedup_key).toBe("dedup:roundtrip");
 
 		// Now apply this op on a "target" DB (same DB, different import key scenario)
 		// Delete the original memory AND the recorded op so the apply treats this as new
@@ -3780,6 +3781,40 @@ describe("replication payload round-trip parity", () => {
 		expect(applied.narrative).toBe("A narrative");
 		expect(applied.user_prompt_id).toBe(42);
 		expect(applied.prompt_number).toBe(7);
+		expect(applied.dedup_key).toBe("dedup:roundtrip");
+	});
+
+	it("preserves existing dedup_key when older peers omit it on update", () => {
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, confidence, tags_text, active,
+			 created_at, updated_at, metadata_json, import_key, rev, dedup_key)
+			 VALUES (?, 'decision', 'Old', 'Old body', 0.5, '', 1, ?, ?, ?, 'older-peer-key', 1, 'dedup:keep')`,
+		).run(sessionId, now, now, toJson({ clock_device_id: "remote-device" }));
+
+		const op: ReplicationOp = {
+			op_id: "older-peer-dedup-omitted",
+			entity_type: "memory_item",
+			entity_id: "older-peer-key",
+			op_type: "upsert",
+			payload_json: toJson({
+				title: "New",
+				body_text: "New body",
+				updated_at: "2026-01-02T00:00:00Z",
+			}),
+			clock_rev: 2,
+			clock_updated_at: "2026-01-02T00:00:00Z",
+			clock_device_id: "remote-device",
+			device_id: "remote-device",
+			created_at: "2026-01-02T00:00:00Z",
+			scope_id: null,
+		};
+
+		expect(applyReplicationOps(db, [op], "local-device").applied).toBe(1);
+		const row = db
+			.prepare("SELECT dedup_key FROM memory_items WHERE import_key = ?")
+			.get("older-peer-key") as { dedup_key: string | null };
+		expect(row.dedup_key).toBe("dedup:keep");
 	});
 });
 

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -138,6 +138,7 @@ interface MemoryPayload {
 	has_deleted_at: boolean;
 	rev: number;
 	import_key: string | null;
+	dedup_key: string | null;
 	project?: string | null;
 }
 
@@ -239,6 +240,7 @@ function parseMemoryPayload(op: ReplicationOp, errors: string[]): MemoryPayload 
 		has_deleted_at: Object.hasOwn(raw, "deleted_at"),
 		rev: asNumberOrNull(raw.rev) ?? 0,
 		import_key: asStringOrNull(raw.import_key),
+		dedup_key: asStringOrNull(raw.dedup_key),
 		project: asStringOrNull(raw.project),
 	};
 }
@@ -882,6 +884,7 @@ export function recordReplicationOp(
 			prompt_number: row.prompt_number,
 			deleted_at: row.deleted_at,
 			scope_id: scopeId,
+			dedup_key: row.dedup_key,
 		});
 	} else {
 		payloadJson = null;
@@ -3033,6 +3036,7 @@ function buildPayloadFromMemoryRow(row: MemoryItemRow): MemoryPayload {
 		has_deleted_at: row.deleted_at != null,
 		rev: row.rev ?? 0,
 		import_key: row.import_key ?? null,
+		dedup_key: row.dedup_key ?? null,
 		// Denormalized project from memory_items so the outbound payload
 		// carries it without a session join. Callers may still override with
 		// sessions.project for legacy rows whose memory_items.project is null.
@@ -3243,6 +3247,7 @@ export function applyReplicationOps(
 								user_prompt_id: payload.user_prompt_id,
 								prompt_number: payload.prompt_number,
 								scope_id: sql`COALESCE(${opScopeId}, ${schema.memoryItems.scope_id})`,
+								dedup_key: sql`COALESCE(${payload.dedup_key}, ${schema.memoryItems.dedup_key})`,
 								// Backfill project on existing rows when the inbound
 								// payload carries it; preserve the existing value when
 								// the sender (older code) omitted the field.
@@ -3316,6 +3321,7 @@ export function applyReplicationOps(
 								user_prompt_id: payload.user_prompt_id,
 								prompt_number: payload.prompt_number,
 								scope_id: opScopeId,
+								dedup_key: payload.dedup_key ?? null,
 								// Persist replicated project name so the Projects read
 								// model can surface this memory under its originating
 								// project identity without joining through sessions.


### PR DESCRIPTION
## Description
Implements the derived-fact derivation pass (codemem-ovk2.11) — the durable 'what future work should remember' layer. Implements design C1-C16 from docs/plans/2026-06-29-derived-fact-derivation-design.md.

Core:
- store.upsertDerivedFact(input): dedicated derived-fact write path that BYPASSES remember()/legacy title dedup (C4). Sets dedup_key=claim_key (C2), inherits scope/visibility/workspace/trust_state from provenance (C1/C16), deterministic import_key=df:<sha256(scope␟claim)>, origin_source=derive-batch, confidence default 0.7, full secret-scan/redaction parity, populateMemoryRefs, replication op; vector enqueue AFTER commit. Tombstone-aware idempotency => skipped_tombstone (C11); active legacy collision => skipped_legacy_conflict; re-run unions provenance source without rewriting title/body.
- packages/core/src/derive.ts: pure helpers (computeClaimKey [excludes grounding tokens, C12], computeScopeKey, groundingTokensPresent [includes summary body, C3], reduceProvenance [rejects mixed; least-trusted], leastTrustedState, kindForClaimType) + bounded selectDeriveCorpus (C14, no index) + deriveClaimsFromBundle (reuses classifyMemoryWorthiness) + runDerivePass.

Sync (C7/C8): dedup_key added additively to MemoryPayload/parse/outbound/apply with COALESCE on update so older peers can't clobber it; provenance stores stable import_keys, not local row ids. No SCHEMA_VERSION bump.

Maintenance: dedup-key backfill skips derived_fact rows so a claim_key is never overwritten with a title hash.

Security hardening (review): upsertDerivedFact now REQUIRES explicit visibility/workspace_kind/trust_state (throws on blank) instead of fail-open defaulting to shared/trusted — prevents laundering a private/unreviewed source. Regression tests included.

Upgrade-safe: additive only, no schema/kind/version change, idempotent, no hard delete.

Tracking: codemem-ovk2.11.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance
- [x] 🧪 Testing

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

vitest derive + store + sync-replication + maintenance = 333 pass (14 derive incl. tombstone, legacy-conflict, idempotency, title-dedup bypass, private/unreviewed preservation, mixed-provenance reject, fail-closed provenance); tsc; lint green. Independent CodeReviewer pass; flagged fail-open provenance defaults which were hardened. Note: 3 pre-existing claude-hooks.test.ts failures are an unrelated @codemem/core build-resolution issue (reproduces without this change).

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
