### PR TITLE
docs(release): narrow 0.41 to validated reliability work

### DIFF
--- a/docs/plans/2026-04-08-pack-trace-context-inspector-design.md
+++ b/docs/plans/2026-04-08-pack-trace-context-inspector-design.md
@@ -12,8 +12,9 @@ proposed Search entry point.
 
 The current UI contract predates near-duplicate compression: it omits the
 `compressed` candidate disposition and `assembly.compressed_clusters`, so
-compressed candidates are not rendered. That narrow parity gap is tracked for
-0.41; the broader Doctor surface remains deferred.
+compressed candidates are not rendered. That narrow parity gap is deferred
+outside 0.41 after the release was narrowed to validated performance and
+reliability work; the broader Doctor surface remains deferred.
 
 ## Context
 

--- a/docs/plans/2026-04-08-phase-b-pack-dedup-design.md
+++ b/docs/plans/2026-04-08-phase-b-pack-dedup-design.md
@@ -282,8 +282,8 @@ The trace should report compression:
 - `item_ids` retains compressed IDs only when their representative survives
   budgeting
 - Compression token impact versus uncompressed is not covered by current tests;
-  the deterministic `off`-versus-`ids` net-reduction fixture is tracked in the
-  0.41 plan
+  the deterministic `off`-versus-`ids` net-reduction fixture is deferred outside
+  0.41 with the automatic full-pack compression default
 - Task mode skips compression
 - Compact mode: compressed items excluded from index, only representative shown
 - Trace reports `compressed_clusters`

--- a/docs/plans/2026-08-10-release-0.41-fast-focused-recall-design.md
+++ b/docs/plans/2026-08-10-release-0.41-fast-focused-recall-design.md
@@ -1,261 +1,220 @@
-# Codemem 0.41: Fast, Focused Recall
+# Codemem 0.41: Performance and Reliability
 
-**Status:** Approved direction; implementation baseline verified against v0.40.2
-**Date:** 2026-08-10
+**Status:** Approved narrowed scope; implementation present on `main`, release validation pending
+**Date:** 2026-08-13
 **Release target:** 0.41
+
+The filename remains unchanged so existing roadmap links continue to work. This
+document supersedes the original broader scope.
 
 ## Release promise
 
-Codemem delivers useful context faster, avoids repeating the same idea, and
-clearly shows what it supplied.
+Codemem supplies prompt context with less process overhead, detects stable updates
+without disrupting startup, and gives users safer upgrade and operational recovery
+paths.
 
-This is an external-user-value release. It is not a general backlog milestone.
-Work belongs in 0.41 only when it directly improves that promise or closes a
-confirmed security or privacy defect that would make the release unsafe.
+This release is about measured performance and reliability. It is not a general
+recall-quality, sharing, identity, or transport milestone.
 
-## Source-of-truth rule
+## Why the scope changed
 
-The implementation baseline in this document was verified against `origin/main`
-at v0.40.2 (`6b3c3d4e`). Current source and tests outrank older roadmap prose and
-Bead descriptions. Historical measurements are labelled as such and are not
-release evidence unless their commands and results are reproduced.
+The original 0.41 roadmap combined one demonstrated performance problem with
+several plausible but unproven product ideas. Current implementation and review
+evidence support a narrower release:
 
-Before implementation, each work unit must record its current source path,
-existing tests, missing behavior, and explicit non-goals. Discovery of an already
-shipped capability narrows the work unit; it does not authorize reimplementation.
+- OpenCode prompt injection paid avoidable process-start and embedding-model
+  startup costs. The merged viewer-backed path removes pack and ledger CLI
+  subprocesses from healthy flows while retaining classified fallback.
+- Users lacked a bounded way to discover stable releases and distinguish advice
+  from safe automatic execution. The merged updater now separates read-only
+  checks, notifications, eligibility, and guarded installation.
+- Operational failures were difficult to distinguish from inventory or setup
+  problems. Merged health, status, probe, and sync-maintenance work provides
+  clearer local evidence and safer recovery behavior.
+- Automatic full-pack compression did not demonstrate reliable answer-quality
+  value. Token reduction alone is insufficient, so compression default changes
+  and their Context Inspector work are deferred.
+- Direct signed sync succeeded when listeners, bootstrap state, and identity
+  material were healthy. Relay therefore addresses no demonstrated 0.41 blocker
+  and remains deferred until route-unavailable evidence exists.
 
-## Why this release
+Source and tests on `main` outrank the superseded roadmap prose. Claims in release
+notes must be limited to behavior that is merged and evidence reproduced for the
+release candidate.
 
-Three verified gaps affect the core recall loop:
+## Shipped implementation baseline
 
-1. Every new eligible uncached OpenCode injection starts a `codemem pack` CLI
-   process. Successful delivery, skipped attempts, and cache reuse also use the
-   `prompt-pack-ledger` CLI. The long-lived viewer already exposes pack building
-   but does not support the complete injection contract.
-2. A historical 30-trace audit reported substantial repetition in default and
-   recall packs, but its runnable corpus is not checked in. Core subsequently
-   shipped the audited compression behavior; automatic full packs do not enable
-   it by default.
-3. Core already implements the audited cluster-compression heuristic and records
-   `PackTrace.assembly.compressed_clusters`, but its default `compact` setting
-   applies compression only to compact packs. Automatic full packs do not enable
-   it, and the Context Inspector does not render the existing cluster metadata.
+### 1. Viewer-backed OpenCode prompt packs
 
-One confirmed presentation defect also gates release quality:
+OpenCode now requests prompt packs and prompt-pack ledger transitions from the
+long-lived local viewer on healthy paths. The viewer reuses the shared core pack
+builder, store, and process-wide embedding client.
 
-- received memories can show raw actor or device identifiers as primary Feed
-  labels.
+The transport preserves existing query construction, working-set handling,
+artifact fingerprints, attempt identity, delivery, skipped-attempt and cache-reuse
+records, and idempotency repair. Retryable connection, protocol, older-viewer,
+server, or unusable-response failures retain the CLI fallback. Validated request
+errors remain terminal instead of being hidden by fallback.
 
-Recipient-unbound peer signatures remain a P1 security issue, but they use shared
-direct/coordinator canonicalization and a second worker verifier. That work moves
-on an independent security track rather than blocking this recall release on an
-unapproved cryptographic rollout policy.
+Deterministic tests prove that healthy pack, delivery, skipped, and cache-reuse
+paths start neither `codemem pack` nor `prompt-pack-ledger` subprocesses. That is
+valid architectural evidence. It is not yet a measured latency result.
 
-## How packs work today
+### 2. Stable release discovery and notifications
 
-All pack surfaces eventually call the shared core pack builder, but they do not
-share one transport or process lifecycle.
+`codemem update check` is the canonical read-only update surface. It:
 
-| Surface | Current path | Process lifecycle |
-|---|---|---|
-| OpenCode automatic injection | plugin `buildInjectedContext` → `runCli(packArgs)` → `codemem pack`; separate ledger CLI calls | New processes for each uncached pack and subsequent ledger transitions |
-| Claude hook injection | existing `GET /api/pack` HTTP-first path → local core fallback | Viewer when available; one-shot hook fallback |
-| Codex hook injection | existing `GET /api/pack` HTTP-first path → local core fallback | Viewer when available; one-shot hook fallback |
-| CLI `codemem pack` | CLI command → core pack builder | One process per invocation |
-| Viewer `GET /api/pack` | viewer route → shared core builder; no working-set, render-option, or ledger input | Long-lived viewer process |
-| Context Inspector `POST /api/pack/trace` | viewer route → trace builder; no render-option input | Long-lived viewer process |
-| MCP `memory_pack` | MCP handler → shared core retrieval with compact/compression options | Long-lived MCP process |
+- accepts only strict stable semantic versions;
+- rejects prereleases, malformed versions, downgrades, and oversized values;
+- uses a bounded public-registry request and six-hour atomic cache;
+- can use clearly labelled valid stale status for guidance after refresh failure;
+- exposes human output, stable JSON, `--refresh`, `GET /api/update-status`, the
+  Viewer Health UI, and installation-specific guidance.
 
-The viewer therefore already has an HTTP pack endpoint, and core already owns
-both pack and ledger semantics. The 0.41 work adds transport parity and makes the
-OpenCode plugin use it. It does not create a second pack or ledger implementation.
-The embedding client is a process-wide lazy singleton, so the long-lived viewer
-can reuse it while one-shot CLI processes cannot.
+The OpenCode plugin runs the check asynchronously after startup. `notify` remains
+the default policy, `off` disables release checks, and each discovered version is
+notified at most once per plugin process. This is a plugin-startup check, not a
+universal background scheduler for every Codemem integration.
 
-Claude/Codex pack fallback and OpenCode raw-event streaming already implement
-HTTP-first/local-fallback patterns. OpenCode pack transport extends those patterns
-instead of designing a new retry subsystem.
+### 3. Guarded opt-in npm upgrades
 
-## Scope
+`CODEMEM_BACKEND_UPDATE_POLICY=auto` may invoke `codemem update install` only when
+fresh status proves all eligibility conditions. The installer:
 
-### 1. Viewer-backed automatic injection
+- requires a stable release observed for at least 24 hours;
+- requires proven global npm installation provenance;
+- refuses pinned, npx, Docker, repository-development, stale, prerelease,
+  downgrade, and unknown installations;
+- installs the exact validated version from the public npm registry;
+- uses a cross-process lock with stale-lock recovery;
+- bounds child-process execution and process-tree cleanup;
+- verifies the active `codemem version` after installation;
+- restarts a viewer only when the current plugin process recorded that it started
+  that viewer; it does not restart a pre-existing viewer.
 
-Keep `GET /api/pack` for existing Claude/Codex compatibility. Add a structured
-`POST /api/pack` only because OpenCode injection carries working-set arrays,
-render options, and attempt metadata that do not belong in a query string. Add
-one `POST /api/prompt-pack-ledger` action dispatcher using the same payload and
-core operations as the existing `prompt-pack-ledger` CLI command.
+The installer and policy are heavily covered by focused and full CI tests. A real
+published-version upgrade rehearsal remains release-candidate evidence rather
+than a claim already proven by unit tests.
 
-The pack POST request reproduces the effective inputs of the current CLI path:
+### 4. Operational and direct-sync reliability
 
-- context query;
-- limit and token budget;
-- project resolution with the same environment/cwd precedence as the CLI, plus
-  normalized repository-relative working-set paths;
-- prompt-pack attempt identity and bounded ledger metadata.
+The post-0.40.2 baseline also includes:
 
-The response preserves the existing machine-readable pack result, artifact
-fingerprint, and retrieval-ledger conflict semantics. The viewer continues to use
-its long-lived store and process-wide embedding client.
+- `codemem status` for offline local subsystem health;
+- `GET /api/health` and consolidated Viewer/plugin/CLI probe semantics;
+- command-tree parity and deprecation hygiene;
+- safer enrollment maintenance and restored-peer identity behavior;
+- fail-closed Team/device eligibility and recipient-edge validation;
+- peer runtime-version reporting for upgrade diagnosis;
+- worker-bundle and schema-compatibility hardening.
 
-OpenCode automatic injection becomes HTTP-first:
+These changes support reliable operation and diagnosis. They are not marketed as
+new recall-quality or collaboration features.
 
-1. request the pack from the configured local viewer;
-2. validate the response before injection;
-3. record attempt, delivery, skipped, and cache-reuse ledger transitions through
-   the viewer rather than spawning `prompt-pack-ledger`;
-4. retry an idempotency conflict with the existing fresh-identity algorithm over
-   HTTP rather than repeating the same conflict through the CLI;
-5. reuse the plugin's existing HTTP backoff and fallback classification patterns;
-6. retain the current CLI paths only when the result is classified retryable,
-   including connection failure, timeout, an older viewer returning 404/405,
-   server failure, or an unusable success response;
-7. treat validated request 4xx responses as terminal contract errors rather than
-   masking them with fallback;
-8. report the existing `{ cause, retryable }` shape through bounded local
-   diagnostics, without expanding the persisted attribution-ledger schema.
+## Required release evidence
 
-Existing cache-reuse, retry identity, handoff confirmation, privacy, and
-non-blocking ledger behavior remain unchanged.
+### Prompt-path benchmark
 
-### 2. Enable existing rendering-time compression
+Run a development-only benchmark against one fixed, privacy-safe fixture with
+identical query, project, working set, render options, and database inputs:
 
-Use the shipped Layer 2 pack-time cluster compression instead of implementing a
-second algorithm. Core already provides `compressClusters`, `off`/`compact`/`ids`
-modes, representative selection, compressed member IDs, and PackTrace metadata.
+1. Warm the viewer store and embedding client and discard one setup run per path.
+2. Measure 30 repetitions each for direct CLI pack, healthy viewer-backed plugin
+   transport, and viewer-unavailable classified CLI fallback.
+3. Record aggregate median and p95 latency plus pack and ledger subprocess counts.
+4. Report terminal contract, retryable transport/protocol, and harness failures
+   separately; exclude none silently.
+5. Persist no prompts, memory text, IDs, absolute paths, or per-query outputs.
+   Unlabelled per-run latency values may be retained only as a sorted list.
 
-- Add `compression_mode` to viewer pack and trace requests.
-- Add the effective compression mode to PackTrace as an additive version-1 field;
-  older clients ignore it.
-- Export one automatic-compression resolver so OpenCode, Claude, and Codex do not
-  duplicate environment aliases. A valid `CODEMEM_PACK_COMPRESSION` value wins
-  over the automatic default; otherwise automatic full packs request `ids`.
-- Preserve the existing manual CLI/MCP default (`compact`) and explicit
-  `off`/`compact`/`ids` caller overrides.
-- Keep the existing task-mode skip unchanged.
-- Preserve the existing representative, `(+N related)`, compressed member ID,
-  result, and trace contracts.
-- Validate rollout with a documented, reproducible query set and aggregate output;
-  do not cite the historical 30-trace numbers as new release evidence.
-- Make no storage, ingestion, ranking, or authorization changes.
+The performance claim ships only if healthy-viewer median is lower than direct-CLI
+median and healthy-viewer p95 is no higher than direct-CLI p95 on the same fixture.
+With 30 samples, p95 is a coarse tail indicator, so the report must also include
+sorted aggregate timings and avoid stronger statistical claims. Fallback latency
+is reported separately and does not gate the performance claim. If p95 regresses,
+repeat the complete 30-run comparison once; a repeated regression fails the gate.
 
-`ids` intentionally renders `(+N related: [id], ...)` rather than the terse
-`(+N related)` suffix. This preserves fetch-more identity but consumes some of the
-tokens compression saves. A deterministic `off` versus `ids` fixture must show a
-net reduction before `ids` becomes the automatic default; otherwise the default
-change is deferred rather than inventing a fourth compression mode in 0.41.
+### Packaged-upgrade rehearsal
 
-There are no LLM calls, network calls, schema migrations, or writes in this
-compression path.
+Before release, exercise behavior that deterministic tests cannot fully prove,
+using disposable global npm installations and a published older/newer
+stable-version pair. Verify:
 
-### 3. Compression explanation
+- exact public-registry target selection;
+- successful installation and active-version verification;
+- real cross-process lock contention and failed-install behavior;
+- owned-viewer restart behavior without touching unrelated viewer processes.
 
-First restore client/server contract parity: the UI type adds the existing
-`compressed` disposition, `assembly.compressed_clusters`, and effective
-compression mode, and the trace request uses the same mode as the pack being
-investigated. For each cluster, show:
+Use the existing core, CLI, and plugin tests as evidence for parsing, caching,
+freshness, notification policy, prerelease/downgrade rejection, and unsupported
+installation refusal instead of manually duplicating those cases.
 
-- the representative memory;
-- compressed member IDs and available candidate titles;
-- the heuristic pattern and recorded all-cluster overlap terms, labelled as
-  algorithmic evidence rather than a causal explanation;
-- compressed member count and final pack token count.
+If a real newer published candidate is unavailable, the release notes must state
+that automatic installation is CI-validated but not production-dogfooded across a
+published upgrade.
 
-Current PackTrace does not contain an uncompressed token baseline or pairwise
-cluster edges. The Inspector must not invent token savings or claim that empty
-all-cluster overlap terms fully explain a transitive cluster. Offline rollout
-validation compares `off` and `ids` using the same queries.
+### Final release candidate
 
-This is not a general Context Inspector redesign. Existing unrelated rough edges
-remain follow-up work.
-
-### 4. Release-gating fix
-
-#### Human-readable received-memory identity
-
-Name preservation for direct Project, Team, and add-device onboarding is already
-partially shipped. The remaining gate resolves Feed provenance from trusted actor
-and peer facts, rejects machine-shaped display names at server ingress, and uses a
-safe presentation fallback for legacy malformed rows. Raw UUIDs and
-`local:<uuid>` values remain diagnostics-only.
+- Align all package and plugin versions at `0.41.0` first.
+- Run `pnpm run check` on that exact bumped candidate commit.
+- Build Viewer assets and run plugin/package smoke and relevant E2E suites.
+- Run release version and tag preflights.
+- Merge the release PR, then confirm the merged `main` tree matches the validated
+  candidate tree or rerun `pnpm run check` and tag preflight on merged `main`.
+- Tag only that merged `main` commit.
 
 ## Success criteria
 
-### Latency
+### Performance
 
-- OpenCode automatic injection does not start a pack or prompt-pack-ledger CLI
-  process on healthy retrieval, delivery, skipped-attempt, or cache-reuse paths.
-- A documented development benchmark records median and p95 for identical warm
-  healthy-viewer queries through CLI and viewer paths. If viewer median is not
-  lower or healthy-viewer p95 regresses, transport does not ship as a performance
-  improvement. Fallback latency is measured separately.
+- Healthy OpenCode prompt-pack and ledger paths start zero pack/ledger CLI
+  subprocesses.
+- The reproduced 30-run benchmark meets the median and p95 gate above.
 - Viewer-unavailable fallback still supplies usable context when the CLI succeeds.
-- Diagnostics emit stable `{ cause, retryable }` values; focused tests cover
-  representative transport, contract, conflict, and fallback failures.
 
-### Pack quality
+### Update reliability
 
-- A checked-in synthetic fixture contains known clusters and known non-clusters;
-  automatic `ids` compresses exactly the expected groups.
-- Automatic full-pack default/recall paths enable the shipped compression and
-  represent fixture-defined clusters once while retaining member identities
-  in metadata.
-- Task-mode pack text and selection remain unchanged.
-- The same fixture demonstrates a net token reduction for `ids` versus `off`
-  despite related-ID suffixes. No historical percentage is reused.
+- Update checks never block plugin startup and fail safely on malformed or
+  unavailable registry data.
+- Default behavior is notification-only.
+- Automatic installation remains explicit, exact-version, public-registry,
+  serialized, verified, and fail-closed.
+- Unsupported install kinds receive guidance without mutation.
 
-### Transparency
+### Operational reliability
 
-- The Context Inspector shows which memories were compressed, the representative,
-  and the heuristic evidence actually present in PackTrace.
-- Pack text, response metadata, and trace metadata agree on cluster membership.
+- Local status and health surfaces distinguish actionable subsystem failures from
+  inventory and configuration facts.
+- Direct-sync maintenance and identity failures remain visible and do not silently
+  broaden trust or authorization.
+- Standard TypeScript, smoke, security, and relevant E2E checks pass.
 
-### Release safety
+## Deferred work
 
-- Normal Feed presentation never uses a raw actor/device UUID as its primary
-  identity label.
-- The standard TypeScript quality gate and focused integration tests pass.
+The following work is explicitly outside 0.41:
 
-## Explicit non-goals
+- promoting `ids` compression to the automatic full-pack default;
+- Context Inspector compression explanation or broader redesign;
+- Feed identity presentation repair. The existing P1 identity/privacy bug
+  (`codemem-g9sp`) remains independently prioritized, but is not a 0.41 release
+  dependency;
+- relay-assisted or durable store-and-forward sync;
+- lost-key recovery or healthy-key rotation;
+- human-principal, OAuth, or OIDC product identity;
+- sharing, Teams, Spaces, pairing, or mDNS expansion;
+- efficacy studies, hosted MCP expansion, or broad backend refactors.
 
-- Further ingestion-time or cross-session near-deduplication beyond the shipped
-  `dedup_key` path.
-- New memory schema or migration work for compression.
-- Outcome-evidence collectors, attribution rules, or randomized efficacy study.
-- Relay transport implementation.
-- Recipient-signature versioning, coordinator canonicalization, or worker verifier
-  changes; these remain on the dedicated P1 security track.
-- Lost-key recovery or healthy-key rotation.
-- Human principal, account linking, OAuth, or OIDC product identity.
-- Teams, Spaces, sharing, pairing, or mDNS expansion unless a blocking regression
-  is discovered.
-- Hosted or multitenant MCP expansion.
-- Broad Context Inspector, Feed, Sync, or settings redesign.
-- Broad backend refactors or generic performance cleanup.
+Relay can be reconsidered only after authorized peers are simultaneously online,
+listeners are independently healthy, no acceptable stable direct route exists,
+and both peers have outbound transport that a relay could use. Listener lifecycle,
+bootstrap, or key-persistence failures do not satisfy that gate.
 
-## Delivery sequence
+Existing manual and compact-pack compression behavior remains unchanged. The
+deferral applies only to changing automatic full-pack defaults and building UI
+explanation specifically for that unshipped default.
 
-The release has two lanes so unrelated security work does not block review of the
-recall stack.
+## Delivery decision
 
-### Recall lane
-
-1. Record the development transport baseline and add deterministic zero-subprocess
-   tests; do not add a public benchmark CLI command.
-2. Extend and test the existing viewer pack and prompt-pack-ledger HTTP contracts
-   for semantic parity only.
-3. Move OpenCode pack construction and ledger transitions to HTTP-first with
-   classified CLI fallback; verify zero healthy-path subprocesses.
-4. Propagate the existing compression mode through OpenCode, Claude, Codex,
-   viewer, trace, and fallback paths using the shared resolver.
-5. Restore Context Inspector type/rendering parity for existing compression data.
-6. Run the documented latency benchmark and synthetic compression fixture, and
-   publish only measured results in release notes.
-
-### Release-gate lane
-
-1. Fix Feed identity resolution, server display-name validation, and legacy-row
-   fallback with focused regression coverage.
-
-The recall lane and Feed gate must pass before 0.41 is released. Neither absorbs
-deferred work merely because it touches the same files.
+0.41 is ready to enter release-candidate validation when the benchmark and updater
+rehearsal are complete. New feature work does not enter the release merely because
+it touches pack, Viewer, plugin, update, or sync code.

--- a/docs/plans/2026-08-10-release-0.41-fast-focused-recall-implementation.md
+++ b/docs/plans/2026-08-10-release-0.41-fast-focused-recall-implementation.md
@@ -1,156 +1,141 @@
-# Codemem 0.41 Fast, Focused Recall: Implementation Plan
+# Codemem 0.41 Performance and Reliability: Release Plan
 
-**Design:** [Codemem 0.41: Fast, Focused Recall](./2026-08-10-release-0.41-fast-focused-recall-design.md)
-**Status:** Ready for scoped execution
-**Date:** 2026-08-10
+**Design:** [Codemem 0.41: Performance and Reliability](./2026-08-10-release-0.41-fast-focused-recall-design.md)
+**Status:** Implementation merged; release validation pending
+**Date:** 2026-08-13
 
-## Release work units
+The filename remains unchanged so existing roadmap links continue to work. This
+plan replaces the original broader execution scope.
 
-### Recall 0: Baseline and deterministic fixtures
+## Scope summary
 
-**Tracking:** `codemem-83te`, `codemem-2ucx`
+0.41 packages already-merged prompt-path performance, update safety, and local
+operational reliability work. Remaining work is evidence and release execution,
+not another feature stack.
 
-- Document a development-only benchmark procedure for identical warm pack queries
-  through the existing CLI and viewer paths; do not add a public CLI command.
-- Record median and p95 for healthy-viewer and fallback paths separately.
-- Add deterministic tests that count pack/ledger subprocess calls.
-- Add a synthetic compression fixture with known clusters and non-clusters.
-- Treat historical latency and 30-trace numbers as rationale only until
-  reproduced.
+## Merged work
 
-**Verification:** the fixture is deterministic and privacy-safe; the documented
-measurement does not persist prompt or memory content.
+### Performance: viewer-backed OpenCode prompt packs
 
-#### Development-only warm transport benchmark
+**Tracking:** `codemem-83te` — closed
+**Merged:** PR #1435
 
-Do not add a public CLI command or package script. Use a local benchmark harness
-against one fixed, privacy-safe query fixture and identical pack inputs (query,
-project/cwd, working set, render options, and database) for each path:
+- Structured viewer `POST /api/pack` and prompt-pack ledger actions.
+- Healthy OpenCode pack, delivery, skipped, and cache-reuse paths avoid pack and
+  ledger CLI subprocesses.
+- Classified CLI fallback, terminal request errors, identity repair, and existing
+  pack bytes remain covered.
+- Plugin, Viewer, smoke, TypeScript, lint, full test, E2E, CodeQL, and Snyk checks
+  passed before merge.
 
-1. Start one viewer and warm the viewer store and embedding client with each case;
-   also run and discard one CLI case so setup is excluded.
-2. Run 30 measured repetitions per case for: direct CLI pack, healthy viewer-backed
-   plugin transport, and viewer-unavailable plugin transport that takes the
-   classified retryable CLI fallback. Keep the viewer alive for the healthy path.
-3. Report aggregate median and p95 latency and pack/`prompt-pack-ledger`
-   subprocess counts for each path; never write prompts, memory text, IDs, or
-   per-query results to benchmark output.
-4. Classify every failed repetition as terminal contract (validated 4xx), retryable
-   transport/protocol (connection, timeout, 404/405, 5xx, unusable response), or
-   harness/environment failure. Exclude none silently; report counts separately.
+### Reliability: release discovery and guarded upgrades
 
-Historical latency and 30-trace figures remain rationale only. Publish results as
-new measurement evidence only after this procedure completes.
+**Merged:** PRs #1449, #1450, and #1452
 
-### Recall 1: Viewer pack transport contract
+- Strict stable-version discovery, bounded registry access, atomic caching, and
+  stale guidance.
+- CLI, Viewer Health, and asynchronous OpenCode notification surfaces.
+- Explicit opt-in exact-version global npm installation with provenance checks,
+  24-hour observation, locking, bounded cleanup, verification, and owned-viewer
+  restart.
+- Focused updater suites, full TypeScript/test/lint gates, smoke/E2E, CodeQL, and
+  Snyk passed before merge.
 
-**Tracking:** `codemem-83te`
+### Reliability: status, health, and direct-sync hardening
 
-- Retain `GET /api/pack` for existing Claude/Codex clients and add structured
-  `POST /api/pack` for OpenCode working-set/render/attempt payloads.
-- Add one `POST /api/prompt-pack-ledger` action dispatcher for attempt recording,
-  delivery, skipped attempts, and cache reuse.
-- Reuse the existing core pack builder and long-lived viewer store.
-- Reuse the existing core ledger operations behind `prompt-pack-ledger`.
-- Preserve effective project resolution from environment/cwd, working-set paths,
-  render options, and bounded prompt-pack ledger metadata.
-- Return the existing machine-readable pack result, artifact fingerprint,
-  idempotency-conflict outcome, and stable structured errors.
-- Cover valid requests, invalid fields, ledger conflicts, idempotent ledger
-  transitions, and store failures.
+- Sync architecture, identity, worker-bundle, and maintenance fixes: PRs #1416,
+  #1420, #1433, #1434, and #1437.
+- Operational status, health, and probe consolidation: PRs #1438–#1443.
+- Fail-closed Team/device and recipient-edge hardening: PRs #1436 and #1444–#1447.
+- Peer runtime-version reporting: PR #1451.
 
-**Verification:** focused viewer route tests, typecheck, lint.
+These merged changes are supporting release evidence, not an invitation to absorb
+additional sharing or identity roadmap work.
 
-### Recall 2: OpenCode HTTP-first injection
+## Remaining release work
 
-**Tracking:** `codemem-83te`
+### RC 1: Reproduce prompt-path performance evidence
 
-- Extend the source-of-truth OpenCode plugin's shipped raw-event
-  HTTP/backoff/fallback pattern to pack and ledger payloads.
-- Route attempt recording, delivery confirmation, skipped attempts, and cache
-  reuse through the viewer on the healthy path.
-- Preserve existing query construction, retry identity, cache reuse, handoff, and
-  fallback bytes.
-- Retry ledger conflicts with a fresh identity over HTTP.
-- Reuse the existing `{ cause, retryable }` classification shape; use `pack` and
-  `prompt-pack-ledger` CLI only for retryable transport/protocol failures.
-- Treat validated request 4xx responses as terminal contract failures and record
-  bounded diagnostics without adding outcome-attribution schema.
-- Keep wrapper plugin files as re-exports; do not duplicate implementation.
+**Tracking:** `codemem-x4cu.1`
 
-**Verification:** plugin tests/smoke tests, focused viewer integration tests, warm
-latency comparison against the existing CLI path.
+Use the development-only benchmark procedure from the design. Run 30 measured
+repetitions for direct CLI, healthy viewer-backed plugin transport, and classified
+CLI fallback with identical privacy-safe inputs.
 
-### Recall 3: Enable existing full-pack compression
+Record only:
 
-**Tracking:** `codemem-2ucx`
+- aggregate median and p95 latency;
+- aggregate pack and ledger subprocess counts;
+- counts by terminal contract, retryable transport/protocol, and harness failure.
 
-- Add `compression_mode` to viewer pack and trace request validation.
-- Add the effective compression mode to the additive PackTrace contract.
-- Export one automatic resolver for OpenCode, Claude, and Codex. A valid
-  `CODEMEM_PACK_COMPRESSION` value wins over the automatic default; otherwise
-  automatic full packs request `ids`. The resolved mode is then passed explicitly
-  to core, whose normal explicit-option precedence remains unchanged.
-- Keep manual CLI/MCP default behavior and explicit `off`, `compact`, and `ids`
-  overrides unchanged.
-- Keep the existing task-mode skip, representative selection, member-ID
-  preservation, and result/PackTrace metadata unchanged.
-- Accept the existing verbose related-ID suffix only if the synthetic fixture
-  shows a net token reduction versus `off`.
-- Change the shipped heuristic only if the fixture demonstrates a concrete defect.
-- Avoid all persistence changes.
+**Gate:** healthy-viewer median must be lower than direct-CLI median,
+healthy-viewer p95 must be no higher than direct-CLI p95 on the same fixture, and
+healthy pack/ledger subprocess counts must remain zero. Report sorted aggregate
+timings because 30 samples make p95 a coarse indicator. If the gate fails, do not
+market 0.41 as a performance release until the complete 30-run comparison has
+been repeated once. A repeated regression fails the gate until the cause is fixed
+or the claim is narrowed.
 
-**Verification:** existing core compression tests, OpenCode/Claude/Codex/viewer
-option propagation, explicit `ids` task-mode parity, trace/result parity, and the
-synthetic fixture.
+### RC 2: Rehearse packaged update behavior
 
-### Recall 4: Context Inspector explanation
+**Tracking:** `codemem-x4cu.2`
 
-**Tracking:** `codemem-f2u0`
+Use disposable npm prefixes and published stable versions. Do not mutate the
+developer's active global installation.
 
-- Add the shipped `compressed` disposition and
-  `PackTrace.assembly.compressed_clusters` to viewer API types.
-- Render representative, available member titles/IDs, heuristic pattern, recorded
-  overlap terms, compressed count, and final pack tokens.
-- Display the effective compression mode from PackTrace so a manual trace can
-  match the automatic pack under investigation.
-- Do not claim per-cluster or total token savings; current PackTrace has no
-  uncompressed baseline.
-- Keep the change within the existing inspector information architecture.
+Verify the integration behavior that deterministic tests cannot fully prove:
 
-**Verification:** focused UI rendering tests, UI build, viewer route integration.
+1. Exact public-registry installation for a proven global npm installation.
+2. Active-version verification against the disposable installed command.
+3. Real cross-process lock contention and stale-lock recovery.
+4. Viewer restart only when the current plugin process started that viewer.
+5. Failed installation or verification produces guidance and no success claim.
 
-### Gate 1: Human-readable shared identity
+Cite existing core, CLI, and plugin tests for parsing, caching, freshness,
+notification policy, prerelease/downgrade rejection, and unsupported installation
+refusal rather than manually duplicating them.
 
-**Tracking:** `codemem-g9sp`
+If no newer published stable candidate exists, record the limitation and retain
+the CI evidence without manufacturing a production-upgrade claim.
 
-- Reuse already-shipped onboarding name preservation rather than rebuilding it.
-- Resolve Feed author/device labels from trusted actor and peer facts.
-- Reject or normalize machine-shaped display names at server ingress.
-- Use safe unresolved labels for already persisted malformed rows.
-- Keep raw IDs diagnostics-only.
+### RC 3: Final candidate gate
 
-**Verification:** focused Feed/API tests, one direct-Project provenance regression,
-and malformed legacy-row coverage. Do not duplicate already-shipped Team and
-add-device suites without a distinct path gap.
+**Tracking:** `codemem-x4cu.3`
+**Depends on:** `codemem-x4cu.1`, `codemem-x4cu.2`
 
-## Integration and release validation
+On the exact proposed release commit:
 
-1. Run focused checks after each work unit.
-2. Run `pnpm run check` after each ready stack and on the final release candidate.
-3. Build viewer assets before viewer integration or E2E validation.
-4. Run the relevant plugin smoke tests with nested runtime dependencies installed.
-5. Run the synthetic compression fixture and record item/token deltas.
-6. Benchmark warm viewer-backed injection against the current CLI baseline.
-7. Run focused Feed provenance scenarios.
-8. Update README/user guidance and release notes only for behavior that shipped.
+1. Run the repository's release-version alignment script for `0.41.0`.
+2. Run `pnpm run check` on the bumped commit.
+3. Run `pnpm run build` so Viewer assets are staged from source.
+4. Run packaged plugin smoke and relevant E2E smoke/sharing suites.
+5. Review open critical/high security and release-blocking defects.
+6. Update release notes using only reproduced benchmark and rehearsal evidence.
+7. Run release and tag preflights.
+8. Merge the release PR, then confirm the merged `main` tree matches the validated
+   candidate tree or rerun `pnpm run check` and tag preflight on merged `main`.
+9. Tag only that merged `main` commit.
+
+## Tracking reconciliation
+
+- `codemem-x4cu` tracks the narrowed 0.41 performance/reliability release.
+- `codemem-83te` remains closed as the merged prompt-path implementation.
+- `codemem-2ucx` remains deferred; token reduction did not prove answer-quality
+  value.
+- `codemem-f2u0` is deferred outside 0.41 because its compression explanation no
+  longer supports a shipping 0.41 behavior.
+- `codemem-g9sp` remains an independently prioritized P1 identity/privacy bug, not
+  a 0.41 release dependency.
+- Relay work remains deferred behind direct-route evidence and separate security
+  approval.
 
 ## Stop conditions
 
-- Do not add ingestion deduplication to solve a pack-rendering issue.
-- Do not redesign the inspector beyond compression explanation.
-- Keep recipient-signature/coordinator/worker security work on its dedicated P1
-  track rather than pulling it into this release.
-- Do not expand identity-label repair into human-principal architecture.
-- File newly discovered adjacent work separately and keep it out of 0.41 unless it
-  blocks a stated success criterion.
+- Do not promote `ids` compression to the automatic full-pack default to make the
+  old roadmap look complete; shipped manual and compact behavior remains intact.
+- Do not claim measured speed from zero-subprocess tests alone.
+- Do not turn plugin-startup update checks into a universal daemon or scheduler.
+- Do not weaken updater provenance or freshness gates to make rehearsal easier.
+- Do not add relay to mask listener, bootstrap, or identity-persistence failures.
+- Do not pull Feed, sharing, identity architecture, hosted MCP, efficacy, or broad
+  refactor work into the release without a newly confirmed release-blocking defect.


### PR DESCRIPTION
## Description

Narrow the Codemem 0.41 roadmap to already-merged performance and reliability work, with measurable release-candidate evidence. Clarify benchmark gates, packaged-update rehearsal, version-before-validation ordering, and deferred compression, Context Inspector, Feed identity, and relay scope.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation: `git diff --check`; focused independent documentation review found no blockers.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced