### PR TITLE
chore(cli): enforce command-tree parity and deprecation hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | | `codemem codex-hook-ingest` | Codex hook event ingestion (stdin, experimental) |
 | | `codemem codex-hook-inject` | Codex prompt-time memory injection (stdin, experimental) |
 
-Run `codemem --help` for the full list. Legacy top-level aliases (`export-memories`, `import-memories`, `show`, `forget`, `remember`) still work but are hidden from help.
+Run `codemem --help` for the full list. `show`, `forget`, and `remember` still work as hidden top-level aliases. `export-memories` and `import-memories` remain visible but are deprecated — they warn on stderr and will be hidden from help and completion in a future release; use `codemem memory export` / `codemem memory import`.
 
 Use `codemem status` to answer whether the local database, viewer, sync, maintenance,
 semantic index, raw-event ingestion, and observer need attention. It is observational:
@@ -276,7 +276,7 @@ codemem memory export project.json
 codemem memory import project.json --remap-project ~/workspace/myproject
 ```
 
-See `codemem memory export --help` and `codemem memory import --help` for full options. Legacy top-level aliases still work but are hidden from help.
+See `codemem memory export --help` and `codemem memory import --help` for full options. The legacy top-level `export-memories` / `import-memories` forms still work but emit a deprecation warning.
 
 ## Sharing and devices
 
@@ -328,7 +328,7 @@ Use manual pairing only for a same-person device, an existing integration, or a 
 ```text
 codemem sync enable        # generate device keys
 codemem sync pair          # generate pairing payload
-codemem sync start         # start the viewer-backed sync runtime
+codemem serve start        # start it; use serve stop/restart for lifecycle management
 codemem sync once          # run one immediate sync pass
 ```
 

--- a/docs/anchor-peer-deployment.md
+++ b/docs/anchor-peer-deployment.md
@@ -94,9 +94,11 @@ Coordinator group enrollment is not enough. Grant the anchor peer to each
 Sharing domain explicitly:
 
 ```fish
-codemem coordinator grant-scope-member team-alpha acme-work <anchor-device-id> --db-path ~/.codemem/coordinator.sqlite
-codemem coordinator grant-scope-member team-alpha oss-codemem <anchor-device-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator grant-scope-member team-alpha acme-work <anchor-device-id> --effect-id <effect-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator grant-scope-member team-alpha oss-codemem <anchor-device-id> --effect-id <effect-id> --db-path ~/.codemem/coordinator.sqlite
 ```
+
+Effect ids make membership mutations deterministic and idempotent; use a stable unique value for each intended mutation.
 
 Review grants regularly:
 
@@ -107,7 +109,7 @@ codemem coordinator list-scope-members team-alpha acme-work --db-path ~/.codemem
 Revoke a domain when the anchor peer should stop receiving future data for it:
 
 ```fish
-codemem coordinator revoke-scope-member team-alpha acme-work <anchor-device-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator revoke-scope-member team-alpha acme-work <anchor-device-id> --effect-id <effect-id> --db-path ~/.codemem/coordinator.sqlite
 ```
 
 Revocation is forward-looking. Rotate or destroy the anchor peer's local storage

--- a/docs/cloudflare-coordinator-deployment.md
+++ b/docs/cloudflare-coordinator-deployment.md
@@ -3,7 +3,7 @@
 Use this runbook when you specifically want to deploy the coordinator discovery contract on Cloudflare Workers + D1.
 
 This is the canonical Cloudflare deployment reference for the current TypeScript worker path. It is still a secondary
-deployment target behind the built-in coordinator service in `codemem sync coordinator serve`, but if you are choosing
+deployment target behind the built-in coordinator service in `codemem coordinator serve`, but if you are choosing
 the Worker path, this document is the source of truth.
 
 ## What this deploys

--- a/docs/coordinator-deployment.md
+++ b/docs/coordinator-deployment.md
@@ -3,7 +3,7 @@
 The built-in TypeScript coordinator is the canonical **operator deployment** target for cross-network discovery. Normal teammate sharing is **Projects → Sharing → Devices → Health**; the coordinator, Teams, Spaces, grants, and direct-peer state are Advanced compatibility and operations mechanics.
 
 The coordinator HTTP service is Hono-based, but the canonical deployment path today is still the built-in
-`codemem sync coordinator serve` runtime on Node/Linux with a local SQLite database. If your end goal is Cloudflare,
+`codemem coordinator serve` runtime on Node/Linux with a local SQLite database. If your end goal is Cloudflare,
 validate this Linux/Node flow first, then use the dedicated Worker runbook in [Cloudflare coordinator deployment](cloudflare-coordinator-deployment.md).
 
 If you want the fastest clean validation path, use [the coordinator E2E runbook](coordinator-e2e-runbook.md) alongside this guide.
@@ -24,13 +24,13 @@ Use the controls below only when you operate a coordinator, diagnose compatibili
 npm install -g codemem
 
 # Create a coordinator group
-codemem sync coordinator group-create my-team --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator group-create my-team --db-path ~/.codemem/coordinator.sqlite
 
 # Set an admin secret (required for creating invites via the API)
 set -x CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET (openssl rand -base64 32)
 
 # Start the coordinator
-codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
+codemem coordinator serve --db-path ~/.codemem/coordinator.sqlite --coordinator-host 0.0.0.0 --coordinator-port 7347
 ```
 
 The coordinator is now listening on port 7347. Devices on the same network can connect using this machine's IP address.
@@ -43,58 +43,58 @@ coordinator rejects admin operations (invite creation, join request review) with
 ### Coordinator server
 
 ```fish
-codemem sync coordinator serve [OPTIONS]
+codemem coordinator serve [OPTIONS]
 ```
 
 | Option      | Default       | Description                            |
 |-------------|---------------|----------------------------------------|
 | `--db-path` | `~/.codemem/coordinator.sqlite` | Path to coordinator SQLite database    |
-| `--host`    | `127.0.0.1`   | Bind address (`0.0.0.0` for all interfaces) |
-| `--port`    | `7347`        | Listen port                            |
+| `--coordinator-host` | `127.0.0.1`   | Bind address (`0.0.0.0` for all interfaces) |
+| `--coordinator-port` | `7347`        | Listen port                            |
 
 ### Team management (Advanced/operator)
 
 ```fish
 # Create a group
-codemem sync coordinator group-create <group-id> --db-path <path>
+codemem coordinator group-create <group-id> --db-path <path>
 
 # List groups
-codemem sync coordinator list-groups --db-path <path>
+codemem coordinator list-groups --db-path <path>
 
 # Enroll a device directly (admin)
-codemem sync coordinator enroll-device <group-id> <device-id> \
+codemem coordinator enroll-device <group-id> <device-id> \
   --fingerprint <fingerprint> --public-key-file <path> --db-path <path>
 
 # List enrolled devices
-codemem sync coordinator list-devices <group-id> --db-path <path>
+codemem coordinator list-devices <group-id> --db-path <path>
 
 # Rename, disable, or remove a device
-codemem sync coordinator rename-device <group-id> <device-id> --name "work-laptop" --db-path <path>
-codemem sync coordinator disable-device <group-id> <device-id> --db-path <path>
-codemem sync coordinator remove-device <group-id> <device-id> --db-path <path>
+codemem coordinator rename-device <group-id> <device-id> --name "work-laptop" --db-path <path>
+codemem coordinator disable-device <group-id> <device-id> --db-path <path>
+codemem coordinator remove-device <group-id> <device-id> --db-path <path>
 
 # Invite / join-request commands
-codemem sync coordinator create-invite <group-id> --db-path <path>
-codemem sync coordinator list-join-requests <group-id> --db-path <path>
-codemem sync coordinator approve-join-request <request-id> --db-path <path>
-codemem sync coordinator deny-join-request <request-id> --db-path <path>
+codemem coordinator create-invite <group-id> --db-path <path>
+codemem coordinator list-join-requests <group-id> --db-path <path>
+codemem coordinator approve-join-request <request-id> --db-path <path>
+codemem coordinator deny-join-request <request-id> --db-path <path>
 ```
 
 ### Invite and join flow
 
 ```fish
 # Create an invite (admin)
-codemem sync coordinator create-invite <group-id> --db-path <path>
+codemem coordinator create-invite <group-id> --db-path <path>
 
 # Import an invite (teammate)
-codemem sync coordinator import-invite <encoded-invite>
+codemem coordinator import-invite <encoded-invite>
 
 # List pending join requests (admin)
-codemem sync coordinator list-join-requests <group-id> --db-path <path>
+codemem coordinator list-join-requests <group-id> --db-path <path>
 
 # Approve or deny (admin)
-codemem sync coordinator approve-join-request <request-id> --db-path <path>
-codemem sync coordinator deny-join-request <request-id> --db-path <path>
+codemem coordinator approve-join-request <request-id> --db-path <path>
+codemem coordinator deny-join-request <request-id> --db-path <path>
 ```
 
 ## Container deployment
@@ -110,9 +110,9 @@ VOLUME /data
 
 EXPOSE 7347
 
-ENTRYPOINT ["codemem", "sync", "coordinator", "serve", \
+ENTRYPOINT ["codemem", "coordinator", "serve", \
   "--db-path", "/data/coordinator.sqlite", \
-  "--host", "0.0.0.0", "--port", "7347"]
+  "--coordinator-host", "0.0.0.0", "--coordinator-port", "7347"]
 ```
 
 Build and run:
@@ -125,7 +125,7 @@ docker run -d --name coordinator -p 7347:7347 -v coordinator-data:/data codemem-
 Initialize the group from the host:
 
 ```fish
-docker exec coordinator codemem sync coordinator group-create my-team --db-path /data/coordinator.sqlite
+docker exec coordinator codemem coordinator group-create my-team --db-path /data/coordinator.sqlite
 ```
 
 ## Exposing the coordinator
@@ -138,7 +138,7 @@ Tailscale Funnel exposes a local port to the internet via your Tailscale network
 
 ```fish
 # Start the coordinator
-codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
+codemem coordinator serve --db-path ~/.codemem/coordinator.sqlite --coordinator-host 0.0.0.0 --coordinator-port 7347
 
 # In another terminal, expose via Funnel
 tailscale funnel 7347
@@ -154,7 +154,7 @@ itself.
 
 ```fish
 # Start the coordinator
-codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 127.0.0.1 --port 7347
+codemem coordinator serve --db-path ~/.codemem/coordinator.sqlite --coordinator-host 127.0.0.1 --coordinator-port 7347
 
 # Start the tunnel
 cloudflared tunnel --url http://localhost:7347
@@ -211,7 +211,7 @@ Joining the coordinator Team enrolls the device for coordinator-backed discovery
 The admin can enroll a teammate's device directly from the local coordinator machine:
 
 ```fish
-codemem sync coordinator enroll-device my-team <device-id> \
+codemem coordinator enroll-device my-team <device-id> \
   --fingerprint <fingerprint> --public-key-file <path> \
   --db-path ~/.codemem/coordinator.sqlite
 ```
@@ -221,13 +221,13 @@ codemem sync coordinator enroll-device my-team <device-id> \
 The admin creates an invite and shares it:
 
 ```fish
-codemem sync coordinator create-invite my-team --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator create-invite my-team --db-path ~/.codemem/coordinator.sqlite
 ```
 
 This outputs an encoded invite string. Share it with the teammate, who imports it:
 
 ```fish
-codemem sync coordinator import-invite <encoded-invite>
+codemem coordinator import-invite <encoded-invite>
 ```
 
 Or paste the invite in the viewer UI under **Advanced → Team sync → Join team**.
@@ -250,10 +250,10 @@ peer-to-peer sync remains the data path.
 
 ## Troubleshooting
 
-**Coordinator not reachable**: verify the `--host` binding. Use `0.0.0.0` to listen on all interfaces. Check firewall
+**Coordinator not reachable**: verify the `--coordinator-host` binding. Use `0.0.0.0` to listen on all interfaces. Check firewall
 rules and that the tunnel/funnel is active.
 
-**Device not enrolled**: run `codemem sync coordinator list-devices <group> --db-path <path>` to confirm enrollment.
+**Device not enrolled**: run `codemem coordinator list-devices <group> --db-path <path>` to confirm enrollment.
 Use the invite flow for self-service enrollment.
 
 **Presence not refreshing**: check that the client's `sync_coordinator_url` matches the coordinator's reachable address

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -91,15 +91,16 @@ codemem coordinator enroll-device team-alpha <device-id> --fingerprint <fingerpr
 codemem coordinator list-devices team-alpha --db-path ~/.codemem/coordinator.sqlite
 codemem coordinator list-scopes team-alpha --db-path ~/.codemem/coordinator.sqlite
 codemem coordinator create-scope team-alpha acme-work --label "Acme Work" --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator update-scope team-alpha acme-work --label "Acme Work" --db-path ~/.codemem/coordinator.sqlite
 codemem coordinator list-scope-members team-alpha acme-work --db-path ~/.codemem/coordinator.sqlite
-codemem coordinator grant-scope-member team-alpha acme-work <device-id> --db-path ~/.codemem/coordinator.sqlite
-codemem coordinator revoke-scope-member team-alpha acme-work <device-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator grant-scope-member team-alpha acme-work <device-id> --effect-id <effect-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator revoke-scope-member team-alpha acme-work <device-id> --effect-id <effect-id> --db-path ~/.codemem/coordinator.sqlite
 codemem coordinator rename-device team-alpha <device-id> --name "work-laptop" --db-path ~/.codemem/coordinator.sqlite
 codemem coordinator disable-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
 codemem coordinator remove-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
 codemem coordinator list-bootstrap-grants team-alpha --db-path ~/.codemem/coordinator.sqlite
 codemem coordinator revoke-bootstrap-grant <grant-id> --db-path ~/.codemem/coordinator.sqlite
-codemem coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
+codemem coordinator serve --db-path ~/.codemem/coordinator.sqlite --coordinator-host 0.0.0.0 --coordinator-port 7347
 codemem coordinator create-invite team-alpha --db-path ~/.codemem/coordinator.sqlite
 codemem coordinator import-invite <invite>
 codemem coordinator list-join-requests team-alpha --db-path ~/.codemem/coordinator.sqlite
@@ -163,12 +164,13 @@ Minimal flow:
 
 ```fish
 codemem coordinator create-scope team-alpha acme-work --label "Acme Work" --db-path ~/.codemem/coordinator.sqlite
-codemem coordinator grant-scope-member team-alpha acme-work <device-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator grant-scope-member team-alpha acme-work <device-id> --effect-id <effect-id> --db-path ~/.codemem/coordinator.sqlite
 codemem coordinator list-scope-members team-alpha acme-work --db-path ~/.codemem/coordinator.sqlite
 ```
 
 Operational rules:
 
+- Effect ids make membership mutations deterministic and idempotent; use a stable unique value for each intended mutation.
 - Grants and revocations are explicit per `(group, scope_id, device_id)`.
 - Membership epochs make cached grants stale after revocation or replacement.
 - Revocation stops future sync after peers refresh membership. It does not erase

--- a/docs/coordinator-e2e-runbook.md
+++ b/docs/coordinator-e2e-runbook.md
@@ -29,9 +29,9 @@ On the coordinator host:
 
 ```fish
 rm ~/.codemem/coordinator.sqlite
-codemem sync coordinator group-create my-team --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator group-create my-team --db-path ~/.codemem/coordinator.sqlite
 set -x CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET (openssl rand -base64 32)
-codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
+codemem coordinator serve --db-path ~/.codemem/coordinator.sqlite --coordinator-host 0.0.0.0 --coordinator-port 7347
 ```
 
 If you do not want to expose the raw host directly, put it behind Tailscale Funnel or Cloudflare Tunnel and use that
@@ -60,7 +60,7 @@ block you because private-network deployments can still be valid.
 On the admin device:
 
 ```fish
-codemem sync coordinator create-invite my-team --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator create-invite my-team --db-path ~/.codemem/coordinator.sqlite
 ```
 
 This returns:
@@ -76,7 +76,7 @@ Share the encoded invite with the teammate device.
 On the teammate device:
 
 ```fish
-codemem sync coordinator import-invite <encoded-invite>
+codemem coordinator import-invite <encoded-invite>
 ```
 
 Expected result:
@@ -94,8 +94,8 @@ out, check reachability of the invite’s `coordinator_url` from the teammate ma
 If the invite policy is `approval_required`, on the admin host:
 
 ```fish
-codemem sync coordinator list-join-requests my-team --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator approve-join-request <request-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator list-join-requests my-team --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator approve-join-request <request-id> --db-path ~/.codemem/coordinator.sqlite
 ```
 
 ## 6. Inspect the discovered device (Advanced)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -250,7 +250,7 @@ Legacy `#sync` and `#sync/diagnostics` viewer links remain valid Advanced routes
 ### Sync runtime
 
 - `codemem sync enable` generates keys and writes config.
-- `codemem sync start` starts the viewer-backed sync runtime.
+- `codemem serve start|stop|restart` manages the viewer-backed sync runtime.
 - `codemem sync status` shows device info and peer health.
 
 ### Manual pairing

--- a/e2e/lib/seed.ts
+++ b/e2e/lib/seed.ts
@@ -25,7 +25,7 @@ export function seedPeer(
 		compose.copyToContainer(resolvedInput, containerPath, `${artifactName}-copy-local-import`);
 		compose.exec(
 			service,
-			[...CLI_PREFIX, "import-memories", `/tmp/${basename(resolvedInput)}`, "--db-path", dbPath],
+			[...CLI_PREFIX, "memory", "import", `/tmp/${basename(resolvedInput)}`, "--db-path", dbPath],
 			`${artifactName}-import-local-import`,
 			300_000,
 		);

--- a/packages/cli/src/command-tree.test.ts
+++ b/packages/cli/src/command-tree.test.ts
@@ -1,0 +1,108 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	COMPLETION_ONLY_TOKENS,
+	invokedAsTopLevelAlias,
+	ROOT_COMPLETION_COMMANDS,
+	registerRootCommands,
+} from "./command-tree.js";
+import { memoryCommand } from "./commands/memory.js";
+import { syncCommand } from "./commands/sync.js";
+import { helpStyle } from "./help-style.js";
+
+const completionOnly = new Set<string>(["help", ...COMPLETION_ONLY_TOKENS]);
+
+// The exact assembly used by the runtime entrypoint (index.ts).
+const program = registerRootCommands(new Command("codemem").configureHelp(helpStyle));
+
+describe("root command tree", () => {
+	it("keeps visible registrations and completions in parity", () => {
+		const registeredNames = new Set(program.commands.map((command) => command.name()));
+		const visibleNames = program
+			.createHelp()
+			.visibleCommands(program)
+			.map((command) => command.name());
+
+		for (const commandName of visibleNames) {
+			expect(ROOT_COMPLETION_COMMANDS).toContain(commandName);
+		}
+
+		for (const completion of ROOT_COMPLETION_COMMANDS) {
+			if (completionOnly.has(completion)) continue;
+			expect(registeredNames).toContain(completion);
+		}
+	});
+
+	it("keeps hidden compatibility commands out of shell completion", () => {
+		const visibleNames = new Set(
+			program
+				.createHelp()
+				.visibleCommands(program)
+				.map((command) => command.name()),
+		);
+		const hiddenNames = program.commands
+			.map((command) => command.name())
+			.filter((name) => name !== "help" && !visibleNames.has(name));
+
+		expect(hiddenNames).toEqual(
+			expect.arrayContaining(["show", "forget", "remember", "prompt-pack-ledger"]),
+		);
+		for (const hiddenName of hiddenNames) {
+			expect(ROOT_COMPLETION_COMMANDS).not.toContain(hiddenName);
+		}
+	});
+
+	it("shows warned aliases and omits hidden root compatibility commands", () => {
+		const help = program.helpInformation();
+
+		expect(help).toMatch(/^\s+export-memories(?:\s|$)/m);
+		expect(help).toMatch(/^\s+import-memories(?:\s|$)/m);
+		for (const hiddenName of ["show", "forget", "remember", "prompt-pack-ledger"]) {
+			expect(help).not.toMatch(new RegExp(`^\\s+${hiddenName}(?:\\s|$)`, "m"));
+		}
+	});
+
+	it("registers the memory export/import wrappers exactly once", () => {
+		registerRootCommands(new Command("codemem-again").configureHelp(helpStyle));
+
+		const wrapperNames = memoryCommand.commands
+			.map((command) => command.name())
+			.filter((name) => name === "export" || name === "import");
+		expect(wrapperNames.sort()).toEqual(["export", "import"]);
+	});
+
+	it("hides sync coordinator from help without unregistering it", () => {
+		const coordinator = syncCommand.commands.find((command) => command.name() === "coordinator");
+
+		expect(coordinator).toBeDefined();
+		expect(syncCommand.helpInformation()).not.toMatch(/^\s+coordinator(?:\s|$)/m);
+	});
+});
+
+describe("invokedAsTopLevelAlias", () => {
+	const originalArgv = process.argv;
+	afterEach(() => {
+		process.argv = originalArgv;
+	});
+
+	it("matches an alias when it is the first non-flag token", () => {
+		expect(invokedAsTopLevelAlias("export-memories", ["--verbose", "export-memories"])).toBe(true);
+	});
+
+	it("does not match aliases forwarded through the memory group", () => {
+		expect(invokedAsTopLevelAlias("export-memories", ["memory", "export"])).toBe(false);
+		expect(invokedAsTopLevelAlias("import-memories", ["memory", "import"])).toBe(false);
+	});
+
+	it("stops scanning at the -- terminator", () => {
+		expect(invokedAsTopLevelAlias("export-memories", ["--", "export-memories"])).toBe(false);
+	});
+
+	it("reads the real process argv by default", () => {
+		process.argv = ["node", "codemem", "export-memories", "out.json"];
+		expect(invokedAsTopLevelAlias("export-memories")).toBe(true);
+
+		process.argv = ["node", "codemem", "memory", "export", "out.json"];
+		expect(invokedAsTopLevelAlias("export-memories")).toBe(false);
+	});
+});

--- a/packages/cli/src/command-tree.ts
+++ b/packages/cli/src/command-tree.ts
@@ -1,0 +1,199 @@
+/**
+ * Assembled root command tree — single source of truth shared by the runtime
+ * entrypoint (`index.ts`) and the command-tree parity tests.
+ *
+ * `index.ts` stays the only module with import-time side effects (omelette
+ * completion init, `program.parse()`); everything here is side-effect free
+ * until `registerRootCommands` is called.
+ */
+
+import { Command } from "commander";
+import { claudeHookFileContextCommand } from "./commands/claude-hook-file-context.js";
+import { claudeHookIngestCommand } from "./commands/claude-hook-ingest.js";
+import { claudeHookInjectCommand } from "./commands/claude-hook-inject.js";
+import { codexHookIngestCommand } from "./commands/codex-hook-ingest.js";
+import { codexHookInjectCommand } from "./commands/codex-hook-inject.js";
+import { configCommand } from "./commands/config.js";
+import { coordinatorCommand } from "./commands/coordinator.js";
+import { dbCommand } from "./commands/db.js";
+import { distillCommand } from "./commands/distill.js";
+import { embedCommand } from "./commands/embed.js";
+import { enqueueRawEventCommand } from "./commands/enqueue-raw-event.js";
+import { exportMemoriesCommand } from "./commands/export-memories.js";
+import { importMemoriesCommand } from "./commands/import-memories.js";
+import { maintenanceCommand } from "./commands/maintenance.js";
+import { mcpCommand } from "./commands/mcp.js";
+import {
+	forgetMemoryCommand,
+	memoryCommand,
+	rememberMemoryCommand,
+	showMemoryCommand,
+} from "./commands/memory.js";
+import { packCommand, promptPackLedgerCommand } from "./commands/pack.js";
+import { recentCommand } from "./commands/recent.js";
+import { searchCommand } from "./commands/search.js";
+import { serveCommand } from "./commands/serve.js";
+import { setupCommand } from "./commands/setup.js";
+import { statsCommand } from "./commands/stats.js";
+import { statusCommand } from "./commands/status.js";
+import { syncCommand } from "./commands/sync.js";
+import { versionCommand } from "./commands/version.js";
+import { helpStyle } from "./help-style.js";
+
+export const ROOT_COMPLETION_COMMANDS = [
+	"claude-hook-file-context",
+	"claude-hook-inject",
+	"claude-hook-ingest",
+	"codex-hook-inject",
+	"codex-hook-ingest",
+	"config",
+	"coordinator",
+	"db",
+	"distill",
+	"embed",
+	"enqueue-raw-event",
+	"export-memories",
+	"import-memories",
+	"maintenance",
+	"mcp",
+	"memory",
+	"pack",
+	"recent",
+	"search",
+	"serve",
+	"setup",
+	"stats",
+	"status",
+	"sync",
+	"version",
+	"help",
+	"--help",
+	"--version",
+] as const;
+
+/** Completion entries that are not registered Commander commands. */
+export const COMPLETION_ONLY_TOKENS = ["--help", "--version"] as const;
+
+/**
+ * True when the CLI process was invoked through the named top-level
+ * compatibility alias (first non-flag token of the real argv). Forwarding
+ * wrappers such as `memory export` re-parse the alias command with synthetic
+ * argv, so this stays false for canonical invocations.
+ */
+export function invokedAsTopLevelAlias(
+	name: string,
+	argv: readonly string[] = process.argv.slice(2),
+): boolean {
+	for (const token of argv) {
+		if (token === "--") return false;
+		if (!token.startsWith("-")) return token === name;
+	}
+	return false;
+}
+
+function registerMemoryGroupWrappers(): void {
+	// Idempotence guard: module singletons must not accumulate duplicate
+	// subcommands if the tree is assembled more than once (e.g. in tests).
+	if (memoryCommand.commands.some((command) => command.name() === "export")) return;
+
+	// Per cli-design-conventions.md, export/import belong under their noun
+	// group. The top-level export-memories/import-memories remain as warned
+	// compatibility aliases.
+	//
+	// Slice the forwarded argv tail starting from the `memory <sub>` token pair
+	// rather than the first raw occurrence of the subcommand name. Anchoring on
+	// the `memory` group token first guarantees the subcommand token we slice
+	// from is the actual subcommand position, so a positional argument that
+	// happens to be literally "export" or "import" cannot shift the tail.
+	const forwardedTail = (subcommand: "export" | "import"): string[] => {
+		const argv = process.argv.slice(2);
+		const groupIdx = argv.indexOf("memory");
+		const searchFrom = groupIdx >= 0 ? groupIdx + 1 : 0;
+		const subIdx = argv.indexOf(subcommand, searchFrom);
+		return subIdx >= 0 ? argv.slice(subIdx + 1) : [];
+	};
+
+	const memExport = new Command("export")
+		.description("Export memories to a JSON file for sharing or backup")
+		.argument("<output>", "output file path (use '-' for stdout)")
+		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
+		.option("--project <project>", "filter by project")
+		.option("--all-projects", "export all projects")
+		.option("--include-inactive", "include deactivated memories")
+		.option("--since <iso>", "only export memories created after this ISO timestamp")
+		.configureHelp(helpStyle)
+		.allowUnknownOption(true)
+		.allowExcessArguments(true)
+		.action(async () => {
+			// Forward to the original command by re-parsing the raw argv tail.
+			// `memory export <args>` → `export-memories <args>`
+			await exportMemoriesCommand.parseAsync([
+				"node",
+				"export-memories",
+				...forwardedTail("export"),
+			]);
+		});
+
+	const memImport = new Command("import")
+		.description("Import memories from an exported JSON file")
+		.argument("<inputFile>", "input JSON file (use '-' for stdin)")
+		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
+		.option("--remap-project <path>", "remap all projects to this path on import")
+		.option("--dry-run", "preview import without writing")
+		.configureHelp(helpStyle)
+		.allowUnknownOption(true)
+		.allowExcessArguments(true)
+		.action(async () => {
+			await importMemoriesCommand.parseAsync([
+				"node",
+				"import-memories",
+				...forwardedTail("import"),
+			]);
+		});
+
+	memoryCommand.addCommand(memExport);
+	memoryCommand.addCommand(memImport);
+}
+
+/** Register every root command (visible and hidden) on the given program. */
+export function registerRootCommands(program: Command): Command {
+	registerMemoryGroupWrappers();
+
+	program.addCommand(serveCommand);
+	program.addCommand(configCommand);
+	program.addCommand(coordinatorCommand);
+	program.addCommand(mcpCommand);
+	program.addCommand(claudeHookInjectCommand);
+	program.addCommand(claudeHookIngestCommand);
+	program.addCommand(claudeHookFileContextCommand);
+	program.addCommand(codexHookInjectCommand);
+	program.addCommand(codexHookIngestCommand);
+	program.addCommand(dbCommand);
+	program.addCommand(distillCommand);
+	// Warned compatibility aliases — visible for their first warned release;
+	// hide from help and completion in a later release (see export-memories.ts).
+	program.addCommand(exportMemoriesCommand);
+	program.addCommand(importMemoriesCommand);
+	program.addCommand(statsCommand);
+	program.addCommand(statusCommand);
+	program.addCommand(maintenanceCommand);
+	program.addCommand(embedCommand);
+	program.addCommand(recentCommand);
+	program.addCommand(searchCommand);
+	program.addCommand(packCommand);
+	program.addCommand(promptPackLedgerCommand, { hidden: true });
+	// Deprecated top-level aliases — use `memory show`, `memory forget`,
+	// `memory remember` instead. Hidden from --help and shell completion but
+	// still functional for backwards compat.
+	program.addCommand(showMemoryCommand, { hidden: true });
+	program.addCommand(forgetMemoryCommand, { hidden: true });
+	program.addCommand(rememberMemoryCommand, { hidden: true });
+	program.addCommand(memoryCommand);
+	program.addCommand(syncCommand);
+	program.addCommand(setupCommand);
+	program.addCommand(enqueueRawEventCommand);
+	program.addCommand(versionCommand);
+	return program;
+}

--- a/packages/cli/src/commands/alias-deprecation.test.ts
+++ b/packages/cli/src/commands/alias-deprecation.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemoryStore } from "@codemem/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { exportMemoriesCommand } from "./export-memories.js";
+import { importMemoriesCommand } from "./import-memories.js";
+
+describe("deprecated top-level alias warnings", () => {
+	const originalArgv = process.argv;
+	let dir: string;
+	let dbPath: string;
+
+	beforeEach(() => {
+		process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+		dir = mkdtempSync(join(tmpdir(), "codemem-alias-"));
+		dbPath = join(dir, "alias.sqlite");
+		new MemoryStore(dbPath).close();
+	});
+
+	afterEach(() => {
+		process.argv = originalArgv;
+		delete process.env.CODEMEM_EMBEDDING_DISABLED;
+		vi.restoreAllMocks();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("warns on the top-level alias but keeps JSON automation paths clean", async () => {
+		const exportPath = join(dir, "export.json");
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+		// Top-level file export warns on stderr.
+		process.argv = ["node", "codemem", "export-memories", exportPath];
+		await exportMemoriesCommand.parseAsync([
+			"node",
+			"export-memories",
+			exportPath,
+			"--db-path",
+			dbPath,
+			"--all-projects",
+		]);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("deprecated"));
+
+		// Stdout export streams machine-readable JSON: no stderr warning.
+		errorSpy.mockClear();
+		process.argv = ["node", "codemem", "export-memories", "-"];
+		await exportMemoriesCommand.parseAsync([
+			"node",
+			"export-memories",
+			"-",
+			"--db-path",
+			dbPath,
+			"--all-projects",
+		]);
+		expect(errorSpy).not.toHaveBeenCalled();
+
+		// JSON-mode import: no stderr warning.
+		process.argv = ["node", "codemem", "import-memories", exportPath, "--json"];
+		await importMemoriesCommand.parseAsync([
+			"node",
+			"import-memories",
+			exportPath,
+			"--db-path",
+			dbPath,
+			"--json",
+		]);
+		expect(errorSpy).not.toHaveBeenCalled();
+
+		// Human-mode top-level import still warns.
+		process.argv = ["node", "codemem", "import-memories", exportPath];
+		await importMemoriesCommand.parseAsync([
+			"node",
+			"import-memories",
+			exportPath,
+			"--db-path",
+			dbPath,
+		]);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("deprecated"));
+	});
+});

--- a/packages/cli/src/commands/export-memories.ts
+++ b/packages/cli/src/commands/export-memories.ts
@@ -4,8 +4,14 @@ import { join } from "node:path";
 import * as p from "@clack/prompts";
 import { exportMemories, resolveDbPath } from "@codemem/core";
 import { Command } from "commander";
+import { invokedAsTopLevelAlias } from "../command-tree.js";
 import { helpStyle } from "../help-style.js";
-import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
+import {
+	addDbOption,
+	type DbOpts,
+	emitDeprecationWarning,
+	resolveDbOpt,
+} from "../shared-options.js";
 
 function expandUserPath(value: string): string {
 	return value.startsWith("~/") ? join(homedir(), value.slice(2)) : value;
@@ -32,6 +38,12 @@ cmd.action(
 			since?: string;
 		},
 	) => {
+		// Keep visible for this first warned release; hide the alias in a later release.
+		// Suppressed for stdout export: `-` streams machine-readable JSON, so
+		// stderr stays clean for piped automation.
+		if (output !== "-" && invokedAsTopLevelAlias("export-memories")) {
+			emitDeprecationWarning("codemem export-memories", "codemem memory export");
+		}
 		const payload = exportMemories({
 			dbPath: resolveDbPath(resolveDbOpt(opts)),
 			project: opts.project,

--- a/packages/cli/src/commands/import-memories.ts
+++ b/packages/cli/src/commands/import-memories.ts
@@ -2,11 +2,13 @@ import * as p from "@clack/prompts";
 import type { ExportPayload } from "@codemem/core";
 import { importMemories, readImportPayload, resolveDbPath } from "@codemem/core";
 import { Command } from "commander";
+import { invokedAsTopLevelAlias } from "../command-tree.js";
 import { helpStyle } from "../help-style.js";
 import {
 	addDbOption,
 	addJsonOption,
 	type DbOpts,
+	emitDeprecationWarning,
 	emitJsonError,
 	type JsonOpts,
 	resolveDbOpt,
@@ -31,6 +33,12 @@ cmd.action(
 				dryRun?: boolean;
 			},
 	) => {
+		// Keep visible for this first warned release; hide the alias in a later release.
+		// Suppressed in --json mode: the automation contract keeps stderr clean
+		// for successful JSON invocations (docs/cli-design-conventions.md).
+		if (!opts.json && invokedAsTopLevelAlias("import-memories")) {
+			emitDeprecationWarning("codemem import-memories", "codemem memory import");
+		}
 		let payload: ExportPayload;
 		try {
 			payload = readImportPayload(inputFile);

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1383,4 +1383,4 @@ syncCoordinatorAlias.hook("preAction", (_thisCmd: Command, actionCmd: Command) =
 	emitDeprecationWarning(`codemem sync coordinator ${subName}`, `codemem coordinator ${subName}`);
 });
 
-syncCommand.addCommand(syncCoordinatorAlias);
+syncCommand.addCommand(syncCoordinatorAlias, { hidden: true });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,36 +14,7 @@
 import { VERSION } from "@codemem/core";
 import { Command } from "commander";
 import omelette from "omelette";
-import { claudeHookFileContextCommand } from "./commands/claude-hook-file-context.js";
-import { claudeHookIngestCommand } from "./commands/claude-hook-ingest.js";
-import { claudeHookInjectCommand } from "./commands/claude-hook-inject.js";
-import { codexHookIngestCommand } from "./commands/codex-hook-ingest.js";
-import { codexHookInjectCommand } from "./commands/codex-hook-inject.js";
-import { configCommand } from "./commands/config.js";
-import { coordinatorCommand } from "./commands/coordinator.js";
-import { dbCommand } from "./commands/db.js";
-import { distillCommand } from "./commands/distill.js";
-import { embedCommand } from "./commands/embed.js";
-import { enqueueRawEventCommand } from "./commands/enqueue-raw-event.js";
-import { exportMemoriesCommand } from "./commands/export-memories.js";
-import { importMemoriesCommand } from "./commands/import-memories.js";
-import { maintenanceCommand } from "./commands/maintenance.js";
-import { mcpCommand } from "./commands/mcp.js";
-import {
-	forgetMemoryCommand,
-	memoryCommand,
-	rememberMemoryCommand,
-	showMemoryCommand,
-} from "./commands/memory.js";
-import { packCommand, promptPackLedgerCommand } from "./commands/pack.js";
-import { recentCommand } from "./commands/recent.js";
-import { searchCommand } from "./commands/search.js";
-import { serveCommand } from "./commands/serve.js";
-import { setupCommand } from "./commands/setup.js";
-import { statsCommand } from "./commands/stats.js";
-import { statusCommand } from "./commands/status.js";
-import { syncCommand } from "./commands/sync.js";
-import { versionCommand } from "./commands/version.js";
+import { ROOT_COMPLETION_COMMANDS, registerRootCommands } from "./command-tree.js";
 import { helpStyle } from "./help-style.js";
 
 type CompletionWithScriptGenerators = ReturnType<typeof omelette> & {
@@ -54,35 +25,7 @@ type CompletionWithScriptGenerators = ReturnType<typeof omelette> & {
 // Shell completion (bash/zsh/fish)
 const completion = omelette("codemem <command>") as CompletionWithScriptGenerators;
 completion.on("command", ({ reply }) => {
-	reply([
-		"claude-hook-file-context",
-		"claude-hook-inject",
-		"claude-hook-ingest",
-		"codex-hook-inject",
-		"codex-hook-ingest",
-		"config",
-		"coordinator",
-		"db",
-		"distill",
-		"embed",
-		"enqueue-raw-event",
-		"export-memories",
-		"import-memories",
-		"mcp",
-		"memory",
-		"pack",
-		"recent",
-		"search",
-		"serve",
-		"setup",
-		"stats",
-		"status",
-		"sync",
-		"version",
-		"help",
-		"--help",
-		"--version",
-	]);
+	reply([...ROOT_COMPLETION_COMMANDS]);
 });
 completion.init();
 
@@ -129,102 +72,6 @@ if (hasRootFlag("--cleanup-completion")) {
 	process.exit(0);
 }
 
-// --- Memory subcommands: export/import registered under `memory` group ---
-// Per cli-design-conventions.md, export/import belong under their noun group.
-// The top-level export-memories/import-memories remain as compatibility aliases.
-//
-// We create thin wrapper commands that replicate the same argument/option shape
-// and delegate to the original command's parseAsync with synthetic argv.
-// This avoids accessing Commander internals while keeping a single source of
-// truth for the action logic in the original command modules.
-{
-	// Slice the forwarded argv tail starting from the `memory <sub>` token pair
-	// rather than the first raw occurrence of the subcommand name. Anchoring on
-	// the `memory` group token first guarantees the subcommand token we slice
-	// from is the actual subcommand position, so a positional argument that
-	// happens to be literally "export" or "import" cannot shift the tail.
-	const forwardedTail = (subcommand: "export" | "import"): string[] => {
-		const argv = process.argv.slice(2);
-		const groupIdx = argv.indexOf("memory");
-		const searchFrom = groupIdx >= 0 ? groupIdx + 1 : 0;
-		const subIdx = argv.indexOf(subcommand, searchFrom);
-		return subIdx >= 0 ? argv.slice(subIdx + 1) : [];
-	};
-
-	const memExport = new Command("export")
-		.description("Export memories to a JSON file for sharing or backup")
-		.argument("<output>", "output file path (use '-' for stdout)")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--project <project>", "filter by project")
-		.option("--all-projects", "export all projects")
-		.option("--include-inactive", "include deactivated memories")
-		.option("--since <iso>", "only export memories created after this ISO timestamp")
-		.configureHelp(helpStyle)
-		.allowUnknownOption(true)
-		.allowExcessArguments(true)
-		.action(async () => {
-			// Forward to the original command by re-parsing the raw argv tail.
-			// `memory export <args>` → `export-memories <args>`
-			await exportMemoriesCommand.parseAsync([
-				"node",
-				"export-memories",
-				...forwardedTail("export"),
-			]);
-		});
-
-	const memImport = new Command("import")
-		.description("Import memories from an exported JSON file")
-		.argument("<inputFile>", "input JSON file (use '-' for stdin)")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--remap-project <path>", "remap all projects to this path on import")
-		.option("--dry-run", "preview import without writing")
-		.configureHelp(helpStyle)
-		.allowUnknownOption(true)
-		.allowExcessArguments(true)
-		.action(async () => {
-			await importMemoriesCommand.parseAsync([
-				"node",
-				"import-memories",
-				...forwardedTail("import"),
-			]);
-		});
-
-	memoryCommand.addCommand(memExport);
-	memoryCommand.addCommand(memImport);
-}
-
-program.addCommand(serveCommand);
-program.addCommand(configCommand);
-program.addCommand(coordinatorCommand);
-program.addCommand(mcpCommand);
-program.addCommand(claudeHookInjectCommand);
-program.addCommand(claudeHookIngestCommand);
-program.addCommand(claudeHookFileContextCommand);
-program.addCommand(codexHookInjectCommand);
-program.addCommand(codexHookIngestCommand);
-program.addCommand(dbCommand);
-program.addCommand(distillCommand);
-program.addCommand(exportMemoriesCommand);
-program.addCommand(importMemoriesCommand);
-program.addCommand(statsCommand);
-program.addCommand(statusCommand);
-program.addCommand(maintenanceCommand);
-program.addCommand(embedCommand);
-program.addCommand(recentCommand);
-program.addCommand(searchCommand);
-program.addCommand(packCommand);
-program.addCommand(promptPackLedgerCommand, { hidden: true });
-// Deprecated top-level aliases — use `memory show`, `memory forget`, `memory remember` instead.
-// These are hidden from --help and shell completion but still functional for backwards compat.
-program.addCommand(showMemoryCommand, { hidden: true });
-program.addCommand(forgetMemoryCommand, { hidden: true });
-program.addCommand(rememberMemoryCommand, { hidden: true });
-program.addCommand(memoryCommand);
-program.addCommand(syncCommand);
-program.addCommand(setupCommand);
-program.addCommand(enqueueRawEventCommand);
-program.addCommand(versionCommand);
+registerRootCommands(program);
 
 program.parse();


### PR DESCRIPTION
## Description

Final PR of the operational-status stack: makes the visible command tree, shell completion, docs, and compatibility policy agree.

- Root registration is extracted into `command-tree.ts` (`registerRootCommands` + `ROOT_COMPLETION_COMMANDS`) so the runtime entrypoint and the new assembled parity test share one source of truth; the test asserts visible⊆completion, completion⊆registered, and hidden-commands-stay-out-of-completion.
- Completion now includes `maintenance` (and `status` from PR3).
- The already-warned `sync coordinator` compatibility path is hidden from help; behavior, arguments, JSON, exit codes, and its stderr deprecation warning are unchanged.
- Top-level `export-memories`/`import-memories` now emit stderr deprecation warnings pointing at `codemem memory export`/`import`, fire only for the top-level alias invocation (never for the canonical `memory export`/`import` forwarding path), and remain visible in help and completion for this first warned release; the future hide target is recorded in code and README.
- Docs drift repaired: `sync start` guidance replaced with `serve start|stop|restart`; ~30 `codemem sync coordinator …` examples migrated to canonical `codemem coordinator …` with current `--coordinator-host`/`--coordinator-port` flags; required `--effect-id` added to every `grant/revoke-scope-member` example; `update-scope` added to the discovery surface list; e2e seeding switched to the canonical import path. No aliases were removed.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

New assembled command-tree parity tests plus alias-detection unit tests (including the `--` terminator and real-argv default). CLI smokes verified: root help shows `status`/`maintenance`/warned aliases, `sync --help` hides `coordinator`, top-level `export-memories` warns while `memory export` stays silent. Every doc example was verified against `coordinator.ts` signatures. Full workspace suite: 183 files, 3,988 tests, 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced