### PR TITLE
feat(viewer): add source-aware normalized ingress

### DIFF
--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -373,6 +373,7 @@ export interface ApiRawEventsStatusResponse {
  */
 export interface ApiRawEventsPostResponse {
 	inserted: number;
+	skipped: number;
 	received: number;
 }
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -221,6 +221,25 @@ function postViewerJson(app: ReturnType<typeof createApp>, path: string, body: u
 	});
 }
 
+function rawEventState(store: MemoryStore): { events: unknown[]; sessions: unknown[] } {
+	return {
+		events: store.db
+			.prepare(
+				`SELECT source, stream_id, opencode_session_id, event_id, event_seq,
+					event_type, ts_wall_ms, ts_mono_ms, payload_json
+				 FROM raw_events ORDER BY source, stream_id, event_seq`,
+			)
+			.all(),
+		sessions: store.db
+			.prepare(
+				`SELECT source, stream_id, opencode_session_id, cwd, project, started_at,
+					last_seen_ts_wall_ms, last_received_event_seq, last_flushed_event_seq
+				 FROM raw_event_sessions ORDER BY source, stream_id`,
+			)
+			.all(),
+	};
+}
+
 function createAuthenticatedSyncPeer(
 	store: MemoryStore,
 	input: {
@@ -480,6 +499,341 @@ describe("viewer-server", () => {
 				if (previousValue == null) delete process.env[envName];
 				else process.env[envName] = previousValue;
 				rmSync(parent, { recursive: true, force: true });
+			}
+		});
+	});
+
+	describe("raw event HTTP ingestion", () => {
+		it("defaults omitted source to opencode and returns exactly the canonical result fields", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const response = await postViewerJson(app, "/api/raw-events", {
+					session_id: "session-omitted-source",
+					event_id: "event-omitted-source",
+					event_type: "prompt",
+					payload: { text: "hello" },
+				});
+
+				expect(response.status).toBe(200);
+				expect(await response.json()).toEqual({
+					inserted: 1,
+					skipped: 0,
+					received: 1,
+				});
+				expect(rawEventState(ensureStore()).events).toMatchObject([
+					{ source: "opencode", stream_id: "session-omitted-source" },
+				]);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects an oversized streaming body without Content-Length before writes", async () => {
+			const cancel = vi.fn();
+			const body = new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(new Uint8Array(1_048_577));
+				},
+				cancel,
+			});
+			type StreamingRequestInit = RequestInit & { duplex: "half" };
+			const request = new Request("http://localhost/api/raw-events", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Origin: "http://127.0.0.1:38888",
+				},
+				body,
+				duplex: "half",
+			} as StreamingRequestInit);
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				expect(request.headers.has("content-length")).toBe(false);
+				const response = await app.fetch(request);
+
+				expect(response.status).toBe(413);
+				expect(await response.json()).toEqual({
+					error: "payload too large",
+					max_bytes: 1_048_576,
+				});
+				expect(cancel).toHaveBeenCalledOnce();
+				expect(rawEventState(ensureStore())).toEqual({ events: [], sessions: [] });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("keeps identical stream and event ids separate by source", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				for (const source of ["opencode", "claude", "codex"]) {
+					const response = await postViewerJson(app, "/api/raw-events", {
+						source,
+						session_id: "shared-stream",
+						event_id: "shared-event",
+						event_type: "prompt",
+						payload: { text: "same" },
+					});
+					expect(await response.json()).toEqual({
+						inserted: 1,
+						skipped: 0,
+						received: 1,
+					});
+				}
+
+				expect(rawEventState(ensureStore()).events).toMatchObject([
+					{ source: "claude", stream_id: "shared-stream", event_id: "shared-event" },
+					{ source: "codex", stream_id: "shared-stream", event_id: "shared-event" },
+					{ source: "opencode", stream_id: "shared-stream", event_id: "shared-event" },
+				]);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("reports duplicate skips and nudges every validated session on retries", async () => {
+			const nudge = vi.fn();
+			const { app, cleanup } = createTestApp({ sweeper: { nudge } });
+			const event = {
+				source: "claude",
+				session_id: "session-duplicate",
+				event_id: "event-duplicate",
+				event_type: "claude.hook",
+				payload: {},
+			};
+			try {
+				const first = await postViewerJson(app, "/api/raw-events", event);
+				const duplicate = await postViewerJson(app, "/api/raw-events", event);
+
+				expect(await first.json()).toEqual({ inserted: 1, skipped: 0, received: 1 });
+				expect(await duplicate.json()).toEqual({
+					inserted: 0,
+					skipped: 1,
+					received: 1,
+				});
+				expect(nudge.mock.calls).toEqual([
+					["session-duplicate", "claude"],
+					["session-duplicate", "claude"],
+				]);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("persists multi-stream batches deterministically and nudges streams in first-seen order", async () => {
+			const nudge = vi.fn().mockImplementationOnce(() => {
+				throw new Error("simulated nudge failure");
+			});
+			const { app, ensureStore, cleanup } = createTestApp({ sweeper: { nudge } });
+			try {
+				const response = await postViewerJson(app, "/api/raw-events", {
+					source: "Codex",
+					events: [
+						{
+							session_id: "stream-b",
+							event_id: "event-b-1",
+							event_type: "prompt",
+							payload: { text: "b1" },
+						},
+						{
+							session_id: "stream-a",
+							event_id: "event-a-1",
+							event_type: "prompt",
+							payload: { text: "a1" },
+						},
+						{
+							session_id: "stream-b",
+							event_id: "event-b-2",
+							event_type: "assistant",
+							payload: { text: "b2" },
+						},
+					],
+				});
+
+				expect(await response.json()).toEqual({ inserted: 3, skipped: 0, received: 3 });
+				expect(rawEventState(ensureStore()).events).toMatchObject([
+					{ source: "codex", stream_id: "stream-a", event_id: "event-a-1", event_seq: 0 },
+					{ source: "codex", stream_id: "stream-b", event_id: "event-b-1", event_seq: 0 },
+					{ source: "codex", stream_id: "stream-b", event_id: "event-b-2", event_seq: 1 },
+				]);
+				expect(nudge.mock.calls).toEqual([
+					["stream-b", "codex"],
+					["stream-a", "codex"],
+				]);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it.each([
+			{
+				source: "../claude",
+				error: "source must use 1-64 letters, digits, dots, underscores, or hyphens",
+			},
+			{ source: 42, error: "source must be string" },
+		])("rejects malformed source $source with a bounded error before writes", async ({
+			source,
+			error,
+		}) => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const response = await postViewerJson(app, "/api/raw-events", {
+					source,
+					session_id: "session-invalid-source",
+					event_id: "event-invalid-source",
+					event_type: "prompt",
+					payload: {},
+				});
+
+				expect(response.status).toBe(400);
+				expect(await response.json()).toEqual({ error });
+				expect(rawEventState(ensureStore())).toEqual({ events: [], sessions: [] });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects a conflicting per-event source for the whole batch before writes", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const response = await postViewerJson(app, "/api/raw-events", {
+					source: "claude",
+					session_id: "session-mixed-source",
+					events: [
+						{
+							event_id: "event-valid-first",
+							event_type: "prompt",
+							payload: { text: "must not persist" },
+						},
+						{
+							source: "codex",
+							event_id: "event-conflicting-second",
+							event_type: "assistant",
+							payload: { text: "conflict" },
+						},
+					],
+				});
+
+				expect(response.status).toBe(400);
+				expect(await response.json()).toEqual({
+					error: "event source conflicts with request source",
+				});
+				expect(rawEventState(ensureStore())).toEqual({ events: [], sessions: [] });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it.each([
+			{
+				label: "Claude",
+				route: "/api/claude-hooks",
+				native: {
+					hook_event_name: "UserPromptSubmit",
+					session_id: "session-claude-parity",
+					prompt: "same Claude prompt",
+					ts: "2026-08-15T12:00:00Z",
+					cwd: "/tmp/claude-project",
+					project: "claude-project",
+				},
+				normalize: (payload: Record<string, unknown>) =>
+					core.buildRawEventEnvelopeFromHook(payload, core.TRUSTED_HOOK_MAPPER_OPTIONS),
+			},
+			{
+				label: "Codex",
+				route: "/api/codex-hooks",
+				native: {
+					hook_event_name: "UserPromptSubmit",
+					session_id: "session-codex-parity",
+					prompt: "same Codex prompt",
+					ts: "2026-08-15T12:00:00Z",
+					cwd: "/tmp/codex-project",
+					project: "codex-project",
+				},
+				normalize: (payload: Record<string, unknown>) =>
+					core.buildRawEventEnvelopeFromCodexHook(payload, core.TRUSTED_HOOK_MAPPER_OPTIONS),
+			},
+		])("produces identical rows through canonical and named $label routes", async ({
+			route,
+			native,
+			normalize,
+		}) => {
+			const canonical = createTestApp();
+			const compatibility = createTestApp();
+			try {
+				const envelope = normalize(native);
+				expect(envelope).not.toBeNull();
+
+				const canonicalResponse = await postViewerJson(canonical.app, "/api/raw-events", envelope);
+				const compatibilityResponse = await postViewerJson(compatibility.app, route, native);
+
+				expect(await canonicalResponse.json()).toEqual({
+					inserted: 1,
+					skipped: 0,
+					received: 1,
+				});
+				const compatibilityBody = await compatibilityResponse.json();
+				expect(compatibilityBody).toEqual({ inserted: 1, skipped: 0 });
+				expect(compatibilityBody).not.toHaveProperty("received");
+				expect(rawEventState(canonical.ensureStore())).toEqual(
+					rawEventState(compatibility.ensureStore()),
+				);
+			} finally {
+				canonical.cleanup();
+				compatibility.cleanup();
+			}
+		});
+
+		it.each([
+			"/api/claude-hooks",
+			"/api/codex-hooks",
+		])("returns bounded validation errors without writes on %s", async (route) => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const response = await postViewerJson(app, route, {
+					hook_event_name: "UserPromptSubmit",
+					session_id: "msg_client-controlled",
+					prompt: "must not persist",
+					ts: "2026-08-15T12:00:00Z",
+				});
+				const body = await response.json();
+
+				expect(response.status).toBe(400);
+				expect(body).toEqual({ error: "invalid session id" });
+				expect(body).not.toHaveProperty("received");
+				expect(rawEventState(ensureStore())).toEqual({ events: [], sessions: [] });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it.each([
+			"/api/claude-hooks",
+			"/api/codex-hooks",
+		])("keeps native parse and payload-limit errors bounded on %s", async (route) => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const malformed = await app.request(route, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: "{",
+				});
+				expect(malformed.status).toBe(400);
+				expect(await malformed.json()).toEqual({ error: "invalid json" });
+
+				const oversized = await postViewerJson(app, route, {
+					payload: "x".repeat(1_048_576),
+				});
+				expect(oversized.status).toBe(413);
+				expect(await oversized.json()).toEqual({
+					error: "payload too large",
+					max_bytes: 1_048_576,
+				});
+			} finally {
+				cleanup();
 			}
 		});
 	});

--- a/packages/viewer-server/src/routes/raw-events.ts
+++ b/packages/viewer-server/src/routes/raw-events.ts
@@ -3,15 +3,15 @@
  * POST /api/claude-hooks, POST /api/codex-hooks.
  */
 
-import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { MemoryStore, RawEventSweeper } from "@codemem/core";
 import {
 	buildRawEventEnvelopeFromCodexHook,
 	buildRawEventEnvelopeFromHook,
+	ingestRawEvents,
+	RawEventIngestValidationError,
 	schema,
-	stripPrivateObj,
 } from "@codemem/core";
 import { desc } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -19,9 +19,18 @@ import { Hono } from "hono";
 import { queryInt } from "../helpers.js";
 
 type StoreFactory = () => MemoryStore;
+type JsonResponder = {
+	json: (data: unknown, status?: number) => Response;
+};
 
-const MAX_RAW_EVENTS_BODY_BYTES =
-	Number.parseInt(process.env.CODEMEM_RAW_EVENTS_MAX_BODY_BYTES ?? "", 10) || 1048576;
+const DEFAULT_MAX_RAW_EVENTS_BODY_BYTES = 1_048_576;
+
+function configuredMaxRawEventsBodyBytes(): number {
+	const parsed = Number(process.env.CODEMEM_RAW_EVENTS_MAX_BODY_BYTES?.trim() ?? "");
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_RAW_EVENTS_BODY_BYTES;
+}
+
+const MAX_RAW_EVENTS_BODY_BYTES = configuredMaxRawEventsBodyBytes();
 
 function claudeTranscriptRoot(): string {
 	return join(process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude"), "projects");
@@ -31,45 +40,13 @@ function codexTranscriptRoot(): string {
 	return join(process.env.CODEX_HOME?.trim() || join(homedir(), ".codex"), "sessions");
 }
 
-/** Keys to check (in priority order) when resolving a session stream id. */
-const SESSION_ID_KEYS = [
-	"session_stream_id",
-	"session_id",
-	"stream_id",
-	"opencode_session_id",
-] as const;
-
-/**
- * Resolve a session stream id from a payload object.
- * Checks multiple field aliases. Throws on conflicting values.
- */
-function resolveSessionStreamId(payload: Record<string, unknown>): string | null {
-	const values = new Map<string, string>();
-	for (const key of SESSION_ID_KEYS) {
-		const value = payload[key];
-		if (value == null) continue;
-		if (typeof value !== "string") throw new Error(`${key} must be string`);
-		const text = value.trim();
-		if (text) values.set(key, text);
-	}
-	if (values.size === 0) return null;
-	const unique = new Set(values.values());
-	if (unique.size > 1) throw new Error("conflicting session id fields");
-	// Return the first matching key's value (preserves priority order)
-	for (const key of SESSION_ID_KEYS) {
-		const v = values.get(key);
-		if (v) return v;
-	}
-	return null;
-}
-
 /**
  * Parse and validate a JSON object body, enforcing size limits.
  * Returns the parsed payload or a Hono Response on error.
  */
 async function parseJsonObjectBody(
 	c: {
-		req: { header: (name: string) => string | undefined; text: () => Promise<string> };
+		req: { header: (name: string) => string | undefined; raw: Request };
 		json: (data: unknown, status?: number) => Response;
 	},
 	maxBytes: number,
@@ -81,14 +58,42 @@ async function parseJsonObjectBody(
 	if (contentLength > maxBytes) {
 		return c.json({ error: "payload too large", max_bytes: maxBytes }, 413);
 	}
-	let raw: string;
+	let raw = "";
 	try {
-		raw = await c.req.text();
+		const body = c.req.raw.body;
+		if (body !== null) {
+			const reader = body.getReader();
+			const chunks: Uint8Array[] = [];
+			let totalBytes = 0;
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					totalBytes += value.byteLength;
+					if (totalBytes > maxBytes) {
+						try {
+							await reader.cancel();
+						} catch {
+							// The size rejection is authoritative even if cancellation fails.
+						}
+						return c.json({ error: "payload too large", max_bytes: maxBytes }, 413);
+					}
+					chunks.push(value);
+				}
+			} finally {
+				reader.releaseLock();
+			}
+
+			const bytes = new Uint8Array(totalBytes);
+			let offset = 0;
+			for (const chunk of chunks) {
+				bytes.set(chunk, offset);
+				offset += chunk.byteLength;
+			}
+			raw = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+		}
 	} catch {
 		return c.json({ error: "invalid json" }, 400);
-	}
-	if (Buffer.byteLength(raw, "utf-8") > maxBytes) {
-		return c.json({ error: "payload too large", max_bytes: maxBytes }, 413);
 	}
 	let parsed: unknown;
 	try {
@@ -105,16 +110,71 @@ async function parseJsonObjectBody(
 /** Nudge the sweeper safely — never crashes the caller. */
 function nudgeSweeper(
 	sweeper: RawEventSweeper | null | undefined,
-	sessionIds: Iterable<string>,
-	source = "opencode",
+	sessions: Iterable<{ source: string; streamId: string }>,
 ): void {
-	try {
-		for (const sessionId of sessionIds) {
-			sweeper?.nudge(sessionId, source);
+	for (const session of sessions) {
+		try {
+			sweeper?.nudge(session.streamId, session.source);
+		} catch {
+			// A failed nudge must not block later validated sessions.
 		}
-	} catch {
-		// never crash the request if sweeper nudge fails
 	}
+}
+
+const SAFE_INGEST_VALIDATION_ERRORS = new Set([
+	"source must be string",
+	"source is required",
+	"source must use 1-64 letters, digits, dots, underscores, or hyphens",
+	"session_stream_id must be string",
+	"session_id must be string",
+	"stream_id must be string",
+	"opencode_session_id must be string",
+	"conflicting session id fields",
+	"invalid session id",
+	"event source conflicts with request source",
+	"session id required",
+	"event_type must be string",
+	"event_type required",
+	"event_type has invalid syntax",
+	"event_id must be string",
+	"event_id required",
+	"event_id has invalid syntax",
+	"event_seq must be int",
+	"ts_wall_ms must be number",
+	"ts_mono_ms must be number",
+	"payload must be an object",
+	"cwd must be string",
+	"project must be string",
+	"started_at must be string",
+	"events must be a list",
+	"event must be an object",
+]);
+
+function boundedIngestValidationMessage(error: RawEventIngestValidationError): string {
+	return SAFE_INGEST_VALIDATION_ERRORS.has(error.message)
+		? error.message
+		: "invalid raw event request";
+}
+
+function boundedIngestErrorResponse(c: JsonResponder, error: unknown): Response {
+	if (error instanceof RawEventIngestValidationError) {
+		return c.json({ error: boundedIngestValidationMessage(error) }, 400);
+	}
+	const response: Record<string, unknown> = { error: "internal server error" };
+	if (process.env.CODEMEM_VIEWER_DEBUG === "1") {
+		response.detail = error instanceof Error ? error.message : String(error);
+	}
+	return c.json(response, 500);
+}
+
+function ingestNormalizedEnvelope(
+	store: MemoryStore,
+	sweeper: RawEventSweeper | null | undefined,
+	envelope: object,
+) {
+	const result = ingestRawEvents(store, envelope);
+	nudgeSweeper(sweeper, result.sessions);
+	return result;
 }
 
 export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweeper | null) {
@@ -173,226 +233,15 @@ export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweepe
 	app.post("/api/raw-events", async (c) => {
 		const result = await parseJsonObjectBody(c, MAX_RAW_EVENTS_BODY_BYTES);
 		if (result instanceof Response) return result;
-		const payload = result;
-
-		const store = getStore();
 		try {
-			// Validate top-level string fields
-			const cwd = payload.cwd;
-			if (cwd != null && typeof cwd !== "string") {
-				return c.json({ error: "cwd must be string" }, 400);
-			}
-			const project = payload.project;
-			if (project != null && typeof project !== "string") {
-				return c.json({ error: "project must be string" }, 400);
-			}
-			const startedAt = payload.started_at;
-			if (startedAt != null && typeof startedAt !== "string") {
-				return c.json({ error: "started_at must be string" }, 400);
-			}
-
-			// Determine event list: batch (events array) or single-event payload
-			let items = payload.events;
-			if (items == null) {
-				items = [payload];
-			}
-			if (!Array.isArray(items)) {
-				return c.json({ error: "events must be a list" }, 400);
-			}
-
-			// Resolve default session id from top-level payload
-			let defaultSessionId: string;
-			try {
-				defaultSessionId = resolveSessionStreamId(payload) ?? "";
-			} catch (err) {
-				return c.json({ error: (err as Error).message }, 400);
-			}
-			if (defaultSessionId.startsWith("msg_")) {
-				return c.json({ error: "invalid session id" }, 400);
-			}
-
-			let inserted = 0;
-			const lastSeenBySession = new Map<string, number>();
-			const metaBySession = new Map<string, Record<string, string>>();
-			const sessionIds = new Set<string>();
-			const batchBySession = new Map<string, Record<string, unknown>[]>();
-
-			for (const item of items) {
-				if (item == null || typeof item !== "object" || Array.isArray(item)) {
-					return c.json({ error: "event must be an object" }, 400);
-				}
-				const itemObj = item as Record<string, unknown>;
-
-				let itemSessionId: string | null;
-				try {
-					itemSessionId = resolveSessionStreamId(itemObj);
-				} catch (err) {
-					return c.json({ error: (err as Error).message }, 400);
-				}
-				const opencodeSessionId = String(itemSessionId ?? defaultSessionId ?? "");
-				if (!opencodeSessionId) {
-					return c.json({ error: "session id required" }, 400);
-				}
-				if (opencodeSessionId.startsWith("msg_")) {
-					return c.json({ error: "invalid session id" }, 400);
-				}
-
-				let eventId = String(itemObj.event_id ?? "");
-				const eventType = String(itemObj.event_type ?? "");
-				if (!eventType) {
-					return c.json({ error: "event_type required" }, 400);
-				}
-
-				const eventSeqValue = itemObj.event_seq;
-				if (eventSeqValue != null) {
-					const parsed = Number(eventSeqValue);
-					if (!Number.isFinite(parsed) || parsed !== Math.floor(parsed)) {
-						return c.json({ error: "event_seq must be int" }, 400);
-					}
-				}
-
-				let tsWallMs = itemObj.ts_wall_ms;
-				if (tsWallMs != null) {
-					const parsed = Number(tsWallMs);
-					if (!Number.isFinite(parsed)) {
-						return c.json({ error: "ts_wall_ms must be int" }, 400);
-					}
-					tsWallMs = Math.floor(parsed);
-					const prev = lastSeenBySession.get(opencodeSessionId) ?? (tsWallMs as number);
-					lastSeenBySession.set(opencodeSessionId, Math.max(prev, tsWallMs as number));
-				}
-
-				let tsMonoMs = itemObj.ts_mono_ms;
-				if (tsMonoMs != null) {
-					const parsed = Number(tsMonoMs);
-					if (!Number.isFinite(parsed)) {
-						return c.json({ error: "ts_mono_ms must be number" }, 400);
-					}
-					tsMonoMs = parsed;
-				}
-
-				let eventPayload = itemObj.payload;
-				if (eventPayload == null) eventPayload = {};
-				if (typeof eventPayload !== "object" || Array.isArray(eventPayload)) {
-					return c.json({ error: "payload must be an object" }, 400);
-				}
-
-				// Per-item meta fields
-				const itemCwd = itemObj.cwd;
-				if (itemCwd != null && typeof itemCwd !== "string") {
-					return c.json({ error: "cwd must be string" }, 400);
-				}
-				const itemProject = itemObj.project;
-				if (itemProject != null && typeof itemProject !== "string") {
-					return c.json({ error: "project must be string" }, 400);
-				}
-				const itemStartedAt = itemObj.started_at;
-				if (itemStartedAt != null && typeof itemStartedAt !== "string") {
-					return c.json({ error: "started_at must be string" }, 400);
-				}
-
-				// Sanitize payload
-				eventPayload = stripPrivateObj(eventPayload) as Record<string, unknown>;
-
-				// Generate stable event_id for legacy senders.
-				// Python uses json.dumps(sort_keys=True) which recursively sorts all keys.
-				// We replicate with a recursive key-sorting replacer.
-				if (!eventId) {
-					const sortedStringify = (obj: unknown): string =>
-						JSON.stringify(obj, (_key, value) => {
-							if (value != null && typeof value === "object" && !Array.isArray(value)) {
-								const sorted: Record<string, unknown> = {};
-								for (const k of Object.keys(value as Record<string, unknown>).sort()) {
-									sorted[k] = (value as Record<string, unknown>)[k];
-								}
-								return sorted;
-							}
-							return value;
-						});
-					if (eventSeqValue != null) {
-						const rawId = sortedStringify({
-							s: eventSeqValue,
-							t: eventType,
-							p: eventPayload,
-						});
-						const hash = createHash("sha256").update(rawId, "utf-8").digest("hex").slice(0, 16);
-						eventId = `legacy-seq-${eventSeqValue}-${hash}`;
-					} else {
-						const rawId = sortedStringify({
-							m: tsMonoMs ?? null,
-							p: eventPayload,
-							t: eventType,
-							w: tsWallMs ?? null,
-						});
-						eventId = `legacy-${createHash("sha256").update(rawId, "utf-8").digest("hex").slice(0, 16)}`;
-					}
-				}
-
-				const eventEntry: Record<string, unknown> = {
-					event_id: eventId,
-					event_type: eventType,
-					payload: eventPayload,
-					ts_wall_ms: tsWallMs ?? null,
-					ts_mono_ms: tsMonoMs ?? null,
-				};
-
-				sessionIds.add(opencodeSessionId);
-				const list = batchBySession.get(opencodeSessionId) ?? [];
-				list.push({ ...eventEntry });
-				batchBySession.set(opencodeSessionId, list);
-
-				if (itemCwd || itemProject || itemStartedAt) {
-					const perSession = metaBySession.get(opencodeSessionId) ?? {};
-					if (itemCwd) perSession.cwd = itemCwd as string;
-					if (itemProject) perSession.project = itemProject as string;
-					if (itemStartedAt) perSession.started_at = itemStartedAt as string;
-					metaBySession.set(opencodeSessionId, perSession);
-				}
-			}
-
-			// Insert events
-			if (sessionIds.size === 1) {
-				const singleSessionId = sessionIds.values().next().value as string;
-				const batch = batchBySession.get(singleSessionId) ?? [];
-				const result = store.recordRawEventsBatch(singleSessionId, batch);
-				inserted = result.inserted;
-			} else {
-				for (const [sid, sidEvents] of batchBySession) {
-					const result = store.recordRawEventsBatch(sid, sidEvents);
-					inserted += result.inserted;
-				}
-			}
-
-			// Update session metadata
-			for (const metaSessionId of sessionIds) {
-				const sessionMeta = metaBySession.get(metaSessionId) ?? {};
-				const applyRequestMeta = sessionIds.size === 1 || metaSessionId === defaultSessionId;
-				store.updateRawEventSessionMeta({
-					opencodeSessionId: metaSessionId,
-					cwd:
-						sessionMeta.cwd ?? (applyRequestMeta ? (cwd as string | undefined) : undefined) ?? null,
-					project:
-						sessionMeta.project ??
-						(applyRequestMeta ? (project as string | undefined) : undefined) ??
-						null,
-					startedAt:
-						sessionMeta.started_at ??
-						(applyRequestMeta ? (startedAt as string | undefined) : undefined) ??
-						null,
-					lastSeenTsWallMs: lastSeenBySession.get(metaSessionId) ?? null,
-				});
-			}
-
-			// Note per-session activity for optional debounced auto-flush.
-			nudgeSweeper(sweeper, sessionIds);
-
-			return c.json({ inserted, received: (items as unknown[]).length });
+			const ingestResult = ingestNormalizedEnvelope(getStore(), sweeper, result);
+			return c.json({
+				inserted: ingestResult.inserted,
+				skipped: ingestResult.skipped,
+				received: ingestResult.received,
+			});
 		} catch (err) {
-			const response: Record<string, unknown> = { error: "internal server error" };
-			if (process.env.CODEMEM_VIEWER_DEBUG === "1") {
-				response.detail = (err as Error).message;
-			}
-			return c.json(response, 500);
+			return boundedIngestErrorResponse(c, err);
 		}
 	});
 
@@ -402,53 +251,21 @@ export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweepe
 		if (result instanceof Response) return result;
 		const payload = result;
 
-		// Map hook payload → raw event envelope
-		const envelope = buildRawEventEnvelopeFromHook(payload, {
-			transcriptPolicy: { trust: "restricted", approvedRoots: [claudeTranscriptRoot()] },
-		});
-		if (envelope === null) {
-			// Unsupported event type or missing required fields — skip gracefully
-			const skipReason =
-				payload.hook_event_name === "Stop" && typeof payload.transcript_path === "string"
-					? "transcript_unavailable"
-					: "unsupported_hook";
-			return c.json({ inserted: 0, skipped: 1, skip_reason: skipReason });
-		}
-
-		const store = getStore();
 		try {
-			const opencodeSessionId = envelope.opencode_session_id;
-			const source = envelope.source;
-			const strippedPayload = stripPrivateObj(envelope.payload) as Record<string, unknown>;
-
-			const inserted = store.recordRawEvent({
-				opencodeSessionId,
-				source,
-				eventId: envelope.event_id,
-				eventType: "claude.hook",
-				payload: strippedPayload,
-				tsWallMs: envelope.ts_wall_ms,
+			const envelope = buildRawEventEnvelopeFromHook(payload, {
+				transcriptPolicy: { trust: "restricted", approvedRoots: [claudeTranscriptRoot()] },
 			});
-
-			store.updateRawEventSessionMeta({
-				opencodeSessionId,
-				source,
-				cwd: envelope.cwd,
-				project: envelope.project,
-				startedAt: envelope.started_at,
-				lastSeenTsWallMs: envelope.ts_wall_ms,
-			});
-
-			// Note activity for optional debounced auto-flush.
-			nudgeSweeper(sweeper, [opencodeSessionId], source);
-
-			return c.json({ inserted: inserted ? 1 : 0, skipped: 0 });
-		} catch (err) {
-			const response: Record<string, unknown> = { error: "internal server error" };
-			if (process.env.CODEMEM_VIEWER_DEBUG === "1") {
-				response.detail = (err as Error).message;
+			if (envelope === null) {
+				const skipReason =
+					payload.hook_event_name === "Stop" && typeof payload.transcript_path === "string"
+						? "transcript_unavailable"
+						: "unsupported_hook";
+				return c.json({ inserted: 0, skipped: 1, skip_reason: skipReason });
 			}
-			return c.json(response, 500);
+			const ingestResult = ingestNormalizedEnvelope(getStore(), sweeper, envelope);
+			return c.json({ inserted: ingestResult.inserted, skipped: ingestResult.skipped });
+		} catch (err) {
+			return boundedIngestErrorResponse(c, err);
 		}
 	});
 
@@ -458,50 +275,21 @@ export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweepe
 		if (result instanceof Response) return result;
 		const payload = result;
 
-		const envelope = buildRawEventEnvelopeFromCodexHook(payload, {
-			transcriptPolicy: { trust: "restricted", approvedRoots: [codexTranscriptRoot()] },
-		});
-		if (envelope === null) {
-			const skipReason =
-				payload.hook_event_name === "Stop" && typeof payload.transcript_path === "string"
-					? "transcript_unavailable"
-					: "unsupported_hook";
-			return c.json({ inserted: 0, skipped: 1, skip_reason: skipReason });
-		}
-
-		const store = getStore();
 		try {
-			const opencodeSessionId = envelope.opencode_session_id;
-			const source = envelope.source;
-			const strippedPayload = stripPrivateObj(envelope.payload) as Record<string, unknown>;
-
-			const inserted = store.recordRawEvent({
-				opencodeSessionId,
-				source,
-				eventId: envelope.event_id,
-				eventType: envelope.event_type,
-				payload: strippedPayload,
-				tsWallMs: envelope.ts_wall_ms,
+			const envelope = buildRawEventEnvelopeFromCodexHook(payload, {
+				transcriptPolicy: { trust: "restricted", approvedRoots: [codexTranscriptRoot()] },
 			});
-
-			store.updateRawEventSessionMeta({
-				opencodeSessionId,
-				source,
-				cwd: envelope.cwd,
-				project: envelope.project,
-				startedAt: envelope.started_at,
-				lastSeenTsWallMs: envelope.ts_wall_ms,
-			});
-
-			nudgeSweeper(sweeper, [opencodeSessionId], source);
-
-			return c.json({ inserted: inserted ? 1 : 0, skipped: 0 });
-		} catch (err) {
-			const response: Record<string, unknown> = { error: "internal server error" };
-			if (process.env.CODEMEM_VIEWER_DEBUG === "1") {
-				response.detail = (err as Error).message;
+			if (envelope === null) {
+				const skipReason =
+					payload.hook_event_name === "Stop" && typeof payload.transcript_path === "string"
+						? "transcript_unavailable"
+						: "unsupported_hook";
+				return c.json({ inserted: 0, skipped: 1, skip_reason: skipReason });
 			}
-			return c.json(response, 500);
+			const ingestResult = ingestNormalizedEnvelope(getStore(), sweeper, envelope);
+			return c.json({ inserted: ingestResult.inserted, skipped: ingestResult.skipped });
+		} catch (err) {
+			return boundedIngestErrorResponse(c, err);
 		}
 	});
 


### PR DESCRIPTION
## Description

Moves Viewer adapter ingress onto the canonical raw-event ingestion contract. `/api/raw-events` delegates to shared ingestion, while the Claude and Codex routes remain compatibility adapters with bounded validation and exact result counts.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run check`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected — automated coverage used

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] Documentation updated or not required
- [x] No new warnings introduced