### PR TITLE
fix(core): harden recipient policy hashing

### DIFF
--- a/docs/plans/2026-08-23-recipient-policy-canonical-hashing-design.md
+++ b/docs/plans/2026-08-23-recipient-policy-canonical-hashing-design.md
@@ -1,0 +1,48 @@
+# Recipient-policy canonical hashing design
+
+## Goal
+
+Make recipient-policy serialization injective over its supported JSON data model and bind each digest cryptographically to its domain prefix.
+
+## Supported values
+
+Canonical serialization accepts only:
+
+- `null`, booleans, and strings;
+- finite numbers other than negative zero;
+- dense arrays without custom properties; and
+- plain objects with enumerable data properties and either `Object.prototype` or `null` as their prototype.
+
+Object keys remain deterministically UTF-16-code-unit sorted and array order remains significant.
+
+Values outside that model throw at the serialization boundary. This includes `undefined`, functions, symbols, bigint values, non-finite numbers, negative zero, sparse arrays, accessors, symbol or non-enumerable properties, non-plain objects, and cycles. Shared acyclic values remain valid because JSON represents their expanded value rather than object identity.
+
+## Digest construction
+
+`recipientPolicyDigest(prefix, value)` retains the external `prefix:<hex>` shape but computes SHA-256 over these bytes in order:
+
+1. the UTF-8 domain prefix;
+2. one NUL byte; and
+3. the canonical JSON value.
+
+Prefixes containing NUL are rejected so the separator is unambiguous.
+
+## Released identifier compatibility
+
+Codemem v0.42.0 already persisted the former hash construction in Team and Identity primary keys, relationship metadata, and review-resolution fingerprints. Rekeying that graph inside this hardening bead would risk orphaned grants and duplicate logical records.
+
+Released digest families therefore continue through an explicitly named compatibility helper that hashes only canonical JSON and preserves their bytes. This includes `deterministicPolicyTeamId` and the existing recipient-policy migration and review flows. New legacy-Team setup digest domains use `recipientPolicyDigest` and receive domain separation. Any future migration away from the compatibility helper requires an explicit database rekey plan.
+
+Other modules with independently versioned confirmation or reconciliation digests remain outside this change; moving those contracts requires their own compatibility analysis.
+
+## Compatibility and errors
+
+No dependency, schema, or public response-shape change is required. Existing callers already provide JSON-shaped policy data. Invalid values throw `TypeError` with a stable boundary message instead of collapsing to another representation.
+
+## Verification
+
+- Preserve stable object-key ordering and array ordering behavior.
+- Reject every unsupported primitive and structural form.
+- Prove formerly colliding values such as `undefined`, functions, and symbols no longer serialize as `null`.
+- Pin domain-separated digest output and show identical values in distinct domains hash differently.
+- Pin both the new domain-separated bytes and released compatibility bytes, then run the full workspace gate.

--- a/packages/core/src/recipient-policy-identifiers.test.ts
+++ b/packages/core/src/recipient-policy-identifiers.test.ts
@@ -2,14 +2,139 @@ import { describe, expect, it } from "vitest";
 import {
 	canonicalRecipientPolicyJson,
 	deterministicPolicyTeamId,
+	legacyRecipientPolicyDigest,
 	legacyTeamCandidateId,
 	legacyTeamRosterFingerprint,
+	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
 
 describe("recipient policy identifiers", () => {
-	it("canonicalizes object keys while preserving array order", () => {
-		expect(canonicalRecipientPolicyJson({ z: 1, a: [{ y: 2, x: 1 }] })).toBe(
-			'{"a":[{"x":1,"y":2}],"z":1}',
+	it.each([
+		["null", null, "null"],
+		["boolean", true, "true"],
+		["string", "recipient", '"recipient"'],
+		["finite number", 1.5, "1.5"],
+		["dense array", [3, 2, 1], "[3,2,1]"],
+		["sorted plain object", { z: 1, a: [{ y: 2, x: 1 }] }, '{"a":[{"x":1,"y":2}],"z":1}'],
+		[
+			"null-prototype object",
+			Object.assign(Object.create(null) as Record<string, unknown>, { z: 1, a: 2 }),
+			'{"a":2,"z":1}',
+		],
+	] as const)("canonicalizes supported %s data", (_label, value, expected) => {
+		const result = canonicalRecipientPolicyJson(value);
+
+		expect(result).toBe(expected);
+	});
+
+	it.each([
+		["undefined", () => undefined],
+		["function", () => () => undefined],
+		["symbol", () => Symbol("unsupported")],
+		["bigint", () => 1n],
+		["NaN", () => Number.NaN],
+		["positive infinity", () => Number.POSITIVE_INFINITY],
+		["negative infinity", () => Number.NEGATIVE_INFINITY],
+		["negative zero", () => -0],
+		["sparse array", () => new Array(1)],
+		["array with a custom property", () => Object.assign([1], { custom: true })],
+		[
+			"object accessor",
+			() => Object.defineProperty({}, "value", { enumerable: true, get: () => 1 }),
+		],
+		["symbol property", () => ({ [Symbol("unsupported")]: true })],
+		["non-enumerable property", () => Object.defineProperty({}, "hidden", { value: true })],
+		["non-plain object", () => new Date(0)],
+		[
+			"cyclic object",
+			() => {
+				const value: Record<string, unknown> = {};
+				value.self = value;
+				return value;
+			},
+		],
+	] as const)("rejects unsupported %s values", (_label, createValue) => {
+		const value = createValue();
+		const act = () => canonicalRecipientPolicyJson(value);
+
+		expect(act).toThrow(TypeError);
+	});
+
+	it("accepts shared acyclic values by expanding each reference", () => {
+		const shared = { value: true };
+		const value = { left: shared, right: shared };
+
+		const result = canonicalRecipientPolicyJson(value);
+
+		expect(result).toBe('{"left":{"value":true},"right":{"value":true}}');
+	});
+
+	it("rejects formerly colliding values inside supported containers", () => {
+		expect(canonicalRecipientPolicyJson({})).toBe("{}");
+		expect(() => canonicalRecipientPolicyJson({ value: undefined })).toThrow(TypeError);
+		expect(() => canonicalRecipientPolicyJson([undefined])).toThrow(TypeError);
+		expect(() => canonicalRecipientPolicyJson({ nested: [{ value: Symbol("x") }] })).toThrow(
+			TypeError,
+		);
+	});
+
+	it("rejects NUL in a digest domain prefix", () => {
+		const act = () => recipientPolicyDigest("recipient\0policy", { value: true });
+
+		expect(act).toThrow(TypeError);
+	});
+
+	it.each([
+		"\uD800",
+		"\uDC00",
+		"recipient\uD800policy",
+		"\uDC00\uD800",
+	])("rejects ill-formed UTF-16 in digest domain prefix %j", (prefix) => {
+		expect(() => recipientPolicyDigest(prefix, { value: true })).toThrow(TypeError);
+	});
+
+	it("keeps well-formed astral-plane digest prefixes stable", () => {
+		const prefix = "recipient-\u{1F600}-v1";
+		const value = { value: true };
+
+		expect(recipientPolicyDigest(prefix, value)).toBe(recipientPolicyDigest(prefix, value));
+		expect(recipientPolicyDigest("\uFFFD", value)).toBeTypeOf("string");
+	});
+
+	it("pins the domain-separated digest bytes and external shape", () => {
+		const result = recipientPolicyDigest("recipient-policy-test-v1", {
+			b: [true, null, "x"],
+			a: 1,
+		});
+
+		expect(result).toBe(
+			"recipient-policy-test-v1:3ccd3e1ed08f09bd3923eadc07eb9dc45f49284ab51fe49c674a0f46c574c06e",
+		);
+	});
+
+	it("produces different hashes for identical values in different domains", () => {
+		const value = { recipient: "identity-a" };
+
+		const first = recipientPolicyDigest("recipient-policy-a-v1", value);
+		const second = recipientPolicyDigest("recipient-policy-b-v1", value);
+
+		expect(first.split(":", 2)[1]).not.toBe(second.split(":", 2)[1]);
+		expect(recipientPolicyDigest("ab", "c").split(":", 2)[1]).not.toBe(
+			recipientPolicyDigest("a", "bc").split(":", 2)[1],
+		);
+	});
+
+	it("preserves released recipient-policy digest bytes without domain separation", () => {
+		expect(
+			legacyRecipientPolicyDigest("recipient-policy-test-v1", {
+				b: [true, null, "x"],
+				a: 1,
+			}),
+		).toBe(
+			"recipient-policy-test-v1:eca8cfb31ab74533e1eb2f4c74d2d55dfe3c79ac704787e54be8647ea7777eb1",
+		);
+		expect(deterministicPolicyTeamId("legacy-team-candidate:test")).toBe(
+			"policy-team-v1:61e1813516059b6f1a1bc74aa7dc1f7a70560dd0b396df5eaccb3b26c1bdebbd",
 		);
 	});
 

--- a/packages/core/src/recipient-policy-identifiers.ts
+++ b/packages/core/src/recipient-policy-identifiers.ts
@@ -1,28 +1,97 @@
 import { createHash } from "node:crypto";
 
 /**
- * Locale-independent codepoint comparison. Every fingerprint and digest in the
- * recipient-policy feature relies on byte-identical ordering across machines,
- * so `localeCompare` (ICU-collation dependent) must never feed a digest.
+ * Locale-independent UTF-16 code-unit comparison. Every fingerprint and digest
+ * in the recipient-policy feature relies on byte-identical ordering across
+ * machines, so `localeCompare` (ICU-collation dependent) must never feed a
+ * digest.
  */
 export function compareCodepoints(left: string, right: string): number {
 	return left < right ? -1 : left > right ? 1 : 0;
 }
 
-export function canonicalRecipientPolicyJson(value: unknown): string {
-	if (Array.isArray(value)) return `[${value.map(canonicalRecipientPolicyJson).join(",")}]`;
-	if (value && typeof value === "object") {
-		return `{${Object.entries(value as Record<string, unknown>)
-			.toSorted(([left], [right]) => compareCodepoints(left, right))
-			.map(([key, child]) => `${JSON.stringify(key)}:${canonicalRecipientPolicyJson(child)}`)
-			.join(",")}}`;
+const INVALID_CANONICAL_JSON_MESSAGE = "Recipient policy value must be strict JSON data";
+
+function invalidCanonicalJson(): never {
+	throw new TypeError(INVALID_CANONICAL_JSON_MESSAGE);
+}
+
+function serializeJsonString(value: string): string {
+	const serialized = JSON.stringify(value);
+	if (serialized === undefined) return invalidCanonicalJson();
+	return serialized;
+}
+
+function canonicalJson(value: unknown, ancestors: WeakSet<object>): string {
+	if (value === null) return "null";
+	if (typeof value === "boolean") return value ? "true" : "false";
+	if (typeof value === "string") return serializeJsonString(value);
+	if (typeof value === "number") {
+		if (!Number.isFinite(value) || Object.is(value, -0)) return invalidCanonicalJson();
+		return String(value);
 	}
-	return JSON.stringify(value) ?? "null";
+	if (typeof value !== "object") return invalidCanonicalJson();
+	if (ancestors.has(value)) return invalidCanonicalJson();
+
+	ancestors.add(value);
+	try {
+		if (Array.isArray(value)) {
+			if (Object.getPrototypeOf(value) !== Array.prototype) return invalidCanonicalJson();
+			const keys = Reflect.ownKeys(value);
+			if (keys.length !== value.length + 1 || keys.some((key) => typeof key !== "string")) {
+				return invalidCanonicalJson();
+			}
+			const children: string[] = [];
+			for (let index = 0; index < value.length; index += 1) {
+				const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+				if (!descriptor?.enumerable || !("value" in descriptor)) return invalidCanonicalJson();
+				children.push(canonicalJson(descriptor.value, ancestors));
+			}
+			return `[${children.join(",")}]`;
+		}
+
+		const prototype = Object.getPrototypeOf(value);
+		if (prototype !== Object.prototype && prototype !== null) return invalidCanonicalJson();
+		const entries = Reflect.ownKeys(value).map((key): [string, unknown] => {
+			if (typeof key !== "string") return invalidCanonicalJson();
+			const descriptor = Object.getOwnPropertyDescriptor(value, key);
+			if (!descriptor?.enumerable || !("value" in descriptor)) return invalidCanonicalJson();
+			return [key, descriptor.value];
+		});
+		return `{${entries
+			.toSorted(([left], [right]) => compareCodepoints(left, right))
+			.map(([key, child]) => `${serializeJsonString(key)}:${canonicalJson(child, ancestors)}`)
+			.join(",")}}`;
+	} finally {
+		ancestors.delete(value);
+	}
+}
+
+export function canonicalRecipientPolicyJson(value: unknown): string {
+	return canonicalJson(value, new WeakSet());
 }
 
 export function recipientPolicyDigest(prefix: string, value: unknown): string {
+	// Node replaces unpaired UTF-16 surrogates with U+FFFD during UTF-8
+	// encoding, so accepting them would make distinct domains hash identically.
+	if (prefix.includes("\0") || !prefix.isWellFormed()) {
+		throw new TypeError("Recipient policy digest prefix must be well-formed without NUL");
+	}
 	return `${prefix}:${createHash("sha256")
-		.update(canonicalRecipientPolicyJson(value))
+		.update(prefix, "utf8")
+		.update("\0", "utf8")
+		.update(canonicalRecipientPolicyJson(value), "utf8")
+		.digest("hex")}`;
+}
+
+/**
+ * Compatibility digest for identifiers persisted by released recipient-policy
+ * flows before domain separation was introduced. New digest domains must use
+ * `recipientPolicyDigest`; changing these bytes requires an explicit DB rekey.
+ */
+export function legacyRecipientPolicyDigest(prefix: string, value: unknown): string {
+	return `${prefix}:${createHash("sha256")
+		.update(canonicalRecipientPolicyJson(value), "utf8")
 		.digest("hex")}`;
 }
 
@@ -44,7 +113,7 @@ export function legacyTeamCandidateId(coordinatorId: string, groupId: string): s
 }
 
 export function deterministicPolicyTeamId(teamCandidateId: string): string {
-	return recipientPolicyDigest("policy-team-v1", teamCandidateId);
+	return legacyRecipientPolicyDigest("policy-team-v1", teamCandidateId);
 }
 
 export function legacyTeamRosterFingerprint(

--- a/packages/core/src/recipient-policy-migration.ts
+++ b/packages/core/src/recipient-policy-migration.ts
@@ -8,7 +8,7 @@ import { RECIPIENT_POLICY_CONTRACT_VERSION } from "./recipient-policy-contract.j
 import {
 	canonicalRecipientPolicyJson,
 	deterministicPolicyTeamId,
-	recipientPolicyDigest,
+	legacyRecipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
 import type {
 	RecipientPolicyActionableReviewItemV1,
@@ -87,7 +87,7 @@ const NO_OP_DECISIONS = new Set([
 ]);
 
 function digest(prefix: string, value: unknown): string {
-	return recipientPolicyDigest(prefix, value);
+	return legacyRecipientPolicyDigest(prefix, value);
 }
 
 export { deterministicPolicyTeamId } from "./recipient-policy-identifiers.js";

--- a/packages/core/src/recipient-policy-review.ts
+++ b/packages/core/src/recipient-policy-review.ts
@@ -24,7 +24,7 @@ import {
 	canonicalRecipientPolicyJson,
 	compareCodepoints,
 	deterministicPolicyTeamId,
-	recipientPolicyDigest,
+	legacyRecipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
 import { canonicalWorkspaceIdentity } from "./scope-resolution.js";
 
@@ -144,7 +144,7 @@ function conditionPresentation(
 }
 
 const canonicalJson = canonicalRecipientPolicyJson;
-const digest = recipientPolicyDigest;
+const digest = legacyRecipientPolicyDigest;
 
 function semanticProjection(
 	projection: LegacyRecipientPolicyProjectionV1,


### PR DESCRIPTION
## Description

Make recipient-policy canonical serialization strict and injective over its supported JSON data model. New legacy-Team digest domains now hash the domain prefix, a NUL separator, and canonical JSON together.

Released v0.42 digest families retain byte-for-byte compatibility through an explicitly named legacy helper, avoiding a database rekey and preventing orphaned Teams, duplicate grants, or reopened review decisions.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Focused validation: 224 tests passed. Full workspace suite: 5035 passed, 3 todo. Snyk Code high-severity scan: 0 issues.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced