### PR TITLE
docs(release): validate 0.42 candidate

### DIFF
--- a/docs/plans/2026-08-20-release-0.42-candidate-validation.md
+++ b/docs/plans/2026-08-20-release-0.42-candidate-validation.md
@@ -1,0 +1,58 @@
+# Codemem 0.42 Candidate Validation
+
+**Candidate:** `fix(ingest): bind viewer raw events to database identity`
+**Date:** 2026-08-20
+**Result:** Pass
+
+## Identity-safe ingestion
+
+A local two-profile collision rehearsal ran one Viewer against profile A's
+database while a Claude hook client targeted profile B through the same loopback
+port. The Viewer database retained zero raw events, the client reported one
+direct-fallback insertion, and profile B's database contained exactly one raw
+event. Both client and Viewer exited cleanly.
+
+A separate compatibility rehearsal posted a canonical raw-event envelope
+without `db_path` or `identity_target`. Viewer returned
+`{"inserted":1,"skipped":0,"received":1}` and persisted exactly one raw event,
+confirming the documented 0.41 compatibility path.
+
+Automated route coverage also verifies all three ingestion routes:
+
+- reject database, identity, and contract mismatches with structured `409`
+  responses before raw-event or transcript-diagnostic writes;
+- reject partial or invalid targeting with structured `400` responses;
+- accept path-equivalent database targets; and
+- accept requests that omit both targeting fields.
+
+## Candidate gates
+
+| Gate | Result |
+| --- | --- |
+| Targeted Viewer/CLI and recipient-bound sync tests | 400 passed |
+| OpenCode plugin tests | 223 passed |
+| CLI smoke | 4 passed |
+| Packaged npm artifact smoke | Passed |
+| Docker E2E smoke with candidate build | Passed |
+| `pnpm run check` | Passed: 17 release tests, 4 adapter-normalizer tests, 4,685 Vitest tests; 3 todo |
+| `pnpm run build` | Passed for all workspace packages, including Worker bundle validation |
+| `pnpm run release:version -- check` | Versions aligned at pre-release version `0.41.0` |
+
+The packaged artifact smoke initially exposed an obsolete byte-for-byte HTTP
+assertion that did not account for the new transport-only targeting fields. The
+assertion now verifies both targeting fields while separately proving the raw
+event envelope and durable spool bytes remain unchanged; the rerun passed.
+
+## Accepted limitations
+
+- Target normalization parity is guaranteed for absolute paths. Relative paths
+  and bare `~` can resolve differently across host runtimes; such differences
+  fail closed with a target conflict and use the identity-correct local fallback.
+- A terminal target mismatch suppresses duplicate fallback for that event, but a
+  later event may probe the Viewer again after the normal backoff window.
+- `GET /api/pack` and `POST /api/pack/trace` remain outside this write-integrity
+  change. Existing prompt-pack profile and identity checks are unchanged.
+- Requests that omit both targeting fields remain accepted only for backward
+  compatibility. New 0.42 clients send both fields.
+
+No release-blocking candidate issue remains from this validation pass.


### PR DESCRIPTION
## Description

Record the reproduced Codemem 0.42 candidate evidence: two-profile collision safety, backward-compatible untargeted ingestion, plugin and packaged-artifact smoke, sync coverage, Docker E2E smoke, full checks, build results, and accepted limitations.

This is PR 2 of the Codemem 0.42 release stack and depends on #1487.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
