### PR TITLE
fix(docker): persist MCP OAuth state

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update \
 RUN npm install -g "codemem@${CODEMEM_VERSION}" \
 	&& npm cache clean --force
 
-RUN mkdir -p /data /config /keys /app \
-	&& chown -R node:node /data /config /keys /app
+RUN mkdir -p /data /config /keys /app /home/node/.codemem \
+	&& chown -R node:node /data /config /keys /app /home/node/.codemem
 
 WORKDIR /app
 USER node

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -114,12 +114,18 @@ Compose creates named volumes:
 - `codemem-data` for `/data/mem.sqlite`
 - `codemem-config` for `/config/codemem.json`
 - `codemem-keys` for sync keys and peer identity material
+- `codemem-home` for `/home/node/.codemem`, including hosted-connector OAuth state
 
 Both services use the same database path:
 
 ```text
 /data/mem.sqlite
 ```
+
+The MCP service stores dynamically registered hosted-connector clients and token hashes
+in `/home/node/.codemem/mcp-oauth-state.json`. Keep `codemem-home` mounted across
+image upgrades and container recreates so Claude, ChatGPT, and other hosted MCP clients
+do not lose their registered `client_id`s after a redeploy.
 
 ## Observer credentials
 
@@ -140,12 +146,6 @@ OPENCODE_API_KEY=...
 
 Do not bake observer API keys into the Dockerfile or committed Compose file. Put them in
 the local `.env`, Docker secrets, or the container manager's private environment settings.
-
-## Current limitation
-
-MCP OAuth state is currently process-local in codemem. If the MCP container restarts,
-Claude may need to re-run the connector authorization flow until durable OAuth storage
-is implemented.
 
 ## Useful commands
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - codemem-data:/data
       - codemem-config:/config
       - codemem-keys:/keys
+      - codemem-home:/home/node/.codemem
     restart: unless-stopped
     healthcheck:
       test:
@@ -99,6 +100,7 @@ services:
       - codemem-data:/data
       - codemem-config:/config
       - codemem-keys:/keys
+      - codemem-home:/home/node/.codemem
     restart: unless-stopped
     healthcheck:
       test:
@@ -118,3 +120,4 @@ volumes:
   codemem-data:
   codemem-config:
   codemem-keys:
+  codemem-home:

--- a/deploy/docker/environment.example
+++ b/deploy/docker/environment.example
@@ -20,7 +20,7 @@ CODEMEM_SYNC_ADVERTISE=http://your-nas-tailnet-name:7337
 # Cloudflare Tunnel, or another TLS ingress. Must include /mcp.
 CODEMEM_MCP_HTTP_PUBLIC_URL=https://your-host.example/mcp
 
-# Upstream OIDC provider used for Claude custom connector authorization.
+# Upstream OIDC provider used for hosted MCP connector authorization.
 CODEMEM_MCP_OIDC_ISSUER_URL=https://accounts.google.com
 CODEMEM_MCP_OIDC_CLIENT_ID=replace-me
 CODEMEM_MCP_OIDC_CLIENT_SECRET=replace-me


### PR DESCRIPTION
## Description
Persist the Docker MCP service home directory so hosted MCP OAuth dynamic-registration state survives image upgrades and container recreates.

This mounts `/home/node/.codemem` as a named volume and documents that `mcp-oauth-state.json` stores registered hosted-connector clients and token hashes.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)

## Testing

- [x] Manually verified changes work as expected

```fish
docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/environment.example config
```

## Checklist

- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
