### PR TITLE
fix(sync): preserve Team recipient names

### DIFF
--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -1217,6 +1217,10 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		opts: CoordinatorConsumeRecipientInviteInput,
 	): Promise<CoordinatorRecipientInviteAcceptance> {
 		const consumedAt = normalizeInviteExpiresAt(opts.now);
+		const recipientDisplayName =
+			opts.inviteKind === "team_member" ? (opts.recipientDisplayName ?? null) : null;
+		const deviceDisplayName =
+			opts.inviteKind === "team_member" ? (opts.deviceDisplayName ?? null) : null;
 		if (
 			!opts.identityId ||
 			!opts.deviceId ||
@@ -1294,7 +1298,8 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				? 0
 				: this.db
 						.prepare(`UPDATE coordinator_invites SET token = ?, consumed_at = ?, bound_device_id = ?,
-							bound_public_key = ?, bound_fingerprint = ?, recipient_actor_id = ?
+							bound_public_key = ?, bound_fingerprint = ?, recipient_actor_id = ?,
+							recipient_display_name = ?, recipient_device_display_name = ?
 							WHERE invite_id = ? AND consumed_at IS NULL AND revoked_at IS NULL
 							AND expires_at > ? AND invite_kind = ?
 							AND EXISTS (SELECT 1 FROM groups g WHERE g.group_id = coordinator_invites.group_id
@@ -1306,6 +1311,8 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 							opts.publicKey,
 							opts.fingerprint,
 							authoritativeIdentityId,
+							recipientDisplayName,
+							deviceDisplayName,
 							invite.invite_id,
 							consumedAt,
 							opts.inviteKind,
@@ -1326,11 +1333,12 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				this.db
 					.prepare(`INSERT INTO enrolled_devices(
 						group_id, device_id, public_key, fingerprint, identity_id, display_name, enabled, created_at
-					) VALUES (?, ?, ?, ?, ?, NULL, 1, ?)
+					) VALUES (?, ?, ?, ?, ?, ?, 1, ?)
 					ON CONFLICT(group_id, device_id) DO UPDATE SET
 						public_key = excluded.public_key,
 						fingerprint = excluded.fingerprint,
 						identity_id = COALESCE(enrolled_devices.identity_id, excluded.identity_id),
+						display_name = COALESCE(enrolled_devices.display_name, excluded.display_name),
 						enabled = 1
 					WHERE enrolled_devices.identity_id IS NULL
 						OR enrolled_devices.identity_id = excluded.identity_id`)
@@ -1340,6 +1348,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 						opts.publicKey,
 						opts.fingerprint,
 						authoritativeIdentityId,
+						deviceDisplayName,
 						consumedAt,
 					);
 			} else {

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -158,6 +158,91 @@ describe("coordinator local admin actions", () => {
 		]);
 	});
 
+	it("retries Team onboarding without optional display names for older coordinators", async () => {
+		const actionDbPath = join(tmpDir, "legacy-coordinator-team.sqlite");
+		const keysDir = join(tmpDir, "legacy-coordinator-team-keys");
+		const configPath = join(tmpDir, "legacy-coordinator-team-config.json");
+		const identityId = "identity-team";
+		const reviewedIntent = teamReviewedIntent("team-a");
+		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+		const capturedBodies: Record<string, unknown>[] = [];
+		const acceptedResponse = {
+			ok: true,
+			status: "accepted",
+			kind: "team_member",
+			group_id: "coordinator-a",
+			identity_id: identityId,
+			policy_team_id: "team-a",
+			assigned_identity_id: identityId,
+			reviewed_preview_digest: reviewedDigest,
+			reviewed_intent: reviewedIntent,
+		};
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_url: string, init?: RequestInit) => {
+				const body =
+					init?.body instanceof Uint8Array ? Buffer.from(init.body).toString("utf8") : "{}";
+				const parsed = JSON.parse(body) as Record<string, unknown>;
+				capturedBodies.push(parsed);
+				return parsed.recipient_display_name
+					? new Response(JSON.stringify({ error: "unexpected_recipient_invite_fields" }), {
+							status: 400,
+						})
+					: new Response(JSON.stringify(acceptedResponse), { status: 200 });
+			}),
+		);
+		const invite = encodeInvitePayload({
+			v: 1,
+			kind: "team_member",
+			coordinator_url: "https://coord.example.test",
+			group_id: "coordinator-a",
+			policy: "auto_admit",
+			token: "legacy-coordinator-team-token",
+			expires_at: "2099-01-01T00:00:00.000Z",
+			team_name: null,
+			policy_team_id: "team-a",
+			assigned_identity_id: identityId,
+			reviewed_preview_digest: reviewedDigest,
+		});
+		const reviewedOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
+			dbPath: actionDbPath,
+			keysDir,
+			invitationId: "legacy-coordinator-team-token",
+			identityId,
+			deviceDisplayName: "Recipient laptop",
+			reviewedIntent,
+		});
+
+		await expect(
+			coordinatorImportInviteAction({
+				inviteValue: invite,
+				dbPath: actionDbPath,
+				keysDir,
+				configPath,
+				recipientDisplayName: "Brian Example",
+				deviceDisplayName: "Recipient laptop",
+				reviewedOnboardingDigest,
+			}),
+		).resolves.toMatchObject({ status: "accepted", identity_id: identityId });
+		expect(capturedBodies).toHaveLength(3);
+		expect(capturedBodies[1]).toMatchObject({
+			invite_kind: "team_member",
+			identity_id: identityId,
+			recipient_display_name: "Brian Example",
+			device_display_name: "Recipient laptop",
+		});
+		expect(capturedBodies[2]).toMatchObject({
+			token: "legacy-coordinator-team-token",
+			device_id: capturedBodies[1]?.device_id,
+			public_key: capturedBodies[1]?.public_key,
+			fingerprint: capturedBodies[1]?.fingerprint,
+			invite_kind: "team_member",
+			identity_id: identityId,
+		});
+		expect(capturedBodies[2]).not.toHaveProperty("recipient_display_name");
+		expect(capturedBodies[2]).not.toHaveProperty("device_display_name");
+	});
+
 	it.each([
 		"operation",
 		"group",
@@ -299,6 +384,8 @@ describe("coordinator local admin actions", () => {
 				deviceId: "device-team-1",
 				publicKey,
 				fingerprint: fingerprintPublicKey(publicKey),
+				recipientDisplayName: "Brian Example",
+				deviceDisplayName: "Brian's MacBook",
 				now: "2026-07-26T00:00:00.000Z",
 			});
 		} finally {
@@ -312,6 +399,8 @@ describe("coordinator local admin actions", () => {
 				policy_team_id: "policy-team-1",
 				assigned_identity_id: identityId,
 				recipient_actor_id: identityId,
+				recipient_display_name: "Brian Example",
+				recipient_device_display_name: "Brian's MacBook",
 				bound_device_id: "device-team-1",
 				consumed_at: "2026-07-26T00:00:00.000Z",
 			},
@@ -610,6 +699,8 @@ describe("coordinator local admin actions", () => {
 			policy_team_id: "policy-team-1",
 			assigned_identity_id: "identity:abcdefghijklmnopqr",
 			recipient_actor_id: "identity:abcdefghijklmnopqr",
+			recipient_display_name: "Brian Example",
+			recipient_device_display_name: "Brian's MacBook",
 			bound_device_id: "device-team-1",
 			consumed_at: "2026-07-26T00:00:00.000Z",
 		};
@@ -619,6 +710,8 @@ describe("coordinator local admin actions", () => {
 			policy_team_id: valid.policy_team_id,
 			assigned_identity_id: valid.assigned_identity_id,
 			recipient_actor_id: valid.recipient_actor_id,
+			recipient_display_name: valid.recipient_display_name,
+			recipient_device_display_name: valid.recipient_device_display_name,
 			bound_device_id: valid.bound_device_id,
 			consumed_at: valid.consumed_at,
 		};
@@ -704,6 +797,42 @@ describe("coordinator local admin actions", () => {
 				}),
 			).rejects.toThrow("coordinator_consumed_team_invite_invalid");
 		}
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							items: [
+								{
+									...valid,
+									recipient_display_name: "Brian\u0000",
+									recipient_device_display_name: "x".repeat(121),
+								},
+							],
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					),
+			),
+		);
+		await expect(
+			coordinatorListConsumedTeamInvitesAction({
+				groupId: "team-a",
+				remoteUrl: "https://coord.example.test",
+				adminSecret: "secret",
+			}),
+		).resolves.toEqual([
+			{
+				invite_id: valid.invite_id,
+				group_id: valid.group_id,
+				policy_team_id: valid.policy_team_id,
+				assigned_identity_id: valid.assigned_identity_id,
+				recipient_actor_id: valid.recipient_actor_id,
+				bound_device_id: valid.bound_device_id,
+				consumed_at: valid.consumed_at,
+			},
+		]);
 
 		for (const malformed of [{}, { items: null }, { items: "not-a-list" }, { items: [null] }]) {
 			vi.stubGlobal(
@@ -1759,31 +1888,34 @@ describe("coordinator local admin actions", () => {
 		const inviterPublicKey = "ssh-ed25519 authoritative-inviter-key";
 		const reviewedIntent = addDeviceReviewedIntent(targetIdentityId);
 		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+		const capturedBodies: Record<string, unknown>[] = [];
 		vi.stubGlobal(
 			"fetch",
-			vi.fn(
-				async () =>
-					new Response(
-						JSON.stringify({
-							ok: true,
-							status: "accepted",
-							kind: "add_device",
-							group_id: "coordinator-a",
-							identity_id: targetIdentityId,
-							target_identity_id: targetIdentityId,
-							bootstrap_grant_id: "grant-authoritative",
-							inviter_device: {
-								device_id: "authoritative-inviter",
-								public_key: inviterPublicKey,
-								fingerprint: fingerprintPublicKey(inviterPublicKey),
-								display_name: "Existing laptop",
-							},
-							reviewed_preview_digest: reviewedDigest,
-							reviewed_intent: reviewedIntent,
-						}),
-						{ status: 200 },
-					),
-			),
+			vi.fn(async (_url: string, init?: RequestInit) => {
+				const body =
+					init?.body instanceof Uint8Array ? Buffer.from(init.body).toString("utf8") : "{}";
+				capturedBodies.push(JSON.parse(body) as Record<string, unknown>);
+				return new Response(
+					JSON.stringify({
+						ok: true,
+						status: "accepted",
+						kind: "add_device",
+						group_id: "coordinator-a",
+						identity_id: targetIdentityId,
+						target_identity_id: targetIdentityId,
+						bootstrap_grant_id: "grant-authoritative",
+						inviter_device: {
+							device_id: "authoritative-inviter",
+							public_key: inviterPublicKey,
+							fingerprint: fingerprintPublicKey(inviterPublicKey),
+							display_name: "Existing laptop",
+						},
+						reviewed_preview_digest: reviewedDigest,
+						reviewed_intent: reviewedIntent,
+					}),
+					{ status: 200 },
+				);
+			}),
 		);
 		const invite = encodeInvitePayload({
 			v: 1,
@@ -2220,26 +2352,29 @@ describe("coordinator local admin actions", () => {
 				? teamReviewedIntent("team-a")
 				: addDeviceReviewedIntent(testCase.identityId);
 		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+		const capturedBodies: Record<string, unknown>[] = [];
 		vi.stubGlobal(
 			"fetch",
-			vi.fn(
-				async () =>
-					new Response(
-						JSON.stringify({
-							ok: true,
-							status: "accepted",
-							kind: testCase.kind,
-							group_id: "coordinator-a",
-							identity_id: testCase.identityId,
-							policy_team_id: testCase.kind === "team_member" ? "team-a" : null,
-							target_identity_id: testCase.kind === "add_device" ? testCase.identityId : null,
-							assigned_identity_id: testCase.kind === "team_member" ? testCase.identityId : null,
-							reviewed_preview_digest: reviewedDigest,
-							reviewed_intent: reviewedIntent,
-						}),
-						{ status: 200 },
-					),
-			),
+			vi.fn(async (_url: string, init?: RequestInit) => {
+				const body =
+					init?.body instanceof Uint8Array ? Buffer.from(init.body).toString("utf8") : "{}";
+				capturedBodies.push(JSON.parse(body) as Record<string, unknown>);
+				return new Response(
+					JSON.stringify({
+						ok: true,
+						status: "accepted",
+						kind: testCase.kind,
+						group_id: "coordinator-a",
+						identity_id: testCase.identityId,
+						policy_team_id: testCase.kind === "team_member" ? "team-a" : null,
+						target_identity_id: testCase.kind === "add_device" ? testCase.identityId : null,
+						assigned_identity_id: testCase.kind === "team_member" ? testCase.identityId : null,
+						reviewed_preview_digest: reviewedDigest,
+						reviewed_intent: reviewedIntent,
+					}),
+					{ status: 200 },
+				);
+			}),
 		);
 		const invite = encodeInvitePayload({
 			v: 1,
@@ -2270,6 +2405,7 @@ describe("coordinator local admin actions", () => {
 			keysDir,
 			configPath,
 			recipientActorId: testCase.identityId,
+			recipientDisplayName: "  Brian   Example  ",
 			deviceDisplayName: "Recipient laptop",
 			reviewedOnboardingDigest,
 		});
@@ -2280,9 +2416,21 @@ describe("coordinator local admin actions", () => {
 			keysDir,
 			configPath,
 			recipientActorId: testCase.identityId,
+			recipientDisplayName: "  Brian   Example  ",
 			deviceDisplayName: "Recipient laptop",
 			reviewedOnboardingDigest,
 		});
+		const joinBodies = capturedBodies.filter((body) => body.invite_kind === testCase.kind);
+		expect(joinBodies).toHaveLength(2);
+		if (testCase.kind === "team_member") {
+			expect(joinBodies[0]).toMatchObject({
+				recipient_display_name: "Brian Example",
+				device_display_name: "Recipient laptop",
+			});
+		} else {
+			expect(joinBodies[0]).not.toHaveProperty("recipient_display_name");
+			expect(joinBodies[0]).not.toHaveProperty("device_display_name");
+		}
 
 		const persistedConfig = readCodememConfigFileAtPath(configPath);
 		expect(persistedConfig).toMatchObject({

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -891,6 +891,8 @@ export interface CoordinatorConsumedTeamInvite {
 	policy_team_id: string;
 	assigned_identity_id: string;
 	recipient_actor_id: string;
+	recipient_display_name?: string | null;
+	recipient_device_display_name?: string | null;
 	bound_device_id: string;
 	consumed_at: string;
 }
@@ -915,6 +917,15 @@ function isCanonicalConsumedTeamInviteTimestamp(value: string): boolean {
 	return value === canonical || value === canonical.replace(/\.000Z$/u, "Z");
 }
 
+function optionalConsumedTeamInviteDisplayName(value: unknown, field: string): string | null {
+	if (value == null || typeof value !== "string") return null;
+	try {
+		return normalizeIdentityDisplayName(value, field);
+	} catch {
+		return null;
+	}
+}
+
 function consumedTeamInvites(
 	invites: Array<Partial<CoordinatorInvite>>,
 ): CoordinatorConsumedTeamInvite[] {
@@ -934,7 +945,15 @@ function consumedTeamInvites(
 			if (!isCanonicalConsumedTeamInviteTimestamp(consumedAt)) {
 				throw new Error("coordinator_consumed_team_invite_invalid");
 			}
-			const row = {
+			const recipientDisplayName = optionalConsumedTeamInviteDisplayName(
+				invite.recipient_display_name,
+				"recipient_display_name",
+			);
+			const recipientDeviceDisplayName = optionalConsumedTeamInviteDisplayName(
+				invite.recipient_device_display_name,
+				"device_display_name",
+			);
+			const row: CoordinatorConsumedTeamInvite = {
 				invite_id: requiredConsumedTeamInviteText(invite.invite_id),
 				group_id: requiredConsumedTeamInviteText(invite.group_id),
 				policy_team_id: requiredConsumedTeamInviteText(invite.policy_team_id, 256),
@@ -942,6 +961,10 @@ function consumedTeamInvites(
 				recipient_actor_id: recipientActorId,
 				bound_device_id: requiredConsumedTeamInviteText(invite.bound_device_id, 256),
 				consumed_at: consumedAt,
+				...(recipientDisplayName == null ? {} : { recipient_display_name: recipientDisplayName }),
+				...(recipientDeviceDisplayName == null
+					? {}
+					: { recipient_device_display_name: recipientDeviceDisplayName }),
 			};
 			if (Object.values(row).some((value) => !value)) {
 				throw new Error("coordinator_consumed_team_invite_invalid");
@@ -2154,37 +2177,62 @@ export async function coordinatorImportInviteAction(opts: {
 			reviewedOnboardingDigest,
 		});
 	}
+	const joinBody: Record<string, unknown> = {
+		token: String(payload.token),
+		device_id: deviceId,
+		public_key: publicKey,
+		fingerprint,
+		...(recipientInvite ? {} : { display_name: displayName }),
+		...(recipientInvite
+			? {
+					invite_kind: payload.kind,
+					identity_id: recipientActorId,
+					...(payload.kind === "team_member"
+						? {
+								recipient_display_name: recipientDisplayName,
+								device_display_name: displayName,
+							}
+						: {}),
+				}
+			: {}),
+		...(projectInvite
+			? {
+					operation_id: payload.operation_id,
+					recipient_actor_id: recipientActorId,
+					recipient_display_name: recipientDisplayName,
+					device_display_name: displayName,
+				}
+			: {}),
+	};
 	let status = 0;
 	let response: Record<string, unknown> | null = null;
 	try {
 		[status, response] = await requestJson(
 			"POST",
 			`${stripTrailingSlashes(coordinatorUrl)}/v1/join`,
-			{
-				body: {
-					token: String(payload.token),
-					device_id: deviceId,
-					public_key: publicKey,
-					fingerprint,
-					...(recipientInvite ? {} : { display_name: displayName }),
-					...(recipientInvite
-						? {
-								invite_kind: payload.kind,
-								identity_id: recipientActorId,
-							}
-						: {}),
-					...(projectInvite
-						? {
-								operation_id: payload.operation_id,
-								recipient_actor_id: recipientActorId,
-								recipient_display_name: recipientDisplayName,
-								device_display_name: displayName,
-							}
-						: {}),
-				},
-				timeoutS: INVITE_IMPORT_TIMEOUT_S,
-			},
+			{ body: joinBody, timeoutS: INVITE_IMPORT_TIMEOUT_S },
 		);
+		if (
+			recipientInvite &&
+			!projectInvite &&
+			"recipient_display_name" in joinBody &&
+			status === 400 &&
+			response?.error === "unexpected_recipient_invite_fields"
+		) {
+			const legacyJoinBody = Object.fromEntries(
+				Object.entries(joinBody).filter(
+					([key]) => key !== "recipient_display_name" && key !== "device_display_name",
+				),
+			);
+			[status, response] = await requestJson(
+				"POST",
+				`${stripTrailingSlashes(coordinatorUrl)}/v1/join`,
+				{
+					body: legacyJoinBody,
+					timeoutS: INVITE_IMPORT_TIMEOUT_S,
+				},
+			);
+		}
 	} catch (error) {
 		throw inviteImportTransportError(error, coordinatorUrl);
 	}

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -988,6 +988,8 @@ describe("createCoordinatorApp dependency injection", () => {
 				token: invite.token,
 				invite_kind: "team_member",
 				identity_id: assignedIdentityId,
+				recipient_display_name: "  Brian   Example  ",
+				device_display_name: "  Brian's   MacBook  ",
 				device_id: "device-brian",
 				public_key: publicKey,
 				fingerprint: fingerprintPublicKey(publicKey),
@@ -1006,8 +1008,62 @@ describe("createCoordinatorApp dependency injection", () => {
 			reviewed_intent: reviewedIntent,
 		});
 		expect(consumeRecipientInvite).toHaveBeenCalledTimes(2);
+		expect(consumeRecipientInvite).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				recipientDisplayName: "Brian Example",
+				deviceDisplayName: "Brian's MacBook",
+			}),
+		);
 		expect(store.enrollDevice).not.toHaveBeenCalled();
 		expect(store.grantScopeMembership).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["recipient_display_name", "Brian\u0000", "recipient_display_name_invalid"],
+		["device_display_name", "x".repeat(121), "device_display_name_too_long"],
+	])("rejects malformed Team invite %s values", async (field, value, expectedError) => {
+		const publicKey = "recipient-public-key";
+		const consumeRecipientInvite = vi.fn();
+		const store = createMockStore({
+			getInviteByTokenForInspection: vi.fn(async () => ({
+				invite_id: "invite-team-invalid-name",
+				group_id: "g1",
+				token: "team-token",
+				policy: "auto_admit",
+				expires_at: "2099-01-01T00:00:00Z",
+				created_at: "2026-03-28T00:00:00Z",
+				created_by: null,
+				team_name_snapshot: "Coordinator One",
+				revoked_at: null,
+				invite_kind: "team_member",
+				policy_team_id: "policy-team-1",
+				assigned_identity_id: "opaque-assigned-team-identity",
+			})),
+			consumeRecipientInvite,
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: { adminSecret: () => "test-secret", now: () => "2026-03-28T00:00:00Z" },
+			requestVerifier: allowRequest,
+		});
+
+		const response = await app.request("/v1/join", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				token: "team-token",
+				invite_kind: "team_member",
+				identity_id: "opaque-assigned-team-identity",
+				device_id: "device-brian",
+				public_key: publicKey,
+				fingerprint: fingerprintPublicKey(publicKey),
+				[field]: value,
+			}),
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: expectedError });
+		expect(consumeRecipientInvite).not.toHaveBeenCalled();
 	});
 
 	it("fails closed when project-first acceptance omits identity confirmation", async () => {

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -2063,6 +2063,8 @@ export function createCoordinatorApp(
 					"device_id",
 					"public_key",
 					"fingerprint",
+					"recipient_display_name",
+					"device_display_name",
 				]);
 				if (Object.keys(data).some((key) => !allowedRecipientAcceptanceFields.has(key))) {
 					return c.json({ error: "unexpected_recipient_invite_fields" }, 400);
@@ -2074,6 +2076,35 @@ export function createCoordinatorApp(
 				}
 				if (identityId.length > 256 || /[\p{Cc}\p{Cf}]/u.test(identityId)) {
 					return c.json({ error: "identity_id_invalid" }, 400);
+				}
+				let normalizedRecipientDisplayName: string | null = null;
+				let normalizedDeviceDisplayName: string | null = null;
+				try {
+					if (data.recipient_display_name != null) {
+						if (typeof data.recipient_display_name !== "string") {
+							throw new Error("recipient_display_name_invalid");
+						}
+						normalizedRecipientDisplayName = normalizeIdentityDisplayName(
+							data.recipient_display_name,
+							"recipient_display_name",
+						);
+					}
+					if (data.device_display_name != null) {
+						if (typeof data.device_display_name !== "string") {
+							throw new Error("device_display_name_invalid");
+						}
+						normalizedDeviceDisplayName = normalizeIdentityDisplayName(
+							data.device_display_name,
+							"device_display_name",
+						);
+					}
+				} catch (error) {
+					return c.json(
+						{
+							error: error instanceof Error ? error.message : "recipient_invite_identity_invalid",
+						},
+						400,
+					);
 				}
 				if (
 					invite.invite_kind === "add_device" &&
@@ -2089,6 +2120,10 @@ export function createCoordinatorApp(
 						deviceId,
 						publicKey,
 						fingerprint,
+						recipientDisplayName:
+							invite.invite_kind === "team_member" ? normalizedRecipientDisplayName : null,
+						deviceDisplayName:
+							invite.invite_kind === "team_member" ? normalizedDeviceDisplayName : null,
 						now: runtime.now(),
 					});
 					return c.json({

--- a/packages/core/src/coordinator-enrollment-reconciler.test.ts
+++ b/packages/core/src/coordinator-enrollment-reconciler.test.ts
@@ -45,6 +45,8 @@ describe("reconcileCoordinatorEnrollmentSnapshot", () => {
 					policy_team_id: "team-a",
 					assigned_identity_id: "identity-team",
 					recipient_actor_id: "identity-team",
+					recipient_display_name: "Brian Example",
+					recipient_device_display_name: "Brian's MacBook",
 					bound_device_id: "device-team",
 					consumed_at: NOW,
 				},
@@ -66,7 +68,7 @@ describe("reconcileCoordinatorEnrollmentSnapshot", () => {
 					public_key: "pk-team",
 					fingerprint: "fp-team",
 					identity_id: "identity-team",
-					display_name: "Team laptop",
+					display_name: "Brian's MacBook",
 					enabled: 1,
 					created_at: NOW,
 				},
@@ -101,6 +103,15 @@ describe("reconcileCoordinatorEnrollmentSnapshot", () => {
 			[{ identity_id: "identity-direct" }, { identity_id: "identity-team" }],
 		);
 		expect(db.prepare("SELECT actor_id FROM sync_peers ORDER BY peer_device_id").all()).toEqual([]);
+		expect(
+			db.prepare("SELECT display_name FROM actors WHERE actor_id = 'identity-team'").pluck().get(),
+		).toBe("Brian Example");
+		expect(
+			db
+				.prepare("SELECT display_name FROM identity_devices WHERE device_id = 'device-team'")
+				.pluck()
+				.get(),
+		).toBe("Brian's MacBook");
 		db.prepare(`INSERT INTO project_recipients(
 			canonical_project_identity, recipient_kind, recipient_id, status, provenance,
 			policy_revision, migration_state, source_fingerprint, idempotency_key, created_at, updated_at
@@ -114,6 +125,101 @@ describe("reconcileCoordinatorEnrollmentSnapshot", () => {
 				(device) => device.deviceId,
 			),
 		).toEqual(["device-direct-2", "device-team"]);
+	});
+
+	it("uses legacy Team member and enrolled device fallbacks when names are absent", () => {
+		const result = reconcileCoordinatorEnrollmentSnapshot(db, {
+			coordinatorId: "https://coord.example.test",
+			groupId: "group-a",
+			now: NOW,
+			consumedTeamInvites: [
+				{
+					invite_id: "invite-legacy-names",
+					group_id: "group-a",
+					policy_team_id: "team-a",
+					assigned_identity_id: "identity-legacy",
+					recipient_actor_id: "identity-legacy",
+					bound_device_id: "device-legacy",
+					consumed_at: NOW,
+				},
+			],
+			enrollments: [
+				{
+					group_id: "group-a",
+					device_id: "device-legacy",
+					public_key: "pk-legacy",
+					fingerprint: "fp-legacy",
+					identity_id: "identity-legacy",
+					display_name: null,
+					enabled: 1,
+					created_at: NOW,
+				},
+			],
+		});
+
+		expect(result.issues).toEqual([]);
+		expect(
+			db
+				.prepare("SELECT display_name FROM actors WHERE actor_id = 'identity-legacy'")
+				.pluck()
+				.get(),
+		).toBe("Team member");
+		expect(
+			db
+				.prepare("SELECT display_name FROM identity_devices WHERE device_id = 'device-legacy'")
+				.pluck()
+				.get(),
+		).toBe("Enrolled device");
+	});
+
+	it("uses neutral fallbacks when optional presentation names are malformed", () => {
+		const result = reconcileCoordinatorEnrollmentSnapshot(db, {
+			coordinatorId: "https://coord.example.test",
+			groupId: "group-a",
+			now: NOW,
+			consumedTeamInvites: [
+				{
+					invite_id: "invite-malformed-names",
+					group_id: "group-a",
+					policy_team_id: "team-a",
+					assigned_identity_id: "identity-malformed-names",
+					recipient_actor_id: "identity-malformed-names",
+					recipient_display_name: "Brian\u0000",
+					recipient_device_display_name: "x".repeat(121),
+					bound_device_id: "device-malformed-names",
+					consumed_at: NOW,
+				},
+			],
+			enrollments: [
+				{
+					group_id: "group-a",
+					device_id: "device-malformed-names",
+					public_key: "pk-malformed-names",
+					fingerprint: "fp-malformed-names",
+					identity_id: "identity-malformed-names",
+					display_name: "x".repeat(121),
+					enabled: 1,
+					created_at: NOW,
+				},
+			],
+		});
+
+		expect(result).toMatchObject({ identitiesAdded: 1, membershipsAdded: 1, devicesAdded: 1 });
+		expect(result.issues).toEqual([]);
+		expect(
+			db
+				.prepare("SELECT display_name FROM actors WHERE actor_id = 'identity-malformed-names'")
+				.pluck()
+				.get(),
+		).toBe("Team member");
+		expect(
+			db
+				.prepare(
+					"SELECT display_name FROM identity_devices WHERE device_id = 'device-malformed-names'",
+				)
+				.pluck()
+				.get(),
+		).toBe("Enrolled device");
 	});
 
 	it("refreshes coordinator-managed device names without overwriting local names", () => {
@@ -155,6 +261,20 @@ describe("reconcileCoordinatorEnrollmentSnapshot", () => {
 		input.enrollments[0].display_name = "Renamed device";
 		reconcileCoordinatorEnrollmentSnapshot(db, input);
 
+		expect(
+			db.prepare("SELECT device_id, display_name FROM identity_devices ORDER BY device_id").all(),
+		).toEqual([
+			{ device_id: "device-coordinator", display_name: "Renamed device" },
+			{ device_id: "device-local", display_name: "My custom name" },
+		]);
+
+		reconcileCoordinatorEnrollmentSnapshot(db, {
+			...input,
+			enrollments: input.enrollments.map((enrollment) => ({
+				...enrollment,
+				display_name: null,
+			})),
+		});
 		expect(
 			db.prepare("SELECT device_id, display_name FROM identity_devices ORDER BY device_id").all(),
 		).toEqual([

--- a/packages/core/src/coordinator-enrollment-reconciler.ts
+++ b/packages/core/src/coordinator-enrollment-reconciler.ts
@@ -3,6 +3,7 @@ import type { CoordinatorConsumedTeamInvite } from "./coordinator-actions.js";
 import { persistCoordinatorEnrollmentReconciliationIssues } from "./coordinator-enrollment-reconciliation-issues.js";
 import type { CoordinatorEnrollment } from "./coordinator-store-contract.js";
 import type { Database } from "./db.js";
+import { normalizeIdentityDisplayName } from "./project-invite-identity.js";
 
 export interface CoordinatorEnrollmentReconcileIssue {
 	kind: "device" | "team_membership";
@@ -32,6 +33,26 @@ function strictId(value: unknown): value is string {
 		value.length <= 256 &&
 		!/[\p{Cc}\p{Cf}]/u.test(value)
 	);
+}
+
+function normalizedDisplayNameOrNull(
+	value: string | null | undefined,
+	field: string,
+): string | null {
+	if (value == null) return null;
+	try {
+		return normalizeIdentityDisplayName(value, field);
+	} catch {
+		return null;
+	}
+}
+
+function displayNameOrFallback(
+	value: string | null | undefined,
+	field: string,
+	fallback: string,
+): string {
+	return normalizedDisplayNameOrNull(value, field) ?? fallback;
 }
 
 export function reconcileCoordinatorEnrollmentSnapshot(
@@ -86,6 +107,11 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 	const apply = db.transaction(() => {
 		for (const invite of input.consumedTeamInvites) {
 			const identityId = invite.assigned_identity_id;
+			const recipientDisplayName = displayNameOrFallback(
+				invite.recipient_display_name,
+				"recipient_display_name",
+				"Team member",
+			);
 			if (
 				invite.group_id !== input.groupId ||
 				!strictId(identityId) ||
@@ -110,7 +136,7 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 			if (!actor) {
 				db.prepare(`INSERT INTO actors(
 					actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
-				) VALUES (?, 'Team member', 0, 'active', NULL, ?, ?)`).run(identityId, now, now);
+				) VALUES (?, ?, 0, 'active', NULL, ?, ?)`).run(identityId, recipientDisplayName, now, now);
 				result.identitiesAdded += 1;
 			} else if (
 				actor.is_local !== 0 ||
@@ -174,7 +200,11 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 				issue("device", enrollment.device_id, "identity_not_active");
 				continue;
 			}
-			const displayName = enrollment.display_name?.trim() || "";
+			const normalizedDisplayName = normalizedDisplayNameOrNull(
+				enrollment.display_name,
+				"device_display_name",
+			);
+			const displayName = normalizedDisplayName ?? "Enrolled device";
 			const existing = db
 				.prepare(
 					`SELECT identity_id, display_name, status, provenance
@@ -187,7 +217,7 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 				if (existing.identity_id === identityId && existing.status === "active") {
 					if (
 						existing.provenance === "coordinator_enrollment" &&
-						displayName &&
+						normalizedDisplayName != null &&
 						existing.display_name !== displayName
 					) {
 						db.prepare(
@@ -235,7 +265,7 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 			) VALUES (?, ?, ?, 'active', 'coordinator_enrollment', ?, 'user_managed', ?, ?, ?, ?)`).run(
 				enrollment.device_id,
 				identityId,
-				displayName || "Enrolled device",
+				displayName,
 				digest("coordinator-identity-device-revision-v1", stableBinding),
 				digest("coordinator-identity-device-source-v1", stableBinding),
 				digest("coordinator-identity-device-idempotency-v1", stableBinding),

--- a/packages/core/src/coordinator-store-contract.ts
+++ b/packages/core/src/coordinator-store-contract.ts
@@ -324,6 +324,8 @@ export interface CoordinatorConsumeRecipientInviteInput {
 	deviceId: string;
 	publicKey: string;
 	fingerprint: string;
+	recipientDisplayName?: string | null;
+	deviceDisplayName?: string | null;
 	/** Runtime-authoritative timestamp used for expiry and binding. */
 	now: string;
 }

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -1085,6 +1085,8 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 						deviceId: "device-brian",
 						publicKey,
 						fingerprint: fingerprintPublicKey(publicKey),
+						recipientDisplayName: "Brian Example",
+						deviceDisplayName: "Brian's MacBook",
 						now: "2026-07-21T00:00:00.000Z",
 					};
 
@@ -1118,14 +1120,26 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					// Assert
 					expect(acceptedTeam).toMatchObject({
 						status: "accepted",
+						invite: {
+							recipient_display_name: "Brian Example",
+							recipient_device_display_name: "Brian's MacBook",
+						},
 						reviewed_intent: reviewedIntent,
 					});
 
-					const replayedTeam = await store.consumeRecipientInvite(teamInput);
+					const replayedTeam = await store.consumeRecipientInvite({
+						...teamInput,
+						recipientDisplayName: "Unexpected replay rename",
+						deviceDisplayName: "Unexpected replay device rename",
+					});
 					const replayedTeamEnrollment = await store.getEnrollment("g1", teamInput.deviceId);
 					expect(replayedTeam).toMatchObject({
 						status: "existing",
-						invite: { assigned_identity_id: assignedIdentityId },
+						invite: {
+							assigned_identity_id: assignedIdentityId,
+							recipient_display_name: "Brian Example",
+							recipient_device_display_name: "Brian's MacBook",
+						},
 						reviewed_intent: reviewedIntent,
 					});
 					await store.enrollDevice("g1", {
@@ -1219,9 +1233,13 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 							public_key: teamInput.publicKey,
 							fingerprint: teamInput.fingerprint,
 							identity_id: assignedIdentityId,
+							display_name: "Brian's MacBook",
 							enabled: 1,
 						}),
-						expect.objectContaining({ identity_id: assignedIdentityId }),
+						expect.objectContaining({
+							identity_id: assignedIdentityId,
+							display_name: "Brian's MacBook",
+						}),
 						expect.objectContaining({
 							identity_id: assignedIdentityId,
 							display_name: "Brian's renamed device",
@@ -1232,9 +1250,13 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 							public_key: addDeviceInput.publicKey,
 							fingerprint: addDeviceInput.fingerprint,
 							identity_id: addDeviceInput.identityId,
+							display_name: null,
 							enabled: 1,
 						}),
-						expect.objectContaining({ identity_id: addDeviceInput.identityId }),
+						expect.objectContaining({
+							identity_id: addDeviceInput.identityId,
+							display_name: null,
+						}),
 					]);
 					expect(await store.listScopeMemberships("scope-project")).toEqual([]);
 				});

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -1059,6 +1059,10 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		_opts: CoordinatorConsumeRecipientInviteInput,
 	): Promise<CoordinatorRecipientInviteAcceptance> {
 		const consumedAt = normalizeInviteExpiresAt(_opts.now);
+		const recipientDisplayName =
+			_opts.inviteKind === "team_member" ? (_opts.recipientDisplayName ?? null) : null;
+		const deviceDisplayName =
+			_opts.inviteKind === "team_member" ? (_opts.deviceDisplayName ?? null) : null;
 		if (
 			!_opts.identityId ||
 			!_opts.deviceId ||
@@ -1123,7 +1127,8 @@ export class D1CoordinatorStore implements CoordinatorStore {
 			const results = await this.db.batch([
 				this.db
 					.prepare(`UPDATE coordinator_invites SET token = ?, consumed_at = ?, bound_device_id = ?,
-						bound_public_key = ?, bound_fingerprint = ?, recipient_actor_id = ?
+						bound_public_key = ?, bound_fingerprint = ?, recipient_actor_id = ?,
+						recipient_display_name = ?, recipient_device_display_name = ?
 						WHERE (token_digest = ? OR token = ?) AND consumed_at IS NULL
 						AND revoked_at IS NULL AND expires_at > ? AND invite_kind = ?
 						AND reviewed_intent_json = ? AND reviewed_preview_digest = ?
@@ -1144,6 +1149,8 @@ export class D1CoordinatorStore implements CoordinatorStore {
 						_opts.publicKey,
 						_opts.fingerprint,
 						authoritativeIdentityId,
+						recipientDisplayName,
+						deviceDisplayName,
 						digest,
 						_opts.token,
 						consumedAt,
@@ -1161,13 +1168,14 @@ export class D1CoordinatorStore implements CoordinatorStore {
 					.prepare(`INSERT INTO enrolled_devices(
 						group_id, device_id, public_key, fingerprint, identity_id, display_name, enabled, created_at
 					) SELECT i.group_id, i.bound_device_id, i.bound_public_key, i.bound_fingerprint,
-						i.recipient_actor_id, NULL, 1, ? FROM coordinator_invites i
+						i.recipient_actor_id, i.recipient_device_display_name, 1, ? FROM coordinator_invites i
 					JOIN groups g ON g.group_id = i.group_id AND g.archived_at IS NULL
 					WHERE (i.token_digest = ? OR i.token = ?) AND i.bound_device_id = ?
 						AND i.bound_public_key = ? AND i.bound_fingerprint = ?
 						AND i.recipient_actor_id = ?
 					ON CONFLICT(group_id, device_id) DO UPDATE SET
 						identity_id = COALESCE(enrolled_devices.identity_id, excluded.identity_id),
+						display_name = COALESCE(enrolled_devices.display_name, excluded.display_name),
 						enabled = 1
 					WHERE enrolled_devices.identity_id IS NULL
 						OR enrolled_devices.identity_id = excluded.identity_id`)


### PR DESCRIPTION
## Description

Fixes `codemem-fh19.1` by preserving validated Team-member recipient and device display names across coordinator acceptance and owner reconciliation.

- carries names through `/v1/join` without using them for authorization
- persists names consistently in Better-SQLite and D1 coordinator stores
- exposes names through consumed Team-invite evidence
- materializes human names on the owner while retaining neutral fallbacks for legacy or malformed presentation metadata
- preserves idempotent replay and does not rename existing bindings silently
- retries once without optional presentation fields when an older coordinator returns `unexpected_recipient_invite_fields`, preserving all Identity and authentication fields

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation:
- focused coordinator compatibility suite: 56 passed
- live Team onboarding retained human Identity/device names
- `pnpm run check`: 177 files passed, 3,878 tests passed, 3 todo
- independent CodeReviewer pass found no blocking or high-severity issues

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed; compatibility behavior is internal)
- [x] No new warnings introduced
