### PR TITLE
feat(sharing): provision exact project access

### DIFF
--- a/packages/cloudflare-coordinator-worker/test/worker.integration.test.ts
+++ b/packages/cloudflare-coordinator-worker/test/worker.integration.test.ts
@@ -674,4 +674,87 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		);
 		expect(dataPlaneRes.status).toBe(404);
 	});
+
+	it("reuses a managed project boundary and grants only the explicit bounded device set", async () => {
+		await env.COORDINATOR_DB.prepare(
+			"INSERT INTO groups (group_id, display_name, created_at) VALUES ('g1', 'Team', ?)",
+		)
+			.bind("2026-07-20T00:00:00Z")
+			.run();
+		const devices = [createIdentity(), createIdentity(), createIdentity(), createIdentity()];
+		for (const [index, device] of devices.entries()) {
+			const enrolled = await exports.default.fetch("https://example.com/v1/admin/devices", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					"X-Codemem-Coordinator-Admin": "test-secret",
+				},
+				body: JSON.stringify({
+					group_id: "g1",
+					device_id: device.deviceId,
+					fingerprint: device.fingerprint,
+					public_key: device.publicKey,
+					display_name: `Device ${index + 1}`,
+				}),
+			});
+			expect(enrolled.status).toBe(200);
+		}
+		const scopeBody = JSON.stringify({
+			scope_id: "managed-project:deterministic",
+			label: "api",
+			kind: "managed_project",
+			authority_type: "coordinator",
+			membership_epoch: 1,
+		});
+		const create = () =>
+			exports.default.fetch("https://example.com/v1/admin/groups/g1/scopes", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					"X-Codemem-Coordinator-Admin": "test-secret",
+				},
+				body: scopeBody,
+			});
+		expect((await create()).status).toBe(201);
+		// Duplicate create may report conflict; the durable boundary remains unique
+		// and is safely recoverable by re-reading it.
+		expect([200, 400, 409]).toContain((await create()).status);
+		const scopes = await exports.default.fetch("https://example.com/v1/admin/groups/g1/scopes", {
+			headers: { "X-Codemem-Coordinator-Admin": "test-secret" },
+		});
+		const scopesPayload = (await scopes.json()) as { items: Array<{ scope_id: string }> };
+		expect(
+			scopesPayload.items.filter((scope) => scope.scope_id === "managed-project:deterministic"),
+		).toHaveLength(1);
+		const reviewed = devices.slice(0, 3);
+		for (const device of reviewed) {
+			const grant = () =>
+				exports.default.fetch(
+					"https://example.com/v1/admin/groups/g1/scopes/managed-project%3Adeterministic/members",
+					{
+						method: "POST",
+						headers: {
+							"content-type": "application/json",
+							"X-Codemem-Coordinator-Admin": "test-secret",
+						},
+						body: JSON.stringify({
+							device_id: device.deviceId,
+							role: "member",
+							membership_epoch: 1,
+						}),
+					},
+				);
+			expect((await grant()).status).toBe(201);
+			expect((await grant()).status).toBe(201);
+		}
+		const listed = await exports.default.fetch(
+			"https://example.com/v1/admin/groups/g1/scopes/managed-project%3Adeterministic/members",
+			{ headers: { "X-Codemem-Coordinator-Admin": "test-secret" } },
+		);
+		const payload = (await listed.json()) as { items: Array<{ device_id: string }> };
+		expect(payload.items.map((item) => item.device_id).sort()).toEqual(
+			reviewed.map((device) => device.deviceId).sort(),
+		);
+		expect(payload.items.some((item) => item.device_id === devices[3]?.deviceId)).toBe(false);
+	});
 });

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -11,7 +11,7 @@
  * Import existing store/entity types where shapes match.
  */
 
-import type { SyncCapability } from "./sync-capability.js";
+import type { SyncCapability, SyncFeature } from "./sync-capability.js";
 import type {
 	Actor,
 	MemoryItemResponse,
@@ -874,6 +874,7 @@ export interface ApiSyncProtocolStatusResponse {
 	fingerprint: string;
 	sync_reset: ApiSyncResetBoundary;
 	sync_capability: SyncCapability;
+	sync_features: SyncFeature[];
 }
 
 export interface ApiSyncOpsIncrementalResponse extends ApiSyncResetBoundary {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -656,6 +656,17 @@ export {
 	SHARE_OPERATION_STATE,
 	shareProjectSetDigest,
 } from "./share-operation.js";
+export type {
+	ManagedProjectPlan,
+	ReassignScopeCapability,
+	ShareProvisioningDependencies,
+	ShareProvisioningPlan,
+} from "./share-provisioning.js";
+export {
+	countShareableProjectMemories,
+	executeShareProvisioning,
+	planShareProvisioning,
+} from "./share-provisioning.js";
 export { MemoryStore } from "./store.js";
 export {
 	hasPendingSummaryDedupBackfill,
@@ -681,14 +692,20 @@ export {
 export { DEFAULT_TIME_WINDOW_S } from "./sync-auth-constants.js";
 export type { BootstrapOptions, BootstrapResult } from "./sync-bootstrap.js";
 export { applyBootstrapSnapshot, fetchAllSnapshotPages } from "./sync-bootstrap.js";
-export type { SyncCapability } from "./sync-capability.js";
+export type { SyncCapability, SyncFeature } from "./sync-capability.js";
 export {
 	isScopedSyncCapability,
 	LOCAL_SYNC_CAPABILITY,
+	LOCAL_SYNC_FEATURES,
 	negotiateSyncCapability,
 	normalizeSyncCapability,
+	normalizeSyncFeatures,
+	SYNC_AUTHORIZATION_REFRESH_HEADER,
 	SYNC_CAPABILITIES,
 	SYNC_CAPABILITY_HEADER,
+	SYNC_FEATURES,
+	SYNC_FEATURES_HEADER,
+	supportsSyncFeature,
 } from "./sync-capability.js";
 export type { SyncDaemonOptions, SyncDaemonPhase, SyncTickResult } from "./sync-daemon.js";
 export {
@@ -754,6 +771,7 @@ export type {
 	InboundScopeRejectionRecord,
 	InboundScopeRejectionSummaryOptions,
 	ListInboundScopeRejectionsOptions,
+	ReassignScopePayload,
 	ReconcileStalePeerReceivedRowsOptions,
 	ReconcileStalePeerReceivedRowsResult,
 	StalePeerReceivedRowDiagnostic,
@@ -780,14 +798,17 @@ export {
 	loadReplicationOpsForPeer,
 	loadReplicationOpsSince,
 	migrateLegacyImportKeys,
+	parseReassignScopePayload,
 	peerCanSyncPrivateOpByPersonalScopeGrant,
 	personalScopeGrantStatusForPeer,
 	planReplicationOpsAgePrune,
 	pruneReplicationOps,
 	pruneReplicationOpsUntilCaughtUp,
+	REASSIGN_SCOPE_OP_TYPE,
 	reconcileStalePeerReceivedRows,
 	recordAccessCleanupOp,
 	recordReplicationOp,
+	recordScopeReassignment,
 	rejectInboundScopeFailures,
 	replicationOpRequiresPersonalScopeAuthorization,
 	setReplicationCursor,

--- a/packages/core/src/share-operation.test.ts
+++ b/packages/core/src/share-operation.test.ts
@@ -500,6 +500,26 @@ describe("share-operation persistence", () => {
 		).toBe("pending");
 	});
 
+	it("does not regress a provisioning lifecycle on authoritative acceptance replay", () => {
+		const operation = plan();
+		persistShareOperation(db, operation, {
+			inviteId: "invite-1",
+			tokenDigest: inviteTokenDigest("token-1"),
+		});
+		const input = acceptanceInput(operation);
+		reconcileShareOperationAcceptance(db, input);
+		db.prepare("UPDATE share_operations SET state = 'initial_sync' WHERE operation_id = ?").run(
+			operation.operationId,
+		);
+		reconcileShareOperationAcceptance(db, input);
+		expect(
+			db
+				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+				.pluck()
+				.get(operation.operationId),
+		).toBe("initial_sync");
+	});
+
 	it("rejects malformed or mismatched authoritative project intent", () => {
 		expect(() => parseAcceptedProjectIntent([{ display_name: "codemem" }])).toThrow(
 			"operation_intent_invalid",

--- a/packages/core/src/share-operation.ts
+++ b/packages/core/src/share-operation.ts
@@ -212,7 +212,9 @@ export function planShareOperation(input: {
 		step(operationId, "invite_creation", input.createdAt, true),
 		step(operationId, "invite_consumption", input.createdAt, false),
 		step(operationId, "person_device_link", input.createdAt, false),
+		step(operationId, "capability_preflight", input.createdAt, false),
 		...projectSteps(operationId, coordinatorGroupId, inviterDeviceIds, projects, input.createdAt),
+		step(operationId, "authorization_refresh", input.createdAt, false),
 		step(operationId, "initial_sync", input.createdAt, false),
 	];
 	return {
@@ -566,7 +568,9 @@ export function reconcileShareOperationAcceptance(
 				.run(input.recipientActorId, input.consumedAt, operation.person_id);
 			if (linked.changes !== 1) throw new Error("pending_person_identity_conflict");
 		}
-		db.prepare(`UPDATE share_operations SET state = 'accepted', person_id = ?, person_kind = 'existing',
+		db.prepare(`UPDATE share_operations SET
+				state = CASE WHEN state IN ('waiting_for_acceptance', 'accepted') THEN 'accepted' ELSE state END,
+				person_id = ?, person_kind = 'existing',
 				pending_person_operation_id = NULL, recipient_actor_id = ?, recipient_display_name = ?,
 				recipient_device_id = ?, recipient_device_display_name = ?, recipient_public_key = ?,
 				recipient_fingerprint = ?, acceptance_consumed_at = ?, trust_state = ?,

--- a/packages/core/src/share-provisioning.test.ts
+++ b/packages/core/src/share-provisioning.test.ts
@@ -1,0 +1,760 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getCachedScopeAuthorization } from "./scope-membership-cache.js";
+import {
+	inviteTokenDigest,
+	persistShareOperation,
+	planShareOperation,
+	reconcileShareOperationAcceptance,
+} from "./share-operation.js";
+import {
+	countShareableProjectMemories,
+	executeShareProvisioning,
+	planShareProvisioning,
+	type ShareProvisioningDependencies,
+} from "./share-provisioning.js";
+import { fingerprintPublicKey } from "./sync-fingerprint.js";
+import { initTestSchema } from "./test-utils.js";
+
+const createdAt = "2026-07-20T12:00:00.000Z";
+const remote = "https://example.invalid/acme/api.git";
+
+describe("exact project share provisioning", () => {
+	let db: InstanceType<typeof Database>;
+	let operationId: string;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+		const sourceScope = "source-space";
+		db.prepare(`INSERT INTO replication_scopes(
+			scope_id, label, kind, authority_type, coordinator_id, group_id,
+			membership_epoch, status, created_at, updated_at
+		) VALUES (?, 'Source', 'team', 'coordinator', 'coord', 'team', 1, 'active', ?, ?)`).run(
+			sourceScope,
+			createdAt,
+			createdAt,
+		);
+		for (const deviceId of [
+			"owner",
+			"owner-proven",
+			"owner-filtered",
+			"unreviewed-source-member",
+		]) {
+			db.prepare(`INSERT INTO scope_memberships(
+				scope_id, device_id, role, status, membership_epoch, coordinator_id, group_id, updated_at
+			) VALUES (?, ?, 'member', 'active', 1, 'coord', 'team', ?)`).run(
+				sourceScope,
+				deviceId,
+				createdAt,
+			);
+		}
+		db.prepare(`INSERT INTO sync_peers(
+			peer_device_id, projects_include_json, projects_exclude_json, created_at
+		) VALUES ('owner-proven', '["api"]', '[]', ?),
+			('owner-filtered', '["other"]', '[]', ?),
+			('unreviewed-source-member', '["api"]', '[]', ?)`).run(createdAt, createdAt, createdAt);
+		const selectedSession = Number(
+			db
+				.prepare("INSERT INTO sessions(started_at, project, git_remote) VALUES (?, 'api', ?)")
+				.run(createdAt, remote).lastInsertRowid,
+		);
+		const unrelatedSession = Number(
+			db
+				.prepare("INSERT INTO sessions(started_at, project, git_remote) VALUES (?, 'other', ?)")
+				.run(createdAt, "https://example.invalid/acme/other.git").lastInsertRowid,
+		);
+		const insertMemory = db.prepare(`INSERT INTO memory_items(
+			session_id, kind, title, body_text, confidence, tags_text, active, created_at,
+			updated_at, metadata_json, import_key, rev, visibility, scope_id
+		) VALUES (?, 'discovery', ?, 'body', 0.8, '', 1, ?, ?, '{}', ?, 1, ?, ?)`);
+		insertMemory.run(
+			selectedSession,
+			"selected-shared",
+			createdAt,
+			createdAt,
+			"selected:shared",
+			"shared",
+			sourceScope,
+		);
+		insertMemory.run(
+			selectedSession,
+			"selected-private",
+			createdAt,
+			createdAt,
+			"selected:private",
+			"private",
+			sourceScope,
+		);
+		insertMemory.run(
+			selectedSession,
+			"selected-local-shared",
+			createdAt,
+			createdAt,
+			null,
+			"shared",
+			sourceScope,
+		);
+		insertMemory.run(
+			unrelatedSession,
+			"unrelated",
+			createdAt,
+			createdAt,
+			"unrelated",
+			"shared",
+			sourceScope,
+		);
+
+		const plan = planShareOperation({
+			inviterActorId: "actor-owner",
+			inviterDeviceIds: ["owner", "owner-proven"],
+			person: { kind: "pending", displayName: "Brian" },
+			projects: [
+				{
+					canonicalIdentity: remote,
+					displayName: "api",
+					identitySource: "git_remote",
+					existingMemoryCount: 2,
+				},
+			],
+			coordinatorGroupId: "team",
+			inviteExpiresAt: "2026-07-27T12:00:00.000Z",
+			createdAt,
+		});
+		operationId = plan.operationId;
+		persistShareOperation(db, plan, {
+			inviteId: "invite",
+			tokenDigest: inviteTokenDigest("token"),
+		});
+		const publicKey = "recipient-key";
+		reconcileShareOperationAcceptance(db, {
+			operationId,
+			coordinatorGroupId: "team",
+			reviewedProjectSetDigest: plan.reviewedProjectSetDigest,
+			recipientActorId: "actor-recipient",
+			recipientDisplayName: "Brian",
+			recipientDeviceId: "recipient",
+			recipientDeviceDisplayName: "Brian's MacBook",
+			recipientPublicKey: publicKey,
+			recipientFingerprint: fingerprintPublicKey(publicKey),
+			consumedAt: "2026-07-20T13:00:00.000Z",
+			trustState: "bootstrap_grant_created",
+			bootstrapGrantId: "grant",
+			projects: [{ canonical_identity: remote, display_name: "api", existing_memory_count: 2 }],
+		});
+	});
+
+	afterEach(() => db.close());
+
+	it("includes locally authored legacy origins without adopting replicated local sentinels", () => {
+		const localSessionId = Number(
+			db
+				.prepare(`INSERT INTO sessions(started_at, project, git_remote, user, tool_version)
+					VALUES (?, 'api', ?, 'adam', 'codemem')`)
+				.run(createdAt, remote).lastInsertRowid,
+		);
+		const replicatedSessionId = Number(
+			db
+				.prepare(`INSERT INTO sessions(started_at, project, git_remote, user, tool_version)
+					VALUES (?, 'api', ?, 'sync', 'sync_replication')`)
+				.run(createdAt, remote).lastInsertRowid,
+		);
+		const insertLegacy = db.prepare(`INSERT INTO memory_items(
+				session_id, kind, title, body_text, confidence, tags_text, active, created_at,
+				updated_at, metadata_json, import_key, rev, visibility, scope_id, origin_device_id
+			) VALUES (?, 'discovery', ?, 'body', 0.8, '', 1, ?, ?, '{}', ?, 1, 'shared',
+				'local-default', 'local')`);
+		const localMemoryId = Number(
+			insertLegacy.run(
+				localSessionId,
+				"locally authored legacy",
+				createdAt,
+				createdAt,
+				"legacy:local-owned",
+			).lastInsertRowid,
+		);
+		const replicatedMemoryId = Number(
+			insertLegacy.run(
+				replicatedSessionId,
+				"replicated legacy",
+				createdAt,
+				createdAt,
+				"legacy:peer-owned",
+			).lastInsertRowid,
+		);
+
+		expect(
+			countShareableProjectMemories(db, {
+				canonicalIdentity: remote,
+				initiatingDeviceId: "owner",
+			}),
+		).toBe(3);
+		db.prepare("UPDATE share_operations SET inviter_device_ids_json = '[\"owner\"]'").run();
+		const project = planShareProvisioning(db, {
+			operationId,
+			initiatingDeviceId: "owner",
+		}).projects[0];
+		expect(project?.memoryIds).toContain(localMemoryId);
+		expect(project?.memoryIds).not.toContain(replicatedMemoryId);
+	});
+
+	function dependencies(overrides: Partial<ShareProvisioningDependencies> = {}) {
+		const plan = planShareProvisioning(db, { operationId, initiatingDeviceId: "owner" });
+		const scopeId = plan.projects[0]?.boundaryId ?? "missing";
+		const deps: ShareProvisioningDependencies = {
+			createOrGetBoundary: vi.fn(async () => ({
+				scope_id: scopeId,
+				label: "api",
+				kind: "managed_project",
+				authority_type: "coordinator",
+				coordinator_id: "coord",
+				group_id: "team",
+				manifest_issuer_device_id: null,
+				membership_epoch: 1,
+				manifest_hash: null,
+				status: "active",
+				created_at: createdAt,
+				updated_at: createdAt,
+			})),
+			grantMembership: vi.fn(async ({ scopeId: grantedScope, deviceId, role }) => ({
+				scope_id: grantedScope,
+				device_id: deviceId,
+				role,
+				status: "active",
+				membership_epoch: 1,
+				coordinator_id: "coord",
+				group_id: "team",
+				manifest_issuer_device_id: null,
+				manifest_hash: null,
+				signed_manifest_json: null,
+				updated_at: createdAt,
+			})),
+			supportsReassignScope: vi.fn(async () => "supported"),
+			refreshAuthorization: vi.fn(async () => {
+				db.prepare(`INSERT OR REPLACE INTO replication_scopes(
+					scope_id, label, kind, authority_type, coordinator_id, group_id,
+					membership_epoch, status, created_at, updated_at
+				) VALUES (?, 'api', 'managed_project', 'coordinator', 'coord', 'team', 1, 'active', ?, ?)`).run(
+					scopeId,
+					createdAt,
+					createdAt,
+				);
+				for (const deviceId of ["owner", "owner-proven", "recipient"]) {
+					db.prepare(`INSERT OR REPLACE INTO scope_memberships(
+						scope_id, device_id, role, status, membership_epoch, coordinator_id, group_id, updated_at
+					) VALUES (?, ?, 'member', 'active', 1, 'coord', 'team', ?)`).run(
+						scopeId,
+						deviceId,
+						createdAt,
+					);
+				}
+				db.prepare(`INSERT OR REPLACE INTO scope_membership_cache_state(
+					coordinator_id, group_id, last_refresh_at, last_success_at, last_error, updated_at
+				) VALUES ('coord', 'team', ?, ?, NULL, ?)`).run(createdAt, createdAt, createdAt);
+			}),
+			runInitialSync: vi.fn(async () => {
+				expect(getCachedScopeAuthorization(db, { deviceId: "recipient", scopeId }).authorized).toBe(
+					true,
+				);
+				return { ok: true, perScopeResults: [{ scope_id: scopeId, ok: true }] };
+			}),
+			...overrides,
+		};
+		return { deps, scopeId };
+	}
+
+	it("derives bounded membership without inheriting unreviewed source members", () => {
+		const plan = planShareProvisioning(db, { operationId, initiatingDeviceId: "owner" });
+		expect(plan.projects[0]?.memberDeviceIds).toEqual(["owner", "owner-proven", "recipient"]);
+		expect(plan.projects[0]?.memoryIds).toHaveLength(2);
+		expect(plan.projects[0]?.localOnlyMemoryIds).toHaveLength(1);
+		expect(plan.projects[0]?.reassignedMemoryIds).toHaveLength(1);
+		expect(plan.requiredCapabilityDeviceIds).toEqual([
+			"owner",
+			"owner-filtered",
+			"owner-proven",
+			"recipient",
+			"unreviewed-source-member",
+		]);
+	});
+
+	it("fails closed when a reviewed inviter device no longer passes current project filters", () => {
+		db.prepare(
+			"UPDATE sync_peers SET projects_include_json = '[\"other\"]' WHERE peer_device_id = 'owner-proven'",
+		).run();
+		expect(() => planShareProvisioning(db, { operationId, initiatingDeviceId: "owner" })).toThrow(
+			"inviter_project_access_ambiguous",
+		);
+	});
+
+	it("fails capability preflight before any boundary, migration, or mapping mutation", async () => {
+		const supportsReassignScope = vi.fn(async (deviceId: string) =>
+			deviceId === "unreviewed-source-member" ? "unsupported" : "supported",
+		);
+		const { deps } = dependencies({ supportsReassignScope });
+		await expect(
+			executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps),
+		).rejects.toThrow("reassign_capability_required");
+		expect(deps.createOrGetBoundary).not.toHaveBeenCalled();
+		expect(
+			db
+				.prepare("SELECT scope_id FROM memory_items WHERE import_key = 'selected:shared'")
+				.pluck()
+				.get(),
+		).toBe("source-space");
+		expect(db.prepare("SELECT COUNT(*) FROM project_scope_mappings").pluck().get()).toBe(0);
+		expect(
+			db
+				.prepare(
+					"SELECT COUNT(*) FROM share_operation_steps WHERE step_key LIKE 'provisioning_member:%'",
+				)
+				.pluck()
+				.get(),
+		).toBe(0);
+		expect(supportsReassignScope).toHaveBeenCalledWith("unreviewed-source-member");
+	});
+
+	it("revalidates a persisted membership plan before retrying grants", async () => {
+		const { deps: baseline } = dependencies();
+		const firstAttempt = {
+			...baseline,
+			createOrGetBoundary: vi.fn(async () => {
+				throw new Error("boundary_unavailable");
+			}),
+		};
+		await expect(
+			executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, firstAttempt),
+		).rejects.toThrow("boundary_unavailable");
+		expect(
+			db
+				.prepare(
+					"SELECT COUNT(*) FROM share_operation_steps WHERE step_key LIKE 'provisioning_member:%'",
+				)
+				.pluck()
+				.get(),
+		).toBeGreaterThan(0);
+
+		db.prepare(
+			"UPDATE sync_peers SET projects_include_json = '[\"other\"]' WHERE peer_device_id = 'owner-proven'",
+		).run();
+		const grantMembership = vi.fn(baseline.grantMembership);
+		const retry = { ...baseline, grantMembership };
+		await expect(
+			executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, retry),
+		).rejects.toThrow("inviter_project_access_ambiguous");
+		expect(grantMembership).not.toHaveBeenCalled();
+	});
+
+	it("reopens capability preflight when the required device set changes", async () => {
+		const supportsReassignScope = vi.fn(async () => "supported" as const);
+		const { deps: baseline } = dependencies({ supportsReassignScope });
+		await expect(
+			executeShareProvisioning(
+				db,
+				{ operationId, initiatingDeviceId: "owner" },
+				{
+					...baseline,
+					createOrGetBoundary: vi.fn(async () => {
+						throw new Error("boundary_unavailable");
+					}),
+				},
+			),
+		).rejects.toThrow("boundary_unavailable");
+		expect(
+			db
+				.prepare(`SELECT status FROM share_operation_steps
+					WHERE operation_id = ? AND step_key = 'capability_preflight'`)
+				.pluck()
+				.get(operationId),
+		).toBe("completed");
+
+		db.prepare(`INSERT INTO scope_memberships(
+			scope_id, device_id, role, status, membership_epoch, coordinator_id, group_id, updated_at
+		) VALUES ('source-space', 'late-source-peer', 'member', 'active', 1, 'coord', 'team', ?)`).run(
+			createdAt,
+		);
+		db.prepare(`INSERT INTO sync_peers(
+			peer_device_id, projects_include_json, projects_exclude_json, created_at
+		) VALUES ('late-source-peer', '["api"]', '[]', ?)`).run(createdAt);
+		db.prepare("UPDATE share_operations SET state = 'needs_attention' WHERE operation_id = ?").run(
+			operationId,
+		);
+		supportsReassignScope.mockImplementation(async (deviceId) =>
+			deviceId === "late-source-peer" ? "unsupported" : "supported",
+		);
+		const { deps: retry } = dependencies({ supportsReassignScope });
+
+		await expect(
+			executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, retry),
+		).rejects.toThrow("reassign_capability_required");
+		expect(supportsReassignScope).toHaveBeenCalledWith("late-source-peer");
+		expect(retry.createOrGetBoundary).not.toHaveBeenCalled();
+		expect(db.prepare("SELECT state FROM share_operations").pluck().get()).toBe("accepted");
+	});
+
+	it("preflights legacy project-filtered peers for local-default reassignment", async () => {
+		const selectedSessionId = db
+			.prepare("SELECT id FROM sessions WHERE project = 'api' LIMIT 1")
+			.pluck()
+			.get() as number;
+		db.prepare(`INSERT INTO memory_items(
+				session_id, kind, title, body_text, confidence, tags_text, active, created_at,
+				updated_at, metadata_json, import_key, rev, visibility, scope_id
+			) VALUES (?, 'discovery', 'legacy default', 'body', 0.8, '', 1, ?, ?, '{}',
+				'selected:legacy-default', 1, 'shared', NULL)`).run(
+			selectedSessionId,
+			createdAt,
+			createdAt,
+		);
+		db.prepare(`INSERT INTO sync_peers(
+				peer_device_id, projects_include_json, projects_exclude_json, created_at
+			) VALUES ('legacy-default-peer', '["api"]', '[]', ?)`).run(createdAt);
+		db.prepare("UPDATE share_operations SET inviter_device_ids_json = '[\"owner\"]'").run();
+
+		const plan = planShareProvisioning(db, { operationId, initiatingDeviceId: "owner" });
+		expect(plan.requiredCapabilityDeviceIds).toContain("legacy-default-peer");
+
+		const supportsReassignScope = vi.fn(async (deviceId: string) =>
+			deviceId === "legacy-default-peer" ? "unsupported" : "supported",
+		);
+		const { deps } = dependencies({ supportsReassignScope });
+		await expect(
+			executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps),
+		).rejects.toThrow("reassign_capability_required");
+		expect(deps.createOrGetBoundary).not.toHaveBeenCalled();
+		expect(supportsReassignScope).toHaveBeenCalledWith("legacy-default-peer");
+	});
+
+	it("moves capability preflight to needs-attention after three failed attempts", async () => {
+		const { deps } = dependencies({ supportsReassignScope: vi.fn(async () => "unsupported") });
+
+		for (let attempt = 1; attempt <= 3; attempt += 1) {
+			await expect(
+				executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps),
+			).rejects.toThrow("reassign_capability_required");
+			expect(
+				db
+					.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+					.pluck()
+					.get(operationId),
+			).toBe(attempt === 3 ? "needs_attention" : "accepted");
+		}
+
+		expect(
+			db
+				.prepare(`SELECT status, attempt_count, safe_error_code FROM share_operation_steps
+					WHERE operation_id = ? AND step_key = 'capability_preflight'`)
+				.get(operationId),
+		).toEqual({
+			status: "failed",
+			attempt_count: 3,
+			safe_error_code: "reassign_capability_required",
+		});
+		expect(deps.createOrGetBoundary).not.toHaveBeenCalled();
+	});
+
+	it("keeps undetermined capability probes retryable while the device is offline", async () => {
+		const { deps } = dependencies({ supportsReassignScope: vi.fn(async () => "undetermined") });
+
+		for (let attempt = 1; attempt <= 4; attempt += 1) {
+			await expect(
+				executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps),
+			).rejects.toThrow("waiting_for_device");
+			expect(
+				db
+					.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+					.pluck()
+					.get(operationId),
+			).toBe("waiting_for_device");
+		}
+
+		expect(
+			db
+				.prepare(`SELECT status, attempt_count, safe_error_code FROM share_operation_steps
+					WHERE operation_id = ? AND step_key = 'capability_preflight'`)
+				.get(operationId),
+		).toEqual({ status: "failed", attempt_count: 4, safe_error_code: "waiting_for_device" });
+		expect(deps.createOrGetBoundary).not.toHaveBeenCalled();
+	});
+
+	it("rejects deterministic boundary reuse when authority or group conflicts", async () => {
+		const expectedScopeId = planShareProvisioning(db, {
+			operationId,
+			initiatingDeviceId: "owner",
+		}).projects[0]?.boundaryId;
+		if (!expectedScopeId) throw new Error("missing boundary fixture");
+		const { deps } = dependencies({
+			createOrGetBoundary: vi.fn(async () => ({
+				scope_id: expectedScopeId,
+				label: "api",
+				kind: "managed_project",
+				authority_type: "local",
+				coordinator_id: null,
+				group_id: "other-team",
+				manifest_issuer_device_id: null,
+				membership_epoch: 0,
+				manifest_hash: null,
+				status: "active",
+				created_at: createdAt,
+				updated_at: createdAt,
+			})),
+		});
+		await expect(
+			executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps),
+		).rejects.toThrow("managed_boundary_conflict");
+		expect(db.prepare("SELECT COUNT(*) FROM project_scope_mappings").pluck().get()).toBe(0);
+	});
+
+	it("migrates only selected memories, persists exact future mapping, refreshes, and observes scoped sync", async () => {
+		const { deps, scopeId } = dependencies();
+		await executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps);
+		expect(
+			vi
+				.mocked(deps.grantMembership)
+				.mock.calls.map(([grant]) => grant.deviceId)
+				.sort(),
+		).toEqual(["owner", "owner-proven", "recipient"]);
+		expect(db.prepare("SELECT title, scope_id FROM memory_items ORDER BY title").all()).toEqual([
+			{ title: "selected-local-shared", scope_id: scopeId },
+			{ title: "selected-private", scope_id: "source-space" },
+			{ title: "selected-shared", scope_id: scopeId },
+			{ title: "unrelated", scope_id: "source-space" },
+		]);
+		expect(
+			db.prepare("SELECT op_type FROM replication_ops WHERE entity_id = 'selected:private'").all(),
+		).toEqual([]);
+		expect(
+			db
+				.prepare(
+					"SELECT op_type, scope_id FROM replication_ops WHERE entity_id = 'selected:shared' ORDER BY scope_id",
+				)
+				.all(),
+		).toEqual([
+			{ op_type: "reassign_scope", scope_id: scopeId },
+			{ op_type: "reassign_scope", scope_id: "source-space" },
+		]);
+		expect(
+			db
+				.prepare(
+					"SELECT workspace_identity, project_pattern, scope_id, source FROM project_scope_mappings",
+				)
+				.get(),
+		).toEqual({
+			workspace_identity: remote,
+			project_pattern: remote,
+			scope_id: scopeId,
+			source: "share_operation",
+		});
+		expect(
+			db
+				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+				.pluck()
+				.get(operationId),
+		).toBe("active");
+	});
+
+	it("preserves completed effects and resumes from the failed grant", async () => {
+		let fail = true;
+		const { deps } = dependencies({
+			grantMembership: vi.fn(async ({ scopeId, deviceId, role }) => {
+				if (fail) {
+					fail = false;
+					throw new Error("grant_failed");
+				}
+				return {
+					scope_id: scopeId,
+					device_id: deviceId,
+					role,
+					status: "active",
+					membership_epoch: 1,
+					coordinator_id: "coord",
+					group_id: "team",
+					manifest_issuer_device_id: null,
+					manifest_hash: null,
+					signed_manifest_json: null,
+					updated_at: createdAt,
+				};
+			}),
+		});
+		await expect(
+			executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps),
+		).rejects.toThrow("grant_failed");
+		expect(
+			db
+				.prepare(`SELECT state FROM share_operations WHERE operation_id = ?`)
+				.pluck()
+				.get(operationId),
+		).toBe("provisioning");
+		expect(
+			db
+				.prepare(`SELECT status, attempt_count FROM share_operation_steps
+					WHERE operation_id = ? AND step_key LIKE 'space_grant:%' AND safe_error_code = 'grant_failed'`)
+				.get(operationId),
+		).toEqual({ status: "pending", attempt_count: 1 });
+		await executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps);
+		expect(deps.createOrGetBoundary).toHaveBeenCalledTimes(1);
+		expect(
+			db
+				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+				.pluck()
+				.get(operationId),
+		).toBe("active");
+	});
+
+	it("moves a non-device provisioning step to needs-attention after three failed attempts", async () => {
+		const { deps } = dependencies({
+			grantMembership: vi.fn(async () => {
+				throw new Error("grant_failed");
+			}),
+		});
+
+		for (let attempt = 1; attempt <= 3; attempt += 1) {
+			await expect(
+				executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps),
+			).rejects.toThrow("grant_failed");
+			expect(
+				db
+					.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+					.pluck()
+					.get(operationId),
+			).toBe(attempt === 3 ? "needs_attention" : "provisioning");
+		}
+
+		expect(
+			db
+				.prepare(`SELECT status, attempt_count, safe_error_code FROM share_operation_steps
+					WHERE operation_id = ? AND step_key LIKE 'space_grant:%' AND safe_error_code = 'grant_failed'`)
+				.get(operationId),
+		).toEqual({ status: "failed", attempt_count: 3, safe_error_code: "grant_failed" });
+	});
+
+	it("waits for an offline device and resumes initial sync without repeating completed work", async () => {
+		// Arrange
+		let offline = true;
+		const { deps } = dependencies({
+			runInitialSync: vi.fn(async () => {
+				if (offline) {
+					offline = false;
+					return { ok: false, failureCategory: "connectivity" };
+				}
+				const scopeId = planShareProvisioning(db, {
+					operationId,
+					initiatingDeviceId: "owner",
+				}).projects[0]?.boundaryId;
+				return { ok: true, perScopeResults: [{ scope_id: scopeId ?? "missing", ok: true }] };
+			}),
+		});
+
+		// Act
+		await expect(
+			executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps),
+		).rejects.toThrow("waiting_for_device");
+
+		// Assert
+		expect(
+			db
+				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+				.pluck()
+				.get(operationId),
+		).toBe("waiting_for_device");
+		expect(
+			db
+				.prepare(
+					"SELECT status, safe_error_code FROM share_operation_steps WHERE operation_id = ? AND step_key = 'initial_sync'",
+				)
+				.get(operationId),
+		).toEqual({ status: "failed", safe_error_code: "waiting_for_device" });
+		const completedCounts = {
+			boundaries: vi.mocked(deps.createOrGetBoundary).mock.calls.length,
+			grants: vi.mocked(deps.grantMembership).mock.calls.length,
+			refreshes: vi.mocked(deps.refreshAuthorization).mock.calls.length,
+			reassignments: Number(
+				db
+					.prepare("SELECT COUNT(*) FROM replication_ops WHERE op_type = 'reassign_scope'")
+					.pluck()
+					.get(),
+			),
+		};
+
+		// Act
+		await executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps);
+
+		// Assert
+		expect(
+			db
+				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+				.pluck()
+				.get(operationId),
+		).toBe("active");
+		expect(vi.mocked(deps.runInitialSync)).toHaveBeenCalledTimes(2);
+		expect(vi.mocked(deps.createOrGetBoundary)).toHaveBeenCalledTimes(completedCounts.boundaries);
+		expect(vi.mocked(deps.grantMembership)).toHaveBeenCalledTimes(completedCounts.grants);
+		expect(vi.mocked(deps.refreshAuthorization)).toHaveBeenCalledTimes(completedCounts.refreshes);
+		expect(
+			Number(
+				db
+					.prepare("SELECT COUNT(*) FROM replication_ops WHERE op_type = 'reassign_scope'")
+					.pluck()
+					.get(),
+			),
+		).toBe(completedCounts.reassignments);
+		expect(db.prepare("SELECT COUNT(*) FROM project_scope_mappings").pluck().get()).toBe(1);
+	});
+
+	it("preserves a pre-existing step effect_id while executing it", async () => {
+		// Arrange
+		const preservedEffectId = "persisted-effect-before-resume";
+		db.prepare(
+			"UPDATE share_operation_steps SET effect_id = ? WHERE operation_id = ? AND step_key = 'authorization_refresh'",
+		).run(preservedEffectId, operationId);
+		const { deps } = dependencies();
+
+		// Act
+		await executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps);
+
+		// Assert
+		expect(
+			db
+				.prepare(
+					"SELECT effect_id, status FROM share_operation_steps WHERE operation_id = ? AND step_key = 'authorization_refresh'",
+				)
+				.get(operationId),
+		).toEqual({ effect_id: preservedEffectId, status: "completed" });
+	});
+
+	it("resumes idempotently across migration, mapping, refresh, and initial-sync failures", async () => {
+		const failures = [
+			"memory_reassignment:",
+			"project_assignment:",
+			"authorization_refresh",
+			"initial_sync",
+		];
+		const { deps } = dependencies({
+			beforeStep: vi.fn((stepKey) => {
+				const next = failures[0];
+				if (next && stepKey.startsWith(next)) {
+					failures.shift();
+					throw new Error(`${next}failed`);
+				}
+			}),
+		});
+		for (const expected of [
+			"memory_reassignment:failed",
+			"project_assignment:failed",
+			"authorization_refreshfailed",
+			"initial_syncfailed",
+		]) {
+			await expect(
+				executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps),
+			).rejects.toThrow(expected);
+		}
+		await executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps);
+		expect(failures).toEqual([]);
+		expect(
+			db
+				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+				.pluck()
+				.get(operationId),
+		).toBe("active");
+	});
+});

--- a/packages/core/src/share-provisioning.ts
+++ b/packages/core/src/share-provisioning.ts
@@ -1,0 +1,739 @@
+import { createHash } from "node:crypto";
+import type { CoordinatorScope, CoordinatorScopeMembership } from "./coordinator-store-contract.js";
+import { type Database, fromJson } from "./db.js";
+import { canonicalWorkspaceIdentity } from "./scope-resolution.js";
+import {
+	DEFAULT_SYNC_SCOPE_ID,
+	recordReplicationOp,
+	recordScopeReassignment,
+	syncProjectAllowed,
+	syncProjectAllowedByFilters,
+} from "./sync-replication.js";
+
+export interface ManagedProjectPlan {
+	canonicalIdentity: string;
+	displayName: string;
+	boundaryId: string;
+	memoryIds: number[];
+	localOnlyMemoryIds: number[];
+	reassignedMemoryIds: number[];
+	memberDeviceIds: string[];
+	reassignmentSourceDeviceIds: string[];
+}
+
+export interface ShareProvisioningPlan {
+	operationId: string;
+	groupId: string;
+	recipientDeviceId: string;
+	projects: ManagedProjectPlan[];
+	requiredCapabilityDeviceIds: string[];
+}
+
+export type ReassignScopeCapability = "supported" | "unsupported" | "undetermined";
+
+export interface ShareProvisioningDependencies {
+	beforeStep?(stepKey: string): Promise<void> | void;
+	createOrGetBoundary(project: ManagedProjectPlan, groupId: string): Promise<CoordinatorScope>;
+	grantMembership(input: {
+		groupId: string;
+		scopeId: string;
+		deviceId: string;
+		role: "admin" | "member";
+	}): Promise<CoordinatorScopeMembership>;
+	supportsReassignScope(deviceId: string): Promise<ReassignScopeCapability>;
+	refreshAuthorization(groupId: string): Promise<void>;
+	runInitialSync(recipientDeviceId: string): Promise<{
+		ok: boolean;
+		failureCategory?: string;
+		perScopeResults?: Array<{ scope_id: string; ok: boolean; error?: string }>;
+	}>;
+}
+
+interface OperationRow {
+	operation_id: string;
+	state: string;
+	inviter_device_ids_json: string;
+	coordinator_group_id: string;
+	recipient_device_id: string | null;
+}
+
+interface ProjectRow {
+	canonical_project_identity: string;
+	display_name: string;
+}
+
+interface MemoryCandidateRow {
+	id: number;
+	import_key: string | null;
+	visibility: string | null;
+	scope_id: string | null;
+	project: string | null;
+	cwd: string | null;
+	git_remote: string | null;
+	git_branch: string | null;
+	workspace_id: string | null;
+	origin_device_id: string | null;
+	session_user: string | null;
+	session_tool_version: string | null;
+}
+
+function clean(value: unknown): string | null {
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function parseStringList(value: string): string[] {
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return Array.isArray(parsed)
+			? [...new Set(parsed.map(clean).filter((item): item is string => item != null))].toSorted()
+			: [];
+	} catch {
+		return [];
+	}
+}
+
+function peerFilters(
+	db: Database,
+	deviceId: string,
+): { include: string[]; exclude: string[] } | null {
+	const row = db
+		.prepare(
+			"SELECT projects_include_json, projects_exclude_json FROM sync_peers WHERE peer_device_id = ?",
+		)
+		.get(deviceId) as
+		| { projects_include_json: string | null; projects_exclude_json: string | null }
+		| undefined;
+	if (!row) return null;
+	const list = (raw: string | null): string[] | null => {
+		if (raw == null) return [];
+		try {
+			const parsed = JSON.parse(raw) as unknown;
+			if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) return null;
+			return parsed;
+		} catch {
+			return null;
+		}
+	};
+	const include = list(row.projects_include_json);
+	const exclude = list(row.projects_exclude_json);
+	return include && exclude ? { include, exclude } : null;
+}
+
+function memoryCandidates(db: Database): MemoryCandidateRow[] {
+	return db
+		.prepare(`SELECT mi.id, mi.import_key, mi.visibility, mi.scope_id, mi.origin_device_id,
+			COALESCE(mi.project, s.project) AS project, s.cwd, s.git_remote, s.git_branch,
+			mi.workspace_id, s.user AS session_user, s.tool_version AS session_tool_version
+		 FROM memory_items mi
+		 JOIN sessions s ON s.id = mi.session_id
+		 WHERE mi.active = 1`)
+		.all() as MemoryCandidateRow[];
+}
+
+function neverReplicationEligible(db: Database, row: MemoryCandidateRow): boolean {
+	if (row.import_key) return false;
+	return !db
+		.prepare(
+			"SELECT 1 FROM replication_ops WHERE entity_type = 'memory_item' AND entity_id = ? LIMIT 1",
+		)
+		.get(String(row.id));
+}
+
+function shareableForManagedProject(row: MemoryCandidateRow): boolean {
+	const visibility = clean(row.visibility)?.toLowerCase() ?? "";
+	return !visibility.startsWith("private") && !visibility.startsWith("personal");
+}
+
+function isInitiatingDeviceMemory(row: MemoryCandidateRow, initiatingDeviceId: string): boolean {
+	const originDeviceId = clean(row.origin_device_id);
+	if (!originDeviceId || originDeviceId === initiatingDeviceId) return true;
+	if (originDeviceId !== "local") return false;
+	return (
+		clean(row.session_user) !== "sync" && clean(row.session_tool_version) !== "sync_replication"
+	);
+}
+
+export function countShareableProjectMemories(
+	db: Database,
+	input: { canonicalIdentity: string; initiatingDeviceId: string },
+): number {
+	return memoryCandidates(db).filter((row) => {
+		if (!shareableForManagedProject(row)) return false;
+		if (!isInitiatingDeviceMemory(row, input.initiatingDeviceId)) return false;
+		return (
+			canonicalWorkspaceIdentity({
+				gitRemote: row.git_remote,
+				gitBranch: row.git_branch,
+				cwd: row.cwd,
+				project: row.project,
+				workspaceId: row.workspace_id,
+			}).value === input.canonicalIdentity
+		);
+	}).length;
+}
+
+function effectiveInviterDevices(
+	db: Database,
+	input: {
+		initiatingDeviceId: string;
+		inviterDeviceIds: string[];
+		sourceScopeIds: string[];
+		projectNames: string[];
+	},
+): string[] {
+	const allowed = new Set([input.initiatingDeviceId]);
+	for (const deviceId of input.inviterDeviceIds) {
+		if (deviceId === input.initiatingDeviceId) continue;
+		const filters = peerFilters(db, deviceId);
+		if (!filters || input.projectNames.length === 0) {
+			throw new Error("inviter_project_access_ambiguous");
+		}
+		const membershipsAreExact = input.sourceScopeIds.every((scopeId) =>
+			db
+				.prepare(`SELECT 1 FROM scope_memberships
+				 WHERE scope_id = ? AND device_id = ? AND status = 'active' LIMIT 1`)
+				.get(scopeId, deviceId),
+		);
+		const filtersAllowEveryName = input.projectNames.every((project) =>
+			syncProjectAllowedByFilters(project, filters),
+		);
+		if (!membershipsAreExact || !filtersAllowEveryName) {
+			throw new Error("inviter_project_access_ambiguous");
+		}
+		allowed.add(deviceId);
+	}
+	return [...allowed].toSorted();
+}
+
+function persistedProjectMembers(
+	db: Database,
+	operationId: string,
+	canonicalIdentity: string,
+): string[] {
+	const prefix = `provisioning_member:${canonicalIdentity}:`;
+	return (
+		db
+			.prepare(`SELECT step_key FROM share_operation_steps
+			 WHERE operation_id = ? AND status = 'completed' AND step_key LIKE 'provisioning_member:%'`)
+			.all(operationId) as Array<{ step_key: string }>
+	)
+		.map((row) => row.step_key)
+		.filter((stepKey) => stepKey.startsWith(prefix))
+		.map((stepKey) => clean(stepKey.slice(prefix.length)))
+		.filter((deviceId): deviceId is string => deviceId != null)
+		.toSorted();
+}
+
+function activeScopeMemberDeviceIds(db: Database, scopeIds: string[]): string[] {
+	const members = new Set<string>();
+	for (const scopeId of scopeIds) {
+		for (const row of db
+			.prepare(`SELECT device_id FROM scope_memberships
+				WHERE scope_id = ? AND status = 'active'`)
+			.all(scopeId) as Array<{ device_id: string }>) {
+			const deviceId = clean(row.device_id);
+			if (deviceId) members.add(deviceId);
+		}
+	}
+	return [...members].toSorted();
+}
+
+function projectAllowedPeerDeviceIds(db: Database, projectValues: Array<string | null>): string[] {
+	if (projectValues.length === 0) return [];
+	return (
+		db.prepare("SELECT peer_device_id FROM sync_peers").all() as Array<{
+			peer_device_id: string;
+		}>
+	)
+		.map((row) => clean(row.peer_device_id))
+		.filter(
+			(deviceId): deviceId is string =>
+				deviceId != null &&
+				projectValues.some((project) => syncProjectAllowed(db, project, deviceId)),
+		)
+		.toSorted();
+}
+
+export function planShareProvisioning(
+	db: Database,
+	input: { operationId: string; initiatingDeviceId: string },
+): ShareProvisioningPlan {
+	const operation = db
+		.prepare(`SELECT operation_id, state, inviter_device_ids_json, coordinator_group_id,
+			recipient_device_id FROM share_operations WHERE operation_id = ?`)
+		.get(input.operationId) as OperationRow | undefined;
+	if (!operation) throw new Error("operation_not_found");
+	if (
+		![
+			"accepted",
+			"provisioning",
+			"initial_sync",
+			"active",
+			"needs_attention",
+			"waiting_for_device",
+		].includes(operation.state)
+	) {
+		throw new Error("operation_not_accepted");
+	}
+	const recipientDeviceId = clean(operation.recipient_device_id);
+	const initiatingDeviceId = clean(input.initiatingDeviceId);
+	if (!recipientDeviceId || !initiatingDeviceId)
+		throw new Error("operation_device_binding_missing");
+	const inviterDeviceIds = parseStringList(operation.inviter_device_ids_json);
+	if (!inviterDeviceIds.includes(initiatingDeviceId))
+		throw new Error("initiating_device_not_reviewed");
+	const projects = db
+		.prepare(`SELECT canonical_project_identity, display_name FROM share_operation_projects
+		 WHERE operation_id = ? ORDER BY ordinal`)
+		.all(operation.operation_id) as ProjectRow[];
+	if (projects.length === 0) throw new Error("operation_intent_invalid");
+	const candidates = memoryCandidates(db);
+	const plans = projects.map((project): ManagedProjectPlan => {
+		const matched = candidates.filter((row) => {
+			if (!shareableForManagedProject(row)) return false;
+			if (!isInitiatingDeviceMemory(row, initiatingDeviceId)) return false;
+			const identity = canonicalWorkspaceIdentity({
+				gitRemote: row.git_remote,
+				gitBranch: row.git_branch,
+				cwd: row.cwd,
+				project: row.project,
+				workspaceId: row.workspace_id,
+			});
+			return identity.value === project.canonical_project_identity;
+		});
+		const sourceScopeIds = [
+			...new Set(matched.map((row) => clean(row.scope_id) ?? "local-default")),
+		].toSorted();
+		const projectNames = [
+			...new Set(
+				matched.map((row) => clean(row.project)).filter((item): item is string => item != null),
+			),
+		].toSorted();
+		const persistedMembers = persistedProjectMembers(
+			db,
+			operation.operation_id,
+			project.canonical_project_identity,
+		);
+		const persistedMembersNeedValidation = persistedMembers.some(
+			(deviceId) =>
+				stepStatus(
+					db,
+					operation.operation_id,
+					`space_grant:${project.canonical_project_identity}:${deviceId}`,
+				) !== "completed",
+		);
+		const currentMemberDeviceIds =
+			persistedMembers.length === 0 || persistedMembersNeedValidation
+				? [
+						...effectiveInviterDevices(db, {
+							initiatingDeviceId,
+							inviterDeviceIds,
+							sourceScopeIds,
+							projectNames,
+						}),
+						recipientDeviceId,
+					]
+				: persistedMembers;
+		if (
+			persistedMembers.length > 0 &&
+			persistedMembers.some((deviceId) => !currentMemberDeviceIds.includes(deviceId))
+		) {
+			throw new Error("inviter_project_access_ambiguous");
+		}
+		const memberDeviceIds = persistedMembers.length > 0 ? persistedMembers : currentMemberDeviceIds;
+		if (
+			!memberDeviceIds.includes(initiatingDeviceId) ||
+			!memberDeviceIds.includes(recipientDeviceId)
+		) {
+			throw new Error("provisioning_membership_plan_invalid");
+		}
+		if (
+			memberDeviceIds.some(
+				(deviceId) => deviceId !== recipientDeviceId && !inviterDeviceIds.includes(deviceId),
+			)
+		) {
+			throw new Error("provisioning_membership_plan_invalid");
+		}
+		const boundaryId = db
+			.prepare(`SELECT effect_id FROM share_operation_steps
+				WHERE operation_id = ? AND step_key = ?`)
+			.pluck()
+			.get(
+				operation.operation_id,
+				`managed_boundary:${project.canonical_project_identity}`,
+			) as string;
+		const localOnlyRows = matched.filter((row) => neverReplicationEligible(db, row));
+		const reassignedRows = matched.filter((row) => !neverReplicationEligible(db, row));
+		const reassignmentScopeIds = [
+			...new Set(
+				reassignedRows
+					.map((row) => clean(row.scope_id) ?? DEFAULT_SYNC_SCOPE_ID)
+					.filter((scopeId) => scopeId !== boundaryId),
+			),
+		];
+		const legacyDefaultProjects = reassignedRows
+			.filter(
+				(row) =>
+					(clean(row.scope_id) ?? DEFAULT_SYNC_SCOPE_ID) === DEFAULT_SYNC_SCOPE_ID &&
+					DEFAULT_SYNC_SCOPE_ID !== boundaryId,
+			)
+			.map((row) => clean(row.project));
+		const reassignmentSourceDeviceIds = [
+			...new Set([
+				...activeScopeMemberDeviceIds(
+					db,
+					reassignmentScopeIds.filter((scopeId) => scopeId !== DEFAULT_SYNC_SCOPE_ID),
+				),
+				...projectAllowedPeerDeviceIds(db, legacyDefaultProjects),
+			]),
+		].toSorted();
+		return {
+			canonicalIdentity: project.canonical_project_identity,
+			displayName: project.display_name,
+			boundaryId,
+			memoryIds: matched.map((row) => row.id).toSorted((a, b) => a - b),
+			localOnlyMemoryIds: localOnlyRows.map((row) => row.id).toSorted((a, b) => a - b),
+			reassignedMemoryIds: reassignedRows.map((row) => row.id).toSorted((a, b) => a - b),
+			memberDeviceIds: [...new Set(memberDeviceIds)].toSorted(),
+			reassignmentSourceDeviceIds,
+		};
+	});
+	if (plans.some((project) => !clean(project.boundaryId)))
+		throw new Error("managed_boundary_plan_missing");
+	return {
+		operationId: operation.operation_id,
+		groupId: operation.coordinator_group_id,
+		recipientDeviceId,
+		projects: plans,
+		requiredCapabilityDeviceIds: [
+			...new Set(
+				plans
+					.filter((project) => project.reassignedMemoryIds.length > 0)
+					.flatMap((project) => [
+						...project.memberDeviceIds,
+						...project.reassignmentSourceDeviceIds,
+					]),
+			),
+		].toSorted(),
+	};
+}
+
+function persistMembershipPlan(db: Database, plan: ShareProvisioningPlan): void {
+	const now = new Date().toISOString();
+	db.transaction(() => {
+		for (const project of plan.projects) {
+			for (const deviceId of project.memberDeviceIds) {
+				const stepKey = `provisioning_member:${project.canonicalIdentity}:${deviceId}`;
+				const effectId = `provisioning-member:${plan.operationId}:${project.canonicalIdentity}:${deviceId}`;
+				db.prepare(`INSERT OR IGNORE INTO share_operation_steps(
+					operation_id, step_key, effect_id, status, attempt_count, started_at,
+					completed_at, last_attempt_at, updated_at
+				) VALUES (?, ?, ?, 'completed', 1, ?, ?, ?, ?)`).run(
+					plan.operationId,
+					stepKey,
+					effectId,
+					now,
+					now,
+					now,
+					now,
+				);
+			}
+		}
+	})();
+}
+
+function ensureStep(
+	db: Database,
+	operationId: string,
+	stepKey: string,
+	effectId: string,
+	now: string,
+): void {
+	db.prepare(`INSERT OR IGNORE INTO share_operation_steps(
+		operation_id, step_key, effect_id, status, attempt_count, updated_at
+	) VALUES (?, ?, ?, 'pending', 0, ?)`).run(operationId, stepKey, effectId, now);
+}
+
+function stepStatus(db: Database, operationId: string, stepKey: string): string | null {
+	return (
+		(db
+			.prepare("SELECT status FROM share_operation_steps WHERE operation_id = ? AND step_key = ?")
+			.pluck()
+			.get(operationId, stepKey) as string | undefined) ?? null
+	);
+}
+
+function startStep(db: Database, operationId: string, stepKey: string, now: string): void {
+	db.prepare(`UPDATE share_operation_steps SET status = 'running', attempt_count = attempt_count + 1,
+		started_at = COALESCE(started_at, ?), last_attempt_at = ?, safe_error_code = NULL, updated_at = ?
+		WHERE operation_id = ? AND step_key = ?`).run(now, now, now, operationId, stepKey);
+}
+
+function finishStep(db: Database, operationId: string, stepKey: string, now: string): void {
+	db.prepare(`UPDATE share_operation_steps SET status = 'completed', completed_at = ?,
+		last_attempt_at = ?, safe_error_code = NULL, updated_at = ?
+		WHERE operation_id = ? AND step_key = ?`).run(now, now, now, operationId, stepKey);
+}
+
+function failStep(
+	db: Database,
+	operationId: string,
+	stepKey: string,
+	code: string,
+	now: string,
+): void {
+	const failed = db
+		.prepare(`UPDATE share_operation_steps SET
+			status = CASE WHEN ? = 'waiting_for_device' OR attempt_count >= 3 THEN 'failed' ELSE 'pending' END,
+			last_attempt_at = ?, safe_error_code = ?, updated_at = ?
+			WHERE operation_id = ? AND step_key = ? RETURNING attempt_count`)
+		.get(code, now, code, now, operationId, stepKey) as { attempt_count: number } | undefined;
+	const state =
+		code === "waiting_for_device"
+			? "waiting_for_device"
+			: Number(failed?.attempt_count ?? 0) >= 3
+				? "needs_attention"
+				: null;
+	if (state) {
+		db.prepare("UPDATE share_operations SET state = ?, updated_at = ? WHERE operation_id = ?").run(
+			state,
+			now,
+			operationId,
+		);
+	} else {
+		db.prepare("UPDATE share_operations SET updated_at = ? WHERE operation_id = ?").run(
+			now,
+			operationId,
+		);
+	}
+}
+
+function persistedEffectId(
+	db: Database,
+	operationId: string,
+	stepKey: string,
+	fallback: string,
+): string {
+	return (
+		clean(
+			db
+				.prepare(
+					"SELECT effect_id FROM share_operation_steps WHERE operation_id = ? AND step_key = ?",
+				)
+				.pluck()
+				.get(operationId, stepKey),
+		) ?? fallback
+	);
+}
+
+function capabilityPreflightEffectId(plan: ShareProvisioningPlan): string {
+	const deviceSetDigest = createHash("sha256")
+		.update(JSON.stringify(plan.requiredCapabilityDeviceIds))
+		.digest("hex");
+	return `capability:${plan.operationId}:${deviceSetDigest}`;
+}
+
+function reopenStepWhenEffectChanges(
+	db: Database,
+	operationId: string,
+	stepKey: string,
+	effectId: string,
+): void {
+	const now = new Date().toISOString();
+	const reopened = db
+		.prepare(`UPDATE share_operation_steps SET effect_id = ?, status = 'pending', attempt_count = 0,
+		started_at = NULL, completed_at = NULL, last_attempt_at = NULL, safe_error_code = NULL,
+		updated_at = ? WHERE operation_id = ? AND step_key = ? AND effect_id <> ?`)
+		.run(effectId, now, operationId, stepKey, effectId);
+	if (reopened.changes > 0) {
+		db.prepare(`UPDATE share_operations SET state = 'accepted', updated_at = ?
+			WHERE operation_id = ? AND state = 'needs_attention'`).run(now, operationId);
+	}
+}
+
+async function runStep(
+	db: Database,
+	operationId: string,
+	stepKey: string,
+	effectId: string,
+	work: () => Promise<void> | void,
+): Promise<void> {
+	const now = new Date().toISOString();
+	ensureStep(db, operationId, stepKey, effectId, now);
+	if (stepStatus(db, operationId, stepKey) === "completed") return;
+	startStep(db, operationId, stepKey, now);
+	try {
+		await work();
+		finishStep(db, operationId, stepKey, new Date().toISOString());
+	} catch (error) {
+		const code =
+			clean(error instanceof Error ? error.message : String(error)) ?? "provisioning_failed";
+		failStep(db, operationId, stepKey, code, new Date().toISOString());
+		throw error;
+	}
+}
+
+function localReassign(db: Database, memoryIds: number[], scopeId: string, deviceId: string): void {
+	const now = new Date().toISOString();
+	db.transaction(() => {
+		for (const memoryId of memoryIds) {
+			const row = db
+				.prepare("SELECT scope_id, rev, metadata_json FROM memory_items WHERE id = ?")
+				.get(memoryId) as
+				| { scope_id: string | null; rev: number | null; metadata_json: string | null }
+				| undefined;
+			if (!row || clean(row.scope_id) === scopeId) continue;
+			const metadata = fromJson(row.metadata_json);
+			metadata.clock_device_id = deviceId;
+			db.prepare(`UPDATE memory_items SET scope_id = ?, rev = COALESCE(rev, 0) + 1,
+				updated_at = ?, metadata_json = ? WHERE id = ?`).run(
+				scopeId,
+				now,
+				JSON.stringify(metadata),
+				memoryId,
+			);
+			recordReplicationOp(db, { memoryId, opType: "upsert", deviceId, scopeId, createdAt: now });
+		}
+	})();
+}
+
+function exactMapping(db: Database, project: ManagedProjectPlan): void {
+	const existing = db
+		.prepare(`SELECT id, scope_id FROM project_scope_mappings
+		 WHERE workspace_identity = ? ORDER BY priority DESC, updated_at DESC, id DESC LIMIT 1`)
+		.get(project.canonicalIdentity) as { id: number; scope_id: string } | undefined;
+	if (existing && existing.scope_id !== project.boundaryId)
+		throw new Error("project_mapping_conflict");
+	if (existing) return;
+	const now = new Date().toISOString();
+	db.prepare(`INSERT INTO project_scope_mappings(
+		workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+	) VALUES (?, ?, ?, 1000, 'share_operation', ?, ?)`).run(
+		project.canonicalIdentity,
+		project.canonicalIdentity,
+		project.boundaryId,
+		now,
+		now,
+	);
+}
+
+export async function executeShareProvisioning(
+	db: Database,
+	input: { operationId: string; initiatingDeviceId: string },
+	dependencies: ShareProvisioningDependencies,
+): Promise<ShareProvisioningPlan> {
+	const plan = planShareProvisioning(db, input);
+	const executeStep = (
+		stepKey: string,
+		effectId: string,
+		work: () => Promise<void> | void,
+	): Promise<void> =>
+		runStep(
+			db,
+			plan.operationId,
+			stepKey,
+			persistedEffectId(db, plan.operationId, stepKey, effectId),
+			async () => {
+				await dependencies.beforeStep?.(stepKey);
+				await work();
+			},
+		);
+	const capabilityEffectId = capabilityPreflightEffectId(plan);
+	reopenStepWhenEffectChanges(db, plan.operationId, "capability_preflight", capabilityEffectId);
+	await runStep(db, plan.operationId, "capability_preflight", capabilityEffectId, async () => {
+		await dependencies.beforeStep?.("capability_preflight");
+		for (const deviceId of plan.requiredCapabilityDeviceIds) {
+			const capability = await dependencies.supportsReassignScope(deviceId);
+			if (capability === "unsupported") throw new Error("reassign_capability_required");
+			if (capability === "undetermined") throw new Error("waiting_for_device");
+		}
+	});
+	persistMembershipPlan(db, plan);
+	db.prepare(
+		"UPDATE share_operations SET state = 'provisioning', updated_at = ? WHERE operation_id = ?",
+	).run(new Date().toISOString(), plan.operationId);
+	for (const project of plan.projects) {
+		await executeStep(
+			`managed_boundary:${project.canonicalIdentity}`,
+			project.boundaryId,
+			async () => {
+				const scope = await dependencies.createOrGetBoundary(project, plan.groupId);
+				if (
+					scope.scope_id !== project.boundaryId ||
+					scope.group_id !== plan.groupId ||
+					scope.kind !== "managed_project" ||
+					scope.authority_type !== "coordinator" ||
+					scope.status !== "active"
+				) {
+					throw new Error("managed_boundary_conflict");
+				}
+			},
+		);
+		for (const deviceId of project.memberDeviceIds) {
+			const stepKey = `space_grant:${project.canonicalIdentity}:${deviceId}`;
+			const expectedRole = deviceId === input.initiatingDeviceId ? "admin" : "member";
+			await executeStep(stepKey, `space-grant:${project.boundaryId}:${deviceId}:1`, async () => {
+				const membership = await dependencies.grantMembership({
+					groupId: plan.groupId,
+					scopeId: project.boundaryId,
+					deviceId,
+					role: expectedRole,
+				});
+				if (
+					membership.scope_id !== project.boundaryId ||
+					membership.device_id !== deviceId ||
+					membership.role !== expectedRole ||
+					membership.status !== "active"
+				) {
+					throw new Error("managed_grant_conflict");
+				}
+			});
+		}
+		await executeStep(
+			`memory_reassignment:${project.canonicalIdentity}`,
+			`memory-reassignment:${plan.operationId}:${project.canonicalIdentity}`,
+			() => {
+				localReassign(db, project.localOnlyMemoryIds, project.boundaryId, input.initiatingDeviceId);
+				for (const memoryId of project.reassignedMemoryIds) {
+					const oldScopeId =
+						clean(
+							db.prepare("SELECT scope_id FROM memory_items WHERE id = ?").pluck().get(memoryId) as
+								| string
+								| null,
+						) ?? "local-default";
+					if (oldScopeId === project.boundaryId) continue;
+					recordScopeReassignment(db, {
+						operationId: plan.operationId,
+						memoryId,
+						oldScopeId,
+						newScopeId: project.boundaryId,
+						deviceId: input.initiatingDeviceId,
+					});
+				}
+			},
+		);
+		await executeStep(`project_assignment:${project.canonicalIdentity}`, project.boundaryId, () =>
+			exactMapping(db, project),
+		);
+	}
+	await executeStep("authorization_refresh", `refresh:${plan.operationId}`, () =>
+		dependencies.refreshAuthorization(plan.groupId),
+	);
+	db.prepare(
+		"UPDATE share_operations SET state = 'initial_sync', updated_at = ? WHERE operation_id = ?",
+	).run(new Date().toISOString(), plan.operationId);
+	await executeStep("initial_sync", `initial-sync:${plan.operationId}`, async () => {
+		const result = await dependencies.runInitialSync(plan.recipientDeviceId);
+		if (!result.ok && result.failureCategory === "connectivity") {
+			throw new Error("waiting_for_device");
+		}
+		for (const project of plan.projects) {
+			const scoped = result.perScopeResults?.find((item) => item.scope_id === project.boundaryId);
+			if (!scoped?.ok) throw new Error(scoped?.error || "initial_sync_scope_incomplete");
+		}
+	});
+	db.prepare(
+		"UPDATE share_operations SET state = 'active', updated_at = ? WHERE operation_id = ?",
+	).run(new Date().toISOString(), plan.operationId);
+	return plan;
+}

--- a/packages/core/src/sync-capability.test.ts
+++ b/packages/core/src/sync-capability.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import {
+	LOCAL_SYNC_CAPABILITY,
+	negotiateSyncCapability,
+	normalizeSyncFeatures,
+	supportsSyncFeature,
+} from "./sync-capability.js";
+
+describe("additive sync features", () => {
+	it("keeps the existing capability rank while negotiating reassign_scope independently", () => {
+		expect(LOCAL_SYNC_CAPABILITY).toBe("scoped");
+		expect(negotiateSyncCapability(LOCAL_SYNC_CAPABILITY, "aware")).toBe("aware");
+		expect(normalizeSyncFeatures(undefined)).toEqual([]);
+		expect(normalizeSyncFeatures(["reassign_scope", "unknown"])).toEqual(["reassign_scope"]);
+		expect(supportsSyncFeature("reassign_scope", "reassign_scope")).toBe(true);
+	});
+});

--- a/packages/core/src/sync-capability.ts
+++ b/packages/core/src/sync-capability.ts
@@ -10,7 +10,28 @@ export const SYNC_CAPABILITIES = ["unsupported", "aware", "enforcing", "scoped"]
 
 export const SYNC_CAPABILITY_HEADER = "X-Codemem-Sync-Capability";
 
+export const SYNC_FEATURES_HEADER = "X-Codemem-Sync-Features";
+export const SYNC_AUTHORIZATION_REFRESH_HEADER = "X-Codemem-Refresh-Authorization";
+export const SYNC_FEATURES = ["reassign_scope"] as const;
+export const LOCAL_SYNC_FEATURES: readonly SyncFeature[] = SYNC_FEATURES;
+
 export type SyncCapability = (typeof SYNC_CAPABILITIES)[number];
+export type SyncFeature = (typeof SYNC_FEATURES)[number];
+
+export function normalizeSyncFeatures(value: unknown): SyncFeature[] {
+	const values = Array.isArray(value) ? value : typeof value === "string" ? value.split(",") : [];
+	return [
+		...new Set(
+			values
+				.map((item) => String(item).trim().toLowerCase())
+				.filter((item): item is SyncFeature => SYNC_FEATURES.includes(item as SyncFeature)),
+		),
+	].toSorted();
+}
+
+export function supportsSyncFeature(value: unknown, feature: SyncFeature): boolean {
+	return normalizeSyncFeatures(value).includes(feature);
+}
 
 /**
  * Local sync capability advertised on every wire response and outbound request.

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -20,10 +20,14 @@ import {
 } from "./sync-bootstrap.js";
 import {
 	LOCAL_SYNC_CAPABILITY,
+	LOCAL_SYNC_FEATURES,
 	negotiateSyncCapability,
 	normalizeSyncCapability,
+	SYNC_AUTHORIZATION_REFRESH_HEADER,
 	SYNC_CAPABILITY_HEADER,
+	SYNC_FEATURES_HEADER,
 	type SyncCapability,
+	supportsSyncFeature,
 } from "./sync-capability.js";
 import { recordPeerSuccess } from "./sync-discovery.js";
 import { buildBaseUrl, requestJson } from "./sync-http-client.js";
@@ -145,6 +149,7 @@ export interface SyncScopeResult {
 export interface SyncPassOptions {
 	limit?: number;
 	keysDir?: string;
+	refreshAuthorization?: boolean;
 	/**
 	 * Secret scanner used to redact peer-shipped content on apply. Callers that
 	 * own a `MemoryStore` should pass `store.scanner` so workspace-level rule
@@ -271,7 +276,10 @@ function capabilityHeader(): Record<string, string> {
 	// Diagnostic advertisement only. This unsigned GET header can opt an
 	// authenticated paired peer into scoped metadata enumeration, but never into
 	// scoped data access; receivers must still authorize every scoped request.
-	return { [SYNC_CAPABILITY_HEADER]: LOCAL_SYNC_CAPABILITY };
+	return {
+		[SYNC_CAPABILITY_HEADER]: LOCAL_SYNC_CAPABILITY,
+		[SYNC_FEATURES_HEADER]: LOCAL_SYNC_FEATURES.join(","),
+	};
 }
 
 function defaultCapabilityDiagnostics(): SyncCapabilityDiagnostics {
@@ -381,7 +389,11 @@ async function pushOps(
 ): Promise<void> {
 	if (ops.length === 0) return;
 
-	const body = { ops, sync_capability: LOCAL_SYNC_CAPABILITY };
+	const body = {
+		ops,
+		sync_capability: LOCAL_SYNC_CAPABILITY,
+		sync_features: LOCAL_SYNC_FEATURES,
+	};
 	const bodyBytes = Buffer.from(JSON.stringify(body), "utf-8");
 	const headers = {
 		...buildAuthHeaders({
@@ -1171,6 +1183,7 @@ export async function syncOnce(
 					bootstrapGrantId: pendingBootstrapGrantId,
 				}),
 				...capabilityHeader(),
+				...(options?.refreshAuthorization ? { [SYNC_AUTHORIZATION_REFRESH_HEADER]: "1" } : {}),
 			};
 			const [statusCode, statusPayload] = await requestJson("GET", statusUrl, {
 				headers: statusHeaders,
@@ -1556,6 +1569,7 @@ export async function syncOnce(
 			const [outboundOps, filteredOutboundCursor, skippedOutbound] =
 				filterReplicationOpsForSyncWithStatus(db, outboundWindow, peerDeviceId, {
 					localDeviceId: deviceId,
+					supportsReassignScope: supportsSyncFeature(statusPayload.sync_features, "reassign_scope"),
 				});
 			const opsSkipped = skippedOutbound?.skipped_count ?? 0;
 			const postUrl = `${baseUrl}/v1/ops`;

--- a/packages/core/src/sync-reassign-scope.test.ts
+++ b/packages/core/src/sync-reassign-scope.test.ts
@@ -1,0 +1,302 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	applyReplicationOps,
+	DEFAULT_SYNC_SCOPE_ID,
+	filterReplicationOpsForSyncWithStatus,
+	parseReassignScopePayload,
+	recordReplicationOp,
+	recordScopeReassignment,
+} from "./sync-replication.js";
+import { initTestSchema } from "./test-utils.js";
+import type { ReplicationOp } from "./types.js";
+
+const now = "2026-07-20T14:00:00.000Z";
+
+function insertMemory(
+	db: InstanceType<typeof Database>,
+	scopeId: string | null = "source",
+): number {
+	const session = db
+		.prepare("INSERT INTO sessions(started_at, project, git_remote) VALUES (?, 'api', ?)")
+		.run(now, "https://example.invalid/acme/api.git");
+	return Number(
+		db
+			.prepare(`INSERT INTO memory_items(
+				session_id, kind, title, body_text, confidence, tags_text, active,
+				created_at, updated_at, metadata_json, import_key, rev, visibility, scope_id
+			) VALUES (?, 'discovery', 'title', 'body', 0.8, '', 1, ?, ?, '{}', 'memory:key', 2, 'shared', ?)`)
+			.run(Number(session.lastInsertRowid), now, now, scopeId).lastInsertRowid,
+	);
+}
+
+function ops(db: InstanceType<typeof Database>): ReplicationOp[] {
+	return db
+		.prepare("SELECT * FROM replication_ops WHERE op_type = 'reassign_scope' ORDER BY scope_id")
+		.all() as ReplicationOp[];
+}
+
+describe("reassign_scope replication", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => db.close());
+
+	it("records one logical revision as deterministic old and new scoped sides", () => {
+		const memoryId = insertMemory(db);
+		const first = recordScopeReassignment(db, {
+			operationId: "share_operation",
+			memoryId,
+			oldScopeId: "source",
+			newScopeId: "managed",
+			deviceId: "owner",
+			createdAt: now,
+		});
+		const replay = recordScopeReassignment(db, {
+			operationId: "share_operation",
+			memoryId,
+			oldScopeId: "source",
+			newScopeId: "managed",
+			deviceId: "owner",
+			createdAt: now,
+		});
+
+		expect(replay).toEqual(first);
+		expect(ops(db)).toHaveLength(2);
+		expect(new Set(ops(db).map((op) => op.clock_rev))).toEqual(new Set([3]));
+		expect(
+			ops(db)
+				.map(parseReassignScopePayload)
+				.map((payload) => payload.side)
+				.sort(),
+		).toEqual(["new", "old"]);
+		const newSide = ops(db).find((op) => parseReassignScopePayload(op).side === "new");
+		expect(JSON.parse(newSide?.payload_json ?? "{}")).toMatchObject({ project: "api" });
+		expect(db.prepare("SELECT scope_id, rev FROM memory_items WHERE id = ?").get(memoryId)).toEqual(
+			{
+				scope_id: "managed",
+				rev: 3,
+			},
+		);
+	});
+
+	it("reassigns replicated legacy memories that use their numeric id as the entity id", () => {
+		const memoryId = insertMemory(db);
+		db.prepare("UPDATE memory_items SET import_key = NULL WHERE id = ?").run(memoryId);
+		recordReplicationOp(db, {
+			memoryId,
+			opType: "upsert",
+			deviceId: "owner",
+			scopeId: "source",
+			createdAt: now,
+		});
+
+		recordScopeReassignment(db, {
+			operationId: "share_legacy",
+			memoryId,
+			oldScopeId: "source",
+			newScopeId: "managed",
+			deviceId: "owner",
+			createdAt: now,
+		});
+
+		expect(new Set(ops(db).map((op) => op.entity_id))).toEqual(new Set([String(memoryId)]));
+		expect(db.prepare("SELECT scope_id FROM memory_items WHERE id = ?").pluck().get(memoryId)).toBe(
+			"managed",
+		);
+	});
+
+	it("applies either authorized side without needing or exposing the other side payload", () => {
+		const sourceId = insertMemory(db);
+		recordScopeReassignment(db, {
+			operationId: "share_operation",
+			memoryId: sourceId,
+			oldScopeId: "source",
+			newScopeId: "managed",
+			deviceId: "owner",
+			createdAt: now,
+		});
+		const [newSide, oldSide] = ops(db);
+		if (!newSide || !oldSide) throw new Error("missing fixture ops");
+
+		const oldReceiver = new Database(":memory:");
+		initTestSchema(oldReceiver);
+		insertMemory(oldReceiver, "source");
+		const oldResult = applyReplicationOps(oldReceiver, [oldSide], "old-receiver");
+		expect(oldResult.errors).toEqual([]);
+		expect(oldReceiver.prepare("SELECT active, scope_id FROM memory_items").get()).toEqual({
+			active: 0,
+			scope_id: "source",
+		});
+
+		const newReceiver = new Database(":memory:");
+		initTestSchema(newReceiver);
+		const newResult = applyReplicationOps(newReceiver, [newSide], "new-receiver");
+		expect(newResult.errors).toEqual([]);
+		expect(newReceiver.prepare("SELECT active, scope_id, title FROM memory_items").get()).toEqual({
+			active: 1,
+			scope_id: "managed",
+			title: "title",
+		});
+		oldReceiver.close();
+		newReceiver.close();
+	});
+
+	it("normalizes a legacy blank scope while applying a local-default reassignment", () => {
+		const sourceId = insertMemory(db, DEFAULT_SYNC_SCOPE_ID);
+		recordScopeReassignment(db, {
+			operationId: "share_default",
+			memoryId: sourceId,
+			oldScopeId: DEFAULT_SYNC_SCOPE_ID,
+			newScopeId: "managed",
+			deviceId: "owner",
+			createdAt: now,
+		});
+		const receiver = new Database(":memory:");
+		initTestSchema(receiver);
+		insertMemory(receiver, null);
+
+		const result = applyReplicationOps(receiver, ops(db), "receiver");
+
+		expect(result.errors).toEqual([]);
+		expect(receiver.prepare("SELECT active, scope_id, rev FROM memory_items").get()).toEqual({
+			active: 1,
+			scope_id: "managed",
+			rev: 3,
+		});
+		receiver.close();
+	});
+
+	it("converges under either side ordering and rejects malformed payloads without mutation", () => {
+		const sourceId = insertMemory(db);
+		recordScopeReassignment(db, {
+			operationId: "share_operation",
+			memoryId: sourceId,
+			oldScopeId: "source",
+			newScopeId: "managed",
+			deviceId: "owner",
+			createdAt: now,
+		});
+		const wireOps = ops(db);
+		for (const ordered of [wireOps, [...wireOps].reverse()]) {
+			const receiver = new Database(":memory:");
+			initTestSchema(receiver);
+			insertMemory(receiver, "source");
+			const result = applyReplicationOps(receiver, ordered, "receiver");
+			expect(result.errors).toEqual([]);
+			expect(receiver.prepare("SELECT active, scope_id, rev FROM memory_items").get()).toEqual({
+				active: 1,
+				scope_id: "managed",
+				rev: 3,
+			});
+			receiver.close();
+		}
+
+		const receiver = new Database(":memory:");
+		initTestSchema(receiver);
+		insertMemory(receiver, "source");
+		const malformed = { ...wireOps[0], payload_json: "{}" } as ReplicationOp;
+		const result = applyReplicationOps(receiver, [malformed], "receiver");
+		expect(result.errors[0]).toContain("reassign_payload_invalid");
+		expect(receiver.prepare("SELECT active, scope_id, rev FROM memory_items").get()).toEqual({
+			active: 1,
+			scope_id: "source",
+			rev: 2,
+		});
+		receiver.close();
+	});
+
+	it("withholds reassignment from peers that did not negotiate the additive feature", () => {
+		const memoryId = insertMemory(db);
+		recordScopeReassignment(db, {
+			operationId: "share_operation",
+			memoryId,
+			oldScopeId: "source",
+			newScopeId: "managed",
+			deviceId: "owner",
+			createdAt: now,
+		});
+		const wireOps = ops(db);
+		const [legacy] = filterReplicationOpsForSyncWithStatus(db, wireOps, "peer", {
+			applyScopeFilter: false,
+		});
+		const [supported] = filterReplicationOpsForSyncWithStatus(db, wireOps, "peer", {
+			applyScopeFilter: false,
+			supportsReassignScope: true,
+		});
+		expect(legacy).toEqual([]);
+		expect(supported).toHaveLength(2);
+	});
+
+	it("keeps visibility filtering on new-side reassignment payloads", () => {
+		const memoryId = insertMemory(db);
+		db.prepare("UPDATE memory_items SET visibility = 'private' WHERE id = ?").run(memoryId);
+		recordScopeReassignment(db, {
+			operationId: "share_private",
+			memoryId,
+			oldScopeId: "source",
+			newScopeId: "managed",
+			deviceId: "owner",
+			createdAt: now,
+		});
+		const newSide = ops(db).find((op) => parseReassignScopePayload(op).side === "new");
+		if (!newSide) throw new Error("missing new-side reassignment");
+
+		const [allowed, cursor, skipped] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[newSide],
+			"peer",
+			{ applyScopeFilter: false, supportsReassignScope: true },
+		);
+
+		expect(allowed).toEqual([]);
+		expect(cursor).toContain(newSide.op_id);
+		expect(skipped).toMatchObject({ reason: "visibility_filter", visibility: "private" });
+	});
+
+	it("sends local-default old-side cleanup only to peers allowed for the project", () => {
+		const memoryId = insertMemory(db, DEFAULT_SYNC_SCOPE_ID);
+		recordScopeReassignment(db, {
+			operationId: "share_default",
+			memoryId,
+			oldScopeId: DEFAULT_SYNC_SCOPE_ID,
+			newScopeId: "managed",
+			deviceId: "owner",
+			createdAt: now,
+		});
+		const oldSide = ops(db).find((op) => parseReassignScopePayload(op).side === "old");
+		if (!oldSide) throw new Error("missing old-side reassignment");
+		for (const [peerDeviceId, projects] of [
+			["allowed-peer", ["api"]],
+			["blocked-peer", ["other"]],
+		] as const) {
+			db.prepare(
+				`INSERT INTO sync_peers(peer_device_id, projects_include_json, created_at)
+				 VALUES (?, ?, ?)`,
+			).run(peerDeviceId, JSON.stringify(projects), now);
+		}
+
+		const [allowed, allowedCursor] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[oldSide],
+			"allowed-peer",
+			{ localDeviceId: "owner", supportsReassignScope: true },
+		);
+		const [blocked, blockedCursor, skipped] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[oldSide],
+			"blocked-peer",
+			{ localDeviceId: "owner", supportsReassignScope: true },
+		);
+
+		expect(allowed).toEqual([oldSide]);
+		expect(allowedCursor).toContain(oldSide.op_id);
+		expect(blocked).toEqual([]);
+		expect(blockedCursor).toContain(oldSide.op_id);
+		expect(skipped).toMatchObject({ reason: "scope_filter", scope_id: DEFAULT_SYNC_SCOPE_ID });
+	});
+});

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -2591,6 +2591,145 @@ describe("applyReplicationOps", () => {
 		expect(memoryExists(op.entity_id)).toBe(true);
 	});
 
+	it("allows sender-owned local-default cleanup for a prior recipient outside the destination", () => {
+		const importKey = "key:default-reassign";
+		insertReplicatedMemory({
+			importKey,
+			originDeviceId: "dev-remote",
+			scopeId: DEFAULT_SYNC_SCOPE_ID,
+		});
+		grantScope("managed-project", ["dev-remote"]);
+		const op = makeReplicationOp({
+			op_id: "default-reassign-old",
+			entity_id: importKey,
+			op_type: "reassign_scope",
+			payload_json: toJson({
+				operation_id: "share_default",
+				memory_id: importKey,
+				old_scope_id: DEFAULT_SYNC_SCOPE_ID,
+				new_scope_id: "managed-project",
+				revision: 2,
+				side: "old",
+			}),
+			clock_rev: 2,
+			clock_updated_at: "2026-01-01T00:00:01Z",
+			created_at: "2026-01-01T00:00:01Z",
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+		});
+
+		const result = applyWithScopeValidation(op);
+
+		expect(result).toMatchObject({ applied: 1, rejected: 0 });
+		expect(
+			db.prepare("SELECT active, scope_id FROM memory_items WHERE import_key = ?").get(importKey),
+		).toEqual({ active: 0, scope_id: DEFAULT_SYNC_SCOPE_ID });
+		expect(
+			db
+				.prepare("SELECT COUNT(*) FROM memory_items WHERE import_key = ? AND scope_id = ?")
+				.pluck()
+				.get(importKey, "managed-project"),
+		).toBe(0);
+	});
+
+	it("rejects local-default reassignment when the sender lacks destination access", () => {
+		const importKey = "key:default-reassign-sender-not-member";
+		insertReplicatedMemory({
+			importKey,
+			originDeviceId: "dev-remote",
+			scopeId: DEFAULT_SYNC_SCOPE_ID,
+		});
+		grantScope("managed-project", ["dev-local"]);
+		const op = makeReplicationOp({
+			entity_id: importKey,
+			op_type: "reassign_scope",
+			payload_json: toJson({
+				operation_id: "share_default",
+				memory_id: importKey,
+				old_scope_id: DEFAULT_SYNC_SCOPE_ID,
+				new_scope_id: "managed-project",
+				revision: 2,
+				side: "old",
+			}),
+			clock_rev: 2,
+			clock_updated_at: "2026-01-01T00:00:01Z",
+			created_at: "2026-01-01T00:00:01Z",
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+		});
+
+		const result = applyWithScopeValidation(op);
+
+		expect(result.rejections[0]?.reason).toBe("sender_not_member");
+		expect(
+			db.prepare("SELECT active FROM memory_items WHERE import_key = ?").pluck().get(importKey),
+		).toBe(1);
+	});
+
+	it("rejects local-default reassignment for an unknown-origin memory", () => {
+		const importKey = "key:unknown-origin-default";
+		insertReplicatedMemory({
+			importKey,
+			originDeviceId: null,
+			scopeId: DEFAULT_SYNC_SCOPE_ID,
+		});
+		grantScope("managed-project", ["dev-remote"]);
+		const op = makeReplicationOp({
+			entity_id: importKey,
+			op_type: "reassign_scope",
+			payload_json: toJson({
+				operation_id: "share_default",
+				memory_id: importKey,
+				old_scope_id: DEFAULT_SYNC_SCOPE_ID,
+				new_scope_id: "managed-project",
+				revision: 2,
+				side: "old",
+			}),
+			clock_rev: 2,
+			clock_updated_at: "2026-01-01T00:00:01Z",
+			created_at: "2026-01-01T00:00:01Z",
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+		});
+
+		const result = applyWithScopeValidation(op);
+
+		expect(result.rejections[0]?.reason).toBe("sender_not_member");
+		expect(
+			db.prepare("SELECT active FROM memory_items WHERE import_key = ?").pluck().get(importKey),
+		).toBe(1);
+	});
+
+	it("rejects local-default reassignment for a receiver-owned memory", () => {
+		const importKey = "key:receiver-owned-default";
+		insertReplicatedMemory({
+			importKey,
+			originDeviceId: "dev-local",
+			scopeId: DEFAULT_SYNC_SCOPE_ID,
+		});
+		grantScope("managed-project", ["dev-remote", "dev-local"]);
+		const op = makeReplicationOp({
+			entity_id: importKey,
+			op_type: "reassign_scope",
+			payload_json: toJson({
+				operation_id: "share_default",
+				memory_id: importKey,
+				old_scope_id: DEFAULT_SYNC_SCOPE_ID,
+				new_scope_id: "managed-project",
+				revision: 2,
+				side: "old",
+			}),
+			clock_rev: 2,
+			clock_updated_at: "2026-01-01T00:00:01Z",
+			created_at: "2026-01-01T00:00:01Z",
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+		});
+
+		const result = applyWithScopeValidation(op);
+
+		expect(result.rejections[0]?.reason).toBe("sender_not_member");
+		expect(
+			db.prepare("SELECT active FROM memory_items WHERE import_key = ?").pluck().get(importKey),
+		).toBe(1);
+	});
+
 	it.each([
 		{
 			name: "missing op-row scope_id",

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -8,7 +8,7 @@
  * a raw Database handle. Ported from codemem/sync/replication.py.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { and, desc, eq, gt, isNotNull, isNull, like, or, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
@@ -31,6 +31,7 @@ import type {
 
 export const DEFAULT_SYNC_SCOPE_ID = "local-default";
 export const ACCESS_CLEANUP_OP_TYPE = "access_cleanup";
+export const REASSIGN_SCOPE_OP_TYPE = "reassign_scope";
 export const SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER =
 	"__codemem_scoped_null_baseline_bootstrap__";
 
@@ -145,6 +146,54 @@ interface AccessCleanupPayload {
 	cleanup_scope_id: string | null;
 	reason: string | null;
 	target_peer_device_id: string | null;
+}
+
+export interface ReassignScopePayload {
+	operation_id: string;
+	memory_id: string;
+	old_scope_id: string;
+	new_scope_id: string;
+	revision: number;
+	side: "old" | "new";
+}
+
+function requiredPayloadText(value: unknown): string | null {
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function parseReassignScopePayload(op: ReplicationOp): ReassignScopePayload {
+	if (op.op_type !== REASSIGN_SCOPE_OP_TYPE) throw new Error("reassign_payload_invalid");
+	const payload = parsePayload(op.payload_json);
+	const operationId = requiredPayloadText(payload?.operation_id);
+	const memoryId = requiredPayloadText(payload?.memory_id);
+	const oldScopeId = requiredPayloadText(payload?.old_scope_id);
+	const newScopeId = requiredPayloadText(payload?.new_scope_id);
+	const side = payload?.side;
+	const revision = payload?.revision;
+	if (
+		!operationId ||
+		!memoryId ||
+		memoryId !== op.entity_id ||
+		!oldScopeId ||
+		!newScopeId ||
+		oldScopeId === newScopeId ||
+		(side !== "old" && side !== "new") ||
+		!Number.isSafeInteger(revision) ||
+		Number(revision) <= 0 ||
+		Number(revision) !== op.clock_rev ||
+		cleanText(op.scope_id) !== (side === "old" ? oldScopeId : newScopeId) ||
+		(side === "new" && cleanText(payload?.scope_id) !== newScopeId)
+	) {
+		throw new Error("reassign_payload_invalid");
+	}
+	return {
+		operation_id: operationId,
+		memory_id: memoryId,
+		old_scope_id: oldScopeId,
+		new_scope_id: newScopeId,
+		revision: Number(revision),
+		side,
+	};
 }
 
 function parseAccessCleanupPayload(op: ReplicationOp): AccessCleanupPayload {
@@ -904,6 +953,146 @@ export function recordReplicationOp(
 		.run();
 
 	return opId;
+}
+
+function deterministicReassignOpId(
+	operationId: string,
+	memoryId: string,
+	oldScopeId: string,
+	newScopeId: string,
+	side: "old" | "new",
+): string {
+	return `reassign_${createHash("sha256")
+		.update(JSON.stringify([operationId, memoryId, oldScopeId, newScopeId, side]))
+		.digest("hex")}`;
+}
+
+export function recordScopeReassignment(
+	db: Database,
+	opts: {
+		operationId: string;
+		memoryId: number;
+		oldScopeId: string;
+		newScopeId: string;
+		deviceId: string;
+		createdAt?: string;
+	},
+): { revision: number; oldOpId: string; newOpId: string } {
+	const operationId = requiredPayloadText(opts.operationId);
+	const oldScopeId = requiredPayloadText(opts.oldScopeId);
+	const newScopeId = requiredPayloadText(opts.newScopeId);
+	const deviceId = requiredPayloadText(opts.deviceId);
+	if (
+		!operationId ||
+		!oldScopeId ||
+		!newScopeId ||
+		oldScopeId === newScopeId ||
+		!deviceId ||
+		!Number.isSafeInteger(opts.memoryId) ||
+		opts.memoryId <= 0
+	) {
+		throw new Error("reassign_input_invalid");
+	}
+	const d = drizzle(db, { schema });
+	const existing = d
+		.select()
+		.from(schema.memoryItems)
+		.where(eq(schema.memoryItems.id, opts.memoryId))
+		.get();
+	if (!existing) throw new Error("reassign_memory_not_found");
+	const memoryId = existing.import_key ?? String(existing.id);
+	const oldOpId = deterministicReassignOpId(operationId, memoryId, oldScopeId, newScopeId, "old");
+	const newOpId = deterministicReassignOpId(operationId, memoryId, oldScopeId, newScopeId, "new");
+	const existingOps = db
+		.prepare("SELECT op_id, clock_rev FROM replication_ops WHERE op_id IN (?, ?)")
+		.all(oldOpId, newOpId) as Array<{ op_id: string; clock_rev: number }>;
+	if (existingOps.length > 0) {
+		if (
+			existingOps.length !== 2 ||
+			existingOps.some((op) => op.clock_rev !== existingOps[0]?.clock_rev)
+		) {
+			throw new Error("reassign_replay_conflict");
+		}
+		return { revision: Number(existingOps[0]?.clock_rev ?? 0), oldOpId, newOpId };
+	}
+	if ((cleanText(existing.scope_id) ?? DEFAULT_SYNC_SCOPE_ID) !== oldScopeId) {
+		throw new Error("reassign_old_scope_mismatch");
+	}
+	const revision = Number(existing.rev ?? 0) + 1;
+	const createdAt = opts.createdAt ?? new Date().toISOString();
+	const metadata = fromJson(existing.metadata_json);
+	metadata.clock_device_id = deviceId;
+	metadata.last_scope_reassignment = {
+		operation_id: operationId,
+		old_scope_id: oldScopeId,
+		new_scope_id: newScopeId,
+		revision,
+	};
+	const write = db.transaction(() => {
+		d.update(schema.memoryItems)
+			.set({
+				scope_id: newScopeId,
+				rev: revision,
+				updated_at: createdAt,
+				metadata_json: toJson(metadata),
+			})
+			.where(eq(schema.memoryItems.id, opts.memoryId))
+			.run();
+		const updated = d
+			.select()
+			.from(schema.memoryItems)
+			.where(eq(schema.memoryItems.id, opts.memoryId))
+			.get();
+		if (!updated) throw new Error("reassign_memory_not_found");
+		const sessionProject = updated.session_id
+			? cleanText(
+					db.prepare("SELECT project FROM sessions WHERE id = ?").pluck().get(updated.session_id),
+				)
+			: null;
+		const common = {
+			operation_id: operationId,
+			memory_id: memoryId,
+			old_scope_id: oldScopeId,
+			new_scope_id: newScopeId,
+			revision,
+		};
+		const insert = db.prepare(`INSERT INTO replication_ops(
+			op_id, entity_type, entity_id, op_type, payload_json, clock_rev,
+			clock_updated_at, clock_device_id, device_id, created_at, scope_id
+		) VALUES (?, 'memory_item', ?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+		insert.run(
+			oldOpId,
+			memoryId,
+			REASSIGN_SCOPE_OP_TYPE,
+			toJson({ ...common, side: "old" }),
+			revision,
+			createdAt,
+			deviceId,
+			deviceId,
+			createdAt,
+			oldScopeId,
+		);
+		insert.run(
+			newOpId,
+			memoryId,
+			REASSIGN_SCOPE_OP_TYPE,
+			toJson({
+				...buildPayloadFromMemoryRow(updated),
+				project: cleanText(updated.project) ?? sessionProject,
+				...common,
+				side: "new",
+				scope_id: newScopeId,
+			}),
+			revision,
+			createdAt,
+			deviceId,
+			deviceId,
+			createdAt,
+			newScopeId,
+		);
+	});
+	write.immediate();
+	return { revision, oldOpId, newOpId };
 }
 
 export function recordAccessCleanupOp(
@@ -1702,7 +1891,7 @@ function effectiveSyncProjectFilters(
 	};
 }
 
-function syncProjectAllowed(
+export function syncProjectAllowed(
 	db: Database,
 	project: string | null,
 	peerDeviceId: string | null,
@@ -1875,6 +2064,7 @@ export interface FilterReplicationSkipped {
 export interface FilterReplicationOpsForSyncOptions {
 	localDeviceId?: string | null;
 	applyScopeFilter?: boolean;
+	supportsReassignScope?: boolean;
 }
 
 interface ExistingMemoryFilterContext {
@@ -1997,6 +2187,23 @@ function outboundScopeAllowed(
 	return localAuth.authorized && localAuth.scope?.authority_type !== "local";
 }
 
+function legacyDefaultReassignAllowed(
+	db: Database,
+	op: ReplicationOp,
+	peerDeviceId: string | null,
+): boolean {
+	const existing = existingMemoryFilterContext(db, op.entity_id);
+	if (!existing) return false;
+	if (
+		(replicationOpRequiresPersonalScopeAuthorization(op, existing.payload) ||
+			!syncVisibilityAllowed(existing.payload)) &&
+		!peerCanSyncPrivateOpByPersonalScopeGrant(db, op, existing.payload, peerDeviceId)
+	) {
+		return false;
+	}
+	return syncProjectAllowed(db, existing.project, peerDeviceId);
+}
+
 /**
  * Filter replication ops for peer sync scopes.
  *
@@ -2017,6 +2224,14 @@ export function filterReplicationOpsForSyncWithStatus(
 	for (const op of ops) {
 		if (op.entity_type === "memory_item") {
 			const payload = parsePayload(op.payload_json);
+			if (op.op_type === REASSIGN_SCOPE_OP_TYPE && options.supportsReassignScope !== true) {
+				addSkipped(skipped, op, {
+					reason: "scope_filter",
+					scope_id: cleanText(op.scope_id),
+				});
+				nextCursor = computeCursor(op.created_at, op.op_id);
+				continue;
+			}
 			if (op.op_type === ACCESS_CLEANUP_OP_TYPE) {
 				if (!accessCleanupTargetsPeer(op, peerDeviceId)) {
 					addSkipped(skipped, op, {
@@ -2029,6 +2244,36 @@ export function filterReplicationOpsForSyncWithStatus(
 				allowed.push(op);
 				nextCursor = computeCursor(op.created_at, op.op_id);
 				continue;
+			}
+			if (op.op_type === REASSIGN_SCOPE_OP_TYPE) {
+				try {
+					const reassignment = parseReassignScopePayload(op);
+					const scopeAllowed =
+						!applyScopeFilter ||
+						(reassignment.side === "old" && reassignment.old_scope_id === DEFAULT_SYNC_SCOPE_ID
+							? legacyDefaultReassignAllowed(db, op, peerDeviceId)
+							: outboundScopeAllowed(db, op, payload, peerDeviceId, options.localDeviceId ?? null));
+					if (!scopeAllowed) {
+						addSkipped(skipped, op, {
+							reason: "scope_filter",
+							scope_id: cleanText(op.scope_id),
+						});
+						nextCursor = computeCursor(op.created_at, op.op_id);
+						continue;
+					}
+					if (reassignment.side === "old") {
+						allowed.push(op);
+						nextCursor = computeCursor(op.created_at, op.op_id);
+						continue;
+					}
+				} catch {
+					addSkipped(skipped, op, {
+						reason: "scope_filter",
+						scope_id: cleanText(op.scope_id),
+					});
+					nextCursor = computeCursor(op.created_at, op.op_id);
+					continue;
+				}
 			}
 			if (
 				applyScopeFilter &&
@@ -2473,10 +2718,6 @@ function validateInboundScopeOp(
 	const opScopeId = normalizeInboundScopeId(op.scope_id);
 
 	if (!opScopeId) return inboundScopeRejection(op, "missing_scope", peerDeviceId, null);
-	if (opScopeId === DEFAULT_SYNC_SCOPE_ID) {
-		return inboundScopeRejection(op, "scope_mismatch", peerDeviceId, opScopeId);
-	}
-
 	const payload = parsePayload(op.payload_json);
 	if (payloadContradictsInboundScope(opScopeId, payload)) {
 		return inboundScopeRejection(op, "scope_mismatch", peerDeviceId, opScopeId);
@@ -2489,23 +2730,48 @@ function validateInboundScopeOp(
 	) {
 		return inboundScopeRejection(op, "sender_not_member", peerDeviceId, opScopeId);
 	}
+	let authorizationScopeId = opScopeId;
+	let requireReceiverMembership = true;
+	if (opScopeId === DEFAULT_SYNC_SCOPE_ID) {
+		try {
+			const reassignment = parseReassignScopePayload(op);
+			if (reassignment.side !== "old" || reassignment.old_scope_id !== DEFAULT_SYNC_SCOPE_ID) {
+				return inboundScopeRejection(op, "scope_mismatch", peerDeviceId, opScopeId);
+			}
+			const existing = db
+				.prepare("SELECT origin_device_id FROM memory_items WHERE import_key = ?")
+				.get(op.entity_id) as { origin_device_id: string | null } | undefined;
+			if (existing && cleanText(existing.origin_device_id) !== senderDeviceId) {
+				return inboundScopeRejection(op, "sender_not_member", peerDeviceId, opScopeId);
+			}
+			authorizationScopeId = reassignment.new_scope_id;
+			// This side only retracts sender-origin data previously delivered through
+			// local-default. Prior recipients intentionally are not members of the new
+			// boundary, and the apply path cannot create a new-scope row for them.
+			requireReceiverMembership = false;
+		} catch {
+			return inboundScopeRejection(op, "scope_mismatch", peerDeviceId, opScopeId);
+		}
+	}
 
 	const senderAuth = getCachedScopeAuthorization(db, {
 		deviceId: senderDeviceId,
-		scopeId: opScopeId,
+		scopeId: authorizationScopeId,
 	});
 	const senderFailure = authorizationFailureReason(senderAuth, "sender_not_member");
 	if (senderFailure) return inboundScopeRejection(op, senderFailure, peerDeviceId, opScopeId);
 
-	if (!receiverDeviceId) {
-		return inboundScopeRejection(op, "receiver_not_member", peerDeviceId, opScopeId);
+	if (requireReceiverMembership) {
+		if (!receiverDeviceId) {
+			return inboundScopeRejection(op, "receiver_not_member", peerDeviceId, opScopeId);
+		}
+		const receiverAuth = getCachedScopeAuthorization(db, {
+			deviceId: receiverDeviceId,
+			scopeId: authorizationScopeId,
+		});
+		const receiverFailure = authorizationFailureReason(receiverAuth, "receiver_not_member");
+		if (receiverFailure) return inboundScopeRejection(op, receiverFailure, peerDeviceId, opScopeId);
 	}
-	const receiverAuth = getCachedScopeAuthorization(db, {
-		deviceId: receiverDeviceId,
-		scopeId: opScopeId,
-	});
-	const receiverFailure = authorizationFailureReason(receiverAuth, "receiver_not_member");
-	if (receiverFailure) return inboundScopeRejection(op, receiverFailure, peerDeviceId, opScopeId);
 
 	return null;
 }
@@ -3127,6 +3393,58 @@ export function applyReplicationOps(
 					continue;
 				}
 
+				const reassignment =
+					op.op_type === REASSIGN_SCOPE_OP_TYPE ? parseReassignScopePayload(op) : null;
+				if (reassignment?.side === "old") {
+					const current = d
+						.select({
+							id: schema.memoryItems.id,
+							rev: schema.memoryItems.rev,
+							updated_at: schema.memoryItems.updated_at,
+							metadata_json: schema.memoryItems.metadata_json,
+							scope_id: schema.memoryItems.scope_id,
+						})
+						.from(schema.memoryItems)
+						.where(eq(schema.memoryItems.import_key, op.entity_id))
+						.get();
+					if (
+						!current ||
+						(cleanText(current.scope_id) ?? DEFAULT_SYNC_SCOPE_ID) !== reassignment.old_scope_id
+					) {
+						insertReplicationOpRow(d, op);
+						result.skipped++;
+						continue;
+					}
+					const currentClock = clockTuple(
+						current.rev ?? 0,
+						current.updated_at ?? "",
+						clockDeviceIdFromMetadataJson(current.metadata_json),
+					);
+					const incomingClock = clockTuple(op.clock_rev, op.clock_updated_at, op.clock_device_id);
+					if (!isNewerClock(incomingClock, currentClock)) {
+						insertReplicationOpRow(d, op);
+						result.conflicts++;
+						continue;
+					}
+					const metadata = fromJson(current.metadata_json);
+					metadata.clock_device_id = op.clock_device_id;
+					metadata.last_scope_reassignment = reassignment;
+					d.update(schema.memoryItems)
+						.set({
+							active: 0,
+							deleted_at: op.clock_updated_at,
+							rev: op.clock_rev,
+							updated_at: op.clock_updated_at,
+							metadata_json: toJson(metadata),
+						})
+						.where(eq(schema.memoryItems.id, current.id))
+						.run();
+					queueVectorDelete(Number(current.id));
+					insertReplicationOpRow(d, op);
+					result.applied++;
+					continue;
+				}
+
 				if (op.op_type === ACCESS_CLEANUP_OP_TYPE) {
 					const cleaned = applyAccessCleanupOp(op);
 					insertReplicationOpRow(d, op);
@@ -3135,7 +3453,7 @@ export function applyReplicationOps(
 					continue;
 				}
 
-				if (op.op_type === "upsert") {
+				if (op.op_type === "upsert" || reassignment?.side === "new") {
 					const importKey = op.entity_id;
 					const opScopeId =
 						typeof op.scope_id === "string" && op.scope_id.trim().length > 0
@@ -3151,6 +3469,7 @@ export function applyReplicationOps(
 							active: schema.memoryItems.active,
 							deleted_at: schema.memoryItems.deleted_at,
 							metadata_json: schema.memoryItems.metadata_json,
+							scope_id: schema.memoryItems.scope_id,
 						})
 						.from(schema.memoryItems)
 						.where(eq(schema.memoryItems.import_key, importKey))
@@ -3165,7 +3484,21 @@ export function applyReplicationOps(
 						);
 						const opClock = clockTuple(op.clock_rev, op.clock_updated_at, op.clock_device_id);
 
-						if (!isNewerClock(opClock, existingClock)) {
+						const sameReassignmentClock =
+							reassignment?.side === "new" &&
+							opClock[0] === existingClock[0] &&
+							opClock[1] === existingClock[1] &&
+							opClock[2] === existingClock[2] &&
+							(cleanText(memRow.scope_id) ?? DEFAULT_SYNC_SCOPE_ID) === reassignment.old_scope_id;
+						if (
+							reassignment &&
+							![reassignment.old_scope_id, reassignment.new_scope_id].includes(
+								cleanText(memRow.scope_id) ?? DEFAULT_SYNC_SCOPE_ID,
+							)
+						) {
+							throw new Error("reassign_existing_scope_mismatch");
+						}
+						if (!isNewerClock(opClock, existingClock) && !sameReassignmentClock) {
 							result.conflicts++;
 							// Still record the op so we don't re-process it
 							insertReplicationOpRow(d, op);

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -3928,6 +3928,80 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("advertises reassign_scope and refreshes authorization only on explicit feature-aware status requests", async () => {
+			// Arrange
+			const configDir = mkdtempSync(join(tmpdir(), "codemem-status-refresh-test-"));
+			const configPath = join(configDir, "config.json");
+			const previousConfig = process.env.CODEMEM_CONFIG;
+			const previousFetch = globalThis.fetch;
+			const fetchMock = vi.fn(
+				async () => new Response(JSON.stringify({ error: "offline" }), { status: 503 }),
+			);
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+					sync_coordinator_admin_secret: "secret",
+				}),
+			);
+			globalThis.fetch = fetchMock as typeof fetch;
+			const { syncApp, ensureStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				const store = ensureStore();
+				const url = "http://localhost/v1/status";
+				peer = createAuthenticatedSyncPeer(store, { url });
+				const signedHeaders = () =>
+					buildAuthHeaders({
+						deviceId: peer?.peerDeviceId ?? "",
+						method: "GET",
+						url,
+						bodyBytes: Buffer.alloc(0),
+						keysDir: peer?.keysDir,
+					});
+
+				// Act
+				const ordinary = await syncApp.request(url, { headers: signedHeaders() });
+				const refreshOnly = await syncApp.request(url, {
+					headers: { ...signedHeaders(), "X-Codemem-Refresh-Authorization": "1" },
+				});
+				const featureOnly = await syncApp.request(url, {
+					headers: { ...signedHeaders(), "X-Codemem-Sync-Features": "reassign_scope" },
+				});
+
+				// Assert
+				expect(ordinary.status).toBe(200);
+				expect((await ordinary.json()) as Record<string, unknown>).toMatchObject({
+					sync_features: ["reassign_scope"],
+				});
+				expect(refreshOnly.status).toBe(200);
+				expect(featureOnly.status).toBe(200);
+				expect(fetchMock).not.toHaveBeenCalled();
+
+				// Act
+				const explicitRefresh = await syncApp.request(url, {
+					headers: {
+						...signedHeaders(),
+						"X-Codemem-Refresh-Authorization": "1",
+						"X-Codemem-Sync-Features": "reassign_scope",
+					},
+				});
+
+				// Assert
+				expect(explicitRefresh.status).toBe(200);
+				expect(fetchMock).toHaveBeenCalled();
+			} finally {
+				peer?.cleanup();
+				cleanup();
+				globalThis.fetch = previousFetch;
+				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previousConfig;
+				rmSync(configDir, { recursive: true, force: true });
+			}
+		});
+
 		it("exposes sync auth failure reasons only when diagnostics are explicitly enabled", async () => {
 			const previous = process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS;
 			process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS = "1";
@@ -5003,6 +5077,184 @@ describe("viewer-server", () => {
 					sync_capability: "scoped",
 					reason: "unsupported_scope",
 					scope_id: null,
+				});
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
+		it("rejects reassign_scope batches without feature advertisement", async () => {
+			// Arrange
+			const { syncApp, ensureStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				const store = ensureStore();
+				const url = "http://localhost/v1/ops";
+				peer = createAuthenticatedSyncPeer(store, { url, method: "POST" });
+				const now = "2026-07-20T14:00:00.000Z";
+				const bodyText = JSON.stringify({
+					sync_capability: "scoped",
+					ops: [
+						{
+							op_id: "reassign-without-feature",
+							entity_type: "memory_item",
+							entity_id: "memory:key",
+							op_type: "reassign_scope",
+							payload_json: JSON.stringify({
+								operation_id: "share_operation",
+								memory_id: "memory:key",
+								old_scope_id: "source",
+								new_scope_id: "managed",
+								revision: 3,
+								side: "old",
+							}),
+							clock_rev: 3,
+							clock_updated_at: now,
+							clock_device_id: peer.peerDeviceId,
+							device_id: peer.peerDeviceId,
+							created_at: now,
+							scope_id: "source",
+						},
+					],
+				});
+				const bodyBytes = Buffer.from(bodyText);
+				const headers = buildAuthHeaders({
+					deviceId: peer.peerDeviceId,
+					method: "POST",
+					url,
+					bodyBytes,
+					keysDir: peer.keysDir,
+				});
+
+				// Act
+				const response = await syncApp.request(url, {
+					method: "POST",
+					headers: { ...headers, "Content-Type": "application/json" },
+					body: bodyText,
+				});
+
+				// Assert
+				expect(response.status).toBe(409);
+				expect(await response.json()).toEqual({ error: "reassign_capability_required" });
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
+		it("rejects malformed feature-advertised reassign_scope payloads", async () => {
+			// Arrange
+			const { syncApp, ensureStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				const store = ensureStore();
+				const url = "http://localhost/v1/ops";
+				peer = createAuthenticatedSyncPeer(store, { url, method: "POST" });
+				const now = "2026-07-20T14:00:00.000Z";
+				const bodyText = JSON.stringify({
+					sync_capability: "scoped",
+					sync_features: ["reassign_scope"],
+					ops: [
+						{
+							op_id: "malformed-reassign",
+							entity_type: "memory_item",
+							entity_id: "memory:key",
+							op_type: "reassign_scope",
+							payload_json: "{}",
+							clock_rev: 3,
+							clock_updated_at: now,
+							clock_device_id: peer.peerDeviceId,
+							device_id: peer.peerDeviceId,
+							created_at: now,
+							scope_id: "source",
+						},
+					],
+				});
+				const bodyBytes = Buffer.from(bodyText);
+				const headers = buildAuthHeaders({
+					deviceId: peer.peerDeviceId,
+					method: "POST",
+					url,
+					bodyBytes,
+					keysDir: peer.keysDir,
+				});
+
+				// Act
+				const response = await syncApp.request(url, {
+					method: "POST",
+					headers: { ...headers, "Content-Type": "application/json" },
+					body: bodyText,
+				});
+
+				// Assert
+				expect(response.status).toBe(400);
+				expect(await response.json()).toEqual({ error: "reassign_payload_invalid" });
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
+		it("accepts authorized feature-advertised reassign_scope batches", async () => {
+			// Arrange
+			const { syncApp, ensureStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				const store = ensureStore();
+				const url = "http://localhost/v1/ops";
+				peer = createAuthenticatedSyncPeer(store, { url, method: "POST" });
+				grantSyncScopeToDevices(store, "source", [store.deviceId, peer.peerDeviceId]);
+				grantSyncScopeToDevices(store, "managed", [store.deviceId, peer.peerDeviceId]);
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "reassign source",
+					originDeviceId: peer.peerDeviceId,
+					scopeId: "source",
+				});
+				core.recordScopeReassignment(store.db, {
+					operationId: "share_operation",
+					memoryId,
+					oldScopeId: "source",
+					newScopeId: "managed",
+					deviceId: peer.peerDeviceId,
+					createdAt: "2026-07-20T14:00:00.000Z",
+				});
+				const ops = store.db
+					.prepare(
+						"SELECT * FROM replication_ops WHERE op_type = 'reassign_scope' ORDER BY scope_id",
+					)
+					.all();
+				const bodyText = JSON.stringify({
+					sync_capability: "scoped",
+					sync_features: ["reassign_scope"],
+					ops,
+				});
+				const bodyBytes = Buffer.from(bodyText);
+				const headers = buildAuthHeaders({
+					deviceId: peer.peerDeviceId,
+					method: "POST",
+					url,
+					bodyBytes,
+					keysDir: peer.keysDir,
+				});
+
+				// Act
+				const response = await syncApp.request(url, {
+					method: "POST",
+					headers: { ...headers, "Content-Type": "application/json" },
+					body: bodyText,
+				});
+
+				// Assert
+				expect(response.status).toBe(200);
+				expect(await response.json()).toMatchObject({
+					applied: 0,
+					rejected: 0,
+					skipped: 2,
+					sync_capability: "scoped",
 				});
 			} finally {
 				peer?.cleanup();
@@ -9268,6 +9520,11 @@ describe("viewer-server", () => {
 				await app.request("/api/stats");
 				const store = getStore();
 				if (!store) throw new Error("store not initialized");
+				expect(store.deviceId).toBe("local");
+				const [localDeviceId] = ensureDeviceIdentity(store.db, {
+					keysDir: process.env.CODEMEM_KEYS_DIR,
+				});
+				expect(localDeviceId).not.toBe("local");
 				store.db
 					.prepare(
 						`INSERT INTO actors(
@@ -9284,13 +9541,42 @@ describe("viewer-server", () => {
 						"codemem",
 						sessionId,
 					);
-				insertTestMemory(store, { sessionId, kind: "discovery", title: "first" });
-				insertTestMemory(store, { sessionId, kind: "decision", title: "second" });
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "first",
+					originDeviceId: localDeviceId,
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "decision",
+					title: "second",
+					originDeviceId: localDeviceId,
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "private",
+					originDeviceId: localDeviceId,
+				});
+				store.db
+					.prepare("UPDATE memory_items SET visibility = 'private' WHERE title = 'private'")
+					.run();
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "personal",
+					originDeviceId: localDeviceId,
+				});
+				store.db
+					.prepare("UPDATE memory_items SET visibility = 'personal' WHERE title = 'personal'")
+					.run();
 				insertTestMemory(store, {
 					sessionId,
 					kind: "discovery",
 					title: "inactive third",
 					active: false,
+					originDeviceId: localDeviceId,
 				});
 				const inventoryRes = await app.request("/api/sync/projects?q=codemem");
 				const inventory = (await inventoryRes.json()) as {
@@ -9415,12 +9701,6 @@ describe("viewer-server", () => {
 					{ project_id: projectId, display_name: "codemem", existing_memory_count: 2 },
 				]);
 				expect(preview.future_memories_shared).toBe(true);
-				const localDeviceId = store.db
-					.prepare("SELECT device_id FROM sync_device LIMIT 1")
-					.pluck()
-					.get() as string | undefined;
-				expect(localDeviceId).toBeTruthy();
-				expect(localDeviceId).not.toBe("local");
 				for (const [body, expectedError] of [
 					[
 						{ teammate_name: "Brian", project_ids: [projectId] },
@@ -9464,7 +9744,12 @@ describe("viewer-server", () => {
 				});
 				expect(changedRes.status).toBe(409);
 				expect(fetchMock).not.toHaveBeenCalled();
-				insertTestMemory(store, { sessionId, kind: "feature", title: "active third" });
+				insertTestMemory(store, {
+					sessionId,
+					kind: "feature",
+					title: "active third",
+					originDeviceId: localDeviceId,
+				});
 				const changedCountRes = await app.request("/api/sync/project-invites", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
@@ -9907,6 +10192,160 @@ describe("viewer-server", () => {
 				globalThis.fetch = prevFetch;
 				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
 				else process.env.CODEMEM_CONFIG = prevConfig;
+			}
+		});
+
+		it("maps project provision errors and preflights reassignment before mutations", async () => {
+			// Arrange
+			const configDir = mkdtempSync(join(tmpdir(), "codemem-provision-route-test-"));
+			const configPath = join(configDir, "config.json");
+			const previousConfig = process.env.CODEMEM_CONFIG;
+			const previousFetch = globalThis.fetch;
+			const recipientPublicKey = "recipient-route-key";
+			const recipientFingerprint = fingerprintPublicKey(recipientPublicKey);
+			let capabilityProbe: "unsupported" | "undetermined" = "unsupported";
+			globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.endsWith("/v1/status")) {
+					return new Response(
+						JSON.stringify(
+							capabilityProbe === "unsupported"
+								? {
+										device_id: "recipient-route",
+										fingerprint: recipientFingerprint,
+										sync_features: [],
+									}
+								: {
+										device_id: "wrong-device",
+										fingerprint: "wrong-fingerprint",
+										sync_features: ["reassign_scope"],
+									},
+						),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			}) as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+					sync_coordinator_admin_secret: "secret",
+				}),
+			);
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const store = ensureStore();
+				const sessionId = insertTestSession(store.db);
+				store.db
+					.prepare("UPDATE sessions SET git_remote = ?, project = ? WHERE id = ?")
+					.run("https://git.example.invalid/codemem.git", "codemem", sessionId);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "provision history",
+					scopeId: "local-default",
+				});
+				const canonicalIdentity = "https://git.example.invalid/codemem.git";
+				const plan = core.planShareOperation({
+					inviterActorId: store.actorId,
+					inviterDeviceIds: [store.deviceId],
+					person: { kind: "pending", displayName: "Brian" },
+					projects: [
+						{
+							canonicalIdentity,
+							displayName: "codemem",
+							identitySource: "git_remote",
+							existingMemoryCount: 1,
+						},
+					],
+					coordinatorGroupId: "team-a",
+					inviteExpiresAt: "2099-01-01T00:00:00.000Z",
+					createdAt: "2026-07-20T12:00:00.000Z",
+				});
+				core.persistShareOperation(store.db, plan, {
+					inviteId: "invite-route",
+					tokenDigest: core.inviteTokenDigest("token-route"),
+				});
+				core.reconcileShareOperationAcceptance(store.db, {
+					operationId: plan.operationId,
+					coordinatorGroupId: "team-a",
+					reviewedProjectSetDigest: plan.reviewedProjectSetDigest,
+					recipientActorId: "actor-recipient-route",
+					recipientDisplayName: "Brian",
+					recipientDeviceId: "recipient-route",
+					recipientDeviceDisplayName: "Brian's MacBook",
+					recipientPublicKey,
+					recipientFingerprint,
+					consumedAt: "2026-07-20T13:00:00.000Z",
+					trustState: "bootstrap_grant_created",
+					bootstrapGrantId: "grant-route",
+					projects: [
+						{
+							canonical_identity: canonicalIdentity,
+							display_name: "codemem",
+							existing_memory_count: 1,
+						},
+					],
+				});
+				store.db
+					.prepare("UPDATE sync_peers SET addresses_json = ? WHERE peer_device_id = ?")
+					.run(JSON.stringify(["https://wrong.example.test"]), "recipient-route");
+				const originalScope = store.db
+					.prepare("SELECT scope_id FROM memory_items WHERE id = ?")
+					.pluck()
+					.get(memoryId);
+
+				// Act
+				const invalid = await app.request("/api/sync/project-invites/not-an-operation/provision", {
+					method: "POST",
+				});
+				const missing = await app.request(
+					`/api/sync/project-invites/share_${"f".repeat(40)}/provision`,
+					{ method: "POST" },
+				);
+				const unsupported = await app.request(
+					`/api/sync/project-invites/${plan.operationId}/provision`,
+					{ method: "POST" },
+				);
+				capabilityProbe = "undetermined";
+				const waiting = await app.request(
+					`/api/sync/project-invites/${plan.operationId}/provision`,
+					{ method: "POST" },
+				);
+
+				// Assert
+				expect(invalid.status).toBe(400);
+				expect(await invalid.json()).toEqual({ error: "operation_id_invalid" });
+				expect(missing.status).toBe(404);
+				expect(await missing.json()).toEqual({ error: "operation_not_found" });
+				expect(unsupported.status).toBe(409);
+				expect(await unsupported.json()).toEqual({ error: "reassign_capability_required" });
+				expect(waiting.status).toBe(409);
+				expect(await waiting.json()).toEqual({ error: "waiting_for_device" });
+				expect(store.db.prepare("SELECT state FROM share_operations").pluck().get()).toBe(
+					"waiting_for_device",
+				);
+				expect(
+					store.db.prepare("SELECT scope_id FROM memory_items WHERE id = ?").pluck().get(memoryId),
+				).toBe(originalScope);
+				expect(store.db.prepare("SELECT COUNT(*) FROM project_scope_mappings").pluck().get()).toBe(
+					0,
+				);
+				expect(
+					store.db
+						.prepare("SELECT COUNT(*) FROM replication_ops WHERE op_type = 'reassign_scope'")
+						.pluck()
+						.get(),
+				).toBe(0);
+			} finally {
+				cleanup();
+				globalThis.fetch = previousFetch;
+				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previousConfig;
+				rmSync(configDir, { recursive: true, force: true });
 			}
 		});
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -13,6 +13,7 @@ import type {
 	MaintenanceJobSnapshot,
 	MemoryStore,
 	ProjectScopeGuardrailWarning,
+	ReassignScopeCapability,
 	ReplicationOp,
 	SemanticIndexDiagnostics,
 	ShareOperationPlan,
@@ -24,6 +25,7 @@ import {
 	addSyncScopeToBoundary,
 	analyzeProjectScopeMappingChangeGuardrails,
 	applyReplicationOps,
+	buildAuthHeaders,
 	buildBaseUrl,
 	canonicalWorkspaceIdentity,
 	cleanupNonces,
@@ -50,6 +52,7 @@ import {
 	coordinatorStatusSnapshot,
 	coordinatorUnarchiveGroupAction,
 	coordinatorUpdateScopeAction,
+	countShareableProjectMemories,
 	createCoordinatorReciprocalApproval,
 	DEFAULT_TIME_WINDOW_S,
 	decodeInvitePayload,
@@ -57,6 +60,7 @@ import {
 	deleteProjectScopeSettingsMapping,
 	diagnoseStalePeerReceivedRows,
 	ensureDeviceIdentity,
+	executeShareProvisioning,
 	extractInvitePayload,
 	extractReplicationOps,
 	type FilterReplicationSkipped,
@@ -73,6 +77,7 @@ import {
 	LEGACY_SHARED_REVIEW_SCOPE_ID,
 	LOCAL_DEFAULT_SCOPE_ID,
 	LOCAL_SYNC_CAPABILITY,
+	LOCAL_SYNC_FEATURES,
 	listAuthorizedScopesForPeer,
 	listCoordinatorJoinRequests,
 	listInboundScopeRejections,
@@ -89,8 +94,10 @@ import {
 	negotiateSyncCapability,
 	normalizeAddress,
 	normalizeSyncCapability,
+	normalizeSyncFeatures,
 	normalizeTeammateName,
 	parseAcceptedProjectIntent,
+	parseReassignScopePayload,
 	parseSyncScopeRequest,
 	persistShareOperation,
 	personalScopeGrantStatusForPeer,
@@ -100,13 +107,17 @@ import {
 	reassignProjectScopeInventoryProject,
 	reconcileShareOperationAcceptance,
 	recordNonce,
+	refreshConfiguredScopeMembershipCache,
 	rejectInboundScopeFailures,
 	requestJson,
 	runSyncPass,
+	SYNC_AUTHORIZATION_REFRESH_HEADER,
 	SYNC_CAPABILITY_HEADER,
+	SYNC_FEATURES_HEADER,
 	SYNC_SCOPE_QUERY_PARAM,
 	schema,
 	summarizeInboundScopeRejections,
+	supportsSyncFeature,
 	syncScopeResetRequiredPayload,
 	updatePeerAddresses,
 	upsertCoordinatorGroupPreference,
@@ -591,9 +602,65 @@ function projectInviteStatus(config = readCoordinatorSyncConfig()): {
 	return { groupId: status.active_group, config };
 }
 
+async function peerSupportsReassignScope(
+	store: MemoryStore,
+	deviceId: string,
+): Promise<ReassignScopeCapability> {
+	const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
+	if (deviceId === localDeviceId) return "supported";
+	const row = store.db
+		.prepare(
+			"SELECT addresses_json, pinned_fingerprint, public_key FROM sync_peers WHERE peer_device_id = ?",
+		)
+		.get(deviceId) as
+		| {
+				addresses_json: string | null;
+				pinned_fingerprint: string | null;
+				public_key: string | null;
+		  }
+		| undefined;
+	const expectedFingerprint =
+		String(row?.pinned_fingerprint ?? "").trim() ||
+		(row?.public_key ? fingerprintPublicKey(row.public_key) : "");
+	const addresses = safeJsonList(row?.addresses_json ?? null);
+	for (const address of addresses) {
+		try {
+			const url = `${buildBaseUrl(address)}/v1/status`;
+			const headers = {
+				...buildAuthHeaders({
+					deviceId: localDeviceId,
+					method: "GET",
+					url,
+					bodyBytes: Buffer.alloc(0),
+					keysDir: syncKeysDir(),
+				}),
+				[SYNC_CAPABILITY_HEADER]: LOCAL_SYNC_CAPABILITY,
+				[SYNC_FEATURES_HEADER]: LOCAL_SYNC_FEATURES.join(","),
+			};
+			const [status, payload] = await requestJson("GET", url, { headers, timeoutS: 5 });
+			if (status >= 200 && status < 300) {
+				if (String(payload?.device_id ?? "").trim() !== deviceId) continue;
+				if (
+					expectedFingerprint &&
+					String(payload?.fingerprint ?? "").trim() !== expectedFingerprint
+				) {
+					continue;
+				}
+				return supportsSyncFeature(payload?.sync_features, "reassign_scope")
+					? "supported"
+					: "unsupported";
+			}
+		} catch {
+			// Try the next reviewed address. Ambiguous/unreachable capability fails closed.
+		}
+	}
+	return "undetermined";
+}
+
 function resolveProjectInviteSelection(
 	store: MemoryStore,
 	requestedIds: string[],
+	initiatingDeviceId: string,
 ): ShareProjectIntent[] {
 	if (requestedIds.length === 0) throw new Error("project_selection_empty");
 	const requested = new Set(requestedIds);
@@ -631,7 +698,10 @@ function resolveProjectInviteSelection(
 			canonicalIdentity: project.workspace_identity,
 			displayName: project.display_project,
 			identitySource: project.identity_source,
-			existingMemoryCount: project.memory_count,
+			existingMemoryCount: countShareableProjectMemories(store.db, {
+				canonicalIdentity: project.workspace_identity,
+				initiatingDeviceId,
+			}),
 		};
 	});
 }
@@ -662,13 +732,14 @@ function projectInvitePlan(
 	inviteExpiresAt: string,
 ): { plan: ShareOperationPlan; config: ReturnType<typeof readCoordinatorSyncConfig> } {
 	const teammateName = normalizeTeammateName(String(body.teammate_name));
+	const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
+	store.adoptEnsuredDeviceIdentity(localDeviceId);
 	const projects = resolveProjectInviteSelection(
 		store,
 		projectInviteStringList(body, "project_ids"),
+		localDeviceId,
 	);
 	const { groupId, config } = projectInviteStatus();
-	const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
-	store.adoptEnsuredDeviceIdentity(localDeviceId);
 	return {
 		plan: planShareOperation({
 			inviterActorId: store.actorId,
@@ -1567,11 +1638,12 @@ function filterOpsForPeer(
 	peerDeviceId: string,
 	localDeviceId: string | null,
 	ops: ReplicationOp[],
-	options: { applyScopeFilter?: boolean } = {},
+	options: { applyScopeFilter?: boolean; supportsReassignScope?: boolean } = {},
 ): { allowed: ReplicationOp[]; skipped: number; skippedDetail: SafeSkippedSyncDetail | null } {
 	const [allowed, , skipped] = filterReplicationOpsForSyncWithStatus(store.db, ops, peerDeviceId, {
 		localDeviceId,
 		applyScopeFilter: options.applyScopeFilter,
+		supportsReassignScope: options.supportsReassignScope,
 	});
 	return {
 		allowed,
@@ -2433,6 +2505,17 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			if (limited) return limited;
 
 			try {
+				if (
+					c.req.header(SYNC_AUTHORIZATION_REFRESH_HEADER) === "1" &&
+					supportsSyncFeature(c.req.header(SYNC_FEATURES_HEADER), "reassign_scope")
+				) {
+					// Project-first provisioning grants at the coordinator immediately before
+					// this status probe. Refresh now so the managed scope can participate in
+					// the same initial sync pass instead of waiting for the daemon interval.
+					await refreshConfiguredScopeMembershipCache(store.db, undefined, {
+						keysDir: syncKeysDir(),
+					});
+				}
 				const [deviceId, fingerprint] = ensureDeviceIdentity(store.db, {
 					keysDir: syncKeysDir(),
 				});
@@ -2450,6 +2533,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 					fingerprint,
 					sync_reset: addSyncScopeToBoundary(syncReset, null),
 					sync_capability: LOCAL_SYNC_CAPABILITY,
+					sync_features: LOCAL_SYNC_FEATURES,
 				};
 				if (authorizedScopes !== null) {
 					response.authorized_scopes = authorizedScopes;
@@ -2526,7 +2610,12 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				);
 			}
 			const { ops, nextCursor, boundary } = result;
-			const filtered = filterOpsForPeer(store, peerDeviceId, localDeviceId, ops);
+			const filtered = filterOpsForPeer(store, peerDeviceId, localDeviceId, ops, {
+				supportsReassignScope: supportsSyncFeature(
+					c.req.header(SYNC_FEATURES_HEADER),
+					"reassign_scope",
+				),
+			});
 			return c.json({
 				reset_required: false,
 				sync_capability: LOCAL_SYNC_CAPABILITY,
@@ -2719,6 +2808,16 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		}
 
 		const normalizedOps = extractReplicationOps(body);
+		const peerFeatures = normalizeSyncFeatures(body.sync_features);
+		const reassignOps = normalizedOps.filter((op) => op.op_type === "reassign_scope");
+		if (reassignOps.length > 0 && !peerFeatures.includes("reassign_scope")) {
+			return c.json({ error: "reassign_capability_required" }, 409);
+		}
+		try {
+			for (const op of reassignOps) parseReassignScopePayload(op);
+		} catch {
+			return c.json({ error: "reassign_payload_invalid" }, 400);
+		}
 		for (const op of normalizedOps) {
 			if (op.device_id !== peerDeviceId || op.clock_device_id !== peerDeviceId) {
 				return c.json(
@@ -2736,6 +2835,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		// scope rejection during rollout, so outbound filtering would silently drop data.
 		const filtered = filterOpsForPeer(store, peerDeviceId, localDeviceId, normalizedOps, {
 			applyScopeFilter: false,
+			supportsReassignScope: peerFeatures.includes("reassign_scope"),
 		});
 		// Scope validation runs against the full signed batch so bad scoped ops cannot
 		// evade fail-closed rejection by also tripping peer project filters.
@@ -3668,6 +3768,90 @@ export function syncRoutes(
 				{ error: error instanceof Error ? error.message : "operation_read_failed" },
 				400,
 			);
+		}
+	});
+
+	app.post("/api/sync/project-invites/:operationId/provision", async (c) => {
+		const store = getStore();
+		const operationId = String(c.req.param("operationId") ?? "").trim();
+		if (!/^share_[a-f0-9]{40}$/u.test(operationId)) {
+			return c.json({ error: "operation_id_invalid" }, 400);
+		}
+		try {
+			const { groupId, config } = projectInviteStatus();
+			const coordinatorId = config.syncCoordinatorUrl || null;
+			if (!coordinatorId) throw new Error("coordinator_not_configured");
+			const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
+			const plan = await executeShareProvisioning(
+				store.db,
+				{ operationId, initiatingDeviceId: localDeviceId },
+				{
+					createOrGetBoundary: async (project, expectedGroupId) => {
+						if (expectedGroupId !== groupId) throw new Error("operation_scope_mismatch");
+						const readExisting = async () =>
+							(
+								await coordinatorListScopesAction({
+									groupId,
+									includeInactive: true,
+									remoteUrl: config.syncCoordinatorUrl || null,
+									adminSecret: config.syncCoordinatorAdminSecret || null,
+								})
+							).find((scope) => scope.scope_id === project.boundaryId) ?? null;
+						const existing = await readExisting();
+						if (existing) return existing;
+						try {
+							return await coordinatorCreateScopeAction({
+								groupId,
+								scopeId: project.boundaryId,
+								label: project.displayName,
+								kind: "managed_project",
+								authorityType: "coordinator",
+								coordinatorId,
+								membershipEpoch: 1,
+								status: "active",
+								remoteUrl: config.syncCoordinatorUrl || null,
+								adminSecret: config.syncCoordinatorAdminSecret || null,
+							});
+						} catch (error) {
+							const reread = await readExisting();
+							if (reread) return reread;
+							throw error;
+						}
+					},
+					grantMembership: ({ groupId: expectedGroupId, scopeId, deviceId, role }) => {
+						if (expectedGroupId !== groupId) throw new Error("operation_scope_mismatch");
+						return coordinatorGrantScopeMembershipAction({
+							groupId,
+							scopeId,
+							deviceId,
+							role,
+							membershipEpoch: 1,
+							coordinatorId,
+							remoteUrl: config.syncCoordinatorUrl || null,
+							adminSecret: config.syncCoordinatorAdminSecret || null,
+						});
+					},
+					supportsReassignScope: (deviceId) => peerSupportsReassignScope(store, deviceId),
+					refreshAuthorization: async (expectedGroupId) => {
+						if (expectedGroupId !== groupId) throw new Error("operation_scope_mismatch");
+						const refreshed = await refreshConfiguredScopeMembershipCache(store.db, config, {
+							keysDir: syncKeysDir(),
+						});
+						const group = refreshed.groups.find((item) => item.groupId === groupId);
+						if (group?.status !== "refreshed") throw new Error("authorization_refresh_failed");
+					},
+					runInitialSync: (recipientDeviceId) =>
+						runSyncPass(store.db, recipientDeviceId, {
+							keysDir: syncKeysDir(),
+							scanner: store.scanner,
+							refreshAuthorization: true,
+						}),
+				},
+			);
+			return c.json({ ok: true, operation_id: operationId, state: "active", plan });
+		} catch (error) {
+			const code = error instanceof Error ? error.message : "provisioning_failed";
+			return c.json({ error: code }, code === "operation_not_found" ? 404 : 409);
 		}
 	});
 


### PR DESCRIPTION
## Description

Fulfill accepted project-share operations with exact managed authorization boundaries. This PR creates/reuses one deterministic boundary per canonical project, grants only proven participating devices, migrates eligible history through additive replay-safe `reassign_scope` operations, persists future mappings, refreshes authorization immediately, and observes first scoped sync.

Private/personal memories remain in their original scopes and are excluded from the promised existing-memory count. Offline recipients transition to `waiting_for_device`; failed steps resume idempotently without broadening access.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated with 2,682 workspace tests, full build, Worker/D1 integration, HTTP fail-closed coverage, capability/reassignment replay tests, Snyk scan review, and independent authorization review.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced