### PR TITLE
fix(sharing): clarify empty recipient-device availability copy

### DIFF
--- a/packages/ui/src/tabs/recipient-policy-management.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-management.test.tsx
@@ -771,8 +771,9 @@ describe("recipient policy management dialog", () => {
 		await reviewSelection();
 
 		expect(document.body.textContent).toContain(
-			"After the update, no current devices will have access to the affected Projects.",
+			"After the update, no recipient devices will have access to the affected Projects yet",
 		);
+		expect(document.body.textContent).toContain("Your own access on this device is not affected.");
 	});
 
 	it("deduplicates effective devices by device ID while preserving first-item order", async () => {

--- a/packages/ui/src/tabs/recipient-policy-management.tsx
+++ b/packages/ui/src/tabs/recipient-policy-management.tsx
@@ -446,7 +446,11 @@ function Review({
 						</ul>
 					</>
 				) : (
-					<p>After the update, no current devices will have access to the affected Projects.</p>
+					<p>
+						After the update, no recipient devices will have access to the affected Projects yet —
+						for example, a Team with no current members. Your own access on this device is not
+						affected.
+					</p>
 				)}
 			</section>
 			<details className="recipient-policy-management-details">


### PR DESCRIPTION
## Description
Dogfood finding (codemem-naur): when sharing a Project with an empty Team, the review dialog said "no current devices will have access to the affected Projects", which reads like the owner loses access. The sentence only describes recipient devices. Clarify that no recipient devices gain access yet (e.g. an empty Team) and that the owner's own access is unaffected.

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
