### PR TITLE
fix(sharing): revoke disabled enrollments by group

### DIFF
--- a/docs/plans/2026-07-28-group-scoped-enrollment-revocation-design.md
+++ b/docs/plans/2026-07-28-group-scoped-enrollment-revocation-design.md
@@ -1,0 +1,50 @@
+# Group-scoped enrollment revocation
+
+## Decision
+
+Disabling a coordinator enrollment revokes access only within that enrollment's coordinator group. It must not globally revoke the device or remove access granted through another active group.
+
+## Why
+
+Coordinator enrollment identity is `(coordinator, group, device)`, while `identity_devices` is a global owner-policy edge keyed only by device. Marking that global edge revoked after one group disables the device would collapse independent trust domains and remove unrelated Project access.
+
+The managed Project boundary already retains its exact coordinator and group in `replication_scopes`. Recipient-policy reconciliation is therefore the correct authority for applying an explicit disabled enrollment to one Project scope.
+
+## Reconciliation contract
+
+For each managed Project reconciliation pass:
+
+1. Read the authoritative scope-membership snapshot for the Project boundary.
+2. Apply owner-policy removals first, preserving the existing fail-closed deny-before-revoke ordering.
+3. Read the complete enrollment snapshot for the boundary's exact coordinator and group, including disabled enrollments.
+4. Interpret enrollment state as follows:
+	- enabled with the expected Identity binding: eligible for retention or grant;
+	- enabled with a conflicting Identity binding: deny and revoke within this scope;
+	- enabled with no Identity binding: cannot receive a new grant, but is not authoritative evidence for revoking an existing membership;
+	- explicitly disabled: deny and revoke within this scope, regardless of the global `identity_devices` edge;
+   - omitted from a successful snapshot: not eligible for a new grant, but not a revocation signal by itself.
+5. Persist a deny overlay before invoking the coordinator membership revoke.
+6. Refresh the local scope-membership cache and coordinator-policy peer trust after effects complete.
+7. Verify parity from a fresh authoritative scope snapshot before clearing deny overlays.
+
+The global `identity_devices` row remains active. Another managed Project in a different group independently evaluates its own enrollment snapshot and can retain access.
+
+## Failure and retry behavior
+
+- Enrollment reads request disabled rows explicitly and fail closed if the response is malformed.
+- A failed or stale enrollment read does not infer revocation from absence.
+- Coordinator membership mutations retain deterministic effect identities and existing receipt validation.
+- Repeated disabled snapshots are idempotent: once the scope membership is revoked, later passes perform no additional revoke effect.
+- A device that becomes disabled during grant preflight is not granted.
+- A device that becomes disabled immediately after grant receives a deny overlay and compensating revoke before reconciliation returns stale.
+
+## Data and API impact
+
+No schema migration or coordinator API change is required. The existing device-list API already supports `include_disabled=1`, recipient-policy deny overlays already carry scope identity, and coordinator-policy trust cleanup already preserves manual and invite-derived trust.
+
+## Validation
+
+- Core tests prove explicit disabled enrollment revokes a current scope member, omission does not revoke, retry is idempotent, and other Project boundaries remain unaffected.
+- Viewer effect tests prove the exact group read includes disabled enrollments and preserves enabled state in the effect contract.
+- Runtime tests continue proving coordinator-policy trust cleanup does not remove manual/invite trust.
+- Project-sharing E2E disables the second device, waits for owner maintenance, and proves it no longer receives new data from the revoked Project while unrelated group access remains intact.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -102,6 +102,7 @@ This scenario reuses one two-peer setup to prove:
 - direct Identity access without Team membership
 - Team access inherited by existing and future members
 - add-device inheritance for an Identity's existing Projects
+- group-scoped add-device enrollment revocation and future-data isolation
 - Personal/Work and unrelated-Project isolation
 - existing and future memory replication for the selected Project
 - stale preview rejection without intent mutation

--- a/e2e/scenarios/project-sharing.ts
+++ b/e2e/scenarios/project-sharing.ts
@@ -18,7 +18,15 @@ interface FixtureSummary {
 	actor_id: string;
 	memories: Array<{ title: string; project: string | null; scope_id: string | null; active: number }>;
 	actors: Array<{ actor_id: string; display_name: string; status: string }>;
-	peers: Array<{ peer_device_id: string; name: string | null; actor_id: string | null }>;
+	peers: Array<{
+		peer_device_id: string;
+		name: string | null;
+		actor_id: string | null;
+		pinned_fingerprint: string | null;
+		trust_provenance: string | null;
+		discovered_via_coordinator_id: string | null;
+		discovered_via_group_id: string | null;
+	}>;
 	managed_memberships: Array<{ scope_id: string; device_id: string; status: string }>;
 	source_memberships: Array<{ device_id: string; status: string }>;
 	operations: Array<{
@@ -29,6 +37,11 @@ interface FixtureSummary {
 		recipient_device_display_name: string | null;
 	}>;
 	policy: {
+		authority_states: Array<{
+			canonical_project_identity: string;
+			authority_state: string;
+			attempt_count: number;
+		}>;
 		team_memberships: Array<{ team_id: string; identity_id: string; status: string }>;
 		identity_devices: Array<{
 			identity_id: string;
@@ -785,6 +798,186 @@ export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<v
 			);
 		},
 		{ description: "future Project data on second device", timeoutMs: 120_000, intervalMs: 3_000 },
+	);
+
+	// Arrange: retain a local-only anchor, then disable peer-c in the exact coordinator group.
+	const localAnchor = fixture(ctx, "peer-c", "add-stale-memory", "39-seed-peer-c-local-anchor");
+	assert(
+		localAnchor.memories.some(
+			(memory) => memory.title === "policy selected stale-preview change" && memory.active === 1,
+		),
+		"second-device local anchor was not created before enrollment revocation",
+	);
+	const beforeEnrollmentDisable = fixture(
+		ctx,
+		"peer-a",
+		"summary",
+		"39-owner-before-peer-c-enrollment-disable",
+	);
+	const selectedScopeMembership = beforeEnrollmentDisable.managed_memberships.find(
+		(member) => member.device_id === peerC.device_id && member.status === "active",
+	);
+	assert(selectedScopeMembership, "peer-c was not active in the selected managed Project before disable");
+	assert(
+		beforeEnrollmentDisable.peers.some(
+			(peer) =>
+				peer.peer_device_id === peerC.device_id &&
+				peer.pinned_fingerprint &&
+				peer.trust_provenance === "coordinator_policy" &&
+				peer.discovered_via_group_id === GROUP_ID,
+		),
+		"owner did not hold group-derived coordinator-policy trust for peer-c before disable",
+	);
+	const disabledEnrollment = ctx.compose.exec(
+		"coordinator",
+		[
+			...CLI_PREFIX,
+			"sync",
+			"coordinator",
+			"disable-device",
+			GROUP_ID,
+			peerC.device_id,
+			"--db-path",
+			"/data/coordinator.sqlite",
+			"--json",
+		],
+		"39-disable-peer-c-enrollment",
+	);
+	assertStatus(disabledEnrollment.status, 0, "peer-c coordinator enrollment disable failed");
+
+	// Act: periodic owner maintenance reads the disabled enrollment and reconciles the exact Project scope.
+	let revocationAttemptCount = -1;
+	await waitFor(
+		async () => {
+			const owner = fixture(ctx, "peer-a", "summary", "39-owner-peer-c-revocation-convergence");
+			assert(
+				owner.managed_memberships.some(
+					(member) =>
+						member.scope_id === selectedScopeMembership.scope_id &&
+						member.device_id === peerC.device_id &&
+						member.status === "revoked",
+				),
+				"owner maintenance has not revoked peer-c from the selected managed Project",
+			);
+			assert(
+				owner.policy.identity_devices.some(
+					(device) => device.device_id === peerC.device_id && device.status === "active",
+				),
+				"group-scoped enrollment disable globally revoked peer-c's Identity device",
+			);
+			assert(
+				!owner.peers.some(
+					(peer) =>
+						peer.peer_device_id === peerC.device_id &&
+						(peer.pinned_fingerprint || peer.trust_provenance === "coordinator_policy"),
+				),
+				"coordinator-policy-derived peer-c trust survived the scope refresh",
+			);
+			const authority = owner.policy.authority_states.find(
+				(state) => state.canonical_project_identity === selected.workspace_identity,
+			);
+			assert(authority, "selected Project recipient-policy authority state is missing");
+			revocationAttemptCount = authority.attempt_count;
+		},
+		{ description: "group-scoped peer-c enrollment revocation", timeoutMs: 180_000, intervalMs: 3_000 },
+	);
+
+	// Act: let another deterministic maintenance tick run to exercise retry convergence.
+	await waitFor(
+		async () => {
+			const owner = fixture(
+				ctx,
+				"peer-a",
+				"summary",
+				"39-owner-peer-c-revocation-retry-attempt",
+			);
+			const authority = owner.policy.authority_states.find(
+				(state) => state.canonical_project_identity === selected.workspace_identity,
+			);
+			assert(
+				authority && authority.attempt_count > revocationAttemptCount,
+				"selected Project reconciliation retry has not advanced",
+			);
+		},
+		{ description: "idempotent enrollment revocation retry", timeoutMs: 120_000, intervalMs: 2_000 },
+	);
+	const afterRevocationRetry = fixture(
+		ctx,
+		"peer-a",
+		"summary",
+		"39-owner-after-peer-c-revocation-retry",
+	);
+	assert(
+		afterRevocationRetry.managed_memberships.filter(
+			(member) =>
+				member.scope_id === selectedScopeMembership.scope_id && member.device_id === peerC.device_id,
+		).length === 1 &&
+			afterRevocationRetry.managed_memberships.some(
+				(member) =>
+					member.scope_id === selectedScopeMembership.scope_id &&
+					member.device_id === peerC.device_id &&
+					member.status === "revoked",
+			),
+		"repeated disabled-enrollment maintenance did not remain idempotently revoked",
+	);
+	assert(
+		!afterRevocationRetry.peers.some(
+			(peer) =>
+				peer.peer_device_id === peerC.device_id &&
+				(peer.pinned_fingerprint || peer.trust_provenance === "coordinator_policy"),
+		),
+		"repeated disabled-enrollment maintenance restored coordinator-policy trust",
+	);
+
+	// Act: publish new selected-Project data and make peer-c attempt a direct refresh from the owner.
+	fixture(ctx, "peer-a", "add-after-revocation", "39-add-selected-memory-after-revocation");
+	const revokedSync = ctx.compose.exec(
+		"peer-c",
+		[
+			...CLI_PREFIX,
+			"sync",
+			"once",
+			"--db-path",
+			"/data/mem.sqlite",
+			"--peer",
+			peerA.device_id,
+			"--json",
+		],
+		"39-sync-peer-c-after-revocation",
+		180_000,
+		true,
+	);
+	assertStatus(revokedSync.status, 1, "revoked peer-c sync was not blocked by the owner");
+	const revokedSyncResult = parseJson<{
+		ok: boolean;
+		results: Array<{ peer_device_id: string; ok: boolean; error?: string }>;
+	}>(revokedSync.stdout, "39-sync-peer-c-after-revocation");
+	assert(
+		revokedSyncResult.ok === false &&
+			revokedSyncResult.results.some(
+				(result) =>
+					result.peer_device_id === peerA.device_id &&
+					result.ok === false &&
+					String(result.error ?? "").includes("unauthorized:unknown_peer"),
+			),
+		"revoked peer-c sync did not fail through the owner's trust boundary",
+	);
+	const peerCAfterRevocation = fixture(
+		ctx,
+		"peer-c",
+		"summary",
+		"39-peer-c-after-revocation-summary",
+	);
+	// Assert: revoked Project data is blocked while unrelated local data remains intact.
+	assert(
+		!peerCAfterRevocation.memories.some((memory) => memory.title === "selected after revocation"),
+		"peer-c received selected Project data after its group-scoped enrollment was revoked",
+	);
+	assert(
+		peerCAfterRevocation.memories.some(
+			(memory) => memory.title === "policy selected stale-preview change" && memory.active === 1,
+		),
+		"group-scoped enrollment revocation removed unrelated local data from peer-c",
 	);
 
 	const ownerConfigBeforePolicyProof = readConfig(

--- a/e2e/scripts/project-sharing-fixture.ts
+++ b/e2e/scripts/project-sharing-fixture.ts
@@ -32,6 +32,7 @@ type Action =
 	| "seed-a"
 	| "add-future"
 	| "add-device-future"
+	| "add-after-revocation"
 	| "summary"
 	| "seed-policy"
 	| "inherit-policy"
@@ -45,6 +46,7 @@ const ACTIONS: Action[] = [
 	"seed-a",
 	"add-future",
 	"add-device-future",
+	"add-after-revocation",
 	"summary",
 	"seed-policy",
 	"inherit-policy",
@@ -280,6 +282,12 @@ function addDeviceFuture(store: MemoryStore): void {
 	stampSourceScope(store, unrelatedId, true);
 }
 
+function addAfterRevocation(store: MemoryStore): void {
+	const selectedSession = session(store, "selected-project", SELECTED_REMOTE);
+	remember(store, selectedSession, "selected after revocation", null);
+	store.endSession(selectedSession, { fixture: "selected-after-revocation" });
+}
+
 function seedReconciliationProject(
 	store: MemoryStore,
 	label: string,
@@ -336,12 +344,14 @@ function reconciliationEffects(
 				identityId: `identity-${label}`,
 				publicKey: `pk-${label}-keep`,
 				fingerprint: `fp-${label}-keep`,
+				enabled: true,
 			},
 			{
 				deviceId: `device-${label}-new`,
 				identityId: `identity-${label}`,
 				publicKey: `pk-${label}-new`,
 				fingerprint: `fp-${label}-new`,
+				enabled: true,
 			},
 		],
 		probeCapability: async ({ deviceId }) => {
@@ -559,7 +569,11 @@ function summary(store: MemoryStore): Record<string, unknown> {
 			.prepare("SELECT actor_id, display_name, status FROM actors ORDER BY actor_id")
 			.all(),
 		peers: store.db
-			.prepare("SELECT peer_device_id, name, actor_id FROM sync_peers ORDER BY peer_device_id")
+			.prepare(
+				`SELECT peer_device_id, name, actor_id, pinned_fingerprint, trust_provenance,
+				 discovered_via_coordinator_id, discovered_via_group_id
+				 FROM sync_peers ORDER BY peer_device_id`,
+			)
 			.all(),
 		managed_memberships: store.db
 			.prepare(
@@ -581,6 +595,12 @@ function summary(store: MemoryStore): Record<string, unknown> {
 			)
 			.all(),
 		policy: {
+			authority_states: store.db
+				.prepare(
+					`SELECT canonical_project_identity, authority_state, attempt_count
+					 FROM recipient_policy_authority_states ORDER BY canonical_project_identity`,
+				)
+				.all(),
 			teams: store.db.prepare("SELECT team_id, display_name, status FROM policy_teams ORDER BY team_id").all(),
 			team_memberships: store.db
 				.prepare(
@@ -614,6 +634,7 @@ async function main(): Promise<void> {
 		if (selectedAction === "seed-a") seedA(store);
 		if (selectedAction === "add-future") addFuture(store);
 		if (selectedAction === "add-device-future") addDeviceFuture(store);
+		if (selectedAction === "add-after-revocation") addAfterRevocation(store);
 		if (selectedAction === "seed-policy") seedRecipientPolicy(store);
 		const actionResult =
 			selectedAction === "inherit-policy"

--- a/packages/core/src/recipient-policy-reconciler.test.ts
+++ b/packages/core/src/recipient-policy-reconciler.test.ts
@@ -74,12 +74,14 @@ function harness(active: string[]) {
 				identityId: "identity-a",
 				publicKey: "pk-keep",
 				fingerprint: "fp-keep",
+				enabled: true,
 			},
 			{
 				deviceId: "device-new",
 				identityId: "identity-a",
 				publicKey: "pk-new",
 				fingerprint: "fp-new",
+				enabled: true,
 			},
 		]),
 		probeCapability: vi.fn(async ({ deviceId }) => {
@@ -184,9 +186,9 @@ describe("recipient-policy reconciler executor", () => {
 				identityId: "identity-a",
 				publicKey: "pk-keep",
 				fingerprint: "fp-keep",
+				enabled: true,
 			},
 		]);
-
 		const outcome = await reconcileRecipientPolicyProject(
 			db,
 			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-boundary" },
@@ -212,12 +214,14 @@ describe("recipient-policy reconciler executor", () => {
 					identityId: "identity-a",
 					publicKey: "pk-keep",
 					fingerprint: "fp-keep",
+					enabled: true,
 				},
 				{
 					deviceId: "device-new",
 					identityId: "identity-a",
 					publicKey: "pk-new",
 					fingerprint: "fp-new",
+					enabled: true,
 				},
 			])
 			.mockResolvedValueOnce([
@@ -226,12 +230,64 @@ describe("recipient-policy reconciler executor", () => {
 					identityId: "identity-a",
 					publicKey: "pk-keep",
 					fingerprint: "fp-keep",
+					enabled: true,
 				},
 				{
 					deviceId: "device-new",
 					identityId: "identity-other",
 					publicKey: "pk-new-other",
 					fingerprint: "fp-new-other",
+					enabled: true,
+				},
+			]);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-identity-race" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "stale",
+			safeErrorCode: "recipient_policy_generation_stale",
+			grantedDeviceIds: [],
+		});
+		expect(effects.grant).not.toHaveBeenCalled();
+	});
+
+	it("does not grant when the enrollment becomes disabled during preflight", async () => {
+		const { effects } = harness(["device-keep"]);
+		vi.mocked(effects.listBoundaryEnrollments)
+			.mockResolvedValueOnce([
+				{
+					deviceId: "device-keep",
+					identityId: "identity-a",
+					publicKey: "pk-keep",
+					fingerprint: "fp-keep",
+					enabled: true,
+				},
+				{
+					deviceId: "device-new",
+					identityId: "identity-a",
+					publicKey: "pk-new",
+					fingerprint: "fp-new",
+					enabled: true,
+				},
+			])
+			.mockResolvedValueOnce([
+				{
+					deviceId: "device-keep",
+					identityId: "identity-a",
+					publicKey: "pk-keep",
+					fingerprint: "fp-keep",
+					enabled: true,
+				},
+				{
+					deviceId: "device-new",
+					identityId: null,
+					publicKey: "pk-new",
+					fingerprint: "fp-new",
+					enabled: false,
 				},
 			]);
 
@@ -257,12 +313,14 @@ describe("recipient-policy reconciler executor", () => {
 				identityId: "identity-a",
 				publicKey: "pk-keep",
 				fingerprint: "fp-keep",
+				enabled: true,
 			},
 			{
 				deviceId: "device-new",
 				identityId: "identity-a",
 				publicKey: "pk-new",
 				fingerprint: "fp-new",
+				enabled: true,
 			},
 		];
 		vi.mocked(effects.listBoundaryEnrollments)
@@ -274,12 +332,76 @@ describe("recipient-policy reconciler executor", () => {
 					identityId: "identity-a",
 					publicKey: "pk-keep",
 					fingerprint: "fp-keep",
+					enabled: true,
 				},
 				{
 					deviceId: "device-new",
 					identityId: "identity-other",
 					publicKey: "pk-new-other",
 					fingerprint: "fp-new-other",
+					enabled: true,
+				},
+			]);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-post-grant-identity-race" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "stale",
+			safeErrorCode: "recipient_policy_generation_stale",
+			grantedDeviceIds: ["device-new"],
+			revokedDeviceIds: ["device-new"],
+		});
+		expect(effects.grant).toHaveBeenCalledWith(expect.objectContaining({ deviceId: "device-new" }));
+		expect(effects.revoke).toHaveBeenCalledWith(
+			expect.objectContaining({ deviceId: "device-new" }),
+		);
+		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([
+			expect.objectContaining({
+				deviceId: "device-new",
+				reasonCode: "enrollment_identity_conflict",
+			}),
+		]);
+	});
+
+	it("revokes a new grant immediately when its enrollment becomes disabled", async () => {
+		const { effects } = harness(["device-keep"]);
+		const matching = [
+			{
+				deviceId: "device-keep",
+				identityId: "identity-a",
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: true,
+			},
+			{
+				deviceId: "device-new",
+				identityId: "identity-a",
+				publicKey: "pk-new",
+				fingerprint: "fp-new",
+				enabled: true,
+			},
+		];
+		vi.mocked(effects.listBoundaryEnrollments)
+			.mockResolvedValueOnce(matching)
+			.mockResolvedValueOnce(matching)
+			.mockResolvedValue([
+				{
+					deviceId: "device-keep",
+					identityId: "identity-a",
+					publicKey: "pk-keep",
+					fingerprint: "fp-keep",
+					enabled: true,
+				},
+				{
+					deviceId: "device-new",
+					identityId: null,
+					publicKey: "pk-new",
+					fingerprint: "fp-new",
+					enabled: false,
 				},
 			]);
 
@@ -302,7 +424,7 @@ describe("recipient-policy reconciler executor", () => {
 		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([
 			expect.objectContaining({
 				deviceId: "device-new",
-				reasonCode: "enrollment_identity_conflict",
+				reasonCode: "enrollment_disabled",
 			}),
 		]);
 	});
@@ -318,6 +440,7 @@ describe("recipient-policy reconciler executor", () => {
 				identityId: "identity-other",
 				publicKey: "key-device-keep-other",
 				fingerprint: "fingerprint-device-keep-other",
+				enabled: true,
 			},
 		]);
 
@@ -337,6 +460,109 @@ describe("recipient-policy reconciler executor", () => {
 		expect(effects.grant).not.toHaveBeenCalled();
 	});
 
+	it("revokes an explicitly disabled current member without mutating global owner policy", async () => {
+		db.prepare(
+			"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
+		).run();
+		const { effects, members } = harness(["device-keep"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: null,
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: false,
+			},
+		]);
+		vi.mocked(effects.revoke).mockImplementation(async (input) => {
+			expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([
+				expect.objectContaining({
+					scopeId: SCOPE,
+					deviceId: "device-keep",
+					reasonCode: "enrollment_disabled",
+				}),
+			]);
+			members.delete(input.deviceId);
+			return {
+				effectId: input.effectId,
+				scopeId: input.scopeId,
+				deviceId: input.deviceId,
+				status: "revoked",
+			};
+		});
+
+		const first = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-disabled-first" },
+			effects,
+		);
+		const second = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-disabled-second" },
+			effects,
+		);
+
+		expect(first).toMatchObject({ status: "parity_pending", revokedDeviceIds: ["device-keep"] });
+		expect(second).toMatchObject({ status: "active", revokedDeviceIds: [] });
+		expect(effects.revoke).toHaveBeenCalledTimes(1);
+		expect(
+			db.prepare("SELECT status FROM identity_devices WHERE device_id = 'device-keep'").get(),
+		).toEqual({ status: "active" });
+	});
+
+	it("leaves the same device active in another managed Project group", async () => {
+		db.prepare(
+			"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
+		).run();
+		const otherProject = "https://git.example.invalid/acme/other.git";
+		const otherScope = "managed-project-scope-other";
+		const now = new Date(BASE_TIME).toISOString();
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'identity', 'identity-a', 'active', 'test', '1', 'native', 'recipient:other', ?, ?)`,
+		).run(otherProject, now, now);
+		db.prepare(
+			`INSERT INTO replication_scopes(
+			 scope_id, label, kind, authority_type, coordinator_id, group_id, membership_epoch,
+			 status, created_at, updated_at
+			 ) VALUES (?, 'Other Project', 'managed_project', 'coordinator', 'coord', 'group-other', 1,
+			 'active', ?, ?)`,
+		).run(otherScope, now, now);
+		db.prepare(
+			`INSERT INTO project_scope_mappings(
+			 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, ?, ?, 1000, 'test', ?, ?)`,
+		).run(otherProject, otherProject, otherScope, now, now);
+		const { effects } = harness(["device-keep"]);
+		vi.mocked(effects.snapshot).mockImplementation(async () => ({
+			authoritative: true,
+			scopeId: otherScope,
+			fingerprint: "snapshot:other:device-keep",
+			observedAt: effects.now(),
+			memberships: [{ deviceId: "device-keep", status: "active" }],
+		}));
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: "identity-a",
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: true,
+			},
+		]);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: otherProject, leaseOwner: "worker-other-group" },
+			effects,
+		);
+
+		expect(outcome.revokedDeviceIds).toEqual([]);
+		expect(effects.revoke).not.toHaveBeenCalled();
+	});
+
 	it("does not revoke a current policy device merely omitted from boundary enrollments", async () => {
 		db.prepare(
 			"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
@@ -347,6 +573,31 @@ describe("recipient-policy reconciler executor", () => {
 		const outcome = await reconcileRecipientPolicyProject(
 			db,
 			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-enrollment-omission" },
+			effects,
+		);
+
+		expect(outcome.revokedDeviceIds).toEqual([]);
+		expect(effects.revoke).not.toHaveBeenCalled();
+	});
+
+	it("does not treat an enabled enrollment without an Identity as a revocation signal", async () => {
+		db.prepare(
+			"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
+		).run();
+		const { effects } = harness(["device-keep"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: null,
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: true,
+			},
+		]);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-null-identity" },
 			effects,
 		);
 

--- a/packages/core/src/recipient-policy-reconciler.ts
+++ b/packages/core/src/recipient-policy-reconciler.ts
@@ -35,6 +35,14 @@ export interface RecipientPolicyCoordinatorEffectReceipt {
 	status: "active" | "revoked";
 }
 
+export interface RecipientPolicyBoundaryEnrollment {
+	deviceId: string;
+	identityId: string | null;
+	publicKey: string;
+	fingerprint: string;
+	enabled: boolean;
+}
+
 export interface RecipientPolicyReconcilerEffects {
 	now(): string;
 	snapshot(input: {
@@ -44,9 +52,7 @@ export interface RecipientPolicyReconcilerEffects {
 	listBoundaryEnrollments(input: {
 		canonicalProjectIdentity: string;
 		scopeId: string;
-	}): Promise<
-		Array<{ deviceId: string; identityId: string; publicKey: string; fingerprint: string }>
-	>;
+	}): Promise<RecipientPolicyBoundaryEnrollment[]>;
 	probeCapability(input: {
 		deviceId: string;
 		scopeId: string;
@@ -323,40 +329,85 @@ function activeSnapshotDevices(
 }
 
 function boundaryEnrollmentIdentities(
-	enrollments: Array<{
-		deviceId: string;
-		identityId: string;
-		publicKey: string;
-		fingerprint: string;
-	}>,
-): Map<string, { identityId: string; publicKey: string; fingerprint: string }> {
-	const bindings = new Map<
-		string,
-		{ identityId: string; publicKey: string; fingerprint: string }
-	>();
+	enrollments: RecipientPolicyBoundaryEnrollment[],
+): Map<string, RecipientPolicyBoundaryEnrollment> {
+	const bindings = new Map<string, RecipientPolicyBoundaryEnrollment>();
 	for (const enrollment of enrollments) {
 		if (
 			!validId(enrollment.deviceId) ||
-			!validId(enrollment.identityId) ||
+			typeof enrollment.enabled !== "boolean" ||
+			(enrollment.identityId !== null && !validId(enrollment.identityId)) ||
 			!validId(enrollment.publicKey) ||
 			!validId(enrollment.fingerprint) ||
 			bindings.has(enrollment.deviceId)
 		) {
 			throw new Error("recipient_policy_snapshot_invalid");
 		}
-		bindings.set(enrollment.deviceId, {
-			identityId: enrollment.identityId,
-			publicKey: enrollment.publicKey,
-			fingerprint: enrollment.fingerprint,
-		});
+		bindings.set(enrollment.deviceId, enrollment);
 	}
 	return bindings;
 }
 
-function boundaryEnrollmentIdentityId(
-	binding: string | { identityId: string } | undefined,
-): string | undefined {
-	return typeof binding === "string" ? binding : binding?.identityId;
+type EnrollmentRevocationReason = "enrollment_disabled" | "enrollment_identity_conflict";
+type EnrollmentRevocationPhase = "steady_state" | "post_grant";
+
+interface EnrollmentRevocation {
+	deviceId: string;
+	reasonCode: EnrollmentRevocationReason;
+}
+
+function enrollmentRevocationReason(
+	binding: RecipientPolicyBoundaryEnrollment | undefined,
+	desiredIdentityId: string | undefined,
+): EnrollmentRevocationReason | null {
+	if (!binding) return null;
+	if (!binding.enabled) return "enrollment_disabled";
+	return desiredIdentityId &&
+		binding.identityId !== null &&
+		binding.identityId !== desiredIdentityId
+		? "enrollment_identity_conflict"
+		: null;
+}
+
+function isEnrollmentEnabledForIdentityGrant(
+	binding: RecipientPolicyBoundaryEnrollment | undefined,
+	desiredIdentityId: string | undefined,
+): boolean {
+	return Boolean(binding?.enabled && desiredIdentityId && binding.identityId === desiredIdentityId);
+}
+
+function unreachableEnrollmentRevocationCase(value: never): never {
+	throw new Error(`recipient_policy_enrollment_revocation_invalid:${String(value)}`);
+}
+
+function enrollmentRevocationStepKey(
+	reasonCode: EnrollmentRevocationReason,
+	phase: EnrollmentRevocationPhase,
+	snapshotStateKey: string,
+	deviceId: string,
+): string {
+	switch (phase) {
+		case "steady_state":
+			switch (reasonCode) {
+				case "enrollment_identity_conflict":
+					return `revoke-enrollment-conflict:${snapshotStateKey}:${deviceId}`;
+				case "enrollment_disabled":
+					return `revoke-enrollment-disabled:${snapshotStateKey}:${deviceId}`;
+				default:
+					return unreachableEnrollmentRevocationCase(reasonCode);
+			}
+		case "post_grant":
+			switch (reasonCode) {
+				case "enrollment_identity_conflict":
+					return `revoke-post-grant-enrollment-conflict:${snapshotStateKey}:${deviceId}`;
+				case "enrollment_disabled":
+					return `revoke-post-grant-enrollment-disabled:${snapshotStateKey}:${deviceId}`;
+				default:
+					return unreachableEnrollmentRevocationCase(reasonCode);
+			}
+		default:
+			return unreachableEnrollmentRevocationCase(phase);
+	}
 }
 
 function generation(db: Database, projectId: string, desiredDigest: string): number {
@@ -509,6 +560,69 @@ function validateReceipt(
 	) {
 		throw new Error("recipient_policy_effect_receipt_invalid");
 	}
+}
+
+async function applyEnrollmentRevocations(
+	db: Database,
+	input: {
+		projectId: string;
+		generation: number;
+		scopeId: string;
+		snapshotStateKey: string;
+		phase: EnrollmentRevocationPhase;
+		revocations: EnrollmentRevocation[];
+		leaseOwner: string;
+		lease: Lease;
+		effects: RecipientPolicyReconcilerEffects;
+	},
+): Promise<string[]> {
+	if (input.revocations.length === 0) return [];
+	resetParity(db, input.projectId, input.effects.now());
+	const changedDeviceIds: string[] = [];
+	for (const { deviceId, reasonCode } of input.revocations) {
+		putRecipientPolicyDenyOverlay(db, {
+			canonicalProjectIdentity: input.projectId,
+			scopeId: input.scopeId,
+			deviceId,
+			generation: input.generation,
+			reasonCode,
+			now: input.effects.now(),
+		});
+		const changed = await step(
+			db,
+			{
+				projectId: input.projectId,
+				generation: input.generation,
+				stepKey: enrollmentRevocationStepKey(
+					reasonCode,
+					input.phase,
+					input.snapshotStateKey,
+					deviceId,
+				),
+				payload: { scopeId: input.scopeId, deviceId, status: "revoked" },
+				leaseOwner: input.leaseOwner,
+				lease: input.lease,
+				now: input.effects.now,
+			},
+			async (effectId) => {
+				const receipt = await input.effects.revoke({
+					effectId,
+					canonicalProjectIdentity: input.projectId,
+					generation: input.generation,
+					scopeId: input.scopeId,
+					deviceId,
+				});
+				validateReceipt(receipt, {
+					effectId,
+					scopeId: input.scopeId,
+					deviceId,
+					status: "revoked",
+				});
+			},
+		);
+		if (changed) changedDeviceIds.push(deviceId);
+	}
+	return changedDeviceIds;
 }
 
 async function preflight(
@@ -708,60 +822,40 @@ export async function reconcileRecipientPolicyProject(
 		const desiredIdentityByDeviceId = new Map(
 			desired.devices.map((device) => [device.deviceId, device.identityId]),
 		);
-		const enrollmentConflictDeviceIds = remainingPolicyCurrentDeviceIds.filter((deviceId) => {
-			const enrollmentIdentityId = boundaryEnrollmentIdentityId(enrollmentIdentities.get(deviceId));
-			const desiredIdentityId = desiredIdentityByDeviceId.get(deviceId);
-			return Boolean(
-				enrollmentIdentityId && desiredIdentityId && enrollmentIdentityId !== desiredIdentityId,
-			);
-		});
-		if (enrollmentConflictDeviceIds.length > 0) resetParity(db, projectId, effects.now());
-		for (const deviceId of enrollmentConflictDeviceIds) {
-			putRecipientPolicyDenyOverlay(db, {
-				canonicalProjectIdentity: projectId,
-				scopeId: managedBoundary.scopeId,
-				deviceId,
+		const enrollmentRevocations: EnrollmentRevocation[] = remainingPolicyCurrentDeviceIds.flatMap(
+			(deviceId) => {
+				const reasonCode = enrollmentRevocationReason(
+					enrollmentIdentities.get(deviceId),
+					desiredIdentityByDeviceId.get(deviceId),
+				);
+				return reasonCode ? [{ deviceId, reasonCode }] : [];
+			},
+		);
+		revokedDeviceIds.push(
+			...(await applyEnrollmentRevocations(db, {
+				projectId,
 				generation: activeGeneration,
-				reasonCode: "enrollment_identity_conflict",
-				now: effects.now(),
-			});
-			const changed = await step(
-				db,
-				{
-					projectId,
-					generation: activeGeneration,
-					stepKey: `revoke-enrollment-conflict:${snapshotStateKey}:${deviceId}`,
-					payload: { scopeId: managedBoundary.scopeId, deviceId, status: "revoked" },
-					leaseOwner: input.leaseOwner,
-					lease,
-					now: effects.now,
-				},
-				async (effectId) => {
-					const receipt = await effects.revoke({
-						effectId,
-						canonicalProjectIdentity: projectId,
-						generation: activeGeneration,
-						scopeId: managedBoundary.scopeId,
-						deviceId,
-					});
-					validateReceipt(receipt, {
-						effectId,
-						scopeId: managedBoundary.scopeId,
-						deviceId,
-						status: "revoked",
-					});
-				},
-			);
-			if (changed) revokedDeviceIds.push(deviceId);
-		}
+				scopeId: managedBoundary.scopeId,
+				snapshotStateKey,
+				phase: "steady_state",
+				revocations: enrollmentRevocations,
+				leaseOwner: input.leaseOwner,
+				lease,
+				effects,
+			})),
+		);
+		const enrollmentRevokedDeviceIds = new Set(
+			enrollmentRevocations.map(({ deviceId }) => deviceId),
+		);
 		const remainingCurrentDeviceIds = remainingPolicyCurrentDeviceIds.filter(
-			(deviceId) => !enrollmentConflictDeviceIds.includes(deviceId),
+			(deviceId) => !enrollmentRevokedDeviceIds.has(deviceId),
 		);
 		const grantEligibleDeviceIds = desired.devices
-			.filter(
-				(device) =>
-					boundaryEnrollmentIdentityId(enrollmentIdentities.get(device.deviceId)) ===
+			.filter((device) =>
+				isEnrollmentEnabledForIdentityGrant(
+					enrollmentIdentities.get(device.deviceId),
 					device.identityId,
+				),
 			)
 			.map((device) => device.deviceId)
 			.toSorted();
@@ -823,8 +917,10 @@ export async function reconcileRecipientPolicyProject(
 			);
 			const changedBinding = grantDeviceIds.some(
 				(deviceId) =>
-					boundaryEnrollmentIdentityId(preGrantEnrollmentIdentities.get(deviceId)) !==
-					desiredIdentityByDeviceId.get(deviceId),
+					!isEnrollmentEnabledForIdentityGrant(
+						preGrantEnrollmentIdentities.get(deviceId),
+						desiredIdentityByDeviceId.get(deviceId),
+					),
 			);
 			if (changedBinding) {
 				resetParity(db, projectId, effects.now());
@@ -880,51 +976,34 @@ export async function reconcileRecipientPolicyProject(
 					scopeId: managedBoundary.scopeId,
 				}),
 			);
-			const changedBindingDeviceIds = grantDeviceIds.filter(
-				(deviceId) =>
-					boundaryEnrollmentIdentityId(postGrantEnrollmentIdentities.get(deviceId)) !==
-					desiredIdentityByDeviceId.get(deviceId),
-			);
-			if (changedBindingDeviceIds.length > 0) {
-				resetParity(db, projectId, effects.now());
-				for (const deviceId of changedBindingDeviceIds) {
-					putRecipientPolicyDenyOverlay(db, {
-						canonicalProjectIdentity: projectId,
-						scopeId: managedBoundary.scopeId,
-						deviceId,
-						generation: activeGeneration,
-						reasonCode: "enrollment_identity_conflict",
-						now: effects.now(),
-					});
-					const changed = await step(
-						db,
-						{
-							projectId,
-							generation: activeGeneration,
-							stepKey: `revoke-post-grant-enrollment-conflict:${snapshotStateKey}:${deviceId}`,
-							payload: { scopeId: managedBoundary.scopeId, deviceId, status: "revoked" },
-							leaseOwner: input.leaseOwner,
-							lease,
-							now: effects.now,
-						},
-						async (effectId) => {
-							const receipt = await effects.revoke({
-								effectId,
-								canonicalProjectIdentity: projectId,
-								generation: activeGeneration,
-								scopeId: managedBoundary.scopeId,
-								deviceId,
-							});
-							validateReceipt(receipt, {
-								effectId,
-								scopeId: managedBoundary.scopeId,
-								deviceId,
-								status: "revoked",
-							});
-						},
-					);
-					if (changed) revokedDeviceIds.push(deviceId);
+			const changedBindings: EnrollmentRevocation[] = grantDeviceIds.flatMap((deviceId) => {
+				const binding = postGrantEnrollmentIdentities.get(deviceId);
+				if (isEnrollmentEnabledForIdentityGrant(binding, desiredIdentityByDeviceId.get(deviceId))) {
+					return [];
 				}
+				return [
+					{
+						deviceId,
+						reasonCode:
+							enrollmentRevocationReason(binding, desiredIdentityByDeviceId.get(deviceId)) ??
+							"enrollment_identity_conflict",
+					},
+				];
+			});
+			if (changedBindings.length > 0) {
+				revokedDeviceIds.push(
+					...(await applyEnrollmentRevocations(db, {
+						projectId,
+						generation: activeGeneration,
+						scopeId: managedBoundary.scopeId,
+						snapshotStateKey,
+						phase: "post_grant",
+						revocations: changedBindings,
+						leaseOwner: input.leaseOwner,
+						lease,
+						effects,
+					})),
+				);
 				authority(db, {
 					projectId,
 					safeErrorCode: "recipient_policy_generation_stale",

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1905,6 +1905,10 @@ function recipientPolicyPresenceCapabilityExpiresAt(
 	return expiresAtMs;
 }
 
+function recipientPolicyEnrollmentValueIsValid(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0 && value === value.trim();
+}
+
 export function createRecipientPolicyReconcilerEffects(
 	store: MemoryStore,
 	options: {
@@ -2015,6 +2019,7 @@ export function createRecipientPolicyReconcilerEffects(
 			const observedAt = now();
 			const enrollments = await listDevices({
 				groupId: targetOptions.groupId,
+				includeDisabled: true,
 				remoteUrl: targetOptions.remoteUrl,
 				adminSecret: targetOptions.adminSecret,
 			}).catch(() => {
@@ -2026,43 +2031,46 @@ export function createRecipientPolicyReconcilerEffects(
 					recipientPolicyPresenceCapabilityExpiresAt(enrollment, observedAt),
 				]),
 			);
-			const mapped = enrollments.flatMap((enrollment) => {
+			const mapped = enrollments.map((enrollment) => {
 				if (
 					enrollment.group_id !== targetOptions.groupId ||
-					typeof enrollment.device_id !== "string" ||
-					typeof enrollment.public_key !== "string" ||
-					typeof enrollment.fingerprint !== "string" ||
+					!recipientPolicyEnrollmentValueIsValid(enrollment.device_id) ||
+					!recipientPolicyEnrollmentValueIsValid(enrollment.public_key) ||
+					!recipientPolicyEnrollmentValueIsValid(enrollment.fingerprint) ||
 					fingerprintPublicKey(enrollment.public_key) !== enrollment.fingerprint ||
-					enrollment.enabled !== 1
+					(enrollment.enabled !== 0 && enrollment.enabled !== 1) ||
+					(enrollment.identity_id !== null &&
+						!recipientPolicyEnrollmentValueIsValid(enrollment.identity_id))
 				) {
 					throw new Error("recipient_policy_snapshot_invalid");
 				}
-				if (enrollment.identity_id == null) return [];
-				if (typeof enrollment.identity_id !== "string") {
-					throw new Error("recipient_policy_snapshot_invalid");
-				}
-				return [
-					{
-						deviceId: enrollment.device_id,
-						identityId: enrollment.identity_id,
-						publicKey: enrollment.public_key,
-						fingerprint: enrollment.fingerprint,
-					},
-				];
+				return {
+					deviceId: enrollment.device_id,
+					identityId: enrollment.identity_id,
+					publicKey: enrollment.public_key,
+					fingerprint: enrollment.fingerprint,
+					enabled: enrollment.enabled === 1,
+				};
 			});
 			boundaryEnrollments.set(
 				scopeId,
 				new Map(
-					mapped.map((enrollment) => [
-						enrollment.deviceId,
-						{
-							identityId: enrollment.identityId,
-							publicKey: enrollment.publicKey,
-							fingerprint: enrollment.fingerprint,
-							presenceCapabilityExpiresAtMs:
-								presenceCapabilityExpiries.get(enrollment.deviceId) ?? null,
-						},
-					]),
+					mapped.flatMap((enrollment) =>
+						enrollment.enabled && enrollment.identityId !== null
+							? [
+									[
+										enrollment.deviceId,
+										{
+											identityId: enrollment.identityId,
+											publicKey: enrollment.publicKey,
+											fingerprint: enrollment.fingerprint,
+											presenceCapabilityExpiresAtMs:
+												presenceCapabilityExpiries.get(enrollment.deviceId) ?? null,
+										},
+									] as const,
+								]
+							: [],
+					),
 				),
 			);
 			return mapped;

--- a/packages/viewer-server/src/share-operation-maintenance.test.ts
+++ b/packages/viewer-server/src/share-operation-maintenance.test.ts
@@ -930,11 +930,12 @@ describe("recipient-policy maintenance", () => {
 		vi.unstubAllGlobals();
 	});
 
-	it("reads identity-bound enrollments from the managed boundary group", async () => {
+	it("reads enabled and disabled enrollments from the exact managed boundary group", async () => {
 		const projectId = "project-boundary-enrollments";
 		const scopeId = "scope-boundary-enrollments";
 		const recipientPublicKey = "boundary-recipient-key";
 		const ownerPublicKey = "boundary-owner-key";
+		const disabledPublicKey = "boundary-disabled-key";
 		seedManagedBoundary(projectId, scopeId);
 		db.prepare("UPDATE replication_scopes SET coordinator_id = ? WHERE scope_id = ?").run(
 			"https://coord.example.test",
@@ -965,6 +966,16 @@ describe("recipient-policy maintenance", () => {
 								enabled: 1,
 								created_at: "2026-07-26T00:00:00.000Z",
 							},
+							{
+								group_id: "group",
+								device_id: "device-disabled",
+								public_key: disabledPublicKey,
+								fingerprint: fingerprintPublicKey(disabledPublicKey),
+								identity_id: null,
+								display_name: null,
+								enabled: 0,
+								created_at: "2026-07-26T00:00:00.000Z",
+							},
 						],
 					}),
 					{ status: 200, headers: { "content-type": "application/json" } },
@@ -987,10 +998,69 @@ describe("recipient-policy maintenance", () => {
 				identityId: "identity-recipient",
 				publicKey: recipientPublicKey,
 				fingerprint: fingerprintPublicKey(recipientPublicKey),
+				enabled: true,
+			},
+			{
+				deviceId: "device-owner",
+				identityId: null,
+				publicKey: ownerPublicKey,
+				fingerprint: fingerprintPublicKey(ownerPublicKey),
+				enabled: true,
+			},
+			{
+				deviceId: "device-disabled",
+				identityId: null,
+				publicKey: disabledPublicKey,
+				fingerprint: fingerprintPublicKey(disabledPublicKey),
+				enabled: false,
 			},
 		]);
 		expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
-			"https://coord.example.test/v1/admin/devices?group_id=group&include_disabled=0",
+			"https://coord.example.test/v1/admin/devices?group_id=group&include_disabled=1",
+		);
+		await expect(effects.probeCapability({ deviceId: "device-owner", scopeId })).resolves.toBe(
+			"undetermined",
+		);
+		await expect(effects.probeCapability({ deviceId: "device-disabled", scopeId })).resolves.toBe(
+			"undetermined",
+		);
+	});
+
+	it("rejects non-binary boundary enrollment state", async () => {
+		const projectId = "project-malformed-enrollment-state";
+		const scopeId = "scope-malformed-enrollment-state";
+		const publicKey = "malformed-state-key";
+		seedManagedBoundary(projectId, scopeId);
+		db.prepare("UPDATE replication_scopes SET coordinator_id = ? WHERE scope_id = ?").run(
+			"https://coord.example.test",
+			scopeId,
+		);
+		const listDevices = vi.fn(async ({ groupId }: { groupId: string }) => [
+			{
+				group_id: groupId,
+				device_id: "device-malformed-state",
+				public_key: publicKey,
+				fingerprint: fingerprintPublicKey(publicKey),
+				identity_id: "identity-malformed-state",
+				display_name: null,
+				enabled: 2,
+				created_at: now,
+			},
+		]);
+		const effects = createRecipientPolicyReconcilerEffects(store, {
+			config: {
+				syncCoordinatorUrl: "https://coord.example.test",
+				syncCoordinatorAdminSecret: "secret",
+				syncCoordinatorGroups: ["group"],
+			} as never,
+			listDevices,
+		});
+
+		await expect(
+			effects.listBoundaryEnrollments({ canonicalProjectIdentity: projectId, scopeId }),
+		).rejects.toThrow("recipient_policy_snapshot_invalid");
+		expect(listDevices).toHaveBeenCalledWith(
+			expect.objectContaining({ groupId: "group", includeDisabled: true }),
 		);
 	});
 
@@ -1171,6 +1241,7 @@ describe("recipient-policy maintenance", () => {
 					identityId: `identity:${projectId}`,
 					publicKey: "pk-revoked",
 					fingerprint: "fp-revoked",
+					enabled: true,
 				},
 			]),
 			probeCapability: vi.fn(async () => "supported"),
@@ -1305,6 +1376,7 @@ describe("recipient-policy maintenance", () => {
 					identityId: `identity:${projectId}`,
 					publicKey: "pk-recipient",
 					fingerprint: "fp-recipient",
+					enabled: true,
 				},
 			]),
 			probeCapability: vi.fn(async () => "supported"),


### PR DESCRIPTION
## Description

Treat explicitly disabled coordinator enrollments as authoritative revocation for the exact coordinator/group/Project boundary. The reconciler writes a deny overlay before revoking the managed scope, removes coordinator-policy trust, and preserves unrelated global Identity state and other groups.

Missing enrollment rows and enabled rows without an Identity remain non-destructive, while null-Identity rows cannot grant new access. Project Sharing E2E coverage proves revoked sync fails closed, future Project data stays isolated, and unrelated access remains active.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation included `pnpm run check` and the Project Sharing three-device E2E scenario. A forced clean Docker rebuild was separately blocked by npm registry download timeouts; the scenario passed with the current source overlaid onto the existing dependency image.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
