### PR TITLE
feat(sync): cache coordinator status and show pending approvals

### DIFF
--- a/docs/plans/2026-08-24-coordinator-d1-free-tier-design.md
+++ b/docs/plans/2026-08-24-coordinator-d1-free-tier-design.md
@@ -8,11 +8,13 @@ Authenticated coordinator calls also maintain replay-protection nonces. Reducing
 
 ## Decision
 
-Keep the five-second local UI refresh, but reuse each remote coordinator status snapshot for 30 seconds. Presence continues to refresh on its existing schedule.
+Keep the five-second local UI refresh, but reuse each remote coordinator peer and approval snapshot for up to 30 seconds. A snapshot expires sooner at its earliest discovered peer presence expiry so cached availability and addresses cannot outlive coordinator presence. Local presence continues to refresh independently on its existing schedule, including while the peer and approval snapshot remains cached.
 
-Successful reciprocal-approval mutations invalidate the affected status snapshot. The next refresh must observe the post-action coordinator state instead of reusing a pre-action snapshot, including after a page reload or in another browser.
+Successful reciprocal-approval mutations invalidate the affected status snapshot. Invalidation increments a per-cache-key generation so a status request that started before the mutation cannot repopulate the cache after it finishes. The next refresh must observe the post-action coordinator state instead of reusing a pre-action snapshot, including after a page reload or in another browser.
 
-This first optimization deliberately does not change nonce retention, add indexes, or alter coordinator API contracts. The smaller change should reduce the principal source of traffic by roughly five-sixths while minimizing operational and security risk.
+Final reciprocal approval carries the group and incoming request ID that the user reviewed. The coordinator completes that exact pending reverse request atomically. If it has disappeared, changed direction, changed group, or already completed, the mutation returns HTTP 409 with `reciprocal_approval_request_changed`; it never silently approves a replacement request. That conflict also invalidates the local status cache so the requested refresh can expose the replacement immediately. Omitting the precondition preserves first-side request creation.
+
+This first optimization deliberately does not change nonce retention or add indexes. The smaller change should reduce the principal source of traffic by roughly five-sixths while minimizing operational and security risk.
 
 ## Approval feedback
 
@@ -24,7 +26,7 @@ When the cached snapshot said this device still needed to approve and the coordi
 2. Keep the device row visible with an **Approval sent** badge.
 3. Explain: **Waiting for refreshed coordinator status. You do not need to approve again.**
 4. Remove the approval button while confirmation is pending.
-5. Clear the pending state when the next uncached coordinator snapshot no longer says that local approval is required.
+5. Clear the pending state when the next complete coordinator snapshot no longer contains the exact incoming reciprocal request that was reviewed. This confirms that request is no longer pending; a replacement request is shown as new work rather than inheriting the old success state.
 
 When this device initiates the first side of reciprocal approval, cache invalidation makes the next refresh expose the coordinator's outgoing pending request. That flow does not use the final-approval marker because its pre-action snapshot did not require local approval.
 
@@ -36,8 +38,8 @@ The pending approval is global optimistic UI state keyed by device ID. Component
 
 The marker is created only after the approval request succeeds and before optional rename or screen-refresh work. Normal sync-data refreshes reconcile that state against coordinator device data before payload-hash short-circuiting:
 
-- matching device and incoming reciprocal request with `needs_local_approval = true`: retain the pending state because the snapshot may still be cached.
-- the reviewed incoming request is observed without `needs_local_approval`: remove the pending state because propagation is confirmed.
+- matching device and incoming reciprocal request: retain the pending state because the snapshot may still be cached.
+- the reviewed incoming request no longer appears in a complete snapshot: remove the pending state because that exact request is no longer pending.
 - the device is absent from the snapshot: retain the pending state rather than claiming success from incomplete data.
 - peer lookup or reciprocal-approval data is incomplete: retain the pending state and do not cache the partial coordinator snapshot.
 - the device ID appears with a different incoming reciprocal request: clear the success marker and require fresh review rather than applying approval feedback to a replacement request.

--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -63,6 +63,7 @@ import type {
 	CoordinatorUpsertPresenceInput,
 } from "./coordinator-store-contract.js";
 import {
+	CoordinatorReciprocalApprovalRequestChangedError,
 	isCoordinatorAssignedIdentityId,
 	normalizeInviteExpiresAt,
 	recipientInviteAuthoritativeIdentityId,
@@ -1724,6 +1725,8 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		const groupId = String(opts.groupId ?? "").trim();
 		const requestingDeviceId = String(opts.requestingDeviceId ?? "").trim();
 		const requestedDeviceId = String(opts.requestedDeviceId ?? "").trim();
+		const hasExpectedIncomingRequestId = opts.expectedIncomingRequestId !== undefined;
+		const expectedIncomingRequestId = opts.expectedIncomingRequestId?.trim() ?? "";
 		if (!groupId || !requestingDeviceId || !requestedDeviceId) {
 			throw new Error("groupId, requestingDeviceId, and requestedDeviceId are required.");
 		}
@@ -1732,6 +1735,25 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		}
 		return this.db.transaction(() => {
 			const now = nowISO();
+			if (hasExpectedIncomingRequestId) {
+				const result = this.db
+					.prepare(`UPDATE coordinator_reciprocal_approvals
+						 SET status = 'completed', resolved_at = ?
+						 WHERE request_id = ?
+						   AND group_id = ?
+						   AND requesting_device_id = ?
+						   AND requested_device_id = ?
+						   AND status = 'pending'`)
+					.run(now, expectedIncomingRequestId, groupId, requestedDeviceId, requestingDeviceId);
+				if (result.changes !== 1) {
+					throw new CoordinatorReciprocalApprovalRequestChangedError();
+				}
+				const completed = this.db
+					.prepare(`SELECT request_id, group_id, requesting_device_id, requested_device_id, status, created_at, resolved_at
+						 FROM coordinator_reciprocal_approvals WHERE request_id = ?`)
+					.get(expectedIncomingRequestId);
+				return rowToRecord<CoordinatorReciprocalApproval>(completed);
+			}
 			const existing = this.db
 				.prepare(`SELECT request_id, group_id, requesting_device_id, requested_device_id, status, created_at, resolved_at
 					 FROM coordinator_reciprocal_approvals

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -23,6 +23,7 @@ import {
 	type CoordinatorPeerRecord,
 	type CoordinatorPresenceRecord,
 	type CoordinatorReciprocalApproval,
+	CoordinatorReciprocalApprovalRequestChangedError,
 	type CoordinatorRequestVerifier,
 	type CoordinatorReviewJoinRequestInput,
 	type CoordinatorRevokeScopeMembershipInput,
@@ -2196,6 +2197,122 @@ describe("createCoordinatorApp dependency injection", () => {
 			requestingDeviceId: "local-device",
 			requestedDeviceId: "peer-a",
 		});
+	});
+
+	it("passes the expected incoming request id when completing a reciprocal approval", async () => {
+		const createReciprocalApproval = vi.fn(async () => ({
+			request_id: "req-1",
+			group_id: "g1",
+			requesting_device_id: "peer-a",
+			requested_device_id: "local-device",
+			status: "completed",
+			created_at: "2026-03-28T00:00:00Z",
+			resolved_at: "2026-03-28T00:01:00Z",
+		}));
+		const store = createMockStore({
+			getGroup: vi.fn(async () => ({
+				group_id: "g1",
+				display_name: "Group 1",
+				archived_at: null,
+				created_at: "2026-03-28T00:00:00Z",
+			})),
+			getEnrollment: vi.fn(async (groupId: string, deviceId: string) =>
+				groupId === "g1" && (deviceId === "local-device" || deviceId === "peer-a")
+					? {
+							group_id: "g1",
+							device_id: deviceId,
+							public_key: `pk-${deviceId}`,
+							fingerprint: `fp-${deviceId}`,
+							identity_id: null,
+							display_name: deviceId,
+							enabled: 1,
+							created_at: "2026-03-28T00:00:00Z",
+						}
+					: null,
+			),
+			createReciprocalApproval,
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: { adminSecret: () => "test-secret", now: () => "2026-03-28T00:00:00Z" },
+			requestVerifier: allowRequest,
+		});
+
+		const res = await app.request("/v1/reciprocal-approvals", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-Opencode-Device": "local-device",
+				"X-Opencode-Signature": "v1:test",
+				"X-Opencode-Timestamp": "123",
+				"X-Opencode-Nonce": "nonce-expected",
+			},
+			body: JSON.stringify({
+				group_id: "g1",
+				requested_device_id: "peer-a",
+				expected_incoming_request_id: "req-1",
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(createReciprocalApproval).toHaveBeenCalledWith({
+			groupId: "g1",
+			requestingDeviceId: "local-device",
+			requestedDeviceId: "peer-a",
+			expectedIncomingRequestId: "req-1",
+		});
+	});
+
+	it("returns a stable conflict when the expected incoming request changed", async () => {
+		const store = createMockStore({
+			getGroup: vi.fn(async () => ({
+				group_id: "g1",
+				display_name: "Group 1",
+				archived_at: null,
+				created_at: "2026-03-28T00:00:00Z",
+			})),
+			getEnrollment: vi.fn(async (groupId: string, deviceId: string) =>
+				groupId === "g1" && (deviceId === "local-device" || deviceId === "peer-a")
+					? {
+							group_id: "g1",
+							device_id: deviceId,
+							public_key: `pk-${deviceId}`,
+							fingerprint: `fp-${deviceId}`,
+							identity_id: null,
+							display_name: deviceId,
+							enabled: 1,
+							created_at: "2026-03-28T00:00:00Z",
+						}
+					: null,
+			),
+			createReciprocalApproval: vi.fn(async () => {
+				throw new CoordinatorReciprocalApprovalRequestChangedError();
+			}),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: { adminSecret: () => "test-secret", now: () => "2026-03-28T00:00:00Z" },
+			requestVerifier: allowRequest,
+		});
+
+		const res = await app.request("/v1/reciprocal-approvals", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-Opencode-Device": "local-device",
+				"X-Opencode-Signature": "v1:test",
+				"X-Opencode-Timestamp": "123",
+				"X-Opencode-Nonce": "nonce-conflict",
+			},
+			body: JSON.stringify({
+				group_id: "g1",
+				requested_device_id: "peer-a",
+				expected_incoming_request_id: "stale-req",
+			}),
+		});
+
+		expect(res.status).toBe(409);
+		expect(await res.json()).toEqual({ error: "reciprocal_approval_request_changed" });
 	});
 
 	it("lists Sharing domains for an admin-authenticated group", async () => {

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -21,6 +21,7 @@ import type {
 	CoordinatorScopeMembership,
 	CoordinatorStore,
 } from "./coordinator-store-contract.js";
+import { CoordinatorReciprocalApprovalRequestChangedError } from "./coordinator-store-contract.js";
 import { PROJECT_INVITE_PENDING_STATUS } from "./project-invite-acceptance.js";
 import {
 	normalizeHumanPresentationName,
@@ -683,6 +684,9 @@ export function createCoordinatorApp(
 
 		const groupId = String(data.group_id ?? "").trim();
 		const requestedDeviceId = String(data.requested_device_id ?? "").trim();
+		const expectedIncomingRequestId = Object.hasOwn(data, "expected_incoming_request_id")
+			? String(data.expected_incoming_request_id ?? "").trim()
+			: undefined;
 		if (!groupId || !requestedDeviceId) {
 			return c.json({ error: "group_id_and_requested_device_id_required" }, 400);
 		}
@@ -714,12 +718,20 @@ export function createCoordinatorApp(
 			if (!targetEnrollment) {
 				return c.json({ error: "requested_device_not_found" }, 404);
 			}
-			const request = await store.createReciprocalApproval({
-				groupId,
-				requestingDeviceId: String(auth.enrollment.device_id),
-				requestedDeviceId,
-			});
-			return c.json({ ok: true, request });
+			try {
+				const request = await store.createReciprocalApproval({
+					groupId,
+					requestingDeviceId: String(auth.enrollment.device_id),
+					requestedDeviceId,
+					...(expectedIncomingRequestId !== undefined ? { expectedIncomingRequestId } : {}),
+				});
+				return c.json({ ok: true, request });
+			} catch (error) {
+				if (error instanceof CoordinatorReciprocalApprovalRequestChangedError) {
+					return c.json({ error: error.code }, 409);
+				}
+				throw error;
+			}
 		} finally {
 			await store.close();
 		}

--- a/packages/core/src/coordinator-runtime.test.ts
+++ b/packages/core/src/coordinator-runtime.test.ts
@@ -3,12 +3,13 @@ import { cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createBetterSqliteCoordinatorApp } from "./better-sqlite-coordinator-runtime.js";
 import { BetterSqliteCoordinatorStore } from "./better-sqlite-coordinator-store.js";
 import {
 	advertisedSyncAddresses,
 	coordinatorStatusSnapshot,
+	createCoordinatorReciprocalApproval,
 	fetchCoordinatorStalePeers,
 	lookupCoordinatorPeers,
 	readCoordinatorSyncConfig,
@@ -248,6 +249,57 @@ describe("lookupCoordinatorPeers", () => {
 			rmSync(keysDir, { recursive: true, force: true });
 		}
 	});
+
+	it("keeps the earliest expiry when merging fresh sightings across groups", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		try {
+			initTestSchema(db);
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const groupId = new URL(String(input)).searchParams.get("group_id") || "";
+				const isLaterGroup = groupId === "team-b";
+				return new Response(
+					JSON.stringify({
+						items: [
+							{
+								device_id: "peer-1",
+								fingerprint: "fp-1",
+								public_key: "pk-1",
+								addresses: [`${groupId}.example.test:7337`],
+								last_seen_at: isLaterGroup
+									? "2026-08-24T00:00:10.000Z"
+									: "2026-08-24T00:00:00.000Z",
+								expires_at: isLaterGroup ? "2026-08-24T00:01:10.000Z" : "2026-08-24T00:01:00.000Z",
+								stale: false,
+							},
+						],
+					}),
+					{ status: 200 },
+				);
+			}) as typeof fetch;
+
+			const peers = await lookupCoordinatorPeers(
+				{ db, dbPath: ":memory:" },
+				readCoordinatorSyncConfig({
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_groups: ["team-a", "team-b"],
+				}),
+				{ keysDir },
+			);
+
+			expect(peers[0]?.addresses).toEqual([
+				"http://team-a.example.test:7337",
+				"http://team-b.example.test:7337",
+			]);
+			expect(peers[0]?.last_seen_at).toBe("2026-08-24T00:00:10.000Z");
+			expect(peers[0]?.expires_at).toBe("2026-08-24T00:01:00.000Z");
+		} finally {
+			globalThis.fetch = prevFetch;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
 });
 
 describe("Node coordinator signature invariance", () => {
@@ -317,6 +369,668 @@ describe("Node coordinator signature invariance", () => {
 });
 
 describe("coordinatorStatusSnapshot", () => {
+	it("reuses remote status for 30 seconds and refreshes at the cache boundary", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		const requestsByPath = new Map<string, number>();
+		try {
+			initTestSchema(db);
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-08-24T00:00:00.000Z"));
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const pathname = new URL(String(input)).pathname;
+				requestsByPath.set(pathname, (requestsByPath.get(pathname) ?? 0) + 1);
+				if (pathname === "/v1/presence") {
+					return new Response(JSON.stringify({ addresses: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/peers" || pathname === "/v1/reciprocal-approvals") {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as typeof fetch;
+			const config = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+			});
+			const store = {
+				db,
+				dbPath: `:memory:-${randomUUID()}`,
+			} as unknown as MemoryStore;
+
+			await coordinatorStatusSnapshot(store, config);
+			const initialRequests = new Map(requestsByPath);
+			vi.advanceTimersByTime(29_999);
+			await coordinatorStatusSnapshot(store, config);
+
+			expect(requestsByPath).toEqual(initialRequests);
+
+			vi.advanceTimersByTime(1);
+			await coordinatorStatusSnapshot(store, config);
+
+			expect(requestsByPath.get("/v1/peers")).toBe(2);
+			expect(requestsByPath.get("/v1/reciprocal-approvals")).toBe(4);
+			expect(requestsByPath.get("/v1/presence")).toBe(1);
+		} finally {
+			vi.useRealTimers();
+			globalThis.fetch = prevFetch;
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
+	it("refreshes short-lived presence independently while reusing the status snapshot", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		const requestsByPath = new Map<string, number>();
+		try {
+			initTestSchema(db);
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-08-24T00:00:00.000Z"));
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const pathname = new URL(String(input)).pathname;
+				requestsByPath.set(pathname, (requestsByPath.get(pathname) ?? 0) + 1);
+				if (pathname === "/v1/presence") {
+					return new Response(JSON.stringify({ addresses: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/peers" || pathname === "/v1/reciprocal-approvals") {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as typeof fetch;
+			const config = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+				sync_coordinator_presence_ttl_s: 20,
+			});
+			const store = {
+				db,
+				dbPath: `:memory:-${randomUUID()}`,
+			} as unknown as MemoryStore;
+
+			await coordinatorStatusSnapshot(store, config);
+			vi.advanceTimersByTime(9_999);
+			await coordinatorStatusSnapshot(store, config);
+			expect(requestsByPath.get("/v1/presence")).toBe(1);
+
+			vi.advanceTimersByTime(1);
+			await coordinatorStatusSnapshot(store, config);
+
+			expect(requestsByPath.get("/v1/presence")).toBe(2);
+			expect(requestsByPath.get("/v1/peers")).toBe(1);
+			expect(requestsByPath.get("/v1/reciprocal-approvals")).toBe(2);
+		} finally {
+			vi.useRealTimers();
+			globalThis.fetch = prevFetch;
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not reuse cached peers after a presence refresh detects enrollment loss", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		let peerRequests = 0;
+		let presenceRequests = 0;
+		try {
+			initTestSchema(db);
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-08-24T00:00:00.000Z"));
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const pathname = new URL(String(input)).pathname;
+				if (pathname === "/v1/presence") {
+					presenceRequests += 1;
+					if (presenceRequests > 1) {
+						return new Response(JSON.stringify({ error: "unknown_device" }), { status: 404 });
+					}
+					return new Response(JSON.stringify({ addresses: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/peers") {
+					peerRequests += 1;
+					if (presenceRequests > 1) {
+						return new Response(JSON.stringify({ error: "unknown_device" }), { status: 404 });
+					}
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-before-revocation",
+									expires_at: "2026-08-24T00:00:30.000Z",
+									stale: false,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				if (pathname === "/v1/reciprocal-approvals") {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as typeof fetch;
+			const config = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+				sync_coordinator_presence_ttl_s: 20,
+			});
+			const store = {
+				db,
+				dbPath: `:memory:-${randomUUID()}`,
+			} as unknown as MemoryStore;
+
+			await coordinatorStatusSnapshot(store, config);
+			vi.advanceTimersByTime(10_000);
+			const revoked = await coordinatorStatusSnapshot(store, config);
+
+			expect(revoked.presence_status).toBe("not_enrolled");
+			expect(revoked.discovered_devices).toEqual([]);
+			expect(peerRequests).toBe(1);
+		} finally {
+			vi.useRealTimers();
+			globalThis.fetch = prevFetch;
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
+	it("refreshes peers when their cache deadline passes during a presence refresh", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		let peerRequests = 0;
+		let presenceRequests = 0;
+		try {
+			initTestSchema(db);
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-08-24T00:00:00.000Z"));
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const pathname = new URL(String(input)).pathname;
+				if (pathname === "/v1/presence") {
+					presenceRequests += 1;
+					if (presenceRequests === 2) vi.advanceTimersByTime(1);
+					return new Response(JSON.stringify({ addresses: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/peers") {
+					peerRequests += 1;
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-expiring-during-presence-refresh",
+									expires_at: "2026-08-24T00:00:15.000Z",
+									stale: peerRequests > 1,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				if (pathname === "/v1/reciprocal-approvals") {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as typeof fetch;
+			const config = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+				sync_coordinator_presence_ttl_s: 20,
+			});
+			const store = {
+				db,
+				dbPath: `:memory:-${randomUUID()}`,
+			} as unknown as MemoryStore;
+
+			await coordinatorStatusSnapshot(store, config);
+			vi.advanceTimersByTime(14_999);
+			await coordinatorStatusSnapshot(store, config);
+
+			expect(presenceRequests).toBe(2);
+			expect(peerRequests).toBe(2);
+		} finally {
+			vi.useRealTimers();
+			globalThis.fetch = prevFetch;
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
+	it("refreshes the status snapshot when its earliest peer presence expires", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		let peerRequests = 0;
+		try {
+			initTestSchema(db);
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-08-24T00:00:00.000Z"));
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const pathname = new URL(String(input)).pathname;
+				if (pathname === "/v1/presence") {
+					return new Response(JSON.stringify({ addresses: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/peers") {
+					peerRequests += 1;
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-expiring",
+									fingerprint: "peer-fingerprint",
+									public_key: "peer-public-key",
+									addresses: ["http://10.0.0.5:7337"],
+									expires_at: "2026-08-24T00:00:15.000Z",
+									stale: peerRequests > 1,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				if (pathname === "/v1/reciprocal-approvals") {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as typeof fetch;
+			const config = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+			});
+			const store = {
+				db,
+				dbPath: `:memory:-${randomUUID()}`,
+			} as unknown as MemoryStore;
+
+			await coordinatorStatusSnapshot(store, config);
+			vi.advanceTimersByTime(14_999);
+			await coordinatorStatusSnapshot(store, config);
+			expect(peerRequests).toBe(1);
+
+			vi.advanceTimersByTime(1);
+			const refreshed = await coordinatorStatusSnapshot(store, config);
+
+			expect(peerRequests).toBe(2);
+			expect(refreshed.discovered_devices).toEqual([
+				expect.objectContaining({ device_id: "peer-expiring", stale: true }),
+			]);
+
+			vi.advanceTimersByTime(1_000);
+			await coordinatorStatusSnapshot(store, config);
+			expect(peerRequests).toBe(2);
+		} finally {
+			vi.useRealTimers();
+			globalThis.fetch = prevFetch;
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not cache a status snapshot whose peer expires while approvals load", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		let peerRequests = 0;
+		let approvalRequests = 0;
+		try {
+			initTestSchema(db);
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-08-24T00:00:00.000Z"));
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const pathname = new URL(String(input)).pathname;
+				if (pathname === "/v1/presence") {
+					return new Response(JSON.stringify({ addresses: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/peers") {
+					peerRequests += 1;
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-expiring-during-load",
+									expires_at: "2026-08-24T00:00:01.000Z",
+									stale: peerRequests > 1,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				if (pathname === "/v1/reciprocal-approvals") {
+					approvalRequests += 1;
+					if (approvalRequests === 1) vi.advanceTimersByTime(1_000);
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as typeof fetch;
+			const config = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+			});
+			const store = {
+				db,
+				dbPath: `:memory:-${randomUUID()}`,
+			} as unknown as MemoryStore;
+
+			await coordinatorStatusSnapshot(store, config);
+			expect(Date.now()).toBe(Date.parse("2026-08-24T00:00:01.000Z"));
+			await coordinatorStatusSnapshot(store, config);
+			await coordinatorStatusSnapshot(store, config);
+
+			expect(peerRequests).toBe(2);
+		} finally {
+			vi.useRealTimers();
+			globalThis.fetch = prevFetch;
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
+	it("invalidates cached status after a reciprocal approval succeeds", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		let peerRequests = 0;
+		let reciprocalApprovalPayload: Record<string, unknown> | null = null;
+		try {
+			initTestSchema(db);
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const pathname = new URL(String(input)).pathname;
+				const method = String(init?.method || "GET").toUpperCase();
+				if (pathname === "/v1/presence") {
+					return new Response(JSON.stringify({ addresses: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/peers") {
+					peerRequests += 1;
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/reciprocal-approvals" && method === "POST") {
+					reciprocalApprovalPayload = JSON.parse(String(init?.body ?? "{}"));
+					return new Response(
+						JSON.stringify({
+							request: {
+								request_id: "approval-1",
+								group_id: "team-a",
+								requesting_device_id: "local-device",
+								requested_device_id: "peer-a",
+								status: "pending",
+							},
+						}),
+						{ status: 200 },
+					);
+				}
+				if (pathname === "/v1/reciprocal-approvals") {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as typeof fetch;
+			const config = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+			});
+			const store = {
+				db,
+				dbPath: `:memory:-${randomUUID()}`,
+			} as unknown as MemoryStore;
+
+			await coordinatorStatusSnapshot(store, config);
+			await coordinatorStatusSnapshot(store, config);
+			expect(peerRequests).toBe(1);
+
+			await createCoordinatorReciprocalApproval(store, config, {
+				groupId: "team-a",
+				requestedDeviceId: "peer-a",
+				expectedIncomingRequestId: "incoming-approval-1",
+			});
+			await coordinatorStatusSnapshot(store, config);
+
+			expect(peerRequests).toBe(2);
+			expect(reciprocalApprovalPayload).toEqual({
+				group_id: "team-a",
+				requested_device_id: "peer-a",
+				expected_incoming_request_id: "incoming-approval-1",
+			});
+		} finally {
+			globalThis.fetch = prevFetch;
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
+	it("invalidates cached status when the reviewed reciprocal approval changed", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		let peerRequests = 0;
+		try {
+			initTestSchema(db);
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const pathname = new URL(String(input)).pathname;
+				const method = String(init?.method || "GET").toUpperCase();
+				if (pathname === "/v1/presence") {
+					return new Response(JSON.stringify({ addresses: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/peers") {
+					peerRequests += 1;
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/reciprocal-approvals" && method === "POST") {
+					return new Response(JSON.stringify({ error: "reciprocal_approval_request_changed" }), {
+						status: 409,
+					});
+				}
+				if (pathname === "/v1/reciprocal-approvals") {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as typeof fetch;
+			const config = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+			});
+			const store = {
+				db,
+				dbPath: `:memory:-${randomUUID()}`,
+			} as unknown as MemoryStore;
+
+			await coordinatorStatusSnapshot(store, config);
+			await expect(
+				createCoordinatorReciprocalApproval(store, config, {
+					groupId: "team-a",
+					requestedDeviceId: "peer-a",
+					expectedIncomingRequestId: "stale-request",
+				}),
+			).rejects.toThrow("reciprocal_approval_request_changed");
+			await coordinatorStatusSnapshot(store, config);
+
+			expect(peerRequests).toBe(2);
+		} finally {
+			globalThis.fetch = prevFetch;
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not cache a status request that started before reciprocal approval invalidation", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		let peerRequests = 0;
+		let markFirstPeerRequestStarted!: () => void;
+		let releaseFirstPeerRequest!: () => void;
+		const firstPeerRequestStarted = new Promise<void>((resolve) => {
+			markFirstPeerRequestStarted = resolve;
+		});
+		const firstPeerRequestBlocked = new Promise<void>((resolve) => {
+			releaseFirstPeerRequest = resolve;
+		});
+		try {
+			initTestSchema(db);
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const pathname = new URL(String(input)).pathname;
+				const method = String(init?.method || "GET").toUpperCase();
+				if (pathname === "/v1/presence") {
+					return new Response(JSON.stringify({ addresses: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/peers") {
+					peerRequests += 1;
+					if (peerRequests === 1) {
+						markFirstPeerRequestStarted();
+						await firstPeerRequestBlocked;
+					}
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/reciprocal-approvals" && method === "POST") {
+					return new Response(
+						JSON.stringify({
+							request: {
+								request_id: "approval-race",
+								group_id: "team-a",
+								requesting_device_id: "local-device",
+								requested_device_id: "peer-a",
+								status: "pending",
+							},
+						}),
+						{ status: 200 },
+					);
+				}
+				if (pathname === "/v1/reciprocal-approvals") {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as typeof fetch;
+			const config = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+			});
+			const store = {
+				db,
+				dbPath: `:memory:-${randomUUID()}`,
+			} as unknown as MemoryStore;
+
+			const staleStatusRequest = coordinatorStatusSnapshot(store, config);
+			await firstPeerRequestStarted;
+			await createCoordinatorReciprocalApproval(store, config, {
+				groupId: "team-a",
+				requestedDeviceId: "peer-a",
+			});
+			releaseFirstPeerRequest();
+			await staleStatusRequest;
+			await coordinatorStatusSnapshot(store, config);
+
+			expect(peerRequests).toBe(2);
+		} finally {
+			releaseFirstPeerRequest();
+			globalThis.fetch = prevFetch;
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not cache a snapshot with incomplete reciprocal approval data", async () => {
+		const db = new Database(":memory:");
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));
+		const prevFetch = globalThis.fetch;
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		let peerRequests = 0;
+		try {
+			initTestSchema(db);
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				const pathname = new URL(String(input)).pathname;
+				if (pathname === "/v1/presence") {
+					return new Response(JSON.stringify({ addresses: [] }), { status: 200 });
+				}
+				if (pathname === "/v1/peers") {
+					peerRequests += 1;
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-a",
+									groups: ["team-a"],
+									stale: false,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				if (pathname === "/v1/reciprocal-approvals") {
+					return new Response(JSON.stringify({ error: "temporary failure" }), { status: 503 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 404 });
+			}) as typeof fetch;
+			const config = readCoordinatorSyncConfig({
+				sync_enabled: true,
+				sync_coordinator_url: "https://coord.example.test",
+				sync_coordinator_group: "team-a",
+			});
+			const store = {
+				db,
+				dbPath: `:memory:-${randomUUID()}`,
+			} as unknown as MemoryStore;
+
+			const first = await coordinatorStatusSnapshot(store, config);
+			const second = await coordinatorStatusSnapshot(store, config);
+
+			expect(first.reciprocal_approval_error).toContain("503");
+			expect(second.reciprocal_approval_error).toContain("503");
+			expect(peerRequests).toBe(2);
+		} finally {
+			globalThis.fetch = prevFetch;
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
+	});
+
 	it("reuses a short-lived coordinator snapshot instead of polling remote status on every viewer refresh", async () => {
 		const db = new Database(":memory:");
 		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -5,7 +5,10 @@ import {
 	mergeAddressesPreferCandidates,
 	normalizeAddress,
 } from "./address-utils.js";
-import type { CoordinatorReciprocalApproval } from "./coordinator-store-contract.js";
+import {
+	type CoordinatorReciprocalApproval,
+	CoordinatorReciprocalApprovalRequestChangedError,
+} from "./coordinator-store-contract.js";
 import type { Database } from "./db.js";
 import { getCodememEnvOverrides, readCodememConfigFile } from "./observer-config.js";
 import { getCachedScopeAuthorization } from "./scope-membership-cache.js";
@@ -69,6 +72,14 @@ function mergeStringLists(existing: string[], candidates: string[]): string[] {
 	return merged;
 }
 
+function earliestValidExpiry(existing: unknown, candidate: unknown): unknown {
+	const existingMs = Date.parse(clean(existing));
+	const candidateMs = Date.parse(clean(candidate));
+	if (!Number.isFinite(existingMs)) return Number.isFinite(candidateMs) ? candidate : existing;
+	if (!Number.isFinite(candidateMs)) return existing;
+	return candidateMs < existingMs ? candidate : existing;
+}
+
 export interface CoordinatorSyncConfig {
 	syncEnabled: boolean;
 	syncHost: string;
@@ -115,7 +126,29 @@ interface CoordinatorStatusCacheEntry {
 
 const coordinatorPresenceCache = new Map<string, PresenceSnapshot>();
 const coordinatorStatusCache = new Map<string, CoordinatorStatusCacheEntry>();
-const COORDINATOR_STATUS_SNAPSHOT_CACHE_MS = 5_000;
+const coordinatorStatusCacheGenerations = new Map<string, number>();
+const COORDINATOR_STATUS_SNAPSHOT_CACHE_MS = 30_000;
+
+function coordinatorStatusRefreshDeadline(now: number, peers: Record<string, unknown>[]): number {
+	let deadline = now + COORDINATOR_STATUS_SNAPSHOT_CACHE_MS;
+	for (const peer of peers) {
+		if (peer.stale) continue;
+		const expiresAtMs = Date.parse(clean(peer.expires_at));
+		if (!Number.isFinite(expiresAtMs)) continue;
+		// Never re-serve an expired peer, even if local clock skew disables this cache.
+		if (expiresAtMs <= now) return now;
+		deadline = Math.min(deadline, expiresAtMs);
+	}
+	return deadline;
+}
+
+function invalidateCoordinatorStatusCache(cacheKey: string): void {
+	coordinatorStatusCache.delete(cacheKey);
+	coordinatorStatusCacheGenerations.set(
+		cacheKey,
+		(coordinatorStatusCacheGenerations.get(cacheKey) ?? 0) + 1,
+	);
+}
 
 function presenceCacheKey(store: PresenceStoreLike, config: CoordinatorSyncConfig): string {
 	const groups = [...config.syncCoordinatorGroups].sort().join(",");
@@ -176,6 +209,52 @@ function presenceRefreshIntervalMs(config: CoordinatorSyncConfig): number {
 
 function presenceRetryIntervalMs(): number {
 	return 30_000;
+}
+
+async function refreshCoordinatorPresenceStatus(
+	store: PresenceStoreLike,
+	config: CoordinatorSyncConfig,
+	snapshot: Record<string, unknown>,
+	now: number,
+): Promise<void> {
+	const presenceKey = presenceCacheKey(store, config);
+	const cachedPresence = coordinatorPresenceCache.get(presenceKey);
+	if (cachedPresence && now < cachedPresence.nextRefreshAtMs) {
+		snapshot.presence_status = cachedPresence.status;
+		snapshot.presence_error = cachedPresence.error;
+		snapshot.advertised_addresses = cachedPresence.advertisedAddresses;
+		return;
+	}
+	try {
+		const registration = await registerCoordinatorPresence(store, config);
+		const first = registration?.responses?.[0];
+		const advertisedAddresses =
+			first && typeof first === "object"
+				? ((first as Record<string, unknown>).addresses ?? [])
+				: [];
+		snapshot.presence_status = "posted";
+		snapshot.presence_error = null;
+		snapshot.advertised_addresses = advertisedAddresses;
+		coordinatorPresenceCache.set(presenceKey, {
+			status: "posted",
+			error: null,
+			advertisedAddresses,
+			nextRefreshAtMs: now + presenceRefreshIntervalMs(config),
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const status: PresenceStatus = message.includes("unknown_device") ? "not_enrolled" : "error";
+		const nextRefreshAtMs = status === "not_enrolled" ? now : now + presenceRetryIntervalMs();
+		snapshot.presence_status = status;
+		snapshot.presence_error = message;
+		snapshot.advertised_addresses = [];
+		coordinatorPresenceCache.set(presenceKey, {
+			status,
+			error: message,
+			advertisedAddresses: [],
+			nextRefreshAtMs,
+		});
+	}
 }
 
 export function readCoordinatorSyncConfig(config?: ConfigRecord): CoordinatorSyncConfig {
@@ -373,6 +452,13 @@ export async function lookupCoordinatorPeers(
 				(isStale && wasStale && clean(record.last_seen_at) > clean(existing.last_seen_at));
 			if (shouldUpdateFreshnessMetadata) {
 				existing.last_seen_at = record.last_seen_at;
+			}
+			// Unioned fresh addresses are valid only until the earliest group expiry.
+			if (!isStale) {
+				existing.expires_at = wasStale
+					? record.expires_at
+					: earliestValidExpiry(existing.expires_at, record.expires_at);
+			} else if (wasStale && shouldUpdateFreshnessMetadata) {
 				existing.expires_at = record.expires_at;
 			}
 		}
@@ -785,19 +871,33 @@ export async function listCoordinatorReciprocalApprovals(
 export async function createCoordinatorReciprocalApproval(
 	store: MemoryStore,
 	config: CoordinatorSyncConfig,
-	options: { groupId: string; requestedDeviceId: string },
+	options: {
+		groupId: string;
+		requestedDeviceId: string;
+		expectedIncomingRequestId?: string;
+	},
 ): Promise<CoordinatorReciprocalApproval> {
 	if (!coordinatorEnabled(config)) throw new Error("Coordinator not configured.");
 	const groupId = options.groupId.trim();
 	const requestedDeviceId = options.requestedDeviceId.trim();
+	const expectedIncomingRequestId = options.expectedIncomingRequestId?.trim();
 	if (!groupId || !requestedDeviceId) {
 		throw new Error("groupId and requestedDeviceId are required.");
+	}
+	if (options.expectedIncomingRequestId !== undefined && !expectedIncomingRequestId) {
+		throw new Error("expectedIncomingRequestId must not be empty when provided.");
 	}
 	const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
 	const [deviceId] = ensureDeviceIdentity(store.db, { keysDir });
 	const baseUrl = buildBaseUrl(config.syncCoordinatorUrl);
 	const url = `${baseUrl}/v1/reciprocal-approvals`;
-	const payload = { group_id: groupId, requested_device_id: requestedDeviceId };
+	const payload = {
+		group_id: groupId,
+		requested_device_id: requestedDeviceId,
+		...(expectedIncomingRequestId !== undefined
+			? { expected_incoming_request_id: expectedIncomingRequestId }
+			: {}),
+	};
 	const bodyBytes = Buffer.from(JSON.stringify(payload), "utf8");
 	const headers = buildAuthHeaders({
 		deviceId,
@@ -815,8 +915,13 @@ export async function createCoordinatorReciprocalApproval(
 	});
 	if (status !== 200 || !response || !response.request || typeof response.request !== "object") {
 		const detail = typeof response?.error === "string" ? response.error : "unknown";
+		if (status === 409 && detail === "reciprocal_approval_request_changed") {
+			invalidateCoordinatorStatusCache(coordinatorStatusCacheKey(store, config));
+			throw new CoordinatorReciprocalApprovalRequestChangedError();
+		}
 		throw new Error(`coordinator reciprocal approval create failed (${status}: ${detail})`);
 	}
+	invalidateCoordinatorStatusCache(coordinatorStatusCacheKey(store, config));
 	return response.request as CoordinatorReciprocalApproval;
 }
 
@@ -851,18 +956,37 @@ export async function coordinatorStatusSnapshot(
 	const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
 	const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir });
 	const cacheKey = coordinatorStatusCacheKey(store, config);
-	const now = Date.now();
+	const cacheGeneration = coordinatorStatusCacheGenerations.get(cacheKey) ?? 0;
+	let now = Date.now();
 	const cachedSnapshot = coordinatorStatusCache.get(cacheKey);
 	if (cachedSnapshot && now < cachedSnapshot.nextRefreshAtMs) {
-		trustCoordinatorPeersWithSharedManagedScopes(
-			store.db,
-			localDeviceId,
-			cachedSnapshot.discoveredPeers,
-		);
-		return {
-			...structuredClone(cachedSnapshot.snapshot),
-			paired_peer_count: pairedPeerCount(store),
-		};
+		const snapshot = structuredClone(cachedSnapshot.snapshot);
+		await refreshCoordinatorPresenceStatus(store, config, snapshot, now);
+		now = Date.now();
+		if (snapshot.presence_status === "not_enrolled") {
+			invalidateCoordinatorStatusCache(cacheKey);
+			snapshot.fresh_peer_count = 0;
+			snapshot.stale_peer_count = 0;
+			snapshot.discovered_peer_count = 0;
+			snapshot.discovered_devices = [];
+			snapshot.reciprocal_approvals = { incoming: [], outgoing: [] };
+			return {
+				...snapshot,
+				paired_peer_count: pairedPeerCount(store),
+			};
+		}
+		if (now < cachedSnapshot.nextRefreshAtMs) {
+			trustCoordinatorPeersWithSharedManagedScopes(
+				store.db,
+				localDeviceId,
+				cachedSnapshot.discoveredPeers,
+			);
+			revokeUnauthorizedCoordinatorPeerTrust(store.db, localDeviceId);
+			return {
+				...snapshot,
+				paired_peer_count: pairedPeerCount(store),
+			};
+		}
 	}
 	const snapshot: Record<string, unknown> = {
 		enabled: true,
@@ -879,42 +1003,7 @@ export async function coordinatorStatusSnapshot(
 		discovered_peer_count: 0,
 		discovered_devices: [],
 	};
-	const presenceKey = presenceCacheKey(store, config);
-	const cachedPresence = coordinatorPresenceCache.get(presenceKey);
-	if (cachedPresence && now < cachedPresence.nextRefreshAtMs) {
-		snapshot.presence_status = cachedPresence.status;
-		snapshot.presence_error = cachedPresence.error;
-		snapshot.advertised_addresses = cachedPresence.advertisedAddresses;
-	} else {
-		try {
-			const registration = await registerCoordinatorPresence(store, config);
-			const first = registration?.responses?.[0];
-			const advertisedAddresses =
-				first && typeof first === "object"
-					? ((first as Record<string, unknown>).addresses ?? [])
-					: [];
-			snapshot.presence_status = "posted";
-			snapshot.advertised_addresses = advertisedAddresses;
-			coordinatorPresenceCache.set(presenceKey, {
-				status: "posted",
-				error: null,
-				advertisedAddresses,
-				nextRefreshAtMs: now + presenceRefreshIntervalMs(config),
-			});
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			const status: PresenceStatus = message.includes("unknown_device") ? "not_enrolled" : "error";
-			const nextRefreshAtMs = status === "not_enrolled" ? now : now + presenceRetryIntervalMs();
-			snapshot.presence_status = status;
-			snapshot.presence_error = message;
-			coordinatorPresenceCache.set(presenceKey, {
-				status,
-				error: message,
-				advertisedAddresses: [],
-				nextRefreshAtMs,
-			});
-		}
-	}
+	await refreshCoordinatorPresenceStatus(store, config, snapshot, now);
 	let discoveredPeers: Record<string, unknown>[] = [];
 	try {
 		const { peers } = await refreshAuthorizedCoordinatorPeerTrust(store, config, { keysDir });
@@ -960,11 +1049,16 @@ export async function coordinatorStatusSnapshot(
 	} catch (error) {
 		snapshot.lookup_error = error instanceof Error ? error.message : String(error);
 	}
-	if (snapshot.presence_status !== "not_enrolled") {
+	if (
+		snapshot.presence_status !== "not_enrolled" &&
+		!snapshot.lookup_error &&
+		!snapshot.reciprocal_approval_error &&
+		(coordinatorStatusCacheGenerations.get(cacheKey) ?? 0) === cacheGeneration
+	) {
 		coordinatorStatusCache.set(cacheKey, {
 			snapshot: structuredClone(snapshot),
 			discoveredPeers,
-			nextRefreshAtMs: Date.now() + COORDINATOR_STATUS_SNAPSHOT_CACHE_MS,
+			nextRefreshAtMs: coordinatorStatusRefreshDeadline(Date.now(), discoveredPeers),
 		});
 	}
 	return snapshot;

--- a/packages/core/src/coordinator-store-contract.ts
+++ b/packages/core/src/coordinator-store-contract.ts
@@ -358,6 +358,19 @@ export interface CoordinatorCreateReciprocalApprovalInput {
 	groupId: string;
 	requestingDeviceId: string;
 	requestedDeviceId: string;
+	/** Complete only this exact pending request in the reverse direction. */
+	expectedIncomingRequestId?: string;
+}
+
+export const RECIPROCAL_APPROVAL_REQUEST_CHANGED = "reciprocal_approval_request_changed" as const;
+
+export class CoordinatorReciprocalApprovalRequestChangedError extends Error {
+	readonly code = RECIPROCAL_APPROVAL_REQUEST_CHANGED;
+
+	constructor() {
+		super(RECIPROCAL_APPROVAL_REQUEST_CHANGED);
+		this.name = "CoordinatorReciprocalApprovalRequestChangedError";
+	}
 }
 
 export interface CoordinatorCreateBootstrapGrantInput {

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -5,6 +5,10 @@ import type {
 	CoordinatorStore,
 } from "./coordinator-store-contract.js";
 import {
+	CoordinatorReciprocalApprovalRequestChangedError,
+	RECIPROCAL_APPROVAL_REQUEST_CHANGED,
+} from "./coordinator-store-contract.js";
+import {
 	canonicalRecipientReviewedIntentJson,
 	recipientReviewedIntentDigest,
 } from "./recipient-reviewed-intent.js";
@@ -2454,6 +2458,116 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 							groupId: "g1",
 							deviceId: "d2",
 							direction: "incoming",
+						}),
+					).toEqual([]);
+				});
+			});
+
+			it("completes only the expected reverse pending approval", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					const incoming = await store.createReciprocalApproval({
+						groupId: "g1",
+						requestingDeviceId: "d1",
+						requestedDeviceId: "d2",
+					});
+
+					const completed = await store.createReciprocalApproval({
+						groupId: "g1",
+						requestingDeviceId: "d2",
+						requestedDeviceId: "d1",
+						expectedIncomingRequestId: incoming.request_id,
+					});
+
+					expect(completed).toEqual(
+						expect.objectContaining({ request_id: incoming.request_id, status: "completed" }),
+					);
+				});
+			});
+
+			it("rejects a changed expected request without creating an outgoing request", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					const incoming = await store.createReciprocalApproval({
+						groupId: "g1",
+						requestingDeviceId: "d1",
+						requestedDeviceId: "d2",
+					});
+
+					await expect(
+						store.createReciprocalApproval({
+							groupId: "g1",
+							requestingDeviceId: "d2",
+							requestedDeviceId: "d1",
+							expectedIncomingRequestId: "changed-request-id",
+						}),
+					).rejects.toMatchObject({
+						code: RECIPROCAL_APPROVAL_REQUEST_CHANGED,
+						name: CoordinatorReciprocalApprovalRequestChangedError.name,
+					});
+					expect(
+						await store.listReciprocalApprovals({
+							groupId: "g1",
+							deviceId: "d2",
+							direction: "outgoing",
+						}),
+					).toEqual([]);
+					expect(
+						await store.listReciprocalApprovals({
+							groupId: "g1",
+							deviceId: "d2",
+							direction: "incoming",
+						}),
+					).toEqual([
+						expect.objectContaining({ request_id: incoming.request_id, status: "pending" }),
+					]);
+				});
+			});
+
+			it("rejects an expected request that is completed or belongs to another pair or group", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.createGroup("g2");
+					const completedIncoming = await store.createReciprocalApproval({
+						groupId: "g1",
+						requestingDeviceId: "d1",
+						requestedDeviceId: "d2",
+					});
+					await store.createReciprocalApproval({
+						groupId: "g1",
+						requestingDeviceId: "d2",
+						requestedDeviceId: "d1",
+					});
+					const otherGroup = await store.createReciprocalApproval({
+						groupId: "g2",
+						requestingDeviceId: "d1",
+						requestedDeviceId: "d2",
+					});
+					const otherPair = await store.createReciprocalApproval({
+						groupId: "g1",
+						requestingDeviceId: "d3",
+						requestedDeviceId: "d4",
+					});
+
+					for (const expectedIncomingRequestId of [
+						completedIncoming.request_id,
+						otherGroup.request_id,
+						otherPair.request_id,
+					]) {
+						await expect(
+							store.createReciprocalApproval({
+								groupId: "g1",
+								requestingDeviceId: "d2",
+								requestedDeviceId: "d1",
+								expectedIncomingRequestId,
+							}),
+						).rejects.toMatchObject({ code: RECIPROCAL_APPROVAL_REQUEST_CHANGED });
+					}
+					expect(
+						await store.listReciprocalApprovals({
+							groupId: "g1",
+							deviceId: "d2",
+							direction: "outgoing",
 						}),
 					).toEqual([]);
 				});

--- a/packages/core/src/coordinator-store.ts
+++ b/packages/core/src/coordinator-store.ts
@@ -36,3 +36,7 @@ export type {
 	CoordinatorUpdateScopeInput,
 	CoordinatorUpsertPresenceInput,
 } from "./coordinator-store-contract.js";
+export {
+	CoordinatorReciprocalApprovalRequestChangedError,
+	RECIPROCAL_APPROVAL_REQUEST_CHANGED,
+} from "./coordinator-store-contract.js";

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -45,6 +45,7 @@ import type {
 	CoordinatorUpsertPresenceInput,
 } from "./coordinator-store-contract.js";
 import {
+	CoordinatorReciprocalApprovalRequestChangedError,
 	isCoordinatorAssignedIdentityId,
 	normalizeInviteExpiresAt,
 	recipientInviteAuthoritativeIdentityId,
@@ -1701,11 +1702,43 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		const groupId = opts.groupId.trim();
 		const requestingDeviceId = opts.requestingDeviceId.trim();
 		const requestedDeviceId = opts.requestedDeviceId.trim();
+		const hasExpectedIncomingRequestId = opts.expectedIncomingRequestId !== undefined;
+		const expectedIncomingRequestId = opts.expectedIncomingRequestId?.trim() ?? "";
 		if (!groupId || !requestingDeviceId || !requestedDeviceId) {
 			throw new Error("groupId, requestingDeviceId, and requestedDeviceId are required.");
 		}
 		if (requestingDeviceId === requestedDeviceId) {
 			throw new Error("requesting and requested device ids must differ.");
+		}
+		if (hasExpectedIncomingRequestId) {
+			const resolvedAt = nowISO();
+			const changes = await runChanges(
+				this.db
+					.prepare(`UPDATE coordinator_reciprocal_approvals
+						 SET status = 'completed', resolved_at = ?
+						 WHERE request_id = ?
+						   AND group_id = ?
+						   AND requesting_device_id = ?
+						   AND requested_device_id = ?
+						   AND status = 'pending'`)
+					.bind(
+						resolvedAt,
+						expectedIncomingRequestId,
+						groupId,
+						requestedDeviceId,
+						requestingDeviceId,
+					),
+			);
+			if (changes !== 1) {
+				throw new CoordinatorReciprocalApprovalRequestChangedError();
+			}
+			const completed = await firstRow<CoordinatorReciprocalApproval>(
+				this.db
+					.prepare(`SELECT request_id, group_id, requesting_device_id, requested_device_id, status, created_at, resolved_at
+						 FROM coordinator_reciprocal_approvals WHERE request_id = ?`)
+					.bind(expectedIncomingRequestId),
+			);
+			return rowToRecord<CoordinatorReciprocalApproval>(completed);
 		}
 		const pendingPair = reciprocalPendingPair(requestingDeviceId, requestedDeviceId);
 		const existing = await firstRow<CoordinatorReciprocalApproval>(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -156,7 +156,9 @@ export {
 	DEFAULT_COORDINATOR_DB_PATH,
 } from "./coordinator-store.js";
 export {
+	CoordinatorReciprocalApprovalRequestChangedError,
 	isCoordinatorAssignedIdentityId,
+	RECIPROCAL_APPROVAL_REQUEST_CHANGED,
 	recipientInviteAuthoritativeIdentityId,
 } from "./coordinator-store-contract.js";
 export type { Database } from "./db.js";

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -229,10 +229,18 @@ export async function renamePeer(peerDeviceId: string, name: string): Promise<un
 
 export async function acceptDiscoveredPeer(
 	peerDeviceId: string,
-	fingerprint?: string,
+	options?: {
+		fingerprint?: string | null;
+		expectedGroupId?: string;
+		expectedIncomingRequestId?: string;
+	},
 ): Promise<AcceptDiscoveredPeerResult> {
 	const body: Record<string, string> = { peer_device_id: peerDeviceId };
-	if (fingerprint) body.fingerprint = fingerprint;
+	if (options?.fingerprint) body.fingerprint = options.fingerprint;
+	if (options?.expectedGroupId) body.expected_group_id = options.expectedGroupId;
+	if (options?.expectedIncomingRequestId) {
+		body.expected_incoming_request_id = options.expectedIncomingRequestId;
+	}
 	const resp = await fetch("/api/sync/peers/accept-discovered", {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -154,13 +154,20 @@ export interface CachedLegacySharedReview {
 export interface DiscoveredDevice {
 	device_id?: string;
 	display_name?: string;
-	fingerprint?: string;
+	fingerprint?: string | null;
 	groups?: string[];
 	stale?: boolean;
 	address_count?: number;
 	addresses?: string[];
 	needs_local_approval?: boolean;
 	waiting_for_peer_approval?: boolean;
+	incoming_reciprocal_request_id?: string | null;
+	outgoing_reciprocal_request_id?: string | null;
+}
+
+export interface PendingCoordinatorApproval {
+	coordinatorUrl: string;
+	incomingRequestId: string;
 }
 
 export interface CachedSyncCoordinator {
@@ -169,6 +176,8 @@ export interface CachedSyncCoordinator {
 	groups?: unknown[];
 	coordinator_url?: string | null;
 	discovered_devices?: DiscoveredDevice[];
+	lookup_error?: string | null;
+	reciprocal_approval_error?: string | null;
 	presence_status?: TeamSyncPresenceState;
 	paired_peer_count?: number;
 }
@@ -305,6 +314,7 @@ export const state = {
 	} | null,
 	syncJoinRequestsFeedback: null as { message: string; tone: "success" | "warning" } | null,
 	syncDiscoveredFeedback: null as { message: string; tone: "success" | "warning" } | null,
+	pendingCoordinatorApprovalsByDeviceId: new Map<string, PendingCoordinatorApproval>(),
 	lastSyncAttempts: [] as unknown[],
 	lastSyncLegacyDevices: [] as unknown[],
 	lastSyncViewModel: null as UiSyncViewModel | null,

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.test.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.test.tsx
@@ -2,7 +2,7 @@ import { render } from "preact";
 import { act } from "preact/test-utils";
 import { afterEach, describe, expect, it } from "vitest";
 import { deriveTeamSyncPrimaryStatus } from "../view-model";
-import { TeamSyncPanel } from "./team-sync-panel";
+import { type TeamSyncDiscoveredRow, TeamSyncPanel } from "./team-sync-panel";
 
 let mount: HTMLDivElement | null = null;
 
@@ -31,6 +31,72 @@ function renderPrimaryStatus(primaryStatus: ReturnType<typeof deriveTeamSyncPrim
 		);
 	});
 	return mount;
+}
+
+function discoveredRow(overrides: Partial<TeamSyncDiscoveredRow> = {}): TeamSyncDiscoveredRow {
+	return {
+		actionMessage: null,
+		actionLabel: "Approve on this device",
+		approvalBadgeLabel: "Needs your approval",
+		approvalState: "needs-local-approval",
+		availabilityLabel: "Available",
+		connectionLabel: "Paired on this device",
+		coordinatorUrl: "https://coord.example.test",
+		deviceId: "device-a",
+		displayName: "Desk Mini",
+		displayTitle: "device-a",
+		fingerprint: "fingerprint-a",
+		groupId: "team-a",
+		incomingRequestId: "request-a",
+		mode: "accept",
+		note: "No fresh addresses",
+		pairedMessage: null,
+		...overrides,
+	};
+}
+
+function renderDiscoveredRows(
+	rows: TeamSyncDiscoveredRow[],
+	onReviewDiscoveredDevice: (row: TeamSyncDiscoveredRow) => Promise<{
+		message: string;
+		tone: "success" | "warning";
+	} | null> = async () => null,
+) {
+	const discoveredListMount = document.createElement("div");
+	document.body.appendChild(discoveredListMount);
+	mount = document.createElement("div");
+	document.body.appendChild(mount);
+	act(() => {
+		render(
+			<TeamSyncPanel
+				actionItems={[]}
+				actionableCount={rows.filter((row) => row.mode === "accept").length}
+				discoveredListMount={discoveredListMount}
+				discoveredRows={rows}
+				joinRequestsMount={null}
+				onApproveJoinRequest={async () => null}
+				onAttentionAction={async () => {}}
+				onDenyJoinRequest={async () => null}
+				onInspectConflict={() => {}}
+				onRemoveConflict={async () => null}
+				onReviewDiscoveredDevice={onReviewDiscoveredDevice}
+				pendingJoinRequests={[]}
+				presenceStatus="posted"
+				primaryStatus={deriveTeamSyncPrimaryStatus({
+					status: { enabled: true, daemon_state: "ok", daemon_running: true },
+					coordinator: {
+						configured: true,
+						sync_enabled: true,
+						groups: ["Acme"],
+						presence_status: "posted",
+					},
+					peers: [{ peer_device_id: "device-a", status: { peer_state: "online" } }],
+				})}
+			/>,
+			mount as HTMLDivElement,
+		);
+	});
+	return discoveredListMount;
 }
 
 afterEach(() => {
@@ -156,5 +222,43 @@ describe("TeamSyncPanel primary status", () => {
 
 		expect(root.textContent).toContain("No urgent team work right now.");
 		expect(root.querySelector("[data-primary-sync-state]")).toBeNull();
+	});
+});
+
+describe("TeamSyncPanel discovered approval rows", () => {
+	it("renders approval pending as ordinary status without another approval action", () => {
+		const discovered = renderDiscoveredRows([
+			discoveredRow({
+				actionMessage:
+					"Waiting for refreshed coordinator status. You do not need to approve again.",
+				actionLabel: null,
+				approvalBadgeLabel: "Approval sent",
+				approvalState: "approval-pending",
+				mode: "approval-pending",
+			}),
+		]);
+
+		expect(discovered.textContent).toContain("Approval sent");
+		expect(discovered.textContent).toContain(
+			"Waiting for refreshed coordinator status. You do not need to approve again.",
+		);
+		expect(discovered.querySelector("button")).toBeNull();
+		expect(discovered.querySelector('[role="status"]')).toBeNull();
+	});
+
+	it("keeps a failed approval action retryable", async () => {
+		const discovered = renderDiscoveredRows([discoveredRow()], async () => ({
+			message: "Approval failed before submission. Try again.",
+			tone: "warning",
+		}));
+		const button = discovered.querySelector("button") as HTMLButtonElement;
+
+		await act(async () => button.click());
+
+		expect(button.textContent).toBe("Retry");
+		expect(button.disabled).toBe(false);
+		expect(discovered.querySelector('[role="alert"]')?.textContent).toContain(
+			"Approval failed before submission",
+		);
 	});
 });

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -9,14 +9,19 @@ import { SyncInlineFeedback } from "./sync-inline-feedback";
 export interface TeamSyncDiscoveredRow {
 	actionMessage: string | null;
 	actionLabel: string | null;
+	approvalState: "needs-local-approval" | "approval-pending" | "not-required";
 	approvalBadgeLabel: string | null;
 	availabilityLabel: string;
+	coordinatorUrl: string;
 	deviceId: string;
 	displayName: string;
 	displayTitle: string | null;
 	fingerprint: string;
+	groupId: string;
+	incomingRequestId: string;
 	mode:
 		| "accept"
+		| "approval-pending"
 		| "ambiguous"
 		| "conflict"
 		| "none"
@@ -212,8 +217,13 @@ function DiscoveredDeviceRow({
 								tone: "success",
 							});
 							try {
-								setFeedback((await onReview(row)) || null);
-								setReviewLabel(row.actionLabel || defaultReviewLabel);
+								const nextFeedback = (await onReview(row)) || null;
+								setFeedback(nextFeedback);
+								setReviewLabel(
+									nextFeedback?.tone === "warning"
+										? "Retry"
+										: row.actionLabel || defaultReviewLabel,
+								);
 							} catch {
 								setFeedback({
 									message: `Pairing ${row.displayName} failed. Try again.`,
@@ -229,6 +239,7 @@ function DiscoveredDeviceRow({
 					</button>
 				) : null}
 				{(row.mode === "stale" ||
+					row.mode === "approval-pending" ||
 					row.mode === "ambiguous" ||
 					row.mode === "scope-pending" ||
 					row.mode === "setup-blocked") &&
@@ -355,7 +366,7 @@ function DiscoveredPortal({
 			<SyncInlineFeedback feedback={state.syncDiscoveredFeedback} />
 			{rows.map((row) => (
 				<DiscoveredDeviceRow
-					key={row.deviceId}
+					key={`${row.deviceId}:${row.incomingRequestId}:${row.fingerprint}`}
 					row={row}
 					onInspectConflict={onInspectConflict}
 					onRemoveConflict={onRemoveConflict}

--- a/packages/ui/src/tabs/sync/index.test.ts
+++ b/packages/ui/src/tabs/sync/index.test.ts
@@ -69,9 +69,271 @@ describe("loadSyncData", () => {
 		state.lastShareOperations = [];
 		state.shareOperationsLoadError = false;
 		state.lastSyncCoordinator = null;
+		state.pendingCoordinatorApprovalsByDeviceId.clear();
 		state.lastSyncViewModel = null;
 		state.lastDeviceIdentityInventory = null;
 		state.deviceIdentityInventoryLoadError = false;
+	});
+
+	it("retains pending approval when the matching device still needs local approval", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		state.pendingCoordinatorApprovalsByDeviceId.set("device-a", {
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-a",
+		});
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({
+			coordinator: {
+				coordinator_url: "https://coord.example.test",
+				groups: ["team-a"],
+				discovered_devices: [
+					{
+						device_id: "device-a",
+						fingerprint: null,
+						groups: ["team-a"],
+						needs_local_approval: true,
+						incoming_reciprocal_request_id: "request-a",
+					},
+				],
+			},
+			peers: [],
+		} as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+
+		await loadSyncData();
+
+		expect(state.pendingCoordinatorApprovalsByDeviceId.get("device-a")).toEqual({
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-a",
+		});
+	});
+
+	it("clears pending approval when the matching device no longer needs local approval", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		state.pendingCoordinatorApprovalsByDeviceId.set("device-a", {
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-a",
+		});
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({
+			coordinator: {
+				coordinator_url: "https://coord.example.test",
+				groups: ["team-a"],
+				discovered_devices: [
+					{
+						device_id: "device-a",
+						fingerprint: "fingerprint-a",
+						groups: ["team-a"],
+						needs_local_approval: false,
+						incoming_reciprocal_request_id: "request-a",
+					},
+				],
+			},
+			peers: [],
+		} as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+
+		await loadSyncData();
+
+		expect(state.pendingCoordinatorApprovalsByDeviceId.has("device-a")).toBe(false);
+	});
+
+	it("retains pending approval when the device is absent from the snapshot", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		state.pendingCoordinatorApprovalsByDeviceId.set("device-a", {
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-a",
+		});
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({
+			coordinator: {
+				coordinator_url: "https://coord.example.test",
+				groups: ["team-a"],
+				discovered_devices: [],
+			},
+			peers: [],
+		} as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+
+		await loadSyncData();
+
+		expect(state.pendingCoordinatorApprovalsByDeviceId.has("device-a")).toBe(true);
+	});
+
+	it("retains pending approval when reciprocal approval data is incomplete", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		state.pendingCoordinatorApprovalsByDeviceId.set("device-a", {
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-a",
+		});
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({
+			coordinator: {
+				coordinator_url: "https://coord.example.test",
+				reciprocal_approval_error: "coordinator request timed out",
+				discovered_devices: [
+					{
+						device_id: "device-a",
+						needs_local_approval: false,
+						incoming_reciprocal_request_id: null,
+					},
+				],
+			},
+			peers: [],
+		} as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+
+		await loadSyncData();
+
+		expect(state.pendingCoordinatorApprovalsByDeviceId.has("device-a")).toBe(true);
+	});
+
+	it("clears pending approval when the device ID has a replacement request", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		state.pendingCoordinatorApprovalsByDeviceId.set("device-a", {
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-reviewed",
+		});
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({
+			coordinator: {
+				coordinator_url: "https://coord.example.test",
+				groups: ["team-a"],
+				discovered_devices: [
+					{
+						device_id: "device-a",
+						fingerprint: "fingerprint-replacement",
+						groups: ["team-a"],
+						needs_local_approval: true,
+						incoming_reciprocal_request_id: "request-replacement",
+					},
+				],
+			},
+			peers: [],
+		} as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+
+		await loadSyncData();
+
+		expect(state.pendingCoordinatorApprovalsByDeviceId.has("device-a")).toBe(false);
+	});
+
+	it("retains pending approval when one duplicate device entry still matches", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		state.pendingCoordinatorApprovalsByDeviceId.set("device-a", {
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-reviewed",
+		});
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({
+			coordinator: {
+				coordinator_url: "https://coord.example.test",
+				groups: ["team-a"],
+				discovered_devices: [
+					{
+						device_id: "device-a",
+						fingerprint: "fingerprint-reviewed",
+						groups: ["team-a"],
+						needs_local_approval: true,
+						incoming_reciprocal_request_id: "request-reviewed",
+					},
+					{
+						device_id: "device-a",
+						fingerprint: "fingerprint-replacement",
+						groups: ["team-a"],
+						needs_local_approval: true,
+						incoming_reciprocal_request_id: "request-replacement",
+					},
+				],
+			},
+			peers: [],
+		} as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+
+		await loadSyncData();
+
+		expect(state.pendingCoordinatorApprovalsByDeviceId.has("device-a")).toBe(true);
+	});
+
+	it.each([
+		["coordinator URL", "https://other-coord.example.test", "request-a"],
+		["reciprocal request", "https://coord.example.test", "request-b"],
+	])("clears pending approval when the %s changes", async (_label, coordinatorUrl, requestId) => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		state.pendingCoordinatorApprovalsByDeviceId.set("device-a", {
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-a",
+		});
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({
+			coordinator: {
+				coordinator_url: coordinatorUrl,
+				groups: ["team-a"],
+				discovered_devices: [
+					{
+						device_id: "device-a",
+						fingerprint: "fingerprint-a",
+						groups: ["team-a"],
+						needs_local_approval: true,
+						incoming_reciprocal_request_id: requestId,
+					},
+				],
+			},
+			peers: [],
+		} as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+
+		await loadSyncData();
+
+		expect(state.pendingCoordinatorApprovalsByDeviceId.has("device-a")).toBe(false);
+	});
+
+	it("rerenders when local pending approval state changes without a payload change", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
+		const { renderTeamSync } = await import("./team-sync");
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({
+			coordinator: {
+				coordinator_url: "https://coord.example.test",
+				groups: ["team-a"],
+				discovered_devices: [
+					{
+						device_id: "device-a",
+						fingerprint: "fingerprint-a",
+						groups: ["team-a"],
+						needs_local_approval: true,
+						incoming_reciprocal_request_id: "request-a",
+					},
+				],
+			},
+			peers: [],
+		} as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+
+		await loadSyncData();
+		state.pendingCoordinatorApprovalsByDeviceId.set("device-a", {
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-a",
+		});
+		await loadSyncData();
+
+		expect(renderTeamSync).toHaveBeenCalledTimes(2);
 	});
 
 	it("ignores stale out-of-order sync payloads from older refreshes", async () => {

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -1,7 +1,12 @@
 /* Sync tab orchestrator — re-exports public API and coordinates sub-modules. */
 
 import * as api from "../../lib/api";
-import { isSyncRedactionEnabled, state } from "../../lib/state";
+import {
+	type CachedSyncCoordinator,
+	type DiscoveredDevice,
+	isSyncRedactionEnabled,
+	state,
+} from "../../lib/state";
 import { renderHealthOverview } from "../health";
 import { ensureSyncRenderBoundary } from "./components/render-root";
 
@@ -45,7 +50,7 @@ let lastSyncHash = "";
 type SyncStatusResponseLike = {
 	status?: Record<string, unknown> | null;
 	peers?: Array<{ peer_device_id?: string }>;
-	coordinator?: Record<string, unknown> | null;
+	coordinator?: CachedSyncCoordinator | null;
 	join_requests?: unknown[];
 	sharing_review?: unknown[];
 	legacy_shared_review?: Record<string, unknown> | null;
@@ -66,6 +71,53 @@ type SyncActorListResponseLike = {
 type SyncPeerSummaryLike = {
 	peer_device_id?: string;
 };
+
+function reconcilePendingCoordinatorApprovals(
+	coordinator: CachedSyncCoordinator | null | undefined,
+): void {
+	if (!coordinator) return;
+	const coordinatorUrl = String(coordinator?.coordinator_url || "").trim();
+	const approvalDataIncomplete = Boolean(
+		coordinator.lookup_error || coordinator.reciprocal_approval_error,
+	);
+	const discoveredDevices = Array.isArray(coordinator?.discovered_devices)
+		? coordinator.discovered_devices
+		: [];
+	const devicesById = new Map<string, DiscoveredDevice[]>();
+	for (const device of discoveredDevices) {
+		const deviceId = String(device.device_id || "").trim();
+		if (!deviceId) continue;
+		devicesById.set(deviceId, [...(devicesById.get(deviceId) || []), device]);
+	}
+
+	for (const [deviceId, pendingApproval] of state.pendingCoordinatorApprovalsByDeviceId) {
+		if (pendingApproval.coordinatorUrl !== coordinatorUrl) {
+			state.pendingCoordinatorApprovalsByDeviceId.delete(deviceId);
+			continue;
+		}
+		if (approvalDataIncomplete) continue;
+		const observedDevices = devicesById.get(deviceId);
+		if (!observedDevices) continue;
+
+		const matchingRequestStillNeedsLocalApproval = observedDevices.some(
+			(device) =>
+				String(device.incoming_reciprocal_request_id || "").trim() ===
+					pendingApproval.incomingRequestId && device.needs_local_approval === true,
+		);
+		if (!matchingRequestStillNeedsLocalApproval) {
+			state.pendingCoordinatorApprovalsByDeviceId.delete(deviceId);
+		}
+	}
+}
+
+function pendingCoordinatorApprovalHashInput(): Array<readonly [string, string, string]> {
+	return [...state.pendingCoordinatorApprovalsByDeviceId]
+		.map(
+			([deviceId, pendingApproval]) =>
+				[deviceId, pendingApproval.coordinatorUrl, pendingApproval.incomingRequestId] as const,
+		)
+		.sort(([leftDeviceId], [rightDeviceId]) => leftDeviceId.localeCompare(rightDeviceId));
+}
 
 let cachedSyncStatus: { key: string; expiresAtMs: number; payload: SyncStatusResponseLike } | null =
 	null;
@@ -179,6 +231,7 @@ export async function loadSyncData() {
 		if (fetchedFreshSyncStatus) {
 			writeCachedSyncStatus(project, normalizeSyncStatusForCache(payload));
 		}
+		reconcilePendingCoordinatorApprovals(payload.coordinator);
 
 		// Skip re-render if data hasn't changed since last poll
 		const hash = JSON.stringify([
@@ -190,6 +243,7 @@ export async function loadSyncData() {
 			shareOperations,
 			shareOperationsLoadError,
 			duplicatePersonDecisions,
+			pendingCoordinatorApprovalHashInput(),
 		]);
 		if (hash === lastSyncHash) return;
 		lastSyncHash = hash;

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.test.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.test.ts
@@ -1,6 +1,29 @@
-import { afterEach, describe, expect, it } from "vitest";
-import type { UiTeamSyncPrimaryStatus } from "../../view-model";
-import { needsCoordinatorGroupReview, renderTeamSyncPrimaryStatus } from "./render-team-sync";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "../../../../lib/api";
+import { state } from "../../../../lib/state";
+import type { TeamSyncDiscoveredRow } from "../../components/team-sync-panel";
+import { deriveTeamSyncPrimaryStatus, type UiTeamSyncPrimaryStatus } from "../../view-model";
+import { teamSyncState } from "../data/state";
+import {
+	needsCoordinatorGroupReview,
+	renderTeamSync,
+	renderTeamSyncPrimaryStatus,
+	submitDiscoveredDeviceReview,
+} from "./render-team-sync";
+
+vi.mock("../../../../lib/api", () => ({
+	acceptDiscoveredPeer: vi.fn(),
+	renamePeer: vi.fn(),
+}));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	state.pendingCoordinatorApprovalsByDeviceId.clear();
+	state.pendingAcceptedSyncPeers = [];
+	state.syncDiscoveredFeedback = null;
+	teamSyncState.loadSyncData = vi.fn(async () => {});
+});
 
 afterEach(() => {
 	document.body.innerHTML = "";
@@ -126,5 +149,188 @@ describe("renderTeamSyncPrimaryStatus", () => {
 		expect(badge.className).toBe(expectedClass);
 		expect(meta.textContent).toBe(status.meta);
 		expect(meta.textContent).not.toContain(status.nextAction ?? "__no_action__");
+	});
+});
+
+function reviewRow(overrides: Partial<TeamSyncDiscoveredRow> = {}): TeamSyncDiscoveredRow {
+	return {
+		actionMessage: null,
+		actionLabel: "Approve on this device",
+		approvalBadgeLabel: "Needs your approval",
+		approvalState: "needs-local-approval",
+		availabilityLabel: "Available",
+		connectionLabel: "Paired on this device",
+		coordinatorUrl: "https://coord.example.test",
+		deviceId: "device-a",
+		displayName: "Desk Mini",
+		displayTitle: "device-a",
+		fingerprint: "fingerprint-a",
+		groupId: "team-a",
+		incomingRequestId: "request-a",
+		mode: "accept",
+		note: "No fresh addresses",
+		pairedMessage: null,
+		...overrides,
+	};
+}
+
+describe("submitDiscoveredDeviceReview", () => {
+	it("records request-bound approval state and feedback before rename finishes", async () => {
+		let finishRename!: () => void;
+		const renamePending = new Promise<void>((resolve) => {
+			finishRename = resolve;
+		});
+		vi.mocked(api.acceptDiscoveredPeer).mockResolvedValue({ name: "Desk Mini" } as never);
+		vi.mocked(api.renamePeer).mockReturnValue(renamePending as never);
+
+		const submission = submitDiscoveredDeviceReview(reviewRow(), "Desk Mini Renamed");
+		await vi.waitFor(() => expect(api.renamePeer).toHaveBeenCalled());
+
+		expect(state.pendingCoordinatorApprovalsByDeviceId.get("device-a")).toEqual({
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-a",
+		});
+		expect(state.syncDiscoveredFeedback).toEqual({
+			message:
+				"Approval sent for this device. This screen may take up to 30 seconds to confirm two-way trust.",
+			tone: "success",
+		});
+
+		finishRename();
+		await submission;
+	});
+
+	it("does not create a marker when approval fails before success", async () => {
+		vi.mocked(api.acceptDiscoveredPeer).mockRejectedValue(new Error("approval rejected"));
+
+		await expect(submitDiscoveredDeviceReview(reviewRow(), "Desk Mini")).rejects.toThrow(
+			"approval rejected",
+		);
+
+		expect(state.pendingCoordinatorApprovalsByDeviceId.has("device-a")).toBe(false);
+	});
+
+	it("approves and records a safe marker when the fingerprint is redacted", async () => {
+		vi.mocked(api.acceptDiscoveredPeer).mockResolvedValue({ name: "Desk Mini" } as never);
+
+		await submitDiscoveredDeviceReview(reviewRow({ fingerprint: "" }), "Desk Mini");
+
+		expect(api.acceptDiscoveredPeer).toHaveBeenCalledWith("device-a", {
+			fingerprint: "",
+			expectedGroupId: "team-a",
+			expectedIncomingRequestId: "request-a",
+		});
+		expect(state.pendingCoordinatorApprovalsByDeviceId.get("device-a")).toEqual({
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-a",
+		});
+	});
+
+	it("does not create an unsafe marker without an incoming request ID", async () => {
+		await expect(
+			submitDiscoveredDeviceReview(reviewRow({ incomingRequestId: "" }), "Desk Mini"),
+		).rejects.toThrow("Device identity is incomplete");
+
+		expect(state.pendingCoordinatorApprovalsByDeviceId.has("device-a")).toBe(false);
+		expect(api.acceptDiscoveredPeer).not.toHaveBeenCalled();
+	});
+
+	it("does not approve without the reviewed coordinator group", async () => {
+		await expect(
+			submitDiscoveredDeviceReview(reviewRow({ groupId: "" }), "Desk Mini"),
+		).rejects.toThrow("Device identity is incomplete");
+
+		expect(api.acceptDiscoveredPeer).not.toHaveBeenCalled();
+	});
+
+	it("preserves the marker and avoids retry-approval guidance after refresh failure", async () => {
+		vi.mocked(api.acceptDiscoveredPeer).mockResolvedValue({ name: "Desk Mini" } as never);
+		teamSyncState.loadSyncData = vi.fn(async () => {
+			throw new Error("refresh failed");
+		});
+
+		const feedback = await submitDiscoveredDeviceReview(reviewRow(), "Desk Mini");
+
+		expect(state.pendingCoordinatorApprovalsByDeviceId.has("device-a")).toBe(true);
+		expect(feedback.message).toContain("Approval was sent");
+		expect(feedback.message).toContain("up to 30 seconds");
+		expect(feedback.message).toContain("do not need to approve again");
+		expect(feedback.message.toLowerCase()).not.toContain("retry approval");
+	});
+});
+
+describe("renderTeamSync pending coordinator approval", () => {
+	it("keeps a stale authoritative approval row visible without counting it as actionable", () => {
+		document.body.innerHTML = `
+			<div id="syncTeamMeta"></div>
+			<div id="syncSetupPanel"></div>
+			<div id="syncTeamActions"></div>
+			<div id="syncCoordinatorDiscovered"></div>
+			<div id="syncCoordinatorDiscoveredMeta"></div>
+			<div id="syncCoordinatorDiscoveredList"></div>
+		`;
+		state.lastSyncStatus = { enabled: true, daemon_state: "ok", daemon_running: true };
+		state.lastSyncPeers = [
+			{
+				peer_device_id: "device-a",
+				fingerprint: "fingerprint-a",
+				status: { peer_state: "online", sync_status: "ok" },
+			},
+		];
+		state.lastSyncCoordinator = {
+			configured: true,
+			coordinator_url: "https://coord.example.test",
+			sync_enabled: true,
+			groups: ["Acme"],
+			presence_status: "posted",
+			discovered_devices: [
+				{
+					device_id: "device-a",
+					display_name: "Desk Mini",
+					fingerprint: null,
+					groups: ["Acme"],
+					needs_local_approval: true,
+					incoming_reciprocal_request_id: "request-a",
+					stale: true,
+				},
+			],
+		};
+		state.lastSyncViewModel = {
+			attentionItems: [
+				{
+					actionLabel: "Open device",
+					deviceId: "device-a",
+					id: "repair:device-a",
+					kind: "device-needs-repair",
+					priority: 10,
+					summary: "Repair this device.",
+					title: "Desk Mini needs attention",
+				},
+			],
+			duplicatePeople: [],
+			primaryStatus: deriveTeamSyncPrimaryStatus({
+				status: state.lastSyncStatus,
+				coordinator: state.lastSyncCoordinator,
+				peers: state.lastSyncPeers,
+			}),
+			summary: { connectedDeviceCount: 0, offlineTeamDeviceCount: 0, seenOnTeamCount: 1 },
+		};
+		state.pendingCoordinatorApprovalsByDeviceId.set("device-a", {
+			coordinatorUrl: "https://coord.example.test",
+			incomingRequestId: "request-a",
+		});
+
+		act(() => renderTeamSync());
+
+		const discovered = document.getElementById("syncCoordinatorDiscoveredList") as HTMLElement;
+		expect(discovered.textContent).toContain("Approval sent");
+		expect(discovered.textContent).toContain("You do not need to approve again");
+		expect(discovered.querySelector("button")).toBeNull();
+		expect(document.getElementById("syncTeamActions")?.textContent).not.toContain(
+			"More team follow-up is listed below",
+		);
+		expect(document.getElementById("syncTeamActions")?.textContent).not.toContain(
+			"Desk Mini needs attention",
+		);
 	});
 });

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -55,6 +55,8 @@ import {
 } from "../helpers/invite-panel-dom";
 
 const TEAM_SYNC_ACTIONS_MOUNT_ID = "syncTeamActionsMount";
+const APPROVAL_SENT_MESSAGE =
+	"Approval sent for this device. This screen may take up to 30 seconds to confirm two-way trust.";
 
 export function needsCoordinatorGroupReview(
 	groupIds: string[],
@@ -299,6 +301,7 @@ export function renderTeamSync() {
 	const discoveredDevices = Array.isArray(coordinator.discovered_devices)
 		? coordinator.discovered_devices
 		: [];
+	const coordinatorUrl = String(coordinator.coordinator_url || "").trim();
 	const discoveredRows: TeamSyncDiscoveredRow[] = discoveredDevices.map((device) => {
 		const deviceId = String(device.device_id || "").trim();
 		const rawCoordinatorName = String(device.display_name || "").trim();
@@ -307,6 +310,7 @@ export function renderTeamSync() {
 			"Discovered device";
 		const displayTitle = deviceId && displayName !== deviceId ? deviceId : null;
 		const fingerprint = String(device.fingerprint || "").trim();
+		const incomingRequestId = String(device.incoming_reciprocal_request_id || "").trim();
 		const groupIds = Array.isArray(device.groups)
 			? device.groups.map((value) => String(value || "").trim()).filter(Boolean)
 			: [];
@@ -326,7 +330,18 @@ export function renderTeamSync() {
 			Boolean(fingerprint) &&
 			Boolean(pairedFingerprint) &&
 			pairedFingerprint !== fingerprint;
+		const pendingApproval = state.pendingCoordinatorApprovalsByDeviceId.get(deviceId);
+		const approvalPending =
+			device.needs_local_approval === true &&
+			pendingApproval?.coordinatorUrl === coordinatorUrl &&
+			pendingApproval?.incomingRequestId === incomingRequestId;
+		const approvalState: TeamSyncDiscoveredRow["approvalState"] = approvalPending
+			? "approval-pending"
+			: device.needs_local_approval === true
+				? "needs-local-approval"
+				: "not-required";
 		const canAccept =
+			!approvalPending &&
 			!setupBlocker &&
 			shouldShowCoordinatorReviewAction({
 				device,
@@ -357,6 +372,9 @@ export function renderTeamSync() {
 
 		if (hasConflict) {
 			mode = "conflict";
+		} else if (approvalPending) {
+			actionMessage = "Waiting for refreshed coordinator status. You do not need to approve again.";
+			mode = "approval-pending";
 		} else if (setupBlocker && (!pairedPeer || approvalSummary.state === "needs-your-approval")) {
 			actionMessage = setupBlocker.message;
 			mode = "setup-blocked";
@@ -402,22 +420,34 @@ export function renderTeamSync() {
 			// their approval-specific label (e.g. "Approve on this device").
 			actionLabel:
 				approvalSummary.actionLabel || (pairedPeer ? "Review device" : "Pair with this device"),
-			approvalBadgeLabel: approvalSummary.badgeLabel,
+			approvalBadgeLabel: approvalPending ? "Approval sent" : approvalSummary.badgeLabel,
+			approvalState,
 			availabilityLabel: device.stale ? "Offline" : "Available",
 			connectionLabel: hasConflict
 				? SYNC_TERMINOLOGY.conflicts
 				: pairedPeer
 					? SYNC_TERMINOLOGY.pairedLocally
 					: "Not connected on this device",
+			coordinatorUrl,
 			deviceId,
 			displayName,
 			displayTitle,
 			fingerprint,
+			groupId: groupIds[0] ?? "",
+			incomingRequestId,
 			mode,
 			note: noteParts.join(" · "),
 			pairedMessage,
 		};
 	});
+	const pendingApprovalDeviceIds = new Set(
+		discoveredRows
+			.filter((row) => row.approvalState === "approval-pending")
+			.map((row) => row.deviceId),
+	);
+	const visibleAttentionItems = attentionItems.filter(
+		(item) => !item.deviceId || !pendingApprovalDeviceIds.has(item.deviceId),
+	);
 
 	const pendingJoinRequests: TeamSyncPendingJoinRequest[] = [];
 	const visibleDiscoveredRows = discoveredRows.filter(
@@ -430,7 +460,7 @@ export function renderTeamSync() {
 		(row) => row.mode === "accept" || row.mode === "scope-pending",
 	).length;
 	const actionableCount =
-		attentionItems.length + pendingJoinRequests.length + discoveredActionableCount;
+		visibleAttentionItems.length + pendingJoinRequests.length + discoveredActionableCount;
 	if (discoveredPanel) {
 		discoveredPanel.hidden = visibleDiscoveredRows.length === 0 && !state.syncDiscoveredFeedback;
 	}
@@ -451,7 +481,7 @@ export function renderTeamSync() {
 	renderIntoSyncMount(
 		actionMount,
 		h(TeamSyncPanel, {
-			actionItems: attentionItems,
+			actionItems: visibleAttentionItems,
 			actionableCount,
 			children: h(SyncInviteJoinPanels, {
 				invitePanel,
@@ -535,67 +565,7 @@ export function renderTeamSync() {
 				try {
 					const reviewedName = await reviewDiscoveredDeviceName(row.displayName);
 					if (!reviewedName) return null;
-					const result = await api.acceptDiscoveredPeer(row.deviceId, row.fingerprint);
-					const optimisticName =
-						String(result?.name || row.displayName || "").trim() || row.displayName;
-					const pendingPeers = Array.isArray(state.pendingAcceptedSyncPeers)
-						? state.pendingAcceptedSyncPeers.filter(
-								(peer) => String(peer?.peer_device_id || "").trim() !== row.deviceId,
-							)
-						: [];
-					state.pendingAcceptedSyncPeers = [
-						...pendingPeers,
-						{
-							peer_device_id: row.deviceId,
-							name: optimisticName,
-							fingerprint: row.fingerprint,
-							addresses: [],
-							claimed_local_actor: false,
-							status: { peer_state: "degraded" },
-							last_error: "Waiting for the other device to approve this one.",
-						},
-					];
-					requestPeerScopeReview(row.deviceId);
-					let feedback: SyncActionFeedback = {
-						message:
-							row.approvalBadgeLabel === "Needs your approval"
-								? `Approved ${row.displayName} on this device. Two-way trust should be ready once both devices refresh.`
-								: `Step 1 complete on this device for ${row.displayName}. Finish onboarding on the other device so both sides trust each other for sync.`,
-						tone: "success",
-					};
-					try {
-						if (reviewedName.trim() !== optimisticName.trim()) {
-							await api.renamePeer(row.deviceId, reviewedName.trim());
-							state.pendingAcceptedSyncPeers = state.pendingAcceptedSyncPeers.map((peer) =>
-								String(peer?.peer_device_id || "").trim() === row.deviceId
-									? { ...peer, name: reviewedName.trim() }
-									: peer,
-							);
-							feedback = {
-								message: `Connected ${reviewedName.trim()} and saved its name.`,
-								tone: "success",
-							};
-						}
-					} catch (error) {
-						feedback = {
-							message: friendlyError(error, "Device connected, but naming did not finish."),
-							tone: "warning",
-						};
-					}
-					state.syncDiscoveredFeedback = feedback;
-					try {
-						await teamSyncState.loadSyncData();
-					} catch (error) {
-						feedback = {
-							message: friendlyError(
-								error,
-								"Device connected, but the screen did not refresh yet. Refresh this page before trying the next step.",
-							),
-							tone: "warning",
-						};
-						state.syncDiscoveredFeedback = feedback;
-					}
-					return feedback;
+					return await submitDiscoveredDeviceReview(row, reviewedName);
 				} catch (error) {
 					return {
 						message: friendlyError(
@@ -611,4 +581,101 @@ export function renderTeamSync() {
 			primaryStatus: syncView.primaryStatus,
 		}),
 	);
+}
+
+export async function submitDiscoveredDeviceReview(
+	row: TeamSyncDiscoveredRow,
+	reviewedName: string,
+): Promise<SyncActionFeedback> {
+	const finalLocalApproval = row.approvalState === "needs-local-approval";
+	const reviewedDeviceId = row.deviceId.trim();
+	const reviewedCoordinatorUrl = row.coordinatorUrl.trim();
+	const reviewedGroupId = row.groupId.trim();
+	const reviewedIncomingRequestId = row.incomingRequestId.trim();
+	if (
+		finalLocalApproval &&
+		(!reviewedDeviceId || !reviewedCoordinatorUrl || !reviewedGroupId || !reviewedIncomingRequestId)
+	) {
+		throw new Error("Device identity is incomplete. Refresh the screen and try approval again.");
+	}
+	const result = await api.acceptDiscoveredPeer(row.deviceId, {
+		fingerprint: row.fingerprint,
+		expectedGroupId: reviewedGroupId || undefined,
+		expectedIncomingRequestId: finalLocalApproval ? reviewedIncomingRequestId : undefined,
+	});
+	const optimisticName = String(result?.name || row.displayName || "").trim() || row.displayName;
+	if (finalLocalApproval) {
+		state.pendingCoordinatorApprovalsByDeviceId.set(reviewedDeviceId, {
+			coordinatorUrl: reviewedCoordinatorUrl,
+			incomingRequestId: reviewedIncomingRequestId,
+		});
+	}
+
+	const pendingPeers = Array.isArray(state.pendingAcceptedSyncPeers)
+		? state.pendingAcceptedSyncPeers.filter(
+				(peer) => String(peer?.peer_device_id || "").trim() !== row.deviceId,
+			)
+		: [];
+	state.pendingAcceptedSyncPeers = [
+		...pendingPeers,
+		{
+			peer_device_id: row.deviceId,
+			name: optimisticName,
+			fingerprint: row.fingerprint,
+			addresses: [],
+			claimed_local_actor: false,
+			status: { peer_state: "degraded" },
+			last_error: "Waiting for the other device to approve this one.",
+		},
+	];
+	requestPeerScopeReview(row.deviceId);
+	let feedback: SyncActionFeedback = finalLocalApproval
+		? { message: APPROVAL_SENT_MESSAGE, tone: "success" }
+		: {
+				message: `Step 1 complete on this device for ${row.displayName}. Finish onboarding on the other device so both sides trust each other for sync.`,
+				tone: "success",
+			};
+	state.syncDiscoveredFeedback = feedback;
+	if (finalLocalApproval) renderTeamSync();
+
+	try {
+		if (reviewedName.trim() !== optimisticName.trim()) {
+			await api.renamePeer(row.deviceId, reviewedName.trim());
+			state.pendingAcceptedSyncPeers = state.pendingAcceptedSyncPeers.map((peer) =>
+				String(peer?.peer_device_id || "").trim() === row.deviceId
+					? { ...peer, name: reviewedName.trim() }
+					: peer,
+			);
+			if (!finalLocalApproval) {
+				feedback = {
+					message: `Connected ${reviewedName.trim()} and saved its name.`,
+					tone: "success",
+				};
+			}
+		}
+	} catch (error) {
+		feedback = {
+			message: finalLocalApproval
+				? "Approval was sent, but naming did not finish. You do not need to approve again."
+				: friendlyError(error, "Device connected, but naming did not finish."),
+			tone: "warning",
+		};
+	}
+	state.syncDiscoveredFeedback = feedback;
+
+	try {
+		await teamSyncState.loadSyncData();
+	} catch (error) {
+		feedback = {
+			message: finalLocalApproval
+				? "Approval was sent. Confirmation may take up to 30 seconds, and you do not need to approve again."
+				: friendlyError(
+						error,
+						"Device connected, but the screen did not refresh yet. Refresh this page before trying the next step.",
+					),
+			tone: "warning",
+		};
+		state.syncDiscoveredFeedback = feedback;
+	}
+	return feedback;
 }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -10521,6 +10521,7 @@ describe("viewer-server", () => {
 					expect(requestBody).toEqual({
 						group_id: "team-a",
 						requested_device_id: "peer-fresh",
+						expected_incoming_request_id: "req-reviewed",
 					});
 					return new Response(
 						JSON.stringify({
@@ -10563,6 +10564,8 @@ describe("viewer-server", () => {
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({
 						peer_device_id: "peer-fresh",
+						expected_group_id: "team-a",
+						expected_incoming_request_id: "req-reviewed",
 					}),
 				});
 				expect(res.status).toBe(200);
@@ -10598,6 +10601,28 @@ describe("viewer-server", () => {
 				else process.env.CODEMEM_CONFIG = prevConfig;
 				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
 				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("rejects an explicitly empty reviewed reciprocal approval request", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						peer_device_id: "peer-fresh",
+						expected_group_id: "team-a",
+						expected_incoming_request_id: " ",
+					}),
+				});
+
+				expect(res.status).toBe(400);
+				expect(await res.json()).toEqual({
+					error: "expected_incoming_request_id must not be empty",
+				});
+			} finally {
+				cleanup();
 			}
 		});
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -43,6 +43,7 @@ import {
 	buildAuthHeaders,
 	buildBaseUrl,
 	buildDirectPeerAuthHeaders,
+	CoordinatorReciprocalApprovalRequestChangedError,
 	canonicalWorkspaceIdentity,
 	cleanupNonces,
 	commitDeviceIdentityBindings,
@@ -3261,6 +3262,9 @@ interface AcceptDiscoveredPeerOptions {
 	// /api/sync/peers/accept-discovered path) the match must belong to
 	// exactly one group and that one is used.
 	expectedGroupId?: string;
+	// When provided, complete only the exact incoming reciprocal approval that
+	// the caller reviewed instead of accepting a replacement request.
+	expectedIncomingRequestId?: string;
 }
 
 type AcceptDiscoveredPeerNotConfiguredReason =
@@ -3461,6 +3465,9 @@ async function acceptDiscoveredPeer(
 	await createCoordinatorReciprocalApproval(store, config, {
 		groupId,
 		requestedDeviceId: input.peerDeviceId,
+		...(input.expectedIncomingRequestId
+			? { expectedIncomingRequestId: input.expectedIncomingRequestId }
+			: {}),
 	});
 
 	// Resolve project-scope seed. On first enrollment (no existing row), apply
@@ -6947,11 +6954,22 @@ export function syncRoutes(
 		}
 		const peerDeviceId = String(body.peer_device_id ?? "").trim();
 		const fingerprint = String(body.fingerprint ?? "").trim();
+		const expectedGroupId = String(body.expected_group_id ?? "").trim();
+		const hasExpectedIncomingRequestId = Object.hasOwn(body, "expected_incoming_request_id");
+		const expectedIncomingRequestId = String(body.expected_incoming_request_id ?? "").trim();
 		if (!peerDeviceId) return c.json({ error: "peer_device_id required" }, 400);
+		if (hasExpectedIncomingRequestId && !expectedIncomingRequestId) {
+			return c.json({ error: "expected_incoming_request_id must not be empty" }, 400);
+		}
+		if (expectedIncomingRequestId && !expectedGroupId) {
+			return c.json({ error: "expected_group_id required" }, 400);
+		}
 		try {
 			const result = await acceptDiscoveredPeer(store, {
 				peerDeviceId,
 				fingerprint: fingerprint || undefined,
+				expectedGroupId: expectedGroupId || undefined,
+				expectedIncomingRequestId: expectedIncomingRequestId || undefined,
 			});
 			if (!result.ok) {
 				return c.json(
@@ -6972,6 +6990,16 @@ export function syncRoutes(
 				needs_scope_review: true,
 			});
 		} catch (error) {
+			if (error instanceof CoordinatorReciprocalApprovalRequestChangedError) {
+				return c.json(
+					{
+						error: error.code,
+						detail:
+							"This approval request changed before it was submitted. Refresh sync status and review the current request.",
+					},
+					{ status: 409 },
+				);
+			}
 			return c.json(
 				{
 					error: "coordinator_lookup_failed",


### PR DESCRIPTION
## Description

Caches remote coordinator status for 30 seconds to reduce D1 reads. Adds fingerprint-safe optimistic approval state so successful approvals remain visible as `Approval sent`, cannot be submitted twice while propagation is pending, and reconcile against authoritative coordinator snapshots.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced