### PR TITLE
fix(core): bound legacy Team setup drafts

### DIFF
--- a/docs/plans/2026-08-23-legacy-team-draft-limits-design.md
+++ b/docs/plans/2026-08-23-legacy-team-draft-limits-design.md
@@ -1,0 +1,44 @@
+# Legacy Team Draft Limits and Retryability
+
+**Date:** 2026-08-23
+
+**Status:** Approved
+
+## Problem
+
+Legacy Team activation rejects drafts with more than 500 Devices or 500 Projects, but draft creation currently accepts unbounded snapshots. That can create an attempt that can never activate and lets Project-based readiness queries exceed SQLite's bound-parameter limit. Refresh also carries reviewed removed Devices into replacement attempts, so the effective row count can exceed the raw coordinator roster.
+
+Activation also marks every `team_setup_conflict` attempt stale. Canonical conflicts remain fail-closed, but many can clear when external canonical state changes. Staling the attempt discards valid review work without improving authorization safety.
+
+## Decision
+
+Use shared internal limits of 500 Devices and 500 Projects in both draft and activation paths.
+
+Draft refresh will reject an oversized snapshot with `legacy_team_setup_roster_too_large` before fingerprinting, assignment lookups, or draft row creation. Replacement attempts will also validate the effective Device union after adding previously reviewed removed Devices. An oversized refresh leaves the current attempt unchanged.
+
+Multi-candidate discovery treats that error as local to the oversized coordinator group and continues returning other reviewable candidates. Carried Device rows are not silently discarded to fit the limit: they represent unresolved or reviewed removal work required by the all-Devices-accounted invariant. A candidate remains bounded and blocked until its current roster plus required carried rows fit the shared limit.
+
+`team_setup_conflict` remains an activation error and continues to block all writes. Persisting that safe error will no longer mark the attempt stale. Roster, Project-inventory, and assignment evidence changes remain terminal for the reviewed snapshot and continue to stale it.
+
+## Boundaries
+
+- The limits helper remains internal to `packages/core`.
+- The error string remains one bounded snapshot error for both Device and Project overflow.
+- `refreshLegacyTeamSetupDraft` exposes the new bounded error to direct callers; multi-candidate discovery handles it per group.
+- No schema or public response shape changes.
+- Retryability changes only attempt preservation; it does not bypass preview, confirmation, canonical validation, or locked revalidation.
+- Existing exact replay and confirmation-staleness behavior is unchanged.
+
+## Verification
+
+Tests will cover:
+
+- exactly 500 and 501 Devices;
+- exactly 500 and 501 Projects;
+- overflow caused by carried removed Devices;
+- pre-limit attempts that already contain more than 500 stored Device rows;
+- discovery and direct refresh rejecting before assignment reads;
+- no partial attempt rows after rejection;
+- preservation of an existing reviewed attempt after oversized refresh;
+- preservation of review state after `team_setup_conflict`; and
+- continued staling after roster, projection, or assignment evidence changes.

--- a/docs/plans/2026-08-23-legacy-team-draft-limits-implementation.md
+++ b/docs/plans/2026-08-23-legacy-team-draft-limits-implementation.md
@@ -1,0 +1,32 @@
+# Legacy Team Draft Limits Implementation Plan
+
+**Date:** 2026-08-23
+
+**Design:** `2026-08-23-legacy-team-draft-limits-design.md`
+
+## 1. Share limits
+
+- Add an internal module for the 500-Device and 500-Project limits.
+- Import those constants from draft and activation code.
+- Preserve activation's existing size-check behavior.
+
+## 2. Bound draft refresh
+
+- Validate raw snapshot counts before fingerprints, assignment reads, or transactions that write attempts.
+- Before creating a replacement attempt, construct the effective Device union with carried removed Devices and validate it.
+- Count carried rows in SQL so pre-limit oversized attempts are not materialized in application memory.
+- Perform the union check before inserting the parent draft row.
+- Throw `legacy_team_setup_roster_too_large` and leave any current attempt untouched.
+- Skip only the oversized coordinator group during multi-candidate discovery; direct single-candidate refresh remains explicit and throws.
+
+## 3. Preserve retryable conflicts
+
+- Keep recording `team_setup_conflict` in `safe_error_code`.
+- Remove it from the set of errors that transition the attempt to `stale`.
+- Keep roster, projection, and assignment change codes in the terminal set.
+
+## 4. Test and validate
+
+- Add draft boundary, no-partial-write, carried-overflow, and preservation tests.
+- Add activation retryability and terminal-staleness tests.
+- Run focused Vitest files, TypeScript, lint, core tests, and diff checks.

--- a/packages/core/src/legacy-team-candidate.test.ts
+++ b/packages/core/src/legacy-team-candidate.test.ts
@@ -8,7 +8,10 @@ import {
 	legacyTeamCandidateProjectInventory,
 	refreshLegacyTeamCandidate,
 } from "./legacy-team-candidate.js";
-import { deterministicPolicyTeamId } from "./recipient-policy-identifiers.js";
+import {
+	deterministicPolicyTeamId,
+	legacyTeamCandidateId,
+} from "./recipient-policy-identifiers.js";
 import { canonicalWorkspaceIdentity } from "./scope-resolution.js";
 import { shareProjectSetDigest } from "./share-operation.js";
 import { initTestSchema } from "./test-utils.js";
@@ -95,6 +98,81 @@ describe("legacy Team candidate discovery", () => {
 		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_draft_projects").pluck().get()).toBe(
 			1,
 		);
+	});
+
+	it("skips an oversized group without aborting other candidate discovery", () => {
+		const input = options();
+		input.groups.unshift({
+			coordinatorId: "coordinator-oversized",
+			groupId: "group-oversized",
+			displayName: "Oversized",
+			devices: Array.from({ length: 501 }, (_, index) => ({
+				deviceId: `oversized-device-${index}`,
+				fingerprint: `oversized-key-${index}`,
+				displayName: `Oversized Device ${index}`,
+				enabled: true,
+			})),
+		});
+
+		const candidates = discoverLegacyTeamCandidates(db, input);
+
+		expect(candidates).toHaveLength(1);
+		expect(candidates[0]?.displayName).toBe("Engineering");
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(1);
+	});
+
+	it("skips oversized existing candidates before changing their state", () => {
+		const initial = options();
+		const [candidate] = discoverLegacyTeamCandidates(db, initial);
+		const oversized = options();
+		const [oversizedGroup] = oversized.groups;
+		if (!oversizedGroup) throw new Error("test_fixture_missing_group");
+		oversizedGroup.devices = Array.from({ length: 501 }, (_, index) => ({
+			deviceId: `oversized-device-${index}`,
+			fingerprint: `oversized-key-${index}`,
+			displayName: `Oversized Device ${index}`,
+			enabled: true,
+		}));
+
+		expect(discoverLegacyTeamCandidates(db, oversized)).toEqual([]);
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE candidate_id = ?")
+				.pluck()
+				.get(candidate?.candidateRef),
+		).toBe("needs_setup");
+
+		db.prepare("UPDATE legacy_team_setup_drafts SET state = 'stale'").run();
+
+		expect(discoverLegacyTeamCandidates(db, oversized)).toEqual([]);
+		expect(db.prepare("SELECT state FROM legacy_team_setup_drafts").pluck().get()).toBe("stale");
+	});
+
+	it("rejects oversized single-candidate refreshes before assignment reads", () => {
+		const input = options();
+		const [group] = input.groups;
+		if (!group) throw new Error("test_fixture_missing_group");
+		group.devices = Array.from({ length: 501 }, (_, index) => ({
+			deviceId: `oversized-device-${index}`,
+			fingerprint: `oversized-key-${index}`,
+			displayName: `Oversized Device ${index}`,
+			enabled: true,
+		}));
+		const prepare = vi.spyOn(db, "prepare");
+
+		expect(() =>
+			refreshLegacyTeamCandidate(
+				db,
+				input,
+				legacyTeamCandidateId(group.coordinatorId, group.groupId),
+			),
+		).toThrow("legacy_team_setup_roster_too_large");
+		expect(
+			prepare.mock.calls.some(([sql]) =>
+				String(sql).includes("SELECT identity_id FROM identity_devices"),
+			),
+		).toBe(false);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(0);
 	});
 
 	it("retains coordinator-backed ambiguous Projects without exposing public Team intent", () => {

--- a/packages/core/src/legacy-team-candidate.ts
+++ b/packages/core/src/legacy-team-candidate.ts
@@ -12,6 +12,10 @@ import {
 	refreshLegacyTeamSetupDraft,
 	refreshLegacyTeamSetupDraftLabels,
 } from "./legacy-team-setup-draft.js";
+import {
+	requireLegacyTeamSetupEffectiveDevicesWithinLimit,
+	requireLegacyTeamSetupSnapshotWithinLimits,
+} from "./legacy-team-setup-limits.js";
 import { derivePolicyTeamDeviceEligibility } from "./policy-team-device-eligibility.js";
 import {
 	compareCodepoints,
@@ -567,6 +571,10 @@ function candidateStatus(
 	return "needs_setup";
 }
 
+function isRosterTooLargeError(error: unknown): boolean {
+	return error instanceof Error && error.message === "legacy_team_setup_roster_too_large";
+}
+
 export function discoverLegacyTeamCandidates(
 	db: Database,
 	options: DiscoverLegacyTeamCandidatesOptions,
@@ -586,62 +594,72 @@ export function discoverLegacyTeamCandidates(
 		// currently displayed Project still needs a reviewable roster so the
 		// Team can become ready for future sharing.
 		const projects = projectInventory(candidateId, evidence);
-		const rosterFingerprint = legacyTeamRosterFingerprint(
-			rosterDevices.map((device) => ({
-				deviceId: device.deviceId,
-				fingerprint: device.fingerprint,
-				enabled: device.enabled,
-				identityId: activeAssignmentIdentity(db, device.deviceId),
-			})),
-		);
-		const expectedProjectionFingerprint = legacyTeamProjectionFingerprint(projects);
 		const row = currentDraftRow(db, candidateId);
-		const ready =
-			row?.state === "completed" &&
-			row.roster_fingerprint === rosterFingerprint &&
-			completedInventoryCompatible(db, row.attempt_id, projects) &&
-			isCompatibleReadyTeam(db, candidateId, row, rosterFingerprint);
 		let draft: LegacyTeamSetupDraftView;
-		if (!row || (row.state === "completed" && !ready)) {
-			draft = refreshLegacyTeamSetupDraft(db, {
-				candidateId,
-				coordinatorId,
-				groupId,
-				displayName: group.displayName,
-				devices: rosterDevices,
-				projects,
-				now,
-			});
-		} else if (row.state === "completed") {
-			draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
-				displayName: group.displayName,
-				devices: rosterDevices,
-				projects,
-				now,
-			});
-		} else if (row.state === "stale") {
-			draft = requireLegacyTeamSetupDraft(db, candidateId);
-		} else if (
-			row.roster_fingerprint !== rosterFingerprint ||
-			row.projection_fingerprint !== expectedProjectionFingerprint
-		) {
-			if (row.state === "needs_setup" || row.state === "in_progress") {
-				db.prepare(
-					`UPDATE legacy_team_setup_drafts SET state = 'stale', updated_at = ?
-					 WHERE attempt_id = ?`,
-				).run(now, row.attempt_id);
+		let ready = false;
+		try {
+			requireLegacyTeamSetupSnapshotWithinLimits({ devices: rosterDevices, projects });
+			requireLegacyTeamSetupEffectiveDevicesWithinLimit(db, rosterDevices, row?.attempt_id ?? null);
+			const rosterFingerprint = legacyTeamRosterFingerprint(
+				rosterDevices.map((device) => ({
+					deviceId: device.deviceId,
+					fingerprint: device.fingerprint,
+					enabled: device.enabled,
+					identityId: activeAssignmentIdentity(db, device.deviceId),
+				})),
+			);
+			const expectedProjectionFingerprint = legacyTeamProjectionFingerprint(projects);
+			ready =
+				row?.state === "completed" &&
+				row.roster_fingerprint === rosterFingerprint &&
+				completedInventoryCompatible(db, row.attempt_id, projects) &&
+				isCompatibleReadyTeam(db, candidateId, row, rosterFingerprint);
+			if (!row || (row.state === "completed" && !ready)) {
+				draft = refreshLegacyTeamSetupDraft(db, {
+					candidateId,
+					coordinatorId,
+					groupId,
+					displayName: group.displayName,
+					devices: rosterDevices,
+					projects,
+					now,
+				});
+			} else if (row.state === "completed") {
+				draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
+					displayName: group.displayName,
+					devices: rosterDevices,
+					projects,
+					now,
+				});
+			} else if (row.state === "stale") {
+				draft = requireLegacyTeamSetupDraft(db, candidateId);
+			} else if (
+				row.roster_fingerprint !== rosterFingerprint ||
+				row.projection_fingerprint !== expectedProjectionFingerprint
+			) {
+				if (row.state === "needs_setup" || row.state === "in_progress") {
+					db.prepare(
+						`UPDATE legacy_team_setup_drafts SET state = 'stale', updated_at = ?
+						 WHERE attempt_id = ?`,
+					).run(now, row.attempt_id);
+				}
+				draft = requireLegacyTeamSetupDraft(db, candidateId);
+			} else {
+				draft = refreshLegacyTeamSetupDraft(db, {
+					candidateId,
+					coordinatorId,
+					groupId,
+					displayName: group.displayName,
+					devices: rosterDevices,
+					projects,
+					now,
+				});
 			}
-			draft = requireLegacyTeamSetupDraft(db, candidateId);
-		} else {
-			draft = refreshLegacyTeamSetupDraft(db, {
-				candidateId,
-				coordinatorId,
-				groupId,
-				displayName: group.displayName,
-				devices: rosterDevices,
-				projects,
-				now,
-			});
+		} catch (error) {
+			// Oversized evidence is local to this coordinator group. It must not
+			// hide otherwise reviewable candidates discovered in the same pass.
+			if (isRosterTooLargeError(error)) continue;
+			throw error;
 		}
 		candidates.push({
 			candidateRef: candidateId,
@@ -687,6 +705,9 @@ export function refreshLegacyTeamCandidate(
 		const { candidateId, coordinatorId, groupId, devices: rosterDevices } = group;
 		if (candidateId !== candidateRef) continue;
 		const projects = projectInventory(candidateId, evidence);
+		const row = currentDraftRow(db, candidateId);
+		requireLegacyTeamSetupSnapshotWithinLimits({ devices: rosterDevices, projects });
+		requireLegacyTeamSetupEffectiveDevicesWithinLimit(db, rosterDevices, row?.attempt_id ?? null);
 		// A compatible Ready completion with unchanged evidence survives an
 		// explicit refresh: only labels update. Creating a replacement attempt
 		// here would immediately drop Ready and force a redundant review cycle.
@@ -698,7 +719,6 @@ export function refreshLegacyTeamCandidate(
 				identityId: activeAssignmentIdentity(db, device.deviceId),
 			})),
 		);
-		const row = currentDraftRow(db, candidateId);
 		if (
 			row?.state === "completed" &&
 			row.roster_fingerprint === rosterFingerprint &&

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -579,6 +579,12 @@ describe("legacy Team setup activation", () => {
 		await expect(operation).rejects.toThrow("team_setup_roster_changed");
 		expect(loadFreshRoster).toHaveBeenCalledOnce();
 		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId),
+		).toBe("stale");
 	});
 
 	it("returns roster unavailable after a failed pre-lock fetch without canonical writes", async () => {
@@ -625,6 +631,12 @@ describe("legacy Team setup activation", () => {
 				.get(),
 		).toBe("identity-b");
 		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId),
+		).toBe("stale");
 	});
 
 	it.each([
@@ -667,6 +679,11 @@ describe("legacy Team setup activation", () => {
 		// Assert
 		await expect(operation).rejects.toThrow("team_setup_conflict");
 		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions").pluck().get()).toBe(0);
+		expect(
+			db
+				.prepare("SELECT state, safe_error_code FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.get(draft.attemptId),
+		).toEqual({ state: "in_progress", safe_error_code: "team_setup_conflict" });
 	});
 
 	it("revalidates Project canonical state after the pre-lock model was accepted", async () => {

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -9,6 +9,10 @@ import {
 	type LegacyTeamSetupProjectInput,
 	legacyTeamProjectionFingerprint,
 } from "./legacy-team-setup-draft.js";
+import {
+	LEGACY_TEAM_SETUP_MAX_DEVICES,
+	LEGACY_TEAM_SETUP_MAX_PROJECTS,
+} from "./legacy-team-setup-limits.js";
 import type {
 	LegacyTeamSetupAccessDeltaV1,
 	LegacyTeamSetupActivationPreviewV1,
@@ -225,8 +229,6 @@ interface CompletionRow {
 const SETUP_MEMBERSHIP_PROVENANCE = "reviewed_active";
 /** Provenance written by the historical `choose_recipients` migration path. */
 const HISTORICAL_TEAM_PROVENANCE = "reviewed_team_candidate";
-const MAX_ACTIVATION_DEVICES = 500;
-const MAX_ACTIVATION_PROJECTS = 500;
 
 function parseJsonObject(json: string): Record<string, unknown> | null {
 	try {
@@ -319,12 +321,12 @@ function persistSafeError(
 ): void {
 	// Confirmation staleness is a property of the caller's tokens (for example
 	// a stale tab), not of the draft: the attempt stays valid and retryable
-	// with fresh tokens. Only real canonical-evidence changes stale the draft.
+	// with fresh tokens. Retryable canonical conflicts can clear externally;
+	// only changes to evidence captured by this review stale the draft.
 	const stale = [
 		"team_setup_roster_changed",
 		"team_setup_projection_changed",
 		"team_setup_assignment_changed",
-		"team_setup_conflict",
 	].includes(error.code);
 	try {
 		db.prepare(
@@ -374,10 +376,10 @@ function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): 
 		.all(input.attemptId) as DraftProjectRow[];
 	if (
 		devices.length === 0 ||
-		devices.length > MAX_ACTIVATION_DEVICES ||
+		devices.length > LEGACY_TEAM_SETUP_MAX_DEVICES ||
 		// A configured group without displayed Projects is a valid setup: the
 		// reviewed Team becomes ready for future sharing with no mappings yet.
-		projects.length > MAX_ACTIVATION_PROJECTS ||
+		projects.length > LEGACY_TEAM_SETUP_MAX_PROJECTS ||
 		devices.some(
 			(device) =>
 				device.decision === "unresolved" ||
@@ -1206,7 +1208,9 @@ function validateFreshRoster(
 	model: ActivationModel,
 	freshRoster: Awaited<ReturnType<FinishLegacyTeamSetupActivationInput["loadFreshRoster"]>>,
 ): void {
-	if (freshRoster.length > MAX_ACTIVATION_DEVICES) activationError("team_setup_roster_changed");
+	if (freshRoster.length > LEGACY_TEAM_SETUP_MAX_DEVICES) {
+		activationError("team_setup_roster_changed");
+	}
 	// Draft creation fingerprints a device's identity only from an active
 	// assignment (`identityId: assignment?.active ? ... : null`). An inactive
 	// row's stored identity must not contribute here, or an unchanged fresh

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -47,6 +47,28 @@ function snapshot(overrides: { fingerprint?: string; deviceName?: string } = {})
 	};
 }
 
+function devices(count: number, start = 0) {
+	return Array.from({ length: count }, (_, index) => {
+		const id = index + start;
+		return {
+			deviceId: `device-${id}`,
+			fingerprint: `key-${id}`,
+			displayName: `Device ${id}`,
+			enabled: true,
+		};
+	});
+}
+
+function projects(count: number) {
+	return Array.from({ length: count }, (_, index) => ({
+		projectRef: `project-ref-${index}`,
+		sourceProjectIdentity: `https://example.invalid/repo-${index}.git`,
+		displayName: `Project ${index}`,
+		sourceFingerprint: `source-${index}`,
+		deterministicProjectIdentity: `https://example.invalid/repo-${index}.git`,
+	}));
+}
+
 function readyDraft(db: InstanceType<typeof Database>) {
 	let draft = refreshLegacyTeamSetupDraft(db, snapshot());
 	const device = draft.devices[0];
@@ -463,6 +485,103 @@ describe("legacy Team setup drafts", () => {
 			"legacy_team_setup_time_invalid",
 		);
 		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(0);
+	});
+
+	it("accepts exactly 500 Devices", () => {
+		const draft = refreshLegacyTeamSetupDraft(db, { ...snapshot(), devices: devices(500) });
+
+		expect(draft.devices).toHaveLength(500);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(1);
+	});
+
+	it("rejects 501 Devices without creating partial attempt rows", () => {
+		expect(() => refreshLegacyTeamSetupDraft(db, { ...snapshot(), devices: devices(501) })).toThrow(
+			"legacy_team_setup_roster_too_large",
+		);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(0);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_draft_devices").pluck().get()).toBe(
+			0,
+		);
+	});
+
+	it("preserves the current reviewed attempt after raw snapshot overflow", () => {
+		const reviewed = readyDraft(db);
+		const before = getLegacyTeamSetupDraft(db, CANDIDATE);
+
+		expect(() => refreshLegacyTeamSetupDraft(db, { ...snapshot(), devices: devices(501) })).toThrow(
+			"legacy_team_setup_roster_too_large",
+		);
+		expect(getLegacyTeamSetupDraft(db, CANDIDATE)).toEqual(before);
+		expect(getLegacyTeamSetupDraft(db, CANDIDATE)?.attemptId).toBe(reviewed.attemptId);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(1);
+	});
+
+	it("accepts exactly 500 Projects", () => {
+		const draft = refreshLegacyTeamSetupDraft(db, { ...snapshot(), projects: projects(500) });
+
+		expect(draft.projects).toHaveLength(500);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(1);
+	});
+
+	it("rejects 501 Projects without creating partial attempt rows", () => {
+		expect(() =>
+			refreshLegacyTeamSetupDraft(db, { ...snapshot(), projects: projects(501) }),
+		).toThrow("legacy_team_setup_roster_too_large");
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(0);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_draft_projects").pluck().get()).toBe(
+			0,
+		);
+	});
+
+	it("rejects carried-device overflow and preserves the reviewed attempt", () => {
+		const current = refreshLegacyTeamSetupDraft(db, { ...snapshot(), devices: devices(500) });
+		db.prepare(
+			"UPDATE legacy_team_setup_drafts SET state = 'in_progress' WHERE attempt_id = ?",
+		).run(current.attemptId);
+		const before = db
+			.prepare(
+				`SELECT attempt_id, state, finish_digest, superseded_at, updated_at
+				 FROM legacy_team_setup_drafts WHERE attempt_id = ?`,
+			)
+			.get(current.attemptId);
+
+		expect(() =>
+			refreshLegacyTeamSetupDraft(db, { ...snapshot(), devices: devices(500, 1) }),
+		).toThrow("legacy_team_setup_roster_too_large");
+		expect(
+			db
+				.prepare(
+					`SELECT attempt_id, state, finish_digest, superseded_at, updated_at
+					 FROM legacy_team_setup_drafts WHERE attempt_id = ?`,
+				)
+				.get(current.attemptId),
+		).toEqual(before);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(1);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_draft_devices").pluck().get()).toBe(
+			500,
+		);
+	});
+
+	it("rejects oversized attempts created before draft limits", () => {
+		const current = refreshLegacyTeamSetupDraft(db, { ...snapshot(), devices: devices(500) });
+		db.prepare(
+			`INSERT INTO legacy_team_setup_draft_devices(
+				attempt_id, device_id, device_ref, key_fingerprint, display_name, enabled,
+				existing_identity_id, existing_assignment_version, verified_evidence_kind,
+				decision, target_identity_id, expected_assignment_kind,
+				expected_assignment_version, updated_at
+			 ) VALUES (?, 'legacy-extra', 'legacy-extra-ref', 'legacy-extra-key',
+			           'Legacy extra', 0, NULL, NULL, NULL, 'unresolved', NULL,
+			           'absent', NULL, ?)`,
+		).run(current.attemptId, NOW);
+
+		expect(() => refreshLegacyTeamSetupDraft(db, { ...snapshot(), devices: [] })).toThrow(
+			"legacy_team_setup_roster_too_large",
+		);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(1);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_draft_devices").pluck().get()).toBe(
+			501,
+		);
 	});
 
 	it("rejects non-canonical explicit Project resolution targets", () => {

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -2,6 +2,10 @@ import { randomUUID } from "node:crypto";
 import type { Database } from "./db.js";
 import { isLegacyTeamProjectCanonicalStateValid } from "./legacy-team-project-canonical-preflight.js";
 import {
+	requireLegacyTeamSetupEffectiveDevicesWithinLimit,
+	requireLegacyTeamSetupSnapshotWithinLimits,
+} from "./legacy-team-setup-limits.js";
+import {
 	compareCodepoints,
 	deterministicPolicyTeamId,
 	legacyTeamRosterFingerprint,
@@ -738,12 +742,26 @@ function storedAssignmentEvidenceMatches(
 		});
 }
 
+/**
+ * Creates or refreshes a bounded setup attempt.
+ *
+ * @throws `legacy_team_setup_roster_too_large` when the supplied snapshot or
+ * its effective Device union exceeds the shared activation limits.
+ * @throws `legacy_team_setup_time_invalid` when `now` is not a valid timestamp.
+ */
 export function refreshLegacyTeamSetupDraft(
 	db: Database,
 	input: LegacyTeamSetupDraftSnapshotInput,
 ): LegacyTeamSetupDraftView {
+	requireLegacyTeamSetupSnapshotWithinLimits(input);
 	const now = validatedNow(input.now);
 	return db.transaction(() => {
+		const existing = currentDraft(db, input.candidateId);
+		requireLegacyTeamSetupEffectiveDevicesWithinLimit(
+			db,
+			input.devices,
+			existing?.attempt_id ?? null,
+		);
 		const assignmentSnapshots = input.devices.map((device) => ({
 			device,
 			assignment: assignmentForDevice(db, device.deviceId),
@@ -758,7 +776,6 @@ export function refreshLegacyTeamSetupDraft(
 		}));
 		const rosterFingerprint = legacyTeamRosterFingerprint(assignments);
 		const projectFingerprint = legacyTeamProjectionFingerprint(input.projects);
-		const existing = currentDraft(db, input.candidateId);
 		if (
 			existing &&
 			(existing.state === "needs_setup" || existing.state === "in_progress") &&

--- a/packages/core/src/legacy-team-setup-limits.ts
+++ b/packages/core/src/legacy-team-setup-limits.ts
@@ -1,0 +1,39 @@
+import type { Database } from "./db.js";
+
+export const LEGACY_TEAM_SETUP_MAX_DEVICES = 500;
+export const LEGACY_TEAM_SETUP_MAX_PROJECTS = 500;
+
+export function requireLegacyTeamSetupSnapshotWithinLimits(input: {
+	devices: readonly unknown[];
+	projects: readonly unknown[];
+}): void {
+	if (
+		input.devices.length > LEGACY_TEAM_SETUP_MAX_DEVICES ||
+		input.projects.length > LEGACY_TEAM_SETUP_MAX_PROJECTS
+	) {
+		throw new Error("legacy_team_setup_roster_too_large");
+	}
+}
+
+export function requireLegacyTeamSetupEffectiveDevicesWithinLimit(
+	db: Database,
+	devices: readonly { deviceId: string }[],
+	previousAttemptId: string | null,
+): void {
+	if (!previousAttemptId) return;
+	const currentDeviceIds = [...new Set(devices.map((device) => device.deviceId))];
+	const placeholders = currentDeviceIds.map(() => "?").join(", ");
+	const excludeCurrent = placeholders ? `AND device_id NOT IN (${placeholders})` : "";
+	const carriedDeviceCount = Number(
+		db
+			.prepare(
+				`SELECT COUNT(*) FROM legacy_team_setup_draft_devices
+				 WHERE attempt_id = ? ${excludeCurrent}`,
+			)
+			.pluck()
+			.get(previousAttemptId, ...currentDeviceIds) ?? 0,
+	);
+	if (devices.length + carriedDeviceCount > LEGACY_TEAM_SETUP_MAX_DEVICES) {
+		throw new Error("legacy_team_setup_roster_too_large");
+	}
+}


### PR DESCRIPTION
## Description

Bound legacy Team setup drafts to 500 Devices and 500 Projects so oversized evidence cannot create unbounded review attempts or bypass activation limits.

- Reject raw and effective oversized snapshots before draft mutation.
- Preserve reviewed attempts for retryable conflicts while keeping roster/projection/assignment drift terminal.
- Isolate oversized coordinator groups so other candidates remain discoverable.
- Document the limits and caller-visible error behavior.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted/core Vitest)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated 175 focused tests and the full core suite: 108 files, 3,236 passed, 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced