### PR TITLE
fix(core): confirm dropped legacy Team mappings

### DIFF
--- a/packages/core/src/legacy-team-candidate.ts
+++ b/packages/core/src/legacy-team-candidate.ts
@@ -22,8 +22,8 @@ import {
 	deterministicPolicyTeamId,
 	INVITE_DECISION_PROVENANCES,
 	legacyTeamCandidateId,
+	legacyTeamProjectRef,
 	legacyTeamRosterFingerprint,
-	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
 import {
 	deriveRecipientPolicyEffectiveDevicesFromDatabase,
@@ -183,10 +183,7 @@ function projectInventory(
 		.map((project) => {
 			const sourceProjectIdentity = project.project.canonicalIdentity;
 			return {
-				projectRef: recipientPolicyDigest("legacy-team-project-ref-v1", [
-					candidateId,
-					sourceProjectIdentity,
-				]),
+				projectRef: legacyTeamProjectRef(candidateId, sourceProjectIdentity),
 				sourceProjectIdentity,
 				displayName: project.project.displayName,
 				sourceFingerprint: project.sourceFingerprint,

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -15,6 +15,7 @@ import {
 	deterministicPolicyTeamId,
 	legacyTeamCandidateId,
 	legacyTeamRosterFingerprint,
+	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
 import { deriveRecipientPolicyEffectiveDevicesFromDatabase } from "./recipient-policy-reconciliation.js";
 import { initTestSchema } from "./test-utils.js";
@@ -1585,7 +1586,7 @@ describe("legacy Team setup activation", () => {
 		);
 	});
 
-	it("revokes stale setup-owned recipient edges when repeat setup drops a Project", async () => {
+	it("confirms and applies setup-owned mapping removal when repeat setup drops a Project", async () => {
 		// Arrange: first setup authorizes PROJECT_A and PROJECT_B; the
 		// refreshed inventory then drops PROJECT_B entirely.
 		await finish(readyDraft());
@@ -1623,6 +1624,15 @@ describe("legacy Team setup activation", () => {
 			recipientId: deterministicPolicyTeamId(CANDIDATE),
 			change: "remove",
 		});
+		expect(review.accessDelta.projectChanges).toContainEqual({
+			projectRef: expect.stringMatching(/^legacy-team-project-ref-v1:/u),
+			fromProjectIdentity: PROJECT_B,
+			toProjectIdentity: null,
+			change: "remove",
+		});
+		expect(review.accessDeltaDigest).toBe(
+			recipientPolicyDigest("legacy-team-access-delta", review.accessDelta),
+		);
 		expect(result).toMatchObject({ status: "completed" });
 		expect(
 			db
@@ -1658,6 +1668,71 @@ describe("legacy Team setup activation", () => {
 				.pluck()
 				.get(PROJECT_A),
 		).toBe(1);
+	});
+
+	it("preserves a dropped-pattern setup mapping owned by another coordinator group", async () => {
+		// Arrange: establish this group's setup, then add a setup-owned mapping
+		// for another group whose pattern is absent from the repeat draft. The
+		// canonical preflight only examines current draft patterns, so cleanup's
+		// ownership filter is the protection under test.
+		await finish(readyDraft());
+		db.prepare(
+			`INSERT INTO replication_scopes(
+			 scope_id, label, kind, authority_type, coordinator_id, group_id,
+			 membership_epoch, status, created_at, updated_at
+			 ) VALUES ('scope-other-group-dropped', 'Other Group', 'team', 'coordinator',
+			 'coordinator-other', 'group-other', 1, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const foreignProject = "https://git.example.invalid/other/dropped.git";
+		db.prepare(
+			`INSERT INTO project_scope_mappings(
+			 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, 'unmapped:other-dropped', 'scope-other-group-dropped', 1000,
+			 'reviewed_team_setup', ?, ?)`,
+		).run(foreignProject, NOW, NOW);
+		let draft = refreshLegacyTeamSetupDraft(db, {
+			...snapshot(),
+			projects: [snapshot().projects[0] as ReturnType<typeof snapshot>["projects"][number]],
+		});
+		for (const device of draft.devices) {
+			const identityId = device.displayName === "Laptop" ? "identity-a" : "identity-b";
+			draft = setLegacyTeamSetupDeviceAssignment(db, {
+				attemptId: draft.attemptId,
+				deviceRef: device.deviceRef,
+				targetIdentityId: identityId,
+				expectation: device.expectation,
+				now: NOW,
+			});
+			draft = setLegacyTeamSetupDeviceDecision(db, {
+				attemptId: draft.attemptId,
+				deviceRef: device.deviceRef,
+				decision: "included",
+				now: NOW,
+			});
+		}
+		const review = preview(draft);
+
+		// Act
+		await finish(draft, review);
+
+		// Assert: neither simulation nor commit treats another group's mapping
+		// as this setup's dropped mapping.
+		expect(review.accessDelta.projectChanges).not.toContainEqual(
+			expect.objectContaining({ fromProjectIdentity: foreignProject, change: "remove" }),
+		);
+		expect(
+			db
+				.prepare(
+					`SELECT workspace_identity, project_pattern, scope_id, source
+					 FROM project_scope_mappings WHERE scope_id = 'scope-other-group-dropped'`,
+				)
+				.get(),
+		).toEqual({
+			workspace_identity: foreignProject,
+			project_pattern: "unmapped:other-dropped",
+			scope_id: "scope-other-group-dropped",
+			source: "reviewed_team_setup",
+		});
 	});
 
 	it("finishes when an excluded device carries a revoked assignment", async () => {

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -21,6 +21,7 @@ import type {
 } from "./recipient-policy-contract.js";
 import {
 	deterministicPolicyTeamId,
+	legacyTeamProjectRef,
 	legacyTeamRosterFingerprint,
 	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
@@ -342,6 +343,18 @@ function persistSafeError(
 
 function compareText(left: string, right: string): number {
 	return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function droppedSetupMappings(model: ActivationModel): MappingRow[] {
+	const committedSourceIdentities = new Set(
+		model.projects.map((project) => project.source_project_identity),
+	);
+	return model.mappings.filter(
+		(mapping) =>
+			mapping.source === "reviewed_team_setup" &&
+			model.groupScopeIds.includes(mapping.scope_id) &&
+			!committedSourceIdentities.has(mapping.project_pattern),
+	);
 }
 
 function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): ActivationModel {
@@ -1041,6 +1054,7 @@ function buildAccessDelta(model: ActivationModel): LegacyTeamSetupAccessDeltaV1 
 				(row) =>
 					row.project_pattern === project.source_project_identity &&
 					row.source === "reviewed_team_setup" &&
+					model.groupScopeIds.includes(row.scope_id) &&
 					row.workspace_identity != null,
 			);
 			accessDelta.projectChanges.push({
@@ -1066,6 +1080,18 @@ function buildAccessDelta(model: ActivationModel): LegacyTeamSetupAccessDeltaV1 
 				change: "add",
 			});
 		}
+	}
+	// Mapping cleanup is independently authorization-relevant: scope stamping
+	// consults these rows without considering recipient status. Represent every
+	// setup-owned deletion in the server-derived payload so it participates in
+	// the same confirmation digest as the mutation it simulates.
+	for (const mapping of droppedSetupMappings(model)) {
+		accessDelta.projectChanges.push({
+			projectRef: legacyTeamProjectRef(model.draft.candidate_id, mapping.project_pattern),
+			fromProjectIdentity: mapping.workspace_identity,
+			toProjectIdentity: null,
+			change: "remove",
+		});
 	}
 	// Stale setup-owned edges are revoked by this activation; the confirmed
 	// delta must list the removal, or the user would approve a payload that
@@ -1127,7 +1153,13 @@ function buildAccessDelta(model: ActivationModel): LegacyTeamSetupAccessDeltaV1 
 		(left, right) =>
 			compareText(left.identityId, right.identityId) || compareText(left.change, right.change),
 	);
-	accessDelta.projectChanges.sort((left, right) => compareText(left.projectRef, right.projectRef));
+	accessDelta.projectChanges.sort(
+		(left, right) =>
+			compareText(left.projectRef, right.projectRef) ||
+			compareText(left.fromProjectIdentity ?? "", right.fromProjectIdentity ?? "") ||
+			compareText(left.toProjectIdentity ?? "", right.toProjectIdentity ?? "") ||
+			compareText(left.change, right.change),
+	);
 	accessDelta.recipientChanges.sort((left, right) =>
 		compareText(left.canonicalProjectIdentity, right.canonicalProjectIdentity),
 	);
@@ -1543,26 +1575,16 @@ function applyActivation(
 	// would keep routing new sessions and memories for the dropped Project
 	// into the Team's coordinator scope despite the confirmed removal — and
 	// could shadow mappings retained by merged resolutions.
-	const committedSourceIdentities = model.projects.map(
-		(project) => project.source_project_identity,
-	);
-	// The scope subquery covers EVERY scope the group has ever exposed, not
-	// only currently active ones: a mapping pointing at a retired or replaced
-	// scope still routes new sessions there because scope stamping never
-	// checks the referenced scope's status.
-	db.prepare(
-		`DELETE FROM project_scope_mappings
-		 WHERE source = 'reviewed_team_setup'
-		   AND scope_id IN (
-		     SELECT scope_id FROM replication_scopes
-		     WHERE coordinator_id = ? AND group_id = ?
-		   )
-		   ${
-					committedSourceIdentities.length > 0
-						? `AND project_pattern NOT IN (${committedSourceIdentities.map(() => "?").join(", ")})`
-						: ""
-}`,
-	).run(model.draft.coordinator_id, model.draft.group_id, ...committedSourceIdentities);
+	// Use the same locked-snapshot plan as the confirmation simulation. It
+	// includes mappings on retired group scopes, while excluding every row not
+	// owned by this setup/group.
+	const droppedMappingIds = droppedSetupMappings(model).map((mapping) => mapping.id);
+	if (droppedMappingIds.length > 0) {
+		db.prepare(
+			`DELETE FROM project_scope_mappings
+			 WHERE id IN (${droppedMappingIds.map(() => "?").join(", ")})`,
+		).run(...droppedMappingIds);
+	}
 
 	// The completion-bound mapping must be the SELECTED mapping. A
 	// pre-existing higher-priority exact mapping for the resolved identity

--- a/packages/core/src/recipient-policy-contract.ts
+++ b/packages/core/src/recipient-policy-contract.ts
@@ -206,7 +206,7 @@ export interface LegacyTeamSetupMembershipChangeV1 {
 export interface LegacyTeamSetupProjectChangeV1 {
 	projectRef: string;
 	fromProjectIdentity: string | null;
-	toProjectIdentity: string;
+	toProjectIdentity: string | null;
 	change: LegacyTeamSetupActivationChangeV1;
 }
 

--- a/packages/core/src/recipient-policy-identifiers.ts
+++ b/packages/core/src/recipient-policy-identifiers.ts
@@ -112,6 +112,10 @@ export function legacyTeamCandidateId(coordinatorId: string, groupId: string): s
 	return `legacy-team-candidate:${digest}`;
 }
 
+export function legacyTeamProjectRef(candidateId: string, sourceProjectIdentity: string): string {
+	return recipientPolicyDigest("legacy-team-project-ref-v1", [candidateId, sourceProjectIdentity]);
+}
+
 export function deterministicPolicyTeamId(teamCandidateId: string): string {
 	return legacyRecipientPolicyDigest("policy-team-v1", teamCandidateId);
 }


### PR DESCRIPTION
## Description

Include dropped setup-owned Project mappings in the activation confirmation delta and digest. Preserve mappings owned by other coordinator groups and keep preview/apply behavior aligned.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, focused Vitest suite)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused validation: 130 tests passed. Snyk high-severity scan reported 0 issues. Code review returned GO.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced