### PR TITLE
feat(sharing): show received Projects on the recipient side

### DIFF
--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -21,6 +21,7 @@ function insertSession(
 		project?: string | null;
 		gitRemote?: string | null;
 		gitBranch?: string | null;
+		toolVersion?: string;
 	} = {},
 ) {
 	const now = "2026-05-06T00:00:00Z";
@@ -38,7 +39,7 @@ function insertSession(
 				: input.gitRemote,
 			input.gitBranch === undefined ? "main" : input.gitBranch,
 			"test-user",
-			"test",
+			input.toolVersion ?? "test",
 		);
 	return Number(result.lastInsertRowid);
 }
@@ -1060,6 +1061,156 @@ describe("project scope settings", () => {
 			inventory.projects.some(
 				(project) => project.workspace_identity === "https://git.example.invalid/exampleco/api.git",
 			),
+		).toBe(true);
+	});
+
+	it("marks projects from incremental replication sessions as peer received", () => {
+		// Sessions minted by ensureSessionForReplication carry no cwd and
+		// tool_version 'sync_replication'. Their memories are peer-owned and
+		// must be classified peer_received, matching bootstrap sessions.
+		const replicatedSession = insertSession(db, {
+			cwd: null,
+			gitRemote: null,
+			project: "codemem",
+			toolVersion: "sync_replication",
+		});
+		insertMemory(db, replicatedSession, {
+			originDeviceId: "peer-a",
+			project: "codemem",
+			workspaceId: "shared:default",
+		});
+
+		const inventory = listProjectScopeInventory(db);
+		expect(inventory.projects).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					display_project: "codemem",
+					memory_count: 1,
+					read_only: true,
+					read_only_reason: "peer_received",
+					workspace_identity: "peer-received:peer-a:project:codemem",
+				}),
+			]),
+		);
+		// The synthetic replication session itself is not listed as a local project.
+		expect(
+			inventory.projects.filter((project) => project.display_project === "codemem"),
+		).toHaveLength(1);
+	});
+
+	it("groups peer-received memories from multiple origin devices by their managed scope", () => {
+		const scopeId = "managed-project:abc123";
+		const bootstrapSession = insertSession(db, {
+			cwd: "__sync_bootstrap__:codemem",
+			gitRemote: null,
+			project: "codemem",
+		});
+		insertMemory(db, bootstrapSession, {
+			originDeviceId: "owner-laptop",
+			project: "codemem",
+			scopeId,
+			workspaceId: "shared:default",
+		});
+		const replicationSession = insertSession(db, {
+			cwd: null,
+			gitRemote: null,
+			project: "codemem",
+			toolVersion: "sync_replication",
+		});
+		insertMemory(db, replicationSession, {
+			originDeviceId: "owner-desktop",
+			project: "codemem",
+			scopeId,
+			workspaceId: "shared:default",
+		});
+
+		const inventory = listProjectScopeInventory(db);
+		const received = inventory.projects.filter(
+			(project) => project.read_only_reason === "peer_received",
+		);
+		// One card for the Project despite two authoring devices.
+		expect(received).toHaveLength(1);
+		expect(received[0]).toMatchObject({
+			display_project: "codemem",
+			memory_count: 2,
+			workspace_identity: `peer-received:scope:${scopeId}`,
+		});
+	});
+
+	it("does not double-list a replicated session whose memories gained a project later", () => {
+		// Older senders create the session without a project; later upserts
+		// backfill only memory_items.project. The session must not surface as a
+		// shareable local project next to the peer-received card.
+		const upgradedSession = insertSession(db, {
+			cwd: null,
+			gitRemote: null,
+			project: null,
+			toolVersion: "sync_replication",
+		});
+		insertMemory(db, upgradedSession, {
+			originDeviceId: "peer-a",
+			project: "codemem",
+			workspaceId: "shared:default",
+		});
+
+		const inventory = listProjectScopeInventory(db);
+		const cards = inventory.projects.filter(
+			(project) => project.display_project === "codemem" || project.project === "codemem",
+		);
+		expect(cards).toHaveLength(1);
+		expect(cards[0]).toMatchObject({ read_only: true, read_only_reason: "peer_received" });
+	});
+
+	it("keeps project-less siblings visible when a replicated session is partially upgraded", () => {
+		// Mixed legacy session: one row upgraded with a project (represented by
+		// the peer-received card) and one still project-less (must stay visible
+		// through the session row without double counting the upgraded one).
+		const mixedSession = insertSession(db, {
+			cwd: null,
+			gitRemote: null,
+			project: null,
+			toolVersion: "sync_replication",
+		});
+		insertMemory(db, mixedSession, {
+			originDeviceId: "peer-a",
+			project: "codemem",
+			workspaceId: "shared:default",
+		});
+		insertMemory(db, mixedSession, {
+			originDeviceId: "peer-a",
+			project: null,
+			workspaceId: "shared:default",
+		});
+
+		const inventory = listProjectScopeInventory(db);
+		const receivedCard = inventory.projects.find(
+			(project) => project.read_only_reason === "peer_received",
+		);
+		expect(receivedCard).toMatchObject({ display_project: "codemem", memory_count: 1 });
+		const sessionCard = inventory.projects.find(
+			(project) => project.read_only_reason !== "peer_received",
+		);
+		// The project-less sibling remains represented, counted once.
+		expect(sessionCard?.memory_count).toBe(1);
+	});
+
+	it("keeps project-less replicated sessions visible via their workspace identity", () => {
+		// Older senders may omit the project on replicated payloads; those
+		// sessions must not vanish from the inventory entirely.
+		const projectlessSession = insertSession(db, {
+			cwd: null,
+			gitRemote: null,
+			project: null,
+			toolVersion: "sync_replication",
+		});
+		insertMemory(db, projectlessSession, {
+			originDeviceId: "peer-a",
+			workspaceId: "shared:default",
+		});
+
+		const inventory = listProjectScopeInventory(db);
+		expect(
+			inventory.projects.some((project) => project.workspace_identity === "shared:default"),
 		).toBe(true);
 	});
 

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -973,15 +973,40 @@ export function listProjectScopeInventory(
 				COUNT(mi_count.id) AS memory_count
 			 FROM sessions s
 			 LEFT JOIN memory_items mi_count ON mi_count.session_id = s.id AND mi_count.active = 1
+				AND NOT (
+					COALESCE(s.tool_version, '') = 'sync_replication'
+					AND COALESCE(TRIM(mi_count.project), '') <> ''
+				)
 			 WHERE (
 			           COALESCE(TRIM(s.git_remote), TRIM(s.cwd), TRIM(s.project), '') <> ''
 			        OR mi_count.id IS NOT NULL
 			       )
 			   AND (s.cwd IS NULL OR substr(s.cwd, 1, length(?)) <> ?)
+			   AND NOT (
+			         COALESCE(s.tool_version, '') = 'sync_replication'
+			     AND (
+			           COALESCE(TRIM(s.project), '') <> ''
+			        OR NOT EXISTS (
+			             SELECT 1 FROM memory_items mp
+			             WHERE mp.session_id = s.id AND mp.active = 1
+			               AND COALESCE(TRIM(mp.project), '') = ''
+			           )
+			         )
+			       )
 			 GROUP BY s.id
 			 ORDER BY MAX(s.started_at) DESC, s.id DESC`,
 		)
 		.all(SYNC_BOOTSTRAP_CWD_PREFIX, SYNC_BOOTSTRAP_CWD_PREFIX) as ProjectScopeCandidateRow[];
+	// Peer-received rows cover both bootstrap snapshot sessions (marked by the
+	// bootstrap cwd prefix) and sessions minted by incremental replication
+	// (tool_version 'sync_replication', no cwd). Both hold peer-owned content
+	// the local device receives but does not manage. Memories in a managed
+	// Project scope key on that scope — it is the sender's canonical Project
+	// identity and stays stable across multiple authoring devices — while
+	// legacy rows without a managed scope fall back to origin device + name.
+	// MAX(project) makes the displayed name deterministic when scope members
+	// briefly disagree (renames converge as replication upserts rewrite the
+	// project on existing rows).
 	const bootstrapRows = db
 		.prepare(
 			`SELECT
@@ -989,10 +1014,13 @@ export function listProjectScopeInventory(
 				'peer_received' AS inventory_source,
 				MAX(COALESCE(mi.updated_at, s.started_at)) AS started_at,
 				NULL AS cwd,
-				TRIM(mi.project) AS project,
+				MAX(TRIM(mi.project)) AS project,
 				NULL AS git_remote,
 				NULL AS git_branch,
-				'peer-received:' || COALESCE(NULLIF(TRIM(mi.origin_device_id), ''), 'unknown') || ':project:' || TRIM(mi.project) AS workspace_id,
+				'peer-received:' || CASE
+					WHEN mi.scope_id LIKE 'managed-project:%' THEN 'scope:' || mi.scope_id
+					ELSE COALESCE(NULLIF(TRIM(mi.origin_device_id), ''), 'unknown') || ':project:' || TRIM(mi.project)
+				END AS workspace_id,
 				0 AS session_count,
 				COUNT(mi.id) AS memory_count
 			 FROM memory_items mi
@@ -1000,9 +1028,14 @@ export function listProjectScopeInventory(
 			 WHERE mi.active = 1
 			   AND mi.project IS NOT NULL
 			   AND TRIM(mi.project) <> ''
-			   AND s.cwd IS NOT NULL
-			   AND substr(s.cwd, 1, length(?)) = ?
-			 GROUP BY TRIM(mi.project), workspace_id
+			   AND (
+			         (s.cwd IS NOT NULL AND substr(s.cwd, 1, length(?)) = ?)
+			      OR (s.cwd IS NULL AND s.tool_version = 'sync_replication')
+			       )
+			 GROUP BY CASE
+				WHEN mi.scope_id LIKE 'managed-project:%' THEN 'scope:' || mi.scope_id
+				ELSE COALESCE(NULLIF(TRIM(mi.origin_device_id), ''), 'unknown') || ':project:' || TRIM(mi.project)
+			 END
 			 ORDER BY MAX(COALESCE(mi.updated_at, s.started_at)) DESC, TRIM(mi.project) ASC`,
 		)
 		.all(SYNC_BOOTSTRAP_CWD_PREFIX, SYNC_BOOTSTRAP_CWD_PREFIX) as ProjectScopeCandidateRow[];

--- a/packages/ui/src/app-sharing.test.tsx
+++ b/packages/ui/src/app-sharing.test.tsx
@@ -73,7 +73,7 @@ describe("Sharing app data refresh", () => {
 	it("replaces stale actions after a refresh failure and restores them after recovery", async () => {
 		document.body.innerHTML =
 			'<div id="recipientPolicySharingMount"></div><div id="recipientPolicyManagementMount"></div>';
-		const loadProjects = vi.fn().mockResolvedValue(projects);
+		const loadProjects = vi.fn().mockResolvedValue({ manageable: projects, received: [] });
 		const loadIntent = vi.fn().mockResolvedValue(intent);
 		const load = createRecipientPolicySharingLoader({ loadIntent, loadProjects });
 

--- a/packages/ui/src/app-sharing.ts
+++ b/packages/ui/src/app-sharing.ts
@@ -4,7 +4,11 @@ import {
 	mountRecipientPolicyManagement,
 	type RecipientPolicyManagementProject,
 } from "./tabs/recipient-policy-management";
-import { toRecipientPolicyManagementProjects } from "./tabs/recipient-policy-projects";
+import {
+	type ReceivedProjectShare,
+	toReceivedProjectShares,
+	toRecipientPolicyManagementProjects,
+} from "./tabs/recipient-policy-projects";
 import { mountRecipientPolicySharing } from "./tabs/recipient-policy-sharing";
 
 const EMPTY_RECIPIENT_POLICY_INTENT: api.RecipientPolicyIntentGraphV1 = {
@@ -16,7 +20,12 @@ const EMPTY_RECIPIENT_POLICY_INTENT: api.RecipientPolicyIntentGraphV1 = {
 	projectRecipients: [],
 };
 
-async function loadRecipientPolicyProjects(): Promise<RecipientPolicyManagementProject[]> {
+interface RecipientPolicyProjectInventory {
+	manageable: RecipientPolicyManagementProject[];
+	received: ReceivedProjectShare[];
+}
+
+async function loadRecipientPolicyProjects(): Promise<RecipientPolicyProjectInventory> {
 	const projects: ProjectScopeInventoryProject[] = [];
 	let offset = 0;
 	while (true) {
@@ -25,12 +34,15 @@ async function loadRecipientPolicyProjects(): Promise<RecipientPolicyManagementP
 		if (!page.has_more) break;
 		offset += page.limit;
 	}
-	return toRecipientPolicyManagementProjects(projects);
+	return {
+		manageable: toRecipientPolicyManagementProjects(projects),
+		received: toReceivedProjectShares(projects),
+	};
 }
 
 interface RecipientPolicySharingLoaderDependencies {
 	loadIntent: typeof api.loadRecipientPolicyIntent;
-	loadProjects: () => Promise<RecipientPolicyManagementProject[]>;
+	loadProjects: () => Promise<RecipientPolicyProjectInventory>;
 	mountManagement: typeof mountRecipientPolicyManagement;
 	mountSharing: typeof mountRecipientPolicySharing;
 }
@@ -58,14 +70,16 @@ export function createRecipientPolicySharingLoader(
 			});
 		}
 		try {
-			const [projects, intent] = await Promise.all([
+			const [inventory, intent] = await Promise.all([
 				dependencies.loadProjects(),
 				dependencies.loadIntent(),
 			]);
-			dependencies.mountSharing(sharingMount, projects, intent);
+			dependencies.mountSharing(sharingMount, inventory.manageable, intent, {
+				received: inventory.received,
+			});
 			loaded = true;
 			if (managementMount) {
-				dependencies.mountManagement(managementMount, projects, intent, {
+				dependencies.mountManagement(managementMount, inventory.manageable, intent, {
 					onCommitted: loadRecipientPolicySharingData,
 				});
 			}

--- a/packages/ui/src/tabs/recipient-policy-projects.ts
+++ b/packages/ui/src/tabs/recipient-policy-projects.ts
@@ -5,6 +5,38 @@ export function isRecipientPolicyManageableProject(project: ProjectScopeInventor
 	return project.identity_source !== "unmapped" && project.read_only !== true;
 }
 
+export interface ReceivedProjectShare {
+	canonicalProjectIdentity: string;
+	displayName: string;
+	existingMemoryCount: number;
+	latestSessionAt: string | null;
+}
+
+/**
+ * Projects this node receives from other people. Sourced from the local
+ * inventory's peer_received markers so the recipient sees inbound access
+ * without depending on the owner's policy graph.
+ */
+export function toReceivedProjectShares(
+	projects: ProjectScopeInventoryProject[],
+): ReceivedProjectShare[] {
+	const byId = new Map<string, ReceivedProjectShare>();
+	for (const project of projects) {
+		if (project.read_only_reason !== "peer_received") continue;
+		byId.set(project.workspace_identity, {
+			canonicalProjectIdentity: project.workspace_identity,
+			displayName: project.display_project,
+			existingMemoryCount: project.memory_count ?? 0,
+			latestSessionAt: project.latest_session_at ?? null,
+		});
+	}
+	return [...byId.values()].sort(
+		(left, right) =>
+			left.displayName.localeCompare(right.displayName) ||
+			left.canonicalProjectIdentity.localeCompare(right.canonicalProjectIdentity),
+	);
+}
+
 export function toRecipientPolicyManagementProjects(
 	projects: ProjectScopeInventoryProject[],
 ): RecipientPolicyManagementProject[] {

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -167,7 +167,7 @@ describe("recipient-focused Sharing", () => {
 		document.body.innerHTML = "";
 	});
 
-	it("renders all three accessible views and recipient-aware invitation controls", () => {
+	it("renders all four accessible views and recipient-aware invitation controls", () => {
 		mount();
 		expect(document.querySelector('[role="tablist"]')?.getAttribute("aria-label")).toBe(
 			"Sharing views",
@@ -175,6 +175,7 @@ describe("recipient-focused Sharing", () => {
 		expect([...document.querySelectorAll('[role="tab"]')].map((item) => item.textContent)).toEqual([
 			"Teams",
 			"Identities",
+			"Received",
 			"Invitations",
 		]);
 		expect(tab("Teams").getAttribute("aria-controls")).toBe("recipient-policy-sharing-panel-teams");
@@ -182,6 +183,8 @@ describe("recipient-focused Sharing", () => {
 
 		clickTab("Identities");
 		expect(visiblePanel().textContent).toContain("Local identity");
+		clickTab("Received");
+		expect(visiblePanel().textContent).toContain("No received Projects on this device");
 		clickTab("Invitations");
 		expect(visiblePanel().textContent).toContain("Invite Team member");
 		expect(visiblePanel().textContent).toContain("Add a device");
@@ -189,6 +192,33 @@ describe("recipient-focused Sharing", () => {
 		expect(visiblePanel().textContent).toContain(
 			"Legacy invitation import remains under Advanced Team administration",
 		);
+	});
+
+	it("lists received Projects with counts, activity, and read-only guidance", () => {
+		mount(intent(), {
+			received: [
+				{
+					canonicalProjectIdentity: "git:received-api",
+					displayName: "Received API",
+					existingMemoryCount: 2,
+					latestSessionAt: "2026-07-25T12:00:00.000Z",
+				},
+				{
+					canonicalProjectIdentity: "git:received-tools",
+					displayName: "Received Tools",
+					existingMemoryCount: 1,
+					latestSessionAt: null,
+				},
+			],
+		});
+		clickTab("Received");
+		const text = visiblePanel().textContent ?? "";
+		expect(text).toContain("Received API");
+		expect(text).toContain("2 memories");
+		expect(text).toContain("Received Tools");
+		expect(text).toContain("1 memory");
+		expect(text).toContain("No recent sessions");
+		expect(text).toContain("Access is managed where the Project is shared from");
 	});
 
 	it("supports automatic keyboard tab activation, wraparound, Home, End, and focus", () => {

--- a/packages/ui/src/tabs/recipient-policy-sharing.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.tsx
@@ -6,17 +6,20 @@ import {
 	openRecipientPolicyManagement,
 	type RecipientPolicyManagementProject,
 } from "./recipient-policy-management";
+import type { ReceivedProjectShare } from "./recipient-policy-projects";
 
 export interface RecipientPolicySharingOptions {
 	loading?: boolean;
 	loadError?: boolean;
+	received?: ReceivedProjectShare[];
 }
 
-type SharingTab = "teams" | "identities" | "invitations";
+type SharingTab = "teams" | "identities" | "received" | "invitations";
 
 const SHARING_TABS: Array<{ id: SharingTab; label: string }> = [
 	{ id: "teams", label: "Teams" },
 	{ id: "identities", label: "Identities" },
+	{ id: "received", label: "Received" },
 	{ id: "invitations", label: "Invitations" },
 ];
 
@@ -318,6 +321,54 @@ function IdentitiesView({
 	);
 }
 
+function ReceivedView({ received }: { received: ReceivedProjectShare[] }) {
+	if (received.length === 0) {
+		return (
+			<p className="small recipient-policy-sharing-empty" role="status">
+				No received Projects on this device. Accepted invitations appear here once their first sync
+				completes.
+			</p>
+		);
+	}
+	return (
+		<div className="recipient-policy-sharing-grid recipient-policy-sharing-responsive-grid">
+			{received.map((share, index) => {
+				const titleId = `recipient-policy-sharing-received-title-${index}`;
+				return (
+					<article
+						aria-labelledby={titleId}
+						className="peer-card peer-card--padded recipient-policy-sharing-card recipient-policy-sharing-received-card"
+						key={share.canonicalProjectIdentity}
+					>
+						<div className="peer-title recipient-policy-sharing-card-title">
+							<h3 id={titleId}>{share.displayName}</h3>
+							<span className="badge actor-badge">Received</span>
+						</div>
+						<dl className="recipient-policy-sharing-details">
+							<div>
+								<dt>Memories on this device</dt>
+								<dd>{countLabel(share.existingMemoryCount, "memory", "memories")}</dd>
+							</div>
+							<div>
+								<dt>Latest activity</dt>
+								<dd>
+									{share.latestSessionAt
+										? new Date(share.latestSessionAt).toLocaleString()
+										: "No recent sessions"}
+								</dd>
+							</div>
+						</dl>
+						<p className="small">
+							This Project is received from another device. Access is managed where the Project is
+							shared from; this device keeps it read-only.
+						</p>
+					</article>
+				);
+			})}
+		</div>
+	);
+}
+
 function RecipientPolicySharing({
 	intent,
 	options,
@@ -403,6 +454,8 @@ function RecipientPolicySharing({
 						<TeamsView intent={intent} projects={projects} />
 					) : tab.id === "identities" ? (
 						<IdentitiesView intent={intent} projects={projects} />
+					) : tab.id === "received" ? (
+						<ReceivedView received={options.received ?? []} />
 					) : (
 						<RecipientPolicyInvitations intent={intent} />
 					)}


### PR DESCRIPTION
## Description
Dogfood finding (codemem-nn9l): the Sharing surface only rendered the local outbound policy graph, so a recipient who accepted a share saw all zeros and reasonably concluded acceptance did nothing. Adds a Received tab listing Projects this device receives from other people, sourced from the local inventory's `peer_received` markers: memory counts, latest activity, and read-only guidance.

## Type of Change
- [x] 🚀 Feature (new functionality)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
