### PR TITLE
perf(plugin): route prompt packs through viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,22 +111,25 @@ Adapters hook into runtime event systems (OpenCode plugin and Claude hooks). The
 sequenceDiagram
 participant OC as OpenCode
 participant PL as codemem plugin
+participant VW as viewer HTTP
 participant ST as MemoryStore
 participant DB as SQLite
 
 OC->>PL: tool.execute.after events
 OC->>PL: experimental.chat.messages.transform
-PL->>ST: build_memory_pack with shaped query
+PL->>VW: POST /api/pack with shaped query
+VW->>ST: build_memory_pack
 ST->>DB: FTS5 BM25 lexical search
 ST->>DB: sqlite vec semantic search
 ST->>ST: merge rerank and section assembly
-ST-->>PL: pack text
+ST-->>VW: pack text
+VW-->>PL: pack JSON
 PL->>OC: inject codemem context
 ```
 
 **Retrieval** combines two strategies: keyword search via SQLite FTS5 with BM25 scoring and semantic similarity via sqlite-vec embeddings. In the pack-building path, results from both are merged, exactly deduplicated, and re-ranked using recency and memory-kind boosts. Near-related memories stay fully rendered by default; use compact rendering or `CODEMEM_PACK_COMPRESSION=ids` only when you intentionally want ID-based expansion via `memory_get_observations`.
 
-**Injection** happens automatically. The plugin builds a query from the current session context (first prompt, latest prompt, project, recently modified files), calls `build_memory_pack`, and appends the result to the latest user message via `experimental.chat.messages.transform`. Prior injected message blocks are replayed byte-for-byte on later turns so provider prompt caches can keep the stable prefix. Set `CODEMEM_INJECT_SURFACE=system` to use the legacy system-prompt surface. OpenCode raw-event capture streams through the viewer and falls back to direct CLI enqueue; explicit SQLite busy/locked results and command timeouts receive one idempotent retry with the same event ID, while terminal failures are reported and dropped instead of requeued. Each retrieval and current-request cache reuse is recorded in the local evidence ledger with bounded memory identities, machine-readable reason codes, delivery status, and safe repository-relative working-set paths. Repository-contained absolute tool paths are converted to repository-relative `/` paths before retrieval; outside-repository, traversing, blank, and overlong paths are omitted. Prompts, pack text, memory content, and absolute paths are not copied into the ledger, historical message reconstruction creates no new attempts, and recording failures never block injection. After a plugin restart, usable context also remains fail-open when fresh ledger-identity repair fails; fallback bytes are injected without attributing delivery to either the conflicted or failed attempt.
+**Injection** happens automatically. The plugin builds a query from the current session context (first prompt, latest prompt, project, recently modified files), asks the long-lived local viewer to build the pack, and appends the result to the latest user message via `experimental.chat.messages.transform`. Before sending prompt-derived POST data, it performs a payload-free viewer/profile handshake and rejects redirects. Retryable viewer transport, version, database-target, effective identity/config-target, compression-setting, or embedding-setting mismatch failures fall back to the existing CLI path; only structured, validated request errors are terminal. Prior injected message blocks are replayed byte-for-byte on later turns so provider prompt caches can keep the stable prefix. Set `CODEMEM_INJECT_SURFACE=system` to use the legacy system-prompt surface. OpenCode raw-event capture streams through the viewer and falls back to direct CLI enqueue; explicit SQLite busy/locked results and command timeouts receive one idempotent retry with the same event ID, while terminal failures are reported and dropped instead of requeued. Each retrieval and current-request cache reuse is recorded through the viewer-backed local evidence ledger with bounded memory identities, machine-readable reason codes, delivery status, and safe repository-relative working-set paths; retryable ledger transport failures retain the CLI fallback. Repository-contained absolute tool paths are converted to repository-relative `/` paths before retrieval; outside-repository, traversing, blank, and overlong paths are omitted. Prompts, pack text, memory content, and absolute paths are not copied into the ledger, historical message reconstruction creates no new attempts, and recording failures never block injection. After a plugin restart, usable context also remains fail-open when fresh ledger-identity repair fails; fallback bytes are injected without attributing delivery to either the conflicted or failed attempt.
 
 **Memories** are typed — `bugfix`, `feature`, `refactor`, `change`, `discovery`, `decision`, `exploration` — with structured fields like `facts`, `concepts`, `files_read`, and `files_modified` that improve retrieval relevance. Low-signal events are filtered at multiple layers before persistence.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ flowchart LR
 ```
 
 1. Adapters capture tool/conversation lifecycle events and normalize them into raw events with optional `_adapter` envelopes.
-2. OpenCode streams raw events to the viewer ingest API (`POST /api/raw-events`) with preflight checks (`GET /api/raw-events/status`) and can fall back to CLI queue enqueue when stream writes fail.
+2. OpenCode streams raw events to the viewer ingest API (`POST /api/raw-events`) with preflight checks (`GET /api/raw-events/status`) and can fall back to CLI queue enqueue when stream writes fail. Prompt-time packs and prompt-pack ledger transitions also use viewer POST APIs first, with CLI fallback only for retryable transport or version failures.
 3. Claude hook ingestion posts to `POST /api/claude-hooks` first and falls back to `codemem claude-hook-ingest` direct enqueue when the local viewer API is unavailable. Codex hook ingestion follows the same HTTP-first shape through `POST /api/codex-hooks`, then `codemem codex-hook-ingest` direct enqueue, with a Codex-specific on-disk spool as the last-resort fallback.
 4. The viewer/store persists raw events and queues durable flush batches.
 5. Idle and sweeper workers claim batches and run them through ingest.
@@ -203,12 +203,13 @@ In plugin mode, these can be overridden via `CODEMEM_INJECT_LIMIT` and `CODEMEM_
 
 The OpenCode plugin uses `experimental.chat.messages.transform` to append the current pack text to the latest user message. Earlier injected message blocks are cached by message ID and replayed byte-for-byte on later turns, preserving the stable prompt prefix for provider prompt caches while only the newest user turn receives volatile recall output. Scope revocation affects newly built packs, but historical injected blocks in the same OpenCode session are not retroactively scrubbed; start a new session after revoking access if prompt history must be clean. Set `CODEMEM_INJECT_SURFACE=system` to use the legacy `experimental.chat.system.transform` system-prompt surface. A toast notification shows injection stats on first inject per session.
 
-Before each pack build, the plugin derives stable attempt and request identities from safe request components so an exact adapter retry is idempotent. At the tool-event boundary, repository-contained absolute working-set paths are converted to repository-relative `/` paths; outside-repository, traversing, blank, and overlong paths are discarded. The same normalized set feeds pack retrieval and its ledger metadata. Pack assembly returns its legacy response and trace from the same retrieval pass, then the local evidence ledger stores at most 50 selected exposures and 20 diagnostics. Exposure snapshots contain bounded identity, revision, scope, score, and reason-code fields; working-set evidence is limited to normalized repository-relative paths. The plugin marks handoff after the exact context bytes are attached. A cache hit for the current request creates and delivers one new attempt without modifying the original, while byte-for-byte reconstruction of historical message parts creates no attempts. Ledger writes are fail-open and do not alter retrieval, rendering, or injection.
+Before each pack build, the plugin derives stable attempt and request identities from safe request components so an exact adapter retry is idempotent. At the tool-event boundary, repository-contained absolute working-set paths are converted to repository-relative `/` paths; outside-repository, traversing, blank, and overlong paths are discarded. The same normalized set feeds pack retrieval and its ledger metadata. Before sending prompt-derived POST data, the plugin performs a payload-free, redirect-disabled handshake that verifies the Codemem viewer marker plus resolved database, identity/config, compression, and embedding targets. The viewer also verifies that its cached store identity still matches current database/config resolution before retrieval or ledger writes. Connection failures, timeouts, unavailable endpoints, unrecognized responses, server failures, unusable success responses, and profile-target mismatches use the compatible CLI fallback, while structured validated request errors are terminal. Pack assembly returns its legacy response and trace from the same retrieval pass, then the local evidence ledger stores at most 50 selected exposures and 20 diagnostics. Exposure snapshots contain bounded identity, revision, scope, score, and reason-code fields; working-set evidence is limited to normalized repository-relative paths. Attempt recording, handoff, skipped attempts, and cache reuse use the viewer ledger dispatcher on healthy paths and retain classified CLI fallback. A cache hit for the current request creates and delivers one new attempt without modifying the original, while byte-for-byte reconstruction of historical message parts creates no attempts. Ledger writes are fail-open and do not alter retrieval, rendering, or injection.
 
 ```mermaid
 sequenceDiagram
 participant OC as OpenCode
 participant PL as codemem plugin
+participant VW as viewer HTTP
 participant CLI as codemem pack
 participant ST as MemoryStore
 participant DB as SQLite
@@ -217,13 +218,18 @@ OC->>PL: tool.execute.after events
 PL->>PL: update session context
 OC->>PL: experimental.chat.messages.transform
 PL->>PL: build injection query from working set
-PL->>CLI: codemem pack with query, limit, token budget
+PL->>VW: POST /api/pack with query, working set, render options, attempt
+alt retryable viewer failure
+PL->>CLI: codemem pack fallback
 CLI->>ST: build_memory_pack
+else healthy viewer
+VW->>ST: build_memory_pack
+end
 ST->>DB: FTS5 BM25 lexical search
 ST->>DB: sqlite-vec semantic search
 ST->>ST: merge, rerank, assemble sections
-ST-->>CLI: pack text and metrics
-CLI-->>PL: JSON result
+ST-->>PL: pack text and metrics through selected transport
+PL->>VW: POST /api/prompt-pack-ledger delivery
 PL->>OC: append codemem context to latest user message
 ```
 

--- a/docs/plans/2026-08-10-release-0.41-fast-focused-recall-implementation.md
+++ b/docs/plans/2026-08-10-release-0.41-fast-focused-recall-implementation.md
@@ -21,6 +21,27 @@
 **Verification:** the fixture is deterministic and privacy-safe; the documented
 measurement does not persist prompt or memory content.
 
+#### Development-only warm transport benchmark
+
+Do not add a public CLI command or package script. Use a local benchmark harness
+against one fixed, privacy-safe query fixture and identical pack inputs (query,
+project/cwd, working set, render options, and database) for each path:
+
+1. Start one viewer and warm the viewer store and embedding client with each case;
+   also run and discard one CLI case so setup is excluded.
+2. Run 30 measured repetitions per case for: direct CLI pack, healthy viewer-backed
+   plugin transport, and viewer-unavailable plugin transport that takes the
+   classified retryable CLI fallback. Keep the viewer alive for the healthy path.
+3. Report aggregate median and p95 latency and pack/`prompt-pack-ledger`
+   subprocess counts for each path; never write prompts, memory text, IDs, or
+   per-query results to benchmark output.
+4. Classify every failed repetition as terminal contract (validated 4xx), retryable
+   transport/protocol (connection, timeout, 404/405, 5xx, unusable response), or
+   harness/environment failure. Exclude none silently; report counts separately.
+
+Historical latency and 30-trace figures remain rationale only. Publish results as
+new measurement evidence only after this procedure completes.
+
 ### Recall 1: Viewer pack transport contract
 
 **Tracking:** `codemem-83te`

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -14,6 +14,20 @@ This page covers advanced plugin behavior, environment variables, and stream rel
 4. Use `codemem stats` and `codemem recent` to confirm ingestion.
 5. Browse the viewer at the printed URL.
 
+OpenCode prompt-time pack construction and prompt-pack ledger transitions use the
+long-lived local viewer first. Retryable connection, timeout, endpoint-version,
+server, or malformed-response failures fall back to the compatible CLI path.
+Validated request errors are terminal and do not spawn a fallback command. The
+HTTP timeout uses `CODEMEM_INJECT_HTTP_MAX_TIME_S` (default: 2 seconds).
+Pack and ledger requests include their resolved default or explicit database,
+identity/config, compression, and embedding targets. The viewer also rejects a cached store
+identity that no longer matches current database/config resolution. A mismatch
+uses the CLI fallback instead of accepting context from another local profile.
+Arbitrary 4xx responses from a process on the viewer port also fall back; only
+structured Codemem validation errors are terminal. A payload-free profile
+handshake runs before each POST, and Fetch redirects are disabled so prompt-derived
+request bodies are not replayed to another endpoint.
+
 ## Claude marketplace install
 
 CodeMem's Claude integration is hook-first and distributed through a Claude plugin marketplace source in this repo (`.claude-plugin/marketplace.json`).
@@ -350,7 +364,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_CODEX_HOOK_LOCK_TTL_S` | Seconds before a Codex hook fallback lock is treated as stale (default `120`). |
 | `CODEMEM_CODEX_HOOK_SPOOL_DIR` | Codex hook fallback spool directory (default `~/.codemem/codex-hook-spool`). |
 | `CODEMEM_INJECT_HTTP_CONNECT_TIMEOUT_S` | `UserPromptSubmit` pack injection connect timeout in seconds (default `1`). |
-| `CODEMEM_INJECT_HTTP_MAX_TIME_S` | `UserPromptSubmit` pack injection total timeout in seconds (default `2`). |
+| `CODEMEM_INJECT_HTTP_MAX_TIME_S` | Viewer request timeout for OpenCode packs/ledger transitions and total HTTP pack timeout for Claude/Codex `UserPromptSubmit` (default `2` seconds). |
 | `CODEMEM_INJECT_HTTP_FALLBACK` | Set to `0` to disable HTTP `/api/pack` fallback for Claude/Codex prompt-time injection (default `1`). |
 | `CODEMEM_INJECT_MAX_CHARS` | Max chars returned as Claude/Codex `additionalContext` (default `16000`). |
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |

--- a/packages/cli/.opencode/tests/plugin-transform-hook.test.js
+++ b/packages/cli/.opencode/tests/plugin-transform-hook.test.js
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { connect } from "../../../core/src/db.js";
 import { buildMemoryPackWithTrace } from "../../../core/src/pack.js";
 import { MemoryStore } from "../../../core/src/store.js";
@@ -37,6 +37,78 @@ const makeProcess = ({ stdout = "", stderr = "", exitCode = 0 }) => {
 	});
 	return proc;
 };
+
+const jsonResponse = (status, body) => ({
+	ok: status >= 200 && status < 300,
+	status,
+	json: vi.fn().mockResolvedValue(body),
+});
+
+const packResponse = (text = "## Summary\n[1] (feature) Viewer-backed context") => ({
+	pack_text: text,
+	metrics: { total_items: 1, pack_tokens: 24 },
+});
+
+const normalizeIdentityPath = (value, cwd = "/tmp/greenroom") => {
+	const trimmed = String(value || "").trim();
+	if (!trimmed) return null;
+	const expanded = trimmed.startsWith("~/")
+		? join(process.env.HOME?.trim() || homedir(), trimmed.slice(2))
+		: trimmed;
+	return resolve(cwd, expanded);
+};
+
+const viewerProfileResponse = () => jsonResponse(200, {
+	service: "codemem-viewer",
+	protocol_version: 1,
+	db_path: resolve(
+		normalizeIdentityPath(process.env.CODEMEM_DB) || join(homedir(), ".codemem", "mem.sqlite"),
+	),
+	identity_target: {
+		device_id: process.env.CODEMEM_DEVICE_ID?.trim() || null,
+		actor_id_present: Object.hasOwn(process.env, "CODEMEM_ACTOR_ID"),
+		actor_id: process.env.CODEMEM_ACTOR_ID?.trim() || null,
+		config_path: normalizeIdentityPath(process.env.CODEMEM_CONFIG),
+		runtime_root: normalizeIdentityPath(process.env.CODEMEM_RUNTIME_ROOT),
+		workspace_id: process.env.CODEMEM_WORKSPACE_ID?.trim() || null,
+		home_dir: normalizeIdentityPath(process.env.HOME || homedir()),
+		pack_compression: process.env.CODEMEM_PACK_COMPRESSION?.trim() || null,
+		embedding_disabled: ["1", "true", "yes"].includes(
+			String(process.env.CODEMEM_EMBEDDING_DISABLED || "").toLowerCase(),
+		),
+		embedding_model: process.env.CODEMEM_EMBEDDING_MODEL || "Xenova/bge-small-en-v1.5",
+	},
+});
+
+const messageOutput = ({
+	messageId = "user-viewer",
+	sessionID = "sess-viewer",
+	text = "use viewer transport",
+} = {}) => ({
+	messages: [
+		{
+			info: { id: messageId, sessionID, role: "user" },
+			parts: [
+				{
+					id: `${messageId}-text`,
+					sessionID,
+					messageID: messageId,
+					type: "text",
+					text,
+				},
+			],
+		},
+	],
+});
+
+const fetchPostCalls = (fetchMock) =>
+	fetchMock.mock.calls.filter(([, options]) => options?.method === "POST");
+
+const fetchBody = (fetchMock, callIndex) =>
+	JSON.parse(fetchPostCalls(fetchMock)[callIndex][1].body);
+
+const isPackOrLedgerSpawn = ([, args]) =>
+	Array.isArray(args) && (args.includes("pack") || args.includes("prompt-pack-ledger"));
 
 const makeProcessFromPackCommand = (args, options = {}) => {
 	const proc = new EventEmitter();
@@ -149,6 +221,19 @@ describe("OpenCode transform-time injection", () => {
 			CODEMEM_PLUGIN_LOG: "0",
 			CODEMEM_INJECT_CONTEXT: "1",
 		};
+		for (const key of [
+			"CODEMEM_DB",
+			"CODEMEM_DEVICE_ID",
+			"CODEMEM_ACTOR_ID",
+			"CODEMEM_CONFIG",
+			"CODEMEM_RUNTIME_ROOT",
+			"CODEMEM_WORKSPACE_ID",
+			"CODEMEM_PACK_COMPRESSION",
+			"CODEMEM_EMBEDDING_DISABLED",
+			"CODEMEM_EMBEDDING_MODEL",
+		]) {
+			delete process.env[key];
+		}
 	});
 
 	afterEach(() => {
@@ -1484,6 +1569,528 @@ describe("OpenCode transform-time injection", () => {
 		expect(userPrompt).not.toContain("forbidden payroll details");
 		expect(showToast).toHaveBeenCalledTimes(1);
 		expect(JSON.stringify(showToast.mock.calls)).not.toContain("forbidden payroll");
+	});
+
+	test.each(["::1", "[::1]"])("uses bracketed IPv6 viewer URLs for %s", async (viewerHost) => {
+		// Arrange
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "0";
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		process.env.CODEMEM_VIEWER_HOST = viewerHost;
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) =>
+			String(url).endsWith("/api/prompt-pack-profile")
+				? viewerProfileResponse()
+				: String(url).endsWith("/api/pack")
+				? jsonResponse(200, packResponse())
+				: jsonResponse(200, { ok: true }),
+		);
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+		const output = messageOutput();
+
+		// Act
+		await hooks["experimental.chat.messages.transform"]({}, output);
+		await vi.waitFor(() => expect(fetchPostCalls(fetchMock)).toHaveLength(2));
+
+		// Assert
+		expect(String(fetchMock.mock.calls[0][0])).toBe(
+			"http://[::1]:38888/api/prompt-pack-profile",
+		);
+		expect(fetchPostCalls(fetchMock).map(([url, options]) => [String(url), options.method])).toEqual([
+			["http://[::1]:38888/api/pack", "POST"],
+			["http://[::1]:38888/api/prompt-pack-ledger", "POST"],
+		]);
+		expect(fetchBody(fetchMock, 1)).toMatchObject({
+			action: "delivery",
+			attempt_id: fetchBody(fetchMock, 0).attempt.attempt_id,
+			delivery_status: "handed_off",
+		});
+		const defaultDbPath = join(homedir(), ".codemem", "mem.sqlite");
+		expect(fetchBody(fetchMock, 0).db_path).toBe(defaultDbPath);
+		expect(fetchBody(fetchMock, 1).db_path).toBe(defaultDbPath);
+		expect(output.messages[0].parts.at(-1).text).toBe(
+			"[codemem context]\n## Summary\n[1] (feature) Viewer-backed context",
+		);
+		expect(spawnMock.mock.calls.filter(isPackOrLedgerSpawn)).toEqual([]);
+	});
+
+	test("records a skipped injection through the healthy viewer without spawning ledger CLI", async () => {
+		// Arrange
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "0";
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		process.env.CODEMEM_INJECT_CONTEXT = "0";
+		process.env.CODEMEM_DB = "~/greenroom.sqlite";
+		process.env.CODEMEM_PACK_COMPRESSION = "off";
+		process.env.CODEMEM_EMBEDDING_DISABLED = "true";
+		process.env.CODEMEM_EMBEDDING_MODEL = "test-embedding-model";
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) =>
+			String(url).endsWith("/api/prompt-pack-profile")
+				? viewerProfileResponse()
+				: jsonResponse(200, { ok: true }),
+		);
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+		const output = messageOutput({ messageId: "user-skipped", sessionID: "sess-skipped" });
+
+		// Act
+		await hooks["experimental.chat.messages.transform"]({}, output);
+		await vi.waitFor(() => expect(fetchPostCalls(fetchMock)).toHaveLength(1));
+
+		// Assert
+		expect(fetchPostCalls(fetchMock)[0][0]).toBe(
+			"http://127.0.0.1:38888/api/prompt-pack-ledger",
+		);
+			expect(fetchBody(fetchMock, 0)).toMatchObject({
+				action: "record",
+				db_path: join(process.env.HOME?.trim() || homedir(), "greenroom.sqlite"),
+				identity_target: {
+					pack_compression: "off",
+					embedding_disabled: true,
+					embedding_model: "test-embedding-model",
+				},
+			retrieval_status: "skipped",
+			failure_code: "injection_disabled",
+		});
+		expect(output.messages[0].parts).toHaveLength(1);
+		expect(spawnMock.mock.calls.filter(isPackOrLedgerSpawn)).toEqual([]);
+	});
+
+	test("records cache reuse and delivery through the healthy viewer without spawning ledger CLI", async () => {
+		// Arrange
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "0";
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		process.env.CODEMEM_DB = "relative.sqlite";
+		process.env.CODEMEM_CONFIG = "config/codemem.json";
+		process.env.CODEMEM_RUNTIME_ROOT = "runtime";
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) =>
+			String(url).endsWith("/api/prompt-pack-profile")
+				? viewerProfileResponse()
+				: String(url).endsWith("/api/pack")
+				? jsonResponse(200, packResponse("## Summary\n[1] (decision) Cache-stable bytes"))
+				: jsonResponse(200, { ok: true }),
+		);
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+		const firstOutput = messageOutput({ messageId: "user-cache", sessionID: "sess-cache" });
+		await hooks["experimental.chat.messages.transform"]({}, firstOutput);
+		await vi.waitFor(() =>
+			expect(fetchPostCalls(fetchMock).some(([url]) => String(url).endsWith("/api/pack"))).toBe(true),
+		);
+		const packCall = fetchPostCalls(fetchMock).find(([url]) => String(url).endsWith("/api/pack"));
+		const originalAttemptId = JSON.parse(packCall[1].body).attempt.attempt_id;
+		const cachedOutput = messageOutput({ messageId: "user-cache", sessionID: "sess-cache" });
+
+		// Act
+		await hooks["experimental.chat.messages.transform"]({}, cachedOutput);
+		await vi.waitFor(() => {
+			const bodies = fetchPostCalls(fetchMock)
+				.filter(([url]) => String(url).endsWith("/api/prompt-pack-ledger"))
+				.map(([, options]) => JSON.parse(options.body));
+			const reuse = bodies.find((body) => body.action === "cache_reuse");
+			expect(reuse?.original_attempt_id).toBe(originalAttemptId);
+			expect(bodies.some((body) =>
+				body.action === "delivery" && body.attempt_id === reuse?.attempt_id)).toBe(true);
+		});
+
+		// Assert
+		const ledgerBodies = fetchPostCalls(fetchMock)
+			.filter(([url]) => String(url).endsWith("/api/prompt-pack-ledger"))
+			.map(([, options]) => JSON.parse(options.body));
+		const cacheReuse = ledgerBodies.find((body) => body.action === "cache_reuse");
+		const cacheDelivery = ledgerBodies.find((body) =>
+			body.action === "delivery" && body.attempt_id === cacheReuse.attempt_id);
+		expect(cacheReuse).toMatchObject({
+			action: "cache_reuse",
+			original_attempt_id: originalAttemptId,
+		});
+		expect(cacheReuse.attempt_id).not.toBe(originalAttemptId);
+		expect(cacheDelivery).toEqual({
+			action: "delivery",
+			attempt_id: cacheReuse.attempt_id,
+			db_path: "/tmp/greenroom/relative.sqlite",
+			delivery_status: "handed_off",
+			identity_target: {
+				device_id: null,
+				actor_id_present: false,
+				actor_id: null,
+				config_path: "/tmp/greenroom/config/codemem.json",
+				runtime_root: "/tmp/greenroom/runtime",
+				workspace_id: null,
+				home_dir: resolve(process.env.HOME?.trim() || homedir()),
+				pack_compression: null,
+				embedding_disabled: false,
+				embedding_model: "Xenova/bge-small-en-v1.5",
+			},
+		});
+		expect(cachedOutput.messages[0].parts.at(-1).text).toBe(
+			"[codemem context]\n## Summary\n[1] (decision) Cache-stable bytes",
+		);
+		expect(spawnMock.mock.calls.filter(isPackOrLedgerSpawn)).toEqual([]);
+	});
+
+	test("repairs a viewer pack idempotency conflict over HTTP with fresh identity and no CLI", async () => {
+		// Arrange
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "0";
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		let packCalls = 0;
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+			if (String(url).endsWith("/api/prompt-pack-profile")) return viewerProfileResponse();
+			if (String(url).endsWith("/api/pack")) {
+				packCalls += 1;
+				return jsonResponse(200, packCalls === 1
+					? {
+						...packResponse("## Summary\n[1] (feature) Stale conflict bytes"),
+						ledger_outcome: {
+							ok: false,
+							errorCode: "retrieval_ledger_write_failed",
+							reason: "idempotency_conflict",
+						},
+					}
+					: packResponse("## Summary\n[2] (decision) Fresh viewer identity"));
+			}
+			return jsonResponse(200, { ok: true });
+		});
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+		const output = messageOutput({ messageId: "user-conflict", sessionID: "sess-conflict" });
+
+		// Act
+		await hooks["experimental.chat.messages.transform"]({}, output);
+		await vi.waitFor(() => {
+			const packBodies = fetchPostCalls(fetchMock)
+				.filter(([url]) => String(url).endsWith("/api/pack"))
+				.map(([, options]) => JSON.parse(options.body))
+				.filter((body) => body.attempt?.stream_id === "sess-conflict");
+			expect(packBodies).toHaveLength(2);
+			const deliveries = fetchPostCalls(fetchMock)
+				.filter(([url]) => String(url).endsWith("/api/prompt-pack-ledger"))
+				.map(([, options]) => JSON.parse(options.body));
+			expect(deliveries.some((body) =>
+				body.action === "delivery" && body.attempt_id === packBodies[1].attempt.attempt_id)).toBe(true);
+		});
+
+		// Assert
+		const conflictPackBodies = fetchPostCalls(fetchMock)
+			.filter(([url]) => String(url).endsWith("/api/pack"))
+			.map(([, options]) => JSON.parse(options.body))
+			.filter((body) => body.attempt?.stream_id === "sess-conflict");
+		const firstAttempt = conflictPackBodies[0].attempt;
+		const repairedAttempt = conflictPackBodies[1].attempt;
+		expect(firstAttempt.attempt_id).not.toBe(repairedAttempt.attempt_id);
+		expect(firstAttempt.request_id).not.toBe(repairedAttempt.request_id);
+		const repairedDelivery = fetchPostCalls(fetchMock)
+			.filter(([url]) => String(url).endsWith("/api/prompt-pack-ledger"))
+			.map(([, options]) => JSON.parse(options.body))
+			.find((body) => body.action === "delivery" && body.attempt_id === repairedAttempt.attempt_id);
+		expect(repairedDelivery).toMatchObject({
+			action: "delivery",
+			attempt_id: repairedAttempt.attempt_id,
+		});
+		expect(output.messages[0].parts.at(-1).text).toContain("Fresh viewer identity");
+		expect(spawnMock.mock.calls.filter(isPackOrLedgerSpawn)).toEqual([]);
+	});
+
+	test.each([
+		["foreign service", () => jsonResponse(200, { service: "not-codemem" })],
+		["untrusted invalid-request response", () => jsonResponse(400, {
+			error: { code: "invalid_request", message: "not your viewer" },
+		})],
+		["stale viewer identity", () => jsonResponse(409, {
+			error: { code: "viewer_identity_mismatch", message: "viewer identity does not match request" },
+		})],
+		["redirect", () => new Response(null, {
+			status: 307,
+			headers: { Location: "http://127.0.0.1:39999/capture" },
+		})],
+	])("falls back before sending prompt data when the viewer profile handshake hits a %s", async (
+		_label,
+		profileResult,
+	) => {
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "0";
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+			if (String(url).endsWith("/api/prompt-pack-profile")) return profileResult();
+			throw new Error("prompt payload must not be sent before profile validation");
+		});
+		spawnMock.mockImplementation((_command, args) =>
+			Array.isArray(args) && args.includes("pack")
+				? makeProcess({ stdout: JSON.stringify(packResponse("## Summary\n[9] Safe CLI fallback")) })
+				: makeProcess({ stdout: "" }),
+		);
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+		const output = messageOutput({ messageId: "user-handshake", sessionID: "sess-handshake" });
+
+		await hooks["experimental.chat.messages.transform"]({}, output);
+		await vi.waitFor(() =>
+			expect(spawnMock.mock.calls.filter(isPackOrLedgerSpawn)).toHaveLength(2),
+		);
+
+		expect(fetchPostCalls(fetchMock)).toEqual([]);
+		expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: "GET", redirect: "manual" });
+		expect(output.messages[0].parts.at(-1).text).toContain("Safe CLI fallback");
+	});
+
+	test.each([
+		["connection failure", () => Promise.reject(new Error("ECONNREFUSED"))],
+		["timeout", () => Promise.reject(Object.assign(new Error("timed out"), { name: "TimeoutError" }))],
+		["404", () => Promise.resolve(jsonResponse(404, { error: "not_found" }))],
+		["405", () => Promise.resolve(jsonResponse(405, { error: "method_not_allowed" }))],
+		["5xx", () => Promise.resolve(jsonResponse(503, { error: "unavailable" }))],
+		["database mismatch", () => Promise.resolve(jsonResponse(409, {
+			error: { code: "viewer_db_mismatch", message: "viewer database does not match request" },
+		}))],
+		["identity mismatch", () => Promise.resolve(jsonResponse(409, {
+			error: { code: "viewer_identity_mismatch", message: "viewer identity does not match request" },
+		}))],
+		["contract mismatch", () => Promise.resolve(jsonResponse(409, {
+			error: { code: "viewer_contract_unsupported", message: "viewer request contract is incompatible" },
+		}))],
+		["unrecognized 400", () => Promise.resolve(jsonResponse(400, { error: "bad_request" }))],
+		["unrecognized 401", () => Promise.resolve(jsonResponse(401, { error: "unauthorized" }))],
+		["malformed 2xx", () => Promise.resolve(jsonResponse(200, { pack_text: 42 }))],
+	])("falls back to pack and ledger CLI after viewer %s while preserving output and ledger handoff", async (
+		_label,
+		viewerResult,
+	) => {
+		// Arrange
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "0";
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		process.env.CODEMEM_DB = "/tmp/greenroom.sqlite";
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((url) =>
+			String(url).endsWith("/api/prompt-pack-profile")
+				? Promise.resolve(viewerProfileResponse())
+				: viewerResult(),
+		);
+		const packPayloads = [];
+		const ledgerPayloads = [];
+		spawnMock.mockImplementation((_command, args) => {
+			if (Array.isArray(args) && args.includes("pack")) {
+				const proc = makeProcess({
+					stdout: JSON.stringify(packResponse("## Summary\n[7] (feature) CLI fallback bytes")),
+				});
+				proc.stdin.write = vi.fn((value) => packPayloads.push(JSON.parse(String(value))));
+				return proc;
+			}
+			const proc = makeProcess({ stdout: "" });
+			if (Array.isArray(args) && args.includes("prompt-pack-ledger")) {
+				proc.stdin.write = vi.fn((value) => ledgerPayloads.push(JSON.parse(String(value))));
+			}
+			return proc;
+		});
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+		const output = messageOutput({ messageId: "user-fallback", sessionID: "sess-fallback" });
+
+		// Act
+		await hooks["experimental.chat.messages.transform"]({}, output);
+		await vi.waitFor(() => expect(ledgerPayloads).toHaveLength(1));
+
+		// Assert
+		expect(fetchPostCalls(fetchMock)).toHaveLength(1);
+		expect(packPayloads).toHaveLength(1);
+		expect(ledgerPayloads).toEqual([
+			{
+				action: "delivery",
+				attempt_id: packPayloads[0].attempt_id,
+				delivery_status: "handed_off",
+			},
+		]);
+		expect(output.messages[0].parts.at(-1).text).toBe(
+			"[codemem context]\n## Summary\n[7] (feature) CLI fallback bytes",
+		);
+		expect(spawnMock.mock.calls.filter(isPackOrLedgerSpawn)).toHaveLength(2);
+	});
+
+	test.each([
+		["connection failure", () => Promise.reject(new Error("ECONNREFUSED"))],
+		["timeout", () => Promise.reject(Object.assign(new Error("timed out"), { name: "TimeoutError" }))],
+		["404", () => Promise.resolve(jsonResponse(404, { error: "not_found" }))],
+		["405", () => Promise.resolve(jsonResponse(405, { error: "method_not_allowed" }))],
+		["unrecognized 401", () => Promise.resolve(jsonResponse(401, { error: "unauthorized" }))],
+		["identity mismatch", () => Promise.resolve(jsonResponse(409, {
+			error: { code: "viewer_identity_mismatch", message: "viewer identity does not match request" },
+		}))],
+		["5xx", () => Promise.resolve(jsonResponse(503, { error: "unavailable" }))],
+		["malformed 2xx", () => Promise.resolve(jsonResponse(200, { ok: "yes" }))],
+	])("falls back only the ledger transition after viewer ledger %s", async (
+		_label,
+		viewerLedgerResult,
+	) => {
+		// Arrange
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "0";
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((url) =>
+			String(url).endsWith("/api/prompt-pack-profile")
+				? Promise.resolve(viewerProfileResponse())
+				: String(url).endsWith("/api/pack")
+				? Promise.resolve(jsonResponse(200, packResponse()))
+				: viewerLedgerResult(),
+		);
+		const ledgerPayloads = [];
+		spawnMock.mockImplementation((_command, args) => {
+			const proc = makeProcess({ stdout: "" });
+			if (Array.isArray(args) && args.includes("prompt-pack-ledger")) {
+				proc.stdin.write = vi.fn((value) => ledgerPayloads.push(JSON.parse(String(value))));
+			}
+			return proc;
+		});
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+		const output = messageOutput({ messageId: "user-ledger-fallback", sessionID: "sess-ledger-fallback" });
+
+		// Act
+		await hooks["experimental.chat.messages.transform"]({}, output);
+		await vi.waitFor(() => expect(ledgerPayloads).toHaveLength(1));
+
+		// Assert
+		const viewerLedgerPayloads = fetchPostCalls(fetchMock)
+			.filter(([url]) => String(url).endsWith("/api/prompt-pack-ledger"))
+			.map(([, options]) => JSON.parse(options.body));
+		const deliveryPayload = viewerLedgerPayloads.find((body) => body.action === "delivery");
+		expect(deliveryPayload).toMatchObject({
+			action: "delivery",
+			delivery_status: "handed_off",
+		});
+		const {
+			db_path: _viewerDbPath,
+			identity_target: _viewerIdentityTarget,
+			...cliLedgerPayload
+		} = deliveryPayload;
+		expect(ledgerPayloads).toEqual([cliLedgerPayload]);
+		expect(output.messages[0].parts.at(-1).text).toContain("Viewer-backed context");
+		expect(spawnMock.mock.calls.filter(isPackOrLedgerSpawn)).toHaveLength(1);
+		expect(spawnMock.mock.calls.filter(isPackOrLedgerSpawn)[0][1]).toContain(
+			"prompt-pack-ledger",
+		);
+	});
+
+	test("treats viewer 400 responses as terminal without spawning pack or ledger CLI", async () => {
+		// Arrange
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "0";
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+			if (String(url).endsWith("/api/prompt-pack-profile")) return viewerProfileResponse();
+			return String(url).endsWith("/api/pack")
+				? jsonResponse(400, { error: { code: "invalid_request", message: "context is required" } })
+				: jsonResponse(400, {
+						error: { code: "invalid_request", message: "attempt_id is required" },
+					});
+		});
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+		const output = messageOutput({ messageId: "user-invalid", sessionID: "sess-invalid" });
+
+		// Act
+		await hooks["experimental.chat.messages.transform"]({}, output);
+		await vi.waitFor(() => expect(fetchPostCalls(fetchMock)).toHaveLength(2));
+
+		// Assert
+		expect(fetchPostCalls(fetchMock).map(([url]) => String(url))).toEqual([
+			"http://127.0.0.1:38888/api/pack",
+			"http://127.0.0.1:38888/api/prompt-pack-ledger",
+		]);
+		expect(fetchBody(fetchMock, 1)).toMatchObject({
+			action: "record",
+			retrieval_status: "failed",
+			failure_code: "pack_command_failed",
+		});
+		expect(output.messages[0].parts).toHaveLength(1);
+		expect(spawnMock.mock.calls.filter(isPackOrLedgerSpawn)).toEqual([]);
+	});
+
+	test.each([
+		["write 404", 404, "retrieval_ledger_write_failed", "attempt_not_found"],
+		["delivery 503", 503, "retrieval_ledger_delivery_write_failed", "storage_unavailable"],
+	])("treats a structured ledger %s as terminal without arming pack backoff", async (
+		_label,
+		status,
+		errorCode,
+		reason,
+	) => {
+		// Arrange
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "0";
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		let postCount = 0;
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+			if (String(url).endsWith("/api/prompt-pack-profile")) return viewerProfileResponse();
+			postCount += 1;
+			if (postCount === 1) return jsonResponse(200, packResponse("## Summary\n[1] First pack"));
+			if (postCount === 2) return jsonResponse(status, { ok: false, errorCode, reason });
+			if (postCount === 3) return jsonResponse(200, packResponse("## Summary\n[2] Next pack"));
+			return jsonResponse(200, { ok: true });
+		});
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+
+		// Act
+		await hooks["experimental.chat.messages.transform"]({}, messageOutput({
+			messageId: "user-ledger-terminal",
+			sessionID: "sess-ledger-terminal",
+		}));
+		await vi.waitFor(() => expect(fetchPostCalls(fetchMock)).toHaveLength(2));
+		await hooks["experimental.chat.messages.transform"]({}, messageOutput({
+			messageId: "user-after-ledger-terminal",
+			sessionID: "sess-ledger-terminal",
+		}));
+		await vi.waitFor(() => expect(fetchPostCalls(fetchMock)).toHaveLength(4));
+
+		// Assert
+		expect(fetchMock.mock.calls.filter(([url]) => String(url).endsWith("/api/pack"))).toHaveLength(2);
+		expect(spawnMock.mock.calls.filter(isPackOrLedgerSpawn)).toEqual([]);
 	});
 
 	test("retries one SQLite-locked raw-event fallback with the identical envelope and marks it delivered", async () => {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -288,6 +288,30 @@ export class MemoryStore {
 		this.crossSessionDedupWindowMs = resolveCrossSessionDedupWindowMs();
 	}
 
+	hasCurrentIdentity(): boolean {
+		const envDeviceId = process.env.CODEMEM_DEVICE_ID?.trim();
+		let dbDeviceId: string | undefined;
+		if (!envDeviceId) {
+			try {
+				const row = this.d
+					.select({ device_id: schema.syncDevice.device_id })
+					.from(schema.syncDevice)
+					.limit(1)
+					.get();
+				dbDeviceId = row?.device_id;
+			} catch {
+				// Older/minimal schemas use the stable local fallback.
+			}
+		}
+		const deviceId = envDeviceId || dbDeviceId || "local";
+		const config = readCodememConfigFile();
+		const configActorId = Object.hasOwn(process.env, "CODEMEM_ACTOR_ID")
+			? cleanStr(process.env.CODEMEM_ACTOR_ID)
+			: (cleanStr(config.actor_id) ?? null);
+		const actorId = configActorId || `local:${deviceId}`;
+		return deviceId === this.deviceId && actorId === this.actorId;
+	}
+
 	refreshPersistedLocalIdentity(expectedActorId: string): boolean {
 		const actorId = cleanStr(expectedActorId);
 		if (!actorId) return false;

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -1,6 +1,7 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join, posix, resolve, win32 } from "node:path";
+import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 import { spawn as nodeSpawn, execSync } from "node:child_process";
 import { tool } from "@opencode-ai/plugin";
@@ -445,6 +446,141 @@ const parsePackOutput = (result) => {
   };
 };
 
+const isRecord = (value) => value != null && typeof value === "object" && !Array.isArray(value);
+
+const isValidPackHttpPayload = (payload) => {
+  if (!isRecord(payload) || typeof payload.pack_text !== "string" || !isRecord(payload.metrics)) {
+    return false;
+  }
+  const itemCount = payload.metrics.total_items;
+  if (!Number.isInteger(itemCount) || itemCount < 0) {
+    return false;
+  }
+  if (
+    payload.ledger_artifact_fingerprint != null
+    && !/^[0-9a-f]{64}$/i.test(payload.ledger_artifact_fingerprint)
+  ) {
+    return false;
+  }
+  if (payload.ledger_outcome != null) {
+    return isRecord(payload.ledger_outcome)
+      && payload.ledger_outcome.ok === false
+      && payload.ledger_outcome.errorCode === "retrieval_ledger_write_failed"
+      && payload.ledger_outcome.reason === "idempotency_conflict";
+  }
+  return true;
+};
+
+const isValidLedgerHttpPayload = (payload) => isRecord(payload) && payload.ok === true;
+
+const isValidLedgerFailureHttpPayload = (payload) =>
+  isRecord(payload)
+  && payload.ok === false
+  && (
+    payload.errorCode === "retrieval_ledger_write_failed"
+    || payload.errorCode === "retrieval_ledger_delivery_write_failed"
+  )
+  && typeof payload.reason === "string";
+
+const isViewerDbMismatchPayload = (payload) =>
+  isRecord(payload)
+  && isRecord(payload.error)
+  && payload.error.code === "viewer_db_mismatch";
+
+const isViewerIdentityMismatchPayload = (payload) =>
+  isRecord(payload)
+  && isRecord(payload.error)
+  && payload.error.code === "viewer_identity_mismatch";
+
+const isViewerContractUnsupportedPayload = (payload) =>
+  isRecord(payload)
+  && isRecord(payload.error)
+  && payload.error.code === "viewer_contract_unsupported";
+
+const isViewerInvalidRequestPayload = (payload) =>
+  isRecord(payload)
+  && isRecord(payload.error)
+  && payload.error.code === "invalid_request"
+  && typeof payload.error.message === "string";
+
+const classifyViewerHttpFailure = ({
+  operation,
+  status = null,
+  error = null,
+  malformed = false,
+  body = null,
+}) => {
+  if (malformed) {
+    return { cause: `${operation} returned malformed success`, retryable: true };
+  }
+  if (
+    isViewerDbMismatchPayload(body)
+    || isViewerIdentityMismatchPayload(body)
+    || isViewerContractUnsupportedPayload(body)
+  ) {
+    return { cause: `${operation} viewer profile mismatch`, retryable: true };
+  }
+  if (operation === "prompt-pack-ledger" && isValidLedgerFailureHttpPayload(body)) {
+    return { cause: `${operation} request rejected (${status})`, retryable: false };
+  }
+  if (isViewerInvalidRequestPayload(body) && !operation.endsWith(" profile")) {
+    return { cause: `${operation} request rejected (${status})`, retryable: false };
+  }
+  if (status === 404 || status === 405) {
+    return { cause: `${operation} endpoint unavailable (${status})`, retryable: true };
+  }
+  if (Number.isInteger(status) && status >= 500) {
+    return { cause: `${operation} server failure (${status})`, retryable: true };
+  }
+  if (Number.isInteger(status)) {
+    return { cause: `${operation} unexpected response (${status})`, retryable: true };
+  }
+  const diagnostic = [
+    error?.name,
+    error?.code,
+    error?.cause?.code,
+    error?.message,
+    error,
+  ].filter(Boolean).join(" ");
+  const timedOut = /AbortError|TimeoutError|timeout|timed out|ETIMEDOUT/i.test(diagnostic);
+  return {
+    cause: timedOut ? `${operation} request timeout` : `${operation} connection failed`,
+    retryable: true,
+  };
+};
+
+const buildPackHttpBody = ({
+  query,
+  filesModified,
+  injectLimit,
+  injectTokenBudget,
+  projectName,
+  cwd,
+  dbPath,
+  identityTarget,
+  attempt,
+}) => ({
+  context: query,
+  limit: injectLimit !== null && Number.isFinite(injectLimit) && injectLimit > 0
+    ? Math.trunc(injectLimit)
+    : 10,
+  token_budget:
+    injectTokenBudget !== null
+    && Number.isFinite(injectTokenBudget)
+    && injectTokenBudget > 0
+      ? Math.trunc(injectTokenBudget)
+      : null,
+  ...(projectName ? { project: projectName } : {}),
+  ...(cwd ? { cwd } : {}),
+  db_path: dbPath,
+  identity_target: identityTarget,
+  working_set_files: Array.from(filesModified || [])
+    .slice(-8)
+    .map((value) => String(value || "").trim())
+    .filter((value) => value && value.length <= MAX_WORKING_SET_PATH_CHARS),
+  attempt,
+});
+
 const canonicalJson = (value) => {
   if (Array.isArray(value)) {
     return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
@@ -491,7 +627,7 @@ const applyInjectedContextToOutput = async ({
   // lastPromptText hadn't yet been captured by the time
   // experimental.chat.system.transform fired) would silently re-serve
   // the first turn's pack. Recompute on every call instead — the chat
-  // path tolerates the runCli round trip, and correctness beats the
+  // path tolerates the transport round trip, and correctness beats the
   // O(1) hit when the cache key isn't tied to the prompt that produced
   // the pack.
   const query = resolveInjectQuery();
@@ -1323,6 +1459,35 @@ export const OpencodeMemPlugin = async ({
   const viewerHost = process.env.CODEMEM_VIEWER_HOST || "127.0.0.1";
   const viewerPort = process.env.CODEMEM_VIEWER_PORT || "38888";
   const viewerDbPath = process.env.CODEMEM_DB || "";
+  const expandedViewerDbPath = viewerDbPath.startsWith("~/")
+    ? join(process.env.HOME?.trim() || homedir(), viewerDbPath.slice(2))
+    : viewerDbPath;
+  const promptPackDbPath = resolve(
+    cwd,
+    expandedViewerDbPath || join(homedir(), ".codemem", "mem.sqlite"),
+  );
+  const normalizeIdentityPath = (value) => {
+    const trimmed = String(value || "").trim();
+    if (!trimmed) return null;
+    const expanded = trimmed.startsWith("~/")
+      ? join(process.env.HOME?.trim() || homedir(), trimmed.slice(2))
+      : trimmed;
+    return resolve(cwd, expanded);
+  };
+  const promptPackIdentityTarget = {
+    device_id: process.env.CODEMEM_DEVICE_ID?.trim() || null,
+    actor_id_present: Object.hasOwn(process.env, "CODEMEM_ACTOR_ID"),
+    actor_id: process.env.CODEMEM_ACTOR_ID?.trim() || null,
+    config_path: normalizeIdentityPath(process.env.CODEMEM_CONFIG),
+    runtime_root: normalizeIdentityPath(process.env.CODEMEM_RUNTIME_ROOT),
+    workspace_id: process.env.CODEMEM_WORKSPACE_ID?.trim() || null,
+    home_dir: normalizeIdentityPath(process.env.HOME || homedir()),
+    pack_compression: process.env.CODEMEM_PACK_COMPRESSION?.trim() || null,
+    embedding_disabled: ["1", "true", "yes"].includes(
+      String(process.env.CODEMEM_EMBEDDING_DISABLED || "").toLowerCase(),
+    ),
+    embedding_model: process.env.CODEMEM_EMBEDDING_MODEL || "Xenova/bge-small-en-v1.5",
+  };
   const viewerConfigPath = process.env.CODEMEM_CONFIG || "";
   // A malformed value (e.g. "abc", "", "-1") falls back to the 20s default
   // instead of NaN, which would silently disable the timeout. An explicit "0"
@@ -1332,6 +1497,8 @@ export const OpencodeMemPlugin = async ({
   const rawCommandTimeout = String(process.env.CODEMEM_PLUGIN_CMD_TIMEOUT ?? "").trim();
   const commandTimeout =
     rawCommandTimeout === "0" ? 0 : parsePositiveInt(rawCommandTimeout, 20000);
+  const promptPackHttpTimeout =
+    parsePositiveInt(process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S || "2", 2) * 1000;
   const backendUpdatePolicy = parseBackendUpdatePolicy(
     process.env.CODEMEM_BACKEND_UPDATE_POLICY || "notify"
   );
@@ -1373,8 +1540,14 @@ export const OpencodeMemPlugin = async ({
   const rawEventsEnabled = envNotDisabled(
     process.env.CODEMEM_RAW_EVENTS || "1"
   );
-  const rawEventsUrl = `http://${viewerHost}:${viewerPort}/api/raw-events`;
-  const rawEventsStatusUrl = `http://${viewerHost}:${viewerPort}/api/raw-events/status?limit=1`;
+  const viewerUrlHost = viewerHost.includes(":") && !viewerHost.startsWith("[")
+    ? `[${viewerHost}]`
+    : viewerHost;
+  const rawEventsUrl = `http://${viewerUrlHost}:${viewerPort}/api/raw-events`;
+  const rawEventsStatusUrl = `http://${viewerUrlHost}:${viewerPort}/api/raw-events/status?limit=1`;
+  const packUrl = `http://${viewerUrlHost}:${viewerPort}/api/pack`;
+  const promptPackProfileUrl = `http://${viewerUrlHost}:${viewerPort}/api/prompt-pack-profile`;
+  const promptPackLedgerUrl = `http://${viewerUrlHost}:${viewerPort}/api/prompt-pack-ledger`;
   const rawEventsBackoffMs = parseNumber(
     process.env.CODEMEM_RAW_EVENTS_BACKOFF_MS || "10000",
     10000
@@ -1392,6 +1565,7 @@ export const OpencodeMemPlugin = async ({
   let fallbackFailureNoted = false;
   let lastStatusCheckAt = 0;
   let lastStatusAvailable = true;
+  let promptPackTransportUnavailableUntil = 0;
 
   // Viewer health-check state
   const HEALTH_CHECK_INTERVAL_MS = 60_000;
@@ -1967,6 +2141,110 @@ export const OpencodeMemPlugin = async ({
   const runCli = async (args, options = {}) =>
     runCommand([runner, ...runnerArgs, ...args], options);
 
+  const postViewerJson = async ({ url, operation, payload, validate }) => {
+    if (!viewerEnabled) {
+      return {
+        ok: false,
+        classification: {
+          cause: `${operation} viewer transport disabled`,
+          retryable: true,
+        },
+      };
+    }
+    if (Date.now() < promptPackTransportUnavailableUntil) {
+      return {
+        ok: false,
+        classification: {
+          cause: `${operation} viewer transport in backoff`,
+          retryable: true,
+        },
+      };
+    }
+
+    let response;
+    try {
+      const profileResponse = await fetch(promptPackProfileUrl, {
+        method: "GET",
+        redirect: "manual",
+        signal: AbortSignal.timeout(promptPackHttpTimeout),
+      });
+      let profileBody;
+      try {
+        profileBody = await profileResponse.json();
+      } catch {
+        profileBody = null;
+      }
+      if (!profileResponse.ok) {
+        const classification = classifyViewerHttpFailure({
+          operation: `${operation} profile`,
+          status: profileResponse.status,
+          body: profileBody,
+        });
+        if (classification.retryable) {
+          promptPackTransportUnavailableUntil = Date.now() + Math.max(1000, rawEventsBackoffMs);
+        }
+        return { ok: false, classification };
+      }
+      if (
+        !isRecord(profileBody)
+        || profileBody.service !== "codemem-viewer"
+        || profileBody.protocol_version !== 1
+        || profileBody.db_path !== promptPackDbPath
+        || canonicalJson(profileBody.identity_target) !== canonicalJson(promptPackIdentityTarget)
+      ) {
+        promptPackTransportUnavailableUntil = Date.now() + Math.max(1000, rawEventsBackoffMs);
+        return {
+          ok: false,
+          classification: {
+            cause: `${operation} viewer profile handshake mismatch`,
+            retryable: true,
+          },
+        };
+      }
+      response = await fetch(url, {
+        method: "POST",
+        redirect: "manual",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(promptPackHttpTimeout),
+      });
+    } catch (error) {
+      const classification = classifyViewerHttpFailure({ operation, error });
+      promptPackTransportUnavailableUntil =
+        Date.now() + Math.max(1000, rawEventsBackoffMs);
+      return { ok: false, classification };
+    }
+
+    let body;
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
+    if (!response.ok) {
+      const classification = classifyViewerHttpFailure({
+        operation,
+        status: response.status,
+        body,
+      });
+      if (classification.retryable) {
+        promptPackTransportUnavailableUntil =
+          Date.now() + Math.max(1000, rawEventsBackoffMs);
+      }
+      return { ok: false, classification };
+    }
+
+    if (!validate(body)) {
+      const classification = classifyViewerHttpFailure({ operation, malformed: true });
+      promptPackTransportUnavailableUntil =
+        Date.now() + Math.max(1000, rawEventsBackoffMs);
+      return { ok: false, classification };
+    }
+
+    promptPackTransportUnavailableUntil = 0;
+    return { ok: true, body };
+  };
+
   const attemptMetadata = (identity, sessionID = null, promptNumber = promptCounter) => ({
     attempt_id: identity.attemptId,
     started_at: (() => {
@@ -1988,10 +2266,39 @@ export const OpencodeMemPlugin = async ({
   });
 
   const runPromptPackLedger = async (payload) => {
+    const viewerPayload = {
+      ...payload,
+      db_path: promptPackDbPath,
+      identity_target: promptPackIdentityTarget,
+    };
+    const httpResult = await postViewerJson({
+      url: promptPackLedgerUrl,
+      operation: "prompt-pack-ledger",
+      payload: viewerPayload,
+      validate: isValidLedgerHttpPayload,
+    });
+    if (httpResult.ok) {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify(httpResult.body),
+        stderr: "",
+        transport: "viewer",
+      };
+    }
+
+    const { cause, retryable } = httpResult.classification;
+    await logLine(
+      `inject.ledger.http_error cause=${JSON.stringify(redactLog(cause, 200))} retryable=${retryable}`
+    );
+    if (!retryable) {
+      return { exitCode: 1, stdout: "", stderr: cause, transport: "viewer" };
+    }
+
     try {
-      return await runCli(["prompt-pack-ledger"], {
+      const result = await runCli(["prompt-pack-ledger"], {
         stdinText: JSON.stringify(payload),
       });
+      return { ...result, transport: "cli" };
     } catch {
       return null;
     }
@@ -2317,12 +2624,51 @@ export const OpencodeMemPlugin = async ({
         injectTokenBudget,
         internalLedger: true,
       });
+      const httpResult = await postViewerJson({
+        url: packUrl,
+        operation: "pack",
+        payload: buildPackHttpBody({
+          query,
+          filesModified: sessionContext.filesModified,
+          injectLimit,
+          injectTokenBudget,
+          projectName: normalizeProjectLabel(process.env.CODEMEM_PROJECT),
+          cwd,
+          dbPath: promptPackDbPath,
+          identityTarget: promptPackIdentityTarget,
+          attempt: metadata,
+        }),
+        validate: isValidPackHttpPayload,
+      });
+      if (httpResult.ok) {
+        return {
+          packArgs,
+          result: {
+            exitCode: 0,
+            stdout: JSON.stringify(httpResult.body),
+            stderr: "",
+            transport: "viewer",
+          },
+        };
+      }
+
+      const { cause, retryable } = httpResult.classification;
+      await logLine(
+        `inject.pack.http_error cause=${JSON.stringify(redactLog(cause, 200))} retryable=${retryable}`
+      );
+      if (!retryable) {
+        return {
+          packArgs,
+          result: { exitCode: 1, stdout: "", stderr: cause, transport: "viewer" },
+        };
+      }
+
       let result = await runCli(packArgs, { stdinText: JSON.stringify(metadata) });
       if (rejectsInternalLedgerFlag(result)) {
         packArgs = packArgs.filter((arg) => arg !== "--internal-ledger");
         result = await runCli(packArgs);
       }
-      return { packArgs, result };
+      return { packArgs, result: { ...result, transport: "cli" } };
     };
     let { packArgs, result } = await runPack();
     let { packText, conflictPackText, metrics, itemCount, ledgerConflict } = parsePackOutput(result);
@@ -2333,7 +2679,7 @@ export const OpencodeMemPlugin = async ({
     let repairFallbackUsed = false;
     if (ledgerConflict) {
       // A restarted plugin has no artifact cache to predict this conflict. The
-      // CLI marker is authoritative: never attribute delivery to the stale
+      // ledger marker is authoritative: never attribute delivery to the stale
       // identity, and retry once with a fresh deterministic identity.
       await log("warn", "codemem prompt-pack ledger conflict; retrying with fresh identity", {
         sessionID,
@@ -2937,9 +3283,9 @@ export const OpencodeMemPlugin = async ({
           } inject_enabled=${injectEnabled} tui_toast=${Boolean(client.tui?.showToast)} query=${JSON.stringify(safeQuery)} first_prompt_len=${firstPromptLen} last_prompt_len=${lastPromptLen} project=${JSON.stringify(projectName)} files_modified=${filesModifiedCount}`
         );
       }
-      // Without the old per-session cache, every transform call shells out
-      // through `runCli`. Swallow rejections here so a single failed pack
-      // build (CLI crash, sqlite locked, network blip on HTTP fallback)
+      // Without the old per-session cache, every transform call rebuilds the
+      // pack. Swallow rejections here so a single failed build (viewer failure,
+      // CLI fallback crash, sqlite lock, or network blip)
       // can't take down the chat path.
       let applied = false;
       try {
@@ -3217,7 +3563,7 @@ export const OpencodeMemPlugin = async ({
           const stats = await runCli(["stats"]);
           const recent = await runCli(["recent", "--limit", "5"]);
           const lines = [
-            `viewer: http://${viewerHost}:${viewerPort}`,
+            `viewer: http://${viewerUrlHost}:${viewerPort}`,
             `log: ${logPath || "disabled"}`,
           ];
           if (stats.exitCode === 0 && stats.stdout.trim()) {
@@ -3276,6 +3622,10 @@ export const __testUtils = {
   redactPackCommand,
   rejectsInternalLedgerFlag,
   classifyFallbackCommandResult,
+  classifyViewerHttpFailure,
+  isValidPackHttpPayload,
+  isValidLedgerHttpPayload,
+  buildPackHttpBody,
   parsePackText,
   parsePackMetrics,
   resolveInjectSurface,

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -6,8 +6,8 @@
  */
 
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
 import { brotliCompressSync } from "node:zlib";
 import * as core from "@codemem/core";
 import {
@@ -200,6 +200,21 @@ function createTestApp(opts?: {
 			storeCleanup = null;
 		},
 	};
+}
+
+function promptPackAttemptId(sequence: number): string {
+	return `018f2db4-f9d3-7a22-8d18-${sequence.toString(16).padStart(12, "0")}`;
+}
+
+function postViewerJson(app: ReturnType<typeof createApp>, path: string, body: unknown) {
+	return app.request(path, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Origin: "http://127.0.0.1:38888",
+		},
+		body: JSON.stringify(body),
+	});
 }
 
 function createAuthenticatedSyncPeer(
@@ -2020,6 +2035,486 @@ describe("viewer-server", () => {
 				expect(body).toEqual(expected);
 				expect(asyncSpy).toHaveBeenCalledTimes(1);
 				expect(syncSpy).not.toHaveBeenCalled();
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
+	describe("POST /api/pack", () => {
+		it("rejects requests from a different viewer identity target", async () => {
+			vi.stubEnv("CODEMEM_DEVICE_ID", "viewer-device");
+			vi.stubEnv("CODEMEM_ACTOR_ID", "viewer-actor");
+			vi.stubEnv("CODEMEM_CONFIG", "/tmp/viewer-config.json");
+			vi.stubEnv("CODEMEM_RUNTIME_ROOT", "/tmp/viewer-runtime");
+			vi.stubEnv("CODEMEM_WORKSPACE_ID", "viewer-workspace");
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const viewerIdentityTarget = {
+					device_id: "viewer-device",
+					actor_id_present: true,
+					actor_id: "viewer-actor",
+					config_path: "/tmp/viewer-config.json",
+					runtime_root: "/tmp/viewer-runtime",
+					workspace_id: "viewer-workspace",
+					home_dir: resolve(process.env.HOME || homedir()),
+					pack_compression: null,
+					embedding_disabled: false,
+					embedding_model: "Xenova/bge-small-en-v1.5",
+				};
+				const profile = await app.request("/api/prompt-pack-profile");
+				expect(profile.status).toBe(200);
+				expect(await profile.json()).toMatchObject({
+					service: "codemem-viewer",
+					protocol_version: 1,
+					db_path: resolve(ensureStore().dbPath),
+					identity_target: viewerIdentityTarget,
+				});
+				const res = await postViewerJson(app, "/api/pack", {
+					context: "viewer identity",
+					db_path: ensureStore().dbPath,
+					identity_target: {
+						...viewerIdentityTarget,
+						device_id: "request-device",
+					},
+				});
+				expect(res.status).toBe(409);
+				expect(await res.json()).toEqual({
+					error: {
+						code: "viewer_identity_mismatch",
+						message: "viewer identity does not match request",
+					},
+				});
+
+				const compressionMismatch = await postViewerJson(app, "/api/pack", {
+					context: "viewer identity",
+					db_path: ensureStore().dbPath,
+					identity_target: { ...viewerIdentityTarget, pack_compression: "ids" },
+				});
+				expect(compressionMismatch.status).toBe(409);
+
+				const embeddingMismatch = await postViewerJson(app, "/api/pack", {
+					context: "viewer identity",
+					db_path: ensureStore().dbPath,
+					identity_target: { ...viewerIdentityTarget, embedding_disabled: true },
+				});
+				expect(embeddingMismatch.status).toBe(409);
+
+				const unsupported = await postViewerJson(app, "/api/pack", {
+					context: "viewer identity",
+					db_path: ensureStore().dbPath,
+					identity_target: { ...viewerIdentityTarget, future_field: "new" },
+				});
+				expect(unsupported.status).toBe(409);
+				expect(await unsupported.json()).toMatchObject({
+					error: { code: "viewer_contract_unsupported" },
+				});
+			} finally {
+				cleanup();
+				vi.unstubAllEnvs();
+			}
+		});
+
+		it("rejects a viewer whose cached effective identity is stale", async () => {
+			const configDir = mkdtempSync(join(tmpdir(), "codemem-viewer-identity-"));
+			const configPath = join(configDir, "config.json");
+			const envKeys = [
+				"CODEMEM_DEVICE_ID",
+				"CODEMEM_ACTOR_ID",
+				"CODEMEM_CONFIG",
+				"CODEMEM_RUNTIME_ROOT",
+				"CODEMEM_WORKSPACE_ID",
+				"CODEMEM_PACK_COMPRESSION",
+				"CODEMEM_EMBEDDING_DISABLED",
+				"CODEMEM_EMBEDDING_MODEL",
+			] as const;
+			const previousEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+			for (const key of envKeys) delete process.env[key];
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(configPath, JSON.stringify({ actor_id: "actor-before" }));
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const store = ensureStore();
+				expect(store.actorId).toBe("actor-before");
+				writeFileSync(configPath, JSON.stringify({ actor_id: "actor-after" }));
+				const res = await postViewerJson(app, "/api/pack", {
+					context: "stale viewer identity",
+					db_path: store.dbPath,
+					identity_target: {
+						device_id: null,
+						actor_id_present: false,
+						actor_id: null,
+						config_path: resolve(configPath),
+						runtime_root: null,
+						workspace_id: null,
+						home_dir: resolve(process.env.HOME || homedir()),
+						pack_compression: null,
+						embedding_disabled: false,
+						embedding_model: "Xenova/bge-small-en-v1.5",
+					},
+				});
+				expect(res.status).toBe(409);
+				expect(await res.json()).toMatchObject({
+					error: { code: "viewer_identity_mismatch" },
+				});
+			} finally {
+				cleanup();
+				rmSync(configDir, { recursive: true, force: true });
+				for (const key of envKeys) {
+					const value = previousEnv[key];
+					if (value == null) delete process.env[key];
+					else process.env[key] = value;
+				}
+			}
+		});
+
+		it("validates structured request fields", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const invalidJson = await app.request("/api/pack", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: "{",
+				});
+				expect(invalidJson.status).toBe(400);
+				expect(await invalidJson.json()).toEqual({
+					error: { code: "invalid_request", message: "invalid json body" },
+				});
+
+				const invalidWorkingSet = await postViewerJson(app, "/api/pack", {
+					context: "viewer transport",
+					working_set_files: ["../private.txt"],
+				});
+				expect(invalidWorkingSet.status).toBe(400);
+				expect(await invalidWorkingSet.json()).toMatchObject({
+					error: {
+						code: "invalid_request",
+						message: "working_set_files contains an invalid repository-relative path",
+					},
+				});
+
+				const mismatchedDb = await postViewerJson(app, "/api/pack", {
+					context: "viewer transport",
+					db_path: `${ensureStore().dbPath}.other`,
+				});
+				expect(mismatchedDb.status).toBe(409);
+				expect(await mismatchedDb.json()).toEqual({
+					error: {
+						code: "viewer_db_mismatch",
+						message: "viewer database does not match request",
+					},
+				});
+
+				const equivalentDb = await postViewerJson(app, "/api/pack", {
+					context: "viewer transport",
+					db_path: `${dirname(ensureStore().dbPath)}/./${basename(ensureStore().dbPath)}`,
+				});
+				expect(equivalentDb.status).toBe(200);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("returns the same machine-readable pack as GET for equivalent inputs", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const store = ensureStore();
+				const sessionId = insertTestSession(store.db);
+				store.remember(
+					sessionId,
+					"decision",
+					"Structured pack parity",
+					"Viewer POST uses the shared pack builder.",
+					0.9,
+				);
+
+				const getResponse = await app.request(
+					"/api/pack?context=structured%20pack%20parity&limit=5&token_budget=800",
+				);
+				const postResponse = await postViewerJson(app, "/api/pack", {
+					context: "structured pack parity",
+					limit: 5,
+					token_budget: 800,
+					all_projects: true,
+				});
+
+				expect(postResponse.status).toBe(200);
+				const postBody = (await postResponse.json()) as Record<string, unknown>;
+				const getBody = (await getResponse.json()) as Record<string, unknown>;
+				expect(postBody).toMatchObject({
+					pack_text: getBody.pack_text,
+					items: getBody.items,
+					item_ids: getBody.item_ids,
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("passes project, working-set, and render options to the shared builder", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			const previousProject = process.env.CODEMEM_PROJECT;
+			process.env.CODEMEM_PROJECT = "stale-viewer-project";
+			try {
+				const store = ensureStore();
+				const builder = vi.spyOn(store, "buildMemoryPackAsync");
+				const response = await postViewerJson(app, "/api/pack", {
+					context: "focused viewer pack",
+					limit: 4,
+					token_budget: 600,
+					project: "viewer-project",
+					working_set_files: ["./packages/viewer-server/src/index.ts"],
+					compact: true,
+					compact_detail_count: 2,
+				});
+
+				expect(response.status).toBe(200);
+				expect(builder).toHaveBeenCalledWith(
+					"focused viewer pack",
+					4,
+					600,
+					{
+						project: "viewer-project",
+						working_set_paths: ["packages/viewer-server/src/index.ts"],
+					},
+					{ compact: true, compactDetailCount: 2 },
+				);
+			} finally {
+				if (previousProject == null) delete process.env.CODEMEM_PROJECT;
+				else process.env.CODEMEM_PROJECT = previousProject;
+				cleanup();
+			}
+		});
+
+		it("records attempts and reports changed-artifact conflicts without blocking pack delivery", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const store = ensureStore();
+				const sessionId = insertTestSession(store.db);
+				store.remember(sessionId, "feature", "Viewer ledger candidate", "first artifact", 0.8);
+				const request = {
+					context: "viewer ledger candidate",
+					all_projects: true,
+					working_set_files: ["./packages/viewer-server/src/index.ts"],
+					attempt: {
+						attempt_id: promptPackAttemptId(1),
+						started_at: "2026-08-03T10:00:00.000Z",
+						source: "opencode",
+						request_id: "viewer-pack-request",
+					},
+				};
+
+				const first = await postViewerJson(app, "/api/pack", request);
+				expect(first.status).toBe(200);
+				const firstBody = (await first.json()) as Record<string, unknown>;
+				expect(firstBody.ledger_artifact_fingerprint).toMatch(/^[a-f0-9]{64}$/);
+				expect(firstBody).not.toHaveProperty("ledger_outcome");
+				expect(core.getRetrievalAttempt(store.db, promptPackAttemptId(1))).toMatchObject({
+					retrievalStatus: "succeeded",
+					workingSetFiles: ["packages/viewer-server/src/index.ts"],
+				});
+
+				const retry = await postViewerJson(app, "/api/pack", request);
+				expect(retry.status).toBe(200);
+				expect(await retry.json()).not.toHaveProperty("ledger_outcome");
+
+				store.remember(
+					sessionId,
+					"decision",
+					"Viewer ledger candidate changed",
+					"second artifact",
+					0.95,
+				);
+				const conflict = await postViewerJson(app, "/api/pack", request);
+				expect(conflict.status).toBe(200);
+				expect(await conflict.json()).toMatchObject({
+					ledger_outcome: {
+						ok: false,
+						errorCode: "retrieval_ledger_write_failed",
+						reason: "idempotency_conflict",
+					},
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("returns a stable structured error when pack construction fails", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				vi.spyOn(ensureStore(), "buildMemoryPackAsync").mockRejectedValue(
+					new Error("private storage detail"),
+				);
+				const response = await postViewerJson(app, "/api/pack", {
+					context: "pack failure",
+					all_projects: true,
+				});
+				expect(response.status).toBe(500);
+				expect(await response.json()).toEqual({
+					error: { code: "pack_failed", message: "memory pack could not be built" },
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("delivers a built pack when ledger instrumentation fails", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const store = ensureStore();
+				const sessionId = insertTestSession(store.db);
+				store.remember(sessionId, "feature", "Viewer pack survives", "ledger outage", 0.8);
+				const build = store.buildMemoryPackWithTraceAsync.bind(store);
+				vi.spyOn(store, "buildMemoryPackWithTraceAsync").mockImplementation(async (...args) => {
+					const artifacts = await build(...args);
+					store.db.exec("DROP TABLE retrieval_attempts");
+					return artifacts;
+				});
+
+				const response = await postViewerJson(app, "/api/pack", {
+					context: "viewer pack survives",
+					all_projects: true,
+					attempt: {
+						attempt_id: promptPackAttemptId(9),
+						started_at: "2026-08-03T10:00:00.000Z",
+						source: "opencode",
+					},
+				});
+
+				expect(response.status).toBe(200);
+				expect(await response.json()).toMatchObject({
+					pack_text: expect.stringContaining("Viewer pack survives"),
+				});
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
+	describe("POST /api/prompt-pack-ledger", () => {
+		it("preserves record, delivery, and cache-reuse idempotency", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const store = ensureStore();
+				const terminal = {
+					action: "record",
+					attempt_id: promptPackAttemptId(10),
+					started_at: "2026-08-03T10:00:00.000Z",
+					source: "opencode",
+					request_id: "skipped-request",
+					retrieval_status: "skipped",
+					failure_code: "injection_disabled",
+					failure_stage: "policy",
+				};
+				const record = await postViewerJson(app, "/api/prompt-pack-ledger", terminal);
+				expect(record.status).toBe(200);
+				expect(await record.json()).toMatchObject({ ok: true, value: { inserted: true } });
+				const recordRetry = await postViewerJson(app, "/api/prompt-pack-ledger", terminal);
+				expect(await recordRetry.json()).toMatchObject({
+					ok: true,
+					value: { inserted: false },
+				});
+				const recordConflict = await postViewerJson(app, "/api/prompt-pack-ledger", {
+					...terminal,
+					failure_code: "compaction_skipped",
+				});
+				expect(recordConflict.status).toBe(409);
+				expect(await recordConflict.json()).toEqual({
+					ok: false,
+					errorCode: "retrieval_ledger_write_failed",
+					reason: "idempotency_conflict",
+				});
+
+				const sessionId = insertTestSession(store.db);
+				store.remember(sessionId, "decision", "Ledger delivery candidate", "bounded body", 0.9);
+				const pack = await postViewerJson(app, "/api/pack", {
+					context: "ledger delivery candidate",
+					all_projects: true,
+					attempt: {
+						attempt_id: promptPackAttemptId(11),
+						started_at: "2026-08-03T10:00:00.500Z",
+						source: "opencode",
+						request_id: "delivery-request",
+					},
+				});
+				expect(pack.status).toBe(200);
+
+				const delivery = {
+					action: "delivery",
+					attempt_id: promptPackAttemptId(11),
+					delivery_status: "handed_off",
+				};
+				const delivered = await postViewerJson(app, "/api/prompt-pack-ledger", delivery);
+				expect(await delivered.json()).toMatchObject({ ok: true, value: { changed: true } });
+				const deliveryRetry = await postViewerJson(app, "/api/prompt-pack-ledger", delivery);
+				expect(await deliveryRetry.json()).toMatchObject({
+					ok: true,
+					value: { changed: false },
+				});
+
+				const cacheReuse = {
+					action: "cache_reuse",
+					attempt_id: promptPackAttemptId(12),
+					started_at: "2026-08-03T10:00:01.000Z",
+					source: "opencode",
+					request_id: "cache-request",
+					original_attempt_id: promptPackAttemptId(11),
+				};
+				const cloned = await postViewerJson(app, "/api/prompt-pack-ledger", cacheReuse);
+				expect(await cloned.json()).toMatchObject({ ok: true, value: { inserted: true } });
+				const cloneRetry = await postViewerJson(app, "/api/prompt-pack-ledger", cacheReuse);
+				expect(await cloneRetry.json()).toMatchObject({
+					ok: true,
+					value: { inserted: false },
+				});
+				expect(core.getRetrievalAttempt(store.db, promptPackAttemptId(12))).toMatchObject({
+					deliveryStatus: "not_attempted",
+					requestId: `cache_reuse:cache-request:from:${promptPackAttemptId(11)}`,
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("returns structured validation and core failure outcomes", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const invalid = await postViewerJson(app, "/api/prompt-pack-ledger", {
+					action: "unknown",
+					attempt_id: promptPackAttemptId(20),
+				});
+				expect(invalid.status).toBe(400);
+				expect(await invalid.json()).toEqual({
+					error: { code: "invalid_request", message: "ledger action is invalid" },
+				});
+
+				const missing = await postViewerJson(app, "/api/prompt-pack-ledger", {
+					action: "cache_reuse",
+					attempt_id: promptPackAttemptId(21),
+					original_attempt_id: promptPackAttemptId(22),
+				});
+				expect(missing.status).toBe(422);
+				expect(await missing.json()).toEqual({
+					ok: false,
+					errorCode: "retrieval_ledger_write_failed",
+					reason: "attempt_not_found",
+				});
+
+				const mismatchedDb = await postViewerJson(app, "/api/prompt-pack-ledger", {
+					action: "record",
+					attempt_id: promptPackAttemptId(23),
+					retrieval_status: "skipped",
+					failure_code: "injection_disabled",
+					failure_stage: "policy",
+					db_path: `${ensureStore().dbPath}.other`,
+				});
+				expect(mismatchedDb.status).toBe(409);
+				expect(await mismatchedDb.json()).toMatchObject({
+					error: { code: "viewer_db_mismatch" },
+				});
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -22,6 +22,7 @@ import {
 import { configRoutes } from "./routes/config.js";
 import { memoryRoutes } from "./routes/memory.js";
 import { observerStatusRoutes } from "./routes/observer-status.js";
+import { packTransportRoutes } from "./routes/pack.js";
 import { rawEventsRoutes } from "./routes/raw-events.js";
 import { statsRoutes } from "./routes/stats.js";
 import { syncProtocolRoutes, syncRoutes } from "./routes/sync.js";
@@ -106,6 +107,7 @@ export function createApp(opts?: AppOptions) {
 	// API routes
 	app.route("/", statsRoutes(storeFactory));
 	app.route("/", memoryRoutes(storeFactory));
+	app.route("/", packTransportRoutes(storeFactory));
 	app.route(
 		"/",
 		observerStatusRoutes({

--- a/packages/viewer-server/src/routes/pack.ts
+++ b/packages/viewer-server/src/routes/pack.ts
@@ -1,0 +1,540 @@
+import { homedir } from "node:os";
+import { isAbsolute, posix, resolve as resolvePath, win32 } from "node:path";
+import type {
+	MemoryFilters,
+	MemoryStore,
+	PackRenderOptions,
+	PromptPackAttemptMetadata,
+	RetrievalLedgerDeliveryOutcome,
+	RetrievalLedgerFailureReason,
+	RetrievalLedgerWriteOutcome,
+} from "@codemem/core";
+import {
+	clonePromptPackAttempt,
+	promptPackArtifactFingerprint,
+	recordPromptPackArtifacts,
+	recordPromptPackTerminal,
+	resolveDbPath,
+	resolveProject,
+	tryUpdateRetrievalDelivery,
+} from "@codemem/core";
+import { Hono } from "hono";
+
+type StoreFactory = () => MemoryStore;
+type LedgerOutcome = RetrievalLedgerWriteOutcome | RetrievalLedgerDeliveryOutcome;
+
+const MAX_LEDGER_PAYLOAD_BYTES = 16 * 1024;
+const MAX_METADATA_FIELD_CHARS = 512;
+const MAX_WORKING_SET_FILES = 50;
+const MAX_WORKING_SET_PATH_CHARS = 512;
+const INVALID_JSON = Symbol("invalid-json");
+
+const PACK_KEYS = new Set([
+	"context",
+	"limit",
+	"token_budget",
+	"project",
+	"cwd",
+	"all_projects",
+	"working_set_files",
+	"compact",
+	"compact_detail_count",
+	"db_path",
+	"identity_target",
+	"attempt",
+]);
+const LEDGER_KEYS = new Set([
+	"action",
+	"attempt_id",
+	"started_at",
+	"source",
+	"stream_id",
+	"source_session_id",
+	"prompt_number",
+	"request_id",
+	"retrieval_status",
+	"delivery_status",
+	"failure_code",
+	"failure_stage",
+	"original_attempt_id",
+	"db_path",
+	"identity_target",
+]);
+const IDENTITY_TARGET_KEYS = new Set([
+	"device_id",
+	"actor_id_present",
+	"actor_id",
+	"config_path",
+	"runtime_root",
+	"workspace_id",
+	"home_dir",
+	"pack_compression",
+	"embedding_disabled",
+	"embedding_model",
+]);
+const BOOLEAN_IDENTITY_TARGET_KEYS = new Set(["actor_id_present", "embedding_disabled"]);
+const ATTEMPT_KEYS = new Set([
+	"attempt_id",
+	"started_at",
+	"source",
+	"stream_id",
+	"source_session_id",
+	"prompt_number",
+	"request_id",
+]);
+const FORBIDDEN_LEDGER_KEYS = new Set([
+	"body",
+	"context",
+	"pack",
+	"pack_text",
+	"path",
+	"preview",
+	"prompt",
+	"query",
+	"raw_prompt",
+	"title",
+]);
+
+type ValidatedPackRequest = {
+	context: string;
+	limit: number;
+	tokenBudget: number | null;
+	filters: MemoryFilters;
+	renderOptions?: PackRenderOptions;
+	attempt?: Record<string, unknown>;
+};
+
+function invalidRequest(message: string) {
+	return { error: { code: "invalid_request", message } };
+}
+
+function viewerDbMismatch() {
+	return {
+		error: {
+			code: "viewer_db_mismatch",
+			message: "viewer database does not match request",
+		},
+	};
+}
+
+function viewerIdentityMismatch() {
+	return {
+		error: {
+			code: "viewer_identity_mismatch",
+			message: "viewer identity does not match request",
+		},
+	};
+}
+
+function viewerContractUnsupported() {
+	return {
+		error: {
+			code: "viewer_contract_unsupported",
+			message: "viewer request contract is incompatible",
+		},
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isAbsolutePath(value: string): boolean {
+	return posix.isAbsolute(value) || win32.isAbsolute(value);
+}
+
+function normalizeWorkingSetPath(value: string): string | null {
+	const trimmed = value.trim();
+	if (!trimmed || trimmed.length > MAX_WORKING_SET_PATH_CHARS || isAbsolutePath(trimmed)) {
+		return null;
+	}
+	const normalized = posix.normalize(trimmed.replaceAll("\\", "/")).replace(/^\.\//, "");
+	if (!normalized || normalized === "." || normalized === ".." || normalized.startsWith("../")) {
+		return null;
+	}
+	return normalized;
+}
+
+function requestedDbMatches(store: MemoryStore, value: unknown): boolean | null {
+	if (value == null) return true;
+	if (typeof value !== "string" || !value.trim()) return null;
+	return resolvePath(resolveDbPath(value)) === resolvePath(store.dbPath);
+}
+
+function normalizeIdentityPath(value: string | undefined): string | null {
+	if (!value?.trim()) return null;
+	return resolvePath(resolveDbPath(value.trim()));
+}
+
+function currentIdentityTarget(): Record<string, string | boolean | null> {
+	return {
+		device_id: process.env.CODEMEM_DEVICE_ID?.trim() || null,
+		actor_id_present: Object.hasOwn(process.env, "CODEMEM_ACTOR_ID"),
+		actor_id: process.env.CODEMEM_ACTOR_ID?.trim() || null,
+		config_path: normalizeIdentityPath(process.env.CODEMEM_CONFIG),
+		runtime_root: normalizeIdentityPath(process.env.CODEMEM_RUNTIME_ROOT),
+		workspace_id: process.env.CODEMEM_WORKSPACE_ID?.trim() || null,
+		home_dir: normalizeIdentityPath(process.env.HOME || homedir()),
+		pack_compression: process.env.CODEMEM_PACK_COMPRESSION?.trim() || null,
+		embedding_disabled: ["1", "true", "yes"].includes(
+			String(process.env.CODEMEM_EMBEDDING_DISABLED || "").toLowerCase(),
+		),
+		embedding_model: process.env.CODEMEM_EMBEDDING_MODEL || "Xenova/bge-small-en-v1.5",
+	};
+}
+
+function requestedIdentityMatches(value: unknown): boolean | null | "unsupported" {
+	if (value == null) return true;
+	if (!isRecord(value)) return null;
+	if (
+		Object.keys(value).length !== IDENTITY_TARGET_KEYS.size ||
+		Object.keys(value).some((key) => !IDENTITY_TARGET_KEYS.has(key))
+	)
+		return "unsupported";
+	const expected = currentIdentityTarget();
+	for (const key of IDENTITY_TARGET_KEYS) {
+		const requested = value[key];
+		if (BOOLEAN_IDENTITY_TARGET_KEYS.has(key)) {
+			if (typeof requested !== "boolean") return null;
+		} else if (requested !== null && typeof requested !== "string") {
+			return null;
+		}
+		if (requested !== expected[key]) return false;
+	}
+	return true;
+}
+
+function validateMetadataFields(
+	payload: Record<string, unknown>,
+	allowedKeys: ReadonlySet<string>,
+): string | null {
+	if (Buffer.byteLength(JSON.stringify(payload), "utf8") > MAX_LEDGER_PAYLOAD_BYTES) {
+		return "ledger metadata exceeds 16384 bytes";
+	}
+	for (const key of Object.keys(payload)) {
+		if (FORBIDDEN_LEDGER_KEYS.has(key)) return `ledger metadata rejects sensitive field: ${key}`;
+		if (!allowedKeys.has(key)) return `ledger metadata contains unsupported field: ${key}`;
+	}
+	if (typeof payload.attempt_id !== "string" || payload.attempt_id.length === 0) {
+		return "ledger metadata requires attempt_id";
+	}
+	if (
+		payload.prompt_number != null &&
+		(typeof payload.prompt_number !== "number" ||
+			!Number.isInteger(payload.prompt_number) ||
+			payload.prompt_number < 0)
+	) {
+		return "ledger metadata prompt_number must be a non-negative integer";
+	}
+	for (const key of [
+		"attempt_id",
+		"started_at",
+		"source",
+		"stream_id",
+		"source_session_id",
+		"request_id",
+		"failure_code",
+		"failure_stage",
+		"original_attempt_id",
+	] as const) {
+		const field = payload[key];
+		if (field != null && (typeof field !== "string" || field.length > MAX_METADATA_FIELD_CHARS)) {
+			return `ledger metadata field ${key} is invalid`;
+		}
+		if (typeof field === "string" && isAbsolutePath(field)) {
+			return `ledger metadata rejects absolute paths in field: ${key}`;
+		}
+	}
+	return null;
+}
+
+function attemptMetadata(payload: Record<string, unknown>): PromptPackAttemptMetadata {
+	return {
+		attemptId: payload.attempt_id as string,
+		startedAt: (payload.started_at as string | undefined) ?? new Date().toISOString(),
+		completedAt: new Date().toISOString(),
+		source: (payload.source as string | undefined) ?? "opencode",
+		streamId: (payload.stream_id as string | undefined) ?? null,
+		sourceSessionId: (payload.source_session_id as string | undefined) ?? null,
+		promptNumber: (payload.prompt_number as number | undefined) ?? null,
+		requestId: (payload.request_id as string | undefined) ?? null,
+	};
+}
+
+function validatePackRequest(value: unknown): ValidatedPackRequest | string {
+	if (!isRecord(value)) return "request body must be an object";
+	for (const key of Object.keys(value)) {
+		if (!PACK_KEYS.has(key)) return `request body contains unsupported field: ${key}`;
+	}
+	const context = typeof value.context === "string" ? value.context.trim() : "";
+	if (!context) return "context required";
+	const limit = value.limit ?? 10;
+	if (typeof limit !== "number" || !Number.isInteger(limit) || limit < 1) {
+		return "limit must be a positive int";
+	}
+	const tokenBudget = value.token_budget ?? null;
+	if (
+		tokenBudget !== null &&
+		(typeof tokenBudget !== "number" || !Number.isInteger(tokenBudget) || tokenBudget < 0)
+	) {
+		return "token_budget must be a non-negative int";
+	}
+	if (value.all_projects != null && typeof value.all_projects !== "boolean") {
+		return "all_projects must be a boolean";
+	}
+	if (value.project != null && (typeof value.project !== "string" || !value.project.trim())) {
+		return "project must be a non-empty string";
+	}
+	if (
+		value.cwd != null &&
+		(typeof value.cwd !== "string" || !value.cwd.trim() || !isAbsolute(value.cwd))
+	) {
+		return "cwd must be an absolute path";
+	}
+	if (value.working_set_files != null && !Array.isArray(value.working_set_files)) {
+		return "working_set_files must be an array of repository-relative strings";
+	}
+	const workingSetValues = (value.working_set_files ?? []) as unknown[];
+	if (workingSetValues.length > MAX_WORKING_SET_FILES) {
+		return `working_set_files must contain at most ${MAX_WORKING_SET_FILES} entries`;
+	}
+	const workingSetFiles: string[] = [];
+	for (const entry of workingSetValues) {
+		if (typeof entry !== "string") {
+			return "working_set_files must be an array of repository-relative strings";
+		}
+		const normalized = normalizeWorkingSetPath(entry);
+		if (!normalized) return "working_set_files contains an invalid repository-relative path";
+		if (!workingSetFiles.includes(normalized)) workingSetFiles.push(normalized);
+	}
+	if (value.compact != null && typeof value.compact !== "boolean") {
+		return "compact must be a boolean";
+	}
+	if (
+		value.compact_detail_count != null &&
+		(typeof value.compact_detail_count !== "number" ||
+			!Number.isInteger(value.compact_detail_count) ||
+			value.compact_detail_count < 0)
+	) {
+		return "compact_detail_count must be a non-negative int";
+	}
+	let attempt: Record<string, unknown> | undefined;
+	if (value.attempt != null) {
+		if (!isRecord(value.attempt)) return "attempt must be an object";
+		const attemptError = validateMetadataFields(value.attempt, ATTEMPT_KEYS);
+		if (attemptError) return attemptError;
+		attempt = value.attempt;
+	}
+
+	const filters: MemoryFilters = {};
+	if (value.all_projects !== true) {
+		const envProject = process.env.CODEMEM_PROJECT?.trim() || null;
+		const requestCwd = value.cwd as string | undefined;
+		const requestProject = value.project as string | undefined;
+		const project = resolveProject(
+			requestCwd ?? process.cwd(),
+			requestProject ?? (requestCwd == null ? envProject : undefined),
+		);
+		if (project) filters.project = project;
+	}
+	if (workingSetFiles.length > 0) filters.working_set_paths = workingSetFiles;
+
+	let renderOptions: PackRenderOptions | undefined;
+	if (value.compact != null || value.compact_detail_count != null) {
+		renderOptions = {
+			compact: value.compact === true || value.compact_detail_count != null,
+			...(value.compact_detail_count != null
+				? { compactDetailCount: value.compact_detail_count as number }
+				: {}),
+		};
+	}
+	return {
+		context,
+		limit,
+		tokenBudget: tokenBudget as number | null,
+		filters,
+		renderOptions,
+		attempt,
+	};
+}
+
+function ledgerFailureStatus(reason: RetrievalLedgerFailureReason): 400 | 409 | 422 | 503 {
+	if (reason === "idempotency_conflict") return 409;
+	if (reason === "attempt_not_found") return 422;
+	if (reason === "storage_unavailable") return 503;
+	return 400;
+}
+
+function dispatchLedger(
+	store: MemoryStore,
+	payload: Record<string, unknown>,
+): LedgerOutcome | string {
+	const action = payload.action;
+	if (action !== "record" && action !== "delivery" && action !== "cache_reuse") {
+		return "ledger action is invalid";
+	}
+	const metadata = attemptMetadata(payload);
+	if (action === "delivery") {
+		const status = payload.delivery_status;
+		if (status !== "handed_off" && status !== "failed" && status !== "unknown") {
+			return "delivery action requires a valid delivery_status";
+		}
+		return tryUpdateRetrievalDelivery(store.db, metadata.attemptId, status);
+	}
+	if (action === "cache_reuse") {
+		if (typeof payload.original_attempt_id !== "string" || !payload.original_attempt_id) {
+			return "cache_reuse action requires original_attempt_id";
+		}
+		return clonePromptPackAttempt(store.db, payload.original_attempt_id, metadata);
+	}
+	if (
+		(payload.retrieval_status !== "skipped" && payload.retrieval_status !== "failed") ||
+		typeof payload.failure_code !== "string" ||
+		!payload.failure_code ||
+		typeof payload.failure_stage !== "string" ||
+		!payload.failure_stage
+	) {
+		return "record action requires retrieval_status, failure_code, and failure_stage";
+	}
+	return recordPromptPackTerminal(
+		store.db,
+		metadata,
+		payload.retrieval_status,
+		payload.failure_code,
+		payload.failure_stage,
+	);
+}
+
+export function packTransportRoutes(getStore: StoreFactory) {
+	const app = new Hono();
+
+	app.get("/api/prompt-pack-profile", (c) => {
+		try {
+			const store = getStore();
+			if (!store.hasCurrentIdentity()) return c.json(viewerIdentityMismatch(), 409);
+			return c.json({
+				service: "codemem-viewer",
+				protocol_version: 1,
+				db_path: resolvePath(store.dbPath),
+				identity_target: currentIdentityTarget(),
+			});
+		} catch {
+			return c.json(
+				{ error: { code: "profile_failed", message: "viewer profile could not be read" } },
+				500,
+			);
+		}
+	});
+
+	app.post("/api/pack", async (c) => {
+		const parsed = await c.req.json().catch(() => INVALID_JSON);
+		if (parsed === INVALID_JSON) return c.json(invalidRequest("invalid json body"), 400);
+		const request = validatePackRequest(parsed);
+		if (typeof request === "string") {
+			if (request.startsWith("request body contains unsupported field:"))
+				return c.json(viewerContractUnsupported(), 409);
+			return c.json(invalidRequest(request), 400);
+		}
+		try {
+			const store = getStore();
+			const dbMatches = requestedDbMatches(store, parsed.db_path);
+			if (dbMatches == null)
+				return c.json(invalidRequest("db_path must be a non-empty string"), 400);
+			if (!dbMatches) return c.json(viewerDbMismatch(), 409);
+			const identityMatches = requestedIdentityMatches(parsed.identity_target);
+			if (identityMatches === "unsupported") return c.json(viewerContractUnsupported(), 409);
+			if (identityMatches == null) return c.json(invalidRequest("identity_target is invalid"), 400);
+			if (!identityMatches) return c.json(viewerIdentityMismatch(), 409);
+			if (!store.hasCurrentIdentity()) return c.json(viewerIdentityMismatch(), 409);
+			if (!request.attempt) {
+				const pack = await store.buildMemoryPackAsync(
+					request.context,
+					request.limit,
+					request.tokenBudget,
+					request.filters,
+					request.renderOptions,
+				);
+				return c.json(pack);
+			}
+			const artifacts = await store.buildMemoryPackWithTraceAsync(
+				request.context,
+				request.limit,
+				request.tokenBudget,
+				request.filters,
+				request.renderOptions,
+			);
+			let ledgerArtifactFingerprint: string | undefined;
+			try {
+				ledgerArtifactFingerprint = promptPackArtifactFingerprint(
+					store.db,
+					request.context,
+					request.filters,
+					artifacts,
+				);
+			} catch {
+				// Fingerprinting is instrumentation and must not block pack delivery.
+			}
+			let ledgerOutcome: RetrievalLedgerWriteOutcome | undefined;
+			try {
+				ledgerOutcome = recordPromptPackArtifacts(
+					store.db,
+					attemptMetadata(request.attempt),
+					request.context,
+					request.filters,
+					artifacts,
+				);
+			} catch {
+				// Ledger instrumentation is best-effort and must not block pack delivery.
+			}
+			return c.json({
+				...artifacts.response,
+				...(ledgerArtifactFingerprint
+					? { ledger_artifact_fingerprint: ledgerArtifactFingerprint }
+					: {}),
+				...(ledgerOutcome?.ok === false && ledgerOutcome.reason === "idempotency_conflict"
+					? { ledger_outcome: ledgerOutcome }
+					: {}),
+			});
+		} catch {
+			return c.json(
+				{ error: { code: "pack_failed", message: "memory pack could not be built" } },
+				500,
+			);
+		}
+	});
+
+	app.post("/api/prompt-pack-ledger", async (c) => {
+		const parsed = await c.req.json().catch(() => INVALID_JSON);
+		if (parsed === INVALID_JSON) return c.json(invalidRequest("invalid json body"), 400);
+		if (!isRecord(parsed)) return c.json(invalidRequest("request body must be an object"), 400);
+		const validationError = validateMetadataFields(parsed, LEDGER_KEYS);
+		if (validationError) {
+			if (validationError.startsWith("ledger metadata contains unsupported field:"))
+				return c.json(viewerContractUnsupported(), 409);
+			return c.json(invalidRequest(validationError), 400);
+		}
+		try {
+			const store = getStore();
+			const dbMatches = requestedDbMatches(store, parsed.db_path);
+			if (dbMatches == null)
+				return c.json(invalidRequest("db_path must be a non-empty string"), 400);
+			if (!dbMatches) return c.json(viewerDbMismatch(), 409);
+			const identityMatches = requestedIdentityMatches(parsed.identity_target);
+			if (identityMatches === "unsupported") return c.json(viewerContractUnsupported(), 409);
+			if (identityMatches == null) return c.json(invalidRequest("identity_target is invalid"), 400);
+			if (!identityMatches) return c.json(viewerIdentityMismatch(), 409);
+			if (!store.hasCurrentIdentity()) return c.json(viewerIdentityMismatch(), 409);
+			const outcome = dispatchLedger(store, parsed);
+			if (typeof outcome === "string") return c.json(invalidRequest(outcome), 400);
+			if (outcome.ok) return c.json(outcome);
+			return c.json(outcome, ledgerFailureStatus(outcome.reason));
+		} catch {
+			return c.json(
+				{ error: { code: "ledger_failed", message: "prompt-pack ledger operation failed" } },
+				500,
+			);
+		}
+	});
+
+	return app;
+}


### PR DESCRIPTION
## Description

Routes OpenCode prompt-time pack construction and prompt-pack ledger transitions through the long-lived local viewer on healthy paths. Adds structured viewer POST contracts, verifies explicit database targets, preserves classified CLI fallback and idempotency repair, and documents a privacy-safe development benchmark procedure.

Tracks `codemem-83te`.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional checks:

- `pnpm --filter codemem test:plugin` — 142 passed
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts` — 244 passed
- `pnpm --filter codemem test:smoke` — 4 passed
- Independent CodeReviewer and pragmatic complexity review — GO
- Snyk Code scan was unavailable because the local Snyk client is not authenticated

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
