### PR TITLE
fix(sharing): bind enrolled devices to identities

### DIFF
--- a/packages/cloudflare-coordinator-worker/migrations/0012_add_enrolled_device_identity.sql
+++ b/packages/cloudflare-coordinator-worker/migrations/0012_add_enrolled_device_identity.sql
@@ -1,0 +1,1 @@
+ALTER TABLE enrolled_devices ADD COLUMN identity_id TEXT;

--- a/packages/cloudflare-coordinator-worker/migrations/0013_add_invite_assigned_identity.sql
+++ b/packages/cloudflare-coordinator-worker/migrations/0013_add_invite_assigned_identity.sql
@@ -1,0 +1,1 @@
+ALTER TABLE coordinator_invites ADD COLUMN assigned_identity_id TEXT;

--- a/packages/cloudflare-coordinator-worker/schema.sql
+++ b/packages/cloudflare-coordinator-worker/schema.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS enrolled_devices (
   device_id TEXT NOT NULL,
   public_key TEXT NOT NULL,
   fingerprint TEXT NOT NULL,
+  identity_id TEXT,
   display_name TEXT,
   enabled INTEGER NOT NULL DEFAULT 1,
   created_at TEXT NOT NULL,
@@ -64,6 +65,7 @@ CREATE TABLE IF NOT EXISTS coordinator_invites (
   invite_kind TEXT,
   policy_team_id TEXT,
   target_identity_id TEXT,
+  assigned_identity_id TEXT,
   reviewed_preview_digest TEXT,
   reviewed_intent_json TEXT
 );

--- a/packages/cloudflare-coordinator-worker/src/index.test.ts
+++ b/packages/cloudflare-coordinator-worker/src/index.test.ts
@@ -320,6 +320,97 @@ describe("createCloudflareCoordinatorWorker", () => {
 		).toEqual({ invite_id: "legacy-invite", reviewed_intent_json: null });
 	});
 
+	it("migration 0012 adds nullable enrollment identity binding and preserves existing rows", () => {
+		// Arrange
+		db.exec(`
+			DROP TABLE enrolled_devices;
+			CREATE TABLE enrolled_devices (
+				group_id TEXT NOT NULL,
+				device_id TEXT NOT NULL,
+				public_key TEXT NOT NULL,
+				fingerprint TEXT NOT NULL,
+				display_name TEXT,
+				enabled INTEGER NOT NULL DEFAULT 1,
+				created_at TEXT NOT NULL,
+				PRIMARY KEY (group_id, device_id)
+			);
+			INSERT INTO enrolled_devices(
+				group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+			) VALUES (
+				'g1', 'legacy-device', 'legacy-key', 'legacy-fingerprint', 'Legacy device', 1,
+				'2026-07-24T00:00:00Z'
+			);
+		`);
+		const migration = readFileSync(
+			join(import.meta.dirname, "../migrations/0012_add_enrolled_device_identity.sql"),
+			"utf8",
+		);
+
+		// Act
+		db.exec(migration);
+
+		// Assert
+		const columns = db.prepare("PRAGMA table_info(enrolled_devices)").all() as Array<{
+			name: string;
+		}>;
+		expect(columns.map((column) => column.name)).toContain("identity_id");
+		expect(
+			db
+				.prepare(
+					"SELECT device_id, identity_id FROM enrolled_devices WHERE device_id = 'legacy-device'",
+				)
+				.get(),
+		).toEqual({ device_id: "legacy-device", identity_id: null });
+	});
+
+	it("migration 0013 adds nullable assigned Team identity and preserves existing invitations", () => {
+		// Arrange
+		db.exec(`
+			DROP TABLE coordinator_invites;
+			CREATE TABLE coordinator_invites (
+				invite_id TEXT PRIMARY KEY,
+				group_id TEXT NOT NULL,
+				token TEXT NOT NULL UNIQUE,
+				policy TEXT NOT NULL,
+				expires_at TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				invite_kind TEXT,
+				policy_team_id TEXT
+			);
+			INSERT INTO coordinator_invites(
+				invite_id, group_id, token, policy, expires_at, created_at, invite_kind, policy_team_id
+			) VALUES (
+				'legacy-team-invite', 'g1', 'legacy-team-token', 'auto_admit',
+				'2099-01-01T00:00:00Z', '2026-07-24T00:00:00Z', 'team_member', 'policy-team-1'
+			);
+		`);
+		const migration = readFileSync(
+			join(import.meta.dirname, "../migrations/0013_add_invite_assigned_identity.sql"),
+			"utf8",
+		);
+
+		// Act
+		db.exec(migration);
+
+		// Assert
+		const columns = db.prepare("PRAGMA table_info(coordinator_invites)").all() as Array<{
+			name: string;
+		}>;
+		expect(columns.map((column) => column.name)).toContain("assigned_identity_id");
+		expect(
+			db
+				.prepare(
+					"SELECT invite_id, invite_kind, policy_team_id, assigned_identity_id FROM coordinator_invites",
+				)
+				.get(),
+		).toEqual({
+			invite_id: "legacy-team-invite",
+			invite_kind: "team_member",
+			policy_team_id: "policy-team-1",
+			assigned_identity_id: null,
+		});
+	});
+
 	it("serves coordinator admin data through the worker entrypoint", async () => {
 		const store = new D1CoordinatorStore(d1db);
 		await store.createGroup("g1", "Team Alpha");
@@ -350,6 +441,7 @@ describe("createCloudflareCoordinatorWorker", () => {
 					device_id: "d1",
 					public_key: "pk1",
 					fingerprint: "fp1",
+					identity_id: null,
 					display_name: "Laptop",
 					enabled: 1,
 					created_at: expect.any(String),

--- a/packages/cloudflare-coordinator-worker/test/worker.integration.test.ts
+++ b/packages/cloudflare-coordinator-worker/test/worker.integration.test.ts
@@ -858,8 +858,6 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		const otherDevice = createIdentity();
 		const teamIntent = teamReviewedIntent();
 		const teamDigest = await recipientReviewedIntentDigest(teamIntent);
-		const addDeviceIntent = addDeviceReviewedIntent();
-		const addDeviceDigest = await recipientReviewedIntentDigest(addDeviceIntent);
 		const adminHeaders = {
 			"content-type": "application/json",
 			"X-Codemem-Coordinator-Admin": "test-secret",
@@ -884,6 +882,26 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 			expect(response.status).toBe(200);
 			return (await response.json()) as { payload: InvitePayload };
 		};
+		const callerAssigned = await exports.default.fetch(
+			"https://example.com/v1/admin/invites",
+			{
+				method: "POST",
+				headers: adminHeaders,
+				body: JSON.stringify({
+					group_id: "g1",
+					policy: "auto_admit",
+					expires_at: "2099-01-01T00:00:00Z",
+					coordinator_url: "https://example.com",
+					invite_kind: "team_member",
+					policy_team_id: "policy-team-1",
+					assigned_identity_id: "identity-owner",
+					reviewed_preview_digest: teamDigest,
+					reviewed_intent: teamIntent,
+				}),
+			},
+		);
+		expect(callerAssigned.status).toBe(400);
+		expect(await callerAssigned.json()).toEqual({ error: "assigned_identity_id_forbidden" });
 
 		const team = await createInvite({
 			invite_kind: "team_member",
@@ -894,8 +912,10 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		expect(team.payload).toMatchObject({
 			kind: "team_member",
 			policy_team_id: "policy-team-1",
+			assigned_identity_id: expect.any(String),
 			reviewed_preview_digest: teamDigest,
 		});
+		const assignedIdentityId = String(team.payload.assigned_identity_id);
 		expect(team.payload).not.toHaveProperty("reviewed_intent");
 		const inspect = await exports.default.fetch("https://example.com/v1/invites/inspect", {
 			method: "POST",
@@ -905,6 +925,7 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		expect(await inspect.json()).toMatchObject({
 			kind: "team_member",
 			policy_team_id: "policy-team-1",
+			assigned_identity_id: assignedIdentityId,
 			reviewed_preview_digest: teamDigest,
 			reviewed_intent: teamIntent,
 			bound: false,
@@ -912,7 +933,7 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		const acceptBody = {
 			token: team.payload.token,
 			invite_kind: "team_member",
-			identity_id: "identity-brian",
+			identity_id: assignedIdentityId,
 			device_id: device.deviceId,
 			public_key: device.publicKey,
 			fingerprint: device.fingerprint,
@@ -923,6 +944,34 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 				headers: { "content-type": "application/json" },
 				body: JSON.stringify(acceptBody),
 			});
+		await env.COORDINATOR_DB.prepare(
+			"UPDATE coordinator_invites SET assigned_identity_id = NULL WHERE token_digest IS NOT NULL AND invite_kind = 'team_member'",
+		).run();
+		const missingAssignment = await exports.default.fetch(
+			"https://example.com/v1/invites/inspect",
+			{
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ token: team.payload.token }),
+			},
+		);
+		expect(missingAssignment.status).toBe(404);
+		expect(await missingAssignment.json()).toEqual({ error: "invite_invalid" });
+		const missingAssignmentAcceptance = await accept();
+		expect(missingAssignmentAcceptance.status).toBe(404);
+		expect(await missingAssignmentAcceptance.json()).toEqual({ error: "invite_invalid" });
+		await env.COORDINATOR_DB.prepare(
+			"UPDATE coordinator_invites SET assigned_identity_id = ? WHERE token_digest IS NOT NULL AND invite_kind = 'team_member'",
+		)
+			.bind(assignedIdentityId)
+			.run();
+		const wrongTeamIdentity = await exports.default.fetch("https://example.com/v1/join", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ ...acceptBody, identity_id: "identity-owner" }),
+		});
+		expect(wrongTeamIdentity.status).toBe(409);
+		expect(await wrongTeamIdentity.json()).toEqual({ error: "invite_identity_conflict" });
 		expect(await (await accept()).json()).toMatchObject({
 			status: "accepted",
 			reviewed_intent: teamIntent,
@@ -944,9 +993,11 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		expect(changedDevice.status).toBe(409);
 		expect(await changedDevice.json()).toEqual({ error: "invite_already_bound" });
 
+		const addDeviceIntent = addDeviceReviewedIntent(assignedIdentityId);
+		const addDeviceDigest = await recipientReviewedIntentDigest(addDeviceIntent);
 		const addDevice = await createInvite({
 			invite_kind: "add_device",
-			target_identity_id: "identity-brian",
+			target_identity_id: assignedIdentityId,
 			reviewed_preview_digest: addDeviceDigest,
 			reviewed_intent: addDeviceIntent,
 		});
@@ -967,7 +1018,7 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		const addDeviceBody = {
 			token: addDevice.payload.token,
 			invite_kind: "add_device",
-			identity_id: "identity-brian",
+			identity_id: assignedIdentityId,
 			device_id: otherDevice.deviceId,
 			public_key: otherDevice.publicKey,
 			fingerprint: otherDevice.fingerprint,
@@ -988,7 +1039,7 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 		});
 
 		const enrollments = await env.COORDINATOR_DB.prepare(
-			`SELECT group_id, device_id, public_key, fingerprint, enabled
+			`SELECT group_id, device_id, public_key, fingerprint, identity_id, enabled
 			 FROM enrolled_devices ORDER BY device_id ASC`,
 		).all<Record<string, unknown>>();
 		expect(enrollments.results).toEqual(
@@ -999,6 +1050,7 @@ function signHeaders(identity: TestIdentity, method: string, url: string, body: 
 					device_id: enrolledDevice.deviceId,
 					public_key: enrolledDevice.publicKey,
 					fingerprint: enrolledDevice.fingerprint,
+					identity_id: assignedIdentityId,
 					enabled: 1,
 				})),
 		);

--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -62,7 +62,11 @@ import type {
 	CoordinatorUpdateScopeInput,
 	CoordinatorUpsertPresenceInput,
 } from "./coordinator-store-contract.js";
-import { normalizeInviteExpiresAt } from "./coordinator-store-contract.js";
+import {
+	isCoordinatorAssignedIdentityId,
+	normalizeInviteExpiresAt,
+	recipientInviteAuthoritativeIdentityId,
+} from "./coordinator-store-contract.js";
 import {
 	canonicalRecipientReviewedIntentJson,
 	parseStoredRecipientReviewedIntent,
@@ -134,8 +138,11 @@ const INVITE_COLUMNS = `invite_id, group_id, token, policy, expires_at, created_
 	inviter_actor_id, inviter_display_name, inviter_device_id, pending_person_id,
 	project_summaries_json, project_intent_json, consumed_at, bound_device_id, bound_public_key, bound_fingerprint,
 	recipient_actor_id, recipient_display_name, recipient_device_display_name, trust_state,
-	bootstrap_grant_id, invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest,
-	reviewed_intent_json`;
+	bootstrap_grant_id, invite_kind, policy_team_id, target_identity_id, assigned_identity_id,
+	reviewed_preview_digest, reviewed_intent_json`;
+
+const ENROLLMENT_COLUMNS =
+	"group_id, device_id, public_key, fingerprint, identity_id, display_name, enabled, created_at";
 
 function rowToRecord<T>(row: unknown): T {
 	if (row == null) throw new Error("expected row");
@@ -267,7 +274,11 @@ async function recipientInspection(
 	invite: CoordinatorInvite,
 ): Promise<CoordinatorRecipientInviteInspection | null> {
 	if (invite.invite_kind === "team_member") {
-		if (!invite.policy_team_id || !invite.reviewed_preview_digest)
+		if (
+			!invite.policy_team_id ||
+			!isCoordinatorAssignedIdentityId(invite.assigned_identity_id) ||
+			!invite.reviewed_preview_digest
+		)
 			throw new Error("invite_invalid");
 		const reviewedIntent = await parseStoredRecipientReviewedIntent(invite.reviewed_intent_json, {
 			target: { kind: "team_member", policyTeamId: invite.policy_team_id },
@@ -277,6 +288,7 @@ async function recipientInspection(
 			kind: "team_member",
 			invite,
 			policy_team_id: invite.policy_team_id,
+			assigned_identity_id: invite.assigned_identity_id,
 			reviewed_preview_digest: invite.reviewed_preview_digest,
 			reviewed_intent: reviewedIntent,
 			bound: Boolean(invite.consumed_at),
@@ -571,6 +583,7 @@ function initializeSchema(db: DatabaseType): void {
 			device_id TEXT NOT NULL,
 			public_key TEXT NOT NULL,
 			fingerprint TEXT NOT NULL,
+			identity_id TEXT,
 			display_name TEXT,
 			enabled INTEGER NOT NULL DEFAULT 1,
 			created_at TEXT NOT NULL,
@@ -625,6 +638,7 @@ function initializeSchema(db: DatabaseType): void {
 			invite_kind TEXT,
 			policy_team_id TEXT,
 			target_identity_id TEXT,
+			assigned_identity_id TEXT,
 			reviewed_preview_digest TEXT,
 			reviewed_intent_json TEXT
 		);
@@ -764,6 +778,11 @@ function initializeSchema(db: DatabaseType): void {
 	} catch {
 		// already exists
 	}
+	try {
+		db.prepare("ALTER TABLE enrolled_devices ADD COLUMN identity_id TEXT").run();
+	} catch {
+		// already exists
+	}
 	for (const column of [
 		"operation_id",
 		"reviewed_project_set_digest",
@@ -786,6 +805,7 @@ function initializeSchema(db: DatabaseType): void {
 		"invite_kind",
 		"policy_team_id",
 		"target_identity_id",
+		"assigned_identity_id",
 		"reviewed_preview_digest",
 		"reviewed_intent_json",
 	]) {
@@ -828,23 +848,29 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 	}
 
 	private enrollDeviceSync(groupId: string, opts: CoordinatorEnrollDeviceInput): void {
-		this.db
+		const result = this.db
 			.prepare(`INSERT INTO enrolled_devices(
-					group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
-				) VALUES (?, ?, ?, ?, ?, 1, ?)
+					group_id, device_id, public_key, fingerprint, identity_id, display_name, enabled, created_at
+				) VALUES (?, ?, ?, ?, ?, ?, 1, ?)
 				ON CONFLICT(group_id, device_id) DO UPDATE SET
 					public_key = excluded.public_key,
 					fingerprint = excluded.fingerprint,
+					identity_id = COALESCE(enrolled_devices.identity_id, excluded.identity_id),
 					display_name = excluded.display_name,
-					enabled = 1`)
+					enabled = 1
+				WHERE excluded.identity_id IS NULL
+					OR enrolled_devices.identity_id IS NULL
+					OR enrolled_devices.identity_id = excluded.identity_id`)
 			.run(
 				groupId,
 				opts.deviceId,
 				opts.publicKey,
 				opts.fingerprint,
+				opts.identityId ?? null,
 				opts.displayName ?? null,
 				nowISO(),
 			);
+		if (result.changes === 0) throw new Error("invite_identity_conflict");
 	}
 
 	async close(): Promise<void> {
@@ -911,7 +937,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 	): Promise<CoordinatorEnrollment[]> {
 		const where = includeDisabled ? "" : "AND enabled = 1";
 		return this.db
-			.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+			.prepare(`SELECT ${ENROLLMENT_COLUMNS}
 				 FROM enrolled_devices
 				 WHERE group_id = ? ${where}
 				 ORDER BY created_at ASC, device_id ASC`)
@@ -921,7 +947,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 
 	async getEnrollment(groupId: string, deviceId: string): Promise<CoordinatorEnrollment | null> {
 		const row = this.db
-			.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+			.prepare(`SELECT ${ENROLLMENT_COLUMNS}
 				 FROM enrolled_devices
 				 WHERE group_id = ? AND device_id = ? AND enabled = 1`)
 			.get(groupId, deviceId);
@@ -991,6 +1017,8 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		const operationId = clean(opts.operationId);
 		const reviewedProjectSetDigest = clean(opts.reviewedProjectSetDigest);
 		const metadata = await normalizeInviteMetadata(opts);
+		const assignedIdentityId =
+			metadata.inviteKind === "team_member" ? `identity:${tokenUrlSafe(18)}` : null;
 		if (Boolean(operationId) !== Boolean(reviewedProjectSetDigest)) {
 			throw new Error("operationId and reviewedProjectSetDigest must be provided together.");
 		}
@@ -1060,9 +1088,9 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 					team_name_snapshot, revoked_at, operation_id, reviewed_project_set_digest,
 					token_digest, inviter_actor_id, inviter_display_name, inviter_device_id,
 					pending_person_id, project_summaries_json, project_intent_json, trust_state,
-					invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest,
-					reviewed_intent_json
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+					invite_kind, policy_team_id, target_identity_id, assigned_identity_id,
+					reviewed_preview_digest, reviewed_intent_json
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 				.run(
 					inviteId,
 					opts.groupId,
@@ -1085,6 +1113,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 					metadata.inviteKind,
 					metadata.policyTeamId,
 					metadata.targetIdentityId,
+					assignedIdentityId,
 					metadata.reviewedPreviewDigest,
 					metadata.reviewedIntentJson,
 				);
@@ -1174,6 +1203,9 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				invite.invite_id !== preflightInvite?.invite_id ||
 				invite.reviewed_intent_json !== preflightInvite.reviewed_intent_json ||
 				invite.reviewed_preview_digest !== preflightInvite.reviewed_preview_digest ||
+				invite.policy_team_id !== preflightInvite.policy_team_id ||
+				invite.target_identity_id !== preflightInvite.target_identity_id ||
+				invite.assigned_identity_id !== preflightInvite.assigned_identity_id ||
 				inspection.kind !== opts.inviteKind ||
 				invite.revoked_at
 			) {
@@ -1190,7 +1222,8 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 			if (fingerprintPublicKey(opts.publicKey) !== opts.fingerprint) {
 				throw new Error("fingerprint_mismatch");
 			}
-			if (inspection.kind === "add_device" && inspection.target_identity_id !== opts.identityId) {
+			const authoritativeIdentityId = recipientInviteAuthoritativeIdentityId(inspection);
+			if (authoritativeIdentityId !== opts.identityId) {
 				throw new Error("invite_identity_conflict");
 			}
 			const sameBinding =
@@ -1198,17 +1231,19 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				invite.bound_public_key === opts.publicKey &&
 				invite.bound_fingerprint === opts.fingerprint;
 			if (invite.consumed_at && !sameBinding) throw new Error("invite_already_bound");
-			if (invite.consumed_at && invite.recipient_actor_id !== opts.identityId) {
+			if (invite.consumed_at && invite.recipient_actor_id !== authoritativeIdentityId) {
 				throw new Error("invite_identity_conflict");
 			}
 			const existingEnrollment = this.db
-				.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+				.prepare(`SELECT ${ENROLLMENT_COLUMNS}
 					FROM enrolled_devices WHERE group_id = ? AND device_id = ?`)
 				.get(invite.group_id, opts.deviceId) as CoordinatorEnrollment | undefined;
 			if (
 				existingEnrollment &&
 				(existingEnrollment.public_key !== opts.publicKey ||
-					existingEnrollment.fingerprint !== opts.fingerprint)
+					existingEnrollment.fingerprint !== opts.fingerprint ||
+					(existingEnrollment.identity_id !== null &&
+						existingEnrollment.identity_id !== authoritativeIdentityId))
 			) {
 				throw new Error("invite_identity_conflict");
 			}
@@ -1227,7 +1262,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 							opts.deviceId,
 							opts.publicKey,
 							opts.fingerprint,
-							opts.identityId,
+							authoritativeIdentityId,
 							invite.invite_id,
 							consumedAt,
 							opts.inviteKind,
@@ -1242,24 +1277,51 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 			) {
 				throw new Error("invite_already_bound");
 			}
-			if (saved.recipient_actor_id !== opts.identityId) throw new Error("invite_identity_conflict");
+			if (saved.recipient_actor_id !== authoritativeIdentityId)
+				throw new Error("invite_identity_conflict");
 			if (changed === 1) {
 				this.db
 					.prepare(`INSERT INTO enrolled_devices(
-						group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
-					) VALUES (?, ?, ?, ?, NULL, 1, ?)
+						group_id, device_id, public_key, fingerprint, identity_id, display_name, enabled, created_at
+					) VALUES (?, ?, ?, ?, ?, NULL, 1, ?)
 					ON CONFLICT(group_id, device_id) DO UPDATE SET
 						public_key = excluded.public_key,
 						fingerprint = excluded.fingerprint,
-						enabled = 1`)
-					.run(invite.group_id, opts.deviceId, opts.publicKey, opts.fingerprint, consumedAt);
+						identity_id = COALESCE(enrolled_devices.identity_id, excluded.identity_id),
+						enabled = 1
+					WHERE enrolled_devices.identity_id IS NULL
+						OR enrolled_devices.identity_id = excluded.identity_id`)
+					.run(
+						invite.group_id,
+						opts.deviceId,
+						opts.publicKey,
+						opts.fingerprint,
+						authoritativeIdentityId,
+						consumedAt,
+					);
+			} else {
+				this.db
+					.prepare(`UPDATE enrolled_devices SET identity_id = ?
+						WHERE group_id = ? AND device_id = ? AND identity_id IS NULL
+							AND public_key = ? AND fingerprint = ?`)
+					.run(
+						authoritativeIdentityId,
+						invite.group_id,
+						opts.deviceId,
+						opts.publicKey,
+						opts.fingerprint,
+					);
 			}
 			const enrollment = this.db
-				.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+				.prepare(`SELECT ${ENROLLMENT_COLUMNS}
 					FROM enrolled_devices WHERE group_id = ? AND device_id = ? AND enabled = 1`)
 				.get(invite.group_id, opts.deviceId) as CoordinatorEnrollment | undefined;
 			if (!enrollment) throw new Error("invite_acceptance_incomplete");
-			if (enrollment.public_key !== opts.publicKey || enrollment.fingerprint !== opts.fingerprint) {
+			if (
+				enrollment.public_key !== opts.publicKey ||
+				enrollment.fingerprint !== opts.fingerprint ||
+				enrollment.identity_id !== authoritativeIdentityId
+			) {
 				throw new Error("invite_identity_conflict");
 			}
 			return {
@@ -1309,7 +1371,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				throw new Error("invite_identity_conflict");
 			}
 			const existingEnrollment = this.db
-				.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+				.prepare(`SELECT ${ENROLLMENT_COLUMNS}
 					FROM enrolled_devices WHERE group_id = ? AND device_id = ?`)
 				.get(invite.group_id, opts.deviceId) as CoordinatorEnrollment | undefined;
 			if (
@@ -1377,7 +1439,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 			}
 			const seed = invite.inviter_device_id
 				? (this.db
-						.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+						.prepare(`SELECT ${ENROLLMENT_COLUMNS}
 							FROM enrolled_devices WHERE group_id = ? AND device_id = ? AND enabled = 1`)
 						.get(invite.group_id, invite.inviter_device_id) as CoordinatorEnrollment | undefined)
 				: undefined;
@@ -1412,7 +1474,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				.prepare(`SELECT ${INVITE_COLUMNS} FROM coordinator_invites WHERE invite_id = ?`)
 				.get(invite.invite_id) as CoordinatorInvite;
 			const enrollment = this.db
-				.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+				.prepare(`SELECT ${ENROLLMENT_COLUMNS}
 					FROM enrolled_devices WHERE group_id = ? AND device_id = ? AND enabled = 1`)
 				.get(invite.group_id, opts.deviceId) as CoordinatorEnrollment | undefined;
 			if (!enrollment) throw new Error("invite_acceptance_incomplete");

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -602,11 +602,13 @@ describe("coordinator local admin actions", () => {
 							invite_id: "invite-team-1",
 							invite_kind: "team_member",
 							policy_team_id: "policy-team-1",
+							assigned_identity_id: "identity-assigned-team",
 							reviewed_preview_digest: digest,
 						},
 						payload: {
 							kind: "team_member",
 							policy_team_id: "policy-team-1",
+							assigned_identity_id: "identity-assigned-team",
 							reviewed_preview_digest: digest,
 						},
 						encoded: "digest-only",
@@ -900,7 +902,7 @@ describe("coordinator local admin actions", () => {
 			expires_at: "2099-01-01T00:00:00.000Z",
 			team_name: null,
 			...(testCase.kind === "team_member"
-				? { policy_team_id: testCase.targetId }
+				? { policy_team_id: testCase.targetId, assigned_identity_id: "identity-team" }
 				: { target_identity_id: testCase.targetId }),
 			reviewed_preview_digest: reviewedDigest,
 		});
@@ -1303,6 +1305,7 @@ describe("coordinator local admin actions", () => {
 							identity_id: testCase.identityId,
 							policy_team_id: testCase.kind === "team_member" ? "team-a" : null,
 							target_identity_id: testCase.kind === "add_device" ? testCase.identityId : null,
+							assigned_identity_id: testCase.kind === "team_member" ? testCase.identityId : null,
 							reviewed_preview_digest: reviewedDigest,
 							reviewed_intent: reviewedIntent,
 						}),
@@ -1320,7 +1323,7 @@ describe("coordinator local admin actions", () => {
 			expires_at: "2099-01-01T00:00:00.000Z",
 			team_name: null,
 			...(testCase.kind === "team_member"
-				? { policy_team_id: "team-a" }
+				? { policy_team_id: "team-a", assigned_identity_id: testCase.identityId }
 				: { target_identity_id: testCase.identityId }),
 			reviewed_preview_digest: reviewedDigest,
 		});
@@ -1442,6 +1445,7 @@ describe("coordinator local admin actions", () => {
 					JSON.stringify({
 						kind: testCase.kind,
 						policy_team_id: testCase.kind === "team_member" ? testCase.targetId : undefined,
+						assigned_identity_id: testCase.kind === "team_member" ? testCase.identityId : undefined,
 						target_identity_id: testCase.kind === "add_device" ? testCase.targetId : undefined,
 						reviewed_preview_digest: reviewedDigest,
 						reviewed_intent: reviewedIntent,
@@ -1461,7 +1465,10 @@ describe("coordinator local admin actions", () => {
 			expires_at: "2099-01-01T00:00:00.000Z",
 			team_name: null,
 			...(testCase.kind === "team_member"
-				? { policy_team_id: testCase.targetId }
+				? {
+						policy_team_id: testCase.targetId,
+						assigned_identity_id: testCase.identityId,
+					}
 				: { target_identity_id: testCase.targetId }),
 			reviewed_preview_digest: reviewedDigest,
 		});
@@ -1545,6 +1552,7 @@ describe("coordinator local admin actions", () => {
 							identity_id: identityId,
 							policy_team_id: "team-a",
 							target_identity_id: null,
+							assigned_identity_id: identityId,
 							reviewed_preview_digest: reviewedDigest,
 							reviewed_intent: reviewedIntent,
 							...testCase.responseOverride,
@@ -1563,6 +1571,7 @@ describe("coordinator local admin actions", () => {
 			expires_at: "2099-01-01T00:00:00.000Z",
 			team_name: null,
 			policy_team_id: "team-a",
+			assigned_identity_id: identityId,
 			reviewed_preview_digest: reviewedDigest,
 		});
 
@@ -1584,32 +1593,49 @@ describe("coordinator local admin actions", () => {
 		expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
 	});
 
-	it("rejects a recipient response changed after valid inspection without local persistence", async () => {
-		const actionDbPath = join(tmpDir, "recipient-post-join-mismatch.sqlite");
-		const keysDir = join(tmpDir, "recipient-post-join-mismatch-keys");
-		const configPath = join(tmpDir, "recipient-post-join-mismatch-config.json");
-		const identityId = "identity-recipient";
-		const token = "recipient-post-join-mismatch-token";
-		const originalConfig = { actor_id: identityId, sync_coordinator_groups: ["existing-group"] };
+	it.each([
+		{
+			kind: "team_member" as const,
+			targetId: "team-a",
+			identityId: "identity-recipient-team",
+		},
+		{
+			kind: "add_device" as const,
+			targetId: "identity-recipient-device",
+			identityId: "identity-recipient-device",
+		},
+	])("rejects a conflicting $kind response Identity after valid inspection without local persistence", async (testCase) => {
+		const actionDbPath = join(tmpDir, `recipient-post-join-${testCase.kind}-mismatch.sqlite`);
+		const keysDir = join(tmpDir, `recipient-post-join-${testCase.kind}-mismatch-keys`);
+		const configPath = join(tmpDir, `recipient-post-join-${testCase.kind}-mismatch-config.json`);
+		const token = `recipient-post-join-${testCase.kind}-mismatch-token`;
+		const originalConfig = {
+			actor_id: testCase.identityId,
+			sync_coordinator_groups: ["existing-group"],
+		};
 		writeCodememConfigFile(originalConfig, configPath);
-		const reviewedIntent = teamReviewedIntent("team-a");
+		const reviewedIntent =
+			testCase.kind === "team_member"
+				? teamReviewedIntent(testCase.targetId)
+				: addDeviceReviewedIntent(testCase.targetId);
 		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
 		const reviewedOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
 			dbPath: actionDbPath,
 			keysDir,
 			invitationId: token,
-			identityId,
+			identityId: testCase.identityId,
 			deviceDisplayName: "Recipient laptop",
 			reviewedIntent,
 		});
 		const validResponse = {
 			ok: true,
 			status: "accepted",
-			kind: "team_member",
+			kind: testCase.kind,
 			group_id: "coordinator-a",
-			identity_id: identityId,
-			policy_team_id: "team-a",
-			target_identity_id: null,
+			identity_id: testCase.identityId,
+			policy_team_id: testCase.kind === "team_member" ? testCase.targetId : null,
+			target_identity_id: testCase.kind === "add_device" ? testCase.targetId : null,
+			assigned_identity_id: testCase.kind === "team_member" ? testCase.identityId : null,
 			reviewed_preview_digest: reviewedDigest,
 			reviewed_intent: reviewedIntent,
 		};
@@ -1623,7 +1649,7 @@ describe("coordinator local admin actions", () => {
 					JSON.stringify(
 						requestedUrl.endsWith("/v1/invites/inspect")
 							? validResponse
-							: { ...validResponse, reviewed_preview_digest: "f".repeat(64) },
+							: { ...validResponse, identity_id: "identity-other" },
 					),
 					{ status: 200 },
 				);
@@ -1631,14 +1657,19 @@ describe("coordinator local admin actions", () => {
 		);
 		const invite = encodeInvitePayload({
 			v: 1,
-			kind: "team_member",
+			kind: testCase.kind,
 			coordinator_url: "https://coord.example.test",
 			group_id: "coordinator-a",
 			policy: "auto_admit",
 			token,
 			expires_at: "2099-01-01T00:00:00.000Z",
 			team_name: null,
-			policy_team_id: "team-a",
+			...(testCase.kind === "team_member"
+				? {
+						policy_team_id: testCase.targetId,
+						assigned_identity_id: testCase.identityId,
+					}
+				: { target_identity_id: testCase.targetId }),
 			reviewed_preview_digest: reviewedDigest,
 		});
 
@@ -1648,7 +1679,7 @@ describe("coordinator local admin actions", () => {
 				dbPath: actionDbPath,
 				keysDir,
 				configPath,
-				recipientActorId: identityId,
+				recipientActorId: testCase.identityId,
 				recipientDisplayName: "Recipient",
 				deviceDisplayName: "Recipient laptop",
 				reviewedOnboardingDigest,

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -21,10 +21,12 @@ import type {
 	CoordinatorGroup,
 	CoordinatorJoinRequest,
 	CoordinatorJoinRequestReviewResult,
+	CoordinatorRecipientInviteKind,
 	CoordinatorRevokeScopeMembershipInput,
 	CoordinatorScope,
 	CoordinatorScopeMembership,
 } from "./coordinator-store-contract.js";
+import { recipientInviteAuthoritativeIdentityId } from "./coordinator-store-contract.js";
 import { connect, resolveDbPath } from "./db.js";
 import { initDatabase } from "./maintenance.js";
 import {
@@ -1114,6 +1116,7 @@ export async function coordinatorCreateInviteAction(opts: {
 			invite_kind: inviteRecord?.invite_kind ?? inviteKind,
 			policy_team_id: inviteRecord?.policy_team_id ?? opts.policyTeamId ?? null,
 			target_identity_id: inviteRecord?.target_identity_id ?? opts.targetIdentityId ?? null,
+			assigned_identity_id: inviteRecord?.assigned_identity_id ?? null,
 			reviewed_preview_digest:
 				inviteRecord?.reviewed_preview_digest ?? opts.reviewedPreviewDigest ?? null,
 			encoded: payload?.encoded,
@@ -1172,6 +1175,7 @@ export async function coordinatorCreateInviteAction(opts: {
 			...(invite.invite_kind === "team_member"
 				? {
 						policy_team_id: invite.policy_team_id ?? undefined,
+						assigned_identity_id: invite.assigned_identity_id ?? undefined,
 						reviewed_preview_digest: invite.reviewed_preview_digest ?? undefined,
 					}
 				: {}),
@@ -1191,6 +1195,7 @@ export async function coordinatorCreateInviteAction(opts: {
 			invite_kind: invite.invite_kind ?? inviteKind,
 			policy_team_id: invite.policy_team_id ?? null,
 			target_identity_id: invite.target_identity_id ?? null,
+			assigned_identity_id: invite.assigned_identity_id ?? null,
 			reviewed_preview_digest: invite.reviewed_preview_digest ?? null,
 			encoded,
 			link: inviteLink(encoded),
@@ -1316,21 +1321,34 @@ async function validateRecipientInviteReview(opts: {
 	deviceDisplayName: string;
 	recipientDisplayName: string;
 	reviewedOnboardingDigest: string;
+	requireResponseIdentity?: boolean;
 }): Promise<{
 	reviewedIntent: RecipientReviewedIntentV1;
 	persistedRecipientDisplayName: string;
 }> {
 	const responseKind = String(opts.response?.kind ?? "").trim();
 	const responseDigest = String(opts.response?.reviewed_preview_digest ?? "").trim();
+	const payloadIdentityId = recipientInviteAuthoritativeIdentityId({
+		kind: opts.payload.kind as CoordinatorRecipientInviteKind,
+		assigned_identity_id: opts.payload.assigned_identity_id,
+		target_identity_id: opts.payload.target_identity_id,
+	});
+	const responseIdentityId = recipientInviteAuthoritativeIdentityId({
+		kind: opts.payload.kind as CoordinatorRecipientInviteKind,
+		assigned_identity_id: opts.response?.assigned_identity_id,
+		target_identity_id: opts.response?.target_identity_id,
+	});
+	const acceptedIdentityId = String(opts.response?.identity_id ?? "").trim();
 	if (
 		responseKind !== opts.payload.kind ||
+		!payloadIdentityId ||
+		opts.identityId !== payloadIdentityId ||
+		responseIdentityId !== payloadIdentityId ||
+		(opts.requireResponseIdentity && acceptedIdentityId !== payloadIdentityId) ||
 		responseDigest !== String(opts.payload.reviewed_preview_digest ?? "").trim() ||
 		(opts.payload.kind === "team_member" &&
 			String(opts.response?.policy_team_id ?? "").trim() !==
-				String(opts.payload.policy_team_id ?? "").trim()) ||
-		(opts.payload.kind === "add_device" &&
-			String(opts.response?.target_identity_id ?? "").trim() !==
-				String(opts.payload.target_identity_id ?? "").trim())
+				String(opts.payload.policy_team_id ?? "").trim())
 	) {
 		throw new Error("recipient_invite_intent_mismatch");
 	}
@@ -1442,31 +1460,36 @@ export async function coordinatorImportInviteAction(opts: {
 	});
 	const explicitRecipientActorId = String(opts.recipientActorId ?? "").trim();
 	const configuredRecipientActorId = String(config.actor_id ?? "").trim();
-	const addDeviceTargetIdentityId =
-		payload.kind === "add_device" ? String(payload.target_identity_id ?? "").trim() : "";
+	const recipientInviteIdentityId = recipientInvite
+		? recipientInviteAuthoritativeIdentityId({
+				kind: payload.kind as CoordinatorRecipientInviteKind,
+				assigned_identity_id: payload.assigned_identity_id,
+				target_identity_id: payload.target_identity_id,
+			})
+		: "";
 	let recipientActorId =
 		explicitRecipientActorId || configuredRecipientActorId || `local:${deviceId}`;
-	if (payload.kind === "add_device") {
+	if (recipientInvite) {
 		if (
-			!addDeviceTargetIdentityId ||
-			(explicitRecipientActorId && explicitRecipientActorId !== addDeviceTargetIdentityId)
+			!recipientInviteIdentityId ||
+			(explicitRecipientActorId && explicitRecipientActorId !== recipientInviteIdentityId)
 		) {
 			throw new Error("invite_identity_conflict");
 		}
 		if (
 			configuredRecipientActorId &&
-			configuredRecipientActorId !== addDeviceTargetIdentityId &&
+			configuredRecipientActorId !== recipientInviteIdentityId &&
 			configuredRecipientActorId !== `local:${deviceId}`
 		) {
 			throw new Error("invite_identity_conflict");
 		}
 		const identityConn = connect(resolvedDbPath);
 		try {
-			assertAddDeviceIdentityAdoptionAllowed(identityConn, addDeviceTargetIdentityId, deviceId);
+			assertAddDeviceIdentityAdoptionAllowed(identityConn, recipientInviteIdentityId, deviceId);
 		} finally {
 			identityConn.close();
 		}
-		recipientActorId = addDeviceTargetIdentityId;
+		recipientActorId = recipientInviteIdentityId;
 	}
 	const recipientDisplayName =
 		projectInvite || recipientInvite
@@ -1612,6 +1635,7 @@ export async function coordinatorImportInviteAction(opts: {
 			response,
 			recipientDisplayName,
 			reviewedOnboardingDigest,
+			requireResponseIdentity: true,
 		});
 		persistedRecipientDisplayName = validatedReview.persistedRecipientDisplayName;
 		recipientOnboarding = {
@@ -1684,9 +1708,15 @@ export async function coordinatorImportInviteAction(opts: {
 			coordinator_url: payload.coordinator_url,
 			status: response?.status ?? null,
 			invite_kind: response?.kind ?? payload.kind,
-			identity_id: response?.identity_id ?? recipientActorId,
+			identity_id: recipientActorId,
 			policy_team_id: response?.policy_team_id ?? payload.policy_team_id ?? null,
 			target_identity_id: response?.target_identity_id ?? payload.target_identity_id ?? null,
+			...(payload.kind === "team_member"
+				? {
+						assigned_identity_id:
+							response?.assigned_identity_id ?? payload.assigned_identity_id ?? null,
+					}
+				: {}),
 			reviewed_preview_digest: response?.reviewed_preview_digest ?? null,
 			sync_enabled: true,
 		};

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { CoordinatorMembershipError } from "./coordinator-membership-effects.js";
 import {
 	BetterSqliteCoordinatorStore,
+	type CoordinatorConsumeRecipientInviteInput,
 	type CoordinatorCreateInviteInput,
 	type CoordinatorCreateJoinRequestInput,
 	type CoordinatorCreateReciprocalApprovalInput,
@@ -178,6 +179,7 @@ describe("createCoordinatorApp dependency injection", () => {
 					device_id: "d1",
 					public_key: "pk1",
 					fingerprint: "fp1",
+					identity_id: null,
 					display_name: "Laptop",
 					enabled: 1,
 					created_at: "2026-03-28T00:00:00Z",
@@ -206,6 +208,7 @@ describe("createCoordinatorApp dependency injection", () => {
 					device_id: "d1",
 					public_key: "pk1",
 					fingerprint: "fp1",
+					identity_id: null,
 					display_name: "Laptop",
 					enabled: 1,
 					created_at: "2026-03-28T00:00:00Z",
@@ -340,8 +343,10 @@ describe("createCoordinatorApp dependency injection", () => {
 	});
 
 	it("validates recipient reviewed intent at creation and keeps invitation payloads digest-only", async () => {
+		// Arrange
 		const reviewedIntent = teamReviewedIntent();
 		const digest = await recipientReviewedIntentDigest(reviewedIntent);
+		const assignedIdentityId = "opaque-assigned-team-identity";
 		const createInvite = vi.fn(async (input: CoordinatorCreateInviteInput) => ({
 			invite_id: "invite-team-1",
 			group_id: input.groupId,
@@ -354,6 +359,7 @@ describe("createCoordinatorApp dependency injection", () => {
 			revoked_at: null,
 			invite_kind: "team_member" as const,
 			policy_team_id: "policy-team-1",
+			assigned_identity_id: assignedIdentityId,
 			reviewed_preview_digest: digest,
 		}));
 		const store = createMockStore({
@@ -420,11 +426,25 @@ describe("createCoordinatorApp dependency injection", () => {
 		expect(digestMismatch.status).toBe(409);
 		expect(await digestMismatch.json()).toEqual({ error: "recipient_invite_intent_mismatch" });
 
+		const callerAssigned = await app.request("/v1/admin/invites", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				...base,
+				assigned_identity_id: "identity-owner",
+				reviewed_intent: reviewedIntent,
+			}),
+		});
+		expect(callerAssigned.status).toBe(400);
+		expect(await callerAssigned.json()).toEqual({ error: "assigned_identity_id_forbidden" });
+
 		const valid = await app.request("/v1/admin/invites", {
 			method: "POST",
 			headers,
 			body: JSON.stringify({ ...base, reviewed_intent: reviewedIntent }),
 		});
+
+		// Assert
 		expect(valid.status).toBe(200);
 		const response = (await valid.json()) as {
 			payload: Record<string, unknown>;
@@ -434,6 +454,7 @@ describe("createCoordinatorApp dependency injection", () => {
 		expect(createInvite).toHaveBeenCalledWith(
 			expect.objectContaining({ reviewedIntent, reviewedPreviewDigest: digest }),
 		);
+		expect(createInvite).toHaveBeenCalledTimes(1);
 		expect(response.payload).not.toHaveProperty("reviewed_intent");
 		expect(response.encoded).not.toContain("reviewed_intent");
 		expect(response.link).not.toContain("reviewed_intent");
@@ -483,9 +504,11 @@ describe("createCoordinatorApp dependency injection", () => {
 	});
 
 	it("inspects and consumes explicit Team invitations without enrollment or scope grants", async () => {
+		// Arrange
 		const publicKey = "recipient-public-key";
 		const reviewedIntent = teamReviewedIntent();
 		const digest = await recipientReviewedIntentDigest(reviewedIntent);
+		const assignedIdentityId = "opaque-assigned-team-identity";
 		const invite: CoordinatorInvite = {
 			invite_id: "invite-team-1",
 			group_id: "g1",
@@ -498,23 +521,30 @@ describe("createCoordinatorApp dependency injection", () => {
 			revoked_at: null,
 			invite_kind: "team_member",
 			policy_team_id: "policy-team-1",
+			assigned_identity_id: assignedIdentityId,
 			reviewed_preview_digest: digest,
 		};
-		const consumeRecipientInvite = vi.fn(async () => ({
-			status: "accepted" as const,
-			invite: {
-				...invite,
-				consumed_at: "2026-03-28T00:00:00Z",
-				recipient_actor_id: "identity-brian",
-			},
-			reviewed_intent: reviewedIntent,
-		}));
+		const consumeRecipientInvite = vi.fn(async (input: CoordinatorConsumeRecipientInviteInput) => {
+			if (input.identityId !== assignedIdentityId) {
+				throw new Error("invite_identity_conflict");
+			}
+			return {
+				status: "accepted" as const,
+				invite: {
+					...invite,
+					consumed_at: "2026-03-28T00:00:00Z",
+					recipient_actor_id: assignedIdentityId,
+				},
+				reviewed_intent: reviewedIntent,
+			};
+		});
 		const store = createMockStore({
 			getInviteByTokenForInspection: vi.fn(async () => invite),
 			inspectRecipientInvite: vi.fn(async () => ({
 				kind: "team_member" as const,
 				invite,
 				policy_team_id: "policy-team-1",
+				assigned_identity_id: assignedIdentityId,
 				reviewed_preview_digest: digest,
 				reviewed_intent: reviewedIntent,
 				bound: false,
@@ -527,41 +557,67 @@ describe("createCoordinatorApp dependency injection", () => {
 			requestVerifier: allowRequest,
 		});
 
+		// Act
 		const inspection = await app.request("/v1/invites/inspect", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ token: invite.token }),
 		});
+
+		// Assert
 		expect(await inspection.json()).toEqual({
 			kind: "team_member",
 			policy_team_id: "policy-team-1",
+			assigned_identity_id: assignedIdentityId,
 			reviewed_preview_digest: digest,
 			reviewed_intent: reviewedIntent,
 			bound: false,
 		});
 
+		// Act
+		const conflicting = await app.request("/v1/join", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				token: invite.token,
+				invite_kind: "team_member",
+				identity_id: "identity-owner",
+				device_id: "device-brian",
+				public_key: publicKey,
+				fingerprint: fingerprintPublicKey(publicKey),
+			}),
+		});
+
+		// Assert
+		expect(conflicting.status).toBe(409);
+		expect(await conflicting.json()).toEqual({ error: "invite_identity_conflict" });
+
+		// Act
 		const accepted = await app.request("/v1/join", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
 				token: invite.token,
 				invite_kind: "team_member",
-				identity_id: "identity-brian",
+				identity_id: assignedIdentityId,
 				device_id: "device-brian",
 				public_key: publicKey,
 				fingerprint: fingerprintPublicKey(publicKey),
 			}),
 		});
+
+		// Assert
 		expect(await accepted.json()).toMatchObject({
 			ok: true,
 			status: "accepted",
 			kind: "team_member",
-			identity_id: "identity-brian",
+			identity_id: assignedIdentityId,
 			policy_team_id: "policy-team-1",
+			assigned_identity_id: assignedIdentityId,
 			reviewed_preview_digest: digest,
 			reviewed_intent: reviewedIntent,
 		});
-		expect(consumeRecipientInvite).toHaveBeenCalledOnce();
+		expect(consumeRecipientInvite).toHaveBeenCalledTimes(2);
 		expect(store.enrollDevice).not.toHaveBeenCalled();
 		expect(store.grantScopeMembership).not.toHaveBeenCalled();
 	});
@@ -1047,6 +1103,7 @@ describe("createCoordinatorApp dependency injection", () => {
 			device_id: "d1",
 			public_key: "pk1",
 			fingerprint: "fp1",
+			identity_id: null,
 			display_name: "Laptop",
 			enabled: 1,
 			created_at: "2026-03-28T00:00:00Z",
@@ -1105,6 +1162,7 @@ describe("createCoordinatorApp dependency injection", () => {
 			device_id: "d1",
 			public_key: "pk1",
 			fingerprint: "fp1",
+			identity_id: null,
 			display_name: "Laptop",
 			enabled: 1,
 			created_at: "2026-03-28T00:00:00Z",
@@ -1254,6 +1312,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				device_id: "local-device",
 				public_key: "pk1",
 				fingerprint: "fp1",
+				identity_id: null,
 				display_name: "Laptop",
 				enabled: 1,
 				created_at: "2026-03-28T00:00:00Z",
@@ -1329,6 +1388,7 @@ describe("createCoordinatorApp dependency injection", () => {
 						device_id: deviceId,
 						public_key: deviceId === "local-device" ? "pk1" : "pk2",
 						fingerprint: deviceId === "local-device" ? "fp1" : "fp2",
+						identity_id: null,
 						display_name: deviceId,
 						enabled: 1,
 						created_at: "2026-03-28T00:00:00Z",
@@ -1724,6 +1784,7 @@ describe("createCoordinatorApp dependency injection", () => {
 					device_id: "device-a",
 					public_key: "pk1",
 					fingerprint: "fp1",
+					identity_id: null,
 					display_name: "Laptop",
 					enabled: 1,
 					created_at: "2026-03-28T00:00:00Z",
@@ -1866,6 +1927,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				device_id: "device-a",
 				public_key: "pk-a",
 				fingerprint: "fp-a",
+				identity_id: null,
 				display_name: "Device A",
 				enabled: 1,
 				created_at: "2026-03-28T00:00:00Z",
@@ -1940,6 +2002,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				device_id: "device-a",
 				public_key: "pk-a",
 				fingerprint: "fp-a",
+				identity_id: null,
 				display_name: "Device A",
 				enabled: 1,
 				created_at: "2026-03-28T00:00:00Z",

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -1350,6 +1350,9 @@ export function createCoordinatorApp(
 		if (!groupId || !["auto_admit", "approval_required"].includes(policy) || !expiresAt) {
 			return c.json({ error: "group_id_policy_and_expires_at_required" }, 400);
 		}
+		if (Object.hasOwn(data, "assigned_identity_id")) {
+			return c.json({ error: "assigned_identity_id_forbidden" }, 400);
+		}
 		// Validate the date at the boundary so store.createInvite's
 		// normalizeInviteExpiresAt throw can't escape as an unhandled 500.
 		if (Number.isNaN(new Date(expiresAt).getTime())) {
@@ -1521,6 +1524,7 @@ export function createCoordinatorApp(
 				...(invite.invite_kind === "team_member"
 					? {
 							policy_team_id: invite.policy_team_id ?? undefined,
+							assigned_identity_id: invite.assigned_identity_id ?? undefined,
 							reviewed_preview_digest: invite.reviewed_preview_digest ?? undefined,
 						}
 					: {}),
@@ -1576,6 +1580,7 @@ export function createCoordinatorApp(
 							? {
 									kind: inspection.kind,
 									policy_team_id: inspection.policy_team_id,
+									assigned_identity_id: inspection.assigned_identity_id,
 									reviewed_preview_digest: inspection.reviewed_preview_digest,
 									reviewed_intent: inspection.reviewed_intent,
 									bound: inspection.bound,
@@ -1903,6 +1908,7 @@ export function createCoordinatorApp(
 						identity_id: acceptance.invite.recipient_actor_id,
 						policy_team_id: acceptance.invite.policy_team_id ?? null,
 						target_identity_id: acceptance.invite.target_identity_id ?? null,
+						assigned_identity_id: acceptance.invite.assigned_identity_id ?? null,
 						reviewed_preview_digest: acceptance.invite.reviewed_preview_digest,
 						reviewed_intent: acceptance.reviewed_intent,
 					});

--- a/packages/core/src/coordinator-invites.ts
+++ b/packages/core/src/coordinator-invites.ts
@@ -20,6 +20,7 @@ export interface InvitePayload {
 	/** Policy metadata for recipient-aware invites. It is preview-only and never grants scope access. */
 	policy_team_id?: string;
 	target_identity_id?: string;
+	assigned_identity_id?: string;
 	reviewed_preview_digest?: string;
 }
 

--- a/packages/core/src/coordinator-store-contract.ts
+++ b/packages/core/src/coordinator-store-contract.ts
@@ -28,6 +28,7 @@ export interface CoordinatorEnrollment {
 	device_id: string;
 	public_key: string;
 	fingerprint: string;
+	identity_id: string | null;
 	display_name: string | null;
 	enabled: number;
 	created_at: string;
@@ -69,6 +70,8 @@ export interface CoordinatorInvite {
 	policy_team_id?: string | null;
 	/** Identity fixed by an add-device invitation. */
 	target_identity_id?: string | null;
+	/** Opaque Identity minted by the coordinator for a Team-member invitation. */
+	assigned_identity_id?: string | null;
 	/** Digest of the server-owned preview reviewed before invitation creation. */
 	reviewed_preview_digest?: string | null;
 	/** Canonical JSON for the inviter-reviewed access intent. */
@@ -85,6 +88,28 @@ export type CoordinatorRecipientInviteKind = Extract<
 	CoordinatorInviteKind,
 	"team_member" | "add_device"
 >;
+
+const COORDINATOR_ASSIGNED_IDENTITY_PATTERN = /^identity:[A-Za-z0-9_-]{18,24}$/u;
+
+export function isCoordinatorAssignedIdentityId(value: unknown): value is string {
+	return (
+		typeof value === "string" &&
+		value === value.trim() &&
+		COORDINATOR_ASSIGNED_IDENTITY_PATTERN.test(value)
+	);
+}
+
+export function recipientInviteAuthoritativeIdentityId(value: {
+	kind: CoordinatorRecipientInviteKind;
+	assigned_identity_id?: unknown;
+	target_identity_id?: unknown;
+}): string {
+	return String(
+		value.kind === "team_member"
+			? (value.assigned_identity_id ?? "")
+			: (value.target_identity_id ?? ""),
+	).trim();
+}
 
 export interface CoordinatorProjectInviteSummary {
 	display_name: string;
@@ -104,6 +129,7 @@ export type CoordinatorRecipientInviteInspection =
 			kind: "team_member";
 			invite: CoordinatorInvite;
 			policy_team_id: string;
+			assigned_identity_id: string;
 			reviewed_preview_digest: string;
 			reviewed_intent?: RecipientReviewedIntentV1;
 			bound: boolean;
@@ -244,6 +270,8 @@ export interface CoordinatorEnrollDeviceInput {
 	fingerprint: string;
 	publicKey: string;
 	displayName?: string | null;
+	/** Null or omitted means the enrollment has no authoritative issuance binding. */
+	identityId?: string | null;
 }
 
 export interface CoordinatorCreateInviteInput {

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -35,6 +35,7 @@ export interface CoordinatorStoreHarnessContext<
 > {
 	store: TStore;
 	clearInviteReviewedIntent: (inviteId: string) => Promise<void> | void;
+	setInviteAssignedIdentity: (inviteId: string, identityId: string | null) => Promise<void> | void;
 	revokeInvite: (inviteId: string, revokedAt: string) => Promise<void> | void;
 	cleanup: () => Promise<void> | void;
 }
@@ -692,9 +693,12 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 		});
 
 		describe("devices", () => {
-			it("enrolls and retrieves a device", async () => {
+			it("keeps direct admin enrollment unbound to an identity", async () => {
 				await withContext(async ({ store }) => {
+					// Arrange
 					await store.createGroup("g1");
+
+					// Act
 					await store.enrollDevice("g1", {
 						deviceId: "d1",
 						fingerprint: "fp1",
@@ -702,9 +706,12 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 						displayName: "Laptop",
 					});
 					const enrollment = await store.getEnrollment("g1", "d1");
+
+					// Assert
 					expect(enrollment).not.toBeNull();
 					expect(enrollment?.device_id).toBe("d1");
 					expect(enrollment?.display_name).toBe("Laptop");
+					expect(enrollment).toEqual(expect.objectContaining({ identity_id: null }));
 				});
 			});
 
@@ -899,7 +906,10 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					const acceptance = {
 						token: invite.token,
 						inviteKind: testCase.kind,
-						identityId: testCase.kind === "add_device" ? testCase.targetId : "identity-recipient",
+						identityId:
+							testCase.kind === "team_member"
+								? String(invite.assigned_identity_id)
+								: testCase.targetId,
 						deviceId: "device-recipient",
 						publicKey: "recipient-public-key",
 						fingerprint: fingerprintPublicKey("recipient-public-key"),
@@ -955,7 +965,10 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					const acceptance = {
 						token: invite.token,
 						inviteKind: testCase.kind,
-						identityId: testCase.kind === "add_device" ? testCase.targetId : "identity-recipient",
+						identityId:
+							testCase.kind === "team_member"
+								? String(invite.assigned_identity_id)
+								: testCase.targetId,
 						deviceId: "device-recipient",
 						publicKey: "recipient-public-key",
 						fingerprint: fingerprintPublicKey("recipient-public-key"),
@@ -995,6 +1008,7 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 
 			it("persists, enrolls, and single-use binds explicit Team and add-device invitations without scope membership", async () => {
 				await withContext(async ({ store }) => {
+					// Arrange
 					await store.createGroup("g1", "Coordinator Alpha");
 					await store.createScope({ scopeId: "scope-project", label: "Project" });
 					const reviewedIntent = teamReviewedIntent("policy-team-1");
@@ -1008,9 +1022,15 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 						reviewedPreviewDigest: digest,
 						reviewedIntent,
 					});
+					const assignedIdentityId = teamInvite.assigned_identity_id;
+					expect(assignedIdentityId).toEqual(expect.any(String));
+					expect(assignedIdentityId?.trim()).toBe(assignedIdentityId);
+					expect(assignedIdentityId).toMatch(/^identity:[A-Za-z0-9_-]{18,24}$/u);
+					expect(assignedIdentityId).not.toBe("identity-owner");
 					expect(teamInvite).toMatchObject({
 						invite_kind: "team_member",
 						policy_team_id: "policy-team-1",
+						assigned_identity_id: assignedIdentityId,
 						reviewed_preview_digest: digest,
 						reviewed_intent_json: canonicalRecipientReviewedIntentJson(reviewedIntent),
 					});
@@ -1021,6 +1041,7 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					expect(teamInspection).toMatchObject({
 						kind: "team_member",
 						policy_team_id: "policy-team-1",
+						assigned_identity_id: assignedIdentityId,
 						reviewed_intent: reviewedIntent,
 						bound: false,
 					});
@@ -1028,29 +1049,68 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					const teamInput = {
 						token: teamInvite.token,
 						inviteKind: "team_member" as const,
-						identityId: "identity-brian",
+						identityId: String(assignedIdentityId),
 						deviceId: "device-brian",
 						publicKey,
 						fingerprint: fingerprintPublicKey(publicKey),
 						now: "2026-07-21T00:00:00.000Z",
 					};
+
+					// Act
+					const ownerConflict = store.consumeRecipientInvite({
+						...teamInput,
+						identityId: "identity-owner",
+					});
+					const differentIdentityConflict = store.consumeRecipientInvite({
+						...teamInput,
+						identityId: "identity-other",
+					});
+
+					// Assert
+					await Promise.all([
+						expect(ownerConflict).rejects.toThrow("invite_identity_conflict"),
+						expect(differentIdentityConflict).rejects.toThrow("invite_identity_conflict"),
+					]);
+					expect(await store.getEnrollment("g1", teamInput.deviceId)).toBeNull();
+					expect(await store.getInviteByTokenForInspection(teamInvite.token)).toMatchObject({
+						assigned_identity_id: assignedIdentityId,
+						consumed_at: null,
+						bound_device_id: null,
+						recipient_actor_id: null,
+					});
+
+					// Act
 					const acceptedTeam = await store.consumeRecipientInvite(teamInput);
-					const replayedTeam = await store.consumeRecipientInvite(teamInput);
+					const acceptedTeamEnrollment = await store.getEnrollment("g1", teamInput.deviceId);
+
+					// Assert
 					expect(acceptedTeam).toMatchObject({
 						status: "accepted",
 						reviewed_intent: reviewedIntent,
 					});
+
+					const replayedTeam = await store.consumeRecipientInvite(teamInput);
+					const replayedTeamEnrollment = await store.getEnrollment("g1", teamInput.deviceId);
 					expect(replayedTeam).toMatchObject({
 						status: "existing",
+						invite: { assigned_identity_id: assignedIdentityId },
 						reviewed_intent: reviewedIntent,
 					});
-					expect(await store.getEnrollment("g1", teamInput.deviceId)).toMatchObject({
-						group_id: "g1",
-						device_id: teamInput.deviceId,
-						public_key: teamInput.publicKey,
+					await store.enrollDevice("g1", {
+						deviceId: teamInput.deviceId,
+						publicKey: teamInput.publicKey,
 						fingerprint: teamInput.fingerprint,
-						enabled: 1,
+						displayName: "Brian's renamed device",
 					});
+					const reenrolledTeamEnrollment = await store.getEnrollment("g1", teamInput.deviceId);
+					await expect(
+						store.enrollDevice("g1", {
+							deviceId: teamInput.deviceId,
+							publicKey: teamInput.publicKey,
+							fingerprint: teamInput.fingerprint,
+							identityId: "identity-other",
+						}),
+					).rejects.toThrow("invite_identity_conflict");
 					await expect(
 						store.consumeRecipientInvite({ ...teamInput, identityId: "identity-other" }),
 					).rejects.toThrow("invite_identity_conflict");
@@ -1093,20 +1153,96 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 						...teamInput,
 						token: addDeviceInvite.token,
 						inviteKind: "add_device" as const,
+						identityId: "identity-brian",
 						deviceId: "device-brian-2",
 						publicKey: "add-device-key",
 						fingerprint: fingerprintPublicKey("add-device-key"),
 					};
 					expect((await store.consumeRecipientInvite(addDeviceInput)).status).toBe("accepted");
+					const acceptedAddDeviceEnrollment = await store.getEnrollment(
+						"g1",
+						addDeviceInput.deviceId,
+					);
 					expect((await store.consumeRecipientInvite(addDeviceInput)).status).toBe("existing");
-					expect(await store.getEnrollment("g1", addDeviceInput.deviceId)).toMatchObject({
-						group_id: "g1",
-						device_id: addDeviceInput.deviceId,
-						public_key: addDeviceInput.publicKey,
-						fingerprint: addDeviceInput.fingerprint,
-						enabled: 1,
-					});
+					const replayedAddDeviceEnrollment = await store.getEnrollment(
+						"g1",
+						addDeviceInput.deviceId,
+					);
+					expect([
+						acceptedTeamEnrollment,
+						replayedTeamEnrollment,
+						reenrolledTeamEnrollment,
+						acceptedAddDeviceEnrollment,
+						replayedAddDeviceEnrollment,
+					]).toEqual([
+						expect.objectContaining({
+							group_id: "g1",
+							device_id: teamInput.deviceId,
+							public_key: teamInput.publicKey,
+							fingerprint: teamInput.fingerprint,
+							identity_id: assignedIdentityId,
+							enabled: 1,
+						}),
+						expect.objectContaining({ identity_id: assignedIdentityId }),
+						expect.objectContaining({
+							identity_id: assignedIdentityId,
+							display_name: "Brian's renamed device",
+						}),
+						expect.objectContaining({
+							group_id: "g1",
+							device_id: addDeviceInput.deviceId,
+							public_key: addDeviceInput.publicKey,
+							fingerprint: addDeviceInput.fingerprint,
+							identity_id: addDeviceInput.identityId,
+							enabled: 1,
+						}),
+						expect.objectContaining({ identity_id: addDeviceInput.identityId }),
+					]);
 					expect(await store.listScopeMemberships("scope-project")).toEqual([]);
+				});
+			});
+
+			it("fails closed for malformed coordinator-assigned Team identities", async () => {
+				await withContext(async ({ store, setInviteAssignedIdentity }) => {
+					await store.createGroup("g1", "Coordinator Alpha");
+					const reviewedIntent = teamReviewedIntent("policy-team-1");
+					const invite = await store.createInvite({
+						groupId: "g1",
+						policy: "auto_admit",
+						expiresAt: "2099-01-01T00:00:00Z",
+						inviteKind: "team_member",
+						policyTeamId: "policy-team-1",
+						reviewedPreviewDigest: await recipientReviewedIntentDigest(reviewedIntent),
+						reviewedIntent,
+					});
+					for (const malformed of [
+						null,
+						"",
+						" identity:abcdefghijklmnopqr ",
+						"identity:abc\u0000defghijklmnop",
+						`identity:${"a".repeat(25)}`,
+						"identity-owner",
+					]) {
+						await setInviteAssignedIdentity(invite.invite_id, malformed);
+						await expect(
+							store.inspectRecipientInvite({
+								token: invite.token,
+								now: "2026-07-21T00:00:00.000Z",
+							}),
+						).rejects.toThrow("invite_invalid");
+						await expect(
+							store.consumeRecipientInvite({
+								token: invite.token,
+								inviteKind: "team_member",
+								identityId: String(malformed ?? "identity:abcdefghijklmnopqr"),
+								deviceId: "device-brian",
+								publicKey: "team-member-key",
+								fingerprint: fingerprintPublicKey("team-member-key"),
+								now: "2026-07-21T00:00:00.000Z",
+							}),
+						).rejects.toThrow();
+					}
+					expect(await store.getEnrollment("g1", "device-brian")).toBeNull();
 				});
 			});
 
@@ -1210,7 +1346,7 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					const input = {
 						token: invite.token,
 						inviteKind: "team_member" as const,
-						identityId: "identity-brian",
+						identityId: String(invite.assigned_identity_id),
 						deviceId: "device-brian",
 						publicKey,
 						fingerprint: fingerprintPublicKey(publicKey),
@@ -1474,6 +1610,9 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 						trust_state: "bootstrap_grant_created",
 					});
 					expect(retry.bootstrap_grant?.seed_device_id).toBe("seed-1");
+					expect(await store.getEnrollment("g1", input.deviceId)).toEqual(
+						expect.objectContaining({ identity_id: null }),
+					);
 					await expect(
 						store.consumeProjectInvite({ ...input, deviceId: "other-device" }),
 					).rejects.toThrow("invite_already_bound");
@@ -1950,6 +2089,7 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					expect(reviewed?.reviewed_by).toBe("admin");
 					const enrollment = await store.getEnrollment("g1", "d-new");
 					expect(enrollment?.fingerprint).toBe("fp-new");
+					expect(enrollment).toEqual(expect.objectContaining({ identity_id: null }));
 				});
 			});
 

--- a/packages/core/src/coordinator-store.test.ts
+++ b/packages/core/src/coordinator-store.test.ts
@@ -17,6 +17,11 @@ describe("CoordinatorStore", () => {
 					.prepare("UPDATE coordinator_invites SET reviewed_intent_json = NULL WHERE invite_id = ?")
 					.run(inviteId);
 			},
+			setInviteAssignedIdentity: (inviteId: string, identityId: string | null) => {
+				store.db
+					.prepare("UPDATE coordinator_invites SET assigned_identity_id = ? WHERE invite_id = ?")
+					.run(identityId, inviteId);
+			},
 			revokeInvite: (inviteId: string, revokedAt: string) => {
 				store.db
 					.prepare("UPDATE coordinator_invites SET revoked_at = ? WHERE invite_id = ?")
@@ -30,6 +35,53 @@ describe("CoordinatorStore", () => {
 	}
 
 	describe("schema", () => {
+		it("adds nullable enrollment identity binding while preserving pre-column rows", async () => {
+			// Arrange
+			const tmpDir = mkdtempSync(join(tmpdir(), "coord-enrollment-identity-upgrade-test-"));
+			const path = join(tmpDir, "coordinator.sqlite");
+			const legacy = new Database(path);
+			legacy.exec(`
+				CREATE TABLE enrolled_devices (
+					group_id TEXT NOT NULL,
+					device_id TEXT NOT NULL,
+					public_key TEXT NOT NULL,
+					fingerprint TEXT NOT NULL,
+					display_name TEXT,
+					enabled INTEGER NOT NULL DEFAULT 1,
+					created_at TEXT NOT NULL,
+					PRIMARY KEY (group_id, device_id)
+				);
+				INSERT INTO enrolled_devices(
+					group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+				) VALUES (
+					'g1', 'legacy-device', 'legacy-key', 'legacy-fingerprint', 'Legacy device', 1,
+					'2026-07-24T00:00:00Z'
+				);
+			`);
+			legacy.close();
+
+			// Act
+			const store = new BetterSqliteCoordinatorStore(path);
+
+			try {
+				// Assert
+				const columns = store.db.prepare("PRAGMA table_info(enrolled_devices)").all() as Array<{
+					name: string;
+				}>;
+				expect(columns.map((column) => column.name)).toContain("identity_id");
+				expect(
+					store.db
+						.prepare(
+							"SELECT device_id, identity_id FROM enrolled_devices WHERE device_id = 'legacy-device'",
+						)
+						.get(),
+				).toEqual({ device_id: "legacy-device", identity_id: null });
+			} finally {
+				await store.close();
+				rmSync(tmpDir, { recursive: true, force: true });
+			}
+		});
+
 		it("upgrades an existing project-intent invite table additively", async () => {
 			const tmpDir = mkdtempSync(join(tmpdir(), "coord-upgrade-test-"));
 			const path = join(tmpDir, "coordinator.sqlite");
@@ -51,7 +103,8 @@ describe("CoordinatorStore", () => {
 				const row = store.db
 					.prepare(
 						`SELECT token, token_digest, consumed_at, bound_device_id, trust_state,
-							invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest,
+							invite_kind, policy_team_id, target_identity_id, assigned_identity_id,
+							reviewed_preview_digest,
 							reviewed_intent_json
 						 FROM coordinator_invites`,
 					)
@@ -65,6 +118,7 @@ describe("CoordinatorStore", () => {
 					invite_kind: "legacy_enrollment",
 					policy_team_id: null,
 					target_identity_id: null,
+					assigned_identity_id: null,
 					reviewed_preview_digest: null,
 					reviewed_intent_json: null,
 				});

--- a/packages/core/src/d1-coordinator-runtime.test.ts
+++ b/packages/core/src/d1-coordinator-runtime.test.ts
@@ -117,6 +117,7 @@ describe("createD1CoordinatorApp", () => {
 					device_id: "d1",
 					public_key: "pk1",
 					fingerprint: "fp1",
+					identity_id: null,
 					display_name: "Laptop",
 					enabled: 1,
 					created_at: expect.any(String),

--- a/packages/core/src/d1-coordinator-store.test.ts
+++ b/packages/core/src/d1-coordinator-store.test.ts
@@ -217,6 +217,11 @@ describe("D1CoordinatorStore", () => {
 					"UPDATE coordinator_invites SET reviewed_intent_json = NULL WHERE invite_id = ?",
 				).run(inviteId);
 			},
+			setInviteAssignedIdentity: (inviteId: string, identityId: string | null) => {
+				db.prepare(
+					"UPDATE coordinator_invites SET assigned_identity_id = ? WHERE invite_id = ?",
+				).run(identityId, inviteId);
+			},
 			revokeInvite: (inviteId: string, revokedAt: string) => {
 				db.prepare("UPDATE coordinator_invites SET revoked_at = ? WHERE invite_id = ?").run(
 					revokedAt,

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -44,7 +44,11 @@ import type {
 	CoordinatorUpdateScopeInput,
 	CoordinatorUpsertPresenceInput,
 } from "./coordinator-store-contract.js";
-import { normalizeInviteExpiresAt } from "./coordinator-store-contract.js";
+import {
+	isCoordinatorAssignedIdentityId,
+	normalizeInviteExpiresAt,
+	recipientInviteAuthoritativeIdentityId,
+} from "./coordinator-store-contract.js";
 import {
 	canonicalRecipientReviewedIntentJson,
 	parseStoredRecipientReviewedIntent,
@@ -170,8 +174,11 @@ const INVITE_COLUMNS = `invite_id, group_id, token, policy, expires_at, created_
 	inviter_actor_id, inviter_display_name, inviter_device_id, pending_person_id,
 	project_summaries_json, project_intent_json, consumed_at, bound_device_id, bound_public_key, bound_fingerprint,
 	recipient_actor_id, recipient_display_name, recipient_device_display_name, trust_state,
-	bootstrap_grant_id, invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest,
-	reviewed_intent_json`;
+	bootstrap_grant_id, invite_kind, policy_team_id, target_identity_id, assigned_identity_id,
+	reviewed_preview_digest, reviewed_intent_json`;
+
+const ENROLLMENT_COLUMNS =
+	"group_id, device_id, public_key, fingerprint, identity_id, display_name, enabled, created_at";
 
 function requireTrimmedBootstrapGrantInput(opts: CoordinatorCreateBootstrapGrantInput): {
 	groupId: string;
@@ -283,7 +290,11 @@ async function recipientInspection(
 	invite: CoordinatorInvite,
 ): Promise<CoordinatorRecipientInviteInspection | null> {
 	if (invite.invite_kind === "team_member") {
-		if (!invite.policy_team_id || !invite.reviewed_preview_digest)
+		if (
+			!invite.policy_team_id ||
+			!isCoordinatorAssignedIdentityId(invite.assigned_identity_id) ||
+			!invite.reviewed_preview_digest
+		)
 			throw new Error("invite_invalid");
 		const reviewedIntent = await parseStoredRecipientReviewedIntent(invite.reviewed_intent_json, {
 			target: { kind: "team_member", policyTeamId: invite.policy_team_id },
@@ -293,6 +304,7 @@ async function recipientInspection(
 			kind: "team_member",
 			invite,
 			policy_team_id: invite.policy_team_id,
+			assigned_identity_id: invite.assigned_identity_id,
 			reviewed_preview_digest: invite.reviewed_preview_digest,
 			reviewed_intent: reviewedIntent,
 			bound: Boolean(invite.consumed_at),
@@ -703,24 +715,31 @@ export class D1CoordinatorStore implements CoordinatorStore {
 	}
 
 	async enrollDevice(_groupId: string, _opts: CoordinatorEnrollDeviceInput): Promise<void> {
-		await this.db
-			.prepare(`INSERT INTO enrolled_devices(
-				group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
-			) VALUES (?, ?, ?, ?, ?, 1, ?)
-			ON CONFLICT(group_id, device_id) DO UPDATE SET
-				public_key = excluded.public_key,
-				fingerprint = excluded.fingerprint,
-				display_name = excluded.display_name,
-				enabled = 1`)
-			.bind(
-				_groupId,
-				_opts.deviceId,
-				_opts.publicKey,
-				_opts.fingerprint,
-				_opts.displayName ?? null,
-				nowISO(),
-			)
-			.run();
+		const changes = await runChanges(
+			this.db
+				.prepare(`INSERT INTO enrolled_devices(
+					group_id, device_id, public_key, fingerprint, identity_id, display_name, enabled, created_at
+				) VALUES (?, ?, ?, ?, ?, ?, 1, ?)
+				ON CONFLICT(group_id, device_id) DO UPDATE SET
+					public_key = excluded.public_key,
+					fingerprint = excluded.fingerprint,
+					identity_id = COALESCE(enrolled_devices.identity_id, excluded.identity_id),
+					display_name = excluded.display_name,
+					enabled = 1
+				WHERE excluded.identity_id IS NULL
+					OR enrolled_devices.identity_id IS NULL
+					OR enrolled_devices.identity_id = excluded.identity_id`)
+				.bind(
+					_groupId,
+					_opts.deviceId,
+					_opts.publicKey,
+					_opts.fingerprint,
+					_opts.identityId ?? null,
+					_opts.displayName ?? null,
+					nowISO(),
+				),
+		);
+		if (changes === 0) throw new Error("invite_identity_conflict");
 	}
 
 	async listEnrolledDevices(
@@ -731,7 +750,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		return (
 			await allRows<CoordinatorEnrollment>(
 				this.db
-					.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+					.prepare(`SELECT ${ENROLLMENT_COLUMNS}
 						 FROM enrolled_devices
 						 WHERE group_id = ? ${where}
 						 ORDER BY created_at ASC, device_id ASC`)
@@ -743,7 +762,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 	async getEnrollment(_groupId: string, _deviceId: string): Promise<CoordinatorEnrollment | null> {
 		const row = await firstRow<CoordinatorEnrollment>(
 			this.db
-				.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+				.prepare(`SELECT ${ENROLLMENT_COLUMNS}
 					 FROM enrolled_devices
 					 WHERE group_id = ? AND device_id = ? AND enabled = 1`)
 				.bind(_groupId, _deviceId),
@@ -826,6 +845,8 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		const operationId = String(_opts.operationId ?? "").trim() || null;
 		const reviewedProjectSetDigest = String(_opts.reviewedProjectSetDigest ?? "").trim() || null;
 		const metadata = await normalizeInviteMetadata(_opts);
+		const assignedIdentityId =
+			metadata.inviteKind === "team_member" ? `identity:${tokenUrlSafe(18)}` : null;
 		if (Boolean(operationId) !== Boolean(reviewedProjectSetDigest)) {
 			throw new Error("operationId and reviewedProjectSetDigest must be provided together.");
 		}
@@ -900,9 +921,9 @@ export class D1CoordinatorStore implements CoordinatorStore {
 				team_name_snapshot, revoked_at, operation_id, reviewed_project_set_digest,
 				token_digest, inviter_actor_id, inviter_display_name, inviter_device_id,
 				pending_person_id, project_summaries_json, project_intent_json, trust_state,
-				invite_kind, policy_team_id, target_identity_id, reviewed_preview_digest,
-				reviewed_intent_json
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+				invite_kind, policy_team_id, target_identity_id, assigned_identity_id,
+				reviewed_preview_digest, reviewed_intent_json
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 				.bind(
 					inviteId,
 					_opts.groupId,
@@ -925,6 +946,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 					metadata.inviteKind,
 					metadata.policyTeamId,
 					metadata.targetIdentityId,
+					assignedIdentityId,
 					metadata.reviewedPreviewDigest,
 					metadata.reviewedIntentJson,
 				)
@@ -1023,7 +1045,8 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		if (fingerprintPublicKey(_opts.publicKey) !== _opts.fingerprint) {
 			throw new Error("fingerprint_mismatch");
 		}
-		if (inspection.kind === "add_device" && inspection.target_identity_id !== _opts.identityId) {
+		const authoritativeIdentityId = recipientInviteAuthoritativeIdentityId(inspection);
+		if (authoritativeIdentityId !== _opts.identityId) {
 			throw new Error("invite_identity_conflict");
 		}
 		const sameBinding =
@@ -1031,19 +1054,21 @@ export class D1CoordinatorStore implements CoordinatorStore {
 			initial.bound_public_key === _opts.publicKey &&
 			initial.bound_fingerprint === _opts.fingerprint;
 		if (initial.consumed_at && !sameBinding) throw new Error("invite_already_bound");
-		if (initial.consumed_at && initial.recipient_actor_id !== _opts.identityId) {
+		if (initial.consumed_at && initial.recipient_actor_id !== authoritativeIdentityId) {
 			throw new Error("invite_identity_conflict");
 		}
 		const existingEnrollment = await firstRow<CoordinatorEnrollment>(
 			this.db
-				.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+				.prepare(`SELECT ${ENROLLMENT_COLUMNS}
 					FROM enrolled_devices WHERE group_id = ? AND device_id = ?`)
 				.bind(initial.group_id, _opts.deviceId),
 		);
 		if (
 			existingEnrollment &&
 			(existingEnrollment.public_key !== _opts.publicKey ||
-				existingEnrollment.fingerprint !== _opts.fingerprint)
+				existingEnrollment.fingerprint !== _opts.fingerprint ||
+				(existingEnrollment.identity_id !== null &&
+					existingEnrollment.identity_id !== authoritativeIdentityId))
 		) {
 			throw new Error("invite_identity_conflict");
 		}
@@ -1058,6 +1083,14 @@ export class D1CoordinatorStore implements CoordinatorStore {
 						WHERE (token_digest = ? OR token = ?) AND consumed_at IS NULL
 						AND revoked_at IS NULL AND expires_at > ? AND invite_kind = ?
 						AND reviewed_intent_json = ? AND reviewed_preview_digest = ?
+						AND ((invite_kind = 'team_member' AND assigned_identity_id = ?)
+							OR (invite_kind = 'add_device' AND target_identity_id = ?))
+						AND NOT EXISTS (
+							SELECT 1 FROM enrolled_devices e
+							WHERE e.group_id = coordinator_invites.group_id AND e.device_id = ?
+								AND (e.public_key <> ? OR e.fingerprint <> ?
+									OR (e.identity_id IS NOT NULL AND e.identity_id <> ?))
+						)
 						AND EXISTS (SELECT 1 FROM groups g WHERE g.group_id = coordinator_invites.group_id
 							AND g.archived_at IS NULL)`)
 					.bind(
@@ -1066,23 +1099,34 @@ export class D1CoordinatorStore implements CoordinatorStore {
 						_opts.deviceId,
 						_opts.publicKey,
 						_opts.fingerprint,
-						_opts.identityId,
+						authoritativeIdentityId,
 						digest,
 						_opts.token,
 						consumedAt,
 						_opts.inviteKind,
 						initial.reviewed_intent_json,
 						initial.reviewed_preview_digest,
+						authoritativeIdentityId,
+						authoritativeIdentityId,
+						_opts.deviceId,
+						_opts.publicKey,
+						_opts.fingerprint,
+						authoritativeIdentityId,
 					),
 				this.db
 					.prepare(`INSERT INTO enrolled_devices(
-						group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+						group_id, device_id, public_key, fingerprint, identity_id, display_name, enabled, created_at
 					) SELECT i.group_id, i.bound_device_id, i.bound_public_key, i.bound_fingerprint,
-						NULL, 1, ? FROM coordinator_invites i
+						i.recipient_actor_id, NULL, 1, ? FROM coordinator_invites i
 					JOIN groups g ON g.group_id = i.group_id AND g.archived_at IS NULL
 					WHERE (i.token_digest = ? OR i.token = ?) AND i.bound_device_id = ?
 						AND i.bound_public_key = ? AND i.bound_fingerprint = ?
-					ON CONFLICT(group_id, device_id) DO UPDATE SET enabled = 1`)
+						AND i.recipient_actor_id = ?
+					ON CONFLICT(group_id, device_id) DO UPDATE SET
+						identity_id = COALESCE(enrolled_devices.identity_id, excluded.identity_id),
+						enabled = 1
+					WHERE enrolled_devices.identity_id IS NULL
+						OR enrolled_devices.identity_id = excluded.identity_id`)
 					.bind(
 						consumedAt,
 						digest,
@@ -1090,6 +1134,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 						_opts.deviceId,
 						_opts.publicKey,
 						_opts.fingerprint,
+						authoritativeIdentityId,
 					),
 			]);
 			changed = batchResultChanges(results[0]);
@@ -1097,6 +1142,21 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		const currentGroup = await this.getGroup(initial.group_id);
 		if (!currentGroup) throw new Error("group_not_found");
 		if (currentGroup.archived_at) throw new Error("group_archived");
+		const currentEnrollment = await firstRow<CoordinatorEnrollment>(
+			this.db
+				.prepare(`SELECT ${ENROLLMENT_COLUMNS}
+					FROM enrolled_devices WHERE group_id = ? AND device_id = ?`)
+				.bind(initial.group_id, _opts.deviceId),
+		);
+		if (
+			currentEnrollment &&
+			(currentEnrollment.public_key !== _opts.publicKey ||
+				currentEnrollment.fingerprint !== _opts.fingerprint ||
+				(currentEnrollment.identity_id !== null &&
+					currentEnrollment.identity_id !== authoritativeIdentityId))
+		) {
+			throw new Error("invite_identity_conflict");
+		}
 		const saved = await this.getInviteByTokenForInspection(_opts.token);
 		if (
 			!saved ||
@@ -1109,6 +1169,10 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		if (!savedInspection || savedInspection.kind !== _opts.inviteKind) {
 			throw new Error("invite_invalid");
 		}
+		const savedIdentityId = recipientInviteAuthoritativeIdentityId(savedInspection);
+		if (savedIdentityId !== authoritativeIdentityId) {
+			throw new Error("invite_identity_conflict");
+		}
 		if (
 			saved.bound_device_id !== _opts.deviceId ||
 			saved.bound_public_key !== _opts.publicKey ||
@@ -1116,10 +1180,27 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		) {
 			throw new Error("invite_already_bound");
 		}
-		if (saved.recipient_actor_id !== _opts.identityId) throw new Error("invite_identity_conflict");
+		if (saved.recipient_actor_id !== authoritativeIdentityId)
+			throw new Error("invite_identity_conflict");
+		await this.db
+			.prepare(`UPDATE enrolled_devices SET identity_id = ?
+				WHERE group_id = ? AND device_id = ? AND identity_id IS NULL
+					AND public_key = ? AND fingerprint = ?`)
+			.bind(
+				authoritativeIdentityId,
+				saved.group_id,
+				_opts.deviceId,
+				_opts.publicKey,
+				_opts.fingerprint,
+			)
+			.run();
 		const enrollment = await this.getEnrollment(saved.group_id, _opts.deviceId);
 		if (!enrollment) throw new Error("invite_acceptance_incomplete");
-		if (enrollment.public_key !== _opts.publicKey || enrollment.fingerprint !== _opts.fingerprint) {
+		if (
+			enrollment.public_key !== _opts.publicKey ||
+			enrollment.fingerprint !== _opts.fingerprint ||
+			enrollment.identity_id !== authoritativeIdentityId
+		) {
 			throw new Error("invite_identity_conflict");
 		}
 		return {
@@ -1164,7 +1245,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		}
 		const existingEnrollment = await firstRow<CoordinatorEnrollment>(
 			this.db
-				.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+				.prepare(`SELECT ${ENROLLMENT_COLUMNS}
 					FROM enrolled_devices WHERE group_id = ? AND device_id = ?`)
 				.bind(initial.group_id, _opts.deviceId),
 		);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,6 +127,10 @@ export {
 	connectCoordinator,
 	DEFAULT_COORDINATOR_DB_PATH,
 } from "./coordinator-store.js";
+export {
+	isCoordinatorAssignedIdentityId,
+	recipientInviteAuthoritativeIdentityId,
+} from "./coordinator-store-contract.js";
 export type { Database } from "./db.js";
 export {
 	assertSchemaReady,

--- a/packages/core/src/recipient-policy-onboarding.ts
+++ b/packages/core/src/recipient-policy-onboarding.ts
@@ -1187,7 +1187,8 @@ export function commitRecipientPolicyOnboardingFromReviewedIntent(
 					identityId: normalized.binding.identityId,
 					displayName: identityDisplayName,
 					deviceId: normalized.binding.deviceId,
-					allowBootstrapAdoption: normalized.journey === "add_device",
+					allowBootstrapAdoption:
+						normalized.journey === "add_device" || normalized.journey === "team",
 				},
 				now,
 			)

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -55,6 +55,7 @@ export type InspectInviteResult =
 			kind: RecipientInvitationKind;
 			recipient_name: string;
 			device_name: string;
+			assigned_identity_id?: string;
 			onboarding: RecipientOnboardingPreviewV1;
 	  };
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -10426,6 +10426,8 @@ describe("viewer-server", () => {
 					team_name: null,
 					policy_team_id: body.policy_team_id ?? undefined,
 					target_identity_id: body.target_identity_id ?? undefined,
+					assigned_identity_id:
+						body.invite_kind === "team_member" ? "identity-assigned-team" : undefined,
 					reviewed_preview_digest: body.reviewed_preview_digest,
 				};
 				return new Response(
@@ -10435,6 +10437,8 @@ describe("viewer-server", () => {
 							invite_kind: body.invite_kind,
 							policy_team_id: body.policy_team_id,
 							target_identity_id: body.target_identity_id,
+							assigned_identity_id:
+								body.invite_kind === "team_member" ? "identity-assigned-team" : null,
 							reviewed_preview_digest: body.reviewed_preview_digest,
 						},
 						payload,
@@ -10523,6 +10527,7 @@ describe("viewer-server", () => {
 
 		it("inspects and accepts Team/add-device invites with intent-only local writes", async () => {
 			for (const kind of ["team_member", "add_device"] as const) {
+				const assignedTeamIdentityId = "identity-assigned-team-recipient";
 				const testDir = mkdtempSync(join(tmpdir(), `codemem-${kind}-accept-`));
 				const configPath = join(testDir, "config.json");
 				const keysDir = join(testDir, "keys");
@@ -10625,7 +10630,10 @@ describe("viewer-server", () => {
 						team_name: null,
 						reviewed_preview_digest: digest,
 						...(kind === "team_member"
-							? { policy_team_id: "policy-team-a" }
+							? {
+									policy_team_id: "policy-team-a",
+									assigned_identity_id: assignedTeamIdentityId,
+								}
 							: { target_identity_id: store.actorId }),
 					};
 					const encoded = core.encodeInvitePayload(payload);
@@ -10640,7 +10648,10 @@ describe("viewer-server", () => {
 									reviewed_intent: reviewedIntent,
 									bound: false,
 									...(kind === "team_member"
-										? { policy_team_id: "policy-team-a" }
+										? {
+												policy_team_id: "policy-team-a",
+												assigned_identity_id: assignedTeamIdentityId,
+											}
 										: { target_identity_id: store.actorId }),
 								}),
 								{ status: 200 },
@@ -10657,11 +10668,15 @@ describe("viewer-server", () => {
 								status: "accepted",
 								kind,
 								group_id: "coordinator-a",
-								identity_id: store.actorId,
+								identity_id: kind === "team_member" ? assignedTeamIdentityId : store.actorId,
 								reviewed_preview_digest: digest,
 								reviewed_intent: reviewedIntent,
 								...(kind === "team_member"
-									? { policy_team_id: "policy-team-a", target_identity_id: null }
+									? {
+											policy_team_id: "policy-team-a",
+											target_identity_id: null,
+											assigned_identity_id: assignedTeamIdentityId,
+										}
 									: { policy_team_id: null, target_identity_id: store.actorId }),
 							}),
 							{ status: 200 },
@@ -10775,6 +10790,7 @@ describe("viewer-server", () => {
 				expires_at: "2099-01-01T00:00:00.000Z",
 				team_name: null,
 				policy_team_id: "team-reviewed",
+				assigned_identity_id: "identity-assigned-team",
 				reviewed_preview_digest: digest,
 			});
 			globalThis.fetch = vi
@@ -10789,6 +10805,7 @@ describe("viewer-server", () => {
 						JSON.stringify({
 							kind: "team_member",
 							policy_team_id: "team-reviewed",
+							assigned_identity_id: "identity-assigned-team",
 							reviewed_preview_digest: digest,
 						}),
 						{ status: 200 },
@@ -10799,6 +10816,7 @@ describe("viewer-server", () => {
 						JSON.stringify({
 							kind: "team_member",
 							policy_team_id: "team-reviewed",
+							assigned_identity_id: "identity-assigned-team",
 							reviewed_preview_digest: digest,
 							reviewed_intent: {
 								...reviewedIntent,
@@ -10872,6 +10890,7 @@ describe("viewer-server", () => {
 				expires_at: "2099-01-01T00:00:00.000Z",
 				team_name: null,
 				policy_team_id: "team-reviewed",
+				assigned_identity_id: "identity-assigned-team",
 				reviewed_preview_digest: digest,
 			});
 			globalThis.fetch = vi.fn(
@@ -10880,6 +10899,7 @@ describe("viewer-server", () => {
 						JSON.stringify({
 							kind: "team_member",
 							policy_team_id: "team-reviewed",
+							assigned_identity_id: "identity-assigned-team",
 							reviewed_preview_digest: digest,
 							reviewed_intent: reviewedIntent,
 							bound: false,
@@ -11064,6 +11084,8 @@ describe("viewer-server", () => {
 				);
 				recipient = createTestApp({ seedDevice: false });
 				const recipientStore = recipient.ensureStore();
+				const bootstrapActorId = recipientStore.actorId;
+				expect(bootstrapActorId.length).toBeGreaterThan(0);
 				expect(recipientStore.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(
 					0,
 				);
@@ -11085,6 +11107,7 @@ describe("viewer-server", () => {
 				);
 				const inspection = (await inspectResponse.json()) as {
 					recipient_name: string;
+					assigned_identity_id?: string;
 					onboarding: {
 						reviewedOnboardingDigest: string;
 						projects: unknown[];
@@ -11093,6 +11116,13 @@ describe("viewer-server", () => {
 				};
 
 				// Assert
+				if (testCase.kind === "team_member") {
+					expect(inspection.assigned_identity_id).toEqual(expect.any(String));
+					expect(inspection.assigned_identity_id?.trim()).toBe(inspection.assigned_identity_id);
+					expect(inspection.assigned_identity_id?.length).toBeGreaterThan(0);
+					expect(inspection.assigned_identity_id).not.toBe(bootstrapActorId);
+					expect(inspection.assigned_identity_id).not.toBe(ownerStore.actorId);
+				}
 				expect(inspection.onboarding.projects).toEqual([
 					{
 						canonicalProjectIdentity: alphaProjectId,
@@ -11133,6 +11163,9 @@ describe("viewer-server", () => {
 				});
 				expect(stale.status).toBe(400);
 				expect(await stale.json()).toEqual({ error: "reviewed_onboarding_stale" });
+				expect(recipientStore.actorId).not.toBe(
+					testCase.kind === "team_member" ? inspection.assigned_identity_id : ownerStore.actorId,
+				);
 
 				const accepted = await recipient.app.request("/api/sync/invites/import", {
 					method: "POST",
@@ -11145,9 +11178,12 @@ describe("viewer-server", () => {
 					type: "recipient_onboarding",
 				});
 				const expectedIdentityId =
-					testCase.kind === "team_member" ? recipientStore.actorId : ownerStore.actorId;
+					testCase.kind === "team_member"
+						? String(inspection.assigned_identity_id)
+						: ownerStore.actorId;
+				expect(recipientStore.actorId).toBe(expectedIdentityId);
+				expect(recipientStore.actorId).not.toBe(bootstrapActorId);
 				if (testCase.kind === "add_device") {
-					expect(recipientStore.actorId).toBe(ownerStore.actorId);
 					expect(recipientStore.actorDisplayName).toBe("Owner Identity");
 				}
 				const recipientDeviceId = recipientStore.db
@@ -11244,6 +11280,9 @@ describe("viewer-server", () => {
 						await coordinatorVerification.getInviteByTokenForInspection(String(payload.token)),
 					).toMatchObject({
 						invite_kind: testCase.kind,
+						...(testCase.kind === "team_member"
+							? { assigned_identity_id: expectedIdentityId }
+							: { target_identity_id: expectedIdentityId }),
 						bound_device_id: recipientDeviceId,
 						recipient_actor_id: expectedIdentityId,
 						consumed_at: expect.any(String),

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -126,6 +126,7 @@ import {
 	readCodememConfigFile,
 	readCoordinatorSyncConfig,
 	reassignProjectScopeInventoryProject,
+	recipientInviteAuthoritativeIdentityId,
 	recipientReviewedIntentDigest,
 	reconcileRecipientPolicyProject,
 	reconcileShareOperationAcceptance,
@@ -819,18 +820,23 @@ function recipientInviteOnboardingPreviewFromReviewedIntent(
 	});
 	const teamId = optionalViewerStrictString(body, "policy_team_id");
 	const targetIdentityId = optionalViewerStrictString(body, "target_identity_id");
+	const assignedIdentityId = optionalViewerStrictString(body, "assigned_identity_id");
 	if (kind === "team_member") {
-		if (!teamId || targetIdentityId) throw new Error("recipient_invite_metadata_invalid");
+		if (!teamId || !assignedIdentityId || targetIdentityId) {
+			throw new Error("recipient_invite_metadata_invalid");
+		}
 		return previewRecipientPolicyOnboardingFromReviewedIntent(reviewedIntent, {
 			version: 1,
 			journey: "team",
 			invitationId,
-			identityId: store.actorId,
+			identityId: assignedIdentityId,
 			...binding,
 			teamId,
 		});
 	}
-	if (!targetIdentityId || teamId) throw new Error("recipient_invite_metadata_invalid");
+	if (!targetIdentityId || teamId || assignedIdentityId) {
+		throw new Error("recipient_invite_metadata_invalid");
+	}
 	return previewRecipientPolicyOnboardingFromReviewedIntent(reviewedIntent, {
 		version: 1,
 		journey: "add_device",
@@ -5834,10 +5840,13 @@ export function syncRoutes(
 				);
 			}
 			const config = readCodememConfigFile();
-			const identityId =
-				payload.kind === "add_device"
-					? String(inspected?.target_identity_id ?? "").trim()
-					: store.actorId;
+			const identityId = recipientInvite
+				? recipientInviteAuthoritativeIdentityId({
+						kind: payload.kind as "team_member" | "add_device",
+						assigned_identity_id: inspected?.assigned_identity_id,
+						target_identity_id: inspected?.target_identity_id,
+					})
+				: store.actorId;
 			const expectedTarget =
 				payload.kind === "team_member"
 					? String(inspected?.policy_team_id ?? "").trim()
@@ -5849,6 +5858,8 @@ export function syncRoutes(
 					String(inspected?.reviewed_preview_digest ?? "").trim() !==
 						String(payload.reviewed_preview_digest ?? "").trim() ||
 					(payload.kind === "team_member" && expectedTarget !== payload.policy_team_id) ||
+					(payload.kind === "team_member" &&
+						(identityId !== String(payload.assigned_identity_id ?? "").trim() || !identityId)) ||
 					(payload.kind === "add_device" && expectedTarget !== payload.target_identity_id)
 				) {
 					return c.json({ error: "recipient_invite_intent_mismatch" }, 409);
@@ -5873,6 +5884,7 @@ export function syncRoutes(
 					{
 						kind: payload.kind,
 						policy_team_id: payload.kind === "team_member" ? expectedTarget : null,
+						assigned_identity_id: payload.kind === "team_member" ? identityId : null,
 						target_identity_id: payload.kind === "add_device" ? identityId : null,
 						device_name: optionalViewerString(body, "device_name"),
 					},
@@ -5972,7 +5984,7 @@ export function syncRoutes(
 			const decoded = decodeInvitePayload(extractInvitePayload(rawValue));
 			projectInvite = Boolean(decoded.operation_id);
 			recipientInvite = decoded.kind === "team_member" || decoded.kind === "add_device";
-			if (decoded.kind === "add_device") ensureStableStoreDeviceIdentity(store);
+			if (recipientInvite) ensureStableStoreDeviceIdentity(store);
 			else ensureStableStoreIdentity(store);
 			const reviewedOnboardingDigest =
 				typeof body.reviewed_onboarding_digest === "string"
@@ -5984,7 +5996,7 @@ export function syncRoutes(
 			const result = await coordinatorImportInviteAction({
 				inviteValue: rawValue,
 				dbPath: store.dbPath,
-				recipientActorId: decoded.kind === "add_device" ? null : store.actorId,
+				recipientActorId: recipientInvite ? null : store.actorId,
 				recipientDisplayName:
 					typeof body.recipient_name === "string" ? body.recipient_name : store.actorDisplayName,
 				deviceDisplayName: typeof body.device_name === "string" ? body.device_name : null,
@@ -5995,10 +6007,8 @@ export function syncRoutes(
 				: projectInvite
 					? "project_share"
 					: "team_join";
-			if (decoded.kind === "add_device") {
-				const persistedIdentityId = String(
-					result.identity_id ?? result.target_identity_id ?? "",
-				).trim();
+			if (recipientInvite) {
+				const persistedIdentityId = String(result.identity_id ?? "").trim();
 				if (!store.refreshPersistedLocalIdentity(persistedIdentityId)) {
 					return c.json(
 						{


### PR DESCRIPTION
## Description

Persist an authoritative Identity binding for enrolled recipient devices across BetterSQLite and D1.

The coordinator now mints an opaque Identity for each Team-member invitation, exposes it during inspection, requires that exact Identity during acceptance, and atomically stores it on the enrolled device. Add-device invitations continue to use their coordinator-owned target Identity. Legacy, admin, and Project enrollment remains unbound.

This prevents recipients from choosing or silently rebinding the Identity later trusted by signed coordinator mutations. Malformed migrated assignments, caller-supplied Team assignments, conflicting re-enrollment, and mismatched join responses fail closed.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional validation:

- `pnpm --filter @codemem/cloudflare-coordinator-worker test:worker`
- Independent security/correctness, test-coverage, and maintainability reviews

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
