### PR TITLE
fix(eval): make observer benchmark scoring auditable

### DIFF
--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -7,6 +7,7 @@ import * as embeddings from "../../../core/src/embeddings.js";
 import {
 	forgetMemoryCommand,
 	memoryCommand,
+	reconcileExtractionBenchmarkStatus,
 	rememberMemoryCommand,
 	showMemoryCommand,
 } from "./memory.js";
@@ -186,6 +187,88 @@ describe("memory command aliases", () => {
 });
 
 describe("memory command error boundaries", () => {
+	it("preserves a repaired benchmark pass when the initial disposition failed", () => {
+		const initialQuality = {
+			summaryDisposition: { expected: "required", actual: "none", score: 0 },
+		};
+		const finalQuality = {
+			summaryDisposition: { expected: "required", actual: "summary", score: 1 },
+		};
+		const result = reconcileExtractionBenchmarkStatus({
+			purpose: "shape_quality",
+			classification: { status: "pass", reason: "repaired output satisfies rubric" },
+			finalFailureReasons: [],
+			initialQuality,
+			finalQuality,
+		});
+
+		expect(result).toEqual({
+			status: "pass",
+			reason: "repaired output satisfies rubric",
+			quality: finalQuality,
+			initialQuality,
+		});
+	});
+
+	it("preserves observer_no_output before summary disposition scoring", () => {
+		const quality = {
+			summaryDisposition: { expected: "required", actual: "none", score: 0 },
+		};
+		const result = reconcileExtractionBenchmarkStatus({
+			purpose: "shape_quality",
+			classification: { status: "observer_no_output", reason: "observer returned no output" },
+			finalFailureReasons: ["observer returned no output"],
+			initialQuality: quality,
+			finalQuality: quality,
+		});
+
+		expect(result).toEqual({
+			status: "observer_no_output",
+			reason: "observer returned no output",
+			quality,
+			initialQuality: quality,
+		});
+	});
+
+	it("does not accept a repaired skip with non-summary final failures", () => {
+		const quality = {
+			summaryDisposition: { expected: "skip", actual: "skip", score: 1 },
+		};
+		const result = reconcileExtractionBenchmarkStatus({
+			purpose: "shape_quality",
+			classification: { status: "shape_fail", reason: "observation count outside range" },
+			finalFailureReasons: [
+				"summary count 0 outside expected range 1-1",
+				"observation count 1 outside expected range 0-0",
+			],
+			initialQuality: quality,
+			finalQuality: quality,
+		});
+
+		expect(result).toEqual({
+			status: "shape_fail",
+			reason: "observation count outside range",
+			quality,
+			initialQuality: quality,
+		});
+	});
+
+	it("accepts a valid skip when the final failure is only summary count", () => {
+		const quality = {
+			summaryDisposition: { expected: "skip", actual: "skip", score: 1 },
+		};
+		const result = reconcileExtractionBenchmarkStatus({
+			purpose: "shape_quality",
+			classification: { status: "shape_fail", reason: "summary count outside range" },
+			finalFailureReasons: ["summary count 0 outside expected range 1-1"],
+			initialQuality: quality,
+			finalQuality: quality,
+		});
+
+		expect(result.status).toBe("pass");
+		expect(result.reason).toBe("valid low-signal skip satisfies benchmark disposition");
+	});
+
 	it("does not throw and emits a JSON error for an invalid extraction-replay batch id", async () => {
 		const extractionReplay = memoryCommand.commands.find(
 			(command) => command.name() === "extraction-replay",

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -924,6 +924,49 @@ function createMemoryExtractionReplayCommand(): Command {
 	return cmd;
 }
 
+interface BenchmarkDispositionQuality {
+	summaryDisposition: {
+		expected: string;
+		actual: string;
+		score: number | null;
+	};
+}
+
+export function reconcileExtractionBenchmarkStatus<T extends BenchmarkDispositionQuality>(input: {
+	purpose: "shape_quality" | "replay_robustness";
+	classification: {
+		status: "pass" | "shape_fail" | "observer_no_output";
+		reason: string;
+	};
+	finalFailureReasons: string[];
+	initialQuality: T | null;
+	finalQuality: T | null;
+}): {
+	status: "pass" | "shape_fail" | "observer_no_output";
+	reason: string;
+	quality: T | null;
+	initialQuality: T | null;
+} {
+	const quality = input.finalQuality;
+	let status = input.classification.status;
+	let reason = input.classification.reason;
+	if (input.purpose === "shape_quality" && quality && status !== "observer_no_output") {
+		if (quality.summaryDisposition.score === 0) {
+			status = "shape_fail";
+			reason = `summary disposition ${quality.summaryDisposition.actual} does not satisfy expected ${quality.summaryDisposition.expected}`;
+		} else if (
+			status === "shape_fail" &&
+			quality.summaryDisposition.actual === "skip" &&
+			input.finalFailureReasons.length > 0 &&
+			input.finalFailureReasons.every((failure) => failure.startsWith("summary count "))
+		) {
+			status = "pass";
+			reason = "valid low-signal skip satisfies benchmark disposition";
+		}
+	}
+	return { status, reason, quality, initialQuality: input.initialQuality };
+}
+
 function createMemoryExtractionBenchmarkCommand(): Command {
 	const cmd = new Command("extraction-benchmark")
 		.configureHelp(helpStyle)
@@ -1026,6 +1069,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					complexity: string;
 					scenarioId: string;
 					expectedTier: string | null;
+					expectedSummaryDisposition: "required" | "optional" | "skip";
 					analysis: {
 						eventSpan: number;
 						promptCount: number;
@@ -1037,6 +1081,11 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					tier: string;
 					provider: string;
 					model: string;
+					transport: string;
+					requestedModel: string;
+					resolvedModel: string | null;
+					modelFallbackApplied: boolean;
+					modelFallbackReason: string | null;
 					openaiUseResponses: boolean;
 					reasoningEffort: string | null;
 					reasoningSummary: string | null;
@@ -1046,6 +1095,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					observations: number;
 					repairApplied: boolean;
 					initial: {
+						raw: string | null;
 						status: "pass" | "shape_fail" | "observer_no_output";
 						reason: string;
 						pass: boolean;
@@ -1055,9 +1105,11 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						diagnostics: ExtractionStructuralDiagnostics | null;
 						elapsedMs: number | null;
 						usage: ObserverTokenUsage | null;
+						quality: ExtractionBenchmarkScore | null;
 					};
 					repair: {
 						applied: boolean;
+						raw: string | null;
 						status: "pass" | "shape_fail" | "observer_no_output" | null;
 						reason: string | null;
 						pass: boolean | null;
@@ -1067,6 +1119,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						diagnostics: ExtractionStructuralDiagnostics | null;
 						elapsedMs: number | null;
 						usage: ObserverTokenUsage | null;
+						quality: ExtractionBenchmarkScore | null;
 					};
 					telemetry: {
 						totalElapsedMs: number | null;
@@ -1077,7 +1130,11 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						initial: ExtractionModelCostEstimate | null;
 						repair: ExtractionModelCostEstimate | null;
 						total: ExtractionModelCostEstimate | null;
-						unavailableReason: "missing_usage" | "unknown_model_pricing" | null;
+						unavailableReason:
+							| "missing_usage"
+							| "unknown_model_pricing"
+							| "model_fallback_unresolved"
+							| null;
 					};
 					quality: ExtractionBenchmarkScore | null;
 				}>;
@@ -1099,25 +1156,27 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 									scenarioId,
 									transcriptBudget: transcriptBudget ?? undefined,
 								});
-					const initialCost = estimateExtractionModelCost(
-						result.observer.model,
-						result.observer.initialUsage,
-					);
-					const repairCost = estimateExtractionModelCost(
-						result.observer.model,
-						result.observer.repairedUsage,
-					);
-					const totalCost = estimateExtractionModelCost(
-						result.observer.model,
-						result.observer.totalUsage,
-					);
-					const pricing = getExtractionModelPricing(result.observer.model);
+					const costModel = result.observer.modelFallbackApplied
+						? result.observer.resolvedModel
+						: (result.observer.resolvedModel ?? result.observer.model);
+					const initialCost = costModel
+						? estimateExtractionModelCost(costModel, result.observer.initialUsage)
+						: null;
+					const repairCost = costModel
+						? estimateExtractionModelCost(costModel, result.observer.repairedUsage)
+						: null;
+					const totalCost = costModel
+						? estimateExtractionModelCost(costModel, result.observer.totalUsage)
+						: null;
+					const pricing = costModel ? getExtractionModelPricing(costModel) : null;
 					const costUnavailableReason = totalCost
 						? null
-						: result.observer.totalUsage == null
-							? "missing_usage"
-							: "unknown_model_pricing";
-					const quality = result.observer.initialDiagnostics
+						: result.observer.modelFallbackApplied && !result.observer.resolvedModel
+							? "model_fallback_unresolved"
+							: result.observer.totalUsage == null
+								? "missing_usage"
+								: "unknown_model_pricing";
+					const initialQuality = result.observer.initialDiagnostics
 						? scoreExtractionBenchmarkOutput({
 								parsed: result.observer.initialParsed,
 								diagnostics: result.observer.initialDiagnostics,
@@ -1126,8 +1185,41 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 									reviewerNotes: "No durable-fact review has been recorded for this batch.",
 								},
 								estimatedCostUsd: initialCost?.totalCostUsd ?? null,
+								expectedSummaryDisposition: batch.expectedSummaryDisposition,
 							})
 						: null;
+					const repairQuality =
+						result.observer.repairedParsed && result.observer.repairedDiagnostics
+							? scoreExtractionBenchmarkOutput({
+									parsed: result.observer.repairedParsed,
+									diagnostics: result.observer.repairedDiagnostics,
+									review: batch.review ?? {
+										status: "unreviewed",
+										reviewerNotes: "No durable-fact review has been recorded for this batch.",
+									},
+									estimatedCostUsd: repairCost?.totalCostUsd ?? null,
+									expectedSummaryDisposition: batch.expectedSummaryDisposition,
+								})
+							: null;
+					const finalQuality = result.observer.diagnostics
+						? scoreExtractionBenchmarkOutput({
+								parsed: result.observer.parsed,
+								diagnostics: result.observer.diagnostics,
+								review: batch.review ?? {
+									status: "unreviewed",
+									reviewerNotes: "No durable-fact review has been recorded for this batch.",
+								},
+								estimatedCostUsd: totalCost?.totalCostUsd ?? null,
+								expectedSummaryDisposition: batch.expectedSummaryDisposition,
+							})
+						: null;
+					const reconciled = reconcileExtractionBenchmarkStatus({
+						purpose: batch.purpose,
+						classification: result.classification,
+						finalFailureReasons: result.evaluation.failureReasons,
+						initialQuality,
+						finalQuality,
+					});
 					runs.push({
 						batchId: batch.batchId,
 						sessionId: batch.sessionId,
@@ -1136,17 +1228,23 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						complexity: batch.complexity,
 						scenarioId,
 						expectedTier: batch.expectedTier ?? null,
+						expectedSummaryDisposition: batch.expectedSummaryDisposition,
 						analysis: {
 							eventSpan: result.analysis.eventSpan,
 							promptCount: result.analysis.promptCount,
 							toolCount: result.analysis.toolCount,
 							transcriptLength: result.analysis.transcriptLength,
 						},
-						status: result.classification.status,
-						reason: result.classification.reason,
+						status: reconciled.status,
+						reason: reconciled.reason,
 						tier: result.observer.tier ?? "manual",
 						provider: result.observer.provider,
 						model: result.observer.model,
+						transport: result.observer.transport,
+						requestedModel: result.observer.requestedModel,
+						resolvedModel: result.observer.resolvedModel,
+						modelFallbackApplied: result.observer.modelFallbackApplied,
+						modelFallbackReason: result.observer.modelFallbackReason,
 						openaiUseResponses: result.observer.openaiUseResponses,
 						reasoningEffort: result.observer.reasoningEffort,
 						reasoningSummary: result.observer.reasoningSummary,
@@ -1156,6 +1254,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						observations: result.evaluation.counts.observations,
 						repairApplied: result.observer.repairApplied,
 						initial: {
+							raw: result.observer.initialRaw,
 							status: result.initialClassification.status,
 							reason: result.initialClassification.reason,
 							pass: result.initialEvaluation.pass,
@@ -1165,9 +1264,11 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 							diagnostics: result.observer.initialDiagnostics,
 							elapsedMs: result.observer.initialElapsedMs,
 							usage: result.observer.initialUsage,
+							quality: reconciled.initialQuality,
 						},
 						repair: {
 							applied: result.observer.repairApplied,
+							raw: result.observer.repairedRaw,
 							status: result.repairedClassification?.status ?? null,
 							reason: result.repairedClassification?.reason ?? null,
 							pass: result.repairedEvaluation?.pass ?? null,
@@ -1177,6 +1278,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 							diagnostics: result.observer.repairedDiagnostics,
 							elapsedMs: result.observer.repairedElapsedMs,
 							usage: result.observer.repairedUsage,
+							quality: repairQuality,
 						},
 						telemetry: {
 							totalElapsedMs: result.observer.totalElapsedMs,
@@ -1189,7 +1291,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 							total: totalCost,
 							unavailableReason: costUnavailableReason,
 						},
-						quality,
+						quality: reconciled.quality,
 					});
 				}
 				const reviewedQualityRuns = runs.filter((run) => run.quality?.weightedQualityScore != null);
@@ -1209,6 +1311,10 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						(run) => run.expectedTier != null && run.expectedTier === run.tier,
 					).length,
 					robustnessNoOutput: runs.filter((run) => run.status === "observer_no_output").length,
+					summaryDispositionTotal: runs.filter((run) => run.quality != null).length,
+					summaryDispositionMatches: runs.filter(
+						(run) => run.quality?.summaryDisposition.score === 1,
+					).length,
 					reviewedQualityRuns: reviewedQualityRuns.length,
 					knownCostRuns: knownCostRuns.length,
 					unknownCostRuns: runs.length - knownCostRuns.length,
@@ -1216,6 +1322,9 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						.length,
 					unknownPricingRuns: runs.filter(
 						(run) => run.cost.unavailableReason === "unknown_model_pricing",
+					).length,
+					fallbackUnresolvedRuns: runs.filter(
+						(run) => run.cost.unavailableReason === "model_fallback_unresolved",
 					).length,
 					totalKnownCostUsd: knownCostRuns.reduce(
 						(sum, run) => sum + (run.cost.total?.totalCostUsd ?? 0),
@@ -1228,12 +1337,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					),
 				};
 				const uniqueObserverKeys = Array.from(
-					new Set(
-						runs.map(
-							(run) =>
-								`${run.provider}::${run.model}::${run.openaiUseResponses ? "responses" : "chat"}`,
-						),
-					),
+					new Set(runs.map((run) => `${run.provider}::${run.model}::${run.transport}`)),
 				);
 				const observerSummary =
 					opts.observerTierRouting === true
@@ -1244,6 +1348,8 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 										: "mixed",
 								model:
 									uniqueObserverKeys.length === 1 ? (runs[0]?.model ?? observer.model) : "mixed",
+								transport:
+									uniqueObserverKeys.length === 1 ? (runs[0]?.transport ?? "unknown") : "mixed",
 								tierRouting: true,
 								openaiUseResponses:
 									uniqueObserverKeys.length === 1
@@ -1271,6 +1377,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						: {
 								provider: observer.provider,
 								model: observer.model,
+								transport: runs[0]?.transport ?? observer.getStatus().runtime,
 								tierRouting: false,
 								openaiUseResponses: observer.openaiUseResponses,
 								reasoningEffort: observer.reasoningEffort,
@@ -1302,6 +1409,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					[
 						`Benchmark: ${benchmark.id} — ${benchmark.title}`,
 						`Observer: ${observerSummary.provider}/${observerSummary.model}`,
+						`Transport: ${observerSummary.transport}`,
 						`Tier routing: ${opts.observerTierRouting === true ? "yes" : "no"}`,
 						`OpenAI Responses: ${observerSummary.openaiUseResponses === null ? "mixed" : observerSummary.openaiUseResponses ? "yes" : "no"}`,
 						`Reasoning effort: ${observerSummary.reasoningEffort ?? "none"}`,
@@ -1313,8 +1421,9 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						`Shape-quality fails: ${summary.shapeQualityFails}`,
 						`Expected-tier matches: ${summary.expectedTierMatches}/${summary.expectedTierTotal}`,
 						`Observer no-output cases: ${summary.robustnessNoOutput}`,
+						`Summary disposition matches: ${summary.summaryDispositionMatches}/${summary.summaryDispositionTotal}`,
 						`Reviewed quality runs: ${summary.reviewedQualityRuns} (compare per-run dimensions; scores are fixture-specific)`,
-						`Known estimated cost: $${summary.totalKnownCostUsd.toFixed(6)} (${summary.knownCostRuns}/${summary.total}; missing usage=${summary.missingUsageRuns}, unknown pricing=${summary.unknownPricingRuns})`,
+						`Known estimated cost: $${summary.totalKnownCostUsd.toFixed(6)} (${summary.knownCostRuns}/${summary.total}; missing usage=${summary.missingUsageRuns}, unknown pricing=${summary.unknownPricingRuns}, unresolved fallback=${summary.fallbackUnresolvedRuns})`,
 						`Known elapsed time: ${summary.totalKnownElapsedMs}ms (${summary.knownElapsedRuns}/${summary.total} run(s))`,
 					].join("\n"),
 				);
@@ -1329,7 +1438,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						run.telemetry.totalElapsedMs == null ? "n/a" : `${run.telemetry.totalElapsedMs}ms`;
 					const missingRequired = run.quality?.requiredRecall.missingLabelIds.join(",") || "none";
 					p.log.message(
-						`  [${run.batchId}] ${run.status.padEnd(18)} ${run.complexity.padEnd(10)} tier=${run.tier.padEnd(6)} expected=${(run.expectedTier ?? "n/a").padEnd(6)} span=${String(run.analysis.eventSpan).padEnd(3)} prompts=${run.analysis.promptCount} tools=${String(run.analysis.toolCount).padEnd(2)} transcript=${run.analysis.transcriptLength} ${run.provider}/${run.model}${run.openaiUseResponses ? " [responses]" : ""} initial=${run.initial.summaries}s/${run.initial.observations}o final=${run.summaries}s/${run.observations}o quality=${qualityLabel} required_missing=${missingRequired} cost=${costLabel} latency=${latencyLabel} schema_loss=${run.initial.diagnostics?.dataLoss === true ? "yes" : "no"} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
+						`  [${run.batchId}] ${run.status.padEnd(18)} ${run.complexity.padEnd(10)} tier=${run.tier.padEnd(6)} expected=${(run.expectedTier ?? "n/a").padEnd(6)} disposition=${run.quality?.summaryDisposition.actual ?? "n/a"}/${run.expectedSummaryDisposition} span=${String(run.analysis.eventSpan).padEnd(3)} prompts=${run.analysis.promptCount} tools=${String(run.analysis.toolCount).padEnd(2)} transcript=${run.analysis.transcriptLength} ${run.provider}/${run.model} [${run.transport}] initial=${run.initial.summaries}s/${run.initial.observations}o final=${run.summaries}s/${run.observations}o quality=${qualityLabel} coverage=${run.quality?.weightedQualityCoverage?.toFixed(3) ?? "n/a"} required_missing=${missingRequired} cost=${costLabel} latency=${latencyLabel} schema_loss=${run.initial.diagnostics?.dataLoss === true ? "yes" : "no"} fallback=${run.modelFallbackApplied ? "yes" : "no"} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
 					);
 				}
 				p.outro("done");

--- a/packages/core/src/extraction-benchmark-scoring.test.ts
+++ b/packages/core/src/extraction-benchmark-scoring.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	calculateCostAdjustedScore,
+	calculateWeightedQualityCoverage,
 	calculateWeightedQualityScore,
 	scoreExtractionBenchmarkOutput,
 } from "./extraction-benchmark-scoring.js";
@@ -119,13 +120,13 @@ describe("extraction benchmark scoring", () => {
 
 	it("scores the two reviewed 18432 lessons as distinct required facts", () => {
 		const learned =
-			"The repair pass keeps pre-repair output transparent. Relinking reduces unmapped sessions but does not solve summary dominance.";
+			"Transparent startup relinking runs during viewer preparation. Relinking reduces unmapped sessions but does not solve summary dominance.";
 		const result = scoreExtractionBenchmarkOutput({
 			parsed: parsed(
 				[
 					observation(
-						"Repair output stays transparent",
-						"The repair pass is reported separately from the initial output.",
+						"Relink repair runs transparently",
+						"Internal relinking runs at startup during PrepareViewerDatabase.",
 					),
 					observation(
 						"Relinking has a bounded benefit",
@@ -140,7 +141,7 @@ describe("extraction benchmark scoring", () => {
 
 		expect(result.requiredRecall.score).toBe(1);
 		expect(result.requiredRecall.matchedLabelIds).toEqual([
-			"transparent-repair-implementation",
+			"transparent-relink-startup",
 			"relinking-does-not-fix-recap-dominance",
 		]);
 		expect(result.summaryBreadth.score).toBe(1);
@@ -174,6 +175,7 @@ describe("extraction benchmark scoring", () => {
 					disposition: "required",
 					keywordGroups: [["durable"], ["contract"]],
 					reviewerNotes: "Required fixture label.",
+					sourceEvidence: "Synthetic test evidence for the durable contract.",
 				},
 				{
 					id: "optional-context",
@@ -181,6 +183,7 @@ describe("extraction benchmark scoring", () => {
 					disposition: "optional",
 					keywordGroups: [["extra"], ["context"]],
 					reviewerNotes: "Optional fixture label.",
+					sourceEvidence: "Synthetic test evidence for the optional context.",
 				},
 			],
 		};
@@ -225,6 +228,7 @@ describe("extraction benchmark scoring", () => {
 
 	it("excludes null and human-only dimensions from weighted quality", () => {
 		const score = calculateWeightedQualityScore({
+			summaryDisposition: null,
 			requiredRecall: 1,
 			optionalRecall: null,
 			worthinessPrecision: null,
@@ -236,6 +240,65 @@ describe("extraction benchmark scoring", () => {
 		});
 
 		expect(score).toBeCloseTo(0.45 / (0.45 + 0.1));
+	});
+
+	it("reports how much of the weighted rubric was actually scored", () => {
+		const coverage = calculateWeightedQualityCoverage({
+			summaryDisposition: 1,
+			requiredRecall: 1,
+			optionalRecall: null,
+			worthinessPrecision: null,
+			summaryBreadth: null,
+			redundancyAvoidance: null,
+			segmentation: null,
+			schemaCompliance: 1,
+			factualGrounding: null,
+		});
+
+		expect(coverage).toBeGreaterThan(0);
+		expect(coverage).toBeLessThan(1);
+	});
+
+	it("accepts a valid low-signal skip only when the batch disposition permits it", () => {
+		const skipped: ParsedOutput = {
+			observations: [],
+			summary: null,
+			skipSummaryReason: "low-signal",
+		};
+		const optional = scoreExtractionBenchmarkOutput({
+			parsed: skipped,
+			diagnostics: { ...CLEAN_DIAGNOSTICS, summaryBlocks: 0, retainedSummaries: 0 },
+			review: reviewedBatch(18503),
+			expectedSummaryDisposition: "optional",
+		});
+		const required = scoreExtractionBenchmarkOutput({
+			parsed: skipped,
+			diagnostics: { ...CLEAN_DIAGNOSTICS, summaryBlocks: 0, retainedSummaries: 0 },
+			review: reviewedBatch(18503),
+			expectedSummaryDisposition: "required",
+		});
+
+		expect(optional.summaryDisposition).toEqual(
+			expect.objectContaining({ actual: "skip", score: 1 }),
+		);
+		expect(required.summaryDisposition).toEqual(
+			expect.objectContaining({ actual: "skip", score: 0 }),
+		);
+	});
+
+	it("normalizes low-signal skip reasons like production ingestion", () => {
+		const score = scoreExtractionBenchmarkOutput({
+			parsed: {
+				observations: [],
+				summary: null,
+				skipSummaryReason: " Low-Signal ",
+			},
+			diagnostics: { ...CLEAN_DIAGNOSTICS, summaryBlocks: 0, retainedSummaries: 0 },
+			review: reviewedBatch(18503),
+			expectedSummaryDisposition: "skip",
+		});
+
+		expect(score.summaryDisposition).toEqual(expect.objectContaining({ actual: "skip", score: 1 }));
 	});
 
 	it("keeps cost-adjusted quality null until an actual cost is supplied", () => {
@@ -271,7 +334,7 @@ describe("extraction benchmark scoring", () => {
 		expect(result.requiredRecall.score).toBe(0);
 		expect(result.worthinessPrecision.score).toBeNull();
 		expect(result.observationSignals.redundancyAvoidance).toBeNull();
-		expect(result.weightedQualityScore).toBeLessThanOrEqual(0.25);
+		expect(result.weightedQualityScore).toBeLessThanOrEqual(0.3);
 	});
 
 	it("scores a reviewed no-output response as zero quality", () => {

--- a/packages/core/src/extraction-benchmark-scoring.ts
+++ b/packages/core/src/extraction-benchmark-scoring.ts
@@ -53,12 +53,20 @@ export interface ExtractionBenchmarkSchemaScore {
 	violations: string[];
 }
 
+export interface ExtractionBenchmarkSummaryDispositionScore {
+	expected: "required" | "optional" | "skip";
+	actual: "summary" | "skip" | "invalid_skip" | "none";
+	skipReason: string | null;
+	score: 0 | 1;
+}
+
 export interface ExtractionBenchmarkScore {
 	reviewStatus: ExtractionBenchmarkReview["status"];
 	matchingPolicy: {
 		mode: "all_keyword_groups_in_one_observation";
 		notes: string;
 	};
+	summaryDisposition: ExtractionBenchmarkSummaryDispositionScore;
 	requiredRecall: ExtractionBenchmarkRecallScore;
 	optionalRecall: ExtractionBenchmarkRecallScore;
 	forbidden: ExtractionBenchmarkForbiddenScore;
@@ -76,11 +84,13 @@ export interface ExtractionBenchmarkScore {
 		notes: string;
 	};
 	weightedQualityScore: number | null;
+	weightedQualityCoverage: number | null;
 	costAdjustedScore: number | null;
 	costAdjustedScoreUnit: "quality_points_per_cent";
 }
 
 export interface ExtractionBenchmarkQualityDimensions {
+	summaryDisposition: number | null;
 	requiredRecall: number | null;
 	optionalRecall: number | null;
 	worthinessPrecision: number | null;
@@ -92,6 +102,7 @@ export interface ExtractionBenchmarkQualityDimensions {
 }
 
 const QUALITY_WEIGHTS: Readonly<Record<keyof ExtractionBenchmarkQualityDimensions, number>> = {
+	summaryDisposition: 0.1,
 	requiredRecall: 0.45,
 	optionalRecall: 0.05,
 	worthinessPrecision: 0.15,
@@ -101,6 +112,11 @@ const QUALITY_WEIGHTS: Readonly<Record<keyof ExtractionBenchmarkQualityDimension
 	schemaCompliance: 0.1,
 	factualGrounding: 0,
 };
+
+const TOTAL_AUTOMATED_QUALITY_WEIGHT = Object.values(QUALITY_WEIGHTS).reduce(
+	(sum, weight) => sum + weight,
+	0,
+);
 
 const REDUNDANCY_THRESHOLD = 0.8;
 
@@ -276,6 +292,52 @@ function schemaScore(
 	return { compliant: violations.length === 0, score: violations.length === 0 ? 1 : 0, violations };
 }
 
+function summaryDispositionScore(
+	parsed: ParsedOutput,
+	expected: ExtractionBenchmarkSummaryDispositionScore["expected"],
+	recognizedOutput: boolean,
+): ExtractionBenchmarkSummaryDispositionScore {
+	if (!recognizedOutput) {
+		return {
+			expected,
+			actual: "none",
+			skipReason: parsed.skipSummaryReason,
+			score: 0,
+		};
+	}
+	const hasSummary = parsed.summary !== null && parsed.skipSummaryReason === null;
+	const normalizedSkipReason = parsed.skipSummaryReason?.trim().toLowerCase() ?? null;
+	const validSkip = parsed.summary === null && normalizedSkipReason === "low-signal";
+	const actual: ExtractionBenchmarkSummaryDispositionScore["actual"] = hasSummary
+		? "summary"
+		: validSkip
+			? "skip"
+			: parsed.skipSummaryReason
+				? "invalid_skip"
+				: "none";
+	const matches =
+		expected === "required"
+			? hasSummary
+			: expected === "skip"
+				? validSkip
+				: hasSummary || validSkip;
+	return {
+		expected,
+		actual,
+		skipReason: parsed.skipSummaryReason,
+		score: matches ? 1 : 0,
+	};
+}
+
+export function calculateWeightedQualityCoverage(
+	dimensions: ExtractionBenchmarkQualityDimensions,
+): number {
+	const scoredWeight = (Object.keys(QUALITY_WEIGHTS) as Array<keyof typeof QUALITY_WEIGHTS>)
+		.filter((key) => dimensions[key] !== null && QUALITY_WEIGHTS[key] > 0)
+		.reduce((sum, key) => sum + QUALITY_WEIGHTS[key], 0);
+	return TOTAL_AUTOMATED_QUALITY_WEIGHT === 0 ? 0 : scoredWeight / TOTAL_AUTOMATED_QUALITY_WEIGHT;
+}
+
 export function calculateWeightedQualityScore(
 	dimensions: ExtractionBenchmarkQualityDimensions,
 ): number {
@@ -309,9 +371,15 @@ export function scoreExtractionBenchmarkOutput(input: {
 	parsed: ParsedOutput;
 	diagnostics: ObserverResponseStructuralDiagnostics;
 	review: ExtractionBenchmarkReview;
+	expectedSummaryDisposition?: "required" | "optional" | "skip";
 	estimatedCostUsd?: number | null;
 }): ExtractionBenchmarkScore {
 	const observations = input.parsed.observations.map(observationText);
+	const summaryDisposition = summaryDispositionScore(
+		input.parsed,
+		input.expectedSummaryDisposition ?? "required",
+		input.diagnostics.recognizedOutput,
+	);
 	const requiredLabels = labelsFor(input.review, "required");
 	const optionalLabels = labelsFor(input.review, "optional");
 	const forbiddenLabels = labelsFor(input.review, "forbidden");
@@ -364,6 +432,21 @@ export function scoreExtractionBenchmarkOutput(input: {
 	const weightedQualityScore =
 		input.review.status === "reviewed"
 			? calculateWeightedQualityScore({
+					summaryDisposition: summaryDisposition.score,
+					requiredRecall: requiredRecall.score,
+					optionalRecall: optionalRecall.score,
+					worthinessPrecision: worthinessPrecision.score,
+					summaryBreadth: summaryBreadth.score,
+					redundancyAvoidance: signals.redundancyAvoidance,
+					segmentation: signals.segmentation,
+					schemaCompliance: schemaCompliance.score,
+					factualGrounding: null,
+				})
+			: null;
+	const weightedQualityCoverage =
+		input.review.status === "reviewed"
+			? calculateWeightedQualityCoverage({
+					summaryDisposition: summaryDisposition.score,
 					requiredRecall: requiredRecall.score,
 					optionalRecall: optionalRecall.score,
 					worthinessPrecision: worthinessPrecision.score,
@@ -381,6 +464,7 @@ export function scoreExtractionBenchmarkOutput(input: {
 			notes:
 				"Deterministic matching is intentionally recall-conservative; inspect matched and missing labels plus raw output before selecting a model.",
 		},
+		summaryDisposition,
 		requiredRecall,
 		optionalRecall,
 		forbidden,
@@ -395,6 +479,7 @@ export function scoreExtractionBenchmarkOutput(input: {
 				"Keyword matching measures repeatable label coverage, not whether claims are factually grounded in the source transcript.",
 		},
 		weightedQualityScore,
+		weightedQualityCoverage,
 		costAdjustedScore: calculateCostAdjustedScore(
 			weightedQualityScore,
 			input.estimatedCostUsd ?? null,

--- a/packages/core/src/extraction-benchmarks.test.ts
+++ b/packages/core/src/extraction-benchmarks.test.ts
@@ -73,7 +73,7 @@ describe("extraction benchmarks", () => {
 				status: "reviewed",
 				labels: expect.arrayContaining([
 					expect.objectContaining({
-						id: "transparent-repair-implementation",
+						id: "transparent-relink-startup",
 						disposition: "required",
 					}),
 					expect.objectContaining({
@@ -83,6 +83,18 @@ describe("extraction benchmarks", () => {
 				]),
 			}),
 		);
+	});
+
+	it("records summary disposition and source evidence for every reviewed label", () => {
+		for (const profile of listExtractionBenchmarkProfiles()) {
+			for (const batch of profile.batches) {
+				expect(["required", "optional", "skip"]).toContain(batch.expectedSummaryDisposition);
+				if (batch.review.status !== "reviewed") continue;
+				for (const label of batch.review.labels) {
+					expect(label.sourceEvidence.trim().length).toBeGreaterThan(0);
+				}
+			}
+		}
 	});
 
 	it("marks batches without known review as explicitly unreviewed", () => {

--- a/packages/core/src/extraction-benchmarks.ts
+++ b/packages/core/src/extraction-benchmarks.ts
@@ -6,6 +6,7 @@ export interface ExtractionBenchmarkBatch {
 	complexity: "simple" | "working" | "rich" | "robustness";
 	scenarioId?: string;
 	expectedTier?: "simple" | "rich";
+	expectedSummaryDisposition: "required" | "optional" | "skip";
 	notes: string;
 	/** Human-reviewed durable-fact labels; omitted profiles are treated as unreviewed. */
 	review?: ExtractionBenchmarkReview;
@@ -19,6 +20,7 @@ export interface ExtractionBenchmarkLabel {
 	disposition: ExtractionBenchmarkLabelDisposition;
 	keywordGroups: string[][];
 	reviewerNotes: string;
+	sourceEvidence: string;
 }
 
 export type ExtractionBenchmarkReview =
@@ -83,6 +85,8 @@ const REVIEWED_BATCHES: Readonly<Record<number, ExtractionBenchmarkReview>> = {
 				],
 				reviewerNotes:
 					"Capture the reusable regression lesson: the TypeScript path must retain stable-session reuse rather than creating a fresh session for each event or flush.",
+				sourceEvidence:
+					"Replay input names #607 / 10d324c5 as the stable-session reuse fix and links the missing behavior to fragmented micro-sessions.",
 			},
 			{
 				id: "graphite-branch-hygiene",
@@ -94,6 +98,8 @@ const REVIEWED_BATCHES: Readonly<Record<number, ExtractionBenchmarkReview>> = {
 				],
 				reviewerNotes:
 					"Branch cleanup and stack-management narration is routine workflow telemetry, not a durable project fact.",
+				sourceEvidence:
+					"Replay input contains Graphite branch cleanup narration, but no reusable product constraint or technical learning from that workflow.",
 			},
 		],
 	},
@@ -103,16 +109,18 @@ const REVIEWED_BATCHES: Readonly<Record<number, ExtractionBenchmarkReview>> = {
 			"Known review identified the transparent repair implementation and a separate limitation of relinking as required durable lessons.",
 		labels: [
 			{
-				id: "transparent-repair-implementation",
-				title: "Repair behavior must remain transparent",
+				id: "transparent-relink-startup",
+				title: "Raw-event relink repair runs transparently at startup",
 				disposition: "required",
 				keywordGroups: [
-					["repair", "repair pass", "repair call"],
-					["transparent", "reported separately", "visible separately"],
-					["initial output", "original output", "pre-repair output"],
+					["relink", "relinking"],
+					["transparent", "internal", "quietly"],
+					["startup", "prepareviewerdatabase", "viewer preparation"],
 				],
 				reviewerNotes:
-					"Capture the implementation contract that initial model output remains visible and repair is reported as a separate recovery step.",
+					"Capture the product behavior evidenced by this replay: safe raw-event relinking is wired into startup/viewer preparation rather than exposed as a user-operated repair step.",
+				sourceEvidence:
+					"The replay request asks for a transparent repair path, and tool/test output shows prepareViewerDatabase invoking the internal relink executor.",
 			},
 			{
 				id: "relinking-does-not-fix-recap-dominance",
@@ -125,6 +133,8 @@ const REVIEWED_BATCHES: Readonly<Record<number, ExtractionBenchmarkReview>> = {
 				],
 				reviewerNotes:
 					"Keep this distinct from transparent repair: relinking reduces the unmapped-session burden, but retrieval can still be dominated by recap/summary artifacts.",
+				sourceEvidence:
+					"Replay transcript explicitly reports that relinking reduces unmapped burden while recap dominance remains a separate ranking problem.",
 			},
 		],
 	},
@@ -193,6 +203,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "rich",
 				scenarioId: "rich-batch-shape",
 				expectedTier: "rich",
+				expectedSummaryDisposition: "required",
 				notes:
 					"Flagship hard case: historically under-extracted batch with multiple meaningful subthreads.",
 				review: benchmarkReview(18503),
@@ -205,6 +216,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "rich",
 				scenarioId: "rich-batch-shape",
 				expectedTier: "rich",
+				expectedSummaryDisposition: "required",
 				notes:
 					"Useful adjacent batch from the same long session; helps avoid overfitting to 18503 alone.",
 				review: benchmarkReview(18502),
@@ -217,6 +229,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "rich",
 				scenarioId: "rich-batch-shape",
 				expectedTier: "rich",
+				expectedSummaryDisposition: "required",
 				notes:
 					"Later large batch from the same session; currently passes on stronger models and validates generalization within the stream.",
 				review: benchmarkReview(18506),
@@ -229,6 +242,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "rich",
 				scenarioId: "rich-batch-shape",
 				expectedTier: "rich",
+				expectedSummaryDisposition: "required",
 				notes:
 					"High-volume snapshot batch used to compare budget and model sensitivity outside the Track 3 stream.",
 				review: benchmarkReview(18432),
@@ -241,6 +255,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "rich",
 				scenarioId: "rich-batch-shape",
 				expectedTier: "rich",
+				expectedSummaryDisposition: "optional",
 				notes:
 					"Useful stubborn case: some models return summary-only or nothing; stronger models plus repair can recover it.",
 				review: benchmarkReview(18446),
@@ -253,6 +268,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "robustness",
 				scenarioId: "rich-batch-shape",
 				expectedTier: "rich",
+				expectedSummaryDisposition: "optional",
 				notes:
 					"Stored extraction passes shape, but replay may return no raw output at all. Track separately as observer/replay robustness, not shape quality.",
 				review: benchmarkReview(18476),
@@ -303,6 +319,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "simple",
 				scenarioId: "simple-batch-shape",
 				expectedTier: "simple",
+				expectedSummaryDisposition: "optional",
 				notes: "Very small batch that should clearly remain on the cheap/simple tier.",
 				review: benchmarkReview(18530),
 			},
@@ -314,6 +331,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "simple",
 				scenarioId: "simple-batch-shape",
 				expectedTier: "simple",
+				expectedSummaryDisposition: "required",
 				notes: "Small batch with low tool count that should not trigger the rich tier.",
 				review: benchmarkReview(18490),
 			},
@@ -325,6 +343,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "simple",
 				scenarioId: "simple-batch-shape",
 				expectedTier: "simple",
+				expectedSummaryDisposition: "required",
 				notes: "Short-session compact batch chosen for genuinely low-complexity characteristics.",
 				review: benchmarkReview(18494),
 			},
@@ -336,6 +355,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "working",
 				scenarioId: "working-batch-shape",
 				expectedTier: "simple",
+				expectedSummaryDisposition: "required",
 				notes: "Moderate batch that should remain cheap unless thresholds are too aggressive.",
 				review: benchmarkReview(18524),
 			},
@@ -347,6 +367,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "working",
 				scenarioId: "working-batch-shape",
 				expectedTier: "simple",
+				expectedSummaryDisposition: "required",
 				notes: "Moderate batch with some prompt/tool activity but still below rich-batch scale.",
 				review: benchmarkReview(18525),
 			},
@@ -358,6 +379,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "working",
 				scenarioId: "working-batch-shape",
 				expectedTier: "simple",
+				expectedSummaryDisposition: "required",
 				notes:
 					"Cross-session moderate batch to verify the simple tier remains viable outside the main stream.",
 				review: benchmarkReview(18460),
@@ -370,6 +392,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "rich",
 				scenarioId: "rich-batch-shape",
 				expectedTier: "rich",
+				expectedSummaryDisposition: "required",
 				notes: "Flagship hard case that should still escalate to the rich tier.",
 				review: benchmarkReview(18503),
 			},
@@ -381,6 +404,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "rich",
 				scenarioId: "rich-batch-shape",
 				expectedTier: "rich",
+				expectedSummaryDisposition: "required",
 				notes: "High-volume snapshot batch that should continue escalating.",
 				review: benchmarkReview(18432),
 			},
@@ -392,6 +416,7 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				complexity: "robustness",
 				scenarioId: "rich-batch-shape",
 				expectedTier: "rich",
+				expectedSummaryDisposition: "optional",
 				notes:
 					"Known no-output replay robustness case retained to make sure routing does not hide robustness failures.",
 				review: benchmarkReview(18476),

--- a/packages/core/src/extraction-replay.test.ts
+++ b/packages/core/src/extraction-replay.test.ts
@@ -37,6 +37,8 @@ describe("extraction replay", () => {
 		}
 
 		const observer = {
+			model: "test-model",
+			requestedModel: "test-model-alias",
 			observe: async () => {
 				callCount += 1;
 				if (callCount === 1) {
@@ -90,8 +92,8 @@ describe("extraction replay", () => {
 			getStatus: () => ({
 				provider: "test",
 				model: "test-model",
-				runtime: "test",
-				auth: { source: "none", type: "none", hasToken: false },
+				runtime: "api_http",
+				auth: { source: "opencode", type: "codex_consumer", hasToken: true },
 			}),
 		} as unknown as ObserverClient;
 		let callCount = 0;
@@ -107,6 +109,10 @@ describe("extraction replay", () => {
 		expect(result.evaluation.counts.summaries).toBe(1);
 		expect(result.evaluation.counts.observations).toBe(2);
 		expect(result.observer.provider).toBe("test");
+		expect(result.observer.requestedModel).toBe("test-model-alias");
+		expect(result.observer.resolvedModel).toBe("test-model");
+		expect(result.observer.transport).toBe("codex_consumer");
+		expect(result.observer.modelFallbackApplied).toBe(false);
 		expect(result.observer.repairApplied).toBe(true);
 		expect(result.observer.initialRaw).toContain("not valid observer XML");
 		expect(result.observer.raw).toContain("<observation>");

--- a/packages/core/src/extraction-replay.ts
+++ b/packages/core/src/extraction-replay.ts
@@ -204,6 +204,11 @@ export interface ExtractionReplayResult {
 	observer: {
 		provider: string;
 		model: string;
+		transport: string;
+		requestedModel: string;
+		resolvedModel: string | null;
+		modelFallbackApplied: boolean;
+		modelFallbackReason: string | null;
 		tier: "simple" | "rich" | null;
 		tierReasons: string[];
 		openaiUseResponses: boolean;
@@ -599,7 +604,14 @@ async function replayPreparedBatch(
 	tier: "simple" | "rich" | null,
 	tierReasons: string[],
 ): Promise<ExtractionReplayResult> {
+	const configuredModel = observer.requestedModel ?? observer.model;
 	const response = await observeStructuredOutput(observer, prepared.system, prepared.user);
+	const requestedModel = configuredModel || response.initial.model;
+	const observerStatus = observer.getStatus();
+	const modelFallbackApplied = observerStatus.modelFallbackApplied === true;
+	const resolvedModel = modelFallbackApplied
+		? (observerStatus.actualModel ?? null)
+		: (observerStatus.actualModel ?? response.initial.model);
 	const session = {
 		id: prepared.batch.session_id,
 		project: prepared.batch.project,
@@ -657,6 +669,11 @@ async function replayPreparedBatch(
 		response.repaired?.usage ?? null,
 		repairApplied,
 	);
+	const transport =
+		observerStatus.auth.type === "codex_consumer" ||
+		observerStatus.auth.type === "anthropic_consumer"
+			? observerStatus.auth.type
+			: observerStatus.runtime;
 
 	return {
 		scenario: {
@@ -674,6 +691,11 @@ async function replayPreparedBatch(
 		observer: {
 			provider: finalResponse.provider,
 			model: finalResponse.model,
+			transport,
+			requestedModel,
+			resolvedModel,
+			modelFallbackApplied,
+			modelFallbackReason: observerStatus.modelFallbackReason ?? null,
 			tier,
 			tierReasons,
 			openaiUseResponses: observer.openaiUseResponses,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -243,9 +243,11 @@ export {
 export type {
 	ExtractionBenchmarkQualityDimensions,
 	ExtractionBenchmarkScore,
+	ExtractionBenchmarkSummaryDispositionScore,
 } from "./extraction-benchmark-scoring.js";
 export {
 	calculateCostAdjustedScore,
+	calculateWeightedQualityCoverage,
 	calculateWeightedQualityScore,
 	scoreExtractionBenchmarkOutput,
 } from "./extraction-benchmark-scoring.js";

--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -1190,6 +1190,8 @@ describe("ObserverClient.observe()", () => {
 				observerAuthTimeoutMs: 1500,
 				observerAuthCacheTtlS: 300,
 			});
+			expect(client.requestedModel).toBe("work/fast");
+			expect(client.model).toBe("gateway-fast");
 
 			const result = await client.observe("system", "user");
 

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -1234,6 +1234,7 @@ function nowMs(): number {
  */
 export class ObserverClient {
 	readonly provider: string;
+	readonly requestedModel: string | null;
 	model: string;
 	readonly runtime: string;
 	readonly temperature: number | null;
@@ -1299,6 +1300,7 @@ export class ObserverClient {
 
 		const provider = (cfg.observerProvider ?? "").toLowerCase();
 		const model = (cfg.observerModel ?? "").trim();
+		this.requestedModel = model || null;
 
 		// Collect known custom providers
 		const customProviders = listConfiguredOpenCodeProviders();


### PR DESCRIPTION
## Summary

- encode required/optional/skip summary disposition and score valid low-signal skips correctly
- repair the impossible batch 18432 label so ground truth is satisfiable from replay input
- preserve raw initial/repaired observer output plus structural diagnostics in benchmark JSON
- record transport, requested/resolved model, and fallback metadata; avoid pricing unresolved fallbacks
- report dimension coverage separately so missing quality dimensions are not silently reweighted

## Testing

- extraction benchmark scoring, profile, replay, and CLI tests
- `pnpm run tsc`
- `pnpm run lint`
- full workspace suite validated from the top of the stack: 2,592 passed, 3 todo