### PR TITLE
fix(core): make legacy Team attempts authoritative

### DIFF
--- a/docs/plans/2026-08-23-legacy-team-candidate-authority-design.md
+++ b/docs/plans/2026-08-23-legacy-team-candidate-authority-design.md
@@ -1,0 +1,52 @@
+# Legacy Team candidate authority design
+
+## Goal
+
+Ensure every legacy Team candidate has one authoritative current setup attempt and that replacement decisions cannot race with another discovery or refresh writer.
+
+## Decision
+
+Use SQLite immediate transactions and insertion-order authority rather than adding schema-level generations or partial unique indexes.
+
+Each candidate read/decision/write sequence runs under an immediate transaction. Creating a replacement marks a mutable attempt stale and records `superseded_at`. A completed attempt retains its historical `completed` state and receives `superseded_at`; insertion order makes the replacement authoritative without revoking completion-bound migration evidence. Completion replay remains bound to the immutable `legacy_team_setup_completions` row.
+
+Draft mutation validates both conditions in one locked read:
+
+1. The attempt is `needs_setup` or `in_progress`.
+2. No newer attempt exists for the same candidate by SQLite `rowid`.
+
+An older attempt therefore cannot mutate even if legacy data incorrectly leaves its state mutable.
+
+## Alternatives rejected
+
+### Partial unique indexes
+
+A partial unique index could prevent two mutable rows, but it would not model replacement of completed attempts or make the preceding read/decision sequence atomic. It would also require a schema migration for an invariant already expressible through the existing insertion-order authority rule.
+
+### Generation-based optimistic concurrency
+
+An explicit generation column would make authority visible but would expand the schema and every mutation contract. Immediate transactions provide the required serialization without changing public or persisted contracts.
+
+## Transaction boundaries
+
+- `refreshLegacyTeamSetupDraft` acquires an immediate transaction before selecting the current attempt, deciding reuse or replacement, and writing child rows.
+- Candidate discovery evaluates and mutates each candidate in its own immediate transaction. One blocked or oversized candidate does not hold a transaction across unrelated groups.
+- Direct candidate refresh performs its Ready/replacement decision under one immediate transaction.
+- Existing nested draft transactions remain savepoints when called inside candidate transactions.
+
+## Compatibility
+
+- Public draft and candidate response shapes remain unchanged.
+- Existing exact completion replay remains valid.
+- Completed setup remains valid historical migration evidence after supersession.
+- Label-only refresh continues reusing the current attempt.
+- Stale attempts remain immutable and completed attempts remain selectable only until explicitly replaced.
+
+## Verification
+
+Focused tests must prove:
+
+- Replacing a completed attempt explicitly supersedes it.
+- A non-current attempt cannot accept device assignments, decisions, or Project mappings even if its state is mutable.
+- Candidate-layer coverage in the next stacked PR proves competing refresh writers serialize and leave one authoritative current attempt.
+- Existing label-only reuse and completion replay behavior remain intact.

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -563,6 +563,35 @@ describe("legacy Team setup activation", () => {
 		await expect(finish(draft, review)).resolves.toMatchObject({ status: "completed" });
 	});
 
+	it("rejects preview and finish for a mutable attempt superseded by a newer row", async () => {
+		// Arrange
+		const draft = readyDraft();
+		const review = preview(draft);
+		const replacement = refreshLegacyTeamSetupDraft(db, {
+			...snapshot(),
+			projects: [
+				...snapshot().projects,
+				{
+					projectRef: "project-ref-c",
+					sourceProjectIdentity: "https://git.example.invalid/acme/worker.git",
+					displayName: "Worker",
+					sourceFingerprint: "source-c",
+					deterministicProjectIdentity: "https://git.example.invalid/acme/worker.git",
+				},
+			],
+		});
+		expect(replacement.attemptId).not.toBe(draft.attemptId);
+		db.prepare(
+			"UPDATE legacy_team_setup_drafts SET state = 'in_progress' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+
+		// Act / Assert
+		expect(() => preview(draft)).toThrow("team_setup_confirmation_stale");
+		await expect(finish(draft, review)).rejects.toThrow("team_setup_confirmation_stale");
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions").pluck().get()).toBe(0);
+	});
+
 	it("rejects a changed roster and fetches it before opening the SQLite write transaction", async () => {
 		// Arrange
 		const draft = readyDraft();

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -346,15 +346,20 @@ function compareText(left: string, right: string): number {
 function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): ActivationModel {
 	const draft = db
 		.prepare(
-			`SELECT attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
-			        roster_fingerprint, projection_fingerprint, finish_digest
-			 FROM legacy_team_setup_drafts WHERE attempt_id = ?`,
+			`SELECT draft.attempt_id, draft.candidate_id, draft.coordinator_id, draft.group_id,
+			        draft.state, draft.display_name, draft.roster_fingerprint,
+			        draft.projection_fingerprint, draft.finish_digest,
+			        NOT EXISTS (
+			          SELECT 1 FROM legacy_team_setup_drafts AS newer
+			          WHERE newer.candidate_id = draft.candidate_id AND newer.rowid > draft.rowid
+			        ) AS is_current
+			 FROM legacy_team_setup_drafts AS draft WHERE draft.attempt_id = ?`,
 		)
-		.get(input.attemptId) as DraftRow | undefined;
+		.get(input.attemptId) as (DraftRow & { is_current: number }) | undefined;
 	if (!draft || draft.candidate_id !== input.candidateRef) {
 		activationError("team_setup_confirmation_stale");
 	}
-	if (draft.state !== "needs_setup" && draft.state !== "in_progress") {
+	if (draft.is_current === 0 || (draft.state !== "needs_setup" && draft.state !== "in_progress")) {
 		activationError("team_setup_confirmation_stale");
 	}
 

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -199,6 +199,7 @@ describe("legacy Team setup drafts", () => {
 	});
 
 	it("binds the finish digest to its attempt even for equivalent replacements", () => {
+		// Arrange
 		const first = refreshLegacyTeamSetupDraft(db, snapshot());
 		db.prepare(
 			`UPDATE legacy_team_setup_drafts
@@ -206,13 +207,107 @@ describe("legacy Team setup drafts", () => {
 			 WHERE attempt_id = ?`,
 		).run(NOW, NOW, first.attemptId);
 
+		// Act
 		const second = refreshLegacyTeamSetupDraft(db, snapshot());
 
+		// Assert
 		expect(second.attemptId).not.toBe(first.attemptId);
 		// A confirmation token from the prior attempt is never valid for the
 		// replacement review cycle.
 		expect(second.finishDigest).not.toBe(first.finishDigest);
+		expect(
+			db
+				.prepare(
+					`SELECT state, superseded_at FROM legacy_team_setup_drafts
+					 WHERE attempt_id = ?`,
+				)
+				.get(first.attemptId),
+		).toEqual({ state: "completed", superseded_at: NOW });
 		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(2);
+	});
+
+	describe.each([
+		"needs_setup",
+		"in_progress",
+	] as const)("with an older non-current attempt manually left %s", (state) => {
+		it.each([
+			[
+				"device assignment",
+				(draft: ReturnType<typeof refreshLegacyTeamSetupDraft>) =>
+					setLegacyTeamSetupDeviceAssignment(db, {
+						attemptId: draft.attemptId,
+						deviceRef: draft.devices[0]?.deviceRef as string,
+						targetIdentityId: "identity-a",
+						expectation: { kind: "absent" },
+						now: NOW,
+					}),
+			],
+			[
+				"device decision",
+				(draft: ReturnType<typeof refreshLegacyTeamSetupDraft>) =>
+					setLegacyTeamSetupDeviceDecision(db, {
+						attemptId: draft.attemptId,
+						deviceRef: draft.devices[0]?.deviceRef as string,
+						decision: "excluded",
+						now: NOW,
+					}),
+			],
+			[
+				"Project mapping",
+				(draft: ReturnType<typeof refreshLegacyTeamSetupDraft>) =>
+					setLegacyTeamSetupProjectMapping(db, {
+						attemptId: draft.attemptId,
+						projectRef: "project-ref-b",
+						resolvedProjectIdentity: "https://example.invalid/repo-b.git",
+						now: NOW,
+					}),
+			],
+		] as const)("rejects %s mutations", (_label, mutate) => {
+			// Arrange
+			const older = refreshLegacyTeamSetupDraft(db, snapshot());
+			const current = refreshLegacyTeamSetupDraft(db, snapshot({ fingerprint: `key-${state}` }));
+			db.prepare("UPDATE legacy_team_setup_drafts SET state = ? WHERE attempt_id = ?").run(
+				state,
+				older.attemptId,
+			);
+			const before = {
+				device: db
+					.prepare(
+						`SELECT decision, target_identity_id FROM legacy_team_setup_draft_devices
+						 WHERE attempt_id = ? AND device_ref = ?`,
+					)
+					.get(older.attemptId, older.devices[0]?.deviceRef),
+				project: db
+					.prepare(
+						`SELECT resolution_kind, resolved_project_identity
+						 FROM legacy_team_setup_draft_projects
+						 WHERE attempt_id = ? AND project_ref = 'project-ref-b'`,
+					)
+					.get(older.attemptId),
+			};
+
+			// Act
+			const act = () => mutate(older);
+
+			// Assert
+			expect(act).toThrow("legacy_team_setup_draft_stale");
+			expect(getLegacyTeamSetupDraft(db, CANDIDATE)?.attemptId).toBe(current.attemptId);
+			expect({
+				device: db
+					.prepare(
+						`SELECT decision, target_identity_id FROM legacy_team_setup_draft_devices
+						 WHERE attempt_id = ? AND device_ref = ?`,
+					)
+					.get(older.attemptId, older.devices[0]?.deviceRef),
+				project: db
+					.prepare(
+						`SELECT resolution_kind, resolved_project_identity
+						 FROM legacy_team_setup_draft_projects
+						 WHERE attempt_id = ? AND project_ref = 'project-ref-b'`,
+					)
+					.get(older.attemptId),
+			}).toEqual(before);
+		});
 	});
 
 	it.each([
@@ -359,7 +454,12 @@ describe("legacy Team setup drafts", () => {
 
 		const second = refreshLegacyTeamSetupDraft(db, snapshot());
 
-		expect(second.rosterFingerprint).toBe(first.rosterFingerprint);
+		const rosterFingerprint = (attemptId: string) =>
+			db
+				.prepare("SELECT roster_fingerprint FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(attemptId);
+		expect(rosterFingerprint(second.attemptId)).toBe(rosterFingerprint(first.attemptId));
 		expect(second.attemptId).not.toBe(first.attemptId);
 		expect(second.devices[0]?.expectation).toEqual({
 			kind: "existing",

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -755,7 +755,7 @@ export function refreshLegacyTeamSetupDraft(
 ): LegacyTeamSetupDraftView {
 	requireLegacyTeamSetupSnapshotWithinLimits(input);
 	const now = validatedNow(input.now);
-	return db.transaction(() => {
+	const refresh = db.transaction(() => {
 		const existing = currentDraft(db, input.candidateId);
 		requireLegacyTeamSetupEffectiveDevicesWithinLimit(
 			db,
@@ -837,6 +837,13 @@ export function refreshLegacyTeamSetupDraft(
 				 SET state = 'stale', superseded_at = ?, updated_at = ?
 				 WHERE attempt_id = ?`,
 			).run(now, now, existing.attempt_id);
+		} else if (existing?.state === "completed") {
+			// Completion remains historical authorization evidence for migration
+			// validation; insertion order makes the replacement authoritative.
+			db.prepare(
+				`UPDATE legacy_team_setup_drafts
+				 SET superseded_at = ?, updated_at = ? WHERE attempt_id = ?`,
+			).run(now, now, existing.attempt_id);
 		}
 		const attemptId = createAttempt(
 			db,
@@ -847,7 +854,8 @@ export function refreshLegacyTeamSetupDraft(
 			now,
 		);
 		return persistFinishDigest(db, attemptId);
-	})();
+	});
+	return refresh.immediate();
 }
 
 export function getLegacyTeamSetupDraft(
@@ -870,7 +878,7 @@ export function refreshLegacyTeamSetupDraftLabels(
 	input: Pick<LegacyTeamSetupDraftSnapshotInput, "displayName" | "devices" | "projects" | "now">,
 ): LegacyTeamSetupDraftView {
 	const now = validatedNow(input.now);
-	return db.transaction(() => {
+	const refreshLabels = db.transaction(() => {
 		const context = db
 			.prepare(
 				"SELECT candidate_id, coordinator_id, group_id FROM legacy_team_setup_drafts WHERE attempt_id = ?",
@@ -919,15 +927,25 @@ export function refreshLegacyTeamSetupDraftLabels(
 			);
 		}
 		return loadDraftView(db, attemptId);
-	})();
+	});
+	return refreshLabels.immediate();
 }
 
 function requireMutableAttempt(db: Database, attemptId: string): void {
 	const row = db
-		.prepare(`SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?`)
-		.get(attemptId) as { state: LegacyTeamSetupDraftState } | undefined;
+		.prepare(
+			`SELECT draft.state,
+			        NOT EXISTS (
+			          SELECT 1 FROM legacy_team_setup_drafts AS newer
+			          WHERE newer.candidate_id = draft.candidate_id
+			            AND newer.rowid > draft.rowid
+			        ) AS is_current
+			 FROM legacy_team_setup_drafts AS draft
+			 WHERE draft.attempt_id = ?`,
+		)
+		.get(attemptId) as { state: LegacyTeamSetupDraftState; is_current: number } | undefined;
 	if (!row) throw new Error("legacy_team_setup_draft_not_found");
-	if (row.state !== "needs_setup" && row.state !== "in_progress") {
+	if (row.is_current === 0 || (row.state !== "needs_setup" && row.state !== "in_progress")) {
 		throw new Error("legacy_team_setup_draft_stale");
 	}
 }
@@ -943,7 +961,7 @@ export function setLegacyTeamSetupDeviceAssignment(
 	},
 ): LegacyTeamSetupDraftView {
 	const now = validatedNow(input.now);
-	return db.transaction(() => {
+	const mutateAssignment = db.transaction(() => {
 		requireMutableAttempt(db, input.attemptId);
 		const device = db
 			.prepare(
@@ -1011,7 +1029,8 @@ export function setLegacyTeamSetupDeviceAssignment(
 			`UPDATE legacy_team_setup_drafts SET state = 'in_progress', updated_at = ? WHERE attempt_id = ?`,
 		).run(now, input.attemptId);
 		return persistFinishDigest(db, input.attemptId);
-	})();
+	});
+	return mutateAssignment.immediate();
 }
 
 export function setLegacyTeamSetupDeviceDecision(
@@ -1031,7 +1050,7 @@ export function setLegacyTeamSetupDeviceDecision(
 		throw new Error("legacy_team_setup_decision_invalid");
 	}
 	const now = validatedNow(input.now);
-	return db.transaction(() => {
+	const mutateDecision = db.transaction(() => {
 		requireMutableAttempt(db, input.attemptId);
 		const device = db
 			.prepare(
@@ -1094,7 +1113,8 @@ export function setLegacyTeamSetupDeviceDecision(
 			`UPDATE legacy_team_setup_drafts SET state = 'in_progress', updated_at = ? WHERE attempt_id = ?`,
 		).run(now, input.attemptId);
 		return persistFinishDigest(db, input.attemptId);
-	})();
+	});
+	return mutateDecision.immediate();
 }
 
 export function setLegacyTeamSetupProjectMapping(
@@ -1140,7 +1160,7 @@ export function setLegacyTeamSetupProjectMapping(
 		throw new Error("legacy_team_setup_project_mapping_invalid");
 	}
 	const now = validatedNow(input.now);
-	return db.transaction(() => {
+	const mutateMapping = db.transaction(() => {
 		requireMutableAttempt(db, input.attemptId);
 		const project = db
 			.prepare(
@@ -1168,5 +1188,6 @@ export function setLegacyTeamSetupProjectMapping(
 			`UPDATE legacy_team_setup_drafts SET state = 'in_progress', updated_at = ? WHERE attempt_id = ?`,
 		).run(now, input.attemptId);
 		return persistFinishDigest(db, input.attemptId);
-	})();
+	});
+	return mutateMapping.immediate();
 }


### PR DESCRIPTION
## Description

Make legacy Team setup attempts authoritative by insertion order. Mutable replacements become stale, completed replacements retain historical completion evidence with an explicit supersession timestamp, and non-current attempts cannot mutate even if legacy state incorrectly leaves them mutable.

This is the first half of `codemem-cads.1`; candidate-level serialization follows in #1500.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [ ] 🚀 Feature (new functionality)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`)
- [x] Added/updated tests for changes
- [x] `pnpm exec vitest run packages/core/src/legacy-team-setup-draft.test.ts packages/core/src/recipient-policy-migration.test.ts`

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced