### PR TITLE
docs(cli): define operational status and consolidation roadmap

### DIFF
--- a/docs/plans/2026-08-11-cli-operational-status-and-command-tree-consolidation-design.md
+++ b/docs/plans/2026-08-11-cli-operational-status-and-command-tree-consolidation-design.md
@@ -1,0 +1,220 @@
+# CLI operational status and command-tree consolidation
+
+**Status:** Approved design
+
+**Date:** 2026-08-11
+
+**Decision:** Add top-level `codemem status` and a cheap viewer `GET /api/health`.
+
+## Problem
+
+Operators cannot currently ask one reliable question—“is codemem running and
+healthy?”—without assembling several commands and endpoint-specific probes.
+`stats` is inventory/usage, not an operational assessment; the detailed
+subsystem commands are necessary but do not provide an overall answer.
+
+## Audit evidence
+
+The current assembled CLI has **29 root commands**, **25 visible roots**, and
+roughly **125 command nodes** when compatibility duplication is included. These
+counts include Commander's implicit `help` root, hidden commands, and the full
+duplicated `sync coordinator` compatibility subtree. The tree has these
+confirmed gaps:
+
+- Operational health is split across `stats`, `sync status`/`sync doctor`,
+  `maintenance status`, and `db raw-events-status`; there is no general
+  `status` command.
+- Deprecated `export-memories`/`import-memories` and legacy sync/coordinator
+  paths remain visible in parts of the surface; compatibility duplication makes
+  the tree harder to discover.
+- Completion omits `maintenance`; completion and registered-command parity is
+  not tested as an assembled tree.
+- README and user-guide material still recommends `sync start`; coordinator
+  discovery examples omit required `--effect-id` arguments for membership
+  changes and retain legacy coordinator host/port forms despite the top-level
+  `coordinator` command.
+- `config workspace` overlaps `sync enable`/`disable`/`connect`, memory CRUD and
+  evaluation-oriented commands share one group, and JSON support is uneven
+  across neighboring sync and database mutation commands.
+
+The endpoint audit also found three incompatible viewer probes:
+
+| Caller | Probe |
+| --- | --- |
+| MCP stdio | `GET /api/health` |
+| Serve lifecycle | `GET /api/stats` |
+| OpenCode plugin | `GET /api/raw-events/status?limit=1` |
+
+`/api/health` is not currently registered. Consequently MCP `ensureViewer`
+misclassifies a healthy viewer as unhealthy and performs redundant detached
+start/poll attempts. This is **not** an MCP startup blocker: `ensureViewer` is
+best-effort/background, and MCP continues with its own store and stdio server.
+
+Evidence sources: `packages/cli/src/index.ts`, `commands/serve.ts`,
+`commands/stats.ts`, `commands/sync.ts`, `commands/maintenance.ts`,
+`commands/db.ts`, `packages/mcp-server/src/stdio.ts`, the OpenCode plugin,
+viewer stats routes, README, user guide, and coordinator documentation.
+
+## Chosen command model
+
+| Alternative | Result |
+| --- | --- |
+| `codemem status` | **Chosen.** A frequent, cross-subsystem operational question is a top-level action, produces a stable automation contract, and does not imply lifecycle mutation. |
+| `codemem serve status` | Rejected. `serve` owns viewer lifecycle; database, sync, ingestion, and observer state exceed that process boundary. |
+| `codemem health` | Rejected. Ambiguous with the HTTP liveness endpoint and less familiar as an operator roll-up. `status` can report degraded detail rather than only pass/fail. |
+
+Boundaries remain explicit:
+
+- **`status`**: operational roll-up—can codemem do useful local work now?
+- **`stats`**: database inventory and usage, not health.
+- **Subsystem commands**: `sync status`, `sync doctor`, `maintenance status`,
+  and `db raw-events-status` remain the detailed source of truth. Release
+  discovery remains a separate concern and is not part of this status contract.
+- **Future `doctor`**: a diagnostic/gating workflow, not a renamed status
+  command. It is not promoted in this stack.
+
+## `codemem status` contract
+
+`codemem status` is offline-capable: it reads local configuration, store state,
+PID metadata, and bounded local checks. It probes the host/port in the trusted
+viewer PID record, falling back to configured loopback defaults when no record
+exists. It may make one short loopback-only request to `/api/health`. On a 404
+from an older running viewer it may make one compatibility request to
+`/api/stats` before using local evidence; connection failure or timeout maps to
+`unreachable`, not `stopped`. It makes no registry, coordinator, non-loopback,
+or other external network request. It uses the shared `--db-path`, `--config`,
+and `--json` option helpers.
+
+Initial JSON is additive-only and contains bounded summaries, not unbounded
+rows or logs:
+
+```json
+{
+  "checked_at": "2026-08-11T12:00:00.000Z",
+  "ok": true,
+  "version": "0.40.2",
+  "database": { "state": "ready" },
+  "runtime": { "viewer": "running", "pid": 1234 },
+  "sync": { "state": "disabled" },
+  "maintenance": { "state": "idle" },
+  "semantic_index": { "state": "healthy" },
+  "raw_events": { "state": "backlogged", "pending": 3 },
+  "observer": { "state": "unconfigured" },
+  "attention": [{ "code": "raw_events_backlogged", "severity": "warning", "message": "3 raw events pending" }]
+}
+```
+
+Required fields are `checked_at`, `ok`, `version`, database state,
+runtime/viewer state, sync summary, maintenance summary, semantic-index
+summary, raw-events summary, observer summary, and bounded `attention` items.
+Subobjects may gain fields; existing names and meanings do not change without a
+major release. Human output presents the same assessment plus the next relevant
+detailed command.
+
+Initial state values are:
+
+- `runtime.viewer`: `running | stopped | unreachable | unknown`
+- `database.state`: `ready | missing | unavailable | unknown`
+- `sync.state`: `healthy | degraded | disabled | error | unknown`
+- `maintenance.state`: `idle | running | failed | unknown`
+- `semantic_index.state`: `healthy | pending | degraded | failed | unknown`
+- `raw_events.state`: `healthy | backlogged | failing | unknown`
+- `observer.state`: `healthy | idle | backoff | failed | unconfigured | unknown`
+
+Consumers must handle future state values as `unknown`/degraded. New values are
+additive; existing meanings remain stable. `attention` contains at most 20
+items, each with `severity: warning | error`, a code of at most 64 characters,
+and a message of at most 500 characters. `ok` is false when any attention item
+has `severity: error`; warnings remain visible without falsifying `ok`. A
+successfully collected report exits zero regardless of `ok`.
+
+Release discovery is deliberately excluded. It has registry/cache semantics;
+including it would violate the offline, predictable status contract.
+
+### Exit behavior
+
+| Condition | Exit |
+| --- | --- |
+| Status collected, including degraded state | `0` |
+| Usage error | `2` |
+| Status could not be collected | `1` |
+
+Degradation belongs in `ok` and `attention`, not in a surprising non-zero exit.
+A future explicit `--fail-on` policy may gate automation after its thresholds
+are designed. In `--json` mode, success is one JSON object on stdout; failure is
+`{"error":"…","message":"…"}` on stdout, with no incidental stdout text.
+
+```fish
+pnpm run codemem -- status --json
+pnpm run codemem -- status --db-path ./codemem.sqlite
+```
+
+## Viewer health endpoint
+
+Add `GET /api/health` as a cheap local liveness/readiness probe:
+
+```json
+{
+  "service": "codemem-viewer",
+  "version": "0.40.2",
+  "pid": 1234,
+  "uptime_ms": 42000,
+  "ready": true,
+  "database": { "reachable": true }
+}
+```
+
+The stable service discriminator prevents treating an arbitrary HTTP service as
+the viewer. The route returns HTTP `200` whenever the viewer process can serve
+requests, including when the database is unreachable. HTTP status plus the
+service discriminator represent liveness; `ready` and `database.reachable`
+represent readiness. A degraded-but-running viewer therefore returns `200`
+with `ready: false` instead of triggering redundant starts, refused stops, or
+restart loops in clients that gate on `response.ok`.
+
+The route performs no expensive stats scans, external egress, or authorization
+of process termination. Existing command-line and listening-PID ownership
+verification remains mandatory before any kill action. The `pid` field is
+informational in this stack and is not a termination input.
+
+Keep the existing `/api/stats` contract and keep `GET /api/runtime`
+version-only. A richer runtime route can be evaluated later only if real
+duplication emerges.
+
+## Compatibility, safety, and failure handling
+
+- Additive JSON only; retain existing endpoints and legacy CLI aliases in this
+  stack.
+- New clients probing an older viewer must fall back to the legacy probe when
+  `/api/health` is absent. Old clients continue to use their current routes.
+  The fallback retains today's weaker endpoint identification and does not gain
+  the new service discriminator.
+- Treat probe timeouts, malformed responses, and database failures as bounded
+  unavailable/degraded observations; do not crash command handlers or block MCP
+  startup.
+- Health checks are loopback-safe and cheap. They are evidence of a responding
+  viewer, never authority to kill a PID.
+- Status collection uses bounded queries and summaries to avoid turning routine
+  checks into database-wide scans.
+
+## Documentation and testing
+
+The status-command PR updates README and the user guide with the new command.
+The final hygiene PR repairs existing lifecycle/coordinator documentation,
+command help, completion, and deprecation drift. Tests cover the JSON and exit
+contract, unavailable and degraded states, no-egress behavior, health response
+and database failure, new-to-old endpoint fallback, and assembled
+registered/help/completion command-tree parity. Run focused Vitest tests per PR;
+the final integration gate is:
+
+```fish
+pnpm run tsc; and pnpm run lint; and pnpm run test
+```
+
+## Non-goals
+
+- Automatic remediation or a daemon-supervisor rewrite.
+- Remote status probing.
+- Alias rename/removal in this stack.
+- Full memory/evaluation command reorganization.
+- Promotion of `doctor` to a general health command.

--- a/docs/plans/2026-08-11-cli-operational-status-and-command-tree-consolidation-plan.md
+++ b/docs/plans/2026-08-11-cli-operational-status-and-command-tree-consolidation-plan.md
@@ -1,0 +1,157 @@
+# CLI operational status and command-tree consolidation: implementation plan
+
+**Status:** Approved implementation roadmap
+
+**Date:** 2026-08-11
+
+## Stack
+
+```text
+main
+└─ docs(cli): define operational status and consolidation roadmap
+   └─ feat(runtime): add lightweight health endpoint
+      └─ feat(cli): add operational status command
+         └─ fix(runtime): consolidate viewer health probes
+            └─ chore(cli): enforce command-tree parity and deprecation hygiene
+```
+
+Each PR is independently useful and keeps existing JSON contracts additive.
+
+## PR 1 — `docs(cli): define operational status and consolidation roadmap`
+
+- **Objective:** Record the approved `codemem status` boundary, health-route
+  contract, audit evidence, and delivery sequence.
+- **Files:** these two plan documents only.
+- **Behavioral work:** None; establishes the implementation contract and
+  deferred scope.
+- **Focused validation:**
+  ```fish
+  git diff --check
+  ```
+- **Safety risks:** Do not document private paths, hosts, or credentials; do not
+  imply aliases are removed before their compatibility period.
+- **Independent value:** Gives later PRs a reviewed contract and prevents a
+  status command from collapsing into stats, doctor, or lifecycle management.
+
+## PR 2 — `feat(runtime): add lightweight health endpoint`
+
+- **Objective:** Add `GET /api/health` for cheap viewer liveness/readiness.
+- **Likely files:** new `packages/viewer-server/src/routes/health.ts`,
+  `packages/viewer-server/src/index.ts`, `packages/viewer-server/src/index.test.ts`,
+  and route-specific tests if split during implementation.
+- **Behavioral work:** Return a stable service discriminator, version, PID,
+  uptime, readiness, and database reachability. Return HTTP `200` for every
+  degraded-but-running viewer, with readiness represented in the body; reserve
+  non-2xx for a process that cannot serve the route. Bound failures without
+  stats aggregation or outbound requests. Preserve existing
+  `/api/stats` and `/api/runtime` contracts; `/api/runtime` stays version-only.
+- **Focused validation:**
+  ```fish
+  pnpm exec vitest run packages/viewer-server/src/index.test.ts
+  pnpm run tsc
+  ```
+- **Safety risks:** The endpoint must not authorize a kill action. Existing
+  command-line/listening-PID ownership validation remains the termination gate.
+- **Independent value:** Fixes the missing endpoint that current MCP probes
+  expect, without changing any client probe behavior.
+
+## PR 3 — `feat(cli): add operational status command`
+
+- **Objective:** Ship top-level `codemem status` as the local operational
+  roll-up.
+- **Likely files:** `packages/cli/src/commands/status.ts`,
+  `packages/cli/src/index.ts`, `packages/cli/src/shared-options.ts`, focused
+  command tests, `README.md`, `docs/user-guide.md`, and core exports only if a
+  reusable bounded summary is needed.
+- **Behavioral work:** Use shared `--db-path`, `--config`, and `--json` options.
+  Collect local database readiness, runtime/viewer, sync, maintenance,
+  semantic-index, raw-events, and observer summaries plus bounded attention
+  items. Emit stable JSON/error objects and `0` for collected degraded status,
+  `2` for usage, `1` for collection failure. Allow one bounded loopback
+  `/api/health` probe plus a `/api/stats` compatibility fallback only when an
+  older viewer returns 404; otherwise use local fallback. Do not call
+  registries, the coordinator, non-loopback endpoints, or update discovery.
+- **Focused validation:**
+  ```fish
+  # New test file introduced by this PR.
+  pnpm exec vitest run packages/cli/src/commands/status.test.ts
+  pnpm run codemem -- status --json
+  pnpm run tsc
+  ```
+- **Safety risks:** Avoid unbounded database scans, leaking operational details
+  in errors, or changing existing automation output. Catch action-handler
+  failures and retain valid JSON-only stdout in `--json` mode.
+- **Independent value:** Answers the operator question while preserving `stats`
+  and subsystem commands as focused surfaces.
+
+## PR 4 — `fix(runtime): consolidate viewer health probes`
+
+- **Objective:** Move MCP, plugin, and serve lifecycle checks to `/api/health`.
+- **Likely files:** `packages/mcp-server/src/stdio.ts`,
+  `packages/opencode-plugin/.opencode/plugins/codemem.js`,
+  `packages/cli/src/commands/serve.ts`, and their focused tests.
+- **Behavioral work:** Validate the service discriminator and use bounded
+  timeouts. When a new client talks to an older viewer without `/api/health`,
+  retain legacy endpoint fallback (`/api/stats` or the existing raw-events probe
+  as appropriate). Keep MCP viewer startup best-effort/background; it must not
+  block MCP stdio startup. Serve lifecycle uses `/api/health` only for the
+  liveness discriminator. PID discovery for termination continues to read
+  `viewer_pid` from `/api/stats`; `/api/health.pid` is informational and MUST
+  NOT become a termination input in this stack. Existing listener-PID and `ps`
+  command-ownership gates remain unchanged.
+- **Focused validation:**
+  ```fish
+  pnpm exec vitest run packages/cli/src/commands/serve.test.ts
+  # New focused MCP stdio test introduced by this PR.
+  pnpm exec vitest run packages/mcp-server/src/stdio.test.ts
+  pnpm run tsc
+  ```
+- **Safety risks:** Do not weaken process-kill safeguards: an HTTP response is
+  insufficient without the existing PID/listener/command ownership checks. Do
+  not convert transient probe failure into a fatal MCP failure.
+- **Independent value:** Eliminates false-unhealthy detection and redundant
+  start/poll behavior while preserving old-viewer interoperability.
+
+## PR 5 — `chore(cli): enforce command-tree parity and deprecation hygiene`
+
+- **Objective:** Make the visible command tree, completions, docs, and
+  compatibility policy agree.
+- **Likely files:** `packages/cli/src/index.ts`, CLI tree/completion tests,
+  `README.md`, `docs/user-guide.md`, `docs/coordinator-discovery.md`,
+  `docs/coordinator-deployment.md`, `docs/coordinator-e2e-runbook.md`,
+  `docs/cloudflare-coordinator-deployment.md`, and affected command modules.
+- **Behavioral work:** Hide the already-warned `sync coordinator` compatibility
+  path. Add warnings to visible `export-memories`/`import-memories`, keep them
+  visible and in completion for their first warned release, and record their
+  future hide target; do not collapse warning and hiding into one release. Add
+  `maintenance` and `status` to completion. Replace `sync start` guidance with
+  `serve start`; add required `--effect-id` arguments and replace legacy
+  coordinator host/port forms in examples; add a new assembled runtime
+  command-tree test for registration, help visibility, and completion parity.
+  Do **not** remove aliases.
+- **Focused validation:**
+  ```fish
+  # New assembled command-tree test introduced by this PR.
+  pnpm exec vitest run packages/cli/src/command-tree.test.ts
+  pnpm run codemem -- --help
+  pnpm run tsc; and pnpm run lint; and pnpm run test
+  ```
+- **Safety risks:** Hidden aliases must preserve arguments, flags, JSON, exit
+  codes, and stderr deprecation behavior. Avoid broad memory/evaluation
+  reorganization while testing the assembled tree.
+- **Independent value:** Reduces discoverability drift and protects automation
+  compatibility without a breaking rename.
+
+## Deferred and non-goals
+
+- No automatic remediation or daemon-supervisor rewrite.
+- No remote status probing.
+- No command rename/removal in this stack.
+- No full memory/evaluation surface reorganization.
+- No `doctor` promotion; it remains a future diagnostic/gating design.
+
+## Final acceptance
+
+The stack is complete when `status --json` is offline and stable, `/api/health`
+is the shared cheap probe with old-viewer fallback, lifecycle kill safeguards are
+unchanged, and the assembled command/help/completion tree agrees with the docs.


### PR DESCRIPTION
## Description

Defines the approved top-level `codemem status` contract, lightweight viewer health boundary, compatibility rules, CLI audit findings, and five-PR consolidation roadmap. This keeps implementation order and additive JSON expectations reviewable before behavior changes land.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated the complete stack at its tip: build and lint pass; the workspace suite reports 3,954 passing tests and 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced