### PR TITLE
perf(core): bound legacy Team setup queries

### DIFF
--- a/packages/core/src/legacy-recipient-policy-projection.ts
+++ b/packages/core/src/legacy-recipient-policy-projection.ts
@@ -271,18 +271,42 @@ export function selectedProjectScopeMapping(
 	db: Database,
 	canonicalProjectIdentity: string,
 ): { scopeId: string; projectPattern: string; workspaceIdentity: string | null } | null {
-	const selected = selectedMapping(loadProjectScopeMappings(db), {
-		canonicalIdentity: canonicalProjectIdentity,
-		displayName: canonicalProjectIdentity,
-		identitySource: "workspace_id",
-		scopeIds: [],
-	});
-	if (!selected) return null;
-	return {
-		scopeId: selected.scopeId,
-		projectPattern: selected.projectPattern,
-		workspaceIdentity: selected.workspaceIdentity ?? null,
-	};
+	return (
+		selectedProjectScopeMappings(db, [canonicalProjectIdentity]).get(canonicalProjectIdentity) ??
+		null
+	);
+}
+
+/** Resolve several Projects against one immutable mapping snapshot. */
+export function selectedProjectScopeMappings(
+	db: Database,
+	canonicalProjectIdentities: readonly string[],
+): Map<string, { scopeId: string; projectPattern: string; workspaceIdentity: string | null }> {
+	const identities = [...new Set(canonicalProjectIdentities)];
+	if (identities.length === 0) return new Map();
+	const mappings = loadProjectScopeMappings(db);
+	return new Map(
+		identities.flatMap((canonicalProjectIdentity) => {
+			const selected = selectedMapping(mappings, {
+				canonicalIdentity: canonicalProjectIdentity,
+				displayName: canonicalProjectIdentity,
+				identitySource: "workspace_id",
+				scopeIds: [],
+			});
+			return selected
+				? [
+						[
+							canonicalProjectIdentity,
+							{
+								scopeId: selected.scopeId,
+								projectPattern: selected.projectPattern,
+								workspaceIdentity: selected.workspaceIdentity ?? null,
+							},
+						] as const,
+					]
+				: [];
+		}),
+	);
 }
 
 function selectedMapping(

--- a/packages/core/src/legacy-team-candidate.test.ts
+++ b/packages/core/src/legacy-team-candidate.test.ts
@@ -251,20 +251,48 @@ describe("legacy Team candidate discovery", () => {
 			enabled: true,
 		}));
 		const prepare = vi.spyOn(db, "prepare");
+		try {
+			expect(() =>
+				refreshLegacyTeamCandidate(
+					db,
+					input,
+					legacyTeamCandidateId(group.coordinatorId, group.groupId),
+				),
+			).toThrow("legacy_team_setup_roster_too_large");
+			expect(
+				prepare.mock.calls.some(([sql]) =>
+					String(sql).includes("SELECT identity_id FROM identity_devices"),
+				),
+			).toBe(false);
+			expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(0);
+		} finally {
+			prepare.mockRestore();
+		}
+	});
 
-		expect(() =>
-			refreshLegacyTeamCandidate(
-				db,
-				input,
-				legacyTeamCandidateId(group.coordinatorId, group.groupId),
-			),
-		).toThrow("legacy_team_setup_roster_too_large");
-		expect(
-			prepare.mock.calls.some(([sql]) =>
-				String(sql).includes("SELECT identity_id FROM identity_devices"),
-			),
-		).toBe(false);
-		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(0);
+	it("bounds assignment statement preparation for multi-device candidate authority", () => {
+		const input = options();
+		const group = input.groups[0];
+		if (!group) throw new Error("test_fixture_missing_group");
+		group.devices = Array.from({ length: 8 }, (_, index) => ({
+			deviceId: `device-${index}`,
+			fingerprint: `key-${index}`,
+			displayName: `Device ${index}`,
+			enabled: true,
+		}));
+		const prepare = vi.spyOn(db, "prepare");
+		try {
+			const [candidate] = discoverLegacyTeamCandidates(db, input);
+
+			expect(candidate?.deviceCount).toBe(8);
+			expect(
+				prepare.mock.calls.filter(([sql]) =>
+					/^\s*SELECT identity_id FROM identity_devices\s+WHERE device_id/u.test(String(sql)),
+				),
+			).toHaveLength(1);
+		} finally {
+			prepare.mockRestore();
+		}
 	});
 
 	it("retains coordinator-backed ambiguous Projects without exposing public Team intent", () => {
@@ -539,7 +567,7 @@ describe("legacy Team candidate discovery", () => {
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("needs_setup");
 	});
 
-	function completeCandidate(): { teamId: string; attemptId: string } {
+	function completeCandidate(): { teamId: string; attemptId: string; candidateId: string } {
 		const [initial] = discoverLegacyTeamCandidates(db, options());
 		const draft = db
 			.prepare(
@@ -571,7 +599,7 @@ describe("legacy Team candidate discovery", () => {
 			 SET state = 'completed', completed_team_id = ?, completed_at = ?, updated_at = ?
 			 WHERE attempt_id = ?`,
 		).run(teamId, NOW, NOW, draft.attempt_id);
-		return { teamId, attemptId: draft.attempt_id };
+		return { teamId, attemptId: draft.attempt_id, candidateId: draft.candidate_id };
 	}
 
 	it("drops Ready when a higher-priority mapping shadows the completion mapping", () => {
@@ -633,7 +661,7 @@ describe("legacy Team candidate discovery", () => {
 	});
 
 	it("keeps Ready when merged resolutions share one selected mapping", () => {
-		const { attemptId } = completeCandidate();
+		const { attemptId, candidateId } = completeCandidate();
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
 
 		// A second confirmed source resolved to the same canonical identity:
@@ -653,12 +681,91 @@ describe("legacy Team candidate discovery", () => {
 		).run(PROJECT_ID, NOW, NOW);
 		const prepareSpy = vi.spyOn(db, "prepare");
 		try {
-			expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
+			expect(isLegacyTeamCandidateSelectable(db, candidateId)).toBe(true);
 			expect(
 				prepareSpy.mock.calls.filter(([sql]) => /FROM actors ORDER BY actor_id/.test(String(sql))),
 			).toHaveLength(1);
+			expect(
+				prepareSpy.mock.calls.filter(([sql]) =>
+					/SELECT 1 FROM project_recipients\s+WHERE canonical_project_identity/u.test(String(sql)),
+				),
+			).toHaveLength(1);
+			expect(
+				prepareSpy.mock.calls.filter(([sql]) =>
+					/FROM project_scope_mappings\s+ORDER BY priority DESC/u.test(String(sql)),
+				),
+			).toHaveLength(1);
 		} finally {
 			prepareSpy.mockRestore();
+		}
+	});
+
+	it("bounds active assignment statement preparation across completion-bound devices", () => {
+		const { teamId, attemptId, candidateId } = completeCandidate();
+		const insertActor = db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES (?, ?, 0, 'active', ?, ?)`,
+		);
+		const insertMembership = db.prepare(
+			`INSERT INTO policy_team_memberships(
+			 team_id, identity_id, role, status, provenance, revision, migration_state,
+			 idempotency_key, created_at, updated_at
+			 ) VALUES (?, ?, 'member', 'reviewed_active', 'reviewed_team_setup', 'r1',
+			 'completed', ?, ?, ?)`,
+		);
+		const insertAssignment = db.prepare(
+			`INSERT INTO identity_devices(
+			 device_id, identity_id, display_name, status, provenance, revision,
+			 migration_state, assignment_version, idempotency_key, created_at, updated_at
+			 ) VALUES (?, ?, ?, 'active', 'reviewed_team_setup', 'r1', 'completed', 1, ?, ?, ?)`,
+		);
+		const insertDraftDevice = db.prepare(
+			`INSERT INTO legacy_team_setup_draft_devices(
+			 attempt_id, device_id, device_ref, key_fingerprint, display_name, enabled,
+			 decision, target_identity_id, updated_at
+			 ) VALUES (?, ?, ?, ?, ?, 1, 'included', ?, ?)`,
+		);
+		const insertDecision = db.prepare(
+			`INSERT INTO policy_team_device_decisions(
+			 team_id, device_id, decision, assignment_version, provenance, revision, created_at, updated_at
+			 ) VALUES (?, ?, 'included', 1, 'reviewed_team_setup', 'r1', ?, ?)`,
+		);
+		for (let index = 0; index < 8; index += 1) {
+			const actorId = `identity-ready-${index}`;
+			const deviceId = `device-ready-${index}`;
+			insertActor.run(actorId, `Ready Person ${index}`, NOW, NOW);
+			insertMembership.run(teamId, actorId, `membership-ready-${index}`, NOW, NOW);
+			insertAssignment.run(
+				deviceId,
+				actorId,
+				`Ready Device ${index}`,
+				`assignment-ready-${index}`,
+				NOW,
+				NOW,
+			);
+			insertDraftDevice.run(
+				attemptId,
+				deviceId,
+				`device-ref-ready-${index}`,
+				`key-ready-${index}`,
+				`Ready Device ${index}`,
+				actorId,
+				NOW,
+			);
+			insertDecision.run(teamId, deviceId, NOW, NOW);
+		}
+		const prepare = vi.spyOn(db, "prepare");
+		try {
+			expect(isLegacyTeamCandidateSelectable(db, candidateId)).toBe(true);
+			expect(
+				prepare.mock.calls.filter(([sql]) =>
+					/SELECT identity_id, assignment_version FROM identity_devices\s+WHERE device_id/u.test(
+						String(sql),
+					),
+				),
+			).toHaveLength(1);
+		} finally {
+			prepare.mockRestore();
 		}
 	});
 
@@ -1130,6 +1237,7 @@ describe("legacy Team candidate discovery", () => {
 		const path = join(directory, "candidate.sqlite");
 		const primary = new Database(path);
 		const competing = new Database(path);
+		let restorePrepare: (() => void) | undefined;
 		try {
 			seedCandidateFixture(primary);
 			const initial = refreshLegacyTeamCandidate(
@@ -1139,6 +1247,7 @@ describe("legacy Team candidate discovery", () => {
 			);
 			primary.pragma("busy_timeout = 1");
 			const prepare = vi.spyOn(primary, "prepare");
+			restorePrepare = () => prepare.mockRestore();
 			const draftReadProbe = () =>
 				prepare.mock.calls.some(([sql]) => String(sql).includes("FROM legacy_team_setup_drafts"));
 			const projectReadProbe = () =>
@@ -1180,6 +1289,7 @@ describe("legacy Team candidate discovery", () => {
 				{ attempt_id: current.attemptId, state: "needs_setup", superseded_at: null },
 			]);
 		} finally {
+			restorePrepare?.();
 			if (competing.inTransaction) competing.exec("ROLLBACK");
 			competing.close();
 			primary.close();

--- a/packages/core/src/legacy-team-candidate.ts
+++ b/packages/core/src/legacy-team-candidate.ts
@@ -2,7 +2,7 @@ import type { Database } from "./db.js";
 import {
 	type ListLegacyRecipientPolicyProjectionsOptions,
 	listLegacyTeamProjectEvidence,
-	selectedProjectScopeMapping,
+	selectedProjectScopeMappings,
 } from "./legacy-recipient-policy-projection.js";
 import {
 	getLegacyTeamSetupDraft,
@@ -168,16 +168,14 @@ function effectiveGroupSnapshots(groups: LegacyTeamConfiguredGroupSnapshot[]): {
 	return { snapshots: [...byCandidate.values()], conflictedCandidateIds };
 }
 
-function activeAssignmentIdentity(db: Database, deviceId: string): string | null {
-	return (
-		(db
-			.prepare(
-				`SELECT identity_id FROM identity_devices
-				 WHERE device_id = ? AND status = 'active' LIMIT 1`,
-			)
-			.pluck()
-			.get(deviceId) as string | undefined) ?? null
-	);
+function activeAssignmentIdentityLookup(db: Database): (deviceId: string) => string | null {
+	const statement = db
+		.prepare(
+			`SELECT identity_id FROM identity_devices
+			 WHERE device_id = ? AND status = 'active' LIMIT 1`,
+		)
+		.pluck();
+	return (deviceId) => (statement.get(deviceId) as string | undefined) ?? null;
 }
 
 function projectInventory(
@@ -412,6 +410,10 @@ function isCompatibleReadyTeam(
 	const eligibleDeviceIds = new Set(eligibility.eligibleDeviceIds);
 	const decisionsByDeviceId = new Map(canonicalDecisions.map((row) => [row.device_id, row]));
 	const expectedEffectiveDevices = new Map<string, string>();
+	const activeAssignment = db.prepare(
+		`SELECT identity_id, assignment_version FROM identity_devices
+		 WHERE device_id = ? AND status = 'active' LIMIT 1`,
+	);
 	const hasUnexplainedDecision = canonicalDecisions.some((row) => {
 		if (expectedDecisionDeviceIds.has(row.device_id)) return false;
 		if (!(INVITE_DECISION_PROVENANCES as readonly string[]).includes(row.provenance)) return true;
@@ -421,12 +423,9 @@ function isCompatibleReadyTeam(
 		// Invite-owned decisions can precede canonical Team membership. Their
 		// completion binding is therefore the live assignment version rather
 		// than membership-derived eligibility.
-		const liveAssignment = db
-			.prepare(
-				`SELECT assignment_version FROM identity_devices
-				 WHERE device_id = ? AND status = 'active' LIMIT 1`,
-			)
-			.get(row.device_id) as { assignment_version: number } | undefined;
+		const liveAssignment = activeAssignment.get(row.device_id) as
+			| { assignment_version: number }
+			| undefined;
 		return !liveAssignment || liveAssignment.assignment_version !== row.assignment_version;
 	});
 	if (hasUnexplainedDecision) return false;
@@ -459,12 +458,9 @@ function isCompatibleReadyTeam(
 		}
 		if (device.decision === "included" && !device.target_identity_id) return false;
 		if (device.decision !== "included") continue;
-		const assignment = db
-			.prepare(
-				`SELECT identity_id FROM identity_devices
-				 WHERE device_id = ? AND status = 'active' LIMIT 1`,
-			)
-			.get(device.device_id) as { identity_id: string } | undefined;
+		const assignment = activeAssignment.get(device.device_id) as
+			| { identity_id: string }
+			| undefined;
 		if (!assignment || assignment.identity_id !== device.target_identity_id) return false;
 		if (decision?.decision !== "included" || !eligibleDeviceIds.has(device.device_id)) return false;
 		expectedEffectiveDevices.set(device.device_id, device.target_identity_id);
@@ -488,15 +484,15 @@ function isCompatibleReadyTeam(
 		string,
 		StrictRecipientPolicyEffectiveDeviceDerivation
 	>();
+	const activeTeamRecipient = db.prepare(
+		`SELECT 1 FROM project_recipients
+		 WHERE canonical_project_identity = ? AND recipient_kind = 'team'
+		   AND recipient_id = ? AND status = 'active' LIMIT 1`,
+	);
+	const selectedMappings = selectedProjectScopeMappings(db, [...confirmedSourcesByResolved.keys()]);
 	for (const project of completionProjectRows) {
 		const resolvedIdentity = project.resolved_project_identity as string;
-		const recipientActive = db
-			.prepare(
-				`SELECT 1 FROM project_recipients
-				 WHERE canonical_project_identity = ? AND recipient_kind = 'team'
-				   AND recipient_id = ? AND status = 'active' LIMIT 1`,
-			)
-			.get(resolvedIdentity, completedTeamId);
+		const recipientActive = activeTeamRecipient.get(resolvedIdentity, completedTeamId);
 		if (!recipientActive) return false;
 		let effectiveDevices = effectiveDevicesByProject.get(resolvedIdentity);
 		if (!effectiveDevices) {
@@ -518,7 +514,7 @@ function isCompatibleReadyTeam(
 		// group leaves the setup-created row in the table but redirects
 		// enforcement to another boundary; mere existence of the shadowed row
 		// is not evidence that the completion still governs the Project.
-		const selected = selectedProjectScopeMapping(db, resolvedIdentity);
+		const selected = selectedMappings.get(resolvedIdentity);
 		if (
 			!selected ||
 			selected.workspaceIdentity == null ||
@@ -589,12 +585,13 @@ function candidateAuthority(
 	const row = currentDraftRow(db, candidateId);
 	requireLegacyTeamSetupSnapshotWithinLimits({ devices: rosterDevices, projects });
 	requireLegacyTeamSetupEffectiveDevicesWithinLimit(db, rosterDevices, row?.attempt_id ?? null);
+	const activeAssignmentIdentity = activeAssignmentIdentityLookup(db);
 	const rosterFingerprint = legacyTeamRosterFingerprint(
 		rosterDevices.map((device) => ({
 			deviceId: device.deviceId,
 			fingerprint: device.fingerprint,
 			enabled: device.enabled,
-			identityId: activeAssignmentIdentity(db, device.deviceId),
+			identityId: activeAssignmentIdentity(device.deviceId),
 		})),
 	);
 	const ready =

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -1,5 +1,5 @@
 import Database from "better-sqlite3";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { previewLegacyTeamSetupActivation } from "./legacy-team-setup-activation.js";
 import {
 	getLegacyTeamSetupDraft,
@@ -160,6 +160,63 @@ describe("legacy Team setup drafts", () => {
 				.get(second.attemptId),
 		).toBeTruthy();
 		expect(second.devices[0]?.displayName).toBe("Renamed Laptop");
+	});
+
+	it("bounds assignment, actor, and label statement preparation for multi-row refreshes", () => {
+		const input = { ...snapshot(), devices: devices(8), projects: projects(8) };
+		const first = refreshLegacyTeamSetupDraft(db, input);
+		const insertActor = db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES (?, ?, 0, 'active', ?, ?)`,
+		);
+		const includeDevice = db.prepare(
+			`UPDATE legacy_team_setup_draft_devices
+			 SET decision = 'included', target_identity_id = ?
+			 WHERE attempt_id = ? AND device_id = ?`,
+		);
+		for (const [index, device] of input.devices.entries()) {
+			const actorId = `identity-${index}`;
+			insertActor.run(actorId, `Person ${index}`, NOW, NOW);
+			includeDevice.run(actorId, first.attemptId, device.deviceId);
+		}
+		const prepare = vi.spyOn(db, "prepare");
+		try {
+			const refreshed = refreshLegacyTeamSetupDraft(db, {
+				...input,
+				displayName: "Renamed Team",
+				devices: input.devices.map((device) => ({
+					...device,
+					displayName: `Renamed ${device.deviceId}`,
+				})),
+				projects: input.projects.map((project) => ({
+					...project,
+					displayName: `Renamed ${project.projectRef}`,
+				})),
+			});
+
+			expect(refreshed.attemptId).toBe(first.attemptId);
+			expect(refreshed.devices).toHaveLength(8);
+			expect(refreshed.projects).toHaveLength(8);
+			const prepared = prepare.mock.calls.map(([sql]) => String(sql));
+			expect(
+				prepared.filter((sql) => /FROM identity_devices\s+WHERE device_id = \?/u.test(sql)),
+			).toHaveLength(2);
+			expect(
+				prepared.filter((sql) => /SELECT 1 FROM actors\s+WHERE actor_id = \?/u.test(sql)),
+			).toHaveLength(1);
+			expect(
+				prepared.filter((sql) =>
+					/UPDATE legacy_team_setup_draft_devices\s+SET display_name/u.test(sql),
+				),
+			).toHaveLength(1);
+			expect(
+				prepared.filter((sql) =>
+					/UPDATE legacy_team_setup_draft_projects\s+SET display_name/u.test(sql),
+				),
+			).toHaveLength(1);
+		} finally {
+			prepare.mockRestore();
+		}
 	});
 
 	it("keeps reads side-effect-free when a persisted digest is absent", () => {

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -282,24 +282,29 @@ interface DeviceAssignmentSnapshot {
  * CAS treats any existing row as evidence, so an inactive row must never be
  * reported as an absent assignment.
  */
+function assignmentLookup(db: Database): (deviceId: string) => DeviceAssignmentSnapshot | null {
+	const statement = db.prepare(
+		`SELECT identity_id, assignment_version, status
+		 FROM identity_devices
+		 WHERE device_id = ?
+		 LIMIT 1`,
+	);
+	return (deviceId) => {
+		const row = statement.get(deviceId) as
+			| { identity_id: string; assignment_version: number; status: string }
+			| undefined;
+		return row
+			? {
+					identityId: row.identity_id,
+					assignmentVersion: row.assignment_version,
+					active: row.status === "active",
+				}
+			: null;
+	};
+}
+
 function assignmentForDevice(db: Database, deviceId: string): DeviceAssignmentSnapshot | null {
-	const row = db
-		.prepare(
-			`SELECT identity_id, assignment_version, status
-			 FROM identity_devices
-			 WHERE device_id = ?
-			 LIMIT 1`,
-		)
-		.get(deviceId) as
-		| { identity_id: string; assignment_version: number; status: string }
-		| undefined;
-	return row
-		? {
-				identityId: row.identity_id,
-				assignmentVersion: row.assignment_version,
-				active: row.status === "active",
-			}
-		: null;
+	return assignmentLookup(db)(deviceId);
 }
 
 /**
@@ -462,8 +467,9 @@ function createAttempt(
 			expected_assignment_kind, expected_assignment_version, updated_at
 		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	);
+	const loadAssignment = assignmentLookup(db);
 	for (const device of devices) {
-		const assignment = assignmentForDevice(db, device.deviceId);
+		const assignment = loadAssignment(device.deviceId);
 		const previous = previousByDevice.get(device.deviceId);
 		const assignmentEvidenceUnchanged =
 			previous != null &&
@@ -606,19 +612,21 @@ function loadDraftView(db: Database, attemptId: string): LegacyTeamSetupDraftVie
 				.map((row) => row.target_identity_id as string),
 		),
 	];
-	const includedTargetsValid = includedTargetIds.every((identityId) =>
-		db
-			.prepare(
+	const includedTargetsValid =
+		includedTargetIds.length === 0 ||
+		(() => {
+			const activeActor = db.prepare(
 				`SELECT 1 FROM actors
 				 WHERE actor_id = ? AND status = 'active' AND merged_into_actor_id IS NULL LIMIT 1`,
-			)
-			.get(identityId),
-	);
+			);
+			return includedTargetIds.every((identityId) => activeActor.get(identityId));
+		})();
 	// Activation compares every stored assignment expectation, including
 	// exclusions. The detail view must report the same condition instead of
 	// advertising a finishable draft whose CAS evidence no longer matches.
+	const loadAssignment = assignmentLookup(db);
 	const assignmentExpectationsValid = deviceRows.every((row) => {
-		const live = assignmentForDevice(db, row.device_id);
+		const live = loadAssignment(row.device_id);
 		return (
 			(row.decision !== "included" || live == null || live.active) &&
 			storedAssignmentRowMatchesLive(row, live, false)
@@ -754,12 +762,13 @@ function storedAssignmentEvidenceMatches(
 	// expectations too; a stale expectation would make their `removed`
 	// decision unsavable while every refresh keeps reusing the attempt.
 	const snapshotDeviceIds = new Set(snapshots.map(({ device }) => device.deviceId));
-	return storedRows
-		.filter((row) => !snapshotDeviceIds.has(row.device_id))
-		.every((row) => {
-			const assignment = assignmentForDevice(db, row.device_id);
-			return storedAssignmentRowMatchesLive(row, assignment, true);
-		});
+	const carriedRows = storedRows.filter((row) => !snapshotDeviceIds.has(row.device_id));
+	if (carriedRows.length === 0) return true;
+	const loadAssignment = assignmentLookup(db);
+	return carriedRows.every((row) => {
+		const assignment = loadAssignment(row.device_id);
+		return storedAssignmentRowMatchesLive(row, assignment, true);
+	});
 }
 
 /**
@@ -782,9 +791,10 @@ export function refreshLegacyTeamSetupDraft(
 			input.devices,
 			existing?.attempt_id ?? null,
 		);
+		const loadAssignment = assignmentLookup(db);
 		const assignmentSnapshots = input.devices.map((device) => ({
 			device,
-			assignment: assignmentForDevice(db, device.deviceId),
+			assignment: loadAssignment(device.deviceId),
 		}));
 		const assignments = assignmentSnapshots.map(({ device, assignment }) => ({
 			deviceId: device.deviceId,
@@ -814,12 +824,13 @@ export function refreshLegacyTeamSetupDraft(
 				now,
 				existing.attempt_id,
 			);
+			const updateDeviceLabel = db.prepare(
+				`UPDATE legacy_team_setup_draft_devices
+				 SET display_name = ?, updated_at = ?
+				 WHERE attempt_id = ? AND device_id = ?`,
+			);
 			for (const device of input.devices) {
-				db.prepare(
-					`UPDATE legacy_team_setup_draft_devices
-					 SET display_name = ?, updated_at = ?
-					 WHERE attempt_id = ? AND device_id = ?`,
-				).run(
+				updateDeviceLabel.run(
 					safeLabel(device.displayName, "Device", [
 						device.deviceId,
 						device.fingerprint,
@@ -831,12 +842,13 @@ export function refreshLegacyTeamSetupDraft(
 					device.deviceId,
 				);
 			}
+			const updateProjectLabel = db.prepare(
+				`UPDATE legacy_team_setup_draft_projects
+				 SET display_name = ?, updated_at = ?
+				 WHERE attempt_id = ? AND project_ref = ?`,
+			);
 			for (const project of input.projects) {
-				db.prepare(
-					`UPDATE legacy_team_setup_draft_projects
-					 SET display_name = ?, updated_at = ?
-					 WHERE attempt_id = ? AND project_ref = ?`,
-				).run(
+				updateProjectLabel.run(
 					safeLabel(project.displayName, "Project", [
 						project.projectRef,
 						project.sourceProjectIdentity,

--- a/packages/core/src/recipient-policy-review.test.ts
+++ b/packages/core/src/recipient-policy-review.test.ts
@@ -1,5 +1,8 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	type LegacyRecipientPolicyProjectionV1,
 	listLegacyRecipientPolicyProjections,
@@ -9,6 +12,7 @@ import {
 	deriveRecipientPolicyReviewState,
 	deriveSelectableRecipientIds,
 	listRecipientPolicyReview,
+	type RecipientPolicyReviewResolveRequestV1,
 	recipientPolicyReviewSourceFingerprint,
 	resolveRecipientPolicyReview,
 	resolveRecipientPolicyReviewBulk,
@@ -487,6 +491,60 @@ describe("recipient policy review persistence", () => {
 		).toBe(0);
 	});
 
+	it("rejects malformed requests before deriving review state", () => {
+		const prepare = vi.spyOn(db, "prepare");
+		const malformed = [
+			{
+				reviewItemId: " ",
+				sourceFingerprint: "source-fingerprint",
+				decision: "keep_current_setup",
+			},
+			{
+				reviewItemId: "review-item",
+				sourceFingerprint: "source-fingerprint",
+				decision: "unsupported",
+			} as RecipientPolicyReviewResolveRequestV1,
+		];
+
+		try {
+			expect(
+				malformed.map((request) => resolveRecipientPolicyReview(db, context, request)),
+			).toEqual([
+				expect.objectContaining({ status: "invalid", errorCode: "request_invalid" }),
+				expect.objectContaining({ status: "invalid", errorCode: "request_invalid" }),
+			]);
+			expect(prepare).not.toHaveBeenCalled();
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
+	it("rejects malformed bulk requests before deriving shared review state", () => {
+		const prepare = vi.spyOn(db, "prepare");
+		const malformed = [
+			{
+				reviewItemId: " ",
+				sourceFingerprint: "source-fingerprint",
+				decision: "keep_current_setup",
+			},
+			{
+				reviewItemId: "review-item",
+				sourceFingerprint: "source-fingerprint",
+				decision: "unsupported",
+			} as RecipientPolicyReviewResolveRequestV1,
+		];
+
+		try {
+			expect(resolveRecipientPolicyReviewBulk(db, context, malformed).results).toEqual([
+				expect.objectContaining({ status: "invalid", errorCode: "request_invalid" }),
+				expect.objectContaining({ status: "invalid", errorCode: "request_invalid" }),
+			]);
+			expect(prepare).not.toHaveBeenCalled();
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
 	it("fails closed when the deciding local Identity is unavailable", () => {
 		db.prepare("UPDATE actors SET status = 'deactivated' WHERE actor_id = ?").run(LOCAL_ACTOR_ID);
 		const item = listRecipientPolicyReview(db, context).reviewItems[0];
@@ -597,6 +655,276 @@ describe("recipient policy review persistence", () => {
 		expect(
 			db.prepare("SELECT COUNT(*) FROM recipient_policy_review_resolutions").pluck().get(),
 		).toBe(1);
+	});
+
+	it("batches saved-resolution existence checks while preserving open-item order", () => {
+		configureUnassignedDeviceReview(db, [
+			"device-unassigned-a",
+			"device-unassigned-b",
+			"device-unassigned-c",
+		]);
+		const initial = listRecipientPolicyReview(db, context).reviewItems;
+		const resolved = initial[1];
+		if (!resolved) throw new Error("saved resolution fixture incomplete");
+		db.prepare(
+			`INSERT INTO recipient_policy_review_resolutions(
+			 review_item_id, source_fingerprint, decision, decision_input_json, preview_json,
+			 decided_by_identity_id, decided_by_device_id, resolved_at
+			 ) VALUES (?, ?, 'keep_current_setup', '{}', '{}', ?, ?, ?)`,
+		).run(resolved.reviewItemId, resolved.sourceFingerprint, LOCAL_ACTOR_ID, LOCAL_DEVICE_ID, NOW);
+		const prepare = vi.spyOn(db, "prepare");
+		try {
+			const listed = listRecipientPolicyReview(db, context);
+
+			expect(listed.reviewItems.map((item) => item.reviewItemId)).toEqual([
+				initial[0]?.reviewItemId,
+				initial[2]?.reviewItemId,
+			]);
+			expect(
+				prepare.mock.calls.filter(([sql]) =>
+					/SELECT review_item_id, source_fingerprint, decision, decision_input_json\s+FROM recipient_policy_review_resolutions/u.test(
+						String(sql),
+					),
+				),
+			).toHaveLength(1);
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
+	it("derives bulk review state once and isolates constraint failures by request", () => {
+		configureUnassignedDeviceReview(db, [
+			"device-unassigned-a",
+			"device-unassigned-b",
+			"device-unassigned-c",
+		]);
+		const items = listRecipientPolicyReview(db, context).reviewItems;
+		const [first, blocked, third] = items;
+		if (!first || !blocked || !third) throw new Error("bulk review fixture incomplete");
+		db.exec(`CREATE TRIGGER reject_one_review_resolution
+			BEFORE INSERT ON recipient_policy_review_resolutions
+			WHEN NEW.review_item_id = '${blocked.reviewItemId.replaceAll("'", "''")}'
+			BEGIN SELECT RAISE(ABORT, 'test conflict'); END;`);
+		const prepare = vi.spyOn(db, "prepare");
+		try {
+			const result = resolveRecipientPolicyReviewBulk(
+				db,
+				context,
+				[first, blocked, third].map((item) => ({
+					reviewItemId: item.reviewItemId,
+					sourceFingerprint: item.sourceFingerprint,
+					decision: "keep_current_setup" as const,
+				})),
+			);
+
+			expect(
+				result.results.map(({ reviewItemId, status, errorCode }) => ({
+					reviewItemId,
+					status,
+					errorCode,
+				})),
+			).toEqual([
+				{ reviewItemId: first.reviewItemId, status: "applied", errorCode: null },
+				{
+					reviewItemId: blocked.reviewItemId,
+					status: "conflict",
+					errorCode: "review_resolution_conflict",
+				},
+				{ reviewItemId: third.reviewItemId, status: "applied", errorCode: null },
+			]);
+			expect(
+				db
+					.prepare("SELECT review_item_id FROM recipient_policy_review_resolutions ORDER BY rowid")
+					.pluck()
+					.all(),
+			).toEqual([first.reviewItemId, third.reviewItemId]);
+			expect(
+				prepare.mock.calls.filter(([sql]) =>
+					/FROM memory_items mi\s+JOIN sessions s ON s.id = mi.session_id/u.test(String(sql)),
+				),
+			).toHaveLength(1);
+			expect(
+				prepare.mock.calls.filter(([sql]) =>
+					/SELECT review_item_id, source_fingerprint, decision, decision_input_json\s+FROM recipient_policy_review_resolutions/u.test(
+						String(sql),
+					),
+				),
+			).toHaveLength(1);
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
+	it("rolls back all savepoint writes when the outer bulk commit loses its lock", () => {
+		const directory = mkdtempSync(join(tmpdir(), "codemem-recipient-review-bulk-"));
+		const path = join(directory, "review.sqlite");
+		const primary = new Database(path);
+		const competing = new Database(path);
+		try {
+			primary.pragma("journal_mode = DELETE");
+			primary.pragma("busy_timeout = 1");
+			initTestSchema(primary);
+			insertLocalFixture(primary);
+			configureUnassignedDeviceReview(primary, [
+				"device-unassigned-a",
+				"device-unassigned-b",
+				"device-unassigned-c",
+			]);
+			const items = listRecipientPolicyReview(primary, context).reviewItems;
+			const [first, second, third] = items;
+			if (!first || !second || !third) throw new Error("bulk lock fixture incomplete");
+			primary
+				.prepare(
+					`INSERT INTO recipient_policy_review_resolutions(
+					 review_item_id, source_fingerprint, decision, decision_input_json, preview_json,
+					 decided_by_identity_id, decided_by_device_id, resolved_at
+					 ) VALUES (?, ?, 'keep_current_setup', '{}', '{}', ?, ?, ?)`,
+				)
+				.run(third.reviewItemId, third.sourceFingerprint, LOCAL_ACTOR_ID, LOCAL_DEVICE_ID, NOW);
+			const duplicate = {
+				reviewItemId: "duplicate-review-item",
+				sourceFingerprint: "duplicate-source",
+				decision: "keep_current_setup" as const,
+			};
+			const requests: RecipientPolicyReviewResolveRequestV1[] = [
+				{
+					reviewItemId: first.reviewItemId,
+					sourceFingerprint: first.sourceFingerprint,
+					decision: "keep_current_setup",
+				},
+				duplicate,
+				{
+					reviewItemId: second.reviewItemId,
+					sourceFingerprint: "stale-fingerprint",
+					decision: "keep_current_setup",
+				},
+				duplicate,
+				{
+					reviewItemId: "missing-review-item",
+					sourceFingerprint: "missing-source",
+					decision: "keep_current_setup",
+				},
+				{
+					reviewItemId: "invalid-review-item",
+					sourceFingerprint: "invalid-source",
+					decision: "unsupported",
+				} as RecipientPolicyReviewResolveRequestV1,
+				{
+					reviewItemId: third.reviewItemId,
+					sourceFingerprint: third.sourceFingerprint,
+					decision: "keep_current_setup",
+				},
+			];
+			competing.exec("BEGIN");
+			competing.prepare("SELECT COUNT(*) FROM recipient_policy_review_resolutions").get();
+			const changesBefore = Number(primary.prepare("SELECT total_changes()").pluck().get());
+
+			const result = resolveRecipientPolicyReviewBulk(primary, context, requests);
+
+			expect(result.results.map((entry) => [entry.status, entry.errorCode])).toEqual([
+				["conflict", "review_resolution_conflict"],
+				["invalid", "duplicate_review_item_id"],
+				["stale", "source_fingerprint_stale"],
+				["invalid", "duplicate_review_item_id"],
+				["not_found", "review_item_not_found"],
+				["invalid", "request_invalid"],
+				["applied", null],
+			]);
+			expect(result.results.at(-1)?.idempotent).toBe(true);
+			// SQLite counts executed writes even when the enclosing transaction is
+			// rolled back, proving the write request completed before COMMIT
+			// lost the competing reader lock.
+			expect(Number(primary.prepare("SELECT total_changes()").pluck().get()) - changesBefore).toBe(
+				1,
+			);
+			expect(primary.inTransaction).toBe(false);
+			competing.exec("ROLLBACK");
+			expect(
+				primary.prepare("SELECT COUNT(*) FROM recipient_policy_review_resolutions").pluck().get(),
+			).toBe(1);
+		} finally {
+			if (competing.inTransaction) competing.exec("ROLLBACK");
+			primary.close();
+			competing.close();
+			rmSync(directory, { force: true, recursive: true });
+		}
+	});
+
+	it("retains earlier non-write results when a later request aborts the outer transaction", () => {
+		configureUnassignedDeviceReview(db, ["device-unassigned-a", "device-unassigned-b"]);
+		const [first, second] = listRecipientPolicyReview(db, context).reviewItems;
+		if (!first || !second) throw new Error("bulk rollback fixture incomplete");
+		db.exec(`CREATE TRIGGER rollback_second_review
+			BEFORE INSERT ON recipient_policy_review_resolutions
+			WHEN NEW.review_item_id = '${second.reviewItemId}'
+			BEGIN
+				SELECT RAISE(ROLLBACK, 'forced rollback');
+			END`);
+
+		const result = resolveRecipientPolicyReviewBulk(db, context, [
+			{
+				reviewItemId: first.reviewItemId,
+				sourceFingerprint: "stale-fingerprint",
+				decision: "keep_current_setup",
+			},
+			{
+				reviewItemId: second.reviewItemId,
+				sourceFingerprint: second.sourceFingerprint,
+				decision: "keep_current_setup",
+			},
+		]);
+
+		expect(result.results.map((entry) => [entry.status, entry.errorCode])).toEqual([
+			["stale", "source_fingerprint_stale"],
+			["conflict", "review_resolution_conflict"],
+		]);
+		expect(db.inTransaction).toBe(false);
+		expect(
+			db.prepare("SELECT COUNT(*) FROM recipient_policy_review_resolutions").pluck().get(),
+		).toBe(0);
+	});
+
+	it("preserves invalid preflight results when the outer bulk begin is busy", () => {
+		const directory = mkdtempSync(join(tmpdir(), "codemem-recipient-review-bulk-begin-"));
+		const path = join(directory, "review.sqlite");
+		const primary = new Database(path);
+		const competing = new Database(path);
+		try {
+			primary.pragma("busy_timeout = 1");
+			initTestSchema(primary);
+			insertLocalFixture(primary);
+			configureUnassignedDeviceReview(primary, ["device-unassigned-a"]);
+			const item = listRecipientPolicyReview(primary, context).reviewItems[0];
+			if (!item) throw new Error("bulk begin lock fixture incomplete");
+			competing.exec("BEGIN IMMEDIATE");
+
+			const result = resolveRecipientPolicyReviewBulk(primary, context, [
+				{
+					reviewItemId: "invalid-review-item",
+					sourceFingerprint: "invalid-source",
+					decision: "unsupported",
+				} as RecipientPolicyReviewResolveRequestV1,
+				{
+					reviewItemId: item.reviewItemId,
+					sourceFingerprint: item.sourceFingerprint,
+					decision: "keep_current_setup",
+				},
+			]);
+
+			expect(result.results.map((entry) => [entry.status, entry.errorCode])).toEqual([
+				["invalid", "request_invalid"],
+				["conflict", "review_resolution_conflict"],
+			]);
+			expect(primary.inTransaction).toBe(false);
+			expect(
+				primary.prepare("SELECT COUNT(*) FROM recipient_policy_review_resolutions").pluck().get(),
+			).toBe(0);
+		} finally {
+			if (competing.inTransaction) competing.exec("ROLLBACK");
+			primary.close();
+			competing.close();
+			rmSync(directory, { force: true, recursive: true });
+		}
 	});
 
 	it("rejects unresolved legacy Team candidates but accepts active canonical Teams", () => {

--- a/packages/core/src/recipient-policy-review.ts
+++ b/packages/core/src/recipient-policy-review.ts
@@ -97,6 +97,11 @@ interface StoredResolution {
 	decision_input_json: string;
 }
 
+interface StoredResolutionRow extends StoredResolution {
+	review_item_id: string;
+	source_fingerprint: string;
+}
+
 const DECISIONS = new Set<RecipientPolicyReviewDecisionV1>([
 	"apply_recommendation",
 	"choose_recipients",
@@ -451,14 +456,56 @@ export function deriveRecipientPolicyReviewState(
 	return { allReviewItems, blockedItems, preservedDiagnosticFindings };
 }
 
-function hasResolution(db: Database, item: RecipientPolicyActionableReviewItemV1): boolean {
-	return Boolean(
-		db
-			.prepare(
-				`SELECT 1 FROM recipient_policy_review_resolutions
-				 WHERE review_item_id = ? AND source_fingerprint = ? LIMIT 1`,
-			)
-			.get(item.reviewItemId, item.sourceFingerprint),
+function resolutionKey(reviewItemId: string, sourceFingerprint: string): string {
+	return `${reviewItemId}\u0000${sourceFingerprint}`;
+}
+
+// Each row binds two variables, so 250 rows use 500 variables: safely below
+// SQLite's historical 999-variable default while also keeping the VALUES list
+// modest on runtimes compiled with tighter parser/resource limits.
+const RESOLUTION_LOOKUP_BATCH_SIZE = 250;
+
+function storedResolutions(
+	db: Database,
+	items: ReadonlyArray<
+		Pick<RecipientPolicyActionableReviewItemV1, "reviewItemId" | "sourceFingerprint">
+	>,
+): Map<string, StoredResolution> {
+	const pairs = [
+		...new Map(
+			items.map((item) => [resolutionKey(item.reviewItemId, item.sourceFingerprint), item]),
+		).values(),
+	];
+	if (pairs.length === 0) return new Map();
+	const query = (count: number) =>
+		`SELECT review_item_id, source_fingerprint, decision, decision_input_json
+		 FROM recipient_policy_review_resolutions
+		 WHERE (review_item_id, source_fingerprint) IN (VALUES ${Array.from(
+				{ length: count },
+				() => "(?, ?)",
+			).join(", ")})`;
+	const fullBatch =
+		pairs.length > RESOLUTION_LOOKUP_BATCH_SIZE
+			? db.prepare(query(RESOLUTION_LOOKUP_BATCH_SIZE))
+			: null;
+	const rows: StoredResolutionRow[] = [];
+	for (let offset = 0; offset < pairs.length; offset += RESOLUTION_LOOKUP_BATCH_SIZE) {
+		const batch = pairs.slice(offset, offset + RESOLUTION_LOOKUP_BATCH_SIZE);
+		const statement =
+			batch.length === RESOLUTION_LOOKUP_BATCH_SIZE && fullBatch
+				? fullBatch
+				: db.prepare(query(batch.length));
+		rows.push(
+			...(statement.all(
+				...batch.flatMap((item) => [item.reviewItemId, item.sourceFingerprint]),
+			) as StoredResolutionRow[]),
+		);
+	}
+	return new Map(
+		rows.map((row) => [
+			resolutionKey(row.review_item_id, row.source_fingerprint),
+			{ decision: row.decision, decision_input_json: row.decision_input_json },
+		]),
 	);
 }
 
@@ -467,7 +514,10 @@ export function listRecipientPolicyReview(
 	context: RecipientPolicyReviewContext,
 ): RecipientPolicyReviewListV1 {
 	const state = deriveRecipientPolicyReviewState(db, context);
-	const reviewItems = state.allReviewItems.filter((item) => !hasResolution(db, item));
+	const resolutions = storedResolutions(db, state.allReviewItems);
+	const reviewItems = state.allReviewItems.filter(
+		(item) => !resolutions.has(resolutionKey(item.reviewItemId, item.sourceFingerprint)),
+	);
 	const findingCount = reviewItems.length + state.preservedDiagnosticFindings.length;
 	return {
 		version: RECIPIENT_POLICY_CONTRACT_VERSION,
@@ -644,21 +694,43 @@ export function deriveSelectableRecipientIds(
 	};
 }
 
+interface RecipientPolicyResolutionOperation {
+	projections: LegacyRecipientPolicyProjectionV1[];
+	state: RecipientPolicyDerivedReviewState;
+	resolutions: Map<string, StoredResolution>;
+}
+
+function deriveResolutionOperation(
+	db: Database,
+	context: RecipientPolicyReviewContext,
+): RecipientPolicyResolutionOperation {
+	const projections = listLegacyRecipientPolicyProjections(db, context);
+	const state = deriveRecipientPolicyReviewState(db, context, projections);
+	return {
+		projections,
+		state,
+		resolutions: storedResolutions(db, state.allReviewItems),
+	};
+}
+
+function isValidResolveRequest(request: RecipientPolicyReviewResolveRequestV1): boolean {
+	return Boolean(
+		request.reviewItemId?.trim() &&
+			request.sourceFingerprint?.trim() &&
+			DECISIONS.has(request.decision),
+	);
+}
+
 function resolveInTransaction(
 	db: Database,
 	context: RecipientPolicyReviewContext,
 	request: RecipientPolicyReviewResolveRequestV1,
+	operation: RecipientPolicyResolutionOperation,
 ): RecipientPolicyReviewResolveResultV1 {
-	if (
-		!request.reviewItemId?.trim() ||
-		!request.sourceFingerprint?.trim() ||
-		!DECISIONS.has(request.decision)
-	) {
+	if (!isValidResolveRequest(request)) {
 		return invalid(request, "request_invalid");
 	}
-	const projections = listLegacyRecipientPolicyProjections(db, context);
-	const state = deriveRecipientPolicyReviewState(db, context, projections);
-	const item = state.allReviewItems.find(
+	const item = operation.state.allReviewItems.find(
 		(candidate) => candidate.reviewItemId === request.reviewItemId,
 	);
 	if (!item) {
@@ -670,7 +742,7 @@ function resolveInTransaction(
 	const selectedOption = item.options.find((candidate) => candidate.decision === request.decision);
 	if (!selectedOption?.preview) return invalid(request, "decision_invalid");
 	const projectId = selectedOption.preview.projects[0]?.canonicalIdentity;
-	const projection = projections.find(
+	const projection = operation.projections.find(
 		(candidate) => candidate.project.canonicalIdentity === projectId,
 	);
 	if (!projection) return { ...invalid(request, "review_item_not_found"), status: "not_found" };
@@ -682,12 +754,8 @@ function resolveInTransaction(
 		context,
 	);
 	if (!normalizedInput.ok) return invalid(request, normalizedInput.errorCode);
-	const existing = db
-		.prepare(
-			`SELECT decision, decision_input_json FROM recipient_policy_review_resolutions
-			 WHERE review_item_id = ? AND source_fingerprint = ?`,
-		)
-		.get(item.reviewItemId, item.sourceFingerprint) as StoredResolution | undefined;
+	const key = resolutionKey(item.reviewItemId, item.sourceFingerprint);
+	const existing = operation.resolutions.get(key);
 	if (existing) {
 		const same =
 			existing.decision === request.decision &&
@@ -726,6 +794,10 @@ function resolveInTransaction(
 		attribution.localDeviceId,
 		(context.now ?? (() => new Date().toISOString()))(),
 	);
+	operation.resolutions.set(key, {
+		decision: request.decision,
+		decision_input_json: normalizedInput.json,
+	});
 	return {
 		reviewItemId: item.reviewItemId,
 		sourceFingerprint: item.sourceFingerprint,
@@ -735,27 +807,43 @@ function resolveInTransaction(
 	};
 }
 
+function conflictResult(
+	error: unknown,
+	request: RecipientPolicyReviewResolveRequestV1,
+): RecipientPolicyReviewResolveResultV1 | null {
+	const code =
+		error && typeof error === "object" && "code" in error
+			? String((error as { code?: unknown }).code ?? "")
+			: "";
+	if (code !== "SQLITE_BUSY" && !code.startsWith("SQLITE_CONSTRAINT")) return null;
+	// Lock loss and uniqueness/trigger races are deliberately indistinguishable
+	// at the contract boundary. Both mean this resolution was not durably
+	// applied, and the existing stable code keeps callers fail-closed without
+	// exposing SQLite details or introducing a new public error vocabulary.
+	return {
+		reviewItemId: request.reviewItemId,
+		sourceFingerprint: request.sourceFingerprint,
+		status: "conflict",
+		errorCode: "review_resolution_conflict",
+		idempotent: false,
+	};
+}
+
 export function resolveRecipientPolicyReview(
 	db: Database,
 	context: RecipientPolicyReviewContext,
 	request: RecipientPolicyReviewResolveRequestV1,
 ): RecipientPolicyReviewResolveResultV1 {
+	if (!isValidResolveRequest(request)) return invalid(request, "request_invalid");
 	try {
-		return db.transaction(() => resolveInTransaction(db, context, request)).immediate();
+		return db
+			.transaction(() =>
+				resolveInTransaction(db, context, request, deriveResolutionOperation(db, context)),
+			)
+			.immediate();
 	} catch (error) {
-		const code =
-			error && typeof error === "object" && "code" in error
-				? String((error as { code?: unknown }).code ?? "")
-				: "";
-		if (code === "SQLITE_BUSY" || code.startsWith("SQLITE_CONSTRAINT")) {
-			return {
-				reviewItemId: request.reviewItemId,
-				sourceFingerprint: request.sourceFingerprint,
-				status: "conflict",
-				errorCode: "review_resolution_conflict",
-				idempotent: false,
-			};
-		}
+		const conflict = conflictResult(error, request);
+		if (conflict) return conflict;
 		throw error;
 	}
 }
@@ -769,12 +857,62 @@ export function resolveRecipientPolicyReviewBulk(
 	for (const request of requests) {
 		counts.set(request.reviewItemId, (counts.get(request.reviewItemId) ?? 0) + 1);
 	}
-	return {
-		version: RECIPIENT_POLICY_CONTRACT_VERSION,
-		results: requests.map((request) =>
-			(counts.get(request.reviewItemId) ?? 0) > 1
-				? invalid(request, "duplicate_review_item_id")
-				: resolveRecipientPolicyReview(db, context, request),
-		),
-	};
+	const duplicateResult = (request: RecipientPolicyReviewResolveRequestV1) =>
+		invalid(request, "duplicate_review_item_id");
+	const preflightResults = requests.map((request) => {
+		if ((counts.get(request.reviewItemId) ?? 0) > 1) return duplicateResult(request);
+		return isValidResolveRequest(request) ? null : invalid(request, "request_invalid");
+	});
+	if (preflightResults.every((result) => result !== null)) {
+		return {
+			version: RECIPIENT_POLICY_CONTRACT_VERSION,
+			results: preflightResults as RecipientPolicyReviewResolveResultV1[],
+		};
+	}
+	const attemptedResults: RecipientPolicyReviewResolveResultV1[] = [];
+	const resolveBulk = db.transaction(() => {
+		const operation = deriveResolutionOperation(db, context);
+		const resolveOne = db.transaction((request: RecipientPolicyReviewResolveRequestV1) =>
+			resolveInTransaction(db, context, request, operation),
+		);
+		for (const [index, request] of requests.entries()) {
+			const preflight = preflightResults[index];
+			if (preflight) {
+				attemptedResults.push(preflight);
+				continue;
+			}
+			try {
+				attemptedResults.push(resolveOne(request));
+			} catch (error) {
+				// Some SQLite errors abort the outer transaction, not only the
+				// request savepoint. Never continue after losing the write lock.
+				if (!db.inTransaction) throw error;
+				const conflict = conflictResult(error, request);
+				if (conflict) {
+					attemptedResults.push(conflict);
+					continue;
+				}
+				throw error;
+			}
+		}
+		return attemptedResults;
+	});
+	try {
+		return { version: RECIPIENT_POLICY_CONTRACT_VERSION, results: resolveBulk.immediate() };
+	} catch (error) {
+		const conflict = requests.find((request) => (counts.get(request.reviewItemId) ?? 0) === 1);
+		if (!conflict || !conflictResult(error, conflict)) throw error;
+		return {
+			version: RECIPIENT_POLICY_CONTRACT_VERSION,
+			results: requests.map((request, index) => {
+				const preflight = preflightResults[index];
+				if (preflight) return preflight;
+				const attempted = attemptedResults[index];
+				if (attempted && (attempted.status !== "applied" || attempted.idempotent)) {
+					return attempted;
+				}
+				return conflictResult(error, request) as RecipientPolicyReviewResolveResultV1;
+			}),
+		};
+	}
 }


### PR DESCRIPTION
## Description

Bound legacy Team setup query preparation by hoisting repeated statements, batching review-resolution lookups, and deriving bulk review state once within the existing atomic transaction boundary.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, focused Vitest suite)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused validation: 190 tests passed, including ordering, duplicate, rollback, and preparation-bound coverage. Snyk high-severity scan reported 0 issues. Code review returned GO.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced