### PR TITLE
fix(sharing): preserve inviter policy during acceptance

### DIFF
--- a/packages/core/src/recipient-policy-onboarding.test.ts
+++ b/packages/core/src/recipient-policy-onboarding.test.ts
@@ -2,6 +2,7 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { listRecipientPolicyIntent } from "./recipient-policy-intent.js";
 import {
+	commitDirectProjectSharePolicyInTransaction,
 	commitRecipientPolicyOnboarding,
 	previewRecipientPolicyOnboarding,
 	type RecipientPolicyOnboardingPreviewRequestV1,
@@ -17,11 +18,12 @@ function insertActor(
 	db: InstanceType<typeof Database>,
 	identityId: string,
 	displayName: string,
+	isLocal = false,
 ): void {
 	db.prepare(
 		`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
-		 VALUES (?, ?, 0, 'active', ?, ?)`,
-	).run(identityId, displayName, NOW, NOW);
+		 VALUES (?, ?, ?, 'active', ?, ?)`,
+	).run(identityId, displayName, isLocal ? 1 : 0, NOW, NOW);
 }
 
 function insertProject(
@@ -340,6 +342,233 @@ describe("recipient-policy onboarding", () => {
 		);
 	});
 
+	it("atomically commits the complete direct-share owner and recipient graph", () => {
+		insertActor(db, "identity-owner", "Owner", true);
+		const membershipsBefore = db
+			.prepare("SELECT * FROM policy_team_memberships ORDER BY rowid")
+			.all();
+		const input = {
+			operationId: "share-complete-graph",
+			inviterIdentityId: "identity-owner",
+			inviterDevices: [
+				{ deviceId: "device-owner", displayName: "Owner laptop" },
+				{ deviceId: "device-owner-proven", displayName: "Owner server" },
+			],
+			recipientIdentityId: "identity-b",
+			recipientDeviceId: "device-recipient",
+			recipientDevicePublicKey: "recipient-public-key",
+			recipientDeviceDisplayName: "Recipient laptop",
+			canonicalProjectIdentities: [PROJECT_C, PROJECT_A],
+			now: NOW,
+		};
+		const commit = db.transaction(() => commitDirectProjectSharePolicyInTransaction(db, input));
+
+		expect(commit()).toBe(7);
+		expect(
+			db.prepare("SELECT identity_id, device_id FROM identity_devices ORDER BY device_id").all(),
+		).toEqual([
+			{ identity_id: "identity-owner", device_id: "device-owner" },
+			{ identity_id: "identity-owner", device_id: "device-owner-proven" },
+			{ identity_id: "identity-b", device_id: "device-recipient" },
+		]);
+		expect(
+			db
+				.prepare(`SELECT canonical_project_identity, recipient_id
+				FROM project_recipients
+				WHERE recipient_id IN ('identity-owner', 'identity-b')
+				ORDER BY canonical_project_identity, recipient_id`)
+				.all(),
+		).toEqual([
+			{ canonical_project_identity: PROJECT_A, recipient_id: "identity-b" },
+			{ canonical_project_identity: PROJECT_A, recipient_id: "identity-owner" },
+			{ canonical_project_identity: PROJECT_C, recipient_id: "identity-b" },
+			{ canonical_project_identity: PROJECT_C, recipient_id: "identity-owner" },
+		]);
+		expect(
+			db.prepare("SELECT 1 FROM identity_devices WHERE device_id = 'source-bystander'").get(),
+		).toBeUndefined();
+		expect(db.prepare("SELECT * FROM policy_team_memberships ORDER BY rowid").all()).toEqual(
+			membershipsBefore,
+		);
+		expect(commit()).toBe(0);
+	});
+
+	it("preserves compatible migration rows and writes only new recipient intent", () => {
+		insertActor(db, "identity-owner", "Owner", true);
+		db.prepare(
+			`INSERT INTO identity_devices(
+			 identity_id, device_id, display_name, status, provenance, revision, migration_state,
+			 source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES ('identity-owner', 'device-owner', 'Migrated owner device', 'active',
+			 'migration', 'migration-device-revision', 'projected', 'migration-device-source',
+			 'migration-device-idempotency', ?, ?)`,
+		).run(NOW, NOW);
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key,
+			 created_at, updated_at
+			 ) VALUES (?, 'identity', 'identity-owner', 'active', 'migration',
+			 'migration-project-revision', 'projected', 'migration-source-fingerprint',
+			 'migration-project-idempotency', ?, ?)`,
+		).run(PROJECT_A, NOW, NOW);
+		const existingDevice = db
+			.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-owner'")
+			.get();
+		const existingProject = db
+			.prepare(`SELECT * FROM project_recipients
+				WHERE canonical_project_identity = ? AND recipient_kind = 'identity'
+				AND recipient_id = 'identity-owner'`)
+			.get(PROJECT_A);
+		const input = {
+			operationId: "share-migrated-owner",
+			inviterIdentityId: "identity-owner",
+			inviterDevices: [{ deviceId: "device-owner", displayName: "Ignored new label" }],
+			recipientIdentityId: "identity-b",
+			recipientDeviceId: "device-recipient",
+			recipientDevicePublicKey: "recipient-public-key",
+			recipientDeviceDisplayName: "Recipient laptop",
+			canonicalProjectIdentities: [PROJECT_A],
+			now: NOW,
+		};
+		const commit = db.transaction(() => commitDirectProjectSharePolicyInTransaction(db, input));
+
+		expect(commit()).toBe(2);
+		expect(
+			db.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-owner'").get(),
+		).toEqual(existingDevice);
+		expect(
+			db
+				.prepare(`SELECT * FROM project_recipients
+				WHERE canonical_project_identity = ? AND recipient_kind = 'identity'
+				AND recipient_id = 'identity-owner'`)
+				.get(PROJECT_A),
+		).toEqual(existingProject);
+		expect(
+			db
+				.prepare("SELECT identity_id, device_id FROM identity_devices WHERE device_id = ?")
+				.get("device-recipient"),
+		).toEqual({ identity_id: "identity-b", device_id: "device-recipient" });
+		expect(commit()).toBe(0);
+	});
+
+	it("rejects a revoked inviter Project edge without partial recipient intent", () => {
+		insertActor(db, "identity-owner", "Owner", true);
+		db.prepare(
+			`INSERT INTO identity_devices(
+			 identity_id, device_id, display_name, status, provenance, revision, migration_state,
+			 source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES ('identity-owner', 'device-owner', 'Migrated owner device', 'active',
+			 'migration', 'migration-device-revision', 'projected', NULL,
+			 'migration-device-idempotency', ?, ?)`,
+		).run(NOW, NOW);
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key,
+			 created_at, updated_at
+			 ) VALUES (?, 'identity', 'identity-owner', 'revoked', 'migration',
+			 'migration-project-revision', 'projected', NULL,
+			 'migration-project-idempotency', ?, ?)`,
+		).run(PROJECT_A, NOW, NOW);
+		const commit = db.transaction(() =>
+			commitDirectProjectSharePolicyInTransaction(db, {
+				operationId: "share-revoked-owner",
+				inviterIdentityId: "identity-owner",
+				inviterDevices: [{ deviceId: "device-owner", displayName: "Owner device" }],
+				recipientIdentityId: "identity-b",
+				recipientDeviceId: "device-recipient",
+				recipientDevicePublicKey: "recipient-public-key",
+				recipientDeviceDisplayName: "Recipient laptop",
+				canonicalProjectIdentities: [PROJECT_A],
+				now: NOW,
+			}),
+		);
+
+		expect(() => commit()).toThrow("intent_conflict");
+		expect(
+			db
+				.prepare("SELECT status FROM project_recipients WHERE recipient_id = 'identity-owner'")
+				.pluck()
+				.get(),
+		).toBe("revoked");
+		expect(
+			db.prepare("SELECT 1 FROM identity_devices WHERE device_id = 'device-recipient'").get(),
+		).toBeUndefined();
+		expect(
+			db.prepare("SELECT 1 FROM project_recipients WHERE recipient_id = 'identity-b'").get(),
+		).toBeUndefined();
+	});
+
+	it("rolls back recipient intent when a reviewed inviter device belongs to another Identity", () => {
+		insertActor(db, "identity-owner", "Owner", true);
+		db.prepare(
+			`INSERT INTO identity_devices(
+			 identity_id, device_id, display_name, status, provenance, revision, migration_state,
+			 source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES ('identity-a', 'device-owner', 'Wrong owner', 'active', 'user',
+			 'existing-revision', 'user_managed', 'existing-source', 'existing-key', ?, ?)`,
+		).run(NOW, NOW);
+		const intentBefore = JSON.stringify({
+			devices: db.prepare("SELECT * FROM identity_devices ORDER BY rowid").all(),
+			recipients: db.prepare("SELECT * FROM project_recipients ORDER BY rowid").all(),
+		});
+		const commit = db.transaction(() =>
+			commitDirectProjectSharePolicyInTransaction(db, {
+				operationId: "share-conflicting-owner",
+				inviterIdentityId: "identity-owner",
+				inviterDevices: [{ deviceId: "device-owner", displayName: "Owner laptop" }],
+				recipientIdentityId: "identity-b",
+				recipientDeviceId: "device-recipient",
+				recipientDevicePublicKey: "recipient-public-key",
+				recipientDeviceDisplayName: "Recipient laptop",
+				canonicalProjectIdentities: [PROJECT_A],
+				now: NOW,
+			}),
+		);
+
+		expect(() => commit()).toThrow("device_binding_conflict");
+		expect(
+			JSON.stringify({
+				devices: db.prepare("SELECT * FROM identity_devices ORDER BY rowid").all(),
+				recipients: db.prepare("SELECT * FROM project_recipients ORDER BY rowid").all(),
+			}),
+		).toBe(intentBefore);
+	});
+
+	it("rejects a non-active inviter device binding", () => {
+		insertActor(db, "identity-owner", "Owner", true);
+		db.prepare(
+			`INSERT INTO identity_devices(
+			 identity_id, device_id, display_name, status, provenance, revision, migration_state,
+			 source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES ('identity-owner', 'device-owner', 'Revoked owner device', 'revoked',
+			 'migration', 'migration-device-revision', 'projected', NULL,
+			 'migration-device-idempotency', ?, ?)`,
+		).run(NOW, NOW);
+		const commit = db.transaction(() =>
+			commitDirectProjectSharePolicyInTransaction(db, {
+				operationId: "share-revoked-device",
+				inviterIdentityId: "identity-owner",
+				inviterDevices: [{ deviceId: "device-owner", displayName: "Owner device" }],
+				recipientIdentityId: "identity-b",
+				recipientDeviceId: "device-recipient",
+				recipientDevicePublicKey: "recipient-public-key",
+				recipientDeviceDisplayName: "Recipient laptop",
+				canonicalProjectIdentities: [PROJECT_A],
+				now: NOW,
+			}),
+		);
+
+		expect(() => commit()).toThrow("device_binding_conflict");
+		expect(
+			db.prepare("SELECT 1 FROM identity_devices WHERE device_id = 'device-recipient'").get(),
+		).toBeUndefined();
+		expect(
+			db.prepare("SELECT 1 FROM project_recipients WHERE recipient_id = 'identity-b'").get(),
+		).toBeUndefined();
+	});
+
 	it("reuses an identical device binding across direct and Team invitations", () => {
 		const direct = baseRequest({
 			journey: "direct_project",
@@ -372,6 +601,35 @@ describe("recipient-policy onboarding", () => {
 		expect(
 			db.prepare("SELECT team_id, identity_id FROM policy_team_memberships").all(),
 		).toContainEqual({ team_id: "team-a", identity_id: "identity-b" });
+	});
+
+	it("rejects a changed device key across distinct invitations", () => {
+		const first = baseRequest({ invitationId: "invite-first" });
+		const firstPreview = previewRecipientPolicyOnboarding(db, first);
+		commitRecipientPolicyOnboarding(
+			db,
+			{ ...first, reviewedOnboardingDigest: firstPreview.reviewedOnboardingDigest },
+			{ now: () => NOW },
+		);
+		const originalBinding = db
+			.prepare("SELECT * FROM identity_devices WHERE device_id = ?")
+			.get(first.deviceId);
+		const second = baseRequest({
+			invitationId: "invite-second",
+			devicePublicKey: "public-key-b",
+		});
+		const secondPreview = previewRecipientPolicyOnboarding(db, second);
+
+		expect(
+			commitRecipientPolicyOnboarding(
+				db,
+				{ ...second, reviewedOnboardingDigest: secondPreview.reviewedOnboardingDigest },
+				{ now: () => NOW },
+			),
+		).toMatchObject({ status: "conflict", errorCode: "device_binding_conflict", writeCount: 0 });
+		expect(
+			db.prepare("SELECT * FROM identity_devices WHERE device_id = ?").get(first.deviceId),
+		).toEqual(originalBinding);
 	});
 
 	it("commits add-device as the only intent write", () => {

--- a/packages/core/src/recipient-policy-onboarding.ts
+++ b/packages/core/src/recipient-policy-onboarding.ts
@@ -88,6 +88,18 @@ export interface RecipientPolicyOnboardingCommitResultV1 {
 	idempotent: boolean;
 }
 
+export interface DirectProjectSharePolicyCommitInput {
+	operationId: string;
+	inviterIdentityId: string;
+	inviterDevices: Array<{ deviceId: string; displayName: string }>;
+	recipientIdentityId: string;
+	recipientDeviceId: string;
+	recipientDevicePublicKey: string;
+	recipientDeviceDisplayName: string;
+	canonicalProjectIdentities: string[];
+	now: string;
+}
+
 export class RecipientPolicyOnboardingRequestError extends Error {
 	readonly status: "invalid" | "not_found";
 	readonly errorCode: string;
@@ -298,6 +310,15 @@ function assertActiveIdentity(db: Database, identityId: string): void {
 		| undefined;
 	if (row?.status !== "active") {
 		throw new RecipientPolicyOnboardingRequestError("not_found", "identity_not_found");
+	}
+}
+
+function assertActiveLocalIdentity(db: Database, identityId: string): void {
+	const row = db
+		.prepare("SELECT is_local, status FROM actors WHERE actor_id = ?")
+		.get(identityId) as { is_local: number; status: string } | undefined;
+	if (row?.status !== "active" || row.is_local !== 1) {
+		throw new Error("inviter_identity_conflict");
 	}
 }
 
@@ -569,6 +590,69 @@ function projectRow(
 	};
 }
 
+function inviterDeviceRow(input: {
+	identityId: string;
+	deviceId: string;
+	displayName: string;
+	now: string;
+}): IntentRow {
+	const stableBinding = { identityId: input.identityId, deviceId: input.deviceId };
+	const metadata = relationshipMetadata(
+		"identity-device",
+		["direct_project_inviter", stableBinding],
+		["direct_project_inviter", stableBinding],
+	);
+	return {
+		table: "identity_devices",
+		key: { device_id: input.deviceId },
+		values: {
+			identity_id: input.identityId,
+			display_name: input.displayName,
+			...baseValues({
+				provenance: "exact_project_invite",
+				revision: metadata.revision,
+				idempotencyKey: metadata.idempotencyKey,
+				sourceFingerprint: digest("recipient-onboarding-inviter-device-v1", stableBinding),
+				now: input.now,
+			}),
+		},
+	};
+}
+
+function inviterProjectRow(input: {
+	identityId: string;
+	projectId: string;
+	now: string;
+}): IntentRow {
+	const stableBinding = {
+		canonicalProjectIdentity: input.projectId,
+		recipientKind: "identity",
+		recipientId: input.identityId,
+	};
+	const metadata = relationshipMetadata(
+		"project-recipient",
+		["direct_project_inviter", stableBinding],
+		["direct_project_inviter", stableBinding],
+	);
+	const values = baseValues({
+		provenance: "exact_project_invite",
+		revision: metadata.revision,
+		idempotencyKey: metadata.idempotencyKey,
+		sourceFingerprint: digest("recipient-onboarding-inviter-project-v1", stableBinding),
+		now: input.now,
+	});
+	const { revision, ...rest } = values;
+	return {
+		table: "project_recipients",
+		key: {
+			canonical_project_identity: input.projectId,
+			recipient_kind: "identity",
+			recipient_id: input.identityId,
+		},
+		values: { ...rest, policy_revision: revision },
+	};
+}
+
 function planRows(request: NormalizedRequest, now: string): IntentRow[] {
 	const rows = [deviceRow(request, now)];
 	if (request.journey === "team") rows.push(membershipRow(request, now));
@@ -601,12 +685,21 @@ function validateOrWriteRow(db: Database, row: IntentRow): boolean {
 	if (existing) {
 		const expected = { ...row.key, ...row.values };
 		if (row.table === "identity_devices" && keyMatch && !idempotencyMatch) {
+			const hasRecipientKeyBinding =
+				keyMatch.provenance === "recipient_invite" && expected.provenance === "recipient_invite";
+			const hasConflictingFingerprint =
+				hasRecipientKeyBinding && keyMatch.source_fingerprint !== expected.source_fingerprint;
 			if (
 				keyMatch.identity_id !== expected.identity_id ||
-				keyMatch.source_fingerprint !== expected.source_fingerprint
+				keyMatch.status !== "active" ||
+				hasConflictingFingerprint
 			) {
 				throw new Error("device_binding_conflict");
 			}
+			return false;
+		}
+		if (row.table === "project_recipients" && keyMatch && !idempotencyMatch) {
+			if (keyMatch.status !== "active") throw new Error("intent_conflict");
 			return false;
 		}
 		const comparableColumns = Object.keys(expected).filter(
@@ -624,6 +717,55 @@ function validateOrWriteRow(db: Database, row: IntentRow): boolean {
 		`INSERT INTO ${row.table}(${columns.join(", ")}) VALUES (${columns.map(() => "?").join(", ")})`,
 	).run(...Object.values(row.key), ...Object.values(row.values));
 	return true;
+}
+
+export function commitDirectProjectSharePolicyInTransaction(
+	db: Database,
+	input: DirectProjectSharePolicyCommitInput,
+): number {
+	if (!db.inTransaction) throw new Error("direct_share_policy_transaction_required");
+	const normalized = normalizeRequest({
+		version: 1,
+		journey: "direct_project",
+		invitationId: input.operationId,
+		identityId: input.recipientIdentityId,
+		deviceId: input.recipientDeviceId,
+		devicePublicKey: input.recipientDevicePublicKey,
+		deviceDisplayName: input.recipientDeviceDisplayName,
+		canonicalProjectIdentities: input.canonicalProjectIdentities,
+	});
+	if (normalized.journey !== "direct_project") throw new Error("journey_invalid");
+	assertActiveIdentity(db, normalized.binding.identityId);
+	assertActiveLocalIdentity(db, input.inviterIdentityId);
+	if (input.inviterDevices.length === 0) throw new Error("inviter_device_binding_missing");
+	const inviterDevices = input.inviterDevices
+		.map((device) => ({
+			deviceId: strictId(device.deviceId, "inviter_device_id", 256),
+			displayName: normalizeIdentityDisplayName(device.displayName, "device_display_name"),
+		}))
+		.toSorted((left, right) => compareText(left.deviceId, right.deviceId));
+	if (new Set(inviterDevices.map((device) => device.deviceId)).size !== inviterDevices.length) {
+		throw new Error("inviter_device_binding_invalid");
+	}
+	const rows = [
+		...inviterDevices.map((device) =>
+			inviterDeviceRow({
+				identityId: input.inviterIdentityId,
+				deviceId: device.deviceId,
+				displayName: device.displayName,
+				now: input.now,
+			}),
+		),
+		...normalized.canonicalProjectIdentities.map((projectId) =>
+			inviterProjectRow({ identityId: input.inviterIdentityId, projectId, now: input.now }),
+		),
+		...planRows(normalized, input.now),
+	];
+	let writeCount = 0;
+	for (const row of rows) {
+		if (validateOrWriteRow(db, row)) writeCount += 1;
+	}
+	return writeCount;
 }
 
 function emptyResult(

--- a/packages/core/src/share-operation.test.ts
+++ b/packages/core/src/share-operation.test.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { previewRecipientPolicyEdges } from "./recipient-policy-edges.js";
 import {
 	inviteTokenDigest,
 	parseAcceptedProjectIntent,
@@ -51,6 +52,7 @@ function acceptanceInput(
 	const publicKey = "recipient-key";
 	return {
 		operationId: operation.operationId,
+		localInviterActorId: operation.inviterActorId,
 		coordinatorGroupId: operation.coordinatorGroupId,
 		reviewedProjectSetDigest: operation.reviewedProjectSetDigest,
 		recipientActorId: "actor-brian",
@@ -232,6 +234,9 @@ describe("share-operation persistence", () => {
 	beforeEach(() => {
 		db = new Database(":memory:");
 		initTestSchema(db);
+		db.prepare(`INSERT INTO actors(
+			actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+		) VALUES ('actor-adam', 'Adam', 1, 'active', NULL, ?, ?)`).run(createdAt, createdAt);
 	});
 
 	afterEach(() => db.close());
@@ -388,6 +393,15 @@ describe("share-operation persistence", () => {
 			inviteId: "invite-1",
 			tokenDigest: inviteTokenDigest("token-1"),
 		});
+		db.prepare(`INSERT INTO replication_scopes(
+			scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+		) VALUES ('source-scope', 'Source', 'team', 'local', 1, 'active', ?, ?)`).run(
+			createdAt,
+			createdAt,
+		);
+		db.prepare(`INSERT INTO scope_memberships(
+			scope_id, device_id, role, status, membership_epoch, updated_at
+		) VALUES ('source-scope', 'source-bystander', 'member', 'active', 1, ?)`).run(createdAt);
 		const protectedBefore = Object.fromEntries(
 			[
 				"replication_scopes",
@@ -402,6 +416,7 @@ describe("share-operation persistence", () => {
 		const publicKey = "recipient-key";
 		reconcileShareOperationAcceptance(db, {
 			operationId: operation.operationId,
+			localInviterActorId: operation.inviterActorId,
 			coordinatorGroupId: operation.coordinatorGroupId,
 			reviewedProjectSetDigest: operation.reviewedProjectSetDigest,
 			recipientActorId: "actor-brian",
@@ -443,22 +458,53 @@ describe("share-operation persistence", () => {
 				.prepare("SELECT actor_id, name FROM sync_peers WHERE peer_device_id = ?")
 				.get("device-brian"),
 		).toEqual({ actor_id: "actor-brian", name: "Brian's MacBook" });
-		expect(db.prepare("SELECT identity_id, device_id FROM identity_devices").all()).toEqual([
+		expect(
+			db.prepare("SELECT identity_id, device_id FROM identity_devices ORDER BY device_id").all(),
+		).toEqual([
+			{ identity_id: "actor-adam", device_id: "device-a" },
+			{ identity_id: "actor-adam", device_id: "device-b" },
 			{ identity_id: "actor-brian", device_id: "device-brian" },
 		]);
 		expect(
 			db
 				.prepare(`SELECT canonical_project_identity, recipient_kind, recipient_id
-					FROM project_recipients ORDER BY canonical_project_identity`)
+					FROM project_recipients ORDER BY canonical_project_identity, recipient_id`)
 				.all(),
 		).toEqual(
-			operation.projects.map((project) => ({
-				canonical_project_identity: project.canonicalIdentity,
-				recipient_kind: "identity",
-				recipient_id: "actor-brian",
-			})),
+			operation.projects.flatMap((project) => [
+				{
+					canonical_project_identity: project.canonicalIdentity,
+					recipient_kind: "identity",
+					recipient_id: "actor-adam",
+				},
+				{
+					canonical_project_identity: project.canonicalIdentity,
+					recipient_kind: "identity",
+					recipient_id: "actor-brian",
+				},
+			]),
 		);
+		expect(
+			db.prepare("SELECT 1 FROM identity_devices WHERE device_id = 'source-bystander'").get(),
+		).toBeUndefined();
 		expect(db.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get()).toBe(0);
+		const reconciliation = previewRecipientPolicyEdges(db, {
+			version: 1,
+			changes: [
+				{
+					canonicalProjectIdentity: operation.projects[0]?.canonicalIdentity,
+					recipient: { recipientKind: "identity", identityId: "actor-adam" },
+					action: "add",
+				},
+			],
+		});
+		expect(
+			reconciliation.effectiveDevices
+				.filter(
+					(device) => device.canonicalProjectIdentity === operation.projects[0]?.canonicalIdentity,
+				)
+				.map((device) => device.deviceId),
+		).toEqual(["device-a", "device-b", "device-brian"]);
 		expect(
 			Object.fromEntries(
 				Object.keys(protectedBefore).map((table) => [
@@ -467,6 +513,124 @@ describe("share-operation persistence", () => {
 				]),
 			),
 		).toEqual(protectedBefore);
+	});
+
+	it("accepts compatible migrated inviter policy without rewriting its metadata", () => {
+		const project = projects[0];
+		if (!project) throw new Error("project fixture missing");
+		const operation = plan({ inviterDeviceIds: ["device-a"], projects: [project] });
+		persistShareOperation(db, operation, {
+			inviteId: "invite-1",
+			tokenDigest: inviteTokenDigest("token-1"),
+		});
+		db.prepare(`INSERT INTO identity_devices(
+			identity_id, device_id, display_name, status, provenance, revision, migration_state,
+			source_fingerprint, idempotency_key, created_at, updated_at
+		) VALUES ('actor-adam', 'device-a', 'Migrated laptop', 'active', 'migration',
+			'migration-device-revision', 'projected', NULL, 'migration-device-key', ?, ?)`).run(
+			createdAt,
+			createdAt,
+		);
+		db.prepare(`INSERT INTO project_recipients(
+			canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			policy_revision, migration_state, source_fingerprint, idempotency_key,
+			created_at, updated_at
+		) VALUES (?, 'identity', 'actor-adam', 'active', 'migration',
+			'migration-project-revision', 'projected', 'different-source',
+			'migration-project-key', ?, ?)`).run(
+			operation.projects[0]?.canonicalIdentity,
+			createdAt,
+			createdAt,
+		);
+		const migratedRows = JSON.stringify({
+			device: db.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-a'").get(),
+			project: db
+				.prepare("SELECT * FROM project_recipients WHERE recipient_id = 'actor-adam'")
+				.get(),
+		});
+		const input = acceptanceInput(operation);
+
+		reconcileShareOperationAcceptance(db, input);
+
+		expect(
+			JSON.stringify({
+				device: db.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-a'").get(),
+				project: db
+					.prepare("SELECT * FROM project_recipients WHERE recipient_id = 'actor-adam'")
+					.get(),
+			}),
+		).toBe(migratedRows);
+		expect(db.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(2);
+		expect(db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(2);
+		const policyAfterFirstAcceptance = JSON.stringify({
+			devices: db.prepare("SELECT * FROM identity_devices ORDER BY device_id").all(),
+			recipients: db.prepare("SELECT * FROM project_recipients ORDER BY recipient_id").all(),
+		});
+
+		reconcileShareOperationAcceptance(db, input);
+
+		expect(
+			JSON.stringify({
+				devices: db.prepare("SELECT * FROM identity_devices ORDER BY device_id").all(),
+				recipients: db.prepare("SELECT * FROM project_recipients ORDER BY recipient_id").all(),
+			}),
+		).toBe(policyAfterFirstAcceptance);
+	});
+
+	it("rolls back acceptance when a reviewed inviter device is bound to another Identity", () => {
+		const operation = plan();
+		persistShareOperation(db, operation, {
+			inviteId: "invite-1",
+			tokenDigest: inviteTokenDigest("token-1"),
+		});
+		db.prepare(`INSERT INTO actors(
+			actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+		) VALUES ('actor-other', 'Other', 0, 'active', NULL, ?, ?)`).run(createdAt, createdAt);
+		db.prepare(`INSERT INTO identity_devices(
+			identity_id, device_id, display_name, status, provenance, revision, migration_state,
+			source_fingerprint, idempotency_key, created_at, updated_at
+		) VALUES ('actor-other', 'device-a', 'Other device', 'active', 'user',
+			'existing-revision', 'user_managed', 'existing-source', 'existing-key', ?, ?)`).run(
+			createdAt,
+			createdAt,
+		);
+
+		expect(() => reconcileShareOperationAcceptance(db, acceptanceInput(operation))).toThrow(
+			"device_binding_conflict",
+		);
+		expect(
+			db
+				.prepare("SELECT state, person_id FROM share_operations WHERE operation_id = ?")
+				.get(operation.operationId),
+		).toEqual({ state: "waiting_for_acceptance", person_id: operation.personId });
+		expect(db.prepare("SELECT 1 FROM actors WHERE actor_id = 'actor-brian'").get()).toBeUndefined();
+		expect(
+			db.prepare("SELECT 1 FROM project_recipients WHERE recipient_id = 'actor-brian'").get(),
+		).toBeUndefined();
+		expect(
+			db
+				.prepare("SELECT identity_id FROM identity_devices WHERE device_id = 'device-a'")
+				.pluck()
+				.get(),
+		).toBe("actor-other");
+	});
+
+	it("rejects acceptance when the persisted inviter does not match the local runtime", () => {
+		const operation = plan();
+		persistShareOperation(db, operation, {
+			inviteId: "invite-1",
+			tokenDigest: inviteTokenDigest("token-1"),
+		});
+
+		expect(() =>
+			reconcileShareOperationAcceptance(
+				db,
+				acceptanceInput(operation, { localInviterActorId: "actor-other-local" }),
+			),
+		).toThrow("operation_scope_mismatch");
+		expect(db.prepare("SELECT 1 FROM actors WHERE actor_id = 'actor-brian'").get()).toBeUndefined();
+		expect(db.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+		expect(db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(0);
 	});
 
 	it("rejects pending acceptance that collides with an existing active Person", () => {
@@ -483,6 +647,7 @@ describe("share-operation persistence", () => {
 		expect(() =>
 			reconcileShareOperationAcceptance(db, {
 				operationId: operation.operationId,
+				localInviterActorId: operation.inviterActorId,
 				coordinatorGroupId: operation.coordinatorGroupId,
 				reviewedProjectSetDigest: operation.reviewedProjectSetDigest,
 				recipientActorId: "actor-alex",
@@ -543,6 +708,14 @@ describe("share-operation persistence", () => {
 		});
 		const input = acceptanceInput(operation);
 		reconcileShareOperationAcceptance(db, input);
+		const firstPolicySnapshot = JSON.stringify({
+			devices: db.prepare("SELECT * FROM identity_devices ORDER BY device_id").all(),
+			recipients: db
+				.prepare(
+					"SELECT * FROM project_recipients ORDER BY canonical_project_identity, recipient_id",
+				)
+				.all(),
+		});
 		db.prepare("UPDATE share_operations SET state = 'initial_sync' WHERE operation_id = ?").run(
 			operation.operationId,
 		);
@@ -553,6 +726,69 @@ describe("share-operation persistence", () => {
 				.pluck()
 				.get(operation.operationId),
 		).toBe("initial_sync");
+		expect(
+			JSON.stringify({
+				devices: db.prepare("SELECT * FROM identity_devices ORDER BY device_id").all(),
+				recipients: db
+					.prepare(
+						"SELECT * FROM project_recipients ORDER BY canonical_project_identity, recipient_id",
+					)
+					.all(),
+			}),
+		).toBe(firstPolicySnapshot);
+	});
+
+	it("uses stable friendly inviter device names without persisting raw long IDs", () => {
+		const longDeviceId = `device-${"x".repeat(180)}`;
+		const operation = plan({ inviterDeviceIds: [longDeviceId, "device-friendly"] });
+		persistShareOperation(db, operation, {
+			inviteId: "invite-1",
+			tokenDigest: inviteTokenDigest("token-1"),
+		});
+		db.prepare(`INSERT INTO sync_peers(peer_device_id, name, created_at)
+			VALUES ('device-friendly', 'Owner laptop', ?), (?, ?, ?)`).run(
+			createdAt,
+			longDeviceId,
+			"x".repeat(121),
+			createdAt,
+		);
+		const input = acceptanceInput(operation);
+
+		reconcileShareOperationAcceptance(db, input);
+
+		expect(
+			db
+				.prepare(`SELECT device_id, display_name FROM identity_devices
+				WHERE identity_id = 'actor-adam' ORDER BY device_id`)
+				.all(),
+		).toEqual([
+			{ device_id: "device-friendly", display_name: "Owner laptop" },
+			{ device_id: longDeviceId, display_name: "Existing device" },
+		]);
+		db.prepare("UPDATE sync_peers SET name = 'Renamed peer' WHERE peer_device_id = ?").run(
+			"device-friendly",
+		);
+		db.prepare("UPDATE sync_peers SET name = 'Now friendly' WHERE peer_device_id = ?").run(
+			longDeviceId,
+		);
+
+		reconcileShareOperationAcceptance(db, input);
+
+		expect(
+			db
+				.prepare(`SELECT device_id, display_name FROM identity_devices
+				WHERE identity_id = 'actor-adam' ORDER BY device_id`)
+				.all(),
+		).toEqual([
+			{ device_id: "device-friendly", display_name: "Owner laptop" },
+			{ device_id: longDeviceId, display_name: "Existing device" },
+		]);
+		expect(
+			db
+				.prepare("SELECT COUNT(*) FROM identity_devices WHERE display_name = ?")
+				.pluck()
+				.get(longDeviceId),
+		).toBe(0);
 	});
 
 	it("rejects malformed or mismatched authoritative project intent", () => {
@@ -568,6 +804,7 @@ describe("share-operation persistence", () => {
 		expect(() =>
 			reconcileShareOperationAcceptance(db, {
 				operationId: operation.operationId,
+				localInviterActorId: operation.inviterActorId,
 				coordinatorGroupId: operation.coordinatorGroupId,
 				reviewedProjectSetDigest: operation.reviewedProjectSetDigest,
 				recipientActorId: "actor-brian",

--- a/packages/core/src/share-operation.ts
+++ b/packages/core/src/share-operation.ts
@@ -1,9 +1,7 @@
 import { createHash } from "node:crypto";
 import type { Database } from "./db.js";
-import {
-	commitRecipientPolicyOnboarding,
-	previewRecipientPolicyOnboarding,
-} from "./recipient-policy-onboarding.js";
+import { normalizeIdentityDisplayName } from "./project-invite-identity.js";
+import { commitDirectProjectSharePolicyInTransaction } from "./recipient-policy-onboarding.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 
 export const SHARE_HISTORY_POLICY = "existing_and_future" as const;
@@ -415,6 +413,7 @@ export interface AcceptedProjectIntent {
 
 export interface ShareOperationAcceptanceInput {
 	operationId: string;
+	localInviterActorId: string;
 	coordinatorGroupId: string;
 	reviewedProjectSetDigest: string;
 	recipientActorId: string;
@@ -427,6 +426,56 @@ export interface ShareOperationAcceptanceInput {
 	trustState: string;
 	bootstrapGrantId: string | null;
 	projects: AcceptedProjectIntent[];
+}
+
+function parsePersistedInviterDeviceIds(value: string): string[] {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		throw new Error("operation_intent_invalid");
+	}
+	if (!Array.isArray(parsed) || parsed.length === 0 || parsed.length > 100) {
+		throw new Error("operation_intent_invalid");
+	}
+	const deviceIds = parsed.map((deviceId) => {
+		if (
+			typeof deviceId !== "string" ||
+			!deviceId ||
+			deviceId !== deviceId.trim() ||
+			deviceId.length > 256 ||
+			/[\p{Cc}\p{Cf}]/u.test(deviceId)
+		) {
+			throw new Error("operation_intent_invalid");
+		}
+		return deviceId;
+	});
+	const canonical = [...new Set(deviceIds)].toSorted();
+	if (JSON.stringify(canonical) !== value) throw new Error("operation_intent_invalid");
+	return canonical;
+}
+
+function validInviterDeviceDisplayName(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	try {
+		return normalizeIdentityDisplayName(value, "device_display_name");
+	} catch {
+		return null;
+	}
+}
+
+function inviterDeviceDisplayName(db: Database, deviceId: string): string {
+	const persistedName = db
+		.prepare("SELECT display_name FROM identity_devices WHERE device_id = ?")
+		.pluck()
+		.get(deviceId);
+	const existing = validInviterDeviceDisplayName(persistedName);
+	if (existing) return existing;
+	const peerName = db
+		.prepare("SELECT name FROM sync_peers WHERE peer_device_id = ?")
+		.pluck()
+		.get(deviceId);
+	return validInviterDeviceDisplayName(peerName) ?? "Existing device";
 }
 
 export function parseAcceptedProjectIntent(value: unknown): AcceptedProjectIntent[] {
@@ -472,12 +521,15 @@ export function reconcileShareOperationAcceptance(
 	const acceptedProjects = parseAcceptedProjectIntent(input.projects);
 	const reconcile = db.transaction(() => {
 		const operation = db
-			.prepare(`SELECT operation_id, state, person_id, person_kind, coordinator_group_id,
-				reviewed_project_set_digest FROM share_operations WHERE operation_id = ?`)
+			.prepare(`SELECT operation_id, state, inviter_actor_id, inviter_device_ids_json,
+				person_id, person_kind, coordinator_group_id, reviewed_project_set_digest
+				FROM share_operations WHERE operation_id = ?`)
 			.get(input.operationId) as
 			| {
 					operation_id: string;
 					state: string;
+					inviter_actor_id: string;
+					inviter_device_ids_json: string;
 					person_id: string;
 					person_kind: string;
 					coordinator_group_id: string;
@@ -486,11 +538,13 @@ export function reconcileShareOperationAcceptance(
 			| undefined;
 		if (!operation) throw new Error("operation_not_found");
 		if (
+			operation.inviter_actor_id !== input.localInviterActorId ||
 			operation.coordinator_group_id !== input.coordinatorGroupId ||
 			operation.reviewed_project_set_digest !== input.reviewedProjectSetDigest
 		) {
 			throw new Error("operation_scope_mismatch");
 		}
+		const inviterDeviceIds = parsePersistedInviterDeviceIds(operation.inviter_device_ids_json);
 		const localProjects = (
 			db
 				.prepare(`SELECT canonical_project_identity, display_name, existing_memory_count
@@ -607,6 +661,21 @@ export function reconcileShareOperationAcceptance(
 			input.consumedAt,
 			input.coordinatorGroupId,
 		);
+		const inviterDevices = inviterDeviceIds.map((deviceId) => ({
+			deviceId,
+			displayName: inviterDeviceDisplayName(db, deviceId),
+		}));
+		commitDirectProjectSharePolicyInTransaction(db, {
+			operationId: operation.operation_id,
+			inviterIdentityId: operation.inviter_actor_id,
+			inviterDevices,
+			recipientIdentityId: input.recipientActorId,
+			recipientDeviceId: input.recipientDeviceId,
+			recipientDevicePublicKey: input.recipientPublicKey,
+			recipientDeviceDisplayName: input.recipientDeviceDisplayName,
+			canonicalProjectIdentities: acceptedProjects.map((project) => project.canonical_identity),
+			now: input.consumedAt,
+		});
 		for (const stepKey of ["invite_consumption", "person_device_link"]) {
 			db.prepare(`UPDATE share_operation_steps SET status = 'completed', attempt_count = 1,
 					started_at = COALESCE(started_at, ?), completed_at = ?, last_attempt_at = ?,
@@ -621,26 +690,4 @@ export function reconcileShareOperationAcceptance(
 		}
 	});
 	reconcile();
-	const onboardingRequest = {
-		version: 1 as const,
-		journey: "direct_project" as const,
-		invitationId: input.operationId,
-		identityId: input.recipientActorId,
-		deviceId: input.recipientDeviceId,
-		devicePublicKey: input.recipientPublicKey,
-		deviceDisplayName: input.recipientDeviceDisplayName,
-		canonicalProjectIdentities: acceptedProjects.map((project) => project.canonical_identity),
-	};
-	const preview = previewRecipientPolicyOnboarding(db, onboardingRequest);
-	const onboarding = commitRecipientPolicyOnboarding(
-		db,
-		{
-			...onboardingRequest,
-			reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
-		},
-		{ now: () => input.consumedAt },
-	);
-	if (onboarding.status !== "applied") {
-		throw new Error(onboarding.errorCode ?? "onboarding_commit_failed");
-	}
 }

--- a/packages/core/src/share-provisioning.test.ts
+++ b/packages/core/src/share-provisioning.test.ts
@@ -26,6 +26,9 @@ describe("exact project share provisioning", () => {
 	beforeEach(() => {
 		db = new Database(":memory:");
 		initTestSchema(db);
+		db.prepare(`INSERT INTO actors(
+			actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+		) VALUES ('actor-owner', 'Owner', 1, 'active', NULL, ?, ?)`).run(createdAt, createdAt);
 		const sourceScope = "source-space";
 		db.prepare(`INSERT INTO replication_scopes(
 			scope_id, label, kind, authority_type, coordinator_id, group_id,
@@ -129,6 +132,7 @@ describe("exact project share provisioning", () => {
 		const publicKey = "recipient-key";
 		reconcileShareOperationAcceptance(db, {
 			operationId,
+			localInviterActorId: "actor-owner",
 			coordinatorGroupId: "team",
 			reviewedProjectSetDigest: plan.reviewedProjectSetDigest,
 			recipientActorId: "actor-recipient",

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -11213,11 +11213,12 @@ describe("viewer-server", () => {
 						person_kind, pending_person_operation_id, teammate_name, history_policy,
 						reviewed_project_set_digest, coordinator_group_id, invite_token_digest,
 						invite_expires_at, created_at, updated_at
-					) VALUES (?, 'waiting_for_acceptance', ?, '[]', 'pending-brian', 'pending', ?,
+					) VALUES (?, 'waiting_for_acceptance', ?, ?, 'pending-brian', 'pending', ?,
 						'Brian', 'existing_and_future', ?, 'team-a', 'digest', '2099-01-01T00:00:00Z', ?, ?)`)
 					.run(
 						operationId,
 						store.actorId,
+						JSON.stringify([store.deviceId]),
 						operationId,
 						reviewedDigest,
 						"2026-07-20T00:00:00Z",
@@ -11401,6 +11402,13 @@ describe("viewer-server", () => {
 			const { app, ensureStore, cleanup } = createTestApp();
 			try {
 				const store = ensureStore();
+				store.db
+					.prepare(
+						`INSERT INTO actors(
+							actor_id, display_name, is_local, status, created_at, updated_at
+						 ) VALUES (?, 'Local inviter', 1, 'active', ?, ?)`,
+					)
+					.run(store.actorId, "2026-07-20T12:00:00.000Z", "2026-07-20T12:00:00.000Z");
 				const sessionId = insertTestSession(store.db);
 				store.db
 					.prepare("UPDATE sessions SET git_remote = ?, project = ? WHERE id = ?")
@@ -11434,6 +11442,7 @@ describe("viewer-server", () => {
 				});
 				core.reconcileShareOperationAcceptance(store.db, {
 					operationId: plan.operationId,
+					localInviterActorId: store.actorId,
 					coordinatorGroupId: "team-a",
 					reviewedProjectSetDigest: plan.reviewedProjectSetDigest,
 					recipientActorId: "actor-recipient-route",

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -911,6 +911,7 @@ async function reconcileProjectInviteAcceptance(
 		.get(operationId) as string | undefined;
 	if (!owner) throw new Error("operation_not_found");
 	if (owner !== store.actorId) throw new Error("operation_scope_mismatch");
+	ensureLocalActorRecord(store);
 	const { groupId, payload } = await coordinatorProjectInvitePayload(operationId);
 	if (payload.state === "waiting_for_acceptance") return { accepted: false, payload };
 	if (payload.state !== "accepted") {
@@ -950,6 +951,7 @@ async function reconcileProjectInviteAcceptance(
 	const projects = parseAcceptedProjectIntent(payload.projects);
 	reconcileShareOperationAcceptance(store.db, {
 		operationId,
+		localInviterActorId: store.actorId,
 		coordinatorGroupId: groupId,
 		reviewedProjectSetDigest: String(payload.reviewed_project_set_digest),
 		recipientActorId: String(payload.recipient_actor_id),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
+		maxWorkers: process.env.CI ? 1 : undefined,
 		projects: ["packages/*/vite.config.ts"],
 	},
 });


### PR DESCRIPTION
## Description

Fixes the direct-Project acceptance and recipient-authority interaction discovered by the expanded project-sharing E2E.

- persists reviewed inviter Identity/device/Project intent atomically with recipient intent
- retains only the inviter devices already recorded by the reviewed operation; source-scope bystanders are never inherited
- keeps migration-created compatible intent rows unchanged while rejecting cross-Identity or revoked bindings
- preserves exact replay idempotency, local inviter validation, lifecycle state, trust, and no-Team-membership semantics
- ensures recipient-policy reconciliation sees the complete owner-and-recipient graph before it can revoke or grant access

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation:

- focused onboarding/share-operation/viewer tests: 272 passed
- `pnpm run check` on the completed stack: 3,019 passed, 3 todo
- project-sharing E2E proves inviter retention plus exact existing/future recipient delivery
- independent security/correctness and maintainability reviews: no remaining blockers

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed; the approved design and ADR already define this invariant)
- [x] No new warnings introduced
