### PR TITLE
fix(core): validate embedding tensor conversion

### DIFF
--- a/packages/core/src/embeddings.test.ts
+++ b/packages/core/src/embeddings.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { chunkText, hashText, serializeFloat32 } from "./embeddings.js";
+import { chunkText, embeddingDataToFloat32, hashText, serializeFloat32 } from "./embeddings.js";
 
 describe("hashText", () => {
 	it("returns a 64-char hex SHA-256 digest", () => {
@@ -58,6 +58,36 @@ describe("chunkText", () => {
 		// No sentence/paragraph breaks — should still produce chunks
 		const chunks = chunkText(text, 100);
 		expect(chunks.length).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe("embeddingDataToFloat32", () => {
+	it("converts numeric typed arrays to Float32Array", () => {
+		const vector = embeddingDataToFloat32(new Float64Array([1.5, -2.25, 3]));
+
+		expect(vector).toEqual(new Float32Array([1.5, -2.25, 3]));
+	});
+
+	it("copies source storage", () => {
+		const source = new Float32Array([1, 2, 3]);
+		const vector = embeddingDataToFloat32(source);
+
+		source[0] = 99;
+		expect(vector[0]).toBe(1);
+		expect(vector.buffer).not.toBe(source.buffer);
+	});
+
+	it("rejects bigint data", () => {
+		expect(() => embeddingDataToFloat32(new BigInt64Array([1n]))).toThrow(TypeError);
+	});
+
+	it.each([
+		Number.NaN,
+		Number.POSITIVE_INFINITY,
+		Number.NEGATIVE_INFINITY,
+		Number.MAX_VALUE,
+	])("rejects non-finite or unrepresentable data: %s", (value) => {
+		expect(() => embeddingDataToFloat32([value])).toThrow(TypeError);
 	});
 });
 

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -24,6 +24,22 @@ export interface EmbeddingClient {
 	embed(texts: string[]): Promise<Float32Array[]>;
 }
 
+/** Copy validated embedding model data into owned Float32 storage. */
+export function embeddingDataToFloat32(data: ArrayLike<number | bigint>): Float32Array {
+	const vector = new Float32Array(data.length);
+	for (let index = 0; index < data.length; index++) {
+		const value = data[index];
+		const float32Value = typeof value === "number" ? Math.fround(value) : Number.NaN;
+		if (!Number.isFinite(float32Value)) {
+			throw new TypeError(
+				`Embedding model returned non-finite, non-numeric, or unrepresentable tensor data at index ${index}`,
+			);
+		}
+		vector[index] = float32Value;
+	}
+	return vector;
+}
+
 // ---------------------------------------------------------------------------
 // Text helpers (ports of semantic.py)
 // ---------------------------------------------------------------------------
@@ -169,7 +185,7 @@ async function createTransformersClient(model: string): Promise<EmbeddingClient>
 			for (const text of texts) {
 				const output = await extractor(text, { pooling: "mean", normalize: true });
 				// output.data is a Float32Array of shape [1, dims]
-				results.push(new Float32Array(output.data));
+				results.push(embeddingDataToFloat32(output.data));
 			}
 			return results;
 		},


### PR DESCRIPTION
## Description

Validate model tensor data at the embedding boundary before storing it as `Float32Array` data.

- copy model output into owned storage;
- reject bigint, NaN, and infinite values;
- reject finite Float64 values that overflow to non-finite Float32 values;
- report the failing tensor index.

Tracked by Bead `codemem-pngx`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Focused embedding tests pass: 18 tests. Full stacked workspace gate passes: 3,427 tests with 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
