### PR TITLE
docs: define focused 0.41 recall roadmap

### DIFF
--- a/docs/plans/2026-04-08-pack-trace-context-inspector-design.md
+++ b/docs/plans/2026-04-08-pack-trace-context-inspector-design.md
@@ -1,8 +1,19 @@
 # Pack Trace and Context Inspector Design
 
-**Status:** Approved design
+**Status:** Implemented through the viewer panel; compression rendering incomplete
 **Date:** 2026-04-08
 **Related bead:** `codemem-ei1c`
+
+## Implementation status (2026-08-10)
+
+PackTrace, `codemem pack trace`, `POST /api/pack/trace`, and the viewer Context
+Inspector are shipped. The panel lives in Feed rather than the originally
+proposed Search entry point.
+
+The current UI contract predates near-duplicate compression: it omits the
+`compressed` candidate disposition and `assembly.compressed_clusters`, so
+compressed candidates are not rendered. That narrow parity gap is tracked for
+0.41; the broader Doctor surface remains deferred.
 
 ## Context
 
@@ -38,8 +49,8 @@ first-class inspectable product. We should not copy noisy log spam.
 - Make pack generation inspectable for a manual query
 - Show a wider retrieval pool, not only final selected items
 - Preserve both machine-readable and human-readable diagnostics
-- Reuse one canonical trace object across CLI and future viewer surfaces
-- Prepare for a future viewer **Context Inspector** entered from Search
+- Reuse one canonical trace object across CLI and viewer surfaces
+- Prepare the viewer **Context Inspector** that ultimately shipped in Feed
 - Leave room for a broader future **Doctor** diagnostics surface
 
 ## Non-Goals
@@ -52,10 +63,12 @@ first-class inspectable product. We should not copy noisy log spam.
 
 ## Design Decision
 
-Add a canonical **PackTrace** diagnostic object in core, then expose it through:
+The original decision was to add a canonical **PackTrace** diagnostic object in
+core, then expose it through:
 
 1. **CLI first** via `codemem pack trace "<query>"`
-2. **Viewer later** via a Context Inspector panel entered from Search
+2. **Viewer later** via a Context Inspector panel; the shipped implementation
+   ultimately used Feed rather than Search
 
 The trace object is the source of truth. Human-readable output is derived from
 it rather than maintained as a separate logic path.
@@ -79,10 +92,10 @@ This should answer the practical questions quickly:
 - Did token-budget trimming remove it?
 - Did the final pack text actually contain it?
 
-### Future viewer workflow
+### Original viewer workflow proposal (superseded — shipped in Feed)
 
-The viewer gets a **Context Inspector** panel attached to Search rather than a
-new top-level tab.
+The original proposal placed a **Context Inspector** panel in Search rather than
+a new top-level tab. The shipped panel is embedded in Feed.
 
 That panel should support manual query inspection first. It can later expand to
 historical prompt inspection and broader doctor-style diagnostics.
@@ -211,6 +224,7 @@ Recommended default pool size: **top 20 candidates**.
   - `dropped`
   - `deduped`
   - `trimmed`
+  - `compressed`
 - `section` is present only when the candidate is selected into a final pack
   section
 
@@ -308,10 +322,11 @@ Final pack
 ...
 ```
 
-## Viewer Follow-On: Context Inspector
+## Viewer Follow-On: Context Inspector (shipped with a different entry point)
 
-The future viewer surface should be a **panel entered from Search**, not a new
-top-level tab.
+The design proposed a panel entered from Search. The shipped panel is embedded in
+Feed and consumes the same PackTrace JSON. This section records the original UX
+rationale rather than current placement.
 
 ### Why Search first
 
@@ -346,21 +361,21 @@ That broader doctor surface is intentionally out of scope for v1.
 
 ## Implementation Plan
 
-### Phase 1: Core trace contract
+### Phase 1: Core trace contract ✅ shipped
 
 - add PackTrace types to core
 - plumb trace capture through pack building without changing normal pack output
 - expose enough ranking and assembly metadata to explain outcomes
 
-### Phase 2: CLI trace command
+### Phase 2: CLI trace command ✅ shipped
 
 - add `codemem pack trace "<query>"`
 - support text and JSON output modes
 - keep normal pack command behavior unchanged
 
-### Phase 3: Viewer Context Inspector panel
+### Phase 3: Viewer Context Inspector panel ✅ shipped in Feed
 
-- add a Search entry point for manual query inspection
+- add a Feed entry point for manual query inspection (the shipped placement)
 - render canonical PackTrace JSON in the viewer
 - keep this as a panel/debug surface rather than a new primary tab
 
@@ -387,7 +402,7 @@ Minimum required coverage:
 
 ### Viewer follow-on tests
 
-- Search entry opens Context Inspector panel
+- Feed entry opens Context Inspector panel
 - manual query inspector renders candidate list and final pack text
 - viewer consumes the canonical JSON shape rather than recreating pack logic
 
@@ -405,7 +420,7 @@ Spin implementation out from `codemem-ei1c` into these follow-on tasks:
 
 1. `codemem-zm46` — core PackTrace contract and pack instrumentation
 2. `codemem-5prk` — CLI `codemem pack trace` command surface
-3. `codemem-b1wo` — viewer Context Inspector panel entered from Search
+3. `codemem-b1wo` — viewer Context Inspector panel (shipped in Feed)
 4. `codemem-dcho` — future doctor-style diagnostics follow-on
 
 These should be linked back to the parent design bead using

--- a/docs/plans/2026-04-08-pack-usefulness-roadmap.md
+++ b/docs/plans/2026-04-08-pack-usefulness-roadmap.md
@@ -1,6 +1,6 @@
 # Pack Usefulness Roadmap
 
-**Status:** Approved design
+**Status:** Shipped — Phases D, A, and B
 **Date:** 2026-04-08
 
 ## Context
@@ -86,8 +86,8 @@ access, inspired by claude-mem's `ID TIME TYPE TITLE` + `get_observations`.
 1. Add a "compact mode" pack option where the pack text contains:
    - a scannable index section with one line per item: `[ID] (kind) title`
    - full narrative/facts only for the top N items (configurable, default ~3)
-   - a footer note like: "Fetch details for any item via
-     `memory_search` or `memory_get`"
+   - the shipped footer guidance: "Use `memory_get` for one item, or
+     `memory_get_observations(ids=[...])` for related IDs shown in the index."
 2. The default pack mode continues to show full content for all items (the
    current behavior, improved by Phase D).
 3. Compact mode is useful for token-constrained injection where a broad overview
@@ -99,7 +99,15 @@ access, inspired by claude-mem's `ID TIME TYPE TITLE` + `get_observations`.
 - compact mode is opt-in via a flag or pack configuration
 - the index lines use the same `[ID] (kind) title` format as full mode headers
 
-### Phase B: Cross-memory synthesis
+### Phase B: Near-duplicate pack compression
+
+**Status:** Rendering-time cluster compression and ingestion-time near-dedup both
+shipped.
+
+The shipped implementation uses heuristic representative selection with a
+`(+N related)` suffix rather than synthesized summary blocks. The goal and design
+approach below are the original proposal, retained as historical rationale;
+`packages/core/src/pack.ts` and its tests are authoritative.
 
 **Goal:** When multiple retrieved memories point at the same recurring pattern,
 compress them into a concise operational summary instead of listing them
@@ -129,16 +137,19 @@ individually.
 - present synthesized sections before the individual memory listing
 - keep individual memories available for detail
 
-**This phase has been specified** based on a 30-trace empirical audit conducted
-after shipping D and A. See
+This phase was specified from a 30-trace empirical audit conducted after shipping
+D and A. The repository retains the aggregate audit results, but not a runnable
+copy of that historical corpus. See
 [Phase B design doc](./2026-04-08-phase-b-pack-dedup-design.md) for the full
-spec, audit data, and implementation plan.
+historical spec and audit data. Current behavior is authoritative in
+`packages/core/src/pack.ts` and its tests.
 
 ## Implementation Order
 
 1. **Phase D** — restore narrative/facts (quick win, high signal) ✅ shipped
 2. **Phase A** — compact index + fetch-more (token efficiency, broad context) ✅ shipped
-3. **Phase B** — cross-memory synthesis (differentiated product value) — [design ready](./2026-04-08-phase-b-pack-dedup-design.md)
+3. **Phase B Layer 2** — rendering-time near-duplicate compression ✅ shipped
+4. **Phase B Layer 1** — ingestion-time near-deduplication ✅ shipped
 
 ## Files Likely to Change
 
@@ -158,10 +169,15 @@ spec, audit data, and implementation plan.
 - `packages/mcp-server/src/index.ts` — expose compact mode in MCP pack tool
 - `packages/cli/src/commands/pack.ts` — add `--compact` flag
 
-### Phase B
-- `packages/core/src/pack.ts` — add cluster detection and synthesis rendering
-- potentially a new `packages/core/src/pack-synthesis.ts` module
-- test coverage for cluster detection heuristics
+### Phase B Layer 2 (shipped)
+- `packages/core/src/pack.ts` — cluster detection, representative selection, and
+  compressed rendering
+- `packages/core/src/types.ts` — compressed member and PackTrace metadata
+- `packages/core/src/pack.test.ts` — compression modes, task-mode skip, budgeting,
+  and trace coverage
+
+No `pack-synthesis.ts` or LLM synthesis call was added. Layer 1 added the
+`memory_items.dedup_key` column and supporting indexes.
 
 ## Testing Strategy
 
@@ -180,5 +196,7 @@ spec, audit data, and implementation plan.
 
 ### Phase B
 - cluster detection groups related memories correctly
-- synthesis produces concise operational summaries
-- individual memories remain accessible after synthesis
+- the representative is the highest-confidence cluster member and compressed
+  members are excluded from rendered text
+- compressed member IDs remain in `item_ids` when the representative survives
+  budgeting

--- a/docs/plans/2026-04-08-phase-b-pack-dedup-design.md
+++ b/docs/plans/2026-04-08-phase-b-pack-dedup-design.md
@@ -1,10 +1,31 @@
 # Phase B: Pack near-duplicate compression
 
 **Parent:** [Pack usefulness roadmap](./2026-04-08-pack-usefulness-roadmap.md)
-**Status:** Design ready — pending approval
+**Status:** Shipped — Layer 2 pack compression and Layer 1 ingestion dedup
 **Prereqs:** Phase D (shipped), Phase A (shipped)
 
+## Implementation status (2026-08-10)
+
+The rendering-only Layer 2 design ships in `packages/core/src/pack.ts` with
+`off`, `compact`, and `ids` modes, compressed member IDs, and
+`PackTrace.assembly.compressed_clusters`. Task mode skips compression. The normal
+pack response excludes compressed-away members from `items` while retaining
+their IDs when the representative survives budgeting.
+
+Layer 1 ingestion-time near-deduplication ships in
+`packages/core/src/store.ts` through `findExistingDuplicateMemory`, backed by the
+`memory_items.dedup_key` column and indexes added in `packages/core/src/db.ts`.
+The shipped key is `sha256(normalize(title))`; session, scope, visibility, and
+workspace constraints are applied by the lookup rather than encoded in the key.
+Cross-session matching defaults to a one-hour window and can be tuned with
+`CODEMEM_MEMORY_CROSS_SESSION_DEDUP_WINDOW_MS`. There is no LLM synthesis path.
+The design below is retained as historical rationale; current source and tests
+are authoritative where its proposals differ from shipped behavior.
+
 ## Empirical findings
+
+**Historical 2026-04-08 audit; not reproducible from the current repository.** The
+aggregate numbers are retained as design rationale, not current release evidence.
 
 A 30-trace pack audit (spanning task, recall, and default modes across diverse
 queries) produced these results:
@@ -43,7 +64,7 @@ From the 27 all-selected clusters:
 | **Recurring failure** — same bug/fix described twice | 2 | Peer deletion cursor leak: two bugfix memories with near-identical titles |
 | **Thematic overlap** — same investigation from different angles | 2 | Python→TS port footguns: a discovery + an exploration |
 
-### Token savings estimate
+### Historical token savings estimate
 
 The most cluster-heavy traces (sync replication: 4 clusters in 10 items, viewer
 inspector: 5-item cluster) could drop 30–40% in token cost if clusters were
@@ -146,8 +167,10 @@ for each pair of selected items (i, j):
 
 **"Significant words"** = words with length > 2, excluding a stopword set
 (the, a, an, and, or, to, in, for, of, on, with, is, was, are, were, from,
-this, that, it, not, no). This is the exact heuristic used in the audit and it
-caught all 27 real clusters with zero false positives across 30 traces.
+this, that, it, not, no). This is the exact heuristic used in the historical
+audit, which reported all 27 clusters with zero false positives. The underlying
+corpus is not checked in, so current validation uses deterministic fixtures rather
+than repeating that claim.
 
 **Transitive closure:** If A clusters with B and B clusters with C, all three
 form one cluster. Use union-find for efficient grouping.
@@ -164,9 +187,10 @@ For each cluster of size ≥ 2:
    existing dedup `support_count` pattern) and a `compressed_ids` list of the
    other cluster members' IDs.
 
-3. **Remove non-representatives** from the rendered pack text. They remain in
-   `item_ids` and `items` (with a `compressed_into` field pointing to the
-   representative) so the model can still fetch them via `memory_get`.
+3. **Remove non-representatives** from the rendered pack text and `items`. They
+   remain in `item_ids` when the representative survives budgeting, and the
+   representative carries `compressed_ids`, so the model can still fetch them via
+   `memory_get`.
 
 4. **Format compressed items** with an indicator:
 
@@ -175,8 +199,8 @@ For each cluster of size ≥ 2:
    The sync pass orchestrator coordinates a complete synchronization exchange...
    ```
 
-   The `(+N related)` suffix signals that more detail exists without consuming
-   extra tokens.
+   The compact `(+N related)` suffix signals that more detail exists at low cost.
+   The shipped `ids` mode appends member IDs and therefore consumes some tokens.
 
 #### Interaction with compact mode
 
@@ -255,8 +279,11 @@ The trace should report compression:
 - Items with < 3 shared words remain separate
 - Representative is highest-confidence member
 - Compressed items get `(+N related)` suffix in pack text
-- `item_ids` still contains all original IDs (including compressed)
-- Compression reduces `pack_tokens` vs. uncompressed
+- `item_ids` retains compressed IDs only when their representative survives
+  budgeting
+- Compression token impact versus uncompressed is not covered by current tests;
+  the deterministic `off`-versus-`ids` net-reduction fixture is tracked in the
+  0.41 plan
 - Task mode skips compression
 - Compact mode: compressed items excluded from index, only representative shown
 - Trace reports `compressed_clusters`
@@ -302,10 +329,8 @@ PR), we can revisit.
 
 ### 3. Compressed items: exclude from `items`, keep in `item_ids`
 
-Compressed-away items are excluded from the `items` response array but remain
-in `item_ids`. The `pack_text` already shows `(+N related)` which signals
-more detail exists, and `item_ids` gives the model IDs to fetch via
-`memory_get`. Adding compressed items to `items` is dead weight in the common
-case where the model trusts the representative. If the "why was this
-compressed" signal is needed, `compressed_clusters` in the response metadata
-(parallel to the trace field) provides it without bloating every item.
+Compressed-away items are excluded from the `items` response array and remain in
+`item_ids` when their representative survives budgeting. The representative
+carries `compressed_ids`, and `pack_text` shows `(+N related)`, so the model can
+fetch details through `memory_get`. Full cluster reasons live in PackTrace only;
+the normal pack response has no top-level `compressed_clusters` field.

--- a/docs/plans/2026-08-10-release-0.41-fast-focused-recall-design.md
+++ b/docs/plans/2026-08-10-release-0.41-fast-focused-recall-design.md
@@ -1,0 +1,261 @@
+# Codemem 0.41: Fast, Focused Recall
+
+**Status:** Approved direction; implementation baseline verified against v0.40.2
+**Date:** 2026-08-10
+**Release target:** 0.41
+
+## Release promise
+
+Codemem delivers useful context faster, avoids repeating the same idea, and
+clearly shows what it supplied.
+
+This is an external-user-value release. It is not a general backlog milestone.
+Work belongs in 0.41 only when it directly improves that promise or closes a
+confirmed security or privacy defect that would make the release unsafe.
+
+## Source-of-truth rule
+
+The implementation baseline in this document was verified against `origin/main`
+at v0.40.2 (`6b3c3d4e`). Current source and tests outrank older roadmap prose and
+Bead descriptions. Historical measurements are labelled as such and are not
+release evidence unless their commands and results are reproduced.
+
+Before implementation, each work unit must record its current source path,
+existing tests, missing behavior, and explicit non-goals. Discovery of an already
+shipped capability narrows the work unit; it does not authorize reimplementation.
+
+## Why this release
+
+Three verified gaps affect the core recall loop:
+
+1. Every new eligible uncached OpenCode injection starts a `codemem pack` CLI
+   process. Successful delivery, skipped attempts, and cache reuse also use the
+   `prompt-pack-ledger` CLI. The long-lived viewer already exposes pack building
+   but does not support the complete injection contract.
+2. A historical 30-trace audit reported substantial repetition in default and
+   recall packs, but its runnable corpus is not checked in. Core subsequently
+   shipped the audited compression behavior; automatic full packs do not enable
+   it by default.
+3. Core already implements the audited cluster-compression heuristic and records
+   `PackTrace.assembly.compressed_clusters`, but its default `compact` setting
+   applies compression only to compact packs. Automatic full packs do not enable
+   it, and the Context Inspector does not render the existing cluster metadata.
+
+One confirmed presentation defect also gates release quality:
+
+- received memories can show raw actor or device identifiers as primary Feed
+  labels.
+
+Recipient-unbound peer signatures remain a P1 security issue, but they use shared
+direct/coordinator canonicalization and a second worker verifier. That work moves
+on an independent security track rather than blocking this recall release on an
+unapproved cryptographic rollout policy.
+
+## How packs work today
+
+All pack surfaces eventually call the shared core pack builder, but they do not
+share one transport or process lifecycle.
+
+| Surface | Current path | Process lifecycle |
+|---|---|---|
+| OpenCode automatic injection | plugin `buildInjectedContext` → `runCli(packArgs)` → `codemem pack`; separate ledger CLI calls | New processes for each uncached pack and subsequent ledger transitions |
+| Claude hook injection | existing `GET /api/pack` HTTP-first path → local core fallback | Viewer when available; one-shot hook fallback |
+| Codex hook injection | existing `GET /api/pack` HTTP-first path → local core fallback | Viewer when available; one-shot hook fallback |
+| CLI `codemem pack` | CLI command → core pack builder | One process per invocation |
+| Viewer `GET /api/pack` | viewer route → shared core builder; no working-set, render-option, or ledger input | Long-lived viewer process |
+| Context Inspector `POST /api/pack/trace` | viewer route → trace builder; no render-option input | Long-lived viewer process |
+| MCP `memory_pack` | MCP handler → shared core retrieval with compact/compression options | Long-lived MCP process |
+
+The viewer therefore already has an HTTP pack endpoint, and core already owns
+both pack and ledger semantics. The 0.41 work adds transport parity and makes the
+OpenCode plugin use it. It does not create a second pack or ledger implementation.
+The embedding client is a process-wide lazy singleton, so the long-lived viewer
+can reuse it while one-shot CLI processes cannot.
+
+Claude/Codex pack fallback and OpenCode raw-event streaming already implement
+HTTP-first/local-fallback patterns. OpenCode pack transport extends those patterns
+instead of designing a new retry subsystem.
+
+## Scope
+
+### 1. Viewer-backed automatic injection
+
+Keep `GET /api/pack` for existing Claude/Codex compatibility. Add a structured
+`POST /api/pack` only because OpenCode injection carries working-set arrays,
+render options, and attempt metadata that do not belong in a query string. Add
+one `POST /api/prompt-pack-ledger` action dispatcher using the same payload and
+core operations as the existing `prompt-pack-ledger` CLI command.
+
+The pack POST request reproduces the effective inputs of the current CLI path:
+
+- context query;
+- limit and token budget;
+- project resolution with the same environment/cwd precedence as the CLI, plus
+  normalized repository-relative working-set paths;
+- prompt-pack attempt identity and bounded ledger metadata.
+
+The response preserves the existing machine-readable pack result, artifact
+fingerprint, and retrieval-ledger conflict semantics. The viewer continues to use
+its long-lived store and process-wide embedding client.
+
+OpenCode automatic injection becomes HTTP-first:
+
+1. request the pack from the configured local viewer;
+2. validate the response before injection;
+3. record attempt, delivery, skipped, and cache-reuse ledger transitions through
+   the viewer rather than spawning `prompt-pack-ledger`;
+4. retry an idempotency conflict with the existing fresh-identity algorithm over
+   HTTP rather than repeating the same conflict through the CLI;
+5. reuse the plugin's existing HTTP backoff and fallback classification patterns;
+6. retain the current CLI paths only when the result is classified retryable,
+   including connection failure, timeout, an older viewer returning 404/405,
+   server failure, or an unusable success response;
+7. treat validated request 4xx responses as terminal contract errors rather than
+   masking them with fallback;
+8. report the existing `{ cause, retryable }` shape through bounded local
+   diagnostics, without expanding the persisted attribution-ledger schema.
+
+Existing cache-reuse, retry identity, handoff confirmation, privacy, and
+non-blocking ledger behavior remain unchanged.
+
+### 2. Enable existing rendering-time compression
+
+Use the shipped Layer 2 pack-time cluster compression instead of implementing a
+second algorithm. Core already provides `compressClusters`, `off`/`compact`/`ids`
+modes, representative selection, compressed member IDs, and PackTrace metadata.
+
+- Add `compression_mode` to viewer pack and trace requests.
+- Add the effective compression mode to PackTrace as an additive version-1 field;
+  older clients ignore it.
+- Export one automatic-compression resolver so OpenCode, Claude, and Codex do not
+  duplicate environment aliases. A valid `CODEMEM_PACK_COMPRESSION` value wins
+  over the automatic default; otherwise automatic full packs request `ids`.
+- Preserve the existing manual CLI/MCP default (`compact`) and explicit
+  `off`/`compact`/`ids` caller overrides.
+- Keep the existing task-mode skip unchanged.
+- Preserve the existing representative, `(+N related)`, compressed member ID,
+  result, and trace contracts.
+- Validate rollout with a documented, reproducible query set and aggregate output;
+  do not cite the historical 30-trace numbers as new release evidence.
+- Make no storage, ingestion, ranking, or authorization changes.
+
+`ids` intentionally renders `(+N related: [id], ...)` rather than the terse
+`(+N related)` suffix. This preserves fetch-more identity but consumes some of the
+tokens compression saves. A deterministic `off` versus `ids` fixture must show a
+net reduction before `ids` becomes the automatic default; otherwise the default
+change is deferred rather than inventing a fourth compression mode in 0.41.
+
+There are no LLM calls, network calls, schema migrations, or writes in this
+compression path.
+
+### 3. Compression explanation
+
+First restore client/server contract parity: the UI type adds the existing
+`compressed` disposition, `assembly.compressed_clusters`, and effective
+compression mode, and the trace request uses the same mode as the pack being
+investigated. For each cluster, show:
+
+- the representative memory;
+- compressed member IDs and available candidate titles;
+- the heuristic pattern and recorded all-cluster overlap terms, labelled as
+  algorithmic evidence rather than a causal explanation;
+- compressed member count and final pack token count.
+
+Current PackTrace does not contain an uncompressed token baseline or pairwise
+cluster edges. The Inspector must not invent token savings or claim that empty
+all-cluster overlap terms fully explain a transitive cluster. Offline rollout
+validation compares `off` and `ids` using the same queries.
+
+This is not a general Context Inspector redesign. Existing unrelated rough edges
+remain follow-up work.
+
+### 4. Release-gating fix
+
+#### Human-readable received-memory identity
+
+Name preservation for direct Project, Team, and add-device onboarding is already
+partially shipped. The remaining gate resolves Feed provenance from trusted actor
+and peer facts, rejects machine-shaped display names at server ingress, and uses a
+safe presentation fallback for legacy malformed rows. Raw UUIDs and
+`local:<uuid>` values remain diagnostics-only.
+
+## Success criteria
+
+### Latency
+
+- OpenCode automatic injection does not start a pack or prompt-pack-ledger CLI
+  process on healthy retrieval, delivery, skipped-attempt, or cache-reuse paths.
+- A documented development benchmark records median and p95 for identical warm
+  healthy-viewer queries through CLI and viewer paths. If viewer median is not
+  lower or healthy-viewer p95 regresses, transport does not ship as a performance
+  improvement. Fallback latency is measured separately.
+- Viewer-unavailable fallback still supplies usable context when the CLI succeeds.
+- Diagnostics emit stable `{ cause, retryable }` values; focused tests cover
+  representative transport, contract, conflict, and fallback failures.
+
+### Pack quality
+
+- A checked-in synthetic fixture contains known clusters and known non-clusters;
+  automatic `ids` compresses exactly the expected groups.
+- Automatic full-pack default/recall paths enable the shipped compression and
+  represent fixture-defined clusters once while retaining member identities
+  in metadata.
+- Task-mode pack text and selection remain unchanged.
+- The same fixture demonstrates a net token reduction for `ids` versus `off`
+  despite related-ID suffixes. No historical percentage is reused.
+
+### Transparency
+
+- The Context Inspector shows which memories were compressed, the representative,
+  and the heuristic evidence actually present in PackTrace.
+- Pack text, response metadata, and trace metadata agree on cluster membership.
+
+### Release safety
+
+- Normal Feed presentation never uses a raw actor/device UUID as its primary
+  identity label.
+- The standard TypeScript quality gate and focused integration tests pass.
+
+## Explicit non-goals
+
+- Further ingestion-time or cross-session near-deduplication beyond the shipped
+  `dedup_key` path.
+- New memory schema or migration work for compression.
+- Outcome-evidence collectors, attribution rules, or randomized efficacy study.
+- Relay transport implementation.
+- Recipient-signature versioning, coordinator canonicalization, or worker verifier
+  changes; these remain on the dedicated P1 security track.
+- Lost-key recovery or healthy-key rotation.
+- Human principal, account linking, OAuth, or OIDC product identity.
+- Teams, Spaces, sharing, pairing, or mDNS expansion unless a blocking regression
+  is discovered.
+- Hosted or multitenant MCP expansion.
+- Broad Context Inspector, Feed, Sync, or settings redesign.
+- Broad backend refactors or generic performance cleanup.
+
+## Delivery sequence
+
+The release has two lanes so unrelated security work does not block review of the
+recall stack.
+
+### Recall lane
+
+1. Record the development transport baseline and add deterministic zero-subprocess
+   tests; do not add a public benchmark CLI command.
+2. Extend and test the existing viewer pack and prompt-pack-ledger HTTP contracts
+   for semantic parity only.
+3. Move OpenCode pack construction and ledger transitions to HTTP-first with
+   classified CLI fallback; verify zero healthy-path subprocesses.
+4. Propagate the existing compression mode through OpenCode, Claude, Codex,
+   viewer, trace, and fallback paths using the shared resolver.
+5. Restore Context Inspector type/rendering parity for existing compression data.
+6. Run the documented latency benchmark and synthetic compression fixture, and
+   publish only measured results in release notes.
+
+### Release-gate lane
+
+1. Fix Feed identity resolution, server display-name validation, and legacy-row
+   fallback with focused regression coverage.
+
+The recall lane and Feed gate must pass before 0.41 is released. Neither absorbs
+deferred work merely because it touches the same files.

--- a/docs/plans/2026-08-10-release-0.41-fast-focused-recall-implementation.md
+++ b/docs/plans/2026-08-10-release-0.41-fast-focused-recall-implementation.md
@@ -1,0 +1,135 @@
+# Codemem 0.41 Fast, Focused Recall: Implementation Plan
+
+**Design:** [Codemem 0.41: Fast, Focused Recall](./2026-08-10-release-0.41-fast-focused-recall-design.md)
+**Status:** Ready for scoped execution
+**Date:** 2026-08-10
+
+## Release work units
+
+### Recall 0: Baseline and deterministic fixtures
+
+**Tracking:** `codemem-83te`, `codemem-2ucx`
+
+- Document a development-only benchmark procedure for identical warm pack queries
+  through the existing CLI and viewer paths; do not add a public CLI command.
+- Record median and p95 for healthy-viewer and fallback paths separately.
+- Add deterministic tests that count pack/ledger subprocess calls.
+- Add a synthetic compression fixture with known clusters and non-clusters.
+- Treat historical latency and 30-trace numbers as rationale only until
+  reproduced.
+
+**Verification:** the fixture is deterministic and privacy-safe; the documented
+measurement does not persist prompt or memory content.
+
+### Recall 1: Viewer pack transport contract
+
+**Tracking:** `codemem-83te`
+
+- Retain `GET /api/pack` for existing Claude/Codex clients and add structured
+  `POST /api/pack` for OpenCode working-set/render/attempt payloads.
+- Add one `POST /api/prompt-pack-ledger` action dispatcher for attempt recording,
+  delivery, skipped attempts, and cache reuse.
+- Reuse the existing core pack builder and long-lived viewer store.
+- Reuse the existing core ledger operations behind `prompt-pack-ledger`.
+- Preserve effective project resolution from environment/cwd, working-set paths,
+  render options, and bounded prompt-pack ledger metadata.
+- Return the existing machine-readable pack result, artifact fingerprint,
+  idempotency-conflict outcome, and stable structured errors.
+- Cover valid requests, invalid fields, ledger conflicts, idempotent ledger
+  transitions, and store failures.
+
+**Verification:** focused viewer route tests, typecheck, lint.
+
+### Recall 2: OpenCode HTTP-first injection
+
+**Tracking:** `codemem-83te`
+
+- Extend the source-of-truth OpenCode plugin's shipped raw-event
+  HTTP/backoff/fallback pattern to pack and ledger payloads.
+- Route attempt recording, delivery confirmation, skipped attempts, and cache
+  reuse through the viewer on the healthy path.
+- Preserve existing query construction, retry identity, cache reuse, handoff, and
+  fallback bytes.
+- Retry ledger conflicts with a fresh identity over HTTP.
+- Reuse the existing `{ cause, retryable }` classification shape; use `pack` and
+  `prompt-pack-ledger` CLI only for retryable transport/protocol failures.
+- Treat validated request 4xx responses as terminal contract failures and record
+  bounded diagnostics without adding outcome-attribution schema.
+- Keep wrapper plugin files as re-exports; do not duplicate implementation.
+
+**Verification:** plugin tests/smoke tests, focused viewer integration tests, warm
+latency comparison against the existing CLI path.
+
+### Recall 3: Enable existing full-pack compression
+
+**Tracking:** `codemem-2ucx`
+
+- Add `compression_mode` to viewer pack and trace request validation.
+- Add the effective compression mode to the additive PackTrace contract.
+- Export one automatic resolver for OpenCode, Claude, and Codex. A valid
+  `CODEMEM_PACK_COMPRESSION` value wins over the automatic default; otherwise
+  automatic full packs request `ids`. The resolved mode is then passed explicitly
+  to core, whose normal explicit-option precedence remains unchanged.
+- Keep manual CLI/MCP default behavior and explicit `off`, `compact`, and `ids`
+  overrides unchanged.
+- Keep the existing task-mode skip, representative selection, member-ID
+  preservation, and result/PackTrace metadata unchanged.
+- Accept the existing verbose related-ID suffix only if the synthetic fixture
+  shows a net token reduction versus `off`.
+- Change the shipped heuristic only if the fixture demonstrates a concrete defect.
+- Avoid all persistence changes.
+
+**Verification:** existing core compression tests, OpenCode/Claude/Codex/viewer
+option propagation, explicit `ids` task-mode parity, trace/result parity, and the
+synthetic fixture.
+
+### Recall 4: Context Inspector explanation
+
+**Tracking:** `codemem-f2u0`
+
+- Add the shipped `compressed` disposition and
+  `PackTrace.assembly.compressed_clusters` to viewer API types.
+- Render representative, available member titles/IDs, heuristic pattern, recorded
+  overlap terms, compressed count, and final pack tokens.
+- Display the effective compression mode from PackTrace so a manual trace can
+  match the automatic pack under investigation.
+- Do not claim per-cluster or total token savings; current PackTrace has no
+  uncompressed baseline.
+- Keep the change within the existing inspector information architecture.
+
+**Verification:** focused UI rendering tests, UI build, viewer route integration.
+
+### Gate 1: Human-readable shared identity
+
+**Tracking:** `codemem-g9sp`
+
+- Reuse already-shipped onboarding name preservation rather than rebuilding it.
+- Resolve Feed author/device labels from trusted actor and peer facts.
+- Reject or normalize machine-shaped display names at server ingress.
+- Use safe unresolved labels for already persisted malformed rows.
+- Keep raw IDs diagnostics-only.
+
+**Verification:** focused Feed/API tests, one direct-Project provenance regression,
+and malformed legacy-row coverage. Do not duplicate already-shipped Team and
+add-device suites without a distinct path gap.
+
+## Integration and release validation
+
+1. Run focused checks after each work unit.
+2. Run `pnpm run check` after each ready stack and on the final release candidate.
+3. Build viewer assets before viewer integration or E2E validation.
+4. Run the relevant plugin smoke tests with nested runtime dependencies installed.
+5. Run the synthetic compression fixture and record item/token deltas.
+6. Benchmark warm viewer-backed injection against the current CLI baseline.
+7. Run focused Feed provenance scenarios.
+8. Update README/user guidance and release notes only for behavior that shipped.
+
+## Stop conditions
+
+- Do not add ingestion deduplication to solve a pack-rendering issue.
+- Do not redesign the inspector beyond compression explanation.
+- Keep recipient-signature/coordinator/worker security work on its dedicated P1
+  track rather than pulling it into this release.
+- Do not expand identity-label repair into human-principal architecture.
+- File newly discovered adjacent work separately and keep it out of 0.41 unless it
+  blocks a stated success criterion.


### PR DESCRIPTION
## Description

Defines Codemem 0.41 as an external-user-value release centered on fast, focused recall. Documents the current pack execution paths, viewer-backed OpenCode injection, rendering-only near-duplicate compression, narrow Context Inspector explanation, release-gating identity/signature fixes, measurable success criteria, and explicit non-goals.

Reconciles Beads under `codemem-x4cu`, with implementation tracked by `codemem-83te`, `codemem-2ucx`, `codemem-f2u0`, `codemem-g9sp`, and `codemem-zjvr.1.10`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Docs-only validation: `git diff --check`; links, issue IDs, current pack paths, scope boundaries, and Graphite ancestry were manually reviewed.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced