### PR TITLE
feat(sharing): add resumable lifecycle UI

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -552,7 +552,8 @@ async function startBackgroundViewer(invocation: ResolvedServeInvocation): Promi
 }
 
 async function startForegroundViewer(invocation: ResolvedServeInvocation): Promise<void> {
-	const { createApp, createSyncApp, closeStore, getStore } = await import("@codemem/server");
+	const { advancePendingProjectShares, createApp, createSyncApp, closeStore, getStore } =
+		await import("@codemem/server");
 	const { serve } = await import("@hono/node-server");
 
 	if (invocation.dbPath) process.env.CODEMEM_DB = invocation.dbPath;
@@ -675,6 +676,14 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 						// rules apply to inbound peer payloads instead of the daemon
 						// silently falling back to the built-in default ruleset.
 						scanner: store.scanner,
+						onAfterCoordinatorRefresh: async () => {
+							const result = await advancePendingProjectShares(store, { limit: 3 });
+							if (result.failed > 0) {
+								throw new Error(
+									`share operation maintenance failed for ${result.failed} of ${result.processed} operations`,
+								);
+							}
+						},
 						onPhaseChange: (phase) => {
 							if (phase === "running") {
 								syncRuntimeStatus.phase = null;

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -510,6 +510,52 @@ describe("createCoordinatorApp dependency injection", () => {
 		expect(consumeProjectInvite).toHaveBeenCalledOnce();
 	});
 
+	it("reconstructs a safe project invite link only while the coordinator token is unconsumed", async () => {
+		const operationId = `share_${"c".repeat(40)}`;
+		const invite = {
+			invite_id: "invite-project-copy",
+			group_id: "g1",
+			token: "token-project-copy",
+			policy: "auto_admit",
+			expires_at: "2099-01-01T00:00:00Z",
+			created_at: "2026-03-28T00:00:00Z",
+			created_by: null,
+			team_name_snapshot: "Team One",
+			revoked_at: null,
+			operation_id: operationId,
+			reviewed_project_set_digest: "d".repeat(64),
+			inviter_display_name: "Adam",
+			project_intent_json: JSON.stringify([
+				{
+					canonical_identity: "git:https://example.test/codemem",
+					display_name: "codemem",
+					existing_memory_count: 3,
+				},
+			]),
+			consumed_at: null as string | null,
+		};
+		const store = createMockStore({ listInvites: vi.fn(async () => [invite]) });
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: { adminSecret: () => "test-secret", now: () => "2026-03-28T00:00:00Z" },
+			requestVerifier: allowRequest,
+		});
+		const request = () =>
+			app.request(`/v1/admin/project-invites/${operationId}?group_id=g1`, {
+				headers: { "X-Codemem-Coordinator-Admin": "test-secret" },
+			});
+
+		const pending = (await (await request()).json()) as Record<string, unknown>;
+		expect(pending.invite_link).toMatch(/^codemem:\/\/join\?invite=/u);
+		expect(JSON.stringify(pending)).not.toContain("token-project-copy");
+
+		invite.consumed_at = "2026-03-28T01:00:00Z";
+		invite.token = "consumed:invite-project-copy";
+		const consumed = (await (await request()).json()) as Record<string, unknown>;
+		expect(consumed.invite_link).toBeNull();
+		expect(JSON.stringify(consumed)).not.toContain("token-project-copy");
+	});
+
 	it("rejects invalid project-invite identity fields before consuming the invite", async () => {
 		const publicKey = "recipient-public-key";
 		const consumeProjectInvite = vi.fn(async () => {

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -1525,6 +1525,33 @@ export function createCoordinatorApp(
 			} catch {
 				return c.json({ error: "operation_intent_invalid" }, 409);
 			}
+			let inviteLinkValue: string | null = null;
+			if (
+				!invite.consumed_at &&
+				!invite.revoked_at &&
+				new Date(invite.expires_at) > new Date(runtime.now()) &&
+				invite.token &&
+				!invite.token.startsWith("consumed:")
+			) {
+				const summaries = projects.map((project) => ({
+					display_name: String(project.display_name ?? ""),
+					existing_memory_count: Number(project.existing_memory_count ?? 0),
+				}));
+				const payload: InvitePayload = {
+					v: 1,
+					kind: "coordinator_team_invite",
+					coordinator_url: new URL(c.req.url).origin,
+					group_id: invite.group_id,
+					policy: invite.policy,
+					token: invite.token,
+					expires_at: invite.expires_at,
+					team_name: invite.team_name_snapshot,
+					operation_id: operationId,
+					inviter_name: invite.inviter_display_name ?? null,
+					project_summaries: summaries,
+				};
+				inviteLinkValue = inviteLink(encodeInvitePayload(payload));
+			}
 			return c.json({
 				operation_id: invite.operation_id,
 				group_id: invite.group_id,
@@ -1541,6 +1568,7 @@ export function createCoordinatorApp(
 				bootstrap_grant_id: invite.bootstrap_grant_id,
 				trust_state: invite.trust_state,
 				projects,
+				invite_link: inviteLinkValue,
 			});
 		} finally {
 			await store.close();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -657,6 +657,18 @@ export {
 	shareProjectSetDigest,
 } from "./share-operation.js";
 export type {
+	ShareOperationLifecycle,
+	ShareOperationLifecycleInput,
+	ShareOperationLifecycleProjection,
+	ShareOperationLifecycleStepInput,
+	ShareOperationPrimaryAction,
+} from "./share-operation-lifecycle.js";
+export {
+	projectShareLifecycle,
+	SHARE_OPERATION_MAX_ATTEMPTS,
+	SHARE_OPERATION_STALE_AFTER_MS,
+} from "./share-operation-lifecycle.js";
+export type {
 	ManagedProjectPlan,
 	ReassignScopeCapability,
 	ShareProvisioningDependencies,
@@ -707,8 +719,15 @@ export {
 	SYNC_FEATURES_HEADER,
 	supportsSyncFeature,
 } from "./sync-capability.js";
-export type { SyncDaemonOptions, SyncDaemonPhase, SyncTickResult } from "./sync-daemon.js";
+export type {
+	SyncDaemonOptions,
+	SyncDaemonPhase,
+	SyncDaemonTickCallback,
+	SyncDaemonTickContext,
+	SyncTickResult,
+} from "./sync-daemon.js";
 export {
+	createSerializedDaemonTickRunner,
 	getSyncDaemonPhase,
 	runSyncDaemon,
 	setSyncDaemonError,

--- a/packages/core/src/share-operation-lifecycle.test.ts
+++ b/packages/core/src/share-operation-lifecycle.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+	projectShareLifecycle,
+	SHARE_OPERATION_STALE_AFTER_MS,
+	type ShareOperationLifecycleStepInput,
+} from "./share-operation-lifecycle.js";
+
+const now = "2026-07-20T12:20:00.000Z";
+
+function step(
+	overrides: Partial<ShareOperationLifecycleStepInput> = {},
+): ShareOperationLifecycleStepInput {
+	return {
+		attemptCount: 0,
+		lastAttemptAt: null,
+		safeErrorCode: null,
+		startedAt: null,
+		status: "pending",
+		stepKey: "authorization_refresh",
+		updatedAt: now,
+		...overrides,
+	};
+}
+
+function project(
+	state: string,
+	steps: ShareOperationLifecycleStepInput[] = [],
+	inviteLink?: string,
+) {
+	return projectShareLifecycle({
+		deviceLastSeenAt: null,
+		deviceName: "Brian's MacBook",
+		inviteLink,
+		now,
+		personName: "Brian",
+		state,
+		steps,
+	});
+}
+
+describe("projectShareLifecycle", () => {
+	it.each([
+		["accepted", "provisioning", "Setting up project access"],
+		["provisioning", "provisioning", "Setting up project access"],
+		["initial_sync", "initial_sync", "Starting first sync"],
+		["active", "active", "Up to date"],
+		["revoking", "revoking", "Removing future access"],
+	])("projects %s as %s", (state, lifecycle, label) => {
+		expect(project(state)).toMatchObject({ lifecycle, label, primaryAction: null });
+	});
+
+	it.each([
+		["revoked", "revoked", "Access removed", { kind: "share_again", label: "Share again" }],
+		[
+			"cancelled",
+			"cancelled",
+			"Invitation cancelled",
+			{ kind: "create_new_invite", label: "Create new invite" },
+		],
+	] as const)("projects %s with its required recovery action", (state, lifecycle, label, action) => {
+		expect(project(state)).toMatchObject({ lifecycle, label, primaryAction: action });
+	});
+
+	it("offers Copy invite only when the safe link is available", () => {
+		expect(project("waiting_for_acceptance", [], "codemem://invite/encoded").primaryAction).toEqual(
+			{
+				inviteLink: "codemem://invite/encoded",
+				kind: "copy_invite",
+				label: "Copy invite",
+			},
+		);
+		expect(project("waiting_for_acceptance").primaryAction).toBeNull();
+	});
+
+	it.each([
+		step({ status: "failed", safeErrorCode: "authorization_refresh_failed" }),
+		step({ status: "running", attemptCount: 3 }),
+		step({
+			status: "running",
+			attemptCount: 1,
+			lastAttemptAt: new Date(
+				new Date(now).getTime() - SHARE_OPERATION_STALE_AFTER_MS - 1,
+			).toISOString(),
+		}),
+	])("moves failed, exhausted, and stale non-device work to needs attention", (item) => {
+		const result = project("provisioning", [item]);
+		expect(result.lifecycle).toBe("needs_attention");
+		expect(result.primaryAction).toEqual({ kind: "retry_setup", label: "Retry setup" });
+	});
+
+	it("does not age never-attempted setup from invite creation", () => {
+		const result = project("accepted", [
+			step({
+				status: "pending",
+				attemptCount: 0,
+				startedAt: null,
+				lastAttemptAt: null,
+				updatedAt: new Date(
+					new Date(now).getTime() - SHARE_OPERATION_STALE_AFTER_MS - 60_000,
+				).toISOString(),
+			}),
+		]);
+
+		expect(result).toMatchObject({ lifecycle: "provisioning", primaryAction: null });
+	});
+
+	it("keeps an offline recipient passive regardless of age and attempts", () => {
+		const result = project("waiting_for_device", [
+			step({
+				attemptCount: 9,
+				lastAttemptAt: "2026-07-01T00:00:00.000Z",
+				safeErrorCode: "waiting_for_device",
+				status: "failed",
+				stepKey: "initial_sync",
+			}),
+		]);
+		expect(result).toMatchObject({ lifecycle: "waiting_for_device", primaryAction: null });
+	});
+
+	it("maps safe failure codes without leaking technical traces", () => {
+		const result = project("needs_attention", [
+			step({ status: "failed", safeErrorCode: "reassign_capability_required" }),
+		]);
+		expect(result.explanation).toContain("device must be updated");
+		expect(result.explanation).not.toContain("reassign_capability_required");
+	});
+
+	it("warns that revocation cannot recall copied memories", () => {
+		expect(project("revoked").explanation).toBe("Previously copied memories may remain.");
+	});
+});

--- a/packages/core/src/share-operation-lifecycle.ts
+++ b/packages/core/src/share-operation-lifecycle.ts
@@ -1,0 +1,178 @@
+export const SHARE_OPERATION_STALE_AFTER_MS = 10 * 60 * 1000;
+export const SHARE_OPERATION_MAX_ATTEMPTS = 3;
+
+export type ShareOperationLifecycle =
+	| "waiting_for_acceptance"
+	| "provisioning"
+	| "initial_sync"
+	| "waiting_for_device"
+	| "active"
+	| "needs_attention"
+	| "revoking"
+	| "revoked"
+	| "cancelled";
+
+export type ShareOperationPrimaryAction =
+	| { kind: "copy_invite"; label: "Copy invite"; inviteLink: string }
+	| { kind: "retry_setup"; label: "Retry setup" }
+	| { kind: "share_again"; label: "Share again" }
+	| { kind: "create_new_invite"; label: "Create new invite" };
+
+export interface ShareOperationLifecycleStepInput {
+	stepKey: string;
+	status: "pending" | "running" | "completed" | "failed";
+	attemptCount: number;
+	startedAt: string | null;
+	lastAttemptAt: string | null;
+	updatedAt: string;
+	safeErrorCode: string | null;
+}
+
+export interface ShareOperationLifecycleInput {
+	state: string;
+	personName: string;
+	deviceName: string | null;
+	deviceLastSeenAt: string | null;
+	inviteLink?: string | null;
+	steps: ShareOperationLifecycleStepInput[];
+	now: string;
+}
+
+export interface ShareOperationLifecycleProjection {
+	lifecycle: ShareOperationLifecycle;
+	label: string;
+	explanation: string;
+	primaryAction: ShareOperationPrimaryAction | null;
+	failureCode: string | null;
+}
+
+const DEVICE_WAIT_CODES = new Set(["waiting_for_device", "device_offline", "recipient_offline"]);
+
+const FAILURE_COPY: Record<string, string> = {
+	authorization_refresh_failed: "Project access could not be refreshed on this device.",
+	initial_sync_scope_incomplete: "The first project sync did not finish.",
+	inviter_project_access_ambiguous:
+		"Existing project access needs review before setup can continue.",
+	managed_boundary_conflict: "The project access boundary does not match the reviewed share.",
+	managed_grant_conflict: "Project access could not be granted as reviewed.",
+	operation_read_failed: "Invitation status could not be refreshed from the coordinator.",
+	project_mapping_conflict: "The project is already assigned to different access settings.",
+	reassign_capability_required:
+		"A participating device must be updated before project history can be shared.",
+	recipient_device_identity_conflict:
+		"The accepted device identity no longer matches this invitation.",
+	provisioning_failed: "Project access setup did not finish.",
+};
+
+function validTime(value: string | null): number | null {
+	if (!value) return null;
+	const time = new Date(value).getTime();
+	return Number.isNaN(time) ? null : time;
+}
+
+function isDeviceWait(step: ShareOperationLifecycleStepInput): boolean {
+	return step.stepKey === "initial_sync" && DEVICE_WAIT_CODES.has(step.safeErrorCode ?? "");
+}
+
+function stepAgeMs(step: ShareOperationLifecycleStepInput, nowMs: number): number {
+	const since = validTime(step.lastAttemptAt) ?? validTime(step.startedAt);
+	return since == null ? 0 : Math.max(0, nowMs - since);
+}
+
+function failureExplanation(code: string | null): string {
+	return FAILURE_COPY[code ?? ""] ?? "Project access setup did not finish safely.";
+}
+
+function passive(
+	lifecycle: ShareOperationLifecycle,
+	label: string,
+	explanation: string,
+): ShareOperationLifecycleProjection {
+	return { lifecycle, label, explanation, primaryAction: null, failureCode: null };
+}
+
+export function projectShareLifecycle(
+	input: ShareOperationLifecycleInput,
+): ShareOperationLifecycleProjection {
+	const personName = input.personName.trim() || "your teammate";
+	const deviceName = input.deviceName?.trim() || `${personName}'s device`;
+	if (input.state === "revoking") {
+		return passive("revoking", "Removing future access", "Previously copied memories may remain.");
+	}
+	if (input.state === "revoked") {
+		return {
+			lifecycle: "revoked",
+			label: "Access removed",
+			explanation: "Previously copied memories may remain.",
+			primaryAction: { kind: "share_again", label: "Share again" },
+			failureCode: null,
+		};
+	}
+	if (input.state === "cancelled") {
+		return {
+			lifecycle: "cancelled",
+			label: "Invitation cancelled",
+			explanation: "No project access was added.",
+			primaryAction: { kind: "create_new_invite", label: "Create new invite" },
+			failureCode: null,
+		};
+	}
+	if (input.state === "waiting_for_acceptance") {
+		const inviteLink = input.inviteLink?.trim();
+		return {
+			lifecycle: "waiting_for_acceptance",
+			label: "Waiting for acceptance",
+			explanation: `Waiting for ${personName} to accept the invitation.`,
+			primaryAction: inviteLink ? { kind: "copy_invite", label: "Copy invite", inviteLink } : null,
+			failureCode: null,
+		};
+	}
+
+	const incomplete = input.steps.filter((step) => step.status !== "completed");
+	const deviceWait = incomplete.find(isDeviceWait);
+	if (input.state === "waiting_for_device" || deviceWait) {
+		const lastSeen = input.deviceLastSeenAt?.trim();
+		return passive(
+			"waiting_for_device",
+			"Waiting for device",
+			lastSeen
+				? `${deviceName} is offline. Sync will continue when it reconnects; last seen ${lastSeen}.`
+				: `${deviceName} is offline. Sync will continue when it reconnects.`,
+		);
+	}
+
+	const nowMs = validTime(input.now) ?? 0;
+	const failed = incomplete.find((step) => step.status === "failed" && !isDeviceWait(step));
+	const exhausted = incomplete.find(
+		(step) =>
+			!isDeviceWait(step) &&
+			(step.attemptCount >= SHARE_OPERATION_MAX_ATTEMPTS ||
+				(["pending", "running"].includes(step.status) &&
+					stepAgeMs(step, nowMs) > SHARE_OPERATION_STALE_AFTER_MS)),
+	);
+	if (input.state === "needs_attention" || failed || exhausted) {
+		const code = failed?.safeErrorCode ?? exhausted?.safeErrorCode ?? null;
+		return {
+			lifecycle: "needs_attention",
+			label: "Setup needs attention",
+			explanation: failureExplanation(code),
+			primaryAction: { kind: "retry_setup", label: "Retry setup" },
+			failureCode: code,
+		};
+	}
+	if (input.state === "initial_sync") {
+		return passive(
+			"initial_sync",
+			"Starting first sync",
+			`Sending the reviewed projects to ${deviceName}.`,
+		);
+	}
+	if (input.state === "active") {
+		return passive("active", "Up to date", "Existing memories and future activity are shared.");
+	}
+	return passive(
+		"provisioning",
+		"Setting up project access",
+		`Preparing the reviewed projects for ${personName}.`,
+	);
+}

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -5,6 +5,7 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { columnExists } from "./db.js";
 import {
+	createSerializedDaemonTickRunner,
 	getSyncDaemonPhase,
 	refreshCoordinatorPresenceForDaemon,
 	resolveSyncDaemonKeysDir,
@@ -386,6 +387,122 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 			verified.close();
 			rmSync(dbPath, { force: true });
 		}
+	});
+
+	it("runs tick maintenance after coordinator refresh and before peer sync", async () => {
+		const { coordinatorEnabled, fetchCoordinatorStalePeers, registerCoordinatorPresence } =
+			await import("./coordinator-runtime.js");
+		const { refreshConfiguredScopeMembershipCache } = await import("./scope-membership-cache.js");
+		const { runSyncPass } = await import("./sync-pass.js");
+		const order: string[] = [];
+		vi.mocked(coordinatorEnabled).mockReturnValue(true);
+		vi.mocked(registerCoordinatorPresence).mockImplementation(async () => {
+			order.push("presence");
+			return null;
+		});
+		vi.mocked(refreshConfiguredScopeMembershipCache).mockImplementation(async () => {
+			order.push("membership");
+			return { status: "skipped", coordinatorId: null, groups: [] } as never;
+		});
+		vi.mocked(fetchCoordinatorStalePeers).mockImplementation(async () => {
+			order.push("stale-peers");
+			return new Set();
+		});
+		vi.mocked(runSyncPass).mockImplementation(async () => {
+			order.push("peer-sync");
+			return { ok: true, opsIn: 0, opsOut: 0, addressErrors: [] } as never;
+		});
+		const dbPath = join(tmpdir(), `codemem-sync-daemon-callback-order-${Date.now()}.sqlite`);
+		const fileDb = new Database(dbPath);
+		try {
+			initTestSchema(fileDb);
+			fileDb
+				.prepare(
+					"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+				)
+				.run("peer-1", "fp1", new Date().toISOString());
+		} finally {
+			fileDb.close();
+		}
+
+		try {
+			await runTickOnce(dbPath, undefined, undefined, () => {
+				order.push("maintenance");
+			});
+			expect(order).toEqual(["presence", "membership", "maintenance", "stale-peers", "peer-sync"]);
+		} finally {
+			rmSync(dbPath, { force: true });
+		}
+	});
+
+	it("records maintenance failure and continues normal peer sync", async () => {
+		const { coordinatorEnabled } = await import("./coordinator-runtime.js");
+		const { runSyncPass } = await import("./sync-pass.js");
+		vi.mocked(coordinatorEnabled).mockReturnValue(false);
+		vi.mocked(runSyncPass).mockResolvedValue({
+			ok: true,
+			opsIn: 0,
+			opsOut: 0,
+			addressErrors: [],
+		} as never);
+		const dbPath = join(tmpdir(), `codemem-sync-daemon-callback-error-${Date.now()}.sqlite`);
+		const fileDb = new Database(dbPath);
+		try {
+			initTestSchema(fileDb);
+			fileDb
+				.prepare(
+					"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+				)
+				.run("peer-1", "fp1", new Date().toISOString());
+		} finally {
+			fileDb.close();
+		}
+
+		try {
+			await runTickOnce(dbPath, undefined, undefined, () => {
+				throw new Error("share maintenance unavailable");
+			});
+			expect(runSyncPass).toHaveBeenCalled();
+			const verified = new Database(dbPath);
+			try {
+				const state = verified
+					.prepare(
+						"SELECT last_error, last_error_at, last_ok_at FROM sync_daemon_state WHERE id = 1",
+					)
+					.get() as { last_error: string; last_error_at: string; last_ok_at: string | null };
+				expect(state.last_error).toContain(
+					"daemon tick callback failed: share maintenance unavailable",
+				);
+				expect(state.last_error_at).toBeTruthy();
+				expect(state.last_ok_at).toBeNull();
+			} finally {
+				verified.close();
+			}
+		} finally {
+			rmSync(dbPath, { force: true });
+		}
+	});
+});
+
+describe("createSerializedDaemonTickRunner", () => {
+	it("does not overlap maintenance callbacks across serialized ticks", async () => {
+		let finishFirst!: () => void;
+		const first = new Promise<void>((resolve) => {
+			finishFirst = resolve;
+		});
+		const tick = vi.fn().mockReturnValueOnce(first).mockResolvedValue(undefined);
+		const firstCompleted = vi.fn();
+		const run = createSerializedDaemonTickRunner(tick, firstCompleted);
+
+		expect(run()).toBe(true);
+		expect(run()).toBe(false);
+		expect(tick).toHaveBeenCalledTimes(1);
+		finishFirst();
+		await first;
+		await Promise.resolve();
+		expect(firstCompleted).toHaveBeenCalledTimes(1);
+		expect(run()).toBe(true);
+		expect(tick).toHaveBeenCalledTimes(2);
 	});
 });
 

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -47,7 +47,21 @@ export interface SyncDaemonOptions {
 	 * stay in lockstep with local writes.
 	 */
 	scanner?: SecretScanner;
+	/**
+	 * Optional maintenance work serialized with each daemon tick. It runs after
+	 * coordinator presence and membership refresh have been attempted and before
+	 * peer synchronization starts. Failures are recorded but do not stop peer sync.
+	 */
+	onAfterCoordinatorRefresh?: SyncDaemonTickCallback;
 }
+
+export interface SyncDaemonTickContext {
+	db: Database;
+	dbPath: string;
+	keysDir?: string;
+}
+
+export type SyncDaemonTickCallback = (context: SyncDaemonTickContext) => Promise<void> | void;
 
 export interface SyncTickResult {
 	ok: boolean;
@@ -249,6 +263,7 @@ export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> 
 	const signal = options?.signal;
 	const onPhaseChange = options?.onPhaseChange;
 	const scanner = options?.scanner;
+	const onAfterCoordinatorRefresh = options?.onAfterCoordinatorRefresh;
 	onPhaseChange?.("starting");
 
 	// Ensure device identity
@@ -275,19 +290,10 @@ export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> 
 	// Importantly, the first tick is scheduled asynchronously so startup callers
 	// are not blocked by large sync preflight work on the main request path.
 	return new Promise<void>((resolve) => {
-		let tickRunning = false;
-		let firstTickCompleted = false;
-		const runTick = () => {
-			if (tickRunning) return; // Skip if previous tick still running
-			tickRunning = true;
-			runTickOnce(dbPath, keysDir, scanner).finally(() => {
-				tickRunning = false;
-				if (!firstTickCompleted) {
-					firstTickCompleted = true;
-					onPhaseChange?.("running");
-				}
-			});
-		};
+		const runTick = createSerializedDaemonTickRunner(
+			() => runTickOnce(dbPath, keysDir, scanner, onAfterCoordinatorRefresh),
+			() => onPhaseChange?.("running"),
+		);
 
 		const timer = setInterval(runTick, intervalS * 1000);
 		setTimeout(runTick, 0).unref?.();
@@ -309,6 +315,26 @@ export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> 
 	});
 }
 
+export function createSerializedDaemonTickRunner(
+	runTick: () => Promise<void>,
+	onFirstCompleted?: () => void,
+): () => boolean {
+	let tickRunning = false;
+	let firstTickCompleted = false;
+	return () => {
+		if (tickRunning) return false;
+		tickRunning = true;
+		void runTick().finally(() => {
+			tickRunning = false;
+			if (!firstTickCompleted) {
+				firstTickCompleted = true;
+				onFirstCompleted?.();
+			}
+		});
+		return true;
+	};
+}
+
 /**
  * Run a single tick, opening and closing a DB connection.
  *
@@ -318,6 +344,7 @@ export async function runTickOnce(
 	dbPath: string,
 	keysDir?: string,
 	scanner?: SecretScanner,
+	onAfterCoordinatorRefresh?: SyncDaemonTickCallback,
 ): Promise<void> {
 	const resolvedKeysDir = resolveSyncDaemonKeysDir(keysDir);
 	const db = connectDb(dbPath);
@@ -329,6 +356,15 @@ export async function runTickOnce(
 			// Coordinator discovery is a supplemental surface. Keep direct peer sync running
 			// even when heartbeat posting fails for this tick.
 		}
+		let callbackFailed = false;
+		try {
+			await onAfterCoordinatorRefresh?.({ db, dbPath, keysDir: resolvedKeysDir });
+		} catch (error) {
+			callbackFailed = true;
+			const message = error instanceof Error ? error.message : String(error);
+			const stack = error instanceof Error ? (error.stack ?? "") : "";
+			setSyncDaemonError(db, `daemon tick callback failed: ${message}`, stack);
+		}
 		// Best-effort: skip peers the coordinator reports as offline.
 		// Returns empty set when coordinator is disabled or lookup fails.
 		const stalePeers = await fetchCoordinatorStalePeers(db, dbPath, resolvedKeysDir);
@@ -336,7 +372,7 @@ export async function runTickOnce(
 		const needsAttention = results.some((r) => !r.ok && r.error?.includes("needs_attention"));
 		if (needsAttention) {
 			setSyncDaemonPhase(db, "needs_attention");
-		} else {
+		} else if (!callbackFailed) {
 			// Clear any prior needs_attention phase — all peers are healthy.
 			setSyncDaemonOk(db);
 		}

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -43,6 +43,7 @@ export { loadProjects, loadRuntimeInfo, pingViewerReady } from "./api/runtime";
 export { loadRawEvents, loadSession, loadStats, loadUsage } from "./api/stats";
 export {
 	acceptDiscoveredPeer,
+	advanceShareOperation,
 	assignPeerActor,
 	claimLegacyDeviceIdentity,
 	createActor,
@@ -58,6 +59,8 @@ export {
 	loadCoordinatorGroupPreferences,
 	loadPairing,
 	loadProjectScopeInventory,
+	loadShareOperation,
+	loadShareOperations,
 	loadSharingDomainSettings,
 	loadSyncActors,
 	loadSyncStatus,

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { triggerSync } from "./sync";
+import {
+	advanceShareOperation,
+	loadShareOperation,
+	loadShareOperations,
+	triggerSync,
+} from "./sync";
 
 const originalFetch = globalThis.fetch;
 
@@ -24,6 +29,50 @@ describe("triggerSync", () => {
 				body: JSON.stringify({ peer_device_id: "peer-redacted" }),
 				method: "POST",
 			}),
+		);
+	});
+});
+
+describe("share operation API", () => {
+	it("loads the typed lifecycle list and advances through the single recovery endpoint", async () => {
+		const operation = {
+			operation_id: `share_${"a".repeat(40)}`,
+			person: { actor_id: "actor-brian", display_name: "Brian" },
+			devices: [],
+			projects: [{ display_name: "codemem", existing_memory_count: 3 }],
+			project_count: 1,
+			lifecycle: {
+				state: "active",
+				label: "Up to date",
+				explanation: "Existing memories and future activity are shared.",
+				primary_action: null,
+			},
+			timestamps: {
+				created_at: "2026-07-20T00:00:00Z",
+				updated_at: "2026-07-20T00:01:00Z",
+				accepted_at: "2026-07-20T00:00:30Z",
+				invite_expires_at: "2026-07-27T00:00:00Z",
+			},
+		} as const;
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(new Response(JSON.stringify({ items: [operation] }), { status: 200 }))
+			.mockResolvedValueOnce(new Response(JSON.stringify(operation), { status: 200 }))
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ ok: true, operation }), { status: 200 }),
+			);
+		globalThis.fetch = fetchMock as typeof fetch;
+
+		expect((await loadShareOperations()).items[0]?.lifecycle.label).toBe("Up to date");
+		expect((await loadShareOperation(operation.operation_id)).operation_id).toBe(
+			operation.operation_id,
+		);
+		expect((await advanceShareOperation(operation.operation_id)).operation_id).toBe(
+			operation.operation_id,
+		);
+		expect(fetchMock).toHaveBeenLastCalledWith(
+			`/api/sync/share-operations/${operation.operation_id}/advance`,
+			{ method: "POST" },
 		);
 	});
 });

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -255,6 +255,54 @@ export interface ProjectScopeInventoryProject extends ProjectScopeCandidate {
 	memory_count: number | null;
 	session_count: number;
 	statuses: ProjectScopeInventoryStatus[];
+	sharing?: ProjectSharingSummary[];
+}
+
+export interface ProjectSharingSummary {
+	person: { actor_id: string; display_name: string };
+	lifecycle: Pick<ShareOperationLifecycle, "state" | "label" | "explanation">;
+}
+
+export type ShareOperationLifecycleState =
+	| "waiting_for_acceptance"
+	| "provisioning"
+	| "initial_sync"
+	| "waiting_for_device"
+	| "active"
+	| "needs_attention"
+	| "revoking"
+	| "revoked"
+	| "cancelled";
+
+export interface ShareOperationLifecycle {
+	state: ShareOperationLifecycleState;
+	label: string;
+	explanation: string;
+	primary_action:
+		| { kind: "copy_invite"; label: string; invite_link?: string }
+		| { kind: "retry_setup"; label: string }
+		| { kind: "share_again"; label: string }
+		| { kind: "create_new_invite"; label: string }
+		| null;
+}
+
+export interface ShareOperationReadModel {
+	operation_id: string;
+	person: { actor_id: string; display_name: string };
+	devices: Array<{ device_id: string; display_name: string; last_seen_at: string | null }>;
+	projects: Array<{ project_id?: string; display_name: string; existing_memory_count: number }>;
+	project_count: number;
+	lifecycle: ShareOperationLifecycle;
+	timestamps: {
+		created_at: string;
+		updated_at: string;
+		accepted_at: string | null;
+		invite_expires_at: string;
+	};
+}
+
+export interface ShareOperationList {
+	items: ShareOperationReadModel[];
 }
 
 export interface ProjectScopeInventoryResult {
@@ -435,6 +483,30 @@ export function createProjectInvite(input: {
 	reviewed_project_set_digest: string;
 }): Promise<CreatedProjectInvite> {
 	return projectInviteRequest("/api/sync/project-invites", input);
+}
+
+export function loadShareOperations(): Promise<ShareOperationList> {
+	return fetchJson<ShareOperationList>("/api/sync/share-operations");
+}
+
+export function loadShareOperation(operationId: string): Promise<ShareOperationReadModel> {
+	return fetchJson<ShareOperationReadModel>(
+		`/api/sync/share-operations/${encodeURIComponent(operationId)}`,
+	);
+}
+
+export async function advanceShareOperation(operationId: string): Promise<ShareOperationReadModel> {
+	const resp = await fetch(
+		`/api/sync/share-operations/${encodeURIComponent(operationId)}/advance`,
+		{ method: "POST" },
+	);
+	const { text, payload } = await readJsonPayload<{
+		error?: string;
+		operation?: ShareOperationReadModel;
+	}>(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	if (!payload?.operation) throw new Error("response missing share operation");
+	return payload.operation;
 }
 
 export async function saveSharingDomainProjectMapping(input: {

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -1,6 +1,7 @@
 /* Global application state — shared across tabs. */
 
 import type { UiSyncViewModel } from "../tabs/sync/view-model";
+import type { ShareOperationReadModel } from "./api/sync";
 
 export type RefreshState = "idle" | "refreshing" | "paused" | "error";
 export type TabId = "feed" | "projects" | "sync" | "health" | "coordinator-admin";
@@ -242,6 +243,8 @@ export const state = {
 	lastSyncStatus: null as CachedSyncStatus | null,
 	lastSyncActors: [] as SyncActor[],
 	lastSyncPeers: [] as SyncPeer[],
+	lastShareOperations: [] as ShareOperationReadModel[],
+	shareOperationsLoadError: false,
 	pendingAcceptedSyncPeers: [] as SyncPeer[],
 	lastSyncSharingReview: [] as SyncSharingReviewRow[],
 	lastSyncLegacySharedReview: null as CachedLegacySharedReview | null,

--- a/packages/ui/src/project-first-layout.test.ts
+++ b/packages/ui/src/project-first-layout.test.ts
@@ -1,0 +1,24 @@
+/// <reference types="vite/client" />
+
+import { describe, expect, it } from "vitest";
+import html from "../static/index.html?raw";
+
+describe("project-first Sync layout", () => {
+	it("includes the Projects share-flow mount used by row-level Share actions", () => {
+		expect(html).toContain('id="projectShareFlowMount"');
+	});
+
+	it("keeps legacy device controls available but outside the primary project-sharing flow", () => {
+		const primary = html.indexOf('id="syncProjectShareOperations"');
+		const advanced = html.indexOf("Manual device and identity controls");
+		const assignment = html.indexOf('id="syncActorCreateButton"');
+		const diagnostics = html.indexOf("Advanced diagnostics");
+
+		expect(primary).toBeGreaterThan(-1);
+		expect(advanced).toBeGreaterThan(primary);
+		expect(assignment).toBeGreaterThan(advanced);
+		expect(diagnostics).toBeGreaterThan(assignment);
+		expect(html.slice(advanced, diagnostics)).toContain("Connect another device");
+		expect(html.slice(advanced, diagnostics)).toContain("Create person");
+	});
+});

--- a/packages/ui/src/tabs/coordinator-admin/components/invites-panel.test.tsx
+++ b/packages/ui/src/tabs/coordinator-admin/components/invites-panel.test.tsx
@@ -1,0 +1,65 @@
+import type { ComponentChildren, VNode } from "preact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { state } from "../../../lib/state";
+import { coordinatorAdminState } from "../data/state";
+import { renderInvitesPanel } from "./invites-panel";
+
+describe("Teams invite panel", () => {
+	function textContent(value: ComponentChildren): string {
+		if (value == null || typeof value === "boolean") return "";
+		if (typeof value === "string" || typeof value === "number") return String(value);
+		if (Array.isArray(value)) return value.map(textContent).join("");
+		return textContent((value as VNode).props.children);
+	}
+
+	beforeEach(() => {
+		state.lastCoordinatorAdminStatus = {
+			active_group: "team-a",
+			has_admin_secret: true,
+			readiness: "ready",
+		};
+		state.lastShareOperations = [
+			{
+				operation_id: `share_${"a".repeat(40)}`,
+				person: { actor_id: "actor-brian", display_name: "Brian" },
+				devices: [],
+				projects: [{ display_name: "codemem", existing_memory_count: 3 }],
+				project_count: 1,
+				lifecycle: {
+					state: "active",
+					label: "Up to date",
+					explanation: "Existing memories and future activity are shared.",
+					primary_action: null,
+				},
+				timestamps: {
+					created_at: "2026-07-20T00:00:00Z",
+					updated_at: "2026-07-20T00:01:00Z",
+					accepted_at: "2026-07-20T00:00:30Z",
+					invite_expires_at: "2026-07-27T00:00:00Z",
+				},
+			},
+		];
+		coordinatorAdminState.invitePending = false;
+	});
+
+	afterEach(() => {
+		state.lastShareOperations = [];
+	});
+
+	it("labels coordinator invites as legacy and reflects project sharing read-only", () => {
+		const text = textContent(
+			renderInvitesPanel({
+				createInvite: vi.fn(),
+				renderShell: vi.fn(),
+				summary: { detail: "", readiness: "ready", title: "Ready" },
+			}),
+		);
+
+		expect(text).toContain("Legacy Team invites");
+		expect(text).toContain("do not grant project access");
+		expect(text).toContain("Brian");
+		expect(text).toContain("codemem");
+		expect(text).toContain("Up to date");
+		expect(text).not.toContain("Share project");
+	});
+});

--- a/packages/ui/src/tabs/coordinator-admin/components/invites-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/invites-panel.ts
@@ -34,12 +34,12 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 	return h(
 		RadixTabsContent,
 		{ className: "coordinator-admin-panel", value: "invites" },
-		h("h3", null, "Create teammate invite"),
+		h("h3", null, "Legacy Team invites"),
 		h(
 			"p",
 			{ class: "peer-submeta" },
 			summary.readiness === "ready"
-				? "Generate an invite for the selected Team. Default Space access is controlled by that Team's auto-grant setting."
+				? "Legacy Team invites enroll a device in the selected Team. They do not grant project access; share projects from Projects instead."
 				: "Finish setup first. Invite creation stays disabled until the local Teams configuration is ready.",
 		),
 		h(
@@ -125,7 +125,7 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 						disabled: inviteDisabled,
 						type: "submit",
 					},
-					coordinatorAdminState.invitePending ? "Creating…" : "Create invite",
+					coordinatorAdminState.invitePending ? "Creating…" : "Create legacy Team invite",
 				),
 				effectiveGroup
 					? h("span", { class: "peer-submeta" }, `Using Team ${effectiveGroup}`)
@@ -157,5 +157,29 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 		warnings?.length
 			? h("div", { class: "peer-meta coordinator-admin-warning-list" }, warnings.join(" · "))
 			: null,
+		h("h3", null, "Project sharing operations"),
+		h(
+			"p",
+			{ class: "peer-submeta" },
+			"Read-only status from the project-first sharing flow. Start new sharing from Projects.",
+		),
+		state.lastShareOperations.length > 0
+			? h(
+					"ul",
+					{ class: "peer-scope-rejections-list", "aria-label": "Project sharing operations" },
+					...state.lastShareOperations.map((operation) =>
+						h(
+							"li",
+							{ key: operation.operation_id },
+							h("strong", null, operation.person.display_name),
+							h(
+								"span",
+								null,
+								` — ${operation.projects.map((project) => project.display_name).join(", ")} — ${operation.lifecycle.label}`,
+							),
+						),
+					),
+				)
+			: h("div", { class: "peer-meta" }, "No project sharing operations yet."),
 	);
 }

--- a/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
+++ b/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
@@ -208,6 +208,12 @@ export async function loadCoordinatorAdminData() {
 	resolveAdminTargetGroup();
 	if (state.lastCoordinatorAdminStatus?.readiness === "ready") {
 		try {
+			const payload = await api.loadShareOperations();
+			state.lastShareOperations = Array.isArray(payload.items) ? payload.items : [];
+		} catch {
+			// Keep the previous read-only reflection; Teams administration remains usable.
+		}
+		try {
 			const groupsPayload = (await api.loadCoordinatorAdminGroupsFiltered(
 				coordinatorAdminState.showArchivedGroups,
 			)) as {

--- a/packages/ui/src/tabs/project-sharing.test.tsx
+++ b/packages/ui/src/tabs/project-sharing.test.tsx
@@ -1,4 +1,4 @@
-import type { ComponentChildren } from "preact";
+import { type ComponentChildren, render } from "preact";
 import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -96,8 +96,29 @@ describe("project sharing flow", () => {
 	});
 
 	afterEach(() => {
+		const mount = document.getElementById("mount");
+		if (mount) act(() => render(null, mount));
 		vi.clearAllMocks();
 		document.body.innerHTML = "";
+	});
+
+	it("opens a queued recovery request after direct Sync-tab startup", async () => {
+		expect(openProjectShareFlow([project.workspace_identity], "Brian")).toBe(true);
+		expect(window.location.hash).toBe("#projects");
+		const mount = document.getElementById("mount");
+		if (!mount) throw new Error("mount missing");
+
+		await act(async () => {
+			renderProjectShareFlow(mount, [project]);
+			await Promise.resolve();
+		});
+
+		expect((document.getElementById("project-share-teammate") as HTMLInputElement).value).toBe(
+			"Brian",
+		);
+		expect((document.querySelector('input[type="checkbox"]') as HTMLInputElement).checked).toBe(
+			true,
+		);
 	});
 
 	it("reviews exact projects, counts, and future sharing without internal terminology", async () => {
@@ -170,10 +191,35 @@ describe("project sharing flow", () => {
 		};
 		act(() => renderProjectShareFlow(mount, [project, selected]));
 
-		act(() => openProjectShareFlow([selected.workspace_identity]));
+		act(() => {
+			openProjectShareFlow([selected.workspace_identity]);
+		});
 
 		const checkboxes = [...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')];
 		expect(checkboxes.map((checkbox) => checkbox.checked)).toEqual([false, true]);
+	});
+
+	it("blocks terminal-action restart when any original project is unavailable", () => {
+		const mount = document.getElementById("mount");
+		if (!mount) throw new Error("mount missing");
+		act(() => renderProjectShareFlow(mount, [project]));
+
+		act(() => {
+			openProjectShareFlow([project.workspace_identity, "git:missing"], "Brian");
+		});
+
+		expect((document.getElementById("project-share-teammate") as HTMLInputElement).value).toBe(
+			"Brian",
+		);
+		expect((document.querySelector('input[type="checkbox"]') as HTMLInputElement).checked).toBe(
+			false,
+		);
+		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+			"original project selection is no longer available",
+		);
+		expect((document.querySelector(".sync-dialog-confirm") as HTMLButtonElement).disabled).toBe(
+			true,
+		);
 	});
 
 	it("uses unique control IDs for canonical identities that sanitize alike", () => {
@@ -209,6 +255,18 @@ describe("project sharing flow", () => {
 		expect(document.getElementById("project-share-inventory-error")?.textContent).toContain(
 			"Refresh Projects to try again",
 		);
+	});
+
+	it("rejects and clears queued requests when the complete inventory cannot be loaded", () => {
+		const mount = document.getElementById("mount");
+		if (!mount) throw new Error("mount missing");
+		expect(openProjectShareFlow([project.workspace_identity], "Old teammate")).toBe(true);
+		act(() => renderProjectShareFlow(mount, [], { inventoryError: true }));
+
+		expect(openProjectShareFlow([project.workspace_identity], "New teammate")).toBe(false);
+		act(() => renderProjectShareFlow(mount, [project]));
+
+		expect(document.querySelector('[role="dialog"]')).toBeNull();
 	});
 
 	it("closes and clears an open selector when the complete inventory becomes unavailable", () => {

--- a/packages/ui/src/tabs/project-sharing.tsx
+++ b/packages/ui/src/tabs/project-sharing.tsx
@@ -8,10 +8,20 @@ import type {
 	ProjectScopeInventoryProject,
 } from "../lib/api/sync";
 
-let requestOpen: ((projectIds: string[]) => void) | null = null;
+type ProjectShareRequest = { projectIds: string[]; teammateName: string };
 
-export function openProjectShareFlow(projectIds: string[] = []): void {
-	requestOpen?.(projectIds);
+let pendingOpen: ProjectShareRequest | null = null;
+let requestOpen: ((projectIds: string[], teammateName?: string) => boolean) | null = null;
+
+export function openProjectShareFlow(projectIds: string[] = [], teammateName = ""): boolean {
+	if (requestOpen) {
+		const opened = requestOpen(projectIds, teammateName);
+		if (!opened) pendingOpen = null;
+		return opened;
+	}
+	pendingOpen = { projectIds, teammateName };
+	window.location.hash = "#projects";
+	return true;
 }
 
 function canShare(project: ProjectScopeInventoryProject): boolean {
@@ -111,21 +121,35 @@ function ProjectShareFlow({
 	const [error, setError] = useState<string | null>(null);
 	const [busy, setBusy] = useState(false);
 	const [copyStatus, setCopyStatus] = useState<string | null>(null);
+	const [selectionBlocked, setSelectionBlocked] = useState(false);
 	const availableProjects = useMemo(() => projects.filter(canShare), [projects]);
 
 	useEffect(() => {
-		requestOpen = (projectIds) => {
-			if (inventoryError) return;
-			setTeammateName("");
-			setSelectedIds(
-				projectIds.filter((id) => availableProjects.some((item) => item.workspace_identity === id)),
+		requestOpen = (projectIds, requestedTeammateName = "") => {
+			if (inventoryError) return false;
+			const requestedIds = [...new Set(projectIds)];
+			const unavailableSelection = requestedIds.some(
+				(id) => !availableProjects.some((item) => item.workspace_identity === id),
 			);
+			setTeammateName(requestedTeammateName.trim());
+			setSelectedIds(unavailableSelection ? [] : requestedIds);
+			setSelectionBlocked(unavailableSelection);
 			setPreview(null);
 			setCreated(null);
-			setError(null);
+			setError(
+				unavailableSelection
+					? "The original project selection is no longer available. Refresh Projects and try again."
+					: null,
+			);
 			setCopyStatus(null);
 			setOpen(true);
+			return true;
 		};
+		if (pendingOpen) {
+			const pending = pendingOpen;
+			pendingOpen = null;
+			requestOpen(pending.projectIds, pending.teammateName);
+		}
 		return () => {
 			requestOpen = null;
 		};
@@ -133,6 +157,7 @@ function ProjectShareFlow({
 
 	useEffect(() => {
 		if (!inventoryError) return;
+		pendingOpen = null;
 		setOpen(false);
 		setTeammateName("");
 		setSelectedIds([]);
@@ -140,6 +165,7 @@ function ProjectShareFlow({
 		setCreated(null);
 		setError(null);
 		setCopyStatus(null);
+		setSelectionBlocked(false);
 	}, [inventoryError]);
 
 	const close = () => {
@@ -308,7 +334,7 @@ function ProjectShareFlow({
 							{!created ? (
 								<button
 									className="settings-button sync-dialog-confirm"
-									disabled={busy}
+									disabled={busy || selectionBlocked}
 									onClick={() => void (preview ? create() : review())}
 									type="button"
 								>

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -403,6 +403,98 @@ describe("Projects tab", () => {
 		);
 	});
 
+	it("shows exact project sharing People without leaking the summary to a sibling identity", async () => {
+		const selected = project({
+			display_project: "codemem",
+			project: "codemem",
+			workspace_identity: "git:https://git.example.invalid/exampleco/codemem.git",
+			sharing: [
+				{
+					person: { actor_id: "actor-brian", display_name: "Brian" },
+					lifecycle: {
+						state: "active",
+						label: "Up to date",
+						explanation: "Existing memories and future activity are shared.",
+					},
+				},
+				{
+					person: { actor_id: "actor-alex", display_name: "Alex" },
+					lifecycle: {
+						state: "waiting_for_device",
+						label: "Waiting for device",
+						explanation: "Sync will continue when the device reconnects.",
+					},
+				},
+			],
+		});
+		const sibling = project({
+			display_project: "codemem-docs",
+			project: "codemem-docs",
+			workspace_identity: "git:https://git.example.invalid/exampleco/codemem-docs.git",
+			sharing: [],
+		});
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [selected, sibling],
+			total: 2,
+		});
+
+		await loadProjectsData();
+
+		const rows = [...document.querySelectorAll<HTMLElement>(".project-inventory-row")];
+		const selectedRow = rows.find(
+			(row) => row.querySelector(".project-inventory-title")?.textContent === "codemem",
+		);
+		const siblingRow = rows.find(
+			(row) => row.querySelector(".project-inventory-title")?.textContent === "codemem-docs",
+		);
+		expect(selectedRow?.querySelector(".project-sharing-summary")?.textContent).toContain("Brian");
+		expect(selectedRow?.querySelector(".project-sharing-summary")?.textContent).toContain("Alex");
+		expect(selectedRow?.textContent).toContain("Up to date");
+		expect(selectedRow?.textContent).toContain("Waiting for device");
+		expect(siblingRow?.querySelector(".project-sharing-summary")).toBeNull();
+	});
+
+	it("describes revoked and cancelled project shares as history", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [
+				project({
+					sharing: [
+						{
+							person: { actor_id: "actor-brian", display_name: "Brian" },
+							lifecycle: {
+								state: "revoked",
+								label: "Access removed",
+								explanation: "Previously copied memories may remain.",
+							},
+						},
+						{
+							person: { actor_id: "actor-alex", display_name: "Alex" },
+							lifecycle: {
+								state: "cancelled",
+								label: "Invitation cancelled",
+								explanation: "No project access was added.",
+							},
+						},
+					],
+				}),
+			],
+			total: 1,
+		});
+
+		await loadProjectsData();
+
+		const summary = document.querySelector(".project-sharing-summary");
+		expect(summary?.textContent).toContain("Previously shared with Brian");
+		expect(summary?.textContent).toContain("Invitation to Alex cancelled");
+		expect(summary?.querySelector("strong")?.textContent).toBe("Project sharing");
+	});
+
 	it("removes the project inventory skeleton when loading fails", async () => {
 		vi.mocked(api.loadProjectScopeInventory).mockRejectedValue(new Error("inventory unavailable"));
 

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -84,6 +84,30 @@ function projectResolutionLabel(project: ProjectScopeInventoryProject): string {
 		: formatResolution(project.resolution_reason);
 }
 
+function projectSharingRelationshipLabel(
+	summary: NonNullable<ProjectScopeInventoryProject["sharing"]>[number],
+): string {
+	const personName = summary.person.display_name;
+	switch (summary.lifecycle.state) {
+		case "waiting_for_acceptance":
+			return `Invitation sent to ${personName}`;
+		case "active":
+			return `Shared with ${personName}`;
+		case "waiting_for_device":
+			return `Waiting for ${personName}'s device`;
+		case "needs_attention":
+			return `Sharing with ${personName} needs attention`;
+		case "revoking":
+			return `Removing sharing with ${personName}`;
+		case "revoked":
+			return `Previously shared with ${personName}`;
+		case "cancelled":
+			return `Invitation to ${personName} cancelled`;
+		default:
+			return `Setting up sharing with ${personName}`;
+	}
+}
+
 function formatLatest(value: string | null): string {
 	if (!value) return "No recent sessions";
 	const date = new Date(value);
@@ -649,6 +673,26 @@ function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 	meta.className = "project-inventory-meta";
 	meta.textContent = `${projectResolutionLabel(project)} · ${project.identity_source} · ${formatLatest(project.latest_session_at)}`;
 	row.appendChild(meta);
+
+	if (project.sharing && project.sharing.length > 0) {
+		const sharing = document.createElement("div");
+		sharing.className = "settings-note project-sharing-summary";
+		const title = document.createElement("strong");
+		title.textContent = "Project sharing";
+		const list = document.createElement("ul");
+		list.setAttribute("aria-label", `People sharing ${project.display_project}`);
+		for (const summary of project.sharing) {
+			const item = document.createElement("li");
+			const person = document.createElement("strong");
+			person.textContent = projectSharingRelationshipLabel(summary);
+			const status = document.createElement("span");
+			status.textContent = ` — ${summary.lifecycle.label}. ${summary.lifecycle.explanation}`;
+			item.append(person, status);
+			list.appendChild(item);
+		}
+		sharing.append(title, list);
+		row.appendChild(sharing);
+	}
 
 	if (isPeerReceivedProject(project)) {
 		const receivedNote = document.createElement("div");

--- a/packages/ui/src/tabs/sync/components/project-share-operations.test.tsx
+++ b/packages/ui/src/tabs/sync/components/project-share-operations.test.tsx
@@ -1,0 +1,256 @@
+import { render } from "preact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../project-sharing", () => ({ openProjectShareFlow: vi.fn() }));
+
+import type { ShareOperationLifecycleState, ShareOperationReadModel } from "../../../lib/api/sync";
+import { openProjectShareFlow } from "../../project-sharing";
+import {
+	ProjectShareOperations,
+	resetProjectShareOperationFeedbackForTests,
+} from "./project-share-operations";
+
+const labels: Record<ShareOperationLifecycleState, string> = {
+	waiting_for_acceptance: "Waiting for acceptance",
+	provisioning: "Setting up project access",
+	initial_sync: "Starting first sync",
+	waiting_for_device: "Waiting for device",
+	active: "Up to date",
+	needs_attention: "Setup needs attention",
+	revoking: "Removing future access",
+	revoked: "Access removed",
+	cancelled: "Invitation cancelled",
+};
+
+function operation(
+	state: ShareOperationLifecycleState,
+	overrides: Partial<ShareOperationReadModel> = {},
+): ShareOperationReadModel {
+	const primaryAction =
+		state === "needs_attention"
+			? ({ kind: "retry_setup", label: "Retry setup" } as const)
+			: state === "waiting_for_acceptance"
+				? ({
+						kind: "copy_invite",
+						label: "Copy invite",
+						invite_link: "codemem://invite/existing-safe-link",
+					} as const)
+				: state === "revoked"
+					? ({ kind: "share_again", label: "Share again" } as const)
+					: state === "cancelled"
+						? ({ kind: "create_new_invite", label: "Create new invite" } as const)
+						: null;
+	return {
+		operation_id: `share_${state.padEnd(40, "a").slice(0, 40)}`,
+		person: { actor_id: "actor-brian", display_name: "Brian" },
+		devices:
+			state === "waiting_for_acceptance"
+				? []
+				: [
+						{
+							device_id: "2e7f4e49-6a83-4c53-9f1f-5ba57f401111",
+							display_name: "Brian's MacBook",
+							last_seen_at: null,
+						},
+					],
+		projects: [
+			{ project_id: "git:codemem", display_name: "codemem", existing_memory_count: 3 },
+			{ project_id: "git:codemem-site", display_name: "codemem-site", existing_memory_count: 2 },
+		],
+		project_count: 2,
+		lifecycle: {
+			state,
+			label: labels[state],
+			explanation:
+				state === "revoked"
+					? "Previously copied memories may remain."
+					: `${labels[state]} explanation.`,
+			primary_action: primaryAction,
+		},
+		timestamps: {
+			created_at: "2026-07-20T00:00:00Z",
+			updated_at: "2026-07-20T00:01:00Z",
+			accepted_at: null,
+			invite_expires_at: "2026-07-27T00:00:00Z",
+		},
+		...overrides,
+	};
+}
+
+describe("ProjectShareOperations", () => {
+	let mount: HTMLDivElement;
+
+	beforeEach(() => {
+		mount = document.createElement("div");
+		document.body.appendChild(mount);
+		resetProjectShareOperationFeedbackForTests();
+	});
+
+	afterEach(() => {
+		render(null, mount);
+		mount.remove();
+	});
+
+	it.each(
+		Object.keys(labels) as ShareOperationLifecycleState[],
+	)("renders %s with one lifecycle and at most one action", (state) => {
+		render(
+			<ProjectShareOperations
+				operations={[operation(state)]}
+				onAdvance={vi.fn()}
+				onReload={vi.fn()}
+			/>,
+			mount,
+		);
+		const card = mount.querySelector("article");
+		expect(card?.textContent).toContain(labels[state]);
+		expect(card?.querySelectorAll("button").length).toBeLessThanOrEqual(1);
+		expect(card?.querySelector('[role="alert"]') != null).toBe(state === "needs_attention");
+	});
+
+	it("groups strictly by actor identity and nests friendly devices and projects", () => {
+		render(
+			<ProjectShareOperations
+				operations={[
+					operation("active"),
+					operation("waiting_for_device", {
+						operation_id: `share_${"c".repeat(40)}`,
+					}),
+					operation("initial_sync", {
+						operation_id: `share_${"b".repeat(40)}`,
+						person: { actor_id: "actor-other-brian", display_name: "Brian" },
+					}),
+				]}
+				onAdvance={vi.fn()}
+				onReload={vi.fn()}
+			/>,
+			mount,
+		);
+
+		expect(mount.querySelectorAll(".project-share-person-group")).toHaveLength(2);
+		expect(mount.querySelectorAll('ul[aria-label^="Devices for Brian"]')).toHaveLength(2);
+		expect(
+			mount
+				.querySelectorAll(".project-share-person-group")[0]
+				.querySelectorAll(".project-share-operation-card"),
+		).toHaveLength(2);
+		expect(
+			mount.querySelectorAll(".project-share-person-group")[0].querySelectorAll("h3"),
+		).toHaveLength(1);
+		expect(mount.textContent).toContain("Brian's MacBook");
+		expect(mount.textContent).toContain("codemem-site");
+		expect(mount.textContent).not.toContain("2e7f4e49");
+		for (const internalTerm of ["scope", "cursor", "fingerprint", "address", "group id"]) {
+			expect(mount.textContent?.toLowerCase()).not.toContain(internalTerm);
+		}
+	});
+
+	it.each([
+		["revoked", "Previously shared"],
+		["cancelled", "Invitation cancelled"],
+	] as const)("describes %s operations as historical rather than current sharing", (state, label) => {
+		render(
+			<ProjectShareOperations
+				operations={[operation(state)]}
+				onAdvance={vi.fn()}
+				onReload={vi.fn()}
+			/>,
+			mount,
+		);
+
+		const operationCard = mount.querySelector(".project-share-operation-card");
+		expect(operationCard?.textContent).toContain(label);
+		expect(operationCard?.querySelector(".peer-scope-summary")?.textContent).not.toBe("Sharing");
+	});
+
+	it.each([
+		["revoked", "Share again"],
+		["cancelled", "Create new invite"],
+	] as const)("reopens exact project sharing for %s operations", (state, label) => {
+		render(
+			<ProjectShareOperations
+				operations={[operation(state)]}
+				onAdvance={vi.fn()}
+				onReload={vi.fn()}
+			/>,
+			mount,
+		);
+
+		const button = mount.querySelector("button") as HTMLButtonElement;
+		expect(button.textContent).toBe(label);
+		button.click();
+
+		expect(openProjectShareFlow).toHaveBeenCalledWith(["git:codemem", "git:codemem-site"], "Brian");
+	});
+
+	it("runs retry through the operation advance callback with busy semantics", async () => {
+		let finishAdvance!: (value: ShareOperationReadModel) => void;
+		const advancePending = new Promise<ShareOperationReadModel>((resolve) => {
+			finishAdvance = resolve;
+		});
+		const advance = vi.fn(() => advancePending);
+		const reload = vi.fn(async () => undefined);
+		render(
+			<ProjectShareOperations
+				operations={[operation("needs_attention")]}
+				onAdvance={advance}
+				onReload={reload}
+			/>,
+			mount,
+		);
+		const button = mount.querySelector("button") as HTMLButtonElement;
+		button.click();
+		await vi.waitFor(() => expect(button.disabled).toBe(true));
+		expect(button.getAttribute("aria-busy")).toBe("true");
+		finishAdvance(operation("active"));
+		await vi.waitFor(() => expect(reload).toHaveBeenCalled());
+		expect(advance).toHaveBeenCalledWith(operation("needs_attention").operation_id);
+		expect(mount.querySelector('[role="status"]')?.textContent).toContain("Setup complete");
+	});
+
+	it("loads an invite link only when the user asks to copy it", async () => {
+		const pending = operation("waiting_for_acceptance");
+		pending.lifecycle.primary_action = { kind: "copy_invite", label: "Copy invite" };
+		const loadOperation = vi.fn(async () => operation("waiting_for_acceptance"));
+		const copyText = vi.fn(async () => undefined);
+		render(
+			<ProjectShareOperations
+				operations={[pending]}
+				onAdvance={vi.fn()}
+				onLoadOperation={loadOperation}
+				onReload={vi.fn()}
+				copyText={copyText}
+			/>,
+			mount,
+		);
+
+		(mount.querySelector("button") as HTMLButtonElement).click();
+
+		await vi.waitFor(() =>
+			expect(copyText).toHaveBeenCalledWith("codemem://invite/existing-safe-link"),
+		);
+		expect(loadOperation).toHaveBeenCalledWith(pending.operation_id);
+	});
+
+	it("keeps recovery error codes in diagnostics instead of primary feedback", async () => {
+		render(
+			<ProjectShareOperations
+				operations={[operation("needs_attention")]}
+				onAdvance={vi.fn(async () => {
+					throw new Error("operation_device_binding_missing");
+				})}
+				onReload={vi.fn()}
+			/>,
+			mount,
+		);
+
+		(mount.querySelector("button") as HTMLButtonElement).click();
+
+		await vi.waitFor(() =>
+			expect(mount.querySelector('[role="status"]')?.textContent).toContain(
+				"accepted device has not been linked",
+			),
+		);
+		expect(mount.textContent).not.toContain("operation_device_binding_missing");
+	});
+});

--- a/packages/ui/src/tabs/sync/components/project-share-operations.tsx
+++ b/packages/ui/src/tabs/sync/components/project-share-operations.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+import type { ShareOperationReadModel } from "../../../lib/api/sync";
+import { openProjectShareFlow } from "../../project-sharing";
+import { renderIntoSyncMount } from "./render-root";
+
+type Feedback = { message: string; tone: "success" | "warning" };
+
+interface ProjectShareOperationsProps {
+	operations: ShareOperationReadModel[];
+	onAdvance: (operationId: string) => Promise<ShareOperationReadModel>;
+	onLoadOperation?: (operationId: string) => Promise<ShareOperationReadModel>;
+	onReload: () => Promise<void>;
+	copyText?: (text: string) => Promise<void>;
+}
+
+const feedbackByOperation = new Map<string, Feedback>();
+let focusFeedbackForOperation: string | null = null;
+
+const RECOVERY_ERROR_COPY: Record<string, string> = {
+	operation_device_binding_missing: "The accepted device has not been linked yet.",
+	operation_not_found: "This sharing operation is no longer available.",
+	operation_scope_mismatch: "The invitation no longer matches the reviewed project access.",
+	operation_state_invalid: "The invitation is no longer in a recoverable state.",
+	reassign_capability_required: "A participating device must be updated before setup can continue.",
+};
+
+function recoveryErrorMessage(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return (
+		RECOVERY_ERROR_COPY[message] ?? "Setup could not be retried. Review diagnostics for details."
+	);
+}
+
+function byPerson(operations: ShareOperationReadModel[]): ShareOperationReadModel[][] {
+	const grouped = new Map<string, ShareOperationReadModel[]>();
+	for (const operation of operations) {
+		const personId = operation.person.actor_id;
+		grouped.set(personId, [...(grouped.get(personId) ?? []), operation]);
+	}
+	return [...grouped.values()];
+}
+
+function personDevices(operations: ShareOperationReadModel[]) {
+	return [
+		...new Map(
+			operations
+				.flatMap((operation) => operation.devices)
+				.map((device) => [device.device_id, device]),
+		).values(),
+	];
+}
+
+function relationshipLabel(state: ShareOperationReadModel["lifecycle"]["state"]): string {
+	switch (state) {
+		case "waiting_for_acceptance":
+			return "Invitation pending";
+		case "active":
+			return "Sharing";
+		case "revoking":
+			return "Removing sharing";
+		case "revoked":
+			return "Previously shared";
+		case "cancelled":
+			return "Invitation cancelled";
+		default:
+			return "Sharing setup";
+	}
+}
+
+type OperationCardProps = Omit<ProjectShareOperationsProps, "operations"> & {
+	operation: ShareOperationReadModel;
+};
+
+function OperationCard({
+	operation,
+	onAdvance,
+	onLoadOperation,
+	onReload,
+	copyText,
+}: OperationCardProps) {
+	const [busy, setBusy] = useState(false);
+	const [feedback, setFeedback] = useState<Feedback | null>(
+		() => feedbackByOperation.get(operation.operation_id) ?? null,
+	);
+	const feedbackRef = useRef<HTMLDivElement | null>(null);
+	const action = operation.lifecycle.primary_action;
+
+	useEffect(() => {
+		if (focusFeedbackForOperation !== operation.operation_id || !feedbackRef.current) return;
+		focusFeedbackForOperation = null;
+		feedbackRef.current.focus();
+	}, [feedback?.message, operation.operation_id]);
+
+	async function copyInvite(link?: string) {
+		setBusy(true);
+		try {
+			let inviteLink = link;
+			if (!inviteLink && onLoadOperation) {
+				const detail = await onLoadOperation(operation.operation_id);
+				const detailAction = detail.lifecycle.primary_action;
+				if (detailAction?.kind === "copy_invite") inviteLink = detailAction.invite_link;
+			}
+			if (!inviteLink) throw new Error("Invitation is no longer available. Refresh the status.");
+			await (copyText ?? ((text) => navigator.clipboard.writeText(text)))(inviteLink);
+			const next = { message: "Invite copied.", tone: "success" } satisfies Feedback;
+			feedbackByOperation.set(operation.operation_id, next);
+			setFeedback(next);
+		} catch (error) {
+			const next = {
+				message: error instanceof Error ? error.message : "Invite could not be copied.",
+				tone: "warning",
+			} satisfies Feedback;
+			feedbackByOperation.set(operation.operation_id, next);
+			setFeedback(next);
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	async function retrySetup() {
+		setBusy(true);
+		try {
+			const updated = await onAdvance(operation.operation_id);
+			const next =
+				updated.lifecycle.state === "active"
+					? ({ message: "Setup complete.", tone: "success" } satisfies Feedback)
+					: updated.lifecycle.state === "needs_attention"
+						? ({ message: "Setup still needs attention.", tone: "warning" } satisfies Feedback)
+						: ({
+								message: `Retry started. ${updated.lifecycle.label}.`,
+								tone: "success",
+							} satisfies Feedback);
+			feedbackByOperation.set(operation.operation_id, next);
+			focusFeedbackForOperation = operation.operation_id;
+			setFeedback(next);
+			await onReload();
+		} catch (error) {
+			const next = {
+				message: recoveryErrorMessage(error),
+				tone: "warning",
+			} satisfies Feedback;
+			feedbackByOperation.set(operation.operation_id, next);
+			setFeedback(next);
+			queueMicrotask(() => feedbackRef.current?.focus());
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	function restartSharing() {
+		const projectIds = operation.projects
+			.map((project) => project.project_id?.trim())
+			.filter((projectId): projectId is string => Boolean(projectId));
+		if (projectIds.length !== operation.projects.length) {
+			const next = {
+				message: "The original project selection is unavailable. Refresh Projects and try again.",
+				tone: "warning",
+			} satisfies Feedback;
+			feedbackByOperation.set(operation.operation_id, next);
+			setFeedback(next);
+			return;
+		}
+		if (!openProjectShareFlow(projectIds, operation.person.display_name)) {
+			const next = {
+				message: "Project sharing is unavailable. Refresh Projects and try again.",
+				tone: "warning",
+			} satisfies Feedback;
+			feedbackByOperation.set(operation.operation_id, next);
+			setFeedback(next);
+		}
+	}
+
+	function runAction() {
+		if (!action) return;
+		if (action.kind === "copy_invite") {
+			void copyInvite(action.invite_link);
+			return;
+		}
+		if (action.kind === "retry_setup") {
+			void retrySetup();
+			return;
+		}
+		restartSharing();
+	}
+
+	return (
+		<section
+			aria-label={`${relationshipLabel(operation.lifecycle.state)} operation`}
+			className="project-share-operation-card"
+		>
+			<div className="peer-scope-summary">{relationshipLabel(operation.lifecycle.state)}</div>
+			<ul
+				aria-label={`${relationshipLabel(operation.lifecycle.state)} projects`}
+				className="peer-scope-chips"
+			>
+				{operation.projects.map((project, index) => (
+					<li className="peer-scope-chip" key={`${project.display_name}:${index}`}>
+						{project.display_name}
+					</li>
+				))}
+			</ul>
+			<div className="peer-scope-summary">{operation.lifecycle.label}</div>
+			<div
+				className="peer-meta"
+				role={operation.lifecycle.state === "needs_attention" ? "alert" : undefined}
+			>
+				{operation.lifecycle.explanation}
+			</div>
+			{action ? (
+				<div className="peer-actions">
+					<button
+						aria-busy={busy}
+						className="settings-button"
+						disabled={busy}
+						type="button"
+						onClick={runAction}
+					>
+						{busy ? (action.kind === "copy_invite" ? "Copying…" : "Retrying…") : action.label}
+					</button>
+				</div>
+			) : null}
+			{feedback ? (
+				<div
+					ref={feedbackRef}
+					className={`settings-note ${feedback.tone === "warning" ? "project-attention-note" : ""}`}
+					role="status"
+					tabIndex={-1}
+				>
+					{feedback.message}
+				</div>
+			) : null}
+		</section>
+	);
+}
+
+function PersonGroup({
+	operations,
+	...props
+}: ProjectShareOperationsProps & {
+	operations: ShareOperationReadModel[];
+}) {
+	const person = operations[0].person;
+	const devices = personDevices(operations);
+	return (
+		<article
+			aria-label={`Project sharing with ${person.display_name}`}
+			className="peer-card project-share-person-group"
+		>
+			<h3 className="device-row-name">{person.display_name}</h3>
+			{devices.length > 0 ? (
+				<ul
+					aria-label={`Devices for ${person.display_name}`}
+					className="peer-scope-rejections-list"
+				>
+					{devices.map((device) => (
+						<li key={device.device_id}>{device.display_name}</li>
+					))}
+				</ul>
+			) : null}
+			{operations.map((operation) => (
+				<OperationCard key={operation.operation_id} operation={operation} {...props} />
+			))}
+		</article>
+	);
+}
+
+export function ProjectShareOperations(props: ProjectShareOperationsProps) {
+	if (props.operations.length === 0) return null;
+	return (
+		<div className="project-share-person-groups">
+			{byPerson(props.operations).map((operations) => (
+				<PersonGroup key={operations[0].person.actor_id} {...props} operations={operations} />
+			))}
+		</div>
+	);
+}
+
+export function renderProjectShareOperations(
+	mount: HTMLElement,
+	props: ProjectShareOperationsProps,
+) {
+	renderIntoSyncMount(mount, <ProjectShareOperations {...props} />);
+}
+
+export function resetProjectShareOperationFeedbackForTests() {
+	feedbackByOperation.clear();
+	focusFeedbackForOperation = null;
+}

--- a/packages/ui/src/tabs/sync/index.test.ts
+++ b/packages/ui/src/tabs/sync/index.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../lib/api", () => ({
 	loadSyncStatus: vi.fn(),
 	loadSyncActors: vi.fn(),
+	loadShareOperations: vi.fn(),
+	loadCoordinatorAdminStatus: vi.fn(),
 }));
 
 vi.mock("../health", () => ({ renderHealthOverview: vi.fn() }));
@@ -25,6 +27,7 @@ vi.mock("./people", () => ({
 	renderSyncPeers: vi.fn(),
 	renderSyncPeopleUnavailable: vi.fn(),
 	renderLegacyDeviceClaims: vi.fn(),
+	renderProjectSharingOperations: vi.fn(),
 	initPeopleEvents: vi.fn(),
 	setLoadSyncData: vi.fn(),
 }));
@@ -62,6 +65,8 @@ describe("loadSyncData", () => {
 		state.lastSyncPeers = [];
 		state.pendingAcceptedSyncPeers = [];
 		state.lastSyncActors = [];
+		state.lastShareOperations = [];
+		state.shareOperationsLoadError = false;
 		state.lastSyncCoordinator = null;
 		state.lastSyncViewModel = null;
 	});
@@ -70,6 +75,7 @@ describe("loadSyncData", () => {
 		const api = await import("../../lib/api");
 		const { state } = await import("../../lib/state");
 		const { loadSyncData } = await import("./index");
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
 
 		const first = deferred<{
 			peers: Array<{ peer_device_id: string }>;
@@ -88,6 +94,7 @@ describe("loadSyncData", () => {
 			.mockReturnValueOnce(first.promise as never)
 			.mockReturnValueOnce(second.promise as never);
 		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
 		const firstLoad = loadSyncData();
 		const secondLoad = loadSyncData();
 
@@ -149,5 +156,24 @@ describe("loadSyncData", () => {
 		await loadSyncData();
 
 		expect(api.loadSyncActors).not.toHaveBeenCalled();
+	});
+
+	it("keeps peer diagnostics when project sharing lifecycle loading fails", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({
+			peers: [{ peer_device_id: "peer-still-visible" }],
+			sharing_review: [],
+			attempts: [],
+			legacy_devices: [],
+		} as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockRejectedValue(new Error("lifecycle unavailable"));
+
+		await loadSyncData();
+
+		expect(state.lastSyncPeers.map((peer) => peer.peer_device_id)).toEqual(["peer-still-visible"]);
+		expect(state.shareOperationsLoadError).toBe(true);
 	});
 });

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -17,6 +17,7 @@ import { hideSkeleton, readDuplicatePersonDecisions } from "./helpers";
 import {
 	initPeopleEvents,
 	renderLegacyDeviceClaims,
+	renderProjectSharingOperations,
 	renderSyncActors,
 	renderSyncActorsUnavailable,
 	renderSyncPeers,
@@ -135,8 +136,10 @@ export async function loadSyncData() {
 
 		let actorsPayload: SyncActorListResponseLike | null = null;
 		let coordinatorAdminStatus: Record<string, unknown> | null = null;
+		let shareOperations = state.lastShareOperations;
 		let actorLoadError = false;
 		let coordinatorAdminLoadError = false;
+		let shareOperationsLoadError = false;
 		const duplicatePersonDecisions = readDuplicatePersonDecisions();
 		try {
 			actorsPayload = await api.loadSyncActors();
@@ -147,6 +150,12 @@ export async function loadSyncData() {
 			coordinatorAdminStatus = (await api.loadCoordinatorAdminStatus()) as Record<string, unknown>;
 		} catch {
 			coordinatorAdminLoadError = true;
+		}
+		try {
+			const sharePayload = await api.loadShareOperations();
+			shareOperations = Array.isArray(sharePayload.items) ? sharePayload.items : [];
+		} catch {
+			shareOperationsLoadError = true;
 		}
 
 		if (requestId !== latestSyncLoadRequestId) return;
@@ -160,6 +169,8 @@ export async function loadSyncData() {
 			payload,
 			actorsPayload,
 			coordinatorAdminStatus,
+			shareOperations,
+			shareOperationsLoadError,
 			duplicatePersonDecisions,
 		]);
 		if (hash === lastSyncHash) return;
@@ -187,6 +198,8 @@ export async function loadSyncData() {
 			: [];
 		state.pendingAcceptedSyncPeers = pendingPeers;
 		state.lastSyncPeers = [...payloadPeers, ...pendingPeers];
+		state.lastShareOperations = shareOperations;
+		state.shareOperationsLoadError = shareOperationsLoadError;
 		state.lastSyncSharingReview = payload.sharing_review || [];
 		state.lastSyncLegacySharedReview =
 			payload.legacy_shared_review && typeof payload.legacy_shared_review === "object"
@@ -210,6 +223,7 @@ export async function loadSyncData() {
 		renderSyncStatus();
 		renderTeamSync();
 		renderSyncActors();
+		renderProjectSharingOperations();
 		renderSyncSharingReview();
 		renderSyncPeers();
 		renderLegacyDeviceClaims();

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -5,6 +5,7 @@ import { clearFieldError, friendlyError, markFieldError } from "../../lib/form";
 import { handlePrimaryActionKeyboard } from "../../lib/keyboard";
 import { showGlobalNotice } from "../../lib/notice";
 import { state } from "../../lib/state";
+import { renderProjectShareOperations } from "./components/project-share-operations";
 import { renderSyncActorsList } from "./components/sync-actors";
 import { renderSyncEmptyState } from "./components/sync-diagnostics";
 import type { SyncActionFeedback } from "./components/sync-inline-feedback";
@@ -102,6 +103,25 @@ export function renderSyncActorsUnavailable() {
 			detail:
 				"Refresh this page to retry. When the people endpoint responds again, named people will reload here.",
 		});
+	}
+}
+
+export function renderProjectSharingOperations() {
+	const mount = document.getElementById("syncProjectShareOperations");
+	if (!mount) return;
+	renderProjectShareOperations(mount, {
+		operations: state.lastShareOperations,
+		onAdvance: (operationId) => api.advanceShareOperation(operationId),
+		onLoadOperation: (operationId) => api.loadShareOperation(operationId),
+		onReload: _loadSyncData,
+	});
+	const meta = document.getElementById("syncProjectShareOperationsMeta");
+	if (meta) {
+		meta.textContent = state.shareOperationsLoadError
+			? "Project sharing status could not be refreshed. Existing device diagnostics remain available below."
+			: state.lastShareOperations.length > 0
+				? "Project access is grouped by Person. Devices appear after invitation acceptance."
+				: "Share a project from Projects to invite a teammate.";
 	}
 }
 

--- a/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.test.ts
+++ b/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.test.ts
@@ -22,8 +22,11 @@ vi.mock("../helpers/invite-panel-dom", () => ({
 	setInviteOutputVisibility: vi.fn(),
 	setJoinFeedbackVisibility: vi.fn(),
 }));
+vi.mock("../../../project-sharing", () => ({ openProjectShareFlow: vi.fn() }));
 
 import * as api from "../../../../lib/api";
+import { showGlobalNotice } from "../../../../lib/notice";
+import { openProjectShareFlow } from "../../../project-sharing";
 import { initTeamSyncEvents } from "./init-team-sync-events";
 
 describe("project invite review events", () => {
@@ -34,8 +37,9 @@ describe("project invite review events", () => {
 				<h4 id="syncProjectInviteReviewHeading" tabindex="-1">Review project invitation</h4>
 				<div id="syncProjectInviteContext"></div>
 				<input id="syncRecipientName" />
-				<input id="syncRecipientDeviceName" />
+			<input id="syncRecipientDeviceName" />
 			</div>
+			<button id="syncShareProjectsButton">Share projects</button>
 			<button id="syncJoinButton">Review invite</button>
 		`;
 		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
@@ -48,6 +52,34 @@ describe("project invite review events", () => {
 			team_name: "Team",
 		});
 		vi.mocked(api.importCoordinatorInvite).mockResolvedValue({ status: "joined" });
+	});
+
+	it("opens the shared project flow from Sync", () => {
+		vi.mocked(openProjectShareFlow).mockReturnValueOnce(true);
+		initTeamSyncEvents(
+			() => {},
+			async () => {},
+		);
+
+		(document.getElementById("syncShareProjectsButton") as HTMLButtonElement).click();
+
+		expect(openProjectShareFlow).toHaveBeenCalledOnce();
+		expect(openProjectShareFlow).toHaveBeenCalledWith();
+	});
+
+	it("explains when the shared project flow is unavailable", () => {
+		vi.mocked(openProjectShareFlow).mockReturnValueOnce(false);
+		initTeamSyncEvents(
+			() => {},
+			async () => {},
+		);
+
+		(document.getElementById("syncShareProjectsButton") as HTMLButtonElement).click();
+
+		expect(showGlobalNotice).toHaveBeenCalledWith(
+			"Project sharing is unavailable. Refresh Projects and try again.",
+			"warning",
+		);
 	});
 
 	afterEach(() => {

--- a/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
+++ b/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
@@ -9,6 +9,7 @@ import { clearFieldError, friendlyError, markFieldError } from "../../../../lib/
 import { handlePrimaryActionKeyboard } from "../../../../lib/keyboard";
 import { showGlobalNotice } from "../../../../lib/notice";
 import { state } from "../../../../lib/state";
+import { openProjectShareFlow } from "../../../project-sharing";
 import type { SyncActionFeedback } from "../../components/sync-inline-feedback";
 import { summarizeSyncRunResult } from "../../view-model";
 import { teamSyncState } from "../data/state";
@@ -24,6 +25,9 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 	renderInvitePolicySelect();
 
 	const syncNowButton = document.getElementById("syncNowButton") as HTMLButtonElement | null;
+	const syncShareProjectsButton = document.getElementById(
+		"syncShareProjectsButton",
+	) as HTMLButtonElement | null;
 	const syncCreateInviteButton = document.getElementById(
 		"syncCreateInviteButton",
 	) as HTMLButtonElement | null;
@@ -49,6 +53,15 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 	) as HTMLInputElement | null;
 	let inspectedInviteValue = "";
 	let inviteInputRevision = 0;
+
+	syncShareProjectsButton?.addEventListener("click", () => {
+		if (!openProjectShareFlow()) {
+			showGlobalNotice(
+				"Project sharing is unavailable. Refresh Projects and try again.",
+				"warning",
+			);
+		}
+	});
 
 	const reviewProjectInvite = async (
 		inviteValue: string,

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -3761,6 +3761,7 @@
             <span class="sync-online-badge" id="syncOnlineBadge" hidden role="status" aria-live="polite"></span>
           </div>
           <div class="section-actions">
+            <button class="settings-button" id="syncShareProjectsButton" type="button">Share projects</button>
             <button class="settings-button" id="syncNowButton">Sync now</button>
             <a class="sync-subview-link" href="#sync/diagnostics">View diagnostics &rarr;</a>
           </div>
@@ -3806,6 +3807,13 @@
       <div class="card" style="animation-delay: 0.04s">
         <h2>People &amp; devices</h2>
 
+        <h3 class="settings-group-title">Project sharing</h3>
+        <div class="section-meta" id="syncProjectShareOperationsMeta">Loading project sharing status…</div>
+        <div class="actor-list" id="syncProjectShareOperations" aria-live="polite"></div>
+
+        <details class="project-inventory-details" style="margin-top: 20px">
+          <summary>Manual device and identity controls</summary>
+
         <h3 class="settings-group-title">People</h3>
         <div class="section-meta" id="syncActorsMeta">Create and rename people here. Assign each device below.</div>
         <div class="actor-create-row">
@@ -3835,6 +3843,7 @@
           <div id="syncPairingDisclosureMount" style="display: contents"></div>
         </div>
         <div id="syncPairingPanelMount" style="display: contents"></div>
+        </details>
 
         <div id="syncSharingReview" hidden>
           <h3 class="settings-group-title" style="margin-top: 20px">What teammates will receive</h3>

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -10051,7 +10051,7 @@ describe("viewer-server", () => {
 			}
 		});
 
-		it("reads and reconciles authoritative project invite acceptance with scoped stable failures", async () => {
+		it("keeps project invite reads pure and reconciles authoritative acceptance explicitly and idempotently", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;
 			const operationId = `share_${"d".repeat(40)}`;
@@ -10084,9 +10084,16 @@ describe("viewer-server", () => {
 					],
 				};
 				if (mode === "waiting" || mode === "wrong_group") {
-					return new Response(JSON.stringify({ ...base, state: "waiting_for_acceptance" }), {
-						status: 200,
-					});
+					return new Response(
+						JSON.stringify({
+							...base,
+							state: "waiting_for_acceptance",
+							invite_link: mode === "waiting" ? "codemem://invite/safe-existing-link" : null,
+						}),
+						{
+							status: 200,
+						},
+					);
 				}
 				return new Response(
 					JSON.stringify({
@@ -10166,8 +10173,13 @@ describe("viewer-server", () => {
 				).toBe("waiting_for_acceptance");
 				mode = "invalid_trust";
 				const invalidTrust = await request();
-				expect(invalidTrust.status).toBe(409);
-				expect(await invalidTrust.json()).toEqual({ error: "operation_trust_state_invalid" });
+				expect(invalidTrust.status).toBe(200);
+				const invalidReconcile = await app.request(
+					`/api/sync/project-invites/${operationId}/reconcile`,
+					{ method: "POST" },
+				);
+				expect(invalidReconcile.status).toBe(409);
+				expect(await invalidReconcile.json()).toEqual({ error: "operation_trust_state_invalid" });
 				expect(
 					store.db
 						.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
@@ -10177,7 +10189,18 @@ describe("viewer-server", () => {
 				mode = "accepted";
 				const accepted = await request();
 				expect(accepted.status).toBe(200);
-				expect(await accepted.json()).toMatchObject({ reconciled: true, state: "accepted" });
+				expect(await accepted.json()).toMatchObject({ state: "accepted" });
+				expect(
+					store.db
+						.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+						.pluck()
+						.get(operationId),
+				).toBe("waiting_for_acceptance");
+
+				const reconcile = () =>
+					app.request(`/api/sync/project-invites/${operationId}/reconcile`, { method: "POST" });
+				expect((await reconcile()).status).toBe(200);
+				expect((await reconcile()).status).toBe(200);
 				expect(
 					store.db
 						.prepare("SELECT state, recipient_actor_id, recipient_device_id FROM share_operations")
@@ -10187,6 +10210,72 @@ describe("viewer-server", () => {
 					recipient_actor_id: "actor-brian",
 					recipient_device_id: "device-brian",
 				});
+
+				mode = "waiting";
+				store.db
+					.prepare(
+						"UPDATE share_operations SET state = 'waiting_for_acceptance' WHERE operation_id = ?",
+					)
+					.run(operationId);
+				const otherOperationId = `share_${"9".repeat(40)}`;
+				store.db
+					.prepare(`INSERT INTO share_operations(
+						operation_id, state, inviter_actor_id, inviter_device_ids_json, person_id,
+						person_kind, teammate_name, history_policy, reviewed_project_set_digest,
+						coordinator_group_id, invite_token_digest, invite_expires_at, created_at, updated_at
+					) VALUES (?, 'cancelled', 'actor-other-owner', '[]', 'actor-brian', 'existing',
+						'Brian', 'existing_and_future', ?, 'team-a', 'other-digest',
+						'2099-01-01T00:00:00Z', ?, ?)`)
+					.run(otherOperationId, "f".repeat(64), "2026-07-20T00:00:00Z", "2026-07-20T00:00:00Z");
+
+				const fetchCallsBeforeList = fetchMock.mock.calls.length;
+				const lifecycleResponse = await app.request("/api/sync/share-operations");
+				expect(lifecycleResponse.status).toBe(200);
+				const lifecyclePayload = (await lifecycleResponse.json()) as {
+					items: Array<Record<string, unknown>>;
+				};
+				expect(lifecyclePayload.items).toHaveLength(1);
+				expect(lifecyclePayload.items[0]).toMatchObject({
+					person: { actor_id: "actor-brian", display_name: "Brian" },
+					projects: [{ project_id: projectId, display_name: "codemem", existing_memory_count: 3 }],
+					lifecycle: {
+						state: "waiting_for_acceptance",
+						primary_action: {
+							kind: "copy_invite",
+						},
+					},
+				});
+				expect(fetchMock).toHaveBeenCalledTimes(fetchCallsBeforeList);
+				const lifecycleDetailResponse = await app.request(
+					`/api/sync/share-operations/${operationId}`,
+				);
+				expect(lifecycleDetailResponse.status).toBe(200);
+				expect(await lifecycleDetailResponse.json()).toMatchObject({
+					lifecycle: {
+						primary_action: {
+							kind: "copy_invite",
+							invite_link: "codemem://invite/safe-existing-link",
+						},
+					},
+				});
+				const serialized = JSON.stringify(lifecyclePayload);
+				for (const sensitive of [
+					"recipient_public_key",
+					"recipient_fingerprint",
+					"canonical_identity",
+					"scope_id",
+				]) {
+					expect(serialized).not.toContain(sensitive);
+				}
+				expect(
+					store.db
+						.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+						.pluck()
+						.get(operationId),
+				).toBe("waiting_for_acceptance");
+				expect((await app.request(`/api/sync/share-operations/${otherOperationId}`)).status).toBe(
+					404,
+				);
 			} finally {
 				cleanup();
 				globalThis.fetch = prevFetch;
@@ -10196,7 +10285,6 @@ describe("viewer-server", () => {
 		});
 
 		it("maps project provision errors and preflights reassignment before mutations", async () => {
-			// Arrange
 			const configDir = mkdtempSync(join(tmpdir(), "codemem-provision-route-test-"));
 			const configPath = join(configDir, "config.json");
 			const previousConfig = process.env.CODEMEM_CONFIG;
@@ -10298,7 +10386,6 @@ describe("viewer-server", () => {
 					.pluck()
 					.get(memoryId);
 
-				// Act
 				const invalid = await app.request("/api/sync/project-invites/not-an-operation/provision", {
 					method: "POST",
 				});
@@ -10310,19 +10397,24 @@ describe("viewer-server", () => {
 					`/api/sync/project-invites/${plan.operationId}/provision`,
 					{ method: "POST" },
 				);
+				const advance = await app.request(
+					`/api/sync/share-operations/${plan.operationId}/advance`,
+					{ method: "POST" },
+				);
 				capabilityProbe = "undetermined";
 				const waiting = await app.request(
 					`/api/sync/project-invites/${plan.operationId}/provision`,
 					{ method: "POST" },
 				);
 
-				// Assert
 				expect(invalid.status).toBe(400);
 				expect(await invalid.json()).toEqual({ error: "operation_id_invalid" });
 				expect(missing.status).toBe(404);
 				expect(await missing.json()).toEqual({ error: "operation_not_found" });
 				expect(unsupported.status).toBe(409);
 				expect(await unsupported.json()).toEqual({ error: "reassign_capability_required" });
+				expect(advance.status).toBe(409);
+				expect(await advance.json()).toEqual({ error: "reassign_capability_required" });
 				expect(waiting.status).toBe(409);
 				expect(await waiting.json()).toEqual({ error: "waiting_for_device" });
 				expect(store.db.prepare("SELECT state FROM share_operations").pluck().get()).toBe(

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -26,6 +26,15 @@ import { rawEventsRoutes } from "./routes/raw-events.js";
 import { statsRoutes } from "./routes/stats.js";
 import { syncProtocolRoutes, syncRoutes } from "./routes/sync.js";
 
+export type {
+	AdvancePendingProjectSharesResult,
+	AdvanceProjectShareOperationResult,
+} from "./routes/sync.js";
+export {
+	advancePendingProjectShares,
+	advanceProjectShareOperation,
+} from "./routes/sync.js";
+
 export { VERSION };
 
 /** Shared store instance — SQLite WAL mode handles concurrent reads safely. */

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -16,6 +16,7 @@ import type {
 	ReassignScopeCapability,
 	ReplicationOp,
 	SemanticIndexDiagnostics,
+	ShareOperationLifecycleStepInput,
 	ShareOperationPlan,
 	SharePersonIntent,
 	ShareProjectIntent,
@@ -102,6 +103,7 @@ import {
 	persistShareOperation,
 	personalScopeGrantStatusForPeer,
 	planShareOperation,
+	projectShareLifecycle,
 	readCodememConfigFile,
 	readCoordinatorSyncConfig,
 	reassignProjectScopeInventoryProject,
@@ -775,6 +777,564 @@ function projectInvitePreview(plan: ShareOperationPlan) {
 		history_policy: plan.historyPolicy,
 		reviewed_project_set_digest: plan.reviewedProjectSetDigest,
 	};
+}
+
+type CoordinatorProjectInvitePayload = Record<string, unknown> & {
+	operation_id?: string;
+	group_id?: string;
+	state?: string;
+};
+
+async function coordinatorProjectInvitePayload(operationId: string): Promise<{
+	groupId: string;
+	config: ReturnType<typeof readCoordinatorSyncConfig>;
+	payload: CoordinatorProjectInvitePayload;
+}> {
+	const { groupId, config } = projectInviteStatus();
+	const [status, payload] = await requestJson(
+		"GET",
+		`${buildBaseUrl(config.syncCoordinatorUrl)}/v1/admin/project-invites/${encodeURIComponent(operationId)}?group_id=${encodeURIComponent(groupId)}`,
+		{
+			headers: { "X-Codemem-Coordinator-Admin": config.syncCoordinatorAdminSecret },
+			timeoutS: 10,
+		},
+	);
+	if (status < 200 || status >= 300) {
+		const error = new Error(String(payload?.error ?? "operation_read_failed"));
+		Object.assign(error, { status });
+		throw error;
+	}
+	if (!payload || payload.operation_id !== operationId || payload.group_id !== groupId) {
+		const error = new Error("operation_scope_mismatch");
+		Object.assign(error, { status: 409 });
+		throw error;
+	}
+	return { groupId, config, payload: payload as CoordinatorProjectInvitePayload };
+}
+
+async function reconcileProjectInviteAcceptance(
+	store: MemoryStore,
+	operationId: string,
+): Promise<{ accepted: boolean; payload: CoordinatorProjectInvitePayload }> {
+	const owner = store.db
+		.prepare("SELECT inviter_actor_id FROM share_operations WHERE operation_id = ?")
+		.pluck()
+		.get(operationId) as string | undefined;
+	if (!owner) throw new Error("operation_not_found");
+	if (owner !== store.actorId) throw new Error("operation_scope_mismatch");
+	const { groupId, payload } = await coordinatorProjectInvitePayload(operationId);
+	if (payload.state === "waiting_for_acceptance") return { accepted: false, payload };
+	if (payload.state !== "accepted") {
+		const error = new Error("operation_state_invalid");
+		Object.assign(error, { status: 409 });
+		throw error;
+	}
+	const required = [
+		"reviewed_project_set_digest",
+		"recipient_actor_id",
+		"recipient_display_name",
+		"recipient_device_id",
+		"recipient_device_display_name",
+		"recipient_public_key",
+		"recipient_fingerprint",
+		"consumed_at",
+		"trust_state",
+	] as const;
+	if (required.some((key) => typeof payload[key] !== "string" || !String(payload[key]).trim())) {
+		const error = new Error("operation_acceptance_invalid");
+		Object.assign(error, { status: 409 });
+		throw error;
+	}
+	const trustState = String(payload.trust_state);
+	const bootstrapGrantId =
+		typeof payload.bootstrap_grant_id === "string" && payload.bootstrap_grant_id.trim()
+			? payload.bootstrap_grant_id
+			: null;
+	if (
+		(trustState !== "pending_inviter_device" && trustState !== "bootstrap_grant_created") ||
+		(trustState === "bootstrap_grant_created") !== Boolean(bootstrapGrantId)
+	) {
+		const error = new Error("operation_trust_state_invalid");
+		Object.assign(error, { status: 409 });
+		throw error;
+	}
+	const projects = parseAcceptedProjectIntent(payload.projects);
+	reconcileShareOperationAcceptance(store.db, {
+		operationId,
+		coordinatorGroupId: groupId,
+		reviewedProjectSetDigest: String(payload.reviewed_project_set_digest),
+		recipientActorId: String(payload.recipient_actor_id),
+		recipientDisplayName: String(payload.recipient_display_name),
+		recipientDeviceId: String(payload.recipient_device_id),
+		recipientDeviceDisplayName: String(payload.recipient_device_display_name),
+		recipientPublicKey: String(payload.recipient_public_key),
+		recipientFingerprint: String(payload.recipient_fingerprint),
+		consumedAt: String(payload.consumed_at),
+		trustState,
+		bootstrapGrantId,
+		projects,
+	});
+	return { accepted: true, payload };
+}
+
+interface ShareOperationReadRow {
+	operation_id: string;
+	state: string;
+	person_id: string;
+	teammate_name: string;
+	recipient_actor_id: string | null;
+	recipient_display_name: string | null;
+	recipient_device_id: string | null;
+	recipient_device_display_name: string | null;
+	invite_expires_at: string;
+	acceptance_consumed_at: string | null;
+	created_at: string;
+	updated_at: string;
+	actor_display_name: string | null;
+	peer_display_name: string | null;
+	device_last_seen_at: string | null;
+}
+
+async function shareOperationReadModels(
+	store: MemoryStore,
+	operationId?: string,
+	includeInviteLinks = true,
+) {
+	const rows = store.db
+		.prepare(`SELECT o.operation_id, o.state, o.person_id, o.teammate_name,
+			o.recipient_actor_id, o.recipient_display_name, o.recipient_device_id,
+			o.recipient_device_display_name, o.invite_expires_at, o.acceptance_consumed_at,
+			o.created_at, o.updated_at, a.display_name AS actor_display_name,
+			p.name AS peer_display_name, p.last_sync_at AS device_last_seen_at
+		 FROM share_operations o
+		 LEFT JOIN actors a ON a.actor_id = o.person_id
+		 LEFT JOIN sync_peers p ON p.peer_device_id = o.recipient_device_id
+		 WHERE o.inviter_actor_id = ? AND (? IS NULL OR o.operation_id = ?)
+		 ORDER BY o.created_at DESC, o.operation_id`)
+		.all(store.actorId, operationId ?? null, operationId ?? null) as ShareOperationReadRow[];
+	const now = new Date().toISOString();
+	return Promise.all(
+		rows.map(async (row) => {
+			const projects = store.db
+				.prepare(`SELECT canonical_project_identity AS project_id, display_name, existing_memory_count
+				 FROM share_operation_projects WHERE operation_id = ? ORDER BY ordinal`)
+				.all(row.operation_id) as Array<{
+				project_id: string;
+				display_name: string;
+				existing_memory_count: number;
+			}>;
+			const steps = (
+				store.db
+					.prepare(`SELECT step_key, status, attempt_count, started_at, last_attempt_at,
+						safe_error_code, updated_at FROM share_operation_steps WHERE operation_id = ?`)
+					.all(row.operation_id) as Array<{
+					step_key: string;
+					status: ShareOperationLifecycleStepInput["status"];
+					attempt_count: number;
+					started_at: string | null;
+					last_attempt_at: string | null;
+					safe_error_code: string | null;
+					updated_at: string;
+				}>
+			).map(
+				(step): ShareOperationLifecycleStepInput => ({
+					attemptCount: step.attempt_count,
+					lastAttemptAt: step.last_attempt_at,
+					safeErrorCode: step.safe_error_code,
+					startedAt: step.started_at,
+					status: step.status,
+					stepKey: step.step_key,
+					updatedAt: step.updated_at,
+				}),
+			);
+			let inviteLink: string | null = null;
+			let projectedState = row.state;
+			if (includeInviteLinks && row.state === "waiting_for_acceptance") {
+				try {
+					const remote = await coordinatorProjectInvitePayload(row.operation_id);
+					if (remote.payload.state === "accepted") projectedState = "accepted";
+					inviteLink =
+						typeof remote.payload.invite_link === "string" && remote.payload.invite_link.trim()
+							? remote.payload.invite_link
+							: null;
+				} catch {
+					// A read-model refresh remains useful when the coordinator is temporarily unavailable.
+				}
+			}
+			const personId = row.recipient_actor_id || row.person_id;
+			const personName = row.recipient_display_name || row.actor_display_name || row.teammate_name;
+			const deviceName = row.recipient_device_display_name || row.peer_display_name;
+			const lifecycle = projectShareLifecycle({
+				deviceLastSeenAt: row.device_last_seen_at,
+				deviceName,
+				inviteLink,
+				now,
+				personName,
+				state: projectedState,
+				steps,
+			});
+			return {
+				operation_id: row.operation_id,
+				person: { actor_id: personId, display_name: personName },
+				devices:
+					row.recipient_device_id && deviceName
+						? [
+								{
+									device_id: row.recipient_device_id,
+									display_name: deviceName,
+									last_seen_at: row.device_last_seen_at,
+								},
+							]
+						: [],
+				projects,
+				project_count: projects.length,
+				lifecycle: {
+					state: lifecycle.lifecycle,
+					label: lifecycle.label,
+					explanation: lifecycle.explanation,
+					primary_action:
+						lifecycle.primaryAction?.kind === "copy_invite"
+							? {
+									kind: "copy_invite",
+									label: lifecycle.primaryAction.label,
+									invite_link: lifecycle.primaryAction.inviteLink,
+								}
+							: !includeInviteLinks && lifecycle.lifecycle === "waiting_for_acceptance"
+								? { kind: "copy_invite", label: "Copy invite" }
+								: lifecycle.primaryAction,
+				},
+				timestamps: {
+					created_at: row.created_at,
+					updated_at: row.updated_at,
+					accepted_at: row.acceptance_consumed_at,
+					invite_expires_at: row.invite_expires_at,
+				},
+			};
+		}),
+	);
+}
+
+async function executeProjectShareProvisioning(store: MemoryStore, operationId: string) {
+	const { groupId, config } = projectInviteStatus();
+	const coordinatorId = config.syncCoordinatorUrl || null;
+	if (!coordinatorId) throw new Error("coordinator_not_configured");
+	const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
+	return executeShareProvisioning(
+		store.db,
+		{ operationId, initiatingDeviceId: localDeviceId },
+		{
+			createOrGetBoundary: async (project, expectedGroupId) => {
+				if (expectedGroupId !== groupId) throw new Error("operation_scope_mismatch");
+				const readExisting = async () =>
+					(
+						await coordinatorListScopesAction({
+							groupId,
+							includeInactive: true,
+							remoteUrl: config.syncCoordinatorUrl || null,
+							adminSecret: config.syncCoordinatorAdminSecret || null,
+						})
+					).find((scope) => scope.scope_id === project.boundaryId) ?? null;
+				const existing = await readExisting();
+				if (existing) return existing;
+				try {
+					return await coordinatorCreateScopeAction({
+						groupId,
+						scopeId: project.boundaryId,
+						label: project.displayName,
+						kind: "managed_project",
+						authorityType: "coordinator",
+						coordinatorId,
+						membershipEpoch: 1,
+						status: "active",
+						remoteUrl: config.syncCoordinatorUrl || null,
+						adminSecret: config.syncCoordinatorAdminSecret || null,
+					});
+				} catch (error) {
+					const reread = await readExisting();
+					if (reread) return reread;
+					throw error;
+				}
+			},
+			grantMembership: ({ groupId: expectedGroupId, scopeId, deviceId, role }) => {
+				if (expectedGroupId !== groupId) throw new Error("operation_scope_mismatch");
+				return coordinatorGrantScopeMembershipAction({
+					groupId,
+					scopeId,
+					deviceId,
+					role,
+					membershipEpoch: 1,
+					coordinatorId,
+					remoteUrl: config.syncCoordinatorUrl || null,
+					adminSecret: config.syncCoordinatorAdminSecret || null,
+				});
+			},
+			supportsReassignScope: (deviceId) => peerSupportsReassignScope(store, deviceId),
+			refreshAuthorization: async (expectedGroupId) => {
+				if (expectedGroupId !== groupId) throw new Error("operation_scope_mismatch");
+				const refreshed = await refreshConfiguredScopeMembershipCache(store.db, config, {
+					keysDir: syncKeysDir(),
+				});
+				const group = refreshed.groups.find((item) => item.groupId === groupId);
+				if (group?.status !== "refreshed") throw new Error("authorization_refresh_failed");
+			},
+			runInitialSync: (recipientDeviceId) =>
+				runSyncPass(store.db, recipientDeviceId, {
+					keysDir: syncKeysDir(),
+					scanner: store.scanner,
+					refreshAuthorization: true,
+				}),
+		},
+	);
+}
+
+export interface AdvanceProjectShareOperationResult {
+	advanced: boolean;
+	state: "active" | "waiting_for_acceptance";
+}
+
+export async function advanceProjectShareOperation(
+	store: MemoryStore,
+	operationId: string,
+): Promise<AdvanceProjectShareOperationResult> {
+	const operation = store.db
+		.prepare(
+			"SELECT state, inviter_actor_id, recipient_device_id FROM share_operations WHERE operation_id = ?",
+		)
+		.get(operationId) as
+		| { state: string; inviter_actor_id: string; recipient_device_id: string | null }
+		| undefined;
+	if (!operation) throw new Error("operation_not_found");
+	if (operation.inviter_actor_id !== store.actorId) throw new Error("operation_scope_mismatch");
+	if (!operation.recipient_device_id) {
+		const reconciliation = await reconcileProjectInviteAcceptance(store, operationId);
+		if (!reconciliation.accepted) {
+			return { advanced: false, state: "waiting_for_acceptance" };
+		}
+	}
+	await executeProjectShareProvisioning(store, operationId);
+	return { advanced: true, state: "active" };
+}
+
+export interface AdvancePendingProjectSharesResult {
+	processed: number;
+	advanced: number;
+	waiting: number;
+	attention: number;
+	failed: number;
+	items: Array<{
+		operationId: string;
+		outcome:
+			| "advanced"
+			| "waiting_for_acceptance"
+			| "waiting_for_device"
+			| "retry_scheduled"
+			| "needs_attention"
+			| "failed";
+		error?: string;
+	}>;
+}
+
+const AUTOMATIC_SHARE_OPERATION_STATES = [
+	"waiting_for_acceptance",
+	"accepted",
+	"provisioning",
+	"initial_sync",
+	"waiting_for_device",
+] as const;
+
+const AUTOMATIC_WAITING_ACCEPTANCE_RETRY_COOLDOWN_MS = 30 * 1000;
+const AUTOMATIC_WAITING_DEVICE_RETRY_COOLDOWN_MS = 5 * 60 * 1000;
+const TERMINAL_SHARE_MAINTENANCE_ERRORS = new Set([
+	"coordinator_not_configured",
+	"team_sharing_not_configured",
+	"team_selection_ambiguous",
+	"initiating_device_not_reviewed",
+	"inviter_project_access_ambiguous",
+	"managed_boundary_plan_missing",
+	"operation_device_binding_missing",
+	"operation_intent_invalid",
+	"provisioning_membership_plan_invalid",
+]);
+const TERMINAL_RECONCILIATION_ERRORS = new Set([
+	"coordinator_not_configured",
+	"team_sharing_not_configured",
+	"team_selection_ambiguous",
+	"operation_not_found",
+	"operation_scope_mismatch",
+	"operation_state_invalid",
+	"operation_acceptance_invalid",
+	"operation_trust_state_invalid",
+	"operation_intent_invalid",
+	"operation_intent_mismatch",
+	"recipient_fingerprint_mismatch",
+	"recipient_device_identity_conflict",
+	"recipient_actor_conflict",
+	"pending_person_identity_conflict",
+]);
+
+function errorStatus(error: unknown): number | null {
+	const value = error && typeof error === "object" ? (error as { status?: unknown }).status : null;
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function isRetryableReconciliationError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	if (TERMINAL_RECONCILIATION_ERRORS.has(message)) return false;
+	const status = errorStatus(error);
+	return status == null || status === 408 || status === 429 || status >= 500;
+}
+
+function safeReconciliationErrorCode(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return TERMINAL_RECONCILIATION_ERRORS.has(message) ? message : "operation_read_failed";
+}
+
+function recordInviteReconciliationFailure(
+	store: MemoryStore,
+	operationId: string,
+	error: unknown,
+	now: string,
+): "retry_scheduled" | "needs_attention" {
+	const safeErrorCode = safeReconciliationErrorCode(error);
+	const retryable = isRetryableReconciliationError(error);
+	store.db
+		.prepare(`UPDATE share_operation_steps SET
+			status = CASE WHEN ? = 1 THEN 'pending' ELSE 'failed' END,
+			attempt_count = attempt_count + 1, last_attempt_at = ?, safe_error_code = ?, updated_at = ?
+			WHERE operation_id = ? AND step_key = 'invite_consumption'`)
+		.run(retryable ? 1 : 0, now, safeErrorCode, now, operationId);
+	const outcome = retryable ? "retry_scheduled" : "needs_attention";
+	store.db
+		.prepare("UPDATE share_operations SET state = ?, updated_at = ? WHERE operation_id = ?")
+		.run(
+			outcome === "needs_attention" ? "needs_attention" : "waiting_for_acceptance",
+			now,
+			operationId,
+		);
+	return outcome;
+}
+
+export async function advancePendingProjectShares(
+	store: MemoryStore,
+	options: {
+		limit?: number;
+		now?: Date;
+		advanceOperation?: (
+			store: MemoryStore,
+			operationId: string,
+		) => Promise<AdvanceProjectShareOperationResult>;
+	} = {},
+): Promise<AdvancePendingProjectSharesResult> {
+	const limit = Math.max(1, Math.min(Math.trunc(options.limit ?? 3), 10));
+	const placeholders = AUTOMATIC_SHARE_OPERATION_STATES.map(() => "?").join(", ");
+	const maintenanceNow = options.now ?? new Date();
+	const waitingAcceptanceRetryBefore = new Date(
+		maintenanceNow.getTime() - AUTOMATIC_WAITING_ACCEPTANCE_RETRY_COOLDOWN_MS,
+	).toISOString();
+	const waitingRetryBefore = new Date(
+		maintenanceNow.getTime() - AUTOMATIC_WAITING_DEVICE_RETRY_COOLDOWN_MS,
+	).toISOString();
+	const rows = store.db
+		.prepare(`SELECT operation_id FROM share_operations
+		 WHERE inviter_actor_id = ?
+		 AND state IN (${placeholders})
+		 AND (state <> 'waiting_for_acceptance' OR updated_at <= ?)
+		 AND (state <> 'waiting_for_device' OR updated_at <= ?)
+		 ORDER BY CASE WHEN state IN ('accepted', 'provisioning', 'initial_sync') THEN 0 ELSE 1 END,
+			CASE WHEN state IN ('waiting_for_acceptance', 'waiting_for_device')
+				THEN updated_at ELSE created_at END ASC,
+			created_at ASC, operation_id ASC
+		 LIMIT ?`)
+		.all(
+			store.actorId,
+			...AUTOMATIC_SHARE_OPERATION_STATES,
+			waitingAcceptanceRetryBefore,
+			waitingRetryBefore,
+			limit,
+		) as Array<{
+		operation_id: string;
+	}>;
+	const advanceOperation = options.advanceOperation ?? advanceProjectShareOperation;
+	const result: AdvancePendingProjectSharesResult = {
+		processed: 0,
+		advanced: 0,
+		waiting: 0,
+		attention: 0,
+		failed: 0,
+		items: [],
+	};
+	for (const row of rows) {
+		result.processed += 1;
+		try {
+			const advanced = await advanceOperation(store, row.operation_id);
+			if (!advanced.advanced) {
+				store.db
+					.prepare("UPDATE share_operations SET updated_at = ? WHERE operation_id = ?")
+					.run(maintenanceNow.toISOString(), row.operation_id);
+				result.waiting += 1;
+				result.items.push({
+					operationId: row.operation_id,
+					outcome: "waiting_for_acceptance",
+				});
+				continue;
+			}
+			result.advanced += 1;
+			result.items.push({ operationId: row.operation_id, outcome: "advanced" });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			const state = store.db
+				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+				.pluck()
+				.get(row.operation_id);
+			if (message === "waiting_for_device" || state === "waiting_for_device") {
+				result.waiting += 1;
+				result.items.push({ operationId: row.operation_id, outcome: "waiting_for_device" });
+				continue;
+			}
+			if (state === "needs_attention") {
+				result.attention += 1;
+				result.items.push({
+					operationId: row.operation_id,
+					outcome: "needs_attention",
+					error: message,
+				});
+				continue;
+			}
+			if (state === "waiting_for_acceptance") {
+				const outcome = recordInviteReconciliationFailure(
+					store,
+					row.operation_id,
+					error,
+					maintenanceNow.toISOString(),
+				);
+				if (outcome === "needs_attention") result.attention += 1;
+				else result.waiting += 1;
+				result.items.push({ operationId: row.operation_id, outcome, error: message });
+				continue;
+			}
+			if (TERMINAL_SHARE_MAINTENANCE_ERRORS.has(message)) {
+				store.db
+					.prepare(
+						"UPDATE share_operations SET state = 'needs_attention', updated_at = ? WHERE operation_id = ?",
+					)
+					.run(maintenanceNow.toISOString(), row.operation_id);
+				result.attention += 1;
+				result.items.push({
+					operationId: row.operation_id,
+					outcome: "needs_attention",
+					error: message,
+				});
+				continue;
+			}
+			result.failed += 1;
+			result.items.push({
+				operationId: row.operation_id,
+				outcome: "failed",
+				error: message,
+			});
+		}
+	}
+	return result;
 }
 
 function sortActiveMaintenanceJobs<
@@ -3508,20 +4068,50 @@ export function syncRoutes(
 		});
 	});
 
-	app.get("/api/sync/projects", (c) => {
+	app.get("/api/sync/projects", async (c) => {
 		const store = getStore();
 		const limit = Math.max(1, queryInt(c.req.query("limit"), 50));
 		const offset = Math.max(0, queryInt(c.req.query("offset"), 0));
-		return c.json(
-			listProjectScopeInventory(store.db, {
-				identitySource: c.req.query("identity_source"),
-				limit,
-				offset,
-				query: c.req.query("q"),
-				scopeId: c.req.query("scope_id"),
-				status: c.req.query("status"),
-			}),
+		const inventory = listProjectScopeInventory(store.db, {
+			identitySource: c.req.query("identity_source"),
+			limit,
+			offset,
+			query: c.req.query("q"),
+			scopeId: c.req.query("scope_id"),
+			status: c.req.query("status"),
+		});
+		const operations = await shareOperationReadModels(store, undefined, false);
+		const operationById = new Map(
+			operations.map((operation) => [operation.operation_id, operation]),
 		);
+		const sharingByProject = new Map<string, Array<Record<string, unknown>>>();
+		const reviewed = store.db
+			.prepare(`SELECT p.operation_id, p.canonical_project_identity
+			 FROM share_operation_projects p
+			 JOIN share_operations o ON o.operation_id = p.operation_id
+			 WHERE o.inviter_actor_id = ? ORDER BY o.created_at, p.ordinal`)
+			.all(store.actorId) as Array<{ operation_id: string; canonical_project_identity: string }>;
+		for (const item of reviewed) {
+			const operation = operationById.get(item.operation_id);
+			if (!operation) continue;
+			const current = sharingByProject.get(item.canonical_project_identity) ?? [];
+			current.push({
+				person: operation.person,
+				lifecycle: {
+					state: operation.lifecycle.state,
+					label: operation.lifecycle.label,
+					explanation: operation.lifecycle.explanation,
+				},
+			});
+			sharingByProject.set(item.canonical_project_identity, current);
+		}
+		return c.json({
+			...inventory,
+			projects: inventory.projects.map((project) => ({
+				...project,
+				sharing: sharingByProject.get(project.workspace_identity) ?? [],
+			})),
+		});
 	});
 
 	app.post("/api/sync/projects/reassign-project", async (c) => {
@@ -3689,87 +4279,82 @@ export function syncRoutes(
 	});
 
 	app.get("/api/sync/project-invites/:operationId", async (c) => {
+		const operationId = String(c.req.param("operationId") ?? "").trim();
+		if (!/^share_[a-f0-9]{40}$/u.test(operationId)) {
+			return c.json({ error: "operation_id_invalid" }, 400);
+		}
+		try {
+			const { payload } = await coordinatorProjectInvitePayload(operationId);
+			return c.json(payload);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "operation_read_failed";
+			return c.json(
+				{ error: message },
+				message === "operation_not_found"
+					? 404
+					: message.includes("mismatch") || message === "operation_intent_invalid"
+						? 409
+						: 400,
+			);
+		}
+	});
+
+	app.post("/api/sync/project-invites/:operationId/reconcile", async (c) => {
 		const store = getStore();
 		const operationId = String(c.req.param("operationId") ?? "").trim();
 		if (!/^share_[a-f0-9]{40}$/u.test(operationId)) {
 			return c.json({ error: "operation_id_invalid" }, 400);
 		}
 		try {
-			const { groupId, config } = projectInviteStatus();
-			const [status, payload] = await requestJson(
-				"GET",
-				`${buildBaseUrl(config.syncCoordinatorUrl)}/v1/admin/project-invites/${encodeURIComponent(operationId)}?group_id=${encodeURIComponent(groupId)}`,
-				{
-					headers: { "X-Codemem-Coordinator-Admin": config.syncCoordinatorAdminSecret },
-					timeoutS: 10,
-				},
-			);
-			if (status < 200 || status >= 300) {
-				return c.json(
-					{ error: String(payload?.error ?? "operation_read_failed") },
-					status === 404 ? 404 : status === 409 ? 409 : 400,
-				);
-			}
-			if (!payload || payload.operation_id !== operationId || payload.group_id !== groupId) {
-				return c.json({ error: "operation_scope_mismatch" }, 409);
-			}
-			if (payload.state === "waiting_for_acceptance") {
-				return c.json(payload);
-			}
-			if (payload.state !== "accepted") {
-				return c.json({ error: "operation_state_invalid" }, 409);
-			}
-			const required = [
-				"reviewed_project_set_digest",
-				"recipient_actor_id",
-				"recipient_display_name",
-				"recipient_device_id",
-				"recipient_device_display_name",
-				"recipient_public_key",
-				"recipient_fingerprint",
-				"consumed_at",
-				"trust_state",
-			] as const;
-			if (
-				required.some((key) => typeof payload[key] !== "string" || !String(payload[key]).trim())
-			) {
-				return c.json({ error: "operation_acceptance_invalid" }, 409);
-			}
-			const trustState = String(payload.trust_state);
-			const bootstrapGrantId =
-				typeof payload.bootstrap_grant_id === "string" && payload.bootstrap_grant_id.trim()
-					? payload.bootstrap_grant_id
-					: null;
-			if (
-				(trustState !== "pending_inviter_device" && trustState !== "bootstrap_grant_created") ||
-				(trustState === "bootstrap_grant_created") !== Boolean(bootstrapGrantId)
-			) {
-				return c.json({ error: "operation_trust_state_invalid" }, 409);
-			}
-			const projects = parseAcceptedProjectIntent(payload.projects);
-			reconcileShareOperationAcceptance(store.db, {
-				operationId,
-				coordinatorGroupId: groupId,
-				reviewedProjectSetDigest: String(payload.reviewed_project_set_digest),
-				recipientActorId: String(payload.recipient_actor_id),
-				recipientDisplayName: String(payload.recipient_display_name),
-				recipientDeviceId: String(payload.recipient_device_id),
-				recipientDeviceDisplayName: String(payload.recipient_device_display_name),
-				recipientPublicKey: String(payload.recipient_public_key),
-				recipientFingerprint: String(payload.recipient_fingerprint),
-				consumedAt: String(payload.consumed_at),
-				trustState,
-				bootstrapGrantId,
-				projects,
+			const result = await reconcileProjectInviteAcceptance(store, operationId);
+			return c.json({
+				ok: true,
+				operation_id: operationId,
+				reconciled: result.accepted,
+				state: result.accepted ? "accepted" : "waiting_for_acceptance",
 			});
-			return c.json({ ...payload, reconciled: true });
 		} catch (error) {
-			return c.json(
-				{ error: error instanceof Error ? error.message : "operation_read_failed" },
-				400,
-			);
+			const message = error instanceof Error ? error.message : "operation_reconcile_failed";
+			return c.json({ error: message }, message === "operation_not_found" ? 404 : 409);
 		}
 	});
+
+	app.get("/api/sync/share-operations", async (c) => {
+		const store = getStore();
+		const items = await shareOperationReadModels(store, undefined, false);
+		return c.json({ items });
+	});
+
+	app.get("/api/sync/share-operations/:operationId", async (c) => {
+		const store = getStore();
+		const operationId = String(c.req.param("operationId") ?? "").trim();
+		if (!/^share_[a-f0-9]{40}$/u.test(operationId)) {
+			return c.json({ error: "operation_id_invalid" }, 400);
+		}
+		const [item] = await shareOperationReadModels(store, operationId);
+		return item ? c.json(item) : c.json({ error: "operation_not_found" }, 404);
+	});
+
+	const advanceProjectShare = async (c: Context) => {
+		const store = getStore();
+		const operationId = String(c.req.param("operationId") ?? "").trim();
+		if (!/^share_[a-f0-9]{40}$/u.test(operationId)) {
+			return c.json({ error: "operation_id_invalid" }, 400);
+		}
+		try {
+			const advanced = await advanceProjectShareOperation(store, operationId);
+			if (!advanced.advanced) {
+				return c.json({ error: "invitation_not_accepted" }, 409);
+			}
+			const [operation] = await shareOperationReadModels(store, operationId);
+			return c.json({ ok: true, operation });
+		} catch (error) {
+			const code = error instanceof Error ? error.message : "provisioning_failed";
+			return c.json({ error: code }, code === "operation_not_found" ? 404 : 409);
+		}
+	};
+
+	app.post("/api/sync/share-operations/:operationId/advance", advanceProjectShare);
 
 	app.post("/api/sync/project-invites/:operationId/provision", async (c) => {
 		const store = getStore();
@@ -3778,76 +4363,7 @@ export function syncRoutes(
 			return c.json({ error: "operation_id_invalid" }, 400);
 		}
 		try {
-			const { groupId, config } = projectInviteStatus();
-			const coordinatorId = config.syncCoordinatorUrl || null;
-			if (!coordinatorId) throw new Error("coordinator_not_configured");
-			const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
-			const plan = await executeShareProvisioning(
-				store.db,
-				{ operationId, initiatingDeviceId: localDeviceId },
-				{
-					createOrGetBoundary: async (project, expectedGroupId) => {
-						if (expectedGroupId !== groupId) throw new Error("operation_scope_mismatch");
-						const readExisting = async () =>
-							(
-								await coordinatorListScopesAction({
-									groupId,
-									includeInactive: true,
-									remoteUrl: config.syncCoordinatorUrl || null,
-									adminSecret: config.syncCoordinatorAdminSecret || null,
-								})
-							).find((scope) => scope.scope_id === project.boundaryId) ?? null;
-						const existing = await readExisting();
-						if (existing) return existing;
-						try {
-							return await coordinatorCreateScopeAction({
-								groupId,
-								scopeId: project.boundaryId,
-								label: project.displayName,
-								kind: "managed_project",
-								authorityType: "coordinator",
-								coordinatorId,
-								membershipEpoch: 1,
-								status: "active",
-								remoteUrl: config.syncCoordinatorUrl || null,
-								adminSecret: config.syncCoordinatorAdminSecret || null,
-							});
-						} catch (error) {
-							const reread = await readExisting();
-							if (reread) return reread;
-							throw error;
-						}
-					},
-					grantMembership: ({ groupId: expectedGroupId, scopeId, deviceId, role }) => {
-						if (expectedGroupId !== groupId) throw new Error("operation_scope_mismatch");
-						return coordinatorGrantScopeMembershipAction({
-							groupId,
-							scopeId,
-							deviceId,
-							role,
-							membershipEpoch: 1,
-							coordinatorId,
-							remoteUrl: config.syncCoordinatorUrl || null,
-							adminSecret: config.syncCoordinatorAdminSecret || null,
-						});
-					},
-					supportsReassignScope: (deviceId) => peerSupportsReassignScope(store, deviceId),
-					refreshAuthorization: async (expectedGroupId) => {
-						if (expectedGroupId !== groupId) throw new Error("operation_scope_mismatch");
-						const refreshed = await refreshConfiguredScopeMembershipCache(store.db, config, {
-							keysDir: syncKeysDir(),
-						});
-						const group = refreshed.groups.find((item) => item.groupId === groupId);
-						if (group?.status !== "refreshed") throw new Error("authorization_refresh_failed");
-					},
-					runInitialSync: (recipientDeviceId) =>
-						runSyncPass(store.db, recipientDeviceId, {
-							keysDir: syncKeysDir(),
-							scanner: store.scanner,
-							refreshAuthorization: true,
-						}),
-				},
-			);
+			const plan = await executeProjectShareProvisioning(store, operationId);
 			return c.json({ ok: true, operation_id: operationId, state: "active", plan });
 		} catch (error) {
 			const code = error instanceof Error ? error.message : "provisioning_failed";

--- a/packages/viewer-server/src/share-operation-maintenance.test.ts
+++ b/packages/viewer-server/src/share-operation-maintenance.test.ts
@@ -1,0 +1,415 @@
+import { initTestSchema, type MemoryStore } from "@codemem/core";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { advancePendingProjectShares } from "./routes/sync.js";
+
+describe("advancePendingProjectShares", () => {
+	let db: InstanceType<typeof Database>;
+	let store: MemoryStore;
+
+	function seedOperation(input: { id: string; state: string; owner?: string; createdAt: string }) {
+		db.prepare(`INSERT INTO share_operations(
+			operation_id, state, inviter_actor_id, inviter_device_ids_json, person_id,
+			person_kind, teammate_name, history_policy, reviewed_project_set_digest,
+			coordinator_group_id, invite_token_digest, invite_expires_at, created_at, updated_at
+		) VALUES (?, ?, ?, '[]', ?, 'existing', 'Brian', 'existing_and_future', ?,
+			'team-a', ?, '2099-01-01T00:00:00.000Z', ?, ?)`).run(
+			input.id,
+			input.state,
+			input.owner ?? "actor-local",
+			`person-${input.id}`,
+			`digest-${input.id}`,
+			`token-${input.id}`,
+			input.createdAt,
+			input.createdAt,
+		);
+		db.prepare(`INSERT INTO share_operation_steps(
+			operation_id, step_key, effect_id, status, attempt_count, updated_at
+		) VALUES (?, 'invite_consumption', ?, 'pending', 0, ?)`).run(
+			input.id,
+			`invite-consumption:${input.id}`,
+			input.createdAt,
+		);
+	}
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+		store = { actorId: "actor-local", db } as unknown as MemoryStore;
+	});
+
+	afterEach(() => db.close());
+
+	it("processes a bounded oldest-first locally owned set and isolates failures", async () => {
+		seedOperation({ id: "share-oldest", state: "accepted", createdAt: "2026-07-20T00:00:00Z" });
+		seedOperation({
+			id: "share-foreign",
+			state: "accepted",
+			owner: "actor-other",
+			createdAt: "2026-07-20T00:00:01Z",
+		});
+		seedOperation({ id: "share-second", state: "provisioning", createdAt: "2026-07-20T00:00:02Z" });
+		seedOperation({ id: "share-third", state: "initial_sync", createdAt: "2026-07-20T00:00:03Z" });
+		seedOperation({ id: "share-revoked", state: "revoked", createdAt: "2026-07-19T00:00:00Z" });
+		seedOperation({ id: "share-revoking", state: "revoking", createdAt: "2026-07-19T00:00:00Z" });
+		seedOperation({ id: "share-cancelled", state: "cancelled", createdAt: "2026-07-19T00:00:01Z" });
+		const visited: string[] = [];
+		const advanceOperation = vi.fn(async (_store: MemoryStore, operationId: string) => {
+			visited.push(operationId);
+			if (operationId === "share-oldest") throw new Error("injected failure");
+			return { advanced: true, state: "active" as const };
+		});
+
+		const result = await advancePendingProjectShares(store, {
+			limit: 2,
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(visited).toEqual(["share-oldest", "share-second"]);
+		expect(result).toMatchObject({ processed: 2, advanced: 1, failed: 1, waiting: 0 });
+		expect(result.items[0]).toMatchObject({
+			operationId: "share-oldest",
+			outcome: "failed",
+			error: "injected failure",
+		});
+		expect(result.items[1]).toEqual({ operationId: "share-second", outcome: "advanced" });
+	});
+
+	it("prioritizes advanceable work over older invite polling", async () => {
+		for (const [id, createdAt] of [
+			["share-waiting-1", "2026-07-20T00:00:00Z"],
+			["share-waiting-2", "2026-07-20T00:00:01Z"],
+			["share-waiting-3", "2026-07-20T00:00:02Z"],
+		] as const) {
+			seedOperation({ id, state: "waiting_for_acceptance", createdAt });
+		}
+		seedOperation({
+			id: "share-accepted-new",
+			state: "accepted",
+			createdAt: "2026-07-20T00:10:00Z",
+		});
+		const advanceOperation = vi.fn(async (_store: MemoryStore, operationId: string) =>
+			operationId === "share-accepted-new"
+				? { advanced: true, state: "active" as const }
+				: { advanced: false, state: "waiting_for_acceptance" as const },
+		);
+
+		await advancePendingProjectShares(store, {
+			limit: 3,
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(advanceOperation).toHaveBeenCalledWith(store, "share-accepted-new");
+	});
+
+	it("retries waiting-for-device operations through the existing advance seam", async () => {
+		seedOperation({
+			id: "share-waiting-device",
+			state: "waiting_for_device",
+			createdAt: "2026-07-20T00:00:00Z",
+		});
+		const advanceOperation = vi.fn(async () => ({ advanced: true, state: "active" as const }));
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(advanceOperation).toHaveBeenCalledWith(store, "share-waiting-device");
+		expect(result).toMatchObject({ processed: 1, advanced: 1, failed: 0 });
+	});
+
+	it("treats an offline recipient as passive waiting instead of a daemon failure", async () => {
+		seedOperation({
+			id: "share-waiting-device",
+			state: "waiting_for_device",
+			createdAt: "2026-07-20T00:00:00Z",
+		});
+		const advanceOperation = vi.fn(async () => {
+			throw new Error("waiting_for_device");
+		});
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(result).toMatchObject({
+			processed: 1,
+			advanced: 0,
+			waiting: 1,
+			attention: 0,
+			failed: 0,
+		});
+		expect(result.items).toEqual([
+			{ operationId: "share-waiting-device", outcome: "waiting_for_device" },
+		]);
+	});
+
+	it("backs off recent waiting-for-device operations", async () => {
+		seedOperation({
+			id: "share-waiting-device",
+			state: "waiting_for_device",
+			createdAt: "2026-07-20T00:58:00Z",
+		});
+		const advanceOperation = vi.fn(async () => ({ advanced: true, state: "active" as const }));
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(advanceOperation).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ processed: 0, waiting: 0, attention: 0, failed: 0 });
+	});
+
+	it("leaves terminal needs-attention operations for explicit user retry", async () => {
+		seedOperation({
+			id: "share-needs-attention",
+			state: "needs_attention",
+			createdAt: "2026-07-20T00:00:00Z",
+		});
+		const advanceOperation = vi.fn(async () => ({ advanced: true, state: "active" as const }));
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(advanceOperation).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ processed: 0, attention: 0, failed: 0 });
+	});
+
+	it("reports a newly terminal operation without failing global daemon health", async () => {
+		seedOperation({
+			id: "share-failed-setup",
+			state: "accepted",
+			createdAt: "2026-07-20T00:00:00Z",
+		});
+		const advanceOperation = vi.fn(async () => {
+			db.prepare(
+				"UPDATE share_operations SET state = 'needs_attention' WHERE operation_id = ?",
+			).run("share-failed-setup");
+			throw new Error("provisioning_failed");
+		});
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(result).toMatchObject({
+			processed: 1,
+			advanced: 0,
+			waiting: 0,
+			attention: 1,
+			failed: 0,
+		});
+		expect(result.items[0]).toMatchObject({
+			operationId: "share-failed-setup",
+			outcome: "needs_attention",
+			error: "provisioning_failed",
+		});
+	});
+
+	it.each([
+		"coordinator_not_configured",
+		"team_sharing_not_configured",
+		"team_selection_ambiguous",
+	])("moves pre-step configuration failure %s to explicit recovery", async (errorCode) => {
+		seedOperation({
+			id: "share-missing-coordinator",
+			state: "accepted",
+			createdAt: "2026-07-20T00:00:00Z",
+		});
+		const advanceOperation = vi.fn(async () => {
+			throw new Error(errorCode);
+		});
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(result).toMatchObject({ processed: 1, attention: 1, failed: 0 });
+		expect(result.items[0]).toMatchObject({ outcome: "needs_attention" });
+		expect(db.prepare("SELECT state FROM share_operations").pluck().get()).toBe("needs_attention");
+	});
+
+	it("polls waiting-for-acceptance operations and backs off after a pending response", async () => {
+		seedOperation({
+			id: "share-awaiting-acceptance",
+			state: "waiting_for_acceptance",
+			createdAt: "2026-07-20T00:00:00Z",
+		});
+		const advanceOperation = vi.fn(async () => ({
+			advanced: false,
+			state: "waiting_for_acceptance" as const,
+		}));
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(advanceOperation).toHaveBeenCalledWith(store, "share-awaiting-acceptance");
+		expect(result).toMatchObject({ processed: 1, advanced: 0, waiting: 1, failed: 0 });
+		expect(db.prepare("SELECT state FROM share_operations").pluck().get()).toBe(
+			"waiting_for_acceptance",
+		);
+		expect(db.prepare("SELECT updated_at FROM share_operations").pluck().get()).toBe(
+			"2026-07-20T01:00:00.000Z",
+		);
+	});
+
+	it("does not poll a recently checked waiting-for-acceptance operation", async () => {
+		seedOperation({
+			id: "share-awaiting-acceptance",
+			state: "waiting_for_acceptance",
+			createdAt: "2026-07-20T00:59:45Z",
+		});
+		const advanceOperation = vi.fn(async () => ({
+			advanced: false,
+			state: "waiting_for_acceptance" as const,
+		}));
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(advanceOperation).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ processed: 0, waiting: 0, failed: 0 });
+	});
+
+	it("backs off transient invite reconciliation errors without poisoning daemon health", async () => {
+		seedOperation({
+			id: "share-awaiting-acceptance",
+			state: "waiting_for_acceptance",
+			createdAt: "2026-07-20T00:00:00Z",
+		});
+		const advanceOperation = vi.fn(async () => {
+			throw new Error("coordinator unavailable");
+		});
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(result).toMatchObject({
+			processed: 1,
+			waiting: 1,
+			attention: 0,
+			failed: 0,
+		});
+		expect(result.items[0]).toMatchObject({ outcome: "retry_scheduled" });
+		expect(
+			db
+				.prepare(`SELECT status, attempt_count, safe_error_code FROM share_operation_steps
+					WHERE operation_id = ? AND step_key = 'invite_consumption'`)
+				.get("share-awaiting-acceptance"),
+		).toEqual({ status: "pending", attempt_count: 1, safe_error_code: "operation_read_failed" });
+	});
+
+	it("moves terminal invite reconciliation errors to explicit recovery", async () => {
+		seedOperation({
+			id: "share-invalid-acceptance",
+			state: "waiting_for_acceptance",
+			createdAt: "2026-07-20T00:00:00Z",
+		});
+		const advanceOperation = vi.fn(async () => {
+			throw Object.assign(new Error("operation_scope_mismatch"), { status: 409 });
+		});
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(result).toMatchObject({ processed: 1, waiting: 0, attention: 1, failed: 0 });
+		expect(result.items[0]).toMatchObject({ outcome: "needs_attention" });
+		expect(db.prepare("SELECT state FROM share_operations").pluck().get()).toBe("needs_attention");
+	});
+
+	it.each([
+		"coordinator_not_configured",
+		"team_sharing_not_configured",
+		"team_selection_ambiguous",
+		"recipient_fingerprint_mismatch",
+		"recipient_device_identity_conflict",
+		"recipient_actor_conflict",
+		"pending_person_identity_conflict",
+		"operation_intent_mismatch",
+	])("moves status-less deterministic conflict %s to explicit recovery", async (errorCode) => {
+		seedOperation({
+			id: "share-invalid-identity",
+			state: "waiting_for_acceptance",
+			createdAt: "2026-07-20T00:00:00Z",
+		});
+		const advanceOperation = vi.fn(async () => {
+			throw new Error(errorCode);
+		});
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(result).toMatchObject({ processed: 1, waiting: 0, attention: 1, failed: 0 });
+		expect(result.items[0]).toMatchObject({ outcome: "needs_attention", error: errorCode });
+		expect(db.prepare("SELECT state FROM share_operations").pluck().get()).toBe("needs_attention");
+		expect(
+			db
+				.prepare(`SELECT status, attempt_count, safe_error_code FROM share_operation_steps
+					WHERE operation_id = ? AND step_key = 'invite_consumption'`)
+				.get("share-invalid-identity"),
+		).toEqual({ status: "failed", attempt_count: 1, safe_error_code: errorCode });
+	});
+
+	it("keeps transient invite reconciliation passive and recovers after the coordinator returns", async () => {
+		seedOperation({
+			id: "share-awaiting-acceptance",
+			state: "waiting_for_acceptance",
+			createdAt: "2026-07-20T00:00:00Z",
+		});
+		db.prepare(`UPDATE share_operation_steps SET attempt_count = 2
+			WHERE operation_id = ? AND step_key = 'invite_consumption'`).run("share-awaiting-acceptance");
+		const advanceOperation = vi.fn(async () => {
+			throw new Error("coordinator unavailable");
+		});
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(result).toMatchObject({ processed: 1, waiting: 1, attention: 0, failed: 0 });
+		expect(result.items[0]).toMatchObject({ outcome: "retry_scheduled" });
+		expect(db.prepare("SELECT state FROM share_operations").pluck().get()).toBe(
+			"waiting_for_acceptance",
+		);
+		expect(
+			db
+				.prepare(`SELECT status, attempt_count, safe_error_code FROM share_operation_steps
+					WHERE operation_id = ? AND step_key = 'invite_consumption'`)
+				.get("share-awaiting-acceptance"),
+		).toEqual({ status: "pending", attempt_count: 3, safe_error_code: "operation_read_failed" });
+
+		const recoveredAdvance = vi.fn(async () => {
+			db.prepare("UPDATE share_operations SET state = 'active' WHERE operation_id = ?").run(
+				"share-awaiting-acceptance",
+			);
+			return { advanced: true, state: "active" as const };
+		});
+		const recovered = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:01:00Z"),
+			advanceOperation: recoveredAdvance,
+		});
+
+		expect(recovered).toMatchObject({ processed: 1, advanced: 1, failed: 0 });
+		expect(recoveredAdvance).toHaveBeenCalledWith(store, "share-awaiting-acceptance");
+	});
+});


### PR DESCRIPTION
## Description

Replace implementation-state sharing UI with a resumable project-first lifecycle. Project sharing is grouped by Person, with friendly devices and exact projects nested below; revoked and cancelled operations are historical rather than current access.

Add read-only operation list/detail APIs, token-on-demand invite copying, explicit reconciliation/advance actions, bounded automatic progression, passive offline handling, retry budgets, and one safe recovery action. Internal scope, cursor, address, membership, and raw-ID details stay out of the primary UI.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated with 2,747 workspace tests, full build, Cloudflare Worker integration tests, focused lifecycle/maintenance/UI suites, independent security review, Gordon review, and pragmatism review.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced