### PR TITLE
fix(core): restore observer XML shape discipline

### DIFF
--- a/packages/core/src/ingest-prompts.test.ts
+++ b/packages/core/src/ingest-prompts.test.ts
@@ -48,7 +48,7 @@ describe("buildObserverPrompt", () => {
 		);
 	});
 
-	it("sets a per-observation worthiness bar and allows zero observations for routine sessions", () => {
+	it("uses the concise worthiness policy validated against the observer output schema", () => {
 		const { system } = buildObserverPrompt({
 			project: "codemem",
 			userPrompt: "Cut release 0.99.0",
@@ -61,19 +61,22 @@ describe("buildObserverPrompt", () => {
 			includeSummary: true,
 		});
 
-		expect(system).toContain("Observation worthiness bar");
+		expect(system).toContain("Observation worthiness policy:");
 		expect(system).toContain(
-			'"If a future session never reads this, will it repeat a mistake or re-derive something?"',
+			"Emit an <observation> only for a durable, reusable lesson such as a constraint, root cause, decision with rationale, or how-it-works insight.",
 		);
-		expect(system).toContain("Routine activity is NOT an observation");
-		expect(system).toContain("release/CI/pipeline status narration");
-		expect(system).toContain("review or validation passes that found no issues");
-		expect(system).toContain("context/docs lookups and their results");
-		expect(system).toContain("restating workflow policy already active in the session");
-		expect(system).toContain("bootstrap/setup narration");
 		expect(system).toContain(
-			"Emitting ZERO <observation> blocks with a normal <summary> is correct and common",
+			"When a durable lesson exists, emit it as an <observation>; do not leave it only in <summary>.",
 		);
+		expect(system).toContain(
+			"Routine status, review, setup, and workflow narration belongs only in <summary>.",
+		);
+		expect(system).toContain(
+			"Zero observations is valid when the session contains no durable lesson.",
+		);
+		// The long v0.38 policy destabilized XML shape across both gpt-5.4 tiers.
+		expect(system).not.toContain("If a future session never reads this");
+		expect(system).not.toContain("release/CI/pipeline status narration");
 		// The old quota forced observations out of routine sessions; it must stay gone.
 		expect(system).not.toContain("ALWAYS emit at least one <observation> block");
 		expect(system).not.toContain("Summary-only output is not sufficient for a rich session.");

--- a/packages/core/src/ingest-prompts.ts
+++ b/packages/core/src/ingest-prompts.ts
@@ -51,22 +51,11 @@ If nothing meaningful happened AND nothing was learned:
 - Output no <observation> blocks
 - Output <skip_summary reason="low-signal"/> instead of a <summary> block.`;
 
-const WORTHINESS_GUIDANCE = `Observation worthiness bar — an <observation> must record a durable lesson:
-a constraint, gotcha, root cause, decision with rationale, or how-something-works
-insight that changes how future work should be done.
-Before emitting an observation, ask: "If a future session never reads this, will it repeat a mistake or re-derive something?"
-If the answer is no, do not emit it — the <summary> already records what happened.
-
-Routine activity is NOT an observation, even when it succeeded and even when the
-session is long or busy. The following belong in the <summary> ONLY:
-- release/CI/pipeline status narration ("workflow is running/passed for tag X")
-- review or validation passes that found no issues
-- context/docs lookups and their results ("no repo-local context found; global standards used")
-- restating workflow policy already active in the session (delegation rules, review gates, commit conventions)
-- bootstrap/setup narration (agent init, plugin loading, workspace detection)
-
-Emitting ZERO <observation> blocks with a normal <summary> is correct and common
-for routine sessions (releases, review passes, dependency bumps, status checks).`;
+const WORTHINESS_GUIDANCE = `Observation worthiness policy:
+- Emit an <observation> only for a durable, reusable lesson such as a constraint, root cause, decision with rationale, or how-it-works insight.
+- When a durable lesson exists, emit it as an <observation>; do not leave it only in <summary>.
+- Routine status, review, setup, and workflow narration belongs only in <summary>.
+- Zero observations is valid when the session contains no durable lesson.`;
 
 const NARRATIVE_GUIDANCE = `Create narratives that tell the complete story:
 - Context: What was the problem or goal? What prompted this work?


### PR DESCRIPTION
## Description
Backports the validated observer worthiness prompt fix to the 0.39 maintenance line. Replaces the long, shape-destabilizing policy with concise guidance while preserving the existing XML schema and zero-observation behavior.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [ ] 🚀 Feature (new functionality)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Focused prompt tests: 5 passed. Full workspace gate: 2545 passed, 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced