### PR TITLE
chore(cli): hide adapter plumbing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,8 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | | `codemem setup` | Interactive first-run setup |
 | **Plumbing** | `codemem mcp` | MCP stdio server; best-effort starts the local viewer unless `CODEMEM_VIEWER=0` or `CODEMEM_VIEWER_AUTO=0` is set |
 | | `codemem mcp http` | Local Streamable HTTP MCP server (`POST /mcp`, loopback-only by default) |
-| | `codemem claude-hook-ingest` | Claude hook event ingestion (stdin) |
-| | `codemem codex-hook-ingest` | Codex hook event ingestion (stdin, experimental) |
-| | `codemem codex-hook-inject` | Codex prompt-time memory injection (stdin, experimental) |
 
-Run `codemem --help` for the full list. `show`, `forget`, and `remember` still work as hidden top-level aliases. `export-memories` and `import-memories` remain visible but are deprecated — they warn on stderr and will be hidden from help and completion in a future release; use `codemem memory export` / `codemem memory import`.
+Run `codemem --help` for the human-facing command list. Adapter plumbing commands (`claude-hook-*`, `codex-hook-*`, `enqueue-raw-event`, and `prompt-pack-ledger`) remain executable for packaged-plugin and stale-client compatibility but are hidden from help and shell completion. `show`, `forget`, and `remember` still work as hidden top-level aliases. `export-memories` and `import-memories` remain visible but are deprecated — they warn on stderr and will be hidden from help and completion in a future release; use `codemem memory export` / `codemem memory import`.
 
 Use `codemem status` to answer whether the local database, viewer, sync, maintenance,
 semantic index, raw-event ingestion, and observer need attention. It is observational:

--- a/docs/cli-design-conventions.md
+++ b/docs/cli-design-conventions.md
@@ -41,7 +41,7 @@ Do **not** create a group for:
 - **User-facing data operations** belong under their noun group: `memory show`, `memory export`, `memory import`, `db prune-memories`.
 - **Operator/admin surfaces** that expose a distinct trust boundary or deployment concern belong in their own top-level group (e.g., `coordinator` for coordinator admin, not nested under `sync`).
 - **Lifecycle/service management** belongs under the service noun: `serve start`, `serve stop`.
-- **Plumbing/adapter commands** that are called by other programs (not humans) may stay top-level with clear naming: `claude-hook-ingest`, `mcp`.
+- **Plumbing/adapter commands** that are called by other programs (not humans) may stay top-level with clear naming. Adapter-only commands such as `claude-hook-*`, `codex-hook-*`, `enqueue-raw-event`, and `prompt-pack-ledger` remain registered for packaged and stale-client compatibility but stay hidden from help and shell completion. User-configured entrypoints such as `mcp` remain visible.
 
 ### Naming
 
@@ -264,7 +264,7 @@ When a command is renamed or moved (e.g., `sync coordinator list-devices` → `c
 - Every new command, renamed command, or flag change must update user-facing docs
   (`README.md`, `docs/user-guide.md`, and any relevant docs under `docs/`) in the same change.
 - If a docs update is deferred, it must be tracked with an explicit issue linked to the implementation PR.
-- Shell completion lists (`packages/cli/src/index.ts` completion handler) must stay in sync with the registered command tree.
+- Shell completion lists (`ROOT_COMPLETION_COMMANDS` in `packages/cli/src/command-tree.ts`) must stay in sync with the registered command tree.
 
 ## Style notes
 

--- a/packages/cli/src/command-tree.test.ts
+++ b/packages/cli/src/command-tree.test.ts
@@ -44,8 +44,19 @@ describe("root command tree", () => {
 			.map((command) => command.name())
 			.filter((name) => name !== "help" && !visibleNames.has(name));
 
-		expect(hiddenNames).toEqual(
-			expect.arrayContaining(["show", "forget", "remember", "prompt-pack-ledger"]),
+		expect(hiddenNames.sort()).toEqual(
+			[
+				"show",
+				"forget",
+				"remember",
+				"prompt-pack-ledger",
+				"claude-hook-file-context",
+				"claude-hook-inject",
+				"claude-hook-ingest",
+				"codex-hook-inject",
+				"codex-hook-ingest",
+				"enqueue-raw-event",
+			].sort(),
 		);
 		for (const hiddenName of hiddenNames) {
 			expect(ROOT_COMPLETION_COMMANDS).not.toContain(hiddenName);
@@ -57,7 +68,18 @@ describe("root command tree", () => {
 
 		expect(help).toMatch(/^\s+export-memories(?:\s|$)/m);
 		expect(help).toMatch(/^\s+import-memories(?:\s|$)/m);
-		for (const hiddenName of ["show", "forget", "remember", "prompt-pack-ledger"]) {
+		for (const hiddenName of [
+			"show",
+			"forget",
+			"remember",
+			"prompt-pack-ledger",
+			"claude-hook-file-context",
+			"claude-hook-inject",
+			"claude-hook-ingest",
+			"codex-hook-inject",
+			"codex-hook-ingest",
+			"enqueue-raw-event",
+		]) {
 			expect(help).not.toMatch(new RegExp(`^\\s+${hiddenName}(?:\\s|$)`, "m"));
 		}
 	});

--- a/packages/cli/src/command-tree.ts
+++ b/packages/cli/src/command-tree.ts
@@ -42,17 +42,11 @@ import { versionCommand } from "./commands/version.js";
 import { helpStyle } from "./help-style.js";
 
 export const ROOT_COMPLETION_COMMANDS = [
-	"claude-hook-file-context",
-	"claude-hook-inject",
-	"claude-hook-ingest",
-	"codex-hook-inject",
-	"codex-hook-ingest",
 	"config",
 	"coordinator",
 	"db",
 	"distill",
 	"embed",
-	"enqueue-raw-event",
 	"export-memories",
 	"import-memories",
 	"maintenance",
@@ -167,11 +161,13 @@ export function registerRootCommands(program: Command): Command {
 	program.addCommand(configCommand);
 	program.addCommand(coordinatorCommand);
 	program.addCommand(mcpCommand);
-	program.addCommand(claudeHookInjectCommand);
-	program.addCommand(claudeHookIngestCommand);
-	program.addCommand(claudeHookFileContextCommand);
-	program.addCommand(codexHookInjectCommand);
-	program.addCommand(codexHookIngestCommand);
+	// Adapter plumbing remains executable for packaged and stale-client
+	// compatibility, but it is not part of the human-facing command surface.
+	program.addCommand(claudeHookInjectCommand, { hidden: true });
+	program.addCommand(claudeHookIngestCommand, { hidden: true });
+	program.addCommand(claudeHookFileContextCommand, { hidden: true });
+	program.addCommand(codexHookInjectCommand, { hidden: true });
+	program.addCommand(codexHookIngestCommand, { hidden: true });
 	program.addCommand(dbCommand);
 	program.addCommand(distillCommand);
 	// Warned compatibility aliases — visible for their first warned release;
@@ -195,7 +191,7 @@ export function registerRootCommands(program: Command): Command {
 	program.addCommand(memoryCommand);
 	program.addCommand(syncCommand);
 	program.addCommand(setupCommand);
-	program.addCommand(enqueueRawEventCommand);
+	program.addCommand(enqueueRawEventCommand, { hidden: true });
 	program.addCommand(updateCommand);
 	program.addCommand(versionCommand);
 	return program;


### PR DESCRIPTION
## Description

Hide adapter plumbing commands from human-facing CLI help and shell completion while preserving their executable compatibility contracts for packaged plugins and stale clients.

Tracks `codemem-2b06.9`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced