### PR TITLE
test(plugin): harden updater restart coverage

### DIFF
--- a/docs/plans/2026-08-17-updater-restart-test-hardening-design.md
+++ b/docs/plans/2026-08-17-updater-restart-test-hardening-design.md
@@ -1,0 +1,16 @@
+# Updater Restart Test Hardening
+
+## Goal
+
+Prevent updater restart regressions by making startup fetch doubles strict and by directly exercising the compatibility-mismatch auto-update path.
+
+## Design
+
+- Keep the change test-only; existing production ownership behavior remains unchanged.
+- Use a URL-aware helper that returns a real `Response` only for the expected Viewer health endpoint and throws for every unexpected request.
+- Preserve release-update coverage while adding compatibility-mismatch scenarios that simulate an outdated CLI, successful installation, and a compatible refreshed version.
+- Verify that compatibility auto-update restarts a Viewer started by the current plugin process and does not restart a Viewer that was already running.
+
+## Validation
+
+Run the focused update-notification test file, followed by the complete OpenCode plugin test suite.

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -22,6 +22,12 @@ const currentStatus = {
 	error: null,
 };
 
+const compatibleStatus = {
+	...currentStatus,
+	current_version: "0.41.0",
+	latest_version: "0.41.0",
+};
+
 const availableStatus = {
 	...currentStatus,
 	latest_version: "0.41.0",
@@ -59,6 +65,26 @@ function installSpawnResult(status = availableStatus) {
 	});
 }
 
+function installCompatibilityAutoUpdateSpawnResult({ startViewer = false } = {}) {
+	let versionCallCount = 0;
+	spawnMock.mockImplementation((_command, args) => {
+		if (startViewer && args?.includes("serve") && args?.includes("start")) {
+			return makeProcess({ emitSpawn: true });
+		}
+		if (args?.includes("version")) {
+			versionCallCount += 1;
+			return makeProcess({
+				stdout: versionCallCount === 1 ? "0.40.2\n" : "0.41.0\n",
+			});
+		}
+		if (args?.includes("update") && args?.includes("check")) {
+			return makeProcess({ stdout: JSON.stringify(compatibleStatus) });
+		}
+		return makeProcess();
+	});
+	return () => versionCallCount;
+}
+
 async function startPlugin(showToast = vi.fn().mockResolvedValue(undefined)) {
 	const { CodememPlugin } = await import("../plugins/codemem.js");
 	const hooks = await CodememPlugin({
@@ -76,6 +102,19 @@ async function startPlugin(showToast = vi.fn().mockResolvedValue(undefined)) {
 async function runStartupChecks() {
 	await vi.advanceTimersByTimeAsync(1_500);
 	await vi.runAllTicks();
+}
+
+function mockViewerHealthFetch(expectedUrl, status) {
+	const unexpectedUrls = [];
+	const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+		const actualUrl = input instanceof Request ? input.url : String(input);
+		if (actualUrl !== expectedUrl) {
+			unexpectedUrls.push(actualUrl);
+			throw new Error(`Unexpected fetch URL: ${actualUrl}`);
+		}
+		return new Response(null, { status });
+	});
+	return { fetchMock, unexpectedUrls };
 }
 
 describe("@codemem/opencode-plugin exports", () => {
@@ -103,6 +142,13 @@ describe("OpenCode startup release notifications", () => {
 			CODEMEM_INJECT_CONTEXT: "0",
 			CODEMEM_BACKEND_UPDATE_POLICY: "notify",
 		};
+		delete process.env.CODEMEM_MIN_VERSION;
+		delete process.env.CODEMEM_RUNNER_FROM;
+		delete process.env.CODEMEM_DB;
+		delete process.env.CODEMEM_CONFIG;
+		delete process.env.CODEMEM_VIEWER_AUTO;
+		delete process.env.CODEMEM_VIEWER_HOST;
+		delete process.env.CODEMEM_VIEWER_PORT;
 	});
 
 	afterEach(() => {
@@ -228,7 +274,10 @@ describe("OpenCode startup release notifications", () => {
 		process.env.CODEMEM_VIEWER_PORT = "48765";
 		process.env.CODEMEM_DB = "/tmp/codemem/viewer.sqlite";
 		process.env.CODEMEM_CONFIG = "/tmp/codemem/config.json";
-		vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("viewer unavailable"));
+		const { fetchMock, unexpectedUrls } = mockViewerHealthFetch(
+			"http://127.0.0.9:48765/api/health",
+			503,
+		);
 		spawnMock.mockImplementation((_command, args) => {
 			if (args?.includes("serve") && args?.includes("start")) {
 				return makeProcess({ emitSpawn: true });
@@ -248,6 +297,11 @@ describe("OpenCode startup release notifications", () => {
 		await runStartupChecks();
 
 		// Assert
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://127.0.0.9:48765/api/health",
+			expect.objectContaining({ method: "GET", redirect: "manual" }),
+		);
+		expect(unexpectedUrls).toEqual([]);
 		expect(spawnMock).toHaveBeenCalledWith(
 			"codemem",
 			[
@@ -302,7 +356,10 @@ describe("OpenCode startup release notifications", () => {
 		process.env.CODEMEM_VIEWER_AUTO = "1";
 		process.env.CODEMEM_VIEWER_HOST = "127.0.0.1";
 		process.env.CODEMEM_VIEWER_PORT = "38888";
-		const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true });
+		const { fetchMock, unexpectedUrls } = mockViewerHealthFetch(
+			"http://127.0.0.1:38888/api/health",
+			200,
+		);
 		installSpawnResult({ ...availableStatus, auto_update_eligible: true });
 
 		// Act
@@ -315,6 +372,7 @@ describe("OpenCode startup release notifications", () => {
 			"http://127.0.0.1:38888/api/health",
 			expect.objectContaining({ method: "GET", redirect: "manual" }),
 		);
+		expect(unexpectedUrls).toEqual([]);
 		expect(
 			spawnMock.mock.calls.some(
 				(call) => call[1]?.includes("update") && call[1]?.includes("install"),
@@ -327,6 +385,120 @@ describe("OpenCode startup release notifications", () => {
 					["start", "restart"].some((action) => call[1]?.includes(action)),
 			),
 		).toBe(false);
+	});
+
+	test("compatibility auto-update restarts the plugin-owned viewer after the refreshed CLI is compatible", async () => {
+		// Arrange
+		process.env.CODEMEM_BACKEND_UPDATE_POLICY = "auto";
+		process.env.CODEMEM_MIN_VERSION = "0.41.0";
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "1";
+		process.env.CODEMEM_VIEWER_HOST = "127.0.0.7";
+		process.env.CODEMEM_VIEWER_PORT = "47777";
+		const { fetchMock, unexpectedUrls } = mockViewerHealthFetch(
+			"http://127.0.0.7:47777/api/health",
+			503,
+		);
+		const getVersionCallCount = installCompatibilityAutoUpdateSpawnResult({
+			startViewer: true,
+		});
+		const showToast = vi.fn().mockResolvedValue(undefined);
+
+		// Act
+		await startPlugin(showToast);
+		await vi.advanceTimersByTimeAsync(0);
+		await runStartupChecks();
+		await vi.waitFor(() => {
+			expect(
+				spawnMock.mock.calls.some((call) => call[1]?.join(" ") === "update check --json"),
+			).toBe(true);
+		});
+
+		// Assert
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://127.0.0.7:47777/api/health",
+			expect.objectContaining({ method: "GET", redirect: "manual" }),
+		);
+		expect(unexpectedUrls).toEqual([]);
+		expect(getVersionCallCount()).toBe(2);
+		const installIndex = spawnMock.mock.calls.findIndex(
+			(call) => call[1]?.join(" ") === "update install --json",
+		);
+		const restartIndex = spawnMock.mock.calls.findIndex(
+			(call) => call[1]?.includes("serve") && call[1]?.includes("restart"),
+		);
+		expect(installIndex).toBeGreaterThanOrEqual(0);
+		expect(restartIndex).toBeGreaterThan(installIndex);
+		expect(spawnMock).toHaveBeenCalledWith(
+			"codemem",
+			["serve", "restart", "--host", "127.0.0.7", "--port", "47777"],
+			{
+				cwd: "/tmp/codemem",
+				env: process.env,
+				stdio: ["pipe", "pipe", "pipe"],
+			},
+		);
+		expect(
+			spawnMock.mock.calls.filter(
+				(call) => call[1]?.includes("serve") && call[1]?.includes("restart"),
+			),
+		).toHaveLength(1);
+		expect(showToast).toHaveBeenCalledWith({
+			body: {
+				message: "Updated codemem backend from 0.40.2 to 0.41.0.",
+				variant: "success",
+			},
+		});
+	});
+
+	test("compatibility auto-update does not restart a pre-existing viewer after verification succeeds", async () => {
+		// Arrange
+		process.env.CODEMEM_BACKEND_UPDATE_POLICY = "auto";
+		process.env.CODEMEM_MIN_VERSION = "0.41.0";
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "1";
+		process.env.CODEMEM_VIEWER_HOST = "127.0.0.8";
+		process.env.CODEMEM_VIEWER_PORT = "48888";
+		const { fetchMock, unexpectedUrls } = mockViewerHealthFetch(
+			"http://127.0.0.8:48888/api/health",
+			200,
+		);
+		const getVersionCallCount = installCompatibilityAutoUpdateSpawnResult();
+		const showToast = vi.fn().mockResolvedValue(undefined);
+
+		// Act
+		await startPlugin(showToast);
+		await vi.advanceTimersByTimeAsync(0);
+		await runStartupChecks();
+		await vi.waitFor(() => {
+			expect(
+				spawnMock.mock.calls.some((call) => call[1]?.join(" ") === "update check --json"),
+			).toBe(true);
+		});
+
+		// Assert
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://127.0.0.8:48888/api/health",
+			expect.objectContaining({ method: "GET", redirect: "manual" }),
+		);
+		expect(unexpectedUrls).toEqual([]);
+		expect(getVersionCallCount()).toBe(2);
+		expect(
+			spawnMock.mock.calls.some((call) => call[1]?.join(" ") === "update install --json"),
+		).toBe(true);
+		expect(
+			spawnMock.mock.calls.some(
+				(call) =>
+					call[1]?.includes("serve") &&
+					["start", "restart"].some((action) => call[1]?.includes(action)),
+			),
+		).toBe(false);
+		expect(showToast).toHaveBeenCalledWith({
+			body: {
+				message: "Updated codemem backend from 0.40.2 to 0.41.0.",
+				variant: "success",
+			},
+		});
 	});
 
 	test("auto remains notification-only until the 24-hour eligibility gate opens", async () => {


### PR DESCRIPTION
## Description

Strengthens updater restart regression coverage without changing production behavior.

- uses URL-aware, real `Response` Viewer health doubles and records unexpected requests
- directly covers compatibility mismatch auto-update from an outdated CLI through refreshed-version verification
- proves only a Viewer started by the current plugin process is restarted
- isolates updater and Viewer environment state between tests

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation:
- `pnpm --filter codemem test:plugin` — 10 files, 219 tests passed
- `pnpm run check` — 195 files, 4,439 passed, 3 todo
- `git diff --check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

Tracks `codemem-j9ew`.