### PR TITLE
fix(sharing): preserve capability preflight errors

### DIFF
--- a/packages/core/src/recipient-policy-reconciler.test.ts
+++ b/packages/core/src/recipient-policy-reconciler.test.ts
@@ -1122,6 +1122,44 @@ describe("recipient-policy reconciler executor", () => {
 		expect(getRecipientPolicyAuthorityState(db, PROJECT)?.authorityState).toBe("active");
 	});
 
+	it("does not rewrite lease loss during capability preflight as undetermined", async () => {
+		const { effects } = harness(["device-keep", "device-new"]);
+		insertActiveAuthority(db);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{
+				canonicalProjectIdentity: PROJECT,
+				leaseOwner: "worker-expired",
+				leaseDurationMs: 1,
+			},
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "needs_attention",
+			safeErrorCode: "recipient_policy_lease_lost",
+		});
+		expect(effects.probeCapability).not.toHaveBeenCalled();
+		expect(getRecipientPolicyAuthorityState(db, PROJECT)?.authorityState).toBe("rolled_back");
+	});
+
+	it("does not rewrite capability effect failures as undetermined", async () => {
+		const { effects } = harness(["device-keep", "device-new"]);
+		vi.mocked(effects.probeCapability).mockRejectedValue(new Error("network_failed"));
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-failed-probe" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "needs_attention",
+			safeErrorCode: "recipient_policy_effect_failed",
+		});
+	});
+
 	it("preserves active authority while the coordinator snapshot is not fresh", async () => {
 		const { effects } = harness(["device-keep", "device-new"]);
 		vi.mocked(effects.snapshot).mockResolvedValue({

--- a/packages/core/src/recipient-policy-reconciler.ts
+++ b/packages/core/src/recipient-policy-reconciler.ts
@@ -784,33 +784,45 @@ async function preflight(
 	const capabilities: RecipientPolicyPeerCapability[] = [];
 	for (const deviceId of input.deviceIds) {
 		let capability: RecipientPolicyPeerCapability = "undetermined";
-		const executed = await step(
-			db,
-			{
-				projectId: input.projectId,
-				generation: input.generation,
-				stepKey: `capability:${input.passKey}:${deviceId}`,
-				payload: { deviceId, passKey: input.passKey },
-				leaseOwner: input.leaseOwner,
-				lease: input.lease,
-				now: input.effects.now,
-			},
-			async () => {
-				const observed = await input.effects.probeCapability({
-					deviceId,
-					scopeId: input.scopeId,
-				});
-				capability = ["supported", "unsupported", "undetermined"].includes(observed)
-					? observed
-					: "undetermined";
-				if (capability === "unsupported") {
-					throw new Error("recipient_policy_capability_unsupported");
-				}
-				if (capability === "undetermined") {
-					throw new Error("recipient_policy_capability_undetermined");
-				}
-			},
-		).catch(() => undefined);
+		let executed: boolean | undefined;
+		try {
+			executed = await step(
+				db,
+				{
+					projectId: input.projectId,
+					generation: input.generation,
+					stepKey: `capability:${input.passKey}:${deviceId}`,
+					payload: { deviceId, passKey: input.passKey },
+					leaseOwner: input.leaseOwner,
+					lease: input.lease,
+					now: input.effects.now,
+				},
+				async () => {
+					const observed = await input.effects.probeCapability({
+						deviceId,
+						scopeId: input.scopeId,
+					});
+					capability = ["supported", "unsupported", "undetermined"].includes(observed)
+						? observed
+						: "undetermined";
+					if (capability === "unsupported") {
+						throw new Error("recipient_policy_capability_unsupported");
+					}
+					if (capability === "undetermined") {
+						throw new Error("recipient_policy_capability_undetermined");
+					}
+				},
+			);
+		} catch (error) {
+			const safeErrorCode = safeError(error, "recipient_policy_reconciliation_failed");
+			if (safeErrorCode === "recipient_policy_capability_unsupported") {
+				capability = "unsupported";
+			} else if (safeErrorCode === "recipient_policy_capability_undetermined") {
+				capability = "undetermined";
+			} else {
+				throw error;
+			}
+		}
 		if (executed === false) capability = "supported";
 		capabilities.push(capability);
 	}


### PR DESCRIPTION
## Description

Preserve recipient-policy control-plane errors during capability preflight instead of rewriting lease loss and reconciliation conflicts as an undetermined device capability. Supported, unsupported, and genuinely undetermined capability outcomes retain their existing behavior.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused coverage verifies that capability outcomes are translated while lease loss propagates unchanged.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced