### PR TITLE
fix(sharing): seed invitation name fields with placeholders, not raw ids

### DIFF
--- a/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
@@ -481,6 +481,37 @@ describe("recipient-policy invitations", () => {
 		expect(document.querySelector('[role="dialog"]')).toBe(dialog);
 	});
 
+	it("seeds machine-generated identity and device names as empty fields with placeholder hints", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
+			...projectShareInspection,
+			recipient_name: "local:203a0bb0-4879-455a-a43d-4d3f1c98acbc",
+			device_name: "916b139e2bb6",
+		});
+		mount();
+
+		act(() => button("Review invitation").click());
+		const dialog = document.querySelector('[role="dialog"]');
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		if (!dialog || !textarea) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "project-invite-payload";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(api.inspectCoordinatorInvite).toHaveBeenCalledOnce());
+		await vi.waitFor(() =>
+			expect(dialog.querySelector("#project-share-recipient-name")).not.toBeNull(),
+		);
+
+		const recipientName = dialog.querySelector<HTMLInputElement>("#project-share-recipient-name");
+		const deviceName = dialog.querySelector<HTMLInputElement>("#project-share-device-name");
+		if (!recipientName || !deviceName) throw new Error("Project identity fields missing");
+		expect(recipientName.value).toBe("");
+		expect(deviceName.value).toBe("");
+		expect(recipientName.placeholder).toContain("Your name");
+		expect(deviceName.placeholder).toContain("This device");
+	});
+
 	it.each([
 		["empty names", "project-share-recipient-name", "   ", "Identity display name is required"],
 		[

--- a/packages/ui/src/tabs/recipient-policy-invitations.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.tsx
@@ -28,6 +28,23 @@ type RecipientAcceptance = {
 	detail: string;
 };
 
+const MACHINE_NAME_PREFIX = /^(?:local:|identity:|pending_)/iu;
+const UUID_NAME = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+const HEX_FRAGMENT_NAME = /^[0-9a-f]{12,}$/iu;
+
+/**
+ * Machine identifiers (device ids, identity ids, uuid fragments) make terrible
+ * display names. Seed the name fields empty instead so the required-field
+ * validation asks the person for a real name, with placeholder text as the hint.
+ */
+function humanProvidedNameOrEmpty(value: string | null | undefined): string {
+	const reviewed = String(value ?? "").trim();
+	if (!reviewed) return "";
+	if (MACHINE_NAME_PREFIX.test(reviewed)) return "";
+	if (UUID_NAME.test(reviewed) || HEX_FRAGMENT_NAME.test(reviewed)) return "";
+	return reviewed;
+}
+
 function displayNameError(value: string, label: string): string {
 	const reviewed = value.trim();
 	if (!reviewed) return `${label} is required.`;
@@ -206,6 +223,7 @@ function ProjectShareConfirmation({
 						aria-invalid={Boolean(recipientNameError)}
 						id="project-share-recipient-name"
 						onInput={(event) => onRecipientNameChange(event.currentTarget.value)}
+						placeholder="Your name — e.g. Alex Rivera"
 						value={recipientName}
 					/>
 				</label>
@@ -221,6 +239,7 @@ function ProjectShareConfirmation({
 						aria-invalid={Boolean(deviceNameError)}
 						id="project-share-device-name"
 						onInput={(event) => onDeviceNameChange(event.currentTarget.value)}
+						placeholder="This device — e.g. Work Laptop"
 						value={deviceName}
 					/>
 				</label>
@@ -450,8 +469,8 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 			if (!isCurrentInspection()) return;
 			setInspected(result);
 			if (result.kind === "project_share_invite") {
-				setProjectRecipientName(result.recipient_name ?? "");
-				setProjectDeviceName(result.device_name ?? "");
+				setProjectRecipientName(humanProvidedNameOrEmpty(result.recipient_name));
+				setProjectDeviceName(humanProvidedNameOrEmpty(result.device_name));
 			}
 			setStatus(
 				result.kind === "team_member" || result.kind === "add_device"


### PR DESCRIPTION
## Description
Dogfood finding (codemem-at4t): invitation review pre-filled the identity/device display-name inputs with machine identifiers (`local:<uuid>`, device-id fragments). Accepting the defaults produced UUID-named identities across sharing surfaces. Machine-generated values are now filtered so the fields start empty (required-field validation already prompts for a real name) with placeholder ghost text as the hint.

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
