### PR TITLE
fix(sharing): clarify recipient access dialogs

### DIFF
--- a/packages/core/src/recipient-policy-edges.test.ts
+++ b/packages/core/src/recipient-policy-edges.test.ts
@@ -538,6 +538,71 @@ describe("recipient-policy edge changes", () => {
 		}
 	});
 
+	it("rejects an already-present preview when the reviewed edge changes before commit", () => {
+		const db = seedGraph();
+		insertProjectRecipient(db, PROJECT_A, "identity-a");
+		const changes = [identityChange(PROJECT_A, "identity-a")];
+		const preview = previewRecipientPolicyEdges(db, { version: 1, changes });
+		expect(preview.outcomes).toEqual([{ change: changes[0], outcome: "already_present" }]);
+
+		db.prepare(
+			`UPDATE project_recipients SET status = 'revoked'
+			 WHERE canonical_project_identity = ? AND recipient_kind = 'identity' AND recipient_id = ?`,
+		).run(PROJECT_A, "identity-a");
+		const before = rowSnapshot(db);
+
+		expect(
+			commitRecipientPolicyEdges(db, {
+				version: 1,
+				changes,
+				reviewedPolicyDigest: preview.reviewedPolicyDigest,
+			}),
+		).toMatchObject({ status: "stale", writeCount: 0 });
+		expect(rowSnapshot(db)).toEqual(before);
+	});
+
+	it("rejects a remove preview when the reviewed edge is removed before commit", () => {
+		const db = seedGraph();
+		insertProjectRecipient(db, PROJECT_A, "identity-a");
+		const changes = [identityChange(PROJECT_A, "identity-a", "remove")];
+		const preview = previewRecipientPolicyEdges(db, { version: 1, changes });
+		expect(preview.outcomes).toEqual([{ change: changes[0], outcome: "removed" }]);
+
+		db.prepare(
+			`UPDATE project_recipients SET status = 'revoked'
+			 WHERE canonical_project_identity = ? AND recipient_kind = 'identity' AND recipient_id = ?`,
+		).run(PROJECT_A, "identity-a");
+		const before = rowSnapshot(db);
+
+		expect(
+			commitRecipientPolicyEdges(db, {
+				version: 1,
+				changes,
+				reviewedPolicyDigest: preview.reviewedPolicyDigest,
+			}),
+		).toMatchObject({ status: "stale", writeCount: 0 });
+		expect(rowSnapshot(db)).toEqual(before);
+	});
+
+	it("rejects an already-absent preview when the edge becomes active before commit", () => {
+		const db = seedGraph();
+		const changes = [identityChange(PROJECT_A, "identity-a", "remove")];
+		const preview = previewRecipientPolicyEdges(db, { version: 1, changes });
+		expect(preview.outcomes).toEqual([{ change: changes[0], outcome: "already_absent" }]);
+
+		insertProjectRecipient(db, PROJECT_A, "identity-a");
+		const before = rowSnapshot(db);
+
+		expect(
+			commitRecipientPolicyEdges(db, {
+				version: 1,
+				changes,
+				reviewedPolicyDigest: preview.reviewedPolicyDigest,
+			}),
+		).toMatchObject({ status: "stale", writeCount: 0 });
+		expect(rowSnapshot(db)).toEqual(before);
+	});
+
 	it("makes a second overlapping preview stale after the first commit changes desired edges", () => {
 		const db = seedGraph();
 		const identityChanges = [identityChange(PROJECT_A, "identity-a")];
@@ -591,10 +656,11 @@ describe("recipient-policy edge changes", () => {
 		competing.exec("ROLLBACK");
 	});
 
-	it("adds, removes, preserves row identity metadata, and replays idempotently", () => {
+	it("adds, removes, preserves row identity metadata, and keeps unchanged previews idempotent", () => {
 		const db = seedGraph();
 		const add = [identityChange(PROJECT_A, "identity-a")];
 		const preview = previewRecipientPolicyEdges(db, { version: 1, changes: add });
+		expect(preview.outcomes).toEqual([{ change: add[0], outcome: "added" }]);
 		const applied = commitRecipientPolicyEdges(
 			db,
 			{ version: 1, changes: add, reviewedPolicyDigest: preview.reviewedPolicyDigest },
@@ -612,10 +678,12 @@ describe("recipient-policy edge changes", () => {
 		});
 		const inserted = rowSnapshot(db)[0] as Record<string, unknown>;
 
+		const presentPreview = previewRecipientPolicyEdges(db, { version: 1, changes: add });
+		expect(presentPreview.outcomes).toEqual([{ change: add[0], outcome: "already_present" }]);
 		const replay = commitRecipientPolicyEdges(db, {
 			version: 1,
 			changes: add,
-			reviewedPolicyDigest: preview.reviewedPolicyDigest,
+			reviewedPolicyDigest: presentPreview.reviewedPolicyDigest,
 		});
 		expect(replay).toMatchObject({
 			status: "applied",
@@ -623,9 +691,17 @@ describe("recipient-policy edge changes", () => {
 			idempotent: true,
 			outcomes: [{ outcome: "already_present" }],
 		});
+		expect(
+			commitRecipientPolicyEdges(db, {
+				version: 1,
+				changes: add,
+				reviewedPolicyDigest: presentPreview.reviewedPolicyDigest,
+			}),
+		).toMatchObject({ status: "applied", writeCount: 0, idempotent: true });
 
 		const remove = [identityChange(PROJECT_A, "identity-a", "remove")];
 		const removePreview = previewRecipientPolicyEdges(db, { version: 1, changes: remove });
+		expect(removePreview.outcomes).toEqual([{ change: remove[0], outcome: "removed" }]);
 		expect(
 			commitRecipientPolicyEdges(
 				db,
@@ -648,13 +724,14 @@ describe("recipient-policy edge changes", () => {
 		});
 
 		const absentPreview = previewRecipientPolicyEdges(db, { version: 1, changes: remove });
-		expect(absentPreview.reviewedPolicyDigest).toBe(removePreview.reviewedPolicyDigest);
+		expect(absentPreview.reviewedPolicyDigest).not.toBe(removePreview.reviewedPolicyDigest);
 		expect(absentPreview.unchangedProjects).toEqual(absentPreview.projects);
+		expect(absentPreview.outcomes).toEqual([{ change: remove[0], outcome: "already_absent" }]);
 		expect(
 			commitRecipientPolicyEdges(db, {
 				version: 1,
 				changes: remove,
-				reviewedPolicyDigest: removePreview.reviewedPolicyDigest,
+				reviewedPolicyDigest: absentPreview.reviewedPolicyDigest,
 			}),
 		).toMatchObject({
 			status: "applied",

--- a/packages/core/src/recipient-policy-edges.ts
+++ b/packages/core/src/recipient-policy-edges.ts
@@ -55,6 +55,7 @@ export interface RecipientPolicyEdgeEffectiveDeviceV1 {
 export interface RecipientPolicyEdgePreviewResponseV1 {
 	version: 1;
 	normalizedChanges: RecipientPolicyEdgeChangeV1[];
+	outcomes: RecipientPolicyEdgeCommitOutcomeV1[];
 	projects: RecipientPolicyEdgePreviewProjectV1[];
 	selectedRecipients: RecipientPolicyEdgeSelectedRecipientV1[];
 	effectiveDevices: RecipientPolicyEdgeEffectiveDeviceV1[];
@@ -634,6 +635,7 @@ function buildPreview(db: Database, request: RecipientPolicyEdgePreviewRequestV1
 	let addCount = 0;
 	let removeCount = 0;
 	const changedProjects = new Set<string>();
+	const outcomes: RecipientPolicyEdgeCommitOutcomeV1[] = [];
 	for (const change of request.changes) {
 		const current = edgesByKey.get(
 			edgeKey(
@@ -645,14 +647,21 @@ function buildPreview(db: Database, request: RecipientPolicyEdgePreviewRequestV1
 		if (change.action === "add" && current?.status !== "active") {
 			addCount += 1;
 			changedProjects.add(change.canonicalProjectIdentity);
+			outcomes.push({ change, outcome: "added" });
+		} else if (change.action === "add") {
+			outcomes.push({ change, outcome: "already_present" });
 		}
 		if (change.action === "remove" && current?.status === "active") {
 			removeCount += 1;
 			changedProjects.add(change.canonicalProjectIdentity);
+			outcomes.push({ change, outcome: "removed" });
+		} else if (change.action === "remove") {
+			outcomes.push({ change, outcome: "already_absent" });
 		}
 	}
 	const reviewedPolicyDigest = digest("edge-preview-v1", {
 		normalizedChanges: request.changes,
+		outcomes,
 		projects,
 		selectedRecipientFacts: selectedRecipientDigestFacts(
 			request.changes,
@@ -667,6 +676,7 @@ function buildPreview(db: Database, request: RecipientPolicyEdgePreviewRequestV1
 		response: {
 			version: 1,
 			normalizedChanges: request.changes,
+			outcomes,
 			projects,
 			selectedRecipients: recipients,
 			effectiveDevices: resultingDevices,

--- a/packages/ui/src/components/primitives/dialog-close-button.tsx
+++ b/packages/ui/src/components/primitives/dialog-close-button.tsx
@@ -1,6 +1,7 @@
 type DialogCloseButtonProps = {
 	ariaLabel: string;
 	className?: string;
+	disabled?: boolean;
 	onClick: () => void;
 	label?: string;
 };
@@ -8,11 +9,18 @@ type DialogCloseButtonProps = {
 export function DialogCloseButton({
 	ariaLabel,
 	className = "modal-close-button",
+	disabled = false,
 	onClick,
 	label = "Close",
 }: DialogCloseButtonProps) {
 	return (
-		<button aria-label={ariaLabel} className={className} onClick={onClick} type="button">
+		<button
+			aria-label={ariaLabel}
+			className={className}
+			disabled={disabled}
+			onClick={onClick}
+			type="button"
+		>
 			<i aria-hidden="true" className="modal-close-button-icon" data-lucide="x" />
 			<span className="modal-close-button-label">{label}</span>
 		</button>

--- a/packages/ui/src/components/primitives/primitives.test.tsx
+++ b/packages/ui/src/components/primitives/primitives.test.tsx
@@ -1,4 +1,5 @@
 import { type ComponentChild, render } from "preact";
+import { useState } from "preact/hooks";
 import { act } from "preact/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -108,6 +109,7 @@ vi.mock("@radix-ui/react-switch", () => ({
 }));
 
 import { DialogCloseButton } from "./dialog-close-button";
+import { RadixDialog } from "./radix-dialog";
 import { RadixRadioGroup } from "./radix-radio-group";
 import { RadixSelect } from "./radix-select";
 import { RadixSwitch } from "./radix-switch";
@@ -150,13 +152,78 @@ describe("DialogCloseButton", () => {
 
 		const button = root.querySelector("button");
 		expect(button?.getAttribute("aria-label")).toBe("Close settings");
+		expect(button?.classList.contains("modal-close-button")).toBe(true);
 		expect(button?.textContent).toContain("Close");
+		expect(button?.querySelector(".modal-close-button-icon")?.getAttribute("aria-hidden")).toBe(
+			"true",
+		);
 
 		act(() => {
 			button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 		});
 
 		expect(onClick).toHaveBeenCalledTimes(1);
+	});
+
+	it("supports a disabled close control without firing onClick", () => {
+		const onClick = vi.fn();
+		const root = renderIntoDocument(
+			<DialogCloseButton ariaLabel="Close busy dialog" disabled onClick={onClick} />,
+		);
+		const button = root.querySelector<HTMLButtonElement>("button");
+
+		expect(button?.disabled).toBe(true);
+		act(() => button?.click());
+		expect(onClick).not.toHaveBeenCalled();
+	});
+});
+
+describe("RadixDialog", () => {
+	it("dismisses with Escape and restores focus to the opening trigger", async () => {
+		function Harness() {
+			const [open, setOpen] = useState(false);
+			return (
+				<>
+					<button id="radix-dialog-trigger" onClick={() => setOpen(true)} type="button">
+						Open dialog
+					</button>
+					<RadixDialog
+						ariaLabelledby="radix-dialog-title"
+						contentId="radix-dialog-content"
+						modal={false}
+						onCloseAutoFocus={(event) => {
+							event.preventDefault();
+							document.getElementById("radix-dialog-trigger")?.focus();
+						}}
+						onOpenChange={setOpen}
+						open={open}
+						overlayId="radix-dialog-overlay"
+					>
+						<h2 id="radix-dialog-title">Primitive dialog</h2>
+						<button type="button">Inside</button>
+					</RadixDialog>
+				</>
+			);
+		}
+
+		const root = renderIntoDocument(<Harness />);
+		const trigger = root.querySelector<HTMLButtonElement>("#radix-dialog-trigger");
+		if (!trigger) throw new Error("dialog trigger missing");
+		trigger.focus();
+		act(() => {
+			trigger.click();
+		});
+		await vi.waitFor(() => {
+			expect(document.getElementById("radix-dialog-content")).not.toBeNull();
+		});
+
+		act(() => {
+			document.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
+		});
+		await vi.waitFor(() => {
+			expect(document.getElementById("radix-dialog-content")).toBeNull();
+			expect(document.activeElement).toBe(trigger);
+		});
 	});
 });
 

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -357,6 +357,7 @@ describe("recipient policy edge API", () => {
 		const preview = {
 			version: 1,
 			normalizedChanges: changes,
+			outcomes: [{ change: changes[0], outcome: "added" }],
 			projects: [],
 			selectedRecipients: [],
 			effectiveDevices: [],
@@ -435,5 +436,28 @@ describe("recipient policy edge API", () => {
 
 		await expect(promise).rejects.toBeInstanceOf(RecipientPolicyEdgesStaleError);
 		await expect(promise).rejects.toMatchObject({ result: stale });
+	});
+
+	it("returns structured conflict results from edge commit 409 responses", async () => {
+		const conflict = {
+			version: 1,
+			status: "conflict",
+			reviewedPolicyDigest: "policy:digest",
+			errorCode: "edge_commit_conflict",
+			outcomes: [],
+			writeCount: 0,
+			idempotent: false,
+		} as const;
+		globalThis.fetch = vi.fn(
+			async () => new Response(JSON.stringify(conflict), { status: 409 }),
+		) as typeof fetch;
+
+		await expect(
+			commitRecipientPolicyEdges({
+				version: 1,
+				changes: [],
+				reviewedPolicyDigest: "policy:digest",
+			}),
+		).resolves.toEqual(conflict);
 	});
 });

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -754,6 +754,7 @@ export interface RecipientPolicyEdgeEffectiveDeviceV1 {
 export interface RecipientPolicyEdgePreviewResponseV1 {
 	version: 1;
 	normalizedChanges: RecipientPolicyEdgeChangeV1[];
+	outcomes: RecipientPolicyEdgeCommitOutcomeV1[];
 	projects: RecipientPolicyEdgePreviewProjectV1[];
 	selectedRecipients: RecipientPolicyEdgeSelectedRecipientV1[];
 	effectiveDevices: RecipientPolicyEdgeEffectiveDeviceV1[];
@@ -825,6 +826,14 @@ async function recipientPolicyEdgeRequest<T>(
 			throw new RecipientPolicyEdgesStaleError(
 				payload as unknown as RecipientPolicyEdgeCommitResultV1,
 			);
+		}
+		if (
+			resp.status === 409 &&
+			payload &&
+			typeof payload === "object" &&
+			(payload as unknown as RecipientPolicyEdgeCommitResultV1).status === "conflict"
+		) {
+			return payload as T;
 		}
 		const edgeErrorCode =
 			payload && typeof payload === "object" && "errorCode" in payload

--- a/packages/ui/src/tabs/recipient-policy-management.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-management.test.tsx
@@ -136,6 +136,10 @@ function preview(changes: RecipientPolicyEdgeChangeV1[]): RecipientPolicyEdgePre
 	return {
 		version: 1,
 		normalizedChanges: changes,
+		outcomes: changes.map((change) => ({
+			change,
+			outcome: change.action === "add" ? "added" : "removed",
+		})),
 		projects: [
 			{
 				canonicalProjectIdentity: "git:codemem",
@@ -191,11 +195,31 @@ function checkbox(label: string): HTMLInputElement {
 	return input;
 }
 
+function actionButton(label: string): HTMLButtonElement {
+	const match = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+		(button) => button.textContent === label,
+	);
+	if (!match) throw new Error(`button missing: ${label}`);
+	return match;
+}
+
 async function reviewSelection() {
 	await act(async () => {
 		(
 			[...document.querySelectorAll<HTMLButtonElement>("button")].find(
 				(button) => button.textContent === "Review changes",
+			) as HTMLButtonElement
+		).click();
+		await Promise.resolve();
+		await Promise.resolve();
+	});
+}
+
+async function confirmChanges() {
+	await act(async () => {
+		(
+			[...document.querySelectorAll<HTMLButtonElement>("button")].find(
+				(button) => button.textContent === "Confirm changes",
 			) as HTMLButtonElement
 		).click();
 		await Promise.resolve();
@@ -255,6 +279,34 @@ describe("recipient policy management dialog", () => {
 		});
 	});
 
+	it("labels an already-active Project recipient edge as unchanged", async () => {
+		vi.mocked(api.previewRecipientPolicyEdges).mockImplementationOnce(async (request) => {
+			const value = preview(request.changes);
+			return {
+				...value,
+				outcomes: request.changes.map((change) => ({ change, outcome: "already_present" })),
+				unchangedProjects: value.projects,
+				addCount: 0,
+				netWriteCount: 0,
+			};
+		});
+		mount(
+			intent({
+				projectRecipients: intent().projectRecipients.filter(
+					(edge) => edge.recipientKind !== "team" || edge.teamId !== "team-example",
+				),
+			}),
+		);
+		act(() => {
+			openRecipientPolicyManagement({ mode: "project-add", projectIds: ["git:codemem"] });
+		});
+		act(() => checkbox("ExampleCo").click());
+		await reviewSelection();
+
+		expect(document.body.textContent).toContain("ExampleCo — Already has access · Team");
+		expect(document.body.textContent).not.toContain("ExampleCo — Adding access · Team");
+	});
+
 	it("project-manage emits only recipient add and remove diffs", async () => {
 		mount();
 		act(() => {
@@ -282,6 +334,48 @@ describe("recipient policy management dialog", () => {
 					action: "add",
 				},
 			],
+		});
+	});
+
+	it("labels recipient removals and additions without claiming unchanged recipients receive access", async () => {
+		vi.mocked(api.previewRecipientPolicyEdges).mockImplementationOnce(async (request) => {
+			const value = preview(request.changes);
+			const [team] = value.selectedRecipients;
+			if (team?.recipientKind !== "team") throw new Error("team fixture is incomplete");
+			return {
+				...value,
+				selectedRecipients: [
+					team,
+					{
+						recipientKind: "identity",
+						identityId: "identity-brian",
+						displayName: "Brian",
+						verification: "local",
+					},
+				],
+			};
+		});
+		mount();
+		act(() => {
+			openRecipientPolicyManagement({ mode: "project-manage", projectId: "git:codemem" });
+		});
+		expect(checkbox("Adam").checked).toBe(true);
+		act(() => {
+			checkbox("ExampleCo").click();
+			checkbox("Brian").click();
+		});
+		await reviewSelection();
+
+		expect(document.body.textContent).toContain("Recipient changes");
+		expect(document.body.textContent).not.toContain("Who receives it");
+		expect(document.body.textContent).toContain("ExampleCo — Removing access · Team");
+		expect(document.body.textContent).toContain("Brian — Adding access · Identity");
+		expect(
+			vi.mocked(api.previewRecipientPolicyEdges).mock.calls[0]?.[0].changes,
+		).not.toContainEqual({
+			canonicalProjectIdentity: "git:codemem",
+			recipient: { recipientKind: "identity", identityId: "identity-adam" },
+			action: expect.any(String),
 		});
 	});
 
@@ -350,6 +444,11 @@ describe("recipient policy management dialog", () => {
 			checkbox("Unavailable Identity").click();
 		});
 		await reviewSelection();
+		expect(document.body.textContent).toContain("Archived Team — Removing access · Team");
+		expect(document.body.textContent).toContain("Merged recipient — Removing access · Identity");
+		expect(document.body.textContent).toContain(
+			"identity-deactivated — Removing access · Identity",
+		);
 
 		expect(api.previewRecipientPolicyEdges).toHaveBeenCalledWith({
 			version: 1,
@@ -410,6 +509,34 @@ describe("recipient policy management dialog", () => {
 				},
 			],
 		});
+	});
+
+	it("labels one recipient with mixed changes across selected Projects", async () => {
+		vi.mocked(api.previewRecipientPolicyEdges).mockImplementationOnce(async (request) => ({
+			...preview(request.changes),
+			selectedRecipients: [
+				{
+					recipientKind: "identity",
+					identityId: "identity-adam",
+					displayName: "Adam",
+					verification: "local",
+				},
+			],
+		}));
+		mount();
+		act(() => {
+			openRecipientPolicyManagement({
+				mode: "recipient-manage",
+				recipient: { recipientKind: "identity", identityId: "identity-adam" },
+			});
+		});
+		act(() => {
+			checkbox("Codemem").click();
+			checkbox("API").click();
+		});
+		await reviewSelection();
+
+		expect(document.body.textContent).toContain("Adam — Mixed changes · Identity");
 	});
 
 	it("recipient-manage exposes stale active Projects only so they can be removed", async () => {
@@ -525,7 +652,25 @@ describe("recipient policy management dialog", () => {
 		expect(vi.mocked(api.previewRecipientPolicyEdges).mock.calls[0]?.[0].changes).toHaveLength(500);
 	});
 
-	it("renders exact preview detail and commits only normalized changes plus digest", async () => {
+	it("renders the three review sections in order and commits normalized changes plus digest", async () => {
+		vi.mocked(api.commitRecipientPolicyEdges).mockResolvedValueOnce({
+			version: 1,
+			status: "applied",
+			reviewedPolicyDigest: "policy:digest",
+			errorCode: null,
+			outcomes: [
+				{
+					change: {
+						canonicalProjectIdentity: "git:codemem",
+						recipient: { recipientKind: "team", teamId: "team-example" },
+						action: "add",
+					},
+					outcome: "already_present",
+				},
+			],
+			writeCount: 0,
+			idempotent: true,
+		});
 		mount();
 		act(() => {
 			openRecipientPolicyManagement({ mode: "project-add", projectIds: ["git:codemem"] });
@@ -533,25 +678,46 @@ describe("recipient policy management dialog", () => {
 		act(() => checkbox("ExampleCo").click());
 		await reviewSelection();
 
-		expect(document.body.textContent).toContain(
-			"Codemem — 436 existing memories and future activity",
+		expect(document.getElementById("recipient-policy-management-title")?.textContent).toBe(
+			"Review recipient access",
 		);
-		expect(document.body.textContent).toContain("436 existing memories total");
+		expect(document.getElementById("recipient-policy-management-description")?.textContent).toBe(
+			"Confirm the exact Projects, recipients, and resulting access.",
+		);
+		expect(
+			[...document.querySelectorAll(".recipient-policy-management-review > section > h3")].map(
+				(heading) => heading.textContent,
+			),
+		).toEqual(["Projects affected", "Recipient changes", "Resulting availability"]);
+		expect(document.body.textContent).not.toContain("Who receives it");
+		expect(document.body.textContent).toContain(
+			"Codemem — Access changes affect 436 existing memories and future activity",
+		);
 		expect(document.body.textContent).toContain("ExampleCo");
+		expect(document.body.textContent).toContain("Team · 2 current members");
 		expect(document.body.textContent).toContain("Adam, Brian");
 		expect(document.body.textContent).toContain("Future Team members inherit access");
-		expect(document.body.textContent).toContain("1 effective device");
-		expect(document.body.textContent).toContain("No other Projects will change");
+		expect(document.body.textContent).toContain(
+			"After the update, the affected Projects will be available on 1 current device across all recipients",
+		);
+		const reviewFooter = document.querySelector(
+			".modal-footer.recipient-policy-management-actions",
+		);
+		const backButton = actionButton("Back");
+		const confirmButton = actionButton("Confirm changes");
+		expect(reviewFooter?.contains(backButton)).toBe(true);
+		expect(reviewFooter?.contains(confirmButton)).toBe(true);
+		expect(backButton.type).toBe("button");
+		expect(confirmButton.type).toBe("button");
+		const changeDetails = [...document.querySelectorAll<HTMLDetailsElement>("details")].find(
+			(details) => details.querySelector("summary")?.textContent === "Change details",
+		);
+		expect(changeDetails).toBeInstanceOf(HTMLDetailsElement);
+		expect(changeDetails?.open).toBe(false);
+		expect(document.querySelector(".recipient-policy-management-details h4")).toBeNull();
+		expect(document.body.textContent).not.toContain("existing memories total");
 
-		await act(async () => {
-			(
-				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Confirm changes",
-				) as HTMLButtonElement
-			).click();
-			await Promise.resolve();
-			await Promise.resolve();
-		});
+		await confirmChanges();
 		expect(api.commitRecipientPolicyEdges).toHaveBeenCalledWith({
 			version: 1,
 			changes: preview([
@@ -563,6 +729,161 @@ describe("recipient policy management dialog", () => {
 			]).normalizedChanges,
 			reviewedPolicyDigest: "policy:digest",
 		});
+		expect(document.getElementById("recipient-policy-management-title")?.textContent).toBe(
+			"Recipient access updated",
+		);
+		const resultDescription = document.getElementById("recipient-policy-management-description");
+		const appliedSummary = "The reviewed recipient access changes are applied.";
+		expect(resultDescription?.textContent).toBe(appliedSummary);
+		expect(resultDescription?.hasAttribute("aria-live")).toBe(false);
+		expect(resultDescription?.hasAttribute("role")).toBe(false);
+		expect(document.activeElement).toBe(
+			document.getElementById("recipient-policy-management-title"),
+		);
+		expect(document.body.textContent?.split(appliedSummary)).toHaveLength(2);
+		expect(document.body.textContent).not.toContain("updated with");
+		expect(document.body.textContent).not.toContain("changes saved");
+		const resultFooter = document.querySelector(
+			".modal-footer.recipient-policy-management-actions",
+		);
+		const doneButton = actionButton("Done");
+		expect(resultFooter?.contains(doneButton)).toBe(true);
+		expect(doneButton.type).toBe("button");
+		expect(document.body.textContent).not.toContain("Confirm changes");
+		const technicalDetails = document.querySelector<HTMLDetailsElement>(
+			".recipient-policy-management-result details",
+		);
+		expect(technicalDetails).toBeInstanceOf(HTMLDetailsElement);
+		expect(technicalDetails?.open).toBe(false);
+		expect(technicalDetails?.querySelector("summary")?.textContent).toBe("Technical details");
+	});
+
+	it("describes zero current-device impact", async () => {
+		vi.mocked(api.previewRecipientPolicyEdges).mockImplementationOnce(async (request) => ({
+			...preview(request.changes),
+			effectiveDevices: [],
+		}));
+		mount();
+		act(() => {
+			openRecipientPolicyManagement({ mode: "project-add", projectIds: ["git:codemem"] });
+		});
+		act(() => checkbox("ExampleCo").click());
+		await reviewSelection();
+
+		expect(document.body.textContent).toContain(
+			"After the update, no current devices will have access to the affected Projects.",
+		);
+	});
+
+	it("deduplicates effective devices by device ID while preserving first-item order", async () => {
+		vi.mocked(api.previewRecipientPolicyEdges).mockImplementationOnce(async (request) => {
+			const value = preview(request.changes);
+			const [device] = value.effectiveDevices;
+			if (!device) throw new Error("device fixture is incomplete");
+			return {
+				...value,
+				effectiveDevices: [
+					device,
+					{
+						...device,
+						canonicalProjectIdentity: "git:api",
+						displayName: "Duplicate project label",
+					},
+					{
+						...device,
+						deviceId: "device-brian",
+						identityId: "identity-brian",
+						displayName: "Brian’s Mac",
+					},
+				],
+			};
+		});
+		mount();
+		act(() => {
+			openRecipientPolicyManagement({ mode: "project-add", projectIds: ["git:codemem"] });
+		});
+		act(() => checkbox("ExampleCo").click());
+		await reviewSelection();
+
+		expect(document.body.textContent).toContain(
+			"After the update, the affected Projects will be available on 2 current devices across all recipients",
+		);
+		const availableSection = document
+			.getElementById("recipient-policy-review-availability")
+			?.closest("section");
+		const deviceNames = [...(availableSection?.querySelectorAll("li") ?? [])].map(
+			(item) => item.textContent,
+		);
+		expect(deviceNames).toEqual(["Adam’s Mac", "Brian’s Mac"]);
+		expect(document.body.textContent).not.toContain("Duplicate project label");
+	});
+
+	it("marks long Project, Team, Identity, member, and device names as wrappable", async () => {
+		const longProject = "Project-with-a-very-long-unbroken-name-that-must-wrap";
+		const longTeam = "Team-with-a-very-long-unbroken-name-that-must-wrap";
+		const longIdentity = "Identity-with-a-very-long-unbroken-name-that-must-wrap";
+		const longMember = "Member-with-a-very-long-unbroken-name-that-must-wrap";
+		const longDevice = "Device-with-a-very-long-unbroken-name-that-must-wrap";
+		vi.mocked(api.previewRecipientPolicyEdges).mockImplementationOnce(async (request) => {
+			const value = preview(request.changes);
+			const [project] = value.projects;
+			const [recipient] = value.selectedRecipients;
+			const [device] = value.effectiveDevices;
+			if (!project || !recipient || recipient.recipientKind !== "team" || !device) {
+				throw new Error("preview fixture is incomplete");
+			}
+			const [currentMember] = recipient.currentMembers;
+			if (!currentMember) {
+				throw new Error("preview fixture is incomplete");
+			}
+			return {
+				...value,
+				projects: [{ ...project, displayName: longProject }],
+				selectedRecipients: [
+					{
+						...recipient,
+						displayName: longTeam,
+						currentMembers: [{ ...currentMember, displayName: longMember }],
+					},
+					{
+						recipientKind: "identity",
+						identityId: "identity-brian",
+						displayName: longIdentity,
+						verification: "local",
+					},
+				],
+				effectiveDevices: [{ ...device, displayName: longDevice }],
+			};
+		});
+		const baseIntent = intent();
+		mount(
+			intent({
+				identities: baseIntent.identities.map((identity, index) => ({
+					...identity,
+					displayName: index === 0 ? longMember : longIdentity,
+				})),
+			}),
+		);
+		act(() => {
+			openRecipientPolicyManagement({ mode: "project-add", projectIds: ["git:codemem"] });
+		});
+		const teamDescription = checkbox("ExampleCo")
+			.closest("label")
+			?.querySelector(".recipient-policy-management-description");
+		expect(teamDescription?.textContent).toContain(longMember);
+		expect(checkbox(longIdentity).closest(".recipient-policy-management-choice")).not.toBeNull();
+		act(() => checkbox("ExampleCo").click());
+		await reviewSelection();
+
+		for (const name of [longProject, longTeam, longIdentity, longDevice]) {
+			const node = [...document.querySelectorAll(".recipient-policy-management-name")].find(
+				(candidate) => candidate.textContent === name,
+			);
+			expect(node).not.toBeUndefined();
+		}
+		expect(document.querySelector(".recipient-policy-management-member-names")?.textContent).toBe(
+			longMember,
+		);
 	});
 
 	it("discards stale preview, preserves selection, and announces another review", async () => {
@@ -593,15 +914,36 @@ describe("recipient policy management dialog", () => {
 			await Promise.resolve();
 		});
 
-		expect(document.body.textContent).toContain("Review the refreshed changes before trying again");
-		expect(document.querySelector("[aria-live='polite']")?.textContent).toContain(
-			"Refresh and review the preserved selection again",
+		const alerts = document.querySelectorAll("[role='alert']");
+		expect(alerts).toHaveLength(1);
+		expect(alerts[0]?.textContent).toBe(
+			"Recipient access changed after this review. Review the refreshed changes before trying again.",
 		);
+		expect(document.querySelector(".recipient-policy-management-status")?.textContent).toBe("");
 		expect(checkbox("ExampleCo").checked).toBe(true);
 		expect(document.body.textContent).toContain("Review changes");
 	});
 
-	it("provides labels, live regions, busy state, target hooks, and neutral opening focus", () => {
+	it("clears review-ready status when returning to selection", async () => {
+		mount();
+		act(() => {
+			openRecipientPolicyManagement({ mode: "project-add", projectIds: ["git:codemem"] });
+		});
+		act(() => checkbox("ExampleCo").click());
+		await reviewSelection();
+		expect(document.querySelector(".recipient-policy-management-status")?.textContent).toContain(
+			"Review ready",
+		);
+
+		act(() => {
+			[...document.querySelectorAll<HTMLButtonElement>("button")]
+				.find((button) => button.textContent === "Back")
+				?.click();
+		});
+		expect(document.querySelector(".recipient-policy-management-status")?.textContent).toBe("");
+	});
+
+	it("provides labels, live regions, busy state, semantic actions, and neutral opening focus", () => {
 		mount();
 		act(() => {
 			openRecipientPolicyManagement({ mode: "project-manage", projectId: "git:codemem" });
@@ -614,11 +956,25 @@ describe("recipient policy management dialog", () => {
 		}
 		expect(document.querySelector("[aria-busy='false']")).not.toBeNull();
 		expect(document.querySelector("[aria-live='polite']")).not.toBeNull();
-		expect(document.querySelectorAll(".recipient-policy-management-target").length).toBeGreaterThan(
-			2,
+		const closeButton = document.querySelector<HTMLButtonElement>(
+			".modal-close-button.recipient-policy-management-target",
 		);
+		expect(closeButton?.getAttribute("aria-label")).toBe("Close Manage Project recipients");
+		expect(closeButton?.type).toBe("button");
+		expect(closeButton?.textContent).toContain("Close");
+		expect(closeButton?.querySelector(".modal-close-button-icon")).not.toBeNull();
+		const footer = document.querySelector(".modal-footer.recipient-policy-management-actions");
+		const cancelButton = actionButton("Cancel");
+		const reviewButton = actionButton("Review changes");
+		expect(footer?.contains(cancelButton)).toBe(true);
+		expect(footer?.contains(reviewButton)).toBe(true);
+		expect(cancelButton.type).toBe("button");
+		expect(reviewButton.type).toBe("button");
 
-		const props = dialogSpy.mock.calls.at(-1)?.[0] as { onOpenAutoFocus: (event: Event) => void };
+		const props = dialogSpy.mock.calls.at(-1)?.[0] as {
+			onOpenAutoFocus: (event: Event) => void;
+			onOpenChange: (open: boolean) => void;
+		};
 		const event = new Event("focus");
 		const preventDefault = vi.spyOn(event, "preventDefault");
 		props.onOpenAutoFocus(event);
@@ -626,6 +982,8 @@ describe("recipient policy management dialog", () => {
 		expect(document.activeElement).toBe(
 			document.getElementById("recipient-policy-management-title"),
 		);
+		act(() => props.onOpenChange(false));
+		expect(document.getElementById("recipientPolicyManagementDialog")).toBeNull();
 	});
 
 	it("restores focus to a stable tab when polling replaced the original trigger", () => {
@@ -651,6 +1009,25 @@ describe("recipient policy management dialog", () => {
 		expect(document.activeElement).toBe(document.getElementById("tabBtn-sharing"));
 	});
 
+	it("restores focus to the connected opening trigger", () => {
+		const trigger = document.getElementById("trigger") as HTMLButtonElement;
+		trigger.focus();
+		mount();
+		act(() => {
+			openRecipientPolicyManagement({ mode: "project-manage", projectId: "git:codemem" });
+		});
+		const props = dialogSpy.mock.calls.at(-1)?.[0] as {
+			onCloseAutoFocus: (event: Event) => void;
+		};
+		const event = new Event("close");
+		const preventDefault = vi.spyOn(event, "preventDefault");
+		document.getElementById("recipient-policy-management-title")?.focus();
+		props.onCloseAutoFocus(event);
+
+		expect(preventDefault).toHaveBeenCalled();
+		expect(document.activeElement).toBe(trigger);
+	});
+
 	it("blocks duplicate preview submissions before the first request settles", async () => {
 		let resolvePreview: ((value: RecipientPolicyEdgePreviewResponseV1) => void) | null = null;
 		vi.mocked(api.previewRecipientPolicyEdges).mockImplementationOnce((request) =>
@@ -673,6 +1050,7 @@ describe("recipient policy management dialog", () => {
 		});
 		expect(api.previewRecipientPolicyEdges).toHaveBeenCalledTimes(1);
 		expect(checkbox("ExampleCo").disabled).toBe(true);
+		expect(document.querySelector<HTMLButtonElement>(".modal-close-button")?.disabled).toBe(true);
 
 		await act(async () => {
 			resolvePreview?.(preview([]));
@@ -700,24 +1078,15 @@ describe("recipient policy management dialog", () => {
 		).toBe(true);
 	});
 
-	it("renders partial commit outcomes with text rather than color-only meaning", async () => {
+	it("renders a realistic non-idempotent conflict with text rather than color-only meaning", async () => {
 		vi.mocked(api.commitRecipientPolicyEdges).mockResolvedValueOnce({
 			version: 1,
 			status: "conflict",
 			reviewedPolicyDigest: "policy:digest",
-			errorCode: "edge_conflict",
-			outcomes: [
-				{
-					change: {
-						canonicalProjectIdentity: "git:codemem",
-						recipient: { recipientKind: "team", teamId: "team-example" },
-						action: "add",
-					},
-					outcome: "already_present",
-				},
-			],
+			errorCode: null,
+			outcomes: [],
 			writeCount: 0,
-			idempotent: true,
+			idempotent: false,
 		});
 		mount();
 		act(() => {
@@ -735,9 +1104,19 @@ describe("recipient policy management dialog", () => {
 			await Promise.resolve();
 		});
 
-		expect(document.body.textContent).toContain(
-			"Some recipient access changes could not be completed",
+		expect(document.getElementById("recipient-policy-management-title")?.textContent).toBe(
+			"Recipient access needs attention",
 		);
-		expect(document.body.textContent).toContain("already present");
+		expect(document.getElementById("recipient-policy-management-description")?.textContent).toBe(
+			"Some reviewed recipient access changes were not applied. Review the technical details.",
+		);
+		expect(document.activeElement).toBe(
+			document.getElementById("recipient-policy-management-title"),
+		);
+		expect(document.body.textContent).toContain("Status: Conflict");
+		expect(document.body.textContent).not.toContain("already present");
+		expect(document.querySelector(".recipient-policy-management-result summary")?.textContent).toBe(
+			"Technical details",
+		);
 	});
 });

--- a/packages/ui/src/tabs/recipient-policy-management.tsx
+++ b/packages/ui/src/tabs/recipient-policy-management.tsx
@@ -1,9 +1,11 @@
 import { render } from "preact";
 import { useEffect, useId, useMemo, useRef, useState } from "preact/hooks";
+import { DialogCloseButton } from "../components/primitives/dialog-close-button";
 import { RadixDialog } from "../components/primitives/radix-dialog";
 import * as api from "../lib/api";
 import type {
 	RecipientPolicyEdgeChangeV1,
+	RecipientPolicyEdgeCommitOutcomeV1,
 	RecipientPolicyEdgeCommitResultV1,
 	RecipientPolicyEdgePreviewResponseV1,
 	RecipientPolicyEdgeRecipientRefV1,
@@ -41,8 +43,12 @@ let requestOpen: ((request: RecipientPolicyManagementRequest) => boolean) | null
 let returnFocus: HTMLElement | null = null;
 
 export function openRecipientPolicyManagement(request: RecipientPolicyManagementRequest): boolean {
+	if (requestOpen) {
+		if (!requestOpen(request)) return false;
+		returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+		return true;
+	}
 	returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-	if (requestOpen) return requestOpen(request);
 	pendingOpen = request;
 	return true;
 }
@@ -104,8 +110,8 @@ function Choice({
 		>
 			<input checked={checked} disabled={disabled} id={id} onChange={onChange} type="checkbox" />
 			<span>
-				<strong>{label}</strong>
-				<span className="small">{description}</span>
+				<strong className="recipient-policy-management-name">{label}</strong>
+				<span className="small recipient-policy-management-description">{description}</span>
 			</span>
 		</label>
 	);
@@ -301,75 +307,174 @@ function dialogCopy(request: RecipientPolicyManagementRequest) {
 	};
 }
 
-function Review({ preview }: { preview: RecipientPolicyEdgePreviewResponseV1 }) {
-	const memoryTotal = preview.projects.reduce(
-		(total, project) => total + project.existingMemoryCount,
-		0,
-	);
+function recipientActionLabel(
+	outcomes: RecipientPolicyEdgeCommitOutcomeV1[],
+	recipient: RecipientPolicyEdgeRecipientRefV1,
+): string {
+	let addsAccess = false;
+	let removesAccess = false;
+	let requestedAdd = false;
+	let requestedRemove = false;
+	const key = recipientKey(recipient);
+	for (const item of outcomes) {
+		const { change, outcome } = item;
+		if (recipientKey(change.recipient) !== key) continue;
+		if (change.action === "add") {
+			requestedAdd = true;
+			if (outcome === "added") addsAccess = true;
+		} else {
+			requestedRemove = true;
+			if (outcome === "removed") removesAccess = true;
+		}
+	}
+	if (addsAccess && removesAccess) return "Mixed changes";
+	if (removesAccess) return "Removing access";
+	if (addsAccess) return "Adding access";
+	if (requestedAdd && !requestedRemove) return "Already has access";
+	if (requestedRemove && !requestedAdd) return "Already without access";
+	return "No changes";
+}
+
+function changedRecipientsMissingFromPreview(
+	preview: RecipientPolicyEdgePreviewResponseV1,
+): RecipientPolicyEdgeRecipientRefV1[] {
+	const selectedKeys = new Set(preview.selectedRecipients.map(recipientKey));
+	const missing = new Map<string, RecipientPolicyEdgeRecipientRefV1>();
+	for (const change of preview.normalizedChanges) {
+		const key = recipientKey(change.recipient);
+		if (!selectedKeys.has(key)) missing.set(key, change.recipient);
+	}
+	return [...missing.values()];
+}
+
+function deduplicateEffectiveDevices(
+	devices: RecipientPolicyEdgePreviewResponseV1["effectiveDevices"],
+): RecipientPolicyEdgePreviewResponseV1["effectiveDevices"] {
+	const seenDeviceIds = new Set<string>();
+	return devices.filter((device) => {
+		if (seenDeviceIds.has(device.deviceId)) return false;
+		seenDeviceIds.add(device.deviceId);
+		return true;
+	});
+}
+
+function Review({
+	preview,
+	recipientLabels,
+}: {
+	preview: RecipientPolicyEdgePreviewResponseV1;
+	recipientLabels: ReadonlyMap<string, string>;
+}) {
+	const effectiveDevices = deduplicateEffectiveDevices(preview.effectiveDevices);
+	const missingChangedRecipients = changedRecipientsMissingFromPreview(preview);
 	return (
 		<div className="sync-dialog-stack recipient-policy-management-review">
-			<section>
-				<h3>Exact Projects</h3>
+			<section aria-labelledby="recipient-policy-review-projects">
+				<h3 id="recipient-policy-review-projects">Projects affected</h3>
 				<ul>
 					{preview.projects.map((project) => (
 						<li key={project.canonicalProjectIdentity}>
-							<strong>{project.displayName}</strong> —{" "}
-							{project.existingMemoryCount.toLocaleString()} existing memories and future activity
+							<strong className="recipient-policy-management-name">{project.displayName}</strong>
+							<span>
+								{" "}
+								— Access changes affect {project.existingMemoryCount.toLocaleString()} existing
+								memories
+								{project.futureMemoriesShared
+									? " and future activity"
+									: "; future activity is not included"}
+							</span>
 						</li>
 					))}
 				</ul>
-				<p className="small">
-					{preview.projects.length.toLocaleString()}{" "}
-					{preview.projects.length === 1 ? "Project" : "Projects"} · {memoryTotal.toLocaleString()}{" "}
-					existing memories total
-				</p>
 			</section>
-			<section>
-				<h3>Selected recipients</h3>
+			<section aria-labelledby="recipient-policy-review-recipients">
+				<h3 id="recipient-policy-review-recipients">Recipient changes</h3>
 				<ul>
 					{preview.selectedRecipients.map((recipient) => (
 						<li key={recipientKey(recipient)}>
-							<strong>{recipient.displayName}</strong>{" "}
+							<strong className="recipient-policy-management-name">{recipient.displayName}</strong>{" "}
+							<span>— {recipientActionLabel(preview.outcomes, recipient)} · </span>
 							{recipient.recipientKind === "identity" ? (
-								<span>— locally verified Identity</span>
+								<span>Identity · locally verified</span>
 							) : (
-								<span>
-									— Team with {recipient.currentMembers.length.toLocaleString()} current{" "}
+								<span className="recipient-policy-management-recipient-context">
+									Team · {recipient.currentMembers.length.toLocaleString()} current{" "}
 									{recipient.currentMembers.length === 1 ? "member" : "members"}
-									{recipient.currentMembers.length
-										? `: ${recipient.currentMembers.map((member) => member.displayName).join(", ")}`
-										: ""}
-									. Future Team members inherit access.
+									{recipient.currentMembers.length ? (
+										<>
+											:{" "}
+											<span className="recipient-policy-management-member-names">
+												{recipient.currentMembers.map((member) => member.displayName).join(", ")}
+											</span>
+										</>
+									) : null}
+									. Future Team members{" "}
+									{recipient.futureMembersInherit ? "inherit" : "do not inherit"} access.
 								</span>
 							)}
 						</li>
 					))}
+					{missingChangedRecipients.map((recipient) => (
+						<li key={recipientKey(recipient)}>
+							<strong className="recipient-policy-management-name">
+								{recipientLabels.get(recipientKey(recipient)) ??
+									(recipient.recipientKind === "team" ? recipient.teamId : recipient.identityId)}
+							</strong>{" "}
+							<span>
+								— {recipientActionLabel(preview.outcomes, recipient)} ·{" "}
+								{recipient.recipientKind === "team" ? "Team" : "Identity"}
+							</span>
+						</li>
+					))}
 				</ul>
 			</section>
-			<p>
-				<strong>
-					{preview.effectiveDevices.length.toLocaleString()} effective{" "}
-					{preview.effectiveDevices.length === 1 ? "device" : "devices"}
-				</strong>
-			</p>
-			{preview.unchangedProjects.length ? (
-				<section>
-					<h3>Unchanged Projects</h3>
-					<ul>
-						{preview.unchangedProjects.map((project) => (
-							<li key={project.canonicalProjectIdentity}>{project.displayName}</li>
-						))}
-					</ul>
-				</section>
-			) : (
-				<p>
-					<strong>No other Projects will change.</strong>
+			<section aria-labelledby="recipient-policy-review-availability">
+				<h3 id="recipient-policy-review-availability">Resulting availability</h3>
+				{effectiveDevices.length ? (
+					<>
+						<p>
+							After the update, the affected Projects will be available on{" "}
+							{effectiveDevices.length.toLocaleString()} current{" "}
+							{effectiveDevices.length === 1 ? "device" : "devices"} across all recipients.
+						</p>
+						<ul>
+							{effectiveDevices.map((device) => (
+								<li className="recipient-policy-management-name" key={device.deviceId}>
+									{device.displayName}
+								</li>
+							))}
+						</ul>
+					</>
+				) : (
+					<p>After the update, no current devices will have access to the affected Projects.</p>
+				)}
+			</section>
+			<details className="recipient-policy-management-details">
+				<summary>Change details</summary>
+				<p className="small">
+					{preview.addCount.toLocaleString()} {preview.addCount === 1 ? "add" : "adds"} ·{" "}
+					{preview.removeCount.toLocaleString()} {preview.removeCount === 1 ? "remove" : "removes"}{" "}
+					· {preview.netWriteCount.toLocaleString()}{" "}
+					{preview.netWriteCount === 1 ? "write" : "writes"}
 				</p>
-			)}
-			<p className="small">
-				Adds {preview.addCount.toLocaleString()} · Removes {preview.removeCount.toLocaleString()} ·{" "}
-				{preview.netWriteCount.toLocaleString()} {preview.netWriteCount === 1 ? "write" : "writes"}
-			</p>
+				{preview.unchangedProjects.length ? (
+					<>
+						<p className="small recipient-policy-management-detail-label">
+							<strong>Unchanged Projects</strong>
+						</p>
+						<ul aria-label="Unchanged Projects">
+							{preview.unchangedProjects.map((project) => (
+								<li
+									className="recipient-policy-management-name"
+									key={project.canonicalProjectIdentity}
+								>
+									{project.displayName}
+								</li>
+							))}
+						</ul>
+					</>
+				) : null}
+			</details>
 		</div>
 	);
 }
@@ -381,41 +486,46 @@ function CommitResult({
 	preview: RecipientPolicyEdgePreviewResponseV1;
 	result: RecipientPolicyEdgeCommitResultV1;
 }) {
-	const complete = result.status === "applied";
+	const technicalStatus =
+		result.status === "applied"
+			? "Applied"
+			: result.status === "not_found"
+				? "Not found"
+				: `${result.status.charAt(0).toUpperCase()}${result.status.slice(1)}`;
 	return (
 		<div className="sync-dialog-stack recipient-policy-management-result">
-			<p role="status">
-				<strong>
-					{complete
-						? `Recipient access updated with ${result.writeCount.toLocaleString()} ${result.writeCount === 1 ? "write" : "writes"}.`
-						: "Some recipient access changes could not be completed."}
-				</strong>
-			</p>
-			{result.outcomes.length ? (
-				<ul>
-					{result.outcomes.map((item) => {
-						const projectName =
-							preview.projects.find(
-								(project) =>
-									project.canonicalProjectIdentity === item.change.canonicalProjectIdentity,
-							)?.displayName ?? "Selected Project";
-						const recipientName =
-							preview.selectedRecipients.find(
-								(recipient) => recipientKey(recipient) === recipientKey(item.change.recipient),
-							)?.displayName ??
-							(item.change.recipient.recipientKind === "team" ? "Team" : "Identity");
-						return (
-							<li
-								key={`${item.change.canonicalProjectIdentity}:${recipientKey(item.change.recipient)}`}
-							>
-								{item.change.action === "add" ? "Add" : "Remove"} {recipientName}{" "}
-								{item.change.action === "add" ? "to" : "from"} {projectName}:{" "}
-								{item.outcome.replaceAll("_", " ")}
-							</li>
-						);
-					})}
-				</ul>
-			) : null}
+			<details className="recipient-policy-management-details">
+				<summary>Technical details</summary>
+				<p>
+					Status: {technicalStatus}. Writes: {result.writeCount.toLocaleString()}.
+				</p>
+				{result.errorCode ? <p>Error code: {result.errorCode.replaceAll("_", " ")}.</p> : null}
+				{result.outcomes.length ? (
+					<ul>
+						{result.outcomes.map((item) => {
+							const projectName =
+								preview.projects.find(
+									(project) =>
+										project.canonicalProjectIdentity === item.change.canonicalProjectIdentity,
+								)?.displayName ?? "Selected Project";
+							const recipientName =
+								preview.selectedRecipients.find(
+									(recipient) => recipientKey(recipient) === recipientKey(item.change.recipient),
+								)?.displayName ??
+								(item.change.recipient.recipientKind === "team" ? "Team" : "Identity");
+							return (
+								<li
+									key={`${item.change.canonicalProjectIdentity}:${recipientKey(item.change.recipient)}`}
+								>
+									{item.change.action === "add" ? "Add" : "Remove"} {recipientName}{" "}
+									{item.change.action === "add" ? "to" : "from"} {projectName}:{" "}
+									{item.outcome.replaceAll("_", " ")}
+								</li>
+							);
+						})}
+					</ul>
+				) : null}
+			</details>
 		</div>
 	);
 }
@@ -431,6 +541,16 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 	const [busy, setBusy] = useState(false);
 	const submitting = useRef(false);
 	const choices = useMemo(() => recipientChoices(intent, request), [intent, request]);
+	const recipientLabels = useMemo(
+		() =>
+			new Map([
+				...intent.teams.map((team) => [`team:${team.teamId}`, team.displayName] as const),
+				...intent.identities.map(
+					(identity) => [`identity:${identity.identityId}`, identity.displayName] as const,
+				),
+			]),
+		[intent],
+	);
 	const projectIds = useMemo(
 		() => new Set(projects.map((project) => project.canonicalProjectIdentity)),
 		[projects],
@@ -461,6 +581,11 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 		};
 	}, [intent]);
 
+	useEffect(() => {
+		if (!result) return;
+		document.getElementById("recipient-policy-management-title")?.focus();
+	}, [result]);
+
 	if (!request) return null;
 	const copy = dialogCopy(request);
 	const fixedProjects = requestProjectIds(request);
@@ -480,6 +605,21 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 	const noChanges =
 		request.mode !== "project-add" && request.mode !== "recipient-add" && changes.length === 0;
 	const availableProjects = projectChoices(projects, request, initial);
+	const resultApplied = result?.status === "applied";
+	const title = result
+		? resultApplied
+			? "Recipient access updated"
+			: "Recipient access needs attention"
+		: preview
+			? "Review recipient access"
+			: copy.title;
+	const description = result
+		? resultApplied
+			? "The reviewed recipient access changes are applied."
+			: "Some reviewed recipient access changes were not applied. Review the technical details."
+		: preview
+			? "Confirm the exact Projects, recipients, and resulting access."
+			: copy.description;
 
 	const close = () => {
 		if (submitting.current) return;
@@ -534,11 +674,7 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 				reviewedPolicyDigest: preview.reviewedPolicyDigest,
 			});
 			setResult(committed);
-			setStatus(
-				committed.status === "applied"
-					? "Recipient access changes saved."
-					: "Some recipient access changes need attention.",
-			);
+			setStatus("");
 			try {
 				await options.onCommitted?.(committed);
 			} catch {
@@ -547,7 +683,7 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 		} catch (cause) {
 			if (cause instanceof api.RecipientPolicyEdgesStaleError) {
 				setPreview(null);
-				setStatus("Recipient access changed. Refresh and review the preserved selection again.");
+				setStatus("");
 			}
 			setError(safeError(cause, "Unable to save recipient access changes."));
 		} finally {
@@ -583,10 +719,10 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 				returnFocus = null;
 			}}
 			onOpenAutoFocus={(event) => {
-				const title = document.getElementById("recipient-policy-management-title");
-				if (!title) return;
+				const titleElement = document.getElementById("recipient-policy-management-title");
+				if (!titleElement) return;
 				event.preventDefault();
-				title.focus();
+				titleElement.focus();
 			}}
 			onOpenChange={(open) => {
 				if (!open) close();
@@ -601,23 +737,18 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 			>
 				<div className="modal-header">
 					<h2 id="recipient-policy-management-title" tabIndex={-1}>
-						{preview ? "Review recipient access" : copy.title}
+						{title}
 					</h2>
-					<button
-						aria-label={`Close ${copy.title}`}
-						className="recipient-policy-management-target"
+					<DialogCloseButton
+						ariaLabel={`Close ${title}`}
+						className="modal-close-button recipient-policy-management-target"
 						disabled={busy}
 						onClick={close}
-						type="button"
-					>
-						×
-					</button>
+					/>
 				</div>
 				<div className="modal-body recipient-policy-management-selection">
 					<p className="small" id="recipient-policy-management-description">
-						{preview
-							? "Confirm the exact Projects, recipients, and resulting access."
-							: copy.description}
+						{description}
 					</p>
 					{unavailableMessage ? (
 						<p aria-live="polite" role={options.loadError ? "alert" : "status"}>
@@ -626,7 +757,7 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 					) : result && preview ? (
 						<CommitResult preview={preview} result={result} />
 					) : preview ? (
-						<Review preview={preview} />
+						<Review preview={preview} recipientLabels={recipientLabels} />
 					) : request.mode === "recipient-add" || request.mode === "recipient-manage" ? (
 						<fieldset className="sync-dialog-radio-list" disabled={busy}>
 							<legend>{copy.legend}</legend>
@@ -670,9 +801,15 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 							)}
 						</fieldset>
 					)}
-					<p aria-live="polite" className="small recipient-policy-management-status" role="status">
-						{status}
-					</p>
+					{result ? null : (
+						<p
+							aria-live="polite"
+							className="small recipient-policy-management-status"
+							role="status"
+						>
+							{status}
+						</p>
+					)}
 					{error ? (
 						<p aria-live="assertive" role="alert">
 							{error}
@@ -690,7 +827,14 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 					<button
 						className="settings-button recipient-policy-management-target"
 						disabled={busy}
-						onClick={preview && !result ? () => setPreview(null) : close}
+						onClick={
+							preview && !result
+								? () => {
+										setPreview(null);
+										setStatus("");
+									}
+								: close
+						}
 						type="button"
 					>
 						{result ? "Done" : preview ? "Back" : "Cancel"}

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1203,7 +1203,32 @@
       .recipient-policy-management-selection fieldset { border: 0; padding: 0; margin: var(--sp-4) 0 0; }
       .recipient-policy-management-selection legend { font-weight: var(--font-weight-semibold); }
       .recipient-policy-management-review section + section { margin-top: var(--sp-4); }
-      .recipient-policy-management-review ul { padding-left: var(--sp-5); }
+      .recipient-policy-management-review h3 { margin: 0 0 var(--sp-2); }
+      .recipient-policy-management-review p,
+      .recipient-policy-management-review ul { margin-top: var(--sp-2); }
+      .recipient-policy-management-review ul,
+      .recipient-policy-management-details ul { padding-left: var(--sp-5); }
+      .recipient-policy-management-name { overflow-wrap: anywhere; }
+      .recipient-policy-management-choice > span { min-width: 0; }
+      .recipient-policy-management-description,
+      .recipient-policy-management-member-names,
+      .recipient-policy-management-recipient-context,
+      .recipient-policy-management-review li,
+      .recipient-policy-management-review li span {
+        min-width: 0;
+        overflow-wrap: anywhere;
+      }
+      .recipient-policy-management-details {
+        margin-top: var(--sp-3);
+        color: var(--text-secondary);
+      }
+      .recipient-policy-management-details summary {
+        color: var(--text-primary);
+        cursor: pointer;
+        font-weight: var(--font-weight-semibold);
+      }
+      .recipient-policy-management-details p { margin-top: var(--sp-2); }
+      .recipient-policy-management-details li { overflow-wrap: anywhere; }
       .recipient-policy-management-status:empty { display: none; }
       .recipient-policy-sharing-header { margin-bottom: var(--sp-4); }
       .recipient-policy-sharing-tabs {
@@ -2773,7 +2798,7 @@
         font-size: var(--font-size-sm);
         transition: border-color var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard);
       }
-      .modal-close-button:hover {
+      .modal-close-button:hover:not(:disabled) {
         border-color: var(--border-hover);
         background: color-mix(in srgb, var(--surface-0) 92%, var(--control-hover-bg));
         color: var(--text-primary);
@@ -2782,6 +2807,13 @@
         outline: 2px solid var(--accent);
         outline-offset: 2px;
         box-shadow: 0 0 0 4px var(--focus-ring);
+      }
+      .modal-close-button:disabled {
+        border-color: var(--border);
+        background: var(--surface-1);
+        color: var(--text-tertiary);
+        cursor: not-allowed;
+        opacity: 0.65;
       }
       .modal-close-button-icon {
         display: inline-flex;

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -97,6 +97,27 @@ export default defineConfig(({ command, mode }) => {
 		test: {
 			environment: "jsdom",
 			name: "ui",
+			server: {
+				deps: {
+					inline: [
+						"@radix-ui/react-compose-refs",
+						"@radix-ui/react-context",
+						"@radix-ui/react-dialog",
+						"@radix-ui/react-dismissable-layer",
+						"@radix-ui/react-focus-guards",
+						"@radix-ui/react-focus-scope",
+						"@radix-ui/react-id",
+						"@radix-ui/react-portal",
+						"@radix-ui/react-presence",
+						"@radix-ui/react-primitive",
+						"@radix-ui/react-slot",
+						"@radix-ui/react-use-callback-ref",
+						"@radix-ui/react-use-controllable-state",
+						"@radix-ui/react-use-escape-keydown",
+						"@radix-ui/react-use-layout-effect",
+					],
+				},
+			},
 		},
 	};
 });


### PR DESCRIPTION
## Description

Reuse the shared themed dialog close control and restructure recipient-access review around three decisions: what is shared, who receives it, and which devices receive it now. Result states use one truthful completion summary, reliable focus, and progressive technical details.

Closes codemem-ehkz and codemem-neb7.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused dialog and primitive tests passed, including real Radix Escape/focus restoration and the production UI build. The complete stack passed `pnpm run check` with 3,310 tests.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced