### PR TITLE
fix(sharing): preserve legacy Team access

### DIFF
--- a/packages/core/src/recipient-policy-review.test.ts
+++ b/packages/core/src/recipient-policy-review.test.ts
@@ -216,6 +216,10 @@ describe("recipient policy review persistence", () => {
 
 		const result = listRecipientPolicyReview(db, context);
 
+		expect(result.continuity).toEqual({
+			findingCount: 1,
+			state: "legacy_access_preserved",
+		});
 		expect(result.reviewItems).toHaveLength(1);
 		const item = result.reviewItems[0];
 		expect(new Set(item?.options.map((option) => option.decision)).size).toBe(item?.options.length);
@@ -252,6 +256,7 @@ describe("recipient policy review persistence", () => {
 
 		const result = listRecipientPolicyReview(db, context);
 
+		expect(result.continuity).toBeNull();
 		expect(result.blockedItems[0]).toMatchObject({
 			ownerLabel: "Project owner",
 			repairAction: expect.any(String),
@@ -288,7 +293,9 @@ describe("recipient policy review persistence", () => {
 			requiresDecisionInput: false,
 		});
 		expect(protectedSnapshot(db)).toBe(before);
-		expect(listRecipientPolicyReview(db, context).reviewItems).toEqual([]);
+		const resolvedReview = listRecipientPolicyReview(db, context);
+		expect(resolvedReview.reviewItems).toEqual([]);
+		expect(resolvedReview.continuity).toBeNull();
 	});
 
 	it("rejects stale fingerprints without writing", () => {

--- a/packages/core/src/recipient-policy-review.ts
+++ b/packages/core/src/recipient-policy-review.ts
@@ -32,10 +32,18 @@ export type RecipientPolicyActionableReviewItemV1 = Omit<RecipientPolicyReviewIt
 	options: RecipientPolicyReviewActionOptionV1[];
 };
 
+export interface RecipientPolicyReviewContinuityV1 {
+	state: "legacy_access_preserved";
+	findingCount: number;
+}
+
+// Patch-level additive wire hint: existing v1 clients ignore the new field,
+// while current clients require it so absence cannot silently change UX mode.
 export interface RecipientPolicyReviewListV1 {
 	version: RecipientPolicyContractVersion;
 	reviewItems: RecipientPolicyActionableReviewItemV1[];
 	blockedItems: RecipientPolicyBlockedItemV1[];
+	continuity: RecipientPolicyReviewContinuityV1 | null;
 }
 
 export interface RecipientPolicyReviewResolveRequestV1 {
@@ -402,10 +410,19 @@ export function listRecipientPolicyReview(
 	context: RecipientPolicyReviewContext,
 ): RecipientPolicyReviewListV1 {
 	const state = deriveRecipientPolicyReviewState(db, context);
+	const reviewItems = state.allReviewItems.filter((item) => !hasResolution(db, item));
+	const findingCount = reviewItems.length;
 	return {
 		version: RECIPIENT_POLICY_CONTRACT_VERSION,
-		reviewItems: state.allReviewItems.filter((item) => !hasResolution(db, item)),
+		reviewItems,
 		blockedItems: state.blockedItems,
+		continuity:
+			findingCount > 0
+				? {
+						state: "legacy_access_preserved",
+						findingCount,
+					}
+				: null,
 	};
 }
 

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -14,6 +14,7 @@ import {
 	previewRecipientInvite,
 	previewRecipientPolicyEdges,
 	RecipientPolicyEdgesStaleError,
+	type RecipientPolicyReviewListV1,
 	RecipientPolicyReviewStaleError,
 	resolveRecipientPolicyReview,
 	resolveRecipientPolicyReviewBulk,
@@ -241,7 +242,12 @@ describe("share operation API", () => {
 
 describe("recipient policy review API", () => {
 	it("loads the camelCase review DTO and submits an input-free decision unchanged", async () => {
-		const review = { version: 1, reviewItems: [], blockedItems: [] } as const;
+		const review: RecipientPolicyReviewListV1 = {
+			version: 1,
+			reviewItems: [],
+			blockedItems: [],
+			continuity: null,
+		};
 		const applied = {
 			reviewItemId: "review-1",
 			sourceFingerprint: "fingerprint-1",
@@ -274,6 +280,24 @@ describe("recipient policy review API", () => {
 				method: "POST",
 			}),
 		);
+	});
+
+	it("keeps legacy review items visible when continuity is absent", async () => {
+		const legacyReview = {
+			version: 1,
+			reviewItems: [{ reviewItemId: "legacy-review" }],
+			blockedItems: [],
+		};
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify(legacyReview), { status: 200 }),
+			) as typeof fetch;
+
+		await expect(loadRecipientPolicyReview()).resolves.toEqual({
+			...legacyReview,
+			continuity: { findingCount: 1, state: "legacy_access_preserved" },
+		});
 	});
 
 	it("throws a typed stale error for a stale 409 result", async () => {

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -591,6 +591,10 @@ export interface RecipientPolicyReviewListV1 {
 	version: 1;
 	reviewItems: RecipientPolicyReviewItemV1[];
 	blockedItems: RecipientPolicyBlockedItemV1[];
+	continuity: {
+		state: "legacy_access_preserved";
+		findingCount: number;
+	} | null;
 }
 
 export interface RecipientPolicyReviewResolveRequestV1 {
@@ -883,8 +887,20 @@ export function createRecipientInvite(
 	return recipientInviteRequest("/api/sync/recipient-policy/v1/invites", input);
 }
 
-export function loadRecipientPolicyReview(): Promise<RecipientPolicyReviewListV1> {
-	return fetchJson<RecipientPolicyReviewListV1>("/api/sync/recipient-policy/v1/review");
+export async function loadRecipientPolicyReview(): Promise<RecipientPolicyReviewListV1> {
+	const review = await fetchJson<
+		Omit<RecipientPolicyReviewListV1, "continuity"> & {
+			continuity?: RecipientPolicyReviewListV1["continuity"];
+		}
+	>("/api/sync/recipient-policy/v1/review");
+	if (review.continuity !== undefined) return { ...review, continuity: review.continuity };
+	return {
+		...review,
+		continuity:
+			review.reviewItems.length > 0
+				? { state: "legacy_access_preserved", findingCount: review.reviewItems.length }
+				: null,
+	};
 }
 
 export async function resolveRecipientPolicyReview(

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -71,7 +71,6 @@ import type {
 	ProjectScopeInventoryProject,
 	ProjectScopeInventoryResult,
 	RecipientPolicyIntentGraphV1,
-	RecipientPolicyReviewDecisionV1,
 	RecipientPolicyReviewItemV1,
 	RecipientPolicyReviewListV1,
 } from "../lib/api/sync";
@@ -178,7 +177,13 @@ function reviewItem(
 function recipientReview(
 	overrides: Partial<RecipientPolicyReviewListV1> = {},
 ): RecipientPolicyReviewListV1 {
-	return { blockedItems: [], reviewItems: [reviewItem()], version: 1, ...overrides };
+	return {
+		blockedItems: [],
+		continuity: { findingCount: 1, state: "legacy_access_preserved" },
+		reviewItems: [reviewItem()],
+		version: 1,
+		...overrides,
+	};
 }
 
 function recipientIntent(
@@ -272,6 +277,7 @@ describe("Projects tab", () => {
 		});
 		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue({
 			blockedItems: [],
+			continuity: null,
 			reviewItems: [],
 			version: 1,
 		});
@@ -329,7 +335,7 @@ describe("Projects tab", () => {
 		expect(document.getElementById("projectsInventorySkeleton")).toBeNull();
 	});
 
-	it("renders all decisions and the selected option's exact project, memory, and device preview", async () => {
+	it("collapses deferred migration evidence into one continuity message without controls", async () => {
 		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
 			has_more: false,
 			limit: 250,
@@ -337,34 +343,36 @@ describe("Projects tab", () => {
 			projects: [],
 			total: 0,
 		});
-		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(recipientReview());
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue({
+			...recipientReview(),
+			blockedItems: [
+				{
+					blockedItemId: "blocked-1",
+					finding: "Project identity is unstable.",
+					ownerLabel: "Project owner",
+					reason: "Codemem requires source-state repair.",
+					repairAction: "Assign a stable canonical Project identity.",
+					version: 1,
+				},
+			],
+			continuity: { findingCount: 37, state: "legacy_access_preserved" },
+		});
 
 		await loadProjectsData();
 
 		const surface = document.querySelector(".recipient-policy-review");
-		const select = surface?.querySelector("select") as HTMLSelectElement | null;
-		expect(surface?.textContent).toContain("Older project sharing needs a decision.");
-		expect(surface?.textContent).toContain("Recommended: Keep current setup unchanged");
-		expect(Array.from(select?.options ?? []).map((option) => option.textContent)).toEqual([
-			"Keep current setup unchanged",
-			"Reject suggestion",
-			"Choose recipients",
-		]);
-		expect(surface?.textContent).toContain("Exact preview: 1 project · 12 memories · 2 devices");
-		expect(surface?.textContent).toContain("Codemem");
-		expect(surface?.textContent).toContain("Adam’s Mac (assigned)");
-		expect(surface?.textContent).toContain("Build host (unassigned)");
-		expect(surface?.textContent).not.toContain("private-project-id");
-		expect(surface?.textContent).not.toContain("private-device-id");
-
-		if (!select) throw new Error("review decision select missing");
-		select.value = "choose_recipients";
-		select.dispatchEvent(new Event("change"));
-		expect(surface?.textContent).toContain("Recipient or device details are required");
-		expect(surface?.querySelector<HTMLButtonElement>("button")?.disabled).toBe(true);
+		expect(surface?.textContent).toContain("Existing sharing kept as-is");
+		expect(surface?.textContent).toContain("No action is required for this update");
+		expect(surface?.textContent).toContain("37 older sharing findings were not changed");
+		expect(surface?.textContent).toContain("current availability cannot be confirmed");
+		expect(surface?.textContent).not.toContain("Current access remains in place");
+		expect(surface?.textContent).not.toContain("will continue using");
+		expect(surface?.textContent).toContain("Assign a stable canonical Project identity");
+		expect(surface?.querySelector("button, select")).toBeNull();
+		expect(document.querySelectorAll(".recipient-policy-review-item")).toHaveLength(0);
 	});
 
-	it("preserves the recipient review DOM, draft decision, and focus across an unchanged refresh", async () => {
+	it("preserves the continuity surface across an unchanged refresh", async () => {
 		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
 			has_more: false,
 			limit: 250,
@@ -375,25 +383,14 @@ describe("Projects tab", () => {
 		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(recipientReview());
 
 		await loadProjectsData();
-		const firstSelect = document.querySelector(
-			".recipient-policy-review select",
-		) as HTMLSelectElement | null;
-		if (!firstSelect) throw new Error("review decision select missing");
-		firstSelect.value = "choose_recipients";
-		firstSelect.dispatchEvent(new Event("change"));
-		firstSelect.focus();
+		const firstSurface = document.querySelector(".recipient-policy-review");
 
 		await loadProjectsData();
 
-		const refreshedSelect = document.querySelector(
-			".recipient-policy-review select",
-		) as HTMLSelectElement | null;
-		expect(refreshedSelect).toBe(firstSelect);
-		expect(refreshedSelect?.value).toBe("choose_recipients");
-		expect(document.activeElement).toBe(firstSelect);
+		expect(document.querySelector(".recipient-policy-review")).toBe(firstSurface);
 	});
 
-	it("rerenders changed recipient evidence while restoring focus and resetting the stale draft", async () => {
+	it("rerenders the continuity surface when the deferred finding count changes", async () => {
 		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
 			has_more: false,
 			limit: 250,
@@ -405,187 +402,17 @@ describe("Projects tab", () => {
 			.mockResolvedValueOnce(recipientReview())
 			.mockResolvedValueOnce(
 				recipientReview({
-					reviewItems: [
-						reviewItem({
-							finding: "Updated recipient evidence needs a decision.",
-							sourceFingerprint: "fingerprint-2",
-						}),
-					],
+					continuity: { findingCount: 2, state: "legacy_access_preserved" },
 				}),
 			);
 
 		await loadProjectsData();
-		const firstSelect = document.querySelector(
-			".recipient-policy-review select",
-		) as HTMLSelectElement | null;
-		if (!firstSelect) throw new Error("review decision select missing");
-		firstSelect.value = "choose_recipients";
-		firstSelect.dispatchEvent(new Event("change"));
-		firstSelect.focus();
+		const firstSurface = document.querySelector(".recipient-policy-review");
 
 		await loadProjectsData();
 
-		const refreshedSelect = document.querySelector(
-			".recipient-policy-review select",
-		) as HTMLSelectElement | null;
-		expect(refreshedSelect).not.toBe(firstSelect);
-		expect(refreshedSelect?.value).toBe("keep_current_setup");
-		expect(document.activeElement).toBe(refreshedSelect);
-		expect(document.body.textContent).toContain("Updated recipient evidence needs a decision.");
-	});
-
-	it("restores focus to an unaffected apply button when other review evidence changes", async () => {
-		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
-			has_more: false,
-			limit: 250,
-			offset: 0,
-			projects: [],
-			total: 0,
-		});
-		const firstItem = reviewItem();
-		const secondItem = reviewItem({
-			finding: "Second recipient finding.",
-			reviewItemId: "review-2",
-			sourceFingerprint: "fingerprint-2",
-		});
-		vi.mocked(api.loadRecipientPolicyReview)
-			.mockResolvedValueOnce(recipientReview({ reviewItems: [firstItem, secondItem] }))
-			.mockResolvedValueOnce(
-				recipientReview({
-					reviewItems: [firstItem, { ...secondItem, finding: "Updated second recipient finding." }],
-				}),
-			);
-
-		await loadProjectsData();
-		const firstButton = document.querySelector<HTMLButtonElement>(
-			'button[data-recipient-policy-focus-key="review-1"]',
-		);
-		if (!firstButton) throw new Error("review apply button missing");
-		firstButton.focus();
-
-		await loadProjectsData();
-
-		const refreshedButton = document.querySelector<HTMLButtonElement>(
-			'button[data-recipient-policy-focus-key="review-1"]',
-		);
-		expect(refreshedButton).not.toBe(firstButton);
-		expect(document.activeElement).toBe(refreshedButton);
-		expect(document.body.textContent).toContain("Updated second recipient finding.");
-	});
-
-	it.each<RecipientPolicyReviewDecisionV1>([
-		"keep_current_setup",
-		"reject_suggestion",
-	])("submits %s without decision input and clears the resolved card after refresh", async (decision) => {
-		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
-			has_more: false,
-			limit: 250,
-			offset: 0,
-			projects: [],
-			total: 0,
-		});
-		vi.mocked(api.loadRecipientPolicyReview)
-			.mockResolvedValueOnce(recipientReview())
-			.mockResolvedValue({ blockedItems: [], reviewItems: [], version: 1 });
-
-		await loadProjectsData();
-		const select = document.querySelector(
-			".recipient-policy-review select",
-		) as HTMLSelectElement | null;
-		if (!select) throw new Error("review decision select missing");
-		select.value = decision;
-		select.dispatchEvent(new Event("change"));
-		document.querySelector<HTMLButtonElement>(".recipient-policy-review button")?.click();
-		await flushAsyncWork();
-
-		expect(api.resolveRecipientPolicyReview).toHaveBeenCalledWith({
-			decision,
-			reviewItemId: "review-1",
-			sourceFingerprint: "fingerprint-1",
-		});
-		expect(document.querySelector(".recipient-policy-review-item")).toBeNull();
-		expect(document.getElementById("recipientPolicyReviewMount")?.hidden).toBe(true);
-	});
-
-	it("re-enables the same input-free decision after a non-stale failure and permits retry", async () => {
-		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
-			has_more: false,
-			limit: 250,
-			offset: 0,
-			projects: [],
-			total: 0,
-		});
-		vi.mocked(api.loadRecipientPolicyReview)
-			.mockResolvedValueOnce(recipientReview())
-			.mockResolvedValue({ blockedItems: [], reviewItems: [], version: 1 });
-		vi.mocked(api.resolveRecipientPolicyReview).mockRejectedValueOnce(
-			new Error("Unable to apply this decision right now."),
-		);
-
-		await loadProjectsData();
-		const select = document.querySelector(
-			".recipient-policy-review select",
-		) as HTMLSelectElement | null;
-		const submit = document.querySelector<HTMLButtonElement>(".recipient-policy-review button");
-		if (!select || !submit) throw new Error("review decision controls missing");
-		select.value = "reject_suggestion";
-		select.dispatchEvent(new Event("change"));
-
-		submit.click();
-		await flushAsyncWork();
-
-		expect(select.value).toBe("reject_suggestion");
-		expect(select.disabled).toBe(false);
-		expect(submit.disabled).toBe(false);
-		expect(submit.textContent).toBe("Apply decision");
-		expect(document.querySelector(".recipient-policy-review-status")?.textContent).toBe(
-			"Unable to apply this decision right now.",
-		);
-
-		submit.click();
-		await flushAsyncWork();
-
-		expect(api.resolveRecipientPolicyReview).toHaveBeenCalledTimes(2);
-		expect(api.resolveRecipientPolicyReview).toHaveBeenNthCalledWith(2, {
-			decision: "reject_suggestion",
-			reviewItemId: "review-1",
-			sourceFingerprint: "fingerprint-1",
-		});
-		expect(document.querySelector(".recipient-policy-review-item")).toBeNull();
-	});
-
-	it("retains a stale card, announces the source change, and refreshes review data", async () => {
-		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
-			has_more: false,
-			limit: 250,
-			offset: 0,
-			projects: [],
-			total: 0,
-		});
-		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(recipientReview());
-		vi.mocked(api.resolveRecipientPolicyReview).mockRejectedValueOnce(
-			new api.RecipientPolicyReviewStaleError({
-				errorCode: "source_fingerprint_stale",
-				idempotent: false,
-				reviewItemId: "review-1",
-				sourceFingerprint: "fingerprint-1",
-				status: "stale",
-			}),
-		);
-
-		await loadProjectsData();
-		const loadsBeforeSubmit = vi.mocked(api.loadRecipientPolicyReview).mock.calls.length;
-		document.querySelector<HTMLButtonElement>(".recipient-policy-review button")?.click();
-		await flushAsyncWork();
-
-		expect(document.querySelector(".recipient-policy-review-item")).not.toBeNull();
-		expect(document.querySelector("[aria-live='polite']")?.textContent).toContain(
-			"Source state changed",
-		);
-		expect(document.body.textContent).toContain("Review the refreshed choices before trying again");
-		expect(vi.mocked(api.loadRecipientPolicyReview).mock.calls.length).toBeGreaterThan(
-			loadsBeforeSubmit,
-		);
+		expect(document.querySelector(".recipient-policy-review")).not.toBe(firstSurface);
+		expect(document.body.textContent).toContain("2 older sharing findings were not changed");
 	});
 
 	it("renders blocked repair ownership without decision controls", async () => {
@@ -608,6 +435,7 @@ describe("Projects tab", () => {
 						version: 1,
 					},
 				],
+				continuity: null,
 				reviewItems: [],
 			}),
 		);
@@ -619,24 +447,6 @@ describe("Projects tab", () => {
 		expect(blocked?.textContent).toContain("Owner: Project owner");
 		expect(blocked?.textContent).toContain("Repair: Assign a stable canonical Project identity.");
 		expect(blocked?.querySelector("button, select")).toBeNull();
-	});
-
-	it("does not render an actionable card with zero decisions", async () => {
-		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
-			has_more: false,
-			limit: 250,
-			offset: 0,
-			projects: [],
-			total: 0,
-		});
-		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
-			recipientReview({ reviewItems: [reviewItem({ options: [] })] }),
-		);
-
-		await loadProjectsData();
-
-		expect(document.querySelector(".recipient-policy-review-item")).toBeNull();
-		expect(document.getElementById("recipientPolicyReviewMount")?.hidden).toBe(true);
 	});
 
 	it("opens row sharing with exactly the selected canonical project", async () => {

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -1318,7 +1318,7 @@ export async function loadProjectsData() {
 		const reviewMount = el<HTMLDivElement>("recipientPolicyReviewMount");
 		if (reviewMount) {
 			if ("review" in recipientPolicyReview) {
-				renderRecipientPolicyReview(reviewMount, recipientPolicyReview.review, loadProjectsData);
+				renderRecipientPolicyReview(reviewMount, recipientPolicyReview.review);
 			} else {
 				renderRecipientPolicyReviewLoadError(reviewMount, recipientPolicyReview.error);
 			}

--- a/packages/ui/src/tabs/recipient-policy-review.ts
+++ b/packages/ui/src/tabs/recipient-policy-review.ts
@@ -1,202 +1,12 @@
-import * as api from "../lib/api";
-import type {
-	RecipientPolicyBlockedItemV1,
-	RecipientPolicyReviewItemV1,
-	RecipientPolicyReviewListV1,
-	RecipientPolicyReviewOptionV1,
-} from "../lib/api/sync";
+import type { RecipientPolicyBlockedItemV1, RecipientPolicyReviewListV1 } from "../lib/api/sync";
 
-type RefreshReview = () => Promise<void>;
-
-const pendingReviewItems = new Set<string>();
-const staleReviewItems = new Set<string>();
 const renderedReviewSignatures = new WeakMap<HTMLElement, string>();
-const decisionDraftsByMount = new WeakMap<HTMLElement, Map<string, string>>();
-let surfaceMessage = "";
 
 function paragraph(text: string, className = ""): HTMLParagraphElement {
 	const node = document.createElement("p");
 	if (className) node.className = className;
 	node.textContent = text;
 	return node;
-}
-
-function optionLabel(item: RecipientPolicyReviewItemV1): string {
-	return (
-		item.options.find((option) => option.decision === item.recommendedDecision)?.label ??
-		item.recommendedDecision.replaceAll("_", " ")
-	);
-}
-
-function renderNamedList(label: string, values: string[]): HTMLElement {
-	const section = document.createElement("div");
-	section.className = "recipient-policy-preview-list";
-	const title = document.createElement("strong");
-	title.textContent = label;
-	const list = document.createElement("ul");
-	for (const value of values) {
-		const item = document.createElement("li");
-		item.textContent = value;
-		list.appendChild(item);
-	}
-	section.append(title, list);
-	return section;
-}
-
-function renderPreview(option: RecipientPolicyReviewOptionV1): HTMLElement {
-	const preview = document.createElement("div");
-	preview.className = "recipient-policy-preview settings-note";
-	const counts = document.createElement("strong");
-	counts.textContent = `Exact preview: ${option.preview.affectedProjectCount.toLocaleString()} project${option.preview.affectedProjectCount === 1 ? "" : "s"} · ${option.preview.affectedMemoryCount.toLocaleString()} memor${option.preview.affectedMemoryCount === 1 ? "y" : "ies"} · ${option.preview.affectedDeviceCount.toLocaleString()} device${option.preview.affectedDeviceCount === 1 ? "" : "s"}`;
-	preview.appendChild(counts);
-	preview.appendChild(
-		renderNamedList(
-			"Projects",
-			option.preview.projects.map((project) => project.displayName),
-		),
-	);
-	preview.appendChild(
-		renderNamedList(
-			"Devices",
-			option.preview.effectiveDevices.map(
-				(device) => `${device.displayName} (${device.assignment})`,
-			),
-		),
-	);
-	return preview;
-}
-
-function renderActionableItem(
-	item: RecipientPolicyReviewItemV1,
-	index: number,
-	status: HTMLElement,
-	onRefresh: RefreshReview,
-	decisionDrafts: Map<string, string>,
-): HTMLElement {
-	const card = document.createElement("article");
-	card.className = "project-inventory-row recipient-policy-review-item";
-
-	const finding = document.createElement("h3");
-	finding.className = "project-inventory-title";
-	finding.textContent = item.finding;
-	const reason = paragraph(item.reason, "project-inventory-meta");
-	const recommended = paragraph(`Recommended: ${optionLabel(item)}`, "settings-note");
-
-	const controls = document.createElement("div");
-	controls.className = "project-inventory-actions";
-	const selectId = `recipient-policy-decision-${index}`;
-	const label = document.createElement("label");
-	label.htmlFor = selectId;
-	label.textContent = "Decision";
-	const select = document.createElement("select");
-	select.id = selectId;
-	select.className = "project-filter recipient-policy-review-select";
-	const draftKey = `${item.reviewItemId}:${item.sourceFingerprint}`;
-	select.dataset.recipientPolicyFocusKey = item.reviewItemId;
-	select.dataset.recipientPolicyFocusTarget = "decision";
-	for (const reviewOption of item.options) {
-		const option = document.createElement("option");
-		option.value = reviewOption.decision;
-		option.textContent = reviewOption.label;
-		select.appendChild(option);
-	}
-	const draftDecision = decisionDrafts.get(draftKey);
-	const initialDecision =
-		draftDecision && item.options.some((option) => option.decision === draftDecision)
-			? draftDecision
-			: item.recommendedDecision;
-	if (item.options.some((option) => option.decision === initialDecision)) {
-		select.value = initialDecision;
-	}
-
-	const submit = document.createElement("button");
-	submit.className = "settings-button";
-	submit.type = "button";
-	submit.textContent = "Apply decision";
-	submit.dataset.recipientPolicyFocusKey = item.reviewItemId;
-	submit.dataset.recipientPolicyFocusTarget = "apply";
-	const deferred = paragraph("", "settings-note recipient-policy-deferred");
-	const previewMount = document.createElement("div");
-	previewMount.className = "recipient-policy-preview-mount";
-	previewMount.setAttribute("aria-live", "polite");
-
-	const selectedOption = () =>
-		item.options.find((option) => option.decision === select.value) ?? item.options[0];
-	const updateSelection = () => {
-		const current = selectedOption();
-		if (!current) return;
-		previewMount.replaceChildren(renderPreview(current));
-		deferred.textContent = current.preview.requiresDecisionInput
-			? "Recipient or device details are required for this decision. Complete it in a later review flow; no incomplete decision will be submitted."
-			: "";
-		deferred.hidden = !current.preview.requiresDecisionInput;
-		submit.disabled =
-			current.preview.requiresDecisionInput || pendingReviewItems.has(item.reviewItemId);
-	};
-	select.addEventListener("change", () => {
-		decisionDrafts.set(draftKey, select.value);
-		updateSelection();
-	});
-	updateSelection();
-
-	if (staleReviewItems.has(item.reviewItemId)) {
-		card.appendChild(
-			paragraph(
-				"Source state changed while this decision was being reviewed. Review the refreshed choices before trying again.",
-				"settings-note project-attention-note",
-			),
-		);
-	}
-
-	submit.addEventListener("click", async () => {
-		const current = selectedOption();
-		if (
-			!current ||
-			current.preview.requiresDecisionInput ||
-			pendingReviewItems.has(item.reviewItemId)
-		) {
-			return;
-		}
-		pendingReviewItems.add(item.reviewItemId);
-		select.disabled = true;
-		submit.disabled = true;
-		submit.textContent = "Applying…";
-		status.textContent = `Applying “${current.label}”…`;
-		try {
-			await api.resolveRecipientPolicyReview({
-				reviewItemId: item.reviewItemId,
-				sourceFingerprint: item.sourceFingerprint,
-				decision: current.decision,
-			});
-			staleReviewItems.delete(item.reviewItemId);
-			surfaceMessage = "Decision applied. Review items refreshed.";
-			pendingReviewItems.delete(item.reviewItemId);
-			await onRefresh();
-		} catch (error) {
-			if (error instanceof api.RecipientPolicyReviewStaleError) {
-				staleReviewItems.add(item.reviewItemId);
-				surfaceMessage =
-					"Source state changed. The review item is still open and its choices were refreshed.";
-				status.textContent = surfaceMessage;
-				pendingReviewItems.delete(item.reviewItemId);
-				await onRefresh();
-				return;
-			}
-			surfaceMessage = error instanceof Error ? error.message : "Unable to apply decision.";
-			status.textContent = surfaceMessage;
-			pendingReviewItems.delete(item.reviewItemId);
-			select.disabled = false;
-			submit.textContent = "Apply decision";
-			updateSelection();
-		} finally {
-			pendingReviewItems.delete(item.reviewItemId);
-		}
-	});
-
-	controls.append(label, select, submit);
-	card.prepend(finding, reason, recommended);
-	card.append(controls, deferred, previewMount);
-	return card;
 }
 
 function renderBlockedItem(item: RecipientPolicyBlockedItemV1): HTMLElement {
@@ -223,79 +33,56 @@ function renderBlockedItem(item: RecipientPolicyBlockedItemV1): HTMLElement {
 export function renderRecipientPolicyReview(
 	mount: HTMLElement,
 	review: RecipientPolicyReviewListV1,
-	onRefresh: RefreshReview,
 ): void {
-	const signature = `review:${JSON.stringify({ review, surfaceMessage })}`;
+	const signature = `review:${JSON.stringify(review)}`;
 	if (renderedReviewSignatures.get(mount) === signature) return;
-	const actionable = review.reviewItems.filter((item) => item.options.length > 0);
-	if (actionable.length === 0 && review.blockedItems.length === 0) {
+	if (!review.continuity && review.blockedItems.length === 0) {
 		mount.replaceChildren();
 		mount.hidden = true;
 		renderedReviewSignatures.set(mount, signature);
 		return;
 	}
 
-	const decisionDrafts = decisionDraftsByMount.get(mount) ?? new Map<string, string>();
-	decisionDraftsByMount.set(mount, decisionDrafts);
-	const activeElement = document.activeElement;
-	const focusedReviewControl =
-		activeElement instanceof HTMLElement && mount.contains(activeElement)
-			? {
-					key: activeElement.dataset.recipientPolicyFocusKey,
-					target: activeElement.dataset.recipientPolicyFocusTarget,
-				}
-			: null;
 	mount.hidden = false;
 	const surface = document.createElement("section");
 	surface.className = "card recipient-policy-review";
 	surface.setAttribute("aria-labelledby", "recipientPolicyReviewTitle");
 	const title = document.createElement("h2");
 	title.id = "recipientPolicyReviewTitle";
-	title.textContent = "Recipient migration review";
-	const intro = paragraph(
-		"Review how older project sharing should be represented. These decisions do not expose internal scope or transport details.",
-		"section-meta",
-	);
-	const status = document.createElement("div");
-	status.className = "section-meta recipient-policy-review-status";
-	status.setAttribute("role", "status");
-	status.setAttribute("aria-live", "polite");
-	status.textContent = surfaceMessage;
-	surface.append(title, intro, status);
+	title.textContent = review.continuity ? "Existing sharing kept as-is" : "Sharing needs repair";
+	surface.appendChild(title);
 
-	if (actionable.length > 0) {
-		const heading = document.createElement("h3");
-		heading.textContent = "Needs review";
-		const list = document.createElement("div");
-		list.className = "project-inventory-list recipient-policy-review-list";
-		actionable.forEach((item, index) => {
-			list.appendChild(renderActionableItem(item, index, status, onRefresh, decisionDrafts));
-		});
-		surface.append(heading, list);
+	if (review.continuity) {
+		const intro = paragraph(
+			"No action is required for this update. Codemem did not change your existing Team or local sharing configuration.",
+			"section-meta",
+		);
+		const findingCount = review.continuity.findingCount;
+		const detail = paragraph(
+			`${findingCount.toLocaleString()} older sharing finding${findingCount === 1 ? " was" : "s were"} not changed because Codemem could not safely translate ${findingCount === 1 ? "it" : "them"} automatically.`,
+			"settings-note",
+		);
+		detail.setAttribute("role", "status");
+		detail.setAttribute("aria-live", "polite");
+		surface.append(intro, detail);
 	}
+
 	if (review.blockedItems.length > 0) {
+		const intro = paragraph(
+			"Codemem did not change access for these items, but their current availability cannot be confirmed until these source-state problems are repaired.",
+			"section-meta project-attention-note",
+		);
 		const heading = document.createElement("h3");
 		heading.className = "recipient-policy-blocked-heading";
-		heading.textContent = "Blocked";
+		heading.textContent = "Needs repair";
 		const list = document.createElement("div");
 		list.className = "project-inventory-list recipient-policy-review-list";
 		for (const item of review.blockedItems) list.appendChild(renderBlockedItem(item));
-		surface.append(heading, list);
+		surface.append(intro, heading, list);
 	}
+
 	mount.replaceChildren(surface);
 	renderedReviewSignatures.set(mount, signature);
-	if (focusedReviewControl?.key && focusedReviewControl.target) {
-		const nextFocusedControl = Array.from(
-			mount.querySelectorAll<HTMLElement>(
-				"[data-recipient-policy-focus-key][data-recipient-policy-focus-target]",
-			),
-		).find(
-			(control) =>
-				control.dataset.recipientPolicyFocusKey === focusedReviewControl.key &&
-				control.dataset.recipientPolicyFocusTarget === focusedReviewControl.target,
-		);
-		nextFocusedControl?.focus();
-	}
 }
 
 export function renderRecipientPolicyReviewLoadError(mount: HTMLElement, error: unknown): void {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -8212,6 +8212,7 @@ describe("viewer-server", () => {
 				).toBeUndefined();
 				const reviewResponse = await app.request("/api/sync/recipient-policy/v1/review");
 				const review = (await reviewResponse.json()) as {
+					continuity: { findingCount: number; state: string } | null;
 					reviewItems: Array<{
 						reviewItemId: string;
 						sourceFingerprint: string;
@@ -8223,6 +8224,10 @@ describe("viewer-server", () => {
 				const serialized = JSON.stringify(review);
 
 				expect(reviewResponse.status).toBe(200);
+				expect(review.continuity).toEqual({
+					findingCount: 1,
+					state: "legacy_access_preserved",
+				});
 				expect(
 					store.db
 						.prepare("SELECT status FROM actors WHERE actor_id = ? AND is_local = 1")
@@ -8348,6 +8353,11 @@ describe("viewer-server", () => {
 					decided_by_identity_id: store.actorId,
 					decided_by_device_id: store.deviceId,
 				});
+				const completedReviewResponse = await app.request("/api/sync/recipient-policy/v1/review");
+				const completedReview = (await completedReviewResponse.json()) as typeof review;
+				expect(completedReviewResponse.status).toBe(200);
+				expect(completedReview.continuity).toBeNull();
+				expect(completedReview).toHaveProperty("continuity");
 			} finally {
 				getStore()?.db.pragma("query_only = OFF");
 				cleanup();


### PR DESCRIPTION
## Description

Preserve existing Team-era access during recipient-policy migration. Replace unsupported per-Project decisions with an aggregate continuity state while keeping blocked source-state repairs visible and leaving core diagnostic APIs intact.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced