### PR TITLE
fix(sharing): preserve umbrella diagnostic continuity

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.40.1"
+    "version": "0.40.2"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.40.1",
+      "version": "0.40.2",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/docs/superpowers/specs/2026-08-10-recipient-policy-multi-project-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-10-recipient-policy-multi-project-diagnostics-design.md
@@ -1,0 +1,40 @@
+# Recipient-policy multi-project diagnostics
+
+**Date:** 2026-08-10
+**Target:** 0.40.2
+**Status:** Approved
+
+## Problem
+
+Legacy recipient-policy projection deliberately refuses to infer per-Project recipient intent when one enforcement scope contains multiple canonical Projects. That fail-closed behavior is correct. The review layer currently converts every projection diagnostic into a repairable `Blocked` card, however, so an intentional umbrella scope is presented as a broken Project-to-scope mapping for every Project it contains.
+
+Accurately moving Projects into their existing umbrella scopes therefore creates more apparent failures even though placement and enforcement are correct.
+
+## Decision
+
+Keep `ambiguous_multi_project_scope` in the legacy projection and continue suppressing recipient inference and actionable migration decisions for affected Projects. Do not convert this diagnostic into a repairable blocked review item. Count it in the existing collapsed `legacy_access_preserved` continuity message instead, so the ambiguity remains observable without producing one false repair card per Project.
+
+Treat `wildcard_scope_mapping` the same way: a deliberate catch-all mapping can be ambiguous for recipient migration without being broken. Continue producing blocked review items for source-state defects that have a concrete repair path, including noncanonical Project identities, conflicting Project-to-scope mappings, and inactive boundaries.
+
+This changes presentation only. It does not create recipient intent, change current access, promote recipient-policy authority, resolve migration findings, or weaken scope enforcement.
+
+## Implementation
+
+- Add an exhaustive, typed presentation classification for every `LegacyRecipientPolicyConditionCodeV1`: actionable, repairable blocked, or preserved continuity. Adding a future condition code must fail compilation until its presentation is selected explicitly.
+- Classify exactly `ambiguous_multi_project_scope` and `wildcard_scope_mapping` as preserved continuity; classify noncanonical identities, conflicting mappings, and inactive boundaries as repairable blocked conditions.
+- Count suppressed diagnostics in the existing `continuity.findingCount` alongside unresolved deferred review items.
+- Preserve the existing `hasDiagnostic` gate so ambiguous Projects remain fail-closed and do not gain actionable review options.
+- When continuity and genuine blocked items coexist, title the surface `Sharing needs repair` and retain the deferred-finding count. Suppress the continuity-only `No action is required` introduction in this mixed state so the copy does not contradict the repair cards.
+- Add regression coverage proving that a multi-Project umbrella scope remains ambiguous in projection, contributes to continuity, and does not become a blocked repair card.
+- Cover mixed intentional and repairable diagnostics, retained blocked-item ID stability, and migration remaining skipped without authoritative evidence.
+- Preserve blocked-card coverage for a genuinely noncanonical Project identity and UI coverage for continuity-only and mixed states. The mixed-state test must intentionally replace its previous `Existing sharing kept as-is` and `No action is required` expectations.
+- Cover the exhaustive presentation classification so a newly added condition code cannot silently disappear from review.
+
+The response shape and contract version remain unchanged. `continuity` is already an additive V1 field; this patch only corrects which legacy findings contribute to it versus `blockedItems`.
+
+## Validation
+
+- Focused recipient-policy projection, review, migration, and Projects UI tests.
+- TypeScript, lint, and workspace tests.
+- Confirm the review API no longer emits one blocked card per Project solely because an intentional scope contains multiple Projects.
+- Run the release version script for 0.40.2 and build the UI before release submission.

--- a/docs/superpowers/specs/2026-08-10-recipient-policy-multi-project-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-10-recipient-policy-multi-project-diagnostics-design.md
@@ -12,7 +12,7 @@ Accurately moving Projects into their existing umbrella scopes therefore creates
 
 ## Decision
 
-Keep `ambiguous_multi_project_scope` in the legacy projection and continue suppressing recipient inference and actionable migration decisions for affected Projects. Do not convert this diagnostic into a repairable blocked review item. Count it in the existing collapsed `legacy_access_preserved` continuity message instead, so the ambiguity remains observable without producing one false repair card per Project.
+Keep `ambiguous_multi_project_scope` in the legacy projection and continue suppressing recipient inference and actionable migration decisions for affected Projects. For known legacy umbrella scope kinds (`user`, `personal`, `team`, `team_default`, `org`, and `client`), do not convert this diagnostic into a repairable blocked review item. Count it in the existing collapsed `legacy_access_preserved` continuity message instead, so the ambiguity remains observable without producing one false repair card per Project. A collision in a project-specific `managed_project` scope remains repairable, and unknown future scope kinds fail closed as repairable rather than being assumed to be umbrellas.
 
 Treat `wildcard_scope_mapping` the same way: a deliberate catch-all mapping can be ambiguous for recipient migration without being broken. Continue producing blocked review items for source-state defects that have a concrete repair path, including noncanonical Project identities, conflicting Project-to-scope mappings, and inactive boundaries.
 
@@ -21,7 +21,7 @@ This changes presentation only. It does not create recipient intent, change curr
 ## Implementation
 
 - Add an exhaustive, typed presentation classification for every `LegacyRecipientPolicyConditionCodeV1`: actionable, repairable blocked, or preserved continuity. Adding a future condition code must fail compilation until its presentation is selected explicitly.
-- Classify exactly `ambiguous_multi_project_scope` and `wildcard_scope_mapping` as preserved continuity; classify noncanonical identities, conflicting mappings, and inactive boundaries as repairable blocked conditions.
+- Classify `ambiguous_multi_project_scope` as preserved continuity only for legacy umbrella scope kinds, and keep a `managed_project` collision repairable. Classify `wildcard_scope_mapping` as preserved continuity; classify noncanonical identities, conflicting mappings, and inactive boundaries as repairable blocked conditions.
 - Count suppressed diagnostics in the existing `continuity.findingCount` alongside unresolved deferred review items.
 - Preserve the existing `hasDiagnostic` gate so ambiguous Projects remain fail-closed and do not gain actionable review options.
 - When continuity and genuine blocked items coexist, title the surface `Sharing needs repair` and retain the deferred-finding count. Suppress the continuity-only `No action is required` introduction in this mixed state so the copy does not contradict the repair cards.
@@ -30,7 +30,7 @@ This changes presentation only. It does not create recipient intent, change curr
 - Preserve blocked-card coverage for a genuinely noncanonical Project identity and UI coverage for continuity-only and mixed states. The mixed-state test must intentionally replace its previous `Existing sharing kept as-is` and `No action is required` expectations.
 - Cover the exhaustive presentation classification so a newly added condition code cannot silently disappear from review.
 
-The response shape and contract version remain unchanged. `continuity` is already an additive V1 field; this patch only corrects which legacy findings contribute to it versus `blockedItems`.
+The review response shape and contract version remain unchanged. The legacy projection condition shape is additively extended with optional `scopeKinds` evidence. `continuity` is already an additive V1 field; this patch only corrects which legacy findings contribute to it versus `blockedItems`.
 
 ## Validation
 

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.40.1";
+const PINNED_BACKEND_VERSION = "0.40.2";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.40.1",
+	"version": "0.40.2",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.40.1",
+	"version": "0.40.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.40.1");
+		expect(VERSION).toBe("0.40.2");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.40.1";
+export const VERSION = "0.40.2";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/core/src/legacy-recipient-policy-projection.ts
+++ b/packages/core/src/legacy-recipient-policy-projection.ts
@@ -86,6 +86,7 @@ export interface LegacyRecipientPolicyConditionV1 {
 	code: LegacyRecipientPolicyConditionCodeV1;
 	kind: "actionable" | "diagnostic";
 	message: string;
+	scopeKinds?: string[];
 }
 
 export interface LegacyRecipientPolicyProjectionV1 {
@@ -165,6 +166,19 @@ export interface LegacyRecipientPolicySnapshot {
 export interface ListLegacyRecipientPolicyProjectionsOptions {
 	localActorId: string;
 	localDeviceId: string;
+}
+
+const LEGACY_UMBRELLA_SCOPE_KINDS = new Set([
+	"user",
+	"personal",
+	"team",
+	"team_default",
+	"org",
+	"client",
+]);
+
+export function isLegacyUmbrellaScopeKind(kind: string): boolean {
+	return LEGACY_UMBRELLA_SCOPE_KINDS.has(kind);
 }
 
 function clean(value: unknown): string | null {
@@ -268,14 +282,21 @@ function condition(
 	code: LegacyRecipientPolicyConditionCodeV1,
 	kind: LegacyRecipientPolicyConditionV1["kind"],
 	message: string,
+	scopeKinds?: string[],
 ): LegacyRecipientPolicyConditionV1 {
-	return { version: RECIPIENT_POLICY_CONTRACT_VERSION, code, kind, message };
+	return {
+		version: RECIPIENT_POLICY_CONTRACT_VERSION,
+		code,
+		kind,
+		message,
+		...(scopeKinds?.length ? { scopeKinds } : {}),
+	};
 }
 
 function blockingConditions(input: {
 	ambiguousScopeMapping: boolean;
 	inactiveScopeBoundary: boolean;
-	multiProjectScope: boolean;
+	multiProjectScopeKinds: string[];
 	noncanonicalProjectIdentity: boolean;
 	wildcardMapping: boolean;
 }): LegacyRecipientPolicyConditionV1[] {
@@ -287,11 +308,12 @@ function blockingConditions(input: {
 					"This Project has no stable canonical identity, so no recipient is inferred.",
 				)
 			: null,
-		input.multiProjectScope
+		input.multiProjectScopeKinds.length > 0
 			? condition(
 					"ambiguous_multi_project_scope",
 					"diagnostic",
 					"Current enforcement contains multiple canonical Projects, so recipients remain unresolved.",
+					input.multiProjectScopeKinds,
 				)
 			: null,
 		input.wildcardMapping
@@ -537,11 +559,13 @@ export function projectLegacyRecipientPolicyProjections(
 			const inactiveScopeBoundary = scopeIds.some(
 				(scopeId) => scopeId !== LOCAL_DEFAULT_SCOPE_ID && !scopes.has(scopeId),
 			);
-			const multiProjectScope = relevantScopes.some(
+			const multiProjectScopes = relevantScopes.filter(
 				(scope) =>
 					scope.scopeId !== LOCAL_DEFAULT_SCOPE_ID &&
 					(projectsByScope.get(scope.scopeId)?.size ?? 0) > 1,
 			);
+			const multiProjectScope = multiProjectScopes.length > 0;
+			const multiProjectScopeKinds = uniqueSorted(multiProjectScopes.map((scope) => scope.kind));
 			const managedScopes = relevantScopes.filter((scope) => scope.kind === "managed_project");
 			const mappedScopeIds = uniqueSorted(exactMappings.map((mapping) => mapping.scopeId));
 			const multipleScopeBoundaries =
@@ -590,7 +614,7 @@ export function projectLegacyRecipientPolicyProjections(
 				ambiguousScopeMapping:
 					!managedExact && (exactMappings.length > 1 || multipleScopeBoundaries),
 				inactiveScopeBoundary,
-				multiProjectScope,
+				multiProjectScopeKinds,
 				noncanonicalProjectIdentity: project.identitySource === "unmapped",
 				wildcardMapping,
 			});

--- a/packages/core/src/recipient-policy-migration.test.ts
+++ b/packages/core/src/recipient-policy-migration.test.ts
@@ -684,7 +684,7 @@ describe("recipient policy intent migration", () => {
 		expect(db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(0);
 	});
 
-	it("never writes diagnostic-only blocked Projects", () => {
+	it("keeps preserved diagnostic-only Projects skipped without migration evidence", () => {
 		const scopeId = "ambiguous-scope";
 		for (const projectId of [
 			"https://git.example.invalid/acme/blocked-one.git",
@@ -708,9 +708,28 @@ describe("recipient policy intent migration", () => {
 			}
 		}
 
+		const projections = listLegacyRecipientPolicyProjections(db, context);
+		const review = listRecipientPolicyReview(db, context);
 		const result = migrateRecipientPolicyIntent(db, context);
 
-		expect(result.results.every((entry) => entry.status === "skipped")).toBe(true);
+		expect(
+			projections.every((projection) =>
+				projection.conditions.some(
+					(condition) => condition.code === "ambiguous_multi_project_scope",
+				),
+			),
+		).toBe(true);
+		expect(review).toMatchObject({
+			blockedItems: [],
+			continuity: { findingCount: 2, state: "legacy_access_preserved" },
+			reviewItems: [],
+		});
+		expect(result.results).toHaveLength(2);
+		expect(
+			result.results.every(
+				(entry) => entry.status === "skipped" && entry.errorCode === "migration_evidence_missing",
+			),
+		).toBe(true);
 		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
 		expect(db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(0);
 	});

--- a/packages/core/src/recipient-policy-review.test.ts
+++ b/packages/core/src/recipient-policy-review.test.ts
@@ -1,7 +1,11 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { LegacyRecipientPolicyProjectionV1 } from "./legacy-recipient-policy-projection.js";
 import {
+	type LegacyRecipientPolicyProjectionV1,
+	listLegacyRecipientPolicyProjections,
+} from "./legacy-recipient-policy-projection.js";
+import {
+	deriveRecipientPolicyReviewState,
 	listRecipientPolicyReview,
 	recipientPolicyReviewSourceFingerprint,
 	resolveRecipientPolicyReview,
@@ -92,6 +96,51 @@ function insertLocalFixture(db: InstanceType<typeof Database>): void {
 			visibility, project, scope_id
 		 ) VALUES (?, 'discovery', 'Review fixture', 'body', 1, ?, ?, 'private', 'review', 'local-default')`,
 	).run(sessionId, NOW, NOW);
+}
+
+function insertLegacyScope(db: InstanceType<typeof Database>, scopeId: string): void {
+	db.prepare(
+		`INSERT INTO replication_scopes(
+			scope_id, label, kind, authority_type, coordinator_id, group_id,
+			membership_epoch, status, created_at, updated_at
+		 ) VALUES (?, ?, 'team', 'coordinator', 'coordinator', 'group', 1, 'active', ?, ?)`,
+	).run(scopeId, scopeId, NOW, NOW);
+}
+
+function mapProject(
+	db: InstanceType<typeof Database>,
+	projectId: string | null,
+	projectPattern: string,
+	scopeId: string,
+): void {
+	db.prepare(
+		`INSERT INTO project_scope_mappings(
+			workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+		 ) VALUES (?, ?, ?, 1000, 'test', ?, ?)`,
+	).run(projectId, projectPattern, scopeId, NOW, NOW);
+}
+
+function configureUmbrellaScope(db: InstanceType<typeof Database>): void {
+	const scopeId = "legacy-umbrella";
+	const secondProjectId = "https://git.example.invalid/acme/review-second.git";
+	insertLegacyScope(db, scopeId);
+	db.prepare("UPDATE memory_items SET scope_id = ?").run(scopeId);
+	mapProject(db, PROJECT_ID, PROJECT_ID, scopeId);
+	const sessionId = Number(
+		db
+			.prepare(
+				`INSERT INTO sessions(started_at, cwd, project, git_remote, git_branch)
+				 VALUES (?, '/workspace/review-second', 'review-second', ?, 'main')`,
+			)
+			.run(NOW, secondProjectId).lastInsertRowid,
+	);
+	db.prepare(
+		`INSERT INTO memory_items(
+			session_id, kind, title, body_text, active, created_at, updated_at,
+			visibility, project, scope_id
+		 ) VALUES (?, 'discovery', 'Second fixture', 'body', 1, ?, ?, 'shared', 'review-second', ?)`,
+	).run(sessionId, NOW, NOW, scopeId);
+	mapProject(db, secondProjectId, secondProjectId, scopeId);
 }
 
 function configureUnassignedDeviceReview(
@@ -262,6 +311,84 @@ describe("recipient policy review persistence", () => {
 			repairAction: expect.any(String),
 		});
 		expect(result.blockedItems[0]).not.toHaveProperty("options");
+	});
+
+	it("keeps an ambiguous umbrella scope as continuity without repair cards", () => {
+		configureUmbrellaScope(db);
+
+		const projections = listLegacyRecipientPolicyProjections(db, context);
+		const result = listRecipientPolicyReview(db, context);
+
+		expect(projections).toHaveLength(2);
+		expect(
+			projections.every(
+				(item) =>
+					item.enforcement.state === "ambiguous" &&
+					item.enforcement.safeErrorCode === "ambiguous_multi_project_scope",
+			),
+		).toBe(true);
+		expect(result).toMatchObject({
+			blockedItems: [],
+			continuity: { findingCount: 2, state: "legacy_access_preserved" },
+			reviewItems: [],
+		});
+	});
+
+	it("keeps a wildcard scope mapping as continuity without repair cards", () => {
+		const scopeId = "legacy-wildcard";
+		insertLegacyScope(db, scopeId);
+		db.prepare("UPDATE memory_items SET scope_id = ?").run(scopeId);
+		mapProject(db, null, "*", scopeId);
+
+		const [legacyProjection] = listLegacyRecipientPolicyProjections(db, context);
+		const result = listRecipientPolicyReview(db, context);
+
+		expect(legacyProjection?.enforcement).toMatchObject({
+			state: "ambiguous",
+			safeErrorCode: "wildcard_scope_mapping",
+		});
+		expect(result).toMatchObject({
+			blockedItems: [],
+			continuity: { findingCount: 1, state: "legacy_access_preserved" },
+			reviewItems: [],
+		});
+	});
+
+	it("emits only repairable cards for mixed diagnostics and keeps blocked IDs stable", () => {
+		const repairableCondition = {
+			version: 1 as const,
+			code: "noncanonical_project_identity" as const,
+			kind: "diagnostic" as const,
+			message: "Project identity is unstable.",
+		};
+		const mixed = projection();
+		mixed.conditions = [
+			repairableCondition,
+			{
+				version: 1,
+				code: "ambiguous_multi_project_scope",
+				kind: "diagnostic",
+				message: "Scope contains multiple Projects.",
+			},
+			...mixed.conditions,
+		];
+		const repairableOnly = projection();
+		repairableOnly.conditions = [repairableCondition];
+
+		const mixedState = deriveRecipientPolicyReviewState(db, context, [mixed]);
+		const repairableState = deriveRecipientPolicyReviewState(db, context, [repairableOnly]);
+
+		expect(mixedState.allReviewItems).toEqual([]);
+		expect(mixedState.preservedDiagnosticFindings).toEqual([
+			{
+				canonicalProjectIdentity: PROJECT_ID,
+				conditionCode: "ambiguous_multi_project_scope",
+			},
+		]);
+		expect(mixedState.blockedItems).toHaveLength(1);
+		expect(mixedState.blockedItems[0]?.blockedItemId).toBe(
+			repairableState.blockedItems[0]?.blockedItemId,
+		);
 	});
 
 	it("records only the immutable resolution with server-derived attribution", () => {

--- a/packages/core/src/recipient-policy-review.test.ts
+++ b/packages/core/src/recipient-policy-review.test.ts
@@ -98,13 +98,17 @@ function insertLocalFixture(db: InstanceType<typeof Database>): void {
 	).run(sessionId, NOW, NOW);
 }
 
-function insertLegacyScope(db: InstanceType<typeof Database>, scopeId: string): void {
+function insertLegacyScope(
+	db: InstanceType<typeof Database>,
+	scopeId: string,
+	kind = "team",
+): void {
 	db.prepare(
 		`INSERT INTO replication_scopes(
 			scope_id, label, kind, authority_type, coordinator_id, group_id,
 			membership_epoch, status, created_at, updated_at
-		 ) VALUES (?, ?, 'team', 'coordinator', 'coordinator', 'group', 1, 'active', ?, ?)`,
-	).run(scopeId, scopeId, NOW, NOW);
+		 ) VALUES (?, ?, ?, 'coordinator', 'coordinator', 'group', 1, 'active', ?, ?)`,
+	).run(scopeId, scopeId, kind, NOW, NOW);
 }
 
 function mapProject(
@@ -120,10 +124,10 @@ function mapProject(
 	).run(projectId, projectPattern, scopeId, NOW, NOW);
 }
 
-function configureUmbrellaScope(db: InstanceType<typeof Database>): void {
+function configureUmbrellaScope(db: InstanceType<typeof Database>, kind = "team"): void {
 	const scopeId = "legacy-umbrella";
 	const secondProjectId = "https://git.example.invalid/acme/review-second.git";
-	insertLegacyScope(db, scopeId);
+	insertLegacyScope(db, scopeId, kind);
 	db.prepare("UPDATE memory_items SET scope_id = ?").run(scopeId);
 	mapProject(db, PROJECT_ID, PROJECT_ID, scopeId);
 	const sessionId = Number(
@@ -334,6 +338,32 @@ describe("recipient policy review persistence", () => {
 		});
 	});
 
+	it.each([
+		"managed_project",
+		"future_project_boundary",
+	])("keeps a %s multi-project scope repairable", (kind) => {
+		configureUmbrellaScope(db, kind);
+
+		const result = listRecipientPolicyReview(db, context);
+
+		expect(result).toMatchObject({
+			blockedItems: [
+				{
+					ownerLabel: "Local administrator",
+					repairAction:
+						"Assign each Project to its own managed scope and move its memories out of the shared boundary.",
+				},
+				{
+					ownerLabel: "Local administrator",
+					repairAction:
+						"Assign each Project to its own managed scope and move its memories out of the shared boundary.",
+				},
+			],
+			continuity: null,
+			reviewItems: [],
+		});
+	});
+
 	it("keeps a wildcard scope mapping as continuity without repair cards", () => {
 		const scopeId = "legacy-wildcard";
 		insertLegacyScope(db, scopeId);
@@ -369,6 +399,7 @@ describe("recipient policy review persistence", () => {
 				code: "ambiguous_multi_project_scope",
 				kind: "diagnostic",
 				message: "Scope contains multiple Projects.",
+				scopeKinds: ["team"],
 			},
 			...mixed.conditions,
 		];

--- a/packages/core/src/recipient-policy-review.ts
+++ b/packages/core/src/recipient-policy-review.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { Database } from "./db.js";
 import {
+	isLegacyUmbrellaScopeKind,
 	type LegacyRecipientPolicyConditionCodeV1,
 	type LegacyRecipientPolicyConditionV1,
 	type LegacyRecipientPolicyProjectionV1,
@@ -109,7 +110,7 @@ const CONDITION_PRESENTATION = {
 	suggest_local_identity: "actionable",
 	suggest_team_candidate: "actionable",
 	unassigned_effective_device: "actionable",
-	ambiguous_multi_project_scope: "preserved_continuity",
+	ambiguous_multi_project_scope: "repairable_blocked",
 	wildcard_scope_mapping: "preserved_continuity",
 	noncanonical_project_identity: "repairable_blocked",
 	ambiguous_scope_mapping: "repairable_blocked",
@@ -118,6 +119,20 @@ const CONDITION_PRESENTATION = {
 	LegacyRecipientPolicyConditionCodeV1,
 	RecipientPolicyConditionPresentation
 >;
+
+function conditionPresentation(
+	condition: LegacyRecipientPolicyConditionV1,
+): RecipientPolicyConditionPresentation {
+	if (
+		condition.code === "ambiguous_multi_project_scope" &&
+		condition.scopeKinds != null &&
+		condition.scopeKinds.length > 0 &&
+		condition.scopeKinds.every(isLegacyUmbrellaScopeKind)
+	) {
+		return "preserved_continuity";
+	}
+	return CONDITION_PRESENTATION[condition.code];
+}
 
 function canonicalJson(value: unknown): string {
 	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
@@ -329,22 +344,34 @@ function blockedOwner(code: LegacyRecipientPolicyConditionCodeV1): {
 	ownerLabel: string;
 	repairAction: string;
 } {
-	if (code === "noncanonical_project_identity") {
-		return {
-			ownerLabel: "Project owner",
-			repairAction: "Assign a stable canonical Project identity.",
-		};
+	switch (code) {
+		case "noncanonical_project_identity":
+			return {
+				ownerLabel: "Project owner",
+				repairAction: "Assign a stable canonical Project identity.",
+			};
+		case "inactive_scope_boundary":
+			return {
+				ownerLabel: "Scope owner",
+				repairAction: "Restore or replace the inactive enforcement boundary.",
+			};
+		case "ambiguous_multi_project_scope":
+			return {
+				ownerLabel: "Local administrator",
+				repairAction:
+					"Assign each Project to its own managed scope and move its memories out of the shared boundary.",
+			};
+		case "ambiguous_scope_mapping":
+			return {
+				ownerLabel: "Local administrator",
+				repairAction: "Repair the ambiguous legacy Project-to-scope mapping in Advanced settings.",
+			};
+		case "suggest_local_identity":
+		case "suggest_team_candidate":
+		case "unassigned_effective_device":
+		case "wildcard_scope_mapping":
+			throw new Error(`Condition ${code} is not repairable.`);
 	}
-	if (code === "inactive_scope_boundary") {
-		return {
-			ownerLabel: "Scope owner",
-			repairAction: "Restore or replace the inactive enforcement boundary.",
-		};
-	}
-	return {
-		ownerLabel: "Local administrator",
-		repairAction: "Repair the ambiguous legacy Project-to-scope mapping in Advanced settings.",
-	};
 }
 
 export function deriveRecipientPolicyReviewState(
@@ -363,7 +390,7 @@ export function deriveRecipientPolicyReviewState(
 			(condition) => condition.kind === "diagnostic",
 		);
 		for (const condition of projection.conditions) {
-			const presentation = CONDITION_PRESENTATION[condition.code];
+			const presentation = conditionPresentation(condition);
 			if (presentation === "preserved_continuity") {
 				preservedDiagnosticFindings.push({
 					canonicalProjectIdentity: projection.project.canonicalIdentity,

--- a/packages/core/src/recipient-policy-review.ts
+++ b/packages/core/src/recipient-policy-review.ts
@@ -76,6 +76,10 @@ export interface RecipientPolicyReviewBulkResultV1 {
 export interface RecipientPolicyDerivedReviewState {
 	allReviewItems: RecipientPolicyActionableReviewItemV1[];
 	blockedItems: RecipientPolicyBlockedItemV1[];
+	preservedDiagnosticFindings: Array<{
+		canonicalProjectIdentity: string;
+		conditionCode: LegacyRecipientPolicyConditionCodeV1;
+	}>;
 }
 
 interface StoredResolution {
@@ -95,6 +99,25 @@ const DECISIONS = new Set<RecipientPolicyReviewDecisionV1>([
 	"create_identity",
 	"remove_stale_device",
 ]);
+
+type RecipientPolicyConditionPresentation =
+	| "actionable"
+	| "repairable_blocked"
+	| "preserved_continuity";
+
+const CONDITION_PRESENTATION = {
+	suggest_local_identity: "actionable",
+	suggest_team_candidate: "actionable",
+	unassigned_effective_device: "actionable",
+	ambiguous_multi_project_scope: "preserved_continuity",
+	wildcard_scope_mapping: "preserved_continuity",
+	noncanonical_project_identity: "repairable_blocked",
+	ambiguous_scope_mapping: "repairable_blocked",
+	inactive_scope_boundary: "repairable_blocked",
+} as const satisfies Record<
+	LegacyRecipientPolicyConditionCodeV1,
+	RecipientPolicyConditionPresentation
+>;
 
 function canonicalJson(value: unknown): string {
 	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
@@ -332,13 +355,23 @@ export function deriveRecipientPolicyReviewState(
 	const memoryCounts = memoryCountsByProject(db);
 	const allReviewItems: RecipientPolicyActionableReviewItemV1[] = [];
 	const blockedItems: RecipientPolicyBlockedItemV1[] = [];
+	const preservedDiagnosticFindings: RecipientPolicyDerivedReviewState["preservedDiagnosticFindings"] =
+		[];
 	for (const projection of projections) {
 		const memoryCount = memoryCounts.get(projection.project.canonicalIdentity) ?? 0;
 		const hasDiagnostic = projection.conditions.some(
 			(condition) => condition.kind === "diagnostic",
 		);
 		for (const condition of projection.conditions) {
-			if (condition.kind === "diagnostic") {
+			const presentation = CONDITION_PRESENTATION[condition.code];
+			if (presentation === "preserved_continuity") {
+				preservedDiagnosticFindings.push({
+					canonicalProjectIdentity: projection.project.canonicalIdentity,
+					conditionCode: condition.code,
+				});
+				continue;
+			}
+			if (presentation === "repairable_blocked") {
 				blockedItems.push({
 					version: RECIPIENT_POLICY_CONTRACT_VERSION,
 					blockedItemId: digest("recipient-policy-blocked-v1", [
@@ -391,7 +424,7 @@ export function deriveRecipientPolicyReviewState(
 			}
 		}
 	}
-	return { allReviewItems, blockedItems };
+	return { allReviewItems, blockedItems, preservedDiagnosticFindings };
 }
 
 function hasResolution(db: Database, item: RecipientPolicyActionableReviewItemV1): boolean {
@@ -411,7 +444,7 @@ export function listRecipientPolicyReview(
 ): RecipientPolicyReviewListV1 {
 	const state = deriveRecipientPolicyReviewState(db, context);
 	const reviewItems = state.allReviewItems.filter((item) => !hasResolution(db, item));
-	const findingCount = reviewItems.length;
+	const findingCount = reviewItems.length + state.preservedDiagnosticFindings.length;
 	return {
 		version: RECIPIENT_POLICY_CONTRACT_VERSION,
 		reviewItems,

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.40.1",
+	"version": "0.40.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.40.1";
+const PINNED_BACKEND_VERSION = "0.40.2";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 const CODEMEM_CONTEXT_PART_ID_PREFIX = "codemem-context-";

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.40.1",
+	"version": "0.40.2",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -335,7 +335,7 @@ describe("Projects tab", () => {
 		expect(document.getElementById("projectsInventorySkeleton")).toBeNull();
 	});
 
-	it("collapses deferred migration evidence into one continuity message without controls", async () => {
+	it("renders mixed continuity and repair state without contradictory copy", async () => {
 		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
 			has_more: false,
 			limit: 250,
@@ -361,8 +361,9 @@ describe("Projects tab", () => {
 		await loadProjectsData();
 
 		const surface = document.querySelector(".recipient-policy-review");
-		expect(surface?.textContent).toContain("Existing sharing kept as-is");
-		expect(surface?.textContent).toContain("No action is required for this update");
+		expect(surface?.textContent).toContain("Sharing needs repair");
+		expect(surface?.textContent).not.toContain("Existing sharing kept as-is");
+		expect(surface?.textContent).not.toContain("No action is required for this update");
 		expect(surface?.textContent).toContain("37 older sharing findings were not changed");
 		expect(surface?.textContent).toContain("current availability cannot be confirmed");
 		expect(surface?.textContent).not.toContain("Current access remains in place");
@@ -384,6 +385,8 @@ describe("Projects tab", () => {
 
 		await loadProjectsData();
 		const firstSurface = document.querySelector(".recipient-policy-review");
+		expect(firstSurface?.textContent).toContain("Existing sharing kept as-is");
+		expect(firstSurface?.textContent).toContain("No action is required for this update");
 
 		await loadProjectsData();
 

--- a/packages/ui/src/tabs/recipient-policy-review.ts
+++ b/packages/ui/src/tabs/recipient-policy-review.ts
@@ -49,14 +49,11 @@ export function renderRecipientPolicyReview(
 	surface.setAttribute("aria-labelledby", "recipientPolicyReviewTitle");
 	const title = document.createElement("h2");
 	title.id = "recipientPolicyReviewTitle";
-	title.textContent = review.continuity ? "Existing sharing kept as-is" : "Sharing needs repair";
+	title.textContent =
+		review.blockedItems.length > 0 ? "Sharing needs repair" : "Existing sharing kept as-is";
 	surface.appendChild(title);
 
 	if (review.continuity) {
-		const intro = paragraph(
-			"No action is required for this update. Codemem did not change your existing Team or local sharing configuration.",
-			"section-meta",
-		);
 		const findingCount = review.continuity.findingCount;
 		const detail = paragraph(
 			`${findingCount.toLocaleString()} older sharing finding${findingCount === 1 ? " was" : "s were"} not changed because Codemem could not safely translate ${findingCount === 1 ? "it" : "them"} automatically.`,
@@ -64,7 +61,15 @@ export function renderRecipientPolicyReview(
 		);
 		detail.setAttribute("role", "status");
 		detail.setAttribute("aria-live", "polite");
-		surface.append(intro, detail);
+		if (review.blockedItems.length === 0) {
+			surface.appendChild(
+				paragraph(
+					"No action is required for this update. Codemem did not change your existing Team or local sharing configuration.",
+					"section-meta",
+				),
+			);
+		}
+		surface.appendChild(detail);
 	}
 
 	if (review.blockedItems.length > 0) {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.40.1",
+	"version": "0.40.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "author": {
     "name": "Adam Kunicki"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codemem",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "description": "Persistent memory for Codex. Capture work across sessions and recall relevant context.",
   "author": {
     "name": "Adam Kunicki"


### PR DESCRIPTION
## Description

Treat supported multi-project and wildcard recipient-policy diagnostics as preserved continuity findings instead of repair-blocking cards. Keep migration fail-closed, count preserved findings alongside deferred review items, update mixed-state UI copy, and align release metadata at 0.40.2.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated from a clean standalone checkout named `codemem`:
- `pnpm run build`
- `pnpm run check` — 177 files passed; 3,914 tests passed; 3 todo
- `pnpm run release:version -- check` — aligned at 0.40.2
- Independent code review: approved with no blocking findings

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced