### PR TITLE
feat(ui): add Team setup dialog host

### DIFF
--- a/docs/plans/2026-08-25-legacy-team-setup-dialog-design.md
+++ b/docs/plans/2026-08-25-legacy-team-setup-dialog-design.md
@@ -1,0 +1,131 @@
+# Legacy Team Setup Dialog Design
+
+**Status:** Approved for implementation on 2026-08-25
+
+## Goal
+
+Add an accessible, resumable viewer dialog that guides a user through reviewing a legacy Team before activating it as canonical Project Sharing state. The dialog must persist each decision immediately, render only server-derived migration evidence, and fail closed when the reviewed state changes.
+
+## Constraints
+
+- The server remains authoritative for setup state, available choices, readiness, access deltas, and confirmation digests.
+- The client must use opaque candidate, device, identity, Project, and resolved-Project references without deriving or decoding identifiers.
+- Assignment, decision, and Project mapping changes persist immediately. Closing or reloading the dialog must not discard completed work.
+- Unresolved devices or Projects block the review step. Missing confirmation evidence blocks finish.
+- Stale or conflicting evidence triggers a safe detail reload instead of optimistic continuation.
+- The complete server-provided access delta is rendered without filtering or client-side access calculations.
+- Existing coordinator, database, and local-path redaction guarantees remain intact.
+- Each implementation PR should stay near 800 changed lines and must split before reaching 1,000 changed lines.
+
+## Architecture
+
+The dialog uses a global host mounted alongside the existing recipient-policy management host. Sharing and Projects both call one imperative opener with an opaque candidate reference. Keeping the host outside either tab prevents polling or tab remounts from destroying in-progress dialog state.
+
+The host owns:
+
+- the active candidate reference;
+- the latest `LegacyTeamSetupDetailResponseV1`;
+- the current step;
+- load, mutation, and finish status;
+- a safe user-facing error message;
+- the element that should receive focus after close.
+
+Every successful mutation is followed by a detail reload. Mutation responses provide authoritative counts but not the complete refreshed rows or access delta, so the dialog never patches local rows optimistically.
+
+## Dialog lifecycle
+
+1. The opener records the currently focused element and opens the global dialog.
+2. The dialog focuses its heading and loads candidate detail.
+3. The current step is selected from authoritative state:
+   - unresolved device work opens the Devices step;
+   - otherwise unresolved Project work opens the Projects step;
+   - otherwise the dialog opens Review.
+4. A successful mutation reloads detail and keeps the user on the current step unless that step is complete.
+5. Closing restores focus to the connected trigger when possible, then falls back to the stable active-tab control.
+6. Reopening starts from freshly loaded server state rather than stale module state.
+
+## Step 1: Devices
+
+Each device exposes its server-provided display name, assignment evidence, decision, and available identity choices.
+
+- Existing valid assignments are shown without requiring redundant entry.
+- Changing an assignment submits the current `attemptId`, target identity reference, and exact assignment expectation.
+- Including a device submits the expected target identity reference after assignment succeeds.
+- Excluding or removing a device submits only the selected decision.
+- Clearing a decision uses the current attempt and reloads the detail.
+- Controls are disabled while their mutation is active. Duplicate submissions are rejected locally.
+- Assignment and decision remain separate persisted operations. If the second operation fails, the first remains resumable and visible after reload.
+
+The user cannot advance while `unresolvedDeviceCount` is nonzero.
+
+## Step 2: Projects
+
+Each Project displays its server-provided name and current resolution.
+
+- Deterministic mappings are read-only.
+- Ambiguous Projects offer only the server-provided opaque mapping choices.
+- Selecting a mapping submits `attemptId` and `resolvedProjectRef`, then reloads detail.
+- The UI does not infer candidate Projects from local inventory or decode mapping references.
+
+The user cannot advance while `unresolvedProjectCount` is nonzero.
+
+## Step 3: Review and finish
+
+Review is available only when `canFinish` is true and the detail includes `accessDelta`, `finishDigest`, and `accessDeltaDigest`.
+
+The UI renders every entry from the server-provided delta:
+
+- Team changes;
+- membership changes;
+- Project changes;
+- recipient changes;
+- device-access changes.
+
+Large deltas remain inside the dialog's scrollable body. No delta entry is silently collapsed or omitted from the accessible DOM.
+
+Finish requires an explicit confirmation control. Submission sends the exact `attemptId`, `finishDigest`, and confirmed access-delta digest from the currently displayed detail. Success announces completion, refreshes Sharing and Projects state, and offers a single close action.
+
+## Error and recovery behavior
+
+Errors use the stable `LegacyTeamSetupApiError` vocabulary and generic safe copy.
+
+- Stale confirmation, assignment change, projection change, or conflict: announce the change and reload detail before allowing more work.
+- Roster unavailable or bounded-data failure: retain the dialog, disable mutations, and offer retry.
+- Network or unexpected safe API failure: retain the current server-derived view and offer retry.
+- Completed setup discovered during retry: transition directly to the completion state.
+
+Raw response bodies, coordinator details, and exception text are never rendered.
+
+## Accessibility
+
+- Use the shared Radix dialog primitive for modal semantics, focus trapping, Escape handling, and background inertness.
+- Give the dialog an explicit labelled heading and description.
+- Use native buttons, radio inputs, checkboxes, fieldsets, legends, and labels.
+- Announce mutation progress politely and errors assertively without moving focus unnecessarily.
+- Move focus to the step heading after explicit step navigation and to the first invalid or unresolved group when advancement is blocked.
+- Keep visible focus indicators and at least 24 by 24 CSS pixel targets.
+- Do not use color as the only status or error indicator.
+- Prevent close only during the short interval in which a mutation or finish request is being submitted.
+- Preserve usable layout and scrolling at 200% zoom and narrow viewport widths.
+
+## Pull request slices
+
+1. **Accessible host and production wiring**
+   - Global host and opener.
+   - Loading, retry, step selection, focus restoration, and scoped styles.
+   - Sharing and Projects callback wiring.
+2. **Device decisions**
+   - Assignment, include, exclude, remove, and clear behavior.
+   - Immediate persistence, busy guards, reload, and recovery tests.
+3. **Project mappings**
+   - Deterministic presentation and explicit mapping choices.
+   - Immediate persistence, reload, and stale-state tests.
+4. **Review and finish**
+   - Complete access-delta rendering.
+   - Explicit confirmation, finish, completion refresh, and retry tests.
+
+If any slice approaches 1,000 changed lines, split rendering from mutation behavior before submission.
+
+## Validation
+
+Each PR runs focused UI tests, TypeScript, lint, and the UI build. The stack tip also runs the full workspace check. Accessibility validation includes automated semantic assertions plus manual keyboard, focus-restoration, 200% zoom, and VoiceOver checks before the migration E2E/docs slice is declared complete.

--- a/packages/ui/src/app-devices.test.tsx
+++ b/packages/ui/src/app-devices.test.tsx
@@ -7,6 +7,7 @@ import html from "../static/index.html?raw";
 const mocks = vi.hoisted(() => ({
 	loadProjectScopeInventory: vi.fn(),
 	loadDeviceIdentityInventory: vi.fn(),
+	loadLegacyTeamSetupDetail: vi.fn(),
 	loadRecipientPolicyIntent: vi.fn(),
 	loadRecipientPolicyReconciliationStatus: vi.fn(),
 	loadSyncData: vi.fn(),
@@ -14,9 +15,12 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./components/primitives/toast", () => ({ mountToastHost: vi.fn() }));
 vi.mock("./lib/api", () => ({
+	clearLegacyTeamSetupDecision: vi.fn(),
+	finishLegacyTeamSetup: vi.fn(),
 	loadCoordinatorAdminStatus: vi.fn(async () => ({ has_admin_secret: false })),
 	loadDeviceIdentityInventory: mocks.loadDeviceIdentityInventory,
 	loadLegacyTeamSetupSummary: vi.fn(async () => ({ version: 1, candidates: [] })),
+	loadLegacyTeamSetupDetail: mocks.loadLegacyTeamSetupDetail,
 	loadProjectScopeInventory: mocks.loadProjectScopeInventory,
 	loadProjects: vi.fn(async () => ["Codemem"]),
 	loadRecipientPolicyIntent: mocks.loadRecipientPolicyIntent,
@@ -24,6 +28,10 @@ vi.mock("./lib/api", () => ({
 	loadRuntimeInfo: vi.fn(async () => ({ version: "test" })),
 	loadSyncStatus: vi.fn(async () => ({})),
 	pingViewerReady: vi.fn(async () => true),
+	refreshLegacyTeamSetupCandidate: vi.fn(),
+	saveLegacyTeamSetupAssignment: vi.fn(),
+	saveLegacyTeamSetupDecision: vi.fn(),
+	saveLegacyTeamSetupProjectMapping: vi.fn(),
 }));
 vi.mock("./tabs/coordinator-admin", () => ({
 	initCoordinatorAdminTab: vi.fn(),
@@ -37,6 +45,10 @@ vi.mock("./tabs/feed", () => ({
 vi.mock("./tabs/health", () => ({
 	initHealthTab: vi.fn(),
 	loadHealthData: vi.fn(async () => undefined),
+}));
+vi.mock("./tabs/legacy-team-setup-dialog", () => ({
+	mountLegacyTeamSetupDialog: vi.fn(),
+	openLegacyTeamSetup: vi.fn(() => true),
 }));
 vi.mock("./tabs/projects", () => ({
 	initProjectsTab: vi.fn(),
@@ -154,6 +166,27 @@ describe("Devices app integration", () => {
 			offset: 0,
 		});
 		mocks.loadRecipientPolicyIntent.mockResolvedValue(intent);
+		mocks.loadLegacyTeamSetupDetail.mockResolvedValue({
+			version: 1,
+			candidate: {
+				candidateRef: "opaque-candidate-ref",
+				displayName: "Example Team",
+				status: "in_progress",
+				deviceCount: 0,
+				projectCount: 0,
+				unresolvedDeviceCount: 0,
+				unresolvedProjectCount: 0,
+			},
+			attemptId: "opaque-attempt",
+			draftState: "in_progress",
+			unresolvedDeviceCount: 0,
+			unresolvedProjectCount: 0,
+			devices: [],
+			projects: [],
+			identityChoices: [],
+			canFinish: false,
+			conflictState: null,
+		});
 		if (expect.getState().currentTestName?.includes("first Devices load")) {
 			mocks.loadDeviceIdentityInventory.mockRejectedValue(new Error("inventory unavailable"));
 		} else {
@@ -251,17 +284,18 @@ describe("Devices app integration", () => {
 		expect(document.activeElement).toBe(document.getElementById("tabBtn-sharing"));
 	});
 
-	it("injects Projects navigation to the canonical Sharing setup overview", async () => {
+	it("opens the global Team setup dialog from Projects without changing tabs", async () => {
 		const { initProjectsTab } = await import("./tabs/projects");
+		const { openLegacyTeamSetup } = await import("./tabs/legacy-team-setup-dialog");
 		const options = vi.mocked(initProjectsTab).mock.calls[0]?.[1];
 		expect(options?.onOpenTeamSetup).toEqual(expect.any(Function));
 
 		act(() => options?.onOpenTeamSetup?.("opaque-candidate-ref"));
 		await Promise.resolve();
 
-		expect(window.location.hash).toBe("#sharing");
-		expect(document.getElementById("tab-sharing")?.hidden).toBe(false);
-		expect(document.activeElement).toBe(document.getElementById("tabBtn-sharing"));
+		expect(openLegacyTeamSetup).toHaveBeenCalledWith("opaque-candidate-ref");
+		expect(window.location.hash).toBe("#devices");
+		expect(document.getElementById("tab-devices")?.hidden).toBe(false);
 	});
 
 	it("keeps existing device details usable when inventory fails on the first Devices load", () => {

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -41,6 +41,7 @@ import {
 } from "./tabs/devices";
 import { initFeedTab, loadFeedData, updateFeedView } from "./tabs/feed";
 import { initHealthTab, loadHealthData } from "./tabs/health";
+import { mountLegacyTeamSetupDialog, openLegacyTeamSetup } from "./tabs/legacy-team-setup-dialog";
 import { initProjectsTab, loadProjectsData } from "./tabs/projects";
 import { toRecipientPolicyManagementProjects } from "./tabs/recipient-policy-projects";
 import { initSettings, isSettingsOpen, loadConfigData } from "./tabs/settings";
@@ -487,16 +488,10 @@ function reviewDevicesFromSharing(deviceId?: string) {
 	switchTab("devices", { canonicalHash: true });
 }
 
-function openTeamSetupOverviewFromProjects() {
-	switchTab("sharing", { canonicalHash: true });
-	queueMicrotask(() => document.getElementById("tabBtn-sharing")?.focus());
-}
-
-// The Projects entry routes to Sharing's server-derived status overview. The
-// Sharing-to-dialog callback remains intentionally unwired until .7.
 const loadRecipientPolicySharingData = createRecipientPolicySharingLoader(
 	{},
 	{
+		onOpenTeamSetup: openLegacyTeamSetup,
 		onReviewDevices: reviewDevicesFromSharing,
 	},
 );
@@ -790,6 +785,8 @@ initState();
 // Toast host — mount first so early notices (from tab init etc.) land.
 const toastRoot = document.getElementById("toastRoot");
 if (toastRoot) mountToastHost(toastRoot);
+const legacyTeamSetupRoot = document.getElementById("legacyTeamSetupMount");
+if (legacyTeamSetupRoot) mountLegacyTeamSetupDialog(legacyTeamSetupRoot);
 
 // Theme
 initThemeToggle($button("themeToggle"));
@@ -801,7 +798,7 @@ initTabs();
 // Tab modules
 initFeedTab();
 initHealthTab();
-initProjectsTab(() => refresh(), { onOpenTeamSetup: openTeamSetupOverviewFromProjects });
+initProjectsTab(() => refresh(), { onOpenTeamSetup: openLegacyTeamSetup });
 initSyncTab(() => refresh());
 initCoordinatorAdminTab();
 initSettings(stopPolling, startPolling, () => refresh());

--- a/packages/ui/src/project-first-layout.test.ts
+++ b/packages/ui/src/project-first-layout.test.ts
@@ -8,6 +8,12 @@ describe("project-first navigation layout", () => {
 	it("includes the Projects share-flow mount used by row-level Share actions", () => {
 		expect(html).toContain('id="projectShareFlowMount"');
 		expect(html).toContain('id="recipientPolicyManagementMount"');
+		expect(html).toContain('id="legacyTeamSetupMount"');
+	});
+
+	it("wires the global Team setup dialog to Sharing and Projects", () => {
+		expect(appSource).toContain("mountLegacyTeamSetupDialog");
+		expect(appSource.match(/onOpenTeamSetup: openLegacyTeamSetup/g)).toHaveLength(2);
 	});
 
 	it("orders the visible navigation as Feed, Projects, Sharing, Devices, Health, Advanced", () => {

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -1,0 +1,349 @@
+import { type ComponentChildren, render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LegacyTeamSetupApiError, type LegacyTeamSetupDetailResponseV1 } from "../lib/api";
+
+const dialogControls = vi.hoisted(() => ({
+	onCloseAutoFocus: undefined as undefined | ((event: { preventDefault: () => void }) => void),
+	onOpenAutoFocus: undefined as undefined | ((event: { preventDefault: () => void }) => void),
+	onOpenChange: undefined as undefined | ((open: boolean) => void),
+}));
+
+vi.mock("../components/primitives/radix-dialog", () => ({
+	RadixDialog: (props: {
+		children?: ComponentChildren;
+		contentId: string;
+		onCloseAutoFocus?: (event: { preventDefault: () => void }) => void;
+		onOpenAutoFocus?: (event: { preventDefault: () => void }) => void;
+		onOpenChange: (open: boolean) => void;
+		open: boolean;
+	}) => {
+		dialogControls.onCloseAutoFocus = props.onCloseAutoFocus;
+		dialogControls.onOpenAutoFocus = props.onOpenAutoFocus;
+		dialogControls.onOpenChange = props.onOpenChange;
+		return props.open ? (
+			<div id={props.contentId} role="dialog">
+				{props.children}
+			</div>
+		) : null;
+	},
+}));
+
+import { mountLegacyTeamSetupDialog, openLegacyTeamSetup } from "./legacy-team-setup-dialog";
+
+function detail({
+	canFinish = false,
+	conflictState = null,
+	draftState = "in_progress",
+	unresolvedDeviceCount = 0,
+	unresolvedProjectCount = 0,
+}: {
+	canFinish?: boolean;
+	conflictState?: LegacyTeamSetupDetailResponseV1["conflictState"];
+	draftState?: "needs_setup" | "in_progress" | "stale" | "completed";
+	unresolvedDeviceCount?: number;
+	unresolvedProjectCount?: number;
+} = {}): LegacyTeamSetupDetailResponseV1 {
+	const base = {
+		version: 1 as const,
+		candidate: {
+			candidateRef: "opaque-candidate",
+			displayName: "Example Team",
+			status: "in_progress" as const,
+			deviceCount: 3,
+			projectCount: 2,
+			unresolvedDeviceCount,
+			unresolvedProjectCount,
+		},
+		attemptId: "opaque-attempt",
+		draftState,
+		unresolvedDeviceCount,
+		unresolvedProjectCount,
+		devices: [],
+		projects: [],
+		identityChoices: [],
+	};
+	return canFinish
+		? {
+				...base,
+				canFinish: true,
+				conflictState: null,
+				finishDigest: "opaque-finish-digest",
+				accessDeltaDigest: "opaque-access-digest",
+				accessDelta: {
+					teamChanges: [],
+					membershipChanges: [],
+					projectChanges: [],
+					recipientChanges: [],
+					deviceAccessChanges: [],
+				},
+			}
+		: { ...base, canFinish: false, conflictState };
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, reject, resolve };
+}
+
+function setup(
+	loadDetail: (candidateRef: string) => Promise<LegacyTeamSetupDetailResponseV1>,
+	overrides: Parameters<typeof mountLegacyTeamSetupDialog>[1] = {},
+) {
+	document.body.innerHTML = `
+		<button class="tab-btn" id="tabBtn-sharing" aria-current="page">Sharing</button>
+		<section id="team-setup-panel"><button id="team-setup-trigger">Continue setup</button></section>
+		<div id="legacyTeamSetupMount"></div>
+	`;
+	const mount = document.getElementById("legacyTeamSetupMount");
+	const trigger = document.getElementById("team-setup-trigger");
+	if (!(mount instanceof HTMLElement) || !(trigger instanceof HTMLButtonElement)) {
+		throw new Error("Team setup test fixture missing");
+	}
+	act(() => mountLegacyTeamSetupDialog(mount, { ...overrides, loadDetail }));
+	trigger.focus();
+	act(() => {
+		openLegacyTeamSetup("opaque-candidate");
+	});
+	return { mount, trigger };
+}
+
+afterEach(() => {
+	const mount = document.getElementById("legacyTeamSetupMount");
+	if (mount) act(() => render(null, mount));
+	document.body.innerHTML = "";
+	vi.clearAllMocks();
+	dialogControls.onCloseAutoFocus = undefined;
+	dialogControls.onOpenAutoFocus = undefined;
+	dialogControls.onOpenChange = undefined;
+});
+
+describe("legacy Team setup dialog", () => {
+	it("opens with loading state and selects Devices from authoritative detail", async () => {
+		const pending = deferred<LegacyTeamSetupDetailResponseV1>();
+		const loadDetail = vi.fn().mockReturnValue(pending.promise);
+		setup(loadDetail);
+
+		expect(loadDetail).toHaveBeenCalledWith("opaque-candidate");
+		expect(document.body.textContent).toContain("Loading the latest Team setup details");
+		expect(document.querySelector(".legacy-team-setup-card")?.getAttribute("aria-busy")).toBe(
+			"true",
+		);
+
+		pending.resolve(detail({ unresolvedDeviceCount: 2, unresolvedProjectCount: 1 }));
+		await vi.waitFor(() => {
+			expect(document.body.textContent).toContain("Set up Example Team");
+			expect(document.body.textContent).toContain("2 of 3 Team devices");
+		});
+		expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Devices");
+		expect(document.querySelector('[role="alert"]')).toBeNull();
+		const projectsButton = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => button.textContent === "Projects",
+		);
+		expect(projectsButton?.disabled).toBe(false);
+		expect(projectsButton?.getAttribute("aria-disabled")).toBe("true");
+		expect(projectsButton?.getAttribute("aria-describedby")).toBe(
+			"legacy-team-setup-block-devices",
+		);
+		expect(document.getElementById("legacy-team-setup-block-devices")?.textContent).toContain(
+			"Finish the device decisions",
+		);
+		act(() => projectsButton?.click());
+		expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Devices");
+	});
+
+	it("treats incomplete setup as normal progress rather than changed state", async () => {
+		setup(
+			vi.fn().mockResolvedValue(
+				detail({
+					conflictState: "team_setup_incomplete",
+					unresolvedDeviceCount: 2,
+					unresolvedProjectCount: 1,
+				}),
+			),
+		);
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("2 of 3 Team devices"));
+		expect(document.querySelector('[role="alert"]')).toBeNull();
+		expect(document.body.textContent).not.toContain("changed since it was last reviewed");
+	});
+
+	it("selects Projects, Review, and completion from fresh server state", async () => {
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(detail({ unresolvedProjectCount: 1 }))
+			.mockResolvedValueOnce(detail({ canFinish: true }))
+			.mockResolvedValueOnce(detail({ draftState: "completed" }));
+		const { trigger } = setup(loadDetail);
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Projects");
+		});
+		act(() =>
+			document.querySelector<HTMLButtonElement>(".legacy-team-setup-actions button")?.click(),
+		);
+		trigger.focus();
+		act(() => {
+			openLegacyTeamSetup("opaque-candidate");
+		});
+		await vi.waitFor(() => {
+			expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Review");
+		});
+		act(() =>
+			document.querySelector<HTMLButtonElement>(".legacy-team-setup-actions button")?.click(),
+		);
+		trigger.focus();
+		act(() => {
+			openLegacyTeamSetup("opaque-candidate");
+		});
+		await vi.waitFor(() => {
+			expect(document.body.textContent).toContain("Team setup complete");
+		});
+		expect(document.querySelector(".legacy-team-setup-steps")).toBeNull();
+		expect(loadDetail).toHaveBeenCalledTimes(3);
+	});
+
+	it("shows safe error copy and retries without exposing exception text", async () => {
+		const retry = deferred<LegacyTeamSetupDetailResponseV1>();
+		const loadDetail = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("private coordinator response"))
+			.mockReturnValueOnce(retry.promise);
+		setup(loadDetail);
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+				"temporarily unavailable",
+			);
+		});
+		expect(document.body.textContent).not.toContain("private coordinator response");
+
+		const retryButton = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => button.textContent === "Retry",
+		);
+		retryButton?.focus();
+		act(() => retryButton?.click());
+		expect(retryButton?.disabled).toBe(false);
+		expect(retryButton?.getAttribute("aria-disabled")).toBe("true");
+		expect(document.activeElement).toBe(retryButton);
+		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+			"temporarily unavailable",
+		);
+		retry.resolve(detail({ unresolvedProjectCount: 1 }));
+		await vi.waitFor(() => {
+			expect(document.body.textContent).toContain("Review Projects");
+		});
+		expect(document.activeElement?.id).toBe("legacy-team-setup-step-projects");
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+	});
+
+	it("uses changed-state copy for stale API errors and stale detail", async () => {
+		const loadDetail = vi
+			.fn()
+			.mockRejectedValueOnce(new LegacyTeamSetupApiError(409, "team_setup_conflict"))
+			.mockResolvedValueOnce(detail({ draftState: "stale", unresolvedProjectCount: 1 }))
+			.mockResolvedValueOnce(detail({ unresolvedProjectCount: 1 }));
+		const refreshCandidate = vi.fn().mockResolvedValue({});
+		setup(loadDetail, { refreshCandidate });
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+				"changed since it was last reviewed",
+			);
+		});
+		act(() => {
+			document.getElementById("legacy-team-setup-retry")?.click();
+		});
+		await vi.waitFor(() => {
+			expect(document.body.textContent).toContain("Review Projects");
+		});
+		expect(refreshCandidate).toHaveBeenCalledTimes(1);
+		expect(refreshCandidate.mock.invocationCallOrder[0]).toBeLessThan(
+			loadDetail.mock.invocationCallOrder[1],
+		);
+		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+			"changed since it was last reviewed",
+		);
+		act(() => {
+			document.getElementById("legacy-team-setup-retry")?.click();
+		});
+		await vi.waitFor(() => {
+			expect(document.querySelector('[role="alert"]')).toBeNull();
+		});
+		expect(refreshCandidate).toHaveBeenCalledTimes(2);
+		expect(loadDetail).toHaveBeenCalledTimes(3);
+	});
+
+	it("focuses explicit step navigation and restores the connected trigger on dismissal", async () => {
+		const loadDetail = vi.fn().mockResolvedValue(detail({ unresolvedProjectCount: 1 }));
+		const { trigger } = setup(loadDetail);
+		await vi.waitFor(() => {
+			expect(document.body.textContent).toContain("Review Projects");
+		});
+
+		const preventOpenDefault = vi.fn();
+		act(() => dialogControls.onOpenAutoFocus?.({ preventDefault: preventOpenDefault }));
+		expect(preventOpenDefault).toHaveBeenCalled();
+		expect(document.activeElement?.id).toBe("legacy-team-setup-title");
+
+		act(() => {
+			[...document.querySelectorAll<HTMLButtonElement>("button")]
+				.find((button) => button.textContent === "Devices")
+				?.click();
+		});
+		await vi.waitFor(() => {
+			expect(document.activeElement?.id).toBe("legacy-team-setup-step-devices");
+		});
+		const reviewButton = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => button.textContent === "Review",
+		);
+		expect(reviewButton?.getAttribute("aria-describedby")).toBe("legacy-team-setup-block-projects");
+		expect(document.getElementById("legacy-team-setup-block-projects")).not.toBeNull();
+		act(() => {
+			[...document.querySelectorAll<HTMLButtonElement>("button")]
+				.find((button) => button.textContent === "Devices")
+				?.click();
+		});
+
+		act(() => dialogControls.onOpenChange?.(false));
+		expect(document.getElementById("legacyTeamSetupDialog")).toBeNull();
+		const preventCloseDefault = vi.fn();
+		act(() => dialogControls.onCloseAutoFocus?.({ preventDefault: preventCloseDefault }));
+		expect(preventCloseDefault).toHaveBeenCalled();
+		expect(document.activeElement).toBe(trigger);
+
+		trigger.focus();
+		act(() => {
+			openLegacyTeamSetup("opaque-candidate");
+		});
+		act(() => dialogControls.onOpenAutoFocus?.({ preventDefault: vi.fn() }));
+		await vi.waitFor(() => {
+			expect(loadDetail).toHaveBeenCalledTimes(2);
+		});
+		expect(document.activeElement?.id).toBe("legacy-team-setup-title");
+		const triggerPanel = document.getElementById("team-setup-panel");
+		if (!(triggerPanel instanceof HTMLElement)) throw new Error("trigger panel missing");
+		triggerPanel.style.display = "none";
+		act(() => dialogControls.onOpenChange?.(false));
+		act(() => dialogControls.onCloseAutoFocus?.({ preventDefault: vi.fn() }));
+		expect(document.activeElement?.id).toBe("tabBtn-sharing");
+
+		triggerPanel.style.display = "";
+		if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+		expect(document.activeElement).toBe(document.body);
+		act(() => {
+			openLegacyTeamSetup("opaque-candidate");
+		});
+		await vi.waitFor(() => {
+			expect(loadDetail).toHaveBeenCalledTimes(3);
+		});
+		act(() => dialogControls.onOpenChange?.(false));
+		act(() => dialogControls.onCloseAutoFocus?.({ preventDefault: vi.fn() }));
+		expect(document.activeElement?.id).toBe("tabBtn-sharing");
+	});
+});

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
@@ -1,0 +1,417 @@
+import { render } from "preact";
+import { useEffect, useRef, useState } from "preact/hooks";
+import { DialogCloseButton } from "../components/primitives/dialog-close-button";
+import { RadixDialog } from "../components/primitives/radix-dialog";
+import * as api from "../lib/api";
+
+type TeamSetupStep = "devices" | "projects" | "review" | "completed";
+const CHANGED_STATE_ERROR =
+	"Team setup changed since it was last reviewed. Reload the latest details to continue.";
+const RELOAD_ERROR_CODES = new Set<api.LegacyTeamSetupErrorCode>([
+	"team_setup_roster_changed",
+	"team_setup_assignment_changed",
+	"team_setup_conflict",
+	"team_setup_confirmation_stale",
+]);
+
+interface LegacyTeamSetupDialogDependencies {
+	loadDetail: typeof api.loadLegacyTeamSetupDetail;
+	refreshCandidate: typeof api.refreshLegacyTeamSetupCandidate;
+}
+
+const defaultDependencies: LegacyTeamSetupDialogDependencies = {
+	loadDetail: api.loadLegacyTeamSetupDetail,
+	refreshCandidate: api.refreshLegacyTeamSetupCandidate,
+};
+
+let pendingCandidateRef: string | null = null;
+let requestOpen: ((candidateRef: string) => void) | null = null;
+let returnFocus: HTMLElement | null = null;
+
+export function openLegacyTeamSetup(candidateRef: string): boolean {
+	if (!candidateRef) return false;
+	returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+	if (requestOpen) requestOpen(candidateRef);
+	else pendingCandidateRef = candidateRef;
+	return true;
+}
+
+function canRestoreFocus(element: HTMLElement | null): element is HTMLElement {
+	if (
+		!element?.isConnected ||
+		element.tabIndex < 0 ||
+		element.matches(":disabled") ||
+		element.closest('[hidden], [inert], [aria-hidden="true"]')
+	) {
+		return false;
+	}
+	for (let current: HTMLElement | null = element; current; current = current.parentElement) {
+		const style = window.getComputedStyle(current);
+		if (
+			style.display === "none" ||
+			style.visibility === "hidden" ||
+			style.visibility === "collapse"
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function initialStep(detail: api.LegacyTeamSetupDetailResponseV1): TeamSetupStep {
+	if (detail.draftState === "completed") return "completed";
+	if (detail.unresolvedDeviceCount > 0) return "devices";
+	if (detail.unresolvedProjectCount > 0) return "projects";
+	return "review";
+}
+
+function detailNeedsRecovery(detail: api.LegacyTeamSetupDetailResponseV1): boolean {
+	return (
+		detail.draftState === "stale" ||
+		(!detail.canFinish &&
+			detail.conflictState !== null &&
+			RELOAD_ERROR_CODES.has(detail.conflictState))
+	);
+}
+
+function safeLoadError(cause: unknown): string {
+	if (isChangedStateError(cause)) {
+		return CHANGED_STATE_ERROR;
+	}
+	return "Team setup details are temporarily unavailable. Retry to load the latest details.";
+}
+
+function isChangedStateError(cause: unknown): boolean {
+	return cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode);
+}
+
+function StepContent({
+	detail,
+	step,
+}: {
+	detail: api.LegacyTeamSetupDetailResponseV1;
+	step: TeamSetupStep;
+}) {
+	if (step === "completed") {
+		return (
+			<section aria-labelledby="legacy-team-setup-step-completed">
+				<h3 id="legacy-team-setup-step-completed" tabIndex={-1}>
+					Team setup complete
+				</h3>
+				<p>This Team is ready for Project sharing.</p>
+			</section>
+		);
+	}
+	if (step === "devices") {
+		return (
+			<section aria-labelledby="legacy-team-setup-step-devices">
+				<h3 id="legacy-team-setup-step-devices" tabIndex={-1}>
+					Review devices
+				</h3>
+				<p>
+					{detail.unresolvedDeviceCount.toLocaleString()} of{" "}
+					{detail.candidate.deviceCount.toLocaleString()} Team devices still need a person or
+					exclusion decision.
+				</p>
+				<p className="small">
+					Next setup action: assign each unresolved device to a person or exclude it from this Team.
+				</p>
+			</section>
+		);
+	}
+	if (step === "projects") {
+		return (
+			<section aria-labelledby="legacy-team-setup-step-projects">
+				<h3 id="legacy-team-setup-step-projects" tabIndex={-1}>
+					Review Projects
+				</h3>
+				<p>
+					{detail.unresolvedProjectCount.toLocaleString()} of{" "}
+					{detail.candidate.projectCount.toLocaleString()} Team Projects still need a mapping
+					decision.
+				</p>
+				<p className="small">
+					Next setup action: map each unresolved Project using the server-provided choices.
+				</p>
+			</section>
+		);
+	}
+	return (
+		<section aria-labelledby="legacy-team-setup-step-review">
+			<h3 id="legacy-team-setup-step-review" tabIndex={-1}>
+				Review and finish
+			</h3>
+			<p>
+				{detail.canFinish
+					? "The server has confirmed that this Team is ready for final review."
+					: "Final review is waiting for current server confirmation evidence."}
+			</p>
+			<p className="small">
+				Next setup action: confirm the server-provided access review before finishing.
+			</p>
+		</section>
+	);
+}
+
+function LegacyTeamSetupDialogHost({
+	dependencies,
+}: {
+	dependencies: LegacyTeamSetupDialogDependencies;
+}) {
+	const [candidateRef, setCandidateRef] = useState<string | null>(null);
+	const [detail, setDetail] = useState<api.LegacyTeamSetupDetailResponseV1 | null>(null);
+	const [step, setStep] = useState<TeamSetupStep>("devices");
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [loadRevision, setLoadRevision] = useState(0);
+	const focusAfterLoad = useRef(false);
+	const focusStepAfterRender = useRef(false);
+	const refreshBeforeLoad = useRef(false);
+	const retryNeedsRefresh = useRef(false);
+
+	useEffect(() => {
+		requestOpen = (nextCandidateRef) => {
+			refreshBeforeLoad.current = false;
+			retryNeedsRefresh.current = false;
+			setCandidateRef(nextCandidateRef);
+			setDetail(null);
+			setError(null);
+			setLoadRevision((current) => current + 1);
+		};
+		if (pendingCandidateRef) {
+			const pending = pendingCandidateRef;
+			pendingCandidateRef = null;
+			requestOpen(pending);
+		}
+		return () => {
+			requestOpen = null;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!candidateRef) return;
+		let current = true;
+		const shouldRefresh = refreshBeforeLoad.current;
+		refreshBeforeLoad.current = false;
+		setLoading(true);
+		const nextDetail = shouldRefresh
+			? dependencies
+					.refreshCandidate(candidateRef)
+					.then(() => dependencies.loadDetail(candidateRef))
+			: dependencies.loadDetail(candidateRef);
+		void nextDetail.then(
+			(nextDetail) => {
+				if (!current) return;
+				retryNeedsRefresh.current = detailNeedsRecovery(nextDetail);
+				setDetail(nextDetail);
+				setStep(initialStep(nextDetail));
+				setError(detailNeedsRecovery(nextDetail) ? CHANGED_STATE_ERROR : null);
+				setLoading(false);
+			},
+			(cause: unknown) => {
+				if (!current) return;
+				retryNeedsRefresh.current = shouldRefresh || isChangedStateError(cause);
+				setError(safeLoadError(cause));
+				setLoading(false);
+			},
+		);
+		return () => {
+			current = false;
+		};
+	}, [candidateRef, dependencies, loadRevision]);
+
+	useEffect(() => {
+		if (!focusStepAfterRender.current) return;
+		focusStepAfterRender.current = false;
+		document.getElementById(`legacy-team-setup-step-${step}`)?.focus();
+	}, [step]);
+
+	useEffect(() => {
+		if (loading || !focusAfterLoad.current) return;
+		focusAfterLoad.current = false;
+		if (error) {
+			document.getElementById("legacy-team-setup-retry")?.focus();
+			return;
+		}
+		document.getElementById(`legacy-team-setup-step-${step}`)?.focus();
+	}, [error, loading, step]);
+
+	if (!candidateRef) return null;
+	const title = detail ? `Set up ${detail.candidate.displayName}` : "Set up Team";
+	const close = () => {
+		focusAfterLoad.current = false;
+		focusStepAfterRender.current = false;
+		refreshBeforeLoad.current = false;
+		retryNeedsRefresh.current = false;
+		setCandidateRef(null);
+		setDetail(null);
+		setError(null);
+		setLoading(false);
+	};
+	const navigate = (nextStep: TeamSetupStep) => {
+		if (nextStep === step) {
+			document.getElementById(`legacy-team-setup-step-${nextStep}`)?.focus();
+			return;
+		}
+		focusStepAfterRender.current = true;
+		setStep(nextStep);
+	};
+	const devicesBlockProgress = detail ? detail.unresolvedDeviceCount > 0 : false;
+	const projectsBlockReview = detail ? detail.unresolvedProjectCount > 0 : false;
+
+	return (
+		<RadixDialog
+			ariaDescribedby="legacy-team-setup-description"
+			ariaLabelledby="legacy-team-setup-title"
+			contentClassName="modal legacy-team-setup-dialog"
+			contentId="legacyTeamSetupDialog"
+			onCloseAutoFocus={(event) => {
+				event.preventDefault();
+				const activeTab = document.querySelector<HTMLElement>('.tab-btn[aria-current="page"]');
+				const target = canRestoreFocus(returnFocus) ? returnFocus : activeTab;
+				target?.focus();
+				returnFocus = null;
+			}}
+			onOpenAutoFocus={(event) => {
+				const heading = document.getElementById("legacy-team-setup-title");
+				if (!heading) return;
+				event.preventDefault();
+				heading.focus();
+			}}
+			onOpenChange={(open) => {
+				if (!open) close();
+			}}
+			open
+			overlayClassName="modal-backdrop"
+			overlayId="legacyTeamSetupDialogBackdrop"
+		>
+			<div aria-busy={loading ? "true" : "false"} className="modal-card legacy-team-setup-card">
+				<div className="modal-header">
+					<h2 id="legacy-team-setup-title" tabIndex={-1}>
+						{title}
+					</h2>
+					<DialogCloseButton ariaLabel={`Close ${title}`} onClick={close} />
+				</div>
+				<div className="modal-body legacy-team-setup-body">
+					<p className="small" id="legacy-team-setup-description">
+						Review the server-provided device and Project work before this Team can be used for
+						sharing.
+					</p>
+					{loading && !detail ? <p role="status">Loading the latest Team setup details…</p> : null}
+					{error ? (
+						<div className="legacy-team-setup-error">
+							<p aria-live="assertive" role="alert">
+								{error}
+							</p>
+							<button
+								aria-disabled={loading ? "true" : undefined}
+								className="settings-button legacy-team-setup-target"
+								id="legacy-team-setup-retry"
+								onClick={() => {
+									if (loading) return;
+									focusAfterLoad.current = true;
+									refreshBeforeLoad.current = retryNeedsRefresh.current;
+									setLoadRevision((current) => current + 1);
+								}}
+								type="button"
+							>
+								{loading ? "Retrying…" : "Retry"}
+							</button>
+						</div>
+					) : null}
+					{detail ? (
+						<>
+							{step !== "completed" ? (
+								<>
+									<ol aria-label="Team setup steps" className="legacy-team-setup-steps">
+										<li>
+											<button
+												aria-current={step === "devices" ? "step" : undefined}
+												className="settings-button legacy-team-setup-target"
+												onClick={() => navigate("devices")}
+												type="button"
+											>
+												Devices
+											</button>
+										</li>
+										<li>
+											<button
+												aria-current={step === "projects" ? "step" : undefined}
+												aria-describedby={
+													devicesBlockProgress ? "legacy-team-setup-block-devices" : undefined
+												}
+												aria-disabled={devicesBlockProgress ? "true" : undefined}
+												className="settings-button legacy-team-setup-target"
+												onClick={() => {
+													if (!devicesBlockProgress) navigate("projects");
+												}}
+												type="button"
+											>
+												Projects
+											</button>
+										</li>
+										<li>
+											<button
+												aria-current={step === "review" ? "step" : undefined}
+												aria-describedby={
+													devicesBlockProgress
+														? "legacy-team-setup-block-devices"
+														: projectsBlockReview
+															? "legacy-team-setup-block-projects"
+															: undefined
+												}
+												aria-disabled={
+													devicesBlockProgress || projectsBlockReview ? "true" : undefined
+												}
+												className="settings-button legacy-team-setup-target"
+												onClick={() => {
+													if (!devicesBlockProgress && !projectsBlockReview) navigate("review");
+												}}
+												type="button"
+											>
+												Review
+											</button>
+										</li>
+									</ol>
+									{devicesBlockProgress ? (
+										<p className="small" id="legacy-team-setup-block-devices">
+											Finish the device decisions before mapping Projects or reviewing access.
+										</p>
+									) : null}
+									{projectsBlockReview ? (
+										<p className="small" id="legacy-team-setup-block-projects">
+											Finish the Project mappings before reviewing access.
+										</p>
+									) : null}
+								</>
+							) : null}
+							{loading ? (
+								<p aria-live="polite" className="small" role="status">
+									Refreshing Team setup details…
+								</p>
+							) : null}
+							<StepContent detail={detail} step={step} />
+						</>
+					) : null}
+				</div>
+				<div className="modal-footer legacy-team-setup-actions">
+					<button
+						className="settings-button legacy-team-setup-target"
+						onClick={close}
+						type="button"
+					>
+						Close
+					</button>
+				</div>
+			</div>
+		</RadixDialog>
+	);
+}
+
+export function mountLegacyTeamSetupDialog(
+	mount: HTMLElement,
+	overrides: Partial<LegacyTeamSetupDialogDependencies> = {},
+): void {
+	const dependencies = { ...defaultDependencies, ...overrides };
+	render(<LegacyTeamSetupDialogHost dependencies={dependencies} />, mount);
+}

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1203,6 +1203,30 @@
         font-weight: var(--font-weight-semibold);
       }
       .recipient-policy-management-dialog .modal-card { width: min(720px, calc(100vw - 32px)); }
+      .legacy-team-setup-dialog .modal-card { width: min(680px, calc(100vw - 32px)); }
+      .legacy-team-setup-steps {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--sp-2);
+        margin: var(--sp-2) 0;
+        padding-left: var(--sp-5);
+      }
+      .legacy-team-setup-steps button { width: 100%; }
+      .legacy-team-setup-steps button[aria-current="step"] {
+        border-color: var(--accent);
+        background: var(--accent-subtle);
+        color: var(--text-primary);
+        font-weight: var(--font-weight-semibold);
+      }
+      .legacy-team-setup-dialog button[aria-disabled="true"] {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+      .legacy-team-setup-body h3 { margin: var(--sp-2) 0; }
+      .legacy-team-setup-body p { overflow-wrap: anywhere; }
+      .legacy-team-setup-error { display: grid; gap: var(--sp-2); justify-items: start; }
+      .legacy-team-setup-actions { justify-content: flex-end; }
+      .legacy-team-setup-target { min-width: 24px; min-height: 24px; }
       .recipient-policy-management-selection fieldset { border: 0; padding: 0; margin: var(--sp-4) 0 0; }
       .recipient-policy-management-selection legend { font-weight: var(--font-weight-semibold); }
       .recipient-policy-management-review section + section { margin-top: var(--sp-4); }
@@ -3644,6 +3668,8 @@
         .tab-bar { padding: 0 var(--sp-4); }
         .modal { padding: var(--sp-3); }
         .modal-card { padding: var(--sp-4); border-radius: var(--radius-lg); }
+        .legacy-team-setup-dialog .modal-card { width: calc(100vw - 16px); }
+        .legacy-team-setup-steps { grid-template-columns: 1fr; }
       }
 
       /* ──────────────────────────────────────────────────────────────────
@@ -3731,6 +3757,7 @@
     </nav>
     <div id="toastRoot"></div>
     <div id="recipientPolicyManagementMount"></div>
+    <div id="legacyTeamSetupMount"></div>
     <div class="viewer-reconnect-overlay" id="viewerReconnectOverlay" hidden>
       <div class="viewer-reconnect-card" role="status" aria-live="assertive">
         <div class="viewer-reconnect-eyebrow">Viewer connection</div>


### PR DESCRIPTION
## Description

Add the global accessible Team setup dialog host, production entry points, authoritative detail loading, retry behavior, step selection, and focus restoration. This establishes the resumable shell used by the remaining stack.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Stack-tip validation also passed `pnpm --filter @codemem/ui build` and `git diff --check`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced