### PR TITLE
fix(ui): clarify legacy Team setup flow

### DIFF
--- a/docs/plans/2026-08-26-legacy-team-setup-ux-hotfix-design.md
+++ b/docs/plans/2026-08-26-legacy-team-setup-ux-hotfix-design.md
@@ -1,0 +1,75 @@
+# Legacy Team setup UX hotfix design
+
+## Context
+
+The `0.43.0` legacy Team setup flow preserves access safety, but dogfooding exposed two usability failures for a valid large migration:
+
+- a Team with 63 automatically mapped Projects skips directly from Devices to Review;
+- six included devices produce 509 exact changes, including a 63-by-6 device-access cross-product that is technically correct but not reviewable as a flat list.
+
+The same pass exposed overlapping numbered step labels and excessive spacing in the Team setup candidate list. Multiple distinct legacy groups can also share the fallback label `Legacy Team`, making their actions difficult to distinguish.
+
+## Goals
+
+- Make automatic Project inclusion explicit without changing which Projects migrate.
+- Keep the exact server-confirmed access delta available while presenting a useful summary first.
+- Safely group repeated human-readable labels without exposing coordinator, group, device, or canonical Project identifiers.
+- Repair the wizard stepper and Team setup candidate layout across supported widths.
+- Preserve server-authoritative refresh, confirmation digests, atomic activation, and fail-closed behavior.
+
+## Non-goals
+
+- Add Project inclusion or exclusion controls.
+- Change device decisions, Team membership, recipient policy, or activation semantics.
+- Recompute or replace the server-provided access delta in the browser.
+- Expose opaque identifiers to disambiguate repeated labels.
+
+## Design
+
+### Wizard progression
+
+An unfinished setup visits Devices, Projects, then Review even when all Project mappings are deterministic. The Projects step explains that all mapped Projects will be included and shows resolved and unresolved totals. Deterministic rows remain read-only; only unresolved mappings expose controls.
+
+The stepper uses explicit number elements inside equal-width step items rather than native ordered-list markers. Desktop layouts retain three columns. Narrow layouts stack without marker overlap and preserve logical keyboard and reading order.
+
+### Team setup candidate list
+
+Candidate entries use compact rows with three aligned areas: Team label, status, and action. Native bullets are removed. Narrow layouts stack the status and action beneath the label.
+
+When multiple candidates have the same normalized display label, the overview groups them under one label and reports the count. Each underlying candidate keeps its own setup action and opaque candidate reference, but visible action labels include a safe ordinal such as `Continue setup for Legacy Team 1 of 2`. No coordinator or group identifier is rendered.
+
+### Review summary
+
+The Review step leads with the effective result rather than the raw mutation count:
+
+- Team policy and membership totals;
+- number of Projects included;
+- number of included devices;
+- number of resulting device-access changes.
+
+Repeated labels are grouped with counts, for example `greenroom — 34 Project identities`. Project mapping, recipient, and device-access sections show grouped summaries by default. Native `details` and `summary` disclosures expose the exact server-provided rows for users who need the full audit trail.
+
+The confirmation checkbox continues to bind to the attempt, finish, access-delta, and viewer-access-delta digests. Expanding or collapsing details does not alter evidence or the finish request.
+
+## Accessibility
+
+- Step labels retain ordered semantics and expose the current step.
+- Candidate actions remain real buttons with unique accessible names.
+- Summary disclosures use native keyboard-accessible elements.
+- Counts and grouping do not rely on color.
+- Focus movement and live-region behavior remain unchanged.
+
+## Validation
+
+- Add failing component tests for automatic Project progression, duplicate candidate labels, stepper hooks, and responsive candidate-row structure.
+- Add review tests modeling 63 Projects, six devices, repeated labels, 509 exact changes, grouped summaries, and expandable exact details.
+- Assert that confirmation evidence and the finish request remain unchanged.
+- Run targeted Vitest files, TypeScript, lint, the full workspace test suite, UI build, and legacy Team migration E2E.
+
+## Delivery
+
+1. `codemem-r4lc.1`: wizard progression, candidate layout, and stepper fixes.
+2. `codemem-r4lc.2`: grouped review summary and exact-detail disclosures.
+3. `codemem-r4lc.3`: focused `0.43.1` release preparation after both fixes merge.
+
+Tagging and public publication remain separately approval-gated.

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -109,7 +109,7 @@ function detail({
 			displayName: "Example Team",
 			status: "in_progress" as const,
 			deviceCount: devices?.length ?? 3,
-			projectCount: projects?.length ?? 2,
+			projectCount: projects?.length ?? 0,
 			unresolvedDeviceCount,
 			unresolvedProjectCount,
 		},
@@ -270,6 +270,129 @@ describe("legacy Team setup dialog", () => {
 		expect(document.body.textContent).toContain(
 			"Finish the Project mappings before reviewing access.",
 		);
+	});
+
+	it("moves to Projects after the final device decision when deterministic Projects remain", async () => {
+		// Arrange
+		const deterministicProject = project({
+			canonicalProjectRef: "opaque-canonical-project",
+			mappingChoices: [],
+			resolution: "deterministic",
+			resolvedProjectRef: "opaque-resolved-project",
+		});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(
+				detail({ devices: [device()], identityChoices: identities, unresolvedDeviceCount: 1 }),
+			)
+			.mockResolvedValueOnce(
+				detail({
+					devices: [device({ decision: "excluded", suggestedIdentityRef: null })],
+					projects: [deterministicProject],
+					unresolvedProjectCount: 0,
+				}),
+			);
+		setup({ loadDetail, saveDecision: vi.fn().mockResolvedValue(mutationResult()) });
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Work laptop"));
+
+		// Act
+		act(() => button("Exclude").click());
+
+		// Assert
+		await vi.waitFor(() => {
+			expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Projects");
+		});
+		expect(document.body.textContent).toContain("Review Projects");
+		expect(document.body.textContent).not.toContain("Review and finish");
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+	});
+
+	it("renders explicit numbered step hooks with list and current-step semantics", async () => {
+		// Arrange
+		setup(vi.fn().mockResolvedValue(detail({ devices: [device()], unresolvedDeviceCount: 1 })));
+
+		// Act
+		const steps = await vi.waitFor(() => {
+			const match = document.querySelector<HTMLElement>(".legacy-team-setup-steps");
+			if (!match) throw new Error("ordered Team setup steps missing");
+			return match;
+		});
+
+		// Assert
+		expect(steps.getAttribute("aria-label")).toBe("Team setup steps");
+		expect(steps.getAttribute("role")).toBe("list");
+		const items = [...steps.children];
+		expect(items).toHaveLength(3);
+		expect(items.every((item) => item.classList.contains("legacy-team-setup-step"))).toBe(true);
+		expect(items.every((item) => item.getAttribute("role") === "listitem")).toBe(true);
+		expect(
+			items.map((item) =>
+				item.querySelector(".legacy-team-setup-step-number")?.textContent?.trim(),
+			),
+		).toEqual(["1", "2", "3"]);
+		expect(steps.querySelectorAll('button[aria-current="step"]')).toHaveLength(1);
+		expect(steps.querySelector('button[aria-current="step"]')?.textContent).toContain("Devices");
+		expect(
+			[...steps.querySelectorAll<HTMLButtonElement>("button")].map((step) =>
+				step.getAttribute("aria-label"),
+			),
+		).toEqual(["Step 1: Devices", "Step 2: Projects", "Step 3: Review"]);
+	});
+
+	it("opens an unfinished ready draft on Projects before Review", async () => {
+		const deterministicProject = project({
+			canonicalProjectRef: "opaque-canonical-project",
+			mappingChoices: [],
+			resolution: "deterministic",
+			resolvedProjectRef: "opaque-resolved-project",
+		});
+		setup(
+			vi.fn().mockResolvedValue(
+				detail({
+					canFinish: true,
+					projects: [deterministicProject],
+					unresolvedDeviceCount: 0,
+					unresolvedProjectCount: 0,
+				}),
+			),
+		);
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Projects");
+		});
+		expect(document.body.textContent).toContain("Review Projects");
+		expect(document.body.textContent).not.toContain("Review and finish");
+		act(() => button("Continue to Review").click());
+		expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Review");
+		expect(document.body.textContent).toContain("Review and finish");
+	});
+
+	it("returns a ready draft to Projects when the dialog is reopened", async () => {
+		const readyDetail = detail({
+			canFinish: true,
+			projects: [
+				project({
+					mappingChoices: [],
+					resolution: "deterministic",
+					resolvedProjectRef: "opaque-resolved-project",
+				}),
+			],
+		});
+		const loadDetail = vi.fn().mockResolvedValue(readyDetail);
+		setup({ loadDetail });
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		act(() => button("Continue to Review").click());
+		expect(document.body.textContent).toContain("Review and finish");
+		act(() => button("Close").click());
+		act(() => {
+			openLegacyTeamSetup("opaque-candidate");
+		});
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Projects");
+		});
+		expect(loadDetail).toHaveBeenCalledTimes(2);
 	});
 
 	it("treats incomplete setup as normal progress rather than changed state", async () => {
@@ -1025,6 +1148,50 @@ describe("legacy Team setup dialog", () => {
 		expect(document.querySelectorAll(".legacy-team-project-select")).toHaveLength(1);
 	});
 
+	it("states that every automatically mapped Project will be included", async () => {
+		// Arrange
+		const deterministic = project({
+			canonicalProjectRef: "opaque-canonical-project",
+			mappingChoices: [],
+			resolution: "deterministic",
+			resolvedProjectRef: "opaque-resolved-project",
+		});
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(
+				detail({
+					projects: [
+						deterministic,
+						project({ projectRef: "project-ref-two", displayName: "Needs mapping" }),
+					],
+					unresolvedProjectCount: 1,
+				}),
+			),
+		});
+
+		// Act
+		const projectsStep = await vi.waitFor(() => {
+			const match = document.querySelector<HTMLElement>(
+				'[aria-labelledby="legacy-team-setup-step-projects"]',
+			);
+			if (!match) throw new Error("Projects step missing");
+			return match;
+		});
+
+		// Assert
+		expect(projectsStep.textContent).toContain(
+			"Automatically mapped Projects are part of this draft and appear in the final access review before activation.",
+		);
+		expect(projectsStep.textContent).toContain(
+			"1 automatic mapping was resolved from server evidence and is listed below for review.",
+		);
+		expect(projectsStep.textContent).not.toMatch(/confirm the automatic/i);
+		expect(projectsStep.textContent).not.toContain("1 of 0 Team Projects");
+		expect(projectsStep.textContent).not.toMatch(
+			/choose (?:or|and) exclude automatically mapped Projects/i,
+		);
+		expect(projectsStep.querySelectorAll(".legacy-team-project-select")).toHaveLength(1);
+	});
+
 	it("persists one explicit Project mapping and advances after authoritative reload", async () => {
 		const initialProject = project();
 		const mappedProject = project({
@@ -1250,7 +1417,9 @@ describe("legacy Team setup dialog", () => {
 		);
 		setup({ loadDetail });
 
-		await vi.waitFor(() => expect(document.body.textContent).toContain("Review every"));
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		act(() => button("Review").click());
+		expect(document.body.textContent).toContain("Review every");
 		const text = document.body.textContent ?? "";
 		expect(text).toContain(
 			"Update Example Team: change device access from all devices assigned to each person to the reviewed device list.",
@@ -1506,6 +1675,43 @@ describe("legacy Team setup dialog", () => {
 		expect(refreshCandidate).toHaveBeenCalledWith("opaque-candidate");
 		expect(loadDetail).toHaveBeenCalledTimes(2);
 		expect(document.querySelector('[role="alert"]')).toBeNull();
+	});
+
+	it("shows Projects again when refresh returns a new setup attempt", async () => {
+		const refreshCandidate = vi.fn().mockResolvedValue(undefined);
+		const oldProject = project({
+			displayName: "Old automatic Project",
+			resolution: "deterministic",
+		});
+		const newProject = project({
+			displayName: "New automatic Project",
+			projectRef: "new-project-ref",
+			resolution: "deterministic",
+		});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(
+				detail({
+					attemptId: "old-attempt",
+					draftState: "stale",
+					projects: [oldProject],
+				}),
+			)
+			.mockResolvedValueOnce(
+				detail({
+					attemptId: "new-attempt",
+					canFinish: true,
+					projects: [newProject],
+				}),
+			);
+		setup({ loadDetail, refreshCandidate });
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Old automatic Project"));
+		act(() => button("Refresh Team setup").click());
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("New automatic Project"));
+		expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Projects");
+		expect(document.body.textContent).not.toContain("Review and finish");
 	});
 
 	it("reports a refresh failure as a refresh failure without private details", async () => {

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
@@ -8,6 +8,10 @@ import { LegacyTeamSetupProjects } from "./legacy-team-setup-projects";
 import { LegacyTeamSetupReview } from "./legacy-team-setup-review";
 
 type TeamSetupStep = "devices" | "projects" | "review" | "completed";
+
+// Safari/VoiceOver can drop list semantics when CSS removes native markers.
+const EXPLICIT_LIST_ROLE = { role: "list" } as const;
+const EXPLICIT_LIST_ITEM_ROLE = { role: "listitem" } as const;
 const CHANGED_STATE_ERROR =
 	"Team setup changed since it was last reviewed. Reload the latest details to continue.";
 const SAVED_RELOAD_ERROR =
@@ -75,9 +79,13 @@ function canRestoreFocus(element: HTMLElement | null): element is HTMLElement {
 	return true;
 }
 
-function initialStep(detail: api.LegacyTeamSetupDetailResponseV1): TeamSetupStep {
+function initialStep(
+	detail: api.LegacyTeamSetupDetailResponseV1,
+	projectsVisited = false,
+): TeamSetupStep {
 	if (detail.draftState === "completed") return "completed";
 	if (detail.unresolvedDeviceCount > 0) return "devices";
+	if (!projectsVisited && detail.projects.length > 0) return "projects";
 	if (detail.unresolvedProjectCount > 0) return "projects";
 	return "review";
 }
@@ -193,6 +201,7 @@ function LegacyTeamSetupDialogHost({
 	const focusStepAfterRender = useRef(false);
 	const refreshBeforeLoad = useRef(false);
 	const retryNeedsRefresh = useRef(false);
+	const projectsVisitedAttemptId = useRef<string | null>(null);
 	const submitting = useRef(false);
 	const dialogGeneration = useRef(0);
 	const completedSurfaceRefresh = useRef<{
@@ -245,6 +254,7 @@ function LegacyTeamSetupDialogHost({
 			dialogGeneration.current += 1;
 			refreshBeforeLoad.current = false;
 			retryNeedsRefresh.current = false;
+			projectsVisitedAttemptId.current = null;
 			setCandidateRef(nextCandidateRef);
 			setDetail(null);
 			setError(null);
@@ -277,7 +287,12 @@ function LegacyTeamSetupDialogHost({
 				if (!current) return;
 				retryNeedsRefresh.current = detailNeedsRecovery(nextDetail);
 				setDetail(nextDetail);
-				setStep(initialStep(nextDetail));
+				const nextStep = initialStep(
+					nextDetail,
+					projectsVisitedAttemptId.current === nextDetail.attemptId,
+				);
+				if (nextStep === "projects") projectsVisitedAttemptId.current = nextDetail.attemptId;
+				setStep(nextStep);
 				setError(detailNeedsRecovery(nextDetail) ? CHANGED_STATE_ERROR : null);
 				setLoading(false);
 				if (nextDetail.draftState === "completed") {
@@ -336,6 +351,7 @@ function LegacyTeamSetupDialogHost({
 		focusStepAfterRender.current = false;
 		refreshBeforeLoad.current = false;
 		retryNeedsRefresh.current = false;
+		projectsVisitedAttemptId.current = null;
 		dialogGeneration.current += 1;
 		setCandidateRef(null);
 		setDetail(null);
@@ -347,6 +363,7 @@ function LegacyTeamSetupDialogHost({
 		setStep("devices");
 	};
 	const navigate = (nextStep: TeamSetupStep) => {
+		if (nextStep === "projects" && detail) projectsVisitedAttemptId.current = detail.attemptId;
 		if (nextStep === step) {
 			document.getElementById(`legacy-team-setup-step-${nextStep}`)?.focus();
 			return;
@@ -397,7 +414,8 @@ function LegacyTeamSetupDialogHost({
 				nextDetail.draftState !== "completed" &&
 				nextDetail.unresolvedDeviceCount > 0
 					? "devices"
-					: initialStep(nextDetail);
+					: initialStep(nextDetail, projectsVisitedAttemptId.current === nextDetail.attemptId);
+			if (nextStep === "projects") projectsVisitedAttemptId.current = nextDetail.attemptId;
 			if (nextStep !== current) focusStepAfterRender.current = true;
 			return nextStep;
 		});
@@ -672,9 +690,17 @@ function LegacyTeamSetupDialogHost({
 						<>
 							{step !== "completed" ? (
 								<>
-									<ol aria-label="Team setup steps" className="legacy-team-setup-steps">
-										<li>
+									<ol
+										{...EXPLICIT_LIST_ROLE}
+										aria-label="Team setup steps"
+										className="legacy-team-setup-steps"
+									>
+										<li {...EXPLICIT_LIST_ITEM_ROLE} className="legacy-team-setup-step">
+											<span aria-hidden="true" className="legacy-team-setup-step-number">
+												1
+											</span>
 											<button
+												aria-label="Step 1: Devices"
 												aria-current={step === "devices" ? "step" : undefined}
 												className="settings-button legacy-team-setup-target"
 												onClick={() => navigate("devices")}
@@ -683,8 +709,12 @@ function LegacyTeamSetupDialogHost({
 												Devices
 											</button>
 										</li>
-										<li>
+										<li {...EXPLICIT_LIST_ITEM_ROLE} className="legacy-team-setup-step">
+											<span aria-hidden="true" className="legacy-team-setup-step-number">
+												2
+											</span>
 											<button
+												aria-label="Step 2: Projects"
 												aria-current={step === "projects" ? "step" : undefined}
 												aria-describedby={
 													devicesBlockProgress ? "legacy-team-setup-block-devices" : undefined
@@ -704,8 +734,12 @@ function LegacyTeamSetupDialogHost({
 												Projects
 											</button>
 										</li>
-										<li>
+										<li {...EXPLICIT_LIST_ITEM_ROLE} className="legacy-team-setup-step">
+											<span aria-hidden="true" className="legacy-team-setup-step-number">
+												3
+											</span>
 											<button
+												aria-label="Step 3: Review"
 												aria-current={step === "review" ? "step" : undefined}
 												aria-describedby={
 													devicesBlockProgress
@@ -794,6 +828,7 @@ function LegacyTeamSetupDialogHost({
 									blockedDescriptionId={mutationBlockDescriptionId}
 									busyProjectRef={busyProjectRef}
 									detail={detail}
+									onContinue={() => navigate("review")}
 									onMap={mapProject}
 								/>
 							) : step === "review" && detail.canFinish ? (

--- a/packages/ui/src/tabs/legacy-team-setup-projects.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-projects.tsx
@@ -6,6 +6,7 @@ export interface LegacyTeamSetupProjectsProps {
 	blockedDescriptionId?: string;
 	busyProjectRef: string | null;
 	detail: LegacyTeamSetupDetailResponseV1;
+	onContinue: () => void;
 	onMap: (project: LegacyTeamSetupProjectV1, resolvedProjectRef: string) => void;
 }
 
@@ -108,15 +109,31 @@ function ProjectRow({
 }
 
 export function LegacyTeamSetupProjects(props: LegacyTeamSetupProjectsProps) {
+	const automaticallyMappedCount = props.detail.projects.filter(
+		(project) => project.resolution === "deterministic",
+	).length;
+	const projectCount = Math.max(
+		props.detail.candidate.projectCount,
+		props.detail.projects.length,
+		props.detail.unresolvedProjectCount,
+	);
 	return (
 		<section aria-labelledby="legacy-team-setup-step-projects">
 			<h3 id="legacy-team-setup-step-projects" tabIndex={-1}>
 				Review Projects
 			</h3>
 			<p>
-				{props.detail.unresolvedProjectCount.toLocaleString()} of{" "}
-				{props.detail.candidate.projectCount.toLocaleString()} Team Projects still need a mapping.
+				{props.detail.unresolvedProjectCount.toLocaleString()} of {projectCount.toLocaleString()}{" "}
+				Team Projects still need a mapping.
 			</p>
+			{automaticallyMappedCount > 0 ? (
+				<p className="small">
+					Automatically mapped Projects are part of this draft and appear in the final access review
+					before activation. The {automaticallyMappedCount.toLocaleString()} automatic{" "}
+					{automaticallyMappedCount === 1 ? "mapping was" : "mappings were"} resolved from server
+					evidence and {automaticallyMappedCount === 1 ? "is" : "are"} listed below for review.
+				</p>
+			) : null}
 			<div className="legacy-team-project-list">
 				{props.detail.projects.map((project, index) => (
 					<ProjectRow
@@ -130,6 +147,19 @@ export function LegacyTeamSetupProjects(props: LegacyTeamSetupProjectsProps) {
 					/>
 				))}
 			</div>
+			{props.detail.unresolvedProjectCount === 0 ? (
+				<button
+					aria-describedby={props.blocked ? props.blockedDescriptionId : undefined}
+					aria-disabled={props.blocked ? "true" : undefined}
+					className="settings-button legacy-team-setup-target"
+					onClick={() => {
+						if (!props.blocked) props.onContinue();
+					}}
+					type="button"
+				>
+					Continue to Review
+				</button>
+			) : null}
 		</section>
 	);
 }

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -608,6 +608,74 @@ describe("recipient-focused Sharing", () => {
 		expect(onOpenTeamSetup).toHaveBeenCalledWith("candidate-progress");
 	});
 
+	it("groups duplicate Team labels into compact rows with unique safe setup actions", () => {
+		// Arrange
+		const onOpenTeamSetup = vi.fn();
+		mount(intent(), {
+			onOpenTeamSetup,
+			teamSetupSummary: {
+				version: 1,
+				candidates: (
+					[
+						{
+							candidateRef: "opaque-candidate-one",
+							displayName: "Legacy Team",
+							status: "needs_setup",
+							deviceCount: 2,
+							projectCount: 3,
+							unresolvedDeviceCount: 1,
+							unresolvedProjectCount: 0,
+						},
+						{
+							candidateRef: "opaque-candidate-two",
+							displayName: "Legacy Team",
+							status: "in_progress",
+							deviceCount: 4,
+							projectCount: 5,
+							unresolvedDeviceCount: 0,
+							unresolvedProjectCount: 1,
+						},
+					] satisfies LegacyTeamSetupSummaryResponseV1["candidates"]
+				).reverse(),
+			},
+		});
+
+		// Act
+		const duplicateGroup = document.querySelector<HTMLElement>(
+			".recipient-policy-sharing-team-setup-group",
+		);
+		expect(
+			document.querySelector(".recipient-policy-sharing-team-setup-list")?.getAttribute("role"),
+		).toBe("list");
+		expect(duplicateGroup?.getAttribute("role")).toBe("listitem");
+		const rows = [
+			...(duplicateGroup?.querySelectorAll<HTMLElement>(
+				".recipient-policy-sharing-team-setup-row",
+			) ?? []),
+		];
+		const buttons = rows.flatMap((row) => [...row.querySelectorAll<HTMLButtonElement>("button")]);
+
+		// Assert
+		expect(duplicateGroup?.textContent).toContain("Legacy Team");
+		expect(duplicateGroup?.textContent).toContain("2 Teams");
+		expect(duplicateGroup?.textContent).toContain("2 devices, 3 Projects");
+		expect(duplicateGroup?.textContent).toContain("4 devices, 5 Projects");
+		expect(rows).toHaveLength(2);
+		for (const row of rows) {
+			expect(row.querySelector(".recipient-policy-sharing-team-setup-status")).not.toBeNull();
+			expect(row.querySelector(".recipient-policy-sharing-team-setup-action")).not.toBeNull();
+		}
+		expect(buttons.map((button) => button.getAttribute("aria-label"))).toEqual([
+			"Continue setup for Legacy Team 1 of 2: 2 devices, 3 Projects",
+			"Continue setup for Legacy Team 2 of 2: 4 devices, 5 Projects",
+		]);
+		expect(new Set(buttons.map((button) => button.getAttribute("aria-label"))).size).toBe(2);
+		expect(duplicateGroup?.textContent).not.toMatch(/opaque-candidate|coordinator|group[_ -]?id/i);
+
+		act(() => buttons[1]?.click());
+		expect(onOpenTeamSetup).toHaveBeenCalledWith("opaque-candidate-two");
+	});
+
 	it("shows Team setup unavailability without inventing candidates on first load", () => {
 		mount(intent(), { teamSetupUnavailable: true });
 

--- a/packages/ui/src/tabs/recipient-policy-sharing.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.tsx
@@ -45,6 +45,10 @@ const TEAM_SETUP_STATUS_CLASSES: Record<LegacyTeamSetupStatusV1, string> = {
 	ready: "",
 };
 
+// Safari/VoiceOver can drop list semantics when CSS removes native markers.
+const EXPLICIT_LIST_ROLE = { role: "list" } as const;
+const EXPLICIT_LIST_ITEM_ROLE = { role: "listitem" } as const;
+
 function teamSetupStatusLabel(status: unknown): string {
 	return typeof status === "string" && Object.hasOwn(TEAM_SETUP_STATUS_LABELS, status)
 		? TEAM_SETUP_STATUS_LABELS[status as LegacyTeamSetupStatusV1]
@@ -57,6 +61,29 @@ function teamSetupStatusClass(status: unknown): string {
 		: "needs_attention";
 }
 
+interface TeamSetupCandidateGroup {
+	displayName: string;
+	candidates: LegacyTeamSetupCandidateSummaryV1[];
+}
+
+function teamSetupCandidateGroups(
+	candidates: LegacyTeamSetupCandidateSummaryV1[],
+): TeamSetupCandidateGroup[] {
+	const groups = new Map<string, TeamSetupCandidateGroup>();
+	for (const candidate of candidates) {
+		const key = candidate.displayName.trim().toLowerCase();
+		const group = groups.get(key);
+		if (group) groups.set(key, { ...group, candidates: [...group.candidates, candidate] });
+		else groups.set(key, { displayName: candidate.displayName, candidates: [candidate] });
+	}
+	return [...groups.values()].map((group) => ({
+		...group,
+		candidates: [...group.candidates].sort((left, right) =>
+			left.candidateRef < right.candidateRef ? -1 : left.candidateRef > right.candidateRef ? 1 : 0,
+		),
+	}));
+}
+
 function TeamSetupOverview({
 	candidates,
 	onOpenTeamSetup,
@@ -66,6 +93,7 @@ function TeamSetupOverview({
 }) {
 	if (candidates.length === 0) return null;
 	const pending = candidates.filter((candidate) => candidate.status !== "ready");
+	const groups = teamSetupCandidateGroups(candidates);
 	return (
 		<aside
 			aria-labelledby="sharing-team-setup-heading"
@@ -79,25 +107,75 @@ function TeamSetupOverview({
 			{pending.length > 0 ? (
 				<p>Tell Codemem who uses each device before using these Teams for sharing.</p>
 			) : null}
-			<ul className="recipient-policy-sharing-details" aria-label="Team setup status">
-				{candidates.map((candidate) => (
-					<li key={candidate.candidateRef}>
-						<strong>{candidate.displayName}</strong> —{` `}
-						<span
-							className={`project-status-badge ${teamSetupStatusClass(candidate.status)}`.trim()}
-						>
-							{teamSetupStatusLabel(candidate.status)}
-						</span>
-						{candidate.status !== "ready" && onOpenTeamSetup ? (
-							<button
-								aria-label={`Continue setup for ${candidate.displayName}`}
-								className="settings-button recipient-policy-sharing-target-24"
-								onClick={() => onOpenTeamSetup(candidate.candidateRef)}
-								type="button"
-							>
-								Continue setup
-							</button>
+			<ul
+				{...EXPLICIT_LIST_ROLE}
+				className="recipient-policy-sharing-team-setup-list"
+				aria-label="Team setup status"
+			>
+				{groups.map((group) => (
+					<li
+						{...EXPLICIT_LIST_ITEM_ROLE}
+						className="recipient-policy-sharing-team-setup-group"
+						key={group.displayName}
+					>
+						{group.candidates.length > 1 ? (
+							<div className="recipient-policy-sharing-team-setup-group-title">
+								<strong>{group.displayName}</strong>
+								<span className="small">{group.candidates.length} Teams</span>
+							</div>
 						) : null}
+						<div className="recipient-policy-sharing-team-setup-rows">
+							{group.candidates.map((candidate, index) => {
+								const ordinal = `${index + 1} of ${group.candidates.length}`;
+								const safeSummary = `${countLabel(candidate.deviceCount, "device")}, ${countLabel(candidate.projectCount, "Project")}`;
+								const actionLabel =
+									group.candidates.length > 1
+										? `Continue setup for ${group.displayName} ${ordinal}: ${safeSummary}`
+										: `Continue setup for ${candidate.displayName}`;
+								return (
+									<div
+										className="recipient-policy-sharing-team-setup-row"
+										key={candidate.candidateRef}
+									>
+										<span className="recipient-policy-sharing-team-setup-label">
+											{group.candidates.length > 1 ? (
+												<span className="small">
+													Team {ordinal} · {safeSummary}
+												</span>
+											) : (
+												<strong>{candidate.displayName}</strong>
+											)}
+											<span
+												aria-hidden="true"
+												className="recipient-policy-sharing-team-setup-separator"
+											>
+												{" "}
+												—{" "}
+											</span>
+										</span>
+										<span className="recipient-policy-sharing-team-setup-status">
+											<span
+												className={`project-status-badge ${teamSetupStatusClass(candidate.status)}`.trim()}
+											>
+												{teamSetupStatusLabel(candidate.status)}
+											</span>
+										</span>
+										<span className="recipient-policy-sharing-team-setup-action">
+											{candidate.status !== "ready" && onOpenTeamSetup ? (
+												<button
+													aria-label={actionLabel}
+													className="settings-button recipient-policy-sharing-target-24"
+													onClick={() => onOpenTeamSetup(candidate.candidateRef)}
+													type="button"
+												>
+													Continue setup
+												</button>
+											) : null}
+										</span>
+									</div>
+								);
+							})}
+						</div>
 					</li>
 				))}
 			</ul>

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1209,9 +1209,22 @@
         grid-template-columns: repeat(3, minmax(0, 1fr));
         gap: var(--sp-2);
         margin: var(--sp-2) 0;
-        padding-left: var(--sp-5);
+        padding: 0;
+        list-style: none;
       }
-      .legacy-team-setup-steps button { width: 100%; }
+      .legacy-team-setup-step {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr);
+        align-items: center;
+        gap: var(--sp-2);
+        min-width: 0;
+      }
+      .legacy-team-setup-step-number {
+        color: var(--text-secondary);
+        font-weight: var(--font-weight-semibold);
+        font-variant-numeric: tabular-nums;
+      }
+      .legacy-team-setup-steps button { width: 100%; min-width: 0; }
       .legacy-team-setup-steps button[aria-current="step"] {
         border-color: var(--accent);
         background: var(--accent-subtle);
@@ -1436,6 +1449,32 @@
       }
       .recipient-policy-sharing-attention p { margin-top: var(--sp-2); }
       .recipient-policy-sharing-attention .settings-button { margin-top: var(--sp-3); }
+      .recipient-policy-sharing-team-setup-list {
+        display: grid;
+        gap: var(--sp-3);
+        margin: var(--sp-3) 0 0;
+        padding: 0;
+        list-style: none;
+      }
+      .recipient-policy-sharing-team-setup-group,
+      .recipient-policy-sharing-team-setup-rows { display: grid; gap: var(--sp-2); }
+      .recipient-policy-sharing-team-setup-group-title {
+        display: flex;
+        align-items: baseline;
+        gap: var(--sp-2);
+        min-width: 0;
+        overflow-wrap: anywhere;
+        flex-wrap: wrap;
+      }
+      .recipient-policy-sharing-team-setup-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto auto;
+        align-items: center;
+        gap: var(--sp-2);
+        min-width: 0;
+      }
+      .recipient-policy-sharing-team-setup-label { min-width: 0; overflow-wrap: anywhere; }
+      .recipient-policy-sharing-team-setup-action .settings-button { margin-top: 0; }
       .device-identity-setup-card fieldset,
       .device-identity-rebind fieldset {
         display: grid;
@@ -3716,6 +3755,9 @@
         .modal-card { padding: var(--sp-4); border-radius: var(--radius-lg); }
         .legacy-team-setup-dialog .modal-card { width: calc(100vw - 16px); }
         .legacy-team-setup-steps { grid-template-columns: 1fr; }
+        .recipient-policy-sharing-team-setup-row { grid-template-columns: 1fr auto; }
+        .recipient-policy-sharing-team-setup-label { grid-column: 1 / -1; }
+        .recipient-policy-sharing-team-setup-separator { display: none; }
       }
 
       /* ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Clarifies the legacy Team setup flow without changing migration or activation semantics.

- Routes every unfinished setup with Projects through the Projects step before Review, including reopened ready drafts.
- Adds an explicit Continue to Review action after deterministic Project mappings.
- Makes the three-step navigation responsive and preserves explicit list/list-item semantics for assistive technology.
- Groups duplicate visible Team labels into compact, stable rows with privacy-safe ordinal and count descriptors.
- Explains that automatic mappings are server evidence included in the draft and final access review.

This is the first PR in the `0.43.1` usability hotfix stack. A follow-up PR will aggregate the large server-confirmed access review while retaining exact changes in accessible disclosures.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation performed:

- `pnpm run check` — 215 test files passed; 5,304 tests passed and 3 remain todo.
- Targeted UI tests — 60 tests passed.
- `pnpm --filter @codemem/ui build` — production build passed.
- Legacy Team migration E2E — passed.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
