### PR TITLE
fix(e2e): count dogfood memories by project, not session git remote

### DIFF
--- a/e2e/scripts/dogfood-sharing-fixture.test.ts
+++ b/e2e/scripts/dogfood-sharing-fixture.test.ts
@@ -283,6 +283,37 @@ describe("runFixtureAction", () => {
 		}
 	});
 
+	it("counts replicated memories whose sessions arrive without a git remote", async () => {
+		const store = createStore("teammate");
+		try {
+			await runFixtureAction(store, "setup-teammate");
+			// Replicated sessions on recipients carry the project name but no
+			// git_remote; the summary must still attribute their memories.
+			const sessionId = store.startSession({
+				project: "dogfood-selected-project",
+				user: "dogfood",
+				toolVersion: "dogfood-sharing-fixture",
+			});
+			store.remember(
+				sessionId,
+				"discovery",
+				"DOGFOOD selected existing",
+				"replicated body",
+				0.9,
+				["dogfood-sharing-fixture"],
+				{ visibility: "shared" },
+			);
+			store.endSession(sessionId, {});
+
+			const summary = await runFixtureAction(store, "summary");
+			expect(summary.projects.selected.memory_count).toBe(1);
+			expect(summary.projects.selected.titles).toEqual(["DOGFOOD selected existing"]);
+			expect(summary.projects.unrelated.memory_count).toBe(0);
+		} finally {
+			store.close();
+		}
+	});
+
 	it("leaves invitation and recipient-policy tables empty after supported actions", async () => {
 		const store = createStore("owner");
 		try {

--- a/e2e/scripts/dogfood-sharing-fixture.ts
+++ b/e2e/scripts/dogfood-sharing-fixture.ts
@@ -122,17 +122,19 @@ function ensureEmptyTeam(store: MemoryStore): void {
 		.run(TEAM_ID, TEAM_NAME, `team:${TEAM_ID}`, FIXTURE_TIME, FIXTURE_TIME);
 }
 
-function memoryExists(store: MemoryStore, remote: string, title: string): boolean {
+// Match memories by the denormalized memory_items.project instead of the
+// session git_remote: replicated sessions on recipients arrive without
+// git_remote, which previously made recipient counts report false zeros.
+function memoryExists(store: MemoryStore, project: string, title: string): boolean {
 	return Boolean(
 		store.db
 			.prepare(
 				`SELECT 1
 				 FROM memory_items mi
-				 JOIN sessions s ON s.id = mi.session_id
-				 WHERE mi.active = 1 AND s.git_remote = ? AND mi.title = ?
+				 WHERE mi.active = 1 AND mi.project = ? AND mi.title = ?
 				 LIMIT 1`,
 			)
-			.get(remote, title),
+			.get(project, title),
 	);
 }
 
@@ -141,7 +143,7 @@ function ensureMemory(
 	project: (typeof PROJECTS)[keyof typeof PROJECTS],
 	title: string,
 ): void {
-	if (memoryExists(store, project.remote, title)) return;
+	if (memoryExists(store, project.project, title)) return;
 	const sessionId = store.startSession({
 		cwd: `/workspace/${project.project}`,
 		project: project.project,
@@ -171,7 +173,7 @@ function assertOwnerBaseline(store: MemoryStore): void {
 		.prepare("SELECT 1 FROM policy_teams WHERE team_id = ?")
 		.get(TEAM_ID);
 	const baselineExists = Object.values(PROJECTS).every((project) =>
-		memoryExists(store, project.remote, project.existingTitle),
+		memoryExists(store, project.project, project.existingTitle),
 	);
 	if (!teamExists || !baselineExists) {
 		throw new Error("Owner fixture is not initialized; run setup-owner first");
@@ -184,11 +186,10 @@ function projectSummary(store: MemoryStore, key: keyof typeof PROJECTS): Project
 		.prepare(
 			`SELECT mi.title
 			 FROM memory_items mi
-			 JOIN sessions s ON s.id = mi.session_id
-			 WHERE mi.active = 1 AND s.git_remote = ?
+			 WHERE mi.active = 1 AND mi.project = ?
 			 ORDER BY mi.title`,
 		)
-		.all(project.remote) as Array<{ title: string }>;
+		.all(project.project) as Array<{ title: string }>;
 	const titles = rows.map((row) => row.title);
 	return { remote: project.remote, memory_count: titles.length, titles };
 }


### PR DESCRIPTION
## Description
Dogfood finding (codemem-qna6): the dogfood summary joined memories to sessions on `git_remote`, but replicated sessions on recipients arrive without `git_remote`, so recipient counts always reported zero even when delivery succeeded — this sent a live dogfood run chasing a phantom delivery failure. Count by the denormalized `memory_items.project` instead, which survives replication. Adds a regression test covering the replicated-session shape.

## Type of Change
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
