### PR TITLE
feat(ui): add Team setup Project mappings

### DIFF
--- a/packages/ui/src/tabs/legacy-team-setup-devices.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-devices.tsx
@@ -80,7 +80,12 @@ function DeviceRow({
 		draftIdentityRef === savedIdentity;
 
 	return (
-		<fieldset aria-busy={busy ? "true" : "false"} className="legacy-team-device-row">
+		<fieldset
+			aria-busy={busy ? "true" : "false"}
+			className="legacy-team-device-row"
+			id={`legacy-team-device-row-${index}`}
+			tabIndex={device.decision === "unresolved" ? -1 : undefined}
+		>
 			<legend>{device.displayName}</legend>
 			<div className="small legacy-team-device-evidence" id={evidenceId}>
 				<span>

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -6,6 +6,7 @@ import {
 	type LegacyTeamSetupDetailResponseV1,
 	type LegacyTeamSetupDeviceV1,
 	type LegacyTeamSetupIdentityChoiceV1,
+	type LegacyTeamSetupProjectV1,
 } from "../lib/api";
 
 const dialogControls = vi.hoisted(() => ({
@@ -60,6 +61,21 @@ function device(overrides: Partial<LegacyTeamSetupDeviceV1> = {}): LegacyTeamSet
 	};
 }
 
+function project(overrides: Partial<LegacyTeamSetupProjectV1> = {}): LegacyTeamSetupProjectV1 {
+	return {
+		projectRef: "project-ref-one",
+		displayName: "Legacy Project",
+		resolution: "unresolved",
+		canonicalProjectRef: null,
+		resolvedProjectRef: null,
+		mappingChoices: [
+			{ resolvedProjectRef: "resolved-project-alpha", displayName: "Project Alpha" },
+			{ resolvedProjectRef: "resolved-project-beta", displayName: "Project Beta" },
+		],
+		...overrides,
+	};
+}
+
 function detail({
 	canFinish = false,
 	conflictState = null,
@@ -67,6 +83,7 @@ function detail({
 	attemptId = "opaque-attempt",
 	devices,
 	identityChoices = [],
+	projects,
 	unresolvedDeviceCount = 0,
 	unresolvedProjectCount = 0,
 }: {
@@ -76,6 +93,7 @@ function detail({
 	attemptId?: string;
 	devices?: LegacyTeamSetupDeviceV1[];
 	identityChoices?: LegacyTeamSetupIdentityChoiceV1[];
+	projects?: LegacyTeamSetupProjectV1[];
 	unresolvedDeviceCount?: number;
 	unresolvedProjectCount?: number;
 } = {}): LegacyTeamSetupDetailResponseV1 {
@@ -86,7 +104,7 @@ function detail({
 			displayName: "Example Team",
 			status: "in_progress" as const,
 			deviceCount: devices?.length ?? 3,
-			projectCount: 2,
+			projectCount: projects?.length ?? 2,
 			unresolvedDeviceCount,
 			unresolvedProjectCount,
 		},
@@ -95,7 +113,7 @@ function detail({
 		unresolvedDeviceCount,
 		unresolvedProjectCount,
 		devices: devices ?? [],
-		projects: [],
+		projects: projects ?? [],
 		identityChoices,
 	};
 	return canFinish
@@ -194,7 +212,17 @@ describe("legacy Team setup dialog", () => {
 			"true",
 		);
 
-		pending.resolve(detail({ unresolvedDeviceCount: 2, unresolvedProjectCount: 1 }));
+		pending.resolve(
+			detail({
+				devices: [
+					device(),
+					device({ deviceRef: "device-ref-two", displayName: "Second laptop" }),
+					device({ deviceRef: "device-ref-three", decision: "excluded" }),
+				],
+				unresolvedDeviceCount: 2,
+				unresolvedProjectCount: 1,
+			}),
+		);
 		await vi.waitFor(() => {
 			expect(document.body.textContent).toContain("Set up Example Team");
 			expect(document.body.textContent).toContain("2 of 3 Team devices");
@@ -214,6 +242,28 @@ describe("legacy Team setup dialog", () => {
 		);
 		act(() => projectsButton?.click());
 		expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Devices");
+		expect(document.activeElement?.id).toBe("legacy-team-device-row-0");
+		expect(document.body.textContent).toContain(
+			"Finish the device decisions before mapping Projects.",
+		);
+	});
+
+	it("moves blocked Review navigation to the unresolved Projects step", async () => {
+		setup(vi.fn().mockResolvedValue(detail({ projects: [project()], unresolvedProjectCount: 1 })));
+		await vi.waitFor(() => {
+			expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Projects");
+		});
+		act(() => button("Devices").click());
+		expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Devices");
+
+		act(() => button("Review").click());
+		await vi.waitFor(() => {
+			expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Projects");
+			expect(document.activeElement?.id).toBe("legacy-team-project-row-0");
+		});
+		expect(document.body.textContent).toContain(
+			"Finish the Project mappings before reviewing access.",
+		);
 	});
 
 	it("treats incomplete setup as normal progress rather than changed state", async () => {
@@ -642,7 +692,7 @@ describe("legacy Team setup dialog", () => {
 		act(() => dialogControls.onOpenChange?.(false));
 		expect(document.getElementById("legacyTeamSetupDialog")).not.toBeNull();
 		expect(document.body.textContent).toContain(
-			"Team setup will stay open while this device change saves",
+			"Team setup will stay open while this change saves",
 		);
 
 		pendingDecision.resolve(mutationResult());
@@ -925,6 +975,165 @@ describe("legacy Team setup dialog", () => {
 		expect(refreshCandidate.mock.invocationCallOrder[0]).toBeLessThan(
 			loadDetail.mock.invocationCallOrder[2],
 		);
+	});
+
+	it("shows deterministic Project mappings as read-only server evidence", async () => {
+		const deterministic = project({
+			canonicalProjectRef: "opaque-canonical-project",
+			mappingChoices: [],
+			resolution: "deterministic",
+			resolvedProjectRef: "opaque-resolved-project",
+		});
+		const unresolved = project({ projectRef: "project-ref-two", displayName: "Needs mapping" });
+		const loadDetail = vi.fn().mockResolvedValue(
+			detail({
+				projects: [deterministic, unresolved],
+				unresolvedProjectCount: 1,
+			}),
+		);
+		setup({ loadDetail });
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Mapped automatically"));
+		expect(document.body.textContent).toContain("Legacy Project");
+		expect(document.body.textContent).not.toContain("opaque-canonical-project");
+		expect(document.querySelectorAll(".legacy-team-project-select")).toHaveLength(1);
+	});
+
+	it("persists one explicit Project mapping and advances after authoritative reload", async () => {
+		const initialProject = project();
+		const mappedProject = project({
+			resolution: "explicit",
+			resolvedProjectRef: "resolved-project-beta",
+		});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(detail({ projects: [initialProject], unresolvedProjectCount: 1 }))
+			.mockResolvedValueOnce(detail({ projects: [mappedProject] }));
+		const saveProjectMapping = vi.fn().mockResolvedValue(mutationResult());
+		setup({ loadDetail, saveProjectMapping });
+
+		const select = await vi.waitFor(() => {
+			const match = document.querySelector<HTMLSelectElement>(".legacy-team-project-select");
+			if (!match) throw new Error("Project mapping select missing");
+			return match;
+		});
+		expect([...select.options].map((option) => option.textContent)).toEqual([
+			"Choose a Project",
+			"Project Alpha",
+			"Project Beta",
+		]);
+		select.value = "resolved-project-beta";
+		act(() => {
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		expect(saveProjectMapping).not.toHaveBeenCalled();
+		act(() => {
+			button("Save mapping").click();
+			button("Save mapping").click();
+		});
+
+		expect(saveProjectMapping).toHaveBeenCalledTimes(1);
+		expect(saveProjectMapping).toHaveBeenCalledWith("opaque-candidate", "project-ref-one", {
+			attemptId: "opaque-attempt",
+			resolvedProjectRef: "resolved-project-beta",
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review and finish"));
+		expect(document.activeElement?.id).toBe("legacy-team-setup-step-review");
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+	});
+
+	it("reloads stale Project mapping evidence and keeps safe recovery copy", async () => {
+		const initialProject = project();
+		const refreshedProject = project({
+			mappingChoices: [
+				{ resolvedProjectRef: "resolved-project-gamma", displayName: "Project Gamma" },
+			],
+		});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(detail({ projects: [initialProject], unresolvedProjectCount: 1 }))
+			.mockResolvedValueOnce(
+				detail({
+					attemptId: "fresh-attempt",
+					projects: [refreshedProject],
+					unresolvedProjectCount: 1,
+				}),
+			)
+			.mockResolvedValue(
+				detail({
+					attemptId: "fresh-attempt",
+					projects: [refreshedProject],
+					unresolvedProjectCount: 1,
+				}),
+			);
+		const saveProjectMapping = vi
+			.fn()
+			.mockRejectedValue(new LegacyTeamSetupApiError(409, "team_setup_confirmation_stale"));
+		const refreshCandidate = vi.fn().mockResolvedValue({});
+		setup({ loadDetail, refreshCandidate, saveProjectMapping });
+
+		const select = await vi.waitFor(() => {
+			const match = document.querySelector<HTMLSelectElement>(".legacy-team-project-select");
+			if (!match) throw new Error("Project mapping select missing");
+			return match;
+		});
+		select.value = "resolved-project-alpha";
+		act(() => {
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		act(() => button("Save mapping").click());
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+				"changed since it was last reviewed",
+			);
+			expect(document.body.textContent).toContain("Project Gamma");
+			expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")?.value).toBe(
+				"",
+			);
+		});
+		expect(document.body.textContent).not.toContain("team_setup_confirmation_stale");
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+		expect(button("Save mapping").getAttribute("aria-disabled")).toBe("true");
+
+		act(() => document.getElementById("legacy-team-setup-retry")?.click());
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
+		expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")?.value).toBe(
+			"",
+		);
+		expect(button("Save mapping").getAttribute("aria-disabled")).toBe("true");
+		expect(loadDetail).toHaveBeenCalledTimes(3);
+		expect(refreshCandidate).toHaveBeenCalledWith("opaque-candidate");
+	});
+
+	it("reports a saved mapping separately when its authoritative reload fails", async () => {
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(detail({ projects: [project()], unresolvedProjectCount: 1 }))
+			.mockRejectedValueOnce(new Error("private reload failure"));
+		const saveProjectMapping = vi.fn().mockResolvedValue(mutationResult());
+		setup({ loadDetail, saveProjectMapping });
+
+		const select = await vi.waitFor(() => {
+			const match = document.querySelector<HTMLSelectElement>(".legacy-team-project-select");
+			if (!match) throw new Error("Project mapping select missing");
+			return match;
+		});
+		select.value = "resolved-project-alpha";
+		act(() => {
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		act(() => button("Save mapping").click());
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+				"was saved, but the latest Team setup details could not be loaded",
+			);
+		});
+		expect(document.body.textContent).not.toContain("private reload failure");
+		expect(document.body.textContent).not.toContain("mapping could not be saved");
+		expect(saveProjectMapping).toHaveBeenCalledTimes(1);
+		expect(loadDetail).toHaveBeenCalledTimes(2);
 	});
 
 	it("focuses explicit step navigation and restores the connected trigger on dismissal", async () => {

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
@@ -4,6 +4,7 @@ import { DialogCloseButton } from "../components/primitives/dialog-close-button"
 import { RadixDialog } from "../components/primitives/radix-dialog";
 import * as api from "../lib/api";
 import { LegacyTeamSetupDevices } from "./legacy-team-setup-devices";
+import { LegacyTeamSetupProjects } from "./legacy-team-setup-projects";
 
 type TeamSetupStep = "devices" | "projects" | "review" | "completed";
 const CHANGED_STATE_ERROR =
@@ -23,6 +24,7 @@ export interface LegacyTeamSetupDialogDependencies {
 	refreshCandidate: typeof api.refreshLegacyTeamSetupCandidate;
 	saveAssignment: typeof api.saveLegacyTeamSetupAssignment;
 	saveDecision: typeof api.saveLegacyTeamSetupDecision;
+	saveProjectMapping: typeof api.saveLegacyTeamSetupProjectMapping;
 }
 
 const defaultDependencies: LegacyTeamSetupDialogDependencies = {
@@ -31,6 +33,7 @@ const defaultDependencies: LegacyTeamSetupDialogDependencies = {
 	refreshCandidate: api.refreshLegacyTeamSetupCandidate,
 	saveAssignment: api.saveLegacyTeamSetupAssignment,
 	saveDecision: api.saveLegacyTeamSetupDecision,
+	saveProjectMapping: api.saveLegacyTeamSetupProjectMapping,
 };
 
 let pendingCandidateRef: string | null = null;
@@ -107,6 +110,13 @@ function safeMutationError(cause: unknown): string {
 	return "This device change could not be saved. Reload the latest details before trying again.";
 }
 
+function safeProjectMutationError(cause: unknown): string {
+	if (cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode)) {
+		return CHANGED_STATE_ERROR;
+	}
+	return "This Project mapping could not be saved. Reload the latest details before trying again.";
+}
+
 function StepContent({
 	detail,
 	step,
@@ -125,23 +135,7 @@ function StepContent({
 		);
 	}
 	if (step === "devices") return null;
-	if (step === "projects") {
-		return (
-			<section aria-labelledby="legacy-team-setup-step-projects">
-				<h3 id="legacy-team-setup-step-projects" tabIndex={-1}>
-					Review Projects
-				</h3>
-				<p>
-					{detail.unresolvedProjectCount.toLocaleString()} of{" "}
-					{detail.candidate.projectCount.toLocaleString()} Team Projects still need a mapping
-					decision.
-				</p>
-				<p className="small">
-					Next setup action: map each unresolved Project using the server-provided choices.
-				</p>
-			</section>
-		);
-	}
+	if (step === "projects") return null;
 	return (
 		<section aria-labelledby="legacy-team-setup-step-review">
 			<h3 id="legacy-team-setup-step-review" tabIndex={-1}>
@@ -171,9 +165,11 @@ function LegacyTeamSetupDialogHost({
 	const [error, setError] = useState<string | null>(null);
 	const [loadRevision, setLoadRevision] = useState(0);
 	const [busyDeviceRef, setBusyDeviceRef] = useState<string | null>(null);
+	const [busyProjectRef, setBusyProjectRef] = useState<string | null>(null);
 	const [operationStatus, setOperationStatus] = useState("");
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const focusAfterLoad = useRef(false);
+	const focusControlAfterRender = useRef<string | null>(null);
 	const focusStepAfterRender = useRef(false);
 	const refreshBeforeLoad = useRef(false);
 	const retryNeedsRefresh = useRef(false);
@@ -231,6 +227,13 @@ function LegacyTeamSetupDialogHost({
 	}, [candidateRef, dependencies, loadRevision]);
 
 	useEffect(() => {
+		if (focusControlAfterRender.current) {
+			const targetId = focusControlAfterRender.current;
+			focusControlAfterRender.current = null;
+			focusStepAfterRender.current = false;
+			document.getElementById(targetId)?.focus();
+			return;
+		}
 		if (!focusStepAfterRender.current) return;
 		focusStepAfterRender.current = false;
 		document.getElementById(`legacy-team-setup-step-${step}`)?.focus();
@@ -251,11 +254,12 @@ function LegacyTeamSetupDialogHost({
 	const close = () => {
 		if (submitting.current) {
 			setOperationStatus(
-				"Team setup will stay open while this device change saves. Close it after saving finishes.",
+				"Team setup will stay open while this change saves. Close it after saving finishes.",
 			);
 			return;
 		}
 		focusAfterLoad.current = false;
+		focusControlAfterRender.current = null;
 		focusStepAfterRender.current = false;
 		refreshBeforeLoad.current = false;
 		retryNeedsRefresh.current = false;
@@ -264,6 +268,7 @@ function LegacyTeamSetupDialogHost({
 		setError(null);
 		setLoading(false);
 		setBusyDeviceRef(null);
+		setBusyProjectRef(null);
 		setOperationStatus("");
 		setStep("devices");
 	};
@@ -274,6 +279,25 @@ function LegacyTeamSetupDialogHost({
 		}
 		focusStepAfterRender.current = true;
 		setStep(nextStep);
+	};
+	const explainBlockedStep = (blockedStep: "devices" | "projects", message: string) => {
+		setOperationStatus(message);
+		const unresolvedIndex =
+			blockedStep === "devices"
+				? detail?.devices.findIndex((device) => device.decision === "unresolved")
+				: detail?.projects.findIndex((project) => project.resolution === "unresolved");
+		const targetId =
+			unresolvedIndex !== undefined && unresolvedIndex >= 0
+				? blockedStep === "devices"
+					? `legacy-team-device-row-${unresolvedIndex}`
+					: `legacy-team-project-row-${unresolvedIndex}`
+				: null;
+		if (targetId && blockedStep === step) {
+			document.getElementById(targetId)?.focus();
+			return;
+		}
+		focusControlAfterRender.current = targetId;
+		navigate(blockedStep);
 	};
 	const devicesBlockProgress = detail ? detail.unresolvedDeviceCount > 0 : false;
 	const projectsBlockReview = detail ? detail.unresolvedProjectCount > 0 : false;
@@ -299,8 +323,8 @@ function LegacyTeamSetupDialogHost({
 		applyAuthoritativeDetail(nextDetail, true);
 		return nextDetail;
 	};
-	const recoverMutation = async (cause: unknown) => {
-		const message = safeMutationError(cause);
+	const recoverMutation = async (cause: unknown, getMessage = safeMutationError) => {
+		const message = getMessage(cause);
 		setOperationStatus("");
 		setError(message);
 		if (
@@ -319,27 +343,30 @@ function LegacyTeamSetupDialogHost({
 		}
 		setError(message);
 	};
-	const runDeviceMutation = async (
-		device: api.LegacyTeamSetupDeviceV1,
+	const runMutation = async (
+		itemRef: string,
 		status: string,
-		operation: () => Promise<void>,
+		savedStatus: string,
+		setBusyRef: (value: string | null) => void,
+		getError: (cause: unknown) => string,
+		operation: () => Promise<unknown>,
 	) => {
 		if (mutationsBlocked || submitting.current) return;
 		submitting.current = true;
 		setIsSubmitting(true);
-		setBusyDeviceRef(device.deviceRef);
+		setBusyRef(itemRef);
 		setOperationStatus(status);
 		setError(null);
 		try {
 			try {
 				await operation();
 			} catch (cause) {
-				await recoverMutation(cause);
+				await recoverMutation(cause, getError);
 				return;
 			}
 			try {
 				await reloadAfterMutation();
-				setOperationStatus(`${device.displayName} saved.`);
+				setOperationStatus(savedStatus);
 			} catch {
 				setOperationStatus("");
 				setError(SAVED_RELOAD_ERROR);
@@ -347,19 +374,25 @@ function LegacyTeamSetupDialogHost({
 		} finally {
 			submitting.current = false;
 			setIsSubmitting(false);
-			setBusyDeviceRef(null);
+			setBusyRef(null);
 		}
 	};
 	const assignDevice = (device: api.LegacyTeamSetupDeviceV1, targetIdentityRef: string) => {
 		const currentDetail = detail;
 		if (!currentDetail) return;
-		void runDeviceMutation(device, `Saving the assignment for ${device.displayName}.`, async () => {
-			await dependencies.saveAssignment(candidateRef, device.deviceRef, {
-				attemptId: currentDetail.attemptId,
-				targetIdentityRef,
-				expectation: device.expectation,
-			});
-		});
+		void runMutation(
+			device.deviceRef,
+			`Saving the assignment for ${device.displayName}.`,
+			`${device.displayName} saved.`,
+			setBusyDeviceRef,
+			safeMutationError,
+			() =>
+				dependencies.saveAssignment(candidateRef, device.deviceRef, {
+					attemptId: currentDetail.attemptId,
+					targetIdentityRef,
+					expectation: device.expectation,
+				}),
+		);
 	};
 	const decideDevice = (
 		device: api.LegacyTeamSetupDeviceV1,
@@ -372,29 +405,58 @@ function LegacyTeamSetupDialogHost({
 			setOperationStatus(`Save a person assignment before including ${device.displayName}.`);
 			return;
 		}
-		void runDeviceMutation(device, `Saving the decision for ${device.displayName}.`, async () => {
-			if (decision === "included" && targetIdentityRef) {
-				await dependencies.saveDecision(candidateRef, device.deviceRef, {
-					attemptId: currentDetail.attemptId,
-					decision: "included",
-					expectedTargetIdentityRef: targetIdentityRef,
-				});
-			} else if (decision !== "included") {
-				await dependencies.saveDecision(candidateRef, device.deviceRef, {
-					attemptId: currentDetail.attemptId,
-					decision,
-				});
-			}
-		});
+		void runMutation(
+			device.deviceRef,
+			`Saving the decision for ${device.displayName}.`,
+			`${device.displayName} saved.`,
+			setBusyDeviceRef,
+			safeMutationError,
+			async () => {
+				if (decision === "included" && targetIdentityRef) {
+					await dependencies.saveDecision(candidateRef, device.deviceRef, {
+						attemptId: currentDetail.attemptId,
+						decision: "included",
+						expectedTargetIdentityRef: targetIdentityRef,
+					});
+				} else if (decision !== "included") {
+					await dependencies.saveDecision(candidateRef, device.deviceRef, {
+						attemptId: currentDetail.attemptId,
+						decision,
+					});
+				}
+			},
+		);
 	};
 	const clearDevice = (device: api.LegacyTeamSetupDeviceV1) => {
 		const currentDetail = detail;
 		if (!currentDetail) return;
-		void runDeviceMutation(device, `Clearing the decision for ${device.displayName}.`, async () => {
-			await dependencies.clearDecision(candidateRef, device.deviceRef, {
-				attemptId: currentDetail.attemptId,
-			});
-		});
+		void runMutation(
+			device.deviceRef,
+			`Clearing the decision for ${device.displayName}.`,
+			`${device.displayName} saved.`,
+			setBusyDeviceRef,
+			safeMutationError,
+			() =>
+				dependencies.clearDecision(candidateRef, device.deviceRef, {
+					attemptId: currentDetail.attemptId,
+				}),
+		);
+	};
+	const mapProject = (project: api.LegacyTeamSetupProjectV1, resolvedProjectRef: string) => {
+		const currentDetail = detail;
+		if (!currentDetail) return;
+		void runMutation(
+			project.projectRef,
+			`Saving the mapping for ${project.displayName}.`,
+			`${project.displayName} saved.`,
+			setBusyProjectRef,
+			safeProjectMutationError,
+			() =>
+				dependencies.saveProjectMapping(candidateRef, project.projectRef, {
+					attemptId: currentDetail.attemptId,
+					resolvedProjectRef,
+				}),
+		);
 	};
 
 	return (
@@ -488,7 +550,12 @@ function LegacyTeamSetupDialogHost({
 												aria-disabled={devicesBlockProgress ? "true" : undefined}
 												className="settings-button legacy-team-setup-target"
 												onClick={() => {
-													if (!devicesBlockProgress) navigate("projects");
+													if (devicesBlockProgress) {
+														explainBlockedStep(
+															"devices",
+															"Finish the device decisions before mapping Projects.",
+														);
+													} else navigate("projects");
 												}}
 												type="button"
 											>
@@ -510,7 +577,17 @@ function LegacyTeamSetupDialogHost({
 												}
 												className="settings-button legacy-team-setup-target"
 												onClick={() => {
-													if (!devicesBlockProgress && !projectsBlockReview) navigate("review");
+													if (devicesBlockProgress) {
+														explainBlockedStep(
+															"devices",
+															"Finish the device decisions before reviewing access.",
+														);
+													} else if (projectsBlockReview) {
+														explainBlockedStep(
+															"projects",
+															"Finish the Project mappings before reviewing access.",
+														);
+													} else navigate("review");
 												}}
 												type="button"
 											>
@@ -546,6 +623,13 @@ function LegacyTeamSetupDialogHost({
 									onAssign={assignDevice}
 									onClear={clearDevice}
 									onDecision={decideDevice}
+								/>
+							) : step === "projects" ? (
+								<LegacyTeamSetupProjects
+									blocked={mutationsBlocked}
+									busyProjectRef={busyProjectRef}
+									detail={detail}
+									onMap={mapProject}
 								/>
 							) : (
 								<StepContent detail={detail} step={step} />

--- a/packages/ui/src/tabs/legacy-team-setup-projects.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-projects.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useId, useState } from "preact/hooks";
+import type { LegacyTeamSetupDetailResponseV1, LegacyTeamSetupProjectV1 } from "../lib/api";
+
+export interface LegacyTeamSetupProjectsProps {
+	blocked: boolean;
+	busyProjectRef: string | null;
+	detail: LegacyTeamSetupDetailResponseV1;
+	onMap: (project: LegacyTeamSetupProjectV1, resolvedProjectRef: string) => void;
+}
+
+function mappingName(project: LegacyTeamSetupProjectV1): string | null {
+	if (!project.resolvedProjectRef) return null;
+	return (
+		project.mappingChoices.find(
+			(choice) => choice.resolvedProjectRef === project.resolvedProjectRef,
+		)?.displayName ?? "Unavailable Project"
+	);
+}
+
+function ProjectRow({
+	blocked,
+	busy,
+	index,
+	onMap,
+	project,
+}: Pick<LegacyTeamSetupProjectsProps, "blocked" | "onMap"> & {
+	busy: boolean;
+	index: number;
+	project: LegacyTeamSetupProjectV1;
+}) {
+	const generatedId = useId();
+	const controlId = `${generatedId}-mapping`;
+	const helpId = `${generatedId}-help`;
+	const savedMapping = project.resolvedProjectRef ?? "";
+	const availableSavedMapping = project.mappingChoices.some(
+		(choice) => choice.resolvedProjectRef === savedMapping,
+	)
+		? savedMapping
+		: "";
+	const choiceKey = JSON.stringify(
+		project.mappingChoices.map((choice) => choice.resolvedProjectRef),
+	);
+	const [draftMapping, setDraftMapping] = useState(availableSavedMapping);
+	useEffect(() => setDraftMapping(availableSavedMapping), [availableSavedMapping, choiceKey]);
+	const controlsBlocked = blocked || busy;
+	const saveBlocked = controlsBlocked || !draftMapping || draftMapping === savedMapping;
+	const savedName = mappingName(project);
+
+	return (
+		<fieldset
+			aria-busy={busy ? "true" : "false"}
+			className="legacy-team-project-row"
+			id={`legacy-team-project-row-${index}`}
+			tabIndex={project.resolution === "unresolved" ? -1 : undefined}
+		>
+			<legend>{project.displayName}</legend>
+			{project.resolution === "deterministic" ? (
+				<p className="small">Mapped automatically from matching Project evidence.</p>
+			) : (
+				<>
+					<p className="small">
+						{savedName ? `Saved mapping: ${savedName}` : "This Project still needs a mapping."}
+					</p>
+					<label htmlFor={controlId}>Canonical Project</label>
+					<select
+						aria-describedby={!draftMapping ? helpId : undefined}
+						className="feed-search legacy-team-project-select"
+						disabled={controlsBlocked}
+						id={controlId}
+						onChange={(event) => setDraftMapping(event.currentTarget.value)}
+						value={draftMapping}
+					>
+						<option value="">Choose a Project</option>
+						{project.mappingChoices.map((choice) => (
+							<option key={choice.resolvedProjectRef} value={choice.resolvedProjectRef}>
+								{choice.displayName}
+							</option>
+						))}
+					</select>
+					{!draftMapping ? (
+						<p className="small" id={helpId}>
+							Choose and save one of the server-provided Project mappings.
+						</p>
+					) : null}
+					<button
+						aria-disabled={saveBlocked ? "true" : undefined}
+						className="settings-button legacy-team-setup-target"
+						onClick={() => {
+							if (!saveBlocked) onMap(project, draftMapping);
+						}}
+						type="button"
+					>
+						Save mapping
+					</button>
+				</>
+			)}
+		</fieldset>
+	);
+}
+
+export function LegacyTeamSetupProjects(props: LegacyTeamSetupProjectsProps) {
+	return (
+		<section aria-labelledby="legacy-team-setup-step-projects">
+			<h3 id="legacy-team-setup-step-projects" tabIndex={-1}>
+				Review Projects
+			</h3>
+			<p>
+				{props.detail.unresolvedProjectCount.toLocaleString()} of{" "}
+				{props.detail.candidate.projectCount.toLocaleString()} Team Projects still need a mapping.
+			</p>
+			<div className="legacy-team-project-list">
+				{props.detail.projects.map((project, index) => (
+					<ProjectRow
+						blocked={props.blocked}
+						busy={props.busyProjectRef === project.projectRef}
+						index={index}
+						key={project.projectRef}
+						onMap={props.onMap}
+						project={project}
+					/>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1248,6 +1248,25 @@
       .legacy-team-device-select { width: 100%; margin: 0; }
       .legacy-team-device-select:disabled { opacity: 0.55; cursor: not-allowed; }
       .legacy-team-device-actions { display: flex; flex-wrap: wrap; gap: var(--sp-2); }
+      .legacy-team-project-list { display: grid; gap: var(--sp-3); margin-top: var(--sp-3); }
+      .legacy-team-project-row {
+        display: grid;
+        gap: var(--sp-2);
+        min-width: 0;
+        margin: 0;
+        padding: var(--sp-3);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-2);
+      }
+      .legacy-team-project-row legend {
+        padding: 0 var(--sp-1);
+        color: var(--text-primary);
+        font-weight: var(--font-weight-semibold);
+      }
+      .legacy-team-project-row label { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); }
+      .legacy-team-project-select { width: 100%; margin: 0; }
+      .legacy-team-project-select:disabled { opacity: 0.55; cursor: not-allowed; }
       .recipient-policy-management-selection fieldset { border: 0; padding: 0; margin: var(--sp-4) 0 0; }
       .recipient-policy-management-selection legend { font-weight: var(--font-weight-semibold); }
       .recipient-policy-management-review section + section { margin-top: var(--sp-4); }


### PR DESCRIPTION
## Description

Add authoritative Team setup Project mapping controls. Deterministic mappings remain read-only, ambiguous mappings use only server-provided opaque choices, mutations persist immediately, and stale state fails closed through detail reloads.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Stack-tip validation also passed `pnpm --filter @codemem/ui build` and `git diff --check`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced