### PR TITLE
docs(plugin): document message-based memory injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ participant ST as MemoryStore
 participant DB as SQLite
 
 OC->>PL: tool.execute.after events
-OC->>PL: experimental.chat.system.transform
+OC->>PL: experimental.chat.messages.transform
 PL->>ST: build_memory_pack with shaped query
 ST->>DB: FTS5 BM25 lexical search
 ST->>DB: sqlite vec semantic search
@@ -126,7 +126,7 @@ PL->>OC: inject codemem context
 
 **Retrieval** combines two strategies: keyword search via SQLite FTS5 with BM25 scoring and semantic similarity via sqlite-vec embeddings. In the pack-building path, results from both are merged, exactly deduplicated, and re-ranked using recency and memory-kind boosts. Near-related memories stay fully rendered by default; use compact rendering or `CODEMEM_PACK_COMPRESSION=ids` only when you intentionally want ID-based expansion via `memory_get_observations`.
 
-**Injection** happens automatically. The plugin builds a query from the current session context (first prompt, latest prompt, project, recently modified files), calls `build_memory_pack`, and appends the result to the system prompt via `experimental.chat.system.transform`.
+**Injection** happens automatically. The plugin builds a query from the current session context (first prompt, latest prompt, project, recently modified files), calls `build_memory_pack`, and appends the result to the latest user message via `experimental.chat.messages.transform`. Prior injected message blocks are replayed byte-for-byte on later turns so provider prompt caches can keep the stable prefix. Set `CODEMEM_INJECT_SURFACE=system` to use the legacy system-prompt surface.
 
 **Memories** are typed — `bugfix`, `feature`, `refactor`, `change`, `discovery`, `decision`, `exploration` — with structured fields like `facts`, `concepts`, `files_read`, and `files_modified` that improve retrieval relevance. Low-signal events are filtered at multiple layers before persistence.
 
@@ -217,6 +217,7 @@ Common overrides:
 |----------|---------|
 | `CODEMEM_DB` | SQLite database path |
 | `CODEMEM_INJECT_CONTEXT` | `0` to disable automatic context injection |
+| `CODEMEM_INJECT_SURFACE` | `message` (default) to inject near the latest OpenCode user message; `system` for the legacy OpenCode system-prompt surface |
 | `CODEMEM_VIEWER_HOST`, `CODEMEM_VIEWER_PORT` | Host/port the plugin-managed viewer should start, probe, and restart |
 | `CODEMEM_VIEWER_AUTO` | `0` to disable auto-starting the viewer |
 | `CODEMEM_MCP_HTTP_HOST`, `CODEMEM_MCP_HTTP_PORT` | Host/port for `codemem mcp http` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,7 +163,7 @@ flowchart TD
 
 ## Context injection
 
-The plugin injects a memory pack into the system prompt on every turn. This is the primary way codemem delivers value — it happens automatically, no manual steps required.
+The plugin injects a memory pack automatically on every turn. In OpenCode, volatile recall output is appended beside the latest user message by default so provider prompt caches can keep the stable system/history prefix.
 
 Feed and retrieval surfaces can scope the corpus without splitting storage into separate pools:
 
@@ -201,7 +201,7 @@ In plugin mode, these can be overridden via `CODEMEM_INJECT_LIMIT` and `CODEMEM_
 
 ### Injection hook
 
-The plugin uses `experimental.chat.system.transform` to append the pack text to the system prompt. It caches the pack per session and re-fetches when the query changes (i.e., when prompts or file activity shift context). A toast notification shows injection stats on first inject per session.
+The OpenCode plugin uses `experimental.chat.messages.transform` to append the current pack text to the latest user message. Earlier injected message blocks are cached by message ID and replayed byte-for-byte on later turns, preserving the stable prompt prefix for provider prompt caches while only the newest user turn receives volatile recall output. Scope revocation affects newly built packs, but historical injected blocks in the same OpenCode session are not retroactively scrubbed; start a new session after revoking access if prompt history must be clean. Set `CODEMEM_INJECT_SURFACE=system` to use the legacy `experimental.chat.system.transform` system-prompt surface. A toast notification shows injection stats on first inject per session.
 
 ```mermaid
 sequenceDiagram
@@ -213,7 +213,7 @@ participant DB as SQLite
 
 OC->>PL: tool.execute.after events
 PL->>PL: update session context
-OC->>PL: experimental.chat.system.transform
+OC->>PL: experimental.chat.messages.transform
 PL->>PL: build injection query from working set
 PL->>CLI: codemem pack with query, limit, token budget
 CLI->>ST: build_memory_pack
@@ -222,7 +222,7 @@ ST->>DB: sqlite-vec semantic search
 ST->>ST: merge, rerank, assemble sections
 ST-->>CLI: pack text and metrics
 CLI-->>PL: JSON result
-PL->>OC: append codemem context to system prompt
+PL->>OC: append codemem context to latest user message
 ```
 
 ## Observer pipeline

--- a/docs/plans/2026-04-05-context-injection-test-design.md
+++ b/docs/plans/2026-04-05-context-injection-test-design.md
@@ -133,7 +133,8 @@ injection path and its supporting query logic.
 
 Required coverage:
 
-- `experimental.chat.system.transform` injects context into `output.system`
+- `experimental.chat.messages.transform` injects context into the latest user message
+- `CODEMEM_INJECT_SURFACE=system` preserves the legacy `experimental.chat.system.transform` fallback
 - injected context is prefixed/formatted according to the adapter contract
 - no injection occurs when pack generation fails
 - no injection occurs for invalid or empty JSON payloads
@@ -187,7 +188,7 @@ These tests provide a simple, stable baseline for adapter consumers.
 
 | Adapter | Entry point | Output mechanism | Query/input source | Cache behavior | Test location |
 |---|---|---|---|---|---|
-| OpenCode | plugin transform | append to system prompt | prompts + project + modified files | per-session/query cache | `packages/cli/.opencode/tests/` |
+| OpenCode | plugin transform | append to latest user message by default; legacy system prompt with `CODEMEM_INJECT_SURFACE=system` | prompts + project + modified files | per-message stable replay for prior injected blocks | `packages/cli/.opencode/tests/` |
 | Claude hook | hook path | hook-emitted prompt/additional context text | hook-specific prompt/context inputs | adapter-defined | Claude hook test file(s) |
 | CLI/manual | `pack` / `memory inject` | stdout JSON or raw text | command arguments | none | `packages/cli/src/commands/*.test.ts` and core tests |
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -10,8 +10,9 @@ This page covers advanced plugin behavior, environment variables, and stream rel
 
 1. Start OpenCode inside this repo (or make the plugin global so it globs in everywhere).
 2. Every tooling session creates memory artifacts in SQLite.
-3. Use `codemem stats` and `codemem recent` to confirm ingestion.
-4. Browse the viewer at the printed URL.
+3. Prompt-time memory injection appends volatile recall output to the latest user message by default, preserving the stable system/history prefix for provider prompt caches.
+4. Use `codemem stats` and `codemem recent` to confirm ingestion.
+5. Browse the viewer at the printed URL.
 
 ## Claude marketplace install
 
@@ -358,6 +359,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_PLUGIN_DEBUG` | Set to `1`, `true`, or `yes` to log plugin lifecycle events. |
 | `CODEMEM_PLUGIN_IGNORE` | Skip all plugin behavior for this process. |
 | `CODEMEM_INJECT_CONTEXT` | Set to `0` to disable memory pack injection (default on). |
+| `CODEMEM_INJECT_SURFACE` | OpenCode injection surface: `message` by default; set `system` for the legacy system-prompt transform. |
 | `CODEMEM_INJECT_LIMIT` | Max memory items in injected pack (default `8`). |
 | `CODEMEM_INJECT_TOKEN_BUDGET` | Approx token budget for injected pack (default `800`). |
 | `CODEMEM_USE_OPENCODE_RUN` | Use `opencode run` for observer generation (default off). |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -97,11 +97,13 @@ Command/file token caching notes:
 - Low-signal observations are filtered before writing.
 
 ## Automatic context injection
-- The plugin can inject a memory pack into the system prompt.
+- The OpenCode plugin injects a memory pack next to the latest user message by default, keeping older prompt prefixes stable for provider prompt caches.
 - Controls:
   - `CODEMEM_INJECT_CONTEXT=0` disables injection.
+  - `CODEMEM_INJECT_SURFACE=system` uses the legacy OpenCode system-prompt injection surface.
   - `CODEMEM_INJECT_LIMIT` caps memory items (default 8).
   - `CODEMEM_INJECT_TOKEN_BUDGET` caps pack size (default 800).
+- Scope revocation affects newly built packs immediately, but already-injected context in the current OpenCode session is not retroactively scrubbed; start a new session after revoking access if you need a clean prompt history.
 - Reuse savings estimate discovery work versus pack read size.
 
 ## Semantic recall


### PR DESCRIPTION
## Description
Documents OpenCode message-based memory injection, the prompt-cache motivation, and the `CODEMEM_INJECT_SURFACE=system` legacy fallback across the README, architecture notes, plugin reference, user guide, and injection test design plan.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run check`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Commands run:

- `pnpm run lint`
- `pnpm run check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
