### PR TITLE
feat(viewer): expose device identity inventory

### DIFF
--- a/docs/plans/2026-08-18-legacy-device-identity-setup-design.md
+++ b/docs/plans/2026-08-18-legacy-device-identity-setup-design.md
@@ -1,0 +1,386 @@
+# Legacy Device Identity Setup and Ownership Repair
+
+**Date:** 2026-08-18
+
+**Status:** Approved
+
+## Summary
+
+Codemem needs to stop presenting every legacy or newly discovered device as if its Identity and owner were already known. Existing stores contain several kinds of device evidence with different trust strengths, and current UI copy sometimes collapses those distinctions too early.
+
+This design introduces an explicit device-identity inventory and a conservative ownership setup workflow. It preserves existing Identity assignments, keeps pairing separate from ownership, treats historical evidence as suggestions unless it is authoritative, and gives users a direct way to confirm which Identity a device belongs to.
+
+The first implementation layer is additive and read-only. It defines the inventory contract, classifies device records, exposes the result to the viewer, and does not change any existing reconciliation or authorization writes.
+
+Implementation-shape clarification: PR1 uses a versioned core projection named `DeviceIdentityInventoryV1`, exposed at `GET /api/sync/recipient-policy/v1/device-inventory`. Coordinator enrollments are injected into the pure core projection by the viewer route; the core projection performs no network reads.
+
+## Problem
+
+Today the viewer can infer or display device ownership from a mixture of:
+
+- the local `sync_device` row,
+- `sync_peers`,
+- `identity_devices`,
+- coordinator enrollments,
+- coordinator presence,
+- pairing or trust state,
+- display names,
+- and historical actor references.
+
+Those sources do not all prove the same thing.
+
+A device can be:
+
+- known locally but not assigned to an Identity,
+- visible through a coordinator but not yet paired,
+- paired but still unassigned,
+- assigned through an existing authoritative binding,
+- represented more than once because historical identifiers differ,
+- or conflicted because evidence disagrees.
+
+The current product language can imply ownership where only reachability or historical association exists. That is unsafe and confusing. A user needs to know what is proven, what is only suggested, and what action is required next.
+
+## Goals
+
+- Preserve existing active device-to-Identity assignments.
+- Preserve authoritative Identity assignments created by the reviewed invitation onboarding path.
+- Never infer ownership from pairing, trust, display names, coordinator groups, addresses, or `sync_peers.actor_id` alone.
+- Distinguish local, paired, coordinator-only, configured, and conflicted devices.
+- Provide a stable, versioned inventory contract for the viewer.
+- Make setup actions explicit and attributable.
+- Keep the first implementation additive and read-only.
+- Fail closed when fingerprints or authoritative bindings conflict.
+- Bound inventory size and report coordinator evidence availability.
+
+## Non-goals
+
+- Replacing the existing invitation onboarding flow.
+- Changing sync authorization or recipient-policy semantics in the first PR.
+- Automatically merging Identities.
+- Automatically assigning an unbound device to the current user.
+- Treating coordinator enrollment as proof of ownership.
+- Treating pairing as proof of ownership.
+- Reworking the viewer UI in the first PR.
+- Migrating or deleting historical rows in the first PR.
+
+## Terminology
+
+### Device
+
+A cryptographic sync endpoint identified by a stable device ID and, when available, public-key fingerprint evidence.
+
+### Identity
+
+A person-level actor represented by an `actors` row and referenced by recipient-policy records.
+
+### Device binding
+
+An `identity_devices` row connecting a device to an Identity. An active binding is authoritative for this design unless conflicting authoritative evidence exists.
+
+### Pairing
+
+The process by which two devices establish mutual sync trust. Pairing proves that the devices have approved communication with each other. It does not prove that they belong to the same person or Identity.
+
+### Coordinator enrollment
+
+A coordinator record describing a device visible in a coordinator group. Enrollment is useful discovery and cryptographic evidence, but enrollment alone is not ownership proof.
+
+### Suggested Identity
+
+A non-authoritative hint that may help prefill setup UI. Suggestions must be confirmed before they become bindings.
+
+## Evidence hierarchy
+
+The projection uses the following evidence hierarchy.
+
+### Authoritative ownership evidence
+
+- An active `identity_devices` row.
+- An Identity-bound coordinator enrollment that has already passed the existing reviewed and consumed invitation evidence path and has materialized an active `identity_devices` row.
+
+The second case is intentionally represented through the resulting active binding rather than by trusting the raw enrollment directly. This preserves current invitation onboarding behavior without widening trust for legacy coordinator rows.
+
+### Strong device identity evidence
+
+- A stable device ID.
+- A local `sync_device` public key and matching fingerprint.
+- A `sync_peers` pinned fingerprint or public key whose derived fingerprint matches.
+- A coordinator enrollment public key and matching fingerprint.
+
+Strong device identity evidence can deduplicate records that refer to the same cryptographic device. It does not assign ownership.
+
+### Suggestive evidence
+
+- `sync_peers.actor_id`.
+- Historical display names.
+- Coordinator display names.
+- A coordinator enrollment `identity_id` that has not passed the reviewed invitation path.
+
+Suggestive evidence can be exposed as a setup hint but cannot create or change an `identity_devices` row.
+
+### Non-ownership evidence
+
+- Pairing or mutual trust state.
+- Coordinator group membership.
+- Network addresses.
+- Discovery source.
+- Device presence.
+- Matching display names.
+
+These facts may explain reachability or guide setup, but they must never be used to infer ownership.
+
+## Inventory states
+
+Every projected device is classified into exactly one of four states.
+
+### `configured`
+
+The device has one active authoritative `identity_devices` binding and no conflicting authoritative or fingerprint evidence.
+
+Configured devices keep their existing Identity. The inventory is descriptive and does not rewrite them.
+
+### `setup_required`
+
+The device is known through the local device row or `sync_peers`, but no authoritative Identity binding exists.
+
+The UI may show a suggested Identity, including a value derived from `sync_peers.actor_id`, but must require explicit confirmation before writing a binding.
+
+### `pairing_required`
+
+The device is visible only through coordinator enrollment evidence. There is no matching local device, peer, or active binding.
+
+This state remains `pairing_required` even when the coordinator enrollment contains an `identity_id`, unless reviewed invitation evidence has already materialized an active local binding. The raw coordinator `identity_id` is not ownership proof.
+
+### `conflicted`
+
+The available evidence cannot be safely represented as one configured or setup-ready device.
+
+Conflicts include:
+
+- one stable device ID associated with multiple validated fingerprints,
+- one validated fingerprint associated with multiple active Identity bindings,
+- multiple active bindings to different Identities after deduplication,
+- an active binding to an inactive, merged, or deactivated Identity,
+- a revoked device binding,
+- a disabled coordinator enrollment that otherwise participates in the record,
+- or a claimed fingerprint that does not match the supplied public key.
+
+Conflicted devices require review. The projection must not choose an owner or silently drop contradictory evidence.
+
+## Deduplication rules
+
+The inventory combines source rows into logical devices conservatively.
+
+### Merge when
+
+- source rows share the same stable device ID, or
+- source rows have the same validated public-key fingerprint.
+
+### Do not merge when
+
+- only display names match,
+- only addresses match,
+- only actor suggestions match,
+- only coordinator groups match,
+- or fingerprints are missing or invalid.
+
+### Conflict instead of merge when
+
+- a shared stable device ID has different validated fingerprints,
+- a claimed fingerprint does not match its public key,
+- or merging fingerprint aliases would combine different active Identity bindings.
+
+The projected record keeps all evidence device IDs so a later repair workflow can explain why records were combined.
+
+## Versioned contract
+
+The first PR adds a versioned core contract with these conceptual fields.
+
+```ts
+interface DeviceIdentityInventoryItemV1 {
+  version: 1;
+  deviceId: string;
+  evidenceDeviceIds: string[];
+  displayName: string;
+  state: "configured" | "setup_required" | "pairing_required" | "conflicted";
+  identityId: string | null;
+  suggestedIdentityId: string | null;
+  validatedFingerprint: string | null;
+  isLocal: boolean;
+  sources: Array<
+    "local_device" | "sync_peer" | "coordinator_enrollment" | "identity_binding"
+  >;
+  conflictCodes: string[];
+}
+
+interface DeviceIdentityInventoryV1 {
+  version: 1;
+  items: DeviceIdentityInventoryItemV1[];
+  coordinatorEvidence: {
+    availability: "available" | "unavailable";
+    safeErrorCode: string | null;
+  };
+  truncated: boolean;
+}
+```
+
+The public endpoint is additive and returns the versioned contract. Coordinator evidence is injected into the pure core projection so core logic performs no network reads.
+
+## Projection flow
+
+1. Read the local `sync_device` row.
+2. Read bounded `sync_peers` rows.
+3. Read `identity_devices` and the referenced actor status.
+4. Receive bounded coordinator enrollment evidence from the viewer-server layer.
+5. Validate public-key and fingerprint pairs.
+6. Build source evidence records.
+7. Group by stable device ID.
+8. Union groups only when validated fingerprints match.
+9. Detect fingerprint and binding conflicts.
+10. Classify each logical device.
+11. Sort deterministically, putting the local device first.
+12. Apply the response limit and expose `truncated`.
+
+The projection performs no writes.
+
+## Coordinator availability
+
+Coordinator evidence is optional at request time. The endpoint must still return local inventory when coordinator configuration is missing or the coordinator cannot be reached.
+
+The response exposes only bounded, safe availability codes such as:
+
+- `coordinator_not_configured`,
+- `coordinator_unavailable`,
+- `coordinator_evidence_too_large`.
+
+Raw coordinator errors, URLs, credentials, and response bodies must not be returned.
+
+If coordinator evidence is incomplete or exceeds its bound, the endpoint marks it unavailable and does not classify from a partial coordinator snapshot. Partial evidence could hide a conflict and incorrectly weaken the result.
+
+## Existing invitation onboarding
+
+The current reviewed invitation path remains authoritative.
+
+When an add-device or team invitation has been reviewed and consumed through the existing flow, reconciliation may materialize an active `identity_devices` row. The inventory then reports that device as `configured` because the authoritative local binding already exists.
+
+The inventory does not re-evaluate or replace that invitation proof. It also does not downgrade such devices merely because the raw coordinator enrollment would otherwise be considered suggestive.
+
+By contrast, a legacy coordinator enrollment with a null Identity, an unreviewed Identity, or no matching local binding remains `pairing_required`.
+
+## Future setup workflow
+
+A later PR may add explicit write actions for `setup_required` devices.
+
+The intended workflow is:
+
+1. Select an existing Identity or create a new one.
+2. Show the evidence supporting the device record.
+3. Require explicit confirmation.
+4. Re-read the current evidence and reject stale decisions.
+5. Write one active `identity_devices` binding with user-confirmed provenance.
+6. Record an audit event.
+7. Recompute recipient policy through the existing reconciliation path.
+
+Coordinator-only devices must be paired or otherwise cryptographically matched before ownership setup becomes available.
+
+Conflicted devices require a separate repair workflow and cannot use the normal setup action.
+
+## Security properties
+
+- Pairing cannot silently assign ownership.
+- A malicious or stale coordinator enrollment cannot overwrite an active local binding.
+- `sync_peers.actor_id` cannot materialize an Identity binding.
+- Matching names cannot merge devices.
+- Invalid public-key and fingerprint pairs fail closed.
+- Partial coordinator results cannot weaken classification.
+- Endpoint errors do not expose coordinator credentials or internals.
+- The read-only PR cannot mutate recipient policy, authorization, actors, or device bindings.
+
+## API behavior
+
+The first PR adds one viewer endpoint under the recipient-policy sync namespace.
+
+The endpoint:
+
+- returns HTTP 200 when local evidence is available even if coordinator evidence is unavailable,
+- returns the versioned response,
+- reports coordinator availability separately,
+- returns a deterministic bounded item list,
+- performs no database writes,
+- and does not trigger coordinator reconciliation.
+
+## Testing strategy
+
+Core tests cover:
+
+- local unbound device becomes `setup_required`,
+- peer-only device becomes `setup_required`,
+- `sync_peers.actor_id` is only a suggestion,
+- coordinator-only null Identity becomes `pairing_required`,
+- coordinator-only unreviewed Identity remains `pairing_required`,
+- an active existing binding becomes `configured`,
+- reviewed-invitation materialized bindings remain `configured`,
+- matching validated fingerprints deduplicate aliases,
+- matching display names do not deduplicate devices,
+- conflicting fingerprints fail closed,
+- conflicting active bindings fail closed,
+- revoked or inactive bindings fail closed,
+- disabled enrollments fail closed,
+- unavailable coordinator evidence does not prevent local inventory,
+- and inventory reads do not create `identity_devices` rows.
+
+Viewer-server tests cover:
+
+- the additive endpoint shape,
+- injected coordinator evidence,
+- coordinator failure redaction,
+- local results during coordinator failure,
+- bounded output,
+- and absence of reconciliation side effects.
+
+## Rollout plan
+
+### PR1: Read-only inventory
+
+- Copy this approved design into the implementation worktree.
+- Add versioned core types and pure projection logic.
+- Add a database evidence loader.
+- Add the viewer endpoint with injected coordinator evidence.
+- Add focused tests.
+- Export the contract and projection from core.
+- Do not change UI behavior.
+- Do not add write actions.
+- Do not change existing invitation reconciliation.
+
+### PR2: Setup UI
+
+- Present configured, setup-required, pairing-required, and conflicted states.
+- Make the primary action explicit.
+- Show suggestions as suggestions, not facts.
+- Keep advanced evidence behind disclosure.
+
+### PR3: Confirmed binding writes
+
+- Add stale-evidence-checked write actions.
+- Add audit records.
+- Reuse existing reconciliation after binding confirmation.
+
+### PR4: Conflict repair
+
+- Add explicit repair choices for duplicate IDs, fingerprint conflicts, and conflicting bindings.
+- Never auto-resolve ownership conflicts.
+
+## Acceptance criteria for PR1
+
+- Existing active device bindings remain configured.
+- Existing invitation onboarding behavior is unchanged.
+- Coordinator-only legacy enrollments do not become owned.
+- Pairing and trust are not treated as ownership.
+- `sync_peers.actor_id` is never materialized by inventory reads.
+- The core projection is pure with respect to coordinator I/O.
+- The viewer endpoint is additive and read-only.
+- Coordinator unavailability is explicit and safely redacted.
+- Device records are deduplicated only through stable IDs or validated fingerprints.
+- Conflicts fail closed.
+- Focused tests pass.
+- Type checking and linting pass.

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -432,6 +432,24 @@ describe("coordinator local admin actions", () => {
 		).rejects.toThrow("coordinator_device_list_malformed");
 	});
 
+	it("rejects remote device lists above the enrollment evidence limit", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify({ items: Array.from({ length: 501 }, () => ({})) })),
+			),
+		);
+
+		await expect(
+			coordinatorListDevicesAction({
+				groupId: "team-a",
+				remoteUrl: "https://coord.example.test",
+				adminSecret: "secret",
+			}),
+		).rejects.toThrow("coordinator_response_too_large");
+	});
+
 	it("normalizes omitted nullable fields from legacy remote device lists", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -131,11 +131,13 @@ async function remoteRequest(
 		headers,
 		body,
 		timeoutS: 3,
+		maxResponseBytes: 2_000_000,
 	});
 	if (status < 200 || status >= 300) {
 		const detail = typeof payload?.error === "string" ? payload.error : "unknown";
 		throw new Error(`Remote coordinator request failed (${status}): ${detail}`);
 	}
+	if (payload?.error === "response_too_large") throw new Error("coordinator_response_too_large");
 	return payload;
 }
 
@@ -828,6 +830,7 @@ export async function coordinatorListDevicesAction(opts: {
 		if (!Array.isArray(payload?.items)) {
 			throw new Error("coordinator_device_list_malformed");
 		}
+		if (payload.items.length > 500) throw new Error("coordinator_response_too_large");
 		return payload.items.map((row) => {
 			if (!row || typeof row !== "object" || Array.isArray(row)) {
 				throw new Error("coordinator_device_list_malformed");

--- a/packages/core/src/device-identity-inventory.test.ts
+++ b/packages/core/src/device-identity-inventory.test.ts
@@ -1,0 +1,529 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CoordinatorEnrollment } from "./coordinator-store-contract.js";
+import {
+	type DeviceIdentityInventorySnapshot,
+	listDeviceIdentityInventory,
+	loadDeviceIdentityInventorySnapshot,
+	projectDeviceIdentityInventory,
+} from "./device-identity-inventory.js";
+import { fingerprintPublicKey } from "./sync-fingerprint.js";
+import { initTestSchema } from "./test-utils.js";
+
+const NOW = "2026-08-18T12:00:00.000Z";
+
+function enrollment(
+	deviceId: string,
+	publicKey: string,
+	overrides: Partial<CoordinatorEnrollment> = {},
+): CoordinatorEnrollment {
+	return {
+		group_id: "group-a",
+		device_id: deviceId,
+		public_key: publicKey,
+		fingerprint: fingerprintPublicKey(publicKey),
+		identity_id: null,
+		display_name: "Laptop",
+		enabled: 1,
+		created_at: NOW,
+		...overrides,
+	};
+}
+
+function snapshot(
+	overrides: Partial<DeviceIdentityInventorySnapshot> = {},
+): DeviceIdentityInventorySnapshot {
+	return {
+		localDevice: null,
+		peers: [],
+		bindings: [],
+		coordinator: { availability: "available", safeErrorCode: null, enrollments: [] },
+		...overrides,
+	};
+}
+
+describe("device Identity inventory projection", () => {
+	it("classifies local and peer evidence as setup_required without binding identities", () => {
+		const result = projectDeviceIdentityInventory(
+			snapshot({
+				localDevice: {
+					deviceId: "device-local",
+					displayName: "This laptop",
+					publicKey: "local-key",
+					fingerprint: fingerprintPublicKey("local-key"),
+				},
+				peers: [
+					{
+						deviceId: "device-peer",
+						displayName: "Peer laptop",
+						publicKey: "peer-key",
+						pinnedFingerprint: fingerprintPublicKey("peer-key"),
+						suggestedIdentityId: "identity-suggestion",
+						trustProvenance: null,
+						claimedLocalActor: false,
+					},
+				],
+			}),
+		);
+
+		expect(result.items).toMatchObject([
+			{ deviceId: "device-local", state: "setup_required", identityId: null, isLocal: true },
+			{
+				deviceId: "device-peer",
+				state: "setup_required",
+				identityId: null,
+				suggestedIdentityId: "identity-suggestion",
+			},
+		]);
+	});
+
+	it("keeps coordinator-only enrollment in pairing_required even when it names an identity", () => {
+		const result = projectDeviceIdentityInventory(
+			snapshot({
+				coordinator: {
+					availability: "available",
+					safeErrorCode: null,
+					enrollments: [
+						enrollment("legacy-device", "legacy-key", { identity_id: "identity-unreviewed" }),
+					],
+				},
+			}),
+		);
+
+		expect(result.items).toMatchObject([
+			{
+				deviceId: "legacy-device",
+				state: "pairing_required",
+				identityId: null,
+				suggestedIdentityId: "identity-unreviewed",
+			},
+		]);
+	});
+
+	it("preserves an active trusted-invitation binding as configured", () => {
+		const result = projectDeviceIdentityInventory(
+			snapshot({
+				bindings: [
+					{
+						deviceId: "invited-device",
+						displayName: "Invited laptop",
+						identityId: "identity-a",
+						status: "active",
+						identityStatus: "active",
+					},
+				],
+				coordinator: {
+					availability: "available",
+					safeErrorCode: null,
+					enrollments: [enrollment("invited-device", "invite-key", { identity_id: "identity-a" })],
+				},
+			}),
+		);
+
+		expect(result.items).toMatchObject([
+			{
+				deviceId: "invited-device",
+				state: "configured",
+				identityId: "identity-a",
+				suggestedIdentityId: null,
+			},
+		]);
+	});
+
+	it("deduplicates validated fingerprints but never equal display names", () => {
+		const sharedFingerprint = fingerprintPublicKey("shared-key");
+		const result = projectDeviceIdentityInventory(
+			snapshot({
+				peers: [
+					{
+						deviceId: "peer-a",
+						displayName: "Laptop",
+						publicKey: "shared-key",
+						pinnedFingerprint: sharedFingerprint,
+						suggestedIdentityId: null,
+						trustProvenance: null,
+						claimedLocalActor: false,
+					},
+					{
+						deviceId: "peer-b",
+						displayName: "Laptop",
+						publicKey: "other-key",
+						pinnedFingerprint: fingerprintPublicKey("other-key"),
+						suggestedIdentityId: null,
+						trustProvenance: null,
+						claimedLocalActor: false,
+					},
+				],
+				coordinator: {
+					availability: "available",
+					safeErrorCode: null,
+					enrollments: [enrollment("coordinator-alias", "shared-key")],
+				},
+			}),
+		);
+
+		expect(result.items).toHaveLength(2);
+		expect(result.items.find((item) => item.deviceId === "peer-a")?.evidenceDeviceIds).toEqual([
+			"coordinator-alias",
+			"peer-a",
+		]);
+	});
+
+	it("fails closed on fingerprint, binding, inactive identity, and disabled-enrollment conflicts", () => {
+		const sharedFingerprint = fingerprintPublicKey("shared-key");
+		const result = projectDeviceIdentityInventory(
+			snapshot({
+				peers: [
+					{
+						deviceId: "device-a",
+						displayName: "A",
+						publicKey: "shared-key",
+						pinnedFingerprint: sharedFingerprint,
+						suggestedIdentityId: null,
+						trustProvenance: null,
+						claimedLocalActor: false,
+					},
+					{
+						deviceId: "device-b",
+						displayName: "B",
+						publicKey: "shared-key",
+						pinnedFingerprint: sharedFingerprint,
+						suggestedIdentityId: null,
+						trustProvenance: null,
+						claimedLocalActor: false,
+					},
+				],
+				bindings: [
+					{
+						deviceId: "device-a",
+						displayName: "A",
+						identityId: "identity-a",
+						status: "active",
+						identityStatus: "active",
+					},
+					{
+						deviceId: "device-b",
+						displayName: "B",
+						identityId: "identity-b",
+						status: "active",
+						identityStatus: "deactivated",
+					},
+				],
+				coordinator: {
+					availability: "available",
+					safeErrorCode: null,
+					enrollments: [enrollment("device-a", "different-key", { enabled: 0 })],
+				},
+			}),
+		);
+
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]).toMatchObject({ state: "conflicted", identityId: null });
+		expect(result.items[0]?.conflictCodes).toEqual([
+			"coordinator_enrollment_disabled",
+			"fingerprint_conflict",
+			"identity_binding_conflict",
+			"identity_inactive",
+		]);
+	});
+
+	it("clears a single active owner when independent evidence is conflicted", () => {
+		const result = projectDeviceIdentityInventory(
+			snapshot({
+				peers: [
+					{
+						deviceId: "device-a",
+						displayName: "A",
+						publicKey: "public-key",
+						pinnedFingerprint: fingerprintPublicKey("different-key"),
+						suggestedIdentityId: null,
+						trustProvenance: null,
+						claimedLocalActor: false,
+					},
+				],
+				bindings: [
+					{
+						deviceId: "device-a",
+						displayName: "A",
+						identityId: "identity-a",
+						status: "active",
+						identityStatus: "active",
+					},
+				],
+			}),
+		);
+
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]).toMatchObject({
+			state: "conflicted",
+			identityId: null,
+			conflictCodes: ["fingerprint_invalid"],
+		});
+	});
+
+	it("treats a binding to a pending Identity as conflicted", () => {
+		const result = projectDeviceIdentityInventory(
+			snapshot({
+				bindings: [
+					{
+						deviceId: "device-a",
+						displayName: "A",
+						identityId: "identity-a",
+						status: "active",
+						identityStatus: "pending",
+					},
+				],
+			}),
+		);
+
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]).toMatchObject({
+			state: "conflicted",
+			identityId: null,
+			conflictCodes: ["identity_inactive"],
+		});
+	});
+
+	it("ignores unavailable coordinator rows and bounds the response", () => {
+		const peers = ["a", "b"].map((suffix) => ({
+			deviceId: `device-${suffix}`,
+			displayName: `Device ${suffix}`,
+			publicKey: `key-${suffix}`,
+			pinnedFingerprint: fingerprintPublicKey(`key-${suffix}`),
+			suggestedIdentityId: null,
+			trustProvenance: null,
+			claimedLocalActor: false,
+		}));
+		const result = projectDeviceIdentityInventory(
+			snapshot({
+				peers,
+				coordinator: {
+					availability: "unavailable",
+					safeErrorCode: "coordinator_unavailable",
+					enrollments: [enrollment("partial-device", "partial-key")],
+				},
+			}),
+			{ limit: 1 },
+		);
+
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]?.deviceId).not.toBe("partial-device");
+		expect(result.truncated).toBe(true);
+		expect(result.coordinatorEvidence).toEqual({
+			availability: "unavailable",
+			safeErrorCode: "coordinator_unavailable",
+		});
+	});
+
+	it("preserves item classifications when bounded local evidence was truncated", () => {
+		const result = projectDeviceIdentityInventory(
+			snapshot({
+				localEvidenceTruncated: true,
+				peers: [
+					{
+						deviceId: "device-a",
+						displayName: "Device A",
+						publicKey: "key-a",
+						pinnedFingerprint: fingerprintPublicKey("key-a"),
+						suggestedIdentityId: null,
+						trustProvenance: null,
+						claimedLocalActor: false,
+					},
+				],
+			}),
+		);
+
+		expect(result).toMatchObject({
+			truncated: true,
+			items: [{ state: "setup_required", conflictCodes: [] }],
+		});
+	});
+
+	it("fails closed on an invalid public-key and fingerprint pair", () => {
+		const result = projectDeviceIdentityInventory(
+			snapshot({
+				peers: [
+					{
+						deviceId: "device-invalid",
+						displayName: "Invalid device",
+						publicKey: "public-key-a",
+						pinnedFingerprint: fingerprintPublicKey("public-key-b"),
+						suggestedIdentityId: null,
+						trustProvenance: null,
+						claimedLocalActor: false,
+					},
+				],
+			}),
+		);
+
+		expect(result.items).toMatchObject([
+			{ state: "conflicted", conflictCodes: ["fingerprint_invalid"] },
+		]);
+	});
+
+	it("fails closed on a revoked binding in isolation", () => {
+		const result = projectDeviceIdentityInventory(
+			snapshot({
+				bindings: [
+					{
+						deviceId: "device-revoked",
+						displayName: "Revoked device",
+						identityId: "identity-a",
+						status: "revoked",
+						identityStatus: "active",
+					},
+				],
+			}),
+		);
+
+		expect(result.items).toMatchObject([
+			{ state: "conflicted", identityId: null, conflictCodes: ["identity_binding_revoked"] },
+		]);
+	});
+});
+
+describe("device Identity inventory database projection", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+		db.prepare(
+			"INSERT INTO sync_device(device_id, public_key, fingerprint, created_at) VALUES (?, ?, ?, ?)",
+		).run("local-device", "local-key", fingerprintPublicKey("local-key"), NOW);
+		db.prepare(
+			`INSERT INTO sync_peers(peer_device_id, name, actor_id, created_at)
+			 VALUES ('legacy-peer', 'Legacy laptop', 'identity-suggestion', ?)`,
+		).run(NOW);
+	});
+
+	afterEach(() => db.close());
+
+	it("is read-only and does not materialize suggested or coordinator identities", () => {
+		const before = db.prepare("SELECT * FROM identity_devices ORDER BY device_id").all();
+
+		const result = listDeviceIdentityInventory(db, {
+			localDeviceId: "local-device",
+			coordinator: {
+				availability: "available",
+				safeErrorCode: null,
+				enrollments: [
+					enrollment("coordinator-device", "coordinator-key", {
+						identity_id: "coordinator-identity",
+					}),
+				],
+			},
+		});
+
+		expect(result.items.find((item) => item.deviceId === "legacy-peer")).toMatchObject({
+			state: "setup_required",
+			identityId: null,
+			suggestedIdentityId: "identity-suggestion",
+		});
+		expect(db.prepare("SELECT * FROM identity_devices ORDER BY device_id").all()).toEqual(before);
+	});
+
+	it("does not fall back to another local sync_device row", () => {
+		const loaded = loadDeviceIdentityInventorySnapshot(db, {
+			localDeviceId: "missing-local-device",
+			coordinator: { availability: "available", safeErrorCode: null, enrollments: [] },
+		});
+
+		expect(loaded.localDevice).toBeNull();
+	});
+
+	it("keeps coordinator-policy peers pairing_required unless they claim the local actor", () => {
+		const fingerprint = fingerprintPublicKey("policy-key");
+		db.prepare(
+			`UPDATE sync_peers SET public_key = ?, pinned_fingerprint = ?,
+			 trust_provenance = 'coordinator_policy', claimed_local_actor = 0
+			 WHERE peer_device_id = 'legacy-peer'`,
+		).run("policy-key", fingerprint);
+		const input = {
+			localDeviceId: "local-device",
+			coordinator: {
+				availability: "available" as const,
+				safeErrorCode: null,
+				enrollments: [enrollment("legacy-peer", "policy-key")],
+			},
+		};
+
+		expect(
+			listDeviceIdentityInventory(db, input).items.find((item) => item.deviceId === "legacy-peer"),
+		).toMatchObject({ state: "pairing_required" });
+
+		db.prepare(
+			"UPDATE sync_peers SET claimed_local_actor = 1 WHERE peer_device_id = 'legacy-peer'",
+		).run();
+		expect(
+			listDeviceIdentityInventory(db, input).items.find((item) => item.deviceId === "legacy-peer"),
+		).toMatchObject({ state: "setup_required" });
+	});
+
+	it("loads an existing reviewed-invitation binding as configured without rewriting it", () => {
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-a', 'Ada', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		db.prepare(
+			`INSERT INTO identity_devices(
+			 device_id, identity_id, display_name, status, provenance, revision, migration_state,
+			 source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES ('invited-device', 'identity-a', 'Invited laptop', 'active',
+			 'coordinator_enrollment', 'revision-a', 'user_managed', 'source-a', 'key-a', ?, ?)`,
+		).run(NOW, NOW);
+		const before = db.prepare("SELECT * FROM identity_devices").all();
+
+		const result = listDeviceIdentityInventory(db, {
+			localDeviceId: "local-device",
+			coordinator: {
+				availability: "available",
+				safeErrorCode: null,
+				enrollments: [enrollment("invited-device", "invite-key", { identity_id: "identity-a" })],
+			},
+		});
+
+		expect(result.items.find((item) => item.deviceId === "invited-device")).toMatchObject({
+			state: "configured",
+			identityId: "identity-a",
+		});
+		expect(db.prepare("SELECT * FROM identity_devices").all()).toEqual(before);
+	});
+
+	it("retains bindings for local and peer devices when binding evidence is truncated", () => {
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-a', 'Ada', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const insert = db.prepare(
+			`INSERT INTO identity_devices(
+			 device_id, identity_id, display_name, status, provenance, revision, migration_state,
+			 idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'identity-a', ?, 'active', 'user_confirmed_identity_setup',
+			 'revision-a', 'user_managed', ?, ?, ?)`,
+		);
+		db.transaction(() => {
+			for (let index = 0; index < 2_001; index += 1) {
+				const deviceId = `aaa-${String(index).padStart(4, "0")}`;
+				insert.run(deviceId, `ZZZ padding ${index}`, `key-${deviceId}`, NOW, NOW);
+			}
+			insert.run("legacy-peer", "Legacy laptop", "key-legacy", NOW, NOW);
+			insert.run("local-device", "This device", "key-local", NOW, NOW);
+		})();
+
+		const result = listDeviceIdentityInventory(db, {
+			localDeviceId: "local-device",
+			coordinator: { availability: "available", safeErrorCode: null, enrollments: [] },
+		});
+
+		expect(result.truncated).toBe(true);
+		expect(result.items.find((item) => item.deviceId === "legacy-peer")).toMatchObject({
+			state: "configured",
+			identityId: "identity-a",
+		});
+		expect(result.items.find((item) => item.deviceId === "local-device")).toMatchObject({
+			state: "configured",
+			identityId: "identity-a",
+		});
+	});
+});

--- a/packages/core/src/device-identity-inventory.ts
+++ b/packages/core/src/device-identity-inventory.ts
@@ -1,0 +1,428 @@
+import type { CoordinatorEnrollment } from "./coordinator-store-contract.js";
+import type { Database } from "./db.js";
+import { fingerprintPublicKey } from "./sync-fingerprint.js";
+
+export const DEVICE_IDENTITY_INVENTORY_VERSION = 1 as const;
+export const DEVICE_IDENTITY_INVENTORY_LIMIT = 500;
+const DEVICE_IDENTITY_EVIDENCE_LIMIT = 2_000;
+
+export type DeviceIdentityInventoryState =
+	| "configured"
+	| "setup_required"
+	| "pairing_required"
+	| "conflicted";
+
+export type DeviceIdentityInventorySource =
+	| "local_device"
+	| "sync_peer"
+	| "coordinator_enrollment"
+	| "identity_binding";
+
+export interface DeviceIdentityLocalDeviceEvidence {
+	deviceId: string;
+	displayName: string;
+	publicKey: string;
+	fingerprint: string;
+}
+
+export interface DeviceIdentityPeerEvidence {
+	deviceId: string;
+	displayName: string;
+	publicKey: string | null;
+	pinnedFingerprint: string | null;
+	suggestedIdentityId: string | null;
+	trustProvenance: string | null;
+	claimedLocalActor: boolean;
+}
+
+export interface DeviceIdentityBindingEvidence {
+	deviceId: string;
+	displayName: string;
+	identityId: string;
+	status: string;
+	identityStatus: string | null;
+}
+
+export interface DeviceIdentityCoordinatorEvidence {
+	availability: "available" | "unavailable";
+	safeErrorCode: string | null;
+	enrollments: CoordinatorEnrollment[];
+}
+
+export interface DeviceIdentityInventorySnapshot {
+	localDevice: DeviceIdentityLocalDeviceEvidence | null;
+	peers: DeviceIdentityPeerEvidence[];
+	bindings: DeviceIdentityBindingEvidence[];
+	coordinator: DeviceIdentityCoordinatorEvidence;
+	localEvidenceTruncated?: boolean;
+}
+
+export interface DeviceIdentityInventoryInput {
+	localDeviceId: string;
+	localDisplayName?: string;
+	coordinator: DeviceIdentityCoordinatorEvidence;
+}
+
+export interface DeviceIdentityInventoryItemV1 {
+	version: typeof DEVICE_IDENTITY_INVENTORY_VERSION;
+	deviceId: string;
+	evidenceDeviceIds: string[];
+	displayName: string;
+	state: DeviceIdentityInventoryState;
+	identityId: string | null;
+	suggestedIdentityId: string | null;
+	validatedFingerprint: string | null;
+	isLocal: boolean;
+	sources: DeviceIdentityInventorySource[];
+	conflictCodes: string[];
+}
+
+export interface DeviceIdentityInventoryV1 {
+	version: typeof DEVICE_IDENTITY_INVENTORY_VERSION;
+	items: DeviceIdentityInventoryItemV1[];
+	coordinatorEvidence: Pick<DeviceIdentityCoordinatorEvidence, "availability" | "safeErrorCode">;
+	truncated: boolean;
+}
+
+interface Evidence {
+	deviceId: string;
+	displayName: string;
+	source: DeviceIdentityInventorySource;
+	fingerprint: string | null;
+	fingerprintConflict: boolean;
+	isLocal: boolean;
+	suggestedIdentityId: string | null;
+	bindingIdentityId: string | null;
+	bindingStatus: string | null;
+	bindingIdentityStatus: string | null;
+	enrollmentEnabled: boolean | null;
+	pairingProof: boolean;
+}
+
+function clean(value: unknown): string | null {
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function fingerprint(
+	publicKey: string | null,
+	claimed: string | null,
+): {
+	value: string | null;
+	conflict: boolean;
+} {
+	if (!publicKey) return { value: claimed, conflict: false };
+	const derived = fingerprintPublicKey(publicKey);
+	if (claimed && claimed !== derived) return { value: null, conflict: true };
+	return { value: claimed ?? derived, conflict: false };
+}
+
+function localEvidence(value: DeviceIdentityLocalDeviceEvidence): Evidence {
+	const validated = fingerprint(clean(value.publicKey), clean(value.fingerprint));
+	return {
+		deviceId: value.deviceId,
+		displayName: value.displayName,
+		source: "local_device",
+		fingerprint: validated.value,
+		fingerprintConflict: validated.conflict,
+		isLocal: true,
+		suggestedIdentityId: null,
+		bindingIdentityId: null,
+		bindingStatus: null,
+		bindingIdentityStatus: null,
+		enrollmentEnabled: null,
+		pairingProof: true,
+	};
+}
+
+function peerEvidence(value: DeviceIdentityPeerEvidence): Evidence {
+	const validated = fingerprint(clean(value.publicKey), clean(value.pinnedFingerprint));
+	return {
+		deviceId: value.deviceId,
+		displayName: value.displayName,
+		source: "sync_peer",
+		fingerprint: validated.value,
+		fingerprintConflict: validated.conflict,
+		isLocal: false,
+		suggestedIdentityId: clean(value.suggestedIdentityId),
+		bindingIdentityId: null,
+		bindingStatus: null,
+		bindingIdentityStatus: null,
+		enrollmentEnabled: null,
+		pairingProof: clean(value.trustProvenance) !== "coordinator_policy" || value.claimedLocalActor,
+	};
+}
+
+function bindingEvidence(value: DeviceIdentityBindingEvidence): Evidence {
+	return {
+		deviceId: value.deviceId,
+		displayName: value.displayName,
+		source: "identity_binding",
+		fingerprint: null,
+		fingerprintConflict: false,
+		isLocal: false,
+		suggestedIdentityId: null,
+		bindingIdentityId: value.identityId,
+		bindingStatus: value.status,
+		bindingIdentityStatus: value.identityStatus,
+		enrollmentEnabled: null,
+		pairingProof: false,
+	};
+}
+
+function enrollmentEvidence(value: CoordinatorEnrollment): Evidence {
+	const validated = fingerprint(clean(value.public_key), clean(value.fingerprint));
+	return {
+		deviceId: value.device_id,
+		displayName: clean(value.display_name) ?? "Enrolled device",
+		source: "coordinator_enrollment",
+		fingerprint: validated.value,
+		fingerprintConflict: validated.conflict,
+		isLocal: false,
+		suggestedIdentityId: clean(value.identity_id),
+		bindingIdentityId: null,
+		bindingStatus: null,
+		bindingIdentityStatus: null,
+		enrollmentEnabled: value.enabled === 1,
+		pairingProof: false,
+	};
+}
+
+function evidence(snapshot: DeviceIdentityInventorySnapshot): Evidence[] {
+	return [
+		...(snapshot.localDevice ? [localEvidence(snapshot.localDevice)] : []),
+		...snapshot.peers.map(peerEvidence),
+		...snapshot.bindings.map(bindingEvidence),
+		...(snapshot.coordinator.availability === "available"
+			? snapshot.coordinator.enrollments.map(enrollmentEvidence)
+			: []),
+	].filter((item) => clean(item.deviceId) != null);
+}
+
+function groups(items: Evidence[]): Evidence[][] {
+	const parent = items.map((_, index) => index);
+	const root = (index: number): number => {
+		const next = parent[index] ?? index;
+		if (next === index) return index;
+		parent[index] = root(next);
+		return parent[index] ?? index;
+	};
+	const union = (left: number, right: number): void => {
+		const leftRoot = root(left);
+		const rightRoot = root(right);
+		if (leftRoot !== rightRoot) parent[rightRoot] = leftRoot;
+	};
+	const byDeviceId = new Map<string, number>();
+	const byFingerprint = new Map<string, number>();
+	items.forEach((item, index) => {
+		const deviceMatch = byDeviceId.get(item.deviceId);
+		if (deviceMatch == null) byDeviceId.set(item.deviceId, index);
+		else union(index, deviceMatch);
+		if (!item.fingerprint || item.fingerprintConflict) return;
+		const fingerprintMatch = byFingerprint.get(item.fingerprint);
+		if (fingerprintMatch == null) byFingerprint.set(item.fingerprint, index);
+		else union(index, fingerprintMatch);
+	});
+	const grouped = new Map<number, Evidence[]>();
+	items.forEach((item, index) => {
+		const key = root(index);
+		grouped.set(key, [...(grouped.get(key) ?? []), item]);
+	});
+	return [...grouped.values()];
+}
+
+const SOURCE_ORDER: DeviceIdentityInventorySource[] = [
+	"local_device",
+	"identity_binding",
+	"sync_peer",
+	"coordinator_enrollment",
+];
+
+function preferred(group: Evidence[], source: DeviceIdentityInventorySource): Evidence | null {
+	return group.find((item) => item.source === source) ?? null;
+}
+
+function projectGroup(group: Evidence[]): DeviceIdentityInventoryItemV1 {
+	const deviceIds = [...new Set(group.map((item) => item.deviceId))].toSorted();
+	const fingerprints = new Set(
+		group.flatMap((item) =>
+			item.fingerprint && !item.fingerprintConflict ? [item.fingerprint] : [],
+		),
+	);
+	const activeBindings = group.filter(
+		(item) => item.source === "identity_binding" && item.bindingStatus === "active",
+	);
+	const bindingIdentityIds = new Set(
+		activeBindings.flatMap((item) => (item.bindingIdentityId ? [item.bindingIdentityId] : [])),
+	);
+	const suggestedIdentityIds = new Set(
+		group.flatMap((item) => (item.suggestedIdentityId ? [item.suggestedIdentityId] : [])),
+	);
+	const conflictCodes = [
+		group.some((item) => item.fingerprintConflict) ? "fingerprint_invalid" : null,
+		fingerprints.size > 1 ? "fingerprint_conflict" : null,
+		bindingIdentityIds.size > 1 ? "identity_binding_conflict" : null,
+		group.some(
+			(item) =>
+				item.source === "identity_binding" &&
+				item.bindingStatus === "active" &&
+				item.bindingIdentityStatus !== "active",
+		)
+			? "identity_inactive"
+			: null,
+		group.some((item) => item.source === "identity_binding" && item.bindingStatus !== "active")
+			? "identity_binding_revoked"
+			: null,
+		group.some(
+			(item) => item.source === "coordinator_enrollment" && item.enrollmentEnabled === false,
+		)
+			? "coordinator_enrollment_disabled"
+			: null,
+	].filter((code): code is string => code != null);
+	const hasPairingProof = group.some((item) => item.pairingProof);
+	const hasCoordinatorEvidence = group.some(
+		(item) =>
+			item.source === "coordinator_enrollment" ||
+			(item.source === "sync_peer" && !item.pairingProof),
+	);
+	const state: DeviceIdentityInventoryState =
+		conflictCodes.length > 0
+			? "conflicted"
+			: activeBindings.length > 0
+				? "configured"
+				: hasCoordinatorEvidence && !hasPairingProof
+					? "pairing_required"
+					: "setup_required";
+	const selected = SOURCE_ORDER.map((source) => preferred(group, source)).find(
+		(item): item is Evidence => item != null,
+	);
+	const sources = SOURCE_ORDER.filter((source) => group.some((item) => item.source === source));
+	return {
+		version: DEVICE_IDENTITY_INVENTORY_VERSION,
+		deviceId: selected?.deviceId ?? deviceIds[0] ?? "",
+		evidenceDeviceIds: deviceIds,
+		displayName: selected?.displayName || "Device",
+		state,
+		identityId:
+			state === "configured" && bindingIdentityIds.size === 1
+				? ([...bindingIdentityIds][0] ?? null)
+				: null,
+		suggestedIdentityId:
+			activeBindings.length === 0 && suggestedIdentityIds.size === 1
+				? ([...suggestedIdentityIds][0] ?? null)
+				: null,
+		validatedFingerprint: fingerprints.size === 1 ? ([...fingerprints][0] ?? null) : null,
+		isLocal: group.some((item) => item.isLocal),
+		sources,
+		conflictCodes: [...new Set(conflictCodes)].toSorted(),
+	};
+}
+
+export function projectDeviceIdentityInventory(
+	snapshot: DeviceIdentityInventorySnapshot,
+	options: { limit?: number } = {},
+): DeviceIdentityInventoryV1 {
+	const limit = Math.max(1, Math.min(options.limit ?? DEVICE_IDENTITY_INVENTORY_LIMIT, 2_000));
+	const projected = groups(evidence(snapshot))
+		.map(projectGroup)
+		.toSorted(
+			(left, right) =>
+				Number(right.isLocal) - Number(left.isLocal) ||
+				left.displayName.localeCompare(right.displayName) ||
+				left.deviceId.localeCompare(right.deviceId),
+		);
+	return {
+		version: DEVICE_IDENTITY_INVENTORY_VERSION,
+		items: projected.slice(0, limit),
+		coordinatorEvidence: {
+			availability: snapshot.coordinator.availability,
+			safeErrorCode: snapshot.coordinator.safeErrorCode,
+		},
+		truncated: snapshot.localEvidenceTruncated === true || projected.length > limit,
+	};
+}
+
+export function loadDeviceIdentityInventorySnapshot(
+	db: Database,
+	input: DeviceIdentityInventoryInput,
+): DeviceIdentityInventorySnapshot {
+	const localRow = db
+		.prepare(
+			`SELECT device_id, public_key, fingerprint FROM sync_device
+			 WHERE device_id = ? LIMIT 1`,
+		)
+		.get(input.localDeviceId) as
+		| { device_id: string; public_key: string; fingerprint: string }
+		| undefined;
+	const peerRows = db
+		.prepare(
+			`SELECT peer_device_id, name, public_key, pinned_fingerprint, actor_id,
+			 trust_provenance, claimed_local_actor
+			 FROM sync_peers ORDER BY peer_device_id LIMIT ?`,
+		)
+		.all(DEVICE_IDENTITY_EVIDENCE_LIMIT + 1);
+	const peers = peerRows
+		.slice(0, DEVICE_IDENTITY_EVIDENCE_LIMIT)
+		.map((row): DeviceIdentityPeerEvidence => {
+			const value = row as Record<string, unknown>;
+			return {
+				deviceId: String(value.peer_device_id ?? ""),
+				displayName: clean(value.name) ?? "Peer device",
+				publicKey: clean(value.public_key),
+				pinnedFingerprint: clean(value.pinned_fingerprint),
+				suggestedIdentityId: clean(value.actor_id),
+				trustProvenance: clean(value.trust_provenance),
+				claimedLocalActor: value.claimed_local_actor === 1,
+			};
+		});
+	const bindingRows = db
+		.prepare(
+			`SELECT device.device_id, device.display_name, device.identity_id, device.status,
+			 actor.status AS identity_status
+			 FROM identity_devices device
+			 LEFT JOIN actors actor ON actor.actor_id = device.identity_id
+			 ORDER BY CASE
+			  WHEN device.device_id = ? THEN 0
+			  WHEN device.device_id IN (
+			   SELECT peer_device_id FROM sync_peers ORDER BY peer_device_id LIMIT ?
+			  ) THEN 1
+			  ELSE 2
+			 END, device.device_id LIMIT ?`,
+		)
+		.all(input.localDeviceId, DEVICE_IDENTITY_EVIDENCE_LIMIT, DEVICE_IDENTITY_EVIDENCE_LIMIT + 2);
+	const bindings = bindingRows
+		.slice(0, DEVICE_IDENTITY_EVIDENCE_LIMIT + 1)
+		.map((row): DeviceIdentityBindingEvidence => {
+			const value = row as Record<string, unknown>;
+			return {
+				deviceId: String(value.device_id ?? ""),
+				displayName: clean(value.display_name) ?? "Registered device",
+				identityId: String(value.identity_id ?? ""),
+				status: String(value.status ?? ""),
+				identityStatus: clean(value.identity_status),
+			};
+		});
+	return {
+		localDevice: localRow
+			? {
+					deviceId: localRow.device_id,
+					displayName: clean(input.localDisplayName) ?? "This device",
+					publicKey: localRow.public_key,
+					fingerprint: localRow.fingerprint,
+				}
+			: null,
+		peers,
+		bindings,
+		coordinator: input.coordinator,
+		localEvidenceTruncated:
+			peerRows.length > DEVICE_IDENTITY_EVIDENCE_LIMIT ||
+			bindingRows.length > DEVICE_IDENTITY_EVIDENCE_LIMIT + 1,
+	};
+}
+
+export function listDeviceIdentityInventory(
+	db: Database,
+	input: DeviceIdentityInventoryInput,
+	options: { limit?: number } = {},
+): DeviceIdentityInventoryV1 {
+	return projectDeviceIdentityInventory(loadDeviceIdentityInventorySnapshot(db, input), options);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -185,6 +185,25 @@ export {
 	runDedupKeyBackfillPass,
 } from "./dedup-key-backfill.js";
 export type {
+	DeviceIdentityBindingEvidence,
+	DeviceIdentityCoordinatorEvidence,
+	DeviceIdentityInventoryInput,
+	DeviceIdentityInventoryItemV1,
+	DeviceIdentityInventorySnapshot,
+	DeviceIdentityInventorySource,
+	DeviceIdentityInventoryState,
+	DeviceIdentityInventoryV1,
+	DeviceIdentityLocalDeviceEvidence,
+	DeviceIdentityPeerEvidence,
+} from "./device-identity-inventory.js";
+export {
+	DEVICE_IDENTITY_INVENTORY_LIMIT,
+	DEVICE_IDENTITY_INVENTORY_VERSION,
+	listDeviceIdentityInventory,
+	loadDeviceIdentityInventorySnapshot,
+	projectDeviceIdentityInventory,
+} from "./device-identity-inventory.js";
+export type {
 	ArtifactKind,
 	ContextFactFeature,
 	DistillCandidate,

--- a/packages/core/src/sync-http-client.test.ts
+++ b/packages/core/src/sync-http-client.test.ts
@@ -122,4 +122,33 @@ describe("requestJson", () => {
 		const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
 		expect(call[1].headers.Authorization).toBe("Bearer tok");
 	});
+
+	it("rejects a declared response larger than the configured limit", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response("{}", {
+				status: 200,
+				headers: { "content-length": "100" },
+			}),
+		);
+
+		await expect(
+			requestJson("GET", "http://localhost:8080/info", { maxResponseBytes: 10 }),
+		).resolves.toEqual([200, { error: "response_too_large" }]);
+	});
+
+	it("stops reading a streamed response after the configured limit", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(new Response("123456", { status: 200 }));
+
+		await expect(
+			requestJson("GET", "http://localhost:8080/info", { maxResponseBytes: 5 }),
+		).resolves.toEqual([200, { error: "response_too_large" }]);
+	});
+
+	it("accepts a response exactly at the configured limit", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+
+		await expect(
+			requestJson("GET", "http://localhost:8080/info", { maxResponseBytes: 2 }),
+		).resolves.toEqual([200, {}]);
+	});
 });

--- a/packages/core/src/sync-http-client.ts
+++ b/packages/core/src/sync-http-client.ts
@@ -51,6 +51,7 @@ export interface RequestJsonOptions {
 	body?: Record<string, unknown>;
 	bodyBytes?: Uint8Array;
 	timeoutS?: number;
+	maxResponseBytes?: number;
 }
 
 /**
@@ -90,7 +91,35 @@ export async function requestJson(
 		signal: AbortSignal.timeout(timeoutS * 1000),
 	});
 
-	const raw = await response.text();
+	let raw: string;
+	if (options.maxResponseBytes != null && response.body) {
+		const declaredLength = Number(response.headers.get("content-length"));
+		if (Number.isFinite(declaredLength) && declaredLength > options.maxResponseBytes) {
+			await response.body.cancel();
+			return [response.status, { error: "response_too_large" }];
+		}
+		const reader = response.body.getReader();
+		const decoder = new TextDecoder();
+		let totalBytes = 0;
+		raw = "";
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				totalBytes += value.byteLength;
+				if (totalBytes > options.maxResponseBytes) {
+					await reader.cancel();
+					return [response.status, { error: "response_too_large" }];
+				}
+				raw += decoder.decode(value, { stream: true });
+			}
+			raw += decoder.decode();
+		} finally {
+			reader.releaseLock();
+		}
+	} else {
+		raw = await response.text();
+	}
 	if (!raw) return [response.status, null];
 
 	let payload: unknown;

--- a/packages/viewer-server/src/device-identity-inventory.test.ts
+++ b/packages/viewer-server/src/device-identity-inventory.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	ensureDeviceIdentity,
+	fingerprintPublicKey,
+	initTestSchema,
+	MemoryStore,
+} from "@codemem/core";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { createApp } from "./index.js";
+
+function testStore(): { store: MemoryStore; cleanup: () => void } {
+	const directory = mkdtempSync(join(tmpdir(), "codemem-device-inventory-test-"));
+	const dbPath = join(directory, "test.sqlite");
+	const keysDir = join(directory, "keys");
+	const db = new Database(dbPath);
+	initTestSchema(db);
+	ensureDeviceIdentity(db, { deviceId: "local-device", keysDir });
+	db.close();
+	const store = new MemoryStore(dbPath);
+	return {
+		store,
+		cleanup: () => {
+			store.close();
+			rmSync(directory, { recursive: true, force: true });
+		},
+	};
+}
+
+describe("GET /api/sync/recipient-policy/v1/device-inventory", () => {
+	it("returns injected coordinator evidence without materializing identity bindings", async () => {
+		const fixture = testStore();
+		try {
+			const before = fixture.store.db.prepare("SELECT * FROM identity_devices").all();
+			const app = createApp({
+				storeFactory: () => fixture.store,
+				loadDeviceIdentityCoordinatorEvidence: async () => ({
+					availability: "available",
+					safeErrorCode: null,
+					enrollments: [
+						{
+							group_id: "group-a",
+							device_id: "legacy-device",
+							public_key: "legacy-key",
+							fingerprint: fingerprintPublicKey("legacy-key"),
+							identity_id: "unreviewed-identity",
+							display_name: "Legacy laptop",
+							enabled: 1,
+							created_at: "2026-08-18T12:00:00.000Z",
+						},
+					],
+				}),
+			});
+
+			const response = await app.request("/api/sync/recipient-policy/v1/device-inventory");
+			const body = (await response.json()) as Record<string, unknown>;
+
+			expect(response.status).toBe(200);
+			expect(body).toMatchObject({
+				version: 1,
+				coordinatorEvidence: { availability: "available", safeErrorCode: null },
+				truncated: false,
+			});
+			expect(body.items).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						deviceId: "legacy-device",
+						state: "pairing_required",
+						identityId: null,
+					}),
+				]),
+			);
+			expect(fixture.store.db.prepare("SELECT * FROM identity_devices").all()).toEqual(before);
+		} finally {
+			fixture.cleanup();
+		}
+	});
+
+	it("keeps the local inventory available when coordinator evidence fails", async () => {
+		const fixture = testStore();
+		try {
+			const app = createApp({
+				storeFactory: () => fixture.store,
+				loadDeviceIdentityCoordinatorEvidence: async () => {
+					throw new Error("sensitive coordinator failure");
+				},
+			});
+
+			const response = await app.request("/api/sync/recipient-policy/v1/device-inventory");
+			const body = (await response.json()) as {
+				coordinatorEvidence: Record<string, unknown>;
+				items: Array<Record<string, unknown>>;
+			};
+			const serialized = JSON.stringify(body);
+
+			expect(response.status).toBe(200);
+			expect(body.coordinatorEvidence).toEqual({
+				availability: "unavailable",
+				safeErrorCode: "coordinator_unavailable",
+			});
+			expect(serialized).not.toContain("sensitive coordinator failure");
+			expect(body.items).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ deviceId: "local-device", state: "setup_required" }),
+				]),
+			);
+		} finally {
+			fixture.cleanup();
+		}
+	});
+});

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -10,7 +10,12 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { GetUpdateStatusOptions, ObserverClient, UpdateStatus } from "@codemem/core";
+import type {
+	DeviceIdentityCoordinatorEvidence,
+	GetUpdateStatusOptions,
+	ObserverClient,
+	UpdateStatus,
+} from "@codemem/core";
 import { MemoryStore, type RawEventSweeper, resolveDbPath, VERSION } from "@codemem/core";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
@@ -75,6 +80,7 @@ export interface AppOptions {
 	sweeper?: RawEventSweeper | null;
 	observer?: ObserverClient | null;
 	getUpdateStatus?: (options: GetUpdateStatusOptions) => Promise<UpdateStatus>;
+	loadDeviceIdentityCoordinatorEvidence?: () => Promise<DeviceIdentityCoordinatorEvidence>;
 	syncRequestRateLimit?: {
 		limiter?: InMemoryRequestRateLimiter;
 		readLimit?: number;
@@ -122,7 +128,12 @@ export function createApp(opts?: AppOptions) {
 	);
 	app.route("/", configRoutes({ getSweeper: () => sweeper }));
 	app.route("/", rawEventsRoutes(storeFactory, sweeper));
-	app.route("/", syncRoutes(storeFactory, getSyncRuntimeStatus));
+	app.route(
+		"/",
+		syncRoutes(storeFactory, getSyncRuntimeStatus, {
+			loadDeviceIdentityCoordinatorEvidence: opts?.loadDeviceIdentityCoordinatorEvidence,
+		}),
+	);
 	app.route("/", updateStatusRoutes({ getUpdateStatus: opts?.getUpdateStatus }));
 
 	// Static assets — serve under /assets/*

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -13,6 +13,7 @@ import type {
 	CoordinatorEnrollmentReconcileResult,
 	CoordinatorScope,
 	CoordinatorScopeMembership,
+	DeviceIdentityCoordinatorEvidence,
 	MaintenanceJobSnapshot,
 	MemoryStore,
 	ProjectScopeGuardrailWarning,
@@ -100,6 +101,7 @@ import {
 	LOCAL_SYNC_FEATURES,
 	listAuthorizedScopesForPeer,
 	listCoordinatorJoinRequests,
+	listDeviceIdentityInventory,
 	listInboundScopeRejections,
 	listLegacyRecipientPolicyProjections,
 	listMaintenanceJobs,
@@ -172,6 +174,8 @@ import { queryBool, queryInt, safeJsonList } from "../helpers.js";
 import type { InMemoryRequestRateLimiter } from "../request-rate-limit.js";
 
 type StoreFactory = () => MemoryStore;
+export type DeviceIdentityCoordinatorEvidenceLoader =
+	() => Promise<DeviceIdentityCoordinatorEvidence>;
 type SyncRuntimeStatus = {
 	phase:
 		| "starting"
@@ -4689,6 +4693,57 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 	return app;
 }
 
+async function loadConfiguredDeviceIdentityCoordinatorEvidence(): Promise<DeviceIdentityCoordinatorEvidence> {
+	const config = readCoordinatorSyncConfig();
+	const remoteUrl = config.syncCoordinatorUrl.trim();
+	const adminSecret = config.syncCoordinatorAdminSecret.trim();
+	const groupIds = [
+		...new Set(config.syncCoordinatorGroups.map((groupId) => groupId.trim())),
+	].filter(Boolean);
+	if (!remoteUrl || !adminSecret || groupIds.length === 0) {
+		return {
+			availability: "unavailable",
+			safeErrorCode: "coordinator_not_configured",
+			enrollments: [],
+		};
+	}
+	if (groupIds.length > 25) {
+		return {
+			availability: "unavailable",
+			safeErrorCode: "coordinator_evidence_too_large",
+			enrollments: [],
+		};
+	}
+	try {
+		const enrollments = (
+			await Promise.all(
+				groupIds.map((groupId) =>
+					coordinatorListDevicesAction({
+						groupId,
+						includeDisabled: true,
+						remoteUrl,
+						adminSecret,
+					}),
+				),
+			)
+		).flat();
+		if (enrollments.length > 500) {
+			return {
+				availability: "unavailable",
+				safeErrorCode: "coordinator_evidence_too_large",
+				enrollments: [],
+			};
+		}
+		return { availability: "available", safeErrorCode: null, enrollments };
+	} catch {
+		return {
+			availability: "unavailable",
+			safeErrorCode: "coordinator_unavailable",
+			enrollments: [],
+		};
+	}
+}
+
 /**
  * Viewer-facing sync management routes (/api/sync/*).
  *
@@ -4699,8 +4754,43 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 export function syncRoutes(
 	getStore: StoreFactory,
 	getSyncRuntimeStatus?: () => SyncRuntimeStatus | null,
+	options: { loadDeviceIdentityCoordinatorEvidence?: DeviceIdentityCoordinatorEvidenceLoader } = {},
 ) {
 	const app = new Hono();
+	const loadCoordinatorEvidence =
+		options.loadDeviceIdentityCoordinatorEvidence ??
+		loadConfiguredDeviceIdentityCoordinatorEvidence;
+
+	app.get("/api/sync/recipient-policy/v1/device-inventory", async (c) => {
+		const store = getStore();
+		let coordinator: DeviceIdentityCoordinatorEvidence;
+		try {
+			coordinator = await loadCoordinatorEvidence();
+		} catch {
+			coordinator = {
+				availability: "unavailable",
+				safeErrorCode: "coordinator_unavailable",
+				enrollments: [],
+			};
+		}
+		let explicitDeviceName = "";
+		try {
+			explicitDeviceName = String(readCodememConfigFile().sync_device_name ?? "");
+		} catch {
+			explicitDeviceName = "";
+		}
+		return c.json(
+			listDeviceIdentityInventory(store.db, {
+				localDeviceId: store.deviceId,
+				localDisplayName: friendlyDeviceName({
+					explicitName: explicitDeviceName,
+					osName: hostname(),
+					fallbackSeed: store.deviceId,
+				}),
+				coordinator,
+			}),
+		);
+	});
 
 	// GET /api/sync/status
 	app.get("/api/sync/status", async (c) => {


### PR DESCRIPTION
## Description

Add a versioned, bounded device Identity inventory that distinguishes configured, setup-required, pairing-required, and conflicted states without inferring ownership from pairing, coordinator groups, names, addresses, or `sync_peers.actor_id`. Expose the projection through the viewer API with safe coordinator evidence handling.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced