### PR TITLE
fix(sharing): distinguish capability waits

### DIFF
--- a/packages/core/src/share-operation-lifecycle.test.ts
+++ b/packages/core/src/share-operation-lifecycle.test.ts
@@ -117,6 +117,42 @@ describe("projectShareLifecycle", () => {
 		expect(result).toMatchObject({ lifecycle: "waiting_for_device", primaryAction: null });
 	});
 
+	it("distinguishes capability evidence waits from an offline recipient", () => {
+		const result = project("waiting_for_device", [
+			step({
+				safeErrorCode: "waiting_for_device",
+				status: "failed",
+				stepKey: "capability_preflight",
+			}),
+		]);
+
+		expect(result).toMatchObject({
+			lifecycle: "waiting_for_device",
+			label: "Checking device compatibility",
+			explanation: "Waiting for a participating device to report the required sharing capability.",
+			primaryAction: null,
+		});
+		expect(result.explanation).not.toContain("reach");
+	});
+
+	it("keeps a running capability retry classified as a compatibility wait", () => {
+		const result = project("waiting_for_device", [
+			step({
+				safeErrorCode: null,
+				status: "running",
+				stepKey: "capability_preflight",
+			}),
+		]);
+
+		expect(result).toMatchObject({
+			lifecycle: "waiting_for_device",
+			label: "Checking device compatibility",
+			explanation: "Waiting for a participating device to report the required sharing capability.",
+			primaryAction: null,
+		});
+		expect(result.explanation).not.toContain("reach");
+	});
+
 	it("maps safe failure codes without leaking technical traces", () => {
 		const result = project("needs_attention", [
 			step({ status: "failed", safeErrorCode: "reassign_capability_required" }),

--- a/packages/core/src/share-operation-lifecycle.ts
+++ b/packages/core/src/share-operation-lifecycle.ts
@@ -131,6 +131,18 @@ export function projectShareLifecycle(
 	}
 
 	const incomplete = input.steps.filter((step) => step.status !== "completed");
+	const capabilityWait = incomplete.find(
+		(step) =>
+			step.stepKey === "capability_preflight" &&
+			(step.status === "running" || DEVICE_WAIT_CODES.has(step.safeErrorCode ?? "")),
+	);
+	if (capabilityWait && input.state === "waiting_for_device") {
+		return passive(
+			"waiting_for_device",
+			"Checking device compatibility",
+			"Waiting for a participating device to report the required sharing capability.",
+		);
+	}
 	const deviceWait = incomplete.find(isDeviceWait);
 	if (input.state === "waiting_for_device" || deviceWait) {
 		const lastSeen = input.deviceLastSeenAt?.trim();

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -788,8 +788,9 @@ describe("Projects tab", () => {
 					person: { actor_id: "actor-alex", display_name: "Alex" },
 					lifecycle: {
 						state: "waiting_for_device",
-						label: "Waiting for device",
-						explanation: "Sync will continue when the device reconnects.",
+						label: "Checking device compatibility",
+						explanation:
+							"Waiting for a participating device to report the required sharing capability.",
 					},
 				},
 			],
@@ -820,7 +821,8 @@ describe("Projects tab", () => {
 		expect(selectedRow?.querySelector(".project-sharing-summary")?.textContent).toContain("Brian");
 		expect(selectedRow?.querySelector(".project-sharing-summary")?.textContent).toContain("Alex");
 		expect(selectedRow?.textContent).toContain("Up to date");
-		expect(selectedRow?.textContent).toContain("Waiting for device");
+		expect(selectedRow?.textContent).toContain("Checking device compatibility");
+		expect(selectedRow?.textContent.match(/Checking device compatibility/g)).toHaveLength(1);
 		expect(siblingRow?.querySelector(".project-sharing-summary")).toBeNull();
 	});
 

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -119,7 +119,7 @@ function projectSharingRelationshipLabel(
 		case "active":
 			return `Shared with ${personName}`;
 		case "waiting_for_device":
-			return `Waiting for ${personName}'s device`;
+			return `Sharing with ${personName}`;
 		case "needs_attention":
 			return `Sharing with ${personName} needs attention`;
 		case "revoking":


### PR DESCRIPTION
## Description

Distinguish capability-preflight waits from offline-device waits in the projected share lifecycle and Projects summary. Capability waits now use neutral participating-device language, retain teammate context, and avoid duplicating the status label.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused lifecycle and Projects UI tests verify capability copy, person context, and single rendering of the compatibility status.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced