### PR TITLE
chore(deps): align pnpm with repository toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "pnpm": {
     "strictPeerDependencies": false
   }


### PR DESCRIPTION
## Description

Align the workspace package-manager pin with the repository-required pnpm 10.33.0 toolchain, including Corepack integrity metadata. The lockfile and dependency graph are unchanged.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated using pnpm 10.33.0: frozen-lockfile install, full `pnpm run check`, and the build-backed E2E smoke scenario all passed. The workspace suite reported 4,627 passing tests and 3 todo. Two raw-event tests timed out during the first full-suite run, then passed in isolation (29/29) and in the complete rerun.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed)
- [x] No new warnings introduced
