### PR TITLE
fix(sharing): harden enrollment revocation ordering

### DIFF
--- a/e2e/scenarios/project-sharing.ts
+++ b/e2e/scenarios/project-sharing.ts
@@ -1326,8 +1326,8 @@ export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<v
 		reconciliation.rollback.result.status === "needs_attention" &&
 			reconciliation.rollback.result.revokedDeviceIds.includes("device-rollback-old") &&
 			reconciliation.rollback.authority?.authorityState === "rolled_back" &&
-			reconciliation.rollback.mutation_calls.length === 1 &&
-			reconciliation.rollback.mutation_calls[0] === "revoke:device-rollback-old",
+			reconciliation.rollback.mutation_calls.join(",") ===
+				"revoke:device-rollback-old,refresh",
 		"unsupported active Project did not revoke stale access and roll back without grants",
 	);
 	const reconciliationStatus = await request<{

--- a/packages/core/src/recipient-policy-reconciler.test.ts
+++ b/packages/core/src/recipient-policy-reconciler.test.ts
@@ -154,6 +154,7 @@ describe("recipient-policy reconciler executor", () => {
 		expect(calls).toEqual([
 			"snapshot",
 			"revoke:device-old",
+			"refresh",
 			"probe:device-keep",
 			"probe:device-new",
 			"grant:device-new",
@@ -174,7 +175,7 @@ describe("recipient-policy reconciler executor", () => {
 		expect(second.grantedDeviceIds).toEqual([]);
 		expect(vi.mocked(effects.revoke)).toHaveBeenCalledTimes(1);
 		expect(vi.mocked(effects.grant)).toHaveBeenCalledTimes(1);
-		expect(vi.mocked(effects.refresh)).toHaveBeenCalledTimes(2);
+		expect(vi.mocked(effects.refresh)).toHaveBeenCalledTimes(3);
 		expect(getRecipientPolicyAuthorityState(db, PROJECT)?.authorityState).toBe("active");
 	});
 
@@ -510,6 +511,51 @@ describe("recipient-policy reconciler executor", () => {
 		).toEqual({ status: "active" });
 	});
 
+	it("stages every disabled-member deny overlay before the first revoke", async () => {
+		const { effects } = harness(["device-keep", "device-new"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: null,
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: false,
+			},
+			{
+				deviceId: "device-new",
+				identityId: null,
+				publicKey: "pk-new",
+				fingerprint: "fp-new",
+				enabled: false,
+			},
+		]);
+		vi.mocked(effects.revoke).mockImplementation(async () => {
+			expect(
+				listRecipientPolicyDenyOverlays(db, PROJECT)
+					.map(({ deviceId }) => deviceId)
+					.toSorted(),
+			).toEqual(["device-keep", "device-new"]);
+			throw new Error("coordinator_unavailable");
+		});
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-disabled-failure" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "needs_attention",
+			safeErrorCode: "recipient_policy_effect_failed",
+		});
+		expect(effects.revoke).toHaveBeenCalledTimes(1);
+		expect(
+			listRecipientPolicyDenyOverlays(db, PROJECT)
+				.map(({ deviceId }) => deviceId)
+				.toSorted(),
+		).toEqual(["device-keep", "device-new"]);
+	});
+
 	it("leaves the same device active in another managed Project group", async () => {
 		db.prepare(
 			"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
@@ -659,6 +705,10 @@ describe("recipient-policy reconciler executor", () => {
 		expect(effects.revoke).toHaveBeenCalledWith(
 			expect.objectContaining({ scopeId: SCOPE, deviceId: "device-old" }),
 		);
+		expect(effects.refresh).toHaveBeenCalledWith({
+			canonicalProjectIdentity: PROJECT,
+			scopeId: SCOPE,
+		});
 		expect(effects.grant).not.toHaveBeenCalled();
 	});
 
@@ -684,7 +734,10 @@ describe("recipient-policy reconciler executor", () => {
 			expect.objectContaining({ deviceId: "device-old" }),
 		);
 		expect(effects.grant).not.toHaveBeenCalled();
-		expect(effects.refresh).not.toHaveBeenCalled();
+		expect(effects.refresh).toHaveBeenCalledWith({
+			canonicalProjectIdentity: PROJECT,
+			scopeId: SCOPE,
+		});
 		expect(vi.mocked(effects.probeCapability).mock.calls.map(([input]) => input.deviceId)).toEqual([
 			"device-keep",
 			"device-new",
@@ -699,6 +752,304 @@ describe("recipient-policy reconciler executor", () => {
 				deviceId: "device-old",
 			}),
 		).toThrow("recipient_policy_legacy_grant_blocked");
+	});
+
+	it("refreshes disabled-member revocations before unsupported capability returns", async () => {
+		const { calls, effects } = harness(["device-keep"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: null,
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: false,
+			},
+			{
+				deviceId: "device-new",
+				identityId: "identity-a",
+				publicKey: "pk-new",
+				fingerprint: "fp-new",
+				enabled: true,
+			},
+		]);
+		vi.mocked(effects.probeCapability).mockImplementation(async ({ deviceId }) => {
+			calls.push(`probe:${deviceId}`);
+			return "unsupported";
+		});
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-disabled-unsupported" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "needs_attention",
+			safeErrorCode: "recipient_policy_capability_unsupported",
+			revokedDeviceIds: ["device-keep"],
+		});
+		expect(calls.indexOf("refresh")).toBeGreaterThan(calls.indexOf("revoke:device-keep"));
+		expect(calls.indexOf("refresh")).toBeLessThan(calls.indexOf("probe:device-new"));
+		expect(effects.grant).not.toHaveBeenCalled();
+	});
+
+	it("retries a failed revocation refresh without repeating the completed revoke", async () => {
+		insertActiveAuthority(db);
+		const { calls, effects } = harness(["device-keep"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: "identity-a",
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: false,
+			},
+			{
+				deviceId: "device-new",
+				identityId: "identity-a",
+				publicKey: "pk-new",
+				fingerprint: "fp-new",
+				enabled: true,
+			},
+		]);
+		vi.mocked(effects.probeCapability).mockImplementation(async ({ deviceId }) => {
+			calls.push(`probe:${deviceId}`);
+			return "unsupported";
+		});
+		vi.mocked(effects.refresh)
+			.mockImplementationOnce(async () => {
+				calls.push("refresh");
+				throw new Error("refresh_failed");
+			})
+			.mockImplementation(async () => {
+				calls.push("refresh");
+			});
+
+		const failed = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-refresh-failed" },
+			effects,
+		);
+		const refreshGenerations = db
+			.prepare(
+				`SELECT DISTINCT generation FROM recipient_policy_reconciliation_steps
+				 WHERE step_key LIKE 'revoke-enrollment-disabled:%'
+				 OR step_key LIKE 'refresh-after-revocations-v2:%'
+				 ORDER BY generation`,
+			)
+			.all();
+		const retried = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-refresh-retry" },
+			effects,
+		);
+
+		expect(failed.safeErrorCode).toBe("recipient_policy_effect_failed");
+		expect(failed.revokedDeviceIds).toEqual(["device-keep"]);
+		expect(retried.safeErrorCode).toBe("recipient_policy_capability_unsupported");
+		expect(refreshGenerations).toEqual([{ generation: 1 }]);
+		expect(
+			db
+				.prepare(
+					`SELECT DISTINCT generation FROM recipient_policy_reconciliation_steps
+					 WHERE step_key LIKE 'revoke-enrollment-disabled:%'
+					 OR step_key LIKE 'refresh-after-revocations-v2:%'
+					 ORDER BY generation`,
+				)
+				.all(),
+		).toEqual([{ generation: 1 }]);
+		expect(effects.revoke).toHaveBeenCalledTimes(1);
+		expect(effects.refresh).toHaveBeenCalledTimes(2);
+		expect(calls.lastIndexOf("refresh")).toBeLessThan(calls.lastIndexOf("probe:device-new"));
+	});
+
+	it("replays a pending refresh through the current boundary after a scope remap", async () => {
+		db.prepare(
+			"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
+		).run();
+		const { effects, members } = harness(["device-keep"]);
+		let currentScopeId = SCOPE;
+		vi.mocked(effects.snapshot).mockImplementation(async () => {
+			const deviceIds = [...members].toSorted();
+			return {
+				authoritative: true,
+				scopeId: currentScopeId,
+				fingerprint: `snapshot:${deviceIds.join(",")}`,
+				observedAt: effects.now(),
+				memberships: deviceIds.map((deviceId) => ({ deviceId, status: "active" as const })),
+			};
+		});
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: "identity-a",
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: false,
+			},
+		]);
+		vi.mocked(effects.refresh)
+			.mockRejectedValueOnce(new Error("refresh_failed"))
+			.mockResolvedValueOnce(undefined)
+			.mockRejectedValue(new Error("redundant_refresh"));
+
+		await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-old-scope" },
+			effects,
+		);
+		currentScopeId = "managed-project-scope-remapped";
+		const now = effects.now();
+		db.prepare(
+			`INSERT INTO replication_scopes(
+			 scope_id, label, kind, authority_type, coordinator_id, group_id, membership_epoch,
+			 status, created_at, updated_at
+			 ) VALUES (?, 'Remapped Project', 'managed_project', 'coordinator', 'coord', 'group-remapped', 1,
+			 'active', ?, ?)`,
+		).run(currentScopeId, now, now);
+		db.prepare("UPDATE project_scope_mappings SET scope_id = ? WHERE workspace_identity = ?").run(
+			currentScopeId,
+			PROJECT,
+		);
+
+		const retried = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-remapped-scope" },
+			effects,
+		);
+
+		expect(retried.safeErrorCode).toBeNull();
+		expect(vi.mocked(effects.refresh).mock.calls.map(([input]) => input.scopeId)).toEqual([
+			SCOPE,
+			currentScopeId,
+		]);
+	});
+
+	it("stages new revocations before retrying an older failed refresh", async () => {
+		db.prepare(
+			"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
+		).run();
+		const { effects, members } = harness(["device-keep"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: "identity-a",
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: false,
+			},
+		]);
+		vi.mocked(effects.refresh).mockRejectedValue(new Error("refresh_failed"));
+
+		await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-old-refresh" },
+			effects,
+		);
+		members.add("device-old");
+		const retried = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-new-revoke" },
+			effects,
+		);
+
+		expect(retried.safeErrorCode).toBe("recipient_policy_effect_failed");
+		expect(vi.mocked(effects.revoke).mock.calls.map(([input]) => input.deviceId)).toEqual([
+			"device-keep",
+			"device-old",
+		]);
+		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([
+			expect.objectContaining({ deviceId: "device-keep" }),
+			expect.objectContaining({ deviceId: "device-old" }),
+		]);
+	});
+
+	it("continues policy revokes and stages enrollment denials after a refresh failure", async () => {
+		const { effects } = harness(["device-keep", "device-old-a", "device-old-b"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: "identity-a",
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: false,
+			},
+			{
+				deviceId: "device-new",
+				identityId: "identity-a",
+				publicKey: "pk-new",
+				fingerprint: "fp-new",
+				enabled: true,
+			},
+		]);
+		vi.mocked(effects.refresh)
+			.mockRejectedValueOnce(new Error("refresh_failed"))
+			.mockResolvedValue(undefined);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-refresh-denials" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "needs_attention",
+			safeErrorCode: "recipient_policy_effect_failed",
+			revokedDeviceIds: ["device-old-a", "device-old-b"],
+		});
+		expect(vi.mocked(effects.revoke).mock.calls.map(([input]) => input.deviceId)).toEqual([
+			"device-old-a",
+			"device-old-b",
+		]);
+		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ deviceId: "device-old-a", reasonCode: "pending_revoke" }),
+				expect.objectContaining({ deviceId: "device-old-b", reasonCode: "pending_revoke" }),
+				expect.objectContaining({ deviceId: "device-keep", reasonCode: "enrollment_disabled" }),
+			]),
+		);
+		expect(effects.grant).not.toHaveBeenCalled();
+	});
+
+	it("refreshes each distinct enrollment revocation reason for the same snapshot", async () => {
+		db.prepare(
+			"UPDATE identity_devices SET status = 'revoked' WHERE device_id = 'device-new'",
+		).run();
+		const { effects, members } = harness(["device-keep"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: "identity-b",
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: true,
+			},
+		]);
+
+		await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-conflict" },
+			effects,
+		);
+		members.add("device-keep");
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: "identity-a",
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: false,
+			},
+		]);
+
+		await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-disabled" },
+			effects,
+		);
+
+		expect(effects.revoke).toHaveBeenCalledTimes(2);
+		expect(effects.refresh).toHaveBeenCalledTimes(2);
 	});
 
 	it("retries a failed coordinator mutation with the same deterministic effect identity", async () => {

--- a/packages/core/src/recipient-policy-reconciler.ts
+++ b/packages/core/src/recipient-policy-reconciler.ts
@@ -356,6 +356,11 @@ interface EnrollmentRevocation {
 	reasonCode: EnrollmentRevocationReason;
 }
 
+interface RevocationStep {
+	deviceId: string;
+	stepKey: string;
+}
+
 function enrollmentRevocationReason(
 	binding: RecipientPolicyBoundaryEnrollment | undefined,
 	desiredIdentityId: string | undefined,
@@ -408,6 +413,32 @@ function enrollmentRevocationStepKey(
 		default:
 			return unreachableEnrollmentRevocationCase(phase);
 	}
+}
+
+function enrollmentRevocationStep(
+	revocation: EnrollmentRevocation,
+	phase: EnrollmentRevocationPhase,
+	snapshotStateKey: string,
+): RevocationStep {
+	return {
+		deviceId: revocation.deviceId,
+		stepKey: enrollmentRevocationStepKey(
+			revocation.reasonCode,
+			phase,
+			snapshotStateKey,
+			revocation.deviceId,
+		),
+	};
+}
+
+function revocationRefreshStepKey(input: {
+	scopeId: string;
+	phase: EnrollmentRevocationPhase;
+	snapshotStateKey: string;
+	revocationSetKey: string;
+}): string {
+	const scopeKey = digest("recipient-policy-revocation-refresh-scope-v1", input.scopeId);
+	return `refresh-after-revocations-v2:${scopeKey}:${input.phase}:${input.snapshotStateKey}:${input.revocationSetKey}`;
 }
 
 function generation(db: Database, projectId: string, desiredDigest: string): number {
@@ -571,35 +602,27 @@ async function applyEnrollmentRevocations(
 		snapshotStateKey: string;
 		phase: EnrollmentRevocationPhase;
 		revocations: EnrollmentRevocation[];
+		changedDeviceIds: string[];
 		leaseOwner: string;
 		lease: Lease;
 		effects: RecipientPolicyReconcilerEffects;
 	},
-): Promise<string[]> {
-	if (input.revocations.length === 0) return [];
-	resetParity(db, input.projectId, input.effects.now());
-	const changedDeviceIds: string[] = [];
-	for (const { deviceId, reasonCode } of input.revocations) {
-		putRecipientPolicyDenyOverlay(db, {
-			canonicalProjectIdentity: input.projectId,
-			scopeId: input.scopeId,
-			deviceId,
-			generation: input.generation,
-			reasonCode,
-			now: input.effects.now(),
-		});
+): Promise<void> {
+	if (input.revocations.length === 0) return;
+	stageEnrollmentRevocationOverlays(db, input);
+	for (const revocation of input.revocations) {
+		const revocationStep = enrollmentRevocationStep(
+			revocation,
+			input.phase,
+			input.snapshotStateKey,
+		);
 		const changed = await step(
 			db,
 			{
 				projectId: input.projectId,
 				generation: input.generation,
-				stepKey: enrollmentRevocationStepKey(
-					reasonCode,
-					input.phase,
-					input.snapshotStateKey,
-					deviceId,
-				),
-				payload: { scopeId: input.scopeId, deviceId, status: "revoked" },
+				stepKey: revocationStep.stepKey,
+				payload: { scopeId: input.scopeId, deviceId: revocation.deviceId, status: "revoked" },
 				leaseOwner: input.leaseOwner,
 				lease: input.lease,
 				now: input.effects.now,
@@ -610,19 +633,139 @@ async function applyEnrollmentRevocations(
 					canonicalProjectIdentity: input.projectId,
 					generation: input.generation,
 					scopeId: input.scopeId,
-					deviceId,
+					deviceId: revocation.deviceId,
 				});
 				validateReceipt(receipt, {
 					effectId,
 					scopeId: input.scopeId,
-					deviceId,
+					deviceId: revocation.deviceId,
 					status: "revoked",
 				});
 			},
 		);
-		if (changed) changedDeviceIds.push(deviceId);
+		if (changed) input.changedDeviceIds.push(revocation.deviceId);
+		await refreshAfterRevocations(db, {
+			projectId: input.projectId,
+			generation: input.generation,
+			scopeId: input.scopeId,
+			snapshotStateKey: input.snapshotStateKey,
+			phase: input.phase,
+			revocations: [revocationStep],
+			leaseOwner: input.leaseOwner,
+			lease: input.lease,
+			effects: input.effects,
+		});
 	}
-	return changedDeviceIds;
+}
+
+function stageEnrollmentRevocationOverlays(
+	db: Database,
+	input: {
+		projectId: string;
+		generation: number;
+		scopeId: string;
+		revocations: EnrollmentRevocation[];
+		effects: RecipientPolicyReconcilerEffects;
+	},
+): void {
+	if (input.revocations.length === 0) return;
+	resetParity(db, input.projectId, input.effects.now());
+	for (const { deviceId, reasonCode } of input.revocations) {
+		putRecipientPolicyDenyOverlay(db, {
+			canonicalProjectIdentity: input.projectId,
+			scopeId: input.scopeId,
+			deviceId,
+			generation: input.generation,
+			reasonCode,
+			now: input.effects.now(),
+		});
+	}
+}
+
+async function refreshAfterRevocations(
+	db: Database,
+	input: {
+		projectId: string;
+		generation: number;
+		scopeId: string;
+		snapshotStateKey: string;
+		phase: EnrollmentRevocationPhase;
+		revocations: RevocationStep[];
+		leaseOwner: string;
+		lease: Lease;
+		effects: RecipientPolicyReconcilerEffects;
+	},
+): Promise<void> {
+	const revocationStepKeys = [
+		...new Set(input.revocations.map(({ stepKey }) => stepKey)),
+	].toSorted();
+	if (revocationStepKeys.length === 0) return;
+	const revocationSetKey = digest("recipient-policy-revocation-refresh-v2", {
+		revocationStepKeys,
+	});
+	await step(
+		db,
+		{
+			projectId: input.projectId,
+			generation: input.generation,
+			stepKey: revocationRefreshStepKey({
+				scopeId: input.scopeId,
+				phase: input.phase,
+				snapshotStateKey: input.snapshotStateKey,
+				revocationSetKey,
+			}),
+			payload: { canonicalProjectIdentity: input.projectId },
+			leaseOwner: input.leaseOwner,
+			lease: input.lease,
+			now: input.effects.now,
+		},
+		async () =>
+			input.effects.refresh({
+				canonicalProjectIdentity: input.projectId,
+				scopeId: input.scopeId,
+			}),
+	);
+}
+
+async function retryPendingRevocationRefreshes(
+	db: Database,
+	input: {
+		projectId: string;
+		scopeId: string;
+		leaseOwner: string;
+		lease: Lease;
+		effects: RecipientPolicyReconcilerEffects;
+	},
+): Promise<boolean> {
+	const pending = db
+		.prepare(
+			`SELECT generation, step_key FROM recipient_policy_reconciliation_steps
+			 WHERE canonical_project_identity = ?
+			 AND step_key LIKE 'refresh-after-revocations-v2:%'
+			 AND status IN ('pending', 'running', 'failed')
+			 ORDER BY generation, step_key`,
+		)
+		.all(input.projectId) as Array<{ generation: number; step_key: string }>;
+	for (const refresh of pending) {
+		await step(
+			db,
+			{
+				projectId: input.projectId,
+				generation: refresh.generation,
+				stepKey: refresh.step_key,
+				payload: { canonicalProjectIdentity: input.projectId },
+				leaseOwner: input.leaseOwner,
+				lease: input.lease,
+				now: input.effects.now,
+			},
+			async () =>
+				input.effects.refresh({
+					canonicalProjectIdentity: input.projectId,
+					scopeId: input.scopeId,
+				}),
+		);
+	}
+	return pending.length > 0;
 }
 
 async function preflight(
@@ -762,14 +905,24 @@ export async function reconcileRecipientPolicyProject(
 		const snapshotStateKey = digest("recipient-policy-snapshot-state-v1", {
 			fingerprint: initialSnapshot.fingerprint,
 		});
-		for (const deviceId of revokeDeviceIds) {
+		const policyRevocations = revokeDeviceIds.map((deviceId) => ({
+			deviceId,
+			stepKey: `revoke:${snapshotStateKey}:${deviceId}`,
+		}));
+		let replayedRevocationRefresh = false;
+		let revocationRefreshError: unknown = null;
+		for (const revocation of policyRevocations) {
 			const changed = await step(
 				db,
 				{
 					projectId,
 					generation: activeGeneration,
-					stepKey: `revoke:${snapshotStateKey}:${deviceId}`,
-					payload: { scopeId: managedBoundary.scopeId, deviceId, status: "revoked" },
+					stepKey: revocation.stepKey,
+					payload: {
+						scopeId: managedBoundary.scopeId,
+						deviceId: revocation.deviceId,
+						status: "revoked",
+					},
 					leaseOwner: input.leaseOwner,
 					lease,
 					now: effects.now,
@@ -780,17 +933,47 @@ export async function reconcileRecipientPolicyProject(
 						canonicalProjectIdentity: projectId,
 						generation: activeGeneration,
 						scopeId: managedBoundary.scopeId,
-						deviceId,
+						deviceId: revocation.deviceId,
 					});
 					validateReceipt(receipt, {
 						effectId,
 						scopeId: managedBoundary.scopeId,
-						deviceId,
+						deviceId: revocation.deviceId,
 						status: "revoked",
 					});
 				},
 			);
-			if (changed) revokedDeviceIds.push(deviceId);
+			if (changed) revokedDeviceIds.push(revocation.deviceId);
+			try {
+				await refreshAfterRevocations(db, {
+					projectId,
+					generation: activeGeneration,
+					scopeId: managedBoundary.scopeId,
+					snapshotStateKey,
+					phase: "steady_state",
+					revocations: [revocation],
+					leaseOwner: input.leaseOwner,
+					lease,
+					effects,
+				});
+				replayedRevocationRefresh = true;
+			} catch (error) {
+				revocationRefreshError ??= error;
+			}
+		}
+		if (!revocationRefreshError) {
+			try {
+				replayedRevocationRefresh =
+					(await retryPendingRevocationRefreshes(db, {
+						projectId,
+						scopeId: managedBoundary.scopeId,
+						leaseOwner: input.leaseOwner,
+						lease,
+						effects,
+					})) || replayedRevocationRefresh;
+			} catch (error) {
+				revocationRefreshError = error;
+			}
 		}
 		const rederived = deriveRecipientPolicyEffectiveDevicesFromDatabase(db, projectId);
 		if (
@@ -831,19 +1014,28 @@ export async function reconcileRecipientPolicyProject(
 				return reasonCode ? [{ deviceId, reasonCode }] : [];
 			},
 		);
-		revokedDeviceIds.push(
-			...(await applyEnrollmentRevocations(db, {
+		if (revocationRefreshError) {
+			stageEnrollmentRevocationOverlays(db, {
 				projectId,
 				generation: activeGeneration,
 				scopeId: managedBoundary.scopeId,
-				snapshotStateKey,
-				phase: "steady_state",
 				revocations: enrollmentRevocations,
-				leaseOwner: input.leaseOwner,
-				lease,
 				effects,
-			})),
-		);
+			});
+			throw revocationRefreshError;
+		}
+		await applyEnrollmentRevocations(db, {
+			projectId,
+			generation: activeGeneration,
+			scopeId: managedBoundary.scopeId,
+			snapshotStateKey,
+			phase: "steady_state",
+			revocations: enrollmentRevocations,
+			changedDeviceIds: revokedDeviceIds,
+			leaseOwner: input.leaseOwner,
+			lease,
+			effects,
+		});
 		const enrollmentRevokedDeviceIds = new Set(
 			enrollmentRevocations.map(({ deviceId }) => deviceId),
 		);
@@ -867,8 +1059,18 @@ export async function reconcileRecipientPolicyProject(
 		].toSorted();
 		const expectedSet = new Set(expectedDeviceIds);
 		const expectedDigest = deviceDigest(expectedDeviceIds);
-		activeGeneration = generation(db, projectId, expectedDigest);
 		const grantDeviceIds = grantEligibleDeviceIds.filter((deviceId) => !currentSet.has(deviceId));
+		const passKey = digest("recipient-policy-pass-v1", {
+			fingerprint: initialSnapshot.fingerprint,
+			observedAt: initialSnapshot.observedAt,
+		});
+		const revocations = [
+			...policyRevocations,
+			...enrollmentRevocations.map((revocation) =>
+				enrollmentRevocationStep(revocation, "steady_state", snapshotStateKey),
+			),
+		];
+		activeGeneration = generation(db, projectId, expectedDigest);
 		upsertRecipientPolicyAuthorityObservation(db, {
 			canonicalProjectIdentity: projectId,
 			generation: activeGeneration,
@@ -880,10 +1082,6 @@ export async function reconcileRecipientPolicyProject(
 			now: effects.now(),
 		});
 		if (grantDeviceIds.length > 0) resetParity(db, projectId, effects.now());
-		const passKey = digest("recipient-policy-pass-v1", {
-			fingerprint: initialSnapshot.fingerprint,
-			observedAt: initialSnapshot.observedAt,
-		});
 		const capability = await preflight(db, {
 			projectId,
 			generation: activeGeneration,
@@ -991,19 +1189,18 @@ export async function reconcileRecipientPolicyProject(
 				];
 			});
 			if (changedBindings.length > 0) {
-				revokedDeviceIds.push(
-					...(await applyEnrollmentRevocations(db, {
-						projectId,
-						generation: activeGeneration,
-						scopeId: managedBoundary.scopeId,
-						snapshotStateKey,
-						phase: "post_grant",
-						revocations: changedBindings,
-						leaseOwner: input.leaseOwner,
-						lease,
-						effects,
-					})),
-				);
+				await applyEnrollmentRevocations(db, {
+					projectId,
+					generation: activeGeneration,
+					scopeId: managedBoundary.scopeId,
+					snapshotStateKey,
+					phase: "post_grant",
+					revocations: changedBindings,
+					changedDeviceIds: revokedDeviceIds,
+					leaseOwner: input.leaseOwner,
+					lease,
+					effects,
+				});
 				authority(db, {
 					projectId,
 					safeErrorCode: "recipient_policy_generation_stale",
@@ -1019,24 +1216,29 @@ export async function reconcileRecipientPolicyProject(
 				);
 			}
 		}
-		await step(
-			db,
-			{
-				projectId,
-				generation: activeGeneration,
-				stepKey: `refresh:${passKey}`,
-				payload: {
-					scopeId: managedBoundary.scopeId,
-					fingerprint: initialSnapshot.fingerprint,
-					observedAt: initialSnapshot.observedAt,
+		if (grantDeviceIds.length > 0 || (revocations.length === 0 && !replayedRevocationRefresh)) {
+			await step(
+				db,
+				{
+					projectId,
+					generation: activeGeneration,
+					stepKey: `refresh:${passKey}`,
+					payload: {
+						scopeId: managedBoundary.scopeId,
+						fingerprint: initialSnapshot.fingerprint,
+						observedAt: initialSnapshot.observedAt,
+					},
+					leaseOwner: input.leaseOwner,
+					lease,
+					now: effects.now,
 				},
-				leaseOwner: input.leaseOwner,
-				lease,
-				now: effects.now,
-			},
-			async () =>
-				effects.refresh({ canonicalProjectIdentity: projectId, scopeId: managedBoundary.scopeId }),
-		);
+				async () =>
+					effects.refresh({
+						canonicalProjectIdentity: projectId,
+						scopeId: managedBoundary.scopeId,
+					}),
+			);
+		}
 		const verificationRequestedAt = effects.now();
 		const verifiedSnapshot = await effects.snapshot({
 			canonicalProjectIdentity: projectId,


### PR DESCRIPTION
## Description

Follow up on post-merge review feedback from #1381.

- stage the complete disabled/conflicting enrollment deny set before any external revoke;
- refresh membership cache and coordinator-policy peer trust after policy/enrollment revocations and before capability early returns;
- persist and replay unfinished revocation refreshes before capability checks or grants, without blocking newly required deny overlays/revokes;
- keep revoke and refresh work in the same generation until refresh succeeds;
- key refreshes by the exact reason-specific revocation step identities and original scope identity;
- replay through the current active boundary so scope remapping cannot wedge reconciliation.

Tracked by Bead `codemem-jna9`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Focused reconciler suite: 33 tests passed. Full workspace gate: 3,485 tests passed with 3 todo. Project Sharing E2E passed. Snyk Code did not flag touched files; the workspace scan reported 12 unrelated findings outside the PR diff. Independent CodeReviewer pass found no remaining merge blockers.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed; no public API/UI change)
- [x] No new warnings introduced