### PR TITLE
fix(viewer): harden feed identity presentation

### DIFF
--- a/docs/coordinator-deployment.md
+++ b/docs/coordinator-deployment.md
@@ -232,6 +232,11 @@ codemem coordinator import-invite <encoded-invite>
 
 Or paste the invite in the viewer UI under **Advanced → Team sync → Join team**.
 
+For an exact-Project invitation, use `--recipient-name "Your name"` or
+`--device-name "Your device"` to replace legacy configured names that look like internal
+identifiers. Team-member and add-device recipient invitations must be accepted in the viewer
+because codemem must show and confirm their reviewed access details before joining.
+
 If the invite policy is `approval_required`, the teammate's join request will appear in the admin's pending queue. The
 admin approves it from the CLI or the viewer UI.
 

--- a/docs/plans/2026-08-18-feed-identity-presentation-hardening-design.md
+++ b/docs/plans/2026-08-18-feed-identity-presentation-hardening-design.md
@@ -1,0 +1,50 @@
+# Feed identity presentation hardening
+
+**Date:** 2026-08-18
+**Status:** Approved
+**Related:** `codemem-g9sp`, `2026-07-21-project-recipient-sharing-identity-design.md`
+
+## Problem
+
+Direct Project acceptance can replace an owner-reviewed pending Identity name with a recipient-supplied machine identifier. Viewer memory responses do not resolve trusted local actor and device facts, and Feed consequently renders raw actor IDs and device UUIDs as ordinary labels. Existing malformed rows need a safe presentation path without rewriting historical provenance.
+
+## Decisions
+
+1. Preserve a human-shaped pending or existing actor name during direct Project reconciliation instead of overwriting it with a machine-shaped accepted name.
+2. Add a dedicated human-presentation name validator. Apply it to invitation acceptance, actor rename, and device rename, but not to Project names.
+3. Keep stored memory provenance unchanged. Viewer memory responses add resolved actor and device display fields derived from trusted local identity records.
+4. Resolve author labels from an active actor first. For an unknown actor, use a fingerprint-bound peer actor; for a known merged actor, follow its active merge target. Use a human-shaped stored memory label only when trusted local facts do not resolve.
+5. Resolve device labels from an active identity device first, then a fingerprint-bound peer with a human-shaped name.
+6. Feed uses resolved fields and neutral fallbacks. Raw actor and device identifiers remain available only to explicit diagnostics.
+
+## API and presentation contract
+
+Memory responses may add:
+
+- `resolved_actor_display_name`
+- `resolved_device_display_name`
+
+The fields are additive and optional for compatibility. Feed falls back to `Teammate` or `Unknown author` for unresolved authors and `Shared device` for unresolved remote devices. It never promotes `local:*`, UUIDs, identity IDs, or hostname-like hexadecimal values to normal labels.
+
+## Validation
+
+Human presentation names continue to use the existing structural limits and additionally reject machine-shaped values. Validation failures return the existing client-error response shape with a clear request-boundary message. Project names retain their current normalization behavior.
+
+Automatically derived device names skip machine-shaped hostnames and fall back to `Codemem device <seed>`, so container and cloud installs remain enrollable without promoting host identifiers to display names.
+
+Mixed-version installations should upgrade accepting clients before coordinators. An upgraded coordinator intentionally rejects machine-shaped names sent by older clients; these validation codes remain explicit and map to actionable Viewer guidance.
+
+## Tests
+
+- Direct Project reconciliation preserves the pending human actor name when acceptance supplies a machine-shaped fallback.
+- Invitation acceptance, actor rename, and device rename reject representative machine-shaped values.
+- Viewer memory endpoints resolve trusted actor and device facts in batches and return neutral results when no trusted fact exists.
+- Feed renders resolved names or neutral fallbacks and does not render raw actor/device identifiers.
+- Existing memory-ID diagnostics remain unchanged.
+
+## Non-goals
+
+- No historical identity backfill or provenance rewrite.
+- No redesign of Sharing, Devices, or Feed.
+- No changes to Project-name validation.
+- No expansion of Team or add-device journey coverage already present elsewhere.

--- a/packages/cli/src/commands/coordinator.test.ts
+++ b/packages/cli/src/commands/coordinator.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	coordinatorImportInviteAction: vi.fn(),
+}));
+
+vi.mock("@codemem/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@codemem/core")>();
+	return {
+		...actual,
+		coordinatorImportInviteAction: mocks.coordinatorImportInviteAction,
+	};
+});
+
+import { buildCoordinatorCommand } from "./coordinator.js";
+
+describe("coordinator import-invite", () => {
+	const previousExitCode = process.exitCode;
+
+	beforeEach(() => {
+		process.exitCode = undefined;
+		mocks.coordinatorImportInviteAction.mockReset();
+		mocks.coordinatorImportInviteAction.mockResolvedValue({
+			group_id: "team-a",
+			coordinator_url: "https://coordinator.example.test",
+			status: "pending",
+		});
+		vi.spyOn(console, "log").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		process.exitCode = previousExitCode;
+		vi.restoreAllMocks();
+	});
+
+	it.each([
+		{
+			label: "long options",
+			args: ["--recipient-name", "  Alice Example  ", "--device-name", "  Work Laptop  "],
+			recipientDisplayName: "Alice Example",
+			deviceDisplayName: "Work Laptop",
+		},
+		{
+			label: "short options",
+			args: ["-R", "  Bob Example  ", "-N", "  Travel Phone  "],
+			recipientDisplayName: "Bob Example",
+			deviceDisplayName: "Travel Phone",
+		},
+	])("trims and forwards $label", async ({ args, recipientDisplayName, deviceDisplayName }) => {
+		await buildCoordinatorCommand().parseAsync(
+			["import-invite", "invite-value", ...args, "--json"],
+			{
+				from: "user",
+			},
+		);
+
+		expect(mocks.coordinatorImportInviteAction).toHaveBeenCalledWith(
+			expect.objectContaining({ recipientDisplayName, deviceDisplayName }),
+		);
+	});
+
+	it("forwards absent or blank names as null", async () => {
+		await buildCoordinatorCommand().parseAsync(
+			["import-invite", "invite-value", "--recipient-name", "   ", "--json"],
+			{ from: "user" },
+		);
+
+		expect(mocks.coordinatorImportInviteAction).toHaveBeenCalledWith(
+			expect.objectContaining({ recipientDisplayName: null, deviceDisplayName: null }),
+		);
+	});
+
+	it.each([
+		["invite_already_bound", "already used"],
+		["invite_expired", "expired"],
+		["invite_invalid", "invalid"],
+		["recipient_display_name_invalid", "--recipient-name"],
+		["recipient_display_name_required", "--recipient-name"],
+		["recipient_display_name_too_long", "--recipient-name"],
+		["device_display_name_invalid", "--device-name"],
+		["device_display_name_required", "--device-name"],
+		["device_display_name_too_long", "--device-name"],
+	])("maps %s to actionable JSON guidance", async (code, expectedFlag) => {
+		mocks.coordinatorImportInviteAction.mockRejectedValueOnce(new Error(code));
+
+		await buildCoordinatorCommand().parseAsync(["import-invite", "invite-value", "--json"], {
+			from: "user",
+		});
+
+		const output = vi.mocked(console.log).mock.calls.at(-1)?.[0];
+		expect(console.log).toHaveBeenCalledTimes(1);
+		expect(JSON.parse(String(output))).toMatchObject({
+			error: "import_invite_failed",
+			message: expect.stringContaining(expectedFlag),
+		});
+		expect(process.exitCode).toBe(1);
+	});
+
+	it.each([
+		"add_device_invite_self_acceptance_forbidden",
+		"invite_identity_conflict",
+		"recipient_invite_intent_mismatch",
+		"recipient_invite_review_unavailable",
+	])("directs %s recipient invitation failures to the Viewer", async (code) => {
+		mocks.coordinatorImportInviteAction.mockRejectedValueOnce(new Error(code));
+
+		await buildCoordinatorCommand().parseAsync(["import-invite", "invite-value", "--json"], {
+			from: "user",
+		});
+
+		const output = vi.mocked(console.log).mock.calls.at(-1)?.[0];
+		expect(JSON.parse(String(output)).message).toContain("codemem serve");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("directs reviewed recipient invitations to the Viewer", async () => {
+		mocks.coordinatorImportInviteAction.mockRejectedValueOnce(
+			new Error("reviewed_onboarding_digest_required"),
+		);
+
+		await buildCoordinatorCommand().parseAsync(["import-invite", "invite-value", "--json"], {
+			from: "user",
+		});
+
+		const output = vi.mocked(console.log).mock.calls.at(-1)?.[0];
+		expect(console.log).toHaveBeenCalledTimes(1);
+		expect(JSON.parse(String(output))).toEqual({
+			error: "import_invite_failed",
+			message:
+				"Accept Team/add-device recipient invitations through the Viewer: run `codemem serve`, review the access details, and confirm the invitation there.",
+		});
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/packages/cli/src/commands/coordinator.ts
+++ b/packages/cli/src/commands/coordinator.ts
@@ -69,6 +69,40 @@ function parseOptionalInteger(value: string | undefined, name: string): number |
 	return parsed;
 }
 
+function formatImportInviteError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	const recipientInviteViewerGuidance =
+		"Accept Team/add-device recipient invitations through the Viewer: run `codemem serve`, review the access details, and confirm the invitation there.";
+	switch (message) {
+		case "invite_already_bound":
+			return "This invite was already used. Ask the sender for a new one.";
+		case "invite_expired":
+			return "This invite has expired. Ask the sender for a new one.";
+		case "invite_invalid":
+			return "This invite is invalid. Copy the full invite and try again.";
+		case "recipient_display_name_invalid":
+			return "Recipient Identity name is invalid. Rerun with --recipient-name <name>.";
+		case "recipient_display_name_required":
+			return "Recipient Identity name is required. Rerun with --recipient-name <name>.";
+		case "recipient_display_name_too_long":
+			return "Recipient Identity name is too long. Rerun with --recipient-name <name> using 120 characters or fewer.";
+		case "device_display_name_invalid":
+			return "Device name is invalid. Rerun with --device-name <name>.";
+		case "device_display_name_required":
+			return "Device name is required. Rerun with --device-name <name>.";
+		case "device_display_name_too_long":
+			return "Device name is too long. Rerun with --device-name <name> using 120 characters or fewer.";
+		case "add_device_invite_self_acceptance_forbidden":
+		case "invite_identity_conflict":
+		case "recipient_invite_intent_mismatch":
+		case "recipient_invite_review_unavailable":
+		case "reviewed_onboarding_digest_required":
+			return recipientInviteViewerGuidance;
+		default:
+			return message;
+	}
+}
+
 /**
  * Build a fresh coordinator command tree. Each call returns independent
  * Commander instances so the tree can be mounted under multiple parents.
@@ -1113,6 +1147,8 @@ export function buildCoordinatorCommand(): Command {
 		.configureHelp(helpStyle)
 		.description("Import a coordinator invite")
 		.argument("<invite>", "invite value or link")
+		.option("-R, --recipient-name <name>", "recipient Identity display name")
+		.option("-N, --device-name <name>", "device display name")
 		.option("--keys-dir <path>", "keys directory");
 	addDbOption(importInviteCmd);
 	addConfigOption(importInviteCmd);
@@ -1125,6 +1161,8 @@ export function buildCoordinatorCommand(): Command {
 				dbPath?: string;
 				keysDir?: string;
 				config?: string;
+				recipientName?: string;
+				deviceName?: string;
 				json?: boolean;
 			},
 		) => {
@@ -1134,6 +1172,8 @@ export function buildCoordinatorCommand(): Command {
 					dbPath: resolveDbOpt(opts) ?? null,
 					keysDir: opts.keysDir ?? null,
 					configPath: opts.config ?? null,
+					recipientDisplayName: opts.recipientName?.trim() || null,
+					deviceDisplayName: opts.deviceName?.trim() || null,
 				});
 				if (opts.json) {
 					console.log(JSON.stringify(result, null, 2));
@@ -1145,11 +1185,12 @@ export function buildCoordinatorCommand(): Command {
 				p.log.message(`- status: ${result.status}`);
 				p.outro("Coordinator config updated");
 			} catch (err) {
+				const message = formatImportInviteError(err);
 				if (opts.json) {
-					emitJsonError("import_invite_failed", err instanceof Error ? err.message : String(err));
+					emitJsonError("import_invite_failed", message);
 					return;
 				}
-				p.log.error(err instanceof Error ? err.message : String(err));
+				p.log.error(message);
 				process.exitCode = 1;
 			}
 		},

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -106,6 +106,10 @@ export interface ApiMemoryItem extends MemoryItemResponse {
 	project: string | null;
 	cwd?: string;
 	owned_by_self?: boolean;
+	/** Presentation-only actor label resolved from trusted local identity data. */
+	resolved_actor_display_name?: string;
+	/** Presentation-only device label resolved from trusted local identity data. */
+	resolved_device_display_name?: string;
 }
 
 /**

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -243,6 +243,88 @@ describe("coordinator local admin actions", () => {
 		expect(capturedBodies[2]).not.toHaveProperty("device_display_name");
 	});
 
+	it("retries add-device onboarding without optional display names for older coordinators", async () => {
+		const actionDbPath = join(tmpDir, "legacy-coordinator-add-device.sqlite");
+		const keysDir = join(tmpDir, "legacy-coordinator-add-device-keys");
+		const configPath = join(tmpDir, "legacy-coordinator-add-device-config.json");
+		const identityId = "identity-owner";
+		const reviewedIntent = addDeviceReviewedIntent(identityId);
+		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+		const capturedBodies: Record<string, unknown>[] = [];
+		const acceptedResponse = {
+			ok: true,
+			status: "accepted",
+			kind: "add_device",
+			group_id: "coordinator-a",
+			identity_id: identityId,
+			target_identity_id: identityId,
+			reviewed_preview_digest: reviewedDigest,
+			reviewed_intent: reviewedIntent,
+		};
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_url: string, init?: RequestInit) => {
+				const body =
+					init?.body instanceof Uint8Array ? Buffer.from(init.body).toString("utf8") : "{}";
+				const parsed = JSON.parse(body) as Record<string, unknown>;
+				capturedBodies.push(parsed);
+				return parsed.device_display_name
+					? new Response(JSON.stringify({ error: "unexpected_recipient_invite_fields" }), {
+							status: 400,
+						})
+					: new Response(JSON.stringify(acceptedResponse), { status: 200 });
+			}),
+		);
+		const invite = encodeInvitePayload({
+			v: 1,
+			kind: "add_device",
+			coordinator_url: "https://coord.example.test",
+			group_id: "coordinator-a",
+			policy: "auto_admit",
+			token: "legacy-coordinator-add-device-token",
+			expires_at: "2099-01-01T00:00:00.000Z",
+			team_name: null,
+			target_identity_id: identityId,
+			reviewed_preview_digest: reviewedDigest,
+		});
+		const reviewedOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
+			dbPath: actionDbPath,
+			keysDir,
+			invitationId: "legacy-coordinator-add-device-token",
+			identityId,
+			deviceDisplayName: "Owner's new laptop",
+			reviewedIntent,
+		});
+
+		await expect(
+			coordinatorImportInviteAction({
+				inviteValue: invite,
+				dbPath: actionDbPath,
+				keysDir,
+				configPath,
+				deviceDisplayName: "Owner's new laptop",
+				reviewedOnboardingDigest,
+			}),
+		).resolves.toMatchObject({ status: "accepted", identity_id: identityId });
+		expect(capturedBodies).toHaveLength(3);
+		expect(capturedBodies[1]).toMatchObject({
+			invite_kind: "add_device",
+			identity_id: identityId,
+			device_display_name: "Owner's new laptop",
+		});
+		expect(capturedBodies[1]).not.toHaveProperty("recipient_display_name");
+		expect(capturedBodies[2]).toMatchObject({
+			token: "legacy-coordinator-add-device-token",
+			device_id: capturedBodies[1]?.device_id,
+			public_key: capturedBodies[1]?.public_key,
+			fingerprint: capturedBodies[1]?.fingerprint,
+			invite_kind: "add_device",
+			identity_id: identityId,
+		});
+		expect(capturedBodies[2]).not.toHaveProperty("recipient_display_name");
+		expect(capturedBodies[2]).not.toHaveProperty("device_display_name");
+	});
+
 	it.each([
 		"operation",
 		"group",
@@ -987,7 +1069,7 @@ describe("coordinator local admin actions", () => {
 			await coordinatorRenameDeviceAction({
 				groupId: "team-a",
 				deviceId: "device-1",
-				displayName: "Work Laptop",
+				displayName: "  Work   Laptop  ",
 				dbPath,
 			}),
 		).toEqual(expect.objectContaining({ display_name: "Work Laptop" }));
@@ -1004,6 +1086,29 @@ describe("coordinator local admin actions", () => {
 		expect(
 			await coordinatorListDevicesAction({ groupId: "team-a", includeDisabled: true, dbPath }),
 		).toEqual([]);
+	});
+
+	it("rejects machine-shaped names before a local device rename", async () => {
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		await coordinatorEnrollDeviceAction({
+			groupId: "team-a",
+			deviceId: "device-1",
+			fingerprint: "fp-1",
+			publicKey: "pk-1",
+			dbPath,
+		});
+
+		await expect(
+			coordinatorRenameDeviceAction({
+				groupId: "team-a",
+				deviceId: "device-1",
+				displayName: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
+				dbPath,
+			}),
+		).rejects.toThrow("display_name_invalid");
+		expect(await coordinatorListDevicesAction({ groupId: "team-a", dbPath })).toEqual([
+			expect.objectContaining({ device_id: "device-1", display_name: null }),
+		]);
 	});
 
 	it("returns the renamed disabled device instead of null", async () => {
@@ -1871,6 +1976,8 @@ describe("coordinator local admin actions", () => {
 	])("requires a reviewed onboarding digest before consuming a $kind invite", async (testCase) => {
 		const actionDbPath = join(tmpDir, `${testCase.kind}-missing-review.sqlite`);
 		const keysDir = join(tmpDir, `${testCase.kind}-missing-review-keys`);
+		const configPath = join(tmpDir, `${testCase.kind}-missing-review-config.json`);
+		writeFileSync(configPath, JSON.stringify({ actor_display_name: "local:\u0000machine" }));
 		const reviewedIntent =
 			testCase.kind === "team_member"
 				? teamReviewedIntent(testCase.targetId)
@@ -1898,6 +2005,7 @@ describe("coordinator local admin actions", () => {
 				inviteValue: invite,
 				dbPath: actionDbPath,
 				keysDir,
+				configPath,
 			}),
 		).rejects.toThrow("reviewed_onboarding_digest_required");
 		expect(fetchMock).not.toHaveBeenCalled();

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -1988,9 +1988,9 @@ describe("coordinator local admin actions", () => {
 		expect(capturedBodies[0]).toEqual({ token: "fresh-add-device-token" });
 		expect(capturedBodies[1]).toMatchObject({
 			identity_id: targetIdentityId,
-			recipient_display_name: "Existing Person",
 			device_display_name: "Recipient laptop",
 		});
+		expect(capturedBodies[1]).not.toHaveProperty("recipient_display_name");
 		expect(readCodememConfigFileAtPath(configPath)).toMatchObject({
 			actor_id: targetIdentityId,
 		});
@@ -2529,7 +2529,10 @@ describe("coordinator local admin actions", () => {
 			keysDir,
 			configPath,
 			recipientActorId: testCase.identityId,
-			recipientDisplayName: "  Brian   Example  ",
+			recipientDisplayName:
+				testCase.kind === "team_member"
+					? "  Brian   Example  "
+					: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
 			deviceDisplayName: "Recipient laptop",
 			reviewedOnboardingDigest,
 		});
@@ -2540,16 +2543,21 @@ describe("coordinator local admin actions", () => {
 			keysDir,
 			configPath,
 			recipientActorId: testCase.identityId,
-			recipientDisplayName: "  Brian   Example  ",
+			recipientDisplayName:
+				testCase.kind === "team_member"
+					? "  Brian   Example  "
+					: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
 			deviceDisplayName: "Recipient laptop",
 			reviewedOnboardingDigest,
 		});
 		const joinBodies = capturedBodies.filter((body) => body.invite_kind === testCase.kind);
 		expect(joinBodies).toHaveLength(2);
-		expect(joinBodies[0]).toMatchObject({
-			recipient_display_name: "Brian Example",
-			device_display_name: "Recipient laptop",
-		});
+		expect(joinBodies[0]).toMatchObject({ device_display_name: "Recipient laptop" });
+		if (testCase.kind === "team_member") {
+			expect(joinBodies[0]).toMatchObject({ recipient_display_name: "Brian Example" });
+		} else {
+			expect(joinBodies[0]).not.toHaveProperty("recipient_display_name");
+		}
 
 		const persistedConfig = readCodememConfigFileAtPath(configPath);
 		expect(persistedConfig).toMatchObject({

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -42,7 +42,11 @@ import {
 	PROJECT_INVITE_PENDING_STATUS,
 	ProjectSyncEnablementError,
 } from "./project-invite-acceptance.js";
-import { friendlyDeviceName, normalizeIdentityDisplayName } from "./project-invite-identity.js";
+import {
+	friendlyDeviceName,
+	normalizeHumanPresentationName,
+	normalizeIdentityDisplayName,
+} from "./project-invite-identity.js";
 import {
 	assertAddDeviceIdentityAdoptionAllowed,
 	commitRecipientPolicyOnboardingFromReviewedIntent,
@@ -1186,10 +1190,11 @@ export async function coordinatorRenameDeviceAction(opts: {
 }): Promise<CoordinatorEnrollment | null> {
 	const groupId = String(opts.groupId ?? "").trim();
 	const deviceId = String(opts.deviceId ?? "").trim();
-	const displayName = String(opts.displayName ?? "").trim();
-	if (!groupId || !deviceId || !displayName) {
+	const requestedDisplayName = String(opts.displayName ?? "").trim();
+	if (!groupId || !deviceId || !requestedDisplayName) {
 		throw new Error("group_id, device_id, and display_name are required.");
 	}
+	const displayName = normalizeHumanPresentationName(requestedDisplayName, "display_name");
 	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
 	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
 	if (remote) {
@@ -2106,6 +2111,10 @@ export async function coordinatorImportInviteAction(opts: {
 		}
 		recipientActorId = recipientInviteIdentityId;
 	}
+	const reviewedOnboardingDigest = String(opts.reviewedOnboardingDigest ?? "").trim();
+	if (recipientInvite && !reviewedOnboardingDigest) {
+		throw new Error("reviewed_onboarding_digest_required");
+	}
 	const recipientDisplayName =
 		payload.kind === "add_device"
 			? ""
@@ -2136,10 +2145,6 @@ export async function coordinatorImportInviteAction(opts: {
 		throw new Error(
 			`This device is already enrolled with coordinator ${existingCoordinator}. Multi-team joining is only supported across groups on the same coordinator.`,
 		);
-	}
-	const reviewedOnboardingDigest = String(opts.reviewedOnboardingDigest ?? "").trim();
-	if (recipientInvite && !reviewedOnboardingDigest) {
-		throw new Error("reviewed_onboarding_digest_required");
 	}
 	if (recipientInvite) {
 		let inspectStatus = 0;
@@ -2217,7 +2222,7 @@ export async function coordinatorImportInviteAction(opts: {
 		if (
 			recipientInvite &&
 			!projectInvite &&
-			"recipient_display_name" in joinBody &&
+			("recipient_display_name" in joinBody || "device_display_name" in joinBody) &&
 			status === 400 &&
 			response?.error === "unexpected_recipient_invite_fields"
 		) {

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -2243,6 +2243,12 @@ export async function coordinatorImportInviteAction(opts: {
 				"invite_expired",
 				"invite_identity_conflict",
 				"invite_invalid",
+				"recipient_display_name_invalid",
+				"recipient_display_name_required",
+				"recipient_display_name_too_long",
+				"device_display_name_invalid",
+				"device_display_name_required",
+				"device_display_name_too_long",
 				"recipient_invite_intent_mismatch",
 				"recipient_invite_review_unavailable",
 			].includes(detail)

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -2107,12 +2107,14 @@ export async function coordinatorImportInviteAction(opts: {
 		recipientActorId = recipientInviteIdentityId;
 	}
 	const recipientDisplayName =
-		projectInvite || recipientInvite
-			? normalizeIdentityDisplayName(
-					String(opts.recipientDisplayName ?? config.actor_display_name ?? fallbackDeviceName),
-					"recipient_display_name",
-				)
-			: String(config.actor_display_name ?? deviceId).trim() || deviceId;
+		payload.kind === "add_device"
+			? ""
+			: projectInvite || recipientInvite
+				? normalizeIdentityDisplayName(
+						String(opts.recipientDisplayName ?? config.actor_display_name ?? fallbackDeviceName),
+						"recipient_display_name",
+					)
+				: String(config.actor_display_name ?? deviceId).trim() || deviceId;
 	const displayName =
 		projectInvite || recipientInvite
 			? normalizeIdentityDisplayName(
@@ -2189,7 +2191,9 @@ export async function coordinatorImportInviteAction(opts: {
 			? {
 					invite_kind: payload.kind,
 					identity_id: recipientActorId,
-					recipient_display_name: recipientDisplayName,
+					...(payload.kind === "team_member"
+						? { recipient_display_name: recipientDisplayName }
+						: {}),
 					device_display_name: displayName,
 				}
 			: {}),

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -272,6 +272,54 @@ describe("createCoordinatorApp dependency injection", () => {
 		expect(store.close).toHaveBeenCalledTimes(1);
 	});
 
+	it("validates human device names at the coordinator rename boundary", async () => {
+		const renameDevice = vi.fn(async () => true);
+		const store = createMockStore({
+			renameDevice,
+			getEnrollment: vi.fn(async () => ({
+				...enrolledDevice(),
+				display_name: "Desk laptop",
+			})),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: {
+				adminSecret: () => "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+			},
+			requestVerifier: allowRequest,
+		});
+		const headers = {
+			"X-Codemem-Coordinator-Admin": "test-secret",
+			"Content-Type": "application/json",
+		};
+
+		const invalid = await app.request("/v1/admin/devices/rename", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				group_id: "g1",
+				device_id: "device-a",
+				display_name: "local:a57f7c7c-d531-4148-9917-78acb586caad",
+			}),
+		});
+		expect(invalid.status).toBe(400);
+		expect(await invalid.json()).toEqual({ error: "display_name_invalid" });
+		expect(renameDevice).not.toHaveBeenCalled();
+
+		const valid = await app.request("/v1/admin/devices/rename", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				group_id: "g1",
+				device_id: "device-a",
+				display_name: "  Desk   laptop  ",
+			}),
+		});
+		expect(valid.status).toBe(200);
+		expect(renameDevice).toHaveBeenCalledWith("g1", "device-a", "Desk laptop");
+	});
+
 	it("rejects an invalid invite expires_at with 400 instead of a 500", async () => {
 		const store = createMockStore({});
 		const app = createCoordinatorApp({

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -395,6 +395,31 @@ describe("createCoordinatorApp dependency injection", () => {
 		);
 
 		const callsBeforeInvalidIntent = createInvite.mock.calls.length;
+		const machineInviterName = await app.request("/v1/admin/invites", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				...base,
+				operation_id: `share_${"e".repeat(40)}`,
+				reviewed_project_set_digest: "f".repeat(64),
+				inviter_actor_id: "actor-adam",
+				inviter_display_name: "local:a57f7c7c-d531-4148-9917-78acb586caad",
+				inviter_device_id: "device-adam",
+				pending_person_id: "pending-brian",
+				project_summaries: [{ display_name: "codemem", existing_memory_count: 3 }],
+				project_intent: [
+					{
+						canonical_identity: "git:https://example.test/codemem",
+						display_name: "codemem",
+						existing_memory_count: 3,
+					},
+				],
+			}),
+		});
+		expect(machineInviterName.status).toBe(400);
+		expect(await machineInviterName.json()).toEqual({ error: "inviter_display_name_invalid" });
+		expect(createInvite).toHaveBeenCalledTimes(callsBeforeInvalidIntent);
+
 		const invalidCanonicalIntent = await app.request("/v1/admin/invites", {
 			method: "POST",
 			headers,
@@ -1021,6 +1046,12 @@ describe("createCoordinatorApp dependency injection", () => {
 	it.each([
 		["recipient_display_name", "Brian\u0000", "recipient_display_name_invalid"],
 		["device_display_name", "x".repeat(121), "device_display_name_too_long"],
+		[
+			"recipient_display_name",
+			"local:a57f7c7c-d531-4148-9917-78acb586caad",
+			"recipient_display_name_invalid",
+		],
+		["device_display_name", "e67fda8c4b44", "device_display_name_invalid"],
 	])("rejects malformed Team invite %s values", async (field, value, expectedError) => {
 		const publicKey = "recipient-public-key";
 		const consumeRecipientInvite = vi.fn();
@@ -1064,6 +1095,62 @@ describe("createCoordinatorApp dependency injection", () => {
 		expect(response.status).toBe(400);
 		expect(await response.json()).toEqual({ error: expectedError });
 		expect(consumeRecipientInvite).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		[
+			"recipient_display_name",
+			"identity:S5gx0LqXsmllifW-1XvXiLfZ",
+			"recipient_display_name_invalid",
+		],
+		["device_display_name", "a57f7c7c-d531-4148-9917-78acb586caad", "device_display_name_invalid"],
+	])("rejects machine-shaped Project invite %s values", async (field, value, expectedError) => {
+		const publicKey = "recipient-public-key";
+		const operationId = `share_${"c".repeat(40)}`;
+		const consumeProjectInvite = vi.fn();
+		const store = createMockStore({
+			getInviteByTokenForInspection: vi.fn(async () => ({
+				invite_id: "invite-project-invalid-name",
+				group_id: "g1",
+				token: "project-token",
+				policy: "auto_admit",
+				expires_at: "2099-01-01T00:00:00Z",
+				created_at: "2026-03-28T00:00:00Z",
+				created_by: null,
+				team_name_snapshot: "Coordinator One",
+				revoked_at: null,
+				operation_id: operationId,
+				reviewed_project_set_digest: acceptedProjectDigest(),
+				project_intent_json: JSON.stringify([ACCEPTED_PROJECT]),
+				inviter_device_id: "device-adam",
+			})),
+			consumeProjectInvite,
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: { adminSecret: () => "test-secret", now: () => "2026-03-28T00:00:00Z" },
+			requestVerifier: allowRequest,
+		});
+
+		const response = await app.request("/v1/join", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				token: "project-token",
+				operation_id: operationId,
+				device_id: "device-brian",
+				public_key: publicKey,
+				fingerprint: fingerprintPublicKey(publicKey),
+				recipient_actor_id: "actor-brian",
+				recipient_display_name: "Brian Example",
+				device_display_name: "Brian's MacBook",
+				[field]: value,
+			}),
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: expectedError });
+		expect(consumeProjectInvite).not.toHaveBeenCalled();
 	});
 
 	it("fails closed when project-first acceptance omits identity confirmation", async () => {

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -23,7 +23,7 @@ import type {
 } from "./coordinator-store-contract.js";
 import { PROJECT_INVITE_PENDING_STATUS } from "./project-invite-acceptance.js";
 import {
-	normalizeIdentityDisplayName,
+	normalizeHumanPresentationName,
 	normalizeProjectInviteSummaries,
 } from "./project-invite-identity.js";
 import { acceptedProjectIntentDigest, parseAcceptedProjectIntent } from "./project-share-intent.js";
@@ -1580,7 +1580,7 @@ export function createCoordinatorApp(
 				return c.json({ error: "project_invite_identity_context_invalid" }, 400);
 			}
 			try {
-				normalizeIdentityDisplayName(inviterDisplayName, "inviter_display_name");
+				normalizeHumanPresentationName(inviterDisplayName, "inviter_display_name");
 				projectSummaries = normalizeProjectInviteSummaries(data.project_summaries);
 				if (
 					!Array.isArray(data.project_intent) ||
@@ -2084,7 +2084,7 @@ export function createCoordinatorApp(
 						if (typeof data.recipient_display_name !== "string") {
 							throw new Error("recipient_display_name_invalid");
 						}
-						normalizedRecipientDisplayName = normalizeIdentityDisplayName(
+						normalizedRecipientDisplayName = normalizeHumanPresentationName(
 							data.recipient_display_name,
 							"recipient_display_name",
 						);
@@ -2093,7 +2093,7 @@ export function createCoordinatorApp(
 						if (typeof data.device_display_name !== "string") {
 							throw new Error("device_display_name_invalid");
 						}
-						normalizedDeviceDisplayName = normalizeIdentityDisplayName(
+						normalizedDeviceDisplayName = normalizeHumanPresentationName(
 							data.device_display_name,
 							"device_display_name",
 						);
@@ -2176,11 +2176,11 @@ export function createCoordinatorApp(
 				let normalizedRecipientName: string;
 				let normalizedDeviceName: string;
 				try {
-					normalizedRecipientName = normalizeIdentityDisplayName(
+					normalizedRecipientName = normalizeHumanPresentationName(
 						recipientDisplayName,
 						"recipient_display_name",
 					);
-					normalizedDeviceName = normalizeIdentityDisplayName(
+					normalizedDeviceName = normalizeHumanPresentationName(
 						deviceDisplayName,
 						"device_display_name",
 					);

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -1343,10 +1343,19 @@ export function createCoordinatorApp(
 		if (!displayName) {
 			return c.json({ error: "display_name_required" }, 400);
 		}
+		let normalizedDisplayName: string;
+		try {
+			normalizedDisplayName = normalizeHumanPresentationName(displayName, "display_name");
+		} catch (error) {
+			return c.json(
+				{ error: error instanceof Error ? error.message : "display_name_invalid" },
+				400,
+			);
+		}
 
 		const store = createStore();
 		try {
-			const ok = await store.renameDevice(groupId, deviceId, displayName);
+			const ok = await store.renameDevice(groupId, deviceId, normalizedDisplayName);
 			if (!ok) return c.json({ error: "device_not_found" }, 404);
 			const device = await store.getEnrollment(groupId, deviceId);
 			return c.json({ ok: true, device });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -608,6 +608,7 @@ export type { ProjectInviteSummary } from "./project-invite-identity.js";
 export {
 	friendlyDeviceName,
 	normalizeDeviceNameHint,
+	normalizeHumanPresentationName,
 	normalizeIdentityDisplayName,
 	normalizeProjectInviteSummaries,
 } from "./project-invite-identity.js";

--- a/packages/core/src/project-invite-identity.test.ts
+++ b/packages/core/src/project-invite-identity.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
+// Deliberately exercise the browser classifier from the core suite so shared
+// fixtures cannot pass while either package's implementation drifts.
 import {
 	humanPresentationLabel,
+	isMachinePresentationLabel,
 	MACHINE_PRESENTATION_LABEL_FIXTURES,
 } from "../../ui/src/lib/identity-presentation.js";
 import {
@@ -75,6 +78,7 @@ describe("project invite identity", () => {
 		MACHINE_PRESENTATION_LABEL_FIXTURES,
 	)("keeps core and browser presentation classifiers aligned for %s", (value) => {
 		expect(isHumanPresentationName(value)).toBe(false);
+		expect(isMachinePresentationLabel(value)).toBe(true);
 		expect(humanPresentationLabel(value)).toBe("");
 	});
 

--- a/packages/core/src/project-invite-identity.test.ts
+++ b/packages/core/src/project-invite-identity.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+	humanPresentationLabel,
+	MACHINE_PRESENTATION_LABEL_FIXTURES,
+} from "../../ui/src/lib/identity-presentation.js";
+import {
 	friendlyDeviceName,
+	isHumanPresentationName,
+	normalizeHumanPresentationName,
 	normalizeIdentityDisplayName,
 	normalizeProjectInviteSummaries,
 } from "./project-invite-identity.js";
@@ -20,6 +26,24 @@ describe("project invite identity", () => {
 		);
 		expect(friendlyDeviceName({ coordinatorName: "Remote" })).toBe("Remote");
 		expect(friendlyDeviceName({ fallbackSeed: "abcd-1234" })).toBe("Codemem device abcd12");
+		expect(friendlyDeviceName({ osName: "e67fda8c4b44", fallbackSeed: "e67fda8c4b44" })).toBe(
+			"Codemem device e67fda",
+		);
+		expect(
+			friendlyDeviceName({
+				osName: "0ea043cc-c61c-427d-8b77-572331b9855c",
+				fallbackSeed: "abcd-1234",
+			}),
+		).toBe("Codemem device abcd12");
+		expect(friendlyDeviceName({ osName: "device_abc123def", fallbackSeed: "abcd-1234" })).toBe(
+			"Codemem device abcd12",
+		);
+		expect(friendlyDeviceName({ explicitName: "x".repeat(121), fallbackSeed: "abcd-1234" })).toBe(
+			"Codemem device abcd12",
+		);
+		expect(
+			friendlyDeviceName({ explicitName: "Travel\u200bLaptop", fallbackSeed: "abcd-1234" }),
+		).toBe("Codemem device abcd12");
 	});
 
 	it("rejects empty, overlong, and control-character identity labels", () => {
@@ -34,6 +58,35 @@ describe("project invite identity", () => {
 		);
 	});
 
+	it.each([
+		"local:a57f7c7c-d531-4148-9917-78acb586caad",
+		"a57f7c7c-d531-4148-9917-78acb586caad",
+		"identity:S5gx0LqXsmllifW-1XvXiLfZ",
+		"actor_a57f7c7c",
+		"e67fda8c4b44",
+	])("rejects machine-shaped human presentation name %s", (value) => {
+		expect(isHumanPresentationName(value)).toBe(false);
+		expect(() => normalizeHumanPresentationName(value, "recipient_display_name")).toThrow(
+			"recipient_display_name_invalid",
+		);
+	});
+
+	it.each(
+		MACHINE_PRESENTATION_LABEL_FIXTURES,
+	)("keeps core and browser presentation classifiers aligned for %s", (value) => {
+		expect(isHumanPresentationName(value)).toBe(false);
+		expect(humanPresentationLabel(value)).toBe("");
+	});
+
+	it("normalizes human actor and device presentation names", () => {
+		expect(normalizeHumanPresentationName("  Brian   Example  ", "recipient_display_name")).toBe(
+			"Brian Example",
+		);
+		expect(normalizeHumanPresentationName("Brian's MacBook", "device_display_name")).toBe(
+			"Brian's MacBook",
+		);
+	});
+
 	it("retains only safe project summaries", () => {
 		expect(
 			normalizeProjectInviteSummaries([{ display_name: "codemem", existing_memory_count: 3 }]),
@@ -41,5 +94,8 @@ describe("project invite identity", () => {
 		expect(() =>
 			normalizeProjectInviteSummaries([{ display_name: "codemem", existing_memory_count: -1 }]),
 		).toThrow("project_summaries_invalid");
+		expect(
+			normalizeProjectInviteSummaries([{ display_name: "e67fda8c4b44", existing_memory_count: 0 }]),
+		).toEqual([{ display_name: "e67fda8c4b44", existing_memory_count: 0 }]);
 	});
 });

--- a/packages/core/src/project-invite-identity.ts
+++ b/packages/core/src/project-invite-identity.ts
@@ -1,4 +1,9 @@
 const MAX_IDENTITY_DISPLAY_LENGTH = 120;
+// Keep machine-shaped cases synchronized with ui/src/lib/identity-presentation.ts.
+const UUID_NAME = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/iu;
+const MACHINE_PREFIX_NAME = /^(?:actor|device|identity|local):\S+$/iu;
+const MACHINE_SLUG_NAME = /^(?:actor|device|identity)[_-][a-z0-9][a-z0-9._:-]{4,}$/iu;
+const HEX_HOSTNAME = /^[a-f0-9]{12,64}$/iu;
 
 export interface ProjectInviteSummary {
 	display_name: string;
@@ -17,6 +22,25 @@ export function normalizeIdentityDisplayName(value: string, field: string): stri
 	return normalized;
 }
 
+export function isHumanPresentationName(value: unknown): boolean {
+	if (typeof value !== "string") return false;
+	let normalized: string;
+	try {
+		normalized = normalizeIdentityDisplayName(value, "display_name");
+	} catch {
+		return false;
+	}
+	return ![UUID_NAME, MACHINE_PREFIX_NAME, MACHINE_SLUG_NAME, HEX_HOSTNAME].some((pattern) =>
+		pattern.test(normalized),
+	);
+}
+
+export function normalizeHumanPresentationName(value: string, field: string): string {
+	const normalized = normalizeIdentityDisplayName(value, field);
+	if (!isHumanPresentationName(normalized)) throw new Error(`${field}_invalid`);
+	return normalized;
+}
+
 export function normalizeDeviceNameHint(value: string | null | undefined): string | null {
 	const raw = String(value ?? "").replace(/\.local$/iu, "");
 	if (!raw.trim()) return null;
@@ -30,8 +54,18 @@ export function friendlyDeviceName(input: {
 	fallbackSeed?: string | null;
 }): string {
 	for (const candidate of [input.explicitName, input.osName, input.coordinatorName]) {
-		const normalized = normalizeDeviceNameHint(candidate);
-		if (normalized) return normalized;
+		const raw = String(candidate ?? "")
+			.replace(/\.local$/iu, "")
+			.trim();
+		// Classify before separator normalization so UUIDs and machine slugs cannot
+		// be disguised as human labels by replacing hyphens or underscores.
+		if (!raw || !isHumanPresentationName(raw)) continue;
+		try {
+			const normalized = normalizeDeviceNameHint(candidate);
+			if (normalized && isHumanPresentationName(normalized)) return normalized;
+		} catch {
+			// Unusable automatic hints must degrade to the generated fallback.
+		}
 	}
 	const seed = String(input.fallbackSeed ?? "")
 		.replace(/[^a-z0-9]/giu, "")

--- a/packages/core/src/project-invite-identity.ts
+++ b/packages/core/src/project-invite-identity.ts
@@ -3,6 +3,7 @@ const MAX_IDENTITY_DISPLAY_LENGTH = 120;
 const UUID_NAME = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/iu;
 const MACHINE_PREFIX_NAME = /^(?:actor|device|identity|local):\S+$/iu;
 const MACHINE_SLUG_NAME = /^(?:actor|device|identity)[_-][a-z0-9][a-z0-9._:-]{4,}$/iu;
+const PENDING_PERSON_NAME = /^pending[_-]\S+$/iu;
 const HEX_HOSTNAME = /^[a-f0-9]{12,64}$/iu;
 
 export interface ProjectInviteSummary {
@@ -30,9 +31,13 @@ export function isHumanPresentationName(value: unknown): boolean {
 	} catch {
 		return false;
 	}
-	return ![UUID_NAME, MACHINE_PREFIX_NAME, MACHINE_SLUG_NAME, HEX_HOSTNAME].some((pattern) =>
-		pattern.test(normalized),
-	);
+	return ![
+		UUID_NAME,
+		MACHINE_PREFIX_NAME,
+		MACHINE_SLUG_NAME,
+		PENDING_PERSON_NAME,
+		HEX_HOSTNAME,
+	].some((pattern) => pattern.test(normalized));
 }
 
 export function normalizeHumanPresentationName(value: string, field: string): string {

--- a/packages/core/src/share-operation.test.ts
+++ b/packages/core/src/share-operation.test.ts
@@ -521,6 +521,27 @@ describe("share-operation persistence", () => {
 		).toEqual(protectedBefore);
 	});
 
+	it("preserves the trusted pending Person name over a machine-shaped acceptance fallback", () => {
+		const operation = plan({ person: { kind: "pending", displayName: "Dogfood Teammate" } });
+		persistShareOperation(db, operation, {
+			inviteId: "invite-1",
+			tokenDigest: inviteTokenDigest("token-1"),
+		});
+
+		const input = acceptanceInput(operation, {
+			recipientDisplayName: "local:a57f7c7c-d531-4148-9917-78acb586caad",
+		});
+		reconcileShareOperationAcceptance(db, input);
+		reconcileShareOperationAcceptance(db, input);
+
+		expect(
+			db.prepare("SELECT display_name FROM actors WHERE actor_id = 'actor-brian'").pluck().get(),
+		).toBe("Dogfood Teammate");
+		expect(db.prepare("SELECT recipient_display_name FROM share_operations").pluck().get()).toBe(
+			"Dogfood Teammate",
+		);
+	});
+
 	it("accepts compatible migrated inviter policy without rewriting its metadata", () => {
 		const project = projects[0];
 		if (!project) throw new Error("project fixture missing");

--- a/packages/core/src/share-operation.ts
+++ b/packages/core/src/share-operation.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import type { Database } from "./db.js";
-import { normalizeIdentityDisplayName } from "./project-invite-identity.js";
+import {
+	isHumanPresentationName,
+	normalizeIdentityDisplayName,
+} from "./project-invite-identity.js";
 import type { AcceptedProjectIntent, ShareProjectIntent } from "./project-share-intent.js";
 import {
 	parseAcceptedProjectIntent,
@@ -550,10 +553,20 @@ export function reconcileShareOperationAcceptance(
 			throw new Error("recipient_device_identity_conflict");
 		}
 		const recipientActor = db
-			.prepare("SELECT actor_id, is_local, status FROM actors WHERE actor_id = ?")
+			.prepare("SELECT actor_id, display_name, is_local, status FROM actors WHERE actor_id = ?")
 			.get(input.recipientActorId) as
-			| { actor_id: string; is_local: number; status: string }
+			| { actor_id: string; display_name: string; is_local: number; status: string }
 			| undefined;
+		const pendingDisplayName = db
+			.prepare("SELECT display_name FROM actors WHERE actor_id = ? AND status = 'pending'")
+			.pluck()
+			.get(operation.person_id);
+		const trustedDisplayName = [recipientActor?.display_name, pendingDisplayName].find(
+			(name): name is string => isHumanPresentationName(name),
+		);
+		const recipientDisplayName = isHumanPresentationName(input.recipientDisplayName)
+			? input.recipientDisplayName
+			: (trustedDisplayName ?? input.recipientDisplayName);
 		const pendingRecipientActorConflict =
 			operation.person_kind === "pending" &&
 			recipientActor != null &&
@@ -576,7 +589,7 @@ export function reconcileShareOperationAcceptance(
 			ON CONFLICT(actor_id) DO UPDATE SET display_name = excluded.display_name,
 				status = 'active', merged_into_actor_id = NULL, updated_at = excluded.updated_at`).run(
 			input.recipientActorId,
-			input.recipientDisplayName,
+			recipientDisplayName,
 			input.consumedAt,
 			input.consumedAt,
 		);
@@ -596,7 +609,7 @@ export function reconcileShareOperationAcceptance(
 				bootstrap_grant_id = ?, updated_at = ? WHERE operation_id = ?`).run(
 			input.recipientActorId,
 			input.recipientActorId,
-			input.recipientDisplayName,
+			recipientDisplayName,
 			input.recipientDeviceId,
 			input.recipientDeviceDisplayName,
 			input.recipientPublicKey,

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -84,7 +84,7 @@ type CoordinatorInviteIdentity =
 			reviewed_onboarding_digest?: never;
 	  }
 	| {
-			recipient_name: string;
+			recipient_name?: string;
 			device_name: string;
 			reviewed_onboarding_digest: string;
 	  };

--- a/packages/ui/src/lib/identity-presentation.ts
+++ b/packages/ui/src/lib/identity-presentation.ts
@@ -1,0 +1,27 @@
+// Keep machine-shaped cases synchronized with core/src/project-invite-identity.ts.
+const UUID_LABEL = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/iu;
+const MACHINE_PREFIX_LABEL = /^(?:actor|device|identity|local):\S+$/iu;
+const MACHINE_SLUG_LABEL = /^(?:actor|device|identity)[_-][a-z0-9][a-z0-9._:-]{4,}$/iu;
+const HEX_HOSTNAME_LABEL = /^[a-f0-9]{12,64}$/iu;
+
+export const MACHINE_PRESENTATION_LABEL_FIXTURES = [
+	"123e4567-e89b-12d3-a456-426614174000",
+	"local:0ea043cc-c61c-427d-8b77-572331b9855c",
+	"actor:peer",
+	"device_abc123def",
+	"a1b2c3d4e5f6",
+] as const;
+
+export function isMachinePresentationLabel(value: string): boolean {
+	return [UUID_LABEL, MACHINE_PREFIX_LABEL, MACHINE_SLUG_LABEL, HEX_HOSTNAME_LABEL].some(
+		(pattern) => pattern.test(value),
+	);
+}
+
+export function humanPresentationLabel(value: unknown): string {
+	if (typeof value !== "string") return "";
+	if ([...value].some((character) => /[\p{Cc}\p{Cf}]/u.test(character))) return "";
+	const label = value.replace(/\s+/gu, " ").trim();
+	if (!label || [...label].length > 120 || isMachinePresentationLabel(label)) return "";
+	return label;
+}

--- a/packages/ui/src/lib/identity-presentation.ts
+++ b/packages/ui/src/lib/identity-presentation.ts
@@ -2,6 +2,7 @@
 const UUID_LABEL = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/iu;
 const MACHINE_PREFIX_LABEL = /^(?:actor|device|identity|local):\S+$/iu;
 const MACHINE_SLUG_LABEL = /^(?:actor|device|identity)[_-][a-z0-9][a-z0-9._:-]{4,}$/iu;
+const PENDING_PERSON_LABEL = /^pending[_-]\S+$/iu;
 const HEX_HOSTNAME_LABEL = /^[a-f0-9]{12,64}$/iu;
 
 export const MACHINE_PRESENTATION_LABEL_FIXTURES = [
@@ -9,13 +10,20 @@ export const MACHINE_PRESENTATION_LABEL_FIXTURES = [
 	"local:0ea043cc-c61c-427d-8b77-572331b9855c",
 	"actor:peer",
 	"device_abc123def",
+	"pending_ab",
+	"pending-brian",
+	"pending_0123456789abcdef0123456789abcdef01234567",
 	"a1b2c3d4e5f6",
 ] as const;
 
 export function isMachinePresentationLabel(value: string): boolean {
-	return [UUID_LABEL, MACHINE_PREFIX_LABEL, MACHINE_SLUG_LABEL, HEX_HOSTNAME_LABEL].some(
-		(pattern) => pattern.test(value),
-	);
+	return [
+		UUID_LABEL,
+		MACHINE_PREFIX_LABEL,
+		MACHINE_SLUG_LABEL,
+		PENDING_PERSON_LABEL,
+		HEX_HOSTNAME_LABEL,
+	].some((pattern) => pattern.test(value));
 }
 
 export function humanPresentationLabel(value: unknown): string {

--- a/packages/ui/src/tabs/feed/components/FeedItemCard.test.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.test.tsx
@@ -1,6 +1,7 @@
 import { h, render } from "preact";
 import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { state } from "../../../lib/state";
 import { FeedItemCard } from "./FeedItemCard";
 
 vi.mock("../../../components/primitives/tooltip", () => ({
@@ -11,6 +12,7 @@ vi.mock("../../../components/primitives/tooltip", () => ({
 let mount: HTMLDivElement;
 
 beforeEach(() => {
+	state.lastStatsPayload = null;
 	mount = document.createElement("div");
 	document.body.appendChild(mount);
 });
@@ -23,21 +25,11 @@ afterEach(() => {
 });
 
 describe("FeedItemCard", () => {
-	it("shows the memory database id as quiet provenance", () => {
+	function renderCard(item: Parameters<typeof FeedItemCard>[0]["item"]): void {
 		act(() => {
 			render(
 				h(FeedItemCard, {
-					item: {
-						body_text: "A diagnostic memory body.",
-						created_at: "2026-05-26T23:30:00.000Z",
-						id: 1234,
-						kind: "discovery",
-						metadata_json: {},
-						owned_by_self: false,
-						project: "btha",
-						title: "BTHA diagnostic memory",
-						visibility: "shared",
-					},
+					item,
 					onReload: async () => {},
 					onRemove: () => {},
 					onReplace: () => {},
@@ -46,9 +38,58 @@ describe("FeedItemCard", () => {
 				mount,
 			);
 		});
+	}
+
+	it("shows the memory database id as quiet provenance", () => {
+		renderCard({
+			body_text: "A diagnostic memory body.",
+			created_at: "2026-05-26T23:30:00.000Z",
+			id: 1234,
+			kind: "discovery",
+			metadata_json: {},
+			owned_by_self: false,
+			project: "btha",
+			title: "BTHA diagnostic memory",
+			visibility: "shared",
+		});
 
 		expect(mount.textContent).toContain("ID 1234");
 		const chip = mount.querySelector(".provenance-chip.memory-id");
 		expect(chip?.textContent).toBe("ID 1234");
+	});
+
+	it("renders resolved identity labels without raw provenance ids", () => {
+		const actorId = "local:0ea043cc-c61c-427d-8b77-572331b9855c";
+		const deviceId = "0ea043cc-c61c-427d-8b77-572331b9855c";
+		renderCard({
+			actor_id: actorId,
+			origin_device_id: deviceId,
+			resolved_actor_display_name: "Ada Lovelace",
+			resolved_device_display_name: "Ada's MacBook",
+			title: "Shared memory",
+		});
+
+		expect(mount.textContent).toContain("Ada Lovelace");
+		expect(mount.textContent).toContain("Device Ada's MacBook");
+		expect(mount.textContent).not.toContain(actorId);
+		expect(mount.textContent).not.toContain(deviceId);
+	});
+
+	it("renders neutral legacy fallbacks without stored machine labels or raw ids", () => {
+		const actorId = "local:0ea043cc-c61c-427d-8b77-572331b9855c";
+		const deviceId = "0ea043cc-c61c-427d-8b77-572331b9855c";
+		renderCard({
+			actor_display_name: actorId,
+			actor_id: actorId,
+			origin_device_id: deviceId,
+			resolved_actor_display_name: actorId,
+			resolved_device_display_name: deviceId,
+			title: "Legacy shared memory",
+		});
+
+		expect(mount.textContent).toContain("Teammate");
+		expect(mount.textContent).toContain("Shared device");
+		expect(mount.textContent).not.toContain(actorId);
+		expect(mount.textContent).not.toContain(deviceId);
 	});
 });

--- a/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
@@ -19,7 +19,7 @@ import {
 	renderNarrativeContent,
 	renderSummarySections,
 } from "../data/body-renderers";
-import { authorLabel, itemKey, mergeMetadata, trustStateLabel } from "../data/helpers";
+import { authorLabel, deviceLabel, itemKey, mergeMetadata, trustStateLabel } from "../data/helpers";
 import {
 	clampClass,
 	defaultObservationView,
@@ -61,10 +61,10 @@ export function FeedItemCard({
 	const files = parseJsonArray(item.files || []);
 	const project = item.project || "";
 	const actor = authorLabel(item);
+	const device = deviceLabel(item, metadata);
 	const visibility = String(item.visibility || metadata?.visibility || "private").trim();
 	const workspaceKind = String(item.workspace_kind || metadata?.workspace_kind || "").trim();
 	const originSource = String(item.origin_source || metadata?.origin_source || "").trim();
-	const originDeviceId = String(item.origin_device_id || metadata?.origin_device_id || "").trim();
 	const trustState = String(item.trust_state || metadata?.trust_state || "").trim();
 	const tagContent = tags.length ? ` · ${tags.map((t) => formatTagLabel(t)).join(", ")}` : "";
 	const fileContent = files.length ? ` · ${formatFileList(files)}` : "";
@@ -134,7 +134,7 @@ export function FeedItemCard({
 	const provenanceDetails = [
 		workspaceKind && workspaceKind !== visibility ? `Workspace ${workspaceKind}` : "",
 		originSource ? `From ${originSource}` : "",
-		originDeviceId && actor !== "You" ? `Device ${originDeviceId}` : "",
+		device,
 		trustState && trustState !== "trusted" ? trustStateLabel(trustState) : "",
 	]
 		.filter(Boolean)

--- a/packages/ui/src/tabs/feed/data/helpers.test.ts
+++ b/packages/ui/src/tabs/feed/data/helpers.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { MACHINE_PRESENTATION_LABEL_FIXTURES } from "../../../lib/identity-presentation";
+import { state } from "../../../lib/state";
+import { authorLabel, deviceLabel } from "./helpers";
+
+beforeEach(() => {
+	state.lastStatsPayload = null;
+});
+
+describe("Feed identity labels", () => {
+	it("prefers resolved actor and device labels", () => {
+		const item = {
+			actor_id: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
+			origin_device_id: "0ea043cc-c61c-427d-8b77-572331b9855c",
+			resolved_actor_display_name: "Ada Lovelace",
+			resolved_device_display_name: "Ada's MacBook",
+		};
+
+		expect(authorLabel(item)).toBe("Ada Lovelace");
+		expect(deviceLabel(item)).toBe("Device Ada's MacBook");
+	});
+
+	it("uses neutral labels for unresolved legacy provenance", () => {
+		const item = {
+			actor_display_name: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
+			actor_id: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
+			origin_device_id: "0ea043cc-c61c-427d-8b77-572331b9855c",
+			resolved_actor_display_name: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
+			resolved_device_display_name: "0ea043cc-c61c-427d-8b77-572331b9855c",
+		};
+
+		expect(authorLabel(item)).toBe("Teammate");
+		expect(deviceLabel(item)).toBe("Shared device");
+	});
+
+	it.each(
+		MACHINE_PRESENTATION_LABEL_FIXTURES,
+	)("never promotes machine-shaped label %s", (value) => {
+		expect(authorLabel({ actor_id: "remote-actor", resolved_actor_display_name: value })).toBe(
+			"Teammate",
+		);
+		expect(
+			deviceLabel({ origin_device_id: "remote-device", resolved_device_display_name: value }),
+		).toBe("Shared device");
+	});
+
+	it("uses unknown author when no actor provenance exists", () => {
+		expect(authorLabel({})).toBe("Unknown author");
+	});
+});

--- a/packages/ui/src/tabs/feed/data/helpers.ts
+++ b/packages/ui/src/tabs/feed/data/helpers.ts
@@ -2,8 +2,15 @@
  */
 
 import { normalize } from "../../../lib/format";
+import { humanPresentationLabel } from "../../../lib/identity-presentation";
 import { state } from "../../../lib/state";
 import type { FeedItem, FeedItemMetadata } from "../types";
+
+function isOwnedBySelf(item: FeedItem): boolean {
+	if (item.owned_by_self === true) return true;
+	const actorId = String(item.actor_id || "").trim();
+	return Boolean(actorId && actorId === state.lastStatsPayload?.identity?.actor_id);
+}
 
 export function mergeMetadata(metadata: unknown): FeedItemMetadata {
 	if (!metadata || typeof metadata !== "object") return {};
@@ -86,11 +93,19 @@ export function trustStateLabel(trustState: string): string {
 }
 
 export function authorLabel(item: FeedItem): string {
-	if (item?.owned_by_self === true) return "You";
+	if (isOwnedBySelf(item)) return "You";
 	const actorId = String(item.actor_id || "").trim();
-	const actorName = String(item.actor_display_name || "").trim();
-	if (actorId && actorId === state.lastStatsPayload?.identity?.actor_id) return "You";
-	return actorName || actorId || "Unknown author";
+	const actorName = humanPresentationLabel(item.resolved_actor_display_name);
+	if (actorName) return actorName;
+	return actorId || item.actor_display_name ? "Teammate" : "Unknown author";
+}
+
+export function deviceLabel(item: FeedItem, metadata: FeedItemMetadata = {}): string {
+	if (isOwnedBySelf(item)) return "";
+	const deviceId = String(item.origin_device_id || metadata.origin_device_id || "").trim();
+	if (!deviceId) return "";
+	const deviceName = humanPresentationLabel(item.resolved_device_display_name);
+	return deviceName ? `Device ${deviceName}` : "Shared device";
 }
 
 export function mergeFeedItems(currentItems: FeedItem[], incomingItems: FeedItem[]): FeedItem[] {

--- a/packages/ui/src/tabs/feed/types.ts
+++ b/packages/ui/src/tabs/feed/types.ts
@@ -40,11 +40,13 @@ export interface FeedItem {
 	project?: string;
 	actor_id?: string;
 	actor_display_name?: string;
+	resolved_actor_display_name?: string;
 	owned_by_self?: boolean;
 	visibility?: string;
 	workspace_kind?: string;
 	origin_source?: string;
 	origin_device_id?: string;
+	resolved_device_display_name?: string;
 	trust_state?: string;
 	metadata_json?: FeedItemMetadata;
 	summary?: unknown;

--- a/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
@@ -339,6 +339,47 @@ describe("recipient-policy invitations", () => {
 		expect(button("Review invitation", reopenedDialog).disabled).toBe(false);
 	});
 
+	it("requires a human Identity name before accepting a Team invitation", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
+			kind: "team_member",
+			recipient_name: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
+			device_name: "Work Laptop",
+			onboarding: teamPreview,
+		});
+		vi.mocked(api.importCoordinatorInvite).mockResolvedValue({ status: "accepted" });
+		mount();
+
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "team-member-invite";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Current Projects for"));
+
+		const recipientName = dialog.querySelector<HTMLInputElement>("#recipient-onboarding-name");
+		if (!recipientName) throw new Error("recipient Identity name field missing");
+		expect(recipientName.value).toBe("");
+		expect(dialog.textContent).toContain("Identity display name is required");
+		expect(button("Accept invitation", dialog).disabled).toBe(true);
+
+		act(() => {
+			recipientName.value = "Fresh Recipient";
+			recipientName.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		expect(button("Accept invitation", dialog).disabled).toBe(false);
+		act(() => button("Accept invitation", dialog).click());
+		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
+		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("team-member-invite", {
+			recipient_name: "Fresh Recipient",
+			device_name: "Work Laptop",
+			reviewed_onboarding_digest: teamPreview.reviewedOnboardingDigest,
+		});
+	});
+
 	it("surfaces restart guidance when Team acceptance enables sync", async () => {
 		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
 			kind: "team_member",

--- a/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
@@ -556,6 +556,13 @@ describe("recipient-policy invitations", () => {
 
 	it.each([
 		["empty names", "project-share-recipient-name", "   ", "Identity display name is required"],
+		["machine actor names", "project-share-recipient-name", "actor:peer", "human-readable name"],
+		[
+			"machine device names",
+			"project-share-device-name",
+			"device_abc123def",
+			"human-readable name",
+		],
 		[
 			"names over 120 Unicode code points",
 			"project-share-recipient-name",

--- a/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
@@ -198,7 +198,7 @@ describe("recipient-policy invitations", () => {
 	it("inspects and accepts add-device access with direct, inherited, and excluded Projects", async () => {
 		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
 			kind: "add_device",
-			recipient_name: "Local Identity",
+			recipient_name: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
 			device_name: "Travel Laptop",
 			onboarding: addDevicePreview,
 		});
@@ -232,7 +232,6 @@ describe("recipient-policy invitations", () => {
 		act(() => button("Accept invitation", dialog).click());
 		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
 		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("recipient-invite", {
-			recipient_name: "Local Identity",
 			device_name: "Travel Laptop",
 			reviewed_onboarding_digest: addDevicePreview.reviewedOnboardingDigest,
 		});

--- a/packages/ui/src/tabs/recipient-policy-invitations.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.tsx
@@ -582,8 +582,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 							device_name: projectDeviceName.trim(),
 						})
 					: await api.importCoordinatorInvite(invite.trim(), {
-							recipient_name:
-								inspected.kind === "team_member" ? recipientName.trim() : inspected.recipient_name,
+							...(inspected.kind === "team_member" ? { recipient_name: recipientName.trim() } : {}),
 							device_name: inspected.device_name,
 							reviewed_onboarding_digest: inspected.onboarding.reviewedOnboardingDigest,
 						});

--- a/packages/ui/src/tabs/recipient-policy-invitations.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.tsx
@@ -80,6 +80,15 @@ function errorMessage(cause: unknown, fallback: string): string {
 	if (cause.message === "invite_identity_conflict") {
 		return "This device already belongs to a different Identity. Use a fresh device or ask the owner for the correct invitation.";
 	}
+	if (cause.message === "recipient_display_name_invalid") {
+		return "Enter a human-readable Identity name instead of an internal identifier.";
+	}
+	if (cause.message === "recipient_display_name_required") {
+		return "Enter an Identity display name before accepting.";
+	}
+	if (cause.message === "recipient_display_name_too_long") {
+		return "Use an Identity display name with 120 characters or fewer.";
+	}
 	return fallback;
 }
 
@@ -194,6 +203,38 @@ function Confirmation({ preview }: { preview: RecipientOnboardingPreviewV1 }) {
 		<TeamConfirmation preview={preview} />
 	) : (
 		<AddDeviceConfirmation preview={preview} />
+	);
+}
+
+function RecipientNameConfirmation({
+	error,
+	name,
+	onChange,
+}: {
+	error: string;
+	name: string;
+	onChange: (value: string) => void;
+}) {
+	return (
+		<section aria-labelledby="recipient-onboarding-name-title">
+			<h3 id="recipient-onboarding-name-title">Who will receive access</h3>
+			<label className="field" htmlFor="recipient-onboarding-name">
+				<span>Identity display name</span>
+				<input
+					aria-describedby={error ? "recipient-onboarding-name-error" : undefined}
+					aria-invalid={Boolean(error)}
+					id="recipient-onboarding-name"
+					onInput={(event) => onChange(event.currentTarget.value)}
+					placeholder="Your name — e.g. Alex Rivera"
+					value={name}
+				/>
+			</label>
+			{error ? (
+				<p className="small" id="recipient-onboarding-name-error" role="alert">
+					{error}
+				</p>
+			) : null}
+		</section>
 	);
 }
 
@@ -369,6 +410,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 	const [inspected, setInspected] = useState<InspectInviteResult | null>(null);
 	const [projectAcceptance, setProjectAcceptance] = useState<ProjectShareAcceptance | null>(null);
 	const [recipientAcceptance, setRecipientAcceptance] = useState<RecipientAcceptance | null>(null);
+	const [recipientName, setRecipientName] = useState("");
 	const [projectRecipientName, setProjectRecipientName] = useState("");
 	const [projectDeviceName, setProjectDeviceName] = useState("");
 	const [created, setCreated] = useState<CreatedRecipientInvite | null>(null);
@@ -403,6 +445,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 		setInspected(null);
 		setProjectAcceptance(null);
 		setRecipientAcceptance(null);
+		setRecipientName("");
 		setProjectRecipientName("");
 		setProjectDeviceName("");
 		setCreated(null);
@@ -485,7 +528,9 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 			const result = await api.inspectCoordinatorInvite(reviewedInvite);
 			if (!isCurrentInspection()) return;
 			setInspected(result);
-			if (result.kind === "project_share_invite") {
+			if (result.kind === "team_member") {
+				setRecipientName(humanProvidedNameOrEmpty(result.recipient_name));
+			} else if (result.kind === "project_share_invite") {
 				setProjectRecipientName(humanProvidedNameOrEmpty(result.recipient_name));
 				setProjectDeviceName(humanProvidedNameOrEmpty(result.device_name));
 			}
@@ -519,6 +564,12 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 		) {
 			return;
 		}
+		if (
+			inspected.kind === "team_member" &&
+			displayNameError(recipientName, "Identity display name")
+		) {
+			return;
+		}
 		accepting.current = true;
 		setBusy(true);
 		setError("");
@@ -531,7 +582,8 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 							device_name: projectDeviceName.trim(),
 						})
 					: await api.importCoordinatorInvite(invite.trim(), {
-							recipient_name: inspected.recipient_name,
+							recipient_name:
+								inspected.kind === "team_member" ? recipientName.trim() : inspected.recipient_name,
 							device_name: inspected.device_name,
 							reviewed_onboarding_digest: inspected.onboarding.reviewedOnboardingDigest,
 						});
@@ -584,6 +636,10 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 			? inspected.onboarding
 			: null;
 	const projectShareInvite = inspected?.kind === "project_share_invite" ? inspected : null;
+	const recipientNameError =
+		inspected?.kind === "team_member"
+			? displayNameError(recipientName, "Identity display name")
+			: "";
 	const projectRecipientNameError = projectShareInvite
 		? displayNameError(projectRecipientName, "Identity display name")
 		: "";
@@ -729,6 +785,16 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 							{recipientPreview && !recipientAcceptance ? (
 								<Confirmation preview={recipientPreview} />
 							) : null}
+							{inspected?.kind === "team_member" && !recipientAcceptance ? (
+								<RecipientNameConfirmation
+									error={recipientNameError}
+									name={recipientName}
+									onChange={(value) => {
+										setRecipientName(value);
+										setError("");
+									}}
+								/>
+							) : null}
 							{projectShareInvite && !projectAcceptance ? (
 								<ProjectShareConfirmation
 									deviceName={projectDeviceName}
@@ -798,6 +864,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 									className="settings-button sync-dialog-confirm"
 									disabled={
 										busy ||
+										Boolean(inspected?.kind === "team_member" && recipientNameError) ||
 										Boolean(
 											projectShareInvite &&
 												(!projectShareInvite.projects?.length ||

--- a/packages/ui/src/tabs/recipient-policy-invitations.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.tsx
@@ -10,6 +10,7 @@ import type {
 	RecipientPolicyIntentGraphV1,
 } from "../lib/api/sync";
 import type { ImportInviteResult } from "../lib/api/types";
+import { humanPresentationLabel, isMachinePresentationLabel } from "../lib/identity-presentation";
 import { openProjectShareFlow } from "./project-sharing";
 
 type CreateKind = "team_member" | "add_device";
@@ -29,10 +30,6 @@ type RecipientAcceptance = {
 	deliveryPending: boolean;
 };
 
-const MACHINE_NAME_PREFIX = /^(?:local:|identity:|pending_)/iu;
-const UUID_NAME = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
-const HEX_FRAGMENT_NAME = /^[0-9a-f]{12,}$/iu;
-
 /**
  * Machine identifiers (device ids, identity ids, uuid fragments) make terrible
  * display names. Seed the name fields empty instead so the required-field
@@ -40,10 +37,8 @@ const HEX_FRAGMENT_NAME = /^[0-9a-f]{12,}$/iu;
  */
 function humanProvidedNameOrEmpty(value: string | null | undefined): string {
 	const reviewed = String(value ?? "").trim();
-	if (!reviewed) return "";
-	if (MACHINE_NAME_PREFIX.test(reviewed)) return "";
-	if (UUID_NAME.test(reviewed) || HEX_FRAGMENT_NAME.test(reviewed)) return "";
-	return reviewed;
+	if (/^pending_/iu.test(reviewed)) return "";
+	return humanPresentationLabel(reviewed);
 }
 
 function displayNameError(value: string, label: string): string {
@@ -52,6 +47,9 @@ function displayNameError(value: string, label: string): string {
 	if ([...reviewed].length > 120) return `${label} must use 120 characters or fewer.`;
 	if ([...reviewed].some((character) => /[\p{Cc}\p{Cf}]/u.test(character))) {
 		return `${label} cannot include control or format characters.`;
+	}
+	if (/^pending_/iu.test(reviewed) || isMachinePresentationLabel(reviewed)) {
+		return `${label} must use a human-readable name.`;
 	}
 	return "";
 }

--- a/packages/ui/src/tabs/recipient-policy-invitations.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.tsx
@@ -36,9 +36,7 @@ type RecipientAcceptance = {
  * validation asks the person for a real name, with placeholder text as the hint.
  */
 function humanProvidedNameOrEmpty(value: string | null | undefined): string {
-	const reviewed = String(value ?? "").trim();
-	if (/^pending_/iu.test(reviewed)) return "";
-	return humanPresentationLabel(reviewed);
+	return humanPresentationLabel(String(value ?? "").trim());
 }
 
 function displayNameError(value: string, label: string): string {
@@ -48,7 +46,7 @@ function displayNameError(value: string, label: string): string {
 	if ([...reviewed].some((character) => /[\p{Cc}\p{Cf}]/u.test(character))) {
 		return `${label} cannot include control or format characters.`;
 	}
-	if (/^pending_/iu.test(reviewed) || isMachinePresentationLabel(reviewed)) {
+	if (isMachinePresentationLabel(reviewed)) {
 		return `${label} must use a human-readable name.`;
 	}
 	return "";

--- a/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.test.ts
+++ b/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.test.ts
@@ -25,6 +25,7 @@ vi.mock("../helpers/invite-panel-dom", () => ({
 vi.mock("../../../project-sharing", () => ({ openProjectShareFlow: vi.fn() }));
 
 import * as api from "../../../../lib/api";
+import { markFieldError } from "../../../../lib/form";
 import { showGlobalNotice } from "../../../../lib/notice";
 import { state } from "../../../../lib/state";
 import { openProjectShareFlow } from "../../../project-sharing";
@@ -113,6 +114,51 @@ describe("project invite review events", () => {
 		invite.dispatchEvent(new Event("input", { bubbles: true }));
 		expect(review.hidden).toBe(true);
 		expect(button.textContent).toBe("Review invite");
+	});
+
+	it("does not prefill project invite identity fields with machine labels", async () => {
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValueOnce({
+			device_name: "device_abc123def",
+			inviter_name: "Adam",
+			kind: "project_share_invite",
+			projects: [{ display_name: "codemem", existing_memory_count: 3 }],
+			recipient_name: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
+		});
+		initTeamSyncEvents(
+			() => {},
+			async () => {},
+		);
+		const invite = document.getElementById("syncJoinInvite") as HTMLTextAreaElement;
+		const button = document.getElementById("syncJoinButton") as HTMLButtonElement;
+		invite.value = "project-invite";
+
+		button.click();
+		await vi.waitFor(() => expect(button.textContent).toBe("Accept and start syncing"));
+
+		expect((document.getElementById("syncRecipientName") as HTMLInputElement).value).toBe("");
+		expect((document.getElementById("syncRecipientDeviceName") as HTMLInputElement).value).toBe("");
+	});
+
+	it.each([
+		["Identity", "syncRecipientName", "local:0ea043cc-c61c-427d-8b77-572331b9855c"],
+		["device", "syncRecipientDeviceName", "device_abc123def"],
+	])("rejects a machine-shaped project invite %s name", async (_label, inputId, value) => {
+		initTeamSyncEvents(
+			() => {},
+			async () => {},
+		);
+		const invite = document.getElementById("syncJoinInvite") as HTMLTextAreaElement;
+		const button = document.getElementById("syncJoinButton") as HTMLButtonElement;
+		invite.value = "project-invite";
+		button.click();
+		await vi.waitFor(() => expect(button.textContent).toBe("Accept and start syncing"));
+		const input = document.getElementById(inputId) as HTMLInputElement;
+		input.value = value;
+
+		button.click();
+
+		expect(markFieldError).toHaveBeenCalledWith(input, expect.stringContaining("human-readable"));
+		expect(api.importCoordinatorInvite).not.toHaveBeenCalled();
 	});
 
 	it("ignores stale inspection results after the invite input changes", async () => {

--- a/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
+++ b/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
@@ -6,6 +6,7 @@
 
 import * as api from "../../../../lib/api";
 import { clearFieldError, friendlyError, markFieldError } from "../../../../lib/form";
+import { humanPresentationLabel } from "../../../../lib/identity-presentation";
 import { handlePrimaryActionKeyboard } from "../../../../lib/keyboard";
 import { showGlobalNotice } from "../../../../lib/notice";
 import { state } from "../../../../lib/state";
@@ -82,8 +83,8 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 		if (projectInviteContext) {
 			projectInviteContext.textContent = `${inspected.inviter_name || "A teammate"} invited you${inspected.team_name ? ` through ${inspected.team_name}` : ""} to share ${projectNames || "selected projects"}.`;
 		}
-		recipientName.value = inspected.recipient_name ?? "";
-		recipientDeviceName.value = inspected.device_name ?? "";
+		recipientName.value = humanPresentationLabel(inspected.recipient_name);
+		recipientDeviceName.value = humanPresentationLabel(inspected.device_name);
 		projectInviteReview.hidden = false;
 		inspectedInviteValue = inviteValue;
 		if (syncJoinButton) syncJoinButton.textContent = "Accept and start syncing";
@@ -197,20 +198,20 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 					}
 				: undefined;
 		if (identity) {
-			const invalid = (value: string) =>
-				!value ||
-				[...value].length > 120 ||
-				[...value].some((character) => /[\p{Cc}\p{Cf}]/u.test(character));
+			const invalid = (value: string) => humanPresentationLabel(value) === "";
 			if (invalid(identity.recipient_name)) {
 				if (recipientName)
-					markFieldError(recipientName, "Enter a valid name using 120 characters or fewer.");
+					markFieldError(
+						recipientName,
+						"Enter a human-readable name using 120 characters or fewer.",
+					);
 				return;
 			}
 			if (invalid(identity.device_name)) {
 				if (recipientDeviceName)
 					markFieldError(
 						recipientDeviceName,
-						"Enter a valid device name using 120 characters or fewer.",
+						"Enter a human-readable device name using 120 characters or fewer.",
 					);
 				return;
 			}

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1964,16 +1964,22 @@ describe("viewer-server", () => {
 				store.db
 					.prepare(
 						`INSERT INTO actors(actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at)
-						 VALUES (?, ?, 0, 'active', NULL, ?, ?), (?, ?, 0, 'merged', ?, ?, ?)`,
+						 VALUES (?, ?, 0, 'active', NULL, ?, ?), (?, ?, 0, 'merged', ?, ?, ?),
+						        (?, ?, 0, 'merged', ?, ?, ?)`,
 					)
 					.run(
 						"actor:merged-target",
 						"Merged Actor",
 						now,
 						now,
+						"actor:merged-middle",
+						"Middle Actor",
+						"actor:merged-target",
+						now,
+						now,
 						"actor:merged",
 						"Old Actor",
-						"actor:merged-target",
+						"actor:merged-middle",
 						now,
 						now,
 					);
@@ -13067,6 +13073,18 @@ describe("viewer-server", () => {
 					device_name: "Recipient Laptop",
 					reviewed_onboarding_digest: inspection.onboarding.reviewedOnboardingDigest,
 				};
+				if (testCase.kind === "team_member") {
+					const invalidName = await recipient.app.request("/api/sync/invites/import", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({
+							...importBody,
+							recipient_name: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
+						}),
+					});
+					expect(invalidName.status).toBe(400);
+					expect(await invalidName.json()).toEqual({ error: "recipient_display_name_invalid" });
+				}
 				const stale = await recipient.app.request("/api/sync/invites/import", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1906,6 +1906,247 @@ describe("viewer-server", () => {
 	});
 
 	describe("memory feed routes", () => {
+		it("keeps memory list routes available when identity tables are unavailable", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Legacy schema identity",
+					actorId: "actor:legacy",
+					originDeviceId: "device:legacy",
+				});
+				store.db.exec("DROP TABLE identity_devices");
+
+				const response = await app.request("/api/observations?limit=10");
+				expect(response.status).toBe(200);
+				const payload = (await response.json()) as { items: Array<Record<string, unknown>> };
+				expect(payload.items[0]?.title).toBe("Legacy schema identity");
+				expect(payload.items[0]).not.toHaveProperty("resolved_actor_display_name");
+				expect(payload.items[0]).not.toHaveProperty("resolved_device_display_name");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("resolves trusted actor and device names across memory list routes", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const now = "2026-08-18T12:00:00.000Z";
+				const malformedId = "123e4567-e89b-12d3-a456-426614174000";
+				store.db
+					.prepare(
+						`INSERT INTO actors(actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at)
+						 VALUES (?, ?, 0, 'active', NULL, ?, ?), (?, ?, 0, 'active', NULL, ?, ?),
+						        (?, ?, 0, 'active', NULL, ?, ?)`,
+					)
+					.run(
+						"actor:direct",
+						"Trusted Actor",
+						now,
+						now,
+						"actor:peer",
+						"Peer Actor",
+						now,
+						now,
+						"actor:legacy",
+						malformedId,
+						now,
+						now,
+					);
+				store.db
+					.prepare(
+						`INSERT INTO actors(actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at)
+						 VALUES (?, ?, 0, 'active', NULL, ?, ?), (?, ?, 0, 'merged', ?, ?, ?)`,
+					)
+					.run(
+						"actor:merged-target",
+						"Merged Actor",
+						now,
+						now,
+						"actor:merged",
+						"Old Actor",
+						"actor:merged-target",
+						now,
+						now,
+					);
+				store.db
+					.prepare(
+						`INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, actor_id, created_at)
+						 VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)`,
+					)
+					.run(
+						"device:direct",
+						"Lower-priority Device",
+						"direct-fingerprint",
+						"actor:peer",
+						now,
+						"device:peer",
+						"Peer Device",
+						"peer-fingerprint",
+						"actor:peer",
+						now,
+						"device:legacy",
+						malformedId,
+						"legacy-fingerprint",
+						"actor:legacy",
+						now,
+					);
+				store.db
+					.prepare(
+						`INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, actor_id, created_at)
+						 VALUES (?, ?, ?, ?, ?), (?, ?, NULL, ?, ?)`,
+					)
+					.run(
+						"device:merged",
+						"Merged Device",
+						"merged-fingerprint",
+						"actor:peer",
+						now,
+						"device:unpinned",
+						"Unpinned Device",
+						"actor:peer",
+						now,
+					);
+				store.db
+					.prepare(
+						`INSERT INTO identity_devices(
+							device_id, identity_id, display_name, status, provenance, revision,
+							migration_state, assignment_version, source_fingerprint, idempotency_key,
+							created_at, updated_at
+						 ) VALUES (?, ?, ?, 'active', 'test', '1', 'user_managed', 1, NULL, ?, ?, ?)`,
+					)
+					.run("device:direct", "actor:direct", "Trusted Device", "identity-device-test", now, now);
+
+				const sessionId = insertTestSession(store.db);
+				const directId = insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Direct identity",
+					actorId: "actor:direct",
+					originDeviceId: "device:direct",
+					createdAt: "2026-08-18T12:03:00.000Z",
+				});
+				const peerId = insertTestMemory(store, {
+					sessionId,
+					kind: "session_summary",
+					title: "Peer identity",
+					actorId: "actor:missing",
+					originDeviceId: "device:peer",
+					createdAt: "2026-08-18T12:02:00.000Z",
+				});
+				const legacyId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Legacy identity",
+					actorId: "actor:legacy",
+					originDeviceId: "device:legacy",
+					createdAt: "2026-08-18T12:01:00.000Z",
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Merged identity",
+					actorId: "actor:merged",
+					originDeviceId: "device:merged",
+					createdAt: "2026-08-18T12:00:00.000Z",
+				});
+				const unpinnedId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Unpinned identity",
+					actorId: "actor:missing-unpinned",
+					originDeviceId: "device:unpinned",
+					createdAt: "2026-08-18T11:59:00.000Z",
+				});
+				store.db
+					.prepare("UPDATE memory_items SET actor_display_name = ? WHERE id = ?")
+					.run("Raw direct provenance", directId);
+				store.db
+					.prepare("UPDATE memory_items SET actor_display_name = ? WHERE id = ?")
+					.run("Raw peer provenance", peerId);
+				store.db
+					.prepare("UPDATE memory_items SET actor_display_name = ? WHERE id = ?")
+					.run("Legacy teammate", legacyId);
+				store.db
+					.prepare("UPDATE memory_items SET actor_display_name = ? WHERE id = ?")
+					.run(malformedId, unpinnedId);
+
+				type IdentityItem = {
+					title: string;
+					actor_id: string;
+					actor_display_name: string;
+					origin_device_id: string;
+					resolved_actor_display_name?: string;
+					resolved_device_display_name?: string;
+				};
+				const load = async (path: string) => {
+					const response = await app.request(path);
+					expect(response.status).toBe(200);
+					return ((await response.json()) as { items: IdentityItem[] }).items;
+				};
+				const observations = await load("/api/observations?limit=10");
+				const summaries = await load("/api/summaries?limit=10");
+				const memories = await load("/api/memory?limit=10");
+				const direct = observations.find((item) => item.title === "Direct identity");
+				const peer = summaries.find((item) => item.title === "Peer identity");
+				const legacy = observations.find((item) => item.title === "Legacy identity");
+				const merged = observations.find((item) => item.title === "Merged identity");
+				const unpinned = observations.find((item) => item.title === "Unpinned identity");
+
+				expect(direct).toMatchObject({
+					actor_id: "actor:direct",
+					actor_display_name: "Raw direct provenance",
+					origin_device_id: "device:direct",
+					resolved_actor_display_name: "Trusted Actor",
+					resolved_device_display_name: "Trusted Device",
+				});
+				expect(peer).toMatchObject({
+					actor_id: "actor:missing",
+					actor_display_name: "Raw peer provenance",
+					origin_device_id: "device:peer",
+					resolved_actor_display_name: "Peer Actor",
+					resolved_device_display_name: "Peer Device",
+				});
+				expect(legacy).toMatchObject({
+					actor_id: "actor:legacy",
+					actor_display_name: "Legacy teammate",
+					origin_device_id: "device:legacy",
+					resolved_actor_display_name: "Legacy teammate",
+				});
+				expect(legacy).not.toHaveProperty("resolved_device_display_name");
+				expect(merged).toMatchObject({
+					actor_id: "actor:merged",
+					resolved_actor_display_name: "Merged Actor",
+					resolved_device_display_name: "Merged Device",
+				});
+				expect(merged?.resolved_actor_display_name).not.toBe("Peer Actor");
+				expect(unpinned).not.toHaveProperty("resolved_actor_display_name");
+				expect(unpinned).not.toHaveProperty("resolved_device_display_name");
+				expect(memories.find((item) => item.title === "Direct identity")).toMatchObject({
+					resolved_actor_display_name: "Trusted Actor",
+					resolved_device_display_name: "Trusted Device",
+				});
+				expect(memories.find((item) => item.title === "Peer identity")).toMatchObject({
+					resolved_actor_display_name: "Peer Actor",
+					resolved_device_display_name: "Peer Device",
+				});
+				expect(memories.find((item) => item.title === "Legacy identity")).toMatchObject({
+					actor_display_name: "Legacy teammate",
+					resolved_actor_display_name: "Legacy teammate",
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("applies sharing-domain visibility to memory list endpoints", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {
@@ -8917,7 +9158,7 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/peers/rename", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ peer_device_id: "peer-rename", name: "Desk Mini" }),
+					body: JSON.stringify({ peer_device_id: "peer-rename", name: "  Desk   Mini  " }),
 				});
 
 				expect(res.status).toBe(200);
@@ -8927,6 +9168,23 @@ describe("viewer-server", () => {
 					.prepare("SELECT name FROM sync_peers WHERE peer_device_id = ?")
 					.get("peer-rename") as { name: string } | undefined;
 				expect(peerRow?.name).toBe("Desk Mini");
+
+				const invalidRes = await app.request("/api/sync/peers/rename", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						peer_device_id: "peer-rename",
+						name: "123e4567-e89b-12d3-a456-426614174000",
+					}),
+				});
+				expect(invalidRes.status).toBe(400);
+				expect(await invalidRes.json()).toEqual({ error: "name_invalid" });
+				expect(
+					store.db
+						.prepare("SELECT name FROM sync_peers WHERE peer_device_id = ?")
+						.pluck()
+						.get("peer-rename"),
+				).toBe("Desk Mini");
 			} finally {
 				cleanup();
 			}
@@ -11011,16 +11269,48 @@ describe("viewer-server", () => {
 				const createRes = await app.request("/api/sync/actors", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ display_name: "Fixture shadow" }),
+					body: JSON.stringify({ display_name: "  Fixture   shadow  " }),
 				});
 				expect(createRes.status).toBe(200);
 				const created = (await createRes.json()) as { actor_id: string; display_name: string };
 				expect(created.display_name).toBe("Fixture shadow");
 
+				const actorCount = store.db.prepare("SELECT COUNT(*) FROM actors").pluck().get();
+				const invalidCreateRes = await app.request("/api/sync/actors", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ display_name: "local:a57f7c7c-d531-4148-9917-78acb586caad" }),
+				});
+				expect(invalidCreateRes.status).toBe(400);
+				expect(await invalidCreateRes.json()).toEqual({ error: "display_name_invalid" });
+				expect(store.db.prepare("SELECT COUNT(*) FROM actors").pluck().get()).toBe(actorCount);
+
+				const invalidRenameRes = await app.request("/api/sync/actors/rename", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						actor_id: created.actor_id,
+						display_name: "123e4567-e89b-12d3-a456-426614174000",
+					}),
+				});
+				expect(invalidRenameRes.status).toBe(400);
+				expect(await invalidRenameRes.json()).toEqual({
+					error: "display_name_invalid",
+				});
+				expect(
+					store.db
+						.prepare("SELECT display_name FROM actors WHERE actor_id = ?")
+						.pluck()
+						.get(created.actor_id),
+				).toBe("Fixture shadow");
+
 				const renameRes = await app.request("/api/sync/actors/rename", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ actor_id: created.actor_id, display_name: "Fixture remote" }),
+					body: JSON.stringify({
+						actor_id: created.actor_id,
+						display_name: "  Fixture   remote  ",
+					}),
 				});
 				expect(renameRes.status).toBe(200);
 				expect((await renameRes.json()).display_name).toBe("Fixture remote");
@@ -15957,6 +16247,20 @@ describe("viewer-server", () => {
 				globalThis.fetch = fetchMock as typeof fetch;
 				const { app, cleanup } = createTestApp();
 				try {
+					const invalidRename = await app.request(
+						"/api/coordinator/admin/devices/device-1/rename",
+						{
+							method: "POST",
+							headers: { "Content-Type": "application/json" },
+							body: JSON.stringify({ display_name: "device:123e4567" }),
+						},
+					);
+					expect(invalidRename.status).toBe(400);
+					expect(await invalidRename.json()).toMatchObject({
+						error: "display_name_invalid",
+					});
+					expect(fetchMock).not.toHaveBeenCalled();
+
 					const renamed = await app.request("/api/coordinator/admin/devices/device-1/rename", {
 						method: "POST",
 						headers: { "Content-Type": "application/json" },

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -13837,6 +13837,7 @@ describe("viewer-server", () => {
 						reviewed_project_set_digest: updatedPreview.reviewed_project_set_digest,
 					}),
 				};
+				store.actorDisplayName = "local:a57f7c7c-d531-4148-9917-78acb586caad";
 				const legacyCoordinatorResponse = await app.request(
 					"/api/sync/project-invites",
 					createRequest,
@@ -13878,6 +13879,7 @@ describe("viewer-server", () => {
 				expect(coordinatorBody).toMatchObject({
 					operation_id: updatedPreview.operation_id,
 					reviewed_project_set_digest: updatedPreview.reviewed_project_set_digest,
+					inviter_display_name: "Project owner",
 					inviter_device_id: localDeviceId,
 				});
 				expect(coordinatorBody).not.toHaveProperty("scope_ids");

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2066,6 +2066,30 @@ describe("viewer-server", () => {
 					originDeviceId: "device:unpinned",
 					createdAt: "2026-08-18T11:59:00.000Z",
 				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Metadata-only identity",
+					actorId: null,
+					originDeviceId: null,
+					metadata: {
+						actor_id: "actor:direct",
+						origin_device_id: "device:direct",
+					},
+					createdAt: "2026-08-18T11:58:00.000Z",
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "session_summary",
+					title: "Metadata-only summary identity",
+					actorId: null,
+					originDeviceId: null,
+					metadata: {
+						actor_id: "actor:direct",
+						origin_device_id: "device:direct",
+					},
+					createdAt: "2026-08-18T11:57:00.000Z",
+				});
 				store.db
 					.prepare("UPDATE memory_items SET actor_display_name = ? WHERE id = ?")
 					.run("Raw direct provenance", directId);
@@ -2100,6 +2124,10 @@ describe("viewer-server", () => {
 				const legacy = observations.find((item) => item.title === "Legacy identity");
 				const merged = observations.find((item) => item.title === "Merged identity");
 				const unpinned = observations.find((item) => item.title === "Unpinned identity");
+				const metadataOnly = observations.find((item) => item.title === "Metadata-only identity");
+				const metadataOnlySummary = summaries.find(
+					(item) => item.title === "Metadata-only summary identity",
+				);
 
 				expect(direct).toMatchObject({
 					actor_id: "actor:direct",
@@ -2130,6 +2158,18 @@ describe("viewer-server", () => {
 				expect(merged?.resolved_actor_display_name).not.toBe("Peer Actor");
 				expect(unpinned).not.toHaveProperty("resolved_actor_display_name");
 				expect(unpinned).not.toHaveProperty("resolved_device_display_name");
+				expect(metadataOnly).toMatchObject({
+					resolved_actor_display_name: "Trusted Actor",
+					resolved_device_display_name: "Trusted Device",
+				});
+				expect(metadataOnlySummary).toMatchObject({
+					resolved_actor_display_name: "Trusted Actor",
+					resolved_device_display_name: "Trusted Device",
+				});
+				expect(memories.find((item) => item.title === "Metadata-only identity")).toMatchObject({
+					resolved_actor_display_name: "Trusted Actor",
+					resolved_device_display_name: "Trusted Device",
+				});
 				expect(memories.find((item) => item.title === "Direct identity")).toMatchObject({
 					resolved_actor_display_name: "Trusted Actor",
 					resolved_device_display_name: "Trusted Device",

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -41,12 +41,17 @@ interface PeerPresentationRow {
 
 const IDENTITY_LOOKUP_BATCH_SIZE = 500;
 
+function identityValue(item: Record<string, unknown>, key: string): string {
+	const direct = String(item[key] ?? "").trim();
+	if (direct) return direct;
+	const rawMetadata = item.metadata ?? item.metadata_json;
+	const metadata = typeof rawMetadata === "string" ? fromJson(rawMetadata) : rawMetadata;
+	if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return "";
+	return String((metadata as Record<string, unknown>)[key] ?? "").trim();
+}
+
 function uniqueStrings(items: Record<string, unknown>[], key: string): string[] {
-	return [
-		...new Set(
-			items.map((item) => String(item[key] ?? "").trim()).filter((value) => value.length > 0),
-		),
-	];
+	return [...new Set(items.map((item) => identityValue(item, key)).filter(Boolean))];
 }
 
 function batchedLookup<T>(
@@ -74,6 +79,8 @@ function humanName(value: unknown): string | undefined {
 
 /**
  * Add presentation-only identity labels without changing persisted provenance.
+ * Resolved names are display hints, not authority or ownership evidence; legacy
+ * metadata receives the same top-level-first fallback as existing read paths.
  */
 function attachResolvedIdentityFieldsUnsafe(
 	store: MemoryStore,
@@ -143,8 +150,8 @@ function attachResolvedIdentityFieldsUnsafe(
 	);
 
 	for (const item of items) {
-		const actorId = String(item.actor_id ?? "").trim();
-		const deviceId = String(item.origin_device_id ?? "").trim();
+		const actorId = identityValue(item, "actor_id");
+		const deviceId = identityValue(item, "origin_device_id");
 		const peer = peerByDevice.get(deviceId);
 		const peerActorId = String(peer?.actor_id ?? "").trim();
 		const knownMemoryActor = actorById.has(actorId);

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -8,6 +8,7 @@ import {
 	canonicalMemoryKind,
 	fromJson,
 	isSummaryLikeMemory as isCoreSummaryLikeMemory,
+	normalizeHumanPresentationName,
 	parseStrictInteger,
 	schema,
 } from "@codemem/core";
@@ -19,6 +20,151 @@ import { queryInt } from "../helpers.js";
 type StoreFactory = () => MemoryStore;
 
 type OwnershipPredicate = (item: Record<string, unknown>) => boolean;
+
+interface ActorPresentationRow {
+	actor_id: string;
+	display_name: string;
+	status: string;
+	merged_into_actor_id: string | null;
+}
+
+interface DevicePresentationRow {
+	device_id: string;
+	display_name: string;
+}
+
+interface PeerPresentationRow {
+	peer_device_id: string;
+	name: string | null;
+	actor_id: string | null;
+}
+
+const IDENTITY_LOOKUP_BATCH_SIZE = 500;
+
+function uniqueStrings(items: Record<string, unknown>[], key: string): string[] {
+	return [
+		...new Set(
+			items.map((item) => String(item[key] ?? "").trim()).filter((value) => value.length > 0),
+		),
+	];
+}
+
+function batchedLookup<T>(
+	store: MemoryStore,
+	values: string[],
+	query: (placeholders: string) => string,
+): T[] {
+	const rows: T[] = [];
+	for (let offset = 0; offset < values.length; offset += IDENTITY_LOOKUP_BATCH_SIZE) {
+		const batch = values.slice(offset, offset + IDENTITY_LOOKUP_BATCH_SIZE);
+		const placeholders = batch.map(() => "?").join(", ");
+		rows.push(...(store.db.prepare(query(placeholders)).all(...batch) as T[]));
+	}
+	return rows;
+}
+
+function humanName(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	try {
+		return normalizeHumanPresentationName(value, "display_name");
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Add presentation-only identity labels without changing persisted provenance.
+ */
+function attachResolvedIdentityFieldsUnsafe(
+	store: MemoryStore,
+	items: Record<string, unknown>[],
+): void {
+	const actorIds = uniqueStrings(items, "actor_id");
+	const deviceIds = uniqueStrings(items, "origin_device_id");
+	const peers = batchedLookup<PeerPresentationRow>(
+		store,
+		deviceIds,
+		(placeholders) =>
+			`SELECT peer_device_id, name, actor_id FROM sync_peers
+		 WHERE peer_device_id IN (${placeholders})
+		   AND TRIM(COALESCE(pinned_fingerprint, '')) <> ''`,
+	);
+	const peerByDevice = new Map(peers.map((peer) => [peer.peer_device_id, peer]));
+	const peerActorIds = peers
+		.map((peer) => String(peer.actor_id ?? "").trim())
+		.filter((actorId) => actorId.length > 0);
+	const actorRows = batchedLookup<ActorPresentationRow>(
+		store,
+		[...new Set([...actorIds, ...peerActorIds])],
+		(placeholders) =>
+			`SELECT actor_id, display_name, status, merged_into_actor_id FROM actors
+			 WHERE actor_id IN (${placeholders})`,
+	);
+	const mergedActorIds = actorRows
+		.map((actor) => String(actor.merged_into_actor_id ?? "").trim())
+		.filter((actorId) => actorId.length > 0);
+	const mergedActorRows = batchedLookup<ActorPresentationRow>(
+		store,
+		[...new Set(mergedActorIds)],
+		(placeholders) =>
+			`SELECT actor_id, display_name, status, merged_into_actor_id FROM actors
+			 WHERE actor_id IN (${placeholders})`,
+	);
+	const devices = batchedLookup<DevicePresentationRow>(
+		store,
+		deviceIds,
+		(placeholders) =>
+			`SELECT device_id, display_name FROM identity_devices
+		 WHERE device_id IN (${placeholders}) AND status = 'active'`,
+	);
+	const actorById = new Map(
+		[...actorRows, ...mergedActorRows].map((actor) => [actor.actor_id, actor] as const),
+	);
+	const activeActorName = (actorId: string): string | undefined => {
+		const actor = actorById.get(actorId);
+		if (actor?.status !== "active" || actor.merged_into_actor_id !== null) {
+			return undefined;
+		}
+		return humanName(actor.display_name);
+	};
+	const resolvedActorName = (actorId: string): string | undefined => {
+		const actor = actorById.get(actorId);
+		if (!actor) return undefined;
+		if (actor.status === "active" && actor.merged_into_actor_id === null) {
+			return humanName(actor.display_name);
+		}
+		const mergedIntoActorId = String(actor.merged_into_actor_id ?? "").trim();
+		return mergedIntoActorId ? activeActorName(mergedIntoActorId) : undefined;
+	};
+	const deviceNameById = new Map(
+		devices
+			.map((device) => [device.device_id, humanName(device.display_name)] as const)
+			.filter((entry): entry is readonly [string, string] => entry[1] !== undefined),
+	);
+
+	for (const item of items) {
+		const actorId = String(item.actor_id ?? "").trim();
+		const deviceId = String(item.origin_device_id ?? "").trim();
+		const peer = peerByDevice.get(deviceId);
+		const peerActorId = String(peer?.actor_id ?? "").trim();
+		const knownMemoryActor = actorById.has(actorId);
+		const actorName = knownMemoryActor
+			? (resolvedActorName(actorId) ?? humanName(item.actor_display_name))
+			: (resolvedActorName(peerActorId) ?? humanName(item.actor_display_name));
+		const deviceName = deviceNameById.get(deviceId) ?? humanName(peer?.name);
+		if (actorName) item.resolved_actor_display_name = actorName;
+		if (deviceName) item.resolved_device_display_name = deviceName;
+	}
+}
+
+function attachResolvedIdentityFields(store: MemoryStore, items: Record<string, unknown>[]): void {
+	try {
+		attachResolvedIdentityFieldsUnsafe(store, items);
+	} catch {
+		// Presentation enrichment is optional; neutral Feed fallbacks must remain
+		// available for legacy or partially initialized databases.
+	}
+}
 
 function serializeMemoryRow(
 	ownedBySelf: OwnershipPredicate,
@@ -357,6 +503,7 @@ export function memoryRoutes(getStore: StoreFactory) {
 			const result = hasMore ? items.slice(0, limit) : items;
 			const asRecords = result as unknown as Record<string, unknown>[];
 			attachSessionFields(store, asRecords);
+			attachResolvedIdentityFields(store, asRecords);
 			return c.json({
 				items: asRecords,
 				pagination: {
@@ -388,6 +535,7 @@ export function memoryRoutes(getStore: StoreFactory) {
 			const result = hasMore ? items.slice(0, limit) : items;
 			const asRecords = result as unknown as Record<string, unknown>[];
 			attachSessionFields(store, asRecords);
+			attachResolvedIdentityFields(store, asRecords);
 			return c.json({
 				items: asRecords,
 				pagination: {
@@ -518,6 +666,7 @@ export function memoryRoutes(getStore: StoreFactory) {
 			const items = store.recent(limit, filters);
 			const asRecords = items as unknown as Record<string, unknown>[];
 			attachSessionFields(store, asRecords);
+			attachResolvedIdentityFields(store, asRecords);
 			return c.json({ items: asRecords });
 		}
 	});

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -107,16 +107,6 @@ function attachResolvedIdentityFieldsUnsafe(
 			`SELECT actor_id, display_name, status, merged_into_actor_id FROM actors
 			 WHERE actor_id IN (${placeholders})`,
 	);
-	const mergedActorIds = actorRows
-		.map((actor) => String(actor.merged_into_actor_id ?? "").trim())
-		.filter((actorId) => actorId.length > 0);
-	const mergedActorRows = batchedLookup<ActorPresentationRow>(
-		store,
-		[...new Set(mergedActorIds)],
-		(placeholders) =>
-			`SELECT actor_id, display_name, status, merged_into_actor_id FROM actors
-			 WHERE actor_id IN (${placeholders})`,
-	);
 	const devices = batchedLookup<DevicePresentationRow>(
 		store,
 		deviceIds,
@@ -124,24 +114,44 @@ function attachResolvedIdentityFieldsUnsafe(
 			`SELECT device_id, display_name FROM identity_devices
 		 WHERE device_id IN (${placeholders}) AND status = 'active'`,
 	);
-	const actorById = new Map(
-		[...actorRows, ...mergedActorRows].map((actor) => [actor.actor_id, actor] as const),
-	);
-	const activeActorName = (actorId: string): string | undefined => {
-		const actor = actorById.get(actorId);
-		if (actor?.status !== "active" || actor.merged_into_actor_id !== null) {
-			return undefined;
-		}
-		return humanName(actor.display_name);
-	};
+	const actorById = new Map(actorRows.map((actor) => [actor.actor_id, actor] as const));
+	let pendingMergeTargets = [
+		...new Set(
+			actorRows
+				.map((actor) => String(actor.merged_into_actor_id ?? "").trim())
+				.filter((actorId) => actorId && !actorById.has(actorId)),
+		),
+	];
+	while (pendingMergeTargets.length > 0) {
+		const targetRows = batchedLookup<ActorPresentationRow>(
+			store,
+			pendingMergeTargets,
+			(placeholders) =>
+				`SELECT actor_id, display_name, status, merged_into_actor_id FROM actors
+				 WHERE actor_id IN (${placeholders})`,
+		);
+		for (const actor of targetRows) actorById.set(actor.actor_id, actor);
+		pendingMergeTargets = [
+			...new Set(
+				targetRows
+					.map((actor) => String(actor.merged_into_actor_id ?? "").trim())
+					.filter((actorId) => actorId && !actorById.has(actorId)),
+			),
+		];
+	}
 	const resolvedActorName = (actorId: string): string | undefined => {
-		const actor = actorById.get(actorId);
-		if (!actor) return undefined;
-		if (actor.status === "active" && actor.merged_into_actor_id === null) {
-			return humanName(actor.display_name);
+		const seen = new Set<string>();
+		let currentActorId = actorId;
+		while (currentActorId && !seen.has(currentActorId)) {
+			seen.add(currentActorId);
+			const actor = actorById.get(currentActorId);
+			if (!actor) return undefined;
+			if (actor.status === "active" && actor.merged_into_actor_id === null) {
+				return humanName(actor.display_name);
+			}
+			currentActorId = String(actor.merged_into_actor_id ?? "").trim();
 		}
-		const mergedIntoActorId = String(actor.merged_into_actor_id ?? "").trim();
-		return mergedIntoActorId ? activeActorName(mergedIntoActorId) : undefined;
+		return undefined;
 	};
 	const deviceNameById = new Map(
 		devices

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -889,10 +889,16 @@ function recipientInviteOnboardingPreviewFromReviewedIntent(
 }
 
 const SAFE_RECIPIENT_INVITE_ERRORS = new Set([
+	"device_display_name_invalid",
+	"device_display_name_required",
+	"device_display_name_too_long",
 	"invite_already_bound",
 	"invite_expired",
 	"invite_identity_conflict",
 	"invite_invalid",
+	"recipient_display_name_invalid",
+	"recipient_display_name_required",
+	"recipient_display_name_too_long",
 	"recipient_invite_intent_mismatch",
 	"recipient_invite_review_unavailable",
 	"reviewed_onboarding_stale",

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -6611,7 +6611,11 @@ export function syncRoutes(
 				dbPath: store.dbPath,
 				recipientActorId: recipientInvite ? null : store.actorId,
 				recipientDisplayName:
-					typeof body.recipient_name === "string" ? body.recipient_name : store.actorDisplayName,
+					decoded.kind === "add_device"
+						? null
+						: typeof body.recipient_name === "string"
+							? body.recipient_name
+							: store.actorDisplayName,
 				deviceDisplayName: typeof body.device_name === "string" ? body.device_name : null,
 				reviewedOnboardingDigest: reviewedOnboardingDigest || null,
 			});

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -694,11 +694,20 @@ function projectInviteAcceptanceFailure(error: unknown): {
 }
 
 const PROJECT_INVITE_TTL_HOURS = 7 * 24;
+const PROJECT_INVITE_OWNER_FALLBACK = "Project owner";
 const PROJECT_INVITE_BODY_KEYS = new Set([
 	"teammate_name",
 	"project_ids",
 	"reviewed_project_set_digest",
 ]);
+
+function projectInviteInviterDisplayName(value: string): string {
+	try {
+		return normalizeHumanPresentationName(value, "inviter_display_name");
+	} catch {
+		return PROJECT_INVITE_OWNER_FALLBACK;
+	}
+}
 
 function projectInviteStringList(body: Record<string, unknown>, key: string): string[] {
 	const value = body[key];
@@ -5784,7 +5793,7 @@ export function syncRoutes(
 				operationId: plan.operationId,
 				reviewedProjectSetDigest: plan.reviewedProjectSetDigest,
 				inviterActorId: plan.inviterActorId,
-				inviterDisplayName: store.actorDisplayName,
+				inviterDisplayName: projectInviteInviterDisplayName(store.actorDisplayName),
 				inviterDeviceId: plan.inviterDeviceIds[0],
 				pendingPersonId: plan.personId,
 				projectSummaries: plan.projects.map((project) => ({

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -117,6 +117,7 @@ import {
 	migrateRecipientPolicyIntent,
 	negotiateSyncCapability,
 	normalizeAddress,
+	normalizeHumanPresentationName,
 	normalizeSyncCapability,
 	normalizeSyncFeatures,
 	normalizeTeammateName,
@@ -674,6 +675,14 @@ function projectInviteAcceptanceFailure(error: unknown): {
 			"The owner's device is not ready to establish trust yet. Retry once, then ask the owner to review the share.",
 		project_invite_trust_state_invalid:
 			"The owner's trust setup could not be verified. Ask the owner to review the share.",
+		recipient_display_name_invalid:
+			"Enter a human-readable Identity name instead of an internal identifier.",
+		recipient_display_name_required: "Enter an Identity display name.",
+		recipient_display_name_too_long: "Use an Identity display name with 120 characters or fewer.",
+		device_display_name_invalid:
+			"Enter a human-readable device name instead of an internal identifier.",
+		device_display_name_required: "Enter a device display name.",
+		device_display_name_too_long: "Use a device display name with 120 characters or fewer.",
 	};
 	const safeCode = Object.hasOwn(detailByCode, code) ? code : "project_invite_acceptance_failed";
 	return {
@@ -5202,9 +5211,15 @@ export function syncRoutes(
 				return c.json({ error: "invalid json" }, 400);
 			}
 			const peerDeviceId = String(body.peer_device_id ?? "").trim();
-			const name = String(body.name ?? "").trim();
+			const rawName = String(body.name ?? "");
 			if (!peerDeviceId) return c.json({ error: "peer_device_id required" }, 400);
-			if (!name) return c.json({ error: "name required" }, 400);
+			if (!rawName.trim()) return c.json({ error: "name required" }, 400);
+			let name: string;
+			try {
+				name = normalizeHumanPresentationName(rawName, "name");
+			} catch (error) {
+				return c.json({ error: error instanceof Error ? error.message : "name_invalid" }, 400);
+			}
 			const exists = d
 				.select({ peer_device_id: schema.syncPeers.peer_device_id })
 				.from(schema.syncPeers)
@@ -6171,8 +6186,17 @@ export function syncRoutes(
 		} catch {
 			return c.json({ error: "invalid json" }, 400);
 		}
-		const displayName = String(body.display_name ?? "").trim();
-		if (!displayName) return c.json({ error: "display_name required" }, 400);
+		const rawDisplayName = String(body.display_name ?? "");
+		if (!rawDisplayName.trim()) return c.json({ error: "display_name required" }, 400);
+		let displayName: string;
+		try {
+			displayName = normalizeHumanPresentationName(rawDisplayName, "display_name");
+		} catch (error) {
+			return c.json(
+				{ error: error instanceof Error ? error.message : "display_name_invalid" },
+				400,
+			);
+		}
 		const d = drizzle(store.db, { schema });
 		const now = new Date().toISOString();
 		const actor = {
@@ -6198,9 +6222,16 @@ export function syncRoutes(
 			return c.json({ error: "invalid json" }, 400);
 		}
 		const actorId = String(body.actor_id ?? "").trim();
-		const displayName = String(body.display_name ?? "").trim();
 		if (!actorId) return c.json({ error: "actor_id required" }, 400);
-		if (!displayName) return c.json({ error: "display_name required" }, 400);
+		let displayName: string;
+		try {
+			displayName = normalizeHumanPresentationName(String(body.display_name ?? ""), "display_name");
+		} catch (error) {
+			return c.json(
+				{ error: error instanceof Error ? error.message : "display_name_invalid" },
+				400,
+			);
+		}
 		const d = drizzle(store.db, { schema });
 		const actor = d.select().from(schema.actors).where(eq(schema.actors.actor_id, actorId)).get();
 		if (!actor) return c.json({ error: "actor not found" }, 404);
@@ -7232,9 +7263,16 @@ export function syncRoutes(
 			return c.json({ error: "invalid json", status }, 400);
 		}
 		const groupId = resolveCoordinatorAdminGroup(String(body.group_id ?? "").trim(), status);
-		const displayName = String(body.display_name ?? "").trim();
 		if (!groupId) return c.json({ error: "group_id required", status }, 400);
-		if (!displayName) return c.json({ error: "display_name required", status }, 400);
+		let displayName: string;
+		try {
+			displayName = normalizeHumanPresentationName(String(body.display_name ?? ""), "display_name");
+		} catch (error) {
+			return c.json(
+				{ error: error instanceof Error ? error.message : "display_name_invalid", status },
+				400,
+			);
+		}
 		try {
 			const device = await coordinatorRenameDeviceAction({
 				groupId,


### PR DESCRIPTION
## Description

Prevent Feed from presenting raw actor IDs, device UUIDs, machine hostnames, or other internal identity values as user-facing labels. Preserve trusted human names during Project acceptance, validate identity mutations at ingress, add optional resolved actor/device presentation fields to Viewer memory responses, and use neutral Feed fallbacks for legacy rows.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional validation: `pnpm --filter @codemem/ui build`; 196 test files passed with 4,469 tests passed and 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced