### PR TITLE
feat(plugin): inject memories into user messages

### DIFF
--- a/packages/cli/.opencode/tests/plugin-injection.test.js
+++ b/packages/cli/.opencode/tests/plugin-injection.test.js
@@ -289,3 +289,229 @@ describe("applyInjectedContextToOutput", () => {
     expect(buildInjectedContext).not.toHaveBeenCalled();
   });
 });
+
+describe("applyInjectedContextToMessages", () => {
+  const userEntry = (messageID, text, sessionID = "sess-messages") => ({
+    info: { id: messageID, sessionID, role: "user" },
+    parts: [{ id: `${messageID}-text`, sessionID, messageID, type: "text", text }],
+  });
+
+  const assistantEntry = (messageID, text, sessionID = "sess-messages") => ({
+    info: { id: messageID, sessionID, role: "assistant" },
+    parts: [{ id: `${messageID}-text`, sessionID, messageID, type: "text", text }],
+  });
+
+  const unidentifiedUserEntry = (text) => ({
+    info: { role: "user" },
+    parts: [{ id: "text", type: "text", text }],
+  });
+
+  test("appends current memory to the latest user message", async () => {
+    const output = {
+      messages: [userEntry("user-1", "fix prompt caching")],
+    };
+    const buildInjectedContext = vi.fn().mockResolvedValue({
+      text: "[codemem context]\n## Summary\n[1] (decision) Message injection",
+      metrics: { total_items: 1, pack_tokens: 42 },
+    });
+    const showToast = vi.fn().mockResolvedValue(undefined);
+
+    const applied = await __testUtils.applyInjectedContextToMessages({
+      injectEnabled: true,
+      input: {},
+      output,
+      injectionToastShown: new Set(),
+      showToast,
+      resolveInjectQuery: vi.fn(({ firstPrompt, lastPromptText }) => `${firstPrompt} ${lastPromptText}`),
+      buildInjectedContext,
+      messageInjectionCache: new Map(),
+    });
+
+    expect(applied).toBe(true);
+    expect(output.messages[0].parts).toEqual([
+      { id: "user-1-text", sessionID: "sess-messages", messageID: "user-1", type: "text", text: "fix prompt caching" },
+      {
+        id: "codemem-context-user-1",
+        sessionID: "sess-messages",
+        messageID: "user-1",
+        type: "text",
+        text: "[codemem context]\n## Summary\n[1] (decision) Message injection",
+        synthetic: true,
+      },
+    ]);
+    expect(buildInjectedContext).toHaveBeenCalledTimes(1);
+    expect(showToast).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves prior injected message blocks and only builds the new turn", async () => {
+    const messageInjectionCache = new Map();
+    const injectionToastShown = new Set();
+    const buildInjectedContext = vi
+      .fn()
+      .mockResolvedValueOnce({ text: "[codemem context]\nturn one" })
+      .mockResolvedValueOnce({ text: "[codemem context]\nturn two" });
+    const resolveInjectQuery = vi.fn(({ firstPrompt, lastPromptText }) =>
+      [firstPrompt, lastPromptText].filter(Boolean).join(" | "),
+    );
+
+    const firstOutput = { messages: [userEntry("user-1", "first prompt")] };
+    await __testUtils.applyInjectedContextToMessages({
+      injectEnabled: true,
+      input: {},
+      output: firstOutput,
+      injectionToastShown,
+      showToast: null,
+      resolveInjectQuery,
+      buildInjectedContext,
+      messageInjectionCache,
+    });
+
+    const secondOutput = {
+      messages: [
+        userEntry("user-1", "first prompt"),
+        assistantEntry("assistant-1", "done"),
+        userEntry("user-2", "second prompt"),
+      ],
+    };
+    await __testUtils.applyInjectedContextToMessages({
+      injectEnabled: true,
+      input: {},
+      output: secondOutput,
+      injectionToastShown,
+      showToast: null,
+      resolveInjectQuery,
+      buildInjectedContext,
+      messageInjectionCache,
+    });
+
+    expect(buildInjectedContext).toHaveBeenCalledTimes(2);
+    expect(secondOutput.messages[0].parts.at(-1).text).toBe("[codemem context]\nturn one");
+    expect(secondOutput.messages[2].parts.at(-1).text).toBe("[codemem context]\nturn two");
+    expect(secondOutput.messages[0].parts.filter(__testUtils.isCodememContextPart)).toHaveLength(1);
+  });
+
+  test("deduplicates already-present codemem message parts", async () => {
+    const output = {
+      messages: [
+        {
+          info: { id: "user-1", sessionID: "sess-messages", role: "user" },
+          parts: [
+            { id: "user-1-text", sessionID: "sess-messages", messageID: "user-1", type: "text", text: "same prompt" },
+            {
+              id: "codemem-context-user-1",
+              sessionID: "sess-messages",
+              messageID: "user-1",
+              type: "text",
+              text: "[codemem context]\nexisting",
+              synthetic: true,
+            },
+          ],
+        },
+      ],
+    };
+    const buildInjectedContext = vi.fn();
+
+    await __testUtils.applyInjectedContextToMessages({
+      injectEnabled: true,
+      input: {},
+      output,
+      injectionToastShown: new Set(),
+      showToast: null,
+      resolveInjectQuery: () => "same prompt",
+      buildInjectedContext,
+      messageInjectionCache: new Map(),
+    });
+
+    expect(buildInjectedContext).not.toHaveBeenCalled();
+    expect(output.messages[0].parts.filter(__testUtils.isCodememContextPart)).toHaveLength(1);
+    expect(output.messages[0].parts.at(-1).text).toBe("[codemem context]\nexisting");
+  });
+
+  test("skips message injection once for compaction and strips codemem parts", async () => {
+    const output = {
+      messages: [
+        {
+          info: { id: "user-compact", sessionID: "sess-compact", role: "user" },
+          parts: [
+            {
+              id: "user-compact-text",
+              sessionID: "sess-compact",
+              messageID: "user-compact",
+              type: "text",
+              text: "compact this session",
+            },
+            {
+              id: "codemem-context-user-compact",
+              sessionID: "sess-compact",
+              messageID: "user-compact",
+              type: "text",
+              text: "[codemem context]\nold synthetic context",
+              synthetic: true,
+            },
+          ],
+        },
+      ],
+    };
+    const buildInjectedContext = vi.fn().mockResolvedValue({ text: "[codemem context]\nnew" });
+    const compactionInjectionSkips = new Map([["sess-compact", Date.now() + 1000]]);
+
+    const applied = await __testUtils.applyInjectedContextToMessages({
+      injectEnabled: true,
+      input: { sessionID: "sess-compact" },
+      output,
+      injectionToastShown: new Set(),
+      showToast: null,
+      resolveInjectQuery: () => "compact this session",
+      buildInjectedContext,
+      messageInjectionCache: new Map(),
+      compactionInjectionSkips,
+    });
+
+    expect(applied).toBe(false);
+    expect(buildInjectedContext).not.toHaveBeenCalled();
+    expect(compactionInjectionSkips.has("sess-compact")).toBe(false);
+    expect(output.messages[0].parts).toEqual([
+      {
+        id: "user-compact-text",
+        sessionID: "sess-compact",
+        messageID: "user-compact",
+        type: "text",
+        text: "compact this session",
+      },
+    ]);
+  });
+
+  test("does not replay cached context for unidentified sessions or positional messages", async () => {
+    const messageInjectionCache = new Map();
+    const buildInjectedContext = vi
+      .fn()
+      .mockResolvedValueOnce({ text: "[codemem context]\nsession A" })
+      .mockResolvedValueOnce({ text: "[codemem context]\nsession B" });
+    const common = {
+      injectEnabled: true,
+      input: {},
+      injectionToastShown: new Set(),
+      showToast: null,
+      resolveInjectQuery: ({ lastPromptText }) => lastPromptText,
+      buildInjectedContext,
+      messageInjectionCache,
+    };
+
+    const firstOutput = { messages: [unidentifiedUserEntry("same prompt")] };
+    await __testUtils.applyInjectedContextToMessages({
+      ...common,
+      output: firstOutput,
+    });
+
+    const secondOutput = { messages: [unidentifiedUserEntry("same prompt")] };
+    await __testUtils.applyInjectedContextToMessages({
+      ...common,
+      output: secondOutput,
+    });
+
+    expect(buildInjectedContext).toHaveBeenCalledTimes(2);
+    expect(messageInjectionCache.size).toBe(0);
+    expect(firstOutput.messages[0].parts.at(-1).text).toBe("[codemem context]\nsession A");
+    expect(secondOutput.messages[0].parts.at(-1).text).toBe("[codemem context]\nsession B");
+  });
+});

--- a/packages/cli/.opencode/tests/plugin-toast.test.js
+++ b/packages/cli/.opencode/tests/plugin-toast.test.js
@@ -22,20 +22,30 @@ describe("buildInjectionToastMessage", () => {
     expect(message).toContain("delta +2/-1");
   });
 
-  test("omits delta segment when unavailable", () => {
-    const message = buildInjectionToastMessage({
-      items: 1,
+	test("omits delta segment when unavailable", () => {
+		const message = buildInjectionToastMessage({
+			items: 1,
       pack_tokens: 50,
       pack_delta_available: false,
       added_ids: [11],
       removed_ids: [7],
     });
 
-    expect(message).toContain("codemem injected");
-    expect(message).not.toContain("delta +");
-  });
+		expect(message).toContain("codemem injected");
+		expect(message).not.toContain("delta +");
+	});
 
-  test("omits avoided-work segment when breakdown metrics are missing", () => {
+	test("uses total_items from real pack metrics when items is absent", () => {
+		const message = buildInjectionToastMessage({
+			total_items: 4,
+			pack_tokens: 120,
+		});
+
+		expect(message).toContain("4 items");
+		expect(message).toContain("~120 tokens");
+	});
+
+	test("omits avoided-work segment when breakdown metrics are missing", () => {
     const message = buildInjectionToastMessage({
       items: 2,
       pack_tokens: 100,

--- a/packages/cli/.opencode/tests/plugin-transform-hook.test.js
+++ b/packages/cli/.opencode/tests/plugin-transform-hook.test.js
@@ -119,7 +119,7 @@ const insertScopedMemory = (
 	).run(sessionId, title, bodyText, now, now, scopeId);
 };
 
-describe("experimental.chat.system.transform", () => {
+describe("OpenCode transform-time injection", () => {
 	const originalEnv = { ...process.env };
 	const tmpDirs = [];
 
@@ -149,13 +149,13 @@ describe("experimental.chat.system.transform", () => {
 		process.env = originalEnv;
 	});
 
-	test("appends built memory pack to output.system", async () => {
+	test("appends built memory pack to the latest user message by default", async () => {
 		spawnMock.mockImplementation((_command, args) => {
 			if (Array.isArray(args) && args.includes("pack")) {
 				return makeProcess({
 					stdout: JSON.stringify({
 						pack_text: "## Summary\n[1] (feature) Titanic artifact client shipped",
-						metrics: { items: 1, pack_tokens: 42 },
+						metrics: { total_items: 1, pack_tokens: 42 },
 					}),
 				});
 			}
@@ -173,19 +173,328 @@ describe("experimental.chat.system.transform", () => {
 			worktree: "/tmp/greenroom",
 		});
 
-		expect(typeof hooks["experimental.chat.system.transform"]).toBe("function");
+		expect(typeof hooks["experimental.chat.messages.transform"]).toBe("function");
+
+		const output = {
+			messages: [
+				{
+					info: { id: "user-1", sessionID: "sess-1", role: "user" },
+					parts: [
+						{
+							id: "user-1-text",
+							sessionID: "sess-1",
+							messageID: "user-1",
+							type: "text",
+							text: "ship the Titanic artifact client",
+						},
+					],
+				},
+			],
+		};
+		await hooks["experimental.chat.messages.transform"]({}, output);
+
+		expect(output.messages[0].parts.at(-1)).toEqual({
+			id: "codemem-context-user-1",
+			sessionID: "sess-1",
+			messageID: "user-1",
+			type: "text",
+			text: "[codemem context]\n## Summary\n[1] (feature) Titanic artifact client shipped",
+			synthetic: true,
+		});
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("skips message injection for the transform immediately following compaction", async () => {
+		const packQueries = [];
+		spawnMock.mockImplementation((_command, args) => {
+			if (Array.isArray(args) && args.includes("pack")) {
+				packQueries.push(args[args.indexOf("pack") + 1]);
+				return makeProcess({
+					stdout: JSON.stringify({
+						pack_text: "## Summary\n[1] (feature) Normal turn context",
+						metrics: { total_items: 1, pack_tokens: 42 },
+					}),
+				});
+			}
+			return makeProcess({ stdout: "" });
+		});
+
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: {
+				app: { log: vi.fn().mockResolvedValue(undefined) },
+				tui: {},
+			},
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+
+		expect(typeof hooks["experimental.session.compacting"]).toBe("function");
+		await hooks["experimental.session.compacting"]({ sessionID: "sess-compact" }, { context: [] });
+
+		const output = {
+			messages: [
+				{
+					info: { id: "user-compact", sessionID: "sess-compact", role: "user" },
+					parts: [
+						{
+							id: "user-compact-text",
+							sessionID: "sess-compact",
+							messageID: "user-compact",
+							type: "text",
+							text: "summarize this session",
+						},
+					],
+				},
+			],
+		};
+
+		await hooks["experimental.chat.messages.transform"]({ sessionID: "sess-compact" }, output);
+		expect(output.messages[0].parts).toHaveLength(1);
+		expect(spawnMock).not.toHaveBeenCalled();
+
+		await hooks["experimental.chat.messages.transform"]({ sessionID: "sess-compact" }, output);
+		expect(output.messages[0].parts.at(-1).text).toBe(
+			"[codemem context]\n## Summary\n[1] (feature) Normal turn context",
+		);
+		expect(packQueries).toEqual(["summarize this session greenroom"]);
+	});
+
+	test("keeps legacy system prompt injection when CODEMEM_INJECT_SURFACE=system", async () => {
+		process.env.CODEMEM_INJECT_SURFACE = "system";
+		spawnMock.mockImplementation((_command, args) => {
+			if (Array.isArray(args) && args.includes("pack")) {
+				return makeProcess({
+					stdout: JSON.stringify({
+						pack_text: "## Summary\n[1] (feature) Legacy system injection",
+						metrics: { total_items: 1, pack_tokens: 42 },
+					}),
+				});
+			}
+			return makeProcess({ stdout: "" });
+		});
+
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: {
+				app: { log: vi.fn().mockResolvedValue(undefined) },
+				tui: {},
+			},
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
 
 		const output = { system: ["base system prompt"] };
 		await hooks["experimental.chat.system.transform"](
-			{ sessionID: "sess-1", model: {} },
+			{ sessionID: "sess-legacy", model: {} },
 			output,
 		);
 
 		expect(output.system).toEqual([
 			"base system prompt",
-			"[codemem context]\n## Summary\n[1] (feature) Titanic artifact client shipped",
+			"[codemem context]\n## Summary\n[1] (feature) Legacy system injection",
+		]);
+	});
+
+	test("skips legacy system injection for the transform immediately following compaction", async () => {
+		process.env.CODEMEM_INJECT_SURFACE = "system";
+		spawnMock.mockImplementation((_command, args) => {
+			if (Array.isArray(args) && args.includes("pack")) {
+				return makeProcess({
+					stdout: JSON.stringify({
+						pack_text: "## Summary\n[1] (feature) Legacy context after compaction",
+						metrics: { total_items: 1, pack_tokens: 42 },
+					}),
+				});
+			}
+			return makeProcess({ stdout: "" });
+		});
+
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: {
+				app: { log: vi.fn().mockResolvedValue(undefined) },
+				tui: {},
+			},
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+
+		await hooks["experimental.session.compacting"]({ sessionID: "sess-legacy-compact" }, { context: [] });
+
+		const output = { system: ["base system prompt"] };
+		await hooks["experimental.chat.system.transform"](
+			{ sessionID: "sess-legacy-compact", model: {} },
+			output,
+		);
+		expect(output.system).toEqual(["base system prompt"]);
+		expect(spawnMock).not.toHaveBeenCalled();
+
+		await hooks["experimental.chat.system.transform"](
+			{ sessionID: "sess-legacy-compact", model: {} },
+			output,
+		);
+		expect(output.system).toEqual([
+			"base system prompt",
+			"[codemem context]\n## Summary\n[1] (feature) Legacy context after compaction",
 		]);
 		expect(spawnMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("does not inject into system prompt in default message mode", async () => {
+		spawnMock.mockImplementation((_command, args) => {
+			if (Array.isArray(args) && args.includes("pack")) {
+				return makeProcess({
+					stdout: JSON.stringify({
+						pack_text: "## Summary\n[1] (feature) Should not be used",
+						metrics: { total_items: 1, pack_tokens: 42 },
+					}),
+				});
+			}
+			return makeProcess({ stdout: "" });
+		});
+
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: {
+				app: { log: vi.fn().mockResolvedValue(undefined) },
+				tui: {},
+			},
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+
+		const output = { system: ["base system prompt"] };
+		await hooks["experimental.chat.system.transform"](
+			{ sessionID: "sess-default-system", model: {} },
+			output,
+		);
+
+		expect(output.system).toEqual(["base system prompt"]);
+		expect(spawnMock).not.toHaveBeenCalled();
+	});
+
+	test("does not inject into messages in legacy system mode", async () => {
+		process.env.CODEMEM_INJECT_SURFACE = "system";
+		spawnMock.mockImplementation((_command, args) => {
+			if (Array.isArray(args) && args.includes("pack")) {
+				return makeProcess({
+					stdout: JSON.stringify({
+						pack_text: "## Summary\n[1] (feature) Should not be used",
+						metrics: { total_items: 1, pack_tokens: 42 },
+					}),
+				});
+			}
+			return makeProcess({ stdout: "" });
+		});
+
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: {
+				app: { log: vi.fn().mockResolvedValue(undefined) },
+				tui: {},
+			},
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+
+		const output = {
+			messages: [
+				{
+					info: { id: "user-legacy", sessionID: "sess-legacy", role: "user" },
+					parts: [
+						{
+							id: "user-legacy-text",
+							sessionID: "sess-legacy",
+							messageID: "user-legacy",
+							type: "text",
+							text: "legacy mode prompt",
+						},
+					],
+				},
+			],
+		};
+		await hooks["experimental.chat.messages.transform"]({}, output);
+
+		expect(output.messages[0].parts).toHaveLength(1);
+		expect(output.messages[0].parts[0].text).toBe("legacy mode prompt");
+		expect(spawnMock).not.toHaveBeenCalled();
+	});
+
+	test("honors empty prompt overrides instead of falling back to stale captured prompts", async () => {
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		const packQueries = [];
+		spawnMock.mockImplementation((_command, args) => {
+			if (Array.isArray(args) && args.includes("pack")) {
+				packQueries.push(args[args.indexOf("pack") + 1]);
+				return makeProcess({
+					stdout: JSON.stringify({
+						pack_text: "## Summary\n[1] (feature) Empty prompt override respected",
+						metrics: { total_items: 1, pack_tokens: 42 },
+					}),
+				});
+			}
+			return makeProcess({ stdout: "" });
+		});
+
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: {
+				app: { log: vi.fn().mockResolvedValue(undefined) },
+				tui: {},
+			},
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+
+		await hooks.event({
+			event: {
+				type: "message.updated",
+				properties: {
+					sessionID: "sess-empty-override",
+					info: { id: "user-stale", role: "user" },
+				},
+			},
+		});
+		await hooks.event({
+			event: {
+				type: "message.part.updated",
+				properties: {
+					sessionID: "sess-empty-override",
+					part: { messageID: "user-stale", type: "text", text: "stale captured prompt" },
+				},
+			},
+		});
+
+		const output = {
+			messages: [
+				{
+					info: { id: "user-empty", sessionID: "sess-empty-override", role: "user" },
+					parts: [
+						{
+							id: "user-empty-text",
+							sessionID: "sess-empty-override",
+							messageID: "user-empty",
+							type: "text",
+							text: "   ",
+						},
+					],
+				},
+			],
+		};
+
+		await hooks["experimental.chat.messages.transform"]({ sessionID: "sess-empty-override" }, output);
+
+		expect(packQueries).toEqual(["greenroom"]);
+		expect(output.messages[0].parts.at(-1).text).toBe(
+			"[codemem context]\n## Summary\n[1] (feature) Empty prompt override respected",
+		);
 	});
 
 	test("injects the CLI-scoped pack without unauthorized scope memories", async () => {
@@ -236,16 +545,28 @@ describe("experimental.chat.system.transform", () => {
 			worktree,
 		});
 
-		const output = { system: ["base system prompt"] };
-		await hooks["experimental.chat.system.transform"](
-			{ sessionID: "sess-scope-a", model: {} },
-			output,
-		);
+		const output = {
+			messages: [
+				{
+					info: { id: "user-scope", sessionID: "sess-scope-a", role: "user" },
+					parts: [
+						{
+							id: "user-scope-text",
+							sessionID: "sess-scope-a",
+							messageID: "user-scope",
+							type: "text",
+							text: "greenroom scope safety",
+						},
+					],
+				},
+			],
+		};
+		await hooks["experimental.chat.messages.transform"]({}, output);
 
-		const systemPrompt = output.system.join("\n");
-		expect(systemPrompt).toContain("Greenroom authorized scope note");
-		expect(systemPrompt).not.toContain("Greenroom forbidden payroll secret");
-		expect(systemPrompt).not.toContain("forbidden payroll details");
+		const userPrompt = output.messages[0].parts.map((part) => part.text || "").join("\n");
+		expect(userPrompt).toContain("Greenroom authorized scope note");
+		expect(userPrompt).not.toContain("Greenroom forbidden payroll secret");
+		expect(userPrompt).not.toContain("forbidden payroll details");
 		expect(showToast).toHaveBeenCalledTimes(1);
 		expect(JSON.stringify(showToast.mock.calls)).not.toContain("forbidden payroll");
 	});

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -18,6 +18,10 @@ const DISABLED_VALUES = ["0", "false", "off"];
 const PINNED_BACKEND_VERSION = "0.38.0";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
+const CODEMEM_CONTEXT_PART_ID_PREFIX = "codemem-context-";
+const MAX_MESSAGE_INJECTION_CACHE_SESSIONS = 20;
+const MAX_MESSAGE_INJECTION_CACHE_MESSAGES = 100;
+const COMPACTION_INJECTION_SKIP_TTL_MS = 30 * 1000;
 
 let compatCheckCache = null;
 
@@ -26,6 +30,16 @@ const envHasValue = (value, truthyValues) =>
   truthyValues.includes(normalizeEnvValue(value));
 const envNotDisabled = (value) =>
   !DISABLED_VALUES.includes(normalizeEnvValue(value));
+
+const resolveInjectSurface = (value) => {
+  const normalized = String(value || "message").trim().toLowerCase();
+  if (normalized === "system") {
+    return "system";
+  }
+  return "message";
+};
+
+const hasOwn = (value, key) => Object.prototype.hasOwnProperty.call(value || {}, key);
 
 const DEFAULT_LOG_PATH = (homeDir, cwd) => `${homeDir || cwd}/.codemem/plugin.log`;
 
@@ -282,6 +296,256 @@ const applyInjectedContextToOutput = async ({
   }
   output.system.push(injected.text);
   return true;
+};
+
+const isUserMessageEntry = (entry) => entry?.info?.role === "user";
+
+const resolveEntryMessageId = (entry) => {
+  const id = entry?.info?.id || entry?.parts?.find((part) => part?.messageID)?.messageID;
+  return id ? String(id) : null;
+};
+
+const fallbackEntryMessageId = (entry, index = 0) => {
+  const id = resolveEntryMessageId(entry);
+  if (id) return id;
+  const text = extractMessageText(entry);
+  if (text) {
+    return `message-${createHash("sha256").update(text).digest("hex").slice(0, 16)}`;
+  }
+  return `message-${index}`;
+};
+
+const resolveEntrySessionID = (entry) => {
+  const id = entry?.info?.sessionID || entry?.parts?.find((part) => part?.sessionID)?.sessionID;
+  return id ? String(id) : null;
+};
+
+const isCodememContextPart = (part) =>
+  part?.type === "text" && String(part?.id || "").startsWith(CODEMEM_CONTEXT_PART_ID_PREFIX);
+
+const extractMessageText = (entry) => {
+  if (!Array.isArray(entry?.parts)) {
+    return "";
+  }
+  return entry.parts
+    .filter((part) => part?.type === "text" && !isCodememContextPart(part))
+    .map((part) => String(part?.text || "").trim())
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+};
+
+const findFirstUserMessage = (messages) => {
+  for (let index = 0; index < messages.length; index += 1) {
+    const entry = messages[index];
+    if (isUserMessageEntry(entry)) {
+      return { entry, index };
+    }
+  }
+  return null;
+};
+
+const findLatestUserMessage = (messages) => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const entry = messages[index];
+    if (isUserMessageEntry(entry)) {
+      return { entry, index };
+    }
+  }
+  return null;
+};
+
+const markCompactionInjectionSkip = (compactionInjectionSkips, sessionID, now = Date.now()) => {
+  if (!compactionInjectionSkips || !sessionID) return;
+  compactionInjectionSkips.set(String(sessionID), now + COMPACTION_INJECTION_SKIP_TTL_MS);
+};
+
+const consumeCompactionInjectionSkip = (compactionInjectionSkips, sessionID, now = Date.now()) => {
+  if (!compactionInjectionSkips || !sessionID) return false;
+  const key = String(sessionID);
+  const expiresAt = compactionInjectionSkips.get(key);
+  if (!expiresAt) return false;
+  compactionInjectionSkips.delete(key);
+  return now <= expiresAt;
+};
+
+// OpenCode does not guarantee that synthetic message parts survive into the
+// next transform call. Cache each message's injected block by message ID and
+// re-append the exact same bytes on later turns: older prompts stay stable for
+// provider prefix caching while only the newest user message triggers a fresh
+// pack build. The replay cache only activates when OpenCode provides both a
+// session ID and a real message ID; unidentified messages still receive current
+// turn context, but are not cached because positional fallbacks can drift across
+// turns or sessions. Do not "simplify" this into recomputing previous turns.
+const getSessionMessageInjectionCache = (messageInjectionCache, sessionID) => {
+  if (!sessionID) {
+    return null;
+  }
+  const cacheKey = sessionID;
+  let sessionCache = messageInjectionCache.get(cacheKey);
+  if (sessionCache) {
+    // Refresh recency so the bounded cache behaves like a small LRU.
+    messageInjectionCache.delete(cacheKey);
+  } else {
+    sessionCache = new Map();
+  }
+  messageInjectionCache.set(cacheKey, sessionCache);
+  while (messageInjectionCache.size > MAX_MESSAGE_INJECTION_CACHE_SESSIONS) {
+    const oldestKey = messageInjectionCache.keys().next().value;
+    if (!oldestKey) break;
+    messageInjectionCache.delete(oldestKey);
+  }
+  return sessionCache;
+};
+
+const trimSessionMessageInjectionCache = (sessionCache) => {
+  if (!sessionCache) return;
+  while (sessionCache.size > MAX_MESSAGE_INJECTION_CACHE_MESSAGES) {
+    const oldestKey = sessionCache.keys().next().value;
+    if (!oldestKey) break;
+    sessionCache.delete(oldestKey);
+  }
+};
+
+const normalizeInjectedMessageParts = (messages, sessionCache) => {
+  for (let index = 0; index < messages.length; index += 1) {
+    const entry = messages[index];
+    if (!isUserMessageEntry(entry) || !Array.isArray(entry.parts)) {
+      continue;
+    }
+
+    const messageId = resolveEntryMessageId(entry);
+    const retainedParts = [];
+    let existingText = null;
+    for (const part of entry.parts) {
+      if (isCodememContextPart(part)) {
+        const text = String(part?.text || "");
+        if (text.trim()) {
+          existingText = text;
+        }
+      } else {
+        retainedParts.push(part);
+      }
+    }
+    if (existingText && sessionCache && messageId && !sessionCache.has(messageId)) {
+      sessionCache.set(messageId, existingText);
+      trimSessionMessageInjectionCache(sessionCache);
+    }
+    if (retainedParts.length !== entry.parts.length) {
+      entry.parts.splice(0, entry.parts.length, ...retainedParts);
+    }
+  }
+};
+
+const buildInjectedContextPart = (entry, index, text, options = {}) => {
+  const messageId = options.messageId || fallbackEntryMessageId(entry, index);
+  const sessionID = options.sessionID || resolveEntrySessionID(entry) || "unknown";
+  return {
+    id: `${CODEMEM_CONTEXT_PART_ID_PREFIX}${messageId}`,
+    sessionID,
+    messageID: messageId,
+    type: "text",
+    text,
+    synthetic: true,
+  };
+};
+
+const appendCachedInjectedContextParts = (messages, sessionCache, sessionID = null) => {
+  let appended = 0;
+  for (let index = 0; index < messages.length; index += 1) {
+    const entry = messages[index];
+    if (!isUserMessageEntry(entry) || !Array.isArray(entry.parts)) {
+      continue;
+    }
+    const messageId = resolveEntryMessageId(entry);
+    if (!messageId) {
+      continue;
+    }
+    const text = sessionCache.get(messageId);
+    if (!text) {
+      continue;
+    }
+    entry.parts.push(buildInjectedContextPart(entry, index, text, { messageId, sessionID }));
+    appended += 1;
+  }
+  return appended;
+};
+
+const applyInjectedContextToMessages = async ({
+  injectEnabled,
+  input,
+  output,
+  injectionToastShown,
+  showToast,
+  resolveInjectQuery,
+  buildInjectedContext,
+  messageInjectionCache,
+  compactionInjectionSkips,
+}) => {
+  if (!injectEnabled || !Array.isArray(output?.messages)) {
+    return false;
+  }
+
+  const latestUser = findLatestUserMessage(output.messages);
+  const sessionID = latestUser
+    ? resolveEntrySessionID(latestUser.entry) || input?.sessionID || null
+    : input?.sessionID || null;
+
+  if (consumeCompactionInjectionSkip(compactionInjectionSkips, sessionID)) {
+    normalizeInjectedMessageParts(output.messages, null);
+    return false;
+  }
+
+  if (!latestUser) {
+    return false;
+  }
+
+  const sessionCache = getSessionMessageInjectionCache(messageInjectionCache, sessionID);
+  normalizeInjectedMessageParts(output.messages, sessionCache);
+
+  const latestMessageId = resolveEntryMessageId(latestUser.entry);
+  const canReplay = Boolean(sessionCache && latestMessageId);
+  if (!canReplay || !sessionCache.has(latestMessageId)) {
+    const firstUser = findFirstUserMessage(output.messages);
+    const query = resolveInjectQuery({
+      firstPrompt: firstUser ? extractMessageText(firstUser.entry) : null,
+      lastPromptText: extractMessageText(latestUser.entry),
+    });
+    const injected = await buildInjectedContext(query);
+    if (injected?.text) {
+      if (canReplay) {
+        sessionCache.set(latestMessageId, injected.text);
+        trimSessionMessageInjectionCache(sessionCache);
+      } else if (Array.isArray(latestUser.entry.parts)) {
+        latestUser.entry.parts.push(
+          buildInjectedContextPart(latestUser.entry, latestUser.index, injected.text, {
+            messageId: latestMessageId || undefined,
+            sessionID: sessionID || undefined,
+          })
+        );
+      }
+
+      const toastKey = sessionID || latestMessageId || "unknown";
+      if (!injectionToastShown.has(toastKey) && showToast) {
+        injectionToastShown.add(toastKey);
+        try {
+          await showToast(buildInjectionToastMessage(injected.metrics));
+        } catch {
+          // best-effort only
+        }
+      }
+    }
+  }
+
+  if (!canReplay) {
+    return Boolean(
+      Array.isArray(latestUser.entry.parts)
+      && latestUser.entry.parts.some(isCodememContextPart)
+    );
+  }
+
+  const appended = appendCachedInjectedContextParts(output.messages, sessionCache, sessionID);
+  return appended > 0;
 };
 
 const mapOpencodeEventTypeToAdapterType = (eventType) => {
@@ -589,7 +853,7 @@ const parsePositiveInt = (value, fallback) => {
 };
 
 export const buildInjectionToastMessage = (metrics) => {
-  const items = asFiniteNonNegativeInt(metrics?.items);
+  const items = asFiniteNonNegativeInt(metrics?.items) ?? asFiniteNonNegativeInt(metrics?.total_items);
   const packTokens = asFiniteNonNegativeInt(metrics?.pack_tokens);
   const avoided = asFiniteNonNegativeInt(metrics?.avoided_work_tokens);
   const avoidedUnknown = asNonNegativeCount(metrics?.avoided_work_unknown_items);
@@ -756,12 +1020,15 @@ export const OpencodeMemPlugin = async ({
   const injectEnabled = envNotDisabled(
     process.env.CODEMEM_INJECT_CONTEXT || "1"
   );
+  const injectSurface = resolveInjectSurface(process.env.CODEMEM_INJECT_SURFACE);
   // Only use env overrides if explicitly set; otherwise CLI uses config defaults
   const injectLimitEnv = process.env.CODEMEM_INJECT_LIMIT;
   const injectLimit = injectLimitEnv ? parseNumber(injectLimitEnv, null) : null;
   const injectTokenBudgetEnv = process.env.CODEMEM_INJECT_TOKEN_BUDGET;
   const injectTokenBudget = injectTokenBudgetEnv ? parseNumber(injectTokenBudgetEnv, null) : null;
   const injectionToastShown = new Set();
+  const messageInjectionCache = new Map();
+  const compactionInjectionSkips = new Map();
   let sessionStartedAt = null;
   let activeSessionID = null;
   let viewerStarted = false;
@@ -1050,6 +1317,20 @@ export const OpencodeMemPlugin = async ({
       return null;
     }
     return event?.properties?.sessionID || null;
+  };
+
+  const extractHookSessionID = (input) => {
+    if (!input || typeof input !== "object") {
+      return null;
+    }
+    return (
+      input.sessionID ||
+      input.sessionId ||
+      input.session?.id ||
+      input.session?.sessionID ||
+      input.properties?.sessionID ||
+      null
+    );
   };
 
   // Session context tracking for comprehensive memories
@@ -1500,21 +1781,34 @@ export const OpencodeMemPlugin = async ({
     await showToast(`${message}. Suggested action: ${guidance.action}`, "warning");
   };
 
-  const resolveInjectQuery = () =>
-    buildInjectQuery({
-      firstPrompt: sessionContext.firstPrompt,
-      lastPromptText,
+  const resolveInjectQuery = (overrides = {}) => {
+    const firstPrompt = hasOwn(overrides, "firstPrompt")
+      ? overrides.firstPrompt
+      : sessionContext.firstPrompt;
+    const resolvedLastPromptText = hasOwn(overrides, "lastPromptText")
+      ? overrides.lastPromptText
+      : lastPromptText;
+    return buildInjectQuery({
+      firstPrompt,
+      lastPromptText: resolvedLastPromptText,
       projectName: resolveProjectName(project, cwd),
       filesModified: sessionContext.filesModified,
     });
+  };
 
-  const describeInjectQuery = (query) => {
+  const describeInjectQuery = (query, overrides = {}) => {
     const safeQuery = redactLog((query || "").trim(), 240);
     const projectName = resolveProjectName(project, cwd) || "";
+    const firstPrompt = hasOwn(overrides, "firstPrompt")
+      ? overrides.firstPrompt
+      : sessionContext.firstPrompt;
+    const resolvedLastPromptText = hasOwn(overrides, "lastPromptText")
+      ? overrides.lastPromptText
+      : lastPromptText;
     return {
       safeQuery,
-      firstPromptLen: sessionContext.firstPrompt?.trim()?.length || 0,
-      lastPromptLen: lastPromptText?.trim()?.length || 0,
+      firstPromptLen: firstPrompt?.trim()?.length || 0,
+      lastPromptLen: resolvedLastPromptText?.trim()?.length || 0,
       projectName,
       filesModifiedCount: sessionContext.filesModified.size,
     };
@@ -1806,7 +2100,87 @@ export const OpencodeMemPlugin = async ({
   };
 
   return {
+    "experimental.session.compacting": async (input) => {
+      const sessionID = extractHookSessionID(input) || activeSessionID;
+      markCompactionInjectionSkip(compactionInjectionSkips, sessionID);
+      if (debug) {
+        await logLine(
+          `inject.compaction_skip_marked sessionID=${sessionID || "unknown"}`
+        );
+      }
+    },
+    "experimental.chat.messages.transform": async (input, output) => {
+      if (injectSurface === "system") {
+        return;
+      }
+      const latestUser = Array.isArray(output?.messages)
+        ? findLatestUserMessage(output.messages)
+        : null;
+      const sessionID = latestUser ? resolveEntrySessionID(latestUser.entry) : input?.sessionID;
+      const latestPromptText = latestUser ? extractMessageText(latestUser.entry) : "";
+      if (debug) {
+        const query = resolveInjectQuery({ lastPromptText: latestPromptText });
+        const { safeQuery, firstPromptLen, lastPromptLen, projectName, filesModifiedCount } =
+          describeInjectQuery(query, { lastPromptText: latestPromptText });
+        await logLine(
+          `inject.messages_transform sessionID=${sessionID || "unknown"} query_len=${
+            query ? query.length : 0
+          } inject_enabled=${injectEnabled} tui_toast=${Boolean(client.tui?.showToast)} query=${JSON.stringify(safeQuery)} first_prompt_len=${firstPromptLen} last_prompt_len=${lastPromptLen} project=${JSON.stringify(projectName)} files_modified=${filesModifiedCount}`
+        );
+      }
+
+      let applied = false;
+      try {
+        applied = await applyInjectedContextToMessages({
+          injectEnabled,
+          input,
+          output,
+          injectionToastShown,
+          showToast: client.tui?.showToast
+            ? async (message) => {
+              await client.tui.showToast({
+                body: {
+                  message,
+                  variant: "info",
+                },
+              });
+            }
+            : null,
+          resolveInjectQuery,
+          buildInjectedContext,
+          messageInjectionCache,
+          compactionInjectionSkips,
+        });
+      } catch (err) {
+        await logLine(
+          `inject.messages_transform.error sessionID=${sessionID || "unknown"} message=${JSON.stringify(err instanceof Error ? err.message : String(err))}`
+        );
+      }
+      if (debug) {
+        const partsCount = Array.isArray(output?.messages)
+          ? output.messages.reduce(
+            (count, entry) => count + (Array.isArray(entry?.parts) ? entry.parts.length : 0),
+            0
+          )
+          : 0;
+        await logLine(
+          `inject.messages_transform.result sessionID=${sessionID || "unknown"} applied=${Boolean(applied)} messages=${Array.isArray(output?.messages) ? output.messages.length : 0} parts=${partsCount}`
+        );
+      }
+    },
     "experimental.chat.system.transform": async (input, output) => {
+      if (injectSurface !== "system") {
+        return;
+      }
+      const hookSessionID = input?.sessionID || activeSessionID;
+      if (consumeCompactionInjectionSkip(compactionInjectionSkips, hookSessionID)) {
+        if (debug) {
+          await logLine(
+            `inject.transform.skip_compaction sessionID=${hookSessionID || "unknown"}`
+          );
+        }
+        return;
+      }
       const query = resolveInjectQuery();
       if (debug) {
         const { safeQuery, firstPromptLen, lastPromptLen, projectName, filesModifiedCount } =
@@ -2033,6 +2407,8 @@ export const OpencodeMemPlugin = async ({
         activeSessionID = null;
         if (sessionID) {
           injectionToastShown.delete(sessionID);
+          messageInjectionCache.delete(sessionID);
+          compactionInjectionSkips.delete(sessionID);
         }
         await stopViewer();
       }
@@ -2143,7 +2519,11 @@ export const __testUtils = {
   buildPackArgs,
   parsePackText,
   parsePackMetrics,
+  resolveInjectSurface,
   applyInjectedContextToOutput,
+  applyInjectedContextToMessages,
+  extractMessageText,
+  isCodememContextPart,
   buildRunnerArgs,
   appendWorkingSetFileArgs,
   extractApplyPatchPaths,


### PR DESCRIPTION
## Description
Moves OpenCode prompt-time codemem injection from the system-transform surface to `experimental.chat.messages.transform` by appending deterministic synthetic context to the latest user message. Prior injected blocks are replayed by message ID so provider prompt-cache prefixes stay stable while only the newest turn receives volatile recall output. Keeps `CODEMEM_INJECT_SURFACE=system` as the legacy fallback, fixes injection-toast item counts for real `total_items` pack metrics, skips codemem injection during compaction transforms, and honors explicit empty prompt overrides instead of falling back to stale captured prompts.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run check`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Commands run:

- `pnpm --filter codemem test:plugin -- plugin-injection.test.js plugin-transform-hook.test.js plugin-toast.test.js`
- `pnpm run lint`
- `pnpm run check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed; see upstack docs PR)
- [x] No new warnings introduced
