### PR TITLE
fix(sharing): cancel superseded share operations once a duplicate is active

### DIFF
--- a/packages/core/src/share-operation-lifecycle.ts
+++ b/packages/core/src/share-operation-lifecycle.ts
@@ -138,8 +138,8 @@ export function projectShareLifecycle(
 			"waiting_for_device",
 			"Waiting for device",
 			lastSeen
-				? `${deviceName} is offline. Sync will continue when it reconnects; last seen ${lastSeen}.`
-				: `${deviceName} is offline. Sync will continue when it reconnects.`,
+				? `Waiting to reach ${deviceName}. Sync continues automatically when it is reachable; last seen ${lastSeen}.`
+				: `Waiting to reach ${deviceName}. Sync continues automatically when it is reachable.`,
 		);
 	}
 

--- a/packages/core/src/share-provisioning.test.ts
+++ b/packages/core/src/share-provisioning.test.ts
@@ -563,6 +563,276 @@ describe("exact project share provisioning", () => {
 		).toBe("active");
 	});
 
+	it("cancels superseded accepted duplicates for the same person and project set once active", async () => {
+		const operationState = (id: string) =>
+			db.prepare("SELECT state FROM share_operations WHERE operation_id = ?").pluck().get(id);
+		const acceptance = (
+			id: string,
+			digest: string,
+			projects: Array<{
+				canonical_identity: string;
+				display_name: string;
+				existing_memory_count: number;
+			}>,
+		) => {
+			const publicKey = "recipient-key";
+			reconcileShareOperationAcceptance(db, {
+				operationId: id,
+				localInviterActorId: "actor-owner",
+				coordinatorGroupId: "team",
+				reviewedProjectSetDigest: digest,
+				recipientActorId: "actor-recipient",
+				recipientDisplayName: "Brian",
+				recipientDeviceId: "recipient",
+				recipientDeviceDisplayName: "Brian's MacBook",
+				recipientPublicKey: publicKey,
+				recipientFingerprint: fingerprintPublicKey(publicKey),
+				consumedAt: "2026-07-20T13:00:00.000Z",
+				trustState: "bootstrap_grant_created",
+				bootstrapGrantId: "grant",
+				projects,
+			});
+		};
+		// Stale duplicate: same recipient, same exact project set, stuck after
+		// acceptance. Uses the existing-person intent (as a redone flow does once
+		// the recipient actor exists) so it gets a distinct operation id.
+		const stale = planShareOperation({
+			inviterActorId: "actor-owner",
+			inviterDeviceIds: ["owner", "owner-proven"],
+			person: { kind: "existing", personId: "actor-recipient", displayName: "Brian" },
+			projects: [
+				{
+					canonicalIdentity: remote,
+					displayName: "api",
+					identitySource: "git_remote",
+					existingMemoryCount: 2,
+				},
+			],
+			coordinatorGroupId: "team",
+			inviteExpiresAt: "2026-07-27T12:00:00.000Z",
+			createdAt: "2026-07-19T12:00:00.000Z",
+		});
+		persistShareOperation(db, stale, {
+			inviteId: "invite-stale",
+			tokenDigest: inviteTokenDigest("token-stale"),
+		});
+		acceptance(stale.operationId, stale.reviewedProjectSetDigest, [
+			{ canonical_identity: remote, display_name: "api", existing_memory_count: 2 },
+		]);
+		db.prepare(
+			"UPDATE share_operations SET state = 'waiting_for_device' WHERE operation_id = ?",
+		).run(stale.operationId);
+		// Control: same recipient but a different project set must stay untouched.
+		const otherRemote = "https://example.invalid/acme/other.git";
+		const unrelated = planShareOperation({
+			inviterActorId: "actor-owner",
+			inviterDeviceIds: ["owner", "owner-proven"],
+			person: { kind: "existing", personId: "actor-recipient", displayName: "Brian" },
+			projects: [
+				{
+					canonicalIdentity: otherRemote,
+					displayName: "other",
+					identitySource: "git_remote",
+					existingMemoryCount: 1,
+				},
+			],
+			coordinatorGroupId: "team",
+			inviteExpiresAt: "2026-07-27T12:00:00.000Z",
+			createdAt: "2026-07-19T12:00:00.000Z",
+		});
+		persistShareOperation(db, unrelated, {
+			inviteId: "invite-other",
+			tokenDigest: inviteTokenDigest("token-other"),
+		});
+		acceptance(unrelated.operationId, unrelated.reviewedProjectSetDigest, [
+			{ canonical_identity: otherRemote, display_name: "other", existing_memory_count: 1 },
+		]);
+		db.prepare(
+			"UPDATE share_operations SET state = 'waiting_for_device' WHERE operation_id = ?",
+		).run(unrelated.operationId);
+
+		// Controls that must SURVIVE supersession. The planner derives operation
+		// ids from group + inviter devices + person + projects, so each control
+		// starts from a distinct inviter-device set for a unique id and then has
+		// the non-varied columns aligned with the active operation via SQL to
+		// isolate exactly one mismatch dimension.
+		const control = (
+			label: string,
+			inviterDeviceIds: string[],
+			recipientDeviceId: string,
+		): string => {
+			const planned = planShareOperation({
+				inviterActorId: "actor-owner",
+				inviterDeviceIds,
+				person: { kind: "existing", personId: "actor-recipient", displayName: "Brian" },
+				projects: [
+					{
+						canonicalIdentity: remote,
+						displayName: "api",
+						identitySource: "git_remote",
+						existingMemoryCount: 2,
+					},
+				],
+				coordinatorGroupId: "team",
+				inviteExpiresAt: "2026-07-27T12:00:00.000Z",
+				createdAt: "2026-07-19T12:00:00.000Z",
+			});
+			persistShareOperation(db, planned, {
+				inviteId: `invite-${label}`,
+				tokenDigest: inviteTokenDigest(`token-${label}`),
+			});
+			// Derive the key from the device id so repeat acceptances for an
+			// already-pinned device present its established key.
+			const publicKey = `${recipientDeviceId}-key`;
+			reconcileShareOperationAcceptance(db, {
+				operationId: planned.operationId,
+				localInviterActorId: "actor-owner",
+				coordinatorGroupId: "team",
+				reviewedProjectSetDigest: planned.reviewedProjectSetDigest,
+				recipientActorId: "actor-recipient",
+				recipientDisplayName: "Brian",
+				recipientDeviceId,
+				recipientDeviceDisplayName: `Brian's ${label}`,
+				recipientPublicKey: publicKey,
+				recipientFingerprint: fingerprintPublicKey(publicKey),
+				consumedAt: "2026-07-20T13:00:00.000Z",
+				trustState: "bootstrap_grant_created",
+				bootstrapGrantId: `grant-${label}`,
+				projects: [{ canonical_identity: remote, display_name: "api", existing_memory_count: 2 }],
+			});
+			db.prepare(
+				"UPDATE share_operations SET state = 'waiting_for_device' WHERE operation_id = ?",
+			).run(planned.operationId);
+			return planned.operationId;
+		};
+		const alignInviterDevices = (id: string) => {
+			db.prepare(
+				`UPDATE share_operations SET inviter_device_ids_json =
+					(SELECT inviter_device_ids_json FROM share_operations WHERE operation_id = ?)
+				 WHERE operation_id = ?`,
+			).run(operationId, id);
+		};
+		// Same person + projects + group + inviter devices, DIFFERENT device.
+		const secondDeviceId = control("second-device", ["owner"], "recipient-second-device");
+		alignInviterDevices(secondDeviceId);
+		// Same everything except a different coordinator group.
+		const otherGroupId = control("other-group", ["owner-proven"], "recipient");
+		alignInviterDevices(otherGroupId);
+		db.prepare(
+			"UPDATE share_operations SET coordinator_group_id = 'other-team' WHERE operation_id = ?",
+		).run(otherGroupId);
+		// Same everything except a different reviewed inviter-device set.
+		const otherInviterSetId = control("other-inviter-set", ["owner-filtered"], "recipient");
+
+		const { deps } = dependencies();
+		await executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps);
+
+		expect(operationState(operationId)).toBe("active");
+		expect(operationState(stale.operationId)).toBe("cancelled");
+		expect(operationState(unrelated.operationId)).toBe("waiting_for_device");
+		expect(operationState(secondDeviceId)).toBe("waiting_for_device");
+		expect(operationState(otherGroupId)).toBe("waiting_for_device");
+		expect(operationState(otherInviterSetId)).toBe("waiting_for_device");
+	});
+
+	it("does not let a superseded invocation finishing late cancel newer duplicates or reactivate", async () => {
+		const operationState = (id: string) =>
+			db.prepare("SELECT state FROM share_operations WHERE operation_id = ?").pluck().get(id);
+		// A duplicate that this invocation would normally supersede.
+		const newer = planShareOperation({
+			inviterActorId: "actor-owner",
+			inviterDeviceIds: ["owner"],
+			person: { kind: "existing", personId: "actor-recipient", displayName: "Brian" },
+			projects: [
+				{
+					canonicalIdentity: remote,
+					displayName: "api",
+					identitySource: "git_remote",
+					existingMemoryCount: 2,
+				},
+			],
+			coordinatorGroupId: "team",
+			inviteExpiresAt: "2026-07-27T12:00:00.000Z",
+			createdAt: "2026-07-21T12:00:00.000Z",
+		});
+		persistShareOperation(db, newer, {
+			inviteId: "invite-newer",
+			tokenDigest: inviteTokenDigest("token-newer"),
+		});
+		const publicKey = "recipient-key";
+		reconcileShareOperationAcceptance(db, {
+			operationId: newer.operationId,
+			localInviterActorId: "actor-owner",
+			coordinatorGroupId: "team",
+			reviewedProjectSetDigest: newer.reviewedProjectSetDigest,
+			recipientActorId: "actor-recipient",
+			recipientDisplayName: "Brian",
+			recipientDeviceId: "recipient",
+			recipientDeviceDisplayName: "Brian's MacBook",
+			recipientPublicKey: publicKey,
+			recipientFingerprint: fingerprintPublicKey(publicKey),
+			consumedAt: "2026-07-20T13:00:00.000Z",
+			trustState: "bootstrap_grant_created",
+			bootstrapGrantId: "grant-newer",
+			projects: [{ canonical_identity: remote, display_name: "api", existing_memory_count: 2 }],
+		});
+		db.prepare(
+			`UPDATE share_operations SET inviter_device_ids_json =
+				(SELECT inviter_device_ids_json FROM share_operations WHERE operation_id = ?),
+				state = 'provisioning'
+			 WHERE operation_id = ?`,
+		).run(operationId, newer.operationId);
+
+		const { deps, scopeId } = dependencies();
+		const cancelSelf = () => {
+			// The duplicate wins the race and supersedes this invocation mid-flight.
+			db.prepare("UPDATE share_operations SET state = 'cancelled' WHERE operation_id = ?").run(
+				operationId,
+			);
+		};
+		// Cancellation during an early await must survive the later provisioning
+		// and initial_sync transitions (all guarded against 'cancelled').
+		const innerRefresh = deps.refreshAuthorization;
+		deps.refreshAuthorization = vi.fn(async (groupId: string) => {
+			cancelSelf();
+			await innerRefresh(groupId);
+		});
+		deps.runInitialSync = vi.fn(async () => ({
+			ok: true,
+			perScopeResults: [{ scope_id: scopeId, ok: true }],
+		}));
+		const result = await executeShareProvisioning(
+			db,
+			{ operationId, initiatingDeviceId: "owner" },
+			deps,
+		);
+
+		// The cancelled invocation neither reactivates nor cancels the newer op,
+		// and it reports the superseded outcome instead of success.
+		expect(result.superseded).toBe(true);
+		expect(operationState(operationId)).toBe("cancelled");
+		expect(operationState(newer.operationId)).toBe("provisioning");
+	});
+
+	it("keeps a superseded operation cancelled when its in-flight step fails afterwards", async () => {
+		const operationState = (id: string) =>
+			db.prepare("SELECT state FROM share_operations WHERE operation_id = ?").pluck().get(id);
+		const { deps } = dependencies();
+		deps.runInitialSync = vi.fn(async () => {
+			// Superseded mid-sync, then the sync fails with a connectivity error —
+			// the failure path must not resurrect waiting_for_device.
+			db.prepare("UPDATE share_operations SET state = 'cancelled' WHERE operation_id = ?").run(
+				operationId,
+			);
+			return { ok: false, failureCategory: "connectivity" as const };
+		});
+
+		await expect(
+			executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps),
+		).rejects.toThrow("waiting_for_device");
+		expect(operationState(operationId)).toBe("cancelled");
+	});
+
 	it("preserves completed effects and resumes from the failed grant", async () => {
 		let fail = true;
 		const { deps } = dependencies({

--- a/packages/core/src/share-provisioning.ts
+++ b/packages/core/src/share-provisioning.ts
@@ -496,12 +496,13 @@ function failStep(
 			: Number(failed?.attempt_count ?? 0) >= 3
 				? "needs_attention"
 				: null;
+	// Never overwrite a concurrent cancellation with a failure state — the
+	// superseded operation must stay cancelled even when its in-flight step
+	// fails afterwards.
 	if (state) {
-		db.prepare("UPDATE share_operations SET state = ?, updated_at = ? WHERE operation_id = ?").run(
-			state,
-			now,
-			operationId,
-		);
+		db.prepare(
+			"UPDATE share_operations SET state = ?, updated_at = ? WHERE operation_id = ? AND state != 'cancelled'",
+		).run(state, now, operationId);
 	} else {
 		db.prepare("UPDATE share_operations SET updated_at = ? WHERE operation_id = ?").run(
 			now,
@@ -623,7 +624,7 @@ export async function executeShareProvisioning(
 	db: Database,
 	input: { operationId: string; initiatingDeviceId: string },
 	dependencies: ShareProvisioningDependencies,
-): Promise<ShareProvisioningPlan> {
+): Promise<ShareProvisioningPlan & { superseded: boolean }> {
 	const plan = planShareProvisioning(db, input);
 	const executeStep = (
 		stepKey: string,
@@ -651,8 +652,11 @@ export async function executeShareProvisioning(
 		}
 	});
 	persistMembershipPlan(db, plan);
+	// Every state transition in this flow is guarded against 'cancelled' so a
+	// concurrently superseded operation can never overwrite its cancellation
+	// while this invocation is between async steps.
 	db.prepare(
-		"UPDATE share_operations SET state = 'provisioning', updated_at = ? WHERE operation_id = ?",
+		"UPDATE share_operations SET state = 'provisioning', updated_at = ? WHERE operation_id = ? AND state != 'cancelled'",
 	).run(new Date().toISOString(), plan.operationId);
 	for (const project of plan.projects) {
 		await executeStep(
@@ -733,7 +737,7 @@ export async function executeShareProvisioning(
 		dependencies.refreshAuthorization(plan.groupId),
 	);
 	db.prepare(
-		"UPDATE share_operations SET state = 'initial_sync', updated_at = ? WHERE operation_id = ?",
+		"UPDATE share_operations SET state = 'initial_sync', updated_at = ? WHERE operation_id = ? AND state != 'cancelled'",
 	).run(new Date().toISOString(), plan.operationId);
 	await executeStep("initial_sync", `initial-sync:${plan.operationId}`, async () => {
 		const result = await dependencies.runInitialSync(plan.recipientDeviceId);
@@ -745,8 +749,97 @@ export async function executeShareProvisioning(
 			if (!scoped?.ok) throw new Error(scoped?.error || "initial_sync_scope_incomplete");
 		}
 	});
-	db.prepare(
-		"UPDATE share_operations SET state = 'active', updated_at = ? WHERE operation_id = ?",
-	).run(new Date().toISOString(), plan.operationId);
-	return plan;
+	const activatedAt = new Date().toISOString();
+	// The state guard keeps a concurrently superseded (cancelled) duplicate from
+	// resurrecting itself to active after its own initial sync resolves. Only an
+	// invocation whose row actually transitioned to active may supersede others;
+	// a cancelled invocation finishing late has no authority to cancel anything.
+	const activation = db
+		.prepare(
+			"UPDATE share_operations SET state = 'active', updated_at = ? WHERE operation_id = ? AND state != 'cancelled'",
+		)
+		.run(activatedAt, plan.operationId);
+	if (activation.changes > 0) {
+		cancelSupersededShareOperations(db, plan.operationId, activatedAt);
+	}
+	// superseded: a duplicate won the race and cancelled this operation while it
+	// was in flight. Callers must not report it as active.
+	return { ...plan, superseded: activation.changes === 0 };
+}
+
+/**
+ * When a redone invite flow reaches active, older accepted-but-unfinished
+ * duplicates for the same recipient device and exact project set become
+ * zombies that report misleading states like "waiting for device". Cancel them
+ * so only the active operation represents the share.
+ *
+ * A duplicate must match the coordinator group (managed boundaries and
+ * memberships are group-specific), the reviewed inviter-device set (different
+ * sets are different provisioning intents), the recipient_device_id (the same
+ * person accepting the same project set on a different device is a legitimate
+ * in-flight share), and the exact project set. Operations in needs_attention
+ * are deliberately excluded — a user may still want to inspect or retry them
+ * explicitly.
+ */
+function cancelSupersededShareOperations(db: Database, operationId: string, now: string): void {
+	const active = db
+		.prepare(
+			`SELECT inviter_actor_id, inviter_device_ids_json, person_id, recipient_actor_id,
+				recipient_device_id, coordinator_group_id
+			 FROM share_operations WHERE operation_id = ?`,
+		)
+		.get(operationId) as
+		| {
+				inviter_actor_id: string;
+				inviter_device_ids_json: string;
+				person_id: string;
+				recipient_actor_id: string | null;
+				recipient_device_id: string | null;
+				coordinator_group_id: string;
+		  }
+		| undefined;
+	if (!active?.recipient_device_id) return;
+	const projectSet = (id: string): string =>
+		(
+			db
+				.prepare(
+					`SELECT canonical_project_identity FROM share_operation_projects
+					 WHERE operation_id = ? ORDER BY canonical_project_identity`,
+				)
+				.all(id) as Array<{ canonical_project_identity: string }>
+		)
+			.map((row) => row.canonical_project_identity)
+			.join("\u0000");
+	const activeProjects = projectSet(operationId);
+	const candidates = db
+		.prepare(
+			`SELECT operation_id FROM share_operations
+			 WHERE operation_id != ? AND inviter_actor_id = ?
+			   AND state IN ('accepted', 'provisioning', 'initial_sync', 'waiting_for_device')
+			   AND coordinator_group_id = ?
+			   AND inviter_device_ids_json = ?
+			   AND recipient_device_id = ?
+			   AND (person_id = ? OR (recipient_actor_id IS NOT NULL AND recipient_actor_id = ?))`,
+		)
+		.all(
+			operationId,
+			active.inviter_actor_id,
+			active.coordinator_group_id,
+			active.inviter_device_ids_json,
+			active.recipient_device_id,
+			active.person_id,
+			active.recipient_actor_id ?? active.person_id,
+		) as Array<{ operation_id: string }>;
+	// Re-check the candidate state at write time: a concurrent provisioning
+	// process may have activated this candidate between selection and update,
+	// and a successfully activated operation must never be overwritten.
+	const cancel = db.prepare(
+		`UPDATE share_operations SET state = 'cancelled', updated_at = ?
+		 WHERE operation_id = ?
+		   AND state IN ('accepted', 'provisioning', 'initial_sync', 'waiting_for_device')`,
+	);
+	for (const row of candidates) {
+		if (projectSet(row.operation_id) !== activeProjects) continue;
+		cancel.run(now, row.operation_id);
+	}
 }

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1411,7 +1411,7 @@ async function executeProjectShareProvisioning(store: MemoryStore, operationId: 
 
 export interface AdvanceProjectShareOperationResult {
 	advanced: boolean;
-	state: "active" | "waiting_for_acceptance";
+	state: "active" | "waiting_for_acceptance" | "cancelled";
 }
 
 export async function advanceProjectShareOperation(
@@ -1427,13 +1427,24 @@ export async function advanceProjectShareOperation(
 		| undefined;
 	if (!operation) throw new Error("operation_not_found");
 	if (operation.inviter_actor_id !== store.actorId) throw new Error("operation_scope_mismatch");
+	if (operation.state === "cancelled") {
+		// Already superseded (possibly earlier in the same maintenance batch);
+		// provisioning a cancelled operation would only produce a misleading
+		// operation_not_accepted failure.
+		return { advanced: false, state: "cancelled" };
+	}
 	if (!operation.recipient_device_id) {
 		const reconciliation = await reconcileProjectInviteAcceptance(store, operationId);
 		if (!reconciliation.accepted) {
 			return { advanced: false, state: "waiting_for_acceptance" };
 		}
 	}
-	await executeProjectShareProvisioning(store, operationId);
+	const plan = await executeProjectShareProvisioning(store, operationId);
+	if (plan.superseded) {
+		// A duplicate operation won the race and cancelled this one mid-flight;
+		// reporting it as active would contradict the stored state.
+		return { advanced: false, state: "cancelled" };
+	}
 	return { advanced: true, state: "active" };
 }
 
@@ -1451,6 +1462,7 @@ export interface AdvancePendingProjectSharesResult {
 			| "waiting_for_device"
 			| "retry_scheduled"
 			| "needs_attention"
+			| "superseded"
 			| "failed";
 		error?: string;
 	}>;
@@ -1625,6 +1637,11 @@ export async function advancePendingProjectShares(
 		try {
 			const advanced = await advanceOperation(store, row.operation_id);
 			if (!advanced.advanced) {
+				if (advanced.state === "cancelled") {
+					// Superseded by a duplicate that reached active first; terminal.
+					result.items.push({ operationId: row.operation_id, outcome: "superseded" });
+					continue;
+				}
 				store.db
 					.prepare("UPDATE share_operations SET updated_at = ? WHERE operation_id = ?")
 					.run(maintenanceNow.toISOString(), row.operation_id);
@@ -1643,6 +1660,13 @@ export async function advancePendingProjectShares(
 				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
 				.pluck()
 				.get(row.operation_id);
+			if (state === "cancelled") {
+				// Superseded by a duplicate while a step was in flight; the stored
+				// state is terminal and benign, so the step's rejection must not be
+				// reported as a failure or push the daemon into an error phase.
+				result.items.push({ operationId: row.operation_id, outcome: "superseded" });
+				continue;
+			}
 			if (message === "waiting_for_device" || state === "waiting_for_device") {
 				result.waiting += 1;
 				result.items.push({ operationId: row.operation_id, outcome: "waiting_for_device" });
@@ -5369,12 +5393,25 @@ export function syncRoutes(
 		try {
 			const advanced = await advanceProjectShareOperation(store, operationId);
 			if (!advanced.advanced) {
-				return c.json({ error: "invitation_not_accepted" }, 409);
+				return c.json(
+					{
+						error:
+							advanced.state === "cancelled" ? "operation_superseded" : "invitation_not_accepted",
+					},
+					409,
+				);
 			}
 			const [operation] = await shareOperationReadModels(store, operationId);
 			return c.json({ ok: true, operation });
 		} catch (error) {
 			const code = error instanceof Error ? error.message : "provisioning_failed";
+			const state = store.db
+				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+				.pluck()
+				.get(operationId);
+			if (state === "cancelled") {
+				return c.json({ error: "operation_superseded" }, 409);
+			}
 			return c.json({ error: code }, code === "operation_not_found" ? 404 : 409);
 		}
 	};
@@ -5389,9 +5426,21 @@ export function syncRoutes(
 		}
 		try {
 			const plan = await executeProjectShareProvisioning(store, operationId);
+			if (plan.superseded) {
+				// Consistent with /advance: a supersession race is a conflict, not a
+				// success with a flag.
+				return c.json({ error: "operation_superseded" }, 409);
+			}
 			return c.json({ ok: true, operation_id: operationId, state: "active", plan });
 		} catch (error) {
 			const code = error instanceof Error ? error.message : "provisioning_failed";
+			const state = store.db
+				.prepare("SELECT state FROM share_operations WHERE operation_id = ?")
+				.pluck()
+				.get(operationId);
+			if (state === "cancelled") {
+				return c.json({ error: "operation_superseded" }, 409);
+			}
 			return c.json({ error: code }, code === "operation_not_found" ? 404 : 409);
 		}
 	});


### PR DESCRIPTION
## Description
Dogfood finding (codemem-e5sn): redoing an invite flow left the earlier accepted-but-unfinished share operation permanently reporting "Waiting for device … is offline" even while the device was online and the newer operation was active. When an operation reaches `active`, accepted/provisioning/initial_sync/waiting_for_device duplicates for the same recipient **device** and exact project set are now cancelled. The waiting-for-device explanation also stops asserting the device is offline — a connectivity failure does not prove offline.

Review hardening: supersession is scoped by `recipient_device_id` so the same person accepting the same project set on a different device (a legitimate in-flight second-device share) survives; the activation update guards against resurrecting a concurrently cancelled duplicate; `needs_attention` operations are deliberately excluded (documented).

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (stale-duplicate cancelled; different-project and different-device controls survive)
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
