### PR TITLE
feat(claude): use direct viewer prompt transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ The Claude plugin starts MCP with the TS CLI (`codemem mcp`).
 
 Claude and Codex plugins normalize native hooks at the plugin edge and send the resulting envelope to the canonical `POST /api/raw-events` endpoint. A retryable Viewer failure sends that exact envelope to `codemem enqueue-raw-event`; Codex retains a durable normalized-envelope spool as its last resort. The checked-in dependency-free normalizers are generated from the TypeScript implementations in `packages/core/src/claude-hooks.ts` and `packages/core/src/codex-hooks.ts`. Older packaged clients remain compatible through the named Viewer hook routes.
 
-Claude hook events share the same raw-event queue pipeline used by OpenCode. `UserPromptSubmit` runs
-capture ingest in the background and injects memory context via Claude `additionalContext` using
-local pack generation by default, with optional HTTP `/api/pack` fallback.
+Claude hook events share the same raw-event queue pipeline used by OpenCode. `UserPromptSubmit` uses
+a dependency-free Node hook to validate the local Viewer profile, retrieve an identity-gated pack,
+write Claude `additionalContext`, and record delivery best-effort. Healthy prompt retrieval starts no
+`codemem`, `npx`, or shell helper child; classified compatibility failures use the local CLI fallback.
+Claude hook HTTP transport rejects configured non-loopback Viewer hosts without fetching them.
 
 ### Codex (early beta)
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -57,6 +57,8 @@
 			"packages/**/src/**/*.js",
 			"packages/**/*.json",
 			"packages/**/vite.config.ts",
+			"plugins/claude/scripts/ingest-hook.mjs",
+			"plugins/claude/scripts/user-prompt-hook.mjs",
 			"vitest.config.ts",
 			"tsconfig.base.json",
 			"tsconfig.json",

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -68,8 +68,10 @@ Ingest one Claude hook payload through the installed wrapper:
 printf '%s\n' '{"hook_event_name":"SessionStart","session_id":"sess-1"}' | node plugins/claude/scripts/ingest-hook.mjs
 ```
 
-`inject-context-hook.sh` is also a thin wrapper and delegates prompt-time context output to
-codemem's local pack-generation path, with optional HTTP `/api/pack` fallback.
+Prompt-time retrieval runs through the packaged dependency-free Node hook. It validates the
+Viewer protocol, database, and runtime identity before sending identity-gated `POST /api/pack`.
+Claude prompt retrieval and event ingestion accept only explicit loopback Viewer hosts
+(`localhost`, `127.0.0.0/8`, or IPv6 loopback); non-loopback hosts are never fetched.
 
 By default, `SessionEnd` triggers a boundary flush after enqueue to preserve progress without waiting for sweeper timing. Set `CODEMEM_CLAUDE_HOOK_FLUSH=0` to force enqueue-only behavior, and set `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1` to include `Stop` boundary flush.
 
@@ -81,11 +83,15 @@ The packaged template currently registers these hook events in `plugins/claude/h
 - `Stop`
 - `SessionEnd`
 
-`UserPromptSubmit` runs `scripts/user-prompt-hook.sh`, which:
+`UserPromptSubmit` runs `scripts/user-prompt-hook.mjs`, which:
 - sends the hook payload into capture ingest (`ingest-hook.mjs`) in the background, and
-- returns `hookSpecificOutput.additionalContext` from local CLI/store pack generation for prompt-time memory injection.
+- returns `hookSpecificOutput.additionalContext` from direct Viewer pack retrieval, then records delivery best-effort with a 500 ms cap.
 
-Prompt-time Claude injection uses local pack generation first and falls back to `/api/pack` only when local generation fails and `CODEMEM_INJECT_HTTP_FALLBACK` is enabled.
+Healthy prompt-time Claude injection starts no `codemem`, `npx`, or shell helper child. Retryable
+transport/version failures and local database/runtime mismatches start one compatibility chain:
+`codemem claude-hook-inject`, then the plugin-version-pinned `npx` equivalent if needed. Valid
+request, policy, authorization, and compatible-profile contract failures do not fall back. Redirects
+are rejected. Ledger failure never retries inline or changes already-written hook output.
 
 For Claude hooks, project resolution precedence is:
 
@@ -373,9 +379,8 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_CODEX_HOOK_LOCK_TTL_S` | Seconds before a Codex hook fallback lock is treated as stale (default `120`). |
 | `CODEMEM_CODEX_HOOK_SPOOL_DIR` | Legacy native Codex hook fallback spool directory (default `~/.codemem/codex-hook-spool`); the normalized wrapper does not read or drain it. |
 | `CODEMEM_CODEX_RAW_EVENT_SPOOL_DIR` | Normalized Codex raw-event envelope spool directory (default `~/.codemem/codex-raw-event-spool`). |
-| `CODEMEM_INJECT_HTTP_CONNECT_TIMEOUT_S` | `UserPromptSubmit` pack injection connect timeout in seconds (default `1`). |
-| `CODEMEM_INJECT_HTTP_MAX_TIME_S` | Viewer request timeout for OpenCode packs/ledger transitions and total HTTP pack timeout for Claude/Codex `UserPromptSubmit` (default `2` seconds). |
-| `CODEMEM_INJECT_HTTP_FALLBACK` | Set to `0` to disable HTTP `/api/pack` fallback for Claude/Codex prompt-time injection (default `1`). |
+| `CODEMEM_INJECT_HTTP_MAX_TIME_S` | Viewer request timeout for OpenCode and Claude prompt retrieval, and the legacy Codex injection path (default `2` seconds). Claude ledger completion has a separate fixed 500 ms cap. |
+| `CODEMEM_INJECT_HTTP_FALLBACK` | Legacy Codex control for HTTP `/api/pack` fallback (default `1`); Claude now uses classified direct-HTTP-to-local fallback. |
 | `CODEMEM_INJECT_MAX_CHARS` | Max chars returned as Claude/Codex `additionalContext` (default `16000`). |
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
 | `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:adapter-normalizers": "node --test scripts/build-adapter-normalizers.test.mjs",
     "test:release-version": "node --test scripts/release-version.test.mjs",
     "test:release-tag-preflight": "node --test scripts/release-tag-preflight.test.mjs",
-    "lint": "pnpm exec biome check packages/",
+    "lint": "pnpm exec biome check .",
     "format": "pnpm exec biome check --write packages/",
     "tsc": "pnpm exec tsc --build",
     "typecheck": "pnpm run tsc",

--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -70,6 +70,12 @@ async function smokeAdapterWrapper(source, isolatedRoot) {
 	const scriptsDirectory = join(isolatedRoot, relativeRoot, "scripts");
 	const wrapperPath = join(scriptsDirectory, "ingest-hook.mjs");
 	cpSync(resolve(workspaceRoot, relativeRoot, "scripts", "ingest-hook.mjs"), wrapperPath);
+	if (source === "claude") {
+		cpSync(
+			resolve(workspaceRoot, relativeRoot, "scripts", "user-prompt-hook.mjs"),
+			join(scriptsDirectory, "user-prompt-hook.mjs"),
+		);
+	}
 	cpSync(
 		resolve(workspaceRoot, relativeRoot, source === "claude" ? ".claude-plugin" : ".codex-plugin"),
 		join(isolatedRoot, relativeRoot, source === "claude" ? ".claude-plugin" : ".codex-plugin"),
@@ -137,12 +143,132 @@ async function smokeAdapterWrapper(source, isolatedRoot) {
 			JSON.stringify(nativePayload),
 		);
 		const child = result;
-		assert(child.status === 0, `${source} wrapper failed without workspace dependencies: ${child.stderr}`);
+		assert(
+			child.status === 0,
+			`${source} wrapper failed without workspace dependencies: ${child.stderr}`,
+		);
 		const received = JSON.parse(receivedBody);
 		assert(received.event_id === expected.event_id, `${source} transport changed event_id`);
-		assert(received.payload._adapter.meta.event_id_algo === `${source}/1`, `${source} algorithm discriminator missing`);
+		assert(
+			received.payload._adapter.meta.event_id_algo === `${source}/1`,
+			`${source} algorithm discriminator missing`,
+		);
 	} finally {
 		server.close();
+	}
+}
+
+async function smokeClaudePromptWrapper(isolatedRoot) {
+	const pluginRoot = join(isolatedRoot, "plugins", "claude");
+	const wrapperPath = join(pluginRoot, "scripts", "user-prompt-hook.mjs");
+	const home = join(isolatedRoot, "claude-home");
+	const dbPath = join(home, ".codemem", "mem.sqlite");
+	mkdirSync(home, { recursive: true });
+	const identityTarget = {
+		device_id: null,
+		actor_id_present: false,
+		actor_id: null,
+		config_path: null,
+		runtime_root: null,
+		workspace_id: null,
+		home_dir: home,
+		pack_compression: null,
+		embedding_disabled: false,
+		embedding_model: "Xenova/bge-small-en-v1.5",
+	};
+	const requestPaths = [];
+	const server = createServer((request, response) => {
+		let body = "";
+		request.setEncoding("utf8");
+		request.on("data", (chunk) => {
+			body += chunk;
+		});
+		request.on("end", () => {
+			requestPaths.push(request.url);
+			response.setHeader("Content-Type", "application/json");
+			if (request.url === "/api/prompt-pack-profile") {
+				response.end(
+					JSON.stringify({
+						service: "codemem-viewer",
+						protocol_version: 1,
+						min_supported_protocol_version: 1,
+						db_path: dbPath,
+						identity_target: identityTarget,
+					}),
+				);
+				return;
+			}
+			if (request.url === "/api/pack") {
+				const payload = JSON.parse(body);
+				assert(
+					payload.attempt?.source === "claude",
+					"Claude prompt request omitted attempt metadata",
+				);
+				response.end('{"pack_text":"PACKED_CLAUDE_CONTEXT","metrics":{"total_items":1}}');
+				return;
+			}
+			if (request.url === "/api/prompt-pack-ledger") {
+				const payload = JSON.parse(body);
+				assert(
+					payload.delivery_status === "handed_off",
+					"Claude prompt delivery was not recorded",
+				);
+				response.end('{"ok":true}');
+				return;
+			}
+			response.end('{"inserted":1,"skipped":0,"received":1}');
+		});
+	});
+	await new Promise((resolvePromise, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolvePromise);
+	});
+	try {
+		const address = server.address();
+		assert(
+			address && typeof address === "object",
+			"Claude prompt smoke server did not bind",
+		);
+		const result = await runAsync(
+			process.execPath,
+			[wrapperPath],
+			{
+				cwd: isolatedRoot,
+				env: {
+					...process.env,
+					PATH: join(isolatedRoot, "no-cli-on-path"),
+					HOME: home,
+					CLAUDE_PLUGIN_ROOT: pluginRoot,
+					CODEMEM_DB: dbPath,
+					CODEMEM_PROJECT: "codemem",
+					CODEMEM_VIEWER_HOST: "127.0.0.1",
+					CODEMEM_VIEWER_PORT: String(address.port),
+				},
+				stdio: ["pipe", "pipe", "pipe"],
+			},
+			JSON.stringify({
+				hook_event_name: "UserPromptSubmit",
+				session_id: "packed-claude-prompt",
+				prompt: "recall the packed hook contract",
+				cwd: isolatedRoot,
+			}),
+		);
+		assert(result.status === 0, `Claude prompt wrapper failed: ${result.stderr}`);
+		assert(
+			result.stdout ===
+				'{"continue":true,"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"PACKED_CLAUDE_CONTEXT"}}',
+			`Claude packed prompt output bytes changed: ${JSON.stringify(result.stdout)}`,
+		);
+		assert(
+			requestPaths.includes("/api/pack"),
+			"Claude packed prompt wrapper skipped direct pack HTTP",
+		);
+		assert(
+			requestPaths.includes("/api/prompt-pack-ledger"),
+			"Claude packed prompt wrapper skipped direct ledger HTTP",
+		);
+	} finally {
+		await new Promise((resolvePromise) => server.close(resolvePromise));
 	}
 }
 
@@ -351,6 +477,7 @@ try {
 		);
 		assert(existsSync(checkedInArtifact), `${source} plugin is missing its generated normalizer`);
 		await smokeAdapterWrapper(source, isolatedAdapters);
+		if (source === "claude") await smokeClaudePromptWrapper(isolatedAdapters);
 	}
 	await smokeCodexSpoolIsolation(isolatedAdapters);
 } finally {

--- a/packages/cli/src/commands/claude-hook-inject.contract.test.ts
+++ b/packages/cli/src/commands/claude-hook-inject.contract.test.ts
@@ -30,11 +30,6 @@ type DepsOverride = {
 		dbPath: string,
 		workingSetPaths?: string[],
 	) => Promise<string> | string;
-	httpPack?: (
-		context: string,
-		project: string | null,
-		maxTimeMs?: number,
-	) => Promise<string> | string;
 };
 
 type Fixture = {
@@ -57,7 +52,6 @@ const fixtures: Fixture[] = [
 		},
 		deps: {
 			buildLocalPack: () => "GOLDEN_PACK_BODY",
-			httpPack: () => "",
 		},
 		expected: {
 			continue: true,
@@ -77,7 +71,6 @@ const fixtures: Fixture[] = [
 		},
 		deps: {
 			buildLocalPack: () => "INVARIANT_PACK",
-			httpPack: () => "",
 		},
 		expected: {
 			continue: true,
@@ -95,7 +88,6 @@ const fixtures: Fixture[] = [
 		},
 		deps: {
 			buildLocalPack: () => "RESILIENT_PACK",
-			httpPack: () => "",
 		},
 		expected: {
 			continue: true,
@@ -114,7 +106,6 @@ const fixtures: Fixture[] = [
 		},
 		deps: {
 			buildLocalPack: () => "should-not-be-emitted",
-			httpPack: () => "",
 		},
 		expected: { continue: true },
 	},
@@ -126,7 +117,6 @@ const fixtures: Fixture[] = [
 		},
 		deps: {
 			buildLocalPack: () => "should-not-be-emitted",
-			httpPack: () => "",
 		},
 		expected: { continue: true },
 	},
@@ -140,12 +130,11 @@ const fixtures: Fixture[] = [
 		envOverrides: { CODEMEM_INJECT_CONTEXT: "0" },
 		deps: {
 			buildLocalPack: () => "should-not-be-emitted",
-			httpPack: () => "",
 		},
 		expected: { continue: true },
 	},
 	{
-		name: "Local pack throws → HTTP fallback wins",
+		name: "Local compatibility pack failure returns bare continue",
 		payload: {
 			hook_event_name: "UserPromptSubmit",
 			session_id: "contract-fallback",
@@ -153,20 +142,12 @@ const fixtures: Fixture[] = [
 			cwd: "/tmp/contract",
 			project: "codemem",
 		},
-		envOverrides: { CODEMEM_INJECT_HTTP_FALLBACK: "1" },
 		deps: {
 			buildLocalPack: () => {
 				throw new Error("simulated local pack failure");
 			},
-			httpPack: () => "HTTP_FALLBACK_PACK",
 		},
-		expected: {
-			continue: true,
-			hookSpecificOutput: {
-				hookEventName: "UserPromptSubmit",
-				additionalContext: "HTTP_FALLBACK_PACK",
-			},
-		},
+		expected: { continue: true },
 	},
 	{
 		name: "Truncation: pack longer than CODEMEM_INJECT_MAX_CHARS gets [pack truncated] marker",
@@ -178,7 +159,6 @@ const fixtures: Fixture[] = [
 		envOverrides: { CODEMEM_INJECT_MAX_CHARS: "22" },
 		deps: {
 			buildLocalPack: () => "memory_one memory_two memory_three memory_four",
-			httpPack: () => "",
 		},
 		expected: {
 			continue: true,
@@ -197,7 +177,6 @@ const fixtures: Fixture[] = [
 		},
 		deps: {
 			buildLocalPack: () => "should-not-be-emitted",
-			httpPack: () => "",
 		},
 		expected: { continue: true },
 	},
@@ -211,7 +190,6 @@ const fixtures: Fixture[] = [
 		},
 		deps: {
 			buildLocalPack: () => "should-not-be-emitted",
-			httpPack: () => "",
 		},
 		expected: { continue: true },
 	},
@@ -223,7 +201,6 @@ const fixtures: Fixture[] = [
 		},
 		deps: {
 			buildLocalPack: () => "should-not-be-emitted",
-			httpPack: () => "",
 		},
 		expected: { continue: true },
 	},
@@ -290,19 +267,11 @@ describe("claude-hook-inject contract fixtures", () => {
 						return toPack(await Promise.resolve(result ?? ""));
 					}
 				: async () => toPack("");
-			const httpPack = deps?.httpPack
-				? async (context: string, project: string | null, maxTimeMs?: number) => {
-						const result = deps.httpPack?.(context, project, maxTimeMs);
-						return toPack(await Promise.resolve(result ?? ""));
-					}
-				: async () => toPack("");
-
 			const result = await buildClaudeHookInjection(
 				payload,
 				{},
 				{
 					buildLocalPack,
-					httpPack,
 					resolveDb: () => "/tmp/contract.sqlite",
 				},
 			);

--- a/packages/cli/src/commands/claude-hook-inject.test.ts
+++ b/packages/cli/src/commands/claude-hook-inject.test.ts
@@ -67,9 +67,6 @@ describe("claude-hook-inject command", () => {
 					expect(workingSetPaths).toEqual([]);
 					return pack("## Summary\n[1] (decision) Auth fix", 1, 42);
 				},
-				httpPack: async () => {
-					throw new Error("http fallback should not run");
-				},
 				resolveDb: () => "/tmp/test.sqlite",
 			},
 		);
@@ -81,51 +78,6 @@ describe("claude-hook-inject command", () => {
 				additionalContext: "## Summary\n[1] (decision) Auth fix",
 			},
 		});
-	});
-
-	it("falls back to HTTP pack generation when local generation fails", async () => {
-		const originalFallback = process.env.CODEMEM_INJECT_HTTP_FALLBACK;
-		const originalHttpMax = process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S;
-		process.env.CODEMEM_INJECT_HTTP_FALLBACK = "1";
-		process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S = "7";
-		try {
-			const result = await buildClaudeHookInjection(
-				{
-					hook_event_name: "UserPromptSubmit",
-					session_id: "sess-2",
-					prompt: "continue sync work",
-					cwd: "/tmp/codemem",
-					project: "codemem",
-				},
-				{},
-				{
-					buildLocalPack: async () => {
-						throw new Error("local pack failed");
-					},
-					httpPack: async (context, project, maxTimeMs) => {
-						// HTTP fallback receives the same rich query as the local path.
-						expect(context).toBe("continue sync work codemem");
-						expect(project).toBe("codemem");
-						expect(maxTimeMs).toBe(7000);
-						return pack("## Timeline\n[4] (feature) Sync continuation", 1, 53);
-					},
-					resolveDb: () => "/tmp/test.sqlite",
-				},
-			);
-
-			expect(result).toEqual({
-				continue: true,
-				hookSpecificOutput: {
-					hookEventName: "UserPromptSubmit",
-					additionalContext: "## Timeline\n[4] (feature) Sync continuation",
-				},
-			});
-		} finally {
-			if (originalFallback === undefined) delete process.env.CODEMEM_INJECT_HTTP_FALLBACK;
-			else process.env.CODEMEM_INJECT_HTTP_FALLBACK = originalFallback;
-			if (originalHttpMax === undefined) delete process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S;
-			else process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S = originalHttpMax;
-		}
 	});
 
 	it("returns continue without additionalContext when CODEMEM_INJECT_CONTEXT disables injection", async () => {
@@ -142,9 +94,6 @@ describe("claude-hook-inject command", () => {
 				{
 					buildLocalPack: async () => {
 						throw new Error("should not build local pack when injection disabled");
-					},
-					httpPack: async () => {
-						throw new Error("should not call http fallback when injection disabled");
 					},
 					resolveDb: () => "/tmp/test.sqlite",
 				},
@@ -169,9 +118,6 @@ describe("claude-hook-inject command", () => {
 				buildLocalPack: async () => {
 					throw new Error("should not build local pack");
 				},
-				httpPack: async () => {
-					throw new Error("should not call http fallback");
-				},
 				resolveDb: () => "/tmp/test.sqlite",
 			},
 		);
@@ -192,7 +138,6 @@ describe("claude-hook-inject command", () => {
 				{},
 				{
 					buildLocalPack: async () => pack("12345678901234567890"),
-					httpPack: async () => pack(""),
 					resolveDb: () => "/tmp/test.sqlite",
 				},
 			);
@@ -226,7 +171,6 @@ describe("claude-hook-inject command", () => {
 			{},
 			{
 				buildLocalPack: async () => pack("Remember to run targeted tests."),
-				httpPack: async () => pack(""),
 				resolveDb: () => "/tmp/test.sqlite",
 			},
 		);
@@ -249,7 +193,6 @@ describe("claude-hook-inject command", () => {
 			{},
 			{
 				buildLocalPack: async () => pack("## Summary\nmemory pack"),
-				httpPack: async () => pack(""),
 				resolveDb: () => "/tmp/test.sqlite",
 			},
 		);
@@ -293,9 +236,6 @@ describe("claude-hook-inject command", () => {
 					]);
 					return pack("## Memory pack");
 				},
-				httpPack: async () => {
-					throw new Error("http fallback should not run");
-				},
 				resolveDb: () => "/tmp/test.sqlite",
 			},
 		);
@@ -320,7 +260,6 @@ describe("claude-hook-inject command", () => {
 				{},
 				{
 					buildLocalPack: async () => pack("memory_one memory_two memory_three memory_four"),
-					httpPack: async () => pack(""),
 					resolveDb: () => "/tmp/test.sqlite",
 				},
 			);
@@ -347,9 +286,6 @@ describe("claude-hook-inject command", () => {
 				{},
 				{
 					buildLocalPack: async () => {
-						throw new Error("should not be called when plugin is ignored");
-					},
-					httpPack: async () => {
 						throw new Error("should not be called when plugin is ignored");
 					},
 					resolveDb: () => "/tmp/test.sqlite",
@@ -396,7 +332,6 @@ describe("claude-hook-inject command", () => {
 					expect(context).toBe("fix the auth callback flow codemem");
 					return pack("## Pack");
 				},
-				httpPack: async () => pack(""),
 				resolveDb: () => "/tmp/test.sqlite",
 			},
 		);
@@ -416,9 +351,6 @@ describe("claude-hook-inject command", () => {
 			{},
 			{
 				buildLocalPack: async () => pack("## Summary\nmemory pack body", 4, 137),
-				httpPack: async () => {
-					throw new Error("http fallback should not run");
-				},
 				resolveDb: () => "/tmp/test.sqlite",
 			},
 		);
@@ -435,42 +367,32 @@ describe("claude-hook-inject command", () => {
 		expect(line).toMatch(/query_len=\d+/);
 	});
 
-	it("logs origin=http when local pack fails and http fallback succeeds", async () => {
-		const originalFallback = process.env.CODEMEM_INJECT_HTTP_FALLBACK;
-		process.env.CODEMEM_INJECT_HTTP_FALLBACK = "1";
-		try {
-			await buildClaudeHookInjection(
-				{
-					hook_event_name: "UserPromptSubmit",
-					session_id: "sess-http-origin",
-					prompt: "fallback path",
-					cwd: "/tmp/codemem",
+	it("logs origin=none when local compatibility generation fails", async () => {
+		await buildClaudeHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "sess-local-failure",
+				prompt: "fallback path",
+				cwd: "/tmp/codemem",
+			},
+			{},
+			{
+				buildLocalPack: async () => {
+					throw new Error("local pack failed");
 				},
-				{},
-				{
-					buildLocalPack: async () => {
-						throw new Error("local pack failed");
-					},
-					httpPack: async () => pack("## Timeline\nfallback pack", 2, 64),
-					resolveDb: () => "/tmp/test.sqlite",
-				},
-			);
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
 
-			const log = readFileSync(pluginLogPath, "utf8");
-			const okLine =
-				log
-					.trim()
-					.split("\n")
-					.reverse()
-					.find((l) => l.includes("inject.pack.ok")) ?? "";
-			expect(okLine).toContain("origin=http");
-			expect(okLine).toContain("items=2");
-			expect(okLine).toContain("pack_tokens=64");
-			expect(okLine).toContain("empty=false");
-		} finally {
-			if (originalFallback === undefined) delete process.env.CODEMEM_INJECT_HTTP_FALLBACK;
-			else process.env.CODEMEM_INJECT_HTTP_FALLBACK = originalFallback;
-		}
+		const log = readFileSync(pluginLogPath, "utf8");
+		const okLine =
+			log
+				.trim()
+				.split("\n")
+				.reverse()
+				.find((l) => l.includes("inject.pack.ok")) ?? "";
+		expect(okLine).toContain("origin=none");
+		expect(okLine).toContain("empty=true");
 	});
 
 	it("logs inject.pack.ok with empty=true when no pack is produced", async () => {
@@ -487,9 +409,6 @@ describe("claude-hook-inject command", () => {
 				{},
 				{
 					buildLocalPack: async () => pack(""),
-					httpPack: async () => {
-						throw new Error("http fallback disabled");
-					},
 					resolveDb: () => "/tmp/test.sqlite",
 				},
 			);
@@ -520,7 +439,6 @@ describe("claude-hook-inject command", () => {
 					buildLocalPack: async () => {
 						throw new Error("local pack failed");
 					},
-					httpPack: async () => pack(""),
 					resolveDb: () => "/tmp/test.sqlite",
 				},
 			);

--- a/packages/cli/src/commands/claude-hook-inject.ts
+++ b/packages/cli/src/commands/claude-hook-inject.ts
@@ -35,22 +35,12 @@ export type PackResult = {
 
 const EMPTY_PACK: PackResult = { packText: "", items: 0, packTokens: 0 };
 
-type HttpPackResponse = {
-	pack_text?: string;
-	items?: unknown;
-	metrics?: { pack_tokens?: unknown };
-};
-
 type InjectDeps = {
 	buildLocalPack?: typeof buildLocalPack;
-	httpPack?: typeof tryHttpPack;
 	resolveDb?: typeof resolveDbPath;
 };
 
-const DEFAULT_VIEWER_HOST = "127.0.0.1";
-const DEFAULT_VIEWER_PORT = 38888;
 const DEFAULT_MAX_CHARS = 16000;
-const DEFAULT_HTTP_MAX_TIME_S = 2;
 
 function emitJson(value: InjectResult): void {
 	console.log(JSON.stringify(value));
@@ -58,7 +48,7 @@ function emitJson(value: InjectResult): void {
 
 function emitError(value: { error: string; message: string }): void {
 	// Errors go to stderr so a non-zero exit from `codemem` doesn't poison
-	// the bash hook's stdout when it falls back to `npx -y codemem ...`.
+	// the Node hook's stdout when its compatibility chain reaches `npx`.
 	process.stderr.write(`${JSON.stringify(value)}\n`);
 }
 
@@ -154,46 +144,6 @@ async function buildLocalPack(
 	}
 }
 
-async function tryHttpPack(
-	context: string,
-	project: string | null,
-	maxTimeMs = DEFAULT_HTTP_MAX_TIME_S * 1000,
-): Promise<PackResult> {
-	const empty: PackResult = { packText: "", items: 0, packTokens: 0 };
-	const host = process.env.CODEMEM_VIEWER_HOST || DEFAULT_VIEWER_HOST;
-	const port = parsePositiveInt(process.env.CODEMEM_VIEWER_PORT, DEFAULT_VIEWER_PORT);
-	const url = new URL(`http://${host}:${port}/api/pack`);
-	url.searchParams.set("context", context);
-	url.searchParams.set("limit", String(parsePositiveInt(process.env.CODEMEM_INJECT_LIMIT, 8)));
-	url.searchParams.set(
-		"token_budget",
-		String(parsePositiveInt(process.env.CODEMEM_INJECT_TOKEN_BUDGET, 800)),
-	);
-	if (project) {
-		url.searchParams.set("project", project);
-	}
-
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), maxTimeMs);
-	try {
-		const res = await fetch(url, { signal: controller.signal });
-		if (!res.ok) {
-			return empty;
-		}
-		const body = (await res.json()) as HttpPackResponse;
-		const packText = String(body.pack_text ?? "").trim();
-		const items = Array.isArray(body.items) ? body.items.length : 0;
-		const packTokens = Number.isFinite(Number(body.metrics?.pack_tokens))
-			? Number(body.metrics?.pack_tokens)
-			: 0;
-		return { packText, items, packTokens };
-	} catch {
-		return empty;
-	} finally {
-		clearTimeout(timeout);
-	}
-}
-
 export async function buildClaudeHookInjection(
 	payload: Record<string, unknown>,
 	opts: InjectOpts,
@@ -224,17 +174,14 @@ export async function buildClaudeHookInjection(
 	}
 
 	const buildPack = deps.buildLocalPack ?? buildLocalPack;
-	const httpPack = deps.httpPack ?? tryHttpPack;
 	const resolveDb = deps.resolveDb ?? resolveDbPath;
 	const project = resolveInjectProject(payload);
 	const query = buildInjectQuery({ prompt: promptText, project, state });
 	const workingSetPaths = workingSetPathsFromState(state);
 	const maxChars = parsePositiveInt(process.env.CODEMEM_INJECT_MAX_CHARS, DEFAULT_MAX_CHARS);
-	const httpMaxTimeMs =
-		parsePositiveInt(process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S, DEFAULT_HTTP_MAX_TIME_S) * 1000;
 
 	let pack: PackResult = EMPTY_PACK;
-	let origin: "local" | "http" | "none" = "none";
+	let origin: "local" | "none" = "none";
 	try {
 		const dbPath = resolveDb(resolveDbOpt(opts));
 		pack = await buildPack(query, project, dbPath, workingSetPaths);
@@ -245,17 +192,6 @@ export async function buildClaudeHookInjection(
 		logHookEvent(
 			`codemem claude-hook-inject local pack failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
-	}
-
-	if (!pack.packText && envNotDisabled(process.env.CODEMEM_INJECT_HTTP_FALLBACK || "1")) {
-		// tryHttpPack swallows its own network errors and returns an empty
-		// result on failure; don't wrap it here so tests that throw from a
-		// stub mock still surface as failures (the existing "should not run"
-		// assertions rely on this).
-		pack = await httpPack(query, project, httpMaxTimeMs);
-		if (pack.packText) {
-			origin = "http";
-		}
 	}
 
 	// `empty` reflects retrieval, not post-truncation delivery, so the metric
@@ -279,7 +215,7 @@ export async function buildClaudeHookInjection(
 
 const claudeHookInjectCmd = new Command("claude-hook-inject")
 	.configureHelp(helpStyle)
-	.description("Return Claude hook additionalContext from local pack generation");
+	.description("Compatibility fallback for Claude hook local additionalContext generation");
 
 addDbOption(claudeHookInjectCmd);
 

--- a/packages/cli/src/commands/claude-user-prompt-hook.test.ts
+++ b/packages/cli/src/commands/claude-user-prompt-hook.test.ts
@@ -1,0 +1,441 @@
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import {
+	classifyPromptTransportFailure as classifyCorePromptTransportFailure,
+	type PromptTransportFailure,
+} from "@codemem/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const hook = await import(
+	new URL("../../../../plugins/claude/scripts/user-prompt-hook.mjs", import.meta.url).href
+);
+const ingestHook = await import(
+	new URL("../../../../plugins/claude/scripts/ingest-hook.mjs", import.meta.url).href
+);
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("dependency-free Claude user prompt hook", () => {
+	let root: string;
+	let env: Record<string, string>;
+	let identity: Record<string, unknown>;
+	let dbPath: string;
+	let payload: Record<string, unknown>;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "codemem-claude-prompt-hook-"));
+		dbPath = join(root, "mem.sqlite");
+		env = {
+			HOME: root,
+			CODEMEM_DB: dbPath,
+			CODEMEM_PROJECT: "codemem",
+			CODEMEM_CLAUDE_HOOK_CONTEXT_DIR: join(root, "state"),
+			CODEMEM_VIEWER_HOST: "127.0.0.1",
+			CODEMEM_VIEWER_PORT: "38888",
+		};
+		identity = {
+			device_id: null,
+			actor_id_present: false,
+			actor_id: null,
+			config_path: null,
+			runtime_root: null,
+			workspace_id: null,
+			home_dir: root,
+			pack_compression: null,
+			embedding_disabled: false,
+			embedding_model: "Xenova/bge-small-en-v1.5",
+		};
+		payload = {
+			hook_event_name: "UserPromptSubmit",
+			session_id: "claude-session",
+			prompt: "now check the fixture",
+			cwd: root,
+			project: "codemem",
+		};
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("builds Viewer URLs only for explicit loopback hosts", () => {
+		expect(hook.viewerBaseUrl({ CODEMEM_VIEWER_PORT: "4000" })).toBe("http://127.0.0.1:4000");
+		expect(
+			hook.viewerBaseUrl({ CODEMEM_VIEWER_HOST: "localhost", CODEMEM_VIEWER_PORT: "4000" }),
+		).toBe("http://localhost:4000");
+		expect(
+			hook.viewerBaseUrl({ CODEMEM_VIEWER_HOST: "127.0.0.2", CODEMEM_VIEWER_PORT: "4000" }),
+		).toBe("http://127.0.0.2:4000");
+		expect(hook.viewerBaseUrl({ CODEMEM_VIEWER_HOST: "::1", CODEMEM_VIEWER_PORT: "4000" })).toBe(
+			"http://[::1]:4000",
+		);
+		expect(hook.viewerBaseUrl({ CODEMEM_VIEWER_HOST: "192.168.1.10" })).toBeNull();
+		expect(hook.viewerBaseUrl({ CODEMEM_VIEWER_HOST: "viewer.example.com" })).toBeNull();
+	});
+
+	it("rejects event-ingest redirects without following them", async () => {
+		let requestInit: RequestInit | undefined;
+		await expect(
+			ingestHook.postEnvelope("{}", {
+				env,
+				fetchImpl: async (_input: string | URL, init?: RequestInit) => {
+					requestInit = init;
+					return new Response(null, {
+						status: 307,
+						headers: { Location: "https://example.com/events" },
+					});
+				},
+			}),
+		).resolves.toBe(false);
+		expect(requestInit?.redirect).toBe("manual");
+	});
+
+	it("fails closed without fetching or falling back for a non-loopback Viewer host", async () => {
+		env.CODEMEM_VIEWER_HOST = "viewer.example.com";
+		const output: string[] = [];
+		let fetchCalls = 0;
+		let fallbackCalls = 0;
+		await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
+			env,
+			fetchImpl: async () => {
+				fetchCalls += 1;
+				return jsonResponse({});
+			},
+			writeOutput: (value: string) => output.push(value),
+			spawnIngestion: () => {},
+			runFallback: () => {
+				fallbackCalls += 1;
+				return { continue: true };
+			},
+		});
+
+		expect({ output, fetchCalls, fallbackCalls }).toEqual({
+			output: ['{"continue":true}'],
+			fetchCalls: 0,
+			fallbackCalls: 0,
+		});
+	});
+
+	it("preserves query, working-set, truncation, output bytes, and ledger ordering", async () => {
+		hook.trackClaudeSessionState(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "claude-session",
+				prompt: "investigate flaky test",
+			},
+			env,
+		);
+		hook.trackClaudeSessionState(
+			{
+				hook_event_name: "PostToolUse",
+				session_id: "claude-session",
+				tool_name: "Edit",
+				tool_input: { filePath: "packages/cli/src/example.ts" },
+			},
+			env,
+		);
+		env.CODEMEM_INJECT_MAX_CHARS = "12";
+
+		const requests: Array<{
+			path: string;
+			body: Record<string, unknown> | null;
+			signal: AbortSignal | null | undefined;
+		}> = [];
+		const output: string[] = [];
+		let fallbackCalls = 0;
+		let ingestionCalls = 0;
+		const fetchImpl = async (input: string | URL, init?: RequestInit) => {
+			const path = new URL(String(input)).pathname;
+			const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : null;
+			requests.push({ path, body, signal: init?.signal });
+			if (path === "/api/prompt-pack-profile") {
+				return jsonResponse({
+					service: "codemem-viewer",
+					protocol_version: 1,
+					min_supported_protocol_version: 1,
+					db_path: dbPath,
+					identity_target: identity,
+				});
+			}
+			if (path === "/api/pack") {
+				return jsonResponse({
+					pack_text: "12345678901234567890",
+					metrics: { total_items: 1, pack_tokens: 10 },
+				});
+			}
+			expect(output).toEqual([
+				'{"continue":true,"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"123456789012\\n\\n[pack truncated]"}}',
+			]);
+			return jsonResponse({ ok: true });
+		};
+
+		await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
+			env,
+			fetchImpl,
+			writeOutput: (value: string) => output.push(value),
+			spawnIngestion: () => {
+				ingestionCalls += 1;
+			},
+			runFallback: () => {
+				fallbackCalls += 1;
+				return null;
+			},
+			now: () => new Date("2026-08-16T00:00:00.000Z"),
+			uuid: (() => {
+				const values = ["attempt-id", "request-id"];
+				return () => values.shift() ?? "unexpected-id";
+			})(),
+		});
+
+		expect(requests.map((request) => request.path)).toEqual([
+			"/api/prompt-pack-profile",
+			"/api/pack",
+			"/api/prompt-pack-ledger",
+		]);
+		expect(requests[0]?.body).toBeNull();
+		expect(requests[0]?.signal).not.toBe(requests[1]?.signal);
+		expect(requests[1]?.body).toMatchObject({
+			context: "investigate flaky test now check the fixture codemem example.ts",
+			working_set_files: ["packages/cli/src/example.ts"],
+			attempt: {
+				attempt_id: "attempt-id",
+				source: "claude",
+				stream_id: "claude-session",
+				request_id: "request-id",
+			},
+		});
+		expect(requests[2]?.body).toMatchObject({
+			action: "delivery",
+			attempt_id: "attempt-id",
+			delivery_status: "handed_off",
+		});
+		expect({ fallbackCalls, ingestionCalls }).toEqual({
+			fallbackCalls: 0,
+			ingestionCalls: 1,
+		});
+	});
+
+	it("drops working-set paths that the Viewer would reject", async () => {
+		for (const filePath of ["a/../../b", String.raw`C:\foo\bar`]) {
+			hook.trackClaudeSessionState(
+				{
+					hook_event_name: "PostToolUse",
+					session_id: "claude-session",
+					tool_name: "Edit",
+					tool_input: { filePath },
+				},
+				env,
+			);
+		}
+		let packBody: Record<string, unknown> | null = null;
+		await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
+			env,
+			fetchImpl: async (input: string | URL, init?: RequestInit) => {
+				const path = new URL(String(input)).pathname;
+				if (path.endsWith("profile")) {
+					return jsonResponse({
+						service: "codemem-viewer",
+						protocol_version: 1,
+						min_supported_protocol_version: 1,
+						db_path: dbPath,
+						identity_target: identity,
+					});
+				}
+				if (path.endsWith("pack")) {
+					packBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+					return jsonResponse({ pack_text: "PACK_BYTES", metrics: { total_items: 1 } });
+				}
+				return jsonResponse({ ok: true });
+			},
+			writeOutput: () => {},
+			spawnIngestion: () => {},
+			runFallback: () => null,
+		});
+
+		expect(packBody).toMatchObject({ working_set_files: [] });
+	});
+
+	it.each([
+		["delivered", { action: "delivery", delivery_status: "handed_off" }],
+		["empty", { action: "delivery", delivery_status: "unknown" }],
+		["skipped", { action: "record", retrieval_status: "skipped" }],
+		["cached", { action: "cache_reuse", original_attempt_id: "original-attempt" }],
+		["failed", { action: "record", retrieval_status: "failed" }],
+	] as const)("sends the %s state to the ledger", async (state, expected) => {
+		let ledgerBody: Record<string, unknown> | null = null;
+		const ok = await hook.recordClaudePromptLedgerState(
+			state,
+			{
+				attempt: {
+					attempt_id: "attempt-id",
+					started_at: "2026-08-16T00:00:00.000Z",
+					source: "claude",
+					request_id: "request-id",
+				},
+				details: { originalAttemptId: "original-attempt" },
+				env,
+				dbPath,
+				identity,
+			},
+			{
+				fetchImpl: async (_input: string | URL, init?: RequestInit) => {
+					ledgerBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+					return jsonResponse({ ok: true });
+				},
+			},
+		);
+
+		expect(ok).toBe(true);
+		expect(ledgerBody).toMatchObject(expected);
+	});
+
+	it("starts one fallback chain for retryable failure and none for terminal failure", async () => {
+		const fallbackPayloads: string[] = [];
+		const output: string[] = [];
+		const profile = {
+			service: "codemem-viewer",
+			protocol_version: 1,
+			min_supported_protocol_version: 1,
+			db_path: dbPath,
+			identity_target: identity,
+		};
+		const runFallback = (raw: string) => {
+			fallbackPayloads.push(raw);
+			return { continue: true };
+		};
+
+		await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
+			env,
+			fetchImpl: async () => jsonResponse({ error: { code: "profile_failed" } }, 503),
+			writeOutput: (value: string) => output.push(value),
+			spawnIngestion: () => {},
+			runFallback,
+		});
+		expect(fallbackPayloads).toHaveLength(1);
+
+		fallbackPayloads.length = 0;
+		await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
+			env,
+			fetchImpl: async (input: string | URL) =>
+				new URL(String(input)).pathname.endsWith("profile")
+					? jsonResponse(profile)
+					: new URL(String(input)).pathname.endsWith("ledger")
+						? jsonResponse({ ok: true })
+						: jsonResponse({ error: { code: "invalid_request", message: "bad request" } }, 400),
+			writeOutput: (value: string) => output.push(value),
+			spawnIngestion: () => {},
+			runFallback,
+		});
+		expect(fallbackPayloads).toHaveLength(0);
+	});
+
+	it.each([
+		{ kind: "profile_absent" },
+		{ kind: "profile_malformed" },
+		{ kind: "protocol_range_mismatch" },
+		{ kind: "network_unavailable" },
+		{ kind: "network_timeout" },
+		{ kind: "network_reset" },
+		{ kind: "viewer_restart" },
+		{ kind: "malformed_response" },
+		{ kind: "database_mismatch" },
+		{ kind: "runtime_identity_mismatch" },
+		{ kind: "invalid_request" },
+		{ kind: "policy_failure" },
+		{ kind: "authorization_failure" },
+		{ kind: "viewer_contract_unsupported", compatibleProfile: false },
+		{ kind: "viewer_contract_unsupported", compatibleProfile: true },
+	] satisfies PromptTransportFailure[])('matches the core classifier for "$kind"', (failure) => {
+		expect(hook.classifyPromptTransportFailure(failure)).toBe(
+			classifyCorePromptTransportFailure(failure),
+		);
+	});
+
+	it("records disabled injection without probing the pack profile", async () => {
+		env.CODEMEM_INJECT_CONTEXT = "0";
+		const output: string[] = [];
+		const requestPaths: string[] = [];
+		await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
+			env,
+			fetchImpl: async (input: string | URL) => {
+				requestPaths.push(new URL(String(input)).pathname);
+				expect(output).toEqual(['{"continue":true}']);
+				return jsonResponse({ ok: true });
+			},
+			writeOutput: (value: string) => output.push(value),
+			spawnIngestion: () => {},
+		});
+
+		expect(requestPaths).toEqual(["/api/prompt-pack-ledger"]);
+	});
+
+	it("writes host output before a ledger timeout and caps the deadline at 500 ms", async () => {
+		const output: string[] = [];
+		const scheduled: number[] = [];
+		const profile = {
+			service: "codemem-viewer",
+			protocol_version: 1,
+			min_supported_protocol_version: 1,
+			db_path: dbPath,
+			identity_target: identity,
+		};
+
+		await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
+			env,
+			fetchImpl: async (input: string | URL) => {
+				const path = new URL(String(input)).pathname;
+				if (path.endsWith("profile")) return jsonResponse(profile);
+				if (path.endsWith("pack")) {
+					return jsonResponse({ pack_text: "PACK_BYTES", metrics: { total_items: 1 } });
+				}
+				expect(output).toEqual([
+					'{"continue":true,"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"PACK_BYTES"}}',
+				]);
+				return new Promise<Response>(() => {});
+			},
+			writeOutput: (value: string) => output.push(value),
+			spawnIngestion: () => {},
+			runFallback: () => null,
+			setTimer: (callback: () => void, milliseconds: number) => {
+				scheduled.push(milliseconds);
+				callback();
+				return { unref() {} };
+			},
+			clearTimer: () => {},
+		});
+
+		expect(scheduled).toEqual([500]);
+	});
+
+	it("rejects redirects and invokes only the classified compatibility fallback", async () => {
+		let fallbackCalls = 0;
+		await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
+			env,
+			fetchImpl: async () =>
+				new Response(null, { status: 307, headers: { Location: "/elsewhere" } }),
+			writeOutput: () => {},
+			spawnIngestion: () => {},
+			runFallback: () => {
+				fallbackCalls += 1;
+				return { continue: true };
+			},
+		});
+
+		expect(fallbackCalls).toBe(1);
+	});
+
+	it("uses the same session-state filename contract as the CLI fallback", () => {
+		hook.trackClaudeSessionState(payload, env, () => new Date("2026-08-16T00:00:00.000Z"));
+		const stateDirectory = env.CODEMEM_CLAUDE_HOOK_CONTEXT_DIR;
+		expect(stateDirectory).toBeTypeOf("string");
+		if (!stateDirectory) throw new Error("Claude hook state directory was not configured");
+		const stateFiles = readdirSync(stateDirectory).filter((name) => name.endsWith(".json"));
+		expect(stateFiles[0]?.startsWith(`${basename(String(payload.session_id))}-`)).toBe(true);
+	});
+});

--- a/plugins/claude/hooks/hooks.json
+++ b/plugins/claude/hooks/hooks.json
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-hook.sh"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-hook.mjs"
           }
         ]
       }

--- a/plugins/claude/scripts/ingest-hook.mjs
+++ b/plugins/claude/scripts/ingest-hook.mjs
@@ -1,21 +1,27 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	buildRawEventEnvelopeFromHook,
 	TRUSTED_HOOK_MAPPER_OPTIONS,
 } from "./codemem-normalizer.mjs";
+import { trackClaudeSessionState, viewerBaseUrl } from "./user-prompt-hook.mjs";
 
 const MAX_BODY_BYTES = 1_048_576;
+const scriptPath = fileURLToPath(import.meta.url);
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT || dirname(scriptDirectory);
 
 function isTruthy(value) {
-	return ["1", "true", "yes", "on"].includes(String(value ?? "").trim().toLowerCase());
+	return ["1", "true", "yes", "on"].includes(
+		String(value ?? "")
+			.trim()
+			.toLowerCase(),
+	);
 }
 
 function log(message) {
@@ -46,27 +52,37 @@ async function readStdin() {
 
 function pinnedVersion() {
 	try {
-		const manifest = JSON.parse(readFileSync(join(pluginRoot, ".claude-plugin", "plugin.json"), "utf8"));
-		return typeof manifest.version === "string" && manifest.version.trim() ? manifest.version.trim() : "latest";
+		const manifest = JSON.parse(
+			readFileSync(join(pluginRoot, ".claude-plugin", "plugin.json"), "utf8"),
+		);
+		return typeof manifest.version === "string" && manifest.version.trim()
+			? manifest.version.trim()
+			: "latest";
 	} catch {
 		return "latest";
 	}
 }
 
-async function postEnvelope(body) {
-	const host = process.env.CODEMEM_VIEWER_HOST?.trim() || "127.0.0.1";
-	const port = process.env.CODEMEM_VIEWER_PORT?.trim() || "38888";
-	const hostForUrl = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+export async function postEnvelope(body, overrides = {}) {
+	const baseUrl = viewerBaseUrl(overrides.env ?? process.env);
+	if (!baseUrl) return false;
 	try {
-		const response = await fetch(`http://${hostForUrl}:${port}/api/raw-events`, {
+		const response = await (overrides.fetchImpl ?? fetch)(`${baseUrl}/api/raw-events`, {
 			method: "POST",
+			redirect: "manual",
 			headers: { "Content-Type": "application/json" },
 			body,
-			signal: AbortSignal.timeout(5000),
+			signal: AbortSignal.timeout(overrides.timeoutMs ?? 5000),
 		});
+		if (response.status >= 300 && response.status < 400) return false;
 		if (!response.ok) return false;
 		const result = await response.json();
-		return result != null && typeof result === "object" && typeof result.inserted === "number" && typeof result.skipped === "number";
+		return (
+			result != null &&
+			typeof result === "object" &&
+			typeof result.inserted === "number" &&
+			typeof result.skipped === "number"
+		);
 	} catch {
 		return false;
 	}
@@ -81,28 +97,57 @@ function runFallback(command, args, body) {
 		timeout: 8000,
 	});
 	if (result.status === 0) return true;
-	const excerpt = String(result.stderr ?? "").replace(/[\u0000-\u001f\u007f]/g, " ").slice(0, 400);
-	log(`codemem enqueue-raw-event failed via ${command} rc=${result.status ?? 1} ms=${Date.now() - startedAt} stderr=${excerpt || "<empty>"}`);
+	const excerpt = [...String(result.stderr ?? "").slice(0, 400)]
+		.map((character) => {
+			const code = character.charCodeAt(0);
+			return code <= 0x1f || code === 0x7f ? " " : character;
+		})
+		.join("");
+	log(
+		`codemem enqueue-raw-event failed via ${command} rc=${result.status ?? 1} ms=${Date.now() - startedAt} stderr=${excerpt || "<empty>"}`,
+	);
 	return false;
 }
 
-try {
-	const raw = await readStdin();
-	if (!raw.trim() || isTruthy(process.env.CODEMEM_PLUGIN_IGNORE)) process.exit(0);
-	const nativePayload = JSON.parse(raw);
-	if (nativePayload == null || typeof nativePayload !== "object" || Array.isArray(nativePayload)) throw new Error("payload must be a JSON object");
+async function runClaudeIngestHook() {
+	try {
+		const raw = await readStdin();
+		if (!raw.trim() || isTruthy(process.env.CODEMEM_PLUGIN_IGNORE)) return 0;
+		const nativePayload = JSON.parse(raw);
+		if (nativePayload == null || typeof nativePayload !== "object" || Array.isArray(nativePayload))
+			throw new Error("payload must be a JSON object");
+		if (nativePayload.hook_event_name !== "UserPromptSubmit") {
+			trackClaudeSessionState(nativePayload);
+		}
 
-	const envelope = buildRawEventEnvelopeFromHook(nativePayload, TRUSTED_HOOK_MAPPER_OPTIONS);
-	if (envelope === null) process.exit(0);
-	const envelopeBody = JSON.stringify(envelope);
+		const envelope = buildRawEventEnvelopeFromHook(nativePayload, TRUSTED_HOOK_MAPPER_OPTIONS);
+		if (envelope === null) return 0;
+		const envelopeBody = JSON.stringify(envelope);
 
-	if (await postEnvelope(envelopeBody)) process.exit(0);
-	if (await postEnvelope(envelopeBody)) process.exit(0);
-	if (runFallback("codemem", ["enqueue-raw-event"], envelopeBody)) process.exit(0);
-	if (runFallback("npx", ["-y", `codemem@${pinnedVersion()}`, "enqueue-raw-event"], envelopeBody)) process.exit(0);
-	log("codemem enqueue-raw-event failed: all command attempts failed");
-	process.exit(1);
-} catch (error) {
-	log(`codemem Claude hook ingest failed: ${error instanceof Error ? error.message : String(error)}`);
-	process.exit(1);
+		if (await postEnvelope(envelopeBody)) return 0;
+		if (await postEnvelope(envelopeBody)) return 0;
+		if (runFallback("codemem", ["enqueue-raw-event"], envelopeBody)) return 0;
+		if (runFallback("npx", ["-y", `codemem@${pinnedVersion()}`, "enqueue-raw-event"], envelopeBody))
+			return 0;
+		log("codemem enqueue-raw-event failed: all command attempts failed");
+		return 1;
+	} catch (error) {
+		log(
+			`codemem Claude hook ingest failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return 1;
+	}
+}
+
+function isMainModule(argvPath = process.argv[1]) {
+	if (!argvPath) return false;
+	try {
+		return realpathSync(resolve(argvPath)) === realpathSync(scriptPath);
+	} catch {
+		return false;
+	}
+}
+
+if (isMainModule()) {
+	process.exit(await runClaudeIngestHook());
 }

--- a/plugins/claude/scripts/user-prompt-hook.mjs
+++ b/plugins/claude/scripts/user-prompt-hook.mjs
@@ -1,0 +1,814 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	realpathSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, posix, relative, resolve, win32 } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_MAX_CHARS = 16_000;
+const DEFAULT_PACK_LIMIT = 8;
+const DEFAULT_TOKEN_BUDGET = 800;
+const DEFAULT_VIEWER_PORT = 38_888;
+const LEDGER_TIMEOUT_MS = 500;
+const MAX_QUERY_CHARS = 500;
+const MAX_QUERY_FILE_BASENAMES = 5;
+const MAX_WORKING_SET_PATHS = 8;
+const MAX_WORKING_SET_PATH_CHARS = 512;
+const PROMPT_TRANSPORT_PROTOCOL_RANGE = Object.freeze({
+	minSupportedProtocolVersion: 1,
+	protocolVersion: 1,
+});
+const scriptPath = fileURLToPath(import.meta.url);
+const scriptDirectory = dirname(scriptPath);
+
+function isRecord(value) {
+	return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isTruthy(value) {
+	return ["1", "true", "yes", "on"].includes(
+		String(value ?? "")
+			.trim()
+			.toLowerCase(),
+	);
+}
+
+function isEnabled(value) {
+	return !["0", "false", "off"].includes(
+		String(value ?? "")
+			.trim()
+			.toLowerCase(),
+	);
+}
+
+function parsePositiveInt(value, fallback) {
+	const parsed = Number.parseInt(String(value ?? ""), 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function expandHome(value, env = process.env) {
+	if (value === "~") return env.HOME?.trim() || homedir();
+	if (value.startsWith("~/")) return join(env.HOME?.trim() || homedir(), value.slice(2));
+	return value;
+}
+
+function normalizeIdentityPath(value, cwd, env) {
+	const trimmed = String(value ?? "").trim();
+	if (!trimmed) return null;
+	return resolve(cwd, expandHome(trimmed, env));
+}
+
+function resolveDbPath(cwd, env) {
+	return resolve(cwd, expandHome(env.CODEMEM_DB?.trim() || "~/.codemem/mem.sqlite", env));
+}
+
+function identityTarget(cwd, env) {
+	return {
+		device_id: env.CODEMEM_DEVICE_ID?.trim() || null,
+		actor_id_present: Object.hasOwn(env, "CODEMEM_ACTOR_ID"),
+		actor_id: env.CODEMEM_ACTOR_ID?.trim() || null,
+		config_path: normalizeIdentityPath(env.CODEMEM_CONFIG, cwd, env),
+		runtime_root: normalizeIdentityPath(env.CODEMEM_RUNTIME_ROOT, cwd, env),
+		workspace_id: env.CODEMEM_WORKSPACE_ID?.trim() || null,
+		home_dir: normalizeIdentityPath(env.HOME || homedir(), cwd, env),
+		pack_compression: env.CODEMEM_PACK_COMPRESSION?.trim() || null,
+		embedding_disabled: ["1", "true", "yes"].includes(
+			String(env.CODEMEM_EMBEDDING_DISABLED ?? "").toLowerCase(),
+		),
+		embedding_model: env.CODEMEM_EMBEDDING_MODEL || "Xenova/bge-small-en-v1.5",
+	};
+}
+
+function canonicalJson(value) {
+	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+	if (isRecord(value)) {
+		return `{${Object.keys(value)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+			.join(",")}}`;
+	}
+	return JSON.stringify(value);
+}
+
+function normalizeProtocolRange(protocolVersion, minSupportedProtocolVersion) {
+	if (!Number.isSafeInteger(protocolVersion) || protocolVersion < 1) return null;
+	const minimum =
+		minSupportedProtocolVersion === undefined ? protocolVersion : minSupportedProtocolVersion;
+	if (!Number.isSafeInteger(minimum) || minimum < 1 || minimum > protocolVersion) return null;
+	return { minSupportedProtocolVersion: minimum, protocolVersion };
+}
+
+function protocolRangesOverlap(left, right) {
+	return (
+		left.minSupportedProtocolVersion <= right.protocolVersion &&
+		right.minSupportedProtocolVersion <= left.protocolVersion
+	);
+}
+
+export function classifyPromptTransportFailure({ kind, compatibleProfile = false }) {
+	if (kind === "database_mismatch" || kind === "runtime_identity_mismatch") {
+		return "local_fallback";
+	}
+	if (kind === "invalid_request" || kind === "policy_failure" || kind === "authorization_failure") {
+		return "terminal";
+	}
+	if (kind === "viewer_contract_unsupported") {
+		return compatibleProfile ? "terminal" : "fallback";
+	}
+	return "fallback";
+}
+
+function errorCode(body) {
+	return isRecord(body) && isRecord(body.error) && typeof body.error.code === "string"
+		? body.error.code
+		: null;
+}
+
+function classifyHttpFailure({
+	status = null,
+	body = null,
+	malformed = false,
+	compatibleProfile = false,
+}) {
+	if (malformed) return classifyPromptTransportFailure({ kind: "malformed_response" });
+	const code = errorCode(body);
+	if (code === "viewer_db_mismatch") {
+		return classifyPromptTransportFailure({ kind: "database_mismatch" });
+	}
+	if (code === "viewer_identity_mismatch") {
+		return classifyPromptTransportFailure({ kind: "runtime_identity_mismatch" });
+	}
+	if (code === "viewer_contract_unsupported") {
+		return classifyPromptTransportFailure({
+			kind: "viewer_contract_unsupported",
+			compatibleProfile,
+		});
+	}
+	if (code === "invalid_request") {
+		return classifyPromptTransportFailure({ kind: "invalid_request" });
+	}
+	if (
+		status === 401 ||
+		status === 403 ||
+		["authorization_failed", "forbidden", "unauthorized"].includes(code)
+	) {
+		return classifyPromptTransportFailure({ kind: "authorization_failure" });
+	}
+	if (["policy_denied", "policy_disabled"].includes(code)) {
+		return classifyPromptTransportFailure({ kind: "policy_failure" });
+	}
+	return "fallback";
+}
+
+export function viewerBaseUrl(env = process.env) {
+	const configuredHost = env.CODEMEM_VIEWER_HOST?.trim() || "127.0.0.1";
+	const normalizedHost = configuredHost.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+	const ipv4Parts = normalizedHost.split(".");
+	const isIpv4Loopback =
+		ipv4Parts.length === 4 &&
+		ipv4Parts[0] === "127" &&
+		ipv4Parts.every(
+			(part) => /^\d+$/.test(part) && String(Number(part)) === part && Number(part) <= 255,
+		);
+	const urlHost =
+		normalizedHost === "localhost" || isIpv4Loopback
+			? normalizedHost
+			: normalizedHost === "::1" || normalizedHost === "0:0:0:0:0:0:0:1"
+				? "[::1]"
+				: null;
+	if (!urlHost) return null;
+	const port = parsePositiveInt(env.CODEMEM_VIEWER_PORT, DEFAULT_VIEWER_PORT);
+	return `http://${urlHost}:${port}`;
+}
+
+async function responseJson(response) {
+	try {
+		return await response.json();
+	} catch {
+		return null;
+	}
+}
+
+async function readViewerProfile({
+	fetchImpl,
+	env,
+	expectedDbPath,
+	expectedIdentity,
+	protocolRange,
+	timeoutSignal,
+}) {
+	const baseUrl = viewerBaseUrl(env);
+	if (!baseUrl) {
+		return { ok: false, disposition: classifyPromptTransportFailure({ kind: "policy_failure" }) };
+	}
+	let response;
+	try {
+		response = await fetchImpl(`${baseUrl}/api/prompt-pack-profile`, {
+			method: "GET",
+			redirect: "manual",
+			signal: timeoutSignal,
+		});
+	} catch {
+		return { ok: false, disposition: "fallback" };
+	}
+	const body = await responseJson(response);
+	if (response.status >= 300 && response.status < 400) {
+		return { ok: false, disposition: "fallback" };
+	}
+	if (!response.ok) {
+		return { ok: false, disposition: classifyHttpFailure({ status: response.status, body }) };
+	}
+	const viewerRange = isRecord(body)
+		? normalizeProtocolRange(body.protocol_version, body.min_supported_protocol_version)
+		: null;
+	if (!isRecord(body) || body.service !== "codemem-viewer" || !viewerRange) {
+		return {
+			ok: false,
+			disposition: classifyPromptTransportFailure({ kind: "profile_malformed" }),
+		};
+	}
+	if (!protocolRangesOverlap(protocolRange, viewerRange)) {
+		return {
+			ok: false,
+			disposition: classifyPromptTransportFailure({ kind: "protocol_range_mismatch" }),
+		};
+	}
+	if (body.db_path !== expectedDbPath) {
+		return {
+			ok: false,
+			disposition: classifyPromptTransportFailure({ kind: "database_mismatch" }),
+		};
+	}
+	if (canonicalJson(body.identity_target) !== canonicalJson(expectedIdentity)) {
+		return {
+			ok: false,
+			disposition: classifyPromptTransportFailure({ kind: "runtime_identity_mismatch" }),
+		};
+	}
+	return { ok: true };
+}
+
+function normalizePromptText(value) {
+	return typeof value === "string" ? value.trim().replaceAll("\n", " ") : "";
+}
+
+function stableSessionSuffix(sessionId) {
+	let hash = 0xcbf29ce484222325n;
+	for (const byte of Buffer.from(sessionId, "utf8")) {
+		hash ^= BigInt(byte);
+		hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+	}
+	return hash.toString(16).padStart(16, "0");
+}
+
+function sessionStatePath(sessionId, env = process.env) {
+	const root = expandHome(
+		env.CODEMEM_CLAUDE_HOOK_CONTEXT_DIR?.trim() || "~/.codemem/claude-hook-context",
+		env,
+	);
+	const label = sessionId
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 24);
+	return join(root, `${label || "session"}-${stableSessionSuffix(sessionId.trim())}.json`);
+}
+
+function defaultSessionState() {
+	return { first_prompt: "", last_prompt: "", files_modified: [], updated_at: "" };
+}
+
+function loadSessionState(sessionId, env) {
+	try {
+		const parsed = JSON.parse(readFileSync(sessionStatePath(sessionId, env), "utf8"));
+		if (!isRecord(parsed)) return defaultSessionState();
+		return {
+			first_prompt: typeof parsed.first_prompt === "string" ? parsed.first_prompt.trim() : "",
+			last_prompt: typeof parsed.last_prompt === "string" ? parsed.last_prompt.trim() : "",
+			files_modified: Array.isArray(parsed.files_modified)
+				? parsed.files_modified
+						.filter((item) => typeof item === "string" && item.trim())
+						.slice(0, 64)
+				: [],
+			updated_at: typeof parsed.updated_at === "string" ? parsed.updated_at.trim() : "",
+		};
+	} catch {
+		return defaultSessionState();
+	}
+}
+
+function saveSessionState(sessionId, state, env) {
+	const path = sessionStatePath(sessionId, env);
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(`${path}.tmp`, JSON.stringify(state), "utf8");
+	renameSync(`${path}.tmp`, path);
+}
+
+function modifiedPaths(payload) {
+	if (!isRecord(payload.tool_input)) return [];
+	const toolName = String(payload.tool_name ?? "")
+		.trim()
+		.toLowerCase();
+	if (!["edit", "write", "multiedit", "notebookedit", "apply_patch"].includes(toolName)) {
+		return [];
+	}
+	const values = [
+		payload.tool_input.filePath,
+		payload.tool_input.file_path,
+		payload.tool_input.path,
+	];
+	const paths = values
+		.filter((value) => typeof value === "string" && value.trim())
+		.map((value) => value.trim());
+	if (toolName === "apply_patch") {
+		const patchText = payload.tool_input.patchText || payload.tool_input.patch;
+		if (typeof patchText === "string") {
+			for (const line of patchText.split(/\r?\n/)) {
+				const match = line.match(/^\*\*\* (?:Update|Add|Delete) File: (.+)$/);
+				const path = match?.[1]?.trim();
+				if (path) paths.push(path);
+			}
+		}
+	}
+	return [...new Set(paths)];
+}
+
+export function trackClaudeSessionState(payload, env = process.env, now = () => new Date()) {
+	const sessionId = typeof payload.session_id === "string" ? payload.session_id.trim() : "";
+	if (!sessionId) return null;
+	if (payload.hook_event_name === "SessionEnd") {
+		try {
+			rmSync(sessionStatePath(sessionId, env), { force: true });
+		} catch {
+			// State cleanup is best effort.
+		}
+		return null;
+	}
+	const state = loadSessionState(sessionId, env);
+	let changed = false;
+	if (payload.hook_event_name === "UserPromptSubmit") {
+		const prompt = normalizePromptText(payload.prompt);
+		if (prompt && !state.first_prompt) {
+			state.first_prompt = prompt;
+			changed = true;
+		}
+		if (prompt && state.last_prompt !== prompt) {
+			state.last_prompt = prompt;
+			changed = true;
+		}
+	} else if (["PostToolUse", "PostToolUseFailure"].includes(payload.hook_event_name)) {
+		const files = state.files_modified.filter((path) => path.trim());
+		for (const path of modifiedPaths(payload)) {
+			if (!files.includes(path)) {
+				files.push(path);
+				changed = true;
+			}
+		}
+		state.files_modified = files.slice(-64);
+	}
+	if (changed) {
+		state.updated_at = now().toISOString();
+		try {
+			saveSessionState(sessionId, state, env);
+		} catch {
+			// Session hints are best effort and must not fail a hook.
+		}
+	}
+	return state;
+}
+
+function normalizeProjectLabel(value) {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	let end = trimmed.length;
+	while (end > 0 && [47, 92].includes(trimmed.charCodeAt(end - 1))) end -= 1;
+	const cleaned = trimmed.slice(0, end);
+	if (!cleaned) return null;
+	return cleaned.replaceAll("\\", "/").split("/").at(-1) || null;
+}
+
+function inferProjectFromCwd(cwd, env) {
+	if (typeof cwd !== "string" || !cwd.trim()) return null;
+	const expanded = expandHome(cwd.trim(), env);
+	if (!isAbsolute(expanded)) return null;
+	try {
+		if (!statSync(expanded).isDirectory()) return null;
+	} catch {
+		return null;
+	}
+	let current = expanded;
+	while (true) {
+		if (existsSync(resolve(current, ".git"))) return basename(current) || null;
+		const parent = dirname(current);
+		if (parent === current) return basename(expanded) || null;
+		current = parent;
+	}
+}
+
+function resolveProject(payload, env) {
+	return (
+		normalizeProjectLabel(env.CODEMEM_PROJECT) ??
+		inferProjectFromCwd(payload.cwd, env) ??
+		normalizeProjectLabel(payload.project)
+	);
+}
+
+function buildInjectQuery(prompt, project, state) {
+	const firstPrompt = state ? normalizePromptText(state.first_prompt) : "";
+	const parts = [];
+	if (firstPrompt) parts.push(firstPrompt);
+	if (prompt && prompt !== firstPrompt && prompt.length > 5) parts.push(prompt);
+	if (project) parts.push(project);
+	const names = (state?.files_modified ?? [])
+		.filter((path) => path.trim())
+		.slice(-MAX_QUERY_FILE_BASENAMES)
+		.map((path) => basename(path.replaceAll("\\", "/")))
+		.filter(Boolean);
+	if (names.length) parts.push(names.join(" "));
+	return (parts.join(" ") || "recent work").slice(0, MAX_QUERY_CHARS);
+}
+
+function truncateAdditionalContext(text, maxChars) {
+	const normalized = text.trim();
+	if (!normalized || normalized.length <= maxChars) return normalized;
+	return `${normalized.slice(0, maxChars).trimEnd()}\n\n[pack truncated]`;
+}
+
+function normalizeWorkingSetPath(value) {
+	const trimmed = value.trim();
+	if (
+		!trimmed ||
+		trimmed.length > MAX_WORKING_SET_PATH_CHARS ||
+		posix.isAbsolute(trimmed) ||
+		win32.isAbsolute(trimmed)
+	) {
+		return null;
+	}
+	const normalized = posix.normalize(trimmed.replaceAll("\\", "/")).replace(/^\.\//, "");
+	return !normalized || normalized === "." || normalized === ".." || normalized.startsWith("../")
+		? null
+		: normalized;
+}
+
+function continueOutput(additionalContext) {
+	return additionalContext
+		? {
+				continue: true,
+				hookSpecificOutput: {
+					hookEventName: "UserPromptSubmit",
+					additionalContext,
+				},
+			}
+		: { continue: true };
+}
+
+function attemptMetadata(payload, now, uuid) {
+	const sessionId = typeof payload.session_id === "string" ? payload.session_id.trim() : "";
+	return {
+		attempt_id: uuid(),
+		started_at: now().toISOString(),
+		source: "claude",
+		...(sessionId ? { stream_id: sessionId, source_session_id: sessionId } : {}),
+		request_id: uuid(),
+	};
+}
+
+function packBody({ query, project, payload, state, dbPath, identity, attempt, env }) {
+	const cwd = typeof payload.cwd === "string" && isAbsolute(payload.cwd) ? payload.cwd : null;
+	const workingSetFiles = (state?.files_modified ?? [])
+		.filter((path) => path.trim())
+		.slice(-MAX_WORKING_SET_PATHS)
+		.map((path) => (cwd && isAbsolute(path) ? relative(cwd, path) : path))
+		.map(normalizeWorkingSetPath)
+		.filter(Boolean);
+	return {
+		context: query,
+		limit: parsePositiveInt(env.CODEMEM_INJECT_LIMIT, DEFAULT_PACK_LIMIT),
+		token_budget: parsePositiveInt(env.CODEMEM_INJECT_TOKEN_BUDGET, DEFAULT_TOKEN_BUDGET),
+		...(project ? { project } : {}),
+		...(cwd ? { cwd } : {}),
+		working_set_files: workingSetFiles,
+		db_path: dbPath,
+		identity_target: identity,
+		attempt,
+	};
+}
+
+function validPackResponse(body) {
+	return (
+		isRecord(body) &&
+		typeof body.pack_text === "string" &&
+		isRecord(body.metrics) &&
+		Number.isInteger(body.metrics.total_items) &&
+		body.metrics.total_items >= 0
+	);
+}
+
+async function postPack({ fetchImpl, env, body, timeoutSignal }) {
+	const baseUrl = viewerBaseUrl(env);
+	if (!baseUrl) {
+		return { ok: false, disposition: classifyPromptTransportFailure({ kind: "policy_failure" }) };
+	}
+	let response;
+	try {
+		response = await fetchImpl(`${baseUrl}/api/pack`, {
+			method: "POST",
+			redirect: "manual",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+			signal: timeoutSignal,
+		});
+	} catch {
+		return { ok: false, disposition: "fallback" };
+	}
+	const responseBody = await responseJson(response);
+	if (response.status >= 300 && response.status < 400) {
+		return { ok: false, disposition: "fallback" };
+	}
+	if (!response.ok) {
+		return {
+			ok: false,
+			disposition: classifyHttpFailure({
+				status: response.status,
+				body: responseBody,
+				compatibleProfile: true,
+			}),
+		};
+	}
+	if (!validPackResponse(responseBody)) {
+		return { ok: false, disposition: classifyHttpFailure({ malformed: true }) };
+	}
+	return { ok: true, body: responseBody };
+}
+
+export function ledgerPayloadForState(state, attempt, details = {}) {
+	if (state === "delivered") {
+		return { action: "delivery", attempt_id: attempt.attempt_id, delivery_status: "handed_off" };
+	}
+	if (state === "empty") {
+		return { action: "delivery", attempt_id: attempt.attempt_id, delivery_status: "unknown" };
+	}
+	if (state === "cached") {
+		return { action: "cache_reuse", ...attempt, original_attempt_id: details.originalAttemptId };
+	}
+	return {
+		action: "record",
+		...attempt,
+		retrieval_status: state,
+		failure_code: details.failureCode || `${state}_prompt_pack`,
+		failure_stage: details.failureStage || (state === "skipped" ? "policy" : "retrieval"),
+	};
+}
+
+async function postLedger({ fetchImpl, env, payload, dbPath, identity, signal }) {
+	const baseUrl = viewerBaseUrl(env);
+	if (!baseUrl) throw new Error("viewer host must be loopback");
+	const response = await fetchImpl(`${baseUrl}/api/prompt-pack-ledger`, {
+		method: "POST",
+		redirect: "manual",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ ...payload, db_path: dbPath, identity_target: identity }),
+		signal,
+	});
+	if (response.status >= 300 && response.status < 400) throw new Error("ledger redirect rejected");
+	const body = await responseJson(response);
+	if (!response.ok || !isRecord(body) || body.ok !== true) throw new Error("ledger write failed");
+}
+
+export async function recordClaudePromptLedgerState(state, context, overrides = {}) {
+	const payload = ledgerPayloadForState(state, context.attempt, context.details);
+	return settleLedgerBestEffort(
+		(signal) =>
+			postLedger({
+				fetchImpl: overrides.fetchImpl ?? fetch,
+				env: context.env,
+				payload,
+				dbPath: context.dbPath,
+				identity: context.identity,
+				signal,
+			}),
+		overrides,
+	);
+}
+
+export async function settleLedgerBestEffort(task, deps = {}) {
+	const setTimer = deps.setTimer ?? setTimeout;
+	const clearTimer = deps.clearTimer ?? clearTimeout;
+	const controller = new AbortController();
+	let timer;
+	const deadline = new Promise((resolveDeadline) => {
+		timer = setTimer(() => {
+			controller.abort();
+			resolveDeadline(false);
+		}, LEDGER_TIMEOUT_MS);
+	});
+	timer?.unref?.();
+	try {
+		return await Promise.race([
+			Promise.resolve(task(controller.signal)).then(
+				() => true,
+				() => false,
+			),
+			deadline,
+		]);
+	} finally {
+		if (timer !== undefined) clearTimer(timer);
+	}
+}
+
+function pinnedVersion(env) {
+	const pluginRoot = env.CLAUDE_PLUGIN_ROOT || dirname(scriptDirectory);
+	try {
+		const manifest = JSON.parse(
+			readFileSync(join(pluginRoot, ".claude-plugin", "plugin.json"), "utf8"),
+		);
+		return typeof manifest.version === "string" && manifest.version.trim()
+			? manifest.version.trim()
+			: "latest";
+	} catch {
+		return "latest";
+	}
+}
+
+function runInject(command, args, raw, env) {
+	const result = spawnSync(command, args, {
+		input: raw,
+		encoding: "utf8",
+		stdio: ["pipe", "pipe", "ignore"],
+		timeout: 8_000,
+		env,
+	});
+	if (result.status !== 0) return null;
+	try {
+		const parsed = JSON.parse(String(result.stdout ?? "").trim());
+		return isRecord(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+function runCompatibilityFallback(raw, env) {
+	return (
+		runInject("codemem", ["claude-hook-inject"], raw, env) ??
+		runInject("npx", ["-y", `codemem@${pinnedVersion(env)}`, "claude-hook-inject"], raw, env)
+	);
+}
+
+function startIngestion(raw, env) {
+	try {
+		const child = spawn(process.execPath, [join(scriptDirectory, "ingest-hook.mjs")], {
+			detached: true,
+			stdio: ["pipe", "ignore", "ignore"],
+			env,
+		});
+		child.stdin.end(raw);
+		child.unref();
+	} catch {
+		// Event ingestion remains best effort and independent of prompt delivery.
+	}
+}
+
+async function readStdin() {
+	const chunks = [];
+	for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+	return Buffer.concat(chunks).toString("utf8");
+}
+
+export async function runClaudeUserPromptHook(raw, overrides = {}) {
+	const env = overrides.env ?? process.env;
+	const writeOutput = overrides.writeOutput ?? ((value) => process.stdout.write(value));
+	if (!raw.trim()) {
+		writeOutput(JSON.stringify(continueOutput()));
+		return;
+	}
+	if (isTruthy(env.CODEMEM_PLUGIN_IGNORE)) {
+		writeOutput(JSON.stringify(continueOutput()));
+		return;
+	}
+
+	let payload;
+	try {
+		payload = JSON.parse(raw);
+	} catch {
+		writeOutput(JSON.stringify(continueOutput()));
+		return;
+	}
+	if (!isRecord(payload)) {
+		writeOutput(JSON.stringify(continueOutput()));
+		return;
+	}
+
+	const spawnIngestion = overrides.spawnIngestion ?? startIngestion;
+	spawnIngestion(raw, env);
+	const state = trackClaudeSessionState(payload, env, overrides.now);
+	const prompt = normalizePromptText(payload.prompt);
+	const now = overrides.now ?? (() => new Date());
+	const uuid = overrides.uuid ?? randomUUID;
+	const attempt = attemptMetadata(payload, now, uuid);
+	const cwd =
+		typeof payload.cwd === "string" && isAbsolute(payload.cwd) ? payload.cwd : process.cwd();
+	const dbPath = resolveDbPath(cwd, env);
+	const identity = identityTarget(cwd, env);
+	const fetchImpl = overrides.fetchImpl ?? fetch;
+	const requestTimeoutMs = parsePositiveInt(env.CODEMEM_INJECT_HTTP_MAX_TIME_S, 2) * 1_000;
+	const requestTimeoutSignal = () => AbortSignal.timeout(requestTimeoutMs);
+
+	if (!isEnabled(env.CODEMEM_INJECT_CONTEXT ?? "1")) {
+		writeOutput(JSON.stringify(continueOutput()));
+		await recordClaudePromptLedgerState(
+			"skipped",
+			{
+				attempt,
+				details: { failureCode: "injection_disabled" },
+				env,
+				dbPath,
+				identity,
+			},
+			{ ...overrides, fetchImpl },
+		);
+		return;
+	}
+	if (!prompt) {
+		writeOutput(JSON.stringify(continueOutput()));
+		return;
+	}
+
+	const project = resolveProject(payload, env);
+	const query = buildInjectQuery(prompt, project, state);
+	const profile = await readViewerProfile({
+		fetchImpl,
+		env,
+		expectedDbPath: dbPath,
+		expectedIdentity: identity,
+		protocolRange: overrides.protocolRange ?? PROMPT_TRANSPORT_PROTOCOL_RANGE,
+		timeoutSignal: requestTimeoutSignal(),
+	});
+	const packResult = profile.ok
+		? await postPack({
+				fetchImpl,
+				env,
+				body: packBody({ query, project, payload, state, dbPath, identity, attempt, env }),
+				timeoutSignal: requestTimeoutSignal(),
+			})
+		: profile;
+
+	if (!packResult.ok && packResult.disposition !== "terminal") {
+		const fallback = overrides.runFallback
+			? overrides.runFallback(raw, env)
+			: runCompatibilityFallback(raw, env);
+		writeOutput(JSON.stringify(fallback ?? continueOutput()));
+		return;
+	}
+
+	if (!packResult.ok) {
+		writeOutput(JSON.stringify(continueOutput()));
+		await recordClaudePromptLedgerState(
+			"failed",
+			{
+				attempt,
+				details: { failureCode: "viewer_request_rejected" },
+				env,
+				dbPath,
+				identity,
+			},
+			{ ...overrides, fetchImpl },
+		);
+		return;
+	}
+
+	const maxChars = parsePositiveInt(env.CODEMEM_INJECT_MAX_CHARS, DEFAULT_MAX_CHARS);
+	const additionalContext = truncateAdditionalContext(packResult.body.pack_text, maxChars);
+	writeOutput(JSON.stringify(continueOutput(additionalContext)));
+	const ledgerState = additionalContext ? "delivered" : "empty";
+	await recordClaudePromptLedgerState(
+		ledgerState,
+		{ attempt, env, dbPath, identity },
+		{ ...overrides, fetchImpl },
+	);
+}
+
+function isMainModule(argvPath = process.argv[1]) {
+	if (!argvPath) return false;
+	try {
+		return realpathSync(resolve(argvPath)) === realpathSync(scriptPath);
+	} catch {
+		return false;
+	}
+}
+
+if (isMainModule()) {
+	await runClaudeUserPromptHook(await readStdin());
+}


### PR DESCRIPTION
## Description

Move Claude UserPromptSubmit retrieval to the packaged dependency-free Node hook. The healthy path validates the local Viewer profile and identity, requests the pack directly, writes byte-compatible additionalContext, and records delivery with a 500 ms cap. Retryable failures use the local compatibility chain; terminal failures fail closed.

Claude prompt and event HTTP transport now enforce loopback-only Viewer targets. This PR also adds packed-artifact coverage, classifier parity tests, Viewer-compatible working-set normalization, per-request timeouts, and Biome coverage for the dependency-free Claude scripts.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation:
- `pnpm --filter codemem test:packed-artifact`
- Focused Claude hook tests: 55 passed
- Full workspace suite: 194 files, 4,366 passed, 3 todo
- Snyk Code scan at high threshold: 0 issues

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced