### PR TITLE
feat(ui): link Projects to Team setup

### DIFF
--- a/packages/ui/src/app-devices.test.tsx
+++ b/packages/ui/src/app-devices.test.tsx
@@ -251,6 +251,19 @@ describe("Devices app integration", () => {
 		expect(document.activeElement).toBe(document.getElementById("tabBtn-sharing"));
 	});
 
+	it("injects Projects navigation to the canonical Sharing setup overview", async () => {
+		const { initProjectsTab } = await import("./tabs/projects");
+		const options = vi.mocked(initProjectsTab).mock.calls[0]?.[1];
+		expect(options?.onOpenTeamSetup).toEqual(expect.any(Function));
+
+		act(() => options?.onOpenTeamSetup?.("opaque-candidate-ref"));
+		await Promise.resolve();
+
+		expect(window.location.hash).toBe("#sharing");
+		expect(document.getElementById("tab-sharing")?.hidden).toBe(false);
+		expect(document.activeElement).toBe(document.getElementById("tabBtn-sharing"));
+	});
+
 	it("keeps existing device details usable when inventory fails on the first Devices load", () => {
 		const panel = document.getElementById("tab-devices");
 		expect(panel?.textContent).toContain("Work Laptop");

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -487,6 +487,13 @@ function reviewDevicesFromSharing(deviceId?: string) {
 	switchTab("devices", { canonicalHash: true });
 }
 
+function openTeamSetupOverviewFromProjects() {
+	switchTab("sharing", { canonicalHash: true });
+	queueMicrotask(() => document.getElementById("tabBtn-sharing")?.focus());
+}
+
+// The Projects entry routes to Sharing's server-derived status overview. The
+// Sharing-to-dialog callback remains intentionally unwired until .7.
 const loadRecipientPolicySharingData = createRecipientPolicySharingLoader(
 	{},
 	{
@@ -794,7 +801,7 @@ initTabs();
 // Tab modules
 initFeedTab();
 initHealthTab();
-initProjectsTab(() => refresh());
+initProjectsTab(() => refresh(), { onOpenTeamSetup: openTeamSetupOverviewFromProjects });
 initSyncTab(() => refresh());
 initCoordinatorAdminTab();
 initSettings(stopPolling, startPolling, () => refresh());

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -6,6 +6,7 @@ vi.mock("../lib/api", () => ({
 	loadProjects: vi.fn(),
 	loadCoordinatorAdminGroupsFiltered: vi.fn(),
 	loadCoordinatorAdminStatus: vi.fn(),
+	loadLegacyTeamSetupSummary: vi.fn(),
 	loadProjectScopeInventory: vi.fn(),
 	loadRecipientPolicyIntent: vi.fn(),
 	loadRecipientPolicyReview: vi.fn(),
@@ -68,6 +69,7 @@ vi.mock("./sync/sync-dialogs", () => ({ openSyncInputDialog: vi.fn() }));
 
 import * as api from "../lib/api";
 import type {
+	LegacyTeamSetupSummaryResponseV1,
 	ProjectScopeInventoryProject,
 	ProjectScopeInventoryResult,
 	RecipientPolicyIntentGraphV1,
@@ -282,6 +284,7 @@ describe("Projects tab", () => {
 			version: 1,
 		});
 		vi.mocked(api.loadRecipientPolicyIntent).mockResolvedValue(recipientIntent());
+		vi.mocked(api.loadLegacyTeamSetupSummary).mockResolvedValue({ version: 1, candidates: [] });
 		vi.mocked(api.resolveRecipientPolicyReview).mockResolvedValue({
 			errorCode: null,
 			idempotent: false,
@@ -371,6 +374,200 @@ describe("Projects tab", () => {
 		expect(surface?.textContent).toContain("Assign a stable canonical Project identity");
 		expect(surface?.querySelector("button, select")).toBeNull();
 		expect(document.querySelectorAll(".recipient-policy-review-item")).toHaveLength(0);
+	});
+
+	it("routes an unfinished server Team candidate into guided setup without resolving recipient review", async () => {
+		const onOpenTeamSetup = vi.fn();
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [],
+			total: 0,
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(recipientReview());
+		vi.mocked(api.loadLegacyTeamSetupSummary).mockResolvedValue({
+			version: 1,
+			candidates: [
+				{
+					candidateRef: "opaque-candidate-ref",
+					displayName: "Example Team",
+					status: "in_progress",
+					deviceCount: 2,
+					projectCount: 1,
+					unresolvedDeviceCount: 1,
+					unresolvedProjectCount: 0,
+				},
+			],
+		});
+
+		initProjectsTab(() => {}, { onOpenTeamSetup });
+		await loadProjectsData();
+		const entry = document.querySelector<HTMLElement>(".project-team-setup-entry");
+		expect(entry?.textContent).toContain("Finish setting up this Team");
+		expect(entry?.textContent).toContain("Example Team");
+		expect(entry?.querySelector("button")?.getAttribute("aria-label")).toBe(
+			"Finish setting up Example Team",
+		);
+		entry?.querySelector<HTMLButtonElement>("button")?.click();
+
+		expect(onOpenTeamSetup).toHaveBeenCalledWith("opaque-candidate-ref");
+		expect(api.resolveRecipientPolicyReview).not.toHaveBeenCalled();
+		expect(recipientPolicyManagement.openRecipientPolicyManagement).not.toHaveBeenCalled();
+	});
+
+	it("preserves the focused Team setup action while a refresh discovery is pending", async () => {
+		const summary = {
+			version: 1 as const,
+			candidates: [
+				{
+					candidateRef: "opaque-candidate-ref",
+					displayName: "Example Team",
+					status: "in_progress" as const,
+					deviceCount: 2,
+					projectCount: 1,
+					unresolvedDeviceCount: 1,
+					unresolvedProjectCount: 0,
+				},
+			],
+		};
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [],
+			total: 0,
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(recipientReview());
+		vi.mocked(api.loadLegacyTeamSetupSummary).mockResolvedValueOnce(summary);
+		initProjectsTab(() => {}, { onOpenTeamSetup: vi.fn() });
+
+		await loadProjectsData();
+		const entry = document.querySelector<HTMLElement>(".project-team-setup-entry");
+		const button = entry?.querySelector<HTMLButtonElement>("button");
+		button?.focus();
+		let resolveSummary!: (value: typeof summary) => void;
+		vi.mocked(api.loadLegacyTeamSetupSummary).mockImplementationOnce(
+			() => new Promise((resolve) => (resolveSummary = resolve)),
+		);
+
+		await loadProjectsData();
+
+		expect(document.querySelector(".project-team-setup-entry")).toBe(entry);
+		expect(button?.isConnected).toBe(true);
+		expect(document.activeElement).toBe(button);
+
+		resolveSummary(summary);
+		await vi.waitFor(() => expect(api.loadLegacyTeamSetupSummary).toHaveBeenCalledTimes(2));
+		await flushAsyncWork();
+		expect(document.querySelector(".project-team-setup-entry")).toBe(entry);
+		expect(document.activeElement).toBe(button);
+
+		vi.mocked(api.loadLegacyTeamSetupSummary).mockRejectedValueOnce(
+			new Error("temporary discovery failure"),
+		);
+		await loadProjectsData();
+		await vi.waitFor(() => expect(api.loadLegacyTeamSetupSummary).toHaveBeenCalledTimes(3));
+		await flushAsyncWork();
+		expect(document.querySelector(".project-team-setup-entry")).toBe(entry);
+		expect(entry?.querySelector('[role="status"]')?.textContent).toBe(
+			"Team setup status is temporarily unavailable. The previous Team setup status is being shown.",
+		);
+		expect(document.activeElement).toBe(button);
+
+		vi.mocked(api.loadLegacyTeamSetupSummary).mockResolvedValueOnce({
+			version: 1,
+			candidates: [],
+		});
+		await loadProjectsData();
+		await vi.waitFor(() => expect(document.querySelector(".project-team-setup-entry")).toBeNull());
+		expect(document.activeElement).toBe(document.getElementById("projectsSearch"));
+	});
+
+	it("keeps Projects usable when guided Team setup discovery is unavailable", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		});
+		vi.mocked(api.loadLegacyTeamSetupSummary).mockRejectedValue(new Error("setup unavailable"));
+
+		await loadProjectsData();
+
+		expect(document.body.textContent).toContain("api");
+		expect(document.querySelector(".project-team-setup-entry")).toBeNull();
+		expect(document.getElementById("projectsInventoryMeta")?.textContent).toContain(
+			"1 project identity found",
+		);
+	});
+
+	it("renders Projects before optional Team setup discovery finishes", async () => {
+		let resolveTeamSetup!: (value: { version: 1; candidates: [] }) => void;
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		});
+		vi.mocked(api.loadLegacyTeamSetupSummary).mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveTeamSetup = resolve;
+				}),
+		);
+
+		const loading = loadProjectsData();
+		await vi.waitFor(() =>
+			expect(document.getElementById("projectsInventoryMeta")?.textContent).toContain(
+				"1 project identity found",
+			),
+		);
+		await loading;
+		expect(document.querySelector(".project-team-setup-entry")).toBeNull();
+
+		resolveTeamSetup({ version: 1, candidates: [] });
+	});
+
+	it("reuses slow Team setup discovery across polling generations", async () => {
+		let resolveTeamSetup!: (value: LegacyTeamSetupSummaryResponseV1) => void;
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		});
+		vi.mocked(api.loadLegacyTeamSetupSummary).mockImplementation(
+			() => new Promise((resolve) => (resolveTeamSetup = resolve)),
+		);
+
+		await loadProjectsData();
+		await loadProjectsData();
+		await loadProjectsData();
+		expect(api.loadLegacyTeamSetupSummary).toHaveBeenCalledTimes(1);
+
+		resolveTeamSetup({
+			version: 1,
+			candidates: [
+				{
+					candidateRef: "opaque-candidate-ref",
+					displayName: "Slow Team",
+					status: "needs_setup",
+					deviceCount: 1,
+					projectCount: 1,
+					unresolvedDeviceCount: 1,
+					unresolvedProjectCount: 0,
+				},
+			],
+		});
+		await vi.waitFor(() =>
+			expect(document.querySelector(".project-team-setup-entry")?.textContent).toContain(
+				"Slow Team",
+			),
+		);
 	});
 
 	it("preserves the continuity surface across an unchanged refresh", async () => {

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -1,5 +1,6 @@
 import * as api from "../lib/api";
 import type {
+	LegacyTeamSetupSummaryResponseV1,
 	ProjectScopeGuardrailWarning,
 	ProjectScopeInventoryProject,
 	RecipientPolicyIntentGraphV1,
@@ -55,6 +56,10 @@ let skippedProjectRefreshForActiveSelect = false;
 let coordinatorGroupNamesCurrent = false;
 let projectShareInventoryReady = false;
 let projectsLoadGeneration = 0;
+type TeamSetupSummaryResult =
+	| { ok: true; summary: LegacyTeamSetupSummaryResponseV1 }
+	| { ok: false };
+let teamSetupSummaryInFlight: Promise<TeamSetupSummaryResult> | null = null;
 const selectedProjectIds = new Set<string>();
 const selectionIdsByCheckbox = new WeakMap<HTMLInputElement, string[]>();
 const emptyRecipientPolicyIntent: RecipientPolicyIntentGraphV1 = {
@@ -67,6 +72,20 @@ const emptyRecipientPolicyIntent: RecipientPolicyIntentGraphV1 = {
 };
 let recipientPolicyIntent = emptyRecipientPolicyIntent;
 let recipientPolicyIntentReady = false;
+let openTeamSetup: ((candidateRef: string) => void) | undefined;
+
+function loadTeamSetupSummaryOnce(): Promise<TeamSetupSummaryResult> {
+	if (teamSetupSummaryInFlight) return teamSetupSummaryInFlight;
+	const request = api
+		.loadLegacyTeamSetupSummary()
+		.then((summary) => ({ ok: true as const, summary }))
+		.catch(() => ({ ok: false as const }));
+	teamSetupSummaryInFlight = request;
+	void request.then(() => {
+		if (teamSetupSummaryInFlight === request) teamSetupSummaryInFlight = null;
+	});
+	return request;
+}
 
 function el<T extends HTMLElement>(id: string): T | null {
 	return document.getElementById(id) as T | null;
@@ -1257,6 +1276,104 @@ function mountProjectRecipientManagement(
 	});
 }
 
+function renderProjectTeamSetupEntry(
+	mount: HTMLElement,
+	summary: LegacyTeamSetupSummaryResponseV1 | undefined,
+) {
+	const candidates = summary?.candidates.filter((candidate) => candidate.status !== "ready") ?? [];
+	const existingEntry = mount.querySelector<HTMLElement>(":scope > .project-team-setup-entry");
+	existingEntry?.querySelector(".project-team-setup-status")?.remove();
+	const focusedCandidateRef = existingEntry?.contains(document.activeElement)
+		? document.activeElement instanceof HTMLButtonElement
+			? document.activeElement.dataset.teamSetupCandidateRef
+			: undefined
+		: undefined;
+	if (candidates.length === 0) {
+		existingEntry?.remove();
+		const reviewContent = mount.querySelector<HTMLElement>(
+			":scope > .project-recipient-policy-review-content",
+		);
+		mount.hidden = reviewContent?.hidden !== false;
+		if (focusedCandidateRef) el<HTMLInputElement>("projectsSearch")?.focus();
+		return;
+	}
+	const signature = JSON.stringify(
+		candidates.map((candidate) => [candidate.candidateRef, candidate.displayName]),
+	);
+	if (existingEntry?.dataset.teamSetupSignature === signature) {
+		mount.hidden = false;
+		return;
+	}
+	existingEntry?.remove();
+	mount.hidden = false;
+	const surface = document.createElement("section");
+	surface.className = "card project-team-setup-entry";
+	surface.dataset.teamSetupSignature = signature;
+	const heading = document.createElement("h2");
+	heading.textContent = "Finish setting up this Team";
+	const detail = document.createElement("p");
+	detail.className = "section-meta";
+	detail.textContent =
+		"Tell Codemem who uses each device before using this Team for Project sharing.";
+	surface.append(heading, detail);
+	for (const candidate of candidates) {
+		const row = document.createElement("div");
+		row.className = "project-inventory-actions";
+		const label = document.createElement("strong");
+		label.textContent = candidate.displayName;
+		row.appendChild(label);
+		if (openTeamSetup) {
+			const button = document.createElement("button");
+			button.setAttribute("aria-label", `Finish setting up ${candidate.displayName}`);
+			button.className = "settings-button";
+			button.type = "button";
+			button.textContent = "Finish setting up this Team";
+			button.dataset.teamSetupCandidateRef = candidate.candidateRef;
+			button.addEventListener("click", () => openTeamSetup?.(candidate.candidateRef));
+			row.appendChild(button);
+		}
+		surface.appendChild(row);
+	}
+	mount.appendChild(surface);
+	if (focusedCandidateRef) {
+		let restored = false;
+		for (const button of surface.querySelectorAll<HTMLButtonElement>("button")) {
+			if (button.dataset.teamSetupCandidateRef === focusedCandidateRef) {
+				button.focus();
+				restored = true;
+				break;
+			}
+		}
+		if (!restored) el<HTMLInputElement>("projectsSearch")?.focus();
+	}
+}
+
+function markProjectTeamSetupEntryUnavailable(mount: HTMLElement) {
+	const existingEntry = mount.querySelector<HTMLElement>(":scope > .project-team-setup-entry");
+	if (!existingEntry) return;
+	let status = existingEntry.querySelector<HTMLElement>(".project-team-setup-status");
+	if (!status) {
+		status = document.createElement("p");
+		status.className = "section-meta project-team-setup-status";
+		status.setAttribute("role", "status");
+		existingEntry.appendChild(status);
+	}
+	status.textContent =
+		"Team setup status is temporarily unavailable. The previous Team setup status is being shown.";
+	mount.hidden = false;
+}
+
+function recipientPolicyReviewContentMount(mount: HTMLElement): HTMLElement {
+	const existing = mount.querySelector<HTMLElement>(
+		":scope > .project-recipient-policy-review-content",
+	);
+	if (existing) return existing;
+	const content = document.createElement("div");
+	content.className = "project-recipient-policy-review-content";
+	mount.prepend(content);
+	return content;
+}
+
 export async function loadProjectsData() {
 	const meta = el<HTMLDivElement>("projectsInventoryMeta");
 	const list = el<HTMLDivElement>("projectsInventoryList");
@@ -1272,6 +1389,7 @@ export async function loadProjectsData() {
 	updateSelectionControls();
 	meta.textContent = "Loading project inventory…";
 	try {
+		const teamSetupSummaryPromise = loadTeamSetupSummaryOnce();
 		const [result, settings, shareInventory, recipientPolicyReview, intentResult] =
 			await Promise.all([
 				api.loadProjectScopeInventory({
@@ -1317,11 +1435,14 @@ export async function loadProjectsData() {
 		}
 		const reviewMount = el<HTMLDivElement>("recipientPolicyReviewMount");
 		if (reviewMount) {
+			const reviewContent = recipientPolicyReviewContentMount(reviewMount);
 			if ("review" in recipientPolicyReview) {
-				renderRecipientPolicyReview(reviewMount, recipientPolicyReview.review);
+				renderRecipientPolicyReview(reviewContent, recipientPolicyReview.review);
 			} else {
-				renderRecipientPolicyReviewLoadError(reviewMount, recipientPolicyReview.error);
+				renderRecipientPolicyReviewLoadError(reviewContent, recipientPolicyReview.error);
 			}
+			reviewMount.hidden =
+				reviewContent.hidden && !reviewMount.querySelector(".project-team-setup-entry");
 		}
 		mountProjectRecipientManagement(
 			shareInventory.projects,
@@ -1330,6 +1451,16 @@ export async function loadProjectsData() {
 		);
 		renderProjectInventory(result);
 		refreshProjectCoordinatorGroupNamesInBackground(result, loadGeneration);
+		void teamSetupSummaryPromise.then((teamSetupSummary) => {
+			if (loadGeneration !== projectsLoadGeneration) return;
+			const currentReviewMount = el<HTMLDivElement>("recipientPolicyReviewMount");
+			if (!currentReviewMount) return;
+			if (!teamSetupSummary.ok) {
+				markProjectTeamSetupEntryUnavailable(currentReviewMount);
+				return;
+			}
+			renderProjectTeamSetupEntry(currentReviewMount, teamSetupSummary.summary);
+		});
 	} catch (error) {
 		if (loadGeneration !== projectsLoadGeneration) return;
 		projectShareInventoryReady = false;
@@ -1345,8 +1476,12 @@ export async function loadProjectsData() {
 	}
 }
 
-export function initProjectsTab(refresh: RefreshFn) {
+export function initProjectsTab(
+	refresh: RefreshFn,
+	options: { onOpenTeamSetup?: (candidateRef: string) => void } = {},
+) {
 	refreshProjects = refresh;
+	openTeamSetup = options.onOpenTeamSetup;
 	selectedProjectIds.clear();
 	const status = el<HTMLSelectElement>("projectsStatusFilter");
 	if (status && status.options.length === 0) {


### PR DESCRIPTION
## Description

Adds the Team setup entry point to Projects and routes it through the existing accessible tab path to the canonical Sharing overview. Navigation does not invoke `choose_recipients`; the interactive setup dialog remains deferred to `codemem-0izz.7`.

Tracks `codemem-0izz.6`.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused stack-tip validation: 108 UI tests, UI typecheck/build, and repository lint. Full validation: `pnpm run check` with 5,181 passed and 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (deferred until the guided workflow is complete)
- [x] No new warnings introduced