### PR TITLE
feat(sharing): accept project invites in Sharing

### DIFF
--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -56,6 +56,23 @@ describe("recipient invitation API", () => {
 		await expect(importCoordinatorInvite("bad-invite")).rejects.toThrow("invalid_invite");
 	});
 
+	it("omits unavailable optional identity names from Project invitation imports", async () => {
+		const fetchMock = vi.fn().mockResolvedValueOnce(
+			new Response(JSON.stringify({ status: "pending_setup", type: "project_share" }), {
+				status: 200,
+			}),
+		);
+		globalThis.fetch = fetchMock as typeof fetch;
+
+		await importCoordinatorInvite("project-invite", {});
+
+		expect(fetchMock).toHaveBeenCalledWith("/api/sync/invites/import", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ invite: "project-invite" }),
+		});
+	});
+
 	it("sends exact Team preview/create and add-device inspect payloads", async () => {
 		const preview = {
 			kind: "team_member",

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -76,6 +76,18 @@ export interface CreatedRecipientInvite extends RecipientInvitePreviewResult {
 	};
 }
 
+type CoordinatorInviteIdentity =
+	| {
+			recipient_name?: string;
+			device_name?: string;
+			reviewed_onboarding_digest?: never;
+	  }
+	| {
+			recipient_name: string;
+			device_name: string;
+			reviewed_onboarding_digest: string;
+	  };
+
 type TriggerSyncTarget = {
 	address?: string;
 	peerDeviceId?: string;
@@ -96,11 +108,7 @@ export async function loadSyncStatus(
 
 export async function importCoordinatorInvite(
 	invite: string,
-	identity?: {
-		recipient_name: string;
-		device_name: string;
-		reviewed_onboarding_digest?: string;
-	},
+	identity?: CoordinatorInviteIdentity,
 ): Promise<ImportInviteResult> {
 	const resp = await fetch("/api/sync/invites/import", {
 		method: "POST",

--- a/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
@@ -112,6 +112,19 @@ const addDevicePreview: RecipientOnboardingPreviewV1 = {
 	reviewedOnboardingDigest: "recipient-onboarding-preview-v1:device",
 };
 
+const projectShareInspection = {
+	kind: "project_share_invite" as const,
+	operation_id: "share-projects",
+	inviter_name: "Adam",
+	team_name: "Example Team",
+	recipient_name: "Brian",
+	device_name: "Brian’s Mac",
+	projects: [
+		{ display_name: "Codemem", existing_memory_count: 41 },
+		{ display_name: "Viewer", existing_memory_count: 1 },
+	],
+};
+
 function button(label: string, root: ParentNode = document): HTMLButtonElement {
 	const match = [...root.querySelectorAll<HTMLButtonElement>("button")].find(
 		(item) => item.textContent?.trim() === label,
@@ -219,6 +232,462 @@ describe("recipient-policy invitations", () => {
 			recipient_name: "Local Identity",
 			device_name: "Travel Laptop",
 			reviewed_onboarding_digest: addDevicePreview.reviewedOnboardingDigest,
+		});
+	});
+
+	it("inspects and accepts a Team invitation with required names, digest, and Team result copy", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
+			kind: "team_member",
+			recipient_name: "Local Identity",
+			device_name: "Work Laptop",
+			onboarding: teamPreview,
+		});
+		vi.mocked(api.importCoordinatorInvite).mockResolvedValue({ status: "accepted" });
+		mount();
+
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "team-member-invite";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Current Projects for"));
+		act(() => button("Accept invitation", dialog).click());
+
+		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
+		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("team-member-invite", {
+			recipient_name: "Local Identity",
+			device_name: "Work Laptop",
+			reviewed_onboarding_digest: teamPreview.reviewedOnboardingDigest,
+		});
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Team invitation accepted"));
+		expect(dialog.textContent).not.toContain("Project setup is pending");
+	});
+
+	it("keeps unknown recipient-import errors generic", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
+			kind: "team_member",
+			recipient_name: "Local Identity",
+			device_name: "Work Laptop",
+			onboarding: teamPreview,
+		});
+		vi.mocked(api.importCoordinatorInvite).mockRejectedValue(
+			new Error("recipient_invite_unmapped_internal"),
+		);
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "team-member-invite";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Current Projects for"));
+		act(() => button("Accept invitation", dialog).click());
+
+		await vi.waitFor(() =>
+			expect(dialog.querySelector('[role="alert"]')?.textContent).toContain(
+				"Unable to accept this invitation.",
+			),
+		);
+		expect(dialog.textContent).not.toContain("recipient_invite_unmapped_internal");
+	});
+
+	it("reviews and accepts direct exact-Project access in the same dialog without repasting", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue(projectShareInspection);
+		vi.mocked(api.importCoordinatorInvite).mockResolvedValue({
+			status: "pending_setup",
+			setup_state: "pending_inviter",
+			sync_enabled: true,
+			type: "project_share",
+		});
+		mount();
+
+		const trigger = button("Review invitation");
+		trigger.focus();
+		act(() => trigger.click());
+		const dialog = document.querySelector('[role="dialog"]');
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		if (!dialog || !textarea) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "project-invite-payload";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+
+		await vi.waitFor(() =>
+			expect(api.inspectCoordinatorInvite).toHaveBeenCalledWith("project-invite-payload"),
+		);
+		await vi.waitFor(() =>
+			expect(document.activeElement).toBe(
+				document.getElementById("project-share-invitation-projects"),
+			),
+		);
+		expect(dialog.textContent).toContain("Invitation from Adam");
+		expect(dialog.textContent).toContain("direct access only");
+		expect(dialog.textContent).toContain("Codemem — 41 existing memories and future activity");
+		expect(dialog.textContent).toContain("Viewer — 1 existing memory and future activity");
+		expect(dialog.textContent).toContain("does not join a Team");
+		expect(dialog.textContent).toContain("No other Projects are included");
+		expect(dialog.textContent).not.toContain("Use Advanced Team administration");
+		expect(document.querySelector("textarea")).toBeNull();
+
+		const recipientName = dialog.querySelector<HTMLInputElement>("#project-share-recipient-name");
+		const deviceName = dialog.querySelector<HTMLInputElement>("#project-share-device-name");
+		if (!recipientName || !deviceName) throw new Error("Project identity fields missing");
+		expect(recipientName.value).toBe("Brian");
+		expect(deviceName.value).toBe("Brian’s Mac");
+		act(() => {
+			recipientName.value = "Reviewed Brian";
+			recipientName.dispatchEvent(new Event("input", { bubbles: true }));
+			deviceName.value = "Reviewed Mac";
+			deviceName.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+
+		const accept = button("Accept Project access", dialog);
+		expect(accept.type).toBe("button");
+		accept.focus();
+		act(() => accept.click());
+		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
+		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("project-invite-payload", {
+			recipient_name: "Reviewed Brian",
+			device_name: "Reviewed Mac",
+		});
+		await vi.waitFor(() =>
+			expect(document.activeElement).toBe(
+				document.getElementById("project-share-invitation-result"),
+			),
+		);
+		expect(dialog.textContent).toContain("Project setup is pending");
+		expect(dialog.textContent).toContain("owner still needs to finish access setup");
+		expect(dialog.textContent).not.toContain("Team invitation accepted");
+		expect(document.querySelector('[role="dialog"]')).toBe(dialog);
+	});
+
+	it.each([
+		["empty names", "project-share-recipient-name", "   ", "Identity display name is required"],
+		[
+			"names over 120 Unicode code points",
+			"project-share-recipient-name",
+			"😀".repeat(121),
+			"120 characters or fewer",
+		],
+		[
+			"control characters",
+			"project-share-device-name",
+			"Travel\u0007Laptop",
+			"control or format characters",
+		],
+		[
+			"format characters",
+			"project-share-device-name",
+			"Travel\u200bLaptop",
+			"control or format characters",
+		],
+	])("blocks Project import for %s", async (_label, fieldId, invalidValue, message) => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue(projectShareInspection);
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "invalid-project-name";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Who will receive access"));
+
+		const field = dialog.querySelector<HTMLInputElement>(`#${fieldId}`);
+		if (!field) throw new Error(`field missing: ${fieldId}`);
+		act(() => {
+			field.value = invalidValue;
+			field.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+
+		expect(field.getAttribute("aria-invalid")).toBe("true");
+		expect(dialog.textContent).toContain(message);
+		const accept = button("Accept Project access", dialog);
+		expect(accept.disabled).toBe(true);
+		act(() => accept.click());
+		expect(api.importCoordinatorInvite).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["missing", undefined],
+		["empty", []],
+	] as Array<
+		[string, typeof projectShareInspection.projects | undefined]
+	>)("blocks Project acceptance when the inspected Project list is $0", async (_label, projects) => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
+			...projectShareInspection,
+			projects,
+		});
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "project-without-details";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+
+		await vi.waitFor(() =>
+			expect(dialog.querySelector('[role="alert"]')?.textContent).toContain(
+				"Project details are unavailable",
+			),
+		);
+		const accept = button("Accept Project access", dialog);
+		expect(accept.disabled).toBe(true);
+		act(() => accept.click());
+		expect(api.importCoordinatorInvite).not.toHaveBeenCalled();
+	});
+
+	it("retries failed Project inspection with the preserved invite text", async () => {
+		vi.mocked(api.inspectCoordinatorInvite)
+			.mockRejectedValueOnce(new Error("coordinator_unavailable"))
+			.mockResolvedValueOnce(projectShareInspection);
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "preserved-project-invite";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() =>
+			expect(dialog.querySelector('[role="alert"]')?.textContent).toContain(
+				"Unable to review this invitation",
+			),
+		);
+		expect(textarea.value).toBe("preserved-project-invite");
+
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Exact Projects shared directly"));
+		expect(api.inspectCoordinatorInvite).toHaveBeenCalledTimes(2);
+		expect(api.inspectCoordinatorInvite).toHaveBeenNthCalledWith(1, "preserved-project-invite");
+		expect(api.inspectCoordinatorInvite).toHaveBeenNthCalledWith(2, "preserved-project-invite");
+		expect(api.importCoordinatorInvite).not.toHaveBeenCalled();
+	});
+
+	it("discards a stale Project inspection after the invitation text changes", async () => {
+		let resolveInspection: (
+			value: Awaited<ReturnType<typeof api.inspectCoordinatorInvite>>,
+		) => void = () => undefined;
+		vi.mocked(api.inspectCoordinatorInvite)
+			.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolveInspection = resolve;
+				}),
+			)
+			.mockResolvedValueOnce({
+				...projectShareInspection,
+				inviter_name: "Payload B owner",
+				projects: [{ display_name: "Current Project B", existing_memory_count: 8 }],
+			});
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "payload-a";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(api.inspectCoordinatorInvite).toHaveBeenCalledWith("payload-a"));
+
+		act(() => {
+			textarea.value = "payload-b";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		await act(async () => {
+			resolveInspection({
+				...projectShareInspection,
+				inviter_name: "Stale payload A owner",
+				projects: [{ display_name: "Stale Project A", existing_memory_count: 99 }],
+			});
+			await Promise.resolve();
+		});
+
+		expect(textarea.value).toBe("payload-b");
+		expect(dialog.textContent).not.toContain("Stale payload A owner");
+		expect(dialog.textContent).not.toContain("Stale Project A");
+		expect(
+			[...dialog.querySelectorAll("button")].some(
+				(candidate) => candidate.textContent?.trim() === "Accept Project access",
+			),
+		).toBe(false);
+		expect(api.importCoordinatorInvite).not.toHaveBeenCalled();
+
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Current Project B"));
+		expect(api.inspectCoordinatorInvite).toHaveBeenNthCalledWith(2, "payload-b");
+		expect(button("Accept Project access", dialog).disabled).toBe(false);
+		expect(api.importCoordinatorInvite).not.toHaveBeenCalled();
+	});
+
+	it("shows restart-required Project setup as pending and restores focus after keyboard close", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue(projectShareInspection);
+		vi.mocked(api.importCoordinatorInvite).mockResolvedValue({
+			status: "pending_setup",
+			setup_state: "restart_required",
+			restart_required: true,
+			type: "project_share",
+		});
+		mount();
+		const trigger = button("Review invitation");
+		trigger.focus();
+		act(() => trigger.click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "restart-project-invite";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Exact Projects shared directly"));
+		act(() => button("Accept Project access", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("codemem must be restarted"));
+		expect(dialog.textContent).toContain("Access remains pending");
+		expect(dialog.textContent).not.toContain("Joined the team");
+
+		const props = dialogSpy.mock.calls.at(-1)?.[0] as {
+			onCloseAutoFocus: (event: Event) => void;
+			onOpenChange: (open: boolean) => void;
+		};
+		const event = new Event("focus", { cancelable: true });
+		act(() => props.onOpenChange(false));
+		props.onCloseAutoFocus(event);
+		expect(event.defaultPrevented).toBe(true);
+		expect(document.activeElement).toBe(trigger);
+	});
+
+	it("shows add-device restart guidance when the active Identity could not refresh", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
+			kind: "add_device",
+			recipient_name: "Owner Identity",
+			device_name: "Travel Laptop",
+			onboarding: addDevicePreview,
+		});
+		vi.mocked(api.importCoordinatorInvite).mockResolvedValue({
+			status: "accepted",
+			type: "recipient_onboarding",
+			setup_state: "restart_required",
+			restart_required: true,
+			detail: "Restart codemem before continuing with the adopted Identity.",
+		});
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "add-device-restart";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Direct Projects"));
+		act(() => button("Accept invitation", dialog).click());
+
+		await vi.waitFor(() =>
+			expect(dialog.textContent).toContain(
+				"Restart codemem before continuing with the adopted Identity.",
+			),
+		);
+		expect(dialog.textContent).not.toContain("Device added.");
+	});
+
+	it("uses safe fallback result copy after reviewing unavailable optional Project identity names", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
+			...projectShareInspection,
+			recipient_name: undefined,
+			device_name: undefined,
+		});
+		vi.mocked(api.importCoordinatorInvite).mockResolvedValue({
+			status: "accepted",
+			type: "team_join",
+		});
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "project-without-names";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Exact Projects shared directly"));
+		const recipientName = dialog.querySelector<HTMLInputElement>("#project-share-recipient-name");
+		const deviceName = dialog.querySelector<HTMLInputElement>("#project-share-device-name");
+		if (!recipientName || !deviceName) throw new Error("Project identity fields missing");
+		expect(recipientName.value).toBe("");
+		expect(deviceName.value).toBe("");
+		expect(button("Accept Project access", dialog).disabled).toBe(true);
+		act(() => {
+			recipientName.value = "Reviewed recipient";
+			recipientName.dispatchEvent(new Event("input", { bubbles: true }));
+			deviceName.value = "Reviewed device";
+			deviceName.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Accept Project access", dialog).click());
+
+		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
+		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("project-without-names", {
+			recipient_name: "Reviewed recipient",
+			device_name: "Reviewed device",
+		});
+		await vi.waitFor(() =>
+			expect(dialog.textContent).toContain("Project setup status could not be confirmed"),
+		);
+		expect(dialog.textContent).not.toContain("Joined the team");
+	});
+
+	it("keeps the reviewed Project payload available for retry after an acceptance error", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue(projectShareInspection);
+		vi.mocked(api.importCoordinatorInvite)
+			.mockRejectedValueOnce(new Error("Ask the owner for a new invitation, then try again."))
+			.mockResolvedValueOnce({
+				status: "pending_setup",
+				setup_state: "pending_inviter",
+				type: "project_share",
+			});
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "retry-project-invite";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Exact Projects shared directly"));
+
+		act(() => button("Accept Project access", dialog).click());
+		await vi.waitFor(() =>
+			expect(dialog.querySelector('[role="alert"]')?.textContent).toContain(
+				"Ask the owner for a new invitation, then try again.",
+			),
+		);
+		expect(dialog.textContent).toContain("Codemem — 41 existing memories");
+		expect(button("Accept Project access", dialog).disabled).toBe(false);
+		act(() => button("Accept Project access", dialog).click());
+		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledTimes(2));
+		expect(api.importCoordinatorInvite).toHaveBeenNthCalledWith(2, "retry-project-invite", {
+			recipient_name: "Brian",
+			device_name: "Brian’s Mac",
 		});
 	});
 

--- a/packages/ui/src/tabs/recipient-policy-invitations.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import { RadixDialog } from "../components/primitives/radix-dialog";
 import * as api from "../lib/api";
 import type {
@@ -8,10 +8,43 @@ import type {
 	RecipientOnboardingPreviewV1,
 	RecipientPolicyIntentGraphV1,
 } from "../lib/api/sync";
+import type { ImportInviteResult } from "../lib/api/types";
 import { openProjectShareFlow } from "./project-sharing";
 
 type CreateKind = "team_member" | "add_device";
 type DialogMode = "create" | "accept";
+type ProjectShareInvite = Extract<InspectInviteResult, { kind: "project_share_invite" }>;
+type ProjectShareAcceptance = Omit<ImportInviteResult, "status"> & {
+	status?: "pending_setup";
+	setup_state?: "pending_inviter" | "restart_required";
+	restart_required?: boolean;
+	detail?: string;
+	type?: "project_share";
+};
+
+function displayNameError(value: string, label: string): string {
+	const reviewed = value.trim();
+	if (!reviewed) return `${label} is required.`;
+	if ([...reviewed].length > 120) return `${label} must use 120 characters or fewer.`;
+	if ([...reviewed].some((character) => /[\p{Cc}\p{Cf}]/u.test(character))) {
+		return `${label} cannot include control or format characters.`;
+	}
+	return "";
+}
+
+function normalizeProjectShareAcceptance(result: ImportInviteResult): ProjectShareAcceptance {
+	return {
+		...result,
+		status: result.status === "pending_setup" ? "pending_setup" : undefined,
+		setup_state:
+			result.setup_state === "pending_inviter" || result.setup_state === "restart_required"
+				? result.setup_state
+				: undefined,
+		restart_required: result.restart_required === true,
+		detail: typeof result.detail === "string" ? result.detail : undefined,
+		type: result.type === "project_share" ? "project_share" : undefined,
+	};
+}
 
 function errorMessage(cause: unknown, fallback: string): string {
 	if (cause instanceof Error && cause.message === "reviewed_onboarding_stale") {
@@ -127,6 +160,123 @@ function Confirmation({ preview }: { preview: RecipientOnboardingPreviewV1 }) {
 	);
 }
 
+function ProjectShareConfirmation({
+	deviceName,
+	deviceNameError,
+	invite,
+	onDeviceNameChange,
+	onRecipientNameChange,
+	recipientName,
+	recipientNameError,
+}: {
+	deviceName: string;
+	deviceNameError: string;
+	invite: ProjectShareInvite;
+	onDeviceNameChange: (value: string) => void;
+	onRecipientNameChange: (value: string) => void;
+	recipientName: string;
+	recipientNameError: string;
+}) {
+	const projects = invite.projects ?? [];
+	return (
+		<div className="sync-dialog-stack">
+			<section aria-labelledby="project-share-invitation-recipient">
+				<h3 id="project-share-invitation-recipient">Who will receive access</h3>
+				<p>Review these display names before importing the invitation.</p>
+				<label className="field" htmlFor="project-share-recipient-name">
+					<span>Identity display name</span>
+					<input
+						aria-describedby={recipientNameError ? "project-share-recipient-name-error" : undefined}
+						aria-invalid={Boolean(recipientNameError)}
+						id="project-share-recipient-name"
+						onInput={(event) => onRecipientNameChange(event.currentTarget.value)}
+						value={recipientName}
+					/>
+				</label>
+				{recipientNameError ? (
+					<p className="small" id="project-share-recipient-name-error" role="alert">
+						{recipientNameError}
+					</p>
+				) : null}
+				<label className="field" htmlFor="project-share-device-name">
+					<span>Device display name</span>
+					<input
+						aria-describedby={deviceNameError ? "project-share-device-name-error" : undefined}
+						aria-invalid={Boolean(deviceNameError)}
+						id="project-share-device-name"
+						onInput={(event) => onDeviceNameChange(event.currentTarget.value)}
+						value={deviceName}
+					/>
+				</label>
+				{deviceNameError ? (
+					<p className="small" id="project-share-device-name-error" role="alert">
+						{deviceNameError}
+					</p>
+				) : null}
+			</section>
+			<section aria-labelledby="project-share-invitation-projects">
+				<h3 id="project-share-invitation-projects" tabIndex={-1}>
+					Exact Projects shared directly
+				</h3>
+				{invite.inviter_name ? <p>Invitation from {invite.inviter_name}.</p> : null}
+				<p>
+					You will receive <strong>direct access only</strong> to the exact Projects listed below.
+				</p>
+				{projects.length ? (
+					<ul>
+						{projects.map((project, index) => (
+							<li key={`${project.display_name}:${index}`}>
+								<strong>{project.display_name}</strong> —{" "}
+								{memoryLabel(project.existing_memory_count)} and future activity
+							</li>
+						))}
+					</ul>
+				) : (
+					<p role="alert">
+						Project details are unavailable. Ask the owner to create a new invitation before
+						accepting.
+					</p>
+				)}
+			</section>
+			<p>
+				<strong>Accepting this invitation does not join a Team.</strong>
+			</p>
+			<p>
+				<strong>No other Projects are included.</strong>
+			</p>
+		</div>
+	);
+}
+
+function ProjectShareResult({ result }: { result: ProjectShareAcceptance }) {
+	const restartRequired =
+		result.restart_required === true || result.setup_state === "restart_required";
+	const pending = result.type === "project_share" && result.status === "pending_setup";
+	return (
+		<div className="sync-dialog-stack">
+			<h3 id="project-share-invitation-result" tabIndex={-1}>
+				Project invitation accepted
+			</h3>
+			{restartRequired ? (
+				<p role="status">
+					<strong>Project setup is pending and codemem must be restarted.</strong> Restart codemem
+					to start the sync service. Access remains pending until setup and the first sync finish.
+				</p>
+			) : pending ? (
+				<p role="status">
+					<strong>Project setup is pending.</strong> The owner still needs to finish access setup,
+					and the Projects will appear after the first sync completes.
+				</p>
+			) : (
+				<p role="status">
+					The invitation was accepted, but Project setup status could not be confirmed. Check Sync
+					before expecting Project data.
+				</p>
+			)}
+		</div>
+	);
+}
+
 function request(kind: CreateKind, targetId: string): RecipientInvitePreviewRequest {
 	return kind === "team_member"
 		? { kind, policy_team_id: targetId }
@@ -142,15 +292,34 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 	const [invite, setInvite] = useState("");
 	const [preview, setPreview] = useState<RecipientOnboardingPreviewV1 | null>(null);
 	const [inspected, setInspected] = useState<InspectInviteResult | null>(null);
+	const [projectAcceptance, setProjectAcceptance] = useState<ProjectShareAcceptance | null>(null);
+	const [projectRecipientName, setProjectRecipientName] = useState("");
+	const [projectDeviceName, setProjectDeviceName] = useState("");
 	const [created, setCreated] = useState<CreatedRecipientInvite | null>(null);
 	const [busy, setBusy] = useState(false);
 	const [status, setStatus] = useState("");
 	const [error, setError] = useState("");
 	const returnFocus = useRef<HTMLElement | null>(null);
+	const inviteRevision = useRef(0);
+	const inviteValue = useRef("");
+
+	useEffect(() => {
+		if (projectAcceptance) {
+			document.getElementById("project-share-invitation-result")?.focus();
+			return;
+		}
+		if (inspected?.kind === "project_share_invite") {
+			document.getElementById("project-share-invitation-projects")?.focus();
+		}
+	}, [inspected, projectAcceptance]);
 
 	const reset = () => {
+		inviteRevision.current += 1;
 		setPreview(null);
 		setInspected(null);
+		setProjectAcceptance(null);
+		setProjectRecipientName("");
+		setProjectDeviceName("");
 		setCreated(null);
 		setStatus("");
 		setError("");
@@ -161,7 +330,14 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 		setMode(nextMode);
 	};
 	const close = () => {
-		if (!busy) setMode(null);
+		if (busy) return;
+		inviteRevision.current += 1;
+		setMode(null);
+	};
+	const updateInvite = (nextInvite: string) => {
+		inviteRevision.current += 1;
+		inviteValue.current = nextInvite;
+		setInvite(nextInvite);
 	};
 	const chooseKind = (nextKind: CreateKind) => {
 		setKind(nextKind);
@@ -209,22 +385,34 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 		}
 	};
 	const inspect = async () => {
-		if (!invite.trim()) {
+		const reviewedInvite = inviteValue.current.trim();
+		const reviewedRevision = inviteRevision.current;
+		if (!reviewedInvite) {
 			setError("Paste an invitation first.");
 			return;
 		}
+		const isCurrentInspection = () =>
+			inviteRevision.current === reviewedRevision && inviteValue.current.trim() === reviewedInvite;
 		setBusy(true);
 		setError("");
 		setStatus("Reviewing invitation…");
 		try {
-			const result = await api.inspectCoordinatorInvite(invite.trim());
+			const result = await api.inspectCoordinatorInvite(reviewedInvite);
+			if (!isCurrentInspection()) return;
 			setInspected(result);
+			if (result.kind === "project_share_invite") {
+				setProjectRecipientName(result.recipient_name ?? "");
+				setProjectDeviceName(result.device_name ?? "");
+			}
 			setStatus(
 				result.kind === "team_member" || result.kind === "add_device"
 					? "Review ready. Confirm before accepting."
-					: "Open Advanced Team administration to continue with this invitation.",
+					: result.kind === "project_share_invite"
+						? "Review ready. Confirm the exact Projects before accepting."
+						: "Open Advanced Team administration to continue with this invitation.",
 			);
 		} catch (cause) {
+			if (!isCurrentInspection()) return;
 			setError(errorMessage(cause, "Unable to review this invitation."));
 			setStatus("");
 		} finally {
@@ -232,21 +420,54 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 		}
 	};
 	const accept = async () => {
-		if (!inspected || (inspected.kind !== "team_member" && inspected.kind !== "add_device")) return;
+		if (!inspected || inspected.kind === "legacy_team_invite") return;
+		if (inspected.kind === "project_share_invite" && !(inspected.projects?.length ?? 0)) return;
+		if (
+			inspected.kind === "project_share_invite" &&
+			(displayNameError(projectRecipientName, "Identity display name") ||
+				displayNameError(projectDeviceName, "Device display name"))
+		) {
+			return;
+		}
 		setBusy(true);
 		setError("");
 		setStatus("Accepting invitation…");
 		try {
-			await api.importCoordinatorInvite(invite.trim(), {
-				recipient_name: inspected.recipient_name,
-				device_name: inspected.device_name,
-				reviewed_onboarding_digest: inspected.onboarding.reviewedOnboardingDigest,
-			});
-			setStatus(inspected.kind === "team_member" ? "Team invitation accepted." : "Device added.");
-			setInspected(null);
-			setInvite("");
+			const result =
+				inspected.kind === "project_share_invite"
+					? await api.importCoordinatorInvite(invite.trim(), {
+							recipient_name: projectRecipientName.trim(),
+							device_name: projectDeviceName.trim(),
+						})
+					: await api.importCoordinatorInvite(invite.trim(), {
+							recipient_name: inspected.recipient_name,
+							device_name: inspected.device_name,
+							reviewed_onboarding_digest: inspected.onboarding.reviewedOnboardingDigest,
+						});
+			if (inspected.kind === "project_share_invite") {
+				setProjectAcceptance(normalizeProjectShareAcceptance(result));
+				setStatus("");
+			} else {
+				const restartRequired =
+					result.restart_required === true || result.setup_state === "restart_required";
+				const detail = typeof result.detail === "string" ? result.detail.trim() : "";
+				setStatus(
+					inspected.kind === "team_member"
+						? "Team invitation accepted."
+						: restartRequired
+							? detail || "Device added. Restart codemem before continuing."
+							: "Device added.",
+				);
+				setInspected(null);
+				updateInvite("");
+			}
 		} catch (cause) {
-			setError(errorMessage(cause, "Unable to accept this invitation."));
+			const detail = cause instanceof Error ? cause.message.trim() : "";
+			const fallback =
+				inspected.kind === "project_share_invite" && detail
+					? detail
+					: "Unable to accept this invitation.";
+			setError(errorMessage(cause, fallback));
 			setStatus("");
 		} finally {
 			setBusy(false);
@@ -270,6 +491,13 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 		inspected?.kind === "team_member" || inspected?.kind === "add_device"
 			? inspected.onboarding
 			: null;
+	const projectShareInvite = inspected?.kind === "project_share_invite" ? inspected : null;
+	const projectRecipientNameError = projectShareInvite
+		? displayNameError(projectRecipientName, "Identity display name")
+		: "";
+	const projectDeviceNameError = projectShareInvite
+		? displayNameError(projectDeviceName, "Device display name")
+		: "";
 	return (
 		<div className="recipient-policy-sharing-grid recipient-policy-sharing-responsive-grid">
 			<article className="peer-card peer-card--padded recipient-policy-sharing-card">
@@ -314,7 +542,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 			</article>
 			<article className="peer-card peer-card--padded recipient-policy-sharing-card">
 				<h3>Accept an invitation</h3>
-				<p>Review Team membership or device access before accepting.</p>
+				<p>Review Team membership, device access, or exact Project access before accepting.</p>
 				<button
 					className="settings-button recipient-policy-sharing-target-24"
 					onClick={(event) => open("accept", event.currentTarget)}
@@ -385,8 +613,11 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 									<textarea
 										id="recipient-invitation-value"
 										onInput={(event) => {
-											setInvite(event.currentTarget.value);
+											updateInvite(event.currentTarget.value);
 											setInspected(null);
+											setProjectAcceptance(null);
+											setStatus("");
+											setError("");
 										}}
 										rows={5}
 										value={invite}
@@ -395,6 +626,24 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 							) : null}
 							{preview ? <Confirmation preview={preview} /> : null}
 							{recipientPreview ? <Confirmation preview={recipientPreview} /> : null}
+							{projectShareInvite && !projectAcceptance ? (
+								<ProjectShareConfirmation
+									deviceName={projectDeviceName}
+									deviceNameError={projectDeviceNameError}
+									invite={projectShareInvite}
+									onDeviceNameChange={(value) => {
+										setProjectDeviceName(value);
+										setError("");
+									}}
+									onRecipientNameChange={(value) => {
+										setProjectRecipientName(value);
+										setError("");
+									}}
+									recipientName={projectRecipientName}
+									recipientNameError={projectRecipientNameError}
+								/>
+							) : null}
+							{projectAcceptance ? <ProjectShareResult result={projectAcceptance} /> : null}
 							{created ? (
 								<div>
 									<p>Share the invitation with the recipient.</p>
@@ -403,8 +652,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 									</button>
 								</div>
 							) : null}
-							{inspected?.kind === "legacy_team_invite" ||
-							inspected?.kind === "project_share_invite" ? (
+							{inspected?.kind === "legacy_team_invite" ? (
 								<p>Use Advanced Team administration to review and import this invitation.</p>
 							) : null}
 							<p aria-live="polite" className="small" role="status">
@@ -418,7 +666,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 						</div>
 						<div className="modal-footer recipient-policy-sharing-responsive-actions">
 							<button className="settings-button" disabled={busy} onClick={close} type="button">
-								{created ? "Done" : "Cancel"}
+								{created || projectAcceptance ? "Done" : "Cancel"}
 							</button>
 							{mode === "create" && !created ? (
 								<button
@@ -438,14 +686,26 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 								>
 									{busy ? "Reviewing…" : "Review invitation"}
 								</button>
-							) : recipientPreview ? (
+							) : recipientPreview || (projectShareInvite && !projectAcceptance) ? (
 								<button
 									className="settings-button sync-dialog-confirm"
-									disabled={busy}
+									disabled={
+										busy ||
+										Boolean(
+											projectShareInvite &&
+												(!projectShareInvite.projects?.length ||
+													projectRecipientNameError ||
+													projectDeviceNameError),
+										)
+									}
 									onClick={() => void accept()}
 									type="button"
 								>
-									{busy ? "Accepting…" : "Accept invitation"}
+									{busy
+										? "Accepting…"
+										: projectShareInvite
+											? "Accept Project access"
+											: "Accept invitation"}
 								</button>
 							) : null}
 						</div>


### PR DESCRIPTION
## Description

Accept current exact-Project invitations directly from Sharing → Invitations. The review explains direct Project access versus Team membership, preserves the inspected payload, reports pending/restart setup truthfully, and leaves legacy import under Advanced.

Closes codemem-z611.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused invitation API, interaction, stale-inspection, focus, and request tests passed. The complete stack passed `pnpm run check` with 3,207 tests.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced