### PR TITLE
refactor(opencode): canonicalize Codemem plugin exports

### DIFF
--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -2,6 +2,7 @@ const PINNED_BACKEND_VERSION = "0.40.2";
 
 export {
 	default,
+	CodememPlugin,
 	OpencodeMemPlugin,
 	__testUtils,
 	buildInjectionToastMessage,

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -56,8 +56,8 @@ function installSpawnResult(status = availableStatus) {
 }
 
 async function startPlugin(showToast = vi.fn().mockResolvedValue(undefined)) {
-	const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
-	const hooks = await OpencodeMemPlugin({
+	const { CodememPlugin } = await import("../plugins/codemem.js");
+	const hooks = await CodememPlugin({
 		project: { name: "codemem" },
 		client: {
 			app: { log: vi.fn().mockResolvedValue(undefined) },
@@ -73,6 +73,15 @@ async function runStartupChecks() {
 	await vi.advanceTimersByTimeAsync(1_500);
 	await vi.runAllTicks();
 }
+
+describe("@codemem/opencode-plugin exports", () => {
+	test("exports CodememPlugin canonically while preserving the legacy alias", async () => {
+		const plugin = await import("../plugins/codemem.js");
+
+		expect(plugin.default).toBe(plugin.CodememPlugin);
+		expect(plugin.OpencodeMemPlugin).toBe(plugin.CodememPlugin);
+	});
+});
 
 describe("OpenCode startup release notifications", () => {
 	const originalEnv = { ...process.env };

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -1609,7 +1609,7 @@ const buildRunnerArgs = ({ runner, runnerFrom, runnerFromExplicit }) => {
   return runnerFromExplicit ? [runnerFrom] : [];
 };
 
-export const OpencodeMemPlugin = async ({
+export const CodememPlugin = async ({
   project,
   client,
   directory,
@@ -3873,7 +3873,13 @@ export const OpencodeMemPlugin = async ({
   };
 };
 
-export default OpencodeMemPlugin;
+export default CodememPlugin;
+
+/**
+ * @deprecated Use CodememPlugin.
+ * Keep this reference-identical: OpenCode deduplicates plugin exports by identity.
+ */
+export const OpencodeMemPlugin = CodememPlugin;
 export const __testUtils = {
   PINNED_BACKEND_VERSION,
   fetchRawEventsStatus,

--- a/packages/opencode-plugin/README.md
+++ b/packages/opencode-plugin/README.md
@@ -21,6 +21,13 @@ Manual config also works. Add the package name to your OpenCode config:
 
 OpenCode installs npm plugins automatically with Bun at startup.
 
+## Exports
+
+`CodememPlugin` is the canonical named export and the package default export.
+`OpencodeMemPlugin` remains available as a deprecated, reference-identical alias
+for compatibility with integrations created before the Codemem rename. No removal
+version is currently scheduled.
+
 ## Documentation
 
 - Repository: https://github.com/kunickiaj/codemem

--- a/packages/opencode-plugin/index.js
+++ b/packages/opencode-plugin/index.js
@@ -1,2 +1,5 @@
-export { OpencodeMemPlugin as default } from "./.opencode/plugins/codemem.js";
-export { OpencodeMemPlugin } from "./.opencode/plugins/codemem.js";
+export {
+	CodememPlugin as default,
+	CodememPlugin,
+	OpencodeMemPlugin,
+} from "./.opencode/plugins/codemem.js";

--- a/packages/opencode-plugin/scripts/packed-artifact-smoke.mjs
+++ b/packages/opencode-plugin/scripts/packed-artifact-smoke.mjs
@@ -70,7 +70,7 @@ try {
 	run(process.execPath, [
 		"--input-type=module",
 		"-e",
-		"const mod = await import('@codemem/opencode-plugin'); if (typeof mod.default !== 'function') throw new Error('default export is not a function'); if (typeof mod.OpencodeMemPlugin !== 'function') throw new Error('named export is not a function');",
+		"const mod = await import('@codemem/opencode-plugin'); if (typeof mod.default !== 'function') throw new Error('default export is not a function'); if (typeof mod.CodememPlugin !== 'function') throw new Error('canonical named export is not a function'); if (mod.default !== mod.CodememPlugin) throw new Error('default export is not canonical'); if (mod.OpencodeMemPlugin !== mod.CodememPlugin) throw new Error('legacy export is not a compatibility alias');",
 	], installDir);
 } finally {
 	rmSync(tempDir, { recursive: true, force: true });

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -70,7 +70,7 @@ export default defineConfig(({ command, mode }) => {
 					emptyOutDir: false,
 					lib: {
 						entry: resolve(__dirname, "src/app.ts"),
-						name: "OpencodeMemViewer",
+						name: "CodememViewer",
 						formats: ["iife"],
 						fileName: () => "app.js",
 					},


### PR DESCRIPTION
## Description

Make `CodememPlugin` the canonical named and default export of `@codemem/opencode-plugin` while preserving `OpencodeMemPlugin` as a deprecated, reference-identical compatibility alias. Update the CLI wrapper, packed artifact contract, package documentation, and internal UI bundle name without touching intentional `opencode-mem` migration paths.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm run tsc`
- `pnpm run lint`
- focused plugin tests: 74 passed
- `pnpm --filter @codemem/opencode-plugin test:packed-artifact`
- `pnpm --filter @codemem/ui build`
- `git diff --check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced