### PR TITLE
docs: explain current sharing lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,29 +267,42 @@ See `codemem memory export --help` and `codemem memory import --help` for full o
 
 ## Sharing and devices
 
-Share selected project memories with a teammate, or use the same Project-first model to understand your own devices. The viewer's normal workflow is **Projects → Sharing → Devices → Health**; sync internals live under **Advanced**.
+Share selected project memories with a teammate, or use the same Project-first model to understand your own devices. The viewer's normal workflow is **Projects → Sharing → Devices → Health**; open **Sharing → Teams** to manage ongoing Team membership and inherited Project access. Sync internals live under **Advanced**.
 
 ### Share projects with a teammate
 
-In the viewer, choose **Share** on a project (or select projects, then choose **Share projects**):
+For ongoing collaboration:
 
-1. Choose or enter the teammate's **Person** name.
+1. Assign exact Projects to a **Team**.
+2. Invite people to join it.
+
+Team onboarding links Identities and devices. The invitation does not assign Projects to the Team, but a new member inherits every current and future Project assigned to it. Review the Team's Projects before sending or accepting the invitation. Use **Share exact Projects** to send a separate direct Project invitation to one Identity. Team sharing must already be configured, but accepting the direct invitation does not add the recipient to the Team.
+
+For a direct share, choose **Create an invitation → Share exact Projects**:
+
+1. Choose or enter the teammate's **Identity display name**.
 2. Select the exact projects to share and review each existing-memory count.
 3. Confirm that existing memories **and future activity** from those projects will share, then send the one expiring invite.
-4. The recipient accepts once, confirms their name and device name, and codemem links the Person and device, establishes trust and access, and starts the first sync.
+4. The recipient reviews and accepts the invitation, then confirms their Identity and device display names. Codemem establishes trust and Project access, then starts the first sync.
 
 Only the reviewed canonical projects are shared—similarly named or sibling projects are not included. A memory marked **Only me** stays local even when its project is shared. Removing access stops future sharing; memories already copied to another device may remain there.
 
+### Add, disable, or restore devices
+
+When an Identity adds another device, codemem shows the exact Projects it will inherit from direct shares and Team policies. Existing exclusions stay excluded. Review that list before sending the add-device invitation; acceptance links the new device to the same Identity without widening Project access.
+
+Disabling a device's enrollment for one coordinator group revokes future delivery only for that group's Projects. The global identity device stays active in **Devices** and can retain access through other groups. In **Advanced → Team administration**, re-enable that group enrollment; the next owner reconciliation pass then restores only the Projects currently authorized through direct shares and Team policies for that group. An offline device simply waits: it keeps its access and catches up when it reconnects. A separate global identity-device revocation removes the device from the active **Devices** list. Neither action remotely erases copied memories.
+
 ### Check devices and health
 
-**Devices** is read-only. Each card shows the device's owning Identity, whether it is available, and the Projects it receives:
+**Devices** is read-only. Each card shows the device's **Owning Identity**, whether it is available, and the Projects it receives:
 
 - **Direct** — the Project was shared with that Identity.
-- **Team** — the Identity receives the Project through a Team.
-- **Waiting** — setup or delivery is waiting for an offline device; it resumes on reconnect.
+- **Team** — the Identity receives the Project through a Team policy.
+- **Waiting** — acceptance, setup, or delivery is waiting; an offline device resumes on reconnect.
 - **Needs attention** — setup reached a terminal failure; use the displayed retry action.
 
-Use **Health** for the current status. Removing access prevents future delivery, but cannot erase a copy already delivered to another device.
+Use **Health** for the current status. Globally revoked identity devices are omitted from the active Devices list. A device disabled only for one coordinator group remains listed; use **Advanced → Team administration** to review or re-enable that group enrollment. Removing access prevents future delivery, but cannot erase a copy already delivered to another device.
 
 ### Advanced and compatibility
 

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -21,6 +21,8 @@ the network boundary you care about (for example VPNs).
 - joining a coordinator group does not, by itself, create an active sync relationship
 - joining a coordinator group does not, by itself, grant access to any Sharing domain
 
+The normal viewer flow can still use the coordinator to complete a Team, direct-Project, or add-device invitation. Those flows create explicit identity, trust, and Project-access records; discovery-group membership alone does not.
+
 ## Config
 
 Set these to enable coordinator-backed discovery:
@@ -129,9 +131,24 @@ authorize a device to receive `acme-work`, `personal:<actor_id>`, or any other
 domain. The coordinator group is the administrative container. The Sharing
 domain grant is the data-access decision.
 
+In the normal viewer vocabulary, people join **Teams**, share exact **Projects**, and review inherited Projects when adding a **device**. **Spaces** are the user-facing access boundaries. Advanced coordinator commands expose the underlying group, Sharing-domain, grant, and `scope_id` records used to enforce those choices.
+
 ## Project-first sharing and advanced administration
 
-For a teammate, start in the viewer's **Projects** tab: choose a Person, choose the exact projects, review existing-memory counts and future sharing, then send one expiring invite. Acceptance links the Person and device, establishes the required trust and access, and starts initial sync.
+For an ongoing group, use two separate steps:
+
+1. Assign exact **Projects** to a **Team**.
+2. Send **Invite Team member**.
+
+That onboarding invitation does not create Project-to-Team assignments. It links the Identity and device, then inherits every current and future Project already assigned to the Team. Review those Projects before sending or accepting the invitation.
+
+For a direct share:
+
+1. Choose **Share exact Projects** and select one Identity and the exact Projects.
+2. Review existing-memory counts and future sharing, then send the expiring invitation.
+3. The recipient reviews and accepts it before initial sync starts.
+
+When an existing Identity adds another device, create an add-device invitation and review the exact Projects inherited from that Identity's direct and Team access. Acceptance cannot add unrelated Projects or remove existing exclusions.
 
 The coordinator remains the authority for the invite and access steps, but its groups, devices, Spaces, grants, and project mappings are advanced administration—not normal teammate setup. Legacy coordinator invites and manual pairing remain compatible, but do not grant project access by themselves.
 
@@ -156,6 +173,8 @@ Operational rules:
 - Membership epochs make cached grants stale after revocation or replacement.
 - Revocation stops future sync after peers refresh membership. It does not erase
   memories already copied to a revoked device.
+- Disabling a device enrollment revokes future delivery only for that coordinator group; merely being offline does not. The global identity device can remain active and retain access through other groups.
+- Re-enabling that group enrollment clears the disabled state. The next owner reconciliation pass restores only the Projects currently authorized through direct shares and Team policies for the group; unrelated Projects stay absent. A global identity-device revocation is separate and is not restored by re-enabling a group enrollment.
 - Project include/exclude filters can only narrow data after the Sharing-domain
   membership check passes.
 - Local-only domains and migration review domains are not valid broad sharing

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -159,15 +159,27 @@ Candidate mining is deterministic and review-first:
 
 ## Projects, Sharing, Devices, and Health
 
-### Share projects with a teammate
+### Choose a sharing flow
 
-The normal teammate flow is **Projects → Sharing → Devices → Health**, not pairing or Teams:
+The normal flow is **Projects → Sharing → Devices → Health**, not manual pairing. Inside **Sharing**, open **Teams** when you want to manage ongoing Team membership and inherited Project access:
 
-1. Choose **Share** for one project, or select projects and choose **Share projects**.
-2. Choose an existing **Person** or enter the teammate's name.
+- **Team onboarding** — create or join a Team when people will collaborate over time.
+  - Accepting the Team invitation links the recipient's Identity and device and inherits every current and future Project assigned to that Team.
+  - The invitation does not create Project-to-Team assignments. Manage those separately, and review the Team's Projects before sending or accepting the invitation.
+- **Direct Project sharing** — once Team sharing is configured, use **Share exact Projects** to invite one Identity to exact Projects without adding the recipient to the Team.
+- **Add device** — invite another device for an existing Identity and review the Projects it will inherit from that Identity's direct and Team access.
+
+Team membership organizes people and devices, but it is not permission to every Project—only Projects explicitly assigned to that Team. Project access remains explicit and uses canonical Project identity.
+
+### Share exact Projects
+
+For direct sharing, including after Team onboarding:
+
+1. Choose **Create an invitation → Share exact Projects**.
+2. Choose an existing **Identity** or enter the teammate's Identity display name.
 3. Select the exact projects and review their existing-memory counts.
 4. Confirm that the invite shares those existing memories and future activity, then send the one expiring invite.
-5. The recipient accepts once and confirms their name and device name. Codemem links the Person and device, establishes trust and project access, and starts initial sync.
+5. The recipient reviews the invitation, accepts once, and confirms their Identity and device display names. Codemem links the Identity and device, establishes trust and Project access, and starts initial sync.
 
 ```text
 Brian will receive:
@@ -178,11 +190,22 @@ No other projects will be shared.
 
 Project access uses canonical project identity, not a display name. Selecting `codemem` does not share a similarly named or sibling project in the same Space. **Only me** keeps a memory local, even when its project is shared.
 
-The invite is single-use, expires, and is limited to the reviewed projects. The recipient cannot add projects during acceptance. Existing and future selected-project memories arrive after setup; unrelated projects remain absent.
+The invite is single-use, expires, and is limited to the reviewed Projects. It names one Identity, not a Team, and the recipient cannot add Projects during acceptance. Existing and future selected-Project memories arrive after setup; unrelated Projects remain absent.
+
+### Add a device for an existing Identity
+
+Create an **Add device** invitation from the existing Identity. Before sending it, review the exact Projects the new device will receive:
+
+- Direct Projects come from access granted to that Identity.
+- Team Projects come from the Identity's Team membership.
+- Existing Project exclusions remain excluded.
+- The invitation cannot silently add unrelated Projects during acceptance.
+
+The recipient accepts on the new device. Codemem links it to the same Identity, establishes the required trust, and starts initial sync for the reviewed Projects.
 
 ### Devices, status, and recovery
 
-**Devices** is a read-only view of where Project access can arrive. A device belongs to one **Identity**. Its Projects are labeled **Direct** when shared with that Identity and **Team** when inherited through a Team; both are limited to the exact canonical Projects selected in Sharing.
+**Devices** is a read-only view of where Project access can arrive. Each device shows its **Owning Identity**. Projects are labeled **Direct** when shared with that Identity and **Team** when inherited through a Team policy; both are limited to exact canonical Projects selected in Sharing.
 
 **Availability** tells you whether the device can currently receive work. It does not change ownership or Project access:
 
@@ -193,9 +216,10 @@ The invite is single-use, expires, and is limited to the reviewed projects. The 
 | Waiting for device | The recipient device is offline. | Wait; sync continues when it reconnects. |
 | Up to date | The selected projects are syncing. | Nothing. |
 | Needs attention | A setup step reached a terminal failure. | Use **Retry setup**. |
-| Access removed | Future access has been removed. Previously copied memories may remain on the other device. | Share again if appropriate. |
 
-An offline device is a passive waiting state, not a failure. Retry only when codemem shows **Needs attention**; it preserves completed setup work and resumes from the failed step. Removing access prevents future delivery, but cannot delete memories already copied to a recipient device.
+An offline device is a passive waiting state, not a failure or revocation. It keeps its current access and catches up after reconnecting. Retry only when codemem shows **Needs attention**; retry preserves completed setup work and resumes from the failed step.
+
+Disabling a device enrollment for one coordinator group revokes future delivery only for Projects in that group. The global identity device remains active, stays in **Devices**, and can retain access granted through other groups. Use **Advanced → Team administration** to review or re-enable the affected group enrollment. Re-enabling clears the disabled state; the next owner reconciliation pass then restores only the Projects currently authorized through the Identity's direct shares and Team policies for that group. Delivery resumes without a broader re-invite, and unrelated Projects remain absent. A separate global identity-device revocation removes the device from the active list; it is not restored through the group enrollment action. Neither revocation nor disabling can delete memories already copied to a recipient device.
 
 ## Advanced operator and compatibility guidance
 
@@ -222,9 +246,17 @@ Optional legacy filters can narrow an already-authorized peer's data; they canno
 - `codemem sync pair --accept '<payload>' --include shared-repo-1,shared-repo-2`
 - `codemem sync pair --accept '<payload>' --exclude private-repo`
 
-### Sharing domains, Spaces, grants, and filters
+### Product terms and internal access boundaries
 
-A **Sharing domain** is an operator boundary that decides which devices may receive a memory. Internally this is stored as `scope_id`. Project filters narrow an already-authorized peer; they never grant Project access.
+Normal sharing uses product terms:
+
+- A **Team** organizes collaborating people and their devices. Team membership can supply inherited access only to Projects explicitly shared with that Team.
+- A **Project** is the exact canonical workspace selected for sharing, not every workspace with a similar display name.
+- A **Space** is the user-facing access boundary that groups related Projects.
+
+Advanced screens and diagnostics may call a Space a **Sharing domain**, a coordinator group an administrative container, and the stored boundary a `scope_id`. Those internal terms explain enforcement; users do not need them to share a Project or add a device. Coordinator-group membership alone never grants Project access.
+
+Project filters narrow an already-authorized peer; they never grant Project access.
 
 Use separate Sharing domains for personal, work, client, and OSS data on the
 same machine:
@@ -258,9 +290,7 @@ For a mixed personal/work laptop, start conservatively:
 5. Use project include/exclude filters only to narrow what an already-authorized
    peer receives.
 
-Do not treat coordinator group membership as data access. A coordinator group can
-help discover and administer peers, but a peer still needs an explicit Sharing
-domain grant before it can receive that domain's memories.
+Do not treat coordinator-group membership as data access. A coordinator group can help discover and administer devices, but a device still needs Project access through a direct recipient or Team policy before it can receive those memories.
 
 ### Upgrade maintenance / Sharing-domain backfill
 


### PR DESCRIPTION
## Description

Update user and operator documentation to match the merged 0.40 sharing lifecycle. The docs now separate Team onboarding from direct exact-Project sharing, explain add-device inheritance review, and distinguish offline waiting from disable/re-enable reconciliation.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with `git diff --check`. The repository has no Prettier command and Markdown files are outside the configured Biome scope.

## Checklist

- [x] Code follows project style (docs-only; `git diff --check` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced