### PR TITLE
fix(sync): preserve add-device recipient names

### DIFF
--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -1217,10 +1217,8 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		opts: CoordinatorConsumeRecipientInviteInput,
 	): Promise<CoordinatorRecipientInviteAcceptance> {
 		const consumedAt = normalizeInviteExpiresAt(opts.now);
-		const recipientDisplayName =
-			opts.inviteKind === "team_member" ? (opts.recipientDisplayName ?? null) : null;
-		const deviceDisplayName =
-			opts.inviteKind === "team_member" ? (opts.deviceDisplayName ?? null) : null;
+		const recipientDisplayName = opts.recipientDisplayName ?? null;
+		const deviceDisplayName = opts.deviceDisplayName ?? null;
 		if (
 			!opts.identityId ||
 			!opts.deviceId ||

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -1849,6 +1849,7 @@ describe("coordinator local admin actions", () => {
 				dbPath: actionDbPath,
 				keysDir,
 				configPath,
+				recipientDisplayName: "Existing Person",
 				deviceDisplayName: "Recipient laptop",
 				reviewedOnboardingDigest,
 			}),
@@ -1866,7 +1867,11 @@ describe("coordinator local admin actions", () => {
 		});
 		expect(capturedBodies).toHaveLength(2);
 		expect(capturedBodies[0]).toEqual({ token: "fresh-add-device-token" });
-		expect(capturedBodies[1]?.identity_id).toBe(targetIdentityId);
+		expect(capturedBodies[1]).toMatchObject({
+			identity_id: targetIdentityId,
+			recipient_display_name: "Existing Person",
+			device_display_name: "Recipient laptop",
+		});
 		expect(readCodememConfigFileAtPath(configPath)).toMatchObject({
 			actor_id: targetIdentityId,
 		});
@@ -2422,15 +2427,10 @@ describe("coordinator local admin actions", () => {
 		});
 		const joinBodies = capturedBodies.filter((body) => body.invite_kind === testCase.kind);
 		expect(joinBodies).toHaveLength(2);
-		if (testCase.kind === "team_member") {
-			expect(joinBodies[0]).toMatchObject({
-				recipient_display_name: "Brian Example",
-				device_display_name: "Recipient laptop",
-			});
-		} else {
-			expect(joinBodies[0]).not.toHaveProperty("recipient_display_name");
-			expect(joinBodies[0]).not.toHaveProperty("device_display_name");
-		}
+		expect(joinBodies[0]).toMatchObject({
+			recipient_display_name: "Brian Example",
+			device_display_name: "Recipient laptop",
+		});
 
 		const persistedConfig = readCodememConfigFileAtPath(configPath);
 		expect(persistedConfig).toMatchObject({

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -2187,12 +2187,8 @@ export async function coordinatorImportInviteAction(opts: {
 			? {
 					invite_kind: payload.kind,
 					identity_id: recipientActorId,
-					...(payload.kind === "team_member"
-						? {
-								recipient_display_name: recipientDisplayName,
-								device_display_name: displayName,
-							}
-						: {}),
+					recipient_display_name: recipientDisplayName,
+					device_display_name: displayName,
 				}
 			: {}),
 		...(projectInvite

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -1148,6 +1148,8 @@ describe("createCoordinatorApp dependency injection", () => {
 				device_id: "device-brian-2",
 				public_key: publicKey,
 				fingerprint: fingerprintPublicKey(publicKey),
+				recipient_display_name: "Brian Example",
+				device_display_name: "Brian's second device",
 			}),
 		});
 
@@ -1157,7 +1159,12 @@ describe("createCoordinatorApp dependency injection", () => {
 			kind: "add_device",
 			target_identity_id: "identity-brian",
 		});
-		expect(consumeRecipientInvite).toHaveBeenCalledOnce();
+		expect(consumeRecipientInvite).toHaveBeenCalledWith(
+			expect.objectContaining({
+				recipientDisplayName: "Brian Example",
+				deviceDisplayName: "Brian's second device",
+			}),
+		);
 	});
 
 	it("rejects add-device invites accepted by the inviter device", async () => {

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -2120,10 +2120,8 @@ export function createCoordinatorApp(
 						deviceId,
 						publicKey,
 						fingerprint,
-						recipientDisplayName:
-							invite.invite_kind === "team_member" ? normalizedRecipientDisplayName : null,
-						deviceDisplayName:
-							invite.invite_kind === "team_member" ? normalizedDeviceDisplayName : null,
+						recipientDisplayName: normalizedRecipientDisplayName,
+						deviceDisplayName: normalizedDeviceDisplayName,
 						now: runtime.now(),
 					});
 					return c.json({

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -1204,9 +1204,17 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 						deviceId: "device-brian-2",
 						publicKey: "add-device-key",
 						fingerprint: fingerprintPublicKey("add-device-key"),
+						recipientDisplayName: "Brian Example",
+						deviceDisplayName: "Brian's iPad",
 					};
 					const acceptedAddDevice = await store.consumeRecipientInvite(addDeviceInput);
-					expect(acceptedAddDevice.status).toBe("accepted");
+					expect(acceptedAddDevice).toMatchObject({
+						status: "accepted",
+						invite: {
+							recipient_display_name: "Brian Example",
+							recipient_device_display_name: "Brian's iPad",
+						},
+					});
 					expect(acceptedAddDevice.bootstrap_grant).toMatchObject({
 						seed_device_id: teamInput.deviceId,
 						worker_device_id: addDeviceInput.deviceId,
@@ -1215,7 +1223,19 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 						"g1",
 						addDeviceInput.deviceId,
 					);
-					expect((await store.consumeRecipientInvite(addDeviceInput)).status).toBe("existing");
+					expect(
+						await store.consumeRecipientInvite({
+							...addDeviceInput,
+							recipientDisplayName: "Unexpected replay rename",
+							deviceDisplayName: "Unexpected replay device rename",
+						}),
+					).toMatchObject({
+						status: "existing",
+						invite: {
+							recipient_display_name: "Brian Example",
+							recipient_device_display_name: "Brian's iPad",
+						},
+					});
 					const replayedAddDeviceEnrollment = await store.getEnrollment(
 						"g1",
 						addDeviceInput.deviceId,
@@ -1250,12 +1270,12 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 							public_key: addDeviceInput.publicKey,
 							fingerprint: addDeviceInput.fingerprint,
 							identity_id: addDeviceInput.identityId,
-							display_name: null,
+							display_name: "Brian's iPad",
 							enabled: 1,
 						}),
 						expect.objectContaining({
 							identity_id: addDeviceInput.identityId,
-							display_name: null,
+							display_name: "Brian's iPad",
 						}),
 					]);
 					expect(await store.listScopeMemberships("scope-project")).toEqual([]);

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -1059,10 +1059,8 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		_opts: CoordinatorConsumeRecipientInviteInput,
 	): Promise<CoordinatorRecipientInviteAcceptance> {
 		const consumedAt = normalizeInviteExpiresAt(_opts.now);
-		const recipientDisplayName =
-			_opts.inviteKind === "team_member" ? (_opts.recipientDisplayName ?? null) : null;
-		const deviceDisplayName =
-			_opts.inviteKind === "team_member" ? (_opts.deviceDisplayName ?? null) : null;
+		const recipientDisplayName = _opts.recipientDisplayName ?? null;
+		const deviceDisplayName = _opts.deviceDisplayName ?? null;
 		if (
 			!_opts.identityId ||
 			!_opts.deviceId ||


### PR DESCRIPTION
## Description

Fixes `codemem-fh19.3` by preserving add-device recipient and device display names through coordinator acceptance and reconciliation.

The add-device path previously dropped both names at three boundaries, leaving consumed invite and enrollment rows null and forcing owner views to show `Enrolled device`. This change:

- sends normalized names for both recipient invitation kinds
- forwards them through `/v1/join` without changing Identity binding or authorization
- persists them in Better-SQLite and D1 coordinator stores
- preserves first-write-wins behavior during invite replay
- keeps null-name compatibility for legacy clients and rows

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional validation:
- focused coordinator action, API, SQLite, and D1 suites: 273 passed
- `pnpm run check`: 177 files passed, 3,877 tests passed, 3 todo
- two CodeReviewer passes; no remaining blocking or high-severity findings

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed; no public API or workflow change)
- [x] No new warnings introduced
