### PR TITLE
feat(core): discover legacy Team setup candidates

### DIFF
--- a/packages/core/src/legacy-team-candidate.test.ts
+++ b/packages/core/src/legacy-team-candidate.test.ts
@@ -12,6 +12,7 @@ import {
 	refreshLegacyTeamCandidate,
 } from "./legacy-team-candidate.js";
 import { latestLegacyTeamSetupAttempt } from "./legacy-team-setup-attempt.js";
+import { getLegacyTeamSetupDraft } from "./legacy-team-setup-draft.js";
 import {
 	deterministicPolicyTeamId,
 	legacyTeamCandidateId,
@@ -463,6 +464,58 @@ describe("legacy Team candidate discovery", () => {
 				.pluck()
 				.get(firstAttempt.attemptId),
 		).toBe(firstAttempt.attemptId);
+	});
+
+	it.each([
+		["newly stale", false],
+		["already stale", true],
+	] as const)("re-sanitizes persisted labels for a %s attempt", (_label, staleFirst) => {
+		const initialOptions = options("key-a", "api");
+		const initialGroup = initialOptions.groups[0];
+		if (!initialGroup) throw new Error("invalid test fixture");
+		initialGroup.displayName = "api";
+		const [initial] = discoverLegacyTeamCandidates(db, initialOptions);
+		const attemptId = latestLegacyTeamSetupAttempt(db, initial?.candidateRef as string)?.attemptId;
+		if (!attemptId) throw new Error("initial sanitization attempt missing");
+		expect(getLegacyTeamSetupDraft(db, initial?.candidateRef as string)).toMatchObject({
+			displayName: "api",
+			devices: [{ displayName: "api" }],
+			projects: [{ displayName: "api" }],
+		});
+
+		if (staleFirst) {
+			const staleOptions = options("key-b", "api");
+			const staleGroup = staleOptions.groups[0];
+			if (!staleGroup) throw new Error("invalid test fixture");
+			staleGroup.displayName = "api";
+			expect(discoverLegacyTeamCandidates(db, staleOptions)[0]?.status).toBe("stale");
+		}
+
+		const changedOptions = options(staleFirst ? "key-b" : "key-a", "api");
+		const changedGroup = changedOptions.groups[0];
+		if (!changedGroup) throw new Error("invalid test fixture");
+		changedGroup.displayName = "api";
+		changedGroup.devices = [
+			{ deviceId: "api", fingerprint: "key-new", displayName: "New Device", enabled: true },
+		];
+		db.prepare("DELETE FROM memory_items").run();
+		db.prepare("DELETE FROM sessions").run();
+		db.prepare("DELETE FROM project_scope_mappings").run();
+
+		const [stale] = discoverLegacyTeamCandidates(db, changedOptions);
+		const staleDraft = getLegacyTeamSetupDraft(db, initial?.candidateRef as string);
+
+		expect(stale).toMatchObject({ displayName: "Legacy Team", status: "stale" });
+		expect(staleDraft).toMatchObject({
+			attemptId,
+			state: "stale",
+			displayName: "Legacy Team",
+			devices: [{ displayName: "Device" }],
+			projects: [{ displayName: "Project" }],
+		});
+		expect(latestLegacyTeamSetupAttempt(db, stale?.candidateRef as string)?.attemptId).toBe(
+			attemptId,
+		);
 	});
 
 	it("keeps a stale attempt blocked if roster evidence reverts", () => {
@@ -1007,12 +1060,25 @@ describe("legacy Team candidate discovery", () => {
 		if (!group) throw new Error("invalid test fixture");
 		// Exact duplicates collapse; the candidate stays discoverable.
 		group.devices = [
-			{ deviceId: "device-a", fingerprint: "key-a", displayName: "Laptop", enabled: true },
-			{ deviceId: "device-a", fingerprint: "key-a", displayName: "Laptop copy", enabled: true },
+			{
+				deviceId: "device-a",
+				fingerprint: "key-a",
+				displayName: "Laptop opaque-duplicate-private",
+				enabled: true,
+				labelRedactionIds: ["opaque-first-private"],
+			},
+			{
+				deviceId: "device-a",
+				fingerprint: "key-a",
+				displayName: "Laptop copy",
+				enabled: true,
+				labelRedactionIds: ["opaque-duplicate-private"],
+			},
 		];
 		const [collapsed] = discoverLegacyTeamCandidates(db, base);
 		expect(collapsed).toMatchObject({ deviceCount: 1 });
 		const candidateRef = collapsed?.candidateRef as string;
+		expect(getLegacyTeamSetupDraft(db, candidateRef)?.devices[0]?.displayName).toBe("Device");
 
 		// A fingerprint conflict is not reviewable evidence: silently keeping
 		// either row would authorize review against arbitrary key material.
@@ -1045,9 +1111,28 @@ describe("legacy Team candidate discovery", () => {
 			"legacy_team_setup_roster_conflict",
 		);
 
-		// Identical twin snapshots still merge.
-		twin.groups = [first, { ...first, displayName: "Engineering copy" }];
+		// Identical twin snapshots still merge and retain the union of their
+		// transient label-redaction identifiers.
+		const firstDevice = first.devices[0];
+		if (!firstDevice) throw new Error("invalid test fixture");
+		firstDevice.displayName = "Laptop opaque-twin-private";
+		firstDevice.labelRedactionIds = ["opaque-first-private"];
+		twin.groups = [
+			first,
+			{
+				...first,
+				displayName: "Engineering copy",
+				devices: [
+					{
+						...firstDevice,
+						displayName: "Laptop copy",
+						labelRedactionIds: ["opaque-twin-private"],
+					},
+				],
+			},
+		];
 		expect(discoverLegacyTeamCandidates(db, twin)).toHaveLength(1);
+		expect(getLegacyTeamSetupDraft(db, candidateRef)?.devices[0]?.displayName).toBe("Device");
 	});
 
 	it("collapses invite-operation identities through explicit resolutions", () => {

--- a/packages/core/src/legacy-team-candidate.ts
+++ b/packages/core/src/legacy-team-candidate.ts
@@ -5,7 +5,6 @@ import {
 	selectedProjectScopeMappings,
 } from "./legacy-recipient-policy-projection.js";
 import {
-	getLegacyTeamSetupDraft,
 	type LegacyTeamSetupDraftView,
 	type LegacyTeamSetupProjectInput,
 	legacyTeamProjectionFingerprint,
@@ -36,6 +35,7 @@ export interface LegacyTeamRosterDeviceSnapshot {
 	fingerprint: string;
 	displayName: string;
 	enabled: boolean;
+	labelRedactionIds?: readonly string[];
 }
 
 export interface LegacyTeamConfiguredGroupSnapshot {
@@ -102,6 +102,12 @@ function dedupedRosterDevices(
 		if (existing.fingerprint !== device.fingerprint || existing.enabled !== device.enabled) {
 			return null;
 		}
+		byId.set(device.deviceId, {
+			...existing,
+			labelRedactionIds: [
+				...new Set([...(existing.labelRedactionIds ?? []), ...(device.labelRedactionIds ?? [])]),
+			],
+		});
 	}
 	return [...byId.values()];
 }
@@ -126,6 +132,22 @@ function rosterDevicesAgree(
 			other != null && other.fingerprint === device.fingerprint && other.enabled === device.enabled
 		);
 	});
+}
+
+function mergeRosterLabelRedactionIds(
+	left: LegacyTeamRosterDeviceSnapshot[],
+	right: LegacyTeamRosterDeviceSnapshot[],
+): LegacyTeamRosterDeviceSnapshot[] {
+	const rightById = new Map(right.map((device) => [device.deviceId, device]));
+	return left.map((device) => ({
+		...device,
+		labelRedactionIds: [
+			...new Set([
+				...(device.labelRedactionIds ?? []),
+				...(rightById.get(device.deviceId)?.labelRedactionIds ?? []),
+			]),
+		],
+	}));
 }
 
 /**
@@ -162,7 +184,11 @@ function effectiveGroupSnapshots(groups: LegacyTeamConfiguredGroupSnapshot[]): {
 			});
 			continue;
 		}
-		if (!rosterDevicesAgree(existing.devices, devices)) conflictedCandidateIds.add(candidateId);
+		if (!rosterDevicesAgree(existing.devices, devices)) {
+			conflictedCandidateIds.add(candidateId);
+		} else {
+			existing.devices = mergeRosterLabelRedactionIds(existing.devices, devices);
+		}
 	}
 	for (const candidateId of conflictedCandidateIds) byCandidate.delete(candidateId);
 	return { snapshots: [...byCandidate.values()], conflictedCandidateIds };
@@ -241,14 +267,6 @@ function completedInventoryCompatible(
 		}
 	}
 	return true;
-}
-
-function requireLegacyTeamSetupDraft(db: Database, candidateId: string): LegacyTeamSetupDraftView {
-	const draft = getLegacyTeamSetupDraft(db, candidateId);
-	// The row was just observed by discovery; its disappearance mid-pass is
-	// drifted state, not a valid empty result.
-	if (!draft) throw new Error("legacy_team_setup_draft_not_found");
-	return draft;
 }
 
 function currentDraftRow(db: Database, candidateId: string): DraftFreshnessRow | null {
@@ -637,7 +655,12 @@ function resolveDiscoveredCandidate(
 				now,
 			});
 		} else if (row.state === "stale") {
-			draft = requireLegacyTeamSetupDraft(db, candidateId);
+			draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
+				displayName: group.displayName,
+				devices: rosterDevices,
+				projects,
+				now,
+			});
 		} else if (
 			row.roster_fingerprint !== rosterFingerprint ||
 			row.projection_fingerprint !== expectedProjectionFingerprint
@@ -648,7 +671,12 @@ function resolveDiscoveredCandidate(
 					 WHERE attempt_id = ?`,
 				).run(now, row.attempt_id);
 			}
-			draft = requireLegacyTeamSetupDraft(db, candidateId);
+			draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
+				displayName: group.displayName,
+				devices: rosterDevices,
+				projects,
+				now,
+			});
 		} else {
 			draft = refreshLegacyTeamSetupDraft(db, {
 				candidateId,


### PR DESCRIPTION
## Description

Connects configured legacy Team snapshots to the setup-draft model.

- Deduplicates compatible roster rows while rejecting conflicting evidence.
- Unions transient label-redaction identifiers across duplicate snapshots.
- Refreshes or stales drafts from authoritative roster and Project fingerprints.
- Keeps completed candidate readiness aligned with current assignments.

This is PR 2 of 4 and depends on #1513.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused: 166 candidate/setup-draft tests passed. The complete stack passed `pnpm run build && pnpm run check`.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced