### PR TITLE
fix(core): serialize legacy Team candidate refresh

### DIFF
--- a/packages/core/src/legacy-team-candidate.test.ts
+++ b/packages/core/src/legacy-team-candidate.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listLegacyRecipientPolicyProjections } from "./legacy-recipient-policy-projection.js";
@@ -44,42 +47,54 @@ function options(
 	};
 }
 
+function seedCandidateFixture(targetDb: InstanceType<typeof Database>): void {
+	initTestSchema(targetDb);
+	targetDb
+		.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('actor-local', 'Local Person', 1, 'active', ?, ?)`,
+		)
+		.run(NOW, NOW);
+	targetDb
+		.prepare(
+			`INSERT INTO replication_scopes(
+				scope_id, label, kind, authority_type, coordinator_id, group_id,
+				membership_epoch, status, created_at, updated_at
+			 ) VALUES ('scope-api', 'Engineering', 'team', 'coordinator',
+			 'coordinator-private', 'group-private', 1, 'active', ?, ?)`,
+		)
+		.run(NOW, NOW);
+	targetDb
+		.prepare(
+			`INSERT INTO project_scope_mappings(
+				workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, ?, 'scope-api', 1000, 'test', ?, ?)`,
+		)
+		.run(PROJECT_ID, PROJECT_ID, NOW, NOW);
+	const sessionId = Number(
+		targetDb
+			.prepare(
+				`INSERT INTO sessions(started_at, project, git_remote, git_branch)
+				 VALUES (?, 'api', ?, 'main')`,
+			)
+			.run(NOW, PROJECT_ID).lastInsertRowid,
+	);
+	targetDb
+		.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, body_text, active, created_at, updated_at,
+				visibility, project, scope_id
+			 ) VALUES (?, 'discovery', 'api', 'body', 1, ?, ?, 'shared', 'api', 'scope-api')`,
+		)
+		.run(sessionId, NOW, NOW);
+}
+
 describe("legacy Team candidate discovery", () => {
 	let db: InstanceType<typeof Database>;
 
 	beforeEach(() => {
 		db = new Database(":memory:");
-		initTestSchema(db);
-		db.prepare(
-			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
-			 VALUES ('actor-local', 'Local Person', 1, 'active', ?, ?)`,
-		).run(NOW, NOW);
-		db.prepare(
-			`INSERT INTO replication_scopes(
-				scope_id, label, kind, authority_type, coordinator_id, group_id,
-				membership_epoch, status, created_at, updated_at
-			 ) VALUES ('scope-api', 'Engineering', 'team', 'coordinator',
-				'coordinator-private', 'group-private', 1, 'active', ?, ?)`,
-		).run(NOW, NOW);
-		db.prepare(
-			`INSERT INTO project_scope_mappings(
-				workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
-			 ) VALUES (?, ?, 'scope-api', 1000, 'test', ?, ?)`,
-		).run(PROJECT_ID, PROJECT_ID, NOW, NOW);
-		const sessionId = Number(
-			db
-				.prepare(
-					`INSERT INTO sessions(started_at, project, git_remote, git_branch)
-					 VALUES (?, 'api', ?, 'main')`,
-				)
-				.run(NOW, PROJECT_ID).lastInsertRowid,
-		);
-		db.prepare(
-			`INSERT INTO memory_items(
-				session_id, kind, title, body_text, active, created_at, updated_at,
-				visibility, project, scope_id
-			 ) VALUES (?, 'discovery', 'api', 'body', 1, ?, ?, 'shared', 'api', 'scope-api')`,
-		).run(sessionId, NOW, NOW);
+		seedCandidateFixture(db);
 	});
 
 	afterEach(() => db.close());
@@ -1030,6 +1045,69 @@ describe("legacy Team candidate discovery", () => {
 		expect(refreshed.devices[0]?.displayName).toBe("Renamed Laptop");
 		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(1);
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
+	});
+
+	it("serializes a competing refresh before reading candidate authority", () => {
+		// Arrange
+		const directory = mkdtempSync(join(tmpdir(), "codemem-legacy-team-authority-"));
+		const path = join(directory, "candidate.sqlite");
+		const primary = new Database(path);
+		const competing = new Database(path);
+		try {
+			seedCandidateFixture(primary);
+			const initial = refreshLegacyTeamCandidate(
+				primary,
+				options(),
+				legacyTeamCandidateId("coordinator-private", "group-private"),
+			);
+			primary.pragma("busy_timeout = 1");
+			const prepare = vi.spyOn(primary, "prepare");
+			const draftReadProbe = () =>
+				prepare.mock.calls.some(([sql]) => String(sql).includes("FROM legacy_team_setup_drafts"));
+			const projectReadProbe = () =>
+				prepare.mock.calls.some(([sql]) => String(sql).includes("FROM project_scope_mappings"));
+			competing.exec("BEGIN IMMEDIATE");
+			competing
+				.prepare("UPDATE legacy_team_setup_drafts SET updated_at = ? WHERE attempt_id = ?")
+				.run("2026-08-21T12:00:01.000Z", initial.attemptId);
+
+			// Act
+			const blockedRefresh = () =>
+				refreshLegacyTeamCandidate(
+					primary,
+					options("key-b"),
+					legacyTeamCandidateId("coordinator-private", "group-private"),
+				);
+
+			// Assert
+			expect(blockedRefresh).toThrow(/SQLITE_BUSY|database is locked/i);
+			expect(draftReadProbe()).toBe(false);
+			expect(projectReadProbe()).toBe(false);
+			competing.exec("ROLLBACK");
+
+			const current = refreshLegacyTeamCandidate(
+				primary,
+				options("key-b"),
+				legacyTeamCandidateId("coordinator-private", "group-private"),
+			);
+			expect(draftReadProbe()).toBe(true);
+			expect(projectReadProbe()).toBe(true);
+			const attempts = primary
+				.prepare(
+					`SELECT attempt_id, state, superseded_at FROM legacy_team_setup_drafts
+					 ORDER BY rowid`,
+				)
+				.all() as Array<{ attempt_id: string; state: string; superseded_at: string | null }>;
+			expect(attempts).toEqual([
+				{ attempt_id: initial.attemptId, state: "stale", superseded_at: NOW },
+				{ attempt_id: current.attemptId, state: "needs_setup", superseded_at: null },
+			]);
+		} finally {
+			if (competing.inTransaction) competing.exec("ROLLBACK");
+			competing.close();
+			primary.close();
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 
 	it("keeps Ready when a group exposes multiple scopes and mappings use their own", () => {

--- a/packages/core/src/legacy-team-candidate.ts
+++ b/packages/core/src/legacy-team-candidate.ts
@@ -575,11 +575,100 @@ function isRosterTooLargeError(error: unknown): boolean {
 	return error instanceof Error && error.message === "legacy_team_setup_roster_too_large";
 }
 
+// Must run under the caller's top-level immediate transaction. Guard ordering
+// is intentional: reject oversized evidence before fingerprint assignment reads.
+function candidateAuthority(
+	db: Database,
+	candidateId: string,
+	rosterDevices: LegacyTeamRosterDeviceSnapshot[],
+	projects: LegacyTeamSetupProjectInput[],
+): { row: DraftFreshnessRow | null; rosterFingerprint: string; ready: boolean } {
+	const row = currentDraftRow(db, candidateId);
+	requireLegacyTeamSetupSnapshotWithinLimits({ devices: rosterDevices, projects });
+	requireLegacyTeamSetupEffectiveDevicesWithinLimit(db, rosterDevices, row?.attempt_id ?? null);
+	const rosterFingerprint = legacyTeamRosterFingerprint(
+		rosterDevices.map((device) => ({
+			deviceId: device.deviceId,
+			fingerprint: device.fingerprint,
+			enabled: device.enabled,
+			identityId: activeAssignmentIdentity(db, device.deviceId),
+		})),
+	);
+	const ready =
+		row?.state === "completed" &&
+		row.roster_fingerprint === rosterFingerprint &&
+		completedInventoryCompatible(db, row.attempt_id, projects) &&
+		isCompatibleReadyTeam(db, candidateId, row, rosterFingerprint);
+	return { row, rosterFingerprint, ready };
+}
+
+function resolveDiscoveredCandidate(
+	db: Database,
+	group: EffectiveGroupSnapshot,
+	projection: ListLegacyRecipientPolicyProjectionsOptions,
+	now: string,
+): { draft: LegacyTeamSetupDraftView; ready: boolean; projectCount: number } {
+	const discover = db.transaction(() => {
+		const { candidateId, coordinatorId, groupId, devices: rosterDevices } = group;
+		const projects = legacyTeamCandidateProjectInventory(db, projection, candidateId);
+		const { row, rosterFingerprint, ready } = candidateAuthority(
+			db,
+			candidateId,
+			rosterDevices,
+			projects,
+		);
+		let draft: LegacyTeamSetupDraftView;
+		const expectedProjectionFingerprint = legacyTeamProjectionFingerprint(projects);
+		if (!row || (row.state === "completed" && !ready)) {
+			draft = refreshLegacyTeamSetupDraft(db, {
+				candidateId,
+				coordinatorId,
+				groupId,
+				displayName: group.displayName,
+				devices: rosterDevices,
+				projects,
+				now,
+			});
+		} else if (row.state === "completed") {
+			draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
+				displayName: group.displayName,
+				devices: rosterDevices,
+				projects,
+				now,
+			});
+		} else if (row.state === "stale") {
+			draft = requireLegacyTeamSetupDraft(db, candidateId);
+		} else if (
+			row.roster_fingerprint !== rosterFingerprint ||
+			row.projection_fingerprint !== expectedProjectionFingerprint
+		) {
+			if (row.state === "needs_setup" || row.state === "in_progress") {
+				db.prepare(
+					`UPDATE legacy_team_setup_drafts SET state = 'stale', updated_at = ?
+					 WHERE attempt_id = ?`,
+				).run(now, row.attempt_id);
+			}
+			draft = requireLegacyTeamSetupDraft(db, candidateId);
+		} else {
+			draft = refreshLegacyTeamSetupDraft(db, {
+				candidateId,
+				coordinatorId,
+				groupId,
+				displayName: group.displayName,
+				devices: rosterDevices,
+				projects,
+				now,
+			});
+		}
+		return { draft, ready, projectCount: projects.length };
+	});
+	return discover.immediate();
+}
+
 export function discoverLegacyTeamCandidates(
 	db: Database,
 	options: DiscoverLegacyTeamCandidatesOptions,
 ): LegacyTeamCandidateView[] {
-	const evidence = listLegacyTeamProjectEvidence(db, options.projection);
 	const now = options.now ?? new Date().toISOString();
 	// Discovery persists this timestamp directly (stale transitions) and
 	// forwards it to every draft write; garbage here corrupts ordering columns.
@@ -589,72 +678,13 @@ export function discoverLegacyTeamCandidates(
 	// are dropped rather than aborting discovery for every other group.
 	const { snapshots } = effectiveGroupSnapshots(options.groups);
 	for (const group of snapshots) {
-		const { candidateId, coordinatorId, groupId, devices: rosterDevices } = group;
+		const { candidateId } = group;
 		// Candidate discovery is driven by configured groups: a group with no
 		// currently displayed Project still needs a reviewable roster so the
 		// Team can become ready for future sharing.
-		const projects = projectInventory(candidateId, evidence);
-		const row = currentDraftRow(db, candidateId);
-		let draft: LegacyTeamSetupDraftView;
-		let ready = false;
+		let result: { draft: LegacyTeamSetupDraftView; ready: boolean; projectCount: number };
 		try {
-			requireLegacyTeamSetupSnapshotWithinLimits({ devices: rosterDevices, projects });
-			requireLegacyTeamSetupEffectiveDevicesWithinLimit(db, rosterDevices, row?.attempt_id ?? null);
-			const rosterFingerprint = legacyTeamRosterFingerprint(
-				rosterDevices.map((device) => ({
-					deviceId: device.deviceId,
-					fingerprint: device.fingerprint,
-					enabled: device.enabled,
-					identityId: activeAssignmentIdentity(db, device.deviceId),
-				})),
-			);
-			const expectedProjectionFingerprint = legacyTeamProjectionFingerprint(projects);
-			ready =
-				row?.state === "completed" &&
-				row.roster_fingerprint === rosterFingerprint &&
-				completedInventoryCompatible(db, row.attempt_id, projects) &&
-				isCompatibleReadyTeam(db, candidateId, row, rosterFingerprint);
-			if (!row || (row.state === "completed" && !ready)) {
-				draft = refreshLegacyTeamSetupDraft(db, {
-					candidateId,
-					coordinatorId,
-					groupId,
-					displayName: group.displayName,
-					devices: rosterDevices,
-					projects,
-					now,
-				});
-			} else if (row.state === "completed") {
-				draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
-					displayName: group.displayName,
-					devices: rosterDevices,
-					projects,
-					now,
-				});
-			} else if (row.state === "stale") {
-				draft = requireLegacyTeamSetupDraft(db, candidateId);
-			} else if (
-				row.roster_fingerprint !== rosterFingerprint ||
-				row.projection_fingerprint !== expectedProjectionFingerprint
-			) {
-				if (row.state === "needs_setup" || row.state === "in_progress") {
-					db.prepare(
-						`UPDATE legacy_team_setup_drafts SET state = 'stale', updated_at = ?
-						 WHERE attempt_id = ?`,
-					).run(now, row.attempt_id);
-				}
-				draft = requireLegacyTeamSetupDraft(db, candidateId);
-			} else {
-				draft = refreshLegacyTeamSetupDraft(db, {
-					candidateId,
-					coordinatorId,
-					groupId,
-					displayName: group.displayName,
-					devices: rosterDevices,
-					projects,
-					now,
-				});
-			}
+			result = resolveDiscoveredCandidate(db, group, options.projection, now);
 		} catch (error) {
 			// Oversized evidence is local to this coordinator group. It must not
 			// hide otherwise reviewable candidates discovered in the same pass.
@@ -663,12 +693,12 @@ export function discoverLegacyTeamCandidates(
 		}
 		candidates.push({
 			candidateRef: candidateId,
-			displayName: draft.displayName,
-			status: candidateStatus(draft, ready),
-			deviceCount: draft.devices.length,
-			projectCount: projects.length,
-			unresolvedDeviceCount: draft.unresolvedDeviceCount,
-			unresolvedProjectCount: draft.unresolvedProjectCount,
+			displayName: result.draft.displayName,
+			status: candidateStatus(result.draft, result.ready),
+			deviceCount: result.draft.devices.length,
+			projectCount: result.projectCount,
+			unresolvedDeviceCount: result.draft.unresolvedDeviceCount,
+			unresolvedProjectCount: result.draft.unresolvedProjectCount,
 		});
 	}
 	return candidates.toSorted((left, right) => left.candidateRef.localeCompare(right.candidateRef));
@@ -696,7 +726,6 @@ export function refreshLegacyTeamCandidate(
 	options: DiscoverLegacyTeamCandidatesOptions,
 	candidateRef: string,
 ): LegacyTeamSetupDraftView {
-	const evidence = listLegacyTeamProjectEvidence(db, options.projection);
 	const { snapshots, conflictedCandidateIds } = effectiveGroupSnapshots(options.groups);
 	if (conflictedCandidateIds.has(candidateRef)) {
 		throw new Error("legacy_team_setup_roster_conflict");
@@ -704,43 +733,31 @@ export function refreshLegacyTeamCandidate(
 	for (const group of snapshots) {
 		const { candidateId, coordinatorId, groupId, devices: rosterDevices } = group;
 		if (candidateId !== candidateRef) continue;
-		const projects = projectInventory(candidateId, evidence);
-		const row = currentDraftRow(db, candidateId);
-		requireLegacyTeamSetupSnapshotWithinLimits({ devices: rosterDevices, projects });
-		requireLegacyTeamSetupEffectiveDevicesWithinLimit(db, rosterDevices, row?.attempt_id ?? null);
-		// A compatible Ready completion with unchanged evidence survives an
-		// explicit refresh: only labels update. Creating a replacement attempt
-		// here would immediately drop Ready and force a redundant review cycle.
-		const rosterFingerprint = legacyTeamRosterFingerprint(
-			rosterDevices.map((device) => ({
-				deviceId: device.deviceId,
-				fingerprint: device.fingerprint,
-				enabled: device.enabled,
-				identityId: activeAssignmentIdentity(db, device.deviceId),
-			})),
-		);
-		if (
-			row?.state === "completed" &&
-			row.roster_fingerprint === rosterFingerprint &&
-			completedInventoryCompatible(db, row.attempt_id, projects) &&
-			isCompatibleReadyTeam(db, candidateId, row, rosterFingerprint)
-		) {
-			return refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
+		const refresh = db.transaction(() => {
+			const projects = legacyTeamCandidateProjectInventory(db, options.projection, candidateId);
+			const { row, ready } = candidateAuthority(db, candidateId, rosterDevices, projects);
+			// A compatible Ready completion with unchanged evidence survives an
+			// explicit refresh: only labels update. Creating a replacement attempt
+			// here would immediately drop Ready and force a redundant review cycle.
+			if (row?.state === "completed" && ready) {
+				return refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
+					displayName: group.displayName,
+					devices: rosterDevices,
+					projects,
+					now: options.now,
+				});
+			}
+			return refreshLegacyTeamSetupDraft(db, {
+				candidateId,
+				coordinatorId,
+				groupId,
 				displayName: group.displayName,
 				devices: rosterDevices,
 				projects,
 				now: options.now,
 			});
-		}
-		return refreshLegacyTeamSetupDraft(db, {
-			candidateId,
-			coordinatorId,
-			groupId,
-			displayName: group.displayName,
-			devices: rosterDevices,
-			projects,
-			now: options.now,
 		});
+		return refresh.immediate();
 	}
 	throw new Error("legacy_team_candidate_not_found");
 }


### PR DESCRIPTION
## Description

Serialize each legacy Team candidate discovery/refresh decision under an immediate SQLite transaction before reading current-attempt authority. Centralize limit-before-fingerprint ordering and add deterministic two-connection lock coverage.

This completes `codemem-cads.1` on top of #1499.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [ ] 🚀 Feature (new functionality)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`)
- [x] Added/updated tests for changes
- [x] `pnpm exec vitest run packages/core/src/legacy-team-candidate.test.ts packages/core/src/legacy-team-setup-draft.test.ts`

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated in #1499
- [x] No new warnings introduced