### PR TITLE
feat(ui): add Team setup device decisions

### DIFF
--- a/packages/ui/src/components/primitives/dialog-close-button.tsx
+++ b/packages/ui/src/components/primitives/dialog-close-button.tsx
@@ -1,4 +1,5 @@
 type DialogCloseButtonProps = {
+	ariaDisabled?: boolean;
 	ariaLabel: string;
 	className?: string;
 	disabled?: boolean;
@@ -7,6 +8,7 @@ type DialogCloseButtonProps = {
 };
 
 export function DialogCloseButton({
+	ariaDisabled = false,
 	ariaLabel,
 	className = "modal-close-button",
 	disabled = false,
@@ -15,10 +17,13 @@ export function DialogCloseButton({
 }: DialogCloseButtonProps) {
 	return (
 		<button
+			aria-disabled={ariaDisabled ? "true" : undefined}
 			aria-label={ariaLabel}
 			className={className}
 			disabled={disabled}
-			onClick={onClick}
+			onClick={() => {
+				if (!ariaDisabled) onClick();
+			}}
 			type="button"
 		>
 			<i aria-hidden="true" className="modal-close-button-icon" data-lucide="x" />

--- a/packages/ui/src/tabs/legacy-team-setup-devices.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-devices.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from "preact/hooks";
+import type { LegacyTeamSetupDetailResponseV1, LegacyTeamSetupDeviceV1 } from "../lib/api";
+
+type DeviceDecision = "included" | "excluded" | "removed";
+
+export interface LegacyTeamSetupDevicesProps {
+	blocked: boolean;
+	busyDeviceRef: string | null;
+	detail: LegacyTeamSetupDetailResponseV1;
+	onAssign: (device: LegacyTeamSetupDeviceV1, identityRef: string) => void;
+	onClear: (device: LegacyTeamSetupDeviceV1) => void;
+	onDecision: (
+		device: LegacyTeamSetupDeviceV1,
+		decision: DeviceDecision,
+		identityRef?: string,
+	) => void;
+}
+
+const DECISION_LABELS: Record<LegacyTeamSetupDeviceV1["decision"], string> = {
+	unresolved: "Needs a decision",
+	included: "Included in this Team",
+	excluded: "Excluded from this Team",
+	removed: "Removed from this Team",
+};
+
+function identityName(detail: LegacyTeamSetupDetailResponseV1, identityRef: string | null) {
+	if (!identityRef) return null;
+	return (
+		detail.identityChoices.find((identity) => identity.identityRef === identityRef)?.displayName ??
+		"Unavailable person"
+	);
+}
+
+function initialIdentityRef(device: LegacyTeamSetupDeviceV1): string {
+	return device.targetIdentityRef ?? device.existingIdentityRef ?? "";
+}
+
+function DeviceRow({
+	blocked,
+	busy,
+	detail,
+	device,
+	index,
+	onAssign,
+	onClear,
+	onDecision,
+}: LegacyTeamSetupDevicesProps & {
+	busy: boolean;
+	device: LegacyTeamSetupDeviceV1;
+	index: number;
+}) {
+	const controlId = `legacy-team-device-identity-${index}`;
+	const evidenceId = `legacy-team-device-evidence-${index}`;
+	const assignmentHelpId = `legacy-team-device-assignment-help-${index}`;
+	const initialIdentity = initialIdentityRef(device);
+	const savedIdentity = device.targetIdentityRef ?? "";
+	const [draftIdentityRef, setDraftIdentityRef] = useState(initialIdentity);
+	useEffect(() => setDraftIdentityRef(initialIdentity), [initialIdentity]);
+	const selectedChoiceExists = detail.identityChoices.some(
+		(identity) => identity.identityRef === draftIdentityRef,
+	);
+	const existingName = identityName(detail, device.existingIdentityRef);
+	const suggestedName = identityName(detail, device.suggestedIdentityRef);
+	const controlsBlocked = blocked || busy;
+	const assignmentControlsBlocked = controlsBlocked || !device.enabled;
+	const assignmentEvidenceInactive =
+		device.expectation.kind === "existing" && device.verifiedEvidenceKind !== "active_assignment";
+	const assignmentIdentityUnavailable = Boolean(draftIdentityRef) && !selectedChoiceExists;
+	const includeNeedsHelp =
+		assignmentEvidenceInactive ||
+		assignmentIdentityUnavailable ||
+		!savedIdentity ||
+		draftIdentityRef !== savedIdentity;
+	const includeBlocked = controlsBlocked || includeNeedsHelp;
+	const assignmentBlocked =
+		assignmentControlsBlocked ||
+		!draftIdentityRef ||
+		assignmentEvidenceInactive ||
+		assignmentIdentityUnavailable ||
+		draftIdentityRef === savedIdentity;
+
+	return (
+		<fieldset aria-busy={busy ? "true" : "false"} className="legacy-team-device-row">
+			<legend>{device.displayName}</legend>
+			<div className="small legacy-team-device-evidence" id={evidenceId}>
+				<span>
+					{device.enabled ? "Current Team device" : "Device no longer active on this Team"}
+				</span>
+				{existingName ? (
+					<span>
+						Current assignment: {existingName}
+						{device.verifiedEvidenceKind === "active_assignment"
+							? " · verified active assignment"
+							: ""}
+					</span>
+				) : null}
+				{!existingName && suggestedName ? <span>Suggested person: {suggestedName}</span> : null}
+				<span>Decision: {DECISION_LABELS[device.decision]}</span>
+			</div>
+			<label htmlFor={controlId}>Person using this device</label>
+			<select
+				aria-describedby={`${evidenceId}${includeNeedsHelp ? ` ${assignmentHelpId}` : ""}`}
+				className="feed-search legacy-team-device-select"
+				disabled={assignmentControlsBlocked}
+				id={controlId}
+				onChange={(event) => setDraftIdentityRef(event.currentTarget.value)}
+				value={draftIdentityRef}
+			>
+				<option value="">Choose a person</option>
+				{draftIdentityRef && !selectedChoiceExists ? (
+					<option value={draftIdentityRef}>Current server assignment</option>
+				) : null}
+				{detail.identityChoices.map((identity) => (
+					<option key={identity.identityRef} value={identity.identityRef}>
+						{identity.displayName}
+					</option>
+				))}
+			</select>
+			{!device.enabled ? (
+				<p className="small" id={assignmentHelpId}>
+					Inactive devices can only be removed from this Team.
+				</p>
+			) : assignmentIdentityUnavailable ? (
+				<p className="small" id={assignmentHelpId}>
+					This person is no longer available. Choose an available person and save the assignment
+					before including this device.
+				</p>
+			) : assignmentEvidenceInactive ? (
+				<p className="small" id={assignmentHelpId}>
+					This assignment is inactive. Reconcile this device in Devices or exclude it from this
+					Team.
+				</p>
+			) : !draftIdentityRef || !savedIdentity || draftIdentityRef !== savedIdentity ? (
+				<p className="small" id={assignmentHelpId}>
+					{draftIdentityRef
+						? "Save the selected person assignment before including this device."
+						: "Choose and save a person assignment before including this device."}
+				</p>
+			) : null}
+			<div className="legacy-team-device-actions">
+				<button
+					aria-describedby={!draftIdentityRef ? assignmentHelpId : evidenceId}
+					aria-disabled={assignmentBlocked ? "true" : undefined}
+					className="settings-button legacy-team-setup-target"
+					onClick={() => {
+						if (!assignmentBlocked) onAssign(device, draftIdentityRef);
+					}}
+					type="button"
+				>
+					Save assignment
+				</button>
+				{device.enabled ? (
+					<>
+						<button
+							aria-describedby={includeNeedsHelp ? assignmentHelpId : evidenceId}
+							aria-disabled={includeBlocked ? "true" : undefined}
+							className="settings-button legacy-team-setup-target"
+							onClick={() => {
+								if (!includeBlocked) onDecision(device, "included", savedIdentity);
+							}}
+							type="button"
+						>
+							Include
+						</button>
+						<button
+							aria-disabled={controlsBlocked ? "true" : undefined}
+							className="settings-button legacy-team-setup-target"
+							onClick={() => {
+								if (!controlsBlocked) onDecision(device, "excluded");
+							}}
+							type="button"
+						>
+							Exclude
+						</button>
+					</>
+				) : (
+					<button
+						aria-disabled={controlsBlocked ? "true" : undefined}
+						className="settings-button legacy-team-setup-target"
+						onClick={() => {
+							if (!controlsBlocked) onDecision(device, "removed");
+						}}
+						type="button"
+					>
+						Remove
+					</button>
+				)}
+				{device.decision !== "unresolved" ? (
+					<button
+						aria-disabled={controlsBlocked ? "true" : undefined}
+						className="settings-button legacy-team-setup-target"
+						onClick={() => {
+							if (!controlsBlocked) onClear(device);
+						}}
+						type="button"
+					>
+						Clear decision
+					</button>
+				) : null}
+			</div>
+		</fieldset>
+	);
+}
+
+export function LegacyTeamSetupDevices(props: LegacyTeamSetupDevicesProps) {
+	return (
+		<section aria-labelledby="legacy-team-setup-step-devices">
+			<h3 id="legacy-team-setup-step-devices" tabIndex={-1}>
+				Review devices
+			</h3>
+			<p>
+				{props.detail.unresolvedDeviceCount.toLocaleString()} of{" "}
+				{props.detail.candidate.deviceCount.toLocaleString()} Team devices still need a decision.
+			</p>
+			<div className="legacy-team-device-list">
+				{props.detail.devices.map((device, index) => (
+					<DeviceRow
+						{...props}
+						busy={props.busyDeviceRef === device.deviceRef}
+						device={device}
+						index={index}
+						key={device.deviceRef}
+					/>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -1,7 +1,12 @@
 import { type ComponentChildren, render } from "preact";
 import { act } from "preact/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { LegacyTeamSetupApiError, type LegacyTeamSetupDetailResponseV1 } from "../lib/api";
+import {
+	LegacyTeamSetupApiError,
+	type LegacyTeamSetupDetailResponseV1,
+	type LegacyTeamSetupDeviceV1,
+	type LegacyTeamSetupIdentityChoiceV1,
+} from "../lib/api";
 
 const dialogControls = vi.hoisted(() => ({
 	onCloseAutoFocus: undefined as undefined | ((event: { preventDefault: () => void }) => void),
@@ -29,18 +34,48 @@ vi.mock("../components/primitives/radix-dialog", () => ({
 	},
 }));
 
-import { mountLegacyTeamSetupDialog, openLegacyTeamSetup } from "./legacy-team-setup-dialog";
+import {
+	type LegacyTeamSetupDialogDependencies,
+	mountLegacyTeamSetupDialog,
+	openLegacyTeamSetup,
+} from "./legacy-team-setup-dialog";
+
+const identities: LegacyTeamSetupIdentityChoiceV1[] = [
+	{ identityRef: "identity-ref-alex", displayName: "Alex" },
+	{ identityRef: "identity-ref-sam", displayName: "Sam" },
+];
+
+function device(overrides: Partial<LegacyTeamSetupDeviceV1> = {}): LegacyTeamSetupDeviceV1 {
+	return {
+		deviceRef: "device-ref-one",
+		displayName: "Work laptop",
+		enabled: true,
+		existingIdentityRef: null,
+		suggestedIdentityRef: "identity-ref-alex",
+		verifiedEvidenceKind: null,
+		decision: "unresolved",
+		targetIdentityRef: null,
+		expectation: { kind: "absent" },
+		...overrides,
+	};
+}
 
 function detail({
 	canFinish = false,
 	conflictState = null,
 	draftState = "in_progress",
+	attemptId = "opaque-attempt",
+	devices,
+	identityChoices = [],
 	unresolvedDeviceCount = 0,
 	unresolvedProjectCount = 0,
 }: {
 	canFinish?: boolean;
 	conflictState?: LegacyTeamSetupDetailResponseV1["conflictState"];
 	draftState?: "needs_setup" | "in_progress" | "stale" | "completed";
+	attemptId?: string;
+	devices?: LegacyTeamSetupDeviceV1[];
+	identityChoices?: LegacyTeamSetupIdentityChoiceV1[];
 	unresolvedDeviceCount?: number;
 	unresolvedProjectCount?: number;
 } = {}): LegacyTeamSetupDetailResponseV1 {
@@ -50,18 +85,18 @@ function detail({
 			candidateRef: "opaque-candidate",
 			displayName: "Example Team",
 			status: "in_progress" as const,
-			deviceCount: 3,
+			deviceCount: devices?.length ?? 3,
 			projectCount: 2,
 			unresolvedDeviceCount,
 			unresolvedProjectCount,
 		},
-		attemptId: "opaque-attempt",
+		attemptId,
 		draftState,
 		unresolvedDeviceCount,
 		unresolvedProjectCount,
-		devices: [],
+		devices: devices ?? [],
 		projects: [],
-		identityChoices: [],
+		identityChoices,
 	};
 	return canFinish
 		? {
@@ -92,8 +127,11 @@ function deferred<T>() {
 }
 
 function setup(
-	loadDetail: (candidateRef: string) => Promise<LegacyTeamSetupDetailResponseV1>,
-	overrides: Parameters<typeof mountLegacyTeamSetupDialog>[1] = {},
+	input:
+		| LegacyTeamSetupDialogDependencies["loadDetail"]
+		| (Partial<LegacyTeamSetupDialogDependencies> & {
+				loadDetail: LegacyTeamSetupDialogDependencies["loadDetail"];
+		  }),
 ) {
 	document.body.innerHTML = `
 		<button class="tab-btn" id="tabBtn-sharing" aria-current="page">Sharing</button>
@@ -105,12 +143,33 @@ function setup(
 	if (!(mount instanceof HTMLElement) || !(trigger instanceof HTMLButtonElement)) {
 		throw new Error("Team setup test fixture missing");
 	}
-	act(() => mountLegacyTeamSetupDialog(mount, { ...overrides, loadDetail }));
+	const overrides = typeof input === "function" ? { loadDetail: input } : input;
+	act(() => mountLegacyTeamSetupDialog(mount, overrides));
 	trigger.focus();
 	act(() => {
 		openLegacyTeamSetup("opaque-candidate");
 	});
 	return { mount, trigger };
+}
+
+function button(label: string): HTMLButtonElement {
+	const match = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+		(candidate) => candidate.textContent === label,
+	);
+	if (!match) throw new Error(`button missing: ${label}`);
+	return match;
+}
+
+function mutationResult() {
+	return {
+		version: 1 as const,
+		candidateRef: "opaque-candidate",
+		attemptId: "opaque-attempt",
+		draftState: "in_progress" as const,
+		canFinish: false,
+		unresolvedDeviceCount: 1,
+		unresolvedProjectCount: 0,
+	};
 }
 
 afterEach(() => {
@@ -249,7 +308,7 @@ describe("legacy Team setup dialog", () => {
 			.mockResolvedValueOnce(detail({ draftState: "stale", unresolvedProjectCount: 1 }))
 			.mockResolvedValueOnce(detail({ unresolvedProjectCount: 1 }));
 		const refreshCandidate = vi.fn().mockResolvedValue({});
-		setup(loadDetail, { refreshCandidate });
+		setup({ loadDetail, refreshCandidate });
 
 		await vi.waitFor(() => {
 			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
@@ -277,6 +336,595 @@ describe("legacy Team setup dialog", () => {
 		});
 		expect(refreshCandidate).toHaveBeenCalledTimes(2);
 		expect(loadDetail).toHaveBeenCalledTimes(3);
+	});
+
+	it("persists an identity assignment with exact expectation evidence and reloads detail", async () => {
+		const initialDevice = device({
+			existingIdentityRef: "identity-ref-alex",
+			suggestedIdentityRef: null,
+			verifiedEvidenceKind: "active_assignment",
+			expectation: {
+				kind: "existing",
+				assignmentVersion: 7,
+				identityRef: "identity-ref-alex",
+			},
+		});
+		const refreshedDevice = device({
+			...initialDevice,
+			targetIdentityRef: "identity-ref-sam",
+		});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(
+				detail({ devices: [initialDevice], identityChoices: identities, unresolvedDeviceCount: 1 }),
+			)
+			.mockResolvedValueOnce(
+				detail({
+					devices: [refreshedDevice],
+					identityChoices: identities,
+					unresolvedDeviceCount: 1,
+				}),
+			);
+		const saveAssignment = vi.fn().mockResolvedValue(mutationResult());
+		setup({ loadDetail, saveAssignment });
+
+		const select = await vi.waitFor(() => {
+			const match = document.querySelector<HTMLSelectElement>(".legacy-team-device-select");
+			if (!match) throw new Error("identity select missing");
+			return match;
+		});
+		select.value = "identity-ref-sam";
+		act(() => {
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		expect(saveAssignment).not.toHaveBeenCalled();
+		act(() => button("Save assignment").click());
+
+		await vi.waitFor(() => {
+			expect(saveAssignment).toHaveBeenCalledWith("opaque-candidate", "device-ref-one", {
+				attemptId: "opaque-attempt",
+				targetIdentityRef: "identity-ref-sam",
+				expectation: {
+					kind: "existing",
+					assignmentVersion: 7,
+					identityRef: "identity-ref-alex",
+				},
+			});
+			expect(document.querySelector<HTMLSelectElement>(".legacy-team-device-select")?.value).toBe(
+				"identity-ref-sam",
+			);
+			expect(loadDetail).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	it("lets users confirm an existing assignment before including its device", async () => {
+		const initialDevice = device({
+			existingIdentityRef: "identity-ref-alex",
+			suggestedIdentityRef: null,
+			verifiedEvidenceKind: "active_assignment",
+			expectation: {
+				kind: "existing",
+				assignmentVersion: 7,
+				identityRef: "identity-ref-alex",
+			},
+		});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(
+				detail({ devices: [initialDevice], identityChoices: identities, unresolvedDeviceCount: 1 }),
+			)
+			.mockResolvedValueOnce(
+				detail({
+					devices: [{ ...initialDevice, targetIdentityRef: "identity-ref-alex" }],
+					identityChoices: identities,
+					unresolvedDeviceCount: 1,
+				}),
+			);
+		const saveAssignment = vi.fn().mockResolvedValue(mutationResult());
+		setup({ loadDetail, saveAssignment });
+
+		await vi.waitFor(() => {
+			expect(document.querySelector<HTMLSelectElement>(".legacy-team-device-select")?.value).toBe(
+				"identity-ref-alex",
+			);
+		});
+		expect(button("Save assignment").getAttribute("aria-disabled")).toBeNull();
+		expect(button("Include").getAttribute("aria-disabled")).toBe("true");
+		act(() => button("Save assignment").click());
+
+		await vi.waitFor(() => {
+			expect(saveAssignment).toHaveBeenCalledWith("opaque-candidate", "device-ref-one", {
+				attemptId: "opaque-attempt",
+				targetIdentityRef: "identity-ref-alex",
+				expectation: initialDevice.expectation,
+			});
+			expect(loadDetail).toHaveBeenCalledTimes(2);
+			expect(button("Include").getAttribute("aria-disabled")).toBeNull();
+		});
+	});
+
+	it("blocks Include while a different selected assignment is unsaved", async () => {
+		const savedDevice = device({
+			existingIdentityRef: "identity-ref-alex",
+			suggestedIdentityRef: null,
+			verifiedEvidenceKind: "active_assignment",
+			targetIdentityRef: "identity-ref-alex",
+			expectation: {
+				kind: "existing",
+				assignmentVersion: 7,
+				identityRef: "identity-ref-alex",
+			},
+		});
+		const saveDecision = vi.fn();
+		setup({
+			loadDetail: vi
+				.fn()
+				.mockResolvedValue(
+					detail({ devices: [savedDevice], identityChoices: identities, unresolvedDeviceCount: 1 }),
+				),
+			saveDecision,
+		});
+
+		const select = await vi.waitFor(() => {
+			const match = document.querySelector<HTMLSelectElement>(".legacy-team-device-select");
+			if (!match) throw new Error("identity select missing");
+			return match;
+		});
+		expect(button("Include").getAttribute("aria-disabled")).toBeNull();
+		select.value = "identity-ref-sam";
+		act(() => {
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+
+		expect(button("Include").getAttribute("aria-disabled")).toBe("true");
+		const includeDescription = button("Include").getAttribute("aria-describedby") ?? "";
+		expect(
+			includeDescription
+				.split(" ")
+				.map((id) => document.getElementById(id)?.textContent)
+				.join(" "),
+		).toContain("Save the selected person assignment");
+		act(() => button("Include").click());
+		expect(saveDecision).not.toHaveBeenCalled();
+	});
+
+	it("blocks assignment and Include when the existing assignment evidence is inactive", async () => {
+		const saveAssignment = vi.fn();
+		const saveDecision = vi.fn();
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(
+				detail({
+					devices: [
+						device({
+							existingIdentityRef: "identity-ref-alex",
+							suggestedIdentityRef: null,
+							targetIdentityRef: "identity-ref-alex",
+							expectation: {
+								kind: "existing",
+								assignmentVersion: 7,
+								identityRef: "identity-ref-alex",
+							},
+						}),
+					],
+					identityChoices: identities,
+					unresolvedDeviceCount: 1,
+				}),
+			),
+			saveAssignment,
+			saveDecision,
+		});
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Current assignment: Alex"));
+		expect(button("Save assignment").getAttribute("aria-disabled")).toBe("true");
+		expect(button("Include").getAttribute("aria-disabled")).toBe("true");
+		expect(document.body.textContent).toContain("Reconcile this device in Devices or exclude it");
+		act(() => {
+			button("Save assignment").click();
+			button("Include").click();
+		});
+		expect(saveAssignment).not.toHaveBeenCalled();
+		expect(saveDecision).not.toHaveBeenCalled();
+	});
+
+	it("blocks assignment and inclusion when the selected person is unavailable", async () => {
+		const unavailableAssignment = {
+			existingIdentityRef: "identity-ref-missing",
+			suggestedIdentityRef: "identity-ref-missing",
+			verifiedEvidenceKind: "active_assignment" as const,
+			expectation: {
+				kind: "existing" as const,
+				assignmentVersion: 7,
+				identityRef: "identity-ref-missing",
+			},
+		};
+		const saveAssignment = vi.fn();
+		const saveDecision = vi.fn();
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(
+				detail({
+					devices: [
+						device({ ...unavailableAssignment, displayName: "Unsaved device" }),
+						device({
+							...unavailableAssignment,
+							deviceRef: "device-ref-two",
+							displayName: "Saved device",
+							targetIdentityRef: "identity-ref-missing",
+						}),
+					],
+					identityChoices: identities,
+					unresolvedDeviceCount: 2,
+				}),
+			),
+			saveAssignment,
+			saveDecision,
+		});
+
+		const rows = await vi.waitFor(() => {
+			const matches = [
+				...document.querySelectorAll<HTMLFieldSetElement>(".legacy-team-device-row"),
+			];
+			if (matches.length !== 2) throw new Error("device rows missing");
+			return matches;
+		});
+		const action = (row: HTMLFieldSetElement, label: string) =>
+			[...row.querySelectorAll<HTMLButtonElement>("button")].find(
+				(candidate) => candidate.textContent === label,
+			);
+		const save = action(rows[0], "Save assignment");
+		const include = action(rows[1], "Include");
+		expect(rows[0].textContent).toContain("This person is no longer available");
+		expect(rows[1].textContent).toContain("This person is no longer available");
+		expect(save?.getAttribute("aria-disabled")).toBe("true");
+		expect(include?.getAttribute("aria-disabled")).toBe("true");
+		expect(rows[0].querySelector("select")?.getAttribute("aria-describedby")).toContain(
+			"legacy-team-device-assignment-help-0",
+		);
+		act(() => {
+			save?.click();
+			include?.click();
+		});
+		expect(saveAssignment).not.toHaveBeenCalled();
+		expect(saveDecision).not.toHaveBeenCalled();
+	});
+
+	it("shows suggestions without treating them as reviewed assignments", async () => {
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValue(
+				detail({ devices: [device()], identityChoices: identities, unresolvedDeviceCount: 1 }),
+			);
+		setup({ loadDetail });
+
+		const select = await vi.waitFor(() => {
+			const match = document.querySelector<HTMLSelectElement>(".legacy-team-device-select");
+			if (!match) throw new Error("identity select missing");
+			return match;
+		});
+		expect(select.value).toBe("");
+		expect(document.body.textContent).toContain("Suggested person: Alex");
+		expect(button("Include").getAttribute("aria-disabled")).toBe("true");
+	});
+
+	it("persists exclude once while controls remain focusable and busy-guarded", async () => {
+		const pendingDecision = deferred<ReturnType<typeof mutationResult>>();
+		const initialDevice = device();
+		const excludedDevice = device({ decision: "excluded", suggestedIdentityRef: null });
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(
+				detail({ devices: [initialDevice], identityChoices: identities, unresolvedDeviceCount: 1 }),
+			)
+			.mockResolvedValueOnce(
+				detail({
+					devices: [excludedDevice],
+					identityChoices: identities,
+					unresolvedProjectCount: 1,
+				}),
+			);
+		const saveDecision = vi.fn().mockReturnValue(pendingDecision.promise);
+		setup({ loadDetail, saveDecision });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Work laptop"));
+
+		const exclude = button("Exclude");
+		exclude.focus();
+		act(() => {
+			exclude.click();
+			exclude.click();
+		});
+		expect(saveDecision).toHaveBeenCalledTimes(1);
+		expect(saveDecision).toHaveBeenCalledWith("opaque-candidate", "device-ref-one", {
+			attemptId: "opaque-attempt",
+			decision: "excluded",
+		});
+		expect(exclude.disabled).toBe(false);
+		expect(exclude.getAttribute("aria-disabled")).toBe("true");
+		expect(document.activeElement).toBe(exclude);
+		act(() => dialogControls.onOpenChange?.(false));
+		expect(document.getElementById("legacyTeamSetupDialog")).not.toBeNull();
+		expect(document.body.textContent).toContain(
+			"Team setup will stay open while this device change saves",
+		);
+
+		pendingDecision.resolve(mutationResult());
+		await vi.waitFor(() => {
+			expect(document.body.textContent).toContain("Review Projects");
+		});
+		expect(document.activeElement?.id).toBe("legacy-team-setup-step-projects");
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps a saved assignment resumable when include fails, then resumes only the decision", async () => {
+		const initialDevice = device({
+			existingIdentityRef: "identity-ref-alex",
+			suggestedIdentityRef: null,
+			verifiedEvidenceKind: "active_assignment",
+			expectation: {
+				kind: "existing",
+				assignmentVersion: 4,
+				identityRef: "identity-ref-alex",
+			},
+		});
+		const assignedDevice = device({
+			...initialDevice,
+			targetIdentityRef: "identity-ref-sam",
+		});
+		const includedDevice = device({
+			...assignedDevice,
+			decision: "included",
+		});
+		const assignedDetail = detail({
+			attemptId: "attempt-after-assignment",
+			devices: [assignedDevice],
+			identityChoices: identities,
+			unresolvedDeviceCount: 1,
+		});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(
+				detail({
+					attemptId: "attempt-before-assignment",
+					devices: [initialDevice],
+					identityChoices: identities,
+					unresolvedDeviceCount: 1,
+				}),
+			)
+			.mockResolvedValueOnce(assignedDetail)
+			.mockResolvedValueOnce(assignedDetail)
+			.mockResolvedValueOnce(
+				detail({
+					devices: [includedDevice],
+					identityChoices: identities,
+					unresolvedProjectCount: 1,
+				}),
+			);
+		const saveAssignment = vi.fn().mockResolvedValue(mutationResult());
+		const saveDecision = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("private decision failure"))
+			.mockResolvedValueOnce(mutationResult());
+		setup({ loadDetail, saveAssignment, saveDecision });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Work laptop"));
+
+		const select = document.querySelector<HTMLSelectElement>(".legacy-team-device-select");
+		if (!select) throw new Error("identity select missing");
+		select.value = "identity-ref-sam";
+		act(() => {
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		act(() => button("Save assignment").click());
+		await vi.waitFor(() => {
+			expect(loadDetail).toHaveBeenCalledTimes(2);
+			expect(button("Include").getAttribute("aria-disabled")).toBeNull();
+			expect(document.querySelector<HTMLSelectElement>(".legacy-team-device-select")?.value).toBe(
+				"identity-ref-sam",
+			);
+		});
+		act(() => button("Include").click());
+		await vi.waitFor(() => {
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain("could not be saved");
+		});
+		expect(document.body.textContent).not.toContain("private decision failure");
+		expect(saveAssignment).toHaveBeenCalledWith("opaque-candidate", "device-ref-one", {
+			attemptId: "attempt-before-assignment",
+			targetIdentityRef: "identity-ref-sam",
+			expectation: {
+				kind: "existing",
+				assignmentVersion: 4,
+				identityRef: "identity-ref-alex",
+			},
+		});
+		expect(saveDecision).toHaveBeenLastCalledWith("opaque-candidate", "device-ref-one", {
+			attemptId: "attempt-after-assignment",
+			decision: "included",
+			expectedTargetIdentityRef: "identity-ref-sam",
+		});
+		expect(document.querySelector<HTMLSelectElement>(".legacy-team-device-select")?.value).toBe(
+			"identity-ref-sam",
+		);
+
+		act(() => document.getElementById("legacy-team-setup-retry")?.click());
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
+		act(() => button("Include").click());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		expect(saveAssignment).toHaveBeenCalledTimes(1);
+		expect(saveDecision).toHaveBeenCalledTimes(2);
+		expect(loadDetail).toHaveBeenCalledTimes(4);
+	});
+
+	it("persists remove for inactive devices and reloads authoritative detail", async () => {
+		const initialDevice = device({ enabled: false, suggestedIdentityRef: null });
+		const removedDevice = device({
+			enabled: false,
+			suggestedIdentityRef: null,
+			decision: "removed",
+		});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(detail({ devices: [initialDevice], unresolvedDeviceCount: 1 }))
+			.mockResolvedValueOnce(detail({ devices: [removedDevice], unresolvedProjectCount: 1 }));
+		const saveDecision = vi.fn().mockResolvedValue(mutationResult());
+		const saveAssignment = vi.fn();
+		setup({ loadDetail, saveAssignment, saveDecision });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Device no longer active"));
+		expect(document.querySelector<HTMLSelectElement>(".legacy-team-device-select")?.disabled).toBe(
+			true,
+		);
+		expect(button("Save assignment").getAttribute("aria-disabled")).toBe("true");
+		act(() => button("Save assignment").click());
+		expect(saveAssignment).not.toHaveBeenCalled();
+
+		act(() => button("Remove").click());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		expect(saveDecision).toHaveBeenCalledWith("opaque-candidate", "device-ref-one", {
+			attemptId: "opaque-attempt",
+			decision: "removed",
+		});
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+	});
+
+	it("reports a saved device change separately when its authoritative reload fails", async () => {
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(
+				detail({ devices: [device()], identityChoices: identities, unresolvedDeviceCount: 1 }),
+			)
+			.mockRejectedValueOnce(new Error("private reload failure"));
+		const saveDecision = vi.fn().mockResolvedValue(mutationResult());
+		setup({ loadDetail, saveDecision });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Work laptop"));
+
+		act(() => button("Exclude").click());
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+				"was saved, but the latest Team setup details could not be loaded",
+			);
+		});
+		expect(document.body.textContent).not.toContain("private reload failure");
+		expect(document.body.textContent).not.toContain("device change could not be saved");
+		expect(saveDecision).toHaveBeenCalledTimes(1);
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+	});
+
+	it("clears a persisted decision with the current attempt and reloads detail", async () => {
+		const excludedDevice = device({ decision: "excluded", suggestedIdentityRef: null });
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(detail({ devices: [excludedDevice], unresolvedDeviceCount: 0 }))
+			.mockResolvedValueOnce(
+				detail({ devices: [device()], identityChoices: identities, unresolvedDeviceCount: 1 }),
+			);
+		const clearDecision = vi.fn().mockResolvedValue(mutationResult());
+		setup({ clearDecision, loadDetail });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review and finish"));
+		act(() => button("Devices").click());
+		expect(document.body.textContent).toContain("Clear decision");
+
+		act(() => button("Clear decision").click());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Needs a decision"));
+		expect(clearDecision).toHaveBeenCalledWith("opaque-candidate", "device-ref-one", {
+			attemptId: "opaque-attempt",
+		});
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+	});
+
+	it("reloads authoritative detail after a stale mutation and blocks more changes safely", async () => {
+		const initialDevice = device();
+		const refreshedDevice = device({
+			existingIdentityRef: "identity-ref-sam",
+			suggestedIdentityRef: null,
+			expectation: {
+				kind: "existing",
+				assignmentVersion: 9,
+				identityRef: "identity-ref-sam",
+			},
+		});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(
+				detail({ devices: [initialDevice], identityChoices: identities, unresolvedDeviceCount: 1 }),
+			)
+			.mockResolvedValueOnce(
+				detail({
+					attemptId: "fresh-attempt",
+					devices: [refreshedDevice],
+					identityChoices: identities,
+					unresolvedDeviceCount: 1,
+				}),
+			)
+			.mockResolvedValueOnce(
+				detail({
+					attemptId: "refreshed-attempt",
+					devices: [refreshedDevice],
+					identityChoices: identities,
+					unresolvedDeviceCount: 1,
+				}),
+			);
+		const refreshCandidate = vi.fn().mockResolvedValue({});
+		const saveDecision = vi
+			.fn()
+			.mockRejectedValue(new LegacyTeamSetupApiError(409, "team_setup_assignment_changed"));
+		setup({ loadDetail, refreshCandidate, saveDecision });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Work laptop"));
+
+		act(() => button("Exclude").click());
+		await vi.waitFor(() => {
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+				"changed since it was last reviewed",
+			);
+			expect(document.body.textContent).toContain("Current assignment: Sam");
+		});
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+		const exclude = button("Exclude");
+		expect(exclude.disabled).toBe(false);
+		expect(exclude.getAttribute("aria-disabled")).toBe("true");
+		exclude.focus();
+		expect(document.activeElement).toBe(exclude);
+
+		act(() => document.getElementById("legacy-team-setup-retry")?.click());
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
+		expect(refreshCandidate).toHaveBeenCalledWith("opaque-candidate");
+		expect(refreshCandidate.mock.invocationCallOrder[0]).toBeLessThan(
+			loadDetail.mock.invocationCallOrder[2],
+		);
+		expect(loadDetail).toHaveBeenCalledTimes(3);
+	});
+
+	it("refreshes the candidate before retrying a stale post-mutation detail", async () => {
+		const initialDevice = device();
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(
+				detail({ devices: [initialDevice], identityChoices: identities, unresolvedDeviceCount: 1 }),
+			)
+			.mockResolvedValueOnce(
+				detail({
+					draftState: "stale",
+					devices: [initialDevice],
+					identityChoices: identities,
+					unresolvedDeviceCount: 1,
+				}),
+			)
+			.mockResolvedValueOnce(
+				detail({ devices: [initialDevice], identityChoices: identities, unresolvedDeviceCount: 1 }),
+			);
+		const refreshCandidate = vi.fn().mockResolvedValue({});
+		setup({ loadDetail, refreshCandidate, saveDecision: vi.fn().mockResolvedValue({}) });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Work laptop"));
+
+		act(() => button("Exclude").click());
+		await vi.waitFor(() =>
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+				"changed since it was last reviewed",
+			),
+		);
+		act(() => document.getElementById("legacy-team-setup-retry")?.click());
+
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
+		expect(refreshCandidate).toHaveBeenCalledWith("opaque-candidate");
+		expect(refreshCandidate.mock.invocationCallOrder[0]).toBeLessThan(
+			loadDetail.mock.invocationCallOrder[2],
+		);
 	});
 
 	it("focuses explicit step navigation and restores the connected trigger on dismissal", async () => {

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
@@ -3,10 +3,13 @@ import { useEffect, useRef, useState } from "preact/hooks";
 import { DialogCloseButton } from "../components/primitives/dialog-close-button";
 import { RadixDialog } from "../components/primitives/radix-dialog";
 import * as api from "../lib/api";
+import { LegacyTeamSetupDevices } from "./legacy-team-setup-devices";
 
 type TeamSetupStep = "devices" | "projects" | "review" | "completed";
 const CHANGED_STATE_ERROR =
 	"Team setup changed since it was last reviewed. Reload the latest details to continue.";
+const SAVED_RELOAD_ERROR =
+	"The change was saved, but the latest Team setup details could not be loaded. Reload before continuing.";
 const RELOAD_ERROR_CODES = new Set<api.LegacyTeamSetupErrorCode>([
 	"team_setup_roster_changed",
 	"team_setup_assignment_changed",
@@ -14,14 +17,20 @@ const RELOAD_ERROR_CODES = new Set<api.LegacyTeamSetupErrorCode>([
 	"team_setup_confirmation_stale",
 ]);
 
-interface LegacyTeamSetupDialogDependencies {
+export interface LegacyTeamSetupDialogDependencies {
+	clearDecision: typeof api.clearLegacyTeamSetupDecision;
 	loadDetail: typeof api.loadLegacyTeamSetupDetail;
 	refreshCandidate: typeof api.refreshLegacyTeamSetupCandidate;
+	saveAssignment: typeof api.saveLegacyTeamSetupAssignment;
+	saveDecision: typeof api.saveLegacyTeamSetupDecision;
 }
 
 const defaultDependencies: LegacyTeamSetupDialogDependencies = {
+	clearDecision: api.clearLegacyTeamSetupDecision,
 	loadDetail: api.loadLegacyTeamSetupDetail,
 	refreshCandidate: api.refreshLegacyTeamSetupCandidate,
+	saveAssignment: api.saveLegacyTeamSetupAssignment,
+	saveDecision: api.saveLegacyTeamSetupDecision,
 };
 
 let pendingCandidateRef: string | null = null;
@@ -85,6 +94,19 @@ function isChangedStateError(cause: unknown): boolean {
 	return cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode);
 }
 
+function safeMutationError(cause: unknown): string {
+	if (isChangedStateError(cause)) {
+		return CHANGED_STATE_ERROR;
+	}
+	if (
+		cause instanceof api.LegacyTeamSetupApiError &&
+		cause.errorCode === "team_setup_roster_unavailable"
+	) {
+		return "Team device details are temporarily unavailable. Reload the latest details before trying again.";
+	}
+	return "This device change could not be saved. Reload the latest details before trying again.";
+}
+
 function StepContent({
 	detail,
 	step,
@@ -102,23 +124,7 @@ function StepContent({
 			</section>
 		);
 	}
-	if (step === "devices") {
-		return (
-			<section aria-labelledby="legacy-team-setup-step-devices">
-				<h3 id="legacy-team-setup-step-devices" tabIndex={-1}>
-					Review devices
-				</h3>
-				<p>
-					{detail.unresolvedDeviceCount.toLocaleString()} of{" "}
-					{detail.candidate.deviceCount.toLocaleString()} Team devices still need a person or
-					exclusion decision.
-				</p>
-				<p className="small">
-					Next setup action: assign each unresolved device to a person or exclude it from this Team.
-				</p>
-			</section>
-		);
-	}
+	if (step === "devices") return null;
 	if (step === "projects") {
 		return (
 			<section aria-labelledby="legacy-team-setup-step-projects">
@@ -164,10 +170,14 @@ function LegacyTeamSetupDialogHost({
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [loadRevision, setLoadRevision] = useState(0);
+	const [busyDeviceRef, setBusyDeviceRef] = useState<string | null>(null);
+	const [operationStatus, setOperationStatus] = useState("");
+	const [isSubmitting, setIsSubmitting] = useState(false);
 	const focusAfterLoad = useRef(false);
 	const focusStepAfterRender = useRef(false);
 	const refreshBeforeLoad = useRef(false);
 	const retryNeedsRefresh = useRef(false);
+	const submitting = useRef(false);
 
 	useEffect(() => {
 		requestOpen = (nextCandidateRef) => {
@@ -239,6 +249,12 @@ function LegacyTeamSetupDialogHost({
 	if (!candidateRef) return null;
 	const title = detail ? `Set up ${detail.candidate.displayName}` : "Set up Team";
 	const close = () => {
+		if (submitting.current) {
+			setOperationStatus(
+				"Team setup will stay open while this device change saves. Close it after saving finishes.",
+			);
+			return;
+		}
 		focusAfterLoad.current = false;
 		focusStepAfterRender.current = false;
 		refreshBeforeLoad.current = false;
@@ -247,6 +263,9 @@ function LegacyTeamSetupDialogHost({
 		setDetail(null);
 		setError(null);
 		setLoading(false);
+		setBusyDeviceRef(null);
+		setOperationStatus("");
+		setStep("devices");
 	};
 	const navigate = (nextStep: TeamSetupStep) => {
 		if (nextStep === step) {
@@ -258,6 +277,125 @@ function LegacyTeamSetupDialogHost({
 	};
 	const devicesBlockProgress = detail ? detail.unresolvedDeviceCount > 0 : false;
 	const projectsBlockReview = detail ? detail.unresolvedProjectCount > 0 : false;
+	const mutationsBlocked = loading || isSubmitting || Boolean(error);
+	const applyAuthoritativeDetail = (
+		nextDetail: api.LegacyTeamSetupDetailResponseV1,
+		preserveDevicesStep: boolean,
+	) => {
+		retryNeedsRefresh.current = detailNeedsRecovery(nextDetail);
+		setDetail(nextDetail);
+		setStep((current) => {
+			const nextStep =
+				preserveDevicesStep && current === "devices" && nextDetail.unresolvedDeviceCount > 0
+					? "devices"
+					: initialStep(nextDetail);
+			if (nextStep !== current) focusStepAfterRender.current = true;
+			return nextStep;
+		});
+		setError(detailNeedsRecovery(nextDetail) ? CHANGED_STATE_ERROR : null);
+	};
+	const reloadAfterMutation = async () => {
+		const nextDetail = await dependencies.loadDetail(candidateRef);
+		applyAuthoritativeDetail(nextDetail, true);
+		return nextDetail;
+	};
+	const recoverMutation = async (cause: unknown) => {
+		const message = safeMutationError(cause);
+		setOperationStatus("");
+		setError(message);
+		if (
+			!(cause instanceof api.LegacyTeamSetupApiError) ||
+			!RELOAD_ERROR_CODES.has(cause.errorCode)
+		) {
+			return;
+		}
+		try {
+			const nextDetail = await dependencies.loadDetail(candidateRef);
+			applyAuthoritativeDetail(nextDetail, true);
+			retryNeedsRefresh.current = true;
+		} catch {
+			retryNeedsRefresh.current = true;
+			// Keep the stable mutation error when the best-effort recovery reload also fails.
+		}
+		setError(message);
+	};
+	const runDeviceMutation = async (
+		device: api.LegacyTeamSetupDeviceV1,
+		status: string,
+		operation: () => Promise<void>,
+	) => {
+		if (mutationsBlocked || submitting.current) return;
+		submitting.current = true;
+		setIsSubmitting(true);
+		setBusyDeviceRef(device.deviceRef);
+		setOperationStatus(status);
+		setError(null);
+		try {
+			try {
+				await operation();
+			} catch (cause) {
+				await recoverMutation(cause);
+				return;
+			}
+			try {
+				await reloadAfterMutation();
+				setOperationStatus(`${device.displayName} saved.`);
+			} catch {
+				setOperationStatus("");
+				setError(SAVED_RELOAD_ERROR);
+			}
+		} finally {
+			submitting.current = false;
+			setIsSubmitting(false);
+			setBusyDeviceRef(null);
+		}
+	};
+	const assignDevice = (device: api.LegacyTeamSetupDeviceV1, targetIdentityRef: string) => {
+		const currentDetail = detail;
+		if (!currentDetail) return;
+		void runDeviceMutation(device, `Saving the assignment for ${device.displayName}.`, async () => {
+			await dependencies.saveAssignment(candidateRef, device.deviceRef, {
+				attemptId: currentDetail.attemptId,
+				targetIdentityRef,
+				expectation: device.expectation,
+			});
+		});
+	};
+	const decideDevice = (
+		device: api.LegacyTeamSetupDeviceV1,
+		decision: "included" | "excluded" | "removed",
+		targetIdentityRef?: string,
+	) => {
+		const currentDetail = detail;
+		if (!currentDetail) return;
+		if (decision === "included" && !targetIdentityRef) {
+			setOperationStatus(`Save a person assignment before including ${device.displayName}.`);
+			return;
+		}
+		void runDeviceMutation(device, `Saving the decision for ${device.displayName}.`, async () => {
+			if (decision === "included" && targetIdentityRef) {
+				await dependencies.saveDecision(candidateRef, device.deviceRef, {
+					attemptId: currentDetail.attemptId,
+					decision: "included",
+					expectedTargetIdentityRef: targetIdentityRef,
+				});
+			} else if (decision !== "included") {
+				await dependencies.saveDecision(candidateRef, device.deviceRef, {
+					attemptId: currentDetail.attemptId,
+					decision,
+				});
+			}
+		});
+	};
+	const clearDevice = (device: api.LegacyTeamSetupDeviceV1) => {
+		const currentDetail = detail;
+		if (!currentDetail) return;
+		void runDeviceMutation(device, `Clearing the decision for ${device.displayName}.`, async () => {
+			await dependencies.clearDecision(candidateRef, device.deviceRef, {
+				attemptId: currentDetail.attemptId,
+			});
+		});
+	};
 
 	return (
 		<RadixDialog
@@ -285,12 +423,19 @@ function LegacyTeamSetupDialogHost({
 			overlayClassName="modal-backdrop"
 			overlayId="legacyTeamSetupDialogBackdrop"
 		>
-			<div aria-busy={loading ? "true" : "false"} className="modal-card legacy-team-setup-card">
+			<div
+				aria-busy={loading || isSubmitting ? "true" : "false"}
+				className="modal-card legacy-team-setup-card"
+			>
 				<div className="modal-header">
 					<h2 id="legacy-team-setup-title" tabIndex={-1}>
 						{title}
 					</h2>
-					<DialogCloseButton ariaLabel={`Close ${title}`} onClick={close} />
+					<DialogCloseButton
+						ariaDisabled={isSubmitting}
+						ariaLabel={`Close ${title}`}
+						onClick={close}
+					/>
 				</div>
 				<div className="modal-body legacy-team-setup-body">
 					<p className="small" id="legacy-team-setup-description">
@@ -304,11 +449,11 @@ function LegacyTeamSetupDialogHost({
 								{error}
 							</p>
 							<button
-								aria-disabled={loading ? "true" : undefined}
+								aria-disabled={loading || isSubmitting ? "true" : undefined}
 								className="settings-button legacy-team-setup-target"
 								id="legacy-team-setup-retry"
 								onClick={() => {
-									if (loading) return;
+									if (loading || isSubmitting) return;
 									focusAfterLoad.current = true;
 									refreshBeforeLoad.current = retryNeedsRefresh.current;
 									setLoadRevision((current) => current + 1);
@@ -390,12 +535,27 @@ function LegacyTeamSetupDialogHost({
 									Refreshing Team setup details…
 								</p>
 							) : null}
-							<StepContent detail={detail} step={step} />
+							<p aria-live="polite" className="small" role="status">
+								{operationStatus}
+							</p>
+							{step === "devices" ? (
+								<LegacyTeamSetupDevices
+									blocked={mutationsBlocked}
+									busyDeviceRef={busyDeviceRef}
+									detail={detail}
+									onAssign={assignDevice}
+									onClear={clearDevice}
+									onDecision={decideDevice}
+								/>
+							) : (
+								<StepContent detail={detail} step={step} />
+							)}
 						</>
 					) : null}
 				</div>
 				<div className="modal-footer legacy-team-setup-actions">
 					<button
+						aria-disabled={isSubmitting ? "true" : undefined}
 						className="settings-button legacy-team-setup-target"
 						onClick={close}
 						type="button"

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1227,6 +1227,27 @@
       .legacy-team-setup-error { display: grid; gap: var(--sp-2); justify-items: start; }
       .legacy-team-setup-actions { justify-content: flex-end; }
       .legacy-team-setup-target { min-width: 24px; min-height: 24px; }
+      .legacy-team-device-list { display: grid; gap: var(--sp-3); margin-top: var(--sp-3); }
+      .legacy-team-device-row {
+        display: grid;
+        gap: var(--sp-2);
+        min-width: 0;
+        margin: 0;
+        padding: var(--sp-3);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-2);
+      }
+      .legacy-team-device-row legend {
+        padding: 0 var(--sp-1);
+        color: var(--text-primary);
+        font-weight: var(--font-weight-semibold);
+      }
+      .legacy-team-device-row label { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); }
+      .legacy-team-device-evidence { display: grid; gap: var(--sp-1); }
+      .legacy-team-device-select { width: 100%; margin: 0; }
+      .legacy-team-device-select:disabled { opacity: 0.55; cursor: not-allowed; }
+      .legacy-team-device-actions { display: flex; flex-wrap: wrap; gap: var(--sp-2); }
       .recipient-policy-management-selection fieldset { border: 0; padding: 0; margin: var(--sp-4) 0 0; }
       .recipient-policy-management-selection legend { font-weight: var(--font-weight-semibold); }
       .recipient-policy-management-review section + section { margin-top: var(--sp-4); }


### PR DESCRIPTION
## Description

Add resumable Team setup device assignment and decision controls. Device mutations persist immediately, reject duplicate submissions, reload authoritative detail, and preserve partial progress when a follow-up operation fails.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Stack-tip validation also passed `pnpm --filter @codemem/ui build` and `git diff --check`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced