### PR TITLE
feat(viewer): unify device identity setup

### DIFF
--- a/docs/design/device-row-anatomy.md
+++ b/docs/design/device-row-anatomy.md
@@ -29,9 +29,9 @@ drawer, use a plain `.peer-card` instead.
   │  No addresses                                           │
   │  Sync: 2:31PM · Ping: 2:31PM                            │
   │                                                         │
-  │  Who this device belongs to                             │
-  │  This device belongs to you.                            │
-  │  [You ▾]  [Save assignment]                             │
+   │  Authoritative Identity ownership                       │
+   │  Authoritative Identity: You.                           │
+   │  [Review or rebind in Devices]                          │
   │                                                         │
   │  Advanced sharing scope ▸                               │
   └─────────────────────────────────────────────────────────┘
@@ -50,6 +50,11 @@ Left to right in the compact row:
    review", etc. Each uses `.badge` styling.
 6. **Meta** — T5 (12px / 400 / text-tertiary). Sync timestamp.
 7. **Chevron** — ▸ collapsed / ▾ expanded. Decorative (aria-hidden).
+
+The ownership region is read-only in Advanced. It reports active
+`identity_devices` bindings as authoritative and may show
+`sync_peers.actor_id` only as a suggestion. Setup and rebind actions hand off
+to Devices; pairing and Advanced sharing-scope controls remain separate.
 
 Row height: **56px minimum** (hits the 44px touch target with 10px
 top/bottom padding).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -260,7 +260,7 @@ For several setup-ready devices, select each device, choose an Identity for each
 
 Changing a configured device's Identity is a separate rebind flow. It shows both the previous and target Identities and requires another reviewed confirmation. If device evidence changes after preview, refresh Devices and review the current information before retrying.
 
-The **Sharing** tab shows an attention notice while device setup, pairing, or repair remains. **Review Devices** focuses this workflow. Identity setup records ownership only: it does not grant Projects, add Team membership, change recipient policy, or enable sync access. When no policy Teams exist, Sharing opens the Identities view rather than implying that coordinator groups are Teams.
+The **Sharing** tab shows an attention notice while device setup, pairing, repair, or coordinator enrollment reconciliation remains. **Review Devices** focuses the authoritative ownership workflow. Devices and Sharing show only a safe affected-enrollment count. Identity setup records ownership only: it does not grant Projects, add Team membership, change recipient policy, or enable sync access. When no policy Teams exist, Sharing opens the Identities view rather than implying that coordinator groups are Teams.
 
 **Availability** tells you whether the device can currently receive work. It does not change ownership or Project access:
 
@@ -367,17 +367,17 @@ codemem maintenance status
 
 ### Same-person device recovery
 
-- In **Advanced → Sync**, use `Assigned actor` to map a peer to your local actor when that machine should count as part of your identity.
-- Actor assignment preserves provenance and same-person UI continuity. Private sync still requires membership in a personal Sharing domain; actor assignment is not an access grant.
+- In **Advanced → Sync**, ownership summaries come from active `identity_devices` bindings. Use the device card's **Set up Identity in Devices** or **Review or rebind in Devices** action to confirm or change ownership.
+- A legacy `sync_peers.actor_id` value may appear as a suggested Identity, but it is only a hint. It does not become ownership until you explicitly review and confirm the binding in Devices.
+- Identity setup preserves the distinction between ownership, provenance, pairing, and access. Private sync still requires membership in a personal Sharing domain; an Identity binding is not an access grant.
 - If a machine is replaced or re-paired, use `Claim old device as mine` to reconnect older synced history to your local actor.
 
 ### Advanced actor management
 
 - The Sync panel now has an `Actors` section for creating and renaming non-local actors.
-- The same section can merge a duplicate actor into another actor; this immediately moves assigned peers, while already-stamped historical memories keep their current provenance until a later follow-on flow changes them.
-- Assign each paired peer below to `Unassigned actor`, your local actor, or a named actor.
-- Assigning a peer changes how older synced memories from that peer are attributed.
-- Assigning a peer to a non-local actor keeps that peer's history attributed to that actor; assigning it to your local actor keeps provenance tied to you.
+- The same section can merge a duplicate actor into another actor. This immediately moves assigned peers, device bindings, Team memberships, and direct or received Project access to the target Identity, while already-stamped historical memories keep their current provenance until a later follow-on flow changes them.
+- Historical actor records and `sync_peers.actor_id` remain available to explain provenance and supply setup suggestions. They do not establish device ownership.
+- Create or rename an actor label here when maintaining legacy provenance, then complete any device ownership choice in Devices.
 - Non-local peers receive memories only after Sharing-domain authorization succeeds. Their include/exclude filters can narrow that set, but cannot grant access.
 - Use `Only me` on a memory when it should stay local and not sync to non-local actors.
 - The Sync panel also shows a teammate review card with per-peer counts for memories that will share by default versus memories marked `Only me`, plus a one-click jump into `My memories` in the Feed for review.
@@ -509,8 +509,8 @@ The wire error is intentionally generic. Check the peer serving the bootstrap sn
 - For non-local peers, Sharing-domain membership is the access boundary. Project and per-peer sync filters narrow the eligible set, and `Only me` acts as a per-memory override.
 
 ## Advanced Sync panel
-- The `Actors` section gives actor creation/rename one home, while peer cards keep assignment close to the peer being changed.
-- `Assigned actor` replaces the older `Belongs to me` language in the peer cards.
+- The `Actors` section keeps legacy provenance-label creation and rename controls in one place.
+- Peer cards show authoritative Identity ownership from Devices. Legacy actor values remain suggestions or provenance and cannot be saved as ownership from Advanced.
 - Feed cards you own include a visibility control so shared/private intent can be changed without editing raw metadata.
 - `Redact sensitive details` lives above Recent sync attempts so it is easier to find before you inspect peer addresses and attempt history.
 - Recent sync attempts intentionally show only the latest few rows in the viewer; use CLI diagnostics for deeper history if needed.

--- a/e2e/scenarios/project-sharing.ts
+++ b/e2e/scenarios/project-sharing.ts
@@ -46,6 +46,7 @@ interface FixtureSummary {
 			attempt_count: number;
 		}>;
 		team_memberships: Array<{ team_id: string; identity_id: string; status: string }>;
+		teams: Array<{ team_id: string; display_name: string; status: string }>;
 		identity_devices: Array<{
 			identity_id: string;
 			device_id: string;
@@ -69,6 +70,24 @@ interface FixtureSummary {
 		}>;
 	};
 	action_result?: Record<string, unknown> | null;
+}
+
+interface DeviceIdentityInventory {
+	truncated: boolean;
+	items: Array<{
+		deviceId: string;
+		state: "configured" | "setup_required" | "pairing_required" | "conflicted";
+		identityId: string | null;
+		suggestedIdentityId: string | null;
+	}>;
+}
+
+interface DeviceIdentityBindingResult {
+	status: string;
+	reviewedInventoryDigest: string;
+	writeCount: number;
+	idempotent?: boolean;
+	errorCode?: string | null;
 }
 
 interface RecipientPolicyIntentGraph {
@@ -1447,6 +1466,253 @@ export async function runProjectSharingScenario(ctx: ScenarioContext): Promise<v
 				item.explanation.includes("Legacy scope enforcement remains in control"),
 		),
 		"rollback was not visible through the safe reconciliation API",
+	);
+
+	// Arrange: seed legacy peers whose actor_id values are suggestions, including stale and conflicting evidence.
+	const legacyBefore = fixture(ctx, "peer-a", "summary", "54-legacy-device-identity-before");
+	fixture(ctx, "peer-a", "seed-legacy-device-identities", "55-seed-legacy-device-identities");
+	const legacyInventoryBefore = await request<DeviceIdentityInventory>(
+		ctx,
+		"peer-a",
+		"/api/sync/recipient-policy/v1/device-inventory",
+		"56-legacy-device-inventory-before",
+	);
+	const legacyAdvancedBefore = await request<{
+		peers: Array<{ peer_device_id: string; actor_id: string | null }>;
+	}>(ctx, "peer-a", "/api/sync/status", "57-legacy-advanced-before");
+	const legacySharingBefore = await request<{
+		identityDevices: Array<{ identityId: string; deviceId: string; status: string }>;
+	}>(ctx, "peer-a", "/api/sync/recipient-policy/v1/intent", "58-legacy-sharing-before");
+	for (const deviceId of ["legacy-device-valid-a", "legacy-device-valid-b", "legacy-device-stale"]) {
+		const item = legacyInventoryBefore.body.items.find((candidate) => candidate.deviceId === deviceId);
+		assert(
+			item?.state === "setup_required" &&
+				item.identityId === null &&
+				item.suggestedIdentityId === "identity-direct-personal",
+			`${deviceId} actor_id was not kept as an unconfirmed suggestion`,
+		);
+		assert(
+			!legacySharingBefore.body.identityDevices.some((device) => device.deviceId === deviceId),
+			`${deviceId} actor_id materialized an Identity binding before review`,
+		);
+		assert(
+			legacyAdvancedBefore.body.peers.some(
+				(peer) => peer.peer_device_id === deviceId && peer.actor_id === "identity-direct-personal",
+			),
+			`${deviceId} legacy Advanced provenance hint disappeared`,
+		);
+	}
+	const conflictItem = legacyInventoryBefore.body.items.find(
+		(item) => item.deviceId === "legacy-device-conflict",
+	);
+	assert(conflictItem?.state === "conflicted", "conflicting legacy evidence did not fail closed");
+
+	// Act: review and atomically commit two authoritative bindings through the viewer API.
+	const bindingSelections = ["legacy-device-valid-a", "legacy-device-valid-b"].map((deviceId) => ({
+		deviceId,
+		targetIdentityId: "identity-direct-personal",
+		confirmed: true,
+	}));
+	const legacyPreview = await request<DeviceIdentityBindingResult>(
+		ctx,
+		"peer-a",
+		"/api/sync/recipient-policy/v1/device-bindings/preview",
+		"59-preview-legacy-device-bindings",
+		{ bindings: bindingSelections },
+	);
+	assert(legacyPreview.status === 200 && legacyPreview.body.status === "ready", "legacy binding preview failed");
+	const legacyCommitBody = {
+		bindings: bindingSelections,
+		reviewedInventoryDigest: legacyPreview.body.reviewedInventoryDigest,
+	};
+	const legacyCommit = await request<DeviceIdentityBindingResult>(
+		ctx,
+		"peer-a",
+		"/api/sync/recipient-policy/v1/device-bindings/commit",
+		"60-commit-legacy-device-bindings",
+		legacyCommitBody,
+	);
+	assert(
+		legacyCommit.status === 200 &&
+			legacyCommit.body.status === "applied" &&
+			legacyCommit.body.writeCount === 2,
+		"reviewed legacy device bindings were not committed atomically",
+	);
+	const legacyRetry = await request<DeviceIdentityBindingResult>(
+		ctx,
+		"peer-a",
+		"/api/sync/recipient-policy/v1/device-bindings/commit",
+		"61-retry-legacy-device-bindings",
+		legacyCommitBody,
+	);
+	assert(
+		legacyRetry.status === 200 &&
+			legacyRetry.body.status === "applied" &&
+			legacyRetry.body.writeCount === 0 &&
+			legacyRetry.body.idempotent === true,
+		"legacy device binding retry was not idempotent",
+	);
+
+	// Assert: Devices, Sharing, and Advanced refresh consistently without mutating access policy.
+	const legacyInventoryAfter = await request<DeviceIdentityInventory>(
+		ctx,
+		"peer-a",
+		"/api/sync/recipient-policy/v1/device-inventory",
+		"62-legacy-device-inventory-after",
+	);
+	const legacySharingAfter = await request<{
+		identityDevices: Array<{ identityId: string; deviceId: string; status: string }>;
+	}>(ctx, "peer-a", "/api/sync/recipient-policy/v1/intent", "63-legacy-sharing-after");
+	const legacyAdvancedAfter = await request<{
+		peers: Array<{ peer_device_id: string; actor_id: string | null }>;
+	}>(ctx, "peer-a", "/api/sync/status", "64-legacy-advanced-after");
+	for (const deviceId of ["legacy-device-valid-a", "legacy-device-valid-b"]) {
+		assert(
+			legacyInventoryAfter.body.items.some(
+				(item) =>
+					item.deviceId === deviceId &&
+					item.state === "configured" &&
+					item.identityId === "identity-direct-personal",
+			),
+			`${deviceId} was not configured after refresh`,
+		);
+		assert(
+			legacySharingAfter.body.identityDevices.some(
+				(device) =>
+					device.deviceId === deviceId &&
+					device.identityId === "identity-direct-personal" &&
+					device.status === "active",
+			),
+			`${deviceId} authoritative binding was missing from Sharing refresh`,
+		);
+		assert(
+			legacyAdvancedAfter.body.peers.some(
+				(peer) => peer.peer_device_id === deviceId && peer.actor_id === "identity-direct-personal",
+			),
+			`${deviceId} disappeared from Advanced refresh`,
+		);
+	}
+	const legacyAfter = fixture(ctx, "peer-a", "summary", "65-legacy-device-identity-after");
+	const previousBindingsAfter = legacyAfter.policy.identity_devices.filter(
+		(device) => !device.device_id.startsWith("legacy-device-valid-"),
+	);
+	assert(
+		JSON.stringify(previousBindingsAfter) === JSON.stringify(legacyBefore.policy.identity_devices),
+		"legacy setup changed an existing invitation or policy Identity binding",
+	);
+	for (const [label, before, after] of [
+		["Teams", legacyBefore.policy.teams, legacyAfter.policy.teams],
+		["Team memberships", legacyBefore.policy.team_memberships, legacyAfter.policy.team_memberships],
+		["Project recipients", legacyBefore.policy.project_recipients, legacyAfter.policy.project_recipients],
+		["managed scope grants", legacyBefore.managed_memberships, legacyAfter.managed_memberships],
+		["source scope grants", legacyBefore.source_memberships, legacyAfter.source_memberships],
+	] as const) {
+		assert(JSON.stringify(after) === JSON.stringify(before), `legacy setup changed ${label}`);
+	}
+
+	// Arrange/Act/Assert: changed evidence stales review, while conflicting evidence cannot be previewed.
+	const staleSelection = {
+		deviceId: "legacy-device-stale",
+		targetIdentityId: "identity-direct-personal",
+		confirmed: true,
+	};
+	const staleLegacyPreview = await request<DeviceIdentityBindingResult>(
+		ctx,
+		"peer-a",
+		"/api/sync/recipient-policy/v1/device-bindings/preview",
+		"66-preview-stale-legacy-device",
+		{ bindings: [staleSelection] },
+	);
+	assert(staleLegacyPreview.status === 200, "stale legacy fixture could not be previewed");
+	fixture(ctx, "peer-a", "stale-legacy-device-evidence", "67-change-legacy-device-evidence");
+	const staleLegacyCommit = await request<DeviceIdentityBindingResult>(
+		ctx,
+		"peer-a",
+		"/api/sync/recipient-policy/v1/device-bindings/commit",
+		"68-reject-stale-legacy-device",
+		{
+			bindings: [staleSelection],
+			reviewedInventoryDigest: staleLegacyPreview.body.reviewedInventoryDigest,
+		},
+	);
+	assert(
+		staleLegacyCommit.status === 409 &&
+			staleLegacyCommit.body.status === "stale" &&
+			staleLegacyCommit.body.writeCount === 0,
+		"stale legacy device evidence did not fail closed",
+	);
+	const conflictLegacyPreview = await request<DeviceIdentityBindingResult>(
+		ctx,
+		"peer-a",
+		"/api/sync/recipient-policy/v1/device-bindings/preview",
+		"69-reject-conflicting-legacy-device",
+		{
+			bindings: [
+				{
+					deviceId: "legacy-device-conflict",
+					targetIdentityId: "identity-direct-personal",
+					confirmed: true,
+				},
+			],
+		},
+	);
+	assert(
+		conflictLegacyPreview.status === 409 && conflictLegacyPreview.body.status === "conflict",
+		"conflicting legacy device evidence did not fail closed at preview",
+	);
+	const legacyRejected = fixture(ctx, "peer-a", "summary", "70-legacy-rejected-bindings");
+	assert(
+		!legacyRejected.policy.identity_devices.some(
+			(device) =>
+				device.device_id === "legacy-device-stale" || device.device_id === "legacy-device-conflict",
+		),
+		"failed legacy review materialized an Identity binding",
+	);
+
+	// Arrange/Act/Assert: a bounded inventory rejects both preview and commit at the API boundary.
+	fixture(ctx, "peer-a", "truncate-legacy-device-evidence", "71-truncate-legacy-device-evidence");
+	const truncatedInventory = await request<DeviceIdentityInventory>(
+		ctx,
+		"peer-a",
+		"/api/sync/recipient-policy/v1/device-inventory",
+		"72-truncated-legacy-device-inventory",
+	);
+	assert(truncatedInventory.body.truncated === true, "legacy fixture did not truncate inventory");
+	const truncatedPreview = await request<DeviceIdentityBindingResult>(
+		ctx,
+		"peer-a",
+		"/api/sync/recipient-policy/v1/device-bindings/preview",
+		"73-reject-truncated-legacy-preview",
+		{ bindings: [staleSelection] },
+	);
+	assert(
+		truncatedPreview.status === 409 &&
+			truncatedPreview.body.errorCode === "device_inventory_truncated" &&
+			truncatedPreview.body.writeCount === 0,
+		"truncated legacy inventory did not fail closed at preview",
+	);
+	const truncatedCommit = await request<DeviceIdentityBindingResult>(
+		ctx,
+		"peer-a",
+		"/api/sync/recipient-policy/v1/device-bindings/commit",
+		"74-reject-truncated-legacy-commit",
+		{
+			bindings: [staleSelection],
+			reviewedInventoryDigest: staleLegacyPreview.body.reviewedInventoryDigest,
+		},
+	);
+	assert(
+		truncatedCommit.status === 409 &&
+			truncatedCommit.body.errorCode === "device_inventory_truncated" &&
+			truncatedCommit.body.writeCount === 0,
+		"truncated legacy inventory did not fail closed at commit",
+	);
+	const truncatedRejected = fixture(ctx, "peer-a", "summary", "75-truncated-legacy-rejected");
+	assert(
+		!truncatedRejected.policy.identity_devices.some(
+			(device) => device.device_id === "legacy-device-stale",
+		),
+		"truncated legacy review materialized an Identity binding",
 	);
 
 	ctx.compose.copyFromContainer(

--- a/e2e/scripts/project-sharing-fixture.ts
+++ b/e2e/scripts/project-sharing-fixture.ts
@@ -1,6 +1,7 @@
 import {
 	commitRecipientPolicyOnboarding,
 	deriveRecipientPolicyEffectiveDevicesFromDatabase,
+	fingerprintPublicKey,
 	getRecipientPolicyAuthorityState,
 	initDatabase,
 	listRecipientPolicyDenyOverlays,
@@ -39,6 +40,9 @@ type Action =
 	| "revoke-policy"
 	| "add-stale-memory"
 	| "keep-current"
+	| "seed-legacy-device-identities"
+	| "stale-legacy-device-evidence"
+	| "truncate-legacy-device-evidence"
 	| "reconciliation-proof";
 
 const ACTIONS: Action[] = [
@@ -53,6 +57,9 @@ const ACTIONS: Action[] = [
 	"revoke-policy",
 	"add-stale-memory",
 	"keep-current",
+	"seed-legacy-device-identities",
+	"stale-legacy-device-evidence",
+	"truncate-legacy-device-evidence",
 	"reconciliation-proof",
 ];
 
@@ -179,6 +186,51 @@ function revokeDirectRecipient(store: MemoryStore): void {
 			 WHERE canonical_project_identity = ? AND recipient_kind = 'identity' AND recipient_id = ?`,
 		)
 		.run(NOW, POLICY_SELECTED_REMOTE, DIRECT_IDENTITY);
+}
+
+function seedLegacyDeviceIdentities(store: MemoryStore): void {
+	const insert = store.db.prepare(
+		`INSERT OR REPLACE INTO sync_peers(
+		 peer_device_id, name, actor_id, public_key, pinned_fingerprint, created_at
+		 ) VALUES (?, ?, ?, ?, ?, ?)`,
+	);
+	for (const [deviceId, name, publicKey, pinnedPublicKey] of [
+		["legacy-device-valid-a", "Legacy valid device A", "legacy-valid-key-a", "legacy-valid-key-a"],
+		["legacy-device-valid-b", "Legacy valid device B", "legacy-valid-key-b", "legacy-valid-key-b"],
+		["legacy-device-stale", "Legacy stale device", "legacy-stale-key", "legacy-stale-key"],
+		["legacy-device-conflict", "Legacy conflict device", "legacy-conflict-key-a", "legacy-conflict-key-b"],
+	] as const) {
+		insert.run(
+			deviceId,
+			name,
+			DIRECT_IDENTITY,
+			publicKey,
+			fingerprintPublicKey(pinnedPublicKey),
+			NOW,
+		);
+	}
+}
+
+function staleLegacyDeviceEvidence(store: MemoryStore): void {
+	store.db
+		.prepare(
+			`UPDATE sync_peers
+			 SET public_key = ?, pinned_fingerprint = ?
+			 WHERE peer_device_id = 'legacy-device-stale'`,
+		)
+		.run("legacy-stale-key-replaced", fingerprintPublicKey("legacy-stale-key-replaced"));
+}
+
+function truncateLegacyDeviceEvidence(store: MemoryStore): void {
+	const insert = store.db.prepare(
+		`INSERT OR REPLACE INTO sync_peers(peer_device_id, name, actor_id, created_at)
+		 VALUES (?, ?, ?, ?)`,
+	);
+	store.db.transaction(() => {
+		for (let index = 0; index <= 2_000; index += 1) {
+			insert.run(`legacy-overflow-${index}`, `Legacy overflow ${index}`, DIRECT_IDENTITY, NOW);
+		}
+	})();
 }
 
 function session(store: MemoryStore, project: string, remote: string): number {
@@ -636,6 +688,9 @@ async function main(): Promise<void> {
 		if (selectedAction === "add-device-future") addDeviceFuture(store);
 		if (selectedAction === "add-after-revocation") addAfterRevocation(store);
 		if (selectedAction === "seed-policy") seedRecipientPolicy(store);
+		if (selectedAction === "seed-legacy-device-identities") seedLegacyDeviceIdentities(store);
+		if (selectedAction === "stale-legacy-device-evidence") staleLegacyDeviceEvidence(store);
+		if (selectedAction === "truncate-legacy-device-evidence") truncateLegacyDeviceEvidence(store);
 		const actionResult =
 			selectedAction === "inherit-policy"
 				? inheritRecipientPolicy(store)

--- a/packages/core/src/share-operation.test.ts
+++ b/packages/core/src/share-operation.test.ts
@@ -727,6 +727,56 @@ describe("share-operation persistence", () => {
 		).toBe("pending");
 	});
 
+	it("lets an authoritative device binding override stale legacy peer identity hints", () => {
+		const operation = plan();
+		persistShareOperation(db, operation, {
+			inviteId: "invite-1",
+			tokenDigest: inviteTokenDigest("token-1"),
+		});
+		db.prepare(`INSERT INTO sync_peers(
+				peer_device_id, actor_id, claimed_local_actor, created_at
+			) VALUES ('device-brian', 'actor-adam', 1, ?)`).run(createdAt);
+		db.prepare(`INSERT INTO identity_devices(
+				identity_id, device_id, display_name, status, provenance, revision, migration_state,
+				source_fingerprint, idempotency_key, created_at, updated_at
+			) VALUES ('actor-brian', 'device-brian', 'Brian device', 'active',
+				'user_confirmed_identity_setup', 'reviewed-revision', 'user_managed',
+				'reviewed-source', 'reviewed-key', ?, ?)`).run(createdAt, createdAt);
+
+		expect(() => reconcileShareOperationAcceptance(db, acceptanceInput(operation))).not.toThrow();
+		expect(
+			db
+				.prepare("SELECT state, recipient_actor_id FROM share_operations WHERE operation_id = ?")
+				.get(operation.operationId),
+		).toEqual({ state: "provisioning", recipient_actor_id: "actor-brian" });
+	});
+
+	it("rejects acceptance that conflicts with an authoritative recipient device binding", () => {
+		const operation = plan();
+		persistShareOperation(db, operation, {
+			inviteId: "invite-1",
+			tokenDigest: inviteTokenDigest("token-1"),
+		});
+		db.prepare(`INSERT INTO sync_peers(
+				peer_device_id, actor_id, claimed_local_actor, created_at
+			) VALUES ('device-brian', 'actor-brian', 0, ?)`).run(createdAt);
+		db.prepare(`INSERT INTO identity_devices(
+				identity_id, device_id, display_name, status, provenance, revision, migration_state,
+				source_fingerprint, idempotency_key, created_at, updated_at
+			) VALUES ('actor-alex', 'device-brian', 'Alex device', 'active',
+				'user_confirmed_identity_setup', 'reviewed-revision', 'user_managed',
+				'reviewed-source', 'reviewed-key', ?, ?)`).run(createdAt, createdAt);
+
+		expect(() => reconcileShareOperationAcceptance(db, acceptanceInput(operation))).toThrow(
+			"recipient_device_identity_conflict",
+		);
+		expect(
+			db
+				.prepare("SELECT state, recipient_actor_id FROM share_operations WHERE operation_id = ?")
+				.get(operation.operationId),
+		).toEqual({ state: "waiting_for_acceptance", recipient_actor_id: null });
+	});
+
 	it("does not regress a provisioning lifecycle on authoritative acceptance replay", () => {
 		const operation = plan();
 		persistShareOperation(db, operation, {

--- a/packages/core/src/share-operation.ts
+++ b/packages/core/src/share-operation.ts
@@ -540,16 +540,26 @@ export function reconcileShareOperationAcceptance(
 					claimed_local_actor: number;
 			  }
 			| undefined;
-		if (
-			existingPeer &&
+		const authoritativeBinding = db
+			.prepare(`SELECT identity_id FROM identity_devices
+				WHERE device_id = ? AND status = 'active'
+				AND provenance IN (
+					'user_confirmed_identity_setup', 'recipient_invite',
+					'exact_project_invite', 'review_resolution'
+				)`)
+			.get(input.recipientDeviceId) as { identity_id: string } | undefined;
+		const peerIdentityConflict = authoritativeBinding
+			? authoritativeBinding.identity_id !== input.recipientActorId
+			: existingPeer?.claimed_local_actor === 1 ||
+				(existingPeer?.actor_id != null &&
+					existingPeer.actor_id !== input.recipientActorId &&
+					existingPeer.actor_id !== operation.person_id);
+		const peerKeyConflict =
+			existingPeer != null &&
 			((existingPeer.public_key && existingPeer.public_key !== input.recipientPublicKey) ||
 				(existingPeer.pinned_fingerprint &&
-					existingPeer.pinned_fingerprint !== input.recipientFingerprint) ||
-				existingPeer.claimed_local_actor === 1 ||
-				(existingPeer.actor_id != null &&
-					existingPeer.actor_id !== input.recipientActorId &&
-					existingPeer.actor_id !== operation.person_id))
-		) {
+					existingPeer.pinned_fingerprint !== input.recipientFingerprint));
+		if (peerKeyConflict || peerIdentityConflict) {
 			throw new Error("recipient_device_identity_conflict");
 		}
 		const recipientActor = db

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -6,6 +6,7 @@ import { connect, tableExists } from "./db.js";
 import { buildFilterClauses, buildFilterClausesWithContext } from "./filters.js";
 import { MemoryStore } from "./store.js";
 import { setSyncDaemonPhase } from "./sync-daemon.js";
+import { fingerprintPublicKey } from "./sync-fingerprint.js";
 import { loadReplicationOpsSince } from "./sync-replication.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import * as vectors from "./vectors.js";
@@ -1203,6 +1204,263 @@ describe("MemoryStore", () => {
 			).toBe(false);
 		});
 
+		it("uses active device bindings as authoritative same-actor evidence", () => {
+			const now = "2026-01-01T00:00:00Z";
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES (?, 'Local', 1, 'active', ?, ?)`,
+				)
+				.run(store.actorId, now, now);
+			for (const provenance of [
+				"user_confirmed_identity_setup",
+				"recipient_invite",
+				"exact_project_invite",
+				"review_resolution",
+			]) {
+				const deviceId = `bound-local-${provenance}`;
+				store.db
+					.prepare(
+						`INSERT INTO identity_devices(
+						 device_id, identity_id, display_name, status, provenance, revision, migration_state,
+						 idempotency_key, created_at, updated_at
+						 ) VALUES (?, ?, ?, 'active', ?, ?, 'user_managed', ?, ?, ?)`,
+					)
+					.run(
+						deviceId,
+						store.actorId,
+						deviceId,
+						provenance,
+						`revision-${provenance}`,
+						`key-${provenance}`,
+						now,
+						now,
+					);
+
+				expect(
+					store.memoryOwnedBySelf({ actor_id: null, origin_device_id: deviceId, metadata: {} }),
+				).toBe(true);
+			}
+
+			store.db
+				.prepare(
+					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES ('legacy-unbound-peer', ?, 1, ?)",
+				)
+				.run(store.actorId, now);
+			expect(
+				store.memoryOwnedBySelf({
+					actor_id: "legacy-sync:legacy-unbound-peer",
+					origin_device_id: null,
+					metadata: {},
+				}),
+			).toBe(true);
+		});
+
+		it("does not let stale legacy claims override an authoritative binding", () => {
+			const now = "2026-01-01T00:00:00Z";
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES (?, 'Local', 1, 'active', ?, ?),
+					        ('identity-other', 'Other', 0, 'active', ?, ?)`,
+				)
+				.run(store.actorId, now, now, now, now);
+			for (const [deviceId, identityId, status, provenance] of [
+				["bound-other-peer", "identity-other", "active", "user_confirmed_identity_setup"],
+				["revoked-local-peer", store.actorId, "revoked", "user_confirmed_identity_setup"],
+				["coordinator-local-peer", store.actorId, "active", "coordinator_enrollment"],
+			] as const) {
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES (?, ?, 1, ?)",
+					)
+					.run(deviceId, store.actorId, now);
+				store.db
+					.prepare(
+						`INSERT INTO identity_devices(
+						 device_id, identity_id, display_name, status, provenance, revision, migration_state,
+						 idempotency_key, created_at, updated_at
+						 ) VALUES (?, ?, ?, ?, ?, ?, 'user_managed', ?, ?, ?)`,
+					)
+					.run(
+						deviceId,
+						identityId,
+						deviceId,
+						status,
+						provenance,
+						`revision-${deviceId}`,
+						`key-${deviceId}`,
+						now,
+						now,
+					);
+			}
+
+			for (const deviceId of ["bound-other-peer", "revoked-local-peer", "coordinator-local-peer"]) {
+				expect(
+					store.memoryOwnedBySelf({ actor_id: null, origin_device_id: deviceId, metadata: {} }),
+				).toBe(false);
+				expect(
+					store.memoryOwnedBySelf({
+						actor_id: `legacy-sync:${deviceId}`,
+						origin_device_id: null,
+						metadata: {},
+					}),
+				).toBe(false);
+			}
+		});
+
+		it("suppresses legacy claims for fingerprint aliases of an authoritative binding", () => {
+			const now = "2026-01-01T00:00:00Z";
+			const publicKey = "shared-device-public-key";
+			const fingerprint = fingerprintPublicKey(publicKey);
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES (?, 'Local', 1, 'active', ?, ?),
+					        ('identity-other', 'Other', 0, 'active', ?, ?)`,
+				)
+				.run(store.actorId, now, now, now, now);
+			store.db
+				.prepare(`INSERT INTO sync_peers(
+					peer_device_id, public_key, pinned_fingerprint, actor_id, claimed_local_actor, created_at
+				) VALUES ('bound-canonical', ?, ?, ?, 0, ?), ('stale-alias', ?, ?, ?, 1, ?)`)
+				.run(
+					publicKey,
+					fingerprint,
+					"identity-other",
+					now,
+					publicKey,
+					fingerprint,
+					store.actorId,
+					now,
+				);
+			store.db
+				.prepare(`INSERT INTO identity_devices(
+					device_id, identity_id, display_name, status, provenance, revision, migration_state,
+					idempotency_key, created_at, updated_at
+				) VALUES ('bound-canonical', 'identity-other', 'Bound device', 'active',
+					'user_confirmed_identity_setup', 'r1', 'user_managed', 'alias-binding', ?, ?)`)
+				.run(now, now);
+
+			expect(store.sameActorPeerIds()).toEqual([]);
+			expect(
+				store.memoryOwnedBySelf({
+					actor_id: "legacy-sync:stale-alias",
+					origin_device_id: "stale-alias",
+					metadata: {},
+				}),
+			).toBe(false);
+		});
+
+		it("propagates local bindings only across aliases with public-key evidence", () => {
+			const now = "2026-01-01T00:00:00Z";
+			const publicKey = "local-shared-device-public-key";
+			const fingerprint = fingerprintPublicKey(publicKey);
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES (?, 'Local', 1, 'active', ?, ?)`,
+				)
+				.run(store.actorId, now, now);
+			store.db
+				.prepare(`INSERT INTO sync_peers(
+					peer_device_id, public_key, pinned_fingerprint, created_at
+				) VALUES ('local-canonical', ?, ?, ?), ('proven-alias', ?, ?, ?),
+					('pinned-only-alias', NULL, ?, ?), ('local-pinned-bound', NULL, ?, ?)`)
+				.run(
+					publicKey,
+					fingerprint,
+					now,
+					publicKey,
+					fingerprint,
+					now,
+					fingerprint,
+					now,
+					fingerprint,
+					now,
+				);
+			store.db
+				.prepare(`INSERT INTO identity_devices(
+					device_id, identity_id, display_name, status, provenance, revision, migration_state,
+					idempotency_key, created_at, updated_at
+				) VALUES ('local-canonical', ?, 'Local device', 'active',
+					'user_confirmed_identity_setup', 'r1', 'user_managed', 'local-alias-binding', ?, ?),
+					('local-pinned-bound', ?, 'Local pinned device', 'active',
+					'user_confirmed_identity_setup', 'r2', 'user_managed', 'local-pinned-binding', ?, ?)`)
+				.run(store.actorId, now, now, store.actorId, now, now);
+
+			expect(store.sameActorPeerIds()).toEqual([
+				"local-canonical",
+				"local-pinned-bound",
+				"proven-alias",
+			]);
+		});
+
+		it("does not propagate ownership across fingerprints with conflicting bindings", () => {
+			const now = "2026-01-01T00:00:00Z";
+			const publicKey = "conflicting-shared-device-public-key";
+			const fingerprint = fingerprintPublicKey(publicKey);
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES (?, 'Local', 1, 'active', ?, ?),
+					        ('identity-other', 'Other', 0, 'active', ?, ?)`,
+				)
+				.run(store.actorId, now, now, now, now);
+			store.db
+				.prepare(`INSERT INTO sync_peers(
+					peer_device_id, public_key, pinned_fingerprint, created_at
+				) VALUES ('local-canonical', ?, ?, ?), ('unbound-alias', ?, ?, ?),
+					('conflicting-bound-alias', ?, ?, ?)`)
+				.run(publicKey, fingerprint, now, publicKey, fingerprint, now, publicKey, fingerprint, now);
+			store.db
+				.prepare(`INSERT INTO identity_devices(
+					device_id, identity_id, display_name, status, provenance, revision, migration_state,
+					idempotency_key, created_at, updated_at
+				) VALUES ('local-canonical', ?, 'Local device', 'active',
+					'user_confirmed_identity_setup', 'r1', 'user_managed', 'local-conflict-binding', ?, ?),
+					('conflicting-bound-alias', 'identity-other', 'Other device', 'active',
+					'user_confirmed_identity_setup', 'r2', 'user_managed', 'other-conflict-binding', ?, ?)`)
+				.run(store.actorId, now, now, now, now);
+
+			expect(store.sameActorPeerIds()).toEqual(["local-canonical"]);
+		});
+
+		it("fails closed without throwing for a partial identity binding schema", () => {
+			store.db.prepare("DROP TABLE identity_devices").run();
+			store.db.prepare("CREATE TABLE identity_devices(device_id TEXT PRIMARY KEY)").run();
+			store.db
+				.prepare(
+					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES ('partial-binding-peer', ?, 1, ?)",
+				)
+				.run(store.actorId, "2026-01-01T00:00:00Z");
+
+			expect(() => store.sameActorPeerIds()).not.toThrow();
+			expect(store.sameActorPeerIds()).toEqual([]);
+		});
+
+		it("fails closed without throwing when actor identity state is unavailable", () => {
+			store.db.prepare("DROP TABLE identity_devices").run();
+			store.db.prepare("DROP TABLE actors").run();
+			store.db
+				.prepare(
+					`CREATE TABLE identity_devices(
+					 device_id TEXT PRIMARY KEY, identity_id TEXT NOT NULL, status TEXT NOT NULL,
+					 provenance TEXT NOT NULL
+					 )`,
+				)
+				.run();
+			store.db
+				.prepare(
+					`INSERT INTO identity_devices(device_id, identity_id, status, provenance)
+					 VALUES ('missing-actor-peer', ?, 'active', 'user_confirmed_identity_setup')`,
+				)
+				.run(store.actorId);
+
+			expect(() => store.sameActorPeerIds()).not.toThrow();
+			expect(store.sameActorPeerIds()).toEqual([]);
+		});
+
 		it("returns true for claimed same-actor peer origin_device_id", () => {
 			store.db
 				.prepare(
@@ -1579,6 +1837,55 @@ describe("MemoryStore", () => {
 			expect(theirsIds).not.toContain(metadataDeviceId);
 			expect(theirsIds).not.toContain(metadataLegacyActorId);
 			expect(theirsIds).toContain(otherId);
+		});
+
+		it("uses authoritative bindings for SQL ownership filters", () => {
+			const sessionId = insertTestSession(store.db);
+			const now = "2026-01-01T00:00:00Z";
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES (?, 'Local', 1, 'active', ?, ?),
+					        ('identity-other-filter', 'Other', 0, 'active', ?, ?)`,
+				)
+				.run(store.actorId, now, now, now, now);
+			for (const [deviceId, identityId] of [
+				["bound-local-filter", store.actorId],
+				["bound-other-filter", "identity-other-filter"],
+			] as const) {
+				store.db
+					.prepare(
+						`INSERT INTO identity_devices(
+						 device_id, identity_id, display_name, status, provenance, revision, migration_state,
+						 idempotency_key, created_at, updated_at
+						 ) VALUES (?, ?, ?, 'active', 'user_confirmed_identity_setup', ?,
+						 'user_managed', ?, ?, ?)`,
+					)
+					.run(deviceId, identityId, deviceId, `revision-${deviceId}`, `key-${deviceId}`, now, now);
+			}
+			store.db
+				.prepare(
+					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES ('bound-other-filter', ?, 1, ?)",
+				)
+				.run(store.actorId, now);
+			const insertMemory = (title: string, deviceId: string) =>
+				Number(
+					store.db
+						.prepare(
+							`INSERT INTO memory_items(
+							 session_id, kind, title, body_text, confidence, tags_text, active,
+							 created_at, updated_at, metadata_json, rev, scope_id, origin_device_id
+							 ) VALUES (?, 'discovery', ?, 'Body', 0.5, '', 1, ?, ?, '{}', 1,
+							 'local-default', ?)`,
+						)
+						.run(sessionId, title, now, now, deviceId).lastInsertRowid,
+				);
+			const localId = insertMemory("Authoritatively local", "bound-local-filter");
+			const otherId = insertMemory("Authoritatively other", "bound-other-filter");
+
+			const mineIds = store.recent(10, { ownership_scope: "mine" }).map((item) => item.id);
+			expect(mineIds).toContain(localId);
+			expect(mineIds).not.toContain(otherId);
 		});
 
 		it("intersects explicit scope filters with local authorization", () => {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -16,6 +16,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import {
 	assertSchemaReady,
+	columnExists,
 	connect,
 	DEFAULT_DB_PATH,
 	ensureAdditiveSchemaCompatibility,
@@ -58,6 +59,7 @@ import {
 	type ScanDetection,
 	SecretScanner,
 } from "./secret-scanner.js";
+import { fingerprintPublicKey } from "./sync-fingerprint.js";
 import { recordReplicationOp } from "./sync-replication.js";
 import type {
 	ExplainResponse,
@@ -84,6 +86,15 @@ const ALLOWED_MEMORY_KINDS = new Set([
 	"decision",
 	"exploration",
 	"session_summary",
+]);
+
+// Locally reviewed flows that can establish same-person ownership. Coordinator
+// enrollment remains discovery evidence and must never grant write authority.
+const SAME_PERSON_BINDING_PROVENANCE = new Set([
+	"user_confirmed_identity_setup",
+	"recipient_invite",
+	"exact_project_invite",
+	"review_resolution",
 ]);
 
 /** Normalize and validate a memory kind. Throws on invalid kinds. */
@@ -2713,19 +2724,127 @@ export class MemoryStore {
 	}
 
 	sameActorPeerIds(): string[] {
-		if (!tableExists(this.db, "sync_peers")) return [];
-		const rows = this.d
-			.select({ peer_device_id: schema.syncPeers.peer_device_id })
-			.from(schema.syncPeers)
-			.where(
-				or(
-					eq(schema.syncPeers.claimed_local_actor, 1),
-					eq(schema.syncPeers.actor_id, this.actorId),
-				),
-			)
-			.orderBy(schema.syncPeers.peer_device_id)
-			.all();
-		return rows.map((row) => String(row.peer_device_id ?? "").trim()).filter(Boolean);
+		const deviceIds = new Set<string>();
+		const boundDeviceIds = new Set<string>();
+		const locallyBoundDeviceIds = new Set<string>();
+		const hasIdentityBindings =
+			tableExists(this.db, "identity_devices") &&
+			["device_id", "identity_id", "status", "provenance"].every((column) =>
+				columnExists(this.db, "identity_devices", column),
+			);
+		if (tableExists(this.db, "identity_devices") && !hasIdentityBindings) {
+			// A partial binding schema cannot safely distinguish authoritative evidence.
+			return [];
+		}
+		if (hasIdentityBindings) {
+			const bindings = this.db
+				.prepare("SELECT device_id, identity_id, status, provenance FROM identity_devices")
+				.all() as Array<{
+				device_id: string;
+				identity_id: string;
+				status: string;
+				provenance: string;
+			}>;
+			const hasActorIdentityState =
+				bindings.length > 0 &&
+				tableExists(this.db, "actors") &&
+				["actor_id", "status", "merged_into_actor_id"].every((column) =>
+					columnExists(this.db, "actors", column),
+				);
+			const localActor = hasActorIdentityState
+				? (this.db
+						.prepare("SELECT status, merged_into_actor_id FROM actors WHERE actor_id = ?")
+						.get(this.actorId) as
+						| { status: string; merged_into_actor_id: string | null }
+						| undefined)
+				: undefined;
+			const localActorIsActive =
+				localActor?.status === "active" && !localActor.merged_into_actor_id;
+			for (const binding of bindings) {
+				const deviceId = String(binding.device_id ?? "").trim();
+				if (!deviceId) continue;
+				boundDeviceIds.add(deviceId);
+				if (
+					localActorIsActive &&
+					String(binding.identity_id ?? "").trim() === this.actorId &&
+					binding.status === "active" &&
+					SAME_PERSON_BINDING_PROVENANCE.has(binding.provenance)
+				) {
+					deviceIds.add(deviceId);
+					locallyBoundDeviceIds.add(deviceId);
+				}
+			}
+		}
+		if (tableExists(this.db, "sync_peers")) {
+			const hasAliasEvidence = ["peer_device_id", "public_key", "pinned_fingerprint"].every(
+				(column) => columnExists(this.db, "sync_peers", column),
+			);
+			if (boundDeviceIds.size > 0 && !hasAliasEvidence) return [...deviceIds].sort();
+			if (boundDeviceIds.size > 0 && hasAliasEvidence) {
+				const peerEvidence = this.db
+					.prepare("SELECT peer_device_id, public_key, pinned_fingerprint FROM sync_peers")
+					.all() as Array<{
+					peer_device_id: string;
+					public_key: string | null;
+					pinned_fingerprint: string | null;
+				}>;
+				const validatedFingerprint = (row: (typeof peerEvidence)[number]): string | null => {
+					const publicKey = String(row.public_key ?? "").trim();
+					const pinned = String(row.pinned_fingerprint ?? "").trim();
+					if (!publicKey) return pinned || null;
+					const derived = fingerprintPublicKey(publicKey);
+					return pinned && pinned !== derived ? null : pinned || derived;
+				};
+				const provenFingerprint = (row: (typeof peerEvidence)[number]): string | null =>
+					String(row.public_key ?? "").trim() ? validatedFingerprint(row) : null;
+				const boundFingerprints = new Set<string>();
+				const locallyBoundFingerprints = new Set<string>();
+				const conflictingBoundFingerprints = new Set<string>();
+				for (const row of peerEvidence) {
+					const deviceId = String(row.peer_device_id ?? "").trim();
+					const fingerprint = validatedFingerprint(row);
+					if (!deviceId || !fingerprint || !boundDeviceIds.has(deviceId)) continue;
+					boundFingerprints.add(fingerprint);
+					if (locallyBoundDeviceIds.has(deviceId)) {
+						if (provenFingerprint(row)) locallyBoundFingerprints.add(fingerprint);
+					} else {
+						conflictingBoundFingerprints.add(fingerprint);
+					}
+				}
+				for (const fingerprint of conflictingBoundFingerprints) {
+					locallyBoundFingerprints.delete(fingerprint);
+				}
+				for (const row of peerEvidence) {
+					const deviceId = String(row.peer_device_id ?? "").trim();
+					const fingerprint = validatedFingerprint(row);
+					if (!deviceId || !fingerprint || !boundFingerprints.has(fingerprint)) continue;
+					const hasAuthoritativeBinding = boundDeviceIds.has(deviceId);
+					boundDeviceIds.add(deviceId);
+					if (
+						!hasAuthoritativeBinding &&
+						locallyBoundFingerprints.has(fingerprint) &&
+						provenFingerprint(row)
+					) {
+						deviceIds.add(deviceId);
+					}
+				}
+			}
+			const legacyRows = this.d
+				.select({ peer_device_id: schema.syncPeers.peer_device_id })
+				.from(schema.syncPeers)
+				.where(
+					or(
+						eq(schema.syncPeers.claimed_local_actor, 1),
+						eq(schema.syncPeers.actor_id, this.actorId),
+					),
+				)
+				.all();
+			for (const row of legacyRows) {
+				const deviceId = String(row.peer_device_id ?? "").trim();
+				if (deviceId && !boundDeviceIds.has(deviceId)) deviceIds.add(deviceId);
+			}
+		}
+		return [...deviceIds].sort();
 	}
 
 	claimedSameActorLegacyActorIds(): string[] {

--- a/packages/ui/src/app-devices.test.tsx
+++ b/packages/ui/src/app-devices.test.tsx
@@ -173,6 +173,9 @@ describe("Devices app integration", () => {
 		});
 		mocks.loadSyncData.mockImplementation(async () => {
 			const { state } = await import("./lib/state");
+			state.lastSyncStatus = {
+				coordinator_enrollment_reconciliation_issues: { counts: { open: 2, resolved: 1 } },
+			};
 			state.lastSyncPeers = [
 				{
 					peer_device_id: "device-private",
@@ -216,9 +219,13 @@ describe("Devices app integration", () => {
 		expect(panel?.textContent).toContain("Work Laptop");
 		expect(panel?.textContent).toContain("Available");
 		expect(panel?.textContent).toContain("Needs attention");
+		expect(panel?.textContent).toContain(
+			"2 coordinator enrollments could not be safely reconciled",
+		);
 		expect(mocks.loadRecipientPolicyIntent).toHaveBeenCalledOnce();
 		expect(mocks.loadRecipientPolicyReconciliationStatus).toHaveBeenCalledOnce();
 		expect(mocks.loadSyncData).toHaveBeenCalledOnce();
+		expect(mocks.loadDeviceIdentityInventory).toHaveBeenCalledOnce();
 		expect(panel?.textContent).not.toMatch(
 			/identity-private|device-private|project-private|revision-private|internal warning/i,
 		);
@@ -366,6 +373,43 @@ describe("Devices app integration", () => {
 		expect(document.getElementById("refreshStatus")?.textContent).toBe("refresh failed");
 		expect(document.getElementById("refreshAnnouncer")?.textContent).toBe("Refresh failed.");
 		expect(document.getElementById("refreshStatus")?.textContent).not.toContain("updated");
+	});
+
+	it("uses a fresh Devices inventory instead of accepting cached Sync ownership", async () => {
+		const { state } = await import("./lib/state");
+		state.lastDeviceIdentityInventory = {
+			version: 1,
+			items: intent.identityDevices.map((device) => ({
+				version: 1,
+				deviceId: device.deviceId,
+				evidenceDeviceIds: [device.deviceId],
+				displayName: device.displayName,
+				state: "configured" as const,
+				identityId: device.identityId,
+				suggestedIdentityId: null,
+				validatedFingerprint: null,
+				isLocal: device.deviceId === "device-private",
+				sources: ["identity_binding" as const],
+				conflictCodes: [],
+			})),
+			coordinatorEvidence: { availability: "available", safeErrorCode: null },
+			truncated: false,
+		};
+		mocks.loadDeviceIdentityInventory.mockClear();
+		mocks.loadSyncData.mockImplementationOnce(async () => {
+			state.deviceIdentityInventoryLoadError = true;
+		});
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5_100);
+		});
+
+		expect(mocks.loadDeviceIdentityInventory).toHaveBeenCalledOnce();
+		expect(document.getElementById("tab-devices")?.textContent).toContain("Work Laptop");
+		expect(document.querySelector('#tab-devices [role="alert"]')).toBeNull();
+		expect(document.getElementById("refreshStatus")?.textContent).not.toBe("refresh failed");
+		expect(state.lastDeviceIdentityInventory).toEqual(configuredDeviceInventory());
+		expect(state.deviceIdentityInventoryLoadError).toBe(false);
 	});
 
 	it("moves focus to the Devices tab when a focused device action is removed", async () => {

--- a/packages/ui/src/app-sharing.test.tsx
+++ b/packages/ui/src/app-sharing.test.tsx
@@ -210,4 +210,73 @@ describe("Sharing app data refresh", () => {
 		expect(completedMounts).toHaveLength(1);
 		expect(completedMounts[0]?.[2]).toBe(newestIntent);
 	});
+
+	it("loads the redacted coordinator reconciliation count into normal Sharing", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const mountSharing = vi.fn();
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory: vi.fn().mockResolvedValue({
+				version: 1,
+				items: [],
+				coordinatorEvidence: { availability: "available", safeErrorCode: null },
+				truncated: false,
+			}),
+			loadIntent: vi.fn().mockResolvedValue(intent),
+			loadProjects: vi.fn().mockResolvedValue({ manageable: projects, received: [] }),
+			loadSyncStatus: vi.fn().mockResolvedValue({
+				status: {
+					coordinator_enrollment_reconciliation_issues: {
+						counts: { open: 3, resolved: 8 },
+						issues: [{ coordinator_id: "must-not-reach-normal-sharing" }],
+					},
+				},
+			}),
+			mountSharing,
+		});
+
+		await load();
+
+		expect(mountSharing).toHaveBeenLastCalledWith(
+			document.getElementById("recipientPolicySharingMount"),
+			projects,
+			intent,
+			expect.objectContaining({ coordinatorEnrollmentIssueCount: 3 }),
+		);
+		expect(JSON.stringify(mountSharing.mock.calls.at(-1)?.[3])).not.toContain("coordinator_id");
+	});
+
+	it("preserves reconciliation attention across a transient sync-status failure", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const mountSharing = vi.fn();
+		const loadSyncStatus = vi
+			.fn()
+			.mockResolvedValueOnce({
+				status: {
+					coordinator_enrollment_reconciliation_issues: {
+						counts: { open: 2, resolved: 0 },
+						issues: [],
+					},
+				},
+			})
+			.mockRejectedValueOnce(new Error("temporarily unavailable"));
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory: vi.fn().mockResolvedValue({
+				version: 1,
+				items: [],
+				coordinatorEvidence: { availability: "available", safeErrorCode: null },
+				truncated: false,
+			}),
+			loadIntent: vi.fn().mockResolvedValue(intent),
+			loadProjects: vi.fn().mockResolvedValue({ manageable: projects, received: [] }),
+			loadSyncStatus,
+			mountSharing,
+		});
+
+		await load();
+		await load();
+
+		expect(mountSharing.mock.calls.at(-1)?.[3]).toEqual(
+			expect.objectContaining({ coordinatorEnrollmentIssueCount: 2 }),
+		);
+	});
 });

--- a/packages/ui/src/app-sharing.ts
+++ b/packages/ui/src/app-sharing.ts
@@ -1,5 +1,6 @@
 import * as api from "./lib/api";
 import type { ProjectScopeInventoryProject } from "./lib/api/sync";
+import { coordinatorEnrollmentOpenIssueCount } from "./lib/coordinator-enrollment-attention";
 import {
 	mountRecipientPolicyManagement,
 	type RecipientPolicyManagementProject,
@@ -44,6 +45,7 @@ interface RecipientPolicySharingLoaderDependencies {
 	loadDeviceInventory: typeof api.loadDeviceIdentityInventory;
 	loadIntent: typeof api.loadRecipientPolicyIntent;
 	loadProjects: () => Promise<RecipientPolicyProjectInventory>;
+	loadSyncStatus: typeof api.loadSyncStatus;
 	mountManagement: typeof mountRecipientPolicyManagement;
 	mountSharing: typeof mountRecipientPolicySharing;
 }
@@ -52,6 +54,7 @@ const defaultDependencies: RecipientPolicySharingLoaderDependencies = {
 	loadDeviceInventory: api.loadDeviceIdentityInventory,
 	loadIntent: api.loadRecipientPolicyIntent,
 	loadProjects: loadRecipientPolicyProjects,
+	loadSyncStatus: api.loadSyncStatus,
 	mountManagement: mountRecipientPolicyManagement,
 	mountSharing: mountRecipientPolicySharing,
 };
@@ -64,6 +67,7 @@ export function createRecipientPolicySharingLoader(
 	let loaded = false;
 	let loadRevision = 0;
 	let latestLoad: Promise<boolean> | null = null;
+	let coordinatorEnrollmentIssueCount = 0;
 
 	const loadRecipientPolicySharingData = (): Promise<boolean> => {
 		const revision = ++loadRevision;
@@ -81,19 +85,25 @@ export function createRecipientPolicySharingLoader(
 				loading: true,
 			});
 		}
-		const [inventoryResult, intentResult, deviceInventoryResult] = await Promise.allSettled([
-			dependencies.loadProjects(),
-			dependencies.loadIntent(),
-			dependencies.loadDeviceInventory(),
-		]);
+		const [inventoryResult, intentResult, deviceInventoryResult, syncStatusResult] =
+			await Promise.allSettled([
+				dependencies.loadProjects(),
+				dependencies.loadIntent(),
+				dependencies.loadDeviceInventory(),
+				dependencies.loadSyncStatus(false, "", { includeJoinRequests: false }),
+			]);
 		if (revision !== loadRevision) return latestLoad ?? false;
 		const deviceInventoryUnavailable = deviceInventoryResult.status === "rejected";
+		if (syncStatusResult.status === "fulfilled") {
+			coordinatorEnrollmentIssueCount = coordinatorEnrollmentOpenIssueCount(syncStatusResult.value);
+		}
 		if (inventoryResult.status === "fulfilled" && intentResult.status === "fulfilled") {
 			const inventory = inventoryResult.value;
 			const intent = intentResult.value;
 			const deviceInventory =
 				deviceInventoryResult.status === "fulfilled" ? deviceInventoryResult.value : undefined;
 			dependencies.mountSharing(sharingMount, inventory.manageable, intent, {
+				coordinatorEnrollmentIssueCount,
 				deviceInventory,
 				deviceInventoryUnavailable,
 				onReviewDevices: options.onReviewDevices,

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -13,6 +13,7 @@ import { createRecipientPolicySharingLoader } from "./app-sharing";
 import { mountToastHost } from "./components/primitives/toast";
 import * as api from "./lib/api";
 import type { ProjectScopeInventoryProject } from "./lib/api/sync";
+import { coordinatorEnrollmentOpenIssueCount } from "./lib/coordinator-enrollment-attention";
 import { $, $button, $select } from "./lib/dom";
 import { handlePrimaryActionKeyboard } from "./lib/keyboard";
 import {
@@ -511,6 +512,7 @@ let lastDevicesData: {
 	peerRuntimeMetadata: DevicePeerRuntimeMetadataInput[];
 	inventory: api.DeviceIdentityInventoryV1 | undefined;
 	inventoryUnavailable: boolean;
+	coordinatorEnrollmentIssueCount: number;
 } | null = null;
 
 async function loadRecipientPolicyProjects(): Promise<DevicesProjectInput[]> {
@@ -603,9 +605,17 @@ async function runLoadDevicesData(mount: HTMLElement, revision: number): Promise
 		if (revision !== devicesLoadRevision) return latestDevicesLoad ?? false;
 		const availability = deriveDeviceAvailability();
 		const peerRuntimeMetadata = deriveDevicePeerRuntimeMetadata();
+		const coordinatorEnrollmentIssueCount = coordinatorEnrollmentOpenIssueCount(
+			state.lastSyncStatus,
+		);
+		if (!inventoryResult.unavailable && inventoryResult.inventory) {
+			state.lastDeviceIdentityInventory = inventoryResult.inventory;
+		}
+		state.deviceIdentityInventoryLoadError = inventoryResult.unavailable;
 		mountDevices(mount, intent, reconciliation, projects, availability, {
 			inventory: inventoryResult.inventory,
 			inventoryUnavailable: inventoryResult.unavailable,
+			coordinatorEnrollmentIssueCount,
 			onCommitted: async () => {
 				const [devicesRefreshed, sharingRefreshed] = await Promise.all([
 					loadDevicesData(),
@@ -624,6 +634,7 @@ async function runLoadDevicesData(mount: HTMLElement, revision: number): Promise
 			peerRuntimeMetadata,
 			inventory: inventoryResult.inventory,
 			inventoryUnavailable: inventoryResult.unavailable,
+			coordinatorEnrollmentIssueCount,
 		};
 		devicesLoaded = true;
 		return true;
@@ -637,6 +648,7 @@ async function runLoadDevicesData(mount: HTMLElement, revision: number): Promise
 				lastDevicesData.projects,
 				lastDevicesData.availability,
 				{
+					coordinatorEnrollmentIssueCount: lastDevicesData.coordinatorEnrollmentIssueCount,
 					inventory: lastDevicesData.inventory,
 					inventoryUnavailable: lastDevicesData.inventoryUnavailable,
 					onCommitted: async () => {

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -93,7 +93,6 @@ export type {
 export {
 	acceptDiscoveredPeer,
 	advanceShareOperation,
-	assignPeerActor,
 	claimLegacyDeviceIdentity,
 	commitDeviceIdentityBindings,
 	commitRecipientPolicyEdges,

--- a/packages/ui/src/lib/coordinator-enrollment-attention.test.ts
+++ b/packages/ui/src/lib/coordinator-enrollment-attention.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { coordinatorEnrollmentOpenIssueCount } from "./coordinator-enrollment-attention";
+
+describe("coordinatorEnrollmentOpenIssueCount", () => {
+	it("reads only the bounded open issue count", () => {
+		expect(
+			coordinatorEnrollmentOpenIssueCount({
+				coordinator_enrollment_reconciliation_issues: {
+					counts: { open: 2, resolved: 4 },
+					issues: [{ coordinator_id: "not-for-normal-ui" }],
+				},
+			}),
+		).toBe(2);
+		expect(
+			coordinatorEnrollmentOpenIssueCount({
+				status: {
+					coordinator_enrollment_reconciliation_issues: { counts: { open: 3 } },
+				},
+			}),
+		).toBe(3);
+	});
+
+	it.each([
+		null,
+		{},
+		{ coordinator_enrollment_reconciliation_issues: {} },
+		{ coordinator_enrollment_reconciliation_issues: { counts: { open: -1 } } },
+	])("fails closed to no normal attention for malformed payload %j", (payload) => {
+		expect(coordinatorEnrollmentOpenIssueCount(payload)).toBe(0);
+	});
+});

--- a/packages/ui/src/lib/coordinator-enrollment-attention.ts
+++ b/packages/ui/src/lib/coordinator-enrollment-attention.ts
@@ -1,0 +1,17 @@
+type UnknownRecord = Record<string, unknown>;
+
+function record(value: unknown): UnknownRecord | null {
+	return value !== null && typeof value === "object" ? (value as UnknownRecord) : null;
+}
+
+export function coordinatorEnrollmentOpenIssueCount(payload: unknown): number {
+	const root = record(payload);
+	const status = record(root?.status);
+	const block = record(
+		root?.coordinator_enrollment_reconciliation_issues ??
+			status?.coordinator_enrollment_reconciliation_issues,
+	);
+	const counts = record(block?.counts);
+	const open = counts?.open;
+	return typeof open === "number" && Number.isSafeInteger(open) && open > 0 ? open : 0;
+}

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -5,7 +5,7 @@ import type {
 	TeamSyncPresenceState,
 	UiSyncViewModel,
 } from "../tabs/sync/view-model";
-import type { ShareOperationReadModel } from "./api/sync";
+import type { DeviceIdentityInventoryV1, ShareOperationReadModel } from "./api/sync";
 import type { UpdateStatus } from "./api/types";
 
 export type RefreshState = "idle" | "refreshing" | "paused" | "error";
@@ -94,6 +94,9 @@ export interface CachedSyncStatus {
 	summary?: unknown;
 	discovered_devices?: unknown[];
 	paired_peer_count?: number;
+	coordinator_enrollment_reconciliation_issues?: {
+		counts?: { open?: number; resolved?: number };
+	};
 }
 
 export interface SyncActor {
@@ -264,6 +267,8 @@ export const state = {
 	lastRawEventsPayload: null as CachedRawEventsPayload | null,
 	lastUpdateStatus: null as UpdateStatus | null,
 	lastSyncStatus: null as CachedSyncStatus | null,
+	lastDeviceIdentityInventory: null as DeviceIdentityInventoryV1 | null,
+	deviceIdentityInventoryLoadError: false,
 	pendingDeviceIdentityFocus: undefined as string | null | undefined,
 	lastSyncActors: [] as SyncActor[],
 	lastSyncPeers: [] as SyncPeer[],

--- a/packages/ui/src/tabs/devices.test.tsx
+++ b/packages/ui/src/tabs/devices.test.tsx
@@ -263,6 +263,96 @@ describe("read-only Devices", () => {
 		expect(document.body.textContent).not.toContain("No configured devices are registered.");
 	});
 
+	it("surfaces safe coordinator reconciliation attention without inferring ownership", () => {
+		mount(intent(), reconciliation(), {
+			coordinatorEnrollmentIssueCount: 1,
+			inventory: inventory([]),
+		});
+
+		const attention = document.querySelector<HTMLElement>(
+			'[aria-labelledby="devices-coordinator-reconciliation-heading"]',
+		);
+		expect(attention?.textContent).toContain(
+			"1 coordinator enrollment could not be safely reconciled",
+		);
+		expect(attention?.textContent).toContain("No ownership was inferred");
+		expect(attention?.textContent).toContain("No device on this page can be corrected from here");
+		expect(attention?.textContent).not.toContain("Advanced diagnostics");
+		expect(attention?.textContent).not.toMatch(/fingerprint|group[_ -]?id|coordinator[_ -]?id/i);
+	});
+
+	it("keeps coordinator reconciliation attention visible when inventory is unavailable", () => {
+		mount(intent(), reconciliation(), {
+			coordinatorEnrollmentIssueCount: 1,
+			inventoryUnavailable: true,
+		});
+
+		const attention = document.querySelector<HTMLElement>(
+			'[aria-labelledby="devices-coordinator-reconciliation-heading"]',
+		);
+		expect(attention?.textContent).toContain(
+			"1 coordinator enrollment could not be safely reconciled",
+		);
+		expect(attention?.textContent).toContain("No ownership was inferred");
+	});
+
+	it("points coordinator reconciliation attention at rendered setup recovery", () => {
+		mount(intent(), reconciliation(), {
+			coordinatorEnrollmentIssueCount: 1,
+			inventory: inventory([inventoryItem("setup-device", "Setup device", "setup_required")]),
+		});
+
+		const attention = document.querySelector<HTMLElement>(
+			'[aria-labelledby="devices-coordinator-reconciliation-heading"]',
+		);
+		expect(attention?.textContent).toContain(
+			"Review the affected device setup or pairing state here",
+		);
+	});
+
+	it("focuses a projected configured-device card from its canonical inventory ID", () => {
+		state.pendingDeviceIdentityFocus = "canonical-alias";
+		mount(intent(), reconciliation(), {
+			inventory: inventory([
+				inventoryItem("canonical-alias", "Work Laptop", "configured", {
+					evidenceDeviceIds: ["canonical-alias", "device-address-fingerprint-secret"],
+				}),
+			]),
+		});
+
+		expect(document.activeElement).toBe(
+			document.getElementById("device-identity-card-device-address-fingerprint-secret"),
+		);
+		expect(state.pendingDeviceIdentityFocus).toBeUndefined();
+	});
+
+	it("does not apply delayed setup focus after the user moves focus within Devices", () => {
+		const needsAttention = reconciliation({
+			items: reconciliation().items.map((item) =>
+				item.canonicalProjectIdentity === "project-direct-filter-id"
+					? { ...item, state: "needs_attention", label: "Needs attention" }
+					: item,
+			),
+		});
+		mount(intent(), needsAttention, { inventoryUnavailable: true, onNavigate: vi.fn() });
+		const action = document.querySelector<HTMLButtonElement>(
+			'button[aria-label="Review sharing for Work Laptop"]',
+		);
+		if (!action) throw new Error("Devices action missing");
+		action.focus();
+		state.pendingDeviceIdentityFocus = "setup-device";
+
+		mount(intent(), needsAttention, {
+			inventory: inventory([inventoryItem("setup-device", "Setup device", "setup_required")]),
+			onNavigate: vi.fn(),
+		});
+
+		expect(document.activeElement).not.toBe(
+			document.getElementById("device-identity-card-setup-device"),
+		);
+		expect(state.pendingDeviceIdentityFocus).toBeUndefined();
+	});
+
 	it("projects direct access without inferring per-device Team access from membership intent", () => {
 		const graph = intent();
 		const before = JSON.stringify(graph);

--- a/packages/ui/src/tabs/devices.tsx
+++ b/packages/ui/src/tabs/devices.tsx
@@ -50,6 +50,7 @@ export interface DevicesRendererOptions {
 	onCommitted?: () => boolean | undefined | Promise<boolean | undefined>;
 	previewBindings?: typeof previewDeviceIdentityBindings;
 	commitBindings?: typeof commitDeviceIdentityBindings;
+	coordinatorEnrollmentIssueCount?: number;
 }
 
 export interface DeviceProjectProjection {
@@ -1127,6 +1128,26 @@ function DevicesView({
 			})}
 		</ul>
 	) : null;
+	const coordinatorAttention =
+		(options.coordinatorEnrollmentIssueCount ?? 0) > 0 ? (
+			<aside
+				aria-labelledby="devices-coordinator-reconciliation-heading"
+				className="peer-card peer-card--padded recipient-policy-sharing-attention"
+			>
+				<h3 id="devices-coordinator-reconciliation-heading">Coordinator setup needs attention</h3>
+				<p>
+					{options.coordinatorEnrollmentIssueCount?.toLocaleString()} coordinator enrollment
+					{options.coordinatorEnrollmentIssueCount === 1 ? " could" : "s could"} not be safely
+					reconciled with device Identity setup.
+				</p>
+				<p className="small">
+					No ownership was inferred.{" "}
+					{setupItems.length > 0
+						? "Review the affected device setup or pairing state here, then retry after coordinator data is corrected."
+						: "No device on this page can be corrected from here. Retry after coordinator data is corrected."}
+				</p>
+			</aside>
+		) : null;
 	const inventoryWorkflow = options.inventory ? (
 		<>
 			{options.inventory.truncated ? (
@@ -1154,6 +1175,7 @@ function DevicesView({
 			<>
 				{refreshError}
 				{inventoryUnavailable}
+				{coordinatorAttention}
 				{inventoryWorkflow}
 				{configuredFallbackWorkflow}
 				<p className="small" role="status">
@@ -1173,6 +1195,7 @@ function DevicesView({
 		<>
 			{refreshError}
 			{inventoryUnavailable}
+			{coordinatorAttention}
 			{inventoryWorkflow}
 			{configuredFallbackWorkflow}
 			<ul className="recipient-policy-sharing-grid recipient-policy-sharing-responsive-grid">
@@ -1298,10 +1321,10 @@ export function mountDevices(
 	options: DevicesRendererOptions = {},
 ): void {
 	const focusedElement = document.activeElement;
-	const focusedAction =
-		focusedElement instanceof HTMLElement && mount.contains(focusedElement)
-			? deviceActionFocusIdentities.get(focusedElement)
-			: undefined;
+	const hadDevicesFocus = focusedElement instanceof HTMLElement && mount.contains(focusedElement);
+	const focusedAction = hadDevicesFocus
+		? deviceActionFocusIdentities.get(focusedElement)
+		: undefined;
 	const projection = projectDevices(
 		intent,
 		reconciliation,
@@ -1333,13 +1356,18 @@ export function mountDevices(
 		const inventoryItem = options.inventory?.items.find(
 			(item) => item.deviceId === deviceId || item.evidenceDeviceIds.includes(deviceId ?? ""),
 		);
-		const target =
-			(deviceId ? document.getElementById(`device-identity-card-${deviceId}`) : null) ??
-			(inventoryItem
-				? document.getElementById(`device-identity-card-${inventoryItem.deviceId}`)
-				: null) ??
-			document.getElementById("device-identity-review-heading");
-		if (target) {
+		const focusedCard = [
+			...(deviceId ? [deviceId] : []),
+			...(inventoryItem ? [inventoryItem.deviceId, ...inventoryItem.evidenceDeviceIds] : []),
+		]
+			.map((candidateDeviceId) =>
+				document.getElementById(`device-identity-card-${candidateDeviceId}`),
+			)
+			.find((element): element is HTMLElement => element instanceof HTMLElement);
+		const target = focusedCard ?? document.getElementById("device-identity-review-heading");
+		if (hadDevicesFocus) {
+			state.pendingDeviceIdentityFocus = undefined;
+		} else if (target) {
 			state.pendingDeviceIdentityFocus = undefined;
 			target.focus();
 			return;

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -461,6 +461,24 @@ describe("recipient-focused Sharing", () => {
 		expect(onReviewDevices).toHaveBeenCalledWith("device-setup");
 	});
 
+	it("surfaces a safe coordinator reconciliation count without converting groups to Teams", () => {
+		const onReviewDevices = vi.fn();
+		mount(intent(), { coordinatorEnrollmentIssueCount: 2, onReviewDevices });
+
+		const attention = document.querySelector<HTMLElement>(
+			'[aria-labelledby="sharing-coordinator-reconciliation-heading"]',
+		);
+		expect(attention?.textContent).toContain(
+			"2 coordinator enrollments could not be safely reconciled",
+		);
+		expect(attention?.textContent).toContain(
+			"Coordinator groups are discovery boundaries, not policy Teams",
+		);
+		expect(attention?.textContent).not.toMatch(/fingerprint|group[_ -]?id|coordinator[_ -]?id/i);
+		act(() => (attention?.querySelector("button") as HTMLButtonElement).click());
+		expect(onReviewDevices).toHaveBeenCalledOnce();
+	});
+
 	it("uses visible labels, responsive and target hooks, and no prohibited internal copy", () => {
 		mount();
 		expect(document.querySelector("h2")?.textContent).toBe("Sharing");

--- a/packages/ui/src/tabs/recipient-policy-sharing.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.tsx
@@ -16,6 +16,7 @@ export interface RecipientPolicySharingOptions {
 	received?: ReceivedProjectShare[];
 	deviceInventory?: DeviceIdentityInventoryV1;
 	onReviewDevices?: (deviceId?: string) => void;
+	coordinatorEnrollmentIssueCount?: number;
 }
 
 type SharingTab = "teams" | "identities" | "received" | "invitations";
@@ -372,6 +373,7 @@ function RecipientPolicySharing({
 	const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
 	const setupAttentionItems = deviceIdentityAttentionItems(options.deviceInventory);
 	const setupAttentionCount = setupAttentionItems.length;
+	const reconciliationIssueCount = options.coordinatorEnrollmentIssueCount ?? 0;
 	const hasActiveTeams = intent.teams.some((team) => team.status === "active");
 	useEffect(() => {
 		if (initialSelectionPending.current && !options.loading && !options.loadError) {
@@ -434,6 +436,34 @@ function RecipientPolicySharing({
 						<button
 							className="settings-button recipient-policy-sharing-target-24"
 							onClick={() => options.onReviewDevices?.(setupAttentionItems[0]?.deviceId)}
+							type="button"
+						>
+							Review Devices
+						</button>
+					) : null}
+				</aside>
+			) : null}
+			{reconciliationIssueCount > 0 ? (
+				<aside
+					aria-labelledby="sharing-coordinator-reconciliation-heading"
+					className="peer-card peer-card--padded recipient-policy-sharing-attention"
+				>
+					<h3 id="sharing-coordinator-reconciliation-heading">
+						Device setup reconciliation needs attention
+					</h3>
+					<p>
+						{reconciliationIssueCount.toLocaleString()} coordinator enrollment
+						{reconciliationIssueCount === 1 ? " could" : "s could"} not be safely reconciled.
+						Sharing remains unchanged until the device evidence is valid.
+					</p>
+					<p className="small">
+						Coordinator groups are discovery boundaries, not policy Teams, and do not prove device
+						ownership.
+					</p>
+					{options.onReviewDevices ? (
+						<button
+							className="settings-button recipient-policy-sharing-target-24"
+							onClick={() => options.onReviewDevices?.()}
 							type="button"
 						>
 							Review Devices

--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -252,7 +252,7 @@ function SyncActorsList({
 	if (!actors.length) {
 		return (
 			<SyncEmptyState
-				detail="Create a named person here, then assign devices below so team ownership stays readable."
+				detail="Create a named person here for legacy provenance, then confirm device Identity ownership in Devices."
 				title="No people set up yet."
 			/>
 		);

--- a/packages/ui/src/tabs/sync/components/sync-peers.test.ts
+++ b/packages/ui/src/tabs/sync/components/sync-peers.test.ts
@@ -1,5 +1,30 @@
-import { describe, expect, it } from "vitest";
-import { canManageSpacesInTeams } from "./sync-peers";
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { state } from "../../../lib/state";
+import {
+	advancedDeviceIdentityView,
+	canManageSpacesInTeams,
+	openDeviceIdentitySetup,
+	renderSyncPeersList,
+} from "./sync-peers";
+
+beforeEach(() => {
+	state.lastSyncActors = [
+		{ actor_id: "identity-confirmed", display_name: "Confirmed Person" },
+		{ actor_id: "identity-hint", display_name: "Suggested Person" },
+	];
+	state.lastDeviceIdentityInventory = null;
+	state.deviceIdentityInventoryLoadError = false;
+	state.pendingDeviceIdentityFocus = undefined;
+	window.location.hash = "advanced/sync";
+});
+
+afterEach(() => {
+	const mount = document.getElementById("mount");
+	if (mount) act(() => render(null, mount));
+	document.body.innerHTML = "";
+});
 
 describe("canManageSpacesInTeams", () => {
 	it("allows the Teams management action only for ready coordinator admin devices", () => {
@@ -10,5 +35,118 @@ describe("canManageSpacesInTeams", () => {
 		expect(canManageSpacesInTeams({ has_admin_secret: false, readiness: "ready" })).toBe(false);
 		expect(canManageSpacesInTeams({ has_admin_secret: true, readiness: "partial" })).toBe(false);
 		expect(canManageSpacesInTeams(null)).toBe(false);
+	});
+});
+
+describe("Advanced device Identity ownership", () => {
+	it("uses only an active binding as authoritative ownership", () => {
+		const view = advancedDeviceIdentityView(
+			{
+				version: 1,
+				deviceId: "peer-a",
+				evidenceDeviceIds: ["peer-a"],
+				displayName: "Peer A",
+				state: "configured",
+				identityId: "identity-confirmed",
+				suggestedIdentityId: "identity-hint",
+				validatedFingerprint: null,
+				isLocal: false,
+				sources: ["sync_peer", "identity_binding"],
+				conflictCodes: [],
+			},
+			"identity-hint",
+			state.lastSyncActors,
+		);
+
+		expect(view).toMatchObject({
+			status: "configured",
+			summary: "Authoritative Identity: Confirmed Person.",
+			actionLabel: "Review or rebind in Devices",
+		});
+		expect(view.detail).toContain("active identity_devices binding");
+	});
+
+	it("labels sync_peers.actor_id as a suggestion until setup is confirmed", () => {
+		const view = advancedDeviceIdentityView(undefined, "identity-hint", state.lastSyncActors);
+
+		expect(view.summary).toBe("Suggested Identity: Suggested Person.");
+		expect(view.detail).toContain("sync_peers.actor_id is only a suggestion or hint");
+		expect(view.actionLabel).toBe("Set up Identity in Devices");
+	});
+
+	it("does not present cached ownership as authoritative when inventory refresh fails", () => {
+		const view = advancedDeviceIdentityView(undefined, "identity-hint", state.lastSyncActors, true);
+
+		expect(view).toMatchObject({
+			status: "unavailable",
+			summary: "Authoritative Identity status is temporarily unavailable.",
+			actionLabel: "Review Identity in Devices",
+		});
+		expect(view.detail).toContain("suggestions or provenance only");
+	});
+
+	it("does not infer missing ownership from an incomplete inventory", () => {
+		const view = advancedDeviceIdentityView(
+			undefined,
+			"identity-hint",
+			state.lastSyncActors,
+			false,
+			true,
+		);
+
+		expect(view.status).toBe("unavailable");
+		expect(view.summary).toContain("inventory is incomplete");
+		expect(view.detail).toContain("not shown from a partial inventory");
+	});
+
+	it("routes ownership work to Devices and requests post-render focus", () => {
+		openDeviceIdentitySetup("peer-a");
+
+		expect(window.location.hash).toBe("#devices");
+		expect(state.pendingDeviceIdentityFocus).toBe("peer-a");
+	});
+
+	it("removes the direct actor assignment affordance but keeps Advanced peer actions", () => {
+		document.body.innerHTML = '<div id="mount"></div>';
+		state.lastDeviceIdentityInventory = {
+			version: 1,
+			items: [
+				{
+					version: 1,
+					deviceId: "peer-a",
+					evidenceDeviceIds: ["peer-a"],
+					displayName: "Peer A",
+					state: "setup_required",
+					identityId: null,
+					suggestedIdentityId: "identity-hint",
+					validatedFingerprint: null,
+					isLocal: false,
+					sources: ["sync_peer"],
+					conflictCodes: [],
+				},
+			],
+			coordinatorEvidence: { availability: "available", safeErrorCode: null },
+			truncated: false,
+		};
+		const mount = document.getElementById("mount");
+		if (!mount) throw new Error("mount missing");
+		act(() =>
+			renderSyncPeersList(mount, {
+				peers: [{ peer_device_id: "peer-a", name: "Peer A", actor_id: "identity-hint" }],
+				onRemove: vi.fn(),
+				onRename: vi.fn(),
+				onSync: vi.fn(),
+			}),
+		);
+		const disclosure = mount.querySelector<HTMLButtonElement>('[aria-expanded="false"]');
+		if (!disclosure) throw new Error("peer disclosure missing");
+		act(() => disclosure.click());
+
+		expect(mount.textContent).toContain("Authoritative Identity ownership");
+		expect(mount.textContent).toContain("Set up Identity in Devices");
+		expect(mount.textContent).toContain("Sync now");
+		expect(mount.textContent).toContain("Advanced sharing rules");
+		expect(mount.textContent).not.toContain("Save assignment");
+		expect(mount.querySelector('[aria-label^="Assigned person"]')).toBeNull();
 	});
 });

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -1,13 +1,12 @@
 import * as Collapsible from "@radix-ui/react-collapsible";
 import type { TargetedInputEvent } from "preact";
-import { useEffect, useMemo, useRef, useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import { PresencePip, type PresenceState } from "../../../components/primitives/presence-pip";
-import { RadixSelect } from "../../../components/primitives/radix-select";
 import { TextInput } from "../../../components/primitives/text-input";
+import type { DeviceIdentityInventoryItemV1 } from "../../../lib/api/sync";
 import { formatTimestamp } from "../../../lib/format";
-import { isSyncRedactionEnabled, state } from "../../../lib/state";
+import { isSyncRedactionEnabled, type SyncActor, state } from "../../../lib/state";
 import {
-	buildActorSelectOptions,
 	clearPeerScopeReview,
 	consumePeerScopeReviewRequest,
 	isPeerScopeReviewPending,
@@ -126,11 +125,92 @@ type SyncPeerStatus = NonNullable<SyncPeer["status"]> & {
 
 type SyncPeerCardProps = {
 	peer: SyncPeer;
-	onAssignActor: (peerId: string, actorId: string | null) => Promise<SyncActionFeedback>;
 	onRemove: (peerId: string, label: string) => Promise<SyncActionFeedback>;
 	onRename: (peerId: string, name: string) => Promise<SyncActionFeedback>;
 	onSync: (peer: SyncPeer, address: string | undefined) => Promise<SyncActionFeedback | null>;
 };
+
+export interface AdvancedDeviceIdentityView {
+	status: "configured" | "setup_required" | "pairing_required" | "conflicted" | "unavailable";
+	summary: string;
+	detail: string;
+	actionLabel: string;
+}
+
+function identityName(identityId: string | null, actors: SyncActor[]): string {
+	if (!identityId) return "the selected Identity";
+	const actor = actors.find((candidate) => candidate.actor_id === identityId);
+	return String(actor?.display_name || actor?.actor_display_name || "the selected Identity");
+}
+
+export function advancedDeviceIdentityView(
+	item: DeviceIdentityInventoryItemV1 | undefined,
+	actorHintId: string | null,
+	actors: SyncActor[],
+	inventoryUnavailable = false,
+	inventoryTruncated = false,
+	coordinatorUnavailable = false,
+): AdvancedDeviceIdentityView {
+	if (inventoryTruncated) {
+		return {
+			status: "unavailable",
+			summary: "Authoritative Identity status is unavailable because the inventory is incomplete.",
+			detail:
+				"This installation has more device evidence than Advanced can safely classify. Ownership is not shown from a partial inventory.",
+			actionLabel: "Review Identity inventory in Devices",
+		};
+	}
+	if (inventoryUnavailable || (coordinatorUnavailable && !item)) {
+		return {
+			status: "unavailable",
+			summary: "Authoritative Identity status is temporarily unavailable.",
+			detail:
+				"Refresh before relying on ownership details. Advanced actor_id values remain suggestions or provenance only.",
+			actionLabel: "Review Identity in Devices",
+		};
+	}
+	if (item?.state === "configured") {
+		return {
+			status: "configured",
+			summary: `Authoritative Identity: ${identityName(item.identityId, actors)}.`,
+			detail:
+				"This result comes from an active identity_devices binding. Advanced actor_id values are not authoritative ownership.",
+			actionLabel: "Review or rebind in Devices",
+		};
+	}
+	if (item?.state === "pairing_required") {
+		return {
+			status: "pairing_required",
+			summary: "Identity setup is blocked until pairing is complete.",
+			detail: "Pairing establishes sync trust; it does not establish device ownership.",
+			actionLabel: "Review setup in Devices",
+		};
+	}
+	if (item?.state === "conflicted") {
+		return {
+			status: "conflicted",
+			summary: "Identity ownership needs review.",
+			detail:
+				"Conflicting device evidence failed closed. Advanced actor_id values cannot resolve ownership.",
+			actionLabel: "Review conflict in Devices",
+		};
+	}
+	const suggestedIdentityId = item?.suggestedIdentityId ?? actorHintId;
+	return {
+		status: item?.state ?? "unavailable",
+		summary: suggestedIdentityId
+			? `Suggested Identity: ${identityName(suggestedIdentityId, actors)}.`
+			: "No authoritative Identity binding is configured.",
+		detail:
+			"sync_peers.actor_id is only a suggestion or hint until you confirm an identity_devices binding in Devices.",
+		actionLabel: "Set up Identity in Devices",
+	};
+}
+
+export function openDeviceIdentitySetup(deviceId?: string): void {
+	state.pendingDeviceIdentityFocus = deviceId?.trim() || null;
+	window.location.hash = "devices";
+}
 
 type SyncPeersListProps = Omit<SyncPeerCardProps, "peer"> & {
 	peers: SyncPeer[];
@@ -156,7 +236,7 @@ export function canManageSpacesInTeams(status = state.lastCoordinatorAdminStatus
 	return status?.readiness === "ready" && status.has_admin_secret === true;
 }
 
-function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncPeerCardProps) {
+function SyncPeerCard({ peer, onRemove, onRename, onSync }: SyncPeerCardProps) {
 	const peerId = String(peer.peer_device_id || "");
 	const displayName = peer.name || (peerId ? peerId.slice(0, 8) : "unknown");
 	const destructiveLabel = peer.name || peerId || displayName;
@@ -185,9 +265,17 @@ function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncP
 		: hiddenAddressCount > 0
 			? `${hiddenAddressCount} ${hiddenAddressCount === 1 ? "address" : "addresses"} hidden`
 			: "No addresses";
-	const assignmentSummary = peer.actor_display_name
-		? `This device belongs to ${peer.claimed_local_actor ? "you" : String(peer.actor_display_name)}.`
-		: "This device is not assigned to anyone yet.";
+	const inventoryItem = state.lastDeviceIdentityInventory?.items.find(
+		(item) => item.deviceId === peerId || item.evidenceDeviceIds.includes(peerId),
+	);
+	const ownership = advancedDeviceIdentityView(
+		inventoryItem,
+		String(peer.actor_id || "") || null,
+		state.lastSyncActors,
+		state.deviceIdentityInventoryLoadError,
+		state.lastDeviceIdentityInventory?.truncated === true,
+		state.lastDeviceIdentityInventory?.coordinatorEvidence.availability === "unavailable",
+	);
 	const lastSyncAt = String(peerStatus.last_sync_at || peerStatus.last_sync_at_utc || "");
 	const lastPingAt = String(peerStatus.last_ping_at || peerStatus.last_ping_at_utc || "");
 	const discoverySummary = peer.discovered_via_group_id
@@ -207,29 +295,6 @@ function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncP
 	const [syncBusy, setSyncBusy] = useState(false);
 	const [removeBusy, setRemoveBusy] = useState(false);
 	const [removeLabel, setRemoveLabel] = useState("Remove device");
-	const [selectedActorId, setSelectedActorId] = useState(String(peer.actor_id || ""));
-	const [applyActorBusy, setApplyActorBusy] = useState(false);
-	const [applyActorLabel, setApplyActorLabel] = useState("Save assignment");
-	const actorSelectOptions = useMemo(() => {
-		const options = buildActorSelectOptions(selectedActorId);
-		const hasSelected = options.some((option) => option.value === selectedActorId);
-		if (selectedActorId && !hasSelected) {
-			options.push({
-				value: selectedActorId,
-				label: peer.claimed_local_actor
-					? "You"
-					: String(peer.actor_display_name || "Current assignment"),
-			});
-		}
-		return options;
-	}, [
-		peer.actor_display_name,
-		peer.claimed_local_actor,
-		selectedActorId,
-		state.lastSyncActors,
-		state.lastSyncPeers,
-		state.lastSyncViewModel,
-	]);
 
 	useEffect(() => {
 		if (rawPendingScopeReview && authorizedDomains.total > 0) clearPeerScopeReview(peerId);
@@ -243,9 +308,6 @@ function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncP
 		setSyncBusy(false);
 		setRemoveBusy(false);
 		setRemoveLabel("Remove device");
-		setSelectedActorId(String(peer.actor_id || ""));
-		setApplyActorBusy(false);
-		setApplyActorLabel("Save assignment");
 	}, [displayName, peer.actor_id, peerId]);
 
 	useEffect(() => {
@@ -332,22 +394,6 @@ function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncP
 		} finally {
 			setRemoveBusy(false);
 			if (ok) setRemoveLabel("Remove device");
-		}
-	}
-
-	async function savePerson() {
-		if (!peerId) return;
-		setApplyActorBusy(true);
-		setApplyActorLabel("Saving…");
-		try {
-			const nextFeedback = await onAssignActor(peerId, selectedActorId || null);
-			setFeedback(nextFeedback);
-			state.syncPeerFeedbackById.set(peerId, nextFeedback);
-			setApplyActorLabel("Save assignment");
-		} catch {
-			setApplyActorLabel("Retry");
-		} finally {
-			setApplyActorBusy(false);
 		}
 	}
 
@@ -602,35 +648,21 @@ function SyncPeerCard({ peer, onAssignActor, onRemove, onRename, onSync }: SyncP
 							</div>
 						) : null}
 
-						<div className="peer-scope-summary">Who this device belongs to</div>
-						<div className="peer-meta">{assignmentSummary}</div>
+						<div className="peer-scope-summary">Authoritative Identity ownership</div>
+						<div className="peer-meta">{ownership.summary}</div>
+						<div className="peer-meta">{ownership.detail}</div>
 						{peer.claimed_local_actor ? (
 							<div className="peer-meta">
 								{claimedLocalActorScopeMessage(peer.claimed_local_actor_scope)}
 							</div>
 						) : null}
 						<div className="peer-actor-row">
-							<div className="sync-radix-select-host sync-actor-select-host">
-								<RadixSelect
-									ariaLabel={`Assigned person for ${displayName}`}
-									contentClassName="sync-radix-select-content sync-actor-select-content"
-									disabled={applyActorBusy}
-									itemClassName="sync-radix-select-item"
-									onValueChange={setSelectedActorId}
-									options={actorSelectOptions}
-									placeholder="No person assigned yet"
-									triggerClassName="sync-radix-select-trigger sync-actor-select"
-									value={selectedActorId}
-									viewportClassName="sync-radix-select-viewport"
-								/>
-							</div>
 							<button
 								type="button"
 								className="settings-button"
-								disabled={applyActorBusy}
-								onClick={() => void savePerson()}
+								onClick={() => openDeviceIdentitySetup(inventoryItem?.deviceId ?? peerId)}
 							>
-								{applyActorLabel}
+								{ownership.actionLabel}
 							</button>
 						</div>
 

--- a/packages/ui/src/tabs/sync/helpers.test.ts
+++ b/packages/ui/src/tabs/sync/helpers.test.ts
@@ -1,113 +1,12 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { state } from "../../lib/state";
-import {
-	actorDisplayLabel,
-	assignmentNote,
-	buildActorSelectOptions,
-	shouldClearStalePeersFeedback,
-} from "./helpers";
-
-const originalActors = state.lastSyncActors;
-const originalPeers = state.lastSyncPeers;
-const originalViewModel = state.lastSyncViewModel;
-const healthyPrimaryStatus = {
-	state: "healthy" as const,
-	badgeLabel: "Healthy",
-	meta: "Sync is healthy.",
-	nextAction: null,
-};
-
-afterEach(() => {
-	state.lastSyncActors = originalActors;
-	state.lastSyncPeers = originalPeers;
-	state.lastSyncViewModel = originalViewModel;
-});
+import { actorDisplayLabel, shouldClearStalePeersFeedback } from "./helpers";
 
 describe("actorDisplayLabel", () => {
 	it("labels the local actor as You", () => {
 		expect(
 			actorDisplayLabel({ actor_id: "actor-local", display_name: "Adam", is_local: true }),
 		).toBe("You");
-	});
-});
-
-describe("assignmentNote", () => {
-	it("describes local assignment as identity across devices", () => {
-		state.lastSyncActors = [{ actor_id: "actor-local", display_name: "Adam", is_local: true }];
-
-		expect(assignmentNote("actor-local")).toContain("identity across your devices");
-	});
-});
-
-describe("buildActorSelectOptions", () => {
-	it("keeps You available while hiding unresolved duplicate people elsewhere", () => {
-		state.lastSyncActors = [
-			{ actor_id: "actor-local", display_name: "Adam", is_local: true },
-			{ actor_id: "actor-shadow", display_name: "Adam", is_local: false },
-			{ actor_id: "actor-other", display_name: "Pat", is_local: false },
-		];
-		state.lastSyncPeers = [];
-		state.lastSyncViewModel = {
-			primaryStatus: healthyPrimaryStatus,
-			summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
-			attentionItems: [],
-			duplicatePeople: [
-				{
-					displayName: "Adam",
-					actorIds: ["actor-local", "actor-shadow"],
-					includesLocal: true,
-				},
-			],
-		};
-
-		expect(buildActorSelectOptions()).toEqual([
-			{ value: "", label: "No person assigned" },
-			{ value: "actor-local", label: "You" },
-			{ value: "actor-other", label: "Pat" },
-		]);
-	});
-
-	it("preserves a selected hidden actor so the control never renders blank", () => {
-		state.lastSyncActors = [
-			{ actor_id: "actor-local", display_name: "Adam", is_local: true },
-			{ actor_id: "actor-shadow", display_name: "Adam", is_local: false },
-		];
-		state.lastSyncPeers = [];
-		state.lastSyncViewModel = {
-			primaryStatus: healthyPrimaryStatus,
-			summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
-			attentionItems: [],
-			duplicatePeople: [
-				{
-					displayName: "Adam",
-					actorIds: ["actor-local", "actor-shadow"],
-					includesLocal: true,
-				},
-			],
-		};
-
-		expect(buildActorSelectOptions("actor-shadow")).toEqual([
-			{ value: "", label: "No person assigned" },
-			{ value: "actor-local", label: "You" },
-			{ value: "actor-shadow", label: "Adam" },
-		]);
-	});
-
-	it("keeps an explicit unassigned choice in the option list", () => {
-		state.lastSyncActors = [{ actor_id: "actor-local", display_name: "Adam", is_local: true }];
-		state.lastSyncPeers = [];
-		state.lastSyncViewModel = {
-			primaryStatus: healthyPrimaryStatus,
-			summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
-			attentionItems: [],
-			duplicatePeople: [],
-		};
-
-		expect(buildActorSelectOptions()).toEqual([
-			{ value: "", label: "No person assigned" },
-			{ value: "actor-local", label: "You" },
-		]);
 	});
 });
 

--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -1,6 +1,5 @@
 /* Shared helpers for the Sync tab sub-modules. */
 
-import type { RadixSelectOption } from "../../components/primitives/radix-select";
 import { copyToClipboard, el } from "../../lib/dom";
 import { type SyncActor, state } from "../../lib/state";
 import { deriveVisiblePeopleActors } from "./view-model";
@@ -170,68 +169,12 @@ export function assignedActorCount(actorId: string): number {
 	return peers.filter((peer) => String(peer?.actor_id || "") === actorId).length;
 }
 
-export function assignmentNote(actorId: string): string {
-	if (!actorId)
-		return "Unassigned devices keep legacy fallback attribution until you choose a person.";
-	const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
-	const actor = actors.find((item) => String(item?.actor_id || "") === actorId);
-	if (actor?.is_local) {
-		return "Assigning this device to you keeps it in your identity across your devices, including private sync.";
-	}
-	return "This person receives memories from allowed projects by default. Use Only me on a memory when it should stay local.";
-}
-
 export function visibleSyncActors() {
 	return deriveVisiblePeopleActors({
 		actors: state.lastSyncActors,
 		peers: state.lastSyncPeers,
 		duplicatePeople: state.lastSyncViewModel?.duplicatePeople,
 	}).visibleActors;
-}
-
-export function buildActorSelectOptions(selectedActorId = ""): RadixSelectOption[] {
-	const options: RadixSelectOption[] = [{ value: "", label: "No person assigned" }];
-	const visibleActors = visibleSyncActors();
-	const allActors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
-	const selectedActor = allActors.find(
-		(actor) => String(actor?.actor_id || "") === selectedActorId,
-	);
-	const actors =
-		selectedActor &&
-		!visibleActors.some((actor) => String(actor?.actor_id || "") === selectedActorId)
-			? [...visibleActors, selectedActor]
-			: visibleActors;
-
-	actors.forEach((actor) => {
-		const actorId = String(actor?.actor_id || "").trim();
-		if (!actorId) return;
-		options.push({ value: actorId, label: actorDisplayLabel(actor) });
-	});
-
-	return options.filter(
-		(option, index, all) =>
-			index === all.findIndex((candidate) => candidate.value === option.value),
-	);
-}
-
-export function buildActorOptions(selectedActorId: string): HTMLOptionElement[] {
-	const options: HTMLOptionElement[] = [];
-	const unassigned = document.createElement("option");
-	unassigned.value = "";
-	unassigned.textContent = "No person assigned";
-	options.push(unassigned);
-
-	buildActorSelectOptions(selectedActorId)
-		.filter((option) => option.value)
-		.forEach((selectOption) => {
-			const option = document.createElement("option");
-			option.value = selectOption.value;
-			option.textContent = selectOption.label;
-			option.selected = option.value === selectedActorId;
-			options.push(option);
-		});
-	if (!selectedActorId) options[0].selected = true;
-	return options;
 }
 
 export function mergeTargetActors(actorId: string): SyncActor[] {

--- a/packages/ui/src/tabs/sync/index.test.ts
+++ b/packages/ui/src/tabs/sync/index.test.ts
@@ -5,6 +5,7 @@ vi.mock("../../lib/api", () => ({
 	loadSyncActors: vi.fn(),
 	loadShareOperations: vi.fn(),
 	loadCoordinatorAdminStatus: vi.fn(),
+	loadDeviceIdentityInventory: vi.fn(),
 }));
 
 vi.mock("../health", () => ({ renderHealthOverview: vi.fn() }));
@@ -60,7 +61,7 @@ describe("loadSyncData", () => {
 		const { state } = await import("../../lib/state");
 		const { resetSyncLoadStateForTests } = await import("./index");
 		resetSyncLoadStateForTests();
-		state.activeTab = "sync";
+		state.activeTab = "advanced";
 		state.currentProject = "";
 		state.lastSyncPeers = [];
 		state.pendingAcceptedSyncPeers = [];
@@ -69,6 +70,8 @@ describe("loadSyncData", () => {
 		state.shareOperationsLoadError = false;
 		state.lastSyncCoordinator = null;
 		state.lastSyncViewModel = null;
+		state.lastDeviceIdentityInventory = null;
+		state.deviceIdentityInventoryLoadError = false;
 	});
 
 	it("ignores stale out-of-order sync payloads from older refreshes", async () => {
@@ -76,6 +79,12 @@ describe("loadSyncData", () => {
 		const { state } = await import("../../lib/state");
 		const { loadSyncData } = await import("./index");
 		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadDeviceIdentityInventory).mockResolvedValue({
+			version: 1,
+			items: [],
+			coordinatorEvidence: { availability: "available", safeErrorCode: null },
+			truncated: false,
+		});
 
 		const first = deferred<{
 			peers: Array<{ peer_device_id: string }>;
@@ -148,14 +157,26 @@ describe("loadSyncData", () => {
 
 	it("does not request secondary sync data when status fails", async () => {
 		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
 		const { loadSyncData } = await import("./index");
 
+		state.activeTab = "devices";
+		state.lastDeviceIdentityInventory = {
+			version: 1,
+			items: [],
+			coordinatorEvidence: { availability: "available", safeErrorCode: null },
+			truncated: false,
+		};
+		state.deviceIdentityInventoryLoadError = false;
 		vi.mocked(api.loadSyncStatus).mockRejectedValue(new Error("status unavailable"));
 		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
 
 		await loadSyncData();
 
 		expect(api.loadSyncActors).not.toHaveBeenCalled();
+		expect(api.loadDeviceIdentityInventory).not.toHaveBeenCalled();
+		expect(state.lastDeviceIdentityInventory).not.toBeNull();
+		expect(state.deviceIdentityInventoryLoadError).toBe(true);
 	});
 
 	it("keeps peer diagnostics when project sharing lifecycle loading fails", async () => {
@@ -192,5 +213,105 @@ describe("loadSyncData", () => {
 			badgeLabel: "Refresh needed",
 			nextAction: expect.stringMatching(/Refresh.*retry/),
 		});
+	});
+
+	it("refreshes authoritative device Identity inventory for Advanced", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		state.deviceIdentityInventoryLoadError = true;
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({ peers: [] } as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadDeviceIdentityInventory).mockResolvedValue({
+			version: 1,
+			items: [
+				{
+					version: 1,
+					deviceId: "peer-bound",
+					evidenceDeviceIds: ["peer-bound"],
+					displayName: "Bound peer",
+					state: "configured",
+					identityId: "identity-reviewed",
+					suggestedIdentityId: null,
+					validatedFingerprint: null,
+					isLocal: false,
+					sources: ["identity_binding"],
+					conflictCodes: [],
+				},
+			],
+			coordinatorEvidence: { availability: "available", safeErrorCode: null },
+			truncated: false,
+		});
+
+		await loadSyncData();
+
+		expect(state.lastDeviceIdentityInventory?.items[0]).toMatchObject({
+			deviceId: "peer-bound",
+			state: "configured",
+			identityId: "identity-reviewed",
+		});
+		expect(state.deviceIdentityInventoryLoadError).toBe(false);
+	});
+
+	it("leaves device Identity inventory refreshes to the Devices loader on Devices", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		state.activeTab = "devices";
+		state.lastDeviceIdentityInventory = {
+			version: 1,
+			items: [],
+			coordinatorEvidence: { availability: "available", safeErrorCode: null },
+			truncated: false,
+		};
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({ peers: [] } as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+
+		await loadSyncData();
+
+		expect(api.loadDeviceIdentityInventory).not.toHaveBeenCalled();
+		expect(state.lastDeviceIdentityInventory).not.toBeNull();
+	});
+
+	it("marks authoritative ownership unavailable when its refresh fails", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		state.lastDeviceIdentityInventory = {
+			version: 1,
+			items: [],
+			coordinatorEvidence: { availability: "available", safeErrorCode: null },
+			truncated: false,
+		};
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({ peers: [] } as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadDeviceIdentityInventory).mockRejectedValue(
+			new Error("inventory unavailable"),
+		);
+
+		await loadSyncData();
+
+		expect(state.deviceIdentityInventoryLoadError).toBe(true);
+		expect(state.lastDeviceIdentityInventory).not.toBeNull();
+	});
+
+	it("does not load device Identity inventory for Health-only sync refreshes", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		state.activeTab = "health";
+		state.deviceIdentityInventoryLoadError = true;
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({ peers: [] } as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadCoordinatorAdminStatus).mockResolvedValue({});
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+
+		await loadSyncData();
+
+		expect(api.loadDeviceIdentityInventory).not.toHaveBeenCalled();
+		expect(state.deviceIdentityInventoryLoadError).toBe(true);
 	});
 });

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -142,9 +142,11 @@ export async function loadSyncData() {
 
 		let actorsPayload: SyncActorListResponseLike | null = null;
 		let coordinatorAdminStatus: Record<string, unknown> | null = null;
+		let deviceIdentityInventory = state.lastDeviceIdentityInventory;
 		let shareOperations = state.lastShareOperations;
 		let actorLoadError = false;
 		let coordinatorAdminLoadError = false;
+		let deviceIdentityInventoryLoadError = state.deviceIdentityInventoryLoadError;
 		let shareOperationsLoadError = false;
 		const duplicatePersonDecisions = readDuplicatePersonDecisions();
 		try {
@@ -156,6 +158,14 @@ export async function loadSyncData() {
 			coordinatorAdminStatus = (await api.loadCoordinatorAdminStatus()) as Record<string, unknown>;
 		} catch {
 			coordinatorAdminLoadError = true;
+		}
+		if (state.activeTab === "advanced") {
+			deviceIdentityInventoryLoadError = false;
+			try {
+				deviceIdentityInventory = await api.loadDeviceIdentityInventory();
+			} catch {
+				deviceIdentityInventoryLoadError = true;
+			}
 		}
 		try {
 			const sharePayload = await api.loadShareOperations();
@@ -175,6 +185,8 @@ export async function loadSyncData() {
 			payload,
 			actorsPayload,
 			coordinatorAdminStatus,
+			deviceIdentityInventory,
+			deviceIdentityInventoryLoadError,
 			shareOperations,
 			shareOperationsLoadError,
 			duplicatePersonDecisions,
@@ -204,6 +216,10 @@ export async function loadSyncData() {
 			: [];
 		state.pendingAcceptedSyncPeers = pendingPeers;
 		state.lastSyncPeers = [...payloadPeers, ...pendingPeers];
+		if (!deviceIdentityInventoryLoadError) {
+			state.lastDeviceIdentityInventory = deviceIdentityInventory;
+		}
+		state.deviceIdentityInventoryLoadError = deviceIdentityInventoryLoadError;
 		state.lastShareOperations = shareOperations;
 		state.shareOperationsLoadError = shareOperationsLoadError;
 		state.lastSyncSharingReview = payload.sharing_review || [];
@@ -250,6 +266,7 @@ export async function loadSyncData() {
 	} catch {
 		if (requestId !== latestSyncLoadRequestId) return;
 		lastSyncHash = "";
+		state.deviceIdentityInventoryLoadError = true;
 		// Clear all skeletons so the error state is visible, not masked by loading placeholders
 		hideSkeleton("syncTeamSkeleton");
 		hideSkeleton("syncActorsSkeleton");

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -52,8 +52,8 @@ export function renderSyncActors() {
 	const actors = actorVisibility.visibleActors;
 	if (actorMeta) {
 		actorMeta.textContent = actors.length
-			? "Manage people here, then assign devices below."
-			: "No named people yet. Create a person here, then assign devices below so sync ownership is easier to review.";
+			? "Manage Identity names here. Confirm authoritative device ownership in Devices."
+			: "No named people yet. Create an Identity here, then confirm device ownership in Devices.";
 		if (actorVisibility.hiddenLocalDuplicateCount > 0) {
 			actorMeta.textContent += ` ${actorVisibility.hiddenLocalDuplicateCount} unresolved duplicate ${actorVisibility.hiddenLocalDuplicateCount === 1 ? "entry is" : "entries are"} hidden here until reviewed in Needs attention.`;
 		}
@@ -215,24 +215,6 @@ export function renderSyncPeers() {
 				} satisfies SyncActionFeedback;
 			}
 		},
-		onAssignActor: async (peerId, actorId) => {
-			try {
-				await api.assignPeerActor(peerId, actorId);
-				await _loadSyncData();
-				return {
-					message: actorId ? "Device assignment updated." : "Device assignment cleared.",
-					tone: "success",
-				} satisfies SyncActionFeedback;
-			} catch (error) {
-				return {
-					message: friendlyError(
-						error,
-						"Failed to update device assignment. The current assignment is unchanged.",
-					),
-					tone: "warning",
-				} satisfies SyncActionFeedback;
-			}
-		},
 	});
 }
 
@@ -256,7 +238,7 @@ export function renderSyncPeopleUnavailable() {
 		renderSyncEmptyState(syncPeers, {
 			title: "Devices unavailable right now.",
 			detail:
-				"Refresh this page to retry. When sync is reachable again, paired devices will reload here so you can rename, assign, or re-pair them.",
+				"Refresh this page to retry. When sync is reachable again, paired devices will reload here so you can rename, inspect, or re-pair them.",
 		});
 	}
 }

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -100,6 +100,7 @@ export default defineConfig(({ command, mode }) => {
 			server: {
 				deps: {
 					inline: [
+						"@radix-ui/react-collapsible",
 						"@radix-ui/react-compose-refs",
 						"@radix-ui/react-context",
 						"@radix-ui/react-dialog",

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -11370,6 +11370,144 @@ describe("viewer-server", () => {
 						"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, actor_id, created_at) VALUES (?, ?, ?, ?, ?)",
 					)
 					.run("peer-merge", "Peer Merge", "fp-merge", created.actor_id, new Date().toISOString());
+				const bindingTimestamp = new Date().toISOString();
+				store.db
+					.prepare(`INSERT INTO identity_devices(
+						device_id, identity_id, display_name, status, provenance, revision, migration_state,
+						assignment_version, source_fingerprint, idempotency_key, created_at, updated_at
+					) VALUES (?, ?, ?, 'active', 'user_confirmed_identity_setup', 'r1', 'user_managed',
+						0, NULL, ?, ?, ?)`)
+					.run(
+						"bound-device",
+						created.actor_id,
+						"Bound device",
+						"binding-before-merge",
+						bindingTimestamp,
+						bindingTimestamp,
+					);
+				store.db
+					.prepare(`INSERT INTO policy_teams(
+						team_id, display_name, status, device_eligibility_mode, provenance, revision,
+						migration_state, source_fingerprint, idempotency_key, created_at, updated_at
+					) VALUES (?, ?, 'active', 'reviewed_allowlist', 'user', 'r1', 'user_managed',
+						NULL, ?, ?, ?)`)
+					.run("merge-team", "Merge team", "merge-team-key", bindingTimestamp, bindingTimestamp);
+				store.db
+					.prepare(`INSERT INTO policy_team_device_decisions(
+						team_id, device_id, decision, assignment_version, provenance, revision,
+						created_at, updated_at
+					) VALUES (?, ?, 'included', 0, 'user', 'r1', ?, ?)`)
+					.run("merge-team", "bound-device", bindingTimestamp, bindingTimestamp);
+				store.db
+					.prepare(`INSERT INTO policy_team_memberships(
+						team_id, identity_id, role, status, provenance, revision, migration_state,
+						source_fingerprint, idempotency_key, created_at, updated_at
+					) VALUES (?, ?, 'member', 'reviewed_active', 'user', 'r1', 'user_managed',
+						NULL, ?, ?, ?)`)
+					.run(
+						"merge-team",
+						created.actor_id,
+						"merge-membership-key",
+						bindingTimestamp,
+						bindingTimestamp,
+					);
+				store.db
+					.prepare(`INSERT INTO project_recipients(
+						canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+						policy_revision, migration_state, source_fingerprint, idempotency_key,
+						created_at, updated_at
+					) VALUES (?, 'identity', ?, 'active', 'user', 'r1', 'user_managed', NULL, ?, ?, ?)`)
+					.run(
+						"project-for-merge",
+						created.actor_id,
+						"merge-project-recipient-key",
+						bindingTimestamp,
+						bindingTimestamp,
+					);
+				store.db
+					.prepare(`INSERT INTO recipient_managed_project_projections(
+						canonical_project_identity, display_name, managed_scope_id, coordinator_id,
+						group_id, recipient_identity_id, accepting_device_id, source_operation_id,
+						reviewed_project_set_digest, status, accepted_at, created_at, updated_at
+					) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?)`)
+					.run(
+						"received-project-for-merge",
+						"Received project for merge",
+						"managed-project:merge-team:received-project-for-merge",
+						"https://coordinator.example.test",
+						"merge-team",
+						created.actor_id,
+						"bound-device",
+						"merge-received-project-operation",
+						"merge-reviewed-project-set",
+						bindingTimestamp,
+						bindingTimestamp,
+						bindingTimestamp,
+					);
+				store.db
+					.prepare(`INSERT INTO share_operations(
+						operation_id, state, inviter_actor_id, inviter_device_ids_json, person_id,
+						person_kind, teammate_name, history_policy, reviewed_project_set_digest,
+						coordinator_group_id, invite_token_digest, invite_expires_at,
+						recipient_actor_id, recipient_device_id, created_at, updated_at
+					) VALUES (?, 'completed', ?, '[]', ?, 'existing', ?, 'selected', ?, ?, ?, ?, ?, ?, ?, ?)`)
+					.run(
+						"merge-share-operation",
+						localActor.actor_id,
+						created.actor_id,
+						"Fixture remote",
+						"merge-reviewed-project-set",
+						"merge-team",
+						"merge-invite-token-digest",
+						"2099-01-01T00:00:00.000Z",
+						created.actor_id,
+						"bound-device",
+						bindingTimestamp,
+						bindingTimestamp,
+					);
+				store.db
+					.prepare(`INSERT INTO actors(
+						actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+					) VALUES ('identity-unrelated', 'Unrelated', 0, 'active', NULL, ?, ?)`)
+					.run(bindingTimestamp, bindingTimestamp);
+				store.db
+					.prepare(`INSERT INTO share_operations(
+						operation_id, state, inviter_actor_id, inviter_device_ids_json, person_id,
+						person_kind, teammate_name, history_policy, reviewed_project_set_digest,
+						coordinator_group_id, invite_token_digest, invite_expires_at,
+						recipient_actor_id, recipient_device_id, created_at, updated_at
+					) VALUES (?, 'pending_recipient', ?, '[]', 'identity-unrelated', 'existing', ?,
+						'selected', ?, ?, ?, ?, 'identity-unrelated', 'unrelated-device', ?, ?)`)
+					.run(
+						"merge-inviter-share-operation",
+						created.actor_id,
+						"Unrelated",
+						"merge-inviter-reviewed-project-set",
+						"merge-team",
+						"merge-inviter-token-digest",
+						"2099-01-01T00:00:00.000Z",
+						bindingTimestamp,
+						bindingTimestamp,
+					);
+				store.db
+					.prepare(`INSERT INTO recipient_managed_project_projections(
+						canonical_project_identity, display_name, managed_scope_id, coordinator_id,
+						group_id, recipient_identity_id, accepting_device_id, source_operation_id,
+						reviewed_project_set_digest, status, accepted_at, created_at, updated_at
+					) VALUES (?, ?, ?, ?, ?, 'identity-unrelated', ?, ?, ?, 'active', ?, ?, ?)`)
+					.run(
+						"unrelated-received-project",
+						"Unrelated received project",
+						"managed-project:merge-team:unrelated-received-project",
+						"https://coordinator.example.test",
+						"merge-team",
+						"unrelated-device",
+						"unrelated-received-project-operation",
+						"unrelated-reviewed-project-set",
+						bindingTimestamp,
+						bindingTimestamp,
+						bindingTimestamp,
+					);
 
 				const mergeRes = await app.request("/api/sync/actors/merge", {
 					method: "POST",
@@ -11390,6 +11528,76 @@ describe("viewer-server", () => {
 				expect(mergedActor).toEqual({
 					status: "merged",
 					merged_into_actor_id: localActor.actor_id,
+				});
+				expect(
+					store.db
+						.prepare(
+							"SELECT identity_id, assignment_version FROM identity_devices WHERE device_id = ?",
+						)
+						.get("bound-device"),
+				).toEqual({ identity_id: localActor.actor_id, assignment_version: 1 });
+				expect(
+					store.db
+						.prepare("SELECT COUNT(*) FROM policy_team_device_decisions WHERE device_id = ?")
+						.pluck()
+						.get("bound-device"),
+				).toBe(0);
+				expect(
+					store.db
+						.prepare("SELECT identity_id FROM policy_team_memberships WHERE team_id = ?")
+						.all("merge-team"),
+				).toEqual([{ identity_id: localActor.actor_id }]);
+				expect(
+					store.db
+						.prepare(
+							"SELECT recipient_id FROM project_recipients WHERE canonical_project_identity = ? AND recipient_kind = 'identity'",
+						)
+						.all("project-for-merge"),
+				).toEqual([{ recipient_id: localActor.actor_id }]);
+				expect(
+					store.db
+						.prepare(
+							"SELECT recipient_identity_id FROM recipient_managed_project_projections WHERE canonical_project_identity = ?",
+						)
+						.get("received-project-for-merge"),
+				).toEqual({ recipient_identity_id: localActor.actor_id });
+				expect(
+					store.db
+						.prepare(
+							"SELECT recipient_identity_id FROM recipient_managed_project_projections WHERE canonical_project_identity = ?",
+						)
+						.get("unrelated-received-project"),
+				).toEqual({ recipient_identity_id: "identity-unrelated" });
+				expect(
+					store.db
+						.prepare(
+							"SELECT person_id, recipient_actor_id FROM share_operations WHERE operation_id = ?",
+						)
+						.get("merge-share-operation"),
+				).toEqual({ person_id: localActor.actor_id, recipient_actor_id: localActor.actor_id });
+				expect(
+					store.db
+						.prepare(
+							"SELECT inviter_actor_id, person_id, recipient_actor_id FROM share_operations WHERE operation_id = ?",
+						)
+						.get("merge-inviter-share-operation"),
+				).toEqual({
+					inviter_actor_id: localActor.actor_id,
+					person_id: "identity-unrelated",
+					recipient_actor_id: "identity-unrelated",
+				});
+				expect(
+					store.db
+						.prepare(`SELECT previous_identity_id, target_identity_id, action,
+							previous_assignment_version, resulting_assignment_version
+						 FROM device_identity_binding_audit WHERE device_id = ?`)
+						.get("bound-device"),
+				).toEqual({
+					previous_identity_id: created.actor_id,
+					target_identity_id: localActor.actor_id,
+					action: "rebind",
+					previous_assignment_version: 0,
+					resulting_assignment_version: 1,
 				});
 			} finally {
 				cleanup();

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -6470,42 +6470,317 @@ export function syncRoutes(
 		if (!secondaryActorId) return c.json({ error: "secondary_actor_id required" }, 400);
 		if (primaryActorId === secondaryActorId) return c.json({ error: "actor ids must differ" }, 400);
 		const d = drizzle(store.db, { schema });
-		const primary = d
-			.select()
-			.from(schema.actors)
-			.where(eq(schema.actors.actor_id, primaryActorId))
-			.get();
-		const secondary = d
-			.select()
-			.from(schema.actors)
-			.where(eq(schema.actors.actor_id, secondaryActorId))
-			.get();
-		if (!primary || !secondary) return c.json({ error: "actor not found" }, 404);
-		if (primary.status !== "active") return c.json({ error: "primary actor not active" }, 409);
-		if (secondary.status !== "active") return c.json({ error: "secondary actor not active" }, 409);
-		if (secondary.is_local && secondary.actor_id === store.actorId) {
-			return c.json({ error: "cannot merge this device's own local actor" }, 409);
-		}
 		const now = new Date().toISOString();
-		const mergedCount = store.db.transaction(() => {
-			const peerUpdate = d
-				.update(schema.syncPeers)
-				.set({ actor_id: primaryActorId })
-				.where(eq(schema.syncPeers.actor_id, secondaryActorId))
-				.run();
-			if (primary.is_local) {
-				d.update(schema.syncPeers)
-					.set({ claimed_local_actor: 1 })
-					.where(eq(schema.syncPeers.actor_id, primaryActorId))
+		const result = store.db
+			.transaction(() => {
+				const primary = d
+					.select()
+					.from(schema.actors)
+					.where(eq(schema.actors.actor_id, primaryActorId))
+					.get();
+				const secondary = d
+					.select()
+					.from(schema.actors)
+					.where(eq(schema.actors.actor_id, secondaryActorId))
+					.get();
+				if (!primary || !secondary) return { error: "actor not found", status: 404 as const };
+				if (primary.status !== "active") {
+					return { error: "primary actor not active", status: 409 as const };
+				}
+				if (secondary.status !== "active") {
+					return { error: "secondary actor not active", status: 409 as const };
+				}
+				if (secondary.is_local && secondary.actor_id === store.actorId) {
+					return { error: "cannot merge this device's own local actor", status: 409 as const };
+				}
+				const memberships = d
+					.select()
+					.from(schema.policyTeamMemberships)
+					.where(eq(schema.policyTeamMemberships.identity_id, secondaryActorId))
+					.all();
+				const primaryMemberships = new Map<string, (typeof memberships)[number] | undefined>();
+				for (const membership of memberships) {
+					const primaryMembership = d
+						.select()
+						.from(schema.policyTeamMemberships)
+						.where(
+							and(
+								eq(schema.policyTeamMemberships.team_id, membership.team_id),
+								eq(schema.policyTeamMemberships.identity_id, primaryActorId),
+							),
+						)
+						.get();
+					if (
+						primaryMembership &&
+						(primaryMembership.role !== membership.role ||
+							primaryMembership.status !== membership.status)
+					) {
+						return { error: "actor team memberships conflict", status: 409 as const };
+					}
+					primaryMemberships.set(membership.team_id, primaryMembership);
+				}
+				const directRecipients = d
+					.select()
+					.from(schema.projectRecipients)
+					.where(
+						and(
+							eq(schema.projectRecipients.recipient_kind, "identity"),
+							eq(schema.projectRecipients.recipient_id, secondaryActorId),
+						),
+					)
+					.all();
+				const primaryRecipients = new Map<string, (typeof directRecipients)[number] | undefined>();
+				for (const recipient of directRecipients) {
+					const primaryRecipient = d
+						.select()
+						.from(schema.projectRecipients)
+						.where(
+							and(
+								eq(
+									schema.projectRecipients.canonical_project_identity,
+									recipient.canonical_project_identity,
+								),
+								eq(schema.projectRecipients.recipient_kind, "identity"),
+								eq(schema.projectRecipients.recipient_id, primaryActorId),
+							),
+						)
+						.get();
+					if (primaryRecipient && primaryRecipient.status !== recipient.status) {
+						return { error: "actor project recipients conflict", status: 409 as const };
+					}
+					primaryRecipients.set(recipient.canonical_project_identity, primaryRecipient);
+				}
+
+				const mergeDigest = createHash("sha256")
+					.update(
+						JSON.stringify({
+							kind: "identity-merge-v1",
+							primaryActorId,
+							secondaryActorId,
+							nonce: randomUUID(),
+						}),
+					)
+					.digest("hex");
+				const bindings = d
+					.select({
+						deviceId: schema.identityDevices.device_id,
+						assignmentVersion: schema.identityDevices.assignment_version,
+					})
+					.from(schema.identityDevices)
+					.where(eq(schema.identityDevices.identity_id, secondaryActorId))
+					.all();
+				if (bindings.length > 0) {
+					const commitDigest = mergeDigest;
+					const outcomes = bindings.map((binding) => ({
+						deviceId: binding.deviceId,
+						previousIdentityId: secondaryActorId,
+						targetIdentityId: primaryActorId,
+						action: "rebind",
+					}));
+					store.db
+						.prepare(`INSERT INTO device_identity_binding_commits(
+						commit_digest, reviewed_inventory_digest, request_json, outcomes_json, write_count,
+						decided_by_identity_id, decided_by_device_id, created_at
+					) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+						.run(
+							commitDigest,
+							`identity-merge:${secondaryActorId}:${primaryActorId}`,
+							JSON.stringify({ primaryActorId, secondaryActorId }),
+							JSON.stringify(outcomes),
+							bindings.length,
+							store.actorId,
+							store.deviceId,
+							now,
+						);
+
+					for (const binding of bindings) {
+						const revision = createHash("sha256")
+							.update(`identity-merge-revision-v1\0${commitDigest}\0${binding.deviceId}`)
+							.digest("hex");
+						const idempotencyKey = createHash("sha256")
+							.update(`identity-merge-row-v1\0${commitDigest}\0${binding.deviceId}`)
+							.digest("hex");
+						const bindingUpdate = store.db
+							.prepare(`UPDATE identity_devices SET
+							identity_id = ?, provenance = 'review_resolution', revision = ?,
+							migration_state = 'user_managed', source_fingerprint = ?,
+							idempotency_key = ?, updated_at = ?
+						 WHERE device_id = ? AND identity_id = ?`)
+							.run(
+								primaryActorId,
+								revision,
+								commitDigest,
+								idempotencyKey,
+								now,
+								binding.deviceId,
+								secondaryActorId,
+							);
+						if (bindingUpdate.changes !== 1)
+							throw new Error("identity_merge_binding_update_failed");
+						const rebound = store.db
+							.prepare("SELECT assignment_version FROM identity_devices WHERE device_id = ?")
+							.get(binding.deviceId) as { assignment_version: number } | undefined;
+						if (!rebound || rebound.assignment_version !== binding.assignmentVersion + 1) {
+							throw new Error("identity_merge_assignment_version_unexpected");
+						}
+						store.db
+							.prepare("DELETE FROM policy_team_device_decisions WHERE device_id = ?")
+							.run(binding.deviceId);
+						store.db
+							.prepare(`INSERT INTO device_identity_binding_audit(
+							event_id, commit_digest, device_id, previous_identity_id, target_identity_id,
+							action, previous_assignment_version, resulting_assignment_version,
+							decided_by_identity_id, decided_by_device_id, created_at
+						) VALUES (?, ?, ?, ?, ?, 'rebind', ?, ?, ?, ?, ?)`)
+							.run(
+								createHash("sha256")
+									.update(`identity-merge-event-v1\0${commitDigest}\0${binding.deviceId}`)
+									.digest("hex"),
+								commitDigest,
+								binding.deviceId,
+								secondaryActorId,
+								primaryActorId,
+								binding.assignmentVersion,
+								rebound.assignment_version,
+								store.actorId,
+								store.deviceId,
+								now,
+							);
+					}
+				}
+
+				for (const membership of memberships) {
+					const primaryMembership = primaryMemberships.get(membership.team_id);
+					if (primaryMembership) {
+						d.delete(schema.policyTeamMemberships)
+							.where(
+								and(
+									eq(schema.policyTeamMemberships.team_id, membership.team_id),
+									eq(schema.policyTeamMemberships.identity_id, secondaryActorId),
+								),
+							)
+							.run();
+						continue;
+					}
+					const revision = createHash("sha256")
+						.update(`identity-merge-membership-revision-v1\0${mergeDigest}\0${membership.team_id}`)
+						.digest("hex");
+					const idempotencyKey = createHash("sha256")
+						.update(`identity-merge-membership-row-v1\0${mergeDigest}\0${membership.team_id}`)
+						.digest("hex");
+					d.update(schema.policyTeamMemberships)
+						.set({
+							identity_id: primaryActorId,
+							provenance: "review_resolution",
+							revision,
+							migration_state: "user_managed",
+							source_fingerprint: mergeDigest,
+							idempotency_key: idempotencyKey,
+							updated_at: now,
+						})
+						.where(
+							and(
+								eq(schema.policyTeamMemberships.team_id, membership.team_id),
+								eq(schema.policyTeamMemberships.identity_id, secondaryActorId),
+							),
+						)
+						.run();
+				}
+				for (const recipient of directRecipients) {
+					const primaryRecipient = primaryRecipients.get(recipient.canonical_project_identity);
+					if (primaryRecipient) {
+						d.delete(schema.projectRecipients)
+							.where(
+								and(
+									eq(
+										schema.projectRecipients.canonical_project_identity,
+										recipient.canonical_project_identity,
+									),
+									eq(schema.projectRecipients.recipient_kind, "identity"),
+									eq(schema.projectRecipients.recipient_id, secondaryActorId),
+								),
+							)
+							.run();
+						continue;
+					}
+					const policyRevision = createHash("sha256")
+						.update(
+							`identity-merge-recipient-revision-v1\0${mergeDigest}\0${recipient.canonical_project_identity}`,
+						)
+						.digest("hex");
+					const idempotencyKey = createHash("sha256")
+						.update(
+							`identity-merge-recipient-row-v1\0${mergeDigest}\0${recipient.canonical_project_identity}`,
+						)
+						.digest("hex");
+					d.update(schema.projectRecipients)
+						.set({
+							recipient_id: primaryActorId,
+							provenance: "review_resolution",
+							policy_revision: policyRevision,
+							migration_state: "user_managed",
+							source_fingerprint: mergeDigest,
+							idempotency_key: idempotencyKey,
+							updated_at: now,
+						})
+						.where(
+							and(
+								eq(
+									schema.projectRecipients.canonical_project_identity,
+									recipient.canonical_project_identity,
+								),
+								eq(schema.projectRecipients.recipient_kind, "identity"),
+								eq(schema.projectRecipients.recipient_id, secondaryActorId),
+							),
+						)
+						.run();
+				}
+				d.update(schema.recipientManagedProjectProjections)
+					.set({ recipient_identity_id: primaryActorId, updated_at: now })
+					.where(
+						eq(schema.recipientManagedProjectProjections.recipient_identity_id, secondaryActorId),
+					)
 					.run();
-			}
-			d.update(schema.actors)
-				.set({ status: "merged", merged_into_actor_id: primaryActorId, updated_at: now })
-				.where(eq(schema.actors.actor_id, secondaryActorId))
-				.run();
-			return Number(peerUpdate.changes ?? 0);
-		})();
-		return c.json({ merged_count: mergedCount });
+				store.db
+					.prepare(`UPDATE share_operations SET
+						inviter_actor_id = CASE WHEN inviter_actor_id = ? THEN ? ELSE inviter_actor_id END,
+						recipient_actor_id = CASE WHEN recipient_actor_id = ? THEN ? ELSE recipient_actor_id END,
+						person_id = CASE WHEN person_id = ? THEN ? ELSE person_id END,
+						updated_at = ?
+					 WHERE inviter_actor_id = ? OR recipient_actor_id = ? OR person_id = ?`)
+					.run(
+						secondaryActorId,
+						primaryActorId,
+						secondaryActorId,
+						primaryActorId,
+						secondaryActorId,
+						primaryActorId,
+						now,
+						secondaryActorId,
+						secondaryActorId,
+						secondaryActorId,
+					);
+
+				const peerUpdate = d
+					.update(schema.syncPeers)
+					.set({ actor_id: primaryActorId })
+					.where(eq(schema.syncPeers.actor_id, secondaryActorId))
+					.run();
+				if (primary.is_local) {
+					d.update(schema.syncPeers)
+						.set({ claimed_local_actor: 1 })
+						.where(eq(schema.syncPeers.actor_id, primaryActorId))
+						.run();
+				}
+				d.update(schema.actors)
+					.set({ status: "merged", merged_into_actor_id: primaryActorId, updated_at: now })
+					.where(eq(schema.actors.actor_id, secondaryActorId))
+					.run();
+				return { mergedCount: Number(peerUpdate.changes ?? 0) };
+			})
+			.immediate();
+		if ("error" in result) return c.json({ error: result.error }, result.status);
+		return c.json({ merged_count: result.mergedCount });
 	});
 
 	app.post("/api/sync/actors/deactivate", async (c) => {


### PR DESCRIPTION
## Description

Unify Advanced with the authoritative Devices Identity workflow, remove direct legacy actor assignment, surface safe coordinator reconciliation attention, and document the ownership model. Extend project-sharing E2E coverage for explicit legacy migration, atomicity, idempotency, stale/conflicting evidence, truncated inventories, and unchanged access policy.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced