### PR TITLE
docs(release): define 0.40.1 continuity hotfixes

### DIFF
--- a/docs/plans/2026-08-09-release-0.40.1-continuity-hotfix-design.md
+++ b/docs/plans/2026-08-09-release-0.40.1-continuity-hotfix-design.md
@@ -1,0 +1,112 @@
+# Release 0.40.1 continuity hotfix design
+
+**Status:** Approved
+**Date:** 2026-08-09
+**Base:** `origin/release/0.40.0`
+
+## Context
+
+The v0.40.0 Projects page exposed recipient-policy migration evidence directly. On Team-heavy databases this can produce many repeated review cards and blockers even though the current Team-era scope enforcement remains active. The available decisions are also ahead of the product flow: resolving a review item records an audit decision, but the Projects UI does not run recipient migration or provision the exact managed Project boundary required by reconciliation.
+
+The same page refreshes every five seconds. Each refresh rebuilds the migration surface, replays its entrance animation, resets the selected decision, and drops focus. Separately, the v0.40.0 maintenance worker performs vector migration in batches large enough to saturate one CPU core. When viewer ingestion is briefly unavailable, the plugin's direct-SQLite fallback can fail but reports only its exit code, hiding whether the cause was lock contention, timeout, validation, or process startup.
+
+## Goals
+
+- Keep existing Team-era access working without requiring per-Project decisions.
+- Do not infer policy Teams, recipients, or future-member access from coordinator enrollment.
+- Show only migration actions that the product can apply end to end.
+- Keep background Projects refresh invisible to active interactions.
+- Bound upgrade maintenance so it remains background work.
+- Preserve a useful, redacted fallback failure cause and recover proven transient failures.
+
+## Non-goals
+
+- Automatically split a shared Team scope into one managed boundary per Project.
+- Treat coordinator group enrollment as recipient authorization.
+- Build the complete recipient picker or device-to-Identity repair UI.
+- Delete or rewrite existing scope, memory, recipient, or resolution rows.
+- Tag or publish v0.40.1.
+
+## Considered approaches
+
+### 1. Keep the v0.40.0 workflow and improve its copy
+
+This leaves users with a large manual task and still presents choices that do not perform their stated outcome. Better wording cannot repair an incomplete workflow.
+
+### 2. Continuity-first compatibility mode
+
+Keep legacy scope enforcement authoritative, collapse unresolved migration evidence into one informational state, and remove unsupported decisions from the Projects page. Continue to fail closed: no recipient-policy edge or managed boundary is synthesized from ambiguous Team evidence.
+
+This is the selected approach. It provides a safe no-action upgrade path and leaves exact boundary provisioning for the existing follow-up work.
+
+### 3. Fully automatic Team-to-recipient migration
+
+Splitting scopes and converting coordinator groups into policy Teams would change authorization and future-member inheritance without authoritative evidence. This is not acceptable for a patch release.
+
+## Decision
+
+### Recipient migration continuity
+
+The v0.40.1 Projects page treats unresolved legacy review evidence as deferred compatibility work, not an urgent migration assignment:
+
+- Current legacy scope enforcement remains unchanged and authoritative.
+- The page shows one concise message that existing sharing is being kept as-is and no action is required for v0.40.1.
+- The message may include aggregate counts, but it does not render one card per Project.
+- Decisions whose only immediate effect is an audit row are not presented as migration actions.
+- Decisions requiring recipient or device input are not advertised as completable elsewhere when no connected flow exists.
+- Existing core projection, review, and migration APIs remain available for diagnostics and later 0.41 provisioning work.
+
+The existing exact-operation safety rules remain unchanged. v0.40.1 does not broaden automatic migration beyond digest-valid, accepted, bound exact-Project evidence.
+
+### Projects refresh continuity
+
+Background refresh must not replace unchanged recipient-review DOM. Rendering uses a stable semantic signature of the review payload and error state. If the signature has not changed, the existing surface remains mounted. If data changes, the renderer preserves a draft selection keyed by review item and restores focus when the same control still exists.
+
+Background refresh also avoids presenting the inventory as a fresh initial load. Initial-load feedback remains, while polling updates occur without flashing loading copy or disabling otherwise valid controls.
+
+### Maintenance and raw-event reliability
+
+The maintenance worker uses a smaller vector migration batch than explicit or test callers. Smaller batches shorten CPU bursts and SQLite write-lock duration while preserving resumability and eventual completion.
+
+Before changing fallback behavior, a deterministic test must capture the actual failed command result. The plugin will retain a bounded, redacted diagnostic assembled from structured stdout/stderr instead of reducing every failure to an exit code. Retries or deferred in-memory requeue are limited to proven transient failures such as SQLite busy/locked or command timeout; validation and incompatible-command failures remain terminal and visible in logs. Notifications remain rate-limited.
+
+## Data and safety invariants
+
+- No new `project_recipients`, policy Teams, Team memberships, Identity assignments, managed scopes, or Project mappings are created by compatibility presentation.
+- No existing access is revoked.
+- Legacy review evidence is not deleted or marked successfully reconciled merely because the UI collapses it.
+- A future provisioning flow must still prove one exact managed boundary per canonical Project before recipient-policy authority can activate.
+- Raw event identifiers remain stable across retries so successful duplicate delivery is idempotent.
+
+## Test plan
+
+### UI
+
+- Repeated identical review renders preserve the mounted node, selected value, and focus.
+- Changed review fingerprints rerender with the new state.
+- Team-heavy review payloads render one continuity message and no decision controls.
+- Initial loading remains visible, while background polling does not flash loading state.
+
+### Core and server
+
+- Existing projection and migration safety tests continue to prove that ambiguous Team evidence does not create recipient intent.
+- Exact accepted-operation migration behavior remains unchanged.
+- Existing review APIs continue returning diagnostic evidence for later repair flows.
+
+### Runtime and plugin
+
+- Maintenance runtime constructs vector migration with the bounded worker batch.
+- A simulated SQLite lock or equivalent command result preserves the fallback cause.
+- Only transient fallback failures retry or requeue; validation failures do not.
+- Successful recovery clears failure notification state.
+
+## Delivery
+
+Changes are developed in a clean worktree based on `origin/release/0.40.0` and submitted as a focused stack:
+
+1. This design.
+2. Projects refresh continuity.
+3. Recipient migration compatibility presentation.
+4. Maintenance and raw-event reliability.
+
+Version bump, tagging, publishing, and merging are separate release actions.


### PR DESCRIPTION
## Description

Define the approved continuity-first v0.40.1 hotfix design, including access-preservation invariants, refresh behavior, runtime reliability constraints, test plan, and stacked delivery order.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced