### PR TITLE
fix(hooks): preserve tail boundary records

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ npx -y codemem setup --claude-only
 
 The Claude plugin starts MCP with the TS CLI (`codemem mcp`).
 
-Claude and Codex plugins normalize native hooks at the plugin edge and send the resulting envelope to the canonical `POST /api/raw-events` endpoint. A retryable Viewer failure sends that exact envelope to `codemem enqueue-raw-event`; Codex retains a durable normalized-envelope spool as its last resort. The checked-in dependency-free normalizers are generated from the TypeScript implementations in `packages/core/src/claude-hooks.ts` and `packages/core/src/codex-hooks.ts`. Named Viewer hook routes remain compatibility aliases/callers for older packaged and plugin-free CLI paths.
+Claude and Codex plugins normalize native hooks at the plugin edge and send the resulting envelope to the canonical `POST /api/raw-events` endpoint. A retryable Viewer failure sends that exact envelope to `codemem enqueue-raw-event`; Codex retains a durable normalized-envelope spool as its last resort. Transcript fallback reads at most the final 16 MiB: it preserves the first record when the tail starts immediately after a newline, but discards the first fragment when the tail starts in the middle of a record. The checked-in dependency-free normalizers are generated from the TypeScript implementations in `packages/core/src/claude-hooks.ts` and `packages/core/src/codex-hooks.ts`. Named Viewer hook routes remain compatibility aliases/callers for older packaged and plugin-free CLI paths.
 
 Claude and Codex `UserPromptSubmit` hooks are dependency-free direct Viewer clients. They perform a
 payload-free compatible-profile check, retrieve an identity-gated `POST /api/pack` response, return

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -65,6 +65,8 @@ Claude's Node/ESM wrapper normalizes each native hook once, then sends the exact
 
 The wrapper never remaps the native payload during fallback, so event identity is identical across HTTP and direct enqueue. Named `POST /api/claude-hooks` remains a compatibility alias/caller for older packaged and plugin-free CLI paths.
 
+Transcript fallback reads at most the final 16 MiB. When that tail starts immediately after a newline, the first complete record is retained; when it starts in the middle of a record, the partial first record is discarded before parsing.
+
 Claude preserves its existing best-effort failure posture: if Viewer HTTP and both command fallbacks fail, the wrapper logs the failure and exits non-zero. It does not maintain a file spool; Codex's separately documented normalized-envelope spool is intentionally adapter-specific.
 
 You can update an existing marketplace install with:

--- a/packages/core/src/claude-hooks.test.ts
+++ b/packages/core/src/claude-hooks.test.ts
@@ -191,6 +191,21 @@ describe("extractHookTranscript", () => {
 		}
 	});
 
+	it("preserves a complete record that starts at the retained tail boundary", () => {
+		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-tail-boundary-"));
+		try {
+			const path = join(root, "session.jsonl");
+			const record = '{"role":"assistant","content":"boundary record"}\n';
+			writeFileSync(path, `x\n${record}${" ".repeat(MAX_HOOK_TRANSCRIPT_BYTES - record.length)}`);
+			expect(extractHookTranscript(path, { policy: restrictedTranscriptPolicy(root) })).toEqual([
+				"boundary record",
+				null,
+			]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("returns no extraction when the retained tail contains no complete record", () => {
 		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-oversized-"));
 		try {

--- a/packages/core/src/hook-transcript.ts
+++ b/packages/core/src/hook-transcript.ts
@@ -99,9 +99,13 @@ function readTranscriptTail(path: string): string | null {
 		}
 		let retained = buffer.subarray(0, offset);
 		if (start > 0) {
-			const firstNewline = retained.indexOf(0x0a);
-			if (firstNewline < 0) return null;
-			retained = retained.subarray(firstNewline + 1);
+			const precedingByte = Buffer.allocUnsafe(1);
+			const precedingByteRead = readSync(descriptor, precedingByte, 0, 1, start - 1);
+			if (precedingByteRead !== 1 || precedingByte[0] !== 0x0a) {
+				const firstNewline = retained.indexOf(0x0a);
+				if (firstNewline < 0) return null;
+				retained = retained.subarray(firstNewline + 1);
+			}
 		}
 		return retained.length > 0 ? retained.toString("utf8") : null;
 	} catch {

--- a/plugins/claude/scripts/codemem-normalizer.mjs
+++ b/plugins/claude/scripts/codemem-normalizer.mjs
@@ -58,9 +58,12 @@ function readTranscriptTail(path) {
 		}
 		let retained = buffer.subarray(0, offset);
 		if (start > 0) {
-			const firstNewline = retained.indexOf(10);
-			if (firstNewline < 0) return null;
-			retained = retained.subarray(firstNewline + 1);
+			const precedingByte = Buffer.allocUnsafe(1);
+			if (readSync(descriptor, precedingByte, 0, 1, start - 1) !== 1 || precedingByte[0] !== 10) {
+				const firstNewline = retained.indexOf(10);
+				if (firstNewline < 0) return null;
+				retained = retained.subarray(firstNewline + 1);
+			}
 		}
 		return retained.length > 0 ? retained.toString("utf8") : null;
 	} catch {

--- a/plugins/codex/scripts/codemem-normalizer.mjs
+++ b/plugins/codex/scripts/codemem-normalizer.mjs
@@ -58,9 +58,12 @@ function readTranscriptTail(path) {
 		}
 		let retained = buffer.subarray(0, offset);
 		if (start > 0) {
-			const firstNewline = retained.indexOf(10);
-			if (firstNewline < 0) return null;
-			retained = retained.subarray(firstNewline + 1);
+			const precedingByte = Buffer.allocUnsafe(1);
+			if (readSync(descriptor, precedingByte, 0, 1, start - 1) !== 1 || precedingByte[0] !== 10) {
+				const firstNewline = retained.indexOf(10);
+				if (firstNewline < 0) return null;
+				retained = retained.subarray(firstNewline + 1);
+			}
 		}
 		return retained.length > 0 ? retained.toString("utf8") : null;
 	} catch {


### PR DESCRIPTION
## Description
Preserve a complete JSONL transcript record when the retained 16 MiB tail begins exactly at a record boundary. Regenerate the dependency-free Claude and Codex normalizers so packaged adapters use the same corrected logic.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced