### PR TITLE
fix(core): preserve observer output through repair

### DIFF
--- a/docs/plans/2026-07-28-pre-040-product-completion-design.md
+++ b/docs/plans/2026-07-28-pre-040-product-completion-design.md
@@ -1,0 +1,78 @@
+# Pre-0.40 product completion
+
+## Goal
+
+Reach a feature-complete, known-bug-free product state before starting the stable 0.40 release process. Release evaluation and attestation are deliberately outside the critical path until product correctness work is complete.
+
+## Current state
+
+- The recipient-policy and second-device provisioning stacks are merged on `main`.
+- Main CI, including the three-device Project-sharing scenario, is green.
+- Several product correctness fixes exist only in the separate release-evaluation worktree.
+- Three sharing lifecycle gaps remain tracked as `codemem-8x4i`, `codemem-97si`, and `codemem-10qd`.
+- Several older beads describe behavior already fixed by merged code and need evidence-based closure.
+
+## Approaches considered
+
+### Restack and merge the complete release-evaluation stack first
+
+This preserves the existing branch structure but puts roughly 13,000 lines of evaluation and release-gate work ahead of product bug fixes. It also couples product fixes to release policy that is not currently the priority.
+
+Rejected because it expands review scope and delays product correctness.
+
+### Extract product fixes into focused stacks
+
+Forward-port only the production-facing observer and embedding fixes onto current `main`, then complete sharing lifecycle behavior in one PR per tracked issue. The evaluation stack can later restack over the merged fixes and drop duplicate patches.
+
+Selected because each PR has a narrow behavior contract, independent validation, and a clear rollback boundary.
+
+### Defer the fixes until release preparation
+
+This keeps `main` unchanged but would knowingly enter release preparation with parser, onboarding-review, and stale-access gaps.
+
+Rejected because release preparation must validate a product candidate, not become the place where product behavior is finished.
+
+## Delivery structure
+
+### Stack 1: core correctness
+
+1. Forward-port observer correctness fixes:
+   - preserve the 0.39.1 XML prompt-shape fix on main;
+   - normalize observer prompt Unicode safely;
+   - retain valid observer content when XML shape repair is required;
+   - keep extraction replay behavior consistent with live ingestion.
+2. Validate embedding tensor conversion before accepting model output.
+
+These changes remain separate because observer parsing and embedding conversion have different failure modes and test surfaces.
+
+### Stack 2: sharing completion
+
+1. Reconcile disabled coordinator enrollments and revoke stale device access (`codemem-8x4i`).
+2. Carry the exact inherited Project set through add-device preview, signed intent, and recipient inspection (`codemem-97si`).
+3. Persist enrollment reconciliation issues with an actionable lifecycle (`codemem-10qd`).
+
+Each issue gets its own PR so security-sensitive revocation can land independently of review-state UX.
+
+## Safety rules
+
+- Enrollment and policy decisions fail closed.
+- Revocation is idempotent and does not affect unrelated devices.
+- Reviewed Project intent is bound to stable canonical Project identities.
+- Reconciliation issue persistence is additive and upgrade-safe.
+- Existing databases require no manual migration.
+- No private evaluation corpus or local artifact path enters the repository.
+
+## Validation
+
+Each PR runs focused tests plus the workspace gate. The completed product state must also pass:
+
+- fresh install and identity bootstrap;
+- direct Identity and Team sharing;
+- second-device onboarding and inherited Project review;
+- disabled-device revocation and convergence;
+- unrelated-Project isolation;
+- offline retry and recovery;
+- migration and older-peer compatibility;
+- packaged OpenCode, Claude, and Codex plugin smoke checks.
+
+After these checks pass, stale beads are closed or explicitly superseded. Stable 0.40 release preparation begins only after that backlog and dogfood review.

--- a/packages/core/src/extraction-replay.test.ts
+++ b/packages/core/src/extraction-replay.test.ts
@@ -43,7 +43,20 @@ describe("extraction replay", () => {
 				callCount += 1;
 				if (callCount === 1) {
 					return {
-						raw: "I found several useful threads, but this is not valid observer XML.",
+						raw: `<observation><type>decision</type><title>Track 3 reframed around injection-first quality<narrative>Track 3 was reframed to focus on injection-first quality while 0.23.0 release readiness was discussed as a near-term product pressure.</narrative><subtitle>Track 3 now targets rediscovery reduction.</subtitle><facts><fact>Track 3 was reframed around injection-first quality and rediscovery reduction for 0.23.0 release readiness.</fact></facts><concepts><concept>decision</concept></concepts><files_read><file>/tmp/repo/docs/plans/2026-04-07-track-3-injection-first-memory-policy.md</file></files_read><files_modified></files_modified></observation>
+						<observation><type>exploration</type><title>qd7h closure and graph direction<narrative>Graph and progressive disclosure ideas were captured as future work while qd7h closure confirmed the regression thread could be wrapped up.</narrative><subtitle>Graph relationship retrieval stayed exploratory.</subtitle><facts><fact>qd7h was closed after the root cause had already been identified, and graph progressive disclosure remained future-direction work.</fact></facts><concepts><concept>exploration</concept></concepts><files_read></files_read><files_modified></files_modified></observation>
+						<summary>
+						  <request>Preserve the reviewed batch.</request>
+						  <investigated>Reviewed the policy plan and discussed qd7h closure, release readiness, and graph future direction.</investigated>
+						  <completed>Reframed Track 3 around injection-first quality and captured graph direction as future work.</completed>
+						  <next_steps>Continue quality tuning and finish release readiness.</next_steps>
+						  <files_read><file>/tmp/repo/docs/plans/2026-04-07-track-3-injection-first-memory-policy.md</file></files_read>
+						</summary>
+						<summary>
+						  <request>Preserve the reviewed batch.</request>
+						  <learned>The batch contains durable lessons.</learned>
+						  <notes>Keep the summary broad across the major subthreads.</notes>
+						</summary>`,
 						parsed: null,
 						provider: "test",
 						model: "test-model",
@@ -59,7 +72,7 @@ describe("extraction replay", () => {
 				  <facts><fact>Track 3 was reframed around injection-first quality and rediscovery reduction for 0.23.0 release readiness.</fact></facts>
 				  <narrative>Track 3 was reframed to focus on injection-first quality while 0.23.0 release readiness was discussed as a near-term product pressure.</narrative>
 				  <concepts><concept>decision</concept></concepts>
-				  <files_read><file>docs/plans/2026-04-07-track-3-injection-first-memory-policy.md</file></files_read>
+				  <files_read><file>/tmp/repo/docs/plans/2026-04-07-track-3-injection-first-memory-policy.md</file></files_read>
 				  <files_modified></files_modified>
 				</observation>
 				<observation>
@@ -73,13 +86,13 @@ describe("extraction replay", () => {
 				  <files_modified></files_modified>
 				</observation>
 				<summary>
-				  <request>Investigate qd7h, prep 0.23.0, and reframe Track 3 around injection-first quality.</request>
+				  <request>Preserve the reviewed batch.</request>
 				  <investigated>Reviewed the policy plan and discussed qd7h closure, release readiness, and graph future direction.</investigated>
-				  <learned>qd7h could be closed, 0.23.0 readiness mattered, and graph work should remain future-facing.</learned>
+				  <learned>The batch contains durable lessons.</learned>
 				  <completed>Reframed Track 3 around injection-first quality and captured graph direction as future work.</completed>
 				  <next_steps>Continue quality tuning and finish release readiness.</next_steps>
 				  <notes>Keep the summary broad across the major subthreads.</notes>
-				  <files_read><file>docs/plans/2026-04-07-track-3-injection-first-memory-policy.md</file></files_read>
+				  <files_read><file>/tmp/repo/docs/plans/2026-04-07-track-3-injection-first-memory-policy.md</file></files_read>
 				  <files_modified></files_modified>
 				</summary>`,
 					parsed: null,
@@ -102,7 +115,6 @@ describe("extraction replay", () => {
 			batchId: 18503,
 			scenarioId: "rich-session-under-extraction",
 		});
-
 		expect(result.target).toEqual({ batchId: 18503, sessionId: 166405 });
 		expect(result.classification.status).toBe("pass");
 		expect(result.evaluation.target).toEqual({ type: "batch", sessionId: 166405, batchId: 18503 });
@@ -114,7 +126,9 @@ describe("extraction replay", () => {
 		expect(result.observer.transport).toBe("codex_consumer");
 		expect(result.observer.modelFallbackApplied).toBe(false);
 		expect(result.observer.repairApplied).toBe(true);
-		expect(result.observer.initialRaw).toContain("not valid observer XML");
+		expect(result.observer.initialRaw).toContain(
+			"<observation><type>decision</type><title>Track 3 reframed",
+		);
 		expect(result.observer.raw).toContain("<observation>");
 		expect(result.initialEvaluation.counts.observations).toBe(0);
 		expect(result.initialEvaluation.pass).toBe(false);
@@ -122,7 +136,7 @@ describe("extraction replay", () => {
 		expect(result.repairedClassification?.status).toBe("pass");
 		expect(result.observer.repairedDiagnostics?.dataLoss).toBe(false);
 		expect(result.observer.initialDiagnostics).toMatchObject({
-			recognizedOutput: false,
+			recognizedOutput: true,
 			dataLoss: true,
 		});
 		expect(result.observer.totalElapsedMs).toBe(32);
@@ -135,6 +149,138 @@ describe("extraction replay", () => {
 		expect(result.observerContext.userPrompt).toContain("Track 3");
 		expect(result.evaluation.coverage.totalThreadCoverage).toBeGreaterThanOrEqual(3);
 		expect(result.evaluation.pass).toBe(true);
+	});
+
+	it("uses initial diagnostics when a clean but disjoint repair is rejected", async () => {
+		const dbPath = createDbPath("extraction-replay-rejected-repair");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (166406, '2026-04-06T21:23:59.631Z', '2026-04-07T06:13:45.667Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"post":{"session_class":"durable","summary_disposition":"stored"}}');
+				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+				  ('opencode', 'ses-2', 'ses-2', 166406, '2026-04-06T21:23:59.631Z');
+				INSERT INTO raw_event_flush_batches(id, source, stream_id, opencode_session_id, start_event_seq, end_event_seq, extractor_version, status, attempt_count, created_at, updated_at) VALUES
+				  (18504, 'opencode', 'ses-2', 'ses-2', 1, 1, 'raw_events_v1', 'completed', 1, '2026-04-07T06:13:45.600Z', '2026-04-07T06:13:45.700Z');
+				INSERT INTO raw_events(id, source, stream_id, opencode_session_id, event_id, event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, created_at) VALUES
+				  (4, 'opencode', 'ses-2', 'ses-2', 'evt-4', 1, 'user_prompt', 1000, 1, '{"type":"user_prompt","prompt_text":"Preserve valid replay content"}', '2026-04-07T06:13:45.600Z');
+			`);
+		} finally {
+			db.close();
+		}
+
+		let callCount = 0;
+		const observer = {
+			observe: async () => {
+				callCount += 1;
+				return {
+					raw:
+						callCount === 1
+							? `<observation><type>discovery</type><title>Retained replay lesson</title><narrative>Keep this observation.</narrative></observation><observation><type>discovery</type><title>Truncated`
+							: `<observation><type>discovery</type><title>Different repaired lesson</title><narrative>This omits the retained observation.</narrative></observation>`,
+					parsed: null,
+					provider: "test",
+					model: "test-model",
+				};
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		} as unknown as ObserverClient;
+
+		const result = await replayBatchExtraction(dbPath, observer, {
+			batchId: 18504,
+			scenarioId: "rich-session-under-extraction",
+		});
+
+		expect(callCount).toBe(2);
+		expect(result.observer.raw).toContain("Retained replay lesson");
+		expect(result.observer.parsed.observations[0]?.title).toBe("Retained replay lesson");
+		expect(result.observer.diagnostics).toEqual(result.observer.initialDiagnostics);
+		expect(result.observer.diagnostics.dataLoss).toBe(true);
+		expect(result.observer.repairedDiagnostics?.dataLoss).toBe(false);
+	});
+
+	it("retains usable initial replay output when the repair call throws", async () => {
+		const dbPath = createDbPath("extraction-replay-repair-error");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (166408, '2026-04-06T21:23:59.631Z', '2026-04-07T06:13:45.667Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"post":{"session_class":"durable","summary_disposition":"stored"}}');
+				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+				  ('opencode', 'ses-repair-error', 'ses-repair-error', 166408, '2026-04-06T21:23:59.631Z');
+				INSERT INTO raw_event_flush_batches(id, source, stream_id, opencode_session_id, start_event_seq, end_event_seq, extractor_version, status, attempt_count, created_at, updated_at) VALUES
+				  (18506, 'opencode', 'ses-repair-error', 'ses-repair-error', 1, 1, 'raw_events_v1', 'completed', 1, '2026-04-07T06:13:45.600Z', '2026-04-07T06:13:45.700Z');
+				INSERT INTO raw_events(id, source, stream_id, opencode_session_id, event_id, event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, created_at) VALUES
+				  (23, 'opencode', 'ses-repair-error', 'ses-repair-error', 'evt-23', 1, 'user_prompt', 1000, 1, '{"type":"user_prompt","prompt_text":"Preserve replay output after a repair error"}', '2026-04-07T06:13:45.600Z');
+			`);
+		} finally {
+			db.close();
+		}
+
+		let callCount = 0;
+		let observerStatus = {
+			provider: "test",
+			model: "requested-sidecar-model",
+			runtime: "claude_sidecar",
+			auth: { source: "none", type: "claude_sidecar", hasToken: false },
+			actualModel: "requested-sidecar-model",
+			modelFallbackApplied: false,
+			modelFallbackReason: null as string | null,
+		};
+		const observer = {
+			model: "requested-sidecar-model",
+			requestedModel: "requested-sidecar-model",
+			observe: async () => {
+				callCount += 1;
+				if (callCount === 2) {
+					observerStatus = {
+						...observerStatus,
+						actualModel: "requested-sidecar-model",
+						modelFallbackApplied: false,
+						modelFallbackReason: null,
+					};
+					throw new Error("repair transport failed");
+				}
+				observerStatus = {
+					...observerStatus,
+					model: "fallback-sidecar-model",
+					actualModel: "fallback-sidecar-model",
+					modelFallbackApplied: true,
+					modelFallbackReason: "requested model unavailable",
+				};
+				return {
+					raw: `<observation><type>discovery</type><title>Retained replay result</title><narrative>Keep this usable initial observation.</narrative></observation><observation><type>bugfix</type><title>Truncated`,
+					parsed: null,
+					provider: "test",
+					model: "fallback-sidecar-model",
+				};
+			},
+			getStatus: () => observerStatus,
+		} as unknown as ObserverClient;
+
+		const result = await replayBatchExtraction(dbPath, observer, {
+			batchId: 18506,
+			scenarioId: "rich-session-under-extraction",
+		});
+
+		expect(callCount).toBe(2);
+		expect(result.observer.repairApplied).toBe(false);
+		expect(result.observer.raw).toContain("Retained replay result");
+		expect(result.observer.parsed.observations[0]?.title).toBe("Retained replay result");
+		expect(result.observer.repairedRaw).toBeNull();
+		expect(result.observer.repairedDiagnostics).toBeNull();
+		expect(result.observer.diagnostics).toEqual(result.observer.initialDiagnostics);
+		expect(result.observer.requestedModel).toBe("requested-sidecar-model");
+		expect(result.observer.resolvedModel).toBe("fallback-sidecar-model");
+		expect(result.observer.modelFallbackApplied).toBe(true);
+		expect(result.observer.modelFallbackReason).toBe("requested model unavailable");
 	});
 
 	it("does not repair a rich result when observation count is its only potential failure", async () => {

--- a/packages/core/src/extraction-replay.ts
+++ b/packages/core/src/extraction-replay.ts
@@ -13,7 +13,11 @@ import {
 	projectAdapterToolEvent,
 } from "./ingest-events.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
-import { buildObserverPrompt, truncateObserverTranscript } from "./ingest-prompts.js";
+import {
+	buildObserverPrompt,
+	buildObserverRepairPrompt,
+	truncateObserverTranscript,
+} from "./ingest-prompts.js";
 import {
 	buildTranscript,
 	deriveRequest,
@@ -31,11 +35,17 @@ import type {
 	SessionContext,
 	ToolEvent,
 } from "./ingest-types.js";
-import { parseObserverResponse, SUPPORTED_OBSERVATION_KINDS } from "./ingest-xml-parser.js";
+import {
+	parseObserverResponse,
+	SUPPORTED_OBSERVATION_KINDS,
+	shouldPreferRepairedObserverResponse,
+	shouldRepairObserverResponse,
+} from "./ingest-xml-parser.js";
 import {
 	type ObserverClient,
 	ObserverClient as ObserverClientImpl,
 	type ObserverConfig,
+	type ObserverStatus,
 	type ObserverTokenUsage,
 } from "./observer-client.js";
 import { resolveProject } from "./project.js";
@@ -53,6 +63,15 @@ function normalizePath(path: string, repoRoot: string | null): string {
 
 function normalizePaths(paths: string[], repoRoot: string | null): string[] {
 	return paths.map((p) => normalizePath(p, repoRoot)).filter(Boolean);
+}
+
+function snapshotObserverStatus(observer: ObserverClient): ObserverStatus {
+	const status = observer.getStatus();
+	return {
+		...status,
+		auth: { ...status.auth },
+		...(status.lastError ? { lastError: { ...status.lastError } } : {}),
+	};
 }
 
 function summaryBody(summary: ParsedSummary): string {
@@ -105,6 +124,7 @@ async function observeStructuredOutput(
 		model: string;
 		elapsedMs: number | null;
 		usage: ObserverTokenUsage | null;
+		status: ObserverStatus;
 	};
 	repaired: {
 		raw: string | null;
@@ -113,6 +133,7 @@ async function observeStructuredOutput(
 		model: string;
 		elapsedMs: number | null;
 		usage: ObserverTokenUsage | null;
+		status: ObserverStatus;
 	} | null;
 }> {
 	const first = await observer.observe(system, user);
@@ -126,19 +147,24 @@ async function observeStructuredOutput(
 		model: first.model,
 		elapsedMs: first.elapsedMs ?? null,
 		usage: first.usage ?? null,
+		status: snapshotObserverStatus(observer),
 	};
-	if (
-		!first.raw ||
-		firstParsed.observations.length > 0 ||
-		firstParsed.summary !== null ||
-		firstParsed.skipSummaryReason !== null
-	) {
+	if (!shouldRepairObserverResponse(first.raw, firstParsed)) {
 		return { initial, repaired: null };
 	}
 
-	const repairSystem = `${system}\n\nYour previous reply was invalid because it did not follow the required XML-only schema. Rewrite the same analysis as valid XML only. Do not include prose outside XML.`;
-	const repairUser = `${user}\n\nPrevious invalid response to rewrite as valid XML:\n${first.raw}`;
-	const repaired = await observer.observe(repairSystem, repairUser);
+	const repairPrompt = buildObserverRepairPrompt(
+		system,
+		user,
+		first.raw as string,
+		observer.maxChars,
+	);
+	let repaired: Awaited<ReturnType<ObserverClient["observe"]>>;
+	try {
+		repaired = await observer.observe(repairPrompt.system, repairPrompt.user);
+	} catch {
+		return { initial, repaired: null };
+	}
 	const repairedParsed = repaired.raw
 		? parseObserverResponse(repaired.raw)
 		: { observations: [], summary: null, skipSummaryReason: null };
@@ -151,6 +177,7 @@ async function observeStructuredOutput(
 			model: repaired.model,
 			elapsedMs: repaired.elapsedMs ?? null,
 			usage: repaired.usage ?? null,
+			status: snapshotObserverStatus(observer),
 		},
 	};
 }
@@ -354,9 +381,11 @@ function buildReplayItems(
 		});
 	}
 	if (parsed.summary && !parsed.skipSummaryReason) {
-		const summary = parsed.summary;
-		summary.filesRead = normalizePaths(summary.filesRead, batch.cwd);
-		summary.filesModified = normalizePaths(summary.filesModified, batch.cwd);
+		const summary = {
+			...parsed.summary,
+			filesRead: normalizePaths(parsed.summary.filesRead, batch.cwd),
+			filesModified: normalizePaths(parsed.summary.filesModified, batch.cwd),
+		};
 		let request = summary.request;
 		if (isTrivialRequest(request)) {
 			const derived = deriveRequest(summary);
@@ -607,11 +636,6 @@ async function replayPreparedBatch(
 	const configuredModel = observer.requestedModel ?? observer.model;
 	const response = await observeStructuredOutput(observer, prepared.system, prepared.user);
 	const requestedModel = configuredModel || response.initial.model;
-	const observerStatus = observer.getStatus();
-	const modelFallbackApplied = observerStatus.modelFallbackApplied === true;
-	const resolvedModel = modelFallbackApplied
-		? (observerStatus.actualModel ?? null)
-		: (observerStatus.actualModel ?? response.initial.model);
 	const session = {
 		id: prepared.batch.session_id,
 		project: prepared.batch.project,
@@ -640,8 +664,25 @@ async function replayPreparedBatch(
 				prepared.scenario,
 			)
 		: null;
-	const finalResponse = response.repaired ?? response.initial;
-	const evaluation = repairedEvaluation ?? initialEvaluation;
+	const preferRepaired = response.repaired
+		? shouldPreferRepairedObserverResponse(
+				response.initial.parsed,
+				response.repaired.raw,
+				response.repaired.parsed,
+				response.initial.raw,
+			)
+		: false;
+	const finalResponse = preferRepaired
+		? (response.repaired as NonNullable<typeof response.repaired>)
+		: response.initial;
+	const observerStatus = finalResponse.status;
+	const modelFallbackApplied = observerStatus.modelFallbackApplied === true;
+	const resolvedModel = modelFallbackApplied
+		? (observerStatus.actualModel ?? null)
+		: (observerStatus.actualModel ?? finalResponse.model);
+	const evaluation = preferRepaired
+		? (repairedEvaluation as NonNullable<typeof repairedEvaluation>)
+		: initialEvaluation;
 	const initialClassification = classifyReplayResult({
 		raw: response.initial.raw,
 		evaluation: initialEvaluation,
@@ -659,15 +700,15 @@ async function replayPreparedBatch(
 	const repairedDiagnostics = response.repaired
 		? evaluateExtractionStructure(response.repaired.raw ?? "", response.repaired.parsed)
 		: null;
-	const repairApplied = response.repaired !== null;
+	const repairAttempted = response.repaired !== null;
 	const totalElapsedMs =
-		response.initial.elapsedMs != null && (!repairApplied || response.repaired?.elapsedMs != null)
+		response.initial.elapsedMs != null && (!repairAttempted || response.repaired?.elapsedMs != null)
 			? response.initial.elapsedMs + (response.repaired?.elapsedMs ?? 0)
 			: null;
 	const totalUsage = sumObserverUsage(
 		response.initial.usage,
 		response.repaired?.usage ?? null,
-		repairApplied,
+		repairAttempted,
 	);
 	const transport =
 		observerStatus.auth.type === "codex_consumer" ||
@@ -703,7 +744,7 @@ async function replayPreparedBatch(
 			reasoningSummary: observer.reasoningSummary,
 			maxOutputTokens: observer.maxOutputTokens,
 			temperature: observer.temperature,
-			repairApplied,
+			repairApplied: preferRepaired,
 			initialRaw: response.initial.raw,
 			initialElapsedMs: response.initial.elapsedMs,
 			initialUsage: response.initial.usage,
@@ -718,7 +759,9 @@ async function replayPreparedBatch(
 			totalElapsedMs,
 			totalUsage,
 			parsed: finalResponse.parsed,
-			diagnostics: repairedDiagnostics ?? initialDiagnostics,
+			diagnostics: preferRepaired
+				? (repairedDiagnostics as NonNullable<typeof repairedDiagnostics>)
+				: initialDiagnostics,
 		},
 		observerContext: prepared.observerContext,
 		initialClassification,

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -30,6 +30,8 @@ import {
 	hasMeaningfulObservation,
 	inspectObserverResponseStructure,
 	parseObserverResponse,
+	shouldPreferRepairedObserverResponse,
+	shouldRepairObserverResponse,
 } from "./ingest-xml-parser.js";
 import type { ObserverConfig } from "./observer-client.js";
 import { flushRawEvents } from "./raw-event-flush.js";
@@ -315,6 +317,60 @@ describe("ingest-xml-parser", () => {
 			expect(result.observations).toHaveLength(0);
 			expect(result.summary).toBeNull();
 			expect(result.skipSummaryReason).toBe("low-signal");
+			expect(parseObserverResponse('<skip_summary reason="paired"></skip_summary>')).toMatchObject({
+				skipSummaryReason: "paired",
+			});
+			const unspecified = parseObserverResponse("<skip_summary/>");
+			expect(unspecified).toMatchObject({
+				skipSummaryReason: null,
+			});
+			expect(inspectObserverResponseStructure("<skip_summary/>", unspecified).dataLoss).toBe(true);
+			expect(shouldRepairObserverResponse("<skip_summary/>", unspecified)).toBe(true);
+			const labeledRepair = '<skip_summary reason="low-signal"/>';
+			expect(
+				shouldPreferRepairedObserverResponse(
+					unspecified,
+					labeledRepair,
+					parseObserverResponse(labeledRepair),
+					"<skip_summary/>",
+				),
+			).toBe(true);
+		});
+
+		it("reports contradictory summary decisions as data loss", () => {
+			const xml = `<summary><request>Keep this summary</request></summary>
+				<skip_summary reason="low-signal"></skip_summary>`;
+			const parsed = parseObserverResponse(xml);
+
+			expect(parsed.summary?.request).toBe("Keep this summary");
+			expect(parsed.skipSummaryReason).toBe("low-signal");
+			expect(inspectObserverResponseStructure(xml, parsed).dataLoss).toBe(true);
+			expect(shouldRepairObserverResponse(xml, parsed)).toBe(true);
+
+			const repaired = `<summary><request>Keep this summary</request></summary>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parsed,
+					repaired,
+					parseObserverResponse(repaired),
+					xml,
+				),
+			).toBe(true);
+		});
+
+		it("allows a validated recovered summary to replace a skip marker", () => {
+			const lossy = `<skip_summary reason="low-signal"/>
+				<summary><request>Fix auth`;
+			const repaired = `<summary><request>Fix auth safely</request></summary>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					repaired,
+					parseObserverResponse(repaired),
+					lossy,
+				),
+			).toBe(true);
 		});
 
 		it("handles empty/malformed XML gracefully", () => {
@@ -430,10 +486,1354 @@ describe("ingest-xml-parser", () => {
 		});
 
 		it("reports plain prose as unrecognized lossy output", () => {
-			const result = inspectObserverResponseStructure("I found a durable lesson.");
+			const prose = "I found a durable auth lesson in src/auth.ts.";
+			const result = inspectObserverResponseStructure(prose);
+			const groundedRepair = `<observation>
+				<type>discovery</type>
+				<title>durable auth lesson</title>
+				<subtitle>durable auth lesson</subtitle>
+				<narrative>I found a durable auth lesson in src/auth.ts.</narrative>
+				<facts><fact>durable auth lesson</fact></facts>
+				<concepts><concept>how-it-works</concept></concepts>
+				<files_read><file>src/auth.ts</file></files_read>
+			</observation>
+			<summary><learned>I found a durable auth lesson in src/auth.ts.</learned></summary>`;
+			const embellishedRepair = groundedRepair.replace(
+				"durable auth lesson</fact>",
+				"Deployed the fix</fact>",
+			);
+			const negatedProse = "I did not find a durable auth issue.";
+			const negationDroppingRepair = `<observation>
+				<type>discovery</type><title>find a durable auth issue</title>
+				<narrative>I did not find a durable auth issue.</narrative>
+			</observation><summary><investigated>I did not find a durable auth issue.</investigated></summary>`;
+			const fabricatedSummaryRepair = groundedRepair.replace(
+				"</summary>",
+				"<completed>Deployed the fix</completed></summary>",
+			);
+			const duplicateRepair = groundedRepair.replace(
+				"</observation>",
+				`</observation>
+				<observation><type>discovery</type><title>durable auth lesson</title>
+				<narrative>I found a durable auth lesson in src/auth.ts.</narrative></observation>`,
+			);
+			const summaryOnlyRepair = `<summary><learned>I found a durable auth lesson in src/auth.ts.</learned></summary>`;
+			const skipRepair = `<skip_summary reason="low-signal"/>`;
+			const observationWithoutSummary = groundedRepair.replace(
+				"<summary><learned>I found a durable auth lesson in src/auth.ts.</learned></summary>",
+				"",
+			);
+			const unsupportedConceptRepair = groundedRepair.replace("how-it-works", "discovery");
+			const partialPathRepair = groundedRepair.replace("<file>src/auth.ts", "<file>auth.ts");
+			const contractionProse = "The retry path doesn't recover the batch.";
+			const contractionRepair = `<observation><type>discovery</type><title>recover the batch</title>
+				<narrative>The retry path doesn't recover the batch.</narrative></observation>
+				<summary><learned>The retry path doesn't recover the batch.</learned></summary>`;
+			const prefixedProse = "This is a non-blocking issue.";
+			const prefixedRepair = `<observation><type>discovery</type><title>blocking issue</title>
+				<narrative>This is a non-blocking issue.</narrative></observation>
+				<summary><learned>This is a non-blocking issue.</learned></summary>`;
+			const entityProse = "Fixed the R&D pipeline.";
+			const entityRepair = `<summary><completed>Fixed the R&amp;D pipeline.</completed></summary>`;
 
 			expect(result.recognizedOutput).toBe(false);
 			expect(result.dataLoss).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(prose),
+					groundedRepair,
+					parseObserverResponse(groundedRepair),
+					prose,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(entityProse),
+					entityRepair,
+					parseObserverResponse(entityRepair),
+					entityProse,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(prose),
+					summaryOnlyRepair,
+					parseObserverResponse(summaryOnlyRepair),
+					prose,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(prose),
+					skipRepair,
+					parseObserverResponse(skipRepair),
+					prose,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse("Okay."),
+					skipRepair,
+					parseObserverResponse(skipRepair),
+					"Okay.",
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(prose),
+					embellishedRepair,
+					parseObserverResponse(embellishedRepair),
+					prose,
+				),
+			).toBe(false);
+			for (const ungrounded of [
+				fabricatedSummaryRepair,
+				duplicateRepair,
+				observationWithoutSummary,
+				unsupportedConceptRepair,
+				partialPathRepair,
+			]) {
+				expect(
+					shouldPreferRepairedObserverResponse(
+						parseObserverResponse(prose),
+						ungrounded,
+						parseObserverResponse(ungrounded),
+						prose,
+					),
+				).toBe(false);
+			}
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(negatedProse),
+					negationDroppingRepair,
+					parseObserverResponse(negationDroppingRepair),
+					negatedProse,
+				),
+			).toBe(false);
+			for (const [source, repair] of [
+				[contractionProse, contractionRepair],
+				[prefixedProse, prefixedRepair],
+			] as const) {
+				expect(
+					shouldPreferRepairedObserverResponse(
+						parseObserverResponse(source),
+						repair,
+						parseObserverResponse(repair),
+						source,
+					),
+				).toBe(false);
+			}
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(" "),
+					summaryOnlyRepair,
+					parseObserverResponse(summaryOnlyRepair),
+					" ",
+				),
+			).toBe(false);
+		});
+
+		it("rejects repairs that drop prose surrounding malformed XML", () => {
+			const initial = `Auth race fixed
+				<observation><type>bugfix</type><title>Recovered title`;
+			const reducedRepair = `<observation><type>bugfix</type><title>Recovered title</title>
+				<narrative>Recovered title</narrative></observation>
+				<summary><completed>Recovered title</completed></summary>`;
+			const preservingRepair = reducedRepair
+				.replace(
+					"<narrative>Recovered title</narrative>",
+					"<narrative>Auth race fixed. Recovered title</narrative>",
+				)
+				.replace(
+					"<completed>Recovered title</completed>",
+					"<completed>Auth race fixed</completed>",
+				);
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					reducedRepair,
+					parseObserverResponse(reducedRepair),
+					initial,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					preservingRepair,
+					parseObserverResponse(preservingRepair),
+					initial,
+				),
+			).toBe(true);
+		});
+
+		it("rejects ungrounded fields added while repairing a truncated observation", () => {
+			const initial = `<observation><type>bugfix</type><title>Recovered title`;
+			const inventedRepair = `<observation><type>bugfix</type><title>Recovered title</title>
+				<narrative>Invented deployment result</narrative>
+				<facts><fact>Invented fact</fact></facts>
+				<concepts><concept>gotcha</concept></concepts>
+				<files_modified><file>src/invented.ts</file></files_modified></observation>
+				<summary><completed>Invented deployment result</completed></summary>`;
+			const groundedRepair = `<observation><type>bugfix</type><title>Recovered title</title>
+				<narrative>Recovered title</narrative></observation>
+				<summary><completed>Recovered title</completed></summary>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					inventedRepair,
+					parseObserverResponse(inventedRepair),
+					initial,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					groundedRepair,
+					parseObserverResponse(groundedRepair),
+					initial,
+				),
+			).toBe(true);
+
+			const prefixedInitial = `<observation><type>discovery</type><title>Findings</title>
+				<narrative>This is a non-blocking issue in src/auth.ts</narrative>`;
+			const prefixDroppingRepair = `<observation><type>discovery</type><title>Findings</title>
+				<subtitle>blocking issue</subtitle>
+				<narrative>This is a non-blocking issue in src/auth.ts</narrative></observation>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(prefixedInitial),
+					prefixDroppingRepair,
+					parseObserverResponse(prefixDroppingRepair),
+					prefixedInitial,
+				),
+			).toBe(false);
+
+			const fabricatedSummaryRepair = groundedRepair.replace(
+				"<completed>Recovered title</completed>",
+				"<completed>Invented deployment result</completed>",
+			);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					fabricatedSummaryRepair,
+					parseObserverResponse(fabricatedSummaryRepair),
+					initial,
+				),
+			).toBe(false);
+		});
+
+		it("grounds repairs against visible text inside unrecognized XML roots", () => {
+			const initial = `<result>Auth race fixed</result>`;
+			const groundedRepair = `<summary><completed>Auth race fixed</completed></summary>`;
+			const unrelatedRepair = `<summary><completed>Deployed unrelated fix</completed></summary>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					groundedRepair,
+					parseObserverResponse(groundedRepair),
+					initial,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					unrelatedRepair,
+					parseObserverResponse(unrelatedRepair),
+					initial,
+				),
+			).toBe(false);
+		});
+
+		it("requests repair for malformed children in retained root blocks", () => {
+			const malformed = `<observation><type>discovery</type><title>Durable title
+				<narrative>Durable narrative</narrative></observation>`;
+			const parsed = parseObserverResponse(malformed);
+
+			expect(parsed.observations).toHaveLength(1);
+			expect(parsed.observations[0]?.title).toBe("");
+			expect(inspectObserverResponseStructure(malformed, parsed).dataLoss).toBe(true);
+			expect(shouldRepairObserverResponse(malformed, parsed)).toBe(true);
+		});
+
+		it("requests repair for parser data loss but not retained shape-only nesting", () => {
+			const lossy = `<summary><request>Preserve the result</request><notes><observation></notes></summary>`;
+			const retained = `<summary><request>Preserve the result</request><notes>
+				<observation><type>discovery</type><title>Retained lesson</title></observation>
+			</notes></summary>`;
+			const repaired = `<observation><type>discovery</type><title>Repaired lesson</title></observation>
+				<summary><request>Preserve the result</request></summary>`;
+			const thinnerRepair = `<summary><request>Preserve the result</request></summary>`;
+			const empty = { observations: [], summary: null, skipSummaryReason: null };
+
+			expect(shouldRepairObserverResponse(lossy, parseObserverResponse(lossy))).toBe(true);
+			expect(shouldRepairObserverResponse(retained, parseObserverResponse(retained))).toBe(false);
+			expect(shouldRepairObserverResponse(" ", parseObserverResponse(" "))).toBe(true);
+			expect(shouldRepairObserverResponse(null, empty)).toBe(false);
+			expect(shouldPreferRepairedObserverResponse(parseObserverResponse(lossy), null, empty)).toBe(
+				false,
+			);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					repaired,
+					parseObserverResponse(repaired),
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					lossy,
+					parseObserverResponse(lossy),
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(retained),
+					thinnerRepair,
+					parseObserverResponse(thinnerRepair),
+				),
+			).toBe(false);
+		});
+
+		it("rejects clean repairs that drop retained observations or populated summary fields", () => {
+			const retainedObservation = `<observation>
+				<type>discovery</type><title>Retained lesson</title>
+				<narrative>Keep this exact parsed observation.</narrative>
+			</observation>`;
+			const replacementObservation = `<observation>
+				<type>discovery</type><title>Replacement lesson</title>
+				<narrative>This must not replace the retained lesson.</narrative>
+			</observation>`;
+			const initial = `${retainedObservation}
+				<summary><request>Preserve the result</request><learned>Durable detail</learned></summary>`;
+			const disjointRepair = `${replacementObservation}
+				<summary><request>Preserve the result</request><learned>Different detail</learned></summary>`;
+			const incompleteSummaryRepair = `${retainedObservation}
+				<summary><request>Preserve the result</request></summary>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					disjointRepair,
+					parseObserverResponse(disjointRepair),
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					incompleteSummaryRepair,
+					parseObserverResponse(incompleteSummaryRepair),
+				),
+			).toBe(false);
+		});
+
+		it("matches retained observation lists as order-insensitive multisets", () => {
+			const retained = `<observation><type>discovery</type><title>Retained lesson</title>
+				<facts><fact>First fact</fact><fact>Second fact</fact></facts>
+				<concepts><concept>gotcha</concept><concept>pattern</concept></concepts>
+				<files_read><file>src/a.ts</file><file>src/b.ts</file></files_read>
+			</observation>`;
+			const initial = `${retained}<observation><type>decision</type><title>Recovered decision`;
+			const reordered = retained
+				.replace(
+					"<fact>First fact</fact><fact>Second fact</fact>",
+					"<fact>Second fact</fact><fact>First fact</fact>",
+				)
+				.replace(
+					"<concept>gotcha</concept><concept>pattern</concept>",
+					"<concept>pattern</concept><concept>gotcha</concept>",
+				)
+				.replace(
+					"<file>src/a.ts</file><file>src/b.ts</file>",
+					"<file>src/b.ts</file><file>src/a.ts</file>",
+				);
+			const repair = `${reordered}<observation><type>decision</type><title>Recovered decision</title></observation>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					repair,
+					parseObserverResponse(repair),
+					initial,
+				),
+			).toBe(true);
+		});
+
+		it("rejects clean repairs that rewrite populated summary content", () => {
+			const observation = `<observation>
+				<type>discovery</type><title>Retained lesson</title>
+				<narrative>Keep this exact parsed observation.</narrative>
+			</observation>`;
+			const initial = `${observation}<summary>
+				<request>Preserve the result</request>
+				<files_read><file>src/retained.ts</file></files_read>
+			</summary>`;
+			const rewrittenScalar = initial.replace("Preserve the result", "Replace the result");
+			const rewrittenList = initial.replace("src/retained.ts", "src/replacement.ts");
+			const introducedSkip = `${initial}<skip_summary reason="low-signal"/>`;
+			const duplicateInitial = initial.replace(
+				"<file>src/retained.ts</file>",
+				"<file>src/retained.ts</file><file>src/retained.ts</file>",
+			);
+
+			for (const repair of [rewrittenScalar, rewrittenList, introducedSkip]) {
+				expect(
+					shouldPreferRepairedObserverResponse(
+						parseObserverResponse(initial),
+						repair,
+						parseObserverResponse(repair),
+					),
+				).toBe(false);
+			}
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(duplicateInitial),
+					initial,
+					parseObserverResponse(initial),
+				),
+			).toBe(false);
+		});
+
+		it("accepts repairs that only correct an invalid observation kind", () => {
+			const unsupported = `<observation>
+				<type>unsupported</type><title>Durable lesson</title>
+				<narrative>Preserve every field while correcting the kind.</narrative>
+			</observation>`;
+			const missing = `<observation>
+				<title>Durable lesson</title>
+				<narrative>Preserve every field while correcting the kind.</narrative>
+			</observation>`;
+			const repaired = `<observation>
+				<type>discovery</type><title>Durable lesson</title>
+				<narrative>Preserve every field while correcting the kind.</narrative>
+			</observation>`;
+			const alreadyValid = unsupported.replace("unsupported", "decision");
+			const repairedParsed = parseObserverResponse(repaired);
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unsupported),
+					repaired,
+					repairedParsed,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(missing),
+					repaired,
+					repairedParsed,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(alreadyValid),
+					repaired,
+					repairedParsed,
+				),
+			).toBe(false);
+		});
+
+		it("rejects repairs that preserve parsed items but omit discarded observation blocks", () => {
+			const retained = `<observation>
+				<type>discovery</type><title>Retained lesson</title>
+				<narrative>Keep this observation.</narrative>
+			</observation>`;
+			const lossy = `${retained}<observation>
+				<type>bugfix</type><title>Discarded fix</title>
+				<narrative>Recover this truncated observation.`;
+			const unrelatedRepair = `${retained}<observation>
+				<type>bugfix</type><title>Unrelated clean item</title>
+				<narrative>This does not recover the discarded fix.</narrative>
+			</observation>`;
+			const faithfulRepair = `${retained}<observation>
+				<type>bugfix</type><title>Discarded fix</title>
+				<narrative>Recover this truncated observation.</narrative>
+			</observation>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					retained,
+					parseObserverResponse(retained),
+					lossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					unrelatedRepair,
+					parseObserverResponse(unrelatedRepair),
+					lossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					faithfulRepair,
+					parseObserverResponse(faithfulRepair),
+					lossy,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					`${retained}${retained}`,
+					parseObserverResponse(`${retained}${retained}`),
+					lossy,
+				),
+			).toBe(false);
+
+			const twoDiscarded = `${lossy}<observation>
+				<type>decision</type><title>Second discarded item`;
+			const recoveredOnce = `<observation>
+				<type>bugfix</type><title>Recovered fix</title>
+				<narrative>Only one discarded block was actually recovered.</narrative>
+			</observation>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(twoDiscarded),
+					`${retained}${recoveredOnce}${recoveredOnce}`,
+					parseObserverResponse(`${retained}${recoveredOnce}${recoveredOnce}`),
+					twoDiscarded,
+				),
+			).toBe(false);
+		});
+
+		it("allows recovered structured output to replace a contradictory skip marker", () => {
+			const lossy = `<skip_summary reason="low-signal"/><observation>
+				<type>discovery</type><title>Recovered lesson`;
+			const repaired = `<observation>
+				<type>discovery</type><title>Recovered lesson</title>
+				<narrative>Recovered lesson</narrative>
+			</observation>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					repaired,
+					parseObserverResponse(repaired),
+					lossy,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					`${repaired}<skip_summary reason="rewritten"/>`,
+					parseObserverResponse(`${repaired}<skip_summary reason="rewritten"/>`),
+					lossy,
+				),
+			).toBe(false);
+
+			const summaryRepair = `<summary><request>Recovered summary only</request></summary>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(`<skip_summary reason="low-signal"/><summary><request>Broken`),
+					summaryRepair,
+					parseObserverResponse(summaryRepair),
+					`<skip_summary reason="low-signal"/><summary><request>Broken`,
+				),
+			).toBe(false);
+		});
+
+		it("requires repairs to preserve recoverable fields from a discarded summary", () => {
+			const retained = `<observation>
+				<type>discovery</type><title>Retained lesson</title>
+				<narrative>Keep this observation.</narrative>
+			</observation>`;
+			const lossy = `${retained}<summary>
+				<request>Preserve the original request</request>
+				<files_read><file>src/original.ts</file></files_read>`;
+			const unrelatedRepair = `${retained}<summary>
+				<request>Different request</request>
+				<files_read><file>src/unrelated.ts</file></files_read>
+			</summary>`;
+			const faithfulRepair = `${retained}<summary>
+				<request>Preserve the original request</request>
+				<files_read><file>src/original.ts</file></files_read>
+			</summary>`;
+			const extendedCompleteFieldRepair = faithfulRepair.replace(
+				"Preserve the original request",
+				"Preserve the original request and more",
+			);
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					unrelatedRepair,
+					parseObserverResponse(unrelatedRepair),
+					lossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					extendedCompleteFieldRepair,
+					parseObserverResponse(extendedCompleteFieldRepair),
+					lossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					faithfulRepair,
+					parseObserverResponse(faithfulRepair),
+					lossy,
+				),
+			).toBe(true);
+
+			const unknownLossy = `${retained}<summary><outcome>Auth race fixed`;
+			const unknownFaithfulRepair = `${retained}<summary>
+				<completed>Auth race fixed</completed>
+			</summary>`;
+			const unknownUnrelatedRepair = `${retained}<summary>
+				<completed>Different result</completed>
+			</summary>`;
+			const unknownFabricatedRepair = unknownFaithfulRepair.replace(
+				"</summary>",
+				"<learned>Invented lesson</learned><files_read><file>src/invented.ts</file></files_read></summary>",
+			);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unknownLossy),
+					unknownUnrelatedRepair,
+					parseObserverResponse(unknownUnrelatedRepair),
+					unknownLossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unknownLossy),
+					unknownFaithfulRepair,
+					parseObserverResponse(unknownFaithfulRepair),
+					unknownLossy,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unknownLossy),
+					unknownFabricatedRepair,
+					parseObserverResponse(unknownFabricatedRepair),
+					unknownLossy,
+				),
+			).toBe(false);
+			const adjacentUnknowns = `${retained}<summary>
+				<outcome>Auth race fixed<verdict>Ship it`;
+			const adjacentFaithfulRepair = `${retained}<summary>
+				<completed>Auth race fixed Ship it</completed>
+			</summary>`;
+			const adjacentDroppedRepair = `${retained}<summary>
+				<completed>Auth race fixed safely</completed>
+			</summary>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(adjacentUnknowns),
+					adjacentDroppedRepair,
+					parseObserverResponse(adjacentDroppedRepair),
+					adjacentUnknowns,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(adjacentUnknowns),
+					adjacentFaithfulRepair,
+					parseObserverResponse(adjacentFaithfulRepair),
+					adjacentUnknowns,
+				),
+			).toBe(true);
+
+			const truncatedListItem = `${retained}<summary>
+				<request>Preserve the original request</request>
+				<files_read><file>src/orig`;
+			const unrelatedListRepair = `${retained}<summary>
+				<request>Preserve the original request</request>
+				<files_read><file>src/unrelated.ts</file></files_read>
+			</summary>`;
+			const faithfulListRepair = `${retained}<summary>
+				<request>Preserve the original request</request>
+				<files_read><file>src/original.ts</file></files_read>
+			</summary>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(truncatedListItem),
+					unrelatedListRepair,
+					parseObserverResponse(unrelatedListRepair),
+					truncatedListItem,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(truncatedListItem),
+					faithfulListRepair,
+					parseObserverResponse(faithfulListRepair),
+					truncatedListItem,
+				),
+			).toBe(true);
+
+			const overlappingListItems = `${retained}<summary>
+				<request>Preserve the original request</request>
+				<files_read><file>src/<file>src/a.ts</file>`;
+			const overlappingListRepair = `${retained}<summary>
+				<request>Preserve the original request</request>
+				<files_read><file>src/a.ts</file><file>src/b.ts</file></files_read>
+			</summary>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(overlappingListItems),
+					overlappingListRepair,
+					parseObserverResponse(overlappingListRepair),
+					overlappingListItems,
+				),
+			).toBe(true);
+
+			const duplicateListItems = `${retained}<summary>
+				<request>Preserve the original request</request>
+				<files_read><file>src/a.ts</file><file>src/a.ts</file>`;
+			const missingDuplicateRepair = overlappingListRepair.replace("<file>src/b.ts</file>", "");
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(duplicateListItems),
+					missingDuplicateRepair,
+					parseObserverResponse(missingDuplicateRepair),
+					duplicateListItems,
+				),
+			).toBe(false);
+		});
+
+		it("requires unknown summary values to map into a supported repaired field", () => {
+			const initial = `<summary>
+				<request>Fix auth</request>
+				<outcome>Auth race fixed</outcome>
+			</summary>`;
+			const dropped = `<summary><request>Fix auth</request></summary>`;
+			const mapped = `<summary>
+				<request>Fix auth</request>
+				<completed>Auth race fixed</completed>
+			</summary>`;
+			const embellishedMapping = mapped.replace(
+				"Auth race fixed",
+				"Auth race fixed with unrelated invented detail",
+			);
+			const reusedMapping = mapped.replace(
+				"</summary>",
+				"<learned>Auth race fixed</learned></summary>",
+			);
+			const unclosedUnknown = `<summary>
+				<request>Fix auth</request>
+				<outcome>Auth race fixed<detail>context</detail>
+			</summary>`;
+			const nestedValueMapping = mapped.replace("Auth race fixed", "Auth race fixed context");
+			const embellishedNestedValue = nestedValueMapping.replace(
+				"Auth race fixed context",
+				"Auth race fixed context with unrelated invented detail",
+			);
+			const fabricatedObservation = `${mapped}<observation>
+				<type>bugfix</type><title>Invented repair result</title>
+				<narrative>This observation has no source block.</narrative>
+			</observation>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					dropped,
+					parseObserverResponse(dropped),
+					initial,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					mapped,
+					parseObserverResponse(mapped),
+					initial,
+				),
+			).toBe(true);
+			for (const ungrounded of [embellishedMapping, reusedMapping]) {
+				expect(
+					shouldPreferRepairedObserverResponse(
+						parseObserverResponse(initial),
+						ungrounded,
+						parseObserverResponse(ungrounded),
+						initial,
+					),
+				).toBe(false);
+			}
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unclosedUnknown),
+					nestedValueMapping,
+					parseObserverResponse(nestedValueMapping),
+					unclosedUnknown,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unclosedUnknown),
+					embellishedNestedValue,
+					parseObserverResponse(embellishedNestedValue),
+					unclosedUnknown,
+				),
+			).toBe(false);
+
+			const nestedOccurrence = `<summary>
+				<request>Fix auth</request>
+				<notes>See <outcome>nested context</outcome></notes>
+				<outcome>Direct result</outcome>
+			</summary>`;
+			const directOccurrenceMapping = `<summary>
+				<request>Fix auth</request>
+				<notes>See <outcome>nested context</outcome></notes>
+				<completed>Direct result</completed>
+			</summary>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(nestedOccurrence),
+					directOccurrenceMapping,
+					parseObserverResponse(directOccurrenceMapping),
+					nestedOccurrence,
+				),
+			).toBe(true);
+
+			const quotedAttribute = `<summary>
+				<request>Fix auth</request>
+				<note kind="a > b">Unknown note</note>
+				<outcome>Direct result</outcome>
+			</summary>`;
+			const quotedAttributeMapping = `<summary>
+				<request>Fix auth</request>
+				<notes>Unknown note</notes>
+				<completed>Direct result</completed>
+			</summary>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(quotedAttribute),
+					quotedAttributeMapping,
+					parseObserverResponse(quotedAttributeMapping),
+					quotedAttribute,
+				),
+			).toBe(true);
+			const unbalancedAttribute = quotedAttribute.replace('kind="a > b"', 'kind="broken');
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unbalancedAttribute),
+					quotedAttributeMapping,
+					parseObserverResponse(quotedAttributeMapping),
+					unbalancedAttribute,
+				),
+			).toBe(true);
+
+			const unclosedBeforeKnown = `<summary>
+				<request>Fix auth</request>
+				<outcome>Auth race fixed<completed>Shipped safely</completed>
+			</summary>`;
+			const unclosedBeforeKnownMapping = `<summary>
+				<request>Fix auth</request>
+				<notes>Auth race fixed</notes>
+				<completed>Shipped safely</completed>
+			</summary>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unclosedBeforeKnown),
+					unclosedBeforeKnownMapping,
+					parseObserverResponse(unclosedBeforeKnownMapping),
+					unclosedBeforeKnown,
+				),
+			).toBe(true);
+			const unknownAfterKnown = unclosedBeforeKnown.replace(
+				"</summary>",
+				"<verdict>Ship it</verdict></summary>",
+			);
+			const droppedUnknownAfterKnown = unclosedBeforeKnownMapping;
+			const preservedUnknownAfterKnown = unclosedBeforeKnownMapping.replace(
+				"</summary>",
+				"<learned>Ship it</learned></summary>",
+			);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unknownAfterKnown),
+					droppedUnknownAfterKnown,
+					parseObserverResponse(droppedUnknownAfterKnown),
+					unknownAfterKnown,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unknownAfterKnown),
+					preservedUnknownAfterKnown,
+					parseObserverResponse(preservedUnknownAfterKnown),
+					unknownAfterKnown,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					fabricatedObservation,
+					parseObserverResponse(fabricatedObservation),
+					initial,
+				),
+			).toBe(false);
+
+			const nestedInitial = `<summary>
+				<request>Index files</request>
+				<files><file>src/a.ts</file></files>
+			</summary>`;
+			const nestedMapped = `<summary>
+				<request>Index files</request>
+				<files_read><file>src/a.ts</file></files_read>
+			</summary>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(nestedInitial),
+					nestedMapped,
+					parseObserverResponse(nestedMapped),
+					nestedInitial,
+				),
+			).toBe(true);
+		});
+
+		it("grounds restored retained-summary fields in the malformed raw prefix", () => {
+			const lossy = `<summary>
+				<request>Fix auth</request>
+				<learned>Critical auth race
+			</summary>
+			<observation><type>bugfix</type><title>Recover this fix`;
+			const faithfulRepair = `<summary>
+				<request>Fix auth</request>
+				<learned>Critical auth race in token refresh</learned>
+			</summary>
+			<observation><type>bugfix</type><title>Recover this fix safely</title></observation>`;
+			const unrelatedRepair = faithfulRepair.replace(
+				"Critical auth race in token refresh",
+				"Unrelated cache observation",
+			);
+			const injectedListRepair = faithfulRepair.replace(
+				"</summary>",
+				"<files_modified><file>src/fabricated.ts</file></files_modified></summary>",
+			);
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					unrelatedRepair,
+					parseObserverResponse(unrelatedRepair),
+					lossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					injectedListRepair,
+					parseObserverResponse(injectedListRepair),
+					lossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					faithfulRepair,
+					parseObserverResponse(faithfulRepair),
+					lossy,
+				),
+			).toBe(true);
+		});
+
+		it("allows multiple summaries to merge while preserving every value", () => {
+			const initial = `<summary><request>First request</request></summary>
+				<summary><request>Second request</request></summary>`;
+			const merged = `<summary>
+				<request>First request; Second request</request>
+			</summary>`;
+			const embellishedMerge = merged.replace(
+				"Second request",
+				"Second request with invented detail",
+			);
+			const fabricatedScalar = merged.replace(
+				"</summary>",
+				"<learned>Invented lesson</learned></summary>",
+			);
+			const fabricatedList = merged.replace(
+				"</summary>",
+				"<files_read><file>src/invented.ts</file></files_read></summary>",
+			);
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					merged,
+					parseObserverResponse(merged),
+					initial,
+				),
+			).toBe(true);
+			for (const ungrounded of [embellishedMerge, fabricatedScalar, fabricatedList]) {
+				expect(
+					shouldPreferRepairedObserverResponse(
+						parseObserverResponse(initial),
+						ungrounded,
+						parseObserverResponse(ungrounded),
+						initial,
+					),
+				).toBe(false);
+			}
+
+			const truncatedSecond = `<summary><request>First request</request></summary>
+				<summary><request>Second request`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(truncatedSecond),
+					merged,
+					parseObserverResponse(merged),
+					truncatedSecond,
+				),
+			).toBe(true);
+			for (const ungrounded of [fabricatedScalar, fabricatedList]) {
+				expect(
+					shouldPreferRepairedObserverResponse(
+						parseObserverResponse(truncatedSecond),
+						ungrounded,
+						parseObserverResponse(ungrounded),
+						truncatedSecond,
+					),
+				).toBe(false);
+			}
+			const truncatedUnknownMerge = `<summary><outcome>Result A</outcome></summary>
+				<summary><outcome>Result B`;
+			const groundedTruncatedUnknown = `<summary>
+				<completed>Result A and Result B</completed>
+			</summary>`;
+			const embellishedTruncatedUnknown = groundedTruncatedUnknown.replace(
+				"Result B",
+				"Result B with invented detail",
+			);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(truncatedUnknownMerge),
+					groundedTruncatedUnknown,
+					parseObserverResponse(groundedTruncatedUnknown),
+					truncatedUnknownMerge,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(truncatedUnknownMerge),
+					embellishedTruncatedUnknown,
+					parseObserverResponse(embellishedTruncatedUnknown),
+					truncatedUnknownMerge,
+				),
+			).toBe(false);
+
+			const unknownOnly = `<summary><outcome>Result A</outcome></summary>
+				<summary><outcome>Result B</outcome></summary>`;
+			const groundedUnknownMerge = `<summary><completed>Result A and Result B</completed></summary>`;
+			const reusedUnknownMerge = `<summary>
+				<learned>Result A</learned><completed>Result A and Result B</completed>
+			</summary>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unknownOnly),
+					groundedUnknownMerge,
+					parseObserverResponse(groundedUnknownMerge),
+					unknownOnly,
+				),
+			).toBe(true);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(unknownOnly),
+					reusedUnknownMerge,
+					parseObserverResponse(reusedUnknownMerge),
+					unknownOnly,
+				),
+			).toBe(false);
+
+			const overlappingUnknowns = `<summary><outcome>Result A</outcome>
+				<summary><outcome>Result B</outcome></summary>`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(overlappingUnknowns),
+					reusedUnknownMerge,
+					parseObserverResponse(reusedUnknownMerge),
+					overlappingUnknowns,
+				),
+			).toBe(false);
+
+			const nonFinalTruncatedRequest = `<summary><request>Fix auth
+				<summary><request>Deploy the service</request></summary>`;
+			const exactBoundaryMerge = `<summary>
+				<request>Deploy the service; Fix auth</request>
+			</summary>`;
+			const embellishedBoundaryMerge = exactBoundaryMerge.replace(
+				"Fix auth",
+				"Fix auth in the token refresh path",
+			);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(nonFinalTruncatedRequest),
+					embellishedBoundaryMerge,
+					parseObserverResponse(embellishedBoundaryMerge),
+					nonFinalTruncatedRequest,
+				),
+			).toBe(false);
+		});
+
+		it("requires distinct merged summary scalars to be consumed independently", () => {
+			const initial = `<summary><request>auth</request></summary>
+				<summary><request>oauth</request></summary>`;
+			const reducedRepair = `<summary><request>oauth</request></summary>`;
+			const completeRepair = `<summary><request>auth and oauth</request></summary>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					reducedRepair,
+					parseObserverResponse(reducedRepair),
+					initial,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					completeRepair,
+					parseObserverResponse(completeRepair),
+					initial,
+				),
+			).toBe(true);
+		});
+
+		it("validates discarded fragments even when the initial parse retained nothing", () => {
+			const lossy = `<observation>
+				<type>bugfix</type><title>Recover this bugfix</title>
+				<narrative>Truncated`;
+			const unrelatedRepair = `<summary><request>Unrelated summary</request></summary>`;
+			const faithfulRepair = `<observation>
+				<type>bugfix</type><title>Recover this bugfix</title>
+				<narrative>Truncated content recovered durably.</narrative>
+			</observation>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					unrelatedRepair,
+					parseObserverResponse(unrelatedRepair),
+					lossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					faithfulRepair,
+					parseObserverResponse(faithfulRepair),
+					lossy,
+				),
+			).toBe(true);
+		});
+
+		it("allows repairs to restore recoverable fields in retained malformed observations", () => {
+			const malformedRetained = `<observation>
+				<type>discovery</type>
+				<title>Recovered title prefix
+				<narrative>Keep this parsed narrative.</narrative>
+			</observation>`;
+			const lossy = `${malformedRetained}<observation>
+				<type>bugfix</type><title>Recover the second item`;
+			const faithfulRepair = `<observation>
+				<type>discovery</type>
+				<title>Recovered title prefix with detail</title>
+				<narrative>Keep this parsed narrative.</narrative>
+			</observation>
+			<observation>
+				<type>bugfix</type><title>Recover the second item safely</title>
+			</observation>`;
+			const unrelatedRepair = faithfulRepair.replace(
+				"Recovered title prefix with detail",
+				"Unrelated replacement title",
+			);
+			const injectedRepair = faithfulRepair.replace(
+				"</observation>",
+				"<files_modified><file>src/unrelated.ts</file></files_modified></observation>",
+			);
+			const injectedScalarRepair = faithfulRepair.replace(
+				"</observation>",
+				"<subtitle>Unrelated injected subtitle</subtitle></observation>",
+			);
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					unrelatedRepair,
+					parseObserverResponse(unrelatedRepair),
+					lossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					injectedScalarRepair,
+					parseObserverResponse(injectedScalarRepair),
+					lossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					injectedRepair,
+					parseObserverResponse(injectedRepair),
+					lossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					faithfulRepair,
+					parseObserverResponse(faithfulRepair),
+					lossy,
+				),
+			).toBe(true);
+		});
+
+		it("preserves visible prefixes from scalar tags truncated mid-value", () => {
+			const lossy = `<observation>
+				<type>bugfix</type><title>Critical auth race`;
+			const unrelatedRepair = `<observation>
+				<type>bugfix</type><title>Unrelated cache bug</title>
+			</observation>`;
+			const faithfulRepair = `<observation>
+				<type>bugfix</type><title>Critical auth race in token refresh</title>
+			</observation>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					unrelatedRepair,
+					parseObserverResponse(unrelatedRepair),
+					lossy,
+				),
+			).toBe(false);
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					faithfulRepair,
+					parseObserverResponse(faithfulRepair),
+					lossy,
+				),
+			).toBe(true);
+		});
+
+		it("allows whitespace-only reflow in retained fields during repair", () => {
+			const lossy = `<summary>
+				<learned>Line one
+					Line two</learned>
+				<files_read><file>src/a.ts</file></files_read>
+			</summary>
+			<observation><type>bugfix</type><title>Recover this fix`;
+			const repaired = `<summary>
+				<learned>Line one Line two</learned>
+				<files_read><file>src/a.ts</file></files_read>
+			</summary>
+			<observation><type>bugfix</type><title>Recover this fix safely</title></observation>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					repaired,
+					parseObserverResponse(repaired),
+					lossy,
+				),
+			).toBe(true);
+		});
+
+		it("rejects repaired output containing both a summary and skip marker", () => {
+			const lossy = `<observation>
+				<type>bugfix</type><title>Recover this bugfix`;
+			const contradictoryRepair = `<observation>
+				<type>bugfix</type><title>Recover this bugfix</title>
+			</observation>
+			<summary><request>Recovered summary</request></summary>
+			<skip_summary reason="low-signal"/>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					contradictoryRepair,
+					parseObserverResponse(contradictoryRepair),
+					lossy,
+				),
+			).toBe(false);
+		});
+
+		it("allows unsupported kinds in discarded fragments to be corrected", () => {
+			const retained = `<observation>
+				<type>discovery</type><title>Retained lesson</title>
+			</observation>`;
+			const lossy = `${retained}<observation>
+				<type>memo</type><title>Recover this item</title>`;
+			const correctedRepair = `${retained}<observation>
+				<type>decision</type><title>Recover this item</title>
+			</observation>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(lossy),
+					correctedRepair,
+					parseObserverResponse(correctedRepair),
+					lossy,
+				),
+			).toBe(true);
+
+			const supportedLossy = lossy.replace("memo", "bugfix");
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(supportedLossy),
+					correctedRepair,
+					parseObserverResponse(correctedRepair),
+					supportedLossy,
+				),
+			).toBe(false);
+		});
+
+		it("matches incomplete kinds by supported prefix or corrects unknown kinds", () => {
+			const decisionRepair = `<observation>
+				<type>decision</type><title>Recover this item</title>
+			</observation>`;
+			const bugfixRepair = decisionRepair.replace("decision", "bugfix");
+			for (const lossyKind of ["dec", "memo"]) {
+				const lossy = `<observation><type>${lossyKind}<title>Recover this item`;
+				expect(
+					shouldPreferRepairedObserverResponse(
+						parseObserverResponse(lossy),
+						decisionRepair,
+						parseObserverResponse(decisionRepair),
+						lossy,
+					),
+				).toBe(true);
+			}
+			const supportedPrefix = `<observation><type>dec<title>Recover this item`;
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(supportedPrefix),
+					bugfixRepair,
+					parseObserverResponse(bugfixRepair),
+					supportedPrefix,
+				),
+			).toBe(false);
+		});
+
+		it("reserves exact kind matches before correcting unsupported duplicates", () => {
+			const sharedContent = `<title>Shared content</title>
+				<narrative>Same durable body.</narrative>`;
+			const initial = `<observation><type>memo</type>${sharedContent}</observation>
+				<observation><type>discovery</type>${sharedContent}</observation>`;
+			const repaired = `<observation><type>discovery</type>${sharedContent}</observation>
+				<observation><type>decision</type>${sharedContent}</observation>`;
+
+			expect(
+				shouldPreferRepairedObserverResponse(
+					parseObserverResponse(initial),
+					repaired,
+					parseObserverResponse(repaired),
+					initial,
+				),
+			).toBe(true);
 		});
 	});
 
@@ -707,6 +2107,173 @@ describe("ingest() integration", { timeout: 15_000 }, () => {
 		expect(summaryMetadata.request).toBe("Fix auth timeout");
 		expect(summaryMetadata.completed).toBe("Fixed the timeout");
 		expect(summaryMetadata.learned).toBe("Race condition in handler");
+	});
+
+	it("repairs a structured response when parsing would discard an observation", async () => {
+		const calls: Array<{ system: string; user: string }> = [];
+		const lossy = `<summary>
+			<request>Preserve the parser fix</request>
+			<learned>The parser detected discarded durable content.</learned>
+		</summary>
+		<observation>
+				<type>discovery</type>
+				<title>Parser data loss now triggers repair</title>
+				<narrative>A one-shot repair preserves durable observer content that malformed XML would discard.</narrative>
+				<facts><fact>Parser-confirmed data loss triggers one XML repair call.</fact></facts>
+				<concepts><concept>problem-solution</concept></concepts>
+				<files_read></files_read><files_modified></files_modified>`;
+		const repaired = `<observation>
+			<type>discovery</type>
+			<title>Parser data loss now triggers repair</title>
+			<narrative>A one-shot repair preserves durable observer content that malformed XML would discard.</narrative>
+			<facts><fact>Parser-confirmed data loss triggers one XML repair call.</fact></facts>
+			<concepts><concept>problem-solution</concept></concepts>
+			<files_read></files_read><files_modified></files_modified>
+		</observation>
+		<summary><request>Preserve the parser fix</request><learned>The parser detected discarded durable content.</learned></summary>`;
+		const observer = {
+			observe: async (system: string, user: string) => {
+				calls.push({ system, user });
+				return {
+					raw: calls.length === 1 ? lossy : repaired,
+					parsed: null,
+					provider: "test",
+					model: "test-model",
+				};
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		await ingest(buildPayload(), store, { observer } as unknown as IngestOptions);
+
+		expect(calls).toHaveLength(2);
+		expect(calls[1]?.system).toContain("previous reply was invalid");
+		expect(calls[1]?.user).toContain(lossy);
+		expect(
+			store.recent(10).some((memory) => memory.title === "Parser data loss now triggers repair"),
+		).toBe(true);
+	});
+
+	it("retains valid initial content when the parser repair returns no output", async () => {
+		const calls: Array<{ system: string; user: string }> = [];
+		const partiallyRetained = `<observation>
+			<type>discovery</type>
+			<title>Initial valid lesson survives repair failure</title>
+			<narrative>The parser retained this valid observation before detecting another malformed block.</narrative>
+		</observation>
+		<summary>
+			<request>Keep valid initial content</request>
+			<notes><observation></notes>
+		</summary>`;
+		const observer = {
+			observe: async (system: string, user: string) => {
+				calls.push({ system, user });
+				return {
+					raw: calls.length === 1 ? partiallyRetained : null,
+					parsed: null,
+					provider: "test",
+					model: "test-model",
+				};
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		await ingest(buildPayload(), store, { observer } as unknown as IngestOptions);
+
+		expect(calls).toHaveLength(2);
+		expect(
+			store
+				.recent(10)
+				.some((memory) => memory.title === "Initial valid lesson survives repair failure"),
+		).toBe(true);
+	});
+
+	it("retains valid initial content when the parser repair throws", async () => {
+		let callCount = 0;
+		const partiallyRetained = `<observation>
+			<type>discovery</type>
+			<title>Initial valid lesson survives repair exception</title>
+			<narrative>The parser retained this valid observation before repair failed.</narrative>
+		</observation><observation><type>bugfix</type><title>Truncated`;
+		const observer = {
+			observe: async () => {
+				callCount += 1;
+				if (callCount === 2) throw new Error("repair transport failed");
+				return {
+					raw: partiallyRetained,
+					parsed: null,
+					provider: "test",
+					model: "test-model",
+				};
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		await ingest(buildPayload(), store, { observer } as unknown as IngestOptions);
+
+		expect(callCount).toBe(2);
+		expect(
+			store
+				.recent(10)
+				.some((memory) => memory.title === "Initial valid lesson survives repair exception"),
+		).toBe(true);
+	});
+
+	it("retains valid initial content when a clean repair returns different observations", async () => {
+		const calls: string[] = [];
+		const partiallyRetained = `<observation>
+			<type>discovery</type>
+			<title>Session ownership prevents stale refresh races</title>
+			<narrative>The active session must own the refresh result before replacing authentication state.</narrative>
+		</observation>
+		<observation><type>discovery</type><title>Truncated replacement`;
+		const disjointRepair = `<observation>
+			<type>discovery</type>
+			<title>Cache eviction uses bounded batches</title>
+			<narrative>The clean response describes a different durable outcome.</narrative>
+		</observation>`;
+		const observer = {
+			observe: async () => {
+				calls.push("observe");
+				return {
+					raw: calls.length === 1 ? partiallyRetained : disjointRepair,
+					parsed: null,
+					provider: "test",
+					model: "test-model",
+				};
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		await ingest(buildPayload(), store, { observer } as unknown as IngestOptions);
+
+		expect(calls).toHaveLength(2);
+		expect(store.recent(10).map((memory) => memory.title)).toContain(
+			"Session ownership prevents stale refresh races",
+		);
+		expect(
+			store.recent(10).some((memory) => memory.title === "Cache eviction uses bounded batches"),
+		).toBe(false);
 	});
 
 	it("suppresses telemetry observations with capture routing enabled", async () => {
@@ -1279,7 +2846,7 @@ describe("ingest() integration", { timeout: 15_000 }, () => {
 
 		await expect(
 			ingest(payload, store, { observer: mixedObserver } as unknown as IngestOptions),
-		).rejects.toThrow("observer produced no storable output for raw-event flush");
+		).rejects.toThrow("observer repair remained lossy during raw-event flush");
 
 		expect(store.recent(10)).toHaveLength(0);
 	});
@@ -1397,7 +2964,7 @@ describe("ingest() integration", { timeout: 15_000 }, () => {
 					};
 				}
 				return {
-					raw: `<summary><request>Check restart state</request><completed>Confirmed the observer needed an XML retry.</completed></summary>`,
+					raw: `<observation><type>discovery</type><title>current pack stats and restart state</title><subtitle>current pack stats and restart state</subtitle><narrative>Got it — the session inspected current pack stats and restart state.</narrative><concepts><concept>how-it-works</concept></concepts></observation><summary><investigated>the session inspected current pack stats and restart state</investigated></summary>`,
 					parsed: null,
 					provider: "test",
 					model: "test-model",
@@ -1426,7 +2993,9 @@ describe("ingest() integration", { timeout: 15_000 }, () => {
 
 		expect(calls).toBe(2);
 		const memories = store.recent(10);
-		expect(memories[0]?.title).toBe("Check restart state");
+		expect(memories.some((memory) => memory.title === "current pack stats and restart state")).toBe(
+			true,
+		);
 	});
 
 	it("still fails raw-event flush when observer stays non-XML after retry", async () => {

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -35,7 +35,11 @@ import {
 	projectAdapterToolEvent,
 } from "./ingest-events.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
-import { buildObserverPrompt, truncateObserverTranscript } from "./ingest-prompts.js";
+import {
+	buildObserverPrompt,
+	buildObserverRepairPrompt,
+	truncateObserverTranscript,
+} from "./ingest-prompts.js";
 import { type CaptureRoutedObservation, routeObservationsForCapture } from "./ingest-routing.js";
 import {
 	buildTranscript,
@@ -55,7 +59,12 @@ import type {
 	SessionContext,
 	ToolEvent,
 } from "./ingest-types.js";
-import { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
+import {
+	hasMeaningfulObservation,
+	parseObserverResponse,
+	shouldPreferRepairedObserverResponse,
+	shouldRepairObserverResponse,
+} from "./ingest-xml-parser.js";
 import { type ObserverClient, ObserverClient as ObserverClientImpl } from "./observer-client.js";
 import { resolveProject } from "./project.js";
 import * as schema from "./schema.js";
@@ -279,12 +288,6 @@ export interface IngestOptions {
 	storeTyped?: boolean;
 }
 
-function hasStructuredObserverOutput(parsed: ParsedOutput): boolean {
-	return (
-		parsed.observations.length > 0 || parsed.summary !== null || parsed.skipSummaryReason !== null
-	);
-}
-
 async function observeStructuredOutput(
 	observer: ObserverClient,
 	system: string,
@@ -294,7 +297,7 @@ async function observeStructuredOutput(
 	const firstParsed = first.raw
 		? parseObserverResponse(first.raw)
 		: { observations: [], summary: null, skipSummaryReason: null };
-	if (!first.raw || hasStructuredObserverOutput(firstParsed)) {
+	if (!shouldRepairObserverResponse(first.raw, firstParsed)) {
 		return {
 			raw: first.raw,
 			parsed: firstParsed,
@@ -303,12 +306,34 @@ async function observeStructuredOutput(
 		};
 	}
 
-	const repairSystem = `${system}\n\nYour previous reply was invalid because it did not follow the required XML-only schema. Rewrite the same analysis as valid XML only. Do not include prose outside XML.`;
-	const repairUser = `${user}\n\nPrevious invalid response to rewrite as valid XML:\n${first.raw}`;
-	const repaired = await observer.observe(repairSystem, repairUser);
+	const repairPrompt = buildObserverRepairPrompt(
+		system,
+		user,
+		first.raw as string,
+		observer.maxChars,
+	);
+	let repaired: Awaited<ReturnType<ObserverClient["observe"]>>;
+	try {
+		repaired = await observer.observe(repairPrompt.system, repairPrompt.user);
+	} catch {
+		return {
+			raw: first.raw,
+			parsed: firstParsed,
+			provider: first.provider,
+			model: first.model,
+		};
+	}
 	const repairedParsed = repaired.raw
 		? parseObserverResponse(repaired.raw)
 		: { observations: [], summary: null, skipSummaryReason: null };
+	if (!shouldPreferRepairedObserverResponse(firstParsed, repaired.raw, repairedParsed, first.raw)) {
+		return {
+			raw: first.raw,
+			parsed: firstParsed,
+			provider: first.provider,
+			model: first.model,
+		};
+	}
 	return {
 		raw: repaired.raw,
 		parsed: repairedParsed,
@@ -546,6 +571,15 @@ export async function ingest(
 		// ------------------------------------------------------------------
 		const rawText = response.raw;
 		const parsed = response.parsed;
+		if (
+			sessionContext?.flusher === "raw_events" &&
+			(parsed.observations.length > 0 ||
+				parsed.summary !== null ||
+				parsed.skipSummaryReason !== null) &&
+			shouldRepairObserverResponse(rawText, parsed)
+		) {
+			throw new Error("observer repair remained lossy during raw-event flush");
+		}
 		const observerStatus = selectedObserver.getStatus();
 
 		let observationsToStore: CaptureRoutedObservation[] = [];

--- a/packages/core/src/ingest-prompts.test.ts
+++ b/packages/core/src/ingest-prompts.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildObserverPrompt, truncateObserverTranscript } from "./ingest-prompts.js";
+import {
+	buildObserverPrompt,
+	buildObserverRepairPrompt,
+	truncateObserverTranscript,
+} from "./ingest-prompts.js";
 
 describe("buildObserverPrompt", () => {
 	it("includes the Python parity examples and schema guidance", () => {
@@ -48,7 +52,7 @@ describe("buildObserverPrompt", () => {
 		);
 	});
 
-	it("sets a per-observation worthiness bar and allows zero observations for routine sessions", () => {
+	it("uses the concise worthiness policy validated against the observer output schema", () => {
 		const { system } = buildObserverPrompt({
 			project: "codemem",
 			userPrompt: "Cut release 0.99.0",
@@ -61,19 +65,22 @@ describe("buildObserverPrompt", () => {
 			includeSummary: true,
 		});
 
-		expect(system).toContain("Observation worthiness bar");
+		expect(system).toContain("Observation worthiness policy:");
 		expect(system).toContain(
-			'"If a future session never reads this, will it repeat a mistake or re-derive something?"',
+			"Emit an <observation> only for a durable, reusable lesson such as a constraint, root cause, decision with rationale, or how-it-works insight.",
 		);
-		expect(system).toContain("Routine activity is NOT an observation");
-		expect(system).toContain("release/CI/pipeline status narration");
-		expect(system).toContain("review or validation passes that found no issues");
-		expect(system).toContain("context/docs lookups and their results");
-		expect(system).toContain("restating workflow policy already active in the session");
-		expect(system).toContain("bootstrap/setup narration");
 		expect(system).toContain(
-			"Emitting ZERO <observation> blocks with a normal <summary> is correct and common",
+			"When a durable lesson exists, emit it as an <observation>; do not leave it only in <summary>.",
 		);
+		expect(system).toContain(
+			"Routine status, review, setup, and workflow narration belongs only in <summary>.",
+		);
+		expect(system).toContain(
+			"Zero observations is valid when the session contains no durable lesson.",
+		);
+		// The long v0.38 policy destabilized XML shape across both gpt-5.4 tiers.
+		expect(system).not.toContain("If a future session never reads this");
+		expect(system).not.toContain("release/CI/pipeline status narration");
 		// The old quota forced observations out of routine sessions; it must stay gone.
 		expect(system).not.toContain("ALWAYS emit at least one <observation> block");
 		expect(system).not.toContain("Summary-only output is not sufficient for a rich session.");
@@ -135,5 +142,21 @@ describe("buildObserverPrompt", () => {
 		expect(truncated.startsWith("A")).toBe(true);
 		expect(truncated).toContain("middle context");
 		expect(truncated.endsWith("Z".repeat(16))).toBe(true);
+	});
+
+	it("puts repair context before content clipped by the default observer budget", () => {
+		const previousRaw = `PREVIOUS_START${"P".repeat(6_000)}PREVIOUS_TAIL`;
+		const user = `USER_START${"U".repeat(6_000)}USER_TAIL`;
+		const prompt = buildObserverRepairPrompt("S".repeat(12_000), user, previousRaw);
+
+		expect(prompt.system.slice(0, 9_000)).toContain("previous reply was invalid");
+		expect(prompt.system).toContain("using only wording supported verbatim");
+		expect(prompt.system).toContain('emit only <skip_summary reason="low-signal"/>');
+		expect(prompt.system).toContain("copy the entire previous reply into <narrative>");
+		expect(prompt.user.length).toBeLessThanOrEqual(3_000);
+		expect(prompt.user).toContain("PREVIOUS_START");
+		expect(prompt.user).toContain("PREVIOUS_TAIL");
+		expect(prompt.user).toContain("USER_START");
+		expect(prompt.user).toContain("USER_TAIL");
 	});
 });

--- a/packages/core/src/ingest-prompts.ts
+++ b/packages/core/src/ingest-prompts.ts
@@ -51,22 +51,11 @@ If nothing meaningful happened AND nothing was learned:
 - Output no <observation> blocks
 - Output <skip_summary reason="low-signal"/> instead of a <summary> block.`;
 
-const WORTHINESS_GUIDANCE = `Observation worthiness bar — an <observation> must record a durable lesson:
-a constraint, gotcha, root cause, decision with rationale, or how-something-works
-insight that changes how future work should be done.
-Before emitting an observation, ask: "If a future session never reads this, will it repeat a mistake or re-derive something?"
-If the answer is no, do not emit it — the <summary> already records what happened.
-
-Routine activity is NOT an observation, even when it succeeded and even when the
-session is long or busy. The following belong in the <summary> ONLY:
-- release/CI/pipeline status narration ("workflow is running/passed for tag X")
-- review or validation passes that found no issues
-- context/docs lookups and their results ("no repo-local context found; global standards used")
-- restating workflow policy already active in the session (delegation rules, review gates, commit conventions)
-- bootstrap/setup narration (agent init, plugin loading, workspace detection)
-
-Emitting ZERO <observation> blocks with a normal <summary> is correct and common
-for routine sessions (releases, review passes, dependency bumps, status checks).`;
+const WORTHINESS_GUIDANCE = `Observation worthiness policy:
+- Emit an <observation> only for a durable, reusable lesson such as a constraint, root cause, decision with rationale, or how-it-works insight.
+- When a durable lesson exists, emit it as an <observation>; do not leave it only in <summary>.
+- Routine status, review, setup, and workflow narration belongs only in <summary>.
+- Zero observations is valid when the session contains no durable lesson.`;
 
 const NARRATIVE_GUIDANCE = `Create narratives that tell the complete story:
 - Context: What was the problem or goal? What prompted this work?
@@ -355,6 +344,38 @@ export function buildObserverPrompt(context: ObserverContext): {
 	const user = userBlocks.join("\n\n").trim();
 
 	return { system, user };
+}
+
+/** Build the one-shot prompt used to repair malformed observer XML. */
+export function buildObserverRepairPrompt(
+	system: string,
+	user: string,
+	previousRaw: string,
+	maxChars = 12_000,
+): { system: string; user: string } {
+	const repairDirective =
+		"Your previous reply was invalid because it did not follow the required XML-only schema. " +
+		"Rewrite it as valid XML only, using only wording supported verbatim by your previous reply. " +
+		'Do not add, infer, or rephrase details. If the reply was only a short acknowledgement or another low-signal response, emit only <skip_summary reason="low-signal"/>. ' +
+		"Otherwise emit a <summary> whose fields use phrases from the previous reply, optionally plus one <observation>. " +
+		"For that observation, copy the entire previous reply into <narrative>; use single-clause phrases from it for <title>, <subtitle>, and <fact>; preserve negation words; " +
+		"use only the fixed concept taxonomy and file paths that literally appear in the previous reply. Do not include prose outside XML.";
+	const repairSystem = `${repairDirective}\n\n${system}`;
+	const minUserBudget = Math.floor(maxChars * 0.25);
+	const systemBudget = Math.max(0, maxChars - minUserBudget);
+	const clippedSystemLength = Math.min(repairSystem.length, systemBudget);
+	const userBudget = Math.max(minUserBudget, maxChars - clippedSystemLength);
+	const previousPrefix = "Previous invalid response to rewrite as valid XML:\n";
+	const contextPrefix = "\n\nOriginal session context:\n";
+	const contentBudget = Math.max(0, userBudget - previousPrefix.length - contextPrefix.length);
+	const previousBudget = Math.floor(contentBudget * 0.7);
+	const contextBudget = contentBudget - previousBudget;
+	const previousResponse = truncateMiddle(previousRaw.trim(), previousBudget);
+	const originalContext = truncateMiddle(user.trim(), contextBudget);
+	return {
+		system: repairSystem,
+		user: `${previousPrefix}${previousResponse}${contextPrefix}${originalContext}`,
+	};
 }
 
 export function truncateObserverTranscript(transcript: string, maxChars: number): string {

--- a/packages/core/src/ingest-xml-parser.ts
+++ b/packages/core/src/ingest-xml-parser.ts
@@ -8,6 +8,7 @@
  * is sufficient (no DOM parser needed).
  */
 
+import { isLowSignalObservation } from "./ingest-filters.js";
 import type { ParsedObservation, ParsedOutput, ParsedSummary } from "./ingest-types.js";
 
 // ---------------------------------------------------------------------------
@@ -17,7 +18,8 @@ import type { ParsedObservation, ParsedOutput, ParsedSummary } from "./ingest-ty
 // Match <observation> with optional attributes (LLMs sometimes add kind="...")
 const OBSERVATION_BLOCK_RE = /<observation[^>]*>.*?<\/observation>/gs;
 const SUMMARY_BLOCK_RE = /<summary[^>]*>.*?<\/summary>/gs;
-const SKIP_SUMMARY_RE = /<skip_summary(?:\s+reason="(?<reason>[^"]+)")?\s*\/>/i;
+const SKIP_SUMMARY_RE =
+	/<skip_summary(?:\s+reason="(?<reason>[^"]+)")?\s*(?:\/>|>\s*<\/skip_summary>)/i;
 const CODE_FENCE_RE = /```(?:xml)?/gi;
 
 const SUMMARY_FIELDS = new Set([
@@ -29,6 +31,16 @@ const SUMMARY_FIELDS = new Set([
 	"notes",
 	"files_read",
 	"files_modified",
+]);
+
+const OBSERVATION_CONCEPTS = new Set([
+	"how-it-works",
+	"why-it-exists",
+	"what-changed",
+	"problem-solution",
+	"gotcha",
+	"pattern",
+	"trade-off",
 ]);
 
 export const SUPPORTED_OBSERVATION_KINDS = new Set([
@@ -65,9 +77,14 @@ function cleanXmlText(text: string): string {
 	return text.replace(CODE_FENCE_RE, "").trim();
 }
 
+function escapeRegExpLiteral(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /** Extract text content from within a single XML tag. Returns empty string if not found. */
 function extractTagText(xml: string, tag: string): string {
-	const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, "i");
+	const escapedTag = escapeRegExpLiteral(tag);
+	const re = new RegExp(`<${escapedTag}(?=[\\s/>])[^>]*>([\\s\\S]*?)</${escapedTag}>`, "i");
 	const match = re.exec(xml);
 	if (!match?.[1]) return "";
 	return match[1].trim();
@@ -75,11 +92,19 @@ function extractTagText(xml: string, tag: string): string {
 
 /** Extract text content of repeated child elements within a parent tag. */
 function extractChildTexts(xml: string, parentTag: string, childTag: string): string[] {
-	const parentRe = new RegExp(`<${parentTag}[^>]*>([\\s\\S]*?)</${parentTag}>`, "i");
+	const escapedParentTag = escapeRegExpLiteral(parentTag);
+	const escapedChildTag = escapeRegExpLiteral(childTag);
+	const parentRe = new RegExp(
+		`<${escapedParentTag}(?=[\\s/>])[^>]*>([\\s\\S]*?)</${escapedParentTag}>`,
+		"i",
+	);
 	const parentMatch = parentRe.exec(xml);
 	if (!parentMatch?.[1]) return [];
 
-	const childRe = new RegExp(`<${childTag}[^>]*>([\\s\\S]*?)</${childTag}>`, "gi");
+	const childRe = new RegExp(
+		`<${escapedChildTag}(?=[\\s/>])[^>]*>([\\s\\S]*?)</${escapedChildTag}>`,
+		"gi",
+	);
 	const items: string[] = [];
 	for (
 		let match = childRe.exec(parentMatch[1]);
@@ -92,23 +117,83 @@ function extractChildTexts(xml: string, parentTag: string, childTag: string): st
 	return items;
 }
 
-function directChildTagNames(block: string, rootTag: string): string[] {
-	const inner = extractTagText(block, rootTag);
-	const tags: string[] = [];
-	const tagPattern = /<\/?([A-Za-z_][\w:.-]*)(?:\s[^<>]*?)?\s*\/?>/g;
-	let depth = 0;
-	for (let match = tagPattern.exec(inner); match !== null; match = tagPattern.exec(inner)) {
-		const token = match[0];
+function directChildFragments(
+	block: string,
+	rootTag: string,
+): Array<{ tag: string; value: string; complete: boolean }> {
+	const escapedRootTag = escapeRegExpLiteral(rootTag);
+	const opening = new RegExp(`<${escapedRootTag}(?=[\\s/>])[^>]*>`, "i").exec(block);
+	if (!opening) return [];
+	const contentStart = opening.index + opening[0].length;
+	const remainder = block.slice(contentStart);
+	const closing = new RegExp(`</${escapedRootTag}>`, "i").exec(remainder);
+	const inner = closing ? remainder.slice(0, closing.index) : remainder;
+	const fragments: Array<{ tag: string; value: string; complete: boolean }> = [];
+	const openingTagPattern = /<([A-Za-z_][\w:.-]*)/g;
+	for (
+		let match = openingTagPattern.exec(inner);
+		match !== null;
+		match = openingTagPattern.exec(inner)
+	) {
 		const tag = match[1]?.toLowerCase();
 		if (!tag) continue;
-		if (token.startsWith("</")) {
-			depth = Math.max(0, depth - 1);
+		const tagEnd = openingTagEnd(inner, openingTagPattern.lastIndex);
+		if (tagEnd < 0) break;
+		const token = inner.slice(match.index, tagEnd + 1);
+		openingTagPattern.lastIndex = tagEnd + 1;
+		const childContentStart = (match.index ?? 0) + token.length;
+		if (/\/\s*>$/.test(token)) {
+			fragments.push({ tag, value: "", complete: true });
 			continue;
 		}
-		if (depth === 0) tags.push(tag);
-		if (!token.endsWith("/>")) depth += 1;
+		const escapedTag = escapeRegExpLiteral(tag);
+		const childClosing = new RegExp(`</${escapedTag}>`, "i").exec(inner.slice(childContentStart));
+		if (!childClosing) {
+			const unclosedRemainder = inner.slice(childContentStart);
+			const nextKnownField = new RegExp(
+				`<(?:${[...SUMMARY_FIELDS].map(escapeRegExpLiteral).join("|")})(?=[\\s/>])`,
+				"i",
+			).exec(unclosedRemainder);
+			fragments.push({
+				tag,
+				value: nextKnownField
+					? unclosedRemainder.slice(0, nextKnownField.index)
+					: unclosedRemainder,
+				complete: false,
+			});
+			if (!nextKnownField) break;
+			openingTagPattern.lastIndex = childContentStart + nextKnownField.index;
+			continue;
+		}
+		fragments.push({
+			tag,
+			value: inner.slice(childContentStart, childContentStart + childClosing.index),
+			complete: true,
+		});
+		openingTagPattern.lastIndex = childContentStart + childClosing.index + childClosing[0].length;
 	}
-	return tags;
+	return fragments;
+}
+
+function openingTagEnd(value: string, contentStart: number): number {
+	let quote: '"' | "'" | null = null;
+	let firstClosingBracket = -1;
+	for (let index = contentStart; index < value.length; index += 1) {
+		const character = value[index];
+		if (character === ">") {
+			if (firstClosingBracket < 0) firstClosingBracket = index;
+			if (quote === null) return index;
+			continue;
+		}
+		if (character !== '"' && character !== "'") continue;
+		if (quote === character) quote = null;
+		else if (quote === null) quote = character;
+	}
+	return firstClosingBracket;
+}
+
+function directChildTagNames(block: string, rootTag: string): string[] {
+	return directChildFragments(block, rootTag).map(({ tag }) => tag);
 }
 
 function observationKind(block: string): string {
@@ -211,8 +296,9 @@ export function inspectObserverResponseStructure(
 	const observationBlocks = cleaned.match(/<observation(?:\s|>)/gi)?.length ?? 0;
 	const summaryBlockValues = cleaned.match(SUMMARY_BLOCK_RE) ?? [];
 	const summaryBlocks = cleaned.match(/<summary(?:\s|>)/gi)?.length ?? 0;
-	const recognizedOutput =
-		observationBlocks > 0 || summaryBlocks > 0 || SKIP_SUMMARY_RE.test(cleaned);
+	const skipMatch = SKIP_SUMMARY_RE.exec(cleaned);
+	const unlabeledSkipSummary = skipMatch !== null && !skipMatch.groups?.reason;
+	const recognizedOutput = observationBlocks > 0 || summaryBlocks > 0 || skipMatch !== null;
 	const illegalObservationNestingInSummary = summaryBlockValues.reduce(
 		(count, block) => count + (block.match(/<observation(?:\s|>)/gi)?.length ?? 0),
 		0,
@@ -237,6 +323,14 @@ export function inspectObserverResponseStructure(
 	const retainedSummaries = parsed.summary ? 1 : 0;
 	const discardedObservationBlocks = Math.max(0, observationBlocks - parsed.observations.length);
 	const discardedSummaryBlocks = Math.max(0, summaryBlocks - retainedSummaries);
+	const malformedRetainedChildren = [...observationBlockValues, ...summaryBlockValues].some(
+		(block) => {
+			const rootTag = /^\s*<([A-Za-z_][\w:.-]*)/i.exec(block)?.[1];
+			return rootTag
+				? directChildFragments(block, rootTag).some((fragment) => !fragment.complete)
+				: false;
+		},
+	);
 
 	return {
 		recognizedOutput,
@@ -252,12 +346,1236 @@ export function inspectObserverResponseStructure(
 		discardedSummaryBlocks,
 		dataLoss:
 			(cleaned.length > 0 && !recognizedOutput) ||
+			(parsed.summary !== null && parsed.skipSummaryReason !== null) ||
+			unlabeledSkipSummary ||
 			discardedObservationBlocks > 0 ||
 			discardedSummaryBlocks > 0 ||
 			unknownSummaryFields.length > 0 ||
 			unsupportedObservationKinds.length > 0 ||
-			missingObservationKinds > 0,
+			missingObservationKinds > 0 ||
+			malformedRetainedChildren,
 	};
+}
+
+/** Return true when a completed observer response needs one structural repair attempt. */
+export function shouldRepairObserverResponse(raw: string | null, parsed: ParsedOutput): boolean {
+	if (!raw) return false;
+	const hasStructuredOutput =
+		parsed.observations.length > 0 || parsed.summary !== null || parsed.skipSummaryReason !== null;
+	return !hasStructuredOutput || inspectObserverResponseStructure(raw, parsed).dataLoss;
+}
+
+// Fail closed on rewritten content: a repair may add recovered observations or correct
+// an invalid kind, but every other parsed field must survive modulo whitespace reflow.
+function observationContentKey(observation: ParsedObservation): string {
+	const normalizedList = (values: string[]) => values.map(normalizeRecoverableText).sort();
+	return JSON.stringify({
+		title: normalizeRecoverableText(observation.title),
+		narrative: normalizeRecoverableText(observation.narrative),
+		subtitle: observation.subtitle ? normalizeRecoverableText(observation.subtitle) : null,
+		facts: normalizedList(observation.facts),
+		concepts: normalizedList(observation.concepts),
+		filesRead: normalizedList(observation.filesRead),
+		filesModified: normalizedList(observation.filesModified),
+	});
+}
+
+function preservesParsedObservations(
+	initialObservations: ParsedObservation[],
+	repairedObservations: ParsedObservation[],
+	initialRaw?: string | null,
+): boolean {
+	return (
+		remainingAfterPreservedObservations(initialObservations, repairedObservations, initialRaw) !==
+		null
+	);
+}
+
+function remainingAfterPreservedObservations(
+	initialObservations: ParsedObservation[],
+	repairedObservations: ParsedObservation[],
+	initialRaw?: string | null,
+): ParsedObservation[] | null {
+	const remaining = [...repairedObservations];
+	const unmatched: Array<{ observation: ParsedObservation; fragment: string | null }> = [];
+	const retainedFragments = initialRaw
+		? completeBlockMatches(cleanXmlText(initialRaw), OBSERVATION_BLOCK_RE).flatMap(({ value }) =>
+				parseObservationBlock(value) ? [value] : [],
+			)
+		: [];
+	for (const [index, observation] of initialObservations.entries()) {
+		const key = observationContentKey(observation);
+		const matchIndex = remaining.findIndex(
+			(candidate) =>
+				candidate.kind === observation.kind && observationContentKey(candidate) === key,
+		);
+		if (matchIndex < 0) {
+			unmatched.push({ observation, fragment: retainedFragments[index] ?? null });
+			continue;
+		}
+		remaining.splice(matchIndex, 1);
+	}
+	for (const { observation, fragment } of unmatched) {
+		const canCorrectKind = !SUPPORTED_OBSERVATION_KINDS.has(observation.kind);
+		const canRecoverFields =
+			fragment !== null && hasRecoverableObservationEnrichment(fragment, observation);
+		if (!canCorrectKind && !canRecoverFields) return null;
+		const matchIndex = remaining.findIndex((candidate) => {
+			const kindMatches = canCorrectKind
+				? SUPPORTED_OBSERVATION_KINDS.has(candidate.kind)
+				: candidate.kind === observation.kind;
+			return (
+				kindMatches &&
+				preservesParsedObservationFields(observation, candidate, fragment) &&
+				(fragment
+					? observationMatchesRecoveredFields(fragment, candidate)
+					: observationContentKey(candidate) === observationContentKey(observation))
+			);
+		});
+		if (matchIndex < 0) return null;
+		remaining.splice(matchIndex, 1);
+	}
+	return remaining;
+}
+
+function preservesParsedObservationFields(
+	initial: ParsedObservation,
+	repaired: ParsedObservation,
+	fragment: string | null,
+): boolean {
+	return (
+		preservesRetainedScalar(initial.title, repaired.title, fragment, "title") &&
+		preservesRetainedScalar(initial.narrative, repaired.narrative, fragment, "narrative") &&
+		preservesRetainedScalar(initial.subtitle, repaired.subtitle, fragment, "subtitle") &&
+		preservesRetainedList(
+			initial.facts,
+			repaired.facts,
+			fragment ? extractRecoverableChildTexts(fragment, "facts", "fact") : [],
+		) &&
+		preservesRetainedList(
+			initial.concepts,
+			repaired.concepts,
+			fragment ? extractRecoverableChildTexts(fragment, "concepts", "concept") : [],
+		) &&
+		preservesRetainedList(
+			initial.filesRead,
+			repaired.filesRead,
+			fragment ? extractRecoverableChildTexts(fragment, "files_read", "file") : [],
+		) &&
+		preservesRetainedList(
+			initial.filesModified,
+			repaired.filesModified,
+			fragment ? extractRecoverableChildTexts(fragment, "files_modified", "file") : [],
+		)
+	);
+}
+
+function preservesRetainedScalar(
+	initial: string | null,
+	repaired: string | null,
+	fragment: string | null,
+	tag: string,
+): boolean {
+	if (hasVisibleText(initial ?? "")) {
+		return normalizeRecoverableText(repaired ?? "") === normalizeRecoverableText(initial ?? "");
+	}
+	if (!hasVisibleText(repaired ?? "")) return true;
+	const recovered = fragment ? extractRecoverableTagText(fragment, tag) : null;
+	return (
+		recovered !== null &&
+		hasVisibleText(recovered.value) &&
+		matchesRecoverableText(recovered, repaired)
+	);
+}
+
+function preservesRetainedList(
+	initial: string[],
+	repaired: string[],
+	recovered: RecoverableText[],
+	unknownValues: RecoverableText[] = [],
+): boolean {
+	const repairedExtras = [...repaired];
+	for (const item of initial) {
+		const normalized = normalizeRecoverableText(item);
+		const index = repairedExtras.findIndex(
+			(candidate) => normalizeRecoverableText(candidate) === normalized,
+		);
+		if (index < 0) return false;
+		repairedExtras.splice(index, 1);
+	}
+	const unmatchedRecovered: RecoverableText[] = [];
+	const initialMatches = [...initial];
+	for (const item of recovered) {
+		const normalized = normalizeRecoverableText(item.value);
+		const index = initialMatches.findIndex((candidate) => {
+			const normalizedCandidate = normalizeRecoverableText(candidate);
+			return item.complete
+				? normalizedCandidate === normalized
+				: normalizedCandidate.startsWith(normalized);
+		});
+		if (index < 0) unmatchedRecovered.push(item);
+		else initialMatches.splice(index, 1);
+	}
+	const orderedRecovered = [
+		...unmatchedRecovered.filter((item) => item.complete),
+		...unmatchedRecovered.filter((item) => !item.complete),
+	];
+	for (const item of orderedRecovered) {
+		const normalized = normalizeRecoverableText(item.value);
+		const index = repairedExtras.findIndex((candidate) => {
+			const normalizedCandidate = normalizeRecoverableText(candidate);
+			return item.complete
+				? normalizedCandidate === normalized
+				: normalizedCandidate.startsWith(normalized);
+		});
+		if (index < 0) return false;
+		repairedExtras.splice(index, 1);
+	}
+	for (const item of repairedExtras) {
+		const matchIndex = unknownValues.findIndex((value) => matchesRecoverableText(value, item));
+		if (matchIndex < 0) return false;
+		unknownValues.splice(matchIndex, 1);
+	}
+	return true;
+}
+
+function hasRecoverableObservationEnrichment(
+	fragment: string,
+	initial: ParsedObservation,
+): boolean {
+	const scalarFields = [
+		["title", initial.title],
+		["narrative", initial.narrative],
+		["subtitle", initial.subtitle],
+	] as const;
+	if (
+		scalarFields.some(([tag, value]) => {
+			const recovered = extractRecoverableTagText(fragment, tag);
+			return (
+				recovered !== null &&
+				hasVisibleText(recovered.value) &&
+				!matchesRecoverableText(recovered, value)
+			);
+		})
+	) {
+		return true;
+	}
+	return (
+		!preservesRecoverableItems(
+			extractRecoverableChildTexts(fragment, "facts", "fact"),
+			initial.facts,
+		) ||
+		!preservesRecoverableItems(
+			extractRecoverableChildTexts(fragment, "concepts", "concept"),
+			initial.concepts,
+		) ||
+		!preservesRecoverableItems(
+			extractRecoverableChildTexts(fragment, "files_read", "file"),
+			initial.filesRead,
+		) ||
+		!preservesRecoverableItems(
+			extractRecoverableChildTexts(fragment, "files_modified", "file"),
+			initial.filesModified,
+		)
+	);
+}
+
+function hasVisibleText(value: string): boolean {
+	return visibleTextForComparison(value).length > 0;
+}
+
+function visibleTextForComparison(value: string): string {
+	let visible = "";
+	let index = 0;
+	while (index < value.length) {
+		if (value[index] !== "<") {
+			visible += value[index];
+			index += 1;
+			continue;
+		}
+		const closingBracket = value.indexOf(">", index + 1);
+		if (closingBracket < 0) {
+			visible += value.slice(index);
+			break;
+		}
+		visible += " ";
+		index = closingBracket + 1;
+	}
+	return normalizeRecoverableText(visible);
+}
+
+function preservesStringItems(initialItems: string[], repairedItems: string[]): boolean {
+	const repairedCounts = new Map<string, number>();
+	for (const item of repairedItems) {
+		const normalized = normalizeRecoverableText(item);
+		repairedCounts.set(normalized, (repairedCounts.get(normalized) ?? 0) + 1);
+	}
+	for (const item of initialItems) {
+		const normalized = normalizeRecoverableText(item);
+		const remaining = repairedCounts.get(normalized) ?? 0;
+		if (remaining === 0) return false;
+		repairedCounts.set(normalized, remaining - 1);
+	}
+	return true;
+}
+
+function preservesPopulatedSummaryFields(
+	initialSummary: ParsedSummary | null,
+	repairedSummary: ParsedSummary | null,
+	allowMergedValues = false,
+	initialRaw?: string | null,
+): boolean {
+	if (!initialSummary) return true;
+	if (!repairedSummary) return false;
+	const scalarFields = [
+		["request", "request"],
+		["investigated", "investigated"],
+		["learned", "learned"],
+		["completed", "completed"],
+		["nextSteps", "next_steps"],
+		["notes", "notes"],
+	] as const;
+	const listFields = ["filesRead", "filesModified"] as const;
+	const retainedFragment = initialRaw
+		? completeBlockMatches(cleanXmlText(initialRaw), SUMMARY_BLOCK_RE).at(-1)?.value
+		: undefined;
+	const recoverableUnknownValues = retainedFragment
+		? recoverableUnknownSummaryValues(retainedFragment)
+		: [];
+	const unusedUnknownValues = [...recoverableUnknownValues];
+	return (
+		scalarFields.every(([field, tag]) => {
+			if (!hasVisibleText(initialSummary[field])) {
+				if (!hasVisibleText(repairedSummary[field])) return true;
+				const recovered = retainedFragment
+					? extractRecoverableTagText(retainedFragment, tag)
+					: null;
+				if (recovered && hasVisibleText(recovered.value)) {
+					return allowMergedValues
+						? containsRecoverableText(recovered, repairedSummary[field])
+						: matchesRecoverableText(recovered, repairedSummary[field]);
+				}
+				if (allowMergedValues) return true;
+				const matchIndex = unusedUnknownValues.findIndex((value) =>
+					matchesRecoverableText(value, repairedSummary[field]),
+				);
+				if (matchIndex < 0) return false;
+				unusedUnknownValues.splice(matchIndex, 1);
+				return true;
+			}
+			const initialValue = normalizeRecoverableText(initialSummary[field]);
+			const repairedValue = normalizeRecoverableText(repairedSummary[field]);
+			return allowMergedValues
+				? repairedValue.includes(initialValue)
+				: repairedValue === initialValue;
+		}) &&
+		listFields.every((field) => {
+			if (allowMergedValues) {
+				return preservesStringItems(initialSummary[field], repairedSummary[field]);
+			}
+			const parentTag = field === "filesRead" ? "files_read" : "files_modified";
+			return preservesRetainedList(
+				initialSummary[field],
+				repairedSummary[field],
+				retainedFragment ? extractRecoverableChildTexts(retainedFragment, parentTag, "file") : [],
+				unusedUnknownValues,
+			);
+		})
+	);
+}
+
+function mergedSummaryValuesAreGrounded(
+	initialRaw: string | null | undefined,
+	repairedSummary: ParsedSummary,
+): boolean {
+	if (!initialRaw) return false;
+	const summaryBlocks = allSummaryFragments(initialRaw);
+	if (summaryBlocks.length === 0) return false;
+	const directChildren = summaryBlocks.map((block) => directChildFragments(block, "summary"));
+	const unusedUnknownValues = summaryBlocks
+		.flatMap(recoverableUnknownSummaryValues)
+		.map(({ value, complete }) => ({ value: normalizeRecoverableText(value), complete }));
+	const scalarFields = [
+		["request", "request"],
+		["investigated", "investigated"],
+		["learned", "learned"],
+		["completed", "completed"],
+		["nextSteps", "next_steps"],
+		["notes", "notes"],
+	] as const;
+	for (const [field, tag] of scalarFields) {
+		const actual = repairedSummary[field];
+		if (!hasVisibleText(actual)) continue;
+		const sources: GroundingText[] = directChildren.flatMap((children, fragmentIndex) =>
+			children.flatMap((child) => {
+				if (child.tag !== tag) return [];
+				const value = visibleTextForComparison(child.value);
+				return value
+					? [
+							{
+								value,
+								complete: child.complete,
+								mayComplete: !child.complete && fragmentIndex === directChildren.length - 1,
+							},
+						]
+					: [];
+			}),
+		);
+		if (!consumeComposedRecoverableValues(actual, sources, unusedUnknownValues)) return false;
+	}
+	const listFields = [
+		["filesRead", "files_read"],
+		["filesModified", "files_modified"],
+	] as const;
+	for (const [field, parentTag] of listFields) {
+		const sources = summaryBlocks
+			.flatMap((block, fragmentIndex) =>
+				extractRecoverableChildTexts(block, parentTag, "file").map(({ value, complete }) => ({
+					value: normalizeRecoverableText(value),
+					complete,
+					mayComplete: !complete && fragmentIndex === summaryBlocks.length - 1,
+				})),
+			)
+			.sort((a, b) => Number(b.complete) - Number(a.complete));
+		for (const actual of repairedSummary[field]) {
+			const normalizedActual = normalizeRecoverableText(actual);
+			const sourceIndex = sources.findIndex(
+				(source) =>
+					source.value === normalizedActual ||
+					(source.mayComplete && normalizedActual.startsWith(source.value)),
+			);
+			if (sourceIndex >= 0) {
+				sources.splice(sourceIndex, 1);
+				continue;
+			}
+			const unknownIndex = unusedUnknownValues.findIndex(
+				(source) => source.value === normalizedActual,
+			);
+			if (unknownIndex < 0) return false;
+			unusedUnknownValues.splice(unknownIndex, 1);
+		}
+	}
+	return true;
+}
+
+function consumeComposedRecoverableValues(
+	actual: string,
+	sources: GroundingText[],
+	unknownValues: RecoverableText[],
+): boolean {
+	const normalizedActual = visibleTextForComparison(actual);
+	const candidates = [
+		...sources.map(({ value, complete, mayComplete }) => ({
+			value: normalizeRecoverableText(value),
+			complete,
+			mayComplete,
+			unknownIndex: -1,
+		})),
+		...unknownValues.map(({ value, complete }, unknownIndex) => ({
+			value,
+			complete,
+			mayComplete: false,
+			unknownIndex,
+		})),
+	]
+		.filter(({ value }) => value.length > 0)
+		.map((candidate) => ({ ...candidate, index: normalizedActual.indexOf(candidate.value) }))
+		.filter(({ index }) => index >= 0)
+		.sort(
+			(a, b) =>
+				a.index - b.index || b.value.length - a.value.length || a.unknownIndex - b.unknownIndex,
+		);
+	const selected: typeof candidates = [];
+	let literalEnd = -1;
+	for (const candidate of candidates) {
+		if (candidate.index < literalEnd) continue;
+		selected.push(candidate);
+		literalEnd = candidate.index + candidate.value.length;
+	}
+	if (selected.length === 0) return false;
+	const selectedSourceValues = new Set(
+		selected.filter((candidate) => candidate.unknownIndex < 0).map((candidate) => candidate.value),
+	);
+	if (
+		[...new Set(sources.map((source) => normalizeRecoverableText(source.value)))].some(
+			(value) => !selectedSourceValues.has(value),
+		)
+	) {
+		return false;
+	}
+	let remaining = "";
+	let cursor = 0;
+	const consumedUnknownIndexes = new Set<number>();
+	for (const [index, candidate] of selected.entries()) {
+		remaining += normalizedActual.slice(cursor, candidate.index);
+		const nextCandidate = selected[index + 1];
+		cursor = candidate.mayComplete
+			? (nextCandidate?.index ?? normalizedActual.length)
+			: candidate.index + candidate.value.length;
+		if (candidate.unknownIndex >= 0) consumedUnknownIndexes.add(candidate.unknownIndex);
+	}
+	remaining += normalizedActual.slice(cursor);
+	const residue = remaining
+		.replace(/\b(?:and|then)\b/gi, " ")
+		.replace(/[\s,.;:|/&+()[\]{}-]+/g, "");
+	if (residue.length > 0) return false;
+	for (const index of [...consumedUnknownIndexes].sort((a, b) => b - a)) {
+		unknownValues.splice(index, 1);
+	}
+	return true;
+}
+
+function completeBlockMatches(
+	raw: string,
+	pattern: RegExp,
+): Array<{ index: number; value: string }> {
+	return [...raw.matchAll(new RegExp(pattern.source, pattern.flags))].flatMap((match) =>
+		match.index == null ? [] : [{ index: match.index, value: match[0] }],
+	);
+}
+
+function rootBlockBoundaries(raw: string): number[] {
+	return [...raw.matchAll(/<(?:observation|summary|skip_summary)(?:\s|>)/gi)].flatMap((match) =>
+		match.index == null ? [] : [match.index],
+	);
+}
+
+function blockFragment(
+	raw: string,
+	start: number,
+	complete: string | undefined,
+	boundaries: number[],
+): string {
+	if (complete) return complete;
+	const end = boundaries.find((boundary) => boundary > start) ?? raw.length;
+	return raw.slice(start, end);
+}
+
+function allSummaryFragments(raw: string): string[] {
+	const cleaned = cleanXmlText(raw);
+	const completeByStart = new Map(
+		completeBlockMatches(cleaned, SUMMARY_BLOCK_RE).map((match) => [match.index, match.value]),
+	);
+	const boundaries = rootBlockBoundaries(cleaned);
+	const summaryStarts = [...cleaned.matchAll(/<summary(?:\s|>)/gi)].flatMap((opening) =>
+		opening.index == null ? [] : [opening.index],
+	);
+	return summaryStarts.map((start, index) => {
+		const complete = completeByStart.get(start);
+		const nextSummaryStart = summaryStarts[index + 1];
+		if (complete && nextSummaryStart !== undefined && nextSummaryStart < start + complete.length) {
+			return cleaned.slice(start, nextSummaryStart);
+		}
+		return blockFragment(cleaned, start, complete, boundaries);
+	});
+}
+
+interface RecoverableText {
+	value: string;
+	complete: boolean;
+}
+
+interface GroundingText extends RecoverableText {
+	mayComplete: boolean;
+}
+
+function extractRecoverableTagText(xml: string, tag: string): RecoverableText | null {
+	const escapedTag = escapeRegExpLiteral(tag);
+	const opening = new RegExp(`<${escapedTag}(?=[\\s/>])[^>]*>`, "i").exec(xml);
+	if (!opening) return null;
+	const contentStart = opening.index + opening[0].length;
+	const remainder = xml.slice(contentStart);
+	const closing = new RegExp(`</${escapedTag}>`, "i").exec(remainder);
+	const value = (
+		closing ? remainder.slice(0, closing.index) : (remainder.split("<", 1)[0] ?? "")
+	).trim();
+	return { value, complete: closing !== null };
+}
+
+function matchesRecoverableText(recovered: RecoverableText | null, actual: string | null): boolean {
+	if (!recovered || !hasVisibleText(recovered.value)) return true;
+	const normalizedRecovered = normalizeRecoverableText(recovered.value);
+	const normalizedActual = normalizeRecoverableText(actual ?? "");
+	return recovered.complete
+		? normalizedActual === normalizedRecovered
+		: normalizedActual.startsWith(normalizedRecovered);
+}
+
+function containsRecoverableText(
+	recovered: RecoverableText | null,
+	actual: string | null,
+): boolean {
+	if (!recovered || !hasVisibleText(recovered.value)) return true;
+	return normalizeRecoverableText(actual ?? "").includes(normalizeRecoverableText(recovered.value));
+}
+
+function normalizeRecoverableText(value: string): string {
+	return value
+		.replace(/&lt;/gi, "<")
+		.replace(/&gt;/gi, ">")
+		.replace(/&quot;/gi, '"')
+		.replace(/&apos;/gi, "'")
+		.replace(/&amp;/gi, "&")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function extractRecoverableChildTexts(
+	xml: string,
+	parentTag: string,
+	childTag: string,
+): RecoverableText[] {
+	const escapedParentTag = escapeRegExpLiteral(parentTag);
+	const escapedChildTag = escapeRegExpLiteral(childTag);
+	const parentOpening = new RegExp(`<${escapedParentTag}(?=[\\s/>])[^>]*>`, "i").exec(xml);
+	if (!parentOpening) return [];
+	const parentContentStart = parentOpening.index + parentOpening[0].length;
+	const parentRemainder = xml.slice(parentContentStart);
+	const parentClosing = new RegExp(`</${escapedParentTag}>`, "i").exec(parentRemainder);
+	const siblingContainer = /<(?:facts|concepts|files_read|files_modified)(?:\s|>)/i.exec(
+		parentRemainder,
+	);
+	const parentEnd = Math.min(
+		parentClosing?.index ?? parentRemainder.length,
+		siblingContainer?.index ?? parentRemainder.length,
+	);
+	const parentContent = parentRemainder.slice(0, parentEnd);
+	const openings = [
+		...parentContent.matchAll(new RegExp(`<${escapedChildTag}(?=[\\s/>])[^>]*>`, "gi")),
+	];
+	return openings.flatMap((opening, index) => {
+		if (opening.index == null) return [];
+		const contentStart = opening.index + opening[0].length;
+		const nextOpening = openings[index + 1]?.index ?? parentContent.length;
+		const remainder = parentContent.slice(contentStart, nextOpening);
+		const closing = new RegExp(`</${escapedChildTag}>`, "i").exec(remainder);
+		const value = (
+			closing ? remainder.slice(0, closing.index) : (remainder.split("<", 1)[0] ?? "")
+		).trim();
+		return hasVisibleText(value) ? [{ value, complete: closing !== null }] : [];
+	});
+}
+
+function preservesRecoverableItems(recovered: RecoverableText[], actual: string[]): boolean {
+	const remaining = [...actual];
+	for (const item of recovered.filter((candidate) => candidate.complete)) {
+		const normalizedItem = normalizeRecoverableText(item.value);
+		const matchIndex = remaining.findIndex(
+			(candidate) => normalizeRecoverableText(candidate) === normalizedItem,
+		);
+		if (matchIndex < 0) return false;
+		remaining.splice(matchIndex, 1);
+	}
+	for (const item of recovered.filter((candidate) => !candidate.complete)) {
+		const normalizedItem = normalizeRecoverableText(item.value);
+		const matchIndex = remaining.findIndex((candidate) =>
+			normalizeRecoverableText(candidate).startsWith(normalizedItem),
+		);
+		if (matchIndex < 0) return false;
+		remaining.splice(matchIndex, 1);
+	}
+	return true;
+}
+
+function discardedObservationFragments(raw: string): string[] {
+	const cleaned = cleanXmlText(raw);
+	const completeByStart = new Map(
+		completeBlockMatches(cleaned, OBSERVATION_BLOCK_RE).map((match) => [match.index, match.value]),
+	);
+	const boundaries = rootBlockBoundaries(cleaned);
+	return [...cleaned.matchAll(/<observation(?:\s|>)/gi)].flatMap((opening) => {
+		if (opening.index == null) return [];
+		const complete = completeByStart.get(opening.index);
+		if (complete && parseObservationBlock(complete) !== null) return [];
+		return [blockFragment(cleaned, opening.index, complete, boundaries)];
+	});
+}
+
+function discardedSummaryFragments(raw: string, parsed: ParsedOutput): string[] {
+	const cleaned = cleanXmlText(raw);
+	const completeMatches = completeBlockMatches(cleaned, SUMMARY_BLOCK_RE);
+	const completeByStart = new Map(completeMatches.map((match) => [match.index, match.value]));
+	const retainedStart = parsed.summary ? completeMatches.at(-1)?.index : undefined;
+	const boundaries = rootBlockBoundaries(cleaned);
+	return [...cleaned.matchAll(/<summary(?:\s|>)/gi)].flatMap((opening) => {
+		if (opening.index == null || opening.index === retainedStart) return [];
+		return [blockFragment(cleaned, opening.index, completeByStart.get(opening.index), boundaries)];
+	});
+}
+
+function observationMatchesRecoveredFields(
+	fragment: string,
+	observation: ParsedObservation,
+	additionalGrounding = "",
+): boolean {
+	const recoveredKind = extractRecoverableTagText(fragment, "type");
+	const kind = (recoveredKind?.value || observationKind(fragment)).trim().toLowerCase();
+	const kindCouldBeSupportedPrefix = [...SUPPORTED_OBSERVATION_KINDS].some((supported) =>
+		supported.startsWith(kind),
+	);
+	const kindMatches =
+		!kind ||
+		(recoveredKind?.complete === false
+			? kindCouldBeSupportedPrefix
+				? observation.kind.startsWith(kind)
+				: SUPPORTED_OBSERVATION_KINDS.has(observation.kind)
+			: observation.kind === kind ||
+				(!SUPPORTED_OBSERVATION_KINDS.has(kind) &&
+					SUPPORTED_OBSERVATION_KINDS.has(observation.kind)));
+	return (
+		kindMatches &&
+		matchesRecoverableText(extractRecoverableTagText(fragment, "title"), observation.title) &&
+		matchesRecoverableText(
+			extractRecoverableTagText(fragment, "narrative"),
+			observation.narrative,
+		) &&
+		matchesRecoverableText(extractRecoverableTagText(fragment, "subtitle"), observation.subtitle) &&
+		preservesRecoverableItems(
+			extractRecoverableChildTexts(fragment, "facts", "fact"),
+			observation.facts,
+		) &&
+		preservesRecoverableItems(
+			extractRecoverableChildTexts(fragment, "concepts", "concept"),
+			observation.concepts,
+		) &&
+		preservesRecoverableItems(
+			extractRecoverableChildTexts(fragment, "files_read", "file"),
+			observation.filesRead,
+		) &&
+		preservesRecoverableItems(
+			extractRecoverableChildTexts(fragment, "files_modified", "file"),
+			observation.filesModified,
+		) &&
+		addedObservationFieldsAreGrounded(fragment, observation, additionalGrounding)
+	);
+}
+
+function addedObservationFieldsAreGrounded(
+	fragment: string,
+	observation: ParsedObservation,
+	additionalGrounding: string,
+): boolean {
+	const source = normalizeRecoverableText(
+		`${visibleTextForComparison(fragment)} ${additionalGrounding}`,
+	).toLowerCase();
+	const scalarFields = [
+		["title", observation.title],
+		["subtitle", observation.subtitle ?? ""],
+		["narrative", observation.narrative],
+	] as const;
+	if (
+		scalarFields.some(
+			([tag, value]) =>
+				hasVisibleText(value) &&
+				!hasVisibleText(extractRecoverableTagText(fragment, tag)?.value ?? "") &&
+				!valueIsComposedFromSource(value, source),
+		)
+	) {
+		return false;
+	}
+	return (
+		addedItemsAreGrounded(
+			extractRecoverableChildTexts(fragment, "facts", "fact"),
+			observation.facts,
+			source,
+		) &&
+		addedItemsAreGrounded(
+			extractRecoverableChildTexts(fragment, "concepts", "concept"),
+			observation.concepts,
+			source,
+			(value) => OBSERVATION_CONCEPTS.has(value.trim().toLowerCase()),
+		) &&
+		addedItemsAreGrounded(
+			extractRecoverableChildTexts(fragment, "files_read", "file"),
+			observation.filesRead,
+			source,
+			(value) => isGroundedProsePath(value, source),
+		) &&
+		addedItemsAreGrounded(
+			extractRecoverableChildTexts(fragment, "files_modified", "file"),
+			observation.filesModified,
+			source,
+			(value) => isGroundedProsePath(value, source),
+		)
+	);
+}
+
+function valueIsComposedFromSource(value: string, source: string): boolean {
+	const segments = normalizeRecoverableText(value)
+		.toLowerCase()
+		.split(/(?:[!?;]+|\.(?=\s|$)|\s+[—–]\s+)/)
+		.map((segment) => segment.trim())
+		.filter(Boolean);
+	return segments.length > 0 && segments.every((segment) => isGroundedProsePhrase(segment, source));
+}
+
+function addedItemsAreGrounded(
+	recovered: RecoverableText[],
+	actual: string[],
+	source: string,
+	allowAddition: (value: string) => boolean = (value) => valueIsComposedFromSource(value, source),
+): boolean {
+	const remaining = [...actual];
+	for (const item of recovered) {
+		const matchIndex = remaining.findIndex((candidate) => matchesRecoverableText(item, candidate));
+		if (matchIndex >= 0) remaining.splice(matchIndex, 1);
+	}
+	return remaining.every(allowAddition);
+}
+
+function summaryMatchesRecoveredFields(
+	fragment: string,
+	summary: ParsedSummary,
+	allowMergedValues: boolean,
+): boolean {
+	const scalarFields = [
+		["request", "request"],
+		["investigated", "investigated"],
+		["learned", "learned"],
+		["completed", "completed"],
+		["next_steps", "nextSteps"],
+		["notes", "notes"],
+	] as const;
+	const repairedValues = [
+		summary.request,
+		summary.investigated,
+		summary.learned,
+		summary.completed,
+		summary.nextSteps,
+		summary.notes,
+		...summary.filesRead,
+		...summary.filesModified,
+	];
+	return (
+		scalarFields.every(([tag, field]) =>
+			(allowMergedValues ? containsRecoverableText : matchesRecoverableText)(
+				extractRecoverableTagText(fragment, tag),
+				summary[field],
+			),
+		) &&
+		preservesRecoverableItems(
+			extractRecoverableChildTexts(fragment, "files_read", "file"),
+			summary.filesRead,
+		) &&
+		preservesRecoverableItems(
+			extractRecoverableChildTexts(fragment, "files_modified", "file"),
+			summary.filesModified,
+		) &&
+		recoverableUnknownSummaryValues(fragment).every((recovered) =>
+			repairedValues.some((value) =>
+				(allowMergedValues ? containsRecoverableText : matchesRecoverableText)(recovered, value),
+			),
+		)
+	);
+}
+
+function recoverableUnknownSummaryValues(fragment: string): RecoverableText[] {
+	const completeSummary = /<\/summary>\s*$/i.test(fragment.trim());
+	return directChildFragments(fragment, "summary")
+		.filter(({ tag }) => tag !== "observation" && !SUMMARY_FIELDS.has(tag))
+		.flatMap(({ value: rawValue, complete }) => {
+			const value = visibleTextForComparison(rawValue);
+			return value ? [{ value, complete: complete || completeSummary }] : [];
+		});
+}
+
+function recoversUnknownSummaryFields(
+	initialRaw: string | null | undefined,
+	repairedSummary: ParsedSummary | null,
+): boolean {
+	if (!initialRaw) return true;
+	const unknownValues = completeBlockMatches(cleanXmlText(initialRaw), SUMMARY_BLOCK_RE).flatMap(
+		({ value: block }) => recoverableUnknownSummaryValues(block),
+	);
+	if (unknownValues.length === 0) return true;
+	if (!repairedSummary) return false;
+	const repairedValues = [
+		repairedSummary.request,
+		repairedSummary.investigated,
+		repairedSummary.learned,
+		repairedSummary.completed,
+		repairedSummary.nextSteps,
+		repairedSummary.notes,
+		...repairedSummary.filesRead,
+		...repairedSummary.filesModified,
+	];
+	return unknownValues.every((recovered) =>
+		repairedValues.some((value) => containsRecoverableText(recovered, value)),
+	);
+}
+
+function recoversDiscardedBlocks(
+	initialRaw: string | null | undefined,
+	initialParsed: ParsedOutput,
+	repairedParsed: ParsedOutput,
+): boolean {
+	if (!initialRaw) return true;
+	const initialDiagnostics = inspectObserverResponseStructure(initialRaw, initialParsed);
+	const recoveredObservations = remainingAfterPreservedObservations(
+		initialParsed.observations,
+		repairedParsed.observations,
+		initialRaw,
+	);
+	if (!recoveredObservations) return false;
+	const discardedObservations = discardedObservationFragments(initialRaw);
+	if (discardedObservations.length < initialDiagnostics.discardedObservationBlocks) return false;
+	for (const fragment of discardedObservations) {
+		const surroundingProse = proseOutsideRootBlocks(initialRaw).join(" ");
+		const matchIndex = recoveredObservations.findIndex((observation) =>
+			observationMatchesRecoveredFields(fragment, observation, surroundingProse),
+		);
+		if (matchIndex < 0) return false;
+		recoveredObservations.splice(matchIndex, 1);
+	}
+	if (
+		recoveredObservations.length > 0 &&
+		!observationsAreGroundedInPlainProse(plainProseSource(initialRaw) ?? "", recoveredObservations)
+	) {
+		return false;
+	}
+	if (!preservesProseOutsideRootBlocks(initialRaw, repairedParsed)) return false;
+	const discardedSummaries = discardedSummaryFragments(initialRaw, initialParsed);
+	if (discardedSummaries.length < initialDiagnostics.discardedSummaryBlocks) return false;
+	const allowMergedSummaryValues = initialDiagnostics.summaryBlocks > 1;
+	return (
+		discardedSummaries.length === 0 ||
+		(repairedParsed.summary !== null &&
+			discardedSummaries.every((fragment) =>
+				summaryMatchesRecoveredFields(
+					fragment,
+					repairedParsed.summary as ParsedSummary,
+					allowMergedSummaryValues,
+				),
+			))
+	);
+}
+
+function preservesProseOutsideRootBlocks(initialRaw: string, repaired: ParsedOutput): boolean {
+	const proseFragments = proseOutsideRootBlocks(initialRaw);
+	if (proseFragments.length === 0) return true;
+	const repairedValues = [
+		...repaired.observations.flatMap((observation) => [
+			observation.title,
+			observation.subtitle ?? "",
+			observation.narrative,
+			...observation.facts,
+		]),
+		...(repaired.summary
+			? [
+					repaired.summary.request,
+					repaired.summary.investigated,
+					repaired.summary.learned,
+					repaired.summary.completed,
+					repaired.summary.nextSteps,
+					repaired.summary.notes,
+				]
+			: []),
+	].map((value) => normalizeRecoverableText(value).toLowerCase());
+	return proseFragments.every((fragment) =>
+		repairedValues.some((value) => value.includes(fragment)),
+	);
+}
+
+function proseOutsideRootBlocks(raw: string): string[] {
+	const cleaned = cleanXmlText(raw);
+	const boundaries = rootBlockBoundaries(cleaned);
+	if (boundaries.length === 0) return [];
+	const fragments: string[] = [];
+	let cursor = 0;
+	for (const [index, start] of boundaries.entries()) {
+		if (start < cursor) continue;
+		const prose = visibleTextForComparison(cleaned.slice(cursor, start));
+		if (prose) fragments.push(normalizeRecoverableText(prose).toLowerCase());
+		const remainder = cleaned.slice(start);
+		const rootName = /^<([A-Za-z_][\w:.-]*)/i.exec(remainder)?.[1]?.toLowerCase();
+		const completePattern =
+			rootName === "observation"
+				? /^<observation[^>]*>.*?<\/observation>/is
+				: rootName === "summary"
+					? /^<summary[^>]*>.*?<\/summary>/is
+					: /^<skip_summary(?:\s+reason="[^"]+")?\s*(?:\/>|>\s*<\/skip_summary>)/i;
+		const complete = completePattern.exec(remainder)?.[0];
+		cursor = complete ? start + complete.length : (boundaries[index + 1] ?? cleaned.length);
+	}
+	const trailing = visibleTextForComparison(cleaned.slice(cursor));
+	if (trailing) fragments.push(normalizeRecoverableText(trailing).toLowerCase());
+	return fragments;
+}
+
+function observationsAreGroundedInPlainProse(
+	prose: string,
+	observations: ParsedObservation[],
+): boolean {
+	if (observations.length > 1) return false;
+	if (observations.length === 0) return true;
+	const observation = observations[0];
+	if (!observation) return false;
+	const title = normalizeRecoverableText(observation.title).toLowerCase();
+	const narrative = normalizeRecoverableText(observation.narrative).toLowerCase();
+	return (
+		narrative === prose &&
+		isGroundedProsePhrase(title, prose) &&
+		(!hasVisibleText(observation.subtitle ?? "") ||
+			isGroundedProsePhrase(observation.subtitle as string, prose)) &&
+		observation.facts.every((value) => isGroundedProsePhrase(value, prose)) &&
+		observation.concepts.every((value) => OBSERVATION_CONCEPTS.has(value.trim().toLowerCase())) &&
+		[...observation.filesRead, ...observation.filesModified].every((value) =>
+			isGroundedProsePath(value, prose),
+		)
+	);
+}
+
+function isGroundedProsePhrase(value: string, prose: string): boolean {
+	const normalized = normalizeRecoverableText(value).toLowerCase();
+	if (!normalized) return false;
+	const comparable = normalized.replace(/[.!?]+$/, "");
+	for (const segment of prose
+		.split(/(?:[!?;]+|\.(?=\s|$)|\s+[—–]\s+)/)
+		.map((part) => part.trim())) {
+		if (!segment) continue;
+		const index = segment.indexOf(comparable);
+		if (index < 0) continue;
+		const before = segment[index - 1];
+		const after = segment[index + comparable.length];
+		if ((before && /[\p{L}\p{N}_]/u.test(before)) || (after && /[\p{L}\p{N}_]/u.test(after))) {
+			continue;
+		}
+		const negations =
+			segment.match(
+				/\b(?:not|no|never|without|cannot|can't|unable|failed|none|neither|nor|lacks?|missing|absent|\w+n't)\b/g,
+			) ?? [];
+		if (
+			/(?:\b(?:non|un|mis)-)$/.test(segment.slice(0, index)) ||
+			negations.some(
+				(negation) => !new RegExp(`\\b${escapeRegExpLiteral(negation)}\\b`).test(comparable),
+			)
+		) {
+			continue;
+		}
+		return true;
+	}
+	return false;
+}
+
+function isGroundedProsePath(value: string, prose: string): boolean {
+	const normalized = normalizeRecoverableText(value).toLowerCase();
+	if (!normalized) return false;
+	let index = prose.indexOf(normalized);
+	while (index >= 0) {
+		const before = prose[index - 1];
+		const after = prose[index + normalized.length];
+		const afterNext = prose[index + normalized.length + 1];
+		const afterIsTerminalPunctuation =
+			Boolean(after && /[.,;:!?]/.test(after)) && (!afterNext || /\s/.test(afterNext));
+		if (
+			(!before || !/[\p{L}\p{N}_./-]/u.test(before)) &&
+			(!after || !/[\p{L}\p{N}_./-]/u.test(after) || afterIsTerminalPunctuation)
+		) {
+			return true;
+		}
+		index = prose.indexOf(normalized, index + 1);
+	}
+	return false;
+}
+
+function summaryIsGroundedInPlainProse(
+	prose: string,
+	summary: ParsedSummary | null,
+	requireFullCoverage: boolean,
+): boolean {
+	if (!summary) return false;
+	const scalarValues = [
+		summary.request,
+		summary.investigated,
+		summary.learned,
+		summary.completed,
+		summary.nextSteps,
+		summary.notes,
+	].filter(hasVisibleText);
+	const paths = [...summary.filesRead, ...summary.filesModified];
+	if (scalarValues.length === 0 && paths.length === 0) return false;
+	if (!scalarValues.every((value) => isGroundedProsePhrase(value, prose))) return false;
+	if (!paths.every((value) => isGroundedProsePath(value, prose))) {
+		return false;
+	}
+	if (!requireFullCoverage) return true;
+	const normalizedValues = scalarValues.map((value) =>
+		normalizeRecoverableText(value)
+			.toLowerCase()
+			.replace(/[.!?]+$/, ""),
+	);
+	return prose
+		.split(/(?:[!?;]+|\.(?=\s|$)|\s+[—–]\s+)/)
+		.map((part) => part.trim())
+		.filter(Boolean)
+		.every((segment) => normalizedValues.some((value) => value === segment));
+}
+
+function plainProseSource(initialRaw: string | null | undefined): string | null {
+	if (!initialRaw) return null;
+	const cleaned = cleanXmlText(initialRaw);
+	if (!cleaned) return null;
+	if (rootBlockBoundaries(cleaned).length === 0) {
+		const visible = visibleTextForComparison(cleaned);
+		return visible ? normalizeRecoverableText(visible).toLowerCase() : null;
+	}
+	if (/<\/?[A-Za-z_][\w:.-]*(?:\s|\/?>)/.test(cleaned)) return null;
+	return normalizeRecoverableText(cleaned).toLowerCase();
+}
+
+function proseLooksLowSignal(prose: string): boolean {
+	const normalized = prose.replace(/[.!?]+$/, "").trim();
+	return (
+		isLowSignalObservation(prose) ||
+		/^(?:ok|okay|yes|no|thanks|thank you|got it|understood|approved|sounds good|sure)$/.test(
+			normalized,
+		)
+	);
+}
+
+function repairedOutputIsGroundedInPlainProse(
+	initialRaw: string | null | undefined,
+	repairedParsed: ParsedOutput,
+): boolean {
+	const prose = plainProseSource(initialRaw);
+	if (!prose) return false;
+	if (repairedParsed.skipSummaryReason !== null) {
+		return (
+			repairedParsed.skipSummaryReason.trim().toLowerCase() === "low-signal" &&
+			repairedParsed.observations.length === 0 &&
+			repairedParsed.summary === null &&
+			proseLooksLowSignal(prose)
+		);
+	}
+	if (
+		!summaryIsGroundedInPlainProse(
+			prose,
+			repairedParsed.summary,
+			repairedParsed.observations.length === 0,
+		)
+	) {
+		return false;
+	}
+	return observationsAreGroundedInPlainProse(prose, repairedParsed.observations);
+}
+
+function hasRecoveredUsableObservation(
+	initialObservations: ParsedObservation[],
+	repairedObservations: ParsedObservation[],
+): boolean {
+	const initialKindsByContent = new Map<string, string[]>();
+	for (const observation of initialObservations) {
+		const key = observationContentKey(observation);
+		const kinds = initialKindsByContent.get(key) ?? [];
+		kinds.push(observation.kind);
+		initialKindsByContent.set(key, kinds);
+	}
+	return repairedObservations.some((observation) => {
+		if (!SUPPORTED_OBSERVATION_KINDS.has(observation.kind)) return false;
+		const initialKinds = initialKindsByContent.get(observationContentKey(observation));
+		return !initialKinds?.some((kind) => SUPPORTED_OBSERVATION_KINDS.has(kind));
+	});
+}
+
+/** Prefer a repair only when it improves or replaces unusable observer output. */
+export function shouldPreferRepairedObserverResponse(
+	initialParsed: ParsedOutput,
+	repairedRaw: string | null,
+	repairedParsed: ParsedOutput,
+	initialRaw?: string | null,
+): boolean {
+	if (!repairedRaw) return false;
+	const initialHasStructuredOutput =
+		initialParsed.observations.length > 0 ||
+		initialParsed.summary !== null ||
+		initialParsed.skipSummaryReason !== null;
+	const repairedHasStructuredOutput =
+		repairedParsed.observations.length > 0 ||
+		repairedParsed.summary !== null ||
+		repairedParsed.skipSummaryReason !== null;
+	const repairedHasNoDataLoss = !inspectObserverResponseStructure(repairedRaw, repairedParsed)
+		.dataLoss;
+	const repairedHasConsistentSummaryDecision =
+		repairedParsed.summary === null || repairedParsed.skipSummaryReason === null;
+	const initialHasContradictorySummaryDecision =
+		initialParsed.summary !== null && initialParsed.skipSummaryReason !== null;
+	const initialDiagnostics = initialRaw
+		? inspectObserverResponseStructure(initialRaw, initialParsed)
+		: null;
+	const recoveredUsableSummary =
+		initialParsed.summary === null &&
+		repairedParsed.summary !== null &&
+		(initialDiagnostics?.discardedSummaryBlocks ?? 0) > 0;
+	const allowMergedSummaryValues = (initialDiagnostics?.summaryBlocks ?? 0) > 1;
+	const requiresSummaryGrounding =
+		allowMergedSummaryValues ||
+		(initialParsed.summary === null && (initialDiagnostics?.discardedSummaryBlocks ?? 0) > 0);
+	const mergedSummaryValuesArePreserved =
+		!requiresSummaryGrounding ||
+		(repairedParsed.summary !== null &&
+			mergedSummaryValuesAreGrounded(initialRaw, repairedParsed.summary));
+	const introducedSummaryIsGrounded =
+		initialParsed.summary !== null ||
+		repairedParsed.summary === null ||
+		(initialDiagnostics?.discardedSummaryBlocks ?? 0) > 0 ||
+		(initialRaw !== null &&
+			initialRaw !== undefined &&
+			summaryIsGroundedInPlainProse(
+				normalizeRecoverableText(visibleTextForComparison(initialRaw)).toLowerCase(),
+				repairedParsed.summary,
+				false,
+			));
+	if (!initialHasStructuredOutput) {
+		if (initialRaw !== null && initialRaw !== undefined && !cleanXmlText(initialRaw)) return false;
+		if (plainProseSource(initialRaw) !== null) {
+			return (
+				repairedHasStructuredOutput &&
+				repairedHasNoDataLoss &&
+				repairedHasConsistentSummaryDecision &&
+				repairedOutputIsGroundedInPlainProse(initialRaw, repairedParsed)
+			);
+		}
+		return (
+			repairedHasStructuredOutput &&
+			repairedHasNoDataLoss &&
+			repairedHasConsistentSummaryDecision &&
+			introducedSummaryIsGrounded &&
+			mergedSummaryValuesArePreserved &&
+			recoversUnknownSummaryFields(initialRaw, repairedParsed.summary) &&
+			recoversDiscardedBlocks(initialRaw, initialParsed, repairedParsed)
+		);
+	}
+	const recoveredUsableObservation = hasRecoveredUsableObservation(
+		initialParsed.observations,
+		repairedParsed.observations,
+	);
+	return (
+		repairedHasStructuredOutput &&
+		repairedHasNoDataLoss &&
+		repairedHasConsistentSummaryDecision &&
+		introducedSummaryIsGrounded &&
+		mergedSummaryValuesArePreserved &&
+		recoversUnknownSummaryFields(initialRaw, repairedParsed.summary) &&
+		recoversDiscardedBlocks(initialRaw, initialParsed, repairedParsed) &&
+		preservesParsedObservations(
+			initialParsed.observations,
+			repairedParsed.observations,
+			initialRaw,
+		) &&
+		preservesPopulatedSummaryFields(
+			initialParsed.summary,
+			repairedParsed.summary,
+			allowMergedSummaryValues,
+			initialRaw,
+		) &&
+		(initialParsed.skipSummaryReason !== null
+			? repairedParsed.skipSummaryReason === initialParsed.skipSummaryReason ||
+				(repairedParsed.skipSummaryReason === null &&
+					(recoveredUsableObservation ||
+						recoveredUsableSummary ||
+						initialHasContradictorySummaryDecision))
+			: initialParsed.summary === null || repairedParsed.skipSummaryReason === null)
+	);
 }
 
 /** Return true if at least one observation has a title or narrative. */

--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -1025,6 +1025,33 @@ describe("ObserverClient.observe()", () => {
 		expect(result.usage).toEqual({ inputTokens: 211, outputTokens: 37, totalTokens: 248 });
 	});
 
+	it("normalizes unpaired UTF-16 surrogates after prompt clipping", async () => {
+		const apiKey = fixtureToken("openai-well-formed-unicode");
+		let capturedInput: Array<{ role: string; content: Array<{ text: string }> }> = [];
+		globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			const body = JSON.parse(String(init?.body ?? "{}")) as {
+				input?: Array<{ role: string; content: Array<{ text: string }> }>;
+			};
+			capturedInput = body.input ?? [];
+			return new Response(JSON.stringify({ output_text: "ok" }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof globalThis.fetch;
+		const client = new ObserverClient({
+			...makeClient("openai", apiKey).toConfig(),
+			observerMaxChars: 100,
+		});
+
+		// A 100-char budget gives the system prompt 75 UTF-16 units; the emoji is split at 75.
+		await client.observe(`${"s".repeat(74)}😀`, "user\uDC00");
+
+		const texts = capturedInput.flatMap((item) => item.content.map((content) => content.text));
+		expect(texts).toHaveLength(2);
+		expect(texts.every((text) => text.isWellFormed())).toBe(true);
+		expect(texts.join("\n")).toContain("�");
+	});
+
 	it("keeps token usage isolated across concurrent observe calls", async () => {
 		const apiKey = fixtureToken("openai-concurrent-usage");
 		globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -1592,11 +1592,13 @@ export class ObserverClient {
 		const maxChars = this.maxChars;
 		const minUserBudget = Math.floor(maxChars * 0.25);
 		const systemBudget = Math.max(0, maxChars - minUserBudget);
-		const clippedSystem =
-			systemPrompt.length > systemBudget ? systemPrompt.slice(0, systemBudget) : systemPrompt;
+		const clippedSystem = (
+			systemPrompt.length > systemBudget ? systemPrompt.slice(0, systemBudget) : systemPrompt
+		).toWellFormed();
 		const userBudget = Math.max(minUserBudget, maxChars - clippedSystem.length);
-		const clippedUser =
-			userPrompt.length > userBudget ? userPrompt.slice(0, userBudget) : userPrompt;
+		const clippedUser = (
+			userPrompt.length > userBudget ? userPrompt.slice(0, userBudget) : userPrompt
+		).toWellFormed();
 
 		try {
 			if (this.runtime === "claude_sidecar") {

--- a/packages/core/src/raw-event-flush.test.ts
+++ b/packages/core/src/raw-event-flush.test.ts
@@ -159,6 +159,106 @@ describe("flushRawEvents max retry", () => {
 		expect(batch.status).toBe("failed");
 	});
 
+	it("keeps a lossy batch retryable when the repair is rejected", async () => {
+		const sessionId = "ses_rejected_lossy_repair";
+		seedEvents(sessionId);
+		let callCount = 0;
+		const lossy = `<observation>
+			<type>discovery</type><title>Retained result</title>
+			<narrative>Keep this valid observation.</narrative>
+		</observation><observation><type>bugfix</type><title>Truncated result`;
+		const unrelatedRepair = `<observation>
+			<type>discovery</type><title>Unrelated result</title>
+			<narrative>This does not recover the truncated block.</narrative>
+		</observation>`;
+		const observer = {
+			observe: async () => {
+				callCount += 1;
+				return {
+					raw: callCount === 1 ? lossy : unrelatedRepair,
+					parsed: null,
+					provider: "test",
+					model: "test-model",
+				};
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		await expect(
+			flushRawEvents(store, { observer } as unknown as IngestOptions, {
+				opencodeSessionId: sessionId,
+				source: "opencode",
+				cwd: null,
+				project: null,
+				startedAt: null,
+				maxEvents: null,
+			}),
+		).rejects.toThrow("observer repair remained lossy during raw-event flush");
+
+		expect(callCount).toBe(2);
+		expect(store.rawEventFlushState(sessionId, "opencode")).toBe(-1);
+		const batch = store.db
+			.prepare(
+				"SELECT status, error_message FROM raw_event_flush_batches WHERE opencode_session_id = ?",
+			)
+			.get(sessionId) as { status: string; error_message: string };
+		expect(batch.status).toBe("failed");
+		expect(batch.error_message).toBe(
+			"Test returned structurally incomplete output that could not be repaired.",
+		);
+		expect(store.recent(10)).toHaveLength(0);
+	});
+
+	it("keeps a lossy skip fallback retryable when repair cannot recover it", async () => {
+		const sessionId = "ses_lossy_skip_repair";
+		seedEvents(sessionId);
+		let callCount = 0;
+		const observer = {
+			observe: async () => {
+				callCount += 1;
+				return {
+					raw:
+						callCount === 1
+							? `<skip_summary reason="low-signal"/><observation><type>bugfix</type><title>Truncated durable result`
+							: `<summary><request>Unrelated repair</request></summary>`,
+					parsed: null,
+					provider: "test",
+					model: "test-model",
+				};
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		await expect(
+			flushRawEvents(store, { observer } as unknown as IngestOptions, {
+				opencodeSessionId: sessionId,
+				source: "opencode",
+				cwd: null,
+				project: null,
+				startedAt: null,
+				maxEvents: null,
+			}),
+		).rejects.toThrow("observer repair remained lossy during raw-event flush");
+
+		expect(callCount).toBe(2);
+		expect(store.rawEventFlushState(sessionId, "opencode")).toBe(-1);
+		const batch = store.db
+			.prepare("SELECT status FROM raw_event_flush_batches WHERE opencode_session_id = ?")
+			.get(sessionId) as { status: string };
+		expect(batch.status).toBe("failed");
+		expect(store.recent(10)).toHaveLength(0);
+	});
+
 	it("uses default max of 5 when env var is not set", async () => {
 		delete process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS;
 		const sessionId = "ses_default_max";

--- a/packages/core/src/raw-event-flush.ts
+++ b/packages/core/src/raw-event-flush.ts
@@ -58,6 +58,9 @@ function summarizeFlushFailure(exc: Error, provider: string | null | undefined):
 	) {
 		return `${providerTitle} returned no usable output for raw-event processing.`;
 	}
+	if (rawMessage === "observer repair remained lossy during raw-event flush") {
+		return `${providerTitle} returned structurally incomplete output that could not be repaired.`;
+	}
 	if (/parse|xml|json/i.test(rawMessage)) {
 		return `${providerTitle} response could not be processed.`;
 	}


### PR DESCRIPTION
## Description

Forward-port the production-facing observer correctness fixes from the parked release-evaluation stack onto current `main` without bringing release machinery with them.

- normalize clipped observer prompts to well-formed Unicode;
- restore concise worthiness guidance that preserves XML shape;
- repair parser-confirmed data loss in live ingestion and extraction replay;
- retain valid initial output when a repair is missing, still lossy, or drops parsed content;
- document the product-first pre-0.40 completion plan.

Tracked by Bead `codemem-c011`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Focused observer tests pass: 173 tests. Full workspace gate passes: 3,420 tests with 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
