### PR TITLE
refactor(core): share legacy Team canonical preflight

### DIFF
--- a/docs/plans/2026-08-23-legacy-team-canonical-preflight-design.md
+++ b/docs/plans/2026-08-23-legacy-team-canonical-preflight-design.md
@@ -1,0 +1,43 @@
+# Legacy Team Canonical Preflight Reuse
+
+**Date:** 2026-08-23
+
+**Status:** Approved
+
+## Problem
+
+Legacy Team setup drafts can report `canFinish: true` while activation will reject the same reviewed state with `team_setup_conflict`. Draft readiness currently checks that a Project has an active coordinator scope, but activation also rejects ambiguous multi-scope mappings, conflicting mappings, foreign-Team recipient claims, and unsupported recipient kinds.
+
+That disagreement is both confusing and costly: a user can finish reviewing a draft only to have activation reject it. Activation must still repeat every canonical check under its write lock because canonical state can change after preview.
+
+## Decision
+
+Extract the read-only Project canonical-state rules into an internal data-only preflight module. Both draft readiness and activation validation will call the same predicate.
+
+The shared predicate will evaluate:
+
+- whether existing mappings can safely be preserved or superseded by this coordinator group;
+- whether creating or retargeting a mapping is ambiguous across multiple active scopes;
+- whether another active Team already claims the resolved Project; and
+- whether an active recipient uses an unsupported kind.
+
+Direct Identity recipients remain compatible with the reviewed Team edge. Revoked recipients remain irrelevant. A setup-owned mapping may be superseded only when it belongs to this coordinator group's current or historical scopes.
+
+## Boundaries
+
+- The helper remains internal to `packages/core`; it is not exported from `packages/core/src/index.ts`.
+- Draft readiness loads only the canonical facts required by the predicate and folds its result into `canFinish`.
+- Activation continues to call canonical validation from `loadModel` before preview and again inside `BEGIN IMMEDIATE` before any writes.
+- Post-write selected-mapping precedence remains activation-only; a higher-priority selected mapping can still reject activation after `canFinish` was true.
+- No schema, API contract, authorization, or persistence behavior changes.
+
+## Verification
+
+Focused tests will prove draft readiness and activation agree for:
+
+- a new mapping with multiple active scopes;
+- a Project claimed by another active Team;
+- an active recipient with an unsupported kind; and
+- canonical state that changes after preview but before locked activation validation.
+
+Existing positive coverage for an already-selected mapping across multiple scopes and direct Identity recipient coexistence must remain green.

--- a/packages/core/src/legacy-team-project-canonical-preflight.test.ts
+++ b/packages/core/src/legacy-team-project-canonical-preflight.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+	isLegacyTeamProjectCanonicalStateValid,
+	type LegacyTeamProjectCanonicalPreflightInput,
+} from "./legacy-team-project-canonical-preflight.js";
+
+const PROJECT = "project-a";
+const SOURCE = "source-a";
+const TEAM = "team-a";
+
+const BASELINE: LegacyTeamProjectCanonicalPreflightInput = {
+	teamId: TEAM,
+	scopeIds: ["scope-active"],
+	groupScopeIds: ["scope-active", "scope-historical"],
+	projects: [{ sourceProjectIdentity: SOURCE, resolvedProjectIdentity: PROJECT }],
+	mappings: [],
+	recipients: [],
+};
+
+describe("legacy Team Project canonical preflight", () => {
+	it.each([
+		{
+			name: "accepts the valid baseline",
+			overrides: {},
+			expected: true,
+		},
+		{
+			name: "leaves zero active scope readiness to the caller",
+			overrides: { scopeIds: [] },
+			expected: true,
+		},
+		{
+			name: "rejects an unresolved Project identity defensively",
+			overrides: {
+				projects: [{ sourceProjectIdentity: SOURCE, resolvedProjectIdentity: null }],
+			},
+			expected: false,
+		},
+		{
+			name: "rejects ambiguous active scopes for a new mapping",
+			overrides: {
+				scopeIds: ["scope-active", "scope-active-2"],
+				groupScopeIds: ["scope-active", "scope-active-2", "scope-historical"],
+			},
+			expected: false,
+		},
+		{
+			name: "accepts multiple scopes when a current mapping selects one",
+			overrides: {
+				scopeIds: ["scope-active", "scope-active-2"],
+				groupScopeIds: ["scope-active", "scope-active-2", "scope-historical"],
+				mappings: [
+					{
+						workspaceIdentity: PROJECT,
+						projectPattern: SOURCE,
+						scopeId: "scope-active-2",
+						source: "user",
+					},
+				],
+			},
+			expected: true,
+		},
+		{
+			name: "rejects a foreign mapping for the source pattern",
+			overrides: {
+				mappings: [
+					{
+						workspaceIdentity: "project-foreign",
+						projectPattern: SOURCE,
+						scopeId: "scope-foreign",
+						source: "user",
+					},
+				],
+			},
+			expected: false,
+		},
+		{
+			name: "accepts an own setup mapping in a historical group scope",
+			overrides: {
+				mappings: [
+					{
+						workspaceIdentity: "project-prior-resolution",
+						projectPattern: SOURCE,
+						scopeId: "scope-historical",
+						source: "reviewed_team_setup",
+					},
+				],
+			},
+			expected: true,
+		},
+		{
+			name: "rejects an active foreign Team recipient",
+			overrides: {
+				recipients: [
+					{
+						canonicalProjectIdentity: PROJECT,
+						recipientKind: "team",
+						recipientId: "team-foreign",
+						status: "active",
+					},
+				],
+			},
+			expected: false,
+		},
+		{
+			name: "accepts an active direct Identity recipient",
+			overrides: {
+				recipients: [
+					{
+						canonicalProjectIdentity: PROJECT,
+						recipientKind: "identity",
+						recipientId: "identity-a",
+						status: "active",
+					},
+				],
+			},
+			expected: true,
+		},
+		{
+			name: "rejects an unsupported active recipient kind",
+			overrides: {
+				recipients: [
+					{
+						canonicalProjectIdentity: PROJECT,
+						recipientKind: "service",
+						recipientId: "service-a",
+						status: "active",
+					},
+				],
+			},
+			expected: false,
+		},
+		{
+			name: "ignores a revoked unsupported recipient",
+			overrides: {
+				recipients: [
+					{
+						canonicalProjectIdentity: PROJECT,
+						recipientKind: "service",
+						recipientId: "service-a",
+						status: "revoked",
+					},
+				],
+			},
+			expected: true,
+		},
+	] satisfies Array<{
+		name: string;
+		overrides: Partial<LegacyTeamProjectCanonicalPreflightInput>;
+		expected: boolean;
+	}>)("$name", ({ overrides, expected }) => {
+		expect(isLegacyTeamProjectCanonicalStateValid({ ...BASELINE, ...overrides })).toBe(expected);
+	});
+});

--- a/packages/core/src/legacy-team-project-canonical-preflight.ts
+++ b/packages/core/src/legacy-team-project-canonical-preflight.ts
@@ -1,0 +1,74 @@
+export interface LegacyTeamProjectCanonicalPreflightInput {
+	teamId: string;
+	scopeIds: readonly string[];
+	groupScopeIds: readonly string[];
+	projects: ReadonlyArray<{
+		sourceProjectIdentity: string;
+		resolvedProjectIdentity: string | null;
+	}>;
+	mappings: ReadonlyArray<{
+		workspaceIdentity: string | null;
+		projectPattern: string;
+		scopeId: string;
+		source: string | null;
+	}>;
+	recipients: ReadonlyArray<{
+		canonicalProjectIdentity: string;
+		recipientKind: string;
+		recipientId: string;
+		status: string;
+	}>;
+}
+
+/**
+ * Evaluates only the canonical Project facts shared by draft readiness and
+ * activation. Callers remain responsible for loading fresh facts at their own
+ * consistency boundary; activation repeats this check under its write lock.
+ *
+ * The input must include the complete active-scope set and complete historical
+ * scope set for the coordinator group, every mapping whose Project pattern
+ * matches a supplied source identity, and every recipient whose canonical
+ * identity matches a supplied resolved identity. Unrelated mappings and
+ * recipients may be omitted. Although normal callers invoke this only after
+ * review completeness checks, unresolved or `unmapped:` identities are
+ * rejected defensively so an incomplete caller fails closed.
+ */
+export function isLegacyTeamProjectCanonicalStateValid(
+	input: LegacyTeamProjectCanonicalPreflightInput,
+): boolean {
+	for (const project of input.projects) {
+		const resolvedIdentity = project.resolvedProjectIdentity;
+		if (!resolvedIdentity || resolvedIdentity.startsWith("unmapped:")) return false;
+
+		const relatedMappings = input.mappings.filter(
+			(mapping) => mapping.projectPattern === project.sourceProjectIdentity,
+		);
+		const hasConflictingMapping = relatedMappings.some((mapping) => {
+			const ownSetupMapping =
+				mapping.source === "reviewed_team_setup" && input.groupScopeIds.includes(mapping.scopeId);
+			return (
+				!ownSetupMapping &&
+				(!input.scopeIds.includes(mapping.scopeId) ||
+					mapping.workspaceIdentity !== resolvedIdentity)
+			);
+		});
+		if (hasConflictingMapping) return false;
+
+		const hasCurrentMapping = relatedMappings.some(
+			(mapping) =>
+				mapping.workspaceIdentity === resolvedIdentity && input.scopeIds.includes(mapping.scopeId),
+		);
+		if (!hasCurrentMapping && input.scopeIds.length > 1) return false;
+
+		const hasConflictingRecipient = input.recipients.some(
+			(recipient) =>
+				recipient.canonicalProjectIdentity === resolvedIdentity &&
+				recipient.status === "active" &&
+				((recipient.recipientKind === "team" && recipient.recipientId !== input.teamId) ||
+					(recipient.recipientKind !== "team" && recipient.recipientKind !== "identity")),
+		);
+		if (hasConflictingRecipient) return false;
+	}
+
+	return true;
+}

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -669,6 +669,37 @@ describe("legacy Team setup activation", () => {
 		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions").pluck().get()).toBe(0);
 	});
 
+	it("revalidates Project canonical state after the pre-lock model was accepted", async () => {
+		// Arrange: preview and the finish's initial model are valid. The external
+		// roster fetch yields control before BEGIN IMMEDIATE, during which another
+		// writer can add a conflicting claim. The locked loadModel must reject it
+		// before inventory derivation or any setup write.
+		const draft = readyDraft();
+		const review = preview(draft);
+		const loadFreshRoster = vi.fn(async () => {
+			expect(db.inTransaction).toBe(false);
+			db.prepare(
+				`INSERT INTO project_recipients(
+				 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+				 policy_revision, migration_state, idempotency_key, created_at, updated_at
+				 ) VALUES (?, 'team', 'policy-team-v1:foreign', 'active', 'user', 'r1',
+				 'completed', 'late-foreign-team-claim', ?, ?)`,
+			).run(PROJECT_A, NOW, NOW);
+			return roster;
+		});
+		const loadProjectInventory = vi.fn(() => draftProjectInventory(draft.attemptId));
+
+		// Act
+		const operation = finish(draft, review, loadFreshRoster, loadProjectInventory);
+
+		// Assert
+		await expect(operation).rejects.toThrow("team_setup_conflict");
+		expect(loadFreshRoster).toHaveBeenCalledOnce();
+		expect(loadProjectInventory).not.toHaveBeenCalled();
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions").pluck().get()).toBe(0);
+	});
+
 	it("replays the exact immutable response only for the same candidate route and confirmation", async () => {
 		// Arrange
 		const draft = readyDraft();

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -4,6 +4,7 @@ import {
 	IdentityDeviceAssignmentError,
 } from "./identity-device-assignment.js";
 import { selectedProjectScopeMapping } from "./legacy-recipient-policy-projection.js";
+import { isLegacyTeamProjectCanonicalStateValid } from "./legacy-team-project-canonical-preflight.js";
 import {
 	type LegacyTeamSetupProjectInput,
 	legacyTeamProjectionFingerprint,
@@ -579,53 +580,30 @@ function validateCanonicalState(model: ActivationModel): void {
 		}
 	}
 
-	for (const project of projects) {
-		const resolvedIdentity = project.resolved_project_identity as string;
-		const relatedMappings = model.mappings.filter(
-			(mapping) => mapping.project_pattern === project.source_project_identity,
-		);
-		// A setup-owned mapping whose target differs is a prior activation's
-		// resolution that this reviewed re-resolution supersedes — but ONLY
-		// when that mapping belongs to THIS group's scopes. A same-pattern
-		// mapping owned by another flow or another coordinator group is an
-		// unresolvable conflict: retargeting it would silently reroute the
-		// other group's Project and break its completed Team.
-		if (
-			relatedMappings.some((mapping) => {
-				const ownSetupMapping =
-					mapping.source === "reviewed_team_setup" && groupScopeIds.includes(mapping.scope_id);
-				return (
-					!ownSetupMapping &&
-					(!scopeIds.includes(mapping.scope_id) || mapping.workspace_identity !== resolvedIdentity)
-				);
-			})
-		) {
-			activationError("team_setup_conflict");
-		}
-		// Creating or re-targeting a mapping requires an unambiguous scope.
-		const hasCurrentMapping = relatedMappings.some(
-			(mapping) =>
-				mapping.workspace_identity === resolvedIdentity && scopeIds.includes(mapping.scope_id),
-		);
-		if (!hasCurrentMapping && scopeIds.length > 1) {
-			activationError("team_setup_conflict");
-		}
-		const activeRecipients = recipients.filter(
-			(row) => row.canonical_project_identity === resolvedIdentity && row.status === "active",
-		);
-		// Direct identity shares can legitimately coexist with the Team edge
-		// (for example from a historical choose_recipients resolution that
-		// selected both) and the confirmed delta models every recipient path.
-		// Only another Team claiming the project is an unexplained conflict.
-		if (
-			activeRecipients.some(
-				(row) =>
-					(row.recipient_kind === "team" && row.recipient_id !== teamId) ||
-					(row.recipient_kind !== "team" && row.recipient_kind !== "identity"),
-			)
-		) {
-			activationError("team_setup_conflict");
-		}
+	if (
+		!isLegacyTeamProjectCanonicalStateValid({
+			teamId,
+			scopeIds,
+			groupScopeIds,
+			projects: projects.map((project) => ({
+				sourceProjectIdentity: project.source_project_identity,
+				resolvedProjectIdentity: project.resolved_project_identity,
+			})),
+			mappings: model.mappings.map((mapping) => ({
+				workspaceIdentity: mapping.workspace_identity,
+				projectPattern: mapping.project_pattern,
+				scopeId: mapping.scope_id,
+				source: mapping.source,
+			})),
+			recipients: recipients.map((recipient) => ({
+				canonicalProjectIdentity: recipient.canonical_project_identity,
+				recipientKind: recipient.recipient_kind,
+				recipientId: recipient.recipient_id,
+				status: recipient.status,
+			})),
+		})
+	) {
+		activationError("team_setup_conflict");
 	}
 }
 

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -47,6 +47,31 @@ function snapshot(overrides: { fingerprint?: string; deviceName?: string } = {})
 	};
 }
 
+function readyDraft(db: InstanceType<typeof Database>) {
+	let draft = refreshLegacyTeamSetupDraft(db, snapshot());
+	const device = draft.devices[0];
+	if (!device) throw new Error("invalid test fixture");
+	draft = setLegacyTeamSetupDeviceAssignment(db, {
+		attemptId: draft.attemptId,
+		deviceRef: device.deviceRef,
+		targetIdentityId: "identity-a",
+		expectation: device.expectation,
+		now: NOW,
+	});
+	draft = setLegacyTeamSetupDeviceDecision(db, {
+		attemptId: draft.attemptId,
+		deviceRef: device.deviceRef,
+		decision: "included",
+		now: NOW,
+	});
+	return setLegacyTeamSetupProjectMapping(db, {
+		attemptId: draft.attemptId,
+		projectRef: "project-ref-b",
+		resolvedProjectIdentity: "https://example.invalid/repo-b.git",
+		now: NOW,
+	});
+}
+
 describe("legacy Team setup drafts", () => {
 	let db: InstanceType<typeof Database>;
 
@@ -866,6 +891,108 @@ describe("legacy Team setup drafts", () => {
 		db.prepare("UPDATE actors SET status = 'deactivated' WHERE actor_id = 'identity-a'").run();
 
 		expect(getLegacyTeamSetupDraft(db, CANDIDATE)?.canFinish).toBe(false);
+	});
+
+	it.each([
+		[
+			"the coordinator group has no active scope",
+			() => {
+				db.prepare("UPDATE replication_scopes SET status = 'retired'").run();
+			},
+		],
+		[
+			"a new mapping is ambiguous across active scopes",
+			() => {
+				db.prepare(
+					`INSERT INTO replication_scopes(
+					 scope_id, label, kind, authority_type, coordinator_id, group_id,
+					 membership_epoch, status, created_at, updated_at
+					 ) VALUES ('scope-draft-2', 'Engineering 2', 'managed_project', 'coordinator',
+					 'coordinator-private', 'group-private', 1, 'active', ?, ?)`,
+				).run(NOW, NOW);
+			},
+		],
+		[
+			"a foreign mapping conflicts with the source pattern",
+			() => {
+				db.prepare(
+					`INSERT INTO project_scope_mappings(
+					 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+					 ) VALUES ('https://example.invalid/foreign.git', 'unmapped:repo-b',
+					 'scope-foreign', 1000, 'user', ?, ?)`,
+				).run(NOW, NOW);
+			},
+		],
+		[
+			"another active Team claims the Project",
+			() => {
+				db.prepare(
+					`INSERT INTO project_recipients(
+					 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+					 policy_revision, migration_state, idempotency_key, created_at, updated_at
+					 ) VALUES ('https://example.invalid/repo-a.git', 'team', 'policy-team-v1:foreign',
+					 'active', 'user', 'r1', 'completed', 'foreign-team-claim', ?, ?)`,
+				).run(NOW, NOW);
+			},
+		],
+		[
+			"an active Project recipient has an unsupported kind",
+			() => {
+				db.prepare(
+					`INSERT INTO project_recipients(
+					 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+					 policy_revision, migration_state, idempotency_key, created_at, updated_at
+					 ) VALUES ('https://example.invalid/repo-a.git', 'service', 'service-a',
+					 'active', 'user', 'r1', 'completed', 'unsupported-recipient', ?, ?)`,
+				).run(NOW, NOW);
+			},
+		],
+	] as const)("reports canFinish false when %s", (_label, createConflict) => {
+		createConflict();
+
+		const draft = readyDraft(db);
+
+		expect(draft.canFinish).toBe(false);
+	});
+
+	it("keeps canFinish true for selected mappings across scopes and a direct Identity recipient", () => {
+		db.prepare(
+			`INSERT INTO replication_scopes(
+			 scope_id, label, kind, authority_type, coordinator_id, group_id,
+			 membership_epoch, status, created_at, updated_at
+			 ) VALUES ('scope-draft-2', 'Engineering 2', 'managed_project', 'coordinator',
+			 'coordinator-private', 'group-private', 1, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const insertMapping = db.prepare(
+			`INSERT INTO project_scope_mappings(
+			 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, ?, ?, 1000, 'user', ?, ?)`,
+		);
+		insertMapping.run(
+			"https://example.invalid/repo-a.git",
+			"https://example.invalid/repo-a.git",
+			"scope-draft",
+			NOW,
+			NOW,
+		);
+		insertMapping.run(
+			"https://example.invalid/repo-b.git",
+			"unmapped:repo-b",
+			"scope-draft-2",
+			NOW,
+			NOW,
+		);
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, idempotency_key, created_at, updated_at
+			 ) VALUES ('https://example.invalid/repo-a.git', 'identity', 'identity-a',
+			 'active', 'user', 'r1', 'completed', 'direct-identity-recipient', ?, ?)`,
+		).run(NOW, NOW);
+
+		const draft = readyDraft(db);
+
+		expect(draft.canFinish).toBe(true);
 	});
 
 	it("revalidates the selected identity when saving an included decision", () => {

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
 import type { Database } from "./db.js";
+import { isLegacyTeamProjectCanonicalStateValid } from "./legacy-team-project-canonical-preflight.js";
 import {
 	compareCodepoints,
+	deterministicPolicyTeamId,
 	legacyTeamRosterFingerprint,
 	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
@@ -113,10 +115,95 @@ interface DeviceRow {
 
 interface ProjectRow {
 	project_ref: string;
+	source_project_identity: string;
 	display_name: string;
 	source_fingerprint: string;
 	resolution_kind: LegacyTeamProjectResolution;
 	resolved_project_identity: string | null;
+}
+
+function projectCanonicalStateValid(
+	db: Database,
+	draft: { candidate_id: string; coordinator_id: string; group_id: string },
+	projects: ProjectRow[],
+): boolean {
+	if (projects.length === 0) return true;
+	const sourceProjectIdentities = [
+		...new Set(projects.map((project) => project.source_project_identity)),
+	];
+	const resolvedProjectIdentities = [
+		...new Set(
+			projects.flatMap((project) =>
+				project.resolved_project_identity ? [project.resolved_project_identity] : [],
+			),
+		),
+	];
+	const scopeIds = db
+		.prepare(
+			`SELECT scope_id FROM replication_scopes
+			 WHERE coordinator_id = ? AND group_id = ? AND status = 'active'
+			 ORDER BY scope_id`,
+		)
+		.pluck()
+		.all(draft.coordinator_id, draft.group_id) as string[];
+	const groupScopeIds = db
+		.prepare(
+			`SELECT scope_id FROM replication_scopes
+			 WHERE coordinator_id = ? AND group_id = ? ORDER BY scope_id`,
+		)
+		.pluck()
+		.all(draft.coordinator_id, draft.group_id) as string[];
+	const mappings = db
+		.prepare(
+			`SELECT workspace_identity, project_pattern, scope_id, source
+			 FROM project_scope_mappings
+			 WHERE project_pattern IN (${sourceProjectIdentities.map(() => "?").join(", ")})
+			 ORDER BY id`,
+		)
+		.all(...sourceProjectIdentities) as Array<{
+		workspace_identity: string | null;
+		project_pattern: string;
+		scope_id: string;
+		source: string | null;
+	}>;
+	const recipients =
+		resolvedProjectIdentities.length === 0
+			? []
+			: (db
+					.prepare(
+						`SELECT canonical_project_identity, recipient_kind, recipient_id, status
+						 FROM project_recipients
+						 WHERE canonical_project_identity IN (${resolvedProjectIdentities.map(() => "?").join(", ")})
+						 ORDER BY canonical_project_identity, recipient_kind, recipient_id`,
+					)
+					.all(...resolvedProjectIdentities) as Array<{
+					canonical_project_identity: string;
+					recipient_kind: string;
+					recipient_id: string;
+					status: string;
+				}>);
+
+	return isLegacyTeamProjectCanonicalStateValid({
+		teamId: deterministicPolicyTeamId(draft.candidate_id),
+		scopeIds,
+		groupScopeIds,
+		projects: projects.map((project) => ({
+			sourceProjectIdentity: project.source_project_identity,
+			resolvedProjectIdentity: project.resolved_project_identity,
+		})),
+		mappings: mappings.map((mapping) => ({
+			workspaceIdentity: mapping.workspace_identity,
+			projectPattern: mapping.project_pattern,
+			scopeId: mapping.scope_id,
+			source: mapping.source,
+		})),
+		recipients: recipients.map((recipient) => ({
+			canonicalProjectIdentity: recipient.canonical_project_identity,
+			recipientKind: recipient.recipient_kind,
+			recipientId: recipient.recipient_id,
+			status: recipient.status,
+		})),
+	});
 }
 
 /**
@@ -387,7 +474,8 @@ function createAttempt(
 	const previousProjects = previousAttemptId
 		? (db
 				.prepare(
-					`SELECT project_ref, display_name, source_fingerprint, resolution_kind,
+					`SELECT project_ref, source_project_identity, display_name, source_fingerprint,
+					        resolution_kind,
 					        resolved_project_identity
 					 FROM legacy_team_setup_draft_projects WHERE attempt_id = ?`,
 				)
@@ -463,7 +551,7 @@ function loadDraftView(db: Database, attemptId: string): LegacyTeamSetupDraftVie
 		.all(attemptId) as DeviceRow[];
 	const projectRows = db
 		.prepare(
-			`SELECT project_ref, display_name, source_fingerprint, resolution_kind,
+			`SELECT project_ref, source_project_identity, display_name, source_fingerprint, resolution_kind,
 			        resolved_project_identity
 			 FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref`,
 		)
@@ -528,32 +616,29 @@ function loadDraftView(db: Database, attemptId: string): LegacyTeamSetupDraftVie
 			resolvedProjectIdentity: row.resolved_project_identity,
 		})),
 	});
-	// Activation refuses to write mappings without an active scope for the
-	// group; advertising a finishable draft that activation will always reject
-	// would discard the user's review when the conflict stales the attempt.
-	const scopeAuthorityValid =
-		projectRows.length === 0 ||
-		Boolean(
-			db
-				.prepare(
-					`SELECT 1 FROM replication_scopes
-					 WHERE coordinator_id = ? AND group_id = ? AND status = 'active' LIMIT 1`,
-				)
-				.get(draft.coordinator_id, draft.group_id),
-		);
+	const reviewComplete =
+		(draft.state === "needs_setup" || draft.state === "in_progress") &&
+		unresolvedDeviceCount === 0 &&
+		unresolvedProjectCount === 0 &&
+		includedTargetsValid &&
+		assignmentExpectationsValid &&
+		(projectRows.length === 0 ||
+			Boolean(
+				db
+					.prepare(
+						`SELECT 1 FROM replication_scopes
+						 WHERE coordinator_id = ? AND group_id = ? AND status = 'active' LIMIT 1`,
+					)
+					.get(draft.coordinator_id, draft.group_id),
+			)) &&
+		projectCanonicalStateValid(db, draft, projectRows);
 	return {
 		attemptId,
 		candidateRef: draft.candidate_id,
 		state: draft.state,
 		displayName: draft.display_name,
 		finishDigest,
-		canFinish:
-			(draft.state === "needs_setup" || draft.state === "in_progress") &&
-			unresolvedDeviceCount === 0 &&
-			unresolvedProjectCount === 0 &&
-			includedTargetsValid &&
-			assignmentExpectationsValid &&
-			scopeAuthorityValid,
+		canFinish: reviewComplete,
 		unresolvedDeviceCount,
 		unresolvedProjectCount,
 		// The coordinator key fingerprint stays in persisted CAS state only:


### PR DESCRIPTION
## Description

- extract the pure Project canonical-state preflight into an internal shared predicate
- reuse it from draft `canFinish` and activation validation
- preserve activation revalidation inside `BEGIN IMMEDIATE` and zero-active-scope timing
- add direct predicate, draft parity, and under-lock conflict coverage
- document that post-write selected-mapping precedence remains activation-only

Closes `codemem-5ms5.1`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, core Vitest suite)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation: 140 focused tests passed; 3,229 core tests passed with 3 todo; Snyk Code reported 0 high-severity issues.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced