### PR TITLE
feat(update): add release discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | | `codemem sync once` | Run one immediate sync pass |
 | | `codemem sync doctor` | Diagnose sync configuration issues |
 | | `codemem sync bootstrap` | Bootstrap sync from a peer snapshot |
+| **Updates** | `codemem update check` | Check the npm registry for a newer stable release (`--json` and `--refresh` supported) |
 | **Coordinator** | `codemem coordinator` | Self-hosted coordinator admin (groups, devices, invites) |
 | **Database** | `codemem db prune-memories` | Deactivate low-signal memories (`--dry-run` to preview) |
 | | `codemem db prune-observations` | Deactivate low-signal observations |
@@ -183,6 +184,10 @@ peers, coordinators, registries, or non-loopback hosts. Use `codemem status --js
 for the stable machine-readable report. `codemem stats` remains the inventory and
 usage command; use `sync status`/`sync doctor`, `maintenance status`, and
 `db raw-events-status` for subsystem detail.
+
+`codemem update check` is read-only: it reports the latest validated stable release and
+installation-specific guidance but never installs anything. Results are cached for six hours;
+pass `--refresh` to force a registry request or `--json` for one stable status object.
 
 Pack rendering defaults to self-contained context. For token-constrained experiments, `codemem pack <context> --compact` renders an index plus top details. Near-related compression is controlled by `--compression-mode off|compact|ids` (or `CODEMEM_PACK_COMPRESSION`); MCP `memory_pack` exposes the same setting as `compression_mode`. Use `ids` only when the agent can follow up with `memory_get_observations`.
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM node:24-bookworm-slim
 ARG CODEMEM_VERSION=latest
 
 ENV NODE_ENV=production
+ENV CODEMEM_INSTALL_KIND=docker
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends ca-certificates make g++ python3 tini \

--- a/docs/plans/2026-08-10-release-discovery-and-update-notifications-design.md
+++ b/docs/plans/2026-08-10-release-discovery-and-update-notifications-design.md
@@ -1,0 +1,126 @@
+# Release Discovery and Update Notifications
+
+## Status
+
+Approved for implementation on 2026-08-10.
+
+## Problem
+
+Codemem's existing backend compatibility check compares the active runtime with a configured minimum version. It does not discover newer stable releases. As a result, healthy installations can remain several releases behind without notifying users, and operators must inspect and upgrade every device manually.
+
+## Goals
+
+- Notify users when a newer stable Codemem release is available.
+- Expose the same release status through the CLI, OpenCode plugin, and Viewer.
+- Show optional runtime versions for paired devices so fleet drift is visible.
+- Support opt-in automatic updates for eligible npm installations.
+- Give Docker operators exact rebuild guidance without granting Codemem access to the Docker socket.
+
+## Non-goals
+
+- Remote command execution or fleet-wide unattended orchestration.
+- Automatic Docker image or container replacement.
+- Updating repository-development, pinned, prerelease, downgrade, or unknown installations.
+- Using reported runtime versions for authorization, trust, or protocol negotiation.
+- Replacing the existing minimum-version compatibility check.
+
+## Product policy
+
+`notify` remains the default update policy. `auto` requires explicit configuration. Notifications can appear as soon as a newer stable release is discovered, while automatic installation requires the release to have been observed for at least 24 hours.
+
+The existing `CODEMEM_BACKEND_UPDATE_POLICY` values remain the policy surface:
+
+- `notify`: report newer stable releases and provide an installation-specific action.
+- `auto`: notify immediately, then install only after the first-seen delay when the runner is eligible.
+- `off`: perform no user-facing release notification or automatic installation.
+
+Compatibility-floor checks remain separate and continue to run even though they share the policy value.
+
+## Architecture
+
+### Shared release discovery
+
+`@codemem/core` owns a leaf release-discovery module with no store, SQLite, sync, or embedding dependencies. The module:
+
+- Queries the fixed npm registry endpoint for `codemem`.
+- Accepts only bounded, stable semantic versions.
+- Uses an injected fetch implementation and clock for deterministic tests.
+- Applies a short timeout, process-local single-flight behavior, and a six-hour refresh interval.
+- Persists disposable device-local cache state under the Codemem home directory using an atomic write.
+- Records when the current latest version was first observed.
+- Reuses a valid stale cache after refresh failure but never authorizes an automatic update from failed or malformed refresh data.
+
+The shared result uses a stable, additive JSON contract:
+
+```ts
+interface UpdateStatus {
+  current_version: string;
+  latest_version: string | null;
+  update_available: boolean;
+  first_seen_at: string | null;
+  checked_at: string | null;
+  stale: boolean;
+  install_kind: "npm-global" | "npx" | "docker" | "repo-dev" | "pinned" | "unknown";
+  auto_update_eligible: boolean;
+  recommended_action: string;
+  error: string | null;
+}
+```
+
+### CLI
+
+`codemem update check` is the canonical human and automation surface. It supports `--json` and `--refresh`. Human output explains whether the installation is current and what to do next. JSON output is one stable object. An unavailable check returns structured failure output and a non-zero exit code unless valid stale status can answer the request.
+
+The later automatic-update slice adds `codemem update install`. It refuses ineligible installation kinds before executing anything.
+
+### Plugin and Viewer
+
+The OpenCode plugin invokes the CLI update check through its existing runner boundary rather than importing core. Release notifications are distinct from compatibility warnings and are rate-limited to once per discovered release. The plugin reuses its existing argv-based process execution and guarded viewer restart path.
+
+The Viewer exposes a dedicated update-status route. `/api/runtime` remains a local readiness endpoint and never performs registry work. The Health page renders current, available, stale, and unavailable states with installation-specific guidance.
+
+### Peer runtime versions
+
+The signed peer status response may include an optional `runtime_version`. Receivers validate its length and stable-semver shape after the existing peer identity and fingerprint checks, then persist it in nullable additive peer columns. Missing or malformed values become unknown.
+
+The Devices UI may display a paired peer's reported version. The value is informational only and must not participate in capability negotiation, trust seeding, authorization, or update execution.
+
+### Installation kinds
+
+- `npm-global`: eligible for opt-in automatic installation.
+- `npx`: receives runner-specific guidance; automatic behavior is allowed only where the existing updater can prove an unpinned generic source.
+- `docker`: never self-updates; guidance names the durable version pin and Compose rebuild/start workflow.
+- `repo-dev`, `pinned`, and `unknown`: never self-update.
+
+Detection fails closed to `unknown`. Docker images set an explicit installation-kind marker rather than relying exclusively on filesystem heuristics.
+
+## Failure and security behavior
+
+- Registry access uses a fixed HTTPS origin and strict response validation.
+- Fetch, cache, and toast failures never block plugin or Viewer startup.
+- Cache writes are atomic; malformed cache content is ignored.
+- Stale cache data may inform a notification but cannot trigger installation.
+- Automatic updates never select prereleases, downgrades, or versions other than the validated latest stable release.
+- Commands are executable-plus-argv arrays and never shell strings.
+- Successful installation is verified by querying the active CLI version.
+- Viewer restart is attempted only when the plugin started and owns that viewer lifecycle.
+- Docker and unknown environments return guidance instead of executing a process.
+
+## Validation
+
+- Release resolver unit tests cover semantic versions, first-seen transitions, cache expiry, stale fallback, malformed data, timeout, atomic-write failure, and single-flight behavior.
+- CLI tests cover human output, JSON output, forced refresh, stale success, and structured failure.
+- Plugin tests cover `notify`, `off`, delayed `auto`, ineligible runners, failed installation, verification, and guarded restart.
+- Viewer tests cover the route contract and Health banner states.
+- Sync tests cover current, missing legacy, oversized, malformed, and untrusted reported versions.
+- Devices tests cover version presentation without changing device identity or status behavior.
+- Each stack slice runs focused tests; the complete stack runs the UI build and `pnpm run check`.
+
+## Delivery stack
+
+1. `feat(update): add release discovery`
+2. `feat(update): surface release notifications`
+3. `feat(sync): report peer runtime versions`
+4. `feat(update): enable opt-in npm upgrades`
+
+Each pull request is independently reviewable. Release discovery lands without UI or execution behavior; notifications remain read-only; peer versions remain display-only; automatic execution is isolated in the top pull request.

--- a/docs/plans/2026-08-10-release-discovery-and-update-notifications-plan.md
+++ b/docs/plans/2026-08-10-release-discovery-and-update-notifications-plan.md
@@ -1,0 +1,161 @@
+# Release Discovery and Update Notifications Implementation Plan
+
+## Overview
+
+Deliver the approved updater design as four dependent Graphite pull requests. Each pull request maps to one Beads feature under epic `codemem-eiq9` and must remain independently testable.
+
+## Prerequisites
+
+- Fresh detached worktree based on `origin/main` at `a9fa59d9`.
+- Node 24 and workspace dependencies installed.
+- Approved design: `docs/plans/2026-08-10-release-discovery-and-update-notifications-design.md`.
+- Plugin source changes mirrored into the CLI plugin test harness where required.
+
+## PR 1: Release discovery
+
+**Bead:** `codemem-eiq9.1`  
+**Commit:** `feat(update): add release discovery`
+
+### Tasks
+
+1. Define stable `UpdateStatus`, installation-kind, cache, and resolver contracts in a leaf core module.
+2. Implement strict stable-semver parsing and comparison without adding a dependency.
+3. Implement fixed-origin npm lookup with injected fetch/clock, two-second timeout, six-hour cache, and process-local single-flight behavior.
+4. Persist cache state atomically under the Codemem home directory and preserve `first_seen_at` while the same latest release remains current.
+5. Add `codemem update check` with `--json` and `--refresh`; register command and completions.
+6. Add focused resolver and CLI coverage for current/newer/prerelease/downgrade/malformed/offline/cache/timeout/concurrency behavior.
+7. Include the approved design and implementation plan.
+
+### Main files
+
+- `packages/core/src/release-discovery.ts`
+- `packages/core/src/release-discovery.test.ts`
+- `packages/core/src/index.ts`
+- `packages/cli/src/commands/update.ts`
+- `packages/cli/src/commands/update.test.ts`
+- `packages/cli/src/index.ts`
+- `docs/versioning.md`
+
+### Validation
+
+```fish
+pnpm exec vitest run packages/core/src/release-discovery.test.ts packages/cli/src/commands/update.test.ts
+pnpm run codemem -- update check --json
+pnpm run tsc
+```
+
+## PR 2: Plugin and Viewer notifications
+
+**Bead:** `codemem-eiq9.2`  
+**Depends on:** `codemem-eiq9.1`  
+**Commit:** `feat(update): surface release notifications`
+
+### Tasks
+
+1. Add a dedicated Viewer update-status route; keep `/api/runtime` registry-free.
+2. Add UI API types/client state and Health states for current, available, stale, and unavailable checks.
+3. Add plugin startup release check through the CLI runner and notify once per discovered release.
+4. Respect `notify` and `off` without adding installation behavior.
+5. Mark Docker builds with an explicit install kind and provide durable pin/rebuild guidance.
+6. Update README and plugin reference documentation.
+
+### Main files
+
+- `packages/viewer-server/src/routes/update-status.ts`
+- `packages/viewer-server/src/index.ts`
+- `packages/viewer-server/src/index.test.ts`
+- `packages/ui/src/lib/api/`
+- `packages/ui/src/tabs/health/`
+- `packages/opencode-plugin/.opencode/plugins/codemem.js`
+- `packages/cli/.opencode/tests/`
+- `deploy/docker/Dockerfile`
+- `README.md`
+- `docs/plugin-reference.md`
+
+### Validation
+
+```fish
+pnpm exec vitest run packages/viewer-server/src/index.test.ts packages/ui/src/tabs/health.test.ts
+pnpm --filter codemem test:plugin
+pnpm --filter @codemem/ui build
+pnpm run tsc
+```
+
+## PR 3: Peer runtime versions
+
+**Bead:** `codemem-eiq9.3`  
+**Depends on:** `codemem-eiq9.2`  
+**Commit:** `feat(sync): report peer runtime versions`
+
+### Tasks
+
+1. Add nullable additive peer runtime-version columns and fresh-schema coverage without bumping `SCHEMA_VERSION`.
+2. Add optional `runtime_version` to signed peer status.
+3. Validate bounded stable versions only after existing identity and fingerprint verification.
+4. Persist valid versions with observation time; treat missing or malformed values as unknown.
+5. Expose optional versions in sync API types and render them on paired Device cards.
+6. Prove that runtime versions never affect trust, authorization, status, or capability negotiation.
+
+### Main files
+
+- `packages/core/src/schema.ts`
+- `packages/core/src/schema-bootstrap.ts`
+- `packages/core/src/db.ts`
+- `packages/core/src/sync-pass.ts`
+- `packages/viewer-server/src/routes/sync.ts`
+- `packages/ui/src/lib/api/sync.ts`
+- `packages/ui/src/tabs/devices.tsx`
+- Related core, viewer, and UI tests
+
+### Validation
+
+```fish
+pnpm exec vitest run packages/core/src/db.test.ts packages/core/src/sync-pass.test.ts packages/viewer-server/src/index.test.ts packages/ui/src/tabs/devices.test.tsx packages/ui/src/app-devices.test.tsx
+pnpm --filter @codemem/ui build
+pnpm run tsc
+```
+
+## PR 4: Delayed opt-in npm upgrades
+
+**Bead:** `codemem-eiq9.4`  
+**Depends on:** `codemem-eiq9.3`  
+**Commit:** `feat(update): enable opt-in npm upgrades`
+
+### Tasks
+
+1. Add the 24-hour first-seen eligibility predicate using fresh validated status only.
+2. Add `codemem update install` with fail-closed installation-kind checks.
+3. Extend the existing plugin update plan rather than adding a second execution mechanism.
+4. Verify the active CLI version after installation.
+5. Restart only a plugin-owned Viewer and keep installation/restart failures non-fatal to plugin operation.
+6. Document auto policy, refusal cases, and Docker workflow.
+
+### Main files
+
+- `packages/core/src/release-discovery.ts`
+- `packages/cli/src/commands/update.ts`
+- `packages/opencode-plugin/.opencode/lib/compat.js`
+- `packages/cli/.opencode/lib/compat.js`
+- `packages/opencode-plugin/.opencode/plugins/codemem.js`
+- Related core, CLI, and plugin tests
+- `README.md`
+- `docs/plugin-reference.md`
+- `docs/versioning.md`
+- `deploy/docker/README.md`
+
+### Validation
+
+```fish
+pnpm exec vitest run packages/core/src/release-discovery.test.ts packages/cli/src/commands/update.test.ts
+pnpm --filter codemem test:plugin
+pnpm run tsc
+```
+
+## Full-stack gate
+
+```fish
+pnpm --filter @codemem/ui build
+pnpm run check
+```
+
+After the full gate, run CodeReviewer on the complete stack, with a security focus on peer-authenticated metadata and process execution, then run the pragmatic quality reviewer before `gt submit --stack --no-interactive`.

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -370,6 +370,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
 | `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |
 | `CODEMEM_BACKEND_UPDATE_POLICY` | Backend update behavior on compatibility mismatch: `notify` (default), `auto`, or `off`. |
+| `CODEMEM_INSTALL_KIND` | Internal/advanced release-guidance detection override (`npm-global`, `npx`, `docker`, `repo-dev`, `pinned`, or `unknown`). This does not enable installation. |
 | `CODEMEM_CODEX_ENDPOINT` | Override Codex OAuth endpoint. |
 | `CODEMEM_PLUGIN_DEBUG` | Set to `1`, `true`, or `yes` to log plugin lifecycle events. |
 | `CODEMEM_PLUGIN_IGNORE` | Skip all plugin behavior for this process. |
@@ -423,5 +424,9 @@ Update policy:
   - skipped for `node` dev-mode runners
   - skipped when `CODEMEM_RUNNER_FROM` is pinned to a fixed package/version
 - `CODEMEM_BACKEND_UPDATE_POLICY=off`: no compatibility toast (logging still records mismatch)
+
+Docker images set `CODEMEM_INSTALL_KIND=docker` so release guidance cannot mistake the bundled
+global npm package for a host npm installation. Docker deployments never self-update; rebuild and
+restart the image with the desired `CODEMEM_VERSION` instead.
 
 Compatibility checks do not block plugin startup.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,5 +1,23 @@
 # User Guide
 
+## Check for updates
+
+Use the read-only release check to compare the running CLI with the latest stable npm release:
+
+```fish
+codemem update check
+codemem update check --refresh
+codemem update check --json
+```
+
+- Results are cached locally for six hours; `--refresh` bypasses a fresh cache.
+- `--json` prints one stable status object and uses a non-zero exit code when no validated fresh
+  or stale status is available.
+- Stale validated cache data remains clearly labeled and may provide guidance when the registry is
+  unavailable.
+- This command never installs or executes an update. Release installation remains outside this
+  read-only check.
+
 ## Start or restart the viewer
 - `codemem serve` runs the viewer in the foreground.
 - `codemem serve start` runs it in the background.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -59,7 +59,19 @@ This verifies release tagging safety in two contexts:
 
 Tag only after the release PR has merged to `main` and you have verified that `HEAD` on `main` is the merged release commit. Do not tag the release branch tip directly.
 
-## Compatibility check
+## Release discovery
+
+`codemem update check` queries the fixed public npm registry endpoint for the latest stable
+`codemem` release. Results are cached locally for six hours; use `--refresh` to bypass a fresh
+cache and `--json` for the stable automation contract. If a refresh fails, a previously validated
+cache may be returned as stale guidance. Release discovery is informational and does not install
+or execute anything.
+
+Release discovery compares the running product version with the latest published stable release.
+It is separate from the compatibility-floor check below: discovering a newer release does not
+change whether the current CLI satisfies the plugin's minimum supported version.
+
+## Compatibility-floor check
 
 The OpenCode plugin performs a runtime CLI version check and warns if the local CLI is below
 `CODEMEM_MIN_VERSION` (default `0.9.20`).
@@ -69,6 +81,10 @@ The compatibility reaction is controlled by `CODEMEM_BACKEND_UPDATE_POLICY`:
 - `notify` (default): warn with an upgrade hint
 - `auto`: attempt a best-effort update for eligible runners, then re-check (skips dev runner mode and pinned git refs)
 - `off`: suppress compatibility toasts
+
+This check enforces a minimum supported CLI version. It does not query the npm registry or report
+the latest available release, and its existing policy and update behavior are unchanged by release
+discovery.
 
 Override for testing:
 

--- a/packages/cli/src/command-tree.ts
+++ b/packages/cli/src/command-tree.ts
@@ -37,6 +37,7 @@ import { setupCommand } from "./commands/setup.js";
 import { statsCommand } from "./commands/stats.js";
 import { statusCommand } from "./commands/status.js";
 import { syncCommand } from "./commands/sync.js";
+import { updateCommand } from "./commands/update.js";
 import { versionCommand } from "./commands/version.js";
 import { helpStyle } from "./help-style.js";
 
@@ -65,6 +66,7 @@ export const ROOT_COMPLETION_COMMANDS = [
 	"stats",
 	"status",
 	"sync",
+	"update",
 	"version",
 	"help",
 	"--help",
@@ -194,6 +196,7 @@ export function registerRootCommands(program: Command): Command {
 	program.addCommand(syncCommand);
 	program.addCommand(setupCommand);
 	program.addCommand(enqueueRawEventCommand);
+	program.addCommand(updateCommand);
 	program.addCommand(versionCommand);
 	return program;
 }

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -1,0 +1,226 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { getUpdateStatus } = vi.hoisted(() => ({
+	getUpdateStatus: vi.fn(),
+}));
+
+vi.mock("@codemem/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@codemem/core")>();
+	return {
+		...actual,
+		getUpdateStatus,
+	};
+});
+
+import { updateCommand } from "./update.js";
+
+const availableStatus = {
+	current_version: "0.40.2",
+	latest_version: "0.41.0",
+	update_available: true,
+	first_seen_at: "2026-08-10T12:00:00.000Z",
+	checked_at: "2026-08-10T12:00:00.000Z",
+	stale: false,
+	install_kind: "npm-global",
+	auto_update_eligible: false,
+	recommended_action: "npm install -g codemem@0.41.0",
+	error: null,
+} as const;
+
+const currentStatus = {
+	...availableStatus,
+	latest_version: "0.40.2",
+	update_available: false,
+	recommended_action: "No action required; codemem is up to date.",
+} as const;
+
+const unavailableStatus = {
+	...availableStatus,
+	latest_version: null,
+	update_available: false,
+	first_seen_at: null,
+	checked_at: null,
+	stale: false,
+	install_kind: "unknown",
+	recommended_action: "Check network access and try again.",
+	error: "registry request timed out",
+} as const;
+
+async function parseUpdateCommand(args: string[]): Promise<void> {
+	const root = new Command("codemem");
+	root.enablePositionalOptions();
+	root.addCommand(updateCommand);
+	await root.parseAsync(["update", ...args], { from: "user" });
+}
+
+afterEach(() => {
+	getUpdateStatus.mockReset();
+	process.exitCode = undefined;
+	vi.restoreAllMocks();
+});
+
+describe("update check command", () => {
+	it("renders a concise human message for an available release and its guidance", async () => {
+		// Arrange
+		getUpdateStatus.mockResolvedValue(availableStatus);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		// Act
+		await parseUpdateCommand(["check"]);
+
+		// Assert
+		const output = log.mock.calls.flat().join("\n");
+		expect(output).toContain("0.41.0");
+		expect(output).toContain("0.40.2");
+		expect(output).toContain(availableStatus.recommended_action);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("renders a human up-to-date message when no newer release exists", async () => {
+		// Arrange
+		getUpdateStatus.mockResolvedValue(currentStatus);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		// Act
+		await parseUpdateCommand(["check"]);
+
+		// Assert
+		expect(log.mock.calls.flat().join("\n")).toMatch(/0\.40\.2.*up to date/i);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("qualifies a stale up-to-date human result as cached", async () => {
+		// Arrange
+		getUpdateStatus.mockResolvedValue({
+			...currentStatus,
+			stale: true,
+			error: "registry offline",
+		});
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		// Act
+		await parseUpdateCommand(["check"]);
+
+		// Assert
+		const output = log.mock.calls.flat().join("\n");
+		expect(output).toMatch(/up to date/i);
+		expect(output).toMatch(/cached|stale/i);
+	});
+
+	it("does not tell a human that an unparseable current version is up to date", async () => {
+		// Arrange
+		getUpdateStatus.mockResolvedValue({
+			...currentStatus,
+			current_version: "development",
+			recommended_action: "Verify the current codemem version and try again.",
+		});
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		// Act
+		await parseUpdateCommand(["check"]);
+
+		// Assert
+		const output = log.mock.calls.flat().join("\n");
+		expect(output).not.toMatch(/up to date/i);
+		expect(output).toMatch(/verify.*current.*version/i);
+	});
+
+	it.each([
+		{ label: "cache write", warning: "cache write failed: permission denied" },
+		{ label: "cache read", warning: "cache read failed: corrupt filesystem entry" },
+	])("shows the $label warning in human output", async ({ warning }) => {
+		// Arrange
+		getUpdateStatus.mockResolvedValue({ ...availableStatus, error: warning });
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		// Act
+		await parseUpdateCommand(["check"]);
+
+		// Assert
+		expect(log.mock.calls.flat().join("\n")).toContain(warning);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("emits exactly one stable status object in JSON mode", async () => {
+		// Arrange
+		getUpdateStatus.mockResolvedValue(availableStatus);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		// Act
+		await parseUpdateCommand(["check", "--json"]);
+
+		// Assert
+		expect(log).toHaveBeenCalledTimes(1);
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual(availableStatus);
+		expect(error).not.toHaveBeenCalled();
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("passes forced refresh through to release discovery", async () => {
+		// Arrange
+		getUpdateStatus.mockResolvedValue(currentStatus);
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		// Act
+		await parseUpdateCommand(["check", "--refresh", "--json"]);
+
+		// Assert
+		expect(getUpdateStatus).toHaveBeenCalledWith(
+			expect.objectContaining({ installKind: "unknown", refresh: true }),
+		);
+	});
+
+	it("treats valid stale status as successful and preserves the status JSON", async () => {
+		// Arrange
+		const staleStatus = {
+			...availableStatus,
+			stale: true,
+			auto_update_eligible: false,
+			error: "registry offline",
+		};
+		getUpdateStatus.mockResolvedValue(staleStatus);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		// Act
+		await parseUpdateCommand(["check", "--json"]);
+
+		// Assert
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual(staleStatus);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("returns structured JSON and non-zero status when release status is unavailable", async () => {
+		// Arrange
+		getUpdateStatus.mockResolvedValue(unavailableStatus);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		// Act
+		await parseUpdateCommand(["check", "--json"]);
+
+		// Assert
+		const output = JSON.parse(String(log.mock.calls[0]?.[0]));
+		expect(output).toMatchObject({
+			error: "update_check_unavailable",
+			message: "registry request timed out",
+		});
+		expect(error).not.toHaveBeenCalled();
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("returns non-zero human failure when no valid fresh or stale status exists", async () => {
+		// Arrange
+		getUpdateStatus.mockResolvedValue(unavailableStatus);
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		// Act
+		await parseUpdateCommand(["check"]);
+
+		// Assert
+		expect(error.mock.calls.flat().join("\n")).toContain("registry request timed out");
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,0 +1,72 @@
+import { detectInstallKind, getUpdateStatus, isStableReleaseVersion, VERSION } from "@codemem/core";
+import { Command, Option } from "commander";
+import { helpStyle } from "../help-style.js";
+import { addJsonOption, emitJsonError, type JsonOpts } from "../shared-options.js";
+
+interface UpdateCheckOptions extends JsonOpts {
+	refresh?: boolean;
+}
+
+function cacheQualifier(stale: boolean): string {
+	return stale ? " (cached result)" : "";
+}
+
+function renderStatusWarning(error: string | null): string {
+	return error ? ` Warning: ${error}` : "";
+}
+
+function renderHumanStatus(status: Awaited<ReturnType<typeof getUpdateStatus>>): string {
+	const warning = renderStatusWarning(status.error);
+	if (status.update_available) {
+		return `Update available${cacheQualifier(status.stale)}: ${status.current_version} → ${status.latest_version}. ${status.recommended_action}${warning}`;
+	}
+	if (!isStableReleaseVersion(status.current_version)) {
+		return `Unable to compare current version ${status.current_version} with ${status.latest_version}. ${status.recommended_action}${warning}`;
+	}
+	return `${status.current_version} is up to date${cacheQualifier(status.stale)}.${warning}`;
+}
+
+const checkCommand = addJsonOption(
+	new Command("check").description("Check for a newer stable codemem release"),
+)
+	.addOption(new Option("-r, --refresh", "bypass the six-hour release cache"))
+	.configureHelp(helpStyle)
+	.action(async (options: UpdateCheckOptions) => {
+		try {
+			const installKind = detectInstallKind({
+				entryPath: process.argv[1] ?? "",
+				env: process.env,
+			});
+			const status = await getUpdateStatus({
+				currentVersion: VERSION,
+				installKind,
+				refresh: options.refresh,
+			});
+			if (status.latest_version === null) {
+				const message = status.error ?? "release status is unavailable";
+				if (options.json) emitJsonError("update_check_unavailable", message);
+				else {
+					console.error(`Unable to check for updates: ${message}`);
+					process.exitCode = 1;
+				}
+				return;
+			}
+			if (options.json) {
+				console.log(JSON.stringify(status));
+				return;
+			}
+			console.log(renderHumanStatus(status));
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "release status is unavailable";
+			if (options.json) emitJsonError("update_check_unavailable", message);
+			else {
+				console.error(`Unable to check for updates: ${message}`);
+				process.exitCode = 1;
+			}
+		}
+	});
+
+export const updateCommand = new Command("update")
+	.description("Inspect and manage codemem updates")
+	.configureHelp(helpStyle)
+	.addCommand(checkCommand);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -799,6 +799,7 @@ export {
 export { clearMemoryRefs, normalizeConcept, populateMemoryRefs } from "./ref-populate.js";
 export type { RefQueryOptions, RefQueryResult } from "./ref-queries.js";
 export { findByConcept, findByFile } from "./ref-queries.js";
+export * from "./release-discovery.js";
 export * from "./retrieval-ledger.js";
 export * from "./retrieval-surface-ledger.js";
 export type {

--- a/packages/core/src/release-discovery.test.ts
+++ b/packages/core/src/release-discovery.test.ts
@@ -1,0 +1,773 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	createReleaseCacheIo,
+	createReleaseDiscovery,
+	detectInstallKind,
+	type InstallDetectionInput,
+	type InstallKind,
+	type ReleaseDiscoveryDependencies,
+} from "./release-discovery.js";
+
+const NOW = new Date("2026-08-10T12:00:00.000Z");
+const REGISTRY_URL = "https://registry.npmjs.org/codemem/latest";
+
+type CacheRecord = {
+	schema_version: number;
+	latest_version: string;
+	checked_at: string;
+	first_seen_at: string;
+};
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { recursive: true, force: true })),
+	);
+});
+
+function response(payload: unknown): Response {
+	return new Response(JSON.stringify(payload), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function cacheRecord(overrides: Partial<CacheRecord> = {}): CacheRecord {
+	return {
+		schema_version: 1,
+		latest_version: "0.41.0",
+		checked_at: "2026-08-10T00:00:00.000Z",
+		first_seen_at: "2026-08-09T09:00:00.000Z",
+		...overrides,
+	};
+}
+
+function cacheWithoutSchemaVersion(
+	overrides: Partial<CacheRecord> = {},
+): Omit<CacheRecord, "schema_version"> {
+	const record: Partial<CacheRecord> = { ...cacheRecord(overrides) };
+	delete record.schema_version;
+	return record as Omit<CacheRecord, "schema_version">;
+}
+
+function streamingResponse(options: { chunks: string[]; contentLength?: string; url?: string }): {
+	response: Response;
+	state: { cancelled: boolean; pulls: number };
+} {
+	const encoder = new TextEncoder();
+	const state = { cancelled: false, pulls: 0 };
+	let index = 0;
+	const body = new ReadableStream<Uint8Array>({
+		pull(controller) {
+			state.pulls += 1;
+			const chunk = options.chunks[index];
+			index += 1;
+			if (chunk === undefined) {
+				controller.close();
+				return;
+			}
+			controller.enqueue(encoder.encode(chunk));
+		},
+		cancel() {
+			state.cancelled = true;
+		},
+	});
+	const headers = new Headers({ "content-type": "application/json" });
+	if (options.contentLength !== undefined) headers.set("content-length", options.contentLength);
+	const result = new Response(body, { status: 200, headers });
+	if (options.url) Object.defineProperty(result, "url", { value: options.url });
+	return { response: result, state };
+}
+
+function dependencies(
+	options: {
+		payload?: unknown;
+		cache?: string | null;
+		fetchError?: Error;
+		writeError?: Error;
+		now?: Date;
+	} = {},
+): ReleaseDiscoveryDependencies & {
+	fetch: ReturnType<typeof vi.fn>;
+	readCache: ReturnType<typeof vi.fn>;
+	writeCacheAtomic: ReturnType<typeof vi.fn>;
+	timeoutSignal: ReturnType<typeof vi.fn>;
+} {
+	const signal = new AbortController().signal;
+	return {
+		fetch: vi.fn(async () => {
+			if (options.fetchError) throw options.fetchError;
+			return response("payload" in options ? options.payload : { version: "0.41.0" });
+		}),
+		now: () => options.now ?? NOW,
+		readCache: vi.fn(async () => options.cache ?? null),
+		writeCacheAtomic: vi.fn(async () => {
+			if (options.writeError) throw options.writeError;
+		}),
+		timeoutSignal: vi.fn(() => signal),
+	};
+}
+
+async function check(
+	deps: ReleaseDiscoveryDependencies,
+	options: { currentVersion?: string; installKind?: InstallKind; refresh?: boolean } = {},
+) {
+	const discovery = createReleaseDiscovery(deps);
+	return discovery.check({
+		currentVersion: options.currentVersion ?? "0.40.2",
+		installKind: options.installKind ?? "npm-global",
+		refresh: options.refresh,
+	});
+}
+
+describe("release discovery registry contract", () => {
+	it("reports the current stable release without an update", async () => {
+		// Arrange
+		const deps = dependencies({ payload: { version: "0.40.2" } });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({
+			current_version: "0.40.2",
+			latest_version: "0.40.2",
+			update_available: false,
+			stale: false,
+			error: null,
+		});
+	});
+
+	it("reports a newer stable release", async () => {
+		// Arrange
+		const deps = dependencies({ payload: { version: "0.41.0" } });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({
+			latest_version: "0.41.0",
+			update_available: true,
+			first_seen_at: NOW.toISOString(),
+			checked_at: NOW.toISOString(),
+			stale: false,
+		});
+	});
+
+	it("accepts stable semantic versions with build metadata", async () => {
+		// Arrange
+		const deps = dependencies({ payload: { version: "0.41.0+build.7" } });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({
+			latest_version: "0.41.0+build.7",
+			update_available: true,
+			stale: false,
+		});
+	});
+
+	it("never presents a registry downgrade as an available update", async () => {
+		// Arrange
+		const deps = dependencies({ payload: { version: "0.39.9" } });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({
+			latest_version: "0.39.9",
+			update_available: false,
+			auto_update_eligible: false,
+		});
+	});
+
+	it.each([
+		"0.41.0-beta.1",
+		"0.41.0-rc.0",
+		"v0.41.0",
+		"0.41",
+		"01.2.3",
+		"999999999999999999999999.1.0",
+	])("rejects non-strict or prerelease registry version %s", async (version) => {
+		// Arrange
+		const deps = dependencies({ payload: { version } });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({
+			latest_version: null,
+			update_available: false,
+			auto_update_eligible: false,
+			stale: false,
+		});
+	});
+
+	it.each([
+		{ label: "null", payload: null },
+		{ label: "array", payload: [] },
+		{ label: "empty object", payload: {} },
+		{ label: "numeric version", payload: { version: 41 } },
+		{ label: "empty version", payload: { version: "" } },
+		{ label: "wrong property", payload: { latest: "0.41.0" } },
+	])("rejects malformed registry payload: $label", async ({ payload }) => {
+		// Arrange
+		const deps = dependencies({ payload });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status.error).toMatch(/invalid.*registry/i);
+	});
+
+	it("uses the fixed registry endpoint and injected two-second timeout", async () => {
+		// Arrange
+		const deps = dependencies();
+
+		// Act
+		await check(deps);
+
+		// Assert
+		expect(deps.timeoutSignal).toHaveBeenCalledWith(2_000);
+		expect(deps.fetch).toHaveBeenCalledWith(
+			REGISTRY_URL,
+			expect.objectContaining({ redirect: "error", signal: expect.any(AbortSignal) }),
+		);
+	});
+
+	it("rejects a response whose final URL does not exactly match the fixed registry URL", async () => {
+		// Arrange
+		const deps = dependencies();
+		const mismatched = response({ version: "0.41.0" });
+		Object.defineProperty(mismatched, "url", {
+			value: "https://registry.npmjs.org/codemem",
+		});
+		deps.fetch.mockResolvedValue(mismatched);
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({ latest_version: null, update_available: false });
+		expect(status.error).toMatch(/invalid registry response origin|response url/i);
+	});
+
+	it.each([
+		new DOMException("The operation timed out", "TimeoutError"),
+		new DOMException("The operation was aborted", "AbortError"),
+	])("classifies compatible $name failures as registry timeouts", async (timeoutError) => {
+		// Arrange
+		const deps = dependencies({ fetchError: timeoutError });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({
+			latest_version: null,
+			update_available: false,
+			auto_update_eligible: false,
+			stale: false,
+		});
+		expect(status.error).toBe("registry request timed out");
+	});
+
+	it("classifies a real Node AbortSignal timeout as a registry timeout", async () => {
+		// Arrange
+		const deps = dependencies();
+		deps.timeoutSignal.mockImplementation((milliseconds: number) =>
+			AbortSignal.timeout(Math.min(milliseconds, 1)),
+		);
+		deps.fetch.mockImplementation(async (_url: string, init?: RequestInit) => {
+			const signal = init?.signal;
+			await new Promise<never>((_resolve, reject) => {
+				if (signal?.aborted) {
+					reject(signal.reason);
+					return;
+				}
+				signal?.addEventListener("abort", () => reject(signal?.reason), { once: true });
+			});
+			throw new Error("unreachable");
+		});
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status.error).toBe("registry request timed out");
+	});
+
+	it.each([
+		{ label: "missing Content-Length", contentLength: undefined },
+		{ label: "lying Content-Length", contentLength: "32" },
+	])("caps the streamed response body with $label", async ({ contentLength }) => {
+		// Arrange
+		const deps = dependencies();
+		const chunks = Array.from({ length: 20 }, () => "x".repeat(4_096));
+		const streamed = streamingResponse({ chunks, contentLength, url: REGISTRY_URL });
+		deps.fetch.mockResolvedValue(streamed.response);
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status.error).toMatch(/payload too large/i);
+		expect(streamed.state.cancelled).toBe(true);
+		expect(streamed.state.pulls).toBeLessThan(chunks.length);
+	});
+
+	it("enforces the response cap in bytes rather than decoded string length", async () => {
+		// Arrange
+		const deps = dependencies();
+		const streamed = streamingResponse({
+			chunks: ["é".repeat(9_000)],
+			url: REGISTRY_URL,
+		});
+		deps.fetch.mockResolvedValue(streamed.response);
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status.error).toMatch(/payload too large/i);
+	});
+
+	it("does not report an unparseable current version as up to date", async () => {
+		// Arrange
+		const deps = dependencies({ payload: { version: "0.41.0" } });
+
+		// Act
+		const status = await check(deps, { currentVersion: "development" });
+
+		// Assert
+		expect(status.update_available).toBe(false);
+		expect(status.recommended_action).not.toMatch(/up to date|no action required/i);
+	});
+});
+
+describe("release discovery cache contract", () => {
+	it("uses cache younger than six hours without registry access", async () => {
+		// Arrange
+		const cached = cacheRecord({ checked_at: "2026-08-10T06:00:00.001Z" });
+		const deps = dependencies({ cache: JSON.stringify(cached) });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({
+			latest_version: "0.41.0",
+			first_seen_at: cached.first_seen_at,
+			checked_at: cached.checked_at,
+			stale: false,
+		});
+		expect(deps.fetch).not.toHaveBeenCalled();
+	});
+
+	it("refreshes cache once it is six hours old", async () => {
+		// Arrange
+		const cached = cacheRecord({ checked_at: "2026-08-10T06:00:00.000Z" });
+		const deps = dependencies({ cache: JSON.stringify(cached) });
+
+		// Act
+		await check(deps);
+
+		// Assert
+		expect(deps.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("writes the current cache schema version", async () => {
+		// Arrange
+		const deps = dependencies();
+
+		// Act
+		await check(deps);
+
+		// Assert
+		const contents = String(deps.writeCacheAtomic.mock.calls[0]?.[0]);
+		expect(JSON.parse(contents)).toMatchObject({ schema_version: 1 });
+	});
+
+	it("preserves first-seen time while the same latest release remains current", async () => {
+		// Arrange
+		const cached = cacheRecord();
+		const deps = dependencies({ cache: JSON.stringify(cached), payload: { version: "0.41.0" } });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status.first_seen_at).toBe(cached.first_seen_at);
+	});
+
+	it("resets first-seen time when the latest release changes", async () => {
+		// Arrange
+		const cached = cacheRecord({ latest_version: "0.41.0" });
+		const deps = dependencies({ cache: JSON.stringify(cached), payload: { version: "0.42.0" } });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({
+			latest_version: "0.42.0",
+			first_seen_at: NOW.toISOString(),
+		});
+	});
+
+	it("returns valid stale status when refresh fails", async () => {
+		// Arrange
+		const cached = cacheRecord();
+		const deps = dependencies({
+			cache: JSON.stringify(cached),
+			fetchError: new Error("registry offline"),
+		});
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({
+			latest_version: cached.latest_version,
+			update_available: true,
+			first_seen_at: cached.first_seen_at,
+			checked_at: cached.checked_at,
+			stale: true,
+			auto_update_eligible: false,
+		});
+		expect(status.error).toMatch(/registry offline/i);
+	});
+
+	it("forced refresh bypasses a fresh cache", async () => {
+		// Arrange
+		const cached = cacheRecord({ checked_at: "2026-08-10T11:59:00.000Z" });
+		const deps = dependencies({ cache: JSON.stringify(cached) });
+
+		// Act
+		await check(deps, { refresh: true });
+
+		// Assert
+		expect(deps.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("ignores malformed cache content and refreshes from the registry", async () => {
+		// Arrange
+		const deps = dependencies({ cache: "{ definitely-not-json" });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status.latest_version).toBe("0.41.0");
+		expect(deps.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		{
+			label: "missing schema version",
+			cache: cacheWithoutSchemaVersion({
+				checked_at: "2026-08-10T11:00:00.000Z",
+				first_seen_at: "2026-08-10T10:00:00.000Z",
+			}),
+		},
+		{
+			label: "unsupported schema version",
+			cache: cacheRecord({
+				schema_version: 2,
+				checked_at: "2026-08-10T11:00:00.000Z",
+				first_seen_at: "2026-08-10T10:00:00.000Z",
+			}),
+		},
+	])("rejects cache records with $label", async ({ cache }) => {
+		// Arrange
+		const deps = dependencies({ cache: JSON.stringify(cache) });
+
+		// Act
+		await check(deps);
+
+		// Assert
+		expect(deps.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("ignores cache records containing invalid versions or timestamps", async () => {
+		// Arrange
+		const deps = dependencies({
+			cache: JSON.stringify(
+				cacheRecord({ latest_version: "0.41.0-rc.1", checked_at: "not-a-date" }),
+			),
+		});
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status.latest_version).toBe("0.41.0");
+		expect(deps.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		{
+			label: "checked_at in the future",
+			cache: cacheRecord({ checked_at: "2026-08-10T12:00:00.001Z" }),
+		},
+		{
+			label: "first_seen_at after checked_at",
+			cache: cacheRecord({
+				checked_at: "2026-08-10T11:00:00.000Z",
+				first_seen_at: "2026-08-10T11:00:00.001Z",
+			}),
+		},
+	])("rejects cache records with $label", async ({ cache }) => {
+		// Arrange
+		const deps = dependencies({ cache: JSON.stringify(cache) });
+
+		// Act
+		await check(deps);
+
+		// Assert
+		expect(deps.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns fresh status even when the atomic cache write fails", async () => {
+		// Arrange
+		const deps = dependencies({ writeError: new Error("rename denied") });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({
+			latest_version: "0.41.0",
+			update_available: true,
+			stale: false,
+		});
+		expect(status.error).toMatch(/rename denied|cache/i);
+	});
+
+	it("returns fresh status with a warning when reading the cache fails", async () => {
+		// Arrange
+		const deps = dependencies();
+		deps.readCache.mockRejectedValue(new Error("permission denied"));
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status).toMatchObject({ latest_version: "0.41.0", stale: false });
+		expect(status.error).toMatch(/cache read failed.*permission denied/i);
+	});
+
+	it("coalesces concurrent refreshes into one registry request", async () => {
+		// Arrange
+		let resolveFetch: ((value: Response) => void) | undefined;
+		const deps = dependencies();
+		deps.fetch.mockImplementation(
+			() =>
+				new Promise<Response>((resolve) => {
+					resolveFetch = resolve;
+				}),
+		);
+		const discovery = createReleaseDiscovery(deps);
+
+		// Act
+		const first = discovery.check({ currentVersion: "0.40.2", installKind: "npm-global" });
+		const second = discovery.check({ currentVersion: "0.40.2", installKind: "npm-global" });
+		await vi.waitFor(() => expect(deps.fetch).toHaveBeenCalledTimes(1));
+		resolveFetch?.(response({ version: "0.41.0" }));
+		const statuses = await Promise.all([first, second]);
+
+		// Assert
+		expect(deps.fetch).toHaveBeenCalledTimes(1);
+		expect(statuses[0]).toEqual(statuses[1]);
+	});
+});
+
+describe("release cache file IO", () => {
+	it("atomically writes and reads a private cache file", async () => {
+		// Arrange
+		const directory = await mkdtemp(join(tmpdir(), "codemem-release-cache-"));
+		temporaryDirectories.push(directory);
+		const cacheDirectory = join(directory, ".codemem");
+		const cachePath = join(cacheDirectory, "release-discovery.json");
+		const io = createReleaseCacheIo(cachePath);
+		const contents = JSON.stringify(cacheRecord());
+
+		// Act
+		await io.writeCacheAtomic(contents);
+		const stored = await io.readCache();
+		const directoryMode = (await stat(cacheDirectory)).mode & 0o777;
+		const fileMode = (await stat(cachePath)).mode & 0o777;
+		const entries = await readdir(cacheDirectory);
+
+		// Assert
+		expect(stored).toBe(contents);
+		expect(await readFile(cachePath, "utf8")).toBe(contents);
+		expect(directoryMode).toBe(0o700);
+		expect(fileMode).toBe(0o600);
+		expect(entries).toEqual(["release-discovery.json"]);
+	});
+
+	it("returns null when the cache file does not exist", async () => {
+		// Arrange
+		const directory = await mkdtemp(join(tmpdir(), "codemem-release-cache-"));
+		temporaryDirectories.push(directory);
+		const io = createReleaseCacheIo(join(directory, "missing", "cache.json"));
+
+		// Act
+		const stored = await io.readCache();
+
+		// Assert
+		expect(stored).toBeNull();
+	});
+
+	it("removes its temporary file when the atomic rename fails", async () => {
+		// Arrange
+		const directory = await mkdtemp(join(tmpdir(), "codemem-release-cache-"));
+		temporaryDirectories.push(directory);
+		const cacheDirectory = join(directory, ".codemem");
+		const cachePath = join(cacheDirectory, "release-discovery.json");
+		await mkdir(cachePath, { recursive: true });
+		const io = createReleaseCacheIo(cachePath);
+
+		// Act
+		const write = io.writeCacheAtomic(JSON.stringify(cacheRecord()));
+
+		// Assert
+		await expect(write).rejects.toThrow();
+		const entries = await readdir(cacheDirectory);
+		expect(entries.filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
+	});
+});
+
+describe("installation-kind detection", () => {
+	it.each([
+		{
+			label: "explicit Docker marker",
+			input: {
+				entryPath: "/usr/local/lib/node_modules/codemem/dist/index.js",
+				env: { CODEMEM_INSTALL_KIND: "docker" },
+			},
+			expected: "docker",
+		},
+		{
+			label: "repository development source path",
+			input: { entryPath: "/workspace/codemem/packages/cli/src/index.ts" },
+			expected: "repo-dev",
+		},
+		{
+			label: "npx cache path",
+			input: { entryPath: "/home/user/.npm/_npx/abc123/node_modules/codemem/dist/index.js" },
+			expected: "npx",
+		},
+		{
+			label: "global npm package path",
+			input: { entryPath: "/usr/local/lib/node_modules/codemem/dist/index.js" },
+			expected: "npm-global",
+		},
+		{
+			label: "pinned runner source",
+			input: {
+				entryPath: "/home/user/.npm/_npx/abc123/node_modules/codemem/dist/index.js",
+				env: {
+					CODEMEM_RUNNER_FROM: "git+https://github.com/kunickiaj/codemem.git@v0.40.2",
+				},
+			},
+			expected: "pinned",
+		},
+		{
+			label: "unrecognized path and source",
+			input: { entryPath: "/opt/custom/codemem-cli.js", env: {} },
+			expected: "unknown",
+		},
+	] satisfies Array<{
+		label: string;
+		input: InstallDetectionInput;
+		expected: InstallKind;
+	}>)("detects $label as $expected", ({ input, expected }) => {
+		// Arrange
+		const detectionInput = { ...input, env: { ...input.env } };
+
+		// Act
+		const kind = detectInstallKind(detectionInput);
+
+		// Assert
+		expect(kind).toBe(expected);
+	});
+
+	it.each([
+		["unpinned npm tag", "codemem@latest", "unknown"],
+		["pinned npm version", "codemem@0.40.2", "pinned"],
+		["pinned git ref", "git+https://example.test/codemem.git@v0.40.2", "pinned"],
+		["pinned git fragment", "git+https://example.test/codemem.git#v0.40.2", "pinned"],
+		[
+			"git fragment containing whitespace",
+			"git+https://example.test/codemem.git#release branch",
+			"unknown",
+		],
+		["repeated fragments", `git+https://example.test/codemem.git${"#".repeat(10_000)}`, "unknown"],
+		["repeated git refs", `git+https://example.test/codemem${".git@".repeat(10_000)}`, "unknown"],
+		[
+			"bounded repeated fragments",
+			`git+https://example.test/codemem.git${"#".repeat(2_000)}`,
+			"pinned",
+		],
+		[
+			"bounded repeated git refs",
+			`git+https://example.test/codemem${".git@".repeat(500)}`,
+			"unknown",
+		],
+	] as const)("handles %s runner sources in bounded time", (_label, source, expected) => {
+		expect(
+			detectInstallKind({
+				entryPath: "/opt/custom/codemem-cli.js",
+				env: { CODEMEM_RUNNER_FROM: source },
+			}),
+		).toBe(expected);
+	});
+});
+
+describe("installation guidance", () => {
+	it.each([
+		["npm-global", "npm install -g codemem@0.41.0"],
+		["npx", "npx codemem@0.41.0"],
+		["docker", "CODEMEM_VERSION=0.41.0 docker compose build --pull"],
+		["repo-dev", "git pull"],
+		["pinned", "pinned"],
+		["unknown", "installation method"],
+	] satisfies Array<
+		[InstallKind, string]
+	>)("returns %s-specific upgrade guidance", async (installKind, expectedGuidance) => {
+		// Arrange
+		const deps = dependencies();
+
+		// Act
+		const status = await check(deps, { installKind });
+
+		// Assert
+		expect(status).toMatchObject({ install_kind: installKind });
+		expect(status.recommended_action).toContain(expectedGuidance);
+	});
+
+	it("returns no-upgrade guidance when the installation is current", async () => {
+		// Arrange
+		const deps = dependencies({ payload: { version: "0.40.2" } });
+
+		// Act
+		const status = await check(deps);
+
+		// Assert
+		expect(status.recommended_action).toMatch(/up to date|no action/i);
+	});
+});

--- a/packages/core/src/release-discovery.ts
+++ b/packages/core/src/release-discovery.ts
@@ -1,0 +1,452 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { codememHomeDir } from "./home.js";
+
+const REGISTRY_URL = "https://registry.npmjs.org/codemem/latest";
+const REQUEST_TIMEOUT_MS = 2_000;
+const CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1_000;
+const MAX_RESPONSE_BYTES = 16 * 1_024;
+const MAX_VERSION_LENGTH = 128;
+const MAX_RUNNER_SOURCE_LENGTH = 4_096;
+const RELEASE_CACHE_SCHEMA_VERSION = 1;
+const STABLE_SEMVER =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+export type InstallKind = "npm-global" | "npx" | "docker" | "repo-dev" | "pinned" | "unknown";
+
+export interface UpdateStatus {
+	current_version: string;
+	latest_version: string | null;
+	update_available: boolean;
+	first_seen_at: string | null;
+	checked_at: string | null;
+	stale: boolean;
+	install_kind: InstallKind;
+	auto_update_eligible: boolean;
+	recommended_action: string;
+	error: string | null;
+}
+
+interface ReleaseCacheRecord {
+	schema_version: typeof RELEASE_CACHE_SCHEMA_VERSION;
+	latest_version: string;
+	checked_at: string;
+	first_seen_at: string;
+}
+
+export interface ReleaseCacheIo {
+	readCache: () => Promise<string | null>;
+	writeCacheAtomic: (contents: string) => Promise<void>;
+}
+
+export interface InstallDetectionInput {
+	entryPath: string;
+	env?: Record<string, string | undefined>;
+}
+
+export interface ReleaseDiscoveryDependencies {
+	fetch: (url: string, init?: RequestInit) => Promise<Response>;
+	now: () => Date;
+	readCache: () => Promise<string | null>;
+	writeCacheAtomic: (contents: string) => Promise<void>;
+	timeoutSignal: (milliseconds: number) => AbortSignal;
+}
+
+export interface ReleaseCheckOptions {
+	currentVersion: string;
+	installKind: InstallKind;
+	refresh?: boolean;
+}
+
+export interface ReleaseDiscovery {
+	check(options: ReleaseCheckOptions): Promise<UpdateStatus>;
+}
+
+interface ReleaseResolution {
+	record: ReleaseCacheRecord | null;
+	stale: boolean;
+	error: string | null;
+}
+
+function parseStableSemver(value: unknown): [number, number, number] | null {
+	if (typeof value !== "string" || value.length === 0 || value.length > MAX_VERSION_LENGTH) {
+		return null;
+	}
+	const match = STABLE_SEMVER.exec(value);
+	if (!match) return null;
+	const parts = match.slice(1, 4).map(Number);
+	return parts.every(Number.isSafeInteger) ? (parts as [number, number, number]) : null;
+}
+
+export function isStableReleaseVersion(value: unknown): value is string {
+	return parseStableSemver(value) !== null;
+}
+
+function compareStableSemver(left: string, right: string): number | null {
+	const leftParts = parseStableSemver(left);
+	const rightParts = parseStableSemver(right);
+	if (!leftParts || !rightParts) return null;
+	for (const index of [0, 1, 2] as const) {
+		const difference = leftParts[index] - rightParts[index];
+		if (difference !== 0) return Math.sign(difference);
+	}
+	return 0;
+}
+
+function parseIsoTimestamp(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const timestamp = new Date(value);
+	return Number.isFinite(timestamp.getTime()) && timestamp.toISOString() === value ? value : null;
+}
+
+function parseCache(contents: string | null, now: Date): ReleaseCacheRecord | null {
+	if (contents === null) return null;
+	try {
+		const value: unknown = JSON.parse(contents);
+		if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+		const candidate = value as Record<string, unknown>;
+		if (candidate.schema_version !== RELEASE_CACHE_SCHEMA_VERSION) return null;
+		const latestVersion =
+			typeof candidate.latest_version === "string" && parseStableSemver(candidate.latest_version)
+				? candidate.latest_version
+				: null;
+		const checkedAt = parseIsoTimestamp(candidate.checked_at);
+		const firstSeenAt = parseIsoTimestamp(candidate.first_seen_at);
+		if (!latestVersion || !checkedAt || !firstSeenAt) return null;
+		const checkedTime = Date.parse(checkedAt);
+		const firstSeenTime = Date.parse(firstSeenAt);
+		if (checkedTime > now.getTime() || firstSeenTime > checkedTime) return null;
+		return {
+			schema_version: RELEASE_CACHE_SCHEMA_VERSION,
+			latest_version: latestVersion,
+			checked_at: checkedAt,
+			first_seen_at: firstSeenAt,
+		};
+	} catch {
+		return null;
+	}
+}
+
+function isFresh(record: ReleaseCacheRecord, now: Date): boolean {
+	return now.getTime() - Date.parse(record.checked_at) < CACHE_MAX_AGE_MS;
+}
+
+function errorMessage(error: unknown): string {
+	if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
+		return "registry request timed out";
+	}
+	return error instanceof Error && error.message ? error.message : "release discovery failed";
+}
+
+async function readBoundedResponseBody(response: Response): Promise<string> {
+	const contentLength = response.headers.get("content-length");
+	if (contentLength !== null) {
+		if (!/^\d+$/.test(contentLength)) {
+			await response.body?.cancel();
+			throw new Error("invalid registry response: invalid Content-Length");
+		}
+		const declaredBytes = Number(contentLength);
+		if (!Number.isSafeInteger(declaredBytes) || declaredBytes > MAX_RESPONSE_BYTES) {
+			await response.body?.cancel();
+			throw new Error("invalid registry response: payload too large");
+		}
+	}
+	if (!response.body) throw new Error("invalid registry response: missing body");
+
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let receivedBytes = 0;
+	try {
+		while (true) {
+			const result = await reader.read();
+			if (result.done) break;
+			receivedBytes += result.value.byteLength;
+			if (receivedBytes > MAX_RESPONSE_BYTES) {
+				await reader.cancel();
+				throw new Error("invalid registry response: payload too large");
+			}
+			chunks.push(result.value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	const body = new Uint8Array(receivedBytes);
+	let offset = 0;
+	for (const chunk of chunks) {
+		body.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	try {
+		return new TextDecoder("utf-8", { fatal: true }).decode(body);
+	} catch {
+		throw new Error("invalid registry response payload");
+	}
+}
+
+async function fetchLatestVersion(deps: ReleaseDiscoveryDependencies): Promise<string> {
+	const response = await deps.fetch(REGISTRY_URL, {
+		headers: { accept: "application/json" },
+		redirect: "error",
+		signal: deps.timeoutSignal(REQUEST_TIMEOUT_MS),
+	});
+	if (!response.ok) {
+		await response.body?.cancel();
+		throw new Error(`registry request failed with status ${response.status}`);
+	}
+	if (response.url) {
+		const finalUrl = new URL(response.url);
+		if (finalUrl.href !== REGISTRY_URL) {
+			await response.body?.cancel();
+			throw new Error("invalid registry response URL");
+		}
+	}
+	const body = await readBoundedResponseBody(response);
+	let payload: unknown;
+	try {
+		payload = JSON.parse(body);
+	} catch {
+		throw new Error("invalid registry response payload");
+	}
+	if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+		throw new Error("invalid registry response payload");
+	}
+	const version = (payload as Record<string, unknown>).version;
+	if (typeof version !== "string" || !parseStableSemver(version)) {
+		throw new Error("invalid registry version");
+	}
+	return version;
+}
+
+function recommendedAction(
+	installKind: InstallKind,
+	currentVersion: string,
+	latestVersion: string | null,
+	updateAvailable: boolean,
+): string {
+	if (!latestVersion) return "Check network access and try again.";
+	if (!parseStableSemver(currentVersion)) {
+		return "Verify the current codemem version and try again.";
+	}
+	if (!updateAvailable) return "No action required; codemem is up to date.";
+	switch (installKind) {
+		case "npm-global":
+			return `npm install -g codemem@${latestVersion}`;
+		case "npx":
+			return `Run npx codemem@${latestVersion} or update the version used by your launcher.`;
+		case "docker":
+			return `Set CODEMEM_VERSION=${latestVersion}, then run CODEMEM_VERSION=${latestVersion} docker compose build --pull and docker compose up -d.`;
+		case "repo-dev":
+			return "Run git pull, pnpm install, and pnpm build in the codemem repository.";
+		case "pinned":
+			return `Update the pinned codemem version to ${latestVersion}, then restart codemem.`;
+		default:
+			return `Update codemem to ${latestVersion} using your installation method.`;
+	}
+}
+
+function toStatus(resolution: ReleaseResolution, options: ReleaseCheckOptions): UpdateStatus {
+	const latestVersion = resolution.record?.latest_version ?? null;
+	const comparison = latestVersion
+		? compareStableSemver(latestVersion, options.currentVersion)
+		: null;
+	const updateAvailable = comparison !== null && comparison > 0;
+	return {
+		current_version: options.currentVersion,
+		latest_version: latestVersion,
+		update_available: updateAvailable,
+		first_seen_at: resolution.record?.first_seen_at ?? null,
+		checked_at: resolution.record?.checked_at ?? null,
+		stale: resolution.stale,
+		install_kind: options.installKind,
+		// PR1 is discovery-only. Installation eligibility is introduced behind its own guarded slice.
+		auto_update_eligible: false,
+		recommended_action: recommendedAction(
+			options.installKind,
+			options.currentVersion,
+			latestVersion,
+			updateAvailable,
+		),
+		error: resolution.error,
+	};
+}
+
+export function createReleaseDiscovery(deps: ReleaseDiscoveryDependencies): ReleaseDiscovery {
+	let inFlight: Promise<ReleaseResolution> | null = null;
+
+	async function refresh(cached: ReleaseCacheRecord | null, now: Date): Promise<ReleaseResolution> {
+		try {
+			const latestVersion = await fetchLatestVersion(deps);
+			const timestamp = now.toISOString();
+			const record: ReleaseCacheRecord = {
+				schema_version: RELEASE_CACHE_SCHEMA_VERSION,
+				latest_version: latestVersion,
+				checked_at: timestamp,
+				first_seen_at: cached?.latest_version === latestVersion ? cached.first_seen_at : timestamp,
+			};
+			try {
+				await deps.writeCacheAtomic(JSON.stringify(record));
+				return { record, stale: false, error: null };
+			} catch (error) {
+				return {
+					record,
+					stale: false,
+					error: `cache write failed: ${errorMessage(error)}`,
+				};
+			}
+		} catch (error) {
+			return { record: cached, stale: cached !== null, error: errorMessage(error) };
+		}
+	}
+
+	return {
+		async check(options): Promise<UpdateStatus> {
+			const now = deps.now();
+			let cached: ReleaseCacheRecord | null = null;
+			let cacheReadError: string | null = null;
+			try {
+				cached = parseCache(await deps.readCache(), now);
+			} catch (error) {
+				cacheReadError = `cache read failed: ${errorMessage(error)}`;
+			}
+			if (!options.refresh && cached && isFresh(cached, now)) {
+				return toStatus({ record: cached, stale: false, error: null }, options);
+			}
+			if (!inFlight) {
+				inFlight = refresh(cached, now).finally(() => {
+					inFlight = null;
+				});
+			}
+			const resolution = await inFlight;
+			return toStatus(
+				cacheReadError && !resolution.error ? { ...resolution, error: cacheReadError } : resolution,
+				options,
+			);
+		},
+	};
+}
+
+function defaultCachePath(): string {
+	return join(codememHomeDir(), ".codemem", "release-discovery.json");
+}
+
+export function createReleaseCacheIo(cachePath: string): ReleaseCacheIo {
+	const directory = dirname(cachePath);
+	return {
+		async readCache(): Promise<string | null> {
+			try {
+				return await readFile(cachePath, "utf8");
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+				throw error;
+			}
+		},
+		async writeCacheAtomic(contents: string): Promise<void> {
+			await mkdir(directory, { recursive: true, mode: 0o700 });
+			const temporaryPath = join(
+				directory,
+				`.release-discovery.${process.pid}.${randomUUID()}.tmp`,
+			);
+			let handle: Awaited<ReturnType<typeof open>> | null = null;
+			try {
+				handle = await open(temporaryPath, "wx", 0o600);
+				await handle.writeFile(contents, "utf8");
+				await handle.sync();
+				await handle.close();
+				handle = null;
+				await rename(temporaryPath, cachePath);
+			} catch (error) {
+				await handle?.close().catch(() => undefined);
+				await unlink(temporaryPath).catch(() => undefined);
+				throw error;
+			}
+		},
+	};
+}
+
+function isPinnedSource(source: string): boolean {
+	if (!source || source.length > MAX_RUNNER_SOURCE_LENGTH) return false;
+	const containsWhitespace = (value: string): boolean => {
+		for (const character of value) {
+			if (character.trim() === "") return true;
+		}
+		return false;
+	};
+	const normalized = source.toLowerCase();
+	if (normalized.startsWith("codemem@")) {
+		const requested = source.slice("codemem@".length);
+		return (
+			requested.length > 0 &&
+			!containsWhitespace(requested) &&
+			!["latest", "next", "*"].includes(requested.toLowerCase())
+		);
+	}
+	if (!source.startsWith("git+") && !source.includes(".git")) return false;
+	const queryIndex = source.indexOf("?");
+	const fragmentIndex = source.indexOf("#");
+	const boundaryIndexes = [queryIndex, fragmentIndex].filter((index) => index >= 0);
+	const boundary = boundaryIndexes.length > 0 ? Math.min(...boundaryIndexes) : source.length;
+	const withoutQuery = source.slice(0, boundary);
+	const gitRefIndex = withoutQuery.toLowerCase().lastIndexOf(".git@");
+	const gitRef = gitRefIndex >= 0 ? withoutQuery.slice(gitRefIndex + ".git@".length) : "";
+	if (gitRef.length > 0 && !gitRef.includes("/") && !containsWhitespace(gitRef)) return true;
+	const fragment = fragmentIndex >= 0 ? source.slice(fragmentIndex + 1) : "";
+	return fragment.length > 0 && !containsWhitespace(fragment);
+}
+
+export function detectInstallKind(input: InstallDetectionInput): InstallKind {
+	const env = input.env ?? {};
+	const explicit = env.CODEMEM_INSTALL_KIND?.trim().toLowerCase();
+	const knownKinds: readonly InstallKind[] = [
+		"npm-global",
+		"npx",
+		"docker",
+		"repo-dev",
+		"pinned",
+		"unknown",
+	];
+	if (explicit) {
+		return knownKinds.includes(explicit as InstallKind) ? (explicit as InstallKind) : "unknown";
+	}
+
+	const source = env.CODEMEM_RUNNER_FROM?.trim() ?? "";
+	if (isPinnedSource(source)) return "pinned";
+	const runner = env.CODEMEM_RUNNER?.trim().toLowerCase();
+	if (runner === "node" || runner === "uv") return "repo-dev";
+	if (runner === "npx") return "npx";
+
+	const entryPath = input.entryPath.replaceAll("\\", "/");
+	if (/\/packages\/cli\/src\/index\.ts$/.test(entryPath)) return "repo-dev";
+	if (/\/(?:_npx|\.pnpm\/dlx)\//.test(entryPath)) return "npx";
+	if (/\/lib\/node_modules\/codemem\/dist\/index\.js$/.test(entryPath)) {
+		return "npm-global";
+	}
+	if (/\/AppData\/Roaming\/npm\/node_modules\/codemem\/dist\/index\.js$/i.test(entryPath)) {
+		return "npm-global";
+	}
+	return "unknown";
+}
+
+const defaultReleaseDiscovery = createReleaseDiscovery({
+	fetch: (url, init) => fetch(url, init),
+	now: () => new Date(),
+	readCache: () => createReleaseCacheIo(defaultCachePath()).readCache(),
+	writeCacheAtomic: (contents) =>
+		createReleaseCacheIo(defaultCachePath()).writeCacheAtomic(contents),
+	timeoutSignal: (milliseconds) => AbortSignal.timeout(milliseconds),
+});
+
+export interface GetUpdateStatusOptions {
+	currentVersion: string;
+	installKind?: InstallKind;
+	refresh?: boolean;
+}
+
+export function getUpdateStatus(options: GetUpdateStatusOptions): Promise<UpdateStatus> {
+	return defaultReleaseDiscovery.check({
+		currentVersion: options.currentVersion,
+		installKind: options.installKind ?? "unknown",
+		refresh: options.refresh,
+	});
+}


### PR DESCRIPTION
## Description

Adds shared release discovery and installation-kind detection for the CLI, including cached npm metadata, upgrade guidance, and the `codemem update check` command. The implementation fails closed for unknown or pinned installation sources and uses bounded string parsing for runner metadata to avoid polynomial regex behavior.

This is PR 1 of 4 in the update-notifications stack.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated the full stack with 4,246 passing tests before submission. After the CodeQL hardening, reran the focused release-discovery suite (66 tests), TypeScript, lint, and `git diff --check`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
