### PR TITLE
fix(sharing): stabilize local identity bootstrap

### DIFF
--- a/docs/plans/2026-07-23-sharing-dogfood-stabilization-design.md
+++ b/docs/plans/2026-07-23-sharing-dogfood-stabilization-design.md
@@ -1,0 +1,64 @@
+# Sharing dogfood stabilization design
+
+**Date:** 2026-07-23
+**Status:** approved
+**Scope:** exact-Project onboarding correctness and recipient-facing UX
+
+## Goal
+
+Make the disposable three-peer sandbox prove a truthful, understandable sharing journey: direct exact-Project access, Team inheritance, and add-device inheritance. A fresh recipient must never see fallback identity values, a completed state must mean the intended data can sync, and normal invitation acceptance must not require manual navigation through Advanced controls.
+
+## Confirmed failures
+
+- A profile created before device identity initialization leaves a fallback `local:local` actor, then projects a second device-backed local Identity.
+- Invite inspection and import can reuse that stale fallback Identity, exposing internal values and causing `recipient_actor_conflict` on the inviter.
+- Exact-Project acceptance can enroll coordinator presence while inviter-side setup remains `needs_attention`; the recipient receives no Project data but sees an apparently healthy state.
+- The acceptance action promises to start syncing while the recipient remains configured with sync disabled.
+- Sharing can inspect exact-Project invitations but redirects users to an inaccurate Advanced Team administration dead end.
+- Recipient dialogs use an inconsistent close control and present review/result content as dense, repetitive text.
+
+## Design
+
+### Stable identity bootstrap
+
+Device identity is established before a local actor profile is persisted or projected. If a long-lived viewer store began with the fallback device, invite inspection/import refreshes and adopts the ensured device identity before deriving recipient identity or display defaults. Dogfood fixtures seed human-readable profile names against the stable Identity and assert that each peer has exactly one distinct active local Identity.
+
+### Truthful distributed acceptance
+
+Coordinator token consumption remains the durable acceptance boundary, but it is not described as completed Project delivery. Exact-Project onboarding reports a pending setup state until inviter-side acceptance, recipient-policy persistence, trust, and initial sync converge. Terminal failures remain actionable and visible instead of being hidden behind coordinator presence.
+
+An action labelled “Accept and start syncing” must enable the recipient data plane. If enabling cannot complete, the response and UI remain pending or failed rather than claiming success.
+
+### Normal invitation journey
+
+Sharing → Invitations owns preview and acceptance for Team-member, add-device, and current exact-Project invitations. Exact-Project review explicitly says the recipient receives direct access to the listed Projects and does not join a Team. Advanced retains legacy compatibility and manual pairing controls only.
+
+### Health semantics
+
+Coordinator presence, peer trust, sync enablement, onboarding progress, and data-plane health are separate signals. The primary Sync state is healthy only when sync is enabled and no onboarding or reconciliation blocker outranks it. Presence alone is labelled as enrolled/reachable, not Online.
+
+### Dialog hierarchy
+
+Recipient dialogs reuse the shared themed close control. Review states emphasize three answers: what is shared, with whom, and whether devices receive it now. Counts and write details become secondary. Result states use a completion-specific title and one success summary.
+
+## Delivery stack
+
+1. Stable identity bootstrap and dogfood fixture invariants.
+2. Truthful exact-Project acceptance and sync activation.
+3. Exact-Project acceptance in Sharing.
+4. Sync status truthfulness.
+5. Recipient dialog close treatment and information hierarchy.
+
+## Error handling
+
+- Identity refresh fails closed if a stable device identity cannot be established.
+- Acceptance distinguishes pending setup from terminal conflict.
+- Partial coordinator enrollment cannot render as completed Project delivery.
+- UI errors use actionable, non-internal language while safe codes remain available to diagnostics.
+
+## Validation
+
+- Focused core, viewer-server, UI, and dogfood fixture tests for every layer.
+- Full `pnpm run check` on the completed stack.
+- Fresh three-peer sandbox validation covering direct Project access, Team inheritance, add-device inheritance, selected/unrelated future memories, offline recovery, and restart persistence.
+- Independent code and test review before submission.

--- a/docs/plans/2026-07-23-sharing-dogfood-stabilization-implementation.md
+++ b/docs/plans/2026-07-23-sharing-dogfood-stabilization-implementation.md
@@ -1,0 +1,49 @@
+# Sharing dogfood stabilization implementation plan
+
+**Date:** 2026-07-23
+**Design:** `docs/plans/2026-07-23-sharing-dogfood-stabilization-design.md`
+
+## PR 1 — Stable identity bootstrap
+
+- Add regressions for fallback actor adoption and unique local Identity projection.
+- Ensure viewer invite inspection/import uses a stable ensured device Identity.
+- Initialize dogfood peer identities before profile fixture records.
+- Assert one distinct human-named local Identity per peer.
+- Validate focused core, viewer-server, and dogfood unit tests.
+
+## PR 2 — Truthful exact-Project acceptance
+
+- Add failure and success tests around coordinator acceptance versus inviter-side completion.
+- Enable data sync when exact-Project acceptance promises to start it.
+- Represent post-consumption Project setup as pending until convergence.
+- Surface terminal acceptance/provisioning failures to recipient and owner.
+- Prove selected existing data arrives and unrelated data remains absent.
+
+## PR 3 — Sharing invitation acceptance
+
+- Extend the normal invitation dialog to review exact-Project intent.
+- Accept the reviewed exact-Project invitation without repasting or Advanced navigation.
+- Explain direct access versus Team membership.
+- Preserve legacy-only fallback under Advanced.
+- Add Preact interaction, focus, and API request tests.
+
+## PR 4 — Sync status truthfulness
+
+- Derive primary status from sync enablement, onboarding/reconciliation blockers, trust, and presence in that order.
+- Replace false Online/no-work states with explicit pending, disabled, or needs-attention guidance.
+- Add status/view-model and rendered UI regressions.
+
+## PR 5 — Recipient dialog UX
+
+- Replace raw close buttons with the shared dialog close control.
+- Refactor review and result content into concise semantic summaries.
+- Remove repeated mutation/write messages from normal completion copy.
+- Verify keyboard, screen-reader, dark/light theme, long-name, and responsive behavior.
+
+## Final gate
+
+- Run focused tests after each PR slice.
+- Run `pnpm run check` on the full stack.
+- Run CodeReviewer, TestEngineer, and pragmatic maintainability review.
+- Reset and run the disposable sandbox from merged stack code.
+- Complete the full manual dogfood checklist and capture safe diagnostics before submission.

--- a/e2e/bin/dogfood.test.ts
+++ b/e2e/bin/dogfood.test.ts
@@ -43,7 +43,14 @@ function createHarness(initialState: DogfoodState | null = null) {
 			up: vi.fn(),
 			down: vi.fn(),
 			ps: vi.fn(() => "peer-a running (healthy)"),
-			fixture: vi.fn((_service, action) => ({ ok: true, action })),
+			fixture: vi.fn((service, action) => ({
+				ok: true,
+				action,
+				profile: {
+					identity_id: `identity-${service}`,
+					identity_invariant: { active_local_count: 1, human_named: true },
+				},
+			})),
 			configureAndEnrollOwner: vi.fn(),
 			waitForViewers: vi.fn(async () => undefined),
 			stop: vi.fn(),
@@ -171,6 +178,14 @@ describe("dogfood runner", () => {
 
 	it("checks fixed resources before a fresh successful setup", async () => {
 		const { runner, dependencies, output, getState } = createHarness();
+		vi.mocked(dependencies.operations.fixture).mockImplementation((service, action) => ({
+			ok: true,
+			action,
+			profile: {
+				identity_id: `identity-${service}`,
+				identity_invariant: { active_local_count: 1, human_named: true },
+			},
+		}));
 
 		await runner.run({ name: "setup", build: false, reset: false });
 
@@ -181,6 +196,42 @@ describe("dogfood runner", () => {
 		expect(
 			vi.mocked(dependencies.operations.resourcesExist).mock.invocationCallOrder[0] ?? 0,
 		).toBeLessThan(vi.mocked(dependencies.operations.up).mock.invocationCallOrder[0] ?? 0);
+	});
+
+	it("rejects setup when peer fixture summaries do not prove distinct local Identities", async () => {
+		const { runner, dependencies } = createHarness();
+		vi.mocked(dependencies.operations.fixture).mockImplementation((_service, action) => ({
+			ok: true,
+			action,
+			profile: {
+				identity_id: "local:local",
+				identity_invariant: { active_local_count: 1, human_named: false },
+			},
+		}));
+
+		await expect(runner.run({ name: "setup", build: false, reset: false })).rejects.toThrow(
+			"distinct active human-named local Identity",
+		);
+		expect(dependencies.operations.configureAndEnrollOwner).not.toHaveBeenCalled();
+		expect(dependencies.state.write).not.toHaveBeenCalled();
+	});
+
+	it("rejects otherwise-valid peer proofs that reuse the same Identity", async () => {
+		const { runner, dependencies } = createHarness();
+		vi.mocked(dependencies.operations.fixture).mockImplementation((_service, action) => ({
+			ok: true,
+			action,
+			profile: {
+				identity_id: "identity-reused-by-all-peers",
+				identity_invariant: { active_local_count: 1, human_named: true },
+			},
+		}));
+
+		await expect(runner.run({ name: "setup", build: false, reset: false })).rejects.toThrow(
+			"distinct active human-named local Identity",
+		);
+		expect(dependencies.operations.configureAndEnrollOwner).not.toHaveBeenCalled();
+		expect(dependencies.state.write).not.toHaveBeenCalled();
 	});
 
 	it("resets only the fixed sandbox before deterministic setup", async () => {

--- a/e2e/bin/dogfood.ts
+++ b/e2e/bin/dogfood.ts
@@ -82,6 +82,46 @@ interface DogfoodOperations {
 	captureLogs(): void;
 }
 
+interface FixtureIdentityProof {
+	profile: {
+		identity_id: string;
+		identity_invariant: { active_local_count: number; human_named: boolean };
+	};
+}
+
+function fixtureIdentityProof(value: unknown): FixtureIdentityProof | null {
+	if (!value || typeof value !== "object") return null;
+	const profile = (value as { profile?: unknown }).profile;
+	if (!profile || typeof profile !== "object") return null;
+	const identityId = String((profile as { identity_id?: unknown }).identity_id ?? "").trim();
+	const invariant = (profile as { identity_invariant?: unknown }).identity_invariant;
+	if (!identityId || !invariant || typeof invariant !== "object") return null;
+	return {
+		profile: {
+			identity_id: identityId,
+			identity_invariant: {
+				active_local_count: Number(
+					(invariant as { active_local_count?: unknown }).active_local_count ?? 0,
+				),
+				human_named: (invariant as { human_named?: unknown }).human_named === true,
+			},
+		},
+	};
+}
+
+function assertDistinctFixtureIdentities(summaries: unknown[]): void {
+	const proofs = summaries.map(fixtureIdentityProof);
+	const identities = proofs.map((proof) => proof?.profile.identity_id ?? "");
+	const valid = proofs.every(
+		(proof) =>
+			proof?.profile.identity_invariant.active_local_count === 1 &&
+			proof.profile.identity_invariant.human_named,
+	);
+	if (!valid || new Set(identities).size !== summaries.length) {
+		throw new Error("Each dogfood peer must prove one distinct active human-named local Identity.");
+	}
+}
+
 export interface DogfoodDependencies {
 	state: StateStore;
 	operations: DogfoodOperations;
@@ -259,9 +299,12 @@ async function runSetup(
 		dependencies.state.remove();
 	}
 	dependencies.operations.up(command.build);
-	dependencies.operations.fixture("peer-a", "setup-owner");
-	dependencies.operations.fixture("peer-b", "setup-teammate");
-	dependencies.operations.fixture("peer-c", "setup-second-device");
+	const fixtureSummaries = [
+		dependencies.operations.fixture("peer-a", "setup-owner"),
+		dependencies.operations.fixture("peer-b", "setup-teammate"),
+		dependencies.operations.fixture("peer-c", "setup-second-device"),
+	];
+	assertDistinctFixtureIdentities(fixtureSummaries);
 	dependencies.operations.configureAndEnrollOwner();
 	await dependencies.operations.waitForViewers();
 	dependencies.state.write({

--- a/e2e/scripts/dogfood-sharing-fixture.test.ts
+++ b/e2e/scripts/dogfood-sharing-fixture.test.ts
@@ -11,12 +11,18 @@ import {
 
 const temporaryDirectories: string[] = [];
 
-function createStore(role: string): MemoryStore {
+function createStore(role: string, options: { preseedIdentity?: boolean } = {}): MemoryStore {
 	const directory = mkdtempSync(join(tmpdir(), `codemem-dogfood-${role}-`));
 	temporaryDirectories.push(directory);
 	vi.stubEnv("CODEMEM_CONFIG", join(directory, "missing-config.json"));
-	vi.stubEnv("CODEMEM_DEVICE_ID", `dogfood-${role}-device`);
-	vi.stubEnv("CODEMEM_ACTOR_ID", `dogfood-${role}-identity`);
+	vi.stubEnv("CODEMEM_KEYS_DIR", join(directory, "keys"));
+	if (options.preseedIdentity !== false) {
+		vi.stubEnv("CODEMEM_DEVICE_ID", `dogfood-${role}-device`);
+		vi.stubEnv("CODEMEM_ACTOR_ID", `dogfood-${role}-identity`);
+	} else {
+		vi.stubEnv("CODEMEM_DEVICE_ID", undefined);
+		vi.stubEnv("CODEMEM_ACTOR_ID", undefined);
+	}
 	vi.stubEnv("CODEMEM_ACTOR_DISPLAY_NAME", `Dogfood ${role}`);
 	vi.stubEnv("CODEMEM_EMBEDDING_DISABLED", "1");
 	const databasePath = join(directory, "mem.sqlite");
@@ -132,6 +138,60 @@ describe("runFixtureAction", () => {
 			}
 		},
 	);
+
+	it("ensures device identity before creating one human-named active local Identity", async () => {
+		const store = createStore("owner", { preseedIdentity: false });
+		try {
+			expect(store.actorId).toBe("local:local");
+
+			const summary = await runFixtureAction(store, "setup-owner");
+			const localActors = store.db
+				.prepare(
+					"SELECT actor_id, display_name FROM actors WHERE is_local = 1 AND status = 'active'",
+				)
+				.all() as Array<{ actor_id: string; display_name: string }>;
+
+			expect(summary.profile.identity_id).not.toBe("local:local");
+			expect(summary.profile.identity_invariant).toEqual({
+				active_local_count: 1,
+				human_named: true,
+			});
+			expect(localActors).toEqual([
+				{ actor_id: summary.profile.identity_id, display_name: "Dogfood Owner" },
+			]);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("creates distinct stable human-named Identities for all three fresh peers", async () => {
+		const summaries: Awaited<ReturnType<typeof runFixtureAction>>[] = [];
+		const stores: MemoryStore[] = [];
+		try {
+			for (const role of ["owner", "teammate", "second-device"] as const) {
+				const store = createStore(role, { preseedIdentity: false });
+				stores.push(store);
+				summaries.push(await runFixtureAction(store, `setup-${role}`));
+			}
+
+			expect(new Set(summaries.map((summary) => summary.profile.identity_id)).size).toBe(3);
+			expect(summaries.every((summary) => summary.profile.device_id !== "local")).toBe(true);
+			expect(
+				summaries.every(
+					(summary) =>
+						summary.profile.identity_invariant.active_local_count === 1 &&
+						summary.profile.identity_invariant.human_named,
+				),
+			).toBe(true);
+			expect(summaries.map((summary) => summary.profile.display_name)).toEqual([
+				"Dogfood Owner",
+				"Dogfood Teammate",
+				"Dogfood Teammate Second Device",
+			]);
+		} finally {
+			for (const store of stores) store.close();
+		}
+	});
 
 	it.each(["add-future-selected", "add-future-unrelated"] as const)(
 		"rejects %s before the owner baseline exists",

--- a/e2e/scripts/dogfood-sharing-fixture.ts
+++ b/e2e/scripts/dogfood-sharing-fixture.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { initDatabase, MemoryStore } from "../../packages/core/src/index.ts";
+import { ensureDeviceIdentity, initDatabase, MemoryStore } from "../../packages/core/src/index.ts";
 
 const DB_PATH = "/data/mem.sqlite";
 const FIXTURE_TIME = "2026-07-23T12:00:00.000Z";
@@ -55,6 +55,10 @@ export interface FixtureSummary {
 		identity_id: string;
 		device_id: string;
 		display_name: string;
+		identity_invariant: {
+			active_local_count: number;
+			human_named: boolean;
+		};
 	};
 	team: {
 		team_id: string;
@@ -200,6 +204,19 @@ export function buildSafeSummary(
 	const actor = store.db
 		.prepare("SELECT display_name FROM actors WHERE actor_id = ?")
 		.get(store.actorId) as { display_name: string } | undefined;
+	const activeLocalActors = store.db
+		.prepare(
+			"SELECT actor_id, display_name FROM actors WHERE is_local = 1 AND status = 'active' ORDER BY actor_id",
+		)
+		.all() as Array<{ actor_id: string; display_name: string }>;
+	const canonicalLocalActor = activeLocalActors[0];
+	const humanNamed = Boolean(
+		canonicalLocalActor &&
+			canonicalLocalActor.actor_id === store.actorId &&
+			canonicalLocalActor.display_name.trim() &&
+			canonicalLocalActor.display_name !== canonicalLocalActor.actor_id &&
+			canonicalLocalActor.display_name !== "local:local",
+	);
 	const teamExists = Boolean(
 		store.db.prepare("SELECT 1 FROM policy_teams WHERE team_id = ?").get(TEAM_ID),
 	);
@@ -219,6 +236,10 @@ export function buildSafeSummary(
 			identity_id: store.actorId,
 			device_id: store.deviceId,
 			display_name: actor?.display_name ?? store.actorDisplayName,
+			identity_invariant: {
+				active_local_count: activeLocalActors.length,
+				human_named: humanNamed,
+			},
 		},
 		team: {
 			team_id: TEAM_ID,
@@ -239,6 +260,10 @@ export async function runFixtureAction(
 	store: MemoryStore,
 	action: FixtureAction,
 ): Promise<FixtureSummary> {
+	const [deviceId] = ensureDeviceIdentity(store.db, {
+		keysDir: process.env.CODEMEM_KEYS_DIR?.trim() || undefined,
+	});
+	store.adoptEnsuredDeviceIdentity(deviceId);
 	if (action === "setup-owner") {
 		ensureProfile(store, "owner");
 		ensureEmptyTeam(store);

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -144,6 +144,199 @@ describe("MemoryStore", () => {
 			expect(store.actorId).toBe("local:local");
 		});
 
+		it("adopts an ensured device identity and retires the fallback local actor", () => {
+			const now = "2026-07-23T12:00:00.000Z";
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('local:local', 'Dogfood Owner', 1, 'active', ?, ?)`,
+				)
+				.run(now, now);
+
+			store.adoptEnsuredDeviceIdentity("device-stable-owner");
+
+			expect(store.deviceId).toBe("device-stable-owner");
+			expect(store.actorId).toBe("local:device-stable-owner");
+			expect(store.actorDisplayName).toBe("Dogfood Owner");
+			expect(
+				store.db
+					.prepare(
+						"SELECT actor_id, display_name, is_local, status, merged_into_actor_id FROM actors ORDER BY actor_id",
+					)
+					.all(),
+			).toEqual([
+				{
+					actor_id: "local:device-stable-owner",
+					display_name: "Dogfood Owner",
+					is_local: 1,
+					status: "active",
+					merged_into_actor_id: null,
+				},
+				{
+					actor_id: "local:local",
+					display_name: "Dogfood Owner",
+					is_local: 0,
+					status: "merged",
+					merged_into_actor_id: "local:device-stable-owner",
+				},
+			]);
+		});
+
+		it("migrates fallback-authored memory ownership without rewriting historical device clocks", () => {
+			const sessionId = insertTestSession(store.db);
+			const memoryId = store.remember(sessionId, "discovery", "Fallback memory", "Body", 0.5, [], {
+				visibility: "private",
+			});
+
+			store.adoptEnsuredDeviceIdentity("device-stable-memory");
+
+			const memory = store.db
+				.prepare(
+					`SELECT actor_id, actor_display_name, origin_device_id, workspace_id, metadata_json
+					 FROM memory_items WHERE id = ?`,
+				)
+				.get(memoryId) as {
+				actor_id: string;
+				actor_display_name: string;
+				origin_device_id: string;
+				workspace_id: string;
+				metadata_json: string;
+			};
+			expect(memory).toMatchObject({
+				actor_id: "local:device-stable-memory",
+				origin_device_id: "local",
+				workspace_id: "personal:local:device-stable-memory",
+			});
+			expect(JSON.parse(memory.metadata_json)).toMatchObject({ clock_device_id: "local" });
+			expect(store.memoryOwnedBySelf(memory)).toBe(true);
+			expect(store.recent(10, { ownership_scope: "mine" }).map((item) => item.id)).toContain(
+				memoryId,
+			);
+		});
+
+		it("keeps configured actor identity while adopting the ensured device", () => {
+			store.close();
+			writeFileSync(
+				process.env.CODEMEM_CONFIG as string,
+				JSON.stringify({ actor_id: "actor:configured", actor_display_name: "Configured User" }),
+			);
+			store = new MemoryStore(dbPath);
+
+			store.adoptEnsuredDeviceIdentity("device-for-configured-actor");
+
+			expect(store.deviceId).toBe("device-for-configured-actor");
+			expect(store.actorId).toBe("actor:configured");
+			expect(store.actorDisplayName).toBe("Configured User");
+		});
+
+		it("keeps a configured actor canonical while retiring an active stale fallback actor", () => {
+			store.close();
+			writeFileSync(
+				process.env.CODEMEM_CONFIG as string,
+				JSON.stringify({ actor_id: "actor:configured", actor_display_name: "Configured User" }),
+			);
+			store = new MemoryStore(dbPath);
+			const now = "2026-07-23T12:00:00.000Z";
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('local:local', 'local:local', 1, 'active', ?, ?)`,
+				)
+				.run(now, now);
+
+			store.adoptEnsuredDeviceIdentity("device-for-configured-actor");
+
+			expect(store.deviceId).toBe("device-for-configured-actor");
+			expect(store.actorId).toBe("actor:configured");
+			expect(store.actorDisplayName).toBe("Configured User");
+			expect(
+				store.db
+					.prepare(
+						"SELECT actor_id, display_name FROM actors WHERE is_local = 1 AND status = 'active'",
+					)
+					.all(),
+			).toEqual([{ actor_id: "actor:configured", display_name: "Configured User" }]);
+			expect(
+				store.db
+					.prepare(
+						"SELECT is_local, status, merged_into_actor_id FROM actors WHERE actor_id = 'local:local'",
+					)
+					.get(),
+			).toEqual({
+				is_local: 0,
+				status: "merged",
+				merged_into_actor_id: "actor:configured",
+			});
+		});
+
+		it("does not advance in-memory identity when fallback persistence fails", () => {
+			const sessionId = insertTestSession(store.db);
+			const memoryId = store.remember(sessionId, "discovery", "Rollback memory", "Body", 0.5, [], {
+				visibility: "private",
+			});
+			const now = "2026-07-23T12:00:00.000Z";
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('local:local', 'Fallback User', 1, 'active', ?, ?)`,
+				)
+				.run(now, now);
+			store.db.exec(`CREATE TRIGGER reject_fallback_retirement BEFORE UPDATE ON actors
+				WHEN OLD.actor_id = 'local:local' BEGIN SELECT RAISE(ABORT, 'retirement failed'); END`);
+
+			expect(() => store.adoptEnsuredDeviceIdentity("device-transaction-failure")).toThrow(
+				"retirement failed",
+			);
+			expect(store.deviceId).toBe("local");
+			expect(store.actorId).toBe("local:local");
+			expect(store.db.prepare("SELECT actor_id FROM actors ORDER BY actor_id").all()).toEqual([
+				{ actor_id: "local:local" },
+			]);
+			const memory = store.db
+				.prepare(
+					"SELECT actor_id, workspace_id, origin_device_id, metadata_json FROM memory_items WHERE id = ?",
+				)
+				.get(memoryId) as {
+				actor_id: string;
+				workspace_id: string;
+				origin_device_id: string;
+				metadata_json: string;
+			};
+			expect(memory).toMatchObject({
+				actor_id: "local:local",
+				workspace_id: "personal:local:local",
+				origin_device_id: "local",
+			});
+			expect(JSON.parse(memory.metadata_json)).toMatchObject({ clock_device_id: "local" });
+		});
+
+		it("does not claim fallback actor rows authored by a foreign device", () => {
+			const sessionId = insertTestSession(store.db);
+			const memoryId = store.remember(sessionId, "discovery", "Foreign fallback", "Body", 0.5, [], {
+				actor_id: "local:local",
+				origin_device_id: "foreign-device",
+				visibility: "private",
+			});
+
+			store.adoptEnsuredDeviceIdentity("device-stable-local");
+
+			const memory = store.db
+				.prepare("SELECT actor_id, workspace_id, origin_device_id FROM memory_items WHERE id = ?")
+				.get(memoryId) as { actor_id: string; workspace_id: string; origin_device_id: string };
+			expect(memory).toEqual({
+				actor_id: "local:local",
+				workspace_id: "personal:local:local",
+				origin_device_id: "foreign-device",
+			});
+			expect(store.memoryOwnedBySelf(memory)).toBe(false);
+			expect(store.recent(10, { ownership_scope: "mine" }).map((item) => item.id)).not.toContain(
+				memoryId,
+			);
+			expect(store.recent(10, { ownership_scope: "theirs" }).map((item) => item.id)).toContain(
+				memoryId,
+			);
+		});
+
 		it("loads actor identity defaults from codemem config file", () => {
 			store.close();
 			writeFileSync(

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -288,11 +288,82 @@ export class MemoryStore {
 	adoptEnsuredDeviceIdentity(deviceId: string): void {
 		const normalizedDeviceId = deviceId.trim();
 		if (!normalizedDeviceId || normalizedDeviceId === "local" || this.deviceId !== "local") return;
-		const previousActorId = this.actorId;
+		const previousDeviceId = this.deviceId;
+		const fallbackActorId = `local:${previousDeviceId}`;
+		const hasActorsTable = tableExists(this.db, "actors");
+		const fallbackActor = hasActorsTable
+			? (this.db
+					.prepare(
+						`SELECT display_name FROM actors WHERE actor_id = ?
+						 AND (? = 1 OR (is_local = 1 AND status = 'active'))`,
+					)
+					.get(fallbackActorId, this.actorIdUsesDeviceFallback ? 1 : 0) as
+					| { display_name: string }
+					| undefined)
+			: undefined;
+		if (!this.actorIdUsesDeviceFallback && !fallbackActor) {
+			this.deviceId = normalizedDeviceId;
+			return;
+		}
+
+		const nextActorId = this.actorIdUsesDeviceFallback
+			? `local:${normalizedDeviceId}`
+			: this.actorId;
+		const fallbackDisplayName = cleanStr(fallbackActor?.display_name);
+		const nextActorDisplayName =
+			this.actorIdUsesDeviceFallback &&
+			fallbackDisplayName &&
+			fallbackDisplayName !== fallbackActorId
+				? fallbackDisplayName
+				: this.actorDisplayName === fallbackActorId
+					? nextActorId
+					: this.actorDisplayName;
+		const now = nowIso();
+		this.db.transaction(() => {
+			if (fallbackActor) {
+				this.db
+					.prepare(
+						`INSERT INTO actors(
+						 actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+						 ) VALUES (?, ?, 1, 'active', NULL, ?, ?)
+						 ON CONFLICT(actor_id) DO UPDATE SET
+						 display_name = excluded.display_name, is_local = 1, status = 'active',
+						 merged_into_actor_id = NULL, updated_at = excluded.updated_at`,
+					)
+					.run(nextActorId, nextActorDisplayName, now, now);
+			}
+			this.db
+				.prepare(
+					// Canonicalize only rows that still carry both fallback ownership signals.
+					// origin_device_id and metadata clock_device_id remain historical provenance;
+					// personal workspace identity follows the canonical actor when applicable.
+					`UPDATE memory_items
+					 SET actor_id = ?,
+					     workspace_id = CASE WHEN workspace_id = ? THEN ? ELSE workspace_id END
+					 WHERE actor_id = ?
+					   AND (origin_device_id IS NULL OR TRIM(origin_device_id) = '' OR origin_device_id = ?)`,
+				)
+				.run(
+					nextActorId,
+					`personal:${fallbackActorId}`,
+					`personal:${nextActorId}`,
+					fallbackActorId,
+					previousDeviceId,
+				);
+			if (!fallbackActor) return;
+			this.db
+				.prepare(
+					`UPDATE actors SET is_local = 0, status = 'merged', merged_into_actor_id = ?, updated_at = ?
+					 WHERE actor_id = ?`,
+				)
+				.run(nextActorId, now, fallbackActorId);
+		})();
+		// Publish the new in-memory identity only after every persistence mutation commits.
 		this.deviceId = normalizedDeviceId;
-		if (!this.actorIdUsesDeviceFallback) return;
-		this.actorId = `local:${normalizedDeviceId}`;
-		if (this.actorDisplayName === previousActorId) this.actorDisplayName = this.actorId;
+		if (this.actorIdUsesDeviceFallback) {
+			this.actorId = nextActorId;
+			this.actorDisplayName = nextActorDisplayName;
+		}
 	}
 
 	private findExistingDuplicateMemory(

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -11673,7 +11673,7 @@ describe("viewer-server", () => {
 			}
 		});
 
-		it("imports coordinator invites through the viewer route", async () => {
+		it("imports directly from a fallback store with one stable human-named local actor", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
 			const prevConfig = process.env.CODEMEM_CONFIG;
@@ -11701,12 +11701,19 @@ describe("viewer-server", () => {
 			process.env.CODEMEM_CONFIG = configPath;
 			process.env.CODEMEM_KEYS_DIR = keysDir;
 			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Fixture User" }));
-			const { app, getStore, cleanup } = createTestApp();
+			const { app, getStore, cleanup } = createTestApp({ seedDevice: false });
 			try {
 				await app.request("/api/stats");
 				const store = getStore();
 				if (!store) throw new Error("store not initialized");
-				ensureDeviceIdentity(store.db, { keysDir });
+				expect(store.actorId).toBe("local:local");
+				const fallbackNow = "2026-07-23T12:00:00.000Z";
+				store.db
+					.prepare(
+						`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+						 VALUES ('local:local', 'local:local', 1, 'active', ?, ?)`,
+					)
+					.run(fallbackNow, fallbackNow);
 				const res = await app.request("/api/sync/invites/import", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
@@ -11716,6 +11723,16 @@ describe("viewer-server", () => {
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body.group_id).toBe("team-a");
 				expect(body.status).toBe("pending");
+				expect(store.deviceId).not.toBe("local");
+				expect(store.actorId).toBe(`local:${store.deviceId}`);
+				expect(store.actorDisplayName).toBe("Fixture User");
+				expect(
+					store.db
+						.prepare(
+							"SELECT actor_id, display_name FROM actors WHERE is_local = 1 AND status = 'active'",
+						)
+						.all(),
+				).toEqual([{ actor_id: store.actorId, display_name: "Fixture User" }]);
 				const writtenConfig = JSON.parse(readFileSync(configPath, "utf8")) as Record<
 					string,
 					unknown
@@ -11729,6 +11746,89 @@ describe("viewer-server", () => {
 				else process.env.CODEMEM_CONFIG = prevConfig;
 				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
 				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("keeps configured identity canonical and hides a stale fallback during invite import", async () => {
+			const configDir = mkdtempSync(join(tmpdir(), "codemem-configured-invite-test-"));
+			const configPath = join(configDir, "config.json");
+			const keysDir = join(configDir, "keys");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const invitePayload = {
+				v: 1,
+				kind: "coordinator_team_invite",
+				coordinator_url: "https://coord.example.test",
+				group_id: "team-a",
+				policy: "approval_required",
+				token: "configured-token",
+				expires_at: new Date(Date.now() + 86_400_000).toISOString(),
+				team_name: "Team A",
+			};
+			const invite = Buffer.from(JSON.stringify(invitePayload), "utf8").toString("base64url");
+			let joinBody: Record<string, unknown> = {};
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				if (String(input).includes("/v1/join")) {
+					joinBody = JSON.parse(
+						init?.body instanceof Uint8Array
+							? new TextDecoder().decode(init.body)
+							: String(init?.body ?? "{}"),
+					) as Record<string, unknown>;
+					return new Response(JSON.stringify({ status: "pending" }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			}) as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({ actor_id: "actor:configured", actor_display_name: "Configured User" }),
+			);
+			const { app, getStore, cleanup } = createTestApp({ seedDevice: false });
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const now = "2026-07-23T12:00:00.000Z";
+				store.db
+					.prepare(
+						`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+						 VALUES ('local:local', 'local:local', 1, 'active', ?, ?)`,
+					)
+					.run(now, now);
+
+				const imported = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite }),
+				});
+				const importedBody = (await imported.json()) as Record<string, unknown>;
+				expect(imported.status).toBe(200);
+				expect(JSON.stringify(importedBody)).not.toContain("local:local");
+				expect(joinBody).toMatchObject({ display_name: "Configured User" });
+				expect(JSON.stringify(joinBody)).not.toContain("local:local");
+				expect(store.actorId).toBe("actor:configured");
+
+				const actors = await app.request("/api/sync/actors");
+				const actorsBody = (await actors.json()) as { items: Array<Record<string, unknown>> };
+				expect(actorsBody.items).toEqual([
+					expect.objectContaining({
+						actor_id: "actor:configured",
+						display_name: "Configured User",
+						is_local: 1,
+						status: "active",
+					}),
+				]);
+				expect(JSON.stringify(actorsBody)).not.toContain("local:local");
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+				rmSync(configDir, { recursive: true, force: true });
 			}
 		});
 
@@ -11801,12 +11901,19 @@ describe("viewer-server", () => {
 			process.env.CODEMEM_CONFIG = configPath;
 			process.env.CODEMEM_KEYS_DIR = keysDir;
 			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Local Person" }));
-			const { app, getStore, cleanup } = createTestApp();
+			const { app, getStore, cleanup } = createTestApp({ seedDevice: false });
 			try {
 				await app.request("/api/stats");
 				const store = getStore();
 				if (!store) throw new Error("store not initialized");
-				ensureDeviceIdentity(store.db, { keysDir });
+				expect(store.actorId).toBe("local:local");
+				const fallbackNow = "2026-07-23T12:00:00.000Z";
+				store.db
+					.prepare(
+						`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+						 VALUES ('local:local', 'local:local', 1, 'active', ?, ?)`,
+					)
+					.run(fallbackNow, fallbackNow);
 				const inspect = await app.request("/api/sync/invites/inspect", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
@@ -11817,12 +11924,24 @@ describe("viewer-server", () => {
 					recipient_name: "Local Person",
 					projects: [{ display_name: "codemem", existing_memory_count: 3 }],
 				});
+				expect(store.deviceId).not.toBe("local");
+				expect(store.actorId).toBe(`local:${store.deviceId}`);
+				expect(
+					store.db
+						.prepare(
+							"SELECT is_local, status, merged_into_actor_id FROM actors WHERE actor_id = 'local:local'",
+						)
+						.get(),
+				).toEqual({
+					is_local: 0,
+					status: "merged",
+					merged_into_actor_id: store.actorId,
+				});
 				const accepted = await app.request("/api/sync/invites/import", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({
 						invite,
-						recipient_name: "Brian",
 						device_name: "Brian's Test Mac",
 					}),
 				});
@@ -11831,7 +11950,7 @@ describe("viewer-server", () => {
 				expect(joinBody).toMatchObject({
 					operation_id: operationId,
 					recipient_actor_id: store.actorId,
-					recipient_display_name: "Brian",
+					recipient_display_name: "Local Person",
 					device_display_name: "Brian's Test Mac",
 				});
 				expect(joinBody).not.toHaveProperty("projects");
@@ -11840,7 +11959,14 @@ describe("viewer-server", () => {
 					store.db
 						.prepare("SELECT display_name, status FROM actors WHERE actor_id = ?")
 						.get(store.actorId),
-				).toEqual({ display_name: "Brian", status: "active" });
+				).toEqual({ display_name: "Local Person", status: "active" });
+				expect(
+					store.db
+						.prepare(
+							"SELECT actor_id, display_name FROM actors WHERE is_local = 1 AND status = 'active'",
+						)
+						.all(),
+				).toEqual([{ actor_id: store.actorId, display_name: "Local Person" }]);
 				expect(
 					store.db
 						.prepare("SELECT pending_bootstrap_grant_id FROM sync_peers WHERE peer_device_id = ?")

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -677,9 +677,7 @@ function localOnboardingBinding(
 	devicePublicKey: string;
 	deviceDisplayName: string;
 } {
-	const [deviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
-	store.adoptEnsuredDeviceIdentity(deviceId);
-	ensureLocalActorRecord(store);
+	const deviceId = ensureStableStoreIdentity(store);
 	const devicePublicKey = String(
 		store.db
 			.prepare("SELECT public_key FROM sync_device WHERE device_id = ?")
@@ -2365,6 +2363,13 @@ function ensureLocalActorRecord(store: MemoryStore): void {
 			updated_at: now,
 		})
 		.run();
+}
+
+function ensureStableStoreIdentity(store: MemoryStore): string {
+	const [deviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
+	store.adoptEnsuredDeviceIdentity(deviceId);
+	ensureLocalActorRecord(store);
+	return deviceId;
 }
 
 function findPeerDeviceIdForAddress(store: MemoryStore, address: string): string | null {
@@ -5641,6 +5646,7 @@ export function syncRoutes(
 		if (!body || typeof body.invite !== "string") return c.json({ error: "invite_invalid" }, 400);
 		try {
 			const payload = decodeInvitePayload(extractInvitePayload(body.invite));
+			ensureStableStoreIdentity(store);
 			const recipientInvite = payload.kind === "team_member" || payload.kind === "add_device";
 			if (!payload.operation_id && !recipientInvite) return c.json({ kind: "legacy_team_invite" });
 			const [status, inspected] = await requestJson(
@@ -5770,6 +5776,7 @@ export function syncRoutes(
 
 		try {
 			const decoded = decodeInvitePayload(extractInvitePayload(rawValue));
+			ensureStableStoreIdentity(store);
 			const recipientInvite = decoded.kind === "team_member" || decoded.kind === "add_device";
 			const reviewedOnboardingDigest =
 				typeof body.reviewed_onboarding_digest === "string"


### PR DESCRIPTION
## Description

Adopt the stable device-backed identity before invite defaults or local profile projection. Retire stale `local:local` fallback identities safely, preserve foreign-origin ownership, and add the approved dogfood stabilization design/plan plus fixture invariants.

Closes codemem-h2wu.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused identity/store/viewer/dogfood tests passed. The complete stack passed `pnpm run check` with 3,207 tests.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced