### PR TITLE
fix(codex): use viewer recall in plugin-free hooks

### DIFF
--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -150,8 +150,11 @@ hook failure does not block a session.
 printf '%s\n' '{"hook_event_name":"UserPromptSubmit","session_id":"codex-1","prompt":"what did we change","cwd":"/tmp/demo"}' | codemem codex-hook-inject
 ```
 
-`codemem codex-hook-inject` is retained for compatibility and plugin-free setup; it is not the packaged
-hook's healthy prompt path.
+`codemem codex-hook-inject` is retained for compatibility and plugin-free setup. It now uses the same
+profile-validated, identity-gated Viewer HTTP retrieval before falling back to its local database pack.
+Like the packaged hook, it rejects non-loopback prompt retrieval and fails closed on policy,
+authorization, and compatible-profile contract errors; local packing is limited to classified
+compatibility failures. The packaged hook remains the zero-child healthy path.
 
 For Codex hooks, project resolution precedence matches the Claude hook path:
 
@@ -189,7 +192,7 @@ npx -y codemem setup --codex-only   # or, with a global install: codemem setup -
 What it does (idempotent; honors `CODEX_HOME`; backs up existing files; `--force` to refresh):
 
 - **MCP:** appends `[mcp_servers.codemem]` (`command = "npx"`, `args = ["-y", "codemem", "mcp"]`) to `<CODEX_HOME>/config.toml` if not already present. The file is never reparsed or reformatted — only appended — so comments and unrelated servers (including secrets) are preserved.
-- **Hooks:** merges `SessionStart`, `UserPromptSubmit` (ingest + inject), `PostToolUse`, and `Stop` into `<CODEX_HOME>/hooks.json`, preserving any unrelated user hooks. Hook commands resolve to a direct `codemem codex-hook-*` call when `codemem` is on `PATH`, otherwise `npx -y codemem codex-hook-*`.
+- **Hooks:** merges `SessionStart`, `UserPromptSubmit` (ingest + inject), `PostToolUse`, and `Stop` into `<CODEX_HOME>/hooks.json`, preserving any unrelated user hooks. Hook commands resolve to a direct `codemem codex-hook-*` call when `codemem` is on `PATH`, otherwise `npx -y codemem codex-hook-*`. Prompt injection validates the loopback Viewer profile and retrieves with `POST /api/pack` first, using the local database only for classified compatibility fallback.
 
 Hooks loaded from the user config layer require a one-time trust approval in Codex (you'll be prompted on first run; MCP recall needs no trust). Codex setup also runs automatically in a plain `codemem setup` when a Codex home (`~/.codex` or `$CODEX_HOME`) is detected.
 
@@ -396,7 +399,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_RUNNER` | Override auto-detected runner: `codemem` (global), `npx`, `node` (repo/dev), or custom binary name. |
 | `CODEMEM_RUNNER_FROM` | Runner source override: npm package spec for `npx` (for example `codemem@0.20.0-alpha.7`), or repo/CLI entry path for `node`. |
 | `CODEMEM_VIEWER` | Set to `0`, `false`, or `off` to disable the viewer entirely. |
-| `CODEMEM_VIEWER_HOST`, `CODEMEM_VIEWER_PORT` | Explicit host/port the plugin-managed viewer should start, probe, stop, and restart. |
+| `CODEMEM_VIEWER_HOST`, `CODEMEM_VIEWER_PORT` | Explicit host/port the plugin-managed viewer should start, probe, stop, and restart. Prompt retrieval accepts loopback hosts only. |
 | `CODEMEM_VIEWER_AUTO` | Set to `0`/`false`/`off` to disable auto-start (default on). |
 | `CODEMEM_VIEWER_AUTO_STOP` | Set to `0`/`false`/`off` to keep the viewer running after OpenCode exits (default on). |
 | `CODEMEM_PLUGIN_LOG` | Path for the plugin log file (set `1`/`true`/`yes` for `~/.codemem/plugin.log`; Claude hook failures are logged to this path by default). |
@@ -408,7 +411,8 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_CODEX_HOOK_LOCK_TTL_S` | Seconds before a Codex hook fallback lock is treated as stale (default `120`). |
 | `CODEMEM_CODEX_HOOK_SPOOL_DIR` | Legacy native Codex hook fallback spool directory (default `~/.codemem/codex-hook-spool`); the normalized wrapper does not read or drain it. |
 | `CODEMEM_CODEX_RAW_EVENT_SPOOL_DIR` | Normalized Codex raw-event envelope spool directory (default `~/.codemem/codex-raw-event-spool`). |
-| `CODEMEM_INJECT_HTTP_MAX_TIME_S` | Viewer request timeout for OpenCode and Claude prompt retrieval, and the per-request cap for Codex (default `2` seconds). Claude and Codex ledger completion has a separate fixed 500 ms cap; packaged Codex also enforces a total 4.5-second output budget. |
+| `CODEMEM_CODEX_LOCAL_PACK_ONLY` | Internal coordination flag set by the packaged Codex wrapper when it invokes the CLI compatibility fallback; skips duplicate Viewer retrieval. Not intended for manual use. |
+| `CODEMEM_INJECT_HTTP_MAX_TIME_S` | Viewer request timeout for OpenCode and Claude prompt retrieval, the per-request cap for packaged Codex, and the total profile-plus-pack HTTP budget for plugin-free Codex (default and maximum `2` seconds for plugin-free Codex). Claude and Codex ledger completion has a separate fixed 500 ms cap; packaged Codex also enforces a total 4.5-second output budget. |
 | `CODEMEM_INJECT_MAX_CHARS` | Max chars returned as Claude/Codex `additionalContext` (default `16000`). |
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
 | `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |

--- a/packages/cli/src/commands/codex-hook-inject.test.ts
+++ b/packages/cli/src/commands/codex-hook-inject.test.ts
@@ -1,11 +1,13 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { buildViewerIdentityTarget } from "@codemem/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	buildCodexHookInjection,
 	type CodexPackResult,
 	codexHookInjectCommand,
+	runCodexHookInjection,
 } from "./codex-hook-inject.js";
 
 const pack = (packText: string, items = 0, packTokens = 0): CodexPackResult => ({
@@ -24,26 +26,386 @@ ${packText}`;
 describe("codex-hook-inject command", () => {
 	let tempDir: string;
 	let pluginLogPath: string;
+	let originalLocalPackOnly: string | undefined;
 	let originalPluginLogPath: string | undefined;
 
 	beforeEach(() => {
+		originalLocalPackOnly = process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
 		originalPluginLogPath = process.env.CODEMEM_PLUGIN_LOG_PATH;
 		tempDir = mkdtempSync(join(tmpdir(), "codemem-cli-codex-inject-"));
 		pluginLogPath = join(tempDir, "plugin.log");
 		process.env.CODEMEM_PLUGIN_LOG_PATH = pluginLogPath;
+		process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY = "1";
 	});
 
 	afterEach(() => {
+		if (originalLocalPackOnly === undefined) delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
+		else process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY = originalLocalPackOnly;
 		if (originalPluginLogPath === undefined) delete process.env.CODEMEM_PLUGIN_LOG_PATH;
 		else process.env.CODEMEM_PLUGIN_LOG_PATH = originalPluginLogPath;
 		for (const key of [
+			"CODEMEM_DB",
 			"CODEMEM_INJECT_CONTEXT",
+			"CODEMEM_INJECT_HTTP_MAX_TIME_S",
 			"CODEMEM_INJECT_MAX_CHARS",
 			"CODEMEM_PLUGIN_IGNORE",
+			"CODEMEM_PROJECT",
+			"CODEMEM_VIEWER_HOST",
+			"CODEMEM_VIEWER_PORT",
 		]) {
 			delete process.env[key];
 		}
 		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("uses a compatible Viewer pack before the local database", async () => {
+		delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
+		process.env.CODEMEM_DB = join(tempDir, "mem.sqlite");
+		process.env.CODEMEM_PROJECT = "codemem";
+		process.env.CODEMEM_VIEWER_HOST = "127.0.0.1";
+		process.env.CODEMEM_VIEWER_PORT = "38888";
+		const requests: Array<{ path: string; body: Record<string, unknown> | null }> = [];
+		const identity = buildViewerIdentityTarget();
+
+		const result = await buildCodexHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "codex-session",
+				prompt: "fix auth callback",
+				cwd: tempDir,
+				project: "codemem",
+			},
+			{},
+			{
+				fetchImpl: async (input, init) => {
+					const path = new URL(String(input)).pathname;
+					const body = init?.body
+						? (JSON.parse(String(init.body)) as Record<string, unknown>)
+						: null;
+					requests.push({ path, body });
+					if (path.endsWith("profile")) {
+						return new Response(
+							JSON.stringify({
+								service: "codemem-viewer",
+								protocol_version: 1,
+								min_supported_protocol_version: 1,
+								db_path: process.env.CODEMEM_DB,
+								identity_target: identity,
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					return new Response(
+						JSON.stringify({
+							pack_text: "## Summary\n[1] (decision) Viewer transport",
+							metrics: { total_items: 1, pack_tokens: 17 },
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				},
+				buildLocalPack: async () => {
+					throw new Error("local fallback should not run");
+				},
+				resolveDb: () => process.env.CODEMEM_DB as string,
+				now: () => new Date("2026-08-21T00:00:00.000Z"),
+				uuid: (() => {
+					const values = ["attempt-id", "request-id"];
+					return () => values.shift() ?? "unexpected-id";
+				})(),
+			},
+		);
+
+		expect(requests.map(({ path }) => path)).toEqual(["/api/prompt-pack-profile", "/api/pack"]);
+		expect(requests[1]?.body).toMatchObject({
+			context: "fix auth callback codemem",
+			project: "codemem",
+			db_path: process.env.CODEMEM_DB,
+			identity_target: identity,
+			attempt: {
+				attempt_id: "attempt-id",
+				started_at: "2026-08-21T00:00:00.000Z",
+				source: "codex",
+				stream_id: "codex-session",
+				source_session_id: "codex-session",
+				request_id: "request-id",
+			},
+		});
+		expect(result.hookSpecificOutput?.additionalContext).toContain("Viewer transport");
+	});
+
+	it("shares one bounded HTTP budget across profile and pack requests", async () => {
+		delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
+		process.env.CODEMEM_DB = join(tempDir, "mem.sqlite");
+		const identity = buildViewerIdentityTarget();
+		const timeouts: number[] = [];
+		let elapsedMs = 0;
+
+		await buildCodexHookInjection(
+			{ hook_event_name: "UserPromptSubmit", prompt: "bounded transport" },
+			{},
+			{
+				createTimeoutSignal: (milliseconds) => {
+					timeouts.push(milliseconds);
+					return new AbortController().signal;
+				},
+				fetchImpl: async (input) => {
+					const path = new URL(String(input)).pathname;
+					if (path.endsWith("profile")) {
+						elapsedMs = 1500;
+						return new Response(
+							JSON.stringify({
+								service: "codemem-viewer",
+								protocol_version: 1,
+								min_supported_protocol_version: 1,
+								db_path: process.env.CODEMEM_DB,
+								identity_target: identity,
+							}),
+							{ status: 200 },
+						);
+					}
+					return new Response(JSON.stringify({ pack_text: "PACK", metrics: { total_items: 1 } }), {
+						status: 200,
+					});
+				},
+				monotonicNow: () => elapsedMs,
+				resolveDb: () => process.env.CODEMEM_DB as string,
+			},
+		);
+
+		expect(timeouts).toEqual([2000, 500]);
+	});
+
+	it("falls back to the local database when the Viewer profile is unavailable", async () => {
+		delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
+		let localCalls = 0;
+		const result = await buildCodexHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "codex-session",
+				prompt: "fix auth callback",
+				project: "codemem",
+			},
+			{},
+			{
+				fetchImpl: async () => new Response(null, { status: 404 }),
+				buildLocalPack: async () => {
+					localCalls += 1;
+					return pack("## Summary\n[2] (decision) Local fallback", 1, 12);
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(localCalls).toBe(1);
+		expect(result.hookSpecificOutput?.additionalContext).toContain("Local fallback");
+	});
+
+	it("emits Viewer context before recording delivery", async () => {
+		delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
+		process.env.CODEMEM_DB = join(tempDir, "mem.sqlite");
+		process.env.CODEMEM_PROJECT = "codemem";
+		const identity = buildViewerIdentityTarget();
+		const output: Array<Record<string, unknown>> = [];
+		const events: string[] = [];
+		const requestPaths: string[] = [];
+
+		await runCodexHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "codex-session",
+				prompt: "ship recall",
+				project: "codemem",
+			},
+			{},
+			{
+				fetchImpl: async (input) => {
+					const path = new URL(String(input)).pathname;
+					requestPaths.push(path);
+					if (path.endsWith("profile")) {
+						return new Response(
+							JSON.stringify({
+								service: "codemem-viewer",
+								protocol_version: 1,
+								min_supported_protocol_version: 1,
+								db_path: process.env.CODEMEM_DB,
+								identity_target: identity,
+							}),
+							{ status: 200 },
+						);
+					}
+					if (path.endsWith("pack")) {
+						return new Response(
+							JSON.stringify({
+								pack_text: "VIEWER_PACK",
+								metrics: { total_items: 1, pack_tokens: 9 },
+							}),
+							{ status: 200 },
+						);
+					}
+					events.push("ledger");
+					return new Response(JSON.stringify({ ok: true }), { status: 200 });
+				},
+				resolveDb: () => process.env.CODEMEM_DB as string,
+				writeOutput: (value) => {
+					events.push("output");
+					output.push(value as unknown as Record<string, unknown>);
+				},
+			},
+		);
+
+		expect(requestPaths).toEqual([
+			"/api/prompt-pack-profile",
+			"/api/pack",
+			"/api/prompt-pack-ledger",
+		]);
+		expect(JSON.stringify(output[0])).toContain("VIEWER_PACK");
+		expect(events).toEqual(["output", "ledger"]);
+	});
+
+	it("fails closed for a contract error after a compatible Viewer profile", async () => {
+		delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
+		process.env.CODEMEM_DB = join(tempDir, "mem.sqlite");
+		const identity = buildViewerIdentityTarget();
+		let localCalls = 0;
+
+		const result = await buildCodexHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "codex-session",
+				prompt: "ship recall",
+			},
+			{},
+			{
+				fetchImpl: async (input) => {
+					const path = new URL(String(input)).pathname;
+					if (path.endsWith("profile")) {
+						return new Response(
+							JSON.stringify({
+								service: "codemem-viewer",
+								protocol_version: 1,
+								min_supported_protocol_version: 1,
+								db_path: process.env.CODEMEM_DB,
+								identity_target: identity,
+							}),
+							{ status: 200 },
+						);
+					}
+					return new Response(JSON.stringify({ error: { code: "viewer_contract_unsupported" } }), {
+						status: 409,
+					});
+				},
+				buildLocalPack: async () => {
+					localCalls += 1;
+					return pack("must not be used");
+				},
+				resolveDb: () => process.env.CODEMEM_DB as string,
+			},
+		);
+
+		expect(localCalls).toBe(0);
+		expect(result).toEqual({ continue: true });
+	});
+
+	it.each([
+		["authorization", 403, { error: { code: "forbidden" } }, false],
+		["policy", 409, { error: { code: "policy_denied" } }, false],
+		["invalid request", 400, { error: { code: "invalid_request" } }, false],
+		["database mismatch", 409, { error: { code: "viewer_db_mismatch" } }, true],
+		["malformed success", 200, { pack_text: "missing metrics" }, true],
+	] as const)("classifies a post-profile %s response", async (_label, status, body, fallsBack) => {
+		delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
+		process.env.CODEMEM_DB = join(tempDir, "mem.sqlite");
+		const identity = buildViewerIdentityTarget();
+		let localCalls = 0;
+
+		await buildCodexHookInjection(
+			{ hook_event_name: "UserPromptSubmit", prompt: "classify transport" },
+			{},
+			{
+				fetchImpl: async (input) => {
+					const path = new URL(String(input)).pathname;
+					return path.endsWith("profile")
+						? new Response(
+								JSON.stringify({
+									service: "codemem-viewer",
+									protocol_version: 1,
+									min_supported_protocol_version: 1,
+									db_path: process.env.CODEMEM_DB,
+									identity_target: identity,
+								}),
+								{ status: 200 },
+							)
+						: new Response(JSON.stringify(body), { status });
+				},
+				buildLocalPack: async () => {
+					localCalls += 1;
+					return pack("LOCAL_PACK");
+				},
+				resolveDb: () => process.env.CODEMEM_DB as string,
+			},
+		);
+
+		expect(localCalls).toBe(fallsBack ? 1 : 0);
+	});
+
+	it.each([
+		"db_path",
+		"identity_target",
+	] as const)("uses local fallback when the Viewer profile has a mismatched %s", async (field) => {
+		delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
+		process.env.CODEMEM_DB = join(tempDir, "mem.sqlite");
+		const identity = buildViewerIdentityTarget();
+		let localCalls = 0;
+
+		await buildCodexHookInjection(
+			{ hook_event_name: "UserPromptSubmit", prompt: "profile mismatch" },
+			{},
+			{
+				fetchImpl: async () =>
+					new Response(
+						JSON.stringify({
+							service: "codemem-viewer",
+							protocol_version: 1,
+							min_supported_protocol_version: 1,
+							db_path: field === "db_path" ? "/other.sqlite" : process.env.CODEMEM_DB,
+							identity_target:
+								field === "identity_target" ? { ...identity, workspace_id: "other" } : identity,
+						}),
+						{ status: 200 },
+					),
+				buildLocalPack: async () => {
+					localCalls += 1;
+					return pack("LOCAL_PACK");
+				},
+				resolveDb: () => process.env.CODEMEM_DB as string,
+			},
+		);
+
+		expect(localCalls).toBe(1);
+	});
+
+	it("rejects non-loopback Viewer hosts without touching the network or local database", async () => {
+		delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
+		process.env.CODEMEM_VIEWER_HOST = "viewer.example.com";
+		let calls = 0;
+		const result = await buildCodexHookInjection(
+			{ hook_event_name: "UserPromptSubmit", prompt: "reject remote viewer" },
+			{},
+			{
+				fetchImpl: async () => {
+					calls += 1;
+					throw new Error("must not fetch");
+				},
+				buildLocalPack: async () => {
+					calls += 1;
+					return pack("must not build");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(calls).toBe(0);
+		expect(result).toEqual({ continue: true });
 	});
 
 	it("registers expected options and help text", () => {

--- a/packages/cli/src/commands/codex-hook-inject.ts
+++ b/packages/cli/src/commands/codex-hook-inject.ts
@@ -1,4 +1,16 @@
-import { MemoryStore, resolveDbPath, resolveHookProject } from "@codemem/core";
+import { randomUUID } from "node:crypto";
+import { isAbsolute, resolve } from "node:path";
+import {
+	arePromptTransportProtocolRangesCompatible,
+	buildViewerIdentityTarget,
+	classifyPromptTransportFailure,
+	MemoryStore,
+	normalizePromptTransportProtocolRange,
+	PROMPT_TRANSPORT_PROTOCOL_RANGE,
+	type PromptTransportDisposition,
+	resolveDbPath,
+	resolveHookProject,
+} from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
@@ -21,12 +33,38 @@ export type CodexPackResult = {
 
 type InjectDeps = {
 	buildLocalPack?: typeof buildLocalPack;
+	createTimeoutSignal?: (milliseconds: number) => AbortSignal;
+	fetchImpl?: typeof fetch;
+	monotonicNow?: () => number;
+	now?: () => Date;
 	resolveDb?: typeof resolveDbPath;
+	uuid?: () => string;
+	writeOutput?: (value: InjectResult) => void;
+};
+
+type ViewerPackResult =
+	| {
+			ok: true;
+			pack: CodexPackResult;
+			delivery: {
+				attemptId: string;
+				baseUrl: string;
+				dbPath: string;
+				deliveryStatus: "handed_off" | "unknown";
+				identity: ReturnType<typeof buildViewerIdentityTarget>;
+			};
+	  }
+	| { ok: false; disposition: PromptTransportDisposition };
+
+type InjectionOutcome = {
+	result: InjectResult;
+	delivery?: Extract<ViewerPackResult, { ok: true }>["delivery"];
 };
 
 const HOOK_EVENT_NAME = "UserPromptSubmit" as const;
 const EMPTY_PACK: CodexPackResult = { packText: "", items: 0, packTokens: 0 };
 const DEFAULT_MAX_CHARS = 16000;
+const DEFAULT_VIEWER_PORT = 38888;
 // Codex records UserPromptSubmit additionalContext as an unmarked developer
 // message. Frame the pack explicitly so the model treats memory text as
 // reference data, not ambient instructions or a generic markdown fragment.
@@ -61,6 +99,275 @@ function envTruthy(value: string | undefined): boolean {
 function parsePositiveInt(value: string | undefined, fallback: number): number {
 	const parsed = Number.parseInt(String(value ?? ""), 10);
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonicalJson(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+	if (isRecord(value)) {
+		return `{${Object.keys(value)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+			.join(",")}}`;
+	}
+	return JSON.stringify(value);
+}
+
+function viewerBaseUrl(env: NodeJS.ProcessEnv): string | null {
+	const configuredHost = env.CODEMEM_VIEWER_HOST?.trim() || "127.0.0.1";
+	const host = configuredHost.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+	const ipv4 = host.split(".");
+	const isIpv4Loopback =
+		ipv4.length === 4 &&
+		ipv4[0] === "127" &&
+		ipv4.every(
+			(part) => /^\d+$/.test(part) && String(Number(part)) === part && Number(part) <= 255,
+		);
+	const urlHost =
+		host === "localhost" || isIpv4Loopback
+			? host
+			: host === "::1" || host === "0:0:0:0:0:0:0:1"
+				? "[::1]"
+				: null;
+	if (!urlHost) return null;
+
+	const portText = env.CODEMEM_VIEWER_PORT?.trim() || String(DEFAULT_VIEWER_PORT);
+	const port = Number(portText);
+	const safePort =
+		/^\d+$/.test(portText) &&
+		Number.isSafeInteger(port) &&
+		port >= 1 &&
+		port <= 65535 &&
+		String(port) === portText
+			? port
+			: DEFAULT_VIEWER_PORT;
+	return `http://${urlHost}:${safePort}`;
+}
+
+async function responseJson(response: Response): Promise<unknown> {
+	try {
+		return await response.json();
+	} catch {
+		return null;
+	}
+}
+
+function errorCode(body: unknown): string | null {
+	return isRecord(body) && isRecord(body.error) && typeof body.error.code === "string"
+		? body.error.code
+		: null;
+}
+
+function classifyHttpFailure(
+	status: number,
+	body: unknown,
+	compatibleProfile: boolean,
+): PromptTransportDisposition {
+	const code = errorCode(body);
+	if (code === "viewer_db_mismatch") {
+		return classifyPromptTransportFailure({ kind: "database_mismatch" });
+	}
+	if (code === "viewer_identity_mismatch") {
+		return classifyPromptTransportFailure({ kind: "runtime_identity_mismatch" });
+	}
+	if (code === "viewer_contract_unsupported") {
+		return classifyPromptTransportFailure({
+			kind: "viewer_contract_unsupported",
+			compatibleProfile,
+		});
+	}
+	if (
+		status === 401 ||
+		status === 403 ||
+		["authorization_failed", "forbidden", "unauthorized"].includes(code ?? "")
+	) {
+		return classifyPromptTransportFailure({ kind: "authorization_failure" });
+	}
+	if (["policy_denied", "policy_disabled"].includes(code ?? "")) {
+		return classifyPromptTransportFailure({ kind: "policy_failure" });
+	}
+	if (code === "invalid_request") {
+		return classifyPromptTransportFailure({ kind: "invalid_request", compatibleProfile });
+	}
+	return "fallback";
+}
+
+async function fetchViewerPack(
+	query: string,
+	project: string | null,
+	payload: Record<string, unknown>,
+	dbPath: string,
+	deps: InjectDeps,
+): Promise<ViewerPackResult> {
+	const baseUrl = viewerBaseUrl(process.env);
+	if (!baseUrl) {
+		return {
+			ok: false,
+			disposition: classifyPromptTransportFailure({ kind: "policy_failure" }),
+		};
+	}
+	const fetchImpl = deps.fetchImpl ?? fetch;
+	const timeoutMs = Math.min(
+		parsePositiveInt(process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S, 2) * 1000,
+		2000,
+	);
+	const monotonicNow = deps.monotonicNow ?? (() => performance.now());
+	const createTimeoutSignal =
+		deps.createTimeoutSignal ?? ((milliseconds: number) => AbortSignal.timeout(milliseconds));
+	const deadline = monotonicNow() + timeoutMs;
+	const nextTimeoutSignal = (): AbortSignal | null => {
+		const remainingMs = Math.max(0, Math.floor(deadline - monotonicNow()));
+		return remainingMs > 0 ? createTimeoutSignal(remainingMs) : null;
+	};
+	const identity = buildViewerIdentityTarget();
+
+	const profileSignal = nextTimeoutSignal();
+	if (!profileSignal) return { ok: false, disposition: "fallback" };
+	let profileResponse: Response;
+	try {
+		profileResponse = await fetchImpl(`${baseUrl}/api/prompt-pack-profile`, {
+			method: "GET",
+			redirect: "manual",
+			signal: profileSignal,
+		});
+	} catch {
+		return { ok: false, disposition: "fallback" };
+	}
+	const profile = await responseJson(profileResponse);
+	if (profileResponse.status >= 300 && profileResponse.status < 400) {
+		return { ok: false, disposition: "fallback" };
+	}
+	if (!profileResponse.ok) {
+		return {
+			ok: false,
+			disposition: classifyHttpFailure(profileResponse.status, profile, false),
+		};
+	}
+	const viewerRange = isRecord(profile)
+		? normalizePromptTransportProtocolRange(
+				profile.protocol_version,
+				profile.min_supported_protocol_version,
+			)
+		: null;
+	if (
+		!isRecord(profile) ||
+		profile.service !== "codemem-viewer" ||
+		!viewerRange ||
+		!arePromptTransportProtocolRangesCompatible(PROMPT_TRANSPORT_PROTOCOL_RANGE, viewerRange)
+	) {
+		return { ok: false, disposition: "fallback" };
+	}
+	if (profile.db_path !== dbPath) {
+		return {
+			ok: false,
+			disposition: classifyPromptTransportFailure({ kind: "database_mismatch" }),
+		};
+	}
+	if (canonicalJson(profile.identity_target) !== canonicalJson(identity)) {
+		return {
+			ok: false,
+			disposition: classifyPromptTransportFailure({ kind: "runtime_identity_mismatch" }),
+		};
+	}
+
+	const uuid = deps.uuid ?? randomUUID;
+	const now = deps.now ?? (() => new Date());
+	const sessionId = typeof payload.session_id === "string" ? payload.session_id.trim() : "";
+	const attempt = {
+		attempt_id: uuid(),
+		started_at: now().toISOString(),
+		source: "codex",
+		...(sessionId ? { stream_id: sessionId, source_session_id: sessionId } : {}),
+		request_id: uuid(),
+	};
+	const cwd = typeof payload.cwd === "string" && isAbsolute(payload.cwd) ? payload.cwd : null;
+
+	const packSignal = nextTimeoutSignal();
+	if (!packSignal) return { ok: false, disposition: "fallback" };
+	let packResponse: Response;
+	try {
+		packResponse = await fetchImpl(`${baseUrl}/api/pack`, {
+			method: "POST",
+			redirect: "manual",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				context: query,
+				limit: parsePositiveInt(process.env.CODEMEM_INJECT_LIMIT, 8),
+				token_budget: parsePositiveInt(process.env.CODEMEM_INJECT_TOKEN_BUDGET, 800),
+				...(project ? { project } : {}),
+				...(cwd ? { cwd } : {}),
+				db_path: dbPath,
+				identity_target: identity,
+				attempt,
+			}),
+			signal: packSignal,
+		});
+	} catch {
+		return { ok: false, disposition: "fallback" };
+	}
+	const body = await responseJson(packResponse);
+	if (packResponse.status >= 300 && packResponse.status < 400) {
+		return { ok: false, disposition: "fallback" };
+	}
+	if (!packResponse.ok) {
+		return {
+			ok: false,
+			disposition: classifyHttpFailure(packResponse.status, body, true),
+		};
+	}
+	if (
+		!isRecord(body) ||
+		typeof body.pack_text !== "string" ||
+		!isRecord(body.metrics) ||
+		!Number.isInteger(body.metrics.total_items) ||
+		Number(body.metrics.total_items) < 0
+	) {
+		return { ok: false, disposition: "fallback" };
+	}
+	return {
+		ok: true,
+		pack: {
+			packText: body.pack_text.trim(),
+			items: Number(body.metrics.total_items),
+			packTokens: Number.isFinite(Number(body.metrics.pack_tokens))
+				? Number(body.metrics.pack_tokens)
+				: 0,
+		},
+		delivery: {
+			attemptId: attempt.attempt_id,
+			baseUrl,
+			dbPath,
+			deliveryStatus: body.pack_text.trim() ? "handed_off" : "unknown",
+			identity,
+		},
+	};
+}
+
+async function recordViewerDelivery(
+	delivery: Extract<ViewerPackResult, { ok: true }>["delivery"],
+	fetchImpl: typeof fetch,
+): Promise<void> {
+	try {
+		const response = await fetchImpl(`${delivery.baseUrl}/api/prompt-pack-ledger`, {
+			method: "POST",
+			redirect: "manual",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				action: "delivery",
+				attempt_id: delivery.attemptId,
+				delivery_status: delivery.deliveryStatus,
+				db_path: delivery.dbPath,
+				identity_target: delivery.identity,
+			}),
+			signal: AbortSignal.timeout(500),
+		});
+		await response.body?.cancel().catch(() => {});
+	} catch {
+		// Delivery accounting is best-effort and must never change hook output.
+	}
 }
 
 function continueResult(additionalContext?: string): InjectResult {
@@ -131,17 +438,19 @@ async function buildLocalPack(
 	}
 }
 
-export async function buildCodexHookInjection(
+async function prepareCodexHookInjection(
 	payload: Record<string, unknown>,
 	opts: DbOpts,
 	deps: InjectDeps = {},
-): Promise<InjectResult> {
-	if (envTruthy(process.env.CODEMEM_PLUGIN_IGNORE)) return continueResult();
-	if (!envNotDisabled(process.env.CODEMEM_INJECT_CONTEXT || "1")) return continueResult();
-	if (payload.hook_event_name !== HOOK_EVENT_NAME) return continueResult();
+): Promise<InjectionOutcome> {
+	if (envTruthy(process.env.CODEMEM_PLUGIN_IGNORE)) return { result: continueResult() };
+	if (!envNotDisabled(process.env.CODEMEM_INJECT_CONTEXT || "1")) {
+		return { result: continueResult() };
+	}
+	if (payload.hook_event_name !== HOOK_EVENT_NAME) return { result: continueResult() };
 
 	const promptText = normalizePromptText(payload.prompt);
-	if (!promptText) return continueResult();
+	if (!promptText) return { result: continueResult() };
 
 	const buildPack = deps.buildLocalPack ?? buildLocalPack;
 	const resolveDb = deps.resolveDb ?? resolveDbPath;
@@ -149,15 +458,26 @@ export async function buildCodexHookInjection(
 	const query = buildCodexInjectQuery(promptText, project);
 	const maxChars = parsePositiveInt(process.env.CODEMEM_INJECT_MAX_CHARS, DEFAULT_MAX_CHARS);
 
+	const dbPath = resolve(resolveDb(resolveDbOpt(opts)));
 	let pack: CodexPackResult = EMPTY_PACK;
-	let origin: "local" | "none" = "none";
-	try {
-		pack = await buildPack(query, project, resolveDb(resolveDbOpt(opts)));
-		if (pack.packText) origin = "local";
-	} catch (err) {
-		logHookEvent(
-			`codemem codex-hook-inject local pack failed: ${err instanceof Error ? err.message : String(err)}`,
-		);
+	let origin: "viewer" | "local" | "none" = "none";
+	const viewer = envTruthy(process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY)
+		? ({ ok: false, disposition: "fallback" } as const)
+		: await fetchViewerPack(query, project, payload, dbPath, deps);
+	let delivery: InjectionOutcome["delivery"];
+	if (viewer.ok) {
+		pack = viewer.pack;
+		delivery = viewer.delivery;
+		origin = "viewer";
+	} else if (viewer.disposition !== "terminal") {
+		try {
+			pack = await buildPack(query, project, dbPath);
+			if (pack.packText) origin = "local";
+		} catch (err) {
+			logHookEvent(
+				`codemem codex-hook-inject local pack failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
 	}
 
 	const fields = [
@@ -168,16 +488,40 @@ export async function buildCodexHookInjection(
 		`pack_tokens=${pack.packTokens}`,
 		`query_len=${query.length}`,
 		`empty=${pack.packText ? "false" : "true"}`,
+		`transport=${viewer.ok ? "ok" : viewer.disposition}`,
 	];
 	if (project) fields.push(`project=${JSON.stringify(project)}`);
 	logHookEvent(fields.join(" "));
 
-	return continueResult(formatCodexAdditionalContext(pack.packText, maxChars));
+	return {
+		result: continueResult(formatCodexAdditionalContext(pack.packText, maxChars)),
+		...(delivery ? { delivery } : {}),
+	};
+}
+
+export async function buildCodexHookInjection(
+	payload: Record<string, unknown>,
+	opts: DbOpts,
+	deps: InjectDeps = {},
+): Promise<InjectResult> {
+	return (await prepareCodexHookInjection(payload, opts, deps)).result;
+}
+
+export async function runCodexHookInjection(
+	payload: Record<string, unknown>,
+	opts: DbOpts,
+	deps: InjectDeps = {},
+): Promise<void> {
+	const outcome = await prepareCodexHookInjection(payload, opts, deps);
+	(deps.writeOutput ?? emitJson)(outcome.result);
+	if (outcome.delivery) {
+		await recordViewerDelivery(outcome.delivery, deps.fetchImpl ?? fetch);
+	}
 }
 
 const codexHookInjectCmd = new Command("codex-hook-inject")
 	.configureHelp(helpStyle)
-	.description("Compatibility fallback for Codex hook local additionalContext generation");
+	.description("Generate Codex hook additionalContext through Viewer HTTP with local fallback");
 
 addDbOption(codexHookInjectCmd);
 
@@ -206,8 +550,7 @@ export const codexHookInjectCommand = codexHookInjectCmd.action(async (opts: DbO
 	}
 
 	try {
-		const result = await buildCodexHookInjection(payload, opts);
-		emitJson(result);
+		await runCodexHookInjection(payload, opts);
 	} catch (err) {
 		logHookEvent(
 			`codemem codex-hook-inject failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/cli/src/commands/codex-user-prompt-hook.test.ts
+++ b/packages/cli/src/commands/codex-user-prompt-hook.test.ts
@@ -287,7 +287,12 @@ describe("dependency-free Codex user prompt hook", () => {
 	it("caps HTTP and compatibility fallback timeouts within the prompt output budget", async () => {
 		let elapsedMs = 0;
 		const httpTimeouts: number[] = [];
-		const childCalls: Array<{ command: string; args: string[]; timeout: number }> = [];
+		const childCalls: Array<{
+			command: string;
+			args: string[];
+			localPackOnly: string | undefined;
+			timeout: number;
+		}> = [];
 		const outputAt: number[] = [];
 
 		await hook.runCodexUserPromptHook(JSON.stringify(payload), {
@@ -305,10 +310,15 @@ describe("dependency-free Codex user prompt hook", () => {
 				command: string,
 				args: string[],
 				_raw: string,
-				_env: Record<string, string>,
+				childEnv: Record<string, string>,
 				timeout: number,
 			) => {
-				childCalls.push({ command, args, timeout });
+				childCalls.push({
+					command,
+					args,
+					localPackOnly: childEnv.CODEMEM_CODEX_LOCAL_PACK_ONLY,
+					timeout,
+				});
 				elapsedMs += timeout;
 				return null;
 			},
@@ -318,10 +328,16 @@ describe("dependency-free Codex user prompt hook", () => {
 
 		expect(httpTimeouts).toEqual([2_000]);
 		expect(childCalls).toEqual([
-			{ command: "codemem", args: ["codex-hook-inject"], timeout: 2_500 },
+			{
+				command: "codemem",
+				args: ["codex-hook-inject"],
+				localPackOnly: "1",
+				timeout: 2_500,
+			},
 			{
 				command: "npx",
 				args: ["-y", expect.stringMatching(/^codemem@\d+\.\d+\.\d+$/), "codex-hook-inject"],
+				localPackOnly: "1",
 				timeout: 800,
 			},
 		]);

--- a/plugins/codex/scripts/user-prompt-hook.mjs
+++ b/plugins/codex/scripts/user-prompt-hook.mjs
@@ -535,9 +535,16 @@ function requestTimeoutSignal(maximumMs, deadline, monotonicNow, createTimeoutSi
 export function runCompatibilityFallback(raw, env, deadline, overrides = {}) {
 	const monotonicNow = overrides.monotonicNow ?? (() => performance.now());
 	const runInjectImpl = overrides.runInjectImpl ?? runInject;
+	const fallbackEnv = { ...env, CODEMEM_CODEX_LOCAL_PACK_ONLY: "1" };
 	const codememTimeoutMs = Math.min(2_500, remainingPromptBudgetMs(deadline, monotonicNow));
 	if (codememTimeoutMs <= 0) return null;
-	const direct = runInjectImpl("codemem", ["codex-hook-inject"], raw, env, codememTimeoutMs);
+	const direct = runInjectImpl(
+		"codemem",
+		["codex-hook-inject"],
+		raw,
+		fallbackEnv,
+		codememTimeoutMs,
+	);
 	if (direct) return direct;
 
 	const npxTimeoutMs = Math.min(1_500, remainingPromptBudgetMs(deadline, monotonicNow));
@@ -546,7 +553,7 @@ export function runCompatibilityFallback(raw, env, deadline, overrides = {}) {
 		"npx",
 		["-y", `codemem@${pinnedVersion(env)}`, "codex-hook-inject"],
 		raw,
-		env,
+		fallbackEnv,
 		npxTimeoutMs,
 	);
 }


### PR DESCRIPTION
## Description

Fixes the 0.42.0 Codex plugin-free setup blocker by making `codemem codex-hook-inject` validate the loopback Viewer profile and retrieve recall through `POST /api/pack` before classified local database fallback.

The packaged wrapper now marks its CLI compatibility subprocess as local-pack-only so a failed Viewer request is not retried. Viewer work shares a two-second total budget, output is emitted before bounded delivery-ledger accounting, and existing query/framing/truncation behavior is preserved.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

`pnpm run check` passes: 4,729 tests passed, 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced