### PR TITLE
fix(runtime): consolidate viewer health probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ codemem setup --opencode-only
 
 This updates your OpenCode config to install the plugin and register the MCP server. Restart OpenCode to activate.
 
-The standalone `codemem-mcp-ts` binary runs the same stdio server used by `codemem mcp`. Viewer autostart is on by default for both invocation paths; set `CODEMEM_VIEWER=0` or `CODEMEM_VIEWER_AUTO=0` to disable.
+The standalone `codemem-mcp-ts` binary runs the same stdio server used by `codemem mcp`. Viewer autostart is on by default for both invocation paths; set `CODEMEM_VIEWER=0` or `CODEMEM_VIEWER_AUTO=0` to disable. MCP autostart and the `serve start`/`stop`/`restart` lifecycle identify a running viewer through `GET /api/health` (service discriminator `codemem-viewer`), with one bounded `GET /api/stats` compatibility probe when an older viewer returns `404`.
 
 For local HTTP transport testing, run `codemem mcp http`. It listens on `127.0.0.1:38889` by default and exposes Streamable HTTP at `POST /mcp`; use `--host`, `--port`, and `--db-path` to override those values. OAuth discovery metadata and Dynamic Client Registration are available at `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource/mcp`, and `/register`; set `--public-url` or `CODEMEM_MCP_HTTP_PUBLIC_URL` to the externally reachable `/mcp` URL so advertised endpoints use the public origin. `/authorize` redirects through a configured upstream OIDC provider before issuing public-client authorization codes, `/token` supports PKCE S256 exchange, and `/oauth/revoke` revokes access tokens. When a public URL or OIDC configuration is present, `POST /mcp` requires a valid bearer token; local-only HTTP mode remains unauthenticated for development and still applies loopback Host/Origin checks. Non-loopback binds are rejected unless you explicitly pass `--unsafe-public` or set `CODEMEM_MCP_HTTP_UNSAFE_PUBLIC=1`.
 
@@ -242,6 +242,7 @@ Common overrides:
 Viewer note:
 
 - The plugin manages one explicit viewer target per runtime. If you run multiple viewers, give each one its own DB/runtime folder instead of sharing `viewer.pid` state next to the same SQLite file.
+- The OpenCode plugin monitors viewer liveness through `GET /api/health`. When an older viewer returns `404`, it makes one compatibility probe to the legacy raw-event status endpoint; raw-event ingest preflight remains separate.
 
 The viewer includes a grouped Settings modal (`Connection`, `Processing`, `Device Sync`) with shell-agnostic labels and an advanced-controls toggle for technical fields.
 - Settings show effective values (configured or default) and only persist changed fields on save.

--- a/docs/plans/2026-08-11-cli-operational-status-and-command-tree-consolidation-design.md
+++ b/docs/plans/2026-08-11-cli-operational-status-and-command-tree-consolidation-design.md
@@ -30,9 +30,9 @@ confirmed gaps:
 - Completion omits `maintenance`; completion and registered-command parity is
   not tested as an assembled tree.
 - README and user-guide material still recommends `sync start`; coordinator
-  discovery examples omit required `--effect-id` arguments for membership
-  changes and retain legacy coordinator host/port forms despite the top-level
-  `coordinator` command.
+  discovery and anchor-peer deployment examples omit required `--effect-id`
+  arguments for membership changes and retain legacy coordinator host/port
+  forms despite the top-level `coordinator` command.
 - `config workspace` overlaps `sync enable`/`disable`/`connect`, memory CRUD and
   evaluation-oriented commands share one group, and JSON support is uneven
   across neighboring sync and database mutation commands.
@@ -120,6 +120,11 @@ Initial state values are:
 - `semantic_index.state`: `healthy | pending | degraded | failed | unknown`
 - `raw_events.state`: `healthy | backlogged | failing | unknown`
 - `observer.state`: `healthy | idle | backoff | failed | unconfigured | unknown`
+
+For this offline roll-up, observer `backoff` means the local database contains
+recent retryable observer batches. It does not claim to expose the viewer's
+in-memory authentication-backoff timer from `/api/observer-status`; that remains
+a detailed viewer diagnostic outside this command's bounded `/api/health` probe.
 
 Consumers must handle future state values as `unknown`/degraded. New values are
 additive; existing meanings remain stable. `attention` contains at most 20

--- a/docs/plans/2026-08-11-cli-operational-status-and-command-tree-consolidation-plan.md
+++ b/docs/plans/2026-08-11-cli-operational-status-and-command-tree-consolidation-plan.md
@@ -66,8 +66,11 @@ Each PR is independently useful and keeps existing JSON contracts additive.
 - **Behavioral work:** Use shared `--db-path`, `--config`, and `--json` options.
   Collect local database readiness, runtime/viewer, sync, maintenance,
   semantic-index, raw-events, and observer summaries plus bounded attention
-  items. Emit stable JSON/error objects and `0` for collected degraded status,
-  `2` for usage, `1` for collection failure. Allow one bounded loopback
+  items. Derive observer `backoff` only from recent retryable batches persisted
+  in the local database; do not call `/api/observer-status` or claim the viewer's
+  in-memory auth-backoff timer.
+  Emit stable JSON/error objects and `0` for collected degraded status, `2` for
+  usage, `1` for collection failure. Allow one bounded loopback
   `/api/health` probe plus a `/api/stats` compatibility fallback only when an
   older viewer returns 404; otherwise use local fallback. Do not call
   registries, the coordinator, non-loopback endpoints, or update discovery.
@@ -119,7 +122,8 @@ Each PR is independently useful and keeps existing JSON contracts additive.
 - **Likely files:** `packages/cli/src/index.ts`, CLI tree/completion tests,
   `README.md`, `docs/user-guide.md`, `docs/coordinator-discovery.md`,
   `docs/coordinator-deployment.md`, `docs/coordinator-e2e-runbook.md`,
-  `docs/cloudflare-coordinator-deployment.md`, and affected command modules.
+  `docs/cloudflare-coordinator-deployment.md`, `docs/anchor-peer-deployment.md`,
+  and affected command modules.
 - **Behavioral work:** Hide the already-warned `sync coordinator` compatibility
   path. Add warnings to visible `export-memories`/`import-memories`, keep them
   visible and in completion for their first warned release, and record their

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -182,7 +182,7 @@ set -lx CODEMEM_VIEWER_HOST 127.0.0.1
 set -lx CODEMEM_VIEWER_PORT 38892
 ```
 
-The plugin now passes that explicit host/port through when it auto-starts, health-checks, stops, or restarts the viewer. Do not run multiple viewers against the same DB/runtime folder unless they intentionally share the same bind target; otherwise `viewer.pid` ownership becomes ambiguous.
+The plugin now passes that explicit host/port through when it auto-starts, health-checks, stops, or restarts the viewer. Its liveness monitor requires a successful `GET /api/health` JSON response identifying `service: "codemem-viewer"`; `ready: false` still means the viewer process is live. For compatibility, only a `404` from the health route triggers one bounded probe of the legacy raw-event status endpoint. Raw-event ingest availability keeps its separate preflight behavior. Do not run multiple viewers against the same DB/runtime folder unless they intentionally share the same bind target; otherwise `viewer.pid` ownership becomes ambiguous.
 
 If compatibility toasts appear after restart, follow the runner-specific guidance in Compatibility guidance behavior below.
 

--- a/packages/cli/.opencode/tests/plugin-viewer-health.test.js
+++ b/packages/cli/.opencode/tests/plugin-viewer-health.test.js
@@ -1,0 +1,213 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { __testUtils } from "../plugins/codemem.js";
+
+const HEALTH_URL = "http://127.0.0.1:38888/api/health";
+const LEGACY_URL = "http://127.0.0.1:38888/api/raw-events/status?limit=1";
+
+const response = ({ status = 200, body = { service: "codemem-viewer", ready: true } } = {}) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: vi.fn().mockResolvedValue(body),
+});
+
+const createMonitor = ({ fetchFn, restartViewer = vi.fn().mockResolvedValue({ exitCode: 0 }), now } = {}) => {
+  const logLine = vi.fn().mockResolvedValue(undefined);
+  const timeoutSignal = vi.fn(() => ({ bounded: true }));
+  const monitor = __testUtils.createViewerHealthMonitor({
+    viewerHealthUrl: HEALTH_URL,
+    legacyStatusUrl: LEGACY_URL,
+    isActive: () => true,
+    restartViewer,
+    logLine,
+    fetchFn,
+    now,
+    timeoutSignal,
+  });
+  return { logLine, monitor, restartViewer, timeoutSignal };
+};
+
+describe("OpenCode viewer health monitor", () => {
+  test.each([true, false])("treats ready=%s codemem viewer responses as live", async (ready) => {
+    const fetchFn = vi.fn().mockResolvedValue(response({ body: { service: "codemem-viewer", ready } }));
+    const { monitor, restartViewer, timeoutSignal } = createMonitor({ fetchFn });
+
+    await monitor.check();
+
+    expect(monitor.state().consecutiveFailures).toBe(0);
+    expect(restartViewer).not.toHaveBeenCalled();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(timeoutSignal).toHaveBeenCalledWith(5_000);
+  });
+
+  test("rejects a successful response from the wrong service without fallback", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({ body: { service: "other-service" } }));
+    const { monitor } = createMonitor({ fetchFn });
+
+    await monitor.check();
+
+    expect(monitor.state().consecutiveFailures).toBe(1);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects malformed health JSON without fallback", async () => {
+    const malformed = response();
+    malformed.json.mockRejectedValue(new SyntaxError("bad JSON"));
+    const fetchFn = vi.fn().mockResolvedValue(malformed);
+    const { monitor } = createMonitor({ fetchFn });
+
+    await monitor.check();
+
+    expect(monitor.state().consecutiveFailures).toBe(1);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back once to raw-event status only when health returns 404", async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(response({ status: 404 }))
+      .mockResolvedValueOnce(
+        response({ body: { totals: { pending: 0 }, ingest: { available: true } } }),
+      );
+    const { monitor, timeoutSignal } = createMonitor({ fetchFn });
+
+    await monitor.check();
+
+    expect(monitor.state().consecutiveFailures).toBe(0);
+    expect(fetchFn).toHaveBeenNthCalledWith(1, HEALTH_URL, expect.objectContaining({ method: "GET" }));
+    expect(fetchFn).toHaveBeenNthCalledWith(2, LEGACY_URL, expect.objectContaining({ method: "GET" }));
+    expect(timeoutSignal).toHaveBeenNthCalledWith(1, 5_000);
+    expect(timeoutSignal).toHaveBeenNthCalledWith(2, 5_000);
+  });
+
+  test("rejects a 404 fallback response that does not look like the viewer", async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(response({ status: 404 }))
+      .mockResolvedValueOnce(response({ body: { unrelated: true } }));
+    const { monitor } = createMonitor({ fetchFn });
+
+    await monitor.check();
+
+    expect(monitor.state().consecutiveFailures).toBe(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([
+    ["server error", () => Promise.resolve(response({ status: 500 }))],
+    ["network failure", () => Promise.reject(new Error("connection refused"))],
+    ["timeout", () => Promise.reject(new DOMException("timed out", "TimeoutError"))],
+  ])("does not fall back after %s", async (_label, fetchResult) => {
+    const fetchFn = vi.fn(fetchResult);
+    const { monitor } = createMonitor({ fetchFn });
+
+    await monitor.check();
+
+    expect(monitor.state().consecutiveFailures).toBe(1);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("restarts after three failures and enforces the five-minute cooldown", async () => {
+    let nowMs = 5 * 60_000;
+    const fetchFn = vi.fn().mockResolvedValue(response({ status: 500 }));
+    const restartViewer = vi.fn().mockResolvedValue({ exitCode: 1 });
+    const { monitor } = createMonitor({ fetchFn, restartViewer, now: () => nowMs });
+
+    await monitor.check();
+    await monitor.check();
+    await monitor.check();
+    expect(restartViewer).toHaveBeenCalledTimes(1);
+
+    nowMs += 60_000;
+    await monitor.check();
+    expect(restartViewer).toHaveBeenCalledTimes(1);
+
+    nowMs += 4 * 60_000;
+    await monitor.check();
+    expect(restartViewer).toHaveBeenCalledTimes(2);
+  });
+
+  test("resets failures after a successful restart and logs recovery", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({ status: 500 }));
+    const restartViewer = vi.fn().mockResolvedValue({ exitCode: 0 });
+    const { logLine, monitor } = createMonitor({ fetchFn, now: () => 10 * 60_000, restartViewer });
+
+    await monitor.check();
+    await monitor.check();
+    await monitor.check();
+
+    expect(restartViewer).toHaveBeenCalledTimes(1);
+    expect(monitor.state().consecutiveFailures).toBe(0);
+    expect(logLine).toHaveBeenCalledWith(
+      "viewer.health restart succeeded (exit=0)"
+    );
+
+    fetchFn.mockResolvedValue(response());
+    await monitor.check();
+    expect(monitor.state().consecutiveFailures).toBe(0);
+  });
+
+  test("logs recovery after transient failures clear on their own", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(response({ status: 500 }))
+      .mockResolvedValueOnce(response());
+    const { logLine, monitor } = createMonitor({ fetchFn });
+
+    await monitor.check();
+    await monitor.check();
+
+    expect(monitor.state().consecutiveFailures).toBe(0);
+    expect(logLine).toHaveBeenCalledWith("viewer.health recovered after 1 failure(s)");
+  });
+
+  test("does not restart when stopped while a probe was in flight", async () => {
+    const activeValues = [true, true, true, false];
+    const isActive = vi.fn(() => activeValues.shift() ?? false);
+    const fetchFn = vi.fn().mockResolvedValue(response({ status: 500 }));
+    const restartViewer = vi.fn();
+    const logLine = vi.fn().mockResolvedValue(undefined);
+    const monitor = __testUtils.createViewerHealthMonitor({
+      viewerHealthUrl: HEALTH_URL,
+      legacyStatusUrl: LEGACY_URL,
+      isActive,
+      restartViewer,
+      logLine,
+      fetchFn,
+      now: () => 10 * 60_000,
+      timeoutSignal: vi.fn(() => ({ bounded: true })),
+    });
+
+    await monitor.check();
+    await monitor.check();
+    await monitor.check();
+
+    expect(restartViewer).not.toHaveBeenCalled();
+  });
+
+  test("unrefs its interval and clears monitor state when stopped", () => {
+    const intervalHandle = { unref: vi.fn() };
+    const setIntervalFn = vi.fn(() => intervalHandle);
+    const clearIntervalFn = vi.fn();
+    const monitor = __testUtils.createViewerHealthMonitor({
+      viewerHealthUrl: HEALTH_URL,
+      legacyStatusUrl: LEGACY_URL,
+      isActive: () => true,
+      restartViewer: vi.fn(),
+      logLine: vi.fn(),
+      fetchFn: vi.fn(),
+      setIntervalFn,
+      clearIntervalFn,
+    });
+
+    monitor.start();
+    monitor.stop();
+
+    expect(setIntervalFn).toHaveBeenCalledWith(expect.any(Function), 60_000);
+    expect(intervalHandle.unref).toHaveBeenCalledOnce();
+    expect(clearIntervalFn).toHaveBeenCalledWith(intervalHandle);
+    expect(monitor.state()).toEqual({
+      consecutiveFailures: 0,
+      lastRestartAttempt: 0,
+      running: false,
+    });
+  });
+});

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -16,6 +16,7 @@ import {
 	maintenanceWorkerPidFilePath,
 	pickViewerPidCandidate,
 	prepareViewerDatabase,
+	respondsLikeCodememViewer,
 	runServeCoordinatorMaintenance,
 	sqliteVecFailureDiagnostics,
 	terminateTrustedMaintenanceWorker,
@@ -307,9 +308,55 @@ describe("serve command option resolution", () => {
 
 	it("extracts viewer_pid from stats payload", () => {
 		expect(extractViewerPid({ viewer_pid: 12345 })).toBe(12345);
+		expect(extractViewerPid({ pid: 54321 })).toBeNull();
 		expect(extractViewerPid({ viewer_pid: -1 })).toBeNull();
 		expect(extractViewerPid({ viewer_pid: "12345" })).toBeNull();
 		expect(extractViewerPid({})).toBeNull();
+	});
+
+	it("uses degraded health for liveness without treating health pid as a stop candidate", async () => {
+		const timeoutSpy = vi
+			.spyOn(AbortSignal, "timeout")
+			.mockReturnValue(new AbortController().signal);
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					service: "codemem-viewer",
+					pid: 54321,
+					ready: false,
+					database: { reachable: false },
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		await expect(
+			respondsLikeCodememViewer({ pid: 12345, host: "127.0.0.1", port: 38_888 }, fetchMock),
+		).resolves.toBe(true);
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.1:38888/api/health");
+		expect(timeoutSpy).toHaveBeenCalledWith(1000);
+		expect(extractViewerPid({ pid: 54321 })).toBeNull();
+	});
+
+	it("accepts an old viewer through the 404 stats fallback", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(new Response(null, { status: 404 }))
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ viewer_pid: 12345 }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+			);
+
+		await expect(
+			respondsLikeCodememViewer({ pid: 12345, host: "127.0.0.1", port: 38_888 }, fetchMock),
+		).resolves.toBe(true);
+		expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+			"http://127.0.0.1:38888/api/health",
+			"http://127.0.0.1:38888/api/stats",
+		]);
 	});
 
 	it("selects pid candidate from stats and listener with mismatch protection", () => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -25,17 +25,18 @@ import {
 	emitDeprecationWarning,
 } from "../shared-options.js";
 import {
+	isLoopbackHost,
+	parseViewerPidRecord,
+	probeCodememViewerLiveness,
+	type ViewerPidRecord,
+	viewerUrl,
+} from "../viewer-runtime.js";
+import {
 	type LegacyServeOptions,
 	type ResolvedServeInvocation,
 	resolveServeInvocation,
 	type ServeAction,
 } from "./serve-invocation.js";
-
-interface ViewerPidRecord {
-	pid: number;
-	host: string;
-	port: number;
-}
 
 export function extractViewerPid(payload: unknown): number | null {
 	if (!payload || typeof payload !== "object") return null;
@@ -56,13 +57,7 @@ export function isLocalHost(host: string): boolean {
 }
 
 export function isLoopbackOnlyHost(host: string): boolean {
-	const normalized = host.trim().toLowerCase();
-	return (
-		normalized === "localhost" ||
-		/^127(?:\.\d{1,3}){0,3}$/.test(normalized) ||
-		normalized === "::1" ||
-		normalized === "0:0:0:0:0:0:0:1"
-	);
+	return isLoopbackHost(host);
 }
 
 function warnIfViewerExposed(host: string, port: number): void {
@@ -194,22 +189,11 @@ export function commandHasExactDbPath(command: string, dbPath: string): boolean 
 function readViewerPidRecord(dbPath: string): ViewerPidRecord | null {
 	const pidPath = pidFilePath(dbPath);
 	if (!existsSync(pidPath)) return null;
-	const raw = readFileSync(pidPath, "utf-8").trim();
-	try {
-		const parsed = JSON.parse(raw) as Partial<ViewerPidRecord>;
-		if (
-			typeof parsed.pid === "number" &&
-			typeof parsed.host === "string" &&
-			typeof parsed.port === "number"
-		) {
-			return { pid: parsed.pid, host: parsed.host, port: parsed.port };
-		}
-	} catch {
-		const pid = Number.parseInt(raw, 10);
-		if (Number.isFinite(pid) && pid > 0) {
-			return { pid, host: "127.0.0.1", port: 38888 };
-		}
-	}
+	// Shared strict parser keeps `serve` and `codemem status` agreeing on
+	// what counts as a valid viewer PID record.
+	const parsed = parseViewerPidRecord(readFileSync(pidPath, "utf-8"));
+	if (parsed.state === "valid") return parsed.record;
+	if (parsed.state === "legacy") return { pid: parsed.pid, host: "127.0.0.1", port: 38888 };
 	return null;
 }
 function normalizeViewerHost(host: string): string {
@@ -250,28 +234,22 @@ function isProcessRunning(pid: number): boolean {
 	}
 }
 
-async function respondsLikeCodememViewer(record: ViewerPidRecord): Promise<boolean> {
-	try {
-		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), 1000);
-		const res = await fetch(`http://${record.host}:${record.port}/api/stats`, {
-			signal: controller.signal,
-		});
-		clearTimeout(timer);
-		return res.ok;
-	} catch {
-		return false;
-	}
+export async function respondsLikeCodememViewer(
+	record: ViewerPidRecord,
+	fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
+	const result = await probeCodememViewerLiveness(record, {
+		fetch: fetchImpl,
+		timeoutMs: 1000,
+	});
+	return result.state === "live";
 }
 
 async function lookupViewerPidFromStats(host: string, port: number): Promise<number | null> {
 	try {
-		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), 1000);
-		const res = await fetch(`http://${host}:${port}/api/stats`, {
-			signal: controller.signal,
+		const res = await fetch(viewerUrl({ host, port }, "/api/stats"), {
+			signal: AbortSignal.timeout(1000),
 		});
-		clearTimeout(timer);
 		if (!res.ok) return null;
 		const payload = await res.json();
 		return extractViewerPid(payload);

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -120,6 +120,22 @@ describe("status command", () => {
 		});
 	});
 
+	it("suppresses newer-schema compatibility warnings in JSON mode", async () => {
+		const close = vi.fn();
+		const { command, stdout, stderr } = harness({
+			connectReadOnly: (_path, options) => {
+				options?.warn?.("newer schema compatibility warning");
+				return { close } as unknown as Database;
+			},
+		});
+
+		await command.parseAsync(["--json"], { from: "user" });
+
+		expect(stdout).toHaveLength(1);
+		expect(stderr).toEqual([]);
+		expect(close).toHaveBeenCalledOnce();
+	});
+
 	it("keeps warnings successful and exits zero for degraded reports", async () => {
 		const snapshot = structuredClone(healthySnapshot);
 		snapshot.sync.peer_errors = 2;

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -353,7 +353,9 @@ export async function collectStatusReport(
 	if (deps.exists(dbPath)) {
 		let db: ReturnType<typeof connectReadOnly> | null = null;
 		try {
-			db = deps.connectReadOnly(dbPath);
+			db = deps.connectReadOnly(dbPath, {
+				warn: opts.json ? () => {} : deps.writeStderr,
+			});
 		} catch {
 			databaseState = "unavailable";
 		}

--- a/packages/cli/src/viewer-runtime.test.ts
+++ b/packages/cli/src/viewer-runtime.test.ts
@@ -3,6 +3,7 @@ import {
 	isLoopbackHost,
 	observeViewerRuntime,
 	parseViewerPidRecord,
+	probeCodememViewerLiveness,
 	type ViewerPidRecord,
 } from "./viewer-runtime.js";
 
@@ -37,6 +38,112 @@ describe("viewer PID records", () => {
 		expect(isLoopbackHost("127.0.0.2")).toBe(true);
 		expect(isLoopbackHost("[::1]")).toBe(true);
 		expect(isLoopbackHost("example.test")).toBe(false);
+	});
+});
+
+describe("probeCodememViewerLiveness", () => {
+	it("requires HTTP success and the codemem viewer discriminator", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(healthy));
+
+		await expect(probeCodememViewerLiveness(record, { fetch: fetchMock })).resolves.toEqual({
+			state: "live",
+			degraded: false,
+		});
+	});
+
+	it("treats unready or database-unreachable health as degraded liveness", async () => {
+		for (const payload of [
+			{ ...healthy, ready: false },
+			{ ...healthy, database: { reachable: false } },
+		]) {
+			const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(payload));
+			await expect(probeCodememViewerLiveness(record, { fetch: fetchMock })).resolves.toEqual({
+				state: "live",
+				degraded: true,
+			});
+		}
+	});
+
+	it("falls back to stats exactly once only when health returns 404", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(response(null, { status: 404 }))
+			.mockResolvedValueOnce(response({ viewer_pid: 1234 }));
+
+		await expect(probeCodememViewerLiveness(record, { fetch: fetchMock })).resolves.toEqual({
+			state: "live",
+			degraded: false,
+		});
+		expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+			"http://127.0.0.1:38888/api/health",
+			"http://127.0.0.1:38888/api/stats",
+		]);
+		expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+		expect(fetchMock.mock.calls[1]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+		// The fallback gets its own timeout budget rather than the residual
+		// budget of the health request.
+		expect(fetchMock.mock.calls[1]?.[1]?.signal).not.toBe(fetchMock.mock.calls[0]?.[1]?.signal);
+	});
+
+	it.each([
+		["a server error", response(null, { status: 500 })],
+		["a missing viewer_pid", response({ database: {}, usage: {} })],
+		["an invalid viewer_pid", response({ viewer_pid: "1234" })],
+		["malformed JSON", new Response("{", { status: 200 })],
+	])("reports unavailable when the legacy fallback returns %s", async (_case, statsResponse) => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(response(null, { status: 404 }))
+			.mockResolvedValueOnce(statsResponse);
+
+		await expect(probeCodememViewerLiveness(record, { fetch: fetchMock })).resolves.toEqual({
+			state: "unavailable",
+			reason: "unexpected_response",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("treats absent readiness fields as degraded liveness, not unavailability", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(response({ service: "codemem-viewer" }));
+
+		await expect(probeCodememViewerLiveness(record, { fetch: fetchMock })).resolves.toEqual({
+			state: "live",
+			degraded: true,
+		});
+	});
+
+	it("does not fall back for wrong-service, malformed, 500, or network failures", async () => {
+		const cases: Array<() => Promise<Response>> = [
+			async () => response({ ...healthy, service: "other-service" }),
+			async () => new Response("{", { status: 200 }),
+			async () => response(null, { status: 500 }),
+			async () => {
+				throw new Error("connection refused");
+			},
+		];
+
+		for (const result of cases) {
+			const fetchMock = vi.fn<typeof fetch>().mockImplementation(result);
+			const observed = await probeCodememViewerLiveness(record, { fetch: fetchMock });
+			expect(observed.state).toBe("unavailable");
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+		}
+	});
+
+	it("honors the caller-provided timeout", async () => {
+		const timeoutSignal = new AbortController().signal;
+		const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+		try {
+			const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(healthy));
+			await probeCodememViewerLiveness(record, { fetch: fetchMock, timeoutMs: 25 });
+
+			expect(timeoutSpy).toHaveBeenCalledWith(25);
+			expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(timeoutSignal);
+		} finally {
+			timeoutSpy.mockRestore();
+		}
 	});
 });
 

--- a/packages/cli/src/viewer-runtime.ts
+++ b/packages/cli/src/viewer-runtime.ts
@@ -23,11 +23,21 @@ export interface ViewerRuntimeObservation {
 		| "viewer_wrong_service";
 }
 
-export interface ViewerProbeDependencies {
+export interface ViewerLivenessProbeDependencies {
 	fetch: typeof fetch;
-	isProcessRunning: (pid: number) => boolean | null;
 	timeoutMs?: number;
 }
+
+export interface ViewerProbeDependencies extends ViewerLivenessProbeDependencies {
+	isProcessRunning: (pid: number) => boolean | null;
+}
+
+export type ViewerLivenessProbeResult =
+	| { state: "live"; degraded: boolean }
+	| {
+			state: "unavailable";
+			reason: "unexpected_response" | "wrong_service" | "unreachable";
+	  };
 
 function isValidPid(value: unknown): value is number {
 	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
@@ -90,21 +100,80 @@ export function isLoopbackHost(host: string): boolean {
 
 export type ViewerProbeTarget = Pick<ViewerPidRecord, "host" | "port"> & { pid?: number };
 
-function viewerUrl(record: ViewerProbeTarget, pathname: string): string {
+export function viewerUrl(record: ViewerProbeTarget, pathname: string): string {
 	const host =
 		record.host.includes(":") && !record.host.startsWith("[") ? `[${record.host}]` : record.host;
 	return `http://${host}:${record.port}${pathname}`;
 }
 
 async function request(
-	deps: ViewerProbeDependencies,
+	deps: ViewerLivenessProbeDependencies,
 	record: ViewerProbeTarget,
 	pathname: string,
 ): Promise<Response> {
+	// Each request gets a fresh timeout budget so the 404 compatibility
+	// fallback is not starved by time already spent on the health request.
+	// MCP and OpenCode plugin probes use the same per-request semantics.
 	return deps.fetch(viewerUrl(record, pathname), {
 		method: "GET",
 		signal: AbortSignal.timeout(deps.timeoutMs ?? 750),
 	});
+}
+
+async function isCodememStatsResponse(response: Response): Promise<boolean> {
+	if (!response.ok) return false;
+	try {
+		const payload: unknown = await response.json();
+		if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+		const viewerPid = (payload as { viewer_pid?: unknown }).viewer_pid;
+		return typeof viewerPid === "number" && Number.isSafeInteger(viewerPid) && viewerPid > 0;
+	} catch {
+		return false;
+	}
+}
+
+export async function probeCodememViewerLiveness(
+	record: ViewerProbeTarget,
+	deps: ViewerLivenessProbeDependencies,
+): Promise<ViewerLivenessProbeResult> {
+	try {
+		const health = await request(deps, record, "/api/health");
+		if (health.status === 404) {
+			const stats = await request(deps, record, "/api/stats");
+			return (await isCodememStatsResponse(stats))
+				? { state: "live", degraded: false }
+				: { state: "unavailable", reason: "unexpected_response" };
+		}
+		if (!health.ok) return { state: "unavailable", reason: "unexpected_response" };
+
+		let payload: unknown;
+		try {
+			payload = await health.json();
+		} catch {
+			return { state: "unavailable", reason: "unexpected_response" };
+		}
+		if (!payload || typeof payload !== "object") {
+			return { state: "unavailable", reason: "unexpected_response" };
+		}
+		const healthPayload = payload as {
+			service?: unknown;
+			ready?: unknown;
+			database?: { reachable?: unknown };
+		};
+		if (healthPayload.service !== "codemem-viewer") {
+			return { state: "unavailable", reason: "wrong_service" };
+		}
+		// Liveness is HTTP success plus the service discriminator; `ready` and
+		// `database.reachable` are readiness only. Absent or non-boolean
+		// readiness fields degrade the observation instead of denying
+		// liveness so the health contract stays additive.
+		return {
+			state: "live",
+			degraded: healthPayload.ready !== true || healthPayload.database?.reachable !== true,
+		};
+	} catch {
+		return { state: "unavailable", reason: "unreachable" };
+	}
 }
 
 export async function observeViewerRuntime(
@@ -128,67 +197,19 @@ export async function observeViewerRuntime(
 		return { state: "stopped", pid: record.pid };
 	}
 
-	try {
-		const health = await request(deps, record, "/api/health");
-		if (health.status === 404) {
-			const stats = await request(deps, record, "/api/stats");
-			return stats.ok
-				? record.pid
-					? { state: "running", pid: record.pid }
-					: { state: "running" }
-				: {
-						state: "unknown",
-						pid: record.pid,
-						attention_code: "viewer_unexpected_response",
-					};
-		}
-		if (!health.ok) {
-			return {
-				state: "unknown",
-				pid: record.pid,
-				attention_code: "viewer_unexpected_response",
-			};
-		}
-		let payload: unknown;
-		try {
-			payload = await health.json();
-		} catch {
-			return {
-				state: "unknown",
-				pid: record.pid,
-				attention_code: "viewer_unexpected_response",
-			};
-		}
-		if (!payload || typeof payload !== "object") {
-			return { state: "unknown", pid: record.pid, attention_code: "viewer_wrong_service" };
-		}
-		const healthPayload = payload as {
-			service?: unknown;
-			ready?: unknown;
-			database?: { reachable?: unknown };
-		};
-		if (healthPayload.service !== "codemem-viewer") {
-			return { state: "unknown", pid: record.pid, attention_code: "viewer_wrong_service" };
-		}
-		if (
-			typeof healthPayload.ready !== "boolean" ||
-			typeof healthPayload.database?.reachable !== "boolean"
-		) {
-			return {
-				state: "unknown",
-				pid: record.pid,
-				attention_code: "viewer_unexpected_response",
-			};
-		}
-		if (!healthPayload.ready || !healthPayload.database.reachable) {
-			return {
-				state: "running",
-				pid: record.pid,
-				attention_code: "viewer_not_ready",
-			};
-		}
-		return record.pid ? { state: "running", pid: record.pid } : { state: "running" };
-	} catch {
-		return { state: "unreachable", pid: record.pid };
+	const probe = await probeCodememViewerLiveness(record, deps);
+	if (probe.state === "live") {
+		return probe.degraded
+			? { state: "running", pid: record.pid, attention_code: "viewer_not_ready" }
+			: record.pid
+				? { state: "running", pid: record.pid }
+				: { state: "running" };
 	}
+	if (probe.reason === "unreachable") return { state: "unreachable", pid: record.pid };
+	return {
+		state: "unknown",
+		pid: record.pid,
+		attention_code:
+			probe.reason === "wrong_service" ? "viewer_wrong_service" : "viewer_unexpected_response",
+	};
 }

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -2,10 +2,11 @@ import { existsSync, mkdtempSync, readdirSync, rmSync, utimesSync, writeFileSync
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import BetterSqlite3 from "better-sqlite3";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Database } from "./db.js";
 import {
 	assertSchemaReady,
+	assertSchemaReadyReadOnly,
 	backupOnFirstAccess,
 	columnExists,
 	connect,
@@ -431,6 +432,15 @@ describe("assertSchemaReady", () => {
 	it("warns but continues for a newer schema version", () => {
 		db.pragma(`user_version = ${SCHEMA_VERSION + 1}`);
 		expect(() => assertSchemaReady(db)).not.toThrow();
+	});
+
+	it("routes newer read-only schema warnings through the caller-provided sink", () => {
+		const warn = vi.fn();
+		db.pragma(`user_version = ${SCHEMA_VERSION + 1}`);
+
+		expect(() => assertSchemaReadyReadOnly(db, warn)).not.toThrow();
+		expect(warn).toHaveBeenCalledOnce();
+		expect(warn.mock.calls[0]?.[0]).toContain("newer than this TS runtime");
 	});
 
 	it("throws when required tables are missing", () => {

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -251,7 +251,14 @@ export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
  * Read-tuning pragmas are still applied because they are per-connection and do
  * not write to the file. Schema readiness is validated read-only.
  */
-export function connectReadOnly(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
+export interface ReadOnlyConnectionOptions {
+	warn?: (message: string) => void;
+}
+
+export function connectReadOnly(
+	dbPath: string = DEFAULT_DB_PATH,
+	options: ReadOnlyConnectionOptions = {},
+): DatabaseType {
 	const db = new Database(dbPath, { readonly: true, fileMustExist: true });
 	try {
 		db.pragma("foreign_keys = ON");
@@ -260,7 +267,7 @@ export function connectReadOnly(dbPath: string = DEFAULT_DB_PATH): DatabaseType 
 		db.pragma("cache_size = -65536");
 		db.pragma("mmap_size = 1073741824");
 		db.pragma("temp_store = MEMORY");
-		assertSchemaReadyReadOnly(db);
+		assertSchemaReadyReadOnly(db, options.warn);
 		return db;
 	} catch (error) {
 		db.close();
@@ -272,7 +279,10 @@ export function connectReadOnly(dbPath: string = DEFAULT_DB_PATH): DatabaseType 
  * Validate schema readiness without any writes (no bootstrap, no migration).
  * Mirrors {@link assertSchemaReady} but is safe on read-only connections.
  */
-export function assertSchemaReadyReadOnly(db: DatabaseType): void {
+export function assertSchemaReadyReadOnly(
+	db: DatabaseType,
+	warn: (message: string) => void = console.warn,
+): void {
 	const version = getSchemaVersion(db);
 	if (version === 0) {
 		throw new Error(
@@ -286,7 +296,7 @@ export function assertSchemaReadyReadOnly(db: DatabaseType): void {
 		);
 	}
 	if (version > SCHEMA_VERSION) {
-		console.warn(
+		warn(
 			`Database schema version ${version} is newer than this TS runtime (${SCHEMA_VERSION}). ` +
 				"Running in read-only compatibility mode.",
 		);

--- a/packages/mcp-server/src/stdio-viewer.test.ts
+++ b/packages/mcp-server/src/stdio-viewer.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	ensureViewer,
+	isViewerHealthy,
+	type SpawnViewerProcess,
+	type ViewerChildProcess,
+} from "./stdio-viewer.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function createFetchMock(...responses: Array<Response | Error>): typeof fetch {
+	const fetchMock = vi.fn<typeof fetch>();
+	for (const response of responses) {
+		if (response instanceof Response) fetchMock.mockResolvedValueOnce(response);
+		else fetchMock.mockRejectedValueOnce(response);
+	}
+	return fetchMock;
+}
+
+function createSpawnMock(options: { throws?: boolean } = {}) {
+	const child: ViewerChildProcess = {
+		on: vi.fn(),
+		unref: vi.fn(),
+	};
+	const spawnMock = vi.fn<SpawnViewerProcess>(() => {
+		if (options.throws) throw new Error("spawn failed");
+		return child;
+	});
+	return { child, spawnMock };
+}
+
+describe("MCP viewer probe", () => {
+	it.each([
+		["healthy", { service: "codemem-viewer", ready: true }],
+		["degraded", { service: "codemem-viewer", ready: false }],
+	])("accepts a live %s viewer", async (_state, body) => {
+		const fetchMock = createFetchMock(jsonResponse(body));
+
+		await expect(isViewerHealthy({ fetchImpl: fetchMock })).resolves.toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://127.0.0.1:38888/api/health",
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
+	});
+
+	it.each([
+		["wrong service", jsonResponse({ service: "something-else", ready: true })],
+		["malformed JSON", new Response("not json", { status: 200 })],
+		["server error", jsonResponse({ service: "codemem-viewer" }, 500)],
+		["timeout", new DOMException("timed out", "TimeoutError")],
+		["network failure", new Error("connection refused")],
+	])("rejects %s without compatibility fallback", async (_case, response) => {
+		const fetchMock = createFetchMock(response);
+
+		await expect(isViewerHealthy({ fetchImpl: fetchMock })).resolves.toBe(false);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to stats exactly once when health is absent", async () => {
+		const fetchMock = createFetchMock(
+			new Response(null, { status: 404 }),
+			jsonResponse({ viewer_pid: 1234 }),
+		);
+
+		await expect(isViewerHealthy({ fetchImpl: fetchMock })).resolves.toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			2,
+			"http://127.0.0.1:38888/api/stats",
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
+	});
+
+	it.each([
+		["missing viewer_pid", jsonResponse({})],
+		["invalid viewer_pid", jsonResponse({ viewer_pid: "1234" })],
+		["malformed JSON", new Response("not json", { status: 200 })],
+		["server error", jsonResponse({ viewer_pid: 1234 }, 500)],
+	])("rejects a stats fallback with %s", async (_case, statsResponse) => {
+		const fetchMock = createFetchMock(new Response(null, { status: 404 }), statsResponse);
+
+		await expect(isViewerHealthy({ fetchImpl: fetchMock })).resolves.toBe(false);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("MCP viewer ensure", () => {
+	it("does not spawn when the viewer is healthy", async () => {
+		const { spawnMock } = createSpawnMock();
+
+		await ensureViewer({
+			fetchImpl: createFetchMock(jsonResponse({ service: "codemem-viewer", ready: true })),
+			resolveCliPath: () => "codemem",
+			spawnImpl: spawnMock,
+		});
+
+		expect(spawnMock).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		"CODEMEM_VIEWER",
+		"CODEMEM_VIEWER_AUTO",
+	] as const)("respects the %s opt-out", async (variable) => {
+		const fetchMock = createFetchMock();
+		const { spawnMock } = createSpawnMock();
+
+		await ensureViewer({
+			env: { [variable]: "0" },
+			fetchImpl: fetchMock,
+			spawnImpl: spawnMock,
+		});
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(spawnMock).not.toHaveBeenCalled();
+	});
+
+	it("spawns detached with preserved arguments and polls five times", async () => {
+		const fetchMock = createFetchMock(...Array.from({ length: 6 }, () => new Error("offline")));
+		const sleep = vi.fn(async () => {});
+		const { child, spawnMock } = createSpawnMock();
+
+		await ensureViewer({
+			env: { EXISTING: "value" },
+			execPath: "/node",
+			fetchImpl: fetchMock,
+			host: "localhost",
+			port: "39999",
+			resolveCliPath: () => "/codemem/index.js",
+			sleep,
+			spawnImpl: spawnMock,
+		});
+
+		expect(spawnMock).toHaveBeenCalledWith(
+			"/node",
+			["/codemem/index.js", "serve", "start", "--host", "localhost", "--port", "39999"],
+			{
+				detached: true,
+				stdio: "ignore",
+				env: { EXISTING: "value", CODEMEM_PLUGIN_IGNORE: "1" },
+			},
+		);
+		expect(child.on).toHaveBeenCalledWith("error", expect.any(Function));
+		expect(child.unref).toHaveBeenCalledOnce();
+		expect(sleep).toHaveBeenCalledTimes(5);
+		expect(sleep).toHaveBeenCalledWith(1_000);
+		expect(fetchMock).toHaveBeenCalledTimes(6);
+	});
+
+	it("stops polling as soon as the spawned viewer becomes healthy", async () => {
+		const fetchMock = createFetchMock(
+			new Error("offline"),
+			new Error("offline"),
+			new Error("offline"),
+			jsonResponse({ service: "codemem-viewer", ready: true }),
+		);
+		const sleep = vi.fn(async () => {});
+		const { spawnMock } = createSpawnMock();
+
+		await ensureViewer({
+			fetchImpl: fetchMock,
+			resolveCliPath: () => "codemem",
+			sleep,
+			spawnImpl: spawnMock,
+		});
+
+		expect(spawnMock).toHaveBeenCalledOnce();
+		expect(sleep).toHaveBeenCalledTimes(3);
+		expect(fetchMock).toHaveBeenCalledTimes(4);
+	});
+
+	it("swallows spawn failures", async () => {
+		const { spawnMock } = createSpawnMock({ throws: true });
+
+		await expect(
+			ensureViewer({
+				fetchImpl: createFetchMock(new Error("offline")),
+				resolveCliPath: () => "codemem",
+				spawnImpl: spawnMock,
+			}),
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/mcp-server/src/stdio-viewer.ts
+++ b/packages/mcp-server/src/stdio-viewer.ts
@@ -1,0 +1,136 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const DEFAULT_VIEWER_HOST = "127.0.0.1";
+const DEFAULT_VIEWER_PORT = "38888";
+const VIEWER_PROBE_TIMEOUT_MS = 2_000;
+const VIEWER_POLL_INTERVAL_MS = 1_000;
+const VIEWER_POLL_ATTEMPTS = 5;
+
+export interface ViewerChildProcess {
+	on(event: "error", listener: () => void): unknown;
+	unref(): void;
+}
+
+export type SpawnViewerProcess = (
+	command: string,
+	args: string[],
+	options: {
+		detached: true;
+		stdio: "ignore";
+		env: NodeJS.ProcessEnv;
+	},
+) => ViewerChildProcess;
+
+export interface ViewerProbeOptions {
+	host?: string;
+	port?: string;
+	fetchImpl?: typeof fetch;
+}
+
+export interface EnsureViewerOptions extends ViewerProbeOptions {
+	env?: NodeJS.ProcessEnv;
+	execPath?: string;
+	resolveCliPath?: () => string | null;
+	sleep?: (milliseconds: number) => Promise<void>;
+	spawnImpl?: SpawnViewerProcess;
+}
+
+/** Resolve the `codemem` CLI binary path. Checks package-local paths first, then PATH. */
+export function resolveCliPath(): string | null {
+	const selfDir = dirname(import.meta.dirname ?? ".");
+	const candidates = [
+		join(selfDir, "..", "cli", "dist", "index.js"),
+		join(selfDir, "..", ".bin", "codemem"),
+		join(selfDir, "..", "..", ".bin", "codemem"),
+	];
+	for (const candidate of candidates) {
+		if (existsSync(candidate)) return candidate;
+	}
+	return "codemem";
+}
+
+/** Check for a live CodeMem viewer, with one old-viewer compatibility probe on health 404. */
+export async function isViewerHealthy(options: ViewerProbeOptions = {}): Promise<boolean> {
+	const host = options.host ?? process.env.CODEMEM_VIEWER_HOST ?? DEFAULT_VIEWER_HOST;
+	const port = options.port ?? process.env.CODEMEM_VIEWER_PORT ?? DEFAULT_VIEWER_PORT;
+	const fetchImpl = options.fetchImpl ?? fetch;
+	const baseUrl = `http://${host}:${port}`;
+
+	try {
+		const response = await fetchImpl(`${baseUrl}/api/health`, {
+			signal: AbortSignal.timeout(VIEWER_PROBE_TIMEOUT_MS),
+		});
+		if (response.status === 404) {
+			// Old-viewer compatibility: every released viewer's stats payload
+			// includes `viewer_pid`, so require that identifying evidence
+			// rather than trusting any 2xx from an arbitrary local service.
+			const compatibilityResponse = await fetchImpl(`${baseUrl}/api/stats`, {
+				signal: AbortSignal.timeout(VIEWER_PROBE_TIMEOUT_MS),
+			});
+			if (!compatibilityResponse.ok) return false;
+			try {
+				const stats: unknown = await compatibilityResponse.json();
+				if (!stats || typeof stats !== "object" || Array.isArray(stats)) return false;
+				const viewerPid = (stats as { viewer_pid?: unknown }).viewer_pid;
+				return typeof viewerPid === "number" && Number.isSafeInteger(viewerPid) && viewerPid > 0;
+			} catch {
+				return false;
+			}
+		}
+		if (!response.ok) return false;
+
+		const body: unknown = await response.json();
+		return (
+			typeof body === "object" &&
+			body !== null &&
+			"service" in body &&
+			body.service === "codemem-viewer"
+		);
+	} catch {
+		return false;
+	}
+}
+
+/** Attempt to start the viewer as a detached, best-effort background process. */
+export async function ensureViewer(options: EnsureViewerOptions = {}): Promise<void> {
+	const env = options.env ?? process.env;
+	if (env.CODEMEM_VIEWER === "0" || env.CODEMEM_VIEWER_AUTO === "0") return;
+
+	const host = options.host ?? env.CODEMEM_VIEWER_HOST ?? DEFAULT_VIEWER_HOST;
+	const port = options.port ?? env.CODEMEM_VIEWER_PORT ?? DEFAULT_VIEWER_PORT;
+	const probeOptions = { host, port, fetchImpl: options.fetchImpl };
+	if (await isViewerHealthy(probeOptions)) return;
+
+	const cli = (options.resolveCliPath ?? resolveCliPath)();
+	if (!cli) return;
+
+	try {
+		const isJsFile = cli.endsWith(".js");
+		const command = isJsFile ? (options.execPath ?? process.execPath) : cli;
+		const args = isJsFile ? [cli, "serve", "start"] : ["serve", "start"];
+		if (host !== DEFAULT_VIEWER_HOST) args.push("--host", host);
+		if (port !== DEFAULT_VIEWER_PORT) args.push("--port", port);
+
+		const spawnImpl: SpawnViewerProcess =
+			options.spawnImpl ?? ((command, args, spawnOptions) => spawn(command, args, spawnOptions));
+		const child = spawnImpl(command, args, {
+			detached: true,
+			stdio: "ignore",
+			env: { ...env, CODEMEM_PLUGIN_IGNORE: "1" },
+		});
+		child.on("error", () => {});
+		child.unref();
+
+		const sleep =
+			options.sleep ??
+			((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+		for (let attempt = 0; attempt < VIEWER_POLL_ATTEMPTS; attempt++) {
+			await sleep(VIEWER_POLL_INTERVAL_MS);
+			if (await isViewerHealthy(probeOptions)) return;
+		}
+	} catch {
+		// Best effort — MCP server continues regardless.
+	}
+}

--- a/packages/mcp-server/src/stdio.ts
+++ b/packages/mcp-server/src/stdio.ts
@@ -7,86 +7,10 @@
  * Owns its own better-sqlite3 connection. Communicates via stdio JSON-RPC.
  */
 
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { MemoryStore, resolveDbPath } from "@codemem/core";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createCodememMcpServer } from "./server.js";
-
-/** Default viewer host/port for health checks. */
-const VIEWER_HOST = process.env.CODEMEM_VIEWER_HOST ?? "127.0.0.1";
-const VIEWER_PORT = process.env.CODEMEM_VIEWER_PORT ?? "38888";
-
-/** Resolve the `codemem` CLI binary path. Checks package-local paths first, then PATH. */
-function resolveCliPath(): string | null {
-	// When installed via npm/npx, the MCP server and CLI share node_modules.
-	// Walk up from this file to find the CLI's bin entry.
-	const candidates: string[] = [];
-	const selfDir = dirname(import.meta.dirname ?? ".");
-	// Monorepo dev: sibling package
-	candidates.push(join(selfDir, "..", "cli", "dist", "index.js"));
-	// npm install: node_modules/.bin/codemem
-	candidates.push(join(selfDir, "..", ".bin", "codemem"));
-	// npm install: deeper node_modules
-	candidates.push(join(selfDir, "..", "..", ".bin", "codemem"));
-	for (const p of candidates) {
-		if (existsSync(p)) return p;
-	}
-	// Fall back to PATH
-	return "codemem";
-}
-
-/** Check if the viewer is already running. */
-async function isViewerHealthy(): Promise<boolean> {
-	try {
-		const url = `http://${VIEWER_HOST}:${VIEWER_PORT}/api/health`;
-		const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
-		return response.ok;
-	} catch {
-		return false;
-	}
-}
-
-/**
- * Attempt to start the viewer server as a detached background process.
- * Best-effort: failures are logged to stderr but never block MCP startup.
- */
-async function ensureViewer(): Promise<void> {
-	if (process.env.CODEMEM_VIEWER === "0" || process.env.CODEMEM_VIEWER_AUTO === "0") return;
-
-	if (await isViewerHealthy()) return;
-
-	const cli = resolveCliPath();
-	if (!cli) return;
-
-	try {
-		// If the resolved path is a .js file, run it with node.
-		// Otherwise it's a bin script that can run directly.
-		const isJsFile = cli.endsWith(".js");
-		const cmd = isJsFile ? process.execPath : cli;
-		const args = isJsFile ? [cli, "serve", "start"] : ["serve", "start"];
-		// Pass non-default host/port so the spawned viewer matches what we health-check.
-		if (VIEWER_HOST !== "127.0.0.1") args.push("--host", VIEWER_HOST);
-		if (VIEWER_PORT !== "38888") args.push("--port", VIEWER_PORT);
-
-		const child = spawn(cmd, args, {
-			detached: true,
-			stdio: "ignore",
-			env: { ...process.env, CODEMEM_PLUGIN_IGNORE: "1" },
-		});
-		child.on("error", () => {}); // swallow — best effort
-		child.unref();
-
-		// Brief health check loop — don't block for long
-		for (let i = 0; i < 5; i++) {
-			await new Promise((r) => setTimeout(r, 1_000));
-			if (await isViewerHealthy()) return;
-		}
-	} catch {
-		// Best effort — MCP server continues regardless
-	}
-}
+import { ensureViewer } from "./stdio-viewer.js";
 
 async function main() {
 	const dbPath = resolveDbPath();

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -24,6 +24,10 @@ const MAX_MESSAGE_INJECTION_CACHE_SESSIONS = 20;
 const MAX_MESSAGE_INJECTION_CACHE_MESSAGES = 100;
 const COMPACTION_INJECTION_SKIP_TTL_MS = 30 * 1000;
 const MAX_WORKING_SET_PATH_CHARS = 400;
+const VIEWER_HEALTH_CHECK_INTERVAL_MS = 60_000;
+const VIEWER_HEALTH_TIMEOUT_MS = 5_000;
+const VIEWER_HEALTH_RESTART_THRESHOLD = 3;
+const VIEWER_HEALTH_RESTART_COOLDOWN_MS = 5 * 60_000;
 
 let compatCheckCache = null;
 
@@ -32,6 +36,149 @@ const envHasValue = (value, truthyValues) =>
   truthyValues.includes(normalizeEnvValue(value));
 const envNotDisabled = (value) =>
   !DISABLED_VALUES.includes(normalizeEnvValue(value));
+
+const createViewerHealthMonitor = ({
+  viewerHealthUrl,
+  legacyStatusUrl,
+  isActive,
+  restartViewer,
+  logLine,
+  fetchFn = fetch,
+  now = Date.now,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+  timeoutSignal = (timeoutMs) => AbortSignal.timeout(timeoutMs),
+}) => {
+  let timer = null;
+  let consecutiveFailures = 0;
+  let lastRestartAttempt = 0;
+
+  const boundedFetch = (url) => fetchFn(url, {
+    method: "GET",
+    signal: timeoutSignal(VIEWER_HEALTH_TIMEOUT_MS),
+  });
+
+  const probe = async () => {
+    let response;
+    try {
+      response = await boundedFetch(viewerHealthUrl);
+    } catch (error) {
+      return { live: false, detail: `error: ${String(error).slice(0, 200)}` };
+    }
+
+    if (response.status === 404) {
+      void response.body?.cancel?.();
+      try {
+        // Old-viewer compatibility: released viewers serving this route
+        // always include the `ingest` availability object, so require that
+        // identifying evidence rather than trusting any 2xx from an
+        // arbitrary local service.
+        const fallbackResponse = await boundedFetch(legacyStatusUrl);
+        if (!fallbackResponse.ok) {
+          void fallbackResponse.body?.cancel?.();
+          return { live: false, detail: `fallback status=${fallbackResponse.status}` };
+        }
+        const fallbackPayload = await fallbackResponse.json();
+        const looksLikeViewer =
+          fallbackPayload &&
+          typeof fallbackPayload === "object" &&
+          fallbackPayload.ingest &&
+          typeof fallbackPayload.ingest === "object";
+        return looksLikeViewer
+          ? { live: true }
+          : { live: false, detail: "fallback unexpected payload" };
+      } catch (error) {
+        return { live: false, detail: `fallback error: ${String(error).slice(0, 200)}` };
+      }
+    }
+
+    if (!response.ok) {
+      // Release the unread body so a persistently failing viewer does not
+      // pin connections across the 60s monitor interval.
+      void response.body?.cancel?.();
+      return { live: false, detail: `status=${response.status}` };
+    }
+
+    let payload;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      return { live: false, detail: `invalid JSON: ${String(error).slice(0, 200)}` };
+    }
+    if (!payload || typeof payload !== "object" || payload.service !== "codemem-viewer") {
+      return { live: false, detail: "unexpected service" };
+    }
+    return { live: true };
+  };
+
+  const check = async () => {
+    if (!isActive()) return;
+    const result = await probe();
+    if (result.live) {
+      if (consecutiveFailures > 0) {
+        await logLine(`viewer.health recovered after ${consecutiveFailures} failure(s)`);
+      }
+      consecutiveFailures = 0;
+      return;
+    }
+
+    consecutiveFailures += 1;
+    await logLine(
+      `viewer.health check failed (${result.detail}, consecutive=${consecutiveFailures})`
+    );
+    if (
+      consecutiveFailures < VIEWER_HEALTH_RESTART_THRESHOLD ||
+      now() - lastRestartAttempt < VIEWER_HEALTH_RESTART_COOLDOWN_MS
+    ) {
+      return;
+    }
+
+    // Re-check after the awaited probe: a stop requested while the probe was
+    // in flight must not be undone by a restart.
+    if (!isActive()) return;
+
+    lastRestartAttempt = now();
+    await logLine(`viewer.health restarting viewer after ${consecutiveFailures} consecutive failures`);
+    try {
+      const restartResult = await restartViewer();
+      const restarted = restartResult?.exitCode === 0;
+      await logLine(
+        `viewer.health restart ${restarted ? "succeeded" : "failed"} (exit=${restartResult?.exitCode ?? "unknown"})`
+      );
+      if (restarted) consecutiveFailures = 0;
+    } catch (error) {
+      await logLine(`viewer.health restart error: ${String(error).slice(0, 200)}`);
+    }
+  };
+
+  const start = () => {
+    if (timer) return;
+    consecutiveFailures = 0;
+    timer = setIntervalFn(() => {
+      check().catch(() => {});
+    }, VIEWER_HEALTH_CHECK_INTERVAL_MS);
+    if (timer?.unref) timer.unref();
+  };
+
+  const stop = () => {
+    if (timer) {
+      clearIntervalFn(timer);
+      timer = null;
+    }
+    consecutiveFailures = 0;
+  };
+
+  return {
+    check,
+    start,
+    stop,
+    state: () => ({
+      consecutiveFailures,
+      lastRestartAttempt,
+      running: timer !== null,
+    }),
+  };
+};
 
 const resolveInjectSurface = (value) => {
   const normalized = String(value || "message").trim().toLowerCase();
@@ -1548,6 +1695,7 @@ export const OpencodeMemPlugin = async ({
   const packUrl = `http://${viewerUrlHost}:${viewerPort}/api/pack`;
   const promptPackProfileUrl = `http://${viewerUrlHost}:${viewerPort}/api/prompt-pack-profile`;
   const promptPackLedgerUrl = `http://${viewerUrlHost}:${viewerPort}/api/prompt-pack-ledger`;
+  const viewerHealthUrl = `http://${viewerUrlHost}:${viewerPort}/api/health`;
   const rawEventsBackoffMs = parseNumber(
     process.env.CODEMEM_RAW_EVENTS_BACKOFF_MS || "10000",
     10000
@@ -1567,13 +1715,6 @@ export const OpencodeMemPlugin = async ({
   let lastStatusAvailable = true;
   let promptPackTransportUnavailableUntil = 0;
 
-  // Viewer health-check state
-  const HEALTH_CHECK_INTERVAL_MS = 60_000;
-  const HEALTH_CONSECUTIVE_FAILURES_BEFORE_RESTART = 3;
-  const HEALTH_RESTART_COOLDOWN_MS = 5 * 60_000;
-  let healthCheckTimer = null;
-  let healthConsecutiveFailures = 0;
-  let healthLastRestartAttempt = 0;
   const nextEventId = () => {
     if (typeof crypto !== "undefined" && crypto.randomUUID) {
       return crypto.randomUUID();
@@ -2952,62 +3093,15 @@ export const OpencodeMemPlugin = async ({
     await runCli(buildViewerCliArgs("stop"));
   };
 
-  const checkViewerHealth = async () => {
-    if (!viewerStarted || !viewerEnabled) return;
-    try {
-      const resp = await fetch(rawEventsStatusUrl, {
-        method: "GET",
-        signal: AbortSignal.timeout(5000),
-      });
-      if (resp.ok) {
-        if (healthConsecutiveFailures > 0) {
-          await logLine(`viewer.health recovered after ${healthConsecutiveFailures} failure(s)`);
-        }
-        healthConsecutiveFailures = 0;
-        return;
-      }
-      healthConsecutiveFailures++;
-      await logLine(`viewer.health check failed (status=${resp.status}, consecutive=${healthConsecutiveFailures})`);
-    } catch (err) {
-      healthConsecutiveFailures++;
-      await logLine(`viewer.health check error (consecutive=${healthConsecutiveFailures}): ${String(err).slice(0, 200)}`);
-    }
-
-    if (
-      healthConsecutiveFailures >= HEALTH_CONSECUTIVE_FAILURES_BEFORE_RESTART &&
-      Date.now() - healthLastRestartAttempt >= HEALTH_RESTART_COOLDOWN_MS
-    ) {
-      healthLastRestartAttempt = Date.now();
-      await logLine(`viewer.health restarting viewer after ${healthConsecutiveFailures} consecutive failures`);
-      try {
-        const result = await runCli(buildViewerCliArgs("restart"));
-        const ok = result?.exitCode === 0;
-        await logLine(`viewer.health restart ${ok ? "succeeded" : "failed"} (exit=${result?.exitCode ?? "unknown"})`);
-        if (ok) {
-          healthConsecutiveFailures = 0;
-        }
-      } catch (restartErr) {
-        await logLine(`viewer.health restart error: ${String(restartErr).slice(0, 200)}`);
-      }
-    }
-  };
-
-  const startHealthCheck = () => {
-    if (healthCheckTimer) return;
-    healthConsecutiveFailures = 0;
-    healthCheckTimer = setInterval(() => {
-      checkViewerHealth().catch(() => {});
-    }, HEALTH_CHECK_INTERVAL_MS);
-    if (healthCheckTimer.unref) healthCheckTimer.unref();
-  };
-
-  const stopHealthCheck = () => {
-    if (healthCheckTimer) {
-      clearInterval(healthCheckTimer);
-      healthCheckTimer = null;
-    }
-    healthConsecutiveFailures = 0;
-  };
+  const viewerHealthMonitor = createViewerHealthMonitor({
+    viewerHealthUrl,
+    legacyStatusUrl: rawEventsStatusUrl,
+    isActive: () => viewerStarted && viewerEnabled,
+    restartViewer: () => runCli(buildViewerCliArgs("restart")),
+    logLine,
+  });
+  const startHealthCheck = viewerHealthMonitor.start;
+  const stopHealthCheck = viewerHealthMonitor.stop;
 
   // Get version info (commit hash) for debugging
   let version = "unknown";
@@ -3646,4 +3740,5 @@ export const __testUtils = {
   buildRawEventEnvelope,
   trimEventQueue,
   parsePositiveInt,
+  createViewerHealthMonitor,
 };


### PR DESCRIPTION
## Description

Consolidates the three incompatible viewer probes (MCP stdio, `serve` lifecycle, OpenCode plugin monitor) onto `GET /api/health` with a shared contract: liveness requires HTTP success plus the `codemem-viewer` service discriminator, `ready: false` is live-but-degraded, and exactly one bounded legacy fallback fires only when an older viewer returns `404` (`/api/stats` for CLI/MCP, raw-event status for the plugin). No fallback occurs on wrong service, malformed JSON, 5xx, timeout, or network failure.

Safety and lifecycle invariants are preserved: MCP startup remains non-blocking (`ensureViewer` is never awaited), the plugin keeps its 60s interval / 3-failure restart threshold / 5-minute cooldown (now with a stop-race guard), raw-event ingest preflight is untouched, and `health.pid` never enters the termination path — PID candidates still come only from stats/listener with unchanged `lsof`/`ps` ownership gates.

Also includes small consolidation and polish surfaced in review: `serve` reuses the shared strict PID-record parser, IPv6-safe URLs, and loopback predicate; each probe request gets its own timeout budget; and `connectReadOnly` schema-compatibility warnings are routed through an injectable sink so `codemem status --json` keeps stderr clean. Contract-hoisting into core is tracked as follow-up `codemem-9xv2`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

New focused coverage: MCP probe/ensure (healthy, degraded, wrong service, malformed, 5xx, timeout, 404 fallback, no-spawn-when-healthy, early poll exit, spawn failure swallowing), plugin monitor (liveness, fallback, restart threshold/cooldown/success/recovery, stop-race, timer cleanup), and serve legacy-fallback plus health-pid-exclusion tests. Full build and workspace suite pass: 182 files, 3,979 tests, 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced