### PR TITLE
fix(sharing): resume setup after peer reconnect

### DIFF
--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1612,16 +1612,46 @@ export async function advancePendingProjectShares(
 	const waitingRetryBefore = new Date(
 		maintenanceNow.getTime() - AUTOMATIC_WAITING_DEVICE_RETRY_COOLDOWN_MS,
 	).toISOString();
+	// A later failed attempt supersedes older reachability evidence and keeps the cooldown in force.
 	const rows = store.db
-		.prepare(`SELECT operation_id FROM share_operations
-		 WHERE inviter_actor_id = ?
-		 AND state IN (${placeholders})
-		 AND (state <> 'waiting_for_acceptance' OR updated_at <= ?)
-		 AND (state <> 'waiting_for_device' OR updated_at <= ?)
-		 ORDER BY CASE WHEN state IN ('accepted', 'provisioning', 'initial_sync') THEN 0 ELSE 1 END,
-			CASE WHEN state IN ('waiting_for_acceptance', 'waiting_for_device')
-				THEN updated_at ELSE created_at END ASC,
-			created_at ASC, operation_id ASC
+		.prepare(`SELECT operation.operation_id FROM share_operations AS operation
+		 WHERE operation.inviter_actor_id = ?
+		 AND operation.state IN (${placeholders})
+		 AND (operation.state <> 'waiting_for_acceptance' OR operation.updated_at <= ?)
+		 AND (
+			operation.state <> 'waiting_for_device'
+			OR operation.updated_at <= ?
+			OR (
+				NOT EXISTS (
+					SELECT 1 FROM share_operation_steps AS step
+					WHERE step.operation_id = operation.operation_id
+					AND step.step_key = 'capability_preflight'
+					AND step.status <> 'completed'
+					AND (
+						step.status = 'running'
+						OR step.safe_error_code IN (
+							'waiting_for_device', 'device_offline', 'recipient_offline'
+						)
+					)
+				)
+				AND EXISTS (
+					SELECT 1 FROM sync_attempts AS attempt
+					WHERE attempt.id = (
+						SELECT latest.id FROM sync_attempts AS latest
+						WHERE latest.peer_device_id = operation.recipient_device_id
+						ORDER BY latest.started_at DESC, latest.id DESC
+						LIMIT 1
+					)
+					AND attempt.ok = 1
+					AND julianday(COALESCE(attempt.finished_at, attempt.started_at)) >
+						julianday(operation.updated_at)
+				)
+			)
+		 )
+		 ORDER BY CASE WHEN operation.state IN ('accepted', 'provisioning', 'initial_sync') THEN 0 ELSE 1 END,
+			CASE WHEN operation.state IN ('waiting_for_acceptance', 'waiting_for_device')
+				THEN operation.updated_at ELSE operation.created_at END ASC,
+			operation.created_at ASC, operation.operation_id ASC
 		 LIMIT ?`)
 		.all(
 			store.actorId,

--- a/packages/viewer-server/src/share-operation-maintenance.test.ts
+++ b/packages/viewer-server/src/share-operation-maintenance.test.ts
@@ -577,6 +577,139 @@ describe("advancePendingProjectShares", () => {
 			state: "waiting_for_device",
 			createdAt: "2026-07-20T00:58:00Z",
 		});
+		db.prepare("UPDATE share_operations SET recipient_device_id = ? WHERE operation_id = ?").run(
+			"device-recipient",
+			"share-waiting-device",
+		);
+		db.prepare(`INSERT INTO sync_peers(
+			peer_device_id, addresses_json, created_at, last_seen_at
+		) VALUES (
+			'device-recipient', '[]', '2026-07-20T00:00:00Z', '2026-07-20T00:59:00Z'
+		)`).run();
+		const advanceOperation = vi.fn(async () => ({ advanced: true, state: "active" as const }));
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(advanceOperation).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ processed: 0, waiting: 0, attention: 0, failed: 0 });
+	});
+
+	it("retries a recent waiting-for-device operation after a fully successful sync", async () => {
+		seedOperation({
+			id: "share-reconnected-device",
+			state: "waiting_for_device",
+			createdAt: "2026-07-20T00:58:00Z",
+		});
+		db.prepare("UPDATE share_operations SET recipient_device_id = ? WHERE operation_id = ?").run(
+			"device-recipient",
+			"share-reconnected-device",
+		);
+		db.prepare(`INSERT INTO sync_peers(peer_device_id, created_at, last_sync_at)
+			VALUES ('device-recipient', '2026-07-20T00:00:00Z', '2026-07-20T00:59:00Z')`).run();
+		db.prepare(`INSERT INTO sync_attempts(
+			peer_device_id, started_at, finished_at, ok, ops_in, ops_out
+		) VALUES (
+			'device-recipient', '2026-07-20T00:59:00Z', '2026-07-20T00:59:00Z', 1, 0, 0
+		)`).run();
+		const advanceOperation = vi.fn(async () => ({ advanced: true, state: "active" as const }));
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(advanceOperation).toHaveBeenCalledWith(store, "share-reconnected-device");
+		expect(result).toMatchObject({ processed: 1, advanced: 1, failed: 0 });
+	});
+
+	it("preserves cooldown when the latest peer activity was not a fully successful sync", async () => {
+		seedOperation({
+			id: "share-partial-sync",
+			state: "waiting_for_device",
+			createdAt: "2026-07-20T00:58:00Z",
+		});
+		db.prepare("UPDATE share_operations SET recipient_device_id = ? WHERE operation_id = ?").run(
+			"device-recipient",
+			"share-partial-sync",
+		);
+		db.prepare(`INSERT INTO sync_peers(peer_device_id, created_at, last_sync_at)
+			VALUES ('device-recipient', '2026-07-20T00:00:00Z', '2026-07-20T00:59:00Z')`).run();
+		db.prepare(`INSERT INTO sync_attempts(
+			peer_device_id, started_at, finished_at, ok, ops_in, ops_out
+		) VALUES (
+			'device-recipient', '2026-07-20T00:58:30Z', '2026-07-20T00:58:30Z', 1, 0, 0
+		)`).run();
+		db.prepare(`INSERT INTO sync_attempts(
+			peer_device_id, started_at, finished_at, ok, ops_in, ops_out, error
+		) VALUES (
+			'device-recipient', '2026-07-20T00:59:00Z', '2026-07-20T00:59:00Z',
+			0, 0, 0, 'scoped sync incomplete'
+		)`).run();
+		const advanceOperation = vi.fn(async () => ({ advanced: true, state: "active" as const }));
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(advanceOperation).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ processed: 0, waiting: 0, attention: 0, failed: 0 });
+	});
+
+	it("preserves cooldown while a capability preflight retry is running", async () => {
+		seedOperation({
+			id: "share-running-capability",
+			state: "waiting_for_device",
+			createdAt: "2026-07-20T00:58:00Z",
+		});
+		db.prepare("UPDATE share_operations SET recipient_device_id = ? WHERE operation_id = ?").run(
+			"device-recipient",
+			"share-running-capability",
+		);
+		db.prepare(`INSERT INTO share_operation_steps(
+			operation_id, step_key, effect_id, status, attempt_count, safe_error_code, updated_at
+		) VALUES (?, 'capability_preflight', 'capability:running', 'running', 2,
+			NULL, '2026-07-20T00:58:00Z')`).run("share-running-capability");
+		db.prepare(`INSERT INTO sync_attempts(
+			peer_device_id, started_at, finished_at, ok, ops_in, ops_out
+		) VALUES (
+			'device-recipient', '2026-07-20T00:59:00Z', '2026-07-20T00:59:00Z', 1, 0, 0
+		)`).run();
+		const advanceOperation = vi.fn(async () => ({ advanced: true, state: "active" as const }));
+
+		const result = await advancePendingProjectShares(store, {
+			now: new Date("2026-07-20T01:00:00Z"),
+			advanceOperation,
+		});
+
+		expect(advanceOperation).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ processed: 0, waiting: 0, attention: 0, failed: 0 });
+	});
+
+	it("preserves cooldown when capability preflight waits on another device", async () => {
+		seedOperation({
+			id: "share-capability-wait",
+			state: "waiting_for_device",
+			createdAt: "2026-07-20T00:58:00Z",
+		});
+		db.prepare("UPDATE share_operations SET recipient_device_id = ? WHERE operation_id = ?").run(
+			"device-recipient",
+			"share-capability-wait",
+		);
+		db.prepare(`INSERT INTO share_operation_steps(
+			operation_id, step_key, effect_id, status, attempt_count, safe_error_code, updated_at
+		) VALUES (?, 'capability_preflight', 'capability:test', 'failed', 1,
+			'waiting_for_device', '2026-07-20T00:58:00Z')`).run("share-capability-wait");
+		db.prepare(`INSERT INTO sync_peers(peer_device_id, created_at, last_sync_at)
+			VALUES ('device-recipient', '2026-07-20T00:00:00Z', '2026-07-20T00:59:00Z')`).run();
+		db.prepare(`INSERT INTO sync_attempts(
+			peer_device_id, started_at, finished_at, ok, ops_in, ops_out
+		) VALUES (
+			'device-recipient', '2026-07-20T00:59:00Z', '2026-07-20T00:59:00Z', 1, 0, 0
+		)`).run();
 		const advanceOperation = vi.fn(async () => ({ advanced: true, state: "active" as const }));
 
 		const result = await advancePendingProjectShares(store, {


### PR DESCRIPTION
## Description

Let share-operation maintenance bypass the normal waiting-device cooldown when the recipient has completed a successful sync after the operation entered its wait. This allows setup to resume automatically after a real reconnect without waiting for a hidden manual advance.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused maintenance coverage verifies that a newer successful peer sync resumes the operation while unrelated or stale peer activity does not.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced