### PR TITLE
fix(ingest): dedupe legacy string sequence IDs

### DIFF
--- a/packages/core/src/raw-event-ingest.test.ts
+++ b/packages/core/src/raw-event-ingest.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -181,6 +182,35 @@ describe("ingestRawEvents", () => {
 			expect(rows[0]).toMatchObject({ event_seq: 0 });
 			expect(rows[0]?.event_id).toMatch(/^legacy-seq-7-/);
 			expect(rows[1]).toEqual({ event_id: "event-sequence-next", event_seq: 1 });
+		} finally {
+			store.close();
+		}
+	});
+
+	it("deduplicates a string sequence against its pre-cutover legacy event ID", () => {
+		const store = createStore();
+		try {
+			const payload = { text: "supplied" };
+			const digest = createHash("sha256")
+				.update(JSON.stringify({ p: payload, s: "7", t: "prompt" }), "utf8")
+				.digest("hex")
+				.slice(0, 16);
+			store.recordRawEvent({
+				opencodeSessionId: "session-legacy-string-sequence",
+				eventId: `legacy-seq-7-${digest}`,
+				eventType: "prompt",
+				payload,
+			});
+
+			expect(
+				ingestRawEvents(store, {
+					source: "opencode",
+					session_id: "session-legacy-string-sequence",
+					event_type: "prompt",
+					event_seq: "7",
+					payload,
+				}),
+			).toMatchObject({ inserted: 0, skipped: 1 });
 		} finally {
 			store.close();
 		}

--- a/packages/core/src/raw-event-ingest.ts
+++ b/packages/core/src/raw-event-ingest.ts
@@ -32,6 +32,7 @@ export interface RawEventIngestResult {
 interface NormalizedEvent {
 	streamId: string;
 	eventId: string;
+	eventIdAliases: string[];
 	eventType: string;
 	payload: Record<string, unknown>;
 	tsWallMs: number | null;
@@ -162,6 +163,18 @@ function generatedEventId(
 	return eventSeq == null ? `legacy-${digest}` : `legacy-seq-${eventSeq}-${digest}`;
 }
 
+function legacyStringSequenceEventId(
+	eventType: string,
+	payload: Record<string, unknown>,
+	eventSeq: string,
+): string {
+	const digest = createHash("sha256")
+		.update(stableStringify({ p: payload, s: eventSeq, t: eventType }), "utf8")
+		.digest("hex")
+		.slice(0, 16);
+	return `legacy-seq-${eventSeq}-${digest}`;
+}
+
 function normalizeEvent(
 	item: Record<string, unknown>,
 	defaultStreamId: string | null,
@@ -187,9 +200,15 @@ function normalizeEvent(
 		rawEventId == null || rawEventId === ""
 			? generatedEventId(eventType, payload, eventSeq, tsWallMs, tsMonoMs)
 			: validateEventField(rawEventId, "event_id");
+	const eventIdAliases = [eventId];
+	if ((rawEventId == null || rawEventId === "") && typeof item.event_seq === "string") {
+		const legacyEventId = legacyStringSequenceEventId(eventType, payload, item.event_seq);
+		if (legacyEventId !== eventId) eventIdAliases.push(legacyEventId);
+	}
 	return {
 		streamId,
 		eventId,
+		eventIdAliases,
 		eventType,
 		payload,
 		tsWallMs,
@@ -236,16 +255,17 @@ function persistStream(
 	let skippedDuplicate = 0;
 	const seenIds = new Set<string>();
 	const uniqueCandidates = events.filter((event) => {
-		if (seenIds.has(event.eventId)) {
+		if (event.eventIdAliases.some((eventId) => seenIds.has(eventId))) {
 			skippedDuplicate++;
 			return false;
 		}
-		seenIds.add(event.eventId);
+		for (const eventId of event.eventIdAliases) seenIds.add(eventId);
 		return true;
 	});
 	const existingIds = new Set<string>();
-	for (let offset = 0; offset < uniqueCandidates.length; offset += 500) {
-		const eventIds = uniqueCandidates.slice(offset, offset + 500).map((event) => event.eventId);
+	const candidateEventIds = [...new Set(uniqueCandidates.flatMap((event) => event.eventIdAliases))];
+	for (let offset = 0; offset < candidateEventIds.length; offset += 500) {
+		const eventIds = candidateEventIds.slice(offset, offset + 500);
 		const placeholders = eventIds.map(() => "?").join(", ");
 		const rows = store.db
 			.prepare(
@@ -257,7 +277,9 @@ function persistStream(
 			if (row.event_id) existingIds.add(row.event_id);
 		}
 	}
-	const candidates = uniqueCandidates.filter((event) => !existingIds.has(event.eventId));
+	const candidates = uniqueCandidates.filter(
+		(event) => !event.eventIdAliases.some((eventId) => existingIds.has(eventId)),
+	);
 	skippedDuplicate += uniqueCandidates.length - candidates.length;
 
 	const sessionRow = store.db


### PR DESCRIPTION
## Description
Accept pre-cutover event IDs derived from string sequence values as aliases of the canonical normalized ID. Check those aliases during both in-request and database deduplication so retries across the ID transition do not duplicate raw events.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced