### PR TITLE
feat(core): add canonical raw event ingestion

### DIFF
--- a/docs/plans/2026-08-15-adapter-interoperability-and-prompt-transport-implementation.md
+++ b/docs/plans/2026-08-15-adapter-interoperability-and-prompt-transport-implementation.md
@@ -132,6 +132,7 @@ ingestion outcomes behind one core API.
   required.
 - Update `packages/core/src/index.ts` exports.
 - Update `packages/cli/src/commands/enqueue-raw-event.ts`.
+- Add `packages/cli/src/commands/enqueue-raw-event.test.ts`.
 - Update `packages/cli/src/commands/claude-hook-ingest.ts`.
 - Update `packages/cli/src/commands/codex-hook-ingest.ts`.
 - Update their existing test files.

--- a/packages/cli/src/commands/claude-hook-ingest.test.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.test.ts
@@ -123,7 +123,7 @@ describe("claude-hook-ingest command", () => {
 			const second = directEnqueue(payload, dbPath);
 
 			expect(first).toEqual({ inserted: 1, skipped: 0 });
-			expect(second).toEqual({ inserted: 0, skipped: 0 });
+			expect(second).toEqual({ inserted: 0, skipped: 1 });
 
 			const db = connect(dbPath);
 			try {
@@ -133,6 +133,10 @@ describe("claude-hook-ingest command", () => {
 				};
 				expect(rawCount.c).toBe(1);
 				expect(sessionCount.c).toBe(1);
+				const row = db.prepare("SELECT event_seq FROM raw_events").get() as {
+					event_seq: number;
+				};
+				expect(row.event_seq).toBe(0);
 			} finally {
 				db.close();
 			}

--- a/packages/cli/src/commands/claude-hook-ingest.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.ts
@@ -17,11 +17,11 @@ import {
 	connect,
 	ensureSchemaBootstrapped,
 	flushRawEvents,
+	ingestRawEvents,
 	loadSqliteVec,
 	MemoryStore,
 	ObserverClient,
 	resolveDbPath,
-	stripPrivateObj,
 	TRUSTED_HOOK_MAPPER_OPTIONS,
 } from "@codemem/core";
 import { Command } from "commander";
@@ -138,67 +138,8 @@ export function directEnqueue(
 		// hooks can race its startup (claude-hook-ingest is a separate CLI
 		// process) so we can't rely on that ordering.
 		ensureSchemaBootstrapped(db);
-		const strippedPayload = stripPrivateObj(envelope.payload) as Record<string, unknown>;
-		const existing = db
-			.prepare(
-				"SELECT 1 FROM raw_events WHERE source = ? AND stream_id = ? AND event_id = ? LIMIT 1",
-			)
-			.get(envelope.source, envelope.session_stream_id, envelope.event_id);
-		if (existing) return { inserted: 0, skipped: 0 };
-
-		db.prepare(
-			`INSERT INTO raw_events(
-				source, stream_id, opencode_session_id, event_id, event_seq,
-				event_type, ts_wall_ms, payload_json, created_at
-			) VALUES (?, ?, ?, ?, (
-				SELECT COALESCE(MAX(event_seq), 0) + 1
-				FROM raw_events WHERE source = ? AND stream_id = ?
-			), ?, ?, ?, datetime('now'))`,
-		).run(
-			envelope.source,
-			envelope.session_stream_id,
-			envelope.opencode_session_id,
-			envelope.event_id,
-			envelope.source,
-			envelope.session_stream_id,
-			"claude.hook",
-			envelope.ts_wall_ms,
-			JSON.stringify(strippedPayload),
-		);
-
-		// Query actual max event_seq for this stream to keep session metadata in sync
-		const maxSeqRow = db
-			.prepare(
-				"SELECT COALESCE(MAX(event_seq), 0) AS max_seq FROM raw_events WHERE source = ? AND stream_id = ?",
-			)
-			.get(envelope.source, envelope.session_stream_id) as { max_seq: number };
-		const currentMaxSeq = maxSeqRow.max_seq;
-
-		// Upsert session metadata with accurate sequence tracking
-		db.prepare(
-			`INSERT INTO raw_event_sessions(
-				source, stream_id, opencode_session_id, cwd, project, started_at,
-				last_seen_ts_wall_ms, last_received_event_seq, last_flushed_event_seq, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, -1, datetime('now'))
-			ON CONFLICT(source, stream_id) DO UPDATE SET
-				cwd = COALESCE(excluded.cwd, cwd),
-				project = COALESCE(excluded.project, project),
-				started_at = COALESCE(excluded.started_at, started_at),
-				last_seen_ts_wall_ms = MAX(COALESCE(excluded.last_seen_ts_wall_ms, 0), COALESCE(last_seen_ts_wall_ms, 0)),
-				last_received_event_seq = MAX(excluded.last_received_event_seq, last_received_event_seq),
-				updated_at = datetime('now')`,
-		).run(
-			envelope.source,
-			envelope.session_stream_id,
-			envelope.opencode_session_id,
-			envelope.cwd,
-			envelope.project,
-			envelope.started_at,
-			envelope.ts_wall_ms,
-			currentMaxSeq,
-		);
-
-		return { inserted: 1, skipped: 0 };
+		const result = ingestRawEvents({ db }, envelope);
+		return { inserted: result.inserted, skipped: result.skipped };
 	} finally {
 		db.close();
 	}

--- a/packages/cli/src/commands/codex-hook-ingest.test.ts
+++ b/packages/cli/src/commands/codex-hook-ingest.test.ts
@@ -276,7 +276,7 @@ describe("codex-hook-ingest command", () => {
 			const second = directEnqueueCodexHook(payload, dbPath);
 
 			expect(first).toEqual({ inserted: 1, skipped: 0 });
-			expect(second).toEqual({ inserted: 0, skipped: 0 });
+			expect(second).toEqual({ inserted: 0, skipped: 1 });
 
 			const db = connect(dbPath);
 			try {

--- a/packages/cli/src/commands/codex-hook-ingest.ts
+++ b/packages/cli/src/commands/codex-hook-ingest.ts
@@ -9,9 +9,9 @@ import {
 	buildRawEventEnvelopeFromCodexHook,
 	connect,
 	ensureSchemaBootstrapped,
+	ingestRawEvents,
 	loadSqliteVec,
 	resolveDbPath,
-	stripPrivateObj,
 	TRUSTED_HOOK_MAPPER_OPTIONS,
 } from "@codemem/core";
 import { Command } from "commander";
@@ -134,69 +134,8 @@ export function directEnqueueCodexHook(
 			// sqlite-vec is not required for raw-event enqueue.
 		}
 		ensureSchemaBootstrapped(db);
-		const strippedPayload = stripPrivateObj(envelope.payload) as Record<string, unknown>;
-		const existing = db
-			.prepare(
-				"SELECT 1 FROM raw_events WHERE source = ? AND stream_id = ? AND event_id = ? LIMIT 1",
-			)
-			.get(envelope.source, envelope.session_stream_id, envelope.event_id);
-		if (existing) return { inserted: 0, skipped: 0 };
-
-		// Seed event_seq from a -1 base so a fresh stream's first event is 0,
-		// matching store.recordRawEvent (which increments the session's
-		// last_received_event_seq default of -1). This keeps the direct-fallback
-		// path and the /api/codex-hooks HTTP path on the same sequence base so
-		// maintenance status math does not over/under-count for new streams.
-		db.prepare(
-			`INSERT INTO raw_events(
-				source, stream_id, opencode_session_id, event_id, event_seq,
-				event_type, ts_wall_ms, payload_json, created_at
-			) VALUES (?, ?, ?, ?, (
-				SELECT COALESCE(MAX(event_seq), -1) + 1
-				FROM raw_events WHERE source = ? AND stream_id = ?
-			), ?, ?, ?, datetime('now'))`,
-		).run(
-			envelope.source,
-			envelope.session_stream_id,
-			envelope.opencode_session_id,
-			envelope.event_id,
-			envelope.source,
-			envelope.session_stream_id,
-			envelope.event_type,
-			envelope.ts_wall_ms,
-			JSON.stringify(strippedPayload),
-		);
-
-		const maxSeqRow = db
-			.prepare(
-				"SELECT COALESCE(MAX(event_seq), 0) AS max_seq FROM raw_events WHERE source = ? AND stream_id = ?",
-			)
-			.get(envelope.source, envelope.session_stream_id) as { max_seq: number };
-
-		db.prepare(
-			`INSERT INTO raw_event_sessions(
-				source, stream_id, opencode_session_id, cwd, project, started_at,
-				last_seen_ts_wall_ms, last_received_event_seq, last_flushed_event_seq, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, -1, datetime('now'))
-			ON CONFLICT(source, stream_id) DO UPDATE SET
-				cwd = COALESCE(excluded.cwd, cwd),
-				project = COALESCE(excluded.project, project),
-				started_at = COALESCE(excluded.started_at, started_at),
-				last_seen_ts_wall_ms = MAX(COALESCE(excluded.last_seen_ts_wall_ms, 0), COALESCE(last_seen_ts_wall_ms, 0)),
-				last_received_event_seq = MAX(excluded.last_received_event_seq, last_received_event_seq),
-				updated_at = datetime('now')`,
-		).run(
-			envelope.source,
-			envelope.session_stream_id,
-			envelope.opencode_session_id,
-			envelope.cwd,
-			envelope.project,
-			envelope.started_at,
-			envelope.ts_wall_ms,
-			maxSeqRow.max_seq,
-		);
-
-		return { inserted: 1, skipped: 0 };
+		const result = ingestRawEvents({ db }, envelope);
+		return { inserted: result.inserted, skipped: result.skipped };
 	} finally {
 		db.close();
 	}

--- a/packages/cli/src/commands/enqueue-raw-event.test.ts
+++ b/packages/cli/src/commands/enqueue-raw-event.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runEnqueueRawEvent } from "./enqueue-raw-event.js";
+
+const cleanupPaths: string[] = [];
+const originalExitCode = process.exitCode;
+
+function tempDbPath(): string {
+	const dir = mkdtempSync(join(tmpdir(), "codemem-enqueue-raw-event-"));
+	cleanupPaths.push(dir);
+	return join(dir, "test.sqlite");
+}
+
+afterEach(() => {
+	process.exitCode = originalExitCode;
+	vi.restoreAllMocks();
+	for (const path of cleanupPaths.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("enqueue-raw-event command", () => {
+	it("keeps successful ingestion silent", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		process.exitCode = undefined;
+
+		await runEnqueueRawEvent(
+			{ dbPath: tempDbPath() },
+			{
+				readPayload: async () => ({
+					source: "opencode",
+					session_id: "session-command-success",
+					event_id: "event-command-success",
+					event_type: "prompt",
+					payload: { text: "hello" },
+				}),
+			},
+		);
+
+		expect(log).not.toHaveBeenCalled();
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("reports canonical validation failures as validation_error", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		process.exitCode = undefined;
+
+		await runEnqueueRawEvent(
+			{ dbPath: tempDbPath() },
+			{
+				readPayload: async () => ({
+					source: "opencode",
+					session_id: "session-command-invalid",
+					event_id: "contains spaces",
+					event_type: "prompt",
+					payload: {},
+				}),
+			},
+		);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "validation_error",
+		});
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("reports non-validation failures as enqueue_error", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		process.exitCode = undefined;
+
+		await runEnqueueRawEvent(
+			{ dbPath: tempDbPath() },
+			{
+				readPayload: async () => {
+					throw new Error("stdin failed");
+				},
+			},
+		);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "enqueue_error",
+			message: "stdin failed",
+		});
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/packages/cli/src/commands/enqueue-raw-event.ts
+++ b/packages/cli/src/commands/enqueue-raw-event.ts
@@ -1,32 +1,12 @@
-import { MemoryStore, resolveDbPath, stripPrivateObj } from "@codemem/core";
+import {
+	ingestRawEvents,
+	MemoryStore,
+	RawEventIngestValidationError,
+	resolveDbPath,
+} from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
-
-const SESSION_ID_KEYS = [
-	"session_stream_id",
-	"session_id",
-	"stream_id",
-	"opencode_session_id",
-] as const;
-
-function resolveSessionStreamId(payload: Record<string, unknown>): string | null {
-	const values = new Map<string, string>();
-	for (const key of SESSION_ID_KEYS) {
-		const value = payload[key];
-		if (typeof value !== "string") continue;
-		const text = value.trim();
-		if (text) values.set(key, text);
-	}
-	if (values.size === 0) return null;
-	const unique = new Set(values.values());
-	if (unique.size > 1) return null;
-	for (const key of SESSION_ID_KEYS) {
-		const value = values.get(key);
-		if (value) return value;
-	}
-	return null;
-}
 
 async function readStdinJson(): Promise<Record<string, unknown>> {
 	const chunks: Buffer[] = [];
@@ -47,69 +27,35 @@ function emitStructuredError(errorCode: string, message: string): void {
 	process.exitCode = 1;
 }
 
+interface EnqueueRawEventDependencies {
+	readPayload?: () => Promise<Record<string, unknown>>;
+}
+
+export async function runEnqueueRawEvent(
+	opts: DbOpts,
+	dependencies: EnqueueRawEventDependencies = {},
+): Promise<void> {
+	try {
+		const payload = await (dependencies.readPayload ?? readStdinJson)();
+		const dbPath = resolveDbPath(resolveDbOpt(opts));
+		const store = new MemoryStore(dbPath);
+		try {
+			ingestRawEvents(store, payload);
+		} finally {
+			store.close();
+		}
+	} catch (err) {
+		emitStructuredError(
+			err instanceof RawEventIngestValidationError ? "validation_error" : "enqueue_error",
+			err instanceof Error ? err.message : String(err),
+		);
+	}
+}
+
 const enqueueCmd = new Command("enqueue-raw-event")
 	.configureHelp(helpStyle)
 	.description("Enqueue one raw event from stdin into the durable queue");
 
 addDbOption(enqueueCmd);
 
-export const enqueueRawEventCommand = enqueueCmd.action(async (opts: DbOpts) => {
-	try {
-		const payload = await readStdinJson();
-		const sessionId = resolveSessionStreamId(payload);
-		if (!sessionId) {
-			emitStructuredError("validation_error", "session id required");
-			return;
-		}
-		if (sessionId.startsWith("msg_")) {
-			emitStructuredError("validation_error", "invalid session id");
-			return;
-		}
-
-		const eventType = typeof payload.event_type === "string" ? payload.event_type.trim() : "";
-		if (!eventType) {
-			emitStructuredError("validation_error", "event_type required");
-			return;
-		}
-
-		const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
-		const project = typeof payload.project === "string" ? payload.project : null;
-		const startedAt = typeof payload.started_at === "string" ? payload.started_at : null;
-		const tsWallMs = Number.isFinite(Number(payload.ts_wall_ms))
-			? Math.floor(Number(payload.ts_wall_ms))
-			: null;
-		const tsMonoMs = Number.isFinite(Number(payload.ts_mono_ms))
-			? Number(payload.ts_mono_ms)
-			: null;
-		const eventId = typeof payload.event_id === "string" ? payload.event_id.trim() : "";
-		const eventPayload =
-			payload.payload && typeof payload.payload === "object" && !Array.isArray(payload.payload)
-				? (stripPrivateObj(payload.payload) as Record<string, unknown>)
-				: {};
-
-		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
-		try {
-			store.updateRawEventSessionMeta({
-				opencodeSessionId: sessionId,
-				source: "opencode",
-				cwd,
-				project,
-				startedAt,
-				lastSeenTsWallMs: tsWallMs,
-			});
-			store.recordRawEventsBatch(sessionId, [
-				{
-					event_id: eventId,
-					event_type: eventType,
-					payload: eventPayload,
-					ts_wall_ms: tsWallMs,
-					ts_mono_ms: tsMonoMs,
-				},
-			]);
-		} finally {
-			store.close();
-		}
-	} catch (err) {
-		emitStructuredError("enqueue_error", err instanceof Error ? err.message : String(err));
-	}
-});
+export const enqueueRawEventCommand = enqueueCmd.action((opts: DbOpts) => runEnqueueRawEvent(opts));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -632,6 +632,7 @@ export {
 export * from "./prompt-pack-ledger.js";
 export type { FlushRawEventsOptions } from "./raw-event-flush.js";
 export { buildSessionContext, flushRawEvents } from "./raw-event-flush.js";
+export * from "./raw-event-ingest.js";
 export { RawEventSweeper } from "./raw-event-sweeper.js";
 export type {
 	RecipientPolicyAuthorityV1,

--- a/packages/core/src/raw-event-ingest.test.ts
+++ b/packages/core/src/raw-event-ingest.test.ts
@@ -1,0 +1,463 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import { ingestRawEvents, RawEventIngestValidationError } from "./raw-event-ingest.js";
+import { MemoryStore } from "./store.js";
+import { initTestSchema } from "./test-utils.js";
+
+const cleanupPaths: string[] = [];
+
+function createStore(): MemoryStore {
+	return new MemoryStore(createDbPath());
+}
+
+function createDbPath(): string {
+	const dir = mkdtempSync(join(tmpdir(), "codemem-raw-event-ingest-"));
+	cleanupPaths.push(dir);
+	const dbPath = join(dir, "test.sqlite");
+	const db = connect(dbPath);
+	initTestSchema(db);
+	db.close();
+	return dbPath;
+}
+
+function persistedRows(store: MemoryStore): unknown[] {
+	return store.db
+		.prepare(
+			`SELECT source, stream_id, opencode_session_id, event_id, event_seq,
+				event_type, ts_wall_ms, ts_mono_ms, payload_json
+			 FROM raw_events ORDER BY source, stream_id, event_seq`,
+		)
+		.all();
+}
+
+afterEach(() => {
+	for (const path of cleanupPaths.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("ingestRawEvents", () => {
+	it("matches the current MemoryStore batch and metadata persistence behavior", () => {
+		const directStore = createStore();
+		const referenceStore = createStore();
+		try {
+			const event = {
+				source: "OpenCode",
+				session_stream_id: "session-equivalent",
+				session_id: "session-equivalent",
+				event_id: "event-equivalent-1",
+				event_type: "prompt",
+				ts_wall_ms: 1_786_742_400_000,
+				ts_mono_ms: 42.5,
+				payload: { text: "same row" },
+				cwd: "/tmp/project",
+				project: "project",
+			};
+
+			const direct = ingestRawEvents(directStore, event);
+			const reference = referenceStore.recordRawEventsBatch("session-equivalent", [event]);
+			referenceStore.updateRawEventSessionMeta({
+				opencodeSessionId: "session-equivalent",
+				cwd: event.cwd,
+				project: event.project,
+				lastSeenTsWallMs: event.ts_wall_ms,
+			});
+
+			expect(direct).toEqual({
+				...reference,
+				received: 1,
+				sessions: [{ source: "opencode", streamId: "session-equivalent" }],
+			});
+			expect(persistedRows(directStore)).toEqual(persistedRows(referenceStore));
+			const session = directStore.db
+				.prepare(
+					`SELECT source, stream_id, cwd, project, last_seen_ts_wall_ms,
+						last_received_event_seq
+					 FROM raw_event_sessions`,
+				)
+				.get();
+			expect(session).toEqual({
+				source: "opencode",
+				stream_id: "session-equivalent",
+				cwd: "/tmp/project",
+				project: "project",
+				last_seen_ts_wall_ms: 1_786_742_400_000,
+				last_received_event_seq: 0,
+			});
+		} finally {
+			directStore.close();
+			referenceStore.close();
+		}
+	});
+
+	it("reports duplicate retries as skipped without allocating another sequence", () => {
+		const store = createStore();
+		try {
+			const base = {
+				source: "codex",
+				session_id: "session-dedup",
+				event_id: "event-dedup-1",
+				event_type: "codex.hook",
+				payload: { value: 1 },
+			};
+			expect(ingestRawEvents(store, base).inserted).toBe(1);
+			expect(ingestRawEvents(store, base)).toMatchObject({ inserted: 0, skipped: 1 });
+			expect(ingestRawEvents(store, { ...base, event_id: "event-dedup-2" })).toMatchObject({
+				inserted: 1,
+				skipped: 0,
+			});
+
+			const rows = store.db
+				.prepare("SELECT event_id, event_seq FROM raw_events ORDER BY event_seq")
+				.all() as Array<{ event_id: string; event_seq: number }>;
+			expect(rows).toEqual([
+				{ event_id: "event-dedup-1", event_seq: 0 },
+				{ event_id: "event-dedup-2", event_seq: 1 },
+			]);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("deduplicates candidate ids across bounded query chunks", () => {
+		const store = createStore();
+		try {
+			const events = Array.from({ length: 501 }, (_, index) => ({
+				event_id: `event-chunk-${index.toString().padStart(4, "0")}`,
+				event_type: "tool_call",
+				payload: { index },
+			}));
+			expect(
+				ingestRawEvents(store, {
+					source: "opencode",
+					session_id: "session-chunks",
+					events,
+				}),
+			).toMatchObject({ inserted: 501, skipped: 0 });
+			expect(
+				ingestRawEvents(store, {
+					source: "opencode",
+					session_id: "session-chunks",
+					events,
+				}),
+			).toMatchObject({ inserted: 0, skipped: 501 });
+		} finally {
+			store.close();
+		}
+	});
+
+	it("uses supplied sequences only for legacy identity and assigns contiguous DB sequences", () => {
+		const store = createStore();
+		try {
+			const numeric = ingestRawEvents(store, {
+				source: "opencode",
+				session_id: "session-sequences",
+				event_type: "prompt",
+				event_seq: 7,
+				payload: { text: "supplied" },
+			});
+			const string = ingestRawEvents(store, {
+				source: "opencode",
+				session_id: "session-sequences",
+				event_type: "prompt",
+				event_seq: "7",
+				payload: { text: "supplied" },
+			});
+			ingestRawEvents(store, {
+				source: "opencode",
+				session_id: "session-sequences",
+				event_id: "event-sequence-next",
+				event_type: "assistant",
+				payload: { text: "next" },
+			});
+
+			const rows = store.db
+				.prepare("SELECT event_id, event_seq FROM raw_events ORDER BY event_seq")
+				.all() as Array<{ event_id: string; event_seq: number }>;
+			expect(numeric).toMatchObject({ inserted: 1, skipped: 0 });
+			expect(string).toMatchObject({ inserted: 0, skipped: 1 });
+			expect(rows).toHaveLength(2);
+			expect(rows[0]).toMatchObject({ event_seq: 0 });
+			expect(rows[0]?.event_id).toMatch(/^legacy-seq-7-/);
+			expect(rows[1]).toEqual({ event_id: "event-sequence-next", event_seq: 1 });
+		} finally {
+			store.close();
+		}
+	});
+
+	it("assigns unique contiguous sequences across two connections", () => {
+		const dbPath = createDbPath();
+		const firstStore = new MemoryStore(dbPath);
+		const secondStore = new MemoryStore(dbPath);
+		try {
+			ingestRawEvents(firstStore, {
+				source: "claude",
+				session_id: "session-two-connections",
+				event_id: "cld_evt_first0001",
+				event_type: "claude.hook",
+				payload: {},
+			});
+			ingestRawEvents(secondStore, {
+				source: "claude",
+				session_id: "session-two-connections",
+				event_id: "cld_evt_second002",
+				event_type: "claude.hook",
+				payload: {},
+			});
+
+			const rows = firstStore.db
+				.prepare("SELECT event_id, event_seq FROM raw_events ORDER BY event_seq")
+				.all() as Array<{ event_id: string; event_seq: number }>;
+			expect(rows).toEqual([
+				{ event_id: "cld_evt_first0001", event_seq: 0 },
+				{ event_id: "cld_evt_second002", event_seq: 1 },
+			]);
+		} finally {
+			firstStore.close();
+			secondStore.close();
+		}
+	});
+
+	it.each([
+		{
+			source: "claude",
+			eventId: "cld_evt_0123456789abcdef01234567",
+			eventType: "claude.hook",
+		},
+		{
+			source: "codex",
+			eventId: "cdx_evt_0123456789abcdef01234567",
+			eventType: "codex.hook",
+		},
+		{
+			source: "opencode",
+			eventId: "oc:session.fixture:tool_call:0123456789abcdef0123",
+			eventType: "tool_call",
+		},
+	])("accepts real $source adapter event id and type forms", ({ source, eventId, eventType }) => {
+		const store = createStore();
+		try {
+			expect(
+				ingestRawEvents(store, {
+					source,
+					session_id: `session-${source}-fixture`,
+					event_id: eventId,
+					event_type: eventType,
+					payload: {},
+				}),
+			).toMatchObject({ inserted: 1, skipped: 0 });
+		} finally {
+			store.close();
+		}
+	});
+
+	it.each([
+		"tool.execute.after",
+		"message.part.updated",
+		"session.idle",
+	])("accepts OpenCode wire event type %s", (eventType) => {
+		const store = createStore();
+		try {
+			expect(
+				ingestRawEvents(store, {
+					source: "opencode",
+					session_id: "session-opencode-wire-types",
+					event_id: `event-${eventType}`,
+					event_type: eventType,
+					payload: {},
+				}),
+			).toMatchObject({ inserted: 1, skipped: 0 });
+		} finally {
+			store.close();
+		}
+	});
+
+	it("accepts legacy signed and zero-padded integer sequences without trusting them", () => {
+		const store = createStore();
+		try {
+			const first = ingestRawEvents(store, {
+				source: "opencode",
+				session_id: "session-legacy-sequences",
+				event_type: "message.updated",
+				event_seq: "-1",
+				payload: { text: "first" },
+			});
+			const second = ingestRawEvents(store, {
+				source: "opencode",
+				session_id: "session-legacy-sequences",
+				event_type: "message.updated",
+				event_seq: "07",
+				payload: { text: "second" },
+			});
+			expect({ first, second }).toMatchObject({
+				first: { inserted: 1 },
+				second: { inserted: 1 },
+			});
+			const rows = store.db
+				.prepare("SELECT event_id, event_seq FROM raw_events ORDER BY event_seq")
+				.all() as Array<{ event_id: string; event_seq: number }>;
+			expect(rows.map((row) => row.event_seq)).toEqual([0, 1]);
+			expect(rows[0]?.event_id).toMatch(/^legacy-seq--1-/);
+			expect(rows[1]?.event_id).toMatch(/^legacy-seq-7-/);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("supports per-event stream overrides with event metadata taking precedence", () => {
+		const store = createStore();
+		try {
+			ingestRawEvents(store, {
+				source: "codex",
+				stream_id: "stream-default",
+				cwd: "/request",
+				project: "request-project",
+				events: [
+					{
+						event_id: "cdx_evt_default001",
+						event_type: "codex.hook",
+						payload: {},
+						cwd: "/event",
+						project: "event-project",
+					},
+					{
+						stream_id: "stream-override",
+						event_id: "cdx_evt_override01",
+						event_type: "codex.hook",
+						payload: {},
+					},
+				],
+			});
+
+			const sessions = store.db
+				.prepare("SELECT stream_id, cwd, project FROM raw_event_sessions ORDER BY stream_id")
+				.all();
+			expect(sessions).toEqual([
+				{ stream_id: "stream-default", cwd: "/event", project: "event-project" },
+				{ stream_id: "stream-override", cwd: null, project: null },
+			]);
+		} finally {
+			store.close();
+		}
+	});
+
+	it.each(["claude", "codex"])("starts a fresh %s stream at sequence zero", (source) => {
+		const store = createStore();
+		try {
+			ingestRawEvents(store, {
+				source,
+				session_id: `session-${source}`,
+				event_id: `event-${source}-first`,
+				event_type: `${source}.hook`,
+				payload: {},
+			});
+			const row = store.db.prepare("SELECT event_seq FROM raw_events").get() as {
+				event_seq: number;
+			};
+			expect(row.event_seq).toBe(0);
+		} finally {
+			store.close();
+		}
+	});
+
+	it.each([
+		{
+			name: "a malformed source",
+			request: {
+				source: "../claude",
+				session_id: "session-invalid",
+				event_id: "event-invalid-source",
+				event_type: "prompt",
+				payload: {},
+			},
+		},
+		{
+			name: "conflicting session aliases",
+			request: {
+				source: "claude",
+				session_id: "session-one",
+				stream_id: "session-two",
+				event_id: "event-invalid-session",
+				event_type: "prompt",
+				payload: {},
+			},
+		},
+		{
+			name: "a malformed event id",
+			request: {
+				source: "claude",
+				session_id: "session-invalid",
+				event_id: "contains spaces",
+				event_type: "prompt",
+				payload: {},
+			},
+		},
+		{
+			name: "a malformed supplied sequence",
+			request: {
+				source: "opencode",
+				session_id: "session-invalid",
+				event_id: "event-invalid-sequence",
+				event_type: "prompt",
+				event_seq: " ",
+				payload: {},
+			},
+		},
+	])("rejects $name before any writes", ({ request }) => {
+		const store = createStore();
+		try {
+			expect(() => ingestRawEvents(store, request)).toThrow(RawEventIngestValidationError);
+			const rawCount = store.db.prepare("SELECT COUNT(*) AS count FROM raw_events").get() as {
+				count: number;
+			};
+			const sessionCount = store.db
+				.prepare("SELECT COUNT(*) AS count FROM raw_event_sessions")
+				.get() as { count: number };
+			const statsCount = store.db
+				.prepare("SELECT COUNT(*) AS count FROM raw_event_ingest_stats")
+				.get() as { count: number };
+			expect({
+				raw: rawCount.count,
+				sessions: sessionCount.count,
+				stats: statsCount.count,
+			}).toEqual({
+				raw: 0,
+				sessions: 0,
+				stats: 0,
+			});
+		} finally {
+			store.close();
+		}
+	});
+
+	it("strips private content and redacts sensitive fields before persistence", () => {
+		const store = createStore();
+		try {
+			ingestRawEvents(store, {
+				source: "claude",
+				session_id: "session-private",
+				event_id: "event-private-1",
+				event_type: "assistant",
+				payload: {
+					text: "public <private>do not persist</private> visible",
+					api_key: "do-not-persist",
+					nested: { password: "also-private" },
+				},
+			});
+			const row = store.db.prepare("SELECT payload_json FROM raw_events").get() as {
+				payload_json: string;
+			};
+			const payload = JSON.parse(row.payload_json) as Record<string, unknown>;
+			expect(payload).toEqual({
+				text: "public  visible",
+				api_key: "[REDACTED]",
+				nested: { password: "[REDACTED]" },
+			});
+			expect(row.payload_json).not.toContain("do not persist");
+			expect(row.payload_json).not.toContain("also-private");
+		} finally {
+			store.close();
+		}
+	});
+});

--- a/packages/core/src/raw-event-ingest.ts
+++ b/packages/core/src/raw-event-ingest.ts
@@ -1,0 +1,418 @@
+import { createHash } from "node:crypto";
+import type { Database } from "./db.js";
+import { stripPrivateObj } from "./ingest-sanitize.js";
+
+const SESSION_ID_KEYS = [
+	"session_stream_id",
+	"session_id",
+	"stream_id",
+	"opencode_session_id",
+] as const;
+const SOURCE_PATTERN = /^[a-z][a-z0-9._-]*$/;
+const EVENT_FIELD_PATTERN = /^[A-Za-z0-9._:-]+$/;
+const MAX_SOURCE_LENGTH = 64;
+const MAX_EVENT_FIELD_LENGTH = 128;
+
+export interface RawEventIngestStore {
+	db: Database;
+}
+
+export interface RawEventIngestSession {
+	source: string;
+	streamId: string;
+}
+
+export interface RawEventIngestResult {
+	inserted: number;
+	skipped: number;
+	received: number;
+	sessions: RawEventIngestSession[];
+}
+
+interface NormalizedEvent {
+	streamId: string;
+	eventId: string;
+	eventType: string;
+	payload: Record<string, unknown>;
+	tsWallMs: number | null;
+	tsMonoMs: number | null;
+	cwd: string | null;
+	project: string | null;
+	startedAt: string | null;
+}
+
+interface NormalizedRequest {
+	source: string;
+	defaultStreamId: string | null;
+	events: NormalizedEvent[];
+	received: number;
+	requestMeta: Pick<NormalizedEvent, "cwd" | "project" | "startedAt">;
+}
+
+export class RawEventIngestValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "RawEventIngestValidationError";
+	}
+}
+
+function validationError(message: string): never {
+	throw new RawEventIngestValidationError(message);
+}
+
+function normalizeSource(value: unknown): string {
+	if (value == null) return "opencode";
+	if (typeof value !== "string") validationError("source must be string");
+	const source = value.trim().toLowerCase();
+	if (!source) validationError("source is required");
+	if (source.length > MAX_SOURCE_LENGTH || !SOURCE_PATTERN.test(source)) {
+		validationError("source must use 1-64 letters, digits, dots, underscores, or hyphens");
+	}
+	return source;
+}
+
+function resolveStreamId(value: Record<string, unknown>): string | null {
+	const aliases = new Map<string, string>();
+	for (const key of SESSION_ID_KEYS) {
+		const raw = value[key];
+		if (raw == null) continue;
+		if (typeof raw !== "string") validationError(`${key} must be string`);
+		const normalized = raw.trim();
+		if (normalized) aliases.set(key, normalized);
+	}
+	if (aliases.size === 0) return null;
+	if (new Set(aliases.values()).size !== 1) validationError("conflicting session id fields");
+	const streamId = aliases.values().next().value;
+	if (!streamId) return null;
+	if (streamId.startsWith("msg_")) validationError("invalid session id");
+	return streamId;
+}
+
+function optionalString(value: Record<string, unknown>, key: string): string | null {
+	const raw = value[key];
+	if (raw == null) return null;
+	if (typeof raw !== "string") validationError(`${key} must be string`);
+	return raw || null;
+}
+
+function optionalNumber(value: Record<string, unknown>, key: string): number | null {
+	const raw = value[key];
+	if (raw == null) return null;
+	if (typeof raw !== "number" && typeof raw !== "string") {
+		validationError(`${key} must be number`);
+	}
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed)) validationError(`${key} must be number`);
+	return parsed;
+}
+
+function optionalEventSeq(value: Record<string, unknown>): number | null {
+	const raw = value.event_seq;
+	if (raw == null) return null;
+	if (typeof raw !== "number" && typeof raw !== "string") {
+		validationError("event_seq must be int");
+	}
+	if (typeof raw === "string" && !/^-?\d+$/.test(raw)) {
+		validationError("event_seq must be int");
+	}
+	const parsed = Number(raw);
+	if (!Number.isSafeInteger(parsed)) validationError("event_seq must be int");
+	return parsed;
+}
+
+function validateEventField(value: unknown, field: "event_id" | "event_type"): string {
+	if (typeof value !== "string") validationError(`${field} must be string`);
+	const normalized = value.trim();
+	if (!normalized) validationError(`${field} required`);
+	if (normalized.length > MAX_EVENT_FIELD_LENGTH || !EVENT_FIELD_PATTERN.test(normalized)) {
+		validationError(`${field} has invalid syntax`);
+	}
+	return normalized;
+}
+
+function stableStringify(value: unknown): string {
+	return (
+		JSON.stringify(value, (_key, item) => {
+			if (item == null || typeof item !== "object" || Array.isArray(item)) return item;
+			const sorted: Record<string, unknown> = {};
+			for (const key of Object.keys(item as Record<string, unknown>).sort()) {
+				sorted[key] = (item as Record<string, unknown>)[key];
+			}
+			return sorted;
+		}) ?? ""
+	);
+}
+
+/** Legacy normalized senders may omit event_id until Viewer ingress migrates in PR 3. */
+function generatedEventId(
+	eventType: string,
+	payload: Record<string, unknown>,
+	eventSeq: number | null,
+	tsWallMs: number | null,
+	tsMonoMs: number | null,
+): string {
+	const seed =
+		eventSeq == null
+			? { m: tsMonoMs, p: payload, t: eventType, w: tsWallMs }
+			: { p: payload, s: eventSeq, t: eventType };
+	const digest = createHash("sha256")
+		.update(stableStringify(seed), "utf8")
+		.digest("hex")
+		.slice(0, 16);
+	return eventSeq == null ? `legacy-${digest}` : `legacy-seq-${eventSeq}-${digest}`;
+}
+
+function normalizeEvent(
+	item: Record<string, unknown>,
+	defaultStreamId: string | null,
+	source: string,
+): NormalizedEvent {
+	if (item.source != null && normalizeSource(item.source) !== source) {
+		validationError("event source conflicts with request source");
+	}
+	const streamId = resolveStreamId(item) ?? defaultStreamId;
+	if (!streamId) validationError("session id required");
+	const eventType = validateEventField(item.event_type, "event_type");
+	const eventSeq = optionalEventSeq(item);
+	const tsWallMsValue = optionalNumber(item, "ts_wall_ms");
+	const tsWallMs = tsWallMsValue == null ? null : Math.floor(tsWallMsValue);
+	const tsMonoMs = optionalNumber(item, "ts_mono_ms");
+	const rawPayload = item.payload ?? {};
+	if (typeof rawPayload !== "object" || Array.isArray(rawPayload)) {
+		validationError("payload must be an object");
+	}
+	const payload = stripPrivateObj(rawPayload) as Record<string, unknown>;
+	const rawEventId = item.event_id;
+	const eventId =
+		rawEventId == null || rawEventId === ""
+			? generatedEventId(eventType, payload, eventSeq, tsWallMs, tsMonoMs)
+			: validateEventField(rawEventId, "event_id");
+	return {
+		streamId,
+		eventId,
+		eventType,
+		payload,
+		tsWallMs,
+		tsMonoMs,
+		cwd: optionalString(item, "cwd"),
+		project: optionalString(item, "project"),
+		startedAt: optionalString(item, "started_at"),
+	};
+}
+
+function normalizeRequest(request: Record<string, unknown>): NormalizedRequest {
+	const source = normalizeSource(request.source);
+	const defaultStreamId = resolveStreamId(request);
+	const rawEvents = request.events == null ? [request] : request.events;
+	if (!Array.isArray(rawEvents)) validationError("events must be a list");
+	const events: NormalizedEvent[] = [];
+	for (const rawEvent of rawEvents) {
+		if (rawEvent == null || typeof rawEvent !== "object" || Array.isArray(rawEvent)) {
+			validationError("event must be an object");
+		}
+		events.push(normalizeEvent(rawEvent as Record<string, unknown>, defaultStreamId, source));
+	}
+	return {
+		source,
+		defaultStreamId,
+		events,
+		received: rawEvents.length,
+		requestMeta: {
+			cwd: optionalString(request, "cwd"),
+			project: optionalString(request, "project"),
+			startedAt: optionalString(request, "started_at"),
+		},
+	};
+}
+
+function persistStream(
+	store: RawEventIngestStore,
+	source: string,
+	streamId: string,
+	events: NormalizedEvent[],
+	request: NormalizedRequest,
+	singleStream: boolean,
+): { inserted: number; skippedDuplicate: number } {
+	let skippedDuplicate = 0;
+	const seenIds = new Set<string>();
+	const uniqueCandidates = events.filter((event) => {
+		if (seenIds.has(event.eventId)) {
+			skippedDuplicate++;
+			return false;
+		}
+		seenIds.add(event.eventId);
+		return true;
+	});
+	const existingIds = new Set<string>();
+	for (let offset = 0; offset < uniqueCandidates.length; offset += 500) {
+		const eventIds = uniqueCandidates.slice(offset, offset + 500).map((event) => event.eventId);
+		const placeholders = eventIds.map(() => "?").join(", ");
+		const rows = store.db
+			.prepare(
+				`SELECT event_id FROM raw_events
+				 WHERE source = ? AND stream_id = ? AND event_id IN (${placeholders})`,
+			)
+			.all(source, streamId, ...eventIds) as Array<{ event_id: string | null }>;
+		for (const row of rows) {
+			if (row.event_id) existingIds.add(row.event_id);
+		}
+	}
+	const candidates = uniqueCandidates.filter((event) => !existingIds.has(event.eventId));
+	skippedDuplicate += uniqueCandidates.length - candidates.length;
+
+	const sessionRow = store.db
+		.prepare(
+			"SELECT last_received_event_seq FROM raw_event_sessions WHERE source = ? AND stream_id = ?",
+		)
+		.get(source, streamId) as { last_received_event_seq: number } | undefined;
+	const maxRow = store.db
+		.prepare(
+			"SELECT MAX(event_seq) AS max_event_seq FROM raw_events WHERE source = ? AND stream_id = ?",
+		)
+		.get(source, streamId) as { max_event_seq: number | null };
+	let lastReceived = Math.max(
+		Number(sessionRow?.last_received_event_seq ?? -1),
+		Number(maxRow.max_event_seq ?? -1),
+	);
+
+	const now = new Date().toISOString();
+	const insertEvent = store.db.prepare(
+		`INSERT INTO raw_events(
+			source, stream_id, opencode_session_id, event_id, event_seq,
+			event_type, ts_wall_ms, ts_mono_ms, payload_json, created_at
+		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	);
+	let inserted = 0;
+	for (const event of candidates) {
+		const assignedSeq = lastReceived + 1;
+		insertEvent.run(
+			source,
+			streamId,
+			streamId,
+			event.eventId,
+			assignedSeq,
+			event.eventType,
+			event.tsWallMs,
+			event.tsMonoMs,
+			JSON.stringify(event.payload),
+			now,
+		);
+		inserted++;
+		lastReceived = assignedSeq;
+	}
+
+	const applyRequestMeta = singleStream || request.defaultStreamId === streamId;
+	const eventMeta = events.reduce(
+		(meta, event) => ({
+			cwd: event.cwd ?? meta.cwd,
+			project: event.project ?? meta.project,
+			startedAt: event.startedAt ?? meta.startedAt,
+		}),
+		{ cwd: null, project: null, startedAt: null } as Pick<
+			NormalizedEvent,
+			"cwd" | "project" | "startedAt"
+		>,
+	);
+	const cwd = eventMeta.cwd ?? (applyRequestMeta ? request.requestMeta.cwd : null);
+	const project = eventMeta.project ?? (applyRequestMeta ? request.requestMeta.project : null);
+	const startedAt =
+		eventMeta.startedAt ?? (applyRequestMeta ? request.requestMeta.startedAt : null);
+	const lastSeen = events.reduce<number | null>(
+		(max, event) =>
+			event.tsWallMs == null ? max : Math.max(max ?? event.tsWallMs, event.tsWallMs),
+		null,
+	);
+	store.db
+		.prepare(
+			`INSERT INTO raw_event_sessions(
+				source, stream_id, opencode_session_id, cwd, project, started_at,
+				last_seen_ts_wall_ms, last_received_event_seq, last_flushed_event_seq, updated_at
+			 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, -1, ?)
+			 ON CONFLICT(source, stream_id) DO UPDATE SET
+				opencode_session_id = excluded.opencode_session_id,
+				cwd = COALESCE(excluded.cwd, raw_event_sessions.cwd),
+				project = COALESCE(excluded.project, raw_event_sessions.project),
+				started_at = COALESCE(excluded.started_at, raw_event_sessions.started_at),
+				last_seen_ts_wall_ms = CASE
+					WHEN excluded.last_seen_ts_wall_ms IS NULL THEN raw_event_sessions.last_seen_ts_wall_ms
+					WHEN raw_event_sessions.last_seen_ts_wall_ms IS NULL THEN excluded.last_seen_ts_wall_ms
+					ELSE MAX(excluded.last_seen_ts_wall_ms, raw_event_sessions.last_seen_ts_wall_ms)
+				END,
+				last_received_event_seq = MAX(
+					excluded.last_received_event_seq,
+					raw_event_sessions.last_received_event_seq
+				),
+				updated_at = excluded.updated_at`,
+		)
+		.run(source, streamId, streamId, cwd, project, startedAt, lastSeen, lastReceived, now);
+	return { inserted, skippedDuplicate };
+}
+
+function recordIngestOutcome(
+	store: RawEventIngestStore,
+	inserted: number,
+	skippedDuplicate: number,
+): void {
+	const now = new Date().toISOString();
+	const skipped = skippedDuplicate;
+	store.db
+		.prepare(
+			`INSERT INTO raw_event_ingest_samples(
+				created_at, inserted_events, skipped_invalid, skipped_duplicate, skipped_conflict
+			 ) VALUES (?, ?, 0, ?, ?)`,
+		)
+		.run(now, inserted, skippedDuplicate, 0);
+	store.db
+		.prepare(
+			`INSERT INTO raw_event_ingest_stats(
+				id, inserted_events, skipped_events, skipped_invalid,
+				skipped_duplicate, skipped_conflict, updated_at
+			 ) VALUES (1, ?, ?, 0, ?, ?, ?)
+			 ON CONFLICT(id) DO UPDATE SET
+				inserted_events = raw_event_ingest_stats.inserted_events + excluded.inserted_events,
+				skipped_events = raw_event_ingest_stats.skipped_events + excluded.skipped_events,
+				skipped_invalid = raw_event_ingest_stats.skipped_invalid + excluded.skipped_invalid,
+				skipped_duplicate = raw_event_ingest_stats.skipped_duplicate + excluded.skipped_duplicate,
+				skipped_conflict = raw_event_ingest_stats.skipped_conflict + excluded.skipped_conflict,
+				updated_at = excluded.updated_at`,
+		)
+		.run(inserted, skipped, skippedDuplicate, 0, now);
+}
+
+export function ingestRawEvents(store: RawEventIngestStore, request: object): RawEventIngestResult {
+	const normalized = normalizeRequest(request as Record<string, unknown>);
+	return store.db
+		.transaction(() => {
+			const byStream = new Map<string, NormalizedEvent[]>();
+			for (const event of normalized.events) {
+				const events = byStream.get(event.streamId) ?? [];
+				events.push(event);
+				byStream.set(event.streamId, events);
+			}
+			let inserted = 0;
+			let skippedDuplicate = 0;
+			const sessions: RawEventIngestSession[] = [];
+			const singleStream = byStream.size === 1;
+			for (const [streamId, events] of byStream) {
+				const result = persistStream(
+					store,
+					normalized.source,
+					streamId,
+					events,
+					normalized,
+					singleStream,
+				);
+				inserted += result.inserted;
+				skippedDuplicate += result.skippedDuplicate;
+				sessions.push({ source: normalized.source, streamId });
+			}
+			recordIngestOutcome(store, inserted, skippedDuplicate);
+			return {
+				inserted,
+				skipped: skippedDuplicate,
+				received: normalized.received,
+				sessions,
+			};
+		})
+		.immediate();
+}


### PR DESCRIPTION
## Description

Adds canonical, source-aware raw-event ingestion in core. The shared contract normalizes supported adapter events while preserving `POST /api/raw-events` as the sole canonical ingress endpoint.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run check` at the validated stack tip)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected — automated coverage used

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] Documentation updated or not required
- [x] No new warnings introduced