### PR TITLE
test(e2e): add disposable sharing dogfood harness

### DIFF
--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -1,0 +1,24 @@
+x-dogfood-viewer: &dogfood-viewer
+  command:
+    - "sh"
+    - "-c"
+    - >-
+      pnpm --filter @codemem/ui build &&
+      exec pnpm exec tsx --conditions source packages/cli/src/index.ts
+      serve start --foreground --db-path /data/mem.sqlite --host 0.0.0.0 --port 38888
+
+services:
+  peer-a:
+    <<: *dogfood-viewer
+    ports:
+      - "127.0.0.1:38881:38888"
+
+  peer-b:
+    <<: *dogfood-viewer
+    ports:
+      - "127.0.0.1:38882:38888"
+
+  peer-c:
+    <<: *dogfood-viewer
+    ports:
+      - "127.0.0.1:38883:38888"

--- a/docs/plans/2026-07-23-disposable-sharing-dogfood-design.md
+++ b/docs/plans/2026-07-23-disposable-sharing-dogfood-design.md
@@ -1,0 +1,116 @@
+# Disposable sharing dogfood harness design
+
+**Date:** 2026-07-23
+**Status:** approved
+**Scope:** local interactive validation of Project-recipient sharing
+
+## Goal
+
+Provide a safe, repeatable Docker sandbox for manually exercising the real sharing UI without touching a developer's normal codemem database, config, keys, coordinator, or projects.
+
+The harness complements the automated `projectSharing` E2E scenario. It does not replace that promotion gate and does not automate invitation creation or acceptance, because those are the user journeys being dogfooded.
+
+## Chosen approach
+
+Extend the existing TypeScript E2E infrastructure with a separate persistent dogfood runner. Reuse Compose orchestration, fixture conventions, coordinator helpers, and artifact capture while keeping the harness out of the production CLI.
+
+Rejected alternatives:
+
+- Shell scripts would duplicate orchestration and error handling and be less portable.
+- Product-level `codemem dogfood` commands would expose test infrastructure as a supported CLI surface.
+- Fully API-driven or direct-database onboarding would bypass the UI workflows under evaluation.
+
+## Topology
+
+Run one fixed Compose project, `codemem-dogfood`, with isolated named volumes:
+
+- `coordinator`: local coordinator, reachable only inside Compose;
+- `peer-a`: owner profile, viewer at `http://127.0.0.1:38881`;
+- `peer-b`: teammate profile, viewer at `http://127.0.0.1:38882`;
+- `peer-c`: the teammate's fresh second-device profile, viewer at `http://127.0.0.1:38883`.
+
+The dogfood Compose override publishes only loopback viewer ports. Peer sync and coordinator traffic remain on the Compose network.
+
+## Initial state
+
+`setup` creates a deterministic baseline:
+
+- all three peers have separate databases, configs, and key directories;
+- the owner has one selected Project and one unrelated Project with recognizable synthetic memories;
+- the owner has an active local Identity and one test policy Team;
+- the teammate and second-device profiles are fresh;
+- the coordinator group exists and the owner is enrolled;
+- no invitation has been created or accepted;
+- no recipient has received Project access.
+
+The setup prints the three viewer URLs and an ordered checklist.
+
+## Manual journey
+
+The checklist guides the operator through the real UI:
+
+1. Assign the selected Project to the test Team.
+2. Create an exact-Project invitation on the owner and accept it on the teammate.
+3. Create a Team invitation and accept it on that same teammate profile.
+4. Create an add-device invitation for the teammate Identity and accept it on the fresh second-device profile.
+5. Add future selected and unrelated memories and verify exact delivery and isolation.
+6. Take the teammate offline, revoke access, observe a safe waiting state, restore it, and verify convergence.
+7. Restart recipient profiles and verify Identity and coordinator configuration persistence.
+
+The harness may seed infrastructure, identities, the empty Team, projects, and memories. It must not create, inspect, accept, or commit recipient invitations on the operator's behalf.
+
+## Commands
+
+The intended interface is:
+
+```text
+pnpm run dogfood -- setup [--build] [--reset]
+pnpm run dogfood -- status
+pnpm run dogfood -- add-future selected|unrelated
+pnpm run dogfood -- offline teammate|second-device
+pnpm run dogfood -- online teammate|second-device
+pnpm run dogfood -- restart teammate|second-device
+pnpm run dogfood -- snapshot
+pnpm run dogfood -- logs
+pnpm run dogfood -- cleanup
+```
+
+`status` reports container health, viewer URLs, and safe high-level state. `snapshot` writes diagnostic API responses and database copies under `.tmp/dogfood/` without printing secrets.
+
+## State and safety
+
+- Store harness metadata and artifacts only under ignored `.tmp/dogfood/`.
+- Never discover or use the normal user database, config, or key paths.
+- Use only synthetic names, remotes, projects, and memory text.
+- Bind viewer ports to `127.0.0.1`.
+- Use the existing test-only coordinator secret; never persist or print real credentials.
+- `setup` fails if the fixed sandbox is already running unless `--reset` is explicit.
+- `cleanup` is idempotent and can remove only the fixed `codemem-dogfood` Compose project and its named volumes.
+- Do not accept arbitrary Compose project names or deletion paths.
+- Preserve diagnostics on failure instead of broad cleanup outside the sandbox.
+
+## Error handling
+
+Commands fail with a concise next action:
+
+- missing Docker or unavailable ports: report the prerequisite or conflicting port;
+- missing sandbox state: instruct the operator to run `setup`;
+- invalid lifecycle transition: leave the environment unchanged and print current status;
+- failed peer restart: capture Compose logs and preserve volumes;
+- failed fixture action: record command output under `.tmp/dogfood/` and do not mutate unrelated profiles.
+
+## Validation
+
+- Unit tests cover argument parsing, fixed-project guards, lifecycle state, generated checklist, and target validation.
+- Fixture tests prove selected and unrelated Project data remain distinct.
+- A local smoke runs `setup`, `status`, `snapshot`, and `cleanup` against Docker.
+- Existing E2E scenarios remain unchanged and continue to pass.
+- Normal TypeScript, Biome, and targeted Vitest checks cover touched code.
+
+## Non-goals
+
+- Production deployment or hosted coordinator validation.
+- Browser automation of invitation workflows.
+- Supporting arbitrary peer counts or Compose project names.
+- Importing real user exports or credentials.
+- Fixing dogfood findings inside the harness PR.

--- a/docs/plans/2026-07-23-disposable-sharing-dogfood-implementation.md
+++ b/docs/plans/2026-07-23-disposable-sharing-dogfood-implementation.md
@@ -1,0 +1,64 @@
+# Disposable sharing dogfood harness implementation plan
+
+**Date:** 2026-07-23
+**Design:** `docs/plans/2026-07-23-disposable-sharing-dogfood-design.md`
+
+## Delivery shape
+
+One focused PR adds the local harness, tests, and usage documentation. It does not modify recipient-policy production behavior.
+
+## 1. Compose support
+
+- Add a dogfood Compose override that publishes the three viewer ports on loopback.
+- Extend `ComposeManager` minimally to support multiple Compose files, the existing `bootstrap` profile, and bounded service lifecycle operations needed by `offline`, `online`, and `restart`.
+- Preserve all existing E2E call sites and defaults.
+
+Validation:
+
+- Unit-test generated Compose arguments and fixed project/profile behavior.
+- Run existing smoke and project-sharing scenarios after the compatibility change.
+
+## 2. Deterministic dogfood fixture
+
+- Add a fixture script that initializes peers, seeds the owner's selected/unrelated Projects and memories, and creates the empty test Team.
+- Add actions for selected/unrelated future memories and safe summaries.
+- Keep invitation and recipient edge mutations out of fixture actions.
+
+Validation:
+
+- Prove fixture actions are idempotent where expected.
+- Assert Project remotes, titles, and memory sets remain separated.
+
+## 3. Persistent runner
+
+- Add a TypeScript runner with strict parsing for `setup`, `status`, `add-future`, `offline`, `online`, `restart`, `snapshot`, `logs`, and `cleanup`.
+- Use the fixed `codemem-dogfood` Compose project and ignored `.tmp/dogfood/state.json` metadata.
+- During setup, initialize all peers, configure coordinator connectivity, enroll only the owner, start all viewers, wait for readiness, and print URLs/checklist.
+- Make setup refuse an active environment without `--reset`.
+- Make cleanup idempotent and fixed-target only.
+
+Validation:
+
+- Unit-test parser and lifecycle guards without Docker.
+- Test status/checklist output using injected command and filesystem dependencies.
+
+## 4. Diagnostics and operator workflow
+
+- Implement safe status summaries, API snapshots, database artifact copies, and Compose log capture.
+- Never include the coordinator admin secret or private host paths in normal output.
+- Add `package.json` scripts and document the workflow in `e2e/README.md`.
+
+Validation:
+
+- Run a Docker smoke: setup → status → add-future → snapshot → restart → cleanup.
+- Confirm cleanup removes only dogfood containers and volumes.
+- Confirm the normal local profile remains untouched.
+
+## 5. Final gates
+
+- `pnpm run tsc`
+- `pnpm run lint`
+- targeted dogfood/Compose tests
+- `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1 pnpm run e2e:smoke -- --json`
+- `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1 pnpm run e2e:project-sharing -- --json`
+- manual browser check that all three viewer URLs load and invitation actions remain operator-driven

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,6 +15,55 @@ This directory holds the first local Docker/Compose-based E2E harness for sync s
 - bootstrap scenario plus dirty-local refusal validation
 - seed modes: `empty`, `fixture-small`, `fixture-large`, `local-import`
 - automatic artifact capture under `.tmp/e2e-artifacts/`
+- disposable three-peer sharing dogfood sandbox
+
+## Disposable sharing dogfood sandbox
+
+Use the test-only runner to exercise the real sharing UI. It uses only synthetic, isolated state under `.tmp/dogfood/`; it never reads or changes a normal user database, config, keys, coordinator, or Projects. Invitations remain operator-driven: the fixture never creates, inspects, accepts, or commits them.
+
+Prerequisites: Docker Engine with the Compose plugin, available loopback ports `38881`–`38883`, and built images when using `--build`. Check Docker and a conflicting port with:
+
+```fish
+docker compose version
+lsof -nP -iTCP:38881 -sTCP:LISTEN
+```
+
+Set up the fixed `codemem-dogfood` sandbox:
+
+```fish
+pnpm run dogfood -- setup --build
+```
+
+Setup refuses existing dogfood state. Reset only that fixed sandbox when you intend to discard it:
+
+```fish
+pnpm run dogfood -- setup --reset
+```
+
+View the isolated peers at fixed loopback URLs:
+
+- Owner: `http://127.0.0.1:38881`
+- Teammate: `http://127.0.0.1:38882`
+- Second device: `http://127.0.0.1:38883`
+
+In the UI, assign the selected Project to the test Team; create and accept exact-Project then Team invitations on the teammate; create and accept an add-device invitation on the second device. Add selected and unrelated future memories, then verify delivery, isolation, offline revocation, recovery, and restart persistence.
+
+| Command | Use |
+| --- | --- |
+| `pnpm run dogfood -- status` | Show sandbox status and viewer URLs. |
+| `pnpm run dogfood -- add-future selected` | Add a synthetic future memory to the selected Project. |
+| `pnpm run dogfood -- add-future unrelated` | Add one to the unrelated Project. |
+| `pnpm run dogfood -- offline teammate` | Stop the teammate. |
+| `pnpm run dogfood -- online teammate` | Start the teammate. |
+| `pnpm run dogfood -- restart teammate` | Restart the teammate. |
+| `pnpm run dogfood -- offline second-device` | Stop the second device. |
+| `pnpm run dogfood -- online second-device` | Start the second device. |
+| `pnpm run dogfood -- restart second-device` | Restart the second device. |
+| `pnpm run dogfood -- snapshot` | Save redacted summaries and database copies. |
+| `pnpm run dogfood -- logs` | Capture Compose logs. |
+| `pnpm run dogfood -- cleanup` | Remove only `codemem-dogfood` containers, volumes, and `.tmp/dogfood/`. |
+
+Snapshots, copied databases, state, and logs stay under ignored `.tmp/dogfood/`. `cleanup` is idempotent and fixed-target only; it does not discover or delete normal local state.
 
 ## Run the smoke scenario
 

--- a/e2e/bin/dogfood.test.ts
+++ b/e2e/bin/dogfood.test.ts
@@ -1,0 +1,476 @@
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildManualChecklist,
+	buildOwnerSetupPlan,
+	createDogfoodRunner,
+	createRuntimePaths,
+	parseDogfoodCommand,
+	sanitizeDiagnosticText,
+	type DogfoodDependencies,
+	type DogfoodState,
+} from "./dogfood.js";
+
+const INITIAL_STATE: DogfoodState = {
+	version: 1,
+	createdAt: "2026-07-23T12:00:00.000Z",
+	services: {
+		"peer-a": "online",
+		"peer-b": "online",
+		"peer-c": "online",
+	},
+};
+
+function createHarness(initialState: DogfoodState | null = null) {
+	let state = initialState;
+	const output: string[] = [];
+	const dependencies: DogfoodDependencies = {
+		state: {
+			exists: vi.fn(() => state !== null),
+			read: vi.fn(() => {
+				if (!state) throw new Error("missing state");
+				return state;
+			}),
+			write: vi.fn((next) => {
+				state = next;
+			}),
+			remove: vi.fn(() => {
+				state = null;
+			}),
+		},
+		operations: {
+			resourcesExist: vi.fn(() => false),
+			up: vi.fn(),
+			down: vi.fn(),
+			ps: vi.fn(() => "peer-a running (healthy)"),
+			fixture: vi.fn((_service, action) => ({ ok: true, action })),
+			configureAndEnrollOwner: vi.fn(),
+			waitForViewers: vi.fn(async () => undefined),
+			stop: vi.fn(),
+			start: vi.fn(),
+			restart: vi.fn(),
+			copyDatabases: vi.fn(),
+			writeSnapshot: vi.fn(),
+			captureLogs: vi.fn(),
+		},
+		sanitizeDiagnostic: (message) => sanitizeDiagnosticText(message, "/repo"),
+		writeOutput: (message) => output.push(message),
+		now: () => "2026-07-23T12:00:00.000Z",
+	};
+	return { runner: createDogfoodRunner(dependencies), dependencies, output, getState: () => state };
+}
+
+describe("parseDogfoodCommand", () => {
+	it.each([
+		[["setup"], { name: "setup", build: false, reset: false }],
+		[["--", "setup"], { name: "setup", build: false, reset: false }],
+		[["setup", "--reset", "--build"], { name: "setup", build: true, reset: true }],
+		[["status"], { name: "status" }],
+		[["add-future", "selected"], { name: "add-future", project: "selected" }],
+		[["offline", "teammate"], { name: "offline", target: "teammate" }],
+		[["online", "second-device"], { name: "online", target: "second-device" }],
+		[["restart", "teammate"], { name: "restart", target: "teammate" }],
+		[["snapshot"], { name: "snapshot" }],
+		[["logs"], { name: "logs" }],
+		[["cleanup"], { name: "cleanup" }],
+		[["--help"], { name: "help" }],
+	] as const)("parses only the approved shape %#", (argv, expected) => {
+		expect(parseDogfoodCommand(argv)).toEqual(expected);
+	});
+
+	it.each([
+		[[]],
+		[["setup", "--force"]],
+		[["-h"]],
+		[["setup", "--build", "--build"]],
+		[["status", "--json"]],
+		[["add-future", "other"]],
+		[["offline", "owner"]],
+		[["online"]],
+		[["restart", "peer-b"]],
+		[["cleanup", "anything"]],
+		[["unknown"]],
+	])("rejects unsupported arguments %#", (argv) => {
+		expect(() => parseDogfoodCommand(argv)).toThrow("Usage:");
+	});
+});
+
+describe("fixed runtime paths", () => {
+	it("resolves both Compose files and dogfood artifacts from the repository root", () => {
+		const paths = createRuntimePaths("/repo");
+
+		expect(paths).toEqual({
+			projectName: "codemem-dogfood",
+			composeFiles: [
+				resolve("/repo", "docker-compose.e2e.yml"),
+				resolve("/repo", "docker-compose.dogfood.yml"),
+			],
+			artifactsDir: resolve("/repo", ".tmp/dogfood"),
+			statePath: resolve("/repo", ".tmp/dogfood/state.json"),
+		});
+	});
+
+	it("redacts repository paths and the fixed coordinator credential from diagnostics", () => {
+		expect(
+			sanitizeDiagnosticText(
+				"failed under /Users/example/codemem/.tmp/dogfood with e2e-admin-secret",
+				"/Users/example/codemem",
+			),
+		).toBe("failed under <repo>/.tmp/dogfood with <redacted>");
+	});
+
+	it("redacts every hostile repetition instead of only the first occurrence", () => {
+		const diagnostic = [
+			"/private/repo/.tmp/dogfood e2e-admin-secret",
+			"/private/repo/state.json e2e-admin-secret",
+		].join("\n");
+
+		expect(sanitizeDiagnosticText(diagnostic, "/private/repo")).toBe(
+			"<repo>/.tmp/dogfood <redacted>\n<repo>/state.json <redacted>",
+		);
+	});
+
+	it("builds an owner-only coordinator setup plan", () => {
+		const plan = buildOwnerSetupPlan({
+			device_id: "owner-device",
+			fingerprint: "owner-fingerprint",
+			public_key: "owner-public-key",
+		});
+
+		expect(plan.service).toBe("peer-a");
+		expect(plan.restartService).toBe("peer-a");
+		expect(plan.config.sync_advertise).toBe("http://peer-a:7337");
+		expect(plan.enrollmentCommand).toContain("owner-device");
+		expect(JSON.stringify(plan)).not.toMatch(/peer-b|peer-c|invite/u);
+	});
+});
+
+describe("dogfood runner", () => {
+	it("refuses setup when fixed state exists without mutating the environment", async () => {
+		const { runner, dependencies } = createHarness(INITIAL_STATE);
+
+		await expect(runner.run({ name: "setup", build: false, reset: false })).rejects.toThrow(
+			"already exists",
+		);
+		expect(dependencies.operations.up).not.toHaveBeenCalled();
+		expect(dependencies.operations.down).not.toHaveBeenCalled();
+		expect(dependencies.operations.resourcesExist).not.toHaveBeenCalled();
+	});
+
+	it("refuses setup when fixed Compose resources exist without metadata", async () => {
+		const { runner, dependencies } = createHarness();
+		vi.mocked(dependencies.operations.resourcesExist).mockReturnValue(true);
+
+		await expect(runner.run({ name: "setup", build: false, reset: false })).rejects.toThrow(
+			"resources already exist",
+		);
+		expect(dependencies.operations.up).not.toHaveBeenCalled();
+		expect(dependencies.operations.down).not.toHaveBeenCalled();
+		expect(dependencies.state.write).not.toHaveBeenCalled();
+	});
+
+	it("checks fixed resources before a fresh successful setup", async () => {
+		const { runner, dependencies, output, getState } = createHarness();
+
+		await runner.run({ name: "setup", build: false, reset: false });
+
+		expect(dependencies.operations.resourcesExist).toHaveBeenCalledTimes(1);
+		expect(dependencies.operations.down).not.toHaveBeenCalled();
+		expect(getState()?.services).toEqual(INITIAL_STATE.services);
+		expect(output).toHaveLength(1);
+		expect(
+			vi.mocked(dependencies.operations.resourcesExist).mock.invocationCallOrder[0] ?? 0,
+		).toBeLessThan(vi.mocked(dependencies.operations.up).mock.invocationCallOrder[0] ?? 0);
+	});
+
+	it("resets only the fixed sandbox before deterministic setup", async () => {
+		const { runner, dependencies, getState } = createHarness(INITIAL_STATE);
+
+		await runner.run({ name: "setup", build: true, reset: true });
+
+		expect(dependencies.operations.down).toHaveBeenCalledTimes(1);
+		expect(dependencies.operations.up).toHaveBeenCalledWith(true);
+		expect(dependencies.operations.fixture).toHaveBeenNthCalledWith(1, "peer-a", "setup-owner");
+		expect(dependencies.operations.fixture).toHaveBeenNthCalledWith(2, "peer-b", "setup-teammate");
+		expect(dependencies.operations.fixture).toHaveBeenNthCalledWith(
+			3,
+			"peer-c",
+			"setup-second-device",
+		);
+		expect(dependencies.operations.configureAndEnrollOwner).toHaveBeenCalledTimes(1);
+		expect(dependencies.operations.waitForViewers).toHaveBeenCalledTimes(1);
+		expect(getState()?.services).toEqual(INITIAL_STATE.services);
+		const order = [
+			vi.mocked(dependencies.operations.down).mock.invocationCallOrder[0],
+			vi.mocked(dependencies.state.remove).mock.invocationCallOrder[0],
+			vi.mocked(dependencies.operations.up).mock.invocationCallOrder[0],
+			vi.mocked(dependencies.operations.fixture).mock.invocationCallOrder.at(-1),
+			vi.mocked(dependencies.operations.configureAndEnrollOwner).mock.invocationCallOrder[0],
+			vi.mocked(dependencies.operations.waitForViewers).mock.invocationCallOrder[0],
+			vi.mocked(dependencies.state.write).mock.invocationCallOrder[0],
+		];
+		expect(order).toEqual(order.toSorted((left, right) => (left ?? 0) - (right ?? 0)));
+	});
+
+	it.each([
+		"inspection",
+		"up",
+		"owner-fixture",
+		"teammate-fixture",
+		"second-device-fixture",
+		"enrollment",
+		"readiness",
+	] as const)(
+		"does not persist success state or print a checklist when %s fails",
+		async (stage) => {
+			const { runner, dependencies, output, getState } = createHarness();
+			const failure = new Error(`${stage} failed`);
+			if (stage === "inspection") {
+				vi.mocked(dependencies.operations.resourcesExist).mockImplementation(() => {
+					throw failure;
+				});
+			}
+			if (stage === "up") {
+				vi.mocked(dependencies.operations.up).mockImplementation(() => {
+					throw failure;
+				});
+			}
+			if (stage.endsWith("-fixture")) {
+				const failedAction = `setup-${stage.replace("-fixture", "")}`;
+				vi.mocked(dependencies.operations.fixture).mockImplementation((_service, action) => {
+					if (action === failedAction) {
+						throw failure;
+					}
+					return { ok: true, action };
+				});
+			}
+			if (stage === "enrollment") {
+				vi.mocked(dependencies.operations.configureAndEnrollOwner).mockImplementation(() => {
+					throw failure;
+				});
+			}
+			if (stage === "readiness") {
+				vi.mocked(dependencies.operations.waitForViewers).mockRejectedValue(failure);
+			}
+
+			await expect(runner.run({ name: "setup", build: false, reset: false })).rejects.toThrow(
+				`${stage} failed`,
+			);
+			expect(dependencies.state.write).not.toHaveBeenCalled();
+			expect(getState()).toBeNull();
+			expect(output).toEqual([]);
+		},
+	);
+
+	it("preserves state and does not start setup when reset teardown fails", async () => {
+		const { runner, dependencies, output, getState } = createHarness(INITIAL_STATE);
+		vi.mocked(dependencies.operations.down).mockImplementation(() => {
+			throw new Error("teardown failed");
+		});
+
+		await expect(runner.run({ name: "setup", build: false, reset: true })).rejects.toThrow(
+			"teardown failed",
+		);
+		expect(dependencies.state.remove).not.toHaveBeenCalled();
+		expect(dependencies.operations.up).not.toHaveBeenCalled();
+		expect(getState()).toEqual(INITIAL_STATE);
+		expect(output).toEqual([]);
+	});
+
+	it("adds future memories only through the owner fixture action", async () => {
+		const { runner, dependencies } = createHarness(INITIAL_STATE);
+
+		await runner.run({ name: "add-future", project: "unrelated" });
+
+		expect(dependencies.operations.fixture).toHaveBeenCalledWith(
+			"peer-a",
+			"add-future-unrelated",
+		);
+	});
+
+	it("reports fixed viewer URLs and redacts hostile Compose diagnostics", async () => {
+		const { runner, dependencies, output } = createHarness(INITIAL_STATE);
+		vi.mocked(dependencies.operations.ps).mockReturnValue(
+			"/repo/.tmp/dogfood e2e-admin-secret /repo e2e-admin-secret",
+		);
+
+		await runner.run({ name: "status" });
+
+		expect(output.join("\n")).toContain("http://127.0.0.1:38881");
+		expect(output.join("\n")).toContain("<repo>/.tmp/dogfood <redacted> <repo> <redacted>");
+		expect(output.join("\n")).not.toContain("/repo");
+		expect(output.join("\n")).not.toContain("e2e-admin-secret");
+	});
+
+	it("maps lifecycle targets to fixed peer services", async () => {
+		const { runner, dependencies, getState } = createHarness(INITIAL_STATE);
+
+		await runner.run({ name: "offline", target: "teammate" });
+		await runner.run({ name: "restart", target: "second-device" });
+
+		expect(dependencies.operations.stop).toHaveBeenCalledWith("peer-b");
+		expect(dependencies.operations.restart).toHaveBeenCalledWith("peer-c");
+		expect(getState()?.services["peer-b"]).toBe("offline");
+	});
+
+	it("brings an offline target online once and refuses an already-online target", async () => {
+		const offlineState: DogfoodState = {
+			...INITIAL_STATE,
+			services: { ...INITIAL_STATE.services, "peer-c": "offline" },
+		};
+		const { runner, dependencies, getState } = createHarness(offlineState);
+
+		await runner.run({ name: "online", target: "second-device" });
+		await expect(runner.run({ name: "online", target: "second-device" })).rejects.toThrow(
+			"already online",
+		);
+		expect(dependencies.operations.start).toHaveBeenCalledTimes(1);
+		expect(dependencies.operations.start).toHaveBeenCalledWith("peer-c");
+		expect(getState()?.services["peer-c"]).toBe("online");
+	});
+
+	it.each([
+		["offline", "stop", INITIAL_STATE],
+		[
+			"online",
+			"start",
+			{
+				...INITIAL_STATE,
+				services: { ...INITIAL_STATE.services, "peer-b": "offline" },
+			},
+		],
+		["restart", "restart", INITIAL_STATE],
+	] as const)(
+		"preserves state when %s Compose mutation fails",
+		async (command, operation, state) => {
+			const { runner, dependencies, getState } = createHarness(state);
+			vi.mocked(dependencies.operations[operation]).mockImplementation(() => {
+				throw new Error(`${operation} failed`);
+			});
+
+			await expect(runner.run({ name: command, target: "teammate" })).rejects.toThrow(
+				`${operation} failed`,
+			);
+			expect(dependencies.state.write).not.toHaveBeenCalled();
+			expect(getState()).toEqual(state);
+		},
+	);
+
+	it("rejects invalid lifecycle transitions before Compose mutation", async () => {
+		const offlineState: DogfoodState = {
+			...INITIAL_STATE,
+			services: { ...INITIAL_STATE.services, "peer-b": "offline" },
+		};
+		const { runner, dependencies } = createHarness(offlineState);
+
+		await expect(runner.run({ name: "offline", target: "teammate" })).rejects.toThrow(
+			"already offline",
+		);
+		await expect(runner.run({ name: "restart", target: "teammate" })).rejects.toThrow(
+			"is offline",
+		);
+		expect(dependencies.operations.stop).not.toHaveBeenCalled();
+		expect(dependencies.operations.restart).not.toHaveBeenCalled();
+	});
+
+	it("captures snapshots without printing payloads or private paths", async () => {
+		const { runner, dependencies, output } = createHarness(INITIAL_STATE);
+
+		await runner.run({ name: "snapshot" });
+
+		expect(dependencies.operations.fixture).toHaveBeenCalledTimes(3);
+		expect(dependencies.operations.copyDatabases).toHaveBeenCalledTimes(1);
+		expect(dependencies.operations.writeSnapshot).toHaveBeenCalledTimes(1);
+		expect(output.join("\n")).toBe("Snapshot captured under .tmp/dogfood.");
+	});
+
+	it("snapshots an intentionally offline peer without executing inside it", async () => {
+		const state: DogfoodState = {
+			...INITIAL_STATE,
+			services: { ...INITIAL_STATE.services, "peer-b": "offline" },
+		};
+		const { runner, dependencies } = createHarness(state);
+
+		await runner.run({ name: "snapshot" });
+
+		expect(dependencies.operations.fixture).not.toHaveBeenCalledWith("peer-b", "summary");
+		expect(dependencies.operations.writeSnapshot).toHaveBeenCalledWith(
+			expect.objectContaining({
+				summaries: expect.objectContaining({ "peer-b": { status: "offline" } }),
+			}),
+		);
+	});
+
+	it("captures logs without forwarding raw Compose output", async () => {
+		const { runner, dependencies, output } = createHarness(INITIAL_STATE);
+
+		await runner.run({ name: "logs" });
+
+		expect(dependencies.operations.captureLogs).toHaveBeenCalledTimes(1);
+		expect(output).toEqual(["Logs captured under .tmp/dogfood."]);
+	});
+
+	it("does not report log capture success when Compose logs fail", async () => {
+		const { runner, dependencies, output } = createHarness(INITIAL_STATE);
+		vi.mocked(dependencies.operations.captureLogs).mockImplementation(() => {
+			throw new Error("logs failed");
+		});
+
+		await expect(runner.run({ name: "logs" })).rejects.toThrow("logs failed");
+		expect(output).toEqual([]);
+	});
+
+	it("cleans up twice idempotently even when state is absent", async () => {
+		const { runner, dependencies, output } = createHarness();
+
+		await runner.run({ name: "cleanup" });
+		await runner.run({ name: "cleanup" });
+
+		expect(dependencies.operations.down).toHaveBeenCalledTimes(2);
+		expect(dependencies.state.remove).toHaveBeenCalledTimes(2);
+		expect(output).toEqual([
+			"Dogfood sandbox cleaned up.",
+			"Dogfood sandbox cleaned up.",
+		]);
+	});
+
+	it("preserves state and artifacts when cleanup teardown fails", async () => {
+		const { runner, dependencies, output, getState } = createHarness(INITIAL_STATE);
+		vi.mocked(dependencies.operations.down).mockImplementation(() => {
+			throw new Error("teardown failed");
+		});
+
+		await expect(runner.run({ name: "cleanup" })).rejects.toThrow("teardown failed");
+		expect(dependencies.state.remove).not.toHaveBeenCalled();
+		expect(getState()).toEqual(INITIAL_STATE);
+		expect(output).toEqual([]);
+	});
+
+	it.each([
+		{ name: "status" },
+		{ name: "add-future", project: "selected" },
+		{ name: "offline", target: "teammate" },
+		{ name: "snapshot" },
+		{ name: "logs" },
+	] as const)("refuses $name mutation or diagnostics without state", async (command) => {
+		const { runner, dependencies } = createHarness();
+
+		await expect(runner.run(command)).rejects.toThrow("run setup first");
+		expect(dependencies.operations.fixture).not.toHaveBeenCalled();
+		expect(dependencies.operations.stop).not.toHaveBeenCalled();
+		expect(dependencies.operations.ps).not.toHaveBeenCalled();
+		expect(dependencies.operations.captureLogs).not.toHaveBeenCalled();
+	});
+});
+
+describe("manual checklist", () => {
+	it("prints all fixed viewer URLs and keeps invitations manual", () => {
+		const checklist = buildManualChecklist();
+
+		expect(checklist).toContain("http://127.0.0.1:38881");
+		expect(checklist).toContain("http://127.0.0.1:38882");
+		expect(checklist).toContain("http://127.0.0.1:38883");
+		expect(checklist).toContain("Create an exact-Project invitation in the owner UI");
+		expect(checklist).toContain("Accept the add-device invitation in the second-device UI");
+	});
+});

--- a/e2e/bin/dogfood.ts
+++ b/e2e/bin/dogfood.ts
@@ -1,0 +1,549 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { assertStatus } from "../lib/assert.js";
+import { ComposeManager } from "../lib/compose.js";
+import {
+	ADMIN_SECRET,
+	CLI_PREFIX,
+	GROUP_ID,
+	readPeerIdentity,
+	writePeerConfig,
+} from "../lib/coordinator.js";
+import type { ScenarioContext } from "../lib/scenario-context.js";
+import { waitFor } from "../lib/wait.js";
+import type { FixtureAction } from "../scripts/dogfood-sharing-fixture.js";
+
+const PROJECT_NAME = "codemem-dogfood";
+const SERVICES = ["peer-a", "peer-b", "peer-c"] as const;
+const VIEWER_URLS = {
+	owner: "http://127.0.0.1:38881",
+	teammate: "http://127.0.0.1:38882",
+	"second-device": "http://127.0.0.1:38883",
+} as const;
+const TARGET_SERVICES = {
+	teammate: "peer-b",
+	"second-device": "peer-c",
+} as const;
+const FIXTURE_COMMAND = [
+	"pnpm",
+	"exec",
+	"tsx",
+	"--conditions",
+	"source",
+	"e2e/scripts/dogfood-sharing-fixture.ts",
+] as const;
+
+type DogfoodService = (typeof SERVICES)[number];
+type DogfoodTarget = keyof typeof TARGET_SERVICES;
+type ProjectTarget = "selected" | "unrelated";
+type ServiceState = "online" | "offline";
+
+export type DogfoodCommand =
+	| { name: "setup"; build: boolean; reset: boolean }
+	| { name: "status" }
+	| { name: "add-future"; project: ProjectTarget }
+	| { name: "offline" | "online" | "restart"; target: DogfoodTarget }
+	| { name: "snapshot" | "logs" | "cleanup" | "help" };
+
+export interface DogfoodState {
+	version: 1;
+	createdAt: string;
+	services: Record<DogfoodService, ServiceState>;
+}
+
+export interface RuntimePaths {
+	projectName: typeof PROJECT_NAME;
+	composeFiles: [string, string];
+	artifactsDir: string;
+	statePath: string;
+}
+
+interface StateStore {
+	exists(): boolean;
+	read(): DogfoodState;
+	write(state: DogfoodState): void;
+	remove(): void;
+}
+
+interface DogfoodOperations {
+	resourcesExist(): boolean;
+	up(build: boolean): void;
+	down(): void;
+	ps(): string;
+	fixture(service: DogfoodService, action: FixtureAction): unknown;
+	configureAndEnrollOwner(): void;
+	waitForViewers(): Promise<void>;
+	stop(service: DogfoodService): void;
+	start(service: DogfoodService): void;
+	restart(service: DogfoodService): void;
+	copyDatabases(): void;
+	writeSnapshot(snapshot: Record<string, unknown>): void;
+	captureLogs(): void;
+}
+
+export interface DogfoodDependencies {
+	state: StateStore;
+	operations: DogfoodOperations;
+	sanitizeDiagnostic(message: string): string;
+	writeOutput(message: string): void;
+	now(): string;
+}
+
+export function buildOwnerSetupPlan(identity: {
+	device_id: string;
+	fingerprint: string;
+	public_key: string;
+}) {
+	return {
+		service: "peer-a" as const,
+		restartService: "peer-a" as const,
+		config: {
+			actor_display_name: "Dogfood Owner",
+			sync_device_name: "Dogfood Owner Device",
+			sync_enabled: true,
+			sync_host: "0.0.0.0",
+			sync_port: 7337,
+			sync_advertise: "http://peer-a:7337",
+			sync_interval_s: 2,
+			sync_coordinator_url: "http://coordinator:7347",
+			sync_coordinator_group: GROUP_ID,
+			sync_coordinator_admin_secret: ADMIN_SECRET,
+		},
+		groupCommand: [
+			...CLI_PREFIX,
+			"sync",
+			"coordinator",
+			"group-create",
+			GROUP_ID,
+			"--db-path",
+			"/data/coordinator.sqlite",
+		],
+		enrollmentCommand: [
+			...CLI_PREFIX,
+			"sync",
+			"coordinator",
+			"enroll-device",
+			GROUP_ID,
+			identity.device_id,
+			"--fingerprint",
+			identity.fingerprint,
+			"--public-key",
+			identity.public_key,
+			"--name",
+			"Dogfood Owner Device",
+			"--db-path",
+			"/data/coordinator.sqlite",
+			"--json",
+		],
+	};
+}
+
+const USAGE = `Usage: pnpm run dogfood -- <command>
+Commands:
+  setup [--build] [--reset]
+  status
+  add-future selected|unrelated
+  offline teammate|second-device
+  online teammate|second-device
+  restart teammate|second-device
+  snapshot
+  logs
+  cleanup`;
+
+function usageError(): never {
+	throw new Error(USAGE);
+}
+
+function parseSetup(flags: readonly string[]): DogfoodCommand {
+	if (
+		flags.some((flag) => flag !== "--build" && flag !== "--reset") ||
+		new Set(flags).size !== flags.length
+	) {
+		return usageError();
+	}
+	return { name: "setup", build: flags.includes("--build"), reset: flags.includes("--reset") };
+}
+
+export function parseDogfoodCommand(args: readonly string[]): DogfoodCommand {
+	const normalizedArgs = args[0] === "--" ? args.slice(1) : args;
+	const [name, ...values] = normalizedArgs;
+	if (name === "--help") {
+		if (values.length > 0) return usageError();
+		return { name: "help" };
+	}
+	if (name === "setup") return parseSetup(values);
+	if (["status", "snapshot", "logs", "cleanup"].includes(name ?? "")) {
+		if (values.length > 0) return usageError();
+		return { name: name as "status" | "snapshot" | "logs" | "cleanup" };
+	}
+	if (name === "add-future") {
+		if (values.length !== 1 || (values[0] !== "selected" && values[0] !== "unrelated")) {
+			return usageError();
+		}
+		return { name, project: values[0] };
+	}
+	if (name === "offline" || name === "online" || name === "restart") {
+		if (values.length !== 1 || (values[0] !== "teammate" && values[0] !== "second-device")) {
+			return usageError();
+		}
+		return { name, target: values[0] };
+	}
+	return usageError();
+}
+
+export function createRuntimePaths(repositoryRoot: string): RuntimePaths {
+	const artifactsDir = resolve(repositoryRoot, ".tmp/dogfood");
+	return {
+		projectName: PROJECT_NAME,
+		composeFiles: [
+			resolve(repositoryRoot, "docker-compose.e2e.yml"),
+			resolve(repositoryRoot, "docker-compose.dogfood.yml"),
+		],
+		artifactsDir,
+		statePath: resolve(artifactsDir, "state.json"),
+	};
+}
+
+export function sanitizeDiagnosticText(text: string, repositoryRoot: string): string {
+	return text
+		.split(repositoryRoot)
+		.join("<repo>")
+		.split(ADMIN_SECRET)
+		.join("<redacted>");
+}
+
+export function buildManualChecklist(): string {
+	return `Dogfood viewers:
+  Owner: ${VIEWER_URLS.owner}
+  Teammate: ${VIEWER_URLS.teammate}
+  Second device: ${VIEWER_URLS["second-device"]}
+
+Manual invitation checklist:
+  1. Assign the selected Project to the test Team in the owner UI.
+  2. Create an exact-Project invitation in the owner UI and accept it in the teammate UI.
+  3. Create a Team invitation in the owner UI and accept it in the same teammate profile.
+  4. Create an add-device invitation for the teammate Identity.
+  5. Accept the add-device invitation in the second-device UI.
+  6. Add selected and unrelated future memories and verify exact delivery and isolation.
+  7. Exercise offline revocation, recovery, and restart persistence manually.`;
+}
+
+function requireState(dependencies: DogfoodDependencies): DogfoodState {
+	if (!dependencies.state.exists()) {
+		throw new Error("Dogfood sandbox is not set up; run setup first.");
+	}
+	return dependencies.state.read();
+}
+
+function updatedServiceState(
+	state: DogfoodState,
+	service: DogfoodService,
+	status: ServiceState,
+): DogfoodState {
+	return { ...state, services: { ...state.services, [service]: status } };
+}
+
+async function runSetup(
+	dependencies: DogfoodDependencies,
+	command: Extract<DogfoodCommand, { name: "setup" }>,
+): Promise<void> {
+	if (!command.reset && dependencies.state.exists()) {
+		throw new Error("Dogfood sandbox state already exists; rerun setup with --reset.");
+	}
+	if (!command.reset && dependencies.operations.resourcesExist()) {
+		throw new Error("Dogfood sandbox resources already exist; rerun setup with --reset.");
+	}
+	if (command.reset) {
+		dependencies.operations.down();
+		dependencies.state.remove();
+	}
+	dependencies.operations.up(command.build);
+	dependencies.operations.fixture("peer-a", "setup-owner");
+	dependencies.operations.fixture("peer-b", "setup-teammate");
+	dependencies.operations.fixture("peer-c", "setup-second-device");
+	dependencies.operations.configureAndEnrollOwner();
+	await dependencies.operations.waitForViewers();
+	dependencies.state.write({
+		version: 1,
+		createdAt: dependencies.now(),
+		services: { "peer-a": "online", "peer-b": "online", "peer-c": "online" },
+	});
+	dependencies.writeOutput(buildManualChecklist());
+}
+
+function runLifecycle(
+	dependencies: DogfoodDependencies,
+	command: Extract<DogfoodCommand, { name: "offline" | "online" | "restart" }>,
+): void {
+	const state = requireState(dependencies);
+	const service = TARGET_SERVICES[command.target];
+	const current = state.services[service];
+	if (command.name === "offline") {
+		if (current === "offline") {
+			throw new Error(`${command.target} is already offline; no changes made.`);
+		}
+		dependencies.operations.stop(service);
+		dependencies.state.write(updatedServiceState(state, service, "offline"));
+		return;
+	}
+	if (command.name === "online") {
+		if (current === "online") {
+			throw new Error(`${command.target} is already online; no changes made.`);
+		}
+		dependencies.operations.start(service);
+		dependencies.state.write(updatedServiceState(state, service, "online"));
+		return;
+	}
+	if (current === "offline") throw new Error(`${command.target} is offline; run online first.`);
+	dependencies.operations.restart(service);
+}
+
+function statusOutput(state: DogfoodState, composeStatus: string): string {
+	return [
+		"Dogfood sandbox status:",
+		`  Owner: ${state.services["peer-a"]} — ${VIEWER_URLS.owner}`,
+		`  Teammate: ${state.services["peer-b"]} — ${VIEWER_URLS.teammate}`,
+		`  Second device: ${state.services["peer-c"]} — ${VIEWER_URLS["second-device"]}`,
+		"Compose containers:",
+		composeStatus.trim() || "  No container status returned.",
+	].join("\n");
+}
+
+export function createDogfoodRunner(dependencies: DogfoodDependencies) {
+	return {
+		async run(command: DogfoodCommand): Promise<void> {
+			if (command.name === "help") {
+				dependencies.writeOutput(USAGE);
+				return;
+			}
+			if (command.name === "cleanup") {
+				dependencies.operations.down();
+				dependencies.state.remove();
+				dependencies.writeOutput("Dogfood sandbox cleaned up.");
+				return;
+			}
+			if (command.name === "setup") return runSetup(dependencies, command);
+			if (command.name === "offline" || command.name === "online" || command.name === "restart") {
+				runLifecycle(dependencies, command);
+				return;
+			}
+			const state = requireState(dependencies);
+			if (command.name === "status") {
+				const composeStatus = dependencies.operations.ps();
+				dependencies.writeOutput(
+					statusOutput(state, dependencies.sanitizeDiagnostic(composeStatus)),
+				);
+				return;
+			}
+			if (command.name === "add-future") {
+				dependencies.operations.fixture("peer-a", `add-future-${command.project}`);
+				dependencies.writeOutput(`Added the fixed ${command.project} future memory.`);
+				return;
+			}
+			if (command.name === "logs") {
+				dependencies.operations.captureLogs();
+				dependencies.writeOutput("Logs captured under .tmp/dogfood.");
+				return;
+			}
+			const summaries = Object.fromEntries(
+				SERVICES.map((service) => [
+					service,
+					state.services[service] === "online"
+						? dependencies.operations.fixture(service, "summary")
+						: { status: "offline" },
+				]),
+			);
+			dependencies.operations.copyDatabases();
+			dependencies.operations.writeSnapshot({ capturedAt: dependencies.now(), state, summaries });
+			dependencies.writeOutput("Snapshot captured under .tmp/dogfood.");
+		},
+	};
+}
+
+function isDogfoodState(value: unknown): value is DogfoodState {
+	if (!value || typeof value !== "object") return false;
+	const candidate = value as Partial<DogfoodState>;
+	return (
+		candidate.version === 1 &&
+		typeof candidate.createdAt === "string" &&
+		SERVICES.every(
+			(service) =>
+				candidate.services?.[service] === "online" || candidate.services?.[service] === "offline",
+		)
+	);
+}
+
+function createStateStore(paths: RuntimePaths): StateStore {
+	return {
+		exists: () => existsSync(paths.statePath),
+		read: () => {
+			const parsed: unknown = JSON.parse(readFileSync(paths.statePath, "utf8"));
+			if (!isDogfoodState(parsed)) {
+				throw new Error("Dogfood state is invalid; run cleanup, then setup.");
+			}
+			return parsed;
+		},
+		write: (state) => {
+			mkdirSync(paths.artifactsDir, { recursive: true });
+			writeFileSync(paths.statePath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+		},
+		remove: () => rmSync(paths.artifactsDir, { recursive: true, force: true }),
+	};
+}
+
+function createContext(compose: ComposeManager, artifactsDir: string): ScenarioContext {
+	return {
+		compose,
+		artifactsDir,
+		keepStackOnFailure: true,
+		recordNote: () => undefined,
+		captureFailure: () => undefined,
+	};
+}
+
+function withBuildFlag(build: boolean, operation: () => void): void {
+	const previous = process.env.CODEMEM_E2E_BUILD;
+	try {
+		process.env.CODEMEM_E2E_BUILD = build ? "1" : "0";
+		operation();
+	} finally {
+		if (previous === undefined) delete process.env.CODEMEM_E2E_BUILD;
+		else process.env.CODEMEM_E2E_BUILD = previous;
+	}
+}
+
+function createOperations(paths: RuntimePaths): DogfoodOperations {
+	const compose = new ComposeManager({
+		composeFiles: paths.composeFiles,
+		profiles: ["bootstrap"],
+		artifactsDir: paths.artifactsDir,
+		projectName: paths.projectName,
+	});
+	const context = createContext(compose, paths.artifactsDir);
+	const ensureArtifacts = () => mkdirSync(resolve(paths.artifactsDir, "db"), { recursive: true });
+	return {
+		resourcesExist: () => {
+			ensureArtifacts();
+			return compose.hasProjectResources("dogfood-resources");
+		},
+		up: (build) => {
+			ensureArtifacts();
+			withBuildFlag(build, () => compose.up([...SERVICES, "coordinator"], "01-compose-up"));
+		},
+		down: () => {
+			ensureArtifacts();
+			compose.down("compose-down");
+		},
+		ps: () => {
+			ensureArtifacts();
+			return compose.ps("status-compose-ps").stdout;
+		},
+		fixture: (service, action) => {
+			ensureArtifacts();
+			const result = compose.exec(
+				service,
+				[...FIXTURE_COMMAND, "--action", action],
+				`fixture-${service}-${action}`,
+				120_000,
+			);
+			assertStatus(result.status, 0, `${service} fixture action ${action} failed`);
+			return JSON.parse(result.stdout) as unknown;
+		},
+		configureAndEnrollOwner: () => {
+			const identity = readPeerIdentity(context, "peer-a", "read-owner-identity");
+			const plan = buildOwnerSetupPlan(identity);
+			writePeerConfig(
+				context,
+				plan.service,
+				plan.config,
+				"configure-owner",
+			);
+			const group = compose.exec(
+				"coordinator",
+				plan.groupCommand,
+				"create-owner-group",
+			);
+			assertStatus(group.status, 0, "failed to create dogfood coordinator group");
+			const enrolled = compose.exec(
+				"coordinator",
+				plan.enrollmentCommand,
+				"enroll-owner",
+			);
+			assertStatus(enrolled.status, 0, "failed to enroll dogfood owner");
+			compose.restart(plan.restartService, "restart-configured-owner");
+		},
+		waitForViewers: async () => {
+			await waitFor(
+				async () => {
+					const responses = await Promise.all(
+						Object.values(VIEWER_URLS).map((url) => fetch(`${url}/api/stats`)),
+					);
+					if (responses.some((response) => response.status !== 200)) {
+						throw new Error("one or more viewers are not ready");
+					}
+				},
+				{ description: "dogfood viewers", timeoutMs: 120_000, intervalMs: 2_000 },
+			);
+		},
+		stop: (service) => compose.stop(service, `offline-${service}`),
+		start: (service) => compose.start(service, `online-${service}`),
+		restart: (service) => compose.restart(service, `restart-${service}`),
+		copyDatabases: () => {
+			ensureArtifacts();
+			for (const service of SERVICES) {
+				compose.copyFromContainer(
+					`${service}:/data/mem.sqlite`,
+					resolve(paths.artifactsDir, "db", `${service}.sqlite`),
+					`snapshot-${service}-db`,
+					false,
+				);
+			}
+			compose.copyFromContainer(
+				"coordinator:/data/coordinator.sqlite",
+				resolve(paths.artifactsDir, "db", "coordinator.sqlite"),
+				"snapshot-coordinator-db",
+				false,
+			);
+		},
+		writeSnapshot: (snapshot) => {
+			ensureArtifacts();
+			writeFileSync(
+				resolve(paths.artifactsDir, "snapshot.json"),
+				`${JSON.stringify(snapshot, null, 2)}\n`,
+				"utf8",
+			);
+		},
+		captureLogs: () => {
+			ensureArtifacts();
+			compose.logs("dogfood-logs");
+		},
+	};
+}
+
+function createRuntimeDependencies(repositoryRoot: string): DogfoodDependencies {
+	const paths = createRuntimePaths(repositoryRoot);
+	return {
+		state: createStateStore(paths),
+		operations: createOperations(paths),
+		sanitizeDiagnostic: (message) => sanitizeDiagnosticText(message, repositoryRoot),
+		writeOutput: (message) => process.stdout.write(`${message}\n`),
+		now: () => new Date().toISOString(),
+	};
+}
+
+async function main(): Promise<void> {
+	const command = parseDogfoodCommand(process.argv.slice(2));
+	const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+	await createDogfoodRunner(createRuntimeDependencies(repositoryRoot)).run(command);
+}
+
+const entrypoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (entrypoint === import.meta.url) {
+	void main().catch((error) => {
+		const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+		const message = error instanceof Error ? error.message : String(error);
+		process.stderr.write(`${sanitizeDiagnosticText(message, repositoryRoot)}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/e2e/lib/compose.test.ts
+++ b/e2e/lib/compose.test.ts
@@ -1,0 +1,255 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	ComposeManager,
+	type RunCommandOptions,
+	type RunCommandResult,
+} from "./compose.js";
+
+const SUCCESS: RunCommandResult = {
+	command: "docker compose",
+	status: 0,
+	stdout: "",
+	stderr: "",
+	durationMs: 1,
+};
+
+function createCommandRunner() {
+	return vi.fn((_command: string, _args: string[], _options: RunCommandOptions) => SUCCESS);
+}
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe("ComposeManager", () => {
+	it("preserves the legacy composeFile up arguments and defaults", () => {
+		vi.stubEnv("CODEMEM_E2E_BUILD", "0");
+		const commandRunner = createCommandRunner();
+		const compose = new ComposeManager(
+			{
+				composeFile: "/repo/docker-compose.e2e.yml",
+				artifactsDir: "/artifacts",
+				projectName: "codemem-e2e-smoke",
+			},
+			commandRunner,
+		);
+
+		compose.up(["coordinator", "peer-a"], "compose-up");
+
+		expect(commandRunner).toHaveBeenCalledWith(
+			"docker",
+			[
+				"compose",
+				"-f",
+				"/repo/docker-compose.e2e.yml",
+				"-p",
+				"codemem-e2e-smoke",
+				"up",
+				"-d",
+				"coordinator",
+				"peer-a",
+			],
+			{
+				artifactsDir: "/artifacts",
+				artifactName: "compose-up",
+				timeoutMs: 600_000,
+			},
+		);
+	});
+
+	it("keeps multiple Compose files and fixed profiles in declared order", () => {
+		const commandRunner = createCommandRunner();
+		const compose = new ComposeManager(
+			{
+				composeFiles: [
+					"/repo/docker-compose.e2e.yml",
+					"/repo/docker-compose.dogfood.yml",
+				],
+				profiles: ["bootstrap", "diagnostics"],
+				artifactsDir: "/artifacts",
+				projectName: "codemem-dogfood",
+			},
+			commandRunner,
+		);
+
+		compose.ps("compose-ps");
+
+		expect(commandRunner.mock.calls[0]?.[1]).toEqual([
+			"compose",
+			"-f",
+			"/repo/docker-compose.e2e.yml",
+			"-f",
+			"/repo/docker-compose.dogfood.yml",
+			"-p",
+			"codemem-dogfood",
+			"--profile",
+			"bootstrap",
+			"--profile",
+			"diagnostics",
+			"ps",
+		]);
+	});
+
+	it("preserves the opt-in image build behavior", () => {
+		vi.stubEnv("CODEMEM_E2E_BUILD", "1");
+		const commandRunner = createCommandRunner();
+		const compose = new ComposeManager(
+			{
+				composeFile: "/repo/docker-compose.e2e.yml",
+				artifactsDir: "/artifacts",
+				projectName: "codemem-e2e-smoke",
+			},
+			commandRunner,
+		);
+
+		compose.up(["peer-a"], "compose-up");
+
+		expect(commandRunner.mock.calls[0]?.[1].slice(-4)).toEqual([
+			"up",
+			"-d",
+			"--build",
+			"peer-a",
+		]);
+	});
+
+	it("runs service lifecycle operations with fixed command bounds", () => {
+		const commandRunner = createCommandRunner();
+		const compose = new ComposeManager(
+			{
+				composeFile: "/repo/docker-compose.e2e.yml",
+				artifactsDir: "/artifacts",
+				projectName: "codemem-dogfood",
+			},
+			commandRunner,
+		);
+
+		compose.stop("peer-b", "stop-peer-b");
+		compose.start("peer-b", "start-peer-b");
+		compose.restart("peer-b", "restart-peer-b");
+
+		expect(commandRunner.mock.calls[0]?.[1].slice(-4)).toEqual([
+			"stop",
+			"--timeout",
+			"30",
+			"peer-b",
+		]);
+		expect(commandRunner.mock.calls[1]?.[1].slice(-2)).toEqual(["start", "peer-b"]);
+		expect(commandRunner.mock.calls[2]?.[1].slice(-4)).toEqual([
+			"restart",
+			"--timeout",
+			"30",
+			"peer-b",
+		]);
+		expect(commandRunner.mock.calls.map((call) => call[2].timeoutMs)).toEqual([
+			180_000, 180_000, 180_000,
+		]);
+	});
+
+	it("checks all fixed-project containers and labeled volumes with exact Docker arguments", () => {
+		const commandRunner = createCommandRunner()
+			.mockReturnValueOnce({ ...SUCCESS, stdout: "" })
+			.mockReturnValueOnce({ ...SUCCESS, stdout: "codemem-dogfood_peer-a-data\n" });
+		const compose = new ComposeManager(
+			{
+				composeFile: "/repo/docker-compose.e2e.yml",
+				artifactsDir: "/artifacts",
+				projectName: "codemem-dogfood",
+			},
+			commandRunner,
+		);
+
+		expect(compose.hasProjectResources("dogfood-resources")).toBe(true);
+		expect(commandRunner).toHaveBeenNthCalledWith(
+			1,
+			"docker",
+			[
+				"ps",
+				"-a",
+				"--filter",
+				"label=com.docker.compose.project=codemem-dogfood",
+				"--format",
+				"{{.ID}}",
+			],
+			{
+				artifactsDir: "/artifacts",
+				artifactName: "dogfood-resources-containers",
+				timeoutMs: 30_000,
+			},
+		);
+		expect(commandRunner).toHaveBeenNthCalledWith(
+			2,
+			"docker",
+			[
+				"volume",
+				"ls",
+				"--filter",
+				"label=com.docker.compose.project=codemem-dogfood",
+				"--format",
+				"{{.Name}}",
+			],
+			{
+				artifactsDir: "/artifacts",
+				artifactName: "dogfood-resources-volumes",
+				timeoutMs: 30_000,
+			},
+		);
+	});
+
+	it("reports no fixed-project resources only when containers and volumes are both absent", () => {
+		const commandRunner = createCommandRunner();
+		const compose = new ComposeManager(
+			{
+				composeFile: "/repo/docker-compose.e2e.yml",
+				artifactsDir: "/artifacts",
+				projectName: "codemem-dogfood",
+			},
+			commandRunner,
+		);
+
+		expect(compose.hasProjectResources("dogfood-resources")).toBe(false);
+		expect(commandRunner).toHaveBeenCalledTimes(2);
+	});
+
+	it("detects stopped fixed-project containers even when no labeled volume remains", () => {
+		const commandRunner = createCommandRunner()
+			.mockReturnValueOnce({ ...SUCCESS, stdout: "stopped-container-id\n" })
+			.mockReturnValueOnce({ ...SUCCESS, stdout: "" });
+		const compose = new ComposeManager(
+			{
+				composeFile: "/repo/docker-compose.e2e.yml",
+				artifactsDir: "/artifacts",
+				projectName: "codemem-dogfood",
+			},
+			commandRunner,
+		);
+
+		expect(compose.hasProjectResources("dogfood-resources")).toBe(true);
+		expect(commandRunner).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("docker-compose.dogfood.yml", () => {
+	it("publishes exactly one loopback viewer port per peer", () => {
+		const contents = readFileSync(resolve("docker-compose.dogfood.yml"), "utf8");
+		const lines = contents.split("\n");
+		const portBlocks = lines.flatMap((line, index) => {
+			if (line !== "    ports:") return [];
+			const entries: string[] = [];
+			for (const candidate of lines.slice(index + 1)) {
+				if (!candidate.startsWith("      ")) break;
+				entries.push(candidate.trim());
+			}
+			return [entries];
+		});
+
+		expect(portBlocks).toEqual([
+			['- "127.0.0.1:38881:38888"'],
+			['- "127.0.0.1:38882:38888"'],
+			['- "127.0.0.1:38883:38888"'],
+		]);
+		expect(contents).not.toMatch(/^\s*network_mode:\s*["']?host["']?\s*$/mu);
+		expect(contents).toContain("serve start --foreground");
+	});
+});

--- a/e2e/lib/compose.ts
+++ b/e2e/lib/compose.ts
@@ -2,6 +2,9 @@ import { spawnSync } from "node:child_process";
 import { writeCommandArtifact, type CommandRecord } from "./artifacts.js";
 
 const DEFAULT_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+const RESOURCE_INSPECTION_TIMEOUT_MS = 30_000;
+const SERVICE_OPERATION_TIMEOUT_MS = 180_000;
+const SERVICE_STOP_GRACE_SECONDS = "30";
 
 export interface RunCommandOptions {
 	artifactsDir: string;
@@ -42,28 +45,57 @@ export function runCommand(command: string, args: string[], options: RunCommandO
 }
 
 export interface ComposeManagerOptions {
-	composeFile: string;
+	composeFile?: string;
+	composeFiles?: readonly string[];
+	profiles?: readonly string[];
 	artifactsDir: string;
 	projectName: string;
 }
 
 export class ComposeManager {
-	constructor(private readonly options: ComposeManagerOptions) {}
+	private readonly composeFiles: readonly string[];
+	private readonly profiles: readonly string[];
+
+	constructor(
+		private readonly options: ComposeManagerOptions,
+		private readonly commandRunner: typeof runCommand = runCommand,
+	) {
+		this.composeFiles = [
+			...(options.composeFiles ?? (options.composeFile ? [options.composeFile] : [])),
+		];
+		this.profiles = [...(options.profiles ?? [])];
+		if (this.composeFiles.length === 0) {
+			throw new Error("ComposeManager requires composeFile or at least one composeFiles entry");
+		}
+	}
 
 	private composeArgs(args: string[]): string[] {
 		return [
 			"compose",
-			"-f",
-			this.options.composeFile,
+			...this.composeFiles.flatMap((composeFile) => ["-f", composeFile]),
 			"-p",
 			this.options.projectName,
+			...this.profiles.flatMap((profile) => ["--profile", profile]),
 			...args,
 		];
 	}
 
+	private serviceOperation(args: string[], artifactName: string): RunCommandResult {
+		return this.commandRunner("docker", this.composeArgs(args), {
+			artifactsDir: this.options.artifactsDir,
+			artifactName,
+			timeoutMs: SERVICE_OPERATION_TIMEOUT_MS,
+		});
+	}
+
 	up(services: string[], artifactName: string): RunCommandResult {
-		const args = ["up", "-d", ...(process.env.CODEMEM_E2E_BUILD === "1" ? ["--build"] : []), ...services];
-		return runCommand("docker", this.composeArgs(args), {
+		const args = [
+			"up",
+			"-d",
+			...(process.env.CODEMEM_E2E_BUILD === "1" ? ["--build"] : []),
+			...services,
+		];
+		return this.commandRunner("docker", this.composeArgs(args), {
 			artifactsDir: this.options.artifactsDir,
 			artifactName,
 			timeoutMs: 600_000,
@@ -71,7 +103,7 @@ export class ComposeManager {
 	}
 
 	down(artifactName: string, allowFailure = false): RunCommandResult {
-		return runCommand("docker", this.composeArgs(["down", "-v", "--remove-orphans"]), {
+		return this.commandRunner("docker", this.composeArgs(["down", "-v", "--remove-orphans"]), {
 			artifactsDir: this.options.artifactsDir,
 			artifactName,
 			timeoutMs: 180_000,
@@ -86,7 +118,7 @@ export class ComposeManager {
 		timeoutMs = 120_000,
 		allowFailure = false,
 	): RunCommandResult {
-		return runCommand(
+		return this.commandRunner(
 			"docker",
 			this.composeArgs(["exec", "-T", service, ...commandArgs]),
 			{
@@ -104,7 +136,7 @@ export class ComposeManager {
 		artifactName: string,
 		timeoutMs = 120_000,
 	): RunCommandResult {
-		return runCommand(
+		return this.commandRunner(
 			"docker",
 			this.composeArgs(["exec", "-d", service, ...commandArgs]),
 			{
@@ -116,14 +148,37 @@ export class ComposeManager {
 	}
 
 	ps(artifactName: string): RunCommandResult {
-		return runCommand("docker", this.composeArgs(["ps"]), {
+		return this.commandRunner("docker", this.composeArgs(["ps"]), {
 			artifactsDir: this.options.artifactsDir,
 			artifactName,
 		});
 	}
 
+	hasProjectResources(artifactName: string): boolean {
+		const projectFilter = `label=com.docker.compose.project=${this.options.projectName}`;
+		const containers = this.commandRunner(
+			"docker",
+			["ps", "-a", "--filter", projectFilter, "--format", "{{.ID}}"],
+			{
+				artifactsDir: this.options.artifactsDir,
+				artifactName: `${artifactName}-containers`,
+				timeoutMs: RESOURCE_INSPECTION_TIMEOUT_MS,
+			},
+		);
+		const volumes = this.commandRunner(
+			"docker",
+			["volume", "ls", "--filter", projectFilter, "--format", "{{.Name}}"],
+			{
+				artifactsDir: this.options.artifactsDir,
+				artifactName: `${artifactName}-volumes`,
+				timeoutMs: RESOURCE_INSPECTION_TIMEOUT_MS,
+			},
+		);
+		return containers.stdout.trim().length > 0 || volumes.stdout.trim().length > 0;
+	}
+
 	logs(artifactName: string, allowFailure = false): RunCommandResult {
-		return runCommand("docker", this.composeArgs(["logs", "--no-color"]), {
+		return this.commandRunner("docker", this.composeArgs(["logs", "--no-color"]), {
 			artifactsDir: this.options.artifactsDir,
 			artifactName,
 			timeoutMs: 180_000,
@@ -131,8 +186,26 @@ export class ComposeManager {
 		});
 	}
 
+	stop(service: string, artifactName: string): RunCommandResult {
+		return this.serviceOperation(
+			["stop", "--timeout", SERVICE_STOP_GRACE_SECONDS, service],
+			artifactName,
+		);
+	}
+
+	start(service: string, artifactName: string): RunCommandResult {
+		return this.serviceOperation(["start", service], artifactName);
+	}
+
+	restart(service: string, artifactName: string): RunCommandResult {
+		return this.serviceOperation(
+			["restart", "--timeout", SERVICE_STOP_GRACE_SECONDS, service],
+			artifactName,
+		);
+	}
+
 	copyFromContainer(containerPath: string, hostPath: string, artifactName: string, allowFailure = true) {
-		return runCommand(
+		return this.commandRunner(
 			"docker",
 			this.composeArgs(["cp", containerPath, hostPath]),
 			{
@@ -145,7 +218,7 @@ export class ComposeManager {
 	}
 
 	copyToContainer(hostPath: string, containerPath: string, artifactName: string, allowFailure = false) {
-		return runCommand(
+		return this.commandRunner(
 			"docker",
 			this.composeArgs(["cp", hostPath, containerPath]),
 			{

--- a/e2e/scripts/dogfood-sharing-fixture.test.ts
+++ b/e2e/scripts/dogfood-sharing-fixture.test.ts
@@ -1,0 +1,243 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { initDatabase, MemoryStore } from "../../packages/core/src/index.ts";
+import {
+	FIXTURE_ACTIONS,
+	parseFixtureAction,
+	runFixtureAction,
+} from "./dogfood-sharing-fixture.ts";
+
+const temporaryDirectories: string[] = [];
+
+function createStore(role: string): MemoryStore {
+	const directory = mkdtempSync(join(tmpdir(), `codemem-dogfood-${role}-`));
+	temporaryDirectories.push(directory);
+	vi.stubEnv("CODEMEM_CONFIG", join(directory, "missing-config.json"));
+	vi.stubEnv("CODEMEM_DEVICE_ID", `dogfood-${role}-device`);
+	vi.stubEnv("CODEMEM_ACTOR_ID", `dogfood-${role}-identity`);
+	vi.stubEnv("CODEMEM_ACTOR_DISPLAY_NAME", `Dogfood ${role}`);
+	vi.stubEnv("CODEMEM_EMBEDDING_DISABLED", "1");
+	const databasePath = join(directory, "mem.sqlite");
+	initDatabase(databasePath);
+	return new MemoryStore(databasePath);
+}
+
+function readSharingMutationCounts(store: MemoryStore): Record<string, number> {
+	return Object.fromEntries(
+		[
+			"policy_team_memberships",
+			"project_recipients",
+			"project_scope_mappings",
+			"replication_scopes",
+			"scope_memberships",
+			"share_operations",
+			"share_operation_projects",
+			"share_operation_steps",
+		].map((table) => [
+			table,
+			Number(store.db.prepare(`SELECT COUNT(*) FROM ${table}`).pluck().get()),
+		]),
+	);
+}
+
+const EMPTY_SHARING_MUTATION_COUNTS = {
+	policy_team_memberships: 0,
+	project_recipients: 0,
+	project_scope_mappings: 0,
+	replication_scopes: 0,
+	scope_memberships: 0,
+	share_operations: 0,
+	share_operation_projects: 0,
+	share_operation_steps: 0,
+};
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("parseFixtureAction", () => {
+	it("keeps fixture source free of invitation inspection and network calls", () => {
+		const source = readFileSync(resolve("e2e/scripts/dogfood-sharing-fixture.ts"), "utf8");
+
+		expect(source).not.toMatch(
+			/\b(?:fetch|request)\s*\(|coordinator|invite|project_recipients|share_operations/iu,
+		);
+	});
+
+	it("accepts only one explicit supported action", () => {
+		expect(parseFixtureAction(["--action", "setup-owner"])).toBe("setup-owner");
+	});
+
+	it.each([
+		[[]],
+		[["setup-owner"]],
+		[["--action", "setup-owner", "extra"]],
+		[["--action", "unsupported-policy-mutation"]],
+		[["--action", "create-invite"]],
+		[["--action", "accept-invite"]],
+		[["--action", "inspect-invite"]],
+		[["--action", "commit-invite"]],
+	])("rejects malformed or unsupported arguments: %j", (args) => {
+		expect(() => parseFixtureAction(args)).toThrow(
+			`Expected exactly --action <${FIXTURE_ACTIONS.join("|")}>`,
+		);
+	});
+});
+
+describe("runFixtureAction", () => {
+	it("sets up the owner idempotently with separated Projects and an empty Team", async () => {
+		const store = createStore("owner");
+		try {
+			await runFixtureAction(store, "setup-owner");
+			const summary = await runFixtureAction(store, "setup-owner");
+
+			expect(summary.profile.role).toBe("owner");
+			expect(summary.team).toMatchObject({ exists: true, member_count: 0 });
+			expect(summary.projects.selected.titles).toEqual([
+				"DOGFOOD selected existing",
+			]);
+			expect(summary.projects.unrelated.titles).toEqual([
+				"DOGFOOD unrelated existing",
+			]);
+			expect(summary.separation).toEqual({
+				distinct_remotes: true,
+				overlapping_titles: [],
+				isolated: true,
+			});
+		} finally {
+			store.close();
+		}
+	});
+
+	it.each(["teammate", "second-device"] as const)(
+		"initializes the %s profile idempotently without owner Projects or policy state",
+		async (role) => {
+			const store = createStore(role);
+			try {
+				await runFixtureAction(store, `setup-${role}`);
+				const summary = await runFixtureAction(store, `setup-${role}`);
+
+				expect(summary.profile.role).toBe(role);
+				expect(summary.projects.selected.memory_count).toBe(0);
+				expect(summary.projects.unrelated.memory_count).toBe(0);
+				expect(summary.team).toMatchObject({ exists: false, member_count: 0 });
+				expect(readSharingMutationCounts(store)).toEqual(EMPTY_SHARING_MUTATION_COUNTS);
+			} finally {
+				store.close();
+			}
+		},
+	);
+
+	it.each(["add-future-selected", "add-future-unrelated"] as const)(
+		"rejects %s before the owner baseline exists",
+		async (action) => {
+			const store = createStore("owner");
+			try {
+				await expect(runFixtureAction(store, action)).rejects.toThrow(
+					"Owner fixture is not initialized",
+				);
+			} finally {
+				store.close();
+			}
+		},
+	);
+
+	it("rejects changing an initialized profile to a different dogfood role", async () => {
+		const store = createStore("role-conflict");
+		try {
+			await runFixtureAction(store, "setup-teammate");
+
+			await expect(runFixtureAction(store, "setup-second-device")).rejects.toThrow(
+				"already initialized as teammate",
+			);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("keeps selected and unrelated Projects in exact separate sessions", async () => {
+		const store = createStore("owner");
+		try {
+			const summary = await runFixtureAction(store, "setup-owner");
+			const sessions = store.db
+				.prepare("SELECT project, cwd, git_remote FROM sessions ORDER BY project")
+				.all() as Array<{ project: string; cwd: string; git_remote: string }>;
+
+			expect(summary.projects.selected.remote).toBe(
+				"https://example.invalid/dogfood/selected.git",
+			);
+			expect(summary.projects.unrelated.remote).toBe(
+				"https://example.invalid/dogfood/unrelated.git",
+			);
+			expect(sessions).toEqual([
+				{
+					project: "dogfood-selected-project",
+					cwd: "/workspace/dogfood-selected-project",
+					git_remote: "https://example.invalid/dogfood/selected.git",
+				},
+				{
+					project: "dogfood-unrelated-project",
+					cwd: "/workspace/dogfood-unrelated-project",
+					git_remote: "https://example.invalid/dogfood/unrelated.git",
+				},
+			]);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("adds one idempotent future memory to each exact Project independently", async () => {
+		const store = createStore("owner");
+		try {
+			await runFixtureAction(store, "setup-owner");
+			await runFixtureAction(store, "add-future-selected");
+			await runFixtureAction(store, "add-future-selected");
+			const selected = await runFixtureAction(store, "summary");
+
+			expect(selected.projects.selected.titles).toEqual([
+				"DOGFOOD selected existing",
+				"DOGFOOD selected future",
+			]);
+			expect(selected.projects.unrelated.titles).toEqual([
+				"DOGFOOD unrelated existing",
+			]);
+
+			await runFixtureAction(store, "add-future-unrelated");
+			const unrelated = await runFixtureAction(store, "add-future-unrelated");
+
+			expect(unrelated.projects.selected.titles).toEqual(
+				selected.projects.selected.titles,
+			);
+			expect(unrelated.projects.unrelated.titles).toEqual([
+				"DOGFOOD unrelated existing",
+				"DOGFOOD unrelated future",
+			]);
+			expect(unrelated.separation.isolated).toBe(true);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("leaves invitation and recipient-policy tables empty after supported actions", async () => {
+		const store = createStore("owner");
+		try {
+			for (const action of [
+				"setup-owner",
+				"add-future-selected",
+				"add-future-unrelated",
+				"summary",
+			] as const) {
+				await runFixtureAction(store, action);
+			}
+
+			expect(readSharingMutationCounts(store)).toEqual(EMPTY_SHARING_MUTATION_COUNTS);
+		} finally {
+			store.close();
+		}
+	});
+});

--- a/e2e/scripts/dogfood-sharing-fixture.ts
+++ b/e2e/scripts/dogfood-sharing-fixture.ts
@@ -1,0 +1,283 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { initDatabase, MemoryStore } from "../../packages/core/src/index.ts";
+
+const DB_PATH = "/data/mem.sqlite";
+const FIXTURE_TIME = "2026-07-23T12:00:00.000Z";
+const TEAM_ID = "dogfood-policy-team";
+const TEAM_NAME = "Dogfood Empty Test Team";
+
+const PROJECTS = {
+	selected: {
+		project: "dogfood-selected-project",
+		remote: "https://example.invalid/dogfood/selected.git",
+		existingTitle: "DOGFOOD selected existing",
+		futureTitle: "DOGFOOD selected future",
+	},
+	unrelated: {
+		project: "dogfood-unrelated-project",
+		remote: "https://example.invalid/dogfood/unrelated.git",
+		existingTitle: "DOGFOOD unrelated existing",
+		futureTitle: "DOGFOOD unrelated future",
+	},
+} as const;
+
+const PROFILE_NAMES = {
+	owner: "Dogfood Owner",
+	teammate: "Dogfood Teammate",
+	"second-device": "Dogfood Teammate Second Device",
+} as const;
+
+export type DogfoodProfile = keyof typeof PROFILE_NAMES;
+
+export const FIXTURE_ACTIONS = [
+	"setup-owner",
+	"setup-teammate",
+	"setup-second-device",
+	"add-future-selected",
+	"add-future-unrelated",
+	"summary",
+] as const;
+
+export type FixtureAction = (typeof FIXTURE_ACTIONS)[number];
+
+interface ProjectSummary {
+	remote: string;
+	memory_count: number;
+	titles: string[];
+}
+
+export interface FixtureSummary {
+	ok: true;
+	action: FixtureAction;
+	profile: {
+		role: DogfoodProfile | null;
+		identity_id: string;
+		device_id: string;
+		display_name: string;
+	};
+	team: {
+		team_id: string;
+		display_name: string;
+		exists: boolean;
+		member_count: number;
+	};
+	projects: {
+		selected: ProjectSummary;
+		unrelated: ProjectSummary;
+	};
+	separation: {
+		distinct_remotes: boolean;
+		overlapping_titles: string[];
+		isolated: boolean;
+	};
+}
+
+export function parseFixtureAction(args: readonly string[]): FixtureAction {
+	const error = `Expected exactly --action <${FIXTURE_ACTIONS.join("|")}>`;
+	if (args.length !== 2 || args[0] !== "--action") throw new Error(error);
+	const value = args[1];
+	if (!FIXTURE_ACTIONS.includes(value as FixtureAction)) throw new Error(error);
+	return value as FixtureAction;
+}
+
+function profileFromDisplayName(displayName: string): DogfoodProfile | null {
+	const match = Object.entries(PROFILE_NAMES).find(([, expected]) => expected === displayName);
+	return (match?.[0] as DogfoodProfile | undefined) ?? null;
+}
+
+function ensureProfile(store: MemoryStore, role: DogfoodProfile): void {
+	const displayName = PROFILE_NAMES[role];
+	const existing = store.db
+		.prepare("SELECT display_name FROM actors WHERE actor_id = ?")
+		.get(store.actorId) as { display_name: string } | undefined;
+	const existingRole = existing ? profileFromDisplayName(existing.display_name) : null;
+	if (existingRole && existingRole !== role) {
+		throw new Error(`Dogfood profile is already initialized as ${existingRole}`);
+	}
+	store.db
+		.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES (?, ?, 1, 'active', ?, ?)
+			 ON CONFLICT(actor_id) DO UPDATE SET
+			 display_name = excluded.display_name, is_local = 1, status = 'active', updated_at = excluded.updated_at`,
+		)
+		.run(store.actorId, displayName, FIXTURE_TIME, FIXTURE_TIME);
+}
+
+function ensureEmptyTeam(store: MemoryStore): void {
+	store.db
+		.prepare(
+			`INSERT INTO policy_teams(
+			 team_id, display_name, status, provenance, revision, migration_state,
+			 source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES (?, ?, 'active', 'e2e', '1', 'native', NULL, ?, ?, ?)
+			 ON CONFLICT(team_id) DO UPDATE SET
+			 display_name = excluded.display_name, status = 'active', updated_at = excluded.updated_at`,
+		)
+		.run(TEAM_ID, TEAM_NAME, `team:${TEAM_ID}`, FIXTURE_TIME, FIXTURE_TIME);
+}
+
+function memoryExists(store: MemoryStore, remote: string, title: string): boolean {
+	return Boolean(
+		store.db
+			.prepare(
+				`SELECT 1
+				 FROM memory_items mi
+				 JOIN sessions s ON s.id = mi.session_id
+				 WHERE mi.active = 1 AND s.git_remote = ? AND mi.title = ?
+				 LIMIT 1`,
+			)
+			.get(remote, title),
+	);
+}
+
+function ensureMemory(
+	store: MemoryStore,
+	project: (typeof PROJECTS)[keyof typeof PROJECTS],
+	title: string,
+): void {
+	if (memoryExists(store, project.remote, title)) return;
+	const sessionId = store.startSession({
+		cwd: `/workspace/${project.project}`,
+		project: project.project,
+		gitRemote: project.remote,
+		gitBranch: "main",
+		user: "dogfood",
+		toolVersion: "dogfood-sharing-fixture",
+	});
+	store.remember(
+		sessionId,
+		"discovery",
+		title,
+		`${title}: synthetic content for the disposable sharing sandbox.`,
+		0.9,
+		["dogfood-sharing-fixture"],
+		{
+			visibility: "shared",
+			created_at: FIXTURE_TIME,
+			updated_at: FIXTURE_TIME,
+		},
+	);
+	store.endSession(sessionId, { fixture: title });
+}
+
+function assertOwnerBaseline(store: MemoryStore): void {
+	const teamExists = store.db
+		.prepare("SELECT 1 FROM policy_teams WHERE team_id = ?")
+		.get(TEAM_ID);
+	const baselineExists = Object.values(PROJECTS).every((project) =>
+		memoryExists(store, project.remote, project.existingTitle),
+	);
+	if (!teamExists || !baselineExists) {
+		throw new Error("Owner fixture is not initialized; run setup-owner first");
+	}
+}
+
+function projectSummary(store: MemoryStore, key: keyof typeof PROJECTS): ProjectSummary {
+	const project = PROJECTS[key];
+	const rows = store.db
+		.prepare(
+			`SELECT mi.title
+			 FROM memory_items mi
+			 JOIN sessions s ON s.id = mi.session_id
+			 WHERE mi.active = 1 AND s.git_remote = ?
+			 ORDER BY mi.title`,
+		)
+		.all(project.remote) as Array<{ title: string }>;
+	const titles = rows.map((row) => row.title);
+	return { remote: project.remote, memory_count: titles.length, titles };
+}
+
+export function buildSafeSummary(
+	store: MemoryStore,
+	action: FixtureAction,
+): FixtureSummary {
+	const selected = projectSummary(store, "selected");
+	const unrelated = projectSummary(store, "unrelated");
+	const selectedTitles = new Set(selected.titles);
+	const overlappingTitles = unrelated.titles.filter((title) => selectedTitles.has(title));
+	const actor = store.db
+		.prepare("SELECT display_name FROM actors WHERE actor_id = ?")
+		.get(store.actorId) as { display_name: string } | undefined;
+	const teamExists = Boolean(
+		store.db.prepare("SELECT 1 FROM policy_teams WHERE team_id = ?").get(TEAM_ID),
+	);
+	const memberCount = Number(
+		store.db
+			.prepare(
+				"SELECT COUNT(*) FROM policy_team_memberships WHERE team_id = ? AND status = 'active'",
+			)
+			.pluck()
+			.get(TEAM_ID),
+	);
+	return {
+		ok: true,
+		action,
+		profile: {
+			role: actor ? profileFromDisplayName(actor.display_name) : null,
+			identity_id: store.actorId,
+			device_id: store.deviceId,
+			display_name: actor?.display_name ?? store.actorDisplayName,
+		},
+		team: {
+			team_id: TEAM_ID,
+			display_name: TEAM_NAME,
+			exists: teamExists,
+			member_count: memberCount,
+		},
+		projects: { selected, unrelated },
+		separation: {
+			distinct_remotes: selected.remote !== unrelated.remote,
+			overlapping_titles: overlappingTitles,
+			isolated: selected.remote !== unrelated.remote && overlappingTitles.length === 0,
+		},
+	};
+}
+
+export async function runFixtureAction(
+	store: MemoryStore,
+	action: FixtureAction,
+): Promise<FixtureSummary> {
+	if (action === "setup-owner") {
+		ensureProfile(store, "owner");
+		ensureEmptyTeam(store);
+		ensureMemory(store, PROJECTS.selected, PROJECTS.selected.existingTitle);
+		ensureMemory(store, PROJECTS.unrelated, PROJECTS.unrelated.existingTitle);
+	}
+	if (action === "setup-teammate") ensureProfile(store, "teammate");
+	if (action === "setup-second-device") ensureProfile(store, "second-device");
+	if (action === "add-future-selected") {
+		assertOwnerBaseline(store);
+		ensureMemory(store, PROJECTS.selected, PROJECTS.selected.futureTitle);
+	}
+	if (action === "add-future-unrelated") {
+		assertOwnerBaseline(store);
+		ensureMemory(store, PROJECTS.unrelated, PROJECTS.unrelated.futureTitle);
+	}
+	await store.flushPendingVectorWrites();
+	return buildSafeSummary(store, action);
+}
+
+async function main(): Promise<void> {
+	process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+	const action = parseFixtureAction(process.argv.slice(2));
+	initDatabase(DB_PATH);
+	const store = new MemoryStore(DB_PATH);
+	try {
+		const summary = await runFixtureAction(store, action);
+		process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+	} finally {
+		store.close();
+	}
+}
+
+const entrypoint = process.argv[1]
+	? pathToFileURL(resolve(process.argv[1])).href
+	: null;
+if (entrypoint === import.meta.url) {
+	void main().catch((error) => {
+		process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "clean": "pnpm -r run clean && pnpm exec tsc --build --clean",
     "build": "pnpm -r run build",
+    "dogfood": "pnpm exec tsx e2e/bin/dogfood.ts",
     "e2e": "pnpm exec tsx e2e/bin/run-local.ts",
     "e2e:bootstrap": "pnpm exec tsx e2e/bin/run-local.ts bootstrap",
     "e2e:coordinator": "pnpm exec tsx e2e/bin/run-local.ts coordinator",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,16 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		maxWorkers: process.env.CI ? 1 : undefined,
-		projects: ["packages/*/vite.config.ts"],
+		projects: [
+			"packages/*/vite.config.ts",
+			{
+				extends: true,
+				test: {
+					name: "e2e-unit",
+					environment: "node",
+					include: ["e2e/**/*.test.ts"],
+				},
+			},
+		],
 	},
 });


### PR DESCRIPTION
## Description

- Add a persistent, disposable three-peer Docker sandbox for manually dogfooding Project-recipient sharing through the real viewer UI.
- Keep the sandbox fixed to `codemem-dogfood`, loopback ports `38881`–`38883`, isolated volumes, synthetic fixtures, and ignored `.tmp/dogfood/` artifacts.
- Add strict setup/status/future-memory/lifecycle/snapshot/log/cleanup commands with stale-resource guards and failure-safe teardown.
- Keep invitations operator-driven; fixture actions cannot inspect or mutate invitation/share-policy state.
- Register 86 hermetic E2E unit tests in the normal Vitest suite and document the workflow.

Tracks `codemem-4zwy`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional validation:
- `pnpm exec vitest run --project e2e-unit` — 86 tests passed
- `pnpm run check` — 166 files, 3,139 tests passed, 3 todo
- `pnpm run dogfood -- setup --build --reset` → `status` → `add-future selected` → `snapshot` → `restart teammate` → `cleanup`
- All three viewer `/api/stats` endpoints returned HTTP 200 after restart
- Cleanup left no `codemem-dogfood` containers or labeled volumes
- `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1 pnpm run e2e:smoke -- --json`
- `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1 pnpm run e2e:project-sharing -- --json`
- Targeted Snyk Code scan of `e2e/` found 0 issues
- CodeReviewer and TestEngineer final passes found no blocker/high/medium issues

The manual invitation journey remains intentionally unexecuted by the harness and is the next operator dogfood step.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched configured files; `e2e/` remains outside the existing Biome include)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced