### PR TITLE
feat(eval): add durable-fact and cost-aware model scoring

### DIFF
--- a/docs/plans/2026-07-10-observer-extraction-model-eval-design.md
+++ b/docs/plans/2026-07-10-observer-extraction-model-eval-design.md
@@ -105,3 +105,13 @@ reported as unknown rather than inferred from string length.
 - Existing routine-session zero-observation behavior remains protected.
 - Targeted typecheck, lint, and tests pass for each stacked PR.
 - Calibration results include raw outputs and reviewer-readable dimension scores.
+
+## Initial Model Recommendation
+
+Keep GPT-5.4-mini as the simple-tier default and GPT-5.4 as the rich-tier
+default. Treat GPT-5.6 Terra as the leading cost-matched rich-tier challenger
+and GPT-5.5 as the higher-cost quality ceiling. Existing reviewed samples show
+Terra is competitive, but two batches are not enough evidence for a production
+default change. Use reasoning effort `none` for this extraction workload unless
+the corrected evaluation demonstrates a repeatable gain from additional
+reasoning.

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -8,8 +8,12 @@
 import * as p from "@clack/prompts";
 import {
 	compareMemoryRoleReports,
+	type ExtractionBenchmarkScore,
+	type ExtractionModelCostEstimate,
 	type ExtractionStructuralDiagnostics,
+	estimateExtractionModelCost,
 	getExtractionBenchmarkProfile,
+	getExtractionModelPricing,
 	getInjectionEvalScenarioPack,
 	getInjectionEvalScenarioPrompts,
 	getMemoryArtifactReport,
@@ -21,10 +25,12 @@ import {
 	loadObserverConfig,
 	MemoryStore,
 	ObserverClient,
+	type ObserverTokenUsage,
 	replayBatchExtraction,
 	replayBatchExtractionWithTierRouting,
 	resolveDbPath,
 	resolveProject,
+	scoreExtractionBenchmarkOutput,
 } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
@@ -1047,6 +1053,8 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						summaries: number;
 						observations: number;
 						diagnostics: ExtractionStructuralDiagnostics | null;
+						elapsedMs: number | null;
+						usage: ObserverTokenUsage | null;
 					};
 					repair: {
 						applied: boolean;
@@ -1057,7 +1065,21 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						summaries: number | null;
 						observations: number | null;
 						diagnostics: ExtractionStructuralDiagnostics | null;
+						elapsedMs: number | null;
+						usage: ObserverTokenUsage | null;
 					};
+					telemetry: {
+						totalElapsedMs: number | null;
+						totalUsage: ObserverTokenUsage | null;
+					};
+					pricing: ReturnType<typeof getExtractionModelPricing>;
+					cost: {
+						initial: ExtractionModelCostEstimate | null;
+						repair: ExtractionModelCostEstimate | null;
+						total: ExtractionModelCostEstimate | null;
+						unavailableReason: "missing_usage" | "unknown_model_pricing" | null;
+					};
+					quality: ExtractionBenchmarkScore | null;
 				}>;
 				for (const batch of benchmark.batches) {
 					const scenarioId = batch.scenarioId ?? benchmark.scenarioId;
@@ -1077,6 +1099,35 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 									scenarioId,
 									transcriptBudget: transcriptBudget ?? undefined,
 								});
+					const initialCost = estimateExtractionModelCost(
+						result.observer.model,
+						result.observer.initialUsage,
+					);
+					const repairCost = estimateExtractionModelCost(
+						result.observer.model,
+						result.observer.repairedUsage,
+					);
+					const totalCost = estimateExtractionModelCost(
+						result.observer.model,
+						result.observer.totalUsage,
+					);
+					const pricing = getExtractionModelPricing(result.observer.model);
+					const costUnavailableReason = totalCost
+						? null
+						: result.observer.totalUsage == null
+							? "missing_usage"
+							: "unknown_model_pricing";
+					const quality = result.observer.initialDiagnostics
+						? scoreExtractionBenchmarkOutput({
+								parsed: result.observer.initialParsed,
+								diagnostics: result.observer.initialDiagnostics,
+								review: batch.review ?? {
+									status: "unreviewed",
+									reviewerNotes: "No durable-fact review has been recorded for this batch.",
+								},
+								estimatedCostUsd: initialCost?.totalCostUsd ?? null,
+							})
+						: null;
 					runs.push({
 						batchId: batch.batchId,
 						sessionId: batch.sessionId,
@@ -1112,6 +1163,8 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 							summaries: result.initialEvaluation.counts.summaries,
 							observations: result.initialEvaluation.counts.observations,
 							diagnostics: result.observer.initialDiagnostics,
+							elapsedMs: result.observer.initialElapsedMs,
+							usage: result.observer.initialUsage,
 						},
 						repair: {
 							applied: result.observer.repairApplied,
@@ -1122,9 +1175,26 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 							summaries: result.repairedEvaluation?.counts.summaries ?? null,
 							observations: result.repairedEvaluation?.counts.observations ?? null,
 							diagnostics: result.observer.repairedDiagnostics,
+							elapsedMs: result.observer.repairedElapsedMs,
+							usage: result.observer.repairedUsage,
 						},
+						telemetry: {
+							totalElapsedMs: result.observer.totalElapsedMs,
+							totalUsage: result.observer.totalUsage,
+						},
+						pricing,
+						cost: {
+							initial: initialCost,
+							repair: repairCost,
+							total: totalCost,
+							unavailableReason: costUnavailableReason,
+						},
+						quality,
 					});
 				}
+				const reviewedQualityRuns = runs.filter((run) => run.quality?.weightedQualityScore != null);
+				const knownCostRuns = runs.filter((run) => run.cost.total != null);
+				const knownElapsedRuns = runs.filter((run) => run.telemetry.totalElapsedMs != null);
 				const summary = {
 					total: runs.length,
 					shapeQualityTotal: runs.filter((run) => run.purpose === "shape_quality").length,
@@ -1139,6 +1209,23 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						(run) => run.expectedTier != null && run.expectedTier === run.tier,
 					).length,
 					robustnessNoOutput: runs.filter((run) => run.status === "observer_no_output").length,
+					reviewedQualityRuns: reviewedQualityRuns.length,
+					knownCostRuns: knownCostRuns.length,
+					unknownCostRuns: runs.length - knownCostRuns.length,
+					missingUsageRuns: runs.filter((run) => run.cost.unavailableReason === "missing_usage")
+						.length,
+					unknownPricingRuns: runs.filter(
+						(run) => run.cost.unavailableReason === "unknown_model_pricing",
+					).length,
+					totalKnownCostUsd: knownCostRuns.reduce(
+						(sum, run) => sum + (run.cost.total?.totalCostUsd ?? 0),
+						0,
+					),
+					knownElapsedRuns: knownElapsedRuns.length,
+					totalKnownElapsedMs: knownElapsedRuns.reduce(
+						(sum, run) => sum + (run.telemetry.totalElapsedMs ?? 0),
+						0,
+					),
 				};
 				const uniqueObserverKeys = Array.from(
 					new Set(
@@ -1198,6 +1285,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						id: benchmark.id,
 						title: benchmark.title,
 						scenarioId: benchmark.scenarioId,
+						modelCandidates: benchmark.modelCandidates,
 					},
 					observer: observerSummary,
 					summary,
@@ -1225,11 +1313,23 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						`Shape-quality fails: ${summary.shapeQualityFails}`,
 						`Expected-tier matches: ${summary.expectedTierMatches}/${summary.expectedTierTotal}`,
 						`Observer no-output cases: ${summary.robustnessNoOutput}`,
+						`Reviewed quality runs: ${summary.reviewedQualityRuns} (compare per-run dimensions; scores are fixture-specific)`,
+						`Known estimated cost: $${summary.totalKnownCostUsd.toFixed(6)} (${summary.knownCostRuns}/${summary.total}; missing usage=${summary.missingUsageRuns}, unknown pricing=${summary.unknownPricingRuns})`,
+						`Known elapsed time: ${summary.totalKnownElapsedMs}ms (${summary.knownElapsedRuns}/${summary.total} run(s))`,
 					].join("\n"),
 				);
 				for (const run of runs) {
+					const qualityLabel =
+						run.quality?.weightedQualityScore == null
+							? "n/a"
+							: run.quality.weightedQualityScore.toFixed(3);
+					const costLabel =
+						run.cost.total == null ? "n/a" : `$${run.cost.total.totalCostUsd.toFixed(6)}`;
+					const latencyLabel =
+						run.telemetry.totalElapsedMs == null ? "n/a" : `${run.telemetry.totalElapsedMs}ms`;
+					const missingRequired = run.quality?.requiredRecall.missingLabelIds.join(",") || "none";
 					p.log.message(
-						`  [${run.batchId}] ${run.status.padEnd(18)} ${run.complexity.padEnd(10)} tier=${run.tier.padEnd(6)} expected=${(run.expectedTier ?? "n/a").padEnd(6)} span=${String(run.analysis.eventSpan).padEnd(3)} prompts=${run.analysis.promptCount} tools=${String(run.analysis.toolCount).padEnd(2)} transcript=${run.analysis.transcriptLength} ${run.provider}/${run.model}${run.openaiUseResponses ? " [responses]" : ""} initial=${run.initial.summaries}s/${run.initial.observations}o final=${run.summaries}s/${run.observations}o schema_loss=${run.initial.diagnostics?.dataLoss === true ? "yes" : "no"} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
+						`  [${run.batchId}] ${run.status.padEnd(18)} ${run.complexity.padEnd(10)} tier=${run.tier.padEnd(6)} expected=${(run.expectedTier ?? "n/a").padEnd(6)} span=${String(run.analysis.eventSpan).padEnd(3)} prompts=${run.analysis.promptCount} tools=${String(run.analysis.toolCount).padEnd(2)} transcript=${run.analysis.transcriptLength} ${run.provider}/${run.model}${run.openaiUseResponses ? " [responses]" : ""} initial=${run.initial.summaries}s/${run.initial.observations}o final=${run.summaries}s/${run.observations}o quality=${qualityLabel} required_missing=${missingRequired} cost=${costLabel} latency=${latencyLabel} schema_loss=${run.initial.diagnostics?.dataLoss === true ? "yes" : "no"} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
 					);
 				}
 				p.outro("done");

--- a/packages/core/src/extraction-benchmark-scoring.test.ts
+++ b/packages/core/src/extraction-benchmark-scoring.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "vitest";
+import {
+	calculateCostAdjustedScore,
+	calculateWeightedQualityScore,
+	scoreExtractionBenchmarkOutput,
+} from "./extraction-benchmark-scoring.js";
+import type { ExtractionBenchmarkReview } from "./extraction-benchmarks.js";
+import { getExtractionBenchmarkProfile } from "./extraction-benchmarks.js";
+import type { ParsedObservation, ParsedOutput } from "./ingest-types.js";
+import type { ObserverResponseStructuralDiagnostics } from "./ingest-xml-parser.js";
+
+const CLEAN_DIAGNOSTICS: ObserverResponseStructuralDiagnostics = {
+	recognizedOutput: true,
+	observationBlocks: 0,
+	retainedObservations: 0,
+	summaryBlocks: 1,
+	retainedSummaries: 1,
+	illegalObservationNestingInSummary: 0,
+	unknownSummaryFields: [],
+	unsupportedObservationKinds: [],
+	missingObservationKinds: 0,
+	discardedObservationBlocks: 0,
+	discardedSummaryBlocks: 0,
+	dataLoss: false,
+};
+
+function observation(title: string, narrative: string): ParsedObservation {
+	return {
+		kind: "discovery",
+		title,
+		narrative,
+		subtitle: null,
+		facts: [],
+		concepts: [],
+		filesRead: [],
+		filesModified: [],
+	};
+}
+
+function parsed(observations: ParsedObservation[], learned = ""): ParsedOutput {
+	return {
+		observations,
+		summary: {
+			request: "Evaluate extraction quality.",
+			investigated: "",
+			learned,
+			completed: "",
+			nextSteps: "",
+			notes: "",
+			filesRead: [],
+			filesModified: [],
+		},
+		skipSummaryReason: null,
+	};
+}
+
+function reviewedBatch(batchId: number) {
+	const batch = getExtractionBenchmarkProfile("rich-batch-shape-v1")?.batches.find(
+		(candidate) => candidate.batchId === batchId,
+	);
+	if (batch?.review.status !== "reviewed") {
+		throw new Error(`expected reviewed benchmark batch ${batchId}`);
+	}
+	return batch.review;
+}
+
+describe("extraction benchmark scoring", () => {
+	it("matches all keyword groups and exposes reviewer-readable observation text", () => {
+		const result = scoreExtractionBenchmarkOutput({
+			parsed: parsed([
+				observation(
+					"TypeScript stable-session regression",
+					"The TS rewrite caused a regression by failing to reuse the stable session.",
+				),
+				observation("Graphite branch hygiene", "Graphite branch cleanup kept the stack tidy."),
+			]),
+			diagnostics: CLEAN_DIAGNOSTICS,
+			review: reviewedBatch(18503),
+		});
+
+		expect(result.requiredRecall).toEqual(
+			expect.objectContaining({
+				score: 1,
+				matchedLabelIds: ["stable-session-reuse-regression"],
+				missingLabelIds: [],
+			}),
+		);
+		expect(result.requiredRecall.matches[0]?.observations[0]?.text).toContain(
+			"The TS rewrite caused a regression",
+		);
+		expect(result.forbidden).toEqual(
+			expect.objectContaining({
+				avoidance: 0,
+				matchedLabelIds: ["graphite-branch-hygiene"],
+			}),
+		);
+		expect(result.worthinessPrecision.score).toBe(0.5);
+		expect(result.worthinessPrecision.flaggedObservationIndexes).toEqual([1]);
+		expect(result.factualGrounding).toEqual(
+			expect.objectContaining({ status: "requires_human_review", score: null }),
+		);
+	});
+
+	it("does not match a label when only some keyword groups are present", () => {
+		const result = scoreExtractionBenchmarkOutput({
+			parsed: parsed([
+				observation(
+					"TypeScript regression",
+					"A TypeScript bug was fixed, but session behavior was not analyzed.",
+				),
+			]),
+			diagnostics: CLEAN_DIAGNOSTICS,
+			review: reviewedBatch(18503),
+		});
+
+		expect(result.requiredRecall.score).toBe(0);
+		expect(result.requiredRecall.missingLabelIds).toEqual(["stable-session-reuse-regression"]);
+	});
+
+	it("scores the two reviewed 18432 lessons as distinct required facts", () => {
+		const learned =
+			"The repair pass keeps pre-repair output transparent. Relinking reduces unmapped sessions but does not solve summary dominance.";
+		const result = scoreExtractionBenchmarkOutput({
+			parsed: parsed(
+				[
+					observation(
+						"Repair output stays transparent",
+						"The repair pass is reported separately from the initial output.",
+					),
+					observation(
+						"Relinking has a bounded benefit",
+						"Relinking reduces unmapped sessions but does not fix summary dominance.",
+					),
+				],
+				learned,
+			),
+			diagnostics: CLEAN_DIAGNOSTICS,
+			review: reviewedBatch(18432),
+		});
+
+		expect(result.requiredRecall.score).toBe(1);
+		expect(result.requiredRecall.matchedLabelIds).toEqual([
+			"transparent-repair-implementation",
+			"relinking-does-not-fix-recap-dominance",
+		]);
+		expect(result.summaryBreadth.score).toBe(1);
+		expect(result.observationSignals.segmentation).toBe(1);
+	});
+
+	it("reports duplicate observations as a redundancy signal", () => {
+		const duplicate = observation(
+			"TypeScript stable-session regression",
+			"The TS rewrite caused a regression by failing to reuse the stable session.",
+		);
+		const result = scoreExtractionBenchmarkOutput({
+			parsed: parsed([duplicate, { ...duplicate }]),
+			diagnostics: CLEAN_DIAGNOSTICS,
+			review: reviewedBatch(18503),
+		});
+
+		expect(result.observationSignals.redundantPairs).toEqual([[0, 1]]);
+		expect(result.observationSignals.redundantObservationIndexes).toEqual([0, 1]);
+		expect(result.observationSignals.redundancyAvoidance).toBe(0);
+	});
+
+	it("scores optional recall and flags multi-label observation segmentation", () => {
+		const review: ExtractionBenchmarkReview = {
+			status: "reviewed",
+			reviewerNotes: "Focused scoring fixture.",
+			labels: [
+				{
+					id: "required-contract",
+					title: "Required contract",
+					disposition: "required",
+					keywordGroups: [["durable"], ["contract"]],
+					reviewerNotes: "Required fixture label.",
+				},
+				{
+					id: "optional-context",
+					title: "Optional context",
+					disposition: "optional",
+					keywordGroups: [["extra"], ["context"]],
+					reviewerNotes: "Optional fixture label.",
+				},
+			],
+		};
+		const result = scoreExtractionBenchmarkOutput({
+			parsed: parsed([observation("Combined memory", "A durable contract with extra context.")]),
+			diagnostics: CLEAN_DIAGNOSTICS,
+			review,
+		});
+
+		expect(result.optionalRecall.score).toBe(1);
+		expect(result.optionalRecall.matchedLabelIds).toEqual(["optional-context"]);
+		expect(result.observationSignals.multiLabelObservationIndexes).toEqual([0]);
+		expect(result.observationSignals.segmentation).toBe(0);
+	});
+
+	it("fails schema compliance when structural diagnostics expose parser loss", () => {
+		const result = scoreExtractionBenchmarkOutput({
+			parsed: parsed([]),
+			diagnostics: {
+				...CLEAN_DIAGNOSTICS,
+				unknownSummaryFields: ["result"],
+				unsupportedObservationKinds: ["telemetry"],
+				missingObservationKinds: 1,
+				discardedObservationBlocks: 1,
+				dataLoss: true,
+			},
+			review: reviewedBatch(18503),
+		});
+
+		expect(result.schemaCompliance.compliant).toBe(false);
+		expect(result.schemaCompliance.score).toBe(0);
+		expect(result.schemaCompliance.violations).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining("unknown summary fields"),
+				expect.stringContaining("unsupported observation kinds"),
+				expect.stringContaining("missing a kind"),
+				expect.stringContaining("observation block(s) discarded"),
+				expect.stringContaining("data loss"),
+			]),
+		);
+	});
+
+	it("excludes null and human-only dimensions from weighted quality", () => {
+		const score = calculateWeightedQualityScore({
+			requiredRecall: 1,
+			optionalRecall: null,
+			worthinessPrecision: null,
+			summaryBreadth: null,
+			redundancyAvoidance: null,
+			segmentation: null,
+			schemaCompliance: 0,
+			factualGrounding: 1,
+		});
+
+		expect(score).toBeCloseTo(0.45 / (0.45 + 0.1));
+	});
+
+	it("keeps cost-adjusted quality null until an actual cost is supplied", () => {
+		const withoutCost = scoreExtractionBenchmarkOutput({
+			parsed: parsed([]),
+			diagnostics: CLEAN_DIAGNOSTICS,
+			review: reviewedBatch(18503),
+		});
+		const withCost = scoreExtractionBenchmarkOutput({
+			parsed: parsed([]),
+			diagnostics: CLEAN_DIAGNOSTICS,
+			review: reviewedBatch(18503),
+			estimatedCostUsd: 0.25,
+		});
+
+		expect(withoutCost.costAdjustedScore).toBeNull();
+		expect(withCost.weightedQualityScore).not.toBeNull();
+		expect(withCost.costAdjustedScore).toBeCloseTo(
+			((withCost.weightedQualityScore ?? 0) * 0.01) / 0.25,
+		);
+		expect(withCost.costAdjustedScoreUnit).toBe("quality_points_per_cent");
+		expect(calculateCostAdjustedScore(0.8, -1)).toBeNull();
+		expect(calculateCostAdjustedScore(0.8, 0)).toBeNull();
+	});
+
+	it("does not reward an empty observation set for precision or redundancy", () => {
+		const result = scoreExtractionBenchmarkOutput({
+			parsed: parsed([]),
+			diagnostics: CLEAN_DIAGNOSTICS,
+			review: reviewedBatch(18503),
+		});
+
+		expect(result.requiredRecall.score).toBe(0);
+		expect(result.worthinessPrecision.score).toBeNull();
+		expect(result.observationSignals.redundancyAvoidance).toBeNull();
+		expect(result.weightedQualityScore).toBeLessThanOrEqual(0.25);
+	});
+
+	it("scores a reviewed no-output response as zero quality", () => {
+		const result = scoreExtractionBenchmarkOutput({
+			parsed: parsed([]),
+			diagnostics: { ...CLEAN_DIAGNOSTICS, recognizedOutput: false },
+			review: reviewedBatch(18503),
+		});
+
+		expect(result.schemaCompliance).toEqual(
+			expect.objectContaining({
+				compliant: false,
+				score: 0,
+				violations: expect.arrayContaining([expect.stringContaining("no recognized observer XML")]),
+			}),
+		);
+		expect(result.requiredRecall.score).toBe(0);
+		expect(result.weightedQualityScore).toBe(0);
+	});
+
+	it("does not assign aggregate quality to an unreviewed batch", () => {
+		const batch = getExtractionBenchmarkProfile("rich-batch-shape-v1")?.batches.find(
+			(candidate) => candidate.batchId === 18502,
+		);
+		if (!batch) throw new Error("expected unreviewed benchmark batch 18502");
+		const result = scoreExtractionBenchmarkOutput({
+			parsed: parsed([]),
+			diagnostics: CLEAN_DIAGNOSTICS,
+			review: batch.review,
+			estimatedCostUsd: 0.1,
+		});
+
+		expect(result.reviewStatus).toBe("unreviewed");
+		expect(result.weightedQualityScore).toBeNull();
+		expect(result.costAdjustedScore).toBeNull();
+	});
+});

--- a/packages/core/src/extraction-benchmark-scoring.ts
+++ b/packages/core/src/extraction-benchmark-scoring.ts
@@ -1,0 +1,404 @@
+import type {
+	ExtractionBenchmarkLabel,
+	ExtractionBenchmarkLabelDisposition,
+	ExtractionBenchmarkReview,
+} from "./extraction-benchmarks.js";
+import type { ParsedObservation, ParsedOutput, ParsedSummary } from "./ingest-types.js";
+import type { ObserverResponseStructuralDiagnostics } from "./ingest-xml-parser.js";
+
+export interface ExtractionBenchmarkObservationText {
+	index: number;
+	kind: string;
+	text: string;
+}
+
+export interface ExtractionBenchmarkLabelMatch {
+	labelId: string;
+	labelTitle: string;
+	reviewerNotes: string;
+	observations: ExtractionBenchmarkObservationText[];
+}
+
+export interface ExtractionBenchmarkRecallScore {
+	score: number | null;
+	matchedLabelIds: string[];
+	missingLabelIds: string[];
+	matches: ExtractionBenchmarkLabelMatch[];
+}
+
+export interface ExtractionBenchmarkForbiddenScore {
+	avoidance: number | null;
+	matchedLabelIds: string[];
+	matches: ExtractionBenchmarkLabelMatch[];
+}
+
+export interface ExtractionBenchmarkSummaryBreadthScore {
+	score: number | null;
+	matchedLabelIds: string[];
+	missingLabelIds: string[];
+}
+
+export interface ExtractionBenchmarkObservationSignals {
+	observationCount: number;
+	redundantPairs: Array<[number, number]>;
+	redundantObservationIndexes: number[];
+	redundancyAvoidance: number | null;
+	multiLabelObservationIndexes: number[];
+	segmentation: number | null;
+}
+
+export interface ExtractionBenchmarkSchemaScore {
+	compliant: boolean;
+	score: 0 | 1;
+	violations: string[];
+}
+
+export interface ExtractionBenchmarkScore {
+	reviewStatus: ExtractionBenchmarkReview["status"];
+	matchingPolicy: {
+		mode: "all_keyword_groups_in_one_observation";
+		notes: string;
+	};
+	requiredRecall: ExtractionBenchmarkRecallScore;
+	optionalRecall: ExtractionBenchmarkRecallScore;
+	forbidden: ExtractionBenchmarkForbiddenScore;
+	worthinessPrecision: {
+		score: number | null;
+		flaggedObservationIndexes: number[];
+		notes: string;
+	};
+	summaryBreadth: ExtractionBenchmarkSummaryBreadthScore;
+	observationSignals: ExtractionBenchmarkObservationSignals;
+	schemaCompliance: ExtractionBenchmarkSchemaScore;
+	factualGrounding: {
+		status: "requires_human_review";
+		score: null;
+		notes: string;
+	};
+	weightedQualityScore: number | null;
+	costAdjustedScore: number | null;
+	costAdjustedScoreUnit: "quality_points_per_cent";
+}
+
+export interface ExtractionBenchmarkQualityDimensions {
+	requiredRecall: number | null;
+	optionalRecall: number | null;
+	worthinessPrecision: number | null;
+	summaryBreadth: number | null;
+	redundancyAvoidance: number | null;
+	segmentation: number | null;
+	schemaCompliance: number | null;
+	factualGrounding: number | null;
+}
+
+const QUALITY_WEIGHTS: Readonly<Record<keyof ExtractionBenchmarkQualityDimensions, number>> = {
+	requiredRecall: 0.45,
+	optionalRecall: 0.05,
+	worthinessPrecision: 0.15,
+	summaryBreadth: 0.05,
+	redundancyAvoidance: 0.1,
+	segmentation: 0.1,
+	schemaCompliance: 0.1,
+	factualGrounding: 0,
+};
+
+const REDUNDANCY_THRESHOLD = 0.8;
+
+function normalizeText(value: string): string {
+	return value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+		.replace(/\s+/g, " ");
+}
+
+function observationText(
+	observation: ParsedObservation,
+	index: number,
+): ExtractionBenchmarkObservationText {
+	return {
+		index,
+		kind: observation.kind,
+		text: [observation.title, observation.subtitle, observation.narrative, ...observation.facts]
+			.filter((value): value is string => Boolean(value?.trim()))
+			.join("\n"),
+	};
+}
+
+function summaryText(summary: ParsedSummary | null): string {
+	if (!summary) return "";
+	return normalizeText(
+		[
+			summary.request,
+			summary.investigated,
+			summary.learned,
+			summary.completed,
+			summary.nextSteps,
+			summary.notes,
+		].join("\n"),
+	);
+}
+
+function matchesLabel(text: string, label: ExtractionBenchmarkLabel): boolean {
+	const normalized = normalizeText(text);
+	return label.keywordGroups.every((group) =>
+		group.some((keyword) => normalized.includes(normalizeText(keyword))),
+	);
+}
+
+function labelsFor(
+	review: ExtractionBenchmarkReview,
+	disposition: ExtractionBenchmarkLabelDisposition,
+): ExtractionBenchmarkLabel[] {
+	return review.status === "reviewed"
+		? review.labels.filter((label) => label.disposition === disposition)
+		: [];
+}
+
+function labelMatches(
+	labels: ExtractionBenchmarkLabel[],
+	observations: ExtractionBenchmarkObservationText[],
+): ExtractionBenchmarkLabelMatch[] {
+	return labels.flatMap((label) => {
+		const matchedObservations = observations.filter((observation) =>
+			matchesLabel(observation.text, label),
+		);
+		return matchedObservations.length === 0
+			? []
+			: [
+					{
+						labelId: label.id,
+						labelTitle: label.title,
+						reviewerNotes: label.reviewerNotes,
+						observations: matchedObservations,
+					},
+				];
+	});
+}
+
+function recallScore(
+	review: ExtractionBenchmarkReview,
+	labels: ExtractionBenchmarkLabel[],
+	observations: ExtractionBenchmarkObservationText[],
+): ExtractionBenchmarkRecallScore {
+	const matches = labelMatches(labels, observations);
+	const matchedLabelIds = matches.map((match) => match.labelId);
+	return {
+		score:
+			review.status === "reviewed" && labels.length > 0 ? matches.length / labels.length : null,
+		matchedLabelIds,
+		missingLabelIds: labels
+			.filter((label) => !matchedLabelIds.includes(label.id))
+			.map((label) => label.id),
+		matches,
+	};
+}
+
+function jaccardSimilarity(left: string, right: string): number {
+	const leftWords = new Set(normalizeText(left).split(" ").filter(Boolean));
+	const rightWords = new Set(normalizeText(right).split(" ").filter(Boolean));
+	const union = new Set([...leftWords, ...rightWords]);
+	if (union.size === 0) return 1;
+	const intersectionSize = [...leftWords].filter((word) => rightWords.has(word)).length;
+	return intersectionSize / union.size;
+}
+
+function observationSignals(
+	observations: ExtractionBenchmarkObservationText[],
+	positiveLabels: ExtractionBenchmarkLabel[],
+): ExtractionBenchmarkObservationSignals {
+	const redundantPairs: Array<[number, number]> = [];
+	for (let left = 0; left < observations.length; left += 1) {
+		for (let right = left + 1; right < observations.length; right += 1) {
+			const leftObservation = observations[left];
+			const rightObservation = observations[right];
+			if (
+				leftObservation &&
+				rightObservation &&
+				jaccardSimilarity(leftObservation.text, rightObservation.text) >= REDUNDANCY_THRESHOLD
+			) {
+				redundantPairs.push([leftObservation.index, rightObservation.index]);
+			}
+		}
+	}
+	const totalPairs = (observations.length * (observations.length - 1)) / 2;
+	const matchedObservationLabelCounts = observations.map((observation) => ({
+		index: observation.index,
+		count: positiveLabels.filter((label) => matchesLabel(observation.text, label)).length,
+	}));
+	const labelMatchedObservations = matchedObservationLabelCounts.filter(({ count }) => count > 0);
+	const multiLabelObservationIndexes = labelMatchedObservations
+		.filter(({ count }) => count > 1)
+		.map(({ index }) => index);
+	return {
+		observationCount: observations.length,
+		redundantPairs,
+		redundantObservationIndexes: [...new Set(redundantPairs.flat())].sort((a, b) => a - b),
+		redundancyAvoidance:
+			observations.length === 0
+				? null
+				: totalPairs === 0
+					? 1
+					: 1 - redundantPairs.length / totalPairs,
+		multiLabelObservationIndexes,
+		segmentation:
+			labelMatchedObservations.length === 0
+				? null
+				: 1 - multiLabelObservationIndexes.length / labelMatchedObservations.length,
+	};
+}
+
+function schemaScore(
+	diagnostics: ObserverResponseStructuralDiagnostics,
+): ExtractionBenchmarkSchemaScore {
+	const violations = [
+		!diagnostics.recognizedOutput ? "response contained no recognized observer XML" : null,
+		diagnostics.illegalObservationNestingInSummary > 0
+			? `${diagnostics.illegalObservationNestingInSummary} observation block(s) nested inside summary`
+			: null,
+		diagnostics.unknownSummaryFields.length > 0
+			? `unknown summary fields: ${diagnostics.unknownSummaryFields.join(", ")}`
+			: null,
+		diagnostics.unsupportedObservationKinds.length > 0
+			? `unsupported observation kinds: ${diagnostics.unsupportedObservationKinds.join(", ")}`
+			: null,
+		diagnostics.missingObservationKinds > 0
+			? `${diagnostics.missingObservationKinds} observation block(s) missing a kind`
+			: null,
+		diagnostics.discardedObservationBlocks > 0
+			? `${diagnostics.discardedObservationBlocks} observation block(s) discarded`
+			: null,
+		diagnostics.discardedSummaryBlocks > 0
+			? `${diagnostics.discardedSummaryBlocks} summary block(s) discarded`
+			: null,
+		diagnostics.dataLoss ? "parser diagnostics report data loss" : null,
+	].filter((violation): violation is string => violation !== null);
+	return { compliant: violations.length === 0, score: violations.length === 0 ? 1 : 0, violations };
+}
+
+export function calculateWeightedQualityScore(
+	dimensions: ExtractionBenchmarkQualityDimensions,
+): number {
+	const scoredDimensions = (Object.keys(QUALITY_WEIGHTS) as Array<keyof typeof QUALITY_WEIGHTS>)
+		.map((key) => ({ score: dimensions[key], weight: QUALITY_WEIGHTS[key] }))
+		.filter(
+			(dimension): dimension is { score: number; weight: number } =>
+				dimension.score !== null && dimension.weight > 0,
+		);
+	const totalWeight = scoredDimensions.reduce((sum, dimension) => sum + dimension.weight, 0);
+	if (totalWeight === 0) return 0;
+	return (
+		scoredDimensions.reduce((sum, dimension) => sum + dimension.score * dimension.weight, 0) /
+		totalWeight
+	);
+}
+
+export function calculateCostAdjustedScore(
+	qualityScore: number | null,
+	estimatedCostUsd: number | null,
+): number | null {
+	return qualityScore === null ||
+		estimatedCostUsd === null ||
+		!Number.isFinite(estimatedCostUsd) ||
+		estimatedCostUsd <= 0
+		? null
+		: (qualityScore * 0.01) / estimatedCostUsd;
+}
+
+export function scoreExtractionBenchmarkOutput(input: {
+	parsed: ParsedOutput;
+	diagnostics: ObserverResponseStructuralDiagnostics;
+	review: ExtractionBenchmarkReview;
+	estimatedCostUsd?: number | null;
+}): ExtractionBenchmarkScore {
+	const observations = input.parsed.observations.map(observationText);
+	const requiredLabels = labelsFor(input.review, "required");
+	const optionalLabels = labelsFor(input.review, "optional");
+	const forbiddenLabels = labelsFor(input.review, "forbidden");
+	const requiredRecall = recallScore(input.review, requiredLabels, observations);
+	const optionalRecall = recallScore(input.review, optionalLabels, observations);
+	const forbiddenMatches = labelMatches(forbiddenLabels, observations);
+	const forbidden = {
+		avoidance:
+			input.review.status === "reviewed" && forbiddenLabels.length > 0
+				? 1 - forbiddenMatches.length / forbiddenLabels.length
+				: null,
+		matchedLabelIds: forbiddenMatches.map((match) => match.labelId),
+		matches: forbiddenMatches,
+	};
+	const flaggedObservationIndexes = [
+		...new Set(
+			forbiddenMatches.flatMap((match) =>
+				match.observations.map((observation) => observation.index),
+			),
+		),
+	].sort((left, right) => left - right);
+	const worthinessPrecision = {
+		score:
+			input.review.status === "reviewed" && forbiddenLabels.length > 0
+				? observations.length === 0
+					? null
+					: 1 - flaggedObservationIndexes.length / observations.length
+				: null,
+		flaggedObservationIndexes,
+		notes:
+			"Precision is the share of emitted observations not matched by a reviewed forbidden/noise label; unlabelled claims still require human review.",
+	};
+	const positiveLabels = [...requiredLabels, ...optionalLabels];
+	const normalizedSummary = summaryText(input.parsed.summary);
+	const summaryMatchedLabelIds = positiveLabels
+		.filter((label) => matchesLabel(normalizedSummary, label))
+		.map((label) => label.id);
+	const summaryBreadth = {
+		score:
+			input.review.status === "reviewed" && positiveLabels.length > 0
+				? summaryMatchedLabelIds.length / positiveLabels.length
+				: null,
+		matchedLabelIds: summaryMatchedLabelIds,
+		missingLabelIds: positiveLabels
+			.filter((label) => !summaryMatchedLabelIds.includes(label.id))
+			.map((label) => label.id),
+	};
+	const signals = observationSignals(observations, positiveLabels);
+	const schemaCompliance = schemaScore(input.diagnostics);
+	const weightedQualityScore =
+		input.review.status === "reviewed"
+			? calculateWeightedQualityScore({
+					requiredRecall: requiredRecall.score,
+					optionalRecall: optionalRecall.score,
+					worthinessPrecision: worthinessPrecision.score,
+					summaryBreadth: summaryBreadth.score,
+					redundancyAvoidance: signals.redundancyAvoidance,
+					segmentation: signals.segmentation,
+					schemaCompliance: schemaCompliance.score,
+					factualGrounding: null,
+				})
+			: null;
+	return {
+		reviewStatus: input.review.status,
+		matchingPolicy: {
+			mode: "all_keyword_groups_in_one_observation",
+			notes:
+				"Deterministic matching is intentionally recall-conservative; inspect matched and missing labels plus raw output before selecting a model.",
+		},
+		requiredRecall,
+		optionalRecall,
+		forbidden,
+		worthinessPrecision,
+		summaryBreadth,
+		observationSignals: signals,
+		schemaCompliance,
+		factualGrounding: {
+			status: "requires_human_review",
+			score: null,
+			notes:
+				"Keyword matching measures repeatable label coverage, not whether claims are factually grounded in the source transcript.",
+		},
+		weightedQualityScore,
+		costAdjustedScore: calculateCostAdjustedScore(
+			weightedQualityScore,
+			input.estimatedCostUsd ?? null,
+		),
+		costAdjustedScoreUnit: "quality_points_per_cent",
+	};
+}

--- a/packages/core/src/extraction-benchmarks.test.ts
+++ b/packages/core/src/extraction-benchmarks.test.ts
@@ -19,6 +19,16 @@ describe("extraction benchmarks", () => {
 				temperature: 0.2,
 			}),
 		);
+		expect(profile?.modelCandidates).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ model: "gpt-5.4", role: "rich_baseline" }),
+				expect.objectContaining({ model: "gpt-5.5", role: "quality_ceiling" }),
+				expect.objectContaining({
+					model: "gpt-5.6-terra",
+					role: "cost_matched_challenger",
+				}),
+			]),
+		);
 		expect(profile?.batches).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ batchId: 18503, purpose: "shape_quality" }),
@@ -39,6 +49,50 @@ describe("extraction benchmarks", () => {
 		);
 	});
 
+	it("carries the known durable-fact review for batches 18503 and 18432", () => {
+		const profile = getExtractionBenchmarkProfile("rich-batch-shape-v1");
+		const batch18503 = profile?.batches.find((batch) => batch.batchId === 18503);
+		const batch18432 = profile?.batches.find((batch) => batch.batchId === 18432);
+		expect(batch18503?.review).toEqual(
+			expect.objectContaining({
+				status: "reviewed",
+				labels: expect.arrayContaining([
+					expect.objectContaining({
+						id: "stable-session-reuse-regression",
+						disposition: "required",
+					}),
+					expect.objectContaining({
+						id: "graphite-branch-hygiene",
+						disposition: "forbidden",
+					}),
+				]),
+			}),
+		);
+		expect(batch18432?.review).toEqual(
+			expect.objectContaining({
+				status: "reviewed",
+				labels: expect.arrayContaining([
+					expect.objectContaining({
+						id: "transparent-repair-implementation",
+						disposition: "required",
+					}),
+					expect.objectContaining({
+						id: "relinking-does-not-fix-recap-dominance",
+						disposition: "required",
+					}),
+				]),
+			}),
+		);
+	});
+
+	it("marks batches without known review as explicitly unreviewed", () => {
+		const profile = getExtractionBenchmarkProfile("rich-batch-shape-v1");
+		expect(profile?.batches.find((batch) => batch.batchId === 18502)?.review).toEqual({
+			status: "unreviewed",
+			reviewerNotes: "No durable-fact review has been recorded for this batch.",
+		});
+	});
+
 	it("returns defensive copies from the benchmark listing", () => {
 		const profiles = listExtractionBenchmarkProfiles();
 		expect(profiles.length).toBeGreaterThan(0);
@@ -47,7 +101,20 @@ describe("extraction benchmarks", () => {
 		const firstBatch = firstProfile.batches[0];
 		if (!firstBatch) throw new Error("expected at least one batch in the first profile");
 		firstBatch.label = "mutated";
+		const firstCandidate = firstProfile.modelCandidates[0];
+		if (!firstCandidate) throw new Error("expected at least one model candidate");
+		firstCandidate.model = "mutated-model";
+		if (firstBatch.review?.status === "reviewed") {
+			const firstLabel = firstBatch.review.labels[0];
+			if (!firstLabel) throw new Error("expected reviewed batch to have a label");
+			firstLabel.keywordGroups[0]?.push("mutated keyword");
+		}
 		const fresh = getExtractionBenchmarkProfile("rich-batch-shape-v1");
 		expect(fresh?.batches[0]?.label).not.toBe("mutated");
+		expect(fresh?.modelCandidates[0]?.model).not.toBe("mutated-model");
+		const freshReview = fresh?.batches[0]?.review;
+		expect(
+			freshReview?.status === "reviewed" ? freshReview.labels[0]?.keywordGroups[0] : [],
+		).not.toContain("mutated keyword");
 	});
 });

--- a/packages/core/src/extraction-benchmarks.ts
+++ b/packages/core/src/extraction-benchmarks.ts
@@ -7,7 +7,30 @@ export interface ExtractionBenchmarkBatch {
 	scenarioId?: string;
 	expectedTier?: "simple" | "rich";
 	notes: string;
+	/** Human-reviewed durable-fact labels; omitted profiles are treated as unreviewed. */
+	review?: ExtractionBenchmarkReview;
 }
+
+export type ExtractionBenchmarkLabelDisposition = "required" | "optional" | "forbidden";
+
+export interface ExtractionBenchmarkLabel {
+	id: string;
+	title: string;
+	disposition: ExtractionBenchmarkLabelDisposition;
+	keywordGroups: string[][];
+	reviewerNotes: string;
+}
+
+export type ExtractionBenchmarkReview =
+	| {
+			status: "reviewed";
+			reviewerNotes: string;
+			labels: ExtractionBenchmarkLabel[];
+	  }
+	| {
+			status: "unreviewed";
+			reviewerNotes: string;
+	  };
 
 export interface ExtractionBenchmarkProfile {
 	id: string;
@@ -25,7 +48,90 @@ export interface ExtractionBenchmarkProfile {
 		temperature: number;
 		notes: string;
 	};
+	modelCandidates: ExtractionBenchmarkModelCandidate[];
 	batches: ExtractionBenchmarkBatch[];
+}
+
+export interface ExtractionBenchmarkModelCandidate {
+	provider: string;
+	model: string;
+	role: "simple_baseline" | "rich_baseline" | "quality_ceiling" | "cost_matched_challenger";
+	reasoningEffort: "none";
+	notes: string;
+}
+
+const UNREVIEWED_BATCH: ExtractionBenchmarkReview = {
+	status: "unreviewed",
+	reviewerNotes: "No durable-fact review has been recorded for this batch.",
+};
+
+const REVIEWED_BATCHES: Readonly<Record<number, ExtractionBenchmarkReview>> = {
+	18503: {
+		status: "reviewed",
+		reviewerNotes:
+			"Known review identified one durable TypeScript regression lesson and one routine Graphite workflow topic that must not become durable memory.",
+		labels: [
+			{
+				id: "stable-session-reuse-regression",
+				title: "TypeScript must preserve stable session reuse",
+				disposition: "required",
+				keywordGroups: [
+					["typescript", "ts implementation", "ts rewrite"],
+					["stable session", "stable-session"],
+					["reuse", "reused", "reusing"],
+					["regression", "failure mode", "bug"],
+				],
+				reviewerNotes:
+					"Capture the reusable regression lesson: the TypeScript path must retain stable-session reuse rather than creating a fresh session for each event or flush.",
+			},
+			{
+				id: "graphite-branch-hygiene",
+				title: "Graphite branch hygiene is routine workflow",
+				disposition: "forbidden",
+				keywordGroups: [
+					["graphite", "graphite stack"],
+					["branch hygiene", "branch cleanup", "stack hygiene"],
+				],
+				reviewerNotes:
+					"Branch cleanup and stack-management narration is routine workflow telemetry, not a durable project fact.",
+			},
+		],
+	},
+	18432: {
+		status: "reviewed",
+		reviewerNotes:
+			"Known review identified the transparent repair implementation and a separate limitation of relinking as required durable lessons.",
+		labels: [
+			{
+				id: "transparent-repair-implementation",
+				title: "Repair behavior must remain transparent",
+				disposition: "required",
+				keywordGroups: [
+					["repair", "repair pass", "repair call"],
+					["transparent", "reported separately", "visible separately"],
+					["initial output", "original output", "pre-repair output"],
+				],
+				reviewerNotes:
+					"Capture the implementation contract that initial model output remains visible and repair is reported as a separate recovery step.",
+			},
+			{
+				id: "relinking-does-not-fix-recap-dominance",
+				title: "Relinking reduces unmapped burden but not recap dominance",
+				disposition: "required",
+				keywordGroups: [
+					["relink", "relinking"],
+					["unmapped burden", "unmapped sessions", "unmapped rows"],
+					["recap dominance", "summary dominance", "recap-heavy retrieval"],
+				],
+				reviewerNotes:
+					"Keep this distinct from transparent repair: relinking reduces the unmapped-session burden, but retrieval can still be dominated by recap/summary artifacts.",
+			},
+		],
+	},
+};
+
+function benchmarkReview(batchId: number): ExtractionBenchmarkReview {
+	return REVIEWED_BATCHES[batchId] ?? UNREVIEWED_BATCH;
 }
 
 const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
@@ -48,6 +154,36 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 			notes:
 				"Current cheapest promising candidate. It can pass some hard batches at temperature 0.2, but remains less reliable than full gpt-5.4.",
 		},
+		modelCandidates: [
+			{
+				provider: "openai",
+				model: "gpt-5.4-mini",
+				role: "simple_baseline",
+				reasoningEffort: "none",
+				notes: "Retain as the frequent/simple-tier cost baseline.",
+			},
+			{
+				provider: "openai",
+				model: "gpt-5.4",
+				role: "rich_baseline",
+				reasoningEffort: "none",
+				notes: "Current rich-tier production baseline and primary comparison for Terra.",
+			},
+			{
+				provider: "openai",
+				model: "gpt-5.5",
+				role: "quality_ceiling",
+				reasoningEffort: "none",
+				notes: "Higher-cost reference for quality headroom, not the default candidate.",
+			},
+			{
+				provider: "openai",
+				model: "gpt-5.6-terra",
+				role: "cost_matched_challenger",
+				reasoningEffort: "none",
+				notes: "Leading rich-tier challenger because it is price-matched with GPT-5.4.",
+			},
+		],
 		batches: [
 			{
 				batchId: 18503,
@@ -59,6 +195,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				expectedTier: "rich",
 				notes:
 					"Flagship hard case: historically under-extracted batch with multiple meaningful subthreads.",
+				review: benchmarkReview(18503),
 			},
 			{
 				batchId: 18502,
@@ -70,6 +207,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				expectedTier: "rich",
 				notes:
 					"Useful adjacent batch from the same long session; helps avoid overfitting to 18503 alone.",
+				review: benchmarkReview(18502),
 			},
 			{
 				batchId: 18506,
@@ -81,6 +219,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				expectedTier: "rich",
 				notes:
 					"Later large batch from the same session; currently passes on stronger models and validates generalization within the stream.",
+				review: benchmarkReview(18506),
 			},
 			{
 				batchId: 18432,
@@ -92,6 +231,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				expectedTier: "rich",
 				notes:
 					"High-volume snapshot batch used to compare budget and model sensitivity outside the Track 3 stream.",
+				review: benchmarkReview(18432),
 			},
 			{
 				batchId: 18446,
@@ -103,6 +243,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				expectedTier: "rich",
 				notes:
 					"Useful stubborn case: some models return summary-only or nothing; stronger models plus repair can recover it.",
+				review: benchmarkReview(18446),
 			},
 			{
 				batchId: 18476,
@@ -114,6 +255,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				expectedTier: "rich",
 				notes:
 					"Stored extraction passes shape, but replay may return no raw output at all. Track separately as observer/replay robustness, not shape quality.",
+				review: benchmarkReview(18476),
 			},
 		],
 	},
@@ -136,6 +278,22 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 			notes:
 				"Cheaper path that should remain selected for simpler batches unless routing thresholds are too aggressive.",
 		},
+		modelCandidates: [
+			{
+				provider: "openai",
+				model: "gpt-5.4-mini",
+				role: "simple_baseline",
+				reasoningEffort: "none",
+				notes: "Simple-tier routing baseline.",
+			},
+			{
+				provider: "openai",
+				model: "gpt-5.4",
+				role: "rich_baseline",
+				reasoningEffort: "none",
+				notes: "Rich-tier routing baseline.",
+			},
+		],
 		batches: [
 			{
 				batchId: 18530,
@@ -146,6 +304,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				scenarioId: "simple-batch-shape",
 				expectedTier: "simple",
 				notes: "Very small batch that should clearly remain on the cheap/simple tier.",
+				review: benchmarkReview(18530),
 			},
 			{
 				batchId: 18490,
@@ -156,6 +315,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				scenarioId: "simple-batch-shape",
 				expectedTier: "simple",
 				notes: "Small batch with low tool count that should not trigger the rich tier.",
+				review: benchmarkReview(18490),
 			},
 			{
 				batchId: 18494,
@@ -166,6 +326,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				scenarioId: "simple-batch-shape",
 				expectedTier: "simple",
 				notes: "Short-session compact batch chosen for genuinely low-complexity characteristics.",
+				review: benchmarkReview(18494),
 			},
 			{
 				batchId: 18524,
@@ -176,6 +337,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				scenarioId: "working-batch-shape",
 				expectedTier: "simple",
 				notes: "Moderate batch that should remain cheap unless thresholds are too aggressive.",
+				review: benchmarkReview(18524),
 			},
 			{
 				batchId: 18525,
@@ -186,6 +348,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				scenarioId: "working-batch-shape",
 				expectedTier: "simple",
 				notes: "Moderate batch with some prompt/tool activity but still below rich-batch scale.",
+				review: benchmarkReview(18525),
 			},
 			{
 				batchId: 18460,
@@ -197,6 +360,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				expectedTier: "simple",
 				notes:
 					"Cross-session moderate batch to verify the simple tier remains viable outside the main stream.",
+				review: benchmarkReview(18460),
 			},
 			{
 				batchId: 18503,
@@ -207,6 +371,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				scenarioId: "rich-batch-shape",
 				expectedTier: "rich",
 				notes: "Flagship hard case that should still escalate to the rich tier.",
+				review: benchmarkReview(18503),
 			},
 			{
 				batchId: 18432,
@@ -217,6 +382,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				scenarioId: "rich-batch-shape",
 				expectedTier: "rich",
 				notes: "High-volume snapshot batch that should continue escalating.",
+				review: benchmarkReview(18432),
 			},
 			{
 				batchId: 18476,
@@ -228,6 +394,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				expectedTier: "rich",
 				notes:
 					"Known no-output replay robustness case retained to make sure routing does not hide robustness failures.",
+				review: benchmarkReview(18476),
 			},
 		],
 	},
@@ -235,12 +402,34 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 
 export function getExtractionBenchmarkProfile(id: string): ExtractionBenchmarkProfile | null {
 	const normalized = id.trim().toLowerCase();
-	return EXTRACTION_BENCHMARK_PROFILES.find((profile) => profile.id === normalized) ?? null;
+	const profile = EXTRACTION_BENCHMARK_PROFILES.find((candidate) => candidate.id === normalized);
+	return profile ? cloneProfile(profile) : null;
 }
 
 export function listExtractionBenchmarkProfiles(): ExtractionBenchmarkProfile[] {
-	return EXTRACTION_BENCHMARK_PROFILES.map((profile) => ({
+	return EXTRACTION_BENCHMARK_PROFILES.map(cloneProfile);
+}
+
+function cloneReview(review: ExtractionBenchmarkReview): ExtractionBenchmarkReview {
+	if (review.status === "unreviewed") return { ...review };
+	return {
+		...review,
+		labels: review.labels.map((label) => ({
+			...label,
+			keywordGroups: label.keywordGroups.map((group) => [...group]),
+		})),
+	};
+}
+
+function cloneProfile(profile: ExtractionBenchmarkProfile): ExtractionBenchmarkProfile {
+	return {
 		...profile,
-		batches: profile.batches.map((batch) => ({ ...batch })),
-	}));
+		recommendedTruthModel: { ...profile.recommendedTruthModel },
+		cheapCandidate: { ...profile.cheapCandidate },
+		modelCandidates: profile.modelCandidates.map((candidate) => ({ ...candidate })),
+		batches: profile.batches.map((batch) => ({
+			...batch,
+			...(batch.review ? { review: cloneReview(batch.review) } : {}),
+		})),
+	};
 }

--- a/packages/core/src/extraction-model-pricing.test.ts
+++ b/packages/core/src/extraction-model-pricing.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+	estimateExtractionModelCost,
+	getExtractionModelPricing,
+	listExtractionModelPricing,
+} from "./extraction-model-pricing.js";
+
+describe("extraction model pricing", () => {
+	it("lists the explicit benchmark model prices", () => {
+		expect(listExtractionModelPricing()).toEqual([
+			expect.objectContaining({
+				model: "gpt-5.4-mini",
+				inputUsdPerMillionTokens: 0.75,
+				outputUsdPerMillionTokens: 4.5,
+			}),
+			expect.objectContaining({
+				model: "gpt-5.4",
+				inputUsdPerMillionTokens: 2.5,
+				outputUsdPerMillionTokens: 15,
+			}),
+			expect.objectContaining({
+				model: "gpt-5.5",
+				inputUsdPerMillionTokens: 5,
+				outputUsdPerMillionTokens: 30,
+			}),
+			expect.objectContaining({ model: "gpt-5.6-terra" }),
+			expect.objectContaining({ model: "gpt-5.6-sol" }),
+		]);
+	});
+
+	it.each([
+		["gpt-5.6-terra", "gpt-5.6-terra", 2.5, 15],
+		["Terra", "gpt-5.6-terra", 2.5, 15],
+		["gpt-5.6-sol", "gpt-5.6-sol", 5, 30],
+		["Sol", "gpt-5.6-sol", 5, 30],
+	] as const)("resolves the %s alias", (alias, model, inputRate, outputRate) => {
+		expect(getExtractionModelPricing(alias)).toEqual(
+			expect.objectContaining({
+				model,
+				inputUsdPerMillionTokens: inputRate,
+				outputUsdPerMillionTokens: outputRate,
+			}),
+		);
+	});
+
+	it("estimates cost only from normalized input and output token usage", () => {
+		const estimate = estimateExtractionModelCost("gpt-5.4-mini", {
+			inputTokens: 1_000_000,
+			outputTokens: 200_000,
+		});
+
+		expect(estimate).toEqual({
+			model: "gpt-5.4-mini",
+			usage: { inputTokens: 1_000_000, outputTokens: 200_000 },
+			inputCostUsd: 0.75,
+			outputCostUsd: 0.9,
+			totalCostUsd: 1.65,
+		});
+	});
+
+	it.each([null, undefined])("returns null when normalized usage is %s", (usage) => {
+		expect(estimateExtractionModelCost("gpt-5.4", usage)).toBeNull();
+	});
+
+	it("returns null for unknown pricing or invalid usage", () => {
+		expect(
+			estimateExtractionModelCost("unknown-model", { inputTokens: 10, outputTokens: 5 }),
+		).toBeNull();
+		expect(estimateExtractionModelCost("gpt-5.4", { inputTokens: -1, outputTokens: 5 })).toBeNull();
+	});
+
+	it("returns defensive pricing and usage copies", () => {
+		const prices = listExtractionModelPricing();
+		const first = prices[0];
+		if (!first) throw new Error("expected pricing entry");
+		first.aliases.push("mutated");
+		const fresh = getExtractionModelPricing("gpt-5.4-mini");
+		expect(fresh?.aliases).not.toContain("mutated");
+
+		const usage = { inputTokens: 100, outputTokens: 50 };
+		const estimate = estimateExtractionModelCost("Sol", usage);
+		usage.inputTokens = 999;
+		expect(estimate?.usage.inputTokens).toBe(100);
+	});
+});

--- a/packages/core/src/extraction-model-pricing.ts
+++ b/packages/core/src/extraction-model-pricing.ts
@@ -1,0 +1,106 @@
+export interface ExtractionModelPricing {
+	model: string;
+	aliases: string[];
+	inputUsdPerMillionTokens: number;
+	outputUsdPerMillionTokens: number;
+}
+
+export interface NormalizedExtractionTokenUsage {
+	inputTokens: number;
+	outputTokens: number;
+}
+
+export interface ExtractionModelCostEstimate {
+	model: string;
+	usage: NormalizedExtractionTokenUsage;
+	inputCostUsd: number;
+	outputCostUsd: number;
+	totalCostUsd: number;
+}
+
+// Evaluation pricing snapshot supplied for the 2026-07-10 model-selection run.
+// Cost estimates intentionally use provider-reported input/output totals without
+// applying cache discounts because cache billing fields are not consistent
+// across the supported HTTP and sidecar transports.
+const EXTRACTION_MODEL_PRICING: readonly ExtractionModelPricing[] = [
+	{
+		model: "gpt-5.4-mini",
+		aliases: ["gpt-5.4-mini"],
+		inputUsdPerMillionTokens: 0.75,
+		outputUsdPerMillionTokens: 4.5,
+	},
+	{
+		model: "gpt-5.4",
+		aliases: ["gpt-5.4"],
+		inputUsdPerMillionTokens: 2.5,
+		outputUsdPerMillionTokens: 15,
+	},
+	{
+		model: "gpt-5.5",
+		aliases: ["gpt-5.5"],
+		inputUsdPerMillionTokens: 5,
+		outputUsdPerMillionTokens: 30,
+	},
+	{
+		model: "gpt-5.6-terra",
+		aliases: ["gpt-5.6-terra", "terra"],
+		inputUsdPerMillionTokens: 2.5,
+		outputUsdPerMillionTokens: 15,
+	},
+	{
+		model: "gpt-5.6-sol",
+		aliases: ["gpt-5.6-sol", "sol"],
+		inputUsdPerMillionTokens: 5,
+		outputUsdPerMillionTokens: 30,
+	},
+];
+
+function normalizeModel(model: string): string {
+	return model.trim().toLowerCase();
+}
+
+function clonePricing(pricing: ExtractionModelPricing): ExtractionModelPricing {
+	return { ...pricing, aliases: [...pricing.aliases] };
+}
+
+function isActualUsage(
+	usage: NormalizedExtractionTokenUsage | null | undefined,
+): usage is NormalizedExtractionTokenUsage {
+	return Boolean(
+		usage &&
+			Number.isFinite(usage.inputTokens) &&
+			usage.inputTokens >= 0 &&
+			Number.isFinite(usage.outputTokens) &&
+			usage.outputTokens >= 0,
+	);
+}
+
+export function listExtractionModelPricing(): ExtractionModelPricing[] {
+	return EXTRACTION_MODEL_PRICING.map(clonePricing);
+}
+
+export function getExtractionModelPricing(model: string): ExtractionModelPricing | null {
+	const normalized = normalizeModel(model);
+	const pricing = EXTRACTION_MODEL_PRICING.find((candidate) =>
+		candidate.aliases.some((alias) => normalizeModel(alias) === normalized),
+	);
+	return pricing ? clonePricing(pricing) : null;
+}
+
+export function estimateExtractionModelCost(
+	model: string,
+	usage: NormalizedExtractionTokenUsage | null | undefined,
+): ExtractionModelCostEstimate | null {
+	if (!isActualUsage(usage)) return null;
+	const pricing = getExtractionModelPricing(model);
+	if (!pricing) return null;
+	const inputCostUsd = (usage.inputTokens / 1_000_000) * pricing.inputUsdPerMillionTokens;
+	const outputCostUsd = (usage.outputTokens / 1_000_000) * pricing.outputUsdPerMillionTokens;
+	return {
+		model: pricing.model,
+		usage: { ...usage },
+		inputCostUsd,
+		outputCostUsd,
+		totalCostUsd: inputCostUsd + outputCostUsd,
+	};
+}

--- a/packages/core/src/extraction-replay.test.ts
+++ b/packages/core/src/extraction-replay.test.ts
@@ -45,6 +45,8 @@ describe("extraction replay", () => {
 						parsed: null,
 						provider: "test",
 						model: "test-model",
+						elapsedMs: 12,
+						usage: { inputTokens: 100, outputTokens: 10, totalTokens: 110 },
 					};
 				}
 				return {
@@ -81,6 +83,8 @@ describe("extraction replay", () => {
 					parsed: null,
 					provider: "test",
 					model: "test-model",
+					elapsedMs: 20,
+					usage: { inputTokens: 120, outputTokens: 30, totalTokens: 150 },
 				};
 			},
 			getStatus: () => ({
@@ -114,6 +118,12 @@ describe("extraction replay", () => {
 		expect(result.observer.initialDiagnostics).toMatchObject({
 			recognizedOutput: false,
 			dataLoss: true,
+		});
+		expect(result.observer.totalElapsedMs).toBe(32);
+		expect(result.observer.totalUsage).toEqual({
+			inputTokens: 220,
+			outputTokens: 40,
+			totalTokens: 260,
 		});
 		expect(callCount).toBe(2);
 		expect(result.observerContext.userPrompt).toContain("Track 3");

--- a/packages/core/src/extraction-replay.ts
+++ b/packages/core/src/extraction-replay.ts
@@ -36,6 +36,7 @@ import {
 	type ObserverClient,
 	ObserverClient as ObserverClientImpl,
 	type ObserverConfig,
+	type ObserverTokenUsage,
 } from "./observer-client.js";
 import { resolveProject } from "./project.js";
 import { buildSessionContext } from "./raw-event-flush.js";
@@ -97,8 +98,22 @@ async function observeStructuredOutput(
 	system: string,
 	user: string,
 ): Promise<{
-	initial: { raw: string | null; parsed: ParsedOutput; provider: string; model: string };
-	repaired: { raw: string | null; parsed: ParsedOutput; provider: string; model: string } | null;
+	initial: {
+		raw: string | null;
+		parsed: ParsedOutput;
+		provider: string;
+		model: string;
+		elapsedMs: number | null;
+		usage: ObserverTokenUsage | null;
+	};
+	repaired: {
+		raw: string | null;
+		parsed: ParsedOutput;
+		provider: string;
+		model: string;
+		elapsedMs: number | null;
+		usage: ObserverTokenUsage | null;
+	} | null;
 }> {
 	const first = await observer.observe(system, user);
 	const firstParsed = first.raw
@@ -109,6 +124,8 @@ async function observeStructuredOutput(
 		parsed: firstParsed,
 		provider: first.provider,
 		model: first.model,
+		elapsedMs: first.elapsedMs ?? null,
+		usage: first.usage ?? null,
 	};
 	if (
 		!first.raw ||
@@ -132,7 +149,38 @@ async function observeStructuredOutput(
 			parsed: repairedParsed,
 			provider: repaired.provider,
 			model: repaired.model,
+			elapsedMs: repaired.elapsedMs ?? null,
+			usage: repaired.usage ?? null,
 		},
+	};
+}
+
+function sumObserverUsage(
+	initial: ObserverTokenUsage | null,
+	repaired: ObserverTokenUsage | null,
+	repairApplied: boolean,
+): ObserverTokenUsage | null {
+	if (!initial || (repairApplied && !repaired)) return null;
+	if (!repairApplied) return { ...initial };
+	if (!repaired) return null;
+	const totalTokens =
+		initial.totalTokens != null && repaired.totalTokens != null
+			? initial.totalTokens + repaired.totalTokens
+			: undefined;
+	const cacheReadInputTokens =
+		initial.cacheReadInputTokens != null || repaired.cacheReadInputTokens != null
+			? (initial.cacheReadInputTokens ?? 0) + (repaired.cacheReadInputTokens ?? 0)
+			: undefined;
+	const cacheCreationInputTokens =
+		initial.cacheCreationInputTokens != null || repaired.cacheCreationInputTokens != null
+			? (initial.cacheCreationInputTokens ?? 0) + (repaired.cacheCreationInputTokens ?? 0)
+			: undefined;
+	return {
+		inputTokens: initial.inputTokens + repaired.inputTokens,
+		outputTokens: initial.outputTokens + repaired.outputTokens,
+		...(totalTokens != null ? { totalTokens } : {}),
+		...(cacheReadInputTokens != null ? { cacheReadInputTokens } : {}),
+		...(cacheCreationInputTokens != null ? { cacheCreationInputTokens } : {}),
 	};
 }
 
@@ -165,12 +213,18 @@ export interface ExtractionReplayResult {
 		temperature: number | null;
 		repairApplied: boolean;
 		initialRaw: string | null;
+		initialElapsedMs: number | null;
+		initialUsage: ObserverTokenUsage | null;
 		initialParsed: ParsedOutput;
 		initialDiagnostics: ReturnType<typeof evaluateExtractionStructure> | null;
 		repairedRaw: string | null;
+		repairedElapsedMs: number | null;
+		repairedUsage: ObserverTokenUsage | null;
 		repairedParsed: ParsedOutput | null;
 		repairedDiagnostics: ReturnType<typeof evaluateExtractionStructure> | null;
 		raw: string | null;
+		totalElapsedMs: number | null;
+		totalUsage: ObserverTokenUsage | null;
 		parsed: ParsedOutput;
 		diagnostics: ReturnType<typeof evaluateExtractionStructure> | null;
 	};
@@ -593,6 +647,16 @@ async function replayPreparedBatch(
 	const repairedDiagnostics = response.repaired
 		? evaluateExtractionStructure(response.repaired.raw ?? "", response.repaired.parsed)
 		: null;
+	const repairApplied = response.repaired !== null;
+	const totalElapsedMs =
+		response.initial.elapsedMs != null && (!repairApplied || response.repaired?.elapsedMs != null)
+			? response.initial.elapsedMs + (response.repaired?.elapsedMs ?? 0)
+			: null;
+	const totalUsage = sumObserverUsage(
+		response.initial.usage,
+		response.repaired?.usage ?? null,
+		repairApplied,
+	);
 
 	return {
 		scenario: {
@@ -617,14 +681,20 @@ async function replayPreparedBatch(
 			reasoningSummary: observer.reasoningSummary,
 			maxOutputTokens: observer.maxOutputTokens,
 			temperature: observer.temperature,
-			repairApplied: response.repaired !== null,
+			repairApplied,
 			initialRaw: response.initial.raw,
+			initialElapsedMs: response.initial.elapsedMs,
+			initialUsage: response.initial.usage,
 			initialParsed: response.initial.parsed,
 			initialDiagnostics,
 			repairedRaw: response.repaired?.raw ?? null,
+			repairedElapsedMs: response.repaired?.elapsedMs ?? null,
+			repairedUsage: response.repaired?.usage ?? null,
 			repairedParsed: response.repaired?.parsed ?? null,
 			repairedDiagnostics,
 			raw: finalResponse.raw,
+			totalElapsedMs,
+			totalUsage,
 			parsed: finalResponse.parsed,
 			diagnostics: repairedDiagnostics ?? initialDiagnostics,
 		},

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,8 +241,21 @@ export {
 	readImportPayload,
 } from "./export-import.js";
 export type {
+	ExtractionBenchmarkQualityDimensions,
+	ExtractionBenchmarkScore,
+} from "./extraction-benchmark-scoring.js";
+export {
+	calculateCostAdjustedScore,
+	calculateWeightedQualityScore,
+	scoreExtractionBenchmarkOutput,
+} from "./extraction-benchmark-scoring.js";
+export type {
 	ExtractionBenchmarkBatch,
+	ExtractionBenchmarkLabel,
+	ExtractionBenchmarkLabelDisposition,
+	ExtractionBenchmarkModelCandidate,
 	ExtractionBenchmarkProfile,
+	ExtractionBenchmarkReview,
 } from "./extraction-benchmarks.js";
 export {
 	getExtractionBenchmarkProfile,
@@ -262,6 +275,16 @@ export {
 	getSessionExtractionEval,
 	getSessionExtractionEvalScenario,
 } from "./extraction-eval.js";
+export type {
+	ExtractionModelCostEstimate,
+	ExtractionModelPricing,
+	NormalizedExtractionTokenUsage,
+} from "./extraction-model-pricing.js";
+export {
+	estimateExtractionModelCost,
+	getExtractionModelPricing,
+	listExtractionModelPricing,
+} from "./extraction-model-pricing.js";
 export type { ExtractionReplayResult } from "./extraction-replay.js";
 export {
 	replayBatchExtraction,
@@ -422,7 +445,12 @@ export {
 	resolveOAuthProvider,
 	runAuthCommand,
 } from "./observer-auth.js";
-export type { ObserverConfig, ObserverResponse, ObserverStatus } from "./observer-client.js";
+export type {
+	ObserverConfig,
+	ObserverResponse,
+	ObserverStatus,
+	ObserverTokenUsage,
+} from "./observer-client.js";
 export { loadObserverConfig, ObserverAuthError, ObserverClient } from "./observer-client.js";
 export type {
 	ConfigPathResolution,

--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -888,6 +888,33 @@ describe("ObserverClient.observe()", () => {
 		expect(capturedHeaders?.["x-api-key"]).toBe(apiKey);
 		expect(result.raw).toBe("test response");
 		expect(result.provider).toBe("anthropic");
+		expect(result.usage).toBeNull();
+	});
+
+	it("normalizes Anthropic token usage including cache fields", async () => {
+		const apiKey = fixtureToken("anthropic-usage");
+		globalThis.fetch = (async () =>
+			new Response(
+				JSON.stringify({
+					content: [{ type: "text", text: "anthropic response" }],
+					usage: {
+						input_tokens: 101,
+						output_tokens: 23,
+						cache_read_input_tokens: 17,
+						cache_creation_input_tokens: 11,
+					},
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			)) as typeof globalThis.fetch;
+
+		const result = await makeClient("anthropic", apiKey).observe("system", "user");
+
+		expect(result.usage).toEqual({
+			inputTokens: 101,
+			outputTokens: 23,
+			cacheReadInputTokens: 17,
+			cacheCreationInputTokens: 11,
+		});
 	});
 
 	it("routes OpenAI to chat/completions when user explicitly disables Responses", async () => {
@@ -928,6 +955,37 @@ describe("ObserverClient.observe()", () => {
 		expect(result.raw).toBe("chat completions response");
 	});
 
+	it("normalizes OpenAI chat token usage", async () => {
+		const observerApiKey = fixtureToken("openai-chat-usage");
+		globalThis.fetch = (async () =>
+			new Response(
+				JSON.stringify({
+					choices: [{ message: { content: "chat response" } }],
+					usage: {
+						prompt_tokens: 73,
+						completion_tokens: 19,
+						total_tokens: 92,
+						prompt_tokens_details: { cached_tokens: 31 },
+					},
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			)) as typeof globalThis.fetch;
+		const client = new ObserverClient({
+			...makeClient("openai", observerApiKey).toConfig(),
+			observerOpenAIUseResponses: false,
+			observerExplicitConfigKeys: ["observerOpenAIUseResponses"],
+		});
+
+		const result = await client.observe("system", "user");
+
+		expect(result.usage).toEqual({
+			inputTokens: 73,
+			outputTokens: 19,
+			totalTokens: 92,
+			cacheReadInputTokens: 31,
+		});
+	});
+
 	it("calls OpenAI Responses endpoint by default", async () => {
 		const apiKey = fixtureToken("openai-responses");
 		let capturedUrl: string | undefined;
@@ -948,6 +1006,7 @@ describe("ObserverClient.observe()", () => {
 							content: [{ type: "output_text", text: "openai response text" }],
 						},
 					],
+					usage: { input_tokens: 211, output_tokens: 37, total_tokens: 248 },
 				}),
 				{ status: 200, headers: { "content-type": "application/json" } },
 			);
@@ -962,6 +1021,36 @@ describe("ObserverClient.observe()", () => {
 		expect(capturedBody?.input).toBeDefined();
 		expect(result.raw).toBe("openai response text");
 		expect(result.provider).toBe("openai");
+		expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+		expect(result.usage).toEqual({ inputTokens: 211, outputTokens: 37, totalTokens: 248 });
+	});
+
+	it("keeps token usage isolated across concurrent observe calls", async () => {
+		const apiKey = fixtureToken("openai-concurrent-usage");
+		globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			const request = JSON.parse(String(init?.body)) as {
+				input: Array<{ role: string; content: Array<{ text: string }> }>;
+			};
+			const userText = request.input.find((item) => item.role === "user")?.content[0]?.text;
+			const inputTokens = userText === "slow" ? 10 : 20;
+			if (userText === "slow") await new Promise((resolve) => setTimeout(resolve, 5));
+			return new Response(
+				JSON.stringify({
+					output_text: userText,
+					usage: { input_tokens: inputTokens, output_tokens: 1 },
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof globalThis.fetch;
+		const client = makeClient("openai", apiKey);
+
+		const [slow, fast] = await Promise.all([
+			client.observe("system", "slow"),
+			client.observe("system", "fast"),
+		]);
+
+		expect(slow.usage).toEqual({ inputTokens: 10, outputTokens: 1 });
+		expect(fast.usage).toEqual({ inputTokens: 20, outputTokens: 1 });
 	});
 
 	it("allows no-auth calls to explicit OpenAI-compatible base URLs", async () => {
@@ -1347,7 +1436,11 @@ describe("ObserverClient.observe()", () => {
 		globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
 			capturedBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
 			return new Response(
-				'data: {"type":"response.output_text.delta","delta":"<summary><request>ok</request></summary>"}\n\n',
+				[
+					'data: {"type":"response.output_text.delta","delta":"<summary><request>ok</request></summary>"}',
+					'data: {"type":"response.completed","response":{"usage":{"input_tokens":211,"output_tokens":37,"total_tokens":248}}}',
+					"",
+				].join("\n\n"),
 				{ status: 200, headers: { "content-type": "text/event-stream" } },
 			);
 		}) as typeof globalThis.fetch;
@@ -1370,10 +1463,11 @@ describe("ObserverClient.observe()", () => {
 				observerAuthCacheTtlS: 300,
 			});
 
-			await client.observe("SYSTEM XML CONTRACT", "USER SESSION TRANSCRIPT");
+			const result = await client.observe("SYSTEM XML CONTRACT", "USER SESSION TRANSCRIPT");
 
 			expect(client.getStatus().auth.type).toBe("codex_consumer");
 			expect(capturedBody?.instructions).toBe("SYSTEM XML CONTRACT");
+			expect(result.usage).toEqual({ inputTokens: 211, outputTokens: 37, totalTokens: 248 });
 		} finally {
 			if (prevHome == null) delete process.env.HOME;
 			else process.env.HOME = prevHome;

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -141,13 +141,21 @@ export interface ObserverResponse {
 	parsed: Record<string, unknown> | null;
 	provider: string;
 	model: string;
+	/** Wall-clock duration for this invocation, including an auth retry when needed. */
+	elapsedMs?: number;
+	/** Provider-reported token usage. Null when the transport does not expose it. */
+	usage?: ObserverTokenUsage | null;
 }
 
-export interface ObserverStructuredJsonResponse {
-	raw: string | null;
-	parsed: Record<string, unknown> | null;
-	provider: string;
-	model: string;
+export interface ObserverTokenUsage {
+	inputTokens: number;
+	outputTokens: number;
+	totalTokens?: number;
+	cacheReadInputTokens?: number;
+	cacheCreationInputTokens?: number;
+}
+
+export interface ObserverStructuredJsonResponse extends ObserverResponse {
 	usedStructuredOutputs: boolean;
 }
 
@@ -949,6 +957,45 @@ function parseAnthropicResponse(body: Record<string, unknown>): string | null {
 	return parts.length > 0 ? parts.join("") : null;
 }
 
+interface ObserverCallResult {
+	raw: string | null;
+	usage: ObserverTokenUsage | null;
+}
+
+function tokenCount(value: unknown): number | null {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function normalizeObserverUsage(body: Record<string, unknown>): ObserverTokenUsage | null {
+	const usage = body.usage;
+	if (typeof usage !== "object" || usage == null || Array.isArray(usage)) return null;
+	const record = usage as Record<string, unknown>;
+	const inputTokens = tokenCount(record.input_tokens) ?? tokenCount(record.prompt_tokens);
+	const outputTokens = tokenCount(record.output_tokens) ?? tokenCount(record.completion_tokens);
+	if (inputTokens == null || outputTokens == null) return null;
+
+	const normalized: ObserverTokenUsage = { inputTokens, outputTokens };
+	const totalTokens = tokenCount(record.total_tokens);
+	if (totalTokens != null) normalized.totalTokens = totalTokens;
+
+	const inputDetails = record.input_tokens_details ?? record.prompt_tokens_details;
+	const cachedTokens =
+		typeof inputDetails === "object" && inputDetails != null && !Array.isArray(inputDetails)
+			? tokenCount((inputDetails as Record<string, unknown>).cached_tokens)
+			: null;
+	const cacheReadInputTokens = tokenCount(record.cache_read_input_tokens) ?? cachedTokens;
+	if (cacheReadInputTokens != null) normalized.cacheReadInputTokens = cacheReadInputTokens;
+	const cacheCreationInputTokens = tokenCount(record.cache_creation_input_tokens);
+	if (cacheCreationInputTokens != null) {
+		normalized.cacheCreationInputTokens = cacheCreationInputTokens;
+	}
+	return normalized;
+}
+
+function emptyCallResult(raw: string | null): ObserverCallResult {
+	return { raw, usage: null };
+}
+
 // ---------------------------------------------------------------------------
 // OpenAI helpers
 // ---------------------------------------------------------------------------
@@ -1156,8 +1203,9 @@ function buildCodexPayload(
 function extractTextFromSSE(
 	rawText: string,
 	extractDelta: (event: Record<string, unknown>) => string | null,
-): string | null {
+): ObserverCallResult {
 	const parts: string[] = [];
+	const usageFields: Record<string, unknown> = {};
 	for (const line of rawText.split("\n")) {
 		if (!line.startsWith("data:")) continue;
 		const payload = line.slice(5).trim();
@@ -1166,11 +1214,22 @@ function extractTextFromSSE(
 			const event = JSON.parse(payload) as Record<string, unknown>;
 			const delta = extractDelta(event);
 			if (delta) parts.push(delta);
+			for (const candidate of [event, event.response, event.message]) {
+				if (typeof candidate !== "object" || candidate == null || Array.isArray(candidate))
+					continue;
+				const usage = (candidate as Record<string, unknown>).usage;
+				if (typeof usage === "object" && usage != null && !Array.isArray(usage)) {
+					Object.assign(usageFields, usage);
+				}
+			}
 		} catch {
 			// skip malformed events
 		}
 	}
-	return parts.length > 0 ? parts.join("").trim() : null;
+	return {
+		raw: parts.length > 0 ? parts.join("").trim() : null,
+		usage: normalizeObserverUsage({ usage: usageFields }),
+	};
 }
 
 function extractCodexDelta(event: Record<string, unknown>): string | null {
@@ -1564,6 +1623,7 @@ export class ObserverClient {
 	 * This is the main entry point. On auth errors, attempts one refresh + retry.
 	 */
 	async observe(systemPrompt: string, userPrompt: string): Promise<ObserverResponse> {
+		const startedAt = nowMs();
 		// Enforce configured prompt-length cap (matches Python behavior)
 		const maxChars = this.maxChars;
 		const minUserBudget = Math.floor(maxChars * 0.25);
@@ -1584,14 +1644,9 @@ export class ObserverClient {
 				this._codexSidecarModelFallbackApplied = false;
 				this._codexSidecarModelFallbackReason = null;
 			}
-			const raw = await this._callOnce(clippedSystem, clippedUser);
-			if (raw) this._clearLastError();
-			return {
-				raw,
-				parsed: raw ? tryParseJSON(raw) : null,
-				provider: this.provider,
-				model: this._resolvedResultModel(),
-			};
+			const call = await this._callOnce(clippedSystem, clippedUser);
+			if (call.raw) this._clearLastError();
+			return this._buildResponse(call, startedAt);
 		} catch (err) {
 			if (err instanceof ObserverAuthError) {
 				// Attempt one auth refresh + retry. Note: for sidecar runtimes
@@ -1601,20 +1656,26 @@ export class ObserverClient {
 				this.refreshAuth();
 				if (!this.auth.token) throw err;
 				try {
-					const raw = await this._callOnce(clippedSystem, clippedUser);
-					if (raw) this._clearLastError();
-					return {
-						raw,
-						parsed: raw ? tryParseJSON(raw) : null,
-						provider: this.provider,
-						model: this._resolvedResultModel(),
-					};
+					const call = await this._callOnce(clippedSystem, clippedUser);
+					if (call.raw) this._clearLastError();
+					return this._buildResponse(call, startedAt);
 				} catch {
 					throw err; // re-throw original
 				}
 			}
 			throw err;
 		}
+	}
+
+	private _buildResponse(call: ObserverCallResult, startedAt: number): ObserverResponse {
+		return {
+			raw: call.raw,
+			parsed: call.raw ? tryParseJSON(call.raw) : null,
+			provider: this.provider,
+			model: this._resolvedResultModel(),
+			elapsedMs: Math.max(0, nowMs() - startedAt),
+			usage: call.usage,
+		};
 	}
 
 	/** Model string to report for a result, accounting for sidecar fallback. */
@@ -1635,6 +1696,7 @@ export class ObserverClient {
 		schemaName: string,
 		schema: Record<string, unknown>,
 	): Promise<ObserverStructuredJsonResponse> {
+		const startedAt = nowMs();
 		if (this.provider === "openai" && this.openaiUseResponses && !this._codexAccess) {
 			if (!this.auth.token && !this.canCallOpenAIDirectWithoutAuth()) {
 				this._initProvider(true);
@@ -1644,6 +1706,8 @@ export class ObserverClient {
 						parsed: null,
 						provider: this.provider,
 						model: this.model,
+						elapsedMs: Math.max(0, nowMs() - startedAt),
+						usage: null,
 						usedStructuredOutputs: true,
 					};
 				}
@@ -1671,15 +1735,17 @@ export class ObserverClient {
 				schemaName,
 				schema,
 			);
-			const raw = await this._fetchJSON(url, mergedHeaders, payload, {
+			const call = await this._fetchJSON(url, mergedHeaders, payload, {
 				parseResponse: parseOpenAIResponsesResponse,
 				providerLabel: "OpenAI",
 			});
 			return {
-				raw,
-				parsed: raw ? tryParseJSON(raw) : null,
+				raw: call.raw,
+				parsed: call.raw ? tryParseJSON(call.raw) : null,
 				provider: this.provider,
 				model: this.model,
+				elapsedMs: Math.max(0, nowMs() - startedAt),
+				usage: call.usage,
 				usedStructuredOutputs: true,
 			};
 		}
@@ -1698,7 +1764,7 @@ export class ObserverClient {
 						headers,
 						renderObserverHeaders(this._observerHeaders, this.auth),
 					);
-					const raw = await this._fetchJSON(
+					const call = await this._fetchJSON(
 						resolveAnthropicEndpoint(),
 						mergedHeaders,
 						buildAnthropicStructuredPayload(
@@ -1711,10 +1777,12 @@ export class ObserverClient {
 						{ parseResponse: parseAnthropicResponse, providerLabel: "Anthropic" },
 					);
 					return {
-						raw,
-						parsed: raw ? tryParseJSON(raw) : null,
+						raw: call.raw,
+						parsed: call.raw ? tryParseJSON(call.raw) : null,
 						provider: this.provider,
 						model: this.model,
+						elapsedMs: Math.max(0, nowMs() - startedAt),
+						usage: call.usage,
 						usedStructuredOutputs: true,
 					};
 				}
@@ -1728,6 +1796,8 @@ export class ObserverClient {
 			parsed: fallback.parsed,
 			provider: fallback.provider,
 			model: fallback.model,
+			elapsedMs: Math.max(0, nowMs() - startedAt),
+			usage: fallback.usage,
 			usedStructuredOutputs: false,
 		};
 	}
@@ -1817,15 +1887,15 @@ export class ObserverClient {
 	// LLM call dispatch
 	// -----------------------------------------------------------------------
 
-	private async _callOnce(systemPrompt: string, userPrompt: string): Promise<string | null> {
+	private async _callOnce(systemPrompt: string, userPrompt: string): Promise<ObserverCallResult> {
 		// Claude sidecar path — dispatches before any API-based paths
 		if (this.runtime === "claude_sidecar") {
-			return this._callSidecar(systemPrompt, userPrompt);
+			return emptyCallResult(await this._callSidecar(systemPrompt, userPrompt));
 		}
 
 		// Codex sidecar path — dispatches before any API-based paths
 		if (this.runtime === "codex_sidecar") {
-			return this._callCodexSidecar(systemPrompt, userPrompt);
+			return emptyCallResult(await this._callCodexSidecar(systemPrompt, userPrompt));
 		}
 
 		// Codex consumer path (OpenAI OAuth)
@@ -1845,7 +1915,7 @@ export class ObserverClient {
 			if (this._anthropicOAuthAccess) return this._callAnthropicConsumer(systemPrompt, userPrompt);
 			if (!this.auth.token && !this.canCallOpenAIDirectWithoutAuth()) {
 				this._setLastError(`${capitalize(this.provider)} credentials are missing.`, "auth_missing");
-				return null;
+				return emptyCallResult(null);
 			}
 		}
 
@@ -1863,7 +1933,7 @@ export class ObserverClient {
 	private async _callAnthropicDirect(
 		systemPrompt: string,
 		userPrompt: string,
-	): Promise<string | null> {
+	): Promise<ObserverCallResult> {
 		const url = resolveAnthropicEndpoint();
 		const token = this.auth.token ?? "";
 		const headers = buildAnthropicHeaders(token, false);
@@ -1886,7 +1956,7 @@ export class ObserverClient {
 	private async _callOpenAIDirect(
 		systemPrompt: string,
 		userPrompt: string,
-	): Promise<string | null> {
+	): Promise<ObserverCallResult> {
 		let url: string;
 		if (this._customBaseUrl) {
 			url = `${stripTrailingSlashes(this._customBaseUrl)}/${this.openaiUseResponses ? "responses" : "chat/completions"}`;
@@ -1926,8 +1996,8 @@ export class ObserverClient {
 	private async _callCodexConsumer(
 		systemPrompt: string,
 		userPrompt: string,
-	): Promise<string | null> {
-		if (!this._codexAccess) return null;
+	): Promise<ObserverCallResult> {
+		if (!this._codexAccess) return emptyCallResult(null);
 
 		const headers = buildCodexHeaders(this._codexAccess, this._codexAccountId);
 		if (Object.keys(this._observerHeaders).length > 0) {
@@ -1959,8 +2029,8 @@ export class ObserverClient {
 	private async _callAnthropicConsumer(
 		systemPrompt: string,
 		userPrompt: string,
-	): Promise<string | null> {
-		if (!this._anthropicOAuthAccess) return null;
+	): Promise<ObserverCallResult> {
+		if (!this._anthropicOAuthAccess) return emptyCallResult(null);
 
 		const headers = buildAnthropicHeaders(this._anthropicOAuthAccess, true);
 		if (Object.keys(this._observerHeaders).length > 0) {
@@ -2436,7 +2506,7 @@ export class ObserverClient {
 			parseResponse: (body: Record<string, unknown>) => string | null;
 			providerLabel: string;
 		},
-	): Promise<string | null> {
+	): Promise<ObserverCallResult> {
 		try {
 			const response = await fetch(url, {
 				method: "POST",
@@ -2448,7 +2518,7 @@ export class ObserverClient {
 			if (!response.ok) {
 				const errorText = await response.text().catch(() => "");
 				this._handleHttpError(response.status, errorText, opts.providerLabel);
-				return null;
+				return emptyCallResult(null);
 			}
 
 			const body = (await response.json()) as Record<string, unknown>;
@@ -2459,14 +2529,14 @@ export class ObserverClient {
 					"empty_response",
 				);
 			}
-			return result;
+			return { raw: result, usage: normalizeObserverUsage(body) };
 		} catch (err) {
 			if (err instanceof ObserverAuthError) throw err;
 			this._setLastError(
 				`${opts.providerLabel} processing failed during observer inference.`,
 				"observer_call_failed",
 			);
-			return null;
+			return emptyCallResult(null);
 		}
 	}
 
@@ -2480,7 +2550,7 @@ export class ObserverClient {
 		payload: Record<string, unknown>,
 		extractDelta: (event: Record<string, unknown>) => string | null,
 		opts: { providerLabel: string; authErrorMessage: string },
-	): Promise<string | null> {
+	): Promise<ObserverCallResult> {
 		try {
 			const response = await fetch(url, {
 				method: "POST",
@@ -2500,10 +2570,11 @@ export class ObserverClient {
 					`${opts.providerLabel} request failed during observer processing.`,
 					"provider_request_failed",
 				);
-				return null;
+				return emptyCallResult(null);
 			}
 
-			// Read full response body as text and parse SSE events
+			// Read full response body as text and parse SSE events. Token usage is
+			// collected only from parsed events, never inferred from response length.
 			const rawText = await response.text();
 			return extractTextFromSSE(rawText, extractDelta);
 		} catch (err) {
@@ -2512,7 +2583,7 @@ export class ObserverClient {
 				`${opts.providerLabel} processing failed during observer inference.`,
 				"observer_call_failed",
 			);
-			return null;
+			return emptyCallResult(null);
 		}
 	}
 


### PR DESCRIPTION
## Description

- add required, optional, and forbidden durable-fact labels for reviewed extraction batches
- score recall, worthiness precision, summary breadth, segmentation, redundancy, schema compliance, and human-review grounding
- capture provider token usage and latency without guessing missing usage
- estimate model cost from an explicit dated pricing table and expose cost availability reasons
- add GPT-5.4-mini, GPT-5.4, GPT-5.5, and Terra calibration roles without changing production defaults
- recommend retaining GPT-5.4-mini/simple and GPT-5.4/rich while Terra remains the cost-matched challenger

Stacked on #1322. Tracks `codemem-h67n.2`.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Full local gate: 134 files, 2,583 tests passed, 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced