### PR TITLE
refactor(core): share one viewer health-probe contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Common overrides:
 Viewer note:
 
 - The plugin manages one explicit viewer target per runtime. If you run multiple viewers, give each one its own DB/runtime folder instead of sharing `viewer.pid` state next to the same SQLite file.
-- The OpenCode plugin monitors viewer liveness through `GET /api/health`. When an older viewer returns `404`, it makes one compatibility probe to the legacy raw-event status endpoint; raw-event ingest preflight remains separate.
+- The OpenCode plugin monitors viewer liveness through `GET /api/health`. When an older viewer returns `404`, it makes one compatibility probe to the legacy raw-event status endpoint; raw-event ingest preflight remains separate and is bounded by a 5-second timeout.
 
 The viewer includes a grouped Settings modal (`Connection`, `Processing`, `Device Sync`) with shell-agnostic labels and an advanced-controls toggle for technical fields.
 - Settings show effective values (configured or default) and only persist changed fields on save.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -330,7 +330,7 @@ events.
 - 10+ minutes of continuous work
 
 ### OpenCode stream reliability
-- Preflight check: `GET /api/raw-events/status` with periodic re-checks (`CODEMEM_RAW_EVENTS_STATUS_CHECK_MS`)
+- Preflight check: `GET /api/raw-events/status` with periodic re-checks (`CODEMEM_RAW_EVENTS_STATUS_CHECK_MS`), bounded by a 5-second timeout
 - Backoff on failure: configurable via `CODEMEM_RAW_EVENTS_BACKOFF_MS`; on stream failure the plugin can fall back to CLI enqueue for durable persistence
 - Once events are accepted by the viewer/store queue, flush workers handle retries
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -182,7 +182,7 @@ set -lx CODEMEM_VIEWER_HOST 127.0.0.1
 set -lx CODEMEM_VIEWER_PORT 38892
 ```
 
-The plugin now passes that explicit host/port through when it auto-starts, health-checks, stops, or restarts the viewer. Its liveness monitor requires a successful `GET /api/health` JSON response identifying `service: "codemem-viewer"`; `ready: false` still means the viewer process is live. For compatibility, only a `404` from the health route triggers one bounded probe of the legacy raw-event status endpoint. Raw-event ingest availability keeps its separate preflight behavior. Do not run multiple viewers against the same DB/runtime folder unless they intentionally share the same bind target; otherwise `viewer.pid` ownership becomes ambiguous.
+The plugin now passes that explicit host/port through when it auto-starts, health-checks, stops, or restarts the viewer. Its liveness monitor requires a successful `GET /api/health` JSON response identifying `service: "codemem-viewer"`; `ready: false` still means the viewer process is live. For compatibility, only a `404` from the health route triggers one bounded probe of the legacy raw-event status endpoint. Raw-event ingest availability keeps its separate preflight behavior, now bounded by a 5-second timeout so a hung viewer socket cannot stall event delivery. Do not run multiple viewers against the same DB/runtime folder unless they intentionally share the same bind target; otherwise `viewer.pid` ownership becomes ambiguous.
 
 If compatibility toasts appear after restart, follow the runner-specific guidance in Compatibility guidance behavior below.
 

--- a/packages/cli/.opencode/tests/plugin-probe-parity.test.js
+++ b/packages/cli/.opencode/tests/plugin-probe-parity.test.js
@@ -1,0 +1,156 @@
+// Contract parity between the plain-JS OpenCode plugin viewer monitor and the
+// shared TypeScript probe in @codemem/core (resolved to source via the
+// vitest alias in .opencode/vitest.config.ts). The plugin cannot import core
+// at runtime, so this test pins its hand-written copy to the core contract.
+import { probeCodememViewerLiveness } from "@codemem/core";
+import { describe, expect, test, vi } from "vitest";
+
+import { __testUtils } from "../plugins/codemem.js";
+
+const HEALTH_URL = "http://127.0.0.1:38888/api/health";
+const LEGACY_URL = "http://127.0.0.1:38888/api/raw-events/status?limit=1";
+
+const response = ({ status = 200, body = null } = {}) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json:
+    body instanceof Error
+      ? vi.fn().mockRejectedValue(body)
+      : vi.fn().mockResolvedValue(body),
+});
+
+const jsonResponse = (body, status = 200) =>
+  new Response(body === null ? null : JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const probeCore = async (fetchResult) => {
+  const fetchMock = vi.fn().mockImplementation(fetchResult);
+  const result = await probeCodememViewerLiveness(
+    { host: "127.0.0.1", port: 38_888 },
+    { fetch: fetchMock },
+  );
+  return { live: result.state === "live", urls: fetchMock.mock.calls.map((call) => call[0]) };
+};
+
+const probePlugin = async (fetchResult) => {
+  const fetchMock = vi.fn().mockImplementation(fetchResult);
+  const monitor = __testUtils.createViewerHealthMonitor({
+    viewerHealthUrl: HEALTH_URL,
+    legacyStatusUrl: LEGACY_URL,
+    isActive: () => true,
+    restartViewer: vi.fn(),
+    logLine: vi.fn().mockResolvedValue(undefined),
+    fetchFn: fetchMock,
+    timeoutSignal: vi.fn(() => ({ bounded: true })),
+  });
+  await monitor.check();
+  return {
+    live: monitor.state().consecutiveFailures === 0,
+    urls: fetchMock.mock.calls.map((call) => call[0]),
+  };
+};
+
+describe("plugin monitor stays in parity with the core probe contract", () => {
+  test.each([
+    ["healthy viewer", { service: "codemem-viewer", ready: true, database: { reachable: true } }, true],
+    ["degraded viewer (ready=false)", { service: "codemem-viewer", ready: false }, true],
+    ["viewer without readiness fields", { service: "codemem-viewer" }, true],
+    ["wrong service", { service: "other-service", ready: true }, false],
+    ["non-object payload", 42, false],
+  ])("health payload: %s → live=%s in both clients, without fallback", async (_case, body, expected) => {
+    const core = await probeCore(async () => jsonResponse(body));
+    expect(core.live).toBe(expected);
+    expect(core.urls).toEqual(["http://127.0.0.1:38888/api/health"]);
+
+    const plugin = await probePlugin(async () => response({ body }));
+    expect(plugin.live).toBe(expected);
+    expect(plugin.urls).toEqual([HEALTH_URL]);
+  });
+
+  test("server error (500) → not live in both clients, without fallback", async () => {
+    const core = await probeCore(async () => jsonResponse(null, 500));
+    expect(core.live).toBe(false);
+    expect(core.urls).toEqual(["http://127.0.0.1:38888/api/health"]);
+
+    const plugin = await probePlugin(async () => response({ status: 500 }));
+    expect(plugin.live).toBe(false);
+    expect(plugin.urls).toEqual([HEALTH_URL]);
+  });
+
+  test("network failure → not live in both clients, without fallback", async () => {
+    const reject = async () => {
+      throw new Error("connection refused");
+    };
+    const core = await probeCore(reject);
+    expect(core.live).toBe(false);
+    expect(core.urls).toHaveLength(1);
+
+    const plugin = await probePlugin(reject);
+    expect(plugin.live).toBe(false);
+    expect(plugin.urls).toHaveLength(1);
+  });
+
+  test("malformed health JSON → not live in both clients, without fallback", async () => {
+    const core = await probeCore(async () => new Response("{", { status: 200 }));
+    expect(core.live).toBe(false);
+    expect(core.urls).toHaveLength(1);
+
+    const plugin = await probePlugin(async () => response({ body: new SyntaxError("bad JSON") }));
+    expect(plugin.live).toBe(false);
+    expect(plugin.urls).toHaveLength(1);
+  });
+
+  test("404 with each client's identifying legacy evidence → live after one fallback", async () => {
+    const coreResponses = [jsonResponse(null, 404), jsonResponse({ viewer_pid: 1234 })];
+    const core = await probeCore(async () => coreResponses.shift());
+    expect(core.live).toBe(true);
+    expect(core.urls).toEqual([
+      "http://127.0.0.1:38888/api/health",
+      "http://127.0.0.1:38888/api/stats",
+    ]);
+
+    const pluginResponses = [
+      response({ status: 404 }),
+      response({ body: { ingest: { available: true } } }),
+    ];
+    const plugin = await probePlugin(async () => pluginResponses.shift());
+    expect(plugin.live).toBe(true);
+    expect(plugin.urls).toEqual([HEALTH_URL, LEGACY_URL]);
+  });
+
+  test("404 with unidentifiable legacy payloads → not live in both clients", async () => {
+    const coreResponses = [jsonResponse(null, 404), jsonResponse({ unrelated: true })];
+    const core = await probeCore(async () => coreResponses.shift());
+    expect(core.live).toBe(false);
+    expect(core.urls).toHaveLength(2);
+
+    const pluginResponses = [response({ status: 404 }), response({ body: { unrelated: true } })];
+    const plugin = await probePlugin(async () => pluginResponses.shift());
+    expect(plugin.live).toBe(false);
+    expect(plugin.urls).toHaveLength(2);
+  });
+});
+
+describe("raw-event ingest preflight", () => {
+  test("is bounded by a 5-second abort signal", async () => {
+    const boundedSignal = new AbortController().signal;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(boundedSignal);
+    try {
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValue(response({ body: { ingest: { available: true } } }));
+
+      await __testUtils.fetchRawEventsStatus(LEGACY_URL, fetchFn);
+
+      expect(timeoutSpy).toHaveBeenCalledWith(5_000);
+      expect(fetchFn).toHaveBeenCalledWith(
+        LEGACY_URL,
+        expect.objectContaining({ method: "GET", signal: boundedSignal }),
+      );
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cli/src/viewer-runtime.test.ts
+++ b/packages/cli/src/viewer-runtime.test.ts
@@ -3,7 +3,6 @@ import {
 	isLoopbackHost,
 	observeViewerRuntime,
 	parseViewerPidRecord,
-	probeCodememViewerLiveness,
 	type ViewerPidRecord,
 } from "./viewer-runtime.js";
 
@@ -38,112 +37,6 @@ describe("viewer PID records", () => {
 		expect(isLoopbackHost("127.0.0.2")).toBe(true);
 		expect(isLoopbackHost("[::1]")).toBe(true);
 		expect(isLoopbackHost("example.test")).toBe(false);
-	});
-});
-
-describe("probeCodememViewerLiveness", () => {
-	it("requires HTTP success and the codemem viewer discriminator", async () => {
-		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(healthy));
-
-		await expect(probeCodememViewerLiveness(record, { fetch: fetchMock })).resolves.toEqual({
-			state: "live",
-			degraded: false,
-		});
-	});
-
-	it("treats unready or database-unreachable health as degraded liveness", async () => {
-		for (const payload of [
-			{ ...healthy, ready: false },
-			{ ...healthy, database: { reachable: false } },
-		]) {
-			const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(payload));
-			await expect(probeCodememViewerLiveness(record, { fetch: fetchMock })).resolves.toEqual({
-				state: "live",
-				degraded: true,
-			});
-		}
-	});
-
-	it("falls back to stats exactly once only when health returns 404", async () => {
-		const fetchMock = vi
-			.fn<typeof fetch>()
-			.mockResolvedValueOnce(response(null, { status: 404 }))
-			.mockResolvedValueOnce(response({ viewer_pid: 1234 }));
-
-		await expect(probeCodememViewerLiveness(record, { fetch: fetchMock })).resolves.toEqual({
-			state: "live",
-			degraded: false,
-		});
-		expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
-			"http://127.0.0.1:38888/api/health",
-			"http://127.0.0.1:38888/api/stats",
-		]);
-		expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
-		expect(fetchMock.mock.calls[1]?.[1]?.signal).toBeInstanceOf(AbortSignal);
-		// The fallback gets its own timeout budget rather than the residual
-		// budget of the health request.
-		expect(fetchMock.mock.calls[1]?.[1]?.signal).not.toBe(fetchMock.mock.calls[0]?.[1]?.signal);
-	});
-
-	it.each([
-		["a server error", response(null, { status: 500 })],
-		["a missing viewer_pid", response({ database: {}, usage: {} })],
-		["an invalid viewer_pid", response({ viewer_pid: "1234" })],
-		["malformed JSON", new Response("{", { status: 200 })],
-	])("reports unavailable when the legacy fallback returns %s", async (_case, statsResponse) => {
-		const fetchMock = vi
-			.fn<typeof fetch>()
-			.mockResolvedValueOnce(response(null, { status: 404 }))
-			.mockResolvedValueOnce(statsResponse);
-
-		await expect(probeCodememViewerLiveness(record, { fetch: fetchMock })).resolves.toEqual({
-			state: "unavailable",
-			reason: "unexpected_response",
-		});
-		expect(fetchMock).toHaveBeenCalledTimes(2);
-	});
-
-	it("treats absent readiness fields as degraded liveness, not unavailability", async () => {
-		const fetchMock = vi
-			.fn<typeof fetch>()
-			.mockResolvedValue(response({ service: "codemem-viewer" }));
-
-		await expect(probeCodememViewerLiveness(record, { fetch: fetchMock })).resolves.toEqual({
-			state: "live",
-			degraded: true,
-		});
-	});
-
-	it("does not fall back for wrong-service, malformed, 500, or network failures", async () => {
-		const cases: Array<() => Promise<Response>> = [
-			async () => response({ ...healthy, service: "other-service" }),
-			async () => new Response("{", { status: 200 }),
-			async () => response(null, { status: 500 }),
-			async () => {
-				throw new Error("connection refused");
-			},
-		];
-
-		for (const result of cases) {
-			const fetchMock = vi.fn<typeof fetch>().mockImplementation(result);
-			const observed = await probeCodememViewerLiveness(record, { fetch: fetchMock });
-			expect(observed.state).toBe("unavailable");
-			expect(fetchMock).toHaveBeenCalledTimes(1);
-		}
-	});
-
-	it("honors the caller-provided timeout", async () => {
-		const timeoutSignal = new AbortController().signal;
-		const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
-		try {
-			const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(healthy));
-			await probeCodememViewerLiveness(record, { fetch: fetchMock, timeoutMs: 25 });
-
-			expect(timeoutSpy).toHaveBeenCalledWith(25);
-			expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(timeoutSignal);
-		} finally {
-			timeoutSpy.mockRestore();
-		}
 	});
 });
 

--- a/packages/cli/src/viewer-runtime.ts
+++ b/packages/cli/src/viewer-runtime.ts
@@ -1,3 +1,9 @@
+import { probeCodememViewerLiveness, type ViewerLivenessProbeDependencies } from "@codemem/core";
+
+// The probe contract lives in @codemem/core so the CLI and MCP server share
+// one implementation; re-export it for existing CLI consumers.
+export { probeCodememViewerLiveness, viewerUrl } from "@codemem/core";
+
 export interface ViewerPidRecord {
 	pid: number;
 	host: string;
@@ -23,21 +29,9 @@ export interface ViewerRuntimeObservation {
 		| "viewer_wrong_service";
 }
 
-export interface ViewerLivenessProbeDependencies {
-	fetch: typeof fetch;
-	timeoutMs?: number;
-}
-
 export interface ViewerProbeDependencies extends ViewerLivenessProbeDependencies {
 	isProcessRunning: (pid: number) => boolean | null;
 }
-
-export type ViewerLivenessProbeResult =
-	| { state: "live"; degraded: boolean }
-	| {
-			state: "unavailable";
-			reason: "unexpected_response" | "wrong_service" | "unreachable";
-	  };
 
 function isValidPid(value: unknown): value is number {
 	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
@@ -99,82 +93,6 @@ export function isLoopbackHost(host: string): boolean {
 }
 
 export type ViewerProbeTarget = Pick<ViewerPidRecord, "host" | "port"> & { pid?: number };
-
-export function viewerUrl(record: ViewerProbeTarget, pathname: string): string {
-	const host =
-		record.host.includes(":") && !record.host.startsWith("[") ? `[${record.host}]` : record.host;
-	return `http://${host}:${record.port}${pathname}`;
-}
-
-async function request(
-	deps: ViewerLivenessProbeDependencies,
-	record: ViewerProbeTarget,
-	pathname: string,
-): Promise<Response> {
-	// Each request gets a fresh timeout budget so the 404 compatibility
-	// fallback is not starved by time already spent on the health request.
-	// MCP and OpenCode plugin probes use the same per-request semantics.
-	return deps.fetch(viewerUrl(record, pathname), {
-		method: "GET",
-		signal: AbortSignal.timeout(deps.timeoutMs ?? 750),
-	});
-}
-
-async function isCodememStatsResponse(response: Response): Promise<boolean> {
-	if (!response.ok) return false;
-	try {
-		const payload: unknown = await response.json();
-		if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
-		const viewerPid = (payload as { viewer_pid?: unknown }).viewer_pid;
-		return typeof viewerPid === "number" && Number.isSafeInteger(viewerPid) && viewerPid > 0;
-	} catch {
-		return false;
-	}
-}
-
-export async function probeCodememViewerLiveness(
-	record: ViewerProbeTarget,
-	deps: ViewerLivenessProbeDependencies,
-): Promise<ViewerLivenessProbeResult> {
-	try {
-		const health = await request(deps, record, "/api/health");
-		if (health.status === 404) {
-			const stats = await request(deps, record, "/api/stats");
-			return (await isCodememStatsResponse(stats))
-				? { state: "live", degraded: false }
-				: { state: "unavailable", reason: "unexpected_response" };
-		}
-		if (!health.ok) return { state: "unavailable", reason: "unexpected_response" };
-
-		let payload: unknown;
-		try {
-			payload = await health.json();
-		} catch {
-			return { state: "unavailable", reason: "unexpected_response" };
-		}
-		if (!payload || typeof payload !== "object") {
-			return { state: "unavailable", reason: "unexpected_response" };
-		}
-		const healthPayload = payload as {
-			service?: unknown;
-			ready?: unknown;
-			database?: { reachable?: unknown };
-		};
-		if (healthPayload.service !== "codemem-viewer") {
-			return { state: "unavailable", reason: "wrong_service" };
-		}
-		// Liveness is HTTP success plus the service discriminator; `ready` and
-		// `database.reachable` are readiness only. Absent or non-boolean
-		// readiness fields degrade the observation instead of denying
-		// liveness so the health contract stays additive.
-		return {
-			state: "live",
-			degraded: healthPayload.ready !== true || healthPayload.database?.reachable !== true,
-		};
-	} catch {
-		return { state: "unavailable", reason: "unreachable" };
-	}
-}
 
 export async function observeViewerRuntime(
 	parsed: ParsedViewerPidRecord,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1170,3 +1170,13 @@ export {
 	semanticSearch,
 	storeVectors,
 } from "./vectors.js";
+export type {
+	ViewerLivenessProbeDependencies,
+	ViewerLivenessProbeResult,
+	ViewerTarget,
+} from "./viewer-probe.js";
+export {
+	probeCodememViewerLiveness,
+	VIEWER_SERVICE_DISCRIMINATOR,
+	viewerUrl,
+} from "./viewer-probe.js";

--- a/packages/core/src/viewer-probe.test.ts
+++ b/packages/core/src/viewer-probe.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import { probeCodememViewerLiveness, viewerUrl } from "./viewer-probe.js";
+
+const target = { host: "127.0.0.1", port: 38_888 };
+const healthy = {
+	service: "codemem-viewer",
+	ready: true,
+	database: { reachable: true },
+};
+
+function response(body: unknown, init: ResponseInit = {}): Response {
+	return new Response(body == null ? null : JSON.stringify(body), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+		...init,
+	});
+}
+
+describe("viewerUrl", () => {
+	it("brackets IPv6 hosts and leaves others untouched", () => {
+		expect(viewerUrl(target, "/api/health")).toBe("http://127.0.0.1:38888/api/health");
+		expect(viewerUrl({ host: "::1", port: 38_888 }, "/api/health")).toBe(
+			"http://[::1]:38888/api/health",
+		);
+		expect(viewerUrl({ host: "[::1]", port: 38_888 }, "/api/health")).toBe(
+			"http://[::1]:38888/api/health",
+		);
+	});
+});
+
+describe("probeCodememViewerLiveness", () => {
+	it("requires HTTP success and the codemem viewer discriminator", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(healthy));
+
+		await expect(probeCodememViewerLiveness(target, { fetch: fetchMock })).resolves.toEqual({
+			state: "live",
+			degraded: false,
+		});
+		expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.1:38888/api/health");
+	});
+
+	it("treats unready or database-unreachable health as degraded liveness", async () => {
+		for (const payload of [
+			{ ...healthy, ready: false },
+			{ ...healthy, database: { reachable: false } },
+			{ service: "codemem-viewer" },
+		]) {
+			const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(payload));
+			await expect(probeCodememViewerLiveness(target, { fetch: fetchMock })).resolves.toEqual({
+				state: "live",
+				degraded: true,
+			});
+		}
+	});
+
+	it("falls back to stats exactly once only when health returns 404", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(response(null, { status: 404 }))
+			.mockResolvedValueOnce(response({ viewer_pid: 1234 }));
+
+		await expect(probeCodememViewerLiveness(target, { fetch: fetchMock })).resolves.toEqual({
+			state: "live",
+			degraded: false,
+		});
+		expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+			"http://127.0.0.1:38888/api/health",
+			"http://127.0.0.1:38888/api/stats",
+		]);
+		// The fallback gets its own timeout budget rather than the residual
+		// budget of the health request.
+		expect(fetchMock.mock.calls[1]?.[1]?.signal).not.toBe(fetchMock.mock.calls[0]?.[1]?.signal);
+	});
+
+	it.each([
+		["a server error", response(null, { status: 500 })],
+		["a missing viewer_pid", response({ database: {}, usage: {} })],
+		["an invalid viewer_pid", response({ viewer_pid: "1234" })],
+		["malformed JSON", new Response("{", { status: 200 })],
+	])("reports unavailable when the legacy fallback returns %s", async (_case, statsResponse) => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(response(null, { status: 404 }))
+			.mockResolvedValueOnce(statsResponse);
+
+		await expect(probeCodememViewerLiveness(target, { fetch: fetchMock })).resolves.toEqual({
+			state: "unavailable",
+			reason: "unexpected_response",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not fall back for wrong-service, malformed, 500, or network failures", async () => {
+		const cases: Array<[() => Promise<Response>, string]> = [
+			[async () => response({ ...healthy, service: "other-service" }), "wrong_service"],
+			[async () => new Response("{", { status: 200 }), "unexpected_response"],
+			[async () => response(null, { status: 500 }), "unexpected_response"],
+			[
+				async () => {
+					throw new Error("connection refused");
+				},
+				"unreachable",
+			],
+		];
+
+		for (const [result, reason] of cases) {
+			const fetchMock = vi.fn<typeof fetch>().mockImplementation(result);
+			await expect(probeCodememViewerLiveness(target, { fetch: fetchMock })).resolves.toEqual({
+				state: "unavailable",
+				reason,
+			});
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+		}
+	});
+
+	it("honors the caller-provided timeout and the 750ms default", async () => {
+		const timeoutSignal = new AbortController().signal;
+		const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+		try {
+			const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(healthy));
+			await probeCodememViewerLiveness(target, { fetch: fetchMock, timeoutMs: 25 });
+
+			expect(timeoutSpy).toHaveBeenCalledWith(25);
+			expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(timeoutSignal);
+
+			timeoutSpy.mockClear();
+			await probeCodememViewerLiveness(target, {
+				fetch: vi.fn<typeof fetch>().mockResolvedValue(response(healthy)),
+			});
+			expect(timeoutSpy).toHaveBeenCalledWith(750);
+		} finally {
+			timeoutSpy.mockRestore();
+		}
+	});
+});

--- a/packages/core/src/viewer-probe.ts
+++ b/packages/core/src/viewer-probe.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared viewer liveness-probe contract.
+ *
+ * One implementation of the health-first probe used by every TypeScript
+ * client (CLI `status`/`serve` lifecycle and the MCP stdio server):
+ *
+ * - Liveness requires HTTP success on `GET /api/health` plus the
+ *   `codemem-viewer` service discriminator.
+ * - `ready`/`database.reachable` are readiness only: a running-but-unready
+ *   viewer is live and degraded, never restart-worthy.
+ * - Exactly one old-viewer compatibility request to `GET /api/stats` is made,
+ *   and only when the health route returns 404. The fallback requires the
+ *   legacy payload's identifying `viewer_pid` evidence.
+ * - Wrong service, malformed payloads, other HTTP errors, timeouts, and
+ *   network failures never fall back.
+ *
+ * The plain-JS OpenCode plugin cannot import this module; its equivalent
+ * monitor is pinned by a contract parity test in
+ * `packages/cli/.opencode/tests/plugin-probe-parity.test.js`.
+ */
+
+/** Stable service discriminator returned by `GET /api/health`. */
+export const VIEWER_SERVICE_DISCRIMINATOR = "codemem-viewer";
+
+export interface ViewerTarget {
+	host: string;
+	port: number;
+}
+
+export interface ViewerLivenessProbeDependencies {
+	fetch: typeof fetch;
+	timeoutMs?: number;
+}
+
+export type ViewerLivenessProbeResult =
+	| { state: "live"; degraded: boolean }
+	| {
+			state: "unavailable";
+			reason: "unexpected_response" | "wrong_service" | "unreachable";
+	  };
+
+/**
+ * Build a viewer URL with IPv6-safe host bracketing.
+ *
+ * Performs no host validation — callers own the trust gate (e.g. the CLI's
+ * loopback-only check before probing PID-record hosts).
+ */
+export function viewerUrl(target: ViewerTarget, pathname: string): string {
+	const host =
+		target.host.includes(":") && !target.host.startsWith("[") ? `[${target.host}]` : target.host;
+	return `http://${host}:${target.port}${pathname}`;
+}
+
+async function request(
+	deps: ViewerLivenessProbeDependencies,
+	target: ViewerTarget,
+	pathname: string,
+): Promise<Response> {
+	// Each request gets a fresh timeout budget so the 404 compatibility
+	// fallback is not starved by time already spent on the health request.
+	return deps.fetch(viewerUrl(target, pathname), {
+		method: "GET",
+		signal: AbortSignal.timeout(deps.timeoutMs ?? 750),
+	});
+}
+
+/** Release an unread response body without surfacing cancellation failures. */
+function discardBody(response: Response): void {
+	try {
+		response.body?.cancel().catch(() => {});
+	} catch {
+		// Best effort — a locked or already-errored stream is fine to abandon.
+	}
+}
+
+async function isLegacyViewerStatsResponse(response: Response): Promise<boolean> {
+	if (!response.ok) {
+		discardBody(response);
+		return false;
+	}
+	try {
+		const payload: unknown = await response.json();
+		if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+		const viewerPid = (payload as { viewer_pid?: unknown }).viewer_pid;
+		return typeof viewerPid === "number" && Number.isSafeInteger(viewerPid) && viewerPid > 0;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Probe a viewer target for liveness. Never throws; failures map to bounded
+ * `unavailable` observations.
+ */
+export async function probeCodememViewerLiveness(
+	target: ViewerTarget,
+	deps: ViewerLivenessProbeDependencies,
+): Promise<ViewerLivenessProbeResult> {
+	try {
+		const health = await request(deps, target, "/api/health");
+		if (health.status === 404) {
+			// Release the unread body so repeated probes cannot pin connections.
+			discardBody(health);
+			// Old-viewer compatibility: every released viewer's stats payload
+			// includes `viewer_pid`, so require that identifying evidence
+			// rather than trusting any 2xx from an arbitrary local service.
+			const stats = await request(deps, target, "/api/stats");
+			return (await isLegacyViewerStatsResponse(stats))
+				? { state: "live", degraded: false }
+				: { state: "unavailable", reason: "unexpected_response" };
+		}
+		if (!health.ok) {
+			discardBody(health);
+			return { state: "unavailable", reason: "unexpected_response" };
+		}
+
+		let payload: unknown;
+		try {
+			payload = await health.json();
+		} catch {
+			return { state: "unavailable", reason: "unexpected_response" };
+		}
+		if (!payload || typeof payload !== "object") {
+			return { state: "unavailable", reason: "unexpected_response" };
+		}
+		const healthPayload = payload as {
+			service?: unknown;
+			ready?: unknown;
+			database?: { reachable?: unknown };
+		};
+		if (healthPayload.service !== VIEWER_SERVICE_DISCRIMINATOR) {
+			return { state: "unavailable", reason: "wrong_service" };
+		}
+		// Liveness is HTTP success plus the service discriminator; `ready` and
+		// `database.reachable` are readiness only. Absent or non-boolean
+		// readiness fields degrade the observation instead of denying
+		// liveness so the health contract stays additive.
+		return {
+			state: "live",
+			degraded: healthPayload.ready !== true || healthPayload.database?.reachable !== true,
+		};
+	} catch {
+		return { state: "unavailable", reason: "unreachable" };
+	}
+}

--- a/packages/mcp-server/src/stdio-viewer.ts
+++ b/packages/mcp-server/src/stdio-viewer.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { probeCodememViewerLiveness } from "@codemem/core";
 
 const DEFAULT_VIEWER_HOST = "127.0.0.1";
 const DEFAULT_VIEWER_PORT = "38888";
@@ -51,46 +52,22 @@ export function resolveCliPath(): string | null {
 	return "codemem";
 }
 
-/** Check for a live CodeMem viewer, with one old-viewer compatibility probe on health 404. */
+/** Check for a live CodeMem viewer via the shared core probe contract. */
 export async function isViewerHealthy(options: ViewerProbeOptions = {}): Promise<boolean> {
 	const host = options.host ?? process.env.CODEMEM_VIEWER_HOST ?? DEFAULT_VIEWER_HOST;
-	const port = options.port ?? process.env.CODEMEM_VIEWER_PORT ?? DEFAULT_VIEWER_PORT;
-	const fetchImpl = options.fetchImpl ?? fetch;
-	const baseUrl = `http://${host}:${port}`;
+	const rawPort = options.port ?? process.env.CODEMEM_VIEWER_PORT ?? DEFAULT_VIEWER_PORT;
+	// Strict parse: "38888abc" must not silently probe a different port than
+	// the `--port` value forwarded to `serve start`.
+	if (!/^\d+$/.test(rawPort.trim())) return false;
+	const port = Number.parseInt(rawPort, 10);
+	if (!Number.isInteger(port) || port <= 0 || port > 65_535) return false;
 
-	try {
-		const response = await fetchImpl(`${baseUrl}/api/health`, {
-			signal: AbortSignal.timeout(VIEWER_PROBE_TIMEOUT_MS),
-		});
-		if (response.status === 404) {
-			// Old-viewer compatibility: every released viewer's stats payload
-			// includes `viewer_pid`, so require that identifying evidence
-			// rather than trusting any 2xx from an arbitrary local service.
-			const compatibilityResponse = await fetchImpl(`${baseUrl}/api/stats`, {
-				signal: AbortSignal.timeout(VIEWER_PROBE_TIMEOUT_MS),
-			});
-			if (!compatibilityResponse.ok) return false;
-			try {
-				const stats: unknown = await compatibilityResponse.json();
-				if (!stats || typeof stats !== "object" || Array.isArray(stats)) return false;
-				const viewerPid = (stats as { viewer_pid?: unknown }).viewer_pid;
-				return typeof viewerPid === "number" && Number.isSafeInteger(viewerPid) && viewerPid > 0;
-			} catch {
-				return false;
-			}
-		}
-		if (!response.ok) return false;
-
-		const body: unknown = await response.json();
-		return (
-			typeof body === "object" &&
-			body !== null &&
-			"service" in body &&
-			body.service === "codemem-viewer"
-		);
-	} catch {
-		return false;
-	}
+	// A degraded-but-live viewer must not trigger redundant detached starts.
+	const probe = await probeCodememViewerLiveness(
+		{ host, port },
+		{ fetch: options.fetchImpl ?? fetch, timeoutMs: VIEWER_PROBE_TIMEOUT_MS },
+	);
+	return probe.state === "live";
 }
 
 /** Attempt to start the viewer as a detached, best-effort background process. */

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -28,8 +28,30 @@ const VIEWER_HEALTH_CHECK_INTERVAL_MS = 60_000;
 const VIEWER_HEALTH_TIMEOUT_MS = 5_000;
 const VIEWER_HEALTH_RESTART_THRESHOLD = 3;
 const VIEWER_HEALTH_RESTART_COOLDOWN_MS = 5 * 60_000;
+const RAW_EVENTS_STATUS_TIMEOUT_MS = 5_000;
 
 let compatCheckCache = null;
+
+// Release an unread response body without surfacing cancellation failures.
+const discardResponseBody = (response) => {
+  try {
+    const cancelled = response?.body?.cancel?.();
+    if (cancelled && typeof cancelled.catch === "function") {
+      cancelled.catch(() => {});
+    }
+  } catch {
+    // Best effort — a locked or already-errored stream is fine to abandon.
+  }
+};
+
+// Bounded ingest-availability preflight: a hung viewer socket must not stall
+// raw-event delivery indefinitely. Failures fall into the existing stream
+// backoff + CLI enqueue fallback path.
+const fetchRawEventsStatus = (url, fetchFn = fetch) =>
+  fetchFn(url, {
+    method: "GET",
+    signal: AbortSignal.timeout(RAW_EVENTS_STATUS_TIMEOUT_MS),
+  });
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>
@@ -67,7 +89,7 @@ const createViewerHealthMonitor = ({
     }
 
     if (response.status === 404) {
-      void response.body?.cancel?.();
+      discardResponseBody(response);
       try {
         // Old-viewer compatibility: released viewers serving this route
         // always include the `ingest` availability object, so require that
@@ -75,7 +97,7 @@ const createViewerHealthMonitor = ({
         // arbitrary local service.
         const fallbackResponse = await boundedFetch(legacyStatusUrl);
         if (!fallbackResponse.ok) {
-          void fallbackResponse.body?.cancel?.();
+          discardResponseBody(fallbackResponse);
           return { live: false, detail: `fallback status=${fallbackResponse.status}` };
         }
         const fallbackPayload = await fallbackResponse.json();
@@ -95,7 +117,7 @@ const createViewerHealthMonitor = ({
     if (!response.ok) {
       // Release the unread body so a persistently failing viewer does not
       // pin connections across the 60s monitor interval.
-      void response.body?.cancel?.();
+      discardResponseBody(response);
       return { live: false, detail: `status=${response.status}` };
     }
 
@@ -1840,8 +1862,10 @@ export const OpencodeMemPlugin = async ({
     }
     try {
       if (now - lastStatusCheckAt >= Math.max(1000, rawEventsStatusCheckMs)) {
-        const statusResp = await fetch(rawEventsStatusUrl, { method: "GET" });
+        const statusResp = await fetchRawEventsStatus(rawEventsStatusUrl);
         if (!statusResp.ok) {
+          // Release the unread body before bailing into the backoff path.
+          discardResponseBody(statusResp);
           throw new Error(`raw-events status failed (${statusResp.status})`);
         }
         const statusJson = await statusResp.json();
@@ -3705,6 +3729,7 @@ export const OpencodeMemPlugin = async ({
 export default OpencodeMemPlugin;
 export const __testUtils = {
   PINNED_BACKEND_VERSION,
+  fetchRawEventsStatus,
   inferProjectFromCwd,
   normalizeProjectLabel,
   resolveProjectName,

--- a/packages/viewer-server/src/routes/health.ts
+++ b/packages/viewer-server/src/routes/health.ts
@@ -1,4 +1,4 @@
-import { type MemoryStore, VERSION } from "@codemem/core";
+import { type MemoryStore, VERSION, VIEWER_SERVICE_DISCRIMINATOR } from "@codemem/core";
 import { Hono } from "hono";
 
 type StoreFactory = () => MemoryStore;
@@ -19,7 +19,9 @@ export function healthRoutes(getStore: StoreFactory) {
 		const reachable = databaseReachable(getStore);
 		c.header("Cache-Control", "no-store");
 		return c.json({
-			service: "codemem-viewer",
+			// Bound to the shared probe contract so producer and clients
+			// cannot drift independently.
+			service: VIEWER_SERVICE_DISCRIMINATOR,
 			version: VERSION,
 			pid: process.pid,
 			uptime_ms: Math.max(0, Math.floor(process.uptime() * 1_000)),


### PR DESCRIPTION
## Description

Follow-up `codemem-9xv2` from the operational-status stack: the viewer liveness probe previously existed as three hand-written copies (CLI, MCP, plugin) that had already drifted once during review. This hoists one canonical implementation into `@codemem/core` (`viewer-probe.ts`): health-first probing with the `codemem-viewer` discriminator (now also consumed by the viewer health route, so producer and clients cannot drift), degraded-not-dead readiness, per-request timeout budgets, exactly one 404-only `/api/stats` fallback requiring `viewer_pid` evidence, unread-body cleanup, and no-throw bounded failures.

The CLI (`viewer-runtime.ts`) and MCP (`stdio-viewer.ts`) now consume the core probe (MCP gains strict port parsing and IPv6-safe URLs; its 2s timeout and degraded-is-live semantics are preserved). The plain-JS OpenCode plugin cannot import core, so its monitor copy is pinned by a new cross-client parity test that runs a shared payload matrix through both implementations and asserts identical liveness classification, request counts, and probe URLs.

Also closes the last unbounded plugin fetch: the raw-event ingest preflight now carries a 5-second `AbortSignal.timeout` (failures continue into the existing backoff + CLI-enqueue fallback path).

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Probe contract tests moved to core (including the previously unpinned 750ms default). New parity suite covers healthy/degraded/absent-readiness/wrong-service/malformed/5xx/network plus per-client 404 fallback evidence, with URL and call-count assertions, and pins the 5s preflight bound. Existing CLI/MCP/plugin/viewer-server suites pass unchanged. Full workspace: 185 files, 4,013 tests, 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced