### PR TITLE
fix(core): recover legacy Team assignment evidence

### DIFF
--- a/docs/plans/2026-08-23-legacy-team-assignment-recovery-design.md
+++ b/docs/plans/2026-08-23-legacy-team-assignment-recovery-design.md
@@ -1,0 +1,33 @@
+# Legacy Team assignment recovery design
+
+## Goal
+
+Keep malformed persisted assignment expectations fail-closed without permanently stranding a legacy Team setup attempt, and make removed-device confirmation state independent of stale identity selections.
+
+## Decision
+
+Draft reuse validates the complete stored assignment expectation, not only the copied live assignment fields. A row is reusable only when:
+
+- its copied identity, assignment version, and active-evidence marker match the live assignment;
+- an existing assignment has `expected_assignment_kind = 'existing'` and the same valid assignment version; or
+- an absent assignment has `expected_assignment_kind = 'absent'` and no expected version.
+
+Malformed or contradictory stored expectations therefore force the normal immutable replacement path. The old attempt remains fail-closed and the new attempt snapshots valid current evidence.
+
+If the canonical assignment version itself cannot be represented as a safe non-negative integer, refresh keeps the current attempt stable rather than creating identical replacements. The attempt remains non-finishable until canonical data is repaired.
+
+Saving either `excluded` or `removed` clears `target_identity_id`. Neither decision grants access, and retaining a prior selected identity would make the confirmation digest depend on data irrelevant to the decision.
+
+## Compatibility
+
+- No schema or public response-shape changes.
+- Valid in-progress review state continues to be reused.
+- Corrupt attempts remain immutable history rather than being repaired in place.
+- Included-device assignment CAS behavior is unchanged.
+
+## Verification
+
+- Corrupt existing and absent expectations cause a replacement attempt with normalized evidence.
+- The corrupt attempt cannot finish before replacement.
+- A removed decision clears the selected target and produces the same target-free digest regardless of the prior selection.
+- Focused draft and activation tests continue to pass.

--- a/packages/core/src/legacy-team-assignment-expectation.ts
+++ b/packages/core/src/legacy-team-assignment-expectation.ts
@@ -1,0 +1,22 @@
+export interface StoredLegacyTeamAssignmentExpectation {
+	kind: "absent" | "existing" | null;
+	identityId: string | null;
+	assignmentVersion: number | null;
+}
+
+export function isValidLegacyTeamAssignmentVersion(value: number | null): value is number {
+	return value != null && Number.isSafeInteger(value) && value >= 0;
+}
+
+export function isStoredLegacyTeamAssignmentExpectationWellFormed(
+	expectation: StoredLegacyTeamAssignmentExpectation,
+): boolean {
+	if (expectation.kind === "absent") {
+		return expectation.identityId == null && expectation.assignmentVersion == null;
+	}
+	return (
+		expectation.kind === "existing" &&
+		expectation.identityId != null &&
+		isValidLegacyTeamAssignmentVersion(expectation.assignmentVersion)
+	);
+}

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -4,6 +4,7 @@ import {
 	IdentityDeviceAssignmentError,
 } from "./identity-device-assignment.js";
 import { selectedProjectScopeMapping } from "./legacy-recipient-policy-projection.js";
+import { isStoredLegacyTeamAssignmentExpectationWellFormed } from "./legacy-team-assignment-expectation.js";
 import { isLegacyTeamProjectCanonicalStateValid } from "./legacy-team-project-canonical-preflight.js";
 import {
 	type LegacyTeamSetupProjectInput,
@@ -673,16 +674,18 @@ function validateAssignmentExpectations(model: ActivationModel): void {
 	const assignments = new Map(model.assignments.map((row) => [row.device_id, row]));
 	for (const device of model.devices) {
 		const assignment = assignments.get(device.device_id);
+		if (
+			!isStoredLegacyTeamAssignmentExpectationWellFormed({
+				kind: device.expected_assignment_kind,
+				identityId: device.existing_identity_id,
+				assignmentVersion: device.expected_assignment_version,
+			})
+		) {
+			activationError("team_setup_incomplete");
+		}
 		if (device.expected_assignment_kind === "absent") {
 			if (assignment) activationError("team_setup_assignment_changed");
 			continue;
-		}
-		if (
-			device.expected_assignment_kind !== "existing" ||
-			!device.existing_identity_id ||
-			device.expected_assignment_version == null
-		) {
-			activationError("team_setup_incomplete");
 		}
 		if (
 			!assignment ||

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { previewLegacyTeamSetupActivation } from "./legacy-team-setup-activation.js";
 import {
 	getLegacyTeamSetupDraft,
 	legacyTeamResolvedProjectRef,
@@ -775,6 +776,46 @@ describe("legacy Team setup drafts", () => {
 		).toBe("removed");
 	});
 
+	it("preserves an unconfirmed identity selection across an unrelated Project replacement", () => {
+		// Arrange
+		let draft = refreshLegacyTeamSetupDraft(db, snapshot());
+		const device = draft.devices[0];
+		if (!device) throw new Error("invalid test fixture");
+		draft = setLegacyTeamSetupDeviceAssignment(db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			targetIdentityId: "identity-a",
+			expectation: device.expectation,
+			now: NOW,
+		});
+		expect(draft.devices[0]).toMatchObject({
+			decision: "unresolved",
+			targetIdentityId: "identity-a",
+		});
+
+		// Act
+		const replacement = refreshLegacyTeamSetupDraft(db, {
+			...snapshot(),
+			projects: [
+				...snapshot().projects,
+				{
+					projectRef: "project-ref-c",
+					sourceProjectIdentity: "https://example.invalid/repo-c.git",
+					displayName: "Repo C",
+					sourceFingerprint: "source-c",
+					deterministicProjectIdentity: "https://example.invalid/repo-c.git",
+				},
+			],
+		});
+
+		// Assert
+		expect(replacement.attemptId).not.toBe(draft.attemptId);
+		expect(replacement.devices[0]).toMatchObject({
+			decision: "unresolved",
+			targetIdentityId: "identity-a",
+		});
+	});
+
 	it("replaces the attempt when a carried removed device's assignment changes", () => {
 		const first = refreshLegacyTeamSetupDraft(db, {
 			...snapshot(),
@@ -1043,6 +1084,170 @@ describe("legacy Team setup drafts", () => {
 	});
 
 	it.each([
+		["missing kind", null, 3],
+		["missing version", "existing", null],
+		["negative version", "existing", -1],
+		["fractional version", "existing", 1.5],
+		["unsafe version", "existing", Number.MAX_SAFE_INTEGER + 1],
+		["stale but well-formed version", "existing", 2],
+	] as const)("replaces an existing expectation with %s using normalized evidence", (_variant, expectedKind, expectedVersion) => {
+		// Arrange
+		db.prepare(
+			`INSERT INTO identity_devices(
+				 device_id, identity_id, display_name, status, provenance, revision,
+				 migration_state, assignment_version, idempotency_key, created_at, updated_at
+				 ) VALUES ('device-a', 'identity-a', 'Laptop', 'active', 'test', 'r1',
+				 'complete', 3, 'device-a', ?, ?)`,
+		).run(NOW, NOW);
+		const current = readyDraft(db);
+		expect(current.canFinish).toBe(true);
+		const deviceRef = current.devices[0]?.deviceRef as string;
+		db.prepare(
+			`UPDATE legacy_team_setup_draft_devices
+			 SET expected_assignment_kind = ?, expected_assignment_version = ?
+			 WHERE attempt_id = ? AND device_ref = ?`,
+		).run(expectedKind, expectedVersion, current.attemptId, deviceRef);
+
+		// Act
+		const corrupt = getLegacyTeamSetupDraft(db, CANDIDATE);
+		const cannotFinish = () =>
+			previewLegacyTeamSetupActivation(db, {
+				candidateRef: current.candidateRef,
+				attemptId: current.attemptId,
+			});
+		expect(corrupt?.canFinish).toBe(false);
+		expect(cannotFinish).toThrow(/team_setup_(?:assignment_changed|incomplete)/u);
+		const replacement = refreshLegacyTeamSetupDraft(db, snapshot());
+
+		// Assert
+		expect(replacement).toMatchObject({
+			state: "needs_setup",
+			devices: [
+				{
+					decision: "unresolved",
+					targetIdentityId: null,
+					expectation: { kind: "existing", identityId: "identity-a", assignmentVersion: 3 },
+				},
+			],
+		});
+		expect(replacement.attemptId).not.toBe(current.attemptId);
+		expect(refreshLegacyTeamSetupDraft(db, snapshot()).attemptId).toBe(replacement.attemptId);
+		expect(
+			db
+				.prepare(
+					`SELECT draft.state, device.expected_assignment_kind, device.expected_assignment_version
+						 FROM legacy_team_setup_drafts AS draft
+						 JOIN legacy_team_setup_draft_devices AS device USING(attempt_id)
+						 WHERE draft.attempt_id = ? AND device.device_ref = ?`,
+				)
+				.get(current.attemptId, deviceRef),
+		).toEqual({
+			state: "stale",
+			expected_assignment_kind: expectedKind,
+			expected_assignment_version: expectedVersion,
+		});
+	});
+
+	it("replaces a contradictory absent expectation with normalized evidence", () => {
+		// Arrange
+		const current = readyDraft(db);
+		expect(current.canFinish).toBe(true);
+		const deviceRef = current.devices[0]?.deviceRef as string;
+		db.prepare(
+			`UPDATE legacy_team_setup_draft_devices SET expected_assignment_version = 0
+			 WHERE attempt_id = ? AND device_ref = ?`,
+		).run(current.attemptId, deviceRef);
+
+		// Act
+		const corrupt = getLegacyTeamSetupDraft(db, CANDIDATE);
+		const cannotFinish = () =>
+			previewLegacyTeamSetupActivation(db, {
+				candidateRef: current.candidateRef,
+				attemptId: current.attemptId,
+			});
+		expect(corrupt?.canFinish).toBe(false);
+		expect(cannotFinish).toThrow("team_setup_incomplete");
+		const replacement = refreshLegacyTeamSetupDraft(db, snapshot());
+
+		// Assert
+		expect(replacement.attemptId).not.toBe(current.attemptId);
+		expect(refreshLegacyTeamSetupDraft(db, snapshot()).attemptId).toBe(replacement.attemptId);
+		expect(replacement.devices[0]).toMatchObject({
+			decision: "unresolved",
+			targetIdentityId: null,
+			expectation: { kind: "absent" },
+		});
+		expect(
+			db
+				.prepare(
+					`SELECT draft.state, device.expected_assignment_kind, device.expected_assignment_version
+					 FROM legacy_team_setup_drafts AS draft
+					 JOIN legacy_team_setup_draft_devices AS device USING(attempt_id)
+					 WHERE draft.attempt_id = ? AND device.device_ref = ?`,
+				)
+				.get(current.attemptId, deviceRef),
+		).toEqual({
+			state: "stale",
+			expected_assignment_kind: "absent",
+			expected_assignment_version: 0,
+		});
+	});
+
+	it.each([
+		["excluded", true],
+		["removed", false],
+	] as const)("clears %s targets and produces a deterministic target-free finish digest", (decision, enabled) => {
+		// Arrange
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		let draft = refreshLegacyTeamSetupDraft(db, snapshot());
+		const deviceRef = draft.devices[0]?.deviceRef as string;
+		draft = setLegacyTeamSetupDeviceAssignment(db, {
+			attemptId: draft.attemptId,
+			deviceRef,
+			targetIdentityId: "identity-a",
+			expectation: { kind: "absent" },
+			now: NOW,
+		});
+		db.prepare(
+			`UPDATE legacy_team_setup_draft_devices SET enabled = ?
+			 WHERE attempt_id = ? AND device_ref = ?`,
+		).run(enabled ? 1 : 0, draft.attemptId, deviceRef);
+
+		// Act
+		const decisionAfterA = setLegacyTeamSetupDeviceDecision(db, {
+			attemptId: draft.attemptId,
+			deviceRef,
+			decision,
+			now: NOW,
+		});
+		db.prepare(
+			`UPDATE legacy_team_setup_draft_devices
+			 SET decision = 'unresolved', target_identity_id = 'identity-b'
+			 WHERE attempt_id = ? AND device_ref = ?`,
+		).run(draft.attemptId, deviceRef);
+		const decisionAfterB = setLegacyTeamSetupDeviceDecision(db, {
+			attemptId: draft.attemptId,
+			deviceRef,
+			decision,
+			now: NOW,
+		});
+
+		// Assert
+		expect(decisionAfterA.devices[0]).toMatchObject({
+			decision,
+			targetIdentityId: null,
+		});
+		expect(decisionAfterB.devices[0]).toMatchObject({
+			decision,
+			targetIdentityId: null,
+		});
+		expect(decisionAfterB.finishDigest).toBe(decisionAfterA.finishDigest);
+	});
+
+	it.each([
 		-1,
 		1.5,
 		Number.MAX_SAFE_INTEGER + 1,
@@ -1081,6 +1286,8 @@ describe("legacy Team setup drafts", () => {
 		});
 
 		expect(draft.canFinish).toBe(false);
+		expect(refreshLegacyTeamSetupDraft(db, snapshot()).attemptId).toBe(draft.attemptId);
+		expect(refreshLegacyTeamSetupDraft(db, snapshot()).attemptId).toBe(draft.attemptId);
 	});
 
 	it("reports canFinish false when an included person is later deactivated", () => {

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type { Database } from "./db.js";
+import {
+	isStoredLegacyTeamAssignmentExpectationWellFormed,
+	isValidLegacyTeamAssignmentVersion,
+	type StoredLegacyTeamAssignmentExpectation,
+} from "./legacy-team-assignment-expectation.js";
 import { isLegacyTeamProjectCanonicalStateValid } from "./legacy-team-project-canonical-preflight.js";
 import {
 	requireLegacyTeamSetupEffectiveDevicesWithinLimit,
@@ -271,10 +276,6 @@ interface DeviceAssignmentSnapshot {
 	active: boolean;
 }
 
-function isValidAssignmentVersion(value: number | null): value is number {
-	return value != null && Number.isSafeInteger(value) && value >= 0;
-}
-
 /**
  * Reads the device's assignment row regardless of status. Canonical assignment
  * CAS treats any existing row as evidence, so an inactive row must never be
@@ -309,11 +310,7 @@ function assignmentForDevice(db: Database, deviceId: string): DeviceAssignmentSn
  */
 function assignmentMatchesExpectation(
 	assignment: DeviceAssignmentSnapshot | null,
-	expectation: {
-		kind: "absent" | "existing" | null;
-		identityId: string | null;
-		assignmentVersion: number | null;
-	},
+	expectation: StoredLegacyTeamAssignmentExpectation,
 ): boolean {
 	if (expectation.kind === "absent") return assignment == null;
 	return (
@@ -321,6 +318,42 @@ function assignmentMatchesExpectation(
 		assignment != null &&
 		assignment.identityId === expectation.identityId &&
 		assignment.assignmentVersion === expectation.assignmentVersion
+	);
+}
+
+function storedAssignmentRowMatchesLive(
+	stored: {
+		existing_identity_id: string | null;
+		existing_assignment_version: number | null;
+		verified_evidence_kind: "active_assignment" | null;
+		expected_assignment_kind: "absent" | "existing" | null;
+		expected_assignment_version: number | null;
+	},
+	assignment: DeviceAssignmentSnapshot | null,
+	allowUnrepresentableLiveVersion: boolean,
+): boolean {
+	const copiedEvidenceMatches =
+		stored.existing_identity_id === (assignment?.identityId ?? null) &&
+		stored.existing_assignment_version === (assignment?.assignmentVersion ?? null) &&
+		stored.verified_evidence_kind === (assignment?.active ? "active_assignment" : null);
+	if (!copiedEvidenceMatches) return false;
+	if (
+		allowUnrepresentableLiveVersion &&
+		assignment != null &&
+		!isValidLegacyTeamAssignmentVersion(assignment.assignmentVersion)
+	) {
+		// Replacing the attempt can only copy the same malformed canonical
+		// version. Keep it stable and fail closed until canonical data is fixed.
+		return true;
+	}
+	const expectation = {
+		kind: stored.expected_assignment_kind,
+		identityId: stored.existing_identity_id,
+		assignmentVersion: stored.expected_assignment_version,
+	};
+	return (
+		isStoredLegacyTeamAssignmentExpectationWellFormed(expectation) &&
+		assignmentMatchesExpectation(assignment, expectation)
 	);
 }
 
@@ -434,9 +467,7 @@ function createAttempt(
 		const assignmentEvidenceUnchanged =
 			previous != null &&
 			previous.key_fingerprint === device.fingerprint &&
-			previous.existing_identity_id === (assignment?.identityId ?? null) &&
-			previous.existing_assignment_version === (assignment?.assignmentVersion ?? null) &&
-			previous.verified_evidence_kind === (assignment?.active ? "active_assignment" : null);
+			storedAssignmentRowMatchesLive(previous, assignment, true);
 		const unchanged =
 			assignmentEvidenceUnchanged &&
 			previous != null &&
@@ -444,9 +475,9 @@ function createAttempt(
 			currentDeviceIds.has(device.deviceId) &&
 			previous.enabled === (device.enabled ? 1 : 0) &&
 			device.enabled;
-		// A reviewed removal survives replacement attempts triggered by other
-		// devices or Projects: while the device stays disabled or absent with
-		// unchanged assignment evidence, the user does not re-confirm it.
+		// Reviewed decisions and pending identity selections survive replacement
+		// attempts triggered by other devices or Projects while this device's
+		// assignment evidence remains unchanged. Removed rows stay target-free.
 		const removedCarry =
 			assignmentEvidenceUnchanged &&
 			previous != null &&
@@ -588,14 +619,8 @@ function loadDraftView(db: Database, attemptId: string): LegacyTeamSetupDraftVie
 	const assignmentExpectationsValid = deviceRows.every((row) => {
 		const live = assignmentForDevice(db, row.device_id);
 		return (
-			(row.expected_assignment_kind !== "existing" ||
-				isValidAssignmentVersion(row.expected_assignment_version)) &&
 			(row.decision !== "included" || live == null || live.active) &&
-			assignmentMatchesExpectation(live, {
-				kind: row.expected_assignment_kind,
-				identityId: row.existing_identity_id,
-				assignmentVersion: row.expected_assignment_version,
-			})
+			storedAssignmentRowMatchesLive(row, live, false)
 		);
 	});
 	const finishDigest = recipientPolicyDigest("legacy-team-finish-v1", {
@@ -706,7 +731,8 @@ function storedAssignmentEvidenceMatches(
 ): boolean {
 	const storedRows = db
 		.prepare(
-			`SELECT device_id, existing_identity_id, existing_assignment_version, verified_evidence_kind
+			`SELECT device_id, existing_identity_id, existing_assignment_version, verified_evidence_kind,
+			        expected_assignment_kind, expected_assignment_version
 			 FROM legacy_team_setup_draft_devices WHERE attempt_id = ?`,
 		)
 		.all(attemptId) as Array<{
@@ -714,16 +740,13 @@ function storedAssignmentEvidenceMatches(
 		existing_identity_id: string | null;
 		existing_assignment_version: number | null;
 		verified_evidence_kind: "active_assignment" | null;
+		expected_assignment_kind: "absent" | "existing" | null;
+		expected_assignment_version: number | null;
 	}>;
 	const storedByDevice = new Map(storedRows.map((row) => [row.device_id, row]));
 	const currentMatches = snapshots.every(({ device, assignment }) => {
 		const stored = storedByDevice.get(device.deviceId);
-		return (
-			stored != null &&
-			stored.existing_identity_id === (assignment?.identityId ?? null) &&
-			stored.existing_assignment_version === (assignment?.assignmentVersion ?? null) &&
-			stored.verified_evidence_kind === (assignment?.active ? "active_assignment" : null)
-		);
+		return stored != null && storedAssignmentRowMatchesLive(stored, assignment, true);
 	});
 	if (!currentMatches) return false;
 	// Devices carried into the attempt as removed roster rows keep CAS
@@ -734,11 +757,7 @@ function storedAssignmentEvidenceMatches(
 		.filter((row) => !snapshotDeviceIds.has(row.device_id))
 		.every((row) => {
 			const assignment = assignmentForDevice(db, row.device_id);
-			return (
-				row.existing_identity_id === (assignment?.identityId ?? null) &&
-				row.existing_assignment_version === (assignment?.assignmentVersion ?? null) &&
-				row.verified_evidence_kind === (assignment?.active ? "active_assignment" : null)
-			);
+			return storedAssignmentRowMatchesLive(row, assignment, true);
 		});
 }
 
@@ -1105,7 +1124,7 @@ export function setLegacyTeamSetupDeviceDecision(
 		}
 		db.prepare(
 			`UPDATE legacy_team_setup_draft_devices
-			 SET decision = ?, target_identity_id = CASE WHEN ? = 'excluded' THEN NULL ELSE target_identity_id END,
+			 SET decision = ?, target_identity_id = CASE WHEN ? IN ('excluded', 'removed') THEN NULL ELSE target_identity_id END,
 			     updated_at = ?
 			 WHERE attempt_id = ? AND device_ref = ?`,
 		).run(input.decision, input.decision, now, input.attemptId, input.deviceRef);


### PR DESCRIPTION
## Description

Recover legacy Team setup drafts whose persisted assignment expectations are malformed or contradict current assignment evidence. Refresh now replaces corrupt attempts with normalized immutable evidence, while malformed canonical versions remain stable and fail closed instead of creating replacement churn. Excluded and removed devices clear stale targets so confirmation digests are deterministic.

A pre-existing confirmation may become stale once when a legacy non-included target is normalized; clients recover by re-fetching the draft.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Focused draft and activation validation: 151 passed. Full workspace suite: 5008 passed, 3 todo. Snyk Code high-severity scan: 0 issues.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced