### PR TITLE
test(sharing): cover reconnect auto-resume

### DIFF
--- a/e2e/scenarios/project-sharing.ts
+++ b/e2e/scenarios/project-sharing.ts
@@ -25,6 +25,7 @@ interface FixtureSummary {
 		actor_id: string | null;
 		pinned_fingerprint: string | null;
 		trust_provenance: string | null;
+		last_sync_at: string | null;
 		discovered_via_coordinator_id: string | null;
 		discovered_via_group_id: string | null;
 	}>;
@@ -36,6 +37,7 @@ interface FixtureSummary {
 		teammate_name: string;
 		recipient_device_id: string | null;
 		recipient_device_display_name: string | null;
+		updated_at: string;
 	}>;
 	policy: {
 		authority_states: Array<{
@@ -484,19 +486,118 @@ export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<v
 		"peer-a has no peer-b record after reconciliation",
 	);
 
+	const recipientBeforeOfflineWait = await request<{ daemon_last_ok_at?: string | null }>(
+		ctx,
+		"peer-b",
+		"/api/sync/status?includeDiagnostics=true",
+		"29-recipient-before-offline-wait",
+	);
+	const stoppedRecipient = ctx.compose.stop("peer-b", "29-stop-recipient-before-provisioning");
+	assertStatus(stoppedRecipient.status, 0, "recipient failed to stop before offline provisioning check");
+	const offlineAdvance = await request<{ error?: string }>(
+		ctx,
+		"peer-a",
+		`/api/sync/share-operations/${created.body.operation_id}/advance`,
+		"29-advance-project-share-offline",
+		{},
+	);
+	assert(
+		offlineAdvance.status === 409 && offlineAdvance.body.error === "waiting_for_device",
+		`offline recipient did not enter a safe waiting state: ${JSON.stringify(offlineAdvance.body)}`,
+	);
+	const waitingOwner = fixture(ctx, "peer-a", "summary", "29-peer-a-waiting-summary");
+	const waitingOperation = waitingOwner.operations.find(
+		(item) => item.operation_id === created.body.operation_id,
+	);
+	assert(
+		waitingOperation?.state === "waiting_for_device",
+		`offline recipient did not persist waiting_for_device: ${waitingOperation?.state ?? "missing"}`,
+	);
+
+	const startedRecipient = ctx.compose.start("peer-b", "30-start-recipient-for-auto-resume-container");
+	assertStatus(startedRecipient.status, 0, "recipient container failed to start for automatic resume");
+	startServer(ctx, "peer-b", "30-start-recipient-for-auto-resume-server");
+	await waitForServer(ctx, "peer-b", "30-recipient-ready-for-auto-resume");
 	await waitFor(
 		async () => {
-			const advanced = await request<Record<string, unknown>>(
+			const status = await request<{ daemon_state: string; daemon_last_ok_at?: string | null }>(
 				ctx,
-				"peer-a",
-				`/api/sync/share-operations/${created.body.operation_id}/advance`,
-				"29-advance-project-share",
-				{},
+				"peer-b",
+				"/api/sync/status?includeDiagnostics=true",
+				"30-recipient-sync-ready-after-reconnect",
 			);
-			assert(advanced.status === 200, `project provisioning not ready: ${JSON.stringify(advanced.body)}`);
+			assert(status.body.daemon_state !== "starting", "recipient sync is still starting");
+			assert(status.body.daemon_last_ok_at, "recipient sync has not completed after reconnect");
+			assert(
+				!recipientBeforeOfflineWait.body.daemon_last_ok_at ||
+					status.body.daemon_last_ok_at > recipientBeforeOfflineWait.body.daemon_last_ok_at,
+				"recipient sync status did not advance after reconnect",
+			);
 		},
-		{ description: "project share provisioning", timeoutMs: 180_000, intervalMs: 3_000 },
+		{ description: "recipient sync readiness after reconnect", timeoutMs: 120_000, intervalMs: 2_000 },
 	);
+	syncOnce(ctx, "peer-a", "30-sync-reconnected-recipient", peerB.device_id);
+	const reconnectReadModel = await request<{
+		lifecycle: { state: string; label: string; explanation: string };
+	}>(
+		ctx,
+		"peer-a",
+		`/api/sync/share-operations/${created.body.operation_id}`,
+		"30-reconnected-operation-read-model",
+	);
+	assert(reconnectReadModel.status === 200, "reconnected operation read model failed");
+	assert(
+		reconnectReadModel.body.lifecycle.label !== "Checking device compatibility",
+		`recipient reachability did not resolve capability preflight: ${JSON.stringify(reconnectReadModel.body.lifecycle)}`,
+	);
+	assert(
+		reconnectReadModel.body.lifecycle.state === "waiting_for_device" &&
+			reconnectReadModel.body.lifecycle.label === "Finishing project setup" &&
+			!reconnectReadModel.body.lifecycle.explanation.includes("Waiting to reach"),
+		`online recipient was still described as offline: ${JSON.stringify(reconnectReadModel.body.lifecycle)}`,
+	);
+	const syncedOwner = fixture(ctx, "peer-a", "summary", "30-peer-a-reconnected-sync-summary");
+	const reconnectedPeer = syncedOwner.peers.find((peer) => peer.peer_device_id === peerB.device_id);
+	assert(
+		reconnectedPeer?.last_sync_at && reconnectedPeer.last_sync_at > waitingOperation.updated_at,
+		`owner did not record successful recipient sync after the wait: ${reconnectedPeer?.last_sync_at ?? "missing"}`,
+	);
+	const ownerConfigBeforeAutoResume = readConfig(
+		ctx,
+		"peer-a",
+		"31-read-owner-config-for-auto-resume",
+	);
+	writePeerConfig(
+		ctx,
+		"peer-a",
+		{ ...ownerConfigBeforeAutoResume, sync_interval_s: 2 },
+		"31-enable-owner-maintenance-for-auto-resume",
+	);
+	restartServer(ctx, "peer-a", "31-restart-owner-for-automatic-maintenance");
+	await waitForServer(ctx, "peer-a", "31-owner-ready-for-automatic-maintenance");
+	await waitFor(
+		async () => {
+			const resumedOwner = fixture(ctx, "peer-a", "summary", "31-peer-a-auto-resumed-summary");
+			const resumedOperation = resumedOwner.operations.find(
+				(item) => item.operation_id === created.body.operation_id,
+			);
+			assert(
+				resumedOperation?.state === "active",
+				`project provisioning did not resume automatically: ${resumedOperation?.state ?? "missing"}`,
+			);
+		},
+		{ description: "automatic Project setup resume", timeoutMs: 180_000, intervalMs: 3_000 },
+	);
+	writePeerConfig(
+		ctx,
+		"peer-a",
+		ownerConfigBeforeAutoResume,
+		"31-restore-owner-config-after-auto-resume",
+	);
+	// The running daemon captures its interval at startup; restart to keep the owner quiet
+	// until the second-device no-leak check deliberately re-enables reconciliation below.
+	restartServer(ctx, "peer-a", "31-restart-owner-after-auto-resume");
+	await waitForServer(ctx, "peer-a", "31-owner-ready-after-auto-resume");
 
 	syncOnce(ctx, "peer-a", "32-sync-existing-a");
 	syncOnce(ctx, "peer-b", "33-sync-existing-b");

--- a/e2e/scripts/project-sharing-fixture.ts
+++ b/e2e/scripts/project-sharing-fixture.ts
@@ -570,7 +570,7 @@ function summary(store: MemoryStore): Record<string, unknown> {
 			.all(),
 		peers: store.db
 			.prepare(
-				`SELECT peer_device_id, name, actor_id, pinned_fingerprint, trust_provenance,
+				`SELECT peer_device_id, name, actor_id, pinned_fingerprint, trust_provenance, last_sync_at,
 				 discovered_via_coordinator_id, discovered_via_group_id
 				 FROM sync_peers ORDER BY peer_device_id`,
 			)
@@ -590,7 +590,7 @@ function summary(store: MemoryStore): Record<string, unknown> {
 		operations: store.db
 			.prepare(
 				`SELECT operation_id, state, teammate_name, recipient_device_id,
-					recipient_device_display_name
+					recipient_device_display_name, updated_at
 				 FROM share_operations ORDER BY created_at`,
 			)
 			.all(),

--- a/packages/core/src/share-operation-lifecycle.test.ts
+++ b/packages/core/src/share-operation-lifecycle.test.ts
@@ -117,6 +117,84 @@ describe("projectShareLifecycle", () => {
 		expect(result).toMatchObject({ lifecycle: "waiting_for_device", primaryAction: null });
 	});
 
+	it("does not describe a successfully reconnected recipient as offline while setup resumes", () => {
+		const result = projectShareLifecycle({
+			deviceLastSeenAt: "2026-07-20T12:19:30.000Z",
+			deviceLastReachedAt: "2026-07-20T12:19:00.000Z",
+			deviceName: "Brian's MacBook",
+			now,
+			personName: "Brian",
+			state: "waiting_for_device",
+			steps: [
+				step({
+					lastAttemptAt: "2026-07-20T12:18:00.000Z",
+					safeErrorCode: "waiting_for_device",
+					status: "failed",
+					stepKey: "initial_sync",
+					updatedAt: "2026-07-20T12:18:00.000Z",
+				}),
+			],
+		});
+
+		expect(result).toMatchObject({
+			lifecycle: "waiting_for_device",
+			label: "Finishing project setup",
+			explanation:
+				"A recent sync reached Brian's MacBook. Project setup will continue automatically.",
+			primaryAction: null,
+		});
+		expect(result.explanation).not.toContain("Waiting to reach");
+	});
+
+	it.each([
+		["before the wait", "2026-07-20T12:17:00.000Z"],
+		["at the wait boundary", "2026-07-20T12:18:00.000Z"],
+		["outside the reachability window", "2026-07-20T12:14:00.000Z"],
+		["with an invalid timestamp", "not-a-time"],
+	])("keeps offline copy when the device was last reached %s", (_label, deviceLastReachedAt) => {
+		const result = projectShareLifecycle({
+			deviceLastSeenAt: "2026-07-20T12:19:30.000Z",
+			deviceLastReachedAt,
+			deviceName: "Brian's MacBook",
+			now,
+			personName: "Brian",
+			state: "waiting_for_device",
+			steps: [
+				step({
+					safeErrorCode: "waiting_for_device",
+					status: "failed",
+					stepKey: "initial_sync",
+					updatedAt: "2026-07-20T12:18:00.000Z",
+				}),
+			],
+		});
+
+		expect(result.label).toBe("Waiting for device");
+		expect(result.explanation).toContain("Waiting to reach");
+	});
+
+	it("does not infer recent reachability from display-only last-seen metadata", () => {
+		const result = projectShareLifecycle({
+			deviceLastSeenAt: "2026-07-20T12:19:00.000Z",
+			deviceLastReachedAt: null,
+			deviceName: "Brian's MacBook",
+			now,
+			personName: "Brian",
+			state: "waiting_for_device",
+			steps: [
+				step({
+					safeErrorCode: "waiting_for_device",
+					status: "failed",
+					stepKey: "initial_sync",
+					updatedAt: "2026-07-20T12:18:00.000Z",
+				}),
+			],
+		});
+
+		expect(result.label).toBe("Waiting for device");
+		expect(result.explanation).toContain("Waiting to reach");
+	});
+
 	it("distinguishes capability evidence waits from an offline recipient", () => {
 		const result = project("waiting_for_device", [
 			step({

--- a/packages/core/src/share-operation-lifecycle.ts
+++ b/packages/core/src/share-operation-lifecycle.ts
@@ -1,5 +1,6 @@
 export const SHARE_OPERATION_STALE_AFTER_MS = 10 * 60 * 1000;
 export const SHARE_OPERATION_MAX_ATTEMPTS = 3;
+export const SHARE_OPERATION_DEVICE_REACHABLE_WINDOW_MS = 5 * 60 * 1000;
 
 export type ShareOperationLifecycle =
 	| "waiting_for_acceptance"
@@ -33,6 +34,7 @@ export interface ShareOperationLifecycleInput {
 	personName: string;
 	deviceName: string | null;
 	deviceLastSeenAt: string | null;
+	deviceLastReachedAt?: string | null;
 	inviteLink?: string | null;
 	steps: ShareOperationLifecycleStepInput[];
 	now: string;
@@ -98,6 +100,7 @@ export function projectShareLifecycle(
 ): ShareOperationLifecycleProjection {
 	const personName = input.personName.trim() || "your teammate";
 	const deviceName = input.deviceName?.trim() || `${personName}'s device`;
+	const nowMs = validTime(input.now) ?? 0;
 	if (input.state === "revoking") {
 		return passive("revoking", "Removing future access", "Previously copied memories may remain.");
 	}
@@ -144,6 +147,22 @@ export function projectShareLifecycle(
 		);
 	}
 	const deviceWait = incomplete.find(isDeviceWait);
+	const deviceLastReachedAt = validTime(input.deviceLastReachedAt ?? null);
+	const deviceWaitUpdatedAt = validTime(deviceWait?.updatedAt ?? null);
+	if (
+		deviceWait &&
+		deviceLastReachedAt !== null &&
+		deviceWaitUpdatedAt !== null &&
+		deviceLastReachedAt > deviceWaitUpdatedAt &&
+		deviceLastReachedAt <= nowMs &&
+		nowMs - deviceLastReachedAt <= SHARE_OPERATION_DEVICE_REACHABLE_WINDOW_MS
+	) {
+		return passive(
+			"waiting_for_device",
+			"Finishing project setup",
+			`A recent sync reached ${deviceName}. Project setup will continue automatically.`,
+		);
+	}
 	if (input.state === "waiting_for_device" || deviceWait) {
 		const lastSeen = input.deviceLastSeenAt?.trim();
 		return passive(
@@ -155,7 +174,6 @@ export function projectShareLifecycle(
 		);
 	}
 
-	const nowMs = validTime(input.now) ?? 0;
 	const failed = incomplete.find((step) => step.status === "failed" && !isDeviceWait(step));
 	const exhausted = incomplete.find(
 		(step) =>

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1223,6 +1223,7 @@ interface ShareOperationReadRow {
 	actor_display_name: string | null;
 	peer_display_name: string | null;
 	device_last_seen_at: string | null;
+	device_last_reached_at: string | null;
 }
 
 async function shareOperationReadModels(
@@ -1235,7 +1236,8 @@ async function shareOperationReadModels(
 			o.recipient_actor_id, o.recipient_display_name, o.recipient_device_id,
 			o.recipient_device_display_name, o.invite_expires_at, o.acceptance_consumed_at,
 			o.created_at, o.updated_at, a.display_name AS actor_display_name,
-			p.name AS peer_display_name, p.last_sync_at AS device_last_seen_at
+			p.name AS peer_display_name, p.last_seen_at AS device_last_seen_at,
+			p.last_sync_at AS device_last_reached_at
 		 FROM share_operations o
 		 LEFT JOIN actors a ON a.actor_id = o.person_id
 		 LEFT JOIN sync_peers p ON p.peer_device_id = o.recipient_device_id
@@ -1296,6 +1298,7 @@ async function shareOperationReadModels(
 			const deviceName = row.recipient_device_display_name || row.peer_display_name;
 			const lifecycle = projectShareLifecycle({
 				deviceLastSeenAt: row.device_last_seen_at,
+				deviceLastReachedAt: row.device_last_reached_at,
 				deviceName,
 				inviteLink,
 				now,


### PR DESCRIPTION
## Description

Add bounded lifecycle projection for the interval after a recipient reconnects and before maintenance finishes setup, plus Project Sharing E2E coverage for offline wait, successful reconnect, truthful status copy, and automatic progression to active.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Focused lifecycle and maintenance tests pass. The Project Sharing E2E reached and passed the new reconnect/auto-resume assertions; a later pre-existing enrollment-revocation convergence tail remained flaky and is tracked separately.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced