### PR TITLE
fix(sync): keep local-authority scopes device-local

### DIFF
--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -516,7 +516,7 @@ describe("formatSyncAttempt", () => {
 				store.db
 					.prepare(
 						`INSERT INTO replication_scopes(scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at)
-						 VALUES (?, ?, 'user', 'local', 1, 'active', ?, ?)`,
+						 VALUES (?, ?, 'user', 'coordinator', 1, 'active', ?, ?)`,
 					)
 					.run(scopeId, label, now, now);
 				for (const deviceId of ["local-device", "peer-device"]) {

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1043,6 +1043,43 @@ describe("loadMemorySnapshotPageForPeer", () => {
 		expect(page.items).toEqual([]);
 	});
 
+	it("blocks custom local-authority snapshots while allowing coordinator siblings", () => {
+		for (const scopeId of ["local-notes", "team-notes"]) {
+			setSyncResetState(
+				db,
+				{
+					generation: 4,
+					snapshot_id: "snapshot-4",
+					baseline_cursor: "2026-01-01T00:00:01Z|base-op",
+					retained_floor_cursor: "2026-01-01T00:00:02Z|floor-op",
+				},
+				scopeId,
+			);
+		}
+		grantScope("local-notes", ["local-device", "peer-device"], "local");
+		grantScope("team-notes", ["local-device", "peer-device"]);
+		insertMemory("key-local", { scopeId: "local-notes" });
+		insertMemory("key-team", { scopeId: "team-notes" });
+
+		const localPage = loadMemorySnapshotPageForPeer(db, {
+			peerDeviceId: "peer-device",
+			scopeId: "local-notes",
+			generation: 4,
+			snapshotId: "snapshot-4",
+			baselineCursor: "2026-01-01T00:00:01Z|base-op",
+		});
+		const coordinatorPage = loadMemorySnapshotPageForPeer(db, {
+			peerDeviceId: "peer-device",
+			scopeId: "team-notes",
+			generation: 4,
+			snapshotId: "snapshot-4",
+			baselineCursor: "2026-01-01T00:00:01Z|base-op",
+		});
+
+		expect(localPage.items.map((item) => item.entity_id)).toEqual([]);
+		expect(coordinatorPage.items.map((item) => item.entity_id)).toEqual(["key-team"]);
+	});
+
 	it("requires a matching personal scope grant for claimed local actor snapshot rows", () => {
 		setSyncResetState(
 			db,
@@ -2491,19 +2528,25 @@ describe("applyReplicationOps", () => {
 	function grantScope(
 		scopeId: string,
 		deviceIds: string[],
-		overrides: { scopeEpoch?: number; membershipEpoch?: number; status?: string } = {},
+		overrides: {
+			authorityType?: "coordinator" | "local";
+			scopeEpoch?: number;
+			membershipEpoch?: number;
+			status?: string;
+		} = {},
 	): void {
 		const now = "2026-01-01T00:00:00Z";
 		const scopeEpoch = overrides.scopeEpoch ?? 1;
 		db.prepare(
 			`INSERT INTO replication_scopes(
 				scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
-			 ) VALUES (?, ?, 'team', 'coordinator', ?, 'active', ?, ?)
+			 ) VALUES (?, ?, 'team', ?, ?, 'active', ?, ?)
 			 ON CONFLICT(scope_id) DO UPDATE SET
+				authority_type = excluded.authority_type,
 				membership_epoch = excluded.membership_epoch,
 				status = excluded.status,
 				updated_at = excluded.updated_at`,
-		).run(scopeId, scopeId, scopeEpoch, now, now);
+		).run(scopeId, scopeId, overrides.authorityType ?? "coordinator", scopeEpoch, now, now);
 		for (const deviceId of deviceIds) {
 			db.prepare(
 				`INSERT INTO scope_memberships(
@@ -2737,6 +2780,53 @@ describe("applyReplicationOps", () => {
 		expect(memoryExists(op.entity_id)).toBe(true);
 	});
 
+	it("rejects inbound ops for local-authority scopes even when both devices are members", () => {
+		grantScope("local-notes", ["dev-remote", "dev-local"], { authorityType: "local" });
+		const op = makeReplicationOp({
+			scope_id: "local-notes",
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Blocked local scope",
+				body_text: "Remote body",
+				scope_id: "local-notes",
+			}),
+		});
+
+		const result = applyWithScopeValidation(op);
+
+		expect(result.applied).toBe(0);
+		expect(result.rejected).toBe(1);
+		expect(result.rejections[0]).toMatchObject({ op_id: op.op_id, reason: "missing_scope" });
+		expect(memoryExists(op.entity_id)).toBe(false);
+	});
+
+	it("rejects inbound local-authority ops when strict scope validation is disabled", () => {
+		grantScope("local-notes", ["dev-remote", "dev-local"], { authorityType: "local" });
+		const op = makeReplicationOp({ scope_id: "local-notes" });
+
+		const result = applyReplicationOps(db, [op], "dev-local", undefined, {
+			inboundScopeValidation: { peerDeviceId: "dev-remote", enabled: false },
+		});
+
+		expect(result.applied).toBe(0);
+		expect(result.rejected).toBe(1);
+		expect(result.rejections[0]).toMatchObject({ op_id: op.op_id, reason: "missing_scope" });
+		expect(memoryExists(op.entity_id)).toBe(false);
+	});
+
+	it("rejects unknown non-default scopes when strict scope validation is disabled", () => {
+		const op = makeReplicationOp({ scope_id: "peer-local-unknown" });
+
+		const result = applyReplicationOps(db, [op], "dev-local", undefined, {
+			inboundScopeValidation: { peerDeviceId: "dev-remote", enabled: false },
+		});
+
+		expect(result.applied).toBe(0);
+		expect(result.rejected).toBe(1);
+		expect(result.rejections[0]).toMatchObject({ op_id: op.op_id, reason: "missing_scope" });
+		expect(memoryExists(op.entity_id)).toBe(false);
+	});
+
 	it.each([
 		{ name: "null scope", scopeId: null, reason: "missing_scope" },
 		{ name: "local-default scope", scopeId: DEFAULT_SYNC_SCOPE_ID, reason: "scope_mismatch" },
@@ -2885,6 +2975,85 @@ describe("applyReplicationOps", () => {
 				.prepare("SELECT COUNT(*) FROM memory_items WHERE import_key = ? AND scope_id = ?")
 				.pluck()
 				.get(importKey, "managed-project"),
+		).toBe(0);
+	});
+
+	it("allows sender-owned local-default cleanup into a local-authority destination", () => {
+		const importKey = "key:default-reassign-local-destination";
+		insertReplicatedMemory({
+			importKey,
+			originDeviceId: "dev-remote",
+			scopeId: DEFAULT_SYNC_SCOPE_ID,
+		});
+		grantScope("local-project", ["dev-remote"], { authorityType: "local" });
+		const op = makeReplicationOp({
+			op_id: "default-reassign-local-destination-old",
+			entity_id: importKey,
+			op_type: "reassign_scope",
+			payload_json: toJson({
+				operation_id: "share_local_destination",
+				memory_id: importKey,
+				old_scope_id: DEFAULT_SYNC_SCOPE_ID,
+				new_scope_id: "local-project",
+				revision: 2,
+				side: "old",
+			}),
+			clock_rev: 2,
+			clock_updated_at: "2026-01-01T00:00:01Z",
+			created_at: "2026-01-01T00:00:01Z",
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+		});
+
+		const result = applyWithScopeValidation(op);
+
+		expect(result).toMatchObject({ applied: 1, rejected: 0 });
+		expect(
+			db.prepare("SELECT active, scope_id FROM memory_items WHERE import_key = ?").get(importKey),
+		).toEqual({ active: 0, scope_id: DEFAULT_SYNC_SCOPE_ID });
+		expect(
+			db
+				.prepare("SELECT COUNT(*) FROM memory_items WHERE import_key = ? AND scope_id = ?")
+				.pluck()
+				.get(importKey, "local-project"),
+		).toBe(0);
+	});
+
+	it("allows sender-owned local-default cleanup into an unknown destination", () => {
+		const importKey = "key:default-reassign-unknown-destination";
+		insertReplicatedMemory({
+			importKey,
+			originDeviceId: "dev-remote",
+			scopeId: DEFAULT_SYNC_SCOPE_ID,
+		});
+		const op = makeReplicationOp({
+			op_id: "default-reassign-unknown-destination-old",
+			entity_id: importKey,
+			op_type: "reassign_scope",
+			payload_json: toJson({
+				operation_id: "share_unknown_destination",
+				memory_id: importKey,
+				old_scope_id: DEFAULT_SYNC_SCOPE_ID,
+				new_scope_id: "sender-local-project",
+				revision: 2,
+				side: "old",
+			}),
+			clock_rev: 2,
+			clock_updated_at: "2026-01-01T00:00:01Z",
+			created_at: "2026-01-01T00:00:01Z",
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+		});
+
+		const result = applyWithScopeValidation(op);
+
+		expect(result).toMatchObject({ applied: 1, rejected: 0 });
+		expect(
+			db.prepare("SELECT active, scope_id FROM memory_items WHERE import_key = ?").get(importKey),
+		).toEqual({ active: 0, scope_id: DEFAULT_SYNC_SCOPE_ID });
+		expect(
+			db
+				.prepare("SELECT COUNT(*) FROM memory_items WHERE import_key = ? AND scope_id = ?")
+				.pluck()
+				.get(importKey, "sender-local-project"),
 		).toBe(0);
 	});
 

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -1313,6 +1313,14 @@ export function loadMemorySnapshotPageForPeer(
 	const scopeFilterRequested = options.scopeId !== undefined;
 	const effectiveScopeId = normalizeSyncStateScopeId(options.scopeId);
 	const boundary = getSyncResetState(db, scopeFilterRequested ? options.scopeId : undefined);
+	if (scopeFilterRequested) {
+		const scope = db
+			.prepare("SELECT authority_type FROM replication_scopes WHERE scope_id = ? LIMIT 1")
+			.get(effectiveScopeId) as { authority_type?: string | null } | undefined;
+		if (scope?.authority_type === "local") {
+			return { boundary, items: [], nextPageToken: null, hasMore: false };
+		}
+	}
 	if (options.generation !== boundary.generation) {
 		throw new Error("generation_mismatch");
 	}
@@ -2712,6 +2720,7 @@ function authorizationFailureReason(
 	auth: CachedScopeAuthorizationResult,
 	notMemberReason: "sender_not_member" | "receiver_not_member",
 ): InboundScopeRejectionReason | null {
+	if (auth.scope?.authority_type === "local") return "missing_scope";
 	if (auth.authorized) return null;
 	if (
 		!auth.scope ||
@@ -2796,12 +2805,14 @@ function validateInboundScopeOp(
 	}
 	let authorizationScopeId = opScopeId;
 	let requireReceiverMembership = true;
+	let allowLocalAuthorityRetraction = false;
 	if (opScopeId === DEFAULT_SYNC_SCOPE_ID) {
 		const validation = validateLocalDefaultOldSideReassignment(db, op, senderDeviceId);
 		if (!validation.ok) {
 			return inboundScopeRejection(op, validation.reason, peerDeviceId, opScopeId);
 		}
 		authorizationScopeId = validation.reassignment.new_scope_id;
+		allowLocalAuthorityRetraction = true;
 		// This side only retracts sender-origin data previously delivered through
 		// local-default. Prior recipients intentionally are not members of the new
 		// boundary, and the apply path cannot create a new-scope row for them.
@@ -2812,7 +2823,14 @@ function validateInboundScopeOp(
 		deviceId: senderDeviceId,
 		scopeId: authorizationScopeId,
 	});
-	const senderFailure = authorizationFailureReason(senderAuth, "sender_not_member");
+	// A validated old-side op only retracts a sender-owned local-default row;
+	// it cannot create data in the destination scope. Permit that removal when
+	// the receiver cannot know the sender's new device-local scope.
+	const senderFailure =
+		allowLocalAuthorityRetraction &&
+		(senderAuth.authorized || (senderAuth.state === "not_authorized" && !senderAuth.scope))
+			? null
+			: authorizationFailureReason(senderAuth, "sender_not_member");
 	if (senderFailure) return inboundScopeRejection(op, senderFailure, peerDeviceId, opScopeId);
 
 	if (requireReceiverMembership) {
@@ -2860,7 +2878,15 @@ function validateInboundLocalOnlyBatch(
 			rejections.push(inboundScopeRejection(op, "missing_scope", peerDeviceId, null));
 			continue;
 		}
-		if (scopeId !== DEFAULT_SYNC_SCOPE_ID) continue;
+		if (scopeId !== DEFAULT_SYNC_SCOPE_ID) {
+			const scope = db
+				.prepare("SELECT authority_type FROM replication_scopes WHERE scope_id = ? LIMIT 1")
+				.get(scopeId) as { authority_type?: string | null } | undefined;
+			if (scope?.authority_type === "local" || (!scope && options.enabled === false)) {
+				rejections.push(inboundScopeRejection(op, "missing_scope", peerDeviceId, scopeId));
+			}
+			continue;
+		}
 		if (op.op_type === REASSIGN_SCOPE_OP_TYPE) {
 			const validation = validateLocalDefaultOldSideReassignment(
 				db,

--- a/packages/core/src/sync-scope-protocol.test.ts
+++ b/packages/core/src/sync-scope-protocol.test.ts
@@ -159,6 +159,21 @@ describe("parseSyncScopeRequest scoped path", () => {
 		expect(result).toEqual({ ok: true, mode: "scoped", scope_id: SCOPE_ID });
 	});
 
+	it("rejects an active custom local-authority scope even when both devices are members", () => {
+		insertScope(SCOPE_ID, { authorityType: "local" });
+		grantMembership(SCOPE_ID, LOCAL_DEVICE);
+		grantMembership(SCOPE_ID, PEER_DEVICE);
+
+		const result = parseSyncScopeRequest(SCOPE_ID, true, {
+			db,
+			localDeviceId: LOCAL_DEVICE,
+			negotiatedCapability: "scoped",
+			peerDeviceId: PEER_DEVICE,
+		});
+
+		expect(result).toEqual({ ok: false, reason: "missing_scope" });
+	});
+
 	it("rejects with missing_scope when the scope does not exist", () => {
 		const result = parseSyncScopeRequest("does-not-exist", true, {
 			db,
@@ -384,6 +399,23 @@ describe("listAuthorizedScopesForPeer", () => {
 			peerDeviceId: PEER_DEVICE,
 		});
 		expect(scopes.map((s) => s.scope_id)).toEqual(["acme-work"]);
+	});
+
+	it("excludes custom local-authority scopes while keeping coordinator siblings", () => {
+		insertScope("local-notes", { authorityType: "local" });
+		insertScope("team-notes");
+		for (const scopeId of ["local-notes", "team-notes"]) {
+			grantMembership(scopeId, LOCAL_DEVICE);
+			grantMembership(scopeId, PEER_DEVICE);
+		}
+
+		const scopes = listAuthorizedScopesForPeer(db, {
+			localDeviceId: LOCAL_DEVICE,
+			peerDeviceId: PEER_DEVICE,
+		});
+
+		expect(scopes.map((scope) => scope.scope_id)).toEqual(["team-notes"]);
+		expect(scopes[0]?.authority_type).toBe("coordinator");
 	});
 
 	it("excludes scopes where the peer membership is revoked", () => {

--- a/packages/core/src/sync-scope-protocol.ts
+++ b/packages/core/src/sync-scope-protocol.ts
@@ -127,6 +127,7 @@ export function parseSyncScopeRequest(
 export function scopeAuthorizationFailureReason(
 	authorization: CachedScopeAuthorization,
 ): SyncScopeResetReason | null {
+	if (authorization.scope?.authority_type === "local") return "missing_scope";
 	if (authorization.authorized) return null;
 
 	switch (authorization.state) {
@@ -190,9 +191,7 @@ export interface AuthorizedScopeEntry {
  * - it exists in `replication_scopes` with status `active`, and
  * - both the local device and the peer device have active membership rows
  *   in `scope_memberships`, and
- * - the scope's `authority_type` is either non-`local`, OR the local
- *   membership exists (which is how personal scope grants are modeled — the
- *   grant row is the membership).
+ * - the scope's `authority_type` is not `local`.
  *
  * The legacy `local-default` scope is intentionally excluded. Scoped peers
  * still run the legacy default-scope path alongside per-scope sync to handle
@@ -237,7 +236,7 @@ export function listAuthorizedScopesForPeer(
 			deviceId: localDeviceId,
 			scopeId: local.scope_id,
 		});
-		if (!localAuth.authorized) continue;
+		if (!localAuth.authorized || localAuth.scope?.authority_type === "local") continue;
 
 		// Peer must also be an active member of the same scope, at the same
 		// or higher membership_epoch as the local row, before we advertise.

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -6112,7 +6112,7 @@ describe("viewer-server", () => {
 			}
 		});
 
-		it("accepts non-empty legacy pushes from unsupported peers", async () => {
+		it("rejects unknown scoped pushes from unsupported peers", async () => {
 			const { syncApp, ensureStore, cleanup } = createTestApp();
 			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
 			try {
@@ -6162,27 +6162,28 @@ describe("viewer-server", () => {
 					body: bodyText,
 				});
 
-				expect(res.status).toBe(200);
+				expect(res.status).toBe(403);
 				const body = (await res.json()) as Record<string, unknown>;
-				expect(body).toMatchObject({ applied: 1, skipped: 0, rejected: 0 });
+				expect(body).toMatchObject({ error: "scope_rejected", reason: "missing_scope" });
 				expect(
 					store.db
 						.prepare("SELECT title, scope_id FROM memory_items WHERE import_key = ?")
 						.get("legacy-push-key"),
-				).toMatchObject({ title: "Legacy push title", scope_id: "legacy-explicit" });
+				).toBeUndefined();
 			} finally {
 				peer?.cleanup();
 				cleanup();
 			}
 		});
 
-		it("does not outbound-scope-filter scoped pushes from unsupported peers", async () => {
+		it("accepts known authoritative scoped pushes from unsupported peers", async () => {
 			const { syncApp, ensureStore, cleanup } = createTestApp();
 			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
 			try {
 				const store = ensureStore();
 				const url = "http://localhost/v1/ops";
 				peer = createAuthenticatedSyncPeer(store, { url, method: "POST" });
+				grantSyncScopeToDevices(store, "unsupported-explicit", []);
 				const now = "2026-01-01T00:00:00Z";
 				const payload = {
 					sync_capability: "unsupported",


### PR DESCRIPTION
## Description

Keep local-authority scopes device-local across peer sync boundaries. Local scopes are no longer advertised, available through explicit snapshots, or accepted inbound, including capability-downgraded peers. Coordinator-authority scopes retain existing behavior.

Closes codemem-4e9t.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced