### PR TITLE
perf(team-setup): bound candidate metadata loading

### DIFF
--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -156,6 +156,35 @@ describe("project scope settings", () => {
 		);
 	});
 
+	it("fails closed when candidate mapping metadata exceeds its row budget", () => {
+		const insert = db.prepare(
+			`INSERT INTO project_scope_mappings(
+				workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, ?, ?, 1000, 'user', ?, ?)`,
+		);
+		for (const name of ["one", "two", "three"]) {
+			insert.run(
+				`unmapped:${name}`,
+				name,
+				LOCAL_DEFAULT_SCOPE_ID,
+				"2026-05-06T00:00:00Z",
+				"2026-05-06T00:00:00Z",
+			);
+		}
+
+		expect(() => listProjectScopeCandidates(db, { maxMetadataRows: 2 })).toThrow(
+			"project_scope_candidate_metadata_too_large",
+		);
+	});
+
+	it("fails closed when active Sharing-domain metadata exceeds its row budget", () => {
+		insertScope(db, { scopeId: "scope-extra", label: "Extra" });
+
+		expect(() => listProjectScopeCandidates(db, { maxMetadataRows: 2 })).toThrow(
+			"project_scope_candidate_metadata_too_large",
+		);
+	});
+
 	it("excludes peer-received sessions from locally manageable candidates", () => {
 		insertSession(db, { project: "local", gitRemote: "https://example.invalid/local.git" });
 		insertSession(db, {

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -593,7 +593,14 @@ export function listSharingDomainSettingsScopes(db: Database): SharingDomainSett
 
 export function listProjectScopeSettingsMappings(db: Database): ProjectScopeSettingsMapping[] {
 	ensureScopeBackfillScopes(db);
-	const scopesById = scopeLookup(listSharingDomainSettingsScopes(db));
+	return listProjectScopeSettingsMappingsForScopes(db, listSharingDomainSettingsScopes(db));
+}
+
+function listProjectScopeSettingsMappingsForScopes(
+	db: Database,
+	scopes: SharingDomainSettingsScope[],
+): ProjectScopeSettingsMapping[] {
+	const scopesById = scopeLookup(scopes);
 	return db
 		.prepare(
 			`SELECT id, workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
@@ -884,6 +891,7 @@ export function listProjectScopeCandidates(
 	options: {
 		limit?: number | null;
 		maxScannedRows?: number;
+		maxMetadataRows?: number;
 		excludePeerReceived?: boolean;
 	} = {},
 ): ProjectScopeCandidate[] {
@@ -897,9 +905,20 @@ export function listProjectScopeCandidates(
 	) {
 		throw new Error("project_scope_candidate_scan_too_large");
 	}
+	const maxMetadataRows =
+		options.maxMetadataRows == null ? null : Math.max(1, Math.floor(options.maxMetadataRows));
+	if (
+		maxMetadataRows != null &&
+		(db.prepare("SELECT 1 FROM project_scope_mappings LIMIT 1 OFFSET ?").get(maxMetadataRows) ||
+			db
+				.prepare("SELECT 1 FROM replication_scopes WHERE status = 'active' LIMIT 1 OFFSET ?")
+				.get(maxMetadataRows))
+	) {
+		throw new Error("project_scope_candidate_metadata_too_large");
+	}
 	const queryLimit = limit;
-	const mappings = listProjectScopeSettingsMappings(db);
 	const scopes = listSharingDomainSettingsScopes(db);
+	const mappings = listProjectScopeSettingsMappingsForScopes(db, scopes);
 	const excludePeerReceived = options.excludePeerReceived === true;
 	const sql = `SELECT
 				s.id,

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1271,6 +1271,74 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("fails closed when Project mapping metadata exceeds its row budget", async () => {
+			const { app, ensureStore, cleanup } = createTestApp({
+				loadLegacyTeamConfiguredGroupSnapshots: async () => snapshots,
+			});
+			try {
+				const store = ensureStore();
+				core.listSharingDomainSettingsScopes(store.db);
+				const insert = store.db.prepare(
+					`INSERT INTO project_scope_mappings(
+						workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+					 ) VALUES (?, ?, ?, 1000, 'user', ?, ?)`,
+				);
+				store.db.transaction(() => {
+					for (let index = 0; index < 10_001; index += 1) {
+						const identity = `unmapped:overflow-${index}`;
+						insert.run(
+							identity,
+							identity,
+							core.LOCAL_DEFAULT_SCOPE_ID,
+							"2026-08-24T00:00:00.000Z",
+							"2026-08-24T00:00:00.000Z",
+						);
+					}
+				})();
+				const sourceIdentity = "unmapped:source-project";
+				const projectRef = core.recipientPolicyDigest("legacy-team-project-ref-v1", [
+					candidateRef,
+					sourceIdentity,
+				]);
+				const draft = core.refreshLegacyTeamSetupDraft(store.db, {
+					candidateId: candidateRef,
+					coordinatorId,
+					groupId,
+					displayName: "Migration Team",
+					devices: snapshots[0]?.devices ?? [],
+					projects: [
+						{
+							projectRef,
+							sourceProjectIdentity: sourceIdentity,
+							displayName: "Source Project",
+							sourceFingerprint: "source-fingerprint",
+							deterministicProjectIdentity: null,
+						},
+					],
+				});
+
+				const response = await app.request(
+					`/api/sync/team-setup/v1/${candidateRef}/projects/${projectRef}/mapping`,
+					{
+						method: "PUT",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({
+							attemptId: draft.attemptId,
+							resolvedProjectRef: core.legacyTeamResolvedProjectRef(
+								projectRef,
+								"unmapped:overflow-0",
+							),
+						}),
+					},
+				);
+
+				expect(response.status).toBe(503);
+				expect(await response.json()).toEqual({ error: "team_setup_roster_unavailable" });
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("normalizes scheme-less coordinator URLs before admin roster requests", async () => {
 			const config = {
 				...core.readCoordinatorSyncConfig({}),

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -45,6 +45,7 @@ const MAX_COMPLETED_IDENTITY_CHOICES = MAX_DEVICES * 4;
 const MAX_PROJECT_MAPPING_CHOICES = 500;
 const MAX_TOTAL_PROJECT_MAPPING_CHOICES = 10_000;
 const MAX_PROJECT_MAPPING_SCAN_ROWS = 10_000;
+const MAX_PROJECT_MAPPING_METADATA_ROWS = 10_000;
 const MAX_MUTATION_BODY_BYTES = 8_192;
 const SUMMARY_SNAPSHOT_CACHE_TTL_MS = 30_000;
 export const TEAM_SETUP_ROUTE_PREFIX = "/api/sync/team-setup/v1";
@@ -664,6 +665,7 @@ function projectMappingChoices(store: MemoryStore): ProjectMappingChoiceInternal
 		candidates = listProjectScopeCandidates(store.db, {
 			limit: null,
 			maxScannedRows: MAX_PROJECT_MAPPING_SCAN_ROWS,
+			maxMetadataRows: MAX_PROJECT_MAPPING_METADATA_ROWS,
 			excludePeerReceived: true,
 		}).filter(
 			(candidate) =>
@@ -671,7 +673,11 @@ function projectMappingChoices(store: MemoryStore): ProjectMappingChoiceInternal
 				isLegacyTeamSetupProjectMappingIdentity(candidate.workspace_identity),
 		);
 	} catch (error) {
-		if (error instanceof Error && error.message === "project_scope_candidate_scan_too_large") {
+		if (
+			error instanceof Error &&
+			(error.message === "project_scope_candidate_scan_too_large" ||
+				error.message === "project_scope_candidate_metadata_too_large")
+		) {
 			throw new Error("legacy_team_setup_roster_too_large");
 		}
 		throw error;


### PR DESCRIPTION
## Description

Bounds the mapping metadata loaded while building Team setup Project choices. Candidate discovery now:

- rejects mapping or active Sharing-domain metadata above an explicit 10,000-row budget before materialization
- loads active scopes once for mapping resolution
- maps metadata overflow to the existing safe team_setup_roster_unavailable API response
- covers mapping overflow, scope overflow, and the end-to-end API error contract

Tracks and closes codemem-38ed.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (pnpm run check)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (not needed; no user-facing contract change)
- [x] No new warnings introduced