### PR TITLE
fix(sharing): preserve invitation completion state

### DIFF
--- a/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
@@ -233,9 +233,17 @@ describe("recipient-policy invitations", () => {
 			device_name: "Travel Laptop",
 			reviewed_onboarding_digest: addDevicePreview.reviewedOnboardingDigest,
 		});
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Device added"));
+		const result = dialog.querySelector("#recipient-invitation-result");
+		expect(result).not.toBeNull();
+		expect(document.activeElement).toBe(result);
+		expect(dialog.querySelector("textarea")).toBeNull();
+		expect(() => button("Accept invitation", dialog)).toThrow("button missing");
+		await act(async () => Promise.resolve());
+		expect(dialog.querySelector("#recipient-invitation-result")).toBe(result);
 	});
 
-	it("inspects and accepts a Team invitation with required names, digest, and Team result copy", async () => {
+	it("persists a Team completion, prevents repeat acceptance, and resets after close and reopen", async () => {
 		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
 			kind: "team_member",
 			recipient_name: "Local Identity",
@@ -255,7 +263,11 @@ describe("recipient-policy invitations", () => {
 		});
 		act(() => button("Review invitation", dialog).click());
 		await vi.waitFor(() => expect(dialog.textContent).toContain("Current Projects for"));
-		act(() => button("Accept invitation", dialog).click());
+		const acceptButton = button("Accept invitation", dialog);
+		act(() => {
+			acceptButton.click();
+			acceptButton.click();
+		});
 
 		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
 		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("team-member-invite", {
@@ -265,6 +277,24 @@ describe("recipient-policy invitations", () => {
 		});
 		await vi.waitFor(() => expect(dialog.textContent).toContain("Team invitation accepted"));
 		expect(dialog.textContent).not.toContain("Project setup is pending");
+		const result = dialog.querySelector("#recipient-invitation-result");
+		expect(result).not.toBeNull();
+		expect(document.activeElement).toBe(result);
+		expect(dialog.querySelector("textarea")).toBeNull();
+		expect(() => button("Review invitation", dialog)).toThrow("button missing");
+		expect(() => button("Accept invitation", dialog)).toThrow("button missing");
+		act(() => acceptButton.click());
+		expect(api.importCoordinatorInvite).toHaveBeenCalledOnce();
+
+		act(() => button("Done", dialog).click());
+		expect(document.querySelector('[role="dialog"]')).toBeNull();
+		act(() => button("Review invitation").click());
+		const reopenedDialog = document.querySelector('[role="dialog"]');
+		const reopenedInvite = reopenedDialog?.querySelector<HTMLTextAreaElement>("textarea");
+		if (!reopenedDialog || !reopenedInvite) throw new Error("reopened dialog missing");
+		expect(reopenedInvite.value).toBe("");
+		expect(reopenedDialog.querySelector("#recipient-invitation-result")).toBeNull();
+		expect(button("Review invitation", reopenedDialog).disabled).toBe(false);
 	});
 
 	it("surfaces restart guidance when Team acceptance enables sync", async () => {
@@ -299,6 +329,25 @@ describe("recipient-policy invitations", () => {
 				"Restart codemem to start receiving the reviewed Projects.",
 			),
 		);
+		const result = dialog.querySelector<HTMLElement>("#recipient-invitation-result");
+		if (!result) throw new Error("Team restart completion missing");
+		expect(result.classList.contains("recipient-policy-invitation-result")).toBe(true);
+		expect(result.getAttribute("aria-labelledby")).toBe("recipient-invitation-result-title");
+		expect(result.getAttribute("aria-describedby")).toBe("recipient-invitation-result-detail");
+		expect(
+			result.querySelector(".recipient-policy-invitation-result-mark")?.getAttribute("aria-hidden"),
+		).toBe("true");
+		expect(document.activeElement).toBe(result);
+		expect(dialog.querySelector("textarea")).toBeNull();
+		expect(() => button("Accept invitation", dialog)).toThrow("button missing");
+		expect(
+			dialog
+				.querySelector(".modal-footer")
+				?.classList.contains("recipient-policy-sharing-responsive-actions"),
+		).toBe(true);
+		expect(
+			button("Done", dialog).closest(".recipient-policy-sharing-responsive-actions"),
+		).not.toBeNull();
 	});
 
 	it("keeps unknown recipient-import errors generic", async () => {
@@ -669,6 +718,8 @@ describe("recipient-policy invitations", () => {
 			),
 		);
 		expect(dialog.textContent).not.toContain("Device added.");
+		expect(dialog.querySelector("#recipient-invitation-result")).toBe(document.activeElement);
+		expect(() => button("Accept invitation", dialog)).toThrow("button missing");
 	});
 
 	it("uses safe fallback result copy after reviewing unavailable optional Project identity names", async () => {
@@ -812,6 +863,20 @@ describe("recipient-policy invitations", () => {
 			expect(dialog.querySelector('[role="alert"]')?.textContent).toContain(guidance),
 		);
 		expect(dialog.textContent).not.toContain(code);
+	});
+
+	it("uses the shared labelled close-button structure", () => {
+		mount();
+		act(() => button("Review invitation").click());
+		const dialog = document.querySelector('[role="dialog"]');
+		const closeButton = dialog?.querySelector<HTMLButtonElement>(".modal-close-button");
+		if (!closeButton) throw new Error("shared close button missing");
+		expect(closeButton.getAttribute("aria-label")).toBe("Close invitation");
+		expect(closeButton.querySelector(".modal-close-button-icon")?.getAttribute("data-lucide")).toBe(
+			"x",
+		);
+		expect(closeButton.querySelector(".modal-close-button-label")?.textContent).toBe("Close");
+		expect(closeButton.textContent).not.toContain("×");
 	});
 
 	it("moves focus to the heading and restores it after Radix keyboard close", () => {

--- a/packages/ui/src/tabs/recipient-policy-invitations.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "preact/hooks";
+import { DialogCloseButton } from "../components/primitives/dialog-close-button";
 import { RadixDialog } from "../components/primitives/radix-dialog";
 import * as api from "../lib/api";
 import type {
@@ -20,6 +21,11 @@ type ProjectShareAcceptance = Omit<ImportInviteResult, "status"> & {
 	restart_required?: boolean;
 	detail?: string;
 	type?: "project_share";
+};
+type RecipientAcceptance = {
+	kind: CreateKind;
+	restartRequired: boolean;
+	detail: string;
 };
 
 function displayNameError(value: string, label: string): string {
@@ -287,6 +293,29 @@ function ProjectShareResult({ result }: { result: ProjectShareAcceptance }) {
 	);
 }
 
+function RecipientAcceptanceResult({ result }: { result: RecipientAcceptance }) {
+	const title = result.kind === "team_member" ? "Team invitation accepted" : "Device added";
+	return (
+		<section
+			aria-describedby={result.restartRequired ? "recipient-invitation-result-detail" : undefined}
+			aria-labelledby="recipient-invitation-result-title"
+			className="recipient-policy-invitation-result"
+			id="recipient-invitation-result"
+			tabIndex={-1}
+		>
+			<span aria-hidden="true" className="recipient-policy-invitation-result-mark">
+				✓
+			</span>
+			<div className="recipient-policy-invitation-result-copy">
+				<h3 id="recipient-invitation-result-title">{title}</h3>
+				{result.restartRequired ? (
+					<p id="recipient-invitation-result-detail">{result.detail}</p>
+				) : null}
+			</div>
+		</section>
+	);
+}
+
 function request(kind: CreateKind, targetId: string): RecipientInvitePreviewRequest {
 	return kind === "team_member"
 		? { kind, policy_team_id: targetId }
@@ -303,6 +332,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 	const [preview, setPreview] = useState<RecipientOnboardingPreviewV1 | null>(null);
 	const [inspected, setInspected] = useState<InspectInviteResult | null>(null);
 	const [projectAcceptance, setProjectAcceptance] = useState<ProjectShareAcceptance | null>(null);
+	const [recipientAcceptance, setRecipientAcceptance] = useState<RecipientAcceptance | null>(null);
 	const [projectRecipientName, setProjectRecipientName] = useState("");
 	const [projectDeviceName, setProjectDeviceName] = useState("");
 	const [created, setCreated] = useState<CreatedRecipientInvite | null>(null);
@@ -312,8 +342,13 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 	const returnFocus = useRef<HTMLElement | null>(null);
 	const inviteRevision = useRef(0);
 	const inviteValue = useRef("");
+	const accepting = useRef(false);
 
 	useEffect(() => {
+		if (recipientAcceptance) {
+			document.getElementById("recipient-invitation-result")?.focus();
+			return;
+		}
 		if (projectAcceptance) {
 			document.getElementById("project-share-invitation-result")?.focus();
 			return;
@@ -321,13 +356,17 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 		if (inspected?.kind === "project_share_invite") {
 			document.getElementById("project-share-invitation-projects")?.focus();
 		}
-	}, [inspected, projectAcceptance]);
+	}, [inspected, projectAcceptance, recipientAcceptance]);
 
 	const reset = () => {
 		inviteRevision.current += 1;
+		inviteValue.current = "";
+		accepting.current = false;
+		setInvite("");
 		setPreview(null);
 		setInspected(null);
 		setProjectAcceptance(null);
+		setRecipientAcceptance(null);
 		setProjectRecipientName("");
 		setProjectDeviceName("");
 		setCreated(null);
@@ -341,8 +380,8 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 	};
 	const close = () => {
 		if (busy) return;
-		inviteRevision.current += 1;
 		setMode(null);
+		reset();
 	};
 	const updateInvite = (nextInvite: string) => {
 		inviteRevision.current += 1;
@@ -430,6 +469,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 		}
 	};
 	const accept = async () => {
+		if (busy || accepting.current || recipientAcceptance) return;
 		if (!inspected || inspected.kind === "legacy_team_invite") return;
 		if (inspected.kind === "project_share_invite" && !(inspected.projects?.length ?? 0)) return;
 		if (
@@ -439,6 +479,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 		) {
 			return;
 		}
+		accepting.current = true;
 		setBusy(true);
 		setError("");
 		setStatus("Accepting invitation…");
@@ -458,23 +499,19 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 				setProjectAcceptance(normalizeProjectShareAcceptance(result));
 				setStatus("");
 			} else {
+				const acceptedKind = inspected.kind;
 				const restartRequired =
 					result.restart_required === true || result.setup_state === "restart_required";
 				const detail = typeof result.detail === "string" ? result.detail.trim() : "";
-				setStatus(
-					restartRequired
-						? detail ||
-								(inspected.kind === "team_member"
-									? "Team invitation accepted. Restart codemem before continuing."
-									: "Device added. Restart codemem before continuing.")
-						: inspected.kind === "team_member"
-							? "Team invitation accepted."
-							: "Device added.",
-				);
-				setInspected(null);
-				updateInvite("");
+				setRecipientAcceptance({
+					kind: acceptedKind,
+					restartRequired,
+					detail: detail || "Restart codemem before continuing.",
+				});
+				setStatus("");
 			}
 		} catch (cause) {
+			accepting.current = false;
 			const detail = cause instanceof Error ? cause.message.trim() : "";
 			const fallback =
 				inspected.kind === "project_share_invite" && detail
@@ -592,15 +629,24 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 					<div aria-busy={busy} className="modal-card sync-dialog-card">
 						<div className="modal-header">
 							<h2 id="recipient-invitation-title" tabIndex={-1}>
-								{mode === "create" ? "Create invitation" : "Review invitation"}
+								{recipientAcceptance
+									? "Invitation accepted"
+									: mode === "create"
+										? "Create invitation"
+										: "Review invitation"}
 							</h2>
-							<button aria-label="Close invitation" disabled={busy} onClick={close} type="button">
-								×
-							</button>
+							<DialogCloseButton
+								ariaLabel="Close invitation"
+								className="modal-close-button recipient-policy-sharing-target-24"
+								disabled={busy}
+								onClick={close}
+							/>
 						</div>
 						<div className="modal-body">
 							<p className="small" id="recipient-invitation-description">
-								Confirm exactly what this invitation includes before continuing.
+								{recipientAcceptance
+									? "The invitation has been accepted."
+									: "Confirm exactly what this invitation includes before continuing."}
 							</p>
 							{mode === "create" && !preview && !created ? (
 								<label className="field" htmlFor="recipient-invitation-target">
@@ -620,7 +666,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 										))}
 									</select>
 								</label>
-							) : mode === "accept" && !inspected ? (
+							) : mode === "accept" && !inspected && !recipientAcceptance ? (
 								<label className="field" htmlFor="recipient-invitation-value">
 									<span>Invitation</span>
 									<textarea
@@ -638,7 +684,9 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 								</label>
 							) : null}
 							{preview ? <Confirmation preview={preview} /> : null}
-							{recipientPreview ? <Confirmation preview={recipientPreview} /> : null}
+							{recipientPreview && !recipientAcceptance ? (
+								<Confirmation preview={recipientPreview} />
+							) : null}
 							{projectShareInvite && !projectAcceptance ? (
 								<ProjectShareConfirmation
 									deviceName={projectDeviceName}
@@ -657,6 +705,9 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 								/>
 							) : null}
 							{projectAcceptance ? <ProjectShareResult result={projectAcceptance} /> : null}
+							{recipientAcceptance ? (
+								<RecipientAcceptanceResult result={recipientAcceptance} />
+							) : null}
 							{created ? (
 								<div>
 									<p>Share the invitation with the recipient.</p>
@@ -679,7 +730,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 						</div>
 						<div className="modal-footer recipient-policy-sharing-responsive-actions">
 							<button className="settings-button" disabled={busy} onClick={close} type="button">
-								{created || projectAcceptance ? "Done" : "Cancel"}
+								{created || projectAcceptance || recipientAcceptance ? "Done" : "Cancel"}
 							</button>
 							{mode === "create" && !created ? (
 								<button
@@ -690,7 +741,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 								>
 									{busy ? "Working…" : preview ? "Create invitation" : "Review invitation"}
 								</button>
-							) : mode === "accept" && !inspected ? (
+							) : mode === "accept" && !inspected && !recipientAcceptance ? (
 								<button
 									className="settings-button sync-dialog-confirm"
 									disabled={busy}
@@ -699,7 +750,8 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 								>
 									{busy ? "Reviewing…" : "Review invitation"}
 								</button>
-							) : recipientPreview || (projectShareInvite && !projectAcceptance) ? (
+							) : (recipientPreview && !recipientAcceptance) ||
+								(projectShareInvite && !projectAcceptance) ? (
 								<button
 									className="settings-button sync-dialog-confirm"
 									disabled={

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1260,6 +1260,40 @@
       }
       .recipient-policy-sharing-details dt { color: var(--text-secondary); }
       .recipient-policy-sharing-details dd { margin: 0; color: var(--text-primary); }
+      .recipient-policy-invitation-result {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--sp-3);
+        padding: var(--sp-4);
+        border: 1px solid color-mix(in srgb, var(--status-healthy) 36%, var(--border));
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--status-healthy) 9%, var(--surface-1));
+      }
+      .recipient-policy-invitation-result:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+        box-shadow: 0 0 0 4px var(--focus-ring);
+      }
+      .recipient-policy-invitation-result-mark {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: 0 0 28px;
+        width: 28px;
+        height: 28px;
+        border-radius: var(--radius-pill);
+        background: color-mix(in srgb, var(--status-healthy) 18%, var(--surface-0));
+        color: var(--status-healthy);
+        font-weight: var(--font-weight-semibold);
+        line-height: 1;
+      }
+      .recipient-policy-invitation-result-copy { min-width: 0; }
+      .recipient-policy-invitation-result-copy h3 { margin: 0; }
+      .recipient-policy-invitation-result-copy p {
+        margin-top: var(--sp-2);
+        color: var(--text-secondary);
+        overflow-wrap: anywhere;
+      }
 
       #devicesMount .recipient-policy-sharing-grid {
         grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
@@ -1287,6 +1321,7 @@
         .recipient-policy-sharing-responsive-actions button { min-height: 44px; width: 100%; }
         .recipient-policy-sharing-responsive-tabs { overflow-x: auto; }
         .recipient-policy-sharing-details div { grid-template-columns: 1fr; gap: var(--sp-1); }
+        .recipient-policy-invitation-result { padding: var(--sp-3); }
         #devicesMount .recipient-policy-sharing-card > .settings-button {
           min-height: 44px;
           width: 100%;


### PR DESCRIPTION
## Description

Keep successful Team and add-device invitation acceptance visible in the open dialog instead of resetting to the paste form.

The dialog now enters a stable, focused completion state with truthful restart guidance, removes all repeat review/accept controls, guards against duplicate submissions, and resets only after explicit close/reopen. Project-share completion behavior remains unchanged. The raw close glyph is replaced with the shared accessible close-button primitive, and the result uses a restrained responsive success surface consistent with existing theme tokens.

This fixes the dogfood failure where successful acceptance looked like a reset or failed operation.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional validation:

- `pnpm exec vitest run packages/ui/src/tabs/recipient-policy-invitations.test.tsx`
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`
- Independent state-machine, accessibility, and test-coverage reviews

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
