### PR TITLE
feat(eval): expand observer benchmark corpus

### DIFF
--- a/docs/plans/2026-07-10-observer-eval-and-codex-sidecar-settings-design.md
+++ b/docs/plans/2026-07-10-observer-eval-and-codex-sidecar-settings-design.md
@@ -81,7 +81,8 @@ Every shape case records an expected summary disposition:
 Each reviewed durable-fact label includes a human-readable claim, disposition,
 source-evidence notes, and conservative matching aliases. Labels must be
 satisfiable from the exact replay input. Tests enforce that reviewed labels have
-evidence notes and that impossible or empty reviews cannot enter the benchmark.
+evidence notes. Reviewed skip controls may intentionally have no positive labels;
+their ground truth is the expected `skip` disposition itself.
 
 ## Scoring
 
@@ -116,6 +117,10 @@ This makes every aggregate auditable.
 3. Select finalists per transport and tier.
 4. Run finalists three times on a balanced representative/challenge subset.
 5. Recommend defaults only from repeated results that clear all gates.
+
+The benchmark runner's `--repetitions <n>` option records an iteration on every
+run and reports per-batch pass rates/status sequences, so a three-run finalist
+screen is reproducible rather than assembled from unrelated one-off reports.
 
 Terra remains a rich API finalist because its latency advantage is material and
 its only observed shape miss passed on repetition. Luna remains a Codex-sidecar

--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -156,6 +156,7 @@ describe("memory command aliases", () => {
 		expect(longs).toContain("--max-output-tokens");
 		expect(longs).toContain("--observer-temperature");
 		expect(longs).toContain("--transcript-budget");
+		expect(longs).toContain("--repetitions");
 		expect(longs).toContain("--json");
 	});
 
@@ -315,6 +316,33 @@ describe("memory command error boundaries", () => {
 
 			const output = logSpy.mock.calls.at(-1)?.[0];
 			expect(JSON.parse(String(output))).toMatchObject({ error: expect.any(String) });
+			expect(process.exitCode).toBe(1);
+		} finally {
+			process.exitCode = originalExitCode;
+			logSpy.mockRestore();
+		}
+	});
+
+	it("rejects unsafe extraction-benchmark repetition counts before running a model", async () => {
+		const extractionBenchmark = memoryCommand.commands.find(
+			(command) => command.name() === "extraction-benchmark",
+		);
+		if (!extractionBenchmark) throw new Error("expected extraction-benchmark command");
+
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const originalExitCode = process.exitCode;
+		process.exitCode = undefined;
+		try {
+			await extractionBenchmark.parseAsync(
+				["--benchmark", "balanced-observer-quality-v1", "--repetitions", "11", "--json"],
+				{ from: "user" },
+			);
+
+			const output = logSpy.mock.calls.at(-1)?.[0];
+			expect(JSON.parse(String(output))).toMatchObject({
+				error: "extraction_benchmark_failed",
+				message: expect.stringContaining("Invalid repetitions"),
+			});
 			expect(process.exitCode).toBe(1);
 		} finally {
 			process.exitCode = originalExitCode;

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -997,6 +997,11 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 		.option(
 			"--transcript-budget <chars>",
 			"override replay transcript budget in characters for this benchmark run",
+		)
+		.option(
+			"--repetitions <n>",
+			"run every benchmark batch 1-10 times to measure model stability",
+			"1",
 		);
 	addDbOption(cmd);
 	addJsonOption(cmd);
@@ -1014,6 +1019,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					maxOutputTokens?: string;
 					observerTemperature?: string;
 					transcriptBudget?: string;
+					repetitions?: string;
 				},
 		) => {
 			try {
@@ -1049,6 +1055,11 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						`Invalid max output tokens: ${maxOutputTokensInput || opts.maxOutputTokens}`,
 					);
 				}
+				const repetitionsInput = opts.repetitions?.trim() ?? "1";
+				const repetitions = parseStrictPositiveId(repetitionsInput);
+				if (repetitions === null || repetitions > 10) {
+					throw new Error(`Invalid repetitions: ${repetitionsInput || opts.repetitions}`);
+				}
 				const observerConfig = loadObserverConfig();
 				const observerConfigWithOverrides = {
 					...observerConfig,
@@ -1062,6 +1073,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 				};
 				const observer = new ObserverClient(observerConfigWithOverrides);
 				const runs = [] as Array<{
+					iteration: number;
 					batchId: number;
 					sessionId: number;
 					label: string;
@@ -1138,166 +1150,170 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					};
 					quality: ExtractionBenchmarkScore | null;
 				}>;
-				for (const batch of benchmark.batches) {
-					const scenarioId = batch.scenarioId ?? benchmark.scenarioId;
-					const result =
-						opts.observerTierRouting === true
-							? await replayBatchExtractionWithTierRouting(
-									resolveDbOpt(opts),
-									observerConfigWithOverrides,
-									{
+				for (let iteration = 1; iteration <= repetitions; iteration += 1) {
+					for (const batch of benchmark.batches) {
+						const scenarioId = batch.scenarioId ?? benchmark.scenarioId;
+						const result =
+							opts.observerTierRouting === true
+								? await replayBatchExtractionWithTierRouting(
+										resolveDbOpt(opts),
+										observerConfigWithOverrides,
+										{
+											batchId: batch.batchId,
+											scenarioId,
+											transcriptBudget: transcriptBudget ?? undefined,
+										},
+									)
+								: await replayBatchExtraction(resolveDbOpt(opts), observer, {
 										batchId: batch.batchId,
 										scenarioId,
 										transcriptBudget: transcriptBudget ?? undefined,
-									},
-								)
-							: await replayBatchExtraction(resolveDbOpt(opts), observer, {
-									batchId: batch.batchId,
-									scenarioId,
-									transcriptBudget: transcriptBudget ?? undefined,
-								});
-					const costModel = result.observer.modelFallbackApplied
-						? result.observer.resolvedModel
-						: (result.observer.resolvedModel ?? result.observer.model);
-					const initialCost = costModel
-						? estimateExtractionModelCost(costModel, result.observer.initialUsage)
-						: null;
-					const repairCost = costModel
-						? estimateExtractionModelCost(costModel, result.observer.repairedUsage)
-						: null;
-					const totalCost = costModel
-						? estimateExtractionModelCost(costModel, result.observer.totalUsage)
-						: null;
-					const pricing = costModel ? getExtractionModelPricing(costModel) : null;
-					const costUnavailableReason = totalCost
-						? null
-						: result.observer.modelFallbackApplied && !result.observer.resolvedModel
-							? "model_fallback_unresolved"
-							: result.observer.totalUsage == null
-								? "missing_usage"
-								: "unknown_model_pricing";
-					const initialQuality = result.observer.initialDiagnostics
-						? scoreExtractionBenchmarkOutput({
-								parsed: result.observer.initialParsed,
-								diagnostics: result.observer.initialDiagnostics,
-								review: batch.review ?? {
-									status: "unreviewed",
-									reviewerNotes: "No durable-fact review has been recorded for this batch.",
-								},
-								estimatedCostUsd: initialCost?.totalCostUsd ?? null,
-								expectedSummaryDisposition: batch.expectedSummaryDisposition,
-							})
-						: null;
-					const repairQuality =
-						result.observer.repairedParsed && result.observer.repairedDiagnostics
+									});
+						const costModel = result.observer.modelFallbackApplied
+							? result.observer.resolvedModel
+							: (result.observer.resolvedModel ?? result.observer.model);
+						const initialCost = costModel
+							? estimateExtractionModelCost(costModel, result.observer.initialUsage)
+							: null;
+						const repairCost = costModel
+							? estimateExtractionModelCost(costModel, result.observer.repairedUsage)
+							: null;
+						const totalCost = costModel
+							? estimateExtractionModelCost(costModel, result.observer.totalUsage)
+							: null;
+						const pricing = costModel ? getExtractionModelPricing(costModel) : null;
+						const costUnavailableReason = totalCost
+							? null
+							: result.observer.modelFallbackApplied && !result.observer.resolvedModel
+								? "model_fallback_unresolved"
+								: result.observer.totalUsage == null
+									? "missing_usage"
+									: "unknown_model_pricing";
+						const initialQuality = result.observer.initialDiagnostics
 							? scoreExtractionBenchmarkOutput({
-									parsed: result.observer.repairedParsed,
-									diagnostics: result.observer.repairedDiagnostics,
+									parsed: result.observer.initialParsed,
+									diagnostics: result.observer.initialDiagnostics,
 									review: batch.review ?? {
 										status: "unreviewed",
 										reviewerNotes: "No durable-fact review has been recorded for this batch.",
 									},
-									estimatedCostUsd: repairCost?.totalCostUsd ?? null,
+									estimatedCostUsd: initialCost?.totalCostUsd ?? null,
 									expectedSummaryDisposition: batch.expectedSummaryDisposition,
 								})
 							: null;
-					const finalQuality = result.observer.diagnostics
-						? scoreExtractionBenchmarkOutput({
-								parsed: result.observer.parsed,
-								diagnostics: result.observer.diagnostics,
-								review: batch.review ?? {
-									status: "unreviewed",
-									reviewerNotes: "No durable-fact review has been recorded for this batch.",
-								},
-								estimatedCostUsd: totalCost?.totalCostUsd ?? null,
-								expectedSummaryDisposition: batch.expectedSummaryDisposition,
-							})
-						: null;
-					const reconciled = reconcileExtractionBenchmarkStatus({
-						purpose: batch.purpose,
-						classification: result.classification,
-						finalFailureReasons: result.evaluation.failureReasons,
-						initialQuality,
-						finalQuality,
-					});
-					runs.push({
-						batchId: batch.batchId,
-						sessionId: batch.sessionId,
-						label: batch.label,
-						purpose: batch.purpose,
-						complexity: batch.complexity,
-						scenarioId,
-						expectedTier: batch.expectedTier ?? null,
-						expectedSummaryDisposition: batch.expectedSummaryDisposition,
-						analysis: {
-							eventSpan: result.analysis.eventSpan,
-							promptCount: result.analysis.promptCount,
-							toolCount: result.analysis.toolCount,
-							transcriptLength: result.analysis.transcriptLength,
-						},
-						status: reconciled.status,
-						reason: reconciled.reason,
-						tier: result.observer.tier ?? "manual",
-						provider: result.observer.provider,
-						model: result.observer.model,
-						transport: result.observer.transport,
-						requestedModel: result.observer.requestedModel,
-						resolvedModel: result.observer.resolvedModel,
-						modelFallbackApplied: result.observer.modelFallbackApplied,
-						modelFallbackReason: result.observer.modelFallbackReason,
-						openaiUseResponses: result.observer.openaiUseResponses,
-						reasoningEffort: result.observer.reasoningEffort,
-						reasoningSummary: result.observer.reasoningSummary,
-						maxOutputTokens: result.observer.maxOutputTokens,
-						temperature: result.observer.temperature,
-						summaries: result.evaluation.counts.summaries,
-						observations: result.evaluation.counts.observations,
-						repairApplied: result.observer.repairApplied,
-						initial: {
-							raw: result.observer.initialRaw,
-							status: result.initialClassification.status,
-							reason: result.initialClassification.reason,
-							pass: result.initialEvaluation.pass,
-							failureReasons: result.initialEvaluation.failureReasons,
-							summaries: result.initialEvaluation.counts.summaries,
-							observations: result.initialEvaluation.counts.observations,
-							diagnostics: result.observer.initialDiagnostics,
-							elapsedMs: result.observer.initialElapsedMs,
-							usage: result.observer.initialUsage,
-							quality: reconciled.initialQuality,
-						},
-						repair: {
-							applied: result.observer.repairApplied,
-							raw: result.observer.repairedRaw,
-							status: result.repairedClassification?.status ?? null,
-							reason: result.repairedClassification?.reason ?? null,
-							pass: result.repairedEvaluation?.pass ?? null,
-							failureReasons: result.repairedEvaluation?.failureReasons ?? [],
-							summaries: result.repairedEvaluation?.counts.summaries ?? null,
-							observations: result.repairedEvaluation?.counts.observations ?? null,
-							diagnostics: result.observer.repairedDiagnostics,
-							elapsedMs: result.observer.repairedElapsedMs,
-							usage: result.observer.repairedUsage,
-							quality: repairQuality,
-						},
-						telemetry: {
-							totalElapsedMs: result.observer.totalElapsedMs,
-							totalUsage: result.observer.totalUsage,
-						},
-						pricing,
-						cost: {
-							initial: initialCost,
-							repair: repairCost,
-							total: totalCost,
-							unavailableReason: costUnavailableReason,
-						},
-						quality: reconciled.quality,
-					});
+						const repairQuality =
+							result.observer.repairedParsed && result.observer.repairedDiagnostics
+								? scoreExtractionBenchmarkOutput({
+										parsed: result.observer.repairedParsed,
+										diagnostics: result.observer.repairedDiagnostics,
+										review: batch.review ?? {
+											status: "unreviewed",
+											reviewerNotes: "No durable-fact review has been recorded for this batch.",
+										},
+										estimatedCostUsd: repairCost?.totalCostUsd ?? null,
+										expectedSummaryDisposition: batch.expectedSummaryDisposition,
+									})
+								: null;
+						const finalQuality = result.observer.diagnostics
+							? scoreExtractionBenchmarkOutput({
+									parsed: result.observer.parsed,
+									diagnostics: result.observer.diagnostics,
+									review: batch.review ?? {
+										status: "unreviewed",
+										reviewerNotes: "No durable-fact review has been recorded for this batch.",
+									},
+									estimatedCostUsd: totalCost?.totalCostUsd ?? null,
+									expectedSummaryDisposition: batch.expectedSummaryDisposition,
+								})
+							: null;
+						const reconciled = reconcileExtractionBenchmarkStatus({
+							purpose: batch.purpose,
+							classification: result.classification,
+							finalFailureReasons: result.evaluation.failureReasons,
+							initialQuality,
+							finalQuality,
+						});
+						runs.push({
+							iteration,
+							batchId: batch.batchId,
+							sessionId: batch.sessionId,
+							label: batch.label,
+							purpose: batch.purpose,
+							complexity: batch.complexity,
+							scenarioId,
+							expectedTier: batch.expectedTier ?? null,
+							expectedSummaryDisposition: batch.expectedSummaryDisposition,
+							analysis: {
+								eventSpan: result.analysis.eventSpan,
+								promptCount: result.analysis.promptCount,
+								toolCount: result.analysis.toolCount,
+								transcriptLength: result.analysis.transcriptLength,
+							},
+							status: reconciled.status,
+							reason: reconciled.reason,
+							tier: result.observer.tier ?? "manual",
+							provider: result.observer.provider,
+							model: result.observer.model,
+							transport: result.observer.transport,
+							requestedModel: result.observer.requestedModel,
+							resolvedModel: result.observer.resolvedModel,
+							modelFallbackApplied: result.observer.modelFallbackApplied,
+							modelFallbackReason: result.observer.modelFallbackReason,
+							openaiUseResponses: result.observer.openaiUseResponses,
+							reasoningEffort: result.observer.reasoningEffort,
+							reasoningSummary: result.observer.reasoningSummary,
+							maxOutputTokens: result.observer.maxOutputTokens,
+							temperature: result.observer.temperature,
+							summaries: result.evaluation.counts.summaries,
+							observations: result.evaluation.counts.observations,
+							repairApplied: result.observer.repairApplied,
+							initial: {
+								raw: result.observer.initialRaw,
+								status: result.initialClassification.status,
+								reason: result.initialClassification.reason,
+								pass: result.initialEvaluation.pass,
+								failureReasons: result.initialEvaluation.failureReasons,
+								summaries: result.initialEvaluation.counts.summaries,
+								observations: result.initialEvaluation.counts.observations,
+								diagnostics: result.observer.initialDiagnostics,
+								elapsedMs: result.observer.initialElapsedMs,
+								usage: result.observer.initialUsage,
+								quality: reconciled.initialQuality,
+							},
+							repair: {
+								applied: result.observer.repairApplied,
+								raw: result.observer.repairedRaw,
+								status: result.repairedClassification?.status ?? null,
+								reason: result.repairedClassification?.reason ?? null,
+								pass: result.repairedEvaluation?.pass ?? null,
+								failureReasons: result.repairedEvaluation?.failureReasons ?? [],
+								summaries: result.repairedEvaluation?.counts.summaries ?? null,
+								observations: result.repairedEvaluation?.counts.observations ?? null,
+								diagnostics: result.observer.repairedDiagnostics,
+								elapsedMs: result.observer.repairedElapsedMs,
+								usage: result.observer.repairedUsage,
+								quality: repairQuality,
+							},
+							telemetry: {
+								totalElapsedMs: result.observer.totalElapsedMs,
+								totalUsage: result.observer.totalUsage,
+							},
+							pricing,
+							cost: {
+								initial: initialCost,
+								repair: repairCost,
+								total: totalCost,
+								unavailableReason: costUnavailableReason,
+							},
+							quality: reconciled.quality,
+						});
+					}
 				}
 				const reviewedQualityRuns = runs.filter((run) => run.quality?.weightedQualityScore != null);
 				const knownCostRuns = runs.filter((run) => run.cost.total != null);
 				const knownElapsedRuns = runs.filter((run) => run.telemetry.totalElapsedMs != null);
 				const summary = {
+					repetitions,
 					total: runs.length,
 					shapeQualityTotal: runs.filter((run) => run.purpose === "shape_quality").length,
 					shapeQualityPasses: runs.filter(
@@ -1335,6 +1351,18 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						(sum, run) => sum + (run.telemetry.totalElapsedMs ?? 0),
 						0,
 					),
+					perBatchStability: benchmark.batches.map((batch) => {
+						const batchRuns = runs.filter((run) => run.batchId === batch.batchId);
+						const passes = batchRuns.filter((run) => run.status === "pass").length;
+						return {
+							batchId: batch.batchId,
+							purpose: batch.purpose,
+							passes,
+							total: batchRuns.length,
+							passRate: batchRuns.length > 0 ? passes / batchRuns.length : null,
+							statuses: batchRuns.map((run) => run.status),
+						};
+					}),
 				};
 				const uniqueObserverKeys = Array.from(
 					new Set(runs.map((run) => `${run.provider}::${run.model}::${run.transport}`)),
@@ -1417,6 +1445,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						`Max output tokens: ${observerSummary.maxOutputTokens ?? "mixed"}`,
 						`Temperature: ${observerSummary.temperature ?? "mixed"}`,
 						`Transcript budget override: ${transcriptBudget ?? "default"}`,
+						`Repetitions: ${summary.repetitions}`,
 						`Shape-quality passes: ${summary.shapeQualityPasses}/${summary.shapeQualityTotal}`,
 						`Shape-quality fails: ${summary.shapeQualityFails}`,
 						`Expected-tier matches: ${summary.expectedTierMatches}/${summary.expectedTierTotal}`,
@@ -1438,7 +1467,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						run.telemetry.totalElapsedMs == null ? "n/a" : `${run.telemetry.totalElapsedMs}ms`;
 					const missingRequired = run.quality?.requiredRecall.missingLabelIds.join(",") || "none";
 					p.log.message(
-						`  [${run.batchId}] ${run.status.padEnd(18)} ${run.complexity.padEnd(10)} tier=${run.tier.padEnd(6)} expected=${(run.expectedTier ?? "n/a").padEnd(6)} disposition=${run.quality?.summaryDisposition.actual ?? "n/a"}/${run.expectedSummaryDisposition} span=${String(run.analysis.eventSpan).padEnd(3)} prompts=${run.analysis.promptCount} tools=${String(run.analysis.toolCount).padEnd(2)} transcript=${run.analysis.transcriptLength} ${run.provider}/${run.model} [${run.transport}] initial=${run.initial.summaries}s/${run.initial.observations}o final=${run.summaries}s/${run.observations}o quality=${qualityLabel} coverage=${run.quality?.weightedQualityCoverage?.toFixed(3) ?? "n/a"} required_missing=${missingRequired} cost=${costLabel} latency=${latencyLabel} schema_loss=${run.initial.diagnostics?.dataLoss === true ? "yes" : "no"} fallback=${run.modelFallbackApplied ? "yes" : "no"} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
+						`  [${run.batchId}#${run.iteration}] ${run.status.padEnd(18)} ${run.complexity.padEnd(10)} tier=${run.tier.padEnd(6)} expected=${(run.expectedTier ?? "n/a").padEnd(6)} disposition=${run.quality?.summaryDisposition.actual ?? "n/a"}/${run.expectedSummaryDisposition} span=${String(run.analysis.eventSpan).padEnd(3)} prompts=${run.analysis.promptCount} tools=${String(run.analysis.toolCount).padEnd(2)} transcript=${run.analysis.transcriptLength} ${run.provider}/${run.model} [${run.transport}] initial=${run.initial.summaries}s/${run.initial.observations}o final=${run.summaries}s/${run.observations}o quality=${qualityLabel} coverage=${run.quality?.weightedQualityCoverage?.toFixed(3) ?? "n/a"} required_missing=${missingRequired} cost=${costLabel} latency=${latencyLabel} schema_loss=${run.initial.diagnostics?.dataLoss === true ? "yes" : "no"} fallback=${run.modelFallbackApplied ? "yes" : "no"} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
 					);
 				}
 				p.outro("done");

--- a/packages/core/src/extraction-benchmark-scoring.test.ts
+++ b/packages/core/src/extraction-benchmark-scoring.test.ts
@@ -357,9 +357,9 @@ describe("extraction benchmark scoring", () => {
 
 	it("does not assign aggregate quality to an unreviewed batch", () => {
 		const batch = getExtractionBenchmarkProfile("rich-batch-shape-v1")?.batches.find(
-			(candidate) => candidate.batchId === 18502,
+			(candidate) => candidate.batchId === 18476,
 		);
-		if (!batch) throw new Error("expected unreviewed benchmark batch 18502");
+		if (!batch) throw new Error("expected unreviewed benchmark batch 18476");
 		const result = scoreExtractionBenchmarkOutput({
 			parsed: parsed([]),
 			diagnostics: CLEAN_DIAGNOSTICS,

--- a/packages/core/src/extraction-benchmarks.test.ts
+++ b/packages/core/src/extraction-benchmarks.test.ts
@@ -5,6 +5,36 @@ import {
 } from "./extraction-benchmarks.js";
 
 describe("extraction benchmarks", () => {
+	it("exposes a balanced fully reviewed 18-case quality profile", () => {
+		const profile = getExtractionBenchmarkProfile("balanced-observer-quality-v1");
+		expect(profile).not.toBeNull();
+		const shapeBatches =
+			profile?.batches.filter((batch) => batch.purpose === "shape_quality") ?? [];
+		expect(shapeBatches).toHaveLength(18);
+		for (const complexity of ["simple", "working", "rich"] as const) {
+			expect(shapeBatches.filter((batch) => batch.complexity === complexity)).toHaveLength(6);
+		}
+		expect(shapeBatches.every((batch) => batch.review?.status === "reviewed")).toBe(true);
+		expect(profile?.batches.filter((batch) => batch.purpose === "replay_robustness")).toEqual([
+			expect.objectContaining({ batchId: 18476 }),
+		]);
+	});
+
+	it("routes all balanced zero-observation controls through the routine scenario", () => {
+		const profile = getExtractionBenchmarkProfile("balanced-observer-quality-v1");
+		const zeroObservationBatchIds = new Set([18530, 28350, 28344, 28262, 28301, 18446]);
+		const zeroObservationControls =
+			profile?.batches.filter((batch) => zeroObservationBatchIds.has(batch.batchId)) ?? [];
+
+		expect(zeroObservationControls.map((batch) => batch.batchId)).toEqual([
+			18530, 28350, 28344, 28262, 28301, 18446,
+		]);
+		expect(zeroObservationControls.every((batch) => batch.observationPolicy === "zero")).toBe(true);
+		expect(
+			zeroObservationControls.every((batch) => batch.scenarioId === "routine-batch-shape"),
+		).toBe(true);
+	});
+
 	it("exposes the rich-batch benchmark profile", () => {
 		const profile = getExtractionBenchmarkProfile("rich-batch-shape-v1");
 		expect(profile).not.toBeNull();
@@ -32,6 +62,11 @@ describe("extraction benchmarks", () => {
 		expect(profile?.batches).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ batchId: 18503, purpose: "shape_quality" }),
+				expect.objectContaining({
+					batchId: 18446,
+					scenarioId: "routine-batch-shape",
+					observationPolicy: "zero",
+				}),
 				expect.objectContaining({ batchId: 18476, purpose: "replay_robustness" }),
 			]),
 		);
@@ -42,7 +77,13 @@ describe("extraction benchmarks", () => {
 		expect(profile).not.toBeNull();
 		expect(profile?.batches).toEqual(
 			expect.arrayContaining([
-				expect.objectContaining({ batchId: 18530, complexity: "simple", expectedTier: "simple" }),
+				expect.objectContaining({
+					batchId: 18530,
+					complexity: "simple",
+					expectedTier: "simple",
+					scenarioId: "routine-batch-shape",
+					observationPolicy: "zero",
+				}),
 				expect.objectContaining({ batchId: 18524, complexity: "working", expectedTier: "simple" }),
 				expect.objectContaining({ batchId: 18503, complexity: "rich", expectedTier: "rich" }),
 			]),
@@ -97,9 +138,9 @@ describe("extraction benchmarks", () => {
 		}
 	});
 
-	it("marks batches without known review as explicitly unreviewed", () => {
+	it("marks only robustness batches without known review as explicitly unreviewed", () => {
 		const profile = getExtractionBenchmarkProfile("rich-batch-shape-v1");
-		expect(profile?.batches.find((batch) => batch.batchId === 18502)?.review).toEqual({
+		expect(profile?.batches.find((batch) => batch.batchId === 18476)?.review).toEqual({
 			status: "unreviewed",
 			reviewerNotes: "No durable-fact review has been recorded for this batch.",
 		});

--- a/packages/core/src/extraction-benchmarks.ts
+++ b/packages/core/src/extraction-benchmarks.ts
@@ -7,6 +7,7 @@ export interface ExtractionBenchmarkBatch {
 	scenarioId?: string;
 	expectedTier?: "simple" | "rich";
 	expectedSummaryDisposition: "required" | "optional" | "skip";
+	observationPolicy?: "scenario" | "zero";
 	notes: string;
 	/** Human-reviewed durable-fact labels; omitted profiles are treated as unreviewed. */
 	review?: ExtractionBenchmarkReview;
@@ -68,6 +69,355 @@ const UNREVIEWED_BATCH: ExtractionBenchmarkReview = {
 };
 
 const REVIEWED_BATCHES: Readonly<Record<number, ExtractionBenchmarkReview>> = {
+	28350: {
+		status: "reviewed",
+		reviewerNotes:
+			"This non-development image-generation interaction contains no durable codemem project fact and should be skipped.",
+		labels: [],
+	},
+	28344: {
+		status: "reviewed",
+		reviewerNotes:
+			"This batch only reads a handoff and acknowledges it; it contains no completed work or durable learning and should be skipped.",
+		labels: [],
+	},
+	28262: {
+		status: "reviewed",
+		reviewerNotes:
+			"The requested validation could not be performed because no shell was available; there is no durable result to retain.",
+		labels: [],
+	},
+	28301: {
+		status: "reviewed",
+		reviewerNotes:
+			"A clean re-review found no remaining concerns. The result belongs in the session summary, while review narration must not become a typed durable observation.",
+		labels: [
+			{
+				id: "clean-review-workflow",
+				title: "Clean review and ship narration is routine workflow",
+				disposition: "forbidden",
+				keywordGroups: [["ship", "ship it", "review passed", "no concerns"]],
+				reviewerNotes:
+					"Do not manufacture a durable project fact from a routine clean review with no findings.",
+				sourceEvidence:
+					"The replay concludes that all seven previously raised concerns were fixed and reports SHIP, without identifying a new reusable technical constraint.",
+			},
+		],
+	},
+	28275: {
+		status: "reviewed",
+		reviewerNotes:
+			"The batch implements reviewed-label aggregate scoring and actual-usage cost accounting for model evaluation.",
+		labels: [
+			{
+				id: "reviewed-quality-and-usage-cost",
+				title: "Model evaluation uses reviewed quality and actual usage cost",
+				disposition: "required",
+				keywordGroups: [
+					["reviewed", "human-reviewed", "review labels"],
+					["quality", "recall", "scoring"],
+					["usage", "token usage", "actual tokens"],
+					["cost", "pricing"],
+				],
+				reviewerNotes:
+					"Capture both halves of the implementation: quality aggregates are restricted to reviewed cases and cost is calculated from provider-reported token usage.",
+				sourceEvidence:
+					"The replay reports implemented reviewed-only aggregate quality and actual-usage cost scoring, followed by 24 passing tests.",
+			},
+		],
+	},
+	28256: {
+		status: "reviewed",
+		reviewerNotes:
+			"The batch establishes zero-observation shape semantics and preserves parser/repair diagnostics for auditable replay.",
+		labels: [
+			{
+				id: "zero-observation-shape-policy",
+				title: "Working and rich batches may validly emit zero observations",
+				disposition: "required",
+				keywordGroups: [
+					["working", "rich"],
+					["zero observations", "no observations", "0 observations"],
+					["valid", "allowed", "no minimum"],
+				],
+				reviewerNotes:
+					"Retain the semantic correction that complexity does not impose a minimum observation count.",
+				sourceEvidence:
+					"The replay reports that working/rich scenarios allow zero observations, routine requires exactly zero, and simple allows at most one.",
+			},
+			{
+				id: "auditable-parser-repair-diagnostics",
+				title: "Replay preserves initial, repaired, and structural diagnostics",
+				disposition: "required",
+				keywordGroups: [
+					["initial", "original"],
+					["repair", "repaired"],
+					["diagnostics", "structural diagnostics", "parser diagnostics"],
+				],
+				reviewerNotes:
+					"Capture preservation of both attempts and diagnostics such as nesting, unknown fields, unsupported kinds, and data loss.",
+				sourceEvidence:
+					"The replay explicitly lists preserved initial/repaired parsed output and diagnostics for malformed structure and data loss.",
+			},
+		],
+	},
+	28264: {
+		status: "reviewed",
+		reviewerNotes:
+			"The batch adds normalized elapsed-time/token-usage telemetry and separately establishes the per-invocation state needed for concurrency safety.",
+		labels: [
+			{
+				id: "normalized-observer-telemetry",
+				title: "Observer responses normalize elapsed time and provider token usage",
+				disposition: "required",
+				keywordGroups: [
+					["elapsed", "elapsedms", "latency"],
+					["usage", "token usage"],
+					["openai", "anthropic", "provider"],
+				],
+				reviewerNotes:
+					"Capture the additive elapsed-time and normalized provider-usage response fields; unavailable sidecar/SSE usage remains null rather than inferred.",
+				sourceEvidence:
+					"The exact replay input reports ObserverResponse elapsedMs/usage support for OpenAI and Anthropic paths and null usage when provider telemetry is unavailable.",
+			},
+			{
+				id: "per-invocation-telemetry-state",
+				title: "Telemetry state is scoped per invocation to avoid concurrency races",
+				disposition: "required",
+				keywordGroups: [
+					["per invocation", "per-invocation", "per-call", "call result"],
+					["race", "shared mutable state", "concurrent", "overlapping"],
+				],
+				reviewerNotes:
+					"Keep concurrency safety separate from provider normalization so models are not rewarded for merging two durable facts into one oversized observation.",
+				sourceEvidence:
+					"The exact replay input says shared mutable last-usage state can race across concurrent observe calls and that usage must travel with each invocation result.",
+			},
+		],
+	},
+	18530: {
+		status: "reviewed",
+		reviewerNotes:
+			"The dependency version check resolves the immediate question but produces no durable project change or constraint.",
+		labels: [
+			{
+				id: "routine-dependency-version-check",
+				title: "Routine dependency latest-version check is not durable memory",
+				disposition: "forbidden",
+				keywordGroups: [["better-sqlite3"], ["12.8.0", "latest version", "up to date"]],
+				reviewerNotes:
+					"The user abandoned the thread after confirming the package version; do not promote the transient lookup to a typed observation.",
+				sourceEvidence:
+					"The replay checks whether better-sqlite3 is current, confirms 12.8.0/latest, identifies the warning as upstream noise, and makes no change.",
+			},
+		],
+	},
+	18490: {
+		status: "reviewed",
+		reviewerNotes: "The compact CI diagnosis identifies one exact failing recall-pack behavior.",
+		labels: [
+			{
+				id: "legacy-summary-leaks-into-recall-pack",
+				title: "Legacy summaries leaked into non-summary recall packs",
+				disposition: "required",
+				keywordGroups: [
+					["legacy summary", "legacy summary rows"],
+					["non-summary", "recall pack"],
+					["leak", "included", "injected"],
+				],
+				reviewerNotes: "Capture the exact behavioral failure, not generic CI narration.",
+				sourceEvidence:
+					"The replay identifies pack.test.ts:432 and reports Legacy summary appearing under Summary in a non-summary recall pack.",
+			},
+		],
+	},
+	18494: {
+		status: "reviewed",
+		reviewerNotes:
+			"This independent compact session diagnoses the same legacy-summary recall-pack regression.",
+		labels: [
+			{
+				id: "legacy-summary-leaks-into-recall-pack",
+				title: "Legacy summaries leaked into non-summary recall packs",
+				disposition: "required",
+				keywordGroups: [
+					["legacy summary", "legacy summary rows"],
+					["non-summary", "recall pack"],
+					["leak", "included", "injected"],
+				],
+				reviewerNotes: "Capture the exact behavioral failure, not generic CI narration.",
+				sourceEvidence:
+					"The replay independently identifies the buildMemoryPack test failure and the unexpected Legacy summary output.",
+			},
+		],
+	},
+	18524: {
+		status: "reviewed",
+		reviewerNotes:
+			"The documentation research produces a concrete migration pattern from prebuild-install to prebuildify/node-gyp-build.",
+		labels: [
+			{
+				id: "prebuildify-node-gyp-build-migration",
+				title: "Native packages should bundle Node-API prebuilds with source fallback",
+				disposition: "required",
+				keywordGroups: [
+					["prebuildify"],
+					["napi", "node-api"],
+					["node-gyp-build"],
+					["prebuilds", "bundled prebuilds"],
+					["fallback", "source build", "node-gyp"],
+				],
+				reviewerNotes:
+					"Retain the complete packaging/runtime pattern, including publishing prebuilds and preserving source-build fallback.",
+				sourceEvidence:
+					"The replay's authoritative-doc research recommends prebuildify --napi, bundled prebuilds/**, node-gyp-build at runtime, and source fallback.",
+			},
+		],
+	},
+	18525: {
+		status: "reviewed",
+		reviewerNotes:
+			"The investigation tentatively locates the warning in the better-sqlite3 dependency chain but intentionally stops before implementation.",
+		labels: [
+			{
+				id: "prebuild-warning-transitive-source",
+				title: "The prebuild-install warning likely comes through better-sqlite3",
+				disposition: "optional",
+				keywordGroups: [
+					["prebuild-install", "prebuild warning"],
+					["better-sqlite3"],
+					["transitive", "dependency"],
+				],
+				reviewerNotes:
+					"This was a useful but tentative source attribution, so it is optional rather than required ground truth.",
+				sourceEvidence:
+					"The replay traces the install warning to a likely transitive better-sqlite3 path and asks whether to continue with a fix or spike.",
+			},
+		],
+	},
+	18460: {
+		status: "reviewed",
+		reviewerNotes:
+			"The durable lesson is the stale TypeScript incremental-cache fix; later Graphite/PR-body workflow is noise.",
+		labels: [
+			{
+				id: "tsbuildinfo-clean-build-output",
+				title: "TypeScript incremental state must be cleaned with build outputs",
+				disposition: "required",
+				keywordGroups: [
+					["tsbuildinfofile", "tsbuildinfo", "incremental cache"],
+					["dist", "build output"],
+					["clean", "cleaned", "remove stale"],
+					["tsc --build", "typescript build", "ci"],
+				],
+				reviewerNotes:
+					"Capture that tsBuildInfoFile belongs under dist and CI should clean before the root build to prevent stale cache success.",
+				sourceEvidence:
+					"The replay recommends moving tsBuildInfoFile into dist and cleaning before root tsc --build so stale incremental state cannot survive output cleanup.",
+			},
+			{
+				id: "graphite-pr-body-workflow",
+				title: "Graphite and PR-body updates are routine workflow",
+				disposition: "forbidden",
+				keywordGroups: [
+					["graphite", "gt submit"],
+					["pr body", "pull request body", "ready for review"],
+				],
+				reviewerNotes:
+					"Later branch-management and PR-description narration is not a durable technical observation.",
+				sourceEvidence:
+					"The latter replay events switch from the cache fix to Graphite submission and PR-body/ready-state workflow.",
+			},
+		],
+	},
+	18502: {
+		status: "reviewed",
+		reviewerNotes:
+			"This rich planning batch defines injection-first memory, causal context, progressive disclosure, and a derived graph direction.",
+		labels: [
+			{
+				id: "injection-first-causal-memory",
+				title: "Track 3 optimizes automatic injection for rediscovery reduction",
+				disposition: "required",
+				keywordGroups: [
+					["injection-first", "automatic injection"],
+					["rediscovery", "rework", "scouting"],
+				],
+				reviewerNotes:
+					"Capture the product goal visible in the exact replay prompt: automatic injection should reduce rediscovery, scouting, and repeated work.",
+				sourceEvidence:
+					"The exact truncated replay input contains the injection-first Track 3 goal and reduced rediscovery/scouting language; causal/progressive-disclosure details from the full raw batch are outside that prompt and are intentionally excluded.",
+			},
+			{
+				id: "derived-readonly-relationship-graph",
+				title: "A future graph layer should be derived and read-only first",
+				disposition: "required",
+				keywordGroups: [
+					["graph", "knowledge graph"],
+					["derived"],
+					["read-only", "read only"],
+					["relationship", "edges", "connected"],
+				],
+				reviewerNotes:
+					"Retain the constraint that graph relationships augment retrieval but do not become the source of truth initially.",
+				sourceEvidence:
+					"The replay creates a tracked exploration based on silk-graph and specifies derived, read-only edges over existing memories/metadata.",
+			},
+		],
+	},
+	18506: {
+		status: "reviewed",
+		reviewerNotes:
+			"The batch diagnoses rich-session under-extraction and implements fixes in both observer context and active-session flushing.",
+		labels: [
+			{
+				id: "observer-transcript-omission",
+				title: "Observer under-extraction was caused by omitted transcript context",
+				disposition: "required",
+				keywordGroups: [
+					["transcript", "conversation transcript"],
+					["observer", "observer prompt"],
+					["missing", "omitted", "not sent", "never sent"],
+					["under-extraction", "lossy", "weak memories"],
+				],
+				reviewerNotes:
+					"Capture the root cause and the fix: pass a bounded head-and-tail transcript into ObserverContext/prompt.",
+				sourceEvidence:
+					"The replay traces a 150+ event quality failure to the pipeline building a transcript but never sending it to the observer, then adds bounded head/tail transcript context.",
+			},
+			{
+				id: "bounded-active-session-flushing",
+				title: "Active sessions flush in bounded batches without endless debounce",
+				disposition: "required",
+				keywordGroups: [
+					["active session", "active auto-flush"],
+					["batch limit", "bounded", "batch size"],
+					["debounce", "flush"],
+				],
+				reviewerNotes:
+					"Retain the complementary ingestion fix that prevents active streams from accumulating one giant observer batch.",
+				sourceEvidence:
+					"The replay reports active auto-flush respecting the worker batch limit, reducing the default batch size, and preventing debounce from resetting forever.",
+			},
+		],
+	},
+	18446: {
+		status: "reviewed",
+		reviewerNotes:
+			"This batch is mostly repeated patch intent with no completed durable outcome; either a concise summary or a low-signal skip is acceptable.",
+		labels: [
+			{
+				id: "repeated-patch-intent",
+				title: "Repeated implementation intent is not a durable observation",
+				disposition: "forbidden",
+				keywordGroups: [["will patch", "going to patch", "implement next", "patch intent"]],
+				reviewerNotes:
+					"Do not turn repeated statements of intended work into durable completed-work memory.",
+				sourceEvidence:
+					"The replay repeats plans to patch and implementation narration without evidence of a completed technical outcome in the batch.",
+			},
+		],
+	},
 	18503: {
 		status: "reviewed",
 		reviewerNotes:
@@ -124,17 +474,16 @@ const REVIEWED_BATCHES: Readonly<Record<number, ExtractionBenchmarkReview>> = {
 			},
 			{
 				id: "relinking-does-not-fix-recap-dominance",
-				title: "Relinking reduces unmapped burden but not recap dominance",
+				title: "Relinking does not fix recap dominance",
 				disposition: "required",
 				keywordGroups: [
 					["relink", "relinking"],
-					["unmapped burden", "unmapped sessions", "unmapped rows"],
 					["recap dominance", "summary dominance", "recap-heavy retrieval"],
 				],
 				reviewerNotes:
-					"Keep this distinct from transparent repair: relinking reduces the unmapped-session burden, but retrieval can still be dominated by recap/summary artifacts.",
+					"Keep this distinct from transparent repair: even after relinking, retrieval can remain dominated by recap/summary artifacts.",
 				sourceEvidence:
-					"Replay transcript explicitly reports that relinking reduces unmapped burden while recap dominance remains a separate ranking problem.",
+					"The exact truncated replay input contains relinking and recap-dominance evidence. The full raw batch's separate unmapped-burden phrase is outside the prompt and is intentionally excluded.",
 			},
 		],
 	},
@@ -144,7 +493,247 @@ function benchmarkReview(batchId: number): ExtractionBenchmarkReview {
 	return REVIEWED_BATCHES[batchId] ?? UNREVIEWED_BATCH;
 }
 
+function balancedShapeBatch(
+	batchId: number,
+	sessionId: number,
+	label: string,
+	complexity: "simple" | "working" | "rich",
+	expectedSummaryDisposition: "required" | "optional" | "skip",
+	notes: string,
+	observationPolicy: "scenario" | "zero" = "scenario",
+): ExtractionBenchmarkBatch {
+	return {
+		batchId,
+		sessionId,
+		label,
+		purpose: "shape_quality",
+		complexity,
+		scenarioId: observationPolicy === "zero" ? "routine-batch-shape" : `${complexity}-batch-shape`,
+		expectedTier: complexity === "rich" ? "rich" : "simple",
+		expectedSummaryDisposition,
+		observationPolicy,
+		notes,
+		review: benchmarkReview(batchId),
+	};
+}
+
 const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
+	{
+		id: "balanced-observer-quality-v1",
+		title: "Balanced observer quality benchmark v1",
+		description:
+			"Primary reviewed observer-model benchmark: six simple, six working, and six rich shape cases, plus one separately reported replay-robustness case. It balances positive durable facts, optional facts, forbidden workflow noise, and valid low-signal skips.",
+		scenarioId: "working-batch-shape",
+		recommendedTruthModel: {
+			provider: "openai",
+			model: "gpt-5.4",
+			notes:
+				"Use as the current production baseline while the larger reviewed corpus is calibrated; do not treat it as immutable ground truth.",
+		},
+		cheapCandidate: {
+			provider: "openai",
+			model: "gpt-5.4-mini",
+			temperature: 0.2,
+			notes:
+				"Simple-tier baseline to compare with Luna once the same transport and repeated-run protocol are available.",
+		},
+		modelCandidates: [
+			{
+				provider: "openai",
+				model: "gpt-5.4-mini",
+				role: "simple_baseline",
+				reasoningEffort: "none",
+				notes: "Current simple-tier baseline.",
+			},
+			{
+				provider: "openai",
+				model: "gpt-5.4",
+				role: "rich_baseline",
+				reasoningEffort: "none",
+				notes: "Current rich-tier baseline.",
+			},
+			{
+				provider: "openai",
+				model: "gpt-5.5",
+				role: "quality_ceiling",
+				reasoningEffort: "none",
+				notes: "Higher-cost quality reference.",
+			},
+			{
+				provider: "openai",
+				model: "gpt-5.6-terra",
+				role: "cost_matched_challenger",
+				reasoningEffort: "none",
+				notes:
+					"Fast rich-tier finalist; require repeated runs because the earlier 18446 failure proved stochastic.",
+			},
+		],
+		batches: [
+			balancedShapeBatch(
+				18530,
+				166430,
+				"Abandoned dependency-version check",
+				"simple",
+				"required",
+				"Small completed lookup: summarize the interaction but avoid manufacturing a typed observation.",
+				"zero",
+			),
+			balancedShapeBatch(
+				18490,
+				166412,
+				"Compact CI regression diagnosis A",
+				"simple",
+				"required",
+				"Small batch with one exact durable failure diagnosis.",
+			),
+			balancedShapeBatch(
+				18494,
+				166413,
+				"Compact CI regression diagnosis B",
+				"simple",
+				"required",
+				"Independent compact session covering the same exact regression.",
+			),
+			balancedShapeBatch(
+				28350,
+				169290,
+				"Non-development image workflow",
+				"simple",
+				"skip",
+				"Negative control with no durable software-project content.",
+				"zero",
+			),
+			balancedShapeBatch(
+				28344,
+				169289,
+				"Handoff read and acknowledgement",
+				"simple",
+				"skip",
+				"Negative control for context-only acknowledgement without completed work.",
+				"zero",
+			),
+			balancedShapeBatch(
+				28262,
+				169278,
+				"Blocked validation request",
+				"simple",
+				"skip",
+				"Negative control where validation could not run and produced no durable result.",
+				"zero",
+			),
+			balancedShapeBatch(
+				18524,
+				166429,
+				"Native prebuild migration research",
+				"working",
+				"required",
+				"Moderate documentation-research batch with one reusable packaging recommendation.",
+			),
+			balancedShapeBatch(
+				18525,
+				166430,
+				"Transitive warning investigation",
+				"working",
+				"required",
+				"Moderate investigation with tentative optional evidence and no implementation.",
+			),
+			balancedShapeBatch(
+				18460,
+				166400,
+				"TypeScript cache fix plus PR workflow",
+				"working",
+				"required",
+				"Mixed durable build-system lesson and forbidden routine workflow narration.",
+			),
+			balancedShapeBatch(
+				28301,
+				169286,
+				"Clean eval-fix re-review",
+				"working",
+				"required",
+				"Review-only control: a summary is useful, but zero typed observations is correct.",
+				"zero",
+			),
+			balancedShapeBatch(
+				28275,
+				169282,
+				"Reviewed quality and cost scoring implementation",
+				"working",
+				"required",
+				"Tool-heavy implementation tail with an auditable scoring outcome.",
+			),
+			balancedShapeBatch(
+				28256,
+				169270,
+				"Replay parser and shape-semantics implementation",
+				"working",
+				"required",
+				"Tool-heavy implementation tail with two distinct durable eval semantics.",
+			),
+			balancedShapeBatch(
+				18503,
+				166405,
+				"Stable-session regression investigation",
+				"rich",
+				"required",
+				"Flagship multi-thread case with durable regression evidence and workflow noise.",
+			),
+			balancedShapeBatch(
+				18502,
+				166405,
+				"Injection-first and graph architecture planning",
+				"rich",
+				"required",
+				"Rich product-design case with causal retrieval and graph constraints.",
+			),
+			balancedShapeBatch(
+				18506,
+				166405,
+				"Rich-session under-extraction root cause and fix",
+				"rich",
+				"required",
+				"Rich diagnosis/implementation case spanning observer context and flush behavior.",
+			),
+			balancedShapeBatch(
+				18432,
+				166392,
+				"Transparent relink repair and limitation",
+				"rich",
+				"required",
+				"High-volume snapshot with two separate durable repair lessons.",
+			),
+			balancedShapeBatch(
+				18446,
+				166392,
+				"Repeated patch-intent case",
+				"rich",
+				"optional",
+				"Hard low-signal rich batch where either a concise summary or explicit skip is acceptable.",
+				"zero",
+			),
+			balancedShapeBatch(
+				28264,
+				169280,
+				"Cross-provider observer telemetry implementation",
+				"rich",
+				"required",
+				"Rich implementation case with provider normalization and concurrency constraints.",
+			),
+			{
+				batchId: 18476,
+				sessionId: 166405,
+				label: "Replay no-output robustness case",
+				purpose: "replay_robustness",
+				complexity: "robustness",
+				scenarioId: "rich-batch-shape",
+				expectedTier: "rich",
+				expectedSummaryDisposition: "optional",
+				notes:
+					"Report separately from the 18 shape cases; observer no-output is a transport/replay robustness result, not a shape-quality miss.",
+				review: benchmarkReview(18476),
+			},
+		],
+	},
 	{
 		id: "rich-batch-shape-v1",
 		title: "Rich batch shape benchmark v1",
@@ -253,9 +842,10 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				label: "Hard failing snapshot batch",
 				purpose: "shape_quality",
 				complexity: "rich",
-				scenarioId: "rich-batch-shape",
+				scenarioId: "routine-batch-shape",
 				expectedTier: "rich",
 				expectedSummaryDisposition: "optional",
+				observationPolicy: "zero",
 				notes:
 					"Useful stubborn case: some models return summary-only or nothing; stronger models plus repair can recover it.",
 				review: benchmarkReview(18446),
@@ -317,9 +907,10 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				label: "Tiny prompt-only batch",
 				purpose: "shape_quality",
 				complexity: "simple",
-				scenarioId: "simple-batch-shape",
+				scenarioId: "routine-batch-shape",
 				expectedTier: "simple",
-				expectedSummaryDisposition: "optional",
+				expectedSummaryDisposition: "required",
+				observationPolicy: "zero",
 				notes: "Very small batch that should clearly remain on the cheap/simple tier.",
 				review: benchmarkReview(18530),
 			},


### PR DESCRIPTION
## Summary

- add `balanced-observer-quality-v1` with 18 human-reviewed shape cases: 6 simple, 6 working, and 6 rich
- keep the known no-output replay case separate from shape-quality counts
- add evidence-backed required, optional, and forbidden labels plus explicit skip controls
- add `--repetitions <n>` (capped at 10) with per-run iteration data and per-batch pass-rate/status sequences
- document a repeated, transport-specific finalist workflow for Terra, Luna, and current baselines

## Testing

- profile balance/review invariants and repetition safety coverage
- `pnpm run tsc`
- `pnpm run lint`
- `pnpm run test`: 136 files, 2,592 passed, 3 todo