### PR TITLE
fix(hooks): constrain transcript reads

### DIFF
--- a/docs/plans/2026-08-15-adapter-interoperability-and-prompt-transport-design.md
+++ b/docs/plans/2026-08-15-adapter-interoperability-and-prompt-transport-design.md
@@ -1,0 +1,502 @@
+# Adapter interoperability and prompt transport parity
+
+**Status:** Approved after architecture review
+
+**Date:** 2026-08-15
+
+**Decision:** Use normalized `POST /api/raw-events` as the only canonical event
+ingress. Keep source-specific normalization at the adapter edge, generated from
+one versioned core implementation. Do not add `/api/hooks` or `/api/events`.
+
+## Problem
+
+OpenCode now retrieves prompt packs and records prompt-pack ledger transitions
+through the long-lived Viewer without starting `codemem pack` or
+`prompt-pack-ledger` subprocesses on the healthy path. Claude Code and Codex do
+not have equivalent behavior. Their prompt hooks start `codemem` or `npx`
+processes, and their inject commands build from SQLite before trying Viewer HTTP.
+
+Event ingestion is also asymmetric:
+
+- OpenCode normalizes SDK events and posts them to `POST /api/raw-events`.
+- Claude posts native hook payloads to `POST /api/claude-hooks`.
+- Codex posts native hook payloads to `POST /api/codex-hooks`.
+
+The two named hook routes repeat parsing, persistence, session metadata, sweeper
+nudge, and response logic. More adapters would otherwise add more named routes
+and more opportunities for behavior drift.
+
+`POST /api/raw-events` is not adapter-neutral yet. Its batch store path currently
+defaults stream identity and sweeper routing to OpenCode and does not honor a
+request source. Source-aware canonical ingestion is therefore a prerequisite,
+not an already-shipped capability.
+
+The hooks cannot be treated as identical inputs. Claude and Codex expose
+different lifecycle events and metadata, and OpenCode emits an SDK event stream
+rather than command-hook payloads. The design must unify transport and
+persistence after normalization while retaining source-specific normalization at
+the boundary.
+
+## Goals
+
+- Give Claude and Codex direct Viewer-backed prompt pack and ledger paths.
+- Start zero `codemem` or `npx` child processes on healthy Claude, Codex, and
+  OpenCode prompt paths. Claude and Codex still start the hook process required by
+  their host runtimes.
+- Define one adapter-neutral normalized event contract and one persistence path.
+- Preserve both stable event identity and event-sequence semantics across HTTP,
+  direct fallback, spool replay, and version skew.
+- Preserve source-specific hook information, event identity, and output formats.
+- Replace per-agent HTTP routes with resource-oriented contracts.
+- Keep version-skew failures bounded. Never read from a database or runtime
+  identity-mismatched Viewer; classified fallback may use the intended local
+  configuration instead.
+- Retain local CLI/database or spool fallback for retryable Viewer failures.
+- Separate runtime transport changes from human-facing CLI command-tree cleanup.
+
+## Non-goals
+
+- Making native Claude, Codex, and OpenCode event payloads identical.
+- Removing the Claude or Codex normalizers.
+- Combining event ingestion, pack retrieval, and delivery accounting into one
+  endpoint.
+- Changing memory ranking, pack content, token budgets, or compression defaults.
+- Changing hook availability or lifecycle semantics supplied by host products.
+- Removing compatibility CLI commands in the transport-parity change.
+- Claiming literally zero processes for command-hook hosts.
+- Allowing HTTP request data to expand the Viewer's local file-read authority.
+
+## Current boundaries
+
+### Source-specific inputs
+
+Claude currently supports `SessionStart`, `UserPromptSubmit`, `PreToolUse`,
+`PostToolUse`, `PostToolUseFailure`, `Stop`, and `SessionEnd`. Its mapper can
+preserve permission mode, tool-use identity, failed-tool detail, transcript
+fallback, and assistant usage.
+
+Codex currently supports `SessionStart`, `UserPromptSubmit`, `PreToolUse`,
+`PostToolUse`, and `Stop`. Its mapper additionally handles target metadata,
+turn identity, matcher aliases, model/subagent fields, generated event nonces,
+and different Stop-event deduplication. It does not currently capture Claude's
+failed-tool or session-end equivalents, and it intentionally omits Stop usage.
+
+OpenCode receives structured SDK events in-process. It supplies its own event
+sequence, monotonic and wall-clock timing, working-set state, and plugin lifecycle
+metadata before posting normalized raw events.
+
+### Shared normalized layer
+
+The existing `AdapterEvent v1` shape already establishes the useful boundary:
+
+- schema version;
+- source provenance;
+- source session identity;
+- stable event identity and normalized event type;
+- timestamp and ordering confidence;
+- working directory;
+- normalized payload;
+- source-specific metadata, including preserved unknown hook fields.
+
+Normalization must remain loss-aware. Fields that do not map to common event
+semantics remain under source metadata instead of being discarded or promoted
+into unrelated common fields.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    CS[Canonical core normalizers] -. release build .-> CN[Bundled Claude normalizer]
+    CS -. release build .-> XN[Bundled Codex normalizer]
+    CH[Claude command hook] --> CN
+    CX[Codex command hook] --> XN
+    OC[OpenCode SDK events] --> ON[OpenCode normalizer]
+
+    CN --> AE[AdapterEvent v1]
+    XN --> AE
+    ON --> AE
+
+    AE --> RI[Shared raw-event ingestion service]
+    RI --> DB[(SQLite raw-event queue)]
+    RI --> SW[Raw-event sweeper]
+
+    CH --> PT[Prompt transport client]
+    CX --> PT
+    OC --> PT
+    PT --> PACK[POST /api/pack]
+    PT --> LEDGER[POST /api/prompt-pack-ledger]
+    PT -. retryable failure .-> CLI[Existing CLI fallback]
+```
+
+The architecture has three layers:
+
+1. **Source adapters** understand native lifecycle and payload semantics.
+2. **Normalized services** own event persistence, retrieval, and ledger behavior.
+3. **Compatibility plumbing** handles temporary version skew without becoming a
+   second implementation.
+
+Dependency direction is strict:
+
+```text
+plugins/*  -> generated adapter artifact -> normalized Viewer contracts
+viewer-server routes -> core ingestion/retrieval/ledger services
+CLI fallback -> core ingestion/retrieval services
+```
+
+Core must not import Viewer, CLI, or plugin modules. Viewer routes and CLI
+commands are peer clients of core services.
+
+## Ingestion API boundary
+
+Architecture review considered three options.
+
+### Chosen: normalized raw-event ingress only
+
+```text
+POST /api/raw-events  AdapterEvent/raw-event envelope
+```
+
+Claude and Codex plugin bundles normalize before sending the request. OpenCode
+continues normalizing its SDK event stream in-process.
+
+Advantages:
+
+- one canonical event-ingress endpoint;
+- Viewer has no native hook payload knowledge;
+- adapters fully own their source protocol and trusted transcript access;
+- an HTTP body cannot direct the long-lived Viewer to resolve native transcript
+  paths or gain file-read capability.
+
+Costs:
+
+- the current mappers include transcript handling, event identity, unknown-field
+  preservation, project inference, and source-specific deduplication;
+- standalone marketplace bundles need generated mapper artifacts;
+- event identity must be frozen and versioned so cached plugin artifacts remain
+  safe during skew.
+
+The authored source remains in core. Release tooling produces dependency-free,
+single-file ESM artifacts for each independently distributed plugin. Golden
+fixtures must prove that core, generated artifacts, and CLI fallback produce
+byte-identical normalized envelopes and event IDs.
+
+### Rejected: separate native-hook ingress
+
+```text
+POST /api/hooks       { source, payload }
+POST /api/raw-events  AdapterEvent/raw-event envelope
+```
+
+This is a valid anti-corruption-layer pattern in systems where both request
+types cross the same trust boundary. It is rejected here because native hook
+normalization includes transcript path resolution. Performing that work in the
+Viewer would let an unauthenticated loopback HTTP request expand the Viewer's
+file-read authority. The hook process already receives the path from its host and
+is the correct boundary for that access.
+
+### Rejected: one discriminated event endpoint
+
+```text
+POST /api/events
+{ format: "native-hook", source, payload }
+{ format: "adapter-event-v1", event }
+```
+
+Advantages:
+
+- one URL for all event ingress;
+- preserves server-side native normalizers.
+
+Costs:
+
+- one endpoint owns two abstraction levels and two validation models;
+- retry, diagnostics, and compatibility behavior branch on request format;
+- the apparently simple URL hides rather than removes architectural distinction.
+
+It also preserves server-side native normalization and its trust problem while
+making validation, diagnostics, and retry behavior branch on a format field.
+
+## Canonical event ingestion service
+
+Extract route-independent ingestion functions that accept one normalized event
+or batch plus session metadata. They own:
+
+- body-independent schema validation;
+- source and stream identity validation;
+- private-field stripping;
+- stable idempotent insertion;
+- event sequence assignment;
+- raw-event session metadata updates;
+- per-source sweeper nudge;
+- `{ inserted, skipped, received }` outcome shaping.
+
+Routes parse transport input and call this service. Direct CLI fallback also uses
+the same core ingestion operation rather than maintaining source-specific SQL.
+
+The source-aware batch method replaces the current OpenCode-defaulting batch
+path. `POST /api/raw-events` accepts and honors a validated `source`; requests
+without it default to `opencode` during compatibility. Source tokens are trimmed,
+case-normalized, length-bounded provenance identifiers. They do not grant trust.
+
+The canonical service allocates first-event sequence `0` for every source and
+preserves the same sequence rules for HTTP, direct fallback, and spool replay.
+Source-specific direct SQL is removed; existing Claude and Codex fallback SQL has
+not remained uniform on this invariant. Codex's `-1` default is the reference;
+Claude's current `0` default is repaired by moving both paths to the service.
+
+`source` is provenance, not an authorization principal. Validate its syntax and
+length, but do not grant access or change trust based on its value.
+
+## Frozen event identity
+
+Event identity becomes an explicit versioned contract rather than an incidental
+property of whichever mapper version runs:
+
+```text
+event_id = f(event_id_algo, source, session, hook event, timestamp seed,
+             source discriminators, canonical payload hash)
+```
+
+Add `meta.event_id_algo` to the normalized event contract, initially `claude/1`
+and `codex/1`. Keeping the discriminator under `meta` preserves compatibility
+with the closed AdapterEvent v1 top-level schema. Changing canonicalization,
+discriminators, or hashing requires a new algorithm version. Golden fixtures
+cover timestamp-less retries, transcript fallback, tool calls/results, unknown
+fields, and generated nonces. OpenCode is explicitly exempt because it assigns a
+stable random event ID at event creation rather than deriving one from payload.
+
+## Prompt retrieval and ledger flow
+
+Prompt retrieval remains adapter-neutral:
+
+```text
+POST /api/pack
+POST /api/prompt-pack-ledger
+```
+
+Each adapter retains source-specific query construction and output formatting:
+
+- Claude includes its first/last prompt and working-set state where available and
+  returns Claude's `hookSpecificOutput.additionalContext` contract.
+- Codex keeps its lean prompt-plus-project query until it gains equivalent session
+  state and returns Codex's `additionalContext` contract.
+- OpenCode retains its existing message and compaction injection surfaces.
+
+On a healthy path:
+
+1. The hook adapter creates query, filters, render options, and attempt metadata.
+2. It validates Viewer profile/database/runtime identity.
+3. It sends `POST /api/pack` with attempt metadata. Viewer builds the pack and
+   records retrieval artifacts best-effort.
+4. The adapter formats and writes the host-specific context response.
+5. It sends `POST /api/prompt-pack-ledger` with delivered, empty, skipped,
+   cached, or failed status as appropriate.
+
+Pack delivery must not wait indefinitely for ledger completion. Ledger recording
+is bounded to at most 500 ms, never retried inline, and never delays hook output.
+Failure leaves delivery truth `unknown`; it must not be rewritten as handed off.
+
+Claude and Codex migrate from unauthenticated legacy `GET /api/pack` to the
+identity-gated `POST /api/pack`. Their transport order becomes Viewer HTTP first,
+then classified local CLI fallback. The legacy GET route is deprecated after all
+shipped callers migrate.
+
+## Fallback classification
+
+Local fallback is allowed for:
+
+- connection refusal or reset;
+- bounded timeout;
+- Viewer unavailable during restart;
+- a Viewer profile endpoint that is absent or reports an unsupported
+  `protocol_version`;
+- malformed transport responses that indicate protocol incompatibility rather
+  than a valid request rejection;
+- Viewer database or runtime identity mismatch, because fallback targets the
+  adapter's intended local configuration instead of reading from the mismatched
+  Viewer. The client must not retry against that same Viewer in the request path.
+
+Fallback is not allowed for:
+
+- invalid adapter requests;
+- `viewer_contract_unsupported` returned after the profile reported a supported
+  protocol version;
+- explicit policy disablement;
+- authorization or trust failures if local transport later gains authentication.
+
+The existing CLI inject path remains the compatibility fallback initially. It
+must produce the same source query and host output contract. Direct event fallback
+uses the normalized ingestion service or durable spool and must preserve event
+identity.
+
+All adapters use one classifier. Every request-contract change that an older
+Viewer would reject increments the profile `protocol_version`. The profile also
+advertises `min_supported_protocol_version`, and clients accept an explicit
+supported range rather than requiring literal equality. A non-overlapping range
+is version skew and may fall back; `viewer_contract_unsupported` after a
+compatible profile match is a client/contract defect and fails closed. This
+replaces OpenCode's current behavior of requiring protocol `1` and treating every
+such 409 as retryable, avoiding needless subprocess fallback when a newer Viewer
+still supports an older client.
+
+## Compatibility and rollout
+
+Plugin, CLI, and Viewer versions can skew because marketplace caches, local PATH
+installs, npm packages, and long-running Viewer processes do not update
+atomically.
+
+During the compatibility window, expected to span at least two stable releases:
+
+- `/api/claude-hooks` retains the hardened legacy normalizer, then delegates its
+  normalized output to the canonical ingestion service;
+- `/api/codex-hooks` does the same for Codex;
+- aliases contain no persistence, sequence, or session-update logic of their own;
+- tests prove old request shapes produce the same normalized event and ingestion
+  result as the canonical route.
+
+New adapters stop calling named routes in the first parity release. Remove aliases
+only when repository and packaged-plugin searches show no remaining callers and
+the stale-client fallback matrix passes. Evidence is the binding removal gate;
+elapsed releases alone are insufficient.
+
+New prompt transports must probe the Viewer profile/contract and fall back safely
+when paired with a pre-parity Viewer. A newer Viewer must continue accepting the
+old hook clients during the compatibility window.
+
+## CLI command-tree cleanup
+
+Transport parity and CLI cleanup should form separate review units.
+
+After adapters call HTTP directly on healthy paths:
+
+- classify `claude-hook-*`, `codex-hook-*`, `enqueue-raw-event`,
+  `prompt-pack-ledger`, and similar commands as adapter plumbing;
+- remove plumbing commands from shell completion and human-oriented root help
+  where compatibility permits;
+- retain stable stdin/stdout and exit-code contracts while installed plugins can
+  still call them;
+- consolidate duplicated wrappers around shared transport/fallback functions;
+- follow the documented deprecation window before deleting command aliases;
+- keep command-tree registration, visible help, and completion parity tested.
+
+The transport change must not be delayed on unrelated human-facing command
+renames.
+
+## Security and privacy
+
+- Bind all adapter HTTP transport to configured local Viewer endpoints; do not
+  add external egress.
+- Preserve body-size limits and reject non-object native payloads.
+- Strip private fields before persistence regardless of ingress route.
+- Do not log prompts, pack text, raw hook bodies, database paths, or identity
+  payloads in normal diagnostics.
+- Validate database and runtime identity before Viewer-backed retrieval.
+- Treat source as untrusted provenance data.
+- Move transcript access to generated hook-edge normalizers before canonical HTTP
+  submission.
+- Generated edge normalizers may read the exact `transcript_path` supplied by the
+  host hook, but read at most the final 16 MiB of a transcript and align parsing to
+  the next complete JSONL record.
+- Before retaining legacy named routes, give the core transcript reader an
+  explicit allowlist. Absolute Claude paths must resolve beneath
+  `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects`; absolute Codex paths must resolve
+  beneath `${CODEX_HOME:-$HOME/.codex}/sessions`. Legacy HTTP routes reject
+  relative paths because request-controlled `cwd` must not become an implicit
+  filesystem root. Trusted hook-edge callers may resolve a relative path beneath
+  the host's real `cwd`. Resolve symlinks before containment checks, read at most
+  the final 16 MiB, and reject every other path. Mapper fixtures pass their
+  temporary directory as an explicit test allowlist so existing transcript
+  fallback behavior remains covered.
+- Slice 1 verifies those default roots against current Claude and Codex host
+  behavior before enabling the allowlist. A host relocation produces a benign
+  skip rather than a hook failure; legacy HTTP routes return only a fixed,
+  path-free `skip_reason`. Configured approved roots can bridge host version skew
+  without permitting arbitrary request paths.
+- Verification on 2026-08-15 found that Claude Code 2.1.207 and Codex CLI 0.147.0
+  emit absolute `transcript_path` and `cwd` values beneath their configured roots;
+  both custom home variables relocate transcript persistence as expected.
+- Loopback is the current transport boundary, not authentication. Do not describe
+  loopback reachability as authorization.
+
+## Testing and evidence
+
+### Contract tests
+
+- Claude, Codex, and OpenCode fixtures normalize to AdapterEvent v1 without losing
+  source-only metadata.
+- Canonical and compatibility hook routes produce identical envelopes and
+  insertion outcomes.
+- HTTP and direct/spool fallback preserve event IDs and deduplicate retries.
+- HTTP, direct, and spool paths allocate identical event sequences.
+- Legacy native-hook and canonical raw-event validation errors are deterministic
+  and bounded.
+
+### Prompt transport tests
+
+- Healthy Claude and Codex pack and ledger paths start no `codemem` or `npx`
+  children.
+- Delivered, empty, skipped, cached, and failed transitions reach the ledger.
+- Retryable Viewer failures invoke exactly one classified fallback path.
+- invalid or unsupported requests do not fall back; database/runtime identity
+  mismatch triggers local fallback without retrying the mismatched Viewer.
+- Host-specific `additionalContext` output remains byte-compatible where required.
+- Claude's healthy prompt hook runs as Node/ESM rather than invoking `curl`,
+  `codemem`, or `npx` from shell.
+
+### Packaging and performance evidence
+
+- Claude and Codex packaged-plugin smoke tests run without a globally installed
+  CLI while Viewer is healthy.
+- A stale-client/new-Viewer and new-client/stale-Viewer matrix validates the
+  compatibility window.
+- A 30-run development benchmark reports median and p95 hook latency plus child
+  process counts for direct CLI, healthy Viewer, and classified fallback paths.
+- No benchmark artifacts contain prompts, memory text, IDs, or local paths.
+
+## Delivery slices
+
+1. Verify current host transcript roots, then harden path containment and size
+   limits on existing server-side native-hook normalization before expanding
+   transport work.
+2. Extract a source-aware canonical ingestion service, repair sequence parity,
+   and move existing raw-event routes and CLI fallbacks onto it without changing
+   the HTTP request schema.
+3. Freeze versioned event identity and add cross-artifact golden fixtures.
+4. Extend the `/api/raw-events` HTTP request schema to honor source, add its
+   `opencode` compatibility default once, and reduce named hook routes to
+   compatibility adapters over the canonical service.
+5. Generate standalone Claude and Codex mapper artifacts; convert Claude's prompt
+   hook to Node/ESM; cut new plugins over to normalized `/api/raw-events`.
+6. Add Claude direct profile/pack/ledger transport with classified CLI fallback.
+7. Add Codex direct profile/pack/ledger transport with classified CLI fallback.
+8. Run packaged skew/parity/performance evidence and update plugin documentation.
+9. Perform the separate CLI plumbing/help/completion cleanup.
+10. Remove named hook aliases and legacy `GET /api/pack` only after the
+    compatibility evidence passes.
+
+## Architecture review disposition
+
+Architecture review returned **revise** on the initial `/api/hooks` proposal and
+established these decisions:
+
+- `/api/raw-events` becomes the sole canonical normalized ingress after it is
+  made source-aware.
+- Native hook normalization runs at the trusted hook edge using generated
+  artifacts from one core source.
+- Event identity and event sequence are both cross-transport invariants.
+- CLI fallback calls the route-independent core ingestion service; duplicated
+  direct SQL is not an acceptable durability boundary.
+- Pack retrieval and delivery ledger remain separate. Only the adapter can report
+  whether host handoff occurred, and ledger failure must not block injection.
+- Named hook routes remain temporary compatibility adapters for two releases and
+  until stale-client evidence permits removal.
+- CLI cleanup remains a separate review unit.
+
+## Related documents
+
+- `docs/plans/2026-03-02-multi-agent-adapter-architecture-design.md`
+- `docs/plans/adapter-event-v1.schema.json`
+- `docs/plans/2026-05-28-codex-first-class-integration.md`
+- `docs/plans/2026-08-10-release-0.41-fast-focused-recall-design.md`
+- `docs/plans/2026-08-11-cli-operational-status-and-command-tree-consolidation-design.md`
+- `docs/cli-design-conventions.md`

--- a/docs/plans/2026-08-15-adapter-interoperability-and-prompt-transport-implementation.md
+++ b/docs/plans/2026-08-15-adapter-interoperability-and-prompt-transport-implementation.md
@@ -1,0 +1,531 @@
+# Adapter interoperability and prompt transport parity: implementation plan
+
+**Design:** [Adapter interoperability and prompt transport parity](./2026-08-15-adapter-interoperability-and-prompt-transport-design.md)
+**Tracking:** `codemem-2b06`
+**Status:** Approved for implementation
+**Date:** 2026-08-15
+
+## Outcome
+
+Claude Code, Codex, and OpenCode will share:
+
+- one source-aware normalized event ingress at `POST /api/raw-events`;
+- one route-independent core ingestion service for HTTP, direct fallback, and
+  spool replay;
+- one prompt-pack profile, retrieval, fallback-classification, and delivery-ledger
+  contract;
+- source-specific edge normalizers and host output formats;
+- zero `codemem` or `npx` children on healthy prompt paths.
+
+The existing `/api/claude-hooks` and `/api/codex-hooks` routes remain temporary
+compatibility adapters. Human-facing CLI cleanup is a separate workstream and is
+not allowed to destabilize transport parity.
+
+## Non-negotiable contracts
+
+1. HTTP request data must not expand the Viewer's filesystem authority.
+2. Event identity and first-event sequence `0` must match across HTTP, direct
+   fallback, and spool replay.
+3. Database/runtime identity mismatch must never read from the mismatched Viewer;
+   classified local fallback may use the intended local configuration.
+4. A compatible profile followed by `viewer_contract_unsupported` fails closed.
+   Missing or non-overlapping protocol support may fall back.
+5. Pack retrieval and delivery reporting remain separate. Ledger failure cannot
+   delay host output or turn an unknown delivery into a claimed handoff.
+6. New plugin artifacts must work without a globally installed CLI while the
+   Viewer is healthy.
+7. Existing host-specific output bytes remain compatible.
+
+## Proposed Graphite stack
+
+```text
+main
+  <- PR 1: harden bounded transcript reads
+  <- PR 2: add canonical raw-event ingestion service
+  <- PR 3: make normalized HTTP ingress source-aware
+  <- PR 4: generate and ship edge normalizers
+  <- PR 5: unify prompt transport profile and classification
+  <- PR 6: move Claude prompt transport to direct Viewer HTTP
+  <- PR 7: move Codex prompt transport to direct Viewer HTTP
+  <- PR 8: prove packaged parity and update documentation
+```
+
+Each PR must be independently testable. Do not combine CLI command-tree cleanup
+with this stack.
+
+## PR 1: Harden bounded transcript reads
+
+### Purpose
+
+Remove arbitrary Viewer-side file reads before retaining legacy native-hook
+routes, without regressing Stop-event transcript capture.
+
+### Files
+
+- Add `packages/core/src/hook-transcript.ts`.
+- Update `packages/core/src/api-types.ts`.
+- Update `packages/core/src/claude-hooks.ts`.
+- Update `packages/core/src/codex-hooks.ts`.
+- Update `packages/core/src/claude-hooks.test.ts`.
+- Update `packages/core/src/codex-hooks.test.ts`.
+- Update `packages/viewer-server/src/routes/raw-events.ts`.
+- Update `packages/viewer-server/src/index.test.ts`.
+
+### Steps
+
+1. Before changing code, validate current host behavior with synthetic sessions:
+   - Claude default and `CLAUDE_CONFIG_DIR` transcript locations;
+   - Codex default and `CODEX_HOME` session locations;
+   - whether each host supplies absolute or relative `transcript_path` values.
+   Record only generic conclusions in the repository; no local paths or session
+   content.
+   Verified on 2026-08-15: Claude Code 2.1.207 and Codex CLI 0.147.0 both emit
+   absolute `transcript_path` and `cwd` values beneath their configured roots;
+   `CLAUDE_CONFIG_DIR` and `CODEX_HOME` relocate transcript persistence.
+2. Extract a transcript reader with explicit dependencies:
+   - approved realpath roots supplied by the caller;
+   - optional real `cwd` for relative paths from trusted hook-edge callers;
+   - a 16 MiB tail-read limit;
+   - JSONL alignment to the next complete record;
+   - symlink resolution before containment checks;
+   - benign failure semantics and fixed, path-free legacy HTTP skip reasons.
+3. Edge callers may pass the exact host-provided path as trusted input. Legacy
+   HTTP routes accept only absolute paths beneath verified default/configured
+   roots; they reject relative paths so request-controlled `cwd` cannot become a
+   filesystem root.
+4. Preserve assistant text and usage extraction. A rejected transcript produces a
+   benign skip, never a hook failure.
+
+### Tests
+
+- Absolute paths under each approved root succeed.
+- Relative paths under real `cwd` succeed only for trusted edge callers and are
+  rejected by restricted legacy HTTP callers.
+- Traversal, sibling-prefix, symlink escape, non-file, missing file, and
+  oversized-line cases fail safely.
+- A transcript larger than 16 MiB still finds a final complete assistant record.
+- Existing Claude and Codex transcript fixtures pass with explicit temporary test
+  roots.
+
+```text
+pnpm exec vitest run packages/core/src/claude-hooks.test.ts packages/core/src/codex-hooks.test.ts
+pnpm exec vitest run packages/viewer-server/src/index.test.ts
+```
+
+### Rollback
+
+The extracted reader can be reverted without changing event or HTTP schemas. Do
+not relax containment to recover capture; add a verified configured root instead.
+
+## PR 2: Add canonical raw-event ingestion service
+
+### Purpose
+
+Put validation, sanitization, deduplication, sequencing, session metadata, and
+ingestion outcomes behind one core API.
+
+### Files
+
+- Add `packages/core/src/raw-event-ingest.ts`.
+- Add `packages/core/src/raw-event-ingest.test.ts`.
+- Update `packages/core/src/store.ts` only where a narrower store primitive is
+  required.
+- Update `packages/core/src/index.ts` exports.
+- Update `packages/cli/src/commands/enqueue-raw-event.ts`.
+- Update `packages/cli/src/commands/claude-hook-ingest.ts`.
+- Update `packages/cli/src/commands/codex-hook-ingest.ts`.
+- Update their existing test files.
+
+### Steps
+
+1. Define a source-aware normalized request type and a single
+   `{ inserted, skipped, received }` result.
+2. Validate source syntax and length as provenance only; source grants no trust.
+3. Normalize aliases for stream/session identity and reject conflicting values.
+4. Strip private fields before persistence.
+5. Deduplicate by `(source, stream_id, event_id)`.
+6. Allocate a fresh stream's first sequence as `0`; keep supplied valid sequence
+   semantics where the normalized contract permits them.
+7. Update session metadata and return the session/source pairs that need a sweeper
+   nudge without importing Viewer concerns into core.
+8. Replace the Claude `COALESCE(MAX(event_seq), 0) + 1`, Codex direct SQL, and
+   `enqueue-raw-event`'s OpenCode-only writes with calls to the service.
+
+### Tests
+
+- HTTP-equivalent, direct, and replayed requests produce identical rows.
+- Duplicate retries report `skipped` without allocating another sequence.
+- Claude and Codex first events both receive sequence `0`.
+- Conflicting session aliases and malformed source/event fields fail before writes.
+- Private fields never reach persisted payload JSON.
+
+```text
+pnpm exec vitest run packages/core/src/raw-event-ingest.test.ts
+pnpm exec vitest run packages/cli/src/commands/claude-hook-ingest.test.ts packages/cli/src/commands/codex-hook-ingest.test.ts
+```
+
+### Rollback
+
+Keep store schema unchanged. The old callers can be restored while the service
+remains unused; do not maintain two SQL implementations after cutover.
+
+## PR 3: Make normalized HTTP ingress source-aware
+
+### Purpose
+
+Make `POST /api/raw-events` the canonical source-neutral wire contract and reduce
+named routes to compatibility adapters.
+
+### Files
+
+- Update `packages/viewer-server/src/routes/raw-events.ts`.
+- Update `packages/viewer-server/src/index.test.ts`.
+- Update `docs/plans/adapter-event-v1.schema.json` only for clarified metadata,
+  not a breaking top-level field.
+
+### Steps
+
+1. Parse and validate top-level `source`; default omitted source to `opencode`
+   during compatibility.
+2. Delegate single and batch requests to the core ingestion service.
+3. Nudge the sweeper with the validated source returned by the service.
+4. Keep response shape `{ inserted, skipped, received }`.
+5. Keep `/api/claude-hooks` and `/api/codex-hooks`, but make each route:
+   - parse a bounded native payload;
+   - invoke its hardened legacy normalizer;
+   - pass only normalized output to the canonical service;
+   - contain no persistence, sequence, or metadata SQL.
+
+### Tests
+
+- Omitted source preserves current OpenCode behavior.
+- Claude, Codex, and OpenCode sources remain separate for identical stream IDs.
+- Canonical and named compatibility routes produce identical normalized rows.
+- Mixed-source batches are either explicitly rejected or split according to the
+  final request schema; behavior must be deterministic and documented.
+- Invalid source, body size, and native payload errors are bounded.
+
+```text
+pnpm exec vitest run packages/viewer-server/src/index.test.ts
+pnpm exec vitest run packages/core/src/raw-event-sweeper.test.ts
+```
+
+### Rollback
+
+The `opencode` default preserves old clients. Retain named aliases if generated
+edge artifacts reveal version-skew defects; do not restore duplicated writes.
+
+## PR 4: Generate and ship edge normalizers
+
+### Purpose
+
+Move native hook interpretation and trusted transcript access to standalone
+plugin artifacts while preserving one authored TypeScript implementation.
+
+### Files
+
+- Update `packages/core/src/claude-hooks.ts` and `codex-hooks.ts` as the authored
+  normalizer sources.
+- Update `packages/core/src/claude-hooks.test.ts` and `codex-hooks.test.ts` with
+  frozen golden fixtures.
+- Add `scripts/build-adapter-normalizers.mjs`.
+- Add `scripts/build-adapter-normalizers.test.mjs`.
+- Add generated, dependency-free artifacts under:
+  - `plugins/claude/scripts/codemem-normalizer.mjs`;
+  - `plugins/codex/scripts/codemem-normalizer.mjs`.
+- Replace `plugins/claude/scripts/ingest-hook.sh` with a Node/ESM ingest wrapper.
+- Update `plugins/codex/scripts/ingest-hook.mjs`.
+- Update `plugins/claude/hooks/hooks.json` if script names change.
+- Update `packages/cli/scripts/packed-artifact-smoke.mjs`.
+
+### Steps
+
+1. Freeze `meta.event_id_algo` as `claude/1` and `codex/1`. Keep it under `meta`
+   so AdapterEvent v1's closed top-level schema remains valid.
+2. State and test that OpenCode's client-assigned random event IDs are exempt from
+   derived-ID algorithms.
+3. Bundle each normalizer to one checked-in ESM artifact with Node built-ins only.
+4. Add a drift test that regenerates in a temporary directory and compares bytes
+   with checked-in artifacts.
+5. Make plugin wrappers normalize once, then send that exact envelope to
+   `/api/raw-events`.
+6. On retryable HTTP failure, send the same normalized envelope through
+   `enqueue-raw-event` or spool it. Never remap the native payload during fallback.
+7. Preserve Codex timestamp/nonce generation before normalization.
+
+### Tests
+
+- Core and generated mappers produce byte-identical envelopes for golden Claude
+  and Codex fixtures.
+- Timestamp-less retries, unknown fields, tool failures/results, transcript
+  fallback, and nonce behavior preserve IDs.
+- HTTP, CLI fallback, and spool replay use the same event ID.
+- Generated artifacts import without workspace dependencies.
+
+```text
+pnpm exec vitest run packages/core/src/claude-hooks.test.ts packages/core/src/codex-hooks.test.ts
+node --test scripts/build-adapter-normalizers.test.mjs
+pnpm --filter codemem test:packed-artifact
+```
+
+### Rollback
+
+Old packaged clients continue using named routes. A new plugin can temporarily
+return to a named route, but must keep its normalized fallback artifact and must
+not reintroduce Viewer-side unrestricted transcript reads.
+
+## PR 5: Unify prompt transport profile and classification
+
+### Purpose
+
+Give every adapter one version-skew, identity, request, and retry classifier
+before Claude and Codex adopt direct prompt HTTP.
+
+### Files
+
+- Add `packages/core/src/prompt-transport.ts`.
+- Add `packages/core/src/prompt-transport.test.ts`.
+- Update `packages/core/src/index.ts`.
+- Update `packages/viewer-server/src/routes/pack.ts`.
+- Update `packages/viewer-server/src/index.test.ts`.
+- Update `packages/opencode-plugin/.opencode/plugins/codemem.js`.
+- Update `packages/cli/.opencode/tests/plugin-injection.test.js` and
+  `plugin-injection-failures.test.js`.
+
+### Steps
+
+1. Extend `/api/prompt-pack-profile` with
+   `min_supported_protocol_version` while preserving `protocol_version`.
+2. Define pure helpers for compatible-range checks and terminal versus fallback
+   failure classification.
+3. Require profile/database/runtime identity validation before pack retrieval.
+4. Classify:
+   - absent/non-overlapping profile, timeout, reset, and restart as fallback;
+   - database/runtime mismatch as local fallback without retrying that Viewer;
+   - invalid request, policy/auth failure, and
+     `viewer_contract_unsupported` after a compatible profile as terminal.
+5. Update OpenCode to consume a supported range instead of literal protocol `1`
+   and stop treating every contract 409 as retryable.
+
+### Tests
+
+- Old client/new Viewer and new client/old Viewer profile matrices.
+- Compatible profile plus contract 409 fails closed.
+- Identity mismatch invokes local fallback once and never reads the Viewer pack.
+- Terminal failures do not start a CLI child.
+- Existing OpenCode injection bytes and healthy zero-child behavior remain stable.
+
+```text
+pnpm exec vitest run packages/core/src/prompt-transport.test.ts packages/viewer-server/src/index.test.ts
+pnpm --filter codemem test:plugin
+```
+
+### Rollback
+
+Profile fields are additive. Reverting the OpenCode client leaves the server
+compatible; do not remove the minimum-supported field once Claude/Codex ship.
+
+## PR 6: Move Claude prompt transport to direct Viewer HTTP
+
+### Purpose
+
+Replace Claude's shell/CLI healthy path with a dependency-free Node hook that
+retrieves packs and records delivery directly.
+
+### Files
+
+- Add `plugins/claude/scripts/user-prompt-hook.mjs`.
+- Update `plugins/claude/hooks/hooks.json`.
+- Retire `plugins/claude/scripts/user-prompt-hook.sh` only after packaged tests use
+  the Node entrypoint.
+- Update `packages/cli/src/commands/claude-hook-inject.ts` as compatibility
+  fallback, not the healthy transport.
+- Update `packages/cli/src/commands/claude-hook-inject.test.ts` and
+  `claude-hook-inject.contract.test.ts`.
+- Extend packed-plugin smoke coverage under `packages/cli/scripts/` or the CLI
+  plugin test suite.
+
+### Steps
+
+1. Preserve Claude session-state query construction, working-set paths,
+   truncation, and `hookSpecificOutput.additionalContext` bytes.
+2. Probe the profile and send identity-gated `POST /api/pack` first.
+3. Include attempt metadata so Viewer retrieval artifacts remain attributable.
+4. Write host output before awaiting ledger completion.
+5. Bound `POST /api/prompt-pack-ledger` to 500 ms, never retry inline, and leave
+   delivery truth unknown on timeout/failure.
+6. Start `codemem claude-hook-inject` or pinned `npx` only for classified local
+   fallback.
+7. Keep fire-and-forget event ingestion independent of pack delivery.
+
+### Tests
+
+- Healthy delivered, empty, skipped, cached, and failed states reach the ledger.
+- Healthy path starts no `codemem`, `npx`, or shell helper child.
+- Retryable failure starts exactly one fallback chain.
+- Terminal failure starts no fallback.
+- Hook output is byte-compatible with current Claude contract fixtures.
+- Ledger timeout does not delay output beyond its bound.
+
+```text
+pnpm exec vitest run packages/cli/src/commands/claude-hook-inject.test.ts packages/cli/src/commands/claude-hook-inject.contract.test.ts
+pnpm --filter codemem test:packed-artifact
+```
+
+### Rollback
+
+Restore the shell entrypoint and CLI fallback while leaving Viewer profile and
+ledger APIs intact. Do not roll back to unauthenticated `GET /api/pack`.
+
+## PR 7: Move Codex prompt transport to direct Viewer HTTP
+
+### Purpose
+
+Apply the same direct profile/pack/ledger transport to Codex while preserving its
+lean query and explicit memory-context framing.
+
+### Files
+
+- Update `plugins/codex/scripts/user-prompt-hook.mjs`.
+- Update `packages/cli/src/commands/codex-hook-inject.ts` as compatibility
+  fallback.
+- Update `packages/cli/src/commands/codex-hook-inject.test.ts`.
+- Extend packed-plugin smoke coverage.
+
+### Steps
+
+1. Preserve Codex's prompt-plus-project query, context header, truncation, and
+   output JSON.
+2. Reuse the same profile range and failure classifier as Claude/OpenCode.
+3. Retrieve with identity-gated `POST /api/pack` before local CLI fallback.
+4. Emit host output independently from the 500 ms best-effort ledger call.
+5. Keep detached event ingestion/spooling separate from prompt retrieval.
+
+### Tests
+
+- Same delivery-state, classifier, zero-child, and ledger-bound matrix as Claude.
+- Codex context framing remains byte-compatible.
+- Detached ingestion cannot contaminate prompt-path subprocess accounting.
+- A stale Viewer falls back once; a compatible contract defect fails closed.
+
+```text
+pnpm exec vitest run packages/cli/src/commands/codex-hook-inject.test.ts packages/cli/src/commands/codex-hook-ingest.test.ts
+pnpm --filter codemem test:packed-artifact
+```
+
+### Rollback
+
+Restore CLI injection fallback as the primary path without changing normalized
+event ingestion or removing compatibility APIs.
+
+## PR 8: Prove packaged parity and update documentation
+
+### Purpose
+
+Demonstrate behavior under real packaging/version skew and update every affected
+operator surface.
+
+### Files
+
+- Update `README.md`.
+- Update `docs/architecture.md`.
+- Update `docs/plugin-reference.md`.
+- Update any affected package smoke/evidence scripts.
+- Update `scripts/release-version.mjs` and its test only if generated artifact
+  packaging/version checks require it.
+
+### Evidence
+
+1. Run packaged Claude and Codex plugins without a global `codemem` binary against
+   a healthy Viewer.
+2. Run stale-client/new-Viewer and new-client/stale-Viewer matrices for:
+   - normalized event ingestion;
+   - profile/pack retrieval;
+   - delivery ledger;
+   - classified fallback.
+3. Run 30 repetitions for direct CLI, healthy Viewer, and classified fallback.
+   Report median, p95, and phase-isolated child counts with privacy-safe fixtures.
+4. Verify healthy prompt paths have zero `codemem`/`npx` children.
+5. Search repository and packed artifacts for named-route callers. Record results
+   but do not remove aliases until evidence remains clean through the compatibility
+   window.
+
+### Validation
+
+```text
+pnpm run check
+pnpm run build
+pnpm --filter codemem test:packed-artifact
+pnpm --filter @codemem/opencode-plugin test:packed-artifact
+CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1 pnpm run e2e:smoke -- --json
+```
+
+Generated files under `packages/viewer-server/static/` and evidence under `.tmp/`
+must remain untracked.
+
+## Separate workstream: CLI plumbing cleanup
+
+Start only after the parity stack is stable. Use the existing CLI cleanup design
+and `docs/cli-design-conventions.md`.
+
+Likely files:
+
+- `packages/cli/src/command-tree.ts`;
+- `packages/cli/src/command-tree.test.ts`;
+- completion/help tests;
+- `docs/cli-design-conventions.md` and command reference documentation.
+
+Scope:
+
+- classify `claude-hook-*`, `codex-hook-*`, `enqueue-raw-event`, and
+  `prompt-pack-ledger` as adapter plumbing;
+- hide plumbing from human help/completion where compatibility permits;
+- retain stdin/stdout and exit-code contracts while shipped plugins may call them;
+- remove commands and named HTTP aliases only after repository, packaged-artifact,
+  and stale-client evidence shows no callers.
+
+This work gets its own Bead and Graphite stack. It is not PR 9 of the transport
+stack.
+
+## Dependency order
+
+```text
+PR 1 transcript safety
+  -> PR 3 legacy route retention
+
+PR 2 canonical ingestion
+  -> PR 3 source-aware HTTP
+  -> PR 4 generated edge normalizers
+
+PR 5 prompt profile/classifier
+  -> PR 6 Claude prompt transport
+  -> PR 7 Codex prompt transport
+
+PRs 4, 6, and 7
+  -> PR 8 packaged evidence and docs
+```
+
+PR 1 and PR 2 may be developed independently but should remain separate review
+units. PR 5 may proceed beside PR 4 after PR 2's exported contracts stabilize.
+
+## Review gates
+
+- PRs 1, 3, 4, 5, 6, and 7 are medium/high risk because they touch filesystem
+  trust, compatibility, plugin packaging, or delivery truth. Require
+  `CodeReviewer` after self-review.
+- Run `code-quality-pragmatist` on PR 4 or PR 5 if generated artifacts and shared
+  transport abstractions begin duplicating policy or growing a framework.
+- Run Snyk Code on changed TypeScript/JavaScript paths before final stack
+  submission because the work changes filesystem and HTTP trust boundaries.
+- Do not submit a stack with generated artifact drift, tracked private evidence,
+  or a failing focused/full gate.
+
+## Stop conditions
+
+- Host transcript roots cannot be verified safely.
+- A normalized event changes ID between healthy and fallback paths.
+- A first event receives sequence `1` on any path.
+- A compatible contract error falls back silently.
+- Ledger completion delays host output or claims delivery without adapter evidence.
+- Packaged plugins require workspace modules or a global CLI on the healthy path.
+- Compatibility requires restoring arbitrary Viewer-side transcript reads.

--- a/packages/cli/src/commands/claude-hook-ingest.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.ts
@@ -22,6 +22,7 @@ import {
 	ObserverClient,
 	resolveDbPath,
 	stripPrivateObj,
+	TRUSTED_HOOK_MAPPER_OPTIONS,
 } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
@@ -122,7 +123,7 @@ export function directEnqueue(
 	payload: Record<string, unknown>,
 	dbPath: string,
 ): { inserted: number; skipped: number } {
-	const envelope = buildRawEventEnvelopeFromHook(payload);
+	const envelope = buildRawEventEnvelopeFromHook(payload, TRUSTED_HOOK_MAPPER_OPTIONS);
 	if (!envelope) return { inserted: 0, skipped: 1 };
 
 	const db = connect(dbPath);
@@ -219,7 +220,7 @@ async function flushBoundaryRawEvents(
 	payload: Record<string, unknown>,
 	dbPath: string,
 ): Promise<void> {
-	const envelope = buildRawEventEnvelopeFromHook(payload);
+	const envelope = buildRawEventEnvelopeFromHook(payload, TRUSTED_HOOK_MAPPER_OPTIONS);
 	if (!envelope) return;
 
 	let observer: ObserverClient;

--- a/packages/cli/src/commands/codex-hook-ingest.ts
+++ b/packages/cli/src/commands/codex-hook-ingest.ts
@@ -12,6 +12,7 @@ import {
 	loadSqliteVec,
 	resolveDbPath,
 	stripPrivateObj,
+	TRUSTED_HOOK_MAPPER_OPTIONS,
 } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
@@ -122,7 +123,7 @@ export function directEnqueueCodexHook(
 	payload: Record<string, unknown>,
 	dbPath: string,
 ): { inserted: number; skipped: number } {
-	const envelope = buildRawEventEnvelopeFromCodexHook(payload);
+	const envelope = buildRawEventEnvelopeFromCodexHook(payload, TRUSTED_HOOK_MAPPER_OPTIONS);
 	if (!envelope) return { inserted: 0, skipped: 1 };
 
 	const db = connect(dbPath);

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -382,7 +382,11 @@ export interface ApiRawEventsPostResponse {
 export interface ApiClaudeHooksPostResponse {
 	inserted: number;
 	skipped: number;
+	skip_reason?: "transcript_unavailable" | "unsupported_hook";
 }
+
+/** POST /api/codex-hooks — response. */
+export type ApiCodexHooksPostResponse = ApiClaudeHooksPostResponse;
 
 // ---------------------------------------------------------------------------
 // Sync — sync.py

--- a/packages/core/src/claude-hooks.test.ts
+++ b/packages/core/src/claude-hooks.test.ts
@@ -8,15 +8,191 @@
  *  - buildIngestPayloadFromHook: session context fields
  */
 
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	buildIngestPayloadFromHook,
-	buildRawEventEnvelopeFromHook,
-	mapClaudeHookPayload,
+	buildIngestPayloadFromHook as buildIngestPayloadFromHookWithPolicy,
+	buildRawEventEnvelopeFromHook as buildRawEventEnvelopeFromHookWithPolicy,
+	mapClaudeHookPayload as mapClaudeHookPayloadWithPolicy,
+	TRUSTED_HOOK_MAPPER_OPTIONS,
 } from "./claude-hooks.js";
+import { extractHookTranscript, MAX_HOOK_TRANSCRIPT_BYTES } from "./hook-transcript.js";
+
+function restrictedTranscriptPolicy(root: string) {
+	return { trust: "restricted" as const, approvedRoots: [root] };
+}
+
+const mapClaudeHookPayload = (payload: Record<string, unknown>) =>
+	mapClaudeHookPayloadWithPolicy(payload, TRUSTED_HOOK_MAPPER_OPTIONS);
+const buildRawEventEnvelopeFromHook = (payload: Record<string, unknown>) =>
+	buildRawEventEnvelopeFromHookWithPolicy(payload, TRUSTED_HOOK_MAPPER_OPTIONS);
+const buildIngestPayloadFromHook = (payload: Record<string, unknown>) =>
+	buildIngestPayloadFromHookWithPolicy(payload, TRUSTED_HOOK_MAPPER_OPTIONS);
+
+describe("extractHookTranscript", () => {
+	it("reads an absolute transcript beneath an approved root", () => {
+		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-root-"));
+		try {
+			const path = join(root, "session.jsonl");
+			writeFileSync(path, '{"role":"assistant","content":"allowed"}\n');
+			expect(extractHookTranscript(path, { policy: restrictedTranscriptPolicy(root) })).toEqual([
+				"allowed",
+				null,
+			]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a restricted relative transcript even beneath the real cwd", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "codemem-transcript-cwd-"));
+		try {
+			writeFileSync(join(cwd, "session.jsonl"), '{"role":"assistant","content":"relative"}\n');
+			expect(
+				extractHookTranscript("session.jsonl", {
+					policy: restrictedTranscriptPolicy(join(cwd, "unused-root")),
+					cwd,
+				}),
+			).toEqual([null, null]);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it.each([
+		"../outside.jsonl",
+		"../../outside.jsonl",
+	])("rejects relative traversal %s", (transcriptPath) => {
+		const parent = mkdtempSync(join(tmpdir(), "codemem-transcript-traversal-"));
+		const cwd = join(parent, "cwd");
+		mkdirSync(cwd);
+		writeFileSync(join(parent, "outside.jsonl"), '{"role":"assistant","content":"outside"}\n');
+		try {
+			expect(
+				extractHookTranscript(transcriptPath, {
+					policy: restrictedTranscriptPolicy(parent),
+					cwd,
+				}),
+			).toEqual([null, null]);
+		} finally {
+			rmSync(parent, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects an absolute path beneath a sibling with the same prefix", () => {
+		const parent = mkdtempSync(join(tmpdir(), "codemem-transcript-prefix-"));
+		const root = join(parent, "approved");
+		const sibling = join(parent, "approved-sibling");
+		mkdirSync(root);
+		mkdirSync(sibling);
+		const path = join(sibling, "session.jsonl");
+		writeFileSync(path, '{"role":"assistant","content":"outside"}\n');
+		try {
+			expect(extractHookTranscript(path, { policy: restrictedTranscriptPolicy(root) })).toEqual([
+				null,
+				null,
+			]);
+		} finally {
+			rmSync(parent, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a relative symlink escape from cwd", () => {
+		const parent = mkdtempSync(join(tmpdir(), "codemem-transcript-symlink-"));
+		const cwd = join(parent, "cwd");
+		mkdirSync(cwd);
+		const outside = join(parent, "outside.jsonl");
+		writeFileSync(outside, '{"role":"assistant","content":"outside"}\n');
+		symlinkSync(outside, join(cwd, "linked.jsonl"));
+		try {
+			expect(
+				extractHookTranscript("linked.jsonl", {
+					policy: restrictedTranscriptPolicy(cwd),
+					cwd,
+				}),
+			).toEqual([null, null]);
+		} finally {
+			rmSync(parent, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects an absolute symlink beneath an approved root that escapes it", () => {
+		const parent = mkdtempSync(join(tmpdir(), "codemem-transcript-root-symlink-"));
+		const root = join(parent, "approved");
+		mkdirSync(root);
+		const outside = join(parent, "outside.jsonl");
+		writeFileSync(outside, '{"role":"assistant","content":"outside"}\n');
+		const linked = join(root, "linked.jsonl");
+		symlinkSync(outside, linked);
+		try {
+			expect(extractHookTranscript(linked, { policy: restrictedTranscriptPolicy(root) })).toEqual([
+				null,
+				null,
+			]);
+		} finally {
+			rmSync(parent, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a non-file beneath an approved root", () => {
+		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-directory-"));
+		const directory = join(root, "session.jsonl");
+		mkdirSync(directory);
+		try {
+			expect(
+				extractHookTranscript(directory, { policy: restrictedTranscriptPolicy(root) }),
+			).toEqual([null, null]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("returns no extraction for a missing file", () => {
+		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-missing-"));
+		try {
+			expect(
+				extractHookTranscript(join(root, "missing.jsonl"), {
+					policy: restrictedTranscriptPolicy(root),
+				}),
+			).toEqual([null, null]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("finds the final assistant record in a transcript larger than 16 MiB", () => {
+		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-tail-"));
+		try {
+			const path = join(root, "session.jsonl");
+			writeFileSync(
+				path,
+				`${"x".repeat(MAX_HOOK_TRANSCRIPT_BYTES + 1024)}\n{"role":"assistant","content":"tail record"}\n`,
+			);
+			expect(extractHookTranscript(path, { policy: restrictedTranscriptPolicy(root) })).toEqual([
+				"tail record",
+				null,
+			]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("returns no extraction when the retained tail contains no complete record", () => {
+		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-oversized-"));
+		try {
+			const path = join(root, "session.jsonl");
+			writeFileSync(path, `${"x".repeat(MAX_HOOK_TRANSCRIPT_BYTES + 1024)}\n`);
+			expect(extractHookTranscript(path, { policy: restrictedTranscriptPolicy(root) })).toEqual([
+				null,
+				null,
+			]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
 
 // ---------------------------------------------------------------------------
 // mapClaudeHookPayload — event type mapping
@@ -758,7 +934,11 @@ describe("POST /api/claude-hooks via viewer-server", () => {
 		});
 
 		expect(res.status).toBe(200);
-		expect(await res.json()).toEqual({ inserted: 0, skipped: 1 });
+		expect(await res.json()).toEqual({
+			inserted: 0,
+			skipped: 1,
+			skip_reason: "unsupported_hook",
+		});
 	});
 
 	it("returns 400 for invalid JSON", async () => {
@@ -782,6 +962,10 @@ describe("POST /api/claude-hooks via viewer-server", () => {
 
 		// Should NOT be 403 — CLI callers don't send Origin
 		expect(res.status).toBe(200);
-		expect(await res.json()).toEqual({ inserted: 0, skipped: 1 });
+		expect(await res.json()).toEqual({
+			inserted: 0,
+			skipped: 1,
+			skip_reason: "unsupported_hook",
+		});
 	});
 });

--- a/packages/core/src/claude-hooks.ts
+++ b/packages/core/src/claude-hooks.ts
@@ -12,9 +12,14 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, resolve } from "node:path";
+import {
+	extractHookTranscript,
+	type HookTranscriptPolicy,
+	TRUSTED_HOOK_TRANSCRIPT_POLICY,
+} from "./hook-transcript.js";
 
 // ---------------------------------------------------------------------------
 // Path helpers
@@ -283,24 +288,6 @@ function normalizeUsage(value: unknown): Record<string, number> | null {
 }
 
 // ---------------------------------------------------------------------------
-// Text extraction from content blocks
-// ---------------------------------------------------------------------------
-
-function textFromContent(value: unknown): string {
-	if (typeof value === "string") return value.trim();
-	if (Array.isArray(value)) {
-		const parts = value.map(textFromContent).filter(Boolean);
-		return parts.join("\n").trim();
-	}
-	if (value != null && typeof value === "object") {
-		const v = value as Record<string, unknown>;
-		if (typeof v.text === "string") return v.text.trim();
-		return textFromContent(v.content);
-	}
-	return "";
-}
-
-// ---------------------------------------------------------------------------
 // Transcript extraction (for Stop events without last_assistant_message)
 // ---------------------------------------------------------------------------
 
@@ -314,96 +301,18 @@ function textFromContent(value: unknown): string {
 export function extractFromTranscript(
 	transcriptPath: unknown,
 	cwdHint?: string | null,
+	policy: HookTranscriptPolicy = { trust: "restricted", approvedRoots: [] },
 ): [string | null, Record<string, number> | null] {
-	if (typeof transcriptPath !== "string") return [null, null];
-	const raw = expandUser(transcriptPath.trim());
-	if (!raw) return [null, null];
-
-	let resolvedPath: string;
-	if (isAbsolute(raw)) {
-		resolvedPath = raw;
-	} else {
-		if (typeof cwdHint !== "string" || !cwdHint.trim()) return [null, null];
-		const base = expandUser(cwdHint.trim());
-		if (!isAbsolute(base)) return [null, null];
-		try {
-			const stat = statSync(base, { throwIfNoEntry: false });
-			if (!stat?.isDirectory()) return [null, null];
-		} catch {
-			return [null, null];
-		}
-		resolvedPath = resolve(base, raw);
-	}
-
-	try {
-		const stat = statSync(resolvedPath, { throwIfNoEntry: false });
-		if (!stat?.isFile()) return [null, null];
-	} catch {
-		return [null, null];
-	}
-
-	let assistantText: string | null = null;
-	let assistantUsage: Record<string, number> | null = null;
-
-	try {
-		const content = readFileSync(resolvedPath, "utf-8");
-		for (const rawLine of content.split("\n")) {
-			const line = rawLine.trim();
-			if (!line) continue;
-			let record: unknown;
-			try {
-				record = JSON.parse(line);
-			} catch {
-				continue;
-			}
-			if (record == null || typeof record !== "object" || Array.isArray(record)) continue;
-			const r = record as Record<string, unknown>;
-
-			// A line may be the record itself or have a nested `message` field
-			const candidates: Record<string, unknown>[] = [r];
-			if (r.message != null && typeof r.message === "object" && !Array.isArray(r.message)) {
-				candidates.push(r.message as Record<string, unknown>);
-			}
-
-			let role = "";
-			let contentValue: unknown = null;
-			let usageValue: unknown = null;
-
-			for (const c of candidates) {
-				if (!role) {
-					if (typeof c.role === "string") role = c.role.trim().toLowerCase();
-					else if (c.type === "assistant") role = "assistant";
-				}
-				if (contentValue == null) {
-					for (const field of ["content", "text"]) {
-						if (field in c) {
-							contentValue = c[field];
-							break;
-						}
-					}
-				}
-				if (usageValue == null) {
-					for (const field of ["usage", "token_usage", "tokenUsage"]) {
-						if (field in c) {
-							usageValue = c[field];
-							break;
-						}
-					}
-				}
-			}
-
-			if (role !== "assistant") continue;
-			const text = textFromContent(contentValue);
-			if (!text) continue;
-			assistantText = text;
-			assistantUsage = normalizeUsage(usageValue);
-		}
-	} catch {
-		return [null, null];
-	}
-
-	return [assistantText, assistantUsage];
+	return extractHookTranscript(transcriptPath, { policy, cwd: cwdHint });
 }
+
+export interface HookMapperOptions {
+	transcriptPolicy: HookTranscriptPolicy;
+}
+
+export const TRUSTED_HOOK_MAPPER_OPTIONS: HookMapperOptions = {
+	transcriptPolicy: TRUSTED_HOOK_TRANSCRIPT_POLICY,
+};
 
 // ---------------------------------------------------------------------------
 // Session id
@@ -439,6 +348,7 @@ export interface ClaudeHookAdapterEvent {
  */
 export function mapClaudeHookPayload(
 	payload: Record<string, unknown>,
+	options: HookMapperOptions,
 ): ClaudeHookAdapterEvent | null {
 	const hookEvent = String(payload.hook_event_name ?? "").trim();
 	if (!MAPPABLE_CLAUDE_HOOK_EVENTS.has(hookEvent)) return null;
@@ -546,7 +456,11 @@ export function mapClaudeHookPayload(
 
 		if (!assistantText || usage === null) {
 			const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
-			const [transcriptText, transcriptUsage] = extractFromTranscript(payload.transcript_path, cwd);
+			const [transcriptText, transcriptUsage] = extractFromTranscript(
+				payload.transcript_path,
+				cwd,
+				options.transcriptPolicy,
+			);
 			if (!assistantText && transcriptText) assistantText = transcriptText;
 			if (usage === null && transcriptUsage !== null) usage = transcriptUsage;
 		}
@@ -658,8 +572,9 @@ export interface ClaudeHookRawEventEnvelope {
  */
 export function buildRawEventEnvelopeFromHook(
 	hookPayload: Record<string, unknown>,
+	options: HookMapperOptions,
 ): ClaudeHookRawEventEnvelope | null {
-	const adapterEvent = mapClaudeHookPayload(hookPayload);
+	const adapterEvent = mapClaudeHookPayload(hookPayload, options);
 	if (adapterEvent === null) return null;
 
 	const sessionId = adapterEvent.session_id.trim();
@@ -707,8 +622,9 @@ export function buildRawEventEnvelopeFromHook(
  */
 export function buildIngestPayloadFromHook(
 	hookPayload: Record<string, unknown>,
+	options: HookMapperOptions,
 ): Record<string, unknown> | null {
-	const adapterEvent = mapClaudeHookPayload(hookPayload);
+	const adapterEvent = mapClaudeHookPayload(hookPayload, options);
 	if (adapterEvent === null) return null;
 
 	const sessionId = adapterEvent.session_id;

--- a/packages/core/src/codex-hooks.test.ts
+++ b/packages/core/src/codex-hooks.test.ts
@@ -2,11 +2,21 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { type HookMapperOptions, TRUSTED_HOOK_MAPPER_OPTIONS } from "./claude-hooks.js";
 import {
-	buildIngestPayloadFromCodexHook,
-	buildRawEventEnvelopeFromCodexHook,
-	mapCodexHookPayload,
+	buildIngestPayloadFromCodexHook as buildIngestPayloadFromCodexHookWithPolicy,
+	buildRawEventEnvelopeFromCodexHook as buildRawEventEnvelopeFromCodexHookWithPolicy,
+	mapCodexHookPayload as mapCodexHookPayloadWithPolicy,
 } from "./codex-hooks.js";
+
+const mapCodexHookPayload = (
+	payload: Record<string, unknown>,
+	options: HookMapperOptions = TRUSTED_HOOK_MAPPER_OPTIONS,
+) => mapCodexHookPayloadWithPolicy(payload, options);
+const buildRawEventEnvelopeFromCodexHook = (payload: Record<string, unknown>) =>
+	buildRawEventEnvelopeFromCodexHookWithPolicy(payload, TRUSTED_HOOK_MAPPER_OPTIONS);
+const buildIngestPayloadFromCodexHook = (payload: Record<string, unknown>) =>
+	buildIngestPayloadFromCodexHookWithPolicy(payload, TRUSTED_HOOK_MAPPER_OPTIONS);
 
 const tempDirs: string[] = [];
 
@@ -127,6 +137,25 @@ describe("mapCodexHookPayload", () => {
 		expect(event).not.toBeNull();
 		expect(event?.event_type).toBe("assistant");
 		expect(event?.payload.text).toBe("Finished the thing");
+	});
+
+	it("maps Stop via an explicitly approved transcript root", () => {
+		const transcriptPath = writeTranscript([{ role: "assistant", content: "Approved result" }]);
+		const event = mapCodexHookPayload(
+			{
+				hook_event_name: "Stop",
+				session_id: "codex-session",
+				transcript_path: transcriptPath,
+			},
+			{
+				transcriptPolicy: {
+					trust: "restricted",
+					approvedRoots: [join(transcriptPath, "..")],
+				},
+			},
+		);
+
+		expect(event?.payload.text).toBe("Approved result");
 	});
 
 	it("keeps Stop event IDs stable across transcript-fallback retries", () => {

--- a/packages/core/src/codex-hooks.ts
+++ b/packages/core/src/codex-hooks.ts
@@ -8,6 +8,7 @@
 import { createHash } from "node:crypto";
 import {
 	extractFromTranscript,
+	type HookMapperOptions,
 	normalizeProjectLabel,
 	resolveHookProject,
 } from "./claude-hooks.js";
@@ -86,6 +87,7 @@ export interface CodexHookAdapterEvent {
 
 export function mapCodexHookPayload(
 	payload: Record<string, unknown>,
+	options: HookMapperOptions,
 ): CodexHookAdapterEvent | null {
 	const hookEvent = coerceString(payload.hook_event_name);
 	if (!MAPPABLE_CODEX_HOOK_EVENTS.has(hookEvent)) return null;
@@ -175,7 +177,11 @@ export function mapCodexHookPayload(
 		let assistantText = rawAssistantText;
 		if (!assistantText) {
 			const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
-			const [transcriptText] = extractFromTranscript(payload.transcript_path, cwd);
+			const [transcriptText] = extractFromTranscript(
+				payload.transcript_path,
+				cwd,
+				options.transcriptPolicy,
+			);
 			if (transcriptText) assistantText = transcriptText.trim();
 		}
 		if (!assistantText) return null;
@@ -264,8 +270,9 @@ export interface CodexHookRawEventEnvelope {
 
 export function buildRawEventEnvelopeFromCodexHook(
 	hookPayload: Record<string, unknown>,
+	options: HookMapperOptions,
 ): CodexHookRawEventEnvelope | null {
-	const adapterEvent = mapCodexHookPayload(hookPayload);
+	const adapterEvent = mapCodexHookPayload(hookPayload, options);
 	if (adapterEvent === null) return null;
 
 	const sessionId = adapterEvent.session_id.trim();
@@ -299,8 +306,9 @@ export function buildRawEventEnvelopeFromCodexHook(
 
 export function buildIngestPayloadFromCodexHook(
 	hookPayload: Record<string, unknown>,
+	options: HookMapperOptions,
 ): Record<string, unknown> | null {
-	const adapterEvent = mapCodexHookPayload(hookPayload);
+	const adapterEvent = mapCodexHookPayload(hookPayload, options);
 	if (adapterEvent === null) return null;
 	const sessionId = adapterEvent.session_id;
 	return {

--- a/packages/core/src/extraction-replay.test.ts
+++ b/packages/core/src/extraction-replay.test.ts
@@ -2,7 +2,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
-import { buildRawEventEnvelopeFromHook } from "./claude-hooks.js";
+import { buildRawEventEnvelopeFromHook, TRUSTED_HOOK_MAPPER_OPTIONS } from "./claude-hooks.js";
 import { buildTierRoutedReplayObserverConfig, replayBatchExtraction } from "./extraction-replay.js";
 import {
 	type ObserverClient,
@@ -670,7 +670,7 @@ describe("extraction replay", () => {
 				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			);
 			hookEvents.forEach((hook, index) => {
-				const envelope = buildRawEventEnvelopeFromHook(hook);
+				const envelope = buildRawEventEnvelopeFromHook(hook, TRUSTED_HOOK_MAPPER_OPTIONS);
 				if (envelope == null) throw new Error("expected envelope");
 				insertRaw.run(
 					envelope.source,

--- a/packages/core/src/hook-transcript.ts
+++ b/packages/core/src/hook-transcript.ts
@@ -1,0 +1,215 @@
+import {
+	closeSync,
+	constants,
+	fstatSync,
+	openSync,
+	readSync,
+	realpathSync,
+	statSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+export const MAX_HOOK_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
+
+export type HookTranscriptPolicy =
+	| { trust: "trusted" }
+	| { trust: "restricted"; approvedRoots: readonly string[] };
+
+export const TRUSTED_HOOK_TRANSCRIPT_POLICY: HookTranscriptPolicy = { trust: "trusted" };
+
+export interface HookTranscriptReadOptions {
+	policy: HookTranscriptPolicy;
+	cwd?: string | null;
+}
+
+type TranscriptExtraction = [string | null, Record<string, number> | null];
+
+function expandUser(path: string): string {
+	return path.startsWith("~/") ? resolve(homedir(), path.slice(2)) : path;
+}
+
+function isContained(root: string, target: string): boolean {
+	const pathFromRoot = relative(root, target);
+	return (
+		pathFromRoot === "" ||
+		(pathFromRoot !== ".." && !pathFromRoot.startsWith(`..${sep}`) && !isAbsolute(pathFromRoot))
+	);
+}
+
+function resolveTranscriptPath(
+	transcriptPath: unknown,
+	options: HookTranscriptReadOptions,
+): string | null {
+	if (typeof transcriptPath !== "string") return null;
+	const requestedPath = expandUser(transcriptPath.trim());
+	if (!requestedPath) return null;
+
+	try {
+		if (!isAbsolute(requestedPath)) {
+			if (options.policy.trust !== "trusted") return null;
+			if (typeof options.cwd !== "string") return null;
+			const cwd = expandUser(options.cwd.trim());
+			if (!isAbsolute(cwd)) return null;
+			const realCwd = realpathSync(cwd);
+			if (!statSync(realCwd).isDirectory()) return null;
+			const realTarget = realpathSync(resolve(realCwd, requestedPath));
+			return isContained(realCwd, realTarget) ? realTarget : null;
+		}
+
+		const realTarget = realpathSync(requestedPath);
+		if (options.policy.trust === "trusted") return realTarget;
+		for (const root of options.policy.approvedRoots) {
+			try {
+				const realRoot = realpathSync(expandUser(root));
+				if (statSync(realRoot).isDirectory() && isContained(realRoot, realTarget))
+					return realTarget;
+			} catch {
+				// Missing or unreadable approved roots are simply ineligible.
+			}
+		}
+	} catch {
+		return null;
+	}
+	return null;
+}
+
+function readTranscriptTail(path: string): string | null {
+	let descriptor: number | null = null;
+	try {
+		descriptor = openSync(
+			path,
+			constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0),
+		);
+		const stat = fstatSync(descriptor);
+		if (!stat.isFile()) return null;
+		const openedPath = realpathSync(path);
+		const openedPathStat = statSync(openedPath);
+		if (openedPath !== path || openedPathStat.dev !== stat.dev || openedPathStat.ino !== stat.ino) {
+			return null;
+		}
+		const bytesToRead = Math.min(stat.size, MAX_HOOK_TRANSCRIPT_BYTES);
+		const start = stat.size - bytesToRead;
+		const buffer = Buffer.allocUnsafe(bytesToRead);
+		let offset = 0;
+		while (offset < bytesToRead) {
+			const bytesRead = readSync(descriptor, buffer, offset, bytesToRead - offset, start + offset);
+			if (bytesRead === 0) break;
+			offset += bytesRead;
+		}
+		let retained = buffer.subarray(0, offset);
+		if (start > 0) {
+			const firstNewline = retained.indexOf(0x0a);
+			if (firstNewline < 0) return null;
+			retained = retained.subarray(firstNewline + 1);
+		}
+		return retained.length > 0 ? retained.toString("utf8") : null;
+	} catch {
+		return null;
+	} finally {
+		if (descriptor !== null) {
+			try {
+				closeSync(descriptor);
+			} catch {
+				// A close failure does not make transcript extraction fatal.
+			}
+		}
+	}
+}
+
+function textFromContent(value: unknown): string {
+	if (typeof value === "string") return value.trim();
+	if (Array.isArray(value)) return value.map(textFromContent).filter(Boolean).join("\n").trim();
+	if (value != null && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		if (typeof record.text === "string") return record.text.trim();
+		return textFromContent(record.content);
+	}
+	return "";
+}
+
+function normalizeUsage(value: unknown): Record<string, number> | null {
+	if (value == null || typeof value !== "object" || Array.isArray(value)) return null;
+	const usage = value as Record<string, unknown>;
+	const toInt = (key: string): number => {
+		try {
+			const parsed = Number(usage[key] ?? 0);
+			return Number.isFinite(parsed) ? Math.trunc(parsed) : 0;
+		} catch {
+			return 0;
+		}
+	};
+	const normalized = {
+		input_tokens: toInt("input_tokens"),
+		output_tokens: toInt("output_tokens"),
+		cache_creation_input_tokens: toInt("cache_creation_input_tokens"),
+		cache_read_input_tokens: toInt("cache_read_input_tokens"),
+	};
+	const total = Object.values(normalized).reduce((sum, count) => sum + count, 0);
+	return total > 0 ? normalized : null;
+}
+
+function parseTranscript(content: string): TranscriptExtraction {
+	let assistantText: string | null = null;
+	let assistantUsage: Record<string, number> | null = null;
+	for (const rawLine of content.split("\n")) {
+		const line = rawLine.trim();
+		if (!line) continue;
+		try {
+			const parsed: unknown = JSON.parse(line);
+			if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+			const record = parsed as Record<string, unknown>;
+			const candidates = [record];
+			if (
+				record.message != null &&
+				typeof record.message === "object" &&
+				!Array.isArray(record.message)
+			) {
+				candidates.push(record.message as Record<string, unknown>);
+			}
+			let role = "";
+			let contentValue: unknown = null;
+			let usageValue: unknown = null;
+			for (const candidate of candidates) {
+				if (!role) {
+					if (typeof candidate.role === "string") role = candidate.role.trim().toLowerCase();
+					else if (candidate.type === "assistant") role = "assistant";
+				}
+				if (contentValue == null) {
+					for (const field of ["content", "text"]) {
+						if (field in candidate) {
+							contentValue = candidate[field];
+							break;
+						}
+					}
+				}
+				if (usageValue == null) {
+					for (const field of ["usage", "token_usage", "tokenUsage"]) {
+						if (field in candidate) {
+							usageValue = candidate[field];
+							break;
+						}
+					}
+				}
+			}
+			if (role !== "assistant") continue;
+			const text = textFromContent(contentValue);
+			if (!text) continue;
+			assistantText = text;
+			assistantUsage = normalizeUsage(usageValue);
+		} catch {
+			// Ignore malformed JSONL records and continue scanning the bounded tail.
+		}
+	}
+	return [assistantText, assistantUsage];
+}
+
+export function extractHookTranscript(
+	transcriptPath: unknown,
+	options: HookTranscriptReadOptions,
+): TranscriptExtraction {
+	const resolvedPath = resolveTranscriptPath(transcriptPath, options);
+	if (!resolvedPath) return [null, null];
+	const content = readTranscriptTail(resolvedPath);
+	return content === null ? [null, null] : parseTranscript(content);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,11 @@ export * from "./attribution-assessment.js";
 export * from "./attribution-diagnostics.js";
 export type { CreateBetterSqliteCoordinatorAppOptions } from "./better-sqlite-coordinator-runtime.js";
 export { createBetterSqliteCoordinatorApp } from "./better-sqlite-coordinator-runtime.js";
-export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";
+export type {
+	ClaudeHookAdapterEvent,
+	ClaudeHookRawEventEnvelope,
+	HookMapperOptions,
+} from "./claude-hooks.js";
 export {
 	buildIngestPayloadFromHook,
 	buildRawEventEnvelopeFromHook,
@@ -21,6 +25,7 @@ export {
 	mapClaudeHookPayload,
 	normalizeProjectLabel,
 	resolveHookProject,
+	TRUSTED_HOOK_MAPPER_OPTIONS,
 } from "./claude-hooks.js";
 export type { CodexHookAdapterEvent, CodexHookRawEventEnvelope } from "./codex-hooks.js";
 export {
@@ -333,6 +338,12 @@ export {
 	SIMPLE_TIER_DEFAULTS,
 } from "./extraction-tier-routing.js";
 export { buildFilterClauses, buildFilterClausesWithContext } from "./filters.js";
+export type { HookTranscriptPolicy, HookTranscriptReadOptions } from "./hook-transcript.js";
+export {
+	extractHookTranscript,
+	MAX_HOOK_TRANSCRIPT_BYTES,
+	TRUSTED_HOOK_TRANSCRIPT_POLICY,
+} from "./hook-transcript.js";
 // Ingest pipeline
 export {
 	budgetToolEvents,

--- a/packages/core/src/raw-event-flush.test.ts
+++ b/packages/core/src/raw-event-flush.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildRawEventEnvelopeFromHook } from "./claude-hooks.js";
+import { buildRawEventEnvelopeFromHook, TRUSTED_HOOK_MAPPER_OPTIONS } from "./claude-hooks.js";
 import { connect } from "./db.js";
 import type { IngestOptions } from "./ingest-pipeline.js";
 import { flushRawEvents } from "./raw-event-flush.js";
@@ -423,7 +423,7 @@ describe("flushRawEvents max retry", () => {
 		];
 
 		for (const hook of hookEvents) {
-			const envelope = buildRawEventEnvelopeFromHook(hook);
+			const envelope = buildRawEventEnvelopeFromHook(hook, TRUSTED_HOOK_MAPPER_OPTIONS);
 			expect(envelope).not.toBeNull();
 			if (envelope == null) throw new Error("envelope");
 			store.recordRawEvent({

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -416,6 +416,74 @@ describe("viewer-server", () => {
 		).toBe(true);
 	});
 
+	describe.each([
+		{
+			label: "Claude",
+			route: "/api/claude-hooks",
+			envName: "CLAUDE_CONFIG_DIR",
+			rootName: "projects",
+		},
+		{
+			label: "Codex",
+			route: "/api/codex-hooks",
+			envName: "CODEX_HOME",
+			rootName: "sessions",
+		},
+	])("legacy $label hook transcript containment", ({ route, envName, rootName }) => {
+		it("accepts configured-root transcripts and rejects outside files", async () => {
+			const parent = mkdtempSync(join(tmpdir(), "codemem-viewer-transcript-root-"));
+			const configuredHome = join(parent, "host-home");
+			const approvedRoot = join(configuredHome, rootName);
+			mkdirSync(approvedRoot, { recursive: true });
+			const allowedPath = join(approvedRoot, "allowed.jsonl");
+			const outsidePath = join(parent, "outside.jsonl");
+			writeFileSync(allowedPath, '{"role":"assistant","content":"allowed result"}\n');
+			writeFileSync(outsidePath, '{"role":"assistant","content":"outside result"}\n');
+			const previousValue = process.env[envName];
+			process.env[envName] = configuredHome;
+			const { app, cleanup } = createTestApp();
+			try {
+				const allowed = await postViewerJson(app, route, {
+					hook_event_name: "Stop",
+					session_id: "allowed-session",
+					transcript_path: allowedPath,
+				});
+				expect(allowed.status).toBe(200);
+				expect(await allowed.json()).toEqual({ inserted: 1, skipped: 0 });
+
+				const rejected = await postViewerJson(app, route, {
+					hook_event_name: "Stop",
+					session_id: "rejected-session",
+					transcript_path: outsidePath,
+				});
+				expect(rejected.status).toBe(200);
+				expect(await rejected.json()).toEqual({
+					inserted: 0,
+					skipped: 1,
+					skip_reason: "transcript_unavailable",
+				});
+
+				const relativeRejected = await postViewerJson(app, route, {
+					hook_event_name: "Stop",
+					session_id: "relative-rejected-session",
+					cwd: parent,
+					transcript_path: "outside.jsonl",
+				});
+				expect(relativeRejected.status).toBe(200);
+				expect(await relativeRejected.json()).toEqual({
+					inserted: 0,
+					skipped: 1,
+					skip_reason: "transcript_unavailable",
+				});
+			} finally {
+				cleanup();
+				if (previousValue == null) delete process.env[envName];
+				else process.env[envName] = previousValue;
+				rmSync(parent, { recursive: true, force: true });
+			}
+		});
+	});
+
 	describe("GET /api/stats", () => {
 		it("returns database stats", async () => {
 			const { app, cleanup } = createTestApp();

--- a/packages/viewer-server/src/routes/raw-events.ts
+++ b/packages/viewer-server/src/routes/raw-events.ts
@@ -4,6 +4,8 @@
  */
 
 import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { MemoryStore, RawEventSweeper } from "@codemem/core";
 import {
 	buildRawEventEnvelopeFromCodexHook,
@@ -20,6 +22,14 @@ type StoreFactory = () => MemoryStore;
 
 const MAX_RAW_EVENTS_BODY_BYTES =
 	Number.parseInt(process.env.CODEMEM_RAW_EVENTS_MAX_BODY_BYTES ?? "", 10) || 1048576;
+
+function claudeTranscriptRoot(): string {
+	return join(process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude"), "projects");
+}
+
+function codexTranscriptRoot(): string {
+	return join(process.env.CODEX_HOME?.trim() || join(homedir(), ".codex"), "sessions");
+}
 
 /** Keys to check (in priority order) when resolving a session stream id. */
 const SESSION_ID_KEYS = [
@@ -393,10 +403,16 @@ export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweepe
 		const payload = result;
 
 		// Map hook payload → raw event envelope
-		const envelope = buildRawEventEnvelopeFromHook(payload);
+		const envelope = buildRawEventEnvelopeFromHook(payload, {
+			transcriptPolicy: { trust: "restricted", approvedRoots: [claudeTranscriptRoot()] },
+		});
 		if (envelope === null) {
 			// Unsupported event type or missing required fields — skip gracefully
-			return c.json({ inserted: 0, skipped: 1 });
+			const skipReason =
+				payload.hook_event_name === "Stop" && typeof payload.transcript_path === "string"
+					? "transcript_unavailable"
+					: "unsupported_hook";
+			return c.json({ inserted: 0, skipped: 1, skip_reason: skipReason });
 		}
 
 		const store = getStore();
@@ -442,9 +458,15 @@ export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweepe
 		if (result instanceof Response) return result;
 		const payload = result;
 
-		const envelope = buildRawEventEnvelopeFromCodexHook(payload);
+		const envelope = buildRawEventEnvelopeFromCodexHook(payload, {
+			transcriptPolicy: { trust: "restricted", approvedRoots: [codexTranscriptRoot()] },
+		});
 		if (envelope === null) {
-			return c.json({ inserted: 0, skipped: 1 });
+			const skipReason =
+				payload.hook_event_name === "Stop" && typeof payload.transcript_path === "string"
+					? "transcript_unavailable"
+					: "unsupported_hook";
+			return c.json({ inserted: 0, skipped: 1, skip_reason: skipReason });
 		}
 
 		const store = getStore();


### PR DESCRIPTION
## Description

Bounds Claude and Codex transcript reads so hook ingestion does not load unbounded session files. Preserves adapter behavior while constraining memory use and keeping transcript parsing deterministic.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run check` at the validated stack tip)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected — automated coverage used

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] Documentation updated or not required
- [x] No new warnings introduced