### PR TITLE
fix(worker): keep Node-only sync code out of coordinator bundle

### DIFF
--- a/docs/sync-provenance.md
+++ b/docs/sync-provenance.md
@@ -48,7 +48,9 @@ These fields exist only on the originating device and are NEVER written to a rep
 
 When a memory arrives on a device that has never observed its originating session, the receiver creates a *synthetic placeholder session* (`sessions.cwd = "__sync_bootstrap__:<project>"`) just to satisfy the NOT NULL foreign key on `memory_items.session_id`. These placeholders are internal scaffolding and are filtered out of the Projects tab read model. They never carry any of the device-local fields above — only the `project` value that was carried on the wire.
 
-The shared prefix is exported as `SYNC_BOOTSTRAP_CWD_PREFIX` from `packages/core/src/sync-bootstrap.ts`; readers and writers reference the same constant.
+The shared prefix is defined as `SYNC_BOOTSTRAP_CWD_PREFIX` in the dependency-free
+`packages/core/src/sync-bootstrap-constants.ts` module and re-exported from `sync-bootstrap.ts` for compatibility;
+readers and writers reference the same constant without pulling the bootstrap runtime into unrelated bundles.
 
 ## How `memory_items.project` works
 

--- a/packages/cloudflare-coordinator-worker/package.json
+++ b/packages/cloudflare-coordinator-worker/package.json
@@ -5,10 +5,11 @@
 	"type": "module",
 	"scripts": {
 		"clean": "rm -rf dist tsconfig.tsbuildinfo",
-		"build": "pnpm exec vite build && pnpm exec tsc --build",
+		"build": "pnpm exec vite build && pnpm run check:bundle && pnpm exec tsc --build",
+		"check:bundle": "pnpm --filter @codemem/core build && node --test scripts/assert-worker-bundle-clean.test.mjs && rm -rf ../../.tmp/cloudflare-coordinator-worker-bundle && pnpm exec wrangler deploy --dry-run --config wrangler.jsonc --outdir ../../.tmp/cloudflare-coordinator-worker-bundle && node scripts/assert-worker-bundle-clean.mjs ../../.tmp/cloudflare-coordinator-worker-bundle",
 		"typecheck": "pnpm exec tsc --build",
 		"test:node": "pnpm exec vitest run --config vitest.node.config.ts src/index.test.ts",
-		"test:worker": "pnpm run test:node && pnpm --filter @codemem/core build && pnpm exec vitest run --config vitest.config.ts test/worker.integration.test.ts"
+		"test:worker": "pnpm run check:bundle && pnpm run test:node && pnpm exec vitest run --config vitest.config.ts test/worker.integration.test.ts"
 	},
 	"dependencies": {
 		"@codemem/core": "workspace:^"

--- a/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.mjs
+++ b/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.mjs
@@ -1,0 +1,79 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { builtinModules } from "node:module";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Extend this allowlist only when the Worker runtime and source graph require it.
+const ALLOWED_NODE_IMPORTS = new Set(["node:crypto", "node:path"]);
+const BARE_NODE_IMPORTS = new Set(
+	builtinModules.filter((specifier) => !specifier.startsWith("node:")),
+);
+const FORBIDDEN_IMPORTS = [
+	// Bundled npm packages are listed as intent and are also caught by the
+	// default-deny node:* rule when they pull unsupported builtins into the Worker.
+	"@xenova/transformers",
+	"better-sqlite3",
+	"bonjour-service",
+	"sqlite-vec",
+];
+
+function isForbiddenImport(specifier) {
+	const normalizedNodeImport = specifier.startsWith("node:")
+		? specifier
+		: BARE_NODE_IMPORTS.has(specifier)
+			? `node:${specifier}`
+			: null;
+	if (normalizedNodeImport) return !ALLOWED_NODE_IMPORTS.has(normalizedNodeImport);
+	return FORBIDDEN_IMPORTS.some(
+		(forbidden) => specifier === forbidden || specifier.startsWith(`${forbidden}/`),
+	);
+}
+
+export function findForbiddenWorkerImports(source) {
+	const specifiers = new Set();
+	const patterns = [
+		/\bfrom\s*["']([^"']+)["']/gu,
+		/\bimport\s*["']([^"']+)["']/gu,
+		/\bimport\s*\(\s*["']([^"']+)["']\s*\)/gu,
+		/\b(?:__)?require\d*\s*\(\s*["']([^"']+)["']\s*\)/gu,
+	];
+	for (const pattern of patterns) {
+		for (const match of source.matchAll(pattern)) {
+			if (match[1]) specifiers.add(match[1]);
+		}
+	}
+	return [...specifiers].filter(isForbiddenImport).toSorted();
+}
+
+export async function assertWorkerBundleClean(bundlePath) {
+	const source = await readFile(bundlePath, "utf8");
+	const forbiddenImports = findForbiddenWorkerImports(source);
+	if (forbiddenImports.length > 0) {
+		throw new Error(`Worker bundle contains forbidden imports: ${forbiddenImports.join(", ")}`);
+	}
+}
+
+async function listJavaScriptFiles(path) {
+	const entry = await stat(path);
+	if (entry.isFile()) return path.endsWith(".js") ? [path] : [];
+	const files = [];
+	for (const child of await readdir(path, { withFileTypes: true })) {
+		const childPath = join(path, child.name);
+		if (child.isDirectory()) files.push(...(await listJavaScriptFiles(childPath)));
+		else if (child.isFile() && child.name.endsWith(".js")) files.push(childPath);
+	}
+	return files.toSorted();
+}
+
+export async function assertWorkerBundleOutputClean(bundlePath) {
+	const files = await listJavaScriptFiles(bundlePath);
+	if (files.length === 0) throw new Error(`Worker bundle contains no JavaScript files: ${bundlePath}`);
+	for (const file of files) await assertWorkerBundleClean(file);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	const bundlePath = process.argv[2];
+	if (!bundlePath) throw new Error("Usage: node assert-worker-bundle-clean.mjs <bundle-path>");
+	await assertWorkerBundleOutputClean(bundlePath);
+	console.log(`Worker bundle import check passed: ${bundlePath}`);
+}

--- a/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.test.mjs
+++ b/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+	assertWorkerBundleOutputClean,
+	findForbiddenWorkerImports,
+} from "./assert-worker-bundle-clean.mjs";
+
+test("allows Worker-compatible imports", () => {
+	const source = 'import { createHash } from "node:crypto";\nimport { Hono } from "hono";';
+	assert.deepEqual(findForbiddenWorkerImports(source), []);
+});
+
+test("rejects static, dynamic, and generated require imports of forbidden modules", () => {
+	const source = [
+		'import { createRequire } from "node:module";',
+		'await import("bonjour-service");',
+		'const Database = require("better-sqlite3");',
+		'const fs = __require("node:fs");',
+		'const os = __require2("node:os");',
+		'const bareFs = require("fs");',
+		'import "os";',
+	].join("\n");
+	assert.deepEqual(findForbiddenWorkerImports(source), [
+		"better-sqlite3",
+		"bonjour-service",
+		"fs",
+		"node:fs",
+		"node:module",
+		"node:os",
+		"os",
+	]);
+});
+
+test("allows only the Node imports used by the Worker bundle", () => {
+	const source = [
+		'import { createHash } from "node:crypto";',
+		'import { resolve } from "node:path";',
+		'const crypto = require("crypto");',
+		'import "path";',
+	].join("\n");
+	assert.deepEqual(findForbiddenWorkerImports(source), []);
+});
+
+test("checks every JavaScript chunk in the bundle output", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "codemem-worker-bundle-"));
+	try {
+		await mkdir(join(directory, "chunks"));
+		await writeFile(join(directory, "index.js"), 'import { createHash } from "node:crypto";');
+		await writeFile(join(directory, "chunks", "unsafe.js"), 'import "node:fs";');
+		await assert.rejects(
+			assertWorkerBundleOutputClean(directory),
+			/Worker bundle contains forbidden imports: node:fs/u,
+		);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("rejects a bundle output with no JavaScript", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "codemem-worker-bundle-empty-"));
+	try {
+		await assert.rejects(
+			assertWorkerBundleOutputClean(directory),
+			/Worker bundle contains no JavaScript files:/u,
+		);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -26,6 +26,7 @@ import {
 	normalizeIdentityDisplayName,
 	normalizeProjectInviteSummaries,
 } from "./project-invite-identity.js";
+import { acceptedProjectIntentDigest, parseAcceptedProjectIntent } from "./project-share-intent.js";
 import {
 	RecipientReviewedIntentError,
 	type RecipientReviewedIntentV1,
@@ -36,7 +37,6 @@ import {
 	type InMemoryRequestRateLimiter,
 } from "./request-rate-limit.js";
 import { explainScopeMembershipRevocation } from "./scope-membership-semantics.js";
-import { acceptedProjectIntentDigest, parseAcceptedProjectIntent } from "./share-operation.js";
 import { DEFAULT_TIME_WINDOW_S } from "./sync-auth-constants.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 

--- a/packages/core/src/legacy-recipient-policy-projection.ts
+++ b/packages/core/src/legacy-recipient-policy-projection.ts
@@ -12,7 +12,7 @@ import {
 	type WorkspaceIdentitySource,
 } from "./scope-resolution.js";
 import { shareProjectSetDigest } from "./share-operation.js";
-import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap.js";
+import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap-constants.js";
 
 export type LegacyRecipientPolicyConfidenceV1 = "high" | "medium" | "low";
 

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -9,7 +9,7 @@ import {
 	type ScopeResolutionReason,
 	type WorkspaceIdentitySource,
 } from "./scope-resolution.js";
-import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap.js";
+import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap-constants.js";
 import { recordAccessCleanupOp, recordReplicationOp } from "./sync-replication.js";
 
 export interface SharingDomainSettingsScope {

--- a/packages/core/src/project-share-intent.ts
+++ b/packages/core/src/project-share-intent.ts
@@ -1,0 +1,96 @@
+import { createHash } from "node:crypto";
+import { normalizeIdentityDisplayName } from "./project-invite-identity.js";
+import { canonicalWorkspaceIdentity } from "./scope-resolution.js";
+
+export const SHARE_HISTORY_POLICY = "existing_and_future" as const;
+
+export interface ShareProjectIntent {
+	canonicalIdentity: string;
+	displayName: string;
+	identitySource: string;
+	existingMemoryCount: number;
+}
+
+export interface AcceptedProjectIntent {
+	canonical_identity: string;
+	display_name: string;
+	existing_memory_count: number;
+}
+
+function digest(value: unknown): string {
+	return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+export function shareProjectSetDigest(projects: ShareProjectIntent[]): string {
+	const reviewedProjects = projects
+		.map((project) => ({
+			canonicalIdentity: project.canonicalIdentity,
+			existingMemoryCount: project.existingMemoryCount,
+		}))
+		.toSorted((left, right) => left.canonicalIdentity.localeCompare(right.canonicalIdentity));
+	return digest({ v: 1, historyPolicy: SHARE_HISTORY_POLICY, projects: reviewedProjects });
+}
+
+export function acceptedProjectIntentDigest(projects: AcceptedProjectIntent[]): string {
+	return shareProjectSetDigest(
+		projects.map((project) => ({
+			canonicalIdentity: project.canonical_identity,
+			displayName: project.display_name,
+			identitySource: "coordinator_acceptance",
+			existingMemoryCount: project.existing_memory_count,
+		})),
+	);
+}
+
+export function parseAcceptedProjectIntent(value: unknown): AcceptedProjectIntent[] {
+	if (!Array.isArray(value) || value.length === 0 || value.length > 100) {
+		throw new Error("operation_intent_invalid");
+	}
+	const projects = value.map((item) => {
+		if (!item || typeof item !== "object" || Array.isArray(item)) {
+			throw new Error("operation_intent_invalid");
+		}
+		const record = item as Record<string, unknown>;
+		if (typeof record.canonical_identity !== "string" || typeof record.display_name !== "string") {
+			throw new Error("operation_intent_invalid");
+		}
+		const canonicalIdentityRaw = record.canonical_identity;
+		const canonicalIdentity = canonicalIdentityRaw.trim();
+		const displayNameRaw = record.display_name;
+		let displayName: string;
+		try {
+			displayName = normalizeIdentityDisplayName(displayNameRaw, "project_name");
+		} catch {
+			throw new Error("operation_intent_invalid");
+		}
+		const count = record.existing_memory_count;
+		const canonicalIdentityRoundTrip = canonicalWorkspaceIdentity({
+			gitRemote: canonicalIdentity,
+		}).value;
+		if (
+			!canonicalIdentity ||
+			canonicalIdentity !== canonicalIdentityRaw ||
+			canonicalIdentity.length > 2048 ||
+			canonicalIdentity.startsWith("unmapped:") ||
+			canonicalIdentityRoundTrip !== canonicalIdentity ||
+			displayName !== displayNameRaw ||
+			!Number.isSafeInteger(count) ||
+			Number(count) < 0 ||
+			/[\p{Cc}\p{Cf}]/u.test(canonicalIdentity) ||
+			/[\p{Cc}\p{Cf}]/u.test(displayName)
+		) {
+			throw new Error("operation_intent_invalid");
+		}
+		return {
+			canonical_identity: canonicalIdentity,
+			display_name: displayName,
+			existing_memory_count: Number(count),
+		};
+	});
+	if (new Set(projects.map((project) => project.canonical_identity)).size !== projects.length) {
+		throw new Error("operation_intent_invalid");
+	}
+	return projects.toSorted((left, right) =>
+		left.canonical_identity.localeCompare(right.canonical_identity),
+	);
+}

--- a/packages/core/src/recipient-policy-edges.ts
+++ b/packages/core/src/recipient-policy-edges.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type { Database } from "./db.js";
 import { canonicalWorkspaceIdentity } from "./scope-resolution.js";
-import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap.js";
+import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap-constants.js";
 
 export type RecipientPolicyEdgeRecipientRefV1 =
 	| { recipientKind: "identity"; identityId: string }

--- a/packages/core/src/recipient-policy-onboarding.ts
+++ b/packages/core/src/recipient-policy-onboarding.ts
@@ -7,7 +7,7 @@ import {
 } from "./recipient-reviewed-intent.js";
 import { canonicalWorkspaceIdentity } from "./scope-resolution.js";
 import { managedProjectScopeId } from "./share-operation.js";
-import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap.js";
+import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap-constants.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 import { buildBaseUrl } from "./sync-http-client.js";
 

--- a/packages/core/src/share-operation.ts
+++ b/packages/core/src/share-operation.ts
@@ -1,23 +1,28 @@
 import { createHash } from "node:crypto";
 import type { Database } from "./db.js";
 import { normalizeIdentityDisplayName } from "./project-invite-identity.js";
+import type { AcceptedProjectIntent, ShareProjectIntent } from "./project-share-intent.js";
+import {
+	parseAcceptedProjectIntent,
+	SHARE_HISTORY_POLICY,
+	shareProjectSetDigest,
+} from "./project-share-intent.js";
 import { commitDirectProjectSharePolicyInTransaction } from "./recipient-policy-onboarding.js";
-import { canonicalWorkspaceIdentity } from "./scope-resolution.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 
-export const SHARE_HISTORY_POLICY = "existing_and_future" as const;
+export type { AcceptedProjectIntent, ShareProjectIntent } from "./project-share-intent.js";
+export {
+	acceptedProjectIntentDigest,
+	parseAcceptedProjectIntent,
+	SHARE_HISTORY_POLICY,
+	shareProjectSetDigest,
+} from "./project-share-intent.js";
+
 export const SHARE_OPERATION_STATE = "waiting_for_acceptance" as const;
 
 export type SharePersonIntent =
 	| { kind: "existing"; personId: string; displayName: string }
 	| { kind: "pending"; personId?: string; displayName: string };
-
-export interface ShareProjectIntent {
-	canonicalIdentity: string;
-	displayName: string;
-	identitySource: string;
-	existingMemoryCount: number;
-}
 
 export interface ShareOperationStep {
 	stepKey: string;
@@ -66,27 +71,6 @@ export function normalizeTeammateName(value: string): string {
 	});
 	if (hasControlCharacter) throw new Error("teammate_name_invalid");
 	return normalized;
-}
-
-export function shareProjectSetDigest(projects: ShareProjectIntent[]): string {
-	const reviewedProjects = projects
-		.map((project) => ({
-			canonicalIdentity: project.canonicalIdentity,
-			existingMemoryCount: project.existingMemoryCount,
-		}))
-		.toSorted((left, right) => left.canonicalIdentity.localeCompare(right.canonicalIdentity));
-	return digest({ v: 1, historyPolicy: SHARE_HISTORY_POLICY, projects: reviewedProjects });
-}
-
-export function acceptedProjectIntentDigest(projects: AcceptedProjectIntent[]): string {
-	return shareProjectSetDigest(
-		projects.map((project) => ({
-			canonicalIdentity: project.canonical_identity,
-			displayName: project.display_name,
-			identitySource: "coordinator_acceptance",
-			existingMemoryCount: project.existing_memory_count,
-		})),
-	);
 }
 
 export function managedProjectScopeId(
@@ -424,12 +408,6 @@ export function persistShareOperation(
 	save();
 }
 
-export interface AcceptedProjectIntent {
-	canonical_identity: string;
-	display_name: string;
-	existing_memory_count: number;
-}
-
 export interface ShareOperationAcceptanceInput {
 	operationId: string;
 	localInviterActorId: string;
@@ -495,59 +473,6 @@ function inviterDeviceDisplayName(db: Database, deviceId: string): string {
 		.pluck()
 		.get(deviceId);
 	return validInviterDeviceDisplayName(peerName) ?? "Existing device";
-}
-
-export function parseAcceptedProjectIntent(value: unknown): AcceptedProjectIntent[] {
-	if (!Array.isArray(value) || value.length === 0 || value.length > 100) {
-		throw new Error("operation_intent_invalid");
-	}
-	const projects = value.map((item) => {
-		if (!item || typeof item !== "object" || Array.isArray(item)) {
-			throw new Error("operation_intent_invalid");
-		}
-		const record = item as Record<string, unknown>;
-		if (typeof record.canonical_identity !== "string" || typeof record.display_name !== "string") {
-			throw new Error("operation_intent_invalid");
-		}
-		const canonicalIdentityRaw = record.canonical_identity;
-		const canonicalIdentity = canonicalIdentityRaw.trim();
-		const displayNameRaw = record.display_name;
-		let displayName: string;
-		try {
-			displayName = normalizeIdentityDisplayName(displayNameRaw, "project_name");
-		} catch {
-			throw new Error("operation_intent_invalid");
-		}
-		const count = record.existing_memory_count;
-		const canonicalIdentityRoundTrip = canonicalWorkspaceIdentity({
-			gitRemote: canonicalIdentity,
-		}).value;
-		if (
-			!canonicalIdentity ||
-			canonicalIdentity !== canonicalIdentityRaw ||
-			canonicalIdentity.length > 2048 ||
-			canonicalIdentity.startsWith("unmapped:") ||
-			canonicalIdentityRoundTrip !== canonicalIdentity ||
-			displayName !== displayNameRaw ||
-			!Number.isSafeInteger(count) ||
-			Number(count) < 0 ||
-			/[\p{Cc}\p{Cf}]/u.test(canonicalIdentity) ||
-			/[\p{Cc}\p{Cf}]/u.test(displayName)
-		) {
-			throw new Error("operation_intent_invalid");
-		}
-		return {
-			canonical_identity: canonicalIdentity,
-			display_name: displayName,
-			existing_memory_count: Number(count),
-		};
-	});
-	if (new Set(projects.map((project) => project.canonical_identity)).size !== projects.length) {
-		throw new Error("operation_intent_invalid");
-	}
-	return projects.toSorted((left, right) =>
-		left.canonical_identity.localeCompare(right.canonical_identity),
-	);
 }
 
 export function reconcileShareOperationAcceptance(

--- a/packages/core/src/sync-bootstrap-constants.ts
+++ b/packages/core/src/sync-bootstrap-constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Synthetic placeholder cwd used for sessions created during sync bootstrap.
+ * Keep this in a dependency-free module so policy code can use it without
+ * pulling the Node-only bootstrap runtime into Cloudflare Worker bundles.
+ */
+export const SYNC_BOOTSTRAP_CWD_PREFIX = "__sync_bootstrap__";

--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -19,6 +19,7 @@ import { toJson } from "./db.js";
 import * as schema from "./schema.js";
 import { redactMemoryFields, SecretScanner } from "./secret-scanner.js";
 import { buildAuthHeaders } from "./sync-auth.js";
+import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap-constants.js";
 import { LOCAL_SYNC_CAPABILITY, SYNC_CAPABILITY_HEADER } from "./sync-capability.js";
 import { requestJson } from "./sync-http-client.js";
 import {
@@ -33,21 +34,7 @@ import {
 import type { SyncMemorySnapshotItem, SyncResetRequired } from "./types.js";
 import { queueVectorBackfillForSyncBootstrap } from "./vector-migration.js";
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/**
- * Synthetic placeholder cwd written for sessions created during bootstrap
- * snapshot apply. These sessions exist only to satisfy the NOT NULL FK on
- * memory_items.session_id for inbound memories that did not originate on
- * this device. They are not user-facing and should be filtered out of any
- * UI that lists projects or sessions by cwd.
- *
- * Format: `__sync_bootstrap__:<project>` or `__sync_bootstrap__` if no
- * project is associated.
- */
-export const SYNC_BOOTSTRAP_CWD_PREFIX = "__sync_bootstrap__";
+export { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap-constants.js";
 
 // ---------------------------------------------------------------------------
 // Types


### PR DESCRIPTION
## Description

Prevent the Cloudflare coordinator bundle from pulling Node-only sync discovery code into workerd. The coordinator now consumes project-share intent helpers from a focused module, bootstrap-prefix consumers use a dependency-free constants module, and the Worker gate scans the actual Wrangler dry-run artifact for forbidden runtime imports.

Fixes the `createRequire(import.meta.url)` validation failure encountered while preparing the v0.40.2 coordinator deployment.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with:

- `pnpm --filter @codemem/cloudflare-coordinator-worker test:worker`
- `pnpm run tsc`
- `pnpm run lint`
- targeted core tests covering share intent, coordinator API, onboarding, bootstrap, project scope, and recipient policy (223 tests)
- Wrangler dry-run bundle generation and forbidden-import scan

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
