### PR TITLE
chore(release): bump version to 0.40.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.40.0"
+    "version": "0.40.1"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.40.0",
+      "version": "0.40.1",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.40.0";
+const PINNED_BACKEND_VERSION = "0.40.1";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.40.0",
+	"version": "0.40.1",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.40.0",
+	"version": "0.40.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -350,6 +350,125 @@ describe("coordinator local admin actions", () => {
 		).rejects.toThrow("coordinator_device_list_malformed");
 	});
 
+	it("normalizes omitted nullable fields from legacy remote device lists", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							items: [
+								{
+									group_id: "team-a",
+									device_id: "device-with-name",
+									public_key: "pk-with-name",
+									fingerprint: "fp-with-name",
+									display_name: "Legacy device",
+									enabled: 1,
+									created_at: "2026-07-26T00:00:00.000Z",
+								},
+								{
+									group_id: "team-a",
+									device_id: "device-without-name",
+									public_key: "pk-without-name",
+									fingerprint: "fp-without-name",
+									enabled: 1,
+									created_at: "2026-07-26T00:00:00.000Z",
+								},
+								{
+									group_id: "team-a",
+									device_id: "device-with-identity",
+									public_key: "pk-with-identity",
+									fingerprint: "fp-with-identity",
+									identity_id: "identity-1",
+									display_name: "Identified device",
+									enabled: 1,
+									created_at: "2026-07-26T00:00:00.000Z",
+								},
+							],
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					),
+			),
+		);
+
+		await expect(
+			coordinatorListDevicesAction({
+				groupId: "team-a",
+				remoteUrl: "https://coord.example.test",
+				adminSecret: "secret",
+			}),
+		).resolves.toEqual([
+			{
+				group_id: "team-a",
+				device_id: "device-with-name",
+				public_key: "pk-with-name",
+				fingerprint: "fp-with-name",
+				identity_id: null,
+				display_name: "Legacy device",
+				enabled: 1,
+				created_at: "2026-07-26T00:00:00.000Z",
+			},
+			{
+				group_id: "team-a",
+				device_id: "device-without-name",
+				public_key: "pk-without-name",
+				fingerprint: "fp-without-name",
+				identity_id: null,
+				display_name: null,
+				enabled: 1,
+				created_at: "2026-07-26T00:00:00.000Z",
+			},
+			{
+				group_id: "team-a",
+				device_id: "device-with-identity",
+				public_key: "pk-with-identity",
+				fingerprint: "fp-with-identity",
+				identity_id: "identity-1",
+				display_name: "Identified device",
+				enabled: 1,
+				created_at: "2026-07-26T00:00:00.000Z",
+			},
+		]);
+	});
+
+	it.each([
+		{ identity_id: "" },
+		{ identity_id: 0 },
+		{ display_name: 0 },
+		{ display_name: false },
+	])("rejects malformed non-null nullable remote device fields: %j", async (override) => {
+		const device = {
+			group_id: "team-a",
+			device_id: "device-1",
+			public_key: "pk-1",
+			fingerprint: "fp-1",
+			identity_id: null,
+			display_name: null,
+			enabled: 1,
+			created_at: "2026-07-26T00:00:00.000Z",
+			...override,
+		};
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify({ items: [device] }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+			),
+		);
+
+		await expect(
+			coordinatorListDevicesAction({
+				groupId: "team-a",
+				remoteUrl: "https://coord.example.test",
+				adminSecret: "secret",
+			}),
+		).rejects.toThrow("coordinator_device_list_malformed");
+	});
+
 	it("lists only consumed Team invites without tokens", async () => {
 		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
 		const reviewedIntent = teamReviewedIntent();

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -829,13 +829,15 @@ export async function coordinatorListDevicesAction(opts: {
 				throw new Error("coordinator_device_list_malformed");
 			}
 			const record = row as Record<string, unknown>;
+			const identityId = record.identity_id ?? null;
+			const displayName = record.display_name ?? null;
 			if (
 				record.group_id !== groupId ||
 				!isCanonicalCoordinatorIdentifier(record.device_id) ||
 				typeof record.public_key !== "string" ||
 				typeof record.fingerprint !== "string" ||
-				(record.identity_id !== null && !isCanonicalCoordinatorIdentifier(record.identity_id)) ||
-				(record.display_name !== null && typeof record.display_name !== "string") ||
+				(identityId !== null && !isCanonicalCoordinatorIdentifier(identityId)) ||
+				(displayName !== null && typeof displayName !== "string") ||
 				typeof record.enabled !== "number" ||
 				typeof record.created_at !== "string"
 			) {
@@ -846,8 +848,8 @@ export async function coordinatorListDevicesAction(opts: {
 				device_id: record.device_id,
 				public_key: record.public_key,
 				fingerprint: record.fingerprint,
-				identity_id: record.identity_id,
-				display_name: record.display_name,
+				identity_id: identityId,
+				display_name: displayName,
 				enabled: record.enabled,
 				created_at: record.created_at,
 			};

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.40.0");
+		expect(VERSION).toBe("0.40.1");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.40.0";
+export const VERSION = "0.40.1";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.40.0",
+	"version": "0.40.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.40.0";
+const PINNED_BACKEND_VERSION = "0.40.1";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 const CODEMEM_CONTEXT_PART_ID_PREFIX = "codemem-context-";

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.40.0",
+	"version": "0.40.1",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.40.0",
+	"version": "0.40.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "author": {
     "name": "Adam Kunicki"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codemem",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Persistent memory for Codex. Capture work across sessions and recall relevant context.",
   "author": {
     "name": "Adam Kunicki"


### PR DESCRIPTION
## Description

Bump all managed CodeMem release surfaces from 0.40.0 to 0.40.1. This release includes the merged continuity hotfixes plus the legacy coordinator device-row compatibility fix in the downstack PR.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation:
- `pnpm run release:version -- check` — aligned at 0.40.1
- `pnpm run test:release-version` — 11 passed
- `pnpm run check` — 177 files; 3911 passed, 3 todo
- `pnpm run build` — all workspace packages built successfully

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (release design already merged in #1421)
- [x] No new warnings introduced