### PR TITLE
test(sharing): align provisioning retry lifecycle

### DIFF
--- a/packages/core/src/share-provisioning.test.ts
+++ b/packages/core/src/share-provisioning.test.ts
@@ -431,6 +431,12 @@ describe("exact project share provisioning", () => {
 
 	it("moves capability preflight to needs-attention after three failed attempts", async () => {
 		const { deps } = dependencies({ supportsReassignScope: vi.fn(async () => "unsupported") });
+		expect(
+			db
+				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+				.pluck()
+				.get(operationId),
+		).toBe("provisioning");
 
 		for (let attempt = 1; attempt <= 3; attempt += 1) {
 			await expect(
@@ -441,7 +447,7 @@ describe("exact project share provisioning", () => {
 					.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
 					.pluck()
 					.get(operationId),
-			).toBe(attempt === 3 ? "needs_attention" : "accepted");
+			).toBe(attempt === 3 ? "needs_attention" : "provisioning");
 		}
 
 		expect(


### PR DESCRIPTION
## Description

Align the capability-preflight retry regression with the truthful lifecycle introduced downstack: accepted exact-Project operations begin provisioning immediately, remain provisioning through retryable failures, and move to needs attention on the third failure.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

The targeted provisioning retry test and complete `pnpm run check` passed with 3,207 tests. Automated Project-sharing E2E also passed.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced