### PR TITLE
fix(sharing): bootstrap fresh recipient invitations

### DIFF
--- a/docs/plans/2026-07-23-fresh-recipient-invitation-bootstrap-design.md
+++ b/docs/plans/2026-07-23-fresh-recipient-invitation-bootstrap-design.md
@@ -1,0 +1,90 @@
+# Fresh recipient invitation bootstrap design
+
+**Date:** 2026-07-23
+**Status:** approved
+**Scope:** Team-member and add-device invitation review and acceptance on fresh recipients
+
+## Goal
+
+Let a fresh codemem installation review and accept a Team-member or add-device invitation without already containing the Team, Identity, Project-recipient, or membership facts that the invitation establishes. The reviewed access must remain exact, coordinator-owned, key-bound, and fail-closed.
+
+## Root cause
+
+The inviter currently reviews recipient access from its local policy database, but the coordinator stores only a digest and target identifiers. During inspection and acceptance, the recipient rebuilds the review from its own database. A fresh recipient does not yet have the invited Team or target Identity, so Team review fails with `team_not_found`, add-device review fails with `identity_not_found`, and the viewer collapses both to `invite_invalid`.
+
+The digest alone cannot reconstruct the reviewed Team, Project sources, exclusions, display names, or memory counts. Pre-seeding those facts would preserve the same bootstrap inversion.
+
+## Reviewed intent snapshot
+
+Recipient invitations store a canonical, versioned reviewed-intent snapshot alongside its digest. The snapshot contains only access intent and presentation facts owned by the inviter:
+
+- journey kind;
+- Team identifier, display name, and future-Project inheritance for Team invitations;
+- target Identity identifier and display name for add-device invitations;
+- included Projects with display names, existing-memory counts, future-memory behavior, and direct or Team sources;
+- explicitly excluded Projects for add-device invitations, where the recipient is adopting the same Identity.
+
+Team-member snapshots omit non-Team Project identifiers, names, and memory counts. The included Project list fully defines the Team grant without disclosing unrelated private Projects to an invitation bearer.
+
+The snapshot excludes the eventual recipient device identifier, public key, fingerprint, and display name. Those values are unknown at invitation creation and remain bound locally during inspection and acceptance.
+
+The invitation URL continues to carry only immutable target metadata and the reviewed-intent digest. It does not embed the snapshot.
+
+## Data flow
+
+### Creation
+
+1. The inviter computes the access review from inviter-owned policy facts.
+2. The viewer derives a canonical reviewed-intent snapshot, excluding the inviter's local device binding.
+3. The coordinator validates the snapshot shape, kind, target metadata, and digest.
+4. The coordinator stores the canonical snapshot JSON and digest with the invitation.
+
+### Inspection
+
+1. The recipient sends the bearer token to `/v1/invites/inspect`.
+2. The coordinator returns the stored reviewed intent and immutable invitation metadata.
+3. The viewer verifies the returned kind, target, and digest against the invitation payload.
+4. The viewer combines the reviewed intent with the recipient's stable local device binding and computes a recipient-specific onboarding digest.
+5. The UI renders that combined review without querying recipient-local Team or Identity policy rows.
+
+### Acceptance
+
+1. The recipient submits the caller-supplied, recipient-specific onboarding digest and key-bound device data; imports without that reviewed digest fail before the invitation is consumed.
+2. The coordinator revalidates expiry, revocation, target Identity, token binding, and device-key fingerprint before consuming or replaying the invitation.
+3. The acceptance response returns the same stored reviewed intent and digest.
+4. The recipient verifies both again, then atomically materializes the minimum local Identity, Team, membership, and device facts required by the journey.
+5. Acceptance enables local sync with safe defaults so the reviewed Projects can arrive; when the sync runtime is currently disabled, the viewer explicitly asks for a restart.
+6. Repeated acceptance remains idempotent. Conflicting existing policy or device bindings fail closed.
+
+For add-device onboarding, a pristine bootstrap Identity may be replaced by the invitation's fixed target Identity. A non-pristine or differently bound local Identity remains a conflict; the invitation cannot silently reassign an established profile.
+
+## Storage and compatibility
+
+Add a nullable reviewed-intent JSON column to both coordinator stores. Existing legacy, exact-Project, and pre-migration recipient invitations remain readable. A recipient invitation without a valid stored snapshot cannot use the fresh-recipient path and returns a safe recreate-invitation error rather than inventing access intent.
+
+The TypeScript coordinator and Cloudflare Worker use the same validation and canonicalization contract. Invalid or oversized snapshots are rejected at the admin API boundary.
+
+## Error handling
+
+- Payload, coordinator target, and reviewed-intent digest mismatches return `recipient_invite_intent_mismatch`.
+- Missing or invalid stored snapshots return `recipient_invite_review_unavailable`.
+- A non-pristine local Identity that conflicts with an add-device target returns `invite_identity_conflict`.
+- Expired, revoked, replay-conflicting, or key-conflicting invitations retain their existing fail-closed behavior.
+- The viewer maps safe codes to contextual guidance and does not collapse every recipient-review failure to `invite_invalid`.
+
+## Validation
+
+- Core unit tests cover canonical intent normalization, digest validation, snapshot-based preview, atomic commit, conflicts, and idempotency.
+- Both coordinator store implementations pass the shared contract suite for create, inspect, accept, and replay.
+- Coordinator API and Worker tests cover malformed, mismatched, missing, and valid reviewed intent.
+- Viewer integration tests create invitations on an owner and inspect/accept them on recipients with empty policy tables for both journeys.
+- Existing exact-Project and legacy invitation tests remain unchanged and green.
+- A rebuilt disposable sandbox proves Team and add-device review and acceptance before broader sharing isolation is re-evaluated.
+
+## Delivery
+
+Ship as one additional Graphite PR on top of the sharing dogfood stabilization stack:
+
+`fix(sharing): bootstrap fresh recipient invitations`
+
+Copy/IA cleanup and the separate Project-isolation leak remain outside this PR.

--- a/docs/plans/2026-07-23-fresh-recipient-invitation-bootstrap-implementation.md
+++ b/docs/plans/2026-07-23-fresh-recipient-invitation-bootstrap-implementation.md
@@ -1,0 +1,53 @@
+# Fresh recipient invitation bootstrap implementation plan
+
+**Date:** 2026-07-23
+**Design:** `docs/plans/2026-07-23-fresh-recipient-invitation-bootstrap-design.md`
+**Bead:** `codemem-wosg`
+
+## 1. Contract and pure validation
+
+- Add a versioned recipient reviewed-intent type in core.
+- Add pure normalization, canonical serialization, and digest helpers.
+- Separate access intent from recipient-specific device binding in onboarding previews.
+- Add failing unit tests for Team and add-device snapshots, malformed inputs, target mismatches, ordering, and digest mismatches.
+
+## 2. Coordinator persistence
+
+- Extend the coordinator invite contract with nullable reviewed-intent JSON.
+- Add the additive SQLite and Cloudflare D1 schema migrations.
+- Update both store implementations and the shared store harness.
+- Prove valid snapshots survive create, inspect, acceptance, and idempotent replay.
+- Prove missing or malformed snapshots fail closed for current recipient invitations.
+
+## 3. Coordinator API and actions
+
+- Send reviewed intent during recipient invitation creation.
+- Validate kind, target metadata, size, canonical form, and digest at the admin API boundary.
+- Return reviewed intent from inspect and acceptance responses.
+- Keep invitation links digest-only.
+- Add API/action regressions for tampering, expiry, revocation, target mismatch, key mismatch, and replay.
+
+## 4. Fresh-recipient local onboarding
+
+- Build inspection previews from coordinator-reviewed intent plus the stable local device binding.
+- Add snapshot-based atomic commit for Team membership and add-device binding.
+- Materialize missing Team/Identity facts only from validated reviewed intent.
+- Allow safe add-device adoption only from a pristine bootstrap Identity; reject established conflicting profiles.
+- Preserve idempotency and existing device-key conflict protections.
+
+## 5. Viewer and UI integration
+
+- Stop rebuilding recipient invitation intent from recipient-local policy rows.
+- Preserve kind, target, and digest checks across payload, inspect, and acceptance.
+- Return safe contextual review errors instead of a blanket `invite_invalid`.
+- Keep the current Team and add-device review layout, now populated from coordinator-owned facts.
+- Add owner-create to fresh-recipient inspect/accept integration tests for both journeys.
+
+## 6. Validation and review
+
+- Run focused core onboarding, coordinator store/API/action, Worker, viewer-server, and invitation UI tests.
+- Run `pnpm run tsc`, `pnpm run lint`, and the affected package tests.
+- Run `pnpm run check` before submission.
+- Run CodeReviewer, TestEngineer, and pragmatic maintainability review.
+- Rebuild and reset the disposable sandbox, then repeat Team and add-device onboarding on fresh recipients.
+- Create the PR with `gt create`, submit the stack, populate the PR template, mark it ready, and verify PR metadata.

--- a/packages/cloudflare-coordinator-worker/migrations/0011_add_recipient_reviewed_intent.sql
+++ b/packages/cloudflare-coordinator-worker/migrations/0011_add_recipient_reviewed_intent.sql
@@ -1,0 +1,1 @@
+ALTER TABLE coordinator_invites ADD COLUMN reviewed_intent_json TEXT;

--- a/packages/cloudflare-coordinator-worker/schema.sql
+++ b/packages/cloudflare-coordinator-worker/schema.sql
@@ -64,7 +64,8 @@ CREATE TABLE IF NOT EXISTS coordinator_invites (
   invite_kind TEXT,
   policy_team_id TEXT,
   target_identity_id TEXT,
-  reviewed_preview_digest TEXT
+  reviewed_preview_digest TEXT,
+  reviewed_intent_json TEXT
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_coordinator_invites_operation_id

--- a/packages/cloudflare-coordinator-worker/src/index.test.ts
+++ b/packages/cloudflare-coordinator-worker/src/index.test.ts
@@ -293,6 +293,33 @@ describe("createCloudflareCoordinatorWorker", () => {
 		]);
 	});
 
+	it("migration 0011 adds nullable reviewed intent without changing existing invitations", () => {
+		db.exec(`
+			DROP TABLE coordinator_invites;
+			CREATE TABLE coordinator_invites (
+				invite_id TEXT PRIMARY KEY,
+				group_id TEXT NOT NULL,
+				token TEXT NOT NULL UNIQUE,
+				policy TEXT NOT NULL,
+				expires_at TEXT NOT NULL,
+				created_at TEXT NOT NULL
+			);
+			INSERT INTO coordinator_invites(invite_id, group_id, token, policy, expires_at, created_at)
+			VALUES ('legacy-invite', 'g1', 'legacy-token', 'auto_admit', '2099-01-01T00:00:00Z',
+				'2026-03-28T00:00:00Z');
+		`);
+		const migration = readFileSync(
+			join(import.meta.dirname, "../migrations/0011_add_recipient_reviewed_intent.sql"),
+			"utf8",
+		);
+
+		db.exec(migration);
+
+		expect(
+			db.prepare("SELECT invite_id, reviewed_intent_json FROM coordinator_invites").get(),
+		).toEqual({ invite_id: "legacy-invite", reviewed_intent_json: null });
+	});
+
 	it("serves coordinator admin data through the worker entrypoint", async () => {
 		const store = new D1CoordinatorStore(d1db);
 		await store.createGroup("g1", "Team Alpha");

--- a/packages/cloudflare-coordinator-worker/test/worker.integration.test.ts
+++ b/packages/cloudflare-coordinator-worker/test/worker.integration.test.ts
@@ -3,6 +3,8 @@ import {
 	type CoordinatorPeerRecord,
 	fingerprintPublicKey,
 	type InvitePayload,
+	recipientReviewedIntentDigest,
+	type RecipientReviewedIntentV1,
 	SIGNATURE_VERSION,
 } from "@codemem/core";
 import { env, exports } from "cloudflare:workers";
@@ -50,6 +52,26 @@ function createIdentity(): TestIdentity {
 		publicKey: sshPublic,
 		fingerprint: fingerprintPublicKey(sshPublic),
 		privateKey,
+	};
+}
+
+function teamReviewedIntent(teamId = "policy-team-1"): RecipientReviewedIntentV1 {
+	return {
+		version: 1,
+		journey: "team",
+		team: { teamId, displayName: "Product", futureProjectsInherit: true },
+		projects: [],
+		excludedProjects: [],
+	};
+}
+
+function addDeviceReviewedIntent(identityId = "identity-brian"): RecipientReviewedIntentV1 {
+	return {
+		version: 1,
+		journey: "add_device",
+		targetIdentity: { identityId, displayName: "Brian" },
+		projects: [],
+		excludedProjects: [],
 	};
 }
 
@@ -834,6 +856,10 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 	it("persists explicit Team and add-device invitation bindings without mutating coordinator memberships", async () => {
 		const device = createIdentity();
 		const otherDevice = createIdentity();
+		const teamIntent = teamReviewedIntent();
+		const teamDigest = await recipientReviewedIntentDigest(teamIntent);
+		const addDeviceIntent = addDeviceReviewedIntent();
+		const addDeviceDigest = await recipientReviewedIntentDigest(addDeviceIntent);
 		const adminHeaders = {
 			"content-type": "application/json",
 			"X-Codemem-Coordinator-Admin": "test-secret",
@@ -862,13 +888,15 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		const team = await createInvite({
 			invite_kind: "team_member",
 			policy_team_id: "policy-team-1",
-			reviewed_preview_digest: "a".repeat(64),
+			reviewed_preview_digest: teamDigest,
+			reviewed_intent: teamIntent,
 		});
 		expect(team.payload).toMatchObject({
 			kind: "team_member",
 			policy_team_id: "policy-team-1",
-			reviewed_preview_digest: "a".repeat(64),
+			reviewed_preview_digest: teamDigest,
 		});
+		expect(team.payload).not.toHaveProperty("reviewed_intent");
 		const inspect = await exports.default.fetch("https://example.com/v1/invites/inspect", {
 			method: "POST",
 			headers: { "content-type": "application/json" },
@@ -877,6 +905,8 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		expect(await inspect.json()).toMatchObject({
 			kind: "team_member",
 			policy_team_id: "policy-team-1",
+			reviewed_preview_digest: teamDigest,
+			reviewed_intent: teamIntent,
 			bound: false,
 		});
 		const acceptBody = {
@@ -893,8 +923,14 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 				headers: { "content-type": "application/json" },
 				body: JSON.stringify(acceptBody),
 			});
-		expect(await (await accept()).json()).toMatchObject({ status: "accepted" });
-		expect(await (await accept()).json()).toMatchObject({ status: "existing" });
+		expect(await (await accept()).json()).toMatchObject({
+			status: "accepted",
+			reviewed_intent: teamIntent,
+		});
+		expect(await (await accept()).json()).toMatchObject({
+			status: "existing",
+			reviewed_intent: teamIntent,
+		});
 		const changedDevice = await exports.default.fetch("https://example.com/v1/join", {
 			method: "POST",
 			headers: { "content-type": "application/json" },
@@ -911,7 +947,8 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		const addDevice = await createInvite({
 			invite_kind: "add_device",
 			target_identity_id: "identity-brian",
-			reviewed_preview_digest: "b".repeat(64),
+			reviewed_preview_digest: addDeviceDigest,
+			reviewed_intent: addDeviceIntent,
 		});
 		const wrongIdentity = await exports.default.fetch("https://example.com/v1/join", {
 			method: "POST",
@@ -941,17 +978,73 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 				headers: { "content-type": "application/json" },
 				body: JSON.stringify(addDeviceBody),
 			});
-		expect(await (await acceptAddDevice()).json()).toMatchObject({ status: "accepted" });
-		expect(await (await acceptAddDevice()).json()).toMatchObject({ status: "existing" });
+		expect(await (await acceptAddDevice()).json()).toMatchObject({
+			status: "accepted",
+			reviewed_intent: addDeviceIntent,
+		});
+		expect(await (await acceptAddDevice()).json()).toMatchObject({
+			status: "existing",
+			reviewed_intent: addDeviceIntent,
+		});
 
-		expect(
-			await env.COORDINATOR_DB.prepare("SELECT COUNT(*) AS count FROM enrolled_devices")
-				.first<{ count: number }>(),
-		).toEqual({ count: 0 });
+		const enrollments = await env.COORDINATOR_DB.prepare(
+			`SELECT group_id, device_id, public_key, fingerprint, enabled
+			 FROM enrolled_devices ORDER BY device_id ASC`,
+		).all<Record<string, unknown>>();
+		expect(enrollments.results).toEqual(
+			[device, otherDevice]
+				.toSorted((left, right) => left.deviceId.localeCompare(right.deviceId))
+				.map((enrolledDevice) => ({
+					group_id: "g1",
+					device_id: enrolledDevice.deviceId,
+					public_key: enrolledDevice.publicKey,
+					fingerprint: enrolledDevice.fingerprint,
+					enabled: 1,
+				})),
+		);
 		expect(
 			await env.COORDINATOR_DB.prepare("SELECT COUNT(*) AS count FROM coordinator_scope_memberships")
 				.first<{ count: number }>(),
 		).toEqual({ count: 0 });
+
+		const storedTeamReview = await env.COORDINATOR_DB.prepare(
+			"SELECT reviewed_intent_json, reviewed_preview_digest FROM coordinator_invites WHERE invite_kind = 'team_member'",
+		).first<{ reviewed_intent_json: string; reviewed_preview_digest: string }>();
+		if (!storedTeamReview) throw new Error("Expected stored Team reviewed intent.");
+		await env.COORDINATOR_DB.prepare(
+			"UPDATE coordinator_invites SET reviewed_intent_json = ? WHERE invite_kind = 'team_member'",
+		)
+			.bind('{"invalid":true}')
+			.run();
+		const unavailable = await exports.default.fetch("https://example.com/v1/invites/inspect", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ token: team.payload.token }),
+		});
+		expect(unavailable.status).toBe(409);
+		expect(await unavailable.json()).toEqual({ error: "recipient_invite_review_unavailable" });
+		const unavailableAcceptance = await accept();
+		expect(unavailableAcceptance.status).toBe(409);
+		expect(await unavailableAcceptance.json()).toEqual({
+			error: "recipient_invite_review_unavailable",
+		});
+		await env.COORDINATOR_DB.prepare(
+			"UPDATE coordinator_invites SET reviewed_intent_json = ?, reviewed_preview_digest = ? WHERE invite_kind = 'team_member'",
+		)
+			.bind(storedTeamReview.reviewed_intent_json, "f".repeat(64))
+			.run();
+		const mismatched = await exports.default.fetch("https://example.com/v1/invites/inspect", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ token: team.payload.token }),
+		});
+		expect(mismatched.status).toBe(409);
+		expect(await mismatched.json()).toEqual({ error: "recipient_invite_intent_mismatch" });
+		await env.COORDINATOR_DB.prepare(
+			"UPDATE coordinator_invites SET reviewed_preview_digest = ? WHERE invite_kind = 'team_member'",
+		)
+			.bind(storedTeamReview.reviewed_preview_digest)
+			.run();
 
 		await env.COORDINATOR_DB.prepare(
 			"UPDATE coordinator_invites SET revoked_at = ? WHERE token_digest IS NOT NULL AND invite_kind = 'team_member'",

--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -63,6 +63,12 @@ import type {
 	CoordinatorUpsertPresenceInput,
 } from "./coordinator-store-contract.js";
 import { normalizeInviteExpiresAt } from "./coordinator-store-contract.js";
+import {
+	canonicalRecipientReviewedIntentJson,
+	parseStoredRecipientReviewedIntent,
+	type RecipientReviewedIntentTargetV1,
+	verifyRecipientReviewedIntent,
+} from "./recipient-reviewed-intent.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 
 export const DEFAULT_COORDINATOR_DB_PATH = join(homedir(), ".codemem", "coordinator.sqlite");
@@ -128,7 +134,8 @@ const INVITE_COLUMNS = `invite_id, group_id, token, policy, expires_at, created_
 	inviter_actor_id, inviter_display_name, inviter_device_id, pending_person_id,
 	project_summaries_json, project_intent_json, consumed_at, bound_device_id, bound_public_key, bound_fingerprint,
 	recipient_actor_id, recipient_display_name, recipient_device_display_name, trust_state,
-	bootstrap_grant_id, invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest`;
+	bootstrap_grant_id, invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest,
+	reviewed_intent_json`;
 
 function rowToRecord<T>(row: unknown): T {
 	if (row == null) throw new Error("expected row");
@@ -173,12 +180,13 @@ function clean(value: string | null | undefined): string | null {
 	return trimmed ? trimmed : null;
 }
 
-function normalizeInviteMetadata(opts: CoordinatorCreateInviteInput): {
+async function normalizeInviteMetadata(opts: CoordinatorCreateInviteInput): Promise<{
 	inviteKind: CoordinatorInviteKind;
 	policyTeamId: string | null;
 	targetIdentityId: string | null;
 	reviewedPreviewDigest: string | null;
-} {
+	reviewedIntentJson: string | null;
+}> {
 	const inviteKind =
 		opts.inviteKind ?? (clean(opts.operationId) ? "project_share" : "legacy_enrollment");
 	const policyTeamId = clean(opts.policyTeamId);
@@ -221,31 +229,72 @@ function normalizeInviteMetadata(opts: CoordinatorCreateInviteInput): {
 			throw new Error("add_device invite metadata is invalid.");
 		}
 	}
-	return { inviteKind, policyTeamId, targetIdentityId, reviewedPreviewDigest };
+	const reviewedIntentProvided = opts.reviewedIntent !== undefined && opts.reviewedIntent !== null;
+	if (!reviewedIntentProvided) {
+		if (inviteKind === "team_member" || inviteKind === "add_device") {
+			throw new Error("recipient_invite_review_unavailable");
+		}
+		return {
+			inviteKind,
+			policyTeamId,
+			targetIdentityId,
+			reviewedPreviewDigest,
+			reviewedIntentJson: null,
+		};
+	}
+	let target: RecipientReviewedIntentTargetV1;
+	if (inviteKind === "team_member" && policyTeamId && reviewedPreviewDigest) {
+		target = { kind: "team_member", policyTeamId };
+	} else if (inviteKind === "add_device" && targetIdentityId && reviewedPreviewDigest) {
+		target = { kind: "add_device", targetIdentityId };
+	} else {
+		throw new Error("recipient invite metadata requires a recipient invite kind.");
+	}
+	await verifyRecipientReviewedIntent(opts.reviewedIntent, {
+		target,
+		digest: reviewedPreviewDigest,
+	});
+	return {
+		inviteKind,
+		policyTeamId,
+		targetIdentityId,
+		reviewedPreviewDigest,
+		reviewedIntentJson: canonicalRecipientReviewedIntentJson(opts.reviewedIntent, target),
+	};
 }
 
-function recipientInspection(
+async function recipientInspection(
 	invite: CoordinatorInvite,
-): CoordinatorRecipientInviteInspection | null {
+): Promise<CoordinatorRecipientInviteInspection | null> {
 	if (invite.invite_kind === "team_member") {
 		if (!invite.policy_team_id || !invite.reviewed_preview_digest)
 			throw new Error("invite_invalid");
+		const reviewedIntent = await parseStoredRecipientReviewedIntent(invite.reviewed_intent_json, {
+			target: { kind: "team_member", policyTeamId: invite.policy_team_id },
+			digest: invite.reviewed_preview_digest,
+		});
 		return {
 			kind: "team_member",
 			invite,
 			policy_team_id: invite.policy_team_id,
 			reviewed_preview_digest: invite.reviewed_preview_digest,
+			reviewed_intent: reviewedIntent,
 			bound: Boolean(invite.consumed_at),
 		};
 	}
 	if (invite.invite_kind === "add_device") {
 		if (!invite.target_identity_id || !invite.reviewed_preview_digest)
 			throw new Error("invite_invalid");
+		const reviewedIntent = await parseStoredRecipientReviewedIntent(invite.reviewed_intent_json, {
+			target: { kind: "add_device", targetIdentityId: invite.target_identity_id },
+			digest: invite.reviewed_preview_digest,
+		});
 		return {
 			kind: "add_device",
 			invite,
 			target_identity_id: invite.target_identity_id,
 			reviewed_preview_digest: invite.reviewed_preview_digest,
+			reviewed_intent: reviewedIntent,
 			bound: Boolean(invite.consumed_at),
 		};
 	}
@@ -576,7 +625,8 @@ function initializeSchema(db: DatabaseType): void {
 			invite_kind TEXT,
 			policy_team_id TEXT,
 			target_identity_id TEXT,
-			reviewed_preview_digest TEXT
+			reviewed_preview_digest TEXT,
+			reviewed_intent_json TEXT
 		);
 
 		CREATE TABLE IF NOT EXISTS coordinator_join_requests (
@@ -737,6 +787,7 @@ function initializeSchema(db: DatabaseType): void {
 		"policy_team_id",
 		"target_identity_id",
 		"reviewed_preview_digest",
+		"reviewed_intent_json",
 	]) {
 		try {
 			db.prepare(`ALTER TABLE coordinator_invites ADD COLUMN ${column} TEXT`).run();
@@ -939,7 +990,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		const group = await this.getGroup(opts.groupId);
 		const operationId = clean(opts.operationId);
 		const reviewedProjectSetDigest = clean(opts.reviewedProjectSetDigest);
-		const metadata = normalizeInviteMetadata(opts);
+		const metadata = await normalizeInviteMetadata(opts);
 		if (Boolean(operationId) !== Boolean(reviewedProjectSetDigest)) {
 			throw new Error("operationId and reviewedProjectSetDigest must be provided together.");
 		}
@@ -968,7 +1019,8 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 					(opts.projectIntent ? JSON.stringify(opts.projectIntent) : null) ||
 				existing.policy_team_id !== metadata.policyTeamId ||
 				existing.target_identity_id !== metadata.targetIdentityId ||
-				existing.reviewed_preview_digest !== metadata.reviewedPreviewDigest
+				existing.reviewed_preview_digest !== metadata.reviewedPreviewDigest ||
+				existing.reviewed_intent_json !== metadata.reviewedIntentJson
 			) {
 				throw new Error("invite_operation_intent_conflict");
 			}
@@ -1008,8 +1060,9 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 					team_name_snapshot, revoked_at, operation_id, reviewed_project_set_digest,
 					token_digest, inviter_actor_id, inviter_display_name, inviter_device_id,
 					pending_person_id, project_summaries_json, project_intent_json, trust_state,
-					invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+					invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest,
+					reviewed_intent_json
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 				.run(
 					inviteId,
 					opts.groupId,
@@ -1033,6 +1086,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 					metadata.policyTeamId,
 					metadata.targetIdentityId,
 					metadata.reviewedPreviewDigest,
+					metadata.reviewedIntentJson,
 				);
 		} catch (error) {
 			if (operationId) {
@@ -1072,7 +1126,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 	): Promise<CoordinatorRecipientInviteInspection | null> {
 		const invite = await this.getInviteByTokenForInspection(opts.token);
 		if (!invite) return null;
-		const inspection = recipientInspection(invite);
+		const inspection = await recipientInspection(invite);
 		if (!inspection) return null;
 		if (invite.revoked_at) throw new Error("invite_invalid");
 		if (
@@ -1105,14 +1159,24 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		) {
 			throw new Error("invite_identity_conflict");
 		}
+		const preflightInvite = await this.getInviteByTokenForInspection(opts.token);
+		const preflightInspection = preflightInvite ? await recipientInspection(preflightInvite) : null;
 		return this.db.transaction((): CoordinatorRecipientInviteAcceptance => {
 			const invite = this.db
 				.prepare(
 					`SELECT ${INVITE_COLUMNS} FROM coordinator_invites WHERE token_digest = ? OR token = ?`,
 				)
 				.get(tokenDigest(opts.token), opts.token) as CoordinatorInvite | undefined;
-			const inspection = invite ? recipientInspection(invite) : null;
-			if (!invite || !inspection || inspection.kind !== opts.inviteKind || invite.revoked_at) {
+			const inspection = invite ? preflightInspection : null;
+			if (
+				!invite ||
+				!inspection ||
+				invite.invite_id !== preflightInvite?.invite_id ||
+				invite.reviewed_intent_json !== preflightInvite.reviewed_intent_json ||
+				invite.reviewed_preview_digest !== preflightInvite.reviewed_preview_digest ||
+				inspection.kind !== opts.inviteKind ||
+				invite.revoked_at
+			) {
 				throw new Error("invite_invalid");
 			}
 			const group = this.db
@@ -1135,6 +1199,17 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				invite.bound_fingerprint === opts.fingerprint;
 			if (invite.consumed_at && !sameBinding) throw new Error("invite_already_bound");
 			if (invite.consumed_at && invite.recipient_actor_id !== opts.identityId) {
+				throw new Error("invite_identity_conflict");
+			}
+			const existingEnrollment = this.db
+				.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+					FROM enrolled_devices WHERE group_id = ? AND device_id = ?`)
+				.get(invite.group_id, opts.deviceId) as CoordinatorEnrollment | undefined;
+			if (
+				existingEnrollment &&
+				(existingEnrollment.public_key !== opts.publicKey ||
+					existingEnrollment.fingerprint !== opts.fingerprint)
+			) {
 				throw new Error("invite_identity_conflict");
 			}
 			const changed = invite.consumed_at
@@ -1168,7 +1243,30 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				throw new Error("invite_already_bound");
 			}
 			if (saved.recipient_actor_id !== opts.identityId) throw new Error("invite_identity_conflict");
-			return { status: changed === 1 ? "accepted" : "existing", invite: saved };
+			if (changed === 1) {
+				this.db
+					.prepare(`INSERT INTO enrolled_devices(
+						group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+					) VALUES (?, ?, ?, ?, NULL, 1, ?)
+					ON CONFLICT(group_id, device_id) DO UPDATE SET
+						public_key = excluded.public_key,
+						fingerprint = excluded.fingerprint,
+						enabled = 1`)
+					.run(invite.group_id, opts.deviceId, opts.publicKey, opts.fingerprint, consumedAt);
+			}
+			const enrollment = this.db
+				.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+					FROM enrolled_devices WHERE group_id = ? AND device_id = ? AND enabled = 1`)
+				.get(invite.group_id, opts.deviceId) as CoordinatorEnrollment | undefined;
+			if (!enrollment) throw new Error("invite_acceptance_incomplete");
+			if (enrollment.public_key !== opts.publicKey || enrollment.fingerprint !== opts.fingerprint) {
+				throw new Error("invite_identity_conflict");
+			}
+			return {
+				status: changed === 1 ? "accepted" : "existing",
+				invite: saved,
+				reviewed_intent: inspection.reviewed_intent,
+			};
 		})();
 	}
 

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -32,8 +32,69 @@ import {
 	PROJECT_SYNC_ENABLEMENT_FAILURE_DETAIL,
 	ProjectSyncEnablementError,
 } from "./project-invite-acceptance.js";
-import { previewRecipientPolicyOnboarding } from "./recipient-policy-onboarding.js";
+import { previewRecipientPolicyOnboardingFromReviewedIntent } from "./recipient-policy-onboarding.js";
+import {
+	type RecipientReviewedIntentV1,
+	recipientReviewedIntentDigest,
+} from "./recipient-reviewed-intent.js";
 import { ensureDeviceIdentity, fingerprintPublicKey, loadPublicKey } from "./sync-identity.js";
+
+type TeamReviewedIntent = Extract<RecipientReviewedIntentV1, { journey: "team" }>;
+type AddDeviceReviewedIntent = Extract<RecipientReviewedIntentV1, { journey: "add_device" }>;
+
+function teamReviewedIntent(teamId = "policy-team-1"): TeamReviewedIntent {
+	return {
+		version: 1,
+		journey: "team",
+		team: { teamId, displayName: "Product", futureProjectsInherit: true },
+		projects: [],
+		excludedProjects: [],
+	};
+}
+
+function addDeviceReviewedIntent(identityId: string): AddDeviceReviewedIntent {
+	return {
+		version: 1,
+		journey: "add_device",
+		targetIdentity: { identityId, displayName: "Existing Person" },
+		projects: [],
+		excludedProjects: [],
+	};
+}
+
+function reviewedOnboardingDigestForRecipientInvite(opts: {
+	dbPath: string;
+	keysDir: string;
+	invitationId: string;
+	identityId: string;
+	deviceDisplayName: string;
+	reviewedIntent: RecipientReviewedIntentV1;
+}): string {
+	initDatabase(opts.dbPath);
+	const conn = connect(opts.dbPath);
+	let deviceId = "";
+	try {
+		[deviceId] = ensureDeviceIdentity(conn, { keysDir: opts.keysDir });
+	} finally {
+		conn.close();
+	}
+	const devicePublicKey = loadPublicKey(opts.keysDir);
+	if (!devicePublicKey) throw new Error("test public key missing");
+	const base = {
+		version: 1 as const,
+		invitationId: opts.invitationId,
+		identityId: opts.identityId,
+		deviceId,
+		devicePublicKey,
+		deviceDisplayName: opts.deviceDisplayName,
+	};
+	const request =
+		opts.reviewedIntent.journey === "team"
+			? { ...base, journey: "team" as const, teamId: opts.reviewedIntent.team.teamId }
+			: { ...base, journey: "add_device" as const };
+	return previewRecipientPolicyOnboardingFromReviewedIntent(opts.reviewedIntent, request)
+		.reviewedOnboardingDigest;
+}
 
 describe("coordinator local admin actions", () => {
 	let tmpDir: string;
@@ -480,6 +541,99 @@ describe("coordinator local admin actions", () => {
 		expect(invite.warnings).toEqual([]);
 	});
 
+	it("stores canonical reviewed intent for local recipient invites without embedding it in links", async () => {
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		const reviewedIntent = teamReviewedIntent();
+		const digest = await recipientReviewedIntentDigest(reviewedIntent);
+		await expect(
+			coordinatorCreateInviteAction({
+				groupId: "team-a",
+				coordinatorUrl: "https://coord.example.test",
+				policy: "auto_admit",
+				ttlHours: 24,
+				dbPath,
+				inviteKind: "team_member",
+				policyTeamId: "policy-team-1",
+				reviewedPreviewDigest: digest,
+			}),
+		).rejects.toThrow("recipient_invite_review_unavailable");
+		const result = await coordinatorCreateInviteAction({
+			groupId: "team-a",
+			coordinatorUrl: "https://coord.example.test",
+			policy: "auto_admit",
+			ttlHours: 24,
+			dbPath,
+			inviteKind: "team_member",
+			policyTeamId: "policy-team-1",
+			reviewedPreviewDigest: digest,
+			reviewedIntent,
+		});
+		const payload = result.payload as Record<string, unknown>;
+		expect(payload).not.toHaveProperty("reviewed_intent");
+		expect(String(result.link)).not.toContain("reviewed_intent");
+
+		const store = new BetterSqliteCoordinatorStore(dbPath);
+		try {
+			const inspected = await store.inspectRecipientInvite({
+				token: String(payload.token),
+				now: new Date().toISOString(),
+			});
+			expect(inspected?.reviewed_intent).toEqual(reviewedIntent);
+		} finally {
+			await store.close();
+		}
+	});
+
+	it("sends canonical reviewed intent when creating remote recipient invites", async () => {
+		const reviewedIntent = teamReviewedIntent();
+		const digest = await recipientReviewedIntentDigest(reviewedIntent);
+		let requestBody: Record<string, unknown> | null = null;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_url: string, init?: RequestInit) => {
+				const body =
+					init?.body instanceof Uint8Array
+						? Buffer.from(init.body).toString("utf8")
+						: String(init?.body ?? "{}");
+				requestBody = JSON.parse(body) as Record<string, unknown>;
+				return new Response(
+					JSON.stringify({
+						invite: {
+							invite_id: "invite-team-1",
+							invite_kind: "team_member",
+							policy_team_id: "policy-team-1",
+							reviewed_preview_digest: digest,
+						},
+						payload: {
+							kind: "team_member",
+							policy_team_id: "policy-team-1",
+							reviewed_preview_digest: digest,
+						},
+						encoded: "digest-only",
+						link: "https://coord.example.test/invite#digest-only",
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}),
+		);
+
+		const result = await coordinatorCreateInviteAction({
+			groupId: "team-a",
+			coordinatorUrl: "https://coord.example.test",
+			policy: "auto_admit",
+			ttlHours: 24,
+			remoteUrl: "https://coord.example.test",
+			adminSecret: "secret",
+			inviteKind: "team_member",
+			policyTeamId: "policy-team-1",
+			reviewedPreviewDigest: digest,
+			reviewedIntent,
+		});
+
+		expect(requestBody).toMatchObject({ reviewed_intent: reviewedIntent });
+		expect(result.payload).not.toHaveProperty("reviewed_intent");
+	});
+
 	it("imports invites using CODEMEM_DB and CODEMEM_KEYS_DIR when flags are omitted", async () => {
 		const envDbPath = join(tmpDir, "env-mem.sqlite");
 		const envKeysDir = join(tmpDir, "env-keys");
@@ -723,11 +877,59 @@ describe("coordinator local admin actions", () => {
 		}
 	});
 
+	it.each([
+		{ kind: "team_member" as const, targetId: "team-a" },
+		{ kind: "add_device" as const, targetId: "identity-existing" },
+	])("requires a reviewed onboarding digest before consuming a $kind invite", async (testCase) => {
+		const actionDbPath = join(tmpDir, `${testCase.kind}-missing-review.sqlite`);
+		const keysDir = join(tmpDir, `${testCase.kind}-missing-review-keys`);
+		const reviewedIntent =
+			testCase.kind === "team_member"
+				? teamReviewedIntent(testCase.targetId)
+				: addDeviceReviewedIntent(testCase.targetId);
+		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const invite = encodeInvitePayload({
+			v: 1,
+			kind: testCase.kind,
+			coordinator_url: "https://coord.example.test",
+			group_id: "coordinator-a",
+			policy: "auto_admit",
+			token: `${testCase.kind}-missing-review-token`,
+			expires_at: "2099-01-01T00:00:00.000Z",
+			team_name: null,
+			...(testCase.kind === "team_member"
+				? { policy_team_id: testCase.targetId }
+				: { target_identity_id: testCase.targetId }),
+			reviewed_preview_digest: reviewedDigest,
+		});
+
+		await expect(
+			coordinatorImportInviteAction({
+				inviteValue: invite,
+				dbPath: actionDbPath,
+				keysDir,
+			}),
+		).rejects.toThrow("reviewed_onboarding_digest_required");
+		expect(fetchMock).not.toHaveBeenCalled();
+		const conn = connect(actionDbPath);
+		try {
+			expect(conn.prepare("SELECT COUNT(*) FROM actors").pluck().get()).toBe(0);
+			expect(conn.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+			expect(conn.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get()).toBe(0);
+		} finally {
+			conn.close();
+		}
+	});
+
 	it("adopts the add-device target identity on a fresh profile", async () => {
 		const actionDbPath = join(tmpDir, "fresh-add-device.sqlite");
 		const keysDir = join(tmpDir, "fresh-add-device-keys");
 		const configPath = join(tmpDir, "fresh-add-device-config.json");
 		const targetIdentityId = "identity-existing";
+		const reviewedIntent = addDeviceReviewedIntent(targetIdentityId);
+		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
 		const capturedBodies: Record<string, unknown>[] = [];
 		vi.stubGlobal(
 			"fetch",
@@ -744,7 +946,8 @@ describe("coordinator local admin actions", () => {
 						identity_id: targetIdentityId,
 						policy_team_id: null,
 						target_identity_id: targetIdentityId,
-						reviewed_preview_digest: "coordinator-review",
+						reviewed_preview_digest: reviewedDigest,
+						reviewed_intent: reviewedIntent,
 					}),
 					{ status: 200 },
 				);
@@ -760,7 +963,15 @@ describe("coordinator local admin actions", () => {
 			expires_at: "2099-01-01T00:00:00.000Z",
 			team_name: null,
 			target_identity_id: targetIdentityId,
-			reviewed_preview_digest: "coordinator-review",
+			reviewed_preview_digest: reviewedDigest,
+		});
+		const reviewedOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
+			dbPath: actionDbPath,
+			keysDir,
+			invitationId: "fresh-add-device-token",
+			identityId: targetIdentityId,
+			deviceDisplayName: "Recipient laptop",
+			reviewedIntent,
 		});
 
 		await expect(
@@ -769,6 +980,8 @@ describe("coordinator local admin actions", () => {
 				dbPath: actionDbPath,
 				keysDir,
 				configPath,
+				deviceDisplayName: "Recipient laptop",
+				reviewedOnboardingDigest,
 			}),
 		).resolves.toEqual({
 			group_id: "coordinator-a",
@@ -778,9 +991,12 @@ describe("coordinator local admin actions", () => {
 			identity_id: targetIdentityId,
 			policy_team_id: null,
 			target_identity_id: targetIdentityId,
-			reviewed_preview_digest: "coordinator-review",
+			reviewed_preview_digest: reviewedDigest,
+			sync_enabled: true,
 		});
-		expect(capturedBodies[0]?.identity_id).toBe(targetIdentityId);
+		expect(capturedBodies).toHaveLength(2);
+		expect(capturedBodies[0]).toEqual({ token: "fresh-add-device-token" });
+		expect(capturedBodies[1]?.identity_id).toBe(targetIdentityId);
 		expect(readCodememConfigFileAtPath(configPath)).toMatchObject({
 			actor_id: targetIdentityId,
 		});
@@ -791,6 +1007,216 @@ describe("coordinator local admin actions", () => {
 			});
 		} finally {
 			conn.close();
+		}
+	});
+
+	it("does not adopt the add-device target when the config write fails and converges on retry", async () => {
+		const actionDbPath = join(tmpDir, "add-device-config-failure.sqlite");
+		const keysDir = join(tmpDir, "add-device-config-failure-keys");
+		const blockedParent = join(tmpDir, "blocked-config-parent");
+		const configPath = join(blockedParent, "config.json");
+		const targetIdentityId = "identity-existing";
+		const reviewedIntent = addDeviceReviewedIntent(targetIdentityId);
+		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+		writeFileSync(blockedParent, "not a directory", "utf8");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							ok: true,
+							status: "accepted",
+							kind: "add_device",
+							group_id: "coordinator-a",
+							identity_id: targetIdentityId,
+							policy_team_id: null,
+							target_identity_id: targetIdentityId,
+							reviewed_preview_digest: reviewedDigest,
+							reviewed_intent: reviewedIntent,
+						}),
+						{ status: 200 },
+					),
+			),
+		);
+		const invite = encodeInvitePayload({
+			v: 1,
+			kind: "add_device",
+			coordinator_url: "https://coord.example.test",
+			group_id: "coordinator-a",
+			policy: "auto_admit",
+			token: "add-device-config-failure-token",
+			expires_at: "2099-01-01T00:00:00.000Z",
+			team_name: null,
+			target_identity_id: targetIdentityId,
+			reviewed_preview_digest: reviewedDigest,
+		});
+		const reviewedOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
+			dbPath: actionDbPath,
+			keysDir,
+			invitationId: "add-device-config-failure-token",
+			identityId: targetIdentityId,
+			deviceDisplayName: "Recipient laptop",
+			reviewedIntent,
+		});
+
+		await expect(
+			coordinatorImportInviteAction({
+				inviteValue: invite,
+				dbPath: actionDbPath,
+				keysDir,
+				configPath,
+				deviceDisplayName: "Recipient laptop",
+				reviewedOnboardingDigest,
+			}),
+		).rejects.toThrow();
+		const failed = connect(actionDbPath);
+		try {
+			expect(failed.prepare("SELECT COUNT(*) FROM actors").pluck().get()).toBe(0);
+			expect(failed.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+		} finally {
+			failed.close();
+		}
+
+		rmSync(blockedParent);
+		await expect(
+			coordinatorImportInviteAction({
+				inviteValue: invite,
+				dbPath: actionDbPath,
+				keysDir,
+				configPath,
+				deviceDisplayName: "Recipient laptop",
+				reviewedOnboardingDigest,
+			}),
+		).resolves.toMatchObject({ status: "accepted", identity_id: targetIdentityId });
+		expect(readCodememConfigFileAtPath(configPath)).toMatchObject({ actor_id: targetIdentityId });
+		const retried = connect(actionDbPath);
+		try {
+			expect(retried.prepare("SELECT identity_id FROM identity_devices").pluck().get()).toBe(
+				targetIdentityId,
+			);
+		} finally {
+			retried.close();
+		}
+	});
+
+	it("restores bootstrap config when add-device local commit fails and converges on retry", async () => {
+		const actionDbPath = join(tmpDir, "add-device-commit-failure.sqlite");
+		const keysDir = join(tmpDir, "add-device-commit-failure-keys");
+		const configPath = join(tmpDir, "add-device-commit-failure-config.json");
+		const targetIdentityId = "identity-existing";
+		const reviewedIntent = addDeviceReviewedIntent(targetIdentityId);
+		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+		initDatabase(actionDbPath);
+		const setup = connect(actionDbPath);
+		let bootstrapIdentityId = "";
+		try {
+			const [deviceId] = ensureDeviceIdentity(setup, { keysDir });
+			bootstrapIdentityId = `local:${deviceId}`;
+			setup
+				.prepare(`INSERT INTO actors(
+					actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+				) VALUES (?, 'Ada', 1, 'active', NULL, ?, ?)`)
+				.run(bootstrapIdentityId, "2026-07-23T00:00:00.000Z", "2026-07-23T00:00:00.000Z");
+			setup.exec(`CREATE TRIGGER fail_add_device_binding BEFORE INSERT ON identity_devices
+				BEGIN SELECT RAISE(ABORT, 'test identity-device failure'); END`);
+		} finally {
+			setup.close();
+		}
+		const originalConfig = {
+			actor_id: bootstrapIdentityId,
+			actor_display_name: "Ada",
+			sync_coordinator_groups: ["existing-group"],
+		};
+		writeCodememConfigFile(originalConfig, configPath);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							ok: true,
+							status: "accepted",
+							kind: "add_device",
+							group_id: "coordinator-a",
+							identity_id: targetIdentityId,
+							policy_team_id: null,
+							target_identity_id: targetIdentityId,
+							reviewed_preview_digest: reviewedDigest,
+							reviewed_intent: reviewedIntent,
+						}),
+						{ status: 200 },
+					),
+			),
+		);
+		const invite = encodeInvitePayload({
+			v: 1,
+			kind: "add_device",
+			coordinator_url: "https://coord.example.test",
+			group_id: "coordinator-a",
+			policy: "auto_admit",
+			token: "add-device-commit-failure-token",
+			expires_at: "2099-01-01T00:00:00.000Z",
+			team_name: null,
+			target_identity_id: targetIdentityId,
+			reviewed_preview_digest: reviewedDigest,
+		});
+		const reviewedOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
+			dbPath: actionDbPath,
+			keysDir,
+			invitationId: "add-device-commit-failure-token",
+			identityId: targetIdentityId,
+			deviceDisplayName: "Recipient laptop",
+			reviewedIntent,
+		});
+
+		await expect(
+			coordinatorImportInviteAction({
+				inviteValue: invite,
+				dbPath: actionDbPath,
+				keysDir,
+				configPath,
+				deviceDisplayName: "Recipient laptop",
+				reviewedOnboardingDigest,
+			}),
+		).rejects.toThrow("onboarding_intent_conflict");
+		expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
+		const failed = connect(actionDbPath);
+		try {
+			expect(
+				failed.prepare("SELECT actor_id, is_local, status, merged_into_actor_id FROM actors").all(),
+			).toEqual([
+				{
+					actor_id: bootstrapIdentityId,
+					is_local: 1,
+					status: "active",
+					merged_into_actor_id: null,
+				},
+			]);
+			expect(failed.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+			failed.exec("DROP TRIGGER fail_add_device_binding");
+		} finally {
+			failed.close();
+		}
+
+		await expect(
+			coordinatorImportInviteAction({
+				inviteValue: invite,
+				dbPath: actionDbPath,
+				keysDir,
+				configPath,
+				deviceDisplayName: "Recipient laptop",
+				reviewedOnboardingDigest,
+			}),
+		).resolves.toMatchObject({ status: "accepted", identity_id: targetIdentityId });
+		expect(readCodememConfigFileAtPath(configPath)).toMatchObject({ actor_id: targetIdentityId });
+		const retried = connect(actionDbPath);
+		try {
+			expect(retried.prepare("SELECT identity_id FROM identity_devices").pluck().get()).toBe(
+				targetIdentityId,
+			);
+		} finally {
+			retried.close();
 		}
 	});
 
@@ -859,24 +1285,11 @@ describe("coordinator local admin actions", () => {
 		const keysDir = join(tmpDir, `${testCase.kind}-config-keys`);
 		const configPath = join(tmpDir, `${testCase.kind}-config.json`);
 		writeCodememConfigFile(testCase.initialConfig, configPath);
-		if (testCase.kind === "team_member") {
-			initDatabase(actionDbPath);
-			const conn = connect(actionDbPath);
-			try {
-				const now = "2026-07-21T12:00:00.000Z";
-				conn
-					.prepare(
-						`INSERT INTO policy_teams(
-							 team_id, display_name, status, provenance, revision, migration_state,
-							 idempotency_key, created_at, updated_at
-							 ) VALUES ('team-a', 'Team A', 'active', 'user', 'r1', 'user_managed',
-							 'team-a', ?, ?)`,
-					)
-					.run(now, now);
-			} finally {
-				conn.close();
-			}
-		}
+		const reviewedIntent =
+			testCase.kind === "team_member"
+				? teamReviewedIntent("team-a")
+				: addDeviceReviewedIntent(testCase.identityId);
+		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
 		vi.stubGlobal(
 			"fetch",
 			vi.fn(
@@ -890,7 +1303,8 @@ describe("coordinator local admin actions", () => {
 							identity_id: testCase.identityId,
 							policy_team_id: testCase.kind === "team_member" ? "team-a" : null,
 							target_identity_id: testCase.kind === "add_device" ? testCase.identityId : null,
-							reviewed_preview_digest: "coordinator-review",
+							reviewed_preview_digest: reviewedDigest,
+							reviewed_intent: reviewedIntent,
 						}),
 						{ status: 200 },
 					),
@@ -908,91 +1322,216 @@ describe("coordinator local admin actions", () => {
 			...(testCase.kind === "team_member"
 				? { policy_team_id: "team-a" }
 				: { target_identity_id: testCase.identityId }),
-			reviewed_preview_digest: "coordinator-review",
+			reviewed_preview_digest: reviewedDigest,
+		});
+		const reviewedOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
+			dbPath: actionDbPath,
+			keysDir,
+			invitationId: `${testCase.kind}-config-token`,
+			identityId: testCase.identityId,
+			deviceDisplayName: "Recipient laptop",
+			reviewedIntent,
 		});
 
+		const result = await coordinatorImportInviteAction({
+			inviteValue: invite,
+			dbPath: actionDbPath,
+			keysDir,
+			configPath,
+			recipientActorId: testCase.identityId,
+			deviceDisplayName: "Recipient laptop",
+			reviewedOnboardingDigest,
+		});
+		expect(result).toMatchObject({ status: "accepted", sync_enabled: true });
 		await coordinatorImportInviteAction({
 			inviteValue: invite,
 			dbPath: actionDbPath,
 			keysDir,
 			configPath,
 			recipientActorId: testCase.identityId,
+			deviceDisplayName: "Recipient laptop",
+			reviewedOnboardingDigest,
 		});
 
 		const persistedConfig = readCodememConfigFileAtPath(configPath);
 		expect(persistedConfig).toMatchObject({
 			actor_id: testCase.identityId,
+			sync_enabled: true,
+			sync_host: "0.0.0.0",
+			sync_port: 7337,
+			sync_interval_s: 120,
 			sync_coordinator_url: "https://coord.example.test",
 			sync_coordinator_groups: testCase.expectedGroups,
 			sync_coordinator_group: "existing-group",
 		});
-		expect(persistedConfig).not.toHaveProperty("sync_enabled");
-		expect(persistedConfig).not.toHaveProperty("sync_host");
-		expect(persistedConfig).not.toHaveProperty("sync_port");
-		expect(persistedConfig).not.toHaveProperty("sync_interval_s");
-	});
-
-	it("rejects recipient onboarding when local access changes after the reviewed preview", async () => {
-		const actionDbPath = join(tmpDir, "recipient-invite-stale.sqlite");
-		const keysDir = join(tmpDir, "recipient-invite-stale-keys");
-		const configPath = join(tmpDir, "recipient-invite-stale-config.json");
-		const originalConfig = { sync_coordinator_groups: ["existing-group"] };
-		writeCodememConfigFile(originalConfig, configPath);
-		const identityId = "identity-recipient";
-		initDatabase(actionDbPath);
 		const conn = connect(actionDbPath);
-		let deviceId = "";
-		let reviewedOnboardingDigest = "";
 		try {
-			[deviceId] = ensureDeviceIdentity(conn, { keysDir });
-			const now = "2026-07-21T12:00:00.000Z";
-			conn
-				.prepare(
-					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
-				 VALUES (?, 'Recipient', 1, 'active', ?, ?)`,
-				)
-				.run(identityId, now, now);
-			conn
-				.prepare(
-					`INSERT INTO policy_teams(
-				 team_id, display_name, status, provenance, revision, migration_state,
-				 idempotency_key, created_at, updated_at
-				 ) VALUES ('team-a', 'Team A', 'active', 'user', 'r1', 'user_managed', 'team-a', ?, ?)`,
-				)
-				.run(now, now);
-			conn
-				.prepare(
-					`INSERT INTO project_recipients(
-				 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
-				 policy_revision, migration_state, idempotency_key, created_at, updated_at
-				 ) VALUES ('project-one', 'team', 'team-a', 'active', 'user', 'r1',
-				 'user_managed', 'project-one-team-a', ?, ?)`,
-				)
-				.run(now, now);
-			const publicKey = loadPublicKey(keysDir);
-			if (!publicKey) throw new Error("public key missing");
-			reviewedOnboardingDigest = previewRecipientPolicyOnboarding(conn, {
-				version: 1,
-				journey: "team",
-				invitationId: "recipient-token",
-				identityId,
-				deviceId,
-				devicePublicKey: publicKey,
-				deviceDisplayName: "Recipient laptop",
-				teamId: "team-a",
-			}).reviewedOnboardingDigest;
-			conn
-				.prepare(
-					`INSERT INTO project_recipients(
-				 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
-				 policy_revision, migration_state, idempotency_key, created_at, updated_at
-				 ) VALUES ('project-two', 'team', 'team-a', 'active', 'user', 'r2',
-				 'user_managed', 'project-two-team-a', ?, ?)`,
-				)
-				.run(now, now);
+			expect(conn.prepare("SELECT COUNT(*) FROM actors").pluck().get()).toBe(1);
+			expect(conn.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(1);
+			expect(conn.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(0);
+			expect(conn.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(
+				testCase.kind === "team_member" ? 1 : 0,
+			);
+			expect(conn.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get()).toBe(
+				testCase.kind === "team_member" ? 1 : 0,
+			);
 		} finally {
 			conn.close();
 		}
+	});
+
+	it.each([
+		{ kind: "team_member" as const, identityId: "identity-team", targetId: "team-a" },
+		{
+			kind: "add_device" as const,
+			identityId: "identity-add-device",
+			targetId: "identity-add-device",
+		},
+	])("rejects stale $kind onboarding before consuming the invite or mutating local state", async (testCase) => {
+		const actionDbPath = join(tmpDir, `${testCase.kind}-stale-preflight.sqlite`);
+		const keysDir = join(tmpDir, `${testCase.kind}-stale-preflight-keys`);
+		const configPath = join(tmpDir, `${testCase.kind}-stale-preflight-config.json`);
+		const originalConfig = {
+			actor_id: testCase.identityId,
+			sync_coordinator_groups: ["existing-group"],
+		};
+		writeCodememConfigFile(originalConfig, configPath);
+		const reviewedIntent =
+			testCase.kind === "team_member"
+				? teamReviewedIntent(testCase.targetId)
+				: addDeviceReviewedIntent(testCase.targetId);
+		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+		const validOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
+			dbPath: actionDbPath,
+			keysDir,
+			invitationId: `${testCase.kind}-stale-token`,
+			identityId: testCase.identityId,
+			deviceDisplayName: "Recipient laptop",
+			reviewedIntent,
+		});
+		const localSnapshot = () => {
+			const db = connect(actionDbPath);
+			try {
+				return JSON.stringify(
+					Object.fromEntries(
+						[
+							"actors",
+							"sync_device",
+							"identity_devices",
+							"policy_teams",
+							"policy_team_memberships",
+							"project_recipients",
+						].map((table) => [table, db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all()]),
+					),
+				);
+			} finally {
+				db.close();
+			}
+		};
+		const beforeDb = localSnapshot();
+		const requestedUrls: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string | URL) => {
+				const requestedUrl = String(url);
+				requestedUrls.push(requestedUrl);
+				if (!requestedUrl.endsWith("/v1/invites/inspect")) {
+					throw new Error(`unexpected request: ${requestedUrl}`);
+				}
+				return new Response(
+					JSON.stringify({
+						kind: testCase.kind,
+						policy_team_id: testCase.kind === "team_member" ? testCase.targetId : undefined,
+						target_identity_id: testCase.kind === "add_device" ? testCase.targetId : undefined,
+						reviewed_preview_digest: reviewedDigest,
+						reviewed_intent: reviewedIntent,
+						bound: false,
+					}),
+					{ status: 200 },
+				);
+			}),
+		);
+		const invite = encodeInvitePayload({
+			v: 1,
+			kind: testCase.kind,
+			coordinator_url: "https://coord.example.test",
+			group_id: "coordinator-a",
+			policy: "auto_admit",
+			token: `${testCase.kind}-stale-token`,
+			expires_at: "2099-01-01T00:00:00.000Z",
+			team_name: null,
+			...(testCase.kind === "team_member"
+				? { policy_team_id: testCase.targetId }
+				: { target_identity_id: testCase.targetId }),
+			reviewed_preview_digest: reviewedDigest,
+		});
+
+		await expect(
+			coordinatorImportInviteAction({
+				inviteValue: invite,
+				dbPath: actionDbPath,
+				keysDir,
+				configPath,
+				recipientActorId: testCase.identityId,
+				deviceDisplayName: "Recipient laptop",
+				reviewedOnboardingDigest: `${validOnboardingDigest}-stale`,
+			}),
+		).rejects.toThrow("reviewed_onboarding_stale");
+		expect(requestedUrls).toEqual(["https://coord.example.test/v1/invites/inspect"]);
+		expect(localSnapshot()).toBe(beforeDb);
+		expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
+	});
+
+	it.each([
+		{ label: "kind", responseOverride: { kind: "add_device" } },
+		{ label: "target ID", responseOverride: { policy_team_id: "team-other" } },
+		{ label: "reviewed digest", responseOverride: { reviewed_preview_digest: "f".repeat(64) } },
+	])("rejects a mismatched $label returned by recipient invite inspection without local mutation", async (testCase) => {
+		// Arrange
+		const actionDbPath = join(
+			tmpDir,
+			`recipient-invite-${testCase.label.replaceAll(" ", "-")}.sqlite`,
+		);
+		const keysDir = join(tmpDir, `recipient-invite-${testCase.label.replaceAll(" ", "-")}-keys`);
+		const configPath = join(
+			tmpDir,
+			`recipient-invite-${testCase.label.replaceAll(" ", "-")}-config.json`,
+		);
+		const identityId = "identity-recipient";
+		const originalConfig = {
+			actor_id: identityId,
+			sync_coordinator_groups: ["existing-group"],
+		};
+		writeCodememConfigFile(originalConfig, configPath);
+		initDatabase(actionDbPath);
+		const setup = connect(actionDbPath);
+		try {
+			ensureDeviceIdentity(setup, { keysDir });
+		} finally {
+			setup.close();
+		}
+		const localSnapshot = () => {
+			const db = connect(actionDbPath);
+			try {
+				return JSON.stringify(
+					Object.fromEntries(
+						[
+							"actors",
+							"sync_device",
+							"identity_devices",
+							"policy_teams",
+							"policy_team_memberships",
+							"project_recipients",
+						].map((table) => [table, db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all()]),
+					),
+				);
+			} finally {
+				db.close();
+			}
+		};
+		const beforeDb = localSnapshot();
+		const reviewedIntent = teamReviewedIntent("team-a");
+		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
 		vi.stubGlobal(
 			"fetch",
 			vi.fn(
@@ -1006,7 +1545,9 @@ describe("coordinator local admin actions", () => {
 							identity_id: identityId,
 							policy_team_id: "team-a",
 							target_identity_id: null,
-							reviewed_preview_digest: "coordinator-review",
+							reviewed_preview_digest: reviewedDigest,
+							reviewed_intent: reviewedIntent,
+							...testCase.responseOverride,
 						}),
 						{ status: 200 },
 					),
@@ -1018,11 +1559,87 @@ describe("coordinator local admin actions", () => {
 			coordinator_url: "https://coord.example.test",
 			group_id: "coordinator-a",
 			policy: "auto_admit",
-			token: "recipient-token",
+			token: `recipient-${testCase.label}-token`,
 			expires_at: "2099-01-01T00:00:00.000Z",
 			team_name: null,
 			policy_team_id: "team-a",
-			reviewed_preview_digest: "coordinator-review",
+			reviewed_preview_digest: reviewedDigest,
+		});
+
+		// Act
+		const acceptance = coordinatorImportInviteAction({
+			inviteValue: invite,
+			dbPath: actionDbPath,
+			keysDir,
+			configPath,
+			recipientActorId: identityId,
+			recipientDisplayName: "Recipient",
+			deviceDisplayName: "Recipient laptop",
+			reviewedOnboardingDigest: `recipient-onboarding-preview-v1:${"a".repeat(64)}`,
+		});
+
+		// Assert
+		await expect(acceptance).rejects.toThrow("recipient_invite_intent_mismatch");
+		expect(localSnapshot()).toBe(beforeDb);
+		expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
+	});
+
+	it("rejects a recipient response changed after valid inspection without local persistence", async () => {
+		const actionDbPath = join(tmpDir, "recipient-post-join-mismatch.sqlite");
+		const keysDir = join(tmpDir, "recipient-post-join-mismatch-keys");
+		const configPath = join(tmpDir, "recipient-post-join-mismatch-config.json");
+		const identityId = "identity-recipient";
+		const token = "recipient-post-join-mismatch-token";
+		const originalConfig = { actor_id: identityId, sync_coordinator_groups: ["existing-group"] };
+		writeCodememConfigFile(originalConfig, configPath);
+		const reviewedIntent = teamReviewedIntent("team-a");
+		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+		const reviewedOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
+			dbPath: actionDbPath,
+			keysDir,
+			invitationId: token,
+			identityId,
+			deviceDisplayName: "Recipient laptop",
+			reviewedIntent,
+		});
+		const validResponse = {
+			ok: true,
+			status: "accepted",
+			kind: "team_member",
+			group_id: "coordinator-a",
+			identity_id: identityId,
+			policy_team_id: "team-a",
+			target_identity_id: null,
+			reviewed_preview_digest: reviewedDigest,
+			reviewed_intent: reviewedIntent,
+		};
+		const requestedUrls: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string | URL) => {
+				const requestedUrl = String(url);
+				requestedUrls.push(requestedUrl);
+				return new Response(
+					JSON.stringify(
+						requestedUrl.endsWith("/v1/invites/inspect")
+							? validResponse
+							: { ...validResponse, reviewed_preview_digest: "f".repeat(64) },
+					),
+					{ status: 200 },
+				);
+			}),
+		);
+		const invite = encodeInvitePayload({
+			v: 1,
+			kind: "team_member",
+			coordinator_url: "https://coord.example.test",
+			group_id: "coordinator-a",
+			policy: "auto_admit",
+			token,
+			expires_at: "2099-01-01T00:00:00.000Z",
+			team_name: null,
+			policy_team_id: "team-a",
+			reviewed_preview_digest: reviewedDigest,
 		});
 
 		await expect(
@@ -1036,15 +1653,20 @@ describe("coordinator local admin actions", () => {
 				deviceDisplayName: "Recipient laptop",
 				reviewedOnboardingDigest,
 			}),
-		).rejects.toThrow("reviewed_onboarding_stale");
-		expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
-		const after = connect(actionDbPath);
+		).rejects.toThrow("recipient_invite_intent_mismatch");
+		expect(requestedUrls).toEqual([
+			"https://coord.example.test/v1/invites/inspect",
+			"https://coord.example.test/v1/join",
+		]);
+		const db = connect(actionDbPath);
 		try {
-			expect(after.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
-			expect(after.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get()).toBe(0);
+			expect(db.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+			expect(db.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get()).toBe(0);
+			expect(db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(0);
 		} finally {
-			after.close();
+			db.close();
 		}
+		expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
 	});
 
 	it("warns when local invite coordinator URL uses private IPv6 space", async () => {

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -38,10 +38,16 @@ import {
 } from "./project-invite-acceptance.js";
 import { friendlyDeviceName, normalizeIdentityDisplayName } from "./project-invite-identity.js";
 import {
-	commitRecipientPolicyOnboarding,
-	previewRecipientPolicyOnboarding,
-	type RecipientPolicyOnboardingPreviewRequestV1,
+	assertAddDeviceIdentityAdoptionAllowed,
+	commitRecipientPolicyOnboardingFromReviewedIntent,
+	previewRecipientPolicyOnboardingFromReviewedIntent,
+	type RecipientPolicyReviewedIntentPreviewRequestV1,
 } from "./recipient-policy-onboarding.js";
+import {
+	RecipientReviewedIntentError,
+	type RecipientReviewedIntentV1,
+	verifyRecipientReviewedIntent,
+} from "./recipient-reviewed-intent.js";
 import { updatePeerAddresses } from "./sync-discovery.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 import { buildBaseUrl, requestJson } from "./sync-http-client.js";
@@ -61,7 +67,7 @@ function stripTrailingSlashes(value: string): string {
 	return end === value.length ? value : value.slice(0, end);
 }
 
-function enableProjectInviteSync(config: Record<string, unknown>): Record<string, unknown> {
+function enableInviteSync(config: Record<string, unknown>): Record<string, unknown> {
 	const port = Number(config.sync_port);
 	const intervalS = Number(config.sync_interval_s);
 	return {
@@ -1015,6 +1021,7 @@ export async function coordinatorCreateInviteAction(opts: {
 	policyTeamId?: string | null;
 	targetIdentityId?: string | null;
 	reviewedPreviewDigest?: string | null;
+	reviewedIntent?: unknown;
 }): Promise<Record<string, unknown>> {
 	if (!VALID_INVITE_POLICIES.has(opts.policy)) throw new Error(`Invalid policy: ${opts.policy}`);
 	if (
@@ -1034,8 +1041,33 @@ export async function coordinatorCreateInviteAction(opts: {
 		(inviteKind === "team_member" &&
 			(!opts.policyTeamId || !opts.reviewedPreviewDigest || opts.targetIdentityId)) ||
 		(inviteKind === "add_device" &&
-			(!opts.targetIdentityId || !opts.reviewedPreviewDigest || opts.policyTeamId))
+			(!opts.targetIdentityId || !opts.reviewedPreviewDigest || opts.policyTeamId)) ||
+		(!["team_member", "add_device"].includes(inviteKind) &&
+			Boolean(opts.policyTeamId || opts.targetIdentityId || opts.reviewedPreviewDigest))
 	) {
+		throw new Error("recipient_invite_context_required");
+	}
+	let reviewedIntent: RecipientReviewedIntentV1 | undefined;
+	if (inviteKind === "team_member" || inviteKind === "add_device") {
+		if (opts.reviewedIntent == null) throw new Error("recipient_invite_review_unavailable");
+		try {
+			reviewedIntent = await verifyRecipientReviewedIntent(opts.reviewedIntent, {
+				target:
+					inviteKind === "team_member"
+						? { kind: "team_member", policyTeamId: String(opts.policyTeamId) }
+						: { kind: "add_device", targetIdentityId: String(opts.targetIdentityId) },
+				digest: String(opts.reviewedPreviewDigest),
+			});
+		} catch (error) {
+			if (
+				error instanceof RecipientReviewedIntentError &&
+				error.code === "recipient_invite_intent_mismatch"
+			) {
+				throw error;
+			}
+			throw new Error("recipient_invite_review_unavailable");
+		}
+	} else if (opts.reviewedIntent != null) {
 		throw new Error("recipient_invite_context_required");
 	}
 	const expiresAt = new Date(Date.now() + opts.ttlHours * 3600 * 1000).toISOString();
@@ -1066,6 +1098,7 @@ export async function coordinatorCreateInviteAction(opts: {
 				policy_team_id: opts.policyTeamId ?? null,
 				target_identity_id: opts.targetIdentityId ?? null,
 				reviewed_preview_digest: opts.reviewedPreviewDigest ?? null,
+				reviewed_intent: reviewedIntent ?? null,
 			},
 		);
 		const invite = payload?.invite;
@@ -1115,6 +1148,7 @@ export async function coordinatorCreateInviteAction(opts: {
 			policyTeamId: opts.policyTeamId ?? null,
 			targetIdentityId: opts.targetIdentityId ?? null,
 			reviewedPreviewDigest: opts.reviewedPreviewDigest ?? null,
+			reviewedIntent,
 		});
 		const payload: InvitePayload = {
 			v: 1,
@@ -1255,7 +1289,7 @@ function recipientInviteOnboardingRequest(opts: {
 	deviceId: string;
 	publicKey: string;
 	deviceDisplayName: string;
-}): RecipientPolicyOnboardingPreviewRequestV1 {
+}): RecipientPolicyReviewedIntentPreviewRequestV1 {
 	const base = {
 		version: 1 as const,
 		invitationId: String(opts.payload.token),
@@ -1273,34 +1307,74 @@ function recipientInviteOnboardingRequest(opts: {
 		: { ...base, journey: "add_device" };
 }
 
-function previewRecipientInviteOnboardingDigest(opts: {
-	dbPath: string;
+async function validateRecipientInviteReview(opts: {
 	payload: InvitePayload;
+	response: Record<string, unknown> | null;
 	identityId: string;
-	identityDisplayName: string;
 	deviceId: string;
 	publicKey: string;
 	deviceDisplayName: string;
-}): string {
-	const conn = connect(opts.dbPath);
-	try {
-		conn.exec("BEGIN");
-		const now = new Date().toISOString();
-		conn
-			.prepare(`INSERT INTO actors(
-			actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
-		) VALUES (?, ?, 1, 'active', NULL, ?, ?)
-		ON CONFLICT(actor_id) DO NOTHING`)
-			.run(opts.identityId, opts.identityDisplayName, now, now);
-		const preview = previewRecipientPolicyOnboarding(conn, recipientInviteOnboardingRequest(opts));
-		conn.exec("ROLLBACK");
-		return preview.reviewedOnboardingDigest;
-	} catch (error) {
-		if (conn.inTransaction) conn.exec("ROLLBACK");
-		throw error;
-	} finally {
-		conn.close();
+	recipientDisplayName: string;
+	reviewedOnboardingDigest: string;
+}): Promise<{
+	reviewedIntent: RecipientReviewedIntentV1;
+	persistedRecipientDisplayName: string;
+}> {
+	const responseKind = String(opts.response?.kind ?? "").trim();
+	const responseDigest = String(opts.response?.reviewed_preview_digest ?? "").trim();
+	if (
+		responseKind !== opts.payload.kind ||
+		responseDigest !== String(opts.payload.reviewed_preview_digest ?? "").trim() ||
+		(opts.payload.kind === "team_member" &&
+			String(opts.response?.policy_team_id ?? "").trim() !==
+				String(opts.payload.policy_team_id ?? "").trim()) ||
+		(opts.payload.kind === "add_device" &&
+			String(opts.response?.target_identity_id ?? "").trim() !==
+				String(opts.payload.target_identity_id ?? "").trim())
+	) {
+		throw new Error("recipient_invite_intent_mismatch");
 	}
+	let reviewedIntent: RecipientReviewedIntentV1;
+	try {
+		reviewedIntent = await verifyRecipientReviewedIntent(opts.response?.reviewed_intent, {
+			target:
+				opts.payload.kind === "team_member"
+					? {
+							kind: "team_member",
+							policyTeamId: String(opts.payload.policy_team_id ?? "").trim(),
+						}
+					: {
+							kind: "add_device",
+							targetIdentityId: String(opts.payload.target_identity_id ?? "").trim(),
+						},
+			digest: responseDigest,
+		});
+	} catch (error) {
+		if (error instanceof RecipientReviewedIntentError) {
+			throw new Error("recipient_invite_intent_mismatch");
+		}
+		throw error;
+	}
+	const preview = previewRecipientPolicyOnboardingFromReviewedIntent(
+		reviewedIntent,
+		recipientInviteOnboardingRequest({
+			payload: opts.payload,
+			identityId: opts.identityId,
+			deviceId: opts.deviceId,
+			publicKey: opts.publicKey,
+			deviceDisplayName: opts.deviceDisplayName,
+		}),
+	);
+	if (opts.reviewedOnboardingDigest !== preview.reviewedOnboardingDigest) {
+		throw new Error("reviewed_onboarding_stale");
+	}
+	return {
+		reviewedIntent,
+		persistedRecipientDisplayName:
+			reviewedIntent.journey === "add_device"
+				? reviewedIntent.targetIdentity.displayName
+				: opts.recipientDisplayName,
+	};
 }
 
 function persistRecipientInviteOnboarding(opts: {
@@ -1311,20 +1385,16 @@ function persistRecipientInviteOnboarding(opts: {
 	deviceId: string;
 	publicKey: string;
 	deviceDisplayName: string;
+	reviewedIntent: RecipientReviewedIntentV1;
 	reviewedOnboardingDigest: string;
 }): void {
 	const conn = connect(opts.dbPath);
 	try {
-		const now = new Date().toISOString();
-		conn
-			.prepare(`INSERT INTO actors(
-			actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
-		) VALUES (?, ?, 1, 'active', NULL, ?, ?)
-		ON CONFLICT(actor_id) DO NOTHING`)
-			.run(opts.identityId, opts.identityDisplayName, now, now);
 		const request = recipientInviteOnboardingRequest(opts);
-		const result = commitRecipientPolicyOnboarding(conn, {
+		const result = commitRecipientPolicyOnboardingFromReviewedIntent(conn, {
 			...request,
+			identityDisplayName: opts.identityDisplayName,
+			reviewedIntent: opts.reviewedIntent,
 			reviewedOnboardingDigest: opts.reviewedOnboardingDigest,
 		});
 		if (result.status !== "applied")
@@ -1374,18 +1444,29 @@ export async function coordinatorImportInviteAction(opts: {
 	const configuredRecipientActorId = String(config.actor_id ?? "").trim();
 	const addDeviceTargetIdentityId =
 		payload.kind === "add_device" ? String(payload.target_identity_id ?? "").trim() : "";
-	const recipientActorId =
-		explicitRecipientActorId ||
-		configuredRecipientActorId ||
-		addDeviceTargetIdentityId ||
-		`local:${deviceId}`;
-	if (
-		payload.kind === "add_device" &&
-		[recipientActorId, explicitRecipientActorId, configuredRecipientActorId].some(
-			(identityId) => identityId.length > 0 && identityId !== addDeviceTargetIdentityId,
-		)
-	) {
-		throw new Error("invite_identity_conflict");
+	let recipientActorId =
+		explicitRecipientActorId || configuredRecipientActorId || `local:${deviceId}`;
+	if (payload.kind === "add_device") {
+		if (
+			!addDeviceTargetIdentityId ||
+			(explicitRecipientActorId && explicitRecipientActorId !== addDeviceTargetIdentityId)
+		) {
+			throw new Error("invite_identity_conflict");
+		}
+		if (
+			configuredRecipientActorId &&
+			configuredRecipientActorId !== addDeviceTargetIdentityId &&
+			configuredRecipientActorId !== `local:${deviceId}`
+		) {
+			throw new Error("invite_identity_conflict");
+		}
+		const identityConn = connect(resolvedDbPath);
+		try {
+			assertAddDeviceIdentityAdoptionAllowed(identityConn, addDeviceTargetIdentityId, deviceId);
+		} finally {
+			identityConn.close();
+		}
+		recipientActorId = addDeviceTargetIdentityId;
 	}
 	const recipientDisplayName =
 		projectInvite || recipientInvite
@@ -1401,18 +1482,6 @@ export async function coordinatorImportInviteAction(opts: {
 					"device_display_name",
 				)
 			: recipientDisplayName;
-	const reviewedOnboardingDigest = recipientInvite
-		? String(opts.reviewedOnboardingDigest ?? "").trim() ||
-			previewRecipientInviteOnboardingDigest({
-				dbPath: resolvedDbPath,
-				payload,
-				identityId: recipientActorId,
-				identityDisplayName: recipientDisplayName,
-				deviceId,
-				publicKey,
-				deviceDisplayName: displayName,
-			})
-		: null;
 	// V1 of multi-team assumes one coordinator hosting multiple groups.
 	// If this device is already enrolled in a different coordinator, surface
 	// that as a hard error instead of silently overwriting the existing
@@ -1427,6 +1496,50 @@ export async function coordinatorImportInviteAction(opts: {
 		throw new Error(
 			`This device is already enrolled with coordinator ${existingCoordinator}. Multi-team joining is only supported across groups on the same coordinator.`,
 		);
+	}
+	const reviewedOnboardingDigest = String(opts.reviewedOnboardingDigest ?? "").trim();
+	if (recipientInvite && !reviewedOnboardingDigest) {
+		throw new Error("reviewed_onboarding_digest_required");
+	}
+	if (recipientInvite) {
+		let inspectStatus = 0;
+		let inspection: Record<string, unknown> | null = null;
+		try {
+			[inspectStatus, inspection] = await requestJson(
+				"POST",
+				`${stripTrailingSlashes(coordinatorUrl)}/v1/invites/inspect`,
+				{
+					body: { token: String(payload.token) },
+					timeoutS: INVITE_IMPORT_TIMEOUT_S,
+				},
+			);
+		} catch (error) {
+			throw inviteImportTransportError(error, coordinatorUrl);
+		}
+		if (inspectStatus < 200 || inspectStatus >= 300) {
+			const detail = typeof inspection?.error === "string" ? inspection.error : "unknown";
+			if (
+				[
+					"invite_already_bound",
+					"invite_expired",
+					"invite_invalid",
+					"recipient_invite_review_unavailable",
+				].includes(detail)
+			) {
+				throw new Error(detail);
+			}
+			throw new Error(`Invite inspection failed (${inspectStatus}): ${detail}`);
+		}
+		await validateRecipientInviteReview({
+			payload,
+			response: inspection,
+			identityId: recipientActorId,
+			deviceId,
+			publicKey,
+			deviceDisplayName: displayName,
+			recipientDisplayName,
+			reviewedOnboardingDigest,
+		});
 	}
 	let status = 0;
 	let response: Record<string, unknown> | null = null;
@@ -1470,6 +1583,8 @@ export async function coordinatorImportInviteAction(opts: {
 				"invite_expired",
 				"invite_identity_conflict",
 				"invite_invalid",
+				"recipient_invite_intent_mismatch",
+				"recipient_invite_review_unavailable",
 			].includes(detail)
 		) {
 			throw new Error(detail);
@@ -1485,42 +1600,41 @@ export async function coordinatorImportInviteAction(opts: {
 			response,
 		});
 	}
+	let persistedRecipientDisplayName = recipientDisplayName;
+	let recipientOnboarding: Parameters<typeof persistRecipientInviteOnboarding>[0] | null = null;
 	if (recipientInvite) {
-		const responseKind = String(response?.kind ?? "").trim();
-		const responseDigest = String(response?.reviewed_preview_digest ?? "").trim();
-		if (
-			responseKind !== payload.kind ||
-			responseDigest !== String(payload.reviewed_preview_digest ?? "").trim() ||
-			(payload.kind === "team_member" &&
-				String(response?.policy_team_id ?? "").trim() !==
-					String(payload.policy_team_id ?? "").trim()) ||
-			(payload.kind === "add_device" &&
-				String(response?.target_identity_id ?? "").trim() !==
-					String(payload.target_identity_id ?? "").trim())
-		) {
-			throw new Error("recipient_invite_intent_mismatch");
-		}
-		persistRecipientInviteOnboarding({
-			dbPath: resolvedDbPath,
+		const validatedReview = await validateRecipientInviteReview({
 			payload,
 			identityId: recipientActorId,
-			identityDisplayName: recipientDisplayName,
 			deviceId,
 			publicKey,
 			deviceDisplayName: displayName,
-			reviewedOnboardingDigest: reviewedOnboardingDigest ?? "",
+			response,
+			recipientDisplayName,
+			reviewedOnboardingDigest,
 		});
+		persistedRecipientDisplayName = validatedReview.persistedRecipientDisplayName;
+		recipientOnboarding = {
+			dbPath: resolvedDbPath,
+			payload,
+			identityId: recipientActorId,
+			identityDisplayName: persistedRecipientDisplayName,
+			deviceId,
+			publicKey,
+			deviceDisplayName: displayName,
+			reviewedIntent: validatedReview.reviewedIntent,
+			reviewedOnboardingDigest,
+		};
 	}
-	let nextConfig = opts.configPath
+	const previousConfig = opts.configPath
 		? readCodememConfigFileAtPath(opts.configPath)
 		: readCodememConfigFile();
-	if (projectInvite) nextConfig = enableProjectInviteSync(nextConfig);
+	let nextConfig = { ...previousConfig };
+	if (projectInvite || recipientInvite) nextConfig = enableInviteSync(nextConfig);
 	nextConfig.sync_coordinator_url = coordinatorUrl;
 	if (projectInvite || recipientInvite) {
 		nextConfig.actor_id = recipientActorId;
-	}
-	if (projectInvite) {
-		nextConfig.actor_display_name = recipientDisplayName;
+		nextConfig.actor_display_name = persistedRecipientDisplayName;
 		nextConfig.sync_device_name = displayName;
 	}
 	// Append the new group to sync_coordinator_groups (dedup) instead of
@@ -1552,6 +1666,18 @@ export async function coordinatorImportInviteAction(opts: {
 		}
 		throw error;
 	}
+	if (recipientOnboarding) {
+		try {
+			persistRecipientInviteOnboarding(recipientOnboarding);
+		} catch (error) {
+			try {
+				writeCodememConfigFile(previousConfig, opts.configPath ?? undefined);
+			} catch (restoreError) {
+				throw new AggregateError([error, restoreError], "recipient_invite_config_restore_failed");
+			}
+			throw error;
+		}
+	}
 	if (recipientInvite) {
 		return {
 			group_id: response?.group_id ?? payload.group_id,
@@ -1562,6 +1688,7 @@ export async function coordinatorImportInviteAction(opts: {
 			policy_team_id: response?.policy_team_id ?? payload.policy_team_id ?? null,
 			target_identity_id: response?.target_identity_id ?? payload.target_identity_id ?? null,
 			reviewed_preview_digest: response?.reviewed_preview_digest ?? null,
+			sync_enabled: true,
 		};
 	}
 	return {

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -33,6 +33,8 @@ import {
 	type CoordinatorUpsertPresenceInput,
 	createCoordinatorApp,
 	fingerprintPublicKey,
+	type RecipientReviewedIntentV1,
+	recipientReviewedIntentDigest,
 } from "./index.js";
 import { createInMemoryRequestRateLimiter } from "./request-rate-limit.js";
 
@@ -146,6 +148,24 @@ function authHeaders(deviceId = "device-a", nonce = "nonce-a") {
 		"X-Opencode-Signature": "sig",
 		"X-Opencode-Timestamp": "2026-03-28T00:00:00Z",
 		"X-Opencode-Nonce": nonce,
+	};
+}
+
+function teamReviewedIntent(teamId = "policy-team-1"): RecipientReviewedIntentV1 {
+	return {
+		version: 1,
+		journey: "team",
+		team: { teamId, displayName: "Product", futureProjectsInherit: true },
+		projects: [
+			{
+				canonicalProjectIdentity: "git:https://example.test/codemem",
+				displayName: "codemem",
+				existingMemoryCount: 3,
+				futureMemoriesShared: true,
+				sources: [{ kind: "team", teamId, displayName: "Product" }],
+			},
+		],
+		excludedProjects: [],
 	};
 }
 
@@ -319,9 +339,153 @@ describe("createCoordinatorApp dependency injection", () => {
 		);
 	});
 
+	it("validates recipient reviewed intent at creation and keeps invitation payloads digest-only", async () => {
+		const reviewedIntent = teamReviewedIntent();
+		const digest = await recipientReviewedIntentDigest(reviewedIntent);
+		const createInvite = vi.fn(async (input: CoordinatorCreateInviteInput) => ({
+			invite_id: "invite-team-1",
+			group_id: input.groupId,
+			token: "team-token",
+			policy: input.policy,
+			expires_at: input.expiresAt,
+			created_at: "2026-03-28T00:00:00Z",
+			created_by: null,
+			team_name_snapshot: "Coordinator One",
+			revoked_at: null,
+			invite_kind: "team_member" as const,
+			policy_team_id: "policy-team-1",
+			reviewed_preview_digest: digest,
+		}));
+		const store = createMockStore({
+			createInvite,
+			getGroup: vi.fn(async () => ({
+				group_id: "g1",
+				display_name: "Coordinator One",
+				archived_at: null,
+				created_at: "2026-03-28T00:00:00Z",
+			})),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: { adminSecret: () => "test-secret", now: () => "2026-03-28T00:00:00Z" },
+			requestVerifier: allowRequest,
+		});
+		const headers = {
+			"X-Codemem-Coordinator-Admin": "test-secret",
+			"Content-Type": "application/json",
+		};
+		const base = {
+			group_id: "g1",
+			policy: "auto_admit",
+			expires_at: "2026-04-04T00:00:00Z",
+			coordinator_url: "https://coord.example.test",
+			invite_kind: "team_member",
+			policy_team_id: "policy-team-1",
+			reviewed_preview_digest: digest,
+		};
+
+		const missing = await app.request("/v1/admin/invites", {
+			method: "POST",
+			headers,
+			body: JSON.stringify(base),
+		});
+		expect(missing.status).toBe(400);
+		expect(await missing.json()).toEqual({ error: "recipient_invite_review_unavailable" });
+
+		const mismatched = await app.request("/v1/admin/invites", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({ ...base, reviewed_intent: teamReviewedIntent("other-team") }),
+		});
+		expect(mismatched.status).toBe(409);
+		expect(await mismatched.json()).toEqual({ error: "recipient_invite_intent_mismatch" });
+
+		const malformed = await app.request("/v1/admin/invites", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({ ...base, reviewed_intent: { version: 1, journey: "team" } }),
+		});
+		expect(malformed.status).toBe(400);
+		expect(await malformed.json()).toEqual({ error: "recipient_invite_review_unavailable" });
+
+		const digestMismatch = await app.request("/v1/admin/invites", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				...base,
+				reviewed_preview_digest: "f".repeat(64),
+				reviewed_intent: reviewedIntent,
+			}),
+		});
+		expect(digestMismatch.status).toBe(409);
+		expect(await digestMismatch.json()).toEqual({ error: "recipient_invite_intent_mismatch" });
+
+		const valid = await app.request("/v1/admin/invites", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({ ...base, reviewed_intent: reviewedIntent }),
+		});
+		expect(valid.status).toBe(200);
+		const response = (await valid.json()) as {
+			payload: Record<string, unknown>;
+			encoded: string;
+			link: string;
+		};
+		expect(createInvite).toHaveBeenCalledWith(
+			expect.objectContaining({ reviewedIntent, reviewedPreviewDigest: digest }),
+		);
+		expect(response.payload).not.toHaveProperty("reviewed_intent");
+		expect(response.encoded).not.toContain("reviewed_intent");
+		expect(response.link).not.toContain("reviewed_intent");
+	});
+
+	it("returns safe errors for unavailable or mismatched stored recipient reviews", async () => {
+		const invite: CoordinatorInvite = {
+			invite_id: "invite-team-1",
+			group_id: "g1",
+			token: "team-token",
+			policy: "auto_admit",
+			expires_at: "2099-01-01T00:00:00Z",
+			created_at: "2026-03-28T00:00:00Z",
+			created_by: null,
+			team_name_snapshot: "Coordinator One",
+			revoked_at: null,
+			invite_kind: "team_member",
+			policy_team_id: "policy-team-1",
+			reviewed_preview_digest: "e".repeat(64),
+		};
+		const inspectRecipientInvite = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("recipient_invite_review_unavailable"))
+			.mockRejectedValueOnce(new Error("recipient_invite_intent_mismatch"));
+		const store = createMockStore({
+			getInviteByTokenForInspection: vi.fn(async () => invite),
+			inspectRecipientInvite,
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: { adminSecret: () => "test-secret", now: () => "2026-03-28T00:00:00Z" },
+			requestVerifier: allowRequest,
+		});
+		const inspect = () =>
+			app.request("/v1/invites/inspect", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ token: invite.token }),
+			});
+
+		const unavailable = await inspect();
+		expect(unavailable.status).toBe(409);
+		expect(await unavailable.json()).toEqual({ error: "recipient_invite_review_unavailable" });
+		const mismatched = await inspect();
+		expect(mismatched.status).toBe(409);
+		expect(await mismatched.json()).toEqual({ error: "recipient_invite_intent_mismatch" });
+	});
+
 	it("inspects and consumes explicit Team invitations without enrollment or scope grants", async () => {
 		const publicKey = "recipient-public-key";
-		const digest = "e".repeat(64);
+		const reviewedIntent = teamReviewedIntent();
+		const digest = await recipientReviewedIntentDigest(reviewedIntent);
 		const invite: CoordinatorInvite = {
 			invite_id: "invite-team-1",
 			group_id: "g1",
@@ -343,6 +507,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				consumed_at: "2026-03-28T00:00:00Z",
 				recipient_actor_id: "identity-brian",
 			},
+			reviewed_intent: reviewedIntent,
 		}));
 		const store = createMockStore({
 			getInviteByTokenForInspection: vi.fn(async () => invite),
@@ -351,6 +516,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				invite,
 				policy_team_id: "policy-team-1",
 				reviewed_preview_digest: digest,
+				reviewed_intent: reviewedIntent,
 				bound: false,
 			})),
 			consumeRecipientInvite,
@@ -370,6 +536,7 @@ describe("createCoordinatorApp dependency injection", () => {
 			kind: "team_member",
 			policy_team_id: "policy-team-1",
 			reviewed_preview_digest: digest,
+			reviewed_intent: reviewedIntent,
 			bound: false,
 		});
 
@@ -391,6 +558,8 @@ describe("createCoordinatorApp dependency injection", () => {
 			kind: "team_member",
 			identity_id: "identity-brian",
 			policy_team_id: "policy-team-1",
+			reviewed_preview_digest: digest,
+			reviewed_intent: reviewedIntent,
 		});
 		expect(consumeRecipientInvite).toHaveBeenCalledOnce();
 		expect(store.enrollDevice).not.toHaveBeenCalled();

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -27,6 +27,11 @@ import {
 	normalizeProjectInviteSummaries,
 } from "./project-invite-identity.js";
 import {
+	RecipientReviewedIntentError,
+	type RecipientReviewedIntentV1,
+	verifyRecipientReviewedIntent,
+} from "./recipient-reviewed-intent.js";
+import {
 	createInMemoryRequestRateLimiter,
 	type InMemoryRequestRateLimiter,
 } from "./request-rate-limit.js";
@@ -1334,6 +1339,7 @@ export function createCoordinatorApp(
 		const policyTeamId = String(data.policy_team_id ?? "").trim() || null;
 		const targetIdentityId = String(data.target_identity_id ?? "").trim() || null;
 		const reviewedPreviewDigest = String(data.reviewed_preview_digest ?? "").trim() || null;
+		let reviewedIntent: RecipientReviewedIntentV1 | undefined;
 		let projectSummaries: ReturnType<typeof normalizeProjectInviteSummaries> | null = null;
 		let projectIntent: Array<{
 			canonical_identity: string;
@@ -1383,6 +1389,30 @@ export function createCoordinatorApp(
 				.some((value) => value.length > 256 || /[\p{Cc}\p{Cf}]/u.test(value))
 		) {
 			return c.json({ error: "recipient_invite_identifier_invalid" }, 400);
+		}
+		if (inviteKind === "team_member" || inviteKind === "add_device") {
+			if (data.reviewed_intent == null) {
+				return c.json({ error: "recipient_invite_review_unavailable" }, 400);
+			}
+			try {
+				reviewedIntent = await verifyRecipientReviewedIntent(data.reviewed_intent, {
+					target:
+						inviteKind === "team_member"
+							? { kind: "team_member", policyTeamId: String(policyTeamId) }
+							: { kind: "add_device", targetIdentityId: String(targetIdentityId) },
+					digest: String(reviewedPreviewDigest),
+				});
+			} catch (error) {
+				if (
+					error instanceof RecipientReviewedIntentError &&
+					error.code === "recipient_invite_intent_mismatch"
+				) {
+					return c.json({ error: error.code }, 409);
+				}
+				return c.json({ error: "recipient_invite_review_unavailable" }, 400);
+			}
+		} else if (data.reviewed_intent != null) {
+			return c.json({ error: "recipient_invite_metadata_invalid" }, 400);
 		}
 		if (
 			(operationId && !/^share_[a-f0-9]{40}$/u.test(operationId)) ||
@@ -1466,6 +1496,7 @@ export function createCoordinatorApp(
 				policyTeamId,
 				targetIdentityId,
 				reviewedPreviewDigest,
+				reviewedIntent,
 			});
 
 			const payload: InvitePayload = {
@@ -1546,12 +1577,14 @@ export function createCoordinatorApp(
 									kind: inspection.kind,
 									policy_team_id: inspection.policy_team_id,
 									reviewed_preview_digest: inspection.reviewed_preview_digest,
+									reviewed_intent: inspection.reviewed_intent,
 									bound: inspection.bound,
 								}
 							: {
 									kind: inspection.kind,
 									target_identity_id: inspection.target_identity_id,
 									reviewed_preview_digest: inspection.reviewed_preview_digest,
+									reviewed_intent: inspection.reviewed_intent,
 									bound: inspection.bound,
 								},
 					);
@@ -1871,6 +1904,7 @@ export function createCoordinatorApp(
 						policy_team_id: acceptance.invite.policy_team_id ?? null,
 						target_identity_id: acceptance.invite.target_identity_id ?? null,
 						reviewed_preview_digest: acceptance.invite.reviewed_preview_digest,
+						reviewed_intent: acceptance.reviewed_intent,
 					});
 				} catch (error) {
 					const code = error instanceof Error ? error.message : "invite_invalid";

--- a/packages/core/src/coordinator-store-contract.ts
+++ b/packages/core/src/coordinator-store-contract.ts
@@ -1,3 +1,5 @@
+import type { RecipientReviewedIntentV1 } from "./recipient-reviewed-intent.js";
+
 /**
  * Normalize a caller-supplied invite expiry to a canonical UTC ISO-8601
  * (`...Z`) string. Invite lookups filter with a SQL `expires_at > ?` string
@@ -69,6 +71,8 @@ export interface CoordinatorInvite {
 	target_identity_id?: string | null;
 	/** Digest of the server-owned preview reviewed before invitation creation. */
 	reviewed_preview_digest?: string | null;
+	/** Canonical JSON for the inviter-reviewed access intent. */
+	reviewed_intent_json?: string | null;
 }
 
 export type CoordinatorInviteKind =
@@ -101,6 +105,7 @@ export type CoordinatorRecipientInviteInspection =
 			invite: CoordinatorInvite;
 			policy_team_id: string;
 			reviewed_preview_digest: string;
+			reviewed_intent?: RecipientReviewedIntentV1;
 			bound: boolean;
 	  }
 	| {
@@ -108,12 +113,14 @@ export type CoordinatorRecipientInviteInspection =
 			invite: CoordinatorInvite;
 			target_identity_id: string;
 			reviewed_preview_digest: string;
+			reviewed_intent?: RecipientReviewedIntentV1;
 			bound: boolean;
 	  };
 
 export interface CoordinatorRecipientInviteAcceptance {
 	status: "accepted" | "existing";
 	invite: CoordinatorInvite;
+	reviewed_intent?: RecipientReviewedIntentV1;
 }
 
 export interface CoordinatorJoinRequest {
@@ -256,6 +263,7 @@ export interface CoordinatorCreateInviteInput {
 	policyTeamId?: string | null;
 	targetIdentityId?: string | null;
 	reviewedPreviewDigest?: string | null;
+	reviewedIntent?: unknown;
 }
 
 export interface CoordinatorConsumeProjectInviteInput {

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -4,12 +4,38 @@ import type {
 	CoordinatorCreateInviteInput,
 	CoordinatorStore,
 } from "./coordinator-store-contract.js";
+import {
+	canonicalRecipientReviewedIntentJson,
+	recipientReviewedIntentDigest,
+} from "./recipient-reviewed-intent.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
+
+function teamReviewedIntent(teamId: string) {
+	return {
+		version: 1,
+		journey: "team",
+		team: { teamId, displayName: "Core Team", futureProjectsInherit: true },
+		projects: [],
+		excludedProjects: [],
+	};
+}
+
+function addDeviceReviewedIntent(identityId: string) {
+	return {
+		version: 1,
+		journey: "add_device",
+		targetIdentity: { identityId, displayName: "Brian" },
+		projects: [],
+		excludedProjects: [],
+	};
+}
 
 export interface CoordinatorStoreHarnessContext<
 	TStore extends CoordinatorStore = CoordinatorStore,
 > {
 	store: TStore;
+	clearInviteReviewedIntent: (inviteId: string) => Promise<void> | void;
+	revokeInvite: (inviteId: string, revokedAt: string) => Promise<void> | void;
 	cleanup: () => Promise<void> | void;
 }
 
@@ -848,11 +874,131 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 		});
 
 		describe("invites", () => {
-			it("persists and single-use binds explicit Team and add-device invitations without scope membership", async () => {
+			it.each([
+				{ kind: "team_member" as const, targetId: "policy-team-revoked" },
+				{ kind: "add_device" as const, targetId: "identity-revoked" },
+			])("rejects a revoked $kind invite before first inspection or acceptance", async (testCase) => {
+				await withContext(async ({ store, revokeInvite }) => {
+					// Arrange
+					await store.createGroup("g1", "Coordinator Alpha");
+					const reviewedIntent =
+						testCase.kind === "team_member"
+							? teamReviewedIntent(testCase.targetId)
+							: addDeviceReviewedIntent(testCase.targetId);
+					const invite = await store.createInvite({
+						groupId: "g1",
+						policy: "auto_admit",
+						expiresAt: "2099-01-01T00:00:00Z",
+						inviteKind: testCase.kind,
+						...(testCase.kind === "team_member"
+							? { policyTeamId: testCase.targetId }
+							: { targetIdentityId: testCase.targetId }),
+						reviewedPreviewDigest: await recipientReviewedIntentDigest(reviewedIntent),
+						reviewedIntent,
+					});
+					const acceptance = {
+						token: invite.token,
+						inviteKind: testCase.kind,
+						identityId: testCase.kind === "add_device" ? testCase.targetId : "identity-recipient",
+						deviceId: "device-recipient",
+						publicKey: "recipient-public-key",
+						fingerprint: fingerprintPublicKey("recipient-public-key"),
+						now: "2026-07-23T00:00:00.000Z",
+					};
+					await revokeInvite(invite.invite_id, "2026-07-22T00:00:00.000Z");
+
+					// Act
+					const inspection = store.inspectRecipientInvite({
+						token: invite.token,
+						now: acceptance.now,
+					});
+					const consumption = store.consumeRecipientInvite(acceptance);
+
+					// Assert
+					await Promise.all([
+						expect(inspection).rejects.toThrow("invite_invalid"),
+						expect(consumption).rejects.toThrow("invite_invalid"),
+					]);
+					expect(await store.getInviteByTokenForInspection(invite.token)).toMatchObject({
+						revoked_at: "2026-07-22T00:00:00.000Z",
+						consumed_at: null,
+						bound_device_id: null,
+						bound_public_key: null,
+						bound_fingerprint: null,
+						recipient_actor_id: null,
+					});
+				});
+			});
+
+			it.each([
+				{ kind: "team_member" as const, targetId: "policy-team-replay" },
+				{ kind: "add_device" as const, targetId: "identity-replay" },
+			])("rejects a revoked $kind invite after an accepted replay without changing its binding", async (testCase) => {
+				await withContext(async ({ store, revokeInvite }) => {
+					// Arrange
+					await store.createGroup("g1", "Coordinator Alpha");
+					const reviewedIntent =
+						testCase.kind === "team_member"
+							? teamReviewedIntent(testCase.targetId)
+							: addDeviceReviewedIntent(testCase.targetId);
+					const invite = await store.createInvite({
+						groupId: "g1",
+						policy: "auto_admit",
+						expiresAt: "2099-01-01T00:00:00Z",
+						inviteKind: testCase.kind,
+						...(testCase.kind === "team_member"
+							? { policyTeamId: testCase.targetId }
+							: { targetIdentityId: testCase.targetId }),
+						reviewedPreviewDigest: await recipientReviewedIntentDigest(reviewedIntent),
+						reviewedIntent,
+					});
+					const acceptance = {
+						token: invite.token,
+						inviteKind: testCase.kind,
+						identityId: testCase.kind === "add_device" ? testCase.targetId : "identity-recipient",
+						deviceId: "device-recipient",
+						publicKey: "recipient-public-key",
+						fingerprint: fingerprintPublicKey("recipient-public-key"),
+						now: "2026-07-23T00:00:00.000Z",
+					};
+					expect((await store.consumeRecipientInvite(acceptance)).status).toBe("accepted");
+					expect((await store.consumeRecipientInvite(acceptance)).status).toBe("existing");
+					const boundBeforeRevocation = await store.getInviteByTokenForInspection(invite.token);
+					await revokeInvite(invite.invite_id, "2026-07-23T00:00:01.000Z");
+
+					// Act
+					const inspection = store.inspectRecipientInvite({
+						token: invite.token,
+						now: "2026-07-23T00:00:02.000Z",
+					});
+					const replay = store.consumeRecipientInvite({
+						...acceptance,
+						now: "2026-07-23T00:00:02.000Z",
+					});
+
+					// Assert
+					await Promise.all([
+						expect(inspection).rejects.toThrow("invite_invalid"),
+						expect(replay).rejects.toThrow("invite_invalid"),
+					]);
+					const boundAfterRevocation = await store.getInviteByTokenForInspection(invite.token);
+					expect(boundAfterRevocation).toMatchObject({
+						revoked_at: "2026-07-23T00:00:01.000Z",
+						consumed_at: boundBeforeRevocation?.consumed_at,
+						bound_device_id: boundBeforeRevocation?.bound_device_id,
+						bound_public_key: boundBeforeRevocation?.bound_public_key,
+						bound_fingerprint: boundBeforeRevocation?.bound_fingerprint,
+						recipient_actor_id: boundBeforeRevocation?.recipient_actor_id,
+					});
+				});
+			});
+
+			it("persists, enrolls, and single-use binds explicit Team and add-device invitations without scope membership", async () => {
 				await withContext(async ({ store }) => {
 					await store.createGroup("g1", "Coordinator Alpha");
 					await store.createScope({ scopeId: "scope-project", label: "Project" });
-					const digest = "a".repeat(64);
+					const reviewedIntent = teamReviewedIntent("policy-team-1");
+					const digest = await recipientReviewedIntentDigest(reviewedIntent);
 					const teamInvite = await store.createInvite({
 						groupId: "g1",
 						policy: "auto_admit",
@@ -860,18 +1006,24 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 						inviteKind: "team_member",
 						policyTeamId: "policy-team-1",
 						reviewedPreviewDigest: digest,
+						reviewedIntent,
 					});
 					expect(teamInvite).toMatchObject({
 						invite_kind: "team_member",
 						policy_team_id: "policy-team-1",
 						reviewed_preview_digest: digest,
+						reviewed_intent_json: canonicalRecipientReviewedIntentJson(reviewedIntent),
 					});
-					expect(
-						await store.inspectRecipientInvite({
-							token: teamInvite.token,
-							now: "2026-07-21T00:00:00.000Z",
-						}),
-					).toMatchObject({ kind: "team_member", policy_team_id: "policy-team-1", bound: false });
+					const teamInspection = await store.inspectRecipientInvite({
+						token: teamInvite.token,
+						now: "2026-07-21T00:00:00.000Z",
+					});
+					expect(teamInspection).toMatchObject({
+						kind: "team_member",
+						policy_team_id: "policy-team-1",
+						reviewed_intent: reviewedIntent,
+						bound: false,
+					});
 					const publicKey = "team-member-key";
 					const teamInput = {
 						token: teamInvite.token,
@@ -882,8 +1034,23 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 						fingerprint: fingerprintPublicKey(publicKey),
 						now: "2026-07-21T00:00:00.000Z",
 					};
-					expect((await store.consumeRecipientInvite(teamInput)).status).toBe("accepted");
-					expect((await store.consumeRecipientInvite(teamInput)).status).toBe("existing");
+					const acceptedTeam = await store.consumeRecipientInvite(teamInput);
+					const replayedTeam = await store.consumeRecipientInvite(teamInput);
+					expect(acceptedTeam).toMatchObject({
+						status: "accepted",
+						reviewed_intent: reviewedIntent,
+					});
+					expect(replayedTeam).toMatchObject({
+						status: "existing",
+						reviewed_intent: reviewedIntent,
+					});
+					expect(await store.getEnrollment("g1", teamInput.deviceId)).toMatchObject({
+						group_id: "g1",
+						device_id: teamInput.deviceId,
+						public_key: teamInput.publicKey,
+						fingerprint: teamInput.fingerprint,
+						enabled: 1,
+					});
 					await expect(
 						store.consumeRecipientInvite({ ...teamInput, identityId: "identity-other" }),
 					).rejects.toThrow("invite_identity_conflict");
@@ -898,13 +1065,15 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 						}),
 					).rejects.toThrow("invite_already_bound");
 
+					const addDeviceIntent = addDeviceReviewedIntent("identity-brian");
 					const addDeviceInvite = await store.createInvite({
 						groupId: "g1",
 						policy: "auto_admit",
 						expiresAt: "2099-01-01T00:00:00Z",
 						inviteKind: "add_device",
 						targetIdentityId: "identity-brian",
-						reviewedPreviewDigest: "b".repeat(64),
+						reviewedPreviewDigest: await recipientReviewedIntentDigest(addDeviceIntent),
+						reviewedIntent: addDeviceIntent,
 					});
 					expect(
 						await store.inspectRecipientInvite({
@@ -930,7 +1099,97 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					};
 					expect((await store.consumeRecipientInvite(addDeviceInput)).status).toBe("accepted");
 					expect((await store.consumeRecipientInvite(addDeviceInput)).status).toBe("existing");
+					expect(await store.getEnrollment("g1", addDeviceInput.deviceId)).toMatchObject({
+						group_id: "g1",
+						device_id: addDeviceInput.deviceId,
+						public_key: addDeviceInput.publicKey,
+						fingerprint: addDeviceInput.fingerprint,
+						enabled: 1,
+					});
 					expect(await store.listScopeMemberships("scope-project")).toEqual([]);
+				});
+			});
+
+			it("requires reviewed intent for new recipient invites and fails inspection for migrated null snapshots", async () => {
+				await withContext(async ({ store, clearInviteReviewedIntent }) => {
+					await store.createGroup("g1", "Coordinator Alpha");
+					for (const missing of [
+						{
+							inviteKind: "team_member" as const,
+							policyTeamId: "policy-team-1",
+							reviewedPreviewDigest: "a".repeat(64),
+						},
+						{
+							inviteKind: "add_device" as const,
+							targetIdentityId: "identity-brian",
+							reviewedPreviewDigest: "b".repeat(64),
+						},
+					]) {
+						await expect(
+							store.createInvite({
+								groupId: "g1",
+								policy: "auto_admit",
+								expiresAt: "2099-01-01T00:00:00Z",
+								...missing,
+							}),
+						).rejects.toThrow("recipient_invite_review_unavailable");
+					}
+
+					const legacyIntent = teamReviewedIntent("policy-team-1");
+					const missing = await store.createInvite({
+						groupId: "g1",
+						policy: "auto_admit",
+						expiresAt: "2099-01-01T00:00:00Z",
+						inviteKind: "team_member",
+						policyTeamId: "policy-team-1",
+						reviewedPreviewDigest: await recipientReviewedIntentDigest(legacyIntent),
+						reviewedIntent: legacyIntent,
+					});
+					await clearInviteReviewedIntent(missing.invite_id);
+					expect(await store.getInviteByTokenForInspection(missing.token)).toMatchObject({
+						invite_id: missing.invite_id,
+						reviewed_intent_json: null,
+					});
+					await expect(
+						store.inspectRecipientInvite({
+							token: missing.token,
+							now: "2026-07-21T00:00:00.000Z",
+						}),
+					).rejects.toThrow("recipient_invite_review_unavailable");
+					const valid = teamReviewedIntent("policy-team-1");
+					await expect(
+						store.createInvite({
+							groupId: "g1",
+							policy: "auto_admit",
+							expiresAt: "2099-01-01T00:00:00Z",
+							inviteKind: "team_member",
+							policyTeamId: "policy-team-1",
+							reviewedPreviewDigest: await recipientReviewedIntentDigest(valid),
+							reviewedIntent: { ...valid, version: 2 },
+						}),
+					).rejects.toThrow("recipient_reviewed_intent_invalid");
+					await expect(
+						store.createInvite({
+							groupId: "g1",
+							policy: "auto_admit",
+							expiresAt: "2099-01-01T00:00:00Z",
+							inviteKind: "team_member",
+							policyTeamId: "policy-team-other",
+							reviewedPreviewDigest: await recipientReviewedIntentDigest(valid),
+							reviewedIntent: valid,
+						}),
+					).rejects.toThrow("recipient_invite_intent_mismatch");
+					await expect(
+						store.createInvite({
+							groupId: "g1",
+							policy: "auto_admit",
+							expiresAt: "2099-01-01T00:00:00Z",
+							inviteKind: "team_member",
+							policyTeamId: "policy-team-1",
+							reviewedPreviewDigest: "0".repeat(64),
+							reviewedIntent: valid,
+						}),
+					).rejects.toThrow("recipient_invite_intent_mismatch");
 				});
 			});
 
@@ -938,13 +1197,15 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 				await withContext(async ({ store }) => {
 					await store.createGroup("g1", "Coordinator Alpha");
 					const publicKey = "post-expiry-key";
+					const reviewedIntent = teamReviewedIntent("policy-team-1");
 					const invite = await store.createInvite({
 						groupId: "g1",
 						policy: "auto_admit",
 						expiresAt: "2026-07-21T00:00:01.000Z",
 						inviteKind: "team_member",
 						policyTeamId: "policy-team-1",
-						reviewedPreviewDigest: "e".repeat(64),
+						reviewedPreviewDigest: await recipientReviewedIntentDigest(reviewedIntent),
+						reviewedIntent,
 					});
 					const input = {
 						token: invite.token,
@@ -998,13 +1259,15 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 				await withContext(async ({ store }) => {
 					await store.createGroup("g1", "Coordinator Alpha");
 					const publicKey = "expired-first-use-key";
+					const reviewedIntent = addDeviceReviewedIntent("identity-brian");
 					const invite = await store.createInvite({
 						groupId: "g1",
 						policy: "auto_admit",
 						expiresAt: "2026-07-21T00:00:01.000Z",
 						inviteKind: "add_device",
 						targetIdentityId: "identity-brian",
-						reviewedPreviewDigest: "f".repeat(64),
+						reviewedPreviewDigest: await recipientReviewedIntentDigest(reviewedIntent),
+						reviewedIntent,
 					});
 
 					await expect(
@@ -1024,13 +1287,15 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 			it("fails closed when recipient invitations expire or their coordinator group is archived", async () => {
 				await withContext(async ({ store }) => {
 					await store.createGroup("g1", "Coordinator Alpha");
+					const teamIntent = teamReviewedIntent("policy-team-1");
 					const expired = await store.createInvite({
 						groupId: "g1",
 						policy: "auto_admit",
 						expiresAt: "2000-01-01T00:00:00Z",
 						inviteKind: "team_member",
 						policyTeamId: "policy-team-1",
-						reviewedPreviewDigest: "c".repeat(64),
+						reviewedPreviewDigest: await recipientReviewedIntentDigest(teamIntent),
+						reviewedIntent: teamIntent,
 					});
 					await expect(
 						store.inspectRecipientInvite({
@@ -1049,13 +1314,15 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 							now: "2026-07-21T00:00:00.000Z",
 						}),
 					).rejects.toThrow("invite_expired");
+					const addDeviceIntent = addDeviceReviewedIntent("identity-brian");
 					const active = await store.createInvite({
 						groupId: "g1",
 						policy: "auto_admit",
 						expiresAt: "2099-01-01T00:00:00Z",
 						inviteKind: "add_device",
 						targetIdentityId: "identity-brian",
-						reviewedPreviewDigest: "d".repeat(64),
+						reviewedPreviewDigest: await recipientReviewedIntentDigest(addDeviceIntent),
+						reviewedIntent: addDeviceIntent,
 					});
 					await store.archiveGroup("g1", "2026-07-21T00:00:00.000Z");
 					await expect(

--- a/packages/core/src/coordinator-store.test.ts
+++ b/packages/core/src/coordinator-store.test.ts
@@ -12,6 +12,16 @@ describe("CoordinatorStore", () => {
 		const store = new BetterSqliteCoordinatorStore(join(tmpDir, "coordinator.sqlite"));
 		return {
 			store,
+			clearInviteReviewedIntent: (inviteId: string) => {
+				store.db
+					.prepare("UPDATE coordinator_invites SET reviewed_intent_json = NULL WHERE invite_id = ?")
+					.run(inviteId);
+			},
+			revokeInvite: (inviteId: string, revokedAt: string) => {
+				store.db
+					.prepare("UPDATE coordinator_invites SET revoked_at = ? WHERE invite_id = ?")
+					.run(revokedAt, inviteId);
+			},
 			cleanup: async () => {
 				await store.close();
 				rmSync(tmpDir, { recursive: true, force: true });
@@ -41,7 +51,8 @@ describe("CoordinatorStore", () => {
 				const row = store.db
 					.prepare(
 						`SELECT token, token_digest, consumed_at, bound_device_id, trust_state,
-							invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest
+							invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest,
+							reviewed_intent_json
 						 FROM coordinator_invites`,
 					)
 					.get();
@@ -55,6 +66,7 @@ describe("CoordinatorStore", () => {
 					policy_team_id: null,
 					target_identity_id: null,
 					reviewed_preview_digest: null,
+					reviewed_intent_json: null,
 				});
 			} finally {
 				await store.close();
@@ -113,7 +125,11 @@ describe("CoordinatorStore", () => {
 					name: string;
 				}>;
 				expect(columns.map((column) => column.name)).toEqual(
-					expect.arrayContaining(["operation_id", "reviewed_project_set_digest"]),
+					expect.arrayContaining([
+						"operation_id",
+						"reviewed_project_set_digest",
+						"reviewed_intent_json",
+					]),
 				);
 				expect(
 					store.db

--- a/packages/core/src/d1-coordinator-store.test.ts
+++ b/packages/core/src/d1-coordinator-store.test.ts
@@ -209,8 +209,22 @@ describe("D1CoordinatorStore", () => {
 	}
 
 	runCoordinatorStoreContract("contract", () => {
-		const { store, cleanup } = setupStore();
-		return { store, cleanup };
+		const { store, db, cleanup } = setupStore();
+		return {
+			store,
+			clearInviteReviewedIntent: (inviteId: string) => {
+				db.prepare(
+					"UPDATE coordinator_invites SET reviewed_intent_json = NULL WHERE invite_id = ?",
+				).run(inviteId);
+			},
+			revokeInvite: (inviteId: string, revokedAt: string) => {
+				db.prepare("UPDATE coordinator_invites SET revoked_at = ? WHERE invite_id = ?").run(
+					revokedAt,
+					inviteId,
+				);
+			},
+			cleanup,
+		};
 	});
 
 	it("converges to completed when a reverse pending row appears during insert", async () => {

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -45,6 +45,12 @@ import type {
 	CoordinatorUpsertPresenceInput,
 } from "./coordinator-store-contract.js";
 import { normalizeInviteExpiresAt } from "./coordinator-store-contract.js";
+import {
+	canonicalRecipientReviewedIntentJson,
+	parseStoredRecipientReviewedIntent,
+	type RecipientReviewedIntentTargetV1,
+	verifyRecipientReviewedIntent,
+} from "./recipient-reviewed-intent.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 
 interface D1RunResultLike {
@@ -164,7 +170,8 @@ const INVITE_COLUMNS = `invite_id, group_id, token, policy, expires_at, created_
 	inviter_actor_id, inviter_display_name, inviter_device_id, pending_person_id,
 	project_summaries_json, project_intent_json, consumed_at, bound_device_id, bound_public_key, bound_fingerprint,
 	recipient_actor_id, recipient_display_name, recipient_device_display_name, trust_state,
-	bootstrap_grant_id, invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest`;
+	bootstrap_grant_id, invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest,
+	reviewed_intent_json`;
 
 function requireTrimmedBootstrapGrantInput(opts: CoordinatorCreateBootstrapGrantInput): {
 	groupId: string;
@@ -189,12 +196,13 @@ function clean(value: string | null | undefined): string | null {
 	return trimmed ? trimmed : null;
 }
 
-function normalizeInviteMetadata(opts: CoordinatorCreateInviteInput): {
+async function normalizeInviteMetadata(opts: CoordinatorCreateInviteInput): Promise<{
 	inviteKind: CoordinatorInviteKind;
 	policyTeamId: string | null;
 	targetIdentityId: string | null;
 	reviewedPreviewDigest: string | null;
-} {
+	reviewedIntentJson: string | null;
+}> {
 	const inviteKind =
 		opts.inviteKind ?? (clean(opts.operationId) ? "project_share" : "legacy_enrollment");
 	const policyTeamId = clean(opts.policyTeamId);
@@ -237,31 +245,72 @@ function normalizeInviteMetadata(opts: CoordinatorCreateInviteInput): {
 			throw new Error("add_device invite metadata is invalid.");
 		}
 	}
-	return { inviteKind, policyTeamId, targetIdentityId, reviewedPreviewDigest };
+	const reviewedIntentProvided = opts.reviewedIntent !== undefined && opts.reviewedIntent !== null;
+	if (!reviewedIntentProvided) {
+		if (inviteKind === "team_member" || inviteKind === "add_device") {
+			throw new Error("recipient_invite_review_unavailable");
+		}
+		return {
+			inviteKind,
+			policyTeamId,
+			targetIdentityId,
+			reviewedPreviewDigest,
+			reviewedIntentJson: null,
+		};
+	}
+	let target: RecipientReviewedIntentTargetV1;
+	if (inviteKind === "team_member" && policyTeamId && reviewedPreviewDigest) {
+		target = { kind: "team_member", policyTeamId };
+	} else if (inviteKind === "add_device" && targetIdentityId && reviewedPreviewDigest) {
+		target = { kind: "add_device", targetIdentityId };
+	} else {
+		throw new Error("recipient invite metadata requires a recipient invite kind.");
+	}
+	await verifyRecipientReviewedIntent(opts.reviewedIntent, {
+		target,
+		digest: reviewedPreviewDigest,
+	});
+	return {
+		inviteKind,
+		policyTeamId,
+		targetIdentityId,
+		reviewedPreviewDigest,
+		reviewedIntentJson: canonicalRecipientReviewedIntentJson(opts.reviewedIntent, target),
+	};
 }
 
-function recipientInspection(
+async function recipientInspection(
 	invite: CoordinatorInvite,
-): CoordinatorRecipientInviteInspection | null {
+): Promise<CoordinatorRecipientInviteInspection | null> {
 	if (invite.invite_kind === "team_member") {
 		if (!invite.policy_team_id || !invite.reviewed_preview_digest)
 			throw new Error("invite_invalid");
+		const reviewedIntent = await parseStoredRecipientReviewedIntent(invite.reviewed_intent_json, {
+			target: { kind: "team_member", policyTeamId: invite.policy_team_id },
+			digest: invite.reviewed_preview_digest,
+		});
 		return {
 			kind: "team_member",
 			invite,
 			policy_team_id: invite.policy_team_id,
 			reviewed_preview_digest: invite.reviewed_preview_digest,
+			reviewed_intent: reviewedIntent,
 			bound: Boolean(invite.consumed_at),
 		};
 	}
 	if (invite.invite_kind === "add_device") {
 		if (!invite.target_identity_id || !invite.reviewed_preview_digest)
 			throw new Error("invite_invalid");
+		const reviewedIntent = await parseStoredRecipientReviewedIntent(invite.reviewed_intent_json, {
+			target: { kind: "add_device", targetIdentityId: invite.target_identity_id },
+			digest: invite.reviewed_preview_digest,
+		});
 		return {
 			kind: "add_device",
 			invite,
 			target_identity_id: invite.target_identity_id,
 			reviewed_preview_digest: invite.reviewed_preview_digest,
+			reviewed_intent: reviewedIntent,
 			bound: Boolean(invite.consumed_at),
 		};
 	}
@@ -776,7 +825,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		const group = await this.getGroup(_opts.groupId);
 		const operationId = String(_opts.operationId ?? "").trim() || null;
 		const reviewedProjectSetDigest = String(_opts.reviewedProjectSetDigest ?? "").trim() || null;
-		const metadata = normalizeInviteMetadata(_opts);
+		const metadata = await normalizeInviteMetadata(_opts);
 		if (Boolean(operationId) !== Boolean(reviewedProjectSetDigest)) {
 			throw new Error("operationId and reviewedProjectSetDigest must be provided together.");
 		}
@@ -806,7 +855,8 @@ export class D1CoordinatorStore implements CoordinatorStore {
 					(_opts.projectIntent ? JSON.stringify(_opts.projectIntent) : null) ||
 				existing.policy_team_id !== metadata.policyTeamId ||
 				existing.target_identity_id !== metadata.targetIdentityId ||
-				existing.reviewed_preview_digest !== metadata.reviewedPreviewDigest
+				existing.reviewed_preview_digest !== metadata.reviewedPreviewDigest ||
+				existing.reviewed_intent_json !== metadata.reviewedIntentJson
 			) {
 				throw new Error("invite_operation_intent_conflict");
 			}
@@ -850,8 +900,9 @@ export class D1CoordinatorStore implements CoordinatorStore {
 				team_name_snapshot, revoked_at, operation_id, reviewed_project_set_digest,
 				token_digest, inviter_actor_id, inviter_display_name, inviter_device_id,
 				pending_person_id, project_summaries_json, project_intent_json, trust_state,
-				invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+				invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest,
+				reviewed_intent_json
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 				.bind(
 					inviteId,
 					_opts.groupId,
@@ -875,6 +926,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 					metadata.policyTeamId,
 					metadata.targetIdentityId,
 					metadata.reviewedPreviewDigest,
+					metadata.reviewedIntentJson,
 				)
 				.run();
 		} catch (error) {
@@ -923,7 +975,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 	): Promise<CoordinatorRecipientInviteInspection | null> {
 		const invite = await this.getInviteByTokenForInspection(_opts.token);
 		if (!invite) return null;
-		const inspection = recipientInspection(invite);
+		const inspection = await recipientInspection(invite);
 		if (!inspection) return null;
 		if (invite.revoked_at) throw new Error("invite_invalid");
 		if (
@@ -958,7 +1010,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		}
 		const digest = await tokenDigest(_opts.token);
 		const initial = await this.getInviteByTokenForInspection(_opts.token);
-		const inspection = initial ? recipientInspection(initial) : null;
+		const inspection = initial ? await recipientInspection(initial) : null;
 		if (!initial || !inspection || inspection.kind !== _opts.inviteKind || initial.revoked_at) {
 			throw new Error("invite_invalid");
 		}
@@ -982,29 +1034,66 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		if (initial.consumed_at && initial.recipient_actor_id !== _opts.identityId) {
 			throw new Error("invite_identity_conflict");
 		}
-		const changed = initial.consumed_at
-			? 0
-			: await runChanges(
-					this.db
-						.prepare(`UPDATE coordinator_invites SET token = ?, consumed_at = ?, bound_device_id = ?,
-							bound_public_key = ?, bound_fingerprint = ?, recipient_actor_id = ?
-							WHERE (token_digest = ? OR token = ?) AND consumed_at IS NULL
-							AND revoked_at IS NULL AND expires_at > ? AND invite_kind = ?
-							AND EXISTS (SELECT 1 FROM groups g WHERE g.group_id = coordinator_invites.group_id
-								AND g.archived_at IS NULL)`)
-						.bind(
-							`consumed:${initial.invite_id}`,
-							consumedAt,
-							_opts.deviceId,
-							_opts.publicKey,
-							_opts.fingerprint,
-							_opts.identityId,
-							digest,
-							_opts.token,
-							consumedAt,
-							_opts.inviteKind,
-						),
-				);
+		const existingEnrollment = await firstRow<CoordinatorEnrollment>(
+			this.db
+				.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+					FROM enrolled_devices WHERE group_id = ? AND device_id = ?`)
+				.bind(initial.group_id, _opts.deviceId),
+		);
+		if (
+			existingEnrollment &&
+			(existingEnrollment.public_key !== _opts.publicKey ||
+				existingEnrollment.fingerprint !== _opts.fingerprint)
+		) {
+			throw new Error("invite_identity_conflict");
+		}
+		let changed = 0;
+		if (!initial.consumed_at) {
+			if (!this.db.batch)
+				throw new Error("D1 batch support is required for atomic invite consume.");
+			const results = await this.db.batch([
+				this.db
+					.prepare(`UPDATE coordinator_invites SET token = ?, consumed_at = ?, bound_device_id = ?,
+						bound_public_key = ?, bound_fingerprint = ?, recipient_actor_id = ?
+						WHERE (token_digest = ? OR token = ?) AND consumed_at IS NULL
+						AND revoked_at IS NULL AND expires_at > ? AND invite_kind = ?
+						AND reviewed_intent_json = ? AND reviewed_preview_digest = ?
+						AND EXISTS (SELECT 1 FROM groups g WHERE g.group_id = coordinator_invites.group_id
+							AND g.archived_at IS NULL)`)
+					.bind(
+						`consumed:${initial.invite_id}`,
+						consumedAt,
+						_opts.deviceId,
+						_opts.publicKey,
+						_opts.fingerprint,
+						_opts.identityId,
+						digest,
+						_opts.token,
+						consumedAt,
+						_opts.inviteKind,
+						initial.reviewed_intent_json,
+						initial.reviewed_preview_digest,
+					),
+				this.db
+					.prepare(`INSERT INTO enrolled_devices(
+						group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+					) SELECT i.group_id, i.bound_device_id, i.bound_public_key, i.bound_fingerprint,
+						NULL, 1, ? FROM coordinator_invites i
+					JOIN groups g ON g.group_id = i.group_id AND g.archived_at IS NULL
+					WHERE (i.token_digest = ? OR i.token = ?) AND i.bound_device_id = ?
+						AND i.bound_public_key = ? AND i.bound_fingerprint = ?
+					ON CONFLICT(group_id, device_id) DO UPDATE SET enabled = 1`)
+					.bind(
+						consumedAt,
+						digest,
+						_opts.token,
+						_opts.deviceId,
+						_opts.publicKey,
+						_opts.fingerprint,
+					),
+			]);
+			changed = batchResultChanges(results[0]);
+		}
 		const currentGroup = await this.getGroup(initial.group_id);
 		if (!currentGroup) throw new Error("group_not_found");
 		if (currentGroup.archived_at) throw new Error("group_archived");
@@ -1016,6 +1105,10 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		) {
 			throw new Error("invite_invalid");
 		}
+		const savedInspection = await recipientInspection(saved);
+		if (!savedInspection || savedInspection.kind !== _opts.inviteKind) {
+			throw new Error("invite_invalid");
+		}
 		if (
 			saved.bound_device_id !== _opts.deviceId ||
 			saved.bound_public_key !== _opts.publicKey ||
@@ -1024,7 +1117,16 @@ export class D1CoordinatorStore implements CoordinatorStore {
 			throw new Error("invite_already_bound");
 		}
 		if (saved.recipient_actor_id !== _opts.identityId) throw new Error("invite_identity_conflict");
-		return { status: changed === 1 ? "accepted" : "existing", invite: saved };
+		const enrollment = await this.getEnrollment(saved.group_id, _opts.deviceId);
+		if (!enrollment) throw new Error("invite_acceptance_incomplete");
+		if (enrollment.public_key !== _opts.publicKey || enrollment.fingerprint !== _opts.fingerprint) {
+			throw new Error("invite_identity_conflict");
+		}
+		return {
+			status: changed === 1 ? "accepted" : "existing",
+			invite: saved,
+			reviewed_intent: savedInspection.reviewed_intent,
+		};
 	}
 
 	async consumeProjectInvite(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -640,11 +640,16 @@ export type {
 	RecipientPolicyOnboardingPreviewV1,
 	RecipientPolicyOnboardingProjectSourceV1,
 	RecipientPolicyOnboardingProjectV1,
+	RecipientPolicyReviewedIntentCommitRequestV1,
+	RecipientPolicyReviewedIntentPreviewRequestV1,
 	RecipientPolicyTeamOnboardingRequestV1,
 } from "./recipient-policy-onboarding.js";
 export {
+	assertAddDeviceIdentityAdoptionAllowed,
 	commitRecipientPolicyOnboarding,
+	commitRecipientPolicyOnboardingFromReviewedIntent,
 	previewRecipientPolicyOnboarding,
+	previewRecipientPolicyOnboardingFromReviewedIntent,
 	RecipientPolicyOnboardingRequestError,
 } from "./recipient-policy-onboarding.js";
 export type {
@@ -714,6 +719,22 @@ export {
 	resolveRecipientPolicyReview,
 	resolveRecipientPolicyReviewBulk,
 } from "./recipient-policy-review.js";
+export type {
+	RecipientReviewedIntentExcludedProjectV1,
+	RecipientReviewedIntentProjectSourceV1,
+	RecipientReviewedIntentProjectV1,
+	RecipientReviewedIntentTargetV1,
+	RecipientReviewedIntentV1,
+} from "./recipient-reviewed-intent.js";
+export {
+	canonicalRecipientReviewedIntentJson,
+	normalizeRecipientReviewedIntent,
+	parseStoredRecipientReviewedIntent,
+	RECIPIENT_REVIEWED_INTENT_VERSION,
+	RecipientReviewedIntentError,
+	recipientReviewedIntentDigest,
+	verifyRecipientReviewedIntent,
+} from "./recipient-reviewed-intent.js";
 export {
 	hasPendingRefBackfill,
 	REF_BACKFILL_JOB,

--- a/packages/core/src/recipient-policy-onboarding.test.ts
+++ b/packages/core/src/recipient-policy-onboarding.test.ts
@@ -4,9 +4,13 @@ import { listRecipientPolicyIntent } from "./recipient-policy-intent.js";
 import {
 	commitDirectProjectSharePolicyInTransaction,
 	commitRecipientPolicyOnboarding,
+	commitRecipientPolicyOnboardingFromReviewedIntent,
 	previewRecipientPolicyOnboarding,
+	previewRecipientPolicyOnboardingFromReviewedIntent,
 	type RecipientPolicyOnboardingPreviewRequestV1,
+	type RecipientPolicyReviewedIntentPreviewRequestV1,
 } from "./recipient-policy-onboarding.js";
+import type { RecipientReviewedIntentV1 } from "./recipient-reviewed-intent.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 import { initTestSchema } from "./test-utils.js";
 
@@ -118,6 +122,12 @@ function baseRequest(
 	} as RecipientPolicyOnboardingPreviewRequestV1;
 }
 
+function reviewedIntentRequest(
+	overrides: Partial<RecipientPolicyOnboardingPreviewRequestV1> = {},
+): RecipientPolicyReviewedIntentPreviewRequestV1 {
+	return baseRequest(overrides) as RecipientPolicyReviewedIntentPreviewRequestV1;
+}
+
 function protectedSnapshot(db: InstanceType<typeof Database>): string {
 	const tables = [
 		"replication_scopes",
@@ -137,6 +147,44 @@ function protectedSnapshot(db: InstanceType<typeof Database>): string {
 			tables.map((table) => [table, db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all()]),
 		),
 	);
+}
+
+function teamReviewedIntent(): Extract<RecipientReviewedIntentV1, { journey: "team" }> {
+	return {
+		version: 1,
+		journey: "team",
+		team: { teamId: "team-fresh", displayName: "Fresh Team", futureProjectsInherit: true },
+		projects: [
+			{
+				canonicalProjectIdentity: PROJECT_A,
+				displayName: "alpha",
+				existingMemoryCount: 2,
+				futureMemoriesShared: true,
+				sources: [{ kind: "team", teamId: "team-fresh", displayName: "Fresh Team" }],
+			},
+		],
+		excludedProjects: [
+			{ canonicalProjectIdentity: PROJECT_B, displayName: "beta", existingMemoryCount: 1 },
+		],
+	};
+}
+
+function addDeviceReviewedIntent(): Extract<RecipientReviewedIntentV1, { journey: "add_device" }> {
+	return {
+		version: 1,
+		journey: "add_device",
+		targetIdentity: { identityId: "identity-existing", displayName: "Existing Person" },
+		projects: [
+			{
+				canonicalProjectIdentity: PROJECT_A,
+				displayName: "alpha",
+				existingMemoryCount: 2,
+				futureMemoriesShared: true,
+				sources: [{ kind: "direct" }],
+			},
+		],
+		excludedProjects: [],
+	};
 }
 
 describe("recipient-policy onboarding", () => {
@@ -160,6 +208,407 @@ describe("recipient-policy onboarding", () => {
 	});
 
 	afterEach(() => db.close());
+
+	it("builds fresh Team and add-device previews only from reviewed intent and local binding", () => {
+		const fresh = new Database(":memory:");
+		initTestSchema(fresh);
+		try {
+			const team = previewRecipientPolicyOnboardingFromReviewedIntent(
+				teamReviewedIntent(),
+				reviewedIntentRequest({
+					journey: "team",
+					invitationId: "fresh-team",
+					identityId: "identity-fresh",
+					teamId: "team-fresh",
+				}),
+			);
+			const addDevice = previewRecipientPolicyOnboardingFromReviewedIntent(
+				addDeviceReviewedIntent(),
+				reviewedIntentRequest({ identityId: "identity-existing" }),
+			);
+
+			expect(team).toMatchObject({
+				journey: "team",
+				team: { teamId: "team-fresh", displayName: "Fresh Team" },
+				projects: [{ canonicalProjectIdentity: PROJECT_A, existingMemoryCount: 2 }],
+			});
+			expect(addDevice).toMatchObject({
+				journey: "add_device",
+				binding: { identityId: "identity-existing" },
+				projects: [{ canonicalProjectIdentity: PROJECT_A, sources: [{ kind: "direct" }] }],
+			});
+			expect(fresh.prepare("SELECT COUNT(*) FROM actors").pluck().get()).toBe(0);
+			expect(fresh.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+		} finally {
+			fresh.close();
+		}
+	});
+
+	it("atomically materializes and replays the minimum fresh Team graph", () => {
+		const fresh = new Database(":memory:");
+		initTestSchema(fresh);
+		try {
+			const request = reviewedIntentRequest({
+				journey: "team",
+				invitationId: "fresh-team",
+				identityId: "identity-fresh",
+				teamId: "team-fresh",
+			});
+			const intent = teamReviewedIntent();
+			const preview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, request);
+			const commitRequest = {
+				...request,
+				identityDisplayName: "Fresh Person",
+				reviewedIntent: intent,
+				reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+			};
+
+			const first = commitRecipientPolicyOnboardingFromReviewedIntent(fresh, commitRequest, {
+				now: () => NOW,
+			});
+			const replay = commitRecipientPolicyOnboardingFromReviewedIntent(fresh, commitRequest, {
+				now: () => "2026-07-21T13:00:00.000Z",
+			});
+
+			expect(first).toMatchObject({ status: "applied", writeCount: 4, idempotent: false });
+			expect(replay).toMatchObject({ status: "applied", writeCount: 0, idempotent: true });
+			expect(fresh.prepare("SELECT actor_id, is_local FROM actors").all()).toEqual([
+				{ actor_id: "identity-fresh", is_local: 1 },
+			]);
+			expect(fresh.prepare("SELECT team_id FROM policy_teams").pluck().all()).toEqual([
+				"team-fresh",
+			]);
+			expect(
+				fresh.prepare("SELECT team_id, identity_id FROM policy_team_memberships").all(),
+			).toEqual([{ team_id: "team-fresh", identity_id: "identity-fresh" }]);
+			expect(fresh.prepare("SELECT identity_id FROM identity_devices").pluck().get()).toBe(
+				"identity-fresh",
+			);
+			expect(fresh.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(0);
+		} finally {
+			fresh.close();
+		}
+	});
+
+	it("keeps a zero-reference bootstrap Identity pristine with a human-friendly display name", () => {
+		const fresh = new Database(":memory:");
+		initTestSchema(fresh);
+		insertActor(fresh, "local:device-new", "Ada", true);
+		try {
+			const request = reviewedIntentRequest({ identityId: "identity-existing" });
+			const intent = addDeviceReviewedIntent();
+			const preview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, request);
+
+			const result = commitRecipientPolicyOnboardingFromReviewedIntent(
+				fresh,
+				{
+					...request,
+					identityDisplayName: "Ignored local name",
+					reviewedIntent: intent,
+					reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+				},
+				{ now: () => NOW },
+			);
+			const replay = commitRecipientPolicyOnboardingFromReviewedIntent(
+				fresh,
+				{
+					...request,
+					identityDisplayName: "Ignored local name",
+					reviewedIntent: intent,
+					reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+				},
+				{ now: () => "2026-07-21T13:00:00.000Z" },
+			);
+
+			expect(result).toMatchObject({ status: "applied", writeCount: 2 });
+			expect(replay).toMatchObject({ status: "applied", writeCount: 0, idempotent: true });
+			expect(
+				fresh
+					.prepare(
+						"SELECT actor_id, is_local, status, merged_into_actor_id FROM actors ORDER BY actor_id",
+					)
+					.all(),
+			).toEqual([
+				{
+					actor_id: "identity-existing",
+					is_local: 1,
+					status: "active",
+					merged_into_actor_id: null,
+				},
+				{
+					actor_id: "local:device-new",
+					is_local: 0,
+					status: "merged",
+					merged_into_actor_id: "identity-existing",
+				},
+			]);
+		} finally {
+			fresh.close();
+		}
+	});
+
+	it("adopts and replays a truly empty actorless bootstrap", () => {
+		const fresh = new Database(":memory:");
+		initTestSchema(fresh);
+		try {
+			const request = reviewedIntentRequest({ identityId: "identity-existing" });
+			const intent = addDeviceReviewedIntent();
+			const preview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, request);
+			const commitRequest = {
+				...request,
+				identityDisplayName: "Existing Person",
+				reviewedIntent: intent,
+				reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+			};
+
+			const first = commitRecipientPolicyOnboardingFromReviewedIntent(fresh, commitRequest, {
+				now: () => NOW,
+			});
+			const replay = commitRecipientPolicyOnboardingFromReviewedIntent(fresh, commitRequest, {
+				now: () => "2026-07-21T13:00:00.000Z",
+			});
+
+			expect(first).toMatchObject({ status: "applied", writeCount: 2, idempotent: false });
+			expect(replay).toMatchObject({ status: "applied", writeCount: 0, idempotent: true });
+			expect(fresh.prepare("SELECT actor_id, is_local, status FROM actors").all()).toEqual([
+				{ actor_id: "identity-existing", is_local: 1, status: "active" },
+			]);
+			expect(fresh.prepare("SELECT identity_id FROM identity_devices").pluck().get()).toBe(
+				"identity-existing",
+			);
+		} finally {
+			fresh.close();
+		}
+	});
+
+	it("rejects add-device adoption when fallback-actor memories exist without an actor row", () => {
+		const fresh = new Database(":memory:");
+		initTestSchema(fresh);
+		insertProject(fresh, PROJECT_A, "alpha", 1);
+		fresh.prepare("UPDATE memory_items SET actor_id = ?").run("local:device-new");
+		try {
+			const request = reviewedIntentRequest({ identityId: "identity-existing" });
+			const intent = addDeviceReviewedIntent();
+			const preview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, request);
+
+			expect(
+				commitRecipientPolicyOnboardingFromReviewedIntent(fresh, {
+					...request,
+					identityDisplayName: "Existing Person",
+					reviewedIntent: intent,
+					reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+				}),
+			).toMatchObject({ status: "conflict", errorCode: "invite_identity_conflict", writeCount: 0 });
+			expect(fresh.prepare("SELECT COUNT(*) FROM actors").pluck().get()).toBe(0);
+			expect(fresh.prepare("SELECT actor_id FROM memory_items").pluck().get()).toBe(
+				"local:device-new",
+			);
+			expect(fresh.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+		} finally {
+			fresh.close();
+		}
+	});
+
+	it.each([
+		["an actor assignment", "local:device-new", 0],
+		["a claimed-local assignment", null, 1],
+	] as const)("rejects add-device adoption when a sync peer has %s", (_name, peerActorId, claimed) => {
+		const fresh = new Database(":memory:");
+		initTestSchema(fresh);
+		insertActor(fresh, "local:device-new", "Ada", true);
+		fresh
+			.prepare(
+				`INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at)
+				 VALUES (?, ?, ?, ?)`,
+			)
+			.run("peer-device", peerActorId, claimed, NOW);
+		try {
+			const request = reviewedIntentRequest({ identityId: "identity-existing" });
+			const intent = addDeviceReviewedIntent();
+			const preview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, request);
+
+			expect(
+				commitRecipientPolicyOnboardingFromReviewedIntent(fresh, {
+					...request,
+					identityDisplayName: "Ada",
+					reviewedIntent: intent,
+					reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+				}),
+			).toMatchObject({ status: "conflict", errorCode: "invite_identity_conflict", writeCount: 0 });
+			expect(
+				fresh
+					.prepare("SELECT is_local, status, merged_into_actor_id FROM actors WHERE actor_id = ?")
+					.get("local:device-new"),
+			).toEqual({ is_local: 1, status: "active", merged_into_actor_id: null });
+		} finally {
+			fresh.close();
+		}
+	});
+
+	it("rejects established-profile adoption without writes", () => {
+		const fresh = new Database(":memory:");
+		initTestSchema(fresh);
+		insertActor(fresh, "local:device-new", "Established Person", true);
+		insertTeam(fresh, "team-established", "Established Team");
+		insertMembership(fresh, "team-established", "local:device-new");
+		try {
+			const request = reviewedIntentRequest({ identityId: "identity-existing" });
+			const intent = addDeviceReviewedIntent();
+			const preview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, request);
+
+			expect(
+				commitRecipientPolicyOnboardingFromReviewedIntent(fresh, {
+					...request,
+					identityDisplayName: "Established Person",
+					reviewedIntent: intent,
+					reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+				}),
+			).toMatchObject({ status: "conflict", errorCode: "invite_identity_conflict", writeCount: 0 });
+			expect(fresh.prepare("SELECT actor_id FROM actors").pluck().all()).toEqual([
+				"local:device-new",
+			]);
+			expect(fresh.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+		} finally {
+			fresh.close();
+		}
+	});
+
+	it("rolls back add-device adoption when identity-device insertion fails", () => {
+		const fresh = new Database(":memory:");
+		initTestSchema(fresh);
+		insertActor(fresh, "local:device-new", "Ada", true);
+		try {
+			const request = reviewedIntentRequest({ identityId: "identity-existing" });
+			const intent = addDeviceReviewedIntent();
+			const preview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, request);
+			const commitRequest = {
+				...request,
+				identityDisplayName: "Ada",
+				reviewedIntent: intent,
+				reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+			};
+			fresh.exec(`CREATE TRIGGER fail_add_device_binding BEFORE INSERT ON identity_devices
+				BEGIN SELECT RAISE(ABORT, 'test identity-device failure'); END`);
+
+			expect(commitRecipientPolicyOnboardingFromReviewedIntent(fresh, commitRequest)).toMatchObject(
+				{
+					status: "conflict",
+					writeCount: 0,
+				},
+			);
+			expect(
+				fresh.prepare("SELECT actor_id, is_local, status, merged_into_actor_id FROM actors").all(),
+			).toEqual([
+				{
+					actor_id: "local:device-new",
+					is_local: 1,
+					status: "active",
+					merged_into_actor_id: null,
+				},
+			]);
+			expect(fresh.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+
+			fresh.exec("DROP TRIGGER fail_add_device_binding");
+			expect(commitRecipientPolicyOnboardingFromReviewedIntent(fresh, commitRequest)).toMatchObject(
+				{
+					status: "applied",
+					writeCount: 2,
+				},
+			);
+			expect(
+				fresh
+					.prepare("SELECT identity_id FROM identity_devices WHERE device_id = ?")
+					.pluck()
+					.get("device-new"),
+			).toBe("identity-existing");
+		} finally {
+			fresh.close();
+		}
+	});
+
+	it("rejects snapshot digest and device-key conflicts atomically", () => {
+		const fresh = new Database(":memory:");
+		initTestSchema(fresh);
+		try {
+			const request = reviewedIntentRequest({
+				journey: "team",
+				invitationId: "fresh-team",
+				identityId: "identity-fresh",
+				teamId: "team-fresh",
+			});
+			const intent = teamReviewedIntent();
+			const preview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, request);
+			const invalid = commitRecipientPolicyOnboardingFromReviewedIntent(fresh, {
+				...request,
+				identityDisplayName: "Fresh Person",
+				reviewedIntent: { ...intent, team: { ...intent.team, displayName: "Tampered" } },
+				reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+			});
+			expect(invalid).toMatchObject({
+				status: "stale",
+				errorCode: "reviewed_onboarding_stale",
+			});
+			expect(fresh.prepare("SELECT COUNT(*) FROM actors").pluck().get()).toBe(0);
+
+			commitRecipientPolicyOnboardingFromReviewedIntent(fresh, {
+				...request,
+				identityDisplayName: "Fresh Person",
+				reviewedIntent: intent,
+				reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+			});
+			const changedKey = {
+				...request,
+				invitationId: "fresh-team-two",
+				devicePublicKey: "other-key",
+			};
+			const changedPreview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, changedKey);
+			expect(
+				commitRecipientPolicyOnboardingFromReviewedIntent(fresh, {
+					...changedKey,
+					identityDisplayName: "Fresh Person",
+					reviewedIntent: intent,
+					reviewedOnboardingDigest: changedPreview.reviewedOnboardingDigest,
+				}),
+			).toMatchObject({
+				status: "conflict",
+				errorCode: "device_binding_conflict",
+				writeCount: 0,
+			});
+			expect(fresh.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(1);
+		} finally {
+			fresh.close();
+		}
+	});
+
+	it("rolls back snapshot materialization when a later row fails", () => {
+		const fresh = new Database(":memory:");
+		initTestSchema(fresh);
+		try {
+			const request = reviewedIntentRequest({
+				journey: "team",
+				identityId: "identity-fresh",
+				teamId: "team-fresh",
+			});
+			const intent = teamReviewedIntent();
+			const preview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, request);
+			fresh.exec(`CREATE TRIGGER fail_fresh_membership BEFORE INSERT ON policy_team_memberships
+				BEGIN SELECT RAISE(ABORT, 'test conflict'); END`);
+
+			expect(
+				commitRecipientPolicyOnboardingFromReviewedIntent(fresh, {
+					...request,
+					identityDisplayName: "Fresh Person",
+					reviewedIntent: intent,
+					reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+				}),
+			).toMatchObject({ status: "conflict", writeCount: 0 });
+			expect(fresh.prepare("SELECT COUNT(*) FROM actors").pluck().get()).toBe(0);
+			expect(fresh.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+			expect(fresh.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+		} finally {
+			fresh.close();
+		}
+	});
 
 	it("previews Team Projects, memory counts, exclusions, and future inheritance without writes", () => {
 		const request = baseRequest({

--- a/packages/core/src/recipient-policy-onboarding.ts
+++ b/packages/core/src/recipient-policy-onboarding.ts
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto";
 import type { Database } from "./db.js";
 import { normalizeIdentityDisplayName } from "./project-invite-identity.js";
+import {
+	normalizeRecipientReviewedIntent,
+	type RecipientReviewedIntentV1,
+} from "./recipient-reviewed-intent.js";
 import { canonicalWorkspaceIdentity } from "./scope-resolution.js";
 import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
@@ -49,6 +53,17 @@ export type RecipientPolicyOnboardingPreviewRequestV1 =
 export type RecipientPolicyOnboardingCommitRequestV1 = RecipientPolicyOnboardingPreviewRequestV1 & {
 	reviewedOnboardingDigest: string;
 };
+
+export type RecipientPolicyReviewedIntentPreviewRequestV1 =
+	| RecipientPolicyTeamOnboardingRequestV1
+	| RecipientPolicyAddDeviceOnboardingRequestV1;
+
+export type RecipientPolicyReviewedIntentCommitRequestV1 =
+	RecipientPolicyReviewedIntentPreviewRequestV1 & {
+		identityDisplayName: string;
+		reviewedIntent: RecipientReviewedIntentV1;
+		reviewedOnboardingDigest: string;
+	};
 
 export type RecipientPolicyOnboardingProjectSourceV1 =
 	| { kind: "direct" }
@@ -478,6 +493,52 @@ export function previewRecipientPolicyOnboarding(
 	return buildPreview(db, normalizeRequest(request));
 }
 
+function reviewedIntentTarget(request: NormalizedRequest) {
+	if (request.journey === "team") {
+		return { kind: "team_member" as const, policyTeamId: request.teamId };
+	}
+	if (request.journey === "add_device") {
+		return { kind: "add_device" as const, targetIdentityId: request.binding.identityId };
+	}
+	throw new RecipientPolicyOnboardingRequestError("invalid", "journey_invalid");
+}
+
+function buildReviewedIntentPreview(
+	request: NormalizedRequest,
+	reviewedIntentValue: RecipientReviewedIntentV1,
+): RecipientPolicyOnboardingPreviewV1 {
+	const reviewedIntent = normalizeRecipientReviewedIntent(
+		reviewedIntentValue,
+		reviewedIntentTarget(request),
+	);
+	const team = reviewedIntent.journey === "team" ? reviewedIntent.team : null;
+	const reviewedOnboardingDigest = digest("recipient-onboarding-preview-v1", {
+		journey: request.journey,
+		binding: request.binding,
+		team,
+		projects: reviewedIntent.projects,
+		excludedProjectIdentities: reviewedIntent.excludedProjects.map(
+			(project) => project.canonicalProjectIdentity,
+		),
+	});
+	return {
+		version: 1,
+		journey: request.journey,
+		binding: request.binding,
+		team,
+		projects: reviewedIntent.projects,
+		excludedProjects: reviewedIntent.excludedProjects,
+		reviewedOnboardingDigest,
+	};
+}
+
+export function previewRecipientPolicyOnboardingFromReviewedIntent(
+	reviewedIntent: RecipientReviewedIntentV1,
+	request: RecipientPolicyReviewedIntentPreviewRequestV1,
+): RecipientPolicyOnboardingPreviewV1 {
+	return buildReviewedIntentPreview(normalizeRequest(request), reviewedIntent);
+}
+
 function relationshipMetadata(
 	kind: string,
 	revisionIdentity: unknown,
@@ -662,6 +723,182 @@ function planRows(request: NormalizedRequest, now: string): IntentRow[] {
 		);
 	}
 	return rows;
+}
+
+function isPristineBootstrapIdentity(
+	db: Database,
+	identityId: string,
+	deviceId: string,
+	targetIdentityId: string,
+): boolean {
+	if (identityId !== `local:${deviceId}`) return false;
+	const actor = db
+		.prepare(
+			`SELECT is_local, status, merged_into_actor_id
+			 FROM actors WHERE actor_id = ?`,
+		)
+		.get(identityId) as
+		| {
+				is_local: number;
+				status: string;
+				merged_into_actor_id: string | null;
+		  }
+		| undefined;
+	const pristineActor =
+		!actor ||
+		(actor.is_local === 1 && actor.status === "active" && actor.merged_into_actor_id === null);
+	const alreadyAdoptedActor =
+		actor?.is_local === 0 &&
+		actor.status === "merged" &&
+		actor.merged_into_actor_id === targetIdentityId;
+	if (!pristineActor && !alreadyAdoptedActor) return false;
+	const references = [
+		Number(
+			db.prepare("SELECT COUNT(*) FROM memory_items WHERE actor_id = ?").pluck().get(identityId),
+		),
+		Number(
+			db
+				.prepare("SELECT COUNT(*) FROM identity_devices WHERE identity_id = ?")
+				.pluck()
+				.get(identityId),
+		),
+		Number(
+			db
+				.prepare("SELECT COUNT(*) FROM policy_team_memberships WHERE identity_id = ?")
+				.pluck()
+				.get(identityId),
+		),
+		Number(
+			db
+				.prepare(
+					`SELECT COUNT(*) FROM project_recipients
+					 WHERE recipient_kind = 'identity' AND recipient_id = ?`,
+				)
+				.pluck()
+				.get(identityId),
+		),
+		Number(
+			db
+				.prepare(
+					"SELECT COUNT(*) FROM recipient_policy_review_resolutions WHERE decided_by_identity_id = ?",
+				)
+				.pluck()
+				.get(identityId),
+		),
+		Number(
+			db
+				.prepare("SELECT COUNT(*) FROM sync_peers WHERE actor_id = ? OR claimed_local_actor = 1")
+				.pluck()
+				.get(identityId),
+		),
+	];
+	return references.every((count) => count === 0);
+}
+
+export function assertAddDeviceIdentityAdoptionAllowed(
+	db: Database,
+	targetIdentityId: string,
+	deviceId: string,
+): void {
+	const targetId = strictId(targetIdentityId, "identity_id", 256);
+	const localDeviceId = strictId(deviceId, "device_id", 256);
+	const localIdentities = new Set([
+		...(db
+			.prepare(
+				`SELECT actor_id FROM actors
+			 WHERE is_local = 1 AND status = 'active' AND merged_into_actor_id IS NULL
+			 ORDER BY actor_id`,
+			)
+			.pluck()
+			.all() as string[]),
+		`local:${localDeviceId}`,
+	]);
+	const target = db
+		.prepare("SELECT is_local, status, merged_into_actor_id FROM actors WHERE actor_id = ?")
+		.get(targetId) as
+		| { is_local: number; status: string; merged_into_actor_id: string | null }
+		| undefined;
+	if (
+		target &&
+		(target.is_local !== 1 || target.status !== "active" || target.merged_into_actor_id)
+	) {
+		throw new Error("invite_identity_conflict");
+	}
+	for (const identityId of localIdentities) {
+		if (identityId === targetId) continue;
+		if (!isPristineBootstrapIdentity(db, identityId, localDeviceId, targetId)) {
+			throw new Error("invite_identity_conflict");
+		}
+	}
+}
+
+function materializeLocalIdentity(
+	db: Database,
+	input: {
+		identityId: string;
+		displayName: string;
+		deviceId: string;
+		allowBootstrapAdoption: boolean;
+	},
+	now: string,
+): boolean {
+	if (input.allowBootstrapAdoption) {
+		assertAddDeviceIdentityAdoptionAllowed(db, input.identityId, input.deviceId);
+		db.prepare(
+			`UPDATE actors SET is_local = 0, status = 'merged', merged_into_actor_id = ?, updated_at = ?
+			 WHERE actor_id <> ? AND is_local = 1 AND status = 'active'`,
+		).run(input.identityId, now, input.identityId);
+	}
+	const existing = db
+		.prepare("SELECT is_local, status, merged_into_actor_id FROM actors WHERE actor_id = ?")
+		.get(input.identityId) as
+		| { is_local: number; status: string; merged_into_actor_id: string | null }
+		| undefined;
+	if (existing) {
+		if (existing.is_local !== 1 || existing.status !== "active" || existing.merged_into_actor_id) {
+			throw new Error("invite_identity_conflict");
+		}
+		return false;
+	}
+	db.prepare(
+		`INSERT INTO actors(
+		 actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+		 ) VALUES (?, ?, 1, 'active', NULL, ?, ?)`,
+	).run(input.identityId, input.displayName, now, now);
+	return true;
+}
+
+function materializeReviewedTeam(
+	db: Database,
+	team: { teamId: string; displayName: string; futureProjectsInherit: true },
+	now: string,
+): boolean {
+	const existing = db
+		.prepare("SELECT display_name, status FROM policy_teams WHERE team_id = ?")
+		.get(team.teamId) as { display_name: string; status: string } | undefined;
+	if (existing) {
+		if (existing.display_name !== team.displayName || existing.status !== "active") {
+			throw new Error("intent_conflict");
+		}
+		return false;
+	}
+	const stableTeam = { teamId: team.teamId, displayName: team.displayName };
+	const metadata = relationshipMetadata("team", stableTeam, stableTeam);
+	db.prepare(
+		`INSERT INTO policy_teams(
+		 team_id, display_name, status, provenance, revision, migration_state,
+		 source_fingerprint, idempotency_key, created_at, updated_at
+		 ) VALUES (?, ?, 'active', 'team_invite', ?, 'user_managed', ?, ?, ?, ?)`,
+	).run(
+		team.teamId,
+		team.displayName,
+		metadata.revision,
+		digest("recipient-onboarding-team-v1", stableTeam),
+		metadata.idempotencyKey,
+		now,
+		now,
+	);
+	return true;
 }
 
 function rowWhere(key: Record<string, string>): { clause: string; parameters: string[] } {
@@ -898,6 +1135,102 @@ export function commitRecipientPolicyOnboarding(
 			error instanceof Error && error.message === "device_binding_conflict"
 				? "device_binding_conflict"
 				: "onboarding_intent_conflict";
+		return emptyResult("conflict", errorCode, normalized.journey, request.reviewedOnboardingDigest);
+	}
+}
+
+export function commitRecipientPolicyOnboardingFromReviewedIntent(
+	db: Database,
+	request: RecipientPolicyReviewedIntentCommitRequestV1,
+	options: { now?: () => string } = {},
+): RecipientPolicyOnboardingCommitResultV1 {
+	let normalized: NormalizedRequest;
+	try {
+		normalized = normalizeRequest(request);
+		if (normalized.journey === "direct_project") {
+			return emptyResult("invalid", "journey_invalid", normalized.journey, "");
+		}
+	} catch (error) {
+		if (error instanceof RecipientPolicyOnboardingRequestError) {
+			return emptyResult(error.status, error.errorCode, null, "");
+		}
+		return emptyResult("invalid", "request_invalid", null, "");
+	}
+	if (!/^recipient-onboarding-preview-v1:[a-f0-9]{64}$/u.test(request.reviewedOnboardingDigest)) {
+		return emptyResult("invalid", "reviewed_onboarding_digest_invalid", normalized.journey, "");
+	}
+	try {
+		db.exec("BEGIN IMMEDIATE");
+		try {
+			const reviewedIntent = normalizeRecipientReviewedIntent(
+				request.reviewedIntent,
+				reviewedIntentTarget(normalized),
+			);
+			const preview = buildReviewedIntentPreview(normalized, reviewedIntent);
+			if (preview.reviewedOnboardingDigest !== request.reviewedOnboardingDigest) {
+				db.exec("ROLLBACK");
+				return emptyResult(
+					"stale",
+					"reviewed_onboarding_stale",
+					normalized.journey,
+					preview.reviewedOnboardingDigest,
+				);
+			}
+			const now = (options.now ?? (() => new Date().toISOString()))();
+			const identityDisplayName =
+				normalized.journey === "add_device" && reviewedIntent.journey === "add_device"
+					? reviewedIntent.targetIdentity.displayName
+					: normalizeIdentityDisplayName(request.identityDisplayName, "identity_display_name");
+			let writeCount = materializeLocalIdentity(
+				db,
+				{
+					identityId: normalized.binding.identityId,
+					displayName: identityDisplayName,
+					deviceId: normalized.binding.deviceId,
+					allowBootstrapAdoption: normalized.journey === "add_device",
+				},
+				now,
+			)
+				? 1
+				: 0;
+			if (normalized.journey === "team") {
+				if (reviewedIntent.journey !== "team") throw new Error("intent_conflict");
+				if (materializeReviewedTeam(db, reviewedIntent.team, now)) writeCount += 1;
+			}
+			for (const row of planRows(normalized, now)) {
+				if (validateOrWriteRow(db, row)) writeCount += 1;
+			}
+			db.exec("COMMIT");
+			return {
+				version: 1,
+				status: "applied",
+				journey: normalized.journey,
+				reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+				errorCode: null,
+				writeCount,
+				idempotent: writeCount === 0,
+			};
+		} catch (error) {
+			if (db.inTransaction) db.exec("ROLLBACK");
+			throw error;
+		}
+	} catch (error) {
+		if (isSqliteBusy(error)) throw error;
+		if (error instanceof RecipientPolicyOnboardingRequestError) {
+			return emptyResult(
+				error.status,
+				error.errorCode,
+				normalized.journey,
+				request.reviewedOnboardingDigest,
+			);
+		}
+		const message = error instanceof Error ? error.message : "";
+		const errorCode =
+			message === "device_binding_conflict"
+				? "device_binding_conflict"
+				: message === "invite_identity_conflict"
+					? "invite_identity_conflict"
+					: "onboarding_intent_conflict";
 		return emptyResult("conflict", errorCode, normalized.journey, request.reviewedOnboardingDigest);
 	}
 }

--- a/packages/core/src/recipient-reviewed-intent.test.ts
+++ b/packages/core/src/recipient-reviewed-intent.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import {
+	canonicalRecipientReviewedIntentJson,
+	normalizeRecipientReviewedIntent,
+	parseStoredRecipientReviewedIntent,
+	recipientReviewedIntentDigest,
+	verifyRecipientReviewedIntent,
+} from "./recipient-reviewed-intent.js";
+
+const PROJECT_A = "git:https://example.test/acme/alpha";
+const PROJECT_B = "git:https://example.test/acme/beta";
+
+function teamIntent() {
+	return {
+		version: 1,
+		journey: "team",
+		team: { teamId: "team-core", displayName: "Core Team", futureProjectsInherit: true },
+		projects: [
+			{
+				canonicalProjectIdentity: PROJECT_B,
+				displayName: "Beta",
+				existingMemoryCount: 2,
+				futureMemoriesShared: true,
+				sources: [{ kind: "team", teamId: "team-core", displayName: "Core Team" }],
+			},
+			{
+				canonicalProjectIdentity: PROJECT_A,
+				displayName: "Alpha",
+				existingMemoryCount: 3,
+				futureMemoriesShared: true,
+				sources: [
+					{ kind: "team", teamId: "team-z", displayName: "Zeta" },
+					{ kind: "team", teamId: "team-core", displayName: "Core Team" },
+				],
+			},
+		],
+		excludedProjects: [
+			{
+				canonicalProjectIdentity: "git:https://example.test/acme/excluded",
+				displayName: "Excluded",
+				existingMemoryCount: 1,
+			},
+		],
+	};
+}
+
+function addDeviceIntent() {
+	return {
+		version: 1,
+		journey: "add_device",
+		targetIdentity: { identityId: "identity-ada", displayName: "Ada" },
+		projects: [
+			{
+				canonicalProjectIdentity: PROJECT_A,
+				displayName: "Alpha",
+				existingMemoryCount: 3,
+				futureMemoriesShared: true,
+				sources: [{ kind: "direct" }],
+			},
+		],
+		excludedProjects: [],
+	};
+}
+
+describe("recipient reviewed intent", () => {
+	it("normalizes valid Team and add-device reviewed intents", () => {
+		const team = normalizeRecipientReviewedIntent(teamIntent());
+		const addDevice = normalizeRecipientReviewedIntent(addDeviceIntent());
+
+		expect(team).toMatchObject({ version: 1, journey: "team", team: { teamId: "team-core" } });
+		expect(addDevice).toMatchObject({
+			version: 1,
+			journey: "add_device",
+			targetIdentity: { identityId: "identity-ada" },
+		});
+	});
+
+	it("canonicalizes project and source ordering before digesting", async () => {
+		const reversed = teamIntent();
+		reversed.projects.reverse();
+		reversed.projects[1]?.sources.reverse();
+
+		expect(canonicalRecipientReviewedIntentJson(reversed)).toBe(
+			canonicalRecipientReviewedIntentJson(teamIntent()),
+		);
+		expect(await recipientReviewedIntentDigest(reversed)).toBe(
+			await recipientReviewedIntentDigest(teamIntent()),
+		);
+	});
+
+	it("accepts more than 100 presentation-only excluded Projects within the byte limit", () => {
+		const input = {
+			...teamIntent(),
+			excludedProjects: Array.from({ length: 101 }, (_, index) => ({
+				canonicalProjectIdentity: `git:excluded-${index}`,
+				displayName: `Excluded ${index}`,
+				existingMemoryCount: index,
+			})),
+		};
+
+		expect(normalizeRecipientReviewedIntent(input).excludedProjects).toHaveLength(101);
+	});
+
+	it.each([
+		["unknown version", { ...teamIntent(), version: 2 }],
+		["missing Team", { ...teamIntent(), team: undefined }],
+		[
+			"negative memory count",
+			{ ...teamIntent(), projects: [{ ...teamIntent().projects[0], existingMemoryCount: -1 }] },
+		],
+		[
+			"overlong target Identity display name",
+			{
+				...addDeviceIntent(),
+				targetIdentity: { identityId: "identity-ada", displayName: "a".repeat(121) },
+			},
+		],
+		[
+			"duplicate included Project",
+			{ ...teamIntent(), projects: [teamIntent().projects[0], teamIntent().projects[0]] },
+		],
+		[
+			"included and excluded Project overlap",
+			{ ...teamIntent(), excludedProjects: [{ ...teamIntent().projects[0] }] },
+		],
+		[
+			"duplicate source",
+			{
+				...teamIntent(),
+				projects: [
+					{
+						...teamIntent().projects[0],
+						sources: [teamIntent().projects[0]?.sources[0], teamIntent().projects[0]?.sources[0]],
+					},
+				],
+			},
+		],
+	])("rejects malformed or duplicate input: %s", (_label, input) => {
+		expect(() => normalizeRecipientReviewedIntent(input)).toThrow(
+			"recipient_reviewed_intent_invalid",
+		);
+	});
+
+	it("rejects invitation target mismatches", () => {
+		expect(() =>
+			normalizeRecipientReviewedIntent(teamIntent(), {
+				kind: "team_member",
+				policyTeamId: "team-other",
+			}),
+		).toThrow("recipient_invite_intent_mismatch");
+		expect(() =>
+			normalizeRecipientReviewedIntent(addDeviceIntent(), {
+				kind: "add_device",
+				targetIdentityId: "identity-other",
+			}),
+		).toThrow("recipient_invite_intent_mismatch");
+	});
+
+	it("rejects digest mismatches", async () => {
+		await expect(
+			verifyRecipientReviewedIntent(teamIntent(), {
+				target: { kind: "team_member", policyTeamId: "team-core" },
+				digest: "0".repeat(64),
+			}),
+		).rejects.toThrow("recipient_invite_intent_mismatch");
+	});
+
+	it("fails closed for missing or malformed stored snapshots", async () => {
+		const options = {
+			target: { kind: "team_member" as const, policyTeamId: "team-core" },
+			digest: await recipientReviewedIntentDigest(teamIntent()),
+		};
+
+		await expect(parseStoredRecipientReviewedIntent(null, options)).rejects.toThrow(
+			"recipient_invite_review_unavailable",
+		);
+		await expect(parseStoredRecipientReviewedIntent("{", options)).rejects.toThrow(
+			"recipient_invite_review_unavailable",
+		);
+		await expect(
+			parseStoredRecipientReviewedIntent(JSON.stringify(teamIntent(), null, 2), options),
+		).rejects.toThrow("recipient_invite_review_unavailable");
+	});
+});

--- a/packages/core/src/recipient-reviewed-intent.ts
+++ b/packages/core/src/recipient-reviewed-intent.ts
@@ -1,0 +1,324 @@
+import { normalizeIdentityDisplayName } from "./project-invite-identity.js";
+
+export const RECIPIENT_REVIEWED_INTENT_VERSION = 1 as const;
+
+export type RecipientReviewedIntentProjectSourceV1 =
+	| { kind: "direct" }
+	| { kind: "team"; teamId: string; displayName: string };
+
+export interface RecipientReviewedIntentProjectV1 {
+	canonicalProjectIdentity: string;
+	displayName: string;
+	existingMemoryCount: number;
+	futureMemoriesShared: true;
+	sources: RecipientReviewedIntentProjectSourceV1[];
+}
+
+export interface RecipientReviewedIntentExcludedProjectV1 {
+	canonicalProjectIdentity: string;
+	displayName: string;
+	existingMemoryCount: number;
+}
+
+interface RecipientReviewedIntentBaseV1 {
+	version: 1;
+	projects: RecipientReviewedIntentProjectV1[];
+	excludedProjects: RecipientReviewedIntentExcludedProjectV1[];
+}
+
+export type RecipientReviewedIntentV1 =
+	| (RecipientReviewedIntentBaseV1 & {
+			journey: "team";
+			team: { teamId: string; displayName: string; futureProjectsInherit: true };
+	  })
+	| (RecipientReviewedIntentBaseV1 & {
+			journey: "add_device";
+			targetIdentity: { identityId: string; displayName: string };
+	  });
+
+export type RecipientReviewedIntentTargetV1 =
+	| { kind: "team_member"; policyTeamId: string }
+	| { kind: "add_device"; targetIdentityId: string };
+
+export class RecipientReviewedIntentError extends Error {
+	readonly code: "recipient_reviewed_intent_invalid" | "recipient_invite_intent_mismatch";
+
+	constructor(code: RecipientReviewedIntentError["code"]) {
+		super(code);
+		this.name = "RecipientReviewedIntentError";
+		this.code = code;
+	}
+}
+
+const CONTROL_CHARACTER = /[\p{Cc}\p{Cf}]/u;
+const MAX_PROJECTS = 100;
+const MAX_CANONICAL_BYTES = 64 * 1024;
+
+function invalid(): never {
+	throw new RecipientReviewedIntentError("recipient_reviewed_intent_invalid");
+}
+
+function record(value: unknown): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) invalid();
+	return value as Record<string, unknown>;
+}
+
+function assertKeys(value: Record<string, unknown>, keys: readonly string[]): void {
+	if (Object.keys(value).some((key) => !keys.includes(key))) invalid();
+}
+
+function strictText(value: unknown, maxLength: number): string {
+	if (
+		typeof value !== "string" ||
+		!value ||
+		value !== value.trim() ||
+		value.length > maxLength ||
+		CONTROL_CHARACTER.test(value)
+	) {
+		invalid();
+	}
+	return value;
+}
+
+function displayName(value: unknown): string {
+	if (typeof value !== "string" || CONTROL_CHARACTER.test(value)) invalid();
+	const normalized = value.trim().replace(/\s+/gu, " ");
+	if (!normalized || normalized.length > 256) invalid();
+	return normalized;
+}
+
+function identityDisplayName(value: unknown): string {
+	if (typeof value !== "string") invalid();
+	try {
+		return normalizeIdentityDisplayName(value, "identity_display_name");
+	} catch {
+		return invalid();
+	}
+}
+
+function memoryCount(value: unknown): number {
+	if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) invalid();
+	return value;
+}
+
+function compareText(left: string, right: string): number {
+	return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sourceKey(source: RecipientReviewedIntentProjectSourceV1): string {
+	return source.kind === "direct" ? "direct" : `team\u0000${source.teamId}`;
+}
+
+function normalizeSource(value: unknown): RecipientReviewedIntentProjectSourceV1 {
+	const input = record(value);
+	if (input.kind === "direct") {
+		assertKeys(input, ["kind"]);
+		return { kind: "direct" };
+	}
+	if (input.kind !== "team") invalid();
+	assertKeys(input, ["kind", "teamId", "displayName"]);
+	return {
+		kind: "team",
+		teamId: strictText(input.teamId, 256),
+		displayName: displayName(input.displayName),
+	};
+}
+
+function normalizeProject(value: unknown): RecipientReviewedIntentProjectV1 {
+	const input = record(value);
+	assertKeys(input, [
+		"canonicalProjectIdentity",
+		"displayName",
+		"existingMemoryCount",
+		"futureMemoriesShared",
+		"sources",
+	]);
+	if (
+		input.futureMemoriesShared !== true ||
+		!Array.isArray(input.sources) ||
+		!input.sources.length
+	) {
+		invalid();
+	}
+	const sources = input.sources
+		.map(normalizeSource)
+		.toSorted((left, right) => compareText(sourceKey(left), sourceKey(right)));
+	if (new Set(sources.map(sourceKey)).size !== sources.length) invalid();
+	return {
+		canonicalProjectIdentity: strictText(input.canonicalProjectIdentity, 512),
+		displayName: displayName(input.displayName),
+		existingMemoryCount: memoryCount(input.existingMemoryCount),
+		futureMemoriesShared: true,
+		sources,
+	};
+}
+
+function normalizeExcludedProject(value: unknown): RecipientReviewedIntentExcludedProjectV1 {
+	const input = record(value);
+	assertKeys(input, ["canonicalProjectIdentity", "displayName", "existingMemoryCount"]);
+	return {
+		canonicalProjectIdentity: strictText(input.canonicalProjectIdentity, 512),
+		displayName: displayName(input.displayName),
+		existingMemoryCount: memoryCount(input.existingMemoryCount),
+	};
+}
+
+function normalizeProjectLists(
+	input: Record<string, unknown>,
+): Pick<RecipientReviewedIntentBaseV1, "projects" | "excludedProjects"> {
+	if (
+		!Array.isArray(input.projects) ||
+		!Array.isArray(input.excludedProjects) ||
+		input.projects.length > MAX_PROJECTS
+	) {
+		invalid();
+	}
+	const projects = input.projects
+		.map(normalizeProject)
+		.toSorted((left, right) =>
+			compareText(left.canonicalProjectIdentity, right.canonicalProjectIdentity),
+		);
+	const excludedProjects = input.excludedProjects
+		.map(normalizeExcludedProject)
+		.toSorted((left, right) =>
+			compareText(left.canonicalProjectIdentity, right.canonicalProjectIdentity),
+		);
+	const includedIds = projects.map((project) => project.canonicalProjectIdentity);
+	const excludedIds = excludedProjects.map((project) => project.canonicalProjectIdentity);
+	if (
+		new Set(includedIds).size !== includedIds.length ||
+		new Set(excludedIds).size !== excludedIds.length ||
+		excludedIds.some((projectId) => includedIds.includes(projectId))
+	) {
+		invalid();
+	}
+	return { projects, excludedProjects };
+}
+
+function assertTarget(
+	intent: RecipientReviewedIntentV1,
+	target: RecipientReviewedIntentTargetV1,
+): void {
+	const matches =
+		(intent.journey === "team" &&
+			target.kind === "team_member" &&
+			intent.team.teamId === target.policyTeamId) ||
+		(intent.journey === "add_device" &&
+			target.kind === "add_device" &&
+			intent.targetIdentity.identityId === target.targetIdentityId);
+	if (!matches) throw new RecipientReviewedIntentError("recipient_invite_intent_mismatch");
+}
+
+export function normalizeRecipientReviewedIntent(
+	value: unknown,
+	target?: RecipientReviewedIntentTargetV1,
+): RecipientReviewedIntentV1 {
+	const input = record(value);
+	if (input.version !== RECIPIENT_REVIEWED_INTENT_VERSION) invalid();
+	const projectLists = normalizeProjectLists(input);
+	let intent: RecipientReviewedIntentV1;
+	if (input.journey === "team") {
+		assertKeys(input, ["version", "journey", "team", "projects", "excludedProjects"]);
+		const team = record(input.team);
+		assertKeys(team, ["teamId", "displayName", "futureProjectsInherit"]);
+		if (team.futureProjectsInherit !== true) invalid();
+		intent = {
+			version: 1,
+			journey: "team",
+			team: {
+				teamId: strictText(team.teamId, 256),
+				displayName: displayName(team.displayName),
+				futureProjectsInherit: true,
+			},
+			...projectLists,
+		};
+	} else if (input.journey === "add_device") {
+		assertKeys(input, ["version", "journey", "targetIdentity", "projects", "excludedProjects"]);
+		const identity = record(input.targetIdentity);
+		assertKeys(identity, ["identityId", "displayName"]);
+		intent = {
+			version: 1,
+			journey: "add_device",
+			targetIdentity: {
+				identityId: strictText(identity.identityId, 256),
+				displayName: identityDisplayName(identity.displayName),
+			},
+			...projectLists,
+		};
+	} else {
+		invalid();
+	}
+	if (target) assertTarget(intent, target);
+	if (new TextEncoder().encode(canonicalJson(intent)).byteLength > MAX_CANONICAL_BYTES) invalid();
+	return intent;
+}
+
+function canonicalJson(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+	if (value && typeof value === "object") {
+		return `{${Object.entries(value as Record<string, unknown>)
+			.toSorted(([left], [right]) => compareText(left, right))
+			.map(([key, child]) => `${JSON.stringify(key)}:${canonicalJson(child)}`)
+			.join(",")}}`;
+	}
+	return JSON.stringify(value) ?? "null";
+}
+
+export function canonicalRecipientReviewedIntentJson(
+	value: unknown,
+	target?: RecipientReviewedIntentTargetV1,
+): string {
+	return canonicalJson(normalizeRecipientReviewedIntent(value, target));
+}
+
+export async function recipientReviewedIntentDigest(
+	value: unknown,
+	target?: RecipientReviewedIntentTargetV1,
+): Promise<string> {
+	const canonical = canonicalRecipientReviewedIntentJson(value, target);
+	const bytes = new TextEncoder().encode(`recipient-reviewed-intent-v1\n${canonical}`);
+	const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
+	return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function verifyRecipientReviewedIntent(
+	value: unknown,
+	options: { target: RecipientReviewedIntentTargetV1; digest: string },
+): Promise<RecipientReviewedIntentV1> {
+	const normalized = normalizeRecipientReviewedIntent(value, options.target);
+	if ((await recipientReviewedIntentDigest(normalized)) !== options.digest) {
+		throw new RecipientReviewedIntentError("recipient_invite_intent_mismatch");
+	}
+	return normalized;
+}
+
+export async function parseStoredRecipientReviewedIntent(
+	json: string | null | undefined,
+	options: { target: RecipientReviewedIntentTargetV1; digest: string },
+): Promise<RecipientReviewedIntentV1> {
+	if (!json) throw new Error("recipient_invite_review_unavailable");
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(json);
+	} catch {
+		throw new Error("recipient_invite_review_unavailable");
+	}
+	try {
+		const normalized = normalizeRecipientReviewedIntent(parsed, options.target);
+		if (canonicalJson(normalized) !== json) {
+			throw new Error("recipient_invite_review_unavailable");
+		}
+		return await verifyRecipientReviewedIntent(normalized, options);
+	} catch (error) {
+		if (
+			error instanceof RecipientReviewedIntentError &&
+			error.code === "recipient_invite_intent_mismatch"
+		) {
+			throw error;
+		}
+		if (error instanceof Error && error.message === "recipient_invite_review_unavailable") {
+			throw error;
+		}
+		throw new Error("recipient_invite_review_unavailable");
+	}
+}

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -144,6 +144,49 @@ describe("MemoryStore", () => {
 			expect(store.actorId).toBe("local:local");
 		});
 
+		it("refreshes a proven persisted local identity without restart", () => {
+			const now = "2026-07-23T12:00:00.000Z";
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('identity-reviewed', 'Reviewed Owner', 1, 'active', ?, ?)`,
+				)
+				.run(now, now);
+
+			expect(store.refreshPersistedLocalIdentity("identity-reviewed")).toBe(true);
+			expect(store.actorId).toBe("identity-reviewed");
+			expect(store.actorDisplayName).toBe("Reviewed Owner");
+
+			store.adoptEnsuredDeviceIdentity("device-after-refresh");
+			expect(store.deviceId).toBe("device-after-refresh");
+			expect(store.actorId).toBe("identity-reviewed");
+			expect(store.actorDisplayName).toBe("Reviewed Owner");
+		});
+
+		it.each([
+			["missing", null],
+			["remote", { isLocal: 0, status: "active", mergedInto: null }],
+			["inactive", { isLocal: 1, status: "inactive", mergedInto: null }],
+			["merged", { isLocal: 1, status: "active", mergedInto: "identity-canonical" }],
+		] as const)("does not refresh an unproven persisted identity: %s", (_label, candidate) => {
+			const originalActorId = store.actorId;
+			const originalDisplayName = store.actorDisplayName;
+			if (candidate) {
+				const now = "2026-07-23T12:00:00.000Z";
+				store.db
+					.prepare(
+						`INSERT INTO actors(
+						 actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+						 ) VALUES ('identity-unproven', 'Unproven', ?, ?, ?, ?, ?)`,
+					)
+					.run(candidate.isLocal, candidate.status, candidate.mergedInto, now, now);
+			}
+
+			expect(store.refreshPersistedLocalIdentity("identity-unproven")).toBe(false);
+			expect(store.actorId).toBe(originalActorId);
+			expect(store.actorDisplayName).toBe(originalDisplayName);
+		});
+
 		it("adopts an ensured device identity and retires the fallback local actor", () => {
 			const now = "2026-07-23T12:00:00.000Z";
 			store.db

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -212,7 +212,7 @@ export class MemoryStore {
 	actorId: string;
 	actorDisplayName: string;
 	readonly crossSessionDedupWindowMs: number;
-	private readonly actorIdUsesDeviceFallback: boolean;
+	private actorIdUsesDeviceFallback: boolean;
 	/**
 	 * Per-store secret scanner. Lives on the instance (not as a module global)
 	 * so workspace-level rule overrides and allowlists can be wired without
@@ -283,6 +283,29 @@ export class MemoryStore {
 		this.actorDisplayName =
 			configDisplayName || process.env.USER?.trim() || process.env.USERNAME?.trim() || this.actorId;
 		this.crossSessionDedupWindowMs = resolveCrossSessionDedupWindowMs();
+	}
+
+	refreshPersistedLocalIdentity(expectedActorId: string): boolean {
+		const actorId = cleanStr(expectedActorId);
+		if (!actorId) return false;
+		try {
+			if (!tableExists(this.db, "actors")) return false;
+			const actor = this.db
+				.prepare(
+					`SELECT display_name FROM actors
+					 WHERE actor_id = ? AND is_local = 1 AND status = 'active'
+					   AND merged_into_actor_id IS NULL`,
+				)
+				.get(actorId) as { display_name: string } | undefined;
+			const displayName = cleanStr(actor?.display_name);
+			if (!actor || !displayName) return false;
+			this.actorId = actorId;
+			this.actorDisplayName = displayName;
+			this.actorIdUsesDeviceFallback = false;
+			return true;
+		} catch {
+			return false;
+		}
 	}
 
 	adoptEnsuredDeviceIdentity(deviceId: string): void {

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -162,6 +162,18 @@ describe("recipient invitation API", () => {
 			},
 		]);
 	});
+
+	it("preserves safe recipient invitation error codes for contextual UI guidance", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ error: "recipient_invite_intent_mismatch" }), {
+				status: 409,
+			}),
+		) as typeof fetch;
+
+		await expect(inspectCoordinatorInvite("tampered-invite")).rejects.toThrow(
+			"recipient_invite_intent_mismatch",
+		);
+	});
 });
 
 describe("triggerSync", () => {

--- a/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
@@ -267,6 +267,40 @@ describe("recipient-policy invitations", () => {
 		expect(dialog.textContent).not.toContain("Project setup is pending");
 	});
 
+	it("surfaces restart guidance when Team acceptance enables sync", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
+			kind: "team_member",
+			recipient_name: "Local Identity",
+			device_name: "Work Laptop",
+			onboarding: teamPreview,
+		});
+		vi.mocked(api.importCoordinatorInvite).mockResolvedValue({
+			status: "accepted",
+			setup_state: "restart_required",
+			restart_required: true,
+			sync_enabled: true,
+			detail: "Restart codemem to start receiving the reviewed Projects.",
+		});
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "team-member-invite";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Current Projects for"));
+		act(() => button("Accept invitation", dialog).click());
+
+		await vi.waitFor(() =>
+			expect(dialog.textContent).toContain(
+				"Restart codemem to start receiving the reviewed Projects.",
+			),
+		);
+	});
+
 	it("keeps unknown recipient-import errors generic", async () => {
 		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
 			kind: "team_member",
@@ -296,6 +330,35 @@ describe("recipient-policy invitations", () => {
 			),
 		);
 		expect(dialog.textContent).not.toContain("recipient_invite_unmapped_internal");
+	});
+
+	it("shows contextual Identity guidance when add-device acceptance conflicts", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
+			kind: "add_device",
+			recipient_name: "Owner Identity",
+			device_name: "Travel Laptop",
+			onboarding: addDevicePreview,
+		});
+		vi.mocked(api.importCoordinatorInvite).mockRejectedValue(new Error("invite_identity_conflict"));
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "add-device-invite";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Direct Projects"));
+		act(() => button("Accept invitation", dialog).click());
+
+		await vi.waitFor(() =>
+			expect(dialog.querySelector('[role="alert"]')?.textContent).toContain(
+				"This device already belongs to a different Identity",
+			),
+		);
+		expect(dialog.textContent).not.toContain("invite_identity_conflict");
 	});
 
 	it("reviews and accepts direct exact-Project access in the same dialog without repasting", async () => {
@@ -717,6 +780,38 @@ describe("recipient-policy invitations", () => {
 		);
 		expect(document.body.textContent).toContain("No active Teams or Identities are available");
 		expect(document.body.textContent).not.toMatch(/\b(scope|grant|actor|filter|epoch|cursor)\b/i);
+	});
+
+	it.each([
+		[
+			"recipient_invite_review_unavailable",
+			"The invitation review is unavailable. Ask the owner to create a new invitation.",
+		],
+		[
+			"recipient_invite_intent_mismatch",
+			"The invitation details do not match the reviewed access. Ask the owner to create a new invitation.",
+		],
+		[
+			"invite_identity_conflict",
+			"This device already belongs to a different Identity. Use a fresh device or ask the owner for the correct invitation.",
+		],
+	] as const)("shows contextual guidance for %s", async (code, guidance) => {
+		vi.mocked(api.inspectCoordinatorInvite).mockRejectedValue(new Error(code));
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "safe-invitation";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+
+		await vi.waitFor(() =>
+			expect(dialog.querySelector('[role="alert"]')?.textContent).toContain(guidance),
+		);
+		expect(dialog.textContent).not.toContain(code);
 	});
 
 	it("moves focus to the heading and restores it after Radix keyboard close", () => {

--- a/packages/ui/src/tabs/recipient-policy-invitations.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.tsx
@@ -47,8 +47,18 @@ function normalizeProjectShareAcceptance(result: ImportInviteResult): ProjectSha
 }
 
 function errorMessage(cause: unknown, fallback: string): string {
-	if (cause instanceof Error && cause.message === "reviewed_onboarding_stale") {
+	if (!(cause instanceof Error)) return fallback;
+	if (cause.message === "reviewed_onboarding_stale") {
 		return "Invitation details changed. Review them again before creating it.";
+	}
+	if (cause.message === "recipient_invite_review_unavailable") {
+		return "The invitation review is unavailable. Ask the owner to create a new invitation.";
+	}
+	if (cause.message === "recipient_invite_intent_mismatch") {
+		return "The invitation details do not match the reviewed access. Ask the owner to create a new invitation.";
+	}
+	if (cause.message === "invite_identity_conflict") {
+		return "This device already belongs to a different Identity. Use a fresh device or ask the owner for the correct invitation.";
 	}
 	return fallback;
 }
@@ -452,10 +462,13 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 					result.restart_required === true || result.setup_state === "restart_required";
 				const detail = typeof result.detail === "string" ? result.detail.trim() : "";
 				setStatus(
-					inspected.kind === "team_member"
-						? "Team invitation accepted."
-						: restartRequired
-							? detail || "Device added. Restart codemem before continuing."
+					restartRequired
+						? detail ||
+								(inspected.kind === "team_member"
+									? "Team invitation accepted. Restart codemem before continuing."
+									: "Device added. Restart codemem before continuing.")
+						: inspected.kind === "team_member"
+							? "Team invitation accepted."
 							: "Device added.",
 				);
 				setInspected(null);

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -10487,6 +10487,16 @@ describe("viewer-server", () => {
 					target_identity_id: store.actorId,
 				});
 				for (const body of coordinatorBodies) {
+					expect(body.reviewed_intent).toMatchObject({
+						version: 1,
+						journey: body.invite_kind === "team_member" ? "team" : "add_device",
+					});
+					expect(body.reviewed_preview_digest).toBe(
+						await core.recipientReviewedIntentDigest(body.reviewed_intent),
+					);
+					expect(body.reviewed_intent).not.toHaveProperty("binding");
+					expect(body.reviewed_intent).not.toHaveProperty("reviewedOnboardingDigest");
+					expect(body).not.toHaveProperty("reviewed_onboarding_digest");
 					expect(body).not.toHaveProperty("scope_id");
 					expect(body).not.toHaveProperty("project_ids");
 					expect(body).not.toHaveProperty("operation_id", expect.any(String));
@@ -10513,7 +10523,10 @@ describe("viewer-server", () => {
 				process.env.CODEMEM_CONFIG = configPath;
 				process.env.CODEMEM_KEYS_DIR = keysDir;
 				writeFileSync(configPath, JSON.stringify({ actor_display_name: "Local Identity" }));
-				const { app, ensureStore, cleanup } = createTestApp({ seedDevice: false });
+				const { app, ensureStore, cleanup } = createTestApp({
+					seedDevice: false,
+					getSyncRuntimeStatus: () => ({ phase: "disabled" }),
+				});
 				try {
 					const store = ensureStore();
 					const [deviceId] = ensureDeviceIdentity(store.db, { keysDir });
@@ -10546,7 +10559,52 @@ describe("viewer-server", () => {
 							now,
 							now,
 						);
-					const digest = "a".repeat(64);
+					const reviewedIntent: core.RecipientReviewedIntentV1 =
+						kind === "team_member"
+							? {
+									version: 1,
+									journey: "team",
+									team: {
+										teamId: "policy-team-a",
+										displayName: "Policy Team A",
+										futureProjectsInherit: true,
+									},
+									projects: [
+										{
+											canonicalProjectIdentity: projectId,
+											displayName: "recipient",
+											existingMemoryCount: 1,
+											futureMemoriesShared: true,
+											sources: [
+												{
+													kind: "team",
+													teamId: "policy-team-a",
+													displayName: "Policy Team A",
+												},
+											],
+										},
+									],
+									excludedProjects: [],
+								}
+							: {
+									version: 1,
+									journey: "add_device",
+									targetIdentity: {
+										identityId: store.actorId,
+										displayName: "Local Identity",
+									},
+									projects: [
+										{
+											canonicalProjectIdentity: projectId,
+											displayName: "recipient",
+											existingMemoryCount: 1,
+											futureMemoriesShared: true,
+											sources: [{ kind: "direct" }],
+										},
+									],
+									excludedProjects: [],
+								};
+					const digest = await core.recipientReviewedIntentDigest(reviewedIntent);
 					const payload: core.InvitePayload = {
 						v: 1,
 						kind,
@@ -10570,6 +10628,7 @@ describe("viewer-server", () => {
 								JSON.stringify({
 									kind,
 									reviewed_preview_digest: digest,
+									reviewed_intent: reviewedIntent,
 									bound: false,
 									...(kind === "team_member"
 										? { policy_team_id: "policy-team-a" }
@@ -10591,6 +10650,7 @@ describe("viewer-server", () => {
 								group_id: "coordinator-a",
 								identity_id: store.actorId,
 								reviewed_preview_digest: digest,
+								reviewed_intent: reviewedIntent,
 								...(kind === "team_member"
 									? { policy_team_id: "policy-team-a", target_identity_id: null }
 									: { policy_team_id: null, target_identity_id: store.actorId }),
@@ -10631,17 +10691,21 @@ describe("viewer-server", () => {
 					expect(acceptedBody).toMatchObject({
 						status: "accepted",
 						type: "recipient_onboarding",
+						setup_state: "restart_required",
+						restart_required: true,
+						sync_enabled: true,
+						detail: expect.stringContaining("Restart codemem"),
 					});
-					expect(acceptedBody).not.toHaveProperty("restart_required");
-					expect(acceptedBody).not.toHaveProperty("setup_state");
 					const persistedConfig = JSON.parse(readFileSync(configPath, "utf8")) as Record<
 						string,
 						unknown
 					>;
-					expect(persistedConfig).not.toHaveProperty("sync_enabled");
-					expect(persistedConfig).not.toHaveProperty("sync_host");
-					expect(persistedConfig).not.toHaveProperty("sync_port");
-					expect(persistedConfig).not.toHaveProperty("sync_interval_s");
+					expect(persistedConfig).toMatchObject({
+						sync_enabled: true,
+						sync_host: "0.0.0.0",
+						sync_port: 7337,
+						sync_interval_s: 120,
+					});
 					expect(joinBody).toMatchObject({
 						invite_kind: kind,
 						identity_id: store.actorId,
@@ -10666,6 +10730,532 @@ describe("viewer-server", () => {
 					else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
 					rmSync(testDir, { recursive: true, force: true });
 				}
+			}
+		});
+
+		it("fails closed with safe errors for unavailable or tampered recipient reviewed intent", async () => {
+			// Arrange
+			const testDir = mkdtempSync(join(tmpdir(), "codemem-recipient-intent-errors-"));
+			const configPath = join(testDir, "config.json");
+			const keysDir = join(testDir, "keys");
+			const previousConfig = process.env.CODEMEM_CONFIG;
+			const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const previousFetch = globalThis.fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Fresh Recipient" }));
+			const reviewedIntent: Extract<core.RecipientReviewedIntentV1, { journey: "team" }> = {
+				version: 1,
+				journey: "team",
+				team: {
+					teamId: "team-reviewed",
+					displayName: "Reviewed Team",
+					futureProjectsInherit: true,
+				},
+				projects: [],
+				excludedProjects: [],
+			};
+			const digest = await core.recipientReviewedIntentDigest(reviewedIntent);
+			const encoded = core.encodeInvitePayload({
+				v: 1,
+				kind: "team_member",
+				coordinator_url: "https://coord.example.test",
+				group_id: "coordinator-a",
+				policy: "auto_admit",
+				token: "token-reviewed",
+				expires_at: "2099-01-01T00:00:00.000Z",
+				team_name: null,
+				policy_team_id: "team-reviewed",
+				reviewed_preview_digest: digest,
+			});
+			globalThis.fetch = vi
+				.fn()
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ error: "recipient_invite_review_unavailable" }), {
+						status: 409,
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							kind: "team_member",
+							policy_team_id: "team-reviewed",
+							reviewed_preview_digest: digest,
+						}),
+						{ status: 200 },
+					),
+				)
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							kind: "team_member",
+							policy_team_id: "team-reviewed",
+							reviewed_preview_digest: digest,
+							reviewed_intent: {
+								...reviewedIntent,
+								team: { ...reviewedIntent.team, displayName: "Tampered Team" },
+							},
+						}),
+						{ status: 200 },
+					),
+				) as typeof fetch;
+			const { app, cleanup } = createTestApp({ seedDevice: false });
+			try {
+				// Act / Assert
+				for (const expected of [
+					"recipient_invite_review_unavailable",
+					"recipient_invite_review_unavailable",
+					"recipient_invite_intent_mismatch",
+				]) {
+					const response = await app.request("/api/sync/invites/inspect", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ invite: encoded }),
+					});
+					expect([400, 409]).toContain(response.status);
+					expect(await response.json()).toEqual({ error: expected });
+				}
+			} finally {
+				cleanup();
+				globalThis.fetch = previousFetch;
+				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previousConfig;
+				if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
+				rmSync(testDir, { recursive: true, force: true });
+			}
+		});
+
+		it.each([
+			{ label: "kind", responseOverride: { kind: "add_device" } },
+			{ label: "target ID", responseOverride: { policy_team_id: "team-other" } },
+			{ label: "reviewed digest", responseOverride: { reviewed_preview_digest: "f".repeat(64) } },
+		])("rejects a mismatched inspect $label without mutating the recipient DB or config", async (testCase) => {
+			// Arrange
+			const testDir = mkdtempSync(join(tmpdir(), "codemem-recipient-inspect-mismatch-"));
+			const configPath = join(testDir, "config.json");
+			const keysDir = join(testDir, "keys");
+			const previousConfig = process.env.CODEMEM_CONFIG;
+			const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const previousFetch = globalThis.fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Fresh Recipient" }));
+			const reviewedIntent: Extract<core.RecipientReviewedIntentV1, { journey: "team" }> = {
+				version: 1,
+				journey: "team",
+				team: {
+					teamId: "team-reviewed",
+					displayName: "Reviewed Team",
+					futureProjectsInherit: true,
+				},
+				projects: [],
+				excludedProjects: [],
+			};
+			const digest = await core.recipientReviewedIntentDigest(reviewedIntent);
+			const encoded = core.encodeInvitePayload({
+				v: 1,
+				kind: "team_member",
+				coordinator_url: "https://coord.example.test",
+				group_id: "coordinator-a",
+				policy: "auto_admit",
+				token: "token-reviewed",
+				expires_at: "2099-01-01T00:00:00.000Z",
+				team_name: null,
+				policy_team_id: "team-reviewed",
+				reviewed_preview_digest: digest,
+			});
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							kind: "team_member",
+							policy_team_id: "team-reviewed",
+							reviewed_preview_digest: digest,
+							reviewed_intent: reviewedIntent,
+							bound: false,
+							...testCase.responseOverride,
+						}),
+						{ status: 200 },
+					),
+			) as typeof fetch;
+			const { app, ensureStore, cleanup } = createTestApp({ seedDevice: false });
+			try {
+				const store = ensureStore();
+				const [deviceId] = ensureDeviceIdentity(store.db, { keysDir });
+				store.adoptEnsuredDeviceIdentity(deviceId);
+				const snapshot = () =>
+					JSON.stringify(
+						Object.fromEntries(
+							[
+								"actors",
+								"sync_device",
+								"identity_devices",
+								"policy_teams",
+								"policy_team_memberships",
+								"project_recipients",
+							].map((table) => [
+								table,
+								store.db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all(),
+							]),
+						),
+					);
+				const beforeDb = snapshot();
+				const beforeConfig = readFileSync(configPath, "utf8");
+
+				// Act
+				const response = await app.request("/api/sync/invites/inspect", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite: encoded, device_name: "Recipient Laptop" }),
+				});
+
+				// Assert
+				expect(response.status).toBe(409);
+				expect(await response.json()).toEqual({ error: "recipient_invite_intent_mismatch" });
+				expect(snapshot()).toBe(beforeDb);
+				expect(readFileSync(configPath, "utf8")).toBe(beforeConfig);
+			} finally {
+				cleanup();
+				globalThis.fetch = previousFetch;
+				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previousConfig;
+				if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
+				rmSync(testDir, { recursive: true, force: true });
+			}
+		});
+
+		it.each([
+			{ label: "Team", kind: "team_member" as const },
+			{ label: "add-device", kind: "add_device" as const },
+		])("creates a $label invite through the owner viewer and accepts it in a separate fresh recipient", async (testCase) => {
+			// Arrange
+			const testDir = mkdtempSync(join(tmpdir(), `codemem-${testCase.kind}-coordinator-`));
+			const coordinatorDbPath = join(testDir, "coordinator.sqlite");
+			const ownerConfigPath = join(testDir, "owner-config.json");
+			const ownerKeysDir = join(testDir, "owner-keys");
+			const recipientConfigPath = join(testDir, "recipient-config.json");
+			const recipientKeysDir = join(testDir, "recipient-keys");
+			const previousConfig = process.env.CODEMEM_CONFIG;
+			const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const previousAdminSecret = process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
+			const previousFetch = globalThis.fetch;
+			const setupCoordinator = new core.BetterSqliteCoordinatorStore(coordinatorDbPath);
+			await setupCoordinator.createGroup("coordinator-a", "Coordinator A");
+			await setupCoordinator.close();
+			const coordinatorApp = core.createCoordinatorApp({
+				storeFactory: () => new core.BetterSqliteCoordinatorStore(coordinatorDbPath),
+				runtime: {
+					adminSecret: () => "secret",
+					now: () => "2026-07-23T12:00:00.000Z",
+				},
+				requestVerifier: async () => true,
+			});
+			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) =>
+				coordinatorApp.request(String(input), init),
+			) as typeof fetch;
+			process.env.CODEMEM_CONFIG = ownerConfigPath;
+			process.env.CODEMEM_KEYS_DIR = ownerKeysDir;
+			process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET = "secret";
+			writeFileSync(
+				ownerConfigPath,
+				JSON.stringify({
+					actor_display_name: "Owner Identity",
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "coordinator-a",
+					sync_coordinator_admin_secret: "secret",
+				}),
+			);
+			const owner = createTestApp({ seedDevice: false });
+			let recipient: ReturnType<typeof createTestApp> | null = null;
+			try {
+				const ownerStore = owner.ensureStore();
+				const [ownerDeviceId] = ensureDeviceIdentity(ownerStore.db, { keysDir: ownerKeysDir });
+				ownerStore.adoptEnsuredDeviceIdentity(ownerDeviceId);
+				const teamId = "policy-team-a";
+				const alphaProjectId = "https://git.example.invalid/acme/alpha.git";
+				const betaProjectId = "https://git.example.invalid/acme/beta.git";
+				const now = "2026-07-23T12:00:00.000Z";
+				for (const [projectId, displayName, count] of [
+					[alphaProjectId, "alpha", 2],
+					[betaProjectId, "beta", 1],
+				] as const) {
+					const sessionId = insertTestSession(ownerStore.db);
+					ownerStore.db
+						.prepare("UPDATE sessions SET cwd = ?, git_remote = ?, project = ? WHERE id = ?")
+						.run(`/workspace/${displayName}`, projectId, displayName, sessionId);
+					for (let index = 0; index < count; index += 1) {
+						insertTestMemory(ownerStore, {
+							sessionId,
+							kind: "discovery",
+							title: `${displayName}-${index}`,
+							originDeviceId: ownerDeviceId,
+						});
+					}
+				}
+				ownerStore.db
+					.prepare(`INSERT INTO policy_teams(
+							team_id, display_name, status, provenance, revision, migration_state,
+							source_fingerprint, idempotency_key, created_at, updated_at
+						) VALUES (?, ?, 'active', 'user', 'r1', 'user_managed', NULL, 'team-a', ?, ?)`)
+					.run(teamId, "Policy Team A", now, now);
+				for (const [recipientKind, recipientId] of [
+					["team", teamId],
+					["identity", ownerStore.actorId],
+				] as const) {
+					ownerStore.db
+						.prepare(`INSERT INTO project_recipients(
+								canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+								policy_revision, migration_state, source_fingerprint, idempotency_key,
+								created_at, updated_at
+							) VALUES (?, ?, ?, 'active', 'user', ?, 'user_managed', NULL, ?, ?, ?)`)
+						.run(
+							alphaProjectId,
+							recipientKind,
+							recipientId,
+							`revision-${recipientKind}`,
+							`idempotency-${recipientKind}`,
+							now,
+							now,
+						);
+				}
+				const ownerRequest =
+					testCase.kind === "team_member"
+						? { kind: testCase.kind, policy_team_id: teamId }
+						: { kind: testCase.kind, target_identity_id: ownerStore.actorId };
+				const preview = (await (
+					await owner.app.request("/api/sync/recipient-policy/v1/invites/preview", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify(ownerRequest),
+					})
+				).json()) as { preview: { reviewedOnboardingDigest: string } };
+				const createResponse = await owner.app.request("/api/sync/recipient-policy/v1/invites", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						...ownerRequest,
+						reviewed_onboarding_digest: preview.preview.reviewedOnboardingDigest,
+					}),
+				});
+				expect(createResponse.status, JSON.stringify(await createResponse.clone().json())).toBe(
+					200,
+				);
+				const created = (await createResponse.json()) as { invite: { encoded: string } };
+				const payload = core.decodeInvitePayload(created.invite.encoded);
+
+				process.env.CODEMEM_CONFIG = recipientConfigPath;
+				process.env.CODEMEM_KEYS_DIR = recipientKeysDir;
+				writeFileSync(
+					recipientConfigPath,
+					JSON.stringify(
+						testCase.kind === "team_member" ? { actor_display_name: "Fresh Recipient" } : {},
+					),
+				);
+				recipient = createTestApp({ seedDevice: false });
+				const recipientStore = recipient.ensureStore();
+				expect(recipientStore.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(
+					0,
+				);
+				expect(
+					recipientStore.db.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get(),
+				).toBe(0);
+				expect(
+					recipientStore.db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get(),
+				).toBe(0);
+
+				// Act
+				const inspectResponse = await recipient.app.request("/api/sync/invites/inspect", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite: created.invite.encoded, device_name: "Recipient Laptop" }),
+				});
+				expect(inspectResponse.status, JSON.stringify(await inspectResponse.clone().json())).toBe(
+					200,
+				);
+				const inspection = (await inspectResponse.json()) as {
+					recipient_name: string;
+					onboarding: {
+						reviewedOnboardingDigest: string;
+						projects: unknown[];
+						excludedProjects: unknown[];
+					};
+				};
+
+				// Assert
+				expect(inspection.onboarding.projects).toEqual([
+					{
+						canonicalProjectIdentity: alphaProjectId,
+						displayName: "alpha",
+						existingMemoryCount: 2,
+						futureMemoriesShared: true,
+						sources:
+							testCase.kind === "team_member"
+								? [{ kind: "team", teamId, displayName: "Policy Team A" }]
+								: [{ kind: "direct" }],
+					},
+				]);
+				expect(inspection.onboarding.excludedProjects).toEqual(
+					testCase.kind === "team_member"
+						? []
+						: [
+								{
+									canonicalProjectIdentity: betaProjectId,
+									displayName: "beta",
+									existingMemoryCount: 1,
+								},
+							],
+				);
+				if (testCase.kind === "team_member") {
+					expect(JSON.stringify(inspection)).not.toContain(betaProjectId);
+					expect(JSON.stringify(inspection)).not.toContain('"beta"');
+				}
+				const importBody = {
+					invite: created.invite.encoded,
+					recipient_name: inspection.recipient_name,
+					device_name: "Recipient Laptop",
+					reviewed_onboarding_digest: inspection.onboarding.reviewedOnboardingDigest,
+				};
+				const stale = await recipient.app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ ...importBody, device_name: "Renamed Recipient Laptop" }),
+				});
+				expect(stale.status).toBe(400);
+				expect(await stale.json()).toEqual({ error: "reviewed_onboarding_stale" });
+
+				const accepted = await recipient.app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(importBody),
+				});
+				expect(accepted.status, JSON.stringify(await accepted.clone().json())).toBe(200);
+				expect(await accepted.json()).toMatchObject({
+					status: "accepted",
+					type: "recipient_onboarding",
+				});
+				const expectedIdentityId =
+					testCase.kind === "team_member" ? recipientStore.actorId : ownerStore.actorId;
+				if (testCase.kind === "add_device") {
+					expect(recipientStore.actorId).toBe(ownerStore.actorId);
+					expect(recipientStore.actorDisplayName).toBe("Owner Identity");
+				}
+				const recipientDeviceId = recipientStore.db
+					.prepare("SELECT device_id FROM sync_device LIMIT 1")
+					.pluck()
+					.get() as string;
+				expect(
+					recipientStore.db.prepare("SELECT identity_id, device_id FROM identity_devices").all(),
+				).toEqual([{ identity_id: expectedIdentityId, device_id: recipientDeviceId }]);
+				expect(
+					recipientStore.db
+						.prepare(
+							"SELECT actor_id, display_name, is_local, status FROM actors ORDER BY actor_id",
+						)
+						.all(),
+				).toEqual([
+					{
+						actor_id: expectedIdentityId,
+						display_name: testCase.kind === "team_member" ? "Fresh Recipient" : "Owner Identity",
+						is_local: 1,
+						status: "active",
+					},
+				]);
+				expect(
+					recipientStore.db.prepare("SELECT team_id, display_name, status FROM policy_teams").all(),
+				).toEqual(
+					testCase.kind === "team_member"
+						? [{ team_id: teamId, display_name: "Policy Team A", status: "active" }]
+						: [],
+				);
+				expect(
+					recipientStore.db
+						.prepare("SELECT team_id, identity_id, role, status FROM policy_team_memberships")
+						.all(),
+				).toEqual(
+					testCase.kind === "team_member"
+						? [
+								{
+									team_id: teamId,
+									identity_id: expectedIdentityId,
+									role: "member",
+									status: "active",
+								},
+							]
+						: [],
+				);
+				expect(
+					recipientStore.db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get(),
+				).toBe(0);
+				const persistedConfig = JSON.parse(readFileSync(recipientConfigPath, "utf8"));
+				expect(persistedConfig).toMatchObject({
+					actor_id: expectedIdentityId,
+					actor_display_name:
+						testCase.kind === "team_member" ? "Fresh Recipient" : "Owner Identity",
+					sync_device_name: "Recipient Laptop",
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "coordinator-a",
+					sync_coordinator_groups: ["coordinator-a"],
+				});
+				const materializedState = JSON.stringify({
+					actors: recipientStore.db.prepare("SELECT * FROM actors ORDER BY actor_id").all(),
+					devices: recipientStore.db
+						.prepare("SELECT * FROM identity_devices ORDER BY identity_id")
+						.all(),
+					teams: recipientStore.db.prepare("SELECT * FROM policy_teams ORDER BY team_id").all(),
+					memberships: recipientStore.db
+						.prepare("SELECT * FROM policy_team_memberships ORDER BY team_id, identity_id")
+						.all(),
+				});
+				const persistedConfigText = readFileSync(recipientConfigPath, "utf8");
+				const replay = await recipient.app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(importBody),
+				});
+				expect(replay.status).toBe(200);
+				expect(await replay.json()).toMatchObject({ status: "existing" });
+				expect(
+					JSON.stringify({
+						actors: recipientStore.db.prepare("SELECT * FROM actors ORDER BY actor_id").all(),
+						devices: recipientStore.db
+							.prepare("SELECT * FROM identity_devices ORDER BY identity_id")
+							.all(),
+						teams: recipientStore.db.prepare("SELECT * FROM policy_teams ORDER BY team_id").all(),
+						memberships: recipientStore.db
+							.prepare("SELECT * FROM policy_team_memberships ORDER BY team_id, identity_id")
+							.all(),
+					}),
+				).toBe(materializedState);
+				expect(readFileSync(recipientConfigPath, "utf8")).toBe(persistedConfigText);
+				const coordinatorVerification = new core.BetterSqliteCoordinatorStore(coordinatorDbPath);
+				try {
+					expect(
+						await coordinatorVerification.getInviteByTokenForInspection(String(payload.token)),
+					).toMatchObject({
+						invite_kind: testCase.kind,
+						bound_device_id: recipientDeviceId,
+						recipient_actor_id: expectedIdentityId,
+						consumed_at: expect.any(String),
+					});
+				} finally {
+					await coordinatorVerification.close();
+				}
+			} finally {
+				recipient?.cleanup();
+				owner.cleanup();
+				globalThis.fetch = previousFetch;
+				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previousConfig;
+				if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
+				if (previousAdminSecret == null) {
+					delete process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
+				} else {
+					process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET = previousAdminSecret;
+				}
+				rmSync(testDir, { recursive: true, force: true });
 			}
 		});
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -15,11 +15,13 @@ import type {
 	ProjectScopeGuardrailWarning,
 	ReassignScopeCapability,
 	RecipientPolicyCoordinatorEffectReceipt,
+	RecipientPolicyOnboardingPreviewV1,
 	RecipientPolicyPeerCapability,
 	RecipientPolicyReconcileResult,
 	RecipientPolicyReconcilerEffects,
 	RecipientPolicyReviewDecisionV1,
 	RecipientPolicyReviewResolveRequestV1,
+	RecipientReviewedIntentV1,
 	ReplicationOp,
 	SemanticIndexDiagnostics,
 	ShareOperationLifecycleStepInput,
@@ -118,11 +120,13 @@ import {
 	planShareOperation,
 	previewRecipientPolicyEdges,
 	previewRecipientPolicyOnboarding,
+	previewRecipientPolicyOnboardingFromReviewedIntent,
 	projectShareLifecycle,
 	RecipientPolicyEdgeRequestError,
 	readCodememConfigFile,
 	readCoordinatorSyncConfig,
 	reassignProjectScopeInventoryProject,
+	recipientReviewedIntentDigest,
 	reconcileRecipientPolicyProject,
 	reconcileShareOperationAcceptance,
 	recordNonce,
@@ -144,6 +148,7 @@ import {
 	updatePeerAddresses,
 	upsertCoordinatorGroupPreference,
 	upsertProjectScopeSettingsMapping,
+	verifyRecipientReviewedIntent,
 	verifySignature,
 	writeCodememConfigFile,
 } from "@codemem/core";
@@ -706,12 +711,16 @@ function recipientInviteKind(value: unknown): RecipientInviteKind {
 function localOnboardingBinding(
 	store: MemoryStore,
 	deviceName: string | null,
+	options: { materializeActor?: boolean } = {},
 ): {
 	deviceId: string;
 	devicePublicKey: string;
 	deviceDisplayName: string;
 } {
-	const deviceId = ensureStableStoreIdentity(store);
+	const deviceId =
+		options.materializeActor === false
+			? ensureStableStoreDeviceIdentity(store)
+			: ensureStableStoreIdentity(store);
 	const devicePublicKey = String(
 		store.db
 			.prepare("SELECT public_key FROM sync_device WHERE device_id = ?")
@@ -761,14 +770,93 @@ function recipientInviteOnboardingPreview(
 	});
 }
 
-function recipientInvitePreviewId(kind: RecipientInviteKind, targetId: string): string {
-	return `recipient-invite-preview:${kind}:${targetId}`;
+function recipientInviteReviewedIntent(
+	store: MemoryStore,
+	kind: RecipientInviteKind,
+	targetId: string,
+	preview: RecipientPolicyOnboardingPreviewV1,
+): RecipientReviewedIntentV1 {
+	if (kind === "team_member") {
+		if (preview.journey !== "team" || !preview.team || preview.team.teamId !== targetId) {
+			throw new Error("recipient_invite_intent_mismatch");
+		}
+		return {
+			version: 1,
+			journey: "team",
+			team: preview.team,
+			projects: preview.projects,
+			excludedProjects: [],
+		};
+	}
+	if (preview.journey !== "add_device" || preview.binding.identityId !== targetId) {
+		throw new Error("recipient_invite_intent_mismatch");
+	}
+	const targetIdentity = store.db
+		.prepare(
+			`SELECT display_name FROM actors
+			 WHERE actor_id = ? AND status = 'active' AND merged_into_actor_id IS NULL`,
+		)
+		.get(targetId) as { display_name: string } | undefined;
+	if (!targetIdentity?.display_name) throw new Error("identity_not_found");
+	return {
+		version: 1,
+		journey: "add_device",
+		targetIdentity: { identityId: targetId, displayName: targetIdentity.display_name },
+		projects: preview.projects,
+		excludedProjects: preview.excludedProjects,
+	};
 }
 
-function coordinatorPreviewDigest(reviewedOnboardingDigest: string): string {
-	const match = /^recipient-onboarding-preview-v1:([a-f0-9]{64})$/u.exec(reviewedOnboardingDigest);
-	if (!match?.[1]) throw new Error("reviewed_onboarding_digest_invalid");
-	return match[1];
+function recipientInviteOnboardingPreviewFromReviewedIntent(
+	store: MemoryStore,
+	body: Record<string, unknown>,
+	invitationId: string,
+	reviewedIntent: RecipientReviewedIntentV1,
+) {
+	const kind = recipientInviteKind(body.kind ?? body.invite_kind);
+	const binding = localOnboardingBinding(store, optionalViewerString(body, "device_name"), {
+		materializeActor: false,
+	});
+	const teamId = optionalViewerStrictString(body, "policy_team_id");
+	const targetIdentityId = optionalViewerStrictString(body, "target_identity_id");
+	if (kind === "team_member") {
+		if (!teamId || targetIdentityId) throw new Error("recipient_invite_metadata_invalid");
+		return previewRecipientPolicyOnboardingFromReviewedIntent(reviewedIntent, {
+			version: 1,
+			journey: "team",
+			invitationId,
+			identityId: store.actorId,
+			...binding,
+			teamId,
+		});
+	}
+	if (!targetIdentityId || teamId) throw new Error("recipient_invite_metadata_invalid");
+	return previewRecipientPolicyOnboardingFromReviewedIntent(reviewedIntent, {
+		version: 1,
+		journey: "add_device",
+		invitationId,
+		identityId: targetIdentityId,
+		...binding,
+	});
+}
+
+const SAFE_RECIPIENT_INVITE_ERRORS = new Set([
+	"invite_already_bound",
+	"invite_expired",
+	"invite_identity_conflict",
+	"invite_invalid",
+	"recipient_invite_intent_mismatch",
+	"recipient_invite_review_unavailable",
+	"reviewed_onboarding_stale",
+]);
+
+function safeRecipientInviteError(value: unknown, fallback = "invite_invalid"): string {
+	const code = value instanceof Error ? value.message : String(value ?? "").trim();
+	return SAFE_RECIPIENT_INVITE_ERRORS.has(code) ? code : fallback;
+}
+
+function recipientInvitePreviewId(kind: RecipientInviteKind, targetId: string): string {
+	return `recipient-invite-preview:${kind}:${targetId}`;
 }
 
 export function recipientPolicyCapabilityFromStatus(payload: {
@@ -2433,9 +2521,14 @@ function ensureLocalActorRecord(store: MemoryStore): void {
 }
 
 function ensureStableStoreIdentity(store: MemoryStore): string {
+	const deviceId = ensureStableStoreDeviceIdentity(store);
+	ensureLocalActorRecord(store);
+	return deviceId;
+}
+
+function ensureStableStoreDeviceIdentity(store: MemoryStore): string {
 	const [deviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 	store.adoptEnsuredDeviceIdentity(deviceId);
-	ensureLocalActorRecord(store);
 	return deviceId;
 }
 
@@ -4845,6 +4938,8 @@ export function syncRoutes(
 			if (reviewedDigest !== preview.reviewedOnboardingDigest) {
 				return c.json({ error: "reviewed_onboarding_stale", preview }, 409);
 			}
+			const reviewedIntent = recipientInviteReviewedIntent(store, kind, targetId, preview);
+			const reviewedPreviewDigest = await recipientReviewedIntentDigest(reviewedIntent);
 			const groupId = resolveCoordinatorAdminGroup(optionalViewerString(body, "group_id"), status);
 			const ttlHours = parseInviteTtlHours(body.ttl_hours);
 			if (!groupId) throw new Error("group_id_required");
@@ -4860,7 +4955,8 @@ export function syncRoutes(
 				inviteKind: kind,
 				policyTeamId: kind === "team_member" ? targetId : null,
 				targetIdentityId: kind === "add_device" ? targetId : null,
-				reviewedPreviewDigest: coordinatorPreviewDigest(preview.reviewedOnboardingDigest),
+				reviewedPreviewDigest,
+				reviewedIntent,
 			});
 			return c.json({ ok: true, kind, preview, invite: result });
 		} catch (error) {
@@ -5718,8 +5814,9 @@ export function syncRoutes(
 		if (!body || typeof body.invite !== "string") return c.json({ error: "invite_invalid" }, 400);
 		try {
 			const payload = decodeInvitePayload(extractInvitePayload(body.invite));
-			ensureStableStoreIdentity(store);
 			const recipientInvite = payload.kind === "team_member" || payload.kind === "add_device";
+			if (recipientInvite) ensureStableStoreDeviceIdentity(store);
+			else ensureStableStoreIdentity(store);
 			if (!payload.operation_id && !recipientInvite) return c.json({ kind: "legacy_team_invite" });
 			const [status, inspected] = await requestJson(
 				"POST",
@@ -5728,7 +5825,11 @@ export function syncRoutes(
 			);
 			if (status < 200 || status >= 300) {
 				return c.json(
-					{ error: String(inspected?.error ?? "invite_invalid") },
+					{
+						error: recipientInvite
+							? safeRecipientInviteError(inspected?.error)
+							: String(inspected?.error ?? "invite_invalid"),
+					},
 					status === 410 ? 410 : 400,
 				);
 			}
@@ -5752,7 +5853,22 @@ export function syncRoutes(
 				) {
 					return c.json({ error: "recipient_invite_intent_mismatch" }, 409);
 				}
-				const preview = recipientInviteOnboardingPreview(
+				if (inspected?.reviewed_intent == null) {
+					return c.json({ error: "recipient_invite_review_unavailable" }, 409);
+				}
+				let reviewedIntent: RecipientReviewedIntentV1;
+				try {
+					reviewedIntent = await verifyRecipientReviewedIntent(inspected.reviewed_intent, {
+						target:
+							payload.kind === "team_member"
+								? { kind: "team_member", policyTeamId: expectedTarget }
+								: { kind: "add_device", targetIdentityId: expectedTarget },
+						digest: String(payload.reviewed_preview_digest ?? "").trim(),
+					});
+				} catch {
+					return c.json({ error: "recipient_invite_intent_mismatch" }, 409);
+				}
+				const preview = recipientInviteOnboardingPreviewFromReviewedIntent(
 					store,
 					{
 						kind: payload.kind,
@@ -5761,10 +5877,14 @@ export function syncRoutes(
 						device_name: optionalViewerString(body, "device_name"),
 					},
 					String(payload.token),
+					reviewedIntent,
 				);
 				return c.json({
 					...inspected,
-					recipient_name: store.actorDisplayName,
+					recipient_name:
+						reviewedIntent.journey === "add_device"
+							? reviewedIntent.targetIdentity.displayName
+							: store.actorDisplayName,
 					device_name: preview.binding.deviceDisplayName,
 					onboarding: preview,
 				});
@@ -5778,8 +5898,8 @@ export function syncRoutes(
 					fallbackSeed: store.deviceId,
 				}),
 			});
-		} catch {
-			return c.json({ error: "invite_invalid" }, 400);
+		} catch (error) {
+			return c.json({ error: safeRecipientInviteError(error) }, 400);
 		}
 	});
 
@@ -5847,11 +5967,13 @@ export function syncRoutes(
 		}
 
 		let projectInvite = false;
+		let recipientInvite = false;
 		try {
 			const decoded = decodeInvitePayload(extractInvitePayload(rawValue));
 			projectInvite = Boolean(decoded.operation_id);
-			ensureStableStoreIdentity(store);
-			const recipientInvite = decoded.kind === "team_member" || decoded.kind === "add_device";
+			recipientInvite = decoded.kind === "team_member" || decoded.kind === "add_device";
+			if (decoded.kind === "add_device") ensureStableStoreDeviceIdentity(store);
+			else ensureStableStoreIdentity(store);
 			const reviewedOnboardingDigest =
 				typeof body.reviewed_onboarding_digest === "string"
 					? body.reviewed_onboarding_digest.trim()
@@ -5862,7 +5984,7 @@ export function syncRoutes(
 			const result = await coordinatorImportInviteAction({
 				inviteValue: rawValue,
 				dbPath: store.dbPath,
-				recipientActorId: store.actorId,
+				recipientActorId: decoded.kind === "add_device" ? null : store.actorId,
 				recipientDisplayName:
 					typeof body.recipient_name === "string" ? body.recipient_name : store.actorDisplayName,
 				deviceDisplayName: typeof body.device_name === "string" ? body.device_name : null,
@@ -5873,15 +5995,34 @@ export function syncRoutes(
 				: projectInvite
 					? "project_share"
 					: "team_join";
-			if (projectInvite && getSyncRuntimeStatus?.()?.phase === "disabled") {
+			if (decoded.kind === "add_device") {
+				const persistedIdentityId = String(
+					result.identity_id ?? result.target_identity_id ?? "",
+				).trim();
+				if (!store.refreshPersistedLocalIdentity(persistedIdentityId)) {
+					return c.json(
+						{
+							...result,
+							type,
+							setup_state: "restart_required",
+							restart_required: true,
+							detail:
+								"The invitation was accepted and the reviewed Identity was persisted, but this process could not safely adopt it. Restart codemem before continuing.",
+						},
+						200,
+					);
+				}
+			}
+			if ((projectInvite || recipientInvite) && getSyncRuntimeStatus?.()?.phase === "disabled") {
 				return c.json(
 					{
 						...result,
 						type,
 						setup_state: "restart_required",
 						restart_required: true,
-						detail:
-							"The invitation was accepted and sync was enabled. Restart codemem to start the sync service; Project setup remains pending until the first sync finishes.",
+						detail: projectInvite
+							? "The invitation was accepted and sync was enabled. Restart codemem to start the sync service; Project setup remains pending until the first sync finishes."
+							: "The invitation was accepted and sync was enabled. Restart codemem to start the sync service and receive the reviewed Projects.",
 					},
 					200,
 				);
@@ -5892,6 +6033,7 @@ export function syncRoutes(
 			});
 		} catch (error) {
 			if (projectInvite) return c.json(projectInviteAcceptanceFailure(error), 400);
+			if (recipientInvite) return c.json({ error: safeRecipientInviteError(error) }, 400);
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
 		}
 	});


### PR DESCRIPTION
## Description

Fixes `codemem-wosg` by making Team-member and add-device invitations carry a canonical, coordinator-owned reviewed-intent snapshot. Fresh recipients can now review and accept invitations without preexisting local Team, Identity, membership, or Project-recipient facts.

The snapshot remains digest- and target-bound, invitation URLs remain digest-only, reviewed onboarding is validated before coordinator consumption, add-device Identity adoption is restricted to pristine bootstrap profiles, and local DB/config failures compensate safely. SQLite and D1 coordinator stores share the same fail-closed contract.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation performed:
- `pnpm run check` — 3,310 passed, 3 todo
- `pnpm --filter @codemem/cloudflare-coordinator-worker test:worker` — Node and Worker runtime suites passed
- Real owner viewer → coordinator → separate fresh recipient integration for Team and add-device journeys
- Independent blocker/high security and correctness review found no remaining serious issues

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced