### PR TITLE
feat(ui): surface Team setup status in Sharing

### DIFF
--- a/packages/ui/src/app-devices.test.tsx
+++ b/packages/ui/src/app-devices.test.tsx
@@ -16,6 +16,7 @@ vi.mock("./components/primitives/toast", () => ({ mountToastHost: vi.fn() }));
 vi.mock("./lib/api", () => ({
 	loadCoordinatorAdminStatus: vi.fn(async () => ({ has_admin_secret: false })),
 	loadDeviceIdentityInventory: mocks.loadDeviceIdentityInventory,
+	loadLegacyTeamSetupSummary: vi.fn(async () => ({ version: 1, candidates: [] })),
 	loadProjectScopeInventory: mocks.loadProjectScopeInventory,
 	loadProjects: vi.fn(async () => ["Codemem"]),
 	loadRecipientPolicyIntent: mocks.loadRecipientPolicyIntent,

--- a/packages/ui/src/app-sharing.test.tsx
+++ b/packages/ui/src/app-sharing.test.tsx
@@ -17,7 +17,10 @@ vi.mock("./components/primitives/radix-dialog", () => ({
 }));
 
 import { createRecipientPolicySharingLoader } from "./app-sharing";
-import type { RecipientPolicyIntentGraphV1 } from "./lib/api/sync";
+import type {
+	LegacyTeamSetupSummaryResponseV1,
+	RecipientPolicyIntentGraphV1,
+} from "./lib/api/sync";
 
 const projects = [
 	{ canonicalProjectIdentity: "git:codemem", displayName: "Codemem", existingMemoryCount: 12 },
@@ -85,6 +88,25 @@ describe("Sharing app data refresh", () => {
 			'<div id="recipientPolicySharingMount"></div><div id="recipientPolicyManagementMount"></div>';
 		const loadProjects = vi.fn().mockResolvedValue({ manageable: projects, received: [] });
 		const loadIntent = vi.fn().mockResolvedValue(intent);
+		const teamSetupSummary: LegacyTeamSetupSummaryResponseV1 = {
+			version: 1,
+			candidates: [
+				{
+					candidateRef: "candidate-one",
+					displayName: "Example Team",
+					status: "needs_setup",
+					deviceCount: 1,
+					projectCount: 1,
+					unresolvedDeviceCount: 1,
+					unresolvedProjectCount: 0,
+				},
+			],
+		};
+		const loadTeamSetupSummary = vi
+			.fn()
+			.mockResolvedValueOnce(teamSetupSummary)
+			.mockRejectedValueOnce(new Error("setup unavailable"))
+			.mockResolvedValueOnce(teamSetupSummary);
 		const loadDeviceInventory = vi.fn().mockResolvedValue({
 			version: 1,
 			items: [],
@@ -95,6 +117,7 @@ describe("Sharing app data refresh", () => {
 			loadDeviceInventory,
 			loadIntent,
 			loadProjects,
+			loadTeamSetupSummary,
 		});
 
 		let refreshResult: boolean | undefined;
@@ -119,6 +142,8 @@ describe("Sharing app data refresh", () => {
 			"The complete recipient access inventory is unavailable. Refresh and try again.",
 		);
 		expect(document.body.textContent).toContain("Manage projects");
+		expect(document.body.textContent).toContain("Example Team");
+		expect(document.body.textContent).toContain("The previous Team setup status is being shown.");
 		expect(document.body.textContent).not.toContain("Review changes");
 
 		await act(async () => {
@@ -128,6 +153,9 @@ describe("Sharing app data refresh", () => {
 		expect(document.body.textContent).toContain("Review changes");
 		expect(document.body.textContent).not.toContain(
 			"Refresh failed; showing previous Sharing details",
+		);
+		expect(document.body.textContent).not.toContain(
+			"The previous Team setup status is being shown.",
 		);
 	});
 
@@ -201,7 +229,57 @@ describe("Sharing app data refresh", () => {
 				refreshError: true,
 			}),
 		);
-		expect(mountSharing.mock.calls.filter((call) => call[3]?.loading === true)).toHaveLength(1);
+		expect(
+			mountSharing.mock.calls.filter((call) => call[3]?.loading === true).length,
+		).toBeGreaterThanOrEqual(1);
+	});
+
+	it("preserves failed-refresh guards while a retry is pending", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const inventory = {
+			version: 1 as const,
+			items: [],
+			coordinatorEvidence: { availability: "available" as const, safeErrorCode: null },
+			truncated: false,
+		};
+		const pendingProjects = deferred<{ manageable: typeof projects; received: [] }>();
+		const pendingIntent = deferred<typeof intent>();
+		const pendingInventory = deferred<typeof inventory>();
+		const mountSharing = vi.fn();
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory: vi
+				.fn()
+				.mockResolvedValueOnce(inventory)
+				.mockRejectedValueOnce(new Error("inventory unavailable"))
+				.mockImplementationOnce(() => pendingInventory.promise),
+			loadIntent: vi
+				.fn()
+				.mockResolvedValueOnce(intent)
+				.mockRejectedValueOnce(new Error("intent unavailable"))
+				.mockImplementationOnce(() => pendingIntent.promise),
+			loadProjects: vi
+				.fn()
+				.mockResolvedValueOnce({ manageable: projects, received: [] })
+				.mockRejectedValueOnce(new Error("projects unavailable"))
+				.mockImplementationOnce(() => pendingProjects.promise),
+			mountSharing,
+		});
+
+		await load();
+		await load();
+		const retry = load();
+		expect(mountSharing.mock.calls.at(-1)?.[3]).toEqual(
+			expect.objectContaining({
+				deviceInventoryUnavailable: true,
+				refreshError: true,
+				teamSetupLoading: true,
+			}),
+		);
+
+		pendingProjects.resolve({ manageable: projects, received: [] });
+		pendingIntent.resolve(intent);
+		pendingInventory.resolve(inventory);
+		await expect(retry).resolves.toBe(true);
 	});
 
 	it("waits for delayed device inventory failure before rendering a broader load error", async () => {
@@ -212,6 +290,7 @@ describe("Sharing app data refresh", () => {
 			loadDeviceInventory: vi.fn(() => inventoryResult.promise),
 			loadIntent: vi.fn().mockRejectedValue(new Error("intent unavailable")),
 			loadProjects: vi.fn().mockResolvedValue({ manageable: projects, received: [] }),
+			loadTeamSetupSummary: vi.fn().mockRejectedValue(new Error("setup unavailable")),
 		});
 
 		const result = load();
@@ -221,6 +300,46 @@ describe("Sharing app data refresh", () => {
 		await expect(result).resolves.toBe(false);
 		expect(document.body.textContent).toContain("Sharing details are unavailable");
 		expect(document.body.textContent).toContain("Device Identity information is unavailable");
+		expect(document.body.textContent).toContain("Team setup status is temporarily unavailable.");
+	});
+
+	it("forwards a successful Team summary through first-load required-data failure", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const teamSetupSummary: LegacyTeamSetupSummaryResponseV1 = {
+			version: 1,
+			candidates: [
+				{
+					candidateRef: "candidate-one",
+					displayName: "Example Team",
+					status: "needs_setup",
+					deviceCount: 1,
+					projectCount: 1,
+					unresolvedDeviceCount: 1,
+					unresolvedProjectCount: 0,
+				},
+			],
+		};
+		const mountSharing = vi.fn();
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory: vi.fn().mockResolvedValue({ version: 1, items: [], truncated: false }),
+			loadIntent: vi.fn().mockRejectedValue(new Error("intent unavailable")),
+			loadProjects: vi.fn().mockRejectedValue(new Error("projects unavailable")),
+			loadSyncStatus: vi.fn().mockResolvedValue({}),
+			loadTeamSetupSummary: vi.fn().mockResolvedValue(teamSetupSummary),
+			mountSharing,
+		});
+
+		await expect(load()).resolves.toBe(false);
+		expect(mountSharing).toHaveBeenLastCalledWith(
+			document.getElementById("recipientPolicySharingMount"),
+			[],
+			expect.objectContaining({ version: 1, teams: [] }),
+			expect.objectContaining({
+				loadError: true,
+				teamSetupSummary,
+				teamSetupUnavailable: false,
+			}),
+		);
 	});
 
 	it("lets the newest overlapping refresh own the final mount and result", async () => {
@@ -322,6 +441,267 @@ describe("Sharing app data refresh", () => {
 
 		expect(mountSharing.mock.calls.at(-1)?.[3]).toEqual(
 			expect.objectContaining({ coordinatorEnrollmentIssueCount: 2 }),
+		);
+	});
+
+	it("loads Team setup independently and keeps Sharing usable when that optional request fails", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const onOpenTeamSetup = vi.fn();
+		const mountSharing = vi.fn();
+		const loadTeamSetupSummary = vi
+			.fn()
+			.mockResolvedValueOnce({
+				version: 1,
+				candidates: [
+					{
+						candidateRef: "candidate-one",
+						displayName: "Example Team",
+						status: "needs_setup",
+						deviceCount: 1,
+						projectCount: 1,
+						unresolvedDeviceCount: 1,
+						unresolvedProjectCount: 0,
+					},
+				],
+			})
+			.mockRejectedValueOnce(new Error("optional setup unavailable"));
+		const load = createRecipientPolicySharingLoader(
+			{
+				loadDeviceInventory: vi.fn().mockResolvedValue({ version: 1, items: [], truncated: false }),
+				loadIntent: vi.fn().mockResolvedValue(intent),
+				loadProjects: vi.fn().mockResolvedValue({ manageable: projects, received: [] }),
+				loadTeamSetupSummary,
+				mountSharing,
+			},
+			{ onOpenTeamSetup },
+		);
+
+		await expect(load()).resolves.toBe(true);
+		expect(mountSharing).toHaveBeenLastCalledWith(
+			document.getElementById("recipientPolicySharingMount"),
+			projects,
+			intent,
+			expect.objectContaining({
+				onOpenTeamSetup,
+				teamSetupSummary: expect.objectContaining({ version: 1 }),
+				teamSetupUnavailable: false,
+			}),
+		);
+		await expect(load()).resolves.toBe(true);
+		expect(mountSharing.mock.calls.at(-1)?.[3]).toEqual(
+			expect.objectContaining({
+				teamSetupSummary: expect.objectContaining({ version: 1 }),
+				teamSetupUnavailable: true,
+			}),
+		);
+		expect(mountSharing.mock.calls.at(-1)?.[3]?.refreshError).toBeUndefined();
+	});
+
+	it("renders required Sharing data before optional Team setup discovery settles", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const teamSetupResult = deferred<LegacyTeamSetupSummaryResponseV1>();
+		const mountSharing = vi.fn();
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory: vi.fn().mockResolvedValue({ version: 1, items: [], truncated: false }),
+			loadIntent: vi.fn().mockResolvedValue(intent),
+			loadProjects: vi.fn().mockResolvedValue({ manageable: projects, received: [] }),
+			loadTeamSetupSummary: vi.fn(() => teamSetupResult.promise),
+			mountSharing,
+		});
+
+		const operation = load();
+		await expect(operation).resolves.toBe(true);
+		expect(mountSharing).toHaveBeenLastCalledWith(
+			document.getElementById("recipientPolicySharingMount"),
+			projects,
+			intent,
+			expect.objectContaining({ teamSetupLoading: true, teamSetupSummary: undefined }),
+		);
+
+		await act(async () => {
+			teamSetupResult.resolve({ version: 1, candidates: [] });
+			await Promise.resolve();
+		});
+		expect(mountSharing.mock.calls.at(-1)?.[3]).toEqual(
+			expect.objectContaining({
+				teamSetupSummary: { version: 1, candidates: [] },
+				teamSetupUnavailable: false,
+			}),
+		);
+	});
+
+	it("renders fresh Team setup status before a required Sharing refresh settles", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const projectRefresh = deferred<{ manageable: typeof projects; received: [] }>();
+		const initialSummary: LegacyTeamSetupSummaryResponseV1 = { version: 1, candidates: [] };
+		const freshSummary: LegacyTeamSetupSummaryResponseV1 = {
+			version: 1,
+			candidates: [
+				{
+					candidateRef: "candidate-fresh",
+					displayName: "Fresh Team",
+					status: "needs_setup",
+					deviceCount: 1,
+					projectCount: 0,
+					unresolvedDeviceCount: 1,
+					unresolvedProjectCount: 0,
+				},
+			],
+		};
+		const mountSharing = vi.fn();
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory: vi.fn().mockResolvedValue({ version: 1, items: [], truncated: false }),
+			loadIntent: vi.fn().mockResolvedValue(intent),
+			loadProjects: vi
+				.fn()
+				.mockResolvedValueOnce({ manageable: projects, received: [] })
+				.mockImplementationOnce(() => projectRefresh.promise),
+			loadTeamSetupSummary: vi
+				.fn()
+				.mockResolvedValueOnce(initialSummary)
+				.mockResolvedValueOnce(freshSummary),
+			mountSharing,
+		});
+
+		await load();
+		const refresh = load();
+		await vi.waitFor(() =>
+			expect(mountSharing.mock.calls.at(-1)?.[3]).toEqual(
+				expect.objectContaining({
+					teamSetupLoading: false,
+					teamSetupSummary: freshSummary,
+				}),
+			),
+		);
+
+		projectRefresh.resolve({ manageable: projects, received: [] });
+		await expect(refresh).resolves.toBe(true);
+	});
+
+	it("marks a cached Team setup summary as previous while its refresh is pending", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const refreshResult = deferred<LegacyTeamSetupSummaryResponseV1>();
+		const initialSummary: LegacyTeamSetupSummaryResponseV1 = { version: 1, candidates: [] };
+		const mountSharing = vi.fn();
+		const loadTeamSetupSummary = vi
+			.fn()
+			.mockResolvedValueOnce(initialSummary)
+			.mockRejectedValueOnce(new Error("temporary setup failure"))
+			.mockReturnValueOnce(refreshResult.promise);
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory: vi.fn().mockResolvedValue({ version: 1, items: [], truncated: false }),
+			loadIntent: vi.fn().mockResolvedValue(intent),
+			loadProjects: vi.fn().mockResolvedValue({ manageable: projects, received: [] }),
+			loadTeamSetupSummary,
+			mountSharing,
+		});
+
+		await expect(load()).resolves.toBe(true);
+		await expect(load()).resolves.toBe(true);
+		expect(mountSharing.mock.calls.at(-1)?.[3]).toEqual(
+			expect.objectContaining({
+				teamSetupSummary: initialSummary,
+				teamSetupLoading: false,
+				teamSetupUnavailable: true,
+			}),
+		);
+		await expect(load()).resolves.toBe(true);
+		expect(mountSharing.mock.calls.at(-1)?.[3]).toEqual(
+			expect.objectContaining({
+				teamSetupSummary: initialSummary,
+				teamSetupLoading: true,
+				teamSetupUnavailable: false,
+			}),
+		);
+
+		refreshResult.resolve({ version: 1, candidates: [] });
+	});
+
+	it("reports first-load Team setup unavailability without inventing candidates", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const mountSharing = vi.fn();
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory: vi.fn().mockResolvedValue({ version: 1, items: [], truncated: false }),
+			loadIntent: vi.fn().mockResolvedValue(intent),
+			loadProjects: vi.fn().mockResolvedValue({ manageable: projects, received: [] }),
+			loadTeamSetupSummary: vi.fn().mockRejectedValue(new Error("optional setup unavailable")),
+			mountSharing,
+		});
+
+		await expect(load()).resolves.toBe(true);
+		expect(mountSharing).toHaveBeenLastCalledWith(
+			document.getElementById("recipientPolicySharingMount"),
+			projects,
+			intent,
+			expect.objectContaining({
+				teamSetupSummary: undefined,
+				teamSetupUnavailable: true,
+			}),
+		);
+	});
+
+	it("does not let an older Team summary refresh replace the newest unavailable state", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const initialSummary: LegacyTeamSetupSummaryResponseV1 = {
+			version: 1,
+			candidates: [
+				{
+					candidateRef: "candidate-initial",
+					displayName: "Initial Team",
+					status: "needs_setup",
+					deviceCount: 1,
+					projectCount: 1,
+					unresolvedDeviceCount: 1,
+					unresolvedProjectCount: 0,
+				},
+			],
+		};
+		const olderSummary = deferred<LegacyTeamSetupSummaryResponseV1>();
+		const mountSharing = vi.fn();
+		const loadTeamSetupSummary = vi
+			.fn()
+			.mockResolvedValueOnce(initialSummary)
+			.mockReturnValueOnce(olderSummary.promise)
+			.mockRejectedValueOnce(new Error("newest summary unavailable"));
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory: vi.fn().mockResolvedValue({ version: 1, items: [], truncated: false }),
+			loadIntent: vi.fn().mockResolvedValue(intent),
+			loadProjects: vi.fn().mockResolvedValue({ manageable: projects, received: [] }),
+			loadTeamSetupSummary,
+			mountSharing,
+		});
+
+		await expect(load()).resolves.toBe(true);
+		const olderLoad = load();
+		const newestLoad = load();
+		await expect(newestLoad).resolves.toBe(true);
+		expect(mountSharing.mock.calls.at(-1)?.[3]).toEqual(
+			expect.objectContaining({
+				teamSetupSummary: initialSummary,
+				teamSetupUnavailable: true,
+			}),
+		);
+
+		olderSummary.resolve({
+			version: 1,
+			candidates: [
+				{
+					candidateRef: "candidate-obsolete",
+					displayName: "Obsolete Team",
+					status: "in_progress",
+					deviceCount: 2,
+					projectCount: 1,
+					unresolvedDeviceCount: 0,
+					unresolvedProjectCount: 0,
+				},
+			],
+		});
+		await expect(olderLoad).resolves.toBe(true);
+		expect(mountSharing.mock.calls.at(-1)?.[3]).toEqual(
+			expect.objectContaining({
+				teamSetupSummary: initialSummary,
+				teamSetupUnavailable: true,
+			}),
 		);
 	});
 });

--- a/packages/ui/src/app-sharing.ts
+++ b/packages/ui/src/app-sharing.ts
@@ -10,7 +10,10 @@ import {
 	toReceivedProjectShares,
 	toRecipientPolicyManagementProjects,
 } from "./tabs/recipient-policy-projects";
-import { mountRecipientPolicySharing } from "./tabs/recipient-policy-sharing";
+import {
+	mountRecipientPolicySharing,
+	type RecipientPolicySharingOptions,
+} from "./tabs/recipient-policy-sharing";
 
 const EMPTY_RECIPIENT_POLICY_INTENT: api.RecipientPolicyIntentGraphV1 = {
 	version: 1,
@@ -46,6 +49,7 @@ interface RecipientPolicySharingLoaderDependencies {
 	loadIntent: typeof api.loadRecipientPolicyIntent;
 	loadProjects: () => Promise<RecipientPolicyProjectInventory>;
 	loadSyncStatus: typeof api.loadSyncStatus;
+	loadTeamSetupSummary: typeof api.loadLegacyTeamSetupSummary;
 	mountManagement: typeof mountRecipientPolicyManagement;
 	mountSharing: typeof mountRecipientPolicySharing;
 }
@@ -55,19 +59,28 @@ const defaultDependencies: RecipientPolicySharingLoaderDependencies = {
 	loadIntent: api.loadRecipientPolicyIntent,
 	loadProjects: loadRecipientPolicyProjects,
 	loadSyncStatus: api.loadSyncStatus,
+	loadTeamSetupSummary: api.loadLegacyTeamSetupSummary,
 	mountManagement: mountRecipientPolicyManagement,
 	mountSharing: mountRecipientPolicySharing,
 };
 
 export function createRecipientPolicySharingLoader(
 	overrides: Partial<RecipientPolicySharingLoaderDependencies> = {},
-	options: { onReviewDevices?: (deviceId?: string) => void } = {},
-): () => Promise<boolean> {
+	options: {
+		onOpenTeamSetup?: (candidateRef: string) => void;
+		onReviewDevices?: (deviceId?: string) => void;
+	} = {},
+): RecipientPolicySharingRefresh {
 	const dependencies = { ...defaultDependencies, ...overrides };
 	let loadRevision = 0;
 	let latestLoad: Promise<boolean> | null = null;
 	let coordinatorEnrollmentIssueCount = 0;
 	let lastDeviceInventory: Awaited<ReturnType<typeof dependencies.loadDeviceInventory>> | undefined;
+	let teamSetupSummary: api.LegacyTeamSetupSummaryResponseV1 | undefined;
+	let teamSetupLoading = false;
+	let teamSetupUnavailable = false;
+	let lastRequiredRefreshError = false;
+	let lastDeviceInventoryUnavailable = false;
 	let lastSuccessfulData: {
 		inventory: RecipientPolicyProjectInventory;
 		intent: api.RecipientPolicyIntentGraphV1;
@@ -84,11 +97,53 @@ export function createRecipientPolicySharingLoader(
 		const sharingMount = document.getElementById("recipientPolicySharingMount");
 		if (!sharingMount) return true;
 		const managementMount = document.getElementById("recipientPolicyManagementMount");
-		if (!lastSuccessfulData) {
-			dependencies.mountSharing(sharingMount, [], EMPTY_RECIPIENT_POLICY_INTENT, {
-				loading: true,
-			});
-		}
+		teamSetupLoading = true;
+		teamSetupUnavailable = false;
+		let renderTeamSetupUpdate = () => {
+			const cached = lastSuccessfulData;
+			dependencies.mountSharing(
+				sharingMount,
+				cached?.inventory.manageable ?? [],
+				cached?.intent ?? EMPTY_RECIPIENT_POLICY_INTENT,
+				cached
+					? {
+							coordinatorEnrollmentIssueCount,
+							deviceInventory: lastDeviceInventory,
+							deviceInventoryUnavailable: lastDeviceInventoryUnavailable,
+							onOpenTeamSetup: options.onOpenTeamSetup,
+							onReviewDevices: options.onReviewDevices,
+							received: cached.inventory.received,
+							...(lastRequiredRefreshError ? { refreshError: true } : {}),
+							teamSetupSummary,
+							teamSetupLoading,
+							teamSetupUnavailable,
+						}
+					: {
+							loading: true,
+							teamSetupSummary,
+							teamSetupLoading,
+							teamSetupUnavailable,
+						},
+			);
+		};
+		renderTeamSetupUpdate();
+		void Promise.resolve()
+			.then(() => dependencies.loadTeamSetupSummary())
+			.then(
+				(summary) => {
+					if (revision !== loadRevision) return;
+					teamSetupSummary = summary;
+					teamSetupLoading = false;
+					teamSetupUnavailable = false;
+					renderTeamSetupUpdate();
+				},
+				() => {
+					if (revision !== loadRevision) return;
+					teamSetupLoading = false;
+					teamSetupUnavailable = true;
+					renderTeamSetupUpdate();
+				},
+			);
 		const [inventoryResult, intentResult, deviceInventoryResult, syncStatusResult] =
 			await Promise.allSettled([
 				dependencies.loadProjects(),
@@ -104,20 +159,30 @@ export function createRecipientPolicySharingLoader(
 		if (syncStatusResult.status === "fulfilled") {
 			coordinatorEnrollmentIssueCount = coordinatorEnrollmentOpenIssueCount(syncStatusResult.value);
 		}
-		if (inventoryResult.status === "fulfilled" && intentResult.status === "fulfilled") {
+		let sharingProjects: RecipientPolicyManagementProject[];
+		let sharingIntent: api.RecipientPolicyIntentGraphV1;
+		let sharingOptions: RecipientPolicySharingOptions;
+		const loadSucceeded =
+			inventoryResult.status === "fulfilled" && intentResult.status === "fulfilled";
+		lastRequiredRefreshError = !loadSucceeded;
+		lastDeviceInventoryUnavailable = deviceInventoryUnavailable;
+		if (loadSucceeded) {
 			const inventory = inventoryResult.value;
 			const intent = intentResult.value;
 			lastSuccessfulData = {
 				intent,
 				inventory,
 			};
-			dependencies.mountSharing(sharingMount, inventory.manageable, intent, {
+			sharingProjects = inventory.manageable;
+			sharingIntent = intent;
+			sharingOptions = {
 				coordinatorEnrollmentIssueCount,
 				deviceInventory: lastDeviceInventory,
 				deviceInventoryUnavailable,
+				onOpenTeamSetup: options.onOpenTeamSetup,
 				onReviewDevices: options.onReviewDevices,
 				received: inventory.received,
-			});
+			};
 			if (managementMount) {
 				dependencies.mountManagement(managementMount, inventory.manageable, intent, {
 					onCommitted: async () => {
@@ -125,35 +190,48 @@ export function createRecipientPolicySharingLoader(
 					},
 				});
 			}
-			return true;
-		}
-		if (lastSuccessfulData) {
-			dependencies.mountSharing(
-				sharingMount,
-				lastSuccessfulData.inventory.manageable,
-				lastSuccessfulData.intent,
-				{
-					coordinatorEnrollmentIssueCount,
-					deviceInventory: lastDeviceInventory,
-					deviceInventoryUnavailable,
-					onReviewDevices: options.onReviewDevices,
-					received: lastSuccessfulData.inventory.received,
-					refreshError: true,
-				},
-			);
+		} else if (lastSuccessfulData) {
+			const cached = lastSuccessfulData;
+			sharingProjects = cached.inventory.manageable;
+			sharingIntent = cached.intent;
+			sharingOptions = {
+				coordinatorEnrollmentIssueCount,
+				deviceInventory: lastDeviceInventory,
+				deviceInventoryUnavailable,
+				onOpenTeamSetup: options.onOpenTeamSetup,
+				onReviewDevices: options.onReviewDevices,
+				received: cached.inventory.received,
+				refreshError: true,
+			};
 		} else {
-			dependencies.mountSharing(sharingMount, [], EMPTY_RECIPIENT_POLICY_INTENT, {
+			sharingProjects = [];
+			sharingIntent = EMPTY_RECIPIENT_POLICY_INTENT;
+			sharingOptions = {
 				deviceInventoryUnavailable,
 				loadError: true,
-			});
+			};
 		}
-		if (managementMount) {
+
+		const renderSharing = () => {
+			dependencies.mountSharing(sharingMount, sharingProjects, sharingIntent, {
+				...sharingOptions,
+				teamSetupSummary,
+				teamSetupLoading,
+				teamSetupUnavailable,
+			});
+		};
+		renderSharing();
+		renderTeamSetupUpdate = renderSharing;
+
+		if (!loadSucceeded && managementMount) {
 			dependencies.mountManagement(managementMount, [], EMPTY_RECIPIENT_POLICY_INTENT, {
 				loadError: true,
 			});
 		}
-		return false;
+		return loadSucceeded;
 	}
 
 	return loadRecipientPolicySharingData;
 }
+
+export type RecipientPolicySharingRefresh = () => Promise<boolean>;

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -9,7 +9,10 @@ vi.mock("./recipient-policy-management", async (importOriginal) => {
 	return { ...original, openRecipientPolicyManagement: openManagement };
 });
 
-import type { RecipientPolicyIntentGraphV1 } from "../lib/api/sync";
+import type {
+	LegacyTeamSetupSummaryResponseV1,
+	RecipientPolicyIntentGraphV1,
+} from "../lib/api/sync";
 import type { RecipientPolicyManagementProject } from "./recipient-policy-management";
 import { mountRecipientPolicySharing } from "./recipient-policy-sharing";
 
@@ -530,6 +533,140 @@ describe("recipient-focused Sharing", () => {
 		expect(attention?.textContent).not.toMatch(/fingerprint|group[_ -]?id|coordinator[_ -]?id/i);
 		act(() => (attention?.querySelector("button") as HTMLButtonElement).click());
 		expect(onReviewDevices).toHaveBeenCalledOnce();
+	});
+
+	it("renders only server-provided Team setup statuses and opens the selected opaque candidate", () => {
+		const onOpenTeamSetup = vi.fn();
+		mount(intent(), {
+			onOpenTeamSetup,
+			teamSetupUnavailable: true,
+			teamSetupSummary: {
+				version: 1,
+				candidates: [
+					{
+						candidateRef: "candidate-needs",
+						displayName: "Needs Team",
+						status: "stale",
+						deviceCount: 8,
+						projectCount: 2,
+						unresolvedDeviceCount: 0,
+						unresolvedProjectCount: 0,
+					},
+					{
+						candidateRef: "candidate-progress",
+						displayName: "Progress Team",
+						status: "in_progress",
+						deviceCount: 0,
+						projectCount: 0,
+						unresolvedDeviceCount: 0,
+						unresolvedProjectCount: 0,
+					},
+					{
+						candidateRef: "candidate-ready",
+						displayName: "Ready Team",
+						status: "ready",
+						deviceCount: 0,
+						projectCount: 0,
+						unresolvedDeviceCount: 5,
+						unresolvedProjectCount: 5,
+					},
+				],
+			},
+		});
+
+		const overview = document.querySelector<HTMLElement>(
+			'[aria-labelledby="sharing-team-setup-heading"]',
+		);
+		expect(overview?.textContent).toContain("2 Teams need setup");
+		expect(overview?.textContent).toContain(
+			"Tell Codemem who uses each device before using these Teams for sharing.",
+		);
+		expect(document.body.textContent).toContain(
+			"Team setup status is temporarily unavailable. The previous Team setup status is being shown.",
+		);
+		expect(overview?.textContent).toContain("Needs Team — Needs setup");
+		expect(overview?.textContent).toContain("Progress Team — In progress");
+		expect(overview?.textContent).toContain("Ready Team — Ready");
+		expect(overview?.textContent).not.toContain("5 unresolved");
+		expect(
+			[...document.querySelectorAll<HTMLElement>(".project-status-badge")].map((badge) => [
+				badge.textContent,
+				badge.className,
+			]),
+		).toEqual([
+			["Needs setup", "project-status-badge needs_attention"],
+			["In progress", "project-status-badge suggested"],
+			["Ready", "project-status-badge"],
+		]);
+		const buttons = overview?.querySelectorAll<HTMLButtonElement>("button") ?? [];
+		expect(buttons).toHaveLength(2);
+		expect([...buttons].map((button) => button.getAttribute("aria-label"))).toEqual([
+			"Continue setup for Needs Team",
+			"Continue setup for Progress Team",
+		]);
+		act(() => buttons[1]?.click());
+		expect(onOpenTeamSetup).toHaveBeenCalledWith("candidate-progress");
+	});
+
+	it("shows Team setup unavailability without inventing candidates on first load", () => {
+		mount(intent(), { teamSetupUnavailable: true });
+
+		const status = [...document.querySelectorAll<HTMLElement>('[role="status"]')].find(
+			(item) => item.textContent === "Team setup status is temporarily unavailable.",
+		);
+		expect(status?.getAttribute("aria-live")).toBe("polite");
+		expect(document.getElementById("sharing-team-setup-heading")).toBeNull();
+		expect(document.querySelector(".project-status-badge")).toBeNull();
+	});
+
+	it("labels cached Team setup status as previous while refreshing", () => {
+		mount(intent(), {
+			teamSetupLoading: true,
+			teamSetupSummary: { version: 1, candidates: [] },
+		});
+
+		const status = [...document.querySelectorAll<HTMLElement>('[role="status"]')].find(
+			(item) =>
+				item.textContent ===
+				"Team setup status is being refreshed. The previous Team setup status is being shown.",
+		);
+		expect(status?.getAttribute("aria-live")).toBe("polite");
+	});
+
+	it("labels first-load Team setup discovery as loading without claiming stale status", () => {
+		mount(intent(), { teamSetupLoading: true });
+
+		const status = [...document.querySelectorAll<HTMLElement>('[role="status"]')].find(
+			(item) => item.textContent === "Team setup status is loading.",
+		);
+		expect(status?.getAttribute("aria-live")).toBe("polite");
+		expect(document.body.textContent).not.toContain("previous Team setup status");
+	});
+
+	it("fails an unknown runtime Team setup status closed to Needs setup", () => {
+		const teamSetupSummary = {
+			version: 1,
+			candidates: [
+				{
+					candidateRef: "candidate-future",
+					displayName: "Future Team",
+					status: "future_status",
+					deviceCount: 1,
+					projectCount: 1,
+					unresolvedDeviceCount: 0,
+					unresolvedProjectCount: 0,
+				},
+			],
+		} as unknown as LegacyTeamSetupSummaryResponseV1;
+
+		mount(intent(), { teamSetupSummary });
+
+		const badge = document.querySelector<HTMLElement>(".project-status-badge");
+		expect(badge?.textContent).toBe("Needs setup");
+		expect(badge?.className).toBe("project-status-badge needs_attention");
+		expect(document.getElementById("sharing-team-setup-heading")?.textContent).toBe(
+			"1 Team needs setup",
+		);
 	});
 
 	it("uses visible labels, responsive and target hooks, and no prohibited internal copy", () => {

--- a/packages/ui/src/tabs/recipient-policy-sharing.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.tsx
@@ -1,7 +1,13 @@
 import { render } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
 import { LoadingCardList } from "../components/LoadingCardList";
-import type { DeviceIdentityInventoryV1, RecipientPolicyIntentGraphV1 } from "../lib/api/sync";
+import type {
+	DeviceIdentityInventoryV1,
+	LegacyTeamSetupCandidateSummaryV1,
+	LegacyTeamSetupStatusV1,
+	LegacyTeamSetupSummaryResponseV1,
+	RecipientPolicyIntentGraphV1,
+} from "../lib/api/sync";
 import { deviceIdentityAttentionItems } from "../lib/device-identity-inventory";
 import { RecipientPolicyInvitations } from "./recipient-policy-invitations";
 import {
@@ -17,8 +23,86 @@ export interface RecipientPolicySharingOptions {
 	deviceInventoryUnavailable?: boolean;
 	received?: ReceivedProjectShare[];
 	deviceInventory?: DeviceIdentityInventoryV1;
+	onOpenTeamSetup?: (candidateRef: string) => void;
 	onReviewDevices?: (deviceId?: string) => void;
 	coordinatorEnrollmentIssueCount?: number;
+	teamSetupSummary?: LegacyTeamSetupSummaryResponseV1;
+	teamSetupLoading?: boolean;
+	teamSetupUnavailable?: boolean;
+}
+
+const TEAM_SETUP_STATUS_LABELS: Record<LegacyTeamSetupStatusV1, string> = {
+	needs_setup: "Needs setup",
+	in_progress: "In progress",
+	stale: "Needs setup",
+	ready: "Ready",
+};
+
+const TEAM_SETUP_STATUS_CLASSES: Record<LegacyTeamSetupStatusV1, string> = {
+	needs_setup: "needs_attention",
+	in_progress: "suggested",
+	stale: "needs_attention",
+	ready: "",
+};
+
+function teamSetupStatusLabel(status: unknown): string {
+	return typeof status === "string" && Object.hasOwn(TEAM_SETUP_STATUS_LABELS, status)
+		? TEAM_SETUP_STATUS_LABELS[status as LegacyTeamSetupStatusV1]
+		: "Needs setup";
+}
+
+function teamSetupStatusClass(status: unknown): string {
+	return typeof status === "string" && Object.hasOwn(TEAM_SETUP_STATUS_CLASSES, status)
+		? TEAM_SETUP_STATUS_CLASSES[status as LegacyTeamSetupStatusV1]
+		: "needs_attention";
+}
+
+function TeamSetupOverview({
+	candidates,
+	onOpenTeamSetup,
+}: {
+	candidates: LegacyTeamSetupCandidateSummaryV1[];
+	onOpenTeamSetup?: (candidateRef: string) => void;
+}) {
+	if (candidates.length === 0) return null;
+	const pending = candidates.filter((candidate) => candidate.status !== "ready");
+	return (
+		<aside
+			aria-labelledby="sharing-team-setup-heading"
+			className="peer-card peer-card--padded recipient-policy-sharing-attention"
+		>
+			<h3 id="sharing-team-setup-heading">
+				{pending.length > 0
+					? `${pending.length} ${pending.length === 1 ? "Team needs" : "Teams need"} setup`
+					: "Team setup"}
+			</h3>
+			{pending.length > 0 ? (
+				<p>Tell Codemem who uses each device before using these Teams for sharing.</p>
+			) : null}
+			<ul className="recipient-policy-sharing-details" aria-label="Team setup status">
+				{candidates.map((candidate) => (
+					<li key={candidate.candidateRef}>
+						<strong>{candidate.displayName}</strong> —{` `}
+						<span
+							className={`project-status-badge ${teamSetupStatusClass(candidate.status)}`.trim()}
+						>
+							{teamSetupStatusLabel(candidate.status)}
+						</span>
+						{candidate.status !== "ready" && onOpenTeamSetup ? (
+							<button
+								aria-label={`Continue setup for ${candidate.displayName}`}
+								className="settings-button recipient-policy-sharing-target-24"
+								onClick={() => onOpenTeamSetup(candidate.candidateRef)}
+								type="button"
+							>
+								Continue setup
+							</button>
+						) : null}
+					</li>
+				))}
+			</ul>
+		</aside>
+	);
 }
 
 type SharingTab = "teams" | "identities" | "received" | "invitations";
@@ -425,6 +509,24 @@ function RecipientPolicySharing({
 					changes.
 				</p>
 			</header>
+			<TeamSetupOverview
+				candidates={options.teamSetupSummary?.candidates ?? []}
+				onOpenTeamSetup={options.onOpenTeamSetup}
+			/>
+			{options.teamSetupLoading ? (
+				<p aria-live="polite" className="small recipient-policy-sharing-empty" role="status">
+					{options.teamSetupSummary
+						? "Team setup status is being refreshed. The previous Team setup status is being shown."
+						: "Team setup status is loading."}
+				</p>
+			) : null}
+			{options.teamSetupUnavailable ? (
+				<p aria-live="polite" className="small recipient-policy-sharing-empty" role="status">
+					{options.teamSetupSummary
+						? "Team setup status is temporarily unavailable. The previous Team setup status is being shown."
+						: "Team setup status is temporarily unavailable."}
+				</p>
+			) : null}
 			{options.deviceInventoryUnavailable ? (
 				<p aria-live="polite" className="small recipient-policy-sharing-empty" role="status">
 					Device Identity information is unavailable. Devices needing setup or review cannot be


### PR DESCRIPTION
## Description

Loads the optional Team setup summary into Sharing and renders server-derived setup status and counts. Summary failures preserve the last successful state, complete load failures keep setup context visible, and unknown runtime statuses fail closed to unavailable.

The setup CTA remains intentionally hidden until the guided dialog lands in `codemem-0izz.7`. Tracks `codemem-0izz.6`.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused branch validation: 28 Sharing tests, UI typecheck, and repository lint. Full stack validation: `pnpm run check` with 5,181 passed and 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (deferred until the guided workflow is complete)
- [x] No new warnings introduced