### PR TITLE
fix(core): harden legacy Team evidence identifiers

### DIFF
--- a/docs/adr/0002-legacy-team-hardening-boundaries.md
+++ b/docs/adr/0002-legacy-team-hardening-boundaries.md
@@ -1,0 +1,31 @@
+# ADR 0002: Legacy Team hardening boundaries
+
+**Date:** 2026-08-23
+**Status:** Accepted
+
+## Context
+
+Legacy Team discovery and enrollment reconciliation need deterministic evidence across runtimes. The hardening review also raised whether confirmation should bind a narrower canonical snapshot and whether a repaired Project identity must already appear in discovered evidence.
+
+## Decisions
+
+### Keep the existing broad canonical confirmation binding
+
+Confirmation continues to bind the broad canonical snapshot used by activation: Teams, memberships, device assignments and decisions, Project recipients, mappings, identities, historical resolutions, and active group scopes. This can conservatively stale an in-flight confirmation after an unrelated canonical write, but narrowing the snapshot without a proven dependency closure could accept an outdated access review. Completed setups continue to use their separate authoritative Ready checks rather than this in-flight confirmation digest.
+
+### Allow bounded new Project identity targets
+
+A repaired Project mapping may target a new canonical remote or workspace identity that was not present in the displayed discovery evidence. Legitimate repairs can introduce that identity, so core validation must not require evidence-set membership. The target remains bounded by canonical identity parsing and shareability checks, is persisted in the draft, participates in the finish and access-delta digests, passes canonical preflight, and is applied atomically. The viewer API must preserve those bounds without inventing a narrower evidence allowlist.
+
+### Use locale-independent protocol ordering
+
+Persisted evidence, digests, and protocol-facing arrays use the existing `compareCodepoints` rule. Despite its historical name, the rule compares JavaScript strings by UTF-16 code units (`<` and `>`), not Unicode scalar values or locale collation. Presentation-only ordering may continue to use locale-aware comparison and is outside this decision.
+
+## Consequences
+
+- Canonical enrollment digest objects are serialized by sorted UTF-16 code-unit keys and remain domain-separated raw SHA-256 hex.
+- Canonical eligibility, discovery, and enrollment reconciliation share one strict identifier grammar: nonempty, already trimmed, at most 256 UTF-16 units, with control and format characters rejected.
+- Pre-existing canonical rows outside that grammar become ineligible on upgrade; this is a deliberate fail-closed tightening.
+- Discovery rejects malformed coordinator, group, or device identifiers rather than normalizing them; malformed enrollment fingerprints become isolated device issues.
+- Unrelated canonical writes may conservatively require the user to refresh an in-flight confirmation.
+- No schema, API, UI, or generated-asset change is required.

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -987,6 +987,7 @@ describe("coordinator local admin actions", () => {
 			{ ...valid, assigned_identity_id: ` ${valid.assigned_identity_id}` },
 			{ ...valid, recipient_actor_id: `${valid.recipient_actor_id} ` },
 			{ ...valid, invite_id: ` ${valid.invite_id}` },
+			{ ...valid, invite_id: "i".repeat(257) },
 			{ ...valid, policy_team_id: `${valid.policy_team_id} ` },
 			{ ...valid, policy_team_id: "p".repeat(257) },
 			{ ...valid, bound_device_id: ` ${valid.bound_device_id}` },

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -963,7 +963,7 @@ function consumedTeamInvites(
 				"device_display_name",
 			);
 			const row: CoordinatorConsumedTeamInvite = {
-				invite_id: requiredConsumedTeamInviteText(invite.invite_id),
+				invite_id: requiredConsumedTeamInviteText(invite.invite_id, 256),
 				group_id: requiredConsumedTeamInviteText(invite.group_id),
 				policy_team_id: requiredConsumedTeamInviteText(invite.policy_team_id, 256),
 				assigned_identity_id: assignedIdentityId,

--- a/packages/core/src/coordinator-enrollment-reconciler.test.ts
+++ b/packages/core/src/coordinator-enrollment-reconciler.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Database as DatabaseType } from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { reconcileCoordinatorEnrollmentSnapshot } from "./coordinator-enrollment-reconciler.js";
+import {
+	coordinatorEnrollmentDigest,
+	reconcileCoordinatorEnrollmentSnapshot,
+} from "./coordinator-enrollment-reconciler.js";
 import { connect } from "./db.js";
 import { deriveRecipientPolicyEffectiveDevicesFromDatabase } from "./recipient-policy-reconciliation.js";
 
@@ -31,6 +34,86 @@ describe("reconcileCoordinatorEnrollmentSnapshot", () => {
 	afterEach(() => {
 		db.close();
 		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("pins a canonical reconciliation digest vector with domain separation", () => {
+		const first = coordinatorEnrollmentDigest("recipient-policy-test-v1", {
+			b: [true, null, "x"],
+			a: 1,
+		});
+		const reordered = coordinatorEnrollmentDigest("recipient-policy-test-v1", {
+			a: 1,
+			b: [true, null, "x"],
+		});
+		const changed = coordinatorEnrollmentDigest("recipient-policy-test-v1", {
+			a: 2,
+			b: [true, null, "x"],
+		});
+
+		expect(first).toMatch(/^[a-f0-9]{64}$/u);
+		// These bytes are persisted evidence; changing this vector requires an explicit DB rekey.
+		expect(first).toBe("3ccd3e1ed08f09bd3923eadc07eb9dc45f49284ab51fe49c674a0f46c574c06e");
+		expect(reordered).toBe(first);
+		expect(changed).not.toBe(first);
+		expect(
+			coordinatorEnrollmentDigest("coordinator-identity-device-idempotency-v1", {
+				groupId: "group-a",
+				identityId: "identity-a",
+				deviceId: "device-a",
+				fingerprint: "fp-a",
+			}),
+		).toBe("ead3486605d3bfa1e0ad0b991f0294ee08f1fcf24b3b42e0cd7db984766930b5");
+		expect(
+			coordinatorEnrollmentDigest("recipient-policy-test-b-v1", {
+				a: 1,
+				b: [true, null, "x"],
+			}),
+		).not.toBe(first);
+	});
+
+	it("isolates a runtime-invalid enrollment fingerprint and continues valid work", () => {
+		const result = reconcileCoordinatorEnrollmentSnapshot(db, {
+			coordinatorId: "https://coord.example.test",
+			groupId: "group-a",
+			now: NOW,
+			consumedTeamInvites: [],
+			enrollments: [
+				{
+					group_id: "group-a",
+					device_id: "device-invalid-fingerprint",
+					public_key: "pk-invalid-fingerprint",
+					fingerprint: undefined as unknown as string,
+					identity_id: "identity-direct",
+					display_name: "Invalid fingerprint",
+					enabled: 1,
+					created_at: NOW,
+				},
+				{
+					group_id: "group-a",
+					device_id: "device-valid",
+					public_key: "pk-valid",
+					fingerprint: "fp-valid",
+					identity_id: "identity-direct",
+					display_name: "Valid device",
+					enabled: 1,
+					created_at: NOW,
+				},
+			],
+		});
+
+		expect(result).toMatchObject({
+			devicesAdded: 1,
+			issues: [
+				{
+					kind: "device",
+					referenceId: "device-invalid-fingerprint",
+					code: "enrollment_invalid",
+				},
+			],
+		});
+		expect(db.prepare("SELECT device_id FROM identity_devices").pluck().all()).toEqual([
+			"device-valid",
+		]);
 	});
 
 	it("materializes accepted Team membership and new devices idempotently", () => {
@@ -1091,5 +1174,90 @@ describe("reconcileCoordinatorEnrollmentSnapshot", () => {
 			.get();
 		expect(persistedReferenceId).toBe(result.issues[0]?.referenceId);
 		expect(String(persistedReferenceId)).not.toContain("secret");
+	});
+
+	it("hashes missing runtime reference IDs without rolling back valid enrollment work", () => {
+		const result = reconcileCoordinatorEnrollmentSnapshot(db, {
+			coordinatorId: "https://coord.example.test",
+			groupId: "group-a",
+			now: NOW,
+			consumedTeamInvites: [
+				{
+					invite_id: undefined as unknown as string,
+					group_id: "group-a",
+					policy_team_id: "team-a",
+					assigned_identity_id: "identity-direct",
+					recipient_actor_id: "identity-direct",
+					bound_device_id: "device-invalid-invite",
+					consumed_at: NOW,
+				},
+			],
+			enrollments: [
+				{
+					group_id: "group-a",
+					device_id: undefined as unknown as string,
+					public_key: "pk-invalid",
+					fingerprint: "fp-invalid",
+					identity_id: "identity-direct",
+					display_name: null,
+					enabled: 1,
+					created_at: NOW,
+				},
+				{
+					group_id: "group-a",
+					device_id: "device-valid",
+					public_key: "pk-valid",
+					fingerprint: "fp-valid",
+					identity_id: "identity-direct",
+					display_name: "Valid device",
+					enabled: 1,
+					created_at: NOW,
+				},
+			],
+		});
+
+		expect(result).toMatchObject({
+			devicesAdded: 1,
+			membershipsAdded: 0,
+			issues: [
+				{
+					kind: "device",
+					referenceId: expect.stringMatching(/^invalid-reference:[a-f0-9]{64}$/u),
+					code: "enrollment_invalid",
+				},
+				{
+					kind: "team_membership",
+					referenceId: expect.stringMatching(/^invalid-reference:[a-f0-9]{64}$/u),
+					code: "team_invite_invalid",
+				},
+			],
+		});
+		expect(db.prepare("SELECT device_id FROM identity_devices").pluck().all()).toEqual([
+			"device-valid",
+		]);
+		expect(db.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get()).toBe(0);
+	});
+
+	it("orders persisted reconciliation issues by locale-independent code units", () => {
+		const enrollment = (deviceId: string) => ({
+			group_id: "group-a",
+			device_id: deviceId,
+			public_key: `pk-${deviceId}`,
+			fingerprint: `fp-${deviceId}`,
+			identity_id: "identity-missing",
+			display_name: null,
+			enabled: 1,
+			created_at: NOW,
+		});
+
+		const result = reconcileCoordinatorEnrollmentSnapshot(db, {
+			coordinatorId: "https://coord.example.test",
+			groupId: "group-a",
+			now: NOW,
+			consumedTeamInvites: [],
+			enrollments: [enrollment("ä-device"), enrollment("z-device")],
+		});
+
+		expect(result.issues.map((issue) => issue.referenceId)).toEqual(["z-device", "ä-device"]);
 	});
 });

--- a/packages/core/src/coordinator-enrollment-reconciler.ts
+++ b/packages/core/src/coordinator-enrollment-reconciler.ts
@@ -6,6 +6,11 @@ import type { Database } from "./db.js";
 import { assignIdentityDeviceInTransaction } from "./identity-device-assignment.js";
 import { normalizeIdentityDisplayName } from "./project-invite-identity.js";
 import {
+	canonicalRecipientPolicyJson,
+	compareCodepoints,
+	isStrictRecipientPolicyId,
+} from "./recipient-policy-identifiers.js";
+import {
 	planInviteDeviceDecisionTransition,
 	planInviteMembershipTransition,
 } from "./team-ownership-transitions.js";
@@ -24,20 +29,31 @@ export interface CoordinatorEnrollmentReconcileResult {
 	issues: CoordinatorEnrollmentReconcileIssue[];
 }
 
-function digest(kind: string, value: unknown): string {
+export function coordinatorEnrollmentDigest(kind: string, value: unknown): string {
+	if (kind.includes("\0") || !kind.isWellFormed()) {
+		throw new TypeError("Coordinator enrollment digest kind must be well-formed without NUL");
+	}
 	return createHash("sha256")
-		.update(JSON.stringify([kind, value]))
+		.update(kind, "utf8")
+		.update("\0", "utf8")
+		.update(canonicalRecipientPolicyJson(value), "utf8")
 		.digest("hex");
 }
 
-function strictId(value: unknown): value is string {
-	return (
-		typeof value === "string" &&
-		value.length > 0 &&
-		value === value.trim() &&
-		value.length <= 256 &&
-		!/[\p{Cc}\p{Cf}]/u.test(value)
-	);
+function invalidIssueReferenceEvidence(
+	kind: CoordinatorEnrollmentReconcileIssue["kind"],
+	referenceId: unknown,
+): Record<string, string | null> {
+	if (typeof referenceId === "string") return { kind, referenceId };
+	const referenceType = referenceId === null ? "null" : typeof referenceId;
+	const referenceValue =
+		typeof referenceId === "number" ||
+		typeof referenceId === "boolean" ||
+		typeof referenceId === "bigint" ||
+		typeof referenceId === "symbol"
+			? String(referenceId)
+			: null;
+	return { kind, referenceType, referenceValue };
 }
 
 function normalizedDisplayNameOrNull(
@@ -71,8 +87,8 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 		now?: string;
 	},
 ): CoordinatorEnrollmentReconcileResult {
-	if (!strictId(input.coordinatorId)) throw new Error("coordinator_id_invalid");
-	if (!strictId(input.groupId)) throw new Error("coordinator_group_id_invalid");
+	if (!isStrictRecipientPolicyId(input.coordinatorId)) throw new Error("coordinator_id_invalid");
+	if (!isStrictRecipientPolicyId(input.groupId)) throw new Error("coordinator_group_id_invalid");
 	const now = input.now ?? new Date().toISOString();
 	if (Number.isNaN(new Date(now).getTime())) throw new Error("reconciliation_time_invalid");
 	const result: CoordinatorEnrollmentReconcileResult = {
@@ -84,15 +100,15 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 	};
 	const issue = (
 		kind: CoordinatorEnrollmentReconcileIssue["kind"],
-		referenceId: string,
+		referenceId: unknown,
 		code: string,
 	): void => {
-		const safeReferenceId = strictId(referenceId)
+		const safeReferenceId = isStrictRecipientPolicyId(referenceId)
 			? referenceId
-			: `invalid-reference:${digest("coordinator-enrollment-issue-reference-v1", {
-					kind,
-					referenceId,
-				})}`;
+			: `invalid-reference:${coordinatorEnrollmentDigest(
+					"coordinator-enrollment-issue-reference-v1",
+					invalidIssueReferenceEvidence(kind, referenceId),
+				)}`;
 		result.issues.push({ kind, referenceId: safeReferenceId, code });
 	};
 	const localEnrollmentIdentityIds = new Set(
@@ -102,7 +118,9 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 					enrollment.group_id === input.groupId &&
 					enrollment.enabled === 1 &&
 					enrollment.device_id === input.localDeviceId &&
-					strictId(enrollment.identity_id),
+					isStrictRecipientPolicyId(enrollment.device_id) &&
+					isStrictRecipientPolicyId(enrollment.identity_id) &&
+					isStrictRecipientPolicyId(enrollment.fingerprint),
 			)
 			.map((enrollment) => enrollment.identity_id as string),
 	);
@@ -140,9 +158,10 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 			);
 			if (
 				invite.group_id !== input.groupId ||
-				!strictId(identityId) ||
+				!isStrictRecipientPolicyId(invite.invite_id) ||
+				!isStrictRecipientPolicyId(identityId) ||
 				identityId !== invite.recipient_actor_id ||
-				!strictId(invite.policy_team_id)
+				!isStrictRecipientPolicyId(invite.policy_team_id)
 			) {
 				issue("team_membership", invite.invite_id, "team_invite_invalid");
 				continue;
@@ -240,9 +259,12 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 						 WHERE team_id = ? AND identity_id = ?`,
 					).run(
 						activeMembershipStatus,
-						digest("coordinator-team-membership-revision-v1", stableBinding),
-						digest("coordinator-team-membership-source-v1", stableBinding),
-						digest("coordinator-team-membership-idempotency-v1", stableBinding),
+						coordinatorEnrollmentDigest("coordinator-team-membership-revision-v1", stableBinding),
+						coordinatorEnrollmentDigest("coordinator-team-membership-source-v1", stableBinding),
+						coordinatorEnrollmentDigest(
+							"coordinator-team-membership-idempotency-v1",
+							stableBinding,
+						),
 						now,
 						invite.policy_team_id,
 						identityId,
@@ -276,9 +298,9 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 				invite.policy_team_id,
 				identityId,
 				activeMembershipStatus,
-				digest("coordinator-team-membership-revision-v1", stableBinding),
-				digest("coordinator-team-membership-source-v1", stableBinding),
-				digest("coordinator-team-membership-idempotency-v1", stableBinding),
+				coordinatorEnrollmentDigest("coordinator-team-membership-revision-v1", stableBinding),
+				coordinatorEnrollmentDigest("coordinator-team-membership-source-v1", stableBinding),
+				coordinatorEnrollmentDigest("coordinator-team-membership-idempotency-v1", stableBinding),
 				now,
 				now,
 			);
@@ -303,8 +325,9 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 			if (
 				enrollment.group_id !== input.groupId ||
 				enrollment.enabled !== 1 ||
-				!strictId(enrollment.device_id) ||
-				!strictId(identityId)
+				!isStrictRecipientPolicyId(enrollment.device_id) ||
+				!isStrictRecipientPolicyId(identityId) ||
+				!isStrictRecipientPolicyId(enrollment.fingerprint)
 			) {
 				issue("device", enrollment.device_id, "enrollment_invalid");
 				continue;
@@ -405,10 +428,19 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 				insert: {
 					displayName,
 					provenance: "coordinator_enrollment",
-					revision: digest("coordinator-identity-device-revision-v1", stableBinding),
+					revision: coordinatorEnrollmentDigest(
+						"coordinator-identity-device-revision-v1",
+						stableBinding,
+					),
 					migrationState: "user_managed",
-					sourceFingerprint: digest("coordinator-identity-device-source-v1", stableBinding),
-					idempotencyKey: digest("coordinator-identity-device-idempotency-v1", stableBinding),
+					sourceFingerprint: coordinatorEnrollmentDigest(
+						"coordinator-identity-device-source-v1",
+						stableBinding,
+					),
+					idempotencyKey: coordinatorEnrollmentDigest(
+						"coordinator-identity-device-idempotency-v1",
+						stableBinding,
+					),
 				},
 				now,
 			});
@@ -440,7 +472,10 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 					membership.newlyAdded,
 				);
 				if (transition === "preserve") continue;
-				const revision = digest("coordinator-team-device-decision-revision-v1", stableDecision);
+				const revision = coordinatorEnrollmentDigest(
+					"coordinator-team-device-decision-revision-v1",
+					stableDecision,
+				);
 				const changed =
 					transition === "insert_unresolved"
 						? db
@@ -493,9 +528,9 @@ export function reconcileCoordinatorEnrollmentSnapshot(
 		);
 		result.issues = [...issueSet.values()].sort(
 			(left, right) =>
-				left.kind.localeCompare(right.kind) ||
-				left.referenceId.localeCompare(right.referenceId) ||
-				left.code.localeCompare(right.code),
+				compareCodepoints(left.kind, right.kind) ||
+				compareCodepoints(left.referenceId, right.referenceId) ||
+				compareCodepoints(left.code, right.code),
 		);
 		persistCoordinatorEnrollmentReconciliationIssues(db, {
 			coordinatorId: input.coordinatorId,

--- a/packages/core/src/legacy-team-candidate.test.ts
+++ b/packages/core/src/legacy-team-candidate.test.ts
@@ -115,6 +115,83 @@ describe("legacy Team candidate discovery", () => {
 		);
 	});
 
+	it("rejects malformed discovery identities without hiding independent valid groups", () => {
+		const input = options();
+		const validGroup = input.groups[0];
+		if (!validGroup) throw new Error("invalid test fixture");
+		input.groups = [
+			{
+				...validGroup,
+				coordinatorId: " coordinator-padded",
+				groupId: "group-padded-coordinator",
+				displayName: "Padded coordinator",
+			},
+			{
+				...validGroup,
+				coordinatorId: "coordinator-control-group",
+				groupId: "group-control\n",
+				displayName: "Control group",
+			},
+			{
+				...validGroup,
+				coordinatorId: "coordinator-malformed-roster",
+				groupId: "group-malformed-roster",
+				displayName: "Malformed roster",
+				devices: [
+					...validGroup.devices,
+					{
+						deviceId: "device-padded ",
+						fingerprint: "key-padded",
+						displayName: "Padded device",
+						enabled: true,
+					},
+				],
+			},
+			validGroup,
+		];
+
+		const candidates = discoverLegacyTeamCandidates(db, input);
+
+		expect(candidates).toHaveLength(1);
+		expect(candidates[0]?.displayName).toBe("Engineering");
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(1);
+	});
+
+	it.each([
+		["device ID", (device: { deviceId: string }) => (device.deviceId = "device-\u200B-a")],
+		["fingerprint", (device: { fingerprint: string }) => (device.fingerprint = "key-\u200B-a")],
+	] as const)("rejects refresh with a malformed roster %s before writes", (_label, mutate) => {
+		const initialOptions = options();
+		const [candidate] = discoverLegacyTeamCandidates(db, initialOptions);
+		const candidateRef = candidate?.candidateRef as string;
+		const initialDraft = db
+			.prepare(
+				`SELECT attempt_id, updated_at FROM legacy_team_setup_drafts
+				 WHERE candidate_id = ?`,
+			)
+			.get(candidateRef);
+		const malformedOptions = options();
+		const malformedGroup = malformedOptions.groups[0];
+		const malformedDevice = malformedGroup?.devices[0];
+		if (!malformedGroup || !malformedDevice) throw new Error("invalid test fixture");
+		mutate(malformedDevice);
+
+		expect(() => refreshLegacyTeamCandidate(db, malformedOptions, candidateRef)).toThrow(
+			"legacy_team_setup_roster_conflict",
+		);
+		expect(
+			db
+				.prepare(
+					`SELECT attempt_id, updated_at FROM legacy_team_setup_drafts
+					 WHERE candidate_id = ?`,
+				)
+				.get(candidateRef),
+		).toEqual(initialDraft);
+		expect(
+			db.prepare("SELECT device_id FROM legacy_team_setup_draft_devices").pluck().all(),
+		).toEqual(["device-a"]);
+	});
+
 	it("skips an oversized group without aborting other candidate discovery", () => {
 		const input = options();
 		input.groups.unshift({

--- a/packages/core/src/legacy-team-candidate.ts
+++ b/packages/core/src/legacy-team-candidate.ts
@@ -21,6 +21,7 @@ import {
 	compareCodepoints,
 	deterministicPolicyTeamId,
 	INVITE_DECISION_PROVENANCES,
+	isStrictRecipientPolicyId,
 	legacyTeamCandidateId,
 	legacyTeamProjectRef,
 	legacyTeamRosterFingerprint,
@@ -87,6 +88,12 @@ function dedupedRosterDevices(
 ): LegacyTeamRosterDeviceSnapshot[] | null {
 	const byId = new Map<string, LegacyTeamRosterDeviceSnapshot>();
 	for (const device of devices) {
+		if (
+			!isStrictRecipientPolicyId(device.deviceId) ||
+			!isStrictRecipientPolicyId(device.fingerprint)
+		) {
+			return null;
+		}
 		const existing = byId.get(device.deviceId);
 		if (!existing) {
 			byId.set(device.deviceId, device);
@@ -136,9 +143,8 @@ function effectiveGroupSnapshots(groups: LegacyTeamConfiguredGroupSnapshot[]): {
 	const byCandidate = new Map<string, EffectiveGroupSnapshot>();
 	const conflictedCandidateIds = new Set<string>();
 	for (const group of groups) {
-		const coordinatorId = group.coordinatorId.trim();
-		const groupId = group.groupId.trim();
-		if (!coordinatorId || !groupId) continue;
+		const { coordinatorId, groupId } = group;
+		if (!isStrictRecipientPolicyId(coordinatorId) || !isStrictRecipientPolicyId(groupId)) continue;
 		const candidateId = legacyTeamCandidateId(coordinatorId, groupId);
 		const devices = dedupedRosterDevices(group.devices);
 		if (!devices) {
@@ -698,7 +704,9 @@ export function discoverLegacyTeamCandidates(
 			unresolvedProjectCount: result.draft.unresolvedProjectCount,
 		});
 	}
-	return candidates.toSorted((left, right) => left.candidateRef.localeCompare(right.candidateRef));
+	return candidates.toSorted((left, right) =>
+		compareCodepoints(left.candidateRef, right.candidateRef),
+	);
 }
 
 /**

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -692,6 +692,7 @@ describe("legacy Team setup drafts", () => {
 		for (const target of [
 			"C:\\repos\\acme",
 			"https://git.example.invalid/acme/web.git/",
+			"https://git.example.invalid/acme/web\u200b.git",
 			`https://git.example.invalid/${"a".repeat(2100)}`,
 			// Local paths round-trip unchanged through canonicalWorkspaceIdentity,
 			// so they must be rejected by shape.

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -13,6 +13,7 @@ import {
 import {
 	compareCodepoints,
 	deterministicPolicyTeamId,
+	isStrictRecipientPolicyProjectIdentity,
 	legacyTeamRosterFingerprint,
 	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
@@ -1168,8 +1169,7 @@ export function setLegacyTeamSetupProjectMapping(
 		/^[^/\\@\s]+@[^/\\:\s]+:\S+$/u.test(identity) ||
 		/^[^/\\:\s.]+(?:\.[^/\\:\s.]+)+:\S+$/u.test(identity);
 	if (
-		!identity ||
-		identity.length > 2048 ||
+		!isStrictRecipientPolicyProjectIdentity(identity) ||
 		identity.startsWith("unmapped:") ||
 		/\s/u.test(identity) ||
 		(/[/\\]/u.test(identity) && !isRemoteForm) ||

--- a/packages/core/src/policy-team-device-eligibility.test.ts
+++ b/packages/core/src/policy-team-device-eligibility.test.ts
@@ -147,6 +147,8 @@ describe("Team device eligibility", () => {
 		" device-a",
 		"device-a ",
 		"device-a\n",
+		"device-\u200B-a",
+		"d".repeat(257),
 	])("blocks malformed reviewed decision device ID %j", (deviceId) => {
 		const result = derivePolicyTeamDeviceEligibility({
 			teamId: "team-a",
@@ -161,6 +163,20 @@ describe("Team device eligibility", () => {
 			status: "blocked",
 			blocked: [{ code: "team_device_decision_invalid", referenceId: `team-a:${deviceId}` }],
 		});
+	});
+
+	it("accepts a canonical device ID at the 256 UTF-16-unit boundary", () => {
+		const deviceId = "d".repeat(256);
+		const result = derivePolicyTeamDeviceEligibility({
+			teamId: "team-a",
+			mode: "person_all_devices",
+			identities,
+			memberships: [{ identityId: "identity-a", status: "active" }],
+			devices: [{ identityId: "identity-a", deviceId, status: "active", assignmentVersion: 0 }],
+			decisions: [],
+		});
+
+		expect(result).toMatchObject({ status: "eligible", eligibleDeviceIds: [deviceId] });
 	});
 
 	it("accepts reviewed_active membership only for reviewed_allowlist", () => {

--- a/packages/core/src/policy-team-device-eligibility.ts
+++ b/packages/core/src/policy-team-device-eligibility.ts
@@ -1,3 +1,5 @@
+import { isStrictRecipientPolicyId } from "./recipient-policy-identifiers.js";
+
 export const POLICY_TEAM_DEVICE_ELIGIBILITY_MODES = [
 	"person_all_devices",
 	"reviewed_allowlist",
@@ -77,7 +79,6 @@ const MODES = new Set<string>(POLICY_TEAM_DEVICE_ELIGIBILITY_MODES);
 const DECISIONS = new Set<string>(POLICY_TEAM_DEVICE_DECISIONS);
 const DEVICE_STATUSES = new Set(["active", "revoked"]);
 const INACTIVE_MEMBERSHIP_STATUSES = new Set(["pending", "revoked"]);
-const CONTROL_CHARACTER = /\p{Cc}/u;
 // Surface authority-shape and principal-integrity failures before mutable
 // decision/device facts so callers expose the most security-relevant cause.
 const BLOCK_PRECEDENCE: Record<PolicyTeamDeviceEligibilityBlockCode, number> = {
@@ -93,10 +94,6 @@ const BLOCK_PRECEDENCE: Record<PolicyTeamDeviceEligibilityBlockCode, number> = {
 
 function compareText(left: string, right: string): number {
 	return left < right ? -1 : left > right ? 1 : 0;
-}
-
-function strictId(value: string): boolean {
-	return value.length > 0 && value === value.trim() && !CONTROL_CHARACTER.test(value);
 }
 
 export function isPolicyTeamMembershipActiveForMode(mode: string, status: string): boolean {
@@ -139,7 +136,7 @@ export function derivePolicyTeamDeviceEligibility(
 	const mode = input.mode as PolicyTeamDeviceEligibilityMode;
 	const activeMembers = new Set<string>();
 	for (const membership of input.memberships) {
-		if (!strictId(membership.identityId)) {
+		if (!isStrictRecipientPolicyId(membership.identityId)) {
 			addBlock("team_membership_invalid", `${input.teamId}:${membership.identityId}`);
 			continue;
 		}
@@ -173,7 +170,7 @@ export function derivePolicyTeamDeviceEligibility(
 			continue;
 		}
 		if (
-			!strictId(decision.deviceId) ||
+			!isStrictRecipientPolicyId(decision.deviceId) ||
 			!DECISIONS.has(decision.decision) ||
 			!Number.isSafeInteger(decision.assignmentVersion) ||
 			decision.assignmentVersion < 0 ||
@@ -193,8 +190,8 @@ export function derivePolicyTeamDeviceEligibility(
 		}
 		if (device.status !== "active") continue;
 		if (
-			!strictId(device.identityId) ||
-			!strictId(device.deviceId) ||
+			!isStrictRecipientPolicyId(device.identityId) ||
+			!isStrictRecipientPolicyId(device.deviceId) ||
 			!Number.isSafeInteger(device.assignmentVersion) ||
 			device.assignmentVersion < 0
 		) {

--- a/packages/core/src/recipient-policy-edges.test.ts
+++ b/packages/core/src/recipient-policy-edges.test.ts
@@ -235,7 +235,10 @@ describe("recipient-policy edge changes", () => {
 				],
 			},
 			{ version: 1, changes: [identityChange(` ${PROJECT_A}`, "identity-a")] },
+			{ version: 1, changes: [identityChange(`${PROJECT_A}\u200b`, "identity-a")] },
 			{ version: 1, changes: [identityChange(PROJECT_A, "identity-a\n")] },
+			{ version: 1, changes: [identityChange(PROJECT_A, "identity\u200b-a")] },
+			{ version: 1, changes: [teamChange(PROJECT_A, "team\u200b-a")] },
 			{
 				version: 1,
 				changes: [
@@ -248,6 +251,13 @@ describe("recipient-policy edge changes", () => {
 		]) {
 			expect(parseRecipientPolicyEdgePreviewRequest(invalid)).toBeNull();
 		}
+		expect(
+			parseRecipientPolicyEdgeCommitRequest({
+				version: 1,
+				changes: [identityChange(`${PROJECT_A}\u200b`, "identity-a")],
+				reviewedPolicyDigest: `edge-preview-v1:${"0".repeat(64)}`,
+			}),
+		).toBeNull();
 	});
 
 	it("normalizes project-first and recipient-first ordering identically and writes identical rows", () => {
@@ -701,6 +711,8 @@ describe("recipient-policy edge changes", () => {
 		" device-a",
 		"device-a ",
 		"device-a\n",
+		"device-\u200B-a",
+		"a".repeat(257),
 	])("blocks malformed direct-identity device ID %j identically in preview and authoritative derivation", (deviceId) => {
 		const db = seedGraph();
 		insertProjectRecipient(db, PROJECT_A, "identity-a");

--- a/packages/core/src/recipient-policy-edges.ts
+++ b/packages/core/src/recipient-policy-edges.ts
@@ -5,6 +5,10 @@ import {
 	type PolicyTeamDeviceEligibilityBlock,
 	type PolicyTeamDeviceEligibilityIdentity,
 } from "./policy-team-device-eligibility.js";
+import {
+	isStrictRecipientPolicyId,
+	isStrictRecipientPolicyProjectIdentity,
+} from "./recipient-policy-identifiers.js";
 import { canonicalWorkspaceIdentity } from "./scope-resolution.js";
 import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap-constants.js";
 
@@ -213,11 +217,11 @@ function parseRecipient(value: unknown): RecipientPolicyEdgeRecipientRefV1 | nul
 	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
 	const record = value as Record<string, unknown>;
 	if (record.recipientKind === "identity" && exactKeys(record, ["recipientKind", "identityId"])) {
-		const identityId = strictId(record.identityId, 256);
+		const identityId = isStrictRecipientPolicyId(record.identityId) ? record.identityId : null;
 		return identityId ? { recipientKind: "identity", identityId } : null;
 	}
 	if (record.recipientKind === "team" && exactKeys(record, ["recipientKind", "teamId"])) {
-		const teamId = strictId(record.teamId, 256);
+		const teamId = isStrictRecipientPolicyId(record.teamId) ? record.teamId : null;
 		return teamId ? { recipientKind: "team", teamId } : null;
 	}
 	return null;
@@ -233,7 +237,11 @@ function parseChanges(value: unknown): RecipientPolicyEdgeChangeV1[] | null {
 		if (!item || typeof item !== "object" || Array.isArray(item)) return null;
 		const record = item as Record<string, unknown>;
 		if (!exactKeys(record, ["canonicalProjectIdentity", "recipient", "action"])) return null;
-		const canonicalProjectIdentity = strictId(record.canonicalProjectIdentity, 512);
+		const canonicalProjectIdentity = isStrictRecipientPolicyProjectIdentity(
+			record.canonicalProjectIdentity,
+		)
+			? record.canonicalProjectIdentity
+			: null;
 		const recipient = parseRecipient(record.recipient);
 		if (
 			!canonicalProjectIdentity ||
@@ -625,7 +633,7 @@ function assertDesiredDirectIdentityEligibility(edges: StoredEdge[], devices: De
 		}
 		if (
 			device.status === "active" &&
-			(!strictId(device.identityId) || !strictId(device.deviceId))
+			(!isStrictRecipientPolicyId(device.identityId) || !isStrictRecipientPolicyId(device.deviceId))
 		) {
 			throw new RecipientPolicyEdgeRequestError("invalid", "identity_device_invalid");
 		}

--- a/packages/core/src/recipient-policy-identifiers.test.ts
+++ b/packages/core/src/recipient-policy-identifiers.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
 	canonicalRecipientPolicyJson,
 	deterministicPolicyTeamId,
+	isStrictRecipientPolicyId,
+	isStrictRecipientPolicyProjectIdentity,
 	legacyRecipientPolicyDigest,
 	legacyTeamCandidateId,
 	legacyTeamRosterFingerprint,
@@ -9,6 +11,31 @@ import {
 } from "./recipient-policy-identifiers.js";
 
 describe("recipient policy identifiers", () => {
+	it.each([
+		["ordinary ID", "device-a", true],
+		["256 UTF-16 units", "a".repeat(256), true],
+		["256 astral UTF-16 units", "😀".repeat(128), true],
+		["empty ID", "", false],
+		["leading whitespace", " device-a", false],
+		["trailing whitespace", "device-a ", false],
+		["Cc character", "device-a\n", false],
+		["Cf character", "device-\u200B-a", false],
+		["257 UTF-16 units", "a".repeat(257), false],
+		["258 astral UTF-16 units", "😀".repeat(129), false],
+		["non-string runtime value", undefined, false],
+	] as const)("validates the shared strict grammar for %s", (_label, value, expected) => {
+		expect(isStrictRecipientPolicyId(value)).toBe(expected);
+	});
+
+	it.each([
+		["257 UTF-16 units", "p".repeat(257), true],
+		["2048 UTF-16 units", "p".repeat(2_048), true],
+		["2049 UTF-16 units", "p".repeat(2_049), false],
+		["format character", `project-\u200B${"p".repeat(257)}`, false],
+	] as const)("validates canonical Project identity limits for %s", (_label, value, expected) => {
+		expect(isStrictRecipientPolicyProjectIdentity(value)).toBe(expected);
+	});
+
 	it.each([
 		["null", null, "null"],
 		["boolean", true, "true"],

--- a/packages/core/src/recipient-policy-identifiers.ts
+++ b/packages/core/src/recipient-policy-identifiers.ts
@@ -10,6 +10,26 @@ export function compareCodepoints(left: string, right: string): number {
 	return left < right ? -1 : left > right ? 1 : 0;
 }
 
+const RECIPIENT_POLICY_ID_CONTROL_OR_FORMAT_CHARACTER = /[\p{Cc}\p{Cf}]/u;
+
+function isStrictRecipientPolicyText(value: unknown, maxUtf16Units: number): value is string {
+	return (
+		typeof value === "string" &&
+		value.length > 0 &&
+		value === value.trim() &&
+		value.length <= maxUtf16Units &&
+		!RECIPIENT_POLICY_ID_CONTROL_OR_FORMAT_CHARACTER.test(value)
+	);
+}
+
+export function isStrictRecipientPolicyId(value: unknown): value is string {
+	return isStrictRecipientPolicyText(value, 256);
+}
+
+export function isStrictRecipientPolicyProjectIdentity(value: unknown): value is string {
+	return isStrictRecipientPolicyText(value, 2_048);
+}
+
 const INVALID_CANONICAL_JSON_MESSAGE = "Recipient policy value must be strict JSON data";
 
 function invalidCanonicalJson(): never {
@@ -104,6 +124,10 @@ export function legacyRecipientPolicyDigest(prefix: string, value: unknown): str
  */
 export const INVITE_DECISION_PROVENANCES = ["team_invite", "coordinator_invite"] as const;
 
+/**
+ * Frozen compatibility identifier persisted by released legacy Team drafts.
+ * Changing the JSON tuple bytes or truncation requires an explicit DB rekey.
+ */
 export function legacyTeamCandidateId(coordinatorId: string, groupId: string): string {
 	const digest = createHash("sha256")
 		.update(JSON.stringify([coordinatorId, groupId]))

--- a/packages/core/src/recipient-policy-onboarding.test.ts
+++ b/packages/core/src/recipient-policy-onboarding.test.ts
@@ -301,6 +301,14 @@ describe("recipient-policy onboarding", () => {
 
 	afterEach(() => db.close());
 
+	it.each([
+		["Identity", { identityId: "identity-\u200Bbad" }, "identity_id_invalid"],
+		["device", { deviceId: "device-\u200Bbad" }, "device_id_invalid"],
+		["Team", { journey: "team" as const, teamId: "team-\u200Bbad" }, "team_id_invalid"],
+	] as const)("rejects a format character in the onboarding %s ID", (_label, overrides, error) => {
+		expect(() => previewRecipientPolicyOnboarding(db, baseRequest(overrides))).toThrow(error);
+	});
+
 	it("builds fresh Team and add-device previews only from reviewed intent and local binding", () => {
 		const fresh = new Database(":memory:");
 		initTestSchema(fresh);
@@ -911,6 +919,19 @@ describe("recipient-policy onboarding", () => {
 		expect(addDevice.excludedProjects.map((project) => project.canonicalProjectIdentity)).toEqual([
 			PROJECT_C,
 		]);
+	});
+
+	it("rejects non-canonical direct Project identities at the request boundary", () => {
+		expect(() =>
+			previewRecipientPolicyOnboarding(
+				db,
+				baseRequest({
+					journey: "direct_project",
+					invitationId: "invite-direct-invalid-project",
+					canonicalProjectIdentities: [`${PROJECT_A}\u200b`],
+				}),
+			),
+		).toThrow("canonical_project_identity_invalid");
 	});
 
 	it("does not preview Team inheritance for a revoked existing binding device", () => {

--- a/packages/core/src/recipient-policy-onboarding.ts
+++ b/packages/core/src/recipient-policy-onboarding.ts
@@ -7,6 +7,10 @@ import {
 import { derivePolicyTeamDeviceEligibility } from "./policy-team-device-eligibility.js";
 import { normalizeIdentityDisplayName } from "./project-invite-identity.js";
 import {
+	isStrictRecipientPolicyId,
+	isStrictRecipientPolicyProjectIdentity,
+} from "./recipient-policy-identifiers.js";
+import {
 	normalizeRecipientReviewedIntent,
 	type RecipientReviewedIntentV1,
 } from "./recipient-reviewed-intent.js";
@@ -198,13 +202,20 @@ function strictId(value: unknown, field: string, maxLength = 512): string {
 	return value;
 }
 
+function strictPrincipalId(value: unknown, field: string): string {
+	if (!isStrictRecipientPolicyId(value)) {
+		throw new RecipientPolicyOnboardingRequestError("invalid", `${field}_invalid`);
+	}
+	return value;
+}
+
 function normalizeRequest(request: RecipientPolicyOnboardingPreviewRequestV1): NormalizedRequest {
 	if (request?.version !== 1) {
 		throw new RecipientPolicyOnboardingRequestError("invalid", "request_invalid");
 	}
 	const invitationId = strictId(request.invitationId, "invitation_id", 256);
-	const identityId = strictId(request.identityId, "identity_id", 256);
-	const deviceId = strictId(request.deviceId, "device_id", 256);
+	const identityId = strictPrincipalId(request.identityId, "identity_id");
+	const deviceId = strictPrincipalId(request.deviceId, "device_id");
 	const publicKey = String(request.devicePublicKey ?? "").trim();
 	if (!publicKey || publicKey.length > 16_384) {
 		throw new RecipientPolicyOnboardingRequestError("invalid", "device_public_key_invalid");
@@ -233,7 +244,7 @@ function normalizeRequest(request: RecipientPolicyOnboardingPreviewRequestV1): N
 			version: 1,
 			journey: "team",
 			binding,
-			teamId: strictId(request.teamId, "team_id", 256),
+			teamId: strictPrincipalId(request.teamId, "team_id"),
 		};
 	}
 	if (request.journey === "direct_project") {
@@ -244,9 +255,15 @@ function normalizeRequest(request: RecipientPolicyOnboardingPreviewRequestV1): N
 		) {
 			throw new RecipientPolicyOnboardingRequestError("invalid", "project_set_invalid");
 		}
-		const projects = request.canonicalProjectIdentities.map((projectId) =>
-			strictId(projectId, "canonical_project_identity"),
-		);
+		const projects = request.canonicalProjectIdentities.map((projectId) => {
+			if (!isStrictRecipientPolicyProjectIdentity(projectId)) {
+				throw new RecipientPolicyOnboardingRequestError(
+					"invalid",
+					"canonical_project_identity_invalid",
+				);
+			}
+			return projectId;
+		});
 		if (new Set(projects).size !== projects.length) {
 			throw new RecipientPolicyOnboardingRequestError("invalid", "project_set_invalid");
 		}
@@ -1281,8 +1298,8 @@ export function assertAddDeviceIdentityAdoptionAllowed(
 	targetIdentityId: string,
 	deviceId: string,
 ): void {
-	const targetId = strictId(targetIdentityId, "identity_id", 256);
-	const localDeviceId = strictId(deviceId, "device_id", 256);
+	const targetId = strictPrincipalId(targetIdentityId, "identity_id");
+	const localDeviceId = strictPrincipalId(deviceId, "device_id");
 	const localIdentities = new Set([
 		...(db
 			.prepare(
@@ -1582,7 +1599,7 @@ export function commitDirectProjectSharePolicyInTransaction(
 	if (input.inviterDevices.length === 0) throw new Error("inviter_device_binding_missing");
 	const inviterDevices = input.inviterDevices
 		.map((device) => ({
-			deviceId: strictId(device.deviceId, "inviter_device_id", 256),
+			deviceId: strictPrincipalId(device.deviceId, "inviter_device_id"),
 			displayName: normalizeIdentityDisplayName(device.displayName, "device_display_name"),
 		}))
 		.toSorted((left, right) => compareText(left.deviceId, right.deviceId));

--- a/packages/core/src/recipient-policy-reconciler.test.ts
+++ b/packages/core/src/recipient-policy-reconciler.test.ts
@@ -179,6 +179,39 @@ describe("recipient-policy reconciler executor", () => {
 		expect(getRecipientPolicyAuthorityState(db, PROJECT)?.authorityState).toBe("active");
 	});
 
+	it.each([
+		["oversized", "x".repeat(257)],
+		["format-character", "device-\u200Bbad"],
+	])("rejects %s snapshot device IDs before revocation", async (_label, malformedDeviceId) => {
+		insertActiveAuthority(db);
+		const { effects } = harness(["device-keep"]);
+		vi.mocked(effects.snapshot).mockResolvedValue({
+			authoritative: true,
+			scopeId: SCOPE,
+			fingerprint: "snapshot:malformed-device",
+			observedAt: new Date(BASE_TIME + 1_000).toISOString(),
+			memberships: [
+				{ deviceId: "device-keep", status: "active" },
+				{ deviceId: malformedDeviceId, status: "active" },
+			],
+		});
+
+		const outcome = await reconcileRecipientPolicyProject(
+			db,
+			{ canonicalProjectIdentity: PROJECT, leaseOwner: "worker-invalid-snapshot" },
+			effects,
+		);
+
+		expect(outcome).toMatchObject({
+			status: "needs_attention",
+			safeErrorCode: "recipient_policy_snapshot_invalid",
+		});
+		expect(effects.revoke).not.toHaveBeenCalled();
+		expect(effects.grant).not.toHaveBeenCalled();
+		expect(listRecipientPolicyDenyOverlays(db, PROJECT)).toEqual([]);
+		expect(getRecipientPolicyAuthorityState(db, PROJECT)?.authorityState).toBe("rolled_back");
+	});
+
 	it("does not grant a policy device that is not enrolled in the boundary group", async () => {
 		const { effects } = harness(["device-keep"]);
 		vi.mocked(effects.listBoundaryEnrollments).mockResolvedValue([

--- a/packages/core/src/recipient-policy-reconciler.ts
+++ b/packages/core/src/recipient-policy-reconciler.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { Database } from "./db.js";
+import { isStrictRecipientPolicyId } from "./recipient-policy-identifiers.js";
 import {
 	clearRecipientPolicyDenyOverlay,
 	deriveRecipientPolicyEffectiveDevicesFromDatabase,
@@ -314,7 +315,7 @@ function activeSnapshotDevices(
 	for (const membership of snapshot.memberships) {
 		const membershipEpoch = membership.membershipEpoch ?? 0;
 		if (
-			!validId(membership.deviceId) ||
+			!isStrictRecipientPolicyId(membership.deviceId) ||
 			!(["active", "revoked"] as const).includes(membership.status) ||
 			!Number.isSafeInteger(membershipEpoch) ||
 			membershipEpoch < 0 ||

--- a/packages/core/src/recipient-policy-reconciliation.test.ts
+++ b/packages/core/src/recipient-policy-reconciliation.test.ts
@@ -91,6 +91,21 @@ describe("strict recipient-policy effective-device derivation", () => {
 		expect(result.devices.map((device) => device.deviceId)).toEqual(["device-a", "device-b"]);
 	});
 
+	it("accepts canonical Project identities above the principal-ID limit", () => {
+		const input = graph();
+		const canonicalProjectIdentity = "p".repeat(257);
+		input.canonicalProjectIdentity = canonicalProjectIdentity;
+		input.projectRecipients = input.projectRecipients.map((recipient) => ({
+			...recipient,
+			canonicalProjectIdentity,
+		}));
+
+		const result = deriveRecipientPolicyEffectiveDevices(input);
+
+		expect(result.status).toBe("eligible");
+		expect(result.devices.map((device) => device.deviceId)).toEqual(["device-a", "device-b"]);
+	});
+
 	it("preserves legacy Team inputs without eligibility mode or assignment versions", () => {
 		const input = graph();
 		delete input.teams[0]?.deviceEligibilityMode;
@@ -414,6 +429,22 @@ describe("recipient-policy reconciliation persistence", () => {
 		expect(() =>
 			ensureRecipientPolicyReconciliationStep(db, { ...input, payloadDigest: "payload:changed" }),
 		).toThrow("recipient_policy_reconciliation_step_conflict");
+	});
+
+	it("accepts bounded composite step keys longer than principal identifiers", () => {
+		const digest = "a".repeat(96);
+		const stepKey = `refresh-after-revocations-v2:${digest}:steady_state:${digest}:${digest}`;
+
+		const step = ensureRecipientPolicyReconciliationStep(db, {
+			canonicalProjectIdentity: PROJECT,
+			generation: 3,
+			stepKey,
+			payloadDigest: "payload:composite",
+			now: NOW,
+		});
+
+		expect(step.stepKey).toBe(stepKey);
+		expect(stepKey.length).toBeGreaterThan(256);
 	});
 
 	it("prunes only old completed capability and refresh bookkeeping", () => {

--- a/packages/core/src/recipient-policy-reconciliation.ts
+++ b/packages/core/src/recipient-policy-reconciliation.ts
@@ -1,6 +1,13 @@
 import { createHash } from "node:crypto";
 import type { Database } from "./db.js";
 import { derivePolicyTeamDeviceEligibility } from "./policy-team-device-eligibility.js";
+import {
+	isStrictRecipientPolicyId,
+	isStrictRecipientPolicyProjectIdentity,
+} from "./recipient-policy-identifiers.js";
+
+// Preserve the established module-level import path while sharing one grammar.
+export { isStrictRecipientPolicyId };
 
 export type RecipientPolicyAuthorityState = "legacy" | "eligible" | "active" | "rolled_back";
 
@@ -240,10 +247,11 @@ export interface RecipientPolicyDenyOverlayRecord {
 	updatedAt: string;
 }
 
-const CONTROL_CHARACTER = /\p{Cc}/u;
 const KNOWN_DEVICE_STATUSES = new Set(["active", "revoked"]);
 const DEFAULT_COMPLETED_STEP_RETENTION_PER_KIND = 256;
 const MAX_PENDING_REVOCATION_REFRESH_STEPS = 64;
+const MAX_RECONCILIATION_STEP_KEY_UTF16_UNITS = 1_024;
+const RECONCILIATION_STEP_KEY_CONTROL_OR_FORMAT_CHARACTER = /[\p{Cc}\p{Cf}]/u;
 const PRUNABLE_COMPLETED_STEP_PATTERNS = ["capability:*", "refresh:*"] as const;
 export const PENDING_RECIPIENT_POLICY_REVOCATION_REFRESH_STEPS_SQL = `SELECT generation, step_key FROM recipient_policy_reconciliation_steps
 	 WHERE canonical_project_identity = ?
@@ -257,17 +265,14 @@ function compareText(left: string, right: string): number {
 	return left < right ? -1 : left > right ? 1 : 0;
 }
 
-function strictId(value: string): boolean {
-	return value.length > 0 && value === value.trim() && !CONTROL_CHARACTER.test(value);
-}
-
-/**
- * The identifier rule authoritative eligibility applies to every canonical
- * row. Sibling layers (for example readiness compatibility checks) must use
- * this exact predicate rather than re-implementing it with drifted semantics.
- */
-export function isStrictRecipientPolicyId(value: string): boolean {
-	return strictId(value);
+function isStrictRecipientPolicyReconciliationStepKey(value: unknown): value is string {
+	return (
+		typeof value === "string" &&
+		value.length > 0 &&
+		value === value.trim() &&
+		value.length <= MAX_RECONCILIATION_STEP_KEY_UTF16_UNITS &&
+		!RECONCILIATION_STEP_KEY_CONTROL_OR_FORMAT_CHARACTER.test(value)
+	);
 }
 
 function canonicalJson(value: unknown): string {
@@ -364,7 +369,7 @@ export function deriveRecipientPolicyEffectiveDevices(
 	input: DeriveRecipientPolicyEffectiveDevicesInput,
 ): StrictRecipientPolicyEffectiveDeviceDerivation {
 	const blocked = new Map<string, RecipientPolicyDerivationBlock>();
-	if (!strictId(input.canonicalProjectIdentity)) {
+	if (!isStrictRecipientPolicyProjectIdentity(input.canonicalProjectIdentity)) {
 		block(blocked, "canonical_project_identity_invalid", input.canonicalProjectIdentity);
 	}
 	const identities = new Map(input.identities.map((identity) => [identity.identityId, identity]));
@@ -426,7 +431,10 @@ export function deriveRecipientPolicyEffectiveDevices(
 			}
 			if (device.status !== "active") continue;
 			if (allowedDeviceIds && !allowedDeviceIds.has(device.deviceId)) continue;
-			if (!strictId(device.identityId) || !strictId(device.deviceId)) {
+			if (
+				!isStrictRecipientPolicyId(device.identityId) ||
+				!isStrictRecipientPolicyId(device.deviceId)
+			) {
 				block(blocked, "identity_device_invalid", device.deviceId);
 				continue;
 			}
@@ -450,7 +458,7 @@ export function deriveRecipientPolicyEffectiveDevices(
 			continue;
 		}
 		if (recipient.status !== "active") continue;
-		if (!strictId(recipient.recipientId)) {
+		if (!isStrictRecipientPolicyId(recipient.recipientId)) {
 			block(blocked, "project_recipient_invalid", recipient.recipientId);
 			continue;
 		}
@@ -477,7 +485,10 @@ export function deriveRecipientPolicyEffectiveDevices(
 		}
 		const memberships = membershipsByTeam.get(team.teamId) ?? [];
 		for (const membership of memberships) {
-			if (!strictId(membership.teamId) || !strictId(membership.identityId)) {
+			if (
+				!isStrictRecipientPolicyId(membership.teamId) ||
+				!isStrictRecipientPolicyId(membership.identityId)
+			) {
 				block(blocked, "team_membership_invalid", `${membership.teamId}:${membership.identityId}`);
 			}
 		}
@@ -656,7 +667,7 @@ export function upsertRecipientPolicyAuthorityObservation(
 	input: UpsertRecipientPolicyAuthorityObservationInput,
 ): RecipientPolicyAuthorityStateRecord {
 	if (
-		!strictId(input.canonicalProjectIdentity) ||
+		!isStrictRecipientPolicyProjectIdentity(input.canonicalProjectIdentity) ||
 		!Number.isSafeInteger(input.generation) ||
 		input.generation < 0
 	) {
@@ -822,7 +833,7 @@ export function listPendingRecipientPolicyRevocationRefreshSteps(
 	limit = MAX_PENDING_REVOCATION_REFRESH_STEPS,
 ): PendingRecipientPolicyRevocationRefreshStep[] {
 	if (
-		!strictId(canonicalProjectIdentity) ||
+		!isStrictRecipientPolicyProjectIdentity(canonicalProjectIdentity) ||
 		!Number.isSafeInteger(limit) ||
 		limit < 1 ||
 		limit > MAX_PENDING_REVOCATION_REFRESH_STEPS
@@ -841,7 +852,7 @@ export function listPendingRecipientPolicyRefreshSteps(
 	limit = MAX_PENDING_REVOCATION_REFRESH_STEPS,
 ): PendingRecipientPolicyRefreshStep[] {
 	if (
-		!strictId(canonicalProjectIdentity) ||
+		!isStrictRecipientPolicyProjectIdentity(canonicalProjectIdentity) ||
 		!Number.isSafeInteger(limit) ||
 		limit < 1 ||
 		limit > MAX_PENDING_REVOCATION_REFRESH_STEPS
@@ -868,7 +879,7 @@ export function pruneRecipientPolicyReconciliationSteps(
 	const retainCompletedPerKind =
 		input.retainCompletedPerKind ?? DEFAULT_COMPLETED_STEP_RETENTION_PER_KIND;
 	if (
-		!strictId(input.canonicalProjectIdentity) ||
+		!isStrictRecipientPolicyProjectIdentity(input.canonicalProjectIdentity) ||
 		!Number.isSafeInteger(retainCompletedPerKind) ||
 		retainCompletedPerKind < 0
 	) {
@@ -906,10 +917,10 @@ export function pruneSupersededRecipientPolicyCapabilitySteps(
 	input: PruneSupersededRecipientPolicyCapabilityStepsInput,
 ): number {
 	if (
-		!strictId(input.canonicalProjectIdentity) ||
+		!isStrictRecipientPolicyProjectIdentity(input.canonicalProjectIdentity) ||
 		!Number.isSafeInteger(input.activeGeneration) ||
 		input.activeGeneration < 0 ||
-		!strictId(input.activePassKey)
+		!isStrictRecipientPolicyId(input.activePassKey)
 	) {
 		throw new Error("recipient_policy_reconciliation_step_invalid");
 	}
@@ -931,8 +942,8 @@ export function ensureRecipientPolicyReconciliationStep(
 	input: EnsureRecipientPolicyReconciliationStepInput,
 ): RecipientPolicyReconciliationStepRecord {
 	if (
-		!strictId(input.canonicalProjectIdentity) ||
-		!strictId(input.stepKey) ||
+		!isStrictRecipientPolicyProjectIdentity(input.canonicalProjectIdentity) ||
+		!isStrictRecipientPolicyReconciliationStepKey(input.stepKey) ||
 		!Number.isSafeInteger(input.generation) ||
 		input.generation < 0
 	) {
@@ -1059,9 +1070,8 @@ export function putRecipientPolicyDenyOverlay(
 	},
 ): RecipientPolicyDenyOverlayRecord {
 	if (
-		![input.canonicalProjectIdentity, input.scopeId, input.deviceId, input.reasonCode].every(
-			strictId,
-		) ||
+		!isStrictRecipientPolicyProjectIdentity(input.canonicalProjectIdentity) ||
+		![input.scopeId, input.deviceId, input.reasonCode].every(isStrictRecipientPolicyId) ||
 		!Number.isSafeInteger(input.generation) ||
 		input.generation < 0
 	) {


### PR DESCRIPTION
## Description

Harden legacy Team evidence identifiers with canonical, domain-separated digests and a shared strict recipient-policy identifier grammar. Invalid discovery and enrollment evidence now remains isolated and fail-closed.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, focused Vitest suite)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused validation: 223 tests passed. Snyk high-severity scan reported 0 issues. Code review returned GO.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced