### PR TITLE
feat(update): surface release notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ usage command; use `sync status`/`sync doctor`, `maintenance status`, and
 `codemem update check` is read-only: it reports the latest validated stable release and
 installation-specific guidance but never installs anything. Results are cached for six hours;
 pass `--refresh` to force a registry request or `--json` for one stable status object.
+The Viewer Health page reads the same status from `/api/update-status`. The OpenCode plugin
+checks it after startup and shows at most one best-effort notification for each newly discovered
+release. Set `CODEMEM_BACKEND_UPDATE_POLICY=off` to disable release checks; `notify` and `auto`
+both remain notification-only for release discovery in this delivery slice. Docker guidance is
+always rebuild-and-restart guidance, never an in-container update.
 
 Pack rendering defaults to self-contained context. For token-constrained experiments, `codemem pack <context> --compact` renders an index plus top details. Near-related compression is controlled by `--compression-mode off|compact|ids` (or `CODEMEM_PACK_COMPRESSION`); MCP `memory_pack` exposes the same setting as `compression_mode`. Use `ids` only when the agent can follow up with `memory_get_observations`.
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -369,7 +369,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_INJECT_MAX_CHARS` | Max chars returned as Claude/Codex `additionalContext` (default `16000`). |
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
 | `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |
-| `CODEMEM_BACKEND_UPDATE_POLICY` | Backend update behavior on compatibility mismatch: `notify` (default), `auto`, or `off`. |
+| `CODEMEM_BACKEND_UPDATE_POLICY` | Compatibility and release-notification policy: `notify` (default), `auto`, or `off`. |
 | `CODEMEM_INSTALL_KIND` | Internal/advanced release-guidance detection override (`npm-global`, `npx`, `docker`, `repo-dev`, `pinned`, or `unknown`). This does not enable installation. |
 | `CODEMEM_CODEX_ENDPOINT` | Override Codex OAuth endpoint. |
 | `CODEMEM_PLUGIN_DEBUG` | Set to `1`, `true`, or `yes` to log plugin lifecycle events. |
@@ -420,10 +420,17 @@ When the plugin detects CLI/runtime version mismatch, it shows guidance based on
 Update policy:
 
 - `CODEMEM_BACKEND_UPDATE_POLICY=notify` (default): show warning toast with suggested action
-- `CODEMEM_BACKEND_UPDATE_POLICY=auto`: try a best-effort auto-update for eligible runners, then warn if still outdated
+- `CODEMEM_BACKEND_UPDATE_POLICY=auto`: try a best-effort auto-update for eligible compatibility-floor mismatches, then warn if still outdated
   - skipped for `node` dev-mode runners
   - skipped when `CODEMEM_RUNNER_FROM` is pinned to a fixed package/version
 - `CODEMEM_BACKEND_UPDATE_POLICY=off`: no compatibility toast (logging still records mismatch)
+
+After its startup delay, the plugin also runs `codemem update check --json` through the same
+argv-based CLI runner. `notify` and `auto` show a best-effort toast at most once per latest stable
+release in the current OpenCode process; `off` skips this release check. This release-discovery
+path is read-only: `auto` does not install a discovered release. Current, unavailable, malformed,
+and timed-out results are ignored without delaying plugin startup. Compatibility-floor handling
+above remains separate and unchanged.
 
 Docker images set `CODEMEM_INSTALL_KIND=docker` so release guidance cannot mistake the bundled
 global npm package for a host npm installation. Docker deployments never self-update; rebuild and

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -64,8 +64,9 @@ Tag only after the release PR has merged to `main` and you have verified that `H
 `codemem update check` queries the fixed public npm registry endpoint for the latest stable
 `codemem` release. Results are cached locally for six hours; use `--refresh` to bypass a fresh
 cache and `--json` for the stable automation contract. If a refresh fails, a previously validated
-cache may be returned as stale guidance. Release discovery is informational and does not install
-or execute anything.
+cache may be returned as stale guidance. A running process backs off failed registry checks for 15
+minutes, while `--refresh` bypasses that backoff. Release discovery is informational and does not
+install or execute anything.
 
 Release discovery compares the running product version with the latest published stable release.
 It is separate from the compatibility-floor check below: discovering a newer release does not

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -1,0 +1,279 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const spawnMock = vi.fn();
+const execSyncMock = vi.fn(() => "test-version");
+
+vi.mock("node:child_process", () => ({
+	spawn: (...args) => spawnMock(...args),
+	execSync: (...args) => execSyncMock(...args),
+}));
+
+const currentStatus = {
+	current_version: "0.40.2",
+	latest_version: "0.40.2",
+	update_available: false,
+	first_seen_at: "2026-08-10T12:00:00.000Z",
+	checked_at: "2026-08-10T12:00:00.000Z",
+	stale: false,
+	install_kind: "npm-global",
+	auto_update_eligible: false,
+	recommended_action: "No action required; codemem is up to date.",
+	error: null,
+};
+
+const availableStatus = {
+	...currentStatus,
+	latest_version: "0.41.0",
+	update_available: true,
+	recommended_action: "npm install -g codemem@0.41.0",
+};
+
+function makeProcess({ stdout = "", stderr = "", exitCode = 0, settle = true } = {}) {
+	const proc = new EventEmitter();
+	proc.stdout = new EventEmitter();
+	proc.stderr = new EventEmitter();
+	proc.stdin = { write: vi.fn(), end: vi.fn() };
+	proc.kill = vi.fn();
+	if (settle) {
+		queueMicrotask(() => {
+			if (stdout) proc.stdout.emit("data", stdout);
+			if (stderr) proc.stderr.emit("data", stderr);
+			proc.emit("exit", exitCode);
+		});
+	}
+	return proc;
+}
+
+function installSpawnResult(status = availableStatus) {
+	spawnMock.mockImplementation((_command, args) => {
+		if (args?.includes("update") && args?.includes("check")) {
+			return makeProcess({ stdout: JSON.stringify(status) });
+		}
+		if (args?.includes("version")) return makeProcess({ stdout: "0.40.2\n" });
+		return makeProcess();
+	});
+}
+
+async function startPlugin(showToast = vi.fn().mockResolvedValue(undefined)) {
+	const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+	const hooks = await OpencodeMemPlugin({
+		project: { name: "codemem" },
+		client: {
+			app: { log: vi.fn().mockResolvedValue(undefined) },
+			tui: { showToast },
+		},
+		directory: "/tmp/codemem",
+		worktree: "/tmp/codemem",
+	});
+	return { hooks, showToast };
+}
+
+async function runStartupChecks() {
+	await vi.advanceTimersByTimeAsync(1_500);
+	await vi.runAllTicks();
+}
+
+describe("OpenCode startup release notifications", () => {
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.resetModules();
+		spawnMock.mockReset();
+		execSyncMock.mockClear();
+		process.env = {
+			...originalEnv,
+			CODEMEM_RUNNER: "codemem",
+			CODEMEM_VIEWER: "0",
+			CODEMEM_PLUGIN_LOG: "0",
+			CODEMEM_INJECT_CONTEXT: "0",
+			CODEMEM_BACKEND_UPDATE_POLICY: "notify",
+		};
+	});
+
+	afterEach(() => {
+		vi.clearAllTimers();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		process.env = originalEnv;
+	});
+
+	test("runs `codemem update check --json` asynchronously through the existing runner", async () => {
+		// Arrange
+		installSpawnResult();
+
+		// Act
+		const { hooks } = await startPlugin();
+		const callsBeforeDelay = spawnMock.mock.calls.length;
+		await runStartupChecks();
+
+		// Assert
+		expect(hooks).toBeTypeOf("object");
+		expect(callsBeforeDelay).toBe(0);
+		expect(spawnMock).toHaveBeenCalledWith(
+			"codemem",
+			expect.arrayContaining(["update", "check", "--json"]),
+			expect.objectContaining({ cwd: "/tmp/codemem" }),
+		);
+		const updateCall = spawnMock.mock.calls.find((call) => call[1]?.includes("update"));
+		expect(updateCall?.[2]).not.toHaveProperty("shell");
+	});
+
+	test("notify shows an actionable release toast only once for the same latest version", async () => {
+		// Arrange
+		installSpawnResult();
+		const showToast = vi.fn().mockResolvedValue(undefined);
+
+		// Act
+		await startPlugin(showToast);
+		await runStartupChecks();
+		await startPlugin(showToast);
+		await runStartupChecks();
+
+		// Assert
+		expect(showToast).toHaveBeenCalledTimes(1);
+		expect(showToast).toHaveBeenCalledWith({
+			body: expect.objectContaining({
+				message: expect.stringMatching(/0\.41\.0.*npm install -g codemem@0\.41\.0/i),
+			}),
+		});
+	});
+
+	test("notify allows a new toast when the discovered latest version changes", async () => {
+		// Arrange
+		let status = availableStatus;
+		spawnMock.mockImplementation((_command, args) => {
+			if (args?.includes("update") && args?.includes("check")) {
+				return makeProcess({ stdout: JSON.stringify(status) });
+			}
+			if (args?.includes("version")) return makeProcess({ stdout: "0.40.2\n" });
+			return makeProcess();
+		});
+		const showToast = vi.fn().mockResolvedValue(undefined);
+
+		// Act
+		await startPlugin(showToast);
+		await runStartupChecks();
+		status = {
+			...availableStatus,
+			latest_version: "0.42.0",
+			recommended_action: "npm install -g codemem@0.42.0",
+		};
+		await startPlugin(showToast);
+		await runStartupChecks();
+
+		// Assert
+		expect(showToast).toHaveBeenCalledTimes(2);
+		expect(showToast.mock.calls[1]?.[0]?.body?.message).toMatch(/0\.42\.0/);
+	});
+
+	test("off skips release discovery and notification without disabling compatibility checks", async () => {
+		// Arrange
+		process.env.CODEMEM_BACKEND_UPDATE_POLICY = "off";
+		installSpawnResult();
+		const showToast = vi.fn().mockResolvedValue(undefined);
+
+		// Act
+		await startPlugin(showToast);
+		await runStartupChecks();
+
+		// Assert
+		const args = spawnMock.mock.calls.map((call) => call[1]);
+		expect(args.some((value) => value?.includes("version"))).toBe(true);
+		expect(args.some((value) => value?.includes("update"))).toBe(false);
+		expect(showToast).not.toHaveBeenCalled();
+	});
+
+	test("auto remains read-only in PR2 while still notifying about an available release", async () => {
+		// Arrange
+		process.env.CODEMEM_BACKEND_UPDATE_POLICY = "auto";
+		installSpawnResult();
+		const showToast = vi.fn().mockResolvedValue(undefined);
+
+		// Act
+		await startPlugin(showToast);
+		await runStartupChecks();
+
+		// Assert
+		const args = spawnMock.mock.calls.map((call) => call[1]);
+		expect(args.some((value) => value?.includes("update") && value?.includes("check"))).toBe(true);
+		expect(args.some((value) => value?.includes("install"))).toBe(false);
+		expect(showToast).toHaveBeenCalledTimes(1);
+	});
+
+	test.each([
+		["current", currentStatus, 0],
+		["unavailable", { ...currentStatus, latest_version: null, checked_at: null, error: "offline" }, 1],
+		["malformed", "not-json", 0],
+	])("ignores %s update-check results", async (_label, result, exitCode) => {
+		// Arrange
+		spawnMock.mockImplementation((_command, args) => {
+			if (args?.includes("update") && args?.includes("check")) {
+				return makeProcess({
+					stdout: typeof result === "string" ? result : JSON.stringify(result),
+					exitCode,
+				});
+			}
+			if (args?.includes("version")) return makeProcess({ stdout: "0.40.2\n" });
+			return makeProcess();
+		});
+		const showToast = vi.fn().mockResolvedValue(undefined);
+
+		// Act
+		await startPlugin(showToast);
+		await runStartupChecks();
+
+		// Assert
+		expect(
+			spawnMock.mock.calls.some(
+				(call) => call[1]?.includes("update") && call[1]?.includes("check") && call[1]?.includes("--json"),
+			),
+		).toBe(true);
+		expect(showToast).not.toHaveBeenCalled();
+	});
+
+	test("a hanging update check never blocks plugin startup", async () => {
+		// Arrange
+		spawnMock.mockImplementation((_command, args) => {
+			if (args?.includes("update") && args?.includes("check")) return makeProcess({ settle: false });
+			if (args?.includes("version")) return makeProcess({ stdout: "0.40.2\n" });
+			return makeProcess();
+		});
+
+		// Act
+		const startup = startPlugin();
+		const result = await startup;
+		await runStartupChecks();
+
+		// Assert
+		expect(result.hooks).toBeTypeOf("object");
+		expect(
+			spawnMock.mock.calls.some(
+				(call) => call[1]?.includes("update") && call[1]?.includes("check") && call[1]?.includes("--json"),
+			),
+		).toBe(true);
+	});
+
+	test("Docker notifications remain rebuild-only", async () => {
+		// Arrange
+		installSpawnResult({
+			...availableStatus,
+			install_kind: "docker",
+			recommended_action:
+				"Set CODEMEM_VERSION=0.41.0, then run CODEMEM_VERSION=0.41.0 docker compose build --pull and docker compose up -d.",
+		});
+		const showToast = vi.fn().mockResolvedValue(undefined);
+
+		// Act
+		await startPlugin(showToast);
+		await runStartupChecks();
+
+		// Assert
+		const message = showToast.mock.calls[0]?.[0]?.body?.message ?? "";
+		expect(message).toContain("docker compose build --pull");
+		expect(message).toContain("docker compose up -d");
+		expect(message).not.toMatch(/npm install|codemem update install|self-update/i);
+		expect(spawnMock.mock.calls.some((call) => call[1]?.includes("install"))).toBe(false);
+	});
+});

--- a/packages/core/src/release-discovery.test.ts
+++ b/packages/core/src/release-discovery.test.ts
@@ -462,6 +462,20 @@ describe("release discovery cache contract", () => {
 		expect(deps.fetch).toHaveBeenCalledTimes(1);
 	});
 
+	it("forced refresh bypasses a fresh in-memory result", async () => {
+		// Arrange
+		const deps = dependencies();
+		const discovery = createReleaseDiscovery(deps);
+		const options = { currentVersion: "0.40.2", installKind: "npm-global" as const };
+
+		// Act
+		await discovery.check(options);
+		await discovery.check({ ...options, refresh: true });
+
+		// Assert
+		expect(deps.fetch).toHaveBeenCalledTimes(2);
+	});
+
 	it("ignores malformed cache content and refreshes from the registry", async () => {
 		// Arrange
 		const deps = dependencies({ cache: "{ definitely-not-json" });
@@ -554,6 +568,70 @@ describe("release discovery cache contract", () => {
 			stale: false,
 		});
 		expect(status.error).toMatch(/rename denied|cache/i);
+	});
+
+	it("reuses a fresh in-memory result when the cache cannot be written", async () => {
+		// Arrange
+		const deps = dependencies({ writeError: new Error("rename denied") });
+		const discovery = createReleaseDiscovery(deps);
+		const options = { currentVersion: "0.40.2", installKind: "npm-global" as const };
+
+		// Act
+		const first = await discovery.check(options);
+		const second = await discovery.check(options);
+
+		// Assert
+		expect(deps.fetch).toHaveBeenCalledTimes(1);
+		expect(second).toEqual(first);
+	});
+
+	it("backs off sequential registry failures when no cache exists", async () => {
+		// Arrange
+		const deps = dependencies({ fetchError: new Error("registry offline") });
+		const discovery = createReleaseDiscovery(deps);
+		const options = { currentVersion: "0.40.2", installKind: "npm-global" as const };
+
+		// Act
+		const first = await discovery.check(options);
+		const second = await discovery.check(options);
+
+		// Assert
+		expect(deps.fetch).toHaveBeenCalledTimes(1);
+		expect(second).toEqual(first);
+	});
+
+	it("retries registry discovery after the failure backoff expires", async () => {
+		// Arrange
+		let currentTime = NOW;
+		const deps = dependencies({ fetchError: new Error("registry offline") });
+		deps.now = () => currentTime;
+		const discovery = createReleaseDiscovery(deps);
+		const options = { currentVersion: "0.40.2", installKind: "npm-global" as const };
+
+		// Act
+		await discovery.check(options);
+		currentTime = new Date(NOW.getTime() + 15 * 60 * 1_000);
+		await discovery.check(options);
+
+		// Assert
+		expect(deps.fetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps backing off registry failures when the wall clock moves backwards", async () => {
+		// Arrange
+		let currentTime = NOW;
+		const deps = dependencies({ fetchError: new Error("registry offline") });
+		deps.now = () => currentTime;
+		const discovery = createReleaseDiscovery(deps);
+		const options = { currentVersion: "0.40.2", installKind: "npm-global" as const };
+
+		// Act
+		await discovery.check(options);
+		currentTime = new Date(NOW.getTime() - 60 * 1_000);
+		await discovery.check(options);
+
+		// Assert
+		expect(deps.fetch).toHaveBeenCalledTimes(1);
 	});
 
 	it("returns fresh status with a warning when reading the cache fails", async () => {

--- a/packages/core/src/release-discovery.ts
+++ b/packages/core/src/release-discovery.ts
@@ -6,6 +6,7 @@ import { codememHomeDir } from "./home.js";
 const REGISTRY_URL = "https://registry.npmjs.org/codemem/latest";
 const REQUEST_TIMEOUT_MS = 2_000;
 const CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1_000;
+const FAILURE_RETRY_DELAY_MS = 15 * 60 * 1_000;
 const MAX_RESPONSE_BYTES = 16 * 1_024;
 const MAX_VERSION_LENGTH = 128;
 const MAX_RUNNER_SOURCE_LENGTH = 4_096;
@@ -274,6 +275,15 @@ function toStatus(resolution: ReleaseResolution, options: ReleaseCheckOptions): 
 
 export function createReleaseDiscovery(deps: ReleaseDiscoveryDependencies): ReleaseDiscovery {
 	let inFlight: Promise<ReleaseResolution> | null = null;
+	let memoryResolution: { resolution: ReleaseResolution; resolvedAtMs: number } | null = null;
+
+	function canReuseMemoryResolution(now: Date): boolean {
+		if (!memoryResolution) return false;
+		const ageMs = Math.max(0, now.getTime() - memoryResolution.resolvedAtMs);
+		const { resolution } = memoryResolution;
+		if (resolution.record && !resolution.stale && isFresh(resolution.record, now)) return true;
+		return resolution.error !== null && ageMs < FAILURE_RETRY_DELAY_MS;
+	}
 
 	async function refresh(cached: ReleaseCacheRecord | null, now: Date): Promise<ReleaseResolution> {
 		try {
@@ -313,12 +323,22 @@ export function createReleaseDiscovery(deps: ReleaseDiscoveryDependencies): Rele
 			if (!options.refresh && cached && isFresh(cached, now)) {
 				return toStatus({ record: cached, stale: false, error: null }, options);
 			}
+			if (!options.refresh && canReuseMemoryResolution(now) && memoryResolution) {
+				const resolution = memoryResolution.resolution;
+				return toStatus(
+					cacheReadError && !resolution.error
+						? { ...resolution, error: cacheReadError }
+						: resolution,
+					options,
+				);
+			}
 			if (!inFlight) {
 				inFlight = refresh(cached, now).finally(() => {
 					inFlight = null;
 				});
 			}
 			const resolution = await inFlight;
+			memoryResolution = { resolution, resolvedAtMs: deps.now().getTime() };
 			return toStatus(
 				cacheReadError && !resolution.error ? { ...resolution, error: cacheReadError } : resolution,
 				options,

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -19,6 +19,11 @@ const DISABLED_VALUES = ["0", "false", "off"];
 const PINNED_BACKEND_VERSION = "0.40.2";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_UPDATE_STATUS_BYTES = 16 * 1024;
+const MAX_UPDATE_ACTION_CHARS = 1000;
+const MAX_UPDATE_VERSION_CHARS = 128;
+const STABLE_RELEASE_VERSION =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const CODEMEM_CONTEXT_PART_ID_PREFIX = "codemem-context-";
 const MAX_MESSAGE_INJECTION_CACHE_SESSIONS = 20;
 const MAX_MESSAGE_INJECTION_CACHE_MESSAGES = 100;
@@ -31,6 +36,7 @@ const VIEWER_HEALTH_RESTART_COOLDOWN_MS = 5 * 60_000;
 const RAW_EVENTS_STATUS_TIMEOUT_MS = 5_000;
 
 let compatCheckCache = null;
+const notifiedReleaseVersions = new Set();
 
 // Release an unread response body without surfacing cancellation failures.
 const discardResponseBody = (response) => {
@@ -344,6 +350,39 @@ const writeCompatCheckCache = (cacheKey, value) => {
 
 const clearCompatCheckCache = () => {
   compatCheckCache = null;
+};
+
+const isStableReleaseVersion = (value) => {
+  if (typeof value !== "string" || value.length > MAX_UPDATE_VERSION_CHARS) return false;
+  const match = STABLE_RELEASE_VERSION.exec(value);
+  return Boolean(match && match.slice(1, 4).map(Number).every(Number.isSafeInteger));
+};
+
+const parseReleaseNotification = (result) => {
+  if (result?.exitCode !== 0) return null;
+  const stdout = String(result?.stdout || "").trim();
+  if (!stdout || Buffer.byteLength(stdout, "utf8") > MAX_UPDATE_STATUS_BYTES) return null;
+  try {
+    const status = JSON.parse(stdout);
+    if (!status || typeof status !== "object" || Array.isArray(status)) return null;
+    if (status.update_available !== true) return null;
+    if (!isStableReleaseVersion(status.latest_version)) {
+      return null;
+    }
+    if (
+      typeof status.recommended_action !== "string"
+      || !status.recommended_action.trim()
+      || status.recommended_action.length > MAX_UPDATE_ACTION_CHARS
+    ) {
+      return null;
+    }
+    return {
+      latestVersion: status.latest_version,
+      recommendedAction: status.recommended_action.trim(),
+    };
+  } catch {
+    return null;
+  }
 };
 
 const createLogLine = (logPath) => async (line) => {
@@ -2686,6 +2725,25 @@ export const OpencodeMemPlugin = async ({
     await showToast(`${message}. Suggested action: ${guidance.action}`, "warning");
   };
 
+  const checkForReleaseUpdate = async () => {
+    if (backendUpdatePolicy === "off") return;
+    const notification = parseReleaseNotification(
+      await runCli(["update", "check", "--json"])
+    );
+    if (
+      !notification
+      || !client.tui?.showToast
+      || notifiedReleaseVersions.has(notification.latestVersion)
+    ) {
+      return;
+    }
+    notifiedReleaseVersions.add(notification.latestVersion);
+    await showToast(
+      `codemem ${notification.latestVersion} is available. ${notification.recommendedAction}`,
+      "warning"
+    );
+  };
+
   const resolveInjectQuery = (overrides = {}) => {
     const firstPrompt = hasOwn(overrides, "firstPrompt")
       ? overrides.firstPrompt
@@ -3153,6 +3211,14 @@ export const OpencodeMemPlugin = async ({
     });
   }, COMPAT_CHECK_DELAY_MS);
   if (compatCheckTimer.unref) compatCheckTimer.unref();
+  const releaseCheckTimer = setTimeout(() => {
+    void checkForReleaseUpdate().catch(async (err) => {
+      await logLine(
+        `release.update_check_error message=${String(err?.message || err || "unknown")}`
+      );
+    });
+  }, COMPAT_CHECK_DELAY_MS);
+  if (releaseCheckTimer.unref) releaseCheckTimer.unref();
 
   const truncate = (value) => {
     if (value === undefined || value === null) {

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -141,4 +141,6 @@ export type {
 	RuntimeInfo,
 	SyncRunItem,
 	SyncRunResponse,
+	UpdateStatus,
 } from "./api/types";
+export { loadUpdateStatus, unavailableUpdateStatus } from "./api/update-status";

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -55,6 +55,20 @@ export interface RuntimeInfo {
 	version: string;
 }
 
+/** Browser-side mirror of the additive /api/update-status wire contract. */
+export interface UpdateStatus {
+	current_version: string;
+	latest_version: string | null;
+	update_available: boolean;
+	first_seen_at: string | null;
+	checked_at: string | null;
+	stale: boolean;
+	install_kind: "npm-global" | "npx" | "docker" | "repo-dev" | "pinned" | "unknown";
+	auto_update_eligible: boolean;
+	recommended_action: string;
+	error: string | null;
+}
+
 export interface PackTraceCandidate {
 	id: number;
 	rank: number;

--- a/packages/ui/src/lib/api/update-status.ts
+++ b/packages/ui/src/lib/api/update-status.ts
@@ -1,0 +1,21 @@
+import { fetchJson } from "./internal";
+import type { UpdateStatus } from "./types";
+
+export async function loadUpdateStatus(): Promise<UpdateStatus> {
+	return fetchJson<UpdateStatus>("/api/update-status");
+}
+
+export function unavailableUpdateStatus(error: unknown): UpdateStatus {
+	return {
+		current_version: "unknown",
+		latest_version: null,
+		update_available: false,
+		first_seen_at: null,
+		checked_at: null,
+		stale: false,
+		install_kind: "unknown",
+		auto_update_eligible: false,
+		recommended_action: "Check network access and try again.",
+		error: error instanceof Error ? error.message : "Update status request failed.",
+	};
+}

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -6,6 +6,7 @@ import type {
 	UiSyncViewModel,
 } from "../tabs/sync/view-model";
 import type { ShareOperationReadModel } from "./api/sync";
+import type { UpdateStatus } from "./api/types";
 
 export type RefreshState = "idle" | "refreshing" | "paused" | "error";
 export type CanonicalTabId = "feed" | "projects" | "sharing" | "devices" | "health" | "advanced";
@@ -259,6 +260,7 @@ export const state = {
 	lastStatsPayload: null as CachedStatsPayload | null,
 	lastUsagePayload: null as CachedUsagePayload | null,
 	lastRawEventsPayload: null as CachedRawEventsPayload | null,
+	lastUpdateStatus: null as UpdateStatus | null,
 	lastSyncStatus: null as CachedSyncStatus | null,
 	lastSyncActors: [] as SyncActor[],
 	lastSyncPeers: [] as SyncPeer[],

--- a/packages/ui/src/tabs/health.test.ts
+++ b/packages/ui/src/tabs/health.test.ts
@@ -1,0 +1,196 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UpdateStatus } from "../lib/api";
+import * as api from "../lib/api";
+import { state } from "../lib/state";
+import { renderHealthOverview } from "./health";
+import { loadHealthData } from "./health/lifecycle";
+
+vi.mock("../components/primitives/tooltip", () => ({
+	Tooltip: ({ children }: { children?: unknown }) => children,
+	TooltipProvider: ({ children }: { children?: unknown }) => children,
+}));
+
+const availableStatus: UpdateStatus = {
+	current_version: "0.40.2",
+	latest_version: "0.41.0",
+	update_available: true,
+	first_seen_at: "2026-08-10T12:00:00.000Z",
+	checked_at: "2026-08-10T12:00:00.000Z",
+	stale: false,
+	install_kind: "npm-global",
+	auto_update_eligible: false,
+	recommended_action: "npm install -g codemem@0.41.0",
+	error: null,
+};
+
+function setUpdateStatus(status: UpdateStatus | null): void {
+	state.lastUpdateStatus = status;
+}
+
+function renderOverview(): void {
+	act(() => renderHealthOverview());
+}
+
+function updateBannerText(): string {
+	return document.getElementById("healthUpdateBanner")?.textContent ?? "";
+}
+
+beforeEach(() => {
+	// Arrange shared Health DOM and otherwise healthy state.
+	document.body.innerHTML = `
+		<div id="healthUpdateBanner"></div>
+		<div id="healthGrid"></div>
+		<div id="healthMeta"></div>
+		<div id="healthActions"></div>
+		<div id="healthDot"></div>
+	`;
+	state.lastStatsPayload = {};
+	state.lastUsagePayload = {};
+	state.lastRawEventsPayload = {};
+	state.lastSyncStatus = { enabled: false, daemon_state: "disabled" };
+	state.lastSyncPeers = [];
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	state.activeTab = "feed";
+	setUpdateStatus(null);
+	for (const id of ["healthUpdateBanner", "healthGrid", "healthActions"]) {
+		const element = document.getElementById(id);
+		if (element) act(() => render(null, element));
+	}
+	document.body.innerHTML = "";
+});
+
+describe("Health update banner", () => {
+	it("loads update status only once after the Health tab becomes active", async () => {
+		// Arrange
+		vi.spyOn(api, "loadStats").mockResolvedValue({});
+		vi.spyOn(api, "loadUsage").mockResolvedValue({});
+		vi.spyOn(api, "loadSession").mockResolvedValue({});
+		vi.spyOn(api, "loadRawEvents").mockResolvedValue({});
+		const loadUpdateStatus = vi.spyOn(api, "loadUpdateStatus").mockResolvedValue(availableStatus);
+
+		// Act
+		state.activeTab = "feed";
+		await loadHealthData();
+		state.activeTab = "health";
+		await loadHealthData();
+		await loadHealthData();
+
+		// Assert
+		expect(loadUpdateStatus).toHaveBeenCalledTimes(1);
+	});
+
+	it("shows the current installed version as up to date", () => {
+		// Arrange
+		setUpdateStatus({
+			...availableStatus,
+			latest_version: "0.40.2",
+			update_available: false,
+			recommended_action: "No action required; codemem is up to date.",
+		});
+
+		// Act
+		renderOverview();
+
+		// Assert
+		expect(updateBannerText()).toMatch(/0\.40\.2.*up to date/i);
+		expect(updateBannerText()).not.toContain("npm install");
+		const banner = document.querySelector("#healthUpdateBanner [role='status']");
+		expect(banner?.getAttribute("aria-label")).toBe("Codemem update status");
+		expect(banner?.getAttribute("aria-atomic")).toBe("true");
+		expect(banner?.querySelector("[data-lucide]")?.getAttribute("data-lucide")).toBe(
+			"circle-arrow-up",
+		);
+	});
+
+	it("does not present an unparseable installed version as current", () => {
+		// Arrange
+		setUpdateStatus({
+			...availableStatus,
+			current_version: "0.41.0-rc.1",
+			update_available: false,
+			recommended_action: "Verify the current codemem version and try again.",
+		});
+
+		// Act
+		renderOverview();
+
+		// Assert
+		expect(updateBannerText()).toMatch(/unable to compare/i);
+		expect(updateBannerText()).toContain("Verify the current codemem version and try again.");
+		expect(updateBannerText()).not.toMatch(/up to date|latest stable release/i);
+	});
+
+	it("shows an available release with npm-global installation guidance", () => {
+		// Arrange
+		setUpdateStatus(availableStatus);
+
+		// Act
+		renderOverview();
+
+		// Assert
+		expect(updateBannerText()).toContain("0.41.0");
+		expect(updateBannerText()).toContain("0.40.2");
+		expect(updateBannerText()).toContain("npm install -g codemem@0.41.0");
+	});
+
+	it("qualifies stale release guidance as cached instead of presenting it as fresh", () => {
+		// Arrange
+		setUpdateStatus({ ...availableStatus, stale: true, error: "registry offline" });
+
+		// Act
+		renderOverview();
+
+		// Assert
+		expect(updateBannerText()).toMatch(/cached|stale/i);
+		expect(updateBannerText()).toContain("registry offline");
+		expect(updateBannerText()).toContain(availableStatus.recommended_action);
+	});
+
+	it("shows a recoverable unavailable state without claiming the installation is current", () => {
+		// Arrange
+		setUpdateStatus({
+			...availableStatus,
+			latest_version: null,
+			update_available: false,
+			first_seen_at: null,
+			checked_at: null,
+			install_kind: "unknown",
+			recommended_action: "Check network access and try again.",
+			error: "registry request timed out",
+		});
+
+		// Act
+		renderOverview();
+
+		// Assert
+		expect(updateBannerText()).toMatch(/unavailable|could not check|couldn't check/i);
+		expect(updateBannerText()).toContain("registry request timed out");
+		expect(updateBannerText()).toContain("Check network access and try again.");
+		expect(updateBannerText()).not.toMatch(/up to date/i);
+	});
+
+	it("keeps Docker guidance rebuild-only and never offers an in-container update", () => {
+		// Arrange
+		setUpdateStatus({
+			...availableStatus,
+			install_kind: "docker",
+			recommended_action:
+				"Set CODEMEM_VERSION=0.41.0, then run CODEMEM_VERSION=0.41.0 docker compose build --pull and docker compose up -d.",
+		});
+
+		// Act
+		renderOverview();
+
+		// Assert
+		const banner = updateBannerText();
+		expect(banner).toContain("CODEMEM_VERSION=0.41.0");
+		expect(banner).toContain("docker compose build --pull");
+		expect(banner).toContain("docker compose up -d");
+		expect(banner).not.toMatch(/npm install|codemem update install|self-update/i);
+	});
+});

--- a/packages/ui/src/tabs/health/components.ts
+++ b/packages/ui/src/tabs/health/components.ts
@@ -7,6 +7,7 @@
 
 import { Fragment, h, render } from "preact";
 import { Tooltip, TooltipProvider } from "../../components/primitives/tooltip";
+import type { UpdateStatus } from "../../lib/api";
 import { copyToClipboard } from "../../lib/dom";
 import type {
 	HealthAction,
@@ -16,8 +17,105 @@ import type {
 	StatItem,
 } from "./types";
 
+const STABLE_RELEASE_VERSION =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function isStableReleaseVersion(value: string): boolean {
+	const match = STABLE_RELEASE_VERSION.exec(value);
+	return Boolean(match?.slice(1, 4).map(Number).every(Number.isSafeInteger));
+}
+
 export function buildHealthCard(input: HealthCardInput): HealthCardInput {
 	return input;
+}
+
+function updateBannerCopy(status: UpdateStatus) {
+	if (!status.latest_version) {
+		return {
+			title: "Update check unavailable",
+			detail: status.error
+				? `Could not check for updates: ${status.error}`
+				: "Could not check for updates.",
+			tone: "unavailable",
+		};
+	}
+
+	if (status.stale) {
+		return {
+			title: status.update_available
+				? `Cached update status: Codemem ${status.latest_version} is available`
+				: `Cached update status for Codemem ${status.current_version}`,
+			detail: status.error
+				? `This result is stale because a fresh check failed: ${status.error}`
+				: "This result is cached and may be stale.",
+			tone: "stale",
+		};
+	}
+
+	if (status.update_available) {
+		return {
+			title: `Codemem ${status.latest_version} is available`,
+			detail: `Installed version: ${status.current_version}.`,
+			tone: "available",
+		};
+	}
+
+	if (!isStableReleaseVersion(status.current_version)) {
+		return {
+			title: `Unable to compare Codemem ${status.current_version} with ${status.latest_version}`,
+			detail: "The installed version is not a stable semantic version.",
+			tone: "unavailable",
+		};
+	}
+
+	return {
+		title: `Codemem ${status.current_version} is up to date`,
+		detail: "You are running the latest stable release.",
+		tone: "current",
+	};
+}
+
+function UpdateBanner({ status }: { status: UpdateStatus }) {
+	const copy = updateBannerCopy(status);
+	const showGuidance =
+		status.update_available ||
+		status.stale ||
+		!status.latest_version ||
+		!isStableReleaseVersion(status.current_version);
+	return h(
+		"section",
+		{
+			class: `health-update-banner health-update-banner--${copy.tone}`,
+			role: "status",
+			"aria-atomic": "true",
+			"aria-label": "Codemem update status",
+		},
+		h("i", {
+			"aria-hidden": "true",
+			"data-lucide": "circle-arrow-up",
+			class: "health-update-icon",
+		}),
+		h(
+			"div",
+			{ class: "health-update-copy" },
+			h("h2", null, copy.title),
+			h("p", null, copy.detail),
+			showGuidance && status.recommended_action
+				? h(
+						"p",
+						{ class: "health-update-guidance" },
+						h("span", { class: "health-update-guidance-label" }, "Recommended action"),
+						h("code", null, status.recommended_action),
+					)
+				: null,
+		),
+	);
+}
+
+export function renderUpdateBanner(container: HTMLElement | null, status: UpdateStatus | null) {
+	if (!container) return;
+	container.hidden = !status;
+	render(status ? h(UpdateBanner, { status }) : null, container);
 }
 
 export function HealthCard({ label, value, detail, icon, className, title }: HealthCardInput) {

--- a/packages/ui/src/tabs/health/lifecycle.ts
+++ b/packages/ui/src/tabs/health/lifecycle.ts
@@ -12,16 +12,23 @@ import { renderStats } from "./render/stats";
 
 export async function loadHealthData() {
 	const previousActorId = state.lastStatsPayload?.identity?.actor_id || null;
-	const [statsPayload, usagePayload, _sessionsPayload, rawEventsPayload] = await Promise.all([
-		api.loadStats(),
-		api.loadUsage(state.currentProject),
-		api.loadSession(state.currentProject),
-		api.loadRawEvents(state.currentProject),
-	]);
+	const updateStatusPromise =
+		state.activeTab === "health" && !state.lastUpdateStatus
+			? api.loadUpdateStatus().catch(api.unavailableUpdateStatus)
+			: Promise.resolve(state.lastUpdateStatus);
+	const [statsPayload, usagePayload, _sessionsPayload, rawEventsPayload, updateStatus] =
+		await Promise.all([
+			api.loadStats(),
+			api.loadUsage(state.currentProject),
+			api.loadSession(state.currentProject),
+			api.loadRawEvents(state.currentProject),
+			updateStatusPromise,
+		]);
 
 	state.lastStatsPayload = statsPayload || {};
 	state.lastUsagePayload = usagePayload || {};
 	state.lastRawEventsPayload = rawEventsPayload || {};
+	state.lastUpdateStatus = updateStatus;
 	const nextActorId = state.lastStatsPayload?.identity?.actor_id || null;
 
 	renderStats();

--- a/packages/ui/src/tabs/health/render/health-overview.ts
+++ b/packages/ui/src/tabs/health/render/health-overview.ts
@@ -13,7 +13,13 @@ import {
 	titleCase,
 } from "../../../lib/format";
 import { state } from "../../../lib/state";
-import { buildHealthCard, renderActionList, renderHealthCards, renderIcons } from "../components";
+import {
+	buildHealthCard,
+	renderActionList,
+	renderHealthCards,
+	renderIcons,
+	renderUpdateBanner,
+} from "../components";
 import type { HealthAction, HealthCardInput } from "../types";
 
 const SCOPE_BACKFILL_JOB = "scope_id_backfill";
@@ -24,6 +30,7 @@ export function renderHealthOverview() {
 	const healthActions = document.getElementById("healthActions");
 	const healthDot = document.getElementById("healthDot");
 	if (!healthGrid || !healthMeta) return;
+	renderUpdateBanner(document.getElementById("healthUpdateBanner"), state.lastUpdateStatus);
 
 	const stats = state.lastStatsPayload || {};
 	const usagePayload = state.lastUsagePayload || {};

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1961,6 +1961,58 @@
 
       /* ── Health actions / sync actions ──────────────────────── */
 
+      .health-update-banner {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--sp-3);
+        padding: var(--sp-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        background: var(--surface-1);
+        box-shadow: var(--shadow-sm);
+      }
+      .health-update-banner--current {
+        border-color: color-mix(in srgb, var(--status-healthy) 34%, var(--border));
+        background: color-mix(in srgb, var(--status-healthy) 7%, var(--surface-1));
+      }
+      .health-update-banner--available,
+      .health-update-banner--stale {
+        border-color: color-mix(in srgb, var(--accent-warm) 34%, var(--border));
+        background: color-mix(in srgb, var(--accent-warm-subtle) 34%, var(--surface-1));
+      }
+      .health-update-banner--unavailable {
+        border-color: color-mix(in srgb, var(--status-attention) 34%, var(--border));
+        background: color-mix(in srgb, var(--status-attention) 7%, var(--surface-1));
+      }
+      .health-update-icon {
+        width: 20px;
+        height: 20px;
+        flex: 0 0 20px;
+        margin-top: 2px;
+        color: var(--accent);
+      }
+      .health-update-banner--current .health-update-icon { color: var(--status-healthy); }
+      .health-update-banner--available .health-update-icon,
+      .health-update-banner--stale .health-update-icon { color: var(--accent-warm); }
+      .health-update-banner--unavailable .health-update-icon { color: var(--status-attention); }
+      .health-update-copy { min-width: 0; }
+      .health-update-copy h2 { font-size: var(--font-size-lg); line-height: 1.3; }
+      .health-update-copy p { margin-top: var(--sp-1); color: var(--text-secondary); }
+      .health-update-guidance { display: grid; gap: 3px; }
+      .health-update-guidance-label {
+        color: var(--text-tertiary);
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-semibold);
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+      .health-update-guidance code {
+        color: var(--text-primary);
+        font-family: var(--font-mono);
+        font-size: var(--font-size-sm);
+        overflow-wrap: anywhere;
+      }
+
       .health-actions, .sync-actions {
         display: grid;
         gap: var(--sp-2);
@@ -3896,6 +3948,7 @@
 
     <!-- ── Tab: Health ─────────────────────────────────────── -->
     <div class="tab-panel" id="tab-health" hidden>
+      <div id="healthUpdateBanner" hidden></div>
       <div class="card" style="animation-delay: 0s">
         <div class="section-header">
           <h2>System health</h2>

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -156,6 +156,7 @@ function insertTestMemory(
 function createTestApp(opts?: {
 	seedDevice?: boolean;
 	sweeper?: unknown;
+	getUpdateStatus?: (options: core.GetUpdateStatusOptions) => Promise<core.UpdateStatus>;
 	syncRequestRateLimit?: {
 		readLimit?: number;
 		mutationLimit?: number;
@@ -179,11 +180,13 @@ function createTestApp(opts?: {
 		return store;
 	};
 
-	const app = createApp({
+	const appOptions = {
 		sweeper: (opts?.sweeper ?? null) as never,
 		storeFactory,
+		getUpdateStatus: opts?.getUpdateStatus,
 		getSyncRuntimeStatus: opts?.getSyncRuntimeStatus,
-	});
+	};
+	const app = createApp(appOptions);
 
 	const syncApp = createSyncApp({
 		storeFactory,
@@ -508,6 +511,132 @@ describe("viewer-server", () => {
 				expect(body).toEqual({ version: VERSION });
 			} finally {
 				cleanup();
+			}
+		});
+
+		it("does not invoke release discovery", async () => {
+			// Arrange
+			const getUpdateStatus = vi.fn();
+			const { app, cleanup } = createTestApp({ getUpdateStatus });
+
+			try {
+				// Act
+				const res = await app.request("/api/runtime");
+
+				// Assert
+				expect(res.status).toBe(200);
+				expect(getUpdateStatus).not.toHaveBeenCalled();
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
+	describe("GET /api/update-status", () => {
+		const availableStatus: core.UpdateStatus = {
+			current_version: "0.40.2",
+			latest_version: "0.41.0",
+			update_available: true,
+			first_seen_at: "2026-08-10T12:00:00.000Z",
+			checked_at: "2026-08-10T12:00:00.000Z",
+			stale: false,
+			install_kind: "npm-global",
+			auto_update_eligible: false,
+			recommended_action: "npm install -g codemem@0.41.0",
+			error: null,
+		};
+
+		it.each([
+			{
+				label: "current",
+				status: {
+					...availableStatus,
+					latest_version: "0.40.2",
+					update_available: false,
+					recommended_action: "No action required; codemem is up to date.",
+				},
+			},
+			{ label: "available", status: availableStatus },
+			{
+				label: "stale",
+				status: {
+					...availableStatus,
+					stale: true,
+					error: "registry offline",
+				},
+			},
+			{
+				label: "unavailable",
+				status: {
+					...availableStatus,
+					latest_version: null,
+					update_available: false,
+					first_seen_at: null,
+					checked_at: null,
+					install_kind: "unknown" as const,
+					recommended_action: "Check network access and try again.",
+					error: "registry request timed out",
+				},
+			},
+		])("returns the dedicated $label update-status payload", async ({ status }) => {
+			// Arrange
+			const getUpdateStatus = vi.fn().mockResolvedValue(status);
+			const { app, cleanup } = createTestApp({ getUpdateStatus });
+
+			try {
+				// Act
+				const res = await app.request("/api/update-status");
+
+				// Assert
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual(status);
+				expect(getUpdateStatus).toHaveBeenCalledOnce();
+				expect(getUpdateStatus).toHaveBeenCalledWith(
+					expect.objectContaining({ currentVersion: VERSION }),
+				);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("returns a bounded service error when release discovery throws", async () => {
+			// Arrange
+			const getUpdateStatus = vi.fn().mockRejectedValue(new Error("unexpected failure"));
+			const { app, cleanup } = createTestApp({ getUpdateStatus });
+
+			try {
+				// Act
+				const res = await app.request("/api/update-status");
+
+				// Assert
+				expect(res.status).toBe(503);
+				expect(await res.json()).toEqual({ error: "Update status unavailable." });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("passes explicit Docker install detection to release discovery", async () => {
+			// Arrange
+			vi.stubEnv("CODEMEM_INSTALL_KIND", "docker");
+			const getUpdateStatus = vi.fn().mockResolvedValue({
+				...availableStatus,
+				install_kind: "docker",
+			});
+			const { app, cleanup } = createTestApp({ getUpdateStatus });
+
+			try {
+				// Act
+				const res = await app.request("/api/update-status");
+
+				// Assert
+				expect(res.status).toBe(200);
+				expect(getUpdateStatus).toHaveBeenCalledWith(
+					expect.objectContaining({ installKind: "docker" }),
+				);
+			} finally {
+				cleanup();
+				vi.unstubAllEnvs();
 			}
 		});
 	});

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -10,7 +10,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { ObserverClient } from "@codemem/core";
+import type { GetUpdateStatusOptions, ObserverClient, UpdateStatus } from "@codemem/core";
 import { MemoryStore, type RawEventSweeper, resolveDbPath, VERSION } from "@codemem/core";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
@@ -27,6 +27,7 @@ import { packTransportRoutes } from "./routes/pack.js";
 import { rawEventsRoutes } from "./routes/raw-events.js";
 import { statsRoutes } from "./routes/stats.js";
 import { syncProtocolRoutes, syncRoutes } from "./routes/sync.js";
+import { updateStatusRoutes } from "./routes/update-status.js";
 
 export type {
 	AdvancePendingProjectSharesResult,
@@ -73,6 +74,7 @@ export interface AppOptions {
 	storeFactory?: () => MemoryStore;
 	sweeper?: RawEventSweeper | null;
 	observer?: ObserverClient | null;
+	getUpdateStatus?: (options: GetUpdateStatusOptions) => Promise<UpdateStatus>;
 	syncRequestRateLimit?: {
 		limiter?: InMemoryRequestRateLimiter;
 		readLimit?: number;
@@ -121,6 +123,7 @@ export function createApp(opts?: AppOptions) {
 	app.route("/", configRoutes({ getSweeper: () => sweeper }));
 	app.route("/", rawEventsRoutes(storeFactory, sweeper));
 	app.route("/", syncRoutes(storeFactory, getSyncRuntimeStatus));
+	app.route("/", updateStatusRoutes({ getUpdateStatus: opts?.getUpdateStatus }));
 
 	// Static assets — serve under /assets/*
 	// Resolves to packages/viewer-server/static/ both in dev and when installed from npm.

--- a/packages/viewer-server/src/routes/update-status.ts
+++ b/packages/viewer-server/src/routes/update-status.ts
@@ -1,0 +1,35 @@
+import {
+	getUpdateStatus as defaultGetUpdateStatus,
+	detectInstallKind,
+	type GetUpdateStatusOptions,
+	type UpdateStatus,
+	VERSION,
+} from "@codemem/core";
+import { Hono } from "hono";
+
+export interface UpdateStatusRoutesOptions {
+	getUpdateStatus?: (options: GetUpdateStatusOptions) => Promise<UpdateStatus>;
+}
+
+export function updateStatusRoutes(options: UpdateStatusRoutesOptions = {}) {
+	const getUpdateStatus = options.getUpdateStatus ?? defaultGetUpdateStatus;
+	const app = new Hono();
+
+	app.get("/api/update-status", async (c) => {
+		try {
+			const installKind = detectInstallKind({
+				entryPath: process.argv[1] ?? "",
+				env: process.env,
+			});
+			const status = await getUpdateStatus({
+				currentVersion: VERSION,
+				installKind,
+			});
+			return c.json(status);
+		} catch {
+			return c.json({ error: "Update status unavailable." }, 503);
+		}
+	});
+
+	return app;
+}


### PR DESCRIPTION
## Description

Surfaces release availability through the OpenCode plugin, Viewer server API, and Health UI. Notifications reuse the shared release-discovery cache, stay non-blocking, and include updated plugin and user documentation.

This is PR 2 of 4 in the update-notifications stack and depends on #1449.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated the full stack with 4,246 passing tests, TypeScript, and lint. Added plugin notification, Viewer route, and Health UI coverage.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
