### PR TITLE
feat(ui): add Sharing and Devices loading states

### DIFF
--- a/docs/plans/2026-08-20-sharing-devices-loading-states-design.md
+++ b/docs/plans/2026-08-20-sharing-devices-loading-states-design.md
@@ -1,0 +1,33 @@
+# Sharing and Devices loading states
+
+## Problem
+
+Sharing and Devices currently replace their card content with plain loading text. The text
+confirms that work is happening, but the abrupt shape change makes both tabs feel unfinished and
+causes avoidable layout movement. Sharing also discards previously loaded cards when a background
+refresh fails, even though the last successful data remains useful.
+
+## Decision
+
+Use content-shaped card skeletons for the first unresolved load only. The skeletons reuse the
+Viewer's existing shimmer timing, surfaces, borders, radii, and reduced-motion behavior. They
+approximate the final card anatomy—title, badge, and detail rows—without implying exact content.
+
+After content has loaded once, background refreshes keep the existing cards visible. A failed
+refresh adds an assertive message above the stale content instead of replacing it. Initial failures
+still render the existing unavailable state because there is no trustworthy content to preserve.
+
+## Accessibility
+
+- Screen-reader-only text provides one dedicated loading `role="status"` announcement; the
+  decorative skeleton list separately exposes `aria-busy="true"`. Devices also retains its
+  existing persistent commit-status region.
+- Skeleton geometry is decorative and hidden from assistive technology.
+- Shimmer stops under `prefers-reduced-motion: reduce`.
+- Refresh failures use `role="alert"`; retained cards remain navigable.
+
+## Non-goals
+
+- No API, data model, or navigation changes.
+- No skeletons during mutations or short button-level operations.
+- No loading overlay once either tab has resolved its first data set.

--- a/docs/plans/2026-08-20-sharing-devices-loading-states-implementation.md
+++ b/docs/plans/2026-08-20-sharing-devices-loading-states-implementation.md
@@ -1,0 +1,17 @@
+# Sharing and Devices loading states implementation
+
+## Scope
+
+1. Add a shared Preact card-list skeleton for Sharing and Devices.
+2. Replace both plain initial-loading messages with the shared skeleton.
+3. Add shared CSS beside the existing recipient-policy card styles, using
+   `--duration-shimmer` and the current motion preference.
+4. Cache the last successful Sharing data so a background refresh failure can retain its cards.
+5. Cover initial skeleton semantics, successful replacement, retained background content, and
+   initial versus refresh errors in focused tests.
+
+## Validation
+
+- Run the Sharing, Sharing loader, and Devices Vitest files.
+- Run TypeScript, Biome, and `git diff --check`.
+- Build the UI because Viewer assets and static hosting depend on the UI output.

--- a/packages/ui/src/app-devices.test.tsx
+++ b/packages/ui/src/app-devices.test.tsx
@@ -277,6 +277,20 @@ describe("Devices app integration", () => {
 		expect(rebind?.disabled).toBe(false);
 	});
 
+	it("retains the inventory-unavailable explanation after a failed refresh following the first Devices load", async () => {
+		mocks.loadRecipientPolicyIntent.mockRejectedValueOnce(new Error("refresh failed"));
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5_100);
+		});
+
+		const panel = document.getElementById("tab-devices");
+		expect(panel?.textContent).toContain(
+			"Refresh failed; showing previous device information. Identity setup is disabled until a refresh succeeds.",
+		);
+		expect(panel?.textContent).toContain("Device ownership information is temporarily unavailable");
+	});
+
 	it("retains cached inventory but disables Identity controls during a later inventory outage", async () => {
 		mocks.loadDeviceIdentityInventory.mockRejectedValueOnce(new Error("inventory unavailable"));
 
@@ -302,6 +316,28 @@ describe("Devices app integration", () => {
 			(button) => button.textContent === "Change Identity…",
 		);
 		expect(refreshedRebind?.disabled).toBe(false);
+	});
+
+	it("preserves inventory unavailability when the next required refresh fails", async () => {
+		mocks.loadDeviceIdentityInventory.mockRejectedValueOnce(new Error("inventory unavailable"));
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5_100);
+		});
+		expect(document.getElementById("tab-devices")?.textContent).toContain(
+			"Device ownership information is temporarily unavailable",
+		);
+
+		mocks.loadRecipientPolicyIntent.mockRejectedValueOnce(new Error("intent unavailable"));
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5_100);
+		});
+
+		const panel = document.getElementById("tab-devices");
+		expect(panel?.textContent).toContain(
+			"Refresh failed; showing previous device information. Identity setup is disabled until a refresh succeeds.",
+		);
+		expect(panel?.textContent).toContain("Device ownership information is temporarily unavailable");
 	});
 
 	it("joins runtime metadata only from the matched paired peer", () => {
@@ -368,7 +404,10 @@ describe("Devices app integration", () => {
 		const panel = document.getElementById("tab-devices");
 		expect(panel?.textContent).toContain("Work Laptop");
 		expect(panel?.querySelector('[role="alert"]')?.textContent).toBe(
-			"Refresh failed; showing previous device information.",
+			"Refresh failed; showing previous device information. Identity setup is disabled until a refresh succeeds.",
+		);
+		expect(panel?.textContent).not.toContain(
+			"Device ownership information is temporarily unavailable",
 		);
 		expect(document.getElementById("refreshStatus")?.textContent).toBe("refresh failed");
 		expect(document.getElementById("refreshAnnouncer")?.textContent).toBe("Refresh failed.");

--- a/packages/ui/src/app-sharing.test.tsx
+++ b/packages/ui/src/app-sharing.test.tsx
@@ -80,7 +80,7 @@ afterEach(() => {
 });
 
 describe("Sharing app data refresh", () => {
-	it("replaces stale actions after a refresh failure and restores them after recovery", async () => {
+	it("keeps stale Sharing cards after a refresh failure and restores fresh state after recovery", async () => {
 		document.body.innerHTML =
 			'<div id="recipientPolicySharingMount"></div><div id="recipientPolicyManagementMount"></div>';
 		const loadProjects = vi.fn().mockResolvedValue({ manageable: projects, received: [] });
@@ -113,12 +113,12 @@ describe("Sharing app data refresh", () => {
 		});
 		expect(refreshResult).toBe(false);
 		expect(document.body.textContent).toContain(
-			"Sharing details are unavailable. Refresh and try again.",
+			"Refresh failed; showing previous Sharing details.",
 		);
 		expect(document.body.textContent).toContain(
 			"The complete recipient access inventory is unavailable. Refresh and try again.",
 		);
-		expect(document.body.textContent).not.toContain("Manage projects");
+		expect(document.body.textContent).toContain("Manage projects");
 		expect(document.body.textContent).not.toContain("Review changes");
 
 		await act(async () => {
@@ -126,7 +126,9 @@ describe("Sharing app data refresh", () => {
 		});
 		expect(document.body.textContent).toContain("Manage projects");
 		expect(document.body.textContent).toContain("Review changes");
-		expect(document.body.textContent).not.toContain("Sharing details are unavailable");
+		expect(document.body.textContent).not.toContain(
+			"Refresh failed; showing previous Sharing details",
+		);
 	});
 
 	it("keeps Sharing usable when only device inventory is unavailable", async () => {
@@ -155,8 +157,51 @@ describe("Sharing app data refresh", () => {
 		await act(async () => {
 			await load();
 		});
-		expect(document.body.textContent).toContain("Sharing details are unavailable");
+		expect(document.body.textContent).toContain(
+			"Refresh failed; showing previous Sharing details.",
+		);
+		expect(document.body.textContent).toContain("Manage projects");
 		expect(document.body.textContent).toContain("Device Identity information is unavailable");
+	});
+
+	it("uses current inventory availability while preserving stale Sharing content", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const firstInventory = {
+			version: 1 as const,
+			items: [],
+			coordinatorEvidence: { availability: "available" as const, safeErrorCode: null },
+			truncated: false,
+		};
+		const loadDeviceInventory = vi
+			.fn()
+			.mockResolvedValueOnce(firstInventory)
+			.mockRejectedValueOnce(new Error("inventory unavailable"));
+		const loadIntent = vi
+			.fn()
+			.mockResolvedValueOnce(intent)
+			.mockRejectedValueOnce(new Error("intent unavailable"));
+		const mountSharing = vi.fn();
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory,
+			loadIntent,
+			loadProjects: vi.fn().mockResolvedValue({ manageable: projects, received: [] }),
+			mountSharing,
+		});
+
+		await load();
+		await load();
+
+		expect(mountSharing).toHaveBeenLastCalledWith(
+			document.getElementById("recipientPolicySharingMount"),
+			projects,
+			intent,
+			expect.objectContaining({
+				deviceInventory: firstInventory,
+				deviceInventoryUnavailable: true,
+				refreshError: true,
+			}),
+		);
+		expect(mountSharing.mock.calls.filter((call) => call[3]?.loading === true)).toHaveLength(1);
 	});
 
 	it("waits for delayed device inventory failure before rendering a broader load error", async () => {

--- a/packages/ui/src/app-sharing.ts
+++ b/packages/ui/src/app-sharing.ts
@@ -64,10 +64,14 @@ export function createRecipientPolicySharingLoader(
 	options: { onReviewDevices?: (deviceId?: string) => void } = {},
 ): () => Promise<boolean> {
 	const dependencies = { ...defaultDependencies, ...overrides };
-	let loaded = false;
 	let loadRevision = 0;
 	let latestLoad: Promise<boolean> | null = null;
 	let coordinatorEnrollmentIssueCount = 0;
+	let lastDeviceInventory: Awaited<ReturnType<typeof dependencies.loadDeviceInventory>> | undefined;
+	let lastSuccessfulData: {
+		inventory: RecipientPolicyProjectInventory;
+		intent: api.RecipientPolicyIntentGraphV1;
+	} | null = null;
 
 	const loadRecipientPolicySharingData = (): Promise<boolean> => {
 		const revision = ++loadRevision;
@@ -80,7 +84,7 @@ export function createRecipientPolicySharingLoader(
 		const sharingMount = document.getElementById("recipientPolicySharingMount");
 		if (!sharingMount) return true;
 		const managementMount = document.getElementById("recipientPolicyManagementMount");
-		if (!loaded) {
+		if (!lastSuccessfulData) {
 			dependencies.mountSharing(sharingMount, [], EMPTY_RECIPIENT_POLICY_INTENT, {
 				loading: true,
 			});
@@ -94,22 +98,26 @@ export function createRecipientPolicySharingLoader(
 			]);
 		if (revision !== loadRevision) return latestLoad ?? false;
 		const deviceInventoryUnavailable = deviceInventoryResult.status === "rejected";
+		if (deviceInventoryResult.status === "fulfilled") {
+			lastDeviceInventory = deviceInventoryResult.value;
+		}
 		if (syncStatusResult.status === "fulfilled") {
 			coordinatorEnrollmentIssueCount = coordinatorEnrollmentOpenIssueCount(syncStatusResult.value);
 		}
 		if (inventoryResult.status === "fulfilled" && intentResult.status === "fulfilled") {
 			const inventory = inventoryResult.value;
 			const intent = intentResult.value;
-			const deviceInventory =
-				deviceInventoryResult.status === "fulfilled" ? deviceInventoryResult.value : undefined;
+			lastSuccessfulData = {
+				intent,
+				inventory,
+			};
 			dependencies.mountSharing(sharingMount, inventory.manageable, intent, {
 				coordinatorEnrollmentIssueCount,
-				deviceInventory,
+				deviceInventory: lastDeviceInventory,
 				deviceInventoryUnavailable,
 				onReviewDevices: options.onReviewDevices,
 				received: inventory.received,
 			});
-			loaded = true;
 			if (managementMount) {
 				dependencies.mountManagement(managementMount, inventory.manageable, intent, {
 					onCommitted: async () => {
@@ -119,10 +127,26 @@ export function createRecipientPolicySharingLoader(
 			}
 			return true;
 		}
-		dependencies.mountSharing(sharingMount, [], EMPTY_RECIPIENT_POLICY_INTENT, {
-			deviceInventoryUnavailable,
-			loadError: true,
-		});
+		if (lastSuccessfulData) {
+			dependencies.mountSharing(
+				sharingMount,
+				lastSuccessfulData.inventory.manageable,
+				lastSuccessfulData.intent,
+				{
+					coordinatorEnrollmentIssueCount,
+					deviceInventory: lastDeviceInventory,
+					deviceInventoryUnavailable,
+					onReviewDevices: options.onReviewDevices,
+					received: lastSuccessfulData.inventory.received,
+					refreshError: true,
+				},
+			);
+		} else {
+			dependencies.mountSharing(sharingMount, [], EMPTY_RECIPIENT_POLICY_INTENT, {
+				deviceInventoryUnavailable,
+				loadError: true,
+			});
+		}
 		if (managementMount) {
 			dependencies.mountManagement(managementMount, [], EMPTY_RECIPIENT_POLICY_INTENT, {
 				loadError: true,

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -501,7 +501,6 @@ const emptyRecipientPolicyIntent: api.RecipientPolicyIntentGraphV1 = {
 	identityDevices: [],
 	projectRecipients: [],
 };
-let devicesLoaded = false;
 let devicesLoadRevision = 0;
 let latestDevicesLoad: Promise<boolean> | null = null;
 let lastDevicesData: {
@@ -586,7 +585,7 @@ function loadDevicesData(): Promise<boolean> {
 }
 
 async function runLoadDevicesData(mount: HTMLElement, revision: number): Promise<boolean> {
-	if (!devicesLoaded) {
+	if (!lastDevicesData) {
 		mountDevices(mount, emptyRecipientPolicyIntent, { version: 1, items: [] }, [], [], {
 			loading: true,
 		});
@@ -636,7 +635,6 @@ async function runLoadDevicesData(mount: HTMLElement, revision: number): Promise
 			inventoryUnavailable: inventoryResult.unavailable,
 			coordinatorEnrollmentIssueCount,
 		};
-		devicesLoaded = true;
 		return true;
 	} catch {
 		if (revision !== devicesLoadRevision) return latestDevicesLoad ?? false;

--- a/packages/ui/src/components/LoadingCardList.tsx
+++ b/packages/ui/src/components/LoadingCardList.tsx
@@ -1,0 +1,36 @@
+interface LoadingCardListProps {
+	detailRowCount?: number;
+	label: string;
+}
+
+export function LoadingCardList({ detailRowCount = 3, label }: LoadingCardListProps) {
+	return (
+		<>
+			<span className="sr-only" role="status">
+				{label}
+			</span>
+			<div aria-busy="true" className="loading-card-list">
+				{Array.from({ length: 2 }, (_, cardIndex) => (
+					<div aria-hidden="true" className="loading-card" key={cardIndex}>
+						<div className="loading-card-header">
+							<span
+								className={`loading-card-line loading-card-title ${cardIndex % 2 ? "w-45" : "w-60"}`}
+							/>
+							<span className="loading-card-badge" />
+						</div>
+						<div className="loading-card-details">
+							{Array.from({ length: detailRowCount }, (_, detailIndex) => (
+								<div className="loading-card-detail" key={detailIndex}>
+									<span className="loading-card-line loading-card-label" />
+									<span
+										className={`loading-card-line ${(cardIndex + detailIndex) % 2 ? "w-45" : "w-60"}`}
+									/>
+								</div>
+							))}
+						</div>
+					</div>
+				))}
+			</div>
+		</>
+	);
+}

--- a/packages/ui/src/tabs/devices.test.tsx
+++ b/packages/ui/src/tabs/devices.test.tsx
@@ -353,6 +353,17 @@ describe("read-only Devices", () => {
 		expect(state.pendingDeviceIdentityFocus).toBeUndefined();
 	});
 
+	it("retains requested device focus while a refresh is showing stale inventory", () => {
+		state.pendingDeviceIdentityFocus = "new-device";
+
+		mount(intent(), reconciliation(), {
+			inventory: inventory([]),
+			refreshError: true,
+		});
+
+		expect(state.pendingDeviceIdentityFocus).toBe("new-device");
+	});
+
 	it("projects direct access without inferring per-device Team access from membership intent", () => {
 		const graph = intent();
 		const before = JSON.stringify(graph);
@@ -592,9 +603,18 @@ describe("read-only Devices", () => {
 
 	it("renders loading, error, and active-device empty states with live-region semantics", () => {
 		mount(intent(), reconciliation(), { loading: true });
-		expect(document.querySelector('[role="status"]')?.textContent).toContain("Loading Devices");
+		const loading = [...document.querySelectorAll<HTMLElement>('[role="status"]')].find(
+			(status) => status.textContent === "Loading Devices",
+		);
+		const skeleton = document.querySelector<HTMLElement>(".loading-card-list");
+		expect(loading?.textContent).toBe("Loading Devices");
+		expect(loading?.hasAttribute("aria-busy")).toBe(false);
+		expect(skeleton?.getAttribute("aria-busy")).toBe("true");
+		expect(skeleton?.querySelectorAll(".loading-card")).toHaveLength(2);
+		expect(skeleton?.querySelector(".loading-card")?.getAttribute("aria-hidden")).toBe("true");
 
 		mount(intent(), reconciliation(), { loadError: true });
+		expect(document.querySelector(".loading-card-list")).toBeNull();
 		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
 			"Devices are unavailable",
 		);
@@ -626,8 +646,24 @@ describe("read-only Devices", () => {
 
 		expect(document.querySelector("article h3")?.textContent).toBe("Work Laptop");
 		expect(document.querySelector('[role="alert"]')?.textContent).toBe(
-			"Refresh failed; showing previous device information.",
+			"Refresh failed; showing previous device information. Identity setup is disabled until a refresh succeeds.",
 		);
+	});
+
+	it("disables Identity mutations while showing stale cards after a refresh failure", () => {
+		mount(intent(), reconciliation(), {
+			inventory: inventory([
+				inventoryItem("device-address-fingerprint-secret", "Work Laptop", "configured"),
+			]),
+			refreshError: true,
+		});
+
+		expect(document.querySelector("article h3")?.textContent).toBe("Work Laptop");
+		expect(
+			[...document.querySelectorAll<HTMLButtonElement>("button")].find(
+				(button) => button.textContent === "Change Identity…",
+			)?.disabled,
+		).toBe(true);
 	});
 
 	it("gives repeated actions unique device-specific accessible names", () => {

--- a/packages/ui/src/tabs/devices.tsx
+++ b/packages/ui/src/tabs/devices.tsx
@@ -1,5 +1,6 @@
 import { render } from "preact";
 import { useEffect, useMemo, useRef, useState } from "preact/hooks";
+import { LoadingCardList } from "../components/LoadingCardList";
 import type {
 	RecipientPolicyIntentGraphV1,
 	RecipientPolicyReconciliationReadState,
@@ -51,6 +52,10 @@ export interface DevicesRendererOptions {
 	previewBindings?: typeof previewDeviceIdentityBindings;
 	commitBindings?: typeof commitDeviceIdentityBindings;
 	coordinatorEnrollmentIssueCount?: number;
+}
+
+function identityMutationsBlocked(options: DevicesRendererOptions): boolean {
+	return options.inventoryUnavailable === true || options.refreshError === true;
 }
 
 export interface DeviceProjectProjection {
@@ -408,7 +413,7 @@ function SetupWorkflow({
 	const reviewRevision = useRef(0);
 	const previewApi = options.previewBindings ?? previewDeviceIdentityBindings;
 	const commitApi = options.commitBindings ?? commitDeviceIdentityBindings;
-	const inventoryUnavailable = options.inventoryUnavailable === true;
+	const mutationsBlocked = identityMutationsBlocked(options);
 	const previewReady =
 		reviewed !== null && previewMatchesBindings(reviewed.preview, reviewed.request, items, "bind");
 	const selectedItems = useMemo(
@@ -493,8 +498,8 @@ function SetupWorkflow({
 	});
 
 	const review = async (selected: DeviceIdentityInventoryItemV1[]) => {
-		if (inventoryUnavailable) {
-			setErrorMessage("Refresh device ownership information before reviewing Identity setup.");
+		if (mutationsBlocked) {
+			setErrorMessage("Refresh Devices before reviewing Identity setup.");
 			return;
 		}
 		if (selected.some((item) => item.state !== "setup_required")) {
@@ -536,7 +541,7 @@ function SetupWorkflow({
 	};
 
 	const commit = async () => {
-		if (!reviewed || !reviewConfirmed || inventoryUnavailable || !previewReady) return;
+		if (!reviewed || !reviewConfirmed || mutationsBlocked || !previewReady) return;
 		setBusy(true);
 		setErrorMessage("");
 		try {
@@ -572,7 +577,7 @@ function SetupWorkflow({
 					<strong>{setupRequired.length.toLocaleString()} devices need Identity setup</strong>
 					<button
 						className="settings-button"
-						disabled={busy || inventoryUnavailable || selectedItems.length === 0}
+						disabled={busy || mutationsBlocked || selectedItems.length === 0}
 						onClick={() => void review(selectedItems)}
 						type="button"
 					>
@@ -584,7 +589,7 @@ function SetupWorkflow({
 				{items.map((item, index) => {
 					const choice = choices[item.deviceId];
 					const gate = deviceIdentitySetupGate(inventory, item);
-					const setupBlocked = gate.blocked || inventoryUnavailable;
+					const setupBlocked = gate.blocked || mutationsBlocked;
 					const titleId = `device-inventory-title-${index}`;
 					return (
 						<li key={item.deviceId}>
@@ -748,7 +753,7 @@ function SetupWorkflow({
 					<label>
 						<input
 							checked={reviewConfirmed}
-							disabled={inventoryUnavailable}
+							disabled={mutationsBlocked}
 							onInput={(event) => setReviewConfirmed(event.currentTarget.checked)}
 							type="checkbox"
 						/>{" "}
@@ -768,7 +773,7 @@ function SetupWorkflow({
 						</button>
 						<button
 							className="settings-button sync-dialog-confirm"
-							disabled={busy || inventoryUnavailable || !reviewConfirmed || !previewReady}
+							disabled={busy || mutationsBlocked || !reviewConfirmed || !previewReady}
 							onClick={() => void commit()}
 							type="button"
 						>
@@ -824,7 +829,7 @@ function ConfiguredRebind({
 		reviewed !== null &&
 		previewMatchesBindings(reviewed.preview, reviewed.request, [item], "rebind");
 	const gate = deviceIdentitySetupGate(inventory, item);
-	const rebindBlocked = gate.blocked || options.inventoryUnavailable === true;
+	const rebindBlocked = gate.blocked || identityMutationsBlocked(options);
 	const triggerId = `configured-rebind-trigger-${item.deviceId}`;
 	const targetIdentity =
 		identities.find((identity) => identity.identityId === targetIdentityId)?.displayName ?? "";
@@ -1043,11 +1048,7 @@ function DevicesView({
 	projection: DevicesProjection;
 }) {
 	if (options.loading) {
-		return (
-			<p aria-live="polite" className="small" role="status">
-				Loading Devices…
-			</p>
-		);
+		return <LoadingCardList label="Loading Devices" />;
 	}
 	if (options.loadError) {
 		return (
@@ -1058,7 +1059,8 @@ function DevicesView({
 	}
 	const refreshError = options.refreshError ? (
 		<p aria-live="assertive" role="alert">
-			Refresh failed; showing previous device information.
+			Refresh failed; showing previous device information. Identity setup is disabled until a
+			refresh succeeds.
 		</p>
 	) : null;
 	const visibleProjectedDevices = projection.devices.filter(
@@ -1206,7 +1208,7 @@ function DevicesView({
 								<div className="peer-title recipient-policy-sharing-card-title">
 									<h3 id={titleId}>{device.displayName}</h3>
 									<span className="badge actor-badge">
-										{options.inventoryUnavailable ? "Device" : "Configured"} ·{" "}
+										{identityMutationsBlocked(options) ? "Device" : "Configured"} ·{" "}
 										{device.availabilityLabel}
 									</span>
 								</div>
@@ -1359,7 +1361,7 @@ export function mountDevices(
 			state.pendingDeviceIdentityFocus = undefined;
 			target.focus();
 			return;
-		} else if (!options.inventoryUnavailable) {
+		} else if (!options.inventoryUnavailable && !options.refreshError) {
 			state.pendingDeviceIdentityFocus = undefined;
 			(
 				document.getElementById("devices-heading") ?? document.getElementById("tabBtn-devices")

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -207,12 +207,37 @@ describe("recipient-focused Sharing", () => {
 	});
 
 	it("discloses when device setup attention cannot be loaded", () => {
-		mount(intent(), { deviceInventoryUnavailable: true });
+		mount(intent(), {
+			deviceInventory: {
+				version: 1,
+				items: [
+					{
+						version: 1,
+						deviceId: "stale-device",
+						evidenceDeviceIds: ["stale-device"],
+						displayName: "Stale Device",
+						state: "setup_required",
+						identityId: null,
+						suggestedIdentityId: null,
+						validatedFingerprint: null,
+						isLocal: false,
+						sources: ["sync_peer"],
+						conflictCodes: [],
+					},
+				],
+				coordinatorEvidence: { availability: "available", safeErrorCode: null },
+				truncated: false,
+			},
+			deviceInventoryUnavailable: true,
+		});
 
 		expect(document.querySelector('[role="status"]')?.textContent).toContain(
 			"Device Identity information is unavailable",
 		);
 		expect(document.body.textContent).toContain("Manage projects");
+		expect(document.getElementById("sharing-device-setup-heading")).toBeNull();
+		expect(document.body.textContent).not.toContain("Identity setup needed");
+		expect(document.body.textContent).not.toContain("Review Devices");
 	});
 
 	it("counts only the same nonconfigured inventory states that Devices sends to setup", () => {
@@ -401,14 +426,25 @@ describe("recipient-focused Sharing", () => {
 
 	it("renders loading, error, and empty states with live-region semantics", () => {
 		mount(intent(), { loading: true });
-		expect(document.querySelector('[role="status"]')?.textContent).toContain(
-			"Loading Sharing details",
-		);
+		const loading = visiblePanel().querySelector<HTMLElement>('[role="status"]');
+		const skeleton = visiblePanel().querySelector<HTMLElement>(".loading-card-list");
+		expect(loading?.textContent).toBe("Loading Sharing details");
+		expect(loading?.hasAttribute("aria-busy")).toBe(false);
+		expect(
+			[...document.querySelectorAll('[role="status"]')].filter(
+				(status) => status.textContent === "Loading Sharing details",
+			),
+		).toHaveLength(1);
+		expect(skeleton?.getAttribute("aria-busy")).toBe("true");
+		expect(skeleton?.querySelectorAll(".loading-card")).toHaveLength(2);
+		expect(skeleton?.querySelector(".loading-card")?.getAttribute("aria-hidden")).toBe("true");
 
 		mount(intent(), { loadError: true });
-		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
-			"Sharing details are unavailable",
-		);
+		expect(document.querySelector(".loading-card-list")).toBeNull();
+		const alerts = document.querySelectorAll<HTMLElement>('[role="alert"]');
+		expect(alerts).toHaveLength(1);
+		expect(alerts[0]?.textContent).toContain("Sharing details are unavailable");
+		expect(visiblePanel().contains(alerts[0] ?? null)).toBe(true);
 
 		mount(
 			intent({
@@ -423,6 +459,23 @@ describe("recipient-focused Sharing", () => {
 		expect(visiblePanel().textContent).toContain("No active Identities are available");
 		clickTab("Teams");
 		expect(visiblePanel().textContent).toContain("No active Teams are available");
+	});
+
+	it("keeps loaded Sharing cards visible during a failed background refresh", () => {
+		mount(intent(), { refreshError: true });
+
+		expect(document.querySelector('[role="alert"]')?.textContent).toBe(
+			"Refresh failed; showing previous Sharing details. Team and Identity Project changes are disabled until a refresh succeeds.",
+		);
+		expect(visiblePanel().textContent).toContain("ExampleCo");
+		expect(document.querySelector(".loading-card-list")).toBeNull();
+		const mutationButtons = visiblePanel().querySelectorAll<HTMLButtonElement>(
+			".recipient-policy-sharing-actions button",
+		);
+		expect(mutationButtons).toHaveLength(2);
+		for (const button of mutationButtons) {
+			expect(button.disabled).toBe(true);
+		}
 	});
 
 	it("surfaces device setup attention without implying access and links to Devices", () => {

--- a/packages/ui/src/tabs/recipient-policy-sharing.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.tsx
@@ -1,5 +1,6 @@
 import { render } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
+import { LoadingCardList } from "../components/LoadingCardList";
 import type { DeviceIdentityInventoryV1, RecipientPolicyIntentGraphV1 } from "../lib/api/sync";
 import { deviceIdentityAttentionItems } from "../lib/device-identity-inventory";
 import { RecipientPolicyInvitations } from "./recipient-policy-invitations";
@@ -12,6 +13,7 @@ import type { ReceivedProjectShare } from "./recipient-policy-projects";
 export interface RecipientPolicySharingOptions {
 	loading?: boolean;
 	loadError?: boolean;
+	refreshError?: boolean;
 	deviceInventoryUnavailable?: boolean;
 	received?: ReceivedProjectShare[];
 	deviceInventory?: DeviceIdentityInventoryV1;
@@ -48,10 +50,12 @@ function activeProjectNames(
 
 function RecipientActions({
 	descriptionId,
+	disabled,
 	displayName,
 	recipient,
 }: {
 	descriptionId: string;
+	disabled: boolean;
 	displayName: string;
 	recipient:
 		| { recipientKind: "team"; teamId: string }
@@ -70,6 +74,7 @@ function RecipientActions({
 					aria-describedby={descriptionId}
 					aria-label={`Add Projects for ${displayName}`}
 					className="settings-button recipient-policy-sharing-target recipient-policy-sharing-target-24"
+					disabled={disabled}
 					onClick={openAdd}
 					type="button"
 				>
@@ -78,6 +83,7 @@ function RecipientActions({
 				<button
 					aria-label={`Manage Projects for ${displayName}`}
 					className="settings-button recipient-policy-sharing-target recipient-policy-sharing-target-24"
+					disabled={disabled}
 					onClick={openManagement}
 					type="button"
 				>
@@ -85,16 +91,20 @@ function RecipientActions({
 				</button>
 			</div>
 			<p className="small" id={descriptionId}>
-				Add projects only adds the selected Projects after you preview the exact changes.
+				{disabled
+					? "Team and Identity Project changes are disabled until a refresh succeeds."
+					: "Add projects only adds the selected Projects after you preview the exact changes."}
 			</p>
 		</>
 	);
 }
 
 function TeamsView({
+	disableMutations,
 	intent,
 	projects,
 }: {
+	disableMutations: boolean;
 	intent: RecipientPolicyIntentGraphV1;
 	projects: RecipientPolicyManagementProject[];
 }) {
@@ -188,6 +198,7 @@ function TeamsView({
 						</dl>
 						<RecipientActions
 							descriptionId={addDescriptionId}
+							disabled={disableMutations}
 							displayName={team.displayName}
 							recipient={{ recipientKind: "team", teamId: team.teamId }}
 						/>
@@ -199,9 +210,11 @@ function TeamsView({
 }
 
 function IdentitiesView({
+	disableMutations,
 	intent,
 	projects,
 }: {
+	disableMutations: boolean;
 	intent: RecipientPolicyIntentGraphV1;
 	projects: RecipientPolicyManagementProject[];
 }) {
@@ -299,6 +312,7 @@ function IdentitiesView({
 						</p>
 						<RecipientActions
 							descriptionId={addDescriptionId}
+							disabled={disableMutations}
 							displayName={identity.displayName}
 							recipient={{ recipientKind: "identity", identityId: identity.identityId }}
 						/>
@@ -417,7 +431,7 @@ function RecipientPolicySharing({
 					shown until a refresh succeeds.
 				</p>
 			) : null}
-			{setupAttentionCount > 0 ? (
+			{setupAttentionCount > 0 && !options.deviceInventoryUnavailable ? (
 				<aside
 					aria-labelledby="sharing-device-setup-heading"
 					className="peer-card peer-card--padded recipient-policy-sharing-attention"
@@ -471,6 +485,12 @@ function RecipientPolicySharing({
 					) : null}
 				</aside>
 			) : null}
+			{options.refreshError ? (
+				<p aria-live="assertive" role="alert">
+					Refresh failed; showing previous Sharing details. Team and Identity Project changes are
+					disabled until a refresh succeeds.
+				</p>
+			) : null}
 			<div
 				aria-label="Sharing views"
 				className="recipient-policy-sharing-tabs recipient-policy-sharing-responsive-tabs"
@@ -506,17 +526,27 @@ function RecipientPolicySharing({
 					role="tabpanel"
 				>
 					{options.loading ? (
-						<p aria-live="polite" className="small" role="status">
-							Loading Sharing details…
-						</p>
+						activeTab === tab.id ? (
+							<LoadingCardList detailRowCount={4} label="Loading Sharing details" />
+						) : null
 					) : options.loadError ? (
-						<p aria-live="assertive" role="alert">
-							Sharing details are unavailable. Refresh and try again.
-						</p>
+						activeTab === tab.id ? (
+							<p aria-live="assertive" role="alert">
+								Sharing details are unavailable. Refresh and try again.
+							</p>
+						) : null
 					) : tab.id === "teams" ? (
-						<TeamsView intent={intent} projects={projects} />
+						<TeamsView
+							disableMutations={options.refreshError === true}
+							intent={intent}
+							projects={projects}
+						/>
 					) : tab.id === "identities" ? (
-						<IdentitiesView intent={intent} projects={projects} />
+						<IdentitiesView
+							disableMutations={options.refreshError === true}
+							intent={intent}
+							projects={projects}
+						/>
 					) : tab.id === "received" ? (
 						<ReceivedView received={options.received ?? []} />
 					) : (

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1263,6 +1263,35 @@
       }
       .recipient-policy-sharing-details dt { color: var(--text-secondary); }
       .recipient-policy-sharing-details dd { margin: 0; color: var(--text-primary); }
+
+      .loading-card-list { display: grid; gap: var(--sp-3); }
+      .loading-card {
+        padding: var(--sp-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-1);
+      }
+      .loading-card-header,
+      .loading-card-detail {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--sp-3);
+      }
+      .loading-card-details { display: grid; gap: var(--sp-3); margin-top: var(--sp-4); }
+      .loading-card-line,
+      .loading-card-badge {
+        display: block;
+        background: linear-gradient(90deg, var(--border) 25%, var(--surface-2) 50%, var(--border) 75%);
+        background-size: 400px 100%;
+        animation: sync-shimmer var(--duration-shimmer) var(--ease-in-out) infinite;
+      }
+      .loading-card-line { height: 12px; border-radius: var(--radius-pill); }
+      .loading-card-title { height: 16px; }
+      .loading-card-badge { width: 72px; height: 20px; border-radius: var(--radius-pill); }
+      .loading-card-label { width: 28%; }
+      .loading-card .w-45 { width: 45%; }
+      .loading-card .w-60 { width: 60%; }
       .recipient-policy-invitation-result {
         display: flex;
         align-items: flex-start;


### PR DESCRIPTION
## Description

- add shared card-shaped skeletons for the initial Sharing and Devices loads
- preserve the last successful cards when a background refresh fails
- disable stale Team, Identity, and device mutation controls until current data is available
- keep loading and refresh-error states accessible and reduced-motion friendly

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional validation:

- `pnpm --filter @codemem/ui build`
- 88 focused Sharing and Devices tests
- independent correctness, accessibility, security, and complexity review

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
