### PR TITLE
chore(release): prepare 0.40.0-alpha.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.39.0"
+    "version": "0.40.0-alpha.1"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.39.0",
+      "version": "0.40.0-alpha.1",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.39.0";
+const PINNED_BACKEND_VERSION = "0.40.0-alpha.1";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.39.0",
+	"version": "0.40.0-alpha.1",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.39.0",
+	"version": "0.40.0-alpha.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.39.0");
+		expect(VERSION).toBe("0.40.0-alpha.1");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.39.0";
+export const VERSION = "0.40.0-alpha.1";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.39.0",
+	"version": "0.40.0-alpha.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.39.0";
+const PINNED_BACKEND_VERSION = "0.40.0-alpha.1";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 const CODEMEM_CONTEXT_PART_ID_PREFIX = "codemem-context-";

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.39.0",
+	"version": "0.40.0-alpha.1",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.39.0",
+	"version": "0.40.0-alpha.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.39.0",
+  "version": "0.40.0-alpha.1",
   "author": {
     "name": "Adam Kunicki"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codemem",
-  "version": "0.39.0",
+  "version": "0.40.0-alpha.1",
   "description": "Persistent memory for Codex. Capture work across sessions and recall relevant context.",
   "author": {
     "name": "Adam Kunicki"


### PR DESCRIPTION
## Description
Version bump only: prepare `0.40.0-alpha.1`.

First alpha of the sharing overhaul, for multi-machine fleet dogfooding before stable. Highlights since v0.39.0 (42 commits):

- **Sharing security/identity**: coordinator device→Identity enrollment binding with coordinator-minted `assigned_identity_id` (#1357), signed identity-owned add-device invitations — non-admin devices self-serve add-device without the coordinator admin secret (#1360)
- **Isolation fix**: exact-Project acceptance no longer leaks unrelated local-default data through the restart-before-provisioning window (codemem-l72f, verified at the DB level in a clean three-peer dogfood)
- **Invitation UX**: persistent acceptance completion state (#1359), truthful copy for empty-team availability (#1361), placeholder name fields instead of raw ids (#1362), truthful add-device delivery expectations (#1367)
- **Recipient surface**: new Received tab listing inbound Projects, covering bootstrap + incremental replication with scope-keyed identity (#1366)
- **Lifecycle/ops**: superseded duplicate share operations are cancelled with full race-guarding (#1364), manual `/api/sync/run` signs with the configured keys directory + diagnosable peer-auth logging (#1365), dogfood harness counting fix (#1363)

## Type of Change
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, version-alignment test)
- [ ] Added/updated tests for changes (version bump only)
- [x] Manually verified changes work as expected (`release-version.mjs check` aligned at 0.40.0-alpha.1)

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
