### PR TITLE
feat(sharing): read consumed Team invitations for reconciliation

### DIFF
--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -13,6 +13,7 @@ import {
 	coordinatorEnrollDeviceAction,
 	coordinatorGrantScopeMembershipAction,
 	coordinatorImportInviteAction,
+	coordinatorListConsumedTeamInvitesAction,
 	coordinatorListDevicesAction,
 	coordinatorListGroupsAction,
 	coordinatorListScopeMembershipsAction,
@@ -151,6 +152,209 @@ describe("coordinator local admin actions", () => {
 		expect(await coordinatorListDevicesAction({ groupId: "team-a", dbPath })).toEqual([
 			expect.objectContaining({ device_id: "device-1", display_name: "Laptop" }),
 		]);
+	});
+
+	it.each([
+		{},
+		{ items: null },
+		{ items: "not-a-list" },
+		{ items: [null] },
+	])("rejects malformed remote device lists: %j", async (payload) => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify(payload), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+			),
+		);
+
+		await expect(
+			coordinatorListDevicesAction({
+				groupId: "team-a",
+				remoteUrl: "https://coord.example.test",
+				adminSecret: "secret",
+			}),
+		).rejects.toThrow("coordinator_device_list_malformed");
+	});
+
+	it("lists only consumed Team invites without tokens", async () => {
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		const reviewedIntent = teamReviewedIntent();
+		const reviewedPreviewDigest = await recipientReviewedIntentDigest(reviewedIntent);
+		const created = await coordinatorCreateInviteAction({
+			groupId: "team-a",
+			coordinatorUrl: "https://coord.example.test",
+			policy: "auto_admit",
+			ttlHours: 24,
+			dbPath,
+			inviteKind: "team_member",
+			policyTeamId: "policy-team-1",
+			reviewedPreviewDigest,
+			reviewedIntent,
+		});
+		await coordinatorCreateInviteAction({
+			groupId: "team-a",
+			coordinatorUrl: "https://coord.example.test",
+			policy: "auto_admit",
+			ttlHours: 24,
+			dbPath,
+		});
+		const payload = created.payload as Record<string, unknown>;
+		const identityId = String(payload.assigned_identity_id);
+		const publicKey = "public-key-team-1";
+		const store = new BetterSqliteCoordinatorStore(dbPath);
+		try {
+			await store.consumeRecipientInvite({
+				token: String(payload.token),
+				inviteKind: "team_member",
+				identityId,
+				deviceId: "device-team-1",
+				publicKey,
+				fingerprint: fingerprintPublicKey(publicKey),
+				now: "2026-07-26T00:00:00.000Z",
+			});
+		} finally {
+			await store.close();
+		}
+
+		expect(await coordinatorListConsumedTeamInvitesAction({ groupId: "team-a", dbPath })).toEqual([
+			{
+				invite_id: created.invite_id,
+				group_id: "team-a",
+				policy_team_id: "policy-team-1",
+				assigned_identity_id: identityId,
+				recipient_actor_id: identityId,
+				bound_device_id: "device-team-1",
+				consumed_at: "2026-07-26T00:00:00.000Z",
+			},
+		]);
+	});
+
+	it("validates remote consumed Team invite identity bindings", async () => {
+		const valid = {
+			invite_id: "invite-team-1",
+			group_id: "team-a",
+			invite_kind: "team_member",
+			policy_team_id: "policy-team-1",
+			assigned_identity_id: "identity:abcdefghijklmnopqr",
+			recipient_actor_id: "identity:abcdefghijklmnopqr",
+			bound_device_id: "device-team-1",
+			consumed_at: "2026-07-26T00:00:00.000Z",
+		};
+		const expected = {
+			invite_id: valid.invite_id,
+			group_id: valid.group_id,
+			policy_team_id: valid.policy_team_id,
+			assigned_identity_id: valid.assigned_identity_id,
+			recipient_actor_id: valid.recipient_actor_id,
+			bound_device_id: valid.bound_device_id,
+			consumed_at: valid.consumed_at,
+		};
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						items: [
+							valid,
+							{ ...valid, invite_id: "pending-team", consumed_at: null },
+							{ ...valid, invite_id: "legacy", invite_kind: "legacy_enrollment" },
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			coordinatorListConsumedTeamInvitesAction({
+				groupId: "team-a",
+				remoteUrl: "https://coord.example.test/",
+				adminSecret: "secret",
+			}),
+		).resolves.toEqual([expected]);
+		expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+			"https://coord.example.test/v1/admin/invites?group_id=team-a",
+		);
+		expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+			"X-Codemem-Coordinator-Admin": "secret",
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							items: [{ ...valid, consumed_at: "2026-07-26T00:00:00Z" }],
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					),
+			),
+		);
+		await expect(
+			coordinatorListConsumedTeamInvitesAction({
+				groupId: "team-a",
+				remoteUrl: "https://coord.example.test",
+				adminSecret: "secret",
+			}),
+		).resolves.toEqual([{ ...expected, consumed_at: "2026-07-26T00:00:00Z" }]);
+
+		for (const invalid of [
+			{ ...valid, recipient_actor_id: "identity:stuvwxyzABCDEFGH12" },
+			{ ...valid, assigned_identity_id: ` ${valid.assigned_identity_id}` },
+			{ ...valid, recipient_actor_id: `${valid.recipient_actor_id} ` },
+			{ ...valid, invite_id: ` ${valid.invite_id}` },
+			{ ...valid, policy_team_id: `${valid.policy_team_id} ` },
+			{ ...valid, policy_team_id: "p".repeat(257) },
+			{ ...valid, bound_device_id: ` ${valid.bound_device_id}` },
+			{ ...valid, bound_device_id: "d".repeat(257) },
+			{ ...valid, consumed_at: "2026-07-26T00:00:00.00Z" },
+			{
+				...valid,
+				assigned_identity_id: "identity-team-1",
+				recipient_actor_id: "identity-team-1",
+			},
+		]) {
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(
+					async () =>
+						new Response(JSON.stringify({ items: [invalid] }), {
+							status: 200,
+							headers: { "content-type": "application/json" },
+						}),
+				),
+			);
+			await expect(
+				coordinatorListConsumedTeamInvitesAction({
+					groupId: "team-a",
+					remoteUrl: "https://coord.example.test",
+					adminSecret: "secret",
+				}),
+			).rejects.toThrow("coordinator_consumed_team_invite_invalid");
+		}
+
+		for (const malformed of [{}, { items: null }, { items: "not-a-list" }, { items: [null] }]) {
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(
+					async () =>
+						new Response(JSON.stringify(malformed), {
+							status: 200,
+							headers: { "content-type": "application/json" },
+						}),
+				),
+			);
+			await expect(
+				coordinatorListConsumedTeamInvitesAction({
+					groupId: "team-a",
+					remoteUrl: "https://coord.example.test",
+					adminSecret: "secret",
+				}),
+			).rejects.toThrow("coordinator_invite_list_malformed");
+		}
 	});
 
 	it("renames, disables, and removes devices", async () => {

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -19,6 +19,7 @@ import type {
 	CoordinatorEnrollment,
 	CoordinatorGrantScopeMembershipInput,
 	CoordinatorGroup,
+	CoordinatorInvite,
 	CoordinatorJoinRequest,
 	CoordinatorJoinRequestReviewResult,
 	CoordinatorRecipientInviteKind,
@@ -26,7 +27,10 @@ import type {
 	CoordinatorScope,
 	CoordinatorScopeMembership,
 } from "./coordinator-store-contract.js";
-import { recipientInviteAuthoritativeIdentityId } from "./coordinator-store-contract.js";
+import {
+	isCoordinatorAssignedIdentityId,
+	recipientInviteAuthoritativeIdentityId,
+} from "./coordinator-store-contract.js";
 import { connect, resolveDbPath } from "./db.js";
 import { initDatabase } from "./maintenance.js";
 import {
@@ -810,11 +814,13 @@ export async function coordinatorListDevicesAction(opts: {
 			`${stripTrailingSlashes(remote)}/v1/admin/devices?group_id=${encodeURIComponent(groupId)}&include_disabled=${opts.includeDisabled ? "1" : "0"}`,
 			adminSecret,
 		);
-		return Array.isArray(payload?.items)
-			? payload.items.filter(
-					(row): row is CoordinatorEnrollment => Boolean(row) && typeof row === "object",
-				)
-			: [];
+		if (
+			!Array.isArray(payload?.items) ||
+			payload.items.some((row) => !row || typeof row !== "object" || Array.isArray(row))
+		) {
+			throw new Error("coordinator_device_list_malformed");
+		}
+		return payload.items as CoordinatorEnrollment[];
 	}
 	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
@@ -822,6 +828,115 @@ export async function coordinatorListDevicesAction(opts: {
 	} finally {
 		await store.close();
 	}
+}
+
+export interface CoordinatorConsumedTeamInvite {
+	invite_id: string;
+	group_id: string;
+	policy_team_id: string;
+	assigned_identity_id: string;
+	recipient_actor_id: string;
+	bound_device_id: string;
+	consumed_at: string;
+}
+
+function requiredConsumedTeamInviteText(value: unknown, maxLength = 2048): string {
+	if (
+		typeof value !== "string" ||
+		!value ||
+		value !== value.trim() ||
+		value.length > maxLength ||
+		/[\p{Cc}\p{Cf}]/u.test(value)
+	) {
+		throw new Error("coordinator_consumed_team_invite_invalid");
+	}
+	return value;
+}
+
+function isCanonicalConsumedTeamInviteTimestamp(value: string): boolean {
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) return false;
+	const canonical = parsed.toISOString();
+	return value === canonical || value === canonical.replace(/\.000Z$/u, "Z");
+}
+
+function consumedTeamInvites(
+	invites: Array<Partial<CoordinatorInvite>>,
+): CoordinatorConsumedTeamInvite[] {
+	return invites
+		.filter((invite) => invite.invite_kind === "team_member" && invite.consumed_at != null)
+		.map((invite) => {
+			const assignedIdentityId = invite.assigned_identity_id;
+			const recipientActorId = invite.recipient_actor_id;
+			if (
+				!isCoordinatorAssignedIdentityId(assignedIdentityId) ||
+				!isCoordinatorAssignedIdentityId(recipientActorId) ||
+				assignedIdentityId !== recipientActorId
+			) {
+				throw new Error("coordinator_consumed_team_invite_invalid");
+			}
+			const consumedAt = requiredConsumedTeamInviteText(invite.consumed_at);
+			if (!isCanonicalConsumedTeamInviteTimestamp(consumedAt)) {
+				throw new Error("coordinator_consumed_team_invite_invalid");
+			}
+			const row = {
+				invite_id: requiredConsumedTeamInviteText(invite.invite_id),
+				group_id: requiredConsumedTeamInviteText(invite.group_id),
+				policy_team_id: requiredConsumedTeamInviteText(invite.policy_team_id, 256),
+				assigned_identity_id: assignedIdentityId,
+				recipient_actor_id: recipientActorId,
+				bound_device_id: requiredConsumedTeamInviteText(invite.bound_device_id, 256),
+				consumed_at: consumedAt,
+			};
+			if (Object.values(row).some((value) => !value)) {
+				throw new Error("coordinator_consumed_team_invite_invalid");
+			}
+			return row;
+		})
+		.toSorted(
+			(left, right) =>
+				left.consumed_at.localeCompare(right.consumed_at) ||
+				left.invite_id.localeCompare(right.invite_id),
+		);
+}
+
+export async function coordinatorListConsumedTeamInvitesAction(opts: {
+	groupId: string;
+	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+}): Promise<CoordinatorConsumedTeamInvite[]> {
+	const groupId = String(opts.groupId ?? "").trim();
+	if (!groupId) throw new Error("Group id required.");
+	const remote = opts.remoteUrl ?? null;
+	const adminSecret = opts.adminSecret ?? null;
+	let invites: Array<Partial<CoordinatorInvite>>;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		const payload = await remoteRequest(
+			"GET",
+			`${stripTrailingSlashes(remote)}/v1/admin/invites?group_id=${encodeURIComponent(groupId)}`,
+			adminSecret,
+		);
+		if (
+			!Array.isArray(payload?.items) ||
+			payload.items.some((row) => !row || typeof row !== "object" || Array.isArray(row))
+		) {
+			throw new Error("coordinator_invite_list_malformed");
+		}
+		invites = payload.items as Array<Partial<CoordinatorInvite>>;
+	} else {
+		const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+		try {
+			invites = await store.listInvites(groupId);
+		} finally {
+			await store.close();
+		}
+	}
+	if (invites.some((invite) => invite.group_id !== groupId)) {
+		throw new Error("coordinator_invite_group_mismatch");
+	}
+	return consumedTeamInvites(invites);
 }
 
 export async function coordinatorRenameDeviceAction(opts: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export {
 	MAPPABLE_CODEX_HOOK_EVENTS,
 	mapCodexHookPayload,
 } from "./codex-hooks.js";
+export type { CoordinatorConsumedTeamInvite } from "./coordinator-actions.js";
 export {
 	coordinatorArchiveGroupAction,
 	coordinatorCreateAddDeviceInviteAction,
@@ -39,6 +40,7 @@ export {
 	coordinatorGrantScopeMembershipAction,
 	coordinatorImportInviteAction,
 	coordinatorListBootstrapGrantsAction,
+	coordinatorListConsumedTeamInvitesAction,
 	coordinatorListDevicesAction,
 	coordinatorListGroupsAction,
 	coordinatorListJoinRequestsAction,


### PR DESCRIPTION
## Description
Adds a typed, token-free coordinator read for consumed Team invitations so owner-side reconciliation can ingest authoritative enrollment facts through local or remote coordinators.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced