### PR TITLE
chore(core): drop unused temperature from anthropic observer tier defaults

### DIFF
--- a/packages/core/src/extraction-tier-routing.ts
+++ b/packages/core/src/extraction-tier-routing.ts
@@ -46,16 +46,17 @@ export const RICH_TIER_DEFAULTS: Partial<ObserverConfig> = {
 	observerMaxOutputTokens: 12000,
 };
 
+// No temperature on the Anthropic tiers: the Anthropic request builders and
+// the sidecar runtimes never send a sampling temperature, and newer Claude
+// models reject non-default values outright.
 export const SIMPLE_TIER_ANTHROPIC_DEFAULTS: Partial<ObserverConfig> = {
 	observerProvider: "anthropic",
 	observerModel: "claude-haiku-4-5",
-	observerTemperature: 0.2,
 };
 
 export const RICH_TIER_ANTHROPIC_DEFAULTS: Partial<ObserverConfig> = {
 	observerProvider: "anthropic",
 	observerModel: "claude-sonnet-4-6",
-	observerTemperature: 0.2,
 	observerMaxOutputTokens: 12000,
 };
 


### PR DESCRIPTION
## Description
Removes the dead `observerTemperature` entries from `SIMPLE_TIER_ANTHROPIC_DEFAULTS` and `RICH_TIER_ANTHROPIC_DEFAULTS`. The Anthropic request builders (`buildAnthropicPayload` / structured variant) and the sidecar runtimes never send a sampling temperature, so these fields had no effect. Newer Claude models also reject non-default sampling parameters outright, so dropping the field keeps the defaults forward-compatible with a future rich-tier model bump. The OpenAI tier defaults keep their temperature since that path does send it.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes (no behavior change; existing tier-routing tests pass unchanged — none asserted the removed field on the Anthropic tiers)
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — n/a, internal defaults
- [x] No new warnings introduced
