### PR TITLE
docs(sync): record connectivity experiment outcome

### DIFF
--- a/docs/plans/2026-08-08-relay-assisted-sync-design.md
+++ b/docs/plans/2026-08-08-relay-assisted-sync-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-08
 **Status:** Proposed — review required before implementation
-**Related:** `2026-08-09-remote-workspace-connectivity-evidence-design.md`, `2026-04-30-seed-and-mesh-architecture-converged.md`, `2026-04-30-sharing-domain-scope-design.md`, `2026-05-25-scoped-sync-protocol.md`, `2026-01-24-p2p-sync-phase-1.md`, `2026-01-24-p2p-sync-phase-2.md`, `2026-03-08-identity-aware-sync-shared-memory-foundation.md`, `2026-03-12-coordinator-backed-cross-network-discovery.md`, `2026-03-12-optional-relay-coordinator-mode.md`, `2026-03-12-relay-and-buffered-delivery-follow-on.md`, `2026-07-21-project-recipient-sharing-identity-design.md`, `../architecture.md`
+**Related:** `2026-08-09-remote-workspace-connectivity-evidence-design.md`, `2026-08-09-remote-workspace-connectivity-evidence-report.md`, `2026-04-30-seed-and-mesh-architecture-converged.md`, `2026-04-30-sharing-domain-scope-design.md`, `2026-05-25-scoped-sync-protocol.md`, `2026-01-24-p2p-sync-phase-1.md`, `2026-01-24-p2p-sync-phase-2.md`, `2026-03-08-identity-aware-sync-shared-memory-foundation.md`, `2026-03-12-coordinator-backed-cross-network-discovery.md`, `2026-03-12-optional-relay-coordinator-mode.md`, `2026-03-12-relay-and-buffered-delivery-follow-on.md`, `2026-07-21-project-recipient-sharing-identity-design.md`, `../architecture.md`
 
 ## Executive summary
 
@@ -237,6 +237,8 @@ The relay must contain no payload queue implementation; any observed non-zero du
 | 4 — controlled availability | Co-hosted default deployment plus standalone compatibility test | Relay is optional; relay-free and direct paths remain healthy. |
 | Later — durable delivery decision | Separate cryptographic/key-lifecycle proposal | No durable queue ships without its own approval. |
 
+**Current evidence result:** `2026-08-09-remote-workspace-connectivity-evidence-report.md` records **fix prerequisites first**. Direct signed sync worked on the tested ephemeral private route, but explicit multi-page bootstrap and complete identity restoration blocked two cases; no required route-unavailable peer network was observed. This result does not authorize relay implementation.
+
 ## Test strategy
 
 ### Unit and contract tests
@@ -290,7 +292,7 @@ Extend the mixed-owner fixture from the sharing-domain design: personal, work, a
 
 Implementation is blocked until the live-relay gates have owners and recorded decisions:
 
-1. **Connectivity evidence:** The targeted experiment in `2026-08-09-remote-workspace-connectivity-evidence-design.md` must separate signed-protocol correctness, listener lifecycle, ephemeral-address churn, stable private exposure, and a true route-unavailable/simultaneously-online case. A stopped listener or untested stable endpoint cannot justify relay.
+1. **Connectivity evidence:** The targeted experiment in `2026-08-09-remote-workspace-connectivity-evidence-design.md` separated signed-protocol correctness, listener lifecycle, ephemeral-address churn, stable private exposure, and a true route-unavailable/simultaneously-online case. Its report chose **fix prerequisites first**: direct signed sync worked, while bootstrap and identity restoration remained blocked and no route-unavailable peer network was observed.
 2. **Cryptographic envelope:** What is encrypted/authenticated, how are paired device identities bound, and how are replay, nonce, padding, and frame expiry handled?
 3. **Live key lifecycle:** How are encryption keys introduced alongside existing signing keys, bound to paired devices, rotated, recovered, and given an explicit forward-secrecy posture?
 4. **Recipient-bound peer signature (`codemem-zjvr.1.10`):** Version the canonical peer signature so direct and relayed requests bind the intended recipient before architecture approval. This is direct-sync hardening, not relay transport implementation.
@@ -310,6 +312,6 @@ Implementation is blocked until the live-relay gates have owners and recorded de
 | `codemem-zjvr.2` — Live encrypted relay | Relay-session instrumentation, path selector, relay client/service, coordinator co-hosting, limits, fault tests, standalone compatibility, and dogfood | All production children depend on `codemem-zjvr.1.5`; `codemem-zjvr.2.10` gates controlled availability |
 | `codemem-zjvr.3` — Durable encrypted relay | Separate offline queue threat model, key lifecycle, encrypted storage contract, future vertical slice, and compromise testing | Begins after live-relay review; `codemem-zjvr.3.4` separately approves or rejects implementation |
 
-The evidence precursor is separately gated: `codemem-zjvr.1.8` approves the bounded experiment only, `codemem-zjvr.1.9` runs it without persistent telemetry or sync-behavior changes, and `codemem-zjvr.1.6` evaluates the result. `codemem-zjvr.1.10` owns the recipient-bound canonical-signature prerequisite in direct peer sync and blocks architecture approval. No coordinator/relay transmission, export, or fleet aggregation of evidence is authorized. None of these beads authorizes relay transport.
+The evidence precursor is separately gated: `codemem-zjvr.1.8` approved the bounded experiment, `codemem-zjvr.1.9` ran it without persistent telemetry or sync-behavior changes, and `codemem-zjvr.1.6` recorded fix-prerequisites-first. `codemem-hdah` and `codemem-q71r` own the blocked bootstrap and identity-persistence prerequisites; `codemem-9dnf` owns the bounded rerun. `codemem-zjvr.1.10` owns the recipient-bound canonical-signature prerequisite in direct peer sync and blocks architecture approval. No coordinator/relay transmission, export, or fleet aggregation of evidence is authorized. None of these beads authorizes relay transport.
 
 The graph allows approved measurement, contract, and review work while blocking relay implementation on `codemem-zjvr.1.5`. Durable implementation is blocked again on successful live-relay evidence and the separate `codemem-zjvr.3.4` decision. These epics scope future execution; they do not themselves authorize production code.

--- a/docs/plans/2026-08-09-remote-workspace-connectivity-evidence-design.md
+++ b/docs/plans/2026-08-09-remote-workspace-connectivity-evidence-design.md
@@ -1,9 +1,9 @@
 # Remote Workspace Connectivity Evidence Decision
 
 **Date:** 2026-08-09
-**Status:** Approved targeted experiment; relay implementation remains unauthorized
+**Status:** Experiment approved and executed; `.1.6` outcome is fix-prerequisites-first
 **Bead:** `codemem-zjvr.1.8`
-**Related:** `2026-08-08-relay-assisted-sync-design.md`, `2026-03-12-coordinator-backed-cross-network-discovery.md`, `2026-03-12-relay-and-buffered-delivery-follow-on.md`
+**Related:** `2026-08-09-remote-workspace-connectivity-evidence-report.md`, `2026-08-08-relay-assisted-sync-design.md`, `2026-03-12-coordinator-backed-cross-network-discovery.md`, `2026-03-12-relay-and-buffered-delivery-follow-on.md`
 
 ## Decision
 
@@ -105,11 +105,11 @@ An HTTP 401, 403, 409, 429, or other HTTP response proves reachability. Record 4
 
 The experiment report may record only:
 
-- test case identifier from the five cases above;
+- test case or explicit subcase identifier from the five cases above;
 - UTC date, not exact user activity timestamps;
 - `pass`, `fail`, `blocked`, or `not_applicable`;
 - bounded path class: `ephemeral_direct`, `stable_private_direct`, `outbound_websocket`, or `none`;
-- bounded result class: `http_reached`, `auth_failed`, `scope_failed`, `rate_limited`, `listener_stopped`, `dns_failed`, `connection_refused`, `connect_timeout`, `network_unreachable`, `no_candidate`, or `unknown`;
+- bounded result class: `http_reached`, `auth_failed`, `scope_failed`, `rate_limited`, `listener_stopped`, `dns_failed`, `connection_refused`, `connect_timeout`, `network_unreachable`, `no_candidate`, `precondition_violated`, `bootstrap_incomplete` (reserved for a precondition-valid rerun), or `unknown`;
 - whether the candidate set changed after normal recreation;
 - candidate-cache result after refresh: `replaced`, `merged_stale_retained`, `unchanged`, or `unknown`;
 - outbound overlap: `observed`, `inferred`, or `not_confirmed`; and
@@ -148,7 +148,10 @@ Choose this result when signed sync fails despite an HTTP-reachable listener, th
 
 ## Follow-on ownership
 
-- `codemem-zjvr.1.9` runs and records the targeted experiment without adding persistent telemetry or changing sync behavior.
-- `codemem-zjvr.1.6` evaluates the bounded report and recommends stable-direct, continue-relay-review, or fix-prerequisites-first. Its recommendation must state the single-deployment scope, untested networks and policies, blocked/unknown cases, and limits on generalization.
+- `codemem-zjvr.1.9` ran and recorded the targeted experiment without adding persistent telemetry or changing sync behavior.
+- `codemem-zjvr.1.6` evaluated the bounded report as fix-prerequisites-first, with the single-deployment scope, untested networks and policies, blocked cases, and limits on generalization recorded in the report.
+- `codemem-hdah` owns the explicit multi-page bootstrap rerun with the empty-receiver/no-cursor precondition enforced.
+- `codemem-q71r` owns complete database-plus-signing-key identity persistence across recreation.
+- `codemem-9dnf` owns rerunning blocked cases 1b and 3 after both prerequisites close.
 - Private deployment adapters own environment-specific Service/Ingress or mesh configuration.
 - Relay implementation remains blocked on the existing architecture and security gates.

--- a/docs/plans/2026-08-09-remote-workspace-connectivity-evidence-report.md
+++ b/docs/plans/2026-08-09-remote-workspace-connectivity-evidence-report.md
@@ -1,0 +1,86 @@
+# Remote Workspace Connectivity Evidence Report
+
+**Date:** 2026-08-09
+**Status:** Completed — fix prerequisites first
+**Bead:** `codemem-zjvr.1.6`
+**Experiment:** `codemem-zjvr.1.9`
+**Related:** `2026-08-09-remote-workspace-connectivity-evidence-design.md`, `2026-08-08-relay-assisted-sync-design.md`
+
+## Executive conclusion
+
+Direct signed HTTP synchronization works on the tested ephemeral private route. Signed scoped exchange succeeded in both directions, repeated application remained idempotent, listener stop/restart behavior was classified correctly, and a replacement listener remained reachable after workspace recreation.
+
+The experiment does **not** justify relay implementation:
+
+- no required peer network in the single tested deployment lacked a direct route;
+- no simultaneous-online route-unavailable case was observed;
+- stable private exposure was not tested; and
+- two prerequisite cases were blocked by bootstrap behavior and incomplete peer-identity persistence in the disposable harness.
+
+The approved outcome is **fix prerequisites first**. Relay implementation remains unauthorized. Direct signed HTTP remains canonical for the tested deployment shape.
+
+## Bounded results
+
+| Case | Result | Path/result class | Evidence |
+| --- | --- | --- | --- |
+| 1a. Signed bidirectional exchange and idempotency | `pass` | `ephemeral_direct` / `http_reached` | Signed scoped synchronization passed in both directions. Daemon-driven initial synchronization populated the receiver, and repeated application preserved canonical counts. |
+| 1b. Explicit multi-page snapshot bootstrap | `blocked` | `ephemeral_direct` / `precondition_violated` | Explicit bootstrap ran after daemon-driven synchronization had populated the receiver, violating the required no-records/no-cursor precondition. It applied zero records, so the experiment cannot distinguish correct idempotent behavior from a pagination or application defect. |
+| 2. Listener lifecycle | `pass` | `ephemeral_direct` / `listener_stopped`, then `http_reached` | Stopping the daemon changed the same route from HTTP-reachable to listener refusal. Restart restored signed reachability without corrupting canonical state. |
+| 3. Address churn | `blocked` | `ephemeral_direct` / `precondition_violated` | Normal recreation changed the candidate. The replacement listener was reachable, but coordinator cache refresh for the prior identity could not be tested because its external signing key was not restored with the copied database. This case ran before case 1b completed; that ordering deviation did not cause the independent missing-key blocker. |
+| 4. Stable direct endpoint | `not_applicable` | `none` | No Service, Ingress, mesh route, or other stable endpoint mutation was authorized. |
+| 5. Route-unavailable peer | `not_applicable` | `none` | Not run: no qualifying peer network was available. The tested peer network could route directly to the listener, so the route-unavailable case remains untested rather than disproven. |
+
+## Interpretation
+
+### Direct transport and signed protocol
+
+The experiment separates transport reachability from authentication and replication correctness:
+
+- an HTTP response proved the tested route reached Codemem;
+- signed peer authentication and scoped authorization succeeded;
+- operations traveled in both directions; and
+- repeated synchronization remained idempotent.
+
+The earlier listener refusal was correctly classified as daemon lifecycle, not missing network routing. It must not be reused as relay evidence.
+
+### Multi-page bootstrap prerequisite
+
+Normal daemon-driven synchronization populated the receiver before explicit bootstrap ran. The receiver was therefore no longer in the no-records/no-cursor state required by the experiment design. Explicit bootstrap then applied zero records while the synthetic source exceeded one snapshot page. That result is consistent with either correct idempotent behavior or an undiscovered pagination/application defect; this experiment cannot distinguish them and did not prove explicit paginated bootstrap across at least two pages.
+
+`codemem-hdah` owns a controlled rerun that enforces an empty receiver and absent cursor before explicit bootstrap. Only if that rerun still applies zero records should it be classified as a replication/bootstrap defect. Either outcome is unrelated to transport selection.
+
+### Complete identity persistence prerequisite
+
+Workspace recreation changed the ephemeral candidate and the replacement listener was reachable. Database-only restoration did not preserve the signing material needed to authenticate as the prior peer identity and refresh coordinator presence. The old cached candidate therefore could not be evaluated under a valid restored identity.
+
+`codemem-q71r` owns the backup/restore contract for database state plus external signing-key material. This is an identity-persistence and test-harness prerequisite, not a routing failure.
+
+### Relay decision
+
+The continue-relay-review outcome required at least one authorized, simultaneously online peer network that could not route to any stable direct candidate while both peers could establish outbound WebSocket connections. The experiment did not contain such a network. Case 5 was `not_applicable` because no qualifying network was available; it remains untested rather than disproven, and the experiment supplies no affirmative relay-need evidence.
+
+This conclusion is intentionally narrow. An outbound live relay may still be valuable for other networks or deployment policies, but that claim requires evidence from a real route-unavailable case and remains gated by the architecture and security prerequisites in `2026-08-08-relay-assisted-sync-design.md`.
+
+## Recommendation
+
+1. Rerun explicit multi-page scoped bootstrap with its precondition enforced under `codemem-hdah`.
+2. Define and validate complete peer-identity persistence under `codemem-q71r`.
+3. Rerun cases 1b and 3 under `codemem-9dnf` after both prerequisites close.
+4. Test a stable private endpoint only with separate operator approval.
+5. Run case 5 only when a required peer network genuinely lacks direct routing.
+6. Do not implement relay from the current evidence.
+
+## Limitations
+
+- This was one disposable deployment and one directly routed private peer network.
+- No stable direct endpoint was created or tested.
+- No required route-unavailable peer network participated.
+- Address-cache replacement after recreation was not observed under a restored identity.
+- Case 3 ran before the case 1b bootstrap proof completed, deviating from the planned order; its missing-key blocker was independent of that order.
+- Explicit multi-page bootstrap remained blocked.
+- Synthetic data exercised synchronization behavior; no production corpus or payload was inspected.
+- Results do not generalize to networks, cluster policies, or deployment environments that were not tested.
+
+## Privacy and cleanup
+
+The public report contains no environment-specific names, hostnames, addresses, organization identifiers, device identifiers, credentials, project/scope labels, memory/operation identifiers, raw errors, or payload content. Disposable workspaces, daemons, coordinator state, databases, and temporary artifacts were removed after the experiment.


### PR DESCRIPTION
## Description

Records the bounded remote-workspace connectivity experiment and the fix-prerequisites-first decision. Signed scoped direct synchronization passed bidirectionally and remained idempotent, while listener lifecycle classification also passed. Explicit multi-page bootstrap and complete peer-identity restoration require controlled follow-ups; no route-unavailable peer network was observed.

The report keeps relay implementation unauthorized and assigns the blocked cases to codemem-hdah, codemem-q71r, and codemem-9dnf.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`) — not run locally; documentation-only and these Markdown files are outside Biome
- [ ] Added/updated tests for changes — not applicable
- [x] Manually verified changes work as expected
- [x] `git diff --check` passes
- [x] Changed public docs pass the prohibited-identifier scan
- [x] Independent review found no blocking issues

## Checklist

- [ ] Code follows project style (`pnpm run lint` passes for touched files) — not applicable to these Markdown files
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced