### PR TITLE
feat(sharing): reconcile coordinator enrollment into owner policy

### DIFF
--- a/e2e/scenarios/project-sharing.ts
+++ b/e2e/scenarios/project-sharing.ts
@@ -84,7 +84,7 @@ interface ReconciliationProof {
 		deny_overlays: unknown[];
 	};
 	rollback: {
-		result: { status: string };
+		result: { status: string; revokedDeviceIds: string[] };
 		authority: { authorityState: string } | null;
 		mutation_calls: string[];
 	};
@@ -765,14 +765,20 @@ export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<v
 		"reconciliation-proof",
 		"52-recipient-reconciliation-proof",
 	).action_result as unknown as ReconciliationProof;
-	// Assert: unsupported peers fail before mutation; offline work waits/resumes; revocation and rollback stay visible.
+	// Assert: unsupported grant candidates fail before mutation; offline work waits/resumes; revocation and rollback stay visible.
 	assert(
 		reconciliation.unsupported.result.status === "needs_attention" &&
 			reconciliation.unsupported.result.safeErrorCode === "recipient_policy_capability_unsupported",
-		"unsupported old peer did not fail closed",
+		"unsupported grant candidate did not fail closed",
 	);
-	assert(reconciliation.unsupported.membership_unchanged, "unsupported old peer mutated membership");
-	assert(reconciliation.unsupported.mutation_calls.length === 0, "unsupported old peer ran mutations");
+	assert(
+		reconciliation.unsupported.membership_unchanged,
+		"unsupported grant candidate mutated membership",
+	);
+	assert(
+		reconciliation.unsupported.mutation_calls.length === 0,
+		"unsupported grant candidate ran mutations",
+	);
 	assert(
 		reconciliation.offline_resume.waiting.status === "waiting" &&
 			reconciliation.offline_resume.waiting.safeErrorCode ===
@@ -793,9 +799,11 @@ export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<v
 	);
 	assert(
 		reconciliation.rollback.result.status === "needs_attention" &&
+			reconciliation.rollback.result.revokedDeviceIds.includes("device-rollback-old") &&
 			reconciliation.rollback.authority?.authorityState === "rolled_back" &&
-			reconciliation.rollback.mutation_calls.length === 0,
-		"unsupported active Project did not roll back without grants",
+			reconciliation.rollback.mutation_calls.length === 1 &&
+			reconciliation.rollback.mutation_calls[0] === "revoke:device-rollback-old",
+		"unsupported active Project did not revoke stale access and roll back without grants",
 	);
 	const reconciliationStatus = await request<{
 		items: Array<{ canonicalProjectIdentity: string; state: string; explanation: string }>;

--- a/e2e/scripts/project-sharing-fixture.ts
+++ b/e2e/scripts/project-sharing-fixture.ts
@@ -305,6 +305,7 @@ function reconciliationEffects(
 ): RecipientPolicyReconcilerEffects {
 	let tick = 0;
 	const now = () => new Date(Date.parse(NOW) + tick++ * 1_000).toISOString();
+	const label = scopeId.startsWith("scope-") ? scopeId.slice("scope-".length) : scopeId;
 	return {
 		now,
 		snapshot: async () => ({
@@ -316,6 +317,10 @@ function reconciliationEffects(
 				.toSorted()
 				.map((deviceId) => ({ deviceId, status: "active" as const })),
 		}),
+		listBoundaryEnrollments: async () => [
+			{ deviceId: `device-${label}-keep`, identityId: `identity-${label}` },
+			{ deviceId: `device-${label}-new`, identityId: `identity-${label}` },
+		],
 		probeCapability: async (deviceId) => {
 			calls.push(`probe:${deviceId}`);
 			return capability(deviceId);
@@ -338,10 +343,7 @@ function reconciliationEffects(
 
 async function reconciliationProof(store: MemoryStore): Promise<Record<string, unknown>> {
 	const unsupported = seedReconciliationProject(store, "unsupported-old-peer");
-	const unsupportedMembers = new Set([
-		"device-unsupported-old-peer-keep",
-		"device-unsupported-old-peer-old",
-	]);
+	const unsupportedMembers = new Set(["device-unsupported-old-peer-keep"]);
 	const unsupportedCalls: string[] = [];
 	const membershipsBefore = JSON.stringify([...unsupportedMembers].toSorted());
 	const unsupportedResult = await reconcileRecipientPolicyProject(
@@ -350,7 +352,7 @@ async function reconciliationProof(store: MemoryStore): Promise<Record<string, u
 		reconciliationEffects(
 			unsupported.scopeId,
 			unsupportedMembers,
-			(deviceId) => (deviceId.endsWith("-old") ? "unsupported" : "supported"),
+			(deviceId) => (deviceId.endsWith("-new") ? "unsupported" : "supported"),
 			unsupportedCalls,
 		),
 	);

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -187,37 +187,64 @@ describe("serve command option resolution", () => {
 		]);
 	});
 
-	it("runs recipient-policy maintenance only after existing share maintenance", async () => {
+	it("surfaces recipient-policy failures after running every maintenance stage", async () => {
 		const calls: string[] = [];
 		const store = {} as MemoryStore;
-		const result = await runServeCoordinatorMaintenance(store, {
-			advancePendingProjectShares: vi.fn(async (_store, options) => {
-				calls.push(`shares:${options.limit}`);
-				return { processed: 1, failed: 0 };
+		await expect(
+			runServeCoordinatorMaintenance(store, {
+				advancePendingProjectShares: vi.fn(async (_store, options) => {
+					calls.push(`shares:${options.limit}`);
+					return { processed: 1, failed: 0 };
+				}),
+				reconcileConfiguredCoordinatorEnrollment: vi.fn(async () => {
+					calls.push("enrollment");
+					return { groupsProcessed: 1, failedGroups: 0 };
+				}),
+				reconcileRecipientPolicyProjects: vi.fn(async (_store, options) => {
+					calls.push(`policies:${options.limit}`);
+					return { processed: 2, failed: 1 };
+				}),
 			}),
-			reconcileRecipientPolicyProjects: vi.fn(async (_store, options) => {
-				calls.push(`policies:${options.limit}`);
-				return { processed: 2, failed: 1 };
-			}),
-		});
+		).rejects.toThrow("recipient policy maintenance failed for 1 of 2 projects");
 
-		expect(calls).toEqual(["shares:3", "policies:3"]);
-		expect(result).toEqual({
-			projectShares: { processed: 1, failed: 0 },
-			recipientPolicies: { processed: 2, failed: 1 },
-		});
+		expect(calls).toEqual(["shares:3", "enrollment", "policies:3"]);
 	});
 
-	it("does not start policy reconciliation when old share maintenance fails", async () => {
+	it("runs enrollment and policy reconciliation before surfacing share maintenance failures", async () => {
+		const reconcileConfiguredCoordinatorEnrollment = vi.fn(async () => ({
+			groupsProcessed: 0,
+			failedGroups: 0,
+		}));
 		const reconcileRecipientPolicyProjects = vi.fn(async () => ({ processed: 0, failed: 0 }));
 
 		await expect(
 			runServeCoordinatorMaintenance({} as MemoryStore, {
 				advancePendingProjectShares: vi.fn(async () => ({ processed: 2, failed: 1 })),
+				reconcileConfiguredCoordinatorEnrollment,
 				reconcileRecipientPolicyProjects,
 			}),
 		).rejects.toThrow("share operation maintenance failed for 1 of 2 operations");
-		expect(reconcileRecipientPolicyProjects).not.toHaveBeenCalled();
+		expect(reconcileConfiguredCoordinatorEnrollment).toHaveBeenCalledOnce();
+		expect(reconcileRecipientPolicyProjects).toHaveBeenCalledOnce();
+	});
+
+	it("runs policy reconciliation before surfacing incomplete enrollment reconciliation", async () => {
+		const reconcileRecipientPolicyProjects = vi.fn(async () => ({ processed: 0, failed: 0 }));
+
+		await expect(
+			runServeCoordinatorMaintenance({} as MemoryStore, {
+				advancePendingProjectShares: vi.fn(async () => ({ processed: 0, failed: 0 })),
+				reconcileConfiguredCoordinatorEnrollment: vi.fn(async () => ({
+					groupsProcessed: 1,
+					failedGroups: 1,
+					issues: 2,
+				})),
+				reconcileRecipientPolicyProjects,
+			}),
+		).rejects.toThrow(
+			"coordinator enrollment maintenance failed for 1 group with 2 reconciliation issues",
+		);
+		expect(reconcileRecipientPolicyProjects).toHaveBeenCalledOnce();
 	});
 
 	it("detects sqlite-vec load errors for viewer startup fallback", () => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -517,6 +517,7 @@ export function sqliteVecFailureDiagnostics(error: unknown, dbPath: string): str
 
 export interface ServeCoordinatorMaintenanceResult {
 	projectShares: { processed: number; failed: number };
+	coordinatorEnrollment: { groupsProcessed: number; failedGroups: number; issues?: number };
 	recipientPolicies: { processed: number; failed: number };
 }
 
@@ -531,18 +532,35 @@ export async function runServeCoordinatorMaintenance(
 			store: MemoryStore,
 			options: { limit: number },
 		) => Promise<{ processed: number; failed: number }>;
+		reconcileConfiguredCoordinatorEnrollment: (
+			store: MemoryStore,
+		) => Promise<{ groupsProcessed: number; failedGroups: number; issues?: number }>;
 	},
 ): Promise<ServeCoordinatorMaintenanceResult> {
 	const projectShares = await dependencies.advancePendingProjectShares(store, { limit: 3 });
+	const coordinatorEnrollment = await dependencies.reconcileConfiguredCoordinatorEnrollment(store);
+	const enrollmentIssues = coordinatorEnrollment.issues ?? 0;
+	const recipientPolicies = await dependencies.reconcileRecipientPolicyProjects(store, {
+		limit: 3,
+	});
 	if (projectShares.failed > 0) {
 		throw new Error(
 			`share operation maintenance failed for ${projectShares.failed} of ${projectShares.processed} operations`,
 		);
 	}
-	const recipientPolicies = await dependencies.reconcileRecipientPolicyProjects(store, {
-		limit: 3,
-	});
-	return { projectShares, recipientPolicies };
+	if (coordinatorEnrollment.failedGroups > 0 || enrollmentIssues > 0) {
+		const groupLabel = coordinatorEnrollment.failedGroups === 1 ? "group" : "groups";
+		const issueLabel = enrollmentIssues === 1 ? "issue" : "issues";
+		throw new Error(
+			`coordinator enrollment maintenance failed for ${coordinatorEnrollment.failedGroups} ${groupLabel} with ${enrollmentIssues} reconciliation ${issueLabel}`,
+		);
+	}
+	if (recipientPolicies.failed > 0) {
+		throw new Error(
+			`recipient policy maintenance failed for ${recipientPolicies.failed} of ${recipientPolicies.processed} projects`,
+		);
+	}
+	return { projectShares, coordinatorEnrollment, recipientPolicies };
 }
 
 async function startBackgroundViewer(invocation: ResolvedServeInvocation): Promise<void> {
@@ -588,6 +606,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		createSyncApp,
 		closeStore,
 		getStore,
+		reconcileConfiguredCoordinatorEnrollment,
 		reconcileRecipientPolicyProjects,
 	} = await import("@codemem/server");
 	const { serve } = await import("@hono/node-server");
@@ -715,6 +734,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 						onAfterCoordinatorRefresh: async () => {
 							await runServeCoordinatorMaintenance(store, {
 								advancePendingProjectShares,
+								reconcileConfiguredCoordinatorEnrollment,
 								reconcileRecipientPolicyProjects,
 							});
 						},

--- a/packages/core/src/coordinator-enrollment-reconciler.test.ts
+++ b/packages/core/src/coordinator-enrollment-reconciler.test.ts
@@ -1,0 +1,411 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { reconcileCoordinatorEnrollmentSnapshot } from "./coordinator-enrollment-reconciler.js";
+import { connect } from "./db.js";
+import { deriveRecipientPolicyEffectiveDevicesFromDatabase } from "./recipient-policy-reconciliation.js";
+
+const NOW = "2026-07-26T00:00:00.000Z";
+
+describe("reconcileCoordinatorEnrollmentSnapshot", () => {
+	let dir: string;
+	let db: DatabaseType;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "coordinator-enrollment-reconciler-"));
+		db = connect(join(dir, "test.sqlite"));
+		db.prepare(`INSERT INTO policy_teams(
+			team_id, display_name, status, provenance, revision, migration_state,
+			source_fingerprint, idempotency_key, created_at, updated_at
+		) VALUES ('team-a', 'Team A', 'active', 'test', 'r1', 'user_managed', 's1', 'i1', ?, ?)`).run(
+			NOW,
+			NOW,
+		);
+		db.prepare(`INSERT INTO actors(
+			actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+		) VALUES ('identity-direct', 'Direct recipient', 0, 'active', NULL, ?, ?)`).run(NOW, NOW);
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("materializes accepted Team membership and new devices idempotently", () => {
+		const input = {
+			groupId: "group-a",
+			now: NOW,
+			consumedTeamInvites: [
+				{
+					invite_id: "invite-team",
+					group_id: "group-a",
+					policy_team_id: "team-a",
+					assigned_identity_id: "identity-team",
+					recipient_actor_id: "identity-team",
+					bound_device_id: "device-team",
+					consumed_at: NOW,
+				},
+			],
+			enrollments: [
+				{
+					group_id: "group-a",
+					device_id: "owner-device",
+					public_key: "pk-owner",
+					fingerprint: "fp-owner",
+					identity_id: null,
+					display_name: "Owner laptop",
+					enabled: 1,
+					created_at: NOW,
+				},
+				{
+					group_id: "group-a",
+					device_id: "device-team",
+					public_key: "pk-team",
+					fingerprint: "fp-team",
+					identity_id: "identity-team",
+					display_name: "Team laptop",
+					enabled: 1,
+					created_at: NOW,
+				},
+				{
+					group_id: "group-a",
+					device_id: "device-direct-2",
+					public_key: "pk-direct",
+					fingerprint: "fp-direct",
+					identity_id: "identity-direct",
+					display_name: "Second laptop",
+					enabled: 1,
+					created_at: NOW,
+				},
+			],
+		};
+
+		expect(reconcileCoordinatorEnrollmentSnapshot(db, input)).toEqual({
+			devicesAdded: 2,
+			membershipsAdded: 1,
+			identitiesAdded: 1,
+			unchanged: 0,
+			issues: [],
+		});
+		expect(reconcileCoordinatorEnrollmentSnapshot(db, input)).toEqual({
+			devicesAdded: 0,
+			membershipsAdded: 0,
+			identitiesAdded: 0,
+			unchanged: 3,
+			issues: [],
+		});
+		expect(db.prepare("SELECT identity_id FROM identity_devices ORDER BY device_id").all()).toEqual(
+			[{ identity_id: "identity-direct" }, { identity_id: "identity-team" }],
+		);
+		db.prepare(`INSERT INTO project_recipients(
+			canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			policy_revision, migration_state, source_fingerprint, idempotency_key, created_at, updated_at
+		) VALUES
+			('project-a', 'identity', 'identity-direct', 'active', 'test', 'r1', 'user_managed',
+			 'project-direct', 'project-direct', ?, ?),
+			('project-a', 'team', 'team-a', 'active', 'test', 'r1', 'user_managed',
+			 'project-team', 'project-team', ?, ?)`).run(NOW, NOW, NOW, NOW);
+		expect(
+			deriveRecipientPolicyEffectiveDevicesFromDatabase(db, "project-a").devices.map(
+				(device) => device.deviceId,
+			),
+		).toEqual(["device-direct-2", "device-team"]);
+	});
+
+	it("refreshes coordinator-managed device names without overwriting local names", () => {
+		db.prepare(`INSERT INTO identity_devices(
+			device_id, identity_id, display_name, status, provenance, revision, migration_state,
+			source_fingerprint, idempotency_key, created_at, updated_at
+		) VALUES ('device-local', 'identity-direct', 'My custom name', 'active', 'manual', 'r1',
+			'user_managed', 's1', 'local-device', ?, ?)`).run(NOW, NOW);
+		const input = {
+			groupId: "group-a",
+			now: NOW,
+			consumedTeamInvites: [],
+			enrollments: [
+				{
+					group_id: "group-a",
+					device_id: "device-coordinator",
+					public_key: "pk-coordinator",
+					fingerprint: "fp-coordinator",
+					identity_id: "identity-direct",
+					display_name: "Original name",
+					enabled: 1,
+					created_at: NOW,
+				},
+				{
+					group_id: "group-a",
+					device_id: "device-local",
+					public_key: "pk-local",
+					fingerprint: "fp-local",
+					identity_id: "identity-direct",
+					display_name: "Coordinator name",
+					enabled: 1,
+					created_at: NOW,
+				},
+			],
+		};
+
+		reconcileCoordinatorEnrollmentSnapshot(db, input);
+		input.enrollments[0].display_name = "Renamed device";
+		reconcileCoordinatorEnrollmentSnapshot(db, input);
+
+		expect(
+			db.prepare("SELECT device_id, display_name FROM identity_devices ORDER BY device_id").all(),
+		).toEqual([
+			{ device_id: "device-coordinator", display_name: "Renamed device" },
+			{ device_id: "device-local", display_name: "My custom name" },
+		]);
+	});
+
+	it("preserves an owner-revoked Team membership when the consumed invite is replayed", () => {
+		db.prepare(`INSERT INTO actors(
+			actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+		) VALUES ('identity-team', 'Former member', 0, 'active', NULL, ?, ?)`).run(NOW, NOW);
+		db.prepare(`INSERT INTO policy_team_memberships(
+			team_id, identity_id, role, status, provenance, revision, migration_state,
+			source_fingerprint, idempotency_key, created_at, updated_at
+		) VALUES ('team-a', 'identity-team', 'member', 'revoked', 'manual', 'r1',
+			'user_managed', 'revoked-source', 'revoked-membership', ?, ?)`).run(NOW, NOW);
+
+		const result = reconcileCoordinatorEnrollmentSnapshot(db, {
+			groupId: "group-a",
+			now: NOW,
+			enrollments: [],
+			consumedTeamInvites: [
+				{
+					invite_id: "invite-replayed",
+					group_id: "group-a",
+					policy_team_id: "team-a",
+					assigned_identity_id: "identity-team",
+					recipient_actor_id: "identity-team",
+					bound_device_id: "device-team",
+					consumed_at: NOW,
+				},
+			],
+		});
+
+		expect(result.issues).toEqual([
+			{
+				kind: "team_membership",
+				referenceId: "invite-replayed",
+				code: "membership_not_active",
+			},
+		]);
+		expect(
+			db
+				.prepare(
+					"SELECT status FROM policy_team_memberships WHERE team_id = 'team-a' AND identity_id = 'identity-team'",
+				)
+				.pluck()
+				.get(),
+		).toBe("revoked");
+	});
+
+	it("preserves an owner-revoked device when its enrollment is replayed", () => {
+		db.prepare(`INSERT INTO identity_devices(
+			device_id, identity_id, display_name, status, provenance, revision, migration_state,
+			source_fingerprint, idempotency_key, created_at, updated_at
+		) VALUES ('device-revoked', 'identity-direct', 'Revoked device', 'revoked', 'manual', 'r1',
+			'user_managed', 'revoked-source', 'revoked-device', ?, ?)`).run(NOW, NOW);
+
+		const result = reconcileCoordinatorEnrollmentSnapshot(db, {
+			groupId: "group-a",
+			now: NOW,
+			consumedTeamInvites: [],
+			enrollments: [
+				{
+					group_id: "group-a",
+					device_id: "device-revoked",
+					public_key: "pk-revoked",
+					fingerprint: "fp-revoked",
+					identity_id: "identity-direct",
+					display_name: "Coordinator name",
+					enabled: 1,
+					created_at: NOW,
+				},
+			],
+		});
+
+		expect(result.issues).toEqual([
+			{ kind: "device", referenceId: "device-revoked", code: "device_identity_conflict" },
+		]);
+		expect(
+			db
+				.prepare("SELECT status FROM identity_devices WHERE device_id = 'device-revoked'")
+				.pluck()
+				.get(),
+		).toBe("revoked");
+	});
+
+	it("rejects a consumed Team invite bound to a local actor", () => {
+		db.prepare(`INSERT INTO actors(
+			actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+		) VALUES ('identity-local-team', 'Local actor', 1, 'active', NULL, ?, ?)`).run(NOW, NOW);
+
+		const result = reconcileCoordinatorEnrollmentSnapshot(db, {
+			groupId: "group-a",
+			now: NOW,
+			enrollments: [],
+			consumedTeamInvites: [
+				{
+					invite_id: "invite-local-actor",
+					group_id: "group-a",
+					policy_team_id: "team-a",
+					assigned_identity_id: "identity-local-team",
+					recipient_actor_id: "identity-local-team",
+					bound_device_id: "device-local-team",
+					consumed_at: NOW,
+				},
+			],
+		});
+
+		expect(result).toEqual({
+			devicesAdded: 0,
+			membershipsAdded: 0,
+			identitiesAdded: 0,
+			unchanged: 0,
+			issues: [
+				{
+					kind: "team_membership",
+					referenceId: "invite-local-actor",
+					code: "identity_not_active",
+				},
+			],
+		});
+		expect(
+			db
+				.prepare(
+					"SELECT COUNT(*) FROM policy_team_memberships WHERE team_id = 'team-a' AND identity_id = 'identity-local-team'",
+				)
+				.pluck()
+				.get(),
+		).toBe(0);
+	});
+
+	it("rejects a coordinator device enrollment bound to a local actor", () => {
+		db.prepare(`INSERT INTO actors(
+			actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+		) VALUES ('identity-local-device', 'Local actor', 1, 'active', NULL, ?, ?)`).run(NOW, NOW);
+
+		const result = reconcileCoordinatorEnrollmentSnapshot(db, {
+			groupId: "group-a",
+			localDeviceId: "device-this-machine",
+			now: NOW,
+			consumedTeamInvites: [],
+			enrollments: [
+				{
+					group_id: "group-a",
+					device_id: "device-local-actor",
+					public_key: "pk-local-actor",
+					fingerprint: "fp-local-actor",
+					identity_id: "identity-local-device",
+					display_name: "Foreign device",
+					enabled: 1,
+					created_at: NOW,
+				},
+			],
+		});
+
+		expect(result).toEqual({
+			devicesAdded: 0,
+			membershipsAdded: 0,
+			identitiesAdded: 0,
+			unchanged: 0,
+			issues: [
+				{
+					kind: "device",
+					referenceId: "device-local-actor",
+					code: "identity_not_active",
+				},
+			],
+		});
+		expect(
+			db
+				.prepare("SELECT COUNT(*) FROM identity_devices WHERE device_id = 'device-local-actor'")
+				.pluck()
+				.get(),
+		).toBe(0);
+	});
+
+	it("accepts local and sibling device enrollments after proving the local Identity binding", () => {
+		db.prepare(`INSERT INTO actors(
+			actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+		) VALUES ('identity-local-device', 'Local actor', 1, 'active', NULL, ?, ?)`).run(NOW, NOW);
+
+		const result = reconcileCoordinatorEnrollmentSnapshot(db, {
+			groupId: "group-a",
+			localDeviceId: "device-local-actor",
+			now: NOW,
+			consumedTeamInvites: [],
+			enrollments: [
+				{
+					group_id: "group-a",
+					device_id: "device-local-actor",
+					public_key: "pk-local-actor",
+					fingerprint: "fp-local-actor",
+					identity_id: "identity-local-device",
+					display_name: "This device",
+					enabled: 1,
+					created_at: NOW,
+				},
+				{
+					group_id: "group-a",
+					device_id: "device-sibling",
+					public_key: "pk-sibling",
+					fingerprint: "fp-sibling",
+					identity_id: "identity-local-device",
+					display_name: "Sibling device",
+					enabled: 1,
+					created_at: NOW,
+				},
+			],
+		});
+
+		expect(result).toMatchObject({ devicesAdded: 2, issues: [] });
+		expect(
+			db.prepare("SELECT device_id FROM identity_devices ORDER BY device_id").pluck().all(),
+		).toEqual(["device-local-actor", "device-sibling"]);
+	});
+
+	it("fails closed on conflicting or inactive owner policy state", () => {
+		db.prepare(`INSERT INTO actors(
+			actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+		) VALUES ('identity-other', 'Other', 0, 'active', NULL, ?, ?)`).run(NOW, NOW);
+		db.prepare(`INSERT INTO identity_devices(
+			device_id, identity_id, display_name, status, provenance, revision, migration_state,
+			source_fingerprint, idempotency_key, created_at, updated_at
+		) VALUES ('device-conflict', 'identity-other', 'Other device', 'active', 'test', 'r2',
+			'user_managed', 's2', 'i2', ?, ?)`).run(NOW, NOW);
+		db.prepare("UPDATE actors SET status = 'deactivated' WHERE actor_id = 'identity-direct'").run();
+
+		const result = reconcileCoordinatorEnrollmentSnapshot(db, {
+			groupId: "group-a",
+			now: NOW,
+			consumedTeamInvites: [],
+			enrollments: [
+				{
+					group_id: "group-a",
+					device_id: "device-conflict",
+					public_key: "pk",
+					fingerprint: "fp",
+					identity_id: "identity-direct",
+					display_name: null,
+					enabled: 1,
+					created_at: NOW,
+				},
+			],
+		});
+		expect(result.issues).toEqual([
+			{ kind: "device", referenceId: "device-conflict", code: "identity_not_active" },
+		]);
+		expect(
+			db
+				.prepare("SELECT identity_id FROM identity_devices WHERE device_id = 'device-conflict'")
+				.pluck()
+				.get(),
+		).toBe("identity-other");
+	});
+});

--- a/packages/core/src/coordinator-enrollment-reconciler.ts
+++ b/packages/core/src/coordinator-enrollment-reconciler.ts
@@ -1,0 +1,223 @@
+import { createHash } from "node:crypto";
+import type { CoordinatorConsumedTeamInvite } from "./coordinator-actions.js";
+import type { CoordinatorEnrollment } from "./coordinator-store-contract.js";
+import type { Database } from "./db.js";
+
+export interface CoordinatorEnrollmentReconcileIssue {
+	kind: "device" | "team_membership";
+	referenceId: string;
+	code: string;
+}
+
+export interface CoordinatorEnrollmentReconcileResult {
+	devicesAdded: number;
+	membershipsAdded: number;
+	identitiesAdded: number;
+	unchanged: number;
+	issues: CoordinatorEnrollmentReconcileIssue[];
+}
+
+function digest(kind: string, value: unknown): string {
+	return createHash("sha256")
+		.update(JSON.stringify([kind, value]))
+		.digest("hex");
+}
+
+function strictId(value: unknown): value is string {
+	return (
+		typeof value === "string" &&
+		value.length > 0 &&
+		value === value.trim() &&
+		value.length <= 256 &&
+		!/[\p{Cc}\p{Cf}]/u.test(value)
+	);
+}
+
+export function reconcileCoordinatorEnrollmentSnapshot(
+	db: Database,
+	input: {
+		groupId: string;
+		enrollments: CoordinatorEnrollment[];
+		consumedTeamInvites: CoordinatorConsumedTeamInvite[];
+		localDeviceId?: string;
+		now?: string;
+	},
+): CoordinatorEnrollmentReconcileResult {
+	if (!strictId(input.groupId)) throw new Error("coordinator_group_id_invalid");
+	const now = input.now ?? new Date().toISOString();
+	if (Number.isNaN(new Date(now).getTime())) throw new Error("reconciliation_time_invalid");
+	const result: CoordinatorEnrollmentReconcileResult = {
+		devicesAdded: 0,
+		membershipsAdded: 0,
+		identitiesAdded: 0,
+		unchanged: 0,
+		issues: [],
+	};
+	const issue = (
+		kind: CoordinatorEnrollmentReconcileIssue["kind"],
+		referenceId: string,
+		code: string,
+	): void => {
+		result.issues.push({ kind, referenceId, code });
+	};
+	const localEnrollmentIdentityIds = new Set(
+		input.enrollments
+			.filter(
+				(enrollment) =>
+					enrollment.group_id === input.groupId &&
+					enrollment.enabled === 1 &&
+					enrollment.device_id === input.localDeviceId &&
+					strictId(enrollment.identity_id),
+			)
+			.map((enrollment) => enrollment.identity_id as string),
+	);
+	const locallyProvenIdentityId =
+		localEnrollmentIdentityIds.size === 1 ? [...localEnrollmentIdentityIds][0] : undefined;
+
+	const apply = db.transaction(() => {
+		for (const invite of input.consumedTeamInvites) {
+			const identityId = invite.assigned_identity_id;
+			if (
+				invite.group_id !== input.groupId ||
+				!strictId(identityId) ||
+				identityId !== invite.recipient_actor_id ||
+				!strictId(invite.policy_team_id)
+			) {
+				issue("team_membership", invite.invite_id, "team_invite_invalid");
+				continue;
+			}
+			const team = db
+				.prepare("SELECT status FROM policy_teams WHERE team_id = ?")
+				.get(invite.policy_team_id) as { status: string } | undefined;
+			if (team?.status !== "active") {
+				issue("team_membership", invite.invite_id, "policy_team_not_active");
+				continue;
+			}
+			const actor = db
+				.prepare("SELECT is_local, status, merged_into_actor_id FROM actors WHERE actor_id = ?")
+				.get(identityId) as
+				| { is_local: number; status: string; merged_into_actor_id: string | null }
+				| undefined;
+			if (!actor) {
+				db.prepare(`INSERT INTO actors(
+					actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+				) VALUES (?, 'Team member', 0, 'active', NULL, ?, ?)`).run(identityId, now, now);
+				result.identitiesAdded += 1;
+			} else if (
+				actor.is_local !== 0 ||
+				actor.status !== "active" ||
+				actor.merged_into_actor_id != null
+			) {
+				issue("team_membership", invite.invite_id, "identity_not_active");
+				continue;
+			}
+			const membership = db
+				.prepare("SELECT status FROM policy_team_memberships WHERE team_id = ? AND identity_id = ?")
+				.get(invite.policy_team_id, identityId) as { status: string } | undefined;
+			if (membership) {
+				if (membership.status === "active") result.unchanged += 1;
+				else issue("team_membership", invite.invite_id, "membership_not_active");
+				continue;
+			}
+			const stableBinding = {
+				groupId: input.groupId,
+				inviteId: invite.invite_id,
+				teamId: invite.policy_team_id,
+				identityId,
+			};
+			db.prepare(`INSERT INTO policy_team_memberships(
+				team_id, identity_id, role, status, provenance, revision, migration_state,
+				source_fingerprint, idempotency_key, created_at, updated_at
+			) VALUES (?, ?, 'member', 'active', 'coordinator_invite', ?, 'user_managed', ?, ?, ?, ?)`).run(
+				invite.policy_team_id,
+				identityId,
+				digest("coordinator-team-membership-revision-v1", stableBinding),
+				digest("coordinator-team-membership-source-v1", stableBinding),
+				digest("coordinator-team-membership-idempotency-v1", stableBinding),
+				now,
+				now,
+			);
+			result.membershipsAdded += 1;
+		}
+
+		for (const enrollment of input.enrollments) {
+			const identityId = enrollment.identity_id;
+			if (identityId == null || identityId === "") continue;
+			if (
+				enrollment.group_id !== input.groupId ||
+				enrollment.enabled !== 1 ||
+				!strictId(enrollment.device_id) ||
+				!strictId(identityId)
+			) {
+				issue("device", enrollment.device_id, "enrollment_invalid");
+				continue;
+			}
+			const actor = db
+				.prepare("SELECT is_local, status, merged_into_actor_id FROM actors WHERE actor_id = ?")
+				.get(identityId) as
+				| { is_local: number; status: string; merged_into_actor_id: string | null }
+				| undefined;
+			if (
+				actor?.status !== "active" ||
+				actor.merged_into_actor_id != null ||
+				(actor.is_local !== 0 && identityId !== locallyProvenIdentityId)
+			) {
+				issue("device", enrollment.device_id, "identity_not_active");
+				continue;
+			}
+			const displayName = enrollment.display_name?.trim() || "";
+			const existing = db
+				.prepare(
+					`SELECT identity_id, display_name, status, provenance
+					 FROM identity_devices WHERE device_id = ?`,
+				)
+				.get(enrollment.device_id) as
+				| { identity_id: string; display_name: string; status: string; provenance: string }
+				| undefined;
+			if (existing) {
+				if (existing.identity_id === identityId && existing.status === "active") {
+					if (
+						existing.provenance === "coordinator_enrollment" &&
+						displayName &&
+						existing.display_name !== displayName
+					) {
+						db.prepare(
+							`UPDATE identity_devices SET display_name = ?, updated_at = ?
+							 WHERE device_id = ? AND provenance = 'coordinator_enrollment'`,
+						).run(displayName, now, enrollment.device_id);
+					}
+					result.unchanged += 1;
+				} else {
+					issue("device", enrollment.device_id, "device_identity_conflict");
+				}
+				continue;
+			}
+			const stableBinding = {
+				groupId: input.groupId,
+				identityId,
+				deviceId: enrollment.device_id,
+				fingerprint: enrollment.fingerprint,
+			};
+			db.prepare(`INSERT INTO identity_devices(
+				device_id, identity_id, display_name, status, provenance, revision, migration_state,
+				source_fingerprint, idempotency_key, created_at, updated_at
+			) VALUES (?, ?, ?, 'active', 'coordinator_enrollment', ?, 'user_managed', ?, ?, ?, ?)`).run(
+				enrollment.device_id,
+				identityId,
+				displayName || "Enrolled device",
+				digest("coordinator-identity-device-revision-v1", stableBinding),
+				digest("coordinator-identity-device-source-v1", stableBinding),
+				digest("coordinator-identity-device-idempotency-v1", stableBinding),
+				now,
+				now,
+			);
+			result.devicesAdded += 1;
+		}
+	});
+	apply();
+	result.issues.sort(
+		(left, right) =>
+			left.kind.localeCompare(right.kind) || left.referenceId.localeCompare(right.referenceId),
+	);
+	return result;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,11 @@ export type {
 } from "./coordinator-api.js";
 export { createCoordinatorApp } from "./coordinator-api.js";
 export type {
+	CoordinatorEnrollmentReconcileIssue,
+	CoordinatorEnrollmentReconcileResult,
+} from "./coordinator-enrollment-reconciler.js";
+export { reconcileCoordinatorEnrollmentSnapshot } from "./coordinator-enrollment-reconciler.js";
+export type {
 	CoordinatorGroupPreference,
 	UpsertCoordinatorGroupPreferenceInput,
 } from "./coordinator-group-preferences.js";

--- a/packages/core/src/recipient-policy-reconciler.test.ts
+++ b/packages/core/src/recipient-policy-reconciler.test.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	assertLegacyShareGrantAllowed,
 	type RecipientPolicyReconcilerEffects,
 	reconcileRecipientPolicyProject,
 } from "./recipient-policy-reconciler.js";
@@ -67,6 +68,10 @@ function harness(active: string[]) {
 				memberships: deviceIds.map((deviceId) => ({ deviceId, status: "active" as const })),
 			};
 		}),
+		listBoundaryEnrollments: vi.fn(async () => [
+			{ deviceId: "device-keep", identityId: "identity-a" },
+			{ deviceId: "device-new", identityId: "identity-a" },
+		]),
 		probeCapability: vi.fn(async (deviceId) => {
 			calls.push(`probe:${deviceId}`);
 			return "supported";
@@ -136,10 +141,9 @@ describe("recipient-policy reconciler executor", () => {
 		});
 		expect(calls).toEqual([
 			"snapshot",
+			"revoke:device-old",
 			"probe:device-keep",
 			"probe:device-new",
-			"probe:device-old",
-			"revoke:device-old",
 			"grant:device-new",
 			"refresh",
 			"snapshot",
@@ -162,8 +166,194 @@ describe("recipient-policy reconciler executor", () => {
 		expect(getRecipientPolicyAuthorityState(db, PROJECT)?.authorityState).toBe("active");
 	});
 
-	it("preflights every peer and needs attention without mutations for confirmed unsupported peers", async () => {
+	it("does not grant a policy device that is not enrolled in the boundary group", async () => {
+		const { effects } = harness(["device-keep"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{ deviceId: "device-keep", identityId: "identity-a" },
+		]);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-boundary" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "parity_pending",
+			grantedDeviceIds: [],
+		});
+		expect(effects.grant).not.toHaveBeenCalled();
+		expect(vi.mocked(effects.probeCapability).mock.calls.map(([deviceId]) => deviceId)).toEqual([
+			"device-keep",
+		]);
+	});
+
+	it("does not grant when the enrollment Identity changes during preflight", async () => {
+		const { effects } = harness(["device-keep"]);
+		vi.mocked(effects.listBoundaryEnrollments)
+			.mockResolvedValueOnce([
+				{ deviceId: "device-keep", identityId: "identity-a" },
+				{ deviceId: "device-new", identityId: "identity-a" },
+			])
+			.mockResolvedValueOnce([
+				{ deviceId: "device-keep", identityId: "identity-a" },
+				{ deviceId: "device-new", identityId: "identity-other" },
+			]);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-enrollment-race" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "stale",
+			safeErrorCode: "recipient_policy_generation_stale",
+			grantedDeviceIds: [],
+		});
+		expect(effects.grant).not.toHaveBeenCalled();
+	});
+
+	it("revokes a new grant immediately when its enrollment Identity changes", async () => {
+		const { effects } = harness(["device-keep"]);
+		const matching = [
+			{ deviceId: "device-keep", identityId: "identity-a" },
+			{ deviceId: "device-new", identityId: "identity-a" },
+		];
+		vi.mocked(effects.listBoundaryEnrollments)
+			.mockResolvedValueOnce(matching)
+			.mockResolvedValueOnce(matching)
+			.mockResolvedValue([
+				{ deviceId: "device-keep", identityId: "identity-a" },
+				{ deviceId: "device-new", identityId: "identity-other" },
+			]);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-post-grant-race" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "stale",
+			safeErrorCode: "recipient_policy_generation_stale",
+			grantedDeviceIds: ["device-new"],
+			revokedDeviceIds: ["device-new"],
+		});
+		expect(effects.grant).toHaveBeenCalledWith(expect.objectContaining({ deviceId: "device-new" }));
+		expect(effects.revoke).toHaveBeenCalledWith(
+			expect.objectContaining({ deviceId: "device-new" }),
+		);
+		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([
+			expect.objectContaining({
+				deviceId: "device-new",
+				reasonCode: "enrollment_identity_conflict",
+			}),
+		]);
+	});
+
+	it("revokes a current device whose boundary enrollment changed Identity", async () => {
+		db.prepare(
+			"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
+		).run();
+		const { effects } = harness(["device-keep"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{ deviceId: "device-keep", identityId: "identity-other" },
+		]);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-enrollment-conflict" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			revokedDeviceIds: ["device-keep"],
+			grantedDeviceIds: [],
+		});
+		expect(effects.revoke).toHaveBeenCalledWith(
+			expect.objectContaining({ scopeId: SCOPE, deviceId: "device-keep" }),
+		);
+		expect(effects.grant).not.toHaveBeenCalled();
+	});
+
+	it("does not revoke a current policy device merely omitted from boundary enrollments", async () => {
+		db.prepare(
+			"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
+		).run();
+		const { effects } = harness(["device-keep"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([]);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-enrollment-omission" },
+			effects,
+		);
+
+		expect(outcome.revokedDeviceIds).toEqual([]);
+		expect(effects.revoke).not.toHaveBeenCalled();
+	});
+
+	it("blocks legacy grants when active authority excludes a policy-desired device", () => {
+		insertActiveAuthority(db);
+
+		expect(() =>
+			assertLegacyShareGrantAllowed(db, {
+				canonicalProjectIdentity: PROJECT,
+				deviceId: "device-keep",
+			}),
+		).toThrow("recipient_policy_legacy_grant_blocked");
+	});
+
+	it("allows legacy retries while active authority still matches policy", async () => {
+		const { effects } = harness(["device-keep", "device-new"]);
+		await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-activate-1" },
+			effects,
+		);
+		await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-activate-2" },
+			effects,
+		);
+
+		expect(getRecipientPolicyAuthorityState(db, PROJECT)?.authorityState).toBe("active");
+		expect(() =>
+			assertLegacyShareGrantAllowed(db, {
+				canonicalProjectIdentity: PROJECT,
+				deviceId: "device-keep",
+			}),
+		).not.toThrow();
+	});
+
+	it("revokes owner-policy removals when the boundary enrollment read fails", async () => {
 		const { effects } = harness(["device-keep", "device-old"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockRejectedValue(
+			new Error("recipient_policy_snapshot_not_fresh"),
+		);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-revoke" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "waiting",
+			safeErrorCode: "recipient_policy_snapshot_not_fresh",
+			revokedDeviceIds: ["device-old"],
+			grantedDeviceIds: [],
+		});
+		expect(effects.revoke).toHaveBeenCalledWith(
+			expect.objectContaining({ scopeId: SCOPE, deviceId: "device-old" }),
+		);
+		expect(effects.grant).not.toHaveBeenCalled();
+	});
+
+	it("revokes removals before rejecting an unsupported grant candidate", async () => {
+		const { effects } = harness(["device-keep", "device-old"]);
+		insertActiveAuthority(db);
 		vi.mocked(effects.probeCapability).mockImplementation(async (deviceId) =>
 			deviceId === "device-new" ? "unsupported" : "supported",
 		);
@@ -177,18 +367,27 @@ describe("recipient-policy reconciler executor", () => {
 		expect(outcome).toMatchObject({
 			status: "needs_attention",
 			safeErrorCode: "recipient_policy_capability_unsupported",
+			revokedDeviceIds: ["device-old"],
 		});
-		expect(effects.revoke).not.toHaveBeenCalled();
+		expect(effects.revoke).toHaveBeenCalledWith(
+			expect.objectContaining({ deviceId: "device-old" }),
+		);
 		expect(effects.grant).not.toHaveBeenCalled();
 		expect(effects.refresh).not.toHaveBeenCalled();
 		expect(vi.mocked(effects.probeCapability).mock.calls.map(([deviceId]) => deviceId)).toEqual([
 			"device-keep",
 			"device-new",
-			"device-old",
 		]);
 		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([
 			expect.objectContaining({ scopeId: SCOPE, deviceId: "device-old" }),
 		]);
+		expect(getRecipientPolicyAuthorityState(db, PROJECT)?.authorityState).toBe("rolled_back");
+		expect(() =>
+			assertLegacyShareGrantAllowed(db, {
+				canonicalProjectIdentity: PROJECT,
+				deviceId: "device-old",
+			}),
+		).toThrow("recipient_policy_legacy_grant_blocked");
 	});
 
 	it("retries a failed coordinator mutation with the same deterministic effect identity", async () => {
@@ -379,14 +578,18 @@ describe("recipient-policy reconciler executor", () => {
 	});
 
 	it("cancels a stale generation after revokes and before any grant", async () => {
-		const { effects } = harness(["device-old"]);
-		vi.mocked(effects.probeCapability).mockImplementation(async (deviceId) => {
-			if (deviceId === "device-old") {
-				db.prepare(
-					"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
-				).run();
-			}
-			return "supported";
+		const { effects, members } = harness(["device-old"]);
+		vi.mocked(effects.revoke).mockImplementation(async (input) => {
+			db.prepare(
+				"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
+			).run();
+			members.delete(input.deviceId);
+			return {
+				effectId: input.effectId,
+				scopeId: input.scopeId,
+				deviceId: input.deviceId,
+				status: "revoked",
+			};
 		});
 
 		const outcome = await reconcileRecipientPolicyProject(

--- a/packages/core/src/recipient-policy-reconciler.ts
+++ b/packages/core/src/recipient-policy-reconciler.ts
@@ -41,6 +41,10 @@ export interface RecipientPolicyReconcilerEffects {
 		canonicalProjectIdentity: string;
 		scopeId: string;
 	}): Promise<RecipientPolicyCoordinatorSnapshot>;
+	listBoundaryEnrollments(input: {
+		canonicalProjectIdentity: string;
+		scopeId: string;
+	}): Promise<Array<{ deviceId: string; identityId: string }>>;
 	probeCapability(deviceId: string): Promise<RecipientPolicyPeerCapability>;
 	revoke(input: {
 		effectId: string;
@@ -313,6 +317,29 @@ function activeSnapshotDevices(
 		.toSorted();
 }
 
+function boundaryEnrollmentIdentities(
+	enrollments: Array<{ deviceId: string; identityId: string }>,
+): Map<string, string> {
+	const identities = new Map<string, string>();
+	for (const enrollment of enrollments) {
+		if (
+			!validId(enrollment.deviceId) ||
+			!validId(enrollment.identityId) ||
+			identities.has(enrollment.deviceId)
+		) {
+			throw new Error("recipient_policy_snapshot_invalid");
+		}
+		identities.set(enrollment.deviceId, enrollment.identityId);
+	}
+	return identities;
+}
+
+function boundaryEnrollmentIdentityId(
+	binding: string | { identityId: string } | undefined,
+): string | undefined {
+	return typeof binding === "string" ? binding : binding?.identityId;
+}
+
 function generation(db: Database, projectId: string, desiredDigest: string): number {
 	const state = getRecipientPolicyAuthorityState(db, projectId);
 	if (!state || state.desiredDevicesDigest === null) return 1;
@@ -517,13 +544,18 @@ export function assertLegacyShareGrantAllowed(
 	input: { canonicalProjectIdentity: string; deviceId: string },
 ): void {
 	const state = getRecipientPolicyAuthorityState(db, input.canonicalProjectIdentity);
-	if (state?.authorityState !== "active") return;
+	if (!state || state.authorityState === "legacy") return;
 	const desired = deriveRecipientPolicyEffectiveDevicesFromDatabase(
 		db,
 		input.canonicalProjectIdentity,
 	);
+	const desiredDeviceDigest =
+		desired.status === "eligible"
+			? deviceDigest(desired.devices.map((item) => item.deviceId).toSorted())
+			: null;
 	if (
 		desired.status !== "eligible" ||
+		desiredDeviceDigest !== state.desiredDevicesDigest ||
 		!desired.devices.some((item) => item.deviceId === input.deviceId)
 	) {
 		throw new Error("recipient_policy_legacy_grant_blocked");
@@ -565,7 +597,6 @@ export async function reconcileRecipientPolicyProject(
 				"recipient_policy_desired_state_invalid",
 			);
 		}
-		activeGeneration = generation(db, projectId, desired.desiredDevicesDigest);
 		const initialSnapshot = await effects.snapshot({
 			canonicalProjectIdentity: projectId,
 			scopeId: managedBoundary.scopeId,
@@ -575,26 +606,12 @@ export async function reconcileRecipientPolicyProject(
 			managedBoundary.scopeId,
 			startedAt,
 		);
-		const desiredDeviceIds = desired.devices.map((device) => device.deviceId).toSorted();
-		const desiredSet = new Set(desiredDeviceIds);
+		const policyDesiredDeviceIds = desired.devices.map((device) => device.deviceId).toSorted();
+		const policyDesiredSet = new Set(policyDesiredDeviceIds);
 		const currentSet = new Set(currentDeviceIds);
-		const revokeDeviceIds = currentDeviceIds.filter((deviceId) => !desiredSet.has(deviceId));
-		const grantDeviceIds = desiredDeviceIds.filter((deviceId) => !currentSet.has(deviceId));
-		upsertRecipientPolicyAuthorityObservation(db, {
-			canonicalProjectIdentity: projectId,
-			generation: activeGeneration,
-			desiredDevicesDigest: desired.desiredDevicesDigest,
-			currentDevicesDigest:
-				revokeDeviceIds.length === 0 && grantDeviceIds.length === 0
-					? desired.desiredDevicesDigest
-					: deviceDigest(currentDeviceIds),
-			freshSnapshotFingerprint: initialSnapshot.fingerprint,
-			freshSnapshotObservedAt: initialSnapshot.observedAt,
-			now: effects.now(),
-		});
-		if (revokeDeviceIds.length > 0 || grantDeviceIds.length > 0) {
-			resetParity(db, projectId, effects.now());
-		}
+		const revokeDeviceIds = currentDeviceIds.filter((deviceId) => !policyDesiredSet.has(deviceId));
+		activeGeneration = Math.max(activeGeneration, 1);
+		if (revokeDeviceIds.length > 0) resetParity(db, projectId, effects.now());
 		for (const deviceId of revokeDeviceIds) {
 			putRecipientPolicyDenyOverlay(db, {
 				canonicalProjectIdentity: projectId,
@@ -608,32 +625,6 @@ export async function reconcileRecipientPolicyProject(
 		const snapshotStateKey = digest("recipient-policy-snapshot-state-v1", {
 			fingerprint: initialSnapshot.fingerprint,
 		});
-		const passKey = digest("recipient-policy-pass-v1", {
-			fingerprint: initialSnapshot.fingerprint,
-			observedAt: initialSnapshot.observedAt,
-		});
-		const capability = await preflight(db, {
-			projectId,
-			generation: activeGeneration,
-			deviceIds: [...new Set([...currentDeviceIds, ...desiredDeviceIds])].toSorted(),
-			passKey,
-			leaseOwner: input.leaseOwner,
-			lease,
-			effects,
-		});
-		if (capability !== "supported") {
-			const safeErrorCode =
-				capability === "unsupported"
-					? "recipient_policy_capability_unsupported"
-					: "recipient_policy_capability_undetermined";
-			authority(db, { projectId, safeErrorCode, now: effects.now() });
-			return result(
-				projectId,
-				capability === "unsupported" ? "needs_attention" : "waiting",
-				activeGeneration,
-				safeErrorCode,
-			);
-		}
 		for (const deviceId of revokeDeviceIds) {
 			const changed = await step(
 				db,
@@ -682,6 +673,151 @@ export async function reconcileRecipientPolicyProject(
 				revokedDeviceIds,
 			);
 		}
+		const remainingPolicyCurrentDeviceIds = currentDeviceIds.filter(
+			(deviceId) => !revokeDeviceIds.includes(deviceId),
+		);
+		const enrollmentIdentities = boundaryEnrollmentIdentities(
+			await effects.listBoundaryEnrollments({
+				canonicalProjectIdentity: projectId,
+				scopeId: managedBoundary.scopeId,
+			}),
+		);
+		const desiredIdentityByDeviceId = new Map(
+			desired.devices.map((device) => [device.deviceId, device.identityId]),
+		);
+		const enrollmentConflictDeviceIds = remainingPolicyCurrentDeviceIds.filter((deviceId) => {
+			const enrollmentIdentityId = boundaryEnrollmentIdentityId(enrollmentIdentities.get(deviceId));
+			const desiredIdentityId = desiredIdentityByDeviceId.get(deviceId);
+			return Boolean(
+				enrollmentIdentityId && desiredIdentityId && enrollmentIdentityId !== desiredIdentityId,
+			);
+		});
+		if (enrollmentConflictDeviceIds.length > 0) resetParity(db, projectId, effects.now());
+		for (const deviceId of enrollmentConflictDeviceIds) {
+			putRecipientPolicyDenyOverlay(db, {
+				canonicalProjectIdentity: projectId,
+				scopeId: managedBoundary.scopeId,
+				deviceId,
+				generation: activeGeneration,
+				reasonCode: "enrollment_identity_conflict",
+				now: effects.now(),
+			});
+			const changed = await step(
+				db,
+				{
+					projectId,
+					generation: activeGeneration,
+					stepKey: `revoke-enrollment-conflict:${snapshotStateKey}:${deviceId}`,
+					payload: { scopeId: managedBoundary.scopeId, deviceId, status: "revoked" },
+					leaseOwner: input.leaseOwner,
+					lease,
+					now: effects.now,
+				},
+				async (effectId) => {
+					const receipt = await effects.revoke({
+						effectId,
+						canonicalProjectIdentity: projectId,
+						generation: activeGeneration,
+						scopeId: managedBoundary.scopeId,
+						deviceId,
+					});
+					validateReceipt(receipt, {
+						effectId,
+						scopeId: managedBoundary.scopeId,
+						deviceId,
+						status: "revoked",
+					});
+				},
+			);
+			if (changed) revokedDeviceIds.push(deviceId);
+		}
+		const remainingCurrentDeviceIds = remainingPolicyCurrentDeviceIds.filter(
+			(deviceId) => !enrollmentConflictDeviceIds.includes(deviceId),
+		);
+		const grantEligibleDeviceIds = desired.devices
+			.filter(
+				(device) =>
+					boundaryEnrollmentIdentityId(enrollmentIdentities.get(device.deviceId)) ===
+					device.identityId,
+			)
+			.map((device) => device.deviceId)
+			.toSorted();
+		const expectedDeviceIds = [
+			...new Set([
+				...remainingCurrentDeviceIds.filter((deviceId) => policyDesiredSet.has(deviceId)),
+				...grantEligibleDeviceIds,
+			]),
+		].toSorted();
+		const expectedSet = new Set(expectedDeviceIds);
+		const expectedDigest = deviceDigest(expectedDeviceIds);
+		activeGeneration = generation(db, projectId, expectedDigest);
+		const grantDeviceIds = grantEligibleDeviceIds.filter((deviceId) => !currentSet.has(deviceId));
+		upsertRecipientPolicyAuthorityObservation(db, {
+			canonicalProjectIdentity: projectId,
+			generation: activeGeneration,
+			desiredDevicesDigest: expectedDigest,
+			currentDevicesDigest:
+				grantDeviceIds.length === 0 ? expectedDigest : deviceDigest(remainingCurrentDeviceIds),
+			freshSnapshotFingerprint: initialSnapshot.fingerprint,
+			freshSnapshotObservedAt: initialSnapshot.observedAt,
+			now: effects.now(),
+		});
+		if (grantDeviceIds.length > 0) resetParity(db, projectId, effects.now());
+		const passKey = digest("recipient-policy-pass-v1", {
+			fingerprint: initialSnapshot.fingerprint,
+			observedAt: initialSnapshot.observedAt,
+		});
+		const capability = await preflight(db, {
+			projectId,
+			generation: activeGeneration,
+			deviceIds: expectedDeviceIds,
+			passKey,
+			leaseOwner: input.leaseOwner,
+			lease,
+			effects,
+		});
+		if (capability !== "supported") {
+			const safeErrorCode =
+				capability === "unsupported"
+					? "recipient_policy_capability_unsupported"
+					: "recipient_policy_capability_undetermined";
+			authority(db, { projectId, safeErrorCode, now: effects.now() });
+			return result(
+				projectId,
+				capability === "unsupported" ? "needs_attention" : "waiting",
+				activeGeneration,
+				safeErrorCode,
+				revokedDeviceIds,
+			);
+		}
+		if (grantDeviceIds.length > 0) {
+			const preGrantEnrollmentIdentities = boundaryEnrollmentIdentities(
+				await effects.listBoundaryEnrollments({
+					canonicalProjectIdentity: projectId,
+					scopeId: managedBoundary.scopeId,
+				}),
+			);
+			const changedBinding = grantDeviceIds.some(
+				(deviceId) =>
+					boundaryEnrollmentIdentityId(preGrantEnrollmentIdentities.get(deviceId)) !==
+					desiredIdentityByDeviceId.get(deviceId),
+			);
+			if (changedBinding) {
+				resetParity(db, projectId, effects.now());
+				authority(db, {
+					projectId,
+					safeErrorCode: "recipient_policy_generation_stale",
+					now: effects.now(),
+				});
+				return result(
+					projectId,
+					"stale",
+					activeGeneration,
+					"recipient_policy_generation_stale",
+					revokedDeviceIds,
+				);
+			}
+		}
 		for (const deviceId of grantDeviceIds) {
 			const changed = await step(
 				db,
@@ -712,6 +848,73 @@ export async function reconcileRecipientPolicyProject(
 				},
 			);
 			if (changed) grantedDeviceIds.push(deviceId);
+		}
+		if (grantDeviceIds.length > 0) {
+			const postGrantEnrollmentIdentities = boundaryEnrollmentIdentities(
+				await effects.listBoundaryEnrollments({
+					canonicalProjectIdentity: projectId,
+					scopeId: managedBoundary.scopeId,
+				}),
+			);
+			const changedBindingDeviceIds = grantDeviceIds.filter(
+				(deviceId) =>
+					boundaryEnrollmentIdentityId(postGrantEnrollmentIdentities.get(deviceId)) !==
+					desiredIdentityByDeviceId.get(deviceId),
+			);
+			if (changedBindingDeviceIds.length > 0) {
+				resetParity(db, projectId, effects.now());
+				for (const deviceId of changedBindingDeviceIds) {
+					putRecipientPolicyDenyOverlay(db, {
+						canonicalProjectIdentity: projectId,
+						scopeId: managedBoundary.scopeId,
+						deviceId,
+						generation: activeGeneration,
+						reasonCode: "enrollment_identity_conflict",
+						now: effects.now(),
+					});
+					const changed = await step(
+						db,
+						{
+							projectId,
+							generation: activeGeneration,
+							stepKey: `revoke-post-grant-enrollment-conflict:${snapshotStateKey}:${deviceId}`,
+							payload: { scopeId: managedBoundary.scopeId, deviceId, status: "revoked" },
+							leaseOwner: input.leaseOwner,
+							lease,
+							now: effects.now,
+						},
+						async (effectId) => {
+							const receipt = await effects.revoke({
+								effectId,
+								canonicalProjectIdentity: projectId,
+								generation: activeGeneration,
+								scopeId: managedBoundary.scopeId,
+								deviceId,
+							});
+							validateReceipt(receipt, {
+								effectId,
+								scopeId: managedBoundary.scopeId,
+								deviceId,
+								status: "revoked",
+							});
+						},
+					);
+					if (changed) revokedDeviceIds.push(deviceId);
+				}
+				authority(db, {
+					projectId,
+					safeErrorCode: "recipient_policy_generation_stale",
+					now: effects.now(),
+				});
+				return result(
+					projectId,
+					"stale",
+					activeGeneration,
+					"recipient_policy_generation_stale",
+					revokedDeviceIds,
+					grantedDeviceIds,
+				);
+			}
 		}
 		await step(
 			db,
@@ -745,7 +948,7 @@ export async function reconcileRecipientPolicyProject(
 		for (const overlay of listRecipientPolicyDenyOverlays(db, projectId)) {
 			const revokeVerified = !verifiedSet.has(overlay.deviceId);
 			const desiredActiveVerified =
-				desiredSet.has(overlay.deviceId) && verifiedSet.has(overlay.deviceId);
+				expectedSet.has(overlay.deviceId) && verifiedSet.has(overlay.deviceId);
 			if (
 				overlay.scopeId === managedBoundary.scopeId &&
 				(revokeVerified || desiredActiveVerified)
@@ -759,13 +962,13 @@ export async function reconcileRecipientPolicyProject(
 			}
 		}
 		const parity =
-			verifiedDeviceIds.length === desiredDeviceIds.length &&
-			verifiedDeviceIds.every((deviceId, index) => deviceId === desiredDeviceIds[index]);
+			verifiedDeviceIds.length === expectedDeviceIds.length &&
+			verifiedDeviceIds.every((deviceId, index) => deviceId === expectedDeviceIds[index]);
 		upsertRecipientPolicyAuthorityObservation(db, {
 			canonicalProjectIdentity: projectId,
 			generation: activeGeneration,
-			desiredDevicesDigest: desired.desiredDevicesDigest,
-			currentDevicesDigest: parity ? desired.desiredDevicesDigest : deviceDigest(verifiedDeviceIds),
+			desiredDevicesDigest: expectedDigest,
+			currentDevicesDigest: parity ? expectedDigest : deviceDigest(verifiedDeviceIds),
 			freshSnapshotFingerprint: verifiedSnapshot.fingerprint,
 			freshSnapshotObservedAt: verifiedSnapshot.observedAt,
 			now: effects.now(),
@@ -790,8 +993,8 @@ export async function reconcileRecipientPolicyProject(
 			canonicalProjectIdentity: projectId,
 			generation: activeGeneration,
 			scopeId: managedBoundary.scopeId,
-			desiredDevicesDigest: desired.desiredDevicesDigest,
-			deviceIds: desiredDeviceIds,
+			desiredDevicesDigest: expectedDigest,
+			deviceIds: expectedDeviceIds,
 		});
 		const state = getRecipientPolicyAuthorityState(db, projectId);
 		const laterUnchangedNoOp =

--- a/packages/core/src/recipient-policy-reconciliation.test.ts
+++ b/packages/core/src/recipient-policy-reconciliation.test.ts
@@ -298,4 +298,30 @@ describe("recipient-policy reconciliation persistence", () => {
 			}),
 		).toBe(true);
 	});
+
+	it("allows same-generation deny reasons to become stricter without accepting stale writes", () => {
+		const base = {
+			canonicalProjectIdentity: PROJECT,
+			scopeId: "scope-project",
+			deviceId: "device-a",
+			generation: 4,
+			now: NOW,
+		};
+		putRecipientPolicyDenyOverlay(db, {
+			...base,
+			reasonCode: "enrollment_identity_conflict",
+		});
+		putRecipientPolicyDenyOverlay(db, { ...base, reasonCode: "pending_revoke" });
+
+		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([
+			expect.objectContaining({ generation: 4, reasonCode: "pending_revoke" }),
+		]);
+		expect(() =>
+			putRecipientPolicyDenyOverlay(db, {
+				...base,
+				generation: 3,
+				reasonCode: "enrollment_identity_conflict",
+			}),
+		).toThrow("recipient_policy_deny_overlay_stale");
+	});
 });

--- a/packages/core/src/recipient-policy-reconciliation.ts
+++ b/packages/core/src/recipient-policy-reconciliation.ts
@@ -829,13 +829,6 @@ export function putRecipientPolicyDenyOverlay(
 	if (existing && input.generation < Number(existing.generation)) {
 		throw new Error("recipient_policy_deny_overlay_stale");
 	}
-	if (
-		existing &&
-		input.generation === Number(existing.generation) &&
-		input.reasonCode !== existing.reason_code
-	) {
-		throw new Error("recipient_policy_deny_overlay_conflict");
-	}
 	db.prepare(
 		`INSERT INTO recipient_policy_deny_overlays(
 		 canonical_project_identity, scope_id, device_id, generation, reason_code, created_at, updated_at

--- a/packages/core/src/share-provisioning.test.ts
+++ b/packages/core/src/share-provisioning.test.ts
@@ -1047,7 +1047,7 @@ describe("exact project share provisioning", () => {
 		).toBe("active");
 	});
 
-	it("blocks stale legacy grant retries when active recipient policy no longer desires the device", async () => {
+	it("blocks stale legacy grant retries before any mutation when active policy changed", async () => {
 		const now = createdAt;
 		db.prepare(
 			`INSERT INTO recipient_policy_authority_states(
@@ -1066,17 +1066,16 @@ describe("exact project share provisioning", () => {
 			executeShareProvisioning(db, { operationId, initiatingDeviceId: "owner" }, deps),
 		).rejects.toThrow("recipient_policy_legacy_grant_blocked");
 
-		expect(vi.mocked(deps.grantMembership).mock.calls.map(([input]) => input.deviceId)).toEqual([
-			"owner",
-			"owner-proven",
-		]);
+		expect(deps.grantMembership).not.toHaveBeenCalled();
 		expect(
 			db
 				.prepare(
-					"SELECT safe_error_code FROM share_operation_steps WHERE operation_id = ? AND step_key = ?",
+					"SELECT step_key, safe_error_code FROM share_operation_steps WHERE operation_id = ? AND safe_error_code IS NOT NULL",
 				)
-				.pluck()
-				.get(operationId, `space_grant:${remote}:recipient`),
-		).toBe("recipient_policy_legacy_grant_blocked");
+				.get(operationId),
+		).toEqual({
+			step_key: `space_grant:${remote}:owner`,
+			safe_error_code: "recipient_policy_legacy_grant_blocked",
+		});
 	});
 });

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -31,6 +31,7 @@ export type {
 	AdvanceProjectShareOperationResult,
 	RecipientPolicyReconciliationReadModel,
 	RecipientPolicyReconciliationReadState,
+	ReconcileConfiguredCoordinatorEnrollmentResult,
 	ReconcileRecipientPolicyProjectsResult,
 } from "./routes/sync.js";
 export {
@@ -39,6 +40,7 @@ export {
 	createRecipientPolicyReconcilerEffects,
 	listRecipientPolicyReconciliationStatus,
 	recipientPolicyCapabilityFromStatus,
+	reconcileConfiguredCoordinatorEnrollment,
 	reconcileRecipientPolicyProjects,
 } from "./routes/sync.js";
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -8,6 +8,9 @@ import { hostname, networkInterfaces } from "node:os";
 import { dirname, join } from "node:path";
 import type {
 	CoordinatorBootstrapGrantVerification,
+	CoordinatorConsumedTeamInvite,
+	CoordinatorEnrollment,
+	CoordinatorEnrollmentReconcileResult,
 	CoordinatorScope,
 	CoordinatorScopeMembership,
 	MaintenanceJobSnapshot,
@@ -49,6 +52,7 @@ import {
 	coordinatorGrantScopeMembershipAction,
 	coordinatorImportInviteAction,
 	coordinatorListBootstrapGrantsAction,
+	coordinatorListConsumedTeamInvitesAction,
 	coordinatorListDevicesAction,
 	coordinatorListGroupsAction,
 	coordinatorListJoinRequestsAction,
@@ -129,6 +133,7 @@ import {
 	reassignProjectScopeInventoryProject,
 	recipientInviteAuthoritativeIdentityId,
 	recipientReviewedIntentDigest,
+	reconcileCoordinatorEnrollmentSnapshot,
 	reconcileRecipientPolicyProject,
 	reconcileShareOperationAcceptance,
 	recordNonce,
@@ -1718,6 +1723,92 @@ export async function advancePendingProjectShares(
 	return result;
 }
 
+export interface ReconcileConfiguredCoordinatorEnrollmentResult {
+	skipped: boolean;
+	groupsProcessed: number;
+	failedGroups: number;
+	devicesAdded: number;
+	membershipsAdded: number;
+	identitiesAdded: number;
+	unchanged: number;
+	issues: number;
+}
+
+export async function reconcileConfiguredCoordinatorEnrollment(
+	store: MemoryStore,
+	options: {
+		config?: ReturnType<typeof readCoordinatorSyncConfig>;
+		listDevices?: (input: {
+			groupId: string;
+			remoteUrl: string;
+			adminSecret: string;
+		}) => Promise<CoordinatorEnrollment[]>;
+		listConsumedTeamInvites?: (input: {
+			groupId: string;
+			remoteUrl: string;
+			adminSecret: string;
+		}) => Promise<CoordinatorConsumedTeamInvite[]>;
+		reconcileSnapshot?: (
+			input: Parameters<typeof reconcileCoordinatorEnrollmentSnapshot>[1],
+		) => CoordinatorEnrollmentReconcileResult;
+	} = {},
+): Promise<ReconcileConfiguredCoordinatorEnrollmentResult> {
+	const config = options.config ?? readCoordinatorSyncConfig();
+	const remoteUrl = config.syncCoordinatorUrl.trim();
+	const adminSecret = config.syncCoordinatorAdminSecret.trim();
+	if (!remoteUrl || !adminSecret || config.syncCoordinatorGroups.length === 0) {
+		return {
+			skipped: true,
+			groupsProcessed: 0,
+			failedGroups: 0,
+			devicesAdded: 0,
+			membershipsAdded: 0,
+			identitiesAdded: 0,
+			unchanged: 0,
+			issues: 0,
+		};
+	}
+	const listDevices = options.listDevices ?? coordinatorListDevicesAction;
+	const listConsumedTeamInvites =
+		options.listConsumedTeamInvites ?? coordinatorListConsumedTeamInvitesAction;
+	const reconcileSnapshot =
+		options.reconcileSnapshot ??
+		((input) => reconcileCoordinatorEnrollmentSnapshot(store.db, input));
+	const total: ReconcileConfiguredCoordinatorEnrollmentResult = {
+		skipped: false,
+		groupsProcessed: 0,
+		failedGroups: 0,
+		devicesAdded: 0,
+		membershipsAdded: 0,
+		identitiesAdded: 0,
+		unchanged: 0,
+		issues: 0,
+	};
+	for (const groupId of config.syncCoordinatorGroups) {
+		try {
+			const [enrollments, consumedTeamInvites] = await Promise.all([
+				listDevices({ groupId, remoteUrl, adminSecret }),
+				listConsumedTeamInvites({ groupId, remoteUrl, adminSecret }),
+			]);
+			const result = reconcileSnapshot({
+				groupId,
+				enrollments,
+				consumedTeamInvites,
+				localDeviceId: store.deviceId,
+			});
+			total.groupsProcessed += 1;
+			total.devicesAdded += result.devicesAdded;
+			total.membershipsAdded += result.membershipsAdded;
+			total.identitiesAdded += result.identitiesAdded;
+			total.unchanged += result.unchanged;
+			total.issues += result.issues.length;
+		} catch {
+			total.failedGroups += 1;
+		}
+	}
+	return total;
+}
+
 const RECIPIENT_POLICY_MAINTENANCE_MAX_LIMIT = 10;
 const RECIPIENT_POLICY_MAINTENANCE_DEFAULT_LIMIT = 3;
 const RECIPIENT_POLICY_MAINTENANCE_BACKOFF_MS = 60_000;
@@ -1830,7 +1921,10 @@ export function createRecipientPolicyReconcilerEffects(
 				throw new Error("recipient_policy_snapshot_not_fresh");
 			});
 			const snapshotMemberships = memberships.map((membership) => {
-				if (membership.status !== "active" && membership.status !== "revoked") {
+				if (
+					typeof membership.device_id !== "string" ||
+					(membership.status !== "active" && membership.status !== "revoked")
+				) {
 					throw new Error("recipient_policy_snapshot_invalid");
 				}
 				const status: "active" | "revoked" = membership.status;
@@ -1852,6 +1946,30 @@ export function createRecipientPolicyReconcilerEffects(
 				observedAt: now(),
 				memberships: snapshotMemberships,
 			};
+		},
+		listBoundaryEnrollments: async ({ scopeId }) => {
+			const targetOptions = coordinatorOptions(scopeId);
+			const enrollments = await coordinatorListDevicesAction({
+				groupId: targetOptions.groupId,
+				remoteUrl: targetOptions.remoteUrl,
+				adminSecret: targetOptions.adminSecret,
+			}).catch(() => {
+				throw new Error("recipient_policy_snapshot_not_fresh");
+			});
+			return enrollments.flatMap((enrollment) => {
+				if (
+					enrollment.group_id !== targetOptions.groupId ||
+					typeof enrollment.device_id !== "string" ||
+					enrollment.enabled !== 1
+				) {
+					throw new Error("recipient_policy_snapshot_invalid");
+				}
+				if (enrollment.identity_id == null) return [];
+				if (typeof enrollment.identity_id !== "string") {
+					throw new Error("recipient_policy_snapshot_invalid");
+				}
+				return [{ deviceId: enrollment.device_id, identityId: enrollment.identity_id }];
+			});
 		},
 		probeCapability: (deviceId) =>
 			peerSupportsSyncRequirements(store, deviceId, {

--- a/packages/viewer-server/src/share-operation-maintenance.test.ts
+++ b/packages/viewer-server/src/share-operation-maintenance.test.ts
@@ -9,9 +9,75 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	advancePendingProjectShares,
+	createRecipientPolicyReconcilerEffects,
 	recipientPolicyCapabilityFromStatus,
+	reconcileConfiguredCoordinatorEnrollment,
 	reconcileRecipientPolicyProjects,
 } from "./routes/sync.js";
+
+describe("reconcileConfiguredCoordinatorEnrollment", () => {
+	it("skips recipient devices without coordinator admin configuration", async () => {
+		const result = await reconcileConfiguredCoordinatorEnrollment({ db: {} } as MemoryStore, {
+			config: {
+				syncCoordinatorUrl: "https://coord.example.test",
+				syncCoordinatorAdminSecret: "",
+				syncCoordinatorGroups: ["group-a"],
+			} as never,
+		});
+		expect(result).toMatchObject({ skipped: true, groupsProcessed: 0 });
+	});
+
+	it("reads and reconciles each configured group", async () => {
+		const calls: string[] = [];
+		const result = await reconcileConfiguredCoordinatorEnrollment(
+			{ db: {}, deviceId: "device-local" } as MemoryStore,
+			{
+				config: {
+					syncCoordinatorUrl: "https://coord.example.test",
+					syncCoordinatorAdminSecret: "secret",
+					syncCoordinatorGroups: ["group-a", "group-b"],
+				} as never,
+				listDevices: async ({ groupId }) => {
+					calls.push(`devices:${groupId}`);
+					return [];
+				},
+				listConsumedTeamInvites: async ({ groupId }) => {
+					calls.push(`invites:${groupId}`);
+					return [];
+				},
+				reconcileSnapshot: (input) => {
+					calls.push(`reconcile:${input.groupId}:${input.localDeviceId}`);
+					return {
+						devicesAdded: 1,
+						membershipsAdded: 2,
+						identitiesAdded: 1,
+						unchanged: 3,
+						issues: [],
+					};
+				},
+			},
+		);
+
+		expect(calls).toEqual([
+			"devices:group-a",
+			"invites:group-a",
+			"reconcile:group-a:device-local",
+			"devices:group-b",
+			"invites:group-b",
+			"reconcile:group-b:device-local",
+		]);
+		expect(result).toEqual({
+			skipped: false,
+			groupsProcessed: 2,
+			failedGroups: 0,
+			devicesAdded: 2,
+			membershipsAdded: 4,
+			identitiesAdded: 2,
+			unchanged: 6,
+			issues: 0,
+		});
+	});
+});
 
 describe("advancePendingProjectShares", () => {
 	let db: InstanceType<typeof Database>;
@@ -513,6 +579,9 @@ describe("recipient-policy maintenance", () => {
 			snapshot: vi.fn(async () => {
 				throw new Error("unused");
 			}),
+			listBoundaryEnrollments: vi.fn(async () => {
+				throw new Error("unused");
+			}),
 			probeCapability: vi.fn(async () => "supported"),
 			revoke: vi.fn(async () => {
 				throw new Error("unused");
@@ -530,7 +599,126 @@ describe("recipient-policy maintenance", () => {
 		store = { actorId: "actor-local", db, deviceId: "device-local" } as unknown as MemoryStore;
 	});
 
-	afterEach(() => db.close());
+	afterEach(() => {
+		db.close();
+		vi.unstubAllGlobals();
+	});
+
+	it("reads identity-bound enrollments from the managed boundary group", async () => {
+		const projectId = "project-boundary-enrollments";
+		const scopeId = "scope-boundary-enrollments";
+		seedManagedBoundary(projectId, scopeId);
+		db.prepare("UPDATE replication_scopes SET coordinator_id = ? WHERE scope_id = ?").run(
+			"https://coord.example.test",
+			scopeId,
+		);
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						items: [
+							{
+								group_id: "group",
+								device_id: "device-recipient",
+								identity_id: "identity-recipient",
+								enabled: 1,
+							},
+							{
+								group_id: "group",
+								device_id: "device-owner",
+								identity_id: null,
+								enabled: 1,
+							},
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const effects = createRecipientPolicyReconcilerEffects(store, {
+			config: {
+				syncCoordinatorUrl: "https://coord.example.test",
+				syncCoordinatorAdminSecret: "secret",
+				syncCoordinatorGroups: ["group"],
+			} as never,
+		});
+
+		await expect(
+			effects.listBoundaryEnrollments({ canonicalProjectIdentity: projectId, scopeId }),
+		).resolves.toEqual([{ deviceId: "device-recipient", identityId: "identity-recipient" }]);
+		expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+			"https://coord.example.test/v1/admin/devices?group_id=group&include_disabled=0",
+		);
+	});
+
+	it("rejects malformed boundary enrollment rows before reconciliation", async () => {
+		const projectId = "project-malformed-enrollment";
+		const scopeId = "scope-malformed-enrollment";
+		seedManagedBoundary(projectId, scopeId);
+		db.prepare("UPDATE replication_scopes SET coordinator_id = ? WHERE scope_id = ?").run(
+			"https://coord.example.test",
+			scopeId,
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							items: [{ group_id: "group", identity_id: "identity-recipient", enabled: 1 }],
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					),
+			),
+		);
+		const effects = createRecipientPolicyReconcilerEffects(store, {
+			config: {
+				syncCoordinatorUrl: "https://coord.example.test",
+				syncCoordinatorAdminSecret: "secret",
+				syncCoordinatorGroups: ["group"],
+			} as never,
+		});
+
+		await expect(
+			effects.listBoundaryEnrollments({ canonicalProjectIdentity: projectId, scopeId }),
+		).rejects.toThrow("recipient_policy_snapshot_invalid");
+	});
+
+	it("rejects boundary enrollment reads outside the configured coordinator authority", async () => {
+		const projectId = "project-boundary-authority";
+		const scopeId = "scope-boundary-authority";
+		seedManagedBoundary(projectId, scopeId);
+		db.prepare("UPDATE replication_scopes SET coordinator_id = ? WHERE scope_id = ?").run(
+			"https://coord.example.test",
+			scopeId,
+		);
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		for (const config of [
+			{
+				syncCoordinatorUrl: "https://coord.example.test",
+				syncCoordinatorAdminSecret: "secret",
+				syncCoordinatorGroups: ["other-group"],
+			},
+			{
+				syncCoordinatorUrl: "https://other.example.test",
+				syncCoordinatorAdminSecret: "secret",
+				syncCoordinatorGroups: ["group"],
+			},
+			{
+				syncCoordinatorUrl: "https://coord.example.test",
+				syncCoordinatorAdminSecret: "",
+				syncCoordinatorGroups: ["group"],
+			},
+		]) {
+			const effects = createRecipientPolicyReconcilerEffects(store, { config: config as never });
+			await expect(
+				effects.listBoundaryEnrollments({ canonicalProjectIdentity: projectId, scopeId }),
+			).rejects.toThrow("recipient_policy_effect_failed");
+		}
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
 
 	it("bounds work and isolates one Project failure from the next", async () => {
 		seedRecipientProject("project-a");
@@ -634,6 +822,9 @@ describe("recipient-policy maintenance", () => {
 					})),
 				};
 			}),
+			listBoundaryEnrollments: vi.fn(async () => [
+				{ deviceId: "device-revoked", identityId: `identity:${projectId}` },
+			]),
 			probeCapability: vi.fn(async () => "supported"),
 			revoke: vi.fn(async (input) => {
 				members.delete(input.deviceId);
@@ -760,6 +951,9 @@ describe("recipient-policy maintenance", () => {
 					memberships: deviceIds.map((deviceId) => ({ deviceId, status: "active" as const })),
 				};
 			}),
+			listBoundaryEnrollments: vi.fn(async () => [
+				{ deviceId: "device-recipient", identityId: `identity:${projectId}` },
+			]),
 			probeCapability: vi.fn(async () => "supported"),
 			revoke: vi.fn(async (input) => ({
 				effectId: input.effectId,


### PR DESCRIPTION
## Description
Reconciles active coordinator enrollment facts into owner policy before recipient-policy grants, with idempotent actor, device, Team-membership, and trusted-peer materialization.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced