### PR TITLE
feat(update): enable opt-in npm upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,13 +186,15 @@ usage command; use `sync status`/`sync doctor`, `maintenance status`, and
 `db raw-events-status` for subsystem detail.
 
 `codemem update check` is read-only: it reports the latest validated stable release and
-installation-specific guidance but never installs anything. Results are cached for six hours;
+installation-specific guidance. Results are cached for six hours;
 pass `--refresh` to force a registry request or `--json` for one stable status object.
 The Viewer Health page reads the same status from `/api/update-status`. The OpenCode plugin
 checks it after startup and shows at most one best-effort notification for each newly discovered
-release. Set `CODEMEM_BACKEND_UPDATE_POLICY=off` to disable release checks; `notify` and `auto`
-both remain notification-only for release discovery in this delivery slice. Docker guidance is
-always rebuild-and-restart guidance, never an in-container update.
+release. `notify` is the default. Explicit `auto` policy may run `codemem update install` only for
+a fresh, validated npm release observed for at least 24 hours and an installation whose npm origin
+can be proven. Pinned, prerelease, downgrade, repository-development, stale, Docker, and unknown
+installs refuse execution. Set `CODEMEM_BACKEND_UPDATE_POLICY=off` to disable release checks.
+Docker guidance is always rebuild-and-restart guidance, never an in-container update.
 
 Pack rendering defaults to self-contained context. For token-constrained experiments, `codemem pack <context> --compact` renders an index plus top details. Near-related compression is controlled by `--compression-mode off|compact|ids` (or `CODEMEM_PACK_COMPRESSION`); MCP `memory_pack` exposes the same setting as `compression_mode`. Use `ids` only when the agent can follow up with `memory_get_observations`.
 

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -149,6 +149,15 @@ the local `.env`, Docker secrets, or the container manager's private environment
 
 ## Useful commands
 
+Containers never self-update and do not receive the Docker socket. To move to a specific release,
+set the durable `CODEMEM_VERSION` value in `.env`, then rebuild and restart:
+
+```fish
+set -lx CODEMEM_VERSION 0.41.0
+docker compose build --pull
+docker compose up -d
+```
+
 ```fish
 docker compose pull
 docker compose up -d --build

--- a/docs/plans/2026-08-10-release-discovery-and-update-notifications-plan.md
+++ b/docs/plans/2026-08-10-release-discovery-and-update-notifications-plan.md
@@ -13,7 +13,7 @@ Deliver the approved updater design as four dependent Graphite pull requests. Ea
 
 ## PR 1: Release discovery
 
-**Bead:** `codemem-eiq9.1`  
+**Bead:** `codemem-eiq9.1`
 **Commit:** `feat(update): add release discovery`
 
 ### Tasks
@@ -46,8 +46,8 @@ pnpm run tsc
 
 ## PR 2: Plugin and Viewer notifications
 
-**Bead:** `codemem-eiq9.2`  
-**Depends on:** `codemem-eiq9.1`  
+**Bead:** `codemem-eiq9.2`
+**Depends on:** `codemem-eiq9.1`
 **Commit:** `feat(update): surface release notifications`
 
 ### Tasks
@@ -83,8 +83,8 @@ pnpm run tsc
 
 ## PR 3: Peer runtime versions
 
-**Bead:** `codemem-eiq9.3`  
-**Depends on:** `codemem-eiq9.2`  
+**Bead:** `codemem-eiq9.3`
+**Depends on:** `codemem-eiq9.2`
 **Commit:** `feat(sync): report peer runtime versions`
 
 ### Tasks
@@ -117,8 +117,8 @@ pnpm run tsc
 
 ## PR 4: Delayed opt-in npm upgrades
 
-**Bead:** `codemem-eiq9.4`  
-**Depends on:** `codemem-eiq9.3`  
+**Bead:** `codemem-eiq9.4`
+**Depends on:** `codemem-eiq9.3`
 **Commit:** `feat(update): enable opt-in npm upgrades`
 
 ### Tasks

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -420,17 +420,21 @@ When the plugin detects CLI/runtime version mismatch, it shows guidance based on
 Update policy:
 
 - `CODEMEM_BACKEND_UPDATE_POLICY=notify` (default): show warning toast with suggested action
-- `CODEMEM_BACKEND_UPDATE_POLICY=auto`: try a best-effort auto-update for eligible compatibility-floor mismatches, then warn if still outdated
-  - skipped for `node` dev-mode runners
-  - skipped when `CODEMEM_RUNNER_FROM` is pinned to a fixed package/version
+- `CODEMEM_BACKEND_UPDATE_POLICY=auto`: try a best-effort auto-update for eligible compatibility-floor mismatches and fresh stable releases observed for at least 24 hours, then warn if still outdated
+	- skipped for `node` dev-mode runners
+	- skipped when `CODEMEM_RUNNER_FROM` is pinned to a fixed package/version
+	- skipped for Docker, unknown, stale, prerelease, or downgrade states
 - `CODEMEM_BACKEND_UPDATE_POLICY=off`: no compatibility toast (logging still records mismatch)
 
 After its startup delay, the plugin also runs `codemem update check --json` through the same
 argv-based CLI runner. `notify` and `auto` show a best-effort toast at most once per latest stable
-release in the current OpenCode process; `off` skips this release check. This release-discovery
-path is read-only: `auto` does not install a discovered release. Current, unavailable, malformed,
-and timed-out results are ignored without delaying plugin startup. Compatibility-floor handling
-above remains separate and unchanged.
+release in the current OpenCode process; `off` skips this release check. Under explicit `auto`, an
+eligible result invokes the fail-closed `codemem update install` command and verifies the active CLI
+version before a plugin-owned Viewer is restarted. Current, unavailable, malformed, ineligible, and
+timed-out results are ignored or shown as guidance without delaying plugin startup.
+The installer uses a process-owned lock under `~/.codemem` so simultaneous OpenCode sessions cannot
+run competing global npm installations. A live lock causes later attempts to fail closed; a lock whose
+recorded process no longer exists is reclaimed.
 
 Docker images set `CODEMEM_INSTALL_KIND=docker` so release guidance cannot mistake the bundled
 global npm package for a host npm installation. Docker deployments never self-update; rebuild and

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -16,7 +16,11 @@ codemem update check --json
 - Stale validated cache data remains clearly labeled and may provide guidance when the registry is
   unavailable.
 - This command never installs or executes an update. Release installation remains outside this
-  read-only check.
+  read-only check. `codemem update install` is the separate, fail-closed installer: it refreshes
+  release status, requires a proven global npm installation and a stable release observed for at
+  least 24 hours, installs the exact validated version from the public npm registry, and verifies
+  the active `codemem` command. It refuses npx, Docker, pinned, development, stale, prerelease,
+  downgrade, and unknown installations.
 
 ## Start or restart the viewer
 - `codemem serve` runs the viewer in the foreground.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -65,8 +65,11 @@ Tag only after the release PR has merged to `main` and you have verified that `H
 `codemem` release. Results are cached locally for six hours; use `--refresh` to bypass a fresh
 cache and `--json` for the stable automation contract. If a refresh fails, a previously validated
 cache may be returned as stale guidance. A running process backs off failed registry checks for 15
-minutes, while `--refresh` bypasses that backoff. Release discovery is informational and does not
-install or execute anything.
+minutes, while `--refresh` bypasses that backoff. `codemem update check` remains informational.
+`codemem update install` separately requires fresh validated status, a 24-hour first-seen delay,
+and a proven eligible npm installation before it executes an argv-only npm command and verifies
+the active CLI version. It refuses pinned, prerelease, downgrade, development, stale, Docker, and
+unknown states.
 
 Release discovery compares the running product version with the latest published stable release.
 It is separate from the compatibility-floor check below: discovering a newer release does not
@@ -80,7 +83,7 @@ The OpenCode plugin performs a runtime CLI version check and warns if the local 
 The compatibility reaction is controlled by `CODEMEM_BACKEND_UPDATE_POLICY`:
 
 - `notify` (default): warn with an upgrade hint
-- `auto`: attempt a best-effort update for eligible runners, then re-check (skips dev runner mode and pinned git refs)
+- `auto`: attempt a best-effort update for eligible npm runners and delayed stable releases, then re-check
 - `off`: suppress compatibility toasts
 
 This check enforces a minimum supported CLI version. It does not query the npm registry or report

--- a/packages/cli/.opencode/lib/compat.js
+++ b/packages/cli/.opencode/lib/compat.js
@@ -106,9 +106,17 @@ const isPinnedGitSource = (runnerFrom) => {
   }
 };
 
-export const resolveAutoUpdatePlan = ({ runner, runnerFrom }) => {
-  const normalizedRunner = String(runner || "").trim();
-  const source = String(runnerFrom || "").trim();
+export const resolveAutoUpdatePlan = ({ runner, runnerFrom, runnerFromExplicit = false }) => {
+	const normalizedRunner = String(runner || "").trim();
+	const source = String(runnerFrom || "").trim();
+	if (isPinnedGitSource(source) || /^codemem@(?!latest$|next$|\*$)[^\s]+$/i.test(source)) {
+		return {
+			allowed: false,
+			reason: "pinned-source",
+			command: null,
+			commandText: null,
+		};
+	}
 
   if (normalizedRunner === "node") {
     return {
@@ -119,8 +127,16 @@ export const resolveAutoUpdatePlan = ({ runner, runnerFrom }) => {
     };
   }
 
-  if (normalizedRunner === "npx") {
-    return {
+	if (normalizedRunner === "npx") {
+		if (!runnerFromExplicit || !/^(?:codemem|codemem@(?:latest|next|\*))$/i.test(source)) {
+			return {
+				allowed: false,
+				reason: !runnerFromExplicit ? "implicit-pinned-source" : "custom-source",
+				command: null,
+				commandText: null,
+			};
+		}
+		return {
       allowed: true,
       reason: null,
       command: ["npm", "install", "-g", "codemem@latest"],
@@ -146,10 +162,14 @@ export const resolveAutoUpdatePlan = ({ runner, runnerFrom }) => {
     };
   }
 
-  return {
-    allowed: true,
-    reason: null,
-    command: ["npm", "install", "-g", "codemem@latest"],
-    commandText: "npm install -g codemem@latest",
-  };
+	if (normalizedRunner === "codemem") {
+		return {
+			allowed: true,
+			reason: null,
+			command: ["npm", "install", "-g", "codemem@latest"],
+			commandText: "npm install -g codemem@latest",
+		};
+	}
+
+	return { allowed: false, reason: "unknown-runner", command: null, commandText: null };
 };

--- a/packages/cli/.opencode/tests/compat.test.js
+++ b/packages/cli/.opencode/tests/compat.test.js
@@ -91,6 +91,43 @@ describe("parseBackendUpdatePolicy", () => {
 });
 
 describe("resolveAutoUpdatePlan", () => {
+	test("allows the known global npm runner", () => {
+		const plan = resolveAutoUpdatePlan({ runner: "codemem", runnerFrom: "/tmp/project" });
+		expect(plan.allowed).toBe(true);
+		expect(plan.command).toEqual(["npm", "install", "-g", "codemem@latest"]);
+	});
+
+	test("blocks unknown runners", () => {
+		expect(resolveAutoUpdatePlan({ runner: "custom", runnerFrom: "/tmp/project" })).toMatchObject({
+			allowed: false,
+			reason: "unknown-runner",
+		});
+	});
+
+	test("blocks pinned npm sources before runner-specific allow paths", () => {
+		expect(
+			resolveAutoUpdatePlan({
+				runner: "npx",
+				runnerFrom: "codemem@0.40.2",
+				runnerFromExplicit: true,
+			}),
+		).toMatchObject({ allowed: false, reason: "pinned-source" });
+	});
+
+	test("allows npx only with an explicit generic package source", () => {
+		expect(
+			resolveAutoUpdatePlan({
+				runner: "npx",
+				runnerFrom: "codemem@latest",
+				runnerFromExplicit: true,
+			}),
+		).toMatchObject({ allowed: true });
+		expect(resolveAutoUpdatePlan({ runner: "npx", runnerFrom: "codemem@latest" })).toMatchObject({
+			allowed: false,
+			reason: "implicit-pinned-source",
+		});
+	});
+
   test("blocks auto-update in uv dev mode", () => {
     const plan = resolveAutoUpdatePlan({ runner: "uv", runnerFrom: "/tmp/codemem" });
     expect(plan.allowed).toBe(false);

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -185,10 +185,10 @@ describe("OpenCode startup release notifications", () => {
 		expect(showToast).not.toHaveBeenCalled();
 	});
 
-	test("auto remains read-only in PR2 while still notifying about an available release", async () => {
+	test("auto installs an eligible release through the guarded CLI command", async () => {
 		// Arrange
 		process.env.CODEMEM_BACKEND_UPDATE_POLICY = "auto";
-		installSpawnResult();
+		installSpawnResult({ ...availableStatus, auto_update_eligible: true });
 		const showToast = vi.fn().mockResolvedValue(undefined);
 
 		// Act
@@ -198,8 +198,38 @@ describe("OpenCode startup release notifications", () => {
 		// Assert
 		const args = spawnMock.mock.calls.map((call) => call[1]);
 		expect(args.some((value) => value?.includes("update") && value?.includes("check"))).toBe(true);
-		expect(args.some((value) => value?.includes("install"))).toBe(false);
+		expect(args.some((value) => value?.includes("update") && value?.includes("install"))).toBe(true);
 		expect(showToast).toHaveBeenCalledTimes(1);
+		expect(showToast.mock.calls[0]?.[0]?.body).toMatchObject({
+			message: "Updated codemem to 0.41.0.",
+			variant: "success",
+		});
+	});
+
+	test("auto remains notification-only until the 24-hour eligibility gate opens", async () => {
+		process.env.CODEMEM_BACKEND_UPDATE_POLICY = "auto";
+		installSpawnResult();
+		const showToast = vi.fn().mockResolvedValue(undefined);
+
+		await startPlugin(showToast);
+		await runStartupChecks();
+
+		expect(spawnMock.mock.calls.some((call) => call[1]?.includes("install"))).toBe(false);
+		expect(showToast.mock.calls[0]?.[0]?.body?.message).toMatch(/0\.41\.0.*npm install/i);
+	});
+
+	test("auto does not invoke installation when runner provenance is pinned", async () => {
+		process.env.CODEMEM_BACKEND_UPDATE_POLICY = "auto";
+		process.env.CODEMEM_RUNNER = "npx";
+		process.env.CODEMEM_RUNNER_FROM = "codemem@0.40.2";
+		installSpawnResult({ ...availableStatus, auto_update_eligible: true });
+		const showToast = vi.fn().mockResolvedValue(undefined);
+
+		await startPlugin(showToast);
+		await runStartupChecks();
+
+		expect(spawnMock.mock.calls.some((call) => call[1]?.includes("install"))).toBe(false);
+		expect(showToast.mock.calls.at(-1)?.[0]?.body?.message).toMatch(/0\.41\.0/);
 	});
 
 	test.each([

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -1,9 +1,16 @@
+import { EventEmitter } from "node:events";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Command } from "commander";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getUpdateStatus } = vi.hoisted(() => ({
+const { getUpdateStatus, spawn } = vi.hoisted(() => ({
 	getUpdateStatus: vi.fn(),
+	spawn: vi.fn(),
 }));
+
+vi.mock("node:child_process", () => ({ spawn }));
 
 vi.mock("@codemem/core", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@codemem/core")>();
@@ -14,6 +21,9 @@ vi.mock("@codemem/core", async (importOriginal) => {
 });
 
 import { updateCommand } from "./update.js";
+
+const originalHome = process.env.HOME;
+let testHome = "";
 
 const availableStatus = {
 	current_version: "0.40.2",
@@ -54,11 +64,36 @@ async function parseUpdateCommand(args: string[]): Promise<void> {
 	await root.parseAsync(["update", ...args], { from: "user" });
 }
 
-afterEach(() => {
+beforeEach(async () => {
+	testHome = await mkdtemp(join(tmpdir(), "codemem-update-test-"));
+	process.env.HOME = testHome;
+});
+
+afterEach(async () => {
 	getUpdateStatus.mockReset();
+	spawn.mockReset();
 	process.exitCode = undefined;
+	process.env.HOME = originalHome;
+	await rm(testHome, { recursive: true, force: true });
 	vi.restoreAllMocks();
 });
+
+function commandProcess(options: { stdout?: string; stderr?: string; exitCode?: number } = {}) {
+	const child = new EventEmitter() as EventEmitter & {
+		kill: ReturnType<typeof vi.fn>;
+		stdout: EventEmitter & { setEncoding: () => void };
+		stderr: EventEmitter & { setEncoding: () => void };
+	};
+	child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+	child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+	child.kill = vi.fn();
+	queueMicrotask(() => {
+		if (options.stdout) child.stdout.emit("data", options.stdout);
+		if (options.stderr) child.stderr.emit("data", options.stderr);
+		child.emit("close", options.exitCode ?? 0);
+	});
+	return child;
+}
 
 describe("update check command", () => {
 	it("renders a concise human message for an available release and its guidance", async () => {
@@ -222,5 +257,93 @@ describe("update check command", () => {
 		// Assert
 		expect(error.mock.calls.flat().join("\n")).toContain("registry request timed out");
 		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("update install command", () => {
+	it("refuses before spawning when release status is not eligible", async () => {
+		getUpdateStatus.mockResolvedValue(availableStatus);
+		vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install"]);
+
+		expect(getUpdateStatus).toHaveBeenCalledWith(expect.objectContaining({ refresh: true }));
+		expect(spawn).not.toHaveBeenCalled();
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("installs the exact validated release without a shell and verifies it", async () => {
+		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
+		spawn
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn).toHaveBeenNthCalledWith(
+			1,
+			"npm",
+			["install", "-g", "--registry", "https://registry.npmjs.org/", "codemem@0.41.0"],
+			expect.objectContaining({ shell: false }),
+		);
+		expect(spawn).toHaveBeenNthCalledWith(
+			2,
+			"codemem",
+			["version"],
+			expect.objectContaining({ shell: false }),
+		);
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			previous_version: "0.40.2",
+			installed_version: "0.41.0",
+		});
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("fails when the active CLI does not report the installed version", async () => {
+		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
+		spawn
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.40.2\n" }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "update_verification_failed",
+		});
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("refuses a concurrent installation while another process owns the update lock", async () => {
+		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
+		const lockDirectory = join(testHome, ".codemem");
+		await mkdir(lockDirectory, { recursive: true });
+		await writeFile(join(lockDirectory, "update-install.lock"), `${process.pid}\n`, "utf8");
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn).not.toHaveBeenCalled();
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "update_install_locked",
+		});
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("reclaims a stale update lock before installing", async () => {
+		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
+		const lockDirectory = join(testHome, ".codemem");
+		await mkdir(lockDirectory, { recursive: true });
+		await writeFile(join(lockDirectory, "update-install.lock"), "99999999\n", "utf8");
+		spawn
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn).toHaveBeenCalledTimes(2);
+		expect(process.exitCode).toBeUndefined();
 	});
 });

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,3 +1,7 @@
+import { spawn, spawnSync } from "node:child_process";
+import { mkdir, open, readFile, stat, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
 import { detectInstallKind, getUpdateStatus, isStableReleaseVersion, VERSION } from "@codemem/core";
 import { Command, Option } from "commander";
 import { helpStyle } from "../help-style.js";
@@ -5,6 +9,198 @@ import { addJsonOption, emitJsonError, type JsonOpts } from "../shared-options.j
 
 interface UpdateCheckOptions extends JsonOpts {
 	refresh?: boolean;
+}
+
+interface UpdateInstallOptions extends JsonOpts {}
+
+interface CommandResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+const INSTALL_TIMEOUT_MS = 5 * 60 * 1_000;
+const VERIFY_TIMEOUT_MS = 30_000;
+const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org/";
+const UPDATE_LOCK_FILE = "update-install.lock";
+
+class UpdateInstallLockedError extends Error {}
+
+function updateInstallLockPath(): string {
+	return join(process.env.HOME?.trim() || homedir(), ".codemem", UPDATE_LOCK_FILE);
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+async function removeStaleInstallLock(lockPath: string): Promise<boolean> {
+	try {
+		const [rawPid, lockStat] = await Promise.all([readFile(lockPath, "utf8"), stat(lockPath)]);
+		const pid = Number.parseInt(rawPid.trim(), 10);
+		if (Number.isSafeInteger(pid) && pid > 0) {
+			if (isProcessAlive(pid)) return false;
+		} else if (Date.now() - lockStat.mtimeMs <= INSTALL_TIMEOUT_MS + VERIFY_TIMEOUT_MS) {
+			return false;
+		}
+		await unlink(lockPath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function acquireInstallLock(): Promise<() => Promise<void>> {
+	const lockPath = updateInstallLockPath();
+	await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 });
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		try {
+			const handle = await open(lockPath, "wx", 0o600);
+			await handle.writeFile(`${process.pid}\n`, "utf8");
+			return async () => {
+				await handle.close().catch(() => undefined);
+				await unlink(lockPath).catch(() => undefined);
+			};
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+			if (attempt > 0 || !(await removeStaleInstallLock(lockPath))) {
+				throw new UpdateInstallLockedError(
+					"another codemem update installation is already running",
+				);
+			}
+		}
+	}
+	throw new UpdateInstallLockedError("another codemem update installation is already running");
+}
+
+function runCommand(
+	command: string,
+	args: string[],
+	timeoutMs: number,
+	options: { cwd?: string; windowsVerbatimArguments?: boolean } = {},
+): Promise<CommandResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd: options.cwd,
+			detached: process.platform !== "win32",
+			shell: false,
+			stdio: ["ignore", "pipe", "pipe"],
+			windowsVerbatimArguments: options.windowsVerbatimArguments,
+		});
+		let settled = false;
+		let timedOut = false;
+		let stdout = "";
+		let stderr = "";
+		let timer: ReturnType<typeof setTimeout>;
+		const finish = (result: CommandResult) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve(result);
+		};
+		const terminate = (signal: NodeJS.Signals) => {
+			if (process.platform === "win32" && child.pid) {
+				const systemRoot = process.env.SystemRoot?.trim();
+				if (systemRoot && isAbsolute(systemRoot)) {
+					spawnSync(
+						join(systemRoot, "System32", "taskkill.exe"),
+						["/PID", String(child.pid), "/T", "/F"],
+						{
+							stdio: "ignore",
+							windowsHide: true,
+						},
+					);
+					return;
+				}
+			}
+			if (process.platform !== "win32" && child.pid) {
+				try {
+					process.kill(-child.pid, signal);
+					return;
+				} catch {
+					// Fall back to terminating the direct child.
+				}
+			}
+			child.kill(signal);
+		};
+		timer = setTimeout(() => {
+			timedOut = true;
+			terminate("SIGTERM");
+			setTimeout(() => terminate("SIGKILL"), 5_000).unref();
+		}, timeoutMs);
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk: string) => {
+			stderr += chunk;
+		});
+		child.once("error", (error) => {
+			clearTimeout(timer);
+			if (!settled) reject(error);
+		});
+		child.once("close", (code) =>
+			finish({ exitCode: code ?? 1, stdout, stderr: timedOut ? "command timed out" : stderr }),
+		);
+	});
+}
+
+async function resolveWindowsShim(name: "npm.cmd" | "codemem.cmd"): Promise<string> {
+	const systemRoot = process.env.SystemRoot?.trim();
+	if (!systemRoot || !isAbsolute(systemRoot)) throw new Error("Windows SystemRoot is unavailable");
+	const result = await runCommand(join(systemRoot, "System32", "where.exe"), [name], 10_000, {
+		cwd: join(systemRoot, "System32"),
+	});
+	const shim = result.stdout
+		.split(/\r?\n/)
+		.map((value) => value.trim())
+		.find((value) => isAbsolute(value));
+	if (result.exitCode !== 0 || !shim) throw new Error(`unable to resolve ${name} from PATH`);
+	return shim;
+}
+
+function windowsCommandLine(shim: string, args: string[]): string {
+	return `""${shim}" ${args.join(" ")}"`;
+}
+
+async function resolveInstallCommand(): Promise<{ command: string; args: string[]; cwd?: string }> {
+	if (process.platform !== "win32") return { command: "npm", args: [] };
+	const systemRoot = process.env.SystemRoot?.trim();
+	if (!systemRoot || !isAbsolute(systemRoot)) throw new Error("Windows SystemRoot is unavailable");
+	return {
+		command: join(systemRoot, "System32", "cmd.exe"),
+		args: ["/d", "/s", "/c", await resolveWindowsShim("npm.cmd")],
+		cwd: join(systemRoot, "System32"),
+	};
+}
+
+async function resolveVerificationCommand(): Promise<{
+	command: string;
+	args: string[];
+	cwd?: string;
+}> {
+	if (process.platform !== "win32") return { command: "codemem", args: [] };
+	const systemRoot = process.env.SystemRoot?.trim();
+	if (!systemRoot || !isAbsolute(systemRoot)) throw new Error("Windows SystemRoot is unavailable");
+	return {
+		command: join(systemRoot, "System32", "cmd.exe"),
+		args: ["/d", "/s", "/c", await resolveWindowsShim("codemem.cmd")],
+		cwd: join(systemRoot, "System32"),
+	};
+}
+
+function failInstall(options: UpdateInstallOptions, code: string, message: string): void {
+	if (options.json) emitJsonError(code, message);
+	else {
+		console.error(message);
+		process.exitCode = 1;
+	}
 }
 
 function cacheQualifier(stale: boolean): string {
@@ -66,7 +262,96 @@ const checkCommand = addJsonOption(
 		}
 	});
 
+const installCommand = addJsonOption(
+	new Command("install").description("Install an eligible stable codemem update"),
+)
+	.configureHelp(helpStyle)
+	.action(async (options: UpdateInstallOptions) => {
+		let releaseInstallLock: (() => Promise<void>) | null = null;
+		try {
+			const installKind = detectInstallKind({
+				entryPath: process.argv[1] ?? "",
+				env: process.env,
+			});
+			const status = await getUpdateStatus({
+				currentVersion: VERSION,
+				installKind,
+				refresh: true,
+			});
+			if (!status.auto_update_eligible || !status.latest_version) {
+				failInstall(options, "update_install_refused", status.recommended_action);
+				return;
+			}
+
+			const targetVersion = status.latest_version;
+			if (!isStableReleaseVersion(targetVersion)) {
+				failInstall(
+					options,
+					"update_install_refused",
+					"release version is not a stable semantic version",
+				);
+				return;
+			}
+			releaseInstallLock = await acquireInstallLock();
+			const npm = await resolveInstallCommand();
+			const installation = await runCommand(
+				npm.command,
+				process.platform === "win32"
+					? [
+							...npm.args.slice(0, 3),
+							windowsCommandLine(npm.args[3] ?? "", [
+								"install",
+								"-g",
+								"--registry",
+								PUBLIC_NPM_REGISTRY,
+								`codemem@${targetVersion}`,
+							]),
+						]
+					: ["install", "-g", "--registry", PUBLIC_NPM_REGISTRY, `codemem@${targetVersion}`],
+				INSTALL_TIMEOUT_MS,
+				{ cwd: npm.cwd, windowsVerbatimArguments: process.platform === "win32" },
+			);
+			if (installation.exitCode !== 0) {
+				failInstall(
+					options,
+					"update_install_failed",
+					installation.stderr.trim() || "npm installation failed",
+				);
+				return;
+			}
+
+			const codemem = await resolveVerificationCommand();
+			const verification = await runCommand(
+				codemem.command,
+				process.platform === "win32"
+					? [...codemem.args.slice(0, 3), windowsCommandLine(codemem.args[3] ?? "", ["version"])]
+					: ["version"],
+				VERIFY_TIMEOUT_MS,
+				{ cwd: codemem.cwd, windowsVerbatimArguments: process.platform === "win32" },
+			);
+			if (verification.exitCode !== 0 || verification.stdout.trim() !== targetVersion) {
+				failInstall(options, "update_verification_failed", "installed version verification failed");
+				return;
+			}
+
+			const result = { previous_version: VERSION, installed_version: targetVersion };
+			if (options.json) console.log(JSON.stringify(result));
+			else console.log(`Updated codemem from ${VERSION} to ${targetVersion}.`);
+		} catch (error) {
+			failInstall(
+				options,
+				error instanceof UpdateInstallLockedError
+					? "update_install_locked"
+					: "update_install_failed",
+				error instanceof Error ? error.message : "update installation failed",
+			);
+		} finally {
+			await releaseInstallLock?.();
+		}
+	});
+
 export const updateCommand = new Command("update")
 	.description("Inspect and manage codemem updates")
 	.configureHelp(helpStyle)
-	.addCommand(checkCommand);
+	.addCommand(checkCommand)
+	.addCommand(installCommand);

--- a/packages/core/src/release-discovery.test.ts
+++ b/packages/core/src/release-discovery.test.ts
@@ -191,6 +191,48 @@ describe("release discovery registry contract", () => {
 		});
 	});
 
+	it("allows a fresh npm update only after the release has been observed for 24 hours", async () => {
+		const deps = dependencies({
+			cache: JSON.stringify(
+				cacheRecord({
+					first_seen_at: "2026-08-09T12:00:00.000Z",
+					checked_at: "2026-08-10T12:00:00.000Z",
+				}),
+			),
+		});
+
+		const status = await check(deps, { installKind: "npm-global" });
+
+		expect(status.auto_update_eligible).toBe(true);
+	});
+
+	it("refuses a release observed for less than 24 hours", async () => {
+		const deps = dependencies({
+			cache: JSON.stringify(
+				cacheRecord({ first_seen_at: "2026-08-09T12:00:00.001Z", checked_at: NOW.toISOString() }),
+			),
+		});
+
+		const status = await check(deps, { installKind: "npm-global" });
+
+		expect(status.auto_update_eligible).toBe(false);
+	});
+
+	it("never authorizes automatic installation for npx", async () => {
+		const deps = dependencies({
+			cache: JSON.stringify(
+				cacheRecord({
+					first_seen_at: "2026-08-09T12:00:00.000Z",
+					checked_at: NOW.toISOString(),
+				}),
+			),
+		});
+
+		const status = await check(deps, { installKind: "npx" });
+
+		expect(status.auto_update_eligible).toBe(false);
+	});
+
 	it.each([
 		"0.41.0-beta.1",
 		"0.41.0-rc.0",
@@ -813,6 +855,30 @@ describe("installation-kind detection", () => {
 				env: { CODEMEM_RUNNER_FROM: source },
 			}),
 		).toBe(expected);
+	});
+
+	it("does not let an environment marker override pinned or repository-development evidence", () => {
+		expect(
+			detectInstallKind({
+				entryPath: "/home/user/.npm/_npx/abc/node_modules/codemem/dist/index.js",
+				env: { CODEMEM_INSTALL_KIND: "npm-global", CODEMEM_RUNNER_FROM: "codemem@0.40.2" },
+			}),
+		).toBe("pinned");
+		expect(
+			detectInstallKind({
+				entryPath: "/workspace/codemem/packages/cli/src/index.ts",
+				env: { CODEMEM_INSTALL_KIND: "npm-global" },
+			}),
+		).toBe("repo-dev");
+	});
+
+	it("does not treat CODEMEM_RUNNER=npx as executable installation evidence", () => {
+		expect(
+			detectInstallKind({
+				entryPath: "/opt/custom/codemem-cli.js",
+				env: { CODEMEM_RUNNER: "npx" },
+			}),
+		).toBe("unknown");
 	});
 });
 

--- a/packages/core/src/release-discovery.ts
+++ b/packages/core/src/release-discovery.ts
@@ -11,6 +11,7 @@ const MAX_RESPONSE_BYTES = 16 * 1_024;
 const MAX_VERSION_LENGTH = 128;
 const MAX_RUNNER_SOURCE_LENGTH = 4_096;
 const RELEASE_CACHE_SCHEMA_VERSION = 1;
+const AUTO_UPDATE_DELAY_MS = 24 * 60 * 60 * 1_000;
 const STABLE_SEMVER =
 	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
@@ -261,8 +262,14 @@ function toStatus(resolution: ReleaseResolution, options: ReleaseCheckOptions): 
 		checked_at: resolution.record?.checked_at ?? null,
 		stale: resolution.stale,
 		install_kind: options.installKind,
-		// PR1 is discovery-only. Installation eligibility is introduced behind its own guarded slice.
-		auto_update_eligible: false,
+		auto_update_eligible:
+			options.installKind === "npm-global" &&
+			updateAvailable &&
+			!resolution.stale &&
+			resolution.error === null &&
+			resolution.record !== null &&
+			Date.parse(resolution.record.checked_at) - Date.parse(resolution.record.first_seen_at) >=
+				AUTO_UPDATE_DELAY_MS,
 		recommended_action: recommendedAction(
 			options.installKind,
 			options.currentVersion,
@@ -417,6 +424,12 @@ function isPinnedSource(source: string): boolean {
 
 export function detectInstallKind(input: InstallDetectionInput): InstallKind {
 	const env = input.env ?? {};
+	const source = env.CODEMEM_RUNNER_FROM?.trim() ?? "";
+	if (isPinnedSource(source)) return "pinned";
+
+	const entryPath = input.entryPath.replaceAll("\\", "/");
+	if (/\/packages\/cli\/src\/index\.ts$/.test(entryPath)) return "repo-dev";
+
 	const explicit = env.CODEMEM_INSTALL_KIND?.trim().toLowerCase();
 	const knownKinds: readonly InstallKind[] = [
 		"npm-global",
@@ -427,17 +440,17 @@ export function detectInstallKind(input: InstallDetectionInput): InstallKind {
 		"unknown",
 	];
 	if (explicit) {
-		return knownKinds.includes(explicit as InstallKind) ? (explicit as InstallKind) : "unknown";
+		if (!knownKinds.includes(explicit as InstallKind)) return "unknown";
+		// An environment marker may safely narrow permissions, but it must never
+		// authorize process execution on its own.
+		if (["docker", "repo-dev", "pinned", "unknown"].includes(explicit)) {
+			return explicit as InstallKind;
+		}
 	}
 
-	const source = env.CODEMEM_RUNNER_FROM?.trim() ?? "";
-	if (isPinnedSource(source)) return "pinned";
 	const runner = env.CODEMEM_RUNNER?.trim().toLowerCase();
 	if (runner === "node" || runner === "uv") return "repo-dev";
-	if (runner === "npx") return "npx";
 
-	const entryPath = input.entryPath.replaceAll("\\", "/");
-	if (/\/packages\/cli\/src\/index\.ts$/.test(entryPath)) return "repo-dev";
 	if (/\/(?:_npx|\.pnpm\/dlx)\//.test(entryPath)) return "npx";
 	if (/\/lib\/node_modules\/codemem\/dist\/index\.js$/.test(entryPath)) {
 		return "npm-global";

--- a/packages/opencode-plugin/.opencode/lib/compat.js
+++ b/packages/opencode-plugin/.opencode/lib/compat.js
@@ -106,9 +106,17 @@ const isPinnedGitSource = (runnerFrom) => {
   }
 };
 
-export const resolveAutoUpdatePlan = ({ runner, runnerFrom }) => {
-  const normalizedRunner = String(runner || "").trim();
-  const source = String(runnerFrom || "").trim();
+export const resolveAutoUpdatePlan = ({ runner, runnerFrom, runnerFromExplicit = false }) => {
+	const normalizedRunner = String(runner || "").trim();
+	const source = String(runnerFrom || "").trim();
+	if (isPinnedGitSource(source) || /^codemem@(?!latest$|next$|\*$)[^\s]+$/i.test(source)) {
+		return {
+			allowed: false,
+			reason: "pinned-source",
+			command: null,
+			commandText: null,
+		};
+	}
 
   if (normalizedRunner === "node") {
     return {
@@ -119,8 +127,16 @@ export const resolveAutoUpdatePlan = ({ runner, runnerFrom }) => {
     };
   }
 
-  if (normalizedRunner === "npx") {
-    return {
+	if (normalizedRunner === "npx") {
+		if (!runnerFromExplicit || !/^(?:codemem|codemem@(?:latest|next|\*))$/i.test(source)) {
+			return {
+				allowed: false,
+				reason: !runnerFromExplicit ? "implicit-pinned-source" : "custom-source",
+				command: null,
+				commandText: null,
+			};
+		}
+		return {
       allowed: true,
       reason: null,
       command: ["npm", "install", "-g", "codemem@latest"],
@@ -146,10 +162,14 @@ export const resolveAutoUpdatePlan = ({ runner, runnerFrom }) => {
     };
   }
 
-  return {
-    allowed: true,
-    reason: null,
-    command: ["npm", "install", "-g", "codemem@latest"],
-    commandText: "npm install -g codemem@latest",
-  };
+	if (normalizedRunner === "codemem") {
+		return {
+			allowed: true,
+			reason: null,
+			command: ["npm", "install", "-g", "codemem@latest"],
+			commandText: "npm install -g codemem@latest",
+		};
+	}
+
+	return { allowed: false, reason: "unknown-runner", command: null, commandText: null };
 };

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -379,6 +379,7 @@ const parseReleaseNotification = (result) => {
     return {
       latestVersion: status.latest_version,
       recommendedAction: status.recommended_action.trim(),
+      autoUpdateEligible: status.auto_update_eligible === true,
     };
   } catch {
     return null;
@@ -1734,6 +1735,8 @@ export const OpencodeMemPlugin = async ({
   let sessionStartedAt = null;
   let activeSessionID = null;
   let viewerStarted = false;
+  let viewerStartInFlight = false;
+  let compatibilityAutoUpdateAttempted = false;
   let promptCounter = 0;
   let skippedAttemptCounter = 0;
   let lastPromptText = null;
@@ -2259,12 +2262,28 @@ export const OpencodeMemPlugin = async ({
     return { usage, id: info.id };
   };
 
-  const startViewer = () => {
-    if (!viewerEnabled || !viewerAutoStart || viewerStarted) {
+  const startViewer = async () => {
+    if (!viewerEnabled || !viewerAutoStart || viewerStarted || viewerStartInFlight) {
       if (viewerStarted) logLine("viewer already started, skipping auto-start").catch(() => {});
       return;
     }
-    viewerStarted = true;
+    viewerStartInFlight = true;
+    let existingViewer = false;
+    try {
+      const existing = await fetch(viewerHealthUrl, {
+        method: "GET",
+        redirect: "manual",
+        signal: AbortSignal.timeout(1_000),
+      });
+      existingViewer = existing.ok;
+    } catch {
+      // No live viewer responded; proceed with the plugin-owned start.
+    }
+    if (existingViewer) {
+      viewerStartInFlight = false;
+      logLine("viewer already running, skipping plugin-owned auto-start").catch(() => {});
+      return;
+    }
     const viewerArgs = buildViewerCliArgs("start");
     const cmd = [runner, ...runnerArgs, ...viewerArgs];
     logLine(`auto-starting viewer: ${cmd.join(" ")}`).catch(() => {});
@@ -2275,18 +2294,24 @@ export const OpencodeMemPlugin = async ({
         detached: true,
         stdio: "ignore",
       });
+      child.once("spawn", () => {
+        viewerStarted = true;
+        viewerStartInFlight = false;
+        startHealthCheck();
+      });
       child.on("error", (err) => {
+        viewerStartInFlight = false;
         logLine(`viewer spawn error: ${err.message}`).catch(() => {});
       });
       child.unref();
     } catch (err) {
+      viewerStartInFlight = false;
       logLine(`viewer spawn failed: ${err}`).catch(() => {});
     }
-    startHealthCheck();
   };
 
   const runCommand = async (cmd, options = {}) => {
-    const { stdinText = null } = options;
+    const { stdinText = null, timeoutMs = commandTimeout } = options;
     const [command, ...args] = cmd;
     return new Promise((resolve) => {
       const proc = nodeSpawn(command, args, {
@@ -2325,19 +2350,31 @@ export const OpencodeMemPlugin = async ({
         return;
       }
       let timer = null;
-      if (Number.isFinite(commandTimeout) && commandTimeout > 0) {
+      let killTimer = null;
+      let timedOut = false;
+      let settled = false;
+      const finish = (result) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        if (killTimer) clearTimeout(killTimer);
+        resolve(result);
+      };
+      if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
         timer = setTimeout(() => {
-          try { proc.kill(); } catch { /* ignore */ }
-          resolve({ exitCode: null, stdout, stderr: "timeout" });
-        }, commandTimeout);
+          timedOut = true;
+          try { proc.kill("SIGTERM"); } catch { /* ignore */ }
+          killTimer = setTimeout(() => {
+            try { proc.kill("SIGKILL"); } catch { /* ignore */ }
+          }, 5_000);
+          if (killTimer.unref) killTimer.unref();
+        }, timeoutMs);
       }
       proc.once("exit", (exitCode) => {
-        if (timer) clearTimeout(timer);
-        resolve({ exitCode, stdout, stderr });
+        finish({ exitCode: timedOut ? null : exitCode, stdout, stderr: timedOut ? "timeout" : stderr });
       });
       proc.once("error", (err) => {
-        if (timer) clearTimeout(timer);
-        resolve({ exitCode: 1, stdout: "", stderr: String(err) });
+        finish({ exitCode: 1, stdout: "", stderr: String(err) });
       });
     });
   };
@@ -2588,7 +2625,7 @@ export const OpencodeMemPlugin = async ({
     if (!viewerEnabled || !viewerAutoStart || !viewerStarted) {
       return { attempted: false, ok: false };
     }
-    const restartResult = await runCli(buildViewerCliArgs("restart"));
+    const restartResult = await runCli(buildViewerCliArgs("restart"), { timeoutMs: 60_000 });
     if (restartResult?.exitCode === 0) {
       await logLine("compat.auto_update_viewer_restart ok");
       return { attempted: true, ok: true };
@@ -2668,12 +2705,14 @@ export const OpencodeMemPlugin = async ({
       `compat.version_mismatch current=${currentVersion} required=${minVersion} mode=${guidance.mode} note=${redactLog(guidance.note)}`
     );
 
-    const autoPlan = resolveAutoUpdatePlan({ runner, runnerFrom });
     if (backendUpdatePolicy === "auto") {
-      if (autoPlan.allowed && Array.isArray(autoPlan.command) && autoPlan.command.length > 0) {
-        const commandText = autoPlan.commandText || autoPlan.command.join(" ");
-        await logLine(`compat.auto_update_start cmd=${redactLog(commandText)}`);
-        const updateResult = await runCommand(autoPlan.command);
+      compatibilityAutoUpdateAttempted = true;
+      await logLine("compat.auto_update_start cmd=codemem update install --json");
+      const updateResult = await runCli(
+        ["update", "install", "--json"],
+        { timeoutMs: 420_000 }
+      );
+      if (updateResult?.exitCode === 0) {
         await logLine(
           `compat.auto_update_result exit=${updateResult?.exitCode ?? "unknown"} stderr=${redactLog(
             (updateResult?.stderr || "").trim()
@@ -2683,8 +2722,7 @@ export const OpencodeMemPlugin = async ({
         const refreshedResult = await runCli(["version"]);
         const refreshedVersion = (refreshedResult?.stdout || "").trim();
         if (
-          updateResult?.exitCode === 0
-          && refreshedResult?.exitCode === 0
+          refreshedResult?.exitCode === 0
           && isVersionAtLeast(refreshedVersion, minVersion)
         ) {
           writeCompatCheckCache(cacheKey, refreshedVersion);
@@ -2704,19 +2742,31 @@ export const OpencodeMemPlugin = async ({
           }
           return;
         }
-
+        await logLine(
+          `compat.auto_update_verification_failed current=${redactLog(refreshedVersion || "unknown")} required=${redactLog(minVersion)}`
+        );
         await showToast(
-          `${message}. Auto-update did not resolve it. Suggested action: ${guidance.action}`,
+          `${message}. Auto-update completed, but the active CLI failed verification. Suggested action: ${guidance.action}`,
           "warning"
         );
         return;
       }
-
+      let installError = null;
+      try {
+        installError = JSON.parse((updateResult?.stdout || "").trim())?.error || null;
+      } catch {
+        // Non-JSON output is treated as an installation failure.
+      }
+      const failureReason = installError === "update_install_locked"
+        ? "another update is already running"
+        : installError === "update_install_refused"
+          ? "not eligible"
+          : "installation failed";
       await logLine(
-        `compat.auto_update_skipped reason=${autoPlan.reason || "not-eligible"}`
+        `compat.auto_update_skipped reason=${installError || "update_install_failed"} exit=${updateResult?.exitCode ?? "unknown"} stderr=${redactLog((updateResult?.stderr || "").trim())}`
       );
       await showToast(
-        `${message}. Auto-update skipped (${autoPlan.reason || "not eligible"}). Suggested action: ${guidance.action}`,
+        `${message}. Auto-update skipped (${failureReason}). Suggested action: ${guidance.action}`,
         "warning"
       );
       return;
@@ -2732,12 +2782,40 @@ export const OpencodeMemPlugin = async ({
     );
     if (
       !notification
-      || !client.tui?.showToast
       || notifiedReleaseVersions.has(notification.latestVersion)
     ) {
       return;
     }
     notifiedReleaseVersions.add(notification.latestVersion);
+    if (
+      backendUpdatePolicy === "auto"
+      && notification.autoUpdateEligible
+      && !compatibilityAutoUpdateAttempted
+    ) {
+      const autoPlan = resolveAutoUpdatePlan({ runner, runnerFrom, runnerFromExplicit });
+      if (autoPlan.allowed) {
+        const installation = await runCli(
+          ["update", "install", "--json"],
+          { timeoutMs: 420_000 }
+        );
+        if (installation?.exitCode === 0) {
+          const viewerRestart = await restartViewerAfterAutoUpdate();
+          await showToast(`Updated codemem to ${notification.latestVersion}.`, "success");
+          if (viewerRestart.attempted && !viewerRestart.ok) {
+            await showToast(
+              "Backend updated, but viewer restart failed. Run `codemem serve restart`.",
+              "warning"
+            );
+          }
+          return;
+        }
+        await logLine(
+          `release.auto_update_failed exit=${installation?.exitCode ?? "unknown"} stderr=${redactLog(
+            (installation?.stderr || "").trim()
+          )}`
+        );
+      }
+    }
     await showToast(
       `codemem ${notification.latestVersion} is available. ${notification.recommendedAction}`,
       "warning"
@@ -3202,23 +3280,26 @@ export const OpencodeMemPlugin = async ({
 
   await log("info", "codemem plugin initialized", { cwd, version });
   await logLine(`plugin initialized cwd=${cwd} version=${version}`);
-  startViewer();
-  const compatCheckTimer = setTimeout(() => {
-    void verifyCliCompatibility().catch(async (err) => {
-      await logLine(
-        `compat.version_check_error message=${String(err?.message || err || "unknown")}`
-      );
-    });
+  void startViewer();
+  const updateCheckTimer = setTimeout(() => {
+    void (async () => {
+      try {
+        await verifyCliCompatibility();
+      } catch (err) {
+        await logLine(
+          `compat.version_check_error message=${String(err?.message || err || "unknown")}`
+        );
+      }
+      try {
+        await checkForReleaseUpdate();
+      } catch (err) {
+        await logLine(
+          `release.update_check_error message=${String(err?.message || err || "unknown")}`
+        );
+      }
+    })();
   }, COMPAT_CHECK_DELAY_MS);
-  if (compatCheckTimer.unref) compatCheckTimer.unref();
-  const releaseCheckTimer = setTimeout(() => {
-    void checkForReleaseUpdate().catch(async (err) => {
-      await logLine(
-        `release.update_check_error message=${String(err?.message || err || "unknown")}`
-      );
-    });
-  }, COMPAT_CHECK_DELAY_MS);
-  if (releaseCheckTimer.unref) releaseCheckTimer.unref();
+  if (updateCheckTimer.unref) updateCheckTimer.unref();
 
   const truncate = (value) => {
     if (value === undefined || value === null) {


### PR DESCRIPTION
## Description

Adds explicit opt-in npm upgrades with cross-process locking, stale-lock recovery, exact public-registry installs, bounded child-process cleanup, and serialized plugin execution. Automatic installation remains disabled unless eligibility is established from trusted installation evidence; unknown and pinned sources fail closed.

This is PR 4 of 4 in the update-notifications stack and depends on #1451.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated the full stack with 4,246 passing tests. After restacking, reran the combined release-discovery suite (76 tests), TypeScript, lint, and `git diff --check`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
