### PR TITLE
fix(ui): keep paired multi-group devices out of review

### DIFF
--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.test.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.test.ts
@@ -1,9 +1,19 @@
 import { afterEach, describe, expect, it } from "vitest";
 import type { UiTeamSyncPrimaryStatus } from "../../view-model";
-import { renderTeamSyncPrimaryStatus } from "./render-team-sync";
+import { needsCoordinatorGroupReview, renderTeamSyncPrimaryStatus } from "./render-team-sync";
 
 afterEach(() => {
 	document.body.innerHTML = "";
+});
+
+describe("needsCoordinatorGroupReview", () => {
+	it("keeps a paired device out of review when it belongs to multiple groups", () => {
+		expect(needsCoordinatorGroupReview(["sre", "oss"], true)).toBe(false);
+	});
+
+	it("keeps an unpaired multi-group device in review", () => {
+		expect(needsCoordinatorGroupReview(["sre", "oss"], false)).toBe(true);
+	});
 });
 
 function renderStatus(primaryStatus: UiTeamSyncPrimaryStatus) {

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.test.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.test.ts
@@ -14,6 +14,10 @@ describe("needsCoordinatorGroupReview", () => {
 	it("keeps an unpaired multi-group device in review", () => {
 		expect(needsCoordinatorGroupReview(["sre", "oss"], false)).toBe(true);
 	});
+
+	it("keeps a paired multi-group device in review when local approval is pending", () => {
+		expect(needsCoordinatorGroupReview(["sre", "oss"], true, true)).toBe(true);
+	});
 });
 
 function renderStatus(primaryStatus: UiTeamSyncPrimaryStatus) {

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -56,8 +56,12 @@ import {
 
 const TEAM_SYNC_ACTIONS_MOUNT_ID = "syncTeamActionsMount";
 
-export function needsCoordinatorGroupReview(groupIds: string[], pairedLocally: boolean): boolean {
-	return !pairedLocally && groupIds.length > 1;
+export function needsCoordinatorGroupReview(
+	groupIds: string[],
+	pairedLocally: boolean,
+	needsLocalApproval = false,
+): boolean {
+	return groupIds.length > 1 && (!pairedLocally || needsLocalApproval);
 }
 
 export function renderTeamSyncPrimaryStatus(
@@ -307,7 +311,11 @@ export function renderTeamSync() {
 			? device.groups.map((value) => String(value || "").trim()).filter(Boolean)
 			: [];
 		const pairedPeer = localPeers.find((peer) => String(peer?.peer_device_id || "") === deviceId);
-		const hasAmbiguousCoordinatorGroup = needsCoordinatorGroupReview(groupIds, Boolean(pairedPeer));
+		const hasAmbiguousCoordinatorGroup = needsCoordinatorGroupReview(
+			groupIds,
+			Boolean(pairedPeer),
+			device.needs_local_approval === true,
+		);
 		const approvalSummary = deriveCoordinatorApprovalSummary({
 			device,
 			pairedLocally: Boolean(pairedPeer),
@@ -354,7 +362,7 @@ export function renderTeamSync() {
 			mode = "setup-blocked";
 		} else if (hasAmbiguousCoordinatorGroup) {
 			actionMessage =
-				"This unpaired device appears in multiple coordinator groups. Review the Team setup before approving it here.";
+				"This device appears in multiple coordinator groups. Review the Team setup before approving it here.";
 			mode = "ambiguous";
 		} else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
 			actionMessage =

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -56,6 +56,10 @@ import {
 
 const TEAM_SYNC_ACTIONS_MOUNT_ID = "syncTeamActionsMount";
 
+export function needsCoordinatorGroupReview(groupIds: string[], pairedLocally: boolean): boolean {
+	return !pairedLocally && groupIds.length > 1;
+}
+
 export function renderTeamSyncPrimaryStatus(
 	badge: HTMLElement,
 	meta: HTMLElement,
@@ -302,8 +306,8 @@ export function renderTeamSync() {
 		const groupIds = Array.isArray(device.groups)
 			? device.groups.map((value) => String(value || "").trim()).filter(Boolean)
 			: [];
-		const hasAmbiguousCoordinatorGroup = groupIds.length > 1;
 		const pairedPeer = localPeers.find((peer) => String(peer?.peer_device_id || "") === deviceId);
+		const hasAmbiguousCoordinatorGroup = needsCoordinatorGroupReview(groupIds, Boolean(pairedPeer));
 		const approvalSummary = deriveCoordinatorApprovalSummary({
 			device,
 			pairedLocally: Boolean(pairedPeer),
@@ -350,7 +354,7 @@ export function renderTeamSync() {
 			mode = "setup-blocked";
 		} else if (hasAmbiguousCoordinatorGroup) {
 			actionMessage =
-				"This device appears in multiple coordinator groups. Review team setup first or ask an admin to clean up the duplicate enrollment before approving it here.";
+				"This unpaired device appears in multiple coordinator groups. Review the Team setup before approving it here.";
 			mode = "ambiguous";
 		} else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
 			actionMessage =


### PR DESCRIPTION
## Description

Keep already-paired devices out of the coordinator-group review queue when they legitimately belong to multiple groups. Unpaired multi-group devices remain review-blocked, and the warning no longer implies duplicate enrollment.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, targeted Biome checks, focused Vitest tests)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed)
- [x] No new warnings introduced