### PR TITLE
fix(sharing): harden recipient key binding

### DIFF
--- a/packages/core/src/recipient-policy-onboarding.test.ts
+++ b/packages/core/src/recipient-policy-onboarding.test.ts
@@ -7,6 +7,7 @@ import {
 	previewRecipientPolicyOnboarding,
 	type RecipientPolicyOnboardingPreviewRequestV1,
 } from "./recipient-policy-onboarding.js";
+import { fingerprintPublicKey } from "./sync-fingerprint.js";
 import { initTestSchema } from "./test-utils.js";
 
 const NOW = "2026-07-21T12:00:00.000Z";
@@ -629,6 +630,103 @@ describe("recipient-policy onboarding", () => {
 		).toMatchObject({ status: "conflict", errorCode: "device_binding_conflict", writeCount: 0 });
 		expect(
 			db.prepare("SELECT * FROM identity_devices WHERE device_id = ?").get(first.deviceId),
+		).toEqual(originalBinding);
+	});
+
+	it("key-binds a compatible exact-Project inviter device on recipient onboarding", () => {
+		db.prepare(
+			`INSERT INTO sync_device(device_id, public_key, fingerprint, created_at)
+			 VALUES ('device-new', 'public-key-a', ?, ?)`,
+		).run(fingerprintPublicKey("public-key-a"), NOW);
+		db.prepare(
+			`INSERT INTO identity_devices(
+			 identity_id, device_id, display_name, status, provenance, revision, migration_state,
+			 source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES ('identity-a', 'device-new', 'Original device', 'active',
+			 'exact_project_invite', 'exact-project-revision', 'user_managed',
+			 'exact-project-source', 'exact-project-idempotency', ?, ?)`,
+		).run(NOW, NOW);
+		const request = baseRequest({ invitationId: "invite-key-binding-transition" });
+		const preview = previewRecipientPolicyOnboarding(db, request);
+
+		const result = commitRecipientPolicyOnboarding(
+			db,
+			{ ...request, reviewedOnboardingDigest: preview.reviewedOnboardingDigest },
+			{ now: () => "2026-07-21T12:01:00.000Z" },
+		);
+
+		expect(result).toMatchObject({ status: "applied", writeCount: 1, idempotent: false });
+		expect(
+			db
+				.prepare(
+					`SELECT identity_id, device_id, display_name, status, provenance,
+					 migration_state, source_fingerprint, idempotency_key, created_at, updated_at
+					 FROM identity_devices WHERE device_id = 'device-new'`,
+				)
+				.get(),
+		).toMatchObject({
+			identity_id: "identity-a",
+			device_id: "device-new",
+			display_name: "Ada’s Laptop",
+			status: "active",
+			provenance: "recipient_invite",
+			migration_state: "user_managed",
+			created_at: NOW,
+			updated_at: "2026-07-21T12:01:00.000Z",
+		});
+
+		const changed = baseRequest({
+			invitationId: "invite-after-key-binding-transition",
+			devicePublicKey: "public-key-b",
+		});
+		const changedPreview = previewRecipientPolicyOnboarding(db, changed);
+		const bindingAfterTransition = db
+			.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-new'")
+			.get();
+
+		expect(
+			commitRecipientPolicyOnboarding(db, {
+				...changed,
+				reviewedOnboardingDigest: changedPreview.reviewedOnboardingDigest,
+			}),
+		).toMatchObject({ status: "conflict", errorCode: "device_binding_conflict", writeCount: 0 });
+		expect(
+			db.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-new'").get(),
+		).toEqual(bindingAfterTransition);
+	});
+
+	it.each([
+		null,
+		"different-public-key",
+	])("rejects an exact-Project device transition without matching local key %s", (localPublicKey) => {
+		if (localPublicKey) {
+			db.prepare(
+				`INSERT INTO sync_device(device_id, public_key, fingerprint, created_at)
+					 VALUES ('device-new', ?, ?, ?)`,
+			).run(localPublicKey, fingerprintPublicKey(localPublicKey), NOW);
+		}
+		db.prepare(
+			`INSERT INTO identity_devices(
+				 identity_id, device_id, display_name, status, provenance, revision, migration_state,
+				 source_fingerprint, idempotency_key, created_at, updated_at
+				 ) VALUES ('identity-a', 'device-new', 'Original device', 'active',
+				 'exact_project_invite', 'exact-project-revision', 'user_managed',
+				 'exact-project-source', 'exact-project-idempotency', ?, ?)`,
+		).run(NOW, NOW);
+		const originalBinding = db
+			.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-new'")
+			.get();
+		const request = baseRequest({ invitationId: "invite-rejected-key-transition" });
+		const preview = previewRecipientPolicyOnboarding(db, request);
+
+		expect(
+			commitRecipientPolicyOnboarding(db, {
+				...request,
+				reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+			}),
+		).toMatchObject({ status: "conflict", errorCode: "device_binding_conflict", writeCount: 0 });
+		expect(
+			db.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-new'").get(),
 		).toEqual(originalBinding);
 	});
 

--- a/packages/core/src/recipient-policy-onboarding.ts
+++ b/packages/core/src/recipient-policy-onboarding.ts
@@ -673,6 +673,37 @@ function rowWhere(key: Record<string, string>): { clause: string; parameters: st
 	};
 }
 
+function hasMatchingLocalDeviceKey(db: Database, expected: Record<string, string | null>): boolean {
+	const publicKey = db
+		.prepare("SELECT public_key FROM sync_device WHERE device_id = ?")
+		.pluck()
+		.get(expected.device_id);
+	if (typeof publicKey !== "string" || !publicKey.trim()) return false;
+	return (
+		expected.source_fingerprint ===
+		digest("recipient-onboarding-binding-v1", {
+			identityId: expected.identity_id,
+			deviceId: expected.device_id,
+			deviceKeyFingerprint: fingerprintPublicKey(publicKey),
+		})
+	);
+}
+
+function transitionExactProjectDevice(
+	db: Database,
+	row: IntentRow,
+	where: { clause: string; parameters: string[] },
+): void {
+	const entries = Object.entries(row.values).filter(([column]) => column !== "created_at");
+	const result = db
+		.prepare(
+			`UPDATE identity_devices SET ${entries.map(([column]) => `${column} = ?`).join(", ")}
+			 WHERE ${where.clause}`,
+		)
+		.run(...entries.map(([, value]) => value), ...where.parameters);
+	if (result.changes !== 1) throw new Error("device_binding_conflict");
+}
+
 function validateOrWriteRow(db: Database, row: IntentRow): boolean {
 	const idempotencyMatch = db
 		.prepare(`SELECT * FROM ${row.table} WHERE idempotency_key = ?`)
@@ -695,6 +726,16 @@ function validateOrWriteRow(db: Database, row: IntentRow): boolean {
 				hasConflictingFingerprint
 			) {
 				throw new Error("device_binding_conflict");
+			}
+			if (
+				keyMatch.provenance === "exact_project_invite" &&
+				expected.provenance === "recipient_invite"
+			) {
+				if (!hasMatchingLocalDeviceKey(db, expected)) {
+					throw new Error("device_binding_conflict");
+				}
+				transitionExactProjectDevice(db, row, where);
+				return true;
 			}
 			return false;
 		}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1329,6 +1329,9 @@ const TERMINAL_SHARE_MAINTENANCE_ERRORS = new Set([
 	"operation_device_binding_missing",
 	"operation_intent_invalid",
 	"provisioning_membership_plan_invalid",
+	"device_binding_conflict",
+	"intent_conflict",
+	"inviter_identity_conflict",
 ]);
 const TERMINAL_RECONCILIATION_ERRORS = new Set([
 	"coordinator_not_configured",
@@ -1345,6 +1348,9 @@ const TERMINAL_RECONCILIATION_ERRORS = new Set([
 	"recipient_device_identity_conflict",
 	"recipient_actor_conflict",
 	"pending_person_identity_conflict",
+	"device_binding_conflict",
+	"intent_conflict",
+	"inviter_identity_conflict",
 ]);
 
 function errorStatus(error: unknown): number | null {

--- a/packages/viewer-server/src/share-operation-maintenance.test.ts
+++ b/packages/viewer-server/src/share-operation-maintenance.test.ts
@@ -249,7 +249,7 @@ describe("advancePendingProjectShares", () => {
 		"coordinator_not_configured",
 		"team_sharing_not_configured",
 		"team_selection_ambiguous",
-	])("moves pre-step configuration failure %s to explicit recovery", async (errorCode) => {
+	])("moves deterministic advancement failure %s to explicit recovery", async (errorCode) => {
 		seedOperation({
 			id: "share-missing-coordinator",
 			state: "accepted",
@@ -374,6 +374,9 @@ describe("advancePendingProjectShares", () => {
 		"recipient_actor_conflict",
 		"pending_person_identity_conflict",
 		"operation_intent_mismatch",
+		"device_binding_conflict",
+		"intent_conflict",
+		"inviter_identity_conflict",
 	])("moves status-less deterministic conflict %s to explicit recovery", async (errorCode) => {
 		seedOperation({
 			id: "share-invalid-identity",


### PR DESCRIPTION
## Description

- Atomically upgrade compatible `exact_project_invite` device rows to key-bound `recipient_invite` rows only when the local `sync_device` public key matches.
- Reject missing or mismatched local key proof and preserve the original device row on conflict.
- Classify deterministic recipient-policy commit conflicts as terminal so automatic share maintenance moves operations to `needs_attention` instead of retrying forever.

Tracks `codemem-59fx`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional validation:
- `pnpm exec vitest run packages/core/src/recipient-policy-onboarding.test.ts packages/viewer-server/src/share-operation-maintenance.test.ts`
- CodeReviewer follow-up: no remaining blocker/high/medium findings
- Snyk Code full-repo scan reported findings only in the unrelated untracked `memorybench/` tree; narrower package rescans timed out

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed; this restores documented fail-closed behavior)
- [x] No new warnings introduced