### PR TITLE
feat(retrieval): instrument file and MCP evidence

### DIFF
--- a/packages/cli/src/commands/claude-hook-file-context.test.ts
+++ b/packages/cli/src/commands/claude-hook-file-context.test.ts
@@ -1,7 +1,14 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	connect,
+	initTestSchema,
+	MemoryStore,
+	queryRetrievalAttempts,
+	type RetrievalSurfaceRecordInput,
+} from "@codemem/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	buildClaudeFileContext,
 	claudeHookFileContextCommand,
@@ -500,5 +507,413 @@ describe("claude-hook-file-context command", () => {
 		expect(result).toEqual({ continue: true });
 		const log = readFileSync(pluginLogPath, "utf8");
 		expect(log).toContain("file_context.skip reason=no_observations");
+	});
+
+	it.each([
+		{
+			name: "outside-cwd",
+			filePath: "/private/forbidden.ts",
+			stat: { sizeBytes: 2000, mtimeMs: 0 },
+			status: "skipped",
+			code: "outside_cwd",
+			paths: undefined,
+		},
+		{
+			name: "below-size-gate",
+			filePath: "small.ts",
+			stat: { sizeBytes: 1, mtimeMs: 0 },
+			status: "skipped",
+			code: "below_size_gate",
+			paths: ["small.ts"],
+		},
+		{
+			name: "no-observations",
+			filePath: "empty.ts",
+			stat: { sizeBytes: 2000, mtimeMs: 0 },
+			status: "no_results",
+			code: undefined,
+			paths: ["empty.ts"],
+		},
+	])("records the $name lifecycle without absolute paths", async (fixture) => {
+		const attempts: RetrievalSurfaceRecordInput[] = [];
+		await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: fixture.filePath },
+				cwd: tmp,
+				session_id: "claude-session-1",
+			},
+			{},
+			{
+				queryByFile: () => [],
+				resolveDb: () => join(tmp, "ledger.sqlite"),
+				statFile: () => fixture.stat,
+				recordAttempt: (_path, attempt) => attempts.push(attempt),
+				now: () => new Date("2026-08-03T10:00:00.000Z"),
+				createAttemptId: () => "018f2db4-f9d3-7a22-8d18-000000000001",
+			},
+		);
+
+		expect(attempts).toHaveLength(1);
+		expect(attempts[0]).toMatchObject({
+			surface: "file_context",
+			retrievalStatus: fixture.status,
+			sourceSessionId: "claude-session-1",
+		});
+		expect(attempts[0]?.failureCode).toBe(fixture.code);
+		expect(attempts[0]?.repositoryPaths).toEqual(fixture.paths);
+		expect(JSON.stringify(attempts)).not.toContain("/private/forbidden.ts");
+		expect(JSON.stringify(attempts)).not.toContain(tmp);
+	});
+
+	it("records selected observations as handed off and correlates a known Claude session", async () => {
+		const dbPath = join(tmp, "ledger.sqlite");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		const now = "2026-08-03T10:00:00.000Z";
+		const sessionId = Number(
+			db
+				.prepare(
+					"INSERT INTO sessions(started_at, cwd, project, user, tool_version) VALUES (?, ?, ?, ?, ?)",
+				)
+				.run(now, tmp, "codemem", "test", "test").lastInsertRowid,
+		);
+		db.prepare(
+			"INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES ('claude', ?, ?, ?, ?)",
+		).run("claude-session-2", "claude-session-2", sessionId, now);
+		db.prepare(
+			`INSERT INTO memory_items(
+				id, session_id, kind, title, body_text, created_at, updated_at,
+				import_key, rev, active, scope_id
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			41,
+			sessionId,
+			"decision",
+			"Selected observation",
+			"snapshot body",
+			now,
+			now,
+			"snapshot-41",
+			7,
+			1,
+			"scope-test",
+		);
+		db.close();
+		const file = join(tmp, "selected.ts");
+		writeFileSync(file, "x".repeat(2000));
+		const createStore = vi.fn((path: string) => new MemoryStore(path));
+
+		const result = await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: file },
+				cwd: tmp,
+				session_id: "claude-session-2",
+			},
+			{},
+			{
+				queryByFile: () => [
+					baseRow({
+						id: 41,
+						session_id: sessionId,
+						title: "Selected observation",
+						files_modified: '["selected.ts"]',
+					}),
+				],
+				resolveDb: () => dbPath,
+				createStore,
+				statFile: () => ({ sizeBytes: 2000, mtimeMs: 0 }),
+			},
+		);
+
+		const readDb = connect(dbPath);
+		const attempt = queryRetrievalAttempts(readDb, { surface: "file_context", limit: 1 })[0];
+		readDb.close();
+		expect(result.hookSpecificOutput?.additionalContext).toContain("Selected observation");
+		expect(createStore).toHaveBeenCalledTimes(1);
+		expect(attempt).toMatchObject({
+			retrievalStatus: "succeeded",
+			deliveryStatus: "handed_off",
+			sessionId,
+			sourceSessionId: "claude-session-2",
+			workingSetFiles: ["selected.ts"],
+		});
+		expect(attempt?.exposures[0]).toMatchObject({
+			memoryId: 41,
+			memoryImportKey: "snapshot-41",
+			memoryRev: 7,
+			memoryUpdatedAt: now,
+			memoryScopeId: "scope-test",
+			memoryKind: "decision",
+			memoryActive: true,
+		});
+	});
+
+	it("uses the production store retrieval path when no query dependency is injected", async () => {
+		const dbPath = join(tmp, "production.sqlite");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		const sessionId = Number(
+			db
+				.prepare(
+					"INSERT INTO sessions(started_at, cwd, project, user, tool_version) VALUES (?, ?, ?, ?, ?)",
+				)
+				.run(new Date().toISOString(), tmp, "codemem", "test", "test").lastInsertRowid,
+		);
+		db.close();
+		const seedStore = new MemoryStore(dbPath);
+		seedStore.remember(
+			sessionId,
+			"decision",
+			"Production retrieval observation",
+			"Production retrieval body",
+			0.9,
+			[],
+			{ files_modified: ["production.ts"] },
+		);
+		seedStore.close();
+
+		const result = await buildClaudeFileContext(
+			{
+				tool_input: { file_path: "production.ts" },
+				cwd: tmp,
+				project: "codemem",
+			},
+			{},
+			{
+				resolveDb: () => dbPath,
+				statFile: () => ({ sizeBytes: 2000, mtimeMs: 0 }),
+			},
+		);
+
+		expect(result.hookSpecificOutput?.additionalContext).toContain(
+			"Production retrieval observation",
+		);
+	});
+
+	it("keeps successful delivery fail-open when the ledger recorder throws", async () => {
+		const file = join(tmp, "fail-open.ts");
+		writeFileSync(file, "x".repeat(2000));
+		const result = await buildClaudeFileContext(
+			{ tool_input: { file_path: file }, cwd: tmp },
+			{},
+			{
+				queryByFile: () => [baseRow({ id: 51, title: "Still delivered" })],
+				resolveDb: () => join(tmp, "ledger.sqlite"),
+				statFile: () => ({ sizeBytes: 2000, mtimeMs: 0 }),
+				recordAttempt: () => {
+					throw new Error("ledger unavailable");
+				},
+			},
+		);
+		expect(result.hookSpecificOutput?.additionalContext).toContain("Still delivered");
+	});
+
+	it("keeps successful hook output and handed-off delivery when store cleanup throws", async () => {
+		const dbPath = join(tmp, "close-failure.sqlite");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		const store = new MemoryStore(dbPath);
+		const close = vi.spyOn(store, "close").mockImplementation(() => {
+			throw new Error("close failed after success");
+		});
+
+		try {
+			const result = await buildClaudeFileContext(
+				{ tool_input: { file_path: "close-failure.ts" }, cwd: tmp },
+				{},
+				{
+					queryByFile: () => [baseRow({ id: 52, title: "Delivered before cleanup" })],
+					resolveDb: () => dbPath,
+					createStore: () => store,
+					statFile: () => ({ sizeBytes: 2000, mtimeMs: 0 }),
+					createAttemptId: () => "018f2db4-f9d3-7a22-8d18-000000000052",
+				},
+			);
+
+			const output = JSON.parse(JSON.stringify(result)) as typeof result;
+			expect(output.hookSpecificOutput).toMatchObject({
+				hookEventName: "PreToolUse",
+				permissionDecision: "allow",
+			});
+			expect(output.hookSpecificOutput?.additionalContext).toContain("Delivered before cleanup");
+			expect(close).toHaveBeenCalledTimes(1);
+			expect(
+				queryRetrievalAttempts(store.db, { surface: "file_context", limit: 1 })[0],
+			).toMatchObject({
+				attemptId: "018f2db4-f9d3-7a22-8d18-000000000052",
+				retrievalStatus: "succeeded",
+				deliveryStatus: "handed_off",
+			});
+		} finally {
+			close.mockRestore();
+			store.close();
+		}
+	});
+
+	it("records selection before formatting and confirms delivery afterward", async () => {
+		const attempts: RetrievalSurfaceRecordInput[] = [];
+		const deliveries: string[] = [];
+		const result = await buildClaudeFileContext(
+			{ tool_input: { file_path: "selected.ts" }, cwd: tmp },
+			{},
+			{
+				queryByFile: () => [baseRow({ id: 61, title: "Selected then delivered" })],
+				resolveDb: () => join(tmp, "ledger.sqlite"),
+				statFile: () => ({ sizeBytes: 2000, mtimeMs: 0 }),
+				recordAttempt: (_path, attempt) => attempts.push(attempt),
+				updateDelivery: (_path, attemptId, status) => deliveries.push(`${attemptId}:${status}`),
+				createAttemptId: () => "018f2db4-f9d3-7a22-8d18-000000000061",
+			},
+		);
+		expect(result.hookSpecificOutput?.additionalContext).toContain("Selected then delivered");
+		expect(attempts[0]).toMatchObject({
+			retrievalStatus: "succeeded",
+			deliveryStatus: "not_attempted",
+			candidateIds: [61],
+			selectedIds: [61],
+		});
+		expect(deliveries).toEqual(["018f2db4-f9d3-7a22-8d18-000000000061:handed_off"]);
+	});
+
+	it("records disabled file-context as one skipped attempt without changing hook output", async () => {
+		const original = process.env.CODEMEM_FILE_CONTEXT;
+		process.env.CODEMEM_FILE_CONTEXT = "0";
+		const dbPath = join(tmp, "ledger.sqlite");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		try {
+			const result = await buildClaudeFileContext(
+				{
+					tool_input: { file_path: "disabled.ts" },
+					cwd: tmp,
+					session_id: "claude-session-disabled",
+				},
+				{},
+				{
+					resolveDb: () => dbPath,
+					createAttemptId: () => "018f2db4-f9d3-7a22-8d18-000000000072",
+				},
+			);
+			expect(result).toEqual({ continue: true });
+
+			const readDb = connect(dbPath);
+			const attempts = queryRetrievalAttempts(readDb, { surface: "file_context" });
+			readDb.close();
+			expect(attempts).toHaveLength(1);
+			expect(attempts[0]).toMatchObject({
+				attemptId: "018f2db4-f9d3-7a22-8d18-000000000072",
+				retrievalStatus: "skipped",
+				deliveryStatus: "not_attempted",
+				failureCode: "file_context_disabled",
+				failureStage: "configuration",
+				candidateCount: 0,
+				selectedCount: 0,
+				exposures: [],
+			});
+		} finally {
+			if (original === undefined) delete process.env.CODEMEM_FILE_CONTEXT;
+			else process.env.CODEMEM_FILE_CONTEXT = original;
+		}
+	});
+
+	it("keeps disabled file-context fail-open when the database cannot be resolved", async () => {
+		const original = process.env.CODEMEM_FILE_CONTEXT;
+		process.env.CODEMEM_FILE_CONTEXT = "0";
+		const originalExitCode = process.exitCode;
+		const resolveDb = vi.fn(() => {
+			throw new Error("database unavailable");
+		});
+		try {
+			const result = await buildClaudeFileContext(
+				{ tool_input: { file_path: "disabled.ts" }, cwd: tmp },
+				{},
+				{ resolveDb },
+			);
+
+			expect(result).toEqual({ continue: true });
+			expect(resolveDb).toHaveBeenCalledTimes(1);
+			expect(process.exitCode).toBe(originalExitCode);
+		} finally {
+			if (original === undefined) delete process.env.CODEMEM_FILE_CONTEXT;
+			else process.env.CODEMEM_FILE_CONTEXT = original;
+		}
+	});
+
+	it("keeps disabled file-context fail-open when the ledger write fails", async () => {
+		const original = process.env.CODEMEM_FILE_CONTEXT;
+		process.env.CODEMEM_FILE_CONTEXT = "0";
+		const originalExitCode = process.exitCode;
+		const recordAttempt = vi.fn(() => {
+			throw new Error("ledger unavailable");
+		});
+		try {
+			const result = await buildClaudeFileContext(
+				{ tool_input: { file_path: "disabled.ts" }, cwd: tmp },
+				{},
+				{
+					resolveDb: () => join(tmp, "ledger.sqlite"),
+					recordAttempt,
+				},
+			);
+
+			expect(result).toEqual({ continue: true });
+			expect(recordAttempt).toHaveBeenCalledTimes(1);
+			expect(process.exitCode).toBe(originalExitCode);
+		} finally {
+			if (original === undefined) delete process.env.CODEMEM_FILE_CONTEXT;
+			else process.env.CODEMEM_FILE_CONTEXT = original;
+		}
+	});
+
+	it("delivers file context without recording when retrieval evidence capture is disabled", async () => {
+		const original = process.env.CODEMEM_RETRIEVAL_LEDGER;
+		process.env.CODEMEM_RETRIEVAL_LEDGER = "0";
+		const recordAttempt = vi.fn();
+		try {
+			const result = await buildClaudeFileContext(
+				{ tool_input: { file_path: "capture-disabled.ts" }, cwd: tmp },
+				{},
+				{
+					queryByFile: () => [baseRow({ id: 71, title: "Still delivered" })],
+					resolveDb: () => join(tmp, "ledger.sqlite"),
+					statFile: () => ({ sizeBytes: 2000, mtimeMs: 0 }),
+					recordAttempt,
+				},
+			);
+			expect(result.hookSpecificOutput?.additionalContext).toContain("Still delivered");
+			expect(recordAttempt).not.toHaveBeenCalled();
+		} finally {
+			if (original === undefined) delete process.env.CODEMEM_RETRIEVAL_LEDGER;
+			else process.env.CODEMEM_RETRIEVAL_LEDGER = original;
+		}
+	});
+
+	it("records file-context query failures with a stable code", async () => {
+		const attempts: RetrievalSurfaceRecordInput[] = [];
+		await buildClaudeFileContext(
+			{ tool_input: { file_path: "failed.ts" }, cwd: tmp },
+			{},
+			{
+				resolveDb: () => join(tmp, "ledger.sqlite"),
+				statFile: () => ({ sizeBytes: 2000, mtimeMs: 0 }),
+				queryByFile: () => {
+					throw new Error("raw private database error");
+				},
+				recordAttempt: (_path, attempt) => attempts.push(attempt),
+			},
+		);
+		expect(attempts[0]).toMatchObject({
+			retrievalStatus: "failed",
+			deliveryStatus: "not_attempted",
+			failureCode: "query_failed",
+			failureStage: "retrieval",
+		});
+		expect(JSON.stringify(attempts)).not.toContain("raw private database error");
 	});
 });

--- a/packages/cli/src/commands/claude-hook-file-context.ts
+++ b/packages/cli/src/commands/claude-hook-file-context.ts
@@ -1,7 +1,17 @@
+import { randomUUID } from "node:crypto";
 import { statSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, relative, resolve, sep } from "node:path";
-import { MemoryStore, type RefQueryResult, resolveDbPath, resolveHookProject } from "@codemem/core";
+import {
+	MemoryStore,
+	type RefQueryResult,
+	type RetrievalSurfaceRecordInput,
+	recordRetrievalSurface,
+	resolveDbPath,
+	resolveHookProject,
+	resolveRetrievalSession,
+	tryUpdateRetrievalDelivery,
+} from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
@@ -22,6 +32,11 @@ type FileContextDeps = {
 	queryByFile?: typeof queryByFile;
 	resolveDb?: typeof resolveDbPath;
 	statFile?: typeof statFile;
+	createStore?: (dbPath: string) => MemoryStore;
+	recordAttempt?: (dbPath: string, input: RetrievalSurfaceRecordInput) => void;
+	updateDelivery?: (dbPath: string, attemptId: string, status: "handed_off" | "failed") => void;
+	now?: () => Date;
+	createAttemptId?: () => string;
 };
 
 const FILE_GATE_MIN_BYTES = 1500;
@@ -266,6 +281,11 @@ function resolveProject(payload: Record<string, unknown>): string | null {
 	return resolveHookProject(cwd, payload.project);
 }
 
+function sourceSessionId(payload: Record<string, unknown>): string | null {
+	const value = payload.session_id;
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
 export async function buildClaudeFileContext(
 	payload: Record<string, unknown>,
 	opts: FileContextOpts,
@@ -274,13 +294,89 @@ export async function buildClaudeFileContext(
 	if (envTruthy(process.env.CODEMEM_PLUGIN_IGNORE)) {
 		return continueResult();
 	}
-	if (!envNotDisabled(process.env.CODEMEM_FILE_CONTEXT || "1")) {
-		return continueResult();
-	}
 
 	const filePath = extractFilePath(payload);
 	if (!filePath) {
 		return continueResult();
+	}
+
+	const startedAt = (deps.now ?? (() => new Date()))();
+	const attemptId = (deps.createAttemptId ?? randomUUID)();
+	const resolveDb = deps.resolveDb ?? resolveDbPath;
+	let resolvedDbPath: string | null = null;
+	let activeStore: MemoryStore | null = null;
+	const getStore = (): MemoryStore => {
+		resolvedDbPath ??= resolveDb(resolveDbOpt(opts));
+		activeStore ??= (deps.createStore ?? ((dbPath) => new MemoryStore(dbPath)))(resolvedDbPath);
+		return activeStore;
+	};
+	const finish = (result: FileContextResult): FileContextResult => {
+		try {
+			activeStore?.close();
+		} catch {
+			// Cleanup happens after attribution and must not suppress valid hook output.
+		}
+		activeStore = null;
+		return result;
+	};
+	const record = (
+		attemptInput: Omit<
+			RetrievalSurfaceRecordInput,
+			"attemptId" | "surface" | "trigger" | "startedAt" | "completedAt" | "recorderVersion"
+		>,
+	): void => {
+		if (!envNotDisabled(process.env.CODEMEM_RETRIEVAL_LEDGER || "1")) return;
+		try {
+			resolvedDbPath ??= resolveDb(resolveDbOpt(opts));
+			const completedAt = (deps.now ?? (() => new Date()))();
+			const ledgerInput: RetrievalSurfaceRecordInput = {
+				...attemptInput,
+				attemptId,
+				surface: "file_context",
+				trigger: "automatic",
+				startedAt: startedAt.toISOString(),
+				completedAt: completedAt.toISOString(),
+				latencyMs: Math.max(0, completedAt.getTime() - startedAt.getTime()),
+				recorderVersion: "claude-file-context-v1",
+				source: "claude",
+				streamId: sourceSessionId(payload),
+				sourceSessionId: sourceSessionId(payload),
+				mode: "claude_pre_tool_use_read",
+			};
+			if (deps.recordAttempt) {
+				deps.recordAttempt(resolvedDbPath, ledgerInput);
+			} else {
+				const store = getStore();
+				recordRetrievalSurface(store.db, {
+					...ledgerInput,
+					sessionId: resolveRetrievalSession(store.db, "claude", ledgerInput.sourceSessionId),
+				});
+			}
+		} catch {
+			// Resolving or writing the local ledger must not affect hook output.
+		}
+	};
+	const updateDelivery = (status: "handed_off" | "failed"): void => {
+		if (!envNotDisabled(process.env.CODEMEM_RETRIEVAL_LEDGER || "1")) return;
+		try {
+			resolvedDbPath ??= resolveDb(resolveDbOpt(opts));
+			if (deps.updateDelivery) {
+				deps.updateDelivery(resolvedDbPath, attemptId, status);
+			} else {
+				tryUpdateRetrievalDelivery(getStore().db, attemptId, status);
+			}
+		} catch {
+			// Delivery remains successful even if local attribution cannot be updated.
+		}
+	};
+	if (!envNotDisabled(process.env.CODEMEM_FILE_CONTEXT || "1")) {
+		record({
+			retrievalStatus: "skipped",
+			deliveryStatus: "not_attempted",
+			failureCode: "file_context_disabled",
+			failureStage: "configuration",
+		});
+		return finish(continueResult());
 	}
 
 	const cwd = typeof payload.cwd === "string" && payload.cwd.trim() ? payload.cwd : process.cwd();
@@ -299,7 +395,13 @@ export async function buildClaudeFileContext(
 		logHookEvent(
 			`file_context.skip reason=outside_cwd path=${JSON.stringify(filePath)} cwd=${JSON.stringify(cwd)}`,
 		);
-		return continueResult();
+		record({
+			retrievalStatus: "skipped",
+			deliveryStatus: "not_attempted",
+			failureCode: "outside_cwd",
+			failureStage: "path_validation",
+		});
+		return finish(continueResult());
 	}
 
 	const minBytes = Number.parseInt(
@@ -312,36 +414,70 @@ export async function buildClaudeFileContext(
 	const stat = (deps.statFile ?? statFile)(absolutePath);
 	if (!stat) {
 		logHookEvent(`file_context.skip reason=stat_failed path=${JSON.stringify(relativePath)}`);
-		return continueResult();
+		record({
+			retrievalStatus: "skipped",
+			deliveryStatus: "not_attempted",
+			failureCode: "stat_failed",
+			failureStage: "file_access",
+			repositoryPaths: [relativePath],
+		});
+		return finish(continueResult());
 	}
 	const bypassSizeGate = SMALL_FILE_BYPASS_PATTERNS.some((p) => p.test(relativePath));
 	if (stat.sizeBytes < minBytesEffective && !bypassSizeGate) {
 		logHookEvent(
 			`file_context.skip reason=below_size_gate path=${JSON.stringify(relativePath)} size=${stat.sizeBytes} gate=${minBytesEffective}`,
 		);
-		return continueResult();
+		record({
+			retrievalStatus: "skipped",
+			deliveryStatus: "not_attempted",
+			failureCode: "below_size_gate",
+			failureStage: "size_gate",
+			repositoryPaths: [relativePath],
+		});
+		return finish(continueResult());
 	}
 
 	const project = resolveProject(payload);
-	const resolveDb = deps.resolveDb ?? resolveDbPath;
 	const queryFn = deps.queryByFile ?? queryByFile;
 
 	let rows: RefQueryResult[] = [];
 	try {
-		const dbPath = resolveDb(resolveDbOpt(opts));
-		rows = queryFn(dbPath, relativePath, project, FETCH_LIMIT);
+		resolvedDbPath ??= resolveDb(resolveDbOpt(opts));
+		rows = deps.queryByFile
+			? queryFn(resolvedDbPath, relativePath, project, FETCH_LIMIT)
+			: getStore().findByFile(relativePath, {
+					limit: FETCH_LIMIT,
+					...(project ? { project } : {}),
+				});
 	} catch (err) {
 		logHookEvent(
 			`codemem claude-hook-file-context query failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
-		return continueResult();
+		record({
+			retrievalStatus: "failed",
+			deliveryStatus: "not_attempted",
+			failureCode: "query_failed",
+			failureStage: "retrieval",
+			project,
+			filters: project ? { project } : undefined,
+			repositoryPaths: [relativePath],
+		});
+		return finish(continueResult());
 	}
 
 	if (rows.length === 0) {
 		logHookEvent(
 			`file_context.skip reason=no_observations path=${JSON.stringify(relativePath)} project=${JSON.stringify(project ?? "")}`,
 		);
-		return continueResult();
+		record({
+			retrievalStatus: "no_results",
+			deliveryStatus: "not_attempted",
+			project,
+			filters: project ? { project } : undefined,
+			repositoryPaths: [relativePath],
+		});
+		return finish(continueResult());
 	}
 
 	const top = scoreAndDedupe(rows, relativePath, DISPLAY_LIMIT);
@@ -349,7 +485,19 @@ export async function buildClaudeFileContext(
 		logHookEvent(
 			`file_context.skip reason=no_top_after_dedupe path=${JSON.stringify(relativePath)} candidates=${rows.length}`,
 		);
-		return continueResult();
+		record({
+			retrievalStatus: "succeeded",
+			deliveryStatus: "not_attempted",
+			candidateIds: rows.map((row) => row.id),
+			candidateCount: rows.length,
+			selectedIds: [],
+			failureCode: "no_top_after_dedupe",
+			failureStage: "selection",
+			project,
+			filters: project ? { project } : undefined,
+			repositoryPaths: [relativePath],
+		});
+		return finish(continueResult());
 	}
 
 	let staleness: { fileMtimeMs: number; newestObservationMs: number } | null = null;
@@ -363,19 +511,37 @@ export async function buildClaudeFileContext(
 		}
 	}
 
-	const timeline = formatTimeline(top, relativePath, staleness);
+	record({
+		retrievalStatus: "succeeded",
+		deliveryStatus: "not_attempted",
+		candidateIds: rows.map((row) => row.id),
+		candidateCount: rows.length,
+		selectedIds: top.map((row) => row.id),
+		project,
+		filters: project ? { project } : undefined,
+		repositoryPaths: [relativePath],
+	});
+
+	let timeline: string;
+	try {
+		timeline = formatTimeline(top, relativePath, staleness);
+	} catch {
+		updateDelivery("failed");
+		return finish(continueResult());
+	}
 
 	logHookEvent(
 		`file_context.ok path=${JSON.stringify(relativePath)} candidates=${rows.length} surfaced=${top.length} project=${JSON.stringify(project ?? "")} stale=${staleness ? "true" : "false"}`,
 	);
+	updateDelivery("handed_off");
 
-	return {
+	return finish({
 		hookSpecificOutput: {
 			hookEventName: "PreToolUse",
 			permissionDecision: "allow",
 			additionalContext: timeline,
 		},
-	};
+	});
 }
 
 const claudeHookFileContextCmd = new Command("claude-hook-file-context")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -774,6 +774,7 @@ export { clearMemoryRefs, normalizeConcept, populateMemoryRefs } from "./ref-pop
 export type { RefQueryOptions, RefQueryResult } from "./ref-queries.js";
 export { findByConcept, findByFile } from "./ref-queries.js";
 export * from "./retrieval-ledger.js";
+export * from "./retrieval-surface-ledger.js";
 export type {
 	IdentityDevice,
 	MaintenanceJob,

--- a/packages/core/src/retrieval-ledger.test.ts
+++ b/packages/core/src/retrieval-ledger.test.ts
@@ -21,16 +21,19 @@ import {
 	type RetrievalDeliveryStatus,
 	type RetrievalExposureInput,
 	type RetrievalStatus,
+	reconcileFailedRetrievalAttempt,
 	recordRetrievalAttempt,
 	tryFinalizeRetrievalAttemptRetention,
 	tryRecordRetrievalAttempt,
 	tryUpdateRetrievalDelivery,
 	updateRetrievalDelivery,
 } from "./retrieval-ledger.js";
+import { recordRetrievalSurface, sanitizeRetrievalFilters } from "./retrieval-surface-ledger.js";
 import { ensureRetrievalLedgerSchema } from "./schema-bootstrap.js";
 import { MemoryStore } from "./store.js";
 import { TEST_SCHEMA_BASE_DDL } from "./test-schema.generated.js";
 import { initTestSchema } from "./test-utils.js";
+import type { MemoryFilters } from "./types.js";
 
 const STARTED_AT = "2026-08-03T10:00:00.000Z";
 
@@ -970,6 +973,124 @@ describe("retrieval attribution ledger", () => {
 		).toBe(true);
 	});
 
+	it("replaces only a matching failed request with its handed-off success", () => {
+		const failed = input({
+			attemptId: attemptId(253),
+			requestId: "failed-request-retry",
+			surface: "mcp_search",
+			source: "mcp",
+			retrievalStatus: "failed",
+			deliveryStatus: "not_attempted",
+			candidateCount: 0,
+			selectedCount: 0,
+			exposures: [],
+			failureCode: "tool_failed",
+			failureStage: "retrieval",
+			retentionDays: 7,
+		});
+		recordRetrievalAttempt(db, failed);
+		const succeeded = {
+			...failed,
+			startedAt: "2026-08-03T10:00:00.100Z",
+			completedAt: "2026-08-03T10:00:00.250Z",
+			latencyMs: 150,
+			retentionDays: 7,
+			retrievalStatus: "succeeded" as const,
+			deliveryStatus: "handed_off" as const,
+			candidateCount: 1,
+			selectedCount: 1,
+			failureCode: null,
+			failureStage: null,
+			exposures: [
+				{
+					rank: 1,
+					disposition: "selected" as const,
+					handoffStatus: "handed_off" as const,
+					memoryImportKey: "retry-success",
+				},
+			],
+		};
+
+		expect(() =>
+			reconcileFailedRetrievalAttempt(db, {
+				...succeeded,
+				requestId: "unrelated-request-content",
+			}),
+		).toThrow(/conflicts/);
+		expect(() =>
+			reconcileFailedRetrievalAttempt(db, {
+				...succeeded,
+				startedAt: "2026-08-03T09:59:59.000Z",
+				completedAt: "2026-08-03T09:59:59.500Z",
+			}),
+		).toThrow(/conflicts/);
+		expect(() =>
+			reconcileFailedRetrievalAttempt(db, {
+				...succeeded,
+				retentionDays: 30,
+			}),
+		).toThrow(/conflicts/);
+		expect(getRetrievalAttempt(db, failed.attemptId)?.retrievalStatus).toBe("failed");
+		expect(reconcileFailedRetrievalAttempt(db, succeeded).attempt).toMatchObject({
+			attemptId: failed.attemptId,
+			retrievalStatus: "succeeded",
+			deliveryStatus: "handed_off",
+			failureCode: null,
+			exposures: [{ attemptId: failed.attemptId, handoffStatus: "handed_off" }],
+			startedAt: STARTED_AT,
+			latencyMs: 250,
+			retentionUntil: "2026-08-10T10:00:00.000Z",
+		});
+		expect(recordRetrievalAttempt(db, succeeded).inserted).toBe(false);
+		expect(() => reconcileFailedRetrievalAttempt(db, succeeded)).toThrow(/conflicts/);
+		expect(() => recordRetrievalAttempt(db, failed)).toThrow(/retry conflicts/);
+		expect(getRetrievalAttempt(db, failed.attemptId)?.retrievalStatus).toBe("succeeded");
+	});
+
+	it("replaces only a matching failed request with its empty successful completion", () => {
+		const failed = input({
+			attemptId: attemptId(254),
+			requestId: "failed-empty-request-retry",
+			surface: "mcp_search",
+			source: "mcp",
+			retrievalStatus: "failed",
+			deliveryStatus: "not_attempted",
+			candidateCount: 0,
+			selectedCount: 0,
+			exposures: [],
+			failureCode: "tool_failed",
+			failureStage: "retrieval",
+		});
+		recordRetrievalAttempt(db, failed);
+		const noResults = {
+			...failed,
+			completedAt: "2026-08-03T10:00:00.050Z",
+			retrievalStatus: "no_results" as const,
+			failureCode: null,
+			failureStage: null,
+		};
+
+		expect(() =>
+			reconcileFailedRetrievalAttempt(db, {
+				...noResults,
+				requestId: "unrelated-empty-request-content",
+			}),
+		).toThrow(/conflicts/);
+		expect(reconcileFailedRetrievalAttempt(db, noResults).attempt).toMatchObject({
+			attemptId: failed.attemptId,
+			retrievalStatus: "no_results",
+			deliveryStatus: "not_attempted",
+			candidateCount: 0,
+			selectedCount: 0,
+			failureCode: null,
+			exposures: [],
+		});
+		expect(recordRetrievalAttempt(db, noResults).inserted).toBe(false);
+		expect(() => recordRetrievalAttempt(db, failed)).toThrow(/retry conflicts/);
+		expect(queryRetrievalAttempts(db, { surface: "mcp_search" })).toHaveLength(1);
+		expect(getRetrievalAttempt(db, failed.attemptId)?.retrievalStatus).toBe("no_results");
+	});
+
 	it("keeps missing session and source correlation null", () => {
 		const recorded = recordRetrievalAttempt(
 			db,
@@ -1532,6 +1653,60 @@ describe("retrieval attribution ledger", () => {
 				.pluck()
 				.get(emptySelection.attemptId),
 		).toBe("not_attempted");
+	});
+
+	it("keeps returned selections beyond the persistence cap out of diagnostic rows", () => {
+		const selectedIds = Array.from({ length: 55 }, (_, index) => index + 1);
+		const outcome = recordRetrievalSurface(db, {
+			attemptId: attemptId(303),
+			surface: "mcp_get_observations",
+			trigger: "explicit",
+			startedAt: STARTED_AT,
+			retrievalStatus: "succeeded",
+			deliveryStatus: "handed_off",
+			selectedIds,
+			candidateIds: selectedIds,
+			recorderVersion: "test",
+			source: "mcp",
+		});
+
+		expect(outcome.ok).toBe(true);
+		if (!outcome.ok) return;
+		expect(outcome.value.attempt.selectedCount).toBe(55);
+		expect(outcome.value.attempt.exposures).toHaveLength(50);
+		expect(outcome.value.attempt.exposures.every((row) => row.disposition === "selected")).toBe(
+			true,
+		);
+		expect(
+			outcome.value.attempt.exposures.every((row) =>
+				row.reasonCodes.includes("surface.returned_truncated"),
+			),
+		).toBe(true);
+	});
+
+	it("drops filter strings outside the retrieval ledger bounds", () => {
+		expect(
+			sanitizeRetrievalFilters({
+				project: "x".repeat(513),
+				visibility: ["", "private", "x".repeat(513)],
+			}),
+		).toEqual({ visibility: ["private"] });
+		expect(
+			sanitizeRetrievalFilters({
+				kind: 42,
+				session_id: "wrong-type",
+				include_scope_ids: [7],
+				visibility: ["", "x".repeat(513)],
+			} as unknown as MemoryFilters),
+		).toBeNull();
+		const byteBounded = sanitizeRetrievalFilters({
+			include_scope_ids: Array.from({ length: 50 }, (_, index) => `${index}`.padEnd(512, "x")),
+		});
+		expect(byteBounded).not.toBeNull();
+		expect(Buffer.byteLength(JSON.stringify(byteBounded), "utf8")).toBeLessThanOrEqual(
+			MAX_RETRIEVAL_JSON_BYTES,
+		);
+		expect(byteBounded?.include_scope_ids?.length).toBeLessThan(50);
 	});
 
 	it("accepts JSON at 16 KiB and rejects one byte above", () => {
@@ -2282,6 +2457,16 @@ describe("retrieval attribution ledger", () => {
 				),
 			).toThrow(/retentionDays must be/);
 		}
+		expect(() =>
+			recordRetrievalAttempt(
+				db,
+				input({
+					attemptId: attemptId(898),
+					requestId: "invalid-null-retention",
+					retentionDays: null,
+				} as unknown as Partial<RecordRetrievalAttemptInput>),
+			),
+		).toThrow(/retentionDays must be/);
 		expect(() =>
 			recordRetrievalAttempt(
 				db,

--- a/packages/core/src/retrieval-ledger.ts
+++ b/packages/core/src/retrieval-ledger.ts
@@ -18,6 +18,8 @@ export type RetrievalSurface =
 	| "mcp_search_index"
 	| "mcp_pack"
 	| "mcp_get"
+	| "mcp_get_observations"
+	| "mcp_recent"
 	| "mcp_timeline"
 	| "mcp_expand"
 	| "mcp_explain"
@@ -254,6 +256,8 @@ const RETRIEVAL_SURFACES = new Set<RetrievalSurface>([
 	"mcp_search_index",
 	"mcp_pack",
 	"mcp_get",
+	"mcp_get_observations",
+	"mcp_recent",
 	"mcp_timeline",
 	"mcp_expand",
 	"mcp_explain",
@@ -452,7 +456,7 @@ function retentionUntil(
 	days: number | undefined,
 	pinned: boolean,
 ): string | null {
-	const retentionDays = days ?? DEFAULT_RETRIEVAL_LEDGER_RETENTION_DAYS;
+	const retentionDays = days === undefined ? DEFAULT_RETRIEVAL_LEDGER_RETENTION_DAYS : days;
 	if (!Number.isInteger(retentionDays) || retentionDays < 7 || retentionDays > 365) {
 		throw new Error("retentionDays must be an integer from 7 through 365");
 	}
@@ -674,6 +678,29 @@ function rowsEqual(expected: SqlRow, actual: SqlRow, ignoredKeys: string[] = [])
 	);
 }
 
+function hasSameRetryRetentionPolicy(expected: SqlRow, existing: SqlRow): boolean {
+	if (
+		expected.retention_pinned !== existing.retention_pinned ||
+		expected.retention_finalized_at !== existing.retention_finalized_at
+	) {
+		return false;
+	}
+	if (expected.retention_until == null || existing.retention_until == null) {
+		return expected.retention_until === existing.retention_until;
+	}
+	if (
+		typeof expected.retention_until !== "string" ||
+		typeof existing.retention_until !== "string" ||
+		typeof expected.started_at !== "string" ||
+		typeof existing.started_at !== "string"
+	) {
+		return false;
+	}
+	const expectedDuration = Date.parse(expected.retention_until) - Date.parse(expected.started_at);
+	const existingDuration = Date.parse(existing.retention_until) - Date.parse(existing.started_at);
+	return Number.isFinite(expectedDuration) && expectedDuration === existingDuration;
+}
+
 function memoryIdentityMatchesExposure(
 	exposure: SqlRow,
 	memory: { import_key: string | null; origin_device_id: string | null },
@@ -798,35 +825,39 @@ function isBoundedStringList(value: unknown): value is string[] {
 	return Array.isArray(value) && value.length <= 50 && value.every(isBoundedString);
 }
 
+export function isValidRetrievalFilterSummaryEntry(key: string, entry: unknown): boolean {
+	if (!FILTER_KEYS.has(key)) return false;
+	switch (key) {
+		case "kind":
+		case "since":
+		case "project":
+		case "ownership_scope":
+		case "trust_bias":
+			return isBoundedString(entry);
+		case "session_id":
+		case "widen_shared_min_personal_results":
+		case "widen_shared_min_personal_score":
+		case "widen_project_min_results":
+		case "widen_project_min_score":
+		case "widen_project_max_results":
+			return typeof entry === "number" && Number.isFinite(entry);
+		case "scope_id":
+		case "visibility":
+			return isBoundedString(entry) || isBoundedStringList(entry);
+		case "personal_first":
+		case "widen_shared_when_weak":
+		case "widen_project_when_weak":
+			return typeof entry === "boolean" || isBoundedString(entry);
+		default:
+			return isBoundedStringList(entry);
+	}
+}
+
 function isRetrievalFilterSummary(value: unknown): value is RetrievalFilterSummary {
 	if (!isRecord(value)) return false;
-	return Object.entries(value).every(([key, entry]) => {
-		if (!FILTER_KEYS.has(key)) return false;
-		switch (key) {
-			case "kind":
-			case "since":
-			case "project":
-			case "ownership_scope":
-			case "trust_bias":
-				return isBoundedString(entry);
-			case "session_id":
-			case "widen_shared_min_personal_results":
-			case "widen_shared_min_personal_score":
-			case "widen_project_min_results":
-			case "widen_project_min_score":
-			case "widen_project_max_results":
-				return typeof entry === "number" && Number.isFinite(entry);
-			case "scope_id":
-			case "visibility":
-				return isBoundedString(entry) || isBoundedStringList(entry);
-			case "personal_first":
-			case "widen_shared_when_weak":
-			case "widen_project_when_weak":
-				return typeof entry === "boolean" || isBoundedString(entry);
-			default:
-				return isBoundedStringList(entry);
-		}
-	});
+	return Object.entries(value).every(([key, entry]) =>
+		isValidRetrievalFilterSummaryEntry(key, entry),
+	);
 }
 
 function decodeFilterSummary(value: unknown): RetrievalFilterSummary | null {
@@ -1167,8 +1198,19 @@ export function recordRetrievalAttempt(
 					existing.retention_pinned === 0 &&
 					typeof existing.retention_until === "string" &&
 					decodeIsoTimestamp(existing.retention_finalized_at) != null;
+				const reconciledCompletionRetry =
+					existing.request_id != null &&
+					existing.request_id === attempt.request_id &&
+					existing.retrieval_status === attempt.retrieval_status &&
+					existing.delivery_status === attempt.delivery_status &&
+					((attempt.retrieval_status === "succeeded" && attempt.delivery_status === "handed_off") ||
+						(attempt.retrieval_status === "no_results" &&
+							attempt.delivery_status === "not_attempted"));
+				const sameRetryRetentionPolicy = hasSameRetryRetentionPolicy(attempt, existing);
 				const ignoredAttemptKeys = [
 					...(deliveryTransitioned ? ["delivery_status"] : []),
+					...(reconciledCompletionRetry ? ["started_at", "completed_at", "latency_ms"] : []),
+					...(reconciledCompletionRetry && sameRetryRetentionPolicy ? ["retention_until"] : []),
 					...(retentionFinalized
 						? ["retention_pinned", "retention_until", "retention_finalized_at"]
 						: []),
@@ -1207,6 +1249,82 @@ export function tryRecordRetrievalAttempt(
 ): RetrievalLedgerWriteOutcome {
 	try {
 		return { ok: true, value: recordRetrievalAttempt(db, input) };
+	} catch (error) {
+		return {
+			ok: false,
+			errorCode: "retrieval_ledger_write_failed",
+			reason: safeFailureReason(error),
+		};
+	}
+}
+
+export function reconcileFailedRetrievalAttempt(
+	db: Database,
+	input: RecordRetrievalAttemptInput,
+): RetrievalWriteResult {
+	const attempt = canonicalAttempt(input);
+	const attemptId = attempt.attempt_id as string;
+	const exposures = canonicalExposures(input, attemptId);
+	const isSuccessfulCompletion =
+		(attempt.retrieval_status === "succeeded" && attempt.delivery_status === "handed_off") ||
+		(attempt.retrieval_status === "no_results" && attempt.delivery_status === "not_attempted");
+	if (attempt.request_id == null || !isSuccessfulCompletion) {
+		throw new RetrievalLedgerValidationError(
+			"failed retrieval reconciliation requires a request-bound successful completion",
+		);
+	}
+	db.transaction(() => {
+		const existing = db
+			.prepare("SELECT * FROM retrieval_attempts WHERE attempt_id = ?")
+			.get(attemptId) as SqlRow | undefined;
+		if (
+			!existing ||
+			existing.contract_version !== RETRIEVAL_LEDGER_CONTRACT_VERSION ||
+			existing.source !== attempt.source ||
+			existing.surface !== attempt.surface ||
+			existing.request_id !== attempt.request_id ||
+			existing.retrieval_status !== "failed" ||
+			existing.delivery_status !== "not_attempted"
+		) {
+			throw new Error("failed retrieval reconciliation conflicts with persisted data");
+		}
+		const completedAt = attempt.completed_at as string | null;
+		const originalStartedAt = existing.started_at as string;
+		if (
+			!hasSameRetryRetentionPolicy(attempt, existing) ||
+			(completedAt != null && Date.parse(completedAt) < Date.parse(originalStartedAt))
+		) {
+			throw new Error("failed retrieval reconciliation conflicts with persisted data");
+		}
+		const reconciled = {
+			...attempt,
+			started_at: originalStartedAt,
+			latency_ms:
+				completedAt == null
+					? existing.latency_ms
+					: Math.max(0, Date.parse(completedAt) - Date.parse(originalStartedAt)),
+			retention_until: existing.retention_until,
+			retention_pinned: existing.retention_pinned,
+			retention_finalized_at: existing.retention_finalized_at,
+		};
+		const columns = Object.keys(reconciled).filter((column) => column !== "attempt_id");
+		db.prepare(
+			`UPDATE retrieval_attempts SET ${columns.map((column) => `${column} = @${column}`).join(", ")} WHERE attempt_id = @attempt_id`,
+		).run(reconciled);
+		db.prepare("DELETE FROM retrieval_exposures WHERE attempt_id = ?").run(attemptId);
+		for (const exposure of exposures) insertRow(db, "retrieval_exposures", exposure);
+	}).immediate();
+	const saved = readAttempt(db, attemptId);
+	if (!saved) throw new Error("reconciled retrieval attempt was not persisted");
+	return { attempt: saved, inserted: false };
+}
+
+export function tryReconcileFailedRetrievalAttempt(
+	db: Database,
+	input: RecordRetrievalAttemptInput,
+): RetrievalLedgerWriteOutcome {
+	try {
+		return { ok: true, value: reconcileFailedRetrievalAttempt(db, input) };
 	} catch (error) {
 		return {
 			ok: false,
@@ -1393,8 +1511,9 @@ export function purgeExpiredRetrievalAttempts(
 }
 
 export type RetrievalPrivacyPurgeSelector =
-	| { sessionId: number; source?: never; streamId?: never }
-	| { sessionId?: never; source: string; streamId: string };
+	| { sessionId: number; source?: never; streamId?: never; surface?: never }
+	| { sessionId?: never; source: string; streamId: string; surface?: never }
+	| { sessionId?: never; source: string; streamId?: never; surface: RetrievalSurface };
 
 export function purgeRetrievalAttemptsForPrivacy(
 	db: Database,
@@ -1406,6 +1525,15 @@ export function purgeRetrievalAttemptsForPrivacy(
 		return purgeRetrievalAttemptsWhere(db, "session_id = ?", [sessionId]);
 	}
 	const source = requiredString(selector.source, "source", 128);
+	if (selector.surface != null) {
+		if (!RETRIEVAL_SURFACES.has(selector.surface)) {
+			throw new Error("surface is invalid for contract version 1");
+		}
+		return purgeRetrievalAttemptsWhere(db, "source = ? AND surface = ?", [
+			source,
+			selector.surface,
+		]);
+	}
 	const streamId = requiredString(selector.streamId, "streamId");
 	return purgeRetrievalAttemptsWhere(db, "source = ? AND stream_id = ?", [source, streamId]);
 }

--- a/packages/core/src/retrieval-surface-ledger.ts
+++ b/packages/core/src/retrieval-surface-ledger.ts
@@ -1,0 +1,301 @@
+import { posix, win32 } from "node:path";
+import type { Database } from "./db.js";
+import { estimateTokens } from "./pack.js";
+import { sanitizeSearchQuery } from "./query-sanitizer.js";
+import {
+	hashRetrievalQuery,
+	isValidRetrievalFilterSummaryEntry,
+	MAX_RETRIEVAL_DIAGNOSTIC_EXPOSURES,
+	MAX_RETRIEVAL_JSON_BYTES,
+	MAX_RETRIEVAL_SELECTED_EXPOSURES,
+	type RecordRetrievalAttemptInput,
+	type RetrievalExposureInput,
+	type RetrievalFilterSummary,
+	type RetrievalLedgerWriteOutcome,
+	tryReconcileFailedRetrievalAttempt,
+	tryRecordRetrievalAttempt,
+} from "./retrieval-ledger.js";
+import type { MemoryFilters } from "./types.js";
+
+type Snapshot = {
+	id: number;
+	import_key: string | null;
+	origin_device_id: string | null;
+	rev: number;
+	updated_at: string;
+	scope_id: string | null;
+	kind: string;
+	active: number;
+	deleted_at: string | null;
+};
+
+const FILTER_KEYS = new Set<keyof RetrievalFilterSummary>([
+	"kind",
+	"session_id",
+	"since",
+	"project",
+	"scope_id",
+	"include_scope_ids",
+	"exclude_scope_ids",
+	"visibility",
+	"include_visibility",
+	"exclude_visibility",
+	"include_workspace_ids",
+	"exclude_workspace_ids",
+	"include_workspace_kinds",
+	"exclude_workspace_kinds",
+	"include_actor_ids",
+	"exclude_actor_ids",
+	"include_trust_states",
+	"exclude_trust_states",
+	"ownership_scope",
+	"personal_first",
+	"trust_bias",
+	"widen_shared_when_weak",
+	"widen_shared_min_personal_results",
+	"widen_shared_min_personal_score",
+	"widen_project_when_weak",
+	"widen_project_min_results",
+	"widen_project_min_score",
+	"widen_project_max_results",
+]);
+
+export interface RetrievalSurfaceRecordInput
+	extends Omit<
+		RecordRetrievalAttemptInput,
+		| "candidateCount"
+		| "selectedCount"
+		| "exposures"
+		| "filterSummary"
+		| "queryHashSha256"
+		| "queryCharCount"
+		| "queryTokenEstimate"
+		| "workingSetFiles"
+		| "workingSetFileCount"
+	> {
+	candidateIds?: number[];
+	selectedIds?: number[];
+	candidateCount?: number;
+	filters?: MemoryFilters;
+	query?: string | null;
+	repositoryPaths?: string[];
+}
+
+function safeIdentity(value: string | null): string | null {
+	if (!value || value.length > 512 || posix.isAbsolute(value) || win32.isAbsolute(value))
+		return null;
+	return value;
+}
+
+export function sanitizeRepositoryPaths(paths: string[] | undefined): string[] | null {
+	const output: string[] = [];
+	for (const path of paths ?? []) {
+		if (
+			output.length >= 50 ||
+			path.length > 1024 ||
+			posix.isAbsolute(path) ||
+			win32.isAbsolute(path)
+		) {
+			continue;
+		}
+		const normalized = posix.normalize(path.replaceAll("\\", "/")).replace(/^\.\//, "");
+		if (!normalized || normalized === ".." || normalized.startsWith("../")) continue;
+		if (!output.includes(normalized)) output.push(normalized);
+	}
+	return output.length > 0 ? output : null;
+}
+
+export function sanitizeRetrievalFilters(
+	filters: MemoryFilters | undefined,
+): RetrievalFilterSummary | null {
+	if (!filters) return null;
+	const output: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(filters)) {
+		if (!FILTER_KEYS.has(key as keyof RetrievalFilterSummary) || value === undefined) continue;
+		if (
+			typeof value === "string" &&
+			(!value || value.length > 512 || posix.isAbsolute(value) || win32.isAbsolute(value))
+		) {
+			continue;
+		}
+		if (Array.isArray(value)) {
+			const items = value
+				.slice(0, 50)
+				.filter(
+					(item) =>
+						typeof item === "string" &&
+						item.length > 0 &&
+						item.length <= 512 &&
+						!posix.isAbsolute(item) &&
+						!win32.isAbsolute(item),
+				);
+			const boundedItems: string[] = [];
+			for (const item of items) {
+				const candidate = [...boundedItems, item];
+				if (
+					Buffer.byteLength(JSON.stringify({ ...output, [key]: candidate }), "utf8") >
+					MAX_RETRIEVAL_JSON_BYTES
+				) {
+					break;
+				}
+				boundedItems.push(item);
+			}
+			if (boundedItems.length > 0 && isValidRetrievalFilterSummaryEntry(key, boundedItems)) {
+				output[key] = boundedItems;
+			}
+			continue;
+		}
+		if (
+			isValidRetrievalFilterSummaryEntry(key, value) &&
+			Buffer.byteLength(JSON.stringify({ ...output, [key]: value }), "utf8") <=
+				MAX_RETRIEVAL_JSON_BYTES
+		) {
+			output[key] = value;
+		}
+	}
+	return Object.keys(output).length > 0 ? (output as RetrievalFilterSummary) : null;
+}
+
+function snapshots(db: Database, ids: number[]): Map<number, Snapshot> {
+	if (ids.length === 0) return new Map();
+	const unique = [...new Set(ids)];
+	const rows = db
+		.prepare(
+			`SELECT id, import_key, origin_device_id, rev, updated_at, scope_id, kind, active, deleted_at
+			 FROM memory_items WHERE id IN (${unique.map(() => "?").join(", ")})`,
+		)
+		.all(...unique) as Snapshot[];
+	return new Map(rows.map((row) => [row.id, row]));
+}
+
+function exposureRows(
+	db: Database,
+	candidateIds: number[],
+	selectedIds: number[],
+	deliveryStatus: RecordRetrievalAttemptInput["deliveryStatus"],
+): RetrievalExposureInput[] {
+	const allSelected = new Set(selectedIds);
+	const boundedSelected = selectedIds.slice(0, MAX_RETRIEVAL_SELECTED_EXPOSURES);
+	const selected = new Set(boundedSelected);
+	const ordered = [...new Set([...candidateIds, ...selectedIds])];
+	const retained = [
+		...boundedSelected,
+		...ordered.filter((id) => !allSelected.has(id)).slice(0, MAX_RETRIEVAL_DIAGNOSTIC_EXPOSURES),
+	];
+	const ranks = new Map(ordered.map((id, index) => [id, index + 1]));
+	const byId = snapshots(db, retained);
+	return retained.map((id) => {
+		const snapshot = byId.get(id);
+		const isSelected = selected.has(id);
+		return {
+			memoryId: snapshot?.id ?? null,
+			memoryImportKey: safeIdentity(snapshot?.import_key ?? null),
+			originDeviceId: safeIdentity(snapshot?.origin_device_id ?? null),
+			rank: ranks.get(id) as number,
+			disposition: isSelected ? "selected" : "dropped",
+			handoffStatus: isSelected ? deliveryStatus : "not_attempted",
+			memoryRev: snapshot?.rev ?? null,
+			memoryUpdatedAt: snapshot?.updated_at ?? null,
+			memoryScopeId: safeIdentity(snapshot?.scope_id ?? null),
+			memoryKind: snapshot?.kind ?? null,
+			memoryActive: snapshot == null ? null : snapshot.active === 1,
+			memoryDeletedAt: snapshot?.deleted_at ?? null,
+			reasonCodes: isSelected
+				? [
+						"surface.returned",
+						...(selectedIds.length > MAX_RETRIEVAL_SELECTED_EXPOSURES
+							? ["surface.returned_truncated"]
+							: []),
+					]
+				: ["surface.candidate"],
+		};
+	});
+}
+
+export function resolveRetrievalSession(
+	db: Database,
+	source: string,
+	sourceSessionId: string | null | undefined,
+): number | null {
+	if (!sourceSessionId) return null;
+	try {
+		const row = db
+			.prepare(
+				`SELECT session_id FROM opencode_sessions
+				 WHERE source = ? AND (stream_id = ? OR opencode_session_id = ?)
+				 ORDER BY created_at DESC LIMIT 1`,
+			)
+			.get(source, sourceSessionId, sourceSessionId) as { session_id: number | null } | undefined;
+		return row?.session_id ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function retrievalSurfaceAttempt(
+	db: Database,
+	input: RetrievalSurfaceRecordInput,
+): RecordRetrievalAttemptInput {
+	const {
+		candidateIds: inputCandidateIds,
+		selectedIds: inputSelectedIds,
+		candidateCount,
+		filters,
+		query,
+		repositoryPaths,
+		...attempt
+	} = input;
+	const candidateIds = inputCandidateIds ?? inputSelectedIds ?? [];
+	const selectedIds = [...new Set(inputSelectedIds ?? [])];
+	const paths = sanitizeRepositoryPaths(repositoryPaths);
+	const sanitizedQuery = query ? sanitizeSearchQuery(query).clean_query : "";
+	const queryIdentity = sanitizedQuery ? hashRetrievalQuery(sanitizedQuery) : null;
+	return {
+		...attempt,
+		candidateCount: candidateCount ?? candidateIds.length,
+		selectedCount: selectedIds.length,
+		project: safeIdentity(filters?.project ?? null),
+		scopeId: Array.isArray(filters?.scope_id)
+			? filters.scope_id.length === 1
+				? safeIdentity(filters.scope_id[0] ?? null)
+				: null
+			: safeIdentity(filters?.scope_id ?? null),
+		workingSetFileCount: paths?.length ?? 0,
+		workingSetFiles: paths,
+		queryHashSha256: queryIdentity?.queryHashSha256 ?? null,
+		queryCharCount: queryIdentity?.queryCharCount ?? null,
+		queryTokenEstimate: sanitizedQuery ? estimateTokens(sanitizedQuery) : null,
+		filterSummary: sanitizeRetrievalFilters(filters),
+		exposures: exposureRows(db, candidateIds, selectedIds, input.deliveryStatus),
+	};
+}
+
+export function recordRetrievalSurface(
+	db: Database,
+	input: RetrievalSurfaceRecordInput,
+): RetrievalLedgerWriteOutcome {
+	try {
+		return tryRecordRetrievalAttempt(db, retrievalSurfaceAttempt(db, input));
+	} catch {
+		return {
+			ok: false,
+			errorCode: "retrieval_ledger_write_failed",
+			reason: "storage_unavailable",
+		};
+	}
+}
+
+export function reconcileFailedRetrievalSurface(
+	db: Database,
+	input: RetrievalSurfaceRecordInput,
+): RetrievalLedgerWriteOutcome {
+	try {
+		return tryReconcileFailedRetrievalAttempt(db, retrievalSurfaceAttempt(db, input));
+	} catch {
+		return {
+			ok: false,
+			errorCode: "retrieval_ledger_write_failed",
+			reason: "storage_unavailable",
+		};
+	}
+}

--- a/packages/mcp-server/src/canonical-json.ts
+++ b/packages/mcp-server/src/canonical-json.ts
@@ -1,0 +1,14 @@
+export function canonicalJson(value: unknown): string {
+	return (
+		JSON.stringify(value, (_key, nestedValue) => {
+			if (nestedValue === null || typeof nestedValue !== "object" || Array.isArray(nestedValue)) {
+				return nestedValue;
+			}
+			return Object.fromEntries(
+				Object.entries(nestedValue as Record<string, unknown>).toSorted(([left], [right]) =>
+					left < right ? -1 : left > right ? 1 : 0,
+				),
+			);
+		}) ?? "undefined"
+	);
+}

--- a/packages/mcp-server/src/http.test.ts
+++ b/packages/mcp-server/src/http.test.ts
@@ -3,9 +3,11 @@ import { mkdtempSync } from "node:fs";
 import { request } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { queryRetrievalAttempts } from "@codemem/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OAuthAuditEvent } from "./audit.js";
 import {
+	authenticatedRetrievalPrincipal,
 	type CodememMcpHttpServer,
 	DEFAULT_MCP_HTTP_HOST,
 	DEFAULT_MCP_HTTP_PORT,
@@ -13,6 +15,8 @@ import {
 	isAllowedMcpHttpRequestOrigin,
 	isAllowedMcpHttpRequestRemoteAddress,
 	isUnsafePublicBindAllowed,
+	MCP_HTTP_MAX_JSON_BODY_BYTES,
+	MCP_HTTP_RETRIEVAL_RETRY_WINDOW_MS,
 	parseMcpHttpPort,
 	startCodememMcpHttpServer,
 	validateMcpHttpHost,
@@ -734,6 +738,294 @@ describe("MCP HTTP transport", () => {
 		expect(second.result?.serverInfo?.name).toBe("codemem");
 	});
 
+	it("accepts valid MCP JSON bodies larger than Express's default limit", async () => {
+		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
+		servers.push(server);
+
+		const response = await callTool(server.url, "large-valid-request", "memory_recent", {
+			limit: 1,
+			padding: "x".repeat(128 * 1024),
+		});
+
+		expect(response).toHaveProperty("result");
+	});
+
+	it("returns JSON-RPC errors for malformed and oversized MCP JSON bodies", async () => {
+		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
+		servers.push(server);
+
+		const malformed = await postRawMcpJson(server.url, '{"jsonrpc":"2.0",');
+		const oversized = await postRawMcpJson(
+			server.url,
+			JSON.stringify({
+				jsonrpc: "2.0",
+				id: "oversized-request",
+				method: "tools/call",
+				params: {
+					name: "memory_recent",
+					arguments: { padding: "x".repeat(MCP_HTTP_MAX_JSON_BODY_BYTES) },
+				},
+			}),
+		);
+
+		expect(malformed.status).toBe(400);
+		expect(malformed.headers.get("content-type")).toContain("application/json");
+		expect(await malformed.json()).toEqual({
+			jsonrpc: "2.0",
+			error: { code: -32_700, message: "Parse error" },
+			id: null,
+		});
+		expect(oversized.status).toBe(413);
+		expect(oversized.headers.get("content-type")).toContain("application/json");
+		expect(await oversized.json()).toEqual({
+			jsonrpc: "2.0",
+			error: { code: -32_000, message: "Request body too large" },
+			id: null,
+		});
+	});
+
+	it("records matching anonymous HTTP calls as separate retrieval attempts", async () => {
+		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
+		servers.push(server);
+
+		const first = await callTool(server.url, "retry-request-1", "memory_recent", { limit: 5 });
+		const second = await callTool(server.url, "retry-request-1", "memory_recent", { limit: 5 });
+
+		expect(second).toEqual(first);
+		const attempts = queryRetrievalAttempts(server.store.db, { surface: "mcp_recent" });
+		expect(attempts).toHaveLength(2);
+		expect(new Set(attempts.map((attempt) => attempt.requestId)).size).toBe(2);
+		expect(new Set(attempts.map((attempt) => attempt.streamId)).size).toBe(2);
+	});
+
+	it("deduplicates authenticated retries by principal, content, and JSON-RPC ID", async () => {
+		const tokenStore = createInMemoryOAuthAccessTokenStore();
+		const client = tokenStore.issueToken("stable-retry-client");
+		if (!client) throw new Error("expected access token");
+		const server = await startCodememMcpHttpServer({
+			dbPath: tempDbPath(),
+			port: 0,
+			publicUrl: "https://codemem.example.test/mcp",
+			oauthAccessTokenStore: tokenStore,
+		});
+		servers.push(server);
+		const headers = { authorization: `Bearer ${client.token}` };
+
+		const first = await callTool(
+			server.url,
+			"retry-request-1",
+			"memory_recent",
+			{ limit: 5 },
+			headers,
+		);
+		const retry = await callTool(
+			server.url,
+			"retry-request-1",
+			"memory_recent",
+			{ limit: 5 },
+			headers,
+		);
+		const changedParams = await callTool(
+			server.url,
+			"retry-request-1",
+			"memory_recent",
+			{
+				limit: 6,
+			},
+			headers,
+		);
+		const distinct = await callTool(
+			server.url,
+			"request-2",
+			"memory_recent",
+			{ limit: 5 },
+			headers,
+		);
+
+		expect(retry).toEqual(first);
+		expect(changedParams).toHaveProperty("result");
+		expect(distinct).toHaveProperty("result");
+		const attempts = queryRetrievalAttempts(server.store.db, { surface: "mcp_recent" });
+		expect(attempts).toHaveLength(3);
+		expect(new Set(attempts.map((attempt) => attempt.requestId)).size).toBe(3);
+		expect(new Set(attempts.map((attempt) => attempt.streamId)).size).toBe(3);
+	});
+
+	it("separates authenticated retrieval principals by OAuth client", () => {
+		const first = authenticatedRetrievalPrincipal({
+			clientId: "client-a",
+			token: "token-a",
+			extra: { sub: "shared-subject" },
+		});
+		const retry = authenticatedRetrievalPrincipal({
+			clientId: "client-a",
+			token: "token-b",
+			extra: { sub: "shared-subject" },
+		});
+		const otherClient = authenticatedRetrievalPrincipal({
+			clientId: "client-b",
+			token: "token-c",
+			extra: { sub: "shared-subject" },
+		});
+
+		expect(retry).toBe(first);
+		expect(otherClient).not.toBe(first);
+	});
+
+	it("keeps stateless retries together across an aligned boundary until first-observation expiry", async () => {
+		const firstObservedAt = MCP_HTTP_RETRIEVAL_RETRY_WINDOW_MS * 100 - 1;
+		let now = firstObservedAt;
+		const tokenStore = createInMemoryOAuthAccessTokenStore();
+		const client = tokenStore.issueToken("boundary-retry-client");
+		if (!client) throw new Error("expected access token");
+		const server = await startCodememMcpHttpServer({
+			dbPath: tempDbPath(),
+			port: 0,
+			publicUrl: "https://codemem.example.test/mcp",
+			oauthAccessTokenStore: tokenStore,
+			retrievalLedgerNow: () => now,
+		});
+		servers.push(server);
+		const headers = { authorization: `Bearer ${client.token}` };
+
+		await callTool(server.url, "reusable-request-id", "memory_recent", { limit: 5 }, headers);
+		now = MCP_HTTP_RETRIEVAL_RETRY_WINDOW_MS * 100 + 1;
+		await callTool(server.url, "reusable-request-id", "memory_recent", { limit: 5 }, headers);
+		now = firstObservedAt + MCP_HTTP_RETRIEVAL_RETRY_WINDOW_MS - 1;
+		await callTool(server.url, "reusable-request-id", "memory_recent", { limit: 5 }, headers);
+
+		let attempts = queryRetrievalAttempts(server.store.db, { surface: "mcp_recent" });
+		expect(attempts).toHaveLength(1);
+
+		now = firstObservedAt + MCP_HTTP_RETRIEVAL_RETRY_WINDOW_MS;
+		await callTool(server.url, "reusable-request-id", "memory_recent", { limit: 5 }, headers);
+
+		attempts = queryRetrievalAttempts(server.store.db, { surface: "mcp_recent" });
+		expect(attempts).toHaveLength(2);
+		expect(new Set(attempts.map((attempt) => attempt.streamId)).size).toBe(2);
+	});
+
+	it("canonicalizes stateless request object ordering within the retry window", async () => {
+		const tokenStore = createInMemoryOAuthAccessTokenStore();
+		const client = tokenStore.issueToken("canonical-retry-client");
+		if (!client) throw new Error("expected access token");
+		const server = await startCodememMcpHttpServer({
+			dbPath: tempDbPath(),
+			port: 0,
+			publicUrl: "https://codemem.example.test/mcp",
+			oauthAccessTokenStore: tokenStore,
+		});
+		servers.push(server);
+		const headers = { authorization: `Bearer ${client.token}` };
+
+		await callTool(
+			server.url,
+			"canonical-request-id",
+			"memory_recent",
+			{
+				limit: 5,
+				project: "codemem",
+			},
+			headers,
+		);
+		await callTool(
+			server.url,
+			"canonical-request-id",
+			"memory_recent",
+			{
+				project: "codemem",
+				limit: 5,
+			},
+			headers,
+		);
+
+		expect(queryRetrievalAttempts(server.store.db, { surface: "mcp_recent" })).toHaveLength(1);
+	});
+
+	it("partitions retry identity by authenticated client without leaking request context", async () => {
+		const tokenStore = createInMemoryOAuthAccessTokenStore();
+		const firstClient = tokenStore.issueToken("private-client-one");
+		const secondClient = tokenStore.issueToken("private-client-two");
+		if (!firstClient || !secondClient) throw new Error("expected access tokens");
+		const server = await startCodememMcpHttpServer({
+			dbPath: tempDbPath(),
+			port: 0,
+			publicUrl: "https://codemem.example.test/mcp",
+			oauthAccessTokenStore: tokenStore,
+		});
+		servers.push(server);
+		const query = "private query text must not leak";
+		const userAgent = "private-caller-agent/1.0";
+		const forwardedFor = "203.0.113.77";
+		const request = { query, limit: 5 };
+
+		await callTool(server.url, "shared-request-id", "memory_search", request, {
+			authorization: `Bearer ${firstClient.token}`,
+			"user-agent": userAgent,
+			"x-forwarded-for": forwardedFor,
+		});
+		await callTool(server.url, "shared-request-id", "memory_search", request, {
+			authorization: `Bearer ${secondClient.token}`,
+		});
+
+		const attempts = queryRetrievalAttempts(server.store.db, { surface: "mcp_search" });
+		expect(attempts).toHaveLength(2);
+		expect(new Set(attempts.map((attempt) => attempt.streamId)).size).toBe(2);
+		for (const attempt of attempts) {
+			expect(attempt.streamId).toMatch(/^mcp-http:[a-f0-9]{64}$/);
+		}
+		const persisted = JSON.stringify(attempts);
+		expect(persisted).not.toContain(query);
+		expect(persisted).not.toContain("private-client-one");
+		expect(persisted).not.toContain("private-client-two");
+		expect(persisted).not.toContain("codemem.example.test");
+		expect(persisted).not.toContain(firstClient.token);
+		expect(persisted).not.toContain(secondClient.token);
+		expect(persisted).not.toContain(userAgent);
+		expect(persisted).not.toContain(forwardedFor);
+	});
+
+	it("partitions retry identity for distinct tokens issued to the same authenticated client", async () => {
+		const tokenStore = createInMemoryOAuthAccessTokenStore();
+		const firstUser = tokenStore.issueToken("shared-team-client");
+		const secondUser = tokenStore.issueToken("shared-team-client");
+		if (!firstUser || !secondUser) throw new Error("expected access tokens");
+		const server = await startCodememMcpHttpServer({
+			dbPath: tempDbPath(),
+			port: 0,
+			publicUrl: "https://codemem.example.test/mcp",
+			oauthAccessTokenStore: tokenStore,
+		});
+		servers.push(server);
+
+		await callTool(
+			server.url,
+			"shared-request-id",
+			"memory_recent",
+			{ limit: 5 },
+			{
+				authorization: `Bearer ${firstUser.token}`,
+			},
+		);
+		await callTool(
+			server.url,
+			"shared-request-id",
+			"memory_recent",
+			{ limit: 5 },
+			{
+				authorization: `Bearer ${secondUser.token}`,
+			},
+		);
+
+		const attempts = queryRetrievalAttempts(server.store.db, { surface: "mcp_recent" });
+		expect(attempts).toHaveLength(2);
+		expect(new Set(attempts.map((attempt) => attempt.streamId)).size).toBe(2);
+		const persisted = JSON.stringify(attempts);
+		expect(persisted).not.toContain(firstUser.token);
+		expect(persisted).not.toContain(secondUser.token);
+		expect(persisted).not.toContain("shared-team-client");
+	});
+
 	it("rejects browser requests from non-loopback origins", async () => {
 		const server = await startCodememMcpHttpServer({ dbPath: tempDbPath(), port: 0 });
 		servers.push(server);
@@ -795,6 +1087,43 @@ function initializeBody(id: number): string {
 			capabilities: {},
 			clientInfo: { name: "codemem-test", version: "0.0.0" },
 		},
+	});
+}
+
+async function callTool(
+	url: string,
+	id: string | number,
+	name: string,
+	args: Record<string, unknown>,
+	extraHeaders: Record<string, string> = {},
+): Promise<unknown> {
+	const response = await fetch(url, {
+		method: "POST",
+		headers: {
+			accept: "application/json, text/event-stream",
+			"content-type": "application/json",
+			...extraHeaders,
+		},
+		body: JSON.stringify({
+			jsonrpc: "2.0",
+			id,
+			method: "tools/call",
+			params: { name, arguments: args },
+		}),
+	});
+
+	expect(response.status).toBe(200);
+	return parseSseJson(await response.text());
+}
+
+function postRawMcpJson(url: string, body: string): Promise<Response> {
+	return fetch(url, {
+		method: "POST",
+		headers: {
+			accept: "application/json, text/event-stream",
+			"content-type": "application/json",
+		},
+		body,
 	});
 }
 

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -8,6 +8,7 @@
  * OAuth bearer tokens.
  */
 
+import { createHash, randomUUID } from "node:crypto";
 import { createServer, type IncomingMessage, type Server } from "node:http";
 import { isIP } from "node:net";
 import { pathToFileURL } from "node:url";
@@ -28,6 +29,7 @@ import {
 	resolveOAuthAuditEmitterFromEnv,
 	wrapAuditEmitterBestEffort,
 } from "./audit.js";
+import { canonicalJson } from "./canonical-json.js";
 import {
 	createInMemoryOAuthAccessTokenStore,
 	createInMemoryOAuthAuthorizationCodeStore,
@@ -59,6 +61,9 @@ const CORS_MAX_AGE_SECONDS = "600";
 const MAX_GUARD_LOG_FIELD_LENGTH = 256;
 const PUBLIC_MCP_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 const PUBLIC_MCP_RATE_LIMIT_REQUESTS = 600;
+export const MCP_HTTP_MAX_JSON_BODY_BYTES = 4 * 1024 * 1024;
+export const MCP_HTTP_RETRIEVAL_RETRY_WINDOW_MS = 5 * 60 * 1000;
+const MCP_HTTP_RETRIEVAL_RETRY_MAX_ENTRIES = 2000;
 
 const VALID_HOSTNAME = /^[a-zA-Z0-9.-]+$/;
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
@@ -76,6 +81,7 @@ export interface CodememMcpHttpOptions {
 	oauthAccessTokenStore?: OAuthAccessTokenStore;
 	oauthStatePath?: string;
 	auditEmitter?: OAuthAuditEmitter;
+	retrievalLedgerNow?: () => number;
 }
 
 export interface CodememMcpHttpServer {
@@ -83,6 +89,18 @@ export interface CodememMcpHttpServer {
 	store: MemoryStore;
 	url: string;
 	close: () => Promise<void>;
+}
+
+export function authenticatedRetrievalPrincipal(
+	auth: { clientId?: string; token?: string; extra?: Record<string, unknown> } | undefined,
+): string | undefined {
+	const authSubject = auth?.extra?.sub;
+	if (typeof authSubject === "string" && authSubject.trim().length > 0) {
+		const subject = authSubject.trim();
+		const clientId = auth?.clientId?.trim();
+		return clientId ? `subject-client:${canonicalJson([subject, clientId])}` : `subject:${subject}`;
+	}
+	return auth?.token ? `token:${auth.token}` : undefined;
 }
 
 export function validateMcpHttpHost(host: string | undefined, allowUnsafePublic = false): string {
@@ -220,6 +238,7 @@ export async function startCodememMcpHttpServer(
 		options.auditEmitter ?? resolveOAuthAuditEmitterFromEnv(),
 	);
 	const activeRequests = new Set<ActiveRequest>();
+	const resolveRetrievalLedgerScopeId = createHttpRetrievalLedgerScopeResolver();
 	let closePromise: Promise<void> | null = null;
 
 	const app = express();
@@ -398,28 +417,45 @@ export async function startCodememMcpHttpServer(
 	const bearerAuditMiddleware = shouldRequireMcpBearer
 		? auditBearerPreflight(auditEmit, tokenStore)
 		: (_req: Request, _res: Response, next: NextFunction) => next();
-	app.post("/mcp", bearerAuditMiddleware, bearerMiddleware, async (req, res) => {
-		if (req.auth) {
-			auditEmit(
-				buildOAuthAuditEvent("bearer", {
-					outcome: "success",
-					clientId: req.auth.clientId,
-					remoteAddress: req.socket.remoteAddress ?? undefined,
-				}),
-			);
-		}
-		const mcpServer = createCodememMcpServer(store);
-		const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-		const activeRequest = { mcpServer };
-		activeRequests.add(activeRequest);
-		try {
-			await mcpServer.connect(transport);
-			await transport.handleRequest(req, res);
-		} finally {
-			activeRequests.delete(activeRequest);
-			await mcpServer.close();
-		}
-	});
+	app.post(
+		"/mcp",
+		bearerAuditMiddleware,
+		bearerMiddleware,
+		express.json({ limit: MCP_HTTP_MAX_JSON_BODY_BYTES }),
+		async (req: Request, res: Response) => {
+			if (req.auth) {
+				auditEmit(
+					buildOAuthAuditEvent("bearer", {
+						outcome: "success",
+						clientId: req.auth.clientId,
+						remoteAddress: req.socket.remoteAddress ?? undefined,
+					}),
+				);
+			}
+			const retrievalPrincipal = authenticatedRetrievalPrincipal(req.auth);
+			const retrievalLedgerScopeId = resolveRetrievalLedgerScopeId({
+				endpoint: publicMcpUrlObject,
+				principal: retrievalPrincipal,
+				requestBody: req.body,
+				now: options.retrievalLedgerNow?.() ?? Date.now(),
+			});
+			const mcpServer = createCodememMcpServer(store, {
+				retrievalLedgerScopeId,
+				retrievalLedgerIdentityMode: "stateless",
+			});
+			const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+			const activeRequest = { mcpServer };
+			activeRequests.add(activeRequest);
+			try {
+				await mcpServer.connect(transport);
+				await transport.handleRequest(req, res, req.body);
+			} finally {
+				activeRequests.delete(activeRequest);
+				await mcpServer.close();
+			}
+		},
+		handleMcpJsonBodyError,
+	);
 	app.all("/mcp", (_req, res) => {
 		res.setHeader("Allow", "POST");
 		res.status(405).type("text/plain").send("Method not allowed");
@@ -588,6 +624,87 @@ function formatHostForUrl(host: string): string {
 
 function getServerUrl(server: Server, host: string): string {
 	return `http://${formatHostForUrl(host)}:${getBoundPort(server)}/mcp`;
+}
+
+function createHttpRetrievalLedgerScopeResolver(): (input: {
+	endpoint: URL;
+	principal: string | undefined;
+	requestBody: unknown;
+	now: number;
+}) => string {
+	const scopes = new Map<string, { scopeId: string; expiresAt: number }>();
+
+	return (input) => {
+		// Anonymous HTTP has no stable, trustworthy caller identity. Give each POST
+		// its own opaque scope rather than collapsing unrelated clients that reuse
+		// the same JSON-RPC id and payload. One POST still shares this scope across
+		// its server execution, preserving callback-level idempotency.
+		if (!input.principal) return createOpaqueHttpRetrievalLedgerScopeId(randomUUID());
+
+		for (const [key, scope] of scopes) {
+			if (scope.expiresAt <= input.now) scopes.delete(key);
+		}
+
+		// Stateless HTTP has no dispatch identity beyond the authenticated
+		// principal and request bytes. Exact repeats inside this bounded window
+		// are therefore treated as transport retries; an intentional repeat must
+		// use a new JSON-RPC id or arrive after expiry. Keep only an opaque digest,
+		// and do not slide the first-observation expiry on reads.
+		const contextDigest = createHash("sha256")
+			.update(
+				JSON.stringify([input.endpoint.href, input.principal, canonicalJson(input.requestBody)]),
+			)
+			.digest("hex");
+		const existing = scopes.get(contextDigest);
+		if (existing) return existing.scopeId;
+
+		const scopeId = createOpaqueHttpRetrievalLedgerScopeId(
+			JSON.stringify([contextDigest, input.now]),
+		);
+		scopes.set(contextDigest, {
+			scopeId,
+			expiresAt: input.now + MCP_HTTP_RETRIEVAL_RETRY_WINDOW_MS,
+		});
+		while (scopes.size > MCP_HTTP_RETRIEVAL_RETRY_MAX_ENTRIES) {
+			const oldestKey = scopes.keys().next().value;
+			if (oldestKey === undefined) break;
+			scopes.delete(oldestKey);
+		}
+		return scopeId;
+	};
+}
+
+function createOpaqueHttpRetrievalLedgerScopeId(seed: string): string {
+	return `mcp-http:${createHash("sha256").update(seed).digest("hex")}`;
+}
+
+function handleMcpJsonBodyError(
+	error: unknown,
+	_req: Request,
+	res: Response,
+	next: NextFunction,
+): void {
+	const status = mcpJsonBodyErrorStatus(error);
+	if (status === null) {
+		next(error);
+		return;
+	}
+	res.status(status).json({
+		jsonrpc: "2.0",
+		error: {
+			code: status === 413 ? -32_000 : -32_700,
+			message: status === 413 ? "Request body too large" : "Parse error",
+		},
+		id: null,
+	});
+}
+
+function mcpJsonBodyErrorStatus(error: unknown): 400 | 413 | null {
+	if (error === null || typeof error !== "object") return null;
+	const bodyError = error as { type?: unknown };
+	if (bodyError.type === "entity.too.large") return 413;
+	if (bodyError.type === "entity.parse.failed") return 400;
+	return null;
 }
 
 function getSdkIssuerUrl(publicMcpUrl: URL, port: number): URL {

--- a/packages/mcp-server/src/mcp-retrieval-ledger.ts
+++ b/packages/mcp-server/src/mcp-retrieval-ledger.ts
@@ -1,0 +1,396 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+	type MemoryFilters,
+	type RetrievalStatus,
+	type RetrievalSurface,
+	reconcileFailedRetrievalSurface,
+	recordRetrievalSurface,
+} from "@codemem/core";
+import { canonicalJson } from "./canonical-json.js";
+import { errorContent, jsonContent } from "./content.js";
+import type { ToolRegistrationContext } from "./tool-context.js";
+
+export interface McpRetrievalResult<T> {
+	value: T;
+	memoryIds: number[];
+	candidateCount?: number;
+	filters?: MemoryFilters;
+	retrievalStatus?: RetrievalStatus;
+	error?: string;
+}
+
+interface McpRetrievalInput {
+	surface: RetrievalSurface;
+	toolName: string;
+	toolArguments: unknown;
+	query?: string | null;
+	limit?: number | null;
+	resolveFilters?: () => MemoryFilters | undefined;
+	requestId?: string | number;
+	sourceSessionId?: string | null;
+	invocationIdentity?: object;
+}
+
+const MCP_SESSION_RETRY_TTL_MS = 5 * 60 * 1000;
+const MCP_SESSION_RETRY_MAX_ENTRIES = 2000;
+
+interface InvocationLedgerIdentity {
+	baseRequestId: string | null;
+	requestId: string | null;
+	attemptId: string;
+}
+
+interface PendingFailure {
+	identity: InvocationLedgerIdentity;
+	expiresAt: number;
+	order: number;
+}
+
+interface SessionIdentityTracker {
+	byInvocation: WeakMap<object, InvocationLedgerIdentity>;
+	activeByRequest: Map<string, number>;
+	pendingFailures: Map<string, PendingFailure[]>;
+	pendingFailureCount: number;
+	nextPendingFailureOrder: number;
+	nextInvocationSequence: number;
+}
+
+// Track only live invocation objects and per-base FIFO failure queues. Pending
+// identities expire after five minutes and are capped at 2,000 entries total.
+// The outer WeakMap releases the whole tracker with its server registration context.
+const sessionIdentityTrackers = new WeakMap<ToolRegistrationContext, SessionIdentityTracker>();
+let fallbackAttemptSequence = 0;
+
+function recordMcpRetrieval(
+	context: ToolRegistrationContext,
+	input: Parameters<typeof recordRetrievalSurface>[1],
+	reconcileTransientFailure: boolean,
+): void {
+	if (!context.captureRetrievalLedger) return;
+	try {
+		const outcome = recordRetrievalSurface(context.store.db, input);
+		if (
+			reconcileTransientFailure &&
+			!outcome.ok &&
+			outcome.reason === "idempotency_conflict" &&
+			((input.retrievalStatus === "succeeded" && input.deliveryStatus === "handed_off") ||
+				(input.retrievalStatus === "no_results" && input.deliveryStatus === "not_attempted"))
+		) {
+			reconcileFailedRetrievalSurface(context.store.db, input);
+		}
+	} catch {
+		// MCP responses must remain independent from local diagnostics.
+	}
+}
+
+function requestAttemptId(requestId: string | null): string {
+	if (requestId == null) return randomUUID();
+	const hex = requestId.slice(0, 32).split("");
+	hex[12] = "5";
+	hex[16] = ((Number.parseInt(hex[16] ?? "0", 16) & 0x3) | 0x8).toString(16);
+	const value = hex.join("");
+	return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20)}`;
+}
+
+function baseRequestIdentity(
+	context: ToolRegistrationContext,
+	input: McpRetrievalInput,
+): string | null {
+	if (input.requestId == null) return null;
+	const callContentDigest = createHash("sha256")
+		.update(
+			canonicalJson({
+				method: "tools/call",
+				params: { name: input.toolName, arguments: input.toolArguments },
+			}),
+		)
+		.digest("hex");
+	return createHash("sha256")
+		.update(
+			JSON.stringify([
+				input.sourceSessionId ?? context.retrievalLedgerScopeId,
+				input.requestId,
+				callContentDigest,
+			]),
+		)
+		.digest("hex");
+}
+
+function sessionIdentityTracker(context: ToolRegistrationContext): SessionIdentityTracker {
+	let tracker = sessionIdentityTrackers.get(context);
+	if (!tracker) {
+		tracker = {
+			byInvocation: new WeakMap(),
+			activeByRequest: new Map(),
+			pendingFailures: new Map(),
+			pendingFailureCount: 0,
+			nextPendingFailureOrder: 0,
+			nextInvocationSequence: 0,
+		};
+		sessionIdentityTrackers.set(context, tracker);
+	}
+	return tracker;
+}
+
+function prunePendingFailures(tracker: SessionIdentityTracker, now: number): void {
+	for (const [requestId, pending] of tracker.pendingFailures) {
+		const retained = pending.filter((entry) => entry.expiresAt > now);
+		tracker.pendingFailureCount -= pending.length - retained.length;
+		if (retained.length === 0) tracker.pendingFailures.delete(requestId);
+		else if (retained.length !== pending.length) tracker.pendingFailures.set(requestId, retained);
+	}
+	while (tracker.pendingFailureCount > MCP_SESSION_RETRY_MAX_ENTRIES) {
+		let oldestRequestId: string | undefined;
+		let oldestOrder = Number.POSITIVE_INFINITY;
+		for (const [requestId, pending] of tracker.pendingFailures) {
+			const order = pending[0]?.order;
+			if (order != null && order < oldestOrder) {
+				oldestRequestId = requestId;
+				oldestOrder = order;
+			}
+		}
+		if (oldestRequestId === undefined) break;
+		const pending = tracker.pendingFailures.get(oldestRequestId);
+		const removed = pending?.shift();
+		if (!pending || !removed) {
+			tracker.pendingFailures.delete(oldestRequestId);
+			continue;
+		}
+		tracker.pendingFailureCount -= 1;
+		if (pending.length === 0) tracker.pendingFailures.delete(oldestRequestId);
+	}
+}
+
+function takePendingFailure(
+	tracker: SessionIdentityTracker,
+	baseRequestId: string,
+): InvocationLedgerIdentity | undefined {
+	const pending = tracker.pendingFailures.get(baseRequestId);
+	if (!pending) return undefined;
+	const failure = pending.shift();
+	if (!failure) return undefined;
+	tracker.pendingFailureCount -= 1;
+	if (pending.length === 0) tracker.pendingFailures.delete(baseRequestId);
+	return failure.identity;
+}
+
+function removePendingFailure(
+	tracker: SessionIdentityTracker,
+	baseRequestId: string,
+	attemptId: string,
+): void {
+	const pending = tracker.pendingFailures.get(baseRequestId);
+	const index = pending?.findIndex((entry) => entry.identity.attemptId === attemptId) ?? -1;
+	if (!pending || index < 0) return;
+	pending.splice(index, 1);
+	tracker.pendingFailureCount -= 1;
+	if (pending.length === 0) tracker.pendingFailures.delete(baseRequestId);
+}
+
+function enqueuePendingFailure(
+	tracker: SessionIdentityTracker,
+	baseRequestId: string,
+	identity: InvocationLedgerIdentity,
+	now: number,
+): void {
+	const pending = tracker.pendingFailures.get(baseRequestId) ?? [];
+	if (pending.some((entry) => entry.identity.attemptId === identity.attemptId)) return;
+	pending.push({
+		identity,
+		expiresAt: now + MCP_SESSION_RETRY_TTL_MS,
+		order: tracker.nextPendingFailureOrder,
+	});
+	tracker.nextPendingFailureOrder += 1;
+	tracker.pendingFailures.set(baseRequestId, pending);
+	tracker.pendingFailureCount += 1;
+	prunePendingFailures(tracker, now);
+}
+
+function fallbackInvocationIdentity(): InvocationLedgerIdentity {
+	try {
+		return { baseRequestId: null, requestId: null, attemptId: randomUUID() };
+	} catch {
+		const timestamp = Date.now().toString(16).slice(-8).padStart(8, "0");
+		const sequence = fallbackAttemptSequence.toString(16).slice(-4).padStart(4, "0");
+		fallbackAttemptSequence = (fallbackAttemptSequence + 1) % 0x1_0000;
+		return {
+			baseRequestId: null,
+			requestId: null,
+			attemptId: `00000000-0000-4000-8000-${timestamp}${sequence}`,
+		};
+	}
+}
+
+function beginInvocation(
+	context: ToolRegistrationContext,
+	input: McpRetrievalInput,
+): InvocationLedgerIdentity {
+	const baseRequestId = baseRequestIdentity(context, input);
+	if (context.retrievalLedgerIdentityMode === "stateless" || baseRequestId == null) {
+		return {
+			baseRequestId,
+			requestId: baseRequestId,
+			attemptId: requestAttemptId(baseRequestId),
+		};
+	}
+
+	const tracker = sessionIdentityTracker(context);
+	prunePendingFailures(tracker, Date.now());
+	const candidateInvocation = input.invocationIdentity
+		? tracker.byInvocation.get(input.invocationIdentity)
+		: undefined;
+	const knownInvocation =
+		candidateInvocation?.baseRequestId === baseRequestId ? candidateInvocation : undefined;
+	let identity = knownInvocation;
+	if (!identity) {
+		const activeCount = tracker.activeByRequest.get(baseRequestId) ?? 0;
+		const pending = activeCount === 0 ? takePendingFailure(tracker, baseRequestId) : undefined;
+		if (pending) {
+			identity = pending;
+		} else {
+			const invocationSequence = tracker.nextInvocationSequence;
+			tracker.nextInvocationSequence += 1;
+			const requestId = createHash("sha256")
+				.update(JSON.stringify([baseRequestId, context.retrievalLedgerScopeId, invocationSequence]))
+				.digest("hex");
+			identity = {
+				baseRequestId,
+				requestId,
+				attemptId: requestAttemptId(requestId),
+			};
+		}
+		if (input.invocationIdentity) tracker.byInvocation.set(input.invocationIdentity, identity);
+	}
+	tracker.activeByRequest.set(baseRequestId, (tracker.activeByRequest.get(baseRequestId) ?? 0) + 1);
+	return identity;
+}
+
+function safeBeginInvocation(
+	context: ToolRegistrationContext,
+	input: McpRetrievalInput,
+): InvocationLedgerIdentity {
+	try {
+		return beginInvocation(context, input);
+	} catch {
+		return fallbackInvocationIdentity();
+	}
+}
+
+function completeInvocation(
+	context: ToolRegistrationContext,
+	identity: InvocationLedgerIdentity,
+	status: "completed" | "failed",
+): void {
+	if (context.retrievalLedgerIdentityMode === "stateless" || identity.baseRequestId == null) return;
+	const tracker = sessionIdentityTracker(context);
+	const activeCount = tracker.activeByRequest.get(identity.baseRequestId) ?? 0;
+	if (activeCount <= 1) tracker.activeByRequest.delete(identity.baseRequestId);
+	else tracker.activeByRequest.set(identity.baseRequestId, activeCount - 1);
+
+	if (status === "failed") {
+		enqueuePendingFailure(tracker, identity.baseRequestId, identity, Date.now());
+	} else {
+		removePendingFailure(tracker, identity.baseRequestId, identity.attemptId);
+	}
+}
+
+function safeCompleteInvocation(
+	context: ToolRegistrationContext,
+	identity: InvocationLedgerIdentity,
+	status: "completed" | "failed",
+): void {
+	try {
+		completeInvocation(context, identity, status);
+	} catch {
+		// Retrieval diagnostics must never alter the MCP tool result.
+	}
+}
+
+export async function withMcpRetrieval<T>(
+	context: ToolRegistrationContext,
+	input: McpRetrievalInput,
+	retrieve: (
+		filters: MemoryFilters | undefined,
+	) => McpRetrievalResult<T> | Promise<McpRetrievalResult<T>>,
+) {
+	const invocation = safeBeginInvocation(context, input);
+	const ledgerRequestId = invocation.requestId;
+	const attemptId = invocation.attemptId;
+	const startedAt = new Date();
+	let filters: MemoryFilters | undefined;
+	try {
+		filters = input.resolveFilters?.();
+		const output = await retrieve(filters);
+		const completedAt = new Date();
+		const response = output.error ? errorContent(output.error) : jsonContent(output.value);
+		const streamId = input.sourceSessionId ?? context.retrievalLedgerScopeId;
+		const hasResults = output.memoryIds.length > 0;
+		const isNotFoundCompletion = output.error === "not_found" && !hasResults;
+		const isFailedResult = output.error != null && !isNotFoundCompletion;
+		const recordedMemoryIds = isFailedResult ? [] : output.memoryIds;
+		recordMcpRetrieval(
+			context,
+			{
+				attemptId,
+				surface: input.surface,
+				trigger: "explicit",
+				startedAt: startedAt.toISOString(),
+				completedAt: completedAt.toISOString(),
+				retrievalStatus: isFailedResult
+					? "failed"
+					: hasResults
+						? (output.retrievalStatus ?? "succeeded")
+						: "no_results",
+				deliveryStatus: isFailedResult || !hasResults ? "not_attempted" : "handed_off",
+				candidateIds: recordedMemoryIds,
+				selectedIds: recordedMemoryIds,
+				candidateCount: hasResults && !isFailedResult ? output.candidateCount : 0,
+				recorderVersion: "mcp-retrieval-v1",
+				source: "mcp",
+				streamId,
+				sourceSessionId: input.sourceSessionId ?? null,
+				requestId: ledgerRequestId,
+				latencyMs: Math.max(0, completedAt.getTime() - startedAt.getTime()),
+				filters: output.filters ?? filters,
+				query: input.query,
+				limitRequested: input.limit,
+				failureCode: isFailedResult ? "tool_failed" : undefined,
+				failureStage: isFailedResult ? "retrieval" : undefined,
+			},
+			!isFailedResult,
+		);
+		safeCompleteInvocation(context, invocation, isFailedResult ? "failed" : "completed");
+		return response;
+	} catch (error) {
+		const completedAt = new Date();
+		const streamId = input.sourceSessionId ?? context.retrievalLedgerScopeId;
+		recordMcpRetrieval(
+			context,
+			{
+				attemptId,
+				surface: input.surface,
+				trigger: "explicit",
+				startedAt: startedAt.toISOString(),
+				completedAt: completedAt.toISOString(),
+				retrievalStatus: "failed",
+				deliveryStatus: "not_attempted",
+				candidateIds: [],
+				selectedIds: [],
+				recorderVersion: "mcp-retrieval-v1",
+				source: "mcp",
+				streamId,
+				sourceSessionId: input.sourceSessionId ?? null,
+				requestId: ledgerRequestId,
+				latencyMs: Math.max(0, completedAt.getTime() - startedAt.getTime()),
+				query: input.query,
+				limitRequested: input.limit,
+				filters,
+				failureCode: "tool_failed",
+				failureStage: "retrieval",
+			},
+			false,
+		);
+		safeCompleteInvocation(context, invocation, "failed");
+		return errorContent(error instanceof Error ? error.message : String(error));
+	}
+}

--- a/packages/mcp-server/src/memory-access.test.ts
+++ b/packages/mcp-server/src/memory-access.test.ts
@@ -1,21 +1,38 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { connect, initTestSchema, MemoryStore, seedMixedScopeFixture } from "@codemem/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	connect,
+	getRetrievalAttempt,
+	initTestSchema,
+	MemoryStore,
+	purgeRetrievalAttemptsForPrivacy,
+	queryRetrievalAttempts,
+	seedMixedScopeFixture,
+} from "@codemem/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCodememMcpServer } from "./index.js";
+import { withMcpRetrieval } from "./mcp-retrieval-ledger.js";
 import {
 	forgetMemoryForMcp,
 	getManyForMcp,
 	getMemoryForMcp,
 	rememberMemoryForMcp,
 } from "./memory-access.js";
+import type { ToolRegistrationContext } from "./tool-context.js";
 
 type RegisteredTool = {
-	handler: (args: Record<string, unknown>) => Promise<{
+	handler: (
+		args: Record<string, unknown>,
+		extra?: { requestId: string | number; sessionId?: string; signal?: AbortSignal },
+	) => Promise<{
 		content: Array<{ type: string; text: string }>;
 	}>;
 };
+
+function requestExtra(requestId: string | number, sessionId?: string) {
+	return { requestId, sessionId, signal: new AbortController().signal };
+}
 
 function getTool(server: ReturnType<typeof createCodememMcpServer>, name: string): RegisteredTool {
 	const registry = (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
@@ -52,6 +69,7 @@ describe("MCP memory access scope guards", () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		store?.close();
 		rmSync(tmpDir, { recursive: true, force: true });
 		if (originalDeviceId === undefined) {
@@ -419,6 +437,712 @@ describe("MCP memory access scope guards", () => {
 			const mismatch = result.errors.find((err) => err.code === "PROJECT_MISMATCH");
 			expect(mismatch?.ids).toContain(otherProjectId);
 		});
+
+		it("records explicit MCP surfaces, effective filters, returned IDs, and delivery", async () => {
+			const hiddenId = insertScopedMemory(store, {
+				sessionId,
+				scopeId: "scope-b",
+				title: "Ledger scope target",
+			});
+			store.db
+				.prepare("UPDATE memory_items SET title = ? WHERE id = ?")
+				.run("Ledger scope target", greenroomId);
+			const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			const search = getTool(server, "memory_search");
+			const response = parseToolJson(
+				await search.handler(
+					{ query: "Ledger scope target", scope_id: "scope-a", limit: 10 },
+					{ requestId: "request-search-1", sessionId: "transport-session-1" },
+				),
+			) as { items: Array<{ id: number }> };
+
+			expect(response.items.map((item) => item.id)).toContain(greenroomId);
+			expect(response.items.map((item) => item.id)).not.toContain(hiddenId);
+			const attempt = queryRetrievalAttempts(store.db, { surface: "mcp_search", limit: 1 })[0];
+			if (!attempt) throw new Error("expected a recorded MCP search attempt");
+			expect(attempt).toMatchObject({
+				retrievalStatus: "succeeded",
+				deliveryStatus: "handed_off",
+				project: "greenroom",
+				scopeId: "scope-a",
+				mode: null,
+				streamId: "transport-session-1",
+				limitRequested: 10,
+				filterSummary: { project: "greenroom", scope_id: "scope-a" },
+			});
+			expect(attempt.latencyMs).toBeGreaterThanOrEqual(0);
+			expect(attempt.requestId).toMatch(/^[a-f0-9]{64}$/);
+			expect(attempt.requestId).not.toContain("request-search-1");
+			expect(attempt.exposures.map((exposure) => exposure.memoryId)).toContain(greenroomId);
+			expect(attempt.exposures.map((exposure) => exposure.memoryId)).not.toContain(hiddenId);
+			const persisted = JSON.stringify(
+				store.db
+					.prepare("SELECT * FROM retrieval_attempts WHERE attempt_id = ?")
+					.get(attempt.attemptId),
+			);
+			expect(persisted).not.toContain("Ledger scope target");
+			expect(persisted).not.toContain(`${tmpDir}/`);
+		});
+
+		it("records successful empty search, recent, and timeline calls as undelivered no-results", async () => {
+			const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			await getTool(server, "memory_search").handler({
+				query: "no memory matches this exact query",
+				project: "missing-project",
+				limit: 5,
+			});
+			await getTool(server, "memory_recent").handler({ project: "missing-project", limit: 5 });
+			await getTool(server, "memory_timeline").handler({
+				query: "no timeline anchor matches this exact query",
+				project: "missing-project",
+				depth_before: 1,
+				depth_after: 1,
+			});
+
+			for (const surface of ["mcp_search", "mcp_recent", "mcp_timeline"] as const) {
+				const attempt = queryRetrievalAttempts(store.db, { surface, limit: 1 })[0];
+				expect(attempt, surface).toMatchObject({
+					retrievalStatus: "no_results",
+					deliveryStatus: "not_attempted",
+					candidateCount: 0,
+					selectedCount: 0,
+					exposures: [],
+				});
+			}
+		});
+
+		it("covers direct, observations, index, explain, recent, pack, timeline, and expand surfaces", async () => {
+			const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			await getTool(server, "memory_get").handler({ memory_id: otherProjectId });
+			await getTool(server, "memory_get_observations").handler({
+				ids: [greenroomId, otherProjectId],
+			});
+			await getTool(server, "memory_search_index").handler({ query: "direct-ID note", limit: 8 });
+			await getTool(server, "memory_explain").handler({ ids: [greenroomId], limit: 10 });
+			await getTool(server, "memory_recent").handler({ limit: 8 });
+			await getTool(server, "memory_pack").handler({ context: "direct-ID note", limit: 5 });
+			await getTool(server, "memory_timeline").handler({
+				memory_id: greenroomId,
+				depth_before: 1,
+				depth_after: 1,
+			});
+			await getTool(server, "memory_expand").handler({
+				ids: [otherProjectId],
+				project: "",
+				depth_before: 1,
+				depth_after: 1,
+				include_observations: false,
+			});
+
+			for (const surface of [
+				"mcp_get",
+				"mcp_get_observations",
+				"mcp_search_index",
+				"mcp_explain",
+				"mcp_recent",
+				"mcp_pack",
+				"mcp_timeline",
+				"mcp_expand",
+			] as const) {
+				const attempt = queryRetrievalAttempts(store.db, { surface, limit: 1 })[0];
+				expect(attempt?.mode, surface).toBeNull();
+				expect(attempt?.deliveryStatus, surface).toBe("handed_off");
+			}
+
+			const direct = queryRetrievalAttempts(store.db, { surface: "mcp_get", limit: 1 })[0];
+			expect(direct?.project).toBeNull();
+			expect(direct?.filterSummary).toBeNull();
+			expect(direct?.exposures.map((exposure) => exposure.memoryId)).toEqual([otherProjectId]);
+			const expand = queryRetrievalAttempts(store.db, { surface: "mcp_expand", limit: 1 })[0];
+			expect(expand?.project).toBeNull();
+		});
+
+		it("keeps duplicate processing of one runtime invocation idempotent", async () => {
+			const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			const get = getTool(server, "memory_get");
+			const extra = requestExtra("retry-request-1", "transport-session-2");
+
+			const first = await get.handler({ memory_id: greenroomId }, extra);
+			const retry = await get.handler({ memory_id: greenroomId }, extra);
+			expect(retry).toEqual(first);
+			expect(queryRetrievalAttempts(store.db, { surface: "mcp_get" })).toHaveLength(1);
+			const secondServer = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			await getTool(secondServer, "memory_get").handler(
+				{ memory_id: greenroomId },
+				requestExtra("retry-request-1", "transport-session-3"),
+			);
+			expect(queryRetrievalAttempts(store.db, { surface: "mcp_get" })).toHaveLength(2);
+
+			expect(
+				purgeRetrievalAttemptsForPrivacy(store.db, { source: "mcp", surface: "mcp_get" }),
+			).toBe(2);
+			expect(queryRetrievalAttempts(store.db, { surface: "mcp_get" })).toEqual([]);
+		});
+
+		it("records repeated completed calls with identical IDs and arguments as new attempts", async () => {
+			const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			const get = getTool(server, "memory_get");
+
+			await get.handler(
+				{ memory_id: greenroomId },
+				requestExtra("reused-success-id", "long-lived-session"),
+			);
+			await get.handler(
+				{ memory_id: greenroomId },
+				requestExtra("reused-success-id", "long-lived-session"),
+			);
+			await get.handler(
+				{ memory_id: greenroomId },
+				requestExtra("different-success-id", "long-lived-session"),
+			);
+
+			const attempts = queryRetrievalAttempts(store.db, { surface: "mcp_get" });
+			expect(attempts).toHaveLength(3);
+			expect(new Set(attempts.map((attempt) => attempt.attemptId)).size).toBe(3);
+			expect(new Set(attempts.map((attempt) => attempt.requestId)).size).toBe(3);
+		});
+
+		it("records repeated completed no-results calls as new attempts", async () => {
+			const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			const search = getTool(server, "memory_search");
+			const args = { query: "no repeated result exists", project: "missing-project", limit: 5 };
+
+			await search.handler(args, requestExtra("reused-empty-id", "long-lived-empty-session"));
+			await search.handler(args, requestExtra("reused-empty-id", "long-lived-empty-session"));
+
+			const attempts = queryRetrievalAttempts(store.db, { surface: "mcp_search" });
+			expect(attempts).toHaveLength(2);
+			expect(attempts.every((attempt) => attempt.retrievalStatus === "no_results")).toBe(true);
+			expect(new Set(attempts.map((attempt) => attempt.requestId)).size).toBe(2);
+		});
+
+		it("includes canonical call content when a transport session reuses a request ID", async () => {
+			const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			const search = getTool(server, "memory_search");
+			const recent = getTool(server, "memory_recent");
+			const extra = requestExtra("reused-request-id", "long-lived-session");
+
+			await search.handler({ query: "direct-ID note", limit: 5, project: "greenroom" }, extra);
+			await search.handler({ project: "greenroom", limit: 5, query: "direct-ID note" }, extra);
+			expect(queryRetrievalAttempts(store.db, { surface: "mcp_search" })).toHaveLength(1);
+
+			await search.handler(
+				{ query: "different call content", limit: 5, project: "greenroom" },
+				extra,
+			);
+			const attempts = queryRetrievalAttempts(store.db, { surface: "mcp_search" });
+			expect(attempts).toHaveLength(2);
+			expect(new Set(attempts.map((attempt) => attempt.requestId)).size).toBe(2);
+
+			await recent.handler({ limit: 5, project: "greenroom" }, extra);
+			const recentAttempt = queryRetrievalAttempts(store.db, { surface: "mcp_recent" })[0];
+			expect(recentAttempt?.requestId).toMatch(/^[a-f0-9]{64}$/);
+			expect(attempts.map((attempt) => attempt.requestId)).not.toContain(recentAttempt?.requestId);
+			for (const attempt of attempts) {
+				expect(attempt.requestId).toMatch(/^[a-f0-9]{64}$/);
+				expect(attempt.requestId).not.toContain("direct-ID note");
+				expect(attempt.requestId).not.toContain("different call content");
+			}
+		});
+
+		it("does not capture when MCP retrieval ledger capture is disabled", async () => {
+			const server = createCodememMcpServer(store, {
+				defaultProject: "greenroom",
+				captureRetrievalLedger: false,
+			});
+			const result = parseToolJson(
+				await getTool(server, "memory_get").handler({ memory_id: greenroomId }),
+			) as { id: number };
+			expect(result.id).toBe(greenroomId);
+			expect(queryRetrievalAttempts(store.db, { surface: "mcp_get" })).toEqual([]);
+		});
+
+		it("records retrieval failures without changing the MCP error response", async () => {
+			const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			vi.spyOn(store, "search").mockImplementationOnce(() => {
+				throw new Error("deterministic search failure");
+			});
+			const response = parseToolJson(
+				await getTool(server, "memory_search").handler({ query: "failure", limit: 5 }),
+			) as { error: string };
+			expect(response.error).toBe("deterministic search failure");
+			expect(
+				queryRetrievalAttempts(store.db, { surface: "mcp_search", limit: 1 })[0],
+			).toMatchObject({
+				retrievalStatus: "failed",
+				deliveryStatus: "not_attempted",
+				failureCode: "tool_failed",
+				filterSummary: { project: "greenroom" },
+			});
+		});
+
+		it("keeps filter resolution failures inside the MCP fail-open boundary", async () => {
+			const context = retrievalContext(store, "filter-resolution-scope");
+			const retrieve = vi.fn(() => ({ value: null, memoryIds: [] }));
+			const response = parseToolJson(
+				await withMcpRetrieval(
+					context,
+					{
+						surface: "mcp_search",
+						toolName: "memory_search",
+						toolArguments: { query: "failure" },
+						query: "failure",
+						resolveFilters: () => {
+							throw new Error("filter resolution failed");
+						},
+					},
+					retrieve,
+				),
+			) as { error: string };
+
+			expect(response.error).toBe("filter resolution failed");
+			expect(retrieve).not.toHaveBeenCalled();
+			expect(
+				queryRetrievalAttempts(store.db, { surface: "mcp_search", limit: 1 })[0],
+			).toMatchObject({
+				retrievalStatus: "failed",
+				deliveryStatus: "not_attempted",
+				filterSummary: null,
+				failureCode: "tool_failed",
+			});
+		});
+
+		it("reconciles a failed MCP request retry into the persisted handed-off success", async () => {
+			const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			const search = getTool(server, "memory_search");
+			const extra = requestExtra("failed-then-successful", "retry-session");
+			const searchSpy = vi.spyOn(store, "search");
+			searchSpy.mockImplementationOnce(() => {
+				throw new Error("transient retrieval failure");
+			});
+
+			await search.handler(
+				{ query: "direct-ID note", limit: 5 },
+				requestExtra("failed-then-successful", "retry-session"),
+			);
+			const failed = queryRetrievalAttempts(store.db, { surface: "mcp_search" })[0];
+			expect(failed).toMatchObject({
+				retrievalStatus: "failed",
+				deliveryStatus: "not_attempted",
+				exposures: [],
+			});
+
+			await search.handler({ query: "direct-ID note", limit: 5 }, extra);
+			const attempts = queryRetrievalAttempts(store.db, { surface: "mcp_search" });
+			expect(attempts).toHaveLength(1);
+			expect(attempts[0]).toMatchObject({
+				attemptId: failed?.attemptId,
+				retrievalStatus: "succeeded",
+				deliveryStatus: "handed_off",
+				failureCode: null,
+			});
+			expect(attempts[0]?.exposures.length).toBeGreaterThan(0);
+			expect(
+				attempts[0]?.exposures.every(
+					(exposure) =>
+						exposure.attemptId === attempts[0]?.attemptId &&
+						exposure.handoffStatus === "handed_off",
+				),
+			).toBe(true);
+
+			searchSpy.mockImplementationOnce(() => {
+				throw new Error("later retrieval failure");
+			});
+			await search.handler(
+				{ query: "direct-ID note", limit: 5 },
+				requestExtra("failed-then-successful", "retry-session"),
+			);
+			const afterLaterFailure = queryRetrievalAttempts(store.db, { surface: "mcp_search" });
+			expect(afterLaterFailure).toHaveLength(2);
+			expect(afterLaterFailure).toContainEqual(attempts[0]);
+			expect(afterLaterFailure.some((attempt) => attempt.retrievalStatus === "failed")).toBe(true);
+		});
+
+		it("reconciles a failed MCP request retry into one persisted no-results completion", async () => {
+			const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			const search = getTool(server, "memory_search");
+			const args = {
+				query: "no memory matches this exact retry query",
+				project: "missing-project",
+				limit: 5,
+			};
+			const extra = requestExtra("failed-then-empty", "empty-retry-session");
+			const searchSpy = vi.spyOn(store, "search");
+			searchSpy.mockImplementationOnce(() => {
+				throw new Error("transient empty retrieval failure");
+			});
+
+			await search.handler(args, extra);
+			const failed = queryRetrievalAttempts(store.db, { surface: "mcp_search" })[0];
+			expect(failed).toMatchObject({
+				retrievalStatus: "failed",
+				deliveryStatus: "not_attempted",
+				exposures: [],
+			});
+
+			await search.handler(args, requestExtra("failed-then-empty", "empty-retry-session"));
+			const attempts = queryRetrievalAttempts(store.db, { surface: "mcp_search" });
+			expect(attempts).toHaveLength(1);
+			expect(attempts[0]).toMatchObject({
+				attemptId: failed?.attemptId,
+				retrievalStatus: "no_results",
+				deliveryStatus: "not_attempted",
+				candidateCount: 0,
+				selectedCount: 0,
+				failureCode: null,
+				exposures: [],
+			});
+
+			searchSpy.mockImplementationOnce(() => {
+				throw new Error("later empty retrieval failure");
+			});
+			await search.handler(args, requestExtra("failed-then-empty", "empty-retry-session"));
+			const afterLaterFailure = queryRetrievalAttempts(store.db, { surface: "mcp_search" });
+			expect(afterLaterFailure).toHaveLength(2);
+			expect(afterLaterFailure).toContainEqual(attempts[0]);
+			expect(afterLaterFailure.some((attempt) => attempt.retrievalStatus === "failed")).toBe(true);
+		});
+
+		it("reconciles an exact failed retry when no results are encoded as not_found", async () => {
+			const context = retrievalContext(store, "not-found-error-retry-scope");
+			const args = { memory_id: 999_999 };
+			const retrySignal = new AbortController().signal;
+			const invoke = (
+				signal: AbortSignal,
+				retrieve: () => Promise<{ value: null; memoryIds: number[]; error?: string }>,
+			) =>
+				withMcpRetrieval(
+					context,
+					{
+						surface: "mcp_get",
+						toolName: "memory_get",
+						toolArguments: args,
+						requestId: "failed-then-not-found",
+						sourceSessionId: "not-found-error-retry-session",
+						invocationIdentity: signal,
+					},
+					retrieve,
+				);
+
+			await invoke(new AbortController().signal, async () => {
+				throw new Error("transient direct lookup failure");
+			});
+			const failed = queryRetrievalAttempts(store.db, { surface: "mcp_get" })[0];
+			expect(failed).toMatchObject({
+				retrievalStatus: "failed",
+				deliveryStatus: "not_attempted",
+			});
+
+			const notFound = async () => ({ value: null, memoryIds: [], error: "not_found" });
+			expect(parseToolJson(await invoke(retrySignal, notFound))).toEqual({ error: "not_found" });
+			expect(parseToolJson(await invoke(retrySignal, notFound))).toEqual({ error: "not_found" });
+
+			const attempts = queryRetrievalAttempts(store.db, { surface: "mcp_get" });
+			expect(attempts).toHaveLength(1);
+			expect(attempts[0]).toMatchObject({
+				attemptId: failed?.attemptId,
+				retrievalStatus: "no_results",
+				deliveryStatus: "not_attempted",
+				candidateCount: 0,
+				selectedCount: 0,
+				failureCode: null,
+				exposures: [],
+			});
+		});
+
+		it("preserves ordinary error content as a failed retrieval", async () => {
+			const context = retrievalContext(store, "error-content-scope");
+			const signal = new AbortController().signal;
+			const invoke = () =>
+				withMcpRetrieval(
+					context,
+					{
+						surface: "mcp_get",
+						toolName: "memory_get",
+						toolArguments: { memory_id: greenroomId },
+						requestId: "ordinary-error-content",
+						sourceSessionId: "ordinary-error-session",
+						invocationIdentity: signal,
+					},
+					async () => ({
+						value: null,
+						memoryIds: [],
+						error: "permission_denied",
+					}),
+				);
+
+			expect(parseToolJson(await invoke())).toEqual({ error: "permission_denied" });
+			expect(parseToolJson(await invoke())).toEqual({ error: "permission_denied" });
+
+			const attempts = queryRetrievalAttempts(store.db, { surface: "mcp_get" });
+			expect(attempts).toHaveLength(1);
+			expect(attempts[0]).toMatchObject({
+				retrievalStatus: "failed",
+				deliveryStatus: "not_attempted",
+				candidateCount: 0,
+				selectedCount: 0,
+				failureCode: "tool_failed",
+				failureStage: "retrieval",
+				exposures: [],
+			});
+		});
+
+		it("keeps concurrent identical successful invocations distinct", async () => {
+			const context: ToolRegistrationContext = {
+				store,
+				defaultProject: () => "greenroom",
+				envProject: () => null,
+				captureRetrievalLedger: true,
+				retrievalLedgerScopeId: "concurrent-ledger-scope",
+				retrievalLedgerIdentityMode: "session",
+			};
+			let release!: () => void;
+			const gate = new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			const call = (signal: AbortSignal) =>
+				withMcpRetrieval(
+					context,
+					{
+						surface: "mcp_get",
+						toolName: "memory_get",
+						toolArguments: { memory_id: greenroomId },
+						requestId: "concurrent-reused-id",
+						sourceSessionId: "concurrent-session",
+						invocationIdentity: signal,
+					},
+					async () => {
+						await gate;
+						return { value: { id: greenroomId }, memoryIds: [greenroomId] };
+					},
+				);
+
+			const first = call(new AbortController().signal);
+			const second = call(new AbortController().signal);
+			release();
+			await Promise.all([first, second]);
+
+			const attempts = queryRetrievalAttempts(store.db, { surface: "mcp_get" });
+			expect(attempts).toHaveLength(2);
+			expect(new Set(attempts.map((attempt) => attempt.requestId)).size).toBe(2);
+		});
+
+		it("reconciles a concurrent failure after its successful sibling completes", async () => {
+			const context = retrievalContext(store, "failure-success-race-scope");
+			const args = { memory_id: greenroomId };
+			let rejectFailure!: (error: Error) => void;
+			let resolveSuccess!: () => void;
+			const failureGate = new Promise<never>((_resolve, reject) => {
+				rejectFailure = reject;
+			});
+			const successGate = new Promise<void>((resolve) => {
+				resolveSuccess = resolve;
+			});
+			const invoke = (
+				signal: AbortSignal,
+				retrieve: () => Promise<{ value: object; memoryIds: number[] }>,
+			) =>
+				withMcpRetrieval(
+					context,
+					{
+						surface: "mcp_get",
+						toolName: "memory_get",
+						toolArguments: args,
+						requestId: "failure-success-race",
+						sourceSessionId: "failure-success-session",
+						invocationIdentity: signal,
+					},
+					retrieve,
+				);
+
+			const failedCall = invoke(new AbortController().signal, () => failureGate);
+			const successfulSibling = invoke(new AbortController().signal, async () => {
+				await successGate;
+				return { value: { id: greenroomId }, memoryIds: [greenroomId] };
+			});
+			rejectFailure(new Error("concurrent transient failure"));
+			await failedCall;
+			const failedAttempt = queryRetrievalAttempts(store.db, { surface: "mcp_get" }).find(
+				(attempt) => attempt.retrievalStatus === "failed",
+			);
+			if (!failedAttempt) throw new Error("expected concurrent failed attempt");
+			resolveSuccess();
+			await successfulSibling;
+
+			await invoke(new AbortController().signal, async () => ({
+				value: { id: greenroomId },
+				memoryIds: [greenroomId],
+			}));
+
+			const attempts = queryRetrievalAttempts(store.db, { surface: "mcp_get" });
+			expect(attempts).toHaveLength(2);
+			expect(attempts.every((attempt) => attempt.retrievalStatus === "succeeded")).toBe(true);
+			expect(getRetrievalAttempt(store.db, failedAttempt.attemptId)).toMatchObject({
+				attemptId: failedAttempt.attemptId,
+				retrievalStatus: "succeeded",
+				deliveryStatus: "handed_off",
+			});
+		});
+
+		it("reconciles two concurrent failures one-for-one with sequential successes", async () => {
+			const context = retrievalContext(store, "two-failure-fifo-scope");
+			const args = { memory_id: greenroomId };
+			const invoke = (
+				signal: AbortSignal,
+				retrieve: () => Promise<{ value: object; memoryIds: number[] }>,
+			) =>
+				withMcpRetrieval(
+					context,
+					{
+						surface: "mcp_get",
+						toolName: "memory_get",
+						toolArguments: args,
+						requestId: "two-concurrent-failures",
+						sourceSessionId: "two-failure-session",
+						invocationIdentity: signal,
+					},
+					retrieve,
+				);
+			let rejectFirst!: (error: Error) => void;
+			let rejectSecond!: (error: Error) => void;
+			const firstGate = new Promise<never>((_resolve, reject) => {
+				rejectFirst = reject;
+			});
+			const secondGate = new Promise<never>((_resolve, reject) => {
+				rejectSecond = reject;
+			});
+
+			const firstFailure = invoke(new AbortController().signal, () => firstGate);
+			const secondFailure = invoke(new AbortController().signal, () => secondGate);
+			rejectFirst(new Error("first concurrent failure"));
+			await firstFailure;
+			const firstAttempt = queryRetrievalAttempts(store.db, { surface: "mcp_get" })[0];
+			if (!firstAttempt) throw new Error("expected first concurrent failed attempt");
+			rejectSecond(new Error("second concurrent failure"));
+			await secondFailure;
+			const secondAttempt = queryRetrievalAttempts(store.db, { surface: "mcp_get" }).find(
+				(attempt) => attempt.attemptId !== firstAttempt.attemptId,
+			);
+			if (!secondAttempt) throw new Error("expected second concurrent failed attempt");
+
+			const succeed = () =>
+				invoke(new AbortController().signal, async () => ({
+					value: { id: greenroomId },
+					memoryIds: [greenroomId],
+				}));
+			await succeed();
+			expect(getRetrievalAttempt(store.db, firstAttempt.attemptId)?.retrievalStatus).toBe(
+				"succeeded",
+			);
+			expect(getRetrievalAttempt(store.db, secondAttempt.attemptId)?.retrievalStatus).toBe(
+				"failed",
+			);
+			await succeed();
+
+			const attempts = queryRetrievalAttempts(store.db, { surface: "mcp_get" });
+			expect(attempts).toHaveLength(2);
+			expect(attempts.every((attempt) => attempt.retrievalStatus === "succeeded")).toBe(true);
+		});
+
+		it("does not let completed active siblings consume or erase a pending failure", async () => {
+			const context = retrievalContext(store, "pending-slot-ownership-scope");
+			const args = { memory_id: greenroomId };
+			let resolveSibling!: () => void;
+			const siblingGate = new Promise<void>((resolve) => {
+				resolveSibling = resolve;
+			});
+			const invoke = (retrieve: () => Promise<{ value: object; memoryIds: number[] }>) =>
+				withMcpRetrieval(
+					context,
+					{
+						surface: "mcp_get",
+						toolName: "memory_get",
+						toolArguments: args,
+						requestId: "pending-slot-ownership",
+						sourceSessionId: "pending-slot-session",
+						invocationIdentity: new AbortController().signal,
+					},
+					retrieve,
+				);
+
+			const activeSibling = invoke(async () => {
+				await siblingGate;
+				return { value: { id: greenroomId }, memoryIds: [greenroomId] };
+			});
+			await invoke(async () => {
+				throw new Error("failure while sibling active");
+			});
+			const failedAttempt = queryRetrievalAttempts(store.db, { surface: "mcp_get" }).find(
+				(attempt) => attempt.retrievalStatus === "failed",
+			);
+			if (!failedAttempt) throw new Error("expected pending failed attempt");
+			await invoke(async () => ({ value: { id: greenroomId }, memoryIds: [greenroomId] }));
+			resolveSibling();
+			await activeSibling;
+			expect(getRetrievalAttempt(store.db, failedAttempt.attemptId)?.retrievalStatus).toBe(
+				"failed",
+			);
+
+			await invoke(async () => ({ value: { id: greenroomId }, memoryIds: [greenroomId] }));
+			expect(getRetrievalAttempt(store.db, failedAttempt.attemptId)?.retrievalStatus).toBe(
+				"succeeded",
+			);
+			expect(queryRetrievalAttempts(store.db, { surface: "mcp_get" })).toHaveLength(3);
+		});
+
+		it("keeps successful MCP results fail-open when identity bookkeeping throws", async () => {
+			const context = retrievalContext(store, "hostile-identity-scope");
+			const circularArguments: { self?: unknown } = {};
+			circularArguments.self = circularArguments;
+			const result = parseToolJson(
+				await withMcpRetrieval(
+					context,
+					{
+						surface: "mcp_get",
+						toolName: "memory_get",
+						toolArguments: circularArguments,
+						requestId: "hostile-canonical-args",
+						sourceSessionId: "hostile-session",
+						invocationIdentity: new AbortController().signal,
+					},
+					async () => ({ value: { id: greenroomId }, memoryIds: [greenroomId] }),
+				),
+			) as { id: number };
+			expect(result.id).toBe(greenroomId);
+
+			Object.defineProperty(context, "retrievalLedgerIdentityMode", {
+				get: () => {
+					throw new Error("hostile tracker mode getter");
+				},
+			});
+			const second = parseToolJson(
+				await withMcpRetrieval(
+					context,
+					{
+						surface: "mcp_get",
+						toolName: "memory_get",
+						toolArguments: { memory_id: greenroomId },
+						requestId: "hostile-completion",
+						sourceSessionId: "hostile-session",
+					},
+					async () => ({ value: { id: greenroomId }, memoryIds: [greenroomId] }),
+				),
+			) as { id: number };
+			expect(second.id).toBe(greenroomId);
+			const attempts = queryRetrievalAttempts(store.db, { surface: "mcp_get" });
+			expect(attempts).toHaveLength(2);
+			expect(attempts.every((attempt) => attempt.retrievalStatus === "succeeded")).toBe(true);
+			expect(attempts.every((attempt) => attempt.failureCode === null)).toBe(true);
+		});
+
+		it("keeps MCP delivery fail-open when ledger tables are unavailable", async () => {
+			const server = createCodememMcpServer(store, { defaultProject: "greenroom" });
+			store.db.exec("DROP TABLE retrieval_exposures; DROP TABLE retrieval_attempts;");
+			const response = parseToolJson(
+				await getTool(server, "memory_get").handler({ memory_id: greenroomId }),
+			) as { id: number };
+			expect(response.id).toBe(greenroomId);
+		});
 	});
 });
 
@@ -433,6 +1157,17 @@ function insertSession(
 		)
 		.run(now, input.cwd, input.project, "mcp-test", "test");
 	return Number(info.lastInsertRowid);
+}
+
+function retrievalContext(store: MemoryStore, scopeId: string): ToolRegistrationContext {
+	return {
+		store,
+		defaultProject: () => "greenroom",
+		envProject: () => null,
+		captureRetrievalLedger: true,
+		retrievalLedgerScopeId: scopeId,
+		retrievalLedgerIdentityMode: "session",
+	};
 }
 
 function insertCoordinatorScope(db: ReturnType<typeof connect>, scopeId: string): void {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { type MemoryStore, VERSION } from "@codemem/core";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { resolveDefaultProject } from "./project-scope.js";
@@ -25,6 +26,9 @@ export function createCodememMcpServer(
 		},
 		envProject: () =>
 			options.envProject !== undefined ? options.envProject : (process.env.CODEMEM_PROJECT ?? null),
+		captureRetrievalLedger: options.captureRetrievalLedger !== false,
+		retrievalLedgerScopeId: options.retrievalLedgerScopeId ?? randomUUID(),
+		retrievalLedgerIdentityMode: options.retrievalLedgerIdentityMode ?? "session",
 	};
 
 	registerSearchTools(server, context);

--- a/packages/mcp-server/src/tool-context.ts
+++ b/packages/mcp-server/src/tool-context.ts
@@ -4,10 +4,17 @@ export interface CodememMcpServerOptions {
 	defaultProject?: string | null;
 	resolveDefaultProject?: () => string | null;
 	envProject?: string | null;
+	captureRetrievalLedger?: boolean;
+	retrievalLedgerScopeId?: string;
+	/** Stateless transports retain request-level retry dedupe; sessions count each dispatched call. */
+	retrievalLedgerIdentityMode?: "session" | "stateless";
 }
 
 export interface ToolRegistrationContext {
 	store: MemoryStore;
 	defaultProject: () => string | null;
 	envProject: () => string | null;
+	captureRetrievalLedger: boolean;
+	retrievalLedgerScopeId: string;
+	retrievalLedgerIdentityMode: "session" | "stateless";
 }

--- a/packages/mcp-server/src/tools/items.ts
+++ b/packages/mcp-server/src/tools/items.ts
@@ -2,6 +2,7 @@ import { storeVectors } from "@codemem/core";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { errorContent, jsonContent } from "../content.js";
+import { withMcpRetrieval } from "../mcp-retrieval-ledger.js";
 import {
 	forgetMemoryForMcp,
 	getManyForMcp,
@@ -22,16 +23,28 @@ export function registerItemTools(server: McpServer, context: ToolRegistrationCo
 			memory_id: z.number().int().describe("Memory ID"),
 			...filterSchema,
 		},
-		async (args) => {
-			try {
-				// Direct-ID ops do not inherit the server default project. Callers already
-				// have an exact ID; cwd/env should not silently scope the lookup.
-				const item = getMemoryForMcp(store, args.memory_id, buildFilters(args, null));
-				if (!item) return errorContent("not_found");
-				return jsonContent(item);
-			} catch (err) {
-				return errorContent(err instanceof Error ? err.message : String(err));
-			}
+		async (args, extra) => {
+			// Direct-ID ops do not inherit the server default project. Callers already
+			// have an exact ID; cwd/env should not silently scope the lookup.
+			return withMcpRetrieval(
+				context,
+				{
+					surface: "mcp_get",
+					toolName: "memory_get",
+					toolArguments: args,
+					limit: 1,
+					resolveFilters: () => buildFilters(args, null),
+					requestId: extra?.requestId,
+					sourceSessionId: extra?.sessionId,
+					invocationIdentity: extra?.signal,
+				},
+				(filters) => {
+					const item = getMemoryForMcp(store, args.memory_id, filters);
+					return item
+						? { value: item, memoryIds: [item.id], filters }
+						: { value: null, memoryIds: [], error: "not_found", filters };
+				},
+			);
 		},
 	);
 
@@ -42,13 +55,24 @@ export function registerItemTools(server: McpServer, context: ToolRegistrationCo
 			ids: z.array(z.number().int()).max(200).describe("Memory IDs to fetch"),
 			...filterSchema,
 		},
-		async (args) => {
-			try {
-				const items = getManyForMcp(store, args.ids, buildFilters(args, null));
-				return jsonContent({ items });
-			} catch (err) {
-				return errorContent(err instanceof Error ? err.message : String(err));
-			}
+		async (args, extra) => {
+			return withMcpRetrieval(
+				context,
+				{
+					surface: "mcp_get_observations",
+					toolName: "memory_get_observations",
+					toolArguments: args,
+					limit: args.ids.length,
+					resolveFilters: () => buildFilters(args, null),
+					requestId: extra?.requestId,
+					sourceSessionId: extra?.sessionId,
+					invocationIdentity: extra?.signal,
+				},
+				(filters) => {
+					const items = getManyForMcp(store, args.ids, filters);
+					return { value: { items }, memoryIds: items.map((item) => item.id), filters };
+				},
+			);
 		},
 	);
 

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -1,7 +1,7 @@
 import type { MemoryResult } from "@codemem/core";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { errorContent, jsonContent } from "../content.js";
+import { withMcpRetrieval } from "../mcp-retrieval-ledger.js";
 import { buildFilters } from "../project-scope.js";
 import { filterSchema } from "../schemas.js";
 import type { ToolRegistrationContext } from "../tool-context.js";
@@ -17,25 +17,40 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 			limit: z.number().int().min(1).max(50).default(5).describe("Max results"),
 			...filterSchema,
 		},
-		async (args) => {
-			try {
-				const filters = buildFilters(args, defaultProject());
-				const items = store.search(args.query, args.limit, filters);
-				return jsonContent({
-					items: items.map((m: MemoryResult) => ({
-						id: m.id,
-						title: m.title,
-						kind: m.kind,
-						body: m.body_text,
-						confidence: m.confidence,
-						score: m.score,
-						session_id: m.session_id,
-						metadata: m.metadata,
-					})),
-				});
-			} catch (err) {
-				return errorContent(err instanceof Error ? err.message : String(err));
-			}
+		async (args, extra) => {
+			return withMcpRetrieval(
+				context,
+				{
+					surface: "mcp_search",
+					toolName: "memory_search",
+					toolArguments: args,
+					query: args.query,
+					limit: args.limit,
+					resolveFilters: () => buildFilters(args, defaultProject()),
+					requestId: extra?.requestId,
+					sourceSessionId: extra?.sessionId,
+					invocationIdentity: extra?.signal,
+				},
+				(filters) => {
+					const items = store.search(args.query, args.limit, filters);
+					return {
+						value: {
+							items: items.map((m: MemoryResult) => ({
+								id: m.id,
+								title: m.title,
+								kind: m.kind,
+								body: m.body_text,
+								confidence: m.confidence,
+								score: m.score,
+								session_id: m.session_id,
+								metadata: m.metadata,
+							})),
+						},
+						memoryIds: items.map((item) => item.id),
+						filters,
+					};
+				},
+			);
 		},
 	);
 
@@ -47,24 +62,39 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 			limit: z.number().int().min(1).max(50).default(8).describe("Max results"),
 			...filterSchema,
 		},
-		async (args) => {
-			try {
-				const filters = buildFilters(args, defaultProject());
-				const items = store.search(args.query, args.limit, filters);
-				return jsonContent({
-					items: items.map((m: MemoryResult) => ({
-						id: m.id,
-						kind: m.kind,
-						title: m.title,
-						score: m.score,
-						created_at: m.created_at,
-						session_id: m.session_id,
-						metadata: m.metadata,
-					})),
-				});
-			} catch (err) {
-				return errorContent(err instanceof Error ? err.message : String(err));
-			}
+		async (args, extra) => {
+			return withMcpRetrieval(
+				context,
+				{
+					surface: "mcp_search_index",
+					toolName: "memory_search_index",
+					toolArguments: args,
+					query: args.query,
+					limit: args.limit,
+					resolveFilters: () => buildFilters(args, defaultProject()),
+					requestId: extra?.requestId,
+					sourceSessionId: extra?.sessionId,
+					invocationIdentity: extra?.signal,
+				},
+				(filters) => {
+					const items = store.search(args.query, args.limit, filters);
+					return {
+						value: {
+							items: items.map((m: MemoryResult) => ({
+								id: m.id,
+								kind: m.kind,
+								title: m.title,
+								score: m.score,
+								created_at: m.created_at,
+								session_id: m.session_id,
+								metadata: m.metadata,
+							})),
+						},
+						memoryIds: items.map((item) => item.id),
+						filters,
+					};
+				},
+			);
 		},
 	);
 
@@ -78,16 +108,27 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 			include_pack_context: z.boolean().default(false).describe("Include formatted pack context"),
 			...filterSchema,
 		},
-		async (args) => {
-			try {
-				const filters = buildFilters(args, defaultProject());
-				const result = store.explain(args.query ?? null, args.ids ?? null, args.limit, filters, {
-					includePackContext: args.include_pack_context,
-				});
-				return jsonContent(result);
-			} catch (err) {
-				return errorContent(err instanceof Error ? err.message : String(err));
-			}
+		async (args, extra) => {
+			return withMcpRetrieval(
+				context,
+				{
+					surface: "mcp_explain",
+					toolName: "memory_explain",
+					toolArguments: args,
+					query: args.query,
+					limit: args.limit,
+					resolveFilters: () => buildFilters(args, defaultProject()),
+					requestId: extra?.requestId,
+					sourceSessionId: extra?.sessionId,
+					invocationIdentity: extra?.signal,
+				},
+				(filters) => {
+					const result = store.explain(args.query ?? null, args.ids ?? null, args.limit, filters, {
+						includePackContext: args.include_pack_context,
+					});
+					return { value: result, memoryIds: result.items.map((item) => item.id), filters };
+				},
+			);
 		},
 	);
 
@@ -98,14 +139,24 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 			limit: z.number().int().min(1).max(100).default(8).describe("Max results"),
 			...filterSchema,
 		},
-		async (args) => {
-			try {
-				const filters = buildFilters(args, defaultProject());
-				const items = store.recent(args.limit, filters);
-				return jsonContent({ items });
-			} catch (err) {
-				return errorContent(err instanceof Error ? err.message : String(err));
-			}
+		async (args, extra) => {
+			return withMcpRetrieval(
+				context,
+				{
+					surface: "mcp_recent",
+					toolName: "memory_recent",
+					toolArguments: args,
+					limit: args.limit,
+					resolveFilters: () => buildFilters(args, defaultProject()),
+					requestId: extra?.requestId,
+					sourceSessionId: extra?.sessionId,
+					invocationIdentity: extra?.signal,
+				},
+				(filters) => {
+					const items = store.recent(args.limit, filters);
+					return { value: { items }, memoryIds: items.map((item) => item.id), filters };
+				},
+			);
 		},
 	);
 
@@ -136,28 +187,39 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 				),
 			...filterSchema,
 		},
-		async (args) => {
-			try {
-				const filters = buildFilters(args, defaultProject());
-				const renderOptions =
-					args.compact || args.compact_detail_count != null || args.compression_mode != null
-						? {
-								compact: args.compact ?? (args.compact_detail_count != null ? true : undefined),
-								compactDetailCount: args.compact_detail_count,
-								compressionMode: args.compression_mode,
-							}
-						: undefined;
-				const result = await store.buildMemoryPackAsync(
-					args.context,
-					args.limit ?? undefined,
-					null,
-					filters,
-					renderOptions,
-				);
-				return jsonContent(result);
-			} catch (err) {
-				return errorContent(err instanceof Error ? err.message : String(err));
-			}
+		async (args, extra) => {
+			return withMcpRetrieval(
+				context,
+				{
+					surface: "mcp_pack",
+					toolName: "memory_pack",
+					toolArguments: args,
+					query: args.context,
+					limit: args.limit ?? null,
+					resolveFilters: () => buildFilters(args, defaultProject()),
+					requestId: extra?.requestId,
+					sourceSessionId: extra?.sessionId,
+					invocationIdentity: extra?.signal,
+				},
+				async (filters) => {
+					const renderOptions =
+						args.compact || args.compact_detail_count != null || args.compression_mode != null
+							? {
+									compact: args.compact ?? (args.compact_detail_count != null ? true : undefined),
+									compactDetailCount: args.compact_detail_count,
+									compressionMode: args.compression_mode,
+								}
+							: undefined;
+					const result = await store.buildMemoryPackAsync(
+						args.context,
+						args.limit ?? undefined,
+						null,
+						filters,
+						renderOptions,
+					);
+					return { value: result, memoryIds: result.item_ids, filters };
+				},
+			);
 		},
 	);
 }

--- a/packages/mcp-server/src/tools/timeline.ts
+++ b/packages/mcp-server/src/tools/timeline.ts
@@ -1,7 +1,7 @@
 import { dedupeOrderedIds, type MemoryItemResponse, projectMatchesFilter } from "@codemem/core";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { errorContent, jsonContent } from "../content.js";
+import { withMcpRetrieval } from "../mcp-retrieval-ledger.js";
 import { getManyForMcp } from "../memory-access.js";
 import { buildFilters } from "../project-scope.js";
 import { filterSchema } from "../schemas.js";
@@ -20,20 +20,31 @@ export function registerTimelineTools(server: McpServer, context: ToolRegistrati
 			depth_after: z.number().int().min(0).default(3).describe("Items after anchor"),
 			...filterSchema,
 		},
-		async (args) => {
-			try {
-				const filters = buildFilters(args, defaultProject());
-				const items = store.timeline(
-					args.query ?? null,
-					args.memory_id ?? null,
-					args.depth_before,
-					args.depth_after,
-					filters,
-				);
-				return jsonContent({ items });
-			} catch (err) {
-				return errorContent(err instanceof Error ? err.message : String(err));
-			}
+		async (args, extra) => {
+			return withMcpRetrieval(
+				context,
+				{
+					surface: "mcp_timeline",
+					toolName: "memory_timeline",
+					toolArguments: args,
+					query: args.query,
+					limit: args.depth_before + args.depth_after + 1,
+					resolveFilters: () => buildFilters(args, defaultProject()),
+					requestId: extra?.requestId,
+					sourceSessionId: extra?.sessionId,
+					invocationIdentity: extra?.signal,
+				},
+				(filters) => {
+					const items = store.timeline(
+						args.query ?? null,
+						args.memory_id ?? null,
+						args.depth_before,
+						args.depth_after,
+						filters,
+					);
+					return { value: { items }, memoryIds: items.map((item) => item.id), filters };
+				},
+			);
 		},
 	);
 
@@ -50,140 +61,159 @@ export function registerTimelineTools(server: McpServer, context: ToolRegistrati
 			include_observations: z.boolean().default(false).describe("Include full observation details"),
 			...filterSchema,
 		},
-		async (args) => {
-			try {
-				// Explicit blank `project` clears scoping for cross-project expansion.
-				// Only fall back to the server default when `project` is omitted entirely.
-				const filterDefaultProject =
-					args.project !== undefined && !args.project.trim() ? null : defaultProject();
-				const filters = buildFilters(args, filterDefaultProject);
-				const resolvedProject = filters?.project ?? null;
-				const { ordered: orderedIds, invalid: invalidIds } = dedupeOrderedIds(args.ids);
-				const errors: Array<Record<string, unknown>> = [];
+		async (args, extra) => {
+			return withMcpRetrieval(
+				context,
+				{
+					surface: "mcp_expand",
+					toolName: "memory_expand",
+					toolArguments: args,
+					limit: args.ids.length,
+					resolveFilters: () => {
+						// Explicit blank `project` clears scoping for cross-project expansion.
+						// Only fall back to the server default when `project` is omitted entirely.
+						const filterDefaultProject =
+							args.project !== undefined && !args.project.trim() ? null : defaultProject();
+						return buildFilters(args, filterDefaultProject);
+					},
+					requestId: extra?.requestId,
+					sourceSessionId: extra?.sessionId,
+					invocationIdentity: extra?.signal,
+				},
+				(filters) => {
+					const resolvedProject = filters?.project ?? null;
+					const { ordered: orderedIds, invalid: invalidIds } = dedupeOrderedIds(args.ids);
+					const errors: Array<Record<string, unknown>> = [];
 
-				if (invalidIds.length > 0) {
-					errors.push({
-						code: "INVALID_ARGUMENT",
-						field: "ids",
-						message: "some ids are not valid integers",
-						ids: invalidIds,
-					});
-				}
-
-				const missingNotFound: number[] = [];
-				const missingProjectMismatch: number[] = [];
-				const missingFilterMismatch: number[] = [];
-				const anchors: MemoryItemResponse[] = [];
-				const timelineItems: MemoryItemResponse[] = [];
-				const timelineSeen = new Set<number>();
-				const sessionProjects = new Map<number, string | null>();
-
-				for (const memoryId of orderedIds) {
-					const item = store.get(memoryId);
-					if (!item?.active) {
-						missingNotFound.push(memoryId);
-						continue;
+					if (invalidIds.length > 0) {
+						errors.push({
+							code: "INVALID_ARGUMENT",
+							field: "ids",
+							message: "some ids are not valid integers",
+							ids: invalidIds,
+						});
 					}
 
-					const sessionId = item.session_id;
-					if (resolvedProject && sessionId > 0) {
-						if (!sessionProjects.has(sessionId)) {
-							const row = store.db
-								.prepare("SELECT project FROM sessions WHERE id = ? LIMIT 1")
-								.get(sessionId) as { project: string | null } | undefined;
-							sessionProjects.set(sessionId, typeof row?.project === "string" ? row.project : null);
+					const missingNotFound: number[] = [];
+					const missingProjectMismatch: number[] = [];
+					const missingFilterMismatch: number[] = [];
+					const anchors: MemoryItemResponse[] = [];
+					const timelineItems: MemoryItemResponse[] = [];
+					const timelineSeen = new Set<number>();
+					const sessionProjects = new Map<number, string | null>();
+
+					for (const memoryId of orderedIds) {
+						const item = store.get(memoryId);
+						if (!item?.active) {
+							missingNotFound.push(memoryId);
+							continue;
 						}
-						if (!projectMatchesFilter(resolvedProject, sessionProjects.get(sessionId) ?? null)) {
+
+						const sessionId = item.session_id;
+						if (resolvedProject && sessionId > 0) {
+							if (!sessionProjects.has(sessionId)) {
+								const row = store.db
+									.prepare("SELECT project FROM sessions WHERE id = ? LIMIT 1")
+									.get(sessionId) as { project: string | null } | undefined;
+								sessionProjects.set(
+									sessionId,
+									typeof row?.project === "string" ? row.project : null,
+								);
+							}
+							if (!projectMatchesFilter(resolvedProject, sessionProjects.get(sessionId) ?? null)) {
+								missingProjectMismatch.push(memoryId);
+								continue;
+							}
+						} else if (resolvedProject && sessionId <= 0) {
 							missingProjectMismatch.push(memoryId);
 							continue;
 						}
-					} else if (resolvedProject && sessionId <= 0) {
-						missingProjectMismatch.push(memoryId);
-						continue;
-					}
 
-					const expanded = store.timeline(
-						null,
-						memoryId,
-						args.depth_before,
-						args.depth_after,
-						filters,
-					);
-					const anchor = expanded.find((expandedItem) => expandedItem.id === memoryId);
-					if (!anchor) {
-						missingFilterMismatch.push(memoryId);
-						continue;
-					}
+						const expanded = store.timeline(
+							null,
+							memoryId,
+							args.depth_before,
+							args.depth_after,
+							filters,
+						);
+						const anchor = expanded.find((expandedItem) => expandedItem.id === memoryId);
+						if (!anchor) {
+							missingFilterMismatch.push(memoryId);
+							continue;
+						}
 
-					anchors.push(anchor);
-					for (const expandedItem of expanded) {
-						const expandedId = expandedItem.id;
-						if (expandedId <= 0 || timelineSeen.has(expandedId)) continue;
-						timelineSeen.add(expandedId);
-						timelineItems.push(expandedItem);
-					}
-				}
-
-				if (missingNotFound.length > 0) {
-					errors.push({
-						code: "NOT_FOUND",
-						field: "ids",
-						message: "some requested ids were not found",
-						ids: missingNotFound,
-					});
-				}
-				if (missingProjectMismatch.length > 0) {
-					errors.push({
-						code: "PROJECT_MISMATCH",
-						field: "project",
-						message: "some requested ids are outside the requested project scope",
-						ids: missingProjectMismatch,
-					});
-				}
-				if (missingFilterMismatch.length > 0) {
-					errors.push({
-						code: "FILTER_MISMATCH",
-						field: "filters",
-						message: "some requested ids are outside the requested filters",
-						ids: missingFilterMismatch,
-					});
-				}
-
-				let observations: MemoryItemResponse[] = [];
-				if (args.include_observations) {
-					const observationSeen = new Set<number>();
-					const observationIds: number[] = [];
-					for (const item of [...anchors, ...timelineItems]) {
-						if (item.id > 0 && !observationSeen.has(item.id)) {
-							observationSeen.add(item.id);
-							observationIds.push(item.id);
+						anchors.push(anchor);
+						for (const expandedItem of expanded) {
+							const expandedId = expandedItem.id;
+							if (expandedId <= 0 || timelineSeen.has(expandedId)) continue;
+							timelineSeen.add(expandedId);
+							timelineItems.push(expandedItem);
 						}
 					}
-					observations = getManyForMcp(store, observationIds, filters);
-				}
 
-				return jsonContent({
-					anchors,
-					timeline: timelineItems,
-					observations,
-					missing_ids: orderedIds.filter(
-						(memoryId: number) =>
-							missingNotFound.includes(memoryId) ||
-							missingProjectMismatch.includes(memoryId) ||
-							missingFilterMismatch.includes(memoryId),
-					),
-					errors,
-					metadata: {
-						project: resolvedProject,
-						requested_ids_count: orderedIds.length,
-						returned_anchor_count: anchors.length,
-						timeline_count: timelineItems.length,
-						include_observations: args.include_observations,
-					},
-				});
-			} catch (err) {
-				return errorContent(err instanceof Error ? err.message : String(err));
-			}
+					if (missingNotFound.length > 0) {
+						errors.push({
+							code: "NOT_FOUND",
+							field: "ids",
+							message: "some requested ids were not found",
+							ids: missingNotFound,
+						});
+					}
+					if (missingProjectMismatch.length > 0) {
+						errors.push({
+							code: "PROJECT_MISMATCH",
+							field: "project",
+							message: "some requested ids are outside the requested project scope",
+							ids: missingProjectMismatch,
+						});
+					}
+					if (missingFilterMismatch.length > 0) {
+						errors.push({
+							code: "FILTER_MISMATCH",
+							field: "filters",
+							message: "some requested ids are outside the requested filters",
+							ids: missingFilterMismatch,
+						});
+					}
+
+					let observations: MemoryItemResponse[] = [];
+					if (args.include_observations) {
+						const observationSeen = new Set<number>();
+						const observationIds: number[] = [];
+						for (const item of [...anchors, ...timelineItems]) {
+							if (item.id > 0 && !observationSeen.has(item.id)) {
+								observationSeen.add(item.id);
+								observationIds.push(item.id);
+							}
+						}
+						observations = getManyForMcp(store, observationIds, filters);
+					}
+
+					const value = {
+						anchors,
+						timeline: timelineItems,
+						observations,
+						missing_ids: orderedIds.filter(
+							(memoryId: number) =>
+								missingNotFound.includes(memoryId) ||
+								missingProjectMismatch.includes(memoryId) ||
+								missingFilterMismatch.includes(memoryId),
+						),
+						errors,
+						metadata: {
+							project: resolvedProject,
+							requested_ids_count: orderedIds.length,
+							returned_anchor_count: anchors.length,
+							timeline_count: timelineItems.length,
+							include_observations: args.include_observations,
+						},
+					};
+					const memoryIds = [
+						...new Set([...anchors, ...timelineItems, ...observations].map((item) => item.id)),
+					];
+					return { value, memoryIds, filters };
+				},
+			);
 		},
 	);
 }


### PR DESCRIPTION
## Description

Extends the common retrieval evidence contract to Claude file-context retrieval and explicit MCP memory surfaces. File-context events distinguish gating, selection, delivery, and failure while storing repository-relative path identity rather than unnecessary absolute paths. MCP tools record filters, returned memory identities, latency, and delivery independently from automatic injection.

All instrumentation remains fail-open and preserves existing CLI and MCP response contracts.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

Validated as part of the completed attribution stack with the repository TypeScript, lint, and Vitest gates. Added coverage for path sanitization, scope filtering, disabled capture, ledger failures, successful delivery, and unchanged MCP responses.

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced