### PR TITLE
fix(core): accept legacy coordinator device rows

### DIFF
--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -350,6 +350,125 @@ describe("coordinator local admin actions", () => {
 		).rejects.toThrow("coordinator_device_list_malformed");
 	});
 
+	it("normalizes omitted nullable fields from legacy remote device lists", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							items: [
+								{
+									group_id: "team-a",
+									device_id: "device-with-name",
+									public_key: "pk-with-name",
+									fingerprint: "fp-with-name",
+									display_name: "Legacy device",
+									enabled: 1,
+									created_at: "2026-07-26T00:00:00.000Z",
+								},
+								{
+									group_id: "team-a",
+									device_id: "device-without-name",
+									public_key: "pk-without-name",
+									fingerprint: "fp-without-name",
+									enabled: 1,
+									created_at: "2026-07-26T00:00:00.000Z",
+								},
+								{
+									group_id: "team-a",
+									device_id: "device-with-identity",
+									public_key: "pk-with-identity",
+									fingerprint: "fp-with-identity",
+									identity_id: "identity-1",
+									display_name: "Identified device",
+									enabled: 1,
+									created_at: "2026-07-26T00:00:00.000Z",
+								},
+							],
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					),
+			),
+		);
+
+		await expect(
+			coordinatorListDevicesAction({
+				groupId: "team-a",
+				remoteUrl: "https://coord.example.test",
+				adminSecret: "secret",
+			}),
+		).resolves.toEqual([
+			{
+				group_id: "team-a",
+				device_id: "device-with-name",
+				public_key: "pk-with-name",
+				fingerprint: "fp-with-name",
+				identity_id: null,
+				display_name: "Legacy device",
+				enabled: 1,
+				created_at: "2026-07-26T00:00:00.000Z",
+			},
+			{
+				group_id: "team-a",
+				device_id: "device-without-name",
+				public_key: "pk-without-name",
+				fingerprint: "fp-without-name",
+				identity_id: null,
+				display_name: null,
+				enabled: 1,
+				created_at: "2026-07-26T00:00:00.000Z",
+			},
+			{
+				group_id: "team-a",
+				device_id: "device-with-identity",
+				public_key: "pk-with-identity",
+				fingerprint: "fp-with-identity",
+				identity_id: "identity-1",
+				display_name: "Identified device",
+				enabled: 1,
+				created_at: "2026-07-26T00:00:00.000Z",
+			},
+		]);
+	});
+
+	it.each([
+		{ identity_id: "" },
+		{ identity_id: 0 },
+		{ display_name: 0 },
+		{ display_name: false },
+	])("rejects malformed non-null nullable remote device fields: %j", async (override) => {
+		const device = {
+			group_id: "team-a",
+			device_id: "device-1",
+			public_key: "pk-1",
+			fingerprint: "fp-1",
+			identity_id: null,
+			display_name: null,
+			enabled: 1,
+			created_at: "2026-07-26T00:00:00.000Z",
+			...override,
+		};
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify({ items: [device] }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+			),
+		);
+
+		await expect(
+			coordinatorListDevicesAction({
+				groupId: "team-a",
+				remoteUrl: "https://coord.example.test",
+				adminSecret: "secret",
+			}),
+		).rejects.toThrow("coordinator_device_list_malformed");
+	});
+
 	it("lists only consumed Team invites without tokens", async () => {
 		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
 		const reviewedIntent = teamReviewedIntent();

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -829,13 +829,15 @@ export async function coordinatorListDevicesAction(opts: {
 				throw new Error("coordinator_device_list_malformed");
 			}
 			const record = row as Record<string, unknown>;
+			const identityId = record.identity_id ?? null;
+			const displayName = record.display_name ?? null;
 			if (
 				record.group_id !== groupId ||
 				!isCanonicalCoordinatorIdentifier(record.device_id) ||
 				typeof record.public_key !== "string" ||
 				typeof record.fingerprint !== "string" ||
-				(record.identity_id !== null && !isCanonicalCoordinatorIdentifier(record.identity_id)) ||
-				(record.display_name !== null && typeof record.display_name !== "string") ||
+				(identityId !== null && !isCanonicalCoordinatorIdentifier(identityId)) ||
+				(displayName !== null && typeof displayName !== "string") ||
 				typeof record.enabled !== "number" ||
 				typeof record.created_at !== "string"
 			) {
@@ -846,8 +848,8 @@ export async function coordinatorListDevicesAction(opts: {
 				device_id: record.device_id,
 				public_key: record.public_key,
 				fingerprint: record.fingerprint,
-				identity_id: record.identity_id,
-				display_name: record.display_name,
+				identity_id: identityId,
+				display_name: displayName,
 				enabled: record.enabled,
 				created_at: record.created_at,
 			};


### PR DESCRIPTION
## Description

Accept device-list rows from deployed and legacy coordinators that omit nullable `identity_id` or `display_name` fields. Normalize only omitted/null values to `null`, while retaining strict rejection for malformed non-null values. This prevents `coordinator_device_list_malformed` from breaking enrollment maintenance across legacy Team boundaries.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation:
- `pnpm exec vitest run packages/core/src/coordinator-actions.test.ts` — 61 passed
- `pnpm run check` — 177 files; 3911 passed, 3 todo
- Read-only live parsing — 6 Nerdworld and 6 SRE device rows normalized successfully

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed; compatibility-only parser correction)
- [x] No new warnings introduced