### PR TITLE
fix(sync): restore re-enabled project recipients

### DIFF
--- a/packages/core/src/recipient-policy-reconciler.test.ts
+++ b/packages/core/src/recipient-policy-reconciler.test.ts
@@ -1415,6 +1415,170 @@ describe("recipient-policy reconciler executor", () => {
 		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([]);
 	});
 
+	it("clears a freshly active re-enabled device overlay before capability preflight", async () => {
+		insertActiveAuthority(db);
+		putRecipientPolicyDenyOverlay(db, {
+			canonicalProjectIdentity: PROJECT,
+			scopeId: SCOPE,
+			deviceId: "device-new",
+			generation: 2,
+			reasonCode: "enrollment_disabled",
+			now: new Date(BASE_TIME).toISOString(),
+		});
+		const { effects } = harness(["device-keep", "device-new"]);
+		vi.mocked(effects.snapshot).mockResolvedValue({
+			authoritative: true,
+			scopeId: SCOPE,
+			scopeMembershipEpoch: 3,
+			fingerprint: "snapshot:reenabled-epoch-3",
+			observedAt: new Date(BASE_TIME + 10_000).toISOString(),
+			memberships: ["device-keep", "device-new"].map((deviceId) => ({
+				deviceId,
+				status: "active" as const,
+				membershipEpoch: 3,
+			})),
+		});
+		vi.mocked(effects.probeCapability).mockResolvedValue("undetermined");
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-a" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "waiting",
+			safeErrorCode: "recipient_policy_capability_undetermined",
+		});
+		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([]);
+		expect(effects.grant).not.toHaveBeenCalled();
+		expect(effects.revoke).not.toHaveBeenCalled();
+	});
+
+	it("keeps a deny overlay when active membership lacks matching enabled enrollment proof", async () => {
+		insertActiveAuthority(db);
+		putRecipientPolicyDenyOverlay(db, {
+			canonicalProjectIdentity: PROJECT,
+			scopeId: SCOPE,
+			deviceId: "device-new",
+			generation: 2,
+			reasonCode: "enrollment_disabled",
+			now: new Date(BASE_TIME).toISOString(),
+		});
+		const { effects } = harness(["device-keep", "device-new"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: "identity-a",
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: true,
+			},
+		]);
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-a" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "waiting",
+			safeErrorCode: "recipient_policy_parity_incomplete",
+		});
+		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([
+			expect.objectContaining({ deviceId: "device-new", scopeId: SCOPE }),
+		]);
+	});
+
+	it("keeps a deny overlay when matching enrollment remains disabled", async () => {
+		insertActiveAuthority(db);
+		putRecipientPolicyDenyOverlay(db, {
+			canonicalProjectIdentity: PROJECT,
+			scopeId: SCOPE,
+			deviceId: "device-new",
+			generation: 2,
+			reasonCode: "enrollment_disabled",
+			now: new Date(BASE_TIME).toISOString(),
+		});
+		const { effects } = harness(["device-keep", "device-new"]);
+		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([
+			{
+				deviceId: "device-keep",
+				identityId: "identity-a",
+				publicKey: "pk-keep",
+				fingerprint: "fp-keep",
+				enabled: true,
+			},
+			{
+				deviceId: "device-new",
+				identityId: "identity-a",
+				publicKey: "pk-new",
+				fingerprint: "fp-new",
+				enabled: false,
+			},
+		]);
+		vi.mocked(effects.probeCapability).mockResolvedValue("undetermined");
+
+		await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-a" },
+			effects,
+		);
+
+		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([
+			expect.objectContaining({ deviceId: "device-new", scopeId: SCOPE }),
+		]);
+	});
+
+	it("keeps a deny overlay without fresh active membership proof", async () => {
+		insertActiveAuthority(db);
+		putRecipientPolicyDenyOverlay(db, {
+			canonicalProjectIdentity: PROJECT,
+			scopeId: SCOPE,
+			deviceId: "device-new",
+			generation: 2,
+			reasonCode: "enrollment_disabled",
+			now: new Date(BASE_TIME).toISOString(),
+		});
+		const { effects } = harness(["device-keep"]);
+		vi.mocked(effects.probeCapability).mockResolvedValue("undetermined");
+
+		await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-a" },
+			effects,
+		);
+
+		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([
+			expect.objectContaining({ deviceId: "device-new", scopeId: SCOPE }),
+		]);
+	});
+
+	it("keeps a deny overlay outside the active managed boundary", async () => {
+		insertActiveAuthority(db);
+		putRecipientPolicyDenyOverlay(db, {
+			canonicalProjectIdentity: PROJECT,
+			scopeId: "other-managed-scope",
+			deviceId: "device-new",
+			generation: 2,
+			reasonCode: "enrollment_disabled",
+			now: new Date(BASE_TIME).toISOString(),
+		});
+		const { effects } = harness(["device-keep", "device-new"]);
+		vi.mocked(effects.probeCapability).mockResolvedValue("undetermined");
+
+		await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-a" },
+			effects,
+		);
+
+		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([
+			expect.objectContaining({ deviceId: "device-new", scopeId: "other-managed-scope" }),
+		]);
+	});
+
 	it("cancels a stale generation after revokes and before any grant", async () => {
 		const { effects, members } = harness(["device-old"]);
 		vi.mocked(effects.revoke).mockImplementation(async (input) => {

--- a/packages/core/src/recipient-policy-reconciler.ts
+++ b/packages/core/src/recipient-policy-reconciler.ts
@@ -1114,21 +1114,21 @@ export async function reconcileRecipientPolicyProject(
 			)
 			.map((device) => device.deviceId)
 			.toSorted();
+		const grantEligibleSet = new Set(grantEligibleDeviceIds);
 		const expectedDeviceIds = [
 			...new Set([
 				...remainingCurrentDeviceIds.filter((deviceId) => policyDesiredSet.has(deviceId)),
 				...grantEligibleDeviceIds,
 			]),
 		].toSorted();
-		const expectedSet = new Set(expectedDeviceIds);
 		const expectedDigest = deviceDigest(expectedDeviceIds);
 		const grantDeviceIds = grantEligibleDeviceIds.filter((deviceId) => !currentSet.has(deviceId));
 		const passKey = digest("recipient-policy-pass-v1", {
 			fingerprint: initialSnapshot.fingerprint,
 			observedAt: initialSnapshot.observedAt,
 		});
-		// Keep the lease fence and prune atomic so a replacement worker cannot acquire
-		// the lease between them and lose its in-flight capability steps.
+		// Fence capability-step pruning and generation-verified deny cleanup together;
+		// a replacement worker must not lose its steps or race a stale overlay release.
 		db.transaction(() => {
 			assertLease(db, projectId, input.leaseOwner, effects.now());
 			activeGeneration = generation(db, projectId, expectedDigest);
@@ -1137,6 +1137,20 @@ export async function reconcileRecipientPolicyProject(
 				activeGeneration,
 				activePassKey: passKey,
 			});
+			for (const overlay of listRecipientPolicyDenyOverlays(db, projectId)) {
+				if (
+					overlay.scopeId === managedBoundary.scopeId &&
+					grantEligibleSet.has(overlay.deviceId) &&
+					currentSet.has(overlay.deviceId)
+				) {
+					clearRecipientPolicyDenyOverlay(db, {
+						canonicalProjectIdentity: projectId,
+						scopeId: overlay.scopeId,
+						deviceId: overlay.deviceId,
+						verifiedGeneration: activeGeneration,
+					});
+				}
+			}
 		}).immediate();
 		const revocations = [
 			...policyRevocations,
@@ -1332,7 +1346,7 @@ export async function reconcileRecipientPolicyProject(
 		for (const overlay of listRecipientPolicyDenyOverlays(db, projectId)) {
 			const revokeVerified = !verifiedSet.has(overlay.deviceId);
 			const desiredActiveVerified =
-				expectedSet.has(overlay.deviceId) && verifiedSet.has(overlay.deviceId);
+				grantEligibleSet.has(overlay.deviceId) && verifiedSet.has(overlay.deviceId);
 			if (
 				overlay.scopeId === managedBoundary.scopeId &&
 				(revokeVerified || desiredActiveVerified)
@@ -1345,14 +1359,26 @@ export async function reconcileRecipientPolicyProject(
 				});
 			}
 		}
-		const parity =
+		const deniedDeviceIds = new Set(
+			listRecipientPolicyDenyOverlays(db, projectId)
+				.filter((overlay) => overlay.scopeId === managedBoundary.scopeId)
+				.map((overlay) => overlay.deviceId),
+		);
+		const effectiveVerifiedDeviceIds = verifiedDeviceIds.filter(
+			(deviceId) => !deniedDeviceIds.has(deviceId),
+		);
+		const membershipParity =
 			verifiedDeviceIds.length === expectedDeviceIds.length &&
 			verifiedDeviceIds.every((deviceId, index) => deviceId === expectedDeviceIds[index]);
+		const parity =
+			membershipParity && !expectedDeviceIds.some((deviceId) => deniedDeviceIds.has(deviceId));
 		upsertRecipientPolicyAuthorityObservation(db, {
 			canonicalProjectIdentity: projectId,
 			generation: activeGeneration,
 			desiredDevicesDigest: expectedDigest,
-			currentDevicesDigest: parity ? expectedDigest : deviceDigest(verifiedDeviceIds),
+			currentDevicesDigest: parity
+				? expectedDigest
+				: deviceDigest(membershipParity ? effectiveVerifiedDeviceIds : verifiedDeviceIds),
 			freshSnapshotFingerprint: verifiedSnapshot.fingerprint,
 			freshSnapshotObservedAt: verifiedSnapshot.observedAt,
 			now: effects.now(),

--- a/packages/core/src/scope-membership-cache.test.ts
+++ b/packages/core/src/scope-membership-cache.test.ts
@@ -449,8 +449,36 @@ describe("scope membership cache", () => {
 				scopeId: "scope-acme",
 				now: new Date(now(2)),
 			}),
-		).toMatchObject({ authorized: false, state: "revoked", freshness: "fresh" });
+		).toMatchObject({ authorized: false, state: "scope_inactive", freshness: "fresh" });
 		expect(listCachedScopesForDevice(local, "device-a").memberships).toEqual([]);
+	});
+
+	it("restores unchanged peer memberships when an enrolled device regains scope visibility", async () => {
+		const local = setup();
+		const fetch = async (visible: boolean) =>
+			refreshScopeMembershipCache(local, {
+				groupIds: ["team-a"],
+				coordinatorId: "coord-a",
+				now: new Date(now(visible ? 2 : 1)),
+				fetchers: {
+					listScopes: async () => (visible ? [scope()] : []),
+					listMemberships: async () => [membership(), membership({ device_id: "device-peer" })],
+				},
+			});
+
+		await fetch(true);
+		await fetch(false);
+		await fetch(true);
+
+		expect(
+			getCachedScopeAuthorization(local, { deviceId: "device-a", scopeId: "scope-acme" }),
+		).toMatchObject({ authorized: true, state: "authorized" });
+		expect(
+			getCachedScopeAuthorization(local, {
+				deviceId: "device-peer",
+				scopeId: "scope-acme",
+			}),
+		).toMatchObject({ authorized: true, state: "authorized" });
 	});
 
 	it("does not let stale active grants resurrect revoked memberships", () => {

--- a/packages/core/src/scope-membership-cache.ts
+++ b/packages/core/src/scope-membership-cache.ts
@@ -311,6 +311,8 @@ function reconcileScopeMembershipSnapshot(
 	authority: ScopeMembershipCacheAuthority,
 	timestamp: string,
 ): void {
+	// The authorized scope-members endpoint returns the complete membership list
+	// that is active at the current epoch, so absence is fail-closed here.
 	const deviceIds = memberships.map((membership) => membership.device_id);
 	const deviceFilter =
 		deviceIds.length > 0 ? `AND device_id NOT IN (${placeholders(deviceIds.length)})` : "";
@@ -368,21 +370,9 @@ function reconcileGroupScopeSnapshot(
 			 AND group_id = ?
 			 AND scope_id IN (${placeholders(missingScopeIds.length)})`,
 	).run(timestamp, authority.coordinatorId, authority.groupId, ...missingScopeIds);
-	db.prepare(
-		`UPDATE scope_memberships
-		 SET status = 'revoked', updated_at = ?
-		 WHERE COALESCE(coordinator_id, ?) = ?
-			 AND COALESCE(group_id, ?) = ?
-			 AND scope_id IN (${placeholders(missingScopeIds.length)})
-			 AND status != 'revoked'`,
-	).run(
-		timestamp,
-		authority.coordinatorId,
-		authority.coordinatorId,
-		authority.groupId,
-		authority.groupId,
-		...missingScopeIds,
-	);
+	// Enrolled-device scope listings are filtered by the requester's current access.
+	// Archiving the omitted scope fails closed without poisoning unchanged peer rows
+	// as revoked; a later visible snapshot can reconcile its full membership list.
 }
 
 export function upsertCachedScopeMemberships(

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -3119,6 +3119,16 @@ describe("applyReplicationOps", () => {
 	});
 
 	it("physically deletes matching peer-received rows when access cleanup arrives", () => {
+		setReplicationCursor(
+			db,
+			"dev-remote",
+			{ lastApplied: "scoped-applied", lastAcked: "scoped-acked" },
+			"acme-work",
+		);
+		setReplicationCursor(db, "dev-remote", {
+			lastApplied: "default-applied",
+			lastAcked: "default-acked",
+		});
 		const memoryId = insertReplicatedMemory({
 			importKey: "key:cleanup",
 			originDeviceId: "dev-remote",
@@ -3142,6 +3152,11 @@ describe("applyReplicationOps", () => {
 		expect(
 			db.prepare("SELECT op_type, scope_id FROM replication_ops WHERE op_id = ?").get(op.op_id),
 		).toMatchObject({ op_type: "access_cleanup", scope_id: DEFAULT_SYNC_SCOPE_ID });
+		expect(getReplicationCursor(db, "dev-remote", "acme-work")).toEqual([
+			"scoped-applied",
+			"scoped-acked",
+		]);
+		expect(getReplicationCursor(db, "dev-remote")).toEqual(["default-applied", "default-acked"]);
 	});
 
 	it("does not let access cleanup delete local or differently scoped rows", () => {
@@ -3185,6 +3200,12 @@ describe("applyReplicationOps", () => {
 
 	it("reconciles provably stale peer-received rows without deleting receiver-owned rows", () => {
 		grantScope("acme-work", ["dev-remote"]);
+		setReplicationCursor(
+			db,
+			"dev-remote",
+			{ lastApplied: "stale-applied", lastAcked: "stale-acked" },
+			"acme-work",
+		);
 		const stalePeerMemoryId = insertReplicatedMemory({
 			importKey: "key:stale-peer",
 			originDeviceId: "dev-remote",
@@ -3212,6 +3233,7 @@ describe("applyReplicationOps", () => {
 		expect(
 			db.prepare("SELECT 1 FROM memory_items WHERE id = ?").get(missingOriginMemoryId),
 		).toBeDefined();
+		expect(getReplicationCursor(db, "dev-remote", "acme-work")).toEqual([null, null]);
 		expect(result.ambiguous).toEqual([
 			expect.objectContaining({
 				memory_id: missingOriginMemoryId,
@@ -3221,6 +3243,10 @@ describe("applyReplicationOps", () => {
 	});
 
 	it("removes remote-origin local-only rows conservatively and idempotently", () => {
+		setReplicationCursor(db, "dev-remote", {
+			lastApplied: "default-applied",
+			lastAcked: "default-acked",
+		});
 		const remoteNullId = insertReplicatedMemory({
 			importKey: "key:remote-null",
 			originDeviceId: "dev-remote",
@@ -3280,6 +3306,7 @@ describe("applyReplicationOps", () => {
 		);
 		expect(second.deleted).toBe(0);
 		expect(second.deleted_memory_ids).toEqual([]);
+		expect(getReplicationCursor(db, "dev-remote")).toEqual(["default-applied", "default-acked"]);
 	});
 
 	it("limits local-only cleanup to rows proven to originate from the syncing peer", () => {

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -2535,6 +2535,10 @@ function reconcileStalePeerReceivedRowsInternal(
 		ambiguous: [],
 	};
 	const deleteMemory = deleteRows ? db.prepare("DELETE FROM memory_items WHERE id = ?") : null;
+	const clearDeletedScopeCursor = (originDeviceId: string, scopeId: string): void => {
+		if (!deleteRows || scopeId === DEFAULT_SYNC_SCOPE_ID) return;
+		clearReplicationCursorLastApplied(db, originDeviceId, scopeId);
+	};
 	db.transaction(() => {
 		for (const row of rows) {
 			const memoryId = Number(row.id);
@@ -2599,6 +2603,7 @@ function reconcileStalePeerReceivedRowsInternal(
 				if (deleteRows) {
 					clearMemoryRefs(db, memoryId);
 					deleteMemory?.run(memoryId);
+					clearDeletedScopeCursor(originDeviceId, scopeId);
 				}
 				result.deleted += 1;
 				result.deleted_memory_ids.push(memoryId);
@@ -2619,6 +2624,7 @@ function reconcileStalePeerReceivedRowsInternal(
 			if (deleteRows) {
 				clearMemoryRefs(db, memoryId);
 				deleteMemory?.run(memoryId);
+				clearDeletedScopeCursor(originDeviceId, scopeId);
 			}
 			result.deleted += 1;
 			result.deleted_memory_ids.push(memoryId);


### PR DESCRIPTION
## Description

Restore selected-Project access after a recipient is revoked and later re-enabled.

- clear stale deny overlays before capability preflight only with fresh active-membership and matching enabled-enrollment proof
- keep filtered scope omissions fail-closed without permanently revoking unchanged peer memberships
- rewind only the affected peer/scope cursor when authorization cleanup physically removes replicated rows, allowing snapshot rehydration
- prevent retained deny overlays from producing a falsely healthy parity state

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation:
- `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1 pnpm run e2e:project-sharing -- --json`
- three-peer revoke/re-enable dogfood replay: selected memories restored, unrelated memories remained excluded
- authorization/security review completed with no blocking findings

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed; no CLI/API/UI contract changed)
- [x] No new warnings introduced
