### PR TITLE
refactor(core): centralize Team ownership transitions

### DIFF
--- a/docs/plans/2026-08-22-team-ownership-transitions-design.md
+++ b/docs/plans/2026-08-22-team-ownership-transitions-design.md
@@ -1,0 +1,79 @@
+# Team Ownership Transitions Design
+
+**Status:** Approved on 2026-08-22
+**Bead:** codemem-1jqh
+
+## Problem
+
+Three core writers independently decide whether guided setup or an invite owns a
+Team membership or device decision. The repeated provenance lists and SQL
+conditions have already drifted across activation, onboarding, and coordinator
+reconciliation, multiplying the review surface for authorization-sensitive code.
+
+## Goals
+
+- Define one internal policy for setup-owned and invite-owned rows.
+- Express allowed membership and device-decision transitions as pure functions.
+- Make activation, onboarding, and coordinator reconciliation consume that policy.
+- Preserve all current SQL transaction boundaries, metadata, fingerprints,
+  revisions, counters, and fail-closed behavior.
+
+## Non-goals
+
+- A generic state-machine framework.
+- Schema or public API changes.
+- Consolidating the writers' SQL or digest formats.
+- Changing lifecycle behavior pinned by existing integration tests.
+
+## Ownership Model
+
+Setup owns membership or decision rows whose provenance is
+`reviewed_active`, `reviewed_team_candidate`, or `reviewed_team_setup`. Invite
+flows own rows whose provenance is `team_invite` or `coordinator_invite`.
+Unknown provenance is deliberately classified as other and receives no implicit
+authorization transition.
+
+The new `team-ownership-transitions.ts` module remains internal to the core
+package. It exposes typed, pure classifiers and transition planners rather than
+executing SQL. Writers continue to own persistence and caller-specific metadata.
+
+## Membership Transitions
+
+For a setup activation, a desired setup-owned row may be written or reactivated.
+An invite-owned row remains invite-owned, including its invite metadata, while a
+reviewed Team may normalize its active status to `reviewed_active`. Setup cleanup
+may revoke setup-owned rows only; invite-owned and unknown rows are preserved.
+
+For an invite, an absent row may be inserted. An active setup-owned row may be
+adopted by the invite, and a revoked setup-owned row may be explicitly
+reauthorized by a newly consumed invite. A reviewed Team may normalize a legacy
+invite-owned `active` row to `reviewed_active`. Already-correct invite rows are
+unchanged. Other rows fail closed.
+
+## Device-Decision Transitions
+
+Setup activation may write setup-owned decisions. When an invite already owns a
+decision, activation may update the reviewed decision and assignment version but
+must preserve invite provenance and revision. Setup cleanup may delete only
+setup-owned decisions. Invite-owned decisions removed from the actionable roster
+settle to non-granting `excluded` where current behavior requires it.
+
+Invite onboarding and coordinator reconciliation may adopt a setup-owned decision
+while preserving its reviewed decision. Newly reauthorized coordinator
+memberships retain the existing behavior of replacing non-setup decisions with an
+invite-owned unresolved decision. Unknown rows otherwise remain unchanged.
+
+## Validation
+
+Add table-driven tests for ownership classification and each pure transition
+matrix. Keep the existing activation, onboarding, and coordinator reconciler
+tests as integration coverage, then run core type checking, lint, and the core
+test suite.
+
+## Implementation Order
+
+1. Add the internal policy module and transition-matrix tests.
+2. Replace activation's repeated ownership conditions with planned actions.
+3. Replace onboarding's adoption conditions with planned actions.
+4. Replace coordinator reconciliation's branching with planned actions.
+5. Run focused tests, core gates, and review the resulting diff.

--- a/packages/core/src/coordinator-enrollment-reconciler.test.ts
+++ b/packages/core/src/coordinator-enrollment-reconciler.test.ts
@@ -196,7 +196,7 @@ describe("reconcileCoordinatorEnrollmentSnapshot", () => {
 		db.prepare(`INSERT INTO policy_team_memberships(
 			team_id, identity_id, role, status, provenance, revision, migration_state,
 			idempotency_key, created_at, updated_at
-		) VALUES ('team-a', 'identity-team', 'member', 'revoked', 'reviewed_active',
+		) VALUES ('team-a', 'identity-team', 'member', 'revoked', 'reviewed_team_setup',
 			'setup-r1', 'completed', 'setup-revoked-membership', ?, ?)`).run(NOW, NOW);
 
 		const result = reconcileCoordinatorEnrollmentSnapshot(db, {

--- a/packages/core/src/coordinator-enrollment-reconciler.ts
+++ b/packages/core/src/coordinator-enrollment-reconciler.ts
@@ -5,6 +5,10 @@ import type { CoordinatorEnrollment } from "./coordinator-store-contract.js";
 import type { Database } from "./db.js";
 import { assignIdentityDeviceInTransaction } from "./identity-device-assignment.js";
 import { normalizeIdentityDisplayName } from "./project-invite-identity.js";
+import {
+	planInviteDeviceDecisionTransition,
+	planInviteMembershipTransition,
+} from "./team-ownership-transitions.js";
 
 export interface CoordinatorEnrollmentReconcileIssue {
 	kind: "device" | "team_membership";
@@ -180,17 +184,18 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 				| undefined;
 			const reviewedTeam = team.device_eligibility_mode === "reviewed_allowlist";
 			const activeMembershipStatus = reviewedTeam ? "reviewed_active" : "active";
+			const membershipTransition = planInviteMembershipTransition(
+				membership,
+				activeMembershipStatus,
+			);
 			if (membership) {
-				if (membership.status === activeMembershipStatus) {
-					// A consumed invite owns this membership from now on. Leaving
-					// setup-owned provenance in place would let a later guided setup
-					// that omits the identity revoke the invitee's access.
-					if (["reviewed_active", "reviewed_team_candidate"].includes(membership.provenance)) {
+				if (membershipTransition === "preserve" || membershipTransition === "adopt_setup") {
+					if (membershipTransition === "adopt_setup") {
 						db.prepare(
 							`UPDATE policy_team_memberships
-							 SET provenance = 'coordinator_invite', updated_at = ?
+							 SET status = ?, provenance = 'coordinator_invite', updated_at = ?
 							 WHERE team_id = ? AND identity_id = ?`,
-						).run(now, invite.policy_team_id, identityId);
+						).run(activeMembershipStatus, now, invite.policy_team_id, identityId);
 					}
 					result.unchanged += 1;
 					if (reviewedTeam) {
@@ -204,19 +209,12 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 							});
 						}
 					}
-				} else if (
-					reviewedTeam &&
-					membership.status === "active" &&
-					["team_invite", "coordinator_invite"].includes(membership.provenance)
-				) {
-					// The pre-reviewed reconciler wrote invite memberships as
-					// `active`; normalize to the reviewed-mode status so the row
-					// stops blocking authoritative eligibility.
+				} else if (membershipTransition === "normalize_invite") {
 					db.prepare(
 						`UPDATE policy_team_memberships
-						 SET status = 'reviewed_active', updated_at = ?
+						 SET status = ?, updated_at = ?
 						 WHERE team_id = ? AND identity_id = ?`,
-					).run(now, invite.policy_team_id, identityId);
+					).run(activeMembershipStatus, now, invite.policy_team_id, identityId);
 					result.unchanged += 1;
 					const key = `${invite.policy_team_id}\u0000${identityId}`;
 					if (!reviewedInviteMemberships.has(key)) {
@@ -227,12 +225,7 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 							newlyAdded: false,
 						});
 					}
-				} else if (
-					membership.status === "revoked" &&
-					["reviewed_active", "reviewed_team_candidate"].includes(membership.provenance)
-				) {
-					// Guided setup revoked this person; a newly consumed invite is
-					// explicit re-authorization and adopts the row.
+				} else if (membershipTransition === "reauthorize_setup") {
 					const stableBinding = {
 						groupId: input.groupId,
 						inviteId: invite.invite_id,
@@ -434,57 +427,52 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 					deviceId: device.deviceId,
 					assignmentVersion: device.assignmentVersion,
 				};
-				// Existing setup-owned decisions transition to invite ownership
-				// while keeping their reviewed decision, so a later refreshed
-				// setup roster omitting the device cannot silently revoke
-				// invite-managed access.
-				const inserted = membership.newlyAdded
-					? db
-							.prepare(`INSERT INTO policy_team_device_decisions(
-								team_id, device_id, decision, assignment_version, provenance, revision,
-								created_at, updated_at
-							) VALUES (?, ?, 'unresolved', ?, 'coordinator_invite', ?, ?, ?)
-							ON CONFLICT(team_id, device_id) DO UPDATE SET
-								decision = CASE
-									WHEN policy_team_device_decisions.provenance = 'reviewed_team_setup'
-									THEN policy_team_device_decisions.decision
-									ELSE 'unresolved'
-								END,
-								assignment_version = CASE
-									WHEN policy_team_device_decisions.provenance = 'reviewed_team_setup'
-									THEN policy_team_device_decisions.assignment_version
-									ELSE excluded.assignment_version
-								END,
-								provenance = excluded.provenance,
-								revision = excluded.revision,
-								updated_at = excluded.updated_at`)
-							.run(
-								membership.teamId,
-								device.deviceId,
-								device.assignmentVersion,
-								digest("coordinator-team-device-decision-revision-v1", stableDecision),
-								now,
-								now,
-							)
-					: db
-							.prepare(`INSERT INTO policy_team_device_decisions(
-								team_id, device_id, decision, assignment_version, provenance, revision,
-								created_at, updated_at
-							) VALUES (?, ?, 'unresolved', ?, 'coordinator_invite', ?, ?, ?)
-							ON CONFLICT(team_id, device_id) DO UPDATE SET
-								provenance = excluded.provenance,
-								revision = excluded.revision,
-								updated_at = excluded.updated_at
-							WHERE policy_team_device_decisions.provenance = 'reviewed_team_setup'`)
-							.run(
-								membership.teamId,
-								device.deviceId,
-								device.assignmentVersion,
-								digest("coordinator-team-device-decision-revision-v1", stableDecision),
-								now,
-								now,
-							);
-				if (inserted.changes > 0) {
+				const existingDecision = db
+					.prepare(
+						`SELECT decision, provenance FROM policy_team_device_decisions
+						 WHERE team_id = ? AND device_id = ?`,
+					)
+					.get(membership.teamId, device.deviceId) as
+					| { decision: string; provenance: string }
+					| undefined;
+				const transition = planInviteDeviceDecisionTransition(
+					existingDecision,
+					membership.newlyAdded,
+				);
+				if (transition === "preserve") continue;
+				const revision = digest("coordinator-team-device-decision-revision-v1", stableDecision);
+				const changed =
+					transition === "insert_unresolved"
+						? db
+								.prepare(`INSERT INTO policy_team_device_decisions(
+									team_id, device_id, decision, assignment_version, provenance, revision,
+									created_at, updated_at
+								) VALUES (?, ?, 'unresolved', ?, 'coordinator_invite', ?, ?, ?)`)
+								.run(
+									membership.teamId,
+									device.deviceId,
+									device.assignmentVersion,
+									revision,
+									now,
+									now,
+								)
+						: transition === "adopt_setup"
+							? db
+									.prepare(
+										`UPDATE policy_team_device_decisions
+										 SET provenance = 'coordinator_invite', revision = ?, updated_at = ?
+										 WHERE team_id = ? AND device_id = ?`,
+									)
+									.run(revision, now, membership.teamId, device.deviceId)
+							: db
+									.prepare(
+										`UPDATE policy_team_device_decisions
+										 SET decision = 'unresolved', assignment_version = ?,
+										     provenance = 'coordinator_invite', revision = ?, updated_at = ?
+										 WHERE team_id = ? AND device_id = ?`,
+									)
+									.run(device.assignmentVersion, revision, now, membership.teamId, device.deviceId);
+				if (changed.changes > 0) {
 					db.prepare(
 						`UPDATE policy_teams SET source_fingerprint = NULL, updated_at = ?
 						 WHERE team_id = ? AND device_eligibility_mode = 'reviewed_allowlist'

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -945,6 +945,11 @@ describe("legacy Team setup activation", () => {
 				toDeviceEligibilityMode: "reviewed_allowlist",
 			}),
 		]);
+		expect(review.accessDelta.membershipChanges).toContainEqual({
+			teamId,
+			identityId: "identity-invited",
+			change: "update",
+		});
 		expect(review.accessDelta.deviceAccessChanges).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -983,6 +988,20 @@ describe("legacy Team setup activation", () => {
 				)
 				.get(),
 		).toEqual({ status: "reviewed_active", provenance: "reviewed_active" });
+		expect(
+			db
+				.prepare(
+					`SELECT status, provenance, revision, migration_state, idempotency_key
+					 FROM policy_team_memberships WHERE identity_id = 'identity-invited'`,
+				)
+				.get(),
+		).toEqual({
+			status: "reviewed_active",
+			provenance: "coordinator_invite",
+			revision: "invite-r1",
+			migration_state: "user_managed",
+			idempotency_key: "historical-invite-membership",
+		});
 	});
 
 	it.each([

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -19,6 +19,11 @@ import {
 	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
 import { deriveRecipientPolicyEffectiveDevices } from "./recipient-policy-reconciliation.js";
+import {
+	classifyTeamPolicyOwnership,
+	planSetupDeviceDecisionTransition,
+	planSetupMembershipTransition,
+} from "./team-ownership-transitions.js";
 
 export type LegacyTeamSetupActivationErrorCode =
 	| "team_setup_incomplete"
@@ -219,14 +224,8 @@ interface CompletionRow {
 const SETUP_MEMBERSHIP_PROVENANCE = "reviewed_active";
 /** Provenance written by the historical `choose_recipients` migration path. */
 const HISTORICAL_TEAM_PROVENANCE = "reviewed_team_candidate";
-/** Membership provenance values written by the production invite flows. */
-const INVITE_MEMBERSHIP_PROVENANCES = ["team_invite", "coordinator_invite"] as const;
 const MAX_ACTIVATION_DEVICES = 500;
 const MAX_ACTIVATION_PROJECTS = 500;
-
-function isInviteMembershipProvenance(provenance: string): boolean {
-	return (INVITE_MEMBERSHIP_PROVENANCES as readonly string[]).includes(provenance);
-}
 
 function parseJsonObject(json: string): Record<string, unknown> | null {
 	try {
@@ -554,7 +553,7 @@ function validateCanonicalState(model: ActivationModel): void {
 					row.status !== "revoked" &&
 					// Pre-reviewed production invite paths wrote `active` rows; the
 					// activation sweep normalizes them to `reviewed_active`.
-					!(row.status === "active" && isInviteMembershipProvenance(row.provenance)),
+					!(row.status === "active" && classifyTeamPolicyOwnership(row.provenance) === "invite"),
 			)
 		) {
 			activationError("team_setup_conflict");
@@ -571,7 +570,7 @@ function validateCanonicalState(model: ActivationModel): void {
 		if (
 			memberships.some(
 				(row) =>
-					isInviteMembershipProvenance(row.provenance) &&
+					classifyTeamPolicyOwnership(row.provenance) === "invite" &&
 					(row.status === "active" || row.status === "reviewed_active") &&
 					!validIdentityIds.has(row.identity_id),
 			)
@@ -658,7 +657,7 @@ function validateHistoricalTeamAdoption(model: ActivationModel): void {
 				(row.status !== "active" && row.status !== "revoked" && row.status !== "reviewed_active") ||
 				((row.status === "active" || row.status === "reviewed_active") &&
 					row.provenance !== HISTORICAL_TEAM_PROVENANCE &&
-					!isInviteMembershipProvenance(row.provenance)),
+					classifyTeamPolicyOwnership(row.provenance) !== "invite"),
 		)
 	) {
 		activationError("team_setup_conflict");
@@ -714,12 +713,18 @@ function validateAssignmentExpectations(model: ActivationModel): void {
 interface DerivationRows {
 	identities: Array<{ identityId: string; status: string; mergedIntoIdentityId: string | null }>;
 	teams: Array<{ teamId: string; status: string; deviceEligibilityMode: string }>;
-	teamMemberships: Array<{ teamId: string; identityId: string; status: string }>;
+	teamMemberships: Array<{
+		teamId: string;
+		identityId: string;
+		status: string;
+		provenance: string;
+	}>;
 	teamDeviceDecisions: Array<{
 		teamId: string;
 		deviceId: string;
 		decision: string;
 		assignmentVersion: number;
+		provenance: string;
 	}>;
 	identityDevices: Array<{
 		identityId: string;
@@ -752,12 +757,14 @@ function currentDerivationRows(model: ActivationModel): DerivationRows {
 			teamId: row.team_id,
 			identityId: row.identity_id,
 			status: row.status,
+			provenance: row.provenance,
 		})),
 		teamDeviceDecisions: model.allDecisions.map((row) => ({
 			teamId: row.team_id,
 			deviceId: row.device_id,
 			decision: row.decision,
 			assignmentVersion: row.assignment_version,
+			provenance: row.provenance,
 		})),
 		identityDevices: model.assignments.map((row) => ({
 			identityId: row.identity_id,
@@ -825,29 +832,33 @@ function simulatedDerivationRows(model: ActivationModel): DerivationRows {
 				teamId: row.team_id,
 				identityId: row.identity_id,
 				status: row.status,
+				provenance: row.provenance,
 			});
 			continue;
 		}
 		seenThisTeamMembers.add(row.identity_id);
-		let status = row.status;
-		if (desired.has(row.identity_id)) {
-			status = "reviewed_active";
-		} else if (
-			isInviteMembershipProvenance(row.provenance) &&
-			(row.status === "active" || row.status === "reviewed_active")
-		) {
-			status = "reviewed_active";
-		} else if (
-			[SETUP_MEMBERSHIP_PROVENANCE, HISTORICAL_TEAM_PROVENANCE].includes(row.provenance) &&
-			(row.status === "active" || row.status === "reviewed_active")
-		) {
-			status = "revoked";
-		}
-		teamMemberships.push({ teamId: model.teamId, identityId: row.identity_id, status });
+		const transition = planSetupMembershipTransition(row, desired.has(row.identity_id));
+		const status =
+			transition === "upsert_setup" || transition === "normalize_invite"
+				? "reviewed_active"
+				: transition === "revoke_setup"
+					? "revoked"
+					: row.status;
+		teamMemberships.push({
+			teamId: model.teamId,
+			identityId: row.identity_id,
+			status,
+			provenance: row.provenance,
+		});
 	}
 	for (const identityId of model.desiredIdentityIds) {
 		if (!seenThisTeamMembers.has(identityId)) {
-			teamMemberships.push({ teamId: model.teamId, identityId, status: "reviewed_active" });
+			teamMemberships.push({
+				teamId: model.teamId,
+				identityId,
+				status: "reviewed_active",
+				provenance: SETUP_MEMBERSHIP_PROVENANCE,
+			});
 		}
 	}
 
@@ -865,49 +876,40 @@ function simulatedDerivationRows(model: ActivationModel): DerivationRows {
 			row.decision = "unresolved";
 		}
 	}
-	// Decisions for devices dropped from the refreshed roster are reconciled
-	// away unless invite-owned; the invite allowlist is the single sanctioned
-	// survivor set, mirroring the apply-side reconcile exactly.
-	const draftDeviceIds = new Set(model.devices.map((device) => device.device_id));
-	const inviteOwnedDecisionDeviceIds = new Set(
-		model.allDecisions
-			.filter(
-				(row) =>
-					row.team_id === model.teamId &&
-					["team_invite", "coordinator_invite"].includes(row.provenance),
-			)
-			.map((row) => row.device_id),
-	);
+	const draftDevices = new Map(model.devices.map((device) => [device.device_id, device]));
 	for (const row of model.allDecisions) {
-		if (row.team_id !== model.teamId || draftDeviceIds.has(row.device_id)) continue;
-		if (!["team_invite", "coordinator_invite"].includes(row.provenance)) {
-			teamDeviceDecisions.delete(decisionKey(row.team_id, row.device_id));
-			continue;
+		if (row.team_id !== model.teamId) continue;
+		const draftDevice = draftDevices.get(row.device_id);
+		if (draftDevice && draftDevice.decision !== "removed") continue;
+		const transition = planSetupDeviceDecisionTransition(row, {
+			belongsToRoster: Boolean(draftDevice),
+		});
+		const key = decisionKey(row.team_id, row.device_id);
+		if (transition === "delete_setup") teamDeviceDecisions.delete(key);
+		if (transition === "settle_invite_excluded") {
+			const preserved = teamDeviceDecisions.get(key);
+			if (preserved) preserved.decision = "excluded";
 		}
-		// Mirrors the apply-side reconcile: an invite-owned unresolved decision
-		// for a device absent from the roster settles to `excluded`.
-		const preserved = teamDeviceDecisions.get(decisionKey(row.team_id, row.device_id));
-		if (preserved?.decision === "unresolved") preserved.decision = "excluded";
 	}
 	for (const device of model.devices) {
+		if (device.decision === "removed") continue;
 		const key = decisionKey(model.teamId, device.device_id);
-		if (device.decision === "removed") {
-			// Mirrors the apply-side removed reconcile: any surviving
-			// invite-owned decision settles to the non-granting `excluded`
-			// state — the reviewed removal retires the device's access.
-			if (!inviteOwnedDecisionDeviceIds.has(device.device_id)) {
-				teamDeviceDecisions.delete(key);
-			} else {
-				const preserved = teamDeviceDecisions.get(key);
-				if (preserved && preserved.decision !== "excluded") preserved.decision = "excluded";
-			}
-			continue;
-		}
+		const existing = teamDeviceDecisions.get(key);
+		const desiredDecision = device.decision === "included" ? "included" : "excluded";
+		const transition = planSetupDeviceDecisionTransition(existing, {
+			desiredDecision,
+			belongsToRoster: true,
+		});
+		if (transition === "preserve") continue;
 		teamDeviceDecisions.set(key, {
 			teamId: model.teamId,
 			deviceId: device.device_id,
-			decision: device.decision === "included" ? "included" : "excluded",
+			decision: desiredDecision,
 			assignmentVersion: identityDevices.get(device.device_id)?.assignmentVersion ?? 0,
+			provenance:
+				transition === "upsert_preserving_invite"
+					? (existing?.provenance ?? "team_invite")
+					: "reviewed_team_setup",
 		});
 	}
 
@@ -999,27 +1001,29 @@ function buildAccessDelta(model: ActivationModel): LegacyTeamSetupAccessDeltaV1 
 	const memberships = new Map(model.memberships.map((row) => [row.identity_id, row]));
 	for (const identityId of model.desiredIdentityIds) {
 		const current = memberships.get(identityId);
-		if (!current || !["active", "reviewed_active"].includes(current.status)) {
+		const transition = planSetupMembershipTransition(current, true);
+		if (
+			transition === "upsert_setup" &&
+			(!current || !["active", "reviewed_active"].includes(current.status))
+		) {
 			accessDelta.membershipChanges.push({ teamId: model.teamId, identityId, change: "add" });
-		} else if (current.status === "active") {
+		} else if (
+			(transition === "upsert_setup" || transition === "normalize_invite") &&
+			current?.status === "active"
+		) {
 			accessDelta.membershipChanges.push({ teamId: model.teamId, identityId, change: "update" });
 		}
 	}
 	for (const membership of model.memberships) {
 		if (model.desiredIdentityIds.includes(membership.identity_id)) continue;
-		if (
-			[SETUP_MEMBERSHIP_PROVENANCE, HISTORICAL_TEAM_PROVENANCE].includes(membership.provenance) &&
-			["active", "reviewed_active"].includes(membership.status)
-		) {
+		const transition = planSetupMembershipTransition(membership, false);
+		if (transition === "revoke_setup") {
 			accessDelta.membershipChanges.push({
 				teamId: model.teamId,
 				identityId: membership.identity_id,
 				change: "remove",
 			});
-		} else if (
-			isInviteMembershipProvenance(membership.provenance) &&
-			membership.status === "active"
-		) {
+		} else if (transition === "normalize_invite") {
 			accessDelta.membershipChanges.push({
 				teamId: model.teamId,
 				identityId: membership.identity_id,
@@ -1336,34 +1340,24 @@ function applyActivation(
 	db.prepare(
 		"UPDATE policy_teams SET source_fingerprint = ?, updated_at = ? WHERE team_id = ?",
 	).run(postRosterFingerprint, now, model.teamId);
+	const existingMemberships = new Map(
+		model.allMemberships
+			.filter((row) => row.team_id === model.teamId)
+			.map((row) => [row.identity_id, row]),
+	);
+	const desiredIdentityIds = new Set(model.desiredIdentityIds);
 	for (const identityId of model.desiredIdentityIds) {
+		const transition = planSetupMembershipTransition(existingMemberships.get(identityId), true);
+		if (transition !== "upsert_setup") continue;
 		db.prepare(
 			`INSERT INTO policy_team_memberships(
 			 team_id, identity_id, role, status, provenance, revision, migration_state,
 			 source_fingerprint, idempotency_key, created_at, updated_at
 			 ) VALUES (?, ?, 'member', 'reviewed_active', ?, ?, 'completed', ?, ?, ?, ?)
 			 ON CONFLICT(team_id, identity_id) DO UPDATE SET
-			 role = 'member', status = 'reviewed_active',
-			 provenance = CASE
-			   WHEN policy_team_memberships.provenance IN ('team_invite', 'coordinator_invite')
-			     THEN policy_team_memberships.provenance
-			   ELSE excluded.provenance
-			 END,
-			 revision = CASE
-			   WHEN policy_team_memberships.provenance IN ('team_invite', 'coordinator_invite')
-			     THEN policy_team_memberships.revision
-			   ELSE excluded.revision
-			 END,
-			 migration_state = CASE
-			   WHEN policy_team_memberships.provenance IN ('team_invite', 'coordinator_invite')
-			     THEN policy_team_memberships.migration_state
-			   ELSE 'completed'
-			 END,
-			 source_fingerprint = CASE
-			   WHEN policy_team_memberships.provenance IN ('team_invite', 'coordinator_invite')
-			     THEN policy_team_memberships.source_fingerprint
-			   ELSE excluded.source_fingerprint
-			 END,
+			 role = 'member', status = 'reviewed_active', provenance = excluded.provenance,
+			 revision = excluded.revision, migration_state = 'completed',
+			 source_fingerprint = excluded.source_fingerprint,
 			 updated_at = excluded.updated_at`,
 		).run(
 			model.teamId,
@@ -1376,86 +1370,58 @@ function applyActivation(
 			now,
 		);
 	}
-	db.prepare(
-		`UPDATE policy_team_memberships
-		 SET status = 'reviewed_active', updated_at = ?
-		 WHERE team_id = ? AND provenance IN ('team_invite', 'coordinator_invite')
-		   AND status IN ('active', 'reviewed_active')`,
-	).run(now, model.teamId);
-	// Reconcile memberships owned by guided setup, including the historical
-	// `reviewed_team_candidate` rows adopted by this activation. Invite-managed
-	// memberships are never revoked here.
-	db.prepare(
-		`UPDATE policy_team_memberships
-		 SET status = 'revoked', revision = ?, updated_at = ?
-		 WHERE team_id = ? AND provenance IN (?, ?) AND status IN ('active', 'reviewed_active')
-		   AND identity_id NOT IN (
-		     SELECT DISTINCT target_identity_id FROM legacy_team_setup_draft_devices
-		     WHERE attempt_id = ? AND decision = 'included' AND target_identity_id IS NOT NULL
-		   )`,
-	).run(
-		revision,
-		now,
-		model.teamId,
-		SETUP_MEMBERSHIP_PROVENANCE,
-		HISTORICAL_TEAM_PROVENANCE,
-		model.draft.attempt_id,
-	);
-
-	// A device dropped from the refreshed roster has no draft row, but its
-	// stale decision would keep granting project access. Invite-owned
-	// decisions are the only sanctioned survivors — readiness classifies
-	// anything else outside the completed draft as unexplained — so the
-	// reconcile scope is the complement of the invite allowlist, never a
-	// provenance denylist that a third writer could silently escape.
-	db.prepare(
-		`DELETE FROM policy_team_device_decisions
-		 WHERE team_id = ? AND provenance NOT IN ('team_invite', 'coordinator_invite')
-		   AND device_id NOT IN (
-		     SELECT device_id FROM legacy_team_setup_draft_devices WHERE attempt_id = ?
-		   )`,
-	).run(model.teamId, model.draft.attempt_id);
-	// An invite-owned UNRESOLVED decision for a device the refreshed roster no
-	// longer contains has no draft row through which the user could ever
-	// resolve it — readiness would reopen setup forever with no actionable
-	// device. It settles to the non-granting `excluded` state; invite flows
-	// can still update their own decision if the device later enrolls.
-	// Preserved `included` invite decisions outside the roster remain the
-	// sanctioned effective-access case and are untouched.
-	db.prepare(
-		`UPDATE policy_team_device_decisions
-		 SET decision = 'excluded', updated_at = ?
-		 WHERE team_id = ? AND decision = 'unresolved'
-		   AND provenance IN ('team_invite', 'coordinator_invite')
-		   AND device_id NOT IN (
-		     SELECT device_id FROM legacy_team_setup_draft_devices WHERE attempt_id = ?
-		   )`,
-	).run(now, model.teamId, model.draft.attempt_id);
-	for (const device of model.devices) {
-		if (device.decision === "removed") {
-			// Reviewed removals revoke setup-owned access, but invite flows own
-			// their decisions even for removed roster devices: both invite
-			// writers transition setup decisions to invite ownership precisely
-			// so a refreshed roster cannot silently revoke invite-managed
-			// MEMBERSHIP. The decision itself is different: the reviewed
-			// removal retires this device's access, so any surviving invite
-			// decision settles to the non-granting `excluded` state — an
-			// `included` decision would keep granting Project access to the
-			// removed device, and an `unresolved` one would reopen setup
-			// forever.
+	for (const membership of existingMemberships.values()) {
+		const transition = planSetupMembershipTransition(
+			membership,
+			desiredIdentityIds.has(membership.identity_id),
+		);
+		if (transition === "normalize_invite") {
 			db.prepare(
-				`DELETE FROM policy_team_device_decisions
-				 WHERE team_id = ? AND device_id = ?
-				   AND provenance NOT IN ('team_invite', 'coordinator_invite')`,
-			).run(model.teamId, device.device_id);
-			db.prepare(
-				`UPDATE policy_team_device_decisions
-				 SET decision = 'excluded', updated_at = ?
-				 WHERE team_id = ? AND device_id = ? AND decision <> 'excluded'
-				   AND provenance IN ('team_invite', 'coordinator_invite')`,
-			).run(now, model.teamId, device.device_id);
-			continue;
+				`UPDATE policy_team_memberships SET status = 'reviewed_active', updated_at = ?
+				 WHERE team_id = ? AND identity_id = ?`,
+			).run(now, model.teamId, membership.identity_id);
 		}
+		if (transition === "revoke_setup") {
+			db.prepare(
+				`UPDATE policy_team_memberships SET status = 'revoked', revision = ?, updated_at = ?
+				 WHERE team_id = ? AND identity_id = ?`,
+			).run(revision, now, model.teamId, membership.identity_id);
+		}
+	}
+
+	const existingDecisions = new Map(
+		model.allDecisions
+			.filter((row) => row.team_id === model.teamId)
+			.map((row) => [row.device_id, row]),
+	);
+	const draftDevices = new Map(model.devices.map((device) => [device.device_id, device]));
+	for (const decision of existingDecisions.values()) {
+		const draftDevice = draftDevices.get(decision.device_id);
+		if (draftDevice && draftDevice.decision !== "removed") continue;
+		const transition = planSetupDeviceDecisionTransition(decision, {
+			belongsToRoster: Boolean(draftDevice),
+		});
+		if (transition === "delete_setup") {
+			db.prepare(
+				"DELETE FROM policy_team_device_decisions WHERE team_id = ? AND device_id = ?",
+			).run(model.teamId, decision.device_id);
+		}
+		if (transition === "settle_invite_excluded") {
+			db.prepare(
+				`UPDATE policy_team_device_decisions SET decision = 'excluded', updated_at = ?
+				 WHERE team_id = ? AND device_id = ? AND decision <> 'excluded'`,
+			).run(now, model.teamId, decision.device_id);
+		}
+	}
+	for (const device of model.devices) {
+		if (device.decision === "removed") continue;
+		const desiredDecision = device.decision === "included" ? "included" : "excluded";
+		const transition = planSetupDeviceDecisionTransition(existingDecisions.get(device.device_id), {
+			desiredDecision,
+			belongsToRoster: true,
+		});
+		if (transition === "preserve") continue;
+		const preserveInviteOwnership = transition === "upsert_preserving_invite" ? 1 : 0;
 		const assignmentVersion =
 			device.decision === "included"
 				? assignmentVersions.get(device.device_id)
@@ -1469,17 +1435,27 @@ function applyActivation(
 			 ON CONFLICT(team_id, device_id) DO UPDATE SET
 			 decision = excluded.decision, assignment_version = excluded.assignment_version,
 			 provenance = CASE
-			   WHEN policy_team_device_decisions.provenance IN ('team_invite', 'coordinator_invite')
+			   WHEN ? = 1
 			     THEN policy_team_device_decisions.provenance
 			   ELSE excluded.provenance
 			 END,
 			 revision = CASE
-			   WHEN policy_team_device_decisions.provenance IN ('team_invite', 'coordinator_invite')
+			   WHEN ? = 1
 			     THEN policy_team_device_decisions.revision
 			   ELSE excluded.revision
 			 END,
 			 updated_at = excluded.updated_at`,
-		).run(model.teamId, device.device_id, device.decision, assignmentVersion, revision, now, now);
+		).run(
+			model.teamId,
+			device.device_id,
+			desiredDecision,
+			assignmentVersion,
+			revision,
+			now,
+			now,
+			preserveInviteOwnership,
+			preserveInviteOwnership,
+		);
 	}
 
 	for (const project of model.projects) {

--- a/packages/core/src/recipient-policy-identifiers.ts
+++ b/packages/core/src/recipient-policy-identifiers.ts
@@ -27,11 +27,11 @@ export function recipientPolicyDigest(prefix: string, value: unknown): string {
 }
 
 /**
- * Decision provenances owned by the invite flows. Activation deliberately
- * preserves these rows and readiness must tolerate them; every layer that
- * classifies decision ownership must use this single set — hand-repeated
- * literals with opposite polarity (allowlist vs denylist) are how the two
- * sides drift apart.
+ * Decision and membership provenances owned by the invite flows. Activation
+ * deliberately preserves these rows and readiness must tolerate them; every
+ * layer that classifies invite ownership must use this single set —
+ * hand-repeated literals with opposite polarity (allowlist vs denylist) are
+ * how the two sides drift apart.
  */
 export const INVITE_DECISION_PROVENANCES = ["team_invite", "coordinator_invite"] as const;
 

--- a/packages/core/src/recipient-policy-onboarding.test.ts
+++ b/packages/core/src/recipient-policy-onboarding.test.ts
@@ -1437,7 +1437,12 @@ describe("recipient-policy onboarding", () => {
 			{ now: () => NOW },
 		);
 
-		expect(result).toMatchObject({ status: "applied", errorCode: null });
+		expect(result).toMatchObject({
+			status: "applied",
+			errorCode: null,
+			writeCount: 3,
+			idempotent: false,
+		});
 		expect(
 			db
 				.prepare(
@@ -1452,6 +1457,60 @@ describe("recipient-policy onboarding", () => {
 				.pluck()
 				.get(),
 		).toBe("reviewed-roster");
+	});
+
+	it("normalizes an invite-owned membership without replacing its invite metadata", () => {
+		db.prepare(
+			`UPDATE policy_teams
+			 SET device_eligibility_mode = 'reviewed_allowlist', source_fingerprint = 'reviewed-roster'
+			 WHERE team_id = 'team-a'`,
+		).run();
+		db.prepare(
+			"UPDATE policy_team_memberships SET status = 'reviewed_active' WHERE team_id = 'team-a'",
+		).run();
+		db.prepare(
+			`INSERT INTO policy_team_memberships(
+			 team_id, identity_id, role, status, provenance, revision, migration_state,
+			 source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES ('team-a', 'identity-b', 'member', 'active', 'coordinator_invite',
+			 'coordinator-r1', 'user_managed', 'coordinator-source', 'coordinator-membership', ?, ?)`,
+		).run(NOW, NOW);
+		const request = baseRequest({
+			journey: "team",
+			invitationId: "invite-normalize-member",
+			identityId: "identity-b",
+			teamId: "team-a",
+		});
+		const preview = previewRecipientPolicyOnboarding(db, request);
+
+		const result = commitRecipientPolicyOnboarding(
+			db,
+			{ ...request, reviewedOnboardingDigest: preview.reviewedOnboardingDigest },
+			{ now: () => NOW },
+		);
+
+		expect(result).toMatchObject({
+			status: "applied",
+			errorCode: null,
+			writeCount: 3,
+			idempotent: false,
+		});
+		expect(
+			db
+				.prepare(
+					`SELECT status, provenance, revision, migration_state, source_fingerprint, idempotency_key
+					 FROM policy_team_memberships
+					 WHERE team_id = 'team-a' AND identity_id = 'identity-b'`,
+				)
+				.get(),
+		).toEqual({
+			status: "reviewed_active",
+			provenance: "coordinator_invite",
+			revision: "coordinator-r1",
+			migration_state: "user_managed",
+			source_fingerprint: "coordinator-source",
+			idempotency_key: "coordinator-membership",
+		});
 	});
 
 	it("adopts an existing setup-owned membership when onboarding an invited member", () => {
@@ -1485,7 +1544,12 @@ describe("recipient-policy onboarding", () => {
 			{ now: () => NOW },
 		);
 
-		expect(result).toMatchObject({ status: "applied", errorCode: null });
+		expect(result).toMatchObject({
+			status: "applied",
+			errorCode: null,
+			writeCount: 3,
+			idempotent: false,
+		});
 		expect(
 			db
 				.prepare(
@@ -1500,6 +1564,55 @@ describe("recipient-policy onboarding", () => {
 				.pluck()
 				.get(),
 		).toBe("identity-b");
+	});
+
+	it("counts reauthorizing a revoked setup-owned membership and replays idempotently", () => {
+		db.prepare(
+			`UPDATE policy_teams
+			 SET device_eligibility_mode = 'reviewed_allowlist', source_fingerprint = 'reviewed-roster'
+			 WHERE team_id = 'team-a'`,
+		).run();
+		db.prepare(
+			"UPDATE policy_team_memberships SET status = 'reviewed_active' WHERE team_id = 'team-a'",
+		).run();
+		db.prepare(
+			`INSERT INTO policy_team_memberships(
+			 team_id, identity_id, role, status, provenance, revision, migration_state,
+			 idempotency_key, created_at, updated_at
+			 ) VALUES ('team-a', 'identity-b', 'member', 'revoked', 'reviewed_team_setup',
+			 'setup-r1', 'completed', 'setup-owned-membership', ?, ?)`,
+		).run(NOW, NOW);
+		const request = baseRequest({
+			journey: "team",
+			invitationId: "invite-revoked-member",
+			identityId: "identity-b",
+			teamId: "team-a",
+		});
+		const preview = previewRecipientPolicyOnboarding(db, request);
+		const commitRequest = {
+			...request,
+			reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+		};
+
+		const result = commitRecipientPolicyOnboarding(db, commitRequest, { now: () => NOW });
+		const replay = commitRecipientPolicyOnboarding(db, commitRequest, {
+			now: () => "2026-07-21T13:00:00.000Z",
+		});
+
+		expect(result).toMatchObject({
+			status: "applied",
+			writeCount: 3,
+			idempotent: false,
+		});
+		expect(replay).toMatchObject({ status: "applied", writeCount: 0, idempotent: true });
+		expect(
+			db
+				.prepare(
+					`SELECT status, provenance FROM policy_team_memberships
+					 WHERE team_id = 'team-a' AND identity_id = 'identity-b'`,
+				)
+				.get(),
+		).toEqual({ status: "reviewed_active", provenance: "team_invite" });
 	});
 
 	it("commits exact direct recipients plus device without Team membership", () => {

--- a/packages/core/src/recipient-policy-onboarding.ts
+++ b/packages/core/src/recipient-policy-onboarding.ts
@@ -15,6 +15,10 @@ import { managedProjectScopeId } from "./share-operation.js";
 import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap-constants.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 import { buildBaseUrl } from "./sync-http-client.js";
+import {
+	planInviteDeviceDecisionTransition,
+	planInviteMembershipTransition,
+} from "./team-ownership-transitions.js";
 
 export type RecipientPolicyOnboardingJourneyV1 = "team" | "direct_project" | "add_device";
 
@@ -973,40 +977,36 @@ function applyReviewedTeamInviteDecision(
 		.get(request.teamId, request.binding.deviceId) as
 		| { decision: string; provenance: string }
 		| undefined;
-	// An existing setup-owned decision transitions to invite ownership without
-	// changing its reviewed decision: otherwise a later refreshed setup roster
-	// that omits the device would reconcile the decision away and silently
-	// revoke invite-managed access.
-	const inserted = db
-		.prepare(
-			`INSERT INTO policy_team_device_decisions(
-			 team_id, device_id, decision, assignment_version, provenance, revision,
-			 created_at, updated_at
-			 ) VALUES (?, ?, 'unresolved', ?, 'team_invite', ?, ?, ?)
-			 ON CONFLICT(team_id, device_id) DO UPDATE SET
-			 provenance = excluded.provenance, revision = excluded.revision,
-			 updated_at = excluded.updated_at
-			 WHERE policy_team_device_decisions.provenance = 'reviewed_team_setup'`,
-		)
-		.run(
-			request.teamId,
-			request.binding.deviceId,
-			assignmentVersion,
-			digest("recipient-onboarding-device-decision-revision-v1", stableDecision),
-			now,
-			now,
-		);
+	const transition = planInviteDeviceDecisionTransition(existingDecision, false);
+	if (transition === "preserve") return 0;
+	const revision = digest("recipient-onboarding-device-decision-revision-v1", stableDecision);
+	const result =
+		transition === "insert_unresolved"
+			? db
+					.prepare(
+						`INSERT INTO policy_team_device_decisions(
+						 team_id, device_id, decision, assignment_version, provenance, revision,
+						 created_at, updated_at
+						 ) VALUES (?, ?, 'unresolved', ?, 'team_invite', ?, ?, ?)`,
+					)
+					.run(request.teamId, request.binding.deviceId, assignmentVersion, revision, now, now)
+			: db
+					.prepare(
+						`UPDATE policy_team_device_decisions
+						 SET provenance = 'team_invite', revision = ?, updated_at = ?
+						 WHERE team_id = ? AND device_id = ?`,
+					)
+					.run(revision, now, request.teamId, request.binding.deviceId);
 	const introducedUnresolvedDecision =
 		!existingDecision ||
-		(existingDecision.provenance === "reviewed_team_setup" &&
-			existingDecision.decision === "unresolved");
-	if (inserted.changes > 0 && introducedUnresolvedDecision) {
+		(transition === "adopt_setup" && existingDecision.decision === "unresolved");
+	if (result.changes > 0 && introducedUnresolvedDecision) {
 		db.prepare(
 			`UPDATE policy_teams SET source_fingerprint = NULL, updated_at = ?
 			 WHERE team_id = ? AND device_eligibility_mode = 'reviewed_allowlist'`,
 		).run(now, request.teamId);
 	}
-	return inserted.changes;
+	return result.changes;
 }
 
 function projectRow(
@@ -1103,9 +1103,14 @@ function inviterProjectRow(input: {
 	};
 }
 
-function planRows(db: Database, request: NormalizedRequest, now: string): IntentRow[] {
+function planRows(
+	db: Database,
+	request: NormalizedRequest,
+	now: string,
+	options: { preserveInviteMembership?: boolean } = {},
+): IntentRow[] {
 	const rows = [deviceRow(request, now)];
-	if (request.journey === "team") {
+	if (request.journey === "team" && !options.preserveInviteMembership) {
 		const reviewedTeam = teamDeviceEligibilityMode(db, request.teamId) === "reviewed_allowlist";
 		rows.push(membershipRow(request, now, reviewedTeam ? "reviewed_active" : "active"));
 	}
@@ -1128,46 +1133,77 @@ function applyTeamJourneySideEffects(
 }
 
 /**
- * A consumed invite owns the recipient's membership from now on. When guided
- * setup already materialized the row with setup-owned provenance, transition
- * it to the exact invite-owned row before intent validation: otherwise the
- * exact-row comparison rejects onboarding for an existing roster member, and a
- * later setup omitting the identity would revoke the invitee's access.
+ * A consumed invite owns the recipient's membership from now on. Setup-owned
+ * rows transition to this invite's exact intent before validation. Existing
+ * invite-owned rows retain their original invite metadata; reviewed Teams may
+ * normalize only their active status. Without that distinction, exact-row
+ * validation either rejects a valid invite-owned member or replaces metadata
+ * owned by an earlier invite flow.
  */
-function adoptSetupOwnedTeamMembership(
+function applyInviteOwnedTeamMembershipTransition(
 	db: Database,
 	request: NormalizedRequest,
 	now: string,
-): void {
-	if (request.journey !== "team") return;
+): {
+	preserveInviteMembership: boolean;
+	writes: 0 | 1;
+} {
+	if (request.journey !== "team") {
+		return { preserveInviteMembership: false, writes: 0 };
+	}
 	const existing = db
 		.prepare(
-			`SELECT provenance FROM policy_team_memberships
+			`SELECT provenance, status FROM policy_team_memberships
 			 WHERE team_id = ? AND identity_id = ?`,
 		)
-		.get(request.teamId, request.binding.identityId) as { provenance: string } | undefined;
-	if (!existing || !["reviewed_active", "reviewed_team_candidate"].includes(existing.provenance)) {
-		return;
-	}
+		.get(request.teamId, request.binding.identityId) as
+		| { provenance: string; status: string }
+		| undefined;
 	const reviewedTeam = teamDeviceEligibilityMode(db, request.teamId) === "reviewed_allowlist";
-	const row = membershipRow(request, now, reviewedTeam ? "reviewed_active" : "active");
-	db.prepare(
-		`UPDATE policy_team_memberships
+	const targetStatus = reviewedTeam ? "reviewed_active" : "active";
+	const transition = planInviteMembershipTransition(existing, targetStatus);
+	if (!["adopt_setup", "reauthorize_setup", "normalize_invite"].includes(transition)) {
+		return {
+			preserveInviteMembership: transition === "preserve",
+			writes: 0,
+		};
+	}
+	if (transition === "normalize_invite") {
+		const result = db
+			.prepare(
+				`UPDATE policy_team_memberships SET status = ?, updated_at = ?
+			 WHERE team_id = ? AND identity_id = ?`,
+			)
+			.run(targetStatus, now, request.teamId, request.binding.identityId);
+		return {
+			preserveInviteMembership: true,
+			writes: result.changes > 0 ? 1 : 0,
+		};
+	}
+	const row = membershipRow(request, now, targetStatus);
+	const result = db
+		.prepare(
+			`UPDATE policy_team_memberships
 		 SET role = ?, status = ?, provenance = ?, revision = ?, migration_state = ?,
 		     source_fingerprint = ?, idempotency_key = ?, updated_at = ?
 		 WHERE team_id = ? AND identity_id = ?`,
-	).run(
-		row.values.role,
-		row.values.status,
-		row.values.provenance,
-		row.values.revision,
-		row.values.migration_state,
-		row.values.source_fingerprint,
-		row.values.idempotency_key,
-		now,
-		request.teamId,
-		request.binding.identityId,
-	);
+		)
+		.run(
+			row.values.role,
+			row.values.status,
+			row.values.provenance,
+			row.values.revision,
+			row.values.migration_state,
+			row.values.source_fingerprint,
+			row.values.idempotency_key,
+			now,
+			request.teamId,
+			request.binding.identityId,
+		);
+	return {
+		preserveInviteMembership: false,
+		writes: result.changes > 0 ? 1 : 0,
+	};
 }
 
 function isPristineBootstrapIdentity(
@@ -1638,8 +1674,11 @@ export function commitRecipientPolicyOnboarding(
 			}
 			const now = (options.now ?? (() => new Date().toISOString()))();
 			let writeCount = 0;
-			adoptSetupOwnedTeamMembership(db, normalized, now);
-			for (const row of planRows(db, normalized, now)) {
+			const membershipTransition = applyInviteOwnedTeamMembershipTransition(db, normalized, now);
+			writeCount += membershipTransition.writes;
+			for (const row of planRows(db, normalized, now, {
+				preserveInviteMembership: membershipTransition.preserveInviteMembership,
+			})) {
 				if (validateOrWriteRow(db, row)) writeCount += 1;
 			}
 			writeCount += applyTeamJourneySideEffects(db, normalized, now);
@@ -1734,8 +1773,11 @@ export function commitRecipientPolicyOnboardingFromReviewedIntent(
 				if (reviewedIntent.journey !== "team") throw new Error("intent_conflict");
 				if (materializeReviewedTeam(db, reviewedIntent.team, now)) writeCount += 1;
 			}
-			adoptSetupOwnedTeamMembership(db, normalized, now);
-			for (const row of planRows(db, normalized, now)) {
+			const membershipTransition = applyInviteOwnedTeamMembershipTransition(db, normalized, now);
+			writeCount += membershipTransition.writes;
+			for (const row of planRows(db, normalized, now, {
+				preserveInviteMembership: membershipTransition.preserveInviteMembership,
+			})) {
 				if (validateOrWriteRow(db, row)) writeCount += 1;
 			}
 			writeCount += applyTeamJourneySideEffects(db, normalized, now);

--- a/packages/core/src/team-ownership-transitions.test.ts
+++ b/packages/core/src/team-ownership-transitions.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+	classifyTeamPolicyOwnership,
+	planInviteDeviceDecisionTransition,
+	planInviteMembershipTransition,
+	planSetupDeviceDecisionTransition,
+	planSetupMembershipTransition,
+} from "./team-ownership-transitions.js";
+
+describe("team ownership transitions", () => {
+	it.each([
+		["reviewed_active", "setup"],
+		["reviewed_team_candidate", "setup"],
+		["reviewed_team_setup", "setup"],
+		["team_invite", "invite"],
+		["coordinator_invite", "invite"],
+		["future_writer", "other"],
+	] as const)("classifies %s as %s-owned", (provenance, expected) => {
+		expect(classifyTeamPolicyOwnership(provenance)).toBe(expected);
+	});
+
+	describe("setup membership planning", () => {
+		it.each([
+			[undefined, true, "upsert_setup"],
+			[undefined, false, "preserve"],
+			[{ provenance: "reviewed_active", status: "reviewed_active" }, true, "upsert_setup"],
+			[{ provenance: "reviewed_team_candidate", status: "active" }, false, "revoke_setup"],
+			[{ provenance: "reviewed_team_setup", status: "revoked" }, false, "preserve"],
+			[{ provenance: "reviewed_team_setup", status: "revoked" }, true, "upsert_setup"],
+			[{ provenance: "team_invite", status: "active" }, true, "normalize_invite"],
+			[{ provenance: "coordinator_invite", status: "active" }, false, "normalize_invite"],
+			[{ provenance: "team_invite", status: "reviewed_active" }, false, "preserve"],
+			[{ provenance: "team_invite", status: "revoked" }, true, "preserve"],
+			[{ provenance: "future_writer", status: "active" }, true, "preserve"],
+		] as const)("plans %#", (existing, desired, expected) => {
+			expect(planSetupMembershipTransition(existing, desired)).toBe(expected);
+		});
+	});
+
+	describe("invite membership planning", () => {
+		it.each([
+			[undefined, "active", "insert_invite"],
+			[
+				{ provenance: "reviewed_active", status: "reviewed_active" },
+				"reviewed_active",
+				"adopt_setup",
+			],
+			[{ provenance: "reviewed_team_candidate", status: "revoked" }, "active", "reauthorize_setup"],
+			[{ provenance: "reviewed_team_setup", status: "pending" }, "active", "reject"],
+			[{ provenance: "team_invite", status: "active" }, "active", "preserve"],
+			[
+				{ provenance: "coordinator_invite", status: "active" },
+				"reviewed_active",
+				"normalize_invite",
+			],
+			[{ provenance: "coordinator_invite", status: "reviewed_active" }, "active", "reject"],
+			[{ provenance: "team_invite", status: "revoked" }, "active", "reject"],
+			[{ provenance: "future_writer", status: "active" }, "active", "reject"],
+		] as const)("plans %#", (existing, targetStatus, expected) => {
+			expect(planInviteMembershipTransition(existing, targetStatus)).toBe(expected);
+		});
+	});
+
+	describe("setup device-decision planning", () => {
+		it.each([
+			[undefined, { desiredDecision: "included", belongsToRoster: true }, "upsert_setup"],
+			[undefined, { belongsToRoster: false }, "preserve"],
+			[
+				{ provenance: "reviewed_team_setup", decision: "included" },
+				{ desiredDecision: "excluded", belongsToRoster: true },
+				"upsert_setup",
+			],
+			[
+				{ provenance: "team_invite", decision: "included" },
+				{ desiredDecision: "excluded", belongsToRoster: true },
+				"upsert_preserving_invite",
+			],
+			[
+				{ provenance: "future_writer", decision: "included" },
+				{ desiredDecision: "excluded", belongsToRoster: true },
+				"preserve",
+			],
+			[
+				{ provenance: "reviewed_team_setup", decision: "included" },
+				{ belongsToRoster: true },
+				"delete_setup",
+			],
+			[
+				{ provenance: "coordinator_invite", decision: "included" },
+				{ belongsToRoster: true },
+				"settle_invite_excluded",
+			],
+			[
+				{ provenance: "team_invite", decision: "unresolved" },
+				{ belongsToRoster: false },
+				"settle_invite_excluded",
+			],
+			[{ provenance: "team_invite", decision: "included" }, { belongsToRoster: false }, "preserve"],
+			[
+				{ provenance: "future_writer", decision: "unresolved" },
+				{ belongsToRoster: false },
+				"preserve",
+			],
+		] as const)("plans %#", (existing, options, expected) => {
+			expect(planSetupDeviceDecisionTransition(existing, options)).toBe(expected);
+		});
+	});
+
+	describe("invite device-decision planning", () => {
+		it.each([
+			[undefined, false, "insert_unresolved"],
+			[{ provenance: "reviewed_team_setup", decision: "included" }, false, "adopt_setup"],
+			[{ provenance: "reviewed_active", decision: "excluded" }, true, "adopt_setup"],
+			[{ provenance: "team_invite", decision: "included" }, false, "preserve"],
+			[{ provenance: "coordinator_invite", decision: "included" }, true, "replace_unresolved"],
+			[{ provenance: "future_writer", decision: "excluded" }, false, "preserve"],
+			[{ provenance: "future_writer", decision: "excluded" }, true, "replace_unresolved"],
+		] as const)("plans %#", (existing, newlyAuthorized, expected) => {
+			expect(planInviteDeviceDecisionTransition(existing, newlyAuthorized)).toBe(expected);
+		});
+	});
+});

--- a/packages/core/src/team-ownership-transitions.ts
+++ b/packages/core/src/team-ownership-transitions.ts
@@ -1,0 +1,126 @@
+import { INVITE_DECISION_PROVENANCES } from "./recipient-policy-identifiers.js";
+
+export type TeamPolicyOwnership = "setup" | "invite" | "other";
+
+export interface ExistingTeamMembership {
+	provenance: string;
+	status: string;
+}
+
+export interface ExistingTeamDeviceDecision {
+	provenance: string;
+	decision: string;
+}
+
+export type SetupMembershipTransition =
+	| "upsert_setup"
+	| "revoke_setup"
+	| "normalize_invite"
+	| "preserve";
+
+export type InviteMembershipTransition =
+	| "insert_invite"
+	| "adopt_setup"
+	| "reauthorize_setup"
+	| "normalize_invite"
+	| "preserve"
+	| "reject";
+
+export type SetupDeviceDecisionTransition =
+	| "upsert_setup"
+	| "upsert_preserving_invite"
+	| "delete_setup"
+	| "settle_invite_excluded"
+	| "preserve";
+
+export type InviteDeviceDecisionTransition =
+	| "insert_unresolved"
+	| "adopt_setup"
+	| "replace_unresolved"
+	| "preserve";
+
+const SETUP_PROVENANCES = new Set([
+	"reviewed_active",
+	"reviewed_team_candidate",
+	"reviewed_team_setup",
+]);
+const INVITE_PROVENANCES: ReadonlySet<string> = new Set(INVITE_DECISION_PROVENANCES);
+
+export function classifyTeamPolicyOwnership(provenance: string): TeamPolicyOwnership {
+	if (SETUP_PROVENANCES.has(provenance)) return "setup";
+	if (INVITE_PROVENANCES.has(provenance)) return "invite";
+	return "other";
+}
+
+export function planSetupMembershipTransition(
+	existing: ExistingTeamMembership | undefined,
+	desired: boolean,
+): SetupMembershipTransition {
+	if (!existing) return desired ? "upsert_setup" : "preserve";
+
+	const ownership = classifyTeamPolicyOwnership(existing.provenance);
+	if (desired) {
+		if (ownership === "setup") return "upsert_setup";
+		if (ownership === "invite" && existing.status === "active") return "normalize_invite";
+		return "preserve";
+	}
+
+	if (ownership === "setup") {
+		return ["active", "reviewed_active"].includes(existing.status) ? "revoke_setup" : "preserve";
+	}
+	if (ownership === "invite" && existing.status === "active") return "normalize_invite";
+	return "preserve";
+}
+
+export function planInviteMembershipTransition(
+	existing: ExistingTeamMembership | undefined,
+	targetStatus: "active" | "reviewed_active",
+): InviteMembershipTransition {
+	if (!existing) return "insert_invite";
+
+	const ownership = classifyTeamPolicyOwnership(existing.provenance);
+	if (ownership === "setup") {
+		if (existing.status === "revoked") return "reauthorize_setup";
+		if (["active", "reviewed_active"].includes(existing.status)) return "adopt_setup";
+		return "reject";
+	}
+	if (ownership !== "invite") return "reject";
+	if (existing.status === targetStatus) return "preserve";
+	if (existing.status === "active" && targetStatus === "reviewed_active") {
+		return "normalize_invite";
+	}
+	return "reject";
+}
+
+export function planSetupDeviceDecisionTransition(
+	existing: ExistingTeamDeviceDecision | undefined,
+	options: { desiredDecision?: "included" | "excluded"; belongsToRoster: boolean },
+): SetupDeviceDecisionTransition {
+	if (options.desiredDecision) {
+		if (!existing) return "upsert_setup";
+		const ownership = classifyTeamPolicyOwnership(existing.provenance);
+		if (ownership === "setup") return "upsert_setup";
+		if (ownership === "invite") return "upsert_preserving_invite";
+		return "preserve";
+	}
+	if (!existing) return "preserve";
+
+	const ownership = classifyTeamPolicyOwnership(existing.provenance);
+	if (ownership === "setup") return "delete_setup";
+	if (ownership !== "invite") return "preserve";
+	if (options.belongsToRoster || existing.decision === "unresolved") {
+		return "settle_invite_excluded";
+	}
+	return "preserve";
+}
+
+export function planInviteDeviceDecisionTransition(
+	existing: ExistingTeamDeviceDecision | undefined,
+	newlyAuthorizedMembership: boolean,
+): InviteDeviceDecisionTransition {
+	if (!existing) return "insert_unresolved";
+	if (classifyTeamPolicyOwnership(existing.provenance) === "setup") return "adopt_setup";
+	// A newly authorized membership resets invite-owned and unknown decisions
+	// to non-granting unresolved state so stale grants cannot survive reauthorization.
+	return newlyAuthorizedMembership ? "replace_unresolved" : "preserve";
+}


### PR DESCRIPTION
## Description

Centralizes Team membership and device-decision ownership classification and transition planning in an internal typed policy module. Migrates setup activation, recipient onboarding, and coordinator reconciliation to use the shared rules while preserving each writer’s SQL, transaction, metadata, revision, fingerprint, and counter responsibilities.

Unknown ownership remains fail-closed, setup cleanup affects setup-owned rows only, and invite-owned rows retain their provenance and metadata. No public API or package version change is required.

Tracks codemem-1jqh.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, core Vitest suite)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation: 107 core test files passed; 3210 tests passed and 3 remain todo. Snyk Code reported no high-severity issues.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced