### PR TITLE
test(adapters): prove packaged transport parity

### DIFF
--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -68,12 +68,14 @@ function runAsync(command, args, options, input) {
 async function smokeAdapterWrapper(source, isolatedRoot) {
 	const relativeRoot = join("plugins", source);
 	const scriptsDirectory = join(isolatedRoot, relativeRoot, "scripts");
+	const sourceScriptsDirectory = resolve(workspaceRoot, relativeRoot, "scripts");
 	const wrapperPath = join(scriptsDirectory, "ingest-hook.mjs");
-	cpSync(resolve(workspaceRoot, relativeRoot, "scripts", "ingest-hook.mjs"), wrapperPath);
-	cpSync(
-		resolve(workspaceRoot, relativeRoot, "scripts", "user-prompt-hook.mjs"),
-		join(scriptsDirectory, "user-prompt-hook.mjs"),
-	);
+	for (const scriptName of readdirSync(sourceScriptsDirectory)) {
+		if (scriptName === "codemem-normalizer.mjs") continue;
+		cpSync(join(sourceScriptsDirectory, scriptName), join(scriptsDirectory, scriptName), {
+			recursive: true,
+		});
+	}
 	cpSync(
 		resolve(workspaceRoot, relativeRoot, source === "claude" ? ".claude-plugin" : ".codex-plugin"),
 		join(isolatedRoot, relativeRoot, source === "claude" ? ".claude-plugin" : ".codex-plugin"),
@@ -154,6 +156,23 @@ async function smokeAdapterWrapper(source, isolatedRoot) {
 	} finally {
 		server.close();
 	}
+}
+
+function auditIsolatedAdapterRoutes(source, isolatedRoot) {
+	const scriptsDirectory = join(isolatedRoot, "plugins", source, "scripts");
+	const wrapperContents = readdirSync(scriptsDirectory)
+		.filter((name) => name.endsWith(".mjs") || name.endsWith(".sh"))
+		.map((name) => readFileSync(join(scriptsDirectory, name), "utf8"));
+	for (const namedRoute of ["/api/claude-hooks", "/api/codex-hooks"]) {
+		assert(
+			wrapperContents.every((content) => !content.includes(namedRoute)),
+			`${source} isolated current wrappers still call compatibility route ${namedRoute}`,
+		);
+	}
+	assert(
+		wrapperContents.some((content) => content.includes("/api/raw-events")),
+		`${source} isolated current wrappers are missing canonical /api/raw-events transport`,
+	);
 }
 
 async function smokeClaudePromptWrapper(isolatedRoot) {
@@ -601,6 +620,7 @@ try {
 		);
 		assert(existsSync(checkedInArtifact), `${source} plugin is missing its generated normalizer`);
 		await smokeAdapterWrapper(source, isolatedAdapters);
+		auditIsolatedAdapterRoutes(source, isolatedAdapters);
 		if (source === "claude") await smokeClaudePromptWrapper(isolatedAdapters);
 		if (source === "codex") await smokeCodexPromptWrapper(isolatedAdapters);
 	}

--- a/packages/cli/src/commands/claude-user-prompt-hook.test.ts
+++ b/packages/cli/src/commands/claude-user-prompt-hook.test.ts
@@ -221,6 +221,60 @@ describe("dependency-free Claude user prompt hook", () => {
 		});
 	});
 
+	it.each([
+		{
+			label: "an old v1 client against a current Viewer range",
+			clientRange: { minSupportedProtocolVersion: 1, protocolVersion: 1 },
+			profile: { protocol_version: 2, min_supported_protocol_version: 1 },
+		},
+		{
+			label: "a newer v2 client against a stale single-version Viewer",
+			clientRange: { minSupportedProtocolVersion: 1, protocolVersion: 2 },
+			profile: { protocol_version: 1 },
+		},
+	])("uses direct pack and ledger transport for $label", async ({ clientRange, profile }) => {
+		const requestPaths: string[] = [];
+		const output: string[] = [];
+		let ledgerBody: Record<string, unknown> | null = null;
+		let fallbackCalls = 0;
+		await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
+			env,
+			protocolRange: clientRange,
+			fetchImpl: async (input: string | URL, init?: RequestInit) => {
+				const path = new URL(String(input)).pathname;
+				requestPaths.push(path);
+				if (path.endsWith("profile")) {
+					return jsonResponse({
+						service: "codemem-viewer",
+						...profile,
+						db_path: dbPath,
+						identity_target: identity,
+					});
+				}
+				if (path.endsWith("pack")) {
+					return jsonResponse({ pack_text: "SKEW_PACK", metrics: { total_items: 1 } });
+				}
+				ledgerBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return jsonResponse({ ok: true });
+			},
+			writeOutput: (value: string) => output.push(value),
+			spawnIngestion: () => {},
+			runFallback: () => {
+				fallbackCalls += 1;
+				return { continue: true };
+			},
+		});
+
+		expect(requestPaths).toEqual([
+			"/api/prompt-pack-profile",
+			"/api/pack",
+			"/api/prompt-pack-ledger",
+		]);
+		expect(output[0]).toContain("SKEW_PACK");
+		expect(ledgerBody).toMatchObject({ action: "delivery", delivery_status: "handed_off" });
+		expect(fallbackCalls).toBe(0);
+	});
+
 	it("drops working-set paths that the Viewer would reject", async () => {
 		for (const filePath of ["a/../../b", String.raw`C:\foo\bar`]) {
 			hook.trackClaudeSessionState(
@@ -295,7 +349,7 @@ describe("dependency-free Claude user prompt hook", () => {
 		expect(ledgerBody).toMatchObject(expected);
 	});
 
-	it("starts one fallback chain for retryable failure and none for terminal failure", async () => {
+	it("falls back once for a stale profile and fails closed for a compatible contract defect", async () => {
 		const fallbackPayloads: string[] = [];
 		const output: string[] = [];
 		const profile = {
@@ -312,7 +366,7 @@ describe("dependency-free Claude user prompt hook", () => {
 
 		await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
 			env,
-			fetchImpl: async () => jsonResponse({ error: { code: "profile_failed" } }, 503),
+			fetchImpl: async () => jsonResponse({ error: { code: "not_found" } }, 404),
 			writeOutput: (value: string) => output.push(value),
 			spawnIngestion: () => {},
 			runFallback,
@@ -325,9 +379,7 @@ describe("dependency-free Claude user prompt hook", () => {
 			fetchImpl: async (input: string | URL) =>
 				new URL(String(input)).pathname.endsWith("profile")
 					? jsonResponse(profile)
-					: new URL(String(input)).pathname.endsWith("ledger")
-						? jsonResponse({ ok: true })
-						: jsonResponse({ error: { code: "invalid_request", message: "bad request" } }, 400),
+					: jsonResponse({ error: { code: "viewer_contract_unsupported" } }, 409),
 			writeOutput: (value: string) => output.push(value),
 			spawnIngestion: () => {},
 			runFallback,

--- a/packages/cli/src/commands/codex-user-prompt-hook.test.ts
+++ b/packages/cli/src/commands/codex-user-prompt-hook.test.ts
@@ -385,6 +385,60 @@ describe("dependency-free Codex user prompt hook", () => {
 	});
 
 	it.each([
+		{
+			label: "an old v1 client against a current Viewer range",
+			clientRange: { minSupportedProtocolVersion: 1, protocolVersion: 1 },
+			profile: { protocol_version: 2, min_supported_protocol_version: 1 },
+		},
+		{
+			label: "a newer v2 client against a stale single-version Viewer",
+			clientRange: { minSupportedProtocolVersion: 1, protocolVersion: 2 },
+			profile: { protocol_version: 1 },
+		},
+	])("uses direct pack and ledger transport for $label", async ({ clientRange, profile }) => {
+		const requestPaths: string[] = [];
+		const output: string[] = [];
+		let ledgerBody: Record<string, unknown> | null = null;
+		let fallbackCalls = 0;
+		await hook.runCodexUserPromptHook(JSON.stringify(payload), {
+			env,
+			protocolRange: clientRange,
+			fetchImpl: async (input: string | URL, init?: RequestInit) => {
+				const path = new URL(String(input)).pathname;
+				requestPaths.push(path);
+				if (path.endsWith("profile")) {
+					return jsonResponse({
+						service: "codemem-viewer",
+						...profile,
+						db_path: dbPath,
+						identity_target: identity,
+					});
+				}
+				if (path.endsWith("pack")) {
+					return jsonResponse({ pack_text: "SKEW_PACK", metrics: { total_items: 1 } });
+				}
+				ledgerBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return jsonResponse({ ok: true });
+			},
+			writeOutput: (value: string) => output.push(value),
+			spawnIngestion: () => {},
+			runFallback: () => {
+				fallbackCalls += 1;
+				return { continue: true };
+			},
+		});
+
+		expect(requestPaths).toEqual([
+			"/api/prompt-pack-profile",
+			"/api/pack",
+			"/api/prompt-pack-ledger",
+		]);
+		expect(output[0]).toContain("SKEW_PACK");
+		expect(ledgerBody).toMatchObject({ action: "delivery", delivery_status: "handed_off" });
+		expect(fallbackCalls).toBe(0);
+	});
+
+	it.each([
 		["delivered", { action: "delivery", delivery_status: "handed_off" }],
 		["empty", { action: "delivery", delivery_status: "unknown" }],
 		["skipped", { action: "record", retrieval_status: "skipped" }],

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -591,6 +591,68 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("accepts additive adapter metadata without changing canonical raw-event rows", async () => {
+			const baseline = createTestApp();
+			const additive = createTestApp();
+			try {
+				const envelope = core.buildRawEventEnvelopeFromHook(
+					{
+						hook_event_name: "UserPromptSubmit",
+						session_id: "session-additive-adapter-meta",
+						prompt: "same normalized prompt",
+						ts: "2026-08-16T12:00:00Z",
+					},
+					core.TRUSTED_HOOK_MAPPER_OPTIONS,
+				);
+				expect(envelope).not.toBeNull();
+				if (!envelope) throw new Error("current Claude normalizer skipped prompt fixture");
+				const additiveEnvelope = structuredClone(envelope);
+				const adapter = additiveEnvelope.payload._adapter as {
+					meta: Record<string, unknown>;
+				};
+				adapter.meta.future_adapter_revision = 2;
+
+				const baselineResponse = await postViewerJson(baseline.app, "/api/raw-events", envelope);
+				const additiveResponse = await postViewerJson(
+					additive.app,
+					"/api/raw-events",
+					additiveEnvelope,
+				);
+				expect(await baselineResponse.json()).toEqual({
+					inserted: 1,
+					skipped: 0,
+					received: 1,
+				});
+				expect(await additiveResponse.json()).toEqual({
+					inserted: 1,
+					skipped: 0,
+					received: 1,
+				});
+
+				const baselineState = rawEventState(baseline.ensureStore());
+				const additiveState = rawEventState(additive.ensureStore());
+				expect(additiveState.sessions).toEqual(baselineState.sessions);
+				const baselineEvent = baselineState.events[0] as Record<string, unknown>;
+				const additiveEvent = additiveState.events[0] as Record<string, unknown>;
+				const { payload_json: baselinePayloadJson, ...baselineColumns } = baselineEvent;
+				const { payload_json: additivePayloadJson, ...additiveColumns } = additiveEvent;
+				expect(additiveColumns).toEqual(baselineColumns);
+				const baselinePayload = JSON.parse(String(baselinePayloadJson)) as Record<string, unknown>;
+				const additivePayload = JSON.parse(String(additivePayloadJson)) as Record<string, unknown>;
+				const additiveAdapter = additivePayload._adapter as { meta: Record<string, unknown> };
+				const { future_adapter_revision: futureAdapterRevision, ...compatibleMeta } =
+					additiveAdapter.meta;
+				expect(futureAdapterRevision).toBe(2);
+				expect({
+					...additivePayload,
+					_adapter: { ...additiveAdapter, meta: compatibleMeta },
+				}).toEqual(baselinePayload);
+			} finally {
+				baseline.cleanup();
+				additive.cleanup();
+			}
+		});
+
 		it("reports duplicate skips and nudges every validated session on retries", async () => {
 			const nudge = vi.fn();
 			const { app, cleanup } = createTestApp({ sweeper: { nudge } });


### PR DESCRIPTION
## Description

Proves the packaged adapter prompt transport parity delivered by the two preceding stack layers.

- exercises current packaged Claude and Codex wrappers without a global `codemem` CLI
- covers compatible simulated profile skew, direct pack and ledger delivery, classified fallback, and additive normalized-ingress metadata
- audits every shipped adapter script for canonical `/api/raw-events` use and absence of named compatibility-route calls
- records the privacy-safe 30-run OpenCode prompt-path benchmark and documents its explicit scope
- updates README, architecture, and plugin operator guidance to match current behavior

The compatibility windows are simulated protocol contracts, not runs against historical package tarballs. `/api/claude-hooks` and `/api/codex-hooks` remain supported compatibility aliases.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional gates:
- `pnpm run check` (4,403 tests)
- `pnpm run build`
- `pnpm --filter codemem test:packed-artifact`
- `pnpm --filter @codemem/opencode-plugin test:packed-artifact`
- `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1 pnpm run e2e:smoke -- --json`
- benchmark harness typecheck and 7 unit tests
- Snyk Code high-severity scan: 0 issues

Benchmark (30 repetitions, synthetic fixture):
- direct CLI median/p95: 857.459/1001.124 ms
- healthy Viewer median/p95: 9.478/10.772 ms, zero prompt-path subprocesses
- classified Viewer-unavailable fallback median/p95: 832.101/881.455 ms

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced