### PR TITLE
fix(eval): harden prompt-path subprocess accounting

### DIFF
--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -102,22 +102,28 @@ pnpm exec tsx --conditions source scripts/eval/prompt-path.ts --repetitions 1
 ```
 
 The JSON report contains aggregate median/p95 latency, sorted unlabelled timing
-samples, failure counts by class, and started pack/ledger subprocess counts. The
-median averages the middle pair and p95 uses nearest rank. The harness never
-emits fixture text, prompts, memory IDs, database paths, or per-query results.
+samples, failure counts by class, and started pack, ledger, other, and failed
+subprocess counts. The median averages the middle pair and p95 uses nearest rank.
+The harness never emits fixture text, prompts, memory IDs, database paths, or
+per-query results.
 
-This source-tree benchmark intentionally includes the `pnpm exec tsx` startup
-used by both direct CLI and fallback paths. It validates the benefit of avoiding
-development CLI process startup; its absolute latency and improvement ratio do
-not represent an installed built CLI. The small fixture emphasizes startup and
-transport cost rather than retrieval cost at realistic corpus size.
+This source-tree benchmark intentionally includes an instrumentation shim process
+plus the `pnpm exec tsx` startup used by both direct CLI and fallback paths. The
+shim records subprocess starts and exits; its overhead is part of those timings.
+The comparison validates the benefit of avoiding development CLI process startup,
+but its absolute latency and improvement ratio do not represent an installed built
+CLI. The small fixture emphasizes startup and transport cost rather than retrieval
+cost at realistic corpus size.
 
 The release gate requires a lower healthy-viewer median, a healthy-viewer p95 no
 higher than direct CLI, zero healthy pack/ledger subprocesses, and no failed
-repetitions. Any other healthy-path CLI command also invalidates the run. If p95
-regresses, repeat the complete 30-run comparison once; a second regression fails
-the gate. Fallback latency excludes asynchronous ledger settlement and is
-reported separately rather than gating the performance claim.
+repetitions. The zero-subprocess check includes a bounded two-second
+post-measurement observation window; work that starts or completes in that window
+invalidates the run without affecting measured latency. Any other healthy-path CLI
+command also invalidates the run. If p95 regresses, repeat the complete 30-run
+comparison once; a second regression fails the gate. Fallback latency excludes
+asynchronous ledger settlement and is reported separately rather than gating the
+performance claim.
 
 Validate harness changes explicitly; this tooling remains outside the product
 test command and root CLI scripts:

--- a/scripts/eval/prompt-path-lib.test.ts
+++ b/scripts/eval/prompt-path-lib.test.ts
@@ -7,6 +7,7 @@ import {
 	nearestRank,
 	parseSubprocessLog,
 	PromptPathBenchmarkError,
+	subprocessActivitySettled,
 	summarizeTimings,
 	type GatePath,
 } from "./prompt-path-lib.js";
@@ -58,11 +59,17 @@ describe("prompt-path benchmark summaries", () => {
 	});
 
 	it("counts subprocess starts so in-flight work cannot pass the zero-subprocess gate", () => {
-		assert.deepEqual(parseSubprocessLog("start pack\nstart ledger\nend pack 0\nend ledger 1\n"), {
+		const complete = parseSubprocessLog("start pack\nstart ledger\nend pack 0\nend ledger 1\n");
+		const inFlight = parseSubprocessLog("start pack\n");
+
+		assert.deepEqual(complete, {
 			counts: { pack: 1, ledger: 1, other: 0, failed: 1 },
 			started: 2,
 			ended: 2,
 		});
+		assert.equal(subprocessActivitySettled(complete), true);
+		assert.equal(subprocessActivitySettled(inFlight), false);
+		assert.equal(subprocessActivitySettled({ started: 0, ended: 0 }), true);
 	});
 
 	it("passes only an eligible 30-run improvement with exact subprocess contracts", () => {

--- a/scripts/eval/prompt-path-lib.ts
+++ b/scripts/eval/prompt-path-lib.ts
@@ -32,6 +32,12 @@ export interface SubprocessLogSummary {
 	ended: number;
 }
 
+export function subprocessActivitySettled(
+	activity: Pick<SubprocessLogSummary, "started" | "ended">,
+): boolean {
+	return activity.started === activity.ended;
+}
+
 export interface GatePath {
 	attempted: number;
 	succeeded: number;

--- a/scripts/eval/prompt-path.ts
+++ b/scripts/eval/prompt-path.ts
@@ -17,6 +17,7 @@ import {
 	parseSubprocessLog,
 	PromptPathBenchmarkError,
 	RELEASE_REPETITIONS,
+	subprocessActivitySettled,
 	summarizeTimings,
 	type SubprocessCounts,
 	type TimingSummary,
@@ -27,6 +28,8 @@ const PROJECT = "codemem-benchmark";
 const CLI_TIMEOUT_MS = 120_000;
 const VIEWER_START_TIMEOUT_MS = 30_000;
 const LEDGER_SETTLE_TIMEOUT_MS = 30_000;
+const STARTUP_SETTLE_TIMEOUT_MS = 30_000;
+const HEALTHY_POST_MEASURE_OBSERVE_MS = 2_000;
 const POLL_INTERVAL_MS = 25;
 const ownedChildren = new Set<ChildProcess>();
 
@@ -195,16 +198,28 @@ async function waitFor(
 }
 
 async function settlePluginStartupChecks(counterPath: string): Promise<void> {
-	// The plugin schedules compatibility verification at 1.5s. Let it start,
-	// then require every observed child to finish before resetting the counter.
-	await new Promise((resolveWait) => setTimeout(resolveWait, 2_000));
+	// Plugin initialization schedules verifyCliCompatibility, whose version CLI
+	// invocation is recorded as `other`; observe that causal event before reset.
 	await waitFor(
 		() => {
-			const activity = readSubprocessActivity(counterPath);
-			return activity.started === activity.ended;
+			const counts = readSubprocessCounts(counterPath);
+			return counts.other >= 1 && subprocessActivitySettled(readSubprocessActivity(counterPath));
 		},
+		STARTUP_SETTLE_TIMEOUT_MS,
+		"plugin compatibility version subprocess did not start and settle",
+	);
+}
+
+async function observeHealthySubprocessQuiescence(counterPath: string): Promise<void> {
+	// This bounded post-measurement window catches delayed work without adding it
+	// to measured latency. Two seconds is a defense-in-depth heuristic; the healthy
+	// path has no known per-request delayed spawn source. The aggregate count below
+	// still fails on completed work.
+	await new Promise((resolveWait) => setTimeout(resolveWait, HEALTHY_POST_MEASURE_OBSERVE_MS));
+	await waitFor(
+		() => subprocessActivitySettled(readSubprocessActivity(counterPath)),
 		CLI_TIMEOUT_MS,
-		"plugin startup checks did not settle",
+		"healthy path subprocesses did not settle",
 	);
 }
 
@@ -594,6 +609,7 @@ async function runBenchmark(repetitions: number): Promise<BenchmarkReport> {
 				},
 			},
 		);
+		await observeHealthySubprocessQuiescence(paths.counter);
 		const healthy = withSubprocesses(healthySummary, readSubprocessCounts(paths.counter));
 
 		const fallbackPort = await reservePort();


### PR DESCRIPTION
## Description

Hardens the development-only prompt-path benchmark after final review of #1456.

- Waits for the plugin compatibility subprocess to be observed and settled before resetting startup accounting.
- Adds a bounded two-second post-measurement observation window before the healthy-path aggregate subprocess count.
- Keeps observation and reconciliation outside measured latency.
- Documents the instrumentation shim overhead and bounded zero-subprocess observation semantics.
- Tests complete, in-flight, and zero-activity reconciliation states.

Latest 30-run result:
- Direct CLI: 820.701 ms median / 851.434 ms p95
- Healthy viewer plugin: 9.943 ms median / 10.960 ms p95, zero subprocesses
- Viewer-unavailable fallback: 828.019 ms median / 851.289 ms p95
- 90/90 measured repetitions succeeded; release gate passed

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation:
- `pnpm run eval:pack:typecheck`
- `node --import tsx --test scripts/eval/prompt-path-lib.test.ts`
- `pnpm exec tsx --conditions source scripts/eval/prompt-path.ts --repetitions 1`
- `pnpm exec tsx --conditions source scripts/eval/prompt-path.ts`
- `git diff --check`
- CodeReviewer: GO
- Gordon review: GO, no P0/P1 findings

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced