### PR TITLE
fix(sharing): set truthful delivery expectations in add-device flows

### DIFF
--- a/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
@@ -225,6 +225,9 @@ describe("recipient-policy invitations", () => {
 		expect(dialog.textContent).toContain("through Example Team");
 		expect(dialog.textContent).toContain("Private — 9 existing memories");
 		expect(dialog.textContent).toContain("This device will not receive the Projects listed here");
+		expect(dialog.textContent).toContain(
+			"Project data does not sync to the invited device until the Project owner’s device completes access setup",
+		);
 
 		act(() => button("Accept invitation", dialog).click());
 		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
@@ -234,6 +237,16 @@ describe("recipient-policy invitations", () => {
 			reviewed_onboarding_digest: addDevicePreview.reviewedOnboardingDigest,
 		});
 		await vi.waitFor(() => expect(dialog.textContent).toContain("Device added"));
+		expect(dialog.textContent).toContain(
+			"Existing shared Projects do not sync to this device until",
+		);
+		// The delivery expectation must join the focused result's announcement.
+		expect(
+			dialog
+				.querySelector("#recipient-invitation-result")
+				?.getAttribute("aria-describedby")
+				?.split(" "),
+		).toContain("recipient-invitation-result-delivery");
 		const result = dialog.querySelector("#recipient-invitation-result");
 		expect(result).not.toBeNull();
 		expect(document.activeElement).toBe(result);
@@ -241,6 +254,35 @@ describe("recipient-policy invitations", () => {
 		expect(() => button("Accept invitation", dialog)).toThrow("button missing");
 		await act(async () => Promise.resolve());
 		expect(dialog.querySelector("#recipient-invitation-result")).toBe(result);
+	});
+
+	it("omits the delivery expectation when an add-device invitation shares no Projects", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
+			kind: "add_device",
+			recipient_name: "Local Identity",
+			device_name: "Travel Laptop",
+			onboarding: { ...addDevicePreview, projects: [] },
+		});
+		vi.mocked(api.importCoordinatorInvite).mockResolvedValue({ status: "accepted" });
+		mount();
+
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		if (!textarea) throw new Error("textarea missing");
+		act(() => {
+			textarea.value = "recipient-invite";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!dialog) throw new Error("dialog missing");
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(api.inspectCoordinatorInvite).toHaveBeenCalledOnce());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("No Projects are shared directly"));
+		expect(dialog.textContent).not.toContain("describe access, not delivery");
+
+		act(() => button("Accept invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Device added"));
+		expect(dialog.textContent).not.toContain("Existing shared Projects do not sync");
 	});
 
 	it("persists a Team completion, prevents repeat acceptance, and resets after close and reopen", async () => {

--- a/packages/ui/src/tabs/recipient-policy-invitations.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.tsx
@@ -26,6 +26,7 @@ type RecipientAcceptance = {
 	kind: CreateKind;
 	restartRequired: boolean;
 	detail: string;
+	deliveryPending: boolean;
 };
 
 const MACHINE_NAME_PREFIX = /^(?:local:|identity:|pending_)/iu;
@@ -181,6 +182,13 @@ function AddDeviceConfirmation({ preview }: { preview: RecipientOnboardingPrevie
 				)}
 				<p className="small">This device will not receive the Projects listed here.</p>
 			</section>
+			{preview.projects.length > 0 ? (
+				<p className="small" role="note">
+					The lists above describe access, not delivery: Project data does not sync to the invited
+					device until the Project owner’s device completes access setup for it. Until then, shared
+					memories remain on the Identity’s existing devices.
+				</p>
+			) : null}
 		</div>
 	);
 }
@@ -314,9 +322,16 @@ function ProjectShareResult({ result }: { result: ProjectShareAcceptance }) {
 
 function RecipientAcceptanceResult({ result }: { result: RecipientAcceptance }) {
 	const title = result.kind === "team_member" ? "Team invitation accepted" : "Device added";
+	const describedBy =
+		[
+			result.restartRequired ? "recipient-invitation-result-detail" : null,
+			result.deliveryPending ? "recipient-invitation-result-delivery" : null,
+		]
+			.filter(Boolean)
+			.join(" ") || undefined;
 	return (
 		<section
-			aria-describedby={result.restartRequired ? "recipient-invitation-result-detail" : undefined}
+			aria-describedby={describedBy}
 			aria-labelledby="recipient-invitation-result-title"
 			className="recipient-policy-invitation-result"
 			id="recipient-invitation-result"
@@ -329,6 +344,12 @@ function RecipientAcceptanceResult({ result }: { result: RecipientAcceptance }) 
 				<h3 id="recipient-invitation-result-title">{title}</h3>
 				{result.restartRequired ? (
 					<p id="recipient-invitation-result-detail">{result.detail}</p>
+				) : null}
+				{result.deliveryPending ? (
+					<p className="small" id="recipient-invitation-result-delivery">
+						Existing shared Projects do not sync to this device until the Project owner’s device
+						completes access setup for it.
+					</p>
 				) : null}
 			</div>
 		</section>
@@ -473,11 +494,15 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 				setProjectDeviceName(humanProvidedNameOrEmpty(result.device_name));
 			}
 			setStatus(
-				result.kind === "team_member" || result.kind === "add_device"
-					? "Review ready. Confirm before accepting."
-					: result.kind === "project_share_invite"
-						? "Review ready. Confirm the exact Projects before accepting."
-						: "Open Advanced Team administration to continue with this invitation.",
+				result.kind === "add_device"
+					? (result.onboarding?.projects?.length ?? 0) > 0
+						? "Review ready. Existing shared Projects sync to the invited device only after the owner’s device completes access setup. Confirm before accepting."
+						: "Review ready. Confirm before accepting."
+					: result.kind === "team_member"
+						? "Review ready. Confirm before accepting."
+						: result.kind === "project_share_invite"
+							? "Review ready. Confirm the exact Projects before accepting."
+							: "Open Advanced Team administration to continue with this invitation.",
 			);
 		} catch (cause) {
 			if (!isCurrentInspection()) return;
@@ -526,6 +551,8 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 					kind: acceptedKind,
 					restartRequired,
 					detail: detail || "Restart codemem before continuing.",
+					deliveryPending:
+						acceptedKind === "add_device" && (inspected.onboarding?.projects?.length ?? 0) > 0,
 				});
 				setStatus("");
 			}


### PR DESCRIPTION
## Description
Dogfood finding (codemem-hksk, partial): the add-device review and completion implied listed Projects would arrive on the new device, but no reconciler provisions new devices into existing shares yet — the dogfood second device ended with zero memories while its Identity's first device held the shared Project. The review and completion now state plainly that access is not delivery and existing shares do not sync to the new device until the owner's device completes access setup. Owner-side device provisioning/reconciliation remains tracked in codemem-hksk.

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
