### PR TITLE
feat(core): prepare legacy Team setup drafts

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -753,6 +753,8 @@ export {
 	canonicalRecipientPolicyJson,
 	deterministicPolicyTeamId,
 	legacyTeamCandidateId,
+	legacyTeamCanonicalProjectRef,
+	legacyTeamDeviceRef,
 	legacyTeamRosterFingerprint,
 	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -5,6 +5,7 @@ import {
 	getLegacyTeamSetupDraft,
 	legacyTeamResolvedProjectRef,
 	refreshLegacyTeamSetupDraft,
+	refreshLegacyTeamSetupDraftLabels,
 	setLegacyTeamSetupDeviceAssignment,
 	setLegacyTeamSetupDeviceDecision,
 	setLegacyTeamSetupProjectMapping,
@@ -200,7 +201,7 @@ describe("legacy Team setup drafts", () => {
 			const prepared = prepare.mock.calls.map(([sql]) => String(sql));
 			expect(
 				prepared.filter((sql) => /FROM identity_devices\s+WHERE device_id = \?/u.test(sql)),
-			).toHaveLength(2);
+			).toHaveLength(3);
 			expect(
 				prepared.filter((sql) =>
 					/SELECT actor_id FROM actors\s+WHERE actor_id IN \([^)]*\)\s+AND status = 'active'/u.test(
@@ -943,6 +944,327 @@ describe("legacy Team setup drafts", () => {
 			],
 		});
 		expect(withFingerprint.devices[0]?.displayName).toBe("Device");
+	});
+
+	it("sanitizes every label against all roster identifiers", () => {
+		const input = snapshot();
+		const firstDevice = input.devices[0];
+		const project = input.projects[0];
+		if (!firstDevice || !project) throw new Error("invalid test fixture");
+		const secondDevice = {
+			deviceId: "device-private-b",
+			fingerprint: "fingerprint-private-b",
+			displayName: `Laptop ${firstDevice.deviceId}`,
+			enabled: true,
+		};
+		input.devices.push(secondDevice);
+		input.displayName = `Team ${secondDevice.deviceId}`;
+		firstDevice.displayName = `Laptop ${secondDevice.fingerprint}`;
+		project.displayName = `Project ${secondDevice.deviceId}`;
+
+		const draft = refreshLegacyTeamSetupDraft(db, input);
+
+		expect(draft.displayName).toBe("Legacy Team");
+		expect(draft.devices.map((device) => device.displayName)).toEqual(["Device", "Device"]);
+		expect(draft.projects[0]?.displayName).toBe("Project");
+	});
+
+	it("sanitizes labels against carried device IDs and fingerprints", () => {
+		const withRemovedDevice = {
+			...snapshot(),
+			devices: [
+				...snapshot().devices,
+				{
+					deviceId: "device-gone",
+					fingerprint: "key-gone",
+					displayName: "Old Laptop",
+					enabled: true,
+				},
+			],
+		};
+		refreshLegacyTeamSetupDraft(db, withRemovedDevice);
+		const replacementInput = snapshot();
+		const currentDevice = replacementInput.devices[0];
+		if (!currentDevice) throw new Error("invalid test fixture");
+		replacementInput.displayName = "Team device-gone";
+		currentDevice.displayName = "Laptop key-gone";
+
+		const replacement = refreshLegacyTeamSetupDraft(db, replacementInput);
+
+		expect(replacement.displayName).toBe("Legacy Team");
+		expect(replacement.devices.find((device) => device.enabled)?.displayName).toBe("Device");
+		expect(replacement.devices.find((device) => !device.enabled)?.displayName).toBe(
+			"Removed device",
+		);
+		const carriedDevice = replacement.devices.find((device) => !device.enabled);
+		if (!carriedDevice) throw new Error("invalid test fixture");
+		setLegacyTeamSetupDeviceDecision(db, {
+			attemptId: replacement.attemptId,
+			deviceRef: carriedDevice.deviceRef,
+			decision: "removed",
+			now: NOW,
+		});
+
+		const retryInput = snapshot();
+		const retryDevice = retryInput.devices[0];
+		if (!retryDevice) throw new Error("invalid test fixture");
+		retryInput.displayName = "Team key-gone";
+		retryDevice.displayName = "Laptop device-gone";
+
+		const retry = refreshLegacyTeamSetupDraft(db, retryInput);
+
+		expect(retry.attemptId).toBe(replacement.attemptId);
+		expect(retry.displayName).toBe("Legacy Team");
+		expect(retry.devices.find((device) => device.enabled)?.displayName).toBe("Device");
+	});
+
+	it("matches forbidden identifiers by their NFKC-equivalent form", () => {
+		const input = snapshot();
+		const device = input.devices[0];
+		if (!device) throw new Error("invalid test fixture");
+		device.deviceId = "device-\uff41";
+		input.displayName = "Team device-a";
+
+		const draft = refreshLegacyTeamSetupDraft(db, input);
+
+		expect(draft.displayName).toBe("Legacy Team");
+	});
+
+	it("matches forbidden identifiers after format and whitespace normalization", () => {
+		const input = snapshot();
+		const device = input.devices[0];
+		if (!device) throw new Error("invalid test fixture");
+		device.fingerprint = "key\u200b-\t  private";
+		device.displayName = "Laptop KEY-\nPRIVATE";
+
+		const draft = refreshLegacyTeamSetupDraft(db, input);
+
+		expect(draft.devices[0]?.displayName).toBe("Device");
+	});
+
+	it.each([
+		["coordinator identity", "opaque-person-alpha"],
+		["coordinator public key", "public-key-private"],
+	] as const)("redacts labels containing a %s", (_label, forbiddenId) => {
+		const input = snapshot();
+		const device = input.devices[0];
+		const project = input.projects[0];
+		if (!device || !project) throw new Error("invalid test fixture");
+		Object.assign(device, {
+			labelRedactionIds: ["opaque-person-alpha", "public-key-private"],
+		});
+		input.displayName = `Team ${forbiddenId}`;
+		device.displayName = `Laptop ${forbiddenId}`;
+		project.displayName = `Project ${forbiddenId}`;
+
+		const draft = refreshLegacyTeamSetupDraft(db, input);
+
+		expect(draft).toMatchObject({
+			displayName: "Legacy Team",
+			devices: [{ displayName: "Device" }],
+			projects: [{ displayName: "Project" }, {}],
+		});
+	});
+
+	it("redacts persisted explicit Project identities on replacement and label refresh", () => {
+		let draft = refreshLegacyTeamSetupDraft(db, snapshot());
+		draft = setLegacyTeamSetupProjectMapping(db, {
+			attemptId: draft.attemptId,
+			projectRef: "project-ref-b",
+			resolvedProjectIdentity: "workspace-private",
+			now: NOW,
+		});
+		const replacementInput = snapshot({ fingerprint: "key-replaced" });
+		replacementInput.displayName = "Team workspace-private";
+
+		const replacement = refreshLegacyTeamSetupDraft(db, replacementInput);
+
+		expect(replacement.attemptId).not.toBe(draft.attemptId);
+		expect(replacement.displayName).toBe("Legacy Team");
+		expect(
+			replacement.projects.find((project) => project.projectRef === "project-ref-b")?.resolution,
+		).toBe("explicit");
+
+		const project = replacementInput.projects.find(
+			(candidate) => candidate.projectRef === "project-ref-b",
+		);
+		if (!project) throw new Error("invalid test fixture");
+		project.displayName = "Project workspace-private";
+		const refreshed = refreshLegacyTeamSetupDraftLabels(
+			db,
+			replacement.attemptId,
+			replacementInput,
+		);
+
+		expect(refreshed.displayName).toBe("Legacy Team");
+		expect(
+			refreshed.projects.find((candidate) => candidate.projectRef === "project-ref-b")?.displayName,
+		).toBe("Project");
+	});
+
+	it("redacts existing and selected assignment identities from labels", () => {
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-existing-private', 'Existing Person', 0, 'active', ?, ?),
+			        ('identity-live-private', 'Live Person', 0, 'active', ?, ?)`,
+		).run(NOW, NOW, NOW, NOW);
+		db.prepare(
+			`INSERT INTO identity_devices(
+				device_id, identity_id, display_name, status, provenance, revision,
+				migration_state, assignment_version, idempotency_key, created_at, updated_at
+			 ) VALUES ('device-a', 'identity-existing-private', 'Laptop', 'active', 'test', 'r1',
+				'complete', 1, 'device-a', ?, ?)`,
+		).run(NOW, NOW);
+		const input = snapshot();
+		const inputDevice = input.devices[0];
+		const inputProject = input.projects[0];
+		if (!inputDevice || !inputProject) throw new Error("invalid test fixture");
+		input.displayName = "Team identity-existing-private";
+		inputDevice.displayName = "Laptop identity-existing-private";
+		inputProject.displayName = "Project identity-existing-private";
+
+		let draft = refreshLegacyTeamSetupDraft(db, input);
+
+		expect(draft).toMatchObject({
+			displayName: "Legacy Team",
+			devices: [{ displayName: "Device" }],
+			projects: [{ displayName: "Project" }, {}],
+		});
+		const device = draft.devices[0];
+		if (!device) throw new Error("invalid test fixture");
+		draft = setLegacyTeamSetupDeviceAssignment(db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			targetIdentityId: "identity-a",
+			expectation: device.expectation,
+			now: NOW,
+		});
+		const refreshInput = snapshot();
+		const refreshDevice = refreshInput.devices[0];
+		const refreshProject = refreshInput.projects[0];
+		if (!refreshDevice || !refreshProject) throw new Error("invalid test fixture");
+		db.prepare(
+			"UPDATE identity_devices SET identity_id = 'identity-live-private' WHERE device_id = 'device-a'",
+		).run();
+		refreshInput.displayName = "Team identity-live-private";
+		refreshDevice.displayName = "Laptop identity-live-private";
+		refreshProject.displayName = "Project identity-live-private";
+
+		const refreshed = refreshLegacyTeamSetupDraftLabels(db, draft.attemptId, refreshInput);
+
+		expect(refreshed).toMatchObject({
+			displayName: "Legacy Team",
+			devices: [{ displayName: "Device" }],
+			projects: [{ displayName: "Project" }, {}],
+		});
+	});
+
+	it("redacts a carried removed device's live reassigned identity on replacement", () => {
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-existing-private', 'Existing Person', 0, 'active', ?, ?),
+			        ('identity-reassigned-private', 'Reassigned Person', 0, 'active', ?, ?)`,
+		).run(NOW, NOW, NOW, NOW);
+		db.prepare(
+			`INSERT INTO identity_devices(
+				device_id, identity_id, display_name, status, provenance, revision,
+				migration_state, assignment_version, idempotency_key, created_at, updated_at
+			 ) VALUES ('device-gone', 'identity-existing-private', 'Old Laptop', 'active', 'test',
+				'r1', 'complete', 1, 'device-gone', ?, ?)`,
+		).run(NOW, NOW);
+		refreshLegacyTeamSetupDraft(db, {
+			...snapshot(),
+			devices: [
+				...snapshot().devices,
+				{
+					deviceId: "device-gone",
+					fingerprint: "key-gone",
+					displayName: "Old Laptop",
+					enabled: true,
+				},
+			],
+		});
+		db.prepare(
+			`UPDATE identity_devices
+			 SET identity_id = 'identity-reassigned-private', assignment_version = 2
+			 WHERE device_id = 'device-gone'`,
+		).run();
+		const replacementInput = snapshot();
+		replacementInput.displayName = "Team identity-reassigned-private";
+
+		const replacement = refreshLegacyTeamSetupDraft(db, replacementInput);
+
+		expect(replacement.displayName).toBe("Legacy Team");
+		expect(replacement.devices.find((device) => !device.enabled)).toMatchObject({
+			displayName: "Removed device",
+			expectation: {
+				kind: "existing",
+				identityId: "identity-reassigned-private",
+				assignmentVersion: 2,
+			},
+		});
+	});
+
+	it("does not redact an explicit Project identity that is not carried into the replacement", () => {
+		let draft = refreshLegacyTeamSetupDraft(db, snapshot());
+		draft = setLegacyTeamSetupProjectMapping(db, {
+			attemptId: draft.attemptId,
+			projectRef: "project-ref-b",
+			resolvedProjectIdentity: "workspace-private",
+			now: NOW,
+		});
+		const replacementInput = snapshot();
+		const project = replacementInput.projects.find(
+			(candidate) => candidate.projectRef === "project-ref-b",
+		);
+		if (!project) throw new Error("invalid test fixture");
+		project.sourceFingerprint = "source-b-replaced";
+		replacementInput.displayName = "Team workspace-private";
+
+		const replacement = refreshLegacyTeamSetupDraft(db, replacementInput);
+
+		expect(replacement.displayName).toBe("Team workspace-private");
+		expect(
+			replacement.projects.find((candidate) => candidate.projectRef === "project-ref-b")
+				?.resolution,
+		).toBe("unresolved");
+	});
+
+	it("replaces a draft when a previously mapped Project leaves the inventory", () => {
+		let draft = refreshLegacyTeamSetupDraft(db, snapshot());
+		draft = setLegacyTeamSetupProjectMapping(db, {
+			attemptId: draft.attemptId,
+			projectRef: "project-ref-b",
+			resolvedProjectIdentity: "workspace-private",
+			now: NOW,
+		});
+		const replacementInput = snapshot();
+		replacementInput.projects = replacementInput.projects.filter(
+			(project) => project.projectRef !== "project-ref-b",
+		);
+		replacementInput.displayName = "Team workspace-private";
+
+		const replacement = refreshLegacyTeamSetupDraft(db, replacementInput);
+
+		expect(replacement.attemptId).not.toBe(draft.attemptId);
+		expect(replacement.displayName).toBe("Team workspace-private");
+		expect(replacement.projects.some((project) => project.projectRef === "project-ref-b")).toBe(
+			false,
+		);
+	});
+
+	it("checks identifiers after the display truncation boundary while preserving the limit", () => {
+		const input = snapshot();
+		input.displayName = `${"A".repeat(120)} device-a`;
+
+		const draft = refreshLegacyTeamSetupDraft(db, input);
+		const safeLongLabel = refreshLegacyTeamSetupDraft(db, {
+			...snapshot(),
+			displayName: "B".repeat(130),
+		});
+
+		expect(draft.displayName).toBe("Legacy Team");
+		expect(safeLongLabel.displayName).toBe("B".repeat(120));
 	});
 
 	it("falls back to generic labels for scheme-less hostnames", () => {

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -22,6 +22,8 @@ import {
 	compareCodepoints,
 	deterministicPolicyTeamId,
 	isStrictRecipientPolicyProjectIdentity,
+	legacyTeamCanonicalProjectRef,
+	legacyTeamDeviceRef,
 	legacyTeamRosterFingerprint,
 	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
@@ -39,6 +41,7 @@ export interface LegacyTeamSetupRosterDeviceInput {
 	fingerprint: string;
 	displayName: string;
 	enabled: boolean;
+	labelRedactionIds?: readonly string[];
 }
 
 export interface LegacyTeamSetupProjectInput {
@@ -75,6 +78,7 @@ export interface LegacyTeamSetupDraftProjectView {
 	projectRef: string;
 	displayName: string;
 	resolution: LegacyTeamProjectResolution;
+	canonicalProjectRef: string | null;
 	/**
 	 * Opaque reference to the persisted migration target. Resumed clients can
 	 * confirm and distinguish saved mappings by recomputing the digest for a
@@ -232,6 +236,24 @@ function projectCanonicalStateValid(
  */
 const SAFE_LABEL_PATTERN = /^[\p{L}\p{N} '&,.()_-]*$/u;
 
+function normalizeLabelText(value: string): string {
+	return (
+		value
+			.normalize("NFKC")
+			// Format characters (zero-width joiners, bidi controls) are removed
+			// entirely so they cannot split an address or identifier into innocent
+			// halves; control characters become word separators.
+			.replace(/\p{Cf}/gu, "")
+			.replace(/\p{Cc}/gu, " ")
+			.replace(/\s+/gu, " ")
+			.trim()
+	);
+}
+
+function labelComparisonForm(value: string): string {
+	return normalizeLabelText(value).toLowerCase();
+}
+
 /**
  * Coordinator-supplied display labels are sanitized with an allowlist, not a
  * denylist: multiple review rounds each found one more denylisted shape (bare
@@ -252,37 +274,83 @@ const SAFE_LABEL_PATTERN = /^[\p{L}\p{N} '&,.()_-]*$/u;
  * - Reject labels embedding opaque lookup identifiers (coordinator, group,
  *   device, project references).
  */
-function safeLabel(value: string, fallback: string, forbiddenIds: string[] = []): string {
-	const sanitized = value
-		.slice(0, 512)
-		.normalize("NFKC")
-		// Format characters (zero-width joiners, bidi controls) are removed
-		// entirely so they cannot split an address or identifier into innocent
-		// halves; control characters become word separators.
-		.replace(/\p{Cf}/gu, "")
-		.replace(/\p{Cc}/gu, " ")
-		.replace(/\s+/gu, " ")
-		.trim()
-		.slice(0, 120)
-		.trim();
+function safeLabel(value: string, fallback: string, forbiddenIds: ReadonlySet<string>): string {
+	const boundedValue = value.slice(0, 512);
+	const normalized = normalizeLabelText(boundedValue);
+	const sanitized = normalized.slice(0, 120).trim();
 	if (!sanitized) return fallback;
 	if (!SAFE_LABEL_PATTERN.test(sanitized)) return fallback;
 	if (/[\p{L}\p{N}]\.[\p{L}\p{N}]/u.test(sanitized)) return fallback;
 	// Key-material markers are pure letters/hyphens, so the grammar alone
 	// would keep surrounding text; fail closed on the markers themselves.
 	if (/-----|\b(?:ssh|ecdsa|sk)-[\p{L}\p{N}-]+ /iu.test(sanitized)) return fallback;
-	// Case-insensitively: identifiers such as key fingerprints are the same
-	// identifier in any casing, and the coordinator controls the casing of
-	// both the label and the identifier it embeds.
-	const comparable = sanitized.toLowerCase();
-	if (forbiddenIds.some((id) => id && comparable.includes(id.toLowerCase()))) return fallback;
+	// Compare the complete bounded input before display truncation so an
+	// identifier cannot be hidden just past the visible label boundary.
+	const comparable = normalized.toLowerCase();
+	for (const forbiddenId of forbiddenIds) {
+		if (comparable.includes(forbiddenId)) return fallback;
+	}
 	return sanitized;
+}
+
+function setupLabelForbiddenIds(
+	contextIds: ReadonlyArray<string>,
+	devices: ReadonlyArray<LegacyTeamSetupRosterDeviceInput>,
+	projects: ReadonlyArray<LegacyTeamSetupProjectInput>,
+	persistedDevices: ReadonlyArray<{
+		deviceId: string;
+		fingerprint: string;
+		existingIdentityId: string | null;
+		targetIdentityId: string | null;
+	}>,
+	persistedProjects: ReadonlyArray<{
+		projectRef: string;
+		sourceProjectIdentity: string;
+		sourceFingerprint: string;
+		resolvedProjectIdentity: string | null;
+	}>,
+): ReadonlySet<string> {
+	return new Set(
+		[
+			...contextIds,
+			...devices.flatMap((device) => [
+				device.deviceId,
+				device.fingerprint,
+				...(device.labelRedactionIds ?? []),
+			]),
+			...persistedDevices.flatMap((device) => [
+				device.deviceId,
+				device.fingerprint,
+				device.existingIdentityId ?? "",
+				device.targetIdentityId ?? "",
+			]),
+			...projects.flatMap((project) => [
+				project.projectRef,
+				project.sourceProjectIdentity,
+				project.sourceFingerprint,
+				project.deterministicProjectIdentity ?? "",
+			]),
+			...persistedProjects.flatMap((project) => [
+				project.projectRef,
+				project.sourceProjectIdentity,
+				project.sourceFingerprint,
+				project.resolvedProjectIdentity ?? "",
+			]),
+		]
+			.map(labelComparisonForm)
+			.filter(Boolean),
+	);
 }
 
 interface DeviceAssignmentSnapshot {
 	identityId: string;
 	assignmentVersion: number;
 	active: boolean;
+}
+
+interface DeviceAssignmentInputSnapshot {
+	device: LegacyTeamSetupRosterDeviceInput;
+	assignment: DeviceAssignmentSnapshot | null;
 }
 
 /**
@@ -371,10 +439,6 @@ function storedAssignmentRowMatchesLive(
 	);
 }
 
-function deviceReference(candidateId: string, deviceId: string): string {
-	return recipientPolicyDigest("legacy-team-device-ref-v1", [candidateId, deviceId]);
-}
-
 /**
  * Fingerprint of the completion-bound Project inventory. Discovery compares
  * this against the persisted `projection_fingerprint`, so there must be exactly
@@ -419,30 +483,10 @@ function createAttempt(
 	rosterFingerprint: string,
 	projectFingerprint: string,
 	previousAttemptId: string | null,
+	assignmentSnapshots: ReadonlyArray<DeviceAssignmentInputSnapshot>,
 	now: string,
 ): string {
 	const attemptId = `legacy-team-attempt:${randomUUID()}`;
-	db.prepare(
-		`INSERT INTO legacy_team_setup_drafts(
-			attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
-			roster_fingerprint, projection_fingerprint, created_at, updated_at
-		 ) VALUES (?, ?, ?, ?, 'needs_setup', ?, ?, ?, ?, ?)`,
-	).run(
-		attemptId,
-		input.candidateId,
-		input.coordinatorId,
-		input.groupId,
-		safeLabel(input.displayName, "Legacy Team", [
-			input.candidateId,
-			input.coordinatorId,
-			input.groupId,
-		]),
-		rosterFingerprint,
-		projectFingerprint,
-		now,
-		now,
-	);
-
 	const previousDevices = previousAttemptId
 		? (db
 				.prepare(
@@ -454,8 +498,79 @@ function createAttempt(
 				)
 				.all(previousAttemptId) as DeviceRow[])
 		: [];
+	const previousProjects = previousAttemptId
+		? (db
+				.prepare(
+					`SELECT project_ref, source_project_identity, display_name, source_fingerprint,
+					        resolution_kind, resolved_project_identity
+					 FROM legacy_team_setup_draft_projects WHERE attempt_id = ?`,
+				)
+				.all(previousAttemptId) as ProjectRow[])
+		: [];
+	const currentProjectByRef = new Map(
+		input.projects.map((project) => [project.projectRef, project]),
+	);
+	const carriedProjects = previousProjects.filter((project) => {
+		const current = currentProjectByRef.get(project.project_ref);
+		return (
+			current != null &&
+			current.deterministicProjectIdentity == null &&
+			current.sourceFingerprint === project.source_fingerprint &&
+			project.resolution_kind === "explicit"
+		);
+	});
 	const previousByDevice = new Map(previousDevices.map((device) => [device.device_id, device]));
 	const currentDeviceIds = new Set(input.devices.map((device) => device.deviceId));
+	const loadAssignment = assignmentLookup(db);
+	const assignmentByDevice = new Map(
+		assignmentSnapshots.map(({ device, assignment }) => [device.deviceId, assignment]),
+	);
+	for (const previousDevice of previousDevices) {
+		if (!assignmentByDevice.has(previousDevice.device_id)) {
+			assignmentByDevice.set(previousDevice.device_id, loadAssignment(previousDevice.device_id));
+		}
+	}
+	const forbiddenIds = setupLabelForbiddenIds(
+		[
+			input.candidateId,
+			input.coordinatorId,
+			input.groupId,
+			...Array.from(assignmentByDevice.values()).flatMap((assignment) =>
+				assignment ? [assignment.identityId] : [],
+			),
+		],
+		input.devices,
+		input.projects,
+		previousDevices.map((device) => ({
+			deviceId: device.device_id,
+			fingerprint: device.key_fingerprint,
+			existingIdentityId: device.existing_identity_id,
+			targetIdentityId: device.target_identity_id,
+		})),
+		carriedProjects.map((project) => ({
+			projectRef: project.project_ref,
+			sourceProjectIdentity: project.source_project_identity,
+			sourceFingerprint: project.source_fingerprint,
+			resolvedProjectIdentity: project.resolved_project_identity,
+		})),
+	);
+	db.prepare(
+		`INSERT INTO legacy_team_setup_drafts(
+			attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
+			roster_fingerprint, projection_fingerprint, created_at, updated_at
+		 ) VALUES (?, ?, ?, ?, 'needs_setup', ?, ?, ?, ?, ?)`,
+	).run(
+		attemptId,
+		input.candidateId,
+		input.coordinatorId,
+		input.groupId,
+		safeLabel(input.displayName, "Legacy Team", forbiddenIds),
+		rosterFingerprint,
+		projectFingerprint,
+		now,
+		now,
+	);
+
 	const devices = [
 		...input.devices,
 		...previousDevices
@@ -475,9 +590,8 @@ function createAttempt(
 			expected_assignment_kind, expected_assignment_version, updated_at
 		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	);
-	const loadAssignment = assignmentLookup(db);
 	for (const device of devices) {
-		const assignment = loadAssignment(device.deviceId);
+		const assignment = assignmentByDevice.get(device.deviceId) ?? null;
 		const previous = previousByDevice.get(device.deviceId);
 		const assignmentEvidenceUnchanged =
 			previous != null &&
@@ -501,14 +615,9 @@ function createAttempt(
 		insertDevice.run(
 			attemptId,
 			device.deviceId,
-			deviceReference(input.candidateId, device.deviceId),
+			legacyTeamDeviceRef(input.candidateId, device.deviceId),
 			device.fingerprint,
-			safeLabel(device.displayName, "Device", [
-				device.deviceId,
-				device.fingerprint,
-				input.coordinatorId,
-				input.groupId,
-			]),
+			safeLabel(device.displayName, "Device", forbiddenIds),
 			device.enabled ? 1 : 0,
 			assignment?.identityId ?? null,
 			assignment?.assignmentVersion ?? null,
@@ -521,16 +630,6 @@ function createAttempt(
 		);
 	}
 
-	const previousProjects = previousAttemptId
-		? (db
-				.prepare(
-					`SELECT project_ref, source_project_identity, display_name, source_fingerprint,
-					        resolution_kind,
-					        resolved_project_identity
-					 FROM legacy_team_setup_draft_projects WHERE attempt_id = ?`,
-				)
-				.all(previousAttemptId) as ProjectRow[])
-		: [];
 	const previousByProject = new Map(
 		previousProjects.map((project) => [project.project_ref, project]),
 	);
@@ -552,13 +651,7 @@ function createAttempt(
 			attemptId,
 			project.projectRef,
 			project.sourceProjectIdentity,
-			safeLabel(project.displayName, "Project", [
-				project.projectRef,
-				project.sourceProjectIdentity,
-				input.candidateId,
-				input.coordinatorId,
-				input.groupId,
-			]),
+			safeLabel(project.displayName, "Project", forbiddenIds),
 			project.sourceFingerprint,
 			resolution,
 			project.deterministicProjectIdentity ??
@@ -712,6 +805,9 @@ function loadDraftView(db: Database, attemptId: string): LegacyTeamSetupDraftVie
 			projectRef: row.project_ref,
 			displayName: row.display_name,
 			resolution: row.resolution_kind,
+			canonicalProjectRef: row.resolved_project_identity
+				? legacyTeamCanonicalProjectRef(draft.candidate_id, row.resolved_project_identity)
+				: null,
 			resolvedProjectRef: row.resolved_project_identity
 				? legacyTeamResolvedProjectRef(row.project_ref, row.resolved_project_identity)
 				: null,
@@ -818,55 +914,7 @@ export function refreshLegacyTeamSetupDraft(
 			existing.projection_fingerprint === projectFingerprint &&
 			storedAssignmentEvidenceMatches(db, existing.attempt_id, assignmentSnapshots)
 		) {
-			db.prepare(
-				`UPDATE legacy_team_setup_drafts SET display_name = ?, updated_at = ? WHERE attempt_id = ?`,
-			).run(
-				safeLabel(input.displayName, "Legacy Team", [
-					input.candidateId,
-					input.coordinatorId,
-					input.groupId,
-				]),
-				now,
-				existing.attempt_id,
-			);
-			const updateDeviceLabel = db.prepare(
-				`UPDATE legacy_team_setup_draft_devices
-				 SET display_name = ?, updated_at = ?
-				 WHERE attempt_id = ? AND device_id = ?`,
-			);
-			for (const device of input.devices) {
-				updateDeviceLabel.run(
-					safeLabel(device.displayName, "Device", [
-						device.deviceId,
-						device.fingerprint,
-						input.coordinatorId,
-						input.groupId,
-					]),
-					now,
-					existing.attempt_id,
-					device.deviceId,
-				);
-			}
-			const updateProjectLabel = db.prepare(
-				`UPDATE legacy_team_setup_draft_projects
-				 SET display_name = ?, updated_at = ?
-				 WHERE attempt_id = ? AND project_ref = ?`,
-			);
-			for (const project of input.projects) {
-				updateProjectLabel.run(
-					safeLabel(project.displayName, "Project", [
-						project.projectRef,
-						project.sourceProjectIdentity,
-						input.candidateId,
-						input.coordinatorId,
-						input.groupId,
-					]),
-					now,
-					existing.attempt_id,
-					project.projectRef,
-				);
-			}
-			return loadDraftView(db, existing.attempt_id);
+			return refreshLegacyTeamSetupDraftLabels(db, existing.attempt_id, input);
 		}
 		if (existing && (existing.state === "needs_setup" || existing.state === "in_progress")) {
 			db.prepare(
@@ -888,6 +936,7 @@ export function refreshLegacyTeamSetupDraft(
 			rosterFingerprint,
 			projectFingerprint,
 			existing?.attempt_id ?? null,
+			assignmentSnapshots,
 			now,
 		);
 		return persistFinishDigest(db, attemptId);
@@ -919,42 +968,96 @@ export function refreshLegacyTeamSetupDraftLabels(
 			| undefined;
 		if (!context) throw new Error("legacy_team_setup_draft_not_found");
 		const contextIds = [context.candidate_id, context.coordinator_id, context.group_id];
+		const persistedDevices = db
+			.prepare(
+				`SELECT device_id, key_fingerprint, display_name, existing_identity_id,
+				        target_identity_id
+				 FROM legacy_team_setup_draft_devices WHERE attempt_id = ?`,
+			)
+			.all(attemptId) as Array<{
+			device_id: string;
+			key_fingerprint: string;
+			display_name: string;
+			existing_identity_id: string | null;
+			target_identity_id: string | null;
+		}>;
+		const loadAssignment = assignmentLookup(db);
+		const liveAssignmentIds = [
+			...new Set([
+				...input.devices.map((device) => device.deviceId),
+				...persistedDevices.map((device) => device.device_id),
+			]),
+		].flatMap((deviceId) => {
+			const assignment = loadAssignment(deviceId);
+			return assignment ? [assignment.identityId] : [];
+		});
+		const persistedProjects = db
+			.prepare(
+				`SELECT project_ref, source_project_identity, display_name, source_fingerprint,
+				        resolved_project_identity
+				 FROM legacy_team_setup_draft_projects WHERE attempt_id = ?`,
+			)
+			.all(attemptId) as Array<{
+			project_ref: string;
+			source_project_identity: string;
+			display_name: string;
+			source_fingerprint: string;
+			resolved_project_identity: string | null;
+		}>;
+		const forbiddenIds = setupLabelForbiddenIds(
+			[...contextIds, ...liveAssignmentIds],
+			input.devices,
+			input.projects,
+			persistedDevices.map((device) => ({
+				deviceId: device.device_id,
+				fingerprint: device.key_fingerprint,
+				existingIdentityId: device.existing_identity_id,
+				targetIdentityId: device.target_identity_id,
+			})),
+			persistedProjects.map((project) => ({
+				projectRef: project.project_ref,
+				sourceProjectIdentity: project.source_project_identity,
+				sourceFingerprint: project.source_fingerprint,
+				resolvedProjectIdentity: project.resolved_project_identity,
+			})),
+		);
 		const result = db
 			.prepare(
 				"UPDATE legacy_team_setup_drafts SET display_name = ?, updated_at = ? WHERE attempt_id = ?",
 			)
-			.run(safeLabel(input.displayName, "Legacy Team", contextIds), now, attemptId);
+			.run(safeLabel(input.displayName, "Legacy Team", forbiddenIds), now, attemptId);
 		if (result.changes !== 1) throw new Error("legacy_team_setup_draft_not_found");
 		const updateDevice = db.prepare(
 			`UPDATE legacy_team_setup_draft_devices SET display_name = ?, updated_at = ?
 			 WHERE attempt_id = ? AND device_id = ?`,
 		);
-		for (const device of input.devices) {
+		const inputDeviceById = new Map(input.devices.map((device) => [device.deviceId, device]));
+		for (const persistedDevice of persistedDevices) {
+			const displayName =
+				inputDeviceById.get(persistedDevice.device_id)?.displayName ?? persistedDevice.display_name;
 			updateDevice.run(
-				safeLabel(device.displayName, "Device", [
-					device.deviceId,
-					device.fingerprint,
-					...contextIds,
-				]),
+				safeLabel(displayName, "Device", forbiddenIds),
 				now,
 				attemptId,
-				device.deviceId,
+				persistedDevice.device_id,
 			);
 		}
 		const updateProject = db.prepare(
 			`UPDATE legacy_team_setup_draft_projects SET display_name = ?, updated_at = ?
 			 WHERE attempt_id = ? AND project_ref = ?`,
 		);
-		for (const project of input.projects) {
+		const inputProjectByRef = new Map(
+			input.projects.map((project) => [project.projectRef, project]),
+		);
+		for (const persistedProject of persistedProjects) {
+			const displayName =
+				inputProjectByRef.get(persistedProject.project_ref)?.displayName ??
+				persistedProject.display_name;
 			updateProject.run(
-				safeLabel(project.displayName, "Project", [
-					project.projectRef,
-					project.sourceProjectIdentity,
-					...contextIds,
-				]),
+				safeLabel(displayName, "Project", forbiddenIds),
 				now,
 				attemptId,
-				project.projectRef,
+				persistedProject.project_ref,
 			);
 		}
 		return loadDraftView(db, attemptId);

--- a/packages/core/src/recipient-policy-identifiers.ts
+++ b/packages/core/src/recipient-policy-identifiers.ts
@@ -140,6 +140,20 @@ export function legacyTeamProjectRef(candidateId: string, sourceProjectIdentity:
 	return recipientPolicyDigest("legacy-team-project-ref-v1", [candidateId, sourceProjectIdentity]);
 }
 
+export function legacyTeamCanonicalProjectRef(
+	candidateId: string,
+	canonicalProjectIdentity: string,
+): string {
+	return recipientPolicyDigest("legacy-team-canonical-project-ref-v1", [
+		candidateId,
+		canonicalProjectIdentity,
+	]);
+}
+
+export function legacyTeamDeviceRef(candidateId: string, deviceId: string): string {
+	return recipientPolicyDigest("legacy-team-device-ref-v1", [candidateId, deviceId]);
+}
+
 export function deterministicPolicyTeamId(teamCandidateId: string): string {
 	return legacyRecipientPolicyDigest("policy-team-v1", teamCandidateId);
 }


### PR DESCRIPTION
## Description

Adds the core draft model used by guided legacy Team setup.

- Persists bounded device and Project review state.
- Produces opaque references and conservative display labels.
- Re-sanitizes labels against current roster, assignment, and Project identifiers.
- Keeps coordinator identities and public keys as transient redaction inputs only.

This is PR 1 of 4 in the Team setup read API stack.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused: 115 setup-draft tests passed. The complete stack passed `pnpm run build && pnpm run check`.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced