### PR TITLE
feat: expose Codex sidecar in settings

### DIFF
--- a/docs/plans/2026-07-10-observer-eval-and-codex-sidecar-settings-design.md
+++ b/docs/plans/2026-07-10-observer-eval-and-codex-sidecar-settings-design.md
@@ -1,0 +1,152 @@
+# Observer evaluation and Codex sidecar settings design
+
+## Problem
+
+The current observer benchmark is too small and internally inconsistent to
+support close model-selection decisions. Only two rich batches have durable-fact
+labels, one label cannot be satisfied from the replay input, low-signal skips can
+be counted as shape failures even when the production prompt asks for them, and
+the scoreboard does not preserve raw responses for review.
+
+The settings surface also omits the supported `codex_sidecar` runtime. Core can
+auto-select and run it, but the viewer dropdown does not expose it and the viewer
+config API rejects it. The viewer exposes the protected Claude command but not
+the equivalent Codex command.
+
+## Goals
+
+- Make `codex_sidecar` selectable, saveable, and understandable in Settings.
+- Keep protected command configuration read-only while showing both Claude and
+  Codex command values.
+- Repair benchmark semantics before using results to change defaults.
+- Expand the corpus to balanced simple, working, and rich cases.
+- Keep model selection separate by transport: direct API, Codex sidecar, and
+  OpenCode.
+- Preserve enough evidence for human factual-grounding review.
+- Measure stability with repeated finalist runs instead of trusting one sample.
+
+## Non-goals
+
+- Do not change production observer defaults in this work.
+- Do not claim sidecar latency or subscription usage is directly comparable to
+  metered API latency and token cost.
+- Do not introduce an LLM-as-judge dependency as the source of benchmark truth.
+- Do not silently treat a transport fallback as a successful requested-model run.
+
+## Settings design
+
+Settings > Connection adds **Local Codex session** alongside Direct API and
+Local Claude session. Supporting text explains that sidecars use the respective
+local CLI login and ignore API credential settings.
+
+The viewer config route accepts `codex_sidecar`, includes `codex_command` as a
+protected key, and returns the default `['codex']` command. The advanced settings
+area shows read-only Claude and Codex argv fields using the existing protected
+configuration pattern.
+
+Model inference and status labels recognize the Codex runtime explicitly. With
+no configured model, the UI reports the current Codex-sidecar default,
+`gpt-5.1-codex-mini`. This work documents the current behavior but does not
+change it.
+
+## Benchmark architecture
+
+One shared corpus feeds three transport-specific leaderboards:
+
+1. Direct API: cheap/simple candidates and rich candidates are compared within
+   the metered API transport.
+2. Codex sidecar: Luna and the current Codex default are compared within the
+   local Codex CLI transport.
+3. OpenCode: OpenCode-accessible candidates are compared independently as they
+   become available.
+
+Cross-transport quality results may be shown for context, but latency and cost
+rankings never mix transports.
+
+The target corpus contains 18 reviewed shape cases:
+
+- 6 simple
+- 6 working
+- 6 rich
+
+Replay/no-output and malformed-output cases remain a separate robustness set so
+they cannot distort extraction-quality counts.
+
+Every shape case records an expected summary disposition:
+
+- `required`: meaningful work must produce one summary.
+- `optional`: either a grounded summary or a valid low-signal skip is acceptable.
+- `skip`: a valid low-signal skip is the desired result.
+
+Each reviewed durable-fact label includes a human-readable claim, disposition,
+source-evidence notes, and conservative matching aliases. Labels must be
+satisfiable from the exact replay input. Tests enforce that reviewed labels have
+evidence notes and that impossible or empty reviews cannot enter the benchmark.
+
+## Scoring
+
+The report keeps dimensions separate:
+
+- requested-model and transport availability
+- recognized/valid output rate
+- schema compliance and parser data loss
+- summary-disposition correctness
+- required and optional durable-fact recall
+- forbidden/noise avoidance and worthiness precision
+- summary breadth
+- redundancy and segmentation
+- factual grounding from human review
+- latency and same-transport cost
+- run-to-run stability
+
+The composite quality score remains secondary. A model cannot be recommended
+unless it passes minimum gates for availability, schema/data-loss rate, summary
+disposition, factual grounding, and repeated-run reliability. Missing dimensions
+stay missing rather than being silently reweighted into an apparently strong
+score.
+
+Benchmark JSON preserves initial and repaired raw output, parsed diagnostics,
+usage, latency, requested model, resolved model when known, and fallback status.
+This makes every aggregate auditable.
+
+## Evaluation workflow
+
+1. Run each candidate once across all reviewed cases for screening.
+2. Inspect raw outputs and complete factual-grounding review.
+3. Select finalists per transport and tier.
+4. Run finalists three times on a balanced representative/challenge subset.
+5. Recommend defaults only from repeated results that clear all gates.
+
+Terra remains a rich API finalist because its latency advantage is material and
+its only observed shape miss passed on repetition. Luna remains a Codex-sidecar
+finalist; it is not treated as an API or OpenCode replacement until available on
+those routes.
+
+## Error handling
+
+- Valid `low-signal` skips are classified by expected disposition, not as generic
+  no-output failures.
+- Empty output, malformed XML, unavailable requested models, and fallback-model
+  output remain distinct statuses.
+- Sidecar runs with missing usage report usage as unavailable; they do not invent
+  token cost.
+- Benchmark reports retain partial run evidence when another case fails.
+
+## Testing
+
+- Viewer route tests cover accepting `codex_sidecar`, rejecting unknown runtimes,
+  and protecting `codex_command`.
+- Settings helper/component tests cover runtime options, model hints, auth/status
+  text, and Codex command form state.
+- Benchmark tests cover disposition classification, raw-output preservation,
+  reviewed-label evidence requirements, separate robustness accounting, and
+  non-reweighting of missing quality dimensions.
+- Focused Vitest files run first, followed by `pnpm run tsc`, `pnpm run lint`, and
+  `pnpm run test`.
+
+## Rollout
+
+The settings support can ship without changing runtime defaults. The repaired
+benchmark and expanded annotations ship as evaluation infrastructure. Any future
+default change is a separate decision backed by repeated transport-specific
+results.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -41,16 +41,19 @@
 
 ## Observer auth configuration
 
-- Runtime choices are `api_http` and `claude_sidecar`.
+- Runtime choices are `api_http`, `claude_sidecar`, and `codex_sidecar`.
 - `claude_sidecar` runs observer calls through the local Claude runtime (subscription/session auth) and does not require `ANTHROPIC_API_KEY`.
 - `claude_command` controls how `claude_sidecar` invokes Claude CLI (default `["claude"]`).
   - Wrapper example: `"claude_command": ["wrapper", "claude", "--"]`
+- `codex_sidecar` runs observer calls through the local Codex CLI login and does not require `OPENAI_API_KEY`.
+- `codex_command` controls how `codex_sidecar` invokes Codex CLI (default `["codex"]`).
 - Default model selection:
 - `api_http`: `gpt-5.1-codex-mini` unless `observer_model` is set.
 - `claude_sidecar`: `claude-4.5-haiku` unless `observer_model` is set.
+- `codex_sidecar`: `gpt-5.1-codex-mini` unless `observer_model` is set.
 - Tier routing may pick different simple/rich models automatically when the current runtime/provider path is marked capability-safe.
 - Anthropic direct API calls use Anthropic's direct model IDs. codemem translates the common shorthand `claude-4.5-haiku` to `claude-haiku-4-5`; if you want a fixed snapshot, set a versioned model like `claude-haiku-4-5-20251001` directly.
-- If a configured `observer_model` is unsupported by Claude CLI, codemem retries once with Claude's default model.
+- If a configured `observer_model` is unsupported by a sidecar CLI, codemem retries once with that CLI's default model.
 - Supported auth sources: `auto`, `env`, `file`, `command`, `none`.
 - `observer_auth_command` is argv and must be a JSON string array, not a space-separated string.
   - Config file form: `"observer_auth_command": ["iap-auth", "--audience", "example"]`

--- a/packages/core/src/extraction-tier-routing.test.ts
+++ b/packages/core/src/extraction-tier-routing.test.ts
@@ -190,6 +190,58 @@ describe("extraction tier routing", () => {
 		expect(config.observerRuntime).toBe("claude_sidecar");
 	});
 
+	it("preserves the Codex sidecar default for simple tier routing", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 19001,
+			sessionId: 200001,
+			eventSpan: 12,
+			promptCount: 1,
+			toolCount: 1,
+			transcriptLength: 320,
+		});
+		const selection = buildTieredObserverSelection(
+			baseConfig({
+				observerProvider: "openai",
+				observerModel: "gpt-5.1-codex-mini",
+				observerRuntime: "codex_sidecar",
+				observerSimpleModel: null,
+			}),
+			decision,
+		);
+
+		expect(selection.observer.observerProvider).toBe("openai");
+		expect(selection.observer.observerModel).toBe("gpt-5.1-codex-mini");
+		expect(selection.observer.observerRuntime).toBe("codex_sidecar");
+		expect(selection.metadata.requestedRuntime).toBe("codex_sidecar");
+		expect(selection.metadata.requestedModel).toBe("gpt-5.1-codex-mini");
+	});
+
+	it("preserves the Codex sidecar default for rich tier routing", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+		const selection = buildTieredObserverSelection(
+			baseConfig({
+				observerProvider: "openai",
+				observerModel: "gpt-5.1-codex-mini",
+				observerRuntime: "codex_sidecar",
+				observerRichModel: null,
+			}),
+			decision,
+		);
+
+		expect(selection.observer.observerProvider).toBe("openai");
+		expect(selection.observer.observerModel).toBe("gpt-5.1-codex-mini");
+		expect(selection.observer.observerRuntime).toBe("codex_sidecar");
+		expect(selection.metadata.requestedRuntime).toBe("codex_sidecar");
+		expect(selection.metadata.requestedModel).toBe("gpt-5.1-codex-mini");
+	});
+
 	it("respects observerRichProvider override even when base provider is openai", () => {
 		const decision = decideExtractionReplayTier({
 			batchId: 18503,

--- a/packages/core/src/extraction-tier-routing.ts
+++ b/packages/core/src/extraction-tier-routing.ts
@@ -85,9 +85,9 @@ function resolveRichTierDefaults(provider: KnownTierProvider): Partial<ObserverC
 }
 
 function normalizeRuntime(value: string | null | undefined): string {
-	return typeof value === "string" && value.trim().toLowerCase() === "claude_sidecar"
-		? "claude_sidecar"
-		: "api_http";
+	const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+	if (normalized === "claude_sidecar" || normalized === "codex_sidecar") return normalized;
+	return "api_http";
 }
 
 function nullIfUndefined<T>(value: T | undefined): T | null {
@@ -159,6 +159,52 @@ export function buildTieredObserverSelection(
 		};
 		const fallbackReason =
 			hasExplicitProviderOverride && requestedProvider && requestedProvider !== "anthropic"
+				? "unsupported tier override for runtime"
+				: null;
+		return {
+			observer,
+			metadata: requestedMetadata(
+				decision,
+				{
+					...observer,
+					observerProvider: requestedProvider ?? observer.observerProvider,
+					observerRuntime: normalizedRuntime,
+				},
+				fallbackReason,
+			),
+		};
+	}
+	if (normalizedRuntime === "codex_sidecar") {
+		const sidecarProviderKey =
+			decision.tier === "simple" ? "observerSimpleProvider" : "observerRichProvider";
+		const hasExplicitProviderOverride =
+			explicitConfigKeys.has(sidecarProviderKey) || explicitConfigKeys.has("observerProvider");
+		const requestedProvider =
+			(sidecarProviderKey === "observerSimpleProvider"
+				? trimmedProvider(baseConfig.observerSimpleProvider)
+				: trimmedProvider(baseConfig.observerRichProvider)) ??
+			trimmedProvider(baseConfig.observerProvider);
+		const observer = {
+			...baseConfig,
+			observerProvider: "openai",
+			observerModel:
+				decision.tier === "simple"
+					? (baseConfig.observerSimpleModel ?? baseConfig.observerModel)
+					: (baseConfig.observerRichModel ?? baseConfig.observerModel),
+			observerTemperature:
+				decision.tier === "simple"
+					? (baseConfig.observerSimpleTemperature ?? baseConfig.observerTemperature)
+					: (baseConfig.observerRichTemperature ?? baseConfig.observerTemperature),
+			observerOpenAIUseResponses: undefined,
+			observerReasoningEffort: null,
+			observerReasoningSummary: null,
+			observerMaxOutputTokens:
+				decision.tier === "simple"
+					? baseConfig.observerMaxTokens
+					: (baseConfig.observerRichMaxOutputTokens ?? baseConfig.observerMaxTokens),
+		};
+		const fallbackReason =
+			hasExplicitProviderOverride && requestedProvider && requestedProvider !== "openai"
 				? "unsupported tier override for runtime"
 				: null;
 		return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -459,6 +459,7 @@ export type {
 } from "./observer-config.js";
 export {
 	CODEMEM_CONFIG_ENV_OVERRIDES,
+	coerceObserverCommand,
 	getCodememConfigPath,
 	getCodememEnvOverrides,
 	getOpenCodeProviderConfig,

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -5,7 +5,7 @@
  * an LLM (Anthropic Messages or OpenAI Chat Completions) via fetch to extract
  * memories from session transcripts.
  *
- * Supports api_http and claude_sidecar runtimes (no opencode_run).
+ * Supports api_http, claude_sidecar, and codex_sidecar runtimes (no opencode_run).
  * Non-streaming responses via fetch (no SDK deps).
  */
 
@@ -30,6 +30,7 @@ import {
 	resolveOAuthProvider,
 } from "./observer-auth.js";
 import {
+	coerceObserverCommand,
 	getOpenCodeProviderConfig,
 	getProviderApiKey,
 	listConfiguredOpenCodeProviders,
@@ -355,45 +356,6 @@ function coerceCommand(value: unknown): string[] | null {
 	}
 	return null;
 }
-
-/**
- * Coerce a claude_command value to a string array.
- * Accepts a string (split on whitespace) or an array of strings.
- */
-function coerceClaudeCommand(value: unknown): string[] | null {
-	if (value == null) return null;
-	if (Array.isArray(value)) {
-		const parts = value.filter((v): v is string => typeof v === "string" && v.trim() !== "");
-		return parts.length > 0 ? parts : null;
-	}
-	if (typeof value === "string") {
-		const trimmed = value.trim();
-		if (!trimmed) return null;
-		// Try JSON array first
-		try {
-			const parsed = JSON.parse(trimmed);
-			if (Array.isArray(parsed) && parsed.every((v: unknown) => typeof v === "string")) {
-				const parts = (parsed as string[]).filter((v) => v.trim() !== "");
-				return parts.length > 0 ? parts : null;
-			}
-		} catch {
-			/* not JSON — split on whitespace */
-		}
-		const parts = trimmed.split(/\s+/).filter((v) => v !== "");
-		return parts.length > 0 ? parts : null;
-	}
-	return null;
-}
-
-/**
- * Coerce a codex_command value to a string array.
- * Accepts a string (split on whitespace) or an array of strings.
- * Mirrors coerceClaudeCommand.
- */
-function coerceCodexCommand(value: unknown): string[] | null {
-	return coerceClaudeCommand(value);
-}
-
 /**
  * True when the OpenCode OAuth cache holds usable credentials for any built-in
  * provider (openai/anthropic OAuth access, or an opencode API key). Used to
@@ -600,11 +562,11 @@ export function loadObserverConfig(): ObserverConfig {
 	if (authCmd) cfg.observerAuthCommand = authCmd;
 
 	// claude_command: string or string[] → string[]
-	const claudeCmd = coerceClaudeCommand(data.claude_command);
+	const claudeCmd = coerceObserverCommand(data.claude_command);
 	if (claudeCmd) cfg.claudeCommand = claudeCmd;
 
 	// codex_command: string or string[] → string[]
-	const codexCmd = coerceCodexCommand(data.codex_command);
+	const codexCmd = coerceObserverCommand(data.codex_command);
 	if (codexCmd) cfg.codexCommand = codexCmd;
 
 	// Apply env var overrides (take precedence over file)
@@ -678,10 +640,10 @@ export function loadObserverConfig(): ObserverConfig {
 	const envAuthCmd = coerceCommand(process.env.CODEMEM_OBSERVER_AUTH_COMMAND);
 	if (envAuthCmd) cfg.observerAuthCommand = envAuthCmd;
 
-	const envClaudeCmd = coerceClaudeCommand(process.env.CODEMEM_CLAUDE_COMMAND);
+	const envClaudeCmd = coerceObserverCommand(process.env.CODEMEM_CLAUDE_COMMAND);
 	if (envClaudeCmd) cfg.claudeCommand = envClaudeCmd;
 
-	const envCodexCmd = coerceCodexCommand(process.env.CODEMEM_CODEX_COMMAND);
+	const envCodexCmd = coerceObserverCommand(process.env.CODEMEM_CODEX_COMMAND);
 	if (envCodexCmd) cfg.codexCommand = envCodexCmd;
 
 	// Auto-detect Claude environment for runtime default.

--- a/packages/core/src/observer-config.ts
+++ b/packages/core/src/observer-config.ts
@@ -185,6 +185,7 @@ export const CODEMEM_CONFIG_ENV_OVERRIDES: Record<string, string> = {
 	actor_id: "CODEMEM_ACTOR_ID",
 	actor_display_name: "CODEMEM_ACTOR_DISPLAY_NAME",
 	claude_command: "CODEMEM_CLAUDE_COMMAND",
+	codex_command: "CODEMEM_CODEX_COMMAND",
 	observer_provider: "CODEMEM_OBSERVER_PROVIDER",
 	observer_model: "CODEMEM_OBSERVER_MODEL",
 	observer_temperature: "CODEMEM_OBSERVER_TEMPERATURE",
@@ -232,6 +233,31 @@ export const CODEMEM_CONFIG_ENV_OVERRIDES: Record<string, string> = {
 	raw_events_retention_enabled: "CODEMEM_RAW_EVENTS_RETENTION_ENABLED",
 	raw_events_retention_max_age_days: "CODEMEM_RAW_EVENTS_RETENTION_MAX_AGE_DAYS",
 };
+
+/** Normalize a configured sidecar command from argv or a shell-style string. */
+export function coerceObserverCommand(value: unknown): string[] | null {
+	if (value == null) return null;
+	if (Array.isArray(value)) {
+		const parts = value.filter((item): item is string => {
+			return typeof item === "string" && item.trim() !== "";
+		});
+		return parts.length > 0 ? parts : null;
+	}
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	try {
+		const parsed = JSON.parse(trimmed) as unknown;
+		if (Array.isArray(parsed) && parsed.every((item) => typeof item === "string")) {
+			const parts = parsed.filter((item) => item.trim() !== "");
+			return parts.length > 0 ? parts : null;
+		}
+	} catch {
+		// Non-JSON command strings use the same whitespace splitting as existing config.
+	}
+	const parts = trimmed.split(/\s+/).filter((item) => item !== "");
+	return parts.length > 0 ? parts : null;
+}
 
 // ---------------------------------------------------------------------------
 // Unified config path resolver with full traceability

--- a/packages/ui/src/tabs/settings/components/ObserverPanel.test.tsx
+++ b/packages/ui/src/tabs/settings/components/ObserverPanel.test.tsx
@@ -1,0 +1,74 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_FORM_STATE } from "../data/constants";
+import type { SettingsPanelProps } from "../data/types";
+import { ObserverPanel } from "./ObserverPanel";
+
+vi.mock("../../../components/primitives/radix-select", () => ({
+	RadixSelect: ({
+		id,
+		onValueChange,
+		options,
+		value,
+	}: {
+		id?: string;
+		onValueChange: (value: string) => void;
+		options: Array<{ label: string; value: string }>;
+		value: string;
+	}) => (
+		<select id={id} onChange={(event) => onValueChange(event.currentTarget.value)} value={value}>
+			{options.map((option) => (
+				<option key={option.value} value={option.value}>
+					{option.label}
+				</option>
+			))}
+		</select>
+	),
+}));
+
+let mount: HTMLDivElement | null = null;
+
+function props(): SettingsPanelProps & { observerStatusBannerSlot: null } {
+	return {
+		values: { ...EMPTY_FORM_STATE, observerRuntime: "api_http" },
+		observerMaxCharsDefault: "12000",
+		providerOptions: [],
+		showAuthFile: false,
+		showAuthCommand: false,
+		showTieredRouting: false,
+		hiddenUnlessAdvanced: () => false,
+		onTextInput: () => vi.fn(),
+		onSelectValueChange: () => vi.fn(),
+		onSwitchInput: () => vi.fn(),
+		getObserverModelLabel: () => "Model",
+		getObserverModelTooltip: () => "",
+		getObserverModelDescription: () => "",
+		getObserverModelHint: () => "",
+		getTieredRoutingHelperText: () => "",
+		protectedConfigHelp: (key) => `${key} is protected`,
+		observerStatusBannerSlot: null,
+	};
+}
+
+afterEach(() => {
+	if (mount) {
+		act(() => render(null, mount as HTMLDivElement));
+		mount.remove();
+		mount = null;
+	}
+	document.body.innerHTML = "";
+});
+
+describe("ObserverPanel", () => {
+	it("offers a local Codex runtime and shows its protected command", () => {
+		mount = document.createElement("div");
+		document.body.appendChild(mount);
+		act(() => render(<ObserverPanel {...props()} />, mount as HTMLDivElement));
+
+		const runtime = mount.querySelector<HTMLSelectElement>("#observerRuntime");
+		expect(runtime?.textContent).toContain("Local Codex session");
+		expect(mount.querySelector<HTMLTextAreaElement>("#codexCommand")).not.toBeNull();
+		expect(mount.textContent).toContain("codex_command is protected");
+	});
+});

--- a/packages/ui/src/tabs/settings/components/ObserverPanel.tsx
+++ b/packages/ui/src/tabs/settings/components/ObserverPanel.tsx
@@ -87,7 +87,7 @@ export function ObserverPanel({
 						<button
 							aria-label="About connection mode"
 							className="help-icon"
-							data-tooltip="Direct API uses provider credentials. Local Claude session uses local Claude runtime auth."
+							data-tooltip="Direct API uses provider credentials. Local sessions use the selected Claude or Codex CLI login."
 							type="button"
 						>
 							?
@@ -102,14 +102,26 @@ export function ObserverPanel({
 						options={[
 							{ label: "Direct API (default)", value: "api_http" },
 							{ label: "Local Claude session", value: "claude_sidecar" },
+							{ label: "Local Codex session", value: "codex_sidecar" },
 						]}
 						triggerClassName="settings-select-trigger"
 						value={values.observerRuntime}
 						viewportClassName="settings-select-viewport"
 					/>
 					<div className="small">
-						Switch between provider API credentials and local Claude session auth.
+						Switch between provider API credentials and local Claude or Codex CLI auth.
 					</div>
+				</Field>
+				<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+					<label htmlFor="codexCommand">Codex command (JSON argv)</label>
+					<TextArea
+						disabled
+						id="codexCommand"
+						placeholder='["codex"]'
+						rows={2}
+						value={values.codexCommand}
+					/>
+					<div className="small">{protectedConfigHelp("codex_command")}</div>
 				</Field>
 				<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
 					<label htmlFor="claudeCommand">Claude command (JSON argv)</label>

--- a/packages/ui/src/tabs/settings/components/SyncPanel.test.tsx
+++ b/packages/ui/src/tabs/settings/components/SyncPanel.test.tsx
@@ -32,6 +32,7 @@ function baseProps(): SettingsPanelProps {
 	return {
 		values: {
 			claudeCommand: "",
+			codexCommand: "",
 			observerProvider: "openai",
 			observerModel: "",
 			observerTierRoutingEnabled: false,

--- a/packages/ui/src/tabs/settings/data/collect-payload.ts
+++ b/packages/ui/src/tabs/settings/data/collect-payload.ts
@@ -38,6 +38,26 @@ export function collectSettingsPayload(
 			: [];
 	}
 
+	let codexCommand: string[] = [];
+	try {
+		codexCommand = parseCommandArgv(values.codexCommand, {
+			label: "codex command",
+			normalize: true,
+			requireNonEmpty: true,
+		});
+	} catch (error) {
+		if (!allowUntouchedParseErrors || touchedKeys.has("codex_command")) {
+			throw error;
+		}
+		const baselineValue = baseline.codex_command;
+		codexCommand = Array.isArray(baselineValue)
+			? baselineValue
+					.filter((item): item is string => typeof item === "string")
+					.map((item) => item.trim())
+					.filter((item) => item.length > 0)
+			: [];
+	}
+
 	let authCommand: string[] = [];
 	try {
 		authCommand = parseCommandArgv(values.observerAuthCommand, { label: "observer auth command" });
@@ -118,6 +138,7 @@ export function collectSettingsPayload(
 
 	return {
 		claude_command: claudeCommand,
+		codex_command: codexCommand,
 		observer_provider: normalizeTextValue(values.observerProvider),
 		observer_model: normalizeTextValue(values.observerModel),
 		observer_tier_routing_enabled: values.observerTierRoutingEnabled,

--- a/packages/ui/src/tabs/settings/data/constants.ts
+++ b/packages/ui/src/tabs/settings/data/constants.ts
@@ -17,6 +17,7 @@ export const SETTINGS_TABS: RadixTabOption[] = [
 
 export const INPUT_TO_CONFIG_KEY: Record<keyof SettingsFormState, string> = {
 	claudeCommand: "claude_command",
+	codexCommand: "codex_command",
 	observerProvider: "observer_provider",
 	observerModel: "observer_model",
 	observerTierRoutingEnabled: "observer_tier_routing_enabled",
@@ -51,6 +52,7 @@ export const INPUT_TO_CONFIG_KEY: Record<keyof SettingsFormState, string> = {
 
 export const PROTECTED_VIEWER_CONFIG_KEYS = new Set([
 	"claude_command",
+	"codex_command",
 	"observer_base_url",
 	"observer_auth_file",
 	"observer_auth_command",
@@ -60,6 +62,7 @@ export const PROTECTED_VIEWER_CONFIG_KEYS = new Set([
 
 export const EMPTY_FORM_STATE: SettingsFormState = {
 	claudeCommand: "",
+	codexCommand: "",
 	observerProvider: "",
 	observerModel: "",
 	observerTierRoutingEnabled: false,

--- a/packages/ui/src/tabs/settings/data/form-state.ts
+++ b/packages/ui/src/tabs/settings/data/form-state.ts
@@ -32,6 +32,10 @@ export function formStateFromPayload(payload: ConfigPayload): SettingsFormState 
 	const claudeCommand = Array.isArray(claudeCommandValue)
 		? claudeCommandValue.filter((item): item is string => typeof item === "string")
 		: [];
+	const codexCommandValue = effectiveOrConfigured(config, effective, "codex_command");
+	const codexCommand = Array.isArray(codexCommandValue)
+		? codexCommandValue.filter((item): item is string => typeof item === "string")
+		: [];
 	const authCommandValue = effectiveOrConfigured(config, effective, "observer_auth_command");
 	const authCommand = Array.isArray(authCommandValue)
 		? authCommandValue.filter((item): item is string => typeof item === "string")
@@ -39,6 +43,7 @@ export function formStateFromPayload(payload: ConfigPayload): SettingsFormState 
 
 	return {
 		claudeCommand: claudeCommand.length ? JSON.stringify(claudeCommand, null, 2) : "",
+		codexCommand: codexCommand.length ? JSON.stringify(codexCommand, null, 2) : "",
 		observerProvider: asInputString(effectiveOrConfigured(config, effective, "observer_provider")),
 		observerModel: asInputString(effectiveOrConfigured(config, effective, "observer_model")),
 		observerTierRoutingEnabled: asBooleanValue(

--- a/packages/ui/src/tabs/settings/data/format.ts
+++ b/packages/ui/src/tabs/settings/data/format.ts
@@ -23,6 +23,8 @@ export function formatAuthMethod(method: string): string {
 			return "API key";
 		case "claude_sidecar":
 			return "Local Claude session";
+		case "codex_sidecar":
+			return "Local Codex session";
 		case "opencode_run":
 			return "OpenCode sidecar";
 		default:

--- a/packages/ui/src/tabs/settings/data/model-accessors.ts
+++ b/packages/ui/src/tabs/settings/data/model-accessors.ts
@@ -28,7 +28,7 @@ export function getTieredRoutingHelperText(values: SettingsFormState): string {
 	if (!values.observerTierRoutingEnabled) {
 		return "Off: codemem uses the base observer settings from the Connection tab for all batches. Explicit user settings always win over built-in routing defaults.";
 	}
-	return "On: codemem routes simpler batches to a lighter model and richer batches to a higher-quality configuration. Rich-tier OpenAI requests default to the Responses transport, and Claude sidecar runtimes route both tiers through the local Claude CLI.";
+	return "On: codemem routes simpler batches to a lighter model and richer batches to a higher-quality configuration. Rich-tier OpenAI requests default to the Responses transport, and sidecar runtimes route both tiers through their local CLI.";
 }
 
 export function getObserverModelLabel(values: SettingsFormState): string {
@@ -44,7 +44,7 @@ export function getObserverModelTooltip(values: SettingsFormState): string {
 export function getObserverModelDescription(values: SettingsFormState): string {
 	return values.observerTierRoutingEnabled
 		? "Tiered routing is active. Use this only as a fallback while the Processing tab owns simple/rich model selection and explicit tier settings override built-in defaults."
-		: "Default: `gpt-5.1-codex-mini` for Direct API; `claude-4.5-haiku` for Local Claude session.";
+		: "Default: `gpt-5.1-codex-mini` for Direct API or Local Codex session; `claude-4.5-haiku` for Local Claude session.";
 }
 
 export function hiddenUnlessAdvanced(showAdvanced: boolean): boolean {

--- a/packages/ui/src/tabs/settings/data/types.ts
+++ b/packages/ui/src/tabs/settings/data/types.ts
@@ -6,6 +6,7 @@ export type SettingsTabId = "observer" | "queue" | "sync";
 
 export type SettingsFormState = {
 	claudeCommand: string;
+	codexCommand: string;
 	observerProvider: string;
 	observerModel: string;
 	observerTierRoutingEnabled: boolean;

--- a/packages/ui/src/tabs/settings/data/value-helpers.test.ts
+++ b/packages/ui/src/tabs/settings/data/value-helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { formStateFromPayload } from "./form-state";
+import { formatAuthMethod } from "./format";
+import { inferObserverModel } from "./value-helpers";
+
+describe("Codex sidecar settings helpers", () => {
+	it("infers the current Codex-sidecar default model", () => {
+		expect(inferObserverModel("codex_sidecar", "openai", "")).toEqual({
+			model: "gpt-5.1-codex-mini",
+			source: "Recommended (local Codex session)",
+		});
+	});
+
+	it("formats Codex-sidecar authentication status", () => {
+		expect(formatAuthMethod("codex_sidecar")).toBe("Local Codex session");
+	});
+
+	it("loads the protected Codex command into form state", () => {
+		const values = formStateFromPayload({
+			effective: {
+				observer_runtime: "codex_sidecar",
+				codex_command: ["/Applications/ChatGPT.app/Contents/Resources/codex"],
+			},
+		});
+
+		expect(values.observerRuntime).toBe("codex_sidecar");
+		expect(values.codexCommand).toContain("ChatGPT.app/Contents/Resources/codex");
+	});
+});

--- a/packages/ui/src/tabs/settings/data/value-helpers.ts
+++ b/packages/ui/src/tabs/settings/data/value-helpers.ts
@@ -67,6 +67,9 @@ export function inferObserverModel(
 	if (runtime === "claude_sidecar") {
 		return { model: DEFAULT_ANTHROPIC_MODEL, source: "Recommended (local Claude session)" };
 	}
+	if (runtime === "codex_sidecar") {
+		return { model: DEFAULT_OPENAI_MODEL, source: "Recommended (local Codex session)" };
+	}
 	if (provider === "anthropic") {
 		return { model: DEFAULT_ANTHROPIC_MODEL, source: "Recommended (Anthropic provider)" };
 	}
@@ -84,6 +87,17 @@ export function configuredValueForKey(config: unknown, key: string): unknown {
 	switch (key) {
 		case "claude_command": {
 			const value = cfg.claude_command;
+			if (!Array.isArray(value)) return [];
+			const normalized: string[] = [];
+			value.forEach((item) => {
+				if (typeof item !== "string") return;
+				const token = item.trim();
+				if (token) normalized.push(token);
+			});
+			return normalized;
+		}
+		case "codex_command": {
+			const value = cfg.codex_command;
 			if (!Array.isArray(value)) return [];
 			const normalized: string[] = [];
 			value.forEach((item) => {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2296,6 +2296,7 @@ describe("viewer-server", () => {
 				expect(body.protected_keys).toEqual(
 					expect.arrayContaining([
 						"claude_command",
+						"codex_command",
 						"observer_auth_file",
 						"observer_auth_command",
 						"observer_headers",
@@ -2373,6 +2374,130 @@ describe("viewer-server", () => {
 				cleanup();
 				if (previous == null) delete process.env.CODEMEM_CONFIG;
 				else process.env.CODEMEM_CONFIG = previous;
+			}
+		});
+
+		it("accepts the Codex sidecar runtime and exposes its protected command", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const previous = process.env.CODEMEM_CONFIG;
+			process.env.CODEMEM_CONFIG = configPath;
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({ config: { observer_runtime: "codex_sidecar" } }),
+				});
+
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect((body.config as Record<string, unknown>).observer_runtime).toBe("codex_sidecar");
+				expect((body.effective as Record<string, unknown>).codex_command).toEqual(["codex"]);
+				expect(body.protected_keys).toEqual(expect.arrayContaining(["codex_command"]));
+			} finally {
+				cleanup();
+				if (previous == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previous;
+			}
+		});
+
+		it("reports CODEMEM_CODEX_COMMAND as normalized env-managed config", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const previousConfig = process.env.CODEMEM_CONFIG;
+			const previousCommand = process.env.CODEMEM_CODEX_COMMAND;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_CODEX_COMMAND =
+				'["/Applications/ChatGPT.app/Contents/Resources/codex","--profile","observer"]';
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect((body.effective as Record<string, unknown>).codex_command).toEqual([
+					"/Applications/ChatGPT.app/Contents/Resources/codex",
+					"--profile",
+					"observer",
+				]);
+				expect(body.env_overrides).toEqual(
+					expect.objectContaining({ codex_command: "CODEMEM_CODEX_COMMAND" }),
+				);
+			} finally {
+				cleanup();
+				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previousConfig;
+				if (previousCommand == null) delete process.env.CODEMEM_CODEX_COMMAND;
+				else process.env.CODEMEM_CODEX_COMMAND = previousCommand;
+			}
+		});
+
+		it("normalizes a string-form Codex command from the config file", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const previousConfig = process.env.CODEMEM_CONFIG;
+			const previousCommand = process.env.CODEMEM_CODEX_COMMAND;
+			process.env.CODEMEM_CONFIG = configPath;
+			delete process.env.CODEMEM_CODEX_COMMAND;
+			writeFileSync(configPath, JSON.stringify({ codex_command: "codex --profile observer" }));
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect((body.effective as Record<string, unknown>).codex_command).toEqual([
+					"codex",
+					"--profile",
+					"observer",
+				]);
+			} finally {
+				cleanup();
+				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previousConfig;
+				if (previousCommand == null) delete process.env.CODEMEM_CODEX_COMMAND;
+				else process.env.CODEMEM_CODEX_COMMAND = previousCommand;
+			}
+		});
+
+		it("does not report normalized command arrays as changed on unrelated saves", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const previousConfig = process.env.CODEMEM_CONFIG;
+			const previousClaudeCommand = process.env.CODEMEM_CLAUDE_COMMAND;
+			const previousCodexCommand = process.env.CODEMEM_CODEX_COMMAND;
+			process.env.CODEMEM_CONFIG = configPath;
+			delete process.env.CODEMEM_CLAUDE_COMMAND;
+			delete process.env.CODEMEM_CODEX_COMMAND;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					codex_command: "codex --profile observer",
+					observer_model: "gpt-5.4-mini",
+				}),
+			);
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({ config: { observer_model: "gpt-5.4" } }),
+				});
+
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				const effects = body.effects as Record<string, unknown>;
+				expect(effects.effective_keys).toEqual(["observer_model"]);
+				expect(effects.restart_required_keys).toEqual(["observer_model"]);
+			} finally {
+				cleanup();
+				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previousConfig;
+				if (previousClaudeCommand == null) delete process.env.CODEMEM_CLAUDE_COMMAND;
+				else process.env.CODEMEM_CLAUDE_COMMAND = previousClaudeCommand;
+				if (previousCodexCommand == null) delete process.env.CODEMEM_CODEX_COMMAND;
+				else process.env.CODEMEM_CODEX_COMMAND = previousCodexCommand;
 			}
 		});
 

--- a/packages/viewer-server/src/routes/config.ts
+++ b/packages/viewer-server/src/routes/config.ts
@@ -7,6 +7,7 @@
 
 import {
 	CODEMEM_CONFIG_ENV_OVERRIDES,
+	coerceObserverCommand,
 	getCodememConfigPath,
 	getCodememEnvOverrides,
 	listObserverProviderOptions,
@@ -20,11 +21,12 @@ type ConfigData = Record<string, unknown>;
 
 const REDACTED_VALUE = "[redacted]";
 
-const RUNTIMES = new Set(["api_http", "claude_sidecar"]);
+const RUNTIMES = new Set(["api_http", "claude_sidecar", "codex_sidecar"]);
 const AUTH_SOURCES = new Set(["auto", "env", "file", "command", "none"]);
 const HOT_RELOAD_KEYS = new Set(["raw_events_sweeper_interval_s"]);
 const PROTECTED_WRITE_KEYS = new Set<string>([
 	"claude_command",
+	"codex_command",
 	"observer_base_url",
 	"observer_auth_file",
 	"observer_auth_command",
@@ -40,6 +42,7 @@ const SECRET_CONFIG_KEYS = new Set<string>([
 const REMOVED_CONFIG_KEYS = new Set<string>(["observer_rich_openai_use_responses"]);
 const ALLOWED_KEYS = [
 	"claude_command",
+	"codex_command",
 	"observer_base_url",
 	"observer_provider",
 	"observer_model",
@@ -78,6 +81,7 @@ const ALLOWED_KEYS = [
 
 const DEFAULTS: ConfigData = {
 	claude_command: ["claude"],
+	codex_command: ["codex"],
 	observer_runtime: "api_http",
 	observer_auth_source: "auto",
 	observer_tier_routing_enabled: false,
@@ -119,11 +123,19 @@ function withoutRemovedConfigKeys(configData: ConfigData): ConfigData {
 
 function getEffectiveConfig(configData: ConfigData): ConfigData {
 	const effective: ConfigData = { ...DEFAULTS, ...configData };
+	for (const key of ["claude_command", "codex_command"] as const) {
+		effective[key] = coerceObserverCommand(effective[key]) ?? DEFAULTS[key];
+	}
 	for (const [key, envVar] of Object.entries(CODEMEM_CONFIG_ENV_OVERRIDES) as Array<
 		[string, string]
 	>) {
 		const val = process.env[envVar];
-		if (val != null && val !== "") effective[key] = val;
+		if (val == null || val === "") continue;
+		if (key === "claude_command" || key === "codex_command") {
+			effective[key] = coerceObserverCommand(val) ?? effective[key];
+		} else {
+			effective[key] = val;
+		}
 	}
 	return effective;
 }
@@ -254,7 +266,7 @@ function validateAndApplyUpdate(
 		if (typeof value !== "string") return "observer_runtime must be string";
 		const runtime = value.trim().toLowerCase();
 		if (!RUNTIMES.has(runtime)) {
-			return "observer_runtime must be one of: api_http, claude_sidecar";
+			return "observer_runtime must be one of: api_http, claude_sidecar, codex_sidecar";
 		}
 		configData[key] = runtime;
 		return null;
@@ -268,7 +280,7 @@ function validateAndApplyUpdate(
 		configData[key] = source;
 		return null;
 	}
-	if (key === "claude_command" || key === "observer_auth_command") {
+	if (key === "claude_command" || key === "codex_command" || key === "observer_auth_command") {
 		const argv = asExecutableArgv(value);
 		if (argv == null) return `${key} must be string array`;
 		if (argv.length > 0) configData[key] = argv;
@@ -421,7 +433,7 @@ export function configRoutes(opts: ConfigRouteOptions = {}) {
 		const afterEffective = getEffectiveConfig(nextConfig);
 		const savedChangedKeys = ALLOWED_KEYS.filter((key) => beforeConfig[key] !== nextConfig[key]);
 		const effectiveChangedKeys = ALLOWED_KEYS.filter(
-			(key) => beforeEffective[key] !== afterEffective[key],
+			(key) => !configValuesEqual(beforeEffective[key], afterEffective[key]),
 		);
 		const envOverrides = getCodememEnvOverrides();
 		const ignoredByEnvKeys = savedChangedKeys.filter(


### PR DESCRIPTION
## Summary

- expose the supported `codex_sidecar` observer runtime as **Local Codex session** in Settings
- allow the viewer config API to save that runtime and expose the protected `codex_command` value read-only
- add Codex-specific model, authentication, and status guidance without changing production defaults
- document the observer-evaluation and sidecar-settings architecture used by the follow-up stack

## Testing

- `pnpm run tsc`
- `pnpm run lint`
- focused viewer route and Settings Vitest coverage
- full workspace suite validated from the top of the stack: 2,592 passed, 3 todo