### PR TITLE
feat(distill): judge candidates for durable-lesson worthiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,12 @@ Pack rendering defaults to self-contained context. For token-constrained experim
 ```text
 codemem distill --explain               # ranked candidates + evidence
 codemem distill --all-projects --json   # machine-readable
+codemem distill --no-judge              # skip the observer-model worthiness judgment
 codemem distill --draft                 # draft an AGENTS.md rule for the top candidate and show a diff
 codemem distill --draft --apply         # write it after confirmation
 ```
 
-Candidate mining is deterministic. `--draft` uses your configured observer model to turn the top candidate into a single `AGENTS.md` rule and renders a unified diff; nothing is written. `--apply` writes that rule into a codemem-managed `## Distilled lessons` block (delimited by `<!-- codemem:distilled:begin/end -->` markers, so all distilled edits stay in one place) after prompting for confirmation.
+Candidate mining is deterministic, and by default an observer-model worthiness pass then drops clusters of recurring routine activity (release/CI status, review passes with no findings, context lookups) that recurrence scoring cannot distinguish from real lessons. Without a configured observer model the command falls back to unjudged output with a warning; `--no-judge` opts out entirely. `--draft` uses your configured observer model to turn the top candidate into a single `AGENTS.md` rule and renders a unified diff; nothing is written. `--apply` writes that rule into a codemem-managed `## Distilled lessons` block (delimited by `<!-- codemem:distilled:begin/end -->` markers, so all distilled edits stay in one place) after prompting for confirmation.
 
 ## MCP tools
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -186,12 +186,18 @@ The MCP server exposes memory retrieval and write tools such as `memory_search`,
 `memory_pack`, `memory_recent`, `memory_remember`, and `memory_forget`.
 
 `memory_distill_candidates` mines recurring lessons into reviewable context
-candidates. It is read-only and does not modify documentation files.
+candidates. It is read-only and does not modify documentation files. By
+default an observer-model worthiness pass drops routine-activity clusters
+(release/CI status, review passes with no findings, context lookups) before
+the candidates are returned; pass `judge: false` to skip it. When no observer
+model is configured the tool returns unjudged output with `judged: false` and
+a `judge_error` in the metadata.
 
 Example agent requests:
 
 - "Find recurring project lessons worth adding to AGENTS.md."
 - "Run distill for all projects and show top candidates."
+- "Distill without judging so I can see the raw recurrence ranking."
 
 ## Observer model defaults
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -117,6 +117,7 @@ Use `codemem distill` to find lessons that keep showing up in memory history.
 ```fish
 codemem distill --explain
 codemem distill --all-projects --json
+codemem distill --no-judge       # skip the observer-model worthiness judgment
 codemem distill --draft          # draft an AGENTS.md rule for the top candidate + diff
 codemem distill --draft --apply  # write it after confirmation
 ```
@@ -125,6 +126,7 @@ Candidate mining is deterministic and review-first:
 
 - `project` candidates target that repo's `AGENTS.md`; `user` candidates target global/user context.
 - Without `--draft`, the command only emits ranked candidates and evidence (`draft_text` is null).
+- Candidates are judged by default: one short observer-model call per candidate drops clusters that are recurring *activity* (release/CI status, review passes with no findings, context lookups) rather than recurring *lessons* — recurrence alone cannot tell these apart. Unjudgeable candidates are kept and marked `unjudged`. When no observer model is configured, the command falls back to unjudged output with a warning; `--no-judge` skips the judgment (and its model calls) entirely.
 - `--draft` uses your configured observer model to write one concise rule for the top candidate and prints a unified diff; it does not write anything.
 - `--apply` (implies `--draft`) writes the rule into a codemem-managed `## Distilled lessons` block, delimited by `<!-- codemem:distilled:begin/end -->` markers so every distilled edit stays in one place. It prompts before writing (except with `--json`, which is non-interactive — there `--apply` itself is the explicit consent and the write happens immediately) and appends only (never deletes your existing notes).
 

--- a/packages/cli/src/commands/distill.test.ts
+++ b/packages/cli/src/commands/distill.test.ts
@@ -122,6 +122,7 @@ describe("distill command", () => {
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
 		await parseDistillCommand([
+			"--no-judge",
 			"--json",
 			"--db-path",
 			"memory.sqlite",
@@ -210,7 +211,7 @@ describe("distill command", () => {
 		});
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-		await parseDistillCommand(["--draft", "--json"]);
+		await parseDistillCommand(["--no-judge", "--draft", "--json"]);
 
 		expect(mocks.observe).toHaveBeenCalledTimes(1);
 		const out = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
@@ -225,7 +226,7 @@ describe("distill command", () => {
 		mocks.observe.mockRejectedValue(new Error("no observer auth configured"));
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-		await parseDistillCommand(["--draft", "--json"]);
+		await parseDistillCommand(["--no-judge", "--draft", "--json"]);
 
 		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({
 			error: "draft_failed",
@@ -238,7 +239,7 @@ describe("distill command", () => {
 		mocks.observe.mockResolvedValue({ raw: "SKIP" });
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-		await parseDistillCommand(["--draft", "--json"]);
+		await parseDistillCommand(["--no-judge", "--draft", "--json"]);
 
 		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({
 			draft: null,
@@ -261,7 +262,7 @@ describe("distill command", () => {
 		mocks.buildDistillReport.mockResolvedValue(report);
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-		await parseDistillCommand(["--draft", "--json"]);
+		await parseDistillCommand(["--no-judge", "--draft", "--json"]);
 
 		// The cwd checkout is not "another-unrelated-repo": drafting must refuse
 		// before any model call so the wrong repo's AGENTS.md is never targeted.
@@ -271,5 +272,148 @@ describe("distill command", () => {
 			reason: "project_mismatch",
 			projects: ["another-unrelated-repo"],
 		});
+	});
+
+	it("judges candidates by default and drops routine-activity clusters from the report", async () => {
+		const report = userScopeReport();
+		const [first] = report.candidates;
+		if (!first) throw new Error("expected a seeded candidate");
+		report.candidates.push({
+			...first,
+			representative_id: 2,
+			concepts: ["release-status"],
+			evidence: ["Release workflow confirmed running for tag v0.31.2."],
+		});
+		report.metadata.candidate_count = 2;
+		mocks.buildDistillReport.mockResolvedValue(report);
+		mocks.observe.mockImplementation(async (_system: string, user: string) => ({
+			raw: user.includes("release-status")
+				? "ROUTINE: release status narration"
+				: "LESSON: durable auth workaround",
+		}));
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseDistillCommand(["--json"]);
+
+		expect(mocks.observe).toHaveBeenCalledTimes(2);
+		const out = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(out.metadata.judged).toBe(true);
+		expect(out.metadata.routine_filtered_count).toBe(1);
+		expect(out.metadata.candidate_count).toBe(1);
+		expect(out.candidates).toHaveLength(1);
+		expect(out.candidates[0].representative_id).toBe(1);
+		expect(out.candidates[0].judge).toEqual({
+			verdict: "lesson",
+			reason: "durable auth workaround",
+			raw: "LESSON: durable auth workaround",
+		});
+	});
+
+	it("keeps unjudged candidates when the model output is unparseable", async () => {
+		mocks.buildDistillReport.mockResolvedValue(userScopeReport());
+		mocks.observe.mockResolvedValue({ raw: "hard to say" });
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseDistillCommand(["--json"]);
+
+		const out = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(out.candidates).toHaveLength(1);
+		expect(out.candidates[0].judge.verdict).toBe("unjudged");
+		expect(out.metadata.routine_filtered_count).toBe(0);
+	});
+
+	it("falls back to unjudged output when no observer is configured", async () => {
+		mocks.buildDistillReport.mockResolvedValue(userScopeReport());
+		mocks.observe.mockRejectedValue(new Error("no observer auth configured"));
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseDistillCommand(["--json"]);
+
+		const out = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(out.candidates).toHaveLength(1);
+		expect(out.candidates[0].judge).toBeUndefined();
+		expect(out.metadata.judged).toBe(false);
+		expect(out.metadata.judge_error).toContain("no observer auth configured");
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("overfetches when judging and backfills routine drops up to the limit", async () => {
+		const report = userScopeReport();
+		const [first] = report.candidates;
+		if (!first) throw new Error("expected a seeded candidate");
+		report.candidates = [
+			{
+				...first,
+				representative_id: 1,
+				concepts: ["release-status"],
+				evidence: ["Release workflow confirmed running for tag v0.31.2."],
+			},
+			{ ...first, representative_id: 2, concepts: ["signing"] },
+		];
+		report.metadata.candidate_count = 2;
+		mocks.buildDistillReport.mockResolvedValue(report);
+		mocks.observe.mockImplementation(async (_system: string, user: string) => ({
+			raw: user.includes("release-status")
+				? "ROUTINE: release status narration"
+				: "LESSON: durable auth workaround",
+		}));
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseDistillCommand(["--limit", "1", "--json"]);
+
+		// The deterministic window is overfetched (limit 1 → fetch 3) so the
+		// judged-out top candidate is backfilled by the next survivor.
+		expect(mocks.buildDistillReport).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({ limit: 3 }),
+		);
+		const out = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(out.candidates).toHaveLength(1);
+		expect(out.candidates[0].representative_id).toBe(2);
+		expect(out.metadata.candidate_count).toBe(1);
+		expect(out.metadata.routine_filtered_count).toBe(1);
+	});
+
+	it("skips judging entirely with --no-judge", async () => {
+		mocks.buildDistillReport.mockResolvedValue(userScopeReport());
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseDistillCommand(["--no-judge", "--json"]);
+
+		expect(mocks.observe).not.toHaveBeenCalled();
+		const out = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(out.metadata.judged).toBeUndefined();
+		expect(out.metadata.judge_error).toBeUndefined();
+	});
+
+	it("judges before drafting so the draft targets the top surviving candidate", async () => {
+		const report = userScopeReport();
+		const [first] = report.candidates;
+		if (!first) throw new Error("expected a seeded candidate");
+		report.candidates.unshift({
+			...first,
+			representative_id: 9,
+			concepts: ["release-status"],
+			evidence: ["Release workflow confirmed running for tag v0.31.2."],
+		});
+		report.metadata.candidate_count = 2;
+		mocks.buildDistillReport.mockResolvedValue(report);
+		mocks.observe.mockImplementation(async (system: string, user: string) => {
+			if (system.includes("LESSON:")) {
+				return {
+					raw: user.includes("release-status")
+						? "ROUTINE: release status narration"
+						: "LESSON: durable auth workaround",
+				};
+			}
+			return { raw: "Use the HTTPS rewrite when Graphite SSH auth stalls." };
+		});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseDistillCommand(["--draft", "--json"]);
+
+		const out = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(out.draft.representative_id).toBe(1);
+		expect(out.draft.rule).toBe("Use the HTTPS rewrite when Graphite SSH auth stalls.");
 	});
 });

--- a/packages/cli/src/commands/distill.ts
+++ b/packages/cli/src/commands/distill.ts
@@ -6,9 +6,11 @@ import {
 	applyDistillRule,
 	buildDistillReport,
 	type DistillCandidate,
+	type DistillCandidateJudgement,
 	type DistillContextDocument,
 	type DistillReport,
 	draftDistillRule,
+	judgeDistillReport,
 	type MemoryFilters,
 	MemoryStore,
 	ObserverClient,
@@ -36,6 +38,7 @@ type DistillCommandOptions = DbOpts &
 		draft?: boolean;
 		explain?: boolean;
 		includeDocumented?: boolean;
+		judge?: boolean;
 		kind: string[];
 		limit: string;
 		minRecurrence: string;
@@ -113,8 +116,21 @@ function buildFilters(opts: DistillCommandOptions): MemoryFilters | undefined {
 	return project ? { project } : undefined;
 }
 
-async function runDistill(store: MemoryStore, opts: DistillCommandOptions): Promise<DistillReport> {
-	const limit = parsePositiveInteger(opts.limit, "limit");
+// When judging is on, mine extra candidates so routine drops can be backfilled
+// from the next-ranked clusters instead of shrinking the user's requested limit
+// (e.g. --limit 1 whose top candidate is routine would otherwise return none).
+const JUDGE_OVERFETCH_FACTOR = 3;
+const JUDGE_OVERFETCH_MAX_EXTRA = 20;
+
+function judgeFetchLimit(limit: number): number {
+	return Math.min(limit * JUDGE_OVERFETCH_FACTOR, limit + JUDGE_OVERFETCH_MAX_EXTRA);
+}
+
+async function runDistill(
+	store: MemoryStore,
+	opts: DistillCommandOptions,
+	limit: number,
+): Promise<DistillReport> {
 	const minRecurrence = parsePositiveInteger(opts.minRecurrence, "min recurrence");
 	return buildDistillReport(store, {
 		candidate: {
@@ -131,6 +147,19 @@ async function runDistill(store: MemoryStore, opts: DistillCommandOptions): Prom
 	});
 }
 
+/**
+ * B-side worthiness gate: an LLM judges each deterministic candidate and
+ * routine-activity clusters are dropped. Recurrence alone cannot make this
+ * call — releases, review passes, and context lookups recur by definition.
+ */
+async function judgeReport(report: DistillReport): Promise<DistillReport> {
+	const client = new ObserverClient();
+	return judgeDistillReport(report, async (system, user) => {
+		const response = await client.observe(system, user);
+		return response.raw;
+	});
+}
+
 export function renderDistillReport(report: DistillReport, explain = false): string {
 	if (report.candidates.length === 0) {
 		return "No distill candidates found.";
@@ -144,6 +173,10 @@ export function renderDistillReport(report: DistillReport, explain = false): str
 		lines.push(`   projects: ${candidate.projects.join(", ") || "(none)"}`);
 		lines.push(`   concepts: ${candidate.concepts.join(", ") || "(none)"}`);
 		lines.push(`   members: ${candidate.member_ids.join(", ")}`);
+		const judge = (candidate as { judge?: DistillCandidateJudgement }).judge;
+		if (judge) {
+			lines.push(`   judge: ${judge.verdict}${judge.reason ? ` — ${judge.reason}` : ""}`);
+		}
 		if (explain) {
 			for (const evidence of candidate.evidence) lines.push(`   - ${evidence}`);
 		}
@@ -322,7 +355,33 @@ async function distillAction(opts: DistillCommandOptions): Promise<void> {
 	let store: MemoryStore | null = null;
 	try {
 		store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
-		const result = await runDistill(store, opts);
+		const limit = parsePositiveInteger(opts.limit, "limit");
+		const judging = opts.judge !== false;
+		let result = await runDistill(store, opts, judging ? judgeFetchLimit(limit) : limit);
+		// Judged by default: recurrence scoring alone cannot tell recurring
+		// lessons from recurring routine activity, so unjudged output is only
+		// offered as an explicit opt-out. Judge failure falls back to unjudged
+		// output rather than failing the command.
+		if (judging) {
+			try {
+				result = await judgeReport(result);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				result = {
+					...result,
+					metadata: { ...result.metadata, judged: false, judge_error: message },
+				};
+			}
+			// Trim the overfetched window back to the requested limit; survivors
+			// beyond it exist only to backfill judged-out routine clusters.
+			if (result.candidates.length > limit) {
+				result = {
+					...result,
+					candidates: result.candidates.slice(0, limit),
+					metadata: { ...result.metadata, candidate_count: limit },
+				};
+			}
+		}
 		if (opts.draft || opts.apply) {
 			await draftTopCandidate(result, opts);
 			return;
@@ -333,6 +392,15 @@ async function distillAction(opts: DistillCommandOptions): Promise<void> {
 		}
 		p.intro("codemem distill");
 		console.log(renderDistillReport(result, opts.explain ?? false));
+		if (result.metadata.judged) {
+			p.log.info(
+				`judge dropped ${result.metadata.routine_filtered_count ?? 0} routine-activity candidate(s)`,
+			);
+		} else if (result.metadata.judge_error) {
+			p.log.warn(
+				`worthiness judgment skipped (needs a configured observer model): ${result.metadata.judge_error}. Candidates are unfiltered; recurring routine activity may rank high.`,
+			);
+		}
 		p.outro("review candidates before editing context files");
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -358,6 +426,10 @@ const cmd = new Command("distill")
 	.option("-l, --limit <n>", "max candidates", "10")
 	.option("-e, --explain", "include evidence snippets in human output")
 	.option("--include-documented", "include candidates already represented in context files")
+	.option(
+		"--no-judge",
+		"skip the observer-model worthiness judgment that drops routine-activity clusters",
+	)
 	.option("-D, --draft", "draft an AGENTS.md rule for the top candidate and show the diff")
 	.option(
 		"--apply",

--- a/packages/core/src/distill-draft.ts
+++ b/packages/core/src/distill-draft.ts
@@ -42,6 +42,7 @@ export function buildDistillDraftPrompt(candidate: DistillCandidate): DistillDra
 		"Output exactly one line: an imperative rule with no preamble and no markdown bullet, at most 200 characters.",
 		"It must be specific and actionable so an AI coding agent can follow it without the original evidence.",
 		`If the evidence is too vague or generic to form a useful rule, output the single word: ${SKIP_TOKEN}.`,
+		`If the evidence is routine activity narration (release/CI status, review passes with no findings, context/docs lookups) rather than a durable lesson, output the single word: ${SKIP_TOKEN}.`,
 	].join("\n");
 
 	const evidence = candidate.evidence

--- a/packages/core/src/distill-judge.test.ts
+++ b/packages/core/src/distill-judge.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import type { DistillCandidate } from "./distill.js";
+import {
+	buildDistillJudgePrompt,
+	judgeDistillCandidate,
+	judgeDistillCandidates,
+	judgeDistillReport,
+	parseJudgeVerdict,
+} from "./distill-judge.js";
+
+function candidate(overrides: Partial<DistillCandidate> = {}): DistillCandidate {
+	return {
+		scope: "project",
+		suggested_target: "AGENTS.md",
+		score: 0.5,
+		recurrence: 4,
+		projects: ["codemem"],
+		member_ids: [1, 2, 3, 4],
+		representative_id: 1,
+		concepts: ["release", "preflight"],
+		artifact_kind: "context_fact",
+		evidence: ["Release preflight must run on main.", "Tags require a clean main branch."],
+		draft_text: null,
+		...overrides,
+	};
+}
+
+describe("distill judge", () => {
+	it("builds a prompt that defines the worthiness bar and routine-activity exclusions", () => {
+		const { system, user } = buildDistillJudgePrompt(candidate());
+		expect(system).toContain("durable lesson");
+		expect(system).toContain("Routine activity is NOT a lesson");
+		expect(system).toContain("release/CI/pipeline status narration");
+		expect(system).toContain("review or validation passes that found no issues");
+		expect(system).toContain(
+			"context/docs lookups and their results, even when phrased as guidance or a fallback rule",
+		);
+		expect(system).toContain("Default to ROUTINE when uncertain");
+		expect(system).toContain("LESSON:");
+		expect(system).toContain("ROUTINE:");
+		expect(user).toContain("Scope: project");
+		expect(user).toContain("Times observed: 4");
+		expect(user).toContain("- Release preflight must run on main.");
+	});
+
+	it("parses lesson and routine verdicts with reasons", () => {
+		expect(parseJudgeVerdict("LESSON: preflight cleanliness is a repeatable constraint")).toEqual({
+			verdict: "lesson",
+			reason: "preflight cleanliness is a repeatable constraint",
+		});
+		expect(parseJudgeVerdict("routine: release status narration")).toEqual({
+			verdict: "routine",
+			reason: "release status narration",
+		});
+		expect(parseJudgeVerdict("- ROUTINE — context lookup results")).toEqual({
+			verdict: "routine",
+			reason: "context lookup results",
+		});
+	});
+
+	it("returns unjudged for empty or unparseable output", () => {
+		expect(parseJudgeVerdict(null)).toEqual({ verdict: "unjudged", reason: null });
+		expect(parseJudgeVerdict("")).toEqual({ verdict: "unjudged", reason: null });
+		expect(parseJudgeVerdict("maybe worth keeping?")).toEqual({
+			verdict: "unjudged",
+			reason: null,
+		});
+	});
+
+	it("judges a candidate through the injected drafter", async () => {
+		const judged = await judgeDistillCandidate(candidate(), async () => "ROUTINE: status noise");
+		expect(judged.verdict).toBe("routine");
+		expect(judged.reason).toBe("status noise");
+		expect(judged.raw).toBe("ROUTINE: status noise");
+	});
+
+	it("annotates all candidates in order and preserves the original fields", async () => {
+		const first = candidate({ representative_id: 1 });
+		const second = candidate({ representative_id: 2, concepts: ["signing"] });
+		const results = await judgeDistillCandidates([first, second], async (_system, user) =>
+			user.includes("signing") ? "LESSON: signing constraint" : "ROUTINE: release noise",
+		);
+		expect(results.map((item) => item.judge.verdict)).toEqual(["routine", "lesson"]);
+		expect(results[0]?.representative_id).toBe(1);
+		expect(results[1]?.judge.reason).toBe("signing constraint");
+		expect(results[1]?.evidence).toEqual(second.evidence);
+	});
+
+	it("marks a candidate unjudged when the model returns nothing", async () => {
+		const judged = await judgeDistillCandidate(candidate(), async () => null);
+		expect(judged.verdict).toBe("unjudged");
+		expect(judged.raw).toBeNull();
+	});
+
+	it("keeps other verdicts when a single judge call fails", async () => {
+		const first = candidate({ representative_id: 1, concepts: ["flaky"] });
+		const second = candidate({ representative_id: 2, concepts: ["signing"] });
+		const results = await judgeDistillCandidates([first, second], async (_system, user) => {
+			if (user.includes("flaky")) throw new Error("transient rate limit");
+			return "LESSON: durable constraint";
+		});
+		expect(results.map((item) => item.judge.verdict)).toEqual(["unjudged", "lesson"]);
+	});
+
+	it("rejects when every judge call fails so callers can fall back", async () => {
+		await expect(
+			judgeDistillCandidates([candidate()], async () => {
+				throw new Error("no observer auth configured");
+			}),
+		).rejects.toThrow("no observer auth configured");
+	});
+
+	it("filters routine candidates out of a report and keeps unjudged ones", async () => {
+		const report = {
+			version: 1 as const,
+			candidates: [
+				candidate({ representative_id: 1, concepts: ["release-status"] }),
+				candidate({ representative_id: 2, concepts: ["signing"] }),
+				candidate({ representative_id: 3, concepts: ["unclear"] }),
+			],
+			metadata: {
+				candidate_count: 3,
+				cluster_count: 3,
+				context_document_count: 0,
+				corpus_count: 12,
+				corpus_limit: 2000,
+				documented_cluster_count: 0,
+				include_documented: false,
+				min_recurrence: 2,
+			},
+		};
+		const judged = await judgeDistillReport(report, async (_system, user) => {
+			if (user.includes("release-status")) return "ROUTINE: status narration";
+			if (user.includes("signing")) return "LESSON: durable constraint";
+			return "shrug";
+		});
+		expect(judged.candidates.map((item) => item.representative_id)).toEqual([2, 3]);
+		expect(judged.metadata.candidate_count).toBe(2);
+		expect(judged.metadata.judged).toBe(true);
+		expect(judged.metadata.routine_filtered_count).toBe(1);
+	});
+});

--- a/packages/core/src/distill-judge.ts
+++ b/packages/core/src/distill-judge.ts
@@ -1,0 +1,173 @@
+import type { DistillCandidate, DistillReport } from "./distill.js";
+import type { DistillRuleDrafter } from "./distill-draft.js";
+
+/**
+ * B-side worthiness gate for distill candidates.
+ *
+ * The deterministic A-side clusters by recurrence, but recurrence alone cannot
+ * distinguish a recurring lesson from recurring routine activity (releases,
+ * review passes, context lookups recur by definition). An LLM judge makes that
+ * call per candidate — a handful of short calls per run instead of
+ * reclassifying the whole corpus.
+ */
+
+export type DistillJudgeVerdict = "lesson" | "routine" | "unjudged";
+
+export interface DistillCandidateJudgement {
+	verdict: DistillJudgeVerdict;
+	/** Short model-provided justification; null when unjudged. */
+	reason: string | null;
+	/** Raw model output, for debugging/--json. */
+	raw: string | null;
+}
+
+export interface JudgedDistillCandidate extends DistillCandidate {
+	judge: DistillCandidateJudgement;
+}
+
+const MAX_EVIDENCE_FOR_PROMPT = 8;
+const VERDICT_PATTERN = /^(lesson|routine)\b[\s:—–-]*(.*)$/i;
+
+export interface DistillJudgePrompt {
+	system: string;
+	user: string;
+}
+
+export function buildDistillJudgePrompt(candidate: DistillCandidate): DistillJudgePrompt {
+	const system = [
+		"You judge whether a cluster of recurring engineering observations carries a durable lesson worth promoting into a context file (a repo AGENTS.md or user-global context).",
+		"A durable lesson is a constraint, gotcha, root cause, decision with rationale, or how-something-works insight that changes how future work should be done.",
+		"Routine activity is NOT a lesson, no matter how often it recurs:",
+		"- release/CI/pipeline status narration",
+		"- review or validation passes that found no issues",
+		"- context/docs lookups and their results, even when phrased as guidance or a fallback rule",
+		"- restating workflow policy that is already established",
+		"- bootstrap/setup narration",
+		"Judge skeptically: a true statement is not automatically a lesson — it must change how future work is done. Recurrence is evidence of routine, not of value. Default to ROUTINE when uncertain.",
+		'Output exactly one line: "LESSON: <short reason>" or "ROUTINE: <short reason>".',
+	].join("\n");
+
+	const evidence = candidate.evidence
+		.slice(0, MAX_EVIDENCE_FOR_PROMPT)
+		.map((item) => `- ${item}`)
+		.join("\n");
+
+	const user = [
+		`Scope: ${candidate.scope}`,
+		`Projects: ${candidate.projects.join(", ") || "(unknown)"}`,
+		`Concepts: ${candidate.concepts.join(", ") || "(none)"}`,
+		`Times observed: ${candidate.recurrence}`,
+		"",
+		"Recurring observations:",
+		evidence || "(no evidence)",
+	].join("\n");
+
+	return { system, user };
+}
+
+/** Parse a model response into a verdict; unparseable output stays unjudged. */
+export function parseJudgeVerdict(text: string | null | undefined): {
+	verdict: DistillJudgeVerdict;
+	reason: string | null;
+} {
+	if (!text) return { verdict: "unjudged", reason: null };
+	const firstLine = text
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.find((line) => line.length > 0);
+	if (!firstLine) return { verdict: "unjudged", reason: null };
+
+	const cleaned = firstLine
+		.replace(/^[-*+]\s+/, "")
+		.replace(/^["'`]+|["'`]+$/g, "")
+		.trim();
+	const match = cleaned.match(VERDICT_PATTERN);
+	if (!match) return { verdict: "unjudged", reason: null };
+
+	const verdict = match[1]?.toLowerCase() === "lesson" ? "lesson" : "routine";
+	const reason = match[2]?.trim() || null;
+	return { verdict, reason };
+}
+
+export async function judgeDistillCandidate(
+	candidate: DistillCandidate,
+	drafter: DistillRuleDrafter,
+): Promise<DistillCandidateJudgement> {
+	const { system, user } = buildDistillJudgePrompt(candidate);
+	const raw = await drafter(system, user);
+	const { verdict, reason } = parseJudgeVerdict(raw);
+	return { verdict, reason, raw: raw ?? null };
+}
+
+export interface DistillJudgeOptions {
+	/** Concurrent judge calls; candidates stay in order. */
+	concurrency?: number;
+}
+
+const DEFAULT_JUDGE_CONCURRENCY = 4;
+
+export async function judgeDistillCandidates(
+	candidates: DistillCandidate[],
+	drafter: DistillRuleDrafter,
+	options: DistillJudgeOptions = {},
+): Promise<JudgedDistillCandidate[]> {
+	const concurrency = Math.max(1, options.concurrency ?? DEFAULT_JUDGE_CONCURRENCY);
+	const results: JudgedDistillCandidate[] = new Array(candidates.length);
+	let nextIndex = 0;
+	let errorCount = 0;
+	let firstError: unknown;
+	const workers = Array.from(
+		{ length: Math.min(concurrency, candidates.length) },
+		async (): Promise<void> => {
+			while (true) {
+				const index = nextIndex;
+				nextIndex += 1;
+				if (index >= candidates.length) return;
+				const candidate = candidates[index];
+				if (!candidate) continue;
+				// A single transient failure (rate limit, timeout) must not void
+				// the verdicts already collected for other candidates — mark just
+				// this one unjudged and keep it (fail open, human review follows).
+				let judge: DistillCandidateJudgement;
+				try {
+					judge = await judgeDistillCandidate(candidate, drafter);
+				} catch (error) {
+					errorCount += 1;
+					firstError ??= error;
+					judge = { verdict: "unjudged", reason: null, raw: null };
+				}
+				results[index] = { ...candidate, judge };
+			}
+		},
+	);
+	await Promise.all(workers);
+	// Every call failing means the judge itself is unavailable (no observer
+	// configured, auth broken) — surface that to the caller's fallback path
+	// instead of returning a silently all-unjudged report.
+	if (candidates.length > 0 && errorCount === candidates.length) throw firstError;
+	return results.filter((item): item is JudgedDistillCandidate => item != null);
+}
+
+/**
+ * Judge every candidate in a report and drop routine-activity clusters.
+ * Unjudged candidates (model unavailable or unparseable output) are kept —
+ * the report feeds a human review step, so failing open is the safe default.
+ */
+export async function judgeDistillReport(
+	report: DistillReport,
+	drafter: DistillRuleDrafter,
+	options: DistillJudgeOptions = {},
+): Promise<DistillReport> {
+	const judged = await judgeDistillCandidates(report.candidates, drafter, options);
+	const kept = judged.filter((item) => item.judge.verdict !== "routine");
+	return {
+		...report,
+		candidates: kept,
+		metadata: {
+			...report.metadata,
+			candidate_count: kept.length,
+			judged: true,
+			routine_filtered_count: judged.length - kept.length,
+		},
+	};
+}

--- a/packages/core/src/distill.ts
+++ b/packages/core/src/distill.ts
@@ -170,6 +170,12 @@ export interface DistillReport {
 		documented_cluster_count: number;
 		include_documented: boolean;
 		min_recurrence: number;
+		/** Set when a worthiness judge pass ran over the candidates. */
+		judged?: boolean;
+		/** Candidates the judge classified as routine activity and removed. */
+		routine_filtered_count?: number;
+		/** Why the judge pass was skipped (e.g. no observer model configured). */
+		judge_error?: string;
 	};
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -203,6 +203,19 @@ export {
 	renderUnifiedDiff,
 	sanitizeRuleLine,
 } from "./distill-draft.js";
+export type {
+	DistillCandidateJudgement,
+	DistillJudgePrompt,
+	DistillJudgeVerdict,
+	JudgedDistillCandidate,
+} from "./distill-judge.js";
+export {
+	buildDistillJudgePrompt,
+	judgeDistillCandidate,
+	judgeDistillCandidates,
+	judgeDistillReport,
+	parseJudgeVerdict,
+} from "./distill-judge.js";
 export type { EmbeddingClient } from "./embeddings.js";
 export {
 	_resetEmbeddingClient,

--- a/packages/mcp-server/src/distill.test.ts
+++ b/packages/mcp-server/src/distill.test.ts
@@ -1,8 +1,21 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const observeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@codemem/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@codemem/core")>();
+	return {
+		...actual,
+		ObserverClient: class {
+			observe = observeMock;
+		},
+	};
+});
+
 import { connect, initTestSchema, MemoryStore } from "@codemem/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createCodememMcpServer } from "./index.js";
 
 type RegisteredTool = {
@@ -107,6 +120,61 @@ describe("memory_distill_candidates MCP tool", () => {
 			scope: "user",
 			suggested_target: "~/.config/opencode/AGENTS.md",
 		});
+	});
+
+	it("judges candidates and drops routine-activity clusters when judge is set", async () => {
+		remember("greenroom", "mcp judge greenroom recurring lesson");
+		remember("greenroom", "mcp judge greenroom recurring lesson again");
+		observeMock.mockResolvedValue({ raw: "ROUTINE: release status narration" });
+		const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+		const distill = getTool(server, "memory_distill_candidates");
+
+		const result = parseToolJson(
+			await distill.handler({
+				all_projects: false,
+				include_documented: false,
+				judge: true,
+				limit: 10,
+				max_evidence_items: 5,
+				min_recurrence: 2,
+			}),
+		) as {
+			candidates: unknown[];
+			metadata: { judged?: boolean; routine_filtered_count?: number };
+		};
+
+		expect(observeMock).toHaveBeenCalledTimes(1);
+		expect(result.candidates).toHaveLength(0);
+		expect(result.metadata.judged).toBe(true);
+		expect(result.metadata.routine_filtered_count).toBe(1);
+		observeMock.mockReset();
+	});
+
+	it("falls back to unjudged output when the observer is unavailable", async () => {
+		remember("greenroom", "mcp judge fallback recurring lesson");
+		remember("greenroom", "mcp judge fallback recurring lesson again");
+		observeMock.mockRejectedValue(new Error("no observer auth configured"));
+		const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+		const distill = getTool(server, "memory_distill_candidates");
+
+		const result = parseToolJson(
+			await distill.handler({
+				all_projects: false,
+				include_documented: false,
+				judge: true,
+				limit: 10,
+				max_evidence_items: 5,
+				min_recurrence: 2,
+			}),
+		) as {
+			candidates: unknown[];
+			metadata: { judged?: boolean; judge_error?: string };
+		};
+
+		expect(result.candidates).toHaveLength(1);
+		expect(result.metadata.judged).toBe(false);
+		expect(result.metadata.judge_error).toContain("no observer auth configured");
+		observeMock.mockReset();
 	});
 
 	it("rejects project filters when all-project mining is requested", async () => {

--- a/packages/mcp-server/src/tools/distill.ts
+++ b/packages/mcp-server/src/tools/distill.ts
@@ -4,7 +4,9 @@ import { join } from "node:path";
 import {
 	buildDistillReport,
 	type DistillContextDocument,
+	judgeDistillReport,
 	type MemoryFilters,
+	ObserverClient,
 	projectMatchesFilter,
 	resolveProject,
 	resolveProjectRoot,
@@ -102,6 +104,12 @@ export function registerDistillTools(server: McpServer, context: ToolRegistratio
 				.max(20)
 				.default(5)
 				.describe("Evidence snippets per candidate"),
+			judge: z
+				.boolean()
+				.default(true)
+				.describe(
+					"Judge candidates with the observer model and drop routine-activity clusters (on by default; falls back to unjudged output when no observer model is configured)",
+				),
 			...filterSchema,
 		},
 		async (args) => {
@@ -109,7 +117,10 @@ export function registerDistillTools(server: McpServer, context: ToolRegistratio
 				const resolvedDefaultProject = defaultProject();
 				const filters = buildDistillFilters(args, resolvedDefaultProject);
 				const kinds = args.kind ? [args.kind] : undefined;
-				const result = await buildDistillReport(store, {
+				// When judging, mine extra candidates so routine drops are backfilled
+				// from the next-ranked clusters instead of shrinking the caller's limit.
+				const fetchLimit = args.judge ? Math.min(args.limit * 3, args.limit + 20) : args.limit;
+				let result = await buildDistillReport(store, {
 					candidate: {
 						includeDocumented: args.include_documented,
 						maxEvidenceItems: args.max_evidence_items,
@@ -118,9 +129,33 @@ export function registerDistillTools(server: McpServer, context: ToolRegistratio
 						shouldIncludeProjectContext(args, resolvedDefaultProject),
 					),
 					corpus: { filters: filters ?? null, kinds },
-					limit: args.limit,
+					limit: fetchLimit,
 					minRecurrence: args.min_recurrence,
 				});
+				if (args.judge) {
+					try {
+						const client = new ObserverClient();
+						result = await judgeDistillReport(result, async (system, user) => {
+							const response = await client.observe(system, user);
+							return response.raw;
+						});
+					} catch (err) {
+						// Fall back to unjudged output rather than failing the tool —
+						// the caller sees judged:false + judge_error and can decide.
+						const message = err instanceof Error ? err.message : String(err);
+						result = {
+							...result,
+							metadata: { ...result.metadata, judged: false, judge_error: message },
+						};
+					}
+					if (result.candidates.length > args.limit) {
+						result = {
+							...result,
+							candidates: result.candidates.slice(0, args.limit),
+							metadata: { ...result.metadata, candidate_count: args.limit },
+						};
+					}
+				}
 				return jsonContent(result);
 			} catch (err) {
 				return errorContent(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Description

The deterministic distill pipeline's recurrence × spread scoring cannot distinguish a recurring *lesson* from recurring routine *activity* — releases, review passes, and context lookups recur by definition, and running the miner against a real 2.2GB store showed those dominating the top candidates while genuine gotchas ranked below them. Heuristic/regex classification of LLM-written narrative prose was empirically ineffective, so the B-side gate the design reserved for LLM judgment is implemented at candidate level: a handful of short calls per run instead of reclassifying the corpus.

**Judging is on by default** — unjudged output is a known-bad default, so it is opt-out rather than opt-in:

- `judgeDistillReport` / `judgeDistillCandidates` in core (`distill-judge.ts`), reusing the injected `DistillRuleDrafter` seam; order-preserving bounded concurrency (4) keeps a 10-candidate pass at a few seconds. Each candidate gets a `LESSON`/`ROUTINE` verdict with reason; routine clusters are dropped; unjudgeable ones are kept and marked `unjudged` (output feeds human review — fail open).
- The judge prompt names the empirically observed routine families and instructs skeptical defaults ("a true statement is not automatically a lesson"; "recurrence is evidence of routine, not of value"; "default to ROUTINE when uncertain").
- CLI: judged by default; `--no-judge` opts out; when no observer model is configured the command falls back to unjudged output with a warning (`metadata.judged: false` + `judge_error`) instead of failing, so observer-less installs and CI keep working. Composes with `--draft`, which targets the top surviving candidate.
- MCP: `judge` defaults to `true` on `memory_distill_candidates`, same fallback semantics.
- The draft prompt also gains a routine-activity `SKIP` instruction so `--draft` won't write a routine rule.

Validated read-only against the live store: unjudged top-10 contained ~1–2 genuine lessons; judged runs drop 5–7 routine clusters (including a 36-member context-lookup cluster and all release-status clusters), and the survivors are the genuine gotchas (signing-failure workaround, tag-sync and release-preflight traps). Full run wall time ~7s including the judge pass.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

`pnpm exec vitest run` across the distill suites (core judge/draft/miner, CLI, MCP): all pass, including default-on judging, `--no-judge` opt-out, unjudged-fallback when no observer is configured, and judge-before-draft ordering. End-to-end verified against a real 2.2GB store with the configured observer model (read-only).

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vJr1WCwstAPakxxnbekZE
