### PR TITLE
feat(server): implement bounded Team setup routes

### DIFF
--- a/docs/plans/2026-08-24-pr-1510-label-sanitization-design.md
+++ b/docs/plans/2026-08-24-pr-1510-label-sanitization-design.md
@@ -1,0 +1,15 @@
+# PR #1510 label-sanitization fix
+
+## Problem
+
+Team setup labels are coordinator-controlled and must not expose opaque lookup identifiers. Replacement attempts can retain removed rows whose identifiers are absent from the current roster, and stale drafts can retain labels that become unsafe when new identifiers appear. Identifier checks also happened after display-length truncation, allowing a forbidden identifier later in the source label to escape comparison.
+
+## Design
+
+Prepare one forbidden-identifier set for each draft operation. Normalize identifiers with NFKC, case-fold them, remove empty values, and deduplicate them once. Include candidate, coordinator, group, current device, current Project, coordinator-provided identity IDs and public keys, persisted prior/current-attempt assignment identities, and live canonical assignment identities for every row written into a replacement attempt—including carried removed devices. Coordinator identity IDs and public keys are carried only as transient redaction inputs and are never persisted in the draft.
+
+Normalize the full source label and check it against the prepared set before applying the display-length limit. Continue to apply the existing conservative character grammar and generic fallback labels. Re-sanitize every persisted label when a current attempt is reused or returned stale, while leaving its evidence and state unchanged. Persisted identifiers come only from the current attempt; identifiers from unrelated historical attempts must not over-redact labels.
+
+## Validation
+
+Regression tests cover cross-roster identifiers, carried device IDs and fingerprints, assignment identities, Unicode-equivalent identifiers, identifiers beyond the display truncation boundary, stale summary/detail labels, malformed coordinator enabled flags, and mismatched coordinator key fingerprints. Run focused core and viewer-server tests plus the full repository gate before updating the pull request.

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -432,6 +432,58 @@ describe("coordinator local admin actions", () => {
 		).rejects.toThrow("coordinator_device_list_malformed");
 	});
 
+	it("honors caller-provided remote list timeouts", async () => {
+		const timeoutSignal = new AbortController().signal;
+		const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: string | URL | Request) => {
+				const url = String(input);
+				const items = url.includes("/v1/admin/groups")
+					? []
+					: [
+							{
+								group_id: "team-a",
+								device_id: "device-a",
+								public_key: "pk-a",
+								fingerprint: "fp-a",
+								identity_id: null,
+								display_name: null,
+								enabled: 1,
+								created_at: "2026-08-24T00:00:00.000Z",
+							},
+						];
+				return new Response(JSON.stringify({ items }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}),
+		);
+
+		try {
+			await coordinatorListGroupsAction({
+				remoteUrl: "https://coord.example.test",
+				adminSecret: "secret",
+				timeoutS: 9,
+			});
+			await coordinatorListDevicesAction({
+				groupId: "team-a",
+				remoteUrl: "https://coord.example.test",
+				adminSecret: "secret",
+				timeoutS: 11,
+			});
+			await coordinatorListGroupsAction({
+				remoteUrl: "https://coord.example.test",
+				adminSecret: "secret",
+			});
+			expect(timeoutSpy).toHaveBeenNthCalledWith(1, 9_000);
+			expect(timeoutSpy).toHaveBeenNthCalledWith(2, 11_000);
+			expect(timeoutSpy).toHaveBeenNthCalledWith(3, 3_000);
+		} finally {
+			timeoutSpy.mockRestore();
+		}
+	});
+
 	it("rejects remote device lists above the enrollment evidence limit", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -123,6 +123,7 @@ async function remoteRequest(
 	adminSecret: string,
 	body?: Record<string, unknown>,
 	actorId?: string | null,
+	timeoutS = 3,
 ): Promise<Record<string, unknown> | null> {
 	const headers: Record<string, string> = { "X-Codemem-Coordinator-Admin": adminSecret };
 	const normalizedActorId = String(actorId ?? "").trim();
@@ -130,7 +131,7 @@ async function remoteRequest(
 	const [status, payload] = await requestJson(method, url, {
 		headers,
 		body,
-		timeoutS: 3,
+		timeoutS,
 		maxResponseBytes: 2_000_000,
 	});
 	if (status < 200 || status >= 300) {
@@ -415,6 +416,7 @@ export async function coordinatorListGroupsAction(opts?: {
 	remoteUrl?: string | null;
 	adminSecret?: string | null;
 	includeArchived?: boolean;
+	timeoutS?: number;
 }): Promise<CoordinatorGroup[]> {
 	const remote = opts?.remoteUrl ?? null;
 	const adminSecret = opts?.adminSecret ?? null;
@@ -425,6 +427,9 @@ export async function coordinatorListGroupsAction(opts?: {
 			"GET",
 			`${stripTrailingSlashes(remote)}/v1/admin/groups${includeArchived ? "?include_archived=1" : ""}`,
 			adminSecret,
+			undefined,
+			undefined,
+			opts?.timeoutS,
 		);
 		return Array.isArray(payload?.items)
 			? payload.items.filter(
@@ -815,6 +820,7 @@ export async function coordinatorListDevicesAction(opts: {
 	dbPath?: string | null;
 	remoteUrl?: string | null;
 	adminSecret?: string | null;
+	timeoutS?: number;
 }): Promise<CoordinatorEnrollment[]> {
 	const groupId = String(opts.groupId ?? "").trim();
 	if (!groupId) throw new Error("Group id required.");
@@ -826,6 +832,9 @@ export async function coordinatorListDevicesAction(opts: {
 			"GET",
 			`${stripTrailingSlashes(remote)}/v1/admin/devices?group_id=${encodeURIComponent(groupId)}&include_disabled=${opts.includeDisabled ? "1" : "0"}`,
 			adminSecret,
+			undefined,
+			undefined,
+			opts.timeoutS,
 		);
 		if (!Array.isArray(payload?.items)) {
 			throw new Error("coordinator_device_list_malformed");

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -1,0 +1,61 @@
+import { fingerprintPublicKey, readCoordinatorSyncConfig } from "@codemem/core";
+import { describe, expect, it, vi } from "vitest";
+import { __teamSetupTestHooks } from "./team-setup.js";
+
+describe("Team setup roster loading", () => {
+	it.each([
+		{ configuredTimeoutS: 17, expectedTimeoutS: 17 },
+		{ configuredTimeoutS: 0, expectedTimeoutS: 1 },
+	])("uses normalized coordinator settings with timeout $expectedTimeoutS", async ({
+		configuredTimeoutS,
+		expectedTimeoutS,
+	}) => {
+		const publicKey = "public-key-a";
+		const listGroups = vi.fn(async () => [
+			{
+				group_id: "group-alpha",
+				display_name: "Migration Team",
+				archived_at: null,
+				created_at: "2026-08-24T00:00:00.000Z",
+			},
+		]);
+		const listDevices = vi.fn(async () => [
+			{
+				group_id: "group-alpha",
+				device_id: "device-a",
+				public_key: publicKey,
+				fingerprint: fingerprintPublicKey(publicKey),
+				identity_id: null,
+				display_name: "Laptop",
+				enabled: 1,
+				created_at: "2026-08-24T00:00:00.000Z",
+			},
+		]);
+
+		const snapshots = await __teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
+			readConfig: () => ({
+				...readCoordinatorSyncConfig({}),
+				syncCoordinatorUrl: "localhost:8787/",
+				syncCoordinatorGroups: ["group-alpha"],
+				syncCoordinatorAdminSecret: "private-admin-secret",
+				syncCoordinatorTimeoutS: configuredTimeoutS,
+			}),
+			listGroups,
+			listDevices,
+		});
+
+		expect(snapshots[0]?.coordinatorId).toBe("http://localhost:8787");
+		expect(listGroups).toHaveBeenCalledWith(
+			expect.objectContaining({
+				remoteUrl: "http://localhost:8787",
+				timeoutS: expectedTimeoutS,
+			}),
+		);
+		expect(listDevices).toHaveBeenCalledWith(
+			expect.objectContaining({
+				remoteUrl: "http://localhost:8787",
+				timeoutS: expectedTimeoutS,
+			}),
+		);
+	});
+});

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -1,0 +1,539 @@
+import type {
+	LegacyTeamCandidateView,
+	LegacyTeamConfiguredGroupSnapshot,
+	LegacyTeamSetupAccessDeltaV1,
+	LegacyTeamSetupActivationErrorCode,
+	LegacyTeamSetupDraftView,
+	MemoryStore,
+} from "@codemem/core";
+import {
+	buildBaseUrl,
+	coordinatorListDevicesAction,
+	coordinatorListGroupsAction,
+	discoverLegacyTeamCandidates,
+	fingerprintPublicKey,
+	getLegacyTeamSetupDraft,
+	legacyTeamCandidateId,
+	legacyTeamCanonicalProjectRef,
+	legacyTeamDeviceRef,
+	legacyTeamResolvedProjectRef,
+	legacyTeamSetupApiErrorCode,
+	previewLegacyTeamSetupActivation,
+	readCoordinatorSyncConfig,
+	recipientPolicyDigest,
+} from "@codemem/core";
+import { Hono } from "hono";
+
+const TEAM_SETUP_VERSION = 1 as const;
+const MAX_CONFIGURED_GROUPS = 25;
+const MAX_DEVICES = 500;
+const MAX_PROJECTS = 500;
+const MAX_ACCESS_DELTA_ENTRIES = 10_000;
+export const TEAM_SETUP_ROUTE_PREFIX = "/api/sync/team-setup/v1";
+const CANDIDATE_REF_PATTERN = /^legacy-team-candidate:[0-9a-f]{32}$/u;
+
+export type LegacyTeamConfiguredGroupSnapshotLoader = () => Promise<
+	LegacyTeamConfiguredGroupSnapshot[]
+>;
+
+export interface LegacyTeamSetupCandidateSummaryV1 {
+	candidateRef: string;
+	displayName: string;
+	status: "needs_setup" | "in_progress" | "stale" | "ready";
+	deviceCount: number;
+	projectCount: number;
+	unresolvedDeviceCount: number;
+	unresolvedProjectCount: number;
+}
+
+export interface LegacyTeamSetupSummaryResponseV1 {
+	version: 1;
+	candidates: LegacyTeamSetupCandidateSummaryV1[];
+}
+
+export interface LegacyTeamSetupDeviceV1 {
+	deviceRef: string;
+	displayName: string;
+	enabled: boolean;
+	existingIdentityRef: string | null;
+	suggestedIdentityRef: string | null;
+	verifiedEvidenceKind: "active_assignment" | null;
+	decision: "unresolved" | "included" | "excluded" | "removed";
+	targetIdentityRef: string | null;
+	expectation:
+		| { kind: "absent" }
+		| { kind: "existing"; assignmentVersion: number; identityRef: string };
+}
+
+export interface LegacyTeamSetupProjectV1 {
+	projectRef: string;
+	displayName: string;
+	resolution: "unresolved" | "deterministic" | "explicit";
+	canonicalProjectRef: string | null;
+	resolvedProjectRef: string | null;
+}
+
+export interface LegacyTeamSetupViewerAccessDeltaV1 {
+	teamChanges: Array<{
+		teamRef: string;
+		change: "add" | "update" | "remove";
+		fromDeviceEligibilityMode: "person_all_devices" | "reviewed_allowlist" | null;
+		toDeviceEligibilityMode: "reviewed_allowlist";
+	}>;
+	membershipChanges: Array<{
+		teamRef: string;
+		identityRef: string;
+		change: "add" | "update" | "remove";
+	}>;
+	projectChanges: Array<{
+		projectRef: string;
+		fromResolvedProjectRef: string | null;
+		toResolvedProjectRef: string | null;
+		change: "add" | "update" | "remove";
+	}>;
+	recipientChanges: Array<{
+		canonicalProjectRef: string;
+		recipientKind: "team";
+		recipientRef: string;
+		change: "add" | "update" | "remove";
+	}>;
+	deviceAccessChanges: Array<{
+		canonicalProjectRef: string;
+		deviceRef: string;
+		change: "add" | "remove";
+	}>;
+}
+
+interface LegacyTeamSetupDetailBaseV1 {
+	version: 1;
+	candidate: LegacyTeamSetupCandidateSummaryV1;
+	attemptId: string;
+	draftState: "needs_setup" | "in_progress" | "stale" | "completed";
+	unresolvedDeviceCount: number;
+	unresolvedProjectCount: number;
+	devices: LegacyTeamSetupDeviceV1[];
+	projects: LegacyTeamSetupProjectV1[];
+}
+
+export type LegacyTeamSetupDetailResponseV1 = LegacyTeamSetupDetailBaseV1 &
+	(
+		| {
+				canFinish: true;
+				conflictState: null;
+				finishDigest: string;
+				accessDeltaDigest: string;
+				accessDelta: LegacyTeamSetupViewerAccessDeltaV1;
+		  }
+		| {
+				canFinish: false;
+				conflictState: LegacyTeamSetupActivationErrorCode | null;
+		  }
+	);
+
+export interface LegacyTeamSetupErrorResponseV1 {
+	error: LegacyTeamSetupActivationErrorCode;
+}
+
+interface TeamSetupRoutesOptions {
+	getStore: () => MemoryStore;
+	loadLegacyTeamConfiguredGroupSnapshots?: LegacyTeamConfiguredGroupSnapshotLoader;
+}
+
+interface LegacyTeamSnapshotLoaderDependencies {
+	readConfig: typeof readCoordinatorSyncConfig;
+	listGroups: typeof coordinatorListGroupsAction;
+	listDevices: typeof coordinatorListDevicesAction;
+}
+
+const defaultSnapshotLoaderDependencies: LegacyTeamSnapshotLoaderDependencies = {
+	readConfig: readCoordinatorSyncConfig,
+	listGroups: coordinatorListGroupsAction,
+	listDevices: coordinatorListDevicesAction,
+};
+
+function safeCoordinatorError(): Error {
+	return new Error("team_setup_roster_unavailable");
+}
+
+function isCoordinatorRosterTooLargeError(error: unknown): boolean {
+	return error instanceof Error && error.message === "coordinator_response_too_large";
+}
+
+function configuredGroupIds(groups: string[]): string[] {
+	const unique = [...new Set(groups.map((group) => group.trim()).filter(Boolean))];
+	if (unique.length > MAX_CONFIGURED_GROUPS) throw safeCoordinatorError();
+	return unique;
+}
+
+async function loadConfiguredLegacyTeamGroupSnapshotsWith(
+	dependencies: LegacyTeamSnapshotLoaderDependencies,
+): Promise<LegacyTeamConfiguredGroupSnapshot[]> {
+	let config: ReturnType<typeof readCoordinatorSyncConfig>;
+	try {
+		config = dependencies.readConfig();
+	} catch {
+		throw safeCoordinatorError();
+	}
+	const groupIds = configuredGroupIds(config.syncCoordinatorGroups);
+	const hasUrl = Boolean(config.syncCoordinatorUrl);
+	const hasSecret = Boolean(config.syncCoordinatorAdminSecret);
+	if (!hasUrl && !hasSecret && groupIds.length === 0) return [];
+	if (!hasUrl || !hasSecret || groupIds.length === 0) throw safeCoordinatorError();
+
+	try {
+		const remoteUrl = buildBaseUrl(config.syncCoordinatorUrl);
+		const coordinatorId = remoteUrl;
+		const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
+		const groups = await dependencies.listGroups({
+			remoteUrl,
+			adminSecret: config.syncCoordinatorAdminSecret,
+			includeArchived: false,
+			timeoutS,
+		});
+		const groupById = new Map(groups.map((group) => [group.group_id, group]));
+		const snapshots = await Promise.all(
+			groupIds.map(async (groupId) => {
+				const group = groupById.get(groupId);
+				if (
+					!group ||
+					group.group_id !== groupId ||
+					(group.display_name !== null && typeof group.display_name !== "string") ||
+					group.archived_at != null
+				) {
+					throw safeCoordinatorError();
+				}
+				let devices: Awaited<ReturnType<typeof coordinatorListDevicesAction>>;
+				try {
+					devices = await dependencies.listDevices({
+						groupId,
+						includeDisabled: true,
+						remoteUrl,
+						adminSecret: config.syncCoordinatorAdminSecret,
+						timeoutS,
+					});
+				} catch (error) {
+					if (isCoordinatorRosterTooLargeError(error)) return null;
+					throw error;
+				}
+				if (devices.length > MAX_DEVICES) return null;
+				if (
+					devices.some(
+						(device) =>
+							fingerprintPublicKey(device.public_key) !== device.fingerprint ||
+							(device.enabled !== 0 && device.enabled !== 1),
+					)
+				) {
+					throw safeCoordinatorError();
+				}
+				return {
+					coordinatorId,
+					groupId,
+					displayName: group.display_name ?? "Legacy Team",
+					devices: devices.map((device) => ({
+						deviceId: device.device_id,
+						fingerprint: device.fingerprint,
+						displayName: device.display_name ?? "Device",
+						enabled: device.enabled === 1,
+						labelRedactionIds: [device.identity_id ?? "", device.public_key].filter(Boolean),
+					})),
+				};
+			}),
+		);
+		return snapshots.filter((snapshot) => snapshot !== null);
+	} catch {
+		throw safeCoordinatorError();
+	}
+}
+
+export async function loadConfiguredLegacyTeamGroupSnapshots(): Promise<
+	LegacyTeamConfiguredGroupSnapshot[]
+> {
+	return loadConfiguredLegacyTeamGroupSnapshotsWith(defaultSnapshotLoaderDependencies);
+}
+
+function requireBoundedSnapshots(groups: LegacyTeamConfiguredGroupSnapshot[]): void {
+	if (groups.length > MAX_CONFIGURED_GROUPS) {
+		throw new Error("legacy_team_setup_roster_too_large");
+	}
+}
+
+function projectionOptions(store: MemoryStore) {
+	return { localActorId: store.actorId, localDeviceId: store.deviceId };
+}
+
+function discoverCandidates(
+	store: MemoryStore,
+	groups: LegacyTeamConfiguredGroupSnapshot[],
+): LegacyTeamCandidateView[] {
+	requireBoundedSnapshots(groups);
+	return discoverLegacyTeamCandidates(store.db, {
+		projection: projectionOptions(store),
+		groups,
+	});
+}
+
+function candidateSummary(candidate: LegacyTeamCandidateView): LegacyTeamSetupCandidateSummaryV1 {
+	return {
+		candidateRef: candidate.candidateRef,
+		displayName: candidate.displayName,
+		status: candidate.status,
+		deviceCount: candidate.deviceCount,
+		projectCount: candidate.projectCount,
+		unresolvedDeviceCount: candidate.unresolvedDeviceCount,
+		unresolvedProjectCount: candidate.unresolvedProjectCount,
+	};
+}
+
+function candidateSummaryForDraft(
+	candidate: LegacyTeamCandidateView,
+	draft: LegacyTeamSetupDraftView,
+): LegacyTeamSetupCandidateSummaryV1 {
+	return {
+		...candidateSummary(candidate),
+		status: draft.state === "completed" ? "ready" : draft.state,
+		unresolvedDeviceCount: draft.unresolvedDeviceCount,
+		unresolvedProjectCount: draft.unresolvedProjectCount,
+	};
+}
+
+function identityRef(candidateRef: string, identityId: string | null): string | null {
+	return identityId
+		? recipientPolicyDigest("legacy-team-viewer-identity-ref-v1", [candidateRef, identityId])
+		: null;
+}
+
+function requiredIdentityRef(candidateRef: string, identityId: string): string {
+	return recipientPolicyDigest("legacy-team-viewer-identity-ref-v1", [candidateRef, identityId]);
+}
+
+function teamRef(candidateRef: string, teamId: string): string {
+	return recipientPolicyDigest("legacy-team-viewer-team-ref-v1", [candidateRef, teamId]);
+}
+
+function resolvedProjectRef(projectRef: string, projectIdentity: string | null): string | null {
+	return projectIdentity ? legacyTeamResolvedProjectRef(projectRef, projectIdentity) : null;
+}
+
+function viewerSafeAccessDelta(
+	candidateRef: string,
+	delta: LegacyTeamSetupAccessDeltaV1,
+): LegacyTeamSetupViewerAccessDeltaV1 {
+	return {
+		teamChanges: delta.teamChanges.map((change) => ({
+			teamRef: teamRef(candidateRef, change.teamId),
+			change: change.change,
+			fromDeviceEligibilityMode: change.fromDeviceEligibilityMode,
+			toDeviceEligibilityMode: change.toDeviceEligibilityMode,
+		})),
+		membershipChanges: delta.membershipChanges.map((change) => ({
+			teamRef: teamRef(candidateRef, change.teamId),
+			identityRef: requiredIdentityRef(candidateRef, change.identityId),
+			change: change.change,
+		})),
+		projectChanges: delta.projectChanges.map((change) => ({
+			projectRef: change.projectRef,
+			fromResolvedProjectRef: resolvedProjectRef(change.projectRef, change.fromProjectIdentity),
+			toResolvedProjectRef: resolvedProjectRef(change.projectRef, change.toProjectIdentity),
+			change: change.change,
+		})),
+		recipientChanges: delta.recipientChanges.map((change) => ({
+			canonicalProjectRef: legacyTeamCanonicalProjectRef(
+				candidateRef,
+				change.canonicalProjectIdentity,
+			),
+			recipientKind: change.recipientKind,
+			recipientRef: teamRef(candidateRef, change.recipientId),
+			change: change.change,
+		})),
+		deviceAccessChanges: delta.deviceAccessChanges.map((change) => ({
+			canonicalProjectRef: legacyTeamCanonicalProjectRef(
+				candidateRef,
+				change.canonicalProjectIdentity,
+			),
+			deviceRef: legacyTeamDeviceRef(candidateRef, change.deviceId),
+			change: change.change,
+		})),
+	};
+}
+
+export const __teamSetupTestHooks = {
+	loadConfiguredLegacyTeamGroupSnapshotsWith,
+	viewerSafeAccessDelta,
+};
+
+function requireBoundedAccessDelta(delta: LegacyTeamSetupAccessDeltaV1): void {
+	const total =
+		delta.teamChanges.length +
+		delta.membershipChanges.length +
+		delta.projectChanges.length +
+		delta.recipientChanges.length +
+		delta.deviceAccessChanges.length;
+	if (
+		delta.teamChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
+		delta.membershipChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
+		delta.projectChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
+		delta.recipientChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
+		delta.deviceAccessChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
+		total > MAX_ACCESS_DELTA_ENTRIES
+	) {
+		throw new Error("legacy_team_setup_roster_too_large");
+	}
+}
+
+function viewerSafeDraft(draft: LegacyTeamSetupDraftView): {
+	devices: LegacyTeamSetupDeviceV1[];
+	projects: LegacyTeamSetupProjectV1[];
+} {
+	if (draft.devices.length > MAX_DEVICES || draft.projects.length > MAX_PROJECTS) {
+		throw new Error("legacy_team_setup_roster_too_large");
+	}
+	return {
+		devices: draft.devices.map((device) => ({
+			deviceRef: device.deviceRef,
+			displayName: device.displayName,
+			enabled: device.enabled,
+			existingIdentityRef: identityRef(draft.candidateRef, device.existingIdentityId),
+			suggestedIdentityRef: identityRef(draft.candidateRef, device.suggestedIdentityId),
+			verifiedEvidenceKind: device.verifiedEvidenceKind,
+			decision: device.decision,
+			targetIdentityRef: identityRef(draft.candidateRef, device.targetIdentityId),
+			expectation:
+				device.expectation.kind === "existing"
+					? {
+							kind: "existing" as const,
+							assignmentVersion: device.expectation.assignmentVersion,
+							identityRef: requiredIdentityRef(draft.candidateRef, device.expectation.identityId),
+						}
+					: { kind: "absent" as const },
+		})),
+		projects: draft.projects.map((project) => ({
+			projectRef: project.projectRef,
+			displayName: project.displayName,
+			resolution: project.resolution,
+			canonicalProjectRef: project.canonicalProjectRef,
+			resolvedProjectRef: project.resolvedProjectRef,
+		})),
+	};
+}
+
+function errorStatus(code: LegacyTeamSetupActivationErrorCode): 400 | 409 | 500 | 503 {
+	if (code === "team_setup_roster_unavailable") return 503;
+	if (code === "team_setup_failed") return 500;
+	if (code === "team_setup_incomplete") return 400;
+	return 409;
+}
+
+export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
+	const app = new Hono();
+	const loadSnapshots =
+		options.loadLegacyTeamConfiguredGroupSnapshots ?? loadConfiguredLegacyTeamGroupSnapshots;
+
+	async function loadedSnapshots(): Promise<LegacyTeamConfiguredGroupSnapshot[]> {
+		try {
+			return await loadSnapshots();
+		} catch {
+			throw safeCoordinatorError();
+		}
+	}
+
+	app.get("/api/sync/team-setup/v1", async (c) => {
+		let groups: LegacyTeamConfiguredGroupSnapshot[];
+		try {
+			groups = await loadedSnapshots();
+		} catch {
+			return c.json({ error: "team_setup_roster_unavailable" as const }, 503);
+		}
+		try {
+			const response = {
+				version: TEAM_SETUP_VERSION,
+				candidates: discoverCandidates(options.getStore(), groups).map(candidateSummary),
+			} satisfies LegacyTeamSetupSummaryResponseV1;
+			return c.json(response);
+		} catch (error) {
+			const code = legacyTeamSetupApiErrorCode(error);
+			return c.json({ error: code }, errorStatus(code));
+		}
+	});
+
+	app.get("/api/sync/team-setup/v1/:candidateRef", async (c) => {
+		const candidateRef = c.req.param("candidateRef");
+		if (!CANDIDATE_REF_PATTERN.test(candidateRef)) {
+			return c.json({ error: "team_setup_incomplete" as const }, 400);
+		}
+
+		let groups: LegacyTeamConfiguredGroupSnapshot[];
+		try {
+			groups = await loadedSnapshots();
+		} catch {
+			return c.json({ error: "team_setup_roster_unavailable" as const }, 503);
+		}
+
+		try {
+			const store = options.getStore();
+			const candidateGroups = groups.filter(
+				(group) => legacyTeamCandidateId(group.coordinatorId, group.groupId) === candidateRef,
+			);
+			const candidate = discoverCandidates(store, candidateGroups).find(
+				(item) => item.candidateRef === candidateRef,
+			);
+			if (!candidate) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			}
+			const draft = getLegacyTeamSetupDraft(store.db, candidateRef);
+			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+
+			let conflictState: LegacyTeamSetupActivationErrorCode | null = null;
+			let preview: ReturnType<typeof previewLegacyTeamSetupActivation> | null = null;
+			if (draft.state !== "completed") {
+				try {
+					preview = previewLegacyTeamSetupActivation(store.db, {
+						candidateRef,
+						attemptId: draft.attemptId,
+					});
+				} catch (error) {
+					const code = legacyTeamSetupApiErrorCode(error);
+					if (code === "team_setup_failed") return c.json({ error: code }, 500);
+					preview = null;
+					conflictState = code;
+				}
+			}
+			if (preview) requireBoundedAccessDelta(preview.accessDelta);
+
+			const viewDraft = conflictState
+				? (getLegacyTeamSetupDraft(store.db, candidateRef) ?? draft)
+				: draft;
+			const safeDraft = viewerSafeDraft(viewDraft);
+			const responseBase = {
+				version: TEAM_SETUP_VERSION,
+				candidate: candidateSummaryForDraft(candidate, viewDraft),
+				attemptId: viewDraft.attemptId,
+				draftState: viewDraft.state,
+				unresolvedDeviceCount: viewDraft.unresolvedDeviceCount,
+				unresolvedProjectCount: viewDraft.unresolvedProjectCount,
+				...safeDraft,
+			};
+			if (!preview) {
+				const response = {
+					...responseBase,
+					canFinish: false,
+					conflictState,
+				} satisfies LegacyTeamSetupDetailResponseV1;
+				return c.json(response);
+			}
+			const response = {
+				...responseBase,
+				canFinish: true,
+				conflictState: null,
+				finishDigest: preview.finishDigest,
+				accessDeltaDigest: preview.accessDeltaDigest,
+				accessDelta: viewerSafeAccessDelta(candidateRef, preview.accessDelta),
+			} satisfies LegacyTeamSetupDetailResponseV1;
+			return c.json(response);
+		} catch (error) {
+			const code = legacyTeamSetupApiErrorCode(error);
+			return c.json({ error: code }, errorStatus(code));
+		}
+	});
+
+	return app;
+}


### PR DESCRIPTION
## Description

Implements the versioned Team setup summary/detail route module without registering it on the viewer app yet.

- Loads bounded coordinator roster snapshots.
- Validates key/fingerprint and enabled-state evidence.
- Maps core drafts into explicit redacted HTTP contracts.
- Keeps coordinator fetch URLs separate from stored coordinator identity.

This is PR 3 of 4 and depends on #1514.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

This layer independently passes TypeScript and Biome. The complete stack passed `pnpm run build && pnpm run check`.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced