### PR TITLE
feat(ui): add Team setup review and finish

### DIFF
--- a/docs/plans/2026-08-25-legacy-team-setup-dialog-design.md
+++ b/docs/plans/2026-08-25-legacy-team-setup-dialog-design.md
@@ -71,7 +71,7 @@ The user cannot advance while `unresolvedProjectCount` is nonzero.
 
 ## Step 3: Review and finish
 
-Review is available only when `canFinish` is true and the detail includes `accessDelta`, `finishDigest`, and `accessDeltaDigest`.
+Review is available only when `canFinish` is true and the detail includes `accessDelta`, `finishDigest`, `accessDeltaDigest`, and `viewerAccessDeltaDigest`. The viewer digest binds the complete viewer-safe delta, including the display labels presented for confirmation.
 
 The UI renders every entry from the server-provided delta:
 
@@ -81,9 +81,11 @@ The UI renders every entry from the server-provided delta:
 - recipient changes;
 - device-access changes.
 
+Entries outside the current setup inventory use distinct, non-identifying labels that disclose they are outside the setup and cannot collide with displayed inventory labels.
+
 Large deltas remain inside the dialog's scrollable body. No delta entry is silently collapsed or omitted from the accessible DOM.
 
-Finish requires an explicit confirmation control. Submission sends the exact `attemptId`, `finishDigest`, and confirmed access-delta digest from the currently displayed detail. Success announces completion, refreshes Sharing and Projects state, and offers a single close action.
+Finish requires an explicit confirmation control. Submission sends the exact `attemptId`, `finishDigest`, confirmed access-delta digest, and confirmed viewer access-delta digest from the currently displayed detail. Success announces completion, refreshes Sharing and Projects state, and offers a single close action.
 
 ## Error and recovery behavior
 

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -166,6 +166,7 @@ describe("legacy Team setup activation", () => {
 			confirmedAccessDeltaDigest: review.accessDeltaDigest,
 			loadFreshRoster,
 			loadProjectInventory,
+			validateLockedPreview: () => true,
 			now: NOW,
 		});
 	}
@@ -547,6 +548,7 @@ describe("legacy Team setup activation", () => {
 			confirmedAccessDeltaDigest: review.accessDeltaDigest,
 			loadFreshRoster: vi.fn(async () => roster),
 			loadProjectInventory: vi.fn(() => draftProjectInventory(draft.attemptId)),
+			validateLockedPreview: () => true,
 			now: NOW,
 			...override,
 		});
@@ -767,6 +769,7 @@ describe("legacy Team setup activation", () => {
 			confirmedAccessDeltaDigest: review.accessDeltaDigest,
 			loadFreshRoster,
 			loadProjectInventory: vi.fn(() => draftProjectInventory(draft.attemptId)),
+			validateLockedPreview: () => true,
 			now: NOW,
 		});
 

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -77,6 +77,12 @@ export interface FinishLegacyTeamSetupActivationInput
 	 * database and must not await.
 	 */
 	loadProjectInventory: () => LegacyTeamSetupProjectInput[];
+	/**
+	 * Revalidates adapter-specific confirmation evidence against the final
+	 * preview while the activation transaction holds its immediate lock.
+	 * Implementations must be synchronous and read from the same database.
+	 */
+	validateLockedPreview: (preview: LegacyTeamSetupActivationPreviewV1) => boolean;
 	now?: string;
 }
 
@@ -1717,6 +1723,9 @@ export async function finishLegacyTeamSetupActivation(
 					lockedPreview.finishDigest !== input.finishDigest ||
 					lockedPreview.accessDeltaDigest !== input.confirmedAccessDeltaDigest
 				) {
+					activationError("team_setup_confirmation_stale");
+				}
+				if (!input.validateLockedPreview(lockedPreview)) {
 					activationError("team_setup_confirmation_stale");
 				}
 				return applyActivation(db, model, lockedPreview, freshRoster, now);

--- a/packages/ui/src/app-devices.test.tsx
+++ b/packages/ui/src/app-devices.test.tsx
@@ -8,11 +8,17 @@ const mocks = vi.hoisted(() => ({
 	loadProjectScopeInventory: vi.fn(),
 	loadDeviceIdentityInventory: vi.fn(),
 	loadLegacyTeamSetupDetail: vi.fn(),
+	loadProjectsData: vi.fn(),
 	loadRecipientPolicyIntent: vi.fn(),
 	loadRecipientPolicyReconciliationStatus: vi.fn(),
+	loadRecipientPolicySharingData: vi.fn(),
 	loadSyncData: vi.fn(),
+	mountLegacyTeamSetupDialog: vi.fn(),
 }));
 
+vi.mock("./app-sharing", () => ({
+	createRecipientPolicySharingLoader: vi.fn(() => mocks.loadRecipientPolicySharingData),
+}));
 vi.mock("./components/primitives/toast", () => ({ mountToastHost: vi.fn() }));
 vi.mock("./lib/api", () => ({
 	clearLegacyTeamSetupDecision: vi.fn(),
@@ -47,12 +53,12 @@ vi.mock("./tabs/health", () => ({
 	loadHealthData: vi.fn(async () => undefined),
 }));
 vi.mock("./tabs/legacy-team-setup-dialog", () => ({
-	mountLegacyTeamSetupDialog: vi.fn(),
+	mountLegacyTeamSetupDialog: mocks.mountLegacyTeamSetupDialog,
 	openLegacyTeamSetup: vi.fn(() => true),
 }));
 vi.mock("./tabs/projects", () => ({
 	initProjectsTab: vi.fn(),
-	loadProjectsData: vi.fn(async () => undefined),
+	loadProjectsData: mocks.loadProjectsData,
 }));
 vi.mock("./tabs/recipient-policy-management", () => ({
 	mountRecipientPolicyManagement: vi.fn(),
@@ -166,6 +172,8 @@ describe("Devices app integration", () => {
 			offset: 0,
 		});
 		mocks.loadRecipientPolicyIntent.mockResolvedValue(intent);
+		mocks.loadProjectsData.mockResolvedValue(true);
+		mocks.loadRecipientPolicySharingData.mockResolvedValue(true);
 		mocks.loadLegacyTeamSetupDetail.mockResolvedValue({
 			version: 1,
 			candidate: {
@@ -296,6 +304,46 @@ describe("Devices app integration", () => {
 		expect(openLegacyTeamSetup).toHaveBeenCalledWith("opaque-candidate-ref");
 		expect(window.location.hash).toBe("#devices");
 		expect(document.getElementById("tab-devices")?.hidden).toBe(false);
+	});
+
+	it("refreshes Sharing and Projects with the active surface mounting last", async () => {
+		const options = mocks.mountLegacyTeamSetupDialog.mock.calls[0]?.[1];
+		expect(options?.onCompleted).toEqual(expect.any(Function));
+		const { state } = await import("./lib/state");
+		const refreshOrder: string[] = [];
+		mocks.loadProjectsData.mockImplementation(async () => {
+			refreshOrder.push("projects");
+			return true;
+		});
+		mocks.loadRecipientPolicySharingData.mockImplementation(async () => {
+			refreshOrder.push("sharing");
+			return true;
+		});
+
+		state.activeTab = "sharing";
+		await expect(options?.onCompleted?.("opaque-attempt")).resolves.toBeUndefined();
+		expect(refreshOrder).toEqual(["projects", "sharing"]);
+		expect(mocks.loadProjectsData).toHaveBeenLastCalledWith({ requireTeamSetupSummary: true });
+		expect(mocks.loadRecipientPolicySharingData).toHaveBeenLastCalledWith({
+			requireTeamSetupSummary: true,
+		});
+
+		refreshOrder.length = 0;
+		state.activeTab = "projects";
+		await expect(options?.onCompleted?.("opaque-attempt")).resolves.toBeUndefined();
+		expect(refreshOrder).toEqual(["sharing", "projects"]);
+		expect(mocks.loadProjectsData).toHaveBeenLastCalledWith({ requireTeamSetupSummary: true });
+		expect(mocks.loadRecipientPolicySharingData).toHaveBeenLastCalledWith({
+			requireTeamSetupSummary: true,
+		});
+	});
+
+	it("reports a partial Team setup completion refresh failure", async () => {
+		const options = mocks.mountLegacyTeamSetupDialog.mock.calls[0]?.[1];
+		mocks.loadProjectsData.mockResolvedValueOnce(false);
+		await expect(options?.onCompleted?.("opaque-attempt")).rejects.toThrow(
+			"team_setup_refresh_failed",
+		);
 	});
 
 	it("keeps existing device details usable when inventory fails on the first Devices load", () => {

--- a/packages/ui/src/app-sharing.test.tsx
+++ b/packages/ui/src/app-sharing.test.tsx
@@ -530,6 +530,41 @@ describe("Sharing app data refresh", () => {
 		);
 	});
 
+	it("renders required Sharing data but reports strict refresh failure after Team setup discovery fails", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const teamSetupResult = deferred<LegacyTeamSetupSummaryResponseV1>();
+		const mountSharing = vi.fn();
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory: vi.fn().mockResolvedValue({ version: 1, items: [], truncated: false }),
+			loadIntent: vi.fn().mockResolvedValue(intent),
+			loadProjects: vi.fn().mockResolvedValue({ manageable: projects, received: [] }),
+			loadTeamSetupSummary: vi.fn(() => teamSetupResult.promise),
+			mountSharing,
+		});
+
+		const operation = load({ requireTeamSetupSummary: true });
+		await vi.waitFor(() =>
+			expect(mountSharing).toHaveBeenLastCalledWith(
+				document.getElementById("recipientPolicySharingMount"),
+				projects,
+				intent,
+				expect.objectContaining({ teamSetupLoading: true }),
+			),
+		);
+		let settled = false;
+		void operation.then(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		teamSetupResult.reject(new Error("setup unavailable"));
+		await expect(operation).resolves.toBe(false);
+		expect(mountSharing.mock.calls.at(-1)?.[3]).toEqual(
+			expect.objectContaining({ teamSetupLoading: false, teamSetupUnavailable: true }),
+		);
+	});
+
 	it("renders fresh Team setup status before a required Sharing refresh settles", async () => {
 		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
 		const projectRefresh = deferred<{ manageable: typeof projects; received: [] }>();

--- a/packages/ui/src/app-sharing.ts
+++ b/packages/ui/src/app-sharing.ts
@@ -86,16 +86,29 @@ export function createRecipientPolicySharingLoader(
 		intent: api.RecipientPolicyIntentGraphV1;
 	} | null = null;
 
-	const loadRecipientPolicySharingData = (): Promise<boolean> => {
+	const loadRecipientPolicySharingData = (
+		refreshOptions: RecipientPolicySharingRefreshOptions = {},
+	): Promise<boolean> => {
 		const revision = ++loadRevision;
-		const operation = load(revision);
+		const operation = load(revision, refreshOptions);
 		latestLoad = operation;
 		return operation;
 	};
 
-	async function load(revision: number): Promise<boolean> {
+	async function load(
+		revision: number,
+		refreshOptions: RecipientPolicySharingRefreshOptions,
+	): Promise<boolean> {
 		const sharingMount = document.getElementById("recipientPolicySharingMount");
-		if (!sharingMount) return true;
+		if (!sharingMount) {
+			if (!refreshOptions.requireTeamSetupSummary) return true;
+			try {
+				await dependencies.loadTeamSetupSummary();
+				return true;
+			} catch {
+				return false;
+			}
+		}
 		const managementMount = document.getElementById("recipientPolicyManagementMount");
 		teamSetupLoading = true;
 		teamSetupUnavailable = false;
@@ -127,21 +140,23 @@ export function createRecipientPolicySharingLoader(
 			);
 		};
 		renderTeamSetupUpdate();
-		void Promise.resolve()
+		const teamSetupSummaryPromise = Promise.resolve()
 			.then(() => dependencies.loadTeamSetupSummary())
 			.then(
 				(summary) => {
-					if (revision !== loadRevision) return;
+					if (revision !== loadRevision) return true;
 					teamSetupSummary = summary;
 					teamSetupLoading = false;
 					teamSetupUnavailable = false;
 					renderTeamSetupUpdate();
+					return true;
 				},
 				() => {
-					if (revision !== loadRevision) return;
+					if (revision !== loadRevision) return false;
 					teamSetupLoading = false;
 					teamSetupUnavailable = true;
 					renderTeamSetupUpdate();
+					return false;
 				},
 			);
 		const [inventoryResult, intentResult, deviceInventoryResult, syncStatusResult] =
@@ -151,7 +166,11 @@ export function createRecipientPolicySharingLoader(
 				dependencies.loadDeviceInventory(),
 				dependencies.loadSyncStatus(false, "", { includeJoinRequests: false }),
 			]);
-		if (revision !== loadRevision) return latestLoad ?? false;
+		if (revision !== loadRevision) {
+			if (!refreshOptions.requireTeamSetupSummary) return latestLoad ?? false;
+			await teamSetupSummaryPromise;
+			return false;
+		}
 		const deviceInventoryUnavailable = deviceInventoryResult.status === "rejected";
 		if (deviceInventoryResult.status === "fulfilled") {
 			lastDeviceInventory = deviceInventoryResult.value;
@@ -228,10 +247,19 @@ export function createRecipientPolicySharingLoader(
 				loadError: true,
 			});
 		}
-		return loadSucceeded;
+		if (!refreshOptions.requireTeamSetupSummary) return loadSucceeded;
+		const teamSetupSucceeded = await teamSetupSummaryPromise;
+		if (revision !== loadRevision) return false;
+		return loadSucceeded && teamSetupSucceeded;
 	}
 
 	return loadRecipientPolicySharingData;
 }
 
-export type RecipientPolicySharingRefresh = () => Promise<boolean>;
+export interface RecipientPolicySharingRefreshOptions {
+	requireTeamSetupSummary?: boolean;
+}
+
+export type RecipientPolicySharingRefresh = (
+	options?: RecipientPolicySharingRefreshOptions,
+) => Promise<boolean>;

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -786,7 +786,23 @@ initState();
 const toastRoot = document.getElementById("toastRoot");
 if (toastRoot) mountToastHost(toastRoot);
 const legacyTeamSetupRoot = document.getElementById("legacyTeamSetupMount");
-if (legacyTeamSetupRoot) mountLegacyTeamSetupDialog(legacyTeamSetupRoot);
+if (legacyTeamSetupRoot) {
+	mountLegacyTeamSetupDialog(legacyTeamSetupRoot, {
+		onCompleted: async () => {
+			let sharingUpdated: boolean;
+			let projectsUpdated: boolean;
+			const refreshOptions = { requireTeamSetupSummary: true };
+			if (state.activeTab === "sharing") {
+				projectsUpdated = await loadProjectsData(refreshOptions);
+				sharingUpdated = await loadRecipientPolicySharingData(refreshOptions);
+			} else {
+				sharingUpdated = await loadRecipientPolicySharingData(refreshOptions);
+				projectsUpdated = await loadProjectsData(refreshOptions);
+			}
+			if (!sharingUpdated || !projectsUpdated) throw new Error("team_setup_refresh_failed");
+		},
+	});
+}
 
 // Theme
 initThemeToggle($button("themeToggle"));

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -334,6 +334,7 @@ describe("legacy Team setup API", () => {
 			attemptId: "attempt-one",
 			finishDigest: "finish-digest",
 			confirmedAccessDeltaDigest: "access-digest",
+			confirmedViewerAccessDeltaDigest: "viewer-access-digest",
 		};
 
 		await loadLegacyTeamSetupSummary();
@@ -460,6 +461,49 @@ describe("legacy Team setup API", () => {
 		});
 	});
 
+	it("rejects finishable detail without viewer-bound confirmation evidence", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					version: 1,
+					candidate: {
+						candidateRef: "candidate/ref",
+						displayName: "Example Team",
+						status: "in_progress",
+						deviceCount: 0,
+						projectCount: 0,
+						unresolvedDeviceCount: 0,
+						unresolvedProjectCount: 0,
+					},
+					attemptId: "attempt-one",
+					draftState: "in_progress",
+					unresolvedDeviceCount: 0,
+					unresolvedProjectCount: 0,
+					devices: [],
+					projects: [],
+					identityChoices: [],
+					canFinish: true,
+					conflictState: null,
+					finishDigest: "finish-digest",
+					accessDeltaDigest: "access-digest",
+					accessDelta: {
+						teamChanges: [],
+						membershipChanges: [],
+						projectChanges: [],
+						recipientChanges: [],
+						deviceAccessChanges: [],
+					},
+				}),
+				{ status: 200 },
+			),
+		) as typeof fetch;
+
+		await expect(loadLegacyTeamSetupDetail("candidate/ref")).rejects.toMatchObject({
+			statusCode: 200,
+			errorCode: "team_setup_failed",
+		});
+	});
+
 	it.each([
 		["summary", () => loadLegacyTeamSetupSummary()],
 		["detail", () => loadLegacyTeamSetupDetail("candidate/ref")],
@@ -479,6 +523,7 @@ describe("legacy Team setup API", () => {
 					attemptId: "attempt-one",
 					finishDigest: "finish-digest",
 					confirmedAccessDeltaDigest: "access-digest",
+					confirmedViewerAccessDeltaDigest: "viewer-access-digest",
 				}),
 		],
 	] as const)("rejects a version-only successful %s DTO", async (_name, request) => {

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -830,30 +830,40 @@ export interface LegacyTeamSetupIdentityChoiceV1 {
 export interface LegacyTeamSetupAccessDeltaV1 {
 	teamChanges: Array<{
 		teamRef: string;
+		teamDisplayName: string;
 		change: "add" | "update" | "remove";
 		fromDeviceEligibilityMode: "person_all_devices" | "reviewed_allowlist" | null;
 		toDeviceEligibilityMode: "reviewed_allowlist";
 	}>;
 	membershipChanges: Array<{
 		teamRef: string;
+		teamDisplayName: string;
 		identityRef: string;
+		identityDisplayName: string;
 		change: "add" | "update" | "remove";
 	}>;
 	projectChanges: Array<{
 		projectRef: string;
+		projectDisplayName: string;
 		fromResolvedProjectRef: string | null;
+		fromResolvedProjectDisplayName: string | null;
 		toResolvedProjectRef: string | null;
+		toResolvedProjectDisplayName: string | null;
 		change: "add" | "update" | "remove";
 	}>;
 	recipientChanges: Array<{
 		canonicalProjectRef: string;
+		canonicalProjectDisplayName: string;
 		recipientKind: "team";
 		recipientRef: string;
+		recipientDisplayName: string;
 		change: "add" | "update" | "remove";
 	}>;
 	deviceAccessChanges: Array<{
 		canonicalProjectRef: string;
+		canonicalProjectDisplayName: string;
 		deviceRef: string;
+		deviceDisplayName: string;
 		change: "add" | "remove";
 	}>;
 }
@@ -877,6 +887,7 @@ export type LegacyTeamSetupDetailResponseV1 = LegacyTeamSetupDetailBaseV1 &
 				conflictState: null;
 				finishDigest: string;
 				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
 				accessDelta: LegacyTeamSetupAccessDeltaV1;
 		  }
 		| {
@@ -1035,6 +1046,7 @@ function isLegacyTeamSetupAccessDelta(value: unknown): value is LegacyTeamSetupA
 			(item): item is LegacyTeamSetupAccessDeltaV1["teamChanges"][number] =>
 				isJsonRecord(item) &&
 				typeof item.teamRef === "string" &&
+				typeof item.teamDisplayName === "string" &&
 				validChange(item.change) &&
 				[null, "person_all_devices", "reviewed_allowlist"].includes(
 					item.fromDeviceEligibilityMode as null | string,
@@ -1046,7 +1058,9 @@ function isLegacyTeamSetupAccessDelta(value: unknown): value is LegacyTeamSetupA
 			(item): item is LegacyTeamSetupAccessDeltaV1["membershipChanges"][number] =>
 				isJsonRecord(item) &&
 				typeof item.teamRef === "string" &&
+				typeof item.teamDisplayName === "string" &&
 				typeof item.identityRef === "string" &&
+				typeof item.identityDisplayName === "string" &&
 				validChange(item.change),
 		) &&
 		isArrayOf(
@@ -1054,8 +1068,11 @@ function isLegacyTeamSetupAccessDelta(value: unknown): value is LegacyTeamSetupA
 			(item): item is LegacyTeamSetupAccessDeltaV1["projectChanges"][number] =>
 				isJsonRecord(item) &&
 				typeof item.projectRef === "string" &&
+				typeof item.projectDisplayName === "string" &&
 				isStringOrNull(item.fromResolvedProjectRef) &&
+				isStringOrNull(item.fromResolvedProjectDisplayName) &&
 				isStringOrNull(item.toResolvedProjectRef) &&
+				isStringOrNull(item.toResolvedProjectDisplayName) &&
 				validChange(item.change),
 		) &&
 		isArrayOf(
@@ -1063,8 +1080,10 @@ function isLegacyTeamSetupAccessDelta(value: unknown): value is LegacyTeamSetupA
 			(item): item is LegacyTeamSetupAccessDeltaV1["recipientChanges"][number] =>
 				isJsonRecord(item) &&
 				typeof item.canonicalProjectRef === "string" &&
+				typeof item.canonicalProjectDisplayName === "string" &&
 				item.recipientKind === "team" &&
 				typeof item.recipientRef === "string" &&
+				typeof item.recipientDisplayName === "string" &&
 				validChange(item.change),
 		) &&
 		isArrayOf(
@@ -1072,7 +1091,9 @@ function isLegacyTeamSetupAccessDelta(value: unknown): value is LegacyTeamSetupA
 			(item): item is LegacyTeamSetupAccessDeltaV1["deviceAccessChanges"][number] =>
 				isJsonRecord(item) &&
 				typeof item.canonicalProjectRef === "string" &&
+				typeof item.canonicalProjectDisplayName === "string" &&
 				typeof item.deviceRef === "string" &&
+				typeof item.deviceDisplayName === "string" &&
 				typeof item.change === "string" &&
 				["add", "remove"].includes(item.change),
 		)
@@ -1104,6 +1125,7 @@ function isLegacyTeamSetupDetail(value: unknown): value is LegacyTeamSetupDetail
 			value.conflictState === null &&
 			typeof value.finishDigest === "string" &&
 			typeof value.accessDeltaDigest === "string" &&
+			typeof value.viewerAccessDeltaDigest === "string" &&
 			isLegacyTeamSetupAccessDelta(value.accessDelta)
 		);
 	}
@@ -1283,6 +1305,7 @@ export function finishLegacyTeamSetup(
 		attemptId: string;
 		finishDigest: string;
 		confirmedAccessDeltaDigest: string;
+		confirmedViewerAccessDeltaDigest: string;
 	},
 ): Promise<LegacyTeamSetupFinishResponseV1> {
 	return legacyTeamSetupRequest(

--- a/packages/ui/src/tabs/legacy-team-setup-devices.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-devices.tsx
@@ -5,6 +5,7 @@ type DeviceDecision = "included" | "excluded" | "removed";
 
 export interface LegacyTeamSetupDevicesProps {
 	blocked: boolean;
+	blockedDescriptionId?: string;
 	busyDeviceRef: string | null;
 	detail: LegacyTeamSetupDetailResponseV1;
 	onAssign: (device: LegacyTeamSetupDeviceV1, identityRef: string) => void;
@@ -37,6 +38,7 @@ function initialIdentityRef(device: LegacyTeamSetupDeviceV1): string {
 
 function DeviceRow({
 	blocked,
+	blockedDescriptionId,
 	busy,
 	detail,
 	device,
@@ -78,6 +80,16 @@ function DeviceRow({
 		assignmentEvidenceInactive ||
 		assignmentIdentityUnavailable ||
 		draftIdentityRef === savedIdentity;
+	const assignmentNeedsHelp = !device.enabled || includeNeedsHelp;
+	const globalBlockedDescription = blocked ? blockedDescriptionId : undefined;
+	const assignmentDescription = [
+		evidenceId,
+		assignmentNeedsHelp ? assignmentHelpId : undefined,
+		globalBlockedDescription,
+	]
+		.filter(Boolean)
+		.join(" ");
+	const actionDescription = [evidenceId, globalBlockedDescription].filter(Boolean).join(" ");
 
 	return (
 		<fieldset
@@ -104,7 +116,7 @@ function DeviceRow({
 			</div>
 			<label htmlFor={controlId}>Person using this device</label>
 			<select
-				aria-describedby={`${evidenceId}${includeNeedsHelp ? ` ${assignmentHelpId}` : ""}`}
+				aria-describedby={assignmentDescription}
 				className="feed-search legacy-team-device-select"
 				disabled={assignmentControlsBlocked}
 				id={controlId}
@@ -144,7 +156,7 @@ function DeviceRow({
 			) : null}
 			<div className="legacy-team-device-actions">
 				<button
-					aria-describedby={!draftIdentityRef ? assignmentHelpId : evidenceId}
+					aria-describedby={assignmentDescription}
 					aria-disabled={assignmentBlocked ? "true" : undefined}
 					className="settings-button legacy-team-setup-target"
 					onClick={() => {
@@ -157,7 +169,7 @@ function DeviceRow({
 				{device.enabled ? (
 					<>
 						<button
-							aria-describedby={includeNeedsHelp ? assignmentHelpId : evidenceId}
+							aria-describedby={assignmentDescription}
 							aria-disabled={includeBlocked ? "true" : undefined}
 							className="settings-button legacy-team-setup-target"
 							onClick={() => {
@@ -168,6 +180,7 @@ function DeviceRow({
 							Include
 						</button>
 						<button
+							aria-describedby={actionDescription}
 							aria-disabled={controlsBlocked ? "true" : undefined}
 							className="settings-button legacy-team-setup-target"
 							onClick={() => {
@@ -180,6 +193,7 @@ function DeviceRow({
 					</>
 				) : (
 					<button
+						aria-describedby={actionDescription}
 						aria-disabled={controlsBlocked ? "true" : undefined}
 						className="settings-button legacy-team-setup-target"
 						onClick={() => {
@@ -192,6 +206,7 @@ function DeviceRow({
 				)}
 				{device.decision !== "unresolved" ? (
 					<button
+						aria-describedby={actionDescription}
 						aria-disabled={controlsBlocked ? "true" : undefined}
 						className="settings-button legacy-team-setup-target"
 						onClick={() => {

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -2,6 +2,7 @@ import { type ComponentChildren, render } from "preact";
 import { act } from "preact/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+	type LegacyTeamSetupAccessDeltaV1,
 	LegacyTeamSetupApiError,
 	type LegacyTeamSetupDetailResponseV1,
 	type LegacyTeamSetupDeviceV1,
@@ -81,21 +82,25 @@ function detail({
 	conflictState = null,
 	draftState = "in_progress",
 	attemptId = "opaque-attempt",
+	accessDelta,
 	devices,
 	identityChoices = [],
 	projects,
 	unresolvedDeviceCount = 0,
 	unresolvedProjectCount = 0,
+	viewerAccessDeltaDigest = "opaque-viewer-access-digest",
 }: {
 	canFinish?: boolean;
 	conflictState?: LegacyTeamSetupDetailResponseV1["conflictState"];
 	draftState?: "needs_setup" | "in_progress" | "stale" | "completed";
 	attemptId?: string;
+	accessDelta?: LegacyTeamSetupAccessDeltaV1;
 	devices?: LegacyTeamSetupDeviceV1[];
 	identityChoices?: LegacyTeamSetupIdentityChoiceV1[];
 	projects?: LegacyTeamSetupProjectV1[];
 	unresolvedDeviceCount?: number;
 	unresolvedProjectCount?: number;
+	viewerAccessDeltaDigest?: string;
 } = {}): LegacyTeamSetupDetailResponseV1 {
 	const base = {
 		version: 1 as const,
@@ -123,7 +128,8 @@ function detail({
 				conflictState: null,
 				finishDigest: "opaque-finish-digest",
 				accessDeltaDigest: "opaque-access-digest",
-				accessDelta: {
+				viewerAccessDeltaDigest,
+				accessDelta: accessDelta ?? {
 					teamChanges: [],
 					membershipChanges: [],
 					projectChanges: [],
@@ -283,12 +289,13 @@ describe("legacy Team setup dialog", () => {
 	});
 
 	it("selects Projects, Review, and completion from fresh server state", async () => {
+		const onCompleted = vi.fn().mockRejectedValue(new Error("private refresh failure"));
 		const loadDetail = vi
 			.fn()
 			.mockResolvedValueOnce(detail({ unresolvedProjectCount: 1 }))
 			.mockResolvedValueOnce(detail({ canFinish: true }))
 			.mockResolvedValueOnce(detail({ draftState: "completed" }));
-		const { trigger } = setup(loadDetail);
+		const { trigger } = setup({ loadDetail, onCompleted });
 
 		await vi.waitFor(() => {
 			expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Projects");
@@ -312,9 +319,14 @@ describe("legacy Team setup dialog", () => {
 		});
 		await vi.waitFor(() => {
 			expect(document.body.textContent).toContain("Team setup complete");
+			expect(document.body.textContent).toContain(
+				"Sharing or Projects could not be refreshed; use that view's Refresh control.",
+			);
 		});
 		expect(document.querySelector(".legacy-team-setup-steps")).toBeNull();
 		expect(loadDetail).toHaveBeenCalledTimes(3);
+		expect(onCompleted).toHaveBeenCalledTimes(1);
+		expect(document.body.textContent).not.toContain("private refresh failure");
 	});
 
 	it("shows safe error copy and retries without exposing exception text", async () => {
@@ -360,11 +372,10 @@ describe("legacy Team setup dialog", () => {
 		const refreshCandidate = vi.fn().mockResolvedValue({});
 		setup({ loadDetail, refreshCandidate });
 
-		await vi.waitFor(() => {
-			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
-				"changed since it was last reviewed",
-			);
-		});
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain("changed since it was last reviewed"),
+		);
+		expect(document.querySelector('[role="alert"]')).not.toBeNull();
 		act(() => {
 			document.getElementById("legacy-team-setup-retry")?.click();
 		});
@@ -378,8 +389,10 @@ describe("legacy Team setup dialog", () => {
 		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
 			"changed since it was last reviewed",
 		);
+		expect(document.getElementById("legacy-team-setup-retry")).toBeNull();
+		expect(document.activeElement?.id).toBe("legacy-team-setup-refresh");
 		act(() => {
-			document.getElementById("legacy-team-setup-retry")?.click();
+			button("Refresh Team setup").click();
 		});
 		await vi.waitFor(() => {
 			expect(document.querySelector('[role="alert"]')).toBeNull();
@@ -694,6 +707,13 @@ describe("legacy Team setup dialog", () => {
 		expect(document.body.textContent).toContain(
 			"Team setup will stay open while this change saves",
 		);
+		act(() => {
+			openLegacyTeamSetup("another-candidate");
+		});
+		expect(document.body.textContent).toContain(
+			"Wait for the current Team setup change to finish before opening another Team",
+		);
+		expect(loadDetail).toHaveBeenCalledTimes(1);
 
 		pendingDecision.resolve(mutationResult());
 		await vi.waitFor(() => {
@@ -816,9 +836,14 @@ describe("legacy Team setup dialog", () => {
 		const saveAssignment = vi.fn();
 		setup({ loadDetail, saveAssignment, saveDecision });
 		await vi.waitFor(() => expect(document.body.textContent).toContain("Device no longer active"));
-		expect(document.querySelector<HTMLSelectElement>(".legacy-team-device-select")?.disabled).toBe(
-			true,
-		);
+		const inactiveSelect = document.querySelector<HTMLSelectElement>(".legacy-team-device-select");
+		expect(inactiveSelect?.disabled).toBe(true);
+		expect(
+			(inactiveSelect?.getAttribute("aria-describedby") ?? "")
+				.split(" ")
+				.map((id) => document.getElementById(id)?.textContent)
+				.join(" "),
+		).toContain("Inactive devices can only be removed");
 		expect(button("Save assignment").getAttribute("aria-disabled")).toBe("true");
 		act(() => button("Save assignment").click());
 		expect(saveAssignment).not.toHaveBeenCalled();
@@ -919,11 +944,12 @@ describe("legacy Team setup dialog", () => {
 
 		act(() => button("Exclude").click());
 		await vi.waitFor(() => {
-			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
-				"changed since it was last reviewed",
-			);
+			expect(document.body.textContent).toContain("changed since it was last reviewed");
 			expect(document.body.textContent).toContain("Current assignment: Sam");
 		});
+		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+			"changed since it was last reviewed",
+		);
 		expect(loadDetail).toHaveBeenCalledTimes(2);
 		const exclude = button("Exclude");
 		expect(exclude.disabled).toBe(false);
@@ -968,7 +994,7 @@ describe("legacy Team setup dialog", () => {
 				"changed since it was last reviewed",
 			),
 		);
-		act(() => document.getElementById("legacy-team-setup-retry")?.click());
+		act(() => document.getElementById("legacy-team-setup-refresh")?.click());
 
 		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
 		expect(refreshCandidate).toHaveBeenCalledWith("opaque-candidate");
@@ -1094,6 +1120,9 @@ describe("legacy Team setup dialog", () => {
 		});
 		expect(document.body.textContent).not.toContain("team_setup_confirmation_stale");
 		expect(loadDetail).toHaveBeenCalledTimes(2);
+		expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")?.disabled).toBe(
+			true,
+		);
 		expect(button("Save mapping").getAttribute("aria-disabled")).toBe("true");
 
 		act(() => document.getElementById("legacy-team-setup-retry")?.click());
@@ -1130,10 +1159,462 @@ describe("legacy Team setup dialog", () => {
 				"was saved, but the latest Team setup details could not be loaded",
 			);
 		});
+		const blockedDescription = button("Save mapping").getAttribute("aria-describedby") ?? "";
+		expect(
+			blockedDescription
+				.split(" ")
+				.map((id) => document.getElementById(id)?.textContent)
+				.join(" "),
+		).toContain("latest Team setup details could not be loaded");
 		expect(document.body.textContent).not.toContain("private reload failure");
 		expect(document.body.textContent).not.toContain("mapping could not be saved");
 		expect(saveProjectMapping).toHaveBeenCalledTimes(1);
 		expect(loadDetail).toHaveBeenCalledTimes(2);
+	});
+
+	it("renders every server access-delta entry with human labels and no opaque refs", async () => {
+		const reviewedDevice = device({
+			decision: "included",
+			existingIdentityRef: "identity-ref-alex",
+			targetIdentityRef: "identity-ref-alex",
+		});
+		const reviewedProject = project({
+			canonicalProjectRef: "canonical-project-ref",
+			resolution: "explicit",
+			resolvedProjectRef: "resolved-project-beta",
+		});
+		const loadDetail = vi.fn().mockResolvedValue(
+			detail({
+				canFinish: true,
+				devices: [reviewedDevice],
+				identityChoices: identities,
+				projects: [reviewedProject],
+				accessDelta: {
+					teamChanges: [
+						{
+							teamRef: "opaque-team-ref",
+							teamDisplayName: "Example Team",
+							change: "update",
+							fromDeviceEligibilityMode: "person_all_devices",
+							toDeviceEligibilityMode: "reviewed_allowlist",
+						},
+					],
+					membershipChanges: [
+						{
+							teamRef: "opaque-team-ref",
+							teamDisplayName: "Example Team",
+							identityRef: "identity-ref-alex",
+							identityDisplayName: "Alex",
+							change: "add",
+						},
+					],
+					projectChanges: [
+						{
+							projectRef: "project-ref-one",
+							projectDisplayName: "Legacy Project",
+							fromResolvedProjectRef: "resolved-project-old",
+							fromResolvedProjectDisplayName: "Previous Project",
+							toResolvedProjectRef: "resolved-project-beta",
+							toResolvedProjectDisplayName: "Project Beta",
+							change: "update",
+						},
+					],
+					recipientChanges: [
+						{
+							canonicalProjectRef: "canonical-project-ref",
+							canonicalProjectDisplayName: "Legacy Project",
+							recipientKind: "team",
+							recipientRef: "opaque-team-ref",
+							recipientDisplayName: "Example Team",
+							change: "add",
+						},
+					],
+					deviceAccessChanges: [
+						{
+							canonicalProjectRef: "canonical-project-ref",
+							canonicalProjectDisplayName: "Legacy Project",
+							deviceRef: "device-ref-one",
+							deviceDisplayName: "Work laptop",
+							change: "add",
+						},
+						{
+							canonicalProjectRef: "external-canonical-project-ref",
+							canonicalProjectDisplayName: "External Project",
+							deviceRef: "external-device-ref",
+							deviceDisplayName: "External laptop",
+							change: "remove",
+						},
+					],
+				},
+			}),
+		);
+		setup({ loadDetail });
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review every"));
+		const text = document.body.textContent ?? "";
+		expect(text).toContain(
+			"Update Example Team: change device access from all devices assigned to each person to the reviewed device list.",
+		);
+		expect(text).toContain("Add Alex to Example Team.");
+		expect(text).toContain("Update Legacy Project: Previous Project to Project Beta.");
+		expect(text).toContain("Add Example Team as a recipient for Legacy Project.");
+		expect(text).toContain("Add Work laptop access to Legacy Project.");
+		expect(text).toContain("Remove External laptop access from External Project.");
+		expect(text).toContain("6 access changes to review.");
+		expect(text).not.toContain("opaque-team-ref");
+		expect(text).not.toContain("resolved-project-old");
+		expect(document.querySelectorAll(".legacy-team-setup-delta li")).toHaveLength(6);
+	});
+
+	it("requires explicit confirmation and submits exact displayed finish evidence once", async () => {
+		const pendingFinish = deferred<{
+			version: 1;
+			status: "completed";
+			teamRef: string;
+			attemptId: string;
+			accessDeltaDigest: string;
+			completedAt: string;
+		}>();
+		const finish = vi.fn().mockReturnValue(pendingFinish.promise);
+		const onCompleted = vi.fn();
+		setup({
+			finish,
+			loadDetail: vi.fn().mockResolvedValue(detail({ canFinish: true })),
+			onCompleted,
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Finish Team setup"));
+
+		const finishButton = button("Finish Team setup");
+		expect(finishButton.getAttribute("aria-disabled")).toBe("true");
+		act(() => finishButton.click());
+		expect(finish).not.toHaveBeenCalled();
+		const confirmation = document.querySelector<HTMLInputElement>(
+			".legacy-team-setup-confirmation input",
+		);
+		if (!confirmation) throw new Error("finish confirmation missing");
+		confirmation.checked = true;
+		act(() => {
+			confirmation.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		act(() => {
+			finishButton.click();
+			finishButton.click();
+		});
+		expect(finish).toHaveBeenCalledTimes(1);
+		expect(finish).toHaveBeenCalledWith("opaque-candidate", {
+			attemptId: "opaque-attempt",
+			finishDigest: "opaque-finish-digest",
+			confirmedAccessDeltaDigest: "opaque-access-digest",
+			confirmedViewerAccessDeltaDigest: "opaque-viewer-access-digest",
+		});
+
+		pendingFinish.resolve({
+			version: 1,
+			status: "completed",
+			teamRef: "opaque-team-ref",
+			attemptId: "opaque-attempt",
+			accessDeltaDigest: "opaque-access-digest",
+			completedAt: "2026-08-25T00:00:00.000Z",
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Team setup complete"));
+		expect(document.activeElement?.id).toBe("legacy-team-setup-step-completed");
+		expect(onCompleted).toHaveBeenCalledTimes(1);
+	});
+
+	it("ignores a completion refresh after closing and opening another Team", async () => {
+		const completedRefresh = deferred<void>();
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(detail({ canFinish: true }))
+			.mockResolvedValueOnce(detail({ devices: [device()], unresolvedDeviceCount: 1 }));
+		setup({
+			finish: vi.fn().mockResolvedValue({
+				version: 1,
+				status: "completed",
+				teamRef: "opaque-team-ref",
+				attemptId: "opaque-attempt",
+				accessDeltaDigest: "opaque-access-digest",
+				completedAt: "2026-08-25T00:00:00.000Z",
+			}),
+			loadDetail,
+			onCompleted: vi.fn().mockReturnValue(completedRefresh.promise),
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Finish Team setup"));
+		const confirmation = document.querySelector<HTMLInputElement>(
+			".legacy-team-setup-confirmation input",
+		);
+		if (!confirmation) throw new Error("finish confirmation missing");
+		confirmation.checked = true;
+		act(() => {
+			confirmation.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		act(() => button("Finish Team setup").click());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Team setup complete"));
+
+		act(() => dialogControls.onOpenChange?.(false));
+		act(() => {
+			openLegacyTeamSetup("another-candidate");
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review devices"));
+		expect(document.body.textContent).not.toContain("Team setup complete. Sharing and Projects");
+
+		await act(async () => {
+			completedRefresh.resolve();
+			await Promise.resolve();
+		});
+		expect(document.body.textContent).not.toContain("Sharing and Projects are up to date");
+	});
+
+	it("reuses an in-flight completion refresh when reopening the same attempt", async () => {
+		const completedRefresh = deferred<void>();
+		const completedDetail = detail({ draftState: "completed" });
+		const onCompleted = vi.fn().mockReturnValue(completedRefresh.promise);
+		setup({
+			finish: vi.fn().mockResolvedValue({
+				version: 1,
+				status: "completed",
+				teamRef: "opaque-team-ref",
+				attemptId: "opaque-attempt",
+				accessDeltaDigest: "opaque-access-digest",
+				completedAt: "2026-08-25T00:00:00.000Z",
+			}),
+			loadDetail: vi
+				.fn()
+				.mockResolvedValueOnce(detail({ canFinish: true }))
+				.mockResolvedValueOnce(completedDetail),
+			onCompleted,
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Finish Team setup"));
+		const confirmation = document.querySelector<HTMLInputElement>(
+			".legacy-team-setup-confirmation input",
+		);
+		if (!confirmation) throw new Error("finish confirmation missing");
+		confirmation.checked = true;
+		act(() => {
+			confirmation.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		act(() => button("Finish Team setup").click());
+		await vi.waitFor(() => expect(onCompleted).toHaveBeenCalledTimes(1));
+		await vi.waitFor(() => expect(button("Close").getAttribute("aria-disabled")).toBeNull());
+
+		act(() => dialogControls.onOpenChange?.(false));
+		act(() => {
+			openLegacyTeamSetup("opaque-candidate");
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Team setup complete"));
+		expect(onCompleted).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			completedRefresh.reject(new Error("private refresh failure"));
+			await Promise.resolve();
+		});
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain(
+				"Sharing or Projects could not be refreshed; use that view's Refresh control.",
+			),
+		);
+		expect(document.body.textContent).not.toContain("private refresh failure");
+	});
+
+	it("refreshes completed surfaces again after the previous refresh settles", async () => {
+		const onCompleted = vi.fn().mockResolvedValue(undefined);
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(detail({ draftState: "completed" })),
+			onCompleted,
+		});
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain(
+				"Team setup complete. Sharing and Projects are up to date.",
+			),
+		);
+		expect(onCompleted).toHaveBeenCalledTimes(1);
+
+		act(() => dialogControls.onOpenChange?.(false));
+		act(() => {
+			openLegacyTeamSetup("opaque-candidate");
+		});
+
+		await vi.waitFor(() => expect(onCompleted).toHaveBeenCalledTimes(2));
+	});
+
+	it("offers an explicit server refresh when final confirmation is not ready", async () => {
+		const refreshCandidate = vi.fn().mockResolvedValue({});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(detail())
+			.mockResolvedValueOnce(detail({ canFinish: true }));
+		setup({ loadDetail, refreshCandidate });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Refresh Team setup"));
+		expect(document.getElementById("legacy-team-setup-retry")).toBeNull();
+
+		act(() => button("Refresh Team setup").click());
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Finish Team setup"));
+		expect(refreshCandidate).toHaveBeenCalledWith("opaque-candidate");
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+	});
+
+	it("refreshes dependent views when an explicit refresh discovers completion", async () => {
+		const onCompleted = vi.fn();
+		const refreshCandidate = vi.fn().mockResolvedValue({});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(detail())
+			.mockResolvedValueOnce(
+				detail({
+					conflictState: "team_setup_conflict",
+					draftState: "completed",
+					devices: [device()],
+					unresolvedDeviceCount: 1,
+				}),
+			);
+		setup({ loadDetail, onCompleted, refreshCandidate });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Refresh Team setup"));
+
+		act(() => button("Refresh Team setup").click());
+
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain(
+				"Team setup complete. Sharing and Projects are up to date.",
+			),
+		);
+		expect(onCompleted).toHaveBeenCalledTimes(1);
+		expect(document.querySelector('[role="alert"]')).toBeNull();
+		expect(document.body.textContent).not.toContain("Review devices");
+	});
+
+	it("allows an unresolved stale draft to refresh from its current step", async () => {
+		const refreshCandidate = vi.fn().mockResolvedValue({});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(
+				detail({ draftState: "stale", devices: [device()], unresolvedDeviceCount: 1 }),
+			)
+			.mockResolvedValueOnce(detail({ devices: [device()], unresolvedDeviceCount: 1 }));
+		setup({ loadDetail, refreshCandidate });
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Refresh Team setup"));
+		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+			"changed since it was last reviewed",
+		);
+		expect(document.getElementById("legacy-team-setup-retry")).toBeNull();
+		expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Devices");
+
+		act(() => button("Refresh Team setup").click());
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Team setup refreshed."));
+		expect(refreshCandidate).toHaveBeenCalledWith("opaque-candidate");
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+		expect(document.querySelector('[role="alert"]')).toBeNull();
+	});
+
+	it("reports a refresh failure as a refresh failure without private details", async () => {
+		const refreshCandidate = vi.fn().mockRejectedValue(new Error("private refresh response"));
+		setup({ loadDetail: vi.fn().mockResolvedValue(detail()), refreshCandidate });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Refresh Team setup"));
+
+		act(() => button("Refresh Team setup").click());
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+				"Team setup could not be refreshed",
+			);
+		});
+		expect(document.body.textContent).not.toContain("private refresh response");
+		expect(document.body.textContent).not.toContain("device change could not be saved");
+	});
+
+	it("fails closed and resets confirmation when finish evidence becomes stale", async () => {
+		const accessDelta = (identityDisplayName: string): LegacyTeamSetupAccessDeltaV1 => ({
+			teamChanges: [],
+			membershipChanges: [
+				{
+					teamRef: "opaque-team-ref",
+					teamDisplayName: "Example Team",
+					identityRef: "opaque-identity-ref",
+					identityDisplayName,
+					change: "add",
+				},
+			],
+			projectChanges: [],
+			recipientChanges: [],
+			deviceAccessChanges: [],
+		});
+		const initial = detail({ canFinish: true, accessDelta: accessDelta("Alex") });
+		const refreshed = detail({
+			canFinish: true,
+			accessDelta: accessDelta("Sam"),
+			viewerAccessDeltaDigest: "fresh-viewer-access-digest",
+		});
+		const loadDetail = vi.fn().mockResolvedValueOnce(initial).mockResolvedValueOnce(refreshed);
+		const finish = vi
+			.fn()
+			.mockRejectedValue(new LegacyTeamSetupApiError(409, "team_setup_confirmation_stale"));
+		setup({ finish, loadDetail });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Finish Team setup"));
+		const confirmation = document.querySelector<HTMLInputElement>(
+			".legacy-team-setup-confirmation input",
+		);
+		if (!confirmation) throw new Error("finish confirmation missing");
+		confirmation.checked = true;
+		act(() => {
+			confirmation.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		act(() => button("Finish Team setup").click());
+
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain("changed since it was last reviewed"),
+		);
+		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+			"changed since it was last reviewed",
+		);
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+		expect(finish).toHaveBeenCalledWith("opaque-candidate", {
+			attemptId: "opaque-attempt",
+			finishDigest: "opaque-finish-digest",
+			confirmedAccessDeltaDigest: "opaque-access-digest",
+			confirmedViewerAccessDeltaDigest: "opaque-viewer-access-digest",
+		});
+		expect(
+			document.querySelector<HTMLInputElement>(".legacy-team-setup-confirmation input")?.checked,
+		).toBe(false);
+		expect(document.body.textContent).toContain("Add Sam to Example Team.");
+		expect(button("Finish Team setup").getAttribute("aria-disabled")).toBe("true");
+	});
+
+	it("treats a stale finish recovery that is already completed as success", async () => {
+		const onCompleted = vi.fn().mockRejectedValue(new Error("private refresh failure"));
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(detail({ canFinish: true }))
+			.mockResolvedValueOnce(detail({ draftState: "completed" }));
+		setup({
+			finish: vi
+				.fn()
+				.mockRejectedValue(new LegacyTeamSetupApiError(409, "team_setup_confirmation_stale")),
+			loadDetail,
+			onCompleted,
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Finish Team setup"));
+		const confirmation = document.querySelector<HTMLInputElement>(
+			".legacy-team-setup-confirmation input",
+		);
+		if (!confirmation) throw new Error("finish confirmation missing");
+		confirmation.checked = true;
+		act(() => {
+			confirmation.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		act(() => button("Finish Team setup").click());
+
+		await vi.waitFor(() => {
+			expect(document.body.textContent).toContain("Team setup complete");
+			expect(document.body.textContent).toContain(
+				"Sharing or Projects could not be refreshed; use that view's Refresh control.",
+			);
+		});
+		expect(document.querySelector('[role="alert"]')).toBeNull();
+		expect(onCompleted).toHaveBeenCalledTimes(1);
+		expect(document.body.textContent).not.toContain("private refresh failure");
 	});
 
 	it("focuses explicit step navigation and restores the connected trigger on dismissal", async () => {

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
@@ -5,6 +5,7 @@ import { RadixDialog } from "../components/primitives/radix-dialog";
 import * as api from "../lib/api";
 import { LegacyTeamSetupDevices } from "./legacy-team-setup-devices";
 import { LegacyTeamSetupProjects } from "./legacy-team-setup-projects";
+import { LegacyTeamSetupReview } from "./legacy-team-setup-review";
 
 type TeamSetupStep = "devices" | "projects" | "review" | "completed";
 const CHANGED_STATE_ERROR =
@@ -20,7 +21,9 @@ const RELOAD_ERROR_CODES = new Set<api.LegacyTeamSetupErrorCode>([
 
 export interface LegacyTeamSetupDialogDependencies {
 	clearDecision: typeof api.clearLegacyTeamSetupDecision;
+	finish: typeof api.finishLegacyTeamSetup;
 	loadDetail: typeof api.loadLegacyTeamSetupDetail;
+	onCompleted: () => void | Promise<void>;
 	refreshCandidate: typeof api.refreshLegacyTeamSetupCandidate;
 	saveAssignment: typeof api.saveLegacyTeamSetupAssignment;
 	saveDecision: typeof api.saveLegacyTeamSetupDecision;
@@ -29,7 +32,9 @@ export interface LegacyTeamSetupDialogDependencies {
 
 const defaultDependencies: LegacyTeamSetupDialogDependencies = {
 	clearDecision: api.clearLegacyTeamSetupDecision,
+	finish: api.finishLegacyTeamSetup,
 	loadDetail: api.loadLegacyTeamSetupDetail,
+	onCompleted: () => {},
 	refreshCandidate: api.refreshLegacyTeamSetupCandidate,
 	saveAssignment: api.saveLegacyTeamSetupAssignment,
 	saveDecision: api.saveLegacyTeamSetupDecision,
@@ -78,6 +83,7 @@ function initialStep(detail: api.LegacyTeamSetupDetailResponseV1): TeamSetupStep
 }
 
 function detailNeedsRecovery(detail: api.LegacyTeamSetupDetailResponseV1): boolean {
+	if (detail.draftState === "completed") return false;
 	return (
 		detail.draftState === "stale" ||
 		(!detail.canFinish &&
@@ -115,6 +121,20 @@ function safeProjectMutationError(cause: unknown): string {
 		return CHANGED_STATE_ERROR;
 	}
 	return "This Project mapping could not be saved. Reload the latest details before trying again.";
+}
+
+function safeRefreshError(cause: unknown): string {
+	if (cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode)) {
+		return CHANGED_STATE_ERROR;
+	}
+	return "Team setup could not be refreshed. Retry to load the latest server details.";
+}
+
+function safeFinishError(cause: unknown): string {
+	if (cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode)) {
+		return CHANGED_STATE_ERROR;
+	}
+	return "Team setup could not be finished. Reload the latest details before trying again.";
 }
 
 function StepContent({
@@ -174,14 +194,61 @@ function LegacyTeamSetupDialogHost({
 	const refreshBeforeLoad = useRef(false);
 	const retryNeedsRefresh = useRef(false);
 	const submitting = useRef(false);
+	const dialogGeneration = useRef(0);
+	const completedSurfaceRefresh = useRef<{
+		attemptId: string;
+		candidateRef: string;
+		promise: Promise<void>;
+	} | null>(null);
+	const refreshCompletedSurfaces = (attemptId: string): Promise<void> => {
+		const currentRefresh = completedSurfaceRefresh.current;
+		if (currentRefresh?.attemptId === attemptId && currentRefresh.candidateRef === candidateRef) {
+			return currentRefresh.promise;
+		}
+		const refreshPromise = Promise.resolve().then(() => dependencies.onCompleted());
+		const forgetRefresh = () => {
+			if (completedSurfaceRefresh.current?.promise === trackedPromise) {
+				completedSurfaceRefresh.current = null;
+			}
+		};
+		const trackedPromise = refreshPromise.then(forgetRefresh, (cause: unknown) => {
+			forgetRefresh();
+			throw cause;
+		});
+		completedSurfaceRefresh.current = { attemptId, candidateRef, promise: trackedPromise };
+		return trackedPromise;
+	};
+	const reportCompletedRefresh = (attemptId: string, completionGeneration: number): void => {
+		setOperationStatus("Team setup complete. Sharing and Projects are refreshing.");
+		void refreshCompletedSurfaces(attemptId).then(
+			() => {
+				if (dialogGeneration.current !== completionGeneration) return;
+				setOperationStatus("Team setup complete. Sharing and Projects are up to date.");
+			},
+			() => {
+				if (dialogGeneration.current !== completionGeneration) return;
+				setOperationStatus(
+					"Team setup complete. Sharing or Projects could not be refreshed; use that view's Refresh control.",
+				);
+			},
+		);
+	};
 
 	useEffect(() => {
 		requestOpen = (nextCandidateRef) => {
+			if (submitting.current) {
+				setOperationStatus(
+					"Wait for the current Team setup change to finish before opening another Team.",
+				);
+				return;
+			}
+			dialogGeneration.current += 1;
 			refreshBeforeLoad.current = false;
 			retryNeedsRefresh.current = false;
 			setCandidateRef(nextCandidateRef);
 			setDetail(null);
 			setError(null);
+			setOperationStatus("");
 			setLoadRevision((current) => current + 1);
 		};
 		if (pendingCandidateRef) {
@@ -213,6 +280,9 @@ function LegacyTeamSetupDialogHost({
 				setStep(initialStep(nextDetail));
 				setError(detailNeedsRecovery(nextDetail) ? CHANGED_STATE_ERROR : null);
 				setLoading(false);
+				if (nextDetail.draftState === "completed") {
+					reportCompletedRefresh(nextDetail.attemptId, dialogGeneration.current);
+				}
 			},
 			(cause: unknown) => {
 				if (!current) return;
@@ -243,7 +313,10 @@ function LegacyTeamSetupDialogHost({
 		if (loading || !focusAfterLoad.current) return;
 		focusAfterLoad.current = false;
 		if (error) {
-			document.getElementById("legacy-team-setup-retry")?.focus();
+			(
+				document.getElementById("legacy-team-setup-retry") ??
+				document.getElementById("legacy-team-setup-refresh")
+			)?.focus();
 			return;
 		}
 		document.getElementById(`legacy-team-setup-step-${step}`)?.focus();
@@ -263,6 +336,7 @@ function LegacyTeamSetupDialogHost({
 		focusStepAfterRender.current = false;
 		refreshBeforeLoad.current = false;
 		retryNeedsRefresh.current = false;
+		dialogGeneration.current += 1;
 		setCandidateRef(null);
 		setDetail(null);
 		setError(null);
@@ -301,7 +375,15 @@ function LegacyTeamSetupDialogHost({
 	};
 	const devicesBlockProgress = detail ? detail.unresolvedDeviceCount > 0 : false;
 	const projectsBlockReview = detail ? detail.unresolvedProjectCount > 0 : false;
+	const recoveryRequired = detail ? detailNeedsRecovery(detail) : false;
 	const mutationsBlocked = loading || isSubmitting || Boolean(error);
+	const mutationBlockDescriptionId = error
+		? "legacy-team-setup-error"
+		: loading
+			? "legacy-team-setup-refresh-status"
+			: isSubmitting
+				? "legacy-team-setup-operation-status"
+				: undefined;
 	const applyAuthoritativeDetail = (
 		nextDetail: api.LegacyTeamSetupDetailResponseV1,
 		preserveDevicesStep: boolean,
@@ -310,7 +392,10 @@ function LegacyTeamSetupDialogHost({
 		setDetail(nextDetail);
 		setStep((current) => {
 			const nextStep =
-				preserveDevicesStep && current === "devices" && nextDetail.unresolvedDeviceCount > 0
+				preserveDevicesStep &&
+				current === "devices" &&
+				nextDetail.draftState !== "completed" &&
+				nextDetail.unresolvedDeviceCount > 0
 					? "devices"
 					: initialStep(nextDetail);
 			if (nextStep !== current) focusStepAfterRender.current = true;
@@ -336,6 +421,11 @@ function LegacyTeamSetupDialogHost({
 		try {
 			const nextDetail = await dependencies.loadDetail(candidateRef);
 			applyAuthoritativeDetail(nextDetail, true);
+			if (nextDetail.draftState === "completed") {
+				setError(null);
+				reportCompletedRefresh(nextDetail.attemptId, dialogGeneration.current);
+				return;
+			}
 			retryNeedsRefresh.current = true;
 		} catch {
 			retryNeedsRefresh.current = true;
@@ -458,6 +548,56 @@ function LegacyTeamSetupDialogHost({
 				}),
 		);
 	};
+	const refreshSetup = () => {
+		if (loading || isSubmitting || submitting.current) return;
+		const completionGeneration = dialogGeneration.current;
+		submitting.current = true;
+		setIsSubmitting(true);
+		setOperationStatus("Refreshing Team setup from the latest server state.");
+		setError(null);
+		void dependencies
+			.refreshCandidate(candidateRef)
+			.then(reloadAfterMutation)
+			.then((nextDetail) => {
+				if (nextDetail.draftState === "completed") {
+					reportCompletedRefresh(nextDetail.attemptId, completionGeneration);
+					return;
+				}
+				setOperationStatus("Team setup refreshed.");
+			})
+			.catch((cause: unknown) => recoverMutation(cause, safeRefreshError))
+			.finally(() => {
+				submitting.current = false;
+				setIsSubmitting(false);
+			});
+	};
+	const finishSetup = (finishDetail: api.LegacyTeamSetupDetailResponseV1 & { canFinish: true }) => {
+		if (mutationsBlocked || submitting.current) return;
+		const completionGeneration = dialogGeneration.current;
+		submitting.current = true;
+		setIsSubmitting(true);
+		setOperationStatus("Finishing Team setup.");
+		setError(null);
+		void dependencies
+			.finish(candidateRef, {
+				attemptId: finishDetail.attemptId,
+				finishDigest: finishDetail.finishDigest,
+				confirmedAccessDeltaDigest: finishDetail.accessDeltaDigest,
+				confirmedViewerAccessDeltaDigest: finishDetail.viewerAccessDeltaDigest,
+			})
+			.then(
+				() => {
+					focusStepAfterRender.current = true;
+					setStep("completed");
+					reportCompletedRefresh(finishDetail.attemptId, completionGeneration);
+				},
+				(cause: unknown) => recoverMutation(cause, safeFinishError),
+			)
+			.finally(() => {
+				submitting.current = false;
+				setIsSubmitting(false);
+			});
+	};
 
 	return (
 		<RadixDialog
@@ -507,23 +647,25 @@ function LegacyTeamSetupDialogHost({
 					{loading && !detail ? <p role="status">Loading the latest Team setup details…</p> : null}
 					{error ? (
 						<div className="legacy-team-setup-error">
-							<p aria-live="assertive" role="alert">
+							<p aria-live="assertive" id="legacy-team-setup-error" role="alert">
 								{error}
 							</p>
-							<button
-								aria-disabled={loading || isSubmitting ? "true" : undefined}
-								className="settings-button legacy-team-setup-target"
-								id="legacy-team-setup-retry"
-								onClick={() => {
-									if (loading || isSubmitting) return;
-									focusAfterLoad.current = true;
-									refreshBeforeLoad.current = retryNeedsRefresh.current;
-									setLoadRevision((current) => current + 1);
-								}}
-								type="button"
-							>
-								{loading ? "Retrying…" : "Retry"}
-							</button>
+							{!detail || !recoveryRequired ? (
+								<button
+									aria-disabled={loading || isSubmitting ? "true" : undefined}
+									className="settings-button legacy-team-setup-target"
+									id="legacy-team-setup-retry"
+									onClick={() => {
+										if (loading || isSubmitting) return;
+										focusAfterLoad.current = true;
+										refreshBeforeLoad.current = retryNeedsRefresh.current;
+										setLoadRevision((current) => current + 1);
+									}}
+									type="button"
+								>
+									{loading ? "Retrying…" : "Retry"}
+								</button>
+							) : null}
 						</div>
 					) : null}
 					{detail ? (
@@ -608,16 +750,38 @@ function LegacyTeamSetupDialogHost({
 								</>
 							) : null}
 							{loading ? (
-								<p aria-live="polite" className="small" role="status">
+								<p
+									aria-live="polite"
+									className="small"
+									id="legacy-team-setup-refresh-status"
+									role="status"
+								>
 									Refreshing Team setup details…
 								</p>
 							) : null}
-							<p aria-live="polite" className="small" role="status">
+							<p
+								aria-live="polite"
+								className="small"
+								id="legacy-team-setup-operation-status"
+								role="status"
+							>
 								{operationStatus}
 							</p>
+							{recoveryRequired ? (
+								<button
+									aria-disabled={loading || isSubmitting ? "true" : undefined}
+									className="settings-button legacy-team-setup-target"
+									id="legacy-team-setup-refresh"
+									onClick={refreshSetup}
+									type="button"
+								>
+									Refresh Team setup
+								</button>
+							) : null}
 							{step === "devices" ? (
 								<LegacyTeamSetupDevices
 									blocked={mutationsBlocked}
+									blockedDescriptionId={mutationBlockDescriptionId}
 									busyDeviceRef={busyDeviceRef}
 									detail={detail}
 									onAssign={assignDevice}
@@ -627,12 +791,32 @@ function LegacyTeamSetupDialogHost({
 							) : step === "projects" ? (
 								<LegacyTeamSetupProjects
 									blocked={mutationsBlocked}
+									blockedDescriptionId={mutationBlockDescriptionId}
 									busyProjectRef={busyProjectRef}
 									detail={detail}
 									onMap={mapProject}
 								/>
+							) : step === "review" && detail.canFinish ? (
+								<LegacyTeamSetupReview
+									blocked={mutationsBlocked}
+									blockedDescriptionId={mutationBlockDescriptionId}
+									detail={detail}
+									onFinish={finishSetup}
+								/>
 							) : (
-								<StepContent detail={detail} step={step} />
+								<>
+									<StepContent detail={detail} step={step} />
+									{step === "review" && !detail.canFinish && !recoveryRequired ? (
+										<button
+											aria-disabled={loading || isSubmitting ? "true" : undefined}
+											className="settings-button legacy-team-setup-target"
+											onClick={refreshSetup}
+											type="button"
+										>
+											Refresh Team setup
+										</button>
+									) : null}
+								</>
 							)}
 						</>
 					) : null}

--- a/packages/ui/src/tabs/legacy-team-setup-projects.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-projects.tsx
@@ -3,6 +3,7 @@ import type { LegacyTeamSetupDetailResponseV1, LegacyTeamSetupProjectV1 } from "
 
 export interface LegacyTeamSetupProjectsProps {
 	blocked: boolean;
+	blockedDescriptionId?: string;
 	busyProjectRef: string | null;
 	detail: LegacyTeamSetupDetailResponseV1;
 	onMap: (project: LegacyTeamSetupProjectV1, resolvedProjectRef: string) => void;
@@ -19,11 +20,12 @@ function mappingName(project: LegacyTeamSetupProjectV1): string | null {
 
 function ProjectRow({
 	blocked,
+	blockedDescriptionId,
 	busy,
 	index,
 	onMap,
 	project,
-}: Pick<LegacyTeamSetupProjectsProps, "blocked" | "onMap"> & {
+}: Pick<LegacyTeamSetupProjectsProps, "blocked" | "blockedDescriptionId" | "onMap"> & {
 	busy: boolean;
 	index: number;
 	project: LegacyTeamSetupProjectV1;
@@ -45,6 +47,12 @@ function ProjectRow({
 	const controlsBlocked = blocked || busy;
 	const saveBlocked = controlsBlocked || !draftMapping || draftMapping === savedMapping;
 	const savedName = mappingName(project);
+	const controlDescription = [
+		!draftMapping ? helpId : undefined,
+		blocked ? blockedDescriptionId : undefined,
+	]
+		.filter(Boolean)
+		.join(" ");
 
 	return (
 		<fieldset
@@ -63,7 +71,7 @@ function ProjectRow({
 					</p>
 					<label htmlFor={controlId}>Canonical Project</label>
 					<select
-						aria-describedby={!draftMapping ? helpId : undefined}
+						aria-describedby={controlDescription || undefined}
 						className="feed-search legacy-team-project-select"
 						disabled={controlsBlocked}
 						id={controlId}
@@ -83,6 +91,7 @@ function ProjectRow({
 						</p>
 					) : null}
 					<button
+						aria-describedby={controlDescription || undefined}
 						aria-disabled={saveBlocked ? "true" : undefined}
 						className="settings-button legacy-team-setup-target"
 						onClick={() => {
@@ -112,6 +121,7 @@ export function LegacyTeamSetupProjects(props: LegacyTeamSetupProjectsProps) {
 				{props.detail.projects.map((project, index) => (
 					<ProjectRow
 						blocked={props.blocked}
+						blockedDescriptionId={props.blockedDescriptionId}
 						busy={props.busyProjectRef === project.projectRef}
 						index={index}
 						key={project.projectRef}

--- a/packages/ui/src/tabs/legacy-team-setup-review.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-review.tsx
@@ -1,0 +1,130 @@
+import { useState } from "preact/hooks";
+import type { LegacyTeamSetupDetailResponseV1 } from "../lib/api";
+
+type FinishableDetail = LegacyTeamSetupDetailResponseV1 & { canFinish: true };
+
+export interface LegacyTeamSetupReviewProps {
+	blocked: boolean;
+	blockedDescriptionId?: string;
+	detail: FinishableDetail;
+	onFinish: (detail: FinishableDetail) => void;
+}
+
+const CHANGE_VERBS = { add: "Add", update: "Update", remove: "Remove" } as const;
+
+function DeltaSection({ empty, items, title }: { empty: string; items: string[]; title: string }) {
+	return (
+		<section>
+			<h4>{title}</h4>
+			{items.length > 0 ? (
+				<ul>
+					{items.map((item, index) => (
+						<li key={`${title}-${index}`}>{item}</li>
+					))}
+				</ul>
+			) : (
+				<p className="small">{empty}</p>
+			)}
+		</section>
+	);
+}
+
+export function LegacyTeamSetupReview({
+	blocked,
+	blockedDescriptionId,
+	detail,
+	onFinish,
+}: LegacyTeamSetupReviewProps) {
+	const delta = detail.accessDelta;
+	const evidenceKey = `${detail.attemptId}:${detail.finishDigest}:${detail.accessDeltaDigest}:${detail.viewerAccessDeltaDigest}`;
+	const [confirmedEvidenceKey, setConfirmedEvidenceKey] = useState<string | null>(null);
+	const confirmed = confirmedEvidenceKey === evidenceKey;
+	const finishBlocked = blocked || !confirmed;
+	const finishBlockedDescription = [
+		!confirmed ? "legacy-team-setup-confirmation-label" : null,
+		blocked ? blockedDescriptionId : null,
+	]
+		.filter(Boolean)
+		.join(" ");
+	const teamItems = delta.teamChanges.map((change) => {
+		const fromMode =
+			change.fromDeviceEligibilityMode === "person_all_devices"
+				? "all devices assigned to each person"
+				: change.fromDeviceEligibilityMode === "reviewed_allowlist"
+					? "the reviewed device list"
+					: "no existing device policy";
+		return `${CHANGE_VERBS[change.change]} ${change.teamDisplayName}: change device access from ${fromMode} to the reviewed device list.`;
+	});
+	const membershipItems = delta.membershipChanges.map(
+		(change) =>
+			`${CHANGE_VERBS[change.change]} ${change.identityDisplayName} ${
+				change.change === "remove" ? "from" : "to"
+			} ${change.teamDisplayName}.`,
+	);
+	const projectItems = delta.projectChanges.map(
+		(change) =>
+			`${CHANGE_VERBS[change.change]} ${change.projectDisplayName}: ${
+				change.fromResolvedProjectDisplayName ?? "no Project"
+			} to ${change.toResolvedProjectDisplayName ?? "no Project"}.`,
+	);
+	const recipientItems = delta.recipientChanges.map(
+		(change) =>
+			`${CHANGE_VERBS[change.change]} ${change.recipientDisplayName} ${
+				change.change === "remove" ? "from" : "as"
+			} a recipient for ${change.canonicalProjectDisplayName}.`,
+	);
+	const deviceItems = delta.deviceAccessChanges.map(
+		(change) =>
+			`${CHANGE_VERBS[change.change]} ${change.deviceDisplayName} access ${
+				change.change === "remove" ? "from" : "to"
+			} ${change.canonicalProjectDisplayName}.`,
+	);
+	const accessChangeCount =
+		teamItems.length +
+		membershipItems.length +
+		projectItems.length +
+		recipientItems.length +
+		deviceItems.length;
+
+	return (
+		<section aria-labelledby="legacy-team-setup-step-review">
+			<h3 id="legacy-team-setup-step-review" tabIndex={-1}>
+				Review and finish
+			</h3>
+			<p>Review every server-confirmed access change before activating this Team.</p>
+			<p className="small">
+				{accessChangeCount} access {accessChangeCount === 1 ? "change" : "changes"} to review.
+			</p>
+			<div className="legacy-team-setup-delta">
+				<DeltaSection empty="No Team policy changes." items={teamItems} title="Team policy" />
+				<DeltaSection empty="No membership changes." items={membershipItems} title="Memberships" />
+				<DeltaSection empty="No Project mapping changes." items={projectItems} title="Projects" />
+				<DeltaSection empty="No recipient changes." items={recipientItems} title="Recipients" />
+				<DeltaSection empty="No device access changes." items={deviceItems} title="Device access" />
+			</div>
+			<label className="legacy-team-setup-confirmation" id="legacy-team-setup-confirmation-label">
+				<input
+					aria-disabled={blocked ? "true" : undefined}
+					aria-describedby={blocked ? blockedDescriptionId : undefined}
+					checked={confirmed}
+					onChange={(event) => {
+						if (!blocked) setConfirmedEvidenceKey(event.currentTarget.checked ? evidenceKey : null);
+					}}
+					type="checkbox"
+				/>
+				<span>I reviewed every access change above and approve activating this Team.</span>
+			</label>
+			<button
+				aria-describedby={finishBlockedDescription || undefined}
+				aria-disabled={finishBlocked ? "true" : undefined}
+				className="settings-button legacy-team-setup-target"
+				onClick={() => {
+					if (!finishBlocked) onFinish(detail);
+				}}
+				type="button"
+			>
+				Finish Team setup
+			</button>
+		</section>
+	);
+}

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -531,6 +531,65 @@ describe("Projects tab", () => {
 		resolveTeamSetup({ version: 1, candidates: [] });
 	});
 
+	it("renders Projects but reports strict refresh failure after Team setup discovery fails", async () => {
+		let rejectTeamSetup!: (reason?: unknown) => void;
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		});
+		vi.mocked(api.loadLegacyTeamSetupSummary).mockImplementation(
+			() =>
+				new Promise<LegacyTeamSetupSummaryResponseV1>((_, reject) => {
+					rejectTeamSetup = reject;
+				}),
+		);
+
+		const loading = loadProjectsData({ requireTeamSetupSummary: true });
+		await vi.waitFor(() =>
+			expect(document.getElementById("projectsInventoryMeta")?.textContent).toContain(
+				"1 project identity found",
+			),
+		);
+		let settled = false;
+		void loading.then(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		rejectTeamSetup(new Error("setup unavailable"));
+		await expect(loading).resolves.toBe(false);
+	});
+
+	it("requires a fresh Team setup summary for a strict refresh", async () => {
+		let resolveFirst!: (value: LegacyTeamSetupSummaryResponseV1) => void;
+		let resolveSecond!: (value: LegacyTeamSetupSummaryResponseV1) => void;
+		vi.mocked(api.loadLegacyTeamSetupSummary)
+			.mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+			.mockImplementationOnce(() => new Promise((resolve) => (resolveSecond = resolve)));
+
+		await expect(loadProjectsData()).resolves.toBe(true);
+		const strictRefresh = loadProjectsData({ requireTeamSetupSummary: true });
+		await vi.waitFor(() => expect(api.loadLegacyTeamSetupSummary).toHaveBeenCalledTimes(2));
+
+		resolveSecond({ version: 1, candidates: [] });
+		await expect(strictRefresh).resolves.toBe(true);
+		resolveFirst({ version: 1, candidates: [] });
+	});
+
+	it("fails a strict refresh while a Project domain selection is active", async () => {
+		const select = document.createElement("select");
+		select.className = "project-domain-select";
+		document.body.appendChild(select);
+		select.focus();
+
+		await expect(loadProjectsData({ requireTeamSetupSummary: true })).resolves.toBe(false);
+		expect(api.loadLegacyTeamSetupSummary).not.toHaveBeenCalled();
+	});
+
 	it("reuses slow Team setup discovery across polling generations", async () => {
 		let resolveTeamSetup!: (value: LegacyTeamSetupSummaryResponseV1) => void;
 		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -74,8 +74,8 @@ let recipientPolicyIntent = emptyRecipientPolicyIntent;
 let recipientPolicyIntentReady = false;
 let openTeamSetup: ((candidateRef: string) => void) | undefined;
 
-function loadTeamSetupSummaryOnce(): Promise<TeamSetupSummaryResult> {
-	if (teamSetupSummaryInFlight) return teamSetupSummaryInFlight;
+function loadTeamSetupSummaryOnce(forceFresh = false): Promise<TeamSetupSummaryResult> {
+	if (!forceFresh && teamSetupSummaryInFlight) return teamSetupSummaryInFlight;
 	const request = api
 		.loadLegacyTeamSetupSummary()
 		.then((summary) => ({ ok: true as const, summary }))
@@ -1374,13 +1374,21 @@ function recipientPolicyReviewContentMount(mount: HTMLElement): HTMLElement {
 	return content;
 }
 
-export async function loadProjectsData() {
+export interface ProjectsDataLoadOptions {
+	requireTeamSetupSummary?: boolean;
+}
+
+export async function loadProjectsData(options: ProjectsDataLoadOptions = {}) {
 	const meta = el<HTMLDivElement>("projectsInventoryMeta");
 	const list = el<HTMLDivElement>("projectsInventoryList");
-	if (!meta || !list) return;
+	if (!meta || !list) {
+		if (!options.requireTeamSetupSummary) return true;
+		return (await loadTeamSetupSummaryOnce(true)).ok;
+	}
 	if (isProjectSpaceSelectActive()) {
 		skippedProjectRefreshForActiveSelect = true;
-		return;
+		if (!options.requireTeamSetupSummary) return true;
+		return false;
 	}
 	skippedProjectRefreshForActiveSelect = false;
 	const loadGeneration = ++projectsLoadGeneration;
@@ -1389,7 +1397,9 @@ export async function loadProjectsData() {
 	updateSelectionControls();
 	meta.textContent = "Loading project inventory…";
 	try {
-		const teamSetupSummaryPromise = loadTeamSetupSummaryOnce();
+		const teamSetupSummaryPromise = loadTeamSetupSummaryOnce(
+			options.requireTeamSetupSummary === true,
+		);
 		const [result, settings, shareInventory, recipientPolicyReview, intentResult] =
 			await Promise.all([
 				api.loadProjectScopeInventory({
@@ -1411,7 +1421,10 @@ export async function loadProjectsData() {
 					.then((intent) => ({ ok: true as const, intent }))
 					.catch((error: unknown) => ({ ok: false as const, error })),
 			]);
-		if (loadGeneration !== projectsLoadGeneration) return;
+		if (loadGeneration !== projectsLoadGeneration) {
+			if (options.requireTeamSetupSummary) await teamSetupSummaryPromise;
+			return false;
+		}
 		scopes = settings.scopes;
 		projectShareInventoryReady = shareInventory.ok;
 		recipientPolicyIntentReady = intentResult.ok;
@@ -1461,8 +1474,14 @@ export async function loadProjectsData() {
 			}
 			renderProjectTeamSetupEntry(currentReviewMount, teamSetupSummary.summary);
 		});
+		const requiredLoadSucceeded =
+			shareInventory.ok && "review" in recipientPolicyReview && intentResult.ok;
+		if (!options.requireTeamSetupSummary) return requiredLoadSucceeded;
+		const teamSetupSummary = await teamSetupSummaryPromise;
+		if (loadGeneration !== projectsLoadGeneration) return false;
+		return requiredLoadSucceeded && teamSetupSummary.ok;
 	} catch (error) {
-		if (loadGeneration !== projectsLoadGeneration) return;
+		if (loadGeneration !== projectsLoadGeneration) return false;
 		projectShareInventoryReady = false;
 		recipientPolicyIntentReady = false;
 		recipientPolicyIntent = emptyRecipientPolicyIntent;
@@ -1473,6 +1492,7 @@ export async function loadProjectsData() {
 		hideProjectInventorySkeleton();
 		meta.textContent = "Project inventory failed to load.";
 		renderEmpty(error instanceof Error ? error.message : "Unable to load project inventory.");
+		return false;
 	}
 }
 

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1267,6 +1267,12 @@
       .legacy-team-project-row label { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); }
       .legacy-team-project-select { width: 100%; margin: 0; }
       .legacy-team-project-select:disabled { opacity: 0.55; cursor: not-allowed; }
+      .legacy-team-setup-delta { display: grid; gap: var(--sp-3); }
+      .legacy-team-setup-delta section { padding-block: var(--sp-2); border-bottom: 1px solid var(--border); }
+      .legacy-team-setup-delta h4 { margin: 0 0 var(--sp-2); }
+      .legacy-team-setup-delta ul { display: grid; gap: var(--sp-1); margin: 0; padding-inline-start: var(--sp-5); }
+      .legacy-team-setup-confirmation { display: flex; gap: var(--sp-2); align-items: flex-start; margin-block: var(--sp-4); }
+      .legacy-team-setup-confirmation input { flex: 0 0 auto; margin-top: 0.2em; min-width: 24px; min-height: 24px; }
       .recipient-policy-management-selection fieldset { border: 0; padding: 0; margin: var(--sp-4) 0 0; }
       .recipient-policy-management-selection legend { font-weight: var(--font-weight-semibold); }
       .recipient-policy-management-review section + section { margin-top: var(--sp-4); }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -783,7 +783,48 @@ describe("viewer-server", () => {
 					attemptId: draft?.attemptId,
 					finishDigest: rawPreview.finishDigest,
 					confirmedAccessDeltaDigest: rawPreview.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
 				};
+				store.db
+					.prepare("UPDATE actors SET display_name = ? WHERE actor_id = ?")
+					.run("Renamed Person", rawIdentityId);
+				const staleLabelResponse = await app.request(
+					`/api/sync/team-setup/v1/${candidateRef}/finish`,
+					{
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify(finishRequest),
+					},
+				);
+				expect(staleLabelResponse.status).toBe(409);
+				expect(await staleLabelResponse.json()).toEqual({
+					error: "team_setup_confirmation_stale",
+				});
+				store.db
+					.prepare("UPDATE actors SET display_name = ? WHERE actor_id = ?")
+					.run("Private Person", rawIdentityId);
+				loadSnapshots.mockImplementationOnce(async () => {
+					store.db
+						.prepare("UPDATE actors SET display_name = ? WHERE actor_id = ?")
+						.run("Raced Person", rawIdentityId);
+					return snapshots;
+				});
+				const racedLabelResponse = await app.request(
+					`/api/sync/team-setup/v1/${candidateRef}/finish`,
+					{
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify(finishRequest),
+					},
+				);
+				expect(racedLabelResponse.status).toBe(409);
+				expect(await racedLabelResponse.json()).toEqual({
+					error: "team_setup_confirmation_stale",
+				});
+				expect(core.getLegacyTeamSetupDraft(store.db, candidateRef)?.state).not.toBe("completed");
+				store.db
+					.prepare("UPDATE actors SET display_name = ? WHERE actor_id = ?")
+					.run("Private Person", rawIdentityId);
 				loadSnapshots.mockClear();
 				const finishResponse = await app.request(`/api/sync/team-setup/v1/${candidateRef}/finish`, {
 					method: "POST",
@@ -944,12 +985,79 @@ describe("viewer-server", () => {
 			});
 			expect(JSON.stringify(safe)).not.toContain(fromIdentity);
 			expect(JSON.stringify(safe)).not.toContain(toIdentity);
+			const fromRef = core.legacyTeamResolvedProjectRef(projectRef, fromIdentity);
+			const toRef = core.legacyTeamResolvedProjectRef(projectRef, toIdentity);
 			expect(safe.projectChanges[0]).toEqual({
 				projectRef,
-				fromResolvedProjectRef: core.legacyTeamResolvedProjectRef(projectRef, fromIdentity),
-				toResolvedProjectRef: core.legacyTeamResolvedProjectRef(projectRef, toIdentity),
+				projectDisplayName: "Project outside this setup (1)",
+				fromResolvedProjectRef: fromRef,
+				fromResolvedProjectDisplayName: "Project outside this setup (2)",
+				toResolvedProjectRef: toRef,
+				toResolvedProjectDisplayName: "Project outside this setup (3)",
 				change: "update",
 			});
+		});
+
+		it("gives external delta entries distinct viewer-safe fallback labels", () => {
+			const safe = __teamSetupTestHooks.viewerSafeAccessDelta(
+				candidateRef,
+				{
+					teamChanges: [],
+					membershipChanges: [],
+					projectChanges: [],
+					recipientChanges: [],
+					deviceAccessChanges: [
+						{
+							canonicalProjectIdentity: "file:///private/external-one",
+							deviceId: "external-device-one",
+							change: "add",
+						},
+						{
+							canonicalProjectIdentity: "file:///private/external-two",
+							deviceId: "external-device-two",
+							change: "remove",
+						},
+					],
+				},
+				{
+					teamDisplayName: "Example Team",
+					devices: [
+						{
+							deviceRef: core.legacyTeamDeviceRef(candidateRef, "known-device"),
+							displayName: "Device outside this setup (1)",
+							enabled: true,
+							existingIdentityRef: null,
+							suggestedIdentityRef: null,
+							verifiedEvidenceKind: null,
+							decision: "excluded",
+							targetIdentityRef: null,
+							expectation: { kind: "absent" },
+						},
+					],
+					projects: [
+						{
+							projectRef: "known-project-ref",
+							displayName: "Project outside this setup (1)",
+							resolution: "unresolved",
+							canonicalProjectRef: null,
+							resolvedProjectRef: null,
+							mappingChoices: [],
+						},
+					],
+					identityChoices: [],
+				},
+			);
+
+			expect(safe.deviceAccessChanges.map((change) => change.deviceDisplayName)).toEqual([
+				"Device outside this setup (2)",
+				"Device outside this setup (3)",
+			]);
+			expect(safe.deviceAccessChanges.map((change) => change.canonicalProjectDisplayName)).toEqual([
+				"Project outside this setup (2)",
+				"Project outside this setup (3)",
+			]);
+			expect(JSON.stringify(safe)).not.toContain("external-device");
+			expect(JSON.stringify(safe)).not.toContain("file:///private");
 		});
 
 		it("fails closed when active identity choices exceed their response cap", async () => {

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -181,6 +181,25 @@ describe("Team setup roster loading", () => {
 		]);
 	});
 
+	it("terminates when full-ref disambiguators collide with original labels", () => {
+		expect(
+			__teamSetupTestHooks.disambiguateChoiceLabels(
+				[
+					{ displayName: "Alex", identityRef: "a" },
+					{ displayName: "Alex", identityRef: "b" },
+					{ displayName: "Alex a", identityRef: "c" },
+					{ displayName: "Alex a-1-1", identityRef: "d" },
+				],
+				(choice) => choice.identityRef,
+			),
+		).toEqual([
+			{ displayName: "Alex a-1-2", identityRef: "a" },
+			{ displayName: "Alex b", identityRef: "b" },
+			{ displayName: "Alex a", identityRef: "c" },
+			{ displayName: "Alex a-1-1", identityRef: "d" },
+		]);
+	});
+
 	it("preserves oversized-roster errors for a direct candidate load", async () => {
 		const coordinatorId = "http://localhost:8787";
 		const groupId = "group-alpha";

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -57,6 +57,7 @@ const RESOLVED_PROJECT_REF_PATTERN = /^legacy-team-resolved-project-ref-v1:[0-9a
 const ATTEMPT_ID_PATTERN = /^legacy-team-attempt:[0-9a-f-]{36}$/u;
 const FINISH_DIGEST_PATTERN = /^legacy-team-activation-finish-v1:[0-9a-f]{64}$/u;
 const ACCESS_DELTA_DIGEST_PATTERN = /^legacy-team-access-delta:[0-9a-f]{64}$/u;
+const VIEWER_ACCESS_DELTA_DIGEST_PATTERN = /^legacy-team-viewer-access-delta-v1:[0-9a-f]{64}$/u;
 
 interface LegacyTeamConfiguredGroupSnapshotLoadOptions {
 	candidateRef?: string;
@@ -112,30 +113,40 @@ export interface LegacyTeamSetupIdentityChoiceV1 {
 export interface LegacyTeamSetupViewerAccessDeltaV1 {
 	teamChanges: Array<{
 		teamRef: string;
+		teamDisplayName: string;
 		change: "add" | "update" | "remove";
 		fromDeviceEligibilityMode: "person_all_devices" | "reviewed_allowlist" | null;
 		toDeviceEligibilityMode: "reviewed_allowlist";
 	}>;
 	membershipChanges: Array<{
 		teamRef: string;
+		teamDisplayName: string;
 		identityRef: string;
+		identityDisplayName: string;
 		change: "add" | "update" | "remove";
 	}>;
 	projectChanges: Array<{
 		projectRef: string;
+		projectDisplayName: string;
 		fromResolvedProjectRef: string | null;
+		fromResolvedProjectDisplayName: string | null;
 		toResolvedProjectRef: string | null;
+		toResolvedProjectDisplayName: string | null;
 		change: "add" | "update" | "remove";
 	}>;
 	recipientChanges: Array<{
 		canonicalProjectRef: string;
+		canonicalProjectDisplayName: string;
 		recipientKind: "team";
 		recipientRef: string;
+		recipientDisplayName: string;
 		change: "add" | "update" | "remove";
 	}>;
 	deviceAccessChanges: Array<{
 		canonicalProjectRef: string;
+		canonicalProjectDisplayName: string;
 		deviceRef: string;
+		deviceDisplayName: string;
 		change: "add" | "remove";
 	}>;
 }
@@ -159,6 +170,7 @@ export type LegacyTeamSetupDetailResponseV1 = LegacyTeamSetupDetailBaseV1 &
 				conflictState: null;
 				finishDigest: string;
 				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
 				accessDelta: LegacyTeamSetupViewerAccessDeltaV1;
 		  }
 		| {
@@ -400,43 +412,138 @@ function resolvedProjectRef(projectRef: string, projectIdentity: string | null):
 function viewerSafeAccessDelta(
 	candidateRef: string,
 	delta: LegacyTeamSetupAccessDeltaV1,
+	labels?: {
+		teamDisplayName: string;
+		devices: LegacyTeamSetupDeviceV1[];
+		projects: LegacyTeamSetupProjectV1[];
+		identityChoices: LegacyTeamSetupIdentityChoiceV1[];
+	},
 ): LegacyTeamSetupViewerAccessDeltaV1 {
+	const fallbackLabels = new Map<string, string>();
+	const fallbackLabelCounts = new Map<string, number>();
+	const reservedLabels = new Set(
+		[
+			labels?.teamDisplayName,
+			...(labels?.devices.map((device) => device.displayName) ?? []),
+			...(labels?.projects.flatMap((project) => [
+				project.displayName,
+				...project.mappingChoices.map((choice) => choice.displayName),
+			]) ?? []),
+			...(labels?.identityChoices.map((identity) => identity.displayName) ?? []),
+		]
+			.filter((label): label is string => Boolean(label))
+			.map((label) => normalizeChoiceLabelText(label).toLowerCase()),
+	);
+	const fallbackLabel = (kind: string, ref: string) => {
+		const key = `${kind}:${ref}`;
+		const existing = fallbackLabels.get(key);
+		if (existing) return existing;
+		let index = (fallbackLabelCounts.get(kind) ?? 0) + 1;
+		let label = `${kind} outside this setup (${index})`;
+		while (reservedLabels.has(normalizeChoiceLabelText(label).toLowerCase())) {
+			index += 1;
+			label = `${kind} outside this setup (${index})`;
+		}
+		fallbackLabelCounts.set(kind, index);
+		reservedLabels.add(normalizeChoiceLabelText(label).toLowerCase());
+		fallbackLabels.set(key, label);
+		return label;
+	};
+	const projectsByRef = new Map(labels?.projects.map((project) => [project.projectRef, project]));
+	const projectsByCanonicalRef = new Map(
+		labels?.projects.flatMap((project) =>
+			project.canonicalProjectRef ? [[project.canonicalProjectRef, project] as const] : [],
+		),
+	);
+	const identitiesByRef = new Map(
+		labels?.identityChoices.map((identity) => [identity.identityRef, identity]),
+	);
+	const devicesByRef = new Map(labels?.devices.map((device) => [device.deviceRef, device]));
+	const resolvedDisplayName = (projectRef: string, ref: string | null): string | null => {
+		if (!ref) return null;
+		const project = projectsByRef.get(projectRef);
+		const choice = project?.mappingChoices.find((item) => item.resolvedProjectRef === ref);
+		if (choice) return choice.displayName;
+		if (project?.resolvedProjectRef === ref && project.resolution === "deterministic") {
+			return `${project.displayName} (automatic match)`;
+		}
+		return fallbackLabel("Project", ref);
+	};
 	return {
 		teamChanges: delta.teamChanges.map((change) => ({
 			teamRef: teamRef(candidateRef, change.teamId),
+			teamDisplayName:
+				labels?.teamDisplayName ?? fallbackLabel("Team", teamRef(candidateRef, change.teamId)),
 			change: change.change,
 			fromDeviceEligibilityMode: change.fromDeviceEligibilityMode,
 			toDeviceEligibilityMode: change.toDeviceEligibilityMode,
 		})),
-		membershipChanges: delta.membershipChanges.map((change) => ({
-			teamRef: teamRef(candidateRef, change.teamId),
-			identityRef: requiredIdentityRef(candidateRef, change.identityId),
-			change: change.change,
-		})),
-		projectChanges: delta.projectChanges.map((change) => ({
-			projectRef: change.projectRef,
-			fromResolvedProjectRef: resolvedProjectRef(change.projectRef, change.fromProjectIdentity),
-			toResolvedProjectRef: resolvedProjectRef(change.projectRef, change.toProjectIdentity),
-			change: change.change,
-		})),
-		recipientChanges: delta.recipientChanges.map((change) => ({
-			canonicalProjectRef: legacyTeamCanonicalProjectRef(
+		membershipChanges: delta.membershipChanges.map((change) => {
+			const identityRef = requiredIdentityRef(candidateRef, change.identityId);
+			const membershipTeamRef = teamRef(candidateRef, change.teamId);
+			return {
+				teamRef: membershipTeamRef,
+				teamDisplayName: labels?.teamDisplayName ?? fallbackLabel("Team", membershipTeamRef),
+				identityRef,
+				identityDisplayName:
+					identitiesByRef.get(identityRef)?.displayName ?? fallbackLabel("Person", identityRef),
+				change: change.change,
+			};
+		}),
+		projectChanges: delta.projectChanges.map((change) => {
+			const fromRef = resolvedProjectRef(change.projectRef, change.fromProjectIdentity);
+			const toRef = resolvedProjectRef(change.projectRef, change.toProjectIdentity);
+			return {
+				projectRef: change.projectRef,
+				projectDisplayName:
+					projectsByRef.get(change.projectRef)?.displayName ??
+					fallbackLabel("Project", change.projectRef),
+				fromResolvedProjectRef: fromRef,
+				fromResolvedProjectDisplayName: resolvedDisplayName(change.projectRef, fromRef),
+				toResolvedProjectRef: toRef,
+				toResolvedProjectDisplayName: resolvedDisplayName(change.projectRef, toRef),
+				change: change.change,
+			};
+		}),
+		recipientChanges: delta.recipientChanges.map((change) => {
+			const canonicalProjectRef = legacyTeamCanonicalProjectRef(
 				candidateRef,
 				change.canonicalProjectIdentity,
-			),
-			recipientKind: change.recipientKind,
-			recipientRef: teamRef(candidateRef, change.recipientId),
-			change: change.change,
-		})),
-		deviceAccessChanges: delta.deviceAccessChanges.map((change) => ({
-			canonicalProjectRef: legacyTeamCanonicalProjectRef(
+			);
+			const recipientRef = teamRef(candidateRef, change.recipientId);
+			return {
+				canonicalProjectRef,
+				canonicalProjectDisplayName:
+					projectsByCanonicalRef.get(canonicalProjectRef)?.displayName ??
+					fallbackLabel("Project", canonicalProjectRef),
+				recipientKind: change.recipientKind,
+				recipientRef,
+				recipientDisplayName: labels?.teamDisplayName ?? fallbackLabel("Team", recipientRef),
+				change: change.change,
+			};
+		}),
+		deviceAccessChanges: delta.deviceAccessChanges.map((change) => {
+			const canonicalProjectRef = legacyTeamCanonicalProjectRef(
 				candidateRef,
 				change.canonicalProjectIdentity,
-			),
-			deviceRef: legacyTeamDeviceRef(candidateRef, change.deviceId),
-			change: change.change,
-		})),
+			);
+			const deviceRef = legacyTeamDeviceRef(candidateRef, change.deviceId);
+			return {
+				canonicalProjectRef,
+				canonicalProjectDisplayName:
+					projectsByCanonicalRef.get(canonicalProjectRef)?.displayName ??
+					fallbackLabel("Project", canonicalProjectRef),
+				deviceRef,
+				deviceDisplayName:
+					devicesByRef.get(deviceRef)?.displayName ?? fallbackLabel("Device", deviceRef),
+				change: change.change,
+			};
+		}),
 	};
+}
+
+function viewerAccessDeltaDigest(delta: LegacyTeamSetupViewerAccessDeltaV1): string {
+	return recipientPolicyDigest("legacy-team-viewer-access-delta-v1", delta);
 }
 
 function requireBoundedAccessDelta(delta: LegacyTeamSetupAccessDeltaV1): void {
@@ -517,26 +624,24 @@ function disambiguateChoiceLabels<T extends { displayName: string }>(
 		const ref = choiceRef(choice);
 		let suffixLength = Math.min(6, ref.length);
 		let suffix = ref.slice(-suffixLength);
-		let displayName = "";
-		let finalComparable = "";
-		while (true) {
+		const maxAttempts = ref.length + originalLabels.size + usedLabels.size + 2;
+		for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
 			const baseLength = Math.max(0, 119 - suffix.length);
 			const base = choice.displayName.slice(0, baseLength).trimEnd();
-			displayName = base ? `${base} ${suffix}` : suffix.slice(-120);
-			finalComparable = normalizeChoiceLabelText(displayName).toLowerCase();
-			if (!usedLabels.has(finalComparable) && !originalLabels.has(finalComparable)) break;
+			const displayName = base ? `${base} ${suffix}` : suffix.slice(-120);
+			const finalComparable = normalizeChoiceLabelText(displayName).toLowerCase();
+			if (!usedLabels.has(finalComparable) && !originalLabels.has(finalComparable)) {
+				usedLabels.add(finalComparable);
+				return { ...choice, displayName };
+			}
 			if (suffixLength < ref.length) {
 				suffixLength = Math.min(ref.length, suffixLength + 2);
 				suffix = ref.slice(-suffixLength);
 				continue;
 			}
-			suffix = `${ref.slice(-Math.min(100, ref.length))}-${index + 1}`;
+			suffix = `${ref.slice(-Math.min(96, ref.length))}-${index + 1}-${attempt + 1}`;
 		}
-		usedLabels.add(finalComparable);
-		return {
-			...choice,
-			displayName,
-		};
+		throw new Error("legacy_team_setup_roster_too_large");
 	});
 }
 
@@ -984,13 +1089,18 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				} satisfies LegacyTeamSetupDetailResponseV1;
 				return c.json(response);
 			}
+			const accessDelta = viewerSafeAccessDelta(candidateRef, preview.accessDelta, {
+				teamDisplayName: viewDraft.displayName,
+				...safeDraft,
+			});
 			const response = {
 				...responseBase,
 				canFinish: true,
 				conflictState: null,
 				finishDigest: preview.finishDigest,
 				accessDeltaDigest: preview.accessDeltaDigest,
-				accessDelta: viewerSafeAccessDelta(candidateRef, preview.accessDelta),
+				viewerAccessDeltaDigest: viewerAccessDeltaDigest(accessDelta),
+				accessDelta,
 			} satisfies LegacyTeamSetupDetailResponseV1;
 			return c.json(response);
 		} catch (error) {
@@ -1256,7 +1366,12 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		if (!parsed.ok) {
 			return c.json({ error: "team_setup_incomplete" as const }, 400);
 		}
-		const finishKeys = ["attemptId", "confirmedAccessDeltaDigest", "finishDigest"] as const;
+		const finishKeys = [
+			"attemptId",
+			"confirmedAccessDeltaDigest",
+			"confirmedViewerAccessDeltaDigest",
+			"finishDigest",
+		] as const;
 		if (!hasExactKeys(parsed.value, finishKeys)) {
 			return Object.keys(parsed.value).every((key) =>
 				finishKeys.includes(key as (typeof finishKeys)[number]),
@@ -1264,14 +1379,21 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				? c.json({ error: "team_setup_confirmation_stale" as const }, 409)
 				: c.json({ error: "team_setup_incomplete" as const }, 400);
 		}
-		const { attemptId, confirmedAccessDeltaDigest, finishDigest } = parsed.value;
+		const {
+			attemptId,
+			confirmedAccessDeltaDigest,
+			confirmedViewerAccessDeltaDigest,
+			finishDigest,
+		} = parsed.value;
 		if (
 			typeof attemptId !== "string" ||
 			!ATTEMPT_ID_PATTERN.test(attemptId) ||
 			typeof finishDigest !== "string" ||
 			!FINISH_DIGEST_PATTERN.test(finishDigest) ||
 			typeof confirmedAccessDeltaDigest !== "string" ||
-			!ACCESS_DELTA_DIGEST_PATTERN.test(confirmedAccessDeltaDigest)
+			!ACCESS_DELTA_DIGEST_PATTERN.test(confirmedAccessDeltaDigest) ||
+			typeof confirmedViewerAccessDeltaDigest !== "string" ||
+			!VIEWER_ACCESS_DELTA_DIGEST_PATTERN.test(confirmedViewerAccessDeltaDigest)
 		) {
 			return c.json({ error: "team_setup_incomplete" as const }, 400);
 		}
@@ -1279,6 +1401,26 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			const store = options.getStore();
 			const draft = getLegacyTeamSetupDraft(store.db, candidateRef);
 			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			if (draft.attemptId !== attemptId) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			if (draft.state !== "completed") {
+				const preview = previewLegacyTeamSetupActivation(store.db, {
+					candidateRef,
+					attemptId: draft.attemptId,
+				});
+				requireBoundedAccessDelta(preview.accessDelta);
+				const safeDraft = viewerSafeDraft(store, draft);
+				const currentViewerDigest = viewerAccessDeltaDigest(
+					viewerSafeAccessDelta(candidateRef, preview.accessDelta, {
+						teamDisplayName: draft.displayName,
+						...safeDraft,
+					}),
+				);
+				if (currentViewerDigest !== confirmedViewerAccessDeltaDigest) {
+					return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+				}
+			}
 			const result = await finishLegacyTeamSetupActivation(store.db, {
 				candidateRef,
 				attemptId,
@@ -1294,6 +1436,20 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				},
 				loadProjectInventory: () =>
 					legacyTeamCandidateProjectInventory(store.db, projectionOptions(store), candidateRef),
+				validateLockedPreview: (lockedPreview) => {
+					requireBoundedAccessDelta(lockedPreview.accessDelta);
+					const lockedDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
+					if (!lockedDraft || lockedDraft.attemptId !== attemptId) return false;
+					const safeDraft = viewerSafeDraft(store, lockedDraft);
+					return (
+						viewerAccessDeltaDigest(
+							viewerSafeAccessDelta(candidateRef, lockedPreview.accessDelta, {
+								teamDisplayName: lockedDraft.displayName,
+								...safeDraft,
+							}),
+						) === confirmedViewerAccessDeltaDigest
+					);
+				},
 			});
 			return c.json(finishResponse(candidateRef, result));
 		} catch (error) {


### PR DESCRIPTION
## Description

Add the complete server-derived Team setup review and finish flow. Review renders every access-delta entry, binds confirmation to exact viewer evidence, fails closed on stale state, handles idempotent completion, and refreshes Sharing and Projects with truthful recovery status.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validated at the stack tip with 215 test files and 5,279 passing tests, plus `pnpm --filter @codemem/ui build` and `git diff --check`. CodeReviewer and Gordon review passes both reported clean.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced