### PR TITLE
feat(cli): add operational status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 
 | Group | Command | Description |
 |-------|---------|-------------|
-| **Core** | `codemem stats` | Database statistics |
+| **Core** | `codemem status` | Local operational roll-up (`--json` supported) |
+| | `codemem stats` | Database statistics |
 | | `codemem stats --attribution` | Bounded local retrieval-attribution diagnostics (`--json` supported) |
 | | `codemem recent` | Recent memories |
 | | `codemem search <query>` | Search memories |
@@ -174,6 +175,14 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | | `codemem codex-hook-inject` | Codex prompt-time memory injection (stdin, experimental) |
 
 Run `codemem --help` for the full list. Legacy top-level aliases (`export-memories`, `import-memories`, `show`, `forget`, `remember`) still work but are hidden from help.
+
+Use `codemem status` to answer whether the local database, viewer, sync, maintenance,
+semantic index, raw-event ingestion, and observer need attention. It is observational:
+it does not create a missing database, repair state, inspect credentials, or contact
+peers, coordinators, registries, or non-loopback hosts. Use `codemem status --json`
+for the stable machine-readable report. `codemem stats` remains the inventory and
+usage command; use `sync status`/`sync doctor`, `maintenance status`, and
+`db raw-events-status` for subsystem detail.
 
 Pack rendering defaults to self-contained context. For token-constrained experiments, `codemem pack <context> --compact` renders an index plus top details. Near-related compression is controlled by `--compression-mode off|compact|ids` (or `CODEMEM_PACK_COMPRESSION`); MCP `memory_pack` exposes the same setting as `compression_mode`. Use `ids` only when the agent can follow up with `memory_get_observations`.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -14,6 +14,26 @@
 - Treat the viewer as a local tool. If you must expose it beyond loopback, add your own auth and network restrictions first.
 - This warning applies to the viewer HTTP service, not the separate sync/coordinator listeners documented elsewhere.
 
+## Check local operational status
+
+`codemem status` is the local operational roll-up. It reports database readiness,
+viewer state, sync, maintenance, semantic indexing, raw-event ingestion, and the
+observer without changing configuration or stored data.
+
+```fish
+codemem status
+codemem status --json
+codemem status --db-path ./codemem.sqlite --config ./codemem.json
+```
+
+- `status` answers whether codemem can do useful local work; `stats` reports database inventory and usage.
+- Collection is offline and local-only. It does not contact peers, coordinators, registries, update services, or non-loopback viewer hosts.
+- A missing database is reported without creating it. Existing databases are opened read-only.
+- With no viewer PID record, status probes the configured loopback viewer address; a malformed or non-loopback record reports `unknown` and is not fetched.
+- Warnings and errors appear in the bounded `attention` list. A collected report exits `0` even when `ok` is false; collection failures exit `1`, and usage errors exit `2`.
+- Terminal raw-event and observer failures affect `ok` for 24 hours; use `codemem db raw-events-gate` for the detailed reliability window.
+- Use `codemem sync status` or `codemem sync doctor`, `codemem maintenance status`, and `codemem db raw-events-status` for detailed subsystem diagnostics.
+
 ## Seeing UI changes
 - The viewer UI is built from `packages/ui/` and served by `packages/viewer-server/`.
 - Rebuild UI assets after frontend changes: `pnpm --filter @codemem/ui build`.

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -1,0 +1,293 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type Database, type OperationalStatusSnapshot, VERSION } from "@codemem/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	boundAttention,
+	createStatusCommand,
+	type OperationalStatusReport,
+	type StatusDependencies,
+} from "./status.js";
+
+const healthySnapshot: OperationalStatusSnapshot = {
+	sync: { available: true, daemon_error: false, needs_attention: false, peer_errors: 0 },
+	maintenance: { state: "idle", running: 0, failed: 0 },
+	semantic_index: { state: "healthy", vector_table_present: true },
+	raw_events: { available: true, pending: 0, failed_batches: 0 },
+	observer: { available: true, failed_batches: 0, backoff_batches: 0 },
+};
+
+function harness(
+	overrides: Partial<StatusDependencies> & { snapshot?: OperationalStatusSnapshot } = {},
+) {
+	const stdout: string[] = [];
+	const stderr: string[] = [];
+	const exitCodes: number[] = [];
+	const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+		new Response(
+			JSON.stringify({
+				service: "codemem-viewer",
+				ready: true,
+				database: { reachable: true },
+			}),
+			{
+				status: 200,
+				headers: { "content-type": "application/json" },
+			},
+		),
+	);
+	const fakeDb = { close: vi.fn() } as unknown as Database;
+	const { snapshot = healthySnapshot, ...deps } = overrides;
+	const command = createStatusCommand({
+		now: () => new Date("2026-08-11T12:00:00.000Z"),
+		exists: () => true,
+		readText: () => JSON.stringify({ pid: 1234, host: "127.0.0.1", port: 38_888 }),
+		readConfig: () => ({ sync_enabled: true, observer_provider: "openai" }),
+		resolveDbPath: () => "/safe/test.sqlite",
+		connectReadOnly: () => fakeDb,
+		collectDatabase: () => snapshot,
+		embeddingDisabled: () => false,
+		fetch: fetchMock,
+		isProcessRunning: () => true,
+		env: {},
+		writeStdout: (text) => stdout.push(text),
+		writeStderr: (text) => stderr.push(text),
+		setExitCode: (code) => exitCodes.push(code),
+		...deps,
+	});
+	return { command, stdout, stderr, exitCodes, fetchMock };
+}
+
+describe("status command", () => {
+	const tempDirs: string[] = [];
+	afterEach(() => {
+		for (const path of tempDirs.splice(0)) rmSync(path, { recursive: true, force: true });
+	});
+
+	it("reports a missing database without creating it", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "codemem-status-missing-"));
+		tempDirs.push(dir);
+		const dbPath = join(dir, "missing.sqlite");
+		const collected = vi.fn();
+		const { command, stdout, exitCodes } = harness({
+			exists: () => false,
+			resolveDbPath: () => dbPath,
+			collectDatabase: collected,
+		});
+
+		await command.parseAsync(["--db-path", dbPath, "--json"], { from: "user" });
+
+		expect(existsSync(dbPath)).toBe(false);
+		expect(collected).not.toHaveBeenCalled();
+		expect(JSON.parse(stdout[0] ?? "{}").database.state).toBe("missing");
+		expect(exitCodes).toEqual([0]);
+	});
+
+	it("emits the exact required healthy JSON shape with one stdout object", async () => {
+		const { command, stdout, stderr, exitCodes } = harness();
+		await command.parseAsync(["--json"], { from: "user" });
+
+		const report = JSON.parse(stdout[0] ?? "{}") as OperationalStatusReport;
+		expect(stdout).toHaveLength(1);
+		expect(stderr).toEqual([]);
+		expect(exitCodes).toEqual([0]);
+		expect(Object.keys(report)).toEqual([
+			"checked_at",
+			"ok",
+			"version",
+			"database",
+			"runtime",
+			"sync",
+			"maintenance",
+			"semantic_index",
+			"raw_events",
+			"observer",
+			"attention",
+		]);
+		expect(report).toMatchObject({
+			checked_at: "2026-08-11T12:00:00.000Z",
+			ok: true,
+			version: VERSION,
+			database: { state: "ready" },
+			runtime: { viewer: "running", pid: 1234 },
+			sync: { state: "healthy" },
+			maintenance: { state: "idle" },
+			semantic_index: { state: "healthy" },
+			raw_events: { state: "healthy", pending: 0 },
+			observer: { state: "idle" },
+			attention: [],
+		});
+	});
+
+	it("keeps warnings successful and exits zero for degraded reports", async () => {
+		const snapshot = structuredClone(healthySnapshot);
+		snapshot.sync.peer_errors = 2;
+		const { command, stdout, exitCodes } = harness({ snapshot });
+		await command.parseAsync(["--json"], { from: "user" });
+		const report = JSON.parse(stdout[0] ?? "{}") as OperationalStatusReport;
+		expect(report.sync.state).toBe("degraded");
+		expect(report.ok).toBe(true);
+		expect(report.attention[0]?.severity).toBe("warning");
+		expect(exitCodes).toEqual([0]);
+	});
+
+	it("keeps an unready viewer running and reports its readiness warning", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					service: "codemem-viewer",
+					ready: false,
+					database: { reachable: false },
+				}),
+			),
+		);
+		const { command, stdout } = harness({ fetch: fetchMock });
+		await command.parseAsync(["--json"], { from: "user" });
+		const report = JSON.parse(stdout[0] ?? "{}") as OperationalStatusReport;
+		expect(report.runtime.viewer).toBe("running");
+		expect(report.attention).toContainEqual(
+			expect.objectContaining({ code: "viewer_not_ready", severity: "warning" }),
+		);
+	});
+
+	it("uses configured loopback viewer defaults when no PID record exists", async () => {
+		const { command, fetchMock } = harness({
+			exists: (path) => !path.endsWith("viewer.pid"),
+			env: { CODEMEM_VIEWER_HOST: "127.0.0.2", CODEMEM_VIEWER_PORT: "39999" },
+		});
+		await command.parseAsync(["--json"], { from: "user" });
+		expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.2:39999/api/health");
+	});
+
+	it("sets ok false for error attention while still exiting zero", async () => {
+		const snapshot = structuredClone(healthySnapshot);
+		snapshot.maintenance = { state: "failed", running: 0, failed: 1 };
+		const { command, stdout, exitCodes } = harness({ snapshot });
+		await command.parseAsync(["--json"], { from: "user" });
+		const report = JSON.parse(stdout[0] ?? "{}") as OperationalStatusReport;
+		expect(report.ok).toBe(false);
+		expect(report.attention).toContainEqual(
+			expect.objectContaining({ code: "maintenance_failed", severity: "error" }),
+		);
+		expect(exitCodes).toEqual([0]);
+	});
+
+	it("projects disabled sync, unconfigured observer, and subsystem failures", async () => {
+		const snapshot = structuredClone(healthySnapshot);
+		snapshot.semantic_index.state = "failed";
+		snapshot.raw_events = { available: true, pending: 2_000_000, failed_batches: 1 };
+		snapshot.observer.failed_batches = 1;
+		const { command, stdout } = harness({
+			snapshot,
+			readConfig: () => ({ sync_enabled: false }),
+		});
+		await command.parseAsync(["--json"], { from: "user" });
+		const report = JSON.parse(stdout[0] ?? "{}") as OperationalStatusReport;
+		expect(report.sync.state).toBe("disabled");
+		expect(report.observer.state).toBe("unconfigured");
+		expect(report.semantic_index.state).toBe("failed");
+		expect(report.raw_events).toEqual({ state: "failing", pending: 2_000_000 });
+	});
+
+	it("reads sync and observer presence from environment evidence", async () => {
+		const { command, stdout } = harness({
+			readConfig: () => ({}),
+			env: { CODEMEM_SYNC_ENABLED: "true", CODEMEM_OBSERVER_PROVIDER: "openai" },
+		});
+		await command.parseAsync(["--json"], { from: "user" });
+		const report = JSON.parse(stdout[0] ?? "{}") as OperationalStatusReport;
+		expect(report.sync.state).toBe("healthy");
+		expect(report.observer.state).toBe("idle");
+	});
+
+	it("does not treat observer tuning alone as configured", async () => {
+		const { command, stdout } = harness({
+			readConfig: () => ({ observer_tier_routing_enabled: false, observer_temperature: 0.2 }),
+		});
+		await command.parseAsync(["--json"], { from: "user" });
+		const report = JSON.parse(stdout[0] ?? "{}") as OperationalStatusReport;
+		expect(report.observer.state).toBe("unconfigured");
+	});
+
+	it("reports retryable observer failures as backoff warnings", async () => {
+		const snapshot = structuredClone(healthySnapshot);
+		snapshot.observer.backoff_batches = 1;
+		const { command, stdout } = harness({ snapshot });
+		await command.parseAsync(["--json"], { from: "user" });
+		const report = JSON.parse(stdout[0] ?? "{}") as OperationalStatusReport;
+		expect(report.observer.state).toBe("backoff");
+		expect(report.attention).toContainEqual(
+			expect.objectContaining({ code: "observer_backoff", severity: "warning" }),
+		);
+	});
+
+	it("renders compact human output and detailed command suggestions", async () => {
+		const snapshot = structuredClone(healthySnapshot);
+		snapshot.raw_events.pending = 3;
+		const { command, stdout } = harness({ snapshot });
+		await command.parseAsync([], { from: "user" });
+		expect(stdout).toHaveLength(1);
+		expect(stdout[0]).toContain("codemem status OK");
+		expect(stdout[0]).toContain("Raw events:     backlogged (3 pending)");
+		expect(stdout[0]).toContain("codemem db raw-events-status");
+	});
+
+	it("emits one structured error and exits one on collection failure", async () => {
+		const close = vi.fn();
+		const { command, stdout, stderr, exitCodes } = harness({
+			connectReadOnly: () => ({ close }) as unknown as Database,
+			collectDatabase: () => {
+				throw new Error("sensitive database failure");
+			},
+		});
+		await command.parseAsync(["--json"], { from: "user" });
+		expect(stdout).toEqual([
+			JSON.stringify({ error: "status_failed", message: "Unable to collect operational status" }),
+		]);
+		expect(stderr).toEqual([]);
+		expect(exitCodes).toEqual([1]);
+		expect(stdout[0]).not.toContain("sensitive");
+		expect(close).toHaveBeenCalledOnce();
+	});
+
+	it("rejects positional arguments as usage errors", async () => {
+		const { command, stdout, exitCodes } = harness();
+		await command.parseAsync(["unexpected", "--json"], { from: "user" });
+		expect(JSON.parse(stdout[0] ?? "{}").error).toBe("usage_error");
+		expect(exitCodes).toEqual([2]);
+	});
+
+	it("rejects unknown options as usage errors", async () => {
+		const { command, stdout, exitCodes } = harness();
+		await command.parseAsync(["--json", "--bogus"], { from: "user" });
+		expect(JSON.parse(stdout[0] ?? "{}").error).toBe("usage_error");
+		expect(exitCodes).toEqual([2]);
+	});
+
+	it("registers shared options and no positional arguments", () => {
+		const { command } = harness();
+		expect(command.registeredArguments).toHaveLength(0);
+		expect(command.options.map((option) => option.flags)).toEqual([
+			"-d, --db-path <path>",
+			"--db <path>",
+			"-c, --config <path>",
+			"-j, --json",
+		]);
+		expect(command.helpInformation()).toContain("status [options]");
+	});
+
+	it("caps and bounds attention entries", () => {
+		const attention = boundAttention(
+			Array.from({ length: 25 }, (_, index) => ({
+				code: `unsafe code ${index}${"x".repeat(80)}`,
+				severity: "warning" as const,
+				message: "m".repeat(600),
+			})),
+		);
+		expect(attention).toHaveLength(20);
+		expect(attention.every((item) => item.code.length <= 64 && item.message.length <= 500)).toBe(
+			true,
+		);
+	});
+});

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,461 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+	collectOperationalStatus,
+	connectReadOnly,
+	isEmbeddingDisabled,
+	type OperationalStatusSnapshot,
+	readCodememConfigFile,
+	readCodememConfigFileAtPath,
+	resolveDbPath,
+	VERSION,
+} from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+import {
+	addConfigOption,
+	addDbOption,
+	addJsonOption,
+	type ConfigOpts,
+	type DbOpts,
+	type JsonOpts,
+	resolveDbOpt,
+} from "../shared-options.js";
+import {
+	observeViewerRuntime,
+	parseViewerPidRecord,
+	type ViewerRuntimeObservation,
+} from "../viewer-runtime.js";
+
+export type DatabaseState = "ready" | "missing" | "unavailable" | "unknown";
+export type SyncState = "healthy" | "degraded" | "disabled" | "error" | "unknown";
+export type MaintenanceState = "idle" | "running" | "failed" | "unknown";
+export type SemanticIndexState = "healthy" | "pending" | "degraded" | "failed" | "unknown";
+export type RawEventsState = "healthy" | "backlogged" | "failing" | "unknown";
+export type ObserverState = "healthy" | "idle" | "backoff" | "failed" | "unconfigured" | "unknown";
+export type AttentionSeverity = "warning" | "error";
+
+export interface StatusAttention {
+	code: string;
+	severity: AttentionSeverity;
+	message: string;
+}
+
+export interface OperationalStatusReport {
+	checked_at: string;
+	ok: boolean;
+	version: string;
+	database: { state: DatabaseState };
+	runtime: { viewer: ViewerRuntimeObservation["state"]; pid?: number };
+	sync: { state: SyncState };
+	maintenance: { state: MaintenanceState };
+	semantic_index: { state: SemanticIndexState };
+	raw_events: { state: RawEventsState; pending: number };
+	observer: { state: ObserverState };
+	attention: StatusAttention[];
+}
+
+interface StatusOptions extends DbOpts, ConfigOpts, JsonOpts {}
+
+export interface StatusDependencies {
+	now: () => Date;
+	exists: (path: string) => boolean;
+	readText: (path: string) => string | null;
+	readConfig: (path?: string) => Record<string, unknown>;
+	resolveDbPath: (path?: string) => string;
+	connectReadOnly: typeof connectReadOnly;
+	collectDatabase: typeof collectOperationalStatus;
+	embeddingDisabled: () => boolean;
+	fetch: typeof fetch;
+	isProcessRunning: (pid: number) => boolean | null;
+	env: NodeJS.ProcessEnv;
+	writeStdout: (text: string) => void;
+	writeStderr: (text: string) => void;
+	setExitCode: (code: number) => void;
+}
+
+const MAX_ATTENTION = 20;
+const DEFAULT_VIEWER_PORT = 38_888;
+const RECENT_FAILURE_WINDOW_MS = 24 * 60 * 60 * 1000;
+const OBSERVER_IDENTITY_KEYS = [
+	"observer_provider",
+	"observer_model",
+	"observer_runtime",
+	"observer_base_url",
+	"observer_simple_provider",
+	"observer_simple_model",
+	"observer_rich_provider",
+	"observer_rich_model",
+] as const;
+
+const defaultDependencies: StatusDependencies = {
+	now: () => new Date(),
+	exists: existsSync,
+	readText: (path) => {
+		try {
+			return readFileSync(path, "utf8");
+		} catch {
+			return null;
+		}
+	},
+	readConfig: (path) => (path ? readCodememConfigFileAtPath(path) : readCodememConfigFile()),
+	resolveDbPath,
+	connectReadOnly,
+	collectDatabase: collectOperationalStatus,
+	embeddingDisabled: isEmbeddingDisabled,
+	fetch,
+	isProcessRunning: (pid) => {
+		try {
+			process.kill(pid, 0);
+			return true;
+		} catch (error) {
+			if (
+				typeof error === "object" &&
+				error !== null &&
+				"code" in error &&
+				error.code === "EPERM"
+			) {
+				return null;
+			}
+			return false;
+		}
+	},
+	env: process.env,
+	writeStdout: (text) => console.log(text),
+	writeStderr: (text) => console.error(text),
+	setExitCode: (code) => {
+		process.exitCode = code;
+	},
+};
+
+function boolValue(value: unknown): boolean | null {
+	if (typeof value === "boolean") return value;
+	if (typeof value !== "string") return null;
+	const normalized = value.trim().toLowerCase();
+	if (["1", "true", "yes", "on"].includes(normalized)) return true;
+	if (["0", "false", "no", "off"].includes(normalized)) return false;
+	return null;
+}
+
+function syncEnabled(config: Record<string, unknown>, env: NodeJS.ProcessEnv): boolean {
+	return boolValue(env.CODEMEM_SYNC_ENABLED) ?? boolValue(config.sync_enabled) ?? false;
+}
+
+function observerConfigured(config: Record<string, unknown>, env: NodeJS.ProcessEnv): boolean {
+	const fileConfigured = OBSERVER_IDENTITY_KEYS.some((key) => {
+		const value = config[key];
+		return typeof value === "string" && value.trim() !== "";
+	});
+	const envConfigured = OBSERVER_IDENTITY_KEYS.some((key) => {
+		const value = env[`CODEMEM_${key.toUpperCase()}`];
+		return typeof value === "string" && value.trim() !== "";
+	});
+	return fileConfigured || envConfigured;
+}
+
+function viewerDefaultTarget(env: NodeJS.ProcessEnv): { host: string; port: number } {
+	const host = env.CODEMEM_VIEWER_HOST?.trim() || "127.0.0.1";
+	const parsedPort = Number.parseInt(env.CODEMEM_VIEWER_PORT ?? "", 10);
+	return {
+		host,
+		port:
+			Number.isFinite(parsedPort) && parsedPort > 0 && parsedPort <= 65_535
+				? parsedPort
+				: DEFAULT_VIEWER_PORT,
+	};
+}
+
+export function boundAttention(items: StatusAttention[]): StatusAttention[] {
+	return items.slice(0, MAX_ATTENTION).map((item) => ({
+		code: item.code.replace(/[^a-z0-9_]/gi, "_").slice(0, 64),
+		severity: item.severity,
+		message: item.message.slice(0, 500),
+	}));
+}
+
+function projectSync(
+	enabled: boolean,
+	snapshot: OperationalStatusSnapshot | null,
+	attention: StatusAttention[],
+): SyncState {
+	if (!enabled) return "disabled";
+	if (!snapshot) return "unknown";
+	if (snapshot.sync.daemon_error || snapshot.sync.needs_attention) {
+		attention.push({
+			code: "sync_daemon_error",
+			severity: "error",
+			message: "Sync requires attention; run `codemem sync doctor`",
+		});
+		return "error";
+	}
+	if (snapshot.sync.peer_errors > 0) {
+		attention.push({
+			code: "sync_degraded",
+			severity: "warning",
+			message: "Sync has recent peer failures; run `codemem sync status`",
+		});
+		return "degraded";
+	}
+	if (!snapshot.sync.available) return "unknown";
+	return "healthy";
+}
+
+function addDatabaseAttention(state: DatabaseState, attention: StatusAttention[]): void {
+	if (state === "missing") {
+		attention.push({
+			code: "database_missing",
+			severity: "error",
+			message: "Database does not exist",
+		});
+	} else if (state === "unavailable") {
+		attention.push({
+			code: "database_unavailable",
+			severity: "error",
+			message: "Database could not be read",
+		});
+	}
+}
+
+function addRuntimeAttention(
+	runtime: ViewerRuntimeObservation,
+	attention: StatusAttention[],
+): void {
+	if (runtime.state === "stopped") {
+		attention.push({
+			code: "viewer_stopped",
+			severity: "warning",
+			message: "Viewer is stopped; run `codemem serve start` if needed",
+		});
+		return;
+	}
+	if (runtime.state === "unreachable") {
+		attention.push({
+			code: "viewer_unreachable",
+			severity: "warning",
+			message: "Viewer did not answer its local health check",
+		});
+		return;
+	}
+	if (runtime.attention_code) {
+		const messages: Record<NonNullable<ViewerRuntimeObservation["attention_code"]>, string> = {
+			viewer_pid_malformed: "Viewer PID record is malformed",
+			viewer_non_loopback: "Viewer PID record is not loopback; no request was made",
+			viewer_not_ready: "Viewer is running but its database is not ready",
+			viewer_unexpected_response: "Viewer returned an unexpected local health response",
+			viewer_wrong_service: "Local health endpoint did not identify codemem viewer",
+		};
+		attention.push({
+			code: runtime.attention_code,
+			severity: "warning",
+			message: messages[runtime.attention_code],
+		});
+	}
+}
+
+function projectDatabaseSubsystems(
+	snapshot: OperationalStatusSnapshot | null,
+	configuredObserver: boolean,
+	attention: StatusAttention[],
+): Pick<OperationalStatusReport, "maintenance" | "semantic_index" | "raw_events" | "observer"> {
+	if (!snapshot) {
+		return {
+			maintenance: { state: "unknown" },
+			semantic_index: { state: "unknown" },
+			raw_events: { state: "unknown", pending: 0 },
+			observer: { state: configuredObserver ? "unknown" : "unconfigured" },
+		};
+	}
+	if (snapshot.maintenance.state === "failed") {
+		attention.push({
+			code: "maintenance_failed",
+			severity: "error",
+			message: "Maintenance has failed jobs; run `codemem maintenance status`",
+		});
+	} else if (snapshot.maintenance.state === "running") {
+		attention.push({
+			code: "maintenance_running",
+			severity: "warning",
+			message: "Maintenance work is in progress",
+		});
+	}
+	if (snapshot.semantic_index.state === "failed") {
+		attention.push({
+			code: "semantic_index_failed",
+			severity: "error",
+			message: "Semantic index maintenance failed; run `codemem maintenance status`",
+		});
+	} else if (snapshot.semantic_index.state === "pending") {
+		attention.push({
+			code: "semantic_index_pending",
+			severity: "warning",
+			message: "Semantic index maintenance is pending",
+		});
+	} else if (snapshot.semantic_index.state === "degraded") {
+		attention.push({
+			code: "semantic_index_degraded",
+			severity: "warning",
+			message: "Semantic search is unavailable; keyword search remains available",
+		});
+	}
+
+	const pending = Math.max(0, Math.trunc(snapshot.raw_events.pending));
+	let rawState: RawEventsState = snapshot.raw_events.available ? "healthy" : "unknown";
+	if (snapshot.raw_events.failed_batches > 0) {
+		rawState = "failing";
+		attention.push({
+			code: "raw_events_failing",
+			severity: "error",
+			message: "Raw-event ingestion exhausted retries recently; run `codemem db raw-events-gate`",
+		});
+	} else if (pending > 0) {
+		rawState = "backlogged";
+		attention.push({
+			code: "raw_events_backlogged",
+			severity: "warning",
+			message: `${pending} raw events pending; run \`codemem db raw-events-status\``,
+		});
+	}
+
+	let observerState: ObserverState = "unconfigured";
+	if (configuredObserver) observerState = snapshot.observer.available ? "idle" : "unknown";
+	if (configuredObserver && snapshot.observer.failed_batches > 0) {
+		observerState = "failed";
+		attention.push({
+			code: "observer_failed",
+			severity: "error",
+			message: "Observer exhausted retries recently; run `codemem db raw-events-gate`",
+		});
+	} else if (configuredObserver && snapshot.observer.backoff_batches > 0) {
+		observerState = "backoff";
+		attention.push({
+			code: "observer_backoff",
+			severity: "warning",
+			message: "Observer has retryable failures; run `codemem db raw-events-status`",
+		});
+	}
+	return {
+		maintenance: { state: snapshot.maintenance.state },
+		semantic_index: { state: snapshot.semantic_index.state },
+		raw_events: { state: rawState, pending },
+		observer: { state: observerState },
+	};
+}
+
+export async function collectStatusReport(
+	opts: StatusOptions,
+	deps: StatusDependencies = defaultDependencies,
+): Promise<OperationalStatusReport> {
+	const checkedAt = deps.now();
+	const config = deps.readConfig(opts.config);
+	const dbPath = deps.resolveDbPath(resolveDbOpt(opts));
+	let databaseState: DatabaseState = "missing";
+	let snapshot: OperationalStatusSnapshot | null = null;
+	if (deps.exists(dbPath)) {
+		let db: ReturnType<typeof connectReadOnly> | null = null;
+		try {
+			db = deps.connectReadOnly(dbPath);
+		} catch {
+			databaseState = "unavailable";
+		}
+		if (db) {
+			try {
+				snapshot = deps.collectDatabase(db, {
+					embeddingDisabled: deps.embeddingDisabled(),
+					recentFailureCutoff: new Date(
+						checkedAt.getTime() - RECENT_FAILURE_WINDOW_MS,
+					).toISOString(),
+				});
+				databaseState = "ready";
+			} finally {
+				db.close();
+			}
+		}
+	}
+
+	const pidPath = join(dirname(dbPath), "viewer.pid");
+	const parsedPid = parseViewerPidRecord(deps.exists(pidPath) ? deps.readText(pidPath) : null);
+	const runtime = await observeViewerRuntime(
+		parsedPid,
+		{
+			fetch: deps.fetch,
+			isProcessRunning: deps.isProcessRunning,
+		},
+		viewerDefaultTarget(deps.env),
+	);
+	const attention: StatusAttention[] = [];
+	addDatabaseAttention(databaseState, attention);
+	addRuntimeAttention(runtime, attention);
+	const sync = projectSync(syncEnabled(config, deps.env), snapshot, attention);
+	const subsystems = projectDatabaseSubsystems(
+		snapshot,
+		observerConfigured(config, deps.env),
+		attention,
+	);
+	const ok = !attention.some((item) => item.severity === "error");
+	const boundedAttention = boundAttention(attention);
+	return {
+		checked_at: checkedAt.toISOString(),
+		ok,
+		version: VERSION,
+		database: { state: databaseState },
+		runtime: runtime.pid ? { viewer: runtime.state, pid: runtime.pid } : { viewer: runtime.state },
+		sync: { state: sync },
+		...subsystems,
+		attention: boundedAttention,
+	};
+}
+
+export function renderStatusReport(report: OperationalStatusReport): string {
+	const lines = [
+		`codemem status ${report.ok ? "OK" : "ATTENTION"}`,
+		`Database:       ${report.database.state}`,
+		`Viewer:         ${report.runtime.viewer}${report.runtime.pid ? ` (pid ${report.runtime.pid})` : ""}`,
+		`Sync:           ${report.sync.state}`,
+		`Maintenance:    ${report.maintenance.state}`,
+		`Semantic index: ${report.semantic_index.state}`,
+		`Raw events:     ${report.raw_events.state}${
+			report.raw_events.pending > 0 ? ` (${report.raw_events.pending} pending)` : ""
+		}`,
+		`Observer:       ${report.observer.state}`,
+	];
+	if (report.attention.length > 0) {
+		lines.push(
+			"Attention:",
+			...report.attention.map((item) => `- ${item.severity}: ${item.message}`),
+		);
+	}
+	return lines.join("\n");
+}
+
+export function createStatusCommand(overrides: Partial<StatusDependencies> = {}): Command {
+	const deps: StatusDependencies = { ...defaultDependencies, ...overrides };
+	const command = new Command("status")
+		.configureHelp(helpStyle)
+		.description("Show local operational status")
+		.allowUnknownOption(true)
+		.allowExcessArguments(true);
+	addDbOption(command);
+	addConfigOption(command);
+	addJsonOption(command);
+	return command.action(async (opts: StatusOptions, actionCommand: Command) => {
+		if (actionCommand.args.length > 0) {
+			const message = "status accepts only documented options and no positional arguments";
+			if (opts.json) deps.writeStdout(JSON.stringify({ error: "usage_error", message }));
+			else deps.writeStderr(message);
+			deps.setExitCode(2);
+			return;
+		}
+		try {
+			const report = await collectStatusReport(opts, deps);
+			deps.writeStdout(opts.json ? JSON.stringify(report) : renderStatusReport(report));
+			deps.setExitCode(0);
+		} catch {
+			const error = { error: "status_failed", message: "Unable to collect operational status" };
+			if (opts.json) deps.writeStdout(JSON.stringify(error));
+			else deps.writeStderr(error.message);
+			deps.setExitCode(1);
+		}
+	});
+}
+
+export const statusCommand = createStatusCommand();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,6 +41,7 @@ import { searchCommand } from "./commands/search.js";
 import { serveCommand } from "./commands/serve.js";
 import { setupCommand } from "./commands/setup.js";
 import { statsCommand } from "./commands/stats.js";
+import { statusCommand } from "./commands/status.js";
 import { syncCommand } from "./commands/sync.js";
 import { versionCommand } from "./commands/version.js";
 import { helpStyle } from "./help-style.js";
@@ -75,6 +76,7 @@ completion.on("command", ({ reply }) => {
 		"serve",
 		"setup",
 		"stats",
+		"status",
 		"sync",
 		"version",
 		"help",
@@ -207,6 +209,7 @@ program.addCommand(distillCommand);
 program.addCommand(exportMemoriesCommand);
 program.addCommand(importMemoriesCommand);
 program.addCommand(statsCommand);
+program.addCommand(statusCommand);
 program.addCommand(maintenanceCommand);
 program.addCommand(embedCommand);
 program.addCommand(recentCommand);

--- a/packages/cli/src/viewer-runtime.test.ts
+++ b/packages/cli/src/viewer-runtime.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	isLoopbackHost,
+	observeViewerRuntime,
+	parseViewerPidRecord,
+	type ViewerPidRecord,
+} from "./viewer-runtime.js";
+
+const record: ViewerPidRecord = { pid: 1234, host: "127.0.0.1", port: 38_888 };
+const healthy = {
+	service: "codemem-viewer",
+	ready: true,
+	database: { reachable: true },
+};
+
+function response(body: unknown, init: ResponseInit = {}): Response {
+	return new Response(body == null ? null : JSON.stringify(body), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+		...init,
+	});
+}
+
+describe("viewer PID records", () => {
+	it("parses structured and legacy records", () => {
+		expect(parseViewerPidRecord('{"pid":1234,"host":"localhost","port":38888}')).toEqual({
+			state: "valid",
+			record: { pid: 1234, host: "localhost", port: 38_888 },
+		});
+		expect(parseViewerPidRecord("1234")).toEqual({ state: "legacy", pid: 1234 });
+	});
+
+	it("rejects malformed records and validates loopback hosts", () => {
+		for (const raw of ["", "12oops", '{"pid":0,"host":"localhost","port":38888}', "{}"]) {
+			expect(parseViewerPidRecord(raw).state).toBe("malformed");
+		}
+		expect(isLoopbackHost("127.0.0.2")).toBe(true);
+		expect(isLoopbackHost("[::1]")).toBe(true);
+		expect(isLoopbackHost("example.test")).toBe(false);
+	});
+});
+
+describe("observeViewerRuntime", () => {
+	it("accepts a valid health discriminator", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(healthy));
+		await expect(
+			observeViewerRuntime(
+				{ state: "valid", record },
+				{ fetch: fetchMock, isProcessRunning: () => true },
+			),
+		).resolves.toEqual({ state: "running", pid: 1234 });
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.1:38888/api/health");
+	});
+
+	it("rejects the wrong service discriminator without fallback", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(response({ service: "something-else" }));
+		await expect(
+			observeViewerRuntime(
+				{ state: "valid", record },
+				{ fetch: fetchMock, isProcessRunning: () => true },
+			),
+		).resolves.toMatchObject({ state: "unknown", attention_code: "viewer_wrong_service" });
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses stats fallback only for a health 404", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(response(null, { status: 404 }))
+			.mockResolvedValueOnce(response({ viewer_pid: 1234 }));
+		await expect(
+			observeViewerRuntime(
+				{ state: "valid", record },
+				{ fetch: fetchMock, isProcessRunning: () => true },
+			),
+		).resolves.toEqual({ state: "running", pid: 1234 });
+		expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+			"http://127.0.0.1:38888/api/health",
+			"http://127.0.0.1:38888/api/stats",
+		]);
+	});
+
+	it("does not fall back on 500 or connection failure", async () => {
+		for (const result of [response(null, { status: 500 }), new Error("timeout")]) {
+			const fetchMock = vi.fn<typeof fetch>();
+			if (result instanceof Error) fetchMock.mockRejectedValue(result);
+			else fetchMock.mockResolvedValue(result);
+			const observed = await observeViewerRuntime(
+				{ state: "valid", record },
+				{ fetch: fetchMock, isProcessRunning: () => true },
+			);
+			expect(observed.state).toBe(result instanceof Error ? "unreachable" : "unknown");
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+		}
+	});
+
+	it("never fetches a non-loopback PID record", async () => {
+		const fetchMock = vi.fn<typeof fetch>();
+		await expect(
+			observeViewerRuntime(
+				{ state: "valid", record: { ...record, host: "example.test" } },
+				{ fetch: fetchMock, isProcessRunning: () => true },
+			),
+		).resolves.toMatchObject({ state: "unknown", attention_code: "viewer_non_loopback" });
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("probes the default loopback viewer when the PID record is missing", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(healthy));
+		await expect(
+			observeViewerRuntime(
+				{ state: "missing" },
+				{ fetch: fetchMock, isProcessRunning: () => null },
+			),
+		).resolves.toEqual({ state: "running" });
+		expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.1:38888/api/health");
+	});
+
+	it("uses a configured loopback target when the PID record is missing", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(healthy));
+		await expect(
+			observeViewerRuntime(
+				{ state: "missing" },
+				{ fetch: fetchMock, isProcessRunning: () => null },
+				{ host: "127.0.0.2", port: 39_999 },
+			),
+		).resolves.toEqual({ state: "running" });
+		expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.2:39999/api/health");
+	});
+
+	it("uses the configured target for legacy PID records", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(healthy));
+		await expect(
+			observeViewerRuntime(
+				{ state: "legacy", pid: 1234 },
+				{ fetch: fetchMock, isProcessRunning: () => true },
+				{ host: "127.0.0.2", port: 39_999 },
+			),
+		).resolves.toEqual({ state: "running", pid: 1234 });
+		expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.2:39999/api/health");
+	});
+
+	it("keeps an unready viewer running and surfaces degraded readiness", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(
+				response({ service: "codemem-viewer", ready: false, database: { reachable: false } }),
+			);
+		await expect(
+			observeViewerRuntime(
+				{ state: "valid", record },
+				{ fetch: fetchMock, isProcessRunning: () => true },
+			),
+		).resolves.toEqual({ state: "running", pid: 1234, attention_code: "viewer_not_ready" });
+	});
+
+	it("reports a missing viewer as unreachable and malformed records as unknown", async () => {
+		const deps = {
+			fetch: vi.fn<typeof fetch>().mockRejectedValue(new Error("connection refused")),
+			isProcessRunning: () => null,
+		};
+		await expect(observeViewerRuntime({ state: "missing" }, deps)).resolves.toEqual({
+			state: "unreachable",
+		});
+		await expect(observeViewerRuntime({ state: "malformed" }, deps)).resolves.toMatchObject({
+			state: "unknown",
+			attention_code: "viewer_pid_malformed",
+		});
+	});
+});

--- a/packages/cli/src/viewer-runtime.ts
+++ b/packages/cli/src/viewer-runtime.ts
@@ -1,0 +1,194 @@
+export interface ViewerPidRecord {
+	pid: number;
+	host: string;
+	port: number;
+}
+
+export type ParsedViewerPidRecord =
+	| { state: "missing" }
+	| { state: "malformed" }
+	| { state: "legacy"; pid: number }
+	| { state: "valid"; record: ViewerPidRecord };
+
+export type ViewerRuntimeState = "running" | "stopped" | "unreachable" | "unknown";
+
+export interface ViewerRuntimeObservation {
+	state: ViewerRuntimeState;
+	pid?: number;
+	attention_code?:
+		| "viewer_pid_malformed"
+		| "viewer_non_loopback"
+		| "viewer_not_ready"
+		| "viewer_unexpected_response"
+		| "viewer_wrong_service";
+}
+
+export interface ViewerProbeDependencies {
+	fetch: typeof fetch;
+	isProcessRunning: (pid: number) => boolean | null;
+	timeoutMs?: number;
+}
+
+function isValidPid(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isValidPort(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 65_535;
+}
+
+export function parseViewerPidRecord(raw: string | null): ParsedViewerPidRecord {
+	if (raw == null) return { state: "missing" };
+	const trimmed = raw.trim();
+	if (!trimmed) return { state: "malformed" };
+	try {
+		const parsed = JSON.parse(trimmed) as unknown;
+		if (isValidPid(parsed)) {
+			return { state: "legacy", pid: parsed };
+		}
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return { state: "malformed" };
+		}
+		const candidate = parsed as { pid?: unknown; host?: unknown; port?: unknown };
+		if (
+			!isValidPid(candidate.pid) ||
+			typeof candidate.host !== "string" ||
+			!candidate.host.trim() ||
+			!isValidPort(candidate.port)
+		) {
+			return { state: "malformed" };
+		}
+		return {
+			state: "valid",
+			record: { pid: candidate.pid, host: candidate.host.trim(), port: candidate.port },
+		};
+	} catch {
+		if (!/^\d+$/.test(trimmed)) return { state: "malformed" };
+		const pid = Number(trimmed);
+		return isValidPid(pid) ? { state: "legacy", pid } : { state: "malformed" };
+	}
+}
+
+export function isLoopbackHost(host: string): boolean {
+	const normalized = host
+		.trim()
+		.toLowerCase()
+		.replace(/^\[(.*)\]$/, "$1");
+	const ipv4Parts = normalized.split(".");
+	const isIpv4Loopback =
+		ipv4Parts.length >= 1 &&
+		ipv4Parts.length <= 4 &&
+		ipv4Parts[0] === "127" &&
+		ipv4Parts.every((part) => /^\d+$/.test(part) && Number(part) <= 255);
+	return (
+		normalized === "localhost" ||
+		normalized === "::1" ||
+		normalized === "0:0:0:0:0:0:0:1" ||
+		isIpv4Loopback
+	);
+}
+
+export type ViewerProbeTarget = Pick<ViewerPidRecord, "host" | "port"> & { pid?: number };
+
+function viewerUrl(record: ViewerProbeTarget, pathname: string): string {
+	const host =
+		record.host.includes(":") && !record.host.startsWith("[") ? `[${record.host}]` : record.host;
+	return `http://${host}:${record.port}${pathname}`;
+}
+
+async function request(
+	deps: ViewerProbeDependencies,
+	record: ViewerProbeTarget,
+	pathname: string,
+): Promise<Response> {
+	return deps.fetch(viewerUrl(record, pathname), {
+		method: "GET",
+		signal: AbortSignal.timeout(deps.timeoutMs ?? 750),
+	});
+}
+
+export async function observeViewerRuntime(
+	parsed: ParsedViewerPidRecord,
+	deps: ViewerProbeDependencies,
+	defaultTarget: ViewerProbeTarget = { host: "127.0.0.1", port: 38_888 },
+): Promise<ViewerRuntimeObservation> {
+	if (parsed.state === "malformed") {
+		return { state: "unknown", attention_code: "viewer_pid_malformed" };
+	}
+	const record: ViewerProbeTarget =
+		parsed.state === "valid"
+			? parsed.record
+			: parsed.state === "legacy"
+				? { ...defaultTarget, pid: parsed.pid }
+				: defaultTarget;
+	if (!isLoopbackHost(record.host)) {
+		return { state: "unknown", pid: record.pid, attention_code: "viewer_non_loopback" };
+	}
+	if (record.pid && deps.isProcessRunning(record.pid) === false) {
+		return { state: "stopped", pid: record.pid };
+	}
+
+	try {
+		const health = await request(deps, record, "/api/health");
+		if (health.status === 404) {
+			const stats = await request(deps, record, "/api/stats");
+			return stats.ok
+				? record.pid
+					? { state: "running", pid: record.pid }
+					: { state: "running" }
+				: {
+						state: "unknown",
+						pid: record.pid,
+						attention_code: "viewer_unexpected_response",
+					};
+		}
+		if (!health.ok) {
+			return {
+				state: "unknown",
+				pid: record.pid,
+				attention_code: "viewer_unexpected_response",
+			};
+		}
+		let payload: unknown;
+		try {
+			payload = await health.json();
+		} catch {
+			return {
+				state: "unknown",
+				pid: record.pid,
+				attention_code: "viewer_unexpected_response",
+			};
+		}
+		if (!payload || typeof payload !== "object") {
+			return { state: "unknown", pid: record.pid, attention_code: "viewer_wrong_service" };
+		}
+		const healthPayload = payload as {
+			service?: unknown;
+			ready?: unknown;
+			database?: { reachable?: unknown };
+		};
+		if (healthPayload.service !== "codemem-viewer") {
+			return { state: "unknown", pid: record.pid, attention_code: "viewer_wrong_service" };
+		}
+		if (
+			typeof healthPayload.ready !== "boolean" ||
+			typeof healthPayload.database?.reachable !== "boolean"
+		) {
+			return {
+				state: "unknown",
+				pid: record.pid,
+				attention_code: "viewer_unexpected_response",
+			};
+		}
+		if (!healthPayload.ready || !healthPayload.database.reachable) {
+			return {
+				state: "running",
+				pid: record.pid,
+				attention_code: "viewer_not_ready",
+			};
+		}
+		return record.pid ? { state: "running", pid: record.pid } : { state: "running" };
+	} catch {
+		return { state: "unreachable", pid: record.pid };
+	}
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -158,6 +158,7 @@ export type { Database } from "./db.js";
 export {
 	assertSchemaReady,
 	connect,
+	connectReadOnly,
 	DEFAULT_DB_PATH,
 	fromJson,
 	fromJsonStrict,
@@ -538,6 +539,7 @@ export {
 	writeCodememConfigFile,
 	writeWorkspaceCodememConfigFile,
 } from "./observer-config.js";
+export * from "./operational-status.js";
 export * from "./outcome-evidence.js";
 export type { PackArtifacts } from "./pack.js";
 export {

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -207,6 +207,22 @@ describe("maintenance", { timeout: 15_000 }, () => {
 		expect(metrics.counts.retry_depth_max).toBe(3);
 	});
 
+	it("counts gave-up raw-event batches as terminal reliability failures", () => {
+		const dbPath = createDbPath("gave-up-reliability");
+		seedMaintenanceDb(dbPath);
+		const db = new Database(dbPath);
+		try {
+			db.prepare("UPDATE raw_event_flush_batches SET status = 'gave_up'").run();
+		} finally {
+			db.close();
+		}
+
+		const metrics = getReliabilityMetrics(dbPath);
+		expect(metrics.counts.errored_batches).toBe(1);
+		expect(metrics.counts.terminal_batches).toBe(1);
+		expect(metrics.rates.flush_success_rate).toBe(0);
+	});
+
 	it("backfills tags_text for memories with empty tags", () => {
 		const dbPath = createDbPath("backfill-tags");
 		const db = new Database(dbPath);

--- a/packages/core/src/maintenance/reliability.ts
+++ b/packages/core/src/maintenance/reliability.ts
@@ -44,7 +44,7 @@ export function getReliabilityMetrics(
 							started: sql<number>`COALESCE(SUM(CASE WHEN ${schema.rawEventFlushBatches.status} IN ('started', 'pending') THEN 1 ELSE 0 END), 0)`,
 							running: sql<number>`COALESCE(SUM(CASE WHEN ${schema.rawEventFlushBatches.status} IN ('running', 'claimed') THEN 1 ELSE 0 END), 0)`,
 							completed: sql<number>`COALESCE(SUM(CASE WHEN ${schema.rawEventFlushBatches.status} = 'completed' THEN 1 ELSE 0 END), 0)`,
-							errored: sql<number>`COALESCE(SUM(CASE WHEN ${schema.rawEventFlushBatches.status} IN ('error', 'failed') THEN 1 ELSE 0 END), 0)`,
+							errored: sql<number>`COALESCE(SUM(CASE WHEN ${schema.rawEventFlushBatches.status} IN ('error', 'failed', 'gave_up') THEN 1 ELSE 0 END), 0)`,
 						})
 						.from(schema.rawEventFlushBatches)
 						.where(gte(schema.rawEventFlushBatches.updated_at, cutoffIso))
@@ -54,7 +54,7 @@ export function getReliabilityMetrics(
 							started: sql<number>`COALESCE(SUM(CASE WHEN ${schema.rawEventFlushBatches.status} IN ('started', 'pending') THEN 1 ELSE 0 END), 0)`,
 							running: sql<number>`COALESCE(SUM(CASE WHEN ${schema.rawEventFlushBatches.status} IN ('running', 'claimed') THEN 1 ELSE 0 END), 0)`,
 							completed: sql<number>`COALESCE(SUM(CASE WHEN ${schema.rawEventFlushBatches.status} = 'completed' THEN 1 ELSE 0 END), 0)`,
-							errored: sql<number>`COALESCE(SUM(CASE WHEN ${schema.rawEventFlushBatches.status} IN ('error', 'failed') THEN 1 ELSE 0 END), 0)`,
+							errored: sql<number>`COALESCE(SUM(CASE WHEN ${schema.rawEventFlushBatches.status} IN ('error', 'failed', 'gave_up') THEN 1 ELSE 0 END), 0)`,
 						})
 						.from(schema.rawEventFlushBatches)
 						.get()

--- a/packages/core/src/operational-status.test.ts
+++ b/packages/core/src/operational-status.test.ts
@@ -1,0 +1,129 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { tableExists } from "./db.js";
+import { collectOperationalStatus } from "./operational-status.js";
+import { initTestSchema } from "./test-utils.js";
+
+describe("collectOperationalStatus", () => {
+	it("collects fixed aggregate operational evidence without exposing rows", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			if (tableExists(db, "memory_vectors")) db.exec("DROP TABLE memory_vectors");
+			db.prepare(
+				`INSERT INTO sync_daemon_state(id, last_error_at, last_ok_at, phase)
+				 VALUES (1, '2026-08-11T12:00:00Z', '2026-08-11T11:00:00Z', 'needs_attention')`,
+			).run();
+			db.prepare(
+				`INSERT INTO sync_peers(peer_device_id, created_at, last_error)
+				 VALUES ('peer-1', '2026-08-11T10:00:00Z', 'private peer failure')`,
+			).run();
+			db.prepare(
+				`INSERT INTO maintenance_jobs(kind, title, status, updated_at, error)
+				 VALUES ('vector_model_migration', 'Vectors', 'failed', '2026-08-11T10:00:00Z', 'private vector failure')`,
+			).run();
+			db.prepare(
+				`INSERT INTO raw_event_sessions(
+					source, stream_id, opencode_session_id, last_received_event_seq,
+					last_flushed_event_seq, updated_at
+				 ) VALUES ('opencode', 'session-1', 'session-1', 3, 1, '2026-08-11T10:00:00Z')`,
+			).run();
+			for (const eventSeq of [2, 3]) {
+				db.prepare(
+					`INSERT INTO raw_events(source, stream_id, opencode_session_id, event_seq, event_type, payload_json, created_at)
+					 VALUES ('opencode', 'session-1', 'session-1', ?, 'message', '{}', '2026-08-11T10:00:00Z')`,
+				).run(eventSeq);
+			}
+			db.prepare(
+				`INSERT INTO raw_event_flush_batches(
+					id, source, stream_id, opencode_session_id, start_event_seq, end_event_seq,
+					extractor_version, status, observer_error_code, created_at, updated_at
+				 ) VALUES (1, 'opencode', 'session-1', 'session-1', 1, 3, 'v1', 'gave_up',
+					'auth_failure', '2026-08-11T10:00:00Z', '2026-08-11T10:00:00Z')`,
+			).run();
+			db.prepare(
+				`INSERT INTO raw_event_flush_batches(
+					id, source, stream_id, opencode_session_id, start_event_seq, end_event_seq,
+					extractor_version, status, observer_error_code, created_at, updated_at
+				 ) VALUES (2, 'opencode', 'session-1', 'session-1', 4, 4, 'v1', 'failed',
+					'rate_limited', '2026-08-11T10:00:00Z', '2026-08-11T10:00:00Z')`,
+			).run();
+
+			const result = collectOperationalStatus(db);
+
+			expect(result).toEqual({
+				sync: { available: true, daemon_error: true, needs_attention: true, peer_errors: 1 },
+				maintenance: { state: "idle", running: 0, failed: 0 },
+				semantic_index: { state: "failed", vector_table_present: false },
+				raw_events: { available: true, pending: 2, failed_batches: 1 },
+				observer: { available: true, failed_batches: 1, backoff_batches: 1 },
+			});
+			expect(JSON.stringify(result)).not.toContain("private");
+			const afterRecentWindow = collectOperationalStatus(db, {
+				recentFailureCutoff: "2026-08-12T10:00:00Z",
+			});
+			expect(afterRecentWindow.raw_events.failed_batches).toBe(0);
+			expect(afterRecentWindow.observer).toEqual({
+				available: true,
+				failed_batches: 0,
+				backoff_batches: 1,
+			});
+		} finally {
+			db.close();
+		}
+	});
+
+	it("reports daemon errors when the additive phase column is absent", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			db.exec("DROP TABLE sync_daemon_state");
+			db.exec(
+				`CREATE TABLE sync_daemon_state (
+					id INTEGER PRIMARY KEY,
+					last_error TEXT,
+					last_traceback TEXT,
+					last_error_at TEXT,
+					last_ok_at TEXT
+				)`,
+			);
+			db.prepare(
+				`INSERT INTO sync_daemon_state(id, last_error_at, last_ok_at)
+				 VALUES (1, '2026-08-11T12:00:00Z', '2026-08-11T11:00:00Z')`,
+			).run();
+
+			const result = collectOperationalStatus(db, { embeddingDisabled: true });
+			expect(result.sync.daemon_error).toBe(true);
+			expect(result.sync.needs_attention).toBe(false);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("tolerates optional tables being absent", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			if (tableExists(db, "memory_vectors")) db.exec("DROP TABLE memory_vectors");
+			for (const table of [
+				"maintenance_jobs",
+				"sync_daemon_state",
+				"sync_peers",
+				"sync_attempts",
+				"raw_event_flush_batches",
+			]) {
+				db.exec(`DROP TABLE ${table}`);
+			}
+
+			expect(collectOperationalStatus(db, { embeddingDisabled: true })).toEqual({
+				sync: { available: false, daemon_error: false, needs_attention: false, peer_errors: 0 },
+				maintenance: { state: "unknown", running: 0, failed: 0 },
+				semantic_index: { state: "degraded", vector_table_present: false },
+				raw_events: { available: false, pending: 0, failed_batches: 0 },
+				observer: { available: false, failed_batches: 0, backoff_batches: 0 },
+			});
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/packages/core/src/operational-status.ts
+++ b/packages/core/src/operational-status.ts
@@ -1,0 +1,241 @@
+import { columnExists, type Database, tableExists } from "./db.js";
+import { VECTOR_MODEL_MIGRATION_JOB } from "./vector-migration.js";
+
+export type OperationalMaintenanceState = "idle" | "running" | "failed" | "unknown";
+export type OperationalSemanticState = "healthy" | "pending" | "degraded" | "failed" | "unknown";
+
+export interface OperationalStatusSnapshot {
+	sync: {
+		available: boolean;
+		daemon_error: boolean;
+		needs_attention: boolean;
+		peer_errors: number;
+	};
+	maintenance: {
+		state: OperationalMaintenanceState;
+		running: number;
+		failed: number;
+	};
+	semantic_index: {
+		state: OperationalSemanticState;
+		vector_table_present: boolean;
+	};
+	raw_events: {
+		available: boolean;
+		pending: number;
+		failed_batches: number;
+	};
+	observer: {
+		available: boolean;
+		failed_batches: number;
+		backoff_batches: number;
+	};
+}
+
+function count(row: { count?: unknown } | undefined): number {
+	const value = Number(row?.count ?? 0);
+	return Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+}
+
+function aggregateCount(
+	db: Database,
+	table: string,
+	query: string,
+	params: unknown[] = [],
+): number | null {
+	if (!tableExists(db, table)) return null;
+	try {
+		return count(db.prepare(query).get(...params) as { count?: unknown } | undefined);
+	} catch {
+		return null;
+	}
+}
+
+function collectSync(db: Database): OperationalStatusSnapshot["sync"] {
+	const daemonTablePresent = tableExists(db, "sync_daemon_state");
+	const peersTablePresent = tableExists(db, "sync_peers");
+	let daemonError = false;
+	let needsAttention = false;
+	if (daemonTablePresent) {
+		// `phase` is an additive column; guard it so an older compatible
+		// database still reports daemon errors instead of failing the whole
+		// query into the catch below.
+		const phaseExpression = columnExists(db, "sync_daemon_state", "phase")
+			? "CASE WHEN phase = 'needs_attention' THEN 1 ELSE 0 END"
+			: "0";
+		try {
+			const row = db
+				.prepare(
+					`SELECT
+						CASE WHEN last_error_at IS NOT NULL
+							AND (last_ok_at IS NULL OR last_error_at > last_ok_at) THEN 1 ELSE 0 END AS daemon_error,
+						${phaseExpression} AS needs_attention
+					 FROM sync_daemon_state WHERE id = 1`,
+				)
+				.get() as { daemon_error?: unknown; needs_attention?: unknown } | undefined;
+			daemonError = Number(row?.daemon_error ?? 0) === 1;
+			needsAttention = Number(row?.needs_attention ?? 0) === 1;
+		} catch {
+			// Optional or older table shape: leave the bounded summary unknown/empty.
+		}
+	}
+
+	return {
+		available: daemonTablePresent && peersTablePresent,
+		daemon_error: daemonError,
+		needs_attention: needsAttention,
+		peer_errors:
+			aggregateCount(
+				db,
+				"sync_peers",
+				"SELECT COUNT(*) AS count FROM sync_peers WHERE last_error IS NOT NULL AND TRIM(last_error) != ''",
+			) ?? 0,
+	};
+}
+
+function collectMaintenance(db: Database): OperationalStatusSnapshot["maintenance"] {
+	if (!tableExists(db, "maintenance_jobs")) {
+		return { state: "unknown", running: 0, failed: 0 };
+	}
+	try {
+		const row = db
+			.prepare(
+				`SELECT
+					SUM(CASE WHEN status IN ('pending', 'running') THEN 1 ELSE 0 END) AS running,
+					SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed
+				 FROM maintenance_jobs
+				 WHERE kind <> ?`,
+			)
+			.get(VECTOR_MODEL_MIGRATION_JOB) as { running?: unknown; failed?: unknown } | undefined;
+		const running = count({ count: row?.running });
+		const failed = count({ count: row?.failed });
+		return { state: failed > 0 ? "failed" : running > 0 ? "running" : "idle", running, failed };
+	} catch {
+		return { state: "unknown", running: 0, failed: 0 };
+	}
+}
+
+function collectSemanticIndex(
+	db: Database,
+	embeddingDisabled: boolean,
+): OperationalStatusSnapshot["semantic_index"] {
+	const vectorTablePresent = tableExists(db, "memory_vectors");
+	if (!tableExists(db, "maintenance_jobs")) {
+		return {
+			state: embeddingDisabled || !vectorTablePresent ? "degraded" : "unknown",
+			vector_table_present: vectorTablePresent,
+		};
+	}
+	try {
+		const row = db
+			.prepare("SELECT status FROM maintenance_jobs WHERE kind = ?")
+			.get(VECTOR_MODEL_MIGRATION_JOB) as { status?: unknown } | undefined;
+		const status = typeof row?.status === "string" ? row.status : null;
+		const state: OperationalSemanticState =
+			status === "failed"
+				? "failed"
+				: status === "pending" || status === "running"
+					? "pending"
+					: embeddingDisabled || !vectorTablePresent
+						? "degraded"
+						: "healthy";
+		return { state, vector_table_present: vectorTablePresent };
+	} catch {
+		return { state: "unknown", vector_table_present: vectorTablePresent };
+	}
+}
+
+function collectRawEvents(
+	db: Database,
+	recentFailureCutoff?: string,
+): OperationalStatusSnapshot["raw_events"] {
+	const sessionsTablePresent = tableExists(db, "raw_event_sessions");
+	const eventsTablePresent = tableExists(db, "raw_events");
+	const batchesTablePresent = tableExists(db, "raw_event_flush_batches");
+	let pending = 0;
+	if (sessionsTablePresent && eventsTablePresent) {
+		try {
+			pending = count(
+				db
+					.prepare(
+						`SELECT COALESCE(SUM(max_seq - last_flushed_event_seq), 0) AS count
+						 FROM (
+							SELECT s.last_flushed_event_seq,
+								(SELECT MAX(e.event_seq)
+								 FROM raw_events e
+								 WHERE e.source = s.source AND e.stream_id = s.stream_id) AS max_seq
+							FROM raw_event_sessions s
+						 )
+						 WHERE max_seq > last_flushed_event_seq`,
+					)
+					.get() as { count?: unknown } | undefined,
+			);
+		} catch {
+			pending = 0;
+		}
+	}
+	return {
+		available: sessionsTablePresent && eventsTablePresent && batchesTablePresent,
+		pending,
+		failed_batches:
+			aggregateCount(
+				db,
+				"raw_event_flush_batches",
+				recentFailureCutoff
+					? "SELECT COUNT(*) AS count FROM raw_event_flush_batches WHERE status = 'gave_up' AND updated_at >= ?"
+					: "SELECT COUNT(*) AS count FROM raw_event_flush_batches WHERE status = 'gave_up'",
+				recentFailureCutoff ? [recentFailureCutoff] : [],
+			) ?? 0,
+	};
+}
+
+function collectObserver(
+	db: Database,
+	recentFailureCutoff?: string,
+): OperationalStatusSnapshot["observer"] {
+	const available =
+		tableExists(db, "raw_event_flush_batches") &&
+		columnExists(db, "raw_event_flush_batches", "observer_error_code");
+	if (!available) return { available: false, failed_batches: 0, backoff_batches: 0 };
+	return {
+		available,
+		failed_batches:
+			aggregateCount(
+				db,
+				"raw_event_flush_batches",
+				recentFailureCutoff
+					? `SELECT COUNT(*) AS count FROM raw_event_flush_batches
+				 WHERE status = 'gave_up' AND updated_at >= ?
+				   AND observer_error_code IS NOT NULL
+				   AND TRIM(observer_error_code) != ''`
+					: `SELECT COUNT(*) AS count FROM raw_event_flush_batches
+				 WHERE status = 'gave_up'
+				   AND observer_error_code IS NOT NULL
+				   AND TRIM(observer_error_code) != ''`,
+				recentFailureCutoff ? [recentFailureCutoff] : [],
+			) ?? 0,
+		backoff_batches:
+			aggregateCount(
+				db,
+				"raw_event_flush_batches",
+				`SELECT COUNT(*) AS count FROM raw_event_flush_batches
+				 WHERE status IN ('error', 'failed')
+				   AND observer_error_code IS NOT NULL
+				   AND TRIM(observer_error_code) != ''`,
+			) ?? 0,
+	};
+}
+
+/** Collect bounded operational aggregates from an already-open database without writing schema. */
+export function collectOperationalStatus(
+	db: Database,
+	options: { embeddingDisabled?: boolean; recentFailureCutoff?: string } = {},
+): OperationalStatusSnapshot {
+	return {
+		sync: collectSync(db),
+		maintenance: collectMaintenance(db),
+		semantic_index: collectSemanticIndex(db, options.embeddingDisabled === true),
+		raw_events: collectRawEvents(db, options.recentFailureCutoff),
+		observer: collectObserver(db, options.recentFailureCutoff),
+	};
+}


### PR DESCRIPTION
## Description

Adds top-level `codemem status` with stable JSON and compact human output across database readiness, viewer runtime, sync, maintenance, semantic indexing, raw-event ingestion, and observer state. Collection is read-only and offline except for a bounded loopback viewer health probe with old-viewer fallback.

The implementation keeps transient observer failures as warnings, limits terminal failure impact to a 24-hour reliability window, preserves exact backlog semantics through indexed per-session lookups, rejects non-loopback probes, and leaves detailed remediation to existing subsystem commands.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated 105 focused status, runtime, reliability, and health tests. Full build and lint pass; the workspace suite reports 3,954 passing tests and 3 todo. Independent final review found no blocking, high, or medium issues.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced