### PR TITLE
fix(sync): sign manual sync runs with the configured keys directory

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -4026,7 +4026,10 @@ describe("viewer-server", () => {
 				const res = await syncApp.request("/v1/status");
 				expect(res.status).toBe(401);
 				const body = (await res.json()) as Record<string, unknown>;
-				expect(body).toMatchObject({ error: "unauthorized", reason: "bootstrap_grant_invalid" });
+				// Grant-less callers get the truthful device-auth reason; the generic
+				// bootstrap_grant_invalid masking applies only when a grant header
+				// was actually presented.
+				expect(body).toMatchObject({ error: "unauthorized", reason: "missing_headers" });
 			} finally {
 				if (previous === undefined) delete process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS;
 				else process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS = previous;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -2163,6 +2163,16 @@ function syncKeysDir(): string | undefined {
 	return process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
 }
 
+/** Strip control/format characters and cap length so attacker-controlled
+ * headers cannot forge log lines when included in diagnostics. */
+function loggableHeaderValue(value: string | undefined): string {
+	const sanitized = (value ?? "")
+		.replace(/[\p{Cc}\p{Cf}]/gu, "")
+		.slice(0, 64)
+		.trim();
+	return sanitized || "unknown";
+}
+
 function intEnvOr(name: string, fallback: number): number {
 	const value = Number.parseInt(process.env[name] ?? "", 10);
 	return Number.isFinite(value) ? value : fallback;
@@ -3807,6 +3817,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 			let preauthChecked = false;
 			let bootstrapAttempted = false;
+			let deviceAuthReason: string | null = null;
 			if (!auth.ok) {
 				const bootstrapGrantId = (c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim();
 				if (bootstrapGrantId) {
@@ -3820,6 +3831,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 					const unauthLimited = rateLimitedResponse(c, c.req.path, false);
 					if (unauthLimited) return unauthLimited;
 				}
+				deviceAuthReason = auth.reason;
 				auth = await authorizeBootstrapGrantRequest(store, c.req, Buffer.alloc(0));
 				bootstrapAttempted = true;
 			}
@@ -3828,12 +3840,23 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				// Specific reasons are logged server-side; wire responses use a generic
 				// reason to prevent info-disclosure.
 				const grantPresent = Boolean((c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim());
-				if (bootstrapAttempted && grantPresent) {
+				// Warn only when the caller actually attempted authentication (a
+				// grant or signed device headers); bare probes and health checks
+				// must not fill logs with attacker-controllable noise.
+				const authAttempted =
+					grantPresent || (deviceAuthReason != null && deviceAuthReason !== "missing_headers");
+				if (bootstrapAttempted && authAttempted) {
 					console.warn(
-						`[sync] bootstrap grant auth failed: reason=${auth.reason} grant_present=${grantPresent} path=${c.req.path}`,
+						`[sync] peer auth failed: reason=${auth.reason} device_auth_reason=${deviceAuthReason ?? "none"} grant_present=${grantPresent} path=${c.req.path} device=${loggableHeaderValue(c.req.header("X-Opencode-Device"))}`,
 					);
 				}
-				const wireReason = bootstrapAttempted ? "bootstrap_grant_invalid" : auth.reason;
+				// Mask grant details only when a grant was actually presented; a
+				// grant-less caller gets its device-auth failure reason so signature
+				// and clock issues stay diagnosable from the client side.
+				const wireReason =
+					bootstrapAttempted && grantPresent
+						? "bootstrap_grant_invalid"
+						: (deviceAuthReason ?? auth.reason);
 				return (
 					(preauthChecked ? null : rateLimitedResponse(c, c.req.path, false)) ??
 					c.json(unauthorizedPayload(wireReason, true), 401)
@@ -3980,6 +4003,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 			let preauthChecked = false;
 			let bootstrapAttempted = false;
+			let deviceAuthReason: string | null = null;
 			if (!auth.ok) {
 				const bootstrapGrantId = (c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim();
 				if (bootstrapGrantId) {
@@ -3993,6 +4017,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 					const unauthLimited = rateLimitedResponse(c, c.req.path, false);
 					if (unauthLimited) return unauthLimited;
 				}
+				deviceAuthReason = auth.reason;
 				auth = await authorizeBootstrapGrantRequest(store, c.req, Buffer.alloc(0));
 				bootstrapAttempted = true;
 			}
@@ -4001,12 +4026,23 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				// Specific reasons are logged server-side; wire responses use a generic
 				// reason to prevent info-disclosure.
 				const grantPresent = Boolean((c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim());
-				if (bootstrapAttempted && grantPresent) {
+				// Warn only when the caller actually attempted authentication (a
+				// grant or signed device headers); bare probes and health checks
+				// must not fill logs with attacker-controllable noise.
+				const authAttempted =
+					grantPresent || (deviceAuthReason != null && deviceAuthReason !== "missing_headers");
+				if (bootstrapAttempted && authAttempted) {
 					console.warn(
-						`[sync] bootstrap grant auth failed: reason=${auth.reason} grant_present=${grantPresent} path=${c.req.path}`,
+						`[sync] peer auth failed: reason=${auth.reason} device_auth_reason=${deviceAuthReason ?? "none"} grant_present=${grantPresent} path=${c.req.path} device=${loggableHeaderValue(c.req.header("X-Opencode-Device"))}`,
 					);
 				}
-				const wireReason = bootstrapAttempted ? "bootstrap_grant_invalid" : auth.reason;
+				// Mask grant details only when a grant was actually presented; a
+				// grant-less caller gets its device-auth failure reason so signature
+				// and clock issues stay diagnosable from the client side.
+				const wireReason =
+					bootstrapAttempted && grantPresent
+						? "bootstrap_grant_invalid"
+						: (deviceAuthReason ?? auth.reason);
 				return (
 					(preauthChecked ? null : rateLimitedResponse(c, c.req.path, false)) ??
 					c.json(unauthorizedPayload(wireReason, true), 401)
@@ -4776,7 +4812,13 @@ export function syncRoutes(
 		}
 		const items = [] as Array<Record<string, unknown>>;
 		for (const peerId of peerIds) {
-			const result = await runSyncPass(store.db, peerId, { scanner: store.scanner });
+			// keysDir must match the sync daemon's key material — omitting it made
+			// this route sign with a different device key whenever CODEMEM_KEYS_DIR
+			// was set, so manual sync runs failed peer auth while daemon syncs worked.
+			const result = await runSyncPass(store.db, peerId, {
+				keysDir: syncKeysDir(),
+				scanner: store.scanner,
+			});
 			items.push({
 				peer_device_id: peerId,
 				...result,


### PR DESCRIPTION
## Description
Dogfood finding (codemem-3cpz): `POST /api/sync/run` invoked `runSyncPass` without `keysDir` while every other call site passes `syncKeysDir()`. With `CODEMEM_KEYS_DIR` set, manual sync runs signed requests with mismatched key material and failed peer auth (401 `bootstrap_grant_invalid`) while daemon syncs succeeded — observed bidirectionally in the three-peer dogfood sandbox.

Diagnosability + hardening:
- Peer-auth failures are now logged server-side even without a bootstrap grant header, including the underlying device-auth reason.
- The logged `X-Opencode-Device` header is sanitized (control/format chars stripped, length-capped) to prevent log-line forgery.
- Wire responses mask details as `bootstrap_grant_invalid` only when a grant was actually presented; grant-less callers receive their truthful device-auth reason (e.g. `missing_headers`, `invalid_signature`) so signature/clock issues stay diagnosable client-side.

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (grant-less 401 now asserts the truthful reason under diagnostics)
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
