### PR TITLE
fix(sync): expose enrollment maintenance failure stages

### DIFF
--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -238,13 +238,55 @@ describe("serve command option resolution", () => {
 					groupsProcessed: 1,
 					failedGroups: 1,
 					issues: 2,
+					failures: [
+						{
+							groupId: "group-a",
+							stage: "list_consumed_team_invites" as const,
+							code: "http_404",
+						},
+					],
 				})),
 				reconcileRecipientPolicyProjects,
 			}),
 		).rejects.toThrow(
-			"coordinator enrollment maintenance failed for 1 group with 2 reconciliation issues",
+			"coordinator enrollment maintenance failed for 1 group with 2 reconciliation issues [group-a:list_consumed_team_invites:http_404]",
 		);
 		expect(reconcileRecipientPolicyProjects).toHaveBeenCalledOnce();
+	});
+
+	it("bounds enrollment failure details", async () => {
+		await expect(
+			runServeCoordinatorMaintenance({} as MemoryStore, {
+				advancePendingProjectShares: vi.fn(async () => ({ processed: 0, failed: 0 })),
+				reconcileConfiguredCoordinatorEnrollment: vi.fn(async () => ({
+					groupsProcessed: 0,
+					failedGroups: 4,
+					issues: 0,
+					failures: ["a", "b", "c", "d"].map((groupId) => ({
+						groupId,
+						stage: "list_devices" as const,
+						code: "coordinator_device_list_malformed",
+					})),
+				})),
+				reconcileRecipientPolicyProjects: vi.fn(async () => ({ processed: 0, failed: 0 })),
+			}),
+		).rejects.toThrow(
+			"[a:list_devices:coordinator_device_list_malformed, b:list_devices:coordinator_device_list_malformed, c:list_devices:coordinator_device_list_malformed, +1 more]",
+		);
+	});
+
+	it("reports reconciliation issues without claiming a group failure", async () => {
+		await expect(
+			runServeCoordinatorMaintenance({} as MemoryStore, {
+				advancePendingProjectShares: vi.fn(async () => ({ processed: 0, failed: 0 })),
+				reconcileConfiguredCoordinatorEnrollment: vi.fn(async () => ({
+					groupsProcessed: 1,
+					failedGroups: 0,
+					issues: 1,
+				})),
+				reconcileRecipientPolicyProjects: vi.fn(async () => ({ processed: 0, failed: 0 })),
+			}),
+		).rejects.toThrow("coordinator enrollment reconciliation found 1 issue");
 	});
 
 	it("detects sqlite-vec load errors for viewer startup fallback", () => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -15,6 +15,7 @@ import {
 	resolveDbPath,
 	runSyncDaemon,
 } from "@codemem/core";
+import type { ReconcileConfiguredCoordinatorEnrollmentResult } from "@codemem/server";
 import { Command, Option } from "commander";
 import { helpStyle } from "../help-style.js";
 import {
@@ -517,7 +518,12 @@ export function sqliteVecFailureDiagnostics(error: unknown, dbPath: string): str
 
 export interface ServeCoordinatorMaintenanceResult {
 	projectShares: { processed: number; failed: number };
-	coordinatorEnrollment: { groupsProcessed: number; failedGroups: number; issues?: number };
+	coordinatorEnrollment: {
+		groupsProcessed: number;
+		failedGroups: number;
+		issues?: number;
+		failures?: ReconcileConfiguredCoordinatorEnrollmentResult["failures"];
+	};
 	recipientPolicies: { processed: number; failed: number };
 }
 
@@ -532,9 +538,12 @@ export async function runServeCoordinatorMaintenance(
 			store: MemoryStore,
 			options: { limit: number },
 		) => Promise<{ processed: number; failed: number }>;
-		reconcileConfiguredCoordinatorEnrollment: (
-			store: MemoryStore,
-		) => Promise<{ groupsProcessed: number; failedGroups: number; issues?: number }>;
+		reconcileConfiguredCoordinatorEnrollment: (store: MemoryStore) => Promise<{
+			groupsProcessed: number;
+			failedGroups: number;
+			issues?: number;
+			failures?: ReconcileConfiguredCoordinatorEnrollmentResult["failures"];
+		}>;
 	},
 ): Promise<ServeCoordinatorMaintenanceResult> {
 	const projectShares = await dependencies.advancePendingProjectShares(store, { limit: 3 });
@@ -548,11 +557,24 @@ export async function runServeCoordinatorMaintenance(
 			`share operation maintenance failed for ${projectShares.failed} of ${projectShares.processed} operations`,
 		);
 	}
-	if (coordinatorEnrollment.failedGroups > 0 || enrollmentIssues > 0) {
+	if (coordinatorEnrollment.failedGroups > 0) {
 		const groupLabel = coordinatorEnrollment.failedGroups === 1 ? "group" : "groups";
 		const issueLabel = enrollmentIssues === 1 ? "issue" : "issues";
+		const failures = coordinatorEnrollment.failures ?? [];
+		const failureDetail = failures.length
+			? ` [${failures
+					.slice(0, 3)
+					.map((failure) => `${failure.groupId}:${failure.stage}:${failure.code}`)
+					.join(", ")}${failures.length > 3 ? `, +${failures.length - 3} more` : ""}]`
+			: "";
 		throw new Error(
-			`coordinator enrollment maintenance failed for ${coordinatorEnrollment.failedGroups} ${groupLabel} with ${enrollmentIssues} reconciliation ${issueLabel}`,
+			`coordinator enrollment maintenance failed for ${coordinatorEnrollment.failedGroups} ${groupLabel} with ${enrollmentIssues} reconciliation ${issueLabel}${failureDetail}`,
+		);
+	}
+	if (enrollmentIssues > 0) {
+		const issueLabel = enrollmentIssues === 1 ? "issue" : "issues";
+		throw new Error(
+			`coordinator enrollment reconciliation found ${enrollmentIssues} ${issueLabel}`,
 		);
 	}
 	if (recipientPolicies.failed > 0) {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1764,11 +1764,56 @@ export interface ReconcileConfiguredCoordinatorEnrollmentResult {
 	skipped: boolean;
 	groupsProcessed: number;
 	failedGroups: number;
+	failures: CoordinatorEnrollmentMaintenanceFailure[];
 	devicesAdded: number;
 	membershipsAdded: number;
 	identitiesAdded: number;
 	unchanged: number;
 	issues: number;
+}
+
+export type CoordinatorEnrollmentMaintenanceStage =
+	| "list_devices"
+	| "list_consumed_team_invites"
+	| "reconcile_snapshot";
+
+export interface CoordinatorEnrollmentMaintenanceFailure {
+	groupId: string;
+	stage: CoordinatorEnrollmentMaintenanceStage;
+	code: string;
+}
+
+function coordinatorEnrollmentFailureCode(error: unknown): string {
+	const message = (error instanceof Error ? error.message : String(error)).trim();
+	const httpStatus = message.match(/\((\d{3})(?::|\))/u)?.[1];
+	if (httpStatus) return `http_${httpStatus}`;
+	if (
+		new Set([
+			"coordinator_consumed_team_invite_invalid",
+			"coordinator_device_list_malformed",
+			"coordinator_group_id_invalid",
+			"coordinator_id_invalid",
+			"coordinator_invite_group_mismatch",
+			"coordinator_invite_list_malformed",
+			"reconciliation_time_invalid",
+		]).has(message)
+	) {
+		return message;
+	}
+	if (/timeout|timed out|abort/iu.test(message)) return "request_timeout";
+	if (/fetch failed|network|econn|enotfound/iu.test(message)) return "network_error";
+	return "unexpected_error";
+}
+
+function coordinatorEnrollmentFailure(
+	groupId: string,
+	stage: CoordinatorEnrollmentMaintenanceStage,
+	error: unknown,
+): CoordinatorEnrollmentMaintenanceFailure {
+	const safeGroupId = /^[A-Za-z0-9._-]{1,64}$/u.test(groupId)
+		? groupId
+		: `group_${createHash("sha256").update(groupId).digest("hex").slice(0, 12)}`;
+	return { groupId: safeGroupId, stage, code: coordinatorEnrollmentFailureCode(error) };
 }
 
 export async function reconcileConfiguredCoordinatorEnrollment(
@@ -1798,6 +1843,7 @@ export async function reconcileConfiguredCoordinatorEnrollment(
 			skipped: true,
 			groupsProcessed: 0,
 			failedGroups: 0,
+			failures: [],
 			devicesAdded: 0,
 			membershipsAdded: 0,
 			identitiesAdded: 0,
@@ -1815,6 +1861,7 @@ export async function reconcileConfiguredCoordinatorEnrollment(
 		skipped: false,
 		groupsProcessed: 0,
 		failedGroups: 0,
+		failures: [],
 		devicesAdded: 0,
 		membershipsAdded: 0,
 		identitiesAdded: 0,
@@ -1822,16 +1869,37 @@ export async function reconcileConfiguredCoordinatorEnrollment(
 		issues: 0,
 	};
 	for (const groupId of config.syncCoordinatorGroups) {
+		const [enrollmentsResult, consumedTeamInvitesResult] = await Promise.allSettled([
+			listDevices({ groupId, remoteUrl, adminSecret }),
+			listConsumedTeamInvites({ groupId, remoteUrl, adminSecret }),
+		]);
+		if (enrollmentsResult.status === "rejected") {
+			total.failures.push(
+				coordinatorEnrollmentFailure(groupId, "list_devices", enrollmentsResult.reason),
+			);
+		}
+		if (consumedTeamInvitesResult.status === "rejected") {
+			total.failures.push(
+				coordinatorEnrollmentFailure(
+					groupId,
+					"list_consumed_team_invites",
+					consumedTeamInvitesResult.reason,
+				),
+			);
+		}
+		if (
+			enrollmentsResult.status === "rejected" ||
+			consumedTeamInvitesResult.status === "rejected"
+		) {
+			total.failedGroups += 1;
+			continue;
+		}
 		try {
-			const [enrollments, consumedTeamInvites] = await Promise.all([
-				listDevices({ groupId, remoteUrl, adminSecret }),
-				listConsumedTeamInvites({ groupId, remoteUrl, adminSecret }),
-			]);
 			const result = reconcileSnapshot({
 				coordinatorId: buildBaseUrl(remoteUrl),
 				groupId,
-				enrollments,
-				consumedTeamInvites,
+				enrollments: enrollmentsResult.value,
+				consumedTeamInvites: consumedTeamInvitesResult.value,
 				localDeviceId: store.deviceId,
 			});
 			total.groupsProcessed += 1;
@@ -1840,8 +1908,9 @@ export async function reconcileConfiguredCoordinatorEnrollment(
 			total.identitiesAdded += result.identitiesAdded;
 			total.unchanged += result.unchanged;
 			total.issues += result.issues.length;
-		} catch {
+		} catch (error) {
 			total.failedGroups += 1;
+			total.failures.push(coordinatorEnrollmentFailure(groupId, "reconcile_snapshot", error));
 		}
 	}
 	return total;

--- a/packages/viewer-server/src/share-operation-maintenance.test.ts
+++ b/packages/viewer-server/src/share-operation-maintenance.test.ts
@@ -71,12 +71,94 @@ describe("reconcileConfiguredCoordinatorEnrollment", () => {
 			skipped: false,
 			groupsProcessed: 2,
 			failedGroups: 0,
+			failures: [],
 			devicesAdded: 2,
 			membershipsAdded: 4,
 			identitiesAdded: 2,
 			unchanged: 6,
 			issues: 0,
 		});
+	});
+
+	it("reports sanitized failures for each coordinator fetch stage", async () => {
+		const result = await reconcileConfiguredCoordinatorEnrollment(
+			{ db: {}, deviceId: "device-local" } as MemoryStore,
+			{
+				config: {
+					syncCoordinatorUrl: "https://coord.example.test",
+					syncCoordinatorAdminSecret: "secret",
+					syncCoordinatorGroups: ["group-a"],
+				} as never,
+				listDevices: async () => {
+					throw new Error("Remote coordinator request failed (404): token=do-not-log");
+				},
+				listConsumedTeamInvites: async () => {
+					throw new Error("coordinator_consumed_team_invite_invalid");
+				},
+			},
+		);
+
+		expect(result).toMatchObject({ groupsProcessed: 0, failedGroups: 1 });
+		expect(result.failures).toEqual([
+			{ groupId: "group-a", stage: "list_devices", code: "http_404" },
+			{
+				groupId: "group-a",
+				stage: "list_consumed_team_invites",
+				code: "coordinator_consumed_team_invite_invalid",
+			},
+		]);
+		expect(JSON.stringify(result.failures)).not.toContain("do-not-log");
+	});
+
+	it("reports a sanitized local snapshot reconciliation failure", async () => {
+		const result = await reconcileConfiguredCoordinatorEnrollment(
+			{ db: {}, deviceId: "device-local" } as MemoryStore,
+			{
+				config: {
+					syncCoordinatorUrl: "https://coord.example.test",
+					syncCoordinatorAdminSecret: "secret",
+					syncCoordinatorGroups: ["group-a"],
+				} as never,
+				listDevices: async () => [],
+				listConsumedTeamInvites: async () => [],
+				reconcileSnapshot: () => {
+					throw new Error("database is locked at /private/path");
+				},
+			},
+		);
+
+		expect(result.failures).toEqual([
+			{ groupId: "group-a", stage: "reconcile_snapshot", code: "unexpected_error" },
+		]);
+	});
+
+	it("hashes unsafe group ids and never echoes arbitrary rejection text", async () => {
+		const unsafeGroupId = "group a/../private";
+		const result = await reconcileConfiguredCoordinatorEnrollment(
+			{ db: {}, deviceId: "device-local" } as MemoryStore,
+			{
+				config: {
+					syncCoordinatorUrl: "https://coord.example.test",
+					syncCoordinatorAdminSecret: "secret",
+					syncCoordinatorGroups: [unsafeGroupId],
+				} as never,
+				listDevices: async () => {
+					throw "https://private.example.test/path?token=secret";
+				},
+				listConsumedTeamInvites: async () => [],
+			},
+		);
+
+		expect(result.failures).toEqual([
+			{
+				groupId: expect.stringMatching(/^group_[0-9a-f]{12}$/u),
+				stage: "list_devices",
+				code: "unexpected_error",
+			},
+		]);
+		const serialized = JSON.stringify(result.failures);
+		expect(serialized).not.toContain(unsafeGroupId);
+		expect(serialized).not.toContain("private.example.test");
 	});
 
 	it("preserves issues on fetch failure and resolves them after a successful empty snapshot", async () => {


### PR DESCRIPTION
## Description

Expose bounded, sanitized per-group diagnostics for coordinator enrollment maintenance.

### Proof of value

Before this change, failures in device listing, consumed-invite listing, and local snapshot reconciliation all collapsed into an opaque failed-group count. Operators could not tell whether the coordinator API, response parsing, or local projection failed without reproducing the problem under a debugger.

After this change, maintenance reports the exact safe stage and bounded code (`list_devices`, `list_consumed_team_invites`, or `reconcile_snapshot`). Arbitrary response text, secrets, URLs, unsafe group IDs, and local paths are never emitted. Reconciliation issues are also reported separately instead of being mislabeled as group failures.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused validation: 80 tests passed across CLI maintenance and viewer-server enrollment reconciliation, including stage separation, sanitization, bounded output, and issue-only reporting.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed; bounded internal diagnostics only)
- [x] No new warnings introduced