### PR TITLE
fix(sharing): make project acceptance truthful

### DIFF
--- a/e2e/scenarios/project-sharing.ts
+++ b/e2e/scenarios/project-sharing.ts
@@ -144,6 +144,32 @@ function startServer(ctx: ScenarioContext, service: string, artifact: string): v
 	assertStatus(result.status, 0, `${service} viewer/sync server failed to start`);
 }
 
+function restartServer(ctx: ScenarioContext, service: string, artifact: string): void {
+	const restarted = ctx.compose.restart(service, `${artifact}-container`);
+	assertStatus(restarted.status, 0, `${service} container failed to restart`);
+	startServer(ctx, service, `${artifact}-start`);
+}
+
+function readConfig(
+	ctx: ScenarioContext,
+	service: string,
+	artifact: string,
+): Record<string, unknown> {
+	const result = ctx.compose.exec(
+		service,
+		[
+			"node",
+			"--input-type=module",
+			"-e",
+			"import { readFileSync } from 'node:fs'; console.log(readFileSync('/config/codemem.json', 'utf8'));",
+		],
+		artifact,
+		30_000,
+	);
+	assertStatus(result.status, 0, `${service} config read failed`);
+	return parseJson<Record<string, unknown>>(result.stdout, artifact);
+}
+
 async function request<T>(
 	ctx: ScenarioContext,
 	service: string,
@@ -204,9 +230,9 @@ export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<v
 		"source bystander fixture missing",
 	);
 
-	for (const [service, deviceName] of [
-		["peer-a", "Adam's Test Mac"],
-		["peer-b", "Brian's Test Mac"],
+	for (const [service, deviceName, syncEnabled] of [
+		["peer-a", "Adam's Test Mac", true],
+		["peer-b", "Brian's Test Mac", false],
 	] as const) {
 		writePeerConfig(
 			ctx,
@@ -214,7 +240,7 @@ export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<v
 			{
 				actor_display_name: service === "peer-a" ? "Adam" : "Brian",
 				sync_device_name: deviceName,
-				sync_enabled: true,
+				sync_enabled: syncEnabled,
 				sync_host: "0.0.0.0",
 				sync_port: 7337,
 				sync_advertise: `http://${service}:7337`,
@@ -310,6 +336,22 @@ export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<v
 		{ invite: created.body.invite.encoded, recipient_name: "Brian", device_name: "Brian's Test Mac" },
 	);
 	assert(accepted.status === 200, `project invite acceptance failed: ${JSON.stringify(accepted.body)}`);
+	assert(
+		accepted.body.status === "pending_setup" &&
+			accepted.body.sync_enabled === true &&
+			accepted.body.type === "project_share" &&
+			accepted.body.setup_state === "restart_required" &&
+			accepted.body.restart_required === true,
+		"disabled recipient acceptance must remain pending and require restart",
+	);
+	assert(
+		String(accepted.body.detail ?? "").includes("Restart codemem"),
+		"restart-required acceptance did not provide actionable detail",
+	);
+	const enabledRecipientConfig = readConfig(ctx, "peer-b", "19-read-enabled-peer-b-config");
+	assert(enabledRecipientConfig.sync_enabled === true, "project acceptance did not persist recipient sync");
+	restartServer(ctx, "peer-b", "20-restart-peer-b");
+	await waitForServer(ctx, "peer-b", "21-peer-b-ready-after-restart");
 
 	await waitFor(
 		async () => {
@@ -317,7 +359,7 @@ export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<v
 				ctx,
 				"peer-a",
 				`/api/sync/project-invites/${created.body.operation_id}/reconcile`,
-				"19-reconcile",
+				"23-reconcile",
 				{},
 			);
 			assert(reconciled.status === 200, `acceptance reconciliation failed: ${JSON.stringify(reconciled.body)}`);
@@ -325,7 +367,7 @@ export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<v
 				ctx,
 				"peer-a",
 				`/api/sync/share-operations/${created.body.operation_id}/advance`,
-				"20-advance",
+				"24-advance",
 				{},
 			);
 			assert(advanced.status === 200, `project provisioning not ready: ${JSON.stringify(advanced.body)}`);

--- a/packages/cloudflare-coordinator-worker/test/worker.integration.test.ts
+++ b/packages/cloudflare-coordinator-worker/test/worker.integration.test.ts
@@ -207,6 +207,7 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 
 	it("atomically accepts project invites while preserving legacy join behavior after migration 0008", async () => {
 		const legacyJoiner = createIdentity();
+		const projectInviter = createIdentity();
 		const projectJoiner = createIdentity();
 		const conflictingJoiner = createIdentity();
 		const adminHeaders = {
@@ -257,7 +258,7 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 			reviewed_project_set_digest: reviewedProjectSetDigest,
 			inviter_actor_id: "actor-adam",
 			inviter_display_name: "Adam",
-			inviter_device_id: "inviter-device",
+			inviter_device_id: projectInviter.deviceId,
 			pending_person_id: "pending-brian",
 			project_summaries: [{ display_name: "codemem", existing_memory_count: 3 }],
 			project_intent: [
@@ -382,10 +383,25 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		const projectJoinBody = (await projectJoinResponse.json()) as Record<string, unknown>;
 		expect(projectJoinResponse.status, JSON.stringify(projectJoinBody)).toBe(200);
 		expect(projectJoinBody).toMatchObject({
-			status: "accepted",
+			status: "pending_setup",
 			operation_id: operationId,
 			trust_state: "pending_inviter_device",
 		});
+		const inviterEnrollment = await exports.default.fetch(
+			"https://example.com/v1/admin/devices",
+			{
+				method: "POST",
+				headers: adminHeaders,
+				body: JSON.stringify({
+					group_id: "g1",
+					device_id: projectInviter.deviceId,
+					public_key: projectInviter.publicKey,
+					fingerprint: projectInviter.fingerprint,
+					display_name: "Adam's Mac",
+				}),
+			},
+		);
+		expect(inviterEnrollment.status).toBe(200);
 		const retry = await exports.default.fetch("https://example.com/v1/join", {
 			method: "POST",
 			headers: { "content-type": "application/json" },
@@ -400,7 +416,23 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 				device_display_name: "Brian's Test Mac",
 			}),
 		});
-		expect(await retry.json()).toMatchObject({ status: "existing" });
+		expect(await retry.json()).toMatchObject({
+			status: "pending_setup",
+			trust_state: "bootstrap_grant_created",
+			bootstrap_grant_id: expect.any(String),
+			inviter_device: {
+				device_id: projectInviter.deviceId,
+				public_key: projectInviter.publicKey,
+				fingerprint: projectInviter.fingerprint,
+			},
+		});
+		expect(
+			await env.COORDINATOR_DB.prepare(
+				"SELECT COUNT(*) AS total FROM coordinator_bootstrap_grants WHERE worker_device_id = ?",
+			)
+				.bind(projectJoiner.deviceId)
+				.first(),
+		).toEqual({ total: 1 });
 		const conflictingJoinResponse = await exports.default.fetch(
 			"https://example.com/v1/join",
 			{
@@ -895,6 +927,22 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		});
 		expect(wrongIdentity.status).toBe(409);
 		expect(await wrongIdentity.json()).toEqual({ error: "invite_identity_conflict" });
+		const addDeviceBody = {
+			token: addDevice.payload.token,
+			invite_kind: "add_device",
+			identity_id: "identity-brian",
+			device_id: otherDevice.deviceId,
+			public_key: otherDevice.publicKey,
+			fingerprint: otherDevice.fingerprint,
+		};
+		const acceptAddDevice = () =>
+			exports.default.fetch("https://example.com/v1/join", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(addDeviceBody),
+			});
+		expect(await (await acceptAddDevice()).json()).toMatchObject({ status: "accepted" });
+		expect(await (await acceptAddDevice()).json()).toMatchObject({ status: "existing" });
 
 		expect(
 			await env.COORDINATOR_DB.prepare("SELECT COUNT(*) AS count FROM enrolled_devices")

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -25,6 +25,13 @@ import { encodeInvitePayload } from "./coordinator-invites.js";
 import { connect } from "./db.js";
 import { initDatabase } from "./maintenance.js";
 import { readCodememConfigFileAtPath, writeCodememConfigFile } from "./observer-config.js";
+import {
+	isProjectSyncEnablementError,
+	PROJECT_INVITE_PENDING_STATUS,
+	PROJECT_SYNC_ENABLEMENT_FAILED,
+	PROJECT_SYNC_ENABLEMENT_FAILURE_DETAIL,
+	ProjectSyncEnablementError,
+} from "./project-invite-acceptance.js";
 import { previewRecipientPolicyOnboarding } from "./recipient-policy-onboarding.js";
 import { ensureDeviceIdentity, fingerprintPublicKey, loadPublicKey } from "./sync-identity.js";
 
@@ -504,6 +511,11 @@ describe("coordinator local admin actions", () => {
 		});
 
 		await coordinatorImportInviteAction({ inviteValue: invite });
+		const persistedConfig = readCodememConfigFileAtPath(String(process.env.CODEMEM_CONFIG));
+		expect(persistedConfig).not.toHaveProperty("sync_enabled");
+		expect(persistedConfig).not.toHaveProperty("sync_host");
+		expect(persistedConfig).not.toHaveProperty("sync_port");
+		expect(persistedConfig).not.toHaveProperty("sync_interval_s");
 
 		const publicKey = loadPublicKey(envKeysDir);
 		expect(publicKey).toBeTruthy();
@@ -568,9 +580,18 @@ describe("coordinator local admin actions", () => {
 			operation_id: operationId,
 		});
 
-		await coordinatorImportInviteAction({ inviteValue: invite, dbPath: actionDbPath, keysDir });
+		const imported = await coordinatorImportInviteAction({
+			inviteValue: invite,
+			dbPath: actionDbPath,
+			keysDir,
+		});
 
 		const body = capturedBodies[0];
+		expect(imported).toMatchObject({
+			status: PROJECT_INVITE_PENDING_STATUS,
+			setup_state: "pending_inviter",
+			sync_enabled: true,
+		});
 		expect(body?.recipient_actor_id).toBe(`local:${body?.device_id}`);
 		expect(body?.recipient_display_name).toEqual(expect.any(String));
 		expect(body?.device_display_name).toEqual(expect.any(String));
@@ -593,6 +614,110 @@ describe("coordinator local admin actions", () => {
 					.prepare("SELECT display_name, is_local, status FROM actors WHERE actor_id = ?")
 					.get(body?.recipient_actor_id),
 			).toMatchObject({ is_local: 1, status: "active" });
+		} finally {
+			conn.close();
+		}
+		expect(readCodememConfigFileAtPath(String(process.env.CODEMEM_CONFIG))).toMatchObject({
+			sync_enabled: true,
+			sync_host: "0.0.0.0",
+			sync_port: 7337,
+			sync_interval_s: 120,
+		});
+	});
+
+	it("recovers idempotently when a consumed project invite initially cannot enable sync", async () => {
+		const actionDbPath = join(tmpDir, "project-invite-config-failure.sqlite");
+		const keysDir = join(tmpDir, "project-invite-config-failure-keys");
+		const configParent = join(tmpDir, "blocked-config-parent");
+		const configPath = join(configParent, "config.json");
+		const operationId = `share_${"f".repeat(40)}`;
+		const inviterPublicKey = "ssh-ed25519 inviter-public-key";
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						status: "accepted",
+						operation_id: operationId,
+						trust_state: "bootstrap_grant_created",
+						bootstrap_grant_id: "grant-1",
+						inviter_device: {
+							device_id: "inviter-device",
+							public_key: inviterPublicKey,
+							fingerprint: fingerprintPublicKey(inviterPublicKey),
+						},
+					}),
+					{ status: 200 },
+				),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const invite = encodeInvitePayload({
+			v: 1,
+			kind: "coordinator_team_invite",
+			coordinator_url: "https://coord.example.test",
+			group_id: "team-a",
+			policy: "auto_admit",
+			token: "project-invite-token",
+			expires_at: "2099-01-01T00:00:00.000Z",
+			team_name: "Team A",
+			operation_id: operationId,
+		});
+
+		writeFileSync(configParent, "not-a-directory", "utf8");
+		let failure: unknown;
+		try {
+			await coordinatorImportInviteAction({
+				inviteValue: invite,
+				dbPath: actionDbPath,
+				keysDir,
+				configPath,
+				recipientActorId: "actor-brian",
+				recipientDisplayName: "Brian",
+			});
+		} catch (error) {
+			failure = error;
+		}
+
+		expect(failure).toBeInstanceOf(ProjectSyncEnablementError);
+		expect(isProjectSyncEnablementError(failure)).toBe(true);
+		expect(isProjectSyncEnablementError(new Error(PROJECT_SYNC_ENABLEMENT_FAILURE_DETAIL))).toBe(
+			false,
+		);
+		expect(failure).toMatchObject({
+			code: PROJECT_SYNC_ENABLEMENT_FAILED,
+			detail: PROJECT_SYNC_ENABLEMENT_FAILURE_DETAIL,
+			message: PROJECT_SYNC_ENABLEMENT_FAILURE_DETAIL,
+		});
+
+		rmSync(configParent);
+		const retried = await coordinatorImportInviteAction({
+			inviteValue: invite,
+			dbPath: actionDbPath,
+			keysDir,
+			configPath,
+			recipientActorId: "actor-brian",
+			recipientDisplayName: "Brian",
+		});
+
+		expect(retried).toMatchObject({
+			status: PROJECT_INVITE_PENDING_STATUS,
+			groups: ["team-a"],
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(readCodememConfigFileAtPath(configPath)).toMatchObject({
+			sync_enabled: true,
+			sync_coordinator_groups: ["team-a"],
+		});
+		const conn = connect(actionDbPath);
+		try {
+			expect(
+				conn.prepare("SELECT COUNT(1) AS total FROM actors WHERE actor_id = ?").get("actor-brian"),
+			).toEqual({ total: 1 });
+			expect(
+				conn
+					.prepare(`SELECT COUNT(1) AS total FROM sync_peers
+					 WHERE peer_device_id = ? AND pending_bootstrap_grant_id = ?`)
+					.get("inviter-device", "grant-1"),
+			).toEqual({ total: 1 });
 		} finally {
 			conn.close();
 		}
@@ -794,12 +919,17 @@ describe("coordinator local admin actions", () => {
 			recipientActorId: testCase.identityId,
 		});
 
-		expect(readCodememConfigFileAtPath(configPath)).toMatchObject({
+		const persistedConfig = readCodememConfigFileAtPath(configPath);
+		expect(persistedConfig).toMatchObject({
 			actor_id: testCase.identityId,
 			sync_coordinator_url: "https://coord.example.test",
 			sync_coordinator_groups: testCase.expectedGroups,
 			sync_coordinator_group: "existing-group",
 		});
+		expect(persistedConfig).not.toHaveProperty("sync_enabled");
+		expect(persistedConfig).not.toHaveProperty("sync_host");
+		expect(persistedConfig).not.toHaveProperty("sync_port");
+		expect(persistedConfig).not.toHaveProperty("sync_interval_s");
 	});
 
 	it("rejects recipient onboarding when local access changes after the reviewed preview", async () => {

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -32,6 +32,10 @@ import {
 	readCodememConfigFileAtPath,
 	writeCodememConfigFile,
 } from "./observer-config.js";
+import {
+	PROJECT_INVITE_PENDING_STATUS,
+	ProjectSyncEnablementError,
+} from "./project-invite-acceptance.js";
 import { friendlyDeviceName, normalizeIdentityDisplayName } from "./project-invite-identity.js";
 import {
 	commitRecipientPolicyOnboarding,
@@ -45,11 +49,34 @@ import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
 
 const VALID_INVITE_POLICIES = new Set(["auto_admit", "approval_required"]);
 const INVITE_IMPORT_TIMEOUT_S = 10;
+const PROJECT_INVITE_SYNC_DEFAULTS = {
+	host: "0.0.0.0",
+	intervalS: 120,
+	port: 7337,
+} as const;
 
 function stripTrailingSlashes(value: string): string {
 	let end = value.length;
 	while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
 	return end === value.length ? value : value.slice(0, end);
+}
+
+function enableProjectInviteSync(config: Record<string, unknown>): Record<string, unknown> {
+	const port = Number(config.sync_port);
+	const intervalS = Number(config.sync_interval_s);
+	return {
+		...config,
+		sync_enabled: true,
+		sync_host: String(config.sync_host ?? "").trim() || PROJECT_INVITE_SYNC_DEFAULTS.host,
+		sync_port:
+			Number.isSafeInteger(port) && port > 0 && port <= 65_535
+				? port
+				: PROJECT_INVITE_SYNC_DEFAULTS.port,
+		sync_interval_s:
+			Number.isSafeInteger(intervalS) && intervalS > 0
+				? intervalS
+				: PROJECT_INVITE_SYNC_DEFAULTS.intervalS,
+	};
 }
 
 function coordinatorRemoteTarget(config = readCodememConfigFile()): {
@@ -1484,9 +1511,10 @@ export async function coordinatorImportInviteAction(opts: {
 			reviewedOnboardingDigest: reviewedOnboardingDigest ?? "",
 		});
 	}
-	const nextConfig = opts.configPath
+	let nextConfig = opts.configPath
 		? readCodememConfigFileAtPath(opts.configPath)
 		: readCodememConfigFile();
+	if (projectInvite) nextConfig = enableProjectInviteSync(nextConfig);
 	nextConfig.sync_coordinator_url = coordinatorUrl;
 	if (projectInvite || recipientInvite) {
 		nextConfig.actor_id = recipientActorId;
@@ -1515,7 +1543,15 @@ export async function coordinatorImportInviteAction(opts: {
 	const mergedGroups = Array.from(new Set([...existingGroups, newGroupId]));
 	nextConfig.sync_coordinator_groups = mergedGroups;
 	nextConfig.sync_coordinator_group = mergedGroups[0] ?? newGroupId;
-	const configPath = writeCodememConfigFile(nextConfig, opts.configPath ?? undefined);
+	let configPath: string;
+	try {
+		configPath = writeCodememConfigFile(nextConfig, opts.configPath ?? undefined);
+	} catch (error) {
+		if (projectInvite) {
+			throw new ProjectSyncEnablementError({ cause: error });
+		}
+		throw error;
+	}
 	if (recipientInvite) {
 		return {
 			group_id: response?.group_id ?? payload.group_id,
@@ -1531,7 +1567,15 @@ export async function coordinatorImportInviteAction(opts: {
 	return {
 		group_id: payload.group_id,
 		coordinator_url: payload.coordinator_url,
-		status: response?.status ?? null,
+		status: projectInvite ? PROJECT_INVITE_PENDING_STATUS : (response?.status ?? null),
+		...(projectInvite
+			? {
+					setup_state: "pending_inviter",
+					sync_enabled: true,
+					message:
+						"Invitation accepted. Project access is still being set up and the first sync has not completed yet.",
+				}
+			: {}),
 		operation_id: response?.operation_id ?? payload.operation_id ?? null,
 		trust_state: response?.trust_state ?? null,
 		bootstrap_grant_id: response?.bootstrap_grant_id ?? null,

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -439,6 +439,58 @@ describe("createCoordinatorApp dependency injection", () => {
 		expect(store.createJoinRequest).not.toHaveBeenCalled();
 	});
 
+	it("preserves add-device idempotent existing status", async () => {
+		const publicKey = "add-device-public-key";
+		const invite = {
+			invite_id: "invite-add-device-1",
+			group_id: "g1",
+			token: "token-add-device-1",
+			policy: "auto_admit",
+			expires_at: "2099-01-01T00:00:00Z",
+			created_at: "2026-03-28T00:00:00Z",
+			created_by: null,
+			team_name_snapshot: "Coordinator One",
+			revoked_at: null,
+			invite_kind: "add_device" as const,
+			target_identity_id: "identity-brian",
+			reviewed_preview_digest: "d".repeat(64),
+		};
+		const consumeRecipientInvite = vi.fn(async () => ({
+			status: "existing" as const,
+			invite: { ...invite, recipient_actor_id: "identity-brian" },
+		}));
+		const store = createMockStore({
+			getInviteByTokenForInspection: vi.fn(async () => invite),
+			consumeRecipientInvite,
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: { adminSecret: () => "test-secret", now: () => "2026-03-28T00:00:00Z" },
+			requestVerifier: allowRequest,
+		});
+
+		const response = await app.request("/v1/join", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				token: invite.token,
+				invite_kind: "add_device",
+				identity_id: "identity-brian",
+				device_id: "device-brian-2",
+				public_key: publicKey,
+				fingerprint: fingerprintPublicKey(publicKey),
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			status: "existing",
+			kind: "add_device",
+			target_identity_id: "identity-brian",
+		});
+		expect(consumeRecipientInvite).toHaveBeenCalledOnce();
+	});
+
 	it("rejects project invites accepted by the inviter device", async () => {
 		const publicKey = "inviter-public-key";
 		const operationId = `share_${"a".repeat(40)}`;
@@ -589,7 +641,68 @@ describe("createCoordinatorApp dependency injection", () => {
 		});
 
 		expect(response.status).toBe(200);
-		expect(await response.json()).toMatchObject({ ok: true, status: "existing" });
+		expect(await response.json()).toMatchObject({ ok: true, status: "pending_setup" });
+		expect(consumeProjectInvite).toHaveBeenCalledOnce();
+	});
+
+	it("reports a newly consumed project invite as pending setup", async () => {
+		const publicKey = "recipient-public-key";
+		const operationId = `share_${"b".repeat(40)}`;
+		const consumeProjectInvite = vi.fn(async () => ({
+			status: "accepted" as const,
+			invite: {
+				group_id: "g1",
+				operation_id: operationId,
+				trust_state: "pending_inviter_device",
+			},
+			bootstrap_grant: null,
+			seed_enrollment: null,
+		}));
+		const store = createMockStore({
+			getInviteByTokenForInspection: vi.fn(async () => ({
+				invite_id: "invite-project-new",
+				group_id: "g1",
+				token: "token-project-new",
+				policy: "auto_admit",
+				expires_at: "2099-01-01T00:00:00Z",
+				created_at: "2026-03-28T00:00:00Z",
+				created_by: null,
+				team_name_snapshot: "Team One",
+				revoked_at: null,
+				operation_id: operationId,
+				reviewed_project_set_digest: "c".repeat(64),
+				inviter_device_id: "device-adam",
+			})),
+			consumeProjectInvite,
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: { adminSecret: () => "test-secret", now: () => "2026-03-28T00:00:00Z" },
+			requestVerifier: allowRequest,
+		});
+
+		const response = await app.request("/v1/join", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				token: "token-project-new",
+				operation_id: operationId,
+				device_id: "device-recipient",
+				public_key: publicKey,
+				fingerprint: fingerprintPublicKey(publicKey),
+				recipient_actor_id: "actor-brian",
+				recipient_display_name: "Brian",
+				device_display_name: "Brian's Mac",
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			ok: true,
+			status: "pending_setup",
+			operation_id: operationId,
+			trust_state: "pending_inviter_device",
+		});
 		expect(consumeProjectInvite).toHaveBeenCalledOnce();
 	});
 

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -21,6 +21,7 @@ import type {
 	CoordinatorScopeMembership,
 	CoordinatorStore,
 } from "./coordinator-store-contract.js";
+import { PROJECT_INVITE_PENDING_STATUS } from "./project-invite-acceptance.js";
 import {
 	normalizeIdentityDisplayName,
 	normalizeProjectInviteSummaries,
@@ -1932,7 +1933,7 @@ export function createCoordinatorApp(
 					});
 					return c.json({
 						ok: true,
-						status: acceptance.status,
+						status: PROJECT_INVITE_PENDING_STATUS,
 						group_id: acceptance.invite.group_id,
 						operation_id: acceptance.invite.operation_id,
 						trust_state: acceptance.invite.trust_state,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -526,6 +526,13 @@ export {
 	resolveProject,
 	resolveProjectRoot,
 } from "./project.js";
+export {
+	isProjectSyncEnablementError,
+	PROJECT_INVITE_PENDING_STATUS,
+	PROJECT_SYNC_ENABLEMENT_FAILED,
+	PROJECT_SYNC_ENABLEMENT_FAILURE_DETAIL,
+	ProjectSyncEnablementError,
+} from "./project-invite-acceptance.js";
 export type { ProjectInviteSummary } from "./project-invite-identity.js";
 export {
 	friendlyDeviceName,

--- a/packages/core/src/project-invite-acceptance.ts
+++ b/packages/core/src/project-invite-acceptance.ts
@@ -1,0 +1,27 @@
+export const PROJECT_INVITE_PENDING_STATUS = "pending_setup" as const;
+
+export const PROJECT_SYNC_ENABLEMENT_FAILED = "project_sync_enablement_failed" as const;
+
+export const PROJECT_SYNC_ENABLEMENT_FAILURE_DETAIL =
+	"Invitation was accepted, but sync could not be enabled. Make the codemem config writable, then retry.";
+
+export class ProjectSyncEnablementError extends Error {
+	readonly code = PROJECT_SYNC_ENABLEMENT_FAILED;
+	readonly detail = PROJECT_SYNC_ENABLEMENT_FAILURE_DETAIL;
+
+	constructor(options?: ErrorOptions) {
+		super(PROJECT_SYNC_ENABLEMENT_FAILURE_DETAIL, options);
+		this.name = "ProjectSyncEnablementError";
+	}
+}
+
+export function isProjectSyncEnablementError(error: unknown): error is ProjectSyncEnablementError {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === PROJECT_SYNC_ENABLEMENT_FAILED &&
+		"detail" in error &&
+		error.detail === PROJECT_SYNC_ENABLEMENT_FAILURE_DETAIL
+	);
+}

--- a/packages/core/src/share-operation-lifecycle.test.ts
+++ b/packages/core/src/share-operation-lifecycle.test.ts
@@ -125,6 +125,18 @@ describe("projectShareLifecycle", () => {
 		expect(result.explanation).not.toContain("reassign_capability_required");
 	});
 
+	it("keeps a terminal reviewed-intent failure actionable without exposing its code", () => {
+		const result = project("needs_attention", [
+			step({ status: "failed", safeErrorCode: "operation_intent_mismatch" }),
+		]);
+		expect(result).toMatchObject({
+			lifecycle: "needs_attention",
+			explanation: "The accepted Project list no longer matches the reviewed invitation.",
+			primaryAction: { kind: "retry_setup", label: "Retry setup" },
+		});
+		expect(result.explanation).not.toContain("operation_intent_mismatch");
+	});
+
 	it("warns that revocation cannot recall copied memories", () => {
 		expect(project("revoked").explanation).toBe("Previously copied memories may remain.");
 	});

--- a/packages/core/src/share-operation-lifecycle.ts
+++ b/packages/core/src/share-operation-lifecycle.ts
@@ -55,6 +55,8 @@ const FAILURE_COPY: Record<string, string> = {
 		"Existing project access needs review before setup can continue.",
 	managed_boundary_conflict: "The project access boundary does not match the reviewed share.",
 	managed_grant_conflict: "Project access could not be granted as reviewed.",
+	operation_intent_mismatch: "The accepted Project list no longer matches the reviewed invitation.",
+	operation_scope_mismatch: "The accepted invitation no longer matches this owner's sharing setup.",
 	operation_read_failed: "Invitation status could not be refreshed from the coordinator.",
 	project_mapping_conflict: "The project is already assigned to different access settings.",
 	reassign_capability_required:

--- a/packages/core/src/share-operation.test.ts
+++ b/packages/core/src/share-operation.test.ts
@@ -441,7 +441,7 @@ describe("share-operation persistence", () => {
 					recipient_device_display_name, bootstrap_grant_id FROM share_operations`)
 				.get(),
 		).toEqual({
-			state: "accepted",
+			state: "provisioning",
 			person_id: "actor-brian",
 			recipient_actor_id: "actor-brian",
 			recipient_device_id: "device-brian",

--- a/packages/core/src/share-operation.ts
+++ b/packages/core/src/share-operation.ts
@@ -627,7 +627,7 @@ export function reconcileShareOperationAcceptance(
 			if (linked.changes !== 1) throw new Error("pending_person_identity_conflict");
 		}
 		db.prepare(`UPDATE share_operations SET
-				state = CASE WHEN state IN ('waiting_for_acceptance', 'accepted') THEN 'accepted' ELSE state END,
+				state = CASE WHEN state IN ('waiting_for_acceptance', 'accepted') THEN 'provisioning' ELSE state END,
 				person_id = ?, person_kind = 'existing',
 				pending_person_operation_id = NULL, recipient_actor_id = ?, recipient_display_name = ?,
 				recipient_device_id = ?, recipient_device_display_name = ?, recipient_public_key = ?,

--- a/packages/core/src/share-provisioning.test.ts
+++ b/packages/core/src/share-provisioning.test.ts
@@ -431,6 +431,12 @@ describe("exact project share provisioning", () => {
 
 	it("moves capability preflight to needs-attention after three failed attempts", async () => {
 		const { deps } = dependencies({ supportsReassignScope: vi.fn(async () => "unsupported") });
+		expect(
+			db
+				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+				.pluck()
+				.get(operationId),
+		).toBe("provisioning");
 
 		for (let attempt = 1; attempt <= 3; attempt += 1) {
 			await expect(
@@ -441,7 +447,7 @@ describe("exact project share provisioning", () => {
 					.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
 					.pluck()
 					.get(operationId),
-			).toBe(attempt === 3 ? "needs_attention" : "accepted");
+			).toBe(attempt === 3 ? "needs_attention" : "provisioning");
 		}
 
 		expect(

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -4,6 +4,7 @@ import {
 	advanceShareOperation,
 	commitRecipientPolicyEdges,
 	createRecipientInvite,
+	importCoordinatorInvite,
 	inspectCoordinatorInvite,
 	loadRecipientPolicyIntent,
 	loadRecipientPolicyReconciliationStatus,
@@ -27,6 +28,34 @@ afterEach(() => {
 });
 
 describe("recipient invitation API", () => {
+	it("prefers actionable invite-import detail over an opaque error code", async () => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						detail: "Restart codemem to finish project setup.",
+						error: "sync_runtime_disabled",
+					}),
+					{ status: 409 },
+				),
+		) as typeof fetch;
+
+		await expect(importCoordinatorInvite("project-invite")).rejects.toThrow(
+			"Restart codemem to finish project setup.",
+		);
+	});
+
+	it("ignores blank invite-import detail and falls back to the error code", async () => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ detail: "   ", error: "invalid_invite" }), {
+					status: 400,
+				}),
+		) as typeof fetch;
+
+		await expect(importCoordinatorInvite("bad-invite")).rejects.toThrow("invalid_invite");
+	});
+
 	it("sends exact Team preview/create and add-device inspect payloads", async () => {
 		const preview = {
 			kind: "team_member",

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -108,7 +108,10 @@ export async function importCoordinatorInvite(
 		body: JSON.stringify({ invite, ...identity }),
 	});
 	const { text, payload: data } = await readJsonPayload<ImportInviteResult>(resp);
-	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	if (!resp.ok) {
+		const detail = typeof data?.detail === "string" ? data.detail.trim() : "";
+		throw new Error(detail || payloadError(data) || text || "request failed");
+	}
 	return data;
 }
 

--- a/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.test.ts
+++ b/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../../project-sharing", () => ({ openProjectShareFlow: vi.fn() }));
 
 import * as api from "../../../../lib/api";
 import { showGlobalNotice } from "../../../../lib/notice";
+import { state } from "../../../../lib/state";
 import { openProjectShareFlow } from "../../../project-sharing";
 import { initTeamSyncEvents } from "./init-team-sync-events";
 
@@ -191,5 +192,36 @@ describe("project invite review events", () => {
 			recipient_name: "Brian Updated",
 		});
 		await vi.waitFor(() => expect(button.textContent).toBe("Review invite"));
+	});
+
+	it.each([
+		["restart-required", { restart_required: true }],
+		["pending inviter", { setup_state: "pending_inviter" }],
+		["pending-setup status", { status: "pending_setup" }],
+	])("reports project invitation %s detail as a warning", async (_label, pendingState) => {
+		vi.mocked(api.importCoordinatorInvite).mockResolvedValueOnce({
+			type: "project_share",
+			status: "accepted",
+			detail: "Restart codemem to finish project setup.",
+			...pendingState,
+		});
+		initTeamSyncEvents(
+			() => {},
+			async () => {},
+		);
+		const invite = document.getElementById("syncJoinInvite") as HTMLTextAreaElement;
+		const button = document.getElementById("syncJoinButton") as HTMLButtonElement;
+		invite.value = "project-invite";
+
+		button.click();
+		await vi.waitFor(() => expect(button.textContent).toBe("Accept and start syncing"));
+		button.click();
+
+		await vi.waitFor(() =>
+			expect(state.syncJoinFlowFeedback).toEqual({
+				message: "Restart codemem to finish project setup.",
+				tone: "warning",
+			}),
+		);
 	});
 });

--- a/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
+++ b/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
@@ -220,10 +220,13 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 		try {
 			const result = await api.importCoordinatorInvite(inviteValue, identity);
 			state.lastTeamJoin = result;
-			const resultType =
-				typeof (result as { type?: unknown }).type === "string"
-					? ((result as { type: string }).type as "pair" | "team_join")
-					: "team_join";
+			const resultFields = result as {
+				detail?: unknown;
+				restart_required?: unknown;
+				setup_state?: unknown;
+				type?: unknown;
+			};
+			const resultType = typeof resultFields.type === "string" ? resultFields.type : "team_join";
 			let feedback: SyncActionFeedback;
 			if (resultType === "pair") {
 				const peerId = String((result as { peer_device_id?: unknown }).peer_device_id ?? "").trim();
@@ -233,6 +236,24 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 						: "Paired the device. It will appear in People & devices.",
 					tone: "success",
 				};
+			} else if (resultType === "project_share") {
+				const pendingSetup =
+					resultFields.restart_required === true ||
+					resultFields.setup_state === "pending_inviter" ||
+					result.status === "pending_setup";
+				const detail = typeof resultFields.detail === "string" ? resultFields.detail.trim() : "";
+				feedback = pendingSetup
+					? {
+							message:
+								detail ||
+								(resultFields.restart_required === true
+									? "Project invitation accepted. Restart codemem to finish setup."
+									: resultFields.setup_state === "pending_inviter"
+										? "Project invitation accepted. Waiting for the inviter to finish setup."
+										: "Project invitation accepted. Setup is still pending."),
+							tone: "warning",
+						}
+					: { message: "Project invitation accepted.", tone: "success" };
 			} else {
 				feedback = {
 					message:

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -10612,6 +10612,21 @@ describe("viewer-server", () => {
 						}),
 					});
 					expect(accepted.status, JSON.stringify(await accepted.clone().json())).toBe(200);
+					const acceptedBody = (await accepted.json()) as Record<string, unknown>;
+					expect(acceptedBody).toMatchObject({
+						status: "accepted",
+						type: "recipient_onboarding",
+					});
+					expect(acceptedBody).not.toHaveProperty("restart_required");
+					expect(acceptedBody).not.toHaveProperty("setup_state");
+					const persistedConfig = JSON.parse(readFileSync(configPath, "utf8")) as Record<
+						string,
+						unknown
+					>;
+					expect(persistedConfig).not.toHaveProperty("sync_enabled");
+					expect(persistedConfig).not.toHaveProperty("sync_host");
+					expect(persistedConfig).not.toHaveProperty("sync_port");
+					expect(persistedConfig).not.toHaveProperty("sync_interval_s");
 					expect(joinBody).toMatchObject({
 						invite_kind: kind,
 						identity_id: store.actorId,
@@ -11236,6 +11251,8 @@ describe("viewer-server", () => {
 			const fingerprint = fingerprintPublicKey(publicKey);
 			let mode:
 				| "not_found"
+				| "upstream_500"
+				| "transport"
 				| "malformed"
 				| "wrong_group"
 				| "waiting"
@@ -11244,6 +11261,14 @@ describe("viewer-server", () => {
 			const fetchMock = vi.fn(async () => {
 				if (mode === "not_found") {
 					return new Response(JSON.stringify({ error: "operation_not_found" }), { status: 404 });
+				}
+				if (mode === "upstream_500") {
+					return new Response("coordinator stack trace with internal-host.example", {
+						status: 500,
+					});
+				}
+				if (mode === "transport") {
+					throw new Error("fetch failed for internal-host.example");
 				}
 				if (mode === "malformed") {
 					return new Response(JSON.stringify({ error: "operation_intent_invalid" }), {
@@ -11331,13 +11356,54 @@ describe("viewer-server", () => {
 					.run(operationId, projectId);
 
 				const request = () => app.request(`/api/sync/project-invites/${operationId}`);
-				expect((await request()).status).toBe(404);
+				const notFound = await request();
+				expect(notFound.status).toBe(404);
+				expect(await notFound.json()).toEqual({ error: "operation_not_found" });
+				const missingOperationId = `share_${"8".repeat(40)}`;
+				const missingReconcile = await app.request(
+					`/api/sync/project-invites/${missingOperationId}/reconcile`,
+					{ method: "POST" },
+				);
+				expect(missingReconcile.status).toBe(404);
+				expect(await missingReconcile.json()).toEqual({ error: "operation_not_found" });
+				mode = "upstream_500";
+				for (const [label, response] of [
+					["read", await request()],
+					[
+						"reconcile",
+						await app.request(`/api/sync/project-invites/${operationId}/reconcile`, {
+							method: "POST",
+						}),
+					],
+				] as const) {
+					expect(response.status, label).toBe(502);
+					const body = await response.json();
+					expect(body).toEqual({ error: "coordinator_upstream_failed" });
+					expect(JSON.stringify(body)).not.toContain("internal-host.example");
+				}
+				mode = "transport";
+				for (const [label, response] of [
+					["read", await request()],
+					[
+						"reconcile",
+						await app.request(`/api/sync/project-invites/${operationId}/reconcile`, {
+							method: "POST",
+						}),
+					],
+				] as const) {
+					expect(response.status, label).toBe(503);
+					const body = await response.json();
+					expect(body).toEqual({ error: "coordinator_unavailable" });
+					expect(JSON.stringify(body)).not.toContain("internal-host.example");
+				}
 				mode = "malformed";
 				const malformed = await request();
 				expect(malformed.status).toBe(409);
 				expect(await malformed.json()).toEqual({ error: "operation_intent_invalid" });
 				mode = "wrong_group";
-				expect((await request()).status).toBe(409);
+				const wrongGroup = await request();
+				expect(wrongGroup.status).toBe(409);
+				expect(await wrongGroup.json()).toEqual({ error: "operation_scope_mismatch" });
 				mode = "waiting";
 				const waiting = await request();
 				expect(waiting.status).toBe(200);
@@ -11365,7 +11431,7 @@ describe("viewer-server", () => {
 				mode = "accepted";
 				const accepted = await request();
 				expect(accepted.status).toBe(200);
-				expect(await accepted.json()).toMatchObject({ state: "accepted" });
+				expect(await accepted.json()).toMatchObject({ state: "pending_setup" });
 				expect(
 					store.db
 						.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
@@ -11375,14 +11441,16 @@ describe("viewer-server", () => {
 
 				const reconcile = () =>
 					app.request(`/api/sync/project-invites/${operationId}/reconcile`, { method: "POST" });
-				expect((await reconcile()).status).toBe(200);
+				const firstReconcile = await reconcile();
+				expect(firstReconcile.status).toBe(200);
+				expect(await firstReconcile.json()).toMatchObject({ state: "pending_setup" });
 				expect((await reconcile()).status).toBe(200);
 				expect(
 					store.db
 						.prepare("SELECT state, recipient_actor_id, recipient_device_id FROM share_operations")
 						.get(),
 				).toEqual({
-					state: "accepted",
+					state: "provisioning",
 					recipient_actor_id: "actor-brian",
 					recipient_device_id: "device-brian",
 				});
@@ -11723,6 +11791,8 @@ describe("viewer-server", () => {
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body.group_id).toBe("team-a");
 				expect(body.status).toBe("pending");
+				expect(body.type).toBe("team_join");
+				expect(body).not.toHaveProperty("restart_required");
 				expect(store.deviceId).not.toBe("local");
 				expect(store.actorId).toBe(`local:${store.deviceId}`);
 				expect(store.actorDisplayName).toBe("Fixture User");
@@ -11739,6 +11809,10 @@ describe("viewer-server", () => {
 				>;
 				expect(writtenConfig.sync_coordinator_url).toBe("https://coord.example.test");
 				expect(writtenConfig.sync_coordinator_group).toBe("team-a");
+				expect(writtenConfig).not.toHaveProperty("sync_enabled");
+				expect(writtenConfig).not.toHaveProperty("sync_host");
+				expect(writtenConfig).not.toHaveProperty("sync_port");
+				expect(writtenConfig).not.toHaveProperty("sync_interval_s");
 			} finally {
 				cleanup();
 				globalThis.fetch = prevFetch;
@@ -11854,6 +11928,7 @@ describe("viewer-server", () => {
 			const invite = Buffer.from(JSON.stringify(invitePayload), "utf8").toString("base64url");
 			let joinBody: Record<string, unknown> = {};
 			let corruptInviter = false;
+			let exposeInternalFailure = false;
 			const inviterPublicKey = "inviter-public-key";
 			const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
 				const url = String(input);
@@ -11870,6 +11945,7 @@ describe("viewer-server", () => {
 					);
 				}
 				if (url.includes("/v1/join")) {
+					if (exposeInternalFailure) throw new Error("internal recipient device id: device-secret");
 					joinBody = JSON.parse(
 						init?.body instanceof Uint8Array
 							? new TextDecoder().decode(init.body)
@@ -11947,6 +12023,13 @@ describe("viewer-server", () => {
 				});
 				const acceptedBody = (await accepted.json()) as Record<string, unknown>;
 				expect(accepted.status, JSON.stringify(acceptedBody)).toBe(200);
+				expect(acceptedBody).toMatchObject({
+					status: "pending_setup",
+					setup_state: "pending_inviter",
+					sync_enabled: true,
+					type: "project_share",
+				});
+				expect(acceptedBody).not.toHaveProperty("restart_required");
 				expect(joinBody).toMatchObject({
 					operation_id: operationId,
 					recipient_actor_id: store.actorId,
@@ -11972,6 +12055,16 @@ describe("viewer-server", () => {
 						.prepare("SELECT pending_bootstrap_grant_id FROM sync_peers WHERE peer_device_id = ?")
 						.get("device-adam"),
 				).toEqual({ pending_bootstrap_grant_id: "grant-1" });
+				const enabledConfig = JSON.parse(readFileSync(configPath, "utf8")) as Record<
+					string,
+					unknown
+				>;
+				expect(enabledConfig).toMatchObject({
+					sync_enabled: true,
+					sync_host: "0.0.0.0",
+					sync_port: 7337,
+					sync_interval_s: 120,
+				});
 				corruptInviter = true;
 				const rejected = await app.request("/api/sync/invites/import", {
 					method: "POST",
@@ -11983,7 +12076,21 @@ describe("viewer-server", () => {
 					}),
 				});
 				expect(rejected.status).toBe(400);
-				expect(await rejected.json()).toEqual({ error: "inviter_identity_invalid" });
+				expect(await rejected.json()).toEqual({
+					error: "inviter_identity_invalid",
+					detail:
+						"The owner's device identity could not be verified. Ask the owner to review the share and create a new invitation.",
+				});
+				exposeInternalFailure = true;
+				const redactedFailure = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite, device_name: "Brian's Test Mac" }),
+				});
+				expect(redactedFailure.status).toBe(400);
+				const redactedBody = (await redactedFailure.json()) as Record<string, unknown>;
+				expect(redactedBody.error).toBe("project_invite_acceptance_failed");
+				expect(JSON.stringify(redactedBody)).not.toContain("device-secret");
 			} finally {
 				cleanup();
 				globalThis.fetch = prevFetch;
@@ -11991,6 +12098,171 @@ describe("viewer-server", () => {
 				else process.env.CODEMEM_CONFIG = prevConfig;
 				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
 				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("persists restart-required project setup and replays acceptance without duplicate records", async () => {
+			const testDir = mkdtempSync(join(tmpdir(), "codemem-project-restart-test-"));
+			const configPath = join(testDir, "config.json");
+			const keysDir = join(testDir, "keys");
+			const previousConfig = process.env.CODEMEM_CONFIG;
+			const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const previousFetch = globalThis.fetch;
+			const operationId = `share_${"d".repeat(40)}`;
+			const inviterPublicKey = "restart-inviter-public-key";
+			const invite = core.encodeInvitePayload({
+				v: 1,
+				kind: "coordinator_team_invite",
+				coordinator_url: "https://coord.example.test",
+				group_id: "team-a",
+				policy: "auto_admit",
+				token: "project-restart-token",
+				expires_at: "2099-01-01T00:00:00.000Z",
+				team_name: "Team A",
+				operation_id: operationId,
+			});
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({ actor_display_name: "Brian", sync_enabled: false }),
+			);
+			const fetchMock = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							status: "pending_setup",
+							operation_id: operationId,
+							group_id: "team-a",
+							trust_state: "bootstrap_grant_created",
+							bootstrap_grant_id: "grant-restart",
+							inviter_device: {
+								device_id: "device-adam",
+								public_key: inviterPublicKey,
+								fingerprint: fingerprintPublicKey(inviterPublicKey),
+								display_name: "Adam's Mac",
+							},
+						}),
+						{ status: 200 },
+					),
+			);
+			globalThis.fetch = fetchMock as typeof fetch;
+			const { app, ensureStore, cleanup } = createTestApp({
+				seedDevice: false,
+				getSyncRuntimeStatus: () => ({ phase: "disabled", detail: "Sync is disabled" }),
+			});
+			try {
+				const store = ensureStore();
+				for (let attempt = 0; attempt < 2; attempt += 1) {
+					const response = await app.request("/api/sync/invites/import", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ invite, device_name: "Brian's Mac" }),
+					});
+					expect(response.status).toBe(200);
+					expect(await response.json()).toMatchObject({
+						status: "pending_setup",
+						setup_state: "restart_required",
+						restart_required: true,
+						type: "project_share",
+						detail: expect.stringContaining("Restart codemem"),
+					});
+				}
+				expect(fetchMock).toHaveBeenCalledTimes(2);
+				expect(JSON.parse(readFileSync(configPath, "utf8"))).toMatchObject({
+					sync_enabled: true,
+					sync_host: "0.0.0.0",
+					sync_port: 7337,
+					sync_interval_s: 120,
+					sync_coordinator_groups: ["team-a"],
+				});
+				expect(
+					store.db
+						.prepare("SELECT COUNT(*) FROM sync_peers WHERE peer_device_id = 'device-adam'")
+						.pluck()
+						.get(),
+				).toBe(1);
+				expect(
+					store.db
+						.prepare("SELECT COUNT(*) FROM actors WHERE actor_id = ?")
+						.pluck()
+						.get(store.actorId),
+				).toBe(1);
+			} finally {
+				cleanup();
+				globalThis.fetch = previousFetch;
+				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previousConfig;
+				if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
+				rmSync(testDir, { recursive: true, force: true });
+			}
+		});
+
+		it("returns a safe actionable error when project sync config cannot be written", async () => {
+			const testDir = mkdtempSync(join(tmpdir(), "codemem-project-config-failure-test-"));
+			const configPath = join(testDir, "config-as-directory");
+			const keysDir = join(testDir, "keys");
+			const previousConfig = process.env.CODEMEM_CONFIG;
+			const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const previousFetch = globalThis.fetch;
+			const inviterPublicKey = "config-failure-inviter-public-key";
+			mkdirSync(configPath);
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							status: "pending_setup",
+							operation_id: `share_${"e".repeat(40)}`,
+							group_id: "team-a",
+							trust_state: "bootstrap_grant_created",
+							bootstrap_grant_id: "grant-write",
+							inviter_device: {
+								device_id: "internal-device-id",
+								public_key: inviterPublicKey,
+								fingerprint: fingerprintPublicKey(inviterPublicKey),
+							},
+						}),
+						{ status: 200 },
+					),
+			) as typeof fetch;
+			const invite = core.encodeInvitePayload({
+				v: 1,
+				kind: "coordinator_team_invite",
+				coordinator_url: "https://coord.example.test",
+				group_id: "team-a",
+				policy: "auto_admit",
+				token: "project-config-write-token",
+				expires_at: "2099-01-01T00:00:00.000Z",
+				team_name: "Team A",
+				operation_id: `share_${"e".repeat(40)}`,
+			});
+			const { app, cleanup } = createTestApp({ seedDevice: false });
+			try {
+				const response = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite, recipient_name: "Brian" }),
+				});
+				expect(response.status).toBe(400);
+				const body = (await response.json()) as Record<string, unknown>;
+				expect(body).toEqual({
+					error: "project_sync_enablement_failed",
+					detail:
+						"Invitation was accepted, but sync could not be enabled. Make the codemem config writable, then retry.",
+				});
+				expect(JSON.stringify(body)).not.toContain("internal-device-id");
+				expect(JSON.stringify(body)).not.toContain(configPath);
+			} finally {
+				cleanup();
+				globalThis.fetch = previousFetch;
+				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previousConfig;
+				if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
+				rmSync(testDir, { recursive: true, force: true });
 			}
 		});
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -82,6 +82,7 @@ import {
 	getSyncResetState,
 	type InboundScopeRejectionPeerSummary,
 	inviteTokenDigest,
+	isProjectSyncEnablementError,
 	isScopedSyncCapability,
 	LEGACY_SHARED_REVIEW_SCOPE_ID,
 	LOCAL_DEFAULT_SCOPE_ID,
@@ -617,6 +618,39 @@ function parseInviteTtlHours(value: unknown): number | null {
 	return ttlHours;
 }
 
+function projectInviteAcceptanceFailure(error: unknown): {
+	error: string;
+	detail: string;
+} {
+	if (isProjectSyncEnablementError(error)) {
+		return { error: error.code, detail: error.detail };
+	}
+	const code = error instanceof Error ? error.message : "project_invite_acceptance_failed";
+	const detailByCode: Record<string, string> = {
+		invite_already_bound:
+			"This invitation was accepted by another device. Ask the owner to create a new invitation.",
+		invite_expired: "This invitation expired. Ask the owner to create a new invitation.",
+		invite_identity_conflict:
+			"This invitation does not match this Identity. Ask the owner to create a new invitation for this recipient.",
+		invite_invalid: "This invitation is no longer valid. Ask the owner to create a new invitation.",
+		inviter_identity_invalid:
+			"The owner's device identity could not be verified. Ask the owner to review the share and create a new invitation.",
+		project_invite_self_acceptance_forbidden:
+			"The owner cannot accept this recipient invitation on the owner's device.",
+		project_invite_bootstrap_incomplete:
+			"The owner's device is not ready to establish trust yet. Retry once, then ask the owner to review the share.",
+		project_invite_trust_state_invalid:
+			"The owner's trust setup could not be verified. Ask the owner to review the share.",
+	};
+	const safeCode = Object.hasOwn(detailByCode, code) ? code : "project_invite_acceptance_failed";
+	return {
+		error: safeCode,
+		detail:
+			detailByCode[code] ??
+			"The invitation could not be accepted safely. Retry once, then ask the owner to review the share.",
+	};
+}
+
 const PROJECT_INVITE_TTL_HOURS = 7 * 24;
 const PROJECT_INVITE_BODY_KEYS = new Set([
 	"teammate_name",
@@ -968,7 +1002,11 @@ async function coordinatorProjectInvitePayload(operationId: string): Promise<{
 			headers: { "X-Codemem-Coordinator-Admin": config.syncCoordinatorAdminSecret },
 			timeoutS: 10,
 		},
-	);
+	).catch((cause: unknown) => {
+		const error = new Error("coordinator_unavailable", { cause });
+		Object.assign(error, { status: 503 });
+		throw error;
+	});
 	if (status < 200 || status >= 300) {
 		const error = new Error(String(payload?.error ?? "operation_read_failed"));
 		Object.assign(error, { status });
@@ -1331,11 +1369,7 @@ const TERMINAL_SHARE_MAINTENANCE_ERRORS = new Set([
 	"intent_conflict",
 	"inviter_identity_conflict",
 ]);
-const TERMINAL_RECONCILIATION_ERRORS = new Set([
-	"coordinator_not_configured",
-	"team_sharing_not_configured",
-	"team_selection_ambiguous",
-	"operation_not_found",
+const PROJECT_INVITE_OWNER_CONFLICT_ERRORS = new Set([
 	"operation_scope_mismatch",
 	"operation_state_invalid",
 	"operation_acceptance_invalid",
@@ -1350,10 +1384,43 @@ const TERMINAL_RECONCILIATION_ERRORS = new Set([
 	"intent_conflict",
 	"inviter_identity_conflict",
 ]);
+const TERMINAL_RECONCILIATION_ERRORS = new Set([
+	"coordinator_not_configured",
+	"team_sharing_not_configured",
+	"team_selection_ambiguous",
+	"operation_not_found",
+	...PROJECT_INVITE_OWNER_CONFLICT_ERRORS,
+]);
 
 function errorStatus(error: unknown): number | null {
 	const value = error && typeof error === "object" ? (error as { status?: unknown }).status : null;
-	return typeof value === "number" && Number.isFinite(value) ? value : null;
+	return typeof value === "number" && Number.isInteger(value) && value >= 400 && value <= 599
+		? value
+		: null;
+}
+
+function projectInviteOwnerErrorResponse(
+	error: unknown,
+	fallback: { code: "operation_read_failed" | "operation_reconcile_failed"; status: 400 | 409 },
+): {
+	code: string;
+	status: 400 | 404 | 409 | 502 | 503;
+} {
+	const message = error instanceof Error ? error.message : "";
+	const status = errorStatus(error);
+	if (message === "operation_not_found" && (status == null || status === 404)) {
+		return { code: message, status: 404 };
+	}
+	if (PROJECT_INVITE_OWNER_CONFLICT_ERRORS.has(message) && (status == null || status === 409)) {
+		return { code: message, status: 409 };
+	}
+	if (status != null && status >= 500 && message !== "coordinator_unavailable") {
+		return { code: "coordinator_upstream_failed", status: 502 };
+	}
+	if (message === "coordinator_unavailable" || status === 408 || status === 429 || status === 503) {
+		return { code: "coordinator_unavailable", status: 503 };
+	}
+	return fallback;
 }
 
 function isRetryableReconciliationError(error: unknown): boolean {
@@ -5098,17 +5165,15 @@ export function syncRoutes(
 		}
 		try {
 			const { payload } = await coordinatorProjectInvitePayload(operationId);
-			return c.json(payload);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "operation_read_failed";
 			return c.json(
-				{ error: message },
-				message === "operation_not_found"
-					? 404
-					: message.includes("mismatch") || message === "operation_intent_invalid"
-						? 409
-						: 400,
+				payload.state === "accepted" ? { ...payload, state: "pending_setup" } : payload,
 			);
+		} catch (error) {
+			const mapped = projectInviteOwnerErrorResponse(error, {
+				code: "operation_read_failed",
+				status: 400,
+			});
+			return c.json({ error: mapped.code }, mapped.status);
 		}
 	});
 
@@ -5124,11 +5189,14 @@ export function syncRoutes(
 				ok: true,
 				operation_id: operationId,
 				reconciled: result.accepted,
-				state: result.accepted ? "accepted" : "waiting_for_acceptance",
+				state: result.accepted ? "pending_setup" : "waiting_for_acceptance",
 			});
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "operation_reconcile_failed";
-			return c.json({ error: message }, message === "operation_not_found" ? 404 : 409);
+			const mapped = projectInviteOwnerErrorResponse(error, {
+				code: "operation_reconcile_failed",
+				status: 409,
+			});
+			return c.json({ error: mapped.code }, mapped.status);
 		}
 	});
 
@@ -5715,8 +5783,8 @@ export function syncRoutes(
 	// invite envelope or codemem:// link) and device-pairing payloads
 	// (base64 JSON with { device_id, fingerprint, public_key, addresses }).
 	// The server discriminates by decoding the pasted text — UI callers get
-	// one textarea for both flows. Response carries `type: "team_join"` or
-	// `type: "pair"` so the UI can render the right success message.
+	// one textarea for all flows. Response type distinguishes legacy Team joins,
+	// exact-Project pending setup, recipient onboarding, and direct pairing.
 	app.post("/api/sync/invites/import", async (c) => {
 		const store = getStore();
 		let body: Record<string, unknown>;
@@ -5774,8 +5842,10 @@ export function syncRoutes(
 			}
 		}
 
+		let projectInvite = false;
 		try {
 			const decoded = decodeInvitePayload(extractInvitePayload(rawValue));
+			projectInvite = Boolean(decoded.operation_id);
 			ensureStableStoreIdentity(store);
 			const recipientInvite = decoded.kind === "team_member" || decoded.kind === "add_device";
 			const reviewedOnboardingDigest =
@@ -5794,14 +5864,30 @@ export function syncRoutes(
 				deviceDisplayName: typeof body.device_name === "string" ? body.device_name : null,
 				reviewedOnboardingDigest: reviewedOnboardingDigest || null,
 			});
+			const type = recipientInvite
+				? "recipient_onboarding"
+				: projectInvite
+					? "project_share"
+					: "team_join";
+			if (projectInvite && getSyncRuntimeStatus?.()?.phase === "disabled") {
+				return c.json(
+					{
+						...result,
+						type,
+						setup_state: "restart_required",
+						restart_required: true,
+						detail:
+							"The invitation was accepted and sync was enabled. Restart codemem to start the sync service; Project setup remains pending until the first sync finishes.",
+					},
+					200,
+				);
+			}
 			return c.json({
 				...result,
-				type:
-					decoded.kind === "team_member" || decoded.kind === "add_device"
-						? "recipient_onboarding"
-						: "team_join",
+				type,
 			});
 		} catch (error) {
+			if (projectInvite) return c.json(projectInviteAcceptanceFailure(error), 400);
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
 		}
 	});


### PR DESCRIPTION
## Description

Make exact-Project invitation acceptance truthful: token consumption enters pending setup until inviter provisioning converges, recipient sync is enabled, restart requirements are explicit, and safe typed errors reach both recipient and owner surfaces.

Closes codemem-mzj1.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Core, coordinator API, viewer, worker, and `e2e:project-sharing` validation passed. The complete stack passed `pnpm run check` with 3,207 tests.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced