### PR TITLE
test(sync): cover Team recipient identity reuse

### DIFF
--- a/docs/plans/2026-07-23-disposable-sharing-dogfood-design.md
+++ b/docs/plans/2026-07-23-disposable-sharing-dogfood-design.md
@@ -25,9 +25,9 @@ Rejected alternatives:
 Run one fixed Compose project, `codemem-dogfood`, with isolated named volumes:
 
 - `coordinator`: local coordinator, reachable only inside Compose;
-- `peer-a`: owner profile, viewer at `http://127.0.0.1:38881`;
-- `peer-b`: teammate profile, viewer at `http://127.0.0.1:38882`;
-- `peer-c`: the teammate's fresh second-device profile, viewer at `http://127.0.0.1:38883`.
+- `peer-a`: Owner A profile, viewer at `http://127.0.0.1:38881`;
+- `peer-b`: Teammate B profile, viewer at `http://127.0.0.1:38882`;
+- `peer-c`: the teammate's fresh Second device C profile, viewer at `http://127.0.0.1:38883`.
 
 The dogfood Compose override publishes only loopback viewer ports. Peer sync and coordinator traffic remain on the Compose network, and recipient peers advertise their Compose-reachable service URLs.
 
@@ -49,11 +49,11 @@ The setup prints the three viewer URLs and an ordered checklist.
 
 The checklist guides the operator through the real UI:
 
-1. Assign the selected Project to the test Team.
-2. Create a Team invitation on the owner and accept it on the teammate.
+1. Assign the selected Project to the test Team in the Owner A UI (`38881`).
+2. In the Owner A UI (`38881`), choose **Create an invitation → Invite Team member**. Do not choose **Share exact Projects** at this step. Accept it in the Teammate B UI (`38882`).
 3. If the teammate UI reports that restart is required, run `pnpm run dogfood -- restart teammate` before continuing.
-4. Create an exact-Project invitation on the owner and accept it on that same teammate profile.
-5. Create an add-device invitation for the teammate Identity in the teammate UI and accept it on the fresh second-device profile.
+4. In the Owner A UI (`38881`), choose **Create an invitation → Share exact Projects**; accept it on that same Teammate B profile (`38882`).
+5. In the Teammate B UI (`38882`), choose **Create an invitation → Add a device** for the teammate Identity and accept it on the fresh Second device C profile (`38883`).
 6. Run `pnpm run dogfood -- restart second-device` after add-device acceptance.
 7. Add future selected and unrelated memories and verify exact delivery and isolation.
 8. Take the teammate offline, revoke access, observe a safe waiting state, restore it, and verify convergence.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -42,17 +42,17 @@ pnpm run dogfood -- setup --reset
 
 View the isolated peers at fixed loopback URLs:
 
-- Owner: `http://127.0.0.1:38881`
-- Teammate: `http://127.0.0.1:38882`
-- Second device: `http://127.0.0.1:38883`
+- Owner A: `http://127.0.0.1:38881`
+- Teammate B: `http://127.0.0.1:38882`
+- Second device C: `http://127.0.0.1:38883`
 
 Follow this order in the UI:
 
-1. Assign the selected Project to the test Team in the owner UI.
-2. Create a Team invitation in the owner UI and accept it in the teammate UI.
+1. Assign the selected Project to the test Team in the Owner A UI (`38881`).
+2. In the Owner A UI (`38881`), choose **Create an invitation → Invite Team member**. Do not choose **Share exact Projects** at this step. Accept it in the Teammate B UI (`38882`).
 3. If the teammate UI reports that restart is required, run `pnpm run dogfood -- restart teammate` before continuing.
-4. Create an exact-Project invitation in the owner UI and accept it on that same teammate.
-5. Create an add-device invitation for that Identity in the teammate UI, then accept it in the second-device UI.
+4. In the Owner A UI (`38881`), choose **Create an invitation → Share exact Projects**; accept it on that same Teammate B profile (`38882`).
+5. In the Teammate B UI (`38882`), choose **Create an invitation → Add a device** for that Identity, then accept it in the Second device C UI (`38883`).
 6. Run `pnpm run dogfood -- restart second-device` after add-device acceptance.
 7. Add selected and unrelated future memories, then verify delivery, isolation, offline revocation, recovery, and restart persistence.
 

--- a/e2e/bin/dogfood.test.ts
+++ b/e2e/bin/dogfood.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	buildManualChecklist,
 	buildOwnerSetupPlan,
+	buildRecipientSetupPlans,
 	createDogfoodRunner,
 	createRuntimePaths,
 	parseDogfoodCommand,
@@ -51,6 +52,7 @@ function createHarness(initialState: DogfoodState | null = null) {
 					identity_invariant: { active_local_count: 1, human_named: true },
 				},
 			})),
+			configureRecipientProfiles: vi.fn(),
 			configureAndEnrollOwner: vi.fn(),
 			waitForViewers: vi.fn(async () => undefined),
 			stop: vi.fn(),
@@ -150,6 +152,25 @@ describe("fixed runtime paths", () => {
 		expect(plan.enrollmentCommand).toContain("owner-device");
 		expect(JSON.stringify(plan)).not.toMatch(/peer-b|peer-c|invite/u);
 	});
+
+	it("builds human-named recipient profile setup plans", () => {
+		expect(buildRecipientSetupPlans()).toEqual([
+			{
+				service: "peer-b",
+				config: {
+					actor_display_name: "Dogfood Teammate",
+					sync_device_name: "Dogfood Teammate Device",
+				},
+			},
+			{
+				service: "peer-c",
+				config: {
+					actor_display_name: "Dogfood Teammate Second Device",
+					sync_device_name: "Dogfood Teammate Second Device",
+				},
+			},
+		]);
+	});
 });
 
 describe("dogfood runner", () => {
@@ -248,6 +269,7 @@ describe("dogfood runner", () => {
 			"peer-c",
 			"setup-second-device",
 		);
+		expect(dependencies.operations.configureRecipientProfiles).toHaveBeenCalledTimes(1);
 		expect(dependencies.operations.configureAndEnrollOwner).toHaveBeenCalledTimes(1);
 		expect(dependencies.operations.waitForViewers).toHaveBeenCalledTimes(1);
 		expect(getState()?.services).toEqual(INITIAL_STATE.services);
@@ -256,6 +278,7 @@ describe("dogfood runner", () => {
 			vi.mocked(dependencies.state.remove).mock.invocationCallOrder[0],
 			vi.mocked(dependencies.operations.up).mock.invocationCallOrder[0],
 			vi.mocked(dependencies.operations.fixture).mock.invocationCallOrder.at(-1),
+			vi.mocked(dependencies.operations.configureRecipientProfiles).mock.invocationCallOrder[0],
 			vi.mocked(dependencies.operations.configureAndEnrollOwner).mock.invocationCallOrder[0],
 			vi.mocked(dependencies.operations.waitForViewers).mock.invocationCallOrder[0],
 			vi.mocked(dependencies.state.write).mock.invocationCallOrder[0],
@@ -269,6 +292,7 @@ describe("dogfood runner", () => {
 		"owner-fixture",
 		"teammate-fixture",
 		"second-device-fixture",
+		"recipient-configuration",
 		"enrollment",
 		"readiness",
 	] as const)(
@@ -293,6 +317,11 @@ describe("dogfood runner", () => {
 						throw failure;
 					}
 					return { ok: true, action };
+				});
+			}
+			if (stage === "recipient-configuration") {
+				vi.mocked(dependencies.operations.configureRecipientProfiles).mockImplementation(() => {
+					throw failure;
 				});
 			}
 			if (stage === "enrollment") {
@@ -521,18 +550,23 @@ describe("manual checklist", () => {
 		expect(checklist).toContain("http://127.0.0.1:38881");
 		expect(checklist).toContain("http://127.0.0.1:38882");
 		expect(checklist).toContain("http://127.0.0.1:38883");
-		const teamInvite = "Create a Team invitation in the owner UI";
+		const teamInvite = "Create an invitation → Invite Team member";
 		const teammateRestart = "pnpm run dogfood -- restart teammate";
-		const projectInvite = "Create an exact-Project invitation in the owner UI";
+		const projectInvite = "Create an invitation → Share exact Projects";
 		const addDeviceInvite =
-			"Create an add-device invitation in the teammate UI for that Identity";
-		const addDeviceAccept = "Accept the add-device invitation in the second-device UI";
+			"In the Teammate B UI (38882), choose Create an invitation → Add a device for that Identity";
+		const addDeviceAccept = "Accept the add-device invitation in the Second device C UI (38883)";
 		const secondDeviceRestart = "pnpm run dogfood -- restart second-device";
+		expect(checklist).toContain("Owner A: http://127.0.0.1:38881");
+		expect(checklist).toContain("Teammate B: http://127.0.0.1:38882");
+		expect(checklist).toContain("Second device C: http://127.0.0.1:38883");
 		expect(checklist).toContain(teamInvite);
+		expect(checklist).toContain("Do not choose Share exact Projects at this step");
+		expect(checklist).not.toContain("Create a Team invitation");
 		expect(checklist).toContain("If the teammate UI reports that restart is required");
 		expect(checklist).toContain(teammateRestart);
 		expect(checklist).toContain(projectInvite);
-		expect(checklist).toContain("accept it in the same teammate profile");
+		expect(checklist).toContain("accept it in the same Teammate B profile (38882)");
 		expect(checklist).toContain(addDeviceInvite);
 		expect(checklist).toContain(addDeviceAccept);
 		expect(checklist).toContain(secondDeviceRestart);

--- a/e2e/bin/dogfood.ts
+++ b/e2e/bin/dogfood.ts
@@ -72,6 +72,7 @@ interface DogfoodOperations {
 	down(): void;
 	ps(): string;
 	fixture(service: DogfoodService, action: FixtureAction): unknown;
+	configureRecipientProfiles(): void;
 	configureAndEnrollOwner(): void;
 	waitForViewers(): Promise<void>;
 	stop(service: DogfoodService): void;
@@ -179,6 +180,25 @@ export function buildOwnerSetupPlan(identity: {
 	};
 }
 
+export function buildRecipientSetupPlans() {
+	return [
+		{
+			service: "peer-b" as const,
+			config: {
+				actor_display_name: "Dogfood Teammate",
+				sync_device_name: "Dogfood Teammate Device",
+			},
+		},
+		{
+			service: "peer-c" as const,
+			config: {
+				actor_display_name: "Dogfood Teammate Second Device",
+				sync_device_name: "Dogfood Teammate Second Device",
+			},
+		},
+	] as const;
+}
+
 const USAGE = `Usage: pnpm run dogfood -- <command>
 Commands:
   setup [--build] [--reset]
@@ -255,17 +275,17 @@ export function sanitizeDiagnosticText(text: string, repositoryRoot: string): st
 
 export function buildManualChecklist(): string {
 	return `Dogfood viewers:
-  Owner: ${VIEWER_URLS.owner}
-  Teammate: ${VIEWER_URLS.teammate}
-  Second device: ${VIEWER_URLS["second-device"]}
+  Owner A: ${VIEWER_URLS.owner}
+  Teammate B: ${VIEWER_URLS.teammate}
+  Second device C: ${VIEWER_URLS["second-device"]}
 
 Manual invitation checklist:
-  1. Assign the selected Project to the test Team in the owner UI.
-  2. Create a Team invitation in the owner UI and accept it in the teammate UI.
+  1. Assign the selected Project to the test Team in the Owner A UI (38881).
+  2. In the Owner A UI (38881), choose Create an invitation → Invite Team member. Do not choose Share exact Projects at this step. Accept it in the Teammate B UI (38882).
   3. If the teammate UI reports that restart is required, run: pnpm run dogfood -- restart teammate
-  4. Create an exact-Project invitation in the owner UI and accept it in the same teammate profile.
-  5. Create an add-device invitation in the teammate UI for that Identity.
-  6. Accept the add-device invitation in the second-device UI.
+  4. In the Owner A UI (38881), choose Create an invitation → Share exact Projects; accept it in the same Teammate B profile (38882).
+  5. In the Teammate B UI (38882), choose Create an invitation → Add a device for that Identity.
+  6. Accept the add-device invitation in the Second device C UI (38883).
   7. Restart the second device by running: pnpm run dogfood -- restart second-device
   8. Add selected and unrelated future memories and verify exact delivery and isolation.
   9. Exercise offline revocation, recovery, and restart persistence manually.`;
@@ -307,6 +327,7 @@ async function runSetup(
 		dependencies.operations.fixture("peer-c", "setup-second-device"),
 	];
 	assertDistinctFixtureIdentities(fixtureSummaries);
+	dependencies.operations.configureRecipientProfiles();
 	dependencies.operations.configureAndEnrollOwner();
 	await dependencies.operations.waitForViewers();
 	dependencies.state.write({
@@ -494,6 +515,17 @@ function createOperations(paths: RuntimePaths): DogfoodOperations {
 			);
 			assertStatus(result.status, 0, `${service} fixture action ${action} failed`);
 			return JSON.parse(result.stdout) as unknown;
+		},
+		configureRecipientProfiles: () => {
+			for (const plan of buildRecipientSetupPlans()) {
+				writePeerConfig(
+					context,
+					plan.service,
+					plan.config,
+					`configure-${plan.service}-profile`,
+				);
+				compose.restart(plan.service, `restart-configured-${plan.service}`);
+			}
 		},
 		configureAndEnrollOwner: () => {
 			const identity = readPeerIdentity(context, "peer-a", "read-owner-identity");

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -29,6 +29,7 @@ import Database from "better-sqlite3";
 import { describe, expect, it, vi } from "vitest";
 import { createApp, createSyncApp } from "./index.js";
 import { __usageCacheTestHooks } from "./routes/stats.js";
+import { reconcileConfiguredCoordinatorEnrollment } from "./routes/sync.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -11541,6 +11542,291 @@ describe("viewer-server", () => {
 			} finally {
 				recipient?.cleanup();
 				owner.cleanup();
+				globalThis.fetch = previousFetch;
+				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previousConfig;
+				if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
+				if (previousAdminSecret == null) {
+					delete process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
+				} else {
+					process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET = previousAdminSecret;
+				}
+				rmSync(testDir, { recursive: true, force: true });
+			}
+		});
+
+		it("reuses a reconciled Team identity for a later exact-Project share", async () => {
+			// Arrange
+			const teammateName = "Dogfood Teammate";
+			const testDir = mkdtempSync(join(tmpdir(), "codemem-team-project-regression-"));
+			const coordinatorDbPath = join(testDir, "coordinator.sqlite");
+			const ownerConfigPath = join(testDir, "owner-config.json");
+			const ownerKeysDir = join(testDir, "owner-keys");
+			const recipientConfigPath = join(testDir, "recipient-config.json");
+			const recipientKeysDir = join(testDir, "recipient-keys");
+			const previousConfig = process.env.CODEMEM_CONFIG;
+			const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const previousAdminSecret = process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
+			const previousFetch = globalThis.fetch;
+			const setupCoordinator = new core.BetterSqliteCoordinatorStore(coordinatorDbPath);
+			await setupCoordinator.createGroup("coordinator-a", "Coordinator A");
+			const coordinatorApp = core.createCoordinatorApp({
+				storeFactory: () => new core.BetterSqliteCoordinatorStore(coordinatorDbPath),
+				runtime: {
+					adminSecret: () => "secret",
+					now: () => "2026-08-07T12:00:00.000Z",
+				},
+				requestVerifier: async () => true,
+			});
+			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) =>
+				coordinatorApp.request(String(input), init),
+			) as typeof fetch;
+			const useOwnerConfig = () => {
+				process.env.CODEMEM_CONFIG = ownerConfigPath;
+				process.env.CODEMEM_KEYS_DIR = ownerKeysDir;
+				process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET = "secret";
+			};
+			const useRecipientConfig = () => {
+				process.env.CODEMEM_CONFIG = recipientConfigPath;
+				process.env.CODEMEM_KEYS_DIR = recipientKeysDir;
+				delete process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
+			};
+			useOwnerConfig();
+			writeFileSync(
+				ownerConfigPath,
+				JSON.stringify({
+					actor_display_name: "Owner Identity",
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "coordinator-a",
+					sync_coordinator_admin_secret: "secret",
+				}),
+			);
+			const owner = createTestApp({ seedDevice: false });
+			let recipient: ReturnType<typeof createTestApp> | null = null;
+			try {
+				const ownerStore = owner.ensureStore();
+				const [ownerDeviceId] = ensureDeviceIdentity(ownerStore.db, { keysDir: ownerKeysDir });
+				ownerStore.adoptEnsuredDeviceIdentity(ownerDeviceId);
+				ownerStore.db
+					.prepare(`INSERT OR IGNORE INTO actors(
+						actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+					) VALUES (?, 'Owner Identity', 1, 'active', NULL, ?, ?)`)
+					.run(ownerStore.actorId, "2026-08-07T12:00:00.000Z", "2026-08-07T12:00:00.000Z");
+				const ownerDevice = ownerStore.db
+					.prepare("SELECT public_key, fingerprint FROM sync_device WHERE device_id = ?")
+					.get(ownerDeviceId) as { public_key: string; fingerprint: string };
+				await setupCoordinator.enrollDevice("coordinator-a", {
+					deviceId: ownerDeviceId,
+					publicKey: ownerDevice.public_key,
+					fingerprint: ownerDevice.fingerprint,
+					displayName: "Owner Laptop",
+					identityId: ownerStore.actorId,
+				});
+				const teamId = "policy-team-a";
+				const projectId = "https://git.example.invalid/acme/team-project.git";
+				const now = "2026-08-07T12:00:00.000Z";
+				ownerStore.db
+					.prepare(`INSERT INTO policy_teams(
+						team_id, display_name, status, provenance, revision, migration_state,
+						source_fingerprint, idempotency_key, created_at, updated_at
+					) VALUES (?, 'Policy Team A', 'active', 'user', 'r1', 'user_managed',
+						NULL, 'team-a', ?, ?)`)
+					.run(teamId, now, now);
+				const sessionId = insertTestSession(ownerStore.db);
+				ownerStore.db
+					.prepare("UPDATE sessions SET git_remote = ?, project = ? WHERE id = ?")
+					.run(projectId, "team-project", sessionId);
+				insertTestMemory(ownerStore, {
+					sessionId,
+					kind: "discovery",
+					title: "shared project memory",
+					originDeviceId: ownerDeviceId,
+				});
+				ownerStore.db
+					.prepare(`INSERT INTO project_recipients(
+						canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+						policy_revision, migration_state, source_fingerprint, idempotency_key,
+						created_at, updated_at
+					) VALUES (?, 'team', ?, 'active', 'user', 'r1', 'user_managed', NULL,
+						'team-project', ?, ?)`)
+					.run(projectId, teamId, now, now);
+
+				const teamPreviewResponse = await owner.app.request(
+					"/api/sync/recipient-policy/v1/invites/preview",
+					{
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ kind: "team_member", policy_team_id: teamId }),
+					},
+				);
+				expect(teamPreviewResponse.status).toBe(200);
+				const teamPreview = (await teamPreviewResponse.json()) as {
+					preview: { reviewedOnboardingDigest: string };
+				};
+				const teamCreateResponse = await owner.app.request(
+					"/api/sync/recipient-policy/v1/invites",
+					{
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({
+							kind: "team_member",
+							policy_team_id: teamId,
+							reviewed_onboarding_digest: teamPreview.preview.reviewedOnboardingDigest,
+						}),
+					},
+				);
+				expect(teamCreateResponse.status).toBe(200);
+				const teamCreated = (await teamCreateResponse.json()) as { invite: { encoded: string } };
+
+				useRecipientConfig();
+				writeFileSync(recipientConfigPath, JSON.stringify({ actor_display_name: teammateName }));
+				recipient = createTestApp({ seedDevice: false });
+				const recipientStore = recipient.ensureStore();
+				const inspectTeam = await recipient.app.request("/api/sync/invites/inspect", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						invite: teamCreated.invite.encoded,
+						device_name: "Teammate Laptop",
+					}),
+				});
+				expect(inspectTeam.status).toBe(200);
+				const teamInspection = (await inspectTeam.json()) as {
+					assigned_identity_id: string;
+					recipient_name: string;
+					onboarding: { reviewedOnboardingDigest: string };
+				};
+				expect(teamInspection.recipient_name).toBe(teammateName);
+
+				// Act
+				const acceptTeam = await recipient.app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						invite: teamCreated.invite.encoded,
+						recipient_name: teammateName,
+						device_name: "Teammate Laptop",
+						reviewed_onboarding_digest: teamInspection.onboarding.reviewedOnboardingDigest,
+					}),
+				});
+				expect(acceptTeam.status, JSON.stringify(await acceptTeam.clone().json())).toBe(200);
+				expect(recipientStore.actorId).toBe(teamInspection.assigned_identity_id);
+
+				useOwnerConfig();
+				const enrollmentReconciliation = await reconcileConfiguredCoordinatorEnrollment(ownerStore);
+				expect(enrollmentReconciliation).toMatchObject({
+					failedGroups: 0,
+					identitiesAdded: 1,
+					membershipsAdded: 1,
+					issues: 0,
+				});
+				expect(
+					ownerStore.db
+						.prepare("SELECT display_name, status FROM actors WHERE actor_id = ?")
+						.get(teamInspection.assigned_identity_id),
+				).toEqual({ display_name: teammateName, status: "active" });
+
+				const projectPreviewResponse = await owner.app.request(
+					"/api/sync/project-invites/preview",
+					{
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ teammate_name: teammateName, project_ids: [projectId] }),
+					},
+				);
+				expect(projectPreviewResponse.status).toBe(200);
+				const projectPreview = (await projectPreviewResponse.json()) as {
+					operation_id: string;
+					reviewed_project_set_digest: string;
+					teammate: { match: string; person_id: string };
+				};
+				expect(projectPreview.teammate).toEqual({
+					display_name: teammateName,
+					match: "existing",
+					person_id: teamInspection.assigned_identity_id,
+				});
+				const projectCreateResponse = await owner.app.request("/api/sync/project-invites", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						teammate_name: teammateName,
+						project_ids: [projectId],
+						reviewed_project_set_digest: projectPreview.reviewed_project_set_digest,
+					}),
+				});
+				expect(
+					projectCreateResponse.status,
+					JSON.stringify(await projectCreateResponse.clone().json()),
+				).toBe(200);
+				const projectCreated = (await projectCreateResponse.json()) as {
+					invite: { encoded: string };
+				};
+				expect(
+					ownerStore.db
+						.prepare("SELECT person_id, person_kind FROM share_operations WHERE operation_id = ?")
+						.get(projectPreview.operation_id),
+				).toEqual({ person_id: teamInspection.assigned_identity_id, person_kind: "existing" });
+
+				useRecipientConfig();
+				const inspectProject = await recipient.app.request("/api/sync/invites/inspect", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite: projectCreated.invite.encoded }),
+				});
+				expect(inspectProject.status).toBe(200);
+				const acceptProject = await recipient.app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						invite: projectCreated.invite.encoded,
+						device_name: "Teammate Laptop",
+					}),
+				});
+				expect(acceptProject.status, JSON.stringify(await acceptProject.clone().json())).toBe(200);
+
+				useOwnerConfig();
+				const reconcileProject = await owner.app.request(
+					`/api/sync/project-invites/${projectPreview.operation_id}/reconcile`,
+					{ method: "POST" },
+				);
+
+				// Assert
+				expect(reconcileProject.status, JSON.stringify(await reconcileProject.clone().json())).toBe(
+					200,
+				);
+				expect(await reconcileProject.json()).toMatchObject({
+					reconciled: true,
+					state: "pending_setup",
+				});
+				expect(
+					ownerStore.db
+						.prepare(
+							"SELECT state, person_id, person_kind, recipient_actor_id FROM share_operations WHERE operation_id = ?",
+						)
+						.get(projectPreview.operation_id),
+				).toEqual({
+					state: "provisioning",
+					person_id: teamInspection.assigned_identity_id,
+					person_kind: "existing",
+					recipient_actor_id: teamInspection.assigned_identity_id,
+				});
+				expect(
+					ownerStore.db
+						.prepare("SELECT COUNT(*) FROM actors WHERE display_name = ? AND status = 'pending'")
+						.pluck()
+						.get(teammateName),
+				).toBe(0);
+				expect(
+					ownerStore.db
+						.prepare("SELECT COUNT(*) FROM actors WHERE lower(display_name) = lower(?)")
+						.pluck()
+						.get(teammateName),
+				).toBe(1);
+			} finally {
+				recipient?.cleanup();
+				owner.cleanup();
+				await setupCoordinator.close();
 				globalThis.fetch = previousFetch;
 				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
 				else process.env.CODEMEM_CONFIG = previousConfig;


### PR DESCRIPTION
## Description

Completes `codemem-fh19.2` with a cross-workflow regression proving a Team-onboarded recipient is reused by later exact-Project sharing.

- consumes a real Team-member invitation for `Dogfood Teammate`
- reconciles the coordinator Identity onto the owner under the preserved display name
- proves exact-Project preview resolves that existing Identity
- proves acceptance reaches provisioning without `recipient_actor_conflict`
- asserts no duplicate pending person is created
- configures deterministic human recipient profiles before dogfood viewers accept invitations
- aligns dogfood instructions with exact UI labels and explicit A/B/C roles

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation:
- focused dogfood suite: 63 passed
- live Team → exact-Project flow reused the existing Identity and reached active
- `pnpm run check`: 177 files passed, 3,877 tests passed, 3 todo

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
