### PR TITLE
fix(ui): summarize legacy Team access review

### DIFF
--- a/docs/plans/2026-08-26-legacy-team-setup-ux-hotfix-design.md
+++ b/docs/plans/2026-08-26-legacy-team-setup-ux-hotfix-design.md
@@ -40,14 +40,15 @@ When multiple candidates have the same normalized display label, the overview gr
 
 ### Review summary
 
-The Review step leads with the effective result rather than the raw mutation count:
+The Review step reconciles the raw mutation count across the five exact change categories:
 
-- Team policy and membership totals;
-- number of Projects included;
-- number of included devices;
-- number of resulting device-access changes.
+- Team policy changes;
+- membership changes;
+- Project mapping changes;
+- recipient changes;
+- device-access changes.
 
-Repeated labels are grouped with counts, for example `greenroom — 34 Project identities`. Project mapping, recipient, and device-access sections show grouped summaries by default. Native `details` and `summary` disclosures expose the exact server-provided rows for users who need the full audit trail.
+Project and device inventory counts appear separately as migration scope. Repeated labels are grouped with counts, for example `greenroom — 34 Projects with this name, 34 Project changes`. When grouping reduces a large Project mapping, recipient, or device-access section, the grouped summary appears by default and native `details` and `summary` disclosures expose every exact server-provided row. Small sections and large sections whose labels cannot be usefully grouped keep their exact rows visible.
 
 The confirmation checkbox continues to bind to the attempt, finish, access-delta, and viewer-access-delta digests. Expanding or collapsing details does not alter evidence or the finish request.
 

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -1429,10 +1429,188 @@ describe("legacy Team setup dialog", () => {
 		expect(text).toContain("Add Example Team as a recipient for Legacy Project.");
 		expect(text).toContain("Add Work laptop access to Legacy Project.");
 		expect(text).toContain("Remove External laptop access from External Project.");
-		expect(text).toContain("6 access changes to review.");
+		expect(text).toContain("6 exact access changes to review.");
 		expect(text).not.toContain("opaque-team-ref");
 		expect(text).not.toContain("resolved-project-old");
-		expect(document.querySelectorAll(".legacy-team-setup-delta li")).toHaveLength(6);
+		expect(document.querySelectorAll(".legacy-team-setup-exact-list li")).toHaveLength(6);
+		expect(document.querySelectorAll(".legacy-team-setup-delta details")).toHaveLength(0);
+	});
+
+	it("summarizes a 63 Project by 6 device migration while preserving all 509 exact rows", async () => {
+		const devices = Array.from({ length: 6 }, (_, index) =>
+			device({
+				deviceRef: `internal-device-ref-${index + 1}`,
+				displayName: index < 2 ? "Work laptop" : `Device ${index + 1}`,
+				decision: "included",
+				existingIdentityRef: `internal-identity-ref-${index + 1}`,
+				suggestedIdentityRef: null,
+				targetIdentityRef: `internal-identity-ref-${index + 1}`,
+			}),
+		);
+		const projects = Array.from({ length: 63 }, (_, index) => {
+			const displayName = index < 34 ? "greenroom" : `Project ${index + 1}`;
+			return project({
+				projectRef: `internal-project-ref-${index + 1}`,
+				displayName,
+				resolution: "deterministic",
+				canonicalProjectRef: `internal-canonical-ref-${index + 1}`,
+				resolvedProjectRef: `internal-resolved-ref-${index + 1}`,
+				mappingChoices: [],
+			});
+		});
+		const accessDelta: LegacyTeamSetupAccessDeltaV1 = {
+			teamChanges: [
+				{
+					teamRef: "internal-team-ref",
+					teamDisplayName: "Example Team",
+					change: "update",
+					fromDeviceEligibilityMode: "person_all_devices",
+					toDeviceEligibilityMode: "reviewed_allowlist",
+				},
+			],
+			membershipChanges: Array.from({ length: 4 }, (_, index) => ({
+				teamRef: "internal-team-ref",
+				teamDisplayName: "Example Team",
+				identityRef: `internal-member-ref-${index + 1}`,
+				identityDisplayName: `Person ${index + 1}`,
+				change: "add" as const,
+			})),
+			projectChanges: projects.map((entry) => ({
+				projectRef: entry.projectRef,
+				projectDisplayName: entry.displayName,
+				fromResolvedProjectRef: null,
+				fromResolvedProjectDisplayName: null,
+				toResolvedProjectRef: entry.resolvedProjectRef,
+				toResolvedProjectDisplayName: entry.displayName,
+				change: "add" as const,
+			})),
+			recipientChanges: projects.map((entry) => ({
+				canonicalProjectRef: entry.canonicalProjectRef ?? "",
+				canonicalProjectDisplayName: entry.displayName,
+				recipientKind: "team" as const,
+				recipientRef: "internal-team-ref",
+				recipientDisplayName: "Example Team",
+				change: "add" as const,
+			})),
+			deviceAccessChanges: projects.flatMap((entry) =>
+				devices.map((entryDevice) => ({
+					canonicalProjectRef: entry.canonicalProjectRef ?? "",
+					canonicalProjectDisplayName: entry.displayName,
+					deviceRef: entryDevice.deviceRef,
+					deviceDisplayName: entryDevice.displayName,
+					change: "add" as const,
+				})),
+			),
+		};
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(
+				detail({
+					canFinish: true,
+					devices,
+					projects,
+					accessDelta,
+				}),
+			),
+		});
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		act(() => button("Review").click());
+		const review = document.querySelector<HTMLElement>(
+			'[aria-labelledby="legacy-team-setup-step-review"]',
+		);
+		if (!review) throw new Error("Review step missing");
+		const section = (title: string) => {
+			const heading = [...review.querySelectorAll("h4")].find(
+				(candidate) => candidate.textContent === title,
+			);
+			if (!(heading?.parentElement instanceof HTMLElement)) {
+				throw new Error(`${title} section missing`);
+			}
+			return heading.parentElement;
+		};
+
+		expect(review.textContent).toContain("509 exact access changes");
+		expect(review.textContent).toContain("1 Team policy change");
+		expect(review.textContent).toContain("4 membership changes");
+		expect(review.textContent).toContain("63 Project changes");
+		expect(review.textContent).toContain("63 recipient changes");
+		expect(review.textContent).toContain("63 Projects included");
+		expect(review.textContent).toContain("6 included devices");
+		expect(review.textContent).toContain("378 device-access changes");
+		expect(section("Projects").textContent).toContain(
+			"greenroom — 34 Projects with this name, 34 Project changes",
+		);
+		expect(section("Recipients").textContent).toContain(
+			"greenroom — 34 Projects with this name, 34 recipient changes",
+		);
+		expect(section("Device access").textContent).toContain(
+			"greenroom — 34 Projects with this name, 204 device-access changes",
+		);
+		expect(review.textContent).not.toContain("internal-");
+
+		const expectedExactRows = new Map([
+			["Team policy", 1],
+			["Memberships", 4],
+			["Projects", 63],
+			["Recipients", 63],
+			["Device access", 378],
+		]);
+		for (const [title, expectedCount] of expectedExactRows) {
+			expect(section(title).querySelectorAll(".legacy-team-setup-exact-list > li")).toHaveLength(
+				expectedCount,
+			);
+		}
+		expect(review.querySelectorAll(".legacy-team-setup-exact-list > li")).toHaveLength(509);
+		expect(
+			[...review.querySelectorAll("details > summary")].map((summary) => summary.textContent),
+		).toEqual([
+			"Show all 63 exact Project changes",
+			"Show all 63 exact recipient changes",
+			"Show all 378 exact device-access changes",
+		]);
+		expect(review.querySelectorAll("details")).toHaveLength(3);
+		expect([...review.querySelectorAll("details")].every((details) => !details.open)).toBe(true);
+		expect(
+			[...section("Projects").querySelectorAll(".legacy-team-setup-exact-list > li")].filter(
+				(row) => row.textContent === "Add greenroom: no Project to greenroom.",
+			),
+		).toHaveLength(34);
+		expect(
+			[...section("Device access").querySelectorAll(".legacy-team-setup-exact-list > li")].filter(
+				(row) => row.textContent === "Add Work laptop access to greenroom.",
+			),
+		).toHaveLength(68);
+	});
+
+	it("keeps a large exact section visible when its labels cannot be usefully grouped", async () => {
+		const accessDelta: LegacyTeamSetupAccessDeltaV1 = {
+			teamChanges: [],
+			membershipChanges: [],
+			projectChanges: Array.from({ length: 11 }, (_, index) => ({
+				projectRef: `opaque-project-${index}`,
+				projectDisplayName: `Project ${index + 1}`,
+				fromResolvedProjectRef: null,
+				fromResolvedProjectDisplayName: null,
+				toResolvedProjectRef: `opaque-resolved-project-${index}`,
+				toResolvedProjectDisplayName: `Project ${index + 1}`,
+				change: "add" as const,
+			})),
+			recipientChanges: [],
+			deviceAccessChanges: [],
+		};
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(detail({ canFinish: true, accessDelta })),
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("11 exact access changes"));
+
+		const heading = [...document.querySelectorAll(".legacy-team-setup-delta h4")].find(
+			(candidate) => candidate.textContent === "Projects",
+		);
+		const projects = heading?.parentElement;
+		if (!projects) throw new Error("Projects section missing");
+		expect(projects.querySelector("details")).toBeNull();
+		expect(projects.querySelector(".legacy-team-setup-delta-summary")).toBeNull();
+		expect(projects.querySelectorAll(".legacy-team-setup-exact-list > li")).toHaveLength(11);
 	});
 
 	it("requires explicit confirmation and submits exact displayed finish evidence once", async () => {
@@ -1446,9 +1624,24 @@ describe("legacy Team setup dialog", () => {
 		}>();
 		const finish = vi.fn().mockReturnValue(pendingFinish.promise);
 		const onCompleted = vi.fn();
+		const accessDelta: LegacyTeamSetupAccessDeltaV1 = {
+			teamChanges: [],
+			membershipChanges: [],
+			projectChanges: Array.from({ length: 11 }, (_, index) => ({
+				projectRef: "opaque-project-ref",
+				projectDisplayName: "Legacy Project",
+				fromResolvedProjectRef: null,
+				fromResolvedProjectDisplayName: null,
+				toResolvedProjectRef: "opaque-resolved-project-ref",
+				toResolvedProjectDisplayName: "Canonical Project",
+				change: index % 2 === 0 ? ("add" as const) : ("remove" as const),
+			})),
+			recipientChanges: [],
+			deviceAccessChanges: [],
+		};
 		setup({
 			finish,
-			loadDetail: vi.fn().mockResolvedValue(detail({ canFinish: true })),
+			loadDetail: vi.fn().mockResolvedValue(detail({ canFinish: true, accessDelta })),
 			onCompleted,
 		});
 		await vi.waitFor(() => expect(document.body.textContent).toContain("Finish Team setup"));
@@ -1457,6 +1650,13 @@ describe("legacy Team setup dialog", () => {
 		expect(finishButton.getAttribute("aria-disabled")).toBe("true");
 		act(() => finishButton.click());
 		expect(finish).not.toHaveBeenCalled();
+		const summaries = [...document.querySelectorAll<HTMLElement>("details > summary")];
+		expect(summaries).toHaveLength(1);
+		expect(document.body.textContent).toContain(
+			"Legacy Project — 1 Project with this name, 11 Project changes",
+		);
+		for (const summary of summaries) act(() => summary.click());
+		expect(finishButton.getAttribute("aria-disabled")).toBe("true");
 		const confirmation = document.querySelector<HTMLInputElement>(
 			".legacy-team-setup-confirmation input",
 		);
@@ -1465,6 +1665,12 @@ describe("legacy Team setup dialog", () => {
 		act(() => {
 			confirmation.dispatchEvent(new Event("change", { bubbles: true }));
 		});
+		for (const summary of summaries) {
+			act(() => summary.click());
+			act(() => summary.click());
+		}
+		expect(confirmation.checked).toBe(true);
+		expect(finishButton.getAttribute("aria-disabled")).toBeNull();
 		act(() => {
 			finishButton.click();
 			finishButton.click();
@@ -1476,6 +1682,10 @@ describe("legacy Team setup dialog", () => {
 			confirmedAccessDeltaDigest: "opaque-access-digest",
 			confirmedViewerAccessDeltaDigest: "opaque-viewer-access-digest",
 		});
+		expect(confirmation.getAttribute("aria-disabled")).toBe("true");
+		expect(confirmation.getAttribute("aria-describedby")).toBeTruthy();
+		act(() => confirmation.click());
+		expect(confirmation.checked).toBe(true);
 
 		pendingFinish.resolve({
 			version: 1,

--- a/packages/ui/src/tabs/legacy-team-setup-review.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-review.tsx
@@ -11,21 +11,98 @@ export interface LegacyTeamSetupReviewProps {
 }
 
 const CHANGE_VERBS = { add: "Add", update: "Update", remove: "Remove" } as const;
+const EXACT_DISCLOSURE_THRESHOLD = 10;
 
-function DeltaSection({ empty, items, title }: { empty: string; items: string[]; title: string }) {
+function countLabel(count: number, singular: string, plural = `${singular}s`): string {
+	return `${count.toLocaleString()} ${count === 1 ? singular : plural}`;
+}
+
+interface ProjectIdentityGroup {
+	displayName: string;
+	projectRefs: Set<string>;
+	changeCount: number;
+}
+
+function groupProjectIdentities<T>(
+	items: T[],
+	displayName: (item: T) => string,
+	projectRef: (item: T) => string,
+): ProjectIdentityGroup[] {
+	const groups = new Map<string, ProjectIdentityGroup>();
+	for (const item of items) {
+		const name = displayName(item);
+		const key = name.trim().toLowerCase();
+		const ref = projectRef(item);
+		const group = groups.get(key) ?? {
+			displayName: name,
+			projectRefs: new Set<string>(),
+			changeCount: 0,
+		};
+		group.projectRefs.add(ref);
+		group.changeCount += 1;
+		groups.set(key, group);
+	}
+	return [...groups.values()];
+}
+
+function projectGroupSummary(group: ProjectIdentityGroup): string {
+	return `${group.displayName} — ${countLabel(
+		group.projectRefs.size,
+		"Project with this name",
+		"Projects with this name",
+	)}`;
+}
+
+function DeltaSection({
+	empty,
+	exactItemName,
+	exactItems,
+	summaryItems,
+	title,
+}: {
+	empty: string;
+	exactItemName: string;
+	exactItems: string[];
+	summaryItems?: string[];
+	title: string;
+}) {
+	const hasUsefulSummary = Boolean(summaryItems && summaryItems.length < exactItems.length);
+	const collapsed = hasUsefulSummary && exactItems.length > EXACT_DISCLOSURE_THRESHOLD;
 	return (
 		<section>
 			<h4>{title}</h4>
-			{items.length > 0 ? (
-				<ul>
-					{items.map((item, index) => (
-						<li key={`${title}-${index}`}>{item}</li>
-					))}
-				</ul>
+			{exactItems.length > 0 ? (
+				<>
+					{hasUsefulSummary && summaryItems ? (
+						<ul className="legacy-team-setup-delta-summary">
+							{summaryItems.map((item, index) => (
+								<li key={`${title}-summary-${index}`}>{item}</li>
+							))}
+						</ul>
+					) : null}
+					{collapsed ? (
+						<details>
+							<summary>Show all {countLabel(exactItems.length, `exact ${exactItemName}`)}</summary>
+							<ExactDeltaList items={exactItems} title={title} />
+						</details>
+					) : (
+						<ExactDeltaList items={exactItems} title={title} />
+					)}
+				</>
 			) : (
 				<p className="small">{empty}</p>
 			)}
 		</section>
+	);
+}
+
+function ExactDeltaList({ items, title }: { items: string[]; title: string }) {
+	return (
+		<ul className="legacy-team-setup-exact-list">
+			{items.map((item, index) => (
+				<li key={`${title}-${index}`}>{item}</li>
+			))}
+		</ul>
 	);
 }
 
@@ -36,7 +113,12 @@ export function LegacyTeamSetupReview({
 	onFinish,
 }: LegacyTeamSetupReviewProps) {
 	const delta = detail.accessDelta;
-	const evidenceKey = `${detail.attemptId}:${detail.finishDigest}:${detail.accessDeltaDigest}:${detail.viewerAccessDeltaDigest}`;
+	const evidenceKey = JSON.stringify([
+		detail.attemptId,
+		detail.finishDigest,
+		detail.accessDeltaDigest,
+		detail.viewerAccessDeltaDigest,
+	]);
 	const [confirmedEvidenceKey, setConfirmedEvidenceKey] = useState<string | null>(null);
 	const confirmed = confirmedEvidenceKey === evidenceKey;
 	const finishBlocked = blocked || !confirmed;
@@ -80,11 +162,40 @@ export function LegacyTeamSetupReview({
 			} ${change.canonicalProjectDisplayName}.`,
 	);
 	const accessChangeCount =
-		teamItems.length +
-		membershipItems.length +
-		projectItems.length +
-		recipientItems.length +
-		deviceItems.length;
+		delta.teamChanges.length +
+		delta.membershipChanges.length +
+		delta.projectChanges.length +
+		delta.recipientChanges.length +
+		delta.deviceAccessChanges.length;
+	const projectGroups = groupProjectIdentities(
+		delta.projectChanges,
+		(change) => change.projectDisplayName,
+		(change) => change.projectRef,
+	);
+	const recipientGroups = groupProjectIdentities(
+		delta.recipientChanges,
+		(change) => change.canonicalProjectDisplayName,
+		(change) => change.canonicalProjectRef,
+	);
+	const deviceAccessGroups = groupProjectIdentities(
+		delta.deviceAccessChanges,
+		(change) => change.canonicalProjectDisplayName,
+		(change) => change.canonicalProjectRef,
+	);
+	const includedDeviceCount = detail.devices.filter(
+		(device) => device.decision === "included",
+	).length;
+	const changeSummary = [
+		countLabel(delta.teamChanges.length, "Team policy change"),
+		countLabel(delta.membershipChanges.length, "membership change"),
+		countLabel(delta.projectChanges.length, "Project change"),
+		countLabel(delta.recipientChanges.length, "recipient change"),
+		countLabel(delta.deviceAccessChanges.length, "device-access change"),
+	];
+	const scopeSummary = `${countLabel(detail.projects.length, "Project")} included; ${countLabel(
+		includedDeviceCount,
+		"included device",
+	)}.`;
 
 	return (
 		<section aria-labelledby="legacy-team-setup-step-review">
@@ -92,23 +203,75 @@ export function LegacyTeamSetupReview({
 				Review and finish
 			</h3>
 			<p>Review every server-confirmed access change before activating this Team.</p>
-			<p className="small">
-				{accessChangeCount} access {accessChangeCount === 1 ? "change" : "changes"} to review.
-			</p>
+			<section aria-label="Access review summary" className="legacy-team-setup-review-summary">
+				<p>
+					<strong>{countLabel(accessChangeCount, "exact access change")}</strong> to review.
+				</p>
+				<ul>
+					{changeSummary.map((item) => (
+						<li key={item}>{item}</li>
+					))}
+				</ul>
+				<p className="small">Scope: {scopeSummary}</p>
+			</section>
 			<div className="legacy-team-setup-delta">
-				<DeltaSection empty="No Team policy changes." items={teamItems} title="Team policy" />
-				<DeltaSection empty="No membership changes." items={membershipItems} title="Memberships" />
-				<DeltaSection empty="No Project mapping changes." items={projectItems} title="Projects" />
-				<DeltaSection empty="No recipient changes." items={recipientItems} title="Recipients" />
-				<DeltaSection empty="No device access changes." items={deviceItems} title="Device access" />
+				<DeltaSection
+					empty="No Team policy changes."
+					exactItemName="Team policy change"
+					exactItems={teamItems}
+					title="Team policy"
+				/>
+				<DeltaSection
+					empty="No membership changes."
+					exactItemName="membership change"
+					exactItems={membershipItems}
+					title="Memberships"
+				/>
+				<DeltaSection
+					empty="No Project mapping changes."
+					exactItemName="Project change"
+					exactItems={projectItems}
+					summaryItems={projectGroups.map(
+						(group) =>
+							`${projectGroupSummary(group)}, ${countLabel(group.changeCount, "Project change")}`,
+					)}
+					title="Projects"
+				/>
+				<DeltaSection
+					empty="No recipient changes."
+					exactItemName="recipient change"
+					exactItems={recipientItems}
+					summaryItems={recipientGroups.map(
+						(group) =>
+							`${projectGroupSummary(group)}, ${countLabel(group.changeCount, "recipient change")}`,
+					)}
+					title="Recipients"
+				/>
+				<DeltaSection
+					empty="No device access changes."
+					exactItemName="device-access change"
+					exactItems={deviceItems}
+					summaryItems={deviceAccessGroups.map(
+						(group) =>
+							`${projectGroupSummary(group)}, ${countLabel(group.changeCount, "device-access change")}`,
+					)}
+					title="Device access"
+				/>
 			</div>
 			<label className="legacy-team-setup-confirmation" id="legacy-team-setup-confirmation-label">
 				<input
 					aria-disabled={blocked ? "true" : undefined}
 					aria-describedby={blocked ? blockedDescriptionId : undefined}
 					checked={confirmed}
+					onClick={(event) => {
+						if (blocked) event.preventDefault();
+					}}
 					onChange={(event) => {
-						if (!blocked) setConfirmedEvidenceKey(event.currentTarget.checked ? evidenceKey : null);
+						if (blocked) {
+							event.currentTarget.checked = confirmed;
+							return;
+						}
+						setConfirmedEvidenceKey(event.currentTarget.checked ? evidenceKey : null);
 					}}
 					type="checkbox"
 				/>

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1281,9 +1281,28 @@
       .legacy-team-project-select { width: 100%; margin: 0; }
       .legacy-team-project-select:disabled { opacity: 0.55; cursor: not-allowed; }
       .legacy-team-setup-delta { display: grid; gap: var(--sp-3); }
+      .legacy-team-setup-review-summary {
+        display: grid;
+        gap: var(--sp-2);
+        margin-block: var(--sp-3);
+        padding: var(--sp-3);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface-2);
+      }
+      .legacy-team-setup-review-summary p,
+      .legacy-team-setup-review-summary ul { margin: 0; }
       .legacy-team-setup-delta section { padding-block: var(--sp-2); border-bottom: 1px solid var(--border); }
       .legacy-team-setup-delta h4 { margin: 0 0 var(--sp-2); }
       .legacy-team-setup-delta ul { display: grid; gap: var(--sp-1); margin: 0; padding-inline-start: var(--sp-5); }
+      .legacy-team-setup-delta-summary { font-weight: var(--font-weight-semibold); }
+      .legacy-team-setup-delta details { margin-top: var(--sp-2); }
+      .legacy-team-setup-delta summary { cursor: pointer; font-weight: var(--font-weight-semibold); }
+      .legacy-team-setup-delta .legacy-team-setup-exact-list {
+        margin-top: var(--sp-2);
+        padding-block: var(--sp-2);
+        border-top: 1px solid var(--border);
+      }
       .legacy-team-setup-confirmation { display: flex; gap: var(--sp-2); align-items: flex-start; margin-block: var(--sp-4); }
       .legacy-team-setup-confirmation input { flex: 0 0 auto; margin-top: 0.2em; min-width: 24px; min-height: 24px; }
       .recipient-policy-management-selection fieldset { border: 0; padding: 0; margin: var(--sp-4) 0 0; }


### PR DESCRIPTION
## Description

Summarizes large server-confirmed legacy Team access reviews without changing activation semantics. The Review step now reconciles all five change categories, separates migration scope from mutation totals, groups repeated Project labels using visible names and counts, and keeps every exact row available through native disclosures when grouping usefully reduces a large section.

Small reviews and large reviews with unique labels remain fully expanded. Confirmation stays bound to the same attempt and digest evidence, and blocked confirmation remains focusable without allowing its checked state to drift.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation:

- `pnpm run check` — 5,307 passed, 3 todo
- `pnpm --filter @codemem/ui build`
- `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1 pnpm run e2e:legacy-team-migration -- --json`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
