### PR TITLE
fix(sync): add recipient-bound signature primitives

### DIFF
--- a/docs/plans/2026-08-20-recipient-bound-peer-signatures-design.md
+++ b/docs/plans/2026-08-20-recipient-bound-peer-signatures-design.md
@@ -1,0 +1,125 @@
+# Recipient-bound peer signatures
+
+**Date:** 2026-08-20
+**Status:** Approved
+
+## Decision
+
+Direct-peer sync adds recipient-bound signature v3. It is additive: legacy v2 bytes stay unchanged, while upgraded direct peers send v3 and remember that a peer has done so. A later v2-only request from that peer is rejected.
+
+This fixes a verified replay threat: a valid v2 request proves who signed it, but not which peer it was intended for. An attacker able to redirect or replay that signed material to another trusted peer can reuse it within the timestamp/nonce window. Recipient binding makes that request invalid at every other peer.
+
+## Alternatives
+
+| Option | Result |
+| --- | --- |
+| Flag day | Require v3 everywhere immediately. Simple end state, but breaks mixed-version direct-peer sync. |
+| **Dual additive rollout (selected)** | Keep v2 intact; add v3 for direct peers; lock each peer to v3 after first valid v3 request. Preserves rollout compatibility without allowing silent downgrade after upgrade. |
+
+Mutual TLS was not selected for this change. It could provide channel confidentiality and mutual identity, but it would also add certificate issuance, trust distribution, address continuity, rotation, and recovery. Recipient binding fixes the verified request-level replay flaw without requiring that larger transport migration.
+
+## Wire contract
+
+### Existing v2 (unchanged)
+
+Direct peers and coordinators retain the existing headers:
+
+```http
+X-Opencode-Device: sender-device-id
+X-Opencode-Timestamp: unix-seconds
+X-Opencode-Nonce: random-hex
+X-Opencode-Signature: v2:base64-ed25519-signature
+```
+
+The signed UTF-8 bytes remain exactly these five newline-separated fields:
+
+```text
+METHOD
+path-and-query
+timestamp
+nonce
+sha256(body-bytes)
+```
+
+### Direct-peer v3
+
+An upgraded direct-peer request preserves the legacy v2 signature and adds the intended stable device identity plus a separate v3 signature:
+
+```http
+X-Codemem-Recipient: target-device-id
+X-Codemem-Signature: v3:base64-ed25519-signature
+```
+
+Its canonical UTF-8 bytes are the v2 five fields followed by the recipient ID:
+
+```text
+METHOD
+path-and-query
+timestamp
+nonce
+sha256(body-bytes)
+target-device-id
+```
+
+The recipient header is part of the signed value, not a routing hint. Verification uses the sender device's pinned Ed25519 public key; a v3 signature is valid only for the exact recipient ID in its canonical bytes. Legacy servers ignore the additive Codemem headers and continue verifying `X-Opencode-Signature: v2:...`.
+
+## Direct-peer flow
+
+1. The client obtains the target's stable device ID from the selected/pinned peer and signs every direct request as v3.
+2. This covers status, ops pull and push, scoped ops, snapshot/bootstrap, probes, and sync-pass propagation.
+3. An upgraded server that receives v3 material verifies it and compares its signed recipient with its own stable `sync_device` ID. It never falls back to the accompanying v2 signature when v3 material is present but invalid.
+4. Only after a match does it record the nonce, advance the peer's observed signature version, and execute route behavior.
+
+Bootstrap-grant authorization follows the same recipient and version rules for the endpoints that permit bootstrap grants. It does not create a bypass for recipient binding.
+
+## Sticky anti-downgrade state
+
+Each direct peer has a persistent, monotonic `highest_observed_direct_signature_version` value.
+
+| Current state | Valid v2 | Valid v3 | Invalid or recipient mismatch |
+| --- | --- | --- | --- |
+| No v3 observed | Accept during migration | Accept; persist v3 | Reject; do not mutate state |
+| v3 observed | Reject as downgrade | Accept; remain v3 | Reject; do not mutate state |
+
+The field is additive and nullable. Fresh databases include it; existing databases receive an idempotent compatibility repair, including databases whose schema-compatibility marker was already set. There is no schema-version bump or destructive migration. A write may increase the value but never lower it.
+
+## Failure and privacy behavior
+
+| Condition | Wire response | State effect |
+| --- | --- | --- |
+| Valid v3 for another recipient | `401 unauthorized`; server diagnostic `recipient_mismatch` | No nonce or version update |
+| Valid v2 after v3 was observed | `401 unauthorized`; server diagnostic `signature_downgrade` | No version downgrade |
+| Invalid v3, missing required v3 material, unknown sender, stale timestamp, or replayed nonce | Generic unauthorized response | No version update |
+
+Detailed signature and grant diagnostics remain server-side. The wire response for invalid authentication is intentionally generic so it does not disclose key, grant, peer, or verification details. Existing rate, size, nonce, capability, and authorization checks remain in force.
+
+## Coordinator and Cloudflare invariance
+
+Recipient v3 is direct-peer-only. Coordinator clients keep their existing v1/v2 auth behavior and never send `X-Codemem-Recipient` or `X-Codemem-Signature`. Node and Cloudflare coordinator verifiers retain their existing canonical bytes and continue rejecting a v3 value supplied in the coordinator's `X-Opencode-Signature` header. The coordinator remains discovery and authorization metadata infrastructure, not a memory payload path.
+
+## Migration and deprecation
+
+Mixed direct-peer fleets work during the transition: a peer without recorded v3 support may use valid v2. Upgraded clients emit v3 whenever they know the target device ID; upgraded servers permanently reject v2 from a peer once that peer has demonstrated v3.
+
+V2 is deprecated for direct-peer traffic, not removed in this change. Removal requires a separately approved protocol transition after supported peers have migrated; unsupported older peers must then fail closed rather than silently receive a weaker path. Coordinator v2 is unaffected by that deprecation.
+
+## Delivery split
+
+1. **PR 1 — primitives and invariance:** this decision document; isolated v3 canonical/sign/verify helpers; immutable v2 fixtures; Node and Cloudflare coordinator invariance tests. No direct-peer call-site, enforcement, schema, or coordinator production behavior changes.
+2. **PR 2 — propagation and enforcement:** recipient identity propagation; additive persistence; server-side recipient and downgrade enforcement; replay regressions; end-to-end coverage.
+
+## Tests
+
+- Fixture-test v2 canonical bytes and headers byte-for-byte.
+- Prove v3 accepts only the signed recipient.
+- Assert v3 headers on every direct route family: status, ops, scoped ops, snapshot/bootstrap, probes, and CLI bootstrap.
+- Replay an unchanged request for recipient A against recipient B on status, ops, and snapshot; each must fail before nonce/version mutation.
+- Prove valid v2 remains transitional before v3 observation and fails after it.
+- Prove coordinator Node and Cloudflare paths retain v2 behavior and reject v3.
+- Run focused core, server, and Worker tests, followed by type checking, linting, and the workspace suite.
+
+## Out of scope
+
+- Relay transport or relay approval.
+- Transport/channel confidentiality.
+- TLS or mutual TLS deployment, certificate lifecycle, or peer address trust.

--- a/packages/cloudflare-coordinator-worker/src/index.test.ts
+++ b/packages/cloudflare-coordinator-worker/src/index.test.ts
@@ -471,6 +471,73 @@ describe("createCloudflareCoordinatorWorker", () => {
 		expect(await res.json()).toEqual({ error: "body_too_large" });
 	});
 
+	it("accepts the legacy v2 canonical request and rejects v3 in its signature slot", async () => {
+		// Arrange
+		const identityDb = connect(join(tmpDir, "signature-invariance.sqlite"));
+		const keysDir = join(tmpDir, "signature-invariance-keys");
+		try {
+			initTestSchema(identityDb);
+			const [deviceId, fingerprint] = ensureDeviceIdentity(identityDb, { keysDir });
+			const publicKey = loadPublicKey(keysDir);
+			if (!publicKey) throw new Error("expected device public key");
+
+			const store = new D1CoordinatorStore(d1db);
+			await store.createGroup("g1", "Team One");
+			await store.enrollDevice("g1", { deviceId, fingerprint, publicKey });
+			await store.close();
+
+			const worker = createCloudflareCoordinatorWorker();
+			const body = JSON.stringify({
+				group_id: "g1",
+				fingerprint,
+				addresses: ["http://127.0.0.1:7337"],
+				ttl_s: 180,
+			});
+			const headers = buildAuthHeaders({
+				deviceId,
+				method: "POST",
+				url: "https://coord.example.test/v1/presence",
+				bodyBytes: Buffer.from(body),
+				keysDir,
+				timestamp: String(Math.floor(Date.now() / 1000)),
+				nonce: "worker-coordinator-v2-fixture",
+			});
+			const env = {
+				COORDINATOR_DB: d1db,
+				CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET: "test-secret",
+			};
+
+			// Act
+			const accepted = await worker.fetch(
+				new Request("https://coord.example.test/v1/presence", {
+					method: "POST",
+					headers: { ...headers, "Content-Type": "application/json" },
+					body,
+				}),
+				env,
+			);
+			const rejected = await worker.fetch(
+				new Request("https://coord.example.test/v1/presence", {
+					method: "POST",
+					headers: {
+						...headers,
+						"Content-Type": "application/json",
+						"X-Opencode-Signature": headers["X-Opencode-Signature"].replace(/^v2:/u, "v3:"),
+					},
+					body,
+				}),
+				env,
+			);
+
+			// Assert
+			expect(accepted.status).toBe(200);
+			expect(rejected.status).toBe(401);
+			expect(await rejected.json()).toEqual({ error: "invalid_signature" });
+		} finally {
+			identityDb.close();
+		}
+	});
+
 	it("supports invite, join approval, signed presence, and signed peer lookup through the worker entrypoint", async () => {
 		const worker = createCloudflareCoordinatorWorker({
 			now: () => "2026-03-28T00:00:00Z",

--- a/packages/core/src/coordinator-runtime.test.ts
+++ b/packages/core/src/coordinator-runtime.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createBetterSqliteCoordinatorApp } from "./better-sqlite-coordinator-runtime.js";
+import { BetterSqliteCoordinatorStore } from "./better-sqlite-coordinator-store.js";
 import {
 	advertisedSyncAddresses,
 	coordinatorStatusSnapshot,
@@ -16,6 +18,7 @@ import {
 	trustCoordinatorPeersWithSharedManagedScopes,
 } from "./coordinator-runtime.js";
 import type { MemoryStore } from "./store.js";
+import { buildAuthHeaders } from "./sync-auth.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
 import { initTestSchema } from "./test-utils.js";
@@ -140,13 +143,16 @@ describe("advertisedSyncAddresses", () => {
 });
 
 describe("lookupCoordinatorPeers", () => {
-	it("merges multi-group device groups as plain strings", async () => {
+	it("merges multi-group device groups while emitting only coordinator v2 auth headers", async () => {
+		// Arrange
 		const db = new Database(":memory:");
 		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
 		const prevFetch = globalThis.fetch;
+		const requestHeaders: Headers[] = [];
 		try {
 			initTestSchema(db);
-			globalThis.fetch = (async (input: RequestInfo | URL) => {
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				requestHeaders.push(new Headers(init?.headers));
 				const url = new URL(String(input));
 				const groupId = url.searchParams.get("group_id") || "";
 				return new Response(
@@ -165,6 +171,7 @@ describe("lookupCoordinatorPeers", () => {
 				);
 			}) as typeof fetch;
 
+			// Act
 			const peers = await lookupCoordinatorPeers(
 				{ db, dbPath: ":memory:" },
 				readCoordinatorSyncConfig({
@@ -174,10 +181,17 @@ describe("lookupCoordinatorPeers", () => {
 				{ keysDir },
 			);
 
+			// Assert
 			expect(peers).toHaveLength(1);
 			expect(peers[0]?.coordinator_id).toBe("https://coord.example.test");
 			expect(peers[0]?.groups).toEqual(["team-a", "team-b"]);
 			expect(peers[0]?.fresh_groups).toEqual(["team-a", "team-b"]);
+			expect(requestHeaders).toHaveLength(2);
+			for (const headers of requestHeaders) {
+				expect(headers.get("X-Opencode-Signature")).toMatch(/^v2:/u);
+				expect(headers.has("X-Codemem-Recipient")).toBe(false);
+				expect(headers.has("X-Codemem-Signature")).toBe(false);
+			}
 		} finally {
 			globalThis.fetch = prevFetch;
 			db.close();
@@ -231,6 +245,72 @@ describe("lookupCoordinatorPeers", () => {
 			globalThis.fetch = prevFetch;
 			db.close();
 			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("Node coordinator signature invariance", () => {
+	it("accepts the legacy v2 canonical request and rejects v3 in its signature slot", async () => {
+		// Arrange
+		const coordinatorDir = mkdtempSync(join(tmpdir(), "codemem-node-coordinator-"));
+		const coordinatorDbPath = join(coordinatorDir, "coordinator.sqlite");
+		const deviceDb = new Database(":memory:");
+		const keysDir = join(coordinatorDir, "device-keys");
+		try {
+			initTestSchema(deviceDb);
+			const [deviceId, fingerprint] = ensureDeviceIdentity(deviceDb, { keysDir });
+			const publicKey = loadPublicKey(keysDir);
+			if (!publicKey) throw new Error("expected device public key");
+
+			const setupStore = new BetterSqliteCoordinatorStore(coordinatorDbPath);
+			await setupStore.createGroup("g1", "Team One");
+			await setupStore.enrollDevice("g1", {
+				deviceId,
+				fingerprint,
+				publicKey,
+			});
+			await setupStore.close();
+
+			const app = createBetterSqliteCoordinatorApp({ dbPath: coordinatorDbPath });
+			const body = JSON.stringify({
+				group_id: "g1",
+				fingerprint,
+				addresses: ["http://127.0.0.1:7337"],
+				ttl_s: 180,
+			});
+			const headers = buildAuthHeaders({
+				deviceId,
+				method: "POST",
+				url: "https://coordinator.example.test/v1/presence",
+				bodyBytes: Buffer.from(body),
+				keysDir,
+				timestamp: String(Math.floor(Date.now() / 1000)),
+				nonce: "node-coordinator-v2-fixture",
+			});
+
+			// Act
+			const accepted = await app.request("https://coordinator.example.test/v1/presence", {
+				method: "POST",
+				headers: { ...headers, "Content-Type": "application/json" },
+				body,
+			});
+			const rejected = await app.request("https://coordinator.example.test/v1/presence", {
+				method: "POST",
+				headers: {
+					...headers,
+					"Content-Type": "application/json",
+					"X-Opencode-Signature": headers["X-Opencode-Signature"].replace(/^v2:/u, "v3:"),
+				},
+				body,
+			});
+
+			// Assert
+			expect(accepted.status).toBe(200);
+			expect(rejected.status).toBe(401);
+			expect(await rejected.json()).toEqual({ error: "invalid_signature" });
+		} finally {
+			deviceDb.close();
+			rmSync(coordinatorDir, { recursive: true, force: true });
 		}
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1016,17 +1016,30 @@ export {
 } from "./summary-dedup-backfill.js";
 export { canonicalMemoryKind, getSummaryMetadata, isSummaryLikeMemory } from "./summary-memory.js";
 export type {
+	AuthHeaders,
 	BuildAuthHeadersOptions,
+	BuildDirectPeerAuthHeadersOptions,
+	DirectPeerAuthHeaders,
+	DirectPeerSignatureHeaders,
+	DirectPeerSignatureVerification,
+	SignDirectPeerRequestOptions,
+	SignedRequestHeaders,
 	SignRequestOptions,
+	VerifyDirectPeerSignatureOptions,
 	VerifySignatureOptions,
 } from "./sync-auth.js";
 export {
 	buildAuthHeaders,
 	buildCanonicalRequest,
+	buildDirectPeerAuthHeaders,
+	buildDirectPeerCanonicalRequest,
 	cleanupNonces,
+	DIRECT_PEER_SIGNATURE_VERSION,
 	recordNonce,
 	SIGNATURE_VERSION,
+	signDirectPeerRequest,
 	signRequest,
+	verifyDirectPeerSignature,
 	verifySignature,
 } from "./sync-auth.js";
 export { DEFAULT_TIME_WINDOW_S } from "./sync-auth-constants.js";

--- a/packages/core/src/sync-auth.test.ts
+++ b/packages/core/src/sync-auth.test.ts
@@ -8,9 +8,13 @@ import { connect } from "./db.js";
 import {
 	buildAuthHeaders,
 	buildCanonicalRequest,
+	buildDirectPeerAuthHeaders,
+	buildDirectPeerCanonicalRequest,
 	cleanupNonces,
 	recordNonce,
+	signDirectPeerRequest,
 	signRequest,
+	verifyDirectPeerSignature,
 	verifySignature,
 } from "./sync-auth.js";
 import {
@@ -100,6 +104,20 @@ describe("sync-auth", () => {
 	// -- buildCanonicalRequest ----------------------------------------------
 
 	describe("buildCanonicalRequest", () => {
+		it("preserves the legacy v2 canonical bytes", () => {
+			const result = buildCanonicalRequest(
+				"get",
+				"/api/sync/status?scope=all",
+				"1700000000",
+				"fixture-nonce",
+				Buffer.alloc(0),
+			);
+
+			expect(result.toString("utf-8")).toBe(
+				"GET\n/api/sync/status?scope=all\n1700000000\nfixture-nonce\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			);
+		});
+
 		it("produces deterministic output", () => {
 			const body = Buffer.from('{"hello":"world"}');
 			const r1 = buildCanonicalRequest("POST", "/api/sync", "1700000000", "abc123", body);
@@ -125,6 +143,224 @@ describe("sync-auth", () => {
 			expect(lines[3]).toBe("n1");
 			// Line 4 is the SHA-256 hex digest of "test-body"
 			expect(lines[4]).toMatch(/^[0-9a-f]{64}$/);
+		});
+	});
+
+	describe("direct-peer v3 authentication", () => {
+		function setupIdentity() {
+			const keysDir = join(tmpDir, "direct-peer-keys");
+			const dbPath = join(tmpDir, "direct-peer.sqlite");
+			const db = connect(dbPath);
+			initTestSchema(db);
+			const [deviceId] = ensureDeviceIdentity(db, { keysDir });
+			const publicKey = loadPublicKey(keysDir);
+			if (!publicKey) throw new Error("expected public key after ensureDeviceIdentity");
+			return { db, deviceId, publicKey, keysDir };
+		}
+
+		it("appends the recipient to the unchanged five-field canonical request", () => {
+			const result = buildDirectPeerCanonicalRequest(
+				"get",
+				"/api/sync/status?scope=all",
+				"1700000000",
+				"fixture-nonce",
+				Buffer.alloc(0),
+				"recipient-device",
+			);
+
+			expect(result.toString("utf-8")).toBe(
+				"GET\n/api/sync/status?scope=all\n1700000000\nfixture-nonce\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\nrecipient-device",
+			);
+		});
+
+		it("signs and verifies only the matching recipient", () => {
+			const { db, deviceId, publicKey, keysDir } = setupIdentity();
+			try {
+				const timestamp = String(Math.floor(Date.now() / 1000));
+				const headers = signDirectPeerRequest({
+					method: "POST",
+					url: "https://peer.example.test/api/sync/ops?limit=10",
+					bodyBytes: Buffer.from("{}"),
+					recipientId: "recipient-a",
+					keysDir,
+					deviceId,
+					timestamp,
+					nonce: "v3-round-trip",
+				});
+
+				expect(
+					verifyDirectPeerSignature({
+						method: "POST",
+						pathWithQuery: "/api/sync/ops?limit=10",
+						bodyBytes: Buffer.from("{}"),
+						timestamp,
+						nonce: "v3-round-trip",
+						recipientId: headers["X-Codemem-Recipient"],
+						expectedRecipientId: "recipient-a",
+						signature: headers["X-Codemem-Signature"],
+						publicKey,
+					}),
+				).toEqual({ status: "valid", version: "v3" });
+
+				expect(
+					verifyDirectPeerSignature({
+						method: "POST",
+						pathWithQuery: "/api/sync/ops?limit=10",
+						bodyBytes: Buffer.from("{}"),
+						timestamp,
+						nonce: "v3-round-trip",
+						recipientId: headers["X-Codemem-Recipient"],
+						expectedRecipientId: "recipient-b",
+						signature: headers["X-Codemem-Signature"],
+						publicKey,
+					}),
+				).toEqual({ status: "invalid", reason: "recipient_mismatch" });
+			} finally {
+				db.close();
+			}
+		});
+
+		it("distinguishes absent v3 material from invalid present material", () => {
+			const { db, publicKey } = setupIdentity();
+			try {
+				const base = {
+					method: "GET",
+					pathWithQuery: "/api/sync/status",
+					bodyBytes: Buffer.alloc(0),
+					timestamp: String(Math.floor(Date.now() / 1000)),
+					nonce: "typed-verification",
+					expectedRecipientId: "recipient-a",
+					publicKey,
+				};
+
+				expect(verifyDirectPeerSignature(base)).toEqual({ status: "absent" });
+				expect(verifyDirectPeerSignature({ ...base, recipientId: "", signature: "" })).toEqual({
+					status: "absent",
+				});
+				expect(verifyDirectPeerSignature({ ...base, recipientId: "recipient-a" })).toEqual({
+					status: "invalid",
+					reason: "incomplete_material",
+				});
+				expect(
+					verifyDirectPeerSignature({
+						...base,
+						recipientId: "recipient-a",
+						signature: "v3:not-a-signature",
+					}),
+				).toEqual({ status: "invalid", reason: "invalid_signature" });
+				expect(
+					verifyDirectPeerSignature({
+						...base,
+						recipientId: "recipient-a",
+						signature: "v2:AAAA",
+					}),
+				).toEqual({ status: "invalid", reason: "unsupported_version" });
+				expect(
+					verifyDirectPeerSignature({
+						...base,
+						timestamp: "1",
+						recipientId: "recipient-a",
+						signature: "v3:AAAA",
+					}),
+				).toEqual({ status: "invalid", reason: "invalid_timestamp" });
+			} finally {
+				db.close();
+			}
+		});
+
+		it.each([
+			["method", { method: "PUT" }],
+			["path", { pathWithQuery: "/v1/ops?limit=1" }],
+			["body", { bodyBytes: Buffer.from('{"changed":true}') }],
+			["nonce", { nonce: "changed-nonce" }],
+			["timestamp", { timestamp: "1", timeWindowS: Number.MAX_SAFE_INTEGER }],
+		])("rejects a signature with a mutated %s", (_field, changes) => {
+			const { db, deviceId, publicKey, keysDir } = setupIdentity();
+			try {
+				const timestamp = String(Math.floor(Date.now() / 1000));
+				const headers = signDirectPeerRequest({
+					method: "POST",
+					url: "https://peer.example.test/v1/ops",
+					bodyBytes: Buffer.from("{}"),
+					recipientId: "recipient-a",
+					keysDir,
+					deviceId,
+					timestamp,
+					nonce: "original-nonce",
+				});
+				const result = verifyDirectPeerSignature({
+					method: "POST",
+					pathWithQuery: "/v1/ops",
+					bodyBytes: Buffer.from("{}"),
+					timestamp,
+					nonce: "original-nonce",
+					recipientId: "recipient-a",
+					expectedRecipientId: "recipient-a",
+					signature: headers["X-Codemem-Signature"],
+					publicKey,
+					...changes,
+				});
+
+				expect(result).toEqual({ status: "invalid", reason: "invalid_signature" });
+			} finally {
+				db.close();
+			}
+		});
+
+		it("rejects empty or multiline recipients before signing", () => {
+			const { db, deviceId, keysDir } = setupIdentity();
+			try {
+				const options = {
+					method: "GET",
+					url: "https://peer.example.test/v1/status",
+					bodyBytes: Buffer.alloc(0),
+					keysDir,
+					deviceId,
+					timestamp: String(Math.floor(Date.now() / 1000)),
+					nonce: "recipient-validation",
+				};
+
+				expect(() => signDirectPeerRequest({ ...options, recipientId: "" })).toThrow(
+					"recipientId must be a non-empty single-line value",
+				);
+				expect(() => signDirectPeerRequest({ ...options, recipientId: "peer-a\npeer-b" })).toThrow(
+					"recipientId must be a non-empty single-line value",
+				);
+			} finally {
+				db.close();
+			}
+		});
+
+		it("adds v3 headers without replacing any legacy v2 auth header", () => {
+			const { db, deviceId, keysDir } = setupIdentity();
+			try {
+				const options = {
+					deviceId,
+					method: "GET",
+					url: "https://peer.example.test/api/sync/status",
+					bodyBytes: Buffer.alloc(0),
+					keysDir,
+					timestamp: String(Math.floor(Date.now() / 1000)),
+					nonce: "dual-signature-fixture",
+				};
+				const legacyHeaders = buildAuthHeaders(options);
+				const directHeaders = buildDirectPeerAuthHeaders({
+					...options,
+					recipientId: "recipient-a",
+				});
+
+				expect({
+					"X-Opencode-Device": directHeaders["X-Opencode-Device"],
+					"X-Opencode-Timestamp": directHeaders["X-Opencode-Timestamp"],
+					"X-Opencode-Nonce": directHeaders["X-Opencode-Nonce"],
+					"X-Opencode-Signature": directHeaders["X-Opencode-Signature"],
+				}).toEqual(legacyHeaders);
+				expect(directHeaders["X-Opencode-Signature"]).toMatch(/^v2:/);
+				expect(directHeaders["X-Codemem-Recipient"]).toBe("recipient-a");
+				expect(directHeaders["X-Codemem-Signature"]).toMatch(/^v3:/);
+			} finally {
+				db.close();
+			}
 		});
 	});
 

--- a/packages/core/src/sync-auth.ts
+++ b/packages/core/src/sync-auth.ts
@@ -33,6 +33,15 @@ import { loadPrivateKey } from "./sync-identity.js";
  */
 export const SIGNATURE_VERSION = "v2";
 
+/** Direct-peer-only recipient-bound signature version. */
+export const DIRECT_PEER_SIGNATURE_VERSION = "v3";
+
+function isValidRecipientId(recipientId: string): boolean {
+	return (
+		Boolean(recipientId.trim()) && recipientId === recipientId.trim() && !/[\r\n]/.test(recipientId)
+	);
+}
+
 // ---------------------------------------------------------------------------
 // Canonical request
 // ---------------------------------------------------------------------------
@@ -55,6 +64,28 @@ export function buildCanonicalRequest(
 	return Buffer.from(canonical, "utf-8");
 }
 
+/**
+ * Build the direct-peer v3 canonical request without changing the v2 bytes.
+ * The recipient is the sixth field so the signature cannot be replayed to a
+ * different peer.
+ */
+export function buildDirectPeerCanonicalRequest(
+	method: string,
+	pathWithQuery: string,
+	timestamp: string,
+	nonce: string,
+	bodyBytes: Buffer,
+	recipientId: string,
+): Buffer {
+	if (!isValidRecipientId(recipientId)) {
+		throw new Error("recipientId must be a non-empty single-line value");
+	}
+	return Buffer.concat([
+		buildCanonicalRequest(method, pathWithQuery, timestamp, nonce, bodyBytes),
+		Buffer.from(`\n${recipientId}`, "utf-8"),
+	]);
+}
+
 // ---------------------------------------------------------------------------
 // Sign
 // ---------------------------------------------------------------------------
@@ -70,43 +101,87 @@ export interface SignRequestOptions {
 	nonce?: string;
 }
 
-/**
- * Sign an HTTP request and return the auth headers.
- *
- * Uses Node's native Ed25519 crypto.sign() — no ssh-keygen shelling.
- * Returns X-Opencode-Timestamp, X-Opencode-Nonce, X-Opencode-Signature headers.
- */
-export function signRequest(options: SignRequestOptions): Record<string, string> {
-	const ts = options.timestamp ?? String(Math.floor(Date.now() / 1000));
-	const nonceValue = options.nonce ?? randomBytes(16).toString("hex");
+export interface SignedRequestHeaders {
+	"X-Opencode-Timestamp": string;
+	"X-Opencode-Nonce": string;
+	"X-Opencode-Signature": string;
+}
 
-	const parsed = new URL(options.url);
-	let path = parsed.pathname || "/";
-	if (parsed.search) {
-		path = `${path}${parsed.search}`;
-	}
+interface SigningKeyOptions {
+	keysDir?: string;
+	deviceId?: string;
+	dbPath?: string;
+}
 
-	const canonical = buildCanonicalRequest(options.method, path, ts, nonceValue, options.bodyBytes);
+function requestPath(url: string): string {
+	const parsed = new URL(url);
+	return `${parsed.pathname || "/"}${parsed.search}`;
+}
 
+function signCanonicalRequest(canonical: Buffer, options: SigningKeyOptions): string {
 	const keyData = loadPrivateKey(options.keysDir, options.dbPath, options.deviceId);
-	if (!keyData) {
-		throw new Error("private key missing");
-	}
+	if (!keyData) throw new Error("private key missing");
 
-	// Handle both OpenSSH format (existing keys) and PKCS8 PEM (newly generated)
 	let privateKeyObj: ReturnType<typeof createPrivateKey>;
 	try {
 		privateKeyObj = createPrivateKey(keyData);
 	} catch {
 		privateKeyObj = createPrivateKey({ key: keyData, format: "pem", type: "pkcs8" });
 	}
-	const signatureBytes = sign(null, canonical, privateKeyObj);
-	const signature = signatureBytes.toString("base64");
+	return sign(null, canonical, privateKeyObj).toString("base64");
+}
+
+/**
+ * Sign an HTTP request and return the auth headers.
+ *
+ * Uses Node's native Ed25519 crypto.sign() — no ssh-keygen shelling.
+ * Returns X-Opencode-Timestamp, X-Opencode-Nonce, X-Opencode-Signature headers.
+ */
+export function signRequest(options: SignRequestOptions): SignedRequestHeaders {
+	const ts = options.timestamp ?? String(Math.floor(Date.now() / 1000));
+	const nonceValue = options.nonce ?? randomBytes(16).toString("hex");
+
+	const path = requestPath(options.url);
+	const canonical = buildCanonicalRequest(options.method, path, ts, nonceValue, options.bodyBytes);
+	const signature = signCanonicalRequest(canonical, options);
 
 	return {
 		"X-Opencode-Timestamp": ts,
 		"X-Opencode-Nonce": nonceValue,
 		"X-Opencode-Signature": `${SIGNATURE_VERSION}:${signature}`,
+	};
+}
+
+export interface SignDirectPeerRequestOptions
+	extends Omit<SignRequestOptions, "timestamp" | "nonce"> {
+	recipientId: string;
+	timestamp: string;
+	nonce: string;
+}
+
+export interface DirectPeerSignatureHeaders {
+	"X-Codemem-Recipient": string;
+	"X-Codemem-Signature": string;
+}
+
+/** Sign the isolated recipient-bound v3 material for a direct-peer request. */
+export function signDirectPeerRequest(
+	options: SignDirectPeerRequestOptions,
+): DirectPeerSignatureHeaders {
+	const path = requestPath(options.url);
+	const canonical = buildDirectPeerCanonicalRequest(
+		options.method,
+		path,
+		options.timestamp,
+		options.nonce,
+		options.bodyBytes,
+		options.recipientId,
+	);
+	const signature = signCanonicalRequest(canonical, options);
+
+	return {
+		"X-Codemem-Recipient": options.recipientId,
+		"X-Codemem-Signature": `${DIRECT_PEER_SIGNATURE_VERSION}:${signature}`,
 	};
 }
 
@@ -126,6 +201,18 @@ export interface VerifySignatureOptions {
 	timeWindowS?: number;
 }
 
+function isFreshTimestamp(timestamp: string, timeWindowS: number): boolean {
+	if (!/^\d+$/.test(timestamp)) return false;
+	const seconds = Number.parseInt(timestamp, 10);
+	return Math.abs(Math.floor(Date.now() / 1000) - seconds) <= timeWindowS;
+}
+
+function decodeStrictBase64(encoded: string): Buffer | undefined {
+	if (!encoded) return undefined;
+	const decoded = Buffer.from(encoded, "base64");
+	return decoded.toString("base64") === encoded ? decoded : undefined;
+}
+
 /**
  * Verify a signed request.
  *
@@ -135,13 +222,7 @@ export interface VerifySignatureOptions {
 export function verifySignature(options: VerifySignatureOptions): boolean {
 	const timeWindow = options.timeWindowS ?? DEFAULT_TIME_WINDOW_S;
 
-	// Parse and validate timestamp — reject non-numeric strings (matches Python's int())
-	if (!/^\d+$/.test(options.timestamp)) return false;
-	const tsInt = Number.parseInt(options.timestamp, 10);
-	if (Number.isNaN(tsInt)) return false;
-
-	const now = Math.floor(Date.now() / 1000);
-	if (Math.abs(now - tsInt) > timeWindow) return false;
+	if (!isFreshTimestamp(options.timestamp, timeWindow)) return false;
 
 	// Validate signature version prefix — accept both v1 and v2 during migration
 	const ACCEPTED_VERSIONS = ["v1", "v2"];
@@ -150,17 +231,8 @@ export function verifySignature(options: VerifySignatureOptions): boolean {
 	const sigVersion = options.signature.slice(0, colonIdx);
 	if (!ACCEPTED_VERSIONS.includes(sigVersion)) return false;
 
-	const encoded = options.signature.slice(colonIdx + 1);
-	if (!encoded) return false;
-
-	let signatureBytes: Buffer;
-	try {
-		signatureBytes = Buffer.from(encoded, "base64");
-		// Verify it was valid base64 by round-tripping
-		if (signatureBytes.toString("base64") !== encoded) return false;
-	} catch {
-		return false;
-	}
+	const signatureBytes = decodeStrictBase64(options.signature.slice(colonIdx + 1));
+	if (!signatureBytes) return false;
 
 	const canonical = buildCanonicalRequest(
 		options.method,
@@ -176,6 +248,91 @@ export function verifySignature(options: VerifySignatureOptions): boolean {
 	} catch {
 		return false;
 	}
+}
+
+export interface VerifyDirectPeerSignatureOptions {
+	method: string;
+	pathWithQuery: string;
+	bodyBytes: Buffer;
+	timestamp: string;
+	nonce: string;
+	recipientId?: string;
+	expectedRecipientId: string;
+	signature?: string;
+	publicKey: string;
+	timeWindowS?: number;
+}
+
+export type DirectPeerSignatureVerification =
+	| { status: "absent" }
+	| {
+			status: "invalid";
+			reason:
+				| "incomplete_material"
+				| "malformed_recipient"
+				| "invalid_timestamp"
+				| "unsupported_version"
+				| "invalid_signature"
+				| "recipient_mismatch";
+	  }
+	| { status: "valid"; version: "v3" };
+
+/**
+ * Verify direct-peer v3 material with an explicit absent/invalid distinction.
+ * Callers may permit legacy v2 only for `absent`; any `invalid` result must fail
+ * closed rather than falling back to the accompanying v2 signature.
+ */
+export function verifyDirectPeerSignature(
+	options: VerifyDirectPeerSignatureOptions,
+): DirectPeerSignatureVerification {
+	const recipientId = options.recipientId === "" ? undefined : options.recipientId;
+	const signature = options.signature === "" ? undefined : options.signature;
+	if (recipientId === undefined && signature === undefined) {
+		return { status: "absent" };
+	}
+	if (!recipientId || !signature) {
+		return { status: "invalid", reason: "incomplete_material" };
+	}
+	if (!isValidRecipientId(recipientId)) {
+		return { status: "invalid", reason: "malformed_recipient" };
+	}
+	const timeWindow = options.timeWindowS ?? DEFAULT_TIME_WINDOW_S;
+	if (!isFreshTimestamp(options.timestamp, timeWindow)) {
+		return { status: "invalid", reason: "invalid_timestamp" };
+	}
+
+	const prefix = `${DIRECT_PEER_SIGNATURE_VERSION}:`;
+	if (!signature.startsWith(prefix)) {
+		return { status: "invalid", reason: "unsupported_version" };
+	}
+	const signatureBytes = decodeStrictBase64(signature.slice(prefix.length));
+	if (!signatureBytes) {
+		return { status: "invalid", reason: "invalid_signature" };
+	}
+
+	const canonical = buildDirectPeerCanonicalRequest(
+		options.method,
+		options.pathWithQuery,
+		options.timestamp,
+		options.nonce,
+		options.bodyBytes,
+		recipientId,
+	);
+	try {
+		const publicKeyObj = sshEd25519ToPublicKey(options.publicKey);
+		if (!verify(null, canonical, publicKeyObj, signatureBytes)) {
+			return { status: "invalid", reason: "invalid_signature" };
+		}
+	} catch {
+		return { status: "invalid", reason: "invalid_signature" };
+	}
+	if (recipientId !== options.expectedRecipientId) {
+		return { status: "invalid", reason: "recipient_mismatch" };
+	}
+	return {
+		status: "valid",
+		version: DIRECT_PEER_SIGNATURE_VERSION,
+	};
 }
 
 /**
@@ -229,10 +386,15 @@ export interface BuildAuthHeadersOptions {
 	nonce?: string;
 }
 
+export type AuthHeaders = Record<string, string> &
+	SignedRequestHeaders & {
+		"X-Opencode-Device": string;
+	};
+
 /**
  * Build full auth headers including device ID and request signature.
  */
-export function buildAuthHeaders(options: BuildAuthHeadersOptions): Record<string, string> {
+export function buildAuthHeaders(options: BuildAuthHeadersOptions): AuthHeaders {
 	return {
 		"X-Opencode-Device": options.deviceId,
 		...(options.bootstrapGrantId ? { "X-Codemem-Bootstrap-Grant": options.bootstrapGrantId } : {}),
@@ -246,6 +408,35 @@ export function buildAuthHeaders(options: BuildAuthHeadersOptions): Record<strin
 			timestamp: options.timestamp,
 			nonce: options.nonce,
 		}),
+	};
+}
+
+export interface BuildDirectPeerAuthHeadersOptions extends BuildAuthHeadersOptions {
+	recipientId: string;
+}
+
+export type DirectPeerAuthHeaders = AuthHeaders & DirectPeerSignatureHeaders;
+
+/** Build dual v2 + recipient-bound v3 headers for direct-peer requests only. */
+export function buildDirectPeerAuthHeaders(
+	options: BuildDirectPeerAuthHeadersOptions,
+): DirectPeerAuthHeaders {
+	const legacyHeaders = buildAuthHeaders(options);
+	const directHeaders = signDirectPeerRequest({
+		method: options.method,
+		url: options.url,
+		bodyBytes: options.bodyBytes,
+		recipientId: options.recipientId,
+		keysDir: options.keysDir,
+		deviceId: options.deviceId,
+		dbPath: options.dbPath,
+		timestamp: legacyHeaders["X-Opencode-Timestamp"],
+		nonce: legacyHeaders["X-Opencode-Nonce"],
+	});
+
+	return {
+		...legacyHeaders,
+		...directHeaders,
 	};
 }
 


### PR DESCRIPTION
## Description

Add isolated recipient-bound `v3` signature primitives for direct peer requests while freezing the existing `v2` canonical bytes and coordinator authentication behavior. Includes the rollout design and Node/Cloudflare coordinator invariance tests.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
