### PR TITLE
fix(feed): search all eligible memories

### DIFF
--- a/docs/plans/2026-08-20-feed-global-search-design.md
+++ b/docs/plans/2026-08-20-feed-global-search-design.md
@@ -1,0 +1,74 @@
+# Feed Global Search Design
+
+**Status:** Approved
+**Release:** 0.42.0
+
+## Problem
+
+The Feed search box filters only the pages already loaded in the browser. Older
+eligible memories remain invisible until scrolling loads them, numeric memory IDs
+are not searchable, and several fields rendered by cards are absent from the
+local search haystack. Persisted tags also use `tags_text`, while the client
+expects `tags`.
+
+## Decision
+
+Move Feed text matching to the Viewer server and apply it before pagination.
+Keep the Feed chronological rather than reusing semantic retrieval, which has
+different ranking and result-limit semantics.
+
+Both observation and summary list endpoints accept an optional `q` parameter.
+The query is intersected in SQL with the existing active-memory, sharing-domain,
+project, ownership, and observation-versus-summary predicates before one
+chronologically ordered `LIMIT`/`OFFSET` query is executed per endpoint.
+
+Search uses deterministic JavaScript Unicode lowercasing through a registered
+SQLite scalar function, preserving arbitrary substring matching across the
+stored text that can appear in Feed cards: title, body, kind, tags, facts,
+subtitle, narrative, and
+the summary metadata fields `request`, `subtitle`, `narrative`, `facts`, and
+`summary`. Other metadata is not part of the search haystack. A positive integer
+query in canonical decimal form also matches the exact memory ID; signed and
+zero-padded forms remain text queries. Normalized queries are capped at 256 code
+units before execution.
+Numeric queries may still match textual fields; exact ID support does not turn
+the input into an ID-only mode.
+
+No schema migration or semantic ranking is introduced in this release hotfix.
+
+## Performance check
+
+A synthetic 100,000-row in-memory SQLite benchmark on the release development
+machine measured a rare-term full scan at 77 ms median across five warm runs.
+A common term at offset 400 measured 0.35 ms median because SQLite could stop
+after filling the requested page. The benchmark included the five allowlisted
+JSON metadata extractions but excluded authorization joins, so it is a local
+hotfix guardrail rather than a production latency guarantee. FTS remains a
+follow-up option, but its token matching does not preserve this hotfix's
+arbitrary-substring contract.
+
+## UI behavior
+
+The Feed debounces query changes, resets both pagination streams, and reloads
+observations and summaries with `q`. Local loaded-row filtering is removed so
+the visible result set and `has_more` state come from one server-side contract.
+Whitespace-only edits preserve the controlled input but do not reset or refetch,
+and scroll pagination pauses while a query debounce is pending. Server-matched
+observations bypass the normal low-signal suppression so exact-ID and short-text
+matches remain visible; unfiltered Feed loading keeps that suppression. Scroll
+pagination also pauses while the primary Feed page is loading, preventing a
+duplicate offset-zero request. Feed loading/result metadata is exposed as a
+polite status region.
+Changing project, ownership scope, type, or query cannot widen authorization.
+
+## Validation
+
+Regression coverage must prove:
+
+- a match beyond the first unfiltered page is returned;
+- an exact numeric memory ID is returned without relying on text coincidence;
+- tags and structured card fields are searchable;
+- project, ownership, sharing-domain, active-state, and type boundaries remain
+  enforced;
+- matching rows paginate without duplicates or omissions; and
+- query changes reset and debounce Feed loading.

--- a/docs/plans/2026-08-20-feed-global-search-implementation.md
+++ b/docs/plans/2026-08-20-feed-global-search-implementation.md
@@ -1,0 +1,16 @@
+# Feed Global Search Implementation Plan
+
+1. Extend the Viewer memory-list filtering contract with a normalized optional
+   query, a deterministic Unicode-casefold SQL function, a 256-code-unit cap,
+   and a SQL predicate covering canonical exact IDs and Feed-visible stored fields.
+2. Pass `q` through observation and summary API clients and compose SQL search,
+   authorization, and summary classification before `LIMIT`/`OFFSET`.
+3. Replace immediate loaded-row filtering with debounced server reloads,
+   effective-query comparison, query-aware pagination state, and stale-request
+   guards in the Feed controller. Keep server-matched short observations visible
+   and block scroll pagination while debounce or primary loading is active.
+4. Correct the persisted tag field contract used by Feed cards.
+5. Add server and UI regression tests for completeness, ID matching, structured
+   fields, filters, pagination, and query reset behavior.
+6. Run targeted tests, TypeScript, lint, the full suite, build, and release smoke
+   checks before submitting one Graphite hotfix PR.

--- a/packages/ui/src/lib/api/internal.ts
+++ b/packages/ui/src/lib/api/internal.ts
@@ -32,11 +32,13 @@ export function buildProjectParams(
 	limit?: number,
 	offset?: number,
 	scope?: string,
+	q?: string,
 ): string {
 	const params = new URLSearchParams();
 	params.set("project", project || "");
 	if (typeof limit === "number") params.set("limit", String(limit));
 	if (typeof offset === "number") params.set("offset", String(offset));
 	if (scope) params.set("scope", scope);
+	if (q) params.set("q", q);
 	return params.toString();
 }

--- a/packages/ui/src/lib/api/memories.test.ts
+++ b/packages/ui/src/lib/api/memories.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadMemoriesPage, loadSummariesPage } from "./memories";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("Feed memory API", () => {
+	it("passes q with project, scope, and pagination to both Feed streams", async () => {
+		const fetchMock = vi.fn(
+			async (_input: Parameters<typeof fetch>[0]) =>
+				new Response(JSON.stringify({ items: [], pagination: { has_more: false } }), {
+					status: 200,
+				}),
+		);
+		globalThis.fetch = fetchMock as typeof fetch;
+
+		await loadMemoriesPage("codemem", { limit: 20, offset: 40, scope: "mine", q: "tag value" });
+		await loadSummariesPage("codemem", {
+			limit: 50,
+			offset: 100,
+			scope: "theirs",
+			q: "tag value",
+		});
+
+		expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+			"/api/observations?project=codemem&limit=20&offset=40&scope=mine&q=tag+value",
+			"/api/summaries?project=codemem&limit=50&offset=100&scope=theirs&q=tag+value",
+		]);
+	});
+
+	it("omits empty q and safely encodes reserved query characters", async () => {
+		const fetchMock = vi.fn(
+			async (_input: Parameters<typeof fetch>[0]) =>
+				new Response(JSON.stringify({ items: [], pagination: { has_more: false } }), {
+					status: 200,
+				}),
+		);
+		globalThis.fetch = fetchMock as typeof fetch;
+
+		await loadMemoriesPage("", { q: "" });
+		await loadSummariesPage("", { q: "?&/# +" });
+
+		expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+			"/api/observations?project=",
+			"/api/summaries?project=&q=%3F%26%2F%23+%2B",
+		]);
+	});
+});

--- a/packages/ui/src/lib/api/memories.ts
+++ b/packages/ui/src/lib/api/memories.ts
@@ -12,9 +12,15 @@ export async function loadMemories(project: string): Promise<PaginatedResponse> 
 
 export async function loadMemoriesPage(
 	project: string,
-	options?: { limit?: number; offset?: number; scope?: string },
+	options?: { limit?: number; offset?: number; scope?: string; q?: string },
 ): Promise<PaginatedResponse> {
-	const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
+	const query = buildProjectParams(
+		project,
+		options?.limit,
+		options?.offset,
+		options?.scope,
+		options?.q,
+	);
 	return fetchJson<PaginatedResponse>(`/api/observations?${query}`);
 }
 
@@ -67,9 +73,15 @@ export async function loadSummaries(project: string): Promise<PaginatedResponse>
 
 export async function loadSummariesPage(
 	project: string,
-	options?: { limit?: number; offset?: number; scope?: string },
+	options?: { limit?: number; offset?: number; scope?: string; q?: string },
 ): Promise<PaginatedResponse> {
-	const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
+	const query = buildProjectParams(
+		project,
+		options?.limit,
+		options?.offset,
+		options?.scope,
+		options?.q,
+	);
 	return fetchJson<PaginatedResponse>(`/api/summaries?${query}`);
 }
 

--- a/packages/ui/src/tabs/feed-search.test.ts
+++ b/packages/ui/src/tabs/feed-search.test.ts
@@ -1,0 +1,405 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { state } from "../lib/state";
+
+const apiMocks = vi.hoisted(() => ({
+	loadMemoriesPage: vi.fn(),
+	loadSummariesPage: vi.fn(),
+}));
+const mountMocks = vi.hoisted(() => ({
+	renderIntoFeedMount: vi.fn(),
+}));
+
+vi.mock("../lib/api", () => apiMocks);
+vi.mock("./feed/data/mount", () => ({
+	ensureFeedRenderBoundary: vi.fn(),
+	renderIntoFeedMount: mountMocks.renderIntoFeedMount,
+}));
+
+import {
+	__feedSearchTestHooks,
+	FEED_QUERY_DEBOUNCE_MS,
+	loadFeedData,
+	updateFeedQuery,
+} from "./feed";
+
+interface TestPage {
+	items: Array<{ id: number; kind: string; title: string; body_text: string }>;
+	pagination: { has_more: boolean; next_offset: number | null };
+}
+
+function page(id: number): TestPage {
+	return {
+		items: [
+			{
+				id,
+				kind: "change",
+				title: `Item ${id}`,
+				body_text: `Long enough body for item ${id}`,
+			},
+		],
+		pagination: { has_more: false, next_offset: null },
+	};
+}
+
+function shortPage(
+	id: number,
+	hasMore = false,
+	nextOffset: number | null = null,
+	text = "x",
+): TestPage {
+	return {
+		items: [{ id, kind: "change", title: text, body_text: text }],
+		pagination: { has_more: hasMore, next_offset: nextOffset },
+	};
+}
+
+type FeedPageOptions = { limit?: number; offset?: number; scope?: string; q?: string };
+
+describe("Feed global search controller", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		document.body.innerHTML = "";
+		window.scrollTo = vi.fn();
+		state.activeTab = "feed";
+		state.currentProject = "codemem";
+		state.feedScopeFilter = "all";
+		state.feedTypeFilter = "all";
+		state.feedQuery = "";
+		state.lastFeedItems = [];
+		state.lastFeedFilteredCount = 0;
+		apiMocks.loadMemoriesPage.mockReset();
+		apiMocks.loadSummariesPage.mockReset();
+		mountMocks.renderIntoFeedMount.mockReset();
+	});
+
+	afterEach(() => {
+		vi.clearAllTimers();
+		vi.useRealTimers();
+	});
+
+	it("debounces resets with q, ignores older responses, and omits q when cleared", async () => {
+		let resolveOldObservations: (value: ReturnType<typeof page>) => void = () => undefined;
+		let resolveOldSummaries: (value: ReturnType<typeof page>) => void = () => undefined;
+		const oldObservations = new Promise<ReturnType<typeof page>>((resolve) => {
+			resolveOldObservations = resolve;
+		});
+		const oldSummaries = new Promise<ReturnType<typeof page>>((resolve) => {
+			resolveOldSummaries = resolve;
+		});
+		apiMocks.loadMemoriesPage.mockImplementation((_project: string, options?: FeedPageOptions) =>
+			options?.q === "old query" ? oldObservations : Promise.resolve(page(2)),
+		);
+		apiMocks.loadSummariesPage.mockImplementation((_project: string, options?: FeedPageOptions) =>
+			options?.q === "old query" ? oldSummaries : Promise.resolve({ ...page(3), items: [] }),
+		);
+
+		state.feedQuery = "old query";
+		const staleLoad = loadFeedData();
+		updateFeedQuery("new");
+		updateFeedQuery("new query");
+
+		expect(apiMocks.loadMemoriesPage).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(FEED_QUERY_DEBOUNCE_MS - 1);
+		expect(apiMocks.loadMemoriesPage).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(1);
+
+		expect(apiMocks.loadMemoriesPage).toHaveBeenLastCalledWith("codemem", {
+			limit: 20,
+			offset: 0,
+			scope: "all",
+			q: "new query",
+		});
+		expect(apiMocks.loadSummariesPage).toHaveBeenLastCalledWith("codemem", {
+			limit: 50,
+			offset: 0,
+			scope: "all",
+			q: "new query",
+		});
+		expect(state.lastFeedItems).toMatchObject([{ id: 2 }]);
+
+		resolveOldObservations(page(1));
+		resolveOldSummaries({ ...page(4), items: [] });
+		await staleLoad;
+		expect(state.lastFeedItems).toMatchObject([{ id: 2 }]);
+
+		updateFeedQuery("");
+		await vi.advanceTimersByTimeAsync(FEED_QUERY_DEBOUNCE_MS);
+		expect(apiMocks.loadMemoriesPage).toHaveBeenLastCalledWith("codemem", {
+			limit: 20,
+			offset: 0,
+			scope: "all",
+			q: undefined,
+		});
+		expect(apiMocks.loadSummariesPage).toHaveBeenLastCalledWith("codemem", {
+			limit: 50,
+			offset: 0,
+			scope: "all",
+			q: undefined,
+		});
+	});
+
+	it("rejects an older primary response superseded in the same feed context", async () => {
+		let resolveOlderObservations: (value: ReturnType<typeof page>) => void = () => undefined;
+		let resolveOlderSummaries: (value: ReturnType<typeof page>) => void = () => undefined;
+		apiMocks.loadMemoriesPage
+			.mockReturnValueOnce(
+				new Promise<ReturnType<typeof page>>((resolve) => {
+					resolveOlderObservations = resolve;
+				}),
+			)
+			.mockResolvedValueOnce(page(2));
+		apiMocks.loadSummariesPage
+			.mockReturnValueOnce(
+				new Promise<ReturnType<typeof page>>((resolve) => {
+					resolveOlderSummaries = resolve;
+				}),
+			)
+			.mockResolvedValueOnce({ ...page(3), items: [] });
+
+		const olderLoad = loadFeedData();
+		const newerLoad = loadFeedData();
+		await newerLoad;
+		expect(state.lastFeedItems).toMatchObject([{ id: 2 }]);
+
+		resolveOlderObservations(page(1));
+		resolveOlderSummaries({ ...page(4), items: [] });
+		await olderLoad;
+
+		expect(state.lastFeedItems).toMatchObject([{ id: 2 }]);
+	});
+
+	it("resets both streams and lets new-query pagination proceed past stale load-more", async () => {
+		let resolveOldObservations: (value: ReturnType<typeof page>) => void = () => undefined;
+		let resolveOldSummaries: (value: ReturnType<typeof page>) => void = () => undefined;
+		const oldObservations = new Promise<ReturnType<typeof page>>((resolve) => {
+			resolveOldObservations = resolve;
+		});
+		const oldSummaries = new Promise<ReturnType<typeof page>>((resolve) => {
+			resolveOldSummaries = resolve;
+		});
+		apiMocks.loadMemoriesPage.mockImplementation((_project: string, options?: FeedPageOptions) => {
+			if (options?.q === "old pagination" && options.offset === 20) return oldObservations;
+			if (options?.q === "new pagination" && options.offset === 20) return Promise.resolve(page(3));
+			return Promise.resolve({
+				...page(options?.q === "new pagination" ? 2 : 1),
+				pagination: { has_more: true, next_offset: 20 },
+			});
+		});
+		apiMocks.loadSummariesPage.mockImplementation((_project: string, options?: FeedPageOptions) => {
+			if (options?.q === "old pagination" && options.offset === 50) return oldSummaries;
+			if (options?.q === "new pagination" && options.offset === 50) {
+				return Promise.resolve({ ...page(30), items: [] });
+			}
+			return Promise.resolve({
+				...page(10),
+				items: [],
+				pagination: { has_more: true, next_offset: 50 },
+			});
+		});
+
+		state.feedQuery = "old pagination";
+		await loadFeedData();
+		expect(__feedSearchTestHooks.pagination()).toMatchObject({
+			observationOffset: 20,
+			summaryOffset: 50,
+			observationHasMore: true,
+			summaryHasMore: true,
+		});
+
+		const stalePagination = __feedSearchTestHooks.loadMoreFeedPage();
+		const oldGeneration = __feedSearchTestHooks.pagination().generation;
+		updateFeedQuery("new pagination");
+		expect(__feedSearchTestHooks.pagination()).toMatchObject({
+			observationOffset: 0,
+			summaryOffset: 0,
+			observationHasMore: true,
+			summaryHasMore: true,
+		});
+		expect(__feedSearchTestHooks.pagination().generation).toBeGreaterThan(oldGeneration);
+
+		await vi.advanceTimersByTimeAsync(FEED_QUERY_DEBOUNCE_MS);
+		await __feedSearchTestHooks.loadMoreFeedPage();
+		expect(apiMocks.loadMemoriesPage).toHaveBeenLastCalledWith("codemem", {
+			limit: 20,
+			offset: 20,
+			scope: "all",
+			q: "new pagination",
+		});
+		expect(apiMocks.loadSummariesPage).toHaveBeenLastCalledWith("codemem", {
+			limit: 50,
+			offset: 50,
+			scope: "all",
+			q: "new pagination",
+		});
+		expect(__feedSearchTestHooks.pagination()).toMatchObject({
+			observationOffset: 21,
+			summaryOffset: 50,
+			observationHasMore: false,
+			summaryHasMore: false,
+		});
+
+		resolveOldObservations({
+			...page(99),
+			pagination: { has_more: true, next_offset: 999 },
+		});
+		resolveOldSummaries({
+			...page(100),
+			items: [],
+			pagination: { has_more: true, next_offset: 999 },
+		});
+		await stalePagination;
+		expect(__feedSearchTestHooks.pagination()).toMatchObject({
+			observationOffset: 21,
+			summaryOffset: 50,
+			observationHasMore: false,
+			summaryHasMore: false,
+			loadMoreInFlightGeneration: null,
+		});
+		expect(state.lastFeedItems.map((item) => (item as { id: number }).id)).toEqual([2, 3]);
+	});
+
+	it("keeps short server-matched observations and their pagination state", async () => {
+		state.feedQuery = "7";
+		apiMocks.loadMemoriesPage.mockImplementation((_project: string, options?: FeedPageOptions) =>
+			Promise.resolve(
+				options?.offset === 20 ? shortPage(8, false, null, "7") : shortPage(7, true, 20),
+			),
+		);
+		apiMocks.loadSummariesPage.mockResolvedValue({ ...page(30), items: [] });
+
+		await loadFeedData();
+
+		expect(state.lastFeedItems.map((item) => (item as { id: number }).id)).toEqual([7]);
+		expect(__feedSearchTestHooks.pagination()).toMatchObject({
+			observationOffset: 20,
+			observationHasMore: true,
+		});
+
+		await __feedSearchTestHooks.loadMoreFeedPage();
+		expect(state.lastFeedItems.map((item) => (item as { id: number }).id)).toEqual([7, 8]);
+		expect(__feedSearchTestHooks.pagination()).toMatchObject({
+			observationOffset: 21,
+			observationHasMore: false,
+		});
+	});
+
+	it("keeps low-signal suppression on unfiltered initial and later pages", async () => {
+		apiMocks.loadMemoriesPage.mockImplementation((_project: string, options?: FeedPageOptions) =>
+			Promise.resolve(options?.offset === 20 ? shortPage(8) : shortPage(7, true, 20)),
+		);
+		apiMocks.loadSummariesPage.mockResolvedValue({ ...page(30), items: [] });
+
+		await loadFeedData();
+		expect(state.lastFeedItems).toEqual([]);
+		expect(__feedSearchTestHooks.pagination()).toMatchObject({
+			observationOffset: 20,
+			observationHasMore: true,
+		});
+
+		await __feedSearchTestHooks.loadMoreFeedPage();
+		expect(state.lastFeedItems).toEqual([]);
+		expect(state.lastFeedFilteredCount).toBe(2);
+		expect(__feedSearchTestHooks.pagination().observationHasMore).toBe(false);
+	});
+
+	it("does not start scroll pagination while the primary Feed page is loading", async () => {
+		let resolveObservations: (value: ReturnType<typeof page>) => void = () => undefined;
+		let resolveSummaries: (value: ReturnType<typeof page>) => void = () => undefined;
+		apiMocks.loadMemoriesPage.mockReturnValue(
+			new Promise<ReturnType<typeof page>>((resolve) => {
+				resolveObservations = resolve;
+			}),
+		);
+		apiMocks.loadSummariesPage.mockReturnValue(
+			new Promise<ReturnType<typeof page>>((resolve) => {
+				resolveSummaries = resolve;
+			}),
+		);
+
+		state.feedQuery = "loading";
+		const initialLoad = loadFeedData();
+		expect(__feedSearchTestHooks.pagination().primaryLoadInFlightGeneration).toBe(
+			__feedSearchTestHooks.pagination().generation,
+		);
+
+		__feedSearchTestHooks.maybeLoadMoreFeedPage();
+		expect(apiMocks.loadMemoriesPage).toHaveBeenCalledTimes(1);
+		expect(apiMocks.loadSummariesPage).toHaveBeenCalledTimes(1);
+		expect(apiMocks.loadMemoriesPage).toHaveBeenLastCalledWith(
+			"codemem",
+			expect.objectContaining({ offset: 0 }),
+		);
+
+		resolveObservations(page(1));
+		resolveSummaries({ ...page(2), items: [] });
+		await initialLoad;
+		expect(__feedSearchTestHooks.pagination().primaryLoadInFlightGeneration).toBeNull();
+	});
+
+	it("treats whitespace-only query edits as the same effective query", async () => {
+		state.feedQuery = "needle";
+		apiMocks.loadMemoriesPage.mockResolvedValue(page(1));
+		apiMocks.loadSummariesPage.mockResolvedValue({ ...page(2), items: [] });
+		await loadFeedData();
+		const generation = __feedSearchTestHooks.pagination().generation;
+
+		updateFeedQuery(" needle ");
+		await vi.advanceTimersByTimeAsync(FEED_QUERY_DEBOUNCE_MS);
+
+		expect(state.feedQuery).toBe(" needle ");
+		expect(__feedSearchTestHooks.pagination().generation).toBe(generation);
+		expect(apiMocks.loadMemoriesPage).toHaveBeenCalledTimes(1);
+		expect(apiMocks.loadSummariesPage).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not start scroll pagination while a query debounce is pending", async () => {
+		state.feedQuery = "old";
+		apiMocks.loadMemoriesPage.mockResolvedValue({
+			...page(1),
+			pagination: { has_more: true, next_offset: 20 },
+		});
+		apiMocks.loadSummariesPage.mockResolvedValue({ ...page(2), items: [] });
+		await loadFeedData();
+
+		updateFeedQuery("new");
+		state.activeTab = "feed";
+		__feedSearchTestHooks.maybeLoadMoreFeedPage();
+
+		expect(apiMocks.loadMemoriesPage).toHaveBeenCalledTimes(1);
+		expect(apiMocks.loadSummariesPage).toHaveBeenCalledTimes(1);
+		state.activeTab = "projects";
+		await vi.advanceTimersByTimeAsync(FEED_QUERY_DEBOUNCE_MS);
+		expect(apiMocks.loadMemoriesPage).toHaveBeenCalledTimes(2);
+		expect(apiMocks.loadSummariesPage).toHaveBeenCalledTimes(2);
+	});
+
+	it("shows an error for a failed debounced query and clears it on retry", async () => {
+		document.body.innerHTML = '<section id="tab-feed"></section>';
+		apiMocks.loadMemoriesPage.mockRejectedValue(new Error("viewer restarting"));
+		apiMocks.loadSummariesPage.mockResolvedValue({ ...page(2), items: [] });
+
+		updateFeedQuery("unavailable");
+		expect(mountMocks.renderIntoFeedMount.mock.lastCall?.[1].props.loadingText).toBe(
+			"Searching memories…",
+		);
+
+		await vi.advanceTimersByTimeAsync(FEED_QUERY_DEBOUNCE_MS);
+
+		expect(mountMocks.renderIntoFeedMount.mock.lastCall?.[1].props.loadingText).toBeUndefined();
+		expect(mountMocks.renderIntoFeedMount.mock.lastCall?.[1].props.errorText).toBe(
+			"Feed unavailable. Refresh and try again.",
+		);
+		expect(__feedSearchTestHooks.pagination()).toMatchObject({
+			observationHasMore: false,
+			summaryHasMore: false,
+		});
+		expect(apiMocks.loadMemoriesPage).toHaveBeenCalledTimes(1);
+		expect(apiMocks.loadSummariesPage).toHaveBeenCalledTimes(1);
+
+		apiMocks.loadMemoriesPage.mockResolvedValue(page(3));
+		await loadFeedData();
+
+		expect(mountMocks.renderIntoFeedMount.mock.lastCall?.[1].props.loadingText).toBeUndefined();
+		expect(mountMocks.renderIntoFeedMount.mock.lastCall?.[1].props.errorText).toBeUndefined();
+	});
+});

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -31,16 +31,25 @@ let observationOffset = 0;
 let summaryOffset = 0;
 let observationHasMore = true;
 let summaryHasMore = true;
-let loadMoreInFlight = false;
+let loadMoreInFlightGeneration: number | null = null;
+let primaryLoadRequestSequence = 0;
+let primaryLoadInFlight: { generation: number; requestId: number } | null = null;
 let feedScrollHandlerBound = false;
 let feedProjectGeneration = 0;
 let lastFeedScope = "all";
+let lastFeedQuery = "";
+let feedQueryTimer: ReturnType<typeof setTimeout> | null = null;
+let feedLoadError = "";
+
+export const FEED_QUERY_DEBOUNCE_MS = 250;
 
 import { ensureFeedRenderBoundary, renderIntoFeedMount } from "./feed/data/mount";
 
 function resetPagination(project: string) {
 	lastFeedProject = project;
 	lastFeedScope = state.feedScopeFilter;
+	lastFeedQuery = state.feedQuery.trim();
+	feedLoadError = "";
 	feedProjectGeneration += 1;
 	observationOffset = 0;
 	summaryOffset = 0;
@@ -100,15 +109,17 @@ import type { FeedViewOps } from "./feed/types";
 
 /* ── Filtering ───────────────────────────────────────────── */
 
-import { computeSignature, filterByQuery, filterByType } from "./feed/data/filter";
+import { computeSignature, filterByType } from "./feed/data/filter";
 
 async function loadMoreFeedPage() {
-	if (loadMoreInFlight || !hasMorePages()) return;
-	const requestProject = state.currentProject || "";
+	if (!hasMorePages()) return;
 	const requestGeneration = feedProjectGeneration;
+	if (loadMoreInFlightGeneration === requestGeneration) return;
+	const requestProject = state.currentProject || "";
+	const requestQuery = state.feedQuery.trim();
 	const startObservationOffset = observationOffset;
 	const startSummaryOffset = summaryOffset;
-	loadMoreInFlight = true;
+	loadMoreInFlightGeneration = requestGeneration;
 	try {
 		const [observations, summaries] = await Promise.all([
 			observationHasMore
@@ -116,6 +127,7 @@ async function loadMoreFeedPage() {
 						limit: OBSERVATION_PAGE_SIZE,
 						offset: startObservationOffset,
 						scope: state.feedScopeFilter,
+						q: requestQuery || undefined,
 					})
 				: Promise.resolve({
 						items: [],
@@ -126,6 +138,7 @@ async function loadMoreFeedPage() {
 						limit: SUMMARY_PAGE_SIZE,
 						offset: startSummaryOffset,
 						scope: state.feedScopeFilter,
+						q: requestQuery || undefined,
 					})
 				: Promise.resolve({
 						items: [],
@@ -135,14 +148,17 @@ async function loadMoreFeedPage() {
 
 		if (
 			requestGeneration !== feedProjectGeneration ||
-			requestProject !== (state.currentProject || "")
+			requestProject !== (state.currentProject || "") ||
+			requestQuery !== state.feedQuery.trim()
 		) {
 			return;
 		}
 
 		const summaryItems = (summaries.items || []) as FeedItem[];
 		const observationItems = (observations.items || []) as FeedItem[];
-		const filtered = observationItems.filter((i) => !isLowSignalObservation(i));
+		const filtered = requestQuery
+			? observationItems
+			: observationItems.filter((i) => !isLowSignalObservation(i));
 		state.lastFeedFilteredCount += observationItems.length - filtered.length;
 
 		summaryHasMore = pageHasMore(summaries, summaryItems.length, SUMMARY_PAGE_SIZE);
@@ -161,12 +177,30 @@ async function loadMoreFeedPage() {
 		state.lastFeedItems = feedItems;
 		updateFeedView();
 	} finally {
-		loadMoreInFlight = false;
+		if (loadMoreInFlightGeneration === requestGeneration) {
+			loadMoreInFlightGeneration = null;
+		}
 	}
 }
 
+export const __feedSearchTestHooks = {
+	loadMoreFeedPage,
+	maybeLoadMoreFeedPage,
+	pagination: () => ({
+		observationOffset,
+		summaryOffset,
+		observationHasMore,
+		summaryHasMore,
+		loadMoreInFlightGeneration,
+		primaryLoadInFlightGeneration: primaryLoadInFlight?.generation ?? null,
+		generation: feedProjectGeneration,
+	}),
+};
+
 function maybeLoadMoreFeedPage() {
 	if (state.activeTab !== "feed") return;
+	if (feedQueryTimer) return;
+	if (primaryLoadInFlight) return;
 	if (!hasMorePages()) return;
 	if (!isNearFeedBottom()) return;
 	void loadMoreFeedPage();
@@ -177,15 +211,21 @@ const feedOps: FeedViewOps = {
 	removeFeedItem,
 	updateFeedView: (force?: boolean) => updateFeedView(force),
 	loadFeedData: () => loadFeedData(),
+	updateFeedQuery: (query: string) => updateFeedQuery(query),
 	hasMorePages,
 };
 
-function renderFeedTab(items: FeedItem[], options?: { loadingText?: string }) {
+function renderFeedTab(items: FeedItem[], options?: { errorText?: string; loadingText?: string }) {
 	const feedTab = document.getElementById("tab-feed");
 	if (!feedTab) return false;
 	renderIntoFeedMount(
 		feedTab,
-		h(FeedTabView, { items, loadingText: options?.loadingText, ops: feedOps }),
+		h(FeedTabView, {
+			errorText: options?.errorText,
+			items,
+			loadingText: options?.loadingText,
+			ops: feedOps,
+		}),
 	);
 	const globalLucide = (globalThis as { lucide?: { createIcons: () => void } }).lucide;
 	if (globalLucide && !options?.loadingText) {
@@ -194,8 +234,8 @@ function renderFeedTab(items: FeedItem[], options?: { loadingText?: string }) {
 	return true;
 }
 
-function renderProjectSwitchLoadingState() {
-	renderFeedTab([], { loadingText: "Loading selected project..." });
+function renderFeedLoadingState(message = "Loading selected project...") {
+	renderFeedTab([], { loadingText: message });
 }
 
 /* ── Public API ──────────────────────────────────────────── */
@@ -229,20 +269,33 @@ export function updateFeedScopeToggle() {
 	updateFeedView(true);
 }
 
+export function updateFeedQuery(query: string) {
+	if (query === state.feedQuery) return;
+	const previousQuery = state.feedQuery.trim();
+	state.feedQuery = query;
+	if (query.trim() === previousQuery) return;
+	resetPagination(state.currentProject || "");
+	renderFeedLoadingState("Searching memories…");
+	if (feedQueryTimer) clearTimeout(feedQueryTimer);
+	feedQueryTimer = setTimeout(() => {
+		feedQueryTimer = null;
+		void loadFeedData().catch(() => undefined);
+	}, FEED_QUERY_DEBOUNCE_MS);
+}
+
 export function updateFeedView(force = false) {
 	const feedTab = document.getElementById("tab-feed");
 	if (!feedTab) return;
 
 	const scrollY = window.scrollY;
-	const byType = filterByType(state.lastFeedItems as FeedItem[]);
-	const visible = filterByQuery(byType);
+	const visible = filterByType(state.lastFeedItems as FeedItem[]);
 
 	const sig = computeSignature(visible);
 	const changed = force || sig !== state.lastFeedSignature;
 	state.lastFeedSignature = sig;
 
 	if (changed) {
-		renderFeedTab(visible);
+		renderFeedTab(visible, { errorText: feedLoadError || undefined });
 	}
 
 	window.scrollTo({ top: scrollY });
@@ -252,63 +305,116 @@ export function updateFeedView(force = false) {
 export async function loadFeedData() {
 	const project = state.currentProject || "";
 	const scopeChanged = state.feedScopeFilter !== lastFeedScope;
-	if (project !== lastFeedProject || scopeChanged) {
+	const query = state.feedQuery.trim();
+	const queryChanged = query !== lastFeedQuery;
+	if (project !== lastFeedProject || scopeChanged || queryChanged) {
 		resetPagination(project);
-		renderProjectSwitchLoadingState();
+		renderFeedLoadingState(queryChanged ? "Searching memories…" : undefined);
 	}
 	const requestGeneration = feedProjectGeneration;
-
-	const observationsLimit = OBSERVATION_PAGE_SIZE;
-	const summariesLimit = SUMMARY_PAGE_SIZE;
-
-	const [observations, summaries] = await Promise.all([
-		api.loadMemoriesPage(project, {
-			limit: observationsLimit,
-			offset: 0,
-			scope: state.feedScopeFilter,
-		}),
-		api.loadSummariesPage(project, {
-			limit: summariesLimit,
-			offset: 0,
-			scope: state.feedScopeFilter,
-		}),
-	]);
-
-	if (requestGeneration !== feedProjectGeneration || project !== (state.currentProject || "")) {
-		return;
+	const requestId = ++primaryLoadRequestSequence;
+	primaryLoadInFlight = { generation: requestGeneration, requestId };
+	const recoveringFromLoadError = Boolean(feedLoadError);
+	if (recoveringFromLoadError) {
+		feedLoadError = "";
+		if (state.lastFeedItems.length > 0) {
+			updateFeedView(true);
+		} else {
+			renderFeedLoadingState(query ? "Searching memories…" : undefined);
+		}
 	}
 
-	const summaryItems = (summaries.items || []) as FeedItem[];
-	const observationItems = (observations.items || []) as FeedItem[];
-	const filtered = observationItems.filter((i) => !isLowSignalObservation(i));
-	const filteredCount = observationItems.length - filtered.length;
-	const firstPageFeedItems = [...summaryItems, ...filtered].sort((a, b) => {
-		return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
-	});
-	const feedItems = mergeRefreshFeedItems(state.lastFeedItems as FeedItem[], firstPageFeedItems);
+	try {
+		const observationsLimit = OBSERVATION_PAGE_SIZE;
+		const summariesLimit = SUMMARY_PAGE_SIZE;
 
-	// Only flag newPulse on genuine incremental arrivals. First-time load has
-	// an empty lastFeedItems and every row "looks new" — skip that case so we
-	// don't bulk-pulse the whole feed on open/tab-switch/project-switch.
-	const previousItems = state.lastFeedItems as FeedItem[];
-	const newCount = countNewItems(feedItems, previousItems);
-	if (newCount && previousItems.length > 0) {
-		const seen = new Set(previousItems.map(itemKey));
-		feedItems.forEach((item) => {
-			if (!seen.has(itemKey(item))) state.newItemKeys.add(itemKey(item));
+		const [observations, summaries] = await Promise.all([
+			api.loadMemoriesPage(project, {
+				limit: observationsLimit,
+				offset: 0,
+				scope: state.feedScopeFilter,
+				q: query || undefined,
+			}),
+			api.loadSummariesPage(project, {
+				limit: summariesLimit,
+				offset: 0,
+				scope: state.feedScopeFilter,
+				q: query || undefined,
+			}),
+		]);
+
+		if (
+			primaryLoadInFlight?.generation !== requestGeneration ||
+			primaryLoadInFlight.requestId !== requestId ||
+			requestGeneration !== feedProjectGeneration ||
+			project !== (state.currentProject || "") ||
+			query !== state.feedQuery.trim()
+		) {
+			return;
+		}
+
+		const summaryItems = (summaries.items || []) as FeedItem[];
+		const observationItems = (observations.items || []) as FeedItem[];
+		const filtered = query
+			? observationItems
+			: observationItems.filter((i) => !isLowSignalObservation(i));
+		const filteredCount = observationItems.length - filtered.length;
+		const firstPageFeedItems = [...summaryItems, ...filtered].sort((a, b) => {
+			return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
 		});
-	}
+		const feedItems = mergeRefreshFeedItems(state.lastFeedItems as FeedItem[], firstPageFeedItems);
 
-	state.pendingFeedItems = null;
-	state.lastFeedItems = feedItems;
-	state.lastFeedFilteredCount = Math.max(state.lastFeedFilteredCount, filteredCount);
-	summaryHasMore = pageHasMore(summaries, summaryItems.length, summariesLimit);
-	observationHasMore = pageHasMore(observations, observationItems.length, observationsLimit);
-	summaryOffset = Math.max(summaryOffset, pageNextOffset(summaries, summaryItems.length));
-	observationOffset = Math.max(
-		observationOffset,
-		pageNextOffset(observations, observationItems.length),
-	);
-	lastFeedScope = state.feedScopeFilter;
-	updateFeedView();
+		// Only flag newPulse on genuine incremental arrivals. First-time load has
+		// an empty lastFeedItems and every row "looks new" — skip that case so we
+		// don't bulk-pulse the whole feed on open/tab-switch/project-switch.
+		const previousItems = state.lastFeedItems as FeedItem[];
+		const newCount = countNewItems(feedItems, previousItems);
+		if (newCount && previousItems.length > 0) {
+			const seen = new Set(previousItems.map(itemKey));
+			feedItems.forEach((item) => {
+				if (!seen.has(itemKey(item))) state.newItemKeys.add(itemKey(item));
+			});
+		}
+
+		state.pendingFeedItems = null;
+		state.lastFeedItems = feedItems;
+		feedLoadError = "";
+		state.lastFeedFilteredCount = Math.max(state.lastFeedFilteredCount, filteredCount);
+		summaryHasMore = pageHasMore(summaries, summaryItems.length, summariesLimit);
+		observationHasMore = pageHasMore(observations, observationItems.length, observationsLimit);
+		summaryOffset = Math.max(summaryOffset, pageNextOffset(summaries, summaryItems.length));
+		observationOffset = Math.max(
+			observationOffset,
+			pageNextOffset(observations, observationItems.length),
+		);
+		lastFeedScope = state.feedScopeFilter;
+		if (
+			primaryLoadInFlight?.generation === requestGeneration &&
+			primaryLoadInFlight.requestId === requestId
+		) {
+			primaryLoadInFlight = null;
+		}
+		updateFeedView(recoveringFromLoadError);
+	} catch (error) {
+		if (
+			primaryLoadInFlight?.generation === requestGeneration &&
+			primaryLoadInFlight.requestId === requestId &&
+			requestGeneration === feedProjectGeneration &&
+			project === (state.currentProject || "") &&
+			query === state.feedQuery.trim()
+		) {
+			observationHasMore = false;
+			summaryHasMore = false;
+			feedLoadError = "Feed unavailable. Refresh and try again.";
+			updateFeedView(true);
+		}
+		throw error;
+	} finally {
+		if (
+			primaryLoadInFlight?.generation === requestGeneration &&
+			primaryLoadInFlight.requestId === requestId
+		) {
+			primaryLoadInFlight = null;
+		}
+	}
 }

--- a/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
@@ -19,7 +19,14 @@ import {
 	renderNarrativeContent,
 	renderSummarySections,
 } from "../data/body-renderers";
-import { authorLabel, deviceLabel, itemKey, mergeMetadata, trustStateLabel } from "../data/helpers";
+import {
+	authorLabel,
+	deviceLabel,
+	itemKey,
+	itemTags,
+	mergeMetadata,
+	trustStateLabel,
+} from "../data/helpers";
 import {
 	clampClass,
 	defaultObservationView,
@@ -57,7 +64,7 @@ export function FeedItemCard({
 	const displayTitle = isSessionSummary && metadata?.request ? metadata.request : defaultTitle;
 	const createdAtRaw = item.created_at || item.created_at_utc;
 	const relative = formatRelativeTime(createdAtRaw);
-	const tags = parseJsonArray(item.tags || []);
+	const tags = itemTags(item);
 	const files = parseJsonArray(item.files || []);
 	const project = item.project || "";
 	const actor = authorLabel(item);

--- a/packages/ui/src/tabs/feed/components/FeedTabView.test.ts
+++ b/packages/ui/src/tabs/feed/components/FeedTabView.test.ts
@@ -1,0 +1,41 @@
+/// <reference types="vite/client" />
+
+import { describe, expect, it, vi } from "vitest";
+import staticHtml from "../../../../static/index.html?raw";
+import { FeedSearchInput, FeedStatus } from "./FeedTabView";
+
+describe("FeedTabView accessibility primitives", () => {
+	it("describes the controlled Feed search input without mounting the full Feed", () => {
+		const onQuery = vi.fn();
+		const input = FeedSearchInput({ query: "needle", onQuery });
+
+		expect(input.type).toBe("input");
+		expect(input.props).toMatchObject({
+			"aria-label": "Search memories",
+			type: "search",
+			value: "needle",
+		});
+	});
+
+	it("announces Feed result and loading metadata politely", () => {
+		const status = FeedStatus({ text: "Searching memories…" });
+
+		expect(status.type).toBe("div");
+		expect(status.props).toMatchObject({
+			"aria-live": "polite",
+			role: "status",
+		});
+		expect(status.props.children).toBe("Searching memories…");
+	});
+
+	it("keeps the tracked static Feed fallback accessible", () => {
+		const document = new DOMParser().parseFromString(staticHtml, "text/html");
+		const input = document.getElementById("feedSearch");
+		const status = document.getElementById("feedMeta");
+
+		expect(input?.getAttribute("type")).toBe("search");
+		expect(input?.getAttribute("aria-label")).toBe("Search memories");
+		expect(status?.getAttribute("role")).toBe("status");
+		expect(status?.getAttribute("aria-live")).toBe("polite");
+	});
+});

--- a/packages/ui/src/tabs/feed/components/FeedTabView.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedTabView.tsx
@@ -7,11 +7,41 @@ import { ContextInspectorPanel } from "./ContextInspectorPanel";
 import { FeedList } from "./FeedList";
 import { FeedToggle } from "./FeedToggle";
 
+export function FeedStatus({ text }: { text: string }) {
+	return h(
+		"div",
+		{ "aria-live": "polite", className: "section-meta", id: "feedMeta", role: "status" },
+		text,
+	);
+}
+
+export function FeedSearchInput({
+	query,
+	onQuery,
+}: {
+	query: string;
+	onQuery: (query: string) => void;
+}) {
+	return h("input", {
+		"aria-label": "Search memories",
+		className: "feed-search",
+		id: "feedSearch",
+		onInput: (event) => {
+			onQuery(String((event.currentTarget as HTMLInputElement).value || ""));
+		},
+		placeholder: "Search title, body, tags…",
+		type: "search",
+		value: query,
+	});
+}
+
 export function FeedTabView({
+	errorText,
 	items,
 	loadingText,
 	ops,
 }: {
+	errorText?: string;
 	items: FeedItem[];
 	loadingText?: string;
 	ops: FeedViewOps;
@@ -23,31 +53,20 @@ export function FeedTabView({
 		h(
 			"div",
 			{ className: "feed-controls" },
-			h(
-				"div",
-				{ className: "section-meta", id: "feedMeta" },
-				loadingText || feedMetaText(items.length, ops.hasMorePages()),
-			),
+			h(FeedStatus, {
+				text: loadingText || feedMetaText(items.length, ops.hasMorePages()),
+			}),
 			h(
 				"div",
 				{ className: "feed-controls-right" },
-				h("input", {
-					className: "feed-search",
-					id: "feedSearch",
-					onInput: (event) => {
-						state.feedQuery = String((event.currentTarget as HTMLInputElement).value || "");
-						ops.updateFeedView();
-					},
-					placeholder: "Search title, body, tags…",
-					value: state.feedQuery,
-				}),
+				h(FeedSearchInput, { query: state.feedQuery, onQuery: ops.updateFeedQuery }),
 				h(FeedToggle, {
 					active: state.feedScopeFilter,
 					id: "feedScopeToggle",
 					onSelect: (value) => {
 						if (value === state.feedScopeFilter) return;
 						setFeedScopeFilter(value);
-						void ops.loadFeedData();
+						void ops.loadFeedData().catch(() => undefined);
 					},
 					options: [
 						{ value: "all", label: "All" },
@@ -83,6 +102,31 @@ export function FeedTabView({
 			),
 		),
 		h(ContextInspectorPanel, { open: inspectorOpen }),
-		h("div", { className: "feed-list", id: "feedList" }, h(FeedList, { items, loadingText, ops })),
+		h(
+			"div",
+			{ className: "feed-list", id: "feedList" },
+			h(
+				Fragment,
+				null,
+				errorText
+					? h(
+							"div",
+							{ className: "small feed-empty-state", role: "alert" },
+							h("strong", null, errorText),
+							h("div", null, "Check the viewer connection, then retry the Feed."),
+							h(
+								"button",
+								{
+									className: "settings-button",
+									onClick: () => void ops.loadFeedData().catch(() => undefined),
+									type: "button",
+								},
+								"Retry",
+							),
+						)
+					: null,
+				!errorText || items.length > 0 ? h(FeedList, { items, loadingText, ops }) : null,
+			),
+		),
 	);
 }

--- a/packages/ui/src/tabs/feed/data/filter.ts
+++ b/packages/ui/src/tabs/feed/data/filter.ts
@@ -1,8 +1,8 @@
-/* Feed filtering — by-type / by-query / signature helpers.
+/* Feed filtering — by-type and signature helpers.
  * Reads the feed-tab globals from lib/state directly so callers can stay
  * declarative. */
 
-import { normalize, parseJsonArray } from "../../../lib/format";
+import { normalize } from "../../../lib/format";
 import { state } from "../../../lib/state";
 import type { FeedItem } from "../types";
 import { itemSignature, mergeMetadata } from "./helpers";
@@ -14,25 +14,6 @@ export function filterByType(items: FeedItem[]): FeedItem[] {
 	if (state.feedTypeFilter === "summaries")
 		return items.filter((i) => isSummaryLikeItem(i, mergeMetadata(i?.metadata_json)));
 	return items;
-}
-
-export function filterByQuery(items: FeedItem[]): FeedItem[] {
-	const query = normalize(state.feedQuery);
-	if (!query) return items;
-	return items.filter((item) => {
-		const hay = [
-			normalize(item?.title),
-			normalize(item?.body_text),
-			normalize(item?.kind),
-			parseJsonArray(item?.tags || [])
-				.map((t) => normalize(t))
-				.join(" "),
-			normalize(item?.project),
-		]
-			.join(" ")
-			.trim();
-		return hay.includes(query);
-	});
 }
 
 export function computeSignature(items: FeedItem[]): string {

--- a/packages/ui/src/tabs/feed/data/helpers.test.ts
+++ b/packages/ui/src/tabs/feed/data/helpers.test.ts
@@ -1,10 +1,23 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { MACHINE_PRESENTATION_LABEL_FIXTURES } from "../../../lib/identity-presentation";
 import { state } from "../../../lib/state";
-import { authorLabel, deviceLabel } from "./helpers";
+import { authorLabel, deviceLabel, itemTags } from "./helpers";
 
 beforeEach(() => {
 	state.lastStatsPayload = null;
+});
+
+describe("itemTags", () => {
+	it("uses persisted tags_text when the legacy tags field is absent", () => {
+		expect(itemTags({ tags_text: "release-hotfix searchable-tag" })).toEqual([
+			"release-hotfix",
+			"searchable-tag",
+		]);
+	});
+
+	it("prefers an explicit tags field when both shapes are present", () => {
+		expect(itemTags({ tags: ["legacy"], tags_text: "persisted" })).toEqual(["legacy"]);
+	});
 });
 
 describe("Feed identity labels", () => {

--- a/packages/ui/src/tabs/feed/data/helpers.ts
+++ b/packages/ui/src/tabs/feed/data/helpers.ts
@@ -1,7 +1,7 @@
 /* Pure helper functions for the Feed tab — no rendering, no state mutation.
  */
 
-import { normalize } from "../../../lib/format";
+import { normalize, parseJsonArray } from "../../../lib/format";
 import { humanPresentationLabel } from "../../../lib/identity-presentation";
 import { state } from "../../../lib/state";
 import type { FeedItem, FeedItemMetadata } from "../types";
@@ -78,6 +78,14 @@ export function itemSignature(item: FeedItem): string {
 
 export function itemKey(item: FeedItem): string {
 	return `${String(item.kind || "").toLowerCase()}:${itemSignature(item)}`;
+}
+
+export function itemTags(item: FeedItem): unknown[] {
+	if (item.tags != null) return parseJsonArray(item.tags);
+	const parsed = parseJsonArray(item.tags_text);
+	if (parsed.length > 0) return parsed;
+	if (typeof item.tags_text !== "string") return [];
+	return item.tags_text.trim().split(/\s+/).filter(Boolean);
 }
 
 export function feedScopeLabel(scope: string): string {

--- a/packages/ui/src/tabs/feed/types.ts
+++ b/packages/ui/src/tabs/feed/types.ts
@@ -36,6 +36,7 @@ export interface FeedItem {
 	narrative?: string;
 	facts?: unknown;
 	tags?: unknown;
+	tags_text?: unknown;
 	files?: unknown;
 	project?: string;
 	actor_id?: string;
@@ -66,5 +67,6 @@ export interface FeedViewOps {
 	removeFeedItem: (memoryId: number) => void;
 	updateFeedView: (force?: boolean) => void;
 	loadFeedData: () => Promise<void>;
+	updateFeedQuery: (query: string) => void;
 	hasMorePages: () => boolean;
 }

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -3951,9 +3951,9 @@
     <!-- ── Tab: Feed ───────────────────────────────────────── -->
     <div class="tab-panel" id="tab-feed">
       <div class="feed-controls">
-        <div class="section-meta" id="feedMeta">Loading memories…</div>
+        <div class="section-meta" id="feedMeta" role="status" aria-live="polite">Loading memories…</div>
         <div class="feed-controls-right">
-          <input class="feed-search" id="feedSearch" placeholder="Search title, body, tags…" />
+          <input class="feed-search" id="feedSearch" type="search" aria-label="Search memories" placeholder="Search title, body, tags…" />
           <div class="feed-toggle" id="feedScopeToggle">
             <button class="toggle-button" data-filter="all">All</button>
             <button class="toggle-button" data-filter="mine">My memories</button>

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -116,6 +116,10 @@ function insertTestMemory(
 		kind: string;
 		title: string;
 		bodyText?: string;
+		subtitle?: string;
+		tagsText?: string;
+		facts?: unknown;
+		narrative?: string;
 		metadata?: Record<string, unknown>;
 		actorId?: string | null;
 		originDeviceId?: string | null;
@@ -153,7 +157,21 @@ function insertTestMemory(
 			`${options.kind}-${options.title}-${now}`,
 			options.scopeId ?? null,
 		);
-	return Number(result.lastInsertRowid);
+	const memoryId = Number(result.lastInsertRowid);
+	store.db
+		.prepare(
+			`UPDATE memory_items
+			 SET subtitle = ?, tags_text = ?, facts = ?, narrative = ?
+			 WHERE id = ?`,
+		)
+		.run(
+			options.subtitle ?? null,
+			options.tagsText ?? "",
+			options.facts == null ? null : JSON.stringify(options.facts),
+			options.narrative ?? null,
+			memoryId,
+		);
+	return memoryId;
 }
 
 /** Create a test Hono app backed by a fresh in-memory DB. */
@@ -2077,6 +2095,496 @@ describe("viewer-server", () => {
 	});
 
 	describe("memory feed routes", () => {
+		it("searches eligible observations before pagination and keeps chronological pages stable", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "session_summary",
+					title: "Global needle summary must not consume observation pagination",
+					createdAt: "2026-08-20T12:04:00.000Z",
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Newest unrelated observation",
+					createdAt: "2026-08-20T12:03:00.000Z",
+				});
+				const firstId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Global needle newest match",
+					createdAt: "2026-08-20T12:02:00.000Z",
+				});
+				const secondId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Global needle oldest match",
+					createdAt: "2026-08-20T12:02:00.000Z",
+				});
+
+				const firstPage = (await (
+					await app.request("/api/observations?q=GLOBAL%20NEEDLE&limit=1&offset=0")
+				).json()) as {
+					items: Array<{ id: number }>;
+					pagination: { has_more: boolean; next_offset: number | null };
+				};
+				const secondPage = (await (
+					await app.request(
+						`/api/observations?q=global%20needle&limit=1&offset=${firstPage.pagination.next_offset}`,
+					)
+				).json()) as { items: Array<{ id: number }>; pagination: { has_more: boolean } };
+
+				expect(firstPage.items.map((item) => item.id)).toEqual([secondId]);
+				expect(firstPage.pagination).toMatchObject({ has_more: true, next_offset: 1 });
+				expect(secondPage.items.map((item) => item.id)).toEqual([firstId]);
+				expect(secondPage.pagination.has_more).toBe(false);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("searches observations and summaries by their displayed project", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionProjectId = insertTestSession(store.db);
+				store.db
+					.prepare("UPDATE sessions SET project = ? WHERE id = ?")
+					.run("/tmp/Project Phoenix Observatory", sessionProjectId);
+				const observationId = insertTestMemory(store, {
+					sessionId: sessionProjectId,
+					kind: "change",
+					title: "Unrelated observation",
+				});
+				const summaryId = insertTestMemory(store, {
+					sessionId: sessionProjectId,
+					kind: "session_summary",
+					title: "Unrelated summary",
+				});
+				store.db
+					.prepare("UPDATE memory_items SET project = NULL WHERE id IN (?, ?)")
+					.run(observationId, summaryId);
+
+				const itemProjectSessionId = insertTestSession(store.db);
+				store.db
+					.prepare("UPDATE sessions SET project = ? WHERE id = ?")
+					.run("/tmp/Hidden Artemis Project", itemProjectSessionId);
+				const itemProjectObservationId = insertTestMemory(store, {
+					sessionId: itemProjectSessionId,
+					kind: "change",
+					title: "Another unrelated observation",
+				});
+				const itemProjectSummaryId = insertTestMemory(store, {
+					sessionId: itemProjectSessionId,
+					kind: "session_summary",
+					title: "Another unrelated summary",
+				});
+				store.db
+					.prepare("UPDATE memory_items SET project = ? WHERE id IN (?, ?)")
+					.run("Displayed Apollo Project", itemProjectObservationId, itemProjectSummaryId);
+
+				const controlSessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId: controlSessionId,
+					kind: "change",
+					title: "Negative control observation",
+				});
+				insertTestMemory(store, {
+					sessionId: controlSessionId,
+					kind: "session_summary",
+					title: "Negative control summary",
+				});
+
+				const observations = (await (
+					await app.request("/api/observations?q=phoenix%20observatory")
+				).json()) as { items: Array<{ id: number; project: string }> };
+				const summaries = (await (
+					await app.request("/api/summaries?q=phoenix%20observatory")
+				).json()) as { items: Array<{ id: number; project: string }> };
+
+				expect(observations.items).toMatchObject([
+					{ id: observationId, project: "Project Phoenix Observatory" },
+				]);
+				expect(summaries.items).toMatchObject([
+					{ id: summaryId, project: "Project Phoenix Observatory" },
+				]);
+
+				const itemProjectObservations = (await (
+					await app.request("/api/observations?q=displayed%20apollo")
+				).json()) as { items: Array<{ id: number; project: string }> };
+				const itemProjectSummaries = (await (
+					await app.request("/api/summaries?q=displayed%20apollo")
+				).json()) as { items: Array<{ id: number; project: string }> };
+				expect(itemProjectObservations.items).toEqual([
+					expect.objectContaining({
+						id: itemProjectObservationId,
+						project: "Displayed Apollo Project",
+					}),
+				]);
+				expect(itemProjectSummaries.items).toEqual([
+					expect.objectContaining({
+						id: itemProjectSummaryId,
+						project: "Displayed Apollo Project",
+					}),
+				]);
+
+				const hiddenSessionProject = (await (
+					await app.request("/api/observations?q=hidden%20artemis")
+				).json()) as { items: unknown[] };
+				expect(hiddenSessionProject.items).toEqual([]);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("searches exact positive IDs, tags, structured fields, and summary metadata", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const idMatch = insertTestMemory(store, {
+					sessionId,
+					kind: "decision",
+					title: "x",
+				});
+				const numericTextId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Numeric textual match",
+					bodyText: `References memory ${idMatch} without being that row`,
+				});
+				const structuredId = insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Structured observation",
+					bodyText: "Body-only cormorant",
+					subtitle: "Subtitle falcon",
+					tagsText: "release-hotfix searchable-tag",
+					facts: ["Fact albatross"],
+					narrative: "Narrative kingfisher",
+				});
+				const summaryId = insertTestMemory(store, {
+					sessionId,
+					kind: "session_summary",
+					title: "Summary",
+					subtitle: "Summary subtitle heron",
+					tagsText: "summary-tag",
+					facts: ["Summary fact ibis"],
+					narrative: "Summary narrative tern",
+					metadata: {
+						request: "Metadata osprey",
+						subtitle: "Metadata swan",
+						narrative: "Metadata loon",
+						facts: ["Metadata crane"],
+						summary: "Metadata auk",
+						internal_marker: "Metadata secret",
+					},
+				});
+				const plusAliasId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "x",
+				});
+				insertTestMemory(store, { sessionId, kind: "change", title: "filler" });
+				const leadingZeroAliasId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "x",
+				});
+				const plusTextId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Literal +5 marker",
+				});
+				const leadingZeroTextId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Literal 007 marker",
+				});
+				expect(plusAliasId).toBe(5);
+				expect(leadingZeroAliasId).toBe(7);
+
+				for (const q of [
+					"structured observation",
+					"body-only cormorant",
+					"falcon",
+					"searchable-tag",
+					"albatross",
+					"kingfisher",
+					"discovery",
+				]) {
+					const payload = (await (
+						await app.request(`/api/observations?q=${encodeURIComponent(q)}`)
+					).json()) as { items: Array<{ id: number }> };
+					expect(payload.items.map((item) => item.id)).toEqual([structuredId]);
+				}
+				const idPayload = (await (await app.request(`/api/observations?q=${idMatch}`)).json()) as {
+					items: Array<{ id: number }>;
+				};
+				expect(idPayload.items.map((item) => item.id)).toEqual([numericTextId, idMatch]);
+				const plusPayload = (await (await app.request("/api/observations?q=%2B5")).json()) as {
+					items: Array<{ id: number }>;
+				};
+				expect(plusPayload.items.map((item) => item.id)).toEqual([plusTextId]);
+				const leadingZeroPayload = (await (
+					await app.request("/api/observations?q=007")
+				).json()) as { items: Array<{ id: number }> };
+				expect(leadingZeroPayload.items.map((item) => item.id)).toEqual([leadingZeroTextId]);
+
+				for (const q of [
+					"metadata osprey",
+					"metadata swan",
+					"metadata loon",
+					"metadata crane",
+					"metadata auk",
+					"summary subtitle heron",
+					"summary-tag",
+					"summary fact ibis",
+					"summary narrative tern",
+				]) {
+					const summaryPayload = (await (
+						await app.request(`/api/summaries?q=${encodeURIComponent(q)}`)
+					).json()) as { items: Array<{ id: number }> };
+					expect(summaryPayload.items.map((item) => item.id)).toEqual([summaryId]);
+				}
+				const internalMetadataPayload = (await (
+					await app.request("/api/summaries?q=metadata%20secret")
+				).json()) as { items: Array<{ id: number }> };
+				expect(internalMetadataPayload.items).toEqual([]);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("casefolds Unicode search without locale-dependent rules", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const cafeId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "CAFÉ rollout",
+				});
+				const cyrillicId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "ПРИВЕТ мир",
+				});
+
+				const cafe = (await (
+					await app.request(`/api/observations?q=${encodeURIComponent("café")}`)
+				).json()) as { items: Array<{ id: number }> };
+				const cyrillic = (await (
+					await app.request(`/api/observations?q=${encodeURIComponent("привет")}`)
+				).json()) as { items: Array<{ id: number }> };
+
+				expect(cafe.items.map((item) => item.id)).toEqual([cafeId]);
+				expect(cyrillic.items.map((item) => item.id)).toEqual([cyrillicId]);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("caps normalized Feed queries at 256 code units", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const prefix = "x".repeat(256);
+				const matchingId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: prefix,
+				});
+
+				const payload = (await (
+					await app.request(`/api/observations?q=${encodeURIComponent(`${prefix}TAIL`)}`)
+				).json()) as { items: Array<{ id: number }> };
+
+				expect(payload.items.map((item) => item.id)).toEqual([matchingId]);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("searches summaries beyond the first unfiltered page", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Pelican needle observation must not consume summary pagination",
+					createdAt: "2026-08-20T12:04:00.000Z",
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "session_summary",
+					title: "Newest unrelated summary",
+					createdAt: "2026-08-20T12:03:00.000Z",
+				});
+				const matchingId = insertTestMemory(store, {
+					sessionId,
+					kind: "session_summary",
+					title: "Older summary with pelican needle",
+					createdAt: "2026-08-20T12:01:00.000Z",
+				});
+
+				const payload = (await (
+					await app.request("/api/summaries?q=pelican%20needle&limit=1&offset=0")
+				).json()) as { items: Array<{ id: number }>; pagination: { has_more: boolean } };
+				expect(payload.items.map((item) => item.id)).toEqual([matchingId]);
+				expect(payload.pagination.has_more).toBe(false);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("searches metadata-classified summaries by their canonical displayed kind", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const summaryId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Flag classified summary",
+					metadata: { is_summary: true },
+				});
+				const sourceSummaryId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Source classified summary",
+					metadata: { source: "observer_summary" },
+				});
+				const observationId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Metadata classified observation",
+				});
+
+				const summaries = (await (
+					await app.request("/api/summaries?q=session_summary")
+				).json()) as { items: Array<{ id: number; kind: string }> };
+				const observations = (await (
+					await app.request("/api/observations?q=session_summary")
+				).json()) as { items: Array<{ id: number }> };
+				const changeSummaries = (await (await app.request("/api/summaries?q=change")).json()) as {
+					items: Array<{ id: number }>;
+				};
+				const changeObservations = (await (
+					await app.request("/api/observations?q=change")
+				).json()) as { items: Array<{ id: number; kind: string }> };
+				expect(new Set(summaries.items.map((item) => item.id))).toEqual(
+					new Set([summaryId, sourceSummaryId]),
+				);
+				expect(summaries.items.every((item) => item.kind === "session_summary")).toBe(true);
+				expect(observations.items).toEqual([]);
+				expect(changeSummaries.items).toEqual([]);
+				expect(changeObservations.items).toMatchObject([{ id: observationId, kind: "change" }]);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("intersects search with project, ownership, sharing-domain, active, and type filters", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				grantSyncScopeToDevices(store, "authorized-team", [store.deviceId]);
+				grantSyncScopeToDevices(store, "unauthorized-team", []);
+				const projectSessionId = insertTestSession(store.db);
+				store.db
+					.prepare("UPDATE sessions SET project = ? WHERE id = ?")
+					.run("search-project", projectSessionId);
+				const otherSessionId = insertTestSession(store.db);
+				store.db
+					.prepare("UPDATE sessions SET project = ? WHERE id = ?")
+					.run("other-project", otherSessionId);
+				const visibleId = insertTestMemory(store, {
+					sessionId: projectSessionId,
+					kind: "bugfix",
+					title: "Boundary keyword visible",
+					scopeId: "authorized-team",
+				});
+				const hiddenId = insertTestMemory(store, {
+					sessionId: projectSessionId,
+					kind: "bugfix",
+					title: "Boundary keyword hidden domain",
+					scopeId: "unauthorized-team",
+				});
+				const theirsId = insertTestMemory(store, {
+					sessionId: projectSessionId,
+					kind: "bugfix",
+					title: "Boundary keyword theirs",
+					actorId: "peer:other",
+					originDeviceId: "peer-device-002",
+					scopeId: "authorized-team",
+				});
+				insertTestMemory(store, {
+					sessionId: projectSessionId,
+					kind: "bugfix",
+					title: "Boundary keyword inactive",
+					active: false,
+					scopeId: "authorized-team",
+				});
+				insertTestMemory(store, {
+					sessionId: projectSessionId,
+					kind: "session_summary",
+					title: "Boundary keyword summary",
+					scopeId: "authorized-team",
+				});
+				insertTestMemory(store, {
+					sessionId: otherSessionId,
+					kind: "bugfix",
+					title: "Boundary keyword other project",
+					scopeId: "authorized-team",
+				});
+
+				const payload = (await (
+					await app.request(
+						"/api/observations?q=boundary%20keyword&project=search-project&scope=mine",
+					)
+				).json()) as { items: Array<{ id: number }> };
+				expect(payload.items.map((item) => item.id)).toEqual([visibleId]);
+
+				const theirsPayload = (await (
+					await app.request(
+						"/api/observations?q=boundary%20keyword&project=search-project&scope=theirs",
+					)
+				).json()) as { items: Array<{ id: number }> };
+				expect(theirsPayload.items.map((item) => item.id)).toEqual([theirsId]);
+
+				const hiddenIdPayload = (await (
+					await app.request(`/api/observations?q=${hiddenId}`)
+				).json()) as { items: Array<{ id: number }> };
+				expect(hiddenIdPayload.items).toEqual([]);
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("keeps memory list routes available when identity tables are unavailable", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {
@@ -2943,6 +3451,39 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("does not classify numeric is_summary metadata as a summary", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Numeric summary flag",
+					metadata: { is_summary: 1 },
+				});
+
+				const summariesRes = await app.request("/api/summaries");
+				expect(summariesRes.status).toBe(200);
+				const summaries = ((await summariesRes.json()) as { items: Array<{ title: string }> })
+					.items;
+				expect(summaries.map((item) => item.title)).not.toContain("Numeric summary flag");
+
+				const observationsRes = await app.request("/api/observations");
+				expect(observationsRes.status).toBe(200);
+				const observations = (
+					(await observationsRes.json()) as { items: Array<{ title: string; kind: string }> }
+				).items;
+				expect(observations).toContainEqual(
+					expect.objectContaining({ title: "Numeric summary flag", kind: "change" }),
+				);
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("keeps session observation counts aligned with active feed items", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {
@@ -3071,7 +3612,7 @@ describe("viewer-server", () => {
 			}
 		});
 
-		it("tolerates malformed metadata when classifying summaries", async () => {
+		it("tolerates malformed metadata during classification and search", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {
 				await app.request("/api/stats");
@@ -3088,13 +3629,13 @@ describe("viewer-server", () => {
 					.prepare("UPDATE memory_items SET metadata_json = ? WHERE title = ?")
 					.run("{not-json", "Broken metadata row");
 
-				const observationsRes = await app.request("/api/observations");
+				const observationsRes = await app.request("/api/observations?q=broken%20metadata");
 				expect(observationsRes.status).toBe(200);
 				const observations = ((await observationsRes.json()) as { items: Array<{ title: string }> })
 					.items;
 				expect(observations.map((item) => item.title)).toContain("Broken metadata row");
 
-				const summariesRes = await app.request("/api/summaries");
+				const summariesRes = await app.request("/api/summaries?q=broken%20metadata");
 				expect(summariesRes.status).toBe(200);
 			} finally {
 				cleanup();

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -7,8 +7,8 @@ import {
 	buildFilterClausesWithContext,
 	canonicalMemoryKind,
 	fromJson,
-	isSummaryLikeMemory as isCoreSummaryLikeMemory,
 	normalizeHumanPresentationName,
+	parsePositiveMemoryId,
 	parseStrictInteger,
 	schema,
 } from "@codemem/core";
@@ -20,6 +20,27 @@ import { queryInt } from "../helpers.js";
 type StoreFactory = () => MemoryStore;
 
 type OwnershipPredicate = (item: Record<string, unknown>) => boolean;
+
+const MAX_FEED_QUERY_CODE_UNITS = 256;
+const searchFunctionsRegisteredStores = new WeakSet<MemoryStore>();
+
+function casefold(value: unknown): string {
+	return String(value ?? "").toLowerCase();
+}
+
+function normalizeMemorySearchQuery(value: string | undefined): string | undefined {
+	const normalized = casefold(value?.trim()).slice(0, MAX_FEED_QUERY_CODE_UNITS);
+	return normalized || undefined;
+}
+
+function ensureMemorySearchFunctions(store: MemoryStore): void {
+	if (searchFunctionsRegisteredStores.has(store)) return;
+	store.db.function("codemem_casefold", { deterministic: true }, casefold);
+	store.db.function("codemem_project_basename", { deterministic: true }, (value: unknown) =>
+		projectBasename(String(value ?? "").trim()),
+	);
+	searchFunctionsRegisteredStores.add(store);
+}
 
 interface ActorPresentationRow {
 	actor_id: string;
@@ -284,11 +305,46 @@ function summaryLikeSqlPredicate(): string {
 		OR (
 			json_valid(COALESCE(memory_items.metadata_json, ''))
 			AND (
-				COALESCE(json_extract(memory_items.metadata_json, '$.is_summary') = 1, 0)
+				COALESCE(json_type(memory_items.metadata_json, '$.is_summary') = 'true', 0)
 				OR LOWER(TRIM(COALESCE(json_extract(memory_items.metadata_json, '$.source'), ''))) = 'observer_summary'
 			)
 		)
 	)`;
+}
+
+function memorySearchSql(query: string): { clause: string; params: unknown[] } {
+	const textClause = `INSTR(codemem_casefold(
+		COALESCE(memory_items.title, '') || CHAR(10) ||
+		COALESCE(memory_items.body_text, '') || CHAR(10) ||
+		CASE WHEN ${summaryLikeSqlPredicate()} THEN 'session_summary' ELSE
+			COALESCE(NULLIF(LOWER(TRIM(COALESCE(memory_items.kind, ''))), ''), 'change')
+		END || CHAR(10) ||
+		COALESCE(
+			memory_items.project,
+			codemem_project_basename(
+				(SELECT sessions.project FROM sessions WHERE sessions.id = memory_items.session_id)
+			),
+			''
+		) || CHAR(10) ||
+		COALESCE(memory_items.tags_text, '') || CHAR(10) ||
+		COALESCE(memory_items.facts, '') || CHAR(10) ||
+		COALESCE(memory_items.subtitle, '') || CHAR(10) ||
+		COALESCE(memory_items.narrative, '') || CHAR(10) ||
+		CASE WHEN json_valid(COALESCE(memory_items.metadata_json, '')) THEN
+			COALESCE(json_extract(memory_items.metadata_json, '$.request'), '') || CHAR(10) ||
+			COALESCE(json_extract(memory_items.metadata_json, '$.subtitle'), '') || CHAR(10) ||
+			COALESCE(json_extract(memory_items.metadata_json, '$.narrative'), '') || CHAR(10) ||
+			COALESCE(json_extract(memory_items.metadata_json, '$.facts'), '') || CHAR(10) ||
+			COALESCE(json_extract(memory_items.metadata_json, '$.summary'), '')
+		ELSE '' END
+	), codemem_casefold(?)) > 0`;
+	const parsedMemoryId = parsePositiveMemoryId(query);
+	const memoryId =
+		parsedMemoryId != null && String(parsedMemoryId) === query ? parsedMemoryId : null;
+	if (memoryId != null) {
+		return { clause: `(memory_items.id = ? OR ${textClause})`, params: [memoryId, query] };
+	}
+	return { clause: textClause, params: [query] };
 }
 
 function countVisibleObservationRows(store: MemoryStore, filters?: MemoryFilters | null): number {
@@ -372,14 +428,28 @@ function queryMemoryPage(
 		offset: number;
 		project?: string;
 		scope?: "mine" | "theirs";
+		q?: string;
+		classification: "observation" | "summary";
 	},
 ): Record<string, unknown>[] {
+	ensureMemorySearchFunctions(store);
 	const filters: MemoryFilters = {};
 	if (options.project) filters.project = options.project;
 	if (options.scope) filters.ownership_scope = options.scope;
 
 	const filterResult = buildViewerMemoryFilters(store, filters);
-	const clauses = ["memory_items.active = 1", ...filterResult.clauses];
+	const summaryPredicate = summaryLikeSqlPredicate();
+	const clauses = [
+		"memory_items.active = 1",
+		options.classification === "summary" ? summaryPredicate : `NOT ${summaryPredicate}`,
+		...filterResult.clauses,
+	];
+	const params: unknown[] = [...filterResult.params];
+	if (options.q) {
+		const search = memorySearchSql(options.q);
+		clauses.push(search.clause);
+		params.push(...search.params);
+	}
 	const where = clauses.join(" AND ");
 	const from = filterResult.joinSessions
 		? "memory_items JOIN sessions ON sessions.id = memory_items.session_id"
@@ -389,50 +459,13 @@ function queryMemoryPage(
 		.prepare(
 			`SELECT memory_items.* FROM ${from}
 			 WHERE ${where}
-			 ORDER BY memory_items.created_at DESC
+			 ORDER BY memory_items.created_at DESC, memory_items.id DESC
 			 LIMIT ? OFFSET ?`,
 		)
-		.all(...filterResult.params, options.limit + 1, options.offset) as Record<string, unknown>[];
+		.all(...params, options.limit + 1, options.offset) as Record<string, unknown>[];
 
 	const ownedBySelf = store.buildOwnershipPredicate();
 	return rows.map((row) => serializeMemoryRow(ownedBySelf, row));
-}
-
-function isSummaryLikeMemory(item: Record<string, unknown>): boolean {
-	return isCoreSummaryLikeMemory({
-		kind: item.kind as string | null | undefined,
-		metadata: item.metadata_json,
-	});
-}
-
-function selectMemoryPage(
-	store: MemoryStore,
-	options: {
-		limit: number;
-		offset: number;
-		project?: string;
-		scope?: "mine" | "theirs";
-		matcher: (item: Record<string, unknown>) => boolean;
-	},
-): Record<string, unknown>[] {
-	const pageSize = Math.max(options.limit + options.offset + 10, 50);
-	let rawOffset = 0;
-	const matched: Record<string, unknown>[] = [];
-
-	while (matched.length < options.offset + options.limit + 1) {
-		const page = queryMemoryPage(store, {
-			limit: pageSize,
-			offset: rawOffset,
-			project: options.project,
-			scope: options.scope,
-		});
-		if (page.length === 0) break;
-		matched.push(...page.filter(options.matcher));
-		if (page.length < pageSize) break;
-		rawOffset += page.length;
-	}
-
-	return matched.slice(options.offset, options.offset + options.limit + 1);
 }
 
 export function memoryRoutes(getStore: StoreFactory) {
@@ -509,12 +542,14 @@ export function memoryRoutes(getStore: StoreFactory) {
 			const offset = Math.max(0, queryInt(c.req.query("offset"), 0));
 			const project = c.req.query("project") || undefined;
 			const scope = normalizeScope(c.req.query("scope"));
-			const items = selectMemoryPage(store, {
+			const q = normalizeMemorySearchQuery(c.req.query("q"));
+			const items = queryMemoryPage(store, {
 				limit,
 				offset,
 				project,
 				scope,
-				matcher: (item) => !isSummaryLikeMemory(item),
+				q,
+				classification: "observation",
 			});
 			const hasMore = items.length > limit;
 			const result = hasMore ? items.slice(0, limit) : items;
@@ -541,12 +576,14 @@ export function memoryRoutes(getStore: StoreFactory) {
 			const offset = Math.max(0, queryInt(c.req.query("offset"), 0));
 			const project = c.req.query("project") || undefined;
 			const scope = normalizeScope(c.req.query("scope"));
-			const items = selectMemoryPage(store, {
+			const q = normalizeMemorySearchQuery(c.req.query("q"));
+			const items = queryMemoryPage(store, {
 				limit,
 				offset,
 				project,
 				scope,
-				matcher: (item) => isSummaryLikeMemory(item),
+				q,
+				classification: "summary",
 			});
 			const hasMore = items.length > limit;
 			const result = hasMore ? items.slice(0, limit) : items;


### PR DESCRIPTION
## Description

Move Feed search to the Viewer server so it searches all eligible observations and summaries before pagination instead of filtering only rows already loaded in the browser.

The implementation preserves active-memory, sharing-domain, project, ownership, and stream constraints; adds deterministic Unicode-aware text matching and exact canonical positive ID matching; and hardens UI debounce, pagination, stale-response, and accessibility behavior.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (pnpm run tsc, pnpm run lint, pnpm run test)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation included focused Feed tests (326 tests), the full workspace test/build gates, git diff --check, and the built E2E smoke scenario.

## Checklist

- [x] Code follows project style (pnpm run lint passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced