### PR TITLE
fix(e2e): correct sharing dogfood onboarding

### DIFF
--- a/docker-compose.dogfood.yml
+++ b/docker-compose.dogfood.yml
@@ -15,10 +15,14 @@ services:
 
   peer-b:
     <<: *dogfood-viewer
+    environment:
+      CODEMEM_SYNC_ADVERTISE: http://peer-b:7337
     ports:
       - "127.0.0.1:38882:38888"
 
   peer-c:
     <<: *dogfood-viewer
+    environment:
+      CODEMEM_SYNC_ADVERTISE: http://peer-c:7337
     ports:
       - "127.0.0.1:38883:38888"

--- a/docs/plans/2026-07-23-disposable-sharing-dogfood-design.md
+++ b/docs/plans/2026-07-23-disposable-sharing-dogfood-design.md
@@ -29,7 +29,7 @@ Run one fixed Compose project, `codemem-dogfood`, with isolated named volumes:
 - `peer-b`: teammate profile, viewer at `http://127.0.0.1:38882`;
 - `peer-c`: the teammate's fresh second-device profile, viewer at `http://127.0.0.1:38883`.
 
-The dogfood Compose override publishes only loopback viewer ports. Peer sync and coordinator traffic remain on the Compose network.
+The dogfood Compose override publishes only loopback viewer ports. Peer sync and coordinator traffic remain on the Compose network, and recipient peers advertise their Compose-reachable service URLs.
 
 ## Initial state
 
@@ -50,12 +50,14 @@ The setup prints the three viewer URLs and an ordered checklist.
 The checklist guides the operator through the real UI:
 
 1. Assign the selected Project to the test Team.
-2. Create an exact-Project invitation on the owner and accept it on the teammate.
-3. Create a Team invitation and accept it on that same teammate profile.
-4. Create an add-device invitation for the teammate Identity and accept it on the fresh second-device profile.
-5. Add future selected and unrelated memories and verify exact delivery and isolation.
-6. Take the teammate offline, revoke access, observe a safe waiting state, restore it, and verify convergence.
-7. Restart recipient profiles and verify Identity and coordinator configuration persistence.
+2. Create a Team invitation on the owner and accept it on the teammate.
+3. If the teammate UI reports that restart is required, run `pnpm run dogfood -- restart teammate` before continuing.
+4. Create an exact-Project invitation on the owner and accept it on that same teammate profile.
+5. Create an add-device invitation for the teammate Identity in the teammate UI and accept it on the fresh second-device profile.
+6. Run `pnpm run dogfood -- restart second-device` after add-device acceptance.
+7. Add future selected and unrelated memories and verify exact delivery and isolation.
+8. Take the teammate offline, revoke access, observe a safe waiting state, restore it, and verify convergence.
+9. Restart recipient profiles and verify Identity and coordinator configuration persistence.
 
 The harness may seed infrastructure, identities, the empty Team, projects, and memories. It must not create, inspect, accept, or commit recipient invitations on the operator's behalf.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -46,7 +46,15 @@ View the isolated peers at fixed loopback URLs:
 - Teammate: `http://127.0.0.1:38882`
 - Second device: `http://127.0.0.1:38883`
 
-In the UI, assign the selected Project to the test Team; create and accept exact-Project then Team invitations on the teammate; create and accept an add-device invitation on the second device. Add selected and unrelated future memories, then verify delivery, isolation, offline revocation, recovery, and restart persistence.
+Follow this order in the UI:
+
+1. Assign the selected Project to the test Team in the owner UI.
+2. Create a Team invitation in the owner UI and accept it in the teammate UI.
+3. If the teammate UI reports that restart is required, run `pnpm run dogfood -- restart teammate` before continuing.
+4. Create an exact-Project invitation in the owner UI and accept it on that same teammate.
+5. Create an add-device invitation for that Identity in the teammate UI, then accept it in the second-device UI.
+6. Run `pnpm run dogfood -- restart second-device` after add-device acceptance.
+7. Add selected and unrelated future memories, then verify delivery, isolation, offline revocation, recovery, and restart persistence.
 
 | Command | Use |
 | --- | --- |

--- a/e2e/bin/dogfood.test.ts
+++ b/e2e/bin/dogfood.test.ts
@@ -521,7 +521,28 @@ describe("manual checklist", () => {
 		expect(checklist).toContain("http://127.0.0.1:38881");
 		expect(checklist).toContain("http://127.0.0.1:38882");
 		expect(checklist).toContain("http://127.0.0.1:38883");
-		expect(checklist).toContain("Create an exact-Project invitation in the owner UI");
-		expect(checklist).toContain("Accept the add-device invitation in the second-device UI");
+		const teamInvite = "Create a Team invitation in the owner UI";
+		const teammateRestart = "pnpm run dogfood -- restart teammate";
+		const projectInvite = "Create an exact-Project invitation in the owner UI";
+		const addDeviceInvite =
+			"Create an add-device invitation in the teammate UI for that Identity";
+		const addDeviceAccept = "Accept the add-device invitation in the second-device UI";
+		const secondDeviceRestart = "pnpm run dogfood -- restart second-device";
+		expect(checklist).toContain(teamInvite);
+		expect(checklist).toContain("If the teammate UI reports that restart is required");
+		expect(checklist).toContain(teammateRestart);
+		expect(checklist).toContain(projectInvite);
+		expect(checklist).toContain("accept it in the same teammate profile");
+		expect(checklist).toContain(addDeviceInvite);
+		expect(checklist).toContain(addDeviceAccept);
+		expect(checklist).toContain(secondDeviceRestart);
+		expect(checklist.indexOf(teamInvite)).toBeLessThan(checklist.indexOf(projectInvite));
+		expect(checklist.indexOf(teamInvite)).toBeLessThan(checklist.indexOf(teammateRestart));
+		expect(checklist.indexOf(teammateRestart)).toBeLessThan(checklist.indexOf(projectInvite));
+		expect(checklist.indexOf(projectInvite)).toBeLessThan(checklist.indexOf(addDeviceInvite));
+		expect(checklist.indexOf(addDeviceInvite)).toBeLessThan(checklist.indexOf(addDeviceAccept));
+		expect(checklist.indexOf(addDeviceAccept)).toBeLessThan(
+			checklist.indexOf(secondDeviceRestart),
+		);
 	});
 });

--- a/e2e/bin/dogfood.ts
+++ b/e2e/bin/dogfood.ts
@@ -261,12 +261,14 @@ export function buildManualChecklist(): string {
 
 Manual invitation checklist:
   1. Assign the selected Project to the test Team in the owner UI.
-  2. Create an exact-Project invitation in the owner UI and accept it in the teammate UI.
-  3. Create a Team invitation in the owner UI and accept it in the same teammate profile.
-  4. Create an add-device invitation for the teammate Identity.
-  5. Accept the add-device invitation in the second-device UI.
-  6. Add selected and unrelated future memories and verify exact delivery and isolation.
-  7. Exercise offline revocation, recovery, and restart persistence manually.`;
+  2. Create a Team invitation in the owner UI and accept it in the teammate UI.
+  3. If the teammate UI reports that restart is required, run: pnpm run dogfood -- restart teammate
+  4. Create an exact-Project invitation in the owner UI and accept it in the same teammate profile.
+  5. Create an add-device invitation in the teammate UI for that Identity.
+  6. Accept the add-device invitation in the second-device UI.
+  7. Restart the second device by running: pnpm run dogfood -- restart second-device
+  8. Add selected and unrelated future memories and verify exact delivery and isolation.
+  9. Exercise offline revocation, recovery, and restart persistence manually.`;
 }
 
 function requireState(dependencies: DogfoodDependencies): DogfoodState {

--- a/e2e/images/peer.Dockerfile
+++ b/e2e/images/peer.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim
+FROM node:24-bookworm-slim
 
 ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH

--- a/e2e/lib/compose.test.ts
+++ b/e2e/lib/compose.test.ts
@@ -231,6 +231,12 @@ describe("ComposeManager", () => {
 });
 
 describe("docker-compose.dogfood.yml", () => {
+	it("builds dogfood peers on the supported Node runtime", () => {
+		const contents = readFileSync(resolve("e2e/images/peer.Dockerfile"), "utf8");
+
+		expect(contents).toMatch(/^FROM node:24-bookworm-slim$/mu);
+	});
+
 	it("publishes exactly one loopback viewer port per peer", () => {
 		const contents = readFileSync(resolve("docker-compose.dogfood.yml"), "utf8");
 		const lines = contents.split("\n");
@@ -251,5 +257,16 @@ describe("docker-compose.dogfood.yml", () => {
 		]);
 		expect(contents).not.toMatch(/^\s*network_mode:\s*["']?host["']?\s*$/mu);
 		expect(contents).toContain("serve start --foreground");
+	});
+
+	it("advertises recipient peers by their Compose-reachable service URLs", () => {
+		const contents = readFileSync(resolve("docker-compose.dogfood.yml"), "utf8");
+		const peerA = contents.slice(contents.indexOf("  peer-a:"), contents.indexOf("  peer-b:"));
+		const peerB = contents.slice(contents.indexOf("  peer-b:"), contents.indexOf("  peer-c:"));
+		const peerC = contents.slice(contents.indexOf("  peer-c:"));
+
+		expect(peerA).not.toContain("CODEMEM_SYNC_ADVERTISE");
+		expect(peerB).toContain("CODEMEM_SYNC_ADVERTISE: http://peer-b:7337");
+		expect(peerC).toContain("CODEMEM_SYNC_ADVERTISE: http://peer-c:7337");
 	});
 });


### PR DESCRIPTION
## Description

Fixes `codemem-gccx` by making the disposable three-peer dogfood journey match the current Identity and sync contracts:

- dogfood peers run on the supported Node 24 runtime
- recipient peers advertise Compose-reachable service URLs instead of auto-detected container IPs
- Team enrollment happens before exact-Project sharing so the coordinator-minted Identity is adopted first
- the checklist includes required recipient restarts and creates add-device invitations from the teammate UI
- tests and dogfood documentation lock the corrected sequence

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified merged Compose configuration

Additional validation:
- `pnpm exec vitest run e2e/bin/dogfood.test.ts e2e/lib/compose.test.ts` — 70 passed
- `docker compose -f docker-compose.e2e.yml -f docker-compose.dogfood.yml config --quiet`
- `pnpm run check` — 177 files passed, 3869 tests passed, 3 todo

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

