### PR TITLE
fix(sync): preserve restored peer identities

### DIFF
--- a/docs/anchor-peer-deployment.md
+++ b/docs/anchor-peer-deployment.md
@@ -73,17 +73,41 @@ domains, and bootstrapped from existing peers.
 
 ## Storage and backups
 
-Anchor peers are local-first peers, so their SQLite database matters. For VPS or
-k8s deployments:
+Anchor peers are local-first peers, so restoring their identity requires one
+coherent backup set:
 
-- Use a persistent disk or PVC for the codemem runtime directory.
-- Back up the SQLite database and device key material together.
-- Treat the device key as sensitive: a peer with the key can authenticate as that
-  anchor peer.
-- Prefer filesystem or volume snapshots taken while the process is stopped, or
-  use SQLite-safe backup tooling.
-- Test restore by starting a replacement peer from the backup and verifying it
-  still has the expected device identity and Sharing-domain membership.
+- the effective SQLite database selected by `--db-path` or `CODEMEM_DB`
+- `<keys-dir>/device.key`, the secret Ed25519 private key
+- `<keys-dir>/device.key.pub`, the corresponding public key
+- the effective config selected by `--config`, `CODEMEM_CONFIG`, or the configured
+  runtime root, or equivalent environment settings that select the same database,
+  key directory, coordinator, and listener configuration
+
+Protect the database and config as sensitive data and the private key as a
+credential. Never publish the private key, coordinator secrets, invite tokens, or
+an unredacted config snapshot as diagnostic artifacts.
+
+Use durable storage for the complete set. Prefer a filesystem or volume snapshot
+taken while codemem is stopped, or use SQLite-safe backup tooling. Copying only
+the main database file while it is active in WAL mode can omit committed state.
+`CODEMEM_RUNTIME_ROOT` selects workspace config; it does not automatically move
+the database or key directory, so set `CODEMEM_DB`, `CODEMEM_CONFIG`, and
+`CODEMEM_KEYS_DIR` explicitly when restoring to new paths.
+
+Before starting a restored peer, stop or isolate the old instance. Running two
+instances with the same private key clones one device identity. Then verify that
+the replacement reports the original device ID and fingerprint, refreshes
+coordinator presence, authenticates a signed peer request, and completes a direct
+sync. If the database is present but the private key is missing, invalid, or from
+another identity, codemem fails closed instead of silently rotating the key,
+unless the matching private key remains in the configured platform keychain.
+
+The protected `device.key` file is the portable restore artifact even when
+`CODEMEM_SYNC_KEY_STORE=keychain` is enabled; codemem can repopulate the keychain
+from a matching restored file. If an operator deliberately removes that file and
+keeps the credential only in the platform keychain, it can authenticate only on
+that local platform; migrate the credential with platform-supported secure tooling
+before moving the peer. The database and public-key file alone are never sufficient.
 
 If you use ephemeral storage, the peer can still be useful as a cache/backstop
 while it is running, but it must re-bootstrap after restart.

--- a/docs/contracts/pre-provisioned-workspace-runtime-attachment.md
+++ b/docs/contracts/pre-provisioned-workspace-runtime-attachment.md
@@ -73,9 +73,16 @@ The workspace runtime must provide:
 
 For stable peers, the runtime must also provide durable persistence for:
 
-- keys
-- DB
-- config
+- the effective SQLite database selected by `db_path` / `CODEMEM_DB`
+- `<keys_path>/device.key` and `<keys_path>/device.key.pub`
+- the effective config selected by `config_path` / `CODEMEM_CONFIG`, or equivalent
+  environment settings that restore the coordinator and listener configuration
+
+These artifacts form one identity boundary and must be backed up and restored
+together. A database-only restore is invalid because the database stores the
+device ID and public identity while signed requests require the external private
+key. `CODEMEM_RUNTIME_ROOT` selects workspace config but does not implicitly
+relocate the database or keys.
 
 For ephemeral peers, persistence may be disposable as long as it survives long enough for the swarm run.
 
@@ -111,6 +118,12 @@ The adapter ensures the node has the correct identity behavior:
 
 - stable peers reuse durable keys
 - ephemeral peers create disposable keys
+
+For a stable peer with an existing database identity, initialization must fail
+closed when the original private key is missing, unreadable, or does not match
+the database public key and fingerprint. It must never rotate that identity
+implicitly. A matching private key may be used to recreate a missing public-key
+file because the public key is derivable and not a credential.
 
 Expected outcome:
 - a valid device identity exists before join/bootstrap begins
@@ -186,6 +199,9 @@ The seed peer must accept or pin the worker identity before serving bootstrap da
 Expected outcome:
 - the seed peer has a trusted `sync_peers` entry for the worker
 - the worker can authenticate when requesting bootstrap or sync data
+- restoring the same stable identity onto a replacement requires the old runtime
+  to be stopped or isolated first; two live copies of one private key are one
+  cloned device identity
 
 ### Phase 2: finish-bootstrap
 
@@ -246,6 +262,11 @@ Recommended minimum artifacts:
 
 Sensitive material such as private keys, coordinator admin secrets, invite tokens, and bootstrap tokens must never be copied into shared artifacts. Config snapshots should redact sensitive fields before publication.
 
+Backup storage is not a shared diagnostic artifact. It must preserve the private
+key with credential-grade access controls, while published identity summaries may
+include only the device ID, fingerprint, public key, selected path names, and
+secret-free health results.
+
 ## Cleanup contract
 
 ### Stable nodes
@@ -264,6 +285,8 @@ Sensitive material such as private keys, coordinator admin secrets, invite token
 - codemem install not available
 - configuration path not writable
 - keys path not writable
+- existing database identity has missing private key material
+- restored private key is invalid or does not match the database identity
 - coordinator join failure
 - bootstrap unreachable or refused
 - sync verification failure

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -369,6 +369,15 @@ When selected history may already have replicated, all participating owner devic
 - `codemem sync doctor` diagnoses sync configuration issues (keys, config, peer reachability).
 - `codemem sync bootstrap <peer-device-id>` bootstraps sync state from a peer's snapshot.
 - `codemem sync attempts` shows recent sync attempt history per peer.
+- A restored peer requires its SQLite database and original signing key together.
+  If no matching key exists in `device.key` or the configured platform keychain,
+  sync fails closed with a `device_identity_*` diagnostic instead of silently
+  replacing the enrolled key.
+- The daemon records an `identity_error` state and retries without blocking local
+  memory capture. Restore the original key, then restart the service if mDNS
+  advertisement also needs to be re-established.
+- See [Anchor-peer deployment](anchor-peer-deployment.md#storage-and-backups) for
+  the complete backup and restore contract.
 
 ### Service helpers
 
@@ -388,9 +397,16 @@ When selected history may already have replicated, all participating owner devic
 
 ### Keychain (optional)
 
-- `sync_key_store=keychain` (or `CODEMEM_SYNC_KEY_STORE=keychain`) stores the private key in Secret Service (Linux) or Keychain (macOS).
+- `CODEMEM_SYNC_KEY_STORE=keychain` stores the private key in Secret Service (Linux) or Keychain (macOS).
 - Falls back to file-based storage if the platform tooling is unavailable.
-- On macOS, the Keychain storage uses the `security` CLI and may expose the key in process arguments; use `sync_key_store=file` if that is a concern.
+- On macOS, the Keychain storage uses the `security` CLI and may expose the key in process arguments; use `CODEMEM_SYNC_KEY_STORE=file` if that is a concern.
+- Keep the protected `device.key` file as the portable restore artifact even in
+  keychain mode; codemem can repopulate the keychain from a matching restored
+  file. A matching private key that remains in the platform keychain can also
+  authenticate a local installation if `device.key` is missing, corrupt, or
+  belongs to another identity. That is not a portable migration: moving a
+  keychain-only credential requires platform-supported secure tooling. The
+  database and public-key file alone cannot authenticate the original identity.
 
 ## Troubleshooting
 - If sessions are missing, confirm the viewer and plugin share the same DB path.

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -3,10 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	connect,
+	ensureDeviceIdentity,
 	fingerprintPublicKey,
 	initTestSchema,
 	loadPublicKey,
 	MemoryStore,
+	resolveKeyPaths,
 	startMaintenanceJob,
 } from "@codemem/core";
 import { describe, expect, it, vi } from "vitest";
@@ -573,6 +575,40 @@ describe("formatSyncAttempt", () => {
 		} finally {
 			logSpy.mockRestore();
 			store.close();
+			rmSync(tmpDbDir, { recursive: true, force: true });
+		}
+	});
+
+	it("reports missing restored identity keys in sync doctor output", async () => {
+		const tmpDbDir = mkdtempSync(join(tmpdir(), "sync-doctor-identity-test-"));
+		const dbPath = join(tmpDbDir, "mem.sqlite");
+		const keysDir = join(tmpDbDir, "keys");
+		const rawDb = connect(dbPath);
+		initTestSchema(rawDb);
+		ensureDeviceIdentity(rawDb, { keysDir });
+		rawDb.close();
+		const [privatePath] = resolveKeyPaths(keysDir);
+		rmSync(privatePath);
+		const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		try {
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			await syncCommand.parseAsync(["doctor", "--db-path", dbPath, "--json"], {
+				from: "user",
+			});
+
+			const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
+				identity_error?: string | null;
+				issues?: string[];
+			};
+			expect(payload.identity_error).toContain("device_identity_private_key_missing");
+			expect(payload.issues).toEqual(
+				expect.arrayContaining([expect.stringContaining("device_identity_private_key_missing")]),
+			);
+		} finally {
+			logSpy.mockRestore();
+			if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
 			rmSync(tmpDbDir, { recursive: true, force: true });
 		}
 	});

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -13,6 +13,7 @@ import {
 	applyBootstrapSnapshot,
 	buildAuthHeaders,
 	buildBaseUrl,
+	DeviceIdentityError,
 	ensureDeviceIdentity,
 	fetchAllSnapshotPages,
 	fingerprintPublicKey,
@@ -340,6 +341,7 @@ onceCmd.action(async (opts: { db?: string; dbPath?: string; peer?: string; json?
 		for (const row of rows) {
 			const result = await runSyncPass(store.db, row.peer_device_id, {
 				keysDir,
+				dbPath: store.dbPath,
 				scanner: store.scanner,
 			});
 			if (!result.ok) hadFailure = true;
@@ -629,6 +631,15 @@ pairCmd.action(async (opts: SyncPairOptions) => {
 		console.log(
 			"On the accepting device, --include/--exclude control both what it sends and what it accepts from that peer.",
 		);
+	} catch (error) {
+		const code = error instanceof DeviceIdentityError ? error.code : "pairing_failed";
+		const message = error instanceof Error ? error.message : "Pairing failed";
+		if (opts.json) {
+			emitJsonError(code, message);
+			return;
+		}
+		p.log.error(message);
+		process.exitCode = 1;
 	} finally {
 		store.close();
 	}
@@ -671,6 +682,7 @@ doctorCmd.action(
 				.all();
 
 			const issues: string[] = [];
+			let identityError: string | null = null;
 			const syncHost = typeof config.sync_host === "string" ? config.sync_host : "0.0.0.0";
 			const syncPort = typeof config.sync_port === "number" ? config.sync_port : 7337;
 			const viewerBinding = readViewerBinding(dbPath);
@@ -681,6 +693,16 @@ doctorCmd.action(
 
 			if (!reachable) issues.push("daemon not running");
 			if (!device) issues.push("identity missing");
+			if (device) {
+				try {
+					ensureDeviceIdentity(store.db, {
+						keysDir: process.env.CODEMEM_KEYS_DIR?.trim() || undefined,
+					});
+				} catch (error) {
+					identityError = error instanceof Error ? error.message : "device_identity_unavailable";
+					issues.push(identityError);
+				}
+			}
 			if (
 				daemonState?.last_error &&
 				(!daemonState.last_ok_at || daemonState.last_ok_at < (daemonState.last_error_at ?? ""))
@@ -736,6 +758,7 @@ doctorCmd.action(
 						mdns_source: mdnsSource,
 						daemon: reachable ? "running" : "not running",
 						identity: device?.device_id ?? null,
+						identity_error: identityError,
 						daemon_error: daemonState?.last_error ?? null,
 						peers: peerDetails,
 						issues: [...new Set(issues)],
@@ -755,6 +778,7 @@ doctorCmd.action(
 				console.log("- Identity: missing (run `codemem sync enable`)");
 			} else {
 				console.log(`- Identity: ${device.device_id}`);
+				if (identityError) console.log(`- Identity error: ${identityError}`);
 			}
 
 			if (
@@ -782,6 +806,15 @@ doctorCmd.action(
 			} else {
 				console.log("OK: sync looks healthy");
 			}
+		} catch (error) {
+			const code = error instanceof DeviceIdentityError ? error.code : "doctor_failed";
+			const message = error instanceof Error ? error.message : "Sync diagnostics failed";
+			if (opts.json) {
+				emitJsonError(code, message);
+				return;
+			}
+			p.log.error(message);
+			process.exitCode = 1;
 		} finally {
 			store.close();
 		}
@@ -1242,6 +1275,7 @@ bootstrapCmd.action(
 				const statusUrl = `${candidate}/v1/status`;
 				const headers = buildAuthHeaders({
 					deviceId,
+					dbPath: store.dbPath,
 					method: "GET",
 					url: statusUrl,
 					bodyBytes: Buffer.alloc(0),
@@ -1313,6 +1347,7 @@ bootstrapCmd.action(
 
 			const { items } = await fetchAllSnapshotPages(baseUrl, resetInfo, deviceId, {
 				keysDir,
+				dbPath: store.dbPath,
 				bootstrapGrantId: opts.bootstrapGrant,
 				pageSize,
 			});
@@ -1343,6 +1378,15 @@ bootstrapCmd.action(
 				p.outro(result.ok ? "Bootstrap complete" : "Bootstrap failed");
 			}
 			if (!result.ok) process.exitCode = 1;
+		} catch (error) {
+			const code = error instanceof DeviceIdentityError ? error.code : "bootstrap_failed";
+			const message = error instanceof Error ? error.message : "Bootstrap failed";
+			if (opts.json) {
+				emitJsonError(code, message);
+				return;
+			}
+			p.log.error(message);
+			process.exitCode = 1;
 		} finally {
 			store.close();
 		}

--- a/packages/core/src/coordinator-runtime.test.ts
+++ b/packages/core/src/coordinator-runtime.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
@@ -319,6 +319,8 @@ describe("coordinatorStatusSnapshot", () => {
 			});
 			await coordinatorStatusSnapshot(store, changedAdvertiseConfig);
 			const changedAdvertisePresenceFetchCount = presenceFetchCount;
+			cpSync(join(keysDir, "device.key"), join(alternateKeysDir, "device.key"));
+			cpSync(join(keysDir, "device.key.pub"), join(alternateKeysDir, "device.key.pub"));
 			process.env.CODEMEM_KEYS_DIR = alternateKeysDir;
 			await coordinatorStatusSnapshot(store, changedAdvertiseConfig);
 

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -278,7 +278,14 @@ export async function registerCoordinatorPresence(
 		const groupPayload = { ...payload, group_id: groupId };
 		const bodyBytes = Buffer.from(JSON.stringify(groupPayload), "utf8");
 		const url = `${baseUrl}/v1/presence`;
-		const headers = buildAuthHeaders({ deviceId, method: "POST", url, bodyBytes, keysDir });
+		const headers = buildAuthHeaders({
+			deviceId,
+			dbPath: store.dbPath,
+			method: "POST",
+			url,
+			bodyBytes,
+			keysDir,
+		});
 		const [status, response] = await requestJson("POST", url, {
 			headers,
 			body: groupPayload,
@@ -308,6 +315,7 @@ export async function lookupCoordinatorPeers(
 		const url = `${baseUrl}/v1/peers?group_id=${encodeURIComponent(groupId)}`;
 		const headers = buildAuthHeaders({
 			deviceId,
+			dbPath: store.dbPath,
 			method: "GET",
 			url,
 			bodyBytes: Buffer.alloc(0),
@@ -748,6 +756,7 @@ export async function listCoordinatorReciprocalApprovals(
 		const url = `${baseUrl}/v1/reciprocal-approvals?${params.toString()}`;
 		const headers = buildAuthHeaders({
 			deviceId,
+			dbPath: store.dbPath,
 			method: "GET",
 			url,
 			bodyBytes: Buffer.alloc(0),
@@ -790,7 +799,14 @@ export async function createCoordinatorReciprocalApproval(
 	const url = `${baseUrl}/v1/reciprocal-approvals`;
 	const payload = { group_id: groupId, requested_device_id: requestedDeviceId };
 	const bodyBytes = Buffer.from(JSON.stringify(payload), "utf8");
-	const headers = buildAuthHeaders({ deviceId, method: "POST", url, bodyBytes, keysDir });
+	const headers = buildAuthHeaders({
+		deviceId,
+		dbPath: store.dbPath,
+		method: "POST",
+		url,
+		bodyBytes,
+		keysDir,
+	});
 	const [status, response] = await requestJson("POST", url, {
 		headers,
 		body: payload,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1004,8 +1004,9 @@ export {
 } from "./sync-discovery.js";
 export type { RequestJsonOptions } from "./sync-http-client.js";
 export { buildBaseUrl, requestJson } from "./sync-http-client.js";
-export type { EnsureDeviceIdentityOptions } from "./sync-identity.js";
+export type { DeviceIdentityErrorCode, EnsureDeviceIdentityOptions } from "./sync-identity.js";
 export {
+	DeviceIdentityError,
 	ensureDeviceIdentity,
 	fingerprintPublicKey,
 	generateKeypair,

--- a/packages/core/src/scope-membership-cache.ts
+++ b/packages/core/src/scope-membership-cache.ts
@@ -82,6 +82,7 @@ export interface RefreshScopeMembershipCacheOptions {
 	/** @deprecated The refresh database is taken from refreshScopeMembershipCache(db, opts). */
 	db?: Database;
 	keysDir?: string | null;
+	dbPath?: string;
 	now?: Date;
 	fetchers?: ScopeMembershipCacheFetchers;
 }
@@ -172,6 +173,7 @@ function signedCoordinatorGet(
 	db: Database,
 	url: string,
 	keysDir?: string | null,
+	dbPath?: string,
 ): Promise<Record<string, unknown> | null> {
 	const [deviceId] = ensureDeviceIdentity(db, { keysDir: keysDir ?? undefined });
 	const bodyBytes = Buffer.alloc(0);
@@ -181,6 +183,7 @@ function signedCoordinatorGet(
 		url,
 		bodyBytes,
 		keysDir: keysDir ?? undefined,
+		dbPath,
 	});
 	return requestJson("GET", url, {
 		headers,
@@ -207,12 +210,14 @@ function authenticatedFetchers(
 	return {
 		listScopes: async (groupId) => {
 			const url = `${baseUrl}/v1/scopes?group_id=${encodeURIComponent(groupId)}`;
-			return payloadItems<CoordinatorScope>(await signedCoordinatorGet(db, url, opts.keysDir));
+			return payloadItems<CoordinatorScope>(
+				await signedCoordinatorGet(db, url, opts.keysDir, opts.dbPath),
+			);
 		},
 		listMemberships: async (groupId, scopeId) => {
 			const url = `${baseUrl}/v1/scopes/${encodeURIComponent(scopeId)}/members?group_id=${encodeURIComponent(groupId)}`;
 			return payloadItems<CoordinatorScopeMembership>(
-				await signedCoordinatorGet(db, url, opts.keysDir),
+				await signedCoordinatorGet(db, url, opts.keysDir, opts.dbPath),
 			);
 		},
 	};
@@ -654,7 +659,7 @@ export async function refreshScopeMembershipCache(
 export async function refreshConfiguredScopeMembershipCache(
 	db: Database,
 	config?: CoordinatorSyncConfig,
-	options?: { keysDir?: string | null },
+	options?: { keysDir?: string | null; dbPath?: string },
 ): Promise<RefreshScopeMembershipCacheResult> {
 	const syncConfig = config ?? readCoordinatorSyncConfig();
 	if (!coordinatorEnabled(syncConfig)) {
@@ -666,6 +671,7 @@ export async function refreshConfiguredScopeMembershipCache(
 		remoteUrl: syncConfig.syncCoordinatorUrl,
 		adminSecret: syncConfig.syncCoordinatorAdminSecret,
 		keysDir: options?.keysDir ?? null,
+		dbPath: options?.dbPath,
 	});
 }
 

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -1412,6 +1412,20 @@ describe("MemoryStore", () => {
 			);
 		});
 
+		it("allows shared memory writes when only sync identity is impaired", () => {
+			setSyncDaemonPhase(store.db, "identity_error");
+			const sessionId = insertTestSession(store.db);
+
+			expect(() =>
+				store.remember(
+					sessionId,
+					"discovery",
+					"Local work continues",
+					"Identity recovery must not block local memory capture.",
+				),
+			).not.toThrow();
+		});
+
 		it("blocks updateMemoryVisibility() to shared when phase is needs_attention", () => {
 			const sessionId = insertTestSession(store.db);
 			const memId = store.remember(sessionId, "discovery", "Private", "Body", 0.5, [], {

--- a/packages/core/src/sync-auth.test.ts
+++ b/packages/core/src/sync-auth.test.ts
@@ -1,18 +1,24 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Database } from "./db.js";
 import { connect } from "./db.js";
 import {
+	buildAuthHeaders,
 	buildCanonicalRequest,
 	cleanupNonces,
 	recordNonce,
 	signRequest,
 	verifySignature,
 } from "./sync-auth.js";
-import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
+import {
+	ensureDeviceIdentity,
+	generateKeypair,
+	loadPublicKey,
+	resolveKeyPaths,
+} from "./sync-identity.js";
 import { initTestSchema } from "./test-utils.js";
 
 // ---------------------------------------------------------------------------
@@ -29,6 +35,36 @@ function sshKeygenAvailable(): boolean {
 }
 
 const _HAS_SSH_KEYGEN = sshKeygenAvailable();
+const HAS_KEYCHAIN_PLATFORM = process.platform === "darwin" || process.platform === "linux";
+
+function installFakeKeychainCli(
+	baseDir: string,
+	keychainPath: string,
+	expectedAccount: string,
+): void {
+	const binDir = join(baseDir, "bin");
+	mkdirSync(binDir, { recursive: true });
+	const executable = process.platform === "darwin" ? "security" : "secret-tool";
+	const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const command = args[0];
+const accountFlag = command === "lookup" || command === "store" ? "account" : "-a";
+const accountIndex = args.indexOf(accountFlag);
+if (accountIndex < 0 || args[accountIndex + 1] !== ${JSON.stringify(expectedAccount)}) {
+	process.exit(2);
+}
+if (command === "lookup" || command === "find-generic-password") {
+	process.stdout.write(fs.readFileSync(${JSON.stringify(keychainPath)}));
+} else {
+	process.exit(1);
+}
+`;
+	const executablePath = join(binDir, executable);
+	writeFileSync(executablePath, script);
+	chmodSync(executablePath, 0o755);
+	process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -36,12 +72,28 @@ const _HAS_SSH_KEYGEN = sshKeygenAvailable();
 
 describe("sync-auth", () => {
 	let tmpDir: string;
+	let originalDbPath: string | undefined;
+	let originalKeyStore: string | undefined;
+	let originalKeychainWarning: string | undefined;
+	let originalPath: string | undefined;
 
 	beforeEach(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-sync-auth-test-"));
+		originalDbPath = process.env.CODEMEM_DB;
+		originalKeyStore = process.env.CODEMEM_SYNC_KEY_STORE;
+		originalKeychainWarning = process.env.CODEMEM_SYNC_KEYCHAIN_WARN;
+		originalPath = process.env.PATH;
 	});
 
 	afterEach(() => {
+		if (originalDbPath === undefined) delete process.env.CODEMEM_DB;
+		else process.env.CODEMEM_DB = originalDbPath;
+		if (originalKeyStore === undefined) delete process.env.CODEMEM_SYNC_KEY_STORE;
+		else process.env.CODEMEM_SYNC_KEY_STORE = originalKeyStore;
+		if (originalKeychainWarning === undefined) delete process.env.CODEMEM_SYNC_KEYCHAIN_WARN;
+		else process.env.CODEMEM_SYNC_KEYCHAIN_WARN = originalKeychainWarning;
+		if (originalPath === undefined) delete process.env.PATH;
+		else process.env.PATH = originalPath;
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -126,6 +178,108 @@ describe("sync-auth", () => {
 				db.close();
 			}
 		});
+
+		it.skipIf(!HAS_KEYCHAIN_PLATFORM)(
+			"buildAuthHeaders signs with an explicit device ID without consulting the default DB",
+			() => {
+				const keysDir = join(tmpDir, "explicit-device-keys");
+				const dbPath = join(tmpDir, "custom.sqlite");
+				const keychainPath = join(tmpDir, "keychain-value");
+				process.env.CODEMEM_SYNC_KEY_STORE = "file";
+				const db = connect(dbPath);
+				initTestSchema(db);
+				const [deviceId] = ensureDeviceIdentity(db, { keysDir });
+				const publicKey = loadPublicKey(keysDir);
+				const [privatePath] = resolveKeyPaths(keysDir);
+				writeFileSync(keychainPath, readFileSync(privatePath));
+				rmSync(privatePath);
+				db.close();
+				if (!publicKey) throw new Error("expected public key");
+
+				installFakeKeychainCli(tmpDir, keychainPath, deviceId);
+				process.env.CODEMEM_SYNC_KEY_STORE = "keychain";
+				process.env.CODEMEM_SYNC_KEYCHAIN_WARN = "0";
+				delete process.env.CODEMEM_DB;
+				const bodyBytes = Buffer.from("{}");
+				const timestamp = String(Math.floor(Date.now() / 1000));
+				const headers = buildAuthHeaders({
+					deviceId,
+					method: "POST",
+					url: "https://coordinator.example.test/v1/presence",
+					bodyBytes,
+					keysDir,
+					timestamp,
+					nonce: "explicit-device-id",
+				});
+
+				expect(headers["X-Opencode-Device"]).toBe(deviceId);
+				expect(
+					verifySignature({
+						method: "POST",
+						pathWithQuery: "/v1/presence",
+						bodyBytes,
+						timestamp: headers["X-Opencode-Timestamp"],
+						nonce: headers["X-Opencode-Nonce"],
+						signature: headers["X-Opencode-Signature"],
+						publicKey,
+						deviceId,
+					}),
+				).toBe(true);
+			},
+		);
+
+		it.skipIf(!HAS_KEYCHAIN_PLATFORM)(
+			"signs with the enrolled keychain identity when device.key belongs to another identity",
+			() => {
+				const keysDir = join(tmpDir, "foreign-file-keys");
+				const unrelatedKeysDir = join(tmpDir, "foreign-file-unrelated-keys");
+				const dbPath = join(tmpDir, "foreign-file.sqlite");
+				const keychainPath = join(tmpDir, "foreign-file-keychain-value");
+				process.env.CODEMEM_SYNC_KEY_STORE = "file";
+				const db = connect(dbPath);
+				initTestSchema(db);
+				const [deviceId] = ensureDeviceIdentity(db, { keysDir });
+				const publicKey = loadPublicKey(keysDir);
+				const [privatePath] = resolveKeyPaths(keysDir);
+				const enrolledPrivateKey = readFileSync(privatePath);
+				const [unrelatedPrivatePath, unrelatedPublicPath] = resolveKeyPaths(unrelatedKeysDir);
+				generateKeypair(unrelatedPrivatePath, unrelatedPublicPath);
+				writeFileSync(privatePath, readFileSync(unrelatedPrivatePath));
+				writeFileSync(keychainPath, enrolledPrivateKey);
+				db.close();
+				if (!publicKey) throw new Error("expected public key");
+
+				installFakeKeychainCli(tmpDir, keychainPath, deviceId);
+				process.env.CODEMEM_SYNC_KEY_STORE = "keychain";
+				process.env.CODEMEM_SYNC_KEYCHAIN_WARN = "0";
+				delete process.env.CODEMEM_DB;
+				const bodyBytes = Buffer.from("{}");
+				const timestamp = String(Math.floor(Date.now() / 1000));
+				const headers = buildAuthHeaders({
+					deviceId,
+					dbPath,
+					method: "POST",
+					url: "https://coordinator.example.test/v1/presence",
+					bodyBytes,
+					keysDir,
+					timestamp,
+					nonce: "foreign-file-matching-keychain",
+				});
+
+				expect(
+					verifySignature({
+						method: "POST",
+						pathWithQuery: "/v1/presence",
+						bodyBytes,
+						timestamp: headers["X-Opencode-Timestamp"],
+						nonce: headers["X-Opencode-Nonce"],
+						signature: headers["X-Opencode-Signature"],
+						publicKey,
+						deviceId,
+					}),
+				).toBe(true);
+			},
+		);
 
 		it("rejects expired timestamp", () => {
 			const { db, deviceId, publicKey, keysDir } = setupIdentity();

--- a/packages/core/src/sync-auth.ts
+++ b/packages/core/src/sync-auth.ts
@@ -64,6 +64,8 @@ export interface SignRequestOptions {
 	url: string;
 	bodyBytes: Buffer;
 	keysDir?: string;
+	deviceId?: string;
+	dbPath?: string;
 	timestamp?: string;
 	nonce?: string;
 }
@@ -86,7 +88,7 @@ export function signRequest(options: SignRequestOptions): Record<string, string>
 
 	const canonical = buildCanonicalRequest(options.method, path, ts, nonceValue, options.bodyBytes);
 
-	const keyData = loadPrivateKey(options.keysDir);
+	const keyData = loadPrivateKey(options.keysDir, options.dbPath, options.deviceId);
 	if (!keyData) {
 		throw new Error("private key missing");
 	}
@@ -222,6 +224,7 @@ export interface BuildAuthHeadersOptions {
 	bodyBytes: Buffer;
 	bootstrapGrantId?: string;
 	keysDir?: string;
+	dbPath?: string;
 	timestamp?: string;
 	nonce?: string;
 }
@@ -238,6 +241,8 @@ export function buildAuthHeaders(options: BuildAuthHeadersOptions): Record<strin
 			url: options.url,
 			bodyBytes: options.bodyBytes,
 			keysDir: options.keysDir,
+			deviceId: options.deviceId,
+			dbPath: options.dbPath,
 			timestamp: options.timestamp,
 			nonce: options.nonce,
 		}),

--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -56,6 +56,7 @@ interface ExistingSnapshotRow {
 
 export interface BootstrapOptions {
 	keysDir?: string;
+	dbPath?: string;
 	bootstrapGrantId?: string;
 	/** Max items per page request. Defaults to 200. */
 	pageSize?: number;
@@ -89,6 +90,7 @@ export async function fetchAllSnapshotPages(
 	const pageSize = options?.pageSize ?? 200;
 	const timeoutS = options?.timeoutS ?? 10;
 	const keysDir = options?.keysDir;
+	const dbPath = options?.dbPath;
 	const bootstrapGrantId = options?.bootstrapGrantId?.trim() || undefined;
 	const maxItems = options?.maxItems ?? 100_000;
 
@@ -122,6 +124,7 @@ export async function fetchAllSnapshotPages(
 				bodyBytes: Buffer.alloc(0),
 				bootstrapGrantId,
 				keysDir,
+				dbPath,
 			}),
 			[SYNC_CAPABILITY_HEADER]: LOCAL_SYNC_CAPABILITY,
 		};

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -1,20 +1,22 @@
-import { rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { columnExists } from "./db.js";
+import { columnExists, connect } from "./db.js";
 import {
 	createSerializedDaemonTickRunner,
 	getSyncDaemonPhase,
 	refreshCoordinatorPresenceForDaemon,
 	resolveSyncDaemonKeysDir,
+	runSyncDaemon,
 	runTickOnce,
 	setSyncDaemonError,
 	setSyncDaemonOk,
 	setSyncDaemonPhase,
 	syncDaemonTick,
 } from "./sync-daemon.js";
+import { ensureDeviceIdentity, resolveKeyPaths } from "./sync-identity.js";
 
 import { initTestSchema } from "./test-utils.js";
 
@@ -228,6 +230,96 @@ describe("resolveSyncDaemonKeysDir", () => {
 	});
 });
 
+describe("runSyncDaemon identity recovery", () => {
+	it("records identity_error and keeps retrying when restored private keys are missing", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "codemem-sync-daemon-identity-"));
+		const dbPath = join(tempDir, "mem.sqlite");
+		const keysDir = join(tempDir, "keys");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		ensureDeviceIdentity(db, { keysDir });
+		const [privatePath] = resolveKeyPaths(keysDir);
+		const privateKey = readFileSync(privatePath);
+		rmSync(privatePath);
+		db.close();
+
+		const abort = new AbortController();
+		const daemon = runSyncDaemon({ dbPath, keysDir, intervalS: 0.01, signal: abort.signal });
+		try {
+			await vi.waitFor(() => {
+				const stateDb = connect(dbPath);
+				try {
+					expect(getSyncDaemonPhase(stateDb)).toBe("identity_error");
+					expect(
+						stateDb.prepare("SELECT last_error FROM sync_daemon_state WHERE id = 1").pluck().get(),
+					).toContain("device_identity_private_key_missing");
+				} finally {
+					stateDb.close();
+				}
+			});
+
+			writeFileSync(privatePath, privateKey, { mode: 0o600 });
+			await vi.waitFor(() => {
+				const stateDb = connect(dbPath);
+				try {
+					expect(getSyncDaemonPhase(stateDb)).toBeNull();
+				} finally {
+					stateDb.close();
+				}
+			});
+		} finally {
+			abort.abort();
+			await daemon;
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("records identity_error and recovers when device.key cannot be read", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "codemem-sync-daemon-unreadable-identity-"));
+		const dbPath = join(tempDir, "mem.sqlite");
+		const keysDir = join(tempDir, "keys");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		ensureDeviceIdentity(db, { keysDir });
+		const [privatePath] = resolveKeyPaths(keysDir);
+		const privateKey = readFileSync(privatePath);
+		rmSync(privatePath);
+		mkdirSync(privatePath);
+		db.close();
+
+		const abort = new AbortController();
+		const daemon = runSyncDaemon({ dbPath, keysDir, intervalS: 0.01, signal: abort.signal });
+		try {
+			await vi.waitFor(() => {
+				const stateDb = connect(dbPath);
+				try {
+					expect(getSyncDaemonPhase(stateDb)).toBe("identity_error");
+					expect(
+						stateDb.prepare("SELECT last_error FROM sync_daemon_state WHERE id = 1").pluck().get(),
+					).toContain("device_identity_private_key_invalid");
+				} finally {
+					stateDb.close();
+				}
+			});
+
+			rmSync(privatePath, { recursive: true });
+			writeFileSync(privatePath, privateKey, { mode: 0o600 });
+			await vi.waitFor(() => {
+				const stateDb = connect(dbPath);
+				try {
+					expect(getSyncDaemonPhase(stateDb)).toBeNull();
+				} finally {
+					stateDb.close();
+				}
+			});
+		} finally {
+			abort.abort();
+			await daemon;
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});
+
 describe("refreshCoordinatorPresenceForDaemon", () => {
 	let db: InstanceType<typeof Database>;
 
@@ -284,7 +376,7 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 				syncCoordinatorGroups: ["team"],
 				syncCoordinatorAdminSecret: "secret",
 			}),
-			{ keysDir: "/tmp/keys" },
+			{ keysDir: "/tmp/keys", dbPath: ":memory:" },
 		);
 		expect(refreshAuthorizedCoordinatorPeerTrust).toHaveBeenCalledWith(
 			{ db, dbPath: ":memory:" },
@@ -343,7 +435,9 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 
 	it("threads CODEMEM_KEYS_DIR through one-off ticks when keysDir is omitted", async () => {
 		const { runSyncPass } = await import("./sync-pass.js");
-		process.env.CODEMEM_KEYS_DIR = "/container/keys";
+		const tempDir = mkdtempSync(join(tmpdir(), "codemem-sync-daemon-env-keys-"));
+		const keysDir = join(tempDir, "keys");
+		process.env.CODEMEM_KEYS_DIR = keysDir;
 		const dbPath = join(tmpdir(), `codemem-sync-daemon-env-keys-${Date.now()}.sqlite`);
 		const fileDb = new Database(dbPath);
 		try {
@@ -358,16 +452,19 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 			expect(runSyncPass).toHaveBeenCalledWith(
 				expect.any(Database),
 				"peer-1",
-				expect.objectContaining({ keysDir: "/container/keys" }),
+				expect.objectContaining({ keysDir, dbPath }),
 			);
 		} finally {
 			fileDb.close();
 			rmSync(dbPath, { force: true });
+			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
 
 	it("applies additive schema compatibility before daemon tick state writes", async () => {
-		const dbPath = join(tmpdir(), `codemem-sync-daemon-legacy-${Date.now()}.sqlite`);
+		const tempDir = mkdtempSync(join(tmpdir(), "codemem-sync-daemon-legacy-"));
+		const dbPath = join(tempDir, "mem.sqlite");
+		const keysDir = join(tempDir, "keys");
 		const fileDb = new Database(dbPath);
 		try {
 			fileDb.exec(`
@@ -392,14 +489,21 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 					ops_out INTEGER NOT NULL DEFAULT 0,
 					error TEXT
 				);
+				CREATE TABLE sync_device (
+					device_id TEXT PRIMARY KEY,
+					public_key TEXT NOT NULL,
+					fingerprint TEXT NOT NULL,
+					created_at TEXT NOT NULL
+				);
 			`);
+			ensureDeviceIdentity(fileDb, { keysDir });
 			expect(columnExists(fileDb, "sync_daemon_state", "phase")).toBe(false);
 			expect(columnExists(fileDb, "sync_attempts", "local_sync_capability")).toBe(false);
 		} finally {
 			fileDb.close();
 		}
 
-		await runTickOnce(dbPath);
+		await runTickOnce(dbPath, keysDir);
 
 		const verified = new Database(dbPath);
 		try {
@@ -414,7 +518,7 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 			expect(row?.phase).toBeNull();
 		} finally {
 			verified.close();
-			rmSync(dbPath, { force: true });
+			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
 
@@ -666,6 +770,11 @@ describe("getSyncDaemonPhase / setSyncDaemonPhase", () => {
 	it("persists and retrieves needs_attention phase", () => {
 		setSyncDaemonPhase(db, "needs_attention");
 		expect(getSyncDaemonPhase(db)).toBe("needs_attention");
+	});
+
+	it("persists and retrieves identity_error phase", () => {
+		setSyncDaemonPhase(db, "identity_error");
+		expect(getSyncDaemonPhase(db)).toBe("identity_error");
 	});
 
 	it("clears phase when set to null", () => {

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -22,7 +22,7 @@ import * as schema from "./schema.js";
 import { refreshConfiguredScopeMembershipCache } from "./scope-membership-cache.js";
 import type { SecretScanner } from "./secret-scanner.js";
 import { advertiseMdns, mdnsEnabled } from "./sync-discovery.js";
-import { ensureDeviceIdentity } from "./sync-identity.js";
+import { DeviceIdentityError, ensureDeviceIdentity } from "./sync-identity.js";
 import { runSyncPass, shouldSkipOfflinePeer, syncPassPreflight } from "./sync-pass.js";
 
 // ---------------------------------------------------------------------------
@@ -128,7 +128,7 @@ export function setSyncDaemonError(db: Database, error: string, traceback?: stri
 }
 
 /** Valid sync daemon phases for the rebootstrap safety gate. */
-export type SyncDaemonPhase = "needs_attention" | null;
+export type SyncDaemonPhase = "identity_error" | "needs_attention" | null;
 
 /**
  * Get the current sync daemon phase from sync_daemon_state.
@@ -142,7 +142,7 @@ export function getSyncDaemonPhase(db: Database): SyncDaemonPhase {
 		.where(eq(schema.syncDaemonState.id, 1))
 		.get();
 	const phase = row?.phase;
-	if (phase === "needs_attention") return phase;
+	if (phase === "identity_error" || phase === "needs_attention") return phase;
 	return null;
 }
 
@@ -168,7 +168,7 @@ export async function refreshCoordinatorPresenceForDaemon(
 	const config = readCoordinatorSyncConfig();
 	if (!coordinatorEnabled(config)) return false;
 	await registerCoordinatorPresence({ db, dbPath }, config, { keysDir });
-	await refreshConfiguredScopeMembershipCache(db, config, { keysDir });
+	await refreshConfiguredScopeMembershipCache(db, config, { keysDir, dbPath });
 	await refreshAuthorizedCoordinatorPeerTrust({ db, dbPath }, config, { keysDir });
 	return true;
 }
@@ -188,6 +188,7 @@ export async function syncDaemonTick(
 	keysDir?: string,
 	stalePeers?: Set<string>,
 	scanner?: SecretScanner,
+	dbPath?: string,
 ): Promise<SyncTickResult[]> {
 	const hasPinnedFingerprint = tableColumnExists(db, "sync_peers", "pinned_fingerprint");
 	const rows = db
@@ -230,6 +231,7 @@ export async function syncDaemonTick(
 
 		const result = await runSyncPass(db, peerDeviceId, {
 			keysDir,
+			dbPath,
 			limit: opsLimit,
 			scanner,
 		});
@@ -272,11 +274,17 @@ export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> 
 	const db = connectDb(dbPath);
 	let mdnsHandle: { close(): void } | null = null;
 	try {
-		const [deviceId] = ensureDeviceIdentity(db, { keysDir });
+		try {
+			const [deviceId] = ensureDeviceIdentity(db, { keysDir });
 
-		// Start mDNS advertising if enabled
-		if (mdnsEnabled() && options?.port) {
-			mdnsHandle = advertiseMdns(deviceId, options.port);
+			// Start mDNS advertising if enabled
+			if (mdnsEnabled() && options?.port) {
+				mdnsHandle = advertiseMdns(deviceId, options.port);
+			}
+		} catch (error) {
+			if (!(error instanceof DeviceIdentityError)) throw error;
+			setSyncDaemonError(db, error.message, error.stack ?? "");
+			setSyncDaemonPhase(db, "identity_error");
 		}
 	} finally {
 		db.close();
@@ -352,6 +360,7 @@ export async function runTickOnce(
 	const db = connectDb(dbPath);
 	try {
 		ensureAdditiveSchemaCompatibility(db);
+		ensureDeviceIdentity(db, { keysDir: resolvedKeysDir });
 		try {
 			await refreshCoordinatorPresenceForDaemon(db, dbPath, resolvedKeysDir);
 		} catch {
@@ -370,7 +379,7 @@ export async function runTickOnce(
 		// Best-effort: skip peers the coordinator reports as offline.
 		// Returns empty set when coordinator is disabled or lookup fails.
 		const stalePeers = await fetchCoordinatorStalePeers(db, dbPath, resolvedKeysDir);
-		const results = await syncDaemonTick(db, resolvedKeysDir, stalePeers, scanner);
+		const results = await syncDaemonTick(db, resolvedKeysDir, stalePeers, scanner, dbPath);
 		const needsAttention = results.some((r) => !r.ok && r.error?.includes("needs_attention"));
 		if (needsAttention) {
 			setSyncDaemonPhase(db, "needs_attention");
@@ -382,6 +391,9 @@ export async function runTickOnce(
 		const message = err instanceof Error ? err.message : String(err);
 		const stack = err instanceof Error ? (err.stack ?? "") : "";
 		setSyncDaemonError(db, message, stack);
+		if (err instanceof DeviceIdentityError) {
+			setSyncDaemonPhase(db, "identity_error");
+		}
 	} finally {
 		db.close();
 	}

--- a/packages/core/src/sync-identity.test.ts
+++ b/packages/core/src/sync-identity.test.ts
@@ -1,9 +1,19 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
+import {
+	chmodSync,
+	cpSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connect } from "./db.js";
+import { signRequest, verifySignature } from "./sync-auth.js";
 import {
 	ensureDeviceIdentity,
 	fingerprintPublicKey,
@@ -33,9 +43,50 @@ function sshKeygenAvailable(): boolean {
 }
 
 const HAS_SSH_KEYGEN = sshKeygenAvailable();
+const HAS_KEYCHAIN_PLATFORM = process.platform === "darwin" || process.platform === "linux";
 
 function slashPath(value: string): string {
 	return value.replace(/\\/g, "/");
+}
+
+function installFakeKeychainCli(
+	baseDir: string,
+	keychainPath: string,
+	expectedAccount: string,
+): void {
+	const binDir = join(baseDir, "bin");
+	mkdirSync(binDir, { recursive: true });
+	const command = process.platform === "darwin" ? "security" : "secret-tool";
+	const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const command = args[0];
+const keychainPath = ${JSON.stringify(keychainPath)};
+const expectedAccount = ${JSON.stringify(expectedAccount)};
+const accountFlag = command === "lookup" || command === "store" ? "account" : "-a";
+const accountIndex = args.indexOf(accountFlag);
+if (accountIndex < 0 || args[accountIndex + 1] !== expectedAccount) {
+	process.exit(2);
+}
+if (command === "lookup" || command === "find-generic-password") {
+	try {
+		process.stdout.write(fs.readFileSync(keychainPath));
+	} catch {
+		process.exit(1);
+	}
+} else if (command === "store") {
+	fs.writeFileSync(keychainPath, fs.readFileSync(0));
+} else if (command === "add-generic-password") {
+	const valueIndex = args.indexOf("-w");
+	fs.writeFileSync(keychainPath, args[valueIndex + 1] || "");
+} else {
+	process.exit(1);
+}
+`;
+	const commandPath = join(binDir, command);
+	writeFileSync(commandPath, script);
+	chmodSync(commandPath, 0o755);
+	process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -44,12 +95,24 @@ function slashPath(value: string): string {
 
 describe("sync-identity", () => {
 	let tmpDir: string;
+	let originalKeyStore: string | undefined;
+	let originalKeychainWarning: string | undefined;
+	let originalPath: string | undefined;
 
 	beforeEach(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-sync-id-test-"));
+		originalKeyStore = process.env.CODEMEM_SYNC_KEY_STORE;
+		originalKeychainWarning = process.env.CODEMEM_SYNC_KEYCHAIN_WARN;
+		originalPath = process.env.PATH;
 	});
 
 	afterEach(() => {
+		if (originalKeyStore === undefined) delete process.env.CODEMEM_SYNC_KEY_STORE;
+		else process.env.CODEMEM_SYNC_KEY_STORE = originalKeyStore;
+		if (originalKeychainWarning === undefined) delete process.env.CODEMEM_SYNC_KEYCHAIN_WARN;
+		else process.env.CODEMEM_SYNC_KEYCHAIN_WARN = originalKeychainWarning;
+		if (originalPath === undefined) delete process.env.PATH;
+		else process.env.PATH = originalPath;
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -173,7 +236,7 @@ describe("sync-identity", () => {
 
 	describe("ensureDeviceIdentity", () => {
 		function makeDb() {
-			const dbPath = join(tmpDir, `test-${Date.now()}.sqlite`);
+			const dbPath = join(tmpDir, `test-${randomUUID()}.sqlite`);
 			const db = connect(dbPath);
 			initTestSchema(db);
 			return db;
@@ -219,6 +282,322 @@ describe("sync-identity", () => {
 			try {
 				const [deviceId] = ensureDeviceIdentity(db, { keysDir, deviceId: customId });
 				expect(deviceId).toBe(customId);
+			} finally {
+				db.close();
+			}
+		});
+
+		it("restores the same identity and signs coordinator and direct-peer requests", () => {
+			const sourceDbPath = join(tmpDir, "source.sqlite");
+			const sourceKeysDir = join(tmpDir, "source-keys");
+			const sourceDb = connect(sourceDbPath);
+			initTestSchema(sourceDb);
+			const [sourceDeviceId, sourceFingerprint] = ensureDeviceIdentity(sourceDb, {
+				keysDir: sourceKeysDir,
+			});
+			const sourcePublicKey = loadPublicKey(sourceKeysDir);
+			sourceDb.close();
+			if (!sourcePublicKey) throw new Error("expected source public key");
+
+			const restoredDbPath = join(tmpDir, "restored.sqlite");
+			const restoredKeysDir = join(tmpDir, "restored-keys");
+			cpSync(sourceDbPath, restoredDbPath);
+			cpSync(sourceKeysDir, restoredKeysDir, { recursive: true });
+
+			const restoredDb = connect(restoredDbPath);
+			try {
+				const restoredIdentity = ensureDeviceIdentity(restoredDb, { keysDir: restoredKeysDir });
+				expect(restoredIdentity).toEqual([sourceDeviceId, sourceFingerprint]);
+
+				for (const url of [
+					"https://coordinator.example.test/v1/presence",
+					"https://peer.example.test/v1/status",
+				]) {
+					const timestamp = String(Math.floor(Date.now() / 1000));
+					const bodyBytes = Buffer.from("{}");
+					const headers = signRequest({
+						method: "POST",
+						url,
+						bodyBytes,
+						keysDir: restoredKeysDir,
+						timestamp,
+						nonce: `restore-${new URL(url).pathname}`,
+					});
+					expect(
+						verifySignature({
+							method: "POST",
+							pathWithQuery: new URL(url).pathname,
+							bodyBytes,
+							timestamp: headers["X-Opencode-Timestamp"],
+							nonce: headers["X-Opencode-Nonce"],
+							signature: headers["X-Opencode-Signature"],
+							publicKey: sourcePublicKey,
+							deviceId: sourceDeviceId,
+						}),
+					).toBe(true);
+				}
+			} finally {
+				restoredDb.close();
+			}
+		});
+
+		it("recreates only the public key when the restored private key matches the database", () => {
+			const db = makeDb();
+			const keysDir = join(tmpDir, "keys-private-only");
+			try {
+				const originalIdentity = ensureDeviceIdentity(db, { keysDir });
+				const [, publicPath] = resolveKeyPaths(keysDir);
+				rmSync(publicPath);
+
+				expect(ensureDeviceIdentity(db, { keysDir })).toEqual(originalIdentity);
+				expect(loadPublicKey(keysDir)).toMatch(/^ssh-ed25519 /);
+			} finally {
+				db.close();
+			}
+		});
+
+		it.skipIf(!HAS_KEYCHAIN_PLATFORM).each(["corrupt", "another identity"])(
+			"prefers a matching restored key file over %s keychain material and repopulates the keychain",
+			(keychainMaterial) => {
+				const dbPath = join(tmpDir, "restored-keychain.sqlite");
+				const db = connect(dbPath);
+				initTestSchema(db);
+				const keysDir = join(tmpDir, "keys-restored-keychain");
+				const keychainPath = join(tmpDir, "keychain-value");
+				try {
+					const originalIdentity = ensureDeviceIdentity(db, { keysDir });
+					const [privatePath] = resolveKeyPaths(keysDir);
+					const restoredPrivateKey = readFileSync(privatePath);
+					if (keychainMaterial === "corrupt") {
+						writeFileSync(keychainPath, "not-a-private-key");
+					} else {
+						const unrelatedKeysDir = join(tmpDir, "keys-unrelated-keychain");
+						const [unrelatedPrivatePath, unrelatedPublicPath] = resolveKeyPaths(unrelatedKeysDir);
+						generateKeypair(unrelatedPrivatePath, unrelatedPublicPath);
+						writeFileSync(keychainPath, readFileSync(unrelatedPrivatePath));
+					}
+
+					installFakeKeychainCli(tmpDir, keychainPath, originalIdentity[0]);
+					process.env.CODEMEM_SYNC_KEY_STORE = "keychain";
+					process.env.CODEMEM_SYNC_KEYCHAIN_WARN = "0";
+
+					expect(loadPrivateKey(keysDir, dbPath, originalIdentity[0])).toEqual(restoredPrivateKey);
+					expect(ensureDeviceIdentity(db, { keysDir })).toEqual(originalIdentity);
+					expect(readFileSync(keychainPath)).toEqual(restoredPrivateKey);
+				} finally {
+					db.close();
+				}
+			},
+		);
+
+		it.skipIf(!HAS_KEYCHAIN_PLATFORM)(
+			"uses a matching keychain key when a valid restored file belongs to another identity",
+			() => {
+				const db = makeDb();
+				const keysDir = join(tmpDir, "keys-foreign-file-keychain");
+				const unrelatedKeysDir = join(tmpDir, "keys-foreign-file-keychain-unrelated");
+				const keychainPath = join(tmpDir, "keychain-value");
+				try {
+					const originalIdentity = ensureDeviceIdentity(db, { keysDir });
+					const [privatePath] = resolveKeyPaths(keysDir);
+					const originalPrivateKey = readFileSync(privatePath);
+					const [unrelatedPrivatePath, unrelatedPublicPath] = resolveKeyPaths(unrelatedKeysDir);
+					generateKeypair(unrelatedPrivatePath, unrelatedPublicPath);
+					const unrelatedPrivateKey = readFileSync(unrelatedPrivatePath);
+					writeFileSync(privatePath, unrelatedPrivateKey);
+					writeFileSync(keychainPath, originalPrivateKey);
+					installFakeKeychainCli(tmpDir, keychainPath, originalIdentity[0]);
+					process.env.CODEMEM_SYNC_KEY_STORE = "keychain";
+					process.env.CODEMEM_SYNC_KEYCHAIN_WARN = "0";
+
+					expect(ensureDeviceIdentity(db, { keysDir })).toEqual(originalIdentity);
+					expect(readFileSync(privatePath)).toEqual(unrelatedPrivateKey);
+					expect(readFileSync(keychainPath)).toEqual(originalPrivateKey);
+				} finally {
+					db.close();
+				}
+			},
+		);
+
+		it.skipIf(!HAS_KEYCHAIN_PLATFORM)(
+			"falls back to a valid keychain key when device.key is missing",
+			() => {
+				const dbPath = join(tmpDir, "keychain-only.sqlite");
+				const db = connect(dbPath);
+				initTestSchema(db);
+				const keysDir = join(tmpDir, "keys-keychain-only");
+				const keychainPath = join(tmpDir, "keychain-value");
+				try {
+					const originalIdentity = ensureDeviceIdentity(db, { keysDir });
+					const [privatePath] = resolveKeyPaths(keysDir);
+					const originalPrivateKey = readFileSync(privatePath);
+					writeFileSync(keychainPath, originalPrivateKey);
+					installFakeKeychainCli(tmpDir, keychainPath, originalIdentity[0]);
+					process.env.CODEMEM_SYNC_KEY_STORE = "keychain";
+					process.env.CODEMEM_SYNC_KEYCHAIN_WARN = "0";
+					rmSync(privatePath);
+
+					expect(loadPrivateKey(keysDir, dbPath)).toEqual(originalPrivateKey);
+					expect(ensureDeviceIdentity(db, { keysDir })).toEqual(originalIdentity);
+				} finally {
+					db.close();
+				}
+			},
+		);
+
+		it.skipIf(!HAS_KEYCHAIN_PLATFORM).each(["corrupt", "non-Ed25519"])(
+			"falls back to a valid keychain key when device.key is %s",
+			(fileMaterial) => {
+				const dbPath = join(tmpDir, "corrupt-file-keychain.sqlite");
+				const db = connect(dbPath);
+				initTestSchema(db);
+				const keysDir = join(tmpDir, "keys-corrupt-file-keychain");
+				const keychainPath = join(tmpDir, "keychain-value");
+				try {
+					const originalIdentity = ensureDeviceIdentity(db, { keysDir });
+					const [privatePath] = resolveKeyPaths(keysDir);
+					const originalPrivateKey = readFileSync(privatePath);
+					writeFileSync(keychainPath, originalPrivateKey);
+					installFakeKeychainCli(tmpDir, keychainPath, originalIdentity[0]);
+					process.env.CODEMEM_SYNC_KEY_STORE = "keychain";
+					process.env.CODEMEM_SYNC_KEYCHAIN_WARN = "0";
+					if (fileMaterial === "corrupt") {
+						writeFileSync(privatePath, "not-a-private-key");
+					} else {
+						const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+						writeFileSync(privatePath, privateKey.export({ type: "pkcs8", format: "pem" }));
+					}
+
+					expect(loadPrivateKey(keysDir, dbPath)).toEqual(originalPrivateKey);
+					expect(ensureDeviceIdentity(db, { keysDir })).toEqual(originalIdentity);
+				} finally {
+					db.close();
+				}
+			},
+		);
+
+		it.skipIf(!HAS_KEYCHAIN_PLATFORM)(
+			"falls back to a matching keychain key when device.key cannot be read",
+			() => {
+				const dbPath = join(tmpDir, "unreadable-file-keychain.sqlite");
+				const db = connect(dbPath);
+				initTestSchema(db);
+				const keysDir = join(tmpDir, "keys-unreadable-file-keychain");
+				const keychainPath = join(tmpDir, "keychain-value");
+				try {
+					const originalIdentity = ensureDeviceIdentity(db, { keysDir });
+					const [privatePath] = resolveKeyPaths(keysDir);
+					const originalPrivateKey = readFileSync(privatePath);
+					writeFileSync(keychainPath, originalPrivateKey);
+					installFakeKeychainCli(tmpDir, keychainPath, originalIdentity[0]);
+					process.env.CODEMEM_SYNC_KEY_STORE = "keychain";
+					process.env.CODEMEM_SYNC_KEYCHAIN_WARN = "0";
+					rmSync(privatePath);
+					mkdirSync(privatePath);
+
+					expect(loadPrivateKey(keysDir, dbPath, originalIdentity[0])).toEqual(originalPrivateKey);
+					expect(ensureDeviceIdentity(db, { keysDir })).toEqual(originalIdentity);
+				} finally {
+					db.close();
+				}
+			},
+		);
+
+		it("accepts a matching stored public key with an SSH comment", () => {
+			const db = makeDb();
+			const keysDir = join(tmpDir, "keys-commented-public");
+			try {
+				const [deviceId] = ensureDeviceIdentity(db, { keysDir });
+				const publicKey = loadPublicKey(keysDir);
+				if (!publicKey) throw new Error("expected public key");
+				const commentedPublicKey = `${publicKey} restored@example.test`;
+				const fingerprint = fingerprintPublicKey(commentedPublicKey);
+				const [, publicPath] = resolveKeyPaths(keysDir);
+				writeFileSync(publicPath, `${commentedPublicKey}\n`);
+				db.prepare(
+					"UPDATE sync_device SET public_key = ?, fingerprint = ? WHERE device_id = ?",
+				).run(commentedPublicKey, fingerprint, deviceId);
+
+				expect(ensureDeviceIdentity(db, { keysDir })).toEqual([deviceId, fingerprint]);
+				expect(loadPublicKey(keysDir)).toBe(commentedPublicKey);
+			} finally {
+				db.close();
+			}
+		});
+
+		it("fails closed when a restored database has no private key", () => {
+			const db = makeDb();
+			const keysDir = join(tmpDir, "keys-missing-private");
+			process.env.CODEMEM_SYNC_KEY_STORE = "file";
+			try {
+				ensureDeviceIdentity(db, { keysDir });
+				const [privatePath] = resolveKeyPaths(keysDir);
+				const before = db.prepare("SELECT * FROM sync_device LIMIT 1").get();
+				rmSync(privatePath);
+
+				expect(() => ensureDeviceIdentity(db, { keysDir })).toThrow(
+					"device_identity_private_key_missing",
+				);
+				expect(db.prepare("SELECT * FROM sync_device LIMIT 1").get()).toEqual(before);
+			} finally {
+				db.close();
+			}
+		});
+
+		it("fails closed when restored key material belongs to another identity", () => {
+			const db = makeDb();
+			const originalKeysDir = join(tmpDir, "keys-original");
+			const unrelatedKeysDir = join(tmpDir, "keys-unrelated");
+			const unrelatedDb = makeDb();
+			try {
+				ensureDeviceIdentity(db, { keysDir: originalKeysDir });
+				ensureDeviceIdentity(unrelatedDb, { keysDir: unrelatedKeysDir });
+				const before = db.prepare("SELECT * FROM sync_device LIMIT 1").get();
+
+				expect(() => ensureDeviceIdentity(db, { keysDir: unrelatedKeysDir })).toThrow(
+					"device_identity_key_mismatch",
+				);
+				expect(db.prepare("SELECT * FROM sync_device LIMIT 1").get()).toEqual(before);
+			} finally {
+				db.close();
+				unrelatedDb.close();
+			}
+		});
+
+		it("fails closed when restored private key material is corrupt", () => {
+			const db = makeDb();
+			const keysDir = join(tmpDir, "keys-corrupt-private");
+			process.env.CODEMEM_SYNC_KEY_STORE = "file";
+			try {
+				ensureDeviceIdentity(db, { keysDir });
+				const [privatePath] = resolveKeyPaths(keysDir);
+				const before = db.prepare("SELECT * FROM sync_device LIMIT 1").get();
+				writeFileSync(privatePath, "not-a-private-key");
+
+				expect(() => ensureDeviceIdentity(db, { keysDir })).toThrow(
+					"device_identity_private_key_invalid",
+				);
+				expect(db.prepare("SELECT * FROM sync_device LIMIT 1").get()).toEqual(before);
+			} finally {
+				db.close();
+			}
+		});
+
+		it("rejects non-Ed25519 private key material", () => {
+			const db = makeDb();
+			const keysDir = join(tmpDir, "keys-wrong-algorithm");
+			process.env.CODEMEM_SYNC_KEY_STORE = "file";
+			try {
+				ensureDeviceIdentity(db, { keysDir });
+				const [privatePath] = resolveKeyPaths(keysDir);
+				const before = db.prepare("SELECT * FROM sync_device LIMIT 1").get();
+				const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+				writeFileSync(privatePath, privateKey.export({ type: "pkcs8", format: "pem" }));
+
+				expect(() => ensureDeviceIdentity(db, { keysDir })).toThrow(
+					"device_identity_private_key_invalid",
+				);
+				expect(db.prepare("SELECT * FROM sync_device LIMIT 1").get()).toEqual(before);
 			} finally {
 				db.close();
 			}

--- a/packages/core/src/sync-identity.ts
+++ b/packages/core/src/sync-identity.ts
@@ -9,7 +9,6 @@ import { execFileSync } from "node:child_process";
 import { createPrivateKey, createPublicKey, generateKeyPairSync, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
-import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import { connect as connectDb, resolveDbPath } from "./db.js";
@@ -164,33 +163,73 @@ export function loadPublicKey(keysDir?: string): string | null {
 	return content || null;
 }
 
-/** Read the private key from disk (with keychain fallback). Returns null if unavailable. */
-export function loadPrivateKey(keysDir?: string, dbPath?: string): Buffer | null {
+/**
+ * Read the private key from disk with keychain fallback. When dbPath identifies an
+ * enrolled device, only a key matching that stored identity is returned.
+ */
+export function loadPrivateKey(
+	keysDir?: string,
+	dbPath?: string,
+	deviceId?: string,
+): Buffer | null {
+	const [privatePath] = resolveKeyPaths(keysDir);
+	const privateKeyFile = readPrivateKeyFile(privatePath);
+	const privateKeyFromFile = isUsableEd25519PrivateKey(privateKeyFile.value)
+		? privateKeyFile.value
+		: null;
+	const storedIdentity = dbPath === undefined ? null : loadStoredDeviceIdentity(dbPath);
+	if (storedIdentity && deviceId && storedIdentity.deviceId !== deviceId) return null;
+	if (
+		privateKeyFromFile &&
+		(!storedIdentity || privateKeyMatchesStoredIdentity(privateKeyFromFile, storedIdentity))
+	) {
+		return privateKeyFromFile;
+	}
 	if (keyStoreMode() === "keychain") {
-		const deviceId = loadDeviceId(dbPath);
-		if (deviceId) {
-			const keychainValue = loadPrivateKeyKeychain(deviceId);
-			if (keychainValue) return keychainValue;
+		const keychainIdentity =
+			dbPath === undefined && !deviceId ? loadStoredDeviceIdentity() : storedIdentity;
+		const resolvedDeviceId = deviceId ?? keychainIdentity?.deviceId;
+		if (resolvedDeviceId) {
+			const keychainValue = loadPrivateKeyKeychain(resolvedDeviceId);
+			if (
+				isUsableEd25519PrivateKey(keychainValue) &&
+				(!keychainIdentity || privateKeyMatchesStoredIdentity(keychainValue, keychainIdentity))
+			) {
+				return keychainValue;
+			}
 		}
 	}
-	const [privatePath] = resolveKeyPaths(keysDir);
-	if (!existsSync(privatePath)) return null;
-	return readFileSync(privatePath);
+	return null;
 }
 
-/** Load device_id from the database (for keychain lookups). */
-function loadDeviceId(dbPath?: string): string | null {
+interface StoredDeviceIdentity {
+	deviceId: string;
+	publicKey: string;
+	fingerprint: string;
+}
+
+/** Load the enrolled identity from the database for identity-aware key selection. */
+function loadStoredDeviceIdentity(dbPath?: string): StoredDeviceIdentity | null {
 	const path = resolveDbPath(dbPath);
 	if (!existsSync(path)) return null;
 	const conn = connectDb(path);
 	try {
 		const d = drizzle(conn, { schema });
 		const row = d
-			.select({ device_id: schema.syncDevice.device_id })
+			.select({
+				device_id: schema.syncDevice.device_id,
+				public_key: schema.syncDevice.public_key,
+				fingerprint: schema.syncDevice.fingerprint,
+			})
 			.from(schema.syncDevice)
 			.limit(1)
 			.get();
-		return row?.device_id ?? null;
+		if (!row) return null;
+		return {
+			deviceId: row.device_id,
+			publicKey: row.public_key,
+			fingerprint: row.fingerprint,
+		};
 	} finally {
 		conn.close();
 	}
@@ -200,11 +239,14 @@ function loadDeviceId(dbPath?: string): string | null {
 // Key generation & validation
 // ---------------------------------------------------------------------------
 
+function canonicalEd25519PublicKey(publicKey: string): string | null {
+	const [keyType, keyData] = publicKey.trim().split(/\s+/);
+	if (keyType !== "ssh-ed25519" || !keyData) return null;
+	return `${keyType} ${keyData}`;
+}
+
 function publicKeyLooksValid(publicKey: string): boolean {
-	const value = publicKey.trim();
-	return (
-		value.startsWith("ssh-ed25519 ") || value.startsWith("ssh-rsa ") || value.startsWith("ecdsa-")
-	);
+	return canonicalEd25519PublicKey(publicKey) !== null;
 }
 
 function backupInvalidKeyFile(path: string, stamp: string): void {
@@ -261,7 +303,7 @@ export function generateKeypair(privatePath: string, publicPath: string): void {
  */
 function derToSshEd25519(spkiDer: Buffer): string | null {
 	// Ed25519 SPKI DER is 44 bytes: 12-byte header + 32-byte key
-	if (spkiDer.length < 32) return null;
+	if (spkiDer.length !== 44) return null;
 	const rawKey = spkiDer.subarray(spkiDer.length - 32);
 
 	// SSH wire format: string "ssh-ed25519" + string <32-byte key>
@@ -285,13 +327,87 @@ function derToSshEd25519(spkiDer: Buffer): string | null {
  * handles both transparently.
  */
 function loadPrivateKeyObject(privatePath: string): ReturnType<typeof createPrivateKey> {
-	const raw = readFileSync(privatePath);
+	return loadPrivateKeyObjectFromBytes(readFileSync(privatePath));
+}
+
+function loadPrivateKeyObjectFromBytes(raw: Buffer): ReturnType<typeof createPrivateKey> {
 	// Try PKCS8 PEM first (our generated format), then OpenSSH
 	try {
 		return createPrivateKey(raw);
 	} catch {
 		return createPrivateKey({ key: raw, format: "pem", type: "pkcs8" });
 	}
+}
+
+function derivePublicKey(privateKey: Buffer): string {
+	const privateKeyObject = loadPrivateKeyObjectFromBytes(privateKey);
+	if (privateKeyObject.asymmetricKeyType !== "ed25519") {
+		throw new Error("private key is not Ed25519");
+	}
+	const publicKeyObject = createPublicKey(privateKeyObject);
+	const publicKeyDer = publicKeyObject.export({ type: "spki", format: "der" });
+	const publicKey = derToSshEd25519(publicKeyDer);
+	if (!publicKey || !publicKeyLooksValid(publicKey)) {
+		throw new Error("failed to derive public key");
+	}
+	return publicKey;
+}
+
+function isUsableEd25519PrivateKey(privateKey: Buffer | null): privateKey is Buffer {
+	if (!privateKey) return false;
+	try {
+		derivePublicKey(privateKey);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+type PrivateKeyFileRead =
+	| { status: "available"; value: Buffer }
+	| { status: "missing" | "unreadable"; value: null };
+
+function readPrivateKeyFile(privatePath: string): PrivateKeyFileRead {
+	try {
+		if (!existsSync(privatePath)) return { status: "missing", value: null };
+		return { status: "available", value: readFileSync(privatePath) };
+	} catch {
+		return { status: "unreadable", value: null };
+	}
+}
+
+function privateKeyMatchesStoredIdentity(
+	privateKey: Buffer,
+	identity: StoredDeviceIdentity,
+): boolean {
+	const storedPublicKey = canonicalEd25519PublicKey(identity.publicKey);
+	if (!storedPublicKey || fingerprintPublicKey(identity.publicKey) !== identity.fingerprint) {
+		return false;
+	}
+	try {
+		return canonicalEd25519PublicKey(derivePublicKey(privateKey)) === storedPublicKey;
+	} catch {
+		return false;
+	}
+}
+
+export type DeviceIdentityErrorCode =
+	| "device_identity_private_key_missing"
+	| "device_identity_private_key_invalid"
+	| "device_identity_key_mismatch";
+
+export class DeviceIdentityError extends Error {
+	readonly code: DeviceIdentityErrorCode;
+
+	constructor(code: DeviceIdentityErrorCode, detail: string) {
+		super(`${code}: ${detail}`);
+		this.name = "DeviceIdentityError";
+		this.code = code;
+	}
+}
+
+function existingIdentityError(code: DeviceIdentityErrorCode, detail: string): DeviceIdentityError {
+	return new DeviceIdentityError(code, detail);
 }
 
 /** Validate that an existing keypair is consistent. */
@@ -306,7 +422,7 @@ export function validateExistingKeypair(privatePath: string, publicPath: string)
 		const derived = derToSshEd25519(pubDer);
 		if (!derived || !publicKeyLooksValid(derived)) return false;
 		// Auto-fix mismatched public key file
-		if (derived !== publicKey) {
+		if (canonicalEd25519PublicKey(derived) !== canonicalEd25519PublicKey(publicKey)) {
 			writeFileSync(publicPath, `${derived}\n`, "utf-8");
 		}
 		return true;
@@ -353,6 +469,84 @@ export function ensureDeviceIdentity(
 	const existingPublicKey = row?.public_key ?? "";
 	const existingFingerprint = row?.fingerprint ?? "";
 
+	if (existingDeviceId) {
+		const privateKeyFile = readPrivateKeyFile(privatePath);
+		const validPrivateKeyFromFile = isUsableEd25519PrivateKey(privateKeyFile.value)
+			? privateKeyFile.value
+			: null;
+		const storedIdentity: StoredDeviceIdentity = {
+			deviceId: existingDeviceId,
+			publicKey: existingPublicKey,
+			fingerprint: existingFingerprint,
+		};
+
+		const fileMatchesStoredIdentity =
+			validPrivateKeyFromFile !== null &&
+			privateKeyMatchesStoredIdentity(validPrivateKeyFromFile, storedIdentity);
+		const privateKeyFromKeychain =
+			!fileMatchesStoredIdentity && keyStoreMode() === "keychain"
+				? loadPrivateKeyKeychain(existingDeviceId)
+				: null;
+		const validPrivateKeyFromKeychain = isUsableEd25519PrivateKey(privateKeyFromKeychain)
+			? privateKeyFromKeychain
+			: null;
+		const keychainMatchesStoredIdentity =
+			validPrivateKeyFromKeychain !== null &&
+			privateKeyMatchesStoredIdentity(validPrivateKeyFromKeychain, storedIdentity);
+		const privateKey = fileMatchesStoredIdentity
+			? validPrivateKeyFromFile
+			: keychainMatchesStoredIdentity
+				? validPrivateKeyFromKeychain
+				: null;
+		if (!privateKey) {
+			if (validPrivateKeyFromFile || validPrivateKeyFromKeychain) {
+				throw existingIdentityError(
+					"device_identity_key_mismatch",
+					"the restored private key does not match the peer identity stored in the database",
+				);
+			}
+			throw existingIdentityError(
+				privateKeyFile.status !== "missing" || privateKeyFromKeychain
+					? "device_identity_private_key_invalid"
+					: "device_identity_private_key_missing",
+				privateKeyFile.status !== "missing" || privateKeyFromKeychain
+					? "the restored private key is unreadable or unsupported; restore the original Ed25519 key material"
+					: "the database contains an existing peer identity but its private key is unavailable; restore the original key material with the database",
+			);
+		}
+
+		let derivedPublicKey: string;
+		try {
+			derivedPublicKey = derivePublicKey(privateKey);
+		} catch {
+			throw existingIdentityError(
+				"device_identity_private_key_invalid",
+				"the restored private key is unreadable or unsupported; restore the original Ed25519 key material",
+			);
+		}
+		const storedPublicKey = canonicalEd25519PublicKey(existingPublicKey);
+		if (
+			!storedPublicKey ||
+			canonicalEd25519PublicKey(derivedPublicKey) !== storedPublicKey ||
+			fingerprintPublicKey(existingPublicKey) !== existingFingerprint
+		) {
+			throw existingIdentityError(
+				"device_identity_key_mismatch",
+				"the restored private key does not match the peer identity stored in the database",
+			);
+		}
+
+		const publicKeyOnDisk = loadPublicKey(keysDir);
+		if (publicKeyOnDisk !== existingPublicKey) {
+			mkdirSync(dirname(publicPath), { recursive: true });
+			writeFileSync(publicPath, `${existingPublicKey}\n`, { mode: 0o644 });
+		}
+		if (keyStoreMode() === "keychain" && fileMatchesStoredIdentity) {
+			storePrivateKeyKeychain(privateKey, existingDeviceId);
+		}
+		return [existingDeviceId, existingFingerprint];
+	}
+
 	// Validate or regenerate keys
 	let keysReady = existsSync(privatePath) && existsSync(publicPath);
 	if (keysReady && !validateExistingKeypair(privatePath, publicPath)) {
@@ -374,27 +568,6 @@ export function ensureDeviceIdentity(
 	}
 	const fingerprint = fingerprintPublicKey(publicKey);
 	const now = new Date().toISOString();
-
-	// Update existing device row if keys changed
-	if (existingDeviceId) {
-		if (existingPublicKey !== publicKey || existingFingerprint !== fingerprint) {
-			d.update(schema.syncDevice)
-				.set({ public_key: publicKey, fingerprint })
-				.where(eq(schema.syncDevice.device_id, existingDeviceId))
-				.run();
-		}
-		if (keyStoreMode() === "keychain") {
-			// Read key from file directly — don't go through loadPrivateKey
-			// which would resolve device ID from the default DB
-			const privateKey = existsSync(privatePath)
-				? readFileSync(privatePath)
-				: loadPrivateKeyKeychain(existingDeviceId);
-			if (privateKey) {
-				storePrivateKeyKeychain(privateKey, existingDeviceId);
-			}
-		}
-		return [existingDeviceId, fingerprint];
-	}
 
 	// Insert new device row
 	const resolvedDeviceId = options?.deviceId ?? randomUUID();

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -149,6 +149,7 @@ export interface SyncScopeResult {
 export interface SyncPassOptions {
 	limit?: number;
 	keysDir?: string;
+	dbPath?: string;
 	refreshAuthorization?: boolean;
 	/**
 	 * Secret scanner used to redact peer-shipped content on apply. Callers that
@@ -408,6 +409,7 @@ async function pushOps(
 	deviceId: string,
 	ops: ReplicationOp[],
 	keysDir?: string,
+	dbPath?: string,
 	depth = 0,
 ): Promise<void> {
 	if (ops.length === 0) return;
@@ -425,6 +427,7 @@ async function pushOps(
 			url: postUrl,
 			bodyBytes,
 			keysDir,
+			dbPath,
 		}),
 		...capabilityHeader(),
 	};
@@ -444,8 +447,8 @@ async function pushOps(
 		(detail === "payload_too_large" || detail === "too_many_ops")
 	) {
 		const mid = Math.floor(ops.length / 2);
-		await pushOps(postUrl, deviceId, ops.slice(0, mid), keysDir, depth + 1);
-		await pushOps(postUrl, deviceId, ops.slice(mid), keysDir, depth + 1);
+		await pushOps(postUrl, deviceId, ops.slice(0, mid), keysDir, dbPath, depth + 1);
+		await pushOps(postUrl, deviceId, ops.slice(mid), keysDir, dbPath, depth + 1);
 		return;
 	}
 
@@ -654,6 +657,7 @@ async function runScopedSync(
 		deviceId: string;
 		statusPayload: Record<string, unknown>;
 		keysDir?: string;
+		dbPath?: string;
 		scanner?: SecretScanner;
 		limit: number;
 	},
@@ -671,6 +675,7 @@ async function runScopedSync(
 			deviceId: options.deviceId,
 			scope,
 			keysDir: options.keysDir,
+			dbPath: options.dbPath,
 			scanner: options.scanner,
 			limit: options.limit,
 		});
@@ -707,11 +712,12 @@ async function syncOneScope(
 		deviceId: string;
 		scope: PeerAuthorizedScope;
 		keysDir?: string;
+		dbPath?: string;
 		scanner?: SecretScanner;
 		limit: number;
 	},
 ): Promise<SyncScopeResult> {
-	const { peerDeviceId, baseUrl, deviceId, scope, keysDir, scanner, limit } = options;
+	const { peerDeviceId, baseUrl, deviceId, scope, keysDir, dbPath, scanner, limit } = options;
 	const scopeId = scope.scope_id;
 	const [lastApplied, lastAcked] = getReplicationCursor(db, peerDeviceId, scopeId);
 	const hasNullBaselineBootstrapMarker = lastAcked === SCOPED_NULL_BASELINE_BOOTSTRAP_CURSOR_MARKER;
@@ -770,6 +776,7 @@ async function syncOneScope(
 			};
 			const { items } = await fetchAllSnapshotPages(baseUrl, resetInfo, deviceId, {
 				keysDir,
+				dbPath,
 				pageSize: BOOTSTRAP_PAGE_SIZE,
 				timeoutS: BOOTSTRAP_REQUEST_TIMEOUT_S,
 			});
@@ -827,6 +834,7 @@ async function syncOneScope(
 			};
 			const { items } = await fetchAllSnapshotPages(baseUrl, resetInfo, deviceId, {
 				keysDir,
+				dbPath,
 				pageSize: BOOTSTRAP_PAGE_SIZE,
 				timeoutS: BOOTSTRAP_REQUEST_TIMEOUT_S,
 			});
@@ -908,6 +916,7 @@ async function syncOneScope(
 				url,
 				bodyBytes: Buffer.alloc(0),
 				keysDir,
+				dbPath,
 			}),
 			...capabilityHeader(),
 		};
@@ -1139,6 +1148,7 @@ export async function syncOnce(
 	ensureAdditiveSchemaCompatibility(db);
 	const limit = options?.limit ?? DEFAULT_LIMIT;
 	const keysDir = options?.keysDir;
+	const dbPath = options?.dbPath;
 	const scanner = options?.scanner;
 	if (!scanner && !syncOnceScannerWarned) {
 		syncOnceScannerWarned = true;
@@ -1203,6 +1213,7 @@ export async function syncOnce(
 					url: statusUrl,
 					bodyBytes: Buffer.alloc(0),
 					keysDir,
+					dbPath,
 					bootstrapGrantId: pendingBootstrapGrantId,
 				}),
 				...capabilityHeader(),
@@ -1282,6 +1293,7 @@ export async function syncOnce(
 						}
 						const { items } = await fetchAllSnapshotPages(baseUrl, resetInfo, deviceId, {
 							keysDir,
+							dbPath,
 							pageSize: BOOTSTRAP_PAGE_SIZE,
 							timeoutS: BOOTSTRAP_REQUEST_TIMEOUT_S,
 						});
@@ -1335,6 +1347,7 @@ export async function syncOnce(
 										deviceId,
 										statusPayload,
 										keysDir,
+										dbPath,
 										scanner,
 										limit,
 									})
@@ -1392,6 +1405,7 @@ export async function syncOnce(
 					url: getUrl,
 					bodyBytes: Buffer.alloc(0),
 					keysDir,
+					dbPath,
 				}),
 				...capabilityHeader(),
 			};
@@ -1461,6 +1475,7 @@ export async function syncOnce(
 					}
 					const { items } = await fetchAllSnapshotPages(baseUrl, resetRequired, deviceId, {
 						keysDir,
+						dbPath,
 						timeoutS: BOOTSTRAP_REQUEST_TIMEOUT_S,
 					});
 
@@ -1603,7 +1618,7 @@ export async function syncOnce(
 			if (outboundOps.length > 0) {
 				const batches = chunkOpsBySize(outboundOps, MAX_SYNC_BODY_BYTES);
 				for (const batch of batches) {
-					await pushOps(postUrl, deviceId, batch, keysDir);
+					await pushOps(postUrl, deviceId, batch, keysDir, dbPath);
 				}
 			}
 			const ackCursor = filteredOutboundCursor ?? outboundCursor;
@@ -1629,6 +1644,7 @@ export async function syncOnce(
 							deviceId,
 							statusPayload,
 							keysDir,
+							dbPath,
 							scanner,
 							limit,
 						})

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -38,21 +38,22 @@ import { reconcileConfiguredCoordinatorEnrollment } from "./routes/sync.js";
 function createTestStore(seedDevice = true): { store: MemoryStore; cleanup: () => void } {
 	const tmpDir = mkdtempSync(join(tmpdir(), "codemem-viewer-store-test-"));
 	const dbPath = join(tmpDir, "test.sqlite");
+	const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
+	const keysDir = previousKeysDir?.trim() || join(tmpDir, "keys");
 	const rawDb = new Database(dbPath);
 	initTestSchema(rawDb);
 	if (seedDevice) {
-		rawDb
-			.prepare(
-				"INSERT INTO sync_device(device_id, public_key, fingerprint, created_at) VALUES (?, ?, ?, ?)",
-			)
-			.run("test-device-001", "test-public-key", "test-fingerprint", new Date().toISOString());
+		ensureDeviceIdentity(rawDb, { keysDir, deviceId: "test-device-001" });
 	}
 	rawDb.close();
+	process.env.CODEMEM_KEYS_DIR = keysDir;
 	const store = new MemoryStore(dbPath);
 	return {
 		store,
 		cleanup: () => {
 			store.close();
+			if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
 			rmSync(tmpDir, { recursive: true, force: true });
 		},
 	};

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -929,6 +929,7 @@ async function peerSupportsSyncRequirements(
 			const headers = {
 				...buildAuthHeaders({
 					deviceId: localDeviceId,
+					dbPath: store.dbPath,
 					method: "GET",
 					url,
 					bodyBytes: Buffer.alloc(0),
@@ -1407,6 +1408,7 @@ async function executeProjectShareProvisioning(store: MemoryStore, operationId: 
 				if (expectedGroupId !== groupId) throw new Error("operation_scope_mismatch");
 				const refreshed = await refreshConfiguredScopeMembershipCache(store.db, config, {
 					keysDir: syncKeysDir(),
+					dbPath: store.dbPath,
 				});
 				const group = refreshed.groups.find((item) => item.groupId === groupId);
 				if (group?.status !== "refreshed") throw new Error("authorization_refresh_failed");
@@ -1414,6 +1416,7 @@ async function executeProjectShareProvisioning(store: MemoryStore, operationId: 
 			runInitialSync: (recipientDeviceId) =>
 				runSyncPass(store.db, recipientDeviceId, {
 					keysDir: syncKeysDir(),
+					dbPath: store.dbPath,
 					scanner: store.scanner,
 					refreshAuthorization: true,
 				}),
@@ -2272,6 +2275,7 @@ export function createRecipientPolicyReconcilerEffects(
 			const boundary = target(scopeId);
 			const refreshed = await refreshConfiguredScopeMembershipCache(store.db, config, {
 				keysDir: syncKeysDir(),
+				dbPath: store.dbPath,
 			});
 			const group = refreshed.groups.find((item) => item.groupId === boundary.groupId);
 			if (group?.status !== "refreshed") throw new Error("recipient_policy_effect_failed");
@@ -2744,6 +2748,7 @@ async function authorizeBootstrapGrantRequest(
 				const [status, signedPayload] = await requestJson("GET", lookupUrl, {
 					headers: buildAuthHeaders({
 						deviceId: localDeviceId,
+						dbPath: store.dbPath,
 						method: "GET",
 						url: lookupUrl,
 						bodyBytes: Buffer.alloc(0),
@@ -4279,6 +4284,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 					// the same initial sync pass instead of waiting for the daemon interval.
 					await refreshConfiguredScopeMembershipCache(store.db, undefined, {
 						keysDir: syncKeysDir(),
+						dbPath: store.dbPath,
 					});
 				}
 				const [deviceId, fingerprint] = ensureDeviceIdentity(store.db, {
@@ -5245,6 +5251,7 @@ export function syncRoutes(
 			// was set, so manual sync runs failed peer auth while daemon syncs worked.
 			const result = await runSyncPass(store.db, peerId, {
 				keysDir: syncKeysDir(),
+				dbPath: store.dbPath,
 				scanner: store.scanner,
 			});
 			items.push({


### PR DESCRIPTION
## Description

Preserves an enrolled peer identity across workspace recreation by treating the SQLite database and external Ed25519 key material as one restore boundary.

Existing identities now fail closed when private material is missing, invalid, non-Ed25519, or mismatched. Matching restores preserve the original device ID and fingerprint, safely recreate public-key files, and continue signing coordinator presence and direct-peer requests. The daemon records a retryable identity_error state without blocking local memory capture, and sync doctor reports actionable device_identity diagnostics.

Public guidance now documents the required database, key, configuration, secret-handling, and restore-verification contract.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (pnpm run check)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected through restoration/signature integration tests

## Checklist

- [x] Code follows project style (pnpm run lint passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

## Security review

- Independent CodeReviewer review: merge-ready, no blockers or high findings
- Focused Snyk Code scans of touched production files: no high-severity findings
- Repository-wide Snyk findings were confined to an unrelated untracked local directory and are not part of this PR