### PR TITLE
docs(sync): correct architecture drift

### DIFF
--- a/docs/plans/2026-04-30-seed-and-mesh-architecture-converged.md
+++ b/docs/plans/2026-04-30-seed-and-mesh-architecture-converged.md
@@ -9,7 +9,7 @@
 
 These invariants apply to all sharing/sync work in codemem and supersede any conflicting framing in older docs:
 
-1. **Sharing domain (`scope_id`) is the hard data boundary in Phase 2.** Once a deployment is in Phase 2, a memory may only replicate to a peer if (a) the memory has a non-null `scope_id` recognized by both sides, AND (b) the peer is currently authorized for that `scope_id` at the latest known membership epoch. Memories with no `scope_id` MUST NOT replicate in Phase 2 except via an explicitly configured per-peer legacy compatibility scope, which is a documented, audited exception to this invariant — not an exemption from it.
+1. **Sharing domain (`scope_id`) is the hard data boundary for scoped sync.** A memory may replicate on an explicit scoped stream only when (a) it has a non-null `scope_id` recognized by both sides, AND (b) the peer is currently authorized for that `scope_id` at the latest known membership epoch. Peers negotiated below the `scoped` capability remain on the constrained legacy compatibility path; that path is not an explicit scoped stream and must not be described as equivalent authorization.
 2. **Project include/exclude only narrows.** Per-peer project filters can subtract from what a peer would otherwise receive. They never grant access to a scope the peer is not authorized for. Basename-style project matches are display-only and MUST NOT be used for any scope authorization decision.
 3. **Coordinator group is a discovery, admin, and membership container.** Group membership is not data access. Scope grants are an explicit, separate, audited admin action whose record is independent of group membership changes. There is no auto-grant from group enrollment.
 4. **Coordinator is never a data path.** It does not store, proxy, or relay memory payloads, and it is not a gateway in front of a backend.
@@ -17,7 +17,7 @@ These invariants apply to all sharing/sync work in codemem and supersede any con
 6. **Visibility gates eligibility, not authorization.** `visibility=shared` makes a memory eligible to leave the device; scope membership decides where it may go.
 7. **Revocation prevents future sync only and is enforced per op batch.** Already-replicated data on a revoked device is not magically erased. Outbound sync MUST re-validate scope membership against the local membership cache before each op batch is sent. Cache TTL for scope membership is at most 60 seconds; longer TTLs are a documented operator exception with a stated revocation-lag SLA.
 8. **Local-first.** Writes are durable locally before any replication; quorum writes are not a primitive.
-9. **`sync_peers.claimed_local_actor` is retracted in Phase 2.** Same-actor private sync is expressed exclusively as membership in a `personal:<actor_id>` scope whose membership manifest is signed by an actor-controlled key. The legacy boolean MUST NOT bypass scope or visibility checks once a deployment is in Phase 2; Phase 1→2 promotion fails closed if any `sync_peer` still asserts `claimed_local_actor=1` without a corresponding `personal:` scope grant.
+9. **`sync_peers.claimed_local_actor` is a legacy ownership signal, not scope membership.** It still participates in legacy ownership and private-memory compatibility. On explicit scoped sync, private same-actor access requires membership in the corresponding `personal:<actor_id>` scope; the legacy boolean cannot bypass scoped membership checks. Fully replacing the compatibility signal remains future migration work.
 10. **Local-only scopes never escape the device that minted them.** Scopes with `authority_type='local'` (including all migration-created `local-default`, `legacy-shared-review`, and similar scopes) are not eligible for outbound replication in any phase. Their memories are local artifacts until an admin explicitly reassigns them to an authoritative scope.
 11. **Inbound `scope_id` is taken from the op row, not re-resolved.** The receiver does not re-run project→scope resolution on incoming ops. The sender's resolution at minting time is binding for that op's `scope_id`. The receiver's job is to verify sender authorization, receiver authorization, and scope/payload consistency at the latest known epoch.
 
@@ -37,7 +37,7 @@ The "central seed peer" we considered is reframed as a **deployment property, no
 
 A separate "backbone" tier with quorum semantics, distinct from "joiner" peers, is rejected. So is a "coordinator-as-gateway" pattern that proxies data. The coordinator's job is the minimum required to bridge network boundaries: discovery and group membership. mDNS handles the LAN case (already implemented).
 
-The implementation work is intentionally bounded. The patterns we're adopting are well-established (Syncthing's BEP, BitTorrent's swarm model, Cassandra's anti-entropy, Dynamo's hinted handoff) and we are implementing them in TypeScript ourselves rather than depending on external services or new deployable infrastructure.
+The implementation work is intentionally bounded. Existing replication uses cursor-based operations, paginated snapshots, reset boundaries, and idempotent transactional apply. Merkle anti-entropy and hinted handoff remain future patterns to evaluate rather than implemented foundations.
 
 ## Reference architectures
 
@@ -50,12 +50,12 @@ Mapping codemem onto Syncthing:
 | Syncthing | codemem | Status |
 |---|---|---|
 | Device ID (cert pubkey hash) | Device key | Already exists |
-| Folder | Scope | To be added (additive schema) |
-| Folder shared with N devices | Scope with N members | To be added |
+| Folder | Scope | Implemented |
+| Folder shared with N devices | Scope with N members | Implemented |
 | Global discovery server | Coordinator | Already exists (simplified role going forward) |
 | Local discovery (UDP broadcast) | mDNS | Already exists (`packages/core/src/sync-discovery.ts`) |
 | Relay servers | Optional, deferred | Not built |
-| Block Exchange Protocol over TLS | HTTP/2 + mTLS over `/v1/ops` and `/v1/snapshot` | Already exists |
+| Block Exchange Protocol over TLS | HTTP `/v1/ops` and `/v1/snapshot` with Ed25519-signed requests and pinned device keys | Already exists; confidentiality is not provided by default |
 | Versioning | Lamport scalar clock + LWW + tombstones | Already exists |
 
 The two material differences from Syncthing:
@@ -83,10 +83,10 @@ The earlier framing leaned on Dynamo's lineage (consistent hashing, sloppy quoru
 - Peers are intermittently online by design (laptops sleep)
 - We don't have a coordinator-elected leader for any partition
 
-Two patterns from the Dynamo lineage do still apply because they generalize:
+Two patterns from the Dynamo lineage remain possible future additions because they generalize:
 
-- **Anti-entropy via Merkle ranges** — the convergence engine when two peers meet
-- **Hinted handoff** — store-and-forward when the intended recipient is unreachable
+- **Anti-entropy via Merkle ranges** — a possible future divergence-repair accelerator
+- **Hinted handoff** — possible future store-and-forward when the intended recipient is unreachable
 
 The pieces we explicitly drop: quorum write between peers, consistent-hash placement, SWIM membership protocol, cluster-wide failure detection. None of these fit a Syncthing-shaped peer-to-peer model.
 
@@ -119,17 +119,17 @@ Three mechanisms, in priority order:
 2. **Coordinator** — cross-network discovery and group membership directory. Already exists in a richer form than needed; we will pare it back to: groups, members per group, presence (which device key is currently reachable, at what address). The coordinator never sees memory data.
 3. **Manual / configured addresses** — works when you know where a peer lives and don't need a discovery service. Already supported via `sync_peers` table.
 
-Future addition (deferred): **relay** for NAT-traversal cases where direct connection fails. Syncthing has a community relay pool; codemem could do the same, or have peers relay through any reachable mutual member.
+Future relay support remains deferred. It requires demonstrated direct-reachability failures and a separately approved trust and transport design before implementation.
 
 ### Replication semantics
 
 Writes are local-first. A peer writes to its own SQLite immediately. The write is durable from that peer's perspective the moment SQLite returns.
 
-Sharing is best-effort fanout to reachable members of the same scope, with eventual convergence guaranteed by anti-entropy. Specifically:
+Sharing is best-effort fanout to reachable members of the same scope. Current convergence uses cursor-based operation exchange, paginated snapshots, reset boundaries, and idempotent transactional apply. Specifically:
 
 - After a local write, the peer attempts to push the new ops to currently-reachable members of the scope.
-- If a target member is unreachable, the ops are queued for later push (hinted handoff: "deliver this op to device X when X is reachable, OR when any other member of the scope can forward it").
-- Periodically, pairs of peers exchange Merkle summaries of their op-log per shared scope. On hash mismatch, they exchange the actual missing ops via the existing `/v1/ops` endpoint.
+- If a target member is unreachable, the peer retries when ordinary sync scheduling observes a reachable path. Durable hinted handoff is not implemented.
+- Pairs exchange missing operations through scoped cursors. Merkle anti-entropy is future work and is not required for current synchronization.
 - On cold start (new device joins a scope, or a peer has been offline for a long time), bootstrap via the existing paginated `/v1/snapshot` endpoint, then tail with cursor-based `/v1/ops`.
 
 There is no quorum requirement at the protocol level. Each peer's local copy is the authoritative version of the world it has seen so far. Convergence between peers is eventual, ordered by Lamport clock with LWW for conflicting writes to the same `entity_id`.
@@ -142,7 +142,6 @@ The coordinator is a phone book and a group registry. It does:
 - **Presence directory** — which device keys are currently reachable, at what addresses (TTL'd, peers refresh)
 - **Bootstrap / invite flow** — how a new device gets enrolled in a group (existing bootstrap-grant pattern, possibly simplified)
 - **(Optional, future)** NAT traversal hints (STUN-like: "I see your peer at this public address")
-- **(Optional, future)** Relay fallback when direct peer connection fails
 
 The coordinator does NOT:
 
@@ -162,7 +161,7 @@ One peer. Local SQLite. No coordinator. No replication. mDNS off. This is codeme
 
 ### Two-laptop personal sync
 
-Two peers. Coordinator (or manual address config) for discovery. mDNS for same-LAN. Each laptop is a member of every scope it cares about. They sync directly via HTTP+mTLS. Anti-entropy converges them when both are online. Effectively Syncthing for memories.
+Two peers. Coordinator (or manual address config) for discovery. mDNS for same-LAN. Each laptop is a member of every scope it cares about. They sync directly over HTTP with Ed25519-signed requests and pinned device keys. Scoped cursors and snapshot/reset recovery converge them when both are online. This authenticates requests but does not provide transport confidentiality by default.
 
 ### Small team, single $5 VPS as always-on backstop
 
@@ -174,7 +173,7 @@ N laptops only. Sync happens whenever any two members are online simultaneously.
 
 ### Org-scale (e.g., internal team deployment)
 
-N laptops + a small k8s deployment of, say, 3 always-on codemem instances. The 3 instances are regular peers, members of the team scopes. They participate in the swarm identically to laptops; the only difference is uptime. Each holds full local SQLite (PVC or emptyDir, depending on whether you want them to bootstrap from peers on restart vs. preserve across restarts). Laptops push to whichever of the 3 they reach first; the others pick up the ops via anti-entropy. If one pod dies, the other 2 still have the data; a replacement bootstraps from peers on startup and rejoins.
+N laptops + a small k8s deployment of, say, 3 always-on codemem instances. The 3 instances are regular peers, members of the team scopes. They participate in the swarm identically to laptops; the only difference is uptime. Each holds full local SQLite (PVC or emptyDir, depending on whether you want them to bootstrap from peers on restart vs. preserve across restarts). Laptops synchronize with reachable peers through scoped cursors and snapshots. If one pod dies, the other 2 still have the data; a replacement bootstraps from peers on startup and rejoins.
 
 There is no "internal HA quorum" mode. The 3 instances are 3 peers. The swarm-with-redundancy property comes from running multiple peers, not from a special multi-pod replication protocol.
 
@@ -190,54 +189,26 @@ Two organizations with their own deployed seeds, both holding membership in a sh
 - Replication ops table with Lamport clock + tombstones + UUIDs (`schema.ts`)
 - HTTP sync endpoints: `/v1/ops` (cursor-based) and `/v1/snapshot` (paginated bootstrap)
 - Pull→apply→push sync pass (`packages/core/src/sync-pass.ts`)
-- mTLS-secured peer transport
+- HTTP peer transport authenticated by Ed25519-signed requests and pinned device keys; no transport confidentiality by default
 - Coordinator service with groups, enrolled devices, presence, bootstrap-grants
 - Cloudflare Worker variant of the coordinator (D1-backed)
 - mDNS discovery (`packages/core/src/sync-discovery.ts`)
 - Device key identity model
 
-### What needs to be added
+### Current and future work status
 
-In rough dependency order:
-
-1. **Scope as first-class** (additive schema)
-   - Add `scope_id` to `memory_items` and `replication_ops`
-   - Plumb scope through write paths (coding-session observers tag memories with the scope they belong to)
-   - Plumb scope through read paths (queries filter by scopes the local user is a member of)
-   - Backfill existing memories with a default scope
-   - Estimate: significant ergonomic surface but mechanically straightforward
-
-2. **Membership semantics + auth at the wire**
-   - Coordinator publishes the authorized device-key set per scope (or scope-membership is signed by a group-admin device)
-   - Peers cache membership locally and verify on incoming sync requests (peer X requesting ops for scope Y must have a device key in Y's member set)
-   - Estimate: ~300 LOC across coordinator + peer auth check
-
-3. **Anti-entropy via Merkle ranges over the op-log**
-   - Compute Merkle summaries per scope over `op_id`-ordered ranges (cached, invalidated on new ops)
-   - New endpoint: `GET /v1/scope/{id}/merkle?range=...` returning hash triples
-   - Periodic background job: pick a peer, exchange Merkle for shared scopes, fetch missing ops via existing `/v1/ops`
-   - Estimate: ~400 LOC, the heaviest single piece
-
-4. **Hinted handoff**
-   - New table: `replication_hints` with target device key, scope, op references, expiry
-   - Background drainer: when a hint's target becomes reachable, deliver and clear; also try to forward through any reachable mutual scope-member
-   - Hint storage cap to prevent unbounded growth on long-offline targets
-   - Estimate: ~200 LOC
-
-5. **Coordinator pare-back**
-   - Strip bootstrap-grant complexity if it doesn't earn its keep in the simpler model
-   - Document the coordinator as "discovery + group membership + presence; never a data path"
-   - Estimate: refactor + delete; net code reduction likely
-
-Total budget: roughly 1000-1500 LOC of new TypeScript across `packages/core` and the coordinator, plus the scope-as-first-class ergonomic work which is harder to estimate.
+- First-class scopes, memberships, scoped cursors, per-scope reset/retention state, signed scope requests, and peer-side membership checks are implemented. `2026-05-25-scoped-sync-protocol.md` records the design lineage for the shipped scoped wire contract.
+- Coordinator simplification remains independent work. The coordinator remains outside the memory payload data path.
+- Merkle anti-entropy is an unapproved future repair accelerator. It is not required for current convergence and has no committed endpoint or implementation budget.
+- Hinted handoff is unapproved future durable-delivery work. If pursued, it requires delivery-time membership revalidation under `2026-04-30-sharing-domain-scope-design.md`.
 
 ### Patterns we explicitly do not implement
 
 - Quorum write (Dynamo W+R>N) — wrong shape for intermittently-online peers
 - Consistent hashing for placement — wrong shape, membership = placement
 - SWIM gossip membership — wrong shape, no cluster
-- Coordinator-as-gateway — gone, coordinator is not a data path
-- libp2p — overkill, HTTP+mTLS is enough (Syncthing's BEP works the same way)
+- Coordinator-as-gateway — rejected; the coordinator is not a data path
+- libp2p — overkill; the current signed-HTTP peer protocol remains canonical
 - Internal HA quorum mode for multi-pod seeds — gone, a multi-pod seed is just 3 peers
 - New wire protocol — extensions to the existing HTTP API only
 
@@ -249,15 +220,15 @@ For a reviewer to challenge:
 
 2. **Quorum is the wrong primitive for our writes.** Writers (laptops) are intermittently online. Requiring quorum acks before considering a write durable would block laptop writes during their normal operating mode. Local-immediate-durable + eventual-replication is the right semantics.
 
-3. **The coordinator should be minimal.** It exists to bridge network boundaries and provide group identity. Anything more (proxying data, gating reads, routing decisions) is an architectural mistake driven by deployment-shape thinking.
+3. **The coordinator should be minimal.** It exists to bridge network boundaries and provide group identity. It must not proxy data, gate reads, or make payload-routing decisions.
 
 4. **A "backbone" of always-on peers is a deployment artifact.** It does not require any special protocol mode. The codemem protocol treats a k8s pod identically to a laptop. The org-scale deployment property comes from running multiple peers, not from a different protocol.
 
-5. **HTTP+mTLS is sufficient transport.** libp2p, custom protocols, and other peer-to-peer stacks introduce complexity without buying us anything Syncthing doesn't already get from TLS+TCP.
+5. **The signed-HTTP peer protocol remains the canonical transport contract.** Current Ed25519 request signing and pinned device keys provide authenticity and integrity, not confidentiality. Future channel encryption should be transport-neutral rather than require libp2p or another peer-to-peer stack.
 
-6. **The implementation budget is small (~1000-1500 LOC).** This depends on (4) and (5) being correct. If we needed quorum or libp2p the budget would be much larger.
+6. **Future repair mechanisms must earn their complexity.** Merkle anti-entropy and hinted handoff are not committed scope. Each needs evidence, a bounded contract, and a separate implementation estimate before approval.
 
-7. **No new deployable infrastructure is needed.** No NATS, no Postgres, no DHT bootstrap nodes, no relay pools (yet). Everything runs in the existing codemem process plus the existing coordinator.
+7. **Current direct sync needs no new deployable infrastructure.** No NATS, Postgres, DHT bootstrap nodes, or relay pools are required.
 
 ## Open questions worth challenging
 
@@ -267,7 +238,7 @@ These are places where the position above might be wrong, or where reasonable al
 
 2. **What happens to a scope whose only member's laptop is permanently lost?** Without an always-on peer, that scope's data dies with the last living member. Is this acceptable, or does the design need to push users toward at least one always-on peer for any "important" scope?
 
-3. **Anti-entropy frequency and target selection.** Random pair selection is simple but inefficient at scale; biased toward "peers we haven't synced with recently" is better but more state to track.
+3. **If anti-entropy is adopted, what frequency and target selection are justified?** Random pair selection is simple but inefficient at scale; bias toward peers not synchronized recently is more targeted but requires more state.
 
 4. **Op-log compaction.** Long-lived scopes accumulate ops indefinitely. Do we periodically compact the op-log into a snapshot baseline, dropping old ops? If so, how do peers that have been offline for years catch up?
 
@@ -279,7 +250,7 @@ These are places where the position above might be wrong, or where reasonable al
 
 8. **Deployment ergonomics for "I want my data backed up but don't want to run my own server."** Is the answer "run a $5 VPS yourself," "join a community-run backup pool," "store an encrypted snapshot in object storage as a fallback," or something else?
 
-9. **Performance of Merkle anti-entropy at scale.** How many scopes can a single peer reasonably participate in before the periodic Merkle exchange becomes too costly?
+9. **If Merkle anti-entropy is adopted, how would it perform at scale?** How many scopes could a peer participate in before periodic digest exchange becomes too costly?
 
 10. **Multi-org federation auth.** When two orgs share a scope, who is the trust root for membership? This is out of v1 scope but worth thinking about now to avoid painting ourselves in.
 
@@ -288,8 +259,8 @@ These are places where the position above might be wrong, or where reasonable al
 For an external reviewer reading both docs together: the companion research doc (`2026-04-30-seed-and-mesh-architecture-research.md`) anchors on "two-tier mesh with quorum writes" framed in the Dynamo/Cassandra lineage. That framing was rejected during deliberation. Specifically:
 
 - The companion doc's "two-tier mesh: backbone vs joiner" section is wrong. There is no protocol-level distinction.
-- The companion doc's "scope ring + quorum write + hinted handoff + Merkle anti-entropy + SWIM heartbeats" pattern set is over-specified. Of those, only Merkle anti-entropy and hinted handoff survive in the converged design.
-- The companion doc's "coordinator-as-gateway" pattern is rejected. The coordinator is a phone book.
+- The companion doc's "scope ring + quorum write + hinted handoff + Merkle anti-entropy + SWIM heartbeats" pattern set is over-specified. Merkle anti-entropy and hinted handoff remain possible future work, not implemented foundations.
+- The companion doc's coordinator-as-gateway pattern is rejected. The coordinator remains a phone book, not a data path.
 - The companion doc's "Dynamo as reference architecture" is wrong; the right references are Syncthing and BitTorrent.
 
 The companion doc is preserved because the option survey (single-pod + Litestream, managed Postgres, JetStream log, mesh) is still useful for understanding what was considered and why each was rejected for the long-term default. But its prescriptive recommendations should be read through this doc.

--- a/docs/plans/2026-04-30-sharing-domain-scope-design.md
+++ b/docs/plans/2026-04-30-sharing-domain-scope-design.md
@@ -1,8 +1,8 @@
 # Sharing Domain / Replication Scope Design
 
 **Date:** 2026-04-30  
-**Status:** design / pre-implementation  
-**Related:** `2026-04-30-seed-and-mesh-architecture-converged.md`, `2026-04-30-seed-and-mesh-architecture-research.md`, `2026-04-22-multi-team-coordinator-groups-design.md`, `2026-03-08-shared-memory-trust-state-semantics.md`
+**Status:** accepted scope semantics; phased implementation in progress
+**Related:** `2026-04-30-seed-and-mesh-architecture-converged.md`, `2026-05-25-scoped-sync-protocol.md`, `2026-04-30-seed-and-mesh-architecture-research.md`, `2026-04-22-multi-team-coordinator-groups-design.md`, `2026-03-08-shared-memory-trust-state-semantics.md`
 
 When this document conflicts with `2026-04-30-seed-and-mesh-architecture-research.md`, the converged Syncthing-shaped position wins: no quorum backbone, no coordinator-as-gateway, no coordinator data path, and no special seed protocol role.
 
@@ -10,7 +10,7 @@ When this document conflicts with `2026-04-30-seed-and-mesh-architecture-researc
 
 These mirror the invariants in `2026-04-30-seed-and-mesh-architecture-converged.md` and govern all scope-related work. The converged doc holds the canonical wording; this list is for orientation:
 
-1. Sharing domain (`scope_id`) is the hard data boundary in Phase 2; legacy compatibility is an audited exception, not an exemption.
+1. Sharing domain (`scope_id`) is the hard data boundary for explicit scoped sync; lower-capability peers remain on a constrained legacy compatibility path.
 2. Project include/exclude only narrows; basename matches are display-only.
 3. Coordinator group membership is not data access; scope grants are explicit and audited.
 4. Coordinator is never a data path.
@@ -18,7 +18,7 @@ These mirror the invariants in `2026-04-30-seed-and-mesh-architecture-converged.
 6. Visibility gates eligibility; scope membership gates destination.
 7. Revocation prevents future sync; outbound MUST re-validate membership per op batch; default cache TTL ≤ 60 s.
 8. Local-first; no quorum primitive.
-9. `claimed_local_actor` is retracted in Phase 2; same-actor private sync moves to a signed `personal:<actor_id>` scope.
+9. `claimed_local_actor` is legacy ownership compatibility, not scope membership; explicit scoped private sync requires a `personal:<actor_id>` scope grant.
 10. Local-only scopes (`authority_type='local'`) never replicate outbound.
 11. Inbound `scope_id` is authoritative from the op row; receivers do not re-resolve.
 
@@ -330,7 +330,7 @@ Coordinator additions in v1:
 2. Seed exactly one row in each new table for `scope_id = 'local-default'` from the existing singleton row. Generation, snapshot_id, baseline_cursor, and retained_floor_cursor carry over verbatim.
 3. Existing peer cursors remain valid for `local-default`; they are not invalidated by the migration. There is no forced-resync stampede during Phase 1.
 4. New scopes start at `generation = 1` with no baseline cursor. Bootstrap of a new scope produces an initial baseline.
-5. The singleton tables are kept read-only for one release window for rollback. Phase 1 → Phase 2 promotion deletes them.
+5. The singleton tables were retained during migration while the v2 per-scope tables became canonical. Removing the compatibility tables requires a separate migration decision; there is no runtime Phase 1 → Phase 2 promotion switch.
 6. `(peer_device_id, scope_id)` cursors are added to a new `replication_cursors_v2` table; existing per-peer cursors are migrated as the `local-default` cursor for that peer.
 7. Op streams that straddle the migration boundary remain valid because `local-default` retains the original generation and baseline; ops without `scope_id` resolve to `local-default` for routing under Phase 1 rules only.
 
@@ -452,24 +452,20 @@ Snapshot bootstrap should also be scope-aware. A peer joining `acme-work` should
 
 Snapshot generations, baselines, and retained floors should be tracked per scope so pruning or resetting one sharing domain does not force unrelated domains to resync.
 
-### Compatibility contract locked by `codemem-ov4g.4.1`
+### Current scoped compatibility contract
 
-Until per-scope cursors and scope-limited snapshots land, the wire protocol reserves `scope_id` without serving scoped data from the legacy singleton stream:
+The reservation-only compatibility slice from `codemem-ov4g.4.1` has been superseded by the shipped per-scope protocol whose design lineage is recorded in `2026-05-25-scoped-sync-protocol.md`:
 
-- Omitted `scope_id` means legacy compatibility mode. The peer uses the current singleton reset boundary and existing visibility/project filters. Responses include `scope_id: null` so aware peers can distinguish this from a scoped stream.
-- `GET /v1/ops` uses `scope_id` as a query parameter.
-- `POST /v1/ops` may carry `scope_id` in the JSON body alongside `ops`.
-- `GET /v1/snapshot` uses `scope_id` as a query parameter.
-- Present but empty `scope_id` returns HTTP 409 with `error: "reset_required"`, `reset_required: true`, `reason: "missing_scope"`, the current reset boundary, and `sync_capability: "aware"`.
-- Present non-empty `scope_id` returns HTTP 409 with `reason: "unsupported_scope"` until later `ov4g.4` work adds per-scope cursor/reset/snapshot state and scope-bounded queries.
-- Servers MUST NOT silently ignore an explicit `scope_id`; that would let a caller believe it received a bounded Sharing domain stream when it actually received the legacy unscoped stream.
-- This compatibility slice does not add membership enforcement. Phase 1 still treats `scope_id` metadata as informational and preserves legacy peers that omit `scope_id`.
+- `scoped` peers enumerate mutually authorized scopes and use per-scope cursor, reset, retention, ops, and snapshot state.
+- `GET /v1/ops` and `GET /v1/snapshot` carry `scope_id` as a query parameter. The shipped `POST /v1/ops` client uses a no-scope batch envelope; the signed request body contains ops that each carry their own `scope_id`, which the receiver validates before applying the batch. A top-level `scope_id` is optional.
+- Scoped requests enforce active local and peer membership before serving or applying data.
+- Direct peers that negotiate below `scoped` retain only the constrained legacy compatibility behavior implemented for mixed versions. Servers MUST NOT silently ignore an explicit `scope_id`, and the compatibility path does not make `local-default` or missing scope metadata an authorization boundary.
 
 ### Applying ops
 
 The receiver should reject ops when:
 
-- `scope_id` is missing after compatibility mode ends;
+- a peer negotiated `scoped` but the scoped stream op has no non-empty `scope_id`;
 - sender is not a member of the scope;
 - receiver is not a member of the scope;
 - membership epoch is stale relative to cached revocation data;
@@ -488,9 +484,9 @@ On inbound, `scope_id` is taken from the op row only. The receiver does NOT re-r
 
 Disagreement between op-row `scope_id` and embedded payload `scope_id` is a hard reject with `scope_mismatch`. Project field disagreement is logged but does not change scope routing; the op-row `scope_id` is authoritative.
 
-### Hinted handoff (deferred work) MUST verify membership at delivery time
+### Hinted handoff (unapproved future work) MUST verify membership at delivery time
 
-Hinted handoff is deferred until after the foundation tracks land, but its semantics are pinned now:
+Hinted handoff remains unapproved and requires a separate implementation decision. If pursued, its membership semantics are pinned now:
 
 - A hint stored on peer A targeting peer B is metadata only; the underlying op carries its own `scope_id` and authorization.
 - When peer C (or peer A) attempts to deliver the hint to peer B, C MUST re-validate B's membership in the op's `scope_id` at C's latest known epoch.
@@ -500,110 +496,33 @@ Hinted handoff is deferred until after the foundation tracks land, but its seman
 
 ### Private same-actor sync
 
-Current sync has a `claimed_local_actor` path that allows private memory sync between devices owned by the same actor. In Phase 2 this bypass is retracted (Invariant 9). Private same-actor sync MUST go through a `personal:<actor_id>` scope whose membership manifest is signed by an actor-controlled key. The actor's own devices are the only members. An org/work scope cannot receive private memories merely because a peer claims the same actor.
+`claimed_local_actor` still participates in legacy ownership and private-memory compatibility. It is not equivalent to scope membership and must not grant access to an org/work scope. Fully replacing that compatibility path with `personal:<actor_id>` scope membership remains future migration work.
 
-Phase 1 → Phase 2 promotion fails closed if any `sync_peer` row still asserts `claimed_local_actor=1` without a corresponding `personal:` scope grant for the same device. Operators are guided to migrate by issuing a `personal:<actor_id>` scope and granting the same-actor devices to it before promotion.
+## Legacy peer compatibility and current enforcement
 
-## Legacy peer compatibility and rollout gates
-
-Scope enforcement cannot be turned on globally in one release. Older peers will not understand `scope_id`, and existing databases will not have scope membership populated. The rollout has explicit phases, signaled at the protocol level, with strict rules about when scope metadata becomes authoritative.
+The original rollout used Phase 0/1/2 language to stage schema, membership, and enforcement work across releases. That phase model was a planning scaffold and is not a runtime configuration or derived state. Current explicit scoped requests enforce active local and peer membership. References to “Phase 2” elsewhere in this document mean the shipped scoped-enforcement posture, not a global phase flag.
 
 ### Protocol versioning
 
-- Add a sync protocol capability advertisement (request header or capability field) so peers can discover one another's scope support: `unsupported`, `aware`, `enforcing`.
+- Peers advertise one sync capability: `unsupported`, `aware`, `enforcing`, or `scoped`, in increasing order of support.
+- `scoped` signals the shipped per-Space wire protocol: mutually authorized-scope enumeration plus signed explicit-scope ops and snapshots.
+- `enforcing` is a legacy negotiation rung retained for compatibility; it does not support explicit per-Space streams.
 - A peer's stance is observable per session and recorded in `sync_attempts` for diagnostics.
-- Capability downgrade is allowed (a peer that supports enforcing may speak `aware` to a legacy peer); capability upgrade is not.
-
-### Three-state per-deployment posture
-
-Each deployment has one of:
-
-- **Phase 0 — pre-scope.** Build does not yet include scope schema. No scope behavior. Existing peer/project filters apply.
-- **Phase 1 — aware.** Scope schema and resolver exist; new local writes stamp `scope_id`; outbound sync still uses legacy filters; inbound ops accept missing/unknown `scope_id` for backward compatibility. Scope metadata is informational only.
-- **Phase 2 — enforcing.** Scope membership is authoritative; outbound and inbound sync gate on scope; legacy peers are accepted only with explicit allowlists per peer.
-
-The transition from Phase 1 to Phase 2 is the gate at `codemem-ov4g.8`. Scope metadata MUST NOT be used for security decisions before Phase 2.
-
-#### Phase state is derived, not configured
-
-Phase state MUST be a derived value, not a config flag an operator can flip independently of system state. The derivation is:
-
-```
-phase = 0 if no scope schema is present
-      = 1 if scope schema is present AND any precondition for Phase 2 is unmet
-      = 2 if all of:
-          - every active scope has a current signed or coordinator-issued
-            membership manifest with a non-stale epoch
-          - no `sync_peer` row has `claimed_local_actor=1` without a matching
-            `personal:<actor_id>` scope grant for the same device
-          - the deployment is configured to enforce (operator opt-in flag,
-            but only consulted when the structural preconditions are met)
-          - capability negotiation has been live for at least one full
-            release window
-```
-
-The UI banner that shows "Scope metadata is informational only — boundaries are not yet enforced" reads from the same derived value. There is no path to display Phase 2 in the UI while running Phase 1 enforcement code, or vice versa.
-
-Phase 2 promotion fails closed with a structured error listing the unmet preconditions; the operator cannot bypass.
+- Direct peers negotiate to the lower capability and may retain constrained legacy compatibility behavior. Capability upgrade is never inferred.
 
 ### Behavior toward legacy peers
 
-When a peer advertises `unsupported`:
-
-- It still receives only `visibility=shared` memories that pass existing project filters.
-- In Phase 2, it additionally receives only memories whose resolved `scope_id` matches a per-peer "legacy compatibility scope" the operator has explicitly configured.
-- The default is no legacy compatibility scope, which means a legacy peer receives nothing once enforcing.
-- It cannot send memories that the receiver would have rejected by scope; receivers in Phase 2 reject inbound legacy ops unless the sender is on the legacy compatibility allowlist for the receiver.
-- UI marks the peer with a "legacy" badge and explains what changes when enforcement is enabled.
-
-#### Legacy compatibility scope is bounded
-
-To prevent operators from using legacy compatibility as an unbounded leak primitive, the following constraints are mandatory:
-
-- A scope is a valid legacy compatibility target ONLY IF the legacy peer was already an authorized recipient of that data under pre-Phase-2 rules. Operationally that means the legacy peer's existing `sync_peers` row must show prior successful sync attempts overlapping the project pattern that resolves to that scope.
-- A legacy compatibility scope MUST NOT include any scope created by `migration` source (`legacy-shared-review`, `local-default`, etc.).
-- A legacy compatibility scope MUST NOT include any scope whose `authority_type` is `local` (Invariant 10).
-- Configuring or changing a legacy compatibility scope is a privileged admin action that emits an audit event with reason "legacy-compat-grant", actor identity, target peer, target scope, and prior-sync evidence summary.
-- The UI MUST display "This peer cannot prove scope membership; you are granting it access without cryptographic authorization" each time the operator opens the configuration screen.
-
-If any of these constraints fail, the deployment refuses to set the legacy compatibility scope and reports a structured reason code.
-
-### When scope metadata becomes authoritative
-
-Scope metadata is authoritative if and only if all of the following are true:
-
-1. The local deployment is in Phase 2.
-2. The local membership cache has a current epoch from coordinator or signed manifest authority for the scopes in question.
-3. The op's `scope_id` is present, non-empty, and recognized.
-4. Sender and receiver both pass scope membership checks at the current epoch.
-
-If any condition fails, the op is handled per Phase 1 rules and a diagnostic reason code is recorded. The system MUST NOT silently authorize sync based on partial scope information.
+Direct peers below `scoped` may use the constrained legacy compatibility lane implemented for mixed versions. That lane does not turn missing scope metadata, project filters, `local-default`, or migration-created local scopes into scope authorization. Explicit scoped requests require recognized scope metadata plus current sender and receiver membership. `claimed_local_actor` remains a separate legacy ownership compatibility signal pending migration.
 
 ### Backfill and review behavior
 
-Scope metadata added by migration is treated as classification metadata in Phase 1. It cannot promote a memory's reach beyond what existing peer filters and visibility already allowed. Migration biases toward under-sharing:
+Scope metadata added by migration cannot promote a memory's reach. Migration biases toward under-sharing:
 
 - private/personal visibility -> local-only scope
 - shared with clear workspace + existing peer reach -> migration-tagged shared scope (visible in Sync UI as "Migrated" until reviewed)
 - ambiguous shared -> `legacy-shared-review` scope; not eligible for outbound sync until a human or admin reassigns
 
-Operators must perform a review pass before enabling Phase 2; the UI surfaces an explicit list of unreviewed memories.
-
-### Rollback
-
-Phase 2 -> Phase 1 rollback is supported per-deployment by config. Rollback does not retract data already sent; it stops further enforcement. Rollback past Phase 1 (removing scope metadata) is not supported in v1.
-
-### Diagnostics and warnings
-
-While Phase 1 is active and any UI surface displays scope information, that surface MUST also display "Scope metadata is informational only — boundaries are not yet enforced" or equivalent. Operators must not be allowed to mistake Phase 1 visibility for enforcement.
-
-### Rollout sequencing
-
-The rollout phases map to Beads gates:
-
-- Phase 0 -> Phase 1: enabled when `codemem-ov4g.2.4` lands and scope stamping is correct.
-- Phase 1 -> Phase 2: enabled only after `codemem-ov4g.8` review checkpoint passes; gates outbound/inbound enforcement, snapshot scoping, retrieval/MCP filtering.
-- Phase 2 -> docs/release: gated on `codemem-ov4g.9` review checkpoint.
+Migration-created `legacy-shared-review` and local-authority scopes remain ineligible for outbound replication until explicitly and safely reassigned. UI diagnostics should identify peers below `scoped` and explain their constrained compatibility behavior without implying that scope labels alone grant access.
 
 ## Coordinator role
 
@@ -712,15 +631,17 @@ The product should assume mixed machines are normal. Useful guardrails:
 - Verify each peer receives only its domain.
 - Verify MCP/search on each peer sees only locally authorized scopes by default.
 
-## Rollout plan
+## Historical rollout plan and work tracks
 
-### Phase 0 — Design lock
+This section records the implementation decomposition used to deliver sharing domains; it is not a list of remaining prerequisites. The schema/resolver, membership foundation, and scoped sync-enforcement slices below are implemented. Product UX, diagnostics, and deployment documentation continue independently. Phase 5 remains unapproved future work.
+
+### Phase 0 — Design lock (completed)
 
 - Accept this design or revise it.
 - Record the architecture invariant in the seed/mesh converged plan or an ADR.
 - File Beads work tracks before implementation starts.
 
-### Phase 1 — Schema and resolver foundation
+### Phase 1 — Schema and resolver foundation (implemented)
 
 - Add tables and nullable `scope_id` columns.
 - Add project-to-scope resolver.
@@ -728,7 +649,7 @@ The product should assume mixed machines are normal. Useful guardrails:
 - Keep existing sync behavior unchanged except for stamping scope metadata.
 - Keep scope metadata non-authoritative and mostly invisible until membership authority exists.
 
-### Phase 2 — Membership authority and local cache
+### Phase 2 — Membership authority and local cache (implemented)
 
 - Add coordinator/local scope membership model.
 - Cache memberships locally.
@@ -736,7 +657,7 @@ The product should assume mixed machines are normal. Useful guardrails:
 - Keep group membership separate from scope grants.
 - Define legacy compatibility window for peers without `scope_id`.
 
-### Phase 3 — Sync enforcement
+### Phase 3 — Sync enforcement (implemented)
 
 - Add scope-aware outbound filtering.
 - Add scope-aware inbound validation.
@@ -744,16 +665,16 @@ The product should assume mixed machines are normal. Useful guardrails:
 - Add per-scope reset and retention boundaries.
 - Preserve compatibility for legacy peers during an explicit transition window.
 
-### Phase 4 — UX and diagnostics
+### Phase 4 — UX and diagnostics (ongoing)
 
 - Add sharing-domain settings.
 - Show project/domain mapping.
 - Show peer authorized domains and project filters.
 - Add sync rejection diagnostics.
 
-### Phase 5 — Mesh readiness
+### Phase 5 — Future mesh options (not required for current sync)
 
-- Add per-scope anti-entropy inventory/digest.
+- Add per-scope anti-entropy inventory/digest only if evidence justifies it.
 - Add per-scope hinted handoff if needed.
 - Add seed/anchor-peer deployment docs.
 
@@ -831,7 +752,7 @@ Peers:
 - **personal-peer** — authorized scopes: `personal`. No project filter.
 - **work-peer** — authorized scopes: `acme-work`. Project filter: include `*` (intentionally broad to prove filters cannot widen authorization).
 - **oss-peer** — authorized scopes: `oss-codemem`. Project filter: include `oss/*`.
-- **legacy-peer** — `unsupported` capability. Default behavior: receives nothing once enforcing, unless explicit per-peer compatibility scope is set.
+- **legacy-peer** — `unsupported` capability. Constrained direct compatibility only.
 - **malicious-peer** — adversarial fixture used to verify defensive behavior. Each test below MUST produce a specific reason code AND MUST NOT mutate the local DB.
 
 #### Hostile peer fixtures
@@ -841,12 +762,12 @@ Peers:
 | Sends op with `scope_id=acme-work` but is not a member of `acme-work`. | Reject before apply. | `sender_not_member` |
 | Sends op whose payload `workspace_id` says `personal` but op `scope_id` says `acme-work` (receiver does not re-resolve; payload mismatch detected). | Reject before apply. | `scope_mismatch` |
 | Sends an op_id seen a year ago after being revoked. | Reject; revoked. | `stale_epoch` |
-| Claims `claimed_local_actor` for `actor_id=owner` while presenting a device key not in `personal:owner` scope. | Reject (Phase 2: `claimed_local_actor` is no longer a bypass). | `sender_not_member` |
+| Claims `claimed_local_actor` for `actor_id=owner` while presenting a device key not in `personal:owner` scope. | Reject; `claimed_local_actor` is not an authorization signal. | `sender_not_member` |
 | `clock_rev=Number.MAX_SAFE_INTEGER` to force LWW domination. | Accept clock comparison logic but still gate on scope; if scope check fails, reject. | `sender_not_member` or `scope_mismatch` |
 | Sends an op for `local-default` scope. | Reject; local-only scopes never replicate. | `scope_mismatch` (per Invariant 10) |
 | Replays a snapshot for `acme-work` but local cache shows the snapshot generation has advanced. | Reject; reset required. | `boundary_mismatch` (existing) |
 | Sends a `reassign_scope` op to a scope the sender is not authorized for. | Reject. | `sender_not_member` |
-| Sends an inbound op with `scope_id` set but no membership manifest cached locally. | Reject in Phase 2; apply under Phase 1 informational rules. | `stale_epoch` |
+| Sends an inbound op with `scope_id` set but no current membership authority cached locally. | Reject before apply. | `stale_epoch` |
 
 ### Acceptance behaviors
 
@@ -863,19 +784,11 @@ Peers:
 | MCP tools | memory_search, timeline, pack, expand, recent, remember, forget enforce scope authorization; remember resolves scope safely. | ov4g.5.4 |
 | Viewer/CLI APIs | Memory list/search/detail/stats apply the same store-level scope filters; raw events/artifacts are not newly exposed across scopes. | ov4g.5.5 |
 | Coordinator admin | Adding Mixed owner to coordinator group `acme-eng` does not by itself grant `oss-codemem` or `personal`. Scope grants are explicit; revocations propagate to local cache. | ov4g.3.2, ov4g.3.4 |
-| UI guardrails | Broad org-domain patterns warn; basename collisions require review; scope reassignment warns about already-copied data. Phase 1 surfaces show "informational only" copy. | ov4g.6.4 |
-| Legacy peer behavior | legacy-peer in Phase 2 receives nothing by default. Operator can opt in to a per-peer compatibility scope; UI marks the peer "legacy" with explanation. | ov4g.4.1, ov4g.6.2 |
+| UI guardrails | Broad org-domain patterns warn; basename collisions require review; scope reassignment warns about already-copied data. | ov4g.6.4 |
+| Legacy peer behavior | legacy-peer is limited to constrained direct compatibility and is marked "legacy" with an explanation. | ov4g.4.1, ov4g.6.2 |
 | Revocation | Revoking work-peer mid-run stops future ops to that peer within one membership-cache refresh; UI/docs state already-copied data is not erased. | ov4g.3.4 |
 | Diagnostics | Scope-related rejections produce reason codes (`missing_scope`, `sender_not_member`, `receiver_not_member`, `stale_epoch`, `scope_mismatch`, `visibility_filter`, `project_filter`) visible by peer/scope without payload exposure. | ov4g.4.5, ov4g.6.5 |
 | E2E smoke | A single test fixture (Mixed owner + three peers + legacy-peer) exercises every row above and fails on the first leak. | ov4g.4.6, ov4g.5.6, ov4g.6.6 |
-
-### Rollout-phase acceptance
-
-| Phase transition | Required for green |
-|---|---|
-| Phase 0 -> Phase 1 | Schema present; resolver deterministic; backfill biased to under-sharing; new writes stamp scope_id; legacy peers unaffected. |
-| Phase 1 -> Phase 2 | All sync rows above pass; membership cache stable; revocation honored; review checkpoint `ov4g.8` signed off. |
-| Phase 2 -> release | Retrieval/MCP/UI rows pass; legacy-peer behavior explicit; docs updated; review checkpoint `ov4g.9` signed off. |
 
 ## Beads implementation plan
 
@@ -910,4 +823,4 @@ Agents should work the lowest ready bead, follow its dependencies, and avoid wid
 
 ## Recommended next step
 
-Treat this design as the scope semantics layer underneath the converged seed/mesh plan. Do not start anti-entropy, hinted handoff, or anchor-peer scaling work until Track B and Track C are at least partially implemented and validated.
+Treat this design as the scope semantics layer underneath the converged seed/mesh plan. Anti-entropy, hinted handoff, and anchor-peer scaling remain unapproved future work; each requires evidence, a bounded contract, and a separate implementation decision before coding starts.


### PR DESCRIPTION
## Description

Corrects two governing sync architecture documents to match shipped behavior. The docs now describe Ed25519-signed HTTP without implied transport confidentiality, shipped scoped capability/membership/cursor/snapshot/reset behavior, and current cursor-based convergence. They remove stale Merkle/hinted-handoff implementation claims, obsolete rollout machinery, and speculative implementation estimates.

The earlier relay proposal was discarded after value reassessment; this PR preserves the invariant that the coordinator is never a memory payload data path.

## Demonstrated value

A reader relying on the prior docs could incorrectly assume mTLS confidentiality, implemented Merkle anti-entropy/hinted handoff, or future-only scoped synchronization. Each correction was checked against current source contracts.

## Validation

- `git diff main...HEAD --check`
- Independent source-backed documentation review: GO
- No code paths changed; TypeScript tests are not applicable