### PR TITLE
fix(eval): align extraction evaluation with worthiness policy

### DIFF
--- a/docs/plans/2026-07-10-observer-extraction-model-eval-design.md
+++ b/docs/plans/2026-07-10-observer-extraction-model-eval-design.md
@@ -1,0 +1,107 @@
+# Observer Extraction Model Evaluation Design
+
+**Status:** Approved
+**Date:** 2026-07-10
+**Tracking:** `codemem-h67n`
+
+## Problem
+
+The current `rich-batch-shape` benchmark still treats two to four observations as
+a correctness requirement. That conflicts with the observer worthiness policy
+introduced in PR #1308, where zero or one observation can be correct when only
+that many durable facts clear the worthiness bar. The stale minimum also triggers
+a repair call that pressures models to manufacture additional observations.
+
+As a result, the benchmark rewards observation count even when the additional
+records are redundant or contain routine process narration. It also combines
+initial quality with repair behavior and does not expose content lost because a
+model used unsupported XML fields or invalid nesting.
+
+## Goals
+
+- Judge durable memory quality rather than raw observation count.
+- Keep observation cardinality as descriptive telemetry.
+- Score initial output independently from repaired output.
+- Detect invalid XML structure, unsupported fields, and parser data loss.
+- Label required, optional, and forbidden durable facts for reviewed batches.
+- Report quality, latency, token usage, repair frequency, and estimated cost.
+- Produce output that supports blinded human review.
+
+## Non-goals
+
+- Changing production observer defaults in the evaluation implementation.
+- Replacing provider-aware strict structured output work.
+- Treating a model judge as authoritative without labelled fixtures or review.
+- Requiring every rich batch to produce multiple observations.
+
+## Design
+
+### Worthiness-aligned evaluation
+
+Routine scenarios may continue to enforce zero observations because that is a
+specific behavioural contract. Rich and working scenarios will not fail solely
+because their observation count is below a fixed minimum. A rich result fails
+only when labelled durable content is omitted, forbidden/noisy content is emitted,
+the summary is unusable, or the response cannot be safely parsed.
+
+Replay will preserve the initial response and its evaluation. Repair will be a
+separate recovery measurement. Cardinality alone will not trigger rich-session
+repair.
+
+### Structural diagnostics
+
+Evaluation will inspect the raw XML before relying on the permissive parser. It
+will report illegal nesting, unknown summary fields, multiple summary blocks,
+unsupported observation kinds, and generated content discarded by parsing.
+These diagnostics remain evaluation-only until strict structured extraction is
+available for each provider.
+
+### Durable-fact labels
+
+Reviewed benchmark batches may define:
+
+- `required`: durable facts whose omission is a recall failure;
+- `optional`: useful facts that add value but are not required;
+- `forbidden`: telemetry, routine process narration, unsupported claims, or
+  known redundant framings that should not become durable observations.
+
+Labels use grounded keywords plus reviewer notes. Automated matching provides a
+repeatable first pass; the report retains raw outputs for human adjudication.
+
+### Scoring
+
+The model comparison reports independent dimensions:
+
+- required durable-fact recall;
+- worthiness precision;
+- factual grounding;
+- segmentation and non-redundancy;
+- summary breadth;
+- schema compliance and parser retention.
+
+No single observation-count gate determines the result. Aggregate scores remain
+review aids rather than substitutes for inspecting close comparisons.
+
+### Cost and performance
+
+Each run reports elapsed time, initial and repair call counts, available provider
+usage fields, and estimated cost from an explicit pricing table. Unknown usage is
+reported as unknown rather than inferred from string length.
+
+## Rollout
+
+1. Align replay and existing scenarios with the worthiness policy and add
+   structural diagnostics.
+2. Add labelled durable-fact scoring, usage/cost reporting, and review output.
+3. Calibrate GPT-5.4-mini, GPT-5.4, GPT-5.5, and GPT-5.6 Terra on a small diverse
+   set, then repeat finalists on a larger reviewed set.
+4. Consider changing the rich-tier model only after repeated quality and
+   downstream retrieval results support the change.
+
+## Validation
+
+- Unit tests cover zero/one-observation rich outputs, invalid nesting, unknown
+  fields, parser loss, and initial-versus-repair reporting.
+- Existing routine-session zero-observation behavior remains protected.
+- Targeted typecheck, lint, and tests pass for each stacked PR.
+- Calibration results include raw outputs and reviewer-readable dimension scores.

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -8,6 +8,7 @@
 import * as p from "@clack/prompts";
 import {
 	compareMemoryRoleReports,
+	type ExtractionStructuralDiagnostics,
 	getExtractionBenchmarkProfile,
 	getInjectionEvalScenarioPack,
 	getInjectionEvalScenarioPrompts,
@@ -1038,6 +1039,25 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					summaries: number;
 					observations: number;
 					repairApplied: boolean;
+					initial: {
+						status: "pass" | "shape_fail" | "observer_no_output";
+						reason: string;
+						pass: boolean;
+						failureReasons: string[];
+						summaries: number;
+						observations: number;
+						diagnostics: ExtractionStructuralDiagnostics | null;
+					};
+					repair: {
+						applied: boolean;
+						status: "pass" | "shape_fail" | "observer_no_output" | null;
+						reason: string | null;
+						pass: boolean | null;
+						failureReasons: string[];
+						summaries: number | null;
+						observations: number | null;
+						diagnostics: ExtractionStructuralDiagnostics | null;
+					};
 				}>;
 				for (const batch of benchmark.batches) {
 					const scenarioId = batch.scenarioId ?? benchmark.scenarioId;
@@ -1084,6 +1104,25 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						summaries: result.evaluation.counts.summaries,
 						observations: result.evaluation.counts.observations,
 						repairApplied: result.observer.repairApplied,
+						initial: {
+							status: result.initialClassification.status,
+							reason: result.initialClassification.reason,
+							pass: result.initialEvaluation.pass,
+							failureReasons: result.initialEvaluation.failureReasons,
+							summaries: result.initialEvaluation.counts.summaries,
+							observations: result.initialEvaluation.counts.observations,
+							diagnostics: result.observer.initialDiagnostics,
+						},
+						repair: {
+							applied: result.observer.repairApplied,
+							status: result.repairedClassification?.status ?? null,
+							reason: result.repairedClassification?.reason ?? null,
+							pass: result.repairedEvaluation?.pass ?? null,
+							failureReasons: result.repairedEvaluation?.failureReasons ?? [],
+							summaries: result.repairedEvaluation?.counts.summaries ?? null,
+							observations: result.repairedEvaluation?.counts.observations ?? null,
+							diagnostics: result.observer.repairedDiagnostics,
+						},
 					});
 				}
 				const summary = {
@@ -1190,7 +1229,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 				);
 				for (const run of runs) {
 					p.log.message(
-						`  [${run.batchId}] ${run.status.padEnd(18)} ${run.complexity.padEnd(10)} tier=${run.tier.padEnd(6)} expected=${(run.expectedTier ?? "n/a").padEnd(6)} span=${String(run.analysis.eventSpan).padEnd(3)} prompts=${run.analysis.promptCount} tools=${String(run.analysis.toolCount).padEnd(2)} transcript=${run.analysis.transcriptLength} ${run.provider}/${run.model}${run.openaiUseResponses ? " [responses]" : ""} summaries=${run.summaries} observations=${run.observations} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
+						`  [${run.batchId}] ${run.status.padEnd(18)} ${run.complexity.padEnd(10)} tier=${run.tier.padEnd(6)} expected=${(run.expectedTier ?? "n/a").padEnd(6)} span=${String(run.analysis.eventSpan).padEnd(3)} prompts=${run.analysis.promptCount} tools=${String(run.analysis.toolCount).padEnd(2)} transcript=${run.analysis.transcriptLength} ${run.provider}/${run.model}${run.openaiUseResponses ? " [responses]" : ""} initial=${run.initial.summaries}s/${run.initial.observations}o final=${run.summaries}s/${run.observations}o schema_loss=${run.initial.diagnostics?.dataLoss === true ? "yes" : "no"} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
 					);
 				}
 				p.outro("done");

--- a/packages/core/src/extraction-eval.test.ts
+++ b/packages/core/src/extraction-eval.test.ts
@@ -45,6 +45,105 @@ describe("session extraction eval", () => {
 		);
 	});
 
+	it.each([
+		0, 1, 5,
+	])("does not fail rich-batch output solely because it has %i observations", (observationCount) => {
+		// Arrange
+		const scenario = getSessionExtractionEvalScenario("rich-batch-shape");
+		if (!scenario) throw new Error("scenario missing");
+		const observations = Array.from({ length: observationCount }, (_, index) => ({
+			id: index + 2,
+			kind: "decision",
+			title: `Durable decision ${index + 1}`,
+			bodyText: "A reusable decision that cleared the worthiness bar.",
+			active: true,
+			createdAt: "2026-04-07T06:13:46.000Z",
+			metadata: {},
+		}));
+
+		// Act
+		const result = evaluateSessionExtractionItems(
+			{ type: "batch", sessionId: 166405, batchId: 18503 },
+			{
+				id: 166405,
+				project: "codemem",
+				cwd: "/tmp/repo",
+				startedAt: "2026-04-06T21:23:59.631Z",
+				endedAt: "2026-04-07T06:13:45.667Z",
+				sessionClass: "durable",
+				summaryDisposition: "stored",
+			},
+			[
+				{
+					id: 1,
+					kind: "session_summary",
+					title: "Rich batch summary",
+					bodyText: "A broad, usable summary of the completed work.",
+					active: true,
+					createdAt: "2026-04-07T06:13:45.667Z",
+					metadata: {},
+				},
+				...observations,
+			],
+			scenario,
+		);
+
+		// Assert
+		expect(result.pass).toBe(true);
+		expect(result.counts.observations).toBe(observationCount);
+		expect(result.failureReasons).not.toEqual(
+			expect.arrayContaining([expect.stringContaining("observation count")]),
+		);
+	});
+
+	it("still fails routine-batch output that emits an observation", () => {
+		// Arrange
+		const scenario = getSessionExtractionEvalScenario("routine-batch-shape");
+		if (!scenario) throw new Error("scenario missing");
+
+		// Act
+		const result = evaluateSessionExtractionItems(
+			{ type: "batch", sessionId: 166406, batchId: 18504 },
+			{
+				id: 166406,
+				project: "codemem",
+				cwd: "/tmp/repo",
+				startedAt: "2026-04-06T21:23:59.631Z",
+				endedAt: "2026-04-07T06:13:45.667Z",
+				sessionClass: "working",
+				summaryDisposition: "stored",
+			},
+			[
+				{
+					id: 1,
+					kind: "session_summary",
+					title: "Routine release summary",
+					bodyText: "The release workflow completed normally.",
+					active: true,
+					createdAt: "2026-04-07T06:13:45.667Z",
+					metadata: {},
+				},
+				{
+					id: 2,
+					kind: "change",
+					title: "Release completed",
+					bodyText: "The release workflow was green.",
+					active: true,
+					createdAt: "2026-04-07T06:13:46.000Z",
+					metadata: {},
+				},
+			],
+			scenario,
+		);
+
+		// Assert
+		expect(result.pass).toBe(false);
+		expect(result.counts.observations).toBe(1);
+		expect(result.failureReasons).toEqual([
+			expect.stringContaining("observation count 1 outside expected range 0-0"),
+		]);
+	});
+
 	it("passes when summary and observations cover the major rich-session threads", () => {
 		const scenario = getSessionExtractionEvalScenario("rich-session-under-extraction");
 		if (!scenario) throw new Error("scenario missing");
@@ -113,7 +212,7 @@ describe("session extraction eval", () => {
 		expect(result.coverage.totalThreadCoverage).toBeGreaterThanOrEqual(3);
 	});
 
-	it("fails a narrow summary plus single-observation under-extraction case", () => {
+	it("fails a narrow summary plus single observation on missing thread coverage, not count", () => {
 		const scenario = getSessionExtractionEvalScenario("rich-session-under-extraction");
 		if (!scenario) throw new Error("scenario missing");
 
@@ -155,11 +254,14 @@ describe("session extraction eval", () => {
 		expect(result.pass).toBe(false);
 		expect(result.failureReasons).toEqual(
 			expect.arrayContaining([
-				expect.stringContaining("observation count 1 outside expected range 2-4"),
 				expect.stringContaining("summary thread coverage"),
 				expect.stringContaining("observation thread coverage"),
 			]),
 		);
+		expect(result.failureReasons).not.toEqual(
+			expect.arrayContaining([expect.stringContaining("observation count")]),
+		);
+		expect(result.counts.observations).toBe(1);
 	});
 
 	it("loads and evaluates a session directly from the database", () => {

--- a/packages/core/src/extraction-eval.ts
+++ b/packages/core/src/extraction-eval.ts
@@ -1,5 +1,12 @@
 import { connect, resolveDbPath } from "./db.js";
+import type { ParsedOutput } from "./ingest-types.js";
+import {
+	inspectObserverResponseStructure,
+	type ObserverResponseStructuralDiagnostics,
+} from "./ingest-xml-parser.js";
 import { getSummaryMetadata, isSummaryLikeMemory } from "./summary-memory.js";
+
+export type ExtractionStructuralDiagnostics = ObserverResponseStructuralDiagnostics;
 
 export interface SessionExtractionEvalThread {
 	id: string;
@@ -13,6 +20,7 @@ export interface SessionExtractionEvalScenario {
 	description: string;
 	summaryCountRange: { min: number; max: number };
 	observationCountRange: { min: number; max: number };
+	enforceObservationCountRange: boolean;
 	minSummaryThreadCoverage: number;
 	minObservationThreadCoverage: number;
 	minTotalThreadCoverage: number;
@@ -91,6 +99,7 @@ const EXTRACTION_EVAL_SCENARIOS: SessionExtractionEvalScenario[] = [
 			"Evaluates whether a smaller/simple batch yields one summary and at most one durable observation without unnecessary output sprawl.",
 		summaryCountRange: { min: 1, max: 1 },
 		observationCountRange: { min: 0, max: 1 },
+		enforceObservationCountRange: true,
 		minSummaryThreadCoverage: 0,
 		minObservationThreadCoverage: 0,
 		minTotalThreadCoverage: 0,
@@ -103,6 +112,7 @@ const EXTRACTION_EVAL_SCENARIOS: SessionExtractionEvalScenario[] = [
 			"Evaluates whether a routine-activity batch (release runs, review passes with no findings, status checks, context lookups) yields one summary and zero observations, per the observation worthiness bar.",
 		summaryCountRange: { min: 1, max: 1 },
 		observationCountRange: { min: 0, max: 0 },
+		enforceObservationCountRange: true,
 		minSummaryThreadCoverage: 0,
 		minObservationThreadCoverage: 0,
 		minTotalThreadCoverage: 0,
@@ -112,9 +122,10 @@ const EXTRACTION_EVAL_SCENARIOS: SessionExtractionEvalScenario[] = [
 		id: "working-batch-shape",
 		title: "Working batch output shape",
 		description:
-			"Evaluates whether a moderate working batch yields one summary and a small set of 1-2 durable observations without over-compressing or over-emitting.",
+			"Evaluates whether a moderate working batch yields one summary and no more than two worthwhile durable observations without over-emitting.",
 		summaryCountRange: { min: 1, max: 1 },
-		observationCountRange: { min: 1, max: 2 },
+		observationCountRange: { min: 0, max: 2 },
+		enforceObservationCountRange: false,
 		minSummaryThreadCoverage: 0,
 		minObservationThreadCoverage: 0,
 		minTotalThreadCoverage: 0,
@@ -126,7 +137,8 @@ const EXTRACTION_EVAL_SCENARIOS: SessionExtractionEvalScenario[] = [
 		description:
 			"Evaluates whether a rich batch yields one broad summary plus a small capped set of durable observations, without enforcing scenario-specific thread topics.",
 		summaryCountRange: { min: 1, max: 1 },
-		observationCountRange: { min: 2, max: 4 },
+		observationCountRange: { min: 0, max: 4 },
+		enforceObservationCountRange: false,
 		minSummaryThreadCoverage: 0,
 		minObservationThreadCoverage: 0,
 		minTotalThreadCoverage: 0,
@@ -138,7 +150,8 @@ const EXTRACTION_EVAL_SCENARIOS: SessionExtractionEvalScenario[] = [
 		description:
 			"Evaluates whether a rich session yields one broad summary plus a small set of durable observations covering the major reusable subthreads.",
 		summaryCountRange: { min: 1, max: 1 },
-		observationCountRange: { min: 2, max: 4 },
+		observationCountRange: { min: 0, max: 4 },
+		enforceObservationCountRange: false,
 		minSummaryThreadCoverage: 2,
 		minObservationThreadCoverage: 2,
 		minTotalThreadCoverage: 3,
@@ -195,7 +208,7 @@ function buildFailureReasons(
 			`summary count ${counts.summaries} outside expected range ${scenario.summaryCountRange.min}-${scenario.summaryCountRange.max}`,
 		);
 	}
-	if (!rangeChecks.observationCountInRange) {
+	if (scenario.enforceObservationCountRange && !rangeChecks.observationCountInRange) {
 		failures.push(
 			`observation count ${counts.observations} outside expected range ${scenario.observationCountRange.min}-${scenario.observationCountRange.max}`,
 		);
@@ -226,6 +239,13 @@ function buildFailureReasons(
 export function getSessionExtractionEvalScenario(id: string): SessionExtractionEvalScenario | null {
 	const normalized = normalizeText(id);
 	return EXTRACTION_EVAL_SCENARIOS.find((scenario) => scenario.id === normalized) ?? null;
+}
+
+export function evaluateExtractionStructure(
+	raw: string,
+	parsed: ParsedOutput,
+): ExtractionStructuralDiagnostics {
+	return inspectObserverResponseStructure(raw, parsed);
 }
 
 export function evaluateSessionExtractionItems(

--- a/packages/core/src/extraction-replay.test.ts
+++ b/packages/core/src/extraction-replay.test.ts
@@ -41,16 +41,7 @@ describe("extraction replay", () => {
 				callCount += 1;
 				if (callCount === 1) {
 					return {
-						raw: `<summary>
-						  <request>Investigate qd7h, prep 0.23.0, and reframe Track 3 around injection-first quality.</request>
-						  <investigated>Reviewed the policy plan and discussed qd7h closure, release readiness, and graph future direction.</investigated>
-						  <learned>qd7h could be closed and Track 3 needed reframing.</learned>
-						  <completed>Started the investigation and captured a broad summary only.</completed>
-						  <next_steps>Add durable observations for the missing subthreads.</next_steps>
-						  <notes>This intentionally under-extracts to trigger the repair pass.</notes>
-						  <files_read><file>docs/plans/2026-04-07-track-3-injection-first-memory-policy.md</file></files_read>
-						  <files_modified></files_modified>
-						</summary>`,
+						raw: "I found several useful threads, but this is not valid observer XML.",
 						parsed: null,
 						provider: "test",
 						model: "test-model",
@@ -113,9 +104,78 @@ describe("extraction replay", () => {
 		expect(result.evaluation.counts.observations).toBe(2);
 		expect(result.observer.provider).toBe("test");
 		expect(result.observer.repairApplied).toBe(true);
+		expect(result.observer.initialRaw).toContain("not valid observer XML");
+		expect(result.observer.raw).toContain("<observation>");
+		expect(result.initialEvaluation.counts.observations).toBe(0);
+		expect(result.initialEvaluation.pass).toBe(false);
+		expect(result.initialClassification.status).toBe("shape_fail");
+		expect(result.repairedClassification?.status).toBe("pass");
+		expect(result.observer.repairedDiagnostics?.dataLoss).toBe(false);
+		expect(result.observer.initialDiagnostics).toMatchObject({
+			recognizedOutput: false,
+			dataLoss: true,
+		});
 		expect(callCount).toBe(2);
 		expect(result.observerContext.userPrompt).toContain("Track 3");
 		expect(result.evaluation.coverage.totalThreadCoverage).toBeGreaterThanOrEqual(3);
+		expect(result.evaluation.pass).toBe(true);
+	});
+
+	it("does not repair a rich result when observation count is its only potential failure", async () => {
+		// Arrange
+		const dbPath = createDbPath("extraction-replay-rich-count-only");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (166407, '2026-04-06T21:23:59.631Z', '2026-04-07T06:13:45.667Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"post":{"session_class":"durable","summary_disposition":"stored"}}');
+				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+				  ('opencode', 'ses-3', 'ses-3', 166407, '2026-04-06T21:23:59.631Z');
+				INSERT INTO raw_event_flush_batches(id, source, stream_id, opencode_session_id, start_event_seq, end_event_seq, extractor_version, status, attempt_count, created_at, updated_at) VALUES
+				  (18505, 'opencode', 'ses-3', 'ses-3', 1, 2, 'raw_events_v1', 'completed', 1, '2026-04-07T06:13:45.600Z', '2026-04-07T06:13:45.700Z');
+				INSERT INTO raw_events(id, source, stream_id, opencode_session_id, event_id, event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, created_at) VALUES
+				  (21, 'opencode', 'ses-3', 'ses-3', 'evt-21', 1, 'user_prompt', 1000, 1, '{"type":"user_prompt","prompt_text":"Investigate several extraction evaluation concerns"}', '2026-04-07T06:13:45.600Z'),
+				  (22, 'opencode', 'ses-3', 'ses-3', 'evt-22', 2, 'user_prompt', 1010, 2, '{"type":"user_prompt","prompt_text":"Report only durable outcomes"}', '2026-04-07T06:13:45.610Z');
+			`);
+		} finally {
+			db.close();
+		}
+		const raw = `<summary>
+		  <request>Investigate several extraction evaluation concerns.</request>
+		  <investigated>Reviewed the evaluation policy and replay behavior.</investigated>
+		  <learned>No individual fact cleared the durable observation bar.</learned>
+		  <completed>Produced a broad summary without manufacturing observations.</completed>
+		  <next_steps>Continue with labelled durable-fact evaluation.</next_steps>
+		  <notes>The zero-observation cardinality is intentional.</notes>
+		</summary>`;
+		let callCount = 0;
+		const observer = {
+			observe: async () => {
+				callCount += 1;
+				return { raw, parsed: null, provider: "test", model: "test-model" };
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		} as unknown as ObserverClient;
+
+		// Act
+		const result = await replayBatchExtraction(dbPath, observer, {
+			batchId: 18505,
+			scenarioId: "rich-batch-shape",
+		});
+
+		// Assert
+		expect(callCount).toBe(1);
+		expect(result.observer.repairApplied).toBe(false);
+		expect(result.observer.initialRaw).toBe(raw);
+		expect(result.observer.raw).toBe(raw);
+		expect(result.initialEvaluation.counts.observations).toBe(0);
+		expect(result.evaluation.counts.observations).toBe(0);
 		expect(result.evaluation.pass).toBe(true);
 	});
 
@@ -239,7 +299,8 @@ describe("extraction replay", () => {
 
 		expect(result.evaluation.counts.summaries).toBe(1);
 		expect(result.evaluation.counts.observations).toBe(0);
-		expect(result.classification.status).toBe("shape_fail");
+		expect(result.classification.status).toBe("pass");
+		expect(result.observer.initialDiagnostics?.unsupportedObservationKinds).toEqual(["foo"]);
 	});
 
 	it("populates session context fields from Claude Code adapter-enveloped raw events during replay", async () => {

--- a/packages/core/src/extraction-replay.ts
+++ b/packages/core/src/extraction-replay.ts
@@ -1,5 +1,6 @@
 import { connect, resolveDbPath } from "./db.js";
 import {
+	evaluateExtractionStructure,
 	evaluateSessionExtractionItems,
 	getSessionExtractionEvalScenario,
 } from "./extraction-eval.js";
@@ -30,7 +31,7 @@ import type {
 	SessionContext,
 	ToolEvent,
 } from "./ingest-types.js";
-import { parseObserverResponse } from "./ingest-xml-parser.js";
+import { parseObserverResponse, SUPPORTED_OBSERVATION_KINDS } from "./ingest-xml-parser.js";
 import {
 	type ObserverClient,
 	ObserverClient as ObserverClientImpl,
@@ -38,16 +39,6 @@ import {
 } from "./observer-client.js";
 import { resolveProject } from "./project.js";
 import { buildSessionContext } from "./raw-event-flush.js";
-
-const ALLOWED_KINDS = new Set([
-	"bugfix",
-	"feature",
-	"refactor",
-	"change",
-	"discovery",
-	"decision",
-	"exploration",
-]);
 
 function normalizePath(path: string, repoRoot: string | null): string {
 	if (!path) return "";
@@ -105,23 +96,27 @@ async function observeStructuredOutput(
 	observer: ObserverClient,
 	system: string,
 	user: string,
-): Promise<{ raw: string | null; parsed: ParsedOutput; provider: string; model: string }> {
+): Promise<{
+	initial: { raw: string | null; parsed: ParsedOutput; provider: string; model: string };
+	repaired: { raw: string | null; parsed: ParsedOutput; provider: string; model: string } | null;
+}> {
 	const first = await observer.observe(system, user);
 	const firstParsed = first.raw
 		? parseObserverResponse(first.raw)
 		: { observations: [], summary: null, skipSummaryReason: null };
+	const initial = {
+		raw: first.raw,
+		parsed: firstParsed,
+		provider: first.provider,
+		model: first.model,
+	};
 	if (
 		!first.raw ||
 		firstParsed.observations.length > 0 ||
 		firstParsed.summary !== null ||
 		firstParsed.skipSummaryReason !== null
 	) {
-		return {
-			raw: first.raw,
-			parsed: firstParsed,
-			provider: first.provider,
-			model: first.model,
-		};
+		return { initial, repaired: null };
 	}
 
 	const repairSystem = `${system}\n\nYour previous reply was invalid because it did not follow the required XML-only schema. Rewrite the same analysis as valid XML only. Do not include prose outside XML.`;
@@ -131,10 +126,13 @@ async function observeStructuredOutput(
 		? parseObserverResponse(repaired.raw)
 		: { observations: [], summary: null, skipSummaryReason: null };
 	return {
-		raw: repaired.raw,
-		parsed: repairedParsed,
-		provider: repaired.provider,
-		model: repaired.model,
+		initial,
+		repaired: {
+			raw: repaired.raw,
+			parsed: repairedParsed,
+			provider: repaired.provider,
+			model: repaired.model,
+		},
 	};
 }
 
@@ -167,10 +165,20 @@ export interface ExtractionReplayResult {
 		temperature: number | null;
 		repairApplied: boolean;
 		initialRaw: string | null;
+		initialParsed: ParsedOutput;
+		initialDiagnostics: ReturnType<typeof evaluateExtractionStructure> | null;
+		repairedRaw: string | null;
+		repairedParsed: ParsedOutput | null;
+		repairedDiagnostics: ReturnType<typeof evaluateExtractionStructure> | null;
 		raw: string | null;
 		parsed: ParsedOutput;
+		diagnostics: ReturnType<typeof evaluateExtractionStructure> | null;
 	};
 	observerContext: ObserverContext;
+	initialClassification: ExtractionReplayResult["classification"];
+	repairedClassification: ExtractionReplayResult["classification"] | null;
+	initialEvaluation: ReturnType<typeof evaluateSessionExtractionItems>;
+	repairedEvaluation: ReturnType<typeof evaluateSessionExtractionItems> | null;
 	evaluation: ReturnType<typeof evaluateSessionExtractionItems>;
 }
 
@@ -236,20 +244,6 @@ function classifyReplayResult(input: {
 	};
 }
 
-function isRichReplayCandidate(
-	observerContext: ObserverContext,
-	sessionContext: SessionContext,
-	scenarioThreadCount: number,
-): boolean {
-	const transcriptLength = observerContext.transcript.trim().length;
-	return (
-		(sessionContext.promptCount ?? 0) >= 2 ||
-		(sessionContext.toolCount ?? 0) >= 3 ||
-		transcriptLength >= 1500 ||
-		scenarioThreadCount >= 3
-	);
-}
-
 function buildReplayItems(
 	parsed: ParsedOutput,
 	batch: {
@@ -280,7 +274,7 @@ function buildReplayItems(
 	for (const obs of parsed.observations) {
 		const kind = obs.kind.trim().toLowerCase();
 		if (!kind || (!obs.title && !obs.narrative)) continue;
-		if (!ALLOWED_KINDS.has(kind)) continue;
+		if (!SUPPORTED_OBSERVATION_KINDS.has(kind)) continue;
 		if (isLowSignalObservation(obs.title) || isLowSignalObservation(obs.narrative)) continue;
 		const bodyParts: string[] = [];
 		if (obs.narrative) bodyParts.push(obs.narrative);
@@ -327,56 +321,6 @@ function buildReplayItems(
 		}
 	}
 	return replayItems;
-}
-
-function needsRichSessionRepair(
-	evaluation: ReturnType<typeof evaluateSessionExtractionItems>,
-	observerContext: ObserverContext,
-	sessionContext: SessionContext,
-	scenario: { observationCountRange: { min: number } },
-): boolean {
-	if (!isRichReplayCandidate(observerContext, sessionContext, evaluation.threads.length))
-		return false;
-	// Honor the scenario's own floor: a routine-shape scenario expects zero
-	// observations, and repairing a valid summary-only response would force the
-	// exact routine narration the worthiness bar exists to reject.
-	const minObservations = scenario.observationCountRange.min;
-	if (minObservations <= 0) return false;
-	if (evaluation.counts.observations === 0 && evaluation.counts.summaries >= 1) return true;
-	return evaluation.counts.observations < minObservations;
-}
-
-async function observeRichSessionRepair(
-	observer: ObserverClient,
-	baseSystem: string,
-	baseUser: string,
-	initialRaw: string,
-	evaluation: ReturnType<typeof evaluateSessionExtractionItems>,
-): Promise<{ raw: string | null; parsed: ParsedOutput; provider: string; model: string }> {
-	const missingThreads = evaluation.threads
-		.filter((thread) => !thread.observationMatch)
-		.map((thread) => thread.title);
-	const repairSystem = `${baseSystem}
-
-RICH-SESSION REPAIR REQUIREMENT:
-- The previous output under-extracted a rich batch.
-- For a rich session, summary-only output is not acceptable when multiple durable subthreads are present.
-- Return valid XML with one broad <summary> plus at least 2 durable <observation> blocks covering DISTINCT subthreads.
-- Do not repeat the same dominant thread in multiple observations.
-- Choose observations for reusable decisions, learnings, troubleshooting outcomes, or future-facing exploration that would reduce rediscovery in later sessions.`;
-	const repairUser = `${baseUser}
-
-Previous under-extracted XML to repair:
-${initialRaw}
-
-The previous output failed because:
-- observations returned: ${evaluation.counts.observations}
-- total thread coverage: ${evaluation.coverage.totalThreadCoverage}
-- missing observation coverage for: ${missingThreads.length > 0 ? missingThreads.join(", ") : "none recorded"}
-
-Rewrite the analysis as valid XML only.
-Keep the broad summary, but add 2-4 durable observations for distinct subthreads if the transcript supports them.`;
-	return observeStructuredOutput(observer, repairSystem, repairUser);
 }
 
 async function prepareReplayBatch(
@@ -601,57 +545,54 @@ async function replayPreparedBatch(
 	tier: "simple" | "rich" | null,
 	tierReasons: string[],
 ): Promise<ExtractionReplayResult> {
-	const initialResponse = await observeStructuredOutput(observer, prepared.system, prepared.user);
-	let finalResponse = initialResponse;
-	let replayItems = buildReplayItems(finalResponse.parsed, prepared.batch, prepared.sessionContext);
-	let evaluation = evaluateSessionExtractionItems(
-		{ type: "batch", sessionId: prepared.batch.session_id, batchId: prepared.batch.id },
-		{
-			id: prepared.batch.session_id,
-			project: prepared.batch.project,
-			cwd: prepared.batch.cwd ?? process.cwd(),
-			startedAt: prepared.batch.started_at ?? "",
-			endedAt: prepared.batch.ended_at,
-			sessionClass: String(prepared.sessionPost.session_class ?? "unknown"),
-			summaryDisposition: String(prepared.sessionPost.summary_disposition ?? "unknown"),
-		},
-		replayItems,
+	const response = await observeStructuredOutput(observer, prepared.system, prepared.user);
+	const session = {
+		id: prepared.batch.session_id,
+		project: prepared.batch.project,
+		cwd: prepared.batch.cwd ?? process.cwd(),
+		startedAt: prepared.batch.started_at ?? "",
+		endedAt: prepared.batch.ended_at,
+		sessionClass: String(prepared.sessionPost.session_class ?? "unknown"),
+		summaryDisposition: String(prepared.sessionPost.summary_disposition ?? "unknown"),
+	};
+	const target = {
+		type: "batch" as const,
+		sessionId: prepared.batch.session_id,
+		batchId: prepared.batch.id,
+	};
+	const initialEvaluation = evaluateSessionExtractionItems(
+		target,
+		session,
+		buildReplayItems(response.initial.parsed, prepared.batch, prepared.sessionContext),
 		prepared.scenario,
 	);
-	let repairApplied = false;
-	if (
-		initialResponse.raw &&
-		needsRichSessionRepair(
-			evaluation,
-			prepared.observerContext,
-			prepared.sessionContext,
-			prepared.scenario,
-		)
-	) {
-		repairApplied = true;
-		finalResponse = await observeRichSessionRepair(
-			observer,
-			prepared.system,
-			prepared.user,
-			initialResponse.raw,
-			evaluation,
-		);
-		replayItems = buildReplayItems(finalResponse.parsed, prepared.batch, prepared.sessionContext);
-		evaluation = evaluateSessionExtractionItems(
-			{ type: "batch", sessionId: prepared.batch.session_id, batchId: prepared.batch.id },
-			{
-				id: prepared.batch.session_id,
-				project: prepared.batch.project,
-				cwd: prepared.batch.cwd ?? process.cwd(),
-				startedAt: prepared.batch.started_at ?? "",
-				endedAt: prepared.batch.ended_at,
-				sessionClass: String(prepared.sessionPost.session_class ?? "unknown"),
-				summaryDisposition: String(prepared.sessionPost.summary_disposition ?? "unknown"),
-			},
-			replayItems,
-			prepared.scenario,
-		);
-	}
+	const repairedEvaluation = response.repaired
+		? evaluateSessionExtractionItems(
+				target,
+				session,
+				buildReplayItems(response.repaired.parsed, prepared.batch, prepared.sessionContext),
+				prepared.scenario,
+			)
+		: null;
+	const finalResponse = response.repaired ?? response.initial;
+	const evaluation = repairedEvaluation ?? initialEvaluation;
+	const initialClassification = classifyReplayResult({
+		raw: response.initial.raw,
+		evaluation: initialEvaluation,
+	});
+	const repairedClassification = response.repaired
+		? classifyReplayResult({
+				raw: response.repaired.raw,
+				evaluation: repairedEvaluation ?? initialEvaluation,
+			})
+		: null;
+	const initialDiagnostics = evaluateExtractionStructure(
+		response.initial.raw ?? "",
+		response.initial.parsed,
+	);
+	const repairedDiagnostics = response.repaired
+		? evaluateExtractionStructure(response.repaired.raw ?? "", response.repaired.parsed)
+		: null;
 
 	return {
 		scenario: {
@@ -676,12 +617,22 @@ async function replayPreparedBatch(
 			reasoningSummary: observer.reasoningSummary,
 			maxOutputTokens: observer.maxOutputTokens,
 			temperature: observer.temperature,
-			repairApplied,
-			initialRaw: initialResponse.raw,
+			repairApplied: response.repaired !== null,
+			initialRaw: response.initial.raw,
+			initialParsed: response.initial.parsed,
+			initialDiagnostics,
+			repairedRaw: response.repaired?.raw ?? null,
+			repairedParsed: response.repaired?.parsed ?? null,
+			repairedDiagnostics,
 			raw: finalResponse.raw,
 			parsed: finalResponse.parsed,
+			diagnostics: repairedDiagnostics ?? initialDiagnostics,
 		},
 		observerContext: prepared.observerContext,
+		initialClassification,
+		repairedClassification,
+		initialEvaluation,
+		repairedEvaluation,
 		evaluation,
 	};
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -249,6 +249,7 @@ export {
 	listExtractionBenchmarkProfiles,
 } from "./extraction-benchmarks.js";
 export type {
+	ExtractionStructuralDiagnostics,
 	SessionExtractionEvalItem,
 	SessionExtractionEvalResult,
 	SessionExtractionEvalScenario,
@@ -256,6 +257,7 @@ export type {
 	SessionExtractionEvalThreadResult,
 } from "./extraction-eval.js";
 export {
+	evaluateExtractionStructure,
 	evaluateSessionExtractionItems,
 	getSessionExtractionEval,
 	getSessionExtractionEvalScenario,
@@ -319,7 +321,13 @@ export type {
 	SessionContext,
 	ToolEvent,
 } from "./ingest-types.js";
-export { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
+export type { ObserverResponseStructuralDiagnostics } from "./ingest-xml-parser.js";
+export {
+	hasMeaningfulObservation,
+	inspectObserverResponseStructure,
+	parseObserverResponse,
+	SUPPORTED_OBSERVATION_KINDS,
+} from "./ingest-xml-parser.js";
 export { parsePositiveMemoryId, parseStrictInteger } from "./integers.js";
 export type {
 	BackfillTagsTextOptions,

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -26,7 +26,11 @@ import {
 	normalizeRequestText,
 } from "./ingest-transcript.js";
 import type { IngestPayload, ParsedSummary, ToolEvent } from "./ingest-types.js";
-import { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
+import {
+	hasMeaningfulObservation,
+	inspectObserverResponseStructure,
+	parseObserverResponse,
+} from "./ingest-xml-parser.js";
 import type { ObserverConfig } from "./observer-client.js";
 import { flushRawEvents } from "./raw-event-flush.js";
 import { MemoryStore } from "./store.js";
@@ -297,6 +301,12 @@ describe("ingest-xml-parser", () => {
 			expect(result.summary?.request).toBe("Fix the auth bug");
 			expect(result.summary?.completed).toBe("Fixed the timeout");
 			expect(result.skipSummaryReason).toBeNull();
+			expect(inspectObserverResponseStructure(xml, result)).toMatchObject({
+				dataLoss: false,
+				illegalObservationNestingInSummary: 0,
+				unknownSummaryFields: [],
+				unsupportedObservationKinds: [],
+			});
 		});
 
 		it("handles skip_summary", () => {
@@ -329,6 +339,101 @@ describe("ingest-xml-parser", () => {
 			expect(result.observations).toHaveLength(2);
 			expect(result.observations[0]?.title).toBe("First");
 			expect(result.observations[1]?.title).toBe("Second");
+		});
+
+		it("reports invalid observation nesting inside a summary", () => {
+			// Arrange
+			const xml = `<summary>
+			  <request>Summarize the work.</request>
+			  <observation><type>decision</type><title>Nested decision</title></observation>
+			</summary>`;
+
+			// Act
+			const result = inspectObserverResponseStructure(xml);
+
+			// Assert
+			expect(result.illegalObservationNestingInSummary).toBe(1);
+		});
+
+		it("reports unknown summary fields instead of silently discarding them", () => {
+			// Arrange
+			const xml = `<summary>
+			  <request>Summarize the work.</request>
+			  <outcome>The implementation shipped.</outcome>
+			</summary>`;
+
+			// Act
+			const result = inspectObserverResponseStructure(xml);
+
+			// Assert
+			expect(result.unknownSummaryFields).toEqual(["outcome"]);
+			expect(result.dataLoss).toBe(true);
+		});
+
+		it("reports multiple summaries while retaining the selected summary", () => {
+			// Arrange
+			const xml = `
+			<summary><request>First request</request></summary>
+			<summary><request>Second request</request></summary>`;
+
+			// Act
+			const parsed = parseObserverResponse(xml);
+			const result = inspectObserverResponseStructure(xml, parsed);
+
+			// Assert
+			expect(parsed.summary?.request).toBe("Second request");
+			expect(result.summaryBlocks).toBe(2);
+			expect(result.discardedSummaryBlocks).toBe(1);
+			expect(result.dataLoss).toBe(true);
+		});
+
+		it("reports unsupported observation kinds", () => {
+			// Arrange
+			const xml = `<observation>
+			  <type>status_update</type>
+			  <title>Release status</title>
+			  <narrative>The release workflow was green.</narrative>
+			</observation>`;
+
+			// Act
+			const result = inspectObserverResponseStructure(xml);
+
+			// Assert
+			expect(result.unsupportedObservationKinds).toEqual(["status_update"]);
+		});
+
+		it("reports a retained observation with no kind as data loss", () => {
+			const xml = `<observation>
+			  <title>Durable lesson without a type</title>
+			  <narrative>This block parses but replay cannot store it without a kind.</narrative>
+			</observation>`;
+
+			const result = inspectObserverResponseStructure(xml);
+
+			expect(result.retainedObservations).toBe(1);
+			expect(result.missingObservationKinds).toBe(1);
+			expect(result.dataLoss).toBe(true);
+		});
+
+		it("preserves an observation kind attribute", () => {
+			const xml = `<observation kind="decision">
+			  <title>Durable decision</title>
+			  <narrative>The observer used the supported attribute form.</narrative>
+			</observation>`;
+
+			const parsed = parseObserverResponse(xml);
+			const diagnostics = inspectObserverResponseStructure(xml, parsed);
+
+			expect(parsed.observations[0]?.kind).toBe("decision");
+			expect(diagnostics.missingObservationKinds).toBe(0);
+			expect(diagnostics.dataLoss).toBe(false);
+		});
+
+		it("reports plain prose as unrecognized lossy output", () => {
+			const result = inspectObserverResponseStructure("I found a durable lesson.");
+
+			expect(result.recognizedOutput).toBe(false);
+			expect(result.dataLoss).toBe(true);
 		});
 	});
 

--- a/packages/core/src/ingest-xml-parser.ts
+++ b/packages/core/src/ingest-xml-parser.ts
@@ -20,6 +20,42 @@ const SUMMARY_BLOCK_RE = /<summary[^>]*>.*?<\/summary>/gs;
 const SKIP_SUMMARY_RE = /<skip_summary(?:\s+reason="(?<reason>[^"]+)")?\s*\/>/i;
 const CODE_FENCE_RE = /```(?:xml)?/gi;
 
+const SUMMARY_FIELDS = new Set([
+	"request",
+	"investigated",
+	"learned",
+	"completed",
+	"next_steps",
+	"notes",
+	"files_read",
+	"files_modified",
+]);
+
+export const SUPPORTED_OBSERVATION_KINDS = new Set([
+	"bugfix",
+	"feature",
+	"refactor",
+	"change",
+	"discovery",
+	"decision",
+	"exploration",
+]);
+
+export interface ObserverResponseStructuralDiagnostics {
+	recognizedOutput: boolean;
+	observationBlocks: number;
+	retainedObservations: number;
+	summaryBlocks: number;
+	retainedSummaries: number;
+	illegalObservationNestingInSummary: number;
+	unknownSummaryFields: string[];
+	unsupportedObservationKinds: string[];
+	missingObservationKinds: number;
+	discardedObservationBlocks: number;
+	discardedSummaryBlocks: number;
+	dataLoss: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Text extraction helpers
 // ---------------------------------------------------------------------------
@@ -56,13 +92,39 @@ function extractChildTexts(xml: string, parentTag: string, childTag: string): st
 	return items;
 }
 
+function directChildTagNames(block: string, rootTag: string): string[] {
+	const inner = extractTagText(block, rootTag);
+	const tags: string[] = [];
+	const tagPattern = /<\/?([A-Za-z_][\w:.-]*)(?:\s[^<>]*?)?\s*\/?>/g;
+	let depth = 0;
+	for (let match = tagPattern.exec(inner); match !== null; match = tagPattern.exec(inner)) {
+		const token = match[0];
+		const tag = match[1]?.toLowerCase();
+		if (!tag) continue;
+		if (token.startsWith("</")) {
+			depth = Math.max(0, depth - 1);
+			continue;
+		}
+		if (depth === 0) tags.push(tag);
+		if (!token.endsWith("/>")) depth += 1;
+	}
+	return tags;
+}
+
+function observationKind(block: string): string {
+	const type = extractTagText(block, "type");
+	if (type) return type.trim().toLowerCase();
+	const attribute = /<observation\b[^>]*\bkind=["']([^"']+)["']/i.exec(block)?.[1];
+	return attribute?.trim().toLowerCase() ?? "";
+}
+
 // ---------------------------------------------------------------------------
 // Block parsers
 // ---------------------------------------------------------------------------
 
 function parseObservationBlock(block: string): ParsedObservation | null {
 	// Minimal validation — must have at least a type or title
-	const kind = extractTagText(block, "type");
+	const kind = observationKind(block);
 	const title = extractTagText(block, "title");
 	if (!kind && !title) return null;
 
@@ -137,6 +199,65 @@ export function parseObserverResponse(raw: string): ParsedOutput {
 	const skipReason = skipMatch?.groups?.reason ?? null;
 
 	return { observations, summary, skipSummaryReason: skipReason };
+}
+
+/** Inspect permissively parsed output without changing production parser behavior. */
+export function inspectObserverResponseStructure(
+	raw: string,
+	parsed: ParsedOutput = parseObserverResponse(raw),
+): ObserverResponseStructuralDiagnostics {
+	const cleaned = cleanXmlText(raw);
+	const observationBlockValues = cleaned.match(OBSERVATION_BLOCK_RE) ?? [];
+	const observationBlocks = cleaned.match(/<observation(?:\s|>)/gi)?.length ?? 0;
+	const summaryBlockValues = cleaned.match(SUMMARY_BLOCK_RE) ?? [];
+	const summaryBlocks = cleaned.match(/<summary(?:\s|>)/gi)?.length ?? 0;
+	const recognizedOutput =
+		observationBlocks > 0 || summaryBlocks > 0 || SKIP_SUMMARY_RE.test(cleaned);
+	const illegalObservationNestingInSummary = summaryBlockValues.reduce(
+		(count, block) => count + (block.match(/<observation(?:\s|>)/gi)?.length ?? 0),
+		0,
+	);
+	const unknownSummaryFields = [
+		...new Set(
+			summaryBlockValues
+				.flatMap((block) => directChildTagNames(block, "summary"))
+				.filter((field) => field !== "observation" && !SUMMARY_FIELDS.has(field)),
+		),
+	].sort();
+	const unsupportedObservationKinds = [
+		...new Set(
+			observationBlockValues
+				.map(observationKind)
+				.filter((kind) => kind && !SUPPORTED_OBSERVATION_KINDS.has(kind)),
+		),
+	].sort();
+	const missingObservationKinds = observationBlockValues.filter(
+		(block) => !observationKind(block) && parseObservationBlock(block) !== null,
+	).length;
+	const retainedSummaries = parsed.summary ? 1 : 0;
+	const discardedObservationBlocks = Math.max(0, observationBlocks - parsed.observations.length);
+	const discardedSummaryBlocks = Math.max(0, summaryBlocks - retainedSummaries);
+
+	return {
+		recognizedOutput,
+		observationBlocks,
+		retainedObservations: parsed.observations.length,
+		summaryBlocks,
+		retainedSummaries,
+		illegalObservationNestingInSummary,
+		unknownSummaryFields,
+		unsupportedObservationKinds,
+		missingObservationKinds,
+		discardedObservationBlocks,
+		discardedSummaryBlocks,
+		dataLoss:
+			(cleaned.length > 0 && !recognizedOutput) ||
+			discardedObservationBlocks > 0 ||
+			discardedSummaryBlocks > 0 ||
+			unknownSummaryFields.length > 0 ||
+			unsupportedObservationKinds.length > 0 ||
+			missingObservationKinds > 0,
+	};
 }
 
 /** Return true if at least one observation has a title or narrative. */


### PR DESCRIPTION
## Description

- align extraction evaluation with the current no-minimum worthiness policy
- stop cardinality-only rich-session repair while preserving malformed-output recovery
- report initial and repaired classifications separately
- add structural diagnostics for invalid nesting, unknown fields, unsupported kinds, and parser loss
- document the approved evaluation design

Stack: base PR for #1323. Tracks `codemem-h67n.1`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Full local gate: 134 files, 2,583 tests passed, 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced