### PR TITLE
feat(sharing): define recipient policy contracts

### DIFF
--- a/docs/adr/0001-project-recipient-policy-boundaries.md
+++ b/docs/adr/0001-project-recipient-policy-boundaries.md
@@ -1,0 +1,198 @@
+# ADR 0001: Project-recipient policy boundaries
+
+**Date:** 2026-07-21
+**Status:** Accepted
+**Related design:** `../plans/2026-07-21-project-recipient-sharing-identity-design.md`
+**Implementation plan:** `../plans/2026-07-21-project-recipient-sharing-implementation.md`
+
+## Context
+
+Codemem currently stores human provenance as actors, enrolls devices into coordinator groups, authorizes replication through scope memberships, and provisions exact Project sharing through resumable share operations. The approved recipient-policy design introduces four user-facing concepts—Project, Identity, Team, and Device—without replacing replication scopes as the hard security boundary.
+
+Before adding persistence or routes, the implementation needs stable boundaries between:
+
+```text
+user intent ≠ derived effective recipients ≠ current scope enforcement
+```
+
+This ADR settles the storage and compatibility decisions needed by the versioned recipient-policy contract. It introduces no policy persistence, migration, route, or authorization behavior.
+
+## Decision 1: Actors back Identities
+
+The existing `actors` table is the canonical backing record for V1 Identities.
+
+An Identity ID is an actor ID. The existing actor lifecycle already supports:
+
+- active local and remote identities;
+- pending invitation placeholders;
+- merging a pending placeholder into an accepted identity;
+- durable memory provenance through `memory_items.actor_id`; and
+- device attribution through `sync_peers.actor_id`.
+
+V1 contract language uses **Identity**, not Actor. Future persistence work may add nullable identity kind and verification metadata to `actors`, but it must not introduce a parallel Identity table with a second lifecycle or merge authority.
+
+This decision supersedes the earlier open framing that allowed `actors` to remain only a compatibility projection over a new Identity table.
+
+### Consequences
+
+- Existing provenance and accepted-invite links remain valid.
+- Personal and Work Identities use distinct actor IDs even when one human controls both.
+- `is_local` is not permission to collapse multiple Identities into one principal.
+- OAuth/OIDC may verify an Identity later without replacing the Identity abstraction.
+
+### Rejected alternatives
+
+- A second `identities` table would create duplicate merge and lifecycle authorities.
+- Treating actors as provenance-only would leave device-to-Identity assignment non-authoritative.
+
+## Decision 2: Policy Teams are distinct from coordinator groups
+
+A policy Team is a durable set of Identities that receives explicitly shared Projects. A coordinator group remains a device enrollment, discovery, and administration construct.
+
+Future persistence will model Teams independently and may link a Team to one or more coordinator groups through explicit coordinator/group references. Team membership is Identity-based. Coordinator enrollment remains device-based and cannot create Team membership or Project access by implication.
+
+The policy Team display name is authoritative in normal UI. Coordinator group names are enrollment and diagnostics metadata.
+
+### Consequences
+
+- Team membership can express current and future member inheritance.
+- A Team can outlive or span coordinator deployments.
+- Coordinator enrollment, discovery, and trust never become authorization shortcuts.
+- A later reconciler may enroll or discover Team member devices without treating enrollment as a grant.
+
+### Rejected alternatives
+
+- Making coordinator groups canonical Teams would couple device enrollment to access and cannot represent Identity membership.
+- Modeling Teams as saved direct-recipient lists would lose future-member inheritance.
+
+## Decision 3: Authority cuts over per Project
+
+Recipient policy remains non-authoritative until each canonical Project passes an explicit parity gate. Existing scope enforcement remains authoritative during projection and migration.
+
+A Project is eligible for recipient-policy authority only when:
+
+1. it resolves to exactly one active managed Project scope;
+2. the derived desired device set equals active scope membership;
+3. the equality remains stable across an idempotent reconciliation pass;
+4. every required peer supports the negotiated reassignment capability;
+5. no unresolved review item applies to the Project's current source fingerprint; and
+6. reconciliation has no incomplete or attention-required step.
+
+Cutover and rollback operate per canonical Project. A failure after cutover returns that Project to legacy scope enforcement while preserving recipient intent and review history. No database-wide flag or timed promotion changes every Project at once.
+
+These are minimum parity conditions. Later slices may add stricter fail-closed gates without superseding this ADR.
+
+### Consequences
+
+- Migration blast radius is one Project.
+- Projection and reconciliation must share one deterministic effective-device derivation.
+- Cutover needs a persisted per-Project authority state and observable parity status in later slices.
+- Silence or elapsed time is never evidence of parity.
+
+### Rejected alternatives
+
+- A database-wide cutover flag would turn one migration defect into a system-wide authorization change.
+- Time-based automatic promotion would treat elapsed time as proof and could broaden access without verified parity.
+
+## Decision 4: Review decisions are attributed and durable
+
+Every review resolution is attributed to the deciding local Identity and device. Resolution is validated against the review item's deterministic source-state fingerprint.
+
+The future persisted record includes:
+
+- deciding Identity ID;
+- deciding device ID;
+- selected decision;
+- source-state fingerprint; and
+- resolved timestamp.
+
+`Keep current setup unchanged` and `Reject suggestion` are first-class completed outcomes. They remain cleared until the source fingerprint changes.
+
+If another Identity, device, coordinator administrator, or source owner must act, the condition is `Blocked` with a named owner and repair route. It is not a local review item.
+
+### Consequences
+
+- Review is an auditable decision workflow rather than a warning bucket.
+- Non-local ambiguity cannot masquerade as an actionable local task.
+- Concurrent resolution must validate the source fingerprint before accepting a decision.
+
+### Rejected alternatives
+
+- Identity-only attribution would not identify which runtime observed and approved the source state.
+- Unattributed or transient dismissal would make `Keep current setup unchanged` reappear and provide no durable audit trail.
+
+## Decision 5: Legacy enrollment invitations remain enrollment-only
+
+Legacy pairing and coordinator invitations without persisted reviewed Project intent remain enrollment-only. They may establish discovery, trust, device metadata, and an Identity link, but they never create Project-recipient intent.
+
+An existing invitation may seed a non-authoritative recipient-policy projection only when it carries:
+
+- canonical persisted Project intent;
+- a valid reviewed Project-set digest;
+- the linked share operation; and
+- the bound recipient Identity/device acceptance.
+
+The digest must be revalidated before translation. Translation remains non-authoritative until the Project passes the per-Project parity gate.
+
+### Consequences
+
+- Existing exact-Project invitations remain useful migration evidence.
+- Old Team and pairing invitations continue to work without silently granting data.
+- In-flight enrollment invitations may wait for an explicit Team or Project relationship after acceptance.
+
+### Rejected alternatives
+
+- Treating any accepted Team or pairing invitation as Project authorization would make enrollment an access shortcut.
+- Ignoring all legacy invitations would break valid in-flight enrollment and exact-Project invitations that already carry reviewed intent.
+
+## Decision 6: Legacy navigation remains addressable
+
+The new top-level navigation will add `Sharing` and `Devices`. The existing `sync` route remains a compatibility and advanced-diagnostics alias rather than being removed immediately.
+
+Existing hashes and saved state must resolve predictably:
+
+- `#sync` routes to the new Devices or advanced diagnostics landing;
+- `#sync/diagnostics` preserves the diagnostics destination;
+- existing Teams/coordinator administration links route into Sharing or Advanced administration; and
+- old stored tab values do not strand users on an inaccessible screen.
+
+The final navigation change and redirect tests land only after recipient-policy authority and migration gates pass.
+
+### Consequences
+
+- Existing bookmarks and internal links remain usable.
+- `sync` persists as implementation debt during the compatibility window.
+- Hard-coded navigation assignments require an explicit audit before promotion.
+
+### Rejected alternatives
+
+- Renaming or removing the `sync` route immediately would break bookmarks, saved tab state, and existing internal links.
+- Keeping the current top-level Sync surface unchanged would preserve the engine-first mental model this redesign replaces.
+
+## Versioned contract boundary
+
+PR 1 introduces a dependency-free V1 contract that keeps three representations separate:
+
+1. **Intent:** Project recipients, Team memberships, and Identity devices.
+2. **Effective access:** devices derived from Identity and Team relationships.
+3. **Enforcement:** current managed-scope membership and per-Project authority status.
+
+Intent types contain no scope, grant, coordinator enrollment, trust, connectivity, or filter field. Those facts cannot grant access and belong only in explicit projection or enforcement status.
+
+## Deferred decisions
+
+- OAuth/OIDC provider and account-recovery behavior.
+- Multiple Identities in one runtime.
+- GitHub organization, path, and tag automation.
+- Device profiles and policy defaults.
+- Remote deletion of delivered memories.
+
+## Validation
+
+Pure contract fixtures must prove:
+
+- canonical Projects are keyed by canonical identity;
+- one device edge names exactly one Identity;
+- direct Identity and Team recipients are distinct variants;
+- `Keep current setup unchanged` is a valid actionable decision; and
+- intent fixtures contain no authorization shortcut fields.

--- a/docs/plans/2026-07-21-project-recipient-sharing-identity-design.md
+++ b/docs/plans/2026-07-21-project-recipient-sharing-identity-design.md
@@ -1,0 +1,470 @@
+# Project-recipient sharing and identity design
+
+**Date:** 2026-07-21
+**Status:** Approved
+**Related:** `2026-07-20-project-first-teammate-sharing-design.md`, `2026-04-30-sharing-domain-scope-design.md`, `2026-05-25-access-management-ia-design.md`
+
+## Decision summary
+
+Codemem will present sharing as relationships between Projects and recipients:
+
+> Share these Projects with these Teams or Identities. Their authorized devices receive the Projects automatically, and sync runs in the background.
+
+Projects remain the unit users choose to share. Teams and Identities are the recipients. Devices inherit access through exactly one Identity per runtime. Managed replication scopes remain the hard security boundary, but Codemem creates and reconciles them as system-owned infrastructure instead of asking users to assign Spaces, grants, actors, filters, and trust state manually.
+
+The primary navigation becomes:
+
+```text
+Feed     Projects     Sharing     Devices     Health
+```
+
+`Sync` stops being a top-level administrative concept. Users see sharing intent, device availability, and plain-language progress. Scope, grant, trust, coordinator, and replication details move to an explicit advanced administration surface.
+
+This design supersedes the user-facing Team/Space-first workflow in older plans. It preserves the authorization, exact-project, canonical-identity, local-first, and fail-closed invariants in the scope and project-first sharing designs.
+
+## Problem
+
+The current UI requires users to reconstruct a graph of Projects, Spaces, Teams, People, devices, grants, trust, filters, and sync state. It exposes several implementation layers as if each were an independent task:
+
+- assigning a Project to a Space;
+- enrolling a device in a Team;
+- granting that device Space access;
+- creating or assigning a Person;
+- establishing device trust;
+- configuring project filters;
+- interpreting per-Space replication status.
+
+The product also has two invitations with incompatible semantics. A project invitation grants reviewed project access and starts sync. A Team invitation may only enroll a device for discovery and administration, leaving it with no data access. A user reasonably expects accepting a Team invitation to provide the Team's shared content.
+
+The backend separation is valuable, but the interface makes users operate it directly. The result is both confusing and dangerous: controls that can move or expose thousands of memories compete visually with the intended sharing action.
+
+## Design principles
+
+1. **Intent is the source of truth.** Users specify which Projects go to which Teams or Identities.
+2. **Projects are the sharing unit.** Display names never substitute for canonical project identity.
+3. **Recipients inherit access.** Team members and Identity devices receive the Projects granted to their parent recipient.
+4. **One Identity per runtime.** Personal and Work are separate security contexts even when one human uses both.
+5. **Scopes are system-owned.** They remain real authorization boundaries but are absent from normal workflows.
+6. **Sync is a result.** Users do not administer the replication engine to perform ordinary sharing.
+7. **Review must resolve.** Nothing enters a review queue without concrete decisions, previews, and a durable completion state.
+8. **Every incomplete state is legible.** It names what is happening, who must act, and the one next action when action is required.
+9. **Ambiguity under-shares.** Migration and reconciliation fail closed instead of guessing.
+10. **Bulk workflows are first-class.** Project-first must not mean project-by-project administration.
+
+## User-facing concepts
+
+| Concept | Meaning |
+| --- | --- |
+| Project | The exact unit a user shares. |
+| Identity | One personal, work, or other security context. An Identity may later be verified by OAuth/OIDC. |
+| Team | A durable group of Identities that receives explicitly shared Projects. |
+| Device | One Codemem runtime registered to exactly one Identity. |
+
+The normal UI does not require users to understand Space, scope, grant, actor, peer, membership epoch, fingerprint, replication cursor, or coordinator group.
+
+## Conceptual model
+
+```mermaid
+flowchart LR
+    P[Project] -->|shared directly| I[Identity]
+    P -->|shared with| T[Team]
+    T -->|contains| I
+    I -->|registers| D[Devices]
+    P -. system-managed .-> S[Managed project scope]
+    S -. authorizes effective recipients .-> D
+    D -. direct peer-to-peer .-> SYNC[Background sync]
+```
+
+Example:
+
+```text
+Project: example-oss
+├── Personal Identity
+│   ├── Home laptop
+│   └── Personal server
+├── Work Identity
+│   └── Work laptop
+└── Open Source Team
+    ├── Contributor A
+    └── Contributor B
+```
+
+The explicit Personal-to-Work share allows an OSS Project to reach a Work Identity without exposing unrelated private Projects. Being the same biological person is not an authorization shortcut.
+
+## Access inheritance
+
+### Identity inheritance
+
+A new device registered to an Identity inherits the Projects available to that Identity through:
+
+- direct Project-to-Identity relationships; and
+- the Identity's Team memberships.
+
+It does not inherit Projects belonging to another Identity owned by the same human.
+
+### Team inheritance
+
+When a Project is shared with a Team:
+
+- all current Team member Identities receive it;
+- all future Team member Identities inherit it;
+- each member's registered devices receive it; and
+- unrelated Projects remain excluded.
+
+Accepting a Team invitation means accepting the Team relationship and its current and future shared Projects. The acceptance screen must summarize that consequence before confirmation.
+
+### Direct Identity access
+
+A Project may be shared directly with an Identity without creating Team membership. This is guest or one-off access and can be managed independently from Team access.
+
+## Product surfaces
+
+### Projects: what is shared
+
+Projects is the primary sharing surface. It shows:
+
+- canonical Project groups with concise memory counts;
+- recipient chips for Teams and Identities;
+- one plain-language status;
+- multi-select and `Share selected`;
+- a separate, actionable `Projects needing review` queue.
+
+Normal Project rows do not show Space selectors, bulk scope reassignment, raw canonical identity warnings, or path-level migration controls.
+
+```text
+Projects                                      12 selected
+
+[x] example-oss       Shared with Open Source Team, Work Identity
+[x] docs-site         Shared with Open Source Team
+[ ] private-notes     Personal Identity only
+
+[ Share selected… ]
+```
+
+Project detail answers both directions:
+
+- Who receives this Project?
+- What is its current delivery status?
+
+### Sharing: who receives Projects
+
+Sharing contains three primary views:
+
+```text
+[ Teams ] [ Identities ] [ Invitations ]
+```
+
+A Team detail shows:
+
+- member Identities;
+- registered device count;
+- all shared Projects;
+- `Invite member`;
+- `Add projects` and `Manage projects` bulk actions.
+
+An Identity detail shows:
+
+- verification state (`Local identity` until authenticated);
+- registered devices;
+- Team memberships;
+- directly shared Projects;
+- bulk project management.
+
+### Devices: where Codemem runs
+
+Devices shows the current Identity and its registered runtimes. A row answers:
+
+- Is this device online?
+- Is it up to date?
+- How many Projects does it inherit?
+- Does the user need to act?
+
+Trust direction, addresses, fingerprints, Space counts, and per-scope progress remain in advanced diagnostics.
+
+### Health: system condition
+
+Health retains operational information such as maintenance, indexing, queue health, and service availability. It does not become another sharing administration surface.
+
+### Advanced administration
+
+Advanced administration contains:
+
+- managed scopes and raw grants;
+- coordinator configuration;
+- trust keys and network addresses;
+- canonical project identity repair;
+- narrowing filters;
+- membership epochs;
+- replication cursors and attempts;
+- legacy compatibility controls.
+
+Entering this area should be a deliberate escalation, not part of ordinary sharing.
+
+## Sharing Projects
+
+Users may begin from a Project or a recipient. Both views edit the same durable sharing relationships.
+
+### Project-first bulk flow
+
+```text
+Select Projects
+      ↓
+Choose Teams and Identities
+      ↓
+Review Projects, memories, current members, and future inheritance
+      ↓
+Confirm
+      ↓
+Provision access and start sync
+```
+
+Review example:
+
+```text
+Share 12 Projects with Open Source Team
+
+• 18,420 existing memories
+• Future memories from these Projects
+• Available to 5 current member Identities
+• Future Team members will inherit access
+
+No other Projects are affected.
+```
+
+### Recipient-first bulk flow
+
+From Team or Identity detail, users can search, select, add, or remove many Projects in one operation. This makes Approach 1 scalable without requiring one dialog per Project.
+
+Optional automatic rules based on GitHub organization, path, or tags are deferred. When added, they must be opt-in and preview-first by default; `all Projects` is never an implicit rule.
+
+## Invitations
+
+### Team invitation
+
+```text
+Team → Invite member
+     → enter name or future verified address
+     → review inherited Projects and memory count
+     → create invitation
+     → recipient accepts Team membership on one Identity/device
+     → current Team Projects become available
+     → future Team Projects inherit automatically
+```
+
+Acceptance states plainly that joining the Team includes current shared Projects and Projects shared with the Team later.
+
+### Direct Project invitation
+
+A direct invitation pins the reviewed canonical Project set. The recipient cannot add or replace Projects during acceptance. Acceptance creates or links the recipient Identity, binds one accepting device and public key, provisions exact Project access, and starts sync.
+
+### Add-device invitation
+
+An add-device invitation binds one runtime to exactly one Identity. Before acceptance, it previews all direct and Team access that the device will inherit and explicitly states what it will not receive.
+
+## Lifecycle language
+
+Every operation answers:
+
+1. What is happening?
+2. Is anything blocked?
+3. Who must act?
+4. What is the one next action?
+
+| Status | Meaning | Primary action |
+| --- | --- | --- |
+| Waiting for acceptance | The recipient has not accepted. | Copy invite |
+| Setting up access | Policy and authorization are being reconciled. | None |
+| Starting first sync | Initial replication is running. | None |
+| Waiting for device | Access is ready, but a required device is offline. | None |
+| Up to date | Expected Projects are available. | None |
+| Needs attention | A specific repairable step failed. | One contextual retry or repair action |
+| Access removed | Future replication is disabled; delivered copies may remain. | Share again, when applicable |
+
+Offline is a waiting state, not an error. Technical traces live in diagnostics.
+
+## Actionable review contract
+
+Nothing may enter `Needs review` unless the server can provide:
+
+1. what Codemem found;
+2. why it cannot decide safely;
+3. a recommended decision;
+4. every other valid decision;
+5. a preview of the effect of each choice; and
+6. a durable completion state that clears the item.
+
+Valid outcomes include:
+
+- apply the recommendation;
+- choose different recipients or grouping;
+- preserve current access exactly;
+- keep the Project local;
+- keep identities separate;
+- attach a device to an Identity;
+- create a different Identity;
+- remove a stale device; and
+- keep the current setup unchanged.
+
+`Reject suggestion` and `Keep current setup unchanged` are durable decisions. The item stays cleared until its underlying state fingerprint changes. Repeated items support bulk resolution.
+
+If no local decision can resolve a problem, the state is `Blocked`, names who or what must act, and links to the actual repair action. Raw ambiguity without valid decisions is diagnostic information, not a user review item.
+
+## Authority and reconciliation
+
+The durable user-intent graph contains:
+
+```text
+ProjectRecipient(Project, Identity | Team)
+IdentityDevice(Identity, Device)
+TeamMembership(Team, Identity)
+```
+
+Effective device authorization is derived:
+
+```text
+direct Identity recipients → Identity devices
+Team recipients → member Identities → Identity devices
+```
+
+Each canonical shared Project retains one managed Project scope. A reconciler compares desired effective devices with current scope membership:
+
+```text
+desired − current → grant
+current − desired → revoke
+```
+
+Reconciliation is persisted, idempotent, resumable, immediately refreshes local authorization, and fails closed. A failure may delay sharing but cannot broaden it.
+
+Device trust and connectivity do not grant Project access. Project filters may narrow access but never expand it. The coordinator manages invitations, identity/team membership, scope authority, and discovery; memory payloads continue to move directly between peers.
+
+## Authentication evolution
+
+V1 uses a local Identity plus device-key proof. A manually named Identity is an unverified placeholder, not proof of a human's identity.
+
+Future OAuth/OIDC maps a verified account to the same Identity abstraction:
+
+```text
+OIDC account → verifies Identity → registers devices
+```
+
+Personal and Work logins remain separate Identities. OAuth strengthens verification without changing Project-recipient relationships or collapsing identities that belong to the same human.
+
+## Migration
+
+Migration preserves existing enforcement and never infers broader access from proximity.
+
+| Existing state | Migration behavior |
+| --- | --- |
+| Managed exact-Project scope | Convert to Project-recipient relationships. |
+| Personal scope with one clear Identity | Suggest attaching Projects to that Identity. |
+| Team scope with unambiguous membership | Suggest Team recipients with an exact preview. |
+| Mixed or ambiguous Space | Preserve current access and require actionable review. |
+| Unassigned device | Preserve it and require an Identity decision. |
+| Legacy project filters | Keep only as narrowing compatibility rules. |
+
+Migration phases:
+
+1. **Read-only projection** — render the new Projects, Sharing, and Devices views over current state without changing authorization.
+2. **Policy migration** — create Identity, Team-membership, and Project-recipient records; require decisions for ambiguity.
+3. **Policy authority** — make recipient relationships authoritative and reconcile managed scope membership.
+4. **Legacy demotion** — move old controls to Advanced after policy parity and exactness are proven.
+5. **Deferred automation** — add verified identities and preview-first GitHub organization/path/tag rules later.
+
+Existing scopes continue enforcing access during migration. Existing multi-Project Spaces are not silently split or reinterpreted. Exact Project movement uses the existing idempotent `reassign_scope` contract where required.
+
+## Security invariants
+
+- `scope_id` remains the hard replication authorization boundary.
+- Canonical Project identity, never display name or basename, defines sharing intent.
+- Selecting one Project cannot expose a sibling or similarly named Project.
+- Team membership grants only Projects explicitly shared with that Team.
+- Identity registration grants only Projects available to that Identity.
+- Connectivity, coordinator enrollment, and device trust never imply data access.
+- Filters and visibility gates only narrow eligible data.
+- Invite acceptance is single-use and bound to the reviewed relationship and accepting device/key.
+- Recipient-controlled input cannot broaden persisted Project intent.
+- Revocation blocks future replication but does not claim to erase delivered copies.
+- Ambiguous migration under-shares and preserves existing enforcement until resolved.
+- Unsupported older peers fail closed before partial history migration.
+
+## Validation strategy
+
+### Model and API tests
+
+- Team recipient expansion to current member Identities and devices;
+- future member inheritance;
+- Identity recipient expansion to newly registered devices;
+- Personal and Work Identity isolation;
+- explicit cross-Identity OSS sharing;
+- direct Identity access without Team membership;
+- bulk Project-recipient changes with exact previews;
+- durable accept, reject, and keep-current review outcomes;
+- actionable review fingerprint invalidation only when state changes;
+- idempotent reconciliation and retry;
+- fail-closed ambiguous and unsupported states.
+
+### UI tests
+
+- Projects shows recipients without Space/scope controls;
+- Sharing supports recipient-first bulk management;
+- Team invitation previews current Projects and future inheritance;
+- add-device invitation previews inherited access and exclusions;
+- Devices presents availability and status without raw trust/grant terminology;
+- every `Needs review` item has valid decisions and clears after one is chosen;
+- `Blocked` states identify the actor and route to a real repair action;
+- primary flows contain no raw IDs, scopes, grants, filters, addresses, epochs, or cursors.
+
+### End-to-end tests
+
+1. Share many exact Projects with one Team and verify unrelated Projects remain absent.
+2. Add a future Team member and verify inherited existing and future memories.
+3. Register a new device to one Identity and verify only that Identity's access appears.
+4. Keep Personal and Work Identities isolated, then explicitly share one OSS Project across them.
+5. Share directly with an Identity and verify no Team membership is created.
+6. Remove Team, Identity, and Project relationships and verify future replication stops.
+7. Exercise offline, retry, and old-peer capability paths without duplicate grants or partial broadening.
+8. Migrate ambiguous legacy state and prove no decision broadens access without confirmation.
+
+## V1 scope
+
+V1 includes:
+
+- one Identity per runtime;
+- Project recipients of Team or Identity;
+- Team and Identity inheritance;
+- bulk sharing in both directions;
+- Team and device invitation previews;
+- new primary navigation and surface ownership;
+- system-managed scopes and reconciliation;
+- actionable migration review;
+- legacy controls retained under Advanced.
+
+Deferred:
+
+- OAuth/OIDC verification;
+- multiple Identities in one runtime;
+- GitHub organization, path, or tag rules;
+- device profiles and automatic classifications;
+- remote deletion of delivered memories;
+- replacing direct peer-to-peer memory transport.
+
+## Acceptance criteria
+
+- A user can explain the model as: Projects are shared; Identities use devices; Teams contain Identities; sync happens automatically.
+- A user can share dozens of Projects with a Team in one reviewed operation.
+- Project and recipient views show the same sharing relationships from both directions.
+- A Team invitation clearly describes current and future inherited Projects.
+- An add-device invitation clearly describes inherited access and exclusions.
+- Personal and Work Identities remain isolated unless a Project is explicitly shared across them.
+- Every review item offers valid decisions, including a durable `Keep current setup unchanged` outcome.
+- Normal workflows never require Space, scope, grant, actor, peer, membership epoch, or replication cursor terminology.
+- Exact canonical Project isolation, idempotency, and fail-closed behavior remain proven end to end.
+
+## Non-goals
+
+- Removing replication scopes from the data or protocol model.
+- Treating Team enrollment, trust, or network reachability as implicit data access.
+- Guessing recipient policy from ambiguous existing Spaces.
+- Recalling data already delivered to a previously authorized device.
+- Making the coordinator a memory data path.
+- Solving enterprise authentication in the first implementation.

--- a/docs/plans/2026-07-21-project-recipient-sharing-implementation.md
+++ b/docs/plans/2026-07-21-project-recipient-sharing-implementation.md
@@ -1,0 +1,465 @@
+# Project-recipient sharing implementation plan
+
+**Date:** 2026-07-21
+**Status:** Approved implementation stack
+**Design:** `2026-07-21-project-recipient-sharing-identity-design.md`
+
+## Goal
+
+Replace the default Team/Space/device-grant administration experience with a project-recipient policy model:
+
+- Projects are shared with Identities or Teams.
+- Devices inherit access through exactly one Identity per runtime.
+- Team members inherit Projects explicitly shared with their Team.
+- Managed Project scopes continue enforcing authorization behind the UI.
+- Sync is presented as background status, not a top-level engine users operate.
+- Existing state migrates through actionable, durable decisions without broadening access.
+
+The July 20 project-first sharing stack remains the exact-project invitation and provisioning foundation. This plan adds the durable recipient-policy graph, Team and Identity inheritance, bidirectional bulk management, migration, and new information architecture.
+
+Implementation starts from the merged July 20 stack on current `main`. It does not revert that work. Exact-Project boundaries, invitation binding, reassignment, provisioning, lifecycle, and E2E isolation remain the lower-level foundation; recipient policy and the new information architecture replace or evolve the policy and presentation layers above them.
+
+## Delivery rules
+
+- Build as a Graphite stack from contracts through policy authority and final UI promotion.
+- Keep each PR independently reviewable and safe when deployed without its upstack descendants.
+- Project-recipient intent must not become authorization authority until parity and fail-closed reconciliation are proven.
+- Existing scopes remain the hard boundary throughout migration.
+- Legacy controls remain available under Advanced until the new model is authoritative and rollback-safe.
+- Every policy mutation is preview-first and bound to canonical IDs plus a reviewed revision/digest.
+- OAuth/OIDC and GitHub organization/path/tag rules remain deferred.
+
+## Proposed Graphite stack
+
+```text
+main
+└── PR 1  Recipient-policy contracts and ADRs
+    └── PR 2  Read-only legacy policy projection
+        └── PR 3  Actionable migration review
+            └── PR 4  Durable policy-intent graph
+                └── PR 5  Bulk recipient management and Projects UI
+                    └── PR 6  Identity, Team, device, and invite journeys
+                        └── PR 7  Policy authority and reconciliation
+                            └── PR 8  Navigation promotion, proof, and docs
+```
+
+## PR 1 — Recipient-policy contracts and ADRs
+
+### Objective
+
+Freeze the policy vocabulary and contract boundaries before persistence or UI work.
+
+### Decisions to record
+
+1. **Identity storage:** whether existing `actors` become the Identity backing record or remain a compatibility projection over a new table.
+2. **Team storage:** whether coordinator groups are canonical Team records or external enrollment/discovery records linked to a policy Team.
+3. **Authority cutover:** measurable per-Project parity and rollback criteria.
+4. **Review audit:** attribution and owner-routing rules for review decisions.
+5. **Legacy invitations:** whether they remain enrollment-only or may create non-authoritative policy projections.
+6. **Navigation compatibility:** stable handling for existing `#sync` and Teams deep links.
+
+### Contract
+
+Define versioned shapes for:
+
+- Identity;
+- Team;
+- Team membership;
+- Identity device;
+- Project recipient;
+- policy projection;
+- actionable review item;
+- reconciliation status.
+
+The contract must distinguish:
+
+```text
+user intent ≠ effective recipients ≠ current scope enforcement
+```
+
+### Likely files
+
+- `docs/adr/`
+- `docs/plans/2026-07-21-project-recipient-sharing-identity-design.md`
+- new policy contract modules under `packages/core/src/`
+- `packages/core/src/share-operation.ts`
+
+### Validation
+
+- Fixtures cover canonical Project uniqueness.
+- One device/runtime maps to exactly one Identity.
+- Team and direct Identity recipient shapes are distinct.
+- `Keep current setup unchanged` is a first-class review outcome.
+- No contract field treats group enrollment, trust, connectivity, or filters as authorization.
+
+## PR 2 — Read-only policy projection over legacy state
+
+### Objective
+
+Describe current access through the new model without changing authorization or persistence.
+
+### Contract
+
+Add read-only policy projection APIs that return:
+
+- canonical Projects;
+- candidate Identities and Teams;
+- current effective devices;
+- direct, Team-derived, and legacy provenance;
+- confidence and ambiguity;
+- current scope-enforcement status;
+- actionable versus diagnostic-only conditions.
+
+### Behavior
+
+- Managed exact-Project scopes project cleanly.
+- Clear personal and Team candidates are suggestions only.
+- Ambiguous multi-Project Spaces remain unresolved.
+- Unassigned devices remain visible without receiving inferred Identity access.
+- Replication behavior and scope membership remain unchanged.
+
+### Likely files
+
+- new projection modules under `packages/core/src/`
+- `packages/core/src/share-operation.ts`
+- `packages/core/src/share-operation-lifecycle.ts`
+- `packages/viewer-server/src/routes/sync.ts`
+- `packages/ui/src/lib/api/sync.ts`
+- focused read-only prototypes in Projects/Sync tests
+
+### Validation
+
+- Projection does not mutate the database.
+- Projection cannot broaden access.
+- Normal projection responses omit secrets, payloads, addresses, fingerprints, epochs, and cursors.
+- Tests cover managed, personal, Team candidate, unassigned-device, and ambiguous legacy fixtures.
+
+## PR 3 — Actionable migration review
+
+### Objective
+
+Ensure every ambiguity has concrete decisions and a durable completion state before migration writes exist.
+
+### Persistence
+
+Add review records keyed by a stable source-state fingerprint. Each record includes:
+
+- finding and plain-language reason;
+- recommended decision;
+- all valid decisions;
+- exact preview for each decision;
+- status and selected outcome;
+- deciding Identity/device attribution;
+- source fingerprint and resolved timestamp.
+
+### Required outcomes
+
+- apply recommendation;
+- choose recipients;
+- preserve effective access exactly;
+- keep Project local;
+- keep Identities separate;
+- attach device to Identity;
+- create Identity;
+- remove stale device;
+- keep current setup unchanged.
+
+Rejecting a suggestion or keeping current state clears the item until its source fingerprint changes.
+
+### Likely files
+
+- schema/bootstrap files in `packages/core/src/`
+- new `packages/core/src/policy-review*.ts`
+- `packages/viewer-server/src/routes/sync.ts`
+- `packages/ui/src/tabs/projects.ts`
+- existing sharing-review components under `packages/ui/src/tabs/sync/`
+
+### Validation
+
+- No review item exists without at least one safe decision.
+- Every decision has a preview and clears the item.
+- `Keep current` makes no authorization change.
+- Durable reject outcomes do not reappear until source state changes.
+- Bulk resolution is atomic per review item and reports partial failures precisely.
+- Non-local/source-owned conditions route to a named owner action or become `Blocked`, not `Needs review`.
+
+## PR 4 — Durable policy-intent graph and migration writer
+
+### Objective
+
+Persist recipient intent without changing scope authorization.
+
+### Persistence
+
+Add or adapt durable records for:
+
+```text
+Identity
+Team
+TeamMembership(Team, Identity)
+IdentityDevice(Identity, Device)
+ProjectRecipient(Project, Identity | Team)
+```
+
+Records carry provenance, version/revision, migration state, timestamps, and idempotency identities.
+
+### Migration behavior
+
+- Convert managed exact-Project operations idempotently.
+- Convert only unambiguous legacy state automatically.
+- Require a resolved PR 3 decision for every ambiguous write.
+- Preserve existing scopes, mappings, and narrowing filters.
+- Do not change scope membership in this PR.
+
+### Likely files
+
+- schema/bootstrap files in `packages/core/src/`
+- new `packages/core/src/recipient-policy.ts`
+- `packages/core/src/share-operation.ts`
+- `packages/core/src/store.ts`
+- `packages/viewer-server/src/routes/sync.ts`
+
+### Validation
+
+- Migration is replay-safe and idempotent.
+- Personal and Work Identities remain separate.
+- A device belongs to only one Identity.
+- Team membership changes effective projection but not authorization yet.
+- Recipient-controlled requests cannot replace canonical Project IDs or bypass reviewed revisions.
+
+## PR 5 — Bidirectional recipient management and Projects UI
+
+### Objective
+
+Support scalable Project-to-recipient and recipient-to-Project management against the intent graph.
+
+### API
+
+Preview-first endpoints return:
+
+- exact canonical Projects;
+- selected Teams and Identities;
+- current and future member inheritance;
+- effective devices;
+- existing-memory counts;
+- unchanged Projects;
+- reviewed policy revision/digest.
+
+Commit rejects stale previews and display-name-only selection.
+
+### UI
+
+Projects gains:
+
+- concise Project rows;
+- Team and Identity recipient chips;
+- multi-select;
+- `Share selected`;
+- Project detail recipient management;
+- a separate actionable review queue.
+
+Sharing gains Team and Identity detail with `Add projects` and `Manage projects` bulk workflows.
+
+Legacy Space selectors, mappings, and filters move under Advanced but remain functional.
+
+### Likely files
+
+- `packages/viewer-server/src/routes/sync.ts`
+- `packages/ui/src/lib/api/sync.ts`
+- `packages/ui/src/tabs/projects.ts`
+- `packages/ui/src/tabs/project-sharing.tsx`
+- new Sharing tab modules
+- `packages/ui/static/index.html`
+
+### Validation
+
+- Both management directions produce identical `ProjectRecipient` records.
+- Bulk previews and commits remain exact after concurrent changes.
+- Normal Project flows contain no scope, grant, actor, peer, filter, epoch, or cursor controls.
+- Keyboard, focus, responsive, empty, loading, and partial-failure states have component coverage.
+
+## PR 6 — Identity, Team, device, and invitation journeys
+
+### Objective
+
+Make recipient onboarding and device registration match the approved inheritance model.
+
+### Journeys
+
+#### Team invitation
+
+- Preview current Team Projects, memory counts, and future inheritance.
+- Bind acceptance to one Identity and device/key.
+- Create Team membership.
+- Do not treat enrollment or trust as Project authorization before PR 7 reconciliation.
+
+#### Direct Project invitation
+
+- Preserve the July 20 exact reviewed-Project contract.
+- Create or link one recipient Identity.
+- Do not create Team membership.
+
+#### Add-device invitation
+
+- Bind the device to exactly one Identity.
+- Preview direct and Team-inherited Projects plus exclusions.
+- Reject cross-Identity merging.
+
+### Compatibility
+
+- Existing pairing and coordinator invitations remain valid.
+- Legacy invitations are clearly enrollment-only unless the ADR explicitly defines a safe translation.
+- Manual Identity/device correction remains under Advanced.
+
+### Likely files
+
+- `packages/core/src/share-operation.ts`
+- `packages/core/src/share-operation-lifecycle.ts`
+- `packages/viewer-server/src/routes/sync.ts`
+- coordinator store/API and Worker invite handlers
+- `packages/ui/src/tabs/sync/`
+- `packages/ui/src/tabs/coordinator-admin/`
+- new Sharing/Devices components
+- `packages/ui/static/index.html`
+
+### Validation
+
+- Team acceptance shows current and future inheritance.
+- Add-device acceptance shows exact inherited access and exclusions.
+- Identical retry is idempotent; another device/key is rejected.
+- Friendly names are normalized, escaped, and length-limited.
+- Team enrollment, trust, connectivity, and discovery never create Project access by themselves.
+
+## PR 7 — Policy authority and fail-closed reconciliation
+
+### Objective
+
+Promote recipient policy to desired-state authority and reconcile it into managed exact-Project scopes.
+
+### Reconciler
+
+For each canonical Project:
+
+```text
+desired devices = direct Identity devices
+                + Team member Identity devices
+
+desired − current → grant
+current − desired → revoke
+```
+
+The reconciler:
+
+- persists step state and idempotency identities;
+- verifies one managed scope per canonical shared Project;
+- never copies a source Space's full membership;
+- refreshes authorization immediately;
+- resumes from the first incomplete step;
+- treats offline devices as waiting;
+- fails closed for ambiguity, stale membership, unsupported peers, or capability gaps;
+- preserves truthful revocation warnings for delivered copies.
+
+### Cutover
+
+Use a per-Project dual-read/status period. Legacy scope enforcement remains authoritative until the Project satisfies ADR-defined parity and rollback gates. No global flag flips all Projects at once.
+
+### Likely files
+
+- `packages/core/src/share-provisioning.ts`
+- new recipient-policy reconciler modules
+- `packages/core/src/sync-replication.ts`
+- `packages/core/src/scope-membership-cache.ts`
+- `packages/core/src/sync-daemon.ts`
+- `packages/viewer-server/src/routes/sync.ts`
+- coordinator scope membership handlers
+
+### Validation
+
+- Current and future Team members receive only explicitly Team-shared Projects.
+- New Identity devices inherit only that Identity's access.
+- Personal and Work remain isolated until an explicit cross-Identity share.
+- Desired/current diffs are idempotent under retries and response loss.
+- Revocation blocks future ops and refreshes authorization promptly.
+- Filters and visibility only narrow.
+- Unsupported peers fail before partial reassignment.
+- Every unrelated Project remains absent, including inactive and tombstoned rows.
+
+## PR 8 — Navigation promotion, proof, and documentation
+
+### Objective
+
+Promote the new information architecture only after migration and policy-authority gates pass.
+
+### UI
+
+Ship:
+
+```text
+Feed     Projects     Sharing     Devices     Health
+```
+
+- `Sharing` owns Teams, Identities, and invitations.
+- `Devices` owns device availability and inherited-access summaries.
+- `Sync` becomes an Advanced compatibility/diagnostics alias with stable deep-link handling.
+- Teams/Space/grant administration remains available under Advanced.
+
+### Promotion gates
+
+- policy projection covers current supported state;
+- every blocking review item is actionable;
+- migration decisions are durable;
+- exact per-Project reconciliation parity is proven;
+- rollback visibility remains available;
+- primary UI has no raw internal terminology.
+
+### Likely files
+
+- `packages/ui/src/lib/state.ts`
+- `packages/ui/static/index.html`
+- `packages/ui/src/tabs/projects.ts`
+- new Sharing and Devices modules
+- `packages/ui/src/tabs/sync/`
+- `packages/ui/src/tabs/coordinator-admin/`
+- `e2e/scenarios/project-sharing.ts`
+- `README.md`
+- `docs/user-guide.md`
+- affected sync/coordinator documentation
+
+### Validation
+
+- Team bulk share and future-member inheritance E2E.
+- Direct Identity share without Team membership E2E.
+- New-device Identity inheritance E2E.
+- Personal/Work isolation plus explicit cross-Identity OSS share E2E.
+- Revocation, offline resume, stale preview, and unsupported-peer E2E.
+- Ambiguous migration under-sharing and durable `Keep current` E2E.
+- Normal UI absence assertions for scopes, grants, addresses, fingerprints, filters, epochs, and cursors.
+- `pnpm run check` plus project-sharing, sharing-domain, smoke, and Worker integration gates.
+
+## Rollout and rollback
+
+- Enable projection before persistence.
+- Enable persistence before authority.
+- Cut over one Project at a time after parity proof.
+- Keep legacy enforcement and diagnostics visible until the next stable release proves the new path.
+- A cutover failure returns that Project to legacy enforcement without deleting policy intent or review history.
+- Never perform a database-wide rescope or grant rewrite as one migration transaction.
+
+## Deferred follow-ups
+
+- OAuth/OIDC-backed Identity verification and account recovery.
+- GitHub organization, path, and tag automation with preview-first defaults.
+- Multiple Identities in one runtime.
+- Device profiles or role-based defaults.
+- Remote deletion or cryptographic recall of delivered data.
+- Coordinator data-path or centralized memory storage changes.
+
+## Stack completion criteria
+
+- The four visible concepts are Project, Identity, Team, and Device.
+- Projects and recipients are manageable in bulk from either direction.
+- Team and device invitations preview inherited access truthfully.
+- Every review item provides valid decisions and clears durably.
+- Scopes remain authoritative, exact, and hidden in normal use.
+- No migration or retry path broadens access.
+- Two-node tests prove exact current/future sharing, inheritance, isolation, revocation, and recovery.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -544,6 +544,30 @@ export {
 export type { FlushRawEventsOptions } from "./raw-event-flush.js";
 export { buildSessionContext, flushRawEvents } from "./raw-event-flush.js";
 export { RawEventSweeper } from "./raw-event-sweeper.js";
+export type {
+	RecipientPolicyAuthorityV1,
+	RecipientPolicyBlockedItemV1,
+	RecipientPolicyContractVersion,
+	RecipientPolicyEffectiveDeviceV1,
+	RecipientPolicyEnforcementV1,
+	RecipientPolicyIdentityDeviceV1,
+	RecipientPolicyIdentityKindV1,
+	RecipientPolicyIdentityStatusV1,
+	RecipientPolicyIdentityV1,
+	RecipientPolicyIntentSourceV1,
+	RecipientPolicyParityV1,
+	RecipientPolicyProjectionV1,
+	RecipientPolicyProjectRecipientV1,
+	RecipientPolicyProjectV1,
+	RecipientPolicyReconciliationStatusV1,
+	RecipientPolicyReviewDecisionV1,
+	RecipientPolicyReviewItemV1,
+	RecipientPolicyReviewOptionV1,
+	RecipientPolicyReviewResolutionV1,
+	RecipientPolicyTeamMembershipV1,
+	RecipientPolicyTeamV1,
+} from "./recipient-policy-contract.js";
+export { RECIPIENT_POLICY_CONTRACT_VERSION } from "./recipient-policy-contract.js";
 export {
 	hasPendingRefBackfill,
 	REF_BACKFILL_JOB,

--- a/packages/core/src/recipient-policy-contract.test.ts
+++ b/packages/core/src/recipient-policy-contract.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+	RECIPIENT_POLICY_CONTRACT_VERSION,
+	type RecipientPolicyIdentityDeviceV1,
+	type RecipientPolicyIdentityV1,
+	type RecipientPolicyProjectionV1,
+	type RecipientPolicyProjectRecipientV1,
+	type RecipientPolicyProjectV1,
+	type RecipientPolicyReviewDecisionV1,
+	type RecipientPolicyReviewItemV1,
+	type RecipientPolicyTeamMembershipV1,
+	type RecipientPolicyTeamV1,
+} from "./recipient-policy-contract.js";
+
+const PERSONAL_IDENTITY = {
+	version: RECIPIENT_POLICY_CONTRACT_VERSION,
+	identityId: "identity-personal",
+	displayName: "Personal",
+	kind: "personal",
+	verification: "local",
+	status: "active",
+	mergedIntoIdentityId: null,
+} as const satisfies RecipientPolicyIdentityV1;
+
+const WORK_IDENTITY = {
+	...PERSONAL_IDENTITY,
+	identityId: "identity-work",
+	displayName: "Work",
+	kind: "work",
+} as const satisfies RecipientPolicyIdentityV1;
+
+const TEAM = {
+	version: RECIPIENT_POLICY_CONTRACT_VERSION,
+	teamId: "team-oss",
+	displayName: "Open Source Team",
+	status: "active",
+} as const satisfies RecipientPolicyTeamV1;
+
+const TEAM_MEMBERSHIP = {
+	version: RECIPIENT_POLICY_CONTRACT_VERSION,
+	teamId: TEAM.teamId,
+	identityId: PERSONAL_IDENTITY.identityId,
+	role: "admin",
+	status: "active",
+} as const satisfies RecipientPolicyTeamMembershipV1;
+
+const IDENTITY_DEVICES = [
+	{
+		version: RECIPIENT_POLICY_CONTRACT_VERSION,
+		identityId: PERSONAL_IDENTITY.identityId,
+		deviceId: "device-home",
+		displayName: "Home laptop",
+		status: "active",
+	},
+	{
+		version: RECIPIENT_POLICY_CONTRACT_VERSION,
+		identityId: WORK_IDENTITY.identityId,
+		deviceId: "device-work",
+		displayName: "Work laptop",
+		status: "active",
+	},
+] as const satisfies readonly RecipientPolicyIdentityDeviceV1[];
+
+const PROJECT_RECIPIENTS = [
+	{
+		version: RECIPIENT_POLICY_CONTRACT_VERSION,
+		canonicalProjectIdentity: "git:https://example.invalid/example-oss.git",
+		recipientKind: "identity",
+		identityId: WORK_IDENTITY.identityId,
+		intentSource: "user",
+		policyRevision: "revision-1",
+		status: "active",
+	},
+	{
+		version: RECIPIENT_POLICY_CONTRACT_VERSION,
+		canonicalProjectIdentity: "git:https://example.invalid/example-oss.git",
+		recipientKind: "team",
+		teamId: TEAM.teamId,
+		intentSource: "user",
+		policyRevision: "revision-1",
+		status: "active",
+	},
+] as const satisfies readonly RecipientPolicyProjectRecipientV1[];
+
+const SAME_NAME_PROJECTS = [
+	{
+		version: RECIPIENT_POLICY_CONTRACT_VERSION,
+		canonicalIdentity: "git:https://example.invalid/one/example.git",
+		displayName: "example",
+	},
+	{
+		version: RECIPIENT_POLICY_CONTRACT_VERSION,
+		canonicalIdentity: "git:https://example.invalid/two/example.git",
+		displayName: "example",
+	},
+] as const satisfies readonly RecipientPolicyProjectV1[];
+
+const KEEP_CURRENT_REVIEW = {
+	version: RECIPIENT_POLICY_CONTRACT_VERSION,
+	reviewItemId: "review-1",
+	sourceFingerprint: "fingerprint-1",
+	finding: "Existing access cannot be mapped unambiguously.",
+	reason: "The legacy Space contains several Projects and device audiences.",
+	recommendedDecision: "keep_current_setup",
+	options: [
+		{
+			decision: "keep_current_setup",
+			label: "Keep current setup unchanged",
+			effect: "none",
+			affectedProjectCount: 1,
+			affectedMemoryCount: 0,
+			affectedDeviceCount: 0,
+		},
+	],
+	state: "open",
+	resolution: null,
+} as const satisfies RecipientPolicyReviewItemV1;
+
+describe("recipient policy V1 contract", () => {
+	it("uses a fixed contract version", () => {
+		expect(RECIPIENT_POLICY_CONTRACT_VERSION).toBe(1);
+	});
+
+	it("keeps Personal and Work as distinct Identities", () => {
+		expect(PERSONAL_IDENTITY.identityId).not.toBe(WORK_IDENTITY.identityId);
+		expectTypeOf(PERSONAL_IDENTITY).toMatchTypeOf<RecipientPolicyIdentityV1>();
+		expectTypeOf(WORK_IDENTITY).toMatchTypeOf<RecipientPolicyIdentityV1>();
+	});
+
+	it("maps each device edge to exactly one Identity", () => {
+		const identitiesByDevice = new Map(
+			IDENTITY_DEVICES.map((item) => [item.deviceId, item.identityId]),
+		);
+		expect(identitiesByDevice).toEqual(
+			new Map([
+				["device-home", "identity-personal"],
+				["device-work", "identity-work"],
+			]),
+		);
+	});
+
+	it("uses canonical Project identity instead of display name", () => {
+		expect(new Set(SAME_NAME_PROJECTS.map((project) => project.canonicalIdentity)).size).toBe(2);
+		expect(new Set(SAME_NAME_PROJECTS.map((project) => project.displayName)).size).toBe(1);
+	});
+
+	it("keeps Team membership Identity-based", () => {
+		expect(TEAM_MEMBERSHIP).toMatchObject({
+			teamId: TEAM.teamId,
+			identityId: PERSONAL_IDENTITY.identityId,
+		});
+		expect(TEAM_MEMBERSHIP).not.toHaveProperty("deviceId");
+	});
+
+	it("distinguishes direct Identity and Team recipients", () => {
+		expect(PROJECT_RECIPIENTS.map((item) => item.recipientKind)).toEqual(["identity", "team"]);
+	});
+
+	it("keeps authorization shortcuts out of recipient intent", () => {
+		type ForbiddenIntentKey = Extract<
+			keyof RecipientPolicyProjectRecipientV1,
+			"scopeId" | "deviceId" | "trusted" | "projectFilters"
+		>;
+		expectTypeOf<ForbiddenIntentKey>().toEqualTypeOf<never>();
+	});
+
+	it("makes keeping current setup an actionable outcome", () => {
+		expect(KEEP_CURRENT_REVIEW.recommendedDecision).toBe("keep_current_setup");
+		expect(KEEP_CURRENT_REVIEW.options).toContainEqual(
+			expect.objectContaining({ decision: "keep_current_setup", effect: "none" }),
+		);
+	});
+
+	it("keeps rejection and access-preserving migration as explicit decisions", () => {
+		type ExplicitDecision = Extract<
+			RecipientPolicyReviewDecisionV1,
+			"reject_suggestion" | "preserve_current_access"
+		>;
+		expectTypeOf<ExplicitDecision>().toEqualTypeOf<
+			"reject_suggestion" | "preserve_current_access"
+		>();
+	});
+
+	it("separates intent, effective devices, and enforcement in projections", () => {
+		const projection = {
+			version: RECIPIENT_POLICY_CONTRACT_VERSION,
+			project: {
+				version: RECIPIENT_POLICY_CONTRACT_VERSION,
+				canonicalIdentity: PROJECT_RECIPIENTS[0].canonicalProjectIdentity,
+				displayName: "example-oss",
+			},
+			intent: [...PROJECT_RECIPIENTS],
+			effectiveDevices: [
+				{
+					version: RECIPIENT_POLICY_CONTRACT_VERSION,
+					canonicalProjectIdentity: PROJECT_RECIPIENTS[0].canonicalProjectIdentity,
+					identityId: WORK_IDENTITY.identityId,
+					deviceId: "device-work",
+					via: "direct_identity",
+				},
+			],
+			enforcement: {
+				version: RECIPIENT_POLICY_CONTRACT_VERSION,
+				canonicalProjectIdentity: PROJECT_RECIPIENTS[0].canonicalProjectIdentity,
+				authority: "legacy_scope",
+				parity: "unknown",
+				cutoverState: "legacy",
+				managedScopeId: null,
+				desiredDeviceIds: ["device-work"],
+				currentDeviceIds: [],
+				safeErrorCode: null,
+			},
+			reviewItems: [KEEP_CURRENT_REVIEW],
+			blockedItems: [],
+		} satisfies RecipientPolicyProjectionV1;
+
+		expect(projection.intent).toHaveLength(2);
+		expect(projection.effectiveDevices).toHaveLength(1);
+		expect(projection.enforcement.authority).toBe("legacy_scope");
+	});
+});

--- a/packages/core/src/recipient-policy-contract.ts
+++ b/packages/core/src/recipient-policy-contract.ts
@@ -1,0 +1,165 @@
+export const RECIPIENT_POLICY_CONTRACT_VERSION = 1 as const;
+
+export type RecipientPolicyContractVersion = typeof RECIPIENT_POLICY_CONTRACT_VERSION;
+
+export type RecipientPolicyIdentityKindV1 = "personal" | "work" | "other";
+export type RecipientPolicyIdentityStatusV1 = "active" | "pending" | "merged";
+
+export interface RecipientPolicyIdentityV1 {
+	version: RecipientPolicyContractVersion;
+	identityId: string;
+	displayName: string;
+	kind: RecipientPolicyIdentityKindV1;
+	verification: "local";
+	status: RecipientPolicyIdentityStatusV1;
+	mergedIntoIdentityId: string | null;
+}
+
+export interface RecipientPolicyTeamV1 {
+	version: RecipientPolicyContractVersion;
+	teamId: string;
+	displayName: string;
+	status: "active" | "archived";
+}
+
+export interface RecipientPolicyTeamMembershipV1 {
+	version: RecipientPolicyContractVersion;
+	teamId: string;
+	identityId: string;
+	role: "member" | "admin";
+	status: "active" | "pending" | "revoked";
+}
+
+export interface RecipientPolicyIdentityDeviceV1 {
+	version: RecipientPolicyContractVersion;
+	identityId: string;
+	deviceId: string;
+	displayName: string;
+	status: "active" | "revoked";
+}
+
+export interface RecipientPolicyProjectV1 {
+	version: RecipientPolicyContractVersion;
+	canonicalIdentity: string;
+	displayName: string;
+}
+
+export type RecipientPolicyIntentSourceV1 = "user" | "migration" | "legacy_project_invite";
+
+interface RecipientPolicyProjectRecipientBaseV1 {
+	version: RecipientPolicyContractVersion;
+	canonicalProjectIdentity: string;
+	intentSource: RecipientPolicyIntentSourceV1;
+	policyRevision: string;
+	status: "active" | "revoked";
+}
+
+export type RecipientPolicyProjectRecipientV1 =
+	| (RecipientPolicyProjectRecipientBaseV1 & {
+			recipientKind: "identity";
+			identityId: string;
+	  })
+	| (RecipientPolicyProjectRecipientBaseV1 & {
+			recipientKind: "team";
+			teamId: string;
+	  });
+
+interface RecipientPolicyEffectiveDeviceBaseV1 {
+	version: RecipientPolicyContractVersion;
+	canonicalProjectIdentity: string;
+	identityId: string;
+	deviceId: string;
+}
+
+export type RecipientPolicyEffectiveDeviceV1 =
+	| (RecipientPolicyEffectiveDeviceBaseV1 & {
+			via: "direct_identity";
+	  })
+	| (RecipientPolicyEffectiveDeviceBaseV1 & {
+			via: "team_membership";
+			teamId: string;
+	  });
+
+export type RecipientPolicyAuthorityV1 = "legacy_scope" | "recipient_policy";
+export type RecipientPolicyParityV1 = "unknown" | "matched" | "diverged";
+
+export interface RecipientPolicyEnforcementV1 {
+	version: RecipientPolicyContractVersion;
+	canonicalProjectIdentity: string;
+	authority: RecipientPolicyAuthorityV1;
+	parity: RecipientPolicyParityV1;
+	cutoverState: "legacy" | "eligible" | "active" | "rolled_back";
+	managedScopeId: string | null;
+	desiredDeviceIds: string[];
+	currentDeviceIds: string[];
+	safeErrorCode: string | null;
+}
+
+export type RecipientPolicyReviewDecisionV1 =
+	| "apply_recommendation"
+	| "choose_recipients"
+	| "preserve_current_access"
+	| "reject_suggestion"
+	| "keep_current_setup"
+	| "keep_project_local"
+	| "keep_identities_separate"
+	| "attach_device_to_identity"
+	| "create_identity"
+	| "remove_stale_device";
+
+export interface RecipientPolicyReviewOptionV1 {
+	decision: RecipientPolicyReviewDecisionV1;
+	label: string;
+	effect: "none" | "grant_reviewed_access" | "revoke_reviewed_access" | "metadata_only";
+	affectedProjectCount: number;
+	affectedMemoryCount: number;
+	affectedDeviceCount: number;
+}
+
+export interface RecipientPolicyReviewResolutionV1 {
+	decision: RecipientPolicyReviewDecisionV1;
+	decidedByIdentityId: string;
+	decidedByDeviceId: string;
+	resolvedAt: string;
+}
+
+export interface RecipientPolicyReviewItemV1 {
+	version: RecipientPolicyContractVersion;
+	reviewItemId: string;
+	sourceFingerprint: string;
+	finding: string;
+	reason: string;
+	recommendedDecision: RecipientPolicyReviewDecisionV1;
+	options: RecipientPolicyReviewOptionV1[];
+	state: "open" | "resolved";
+	resolution: RecipientPolicyReviewResolutionV1 | null;
+}
+
+export interface RecipientPolicyBlockedItemV1 {
+	version: RecipientPolicyContractVersion;
+	blockedItemId: string;
+	finding: string;
+	reason: string;
+	ownerLabel: string;
+	repairAction: string;
+}
+
+export interface RecipientPolicyProjectionV1 {
+	version: RecipientPolicyContractVersion;
+	project: RecipientPolicyProjectV1;
+	intent: RecipientPolicyProjectRecipientV1[];
+	effectiveDevices: RecipientPolicyEffectiveDeviceV1[];
+	enforcement: RecipientPolicyEnforcementV1;
+	reviewItems: RecipientPolicyReviewItemV1[];
+	blockedItems: RecipientPolicyBlockedItemV1[];
+}
+
+export interface RecipientPolicyReconciliationStatusV1 {
+	version: RecipientPolicyContractVersion;
+	canonicalProjectIdentity: string;
+	state: "projected" | "parity_verified" | "active" | "waiting" | "needs_attention" | "rolled_back";
+	authority: RecipientPolicyAuthorityV1;
+	parity: RecipientPolicyParityV1;
+	lastCompletedAt: string | null;
+	safeErrorCode: string | null;
+}


### PR DESCRIPTION
## Description

Define the contract boundary for the project-recipient sharing redesign tracked by `codemem-hop0.1`.

- records the approved Project → Identity/Team product model and eight-PR implementation plan
- decides that actors back Identities while policy Teams remain distinct from coordinator groups
- defines per-Project authority cutover, attributed actionable review, legacy invitation, and navigation compatibility rules
- adds dependency-free V1 TypeScript contracts separating intent, effective devices, and current scope enforcement
- adds pure contract fixtures without changing persistence, routes, migrations, or authorization behavior

This builds on the merged exact-project sharing stack; it does not revert or weaken its scope enforcement, provisioning, invitation binding, or replication behavior.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation:

- `pnpm run check` — 150 files passed, 2,809 tests passed, 3 todo
- `pnpm exec vitest run packages/core/src/recipient-policy-contract.test.ts` — 10 passed
- `git diff --check`
- independent CodeReviewer and ADR review; no P0/P1 findings after corrections

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
