### PR TITLE
fix(adapters): harden transcript fallback diagnostics

### DIFF
--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -66,7 +66,7 @@ Claude's Node/ESM wrapper normalizes each native hook once, then sends the exact
 
 The wrapper never remaps the native payload during fallback, so event identity is identical across HTTP and direct enqueue. Named `POST /api/claude-hooks` remains a compatibility alias/caller for older packaged and plugin-free CLI paths.
 
-Transcript fallback reads at most the final 16 MiB. When that tail starts immediately after a newline, the first complete record is retained; when it starts in the middle of a record, the partial first record is discarded before parsing.
+Transcript fallback scans backward through at most the final 16 MiB using a bounded reusable chunk buffer and stops at the latest qualifying assistant record. When that tail starts immediately after a newline, the first complete record is retained; when it starts in the middle of a record, the partial first record is discarded. JSONL records may use LF or CRLF, and UTF-8 characters remain valid across chunk boundaries.
 
 Claude preserves its existing best-effort failure posture: if Viewer HTTP and both command fallbacks fail, the wrapper logs the failure and exits non-zero. It does not maintain a file spool; Codex's separately documented normalized-envelope spool is intentionally adapter-specific.
 
@@ -159,7 +159,7 @@ For Codex hooks, project resolution precedence matches the Claude hook path:
 2. repo/cwd-derived project name
 3. payload `project` fallback (only when cwd is unavailable)
 
-`Stop` events map the inline `last_assistant_message` when present, and fall back to the last assistant message in `transcript_path` so final responses are captured even when the inline field is omitted.
+`Stop` events map the inline `last_assistant_message` when present, and fall back to the last assistant message in `transcript_path` so final responses are captured even when the inline field is omitted. This fallback uses the same backward, bounded 16 MiB JSONL scan and record-boundary rules as Claude.
 
 The packaged Codex template registers `SessionStart`, `UserPromptSubmit`, `PostToolUse`, and `Stop` in `plugins/codex/hooks/hooks.json`. Codex support is early beta; see `docs/plans/2026-05-28-codex-first-class-integration.md` for the rollout plan and validation gates.
 
@@ -326,6 +326,8 @@ Stream contract:
 - Raw events are delivered through the viewer ingest API.
 - Raw-event batches accepted by the viewer are retried by the sweeper flush workers.
 - If the direct CLI fallback reports an explicit SQLite busy/locked result or command timeout, the plugin retries it once with the same event ID. Other failures are reported and dropped rather than requeued or spooled, and logs retain only a bounded failure category rather than raw command output.
+
+`GET /api/raw-events/status` also includes `transcript_diagnostics`, a per-Viewer-process, per-router-instance counter block scoped explicitly to `legacy_compatibility_routes`. It counts Claude and Codex compatibility-route transcript reads by the fixed outcomes `ok`, `not_provided`, `path_rejected`, `unreadable`, `no_complete_record`, and `no_assistant_record`. These counters are not persisted, do not include paths or transcript content, and do not describe the normal generated-adapter path through `POST /api/raw-events`. A skipped legacy `Stop` response keeps `skip_reason: "transcript_unavailable"` and may include one of the non-`ok` outcomes as `skip_detail`; other mapping skips remain `skip_reason: "unsupported_hook"`.
 
 Suggested settings:
 

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -11,6 +11,7 @@
  * Import existing store/entity types where shapes match.
  */
 
+import type { HookTranscriptOutcome } from "./hook-transcript.js";
 import type { SyncCapability, SyncFeature } from "./sync-capability.js";
 import type {
 	Actor,
@@ -366,6 +367,10 @@ export interface ApiRawEventsStatusResponse {
 	items: ApiRawEventBacklogItem[];
 	totals: ApiRawEventBacklogTotals;
 	ingest: ApiRawEventIngestInfo;
+	transcript_diagnostics: {
+		scope: "legacy_compatibility_routes";
+		counts: Record<"claude" | "codex", Record<HookTranscriptOutcome, number>>;
+	};
 }
 
 /**
@@ -384,6 +389,7 @@ export interface ApiClaudeHooksPostResponse {
 	inserted: number;
 	skipped: number;
 	skip_reason?: "transcript_unavailable" | "unsupported_hook";
+	skip_detail?: Exclude<HookTranscriptOutcome, "ok">;
 }
 
 /** POST /api/codex-hooks — response. */

--- a/packages/core/src/claude-hooks.test.ts
+++ b/packages/core/src/claude-hooks.test.ts
@@ -18,7 +18,11 @@ import {
 	mapClaudeHookPayload as mapClaudeHookPayloadWithPolicy,
 	TRUSTED_HOOK_MAPPER_OPTIONS,
 } from "./claude-hooks.js";
-import { extractHookTranscript, MAX_HOOK_TRANSCRIPT_BYTES } from "./hook-transcript.js";
+import {
+	extractHookTranscript,
+	extractHookTranscriptWithOutcome,
+	MAX_HOOK_TRANSCRIPT_BYTES,
+} from "./hook-transcript.js";
 
 const goldenFixtures = JSON.parse(
 	readFileSync(new URL("./fixtures/adapter-normalizer-golden.json", import.meta.url), "utf8"),
@@ -191,6 +195,63 @@ describe("extractHookTranscript", () => {
 		}
 	});
 
+	it("does not read the full retained window when the final assistant record is near the tail", () => {
+		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-bounded-scan-"));
+		try {
+			const path = join(root, "session.jsonl");
+			writeFileSync(
+				path,
+				`${"x".repeat(MAX_HOOK_TRANSCRIPT_BYTES + 1024)}\n{"role":"assistant","content":"tail record"}\n`,
+			);
+			let bytesRead = 0;
+			const result = extractHookTranscriptWithOutcome(path, {
+				policy: restrictedTranscriptPolicy(root),
+				onBytesRead: (count) => {
+					bytesRead += count;
+				},
+			});
+			expect(result).toEqual({ extraction: ["tail record", null], outcome: "ok" });
+			expect(bytesRead).toBeLessThan(256 * 1024);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("decodes UTF-8 correctly when a code point crosses a read-chunk boundary", () => {
+		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-utf8-boundary-"));
+		try {
+			const path = join(root, "session.jsonl");
+			const prefix = '{"role":"assistant","content":"';
+			const filler = "a".repeat(64 * 1024 - Buffer.byteLength(prefix) - 1);
+			const content = `${filler}🙂tail`;
+			writeFileSync(path, `${prefix}${content}"}\r\n`);
+			expect(extractHookTranscript(path, { policy: restrictedTranscriptPolicy(root) })).toEqual([
+				content,
+				null,
+			]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("continues scanning after a non-assistant record spans read chunks", () => {
+		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-spanning-record-"));
+		try {
+			const path = join(root, "session.jsonl");
+			const oversizedUserRecord = JSON.stringify({ role: "user", content: "u".repeat(96 * 1024) });
+			writeFileSync(
+				path,
+				`{"role":"assistant","content":"earlier result"}\n${oversizedUserRecord}\n`,
+			);
+			expect(extractHookTranscript(path, { policy: restrictedTranscriptPolicy(root) })).toEqual([
+				"earlier result",
+				null,
+			]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves a complete record that starts at the retained tail boundary", () => {
 		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-tail-boundary-"));
 		try {
@@ -211,10 +272,22 @@ describe("extractHookTranscript", () => {
 		try {
 			const path = join(root, "session.jsonl");
 			writeFileSync(path, `${"x".repeat(MAX_HOOK_TRANSCRIPT_BYTES + 1024)}\n`);
-			expect(extractHookTranscript(path, { policy: restrictedTranscriptPolicy(root) })).toEqual([
-				null,
-				null,
-			]);
+			expect(
+				extractHookTranscriptWithOutcome(path, { policy: restrictedTranscriptPolicy(root) }),
+			).toEqual({ extraction: [null, null], outcome: "no_complete_record" });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("distinguishes a complete transcript with no assistant record", () => {
+		const root = mkdtempSync(join(tmpdir(), "codemem-transcript-no-assistant-"));
+		try {
+			const path = join(root, "session.jsonl");
+			writeFileSync(path, '{"role":"user","content":"hello"}\n{malformed}\n');
+			expect(
+				extractHookTranscriptWithOutcome(path, { policy: restrictedTranscriptPolicy(root) }),
+			).toEqual({ extraction: [null, null], outcome: "no_assistant_record" });
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
@@ -457,6 +530,30 @@ describe("mapClaudeHookPayload", () => {
 			expect(event).not.toBeNull();
 			expect(event?.event_type).toBe("assistant");
 			expect(event?.payload.text).toBe("assistant from transcript");
+		});
+
+		it("keeps transcript fallback best-effort when the outcome callback throws", () => {
+			const dir = mkdtempSync(join(tmpdir(), "codemem-test-callback-"));
+			try {
+				const transcriptPath = join(dir, "transcript.jsonl");
+				writeFileSync(transcriptPath, '{"role":"assistant","content":"still mapped"}\n');
+				const event = mapClaudeHookPayloadWithPolicy(
+					{
+						hook_event_name: "Stop",
+						session_id: "sess-stop-callback",
+						transcript_path: transcriptPath,
+					},
+					{
+						...TRUSTED_HOOK_MAPPER_OPTIONS,
+						onTranscriptOutcome: () => {
+							throw new Error("diagnostics unavailable");
+						},
+					},
+				);
+				expect(event?.payload.text).toBe("still mapped");
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
 		});
 
 		it("uses relative transcript path with cwd", () => {

--- a/packages/core/src/claude-hooks.ts
+++ b/packages/core/src/claude-hooks.ts
@@ -16,7 +16,8 @@ import { existsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, resolve } from "node:path";
 import {
-	extractHookTranscript,
+	extractHookTranscriptWithOutcome,
+	type HookTranscriptOutcome,
 	type HookTranscriptPolicy,
 	TRUSTED_HOOK_TRANSCRIPT_POLICY,
 } from "./hook-transcript.js";
@@ -305,12 +306,20 @@ export function extractFromTranscript(
 	transcriptPath: unknown,
 	cwdHint?: string | null,
 	policy: HookTranscriptPolicy = { trust: "restricted", approvedRoots: [] },
+	onTranscriptOutcome?: (outcome: HookTranscriptOutcome) => void,
 ): [string | null, Record<string, number> | null] {
-	return extractHookTranscript(transcriptPath, { policy, cwd: cwdHint });
+	const result = extractHookTranscriptWithOutcome(transcriptPath, { policy, cwd: cwdHint });
+	try {
+		onTranscriptOutcome?.(result.outcome);
+	} catch {
+		// Diagnostics are best-effort and must never change hook mapping.
+	}
+	return result.extraction;
 }
 
 export interface HookMapperOptions {
 	transcriptPolicy: HookTranscriptPolicy;
+	onTranscriptOutcome?: (outcome: HookTranscriptOutcome) => void;
 }
 
 export const TRUSTED_HOOK_MAPPER_OPTIONS: HookMapperOptions = {
@@ -463,6 +472,7 @@ export function mapClaudeHookPayload(
 				payload.transcript_path,
 				cwd,
 				options.transcriptPolicy,
+				options.onTranscriptOutcome,
 			);
 			if (!assistantText && transcriptText) assistantText = transcriptText;
 			if (usage === null && transcriptUsage !== null) usage = transcriptUsage;

--- a/packages/core/src/codex-hooks.test.ts
+++ b/packages/core/src/codex-hooks.test.ts
@@ -183,6 +183,28 @@ describe("mapCodexHookPayload", () => {
 		expect(event?.payload.text).toBe("Finished the thing");
 	});
 
+	it("reports transcript outcomes without allowing callback failures to affect Stop mapping", () => {
+		const transcriptPath = writeTranscript([{ role: "assistant", content: "Still finished" }]);
+		const outcomes: string[] = [];
+		const event = mapCodexHookPayload(
+			{
+				hook_event_name: "Stop",
+				session_id: "codex-session",
+				transcript_path: transcriptPath,
+			},
+			{
+				...TRUSTED_HOOK_MAPPER_OPTIONS,
+				onTranscriptOutcome: (outcome) => {
+					outcomes.push(outcome);
+					throw new Error("diagnostics unavailable");
+				},
+			},
+		);
+
+		expect(event?.payload.text).toBe("Still finished");
+		expect(outcomes).toEqual(["ok"]);
+	});
+
 	it("maps Stop via an explicitly approved transcript root", () => {
 		const transcriptPath = writeTranscript([{ role: "assistant", content: "Approved result" }]);
 		const event = mapCodexHookPayload(

--- a/packages/core/src/codex-hooks.ts
+++ b/packages/core/src/codex-hooks.ts
@@ -187,6 +187,7 @@ export function mapCodexHookPayload(
 				payload.transcript_path,
 				cwd,
 				options.transcriptPolicy,
+				options.onTranscriptOutcome,
 			);
 			if (transcriptText) assistantText = transcriptText.trim();
 		}

--- a/packages/core/src/hook-transcript.ts
+++ b/packages/core/src/hook-transcript.ts
@@ -11,6 +11,18 @@ import { homedir } from "node:os";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 
 export const MAX_HOOK_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
+const HOOK_TRANSCRIPT_CHUNK_BYTES = 64 * 1024;
+
+const HOOK_TRANSCRIPT_OUTCOMES = [
+	"ok",
+	"not_provided",
+	"path_rejected",
+	"unreadable",
+	"no_complete_record",
+	"no_assistant_record",
+] as const;
+
+export type HookTranscriptOutcome = (typeof HOOK_TRANSCRIPT_OUTCOMES)[number];
 
 export type HookTranscriptPolicy =
 	| { trust: "trusted" }
@@ -21,9 +33,18 @@ export const TRUSTED_HOOK_TRANSCRIPT_POLICY: HookTranscriptPolicy = { trust: "tr
 export interface HookTranscriptReadOptions {
 	policy: HookTranscriptPolicy;
 	cwd?: string | null;
+	/** Optional instrumentation seam for deterministic bounded-read tests. */
+	onBytesRead?: (count: number) => void;
 }
 
-type TranscriptExtraction = [string | null, Record<string, number> | null];
+export type HookTranscriptExtraction = [string | null, Record<string, number> | null];
+
+export interface HookTranscriptResult {
+	extraction: HookTranscriptExtraction;
+	outcome: HookTranscriptOutcome;
+}
+
+type ResolvedTranscriptPath = { path: string } | { outcome: Exclude<HookTranscriptOutcome, "ok"> };
 
 function expandUser(path: string): string {
 	return path.startsWith("~/") ? resolve(homedir(), path.slice(2)) : path;
@@ -40,85 +61,88 @@ function isContained(root: string, target: string): boolean {
 function resolveTranscriptPath(
 	transcriptPath: unknown,
 	options: HookTranscriptReadOptions,
-): string | null {
-	if (typeof transcriptPath !== "string") return null;
+): ResolvedTranscriptPath {
+	if (typeof transcriptPath !== "string") return { outcome: "not_provided" };
 	const requestedPath = expandUser(transcriptPath.trim());
-	if (!requestedPath) return null;
+	if (!requestedPath) return { outcome: "not_provided" };
+
+	if (!isAbsolute(requestedPath)) {
+		if (options.policy.trust !== "trusted") return { outcome: "path_rejected" };
+		if (typeof options.cwd !== "string") return { outcome: "path_rejected" };
+		try {
+			const cwd = expandUser(options.cwd.trim());
+			if (!isAbsolute(cwd)) return { outcome: "path_rejected" };
+			const realCwd = realpathSync(cwd);
+			if (!statSync(realCwd).isDirectory()) return { outcome: "path_rejected" };
+			const realTarget = realpathSync(resolve(realCwd, requestedPath));
+			return isContained(realCwd, realTarget) ? { path: realTarget } : { outcome: "path_rejected" };
+		} catch {
+			return { outcome: "unreadable" };
+		}
+	}
 
 	try {
-		if (!isAbsolute(requestedPath)) {
-			if (options.policy.trust !== "trusted") return null;
-			if (typeof options.cwd !== "string") return null;
-			const cwd = expandUser(options.cwd.trim());
-			if (!isAbsolute(cwd)) return null;
-			const realCwd = realpathSync(cwd);
-			if (!statSync(realCwd).isDirectory()) return null;
-			const realTarget = realpathSync(resolve(realCwd, requestedPath));
-			return isContained(realCwd, realTarget) ? realTarget : null;
-		}
-
 		const realTarget = realpathSync(requestedPath);
-		if (options.policy.trust === "trusted") return realTarget;
+		if (options.policy.trust === "trusted") return { path: realTarget };
 		for (const root of options.policy.approvedRoots) {
 			try {
 				const realRoot = realpathSync(expandUser(root));
 				if (statSync(realRoot).isDirectory() && isContained(realRoot, realTarget))
-					return realTarget;
+					return { path: realTarget };
 			} catch {
 				// Missing or unreadable approved roots are simply ineligible.
 			}
 		}
 	} catch {
-		return null;
+		return { outcome: "unreadable" };
 	}
-	return null;
+	return { outcome: "path_rejected" };
 }
 
-function readTranscriptTail(path: string): string | null {
-	let descriptor: number | null = null;
+function reportBytesRead(options: HookTranscriptReadOptions, count: number): void {
+	if (count <= 0) return;
 	try {
-		descriptor = openSync(
-			path,
-			constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0),
-		);
-		const stat = fstatSync(descriptor);
-		if (!stat.isFile()) return null;
-		const openedPath = realpathSync(path);
-		const openedPathStat = statSync(openedPath);
-		if (openedPath !== path || openedPathStat.dev !== stat.dev || openedPathStat.ino !== stat.ino) {
-			return null;
-		}
-		const bytesToRead = Math.min(stat.size, MAX_HOOK_TRANSCRIPT_BYTES);
-		const start = stat.size - bytesToRead;
-		const buffer = Buffer.allocUnsafe(bytesToRead);
-		let offset = 0;
-		while (offset < bytesToRead) {
-			const bytesRead = readSync(descriptor, buffer, offset, bytesToRead - offset, start + offset);
-			if (bytesRead === 0) break;
-			offset += bytesRead;
-		}
-		let retained = buffer.subarray(0, offset);
-		if (start > 0) {
-			const precedingByte = Buffer.allocUnsafe(1);
-			const precedingByteRead = readSync(descriptor, precedingByte, 0, 1, start - 1);
-			if (precedingByteRead !== 1 || precedingByte[0] !== 0x0a) {
-				const firstNewline = retained.indexOf(0x0a);
-				if (firstNewline < 0) return null;
-				retained = retained.subarray(firstNewline + 1);
-			}
-		}
-		return retained.length > 0 ? retained.toString("utf8") : null;
+		options.onBytesRead?.(count);
 	} catch {
-		return null;
-	} finally {
-		if (descriptor !== null) {
-			try {
-				closeSync(descriptor);
-			} catch {
-				// A close failure does not make transcript extraction fatal.
-			}
-		}
+		// Instrumentation is best-effort and must not affect extraction.
 	}
+}
+
+function readInto(
+	descriptor: number,
+	buffer: Buffer,
+	length: number,
+	position: number,
+	options: HookTranscriptReadOptions,
+): number {
+	let offset = 0;
+	while (offset < length) {
+		const count = readSync(descriptor, buffer, offset, length - offset, position + offset);
+		if (count === 0) break;
+		offset += count;
+		reportBytesRead(options, count);
+	}
+	return offset;
+}
+
+function decodeRecord(
+	descriptor: number,
+	buffer: Buffer,
+	start: number,
+	end: number,
+	options: HookTranscriptReadOptions,
+): string {
+	const decoder = new TextDecoder("utf-8", { fatal: false });
+	let position = start;
+	let text = "";
+	while (position < end) {
+		const length = Math.min(buffer.length, end - position);
+		const count = readInto(descriptor, buffer, length, position, options);
+		if (count === 0) break;
+		position += count;
+		text += decoder.decode(buffer.subarray(0, count), { stream: position < end });
+	}
+	return text;
 }
 
 function textFromContent(value: unknown): string {
@@ -153,67 +177,145 @@ function normalizeUsage(value: unknown): Record<string, number> | null {
 	return total > 0 ? normalized : null;
 }
 
-function parseTranscript(content: string): TranscriptExtraction {
-	let assistantText: string | null = null;
-	let assistantUsage: Record<string, number> | null = null;
-	for (const rawLine of content.split("\n")) {
-		const line = rawLine.trim();
-		if (!line) continue;
-		try {
-			const parsed: unknown = JSON.parse(line);
-			if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) continue;
-			const record = parsed as Record<string, unknown>;
-			const candidates = [record];
-			if (
-				record.message != null &&
-				typeof record.message === "object" &&
-				!Array.isArray(record.message)
-			) {
-				candidates.push(record.message as Record<string, unknown>);
+function assistantFromRecord(line: string): HookTranscriptExtraction | null {
+	const trimmed = line.trim();
+	if (!trimmed) return null;
+	try {
+		const parsed: unknown = JSON.parse(trimmed);
+		if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+		const record = parsed as Record<string, unknown>;
+		const candidates = [record];
+		if (
+			record.message != null &&
+			typeof record.message === "object" &&
+			!Array.isArray(record.message)
+		) {
+			candidates.push(record.message as Record<string, unknown>);
+		}
+		let role = "";
+		let contentValue: unknown = null;
+		let usageValue: unknown = null;
+		for (const candidate of candidates) {
+			if (!role) {
+				if (typeof candidate.role === "string") role = candidate.role.trim().toLowerCase();
+				else if (candidate.type === "assistant") role = "assistant";
 			}
-			let role = "";
-			let contentValue: unknown = null;
-			let usageValue: unknown = null;
-			for (const candidate of candidates) {
-				if (!role) {
-					if (typeof candidate.role === "string") role = candidate.role.trim().toLowerCase();
-					else if (candidate.type === "assistant") role = "assistant";
-				}
-				if (contentValue == null) {
-					for (const field of ["content", "text"]) {
-						if (field in candidate) {
-							contentValue = candidate[field];
-							break;
-						}
-					}
-				}
-				if (usageValue == null) {
-					for (const field of ["usage", "token_usage", "tokenUsage"]) {
-						if (field in candidate) {
-							usageValue = candidate[field];
-							break;
-						}
+			if (contentValue == null) {
+				for (const field of ["content", "text"]) {
+					if (field in candidate) {
+						contentValue = candidate[field];
+						break;
 					}
 				}
 			}
-			if (role !== "assistant") continue;
-			const text = textFromContent(contentValue);
-			if (!text) continue;
-			assistantText = text;
-			assistantUsage = normalizeUsage(usageValue);
-		} catch {
-			// Ignore malformed JSONL records and continue scanning the bounded tail.
+			if (usageValue == null) {
+				for (const field of ["usage", "token_usage", "tokenUsage"]) {
+					if (field in candidate) {
+						usageValue = candidate[field];
+						break;
+					}
+				}
+			}
+		}
+		if (role !== "assistant") return null;
+		const text = textFromContent(contentValue);
+		return text ? [text, normalizeUsage(usageValue)] : null;
+	} catch {
+		return null;
+	}
+}
+
+function scanTranscript(
+	descriptor: number,
+	size: number,
+	options: HookTranscriptReadOptions,
+): HookTranscriptResult {
+	const windowStart = Math.max(0, size - MAX_HOOK_TRANSCRIPT_BYTES);
+	const buffer = Buffer.allocUnsafe(HOOK_TRANSCRIPT_CHUNK_BYTES);
+	const decodeBuffer = Buffer.allocUnsafe(HOOK_TRANSCRIPT_CHUNK_BYTES);
+	let boundaryAligned = windowStart === 0;
+	if (!boundaryAligned) {
+		boundaryAligned =
+			readInto(descriptor, buffer, 1, windowStart - 1, options) === 1 && buffer[0] === 0x0a;
+	}
+
+	let lineEnd = size;
+	let scanEnd = size;
+	let hasCompleteRecord = false;
+	while (scanEnd > windowStart) {
+		const chunkStart = Math.max(windowStart, scanEnd - buffer.length);
+		const count = readInto(descriptor, buffer, scanEnd - chunkStart, chunkStart, options);
+		if (count === 0) break;
+		for (let index = count - 1; index >= 0; index -= 1) {
+			if (buffer[index] !== 0x0a) continue;
+			const lineStart = chunkStart + index + 1;
+			if (lineEnd > lineStart) {
+				hasCompleteRecord = true;
+				const line =
+					lineEnd <= chunkStart + count
+						? buffer.subarray(index + 1, lineEnd - chunkStart).toString("utf8")
+						: decodeRecord(descriptor, decodeBuffer, lineStart, lineEnd, options);
+				const extraction = assistantFromRecord(line);
+				if (extraction) return { extraction, outcome: "ok" };
+			}
+			lineEnd = chunkStart + index;
+		}
+		scanEnd = chunkStart;
+	}
+
+	if (boundaryAligned && lineEnd > windowStart) {
+		hasCompleteRecord = true;
+		const extraction = assistantFromRecord(
+			decodeRecord(descriptor, decodeBuffer, windowStart, lineEnd, options),
+		);
+		if (extraction) return { extraction, outcome: "ok" };
+	}
+	return {
+		extraction: [null, null],
+		outcome: hasCompleteRecord ? "no_assistant_record" : "no_complete_record",
+	};
+}
+
+function readTranscript(path: string, options: HookTranscriptReadOptions): HookTranscriptResult {
+	let descriptor: number | null = null;
+	try {
+		descriptor = openSync(
+			path,
+			constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0),
+		);
+		const stat = fstatSync(descriptor);
+		if (!stat.isFile()) return { extraction: [null, null], outcome: "unreadable" };
+		const openedPath = realpathSync(path);
+		const openedPathStat = statSync(openedPath);
+		if (openedPath !== path || openedPathStat.dev !== stat.dev || openedPathStat.ino !== stat.ino) {
+			return { extraction: [null, null], outcome: "path_rejected" };
+		}
+		return scanTranscript(descriptor, stat.size, options);
+	} catch {
+		return { extraction: [null, null], outcome: "unreadable" };
+	} finally {
+		if (descriptor !== null) {
+			try {
+				closeSync(descriptor);
+			} catch {
+				// A close failure does not make transcript extraction fatal.
+			}
 		}
 	}
-	return [assistantText, assistantUsage];
 }
 
 export function extractHookTranscript(
 	transcriptPath: unknown,
 	options: HookTranscriptReadOptions,
-): TranscriptExtraction {
-	const resolvedPath = resolveTranscriptPath(transcriptPath, options);
-	if (!resolvedPath) return [null, null];
-	const content = readTranscriptTail(resolvedPath);
-	return content === null ? [null, null] : parseTranscript(content);
+): HookTranscriptExtraction {
+	return extractHookTranscriptWithOutcome(transcriptPath, options).extraction;
+}
+
+export function extractHookTranscriptWithOutcome(
+	transcriptPath: unknown,
+	options: HookTranscriptReadOptions,
+): HookTranscriptResult {
+	const resolved = resolveTranscriptPath(transcriptPath, options);
+	if ("outcome" in resolved) return { extraction: [null, null], outcome: resolved.outcome };
+	return readTranscript(resolved.path, options);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -338,9 +338,16 @@ export {
 	SIMPLE_TIER_DEFAULTS,
 } from "./extraction-tier-routing.js";
 export { buildFilterClauses, buildFilterClausesWithContext } from "./filters.js";
-export type { HookTranscriptPolicy, HookTranscriptReadOptions } from "./hook-transcript.js";
+export type {
+	HookTranscriptExtraction,
+	HookTranscriptOutcome,
+	HookTranscriptPolicy,
+	HookTranscriptReadOptions,
+	HookTranscriptResult,
+} from "./hook-transcript.js";
 export {
 	extractHookTranscript,
+	extractHookTranscriptWithOutcome,
 	MAX_HOOK_TRANSCRIPT_BYTES,
 	TRUSTED_HOOK_TRANSCRIPT_POLICY,
 } from "./hook-transcript.js";

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -454,7 +454,7 @@ describe("viewer-server", () => {
 			envName: "CODEX_HOME",
 			rootName: "sessions",
 		},
-	])("legacy $label hook transcript containment", ({ route, envName, rootName }) => {
+	])("legacy $label hook transcript containment", ({ label, route, envName, rootName }) => {
 		it("accepts configured-root transcripts and rejects outside files", async () => {
 			const parent = mkdtempSync(join(tmpdir(), "codemem-viewer-transcript-root-"));
 			const configuredHome = join(parent, "host-home");
@@ -486,6 +486,7 @@ describe("viewer-server", () => {
 					inserted: 0,
 					skipped: 1,
 					skip_reason: "transcript_unavailable",
+					skip_detail: "path_rejected",
 				});
 
 				const relativeRejected = await postViewerJson(app, route, {
@@ -499,7 +500,65 @@ describe("viewer-server", () => {
 					inserted: 0,
 					skipped: 1,
 					skip_reason: "transcript_unavailable",
+					skip_detail: "path_rejected",
 				});
+
+				writeFileSync(allowedPath, '{"role":"user","content":"no assistant"}\n');
+				const noAssistant = await postViewerJson(app, route, {
+					hook_event_name: "Stop",
+					session_id: "no-assistant-session",
+					transcript_path: allowedPath,
+				});
+				expect(await noAssistant.json()).toEqual({
+					inserted: 0,
+					skipped: 1,
+					skip_reason: "transcript_unavailable",
+					skip_detail: "no_assistant_record",
+				});
+
+				const notProvided = await postViewerJson(app, route, {
+					hook_event_name: "Stop",
+					session_id: "missing-transcript-session",
+				});
+				expect(await notProvided.json()).toEqual({
+					inserted: 0,
+					skipped: 1,
+					skip_reason: "transcript_unavailable",
+					skip_detail: "not_provided",
+				});
+
+				const status = await app.request("/api/raw-events/status");
+				const statusBody = (await status.json()) as Record<string, unknown>;
+				const source = label.toLowerCase() as "claude" | "codex";
+				expect(statusBody.transcript_diagnostics).toMatchObject({
+					scope: "legacy_compatibility_routes",
+					counts: {
+						[source]: {
+							ok: 1,
+							not_provided: 1,
+							path_rejected: 2,
+							no_assistant_record: 1,
+						},
+					},
+				});
+
+				const isolated = createTestApp();
+				try {
+					const isolatedStatus = await isolated.app.request("/api/raw-events/status");
+					const isolatedBody = (await isolatedStatus.json()) as {
+						transcript_diagnostics: { counts: Record<string, Record<string, number>> };
+					};
+					expect(isolatedBody.transcript_diagnostics.counts[source]).toEqual({
+						ok: 0,
+						not_provided: 0,
+						path_rejected: 0,
+						unreadable: 0,
+						no_complete_record: 0,
+						no_assistant_record: 0,
+					});
+				} finally {
+					isolated.cleanup();
+				}
 			} finally {
 				cleanup();
 				if (previousValue == null) delete process.env[envName];

--- a/packages/viewer-server/src/routes/raw-events.ts
+++ b/packages/viewer-server/src/routes/raw-events.ts
@@ -5,7 +5,7 @@
 
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { MemoryStore, RawEventSweeper } from "@codemem/core";
+import type { HookTranscriptOutcome, MemoryStore, RawEventSweeper } from "@codemem/core";
 import {
 	buildRawEventEnvelopeFromCodexHook,
 	buildRawEventEnvelopeFromHook,
@@ -31,6 +31,52 @@ function configuredMaxRawEventsBodyBytes(): number {
 }
 
 const MAX_RAW_EVENTS_BODY_BYTES = configuredMaxRawEventsBodyBytes();
+type LegacyTranscriptSource = "claude" | "codex";
+type TranscriptOutcomeCounts = Record<HookTranscriptOutcome, number>;
+
+function emptyTranscriptOutcomeCounts(): TranscriptOutcomeCounts {
+	return {
+		ok: 0,
+		not_provided: 0,
+		path_rejected: 0,
+		unreadable: 0,
+		no_complete_record: 0,
+		no_assistant_record: 0,
+	} satisfies TranscriptOutcomeCounts;
+}
+
+function createTranscriptDiagnostics() {
+	const counts: Record<LegacyTranscriptSource, TranscriptOutcomeCounts> = {
+		claude: emptyTranscriptOutcomeCounts(),
+		codex: emptyTranscriptOutcomeCounts(),
+	};
+	return {
+		record(source: LegacyTranscriptSource, outcome: HookTranscriptOutcome): void {
+			counts[source][outcome] += 1;
+		},
+		snapshot() {
+			return {
+				scope: "legacy_compatibility_routes" as const,
+				counts: {
+					claude: { ...counts.claude },
+					codex: { ...counts.codex },
+				},
+			};
+		},
+	};
+}
+
+function transcriptSkipResponse(outcome: HookTranscriptOutcome | null) {
+	if (outcome !== null && outcome !== "ok") {
+		return {
+			inserted: 0,
+			skipped: 1,
+			skip_reason: "transcript_unavailable" as const,
+			skip_detail: outcome,
+		};
+	}
+	return { inserted: 0, skipped: 1, skip_reason: "unsupported_hook" as const };
+}
 
 function claudeTranscriptRoot(): string {
 	return join(process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude"), "projects");
@@ -214,6 +260,7 @@ async function ingestNormalizedEnvelope(
 
 export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweeper | null) {
 	const app = new Hono();
+	const transcriptDiagnostics = createTranscriptDiagnostics();
 
 	// GET /api/raw-events (compat endpoint for stats panel)
 	app.get("/api/raw-events", (c) => {
@@ -261,6 +308,7 @@ export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweepe
 				mode: "stream_queue",
 				max_body_bytes: MAX_RAW_EVENTS_BODY_BYTES,
 			},
+			transcript_diagnostics: transcriptDiagnostics.snapshot(),
 		});
 	});
 
@@ -292,15 +340,16 @@ export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweepe
 		const payload = result;
 
 		try {
+			let transcriptOutcome: HookTranscriptOutcome | null = null;
 			const envelope = buildRawEventEnvelopeFromHook(payload, {
 				transcriptPolicy: { trust: "restricted", approvedRoots: [claudeTranscriptRoot()] },
+				onTranscriptOutcome: (outcome) => {
+					transcriptOutcome = outcome;
+					transcriptDiagnostics.record("claude", outcome);
+				},
 			});
 			if (envelope === null) {
-				const skipReason =
-					payload.hook_event_name === "Stop" && typeof payload.transcript_path === "string"
-						? "transcript_unavailable"
-						: "unsupported_hook";
-				return c.json({ inserted: 0, skipped: 1, skip_reason: skipReason });
+				return c.json(transcriptSkipResponse(transcriptOutcome));
 			}
 			const ingestResult = await ingestNormalizedEnvelope(
 				getStore(),
@@ -321,15 +370,16 @@ export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweepe
 		const payload = result;
 
 		try {
+			let transcriptOutcome: HookTranscriptOutcome | null = null;
 			const envelope = buildRawEventEnvelopeFromCodexHook(payload, {
 				transcriptPolicy: { trust: "restricted", approvedRoots: [codexTranscriptRoot()] },
+				onTranscriptOutcome: (outcome) => {
+					transcriptOutcome = outcome;
+					transcriptDiagnostics.record("codex", outcome);
+				},
 			});
 			if (envelope === null) {
-				const skipReason =
-					payload.hook_event_name === "Stop" && typeof payload.transcript_path === "string"
-						? "transcript_unavailable"
-						: "unsupported_hook";
-				return c.json({ inserted: 0, skipped: 1, skip_reason: skipReason });
+				return c.json(transcriptSkipResponse(transcriptOutcome));
 			}
 			const ingestResult = await ingestNormalizedEnvelope(getStore(), sweeper, envelope);
 			return c.json({ inserted: ingestResult.inserted, skipped: ingestResult.skipped });

--- a/plugins/claude/scripts/codemem-normalizer.mjs
+++ b/plugins/claude/scripts/codemem-normalizer.mjs
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 //#region packages/core/src/hook-transcript.ts
 var MAX_HOOK_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
+var HOOK_TRANSCRIPT_CHUNK_BYTES = 64 * 1024;
 var TRUSTED_HOOK_TRANSCRIPT_POLICY = { trust: "trusted" };
 function expandUser$1(path) {
 	return path.startsWith("~/") ? resolve(homedir(), path.slice(2)) : path;
@@ -13,66 +14,62 @@ function isContained(root, target) {
 	return pathFromRoot === "" || pathFromRoot !== ".." && !pathFromRoot.startsWith(`..${sep}`) && !isAbsolute(pathFromRoot);
 }
 function resolveTranscriptPath(transcriptPath, options) {
-	if (typeof transcriptPath !== "string") return null;
+	if (typeof transcriptPath !== "string") return { outcome: "not_provided" };
 	const requestedPath = expandUser$1(transcriptPath.trim());
-	if (!requestedPath) return null;
-	try {
-		if (!isAbsolute(requestedPath)) {
-			if (options.policy.trust !== "trusted") return null;
-			if (typeof options.cwd !== "string") return null;
+	if (!requestedPath) return { outcome: "not_provided" };
+	if (!isAbsolute(requestedPath)) {
+		if (options.policy.trust !== "trusted") return { outcome: "path_rejected" };
+		if (typeof options.cwd !== "string") return { outcome: "path_rejected" };
+		try {
 			const cwd = expandUser$1(options.cwd.trim());
-			if (!isAbsolute(cwd)) return null;
+			if (!isAbsolute(cwd)) return { outcome: "path_rejected" };
 			const realCwd = realpathSync(cwd);
-			if (!statSync(realCwd).isDirectory()) return null;
+			if (!statSync(realCwd).isDirectory()) return { outcome: "path_rejected" };
 			const realTarget = realpathSync(resolve(realCwd, requestedPath));
-			return isContained(realCwd, realTarget) ? realTarget : null;
+			return isContained(realCwd, realTarget) ? { path: realTarget } : { outcome: "path_rejected" };
+		} catch {
+			return { outcome: "unreadable" };
 		}
+	}
+	try {
 		const realTarget = realpathSync(requestedPath);
-		if (options.policy.trust === "trusted") return realTarget;
+		if (options.policy.trust === "trusted") return { path: realTarget };
 		for (const root of options.policy.approvedRoots) try {
 			const realRoot = realpathSync(expandUser$1(root));
-			if (statSync(realRoot).isDirectory() && isContained(realRoot, realTarget)) return realTarget;
+			if (statSync(realRoot).isDirectory() && isContained(realRoot, realTarget)) return { path: realTarget };
 		} catch {}
 	} catch {
-		return null;
+		return { outcome: "unreadable" };
 	}
-	return null;
+	return { outcome: "path_rejected" };
 }
-function readTranscriptTail(path) {
-	let descriptor = null;
+function reportBytesRead(options, count) {
+	if (count <= 0) return;
 	try {
-		descriptor = openSync(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0));
-		const stat = fstatSync(descriptor);
-		if (!stat.isFile()) return null;
-		const openedPath = realpathSync(path);
-		const openedPathStat = statSync(openedPath);
-		if (openedPath !== path || openedPathStat.dev !== stat.dev || openedPathStat.ino !== stat.ino) return null;
-		const bytesToRead = Math.min(stat.size, MAX_HOOK_TRANSCRIPT_BYTES);
-		const start = stat.size - bytesToRead;
-		const buffer = Buffer.allocUnsafe(bytesToRead);
-		let offset = 0;
-		while (offset < bytesToRead) {
-			const bytesRead = readSync(descriptor, buffer, offset, bytesToRead - offset, start + offset);
-			if (bytesRead === 0) break;
-			offset += bytesRead;
-		}
-		let retained = buffer.subarray(0, offset);
-		if (start > 0) {
-			const precedingByte = Buffer.allocUnsafe(1);
-			if (readSync(descriptor, precedingByte, 0, 1, start - 1) !== 1 || precedingByte[0] !== 10) {
-				const firstNewline = retained.indexOf(10);
-				if (firstNewline < 0) return null;
-				retained = retained.subarray(firstNewline + 1);
-			}
-		}
-		return retained.length > 0 ? retained.toString("utf8") : null;
-	} catch {
-		return null;
-	} finally {
-		if (descriptor !== null) try {
-			closeSync(descriptor);
-		} catch {}
+		options.onBytesRead?.(count);
+	} catch {}
+}
+function readInto(descriptor, buffer, length, position, options) {
+	let offset = 0;
+	while (offset < length) {
+		const count = readSync(descriptor, buffer, offset, length - offset, position + offset);
+		if (count === 0) break;
+		offset += count;
+		reportBytesRead(options, count);
 	}
+	return offset;
+}
+function decodeRecord(descriptor, buffer, start, end, options) {
+	const decoder = new TextDecoder("utf-8", { fatal: false });
+	let position = start;
+	let text = "";
+	while (position < end) {
+		const count = readInto(descriptor, buffer, Math.min(buffer.length, end - position), position, options);
+		if (count === 0) break;
+		position += count;
+		text += decoder.decode(buffer.subarray(0, count), { stream: position < end });
+	}
+	return text;
 }
 function textFromContent(value) {
 	if (typeof value === "string") return value.trim();
@@ -103,57 +100,122 @@ function normalizeUsage$1(value) {
 	};
 	return Object.values(normalized).reduce((sum, count) => sum + count, 0) > 0 ? normalized : null;
 }
-function parseTranscript(content) {
-	let assistantText = null;
-	let assistantUsage = null;
-	for (const rawLine of content.split("\n")) {
-		const line = rawLine.trim();
-		if (!line) continue;
-		try {
-			const parsed = JSON.parse(line);
-			if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) continue;
-			const record = parsed;
-			const candidates = [record];
-			if (record.message != null && typeof record.message === "object" && !Array.isArray(record.message)) candidates.push(record.message);
-			let role = "";
-			let contentValue = null;
-			let usageValue = null;
-			for (const candidate of candidates) {
-				if (!role) {
-					if (typeof candidate.role === "string") role = candidate.role.trim().toLowerCase();
-					else if (candidate.type === "assistant") role = "assistant";
-				}
-				if (contentValue == null) {
-					for (const field of ["content", "text"]) if (field in candidate) {
-						contentValue = candidate[field];
-						break;
-					}
-				}
-				if (usageValue == null) {
-					for (const field of [
-						"usage",
-						"token_usage",
-						"tokenUsage"
-					]) if (field in candidate) {
-						usageValue = candidate[field];
-						break;
-					}
+function assistantFromRecord(line) {
+	const trimmed = line.trim();
+	if (!trimmed) return null;
+	try {
+		const parsed = JSON.parse(trimmed);
+		if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+		const record = parsed;
+		const candidates = [record];
+		if (record.message != null && typeof record.message === "object" && !Array.isArray(record.message)) candidates.push(record.message);
+		let role = "";
+		let contentValue = null;
+		let usageValue = null;
+		for (const candidate of candidates) {
+			if (!role) {
+				if (typeof candidate.role === "string") role = candidate.role.trim().toLowerCase();
+				else if (candidate.type === "assistant") role = "assistant";
+			}
+			if (contentValue == null) {
+				for (const field of ["content", "text"]) if (field in candidate) {
+					contentValue = candidate[field];
+					break;
 				}
 			}
-			if (role !== "assistant") continue;
-			const text = textFromContent(contentValue);
-			if (!text) continue;
-			assistantText = text;
-			assistantUsage = normalizeUsage$1(usageValue);
+			if (usageValue == null) {
+				for (const field of [
+					"usage",
+					"token_usage",
+					"tokenUsage"
+				]) if (field in candidate) {
+					usageValue = candidate[field];
+					break;
+				}
+			}
+		}
+		if (role !== "assistant") return null;
+		const text = textFromContent(contentValue);
+		return text ? [text, normalizeUsage$1(usageValue)] : null;
+	} catch {
+		return null;
+	}
+}
+function scanTranscript(descriptor, size, options) {
+	const windowStart = Math.max(0, size - MAX_HOOK_TRANSCRIPT_BYTES);
+	const buffer = Buffer.allocUnsafe(HOOK_TRANSCRIPT_CHUNK_BYTES);
+	const decodeBuffer = Buffer.allocUnsafe(HOOK_TRANSCRIPT_CHUNK_BYTES);
+	let boundaryAligned = windowStart === 0;
+	if (!boundaryAligned) boundaryAligned = readInto(descriptor, buffer, 1, windowStart - 1, options) === 1 && buffer[0] === 10;
+	let lineEnd = size;
+	let scanEnd = size;
+	let hasCompleteRecord = false;
+	while (scanEnd > windowStart) {
+		const chunkStart = Math.max(windowStart, scanEnd - buffer.length);
+		const count = readInto(descriptor, buffer, scanEnd - chunkStart, chunkStart, options);
+		if (count === 0) break;
+		for (let index = count - 1; index >= 0; index -= 1) {
+			if (buffer[index] !== 10) continue;
+			const lineStart = chunkStart + index + 1;
+			if (lineEnd > lineStart) {
+				hasCompleteRecord = true;
+				const extraction = assistantFromRecord(lineEnd <= chunkStart + count ? buffer.subarray(index + 1, lineEnd - chunkStart).toString("utf8") : decodeRecord(descriptor, decodeBuffer, lineStart, lineEnd, options));
+				if (extraction) return {
+					extraction,
+					outcome: "ok"
+				};
+			}
+			lineEnd = chunkStart + index;
+		}
+		scanEnd = chunkStart;
+	}
+	if (boundaryAligned && lineEnd > windowStart) {
+		hasCompleteRecord = true;
+		const extraction = assistantFromRecord(decodeRecord(descriptor, decodeBuffer, windowStart, lineEnd, options));
+		if (extraction) return {
+			extraction,
+			outcome: "ok"
+		};
+	}
+	return {
+		extraction: [null, null],
+		outcome: hasCompleteRecord ? "no_assistant_record" : "no_complete_record"
+	};
+}
+function readTranscript(path, options) {
+	let descriptor = null;
+	try {
+		descriptor = openSync(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0));
+		const stat = fstatSync(descriptor);
+		if (!stat.isFile()) return {
+			extraction: [null, null],
+			outcome: "unreadable"
+		};
+		const openedPath = realpathSync(path);
+		const openedPathStat = statSync(openedPath);
+		if (openedPath !== path || openedPathStat.dev !== stat.dev || openedPathStat.ino !== stat.ino) return {
+			extraction: [null, null],
+			outcome: "path_rejected"
+		};
+		return scanTranscript(descriptor, stat.size, options);
+	} catch {
+		return {
+			extraction: [null, null],
+			outcome: "unreadable"
+		};
+	} finally {
+		if (descriptor !== null) try {
+			closeSync(descriptor);
 		} catch {}
 	}
-	return [assistantText, assistantUsage];
 }
-function extractHookTranscript(transcriptPath, options) {
-	const resolvedPath = resolveTranscriptPath(transcriptPath, options);
-	if (!resolvedPath) return [null, null];
-	const content = readTranscriptTail(resolvedPath);
-	return content === null ? [null, null] : parseTranscript(content);
+function extractHookTranscriptWithOutcome(transcriptPath, options) {
+	const resolved = resolveTranscriptPath(transcriptPath, options);
+	if ("outcome" in resolved) return {
+		extraction: [null, null],
+		outcome: resolved.outcome
+	};
+	return readTranscript(resolved.path, options);
 }
 //#endregion
 //#region packages/core/src/claude-hooks.ts
@@ -363,11 +425,15 @@ function normalizeUsage(value) {
 function extractFromTranscript(transcriptPath, cwdHint, policy = {
 	trust: "restricted",
 	approvedRoots: []
-}) {
-	return extractHookTranscript(transcriptPath, {
+}, onTranscriptOutcome) {
+	const result = extractHookTranscriptWithOutcome(transcriptPath, {
 		policy,
 		cwd: cwdHint
 	});
+	try {
+		onTranscriptOutcome?.(result.outcome);
+	} catch {}
+	return result.extraction;
 }
 var TRUSTED_HOOK_MAPPER_OPTIONS = { transcriptPolicy: TRUSTED_HOOK_TRANSCRIPT_POLICY };
 function coerceSessionId(payload) {
@@ -466,7 +532,7 @@ function mapClaudeHookPayload(payload, options) {
 		let usage = rawUsage;
 		if (!assistantText || usage === null) {
 			const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
-			const [transcriptText, transcriptUsage] = extractFromTranscript(payload.transcript_path, cwd, options.transcriptPolicy);
+			const [transcriptText, transcriptUsage] = extractFromTranscript(payload.transcript_path, cwd, options.transcriptPolicy, options.onTranscriptOutcome);
 			if (!assistantText && transcriptText) assistantText = transcriptText;
 			if (usage === null && transcriptUsage !== null) usage = transcriptUsage;
 		}

--- a/plugins/codex/scripts/codemem-normalizer.mjs
+++ b/plugins/codex/scripts/codemem-normalizer.mjs
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 //#region packages/core/src/hook-transcript.ts
 var MAX_HOOK_TRANSCRIPT_BYTES = 16 * 1024 * 1024;
+var HOOK_TRANSCRIPT_CHUNK_BYTES = 64 * 1024;
 var TRUSTED_HOOK_TRANSCRIPT_POLICY = { trust: "trusted" };
 function expandUser$1(path) {
 	return path.startsWith("~/") ? resolve(homedir(), path.slice(2)) : path;
@@ -13,66 +14,62 @@ function isContained(root, target) {
 	return pathFromRoot === "" || pathFromRoot !== ".." && !pathFromRoot.startsWith(`..${sep}`) && !isAbsolute(pathFromRoot);
 }
 function resolveTranscriptPath(transcriptPath, options) {
-	if (typeof transcriptPath !== "string") return null;
+	if (typeof transcriptPath !== "string") return { outcome: "not_provided" };
 	const requestedPath = expandUser$1(transcriptPath.trim());
-	if (!requestedPath) return null;
-	try {
-		if (!isAbsolute(requestedPath)) {
-			if (options.policy.trust !== "trusted") return null;
-			if (typeof options.cwd !== "string") return null;
+	if (!requestedPath) return { outcome: "not_provided" };
+	if (!isAbsolute(requestedPath)) {
+		if (options.policy.trust !== "trusted") return { outcome: "path_rejected" };
+		if (typeof options.cwd !== "string") return { outcome: "path_rejected" };
+		try {
 			const cwd = expandUser$1(options.cwd.trim());
-			if (!isAbsolute(cwd)) return null;
+			if (!isAbsolute(cwd)) return { outcome: "path_rejected" };
 			const realCwd = realpathSync(cwd);
-			if (!statSync(realCwd).isDirectory()) return null;
+			if (!statSync(realCwd).isDirectory()) return { outcome: "path_rejected" };
 			const realTarget = realpathSync(resolve(realCwd, requestedPath));
-			return isContained(realCwd, realTarget) ? realTarget : null;
+			return isContained(realCwd, realTarget) ? { path: realTarget } : { outcome: "path_rejected" };
+		} catch {
+			return { outcome: "unreadable" };
 		}
+	}
+	try {
 		const realTarget = realpathSync(requestedPath);
-		if (options.policy.trust === "trusted") return realTarget;
+		if (options.policy.trust === "trusted") return { path: realTarget };
 		for (const root of options.policy.approvedRoots) try {
 			const realRoot = realpathSync(expandUser$1(root));
-			if (statSync(realRoot).isDirectory() && isContained(realRoot, realTarget)) return realTarget;
+			if (statSync(realRoot).isDirectory() && isContained(realRoot, realTarget)) return { path: realTarget };
 		} catch {}
 	} catch {
-		return null;
+		return { outcome: "unreadable" };
 	}
-	return null;
+	return { outcome: "path_rejected" };
 }
-function readTranscriptTail(path) {
-	let descriptor = null;
+function reportBytesRead(options, count) {
+	if (count <= 0) return;
 	try {
-		descriptor = openSync(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0));
-		const stat = fstatSync(descriptor);
-		if (!stat.isFile()) return null;
-		const openedPath = realpathSync(path);
-		const openedPathStat = statSync(openedPath);
-		if (openedPath !== path || openedPathStat.dev !== stat.dev || openedPathStat.ino !== stat.ino) return null;
-		const bytesToRead = Math.min(stat.size, MAX_HOOK_TRANSCRIPT_BYTES);
-		const start = stat.size - bytesToRead;
-		const buffer = Buffer.allocUnsafe(bytesToRead);
-		let offset = 0;
-		while (offset < bytesToRead) {
-			const bytesRead = readSync(descriptor, buffer, offset, bytesToRead - offset, start + offset);
-			if (bytesRead === 0) break;
-			offset += bytesRead;
-		}
-		let retained = buffer.subarray(0, offset);
-		if (start > 0) {
-			const precedingByte = Buffer.allocUnsafe(1);
-			if (readSync(descriptor, precedingByte, 0, 1, start - 1) !== 1 || precedingByte[0] !== 10) {
-				const firstNewline = retained.indexOf(10);
-				if (firstNewline < 0) return null;
-				retained = retained.subarray(firstNewline + 1);
-			}
-		}
-		return retained.length > 0 ? retained.toString("utf8") : null;
-	} catch {
-		return null;
-	} finally {
-		if (descriptor !== null) try {
-			closeSync(descriptor);
-		} catch {}
+		options.onBytesRead?.(count);
+	} catch {}
+}
+function readInto(descriptor, buffer, length, position, options) {
+	let offset = 0;
+	while (offset < length) {
+		const count = readSync(descriptor, buffer, offset, length - offset, position + offset);
+		if (count === 0) break;
+		offset += count;
+		reportBytesRead(options, count);
 	}
+	return offset;
+}
+function decodeRecord(descriptor, buffer, start, end, options) {
+	const decoder = new TextDecoder("utf-8", { fatal: false });
+	let position = start;
+	let text = "";
+	while (position < end) {
+		const count = readInto(descriptor, buffer, Math.min(buffer.length, end - position), position, options);
+		if (count === 0) break;
+		position += count;
+		text += decoder.decode(buffer.subarray(0, count), { stream: position < end });
+	}
+	return text;
 }
 function textFromContent(value) {
 	if (typeof value === "string") return value.trim();
@@ -103,57 +100,122 @@ function normalizeUsage(value) {
 	};
 	return Object.values(normalized).reduce((sum, count) => sum + count, 0) > 0 ? normalized : null;
 }
-function parseTranscript(content) {
-	let assistantText = null;
-	let assistantUsage = null;
-	for (const rawLine of content.split("\n")) {
-		const line = rawLine.trim();
-		if (!line) continue;
-		try {
-			const parsed = JSON.parse(line);
-			if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) continue;
-			const record = parsed;
-			const candidates = [record];
-			if (record.message != null && typeof record.message === "object" && !Array.isArray(record.message)) candidates.push(record.message);
-			let role = "";
-			let contentValue = null;
-			let usageValue = null;
-			for (const candidate of candidates) {
-				if (!role) {
-					if (typeof candidate.role === "string") role = candidate.role.trim().toLowerCase();
-					else if (candidate.type === "assistant") role = "assistant";
-				}
-				if (contentValue == null) {
-					for (const field of ["content", "text"]) if (field in candidate) {
-						contentValue = candidate[field];
-						break;
-					}
-				}
-				if (usageValue == null) {
-					for (const field of [
-						"usage",
-						"token_usage",
-						"tokenUsage"
-					]) if (field in candidate) {
-						usageValue = candidate[field];
-						break;
-					}
+function assistantFromRecord(line) {
+	const trimmed = line.trim();
+	if (!trimmed) return null;
+	try {
+		const parsed = JSON.parse(trimmed);
+		if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+		const record = parsed;
+		const candidates = [record];
+		if (record.message != null && typeof record.message === "object" && !Array.isArray(record.message)) candidates.push(record.message);
+		let role = "";
+		let contentValue = null;
+		let usageValue = null;
+		for (const candidate of candidates) {
+			if (!role) {
+				if (typeof candidate.role === "string") role = candidate.role.trim().toLowerCase();
+				else if (candidate.type === "assistant") role = "assistant";
+			}
+			if (contentValue == null) {
+				for (const field of ["content", "text"]) if (field in candidate) {
+					contentValue = candidate[field];
+					break;
 				}
 			}
-			if (role !== "assistant") continue;
-			const text = textFromContent(contentValue);
-			if (!text) continue;
-			assistantText = text;
-			assistantUsage = normalizeUsage(usageValue);
+			if (usageValue == null) {
+				for (const field of [
+					"usage",
+					"token_usage",
+					"tokenUsage"
+				]) if (field in candidate) {
+					usageValue = candidate[field];
+					break;
+				}
+			}
+		}
+		if (role !== "assistant") return null;
+		const text = textFromContent(contentValue);
+		return text ? [text, normalizeUsage(usageValue)] : null;
+	} catch {
+		return null;
+	}
+}
+function scanTranscript(descriptor, size, options) {
+	const windowStart = Math.max(0, size - MAX_HOOK_TRANSCRIPT_BYTES);
+	const buffer = Buffer.allocUnsafe(HOOK_TRANSCRIPT_CHUNK_BYTES);
+	const decodeBuffer = Buffer.allocUnsafe(HOOK_TRANSCRIPT_CHUNK_BYTES);
+	let boundaryAligned = windowStart === 0;
+	if (!boundaryAligned) boundaryAligned = readInto(descriptor, buffer, 1, windowStart - 1, options) === 1 && buffer[0] === 10;
+	let lineEnd = size;
+	let scanEnd = size;
+	let hasCompleteRecord = false;
+	while (scanEnd > windowStart) {
+		const chunkStart = Math.max(windowStart, scanEnd - buffer.length);
+		const count = readInto(descriptor, buffer, scanEnd - chunkStart, chunkStart, options);
+		if (count === 0) break;
+		for (let index = count - 1; index >= 0; index -= 1) {
+			if (buffer[index] !== 10) continue;
+			const lineStart = chunkStart + index + 1;
+			if (lineEnd > lineStart) {
+				hasCompleteRecord = true;
+				const extraction = assistantFromRecord(lineEnd <= chunkStart + count ? buffer.subarray(index + 1, lineEnd - chunkStart).toString("utf8") : decodeRecord(descriptor, decodeBuffer, lineStart, lineEnd, options));
+				if (extraction) return {
+					extraction,
+					outcome: "ok"
+				};
+			}
+			lineEnd = chunkStart + index;
+		}
+		scanEnd = chunkStart;
+	}
+	if (boundaryAligned && lineEnd > windowStart) {
+		hasCompleteRecord = true;
+		const extraction = assistantFromRecord(decodeRecord(descriptor, decodeBuffer, windowStart, lineEnd, options));
+		if (extraction) return {
+			extraction,
+			outcome: "ok"
+		};
+	}
+	return {
+		extraction: [null, null],
+		outcome: hasCompleteRecord ? "no_assistant_record" : "no_complete_record"
+	};
+}
+function readTranscript(path, options) {
+	let descriptor = null;
+	try {
+		descriptor = openSync(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0));
+		const stat = fstatSync(descriptor);
+		if (!stat.isFile()) return {
+			extraction: [null, null],
+			outcome: "unreadable"
+		};
+		const openedPath = realpathSync(path);
+		const openedPathStat = statSync(openedPath);
+		if (openedPath !== path || openedPathStat.dev !== stat.dev || openedPathStat.ino !== stat.ino) return {
+			extraction: [null, null],
+			outcome: "path_rejected"
+		};
+		return scanTranscript(descriptor, stat.size, options);
+	} catch {
+		return {
+			extraction: [null, null],
+			outcome: "unreadable"
+		};
+	} finally {
+		if (descriptor !== null) try {
+			closeSync(descriptor);
 		} catch {}
 	}
-	return [assistantText, assistantUsage];
 }
-function extractHookTranscript(transcriptPath, options) {
-	const resolvedPath = resolveTranscriptPath(transcriptPath, options);
-	if (!resolvedPath) return [null, null];
-	const content = readTranscriptTail(resolvedPath);
-	return content === null ? [null, null] : parseTranscript(content);
+function extractHookTranscriptWithOutcome(transcriptPath, options) {
+	const resolved = resolveTranscriptPath(transcriptPath, options);
+	if ("outcome" in resolved) return {
+		extraction: [null, null],
+		outcome: resolved.outcome
+	};
+	return readTranscript(resolved.path, options);
 }
 //#endregion
 //#region packages/core/src/claude-hooks.ts
@@ -231,11 +293,15 @@ function resolveHookProject(cwd, payloadProject) {
 function extractFromTranscript(transcriptPath, cwdHint, policy = {
 	trust: "restricted",
 	approvedRoots: []
-}) {
-	return extractHookTranscript(transcriptPath, {
+}, onTranscriptOutcome) {
+	const result = extractHookTranscriptWithOutcome(transcriptPath, {
 		policy,
 		cwd: cwdHint
 	});
+	try {
+		onTranscriptOutcome?.(result.outcome);
+	} catch {}
+	return result.extraction;
 }
 var TRUSTED_HOOK_MAPPER_OPTIONS = { transcriptPolicy: TRUSTED_HOOK_TRANSCRIPT_POLICY };
 //#endregion
@@ -370,7 +436,7 @@ function mapCodexHookPayload(payload, options) {
 		let assistantText = rawAssistantText;
 		if (!assistantText) {
 			const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
-			const [transcriptText] = extractFromTranscript(payload.transcript_path, cwd, options.transcriptPolicy);
+			const [transcriptText] = extractFromTranscript(payload.transcript_path, cwd, options.transcriptPolicy, options.onTranscriptOutcome);
 			if (transcriptText) assistantText = transcriptText.trim();
 		}
 		if (!assistantText) return null;


### PR DESCRIPTION
## Description

Harden Claude and Codex transcript fallback by scanning the bounded transcript tail backward in reusable chunks, preserving UTF-8 and record-boundary behavior without materializing the full retained window. Add fixed-cardinality, path-free transcript outcome diagnostics to legacy compatibility-route status and additive skip details to compatibility responses.

Tracks `codemem-2b06.10`. Stacked on #1475.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional checks: `pnpm run test:release`, `pnpm run test:adapter-normalizers`, focused Claude/Codex/viewer tests (361 passed).

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced