### PR TITLE
fix(core): make recipient policy migration atomic

### DIFF
--- a/docs/plans/2026-08-23-recipient-policy-migration-transaction-design.md
+++ b/docs/plans/2026-08-23-recipient-policy-migration-transaction-design.md
@@ -1,0 +1,43 @@
+# Recipient-policy migration transaction design
+
+## Goal
+
+Eliminate the read/validate/write race in `migrateRecipientPolicyIntent` without changing its per-project partial-success contract.
+
+## Transaction boundary
+
+Write-mode migration runs projection, review-state, resolution, plan, validation, and write work inside one outer `BEGIN IMMEDIATE` transaction. This acquires authority before the first migration read and keeps one SQLite snapshot across every Project.
+
+Each Project executes inside a nested transaction/savepoint. A conflict rolls back only that Project and produces its existing blocked result; successful Projects remain pending in the outer transaction and commit together when iteration finishes. Unexpected failure of the outer operation rolls back all pending successful Projects.
+
+Only recognized migration-domain conflicts may become per-Project blocked results. Unknown storage or programming failures propagate, and any error that ends the outer transaction stops iteration immediately so later Projects cannot run in autocommit mode.
+
+Dry-run mode performs the same reads and validation in one deferred read transaction. It does not acquire the writer lock and performs no writes.
+
+The HTTP migration boundary converts writer-lock contention to `503 {"error":"migration_busy"}` and other unexpected failures to `500 {"error":"migration_failed"}` without exposing SQLite details.
+
+## Dynamic SQL boundary
+
+All table and column identifiers used by the generic row helpers must match a static runtime schema allowlist before interpolation. Unknown tables, key columns, value columns, duplicate columns, and invalid key shapes fail with `intent_conflict` before preparing SQL.
+
+## Authorizing evidence
+
+New relationship revisions and idempotency keys use version-two metadata bound to:
+
+- the relationship identity;
+- migration provenance; and
+- the source fingerprint that authorized the row.
+
+Validation compares status/role plus provenance, source fingerprint, revision, and idempotency key. Released version-one metadata remains replay-compatible only when the stored provenance and source fingerprint also match the current plan. Setup-owned device assignments and recipient edges retain their existing completion-bound compatibility exceptions.
+
+Identity-device assignment is global and may be authorized by multiple Project resolutions. Its metadata therefore binds the stable device/Identity relationship and provenance, while Project-specific source evidence remains stored for audit but is not treated as unique relationship identity. Project recipient rows continue to require an exact source-fingerprint match.
+
+## Verification
+
+- A competing SQLite writer cannot mutate migration evidence after migration starts reading it.
+- A late conflict rolls back only its Project while another valid Project commits.
+- Outer failure rolls back all pending Project writes.
+- Dry runs do not write or acquire the immediate writer lock.
+- Tampered provenance, source fingerprint, revision, or idempotency evidence blocks replay.
+- Valid released v1 rows replay unchanged; new inserts carry evidence-bound v2 metadata.
+- Invalid dynamic identifiers are rejected before SQL preparation.

--- a/packages/core/src/recipient-policy-migration.test.ts
+++ b/packages/core/src/recipient-policy-migration.test.ts
@@ -1,9 +1,19 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { listLegacyRecipientPolicyProjections } from "./legacy-recipient-policy-projection.js";
-import { deterministicPolicyTeamId } from "./recipient-policy-identifiers.js";
+import {
+	compareCodepoints,
+	deterministicPolicyTeamId,
+	legacyRecipientPolicyDigest,
+} from "./recipient-policy-identifiers.js";
 import { listRecipientPolicyIntent } from "./recipient-policy-intent.js";
-import { migrateRecipientPolicyIntent } from "./recipient-policy-migration.js";
+import {
+	assertAllowedRecipientPolicyIntentRow,
+	migrateRecipientPolicyIntent,
+} from "./recipient-policy-migration.js";
 import {
 	listRecipientPolicyReview,
 	resolveRecipientPolicyReview,
@@ -115,6 +125,7 @@ function insertLinkedOperation(
 		projectId: string;
 		displayName: string;
 		recipientActorId: string;
+		recipientDeviceId?: string;
 		digestOverride?: string;
 		inviterActorId?: string;
 		accepted?: boolean;
@@ -146,7 +157,7 @@ function insertLinkedOperation(
 		reviewedDigest,
 		`invite-${input.operationId}`,
 		input.recipientActorId,
-		`device-${input.recipientActorId}`,
+		input.recipientDeviceId ?? `device-${input.recipientActorId}`,
 		input.accepted === false ? null : NOW,
 		NOW,
 		NOW,
@@ -178,17 +189,21 @@ function protectedSnapshot(db: InstanceType<typeof Database>): string {
 	);
 }
 
+function initializeMigrationDb(db: InstanceType<typeof Database>): void {
+	initTestSchema(db);
+	insertActor(db, LOCAL_ACTOR_ID, "Personal", true);
+	db.prepare(
+		`INSERT INTO sync_device(device_id, public_key, fingerprint, created_at)
+		 VALUES (?, 'local-key', 'transport-fingerprint', ?)`,
+	).run(LOCAL_DEVICE_ID, NOW);
+}
+
 describe("recipient policy intent migration", () => {
 	let db: InstanceType<typeof Database>;
 
 	beforeEach(() => {
 		db = new Database(":memory:");
-		initTestSchema(db);
-		insertActor(db, LOCAL_ACTOR_ID, "Personal", true);
-		db.prepare(
-			`INSERT INTO sync_device(device_id, public_key, fingerprint, created_at)
-			 VALUES (?, 'local-key', 'transport-fingerprint', ?)`,
-		).run(LOCAL_DEVICE_ID, NOW);
+		initializeMigrationDb(db);
 	});
 
 	afterEach(() => db.close());
@@ -198,23 +213,30 @@ describe("recipient policy intent migration", () => {
 		displayName?: string;
 		recipientActorId?: string;
 		digestOverride?: string;
+		targetDb?: InstanceType<typeof Database>;
 	}): { projectId: string; recipientActorId: string; deviceId: string } {
+		const targetDb = input?.targetDb ?? db;
 		const projectId = input?.projectId ?? "https://git.example.invalid/acme/api.git";
 		const displayName = input?.displayName ?? "api";
 		const recipientActorId = input?.recipientActorId ?? "identity-work";
 		const scopeId = `scope-${recipientActorId}`;
 		const deviceId = `device-${recipientActorId}`;
-		if (!db.prepare("SELECT 1 FROM actors WHERE actor_id = ?").get(recipientActorId)) {
+		if (!targetDb.prepare("SELECT 1 FROM actors WHERE actor_id = ?").get(recipientActorId)) {
 			insertActor(
-				db,
+				targetDb,
 				recipientActorId,
 				recipientActorId === "identity-work" ? "Work" : "Recipient",
 			);
 		}
-		insertProject(db, { projectId, displayName, scopeId });
-		insertScope(db, { scopeId, projectId });
-		assignDevice(db, { scopeId, deviceId, actorId: recipientActorId, displayName: "Work laptop" });
-		insertLinkedOperation(db, {
+		insertProject(targetDb, { projectId, displayName, scopeId });
+		insertScope(targetDb, { scopeId, projectId });
+		assignDevice(targetDb, {
+			scopeId,
+			deviceId,
+			actorId: recipientActorId,
+			displayName: "Work laptop",
+		});
+		insertLinkedOperation(targetDb, {
 			operationId: `operation-${scopeId}`,
 			projectId,
 			displayName,
@@ -263,6 +285,38 @@ describe("recipient policy intent migration", () => {
 			projectId: input.projectId,
 			recipientActorId,
 			unassignedDeviceId: input.unassignedDeviceId,
+		};
+	}
+
+	function resolvedAttachFixture(input?: { projectId?: string; deviceId?: string }): {
+		projectId: string;
+		recipientActorId: string;
+		deviceId: string;
+		sourceFingerprint: string;
+	} {
+		const fixture = reviewDeviceFixture({
+			projectId: input?.projectId ?? "https://git.example.invalid/acme/evidence.git",
+			displayName: "evidence",
+			unassignedDeviceId: input?.deviceId ?? "device-evidence",
+		});
+		const item = listRecipientPolicyReview(db, context).reviewItems.find((candidate) =>
+			candidate.options.some((option) => option.decision === "attach_device_to_identity"),
+		);
+		if (!item) throw new Error("attach-device review item missing");
+		resolveRecipientPolicyReview(db, context, {
+			reviewItemId: item.reviewItemId,
+			sourceFingerprint: item.sourceFingerprint,
+			decision: "attach_device_to_identity",
+			decisionInput: {
+				deviceId: fixture.unassignedDeviceId,
+				identityId: fixture.recipientActorId,
+			},
+		});
+		return {
+			projectId: fixture.projectId,
+			recipientActorId: fixture.recipientActorId,
+			deviceId: fixture.unassignedDeviceId,
+			sourceFingerprint: item.sourceFingerprint,
 		};
 	}
 
@@ -431,6 +485,100 @@ describe("recipient policy intent migration", () => {
 		expect(protectedSnapshot(db)).toBe(before);
 	});
 
+	it("acquires immediate write authority before its first migration read", () => {
+		// Arrange: intercept the first read and synchronously attempt a write from another connection.
+		const directory = mkdtempSync(join(tmpdir(), "codemem-recipient-policy-migration-"));
+		const path = join(directory, "migration.sqlite");
+		const primary = new Database(path);
+		const competing = new Database(path);
+		let competingError: unknown;
+		let attempted = false;
+		let firstPreparedSql: string | null = null;
+		try {
+			initializeMigrationDb(primary);
+			const fixture = exactFixture({ targetDb: primary });
+			competing.pragma("busy_timeout = 1");
+			const prepare = primary.prepare.bind(primary);
+			primary.prepare = ((sql: string) => {
+				if (!attempted) {
+					attempted = true;
+					firstPreparedSql = sql;
+					try {
+						competing
+							.prepare("UPDATE share_operations SET reviewed_project_set_digest = 'tampered'")
+							.run();
+					} catch (error) {
+						competingError = error;
+					}
+				}
+				return prepare(sql);
+			}) as typeof primary.prepare;
+
+			// Act
+			const result = migrateRecipientPolicyIntent(primary, context);
+
+			// Assert: the contender observed the lock before any projection/evidence read ran.
+			expect(attempted).toBe(true);
+			expect(firstPreparedSql?.trimStart()).toMatch(/^SELECT/u);
+			expect(competingError).toMatchObject({ code: "SQLITE_BUSY" });
+			expect(result.results).toContainEqual(
+				expect.objectContaining({
+					canonicalProjectIdentity: fixture.projectId,
+					status: "migrated",
+				}),
+			);
+		} finally {
+			primary.close();
+			competing.close();
+			rmSync(directory, { force: true, recursive: true });
+		}
+	});
+
+	it("keeps dry-run on a read transaction without taking writer authority", () => {
+		// Arrange
+		const directory = mkdtempSync(join(tmpdir(), "codemem-recipient-policy-dry-run-"));
+		const path = join(directory, "migration.sqlite");
+		const primary = new Database(path);
+		const competing = new Database(path);
+		let competingError: unknown;
+		let attempted = false;
+		let firstPreparedSql: string | null = null;
+		try {
+			initializeMigrationDb(primary);
+			exactFixture({ targetDb: primary });
+			competing.pragma("busy_timeout = 1");
+			const prepare = primary.prepare.bind(primary);
+			primary.prepare = ((sql: string) => {
+				if (!attempted) {
+					attempted = true;
+					firstPreparedSql = sql;
+					try {
+						competing.prepare("UPDATE share_operations SET updated_at = '2026-07-22'").run();
+					} catch (error) {
+						competingError = error;
+					}
+				}
+				return prepare(sql);
+			}) as typeof primary.prepare;
+
+			// Act
+			const result = migrateRecipientPolicyIntent(primary, context, { dryRun: true });
+
+			// Assert
+			expect(attempted).toBe(true);
+			expect(firstPreparedSql?.trimStart()).toMatch(/^SELECT/u);
+			expect(competingError).toBeUndefined();
+			expect(result.results).toContainEqual(
+				expect.objectContaining({ status: "would_migrate", writeCount: 0 }),
+			);
+			expect(primary.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(0);
+		} finally {
+			primary.close();
+			competing.close();
+			rmSync(directory, { force: true, recursive: true });
+		}
+	});
+
 	it("fails closed when one device is already assigned to another Identity", () => {
 		const fixture = exactFixture();
 		const metadata = {
@@ -450,6 +598,337 @@ describe("recipient policy intent migration", () => {
 			expect.objectContaining({ status: "blocked", errorCode: "device_identity_conflict" }),
 		);
 		expect(db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(0);
+	});
+
+	it("rolls back one conflicting Project savepoint while another Project commits", () => {
+		// Arrange
+		const blocked = resolvedAttachFixture({
+			projectId: "https://git.example.invalid/acme/a-blocked.git",
+			deviceId: "device-project-rollback",
+		});
+		const committed = exactFixture({
+			projectId: "https://git.example.invalid/acme/z-committed.git",
+			displayName: "committed",
+			recipientActorId: "identity-committed",
+		});
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'identity', ?, 'revoked', 'tampered', 'tampered', 'projected', ?,
+			 'tampered', ?, ?)`,
+		).run(blocked.projectId, blocked.recipientActorId, blocked.sourceFingerprint, NOW, NOW);
+
+		// Act
+		const result = migrateRecipientPolicyIntent(db, context);
+
+		// Assert: identity-device was staged before the conflicting recipient and must be gone.
+		expect(result.results).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					canonicalProjectIdentity: blocked.projectId,
+					status: "blocked",
+					errorCode: "intent_conflict",
+				}),
+				expect.objectContaining({
+					canonicalProjectIdentity: committed.projectId,
+					status: "migrated",
+				}),
+			]),
+		);
+		expect(
+			db.prepare("SELECT 1 FROM identity_devices WHERE device_id = ?").get(blocked.deviceId),
+		).toBeUndefined();
+		expect(
+			db
+				.prepare(
+					`SELECT 1 FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_id = ? AND status = 'active'`,
+				)
+				.get(committed.projectId, committed.recipientActorId),
+		).toBeDefined();
+	});
+
+	it("rolls back all pending Projects when SQLite aborts the outer transaction", () => {
+		// Arrange
+		const first = exactFixture({
+			projectId: "https://git.example.invalid/acme/a-first.git",
+			displayName: "a-first",
+			recipientActorId: "identity-first",
+		});
+		const aborting = exactFixture({
+			projectId: "https://git.example.invalid/acme/m-aborting.git",
+			displayName: "m-aborting",
+			recipientActorId: "identity-aborting",
+		});
+		const later = exactFixture({
+			projectId: "https://git.example.invalid/acme/z-later.git",
+			displayName: "z-later",
+			recipientActorId: "identity-later",
+		});
+		expect(
+			listLegacyRecipientPolicyProjections(db, context).map(
+				(projection) => projection.project.canonicalIdentity,
+			),
+		).toEqual([first.projectId, aborting.projectId, later.projectId]);
+		db.exec(`CREATE TRIGGER abort_recipient_policy_migration
+			BEFORE INSERT ON project_recipients
+			WHEN NEW.canonical_project_identity = '${aborting.projectId}'
+			BEGIN
+				SELECT RAISE(ROLLBACK, 'forced_outer_abort');
+			END`);
+
+		// Act
+		const migrate = () => migrateRecipientPolicyIntent(db, context);
+
+		// Assert
+		expect(migrate).toThrow("forced_outer_abort");
+		expect(db.inTransaction).toBe(false);
+		expect(
+			db
+				.prepare(
+					`SELECT COUNT(*) FROM project_recipients
+					 WHERE canonical_project_identity IN (?, ?, ?)`,
+				)
+				.pluck()
+				.get(first.projectId, aborting.projectId, later.projectId),
+		).toBe(0);
+	});
+
+	it("propagates an unknown live-transaction failure and rolls back pending Projects", () => {
+		// Arrange
+		const first = exactFixture({
+			projectId: "https://git.example.invalid/acme/a-unknown-first.git",
+			displayName: "a-unknown-first",
+			recipientActorId: "identity-unknown-first",
+		});
+		exactFixture({
+			projectId: "https://git.example.invalid/acme/z-unknown-failure.git",
+			displayName: "z-unknown-failure",
+			recipientActorId: "identity-unknown-failure",
+		});
+		const prepare = db.prepare.bind(db);
+		let recipientInsertCount = 0;
+		db.prepare = ((sql: string) => {
+			if (sql.trimStart().startsWith("INSERT INTO project_recipients")) {
+				recipientInsertCount += 1;
+				if (recipientInsertCount === 2) throw new TypeError("forced_unknown_failure");
+			}
+			return prepare(sql);
+		}) as typeof db.prepare;
+
+		// Act / Assert
+		try {
+			expect(() => migrateRecipientPolicyIntent(db, context)).toThrow("forced_unknown_failure");
+		} finally {
+			db.prepare = prepare;
+		}
+		expect(recipientInsertCount).toBe(2);
+		expect(db.inTransaction).toBe(false);
+		expect(
+			db
+				.prepare("SELECT 1 FROM project_recipients WHERE canonical_project_identity = ?")
+				.get(first.projectId),
+		).toBeUndefined();
+	});
+
+	it.each([
+		{ table: "not_a_table", key: { device_id: "device-a" }, values: { status: "active" } },
+		{
+			table: "identity_devices",
+			key: { device_id: "device-a", injected: "x" },
+			values: { status: "active" },
+		},
+		{ table: "identity_devices", key: { wrong_id: "device-a" }, values: { status: "active" } },
+		{ table: "identity_devices", key: { device_id: 1 }, values: { status: "active" } },
+		{
+			table: "project_recipients",
+			key: {
+				canonical_project_identity: "project-a",
+				recipient_kind: "identity",
+				wrong_recipient_id: "identity-a",
+			},
+			values: { status: "active" },
+		},
+		{
+			table: "identity_devices",
+			key: { device_id: "device-a" },
+			values: { injected: "x" },
+		},
+		{ table: "identity_devices", key: { device_id: "device-a" }, values: {} },
+		{
+			table: "identity_devices",
+			key: { device_id: "device-a" },
+			values: { device_id: "device-a", status: "active" },
+		},
+	] as const)("rejects invalid dynamic intent identifiers before SQL preparation", (row) => {
+		expect(() => assertAllowedRecipientPolicyIntentRow(row as never)).toThrow("intent_conflict");
+	});
+
+	it("rejects an unknown intent provenance before SQL preparation", () => {
+		expect(() =>
+			assertAllowedRecipientPolicyIntentRow({
+				table: "project_recipients",
+				key: {
+					canonical_project_identity: "project-a",
+					recipient_kind: "identity",
+					recipient_id: "identity-a",
+				},
+				values: {
+					status: "active",
+					provenance: "unknown_provenance",
+					migration_state: "projected",
+					source_fingerprint: null,
+					policy_revision: "revision-a",
+					idempotency_key: "idempotency-a",
+					created_at: NOW,
+					updated_at: NOW,
+				},
+				releasedV1Metadata: { revision: "revision-v1", idempotencyKey: "idempotency-v1" },
+			}),
+		).toThrow("intent_conflict");
+	});
+
+	it("rejects review device evidence without a source fingerprint", () => {
+		expect(() =>
+			assertAllowedRecipientPolicyIntentRow({
+				table: "identity_devices",
+				key: { device_id: "device-a" },
+				values: {
+					identity_id: "identity-a",
+					display_name: "Laptop",
+					status: "active",
+					provenance: "review_resolution",
+					migration_state: "projected",
+					source_fingerprint: null,
+					revision: "revision-a",
+					idempotency_key: "idempotency-a",
+					created_at: NOW,
+					updated_at: NOW,
+				},
+				releasedV1Metadata: { revision: "revision-v1", idempotencyKey: "idempotency-v1" },
+			}),
+		).toThrow("device_identity_conflict");
+	});
+
+	it.each([
+		["provenance", "tampered-provenance"],
+		["source_fingerprint", "tampered-source"],
+		["policy_revision", "tampered-revision"],
+		["idempotency_key", "tampered-idempotency"],
+	] as const)("blocks replay when stored %s evidence is tampered", (column, tamperedValue) => {
+		// Arrange
+		const fixture = resolvedAttachFixture();
+		migrateRecipientPolicyIntent(db, context);
+		db.prepare(
+			`UPDATE project_recipients SET ${column} = ?
+			 WHERE canonical_project_identity = ? AND recipient_kind = 'identity' AND recipient_id = ?`,
+		).run(tamperedValue, fixture.projectId, fixture.recipientActorId);
+
+		// Act
+		const replay = migrateRecipientPolicyIntent(db, context);
+
+		// Assert
+		expect(replay.results).toContainEqual(
+			expect.objectContaining({
+				canonicalProjectIdentity: fixture.projectId,
+				status: "blocked",
+				errorCode: "intent_conflict",
+			}),
+		);
+	});
+
+	it("replays released v1 metadata when provenance and source evidence still match", () => {
+		// Arrange
+		const fixture = resolvedAttachFixture();
+		const recipientIdentity = [fixture.projectId, "identity", fixture.recipientActorId];
+		const deviceIdentity = [fixture.deviceId, fixture.recipientActorId];
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'identity', ?, 'active', 'review_resolution', ?, 'projected', ?, ?, ?, ?)`,
+		).run(
+			fixture.projectId,
+			fixture.recipientActorId,
+			legacyRecipientPolicyDigest(
+				"recipient-policy-project-recipient-revision-v1",
+				recipientIdentity,
+			),
+			fixture.sourceFingerprint,
+			legacyRecipientPolicyDigest(
+				"recipient-policy-project-recipient-idempotency-v1",
+				recipientIdentity,
+			),
+			NOW,
+			NOW,
+		);
+		db.prepare(
+			`INSERT INTO identity_devices(
+			 device_id, identity_id, display_name, status, provenance, revision, migration_state,
+			 source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES (?, ?, 'Unassigned laptop', 'active', 'review_resolution', ?, 'projected', ?, ?, ?, ?)`,
+		).run(
+			fixture.deviceId,
+			fixture.recipientActorId,
+			legacyRecipientPolicyDigest("recipient-policy-identity-device-revision-v1", deviceIdentity),
+			fixture.sourceFingerprint,
+			legacyRecipientPolicyDigest(
+				"recipient-policy-identity-device-idempotency-v1",
+				deviceIdentity,
+			),
+			NOW,
+			NOW,
+		);
+
+		// Act
+		const result = migrateRecipientPolicyIntent(db, context);
+
+		// Assert
+		expect(result.results).toContainEqual(
+			expect.objectContaining({
+				canonicalProjectIdentity: fixture.projectId,
+				status: "unchanged",
+				writeCount: 0,
+				idempotent: true,
+			}),
+		);
+	});
+
+	it("writes v2 metadata bound to provenance and source evidence", () => {
+		// Arrange
+		const fixture = resolvedAttachFixture();
+
+		// Act
+		const result = migrateRecipientPolicyIntent(db, context);
+		const recipient = db
+			.prepare(
+				`SELECT provenance, source_fingerprint, policy_revision, idempotency_key
+				 FROM project_recipients
+				 WHERE canonical_project_identity = ? AND recipient_kind = 'identity' AND recipient_id = ?`,
+			)
+			.get(fixture.projectId, fixture.recipientActorId) as Record<string, string>;
+		const device = db
+			.prepare(
+				`SELECT provenance, source_fingerprint, revision, idempotency_key
+				 FROM identity_devices WHERE device_id = ?`,
+			)
+			.get(fixture.deviceId) as Record<string, string>;
+
+		// Assert
+		expect(result.results).toContainEqual(expect.objectContaining({ status: "migrated" }));
+		expect(recipient).toMatchObject({
+			provenance: "review_resolution",
+			source_fingerprint: fixture.sourceFingerprint,
+		});
+		expect(recipient.policy_revision).toContain("-v2:");
+		expect(recipient.idempotency_key).toContain("-v2:");
+		expect(device).toMatchObject({
+			provenance: "review_resolution",
+			source_fingerprint: fixture.sourceFingerprint,
+		});
+		expect(device.revision).toContain("-v2:");
+		expect(device.idempotency_key).toContain("-v2:");
 	});
 
 	it("keeps Personal and Work actor IDs and same-name canonical Projects isolated", () => {
@@ -560,6 +1039,401 @@ describe("recipient policy intent migration", () => {
 			expect.objectContaining({
 				canonicalProjectIdentity: projectId,
 				identityId: "identity-assigned",
+			}),
+		);
+	});
+
+	it("prefers automatic evidence when a matching review selects the same recipient", () => {
+		// Arrange
+		const fixture = exactFixture();
+		const scopeId = `scope-${fixture.recipientActorId}`;
+		db.prepare(
+			`INSERT INTO sync_peers(peer_device_id, name, actor_id, created_at)
+			 VALUES ('device-review-extra', 'Review laptop', NULL, ?)`,
+		).run(NOW);
+		db.prepare(
+			`INSERT INTO scope_memberships(scope_id, device_id, status, membership_epoch, updated_at)
+			 VALUES (?, 'device-review-extra', 'active', 1, ?)`,
+		).run(scopeId, NOW);
+		const item = listRecipientPolicyReview(db, context).reviewItems.find((candidate) =>
+			candidate.options.some((option) => option.decision === "choose_recipients"),
+		);
+		if (!item) throw new Error("matching review item missing");
+		resolveRecipientPolicyReview(db, context, {
+			reviewItemId: item.reviewItemId,
+			sourceFingerprint: item.sourceFingerprint,
+			decision: "choose_recipients",
+			decisionInput: { recipientIds: [fixture.recipientActorId] },
+		});
+
+		// Act
+		const result = migrateRecipientPolicyIntent(db, context);
+		const replay = migrateRecipientPolicyIntent(db, context);
+
+		// Assert
+		expect(result.results).toContainEqual(expect.objectContaining({ status: "migrated" }));
+		expect(replay.results).toContainEqual(
+			expect.objectContaining({ status: "unchanged", idempotent: true }),
+		);
+		expect(
+			db
+				.prepare(
+					`SELECT provenance, source_fingerprint FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_kind = 'identity'
+					   AND recipient_id = ?`,
+				)
+				.get(fixture.projectId, fixture.recipientActorId),
+		).toEqual({ provenance: "exact_project_invite", source_fingerprint: null });
+		expect(
+			db
+				.prepare("SELECT provenance, source_fingerprint FROM identity_devices WHERE device_id = ?")
+				.get(fixture.deviceId),
+		).toEqual({ provenance: "managed_exact_project", source_fingerprint: null });
+	});
+
+	it("accepts review device evidence when matching automatic evidence is preferred", () => {
+		// Arrange
+		const fixture = exactFixture({
+			projectId: "https://git.example.invalid/acme/device-replay.git",
+		});
+		const scopeId = `scope-${fixture.recipientActorId}`;
+		db.prepare(
+			`INSERT INTO sync_peers(peer_device_id, name, actor_id, created_at)
+			 VALUES ('device-review-replay', 'Review replay laptop', NULL, ?)`,
+		).run(NOW);
+		db.prepare(
+			`INSERT INTO scope_memberships(scope_id, device_id, status, membership_epoch, updated_at)
+			 VALUES (?, 'device-review-replay', 'active', 1, ?)`,
+		).run(scopeId, NOW);
+		const item = listRecipientPolicyReview(db, context).reviewItems.find((candidate) =>
+			candidate.options.some((option) => option.decision === "choose_recipients"),
+		);
+		if (!item) throw new Error("device replay review item missing");
+		resolveRecipientPolicyReview(db, context, {
+			reviewItemId: item.reviewItemId,
+			sourceFingerprint: item.sourceFingerprint,
+			decision: "choose_recipients",
+			decisionInput: { recipientIds: [fixture.recipientActorId] },
+		});
+		const evidenceIdentity = {
+			identity: [fixture.deviceId, fixture.recipientActorId],
+			provenance: "review_resolution",
+			sourceFingerprint: null,
+		};
+		db.prepare(
+			`INSERT INTO identity_devices(
+			 device_id, identity_id, display_name, status, provenance, revision, migration_state,
+			 source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES (?, ?, 'Work laptop', 'active', 'review_resolution', ?, 'projected', ?, ?, ?, ?)`,
+		).run(
+			fixture.deviceId,
+			fixture.recipientActorId,
+			legacyRecipientPolicyDigest("recipient-policy-identity-device-revision-v2", evidenceIdentity),
+			item.sourceFingerprint,
+			legacyRecipientPolicyDigest(
+				"recipient-policy-identity-device-idempotency-v2",
+				evidenceIdentity,
+			),
+			NOW,
+			NOW,
+		);
+
+		// Act
+		const result = migrateRecipientPolicyIntent(db, context);
+		const replay = migrateRecipientPolicyIntent(db, context);
+
+		// Assert
+		expect(result.results).toContainEqual(
+			expect.objectContaining({
+				canonicalProjectIdentity: fixture.projectId,
+				status: "migrated",
+				errorCode: null,
+			}),
+		);
+		expect(replay.results).toContainEqual(
+			expect.objectContaining({ status: "unchanged", idempotent: true }),
+		);
+		expect(
+			db
+				.prepare("SELECT provenance FROM identity_devices WHERE device_id = ?")
+				.pluck()
+				.get(fixture.deviceId),
+		).toBe("review_resolution");
+
+		db.prepare(
+			"UPDATE identity_devices SET source_fingerprint = 'not-a-current-review' WHERE device_id = ?",
+		).run(fixture.deviceId);
+		const rejected = migrateRecipientPolicyIntent(db, context);
+		expect(rejected.results).toContainEqual(
+			expect.objectContaining({
+				canonicalProjectIdentity: fixture.projectId,
+				status: "blocked",
+				errorCode: "device_identity_conflict",
+			}),
+		);
+	});
+
+	it("accepts current cross-Project device evidence with a different provenance", () => {
+		const fixture = reviewDeviceFixture({
+			projectId: "https://git.example.invalid/acme/review-device-source.git",
+			displayName: "review-device-source",
+			unassignedDeviceId: "device-review-trigger",
+			recipientActorId: "identity-cross-provenance",
+		});
+		const reviewItem = listRecipientPolicyReview(db, context).reviewItems.find((candidate) =>
+			candidate.options.some((option) => option.decision === "choose_recipients"),
+		);
+		if (!reviewItem) throw new Error("cross-provenance review item missing");
+		resolveRecipientPolicyReview(db, context, {
+			reviewItemId: reviewItem.reviewItemId,
+			sourceFingerprint: reviewItem.sourceFingerprint,
+			decision: "choose_recipients",
+			decisionInput: { recipientIds: [fixture.recipientActorId] },
+		});
+		const assignedDeviceId = `device-${fixture.recipientActorId}`;
+		const first = migrateRecipientPolicyIntent(db, context);
+		expect(first.results).toContainEqual(
+			expect.objectContaining({
+				canonicalProjectIdentity: fixture.projectId,
+				status: "migrated",
+			}),
+		);
+
+		const automaticProjectId = "https://git.example.invalid/acme/automatic-device-source.git";
+		const automaticScopeId = "scope-automatic-device-source";
+		insertProject(db, {
+			projectId: automaticProjectId,
+			displayName: "automatic-device-source",
+			scopeId: automaticScopeId,
+		});
+		insertScope(db, { scopeId: automaticScopeId, projectId: automaticProjectId });
+		db.prepare(
+			`INSERT INTO scope_memberships(scope_id, device_id, status, membership_epoch, updated_at)
+			 VALUES (?, ?, 'active', 1, ?)`,
+		).run(automaticScopeId, assignedDeviceId, NOW);
+		insertLinkedOperation(db, {
+			operationId: "operation-automatic-device-source",
+			projectId: automaticProjectId,
+			displayName: "automatic-device-source",
+			recipientActorId: fixture.recipientActorId,
+			recipientDeviceId: assignedDeviceId,
+		});
+
+		const second = migrateRecipientPolicyIntent(db, context);
+		expect(second.results).toContainEqual(
+			expect.objectContaining({
+				canonicalProjectIdentity: automaticProjectId,
+				status: "migrated",
+				errorCode: null,
+			}),
+		);
+		expect(
+			db
+				.prepare("SELECT provenance, source_fingerprint FROM identity_devices WHERE device_id = ?")
+				.get(assignedDeviceId),
+		).toEqual({
+			provenance: "review_resolution",
+			source_fingerprint: reviewItem.sourceFingerprint,
+		});
+	});
+
+	it("deterministically selects one compatible source from two matching reviews", () => {
+		// Arrange
+		const projectId = "https://git.example.invalid/acme/multi-review.git";
+		const scopeId = "scope-multi-review";
+		const recipientId = "identity-multi-review";
+		insertActor(db, recipientId, "Multi-review recipient");
+		insertProject(db, { projectId, displayName: "multi-review", scopeId });
+		insertScope(db, { scopeId, projectId });
+		assignDevice(db, { scopeId, deviceId: "device-multi-assigned", actorId: recipientId });
+		for (const deviceId of ["device-multi-a", "device-multi-b"]) {
+			db.prepare(
+				`INSERT INTO sync_peers(peer_device_id, name, actor_id, created_at)
+				 VALUES (?, ?, NULL, ?)`,
+			).run(deviceId, deviceId, NOW);
+			db.prepare(
+				`INSERT INTO scope_memberships(scope_id, device_id, status, membership_epoch, updated_at)
+				 VALUES (?, ?, 'active', 1, ?)`,
+			).run(scopeId, deviceId, NOW);
+		}
+		const items = listRecipientPolicyReview(db, context).reviewItems.filter((candidate) =>
+			candidate.options.some((option) => option.decision === "choose_recipients"),
+		);
+		expect(items).toHaveLength(2);
+		expect(new Set(items.map((item) => item.sourceFingerprint)).size).toBe(2);
+		for (const item of items) {
+			resolveRecipientPolicyReview(db, context, {
+				reviewItemId: item.reviewItemId,
+				sourceFingerprint: item.sourceFingerprint,
+				decision: "choose_recipients",
+				decisionInput: { recipientIds: [recipientId] },
+			});
+		}
+		const [expectedFingerprint] = items
+			.map((item) => item.sourceFingerprint)
+			.toSorted(compareCodepoints);
+		if (!expectedFingerprint) throw new Error("review fingerprint missing");
+
+		// Act
+		const result = migrateRecipientPolicyIntent(db, context);
+		const replay = migrateRecipientPolicyIntent(db, context);
+
+		// Assert
+		expect(result.results).toContainEqual(expect.objectContaining({ status: "migrated" }));
+		expect(replay.results).toContainEqual(
+			expect.objectContaining({ status: "unchanged", idempotent: true }),
+		);
+		expect(
+			db
+				.prepare(
+					`SELECT source_fingerprint FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_kind = 'identity'
+					   AND recipient_id = ?`,
+				)
+				.pluck()
+				.get(projectId, recipientId),
+		).toBe(expectedFingerprint);
+		expect(
+			db
+				.prepare("SELECT source_fingerprint FROM identity_devices WHERE device_id = ?")
+				.pluck()
+				.get("device-multi-assigned"),
+		).toBe(expectedFingerprint);
+		expect(
+			db
+				.prepare("SELECT COUNT(*) FROM project_recipients WHERE canonical_project_identity = ?")
+				.pluck()
+				.get(projectId),
+		).toBe(1);
+	});
+
+	it.each([
+		"v1",
+		"v2",
+	] as const)("accepts a stored %s recipient edge authorized by a non-preferred current review", (metadataVersion) => {
+		// Arrange
+		const projectId = `https://git.example.invalid/acme/replay-${metadataVersion}.git`;
+		const scopeId = `scope-replay-${metadataVersion}`;
+		const recipientId = `identity-replay-${metadataVersion}`;
+		insertActor(db, recipientId, "Replay recipient");
+		insertProject(db, { projectId, displayName: `replay-${metadataVersion}`, scopeId });
+		insertScope(db, { scopeId, projectId });
+		assignDevice(db, {
+			scopeId,
+			deviceId: `device-replay-assigned-${metadataVersion}`,
+			actorId: recipientId,
+		});
+		for (const deviceId of [
+			`device-replay-${metadataVersion}-a`,
+			`device-replay-${metadataVersion}-b`,
+		]) {
+			db.prepare(
+				`INSERT INTO sync_peers(peer_device_id, name, actor_id, created_at)
+					 VALUES (?, ?, NULL, ?)`,
+			).run(deviceId, deviceId, NOW);
+			db.prepare(
+				`INSERT INTO scope_memberships(scope_id, device_id, status, membership_epoch, updated_at)
+					 VALUES (?, ?, 'active', 1, ?)`,
+			).run(scopeId, deviceId, NOW);
+		}
+		const items = listRecipientPolicyReview(db, context).reviewItems.filter((candidate) =>
+			candidate.options.some((option) => option.decision === "choose_recipients"),
+		);
+		expect(items).toHaveLength(2);
+		expect(new Set(items.map((item) => item.sourceFingerprint)).size).toBe(2);
+		for (const item of items) {
+			resolveRecipientPolicyReview(db, context, {
+				reviewItemId: item.reviewItemId,
+				sourceFingerprint: item.sourceFingerprint,
+				decision: "choose_recipients",
+				decisionInput: { recipientIds: [recipientId] },
+			});
+		}
+		const [, storedFingerprint] = items
+			.map((item) => item.sourceFingerprint)
+			.toSorted(compareCodepoints);
+		if (!storedFingerprint) throw new Error("stored review fingerprint missing");
+		const identity = [projectId, "identity", recipientId];
+		const evidenceIdentity = {
+			identity,
+			provenance: "review_resolution",
+			sourceFingerprint: storedFingerprint,
+		};
+		const metadataIdentity = metadataVersion === "v1" ? identity : evidenceIdentity;
+		db.prepare(
+			`INSERT INTO project_recipients(
+				 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+				 policy_revision, migration_state, source_fingerprint, idempotency_key, created_at, updated_at
+				 ) VALUES (?, 'identity', ?, 'active', 'review_resolution', ?, 'projected', ?, ?, ?, ?)`,
+		).run(
+			projectId,
+			recipientId,
+			legacyRecipientPolicyDigest(
+				`recipient-policy-project-recipient-revision-${metadataVersion}`,
+				metadataIdentity,
+			),
+			storedFingerprint,
+			legacyRecipientPolicyDigest(
+				`recipient-policy-project-recipient-idempotency-${metadataVersion}`,
+				metadataIdentity,
+			),
+			NOW,
+			NOW,
+		);
+
+		// Act
+		const result = migrateRecipientPolicyIntent(db, context);
+		const replay = migrateRecipientPolicyIntent(db, context);
+
+		// Assert
+		expect(result.results).toContainEqual(
+			expect.objectContaining({
+				canonicalProjectIdentity: projectId,
+				status: "migrated",
+				errorCode: null,
+			}),
+		);
+		expect(replay.results).toContainEqual(
+			expect.objectContaining({
+				canonicalProjectIdentity: projectId,
+				status: "unchanged",
+				idempotent: true,
+			}),
+		);
+		expect(
+			db
+				.prepare(
+					`SELECT source_fingerprint FROM project_recipients
+						 WHERE canonical_project_identity = ? AND recipient_kind = 'identity'
+						   AND recipient_id = ?`,
+				)
+				.pluck()
+				.get(projectId, recipientId),
+		).toBe(storedFingerprint);
+
+		db.prepare(
+			`UPDATE project_recipients SET source_fingerprint = 'not-a-current-review'
+				 WHERE canonical_project_identity = ? AND recipient_kind = 'identity' AND recipient_id = ?`,
+		).run(projectId, recipientId);
+		const rejected = migrateRecipientPolicyIntent(db, context);
+		expect(rejected.results).toContainEqual(
+			expect.objectContaining({
+				canonicalProjectIdentity: projectId,
+				status: "blocked",
+				errorCode: "intent_conflict",
+			}),
+		);
+
+		db.prepare(
+			`UPDATE project_recipients SET source_fingerprint = ?, policy_revision = 'tampered-revision'
+			 WHERE canonical_project_identity = ? AND recipient_kind = 'identity' AND recipient_id = ?`,
+		).run(storedFingerprint, projectId, recipientId);
+		const metadataRejected = migrateRecipientPolicyIntent(db, context);
+		expect(metadataRejected.results).toContainEqual(
+			expect.objectContaining({
+				canonicalProjectIdentity: projectId,
+				status: "blocked",
+				errorCode: "intent_conflict",
 			}),
 		);
 	});

--- a/packages/core/src/recipient-policy-migration.ts
+++ b/packages/core/src/recipient-policy-migration.ts
@@ -7,6 +7,7 @@ import {
 import { RECIPIENT_POLICY_CONTRACT_VERSION } from "./recipient-policy-contract.js";
 import {
 	canonicalRecipientPolicyJson,
+	compareCodepoints,
 	deterministicPolicyTeamId,
 	legacyRecipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
@@ -54,9 +55,14 @@ interface StoredResolution {
 }
 
 interface IntentRow {
-	table: "policy_teams" | "policy_team_memberships" | "identity_devices" | "project_recipients";
+	table: "identity_devices" | "project_recipients";
 	key: Record<string, string>;
 	values: Record<string, string | null>;
+	compatibleEvidence?: IntentRow[];
+	releasedV1Metadata?: {
+		revision: string;
+		idempotencyKey: string;
+	};
 }
 
 interface ActorRow {
@@ -86,6 +92,52 @@ const NO_OP_DECISIONS = new Set([
 	"remove_stale_device",
 ]);
 
+const INTENT_ROW_SCHEMAS: Record<
+	IntentRow["table"],
+	{
+		keyColumns: readonly string[];
+		valueColumns: ReadonlySet<string>;
+		semanticColumns: readonly string[];
+	}
+> = {
+	identity_devices: {
+		keyColumns: ["device_id"],
+		valueColumns: new Set([
+			"identity_id",
+			"display_name",
+			"status",
+			"provenance",
+			"revision",
+			"migration_state",
+			"source_fingerprint",
+			"idempotency_key",
+			"created_at",
+			"updated_at",
+		]),
+		semanticColumns: ["identity_id", "display_name", "status"],
+	},
+	project_recipients: {
+		keyColumns: ["canonical_project_identity", "recipient_kind", "recipient_id"],
+		valueColumns: new Set([
+			"status",
+			"provenance",
+			"policy_revision",
+			"migration_state",
+			"source_fingerprint",
+			"idempotency_key",
+			"created_at",
+			"updated_at",
+		]),
+		semanticColumns: ["status"],
+	},
+};
+
+const MIGRATION_EVIDENCE_PROVENANCE_RANK = new Map([
+	["exact_project_invite", 0],
+	["managed_exact_project", 0],
+	["review_resolution", 1],
+]);
+
 function digest(prefix: string, value: unknown): string {
 	return legacyRecipientPolicyDigest(prefix, value);
 }
@@ -95,13 +147,25 @@ export { deterministicPolicyTeamId } from "./recipient-policy-identifiers.js";
 function relationshipMetadata(
 	kind: string,
 	identity: unknown,
+	provenance: string,
+	sourceFingerprint: string | null,
 ): {
 	revision: string;
 	idempotencyKey: string;
+	releasedV1Metadata: { revision: string; idempotencyKey: string };
 } {
+	const evidenceBoundIdentity = {
+		identity,
+		provenance,
+		sourceFingerprint,
+	};
 	return {
-		revision: digest(`recipient-policy-${kind}-revision-v1`, identity),
-		idempotencyKey: digest(`recipient-policy-${kind}-idempotency-v1`, identity),
+		revision: digest(`recipient-policy-${kind}-revision-v2`, evidenceBoundIdentity),
+		idempotencyKey: digest(`recipient-policy-${kind}-idempotency-v2`, evidenceBoundIdentity),
+		releasedV1Metadata: {
+			revision: digest(`recipient-policy-${kind}-revision-v1`, identity),
+			idempotencyKey: digest(`recipient-policy-${kind}-idempotency-v1`, identity),
+		},
 	};
 }
 
@@ -133,12 +197,18 @@ function projectRecipientRow(input: {
 	now: string;
 }): IntentRow {
 	const identity = [input.projectId, input.recipientKind, input.recipientId];
-	const metadata = relationshipMetadata("project-recipient", identity);
+	const sourceFingerprint = input.sourceFingerprint ?? null;
+	const metadata = relationshipMetadata(
+		"project-recipient",
+		identity,
+		input.provenance,
+		sourceFingerprint,
+	);
 	const values = baseValues({
 		provenance: input.provenance,
 		revision: metadata.revision,
 		idempotencyKey: metadata.idempotencyKey,
-		sourceFingerprint: input.sourceFingerprint,
+		sourceFingerprint,
 		now: input.now,
 	});
 	const { revision, ...withoutRevision } = values;
@@ -150,6 +220,7 @@ function projectRecipientRow(input: {
 			recipient_id: input.recipientId,
 		},
 		values: { ...withoutRevision, policy_revision: revision },
+		releasedV1Metadata: metadata.releasedV1Metadata,
 	};
 }
 
@@ -161,7 +232,16 @@ function identityDeviceRow(input: {
 	sourceFingerprint?: string | null;
 	now: string;
 }): IntentRow {
-	const metadata = relationshipMetadata("identity-device", [input.deviceId, input.identityId]);
+	const sourceFingerprint = input.sourceFingerprint ?? null;
+	const metadata = relationshipMetadata(
+		"identity-device",
+		[input.deviceId, input.identityId],
+		input.provenance,
+		// Device assignment is global and may be authorized by more than one
+		// Project resolution. Project-specific source evidence remains stored for
+		// audit, but cannot define the global relationship's stable metadata.
+		null,
+	);
 	return {
 		table: "identity_devices",
 		key: { device_id: input.deviceId },
@@ -172,10 +252,11 @@ function identityDeviceRow(input: {
 				provenance: input.provenance,
 				revision: metadata.revision,
 				idempotencyKey: metadata.idempotencyKey,
-				sourceFingerprint: input.sourceFingerprint,
+				sourceFingerprint,
 				now: input.now,
 			}),
 		},
+		releasedV1Metadata: metadata.releasedV1Metadata,
 	};
 }
 
@@ -470,11 +551,133 @@ function addReviewDecision(
 	return "review_decision_unsupported";
 }
 
-function rowWhere(key: Record<string, string>): { clause: string; parameters: string[] } {
-	const entries = Object.entries(key);
+function collectCompatibleDeviceEvidence(input: {
+	db: Database;
+	context: RecipientPolicyReviewContext;
+	projections: LegacyRecipientPolicyProjectionV1[];
+	currentItemsByProject: ReadonlyMap<string, RecipientPolicyActionableReviewItemV1[]>;
+	resolutionBySource: ReadonlyMap<string, StoredResolution>;
+	now: string;
+}): Map<string, IntentRow[]> {
+	const evidence = new Map<string, IntentRow[]>();
+	for (const projection of input.projections) {
+		const currentItems =
+			input.currentItemsByProject.get(projection.project.canonicalIdentity) ?? [];
+		const matchingResolutions = currentItems.map((currentItem) =>
+			input.resolutionBySource.get(
+				`${currentItem.reviewItemId}\u0000${currentItem.sourceFingerprint}`,
+			),
+		);
+		if (
+			matchingResolutions.some((resolution) => !resolution) ||
+			matchingResolutions.some((resolution) => resolution?.decision === "preserve_current_access")
+		) {
+			continue;
+		}
+		const plan: ProjectPlan = { rows: [], actors: [], hadApplicableEvidence: false };
+		try {
+			if (
+				addAutomaticOperationEvidence(
+					input.db,
+					plan,
+					projection,
+					input.context.localActorId,
+					input.now,
+				) !== null
+			) {
+				continue;
+			}
+			let reviewEvidenceValid = true;
+			for (const [index, resolution] of matchingResolutions.entries()) {
+				const currentItem = currentItems[index];
+				if (
+					!resolution ||
+					!currentItem?.options.some((option) => option.decision === resolution.decision) ||
+					addReviewDecision(
+						input.db,
+						plan,
+						projection,
+						currentItem,
+						resolution,
+						input.context,
+						input.now,
+					) !== null
+				) {
+					reviewEvidenceValid = false;
+					break;
+				}
+			}
+			if (!reviewEvidenceValid) continue;
+		} catch (error) {
+			// Evidence indexing is fail-closed; project migration still reports
+			// the authoritative validation error from its savepoint below.
+			if (projectMigrationErrorCode(error) === null) throw error;
+			continue;
+		}
+		let viablePlan: ProjectPlan;
+		try {
+			viablePlan = deduplicatePlan(plan);
+		} catch (error) {
+			if (projectMigrationErrorCode(error) === null) throw error;
+			continue;
+		}
+		for (const row of viablePlan.rows) {
+			if (row.table !== "identity_devices") continue;
+			const deviceId = row.key.device_id;
+			const identityId = row.values.identity_id;
+			if (typeof deviceId !== "string" || typeof identityId !== "string") continue;
+			const key = deviceRelationshipKey(deviceId, identityId);
+			const candidates = evidence.get(key) ?? [];
+			candidates.push(...intentEvidenceCandidates(row));
+			evidence.set(key, candidates);
+		}
+	}
+	return evidence;
+}
+
+/** Internal module boundary exported for direct security regression coverage. */
+export function assertAllowedRecipientPolicyIntentRow(row: IntentRow): void {
+	if (!Object.hasOwn(INTENT_ROW_SCHEMAS, row.table)) throw new Error("intent_conflict");
+	const schema = INTENT_ROW_SCHEMAS[row.table];
+	const keyColumns = Object.keys(row.key);
+	const valueColumns = Object.keys(row.values);
+	if (
+		keyColumns.length !== schema.keyColumns.length ||
+		schema.keyColumns.some((column) => !Object.hasOwn(row.key, column)) ||
+		keyColumns.some((column) => typeof row.key[column] !== "string") ||
+		valueColumns.length === 0 ||
+		valueColumns.some((column) => !schema.valueColumns.has(column)) ||
+		keyColumns.some((column) => Object.hasOwn(row.values, column))
+	) {
+		throw new Error("intent_conflict");
+	}
+	const provenance = row.values.provenance;
+	const sourceFingerprint = row.values.source_fingerprint;
+	const automaticProvenance =
+		row.table === "identity_devices" ? "managed_exact_project" : "exact_project_invite";
+	if (
+		(provenance !== automaticProvenance && provenance !== "review_resolution") ||
+		(provenance === "review_resolution"
+			? typeof sourceFingerprint !== "string"
+			: sourceFingerprint !== null)
+	) {
+		throw new Error(
+			row.table === "identity_devices" ? "device_identity_conflict" : "intent_conflict",
+		);
+	}
+}
+
+function rowWhere(row: IntentRow): { clause: string; parameters: string[] } {
+	assertAllowedRecipientPolicyIntentRow(row);
+	const entries = INTENT_ROW_SCHEMAS[row.table].keyColumns.map(
+		(column) => [column, row.key[column]] as const,
+	);
 	return {
 		clause: entries.map(([column]) => `${column} = ?`).join(" AND "),
-		parameters: entries.map(([, value]) => value),
+		parameters: entries.map(([, value]) => {
+			if (typeof value !== "string") throw new Error("intent_conflict");
+			return value;
+		}),
 	};
 }
 
@@ -517,6 +720,44 @@ function requiredIntentValue(row: IntentRow, column: string): string {
 	return value;
 }
 
+function intentEvidenceCandidates(row: IntentRow): IntentRow[] {
+	const { compatibleEvidence, ...primary } = row;
+	return [primary, ...(compatibleEvidence ?? [])];
+}
+
+function deviceRelationshipKey(deviceId: string, identityId: string): string {
+	return canonicalRecipientPolicyJson({ deviceId, identityId });
+}
+
+function relationshipMetadataMatches(
+	existing: Record<string, unknown>,
+	row: IntentRow,
+	revisionColumn: "revision" | "policy_revision",
+): boolean {
+	const evidenceMatches =
+		existing.provenance === row.values.provenance &&
+		(existing.source_fingerprint ?? null) === (row.values.source_fingerprint ?? null);
+	if (!evidenceMatches) return false;
+	const currentMetadataMatches =
+		existing[revisionColumn] === row.values[revisionColumn] &&
+		existing.idempotency_key === row.values.idempotency_key;
+	const releasedV1MetadataMatches =
+		row.releasedV1Metadata !== undefined &&
+		existing[revisionColumn] === row.releasedV1Metadata.revision &&
+		existing.idempotency_key === row.releasedV1Metadata.idempotencyKey;
+	return currentMetadataMatches || releasedV1MetadataMatches;
+}
+
+function relationshipMetadataMatchesAny(
+	existing: Record<string, unknown>,
+	row: IntentRow,
+	revisionColumn: "revision" | "policy_revision",
+): boolean {
+	return intentEvidenceCandidates(row).some((candidate) =>
+		relationshipMetadataMatches(existing, candidate, revisionColumn),
+	);
+}
+
 /**
  * Guided setup can reassign a pre-existing device row, which preserves that
  * row's original provenance and revision (`assignIdentityDeviceInTransaction`
@@ -544,13 +785,21 @@ function hasCompletedSetupAssignmentEvidence(
 	);
 }
 
-function validateOrAssignIdentityDevice(db: Database, row: IntentRow, write: boolean): boolean {
+function validateOrAssignIdentityDevice(
+	db: Database,
+	row: IntentRow,
+	write: boolean,
+	compatibleDeviceEvidence: ReadonlyMap<string, IntentRow[]>,
+): boolean {
+	if (row.table !== "identity_devices") throw new Error("intent_conflict");
+	assertAllowedRecipientPolicyIntentRow(row);
 	const deviceId = row.key.device_id;
 	if (!deviceId) throw new Error("intent_conflict");
 	const identityId = requiredIntentValue(row, "identity_id");
 	const existing = db
 		.prepare(
-			`SELECT identity_id, assignment_version, status, revision, provenance
+			`SELECT identity_id, assignment_version, status, revision, provenance,
+			        source_fingerprint, idempotency_key
 			 FROM identity_devices WHERE device_id = ?`,
 		)
 		.get(deviceId) as
@@ -560,6 +809,8 @@ function validateOrAssignIdentityDevice(db: Database, row: IntentRow, write: boo
 				status: string;
 				revision: string;
 				provenance: string;
+				source_fingerprint: string | null;
+				idempotency_key: string;
 		  }
 		| undefined;
 	if (existing) {
@@ -569,14 +820,16 @@ function validateOrAssignIdentityDevice(db: Database, row: IntentRow, write: boo
 		// may also have reassigned a row created by another flow — that row
 		// keeps its old provenance and revision, so completion-bound draft
 		// evidence is what proves the assignment was reviewed.
-		const revisionCompatible =
-			existing.revision === requiredIntentValue(row, "revision") ||
+		const setupCompatible =
 			existing.provenance === "reviewed_team_setup" ||
 			hasCompletedSetupAssignmentEvidence(db, deviceId, identityId);
+		const currentEvidenceMatches = (
+			compatibleDeviceEvidence.get(deviceRelationshipKey(deviceId, identityId)) ?? []
+		).some((candidate) => relationshipMetadataMatches(existing, candidate, "revision"));
 		if (
 			existing.identity_id !== identityId ||
 			existing.status !== requiredIntentValue(row, "status") ||
-			!revisionCompatible
+			(!setupCompatible && !currentEvidenceMatches)
 		) {
 			throw new Error("device_identity_conflict");
 		}
@@ -614,8 +867,8 @@ function validateOrAssignIdentityDevice(db: Database, row: IntentRow, write: boo
 }
 
 function validateOrWriteRow(db: Database, row: IntentRow, write: boolean): boolean {
-	if (row.table === "identity_devices") throw new Error("intent_conflict");
-	const where = rowWhere(row.key);
+	if (row.table !== "project_recipients") throw new Error("intent_conflict");
+	const where = rowWhere(row);
 	const existing = db
 		.prepare(`SELECT * FROM ${row.table} WHERE ${where.clause}`)
 		.get(...where.parameters) as Record<string, unknown> | undefined;
@@ -625,20 +878,16 @@ function validateOrWriteRow(db: Database, row: IntentRow, write: boolean): boole
 		// satisfies the migration intent without requiring the migration
 		// revision, matching the device-row handling above.
 		if (
-			row.table === "project_recipients" &&
 			existing.provenance === "reviewed_team_setup" &&
 			existing.status === "active" &&
 			row.values.status === "active"
 		) {
 			return false;
 		}
-		const relationshipColumns =
-			row.table === "project_recipients"
-				? ["status", "policy_revision"]
-				: row.table === "policy_team_memberships"
-					? ["role", "status", "revision"]
-					: ["status", "revision"];
-		if (relationshipColumns.some((column) => existing[column] !== row.values[column])) {
+		if (
+			existing.status !== row.values.status ||
+			!relationshipMetadataMatchesAny(existing, row, "policy_revision")
+		) {
 			throw new Error("intent_conflict");
 		}
 		return false;
@@ -653,27 +902,79 @@ function validateOrWriteRow(db: Database, row: IntentRow, write: boolean): boole
 	return true;
 }
 
+function intentRowConflict(row: IntentRow): string {
+	return row.table === "identity_devices" ? "device_identity_conflict" : "intent_conflict";
+}
+
+function intentEvidenceKey(row: IntentRow): string {
+	const revisionColumn = row.table === "identity_devices" ? "revision" : "policy_revision";
+	return canonicalRecipientPolicyJson({
+		provenance: requiredIntentValue(row, "provenance"),
+		sourceFingerprint: row.values.source_fingerprint,
+		revision: requiredIntentValue(row, revisionColumn),
+		idempotencyKey: requiredIntentValue(row, "idempotency_key"),
+	});
+}
+
+function preferredIntentEvidence(left: IntentRow, right: IntentRow): IntentRow {
+	const conflict = intentRowConflict(left);
+	const leftProvenance = requiredIntentValue(left, "provenance");
+	const rightProvenance = requiredIntentValue(right, "provenance");
+	const leftRank = MIGRATION_EVIDENCE_PROVENANCE_RANK.get(leftProvenance);
+	const rightRank = MIGRATION_EVIDENCE_PROVENANCE_RANK.get(rightProvenance);
+	if (leftRank === undefined || rightRank === undefined) throw new Error(conflict);
+	if (leftRank !== rightRank) return leftRank < rightRank ? left : right;
+
+	const leftFingerprint = left.values.source_fingerprint as string | null;
+	const rightFingerprint = right.values.source_fingerprint as string | null;
+	if (leftFingerprint !== rightFingerprint) {
+		// The row-boundary provenance check makes this unreachable; retain the
+		// guard so future provenance additions cannot weaken selection silently.
+		if (leftFingerprint === null || rightFingerprint === null) throw new Error(conflict);
+		return compareCodepoints(leftFingerprint, rightFingerprint) < 0 ? left : right;
+	}
+
+	const idempotencyOrder = compareCodepoints(
+		requiredIntentValue(left, "idempotency_key"),
+		requiredIntentValue(right, "idempotency_key"),
+	);
+	if (idempotencyOrder !== 0) return idempotencyOrder < 0 ? left : right;
+	return compareCodepoints(intentEvidenceKey(left), intentEvidenceKey(right)) <= 0 ? left : right;
+}
+
+function mergeCompatibleIntentEvidence(left: IntentRow, right: IntentRow): IntentRow {
+	const candidatesByEvidence = new Map<string, IntentRow>();
+	for (const candidate of [...intentEvidenceCandidates(left), ...intentEvidenceCandidates(right)]) {
+		candidatesByEvidence.set(intentEvidenceKey(candidate), candidate);
+	}
+	const candidates = [...candidatesByEvidence.values()];
+	const preferred = candidates.reduce(preferredIntentEvidence);
+	return {
+		...preferred,
+		compatibleEvidence: candidates.filter((candidate) => candidate !== preferred),
+	};
+}
+
 function deduplicatePlan(plan: ProjectPlan): ProjectPlan {
 	const rows = new Map<string, IntentRow>();
 	for (const row of plan.rows) {
+		assertAllowedRecipientPolicyIntentRow(row);
 		const key = `${row.table}:${canonicalRecipientPolicyJson(row.key)}`;
 		const existing = rows.get(key);
 		if (existing) {
-			const relationshipColumns =
-				row.table === "identity_devices"
-					? ["identity_id", "status", "revision"]
-					: row.table === "project_recipients"
-						? ["status", "policy_revision"]
-						: row.table === "policy_team_memberships"
-							? ["role", "status", "revision"]
-							: ["status", "revision"];
-			if (relationshipColumns.some((column) => existing.values[column] !== row.values[column])) {
-				throw new Error(
-					row.table === "identity_devices" ? "device_identity_conflict" : "intent_conflict",
-				);
+			if (
+				INTENT_ROW_SCHEMAS[row.table].semanticColumns.some(
+					(column) => existing.values[column] !== row.values[column],
+				)
+			) {
+				throw new Error(intentRowConflict(row));
 			}
 		}
-		rows.set(key, existing ?? row);
+		// Keep one complete, valid authorization record rather than synthesizing
+		// metadata that no source actually authorized. Automatic operation evidence
+		// is stable across review churn; matching reviews use fingerprint then
+		// idempotency-key order.
+		rows.set(key, existing ? mergeCompatibleIntentEvidence(existing, row) : row);
 	}
 	const actors = new Map<string, ActorRow>();
 	for (const actor of plan.actors) {
@@ -685,7 +986,7 @@ function deduplicatePlan(plan: ProjectPlan): ProjectPlan {
 	return { ...plan, rows: [...rows.values()], actors: [...actors.values()] };
 }
 
-function safeMigrationErrorCode(error: unknown): string {
+function projectMigrationErrorCode(error: unknown): string | null {
 	const allowed = new Set([
 		"reviewed_project_set_digest_mismatch",
 		"linked_identity_invalid",
@@ -702,22 +1003,149 @@ function safeMigrationErrorCode(error: unknown): string {
 	const message = error instanceof Error ? error.message : "";
 	if (allowed.has(message)) return message;
 	if (message === "team_setup_assignment_changed") return "device_identity_conflict";
-	const code =
-		error && typeof error === "object" && "code" in error
-			? String((error as { code?: unknown }).code ?? "")
-			: "";
-	if (code === "SQLITE_BUSY") return "migration_busy";
-	if (code.startsWith("SQLITE_CONSTRAINT")) return "intent_conflict";
-	return "migration_failed";
+	return null;
 }
 
-export function migrateRecipientPolicyIntent(
+function migrateProjectInTransaction(input: {
+	db: Database;
+	context: RecipientPolicyReviewContext;
+	projection: LegacyRecipientPolicyProjectionV1;
+	currentItems: RecipientPolicyActionableReviewItemV1[];
+	resolutions: StoredResolution[];
+	resolutionBySource: Map<string, StoredResolution>;
+	compatibleDeviceEvidence: ReadonlyMap<string, IntentRow[]>;
+	now: string;
+	write: boolean;
+}): RecipientPolicyMigrationProjectResultV1 {
+	const {
+		db,
+		context,
+		projection,
+		currentItems,
+		resolutions,
+		resolutionBySource,
+		compatibleDeviceEvidence,
+		now,
+		write,
+	} = input;
+	const projectId = projection.project.canonicalIdentity;
+	const matchingResolutions = currentItems.map((item) =>
+		resolutionBySource.get(`${item.reviewItemId}\u0000${item.sourceFingerprint}`),
+	);
+	if (matchingResolutions.some((resolution) => !resolution)) {
+		const hasStaleResolution = currentItems.some((item) =>
+			resolutions.some(
+				(resolution) =>
+					resolution.review_item_id === item.reviewItemId &&
+					resolution.source_fingerprint !== item.sourceFingerprint,
+			),
+		);
+		return {
+			canonicalProjectIdentity: projectId,
+			status: "skipped",
+			writeCount: 0,
+			idempotent: false,
+			errorCode: hasStaleResolution ? "review_resolution_stale" : "review_resolution_missing",
+		};
+	}
+	let plan: ProjectPlan = { rows: [], actors: [], hadApplicableEvidence: false };
+	const preserveResolutions = matchingResolutions
+		.map((resolution, index) => ({ resolution, currentItem: currentItems[index] }))
+		.filter(
+			(
+				entry,
+			): entry is {
+				resolution: StoredResolution;
+				currentItem: RecipientPolicyActionableReviewItemV1;
+			} => entry.resolution?.decision === "preserve_current_access" && entry.currentItem != null,
+		);
+	for (const { resolution, currentItem } of preserveResolutions) {
+		if (!currentItem.options.some((option) => option.decision === resolution.decision)) {
+			throw new Error("review_decision_unsupported");
+		}
+		const reviewError = addReviewDecision(
+			db,
+			plan,
+			projection,
+			currentItem,
+			resolution,
+			context,
+			now,
+		);
+		if (reviewError !== "review_preserves_legacy_access") {
+			throw new Error(reviewError ?? "review_decision_unsupported");
+		}
+	}
+	if (preserveResolutions.length > 0) {
+		return {
+			canonicalProjectIdentity: projectId,
+			status: "skipped",
+			writeCount: 0,
+			idempotent: true,
+			errorCode: "review_preserves_legacy_access",
+		};
+	}
+	const operationError = addAutomaticOperationEvidence(
+		db,
+		plan,
+		projection,
+		context.localActorId,
+		now,
+	);
+	if (operationError) throw new Error(operationError);
+	for (const [index, resolution] of matchingResolutions.entries()) {
+		if (!resolution) continue;
+		const currentItem = currentItems[index];
+		if (!currentItem?.options.some((option) => option.decision === resolution.decision)) {
+			throw new Error("review_decision_unsupported");
+		}
+		const reviewError = addReviewDecision(
+			db,
+			plan,
+			projection,
+			currentItem,
+			resolution,
+			context,
+			now,
+		);
+		if (reviewError) throw new Error(reviewError);
+	}
+	plan = deduplicatePlan(plan);
+	if (!plan.hadApplicableEvidence) {
+		return {
+			canonicalProjectIdentity: projectId,
+			status: "skipped",
+			writeCount: 0,
+			idempotent: false,
+			errorCode: "migration_evidence_missing",
+		};
+	}
+	let plannedWriteCount = 0;
+	for (const actor of plan.actors) {
+		if (validateOrWriteActor(db, actor, now, write)) plannedWriteCount += 1;
+	}
+	for (const row of plan.rows) {
+		const changed =
+			row.table === "identity_devices"
+				? validateOrAssignIdentityDevice(db, row, write, compatibleDeviceEvidence)
+				: validateOrWriteRow(db, row, write);
+		if (changed) plannedWriteCount += 1;
+	}
+	return {
+		canonicalProjectIdentity: projectId,
+		status: plannedWriteCount === 0 ? "unchanged" : write ? "migrated" : "would_migrate",
+		writeCount: write ? plannedWriteCount : 0,
+		idempotent: plannedWriteCount === 0,
+		errorCode: null,
+	};
+}
+
+function migrateRecipientPolicyIntentInTransaction(
 	db: Database,
 	context: RecipientPolicyReviewContext,
-	options: RecipientPolicyMigrationOptions = {},
+	dryRun: boolean,
+	now: string,
 ): RecipientPolicyMigrationResultV1 {
-	const dryRun = options.dryRun === true;
-	const now = (context.now ?? (() => new Date().toISOString()))();
 	const projections = listLegacyRecipientPolicyProjections(db, context);
 	const reviewState = deriveRecipientPolicyReviewState(db, context, projections);
 	const resolutions = db
@@ -732,7 +1160,7 @@ export function migrateRecipientPolicyIntent(
 			resolution,
 		]),
 	);
-	const currentItemsByProject = new Map<string, typeof reviewState.allReviewItems>();
+	const currentItemsByProject = new Map<string, RecipientPolicyActionableReviewItemV1[]>();
 	for (const item of reviewState.allReviewItems) {
 		const projectId = projectIdForReviewItem(item);
 		if (!projectId) continue;
@@ -740,137 +1168,61 @@ export function migrateRecipientPolicyIntent(
 		items.push(item);
 		currentItemsByProject.set(projectId, items);
 	}
+	// This index depends only on the stable review snapshot, never on writes made
+	// while individual Projects migrate below.
+	const compatibleDeviceEvidence = collectCompatibleDeviceEvidence({
+		db,
+		context,
+		projections,
+		currentItemsByProject,
+		resolutionBySource,
+		now,
+	});
 	const results: RecipientPolicyMigrationProjectResultV1[] = [];
 	for (const projection of projections) {
 		const projectId = projection.project.canonicalIdentity;
-		const currentItems = currentItemsByProject.get(projectId) ?? [];
-		const matchingResolutions = currentItems.map((item) =>
-			resolutionBySource.get(`${item.reviewItemId}\u0000${item.sourceFingerprint}`),
-		);
-		if (matchingResolutions.some((resolution) => !resolution)) {
-			const hasStaleResolution = currentItems.some((item) =>
-				resolutions.some(
-					(resolution) =>
-						resolution.review_item_id === item.reviewItemId &&
-						resolution.source_fingerprint !== item.sourceFingerprint,
-				),
-			);
-			results.push({
-				canonicalProjectIdentity: projectId,
-				status: "skipped",
-				writeCount: 0,
-				idempotent: false,
-				errorCode: hasStaleResolution ? "review_resolution_stale" : "review_resolution_missing",
-			});
-			continue;
-		}
 		try {
-			let plan: ProjectPlan = { rows: [], actors: [], hadApplicableEvidence: false };
-			const preserveResolutions = matchingResolutions
-				.map((resolution, index) => ({ resolution, currentItem: currentItems[index] }))
-				.filter(
-					(
-						entry,
-					): entry is {
-						resolution: StoredResolution;
-						currentItem: RecipientPolicyActionableReviewItemV1;
-					} =>
-						entry.resolution?.decision === "preserve_current_access" && entry.currentItem != null,
-				);
-			for (const { resolution, currentItem } of preserveResolutions) {
-				if (!currentItem.options.some((option) => option.decision === resolution.decision)) {
-					throw new Error("review_decision_unsupported");
-				}
-				const reviewError = addReviewDecision(
+			const migrateProject = db.transaction(() =>
+				migrateProjectInTransaction({
 					db,
-					plan,
-					projection,
-					currentItem,
-					resolution,
 					context,
+					projection,
+					currentItems: currentItemsByProject.get(projectId) ?? [],
+					resolutions,
+					resolutionBySource,
+					compatibleDeviceEvidence,
 					now,
-				);
-				if (reviewError !== "review_preserves_legacy_access") {
-					throw new Error(reviewError ?? "review_decision_unsupported");
-				}
-			}
-			if (preserveResolutions.length > 0) {
-				results.push({
-					canonicalProjectIdentity: projectId,
-					status: "skipped",
-					writeCount: 0,
-					idempotent: true,
-					errorCode: "review_preserves_legacy_access",
-				});
-				continue;
-			}
-			const operationError = addAutomaticOperationEvidence(
-				db,
-				plan,
-				projection,
-				context.localActorId,
-				now,
+					write: !dryRun,
+				}),
 			);
-			if (operationError) throw new Error(operationError);
-			for (const [index, resolution] of matchingResolutions.entries()) {
-				if (!resolution) continue;
-				const currentItem = currentItems[index];
-				if (!currentItem?.options.some((option) => option.decision === resolution.decision)) {
-					throw new Error("review_decision_unsupported");
-				}
-				const reviewError = addReviewDecision(
-					db,
-					plan,
-					projection,
-					currentItem,
-					resolution,
-					context,
-					now,
-				);
-				if (reviewError) throw new Error(reviewError);
-			}
-			plan = deduplicatePlan(plan);
-			if (!plan.hadApplicableEvidence) {
-				results.push({
-					canonicalProjectIdentity: projectId,
-					status: "skipped",
-					writeCount: 0,
-					idempotent: false,
-					errorCode: "migration_evidence_missing",
-				});
-				continue;
-			}
-			let plannedWriteCount = 0;
-			const apply = (write: boolean) => {
-				for (const actor of plan.actors) {
-					if (validateOrWriteActor(db, actor, now, write)) plannedWriteCount += 1;
-				}
-				for (const row of plan.rows) {
-					const changed =
-						row.table === "identity_devices"
-							? validateOrAssignIdentityDevice(db, row, write)
-							: validateOrWriteRow(db, row, write);
-					if (changed) plannedWriteCount += 1;
-				}
-			};
-			if (dryRun) apply(false);
-			else db.transaction(() => apply(true)).immediate();
-			results.push({
-				canonicalProjectIdentity: projectId,
-				status: plannedWriteCount === 0 ? "unchanged" : dryRun ? "would_migrate" : "migrated",
-				writeCount: dryRun ? 0 : plannedWriteCount,
-				idempotent: plannedWriteCount === 0,
-				errorCode: null,
-			});
+			results.push(migrateProject());
 		} catch (error) {
+			// Some SQLite failures abort the outer transaction, not only the
+			// savepoint. Never continue in autocommit after losing authority.
+			if (!db.inTransaction) throw error;
+			const errorCode = projectMigrationErrorCode(error);
+			if (!errorCode) throw error;
 			results.push({
 				canonicalProjectIdentity: projectId,
 				status: "blocked",
 				writeCount: 0,
 				idempotent: false,
-				errorCode: safeMigrationErrorCode(error),
+				errorCode,
 			});
 		}
 	}
 	return { version: RECIPIENT_POLICY_CONTRACT_VERSION, dryRun, results };
+}
+
+export function migrateRecipientPolicyIntent(
+	db: Database,
+	context: RecipientPolicyReviewContext,
+	options: RecipientPolicyMigrationOptions = {},
+): RecipientPolicyMigrationResultV1 {
+	const dryRun = options.dryRun === true;
+	const now = (context.now ?? (() => new Date().toISOString()))();
+	const migrate = db.transaction(() =>
+		migrateRecipientPolicyIntentInTransaction(db, context, dryRun, now),
+	);
+	return dryRun ? migrate.deferred() : migrate.immediate();
 }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -11224,6 +11224,60 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("returns a structured response when recipient-policy migration cannot acquire its writer lock", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			let competing: InstanceType<typeof Database> | null = null;
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db.pragma("busy_timeout = 1");
+				competing = new Database(store.db.name);
+				competing.exec("BEGIN IMMEDIATE");
+
+				const response = await app.request("/api/sync/recipient-policy/v1/migrate", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({}),
+				});
+
+				expect(response.status).toBe(503);
+				expect(response.headers.get("Retry-After")).toBe("1");
+				expect(await response.json()).toEqual({ error: "migration_busy" });
+			} finally {
+				if (competing?.inTransaction) competing.exec("ROLLBACK");
+				competing?.close();
+				cleanup();
+			}
+		});
+
+		it("returns a generic recipient-policy migration failure without leaking details", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const prepare = store.db.prepare.bind(store.db);
+				store.db.prepare = (() => {
+					throw new Error("private SQLite migration detail");
+				}) as typeof store.db.prepare;
+
+				const response = await app.request("/api/sync/recipient-policy/v1/migrate", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({}),
+				});
+				store.db.prepare = prepare;
+				const text = await response.text();
+
+				expect(response.status).toBe(500);
+				expect(JSON.parse(text)).toEqual({ error: "migration_failed" });
+				expect(text).not.toContain("private SQLite migration detail");
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("strictly previews and commits safe recipient-policy edge changes", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -5866,13 +5866,21 @@ export function syncRoutes(
 		) {
 			return c.json({ error: "request_invalid" }, 400);
 		}
-		return c.json(
-			migrateRecipientPolicyIntent(
-				store.db,
-				{ localActorId: store.actorId, localDeviceId: store.deviceId },
-				{ dryRun: body.dryRun === true },
-			),
-		);
+		try {
+			return c.json(
+				migrateRecipientPolicyIntent(
+					store.db,
+					{ localActorId: store.actorId, localDeviceId: store.deviceId },
+					{ dryRun: body.dryRun === true },
+				),
+			);
+		} catch (error) {
+			if (isSqliteBusy(error)) {
+				c.header("Retry-After", "1");
+				return c.json({ error: "migration_busy" }, 503);
+			}
+			return c.json({ error: "migration_failed" }, 500);
+		}
 	});
 
 	const parseReviewRequest = (value: unknown): RecipientPolicyReviewResolveRequestV1 | null => {


### PR DESCRIPTION
## Description

- Run recipient-policy migration reads, validation, and writes under one outer transaction: `BEGIN IMMEDIATE` for writes and deferred transactions for dry runs.
- Preserve per-Project conflict isolation with savepoints while propagating transaction-aborting, storage, and unexpected failures so later Projects cannot write in autocommit mode.
- Bind new relationship metadata to authorizing evidence, retain evidence-checked v1 replay compatibility, and validate dynamic SQL identifiers against runtime allowlists.
- Return stable `migration_busy`/`migration_failed` HTTP responses without exposing SQLite details.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Full `pnpm run check`: 5,056 tests passed, 3 todo. Focused core migration and viewer route suites passed. Snyk Code found no high-severity issues in the changed packages. Independent CodeReviewer and pragmatism reviews returned GO.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced