### PR TITLE
fix(ui): theme native form controls globally

### DIFF
--- a/docs/plans/2026-08-19-device-identity-setup-workflow-simplification-design.md
+++ b/docs/plans/2026-08-19-device-identity-setup-workflow-simplification-design.md
@@ -1,0 +1,38 @@
+# Device Identity Setup Workflow Simplification
+
+**Date:** 2026-08-19
+
+**Status:** Approved
+
+## Problem
+
+Device Identity setup currently asks for three overlapping confirmations: include the device in a batch, confirm the device-to-Identity assignment, and confirm the reviewed preview. It also places bulk and per-device review actions on the same screen without clearly stating their different scopes.
+
+## Design
+
+- Keep one per-card checkbox, labeled **Select for setup**, for building a bulk setup batch.
+- Keep the Identity dropdown as the assignment control.
+- Remove the per-device **Confirm device belongs to Identity** checkbox.
+- Require an Identity for every device included in a review.
+- Keep **Review N selected** as the bulk action.
+- Rename the card action to **Review this device**; it reviews only that card regardless of other selections.
+- Keep the final preview confirmation as the single explicit approval step.
+- Label the final action **Apply setup to N device(s)** using the exact reviewed count.
+
+Suggested Identities remain non-authoritative. They may be displayed in the dropdown, but no binding is written until the user reviews the server-generated preview and completes the final confirmation.
+
+## Behavioral Guarantees
+
+- Bulk review previews and applies exactly the selected devices.
+- Per-device review previews and applies exactly that device.
+- Commit uses the preserved reviewed request rather than current selection state.
+- Changing selection or Identity choice invalidates an existing preview.
+- Pairing-required and conflicted devices remain outside normal Identity setup.
+
+## Testing
+
+- Verify the setup card has one checkbox rather than two.
+- Verify Identity selection is sufficient to make a selected device reviewable.
+- Verify bulk review sends all selected devices.
+- Verify per-device review and commit remain scoped to one device.
+- Verify the final action contains the reviewed device count.

--- a/docs/plans/2026-08-19-global-native-control-baseline-design.md
+++ b/docs/plans/2026-08-19-global-native-control-baseline-design.md
@@ -1,0 +1,35 @@
+# Global native control baseline
+
+## Problem
+
+The viewer has tokenized component styles, but native form controls only inherit
+those styles when each feature remembers to add a component-specific class.
+Unclassified selects and checkboxes therefore fall back to browser colors that
+can conflict with the active theme.
+
+## Decision
+
+Provide a low-specificity, token-driven baseline for every native form control.
+Component styles remain free to override the baseline, while newly added native
+controls are usable and visually consistent without feature-specific CSS.
+
+The baseline will:
+
+- declare the active browser `color-scheme` for dark and light themes;
+- style buttons, text-like fields, textareas, and selects with existing tokens;
+- give checkboxes and radio buttons consistent checked, indeterminate, focus,
+  and disabled states;
+- cover native file buttons, range controls, and progress indicators; and
+- preserve native elements, labels, focus order, and keyboard behavior.
+
+Custom component primitives are intentionally out of scope. They already have
+stronger component selectors and continue to override this baseline.
+
+## Verification
+
+- Add a static integration test proving the baseline is loaded and covers the
+  supported control families.
+- Run the UI tests, typecheck, and production build.
+- Inspect representative controls in explicit dark and light themes, including
+  keyboard focus, checked, indeterminate, and disabled states.
+- Confirm checked-state and focus visibility in Windows forced-colors mode.

--- a/packages/ui/scripts/stage-viewer-static.mjs
+++ b/packages/ui/scripts/stage-viewer-static.mjs
@@ -39,7 +39,7 @@ for (const entry of readdirSync(sourceStaticDir, { withFileTypes: true })) {
 // of the freshly rebuilt bundle. In that mode we instead STRIP any existing
 // sidecars so the server falls back to the live raw asset.
 const precompress = process.argv.includes("--precompress");
-for (const name of ["app.js", "themes.css", "tokens.css"]) {
+for (const name of ["app.js", "controls.css", "themes.css", "tokens.css"]) {
 	const filePath = join(viewerStaticDir, name);
 	const gzPath = `${filePath}.gz`;
 	const brPath = `${filePath}.br`;

--- a/packages/ui/src/native-control-styles.test.ts
+++ b/packages/ui/src/native-control-styles.test.ts
@@ -1,0 +1,88 @@
+/// <reference types="vite/client" />
+
+import { describe, expect, it } from "vitest";
+import stagingScript from "../scripts/stage-viewer-static.mjs?raw";
+import controls from "../static/controls.css?inline";
+import html from "../static/index.html?raw";
+import themes from "../static/themes.css?inline";
+import tokens from "../static/tokens.css?inline";
+
+describe("native control styles", () => {
+	it("loads the global control baseline after theme tokens", () => {
+		const tokensIndex = html.indexOf('<link rel="stylesheet" href="/assets/tokens.css" />');
+		const themesIndex = html.indexOf('<link rel="stylesheet" href="/assets/themes.css" />');
+		const controlsIndex = html.indexOf('<link rel="stylesheet" href="/assets/controls.css" />');
+
+		expect(tokensIndex).toBeGreaterThan(-1);
+		expect(themesIndex).toBeGreaterThan(tokensIndex);
+		expect(controlsIndex).toBeGreaterThan(themesIndex);
+	});
+
+	it("covers native control families without feature-specific classes", () => {
+		const normalizedControls = controls.replace(/\s+/g, " ");
+
+		expect(normalizedControls).toContain(":where(button, input, select, textarea)");
+		expect(normalizedControls).toContain('input[type="checkbox"]');
+		expect(normalizedControls).toContain('input[type="radio"]');
+		expect(normalizedControls).toContain('input[type="file"]');
+		expect(normalizedControls).toContain('input[type="range"]');
+		expect(normalizedControls).toContain("@media (forced-colors: active)");
+	});
+
+	it("declares the browser color scheme for dark and light themes", () => {
+		expect(tokens).toContain("color-scheme: dark");
+		expect(themes).toContain("color-scheme: light");
+	});
+
+	it("keeps baseline hover states at zero specificity", () => {
+		const hoverSelectors = [...controls.matchAll(/([^{}]+:hover:not\(:disabled\)[^{}]*)\{/g)].map(
+			([, selector]) => selector.trim(),
+		);
+
+		expect(hoverSelectors).toHaveLength(2);
+		for (const selector of hoverSelectors) {
+			expect(selector.startsWith(":where(")).toBe(true);
+			expect(selector.endsWith(")")).toBe(true);
+		}
+	});
+
+	it("keeps disabled file selector buttons non-interactive", () => {
+		const normalizedControls = controls.replace(/\s+/g, " ");
+
+		expect(normalizedControls).toContain(
+			':where(input[type="file"]:not(:disabled))::file-selector-button:hover',
+		);
+		expect(normalizedControls).not.toContain(
+			':where(input[type="file"])::file-selector-button:hover',
+		);
+		expect(normalizedControls).toContain(
+			':where(input[type="file"]:disabled)::file-selector-button { cursor: not-allowed; }',
+		);
+	});
+
+	it("keeps direct device card actions compact in equal-height grids", () => {
+		const normalizedHtml = html.replace(/\s+/g, " ");
+		const mobileStyles = normalizedHtml.slice(normalizedHtml.indexOf("@media (max-width: 720px)"));
+
+		expect(normalizedHtml).toContain(
+			"#devicesMount .recipient-policy-sharing-card > .settings-button { align-self: end; margin-top: var(--sp-4); }",
+		);
+		expect(normalizedHtml).toContain(
+			"#devicesMount .device-identity-card-actions { align-self: end; display: grid; gap: var(--sp-2); margin-top: var(--sp-4); }",
+		);
+		expect(mobileStyles).toContain(
+			"#devicesMount .recipient-policy-sharing-card > .settings-button, #devicesMount .device-identity-card-actions .settings-button { min-height: 44px; width: 100%; }",
+		);
+	});
+
+	it("precompresses every linked static stylesheet", () => {
+		const stylesheets = [...html.matchAll(/href="\/assets\/([^"?]+\.css)"/g)].map(
+			([, filename]) => filename,
+		);
+
+		expect(stylesheets).not.toHaveLength(0);
+		for (const filename of stylesheets) {
+			expect(stagingScript).toContain(`"${filename}"`);
+		}
+	});
+});

--- a/packages/ui/src/tabs/devices.test.tsx
+++ b/packages/ui/src/tabs/devices.test.tsx
@@ -729,6 +729,23 @@ describe("read-only Devices", () => {
 		expect(text).toContain("Pair this device first");
 		expect(text).toContain("Device evidence conflicts");
 		expect(document.querySelectorAll(".device-identity-setup-card select")).toHaveLength(1);
+		for (const label of ["Review this device", "Go to pairing", "Open Advanced review"]) {
+			const action = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+				(button) => button.textContent === label,
+			);
+			expect(action?.parentElement?.classList.contains("device-identity-card-actions")).toBe(true);
+			expect(action?.closest(".device-identity-setup-card")).not.toBeNull();
+		}
+		expect(document.querySelectorAll(".device-identity-setup-card > fieldset button")).toHaveLength(
+			0,
+		);
+		expect(deviceCard("Home Laptop").querySelectorAll('input[type="checkbox"]')).toHaveLength(0);
+		expect(
+			deviceCard("Home Laptop")
+				.querySelector<HTMLSelectElement>("select")
+				?.getAttribute("aria-label"),
+		).toBe("Choose an Identity for Home Laptop");
+		expect(text).not.toContain("Confirm Home Laptop belongs");
 		expect([...document.querySelectorAll("button")].map((button) => button.textContent)).toContain(
 			"Go to pairing",
 		);
@@ -769,7 +786,7 @@ describe("read-only Devices", () => {
 		expect(onNavigate).toHaveBeenCalledWith("advanced_sync");
 	});
 
-	it("requires an explicit Identity and per-device confirmation before batch review", async () => {
+	it("reviews exactly the selected devices without per-device confirmation", async () => {
 		const previewBindings = vi.fn().mockResolvedValue({
 			version: 1,
 			status: "ready",
@@ -779,7 +796,15 @@ describe("read-only Devices", () => {
 				{
 					deviceId: "one",
 					displayName: "One",
-					targetIdentityId: "identity-target",
+					targetIdentityId: "identity-scope-secret",
+					previousIdentityId: null,
+					action: "bind",
+					isLocal: false,
+				},
+				{
+					deviceId: "two",
+					displayName: "Two",
+					targetIdentityId: "identity-scope-secret",
 					previousIdentityId: null,
 					action: "bind",
 					isLocal: false,
@@ -795,36 +820,29 @@ describe("read-only Devices", () => {
 				inventoryItem("two", "Two", "setup_required", {
 					suggestedIdentityId: "identity-scope-secret",
 				}),
+				inventoryItem("three", "Three", "setup_required", {
+					suggestedIdentityId: "identity-scope-secret",
+				}),
 			]),
 			previewBindings,
 		});
-		const selected = [
-			...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-		].filter((input) => input.parentElement?.textContent?.includes("Include in reviewed setup"));
-		for (const input of selected) {
-			input.checked = true;
-			act(() => {
-				input.dispatchEvent(new Event("input", { bubbles: true }));
-			});
+		const setupCards = [...document.querySelectorAll<HTMLElement>(".device-identity-setup-card")];
+		expect(setupCards).toHaveLength(3);
+		for (const [index, card] of setupCards.entries()) {
+			const name = ["One", "Two", "Three"][index];
+			expect(card.querySelectorAll('input[type="checkbox"]')).toHaveLength(1);
+			expect(card.textContent).toContain("Select for setup");
+			expect(card.textContent).not.toContain("Confirm ");
+			expect(
+				card.querySelector<HTMLInputElement>('input[type="checkbox"]')?.getAttribute("aria-label"),
+			).toBe(`Select for setup: ${name}`);
+			expect(card.querySelector<HTMLSelectElement>("select")?.getAttribute("aria-label")).toBe(
+				`Choose an Identity for ${name}`,
+			);
 		}
-		await act(async () => {
-			(
-				[...document.querySelectorAll<HTMLButtonElement>("button")].find((button) =>
-					button.textContent?.startsWith("Review 2 selected"),
-				) as HTMLButtonElement
-			).click();
-		});
-		expect(previewBindings).not.toHaveBeenCalled();
-		expect(document.querySelector('[role="alert"]')?.textContent).toContain("explicitly confirm");
-
-		const confirmations = [
-			...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-		].filter((input) => input.parentElement?.textContent?.startsWith(" Confirm"));
-		for (const input of confirmations) {
-			input.checked = true;
-			act(() => {
-				input.dispatchEvent(new Event("input", { bubbles: true }));
-			});
+		const selected = setupCards.slice(0, 2).map((card) => cardCheckbox(card, "Select for setup"));
+		for (const input of selected) {
+			setCheckbox(input);
 		}
 		await act(async () => {
 			(
@@ -839,28 +857,77 @@ describe("read-only Devices", () => {
 				{ deviceId: "two", targetIdentityId: "identity-scope-secret", confirmed: true },
 			],
 		});
+		expect(document.body.textContent).toContain("Review Identity setup");
+		expect(document.body.textContent).toContain("I reviewed every device and target Identity");
+		expect(
+			[...document.querySelectorAll<HTMLButtonElement>("button")].find(
+				(button) => button.textContent === "Apply setup to 2 devices",
+			),
+		).toBeTruthy();
 	});
 
-	it("does not guess an Identity for a local device without an authoritative suggestion", () => {
+	it("blocks bulk review when a selected device has no Identity", async () => {
+		const previewBindings = vi.fn();
+		mount(intent(), reconciliation(), {
+			inventory: inventory([
+				inventoryItem("one", "One", "setup_required", {
+					suggestedIdentityId: "identity-scope-secret",
+				}),
+				inventoryItem("two", "Two", "setup_required", {
+					suggestedIdentityId: "identity-scope-secret",
+				}),
+			]),
+			previewBindings,
+		});
+		setCheckbox(cardCheckbox(deviceCard("One"), "Select for setup"));
+		setCheckbox(cardCheckbox(deviceCard("Two"), "Select for setup"));
+		const secondIdentity = deviceCard("Two").querySelector<HTMLSelectElement>("select");
+		if (!secondIdentity) throw new Error("Identity select missing");
+		secondIdentity.value = "";
+		act(() => {
+			secondIdentity.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+
+		await act(async () => {
+			(
+				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
+					(button) => button.textContent === "Review 2 selected",
+				) as HTMLButtonElement
+			).click();
+		});
+
+		expect(document.querySelector('[role="alert"]')?.textContent).toBe(
+			"Choose an Identity for every selected device before review.",
+		);
+		expect(previewBindings).not.toHaveBeenCalled();
+	});
+
+	it("does not guess an Identity or allow review for a local device without a target", () => {
 		mount(intent(), reconciliation(), {
 			inventory: inventory([inventoryItem("local", "Local", "setup_required", { isLocal: true })]),
 		});
 		const select = document.querySelector<HTMLSelectElement>(".device-identity-setup-card select");
-		const confirmation = [
-			...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-		].find((input) => input.parentElement?.textContent?.includes("Confirm Local belongs"));
 		expect(select?.value).toBe("");
-		expect(confirmation?.disabled).toBe(true);
+		expect(select?.getAttribute("aria-label")).toBe("Choose an Identity for Local");
+		expect(deviceCard("Local").querySelectorAll('input[type="checkbox"]')).toHaveLength(0);
+		expect(
+			[...deviceCard("Local").querySelectorAll<HTMLButtonElement>("button")].find(
+				(button) => button.textContent === "Review this device",
+			)?.disabled,
+		).toBe(true);
 	});
 
 	it("blocks incomplete and unavailable remote inventory but permits local-only setup when unconfigured", () => {
-		const local = inventoryItem("local", "Local", "setup_required", { isLocal: true });
+		const local = inventoryItem("local", "Local", "setup_required", {
+			isLocal: true,
+			suggestedIdentityId: "identity-scope-secret",
+		});
 		mount(intent(), reconciliation(), {
 			inventory: { ...inventory([local]), truncated: true },
 		});
 		expect(
 			[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-				(button) => button.textContent === "Review setup",
+				(button) => button.textContent === "Review this device",
 			)?.disabled,
 		).toBe(true);
 		mount(intent(), reconciliation(), {
@@ -888,7 +955,7 @@ describe("read-only Devices", () => {
 		});
 		expect(
 			[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-				(button) => button.textContent === "Review setup",
+				(button) => button.textContent === "Review this device",
 			)?.disabled,
 		).toBe(false);
 
@@ -903,7 +970,7 @@ describe("read-only Devices", () => {
 		});
 		expect(
 			[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-				(button) => button.textContent === "Review setup",
+				(button) => button.textContent === "Review this device",
 			)?.disabled,
 		).toBe(true);
 	});
@@ -942,15 +1009,12 @@ describe("read-only Devices", () => {
 		});
 		const commitBindings = vi.fn();
 		mount(graph, reconciliation(), { inventory: setupInventory, previewBindings, commitBindings });
-		const firstConfirmation = [
-			...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-		].find((input) => input.parentElement?.textContent?.includes("Confirm One belongs"));
-		if (!firstConfirmation) throw new Error("confirmation missing");
-		setCheckbox(firstConfirmation);
+		const firstSelection = cardCheckbox(deviceCard("One"), "Select for setup");
+		setCheckbox(firstSelection);
 		await act(async () => {
 			(
 				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Review setup" && !button.disabled,
+					(button) => button.textContent === "Review this device" && !button.disabled,
 				) as HTMLButtonElement
 			).click();
 		});
@@ -963,7 +1027,7 @@ describe("read-only Devices", () => {
 			commitBindings,
 		});
 
-		expect(firstConfirmation.checked).toBe(true);
+		expect(firstSelection.checked).toBe(true);
 		expect(document.body.textContent).toContain("Review Identity setup");
 		for (const control of document.querySelectorAll<
 			HTMLButtonElement | HTMLInputElement | HTMLSelectElement
@@ -976,11 +1040,11 @@ describe("read-only Devices", () => {
 		expect(commitBindings).not.toHaveBeenCalled();
 
 		mount(graph, reconciliation(), { inventory: setupInventory, previewBindings, commitBindings });
-		expect(firstConfirmation.checked).toBe(true);
+		expect(firstSelection.checked).toBe(true);
 		expect(document.body.textContent).toContain("Review Identity setup");
 		expect(
 			[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-				(button) => button.textContent === "Review setup",
+				(button) => button.textContent === "Review this device",
 			)?.disabled,
 		).toBe(false);
 	});
@@ -1013,18 +1077,10 @@ describe("read-only Devices", () => {
 			writeCount: 1,
 		});
 		mount(graph, reconciliation(), { inventory: inventory([item]), previewBindings });
-		const confirmation = [
-			...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-		].find((input) => input.parentElement?.textContent?.includes("Confirm One belongs"));
-		if (!confirmation) throw new Error("confirmation missing");
-		confirmation.checked = true;
-		act(() => {
-			confirmation.dispatchEvent(new Event("input", { bubbles: true }));
-		});
 		await act(async () => {
 			(
 				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Review setup",
+					(button) => button.textContent === "Review this device",
 				) as HTMLButtonElement
 			).click();
 		});
@@ -1084,7 +1140,7 @@ describe("read-only Devices", () => {
 		);
 		const previewBindings = vi.fn();
 		mount(intent(), reconciliation(), { inventory: inventory(setupItems), previewBindings });
-		setCheckbox(cardCheckbox(deviceCard("One"), "Confirm One belongs"));
+		setCheckbox(cardCheckbox(deviceCard("One"), "Select for setup"));
 		expect(document.body.textContent).toContain("Review 1 selected");
 
 		mount(intent(), reconciliation(), {
@@ -1100,7 +1156,7 @@ describe("read-only Devices", () => {
 		expect(previewBindings).not.toHaveBeenCalled();
 	});
 
-	it("retains an explicit target but clears confirmation and selection when its evidence changes", () => {
+	it("retains an explicit target but clears selection when its evidence changes", () => {
 		const graph = intent({
 			identities: [
 				...intent().identities,
@@ -1126,7 +1182,7 @@ describe("read-only Devices", () => {
 		act(() => {
 			select.dispatchEvent(new Event("input", { bubbles: true }));
 		});
-		setCheckbox(cardCheckbox(card, "Confirm One belongs"));
+		setCheckbox(cardCheckbox(card, "Select for setup"));
 
 		mount(graph, reconciliation(), {
 			inventory: inventory([
@@ -1144,12 +1200,12 @@ describe("read-only Devices", () => {
 		expect(updatedCard.querySelector<HTMLSelectElement>("select")?.value).toBe(
 			"identity-scope-secret",
 		);
-		expect(cardCheckbox(updatedCard, "Confirm One belongs").checked).toBe(false);
-		expect(cardCheckbox(updatedCard, "Include in reviewed setup").checked).toBe(false);
+		expect(updatedCard.querySelectorAll('input[type="checkbox"]')).toHaveLength(1);
+		expect(cardCheckbox(updatedCard, "Select for setup").checked).toBe(false);
 		expect(document.body.textContent).toContain("Review 0 selected");
 	});
 
-	it("preserves an unchanged device confirmation when unrelated device evidence changes", () => {
+	it("preserves selection for an unchanged active target when unrelated evidence changes", () => {
 		const one = inventoryItem("one", "One", "setup_required", {
 			suggestedIdentityId: "identity-scope-secret",
 			validatedFingerprint: "one-fingerprint",
@@ -1159,13 +1215,16 @@ describe("read-only Devices", () => {
 			validatedFingerprint: "two-fingerprint",
 		});
 		mount(intent(), reconciliation(), { inventory: inventory([one, two]) });
-		setCheckbox(cardCheckbox(deviceCard("One"), "Confirm One belongs"));
+		setCheckbox(cardCheckbox(deviceCard("One"), "Select for setup"));
 
 		mount(intent(), reconciliation(), {
 			inventory: inventory([one, { ...two, validatedFingerprint: "two-fingerprint-updated" }]),
 		});
-		expect(cardCheckbox(deviceCard("One"), "Confirm One belongs").checked).toBe(true);
-		expect(cardCheckbox(deviceCard("One"), "Include in reviewed setup").checked).toBe(true);
+		expect(deviceCard("One").querySelectorAll('input[type="checkbox"]')).toHaveLength(1);
+		expect(deviceCard("One").querySelector<HTMLSelectElement>("select")?.value).toBe(
+			"identity-scope-secret",
+		);
+		expect(cardCheckbox(deviceCard("One"), "Select for setup").checked).toBe(true);
 		expect(document.body.textContent).toContain("Review 1 selected");
 	});
 
@@ -1199,19 +1258,24 @@ describe("read-only Devices", () => {
 			commitBindings,
 		});
 		for (const name of ["One", "Two", "Three"]) {
-			setCheckbox(cardCheckbox(deviceCard(name), `Confirm ${name} belongs`));
+			setCheckbox(cardCheckbox(deviceCard(name), "Select for setup"));
 		}
 		expect(document.body.textContent).toContain("Review 3 selected");
 		await act(async () => {
 			(
 				[...deviceCard("Three").querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Review setup",
+					(button) => button.textContent === "Review this device",
 				) as HTMLButtonElement
 			).click();
 		});
 		expect(previewBindings).toHaveBeenCalledWith({
 			bindings: [{ deviceId: "three", targetIdentityId: "identity-scope-secret", confirmed: true }],
 		});
+		expect(
+			[...document.querySelectorAll<HTMLButtonElement>("button")].find(
+				(button) => button.textContent === "Apply setup to 1 device",
+			),
+		).toBeTruthy();
 		setCheckbox(
 			[...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')].find((input) =>
 				input.parentElement?.textContent?.includes("I reviewed every device"),
@@ -1220,7 +1284,7 @@ describe("read-only Devices", () => {
 		await act(async () => {
 			(
 				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Confirm Identity setup",
+					(button) => button.textContent === "Apply setup to 1 device",
 				) as HTMLButtonElement
 			).click();
 		});
@@ -1291,15 +1355,10 @@ describe("read-only Devices", () => {
 			previewBindings,
 			commitBindings,
 		});
-		const confirmation = [
-			...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-		].find((input) => input.parentElement?.textContent?.includes("Confirm One belongs"));
-		if (!confirmation) throw new Error("confirmation missing");
-		setCheckbox(confirmation);
 		await act(async () => {
 			(
 				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Review setup",
+					(button) => button.textContent === "Review this device",
 				) as HTMLButtonElement
 			).click();
 		});
@@ -1326,18 +1385,10 @@ describe("read-only Devices", () => {
 			]),
 			previewBindings,
 		});
-		const confirmation = [
-			...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-		].find((input) => input.parentElement?.textContent?.includes("Confirm One belongs"));
-		if (!confirmation) throw new Error("confirmation missing");
-		confirmation.checked = true;
-		act(() => {
-			confirmation.dispatchEvent(new Event("input", { bubbles: true }));
-		});
 		act(() => {
 			(
 				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Review setup",
+					(button) => button.textContent === "Review this device",
 				) as HTMLButtonElement
 			).click();
 		});
@@ -1722,21 +1773,18 @@ describe("read-only Devices", () => {
 		act(() => {
 			identitySelect.dispatchEvent(new Event("input", { bubbles: true }));
 		});
-		const confirmation = [
-			...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-		].find((input) => input.parentElement?.textContent?.includes("Confirm One belongs"));
-		if (!confirmation) throw new Error("confirmation missing");
-		confirmation.checked = true;
-		act(() => {
-			confirmation.dispatchEvent(new Event("input", { bubbles: true }));
-		});
 		await act(async () =>
 			(
 				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Review setup",
+					(button) => button.textContent === "Review this device",
 				) as HTMLButtonElement
 			).click(),
 		);
+		expect(
+			[...document.querySelectorAll<HTMLButtonElement>("button")].find(
+				(button) => button.textContent === "Apply setup to 1 device",
+			),
+		).toBeTruthy();
 		const finalConfirmation = [
 			...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
 		].find((input) => input.parentElement?.textContent?.includes("I reviewed every device"));
@@ -1748,7 +1796,7 @@ describe("read-only Devices", () => {
 		await act(async () => {
 			(
 				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Confirm Identity setup",
+					(button) => button.textContent === "Apply setup to 1 device",
 				) as HTMLButtonElement
 			).click();
 			await Promise.resolve();

--- a/packages/ui/src/tabs/devices.tsx
+++ b/packages/ui/src/tabs/devices.tsx
@@ -257,7 +257,6 @@ function ProjectList({ empty, projects }: { empty: string; projects: DeviceProje
 
 interface SetupChoice {
 	targetIdentityId: string;
-	confirmed: boolean;
 	selected: boolean;
 	explicit: boolean;
 	itemSignature: string;
@@ -325,7 +324,6 @@ function newSetupChoice(
 			identityIds.has(item.suggestedIdentityId)
 				? item.suggestedIdentityId
 				: "",
-		confirmed: false,
 		selected: false,
 		explicit: false,
 		itemSignature: setupItemSignature(item),
@@ -445,11 +443,7 @@ function SetupWorkflow({
 					}
 					const targetStillActive =
 						existing.targetIdentityId !== "" && identityIds.has(existing.targetIdentityId);
-					if (
-						existing.itemSignature === setupItemSignature(item) &&
-						existing.explicit &&
-						targetStillActive
-					) {
+					if (existing.itemSignature === setupItemSignature(item) && targetStillActive) {
 						return [item.deviceId, existing];
 					}
 					if (existing.explicit && targetStillActive) {
@@ -457,7 +451,6 @@ function SetupWorkflow({
 							item.deviceId,
 							{
 								...existing,
-								confirmed: false,
 								selected: false,
 								itemSignature: setupItemSignature(item),
 							},
@@ -492,7 +485,9 @@ function SetupWorkflow({
 			return {
 				deviceId: item.deviceId,
 				targetIdentityId: choice?.targetIdentityId ?? "",
-				confirmed: choice?.confirmed === true,
+				// The API requires this marker to preview a binding. Final consent remains gated by
+				// the reviewed digest and the confirmation control shown after the server preview.
+				confirmed: true,
 			};
 		}),
 	});
@@ -515,14 +510,9 @@ function SetupWorkflow({
 		}
 		if (
 			selected.length === 0 ||
-			selected.some((item) => {
-				const choice = choices[item.deviceId];
-				return !choice?.targetIdentityId || !choice.confirmed;
-			})
+			selected.some((item) => !choices[item.deviceId]?.targetIdentityId)
 		) {
-			setErrorMessage(
-				"Choose and explicitly confirm an Identity for every selected device before review.",
-			);
+			setErrorMessage("Choose an Identity for every selected device before review.");
 			return;
 		}
 		setBusy(true);
@@ -595,9 +585,6 @@ function SetupWorkflow({
 					const choice = choices[item.deviceId];
 					const gate = deviceIdentitySetupGate(inventory, item);
 					const setupBlocked = gate.blocked || inventoryUnavailable;
-					const targetIdentity = choice?.targetIdentityId
-						? (identityNames.get(choice.targetIdentityId) ?? "Unavailable Identity")
-						: "";
 					const titleId = `device-inventory-title-${index}`;
 					return (
 						<li key={item.deviceId}>
@@ -623,111 +610,111 @@ function SetupWorkflow({
 									</span>
 								</div>
 								{item.state === "setup_required" ? (
-									<fieldset>
-										<legend>Assign an existing Identity</legend>
-										{identities.length === 0 ? (
-											<>
+									<>
+										<fieldset>
+											<legend>Assign an existing Identity</legend>
+											{identities.length === 0 ? (
 												<p>
 													No active Identity is available. Create or restore an Identity before
 													setup.
 												</p>
+											) : null}
+											{setupRequired.length > 1 ? (
+												<label>
+													<input
+														aria-label={`Select for setup: ${item.displayName}`}
+														checked={choice?.selected ?? false}
+														disabled={setupBlocked}
+														onInput={(event) =>
+															update(item.deviceId, { selected: event.currentTarget.checked })
+														}
+														type="checkbox"
+													/>{" "}
+													Select for setup
+												</label>
+											) : null}
+											<label htmlFor={`${titleId}-identity`}>Identity</label>
+											<select
+												aria-label={`Choose an Identity for ${item.displayName}`}
+												disabled={setupBlocked}
+												id={`${titleId}-identity`}
+												onInput={(event) =>
+													update(item.deviceId, {
+														targetIdentityId: event.currentTarget.value,
+														explicit: true,
+													})
+												}
+												value={choice?.targetIdentityId ?? ""}
+											>
+												<option value="">Choose Identity…</option>
+												{identities.map((identity) => (
+													<option key={identity.identityId} value={identity.identityId}>
+														{identity.displayName}
+													</option>
+												))}
+											</select>
+											{item.suggestedIdentityId && identityNames.has(item.suggestedIdentityId) ? (
+												<p className="small">
+													Suggested from historical device information. Review it before applying
+													setup.
+												</p>
+											) : null}
+											{gate.recovery ? <p className="small">{gate.recovery}</p> : null}
+										</fieldset>
+										<div className="device-identity-card-actions">
+											{identities.length === 0 ? (
 												<button
+													aria-label={`Open Identity administration for ${item.displayName}`}
 													className="settings-button"
 													onClick={() => options.onNavigate?.("advanced_sync")}
 													type="button"
 												>
 													Open Identity administration
 												</button>
-											</>
-										) : null}
-										<label>
-											<input
-												checked={choice?.selected ?? false}
-												disabled={setupBlocked}
-												onInput={(event) =>
-													update(item.deviceId, { selected: event.currentTarget.checked })
-												}
-												type="checkbox"
-											/>{" "}
-											Include in reviewed setup
-										</label>
-										<label htmlFor={`${titleId}-identity`}>Identity</label>
-										<select
-											disabled={setupBlocked}
-											id={`${titleId}-identity`}
-											onInput={(event) =>
-												update(item.deviceId, {
-													targetIdentityId: event.currentTarget.value,
-													confirmed: false,
-													explicit: true,
-												})
-											}
-											value={choice?.targetIdentityId ?? ""}
-										>
-											<option value="">Choose Identity…</option>
-											{identities.map((identity) => (
-												<option key={identity.identityId} value={identity.identityId}>
-													{identity.displayName}
-												</option>
-											))}
-										</select>
-										{item.suggestedIdentityId && identityNames.has(item.suggestedIdentityId) ? (
-											<p className="small">
-												Suggested from historical device information. Confirm it before setup.
-											</p>
-										) : null}
-										<label>
-											<input
-												checked={choice?.confirmed ?? false}
-												disabled={setupBlocked || !choice?.targetIdentityId}
-												onInput={(event) =>
-													update(item.deviceId, {
-														confirmed: event.currentTarget.checked,
-														selected: event.currentTarget.checked || choice?.selected === true,
-														explicit: event.currentTarget.checked || choice?.explicit === true,
-													})
-												}
-												type="checkbox"
-											/>{" "}
-											Confirm {item.displayName} belongs to{" "}
-											{targetIdentity || "the selected Identity"}
-										</label>
-										<button
-											className="settings-button"
-											disabled={busy || setupBlocked}
-											onClick={() => void review([item])}
-											type="button"
-										>
-											Review setup
-										</button>
-										{gate.recovery ? <p className="small">{gate.recovery}</p> : null}
-									</fieldset>
+											) : null}
+											<button
+												aria-label={`Review this device: ${item.displayName}`}
+												className="settings-button"
+												disabled={busy || setupBlocked || !choice?.targetIdentityId}
+												onClick={() => void review([item])}
+												type="button"
+											>
+												Review this device
+											</button>
+										</div>
+									</>
 								) : item.state === "pairing_required" ? (
 									<>
 										<p>
 											Pair this device first. Pairing establishes trust but does not choose its
 											Identity.
 										</p>
-										<button
-											className="settings-button"
-											onClick={() => options.onNavigate?.("advanced_sync")}
-											type="button"
-										>
-											Go to pairing
-										</button>
+										<div className="device-identity-card-actions">
+											<button
+												aria-label={`Go to pairing for ${item.displayName}`}
+												className="settings-button"
+												onClick={() => options.onNavigate?.("advanced_sync")}
+												type="button"
+											>
+												Go to pairing
+											</button>
+										</div>
 									</>
 								) : item.state === "conflicted" ? (
 									<>
 										<p>
 											Device evidence conflicts. Review and repair it before assigning an Identity.
 										</p>
-										<button
-											className="settings-button"
-											onClick={() => options.onNavigate?.("advanced_sync")}
-											type="button"
-										>
-											Open Advanced review
-										</button>
+										<div className="device-identity-card-actions">
+											<button
+												aria-label={`Open Advanced review for ${item.displayName}`}
+												className="settings-button"
+												onClick={() => options.onNavigate?.("advanced_sync")}
+												type="button"
+											>
+												Open Advanced review
+											</button>
+										</div>
 									</>
 								) : null}
 							</article>
@@ -785,7 +772,8 @@ function SetupWorkflow({
 							onClick={() => void commit()}
 							type="button"
 						>
-							Confirm Identity setup
+							Apply setup to {reviewed.request.bindings.length.toLocaleString()}{" "}
+							{reviewed.request.bindings.length === 1 ? "device" : "devices"}
 						</button>
 					</div>
 				</section>

--- a/packages/ui/static/controls.css
+++ b/packages/ui/static/controls.css
@@ -1,0 +1,196 @@
+/* Global native-control baseline. Keep selectors low-specificity so component
+ * styles can refine layout and variants without opting out of theme safety. */
+
+:where(button, input, select, textarea) {
+  color: var(--text-primary);
+  font: inherit;
+}
+
+:where(
+  button,
+  input[type="button"],
+  input[type="reset"],
+  input[type="submit"]
+) {
+  border: 1px solid var(--control-border);
+  border-radius: var(--radius-sm);
+  background: var(--control-bg);
+  color: var(--control-text);
+  cursor: pointer;
+  padding: var(--sp-2) var(--sp-3);
+}
+
+:where(
+  input:not([type]),
+  input[type="date"],
+  input[type="datetime-local"],
+  input[type="email"],
+  input[type="month"],
+  input[type="number"],
+  input[type="password"],
+  input[type="search"],
+  input[type="tel"],
+  input[type="text"],
+  input[type="time"],
+  input[type="url"],
+  input[type="week"],
+  select,
+  textarea
+) {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--input-bg);
+  padding: var(--sp-2) var(--sp-3);
+}
+
+:where(select) {
+  cursor: pointer;
+}
+
+:where(textarea) {
+  resize: vertical;
+}
+
+:where(input, textarea)::placeholder {
+  color: var(--text-tertiary);
+  opacity: 1;
+}
+
+:where(
+  button:hover:not(:disabled),
+  input[type="button"]:hover:not(:disabled),
+  input[type="reset"]:hover:not(:disabled),
+  input[type="submit"]:hover:not(:disabled)
+) {
+  border-color: var(--control-hover-border);
+  background: var(--control-hover-bg);
+}
+
+:where(
+  input:not([type]):hover:not(:disabled),
+  input[type="date"]:hover:not(:disabled),
+  input[type="datetime-local"]:hover:not(:disabled),
+  input[type="email"]:hover:not(:disabled),
+  input[type="month"]:hover:not(:disabled),
+  input[type="number"]:hover:not(:disabled),
+  input[type="password"]:hover:not(:disabled),
+  input[type="search"]:hover:not(:disabled),
+  input[type="tel"]:hover:not(:disabled),
+  input[type="text"]:hover:not(:disabled),
+  input[type="time"]:hover:not(:disabled),
+  input[type="url"]:hover:not(:disabled),
+  input[type="week"]:hover:not(:disabled),
+  select:hover:not(:disabled),
+  textarea:hover:not(:disabled)
+) {
+  border-color: var(--border-hover);
+}
+
+:where(button, input, select, textarea):focus-visible {
+  border-color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px var(--focus-ring);
+}
+
+:where(input[type="checkbox"], input[type="radio"]) {
+  appearance: none;
+  display: inline-grid;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  margin: 0;
+  place-content: center;
+  border: 1px solid color-mix(in srgb, var(--text-tertiary) 85%, var(--surface-1));
+  background: var(--surface-1);
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+:where(input[type="checkbox"]) {
+  border-radius: 4px;
+}
+
+:where(input[type="radio"]) {
+  border-radius: 50%;
+}
+
+:where(input[type="checkbox"]):checked,
+:where(input[type="checkbox"]):indeterminate,
+:where(input[type="radio"]):checked {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+:where(input[type="checkbox"])::before {
+  width: 4px;
+  height: 8px;
+  border: solid var(--text-inverse);
+  border-width: 0 2px 2px 0;
+  content: "";
+  transform: scale(0) rotate(45deg);
+}
+
+:where(input[type="checkbox"]):checked::before {
+  transform: scale(1) rotate(45deg);
+}
+
+:where(input[type="checkbox"]):indeterminate::before {
+  width: 8px;
+  height: 2px;
+  border: 0;
+  background: var(--text-inverse);
+  transform: scale(1);
+}
+
+:where(input[type="radio"])::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-inverse);
+  content: "";
+  transform: scale(0);
+}
+
+:where(input[type="radio"]):checked::before {
+  transform: scale(1);
+}
+
+:where(input[type="range"], progress) {
+  accent-color: var(--accent);
+}
+
+:where(input[type="file"])::file-selector-button {
+  margin-right: var(--sp-3);
+  border: 1px solid var(--control-border);
+  border-radius: var(--radius-sm);
+  background: var(--control-bg);
+  color: var(--control-text);
+  cursor: pointer;
+  font: inherit;
+  padding: var(--sp-2) var(--sp-3);
+}
+
+:where(input[type="file"]:not(:disabled))::file-selector-button:hover {
+  border-color: var(--control-hover-border);
+  background: var(--control-hover-bg);
+}
+
+:where(input[type="file"]:disabled)::file-selector-button {
+  cursor: not-allowed;
+}
+
+:where(button, input, select, textarea):disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+@media (forced-colors: active) {
+  :where(input[type="checkbox"], input[type="radio"]) {
+    appearance: auto;
+  }
+
+  :where(button, input, select, textarea):focus-visible {
+    outline: 2px solid CanvasText;
+  }
+}

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -22,6 +22,7 @@
     </script>
     <link rel="stylesheet" href="/assets/tokens.css" />
     <link rel="stylesheet" href="/assets/themes.css" />
+    <link rel="stylesheet" href="/assets/controls.css" />
     <style>
       /* Design tokens (color, surface, accent, status, chrome, body bg,
          inputs, toggles, spacing, radii, typography, motion) and the light
@@ -30,10 +31,12 @@
            1. Dark defaults from tokens.css (:root).
            2. Light overrides from themes.css ([data-theme="light"] +
               @media (prefers-color-scheme: light)).
-           3. The component-level rules below, which reference the tokens
+           3. Low-specificity native controls from controls.css.
+           4. The component-level rules below, which reference the tokens
               via var(--...).
          Edit packages/ui/static/tokens.css and themes.css to change the
-         token surface. Edit this <style> block for per-component styling. */
+         token surface, controls.css for native-control defaults, and this
+         <style> block for per-component styling. */
 
       /* ── Reset & base ──────────────────────────────────────── */
 
@@ -1308,7 +1311,17 @@
         margin-top: var(--sp-2);
         padding-left: var(--sp-5);
       }
-      #devicesMount .recipient-policy-sharing-card > .settings-button { margin-top: var(--sp-4); }
+      #devicesMount .recipient-policy-sharing-card > .settings-button {
+        align-self: end;
+        margin-top: var(--sp-4);
+      }
+
+      #devicesMount .device-identity-card-actions {
+        align-self: end;
+        display: grid;
+        gap: var(--sp-2);
+        margin-top: var(--sp-4);
+      }
       .device-identity-setup-summary,
       .recipient-policy-sharing-attention {
         display: flex;
@@ -1357,7 +1370,8 @@
         .recipient-policy-sharing-responsive-tabs { overflow-x: auto; }
         .recipient-policy-sharing-details div { grid-template-columns: 1fr; gap: var(--sp-1); }
         .recipient-policy-invitation-result { padding: var(--sp-3); }
-        #devicesMount .recipient-policy-sharing-card > .settings-button {
+        #devicesMount .recipient-policy-sharing-card > .settings-button,
+        #devicesMount .device-identity-card-actions .settings-button {
           min-height: 44px;
           width: 100%;
         }
@@ -3385,35 +3399,6 @@
         transform: translateX(14px);
         background: color-mix(in srgb, var(--accent) 88%, white);
         border-color: color-mix(in srgb, var(--accent) 42%, transparent);
-      }
-      .cm-checkbox {
-        appearance: none;
-        width: 16px;
-        height: 16px;
-        border: 1px solid var(--border-hover);
-        border-radius: 4px;
-        background: var(--surface-1);
-        position: relative;
-        cursor: pointer;
-      }
-      .cm-checkbox:checked {
-        background: var(--accent);
-        border-color: var(--accent);
-      }
-      .cm-checkbox:checked::after {
-        content: "";
-        position: absolute;
-        left: 4px;
-        top: 1px;
-        width: 4px;
-        height: 8px;
-        border: solid var(--text-inverse);
-        border-width: 0 2px 2px 0;
-        transform: rotate(45deg);
-      }
-      .cm-checkbox:focus-visible {
-        outline: 2px solid var(--focus-ring);
-        outline-offset: 1px;
       }
       .field textarea { resize: vertical; min-height: 84px; }
       .settings-save {

--- a/packages/ui/static/themes.css
+++ b/packages/ui/static/themes.css
@@ -11,6 +11,8 @@
  * trivially auditable without depending on extra cascade tricks. */
 
 [data-theme="light"] {
+  color-scheme: light;
+
   /* Surface */
   --surface-0: #f7faf8;
   --surface-1: #ffffff;
@@ -81,6 +83,8 @@
 
 @media (prefers-color-scheme: light) {
   :root:not([data-theme="dark"]) {
+    color-scheme: light;
+
     --surface-0: #f7faf8;
     --surface-1: #ffffff;
     --surface-2: #eef5f1;

--- a/packages/ui/static/tokens.css
+++ b/packages/ui/static/tokens.css
@@ -10,6 +10,8 @@
  * Values come from the codemem design handoff (tokens/colors_and_type.css). */
 
 :root {
+  color-scheme: dark;
+
   /* Surface — deep ink */
   --surface-0: #0b1016;
   --surface-1: #0f1720;

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -95,6 +95,9 @@ export default defineConfig(({ command, mode }) => {
 					]),
 		],
 		test: {
+			css: {
+				include: [/\/static\/(?:controls|themes|tokens)\.css(?:\?inline)?$/],
+			},
 			environment: "jsdom",
 			name: "ui",
 			server: {


### PR DESCRIPTION
## Description

Add a token-driven, low-specificity baseline for native form controls so new buttons, fields, selects, checkboxes, radios, file inputs, ranges, and progress indicators cannot fall back to mismatched browser styling. The baseline covers dark/light browser color schemes, visible keyboard focus, disabled states, accessible unchecked-state contrast, and a native forced-colors fallback.

The UI build now stages and precompresses the new stylesheet, with a contract test tying linked static stylesheets to the staging list.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Automated results: 202 test files passed; 4,631 tests passed and 3 remain todo. `pnpm --filter @codemem/ui build` passed and emitted raw, Brotli, and gzip forms of `controls.css`. Snyk Code reported zero high-severity issues. A browser-based visual pass was not available in this environment.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced