### PR TITLE
fix(plugin): suppress execSync stderr noise on OpenCode startup

### DIFF
--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -892,7 +892,7 @@ const detectRunner = ({ cwd, envRunner }) => {
       // Suppress shell "not found" noise when codemem is not on PATH; the
       // catch below falls back to npx. Without this, stderr leaks to the
       // terminal on every OpenCode startup for npx-only installs.
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ["ignore", "pipe", "ignore"],
     }).trim();
     // Accept any global codemem at or above the pinned backend version, so a
     // newer global install is used instead of silently downgrading to
@@ -1955,7 +1955,7 @@ export const OpencodeMemPlugin = async ({
       encoding: "utf-8",
       // Suppress "fatal: not a git repository" when the working directory is
       // not a git repo. The catch below leaves version as "unknown".
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ["ignore", "pipe", "ignore"],
     }).trim();
   } catch (err) {
     // Ignore - version will remain 'unknown'

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -886,7 +886,14 @@ const detectRunner = ({ cwd, envRunner }) => {
   }
   // Prefer the TS codemem if installed globally, fall back to npx
   try {
-    const versionOutput = execSync("codemem --version", { encoding: "utf-8", timeout: 3000 }).trim();
+    const versionOutput = execSync("codemem --version", {
+      encoding: "utf-8",
+      timeout: 3000,
+      // Suppress shell "not found" noise when codemem is not on PATH; the
+      // catch below falls back to npx. Without this, stderr leaks to the
+      // terminal on every OpenCode startup for npx-only installs.
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
     // Accept any global codemem at or above the pinned backend version, so a
     // newer global install is used instead of silently downgrading to
     // `npx codemem@<pin>` (the old check only matched the exact pin or the
@@ -1946,6 +1953,9 @@ export const OpencodeMemPlugin = async ({
       cwd: runnerFrom,
       timeout: 500,
       encoding: "utf-8",
+      // Suppress "fatal: not a git repository" when the working directory is
+      // not a git repo. The catch below leaves version as "unknown".
+      stdio: ["pipe", "pipe", "pipe"],
     }).trim();
   } catch (err) {
     // Ignore - version will remain 'unknown'


### PR DESCRIPTION
## Summary

- Pipe `stdio` for two `execSync` probes in the OpenCode plugin so expected failures no longer leak shell/git stderr to the terminal on every startup.
- `detectRunner()`: `codemem --version` when the CLI is not on PATH (npx-only installs) still falls back to `npx`.
- Plugin init: `git rev-parse --short HEAD` in non-git working directories still leaves `version` as `"unknown"`.

Fixes #1282

## Problem

On OpenCode startup with `@codemem/opencode-plugin` (npx-only install, non-git cwd), users see:

```
/bin/sh: 1: codemem: not found
fatal: not a git repository (or any of the parent directories): .git
```

Both failures are already caught; only stderr was leaking.

## Change

```js
// detectRunner()
execSync("codemem --version", {
  encoding: "utf-8",
  timeout: 3000,
  stdio: ["pipe", "pipe", "pipe"],
})

// plugin init
execSync("git rev-parse --short HEAD", {
  cwd: runnerFrom,
  timeout: 500,
  encoding: "utf-8",
  stdio: ["pipe", "pipe", "pipe"],
})
```

No behavior change — only suppresses cosmetic noise.

## Test plan

- [x] Confirmed both call sites still present and unpiped on `main` / 0.39.0 before the change
- [x] Local Node repro: `execSync` with `stdio: ["pipe","pipe","pipe"]` for a missing command and `git rev-parse` in `/tmp` catches without printing stderr
- [ ] Start OpenCode with npx-only codemem install in a non-git directory — no `codemem: not found` / `fatal: not a git repository` noise
- [ ] With global `codemem` on PATH, `detectRunner()` still prefers the global binary when version matches pin
- [ ] In a git repo, plugin init still logs a short commit hash as `version`