### PR TITLE
feat(runtime): add lightweight health endpoint

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -504,8 +504,7 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/runtime");
 				expect(res.status).toBe(200);
 				const body = (await res.json()) as Record<string, unknown>;
-				expect(body.version).toBe(VERSION);
-				expect(body).not.toHaveProperty("commit");
+				expect(body).toEqual({ version: VERSION });
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -20,6 +20,7 @@ import {
 	type InMemoryRequestRateLimiter,
 } from "./request-rate-limit.js";
 import { configRoutes } from "./routes/config.js";
+import { healthRoutes } from "./routes/health.js";
 import { memoryRoutes } from "./routes/memory.js";
 import { observerStatusRoutes } from "./routes/observer-status.js";
 import { packTransportRoutes } from "./routes/pack.js";
@@ -105,6 +106,7 @@ export function createApp(opts?: AppOptions) {
 	app.use("*", originGuard());
 
 	// API routes
+	app.route("/", healthRoutes(storeFactory));
 	app.route("/", statsRoutes(storeFactory));
 	app.route("/", memoryRoutes(storeFactory));
 	app.route("/", packTransportRoutes(storeFactory));

--- a/packages/viewer-server/src/routes/health.test.ts
+++ b/packages/viewer-server/src/routes/health.test.ts
@@ -1,0 +1,175 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { MemoryStore } from "@codemem/core";
+import { VERSION } from "@codemem/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../index.js";
+
+type HealthPayload = {
+	service: string;
+	version: string;
+	pid: number;
+	uptime_ms: number;
+	ready: boolean;
+	database: { reachable: boolean };
+};
+
+function createStoreDouble(options?: { probeError?: Error }) {
+	const pragma = options?.probeError
+		? vi.fn(() => {
+				throw options.probeError;
+			})
+		: vi.fn(() => 17);
+	const stats = vi.fn(() => {
+		throw new Error("health must not aggregate database stats");
+	});
+	const store = { db: { pragma }, stats } as unknown as MemoryStore;
+	return { store, pragma, stats };
+}
+
+function createMountedApp(storeFactory: () => MemoryStore) {
+	const staticDir = mkdtempSync(join(tmpdir(), "codemem-health-route-test-"));
+	writeFileSync(join(staticDir, "index.html"), "<!doctype html><title>test</title>");
+	const previousStaticDir = process.env.CODEMEM_VIEWER_STATIC_DIR;
+	process.env.CODEMEM_VIEWER_STATIC_DIR = staticDir;
+
+	try {
+		const app = createApp({ storeFactory });
+		return {
+			app,
+			cleanup: () => {
+				if (previousStaticDir == null) delete process.env.CODEMEM_VIEWER_STATIC_DIR;
+				else process.env.CODEMEM_VIEWER_STATIC_DIR = previousStaticDir;
+				rmSync(staticDir, { recursive: true, force: true });
+			},
+		};
+	} catch (error) {
+		if (previousStaticDir == null) delete process.env.CODEMEM_VIEWER_STATIC_DIR;
+		else process.env.CODEMEM_VIEWER_STATIC_DIR = previousStaticDir;
+		rmSync(staticDir, { recursive: true, force: true });
+		throw error;
+	}
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("GET /api/health", () => {
+	it("returns the stable healthy viewer contract through createApp", async () => {
+		// Arrange
+		vi.spyOn(process, "uptime").mockReturnValue(42.125);
+		const { store } = createStoreDouble();
+		const { app, cleanup } = createMountedApp(() => store);
+
+		try {
+			// Act
+			const response = await app.request("/api/health");
+			const body = (await response.json()) as HealthPayload;
+
+			// Assert
+			expect(response.status).toBe(200);
+			expect(body).toMatchObject({
+				service: "codemem-viewer",
+				version: VERSION,
+				pid: process.pid,
+				ready: true,
+				database: { reachable: true },
+			});
+			expect(Object.keys(body).sort()).toEqual([
+				"database",
+				"pid",
+				"ready",
+				"service",
+				"uptime_ms",
+				"version",
+			]);
+			expect(body.uptime_ms).toBe(42_125);
+			expect(Number.isInteger(body.uptime_ms)).toBe(true);
+			expect(response.headers.get("cache-control")).toBe("no-store");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("uses only a cheap schema-page database probe without stats aggregation or egress", async () => {
+		// Arrange
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+		const { store, pragma, stats } = createStoreDouble();
+		const { app, cleanup } = createMountedApp(() => store);
+
+		try {
+			// Act
+			const response = await app.request("/api/health");
+
+			// Assert
+			expect(response.status).toBe(200);
+			expect(pragma).toHaveBeenCalledOnce();
+			expect(pragma).toHaveBeenCalledWith("schema_version", { simple: true });
+			expect(stats).not.toHaveBeenCalled();
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("reports store construction failure as degraded HTTP 200 without error details", async () => {
+		// Arrange
+		const privateErrorDetail = "private database construction detail";
+		const storeFactory = vi.fn((): MemoryStore => {
+			throw new Error(privateErrorDetail);
+		});
+		const { app, cleanup } = createMountedApp(storeFactory);
+
+		try {
+			// Act
+			const response = await app.request("/api/health");
+			const body = (await response.json()) as HealthPayload;
+
+			// Assert
+			expect(response.status).toBe(200);
+			expect(body).toMatchObject({
+				service: "codemem-viewer",
+				version: VERSION,
+				pid: process.pid,
+				ready: false,
+				database: { reachable: false },
+			});
+			expect(JSON.stringify(body)).not.toContain(privateErrorDetail);
+			expect(storeFactory).toHaveBeenCalledOnce();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("reports database probe failure as degraded HTTP 200 without error details", async () => {
+		// Arrange
+		const privateErrorDetail = "private database probe detail";
+		const { store, pragma, stats } = createStoreDouble({
+			probeError: new Error(privateErrorDetail),
+		});
+		const { app, cleanup } = createMountedApp(() => store);
+
+		try {
+			// Act
+			const response = await app.request("/api/health");
+			const body = (await response.json()) as HealthPayload;
+
+			// Assert
+			expect(response.status).toBe(200);
+			expect(body).toMatchObject({
+				service: "codemem-viewer",
+				version: VERSION,
+				pid: process.pid,
+				ready: false,
+				database: { reachable: false },
+			});
+			expect(JSON.stringify(body)).not.toContain(privateErrorDetail);
+			expect(pragma).toHaveBeenCalledOnce();
+			expect(stats).not.toHaveBeenCalled();
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/packages/viewer-server/src/routes/health.ts
+++ b/packages/viewer-server/src/routes/health.ts
@@ -1,0 +1,33 @@
+import { type MemoryStore, VERSION } from "@codemem/core";
+import { Hono } from "hono";
+
+type StoreFactory = () => MemoryStore;
+
+function databaseReachable(getStore: StoreFactory): boolean {
+	try {
+		getStore().db.pragma("schema_version", { simple: true });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function healthRoutes(getStore: StoreFactory) {
+	const app = new Hono();
+
+	app.get("/api/health", (c) => {
+		const reachable = databaseReachable(getStore);
+		c.header("Cache-Control", "no-store");
+		return c.json({
+			service: "codemem-viewer",
+			version: VERSION,
+			pid: process.pid,
+			uptime_ms: Math.max(0, Math.floor(process.uptime() * 1_000)),
+			// Database reachability is the only readiness dependency in this endpoint.
+			ready: reachable,
+			database: { reachable },
+		});
+	});
+
+	return app;
+}


### PR DESCRIPTION
## Description

Adds a cheap `GET /api/health` endpoint for viewer liveness and readiness. The response includes a stable service discriminator, version, PID, uptime, readiness, and bounded SQLite reachability without stats scans, egress, or process-termination authority.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated health success, degraded readiness, database failure redaction, and route registration. The complete stack builds cleanly and the workspace suite reports 3,954 passing tests and 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced