### PR TITLE
test(sharing): prove exact project sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | **Viewer** | `codemem serve [start\|stop\|restart]` | Launch / manage the web viewer |
 | **Sync** | `codemem sync enable\|disable` | Enable or disable peer-to-peer sync |
 | | `codemem sync status` | Device info and peer health |
-| | `codemem sync pair` | Generate or accept a pairing payload |
+| | `codemem sync pair` | Advanced/legacy device pairing |
 | | `codemem sync once` | Run one immediate sync pass |
 | | `codemem sync doctor` | Diagnose sync configuration issues |
 | | `codemem sync bootstrap` | Bootstrap sync from a peer snapshot |
@@ -266,7 +266,26 @@ See `codemem memory export --help` and `codemem memory import --help` for full o
 
 ## Peer-to-peer sync
 
-Replicate memories across devices without a central server.
+Share selected project memories with a teammate, or replicate memories between your own devices, without a central data service.
+
+### Share projects with a teammate
+
+In the viewer, choose **Share** on a project (or select projects, then choose **Share projects**):
+
+1. Choose or enter the teammate's **Person** name.
+2. Select the exact projects to share and review each existing-memory count.
+3. Confirm that existing memories **and future activity** from those projects will share, then send the one expiring invite.
+4. The recipient accepts once, confirms their name and device name, and codemem links the Person and device, establishes trust and access, and starts the first sync.
+
+Only the reviewed canonical projects are shared—similarly named or sibling projects are not included. A memory marked **Only me** stays local even when its project is shared. Removing access stops future sharing; memories already copied to another device may remain there.
+
+While setup is progressing, codemem reports what it is doing. An offline recipient device is waiting, not an error; sync resumes when it reconnects. If a setup step reaches a terminal failure, codemem shows its cause and one **Retry setup** action.
+
+Manual pairing, actor assignment, Space grants, and project mappings remain available for same-person devices, legacy setups, and diagnostics. They are not required for normal teammate sharing. See [the user guide](docs/user-guide.md#share-projects-with-a-teammate).
+
+### Advanced and legacy device pairing
+
+Use manual pairing only for a same-person device, an existing integration, or a compatibility workflow:
 
 ```text
 codemem sync enable        # generate device keys
@@ -275,9 +294,7 @@ codemem sync start         # start the viewer-backed sync runtime
 codemem sync once          # run one immediate sync pass
 ```
 
-The viewer now includes actor management for mapping multiple peers to one logical person, plus owned-memory visibility controls so project-filtered memories share by default while `Only me` stays a per-memory local override.
-
-Project filters, peer-to-actor assignment, visibility controls, and config keys are documented in [docs/user-guide.md](docs/user-guide.md).
+Legacy pairing and legacy coordinator invitations do not grant project access by themselves. For advanced access details, compatibility, and recovery, see [the user guide](docs/user-guide.md).
 
 For cross-network setups where peer addresses change frequently or mDNS does not cross VPN/network boundaries, codemem also supports optional coordinator-backed discovery with a self-hosted coordinator. The preferred deployment path is the built-in `codemem coordinator` service; see [docs/coordinator-discovery.md](docs/coordinator-discovery.md).
 

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -17,7 +17,7 @@ the network boundary you care about (for example VPNs).
 - it does not queue offline sync data
 - it does not replace local SQLite as the source of truth
 - it is not a codemem-hosted public service
-- it does not automatically create or repair `sync_peers`
+- it does not turn discovery-group membership into project access
 - joining a coordinator group does not, by itself, create an active sync relationship
 - joining a coordinator group does not, by itself, grant access to any Sharing domain
 
@@ -129,6 +129,12 @@ authorize a device to receive `acme-work`, `personal:<actor_id>`, or any other
 domain. The coordinator group is the administrative container. The Sharing
 domain grant is the data-access decision.
 
+## Project-first sharing and advanced administration
+
+For a teammate, start in the viewer's **Projects** tab: choose a Person, choose the exact projects, review existing-memory counts and future sharing, then send one expiring invite. Acceptance links the Person and device, establishes the required trust and access, and starts initial sync.
+
+The coordinator remains the authority for the invite and access steps, but its groups, devices, Spaces, grants, and project mappings are advanced administration—not normal teammate setup. Legacy coordinator invites and manual pairing remain compatible, but do not grant project access by themselves.
+
 ## Sharing-domain membership and revocation
 
 Use coordinator Sharing-domain commands when a group needs explicit access
@@ -160,6 +166,12 @@ cached peer addresses and cached membership state. They must not treat a
 coordinator outage as permission to widen access. When membership cannot be
 verified for a scoped operation, fail closed or keep data local until the cache
 is refreshed.
+
+### Compatibility and reassignment
+
+Project-first sharing may move selected project history into a managed boundary. For history that could already have replicated, participating owner devices must negotiate support for `reassign_scope`. If a required device lacks that capability, setup fails closed before any partial migration; update that device and retry the sharing operation.
+
+Older invitations and pairing payloads continue to parse through their legacy enrollment paths. They remain valid for compatibility, but are clearly separate from a project-scoped invite and cannot silently acquire its access.
 
 ## How discovery works
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -137,24 +137,60 @@ Candidate mining is deterministic and review-first:
 
 ## Sync
 
+### Share projects with a teammate
+
+The normal teammate flow starts in **Projects**, not pairing or Teams:
+
+1. Choose **Share** for one project, or select projects and choose **Share projects**.
+2. Choose an existing **Person** or enter the teammate's name.
+3. Select the exact projects and review their existing-memory counts.
+4. Confirm that the invite shares those existing memories and future activity, then send the one expiring invite.
+5. The recipient accepts once and confirms their name and device name. Codemem links the Person and device, establishes trust and project access, and starts initial sync.
+
+```text
+Brian will receive:
+• 436 existing memories and future activity from codemem
+
+No other projects will be shared.
+```
+
+Project access uses canonical project identity, not a display name. Selecting `codemem` does not share a similarly named or sibling project in the same Space. **Only me** keeps a memory local, even when its project is shared.
+
+The invite is single-use, expires, and is limited to the reviewed projects. The recipient cannot add projects during acceptance. Existing and future selected-project memories arrive after setup; unrelated projects remain absent.
+
+### Setup status and recovery
+
+| Status | Meaning | What to do |
+| --- | --- | --- |
+| Waiting for acceptance | The invite has not been accepted. | Copy the invite or cancel it. |
+| Setting up project access / Starting first sync | Codemem is establishing trust, access, and initial replication. | Wait. |
+| Waiting for device | The recipient device is offline. | Wait; sync continues when it reconnects. |
+| Up to date | The selected projects are syncing. | Nothing. |
+| Needs attention | A setup step reached a terminal failure. | Use **Retry setup**. |
+| Access removed | Future access has been removed. Previously copied memories may remain on the other device. | Share again if appropriate. |
+
+An offline device is a passive waiting state, not a failure. Retry only when codemem shows **Needs attention**; it preserves completed setup work and resumes from the failed step.
+
 ### Enable + run
 
 - `codemem sync enable` generates keys and writes config.
 - `codemem sync start` starts the viewer-backed sync runtime.
 - `codemem sync status` shows device info and peer health.
 
-### Pair devices
+### Advanced and legacy device pairing
+
+Use manual pairing for same-person devices, existing integrations, or compatibility—not normal teammate sharing.
 
 1. In the viewer, open the Sync panel and scan/copy the QR payload (recommended).
 2. Or run `codemem sync pair` and copy the payload.
 3. On the other device, run `codemem sync pair --accept '<payload>'`.
 
-Optional (recommended for coworker sync): set a per-peer project filter at accept time:
+Optional legacy filters can narrow an already-authorized peer's data; they cannot grant project access:
 
 - `codemem sync pair --accept '<payload>' --include shared-repo-1,shared-repo-2`
 - `codemem sync pair --accept '<payload>' --exclude private-repo`
 
-### Sharing domains and mixed-device safety
+### Advanced sharing domains and mixed-device safety
 
 A **Sharing domain** is the boundary that decides which devices may receive a
 memory. Internally this is stored as `scope_id`. Project filters still matter,
@@ -214,13 +250,13 @@ Inspect current and completed maintenance jobs with:
 codemem maintenance status
 ```
 
-### Claim your own devices
+### Same-person device recovery
 
 - In the Sync panel, use `Assigned actor` to map a peer to your local actor when that machine should count as part of your identity.
 - Actor assignment preserves provenance and same-person UI continuity. Private sync still requires membership in a personal Sharing domain; actor assignment is not an access grant.
 - If a machine is replaced or re-paired, use `Claim old device as mine` to reconnect older synced history to your local actor.
 
-### Manage actors
+### Advanced actor management
 
 - The Sync panel now has an `Actors` section for creating and renaming non-local actors.
 - The same section can merge a duplicate actor into another actor; this immediately moves assigned peers, while already-stamped historical memories keep their current provenance until a later follow-on flow changes them.
@@ -230,6 +266,12 @@ codemem maintenance status
 - Non-local peers receive memories only after Sharing-domain authorization succeeds. Their include/exclude filters can narrow that set, but cannot grant access.
 - Use `Only me` on a memory when it should stay local and not sync to non-local actors.
 - The Sync panel also shows a teammate review card with per-peer counts for memories that will share by default versus memories marked `Only me`, plus a one-click jump into `My memories` in the Feed for review.
+
+### Advanced compatibility and reassignment
+
+Legacy pairing and coordinator invitations remain supported, but do not grant selected-project access by themselves. Manual Space grants and project mappings are advanced administration.
+
+When selected history may already have replicated, all participating owner devices must support `reassign_scope` before codemem moves it into a project-specific boundary. If any required device lacks support, setup fails closed before partial migration; update that device, then use **Retry setup**. Technical capability details and IDs are available only in diagnostics.
 
 ### One-off sync
 
@@ -258,7 +300,7 @@ codemem maintenance status
 - Use coordinator-backed discovery when peers are reachable but their addresses change frequently or mDNS does not work across network boundaries such as VPNs.
 - Set `sync_coordinator_url` and `sync_coordinator_group` to enable it.
 - The Settings UI exposes coordinator URL, group, timeout, and presence TTL fields under Device Sync.
-- Manage project-to-Space assignment from the Projects tab; Device Sync is only for sync configuration.
+- Use **Share** in Projects for normal teammate sharing. Manual project-to-Space assignment is advanced/legacy administration; Device Sync is for runtime configuration.
 - The coordinator is self-hosted/operator-run and only helps peers discover fresh addresses; direct peer-to-peer sync remains the data path.
 - See [docs/coordinator-discovery.md](coordinator-discovery.md) for setup, config, and current limitations.
 - See [docs/anchor-peer-deployment.md](anchor-peer-deployment.md) if you want an always-on peer as a sync backstop for personal or team Sharing domains.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,6 +10,7 @@ This directory holds the first local Docker/Compose-based E2E harness for sync s
 - fleet spec and Compose fleet-smoke proving scenario
 - coordinator invite/join/approval/discovery scenario
 - direct peer sync scenario with data-plane assertions
+- project-first teammate-sharing scenario with exact-project isolation assertions
 - bootstrap scenario plus dirty-local refusal validation
 - seed modes: `empty`, `fixture-small`, `fixture-large`, `local-import`
 - automatic artifact capture under `.tmp/e2e-artifacts/`
@@ -37,6 +38,16 @@ pnpm run e2e:coordinator
 ```fish
 pnpm run e2e:direct-sync
 ```
+
+## Run the project-sharing scenario
+
+```fish
+set -lx CODEMEM_E2E_BUILD 1
+set -lx CODEMEM_E2E_JSON 1
+pnpm run e2e:project-sharing -- --json
+```
+
+This scenario creates two canonical projects on one peer, shares exactly one through the project-first invite flow, and verifies automatic identity linking, existing and future replication, source-membership isolation, and the absence of unrelated-project rows on the recipient.
 
 ## Run the fleet smoke scenario
 

--- a/e2e/bin/run-local.ts
+++ b/e2e/bin/run-local.ts
@@ -4,6 +4,7 @@ import { runFleetSmokeScenario } from "../scenarios/fleet-smoke.js";
 import { runBootstrapScenario } from "../scenarios/bootstrap.js";
 import { runCoordinatorScenario } from "../scenarios/coordinator.js";
 import { runDirectSyncScenario } from "../scenarios/direct-sync.js";
+import { runProjectSharingScenario } from "../scenarios/project-sharing.js";
 import { runSharingDomainsScenario } from "../scenarios/sharing-domains.js";
 import { runSmokeScenario } from "../scenarios/smoke.js";
 import { createScenarioContext } from "../lib/scenario-context.js";
@@ -15,6 +16,7 @@ const scenarios = {
 	fleetCleanup: runFleetCleanupScenario,
 	fleetReady: runFleetReadyScenario,
 	fleetSmoke: runFleetSmokeScenario,
+	projectSharing: runProjectSharingScenario,
 	sharingDomains: runSharingDomainsScenario,
 	smoke: runSmokeScenario,
 } as const;

--- a/e2e/scenarios/project-sharing.ts
+++ b/e2e/scenarios/project-sharing.ts
@@ -1,0 +1,341 @@
+import { assert, assertStatus } from "../lib/assert.js";
+import {
+	ADMIN_SECRET,
+	CLI_PREFIX,
+	GROUP_ID,
+	parseJson,
+	readPeerIdentity,
+	writePeerConfig,
+} from "../lib/coordinator.js";
+import type { ScenarioContext } from "../lib/scenario-context.js";
+import { waitFor } from "../lib/wait.js";
+
+interface FixtureSummary {
+	memories: Array<{ title: string; project: string | null; scope_id: string | null; active: number }>;
+	actors: Array<{ actor_id: string; display_name: string; status: string }>;
+	peers: Array<{ peer_device_id: string; name: string | null; actor_id: string | null }>;
+	managed_memberships: Array<{ scope_id: string; device_id: string; status: string }>;
+	source_memberships: Array<{ device_id: string; status: string }>;
+	operations: Array<{
+		operation_id: string;
+		state: string;
+		teammate_name: string;
+		recipient_device_id: string | null;
+		recipient_device_display_name: string | null;
+	}>;
+}
+
+function fixture(ctx: ScenarioContext, service: string, action: string, artifact: string): FixtureSummary {
+	const result = ctx.compose.exec(
+		service,
+		[
+			"pnpm",
+			"exec",
+			"tsx",
+			"--conditions",
+			"source",
+			"e2e/scripts/project-sharing-fixture.ts",
+			"--action",
+			action,
+		],
+		artifact,
+		120_000,
+	);
+	assertStatus(result.status, 0, `${service} fixture action ${action} failed`);
+	return parseJson<FixtureSummary>(result.stdout, artifact);
+}
+
+function startServer(ctx: ScenarioContext, service: string, artifact: string): void {
+	const staticResult = ctx.compose.exec(
+		service,
+		[
+			"node",
+			"--input-type=module",
+			"-e",
+			"import { mkdirSync, writeFileSync } from 'node:fs'; mkdirSync('/tmp/viewer-static', { recursive: true }); writeFileSync('/tmp/viewer-static/index.html', '<!doctype html><title>e2e</title>');",
+		],
+		`${artifact}-static`,
+		30_000,
+	);
+	assertStatus(staticResult.status, 0, `${service} static preparation failed`);
+	const result = ctx.compose.execDetached(
+		service,
+		[
+			"env",
+			"CODEMEM_VIEWER_STATIC_DIR=/tmp/viewer-static",
+			...CLI_PREFIX,
+			"serve",
+			"start",
+			"--foreground",
+			"--db-path",
+			"/data/mem.sqlite",
+			"--host",
+			"0.0.0.0",
+			"--port",
+			"38888",
+		],
+		artifact,
+	);
+	assertStatus(result.status, 0, `${service} viewer/sync server failed to start`);
+}
+
+async function request<T>(
+	ctx: ScenarioContext,
+	service: string,
+	path: string,
+	artifact: string,
+	body?: Record<string, unknown>,
+): Promise<{ status: number; body: T }> {
+	const script = `const response = await fetch(${JSON.stringify(`http://127.0.0.1:38888${path}`)}, ${JSON.stringify(
+		body
+			? { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) }
+			: {},
+	)}); const text = await response.text(); console.log(JSON.stringify({ status: response.status, body: text ? JSON.parse(text) : null }));`;
+	const result = ctx.compose.exec(service, ["node", "--input-type=module", "-e", script], artifact, 60_000);
+	assertStatus(result.status, 0, `${service} request ${path} failed`);
+	return parseJson<{ status: number; body: T }>(result.stdout, artifact);
+}
+
+async function waitForServer(ctx: ScenarioContext, service: string, artifact: string): Promise<void> {
+	await waitFor(
+		async () => {
+			const response = await request(ctx, service, "/api/stats", artifact);
+			assert(response.status === 200, `${service} viewer is not ready`);
+		},
+		{ description: `${service} viewer readiness`, timeoutMs: 120_000, intervalMs: 2_000 },
+	);
+}
+
+function syncOnce(ctx: ScenarioContext, service: string, artifact: string): void {
+	const result = ctx.compose.exec(
+		service,
+		[...CLI_PREFIX, "sync", "once", "--db-path", "/data/mem.sqlite"],
+		artifact,
+		180_000,
+		true,
+	);
+	assert(
+		result.status === 0 || result.stderr.includes("no accepted peers"),
+		`${service} sync once failed: ${result.stderr || result.stdout}`,
+	);
+}
+
+export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<void> {
+	ctx.recordNote(
+		"scenario.txt",
+		"Project-first sharing: two isolated peers, two canonical projects, one reviewed project invite, automatic identity/device linking, exact existing-and-future replication, and source-membership non-inheritance.",
+	);
+	ctx.compose.down("00-compose-down-pre", true);
+	ctx.compose.up(["coordinator", "peer-a", "peer-b"], "01-compose-up");
+	ctx.compose.ps("02-compose-ps");
+
+	fixture(ctx, "peer-a", "init", "03-init-peer-a");
+	fixture(ctx, "peer-b", "init", "04-init-peer-b");
+	const peerA = readPeerIdentity(ctx, "peer-a", "05-peer-a-identity");
+	const peerB = readPeerIdentity(ctx, "peer-b", "06-peer-b-identity");
+	const seededA = fixture(ctx, "peer-a", "seed-a", "07-seed-peer-a");
+	assert(
+		seededA.source_memberships.some((member) => member.device_id === "source-bystander"),
+		"source bystander fixture missing",
+	);
+
+	for (const [service, deviceName] of [
+		["peer-a", "Adam's Test Mac"],
+		["peer-b", "Brian's Test Mac"],
+	] as const) {
+		writePeerConfig(
+			ctx,
+			service,
+			{
+				actor_display_name: service === "peer-a" ? "Adam" : "Brian",
+				sync_device_name: deviceName,
+				sync_enabled: true,
+				sync_host: "0.0.0.0",
+				sync_port: 7337,
+				sync_advertise: `http://${service}:7337`,
+				sync_interval_s: 2,
+				sync_coordinator_url: "http://coordinator:7347",
+				sync_coordinator_group: GROUP_ID,
+				sync_coordinator_admin_secret: ADMIN_SECRET,
+			},
+			`08-config-${service}`,
+		);
+	}
+
+	const group = ctx.compose.exec(
+		"coordinator",
+		[...CLI_PREFIX, "sync", "coordinator", "group-create", GROUP_ID, "--db-path", "/data/coordinator.sqlite"],
+		"09-group-create",
+	);
+	assertStatus(group.status, 0, "coordinator group creation failed");
+	const enroll = ctx.compose.exec(
+		"coordinator",
+		[
+			...CLI_PREFIX,
+			"sync",
+			"coordinator",
+			"enroll-device",
+			GROUP_ID,
+			peerA.device_id,
+			"--fingerprint",
+			peerA.fingerprint,
+			"--public-key",
+			peerA.public_key,
+			"--name",
+			"Adam's Test Mac",
+			"--db-path",
+			"/data/coordinator.sqlite",
+			"--json",
+		],
+		"10-enroll-peer-a",
+	);
+	assertStatus(enroll.status, 0, "peer-a enrollment failed");
+
+	startServer(ctx, "peer-a", "11-start-peer-a");
+	startServer(ctx, "peer-b", "12-start-peer-b");
+	await waitForServer(ctx, "peer-a", "13-peer-a-ready");
+	await waitForServer(ctx, "peer-b", "14-peer-b-ready");
+
+	const inventory = await request<{ projects: Array<{ workspace_identity: string; display_project: string }> }>(
+		ctx,
+		"peer-a",
+		"/api/sync/projects?limit=50",
+		"15-project-inventory",
+	);
+	assert(inventory.status === 200, "project inventory failed");
+	assert(inventory.body.projects.length >= 2, "expected at least two canonical projects");
+	const selected = inventory.body.projects.find((project) => project.display_project === "selected-project");
+	const unrelated = inventory.body.projects.find((project) => project.display_project === "unrelated-project");
+	assert(selected && unrelated, "selected/unrelated canonical project fixtures missing");
+
+	const preview = await request<{ reviewed_project_set_digest: string; existing_memory_count: number }>(
+		ctx,
+		"peer-a",
+		"/api/sync/project-invites/preview",
+		"16-preview-share",
+		{ teammate_name: "Brian", project_ids: [selected.workspace_identity] },
+	);
+	assert(preview.status === 200, `project invite preview failed: ${JSON.stringify(preview.body)}`);
+	assert(preview.body.existing_memory_count === 1, "preview must count the selected existing memory");
+	const created = await request<{
+		operation_id: string;
+		invite: { encoded: string };
+		projects: Array<{ project_id: string; existing_memory_count: number }>;
+	}>(
+		ctx,
+		"peer-a",
+		"/api/sync/project-invites",
+		"17-create-share",
+		{
+			teammate_name: "Brian",
+			project_ids: [selected.workspace_identity],
+			reviewed_project_set_digest: preview.body.reviewed_project_set_digest,
+		},
+	);
+	assert(created.status === 200, `project invite creation failed: ${JSON.stringify(created.body)}`);
+	assert(created.body.projects.length === 1, "invite must contain exactly one reviewed project");
+	assert(created.body.projects[0]?.project_id === selected.workspace_identity, "invite project changed after review");
+	assert(created.body.projects[0]?.existing_memory_count === 1, "invite lost the reviewed memory count");
+
+	const accepted = await request<Record<string, unknown>>(
+		ctx,
+		"peer-b",
+		"/api/sync/invites/import",
+		"18-accept-share",
+		{ invite: created.body.invite.encoded, recipient_name: "Brian", device_name: "Brian's Test Mac" },
+	);
+	assert(accepted.status === 200, `project invite acceptance failed: ${JSON.stringify(accepted.body)}`);
+
+	await waitFor(
+		async () => {
+			const reconciled = await request<Record<string, unknown>>(
+				ctx,
+				"peer-a",
+				`/api/sync/project-invites/${created.body.operation_id}/reconcile`,
+				"19-reconcile",
+				{},
+			);
+			assert(reconciled.status === 200, `acceptance reconciliation failed: ${JSON.stringify(reconciled.body)}`);
+			const advanced = await request<Record<string, unknown>>(
+				ctx,
+				"peer-a",
+				`/api/sync/share-operations/${created.body.operation_id}/advance`,
+				"20-advance",
+				{},
+			);
+			assert(advanced.status === 200, `project provisioning not ready: ${JSON.stringify(advanced.body)}`);
+		},
+		{ description: "project share provisioning", timeoutMs: 180_000, intervalMs: 3_000 },
+	);
+
+	syncOnce(ctx, "peer-a", "20-sync-existing-a");
+	syncOnce(ctx, "peer-b", "21-sync-existing-b");
+	await waitFor(
+		async () => {
+			const summary = fixture(ctx, "peer-b", "summary", "22-peer-b-existing-summary");
+			const titles = summary.memories.map((memory) => memory.title);
+			assert(titles.includes("selected existing"), "selected existing memory has not arrived");
+			assert(!titles.includes("unrelated existing"), "unrelated existing memory leaked to peer-b");
+		},
+		{ description: "selected existing memory on peer-b", timeoutMs: 120_000, intervalMs: 3_000 },
+	);
+
+	fixture(ctx, "peer-a", "add-future", "23-add-future-memories");
+	syncOnce(ctx, "peer-a", "24-sync-future-a");
+	syncOnce(ctx, "peer-b", "25-sync-future-b");
+	await waitFor(
+		async () => {
+			const summary = fixture(ctx, "peer-b", "summary", "26-peer-b-future-summary");
+			const titles = summary.memories.map((memory) => memory.title);
+			assert(titles.includes("selected future"), "selected future memory has not arrived");
+			for (const forbidden of ["unrelated existing", "unrelated future"]) {
+				assert(!titles.includes(forbidden), `${forbidden} leaked to peer-b`);
+			}
+		},
+		{ description: "selected future memory and unrelated-project isolation", timeoutMs: 120_000, intervalMs: 3_000 },
+	);
+
+	const finalA = fixture(ctx, "peer-a", "summary", "27-peer-a-final-summary");
+	const operation = finalA.operations.find((item) => item.operation_id === created.body.operation_id);
+	assert(operation?.state === "active", `share operation did not become active: ${operation?.state}`);
+	assert(operation.recipient_device_id === peerB.device_id, "recipient device was not linked automatically");
+	assert(
+		operation.recipient_device_display_name === "Brian's Test Mac",
+		"friendly recipient device name was not preserved",
+	);
+	assert(
+		finalA.actors.some((actor) => actor.display_name === "Brian" && actor.status === "active"),
+		"Brian Person was not activated",
+	);
+	assert(
+		finalA.peers.some(
+			(peer) => peer.peer_device_id === peerB.device_id && peer.name === "Brian's Test Mac",
+		),
+		"Brian's device was not named and linked on peer-a",
+	);
+	assert(
+		finalA.source_memberships.some((member) => member.device_id === "source-bystander"),
+		"source bystander membership fixture disappeared",
+	);
+	assert(
+		!finalA.managed_memberships.some((member) => member.device_id === "source-bystander"),
+		"managed project boundary inherited an unreviewed source member",
+	);
+
+	ctx.compose.copyFromContainer(
+		"peer-a:/data/mem.sqlite",
+		`${ctx.artifactsDir}/db/peer-a-project-sharing.sqlite`,
+		"28-copy-peer-a-db",
+	);
+	ctx.compose.copyFromContainer(
+		"peer-b:/data/mem.sqlite",
+		`${ctx.artifactsDir}/db/peer-b-project-sharing.sqlite`,
+		"29-copy-peer-b-db",
+	);
+	ctx.compose.copyFromContainer(
+		"coordinator:/data/coordinator.sqlite",
+		`${ctx.artifactsDir}/db/coordinator-project-sharing.sqlite`,
+		"30-copy-coordinator-db",
+	);
+	if (!ctx.keepStackOnFailure) ctx.compose.down("31-compose-down-post");
+}

--- a/e2e/scripts/project-sharing-fixture.ts
+++ b/e2e/scripts/project-sharing-fixture.ts
@@ -1,0 +1,164 @@
+import { initDatabase, MemoryStore, recordReplicationOp } from "../../packages/core/src/index.ts";
+
+const DB_PATH = "/data/mem.sqlite";
+const NOW = "2026-07-21T12:00:00.000Z";
+const SOURCE_SCOPE = "project-sharing-source";
+const SELECTED_REMOTE = "https://example.invalid/acme/selected.git";
+const UNRELATED_REMOTE = "https://example.invalid/acme/unrelated.git";
+
+type Action = "init" | "seed-a" | "add-future" | "summary";
+
+function action(): Action {
+	const index = process.argv.indexOf("--action");
+	const value = process.argv[index + 1];
+	if (!value || !["init", "seed-a", "add-future", "summary"].includes(value)) {
+		throw new Error("--action must be init, seed-a, add-future, or summary");
+	}
+	return value as Action;
+}
+
+function session(store: MemoryStore, project: string, remote: string): number {
+	const id = store.startSession({
+		cwd: `/workspace/${project}`,
+		project,
+		user: "e2e",
+		toolVersion: "project-sharing-e2e",
+	});
+	store.db.prepare("UPDATE sessions SET git_remote = ? WHERE id = ?").run(remote, id);
+	return id;
+}
+
+function remember(
+	store: MemoryStore,
+	sessionId: number,
+	title: string,
+	workspaceId: string | null = SOURCE_SCOPE,
+): number {
+	return store.remember(sessionId, "discovery", title, `${title} body`, 0.9, ["project-sharing-e2e"], {
+		visibility: "shared",
+		...(workspaceId ? { workspace_id: workspaceId, workspace_kind: "shared" } : {}),
+		created_at: NOW,
+		updated_at: NOW,
+	});
+}
+
+function stampSourceScope(store: MemoryStore, memoryId: number, replicated: boolean): void {
+	const importKey = store.db
+		.prepare("SELECT import_key FROM memory_items WHERE id = ?")
+		.pluck()
+		.get(memoryId) as string | null;
+	store.db
+		.prepare(
+			`DELETE FROM replication_ops
+			 WHERE entity_type = 'memory_item'
+			   AND entity_id IN (CAST(? AS TEXT), ?)`,
+		)
+		.run(memoryId, importKey ?? "__missing_import_key__");
+	store.db.prepare("UPDATE memory_items SET scope_id = ? WHERE id = ?").run(SOURCE_SCOPE, memoryId);
+	if (replicated) {
+		recordReplicationOp(store.db, {
+			memoryId,
+			opType: "upsert",
+			deviceId: store.deviceId,
+			scopeId: SOURCE_SCOPE,
+			createdAt: NOW,
+		});
+		return;
+	}
+	store.db.prepare("UPDATE memory_items SET import_key = NULL WHERE id = ?").run(memoryId);
+}
+
+function seedA(store: MemoryStore): void {
+	store.db
+		.prepare(
+			`INSERT OR REPLACE INTO replication_scopes(
+				scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+			 ) VALUES (?, 'Project sharing source', 'team', 'local', 1, 'active', ?, ?)`,
+		)
+		.run(SOURCE_SCOPE, NOW, NOW);
+	for (const deviceId of [store.deviceId, "source-bystander"]) {
+		store.db
+			.prepare(
+				`INSERT OR REPLACE INTO scope_memberships(
+					scope_id, device_id, role, status, membership_epoch, updated_at
+				 ) VALUES (?, ?, 'member', 'active', 1, ?)`,
+			)
+			.run(SOURCE_SCOPE, deviceId, NOW);
+	}
+	const selectedSession = session(store, "selected-project", SELECTED_REMOTE);
+	const selectedId = remember(store, selectedSession, "selected existing");
+	store.endSession(selectedSession, { fixture: "selected-existing" });
+	stampSourceScope(store, selectedId, false);
+
+	const unrelatedSession = session(store, "unrelated-project", UNRELATED_REMOTE);
+	const unrelatedId = remember(store, unrelatedSession, "unrelated existing");
+	store.endSession(unrelatedSession, { fixture: "unrelated-existing" });
+	stampSourceScope(store, unrelatedId, true);
+}
+
+function addFuture(store: MemoryStore): void {
+	const selectedSession = session(store, "selected-project", SELECTED_REMOTE);
+	remember(store, selectedSession, "selected future", null);
+	store.endSession(selectedSession, { fixture: "selected-future" });
+
+	const unrelatedSession = session(store, "unrelated-project", UNRELATED_REMOTE);
+	const unrelatedId = remember(store, unrelatedSession, "unrelated future");
+	store.endSession(unrelatedSession, { fixture: "unrelated-future" });
+	stampSourceScope(store, unrelatedId, true);
+}
+
+function summary(store: MemoryStore): Record<string, unknown> {
+	return {
+		device_id: store.deviceId,
+		actor_id: store.actorId,
+		actor_display_name: store.actorDisplayName,
+		memories: store.db
+			.prepare("SELECT title, project, scope_id, active FROM memory_items ORDER BY title")
+			.all(),
+		actors: store.db
+			.prepare("SELECT actor_id, display_name, status FROM actors ORDER BY actor_id")
+			.all(),
+		peers: store.db
+			.prepare("SELECT peer_device_id, name, actor_id FROM sync_peers ORDER BY peer_device_id")
+			.all(),
+		managed_memberships: store.db
+			.prepare(
+				`SELECT sm.scope_id, sm.device_id, sm.status
+				 FROM scope_memberships sm
+				 JOIN replication_scopes rs ON rs.scope_id = sm.scope_id
+				 WHERE rs.kind = 'managed_project'
+				 ORDER BY sm.scope_id, sm.device_id`,
+			)
+			.all(),
+		source_memberships: store.db
+			.prepare("SELECT device_id, status FROM scope_memberships WHERE scope_id = ? ORDER BY device_id")
+			.all(SOURCE_SCOPE),
+		operations: store.db
+			.prepare(
+				`SELECT operation_id, state, teammate_name, recipient_device_id,
+					recipient_device_display_name
+				 FROM share_operations ORDER BY created_at`,
+			)
+			.all(),
+	};
+}
+
+async function main(): Promise<void> {
+	process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+	initDatabase(DB_PATH);
+	const store = new MemoryStore(DB_PATH);
+	try {
+		const selectedAction = action();
+		if (selectedAction === "seed-a") seedA(store);
+		if (selectedAction === "add-future") addFuture(store);
+		await store.flushPendingVectorWrites();
+		console.log(JSON.stringify({ ok: true, action: selectedAction, ...summary(store) }, null, 2));
+	} finally {
+		store.close();
+	}
+}
+
+void main().catch((error) => {
+	console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "e2e:fleet-cleanup": "pnpm exec tsx e2e/bin/run-local.ts fleetCleanup",
     "e2e:fleet-ready": "pnpm exec tsx e2e/bin/run-local.ts fleetReady",
     "e2e:fleet-smoke": "pnpm exec tsx e2e/bin/run-local.ts fleetSmoke",
+    "e2e:project-sharing": "pnpm exec tsx e2e/bin/run-local.ts projectSharing",
     "e2e:sharing-domains": "pnpm exec tsx e2e/bin/run-local.ts sharingDomains",
     "e2e:smoke": "pnpm exec tsx e2e/bin/run-local.ts smoke",
     "test": "pnpm exec vitest run",


### PR DESCRIPTION
## Description

Adds the final proof and documentation layer for project-first teammate sharing:

- adds an isolated two-node Docker E2E scenario that shares exactly one of two canonical projects
- verifies automatic Person/device linking, friendly naming, existing and future selected-project replication, source-membership non-inheritance, and absence of unrelated-project rows
- registers and documents the `e2e:project-sharing` runner
- makes project-first sharing the normal documented workflow while preserving manual pairing, Space grants, actor assignment, and mappings as advanced or compatibility paths

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:

- `pnpm run check` — 2,747 tests passed
- `env CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1 pnpm run e2e:project-sharing -- --json`
- `env CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1 pnpm run e2e:smoke -- --json`
- `git diff --check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
