### PR TITLE
fix: preserve legacy Team names and isolate roster failures

### DIFF
--- a/docs/plans/2026-08-26-legacy-team-setup-ux-hotfix-design.md
+++ b/docs/plans/2026-08-26-legacy-team-setup-ux-hotfix-design.md
@@ -9,6 +9,8 @@ The `0.43.0` legacy Team setup flow preserves access safety, but dogfooding expo
 
 The same pass exposed overlapping numbered step labels and excessive spacing in the Team setup candidate list. Multiple distinct legacy groups can also share the fallback label `Legacy Team`, making their actions difficult to distinguish.
 
+Dogfooding after the initial hotfix found a more fundamental discovery gap. A coordinator group can still back active replication scopes and current access without appearing in `sync_coordinator_groups`. The existing loader considers only configured groups, so this production-shaped legacy Team never reaches the otherwise complete guided migration flow.
+
 ## Goals
 
 - Make automatic Project inclusion explicit without changing which Projects migrate.
@@ -16,6 +18,8 @@ The same pass exposed overlapping numbered step labels and excessive spacing in 
 - Safely group repeated human-readable labels without exposing coordinator, group, device, or canonical Project identifiers.
 - Repair the wizard stepper and Team setup candidate layout across supported widths.
 - Preserve server-authoritative refresh, confirmation digests, atomic activation, and fail-closed behavior.
+- Discover a legacy group when this node has active coordinator-backed scope evidence for it, even if another group is the only configured sync group.
+- Present scope-backed roster devices as proposed migration decisions that require review; never infer Team membership directly from scope membership.
 
 ## Non-goals
 
@@ -23,6 +27,8 @@ The same pass exposed overlapping numbered step labels and excessive spacing in 
 - Change device decisions, Team membership, recipient policy, or activation semantics.
 - Recompute or replace the server-provided access delta in the browser.
 - Expose opaque identifiers to disambiguate repeated labels.
+- Enumerate every administrator-visible coordinator group without local access evidence.
+- Automatically admit scope members to a Sharing Team.
 
 ## Design
 
@@ -37,6 +43,14 @@ The stepper uses explicit number elements inside equal-width step items rather t
 Candidate entries use compact rows with three aligned areas: Team label, status, and action. Native bullets are removed. Narrow layouts stack the status and action beneath the label.
 
 When multiple candidates have the same normalized display label, the overview groups them under one label and reports the count. Each underlying candidate keeps its own setup action and opaque candidate reference, but visible action labels include a safe ordinal such as `Continue setup for Legacy Team 1 of 2`. No coordinator or group identifier is rendered.
+
+The overview names unfinished candidates as `Legacy groups to migrate` and uses `Review and migrate` for the primary action. This makes the existing setup dialog the explicit bridge into Sharing rather than presenting legacy and Sharing Teams as unrelated inventories.
+
+### Scope-backed discovery
+
+Candidate loading uses the bounded union of configured sync groups and group IDs from active coordinator-authoritative replication scopes whose coordinator matches the configured coordinator. The loader then applies the existing current-group and current-roster validation to every candidate. Groups visible only through coordinator administration remain excluded.
+
+Scope membership is discovery evidence, not reviewed Team membership. The current coordinator roster supplies the migration's device inventory, and each device must still be assigned to an identity and explicitly included, excluded, or removed in the guided workflow. Finish continues to create or update the Sharing Team, reviewed memberships, Project recipients, and setup-owned scope mappings atomically from the confirmed preview.
 
 ### Review summary
 
@@ -63,8 +77,11 @@ The confirmation checkbox continues to bind to the attempt, finish, access-delta
 ## Validation
 
 - Add failing component tests for automatic Project progression, duplicate candidate labels, stepper hooks, and responsive candidate-row structure.
+- Add a production-shaped server regression where configuration contains only one group while a second current group has an active coordinator-backed scope and roster. Both groups must be discoverable, and unrelated administrator-visible groups must remain absent.
+- Assert that scope-backed devices remain unresolved until reviewed and are not converted directly into Team memberships.
 - Add review tests modeling 63 Projects, six devices, repeated labels, 509 exact changes, grouped summaries, and expandable exact details.
 - Assert that confirmation evidence and the finish request remain unchanged.
+- Extend the legacy Team migration E2E fixture so the migrated group is scope-backed but absent from `sync_coordinator_groups`.
 - Run targeted Vitest files, TypeScript, lint, the full workspace test suite, UI build, and legacy Team migration E2E.
 
 ## Delivery

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -448,6 +448,69 @@ describe("legacy Team setup drafts", () => {
 		expect(draft.displayName).toBe(label);
 	});
 
+	it.each([
+		{
+			groupId: "sre",
+			teamLabel: "SRE",
+			deviceLabel: "SRE laptop",
+			projectLabel: "SRE Project",
+		},
+		{
+			groupId: "nerdworld",
+			teamLabel: "Nerdworld",
+			deviceLabel: "Nerdworld workstation",
+			projectLabel: "Nerdworld tools",
+		},
+	])("keeps human group alias labels for $teamLabel", (labels) => {
+		const input = snapshot();
+		const device = input.devices[0];
+		const project = input.projects[0];
+		if (!device || !project) throw new Error("invalid test fixture");
+		input.groupId = labels.groupId;
+		input.displayName = labels.teamLabel;
+		device.displayName = labels.deviceLabel;
+		project.displayName = labels.projectLabel;
+
+		const draft = refreshLegacyTeamSetupDraft(db, input);
+		const refreshed = refreshLegacyTeamSetupDraftLabels(db, draft.attemptId, input);
+
+		expect(refreshed.displayName).toBe(labels.teamLabel);
+		expect(refreshed.devices[0]?.displayName).toBe(labels.deviceLabel);
+		expect(refreshed.projects[0]?.displayName).toBe(labels.projectLabel);
+	});
+
+	it("keeps opaque identifiers redacted when a human group alias is allowed", () => {
+		const input = snapshot();
+		const device = input.devices[0];
+		const project = input.projects[0];
+		if (!device || !project) throw new Error("invalid test fixture");
+		input.groupId = "nerdworld";
+		input.displayName = "Nerdworld";
+		device.labelRedactionIds = ["opaquepersonalpha"];
+		device.displayName = "Nerdworld opaquepersonalpha";
+		project.displayName = `Nerdworld ${project.projectRef}`;
+
+		const draft = refreshLegacyTeamSetupDraft(db, input);
+
+		expect(draft.displayName).toBe("Nerdworld");
+		expect(draft.devices[0]?.displayName).toBe("Device");
+		expect(draft.projects[0]?.displayName).toBe("Project");
+	});
+
+	it("keeps a human-shaped group id redacted when its display name does not match", () => {
+		const input = snapshot();
+		const device = input.devices[0];
+		if (!device) throw new Error("invalid test fixture");
+		input.groupId = "sre";
+		input.displayName = "Platform Team";
+		device.displayName = "SRE laptop";
+
+		const draft = refreshLegacyTeamSetupDraft(db, input);
+
+		expect(draft.displayName).toBe("Platform Team");
+		expect(draft.devices[0]?.displayName).toBe("Device");
+	});
+
 	it("keeps devices with inactive assignment rows reviewable but never includable", () => {
 		db.prepare(
 			`INSERT INTO identity_devices(

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -254,6 +254,15 @@ function labelComparisonForm(value: string): string {
 	return normalizeLabelText(value).toLowerCase();
 }
 
+// A coordinator display name is affirmative evidence that a compact alphabetic
+// group slug is a human label alias. Separators, digits, long values, or a
+// mismatched display name remain opaque and stay in the redaction set.
+function humanGroupLabelAlias(groupId: string, displayName: string): string | null {
+	const comparableGroupId = labelComparisonForm(groupId);
+	if (!/^[a-z]{2,24}$/u.test(comparableGroupId)) return null;
+	return labelComparisonForm(displayName) === comparableGroupId ? comparableGroupId : null;
+}
+
 /**
  * Coordinator-supplied display labels are sanitized with an allowlist, not a
  * denylist: multiple review rounds each found one more denylisted shape (bare
@@ -271,8 +280,8 @@ function labelComparisonForm(value: string): string {
  * - Reject `.` squeezed between letters/numbers on both sides: that single
  *   rule removes hostnames, IPs, and dotted file names while keeping ordinary
  *   sentence punctuation like `v2 release.` intact.
- * - Reject labels embedding opaque lookup identifiers (coordinator, group,
- *   device, project references).
+ * - Reject labels embedding opaque lookup identifiers (coordinator, device,
+ *   project, and non-display group references).
  */
 function safeLabel(value: string, fallback: string, forbiddenIds: ReadonlySet<string>): string {
 	const boundedValue = value.slice(0, 512);
@@ -295,6 +304,8 @@ function safeLabel(value: string, fallback: string, forbiddenIds: ReadonlySet<st
 
 function setupLabelForbiddenIds(
 	contextIds: ReadonlyArray<string>,
+	groupId: string,
+	humanGroupAlias: string | null,
 	devices: ReadonlyArray<LegacyTeamSetupRosterDeviceInput>,
 	projects: ReadonlyArray<LegacyTeamSetupProjectInput>,
 	persistedDevices: ReadonlyArray<{
@@ -313,6 +324,7 @@ function setupLabelForbiddenIds(
 	return new Set(
 		[
 			...contextIds,
+			...(humanGroupAlias ? [] : [groupId]),
 			...devices.flatMap((device) => [
 				device.deviceId,
 				device.fingerprint,
@@ -534,11 +546,12 @@ function createAttempt(
 		[
 			input.candidateId,
 			input.coordinatorId,
-			input.groupId,
 			...Array.from(assignmentByDevice.values()).flatMap((assignment) =>
 				assignment ? [assignment.identityId] : [],
 			),
 		],
+		input.groupId,
+		humanGroupLabelAlias(input.groupId, input.displayName),
 		input.devices,
 		input.projects,
 		previousDevices.map((device) => ({
@@ -967,7 +980,7 @@ export function refreshLegacyTeamSetupDraftLabels(
 			| { candidate_id: string; coordinator_id: string; group_id: string }
 			| undefined;
 		if (!context) throw new Error("legacy_team_setup_draft_not_found");
-		const contextIds = [context.candidate_id, context.coordinator_id, context.group_id];
+		const contextIds = [context.candidate_id, context.coordinator_id];
 		const persistedDevices = db
 			.prepare(
 				`SELECT device_id, key_fingerprint, display_name, existing_identity_id,
@@ -1006,6 +1019,8 @@ export function refreshLegacyTeamSetupDraftLabels(
 		}>;
 		const forbiddenIds = setupLabelForbiddenIds(
 			[...contextIds, ...liveAssignmentIds],
+			context.group_id,
+			humanGroupLabelAlias(context.group_id, input.displayName),
 			input.devices,
 			input.projects,
 			persistedDevices.map((device) => ({

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -486,6 +486,19 @@ describe("legacy Team setup dialog", () => {
 		expect(loadDetail).toHaveBeenCalledTimes(2);
 	});
 
+	it("directs roster-unavailable recovery to coordinator connection and settings", async () => {
+		setup(
+			vi.fn().mockRejectedValue(new LegacyTeamSetupApiError(503, "team_setup_roster_unavailable")),
+		);
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+				"Check the coordinator connection and settings, then retry.",
+			);
+		});
+		expect(document.body.textContent).not.toContain("team_setup_roster_unavailable");
+	});
+
 	it("uses changed-state copy for stale API errors and stale detail", async () => {
 		const loadDetail = vi
 			.fn()

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
@@ -100,10 +100,21 @@ function detailNeedsRecovery(detail: api.LegacyTeamSetupDetailResponseV1): boole
 	);
 }
 
+const ROSTER_UNAVAILABLE_ERROR =
+	"Team device details are temporarily unavailable. Check the coordinator connection and settings, then retry.";
+
+function isRosterUnavailableError(cause: unknown): boolean {
+	return (
+		cause instanceof api.LegacyTeamSetupApiError &&
+		cause.errorCode === "team_setup_roster_unavailable"
+	);
+}
+
 function safeLoadError(cause: unknown): string {
 	if (isChangedStateError(cause)) {
 		return CHANGED_STATE_ERROR;
 	}
+	if (isRosterUnavailableError(cause)) return ROSTER_UNAVAILABLE_ERROR;
 	return "Team setup details are temporarily unavailable. Retry to load the latest details.";
 }
 
@@ -115,12 +126,7 @@ function safeMutationError(cause: unknown): string {
 	if (isChangedStateError(cause)) {
 		return CHANGED_STATE_ERROR;
 	}
-	if (
-		cause instanceof api.LegacyTeamSetupApiError &&
-		cause.errorCode === "team_setup_roster_unavailable"
-	) {
-		return "Team device details are temporarily unavailable. Reload the latest details before trying again.";
-	}
+	if (isRosterUnavailableError(cause)) return ROSTER_UNAVAILABLE_ERROR;
 	return "This device change could not be saved. Reload the latest details before trying again.";
 }
 
@@ -128,6 +134,7 @@ function safeProjectMutationError(cause: unknown): string {
 	if (cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode)) {
 		return CHANGED_STATE_ERROR;
 	}
+	if (isRosterUnavailableError(cause)) return ROSTER_UNAVAILABLE_ERROR;
 	return "This Project mapping could not be saved. Reload the latest details before trying again.";
 }
 
@@ -135,6 +142,7 @@ function safeRefreshError(cause: unknown): string {
 	if (cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode)) {
 		return CHANGED_STATE_ERROR;
 	}
+	if (isRosterUnavailableError(cause)) return ROSTER_UNAVAILABLE_ERROR;
 	return "Team setup could not be refreshed. Retry to load the latest server details.";
 }
 
@@ -142,6 +150,7 @@ function safeFinishError(cause: unknown): string {
 	if (cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode)) {
 		return CHANGED_STATE_ERROR;
 	}
+	if (isRosterUnavailableError(cause)) return ROSTER_UNAVAILABLE_ERROR;
 	return "Team setup could not be finished. Reload the latest details before trying again.";
 }
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1515,7 +1515,7 @@ describe("viewer-server", () => {
 			]);
 		});
 
-		it("fails closed for non-size coordinator roster errors", async () => {
+		it("fails closed when the only summary roster is unavailable", async () => {
 			const config = {
 				...core.readCoordinatorSyncConfig({}),
 				syncCoordinatorUrl: "http://localhost:8787",
@@ -1540,7 +1540,7 @@ describe("viewer-server", () => {
 			).rejects.toThrow("team_setup_roster_unavailable");
 		});
 
-		it("rejects coordinator roster fingerprints that do not match their public keys", async () => {
+		it("fails closed when the only summary roster has a mismatched fingerprint", async () => {
 			const config = {
 				...core.readCoordinatorSyncConfig({}),
 				syncCoordinatorUrl: "http://localhost:8787",
@@ -1574,7 +1574,9 @@ describe("viewer-server", () => {
 			).rejects.toThrow("team_setup_roster_unavailable");
 		});
 
-		it.each([2, -1])("rejects invalid coordinator enabled value %i", async (enabled) => {
+		it.each([
+			2, -1,
+		])("fails closed on sole invalid coordinator enabled value %i", async (enabled) => {
 			const publicKey = "public-key-a";
 			const config = {
 				...core.readCoordinatorSyncConfig({}),

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -1,10 +1,18 @@
 import {
+	canonicalWorkspaceIdentity,
 	fingerprintPublicKey,
+	getLegacyTeamSetupDraft,
 	legacyTeamCandidateId,
+	MemoryStore,
 	readCoordinatorSyncConfig,
 } from "@codemem/core";
 import { describe, expect, it, vi } from "vitest";
-import { __teamSetupTestHooks } from "./team-setup.js";
+import { __teamSetupTestHooks, teamSetupRoutes } from "./team-setup.js";
+
+function createRouteStore(): { store: MemoryStore; close: () => void } {
+	const store = new MemoryStore(":memory:");
+	return { store, close: () => store.close() };
+}
 
 describe("Team setup roster loading", () => {
 	it("reuses successful summary snapshots until the cache expires", async () => {
@@ -117,6 +125,561 @@ describe("Team setup roster loading", () => {
 		);
 	});
 
+	it("canonicalizes equivalent coordinator URLs while preserving non-root paths", () => {
+		expect(__teamSetupTestHooks.normalizedCoordinatorId("HTTP://LOCALHOST:80/")).toBe(
+			"http://localhost",
+		);
+		expect(
+			__teamSetupTestHooks.normalizedCoordinatorId("HTTPS://EXAMPLE.COM:443/coordinator/"),
+		).toBe("https://example.com/coordinator");
+		expect(__teamSetupTestHooks.normalizedCoordinatorId("https://example.com/other")).toBe(
+			"https://example.com/other",
+		);
+		expect(__teamSetupTestHooks.normalizedCoordinatorId("http://[")).toBeNull();
+		expect(__teamSetupTestHooks.normalizedCoordinatorId("ftp://example.com")).toBeNull();
+		expect(__teamSetupTestHooks.normalizedCoordinatorId("http://user@localhost:8787")).toBeNull();
+	});
+
+	it("uses normalization only for matching and preserves configured candidate identity", async () => {
+		const { store, close } = createRouteStore();
+		const configuredCoordinatorId = "HTTP://LOCALHOST:80";
+		const now = "2026-08-26T00:00:00.000Z";
+		try {
+			store.db
+				.prepare(
+					`INSERT INTO replication_scopes(
+					 scope_id, label, kind, authority_type, coordinator_id, group_id,
+					 membership_epoch, status, created_at, updated_at
+					 ) VALUES ('configured-scope', 'Configured', 'team', 'coordinator',
+					 'http://localhost', 'configured', 1, 'active', ?, ?)`,
+				)
+				.run(now, now);
+			const snapshots = await __teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith(
+				{
+					readConfig: () => ({
+						...readCoordinatorSyncConfig({}),
+						syncCoordinatorUrl: `${configuredCoordinatorId}/`,
+						syncCoordinatorGroups: ["configured"],
+						syncCoordinatorAdminSecret: "private-admin-secret",
+					}),
+					listGroups: async () => [
+						{
+							group_id: "configured",
+							display_name: "Configured",
+							archived_at: null,
+							created_at: now,
+						},
+					],
+					listDevices: async () => [],
+				},
+				{},
+				() => store,
+			);
+
+			expect(snapshots).toEqual([
+				expect.objectContaining({
+					groupId: "configured",
+					coordinatorId: configuredCoordinatorId,
+				}),
+			]);
+		} finally {
+			close();
+		}
+	});
+
+	it("keeps configured candidates when local scope evidence cannot be read", async () => {
+		const now = "2026-08-26T00:00:00.000Z";
+		const snapshots = await __teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith(
+			{
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "http://localhost:8787",
+					syncCoordinatorGroups: ["configured"],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+				listGroups: async () => [
+					{
+						group_id: "configured",
+						display_name: "Configured",
+						archived_at: null,
+						created_at: now,
+					},
+				],
+				listDevices: async () => [],
+			},
+			{},
+			() => {
+				throw new Error("scope store unavailable");
+			},
+		);
+
+		expect(snapshots).toEqual([
+			expect.objectContaining({
+				groupId: "configured",
+				coordinatorId: "http://localhost:8787",
+			}),
+		]);
+	});
+
+	it("preserves no-config emptiness while partial and empty complete config fail closed", async () => {
+		const base = readCoordinatorSyncConfig({});
+		const dependencies = {
+			readConfig: () => ({
+				...base,
+				syncCoordinatorUrl: "",
+				syncCoordinatorGroups: [],
+				syncCoordinatorAdminSecret: "",
+			}),
+			listGroups: vi.fn(async () => []),
+			listDevices: vi.fn(async () => []),
+		};
+
+		await expect(
+			__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith(dependencies),
+		).resolves.toEqual([]);
+		dependencies.readConfig = () => ({
+			...base,
+			syncCoordinatorUrl: "http://localhost:8787",
+			syncCoordinatorGroups: [],
+			syncCoordinatorAdminSecret: "",
+		});
+		await expect(
+			__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith(dependencies),
+		).rejects.toThrow("team_setup_roster_unavailable");
+		dependencies.readConfig = () => ({
+			...base,
+			syncCoordinatorUrl: "http://localhost:8787",
+			syncCoordinatorGroups: [],
+			syncCoordinatorAdminSecret: "private-admin-secret",
+		});
+		await expect(
+			__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith(dependencies),
+		).rejects.toThrow("team_setup_roster_unavailable");
+		expect(dependencies.listGroups).not.toHaveBeenCalled();
+	});
+
+	it("discovers configured and active locally evidenced groups without inferring membership", async () => {
+		const { store, close } = createRouteStore();
+		const coordinatorId = "http://localhost:8787";
+		const rawCoordinatorId = "localhost:8787/";
+		const now = "2026-08-26T00:00:00.000Z";
+		try {
+			const insertScope = store.db.prepare(
+				`INSERT INTO replication_scopes(
+				 scope_id, label, kind, authority_type, coordinator_id, group_id,
+				 membership_epoch, status, created_at, updated_at
+				 ) VALUES (?, ?, 'team', ?, ?, ?, 1, ?, ?, ?)`,
+			);
+			insertScope.run(
+				"scope-sre",
+				"SRE",
+				"coordinator",
+				rawCoordinatorId,
+				"sre",
+				"active",
+				now,
+				now,
+			);
+			insertScope.run(
+				"scope-sre-duplicate",
+				"SRE duplicate",
+				"coordinator",
+				rawCoordinatorId,
+				" sre ",
+				"active",
+				now,
+				now,
+			);
+			insertScope.run(
+				"scope-unrelated-inactive",
+				"Unrelated",
+				"coordinator",
+				coordinatorId,
+				"unrelated",
+				"inactive",
+				now,
+				now,
+			);
+			insertScope.run(
+				"scope-unrelated-local",
+				"Unrelated",
+				"local",
+				coordinatorId,
+				"unrelated",
+				"active",
+				now,
+				now,
+			);
+			insertScope.run(
+				"scope-unrelated-other",
+				"Unrelated",
+				"coordinator",
+				"http://other-coordinator:8787",
+				"unrelated",
+				"active",
+				now,
+				now,
+			);
+			insertScope.run(
+				"scope-malformed-coordinator",
+				"Malformed coordinator",
+				"coordinator",
+				"http://[",
+				"malformed-only",
+				"active",
+				now,
+				now,
+			);
+			store.db
+				.prepare(
+					`INSERT INTO replication_scopes(
+					 scope_id, label, kind, authority_type, coordinator_id, group_id,
+					 membership_epoch, status, created_at, updated_at
+					 ) VALUES ('scope-managed-only', 'Managed only', 'managed_project', 'coordinator',
+					 ?, 'managed-only', 1, 'active', ?, ?)`,
+				)
+				.run(rawCoordinatorId, now, now);
+			const projectIdentity = canonicalWorkspaceIdentity({ project: "sre-project" }).value;
+			const sessionId = Number(
+				store.db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, 'sre-project')")
+					.run(now).lastInsertRowid,
+			);
+			store.db
+				.prepare(
+					`INSERT INTO memory_items(
+					 session_id, kind, title, body_text, active, created_at, updated_at,
+					 visibility, project, scope_id
+					 ) VALUES (?, 'discovery', 'SRE Project', 'body', 1, ?, ?, 'shared',
+					 'sre-project', 'scope-sre')`,
+				)
+				.run(sessionId, now, now);
+			store.db
+				.prepare(
+					`INSERT INTO project_scope_mappings(
+					 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+					 ) VALUES (?, ?, 'scope-sre', 1000, 'test', ?, ?)`,
+				)
+				.run(projectIdentity, projectIdentity, now, now);
+
+			const groups = [
+				{ group_id: "nerdworld", display_name: "Nerdworld", archived_at: null, created_at: now },
+				{ group_id: "sre", display_name: "SRE", archived_at: null, created_at: now },
+				{
+					group_id: "managed-only",
+					display_name: "Managed only",
+					archived_at: null,
+					created_at: now,
+				},
+				{
+					group_id: "malformed-only",
+					display_name: "Malformed coordinator",
+					archived_at: null,
+					created_at: now,
+				},
+				{ group_id: "unrelated", display_name: "Unrelated", archived_at: null, created_at: now },
+			];
+			const listDevices = vi.fn(async ({ groupId }: { groupId: string }) => {
+				const count = groupId === "sre" ? 6 : 1;
+				return Array.from({ length: count }, (_, index) => {
+					const publicKey = `${groupId}-public-key-${index}`;
+					return {
+						group_id: groupId,
+						device_id: `${groupId}-device-${index}`,
+						public_key: publicKey,
+						fingerprint: fingerprintPublicKey(publicKey),
+						identity_id: null,
+						display_name: `${groupId} device ${index + 1}`,
+						enabled: groupId === "sre" && index === count - 1 ? 0 : 1,
+						created_at: now,
+					};
+				});
+			});
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				snapshotLoaderDependencies: {
+					readConfig: () => ({
+						...readCoordinatorSyncConfig({}),
+						syncCoordinatorUrl: coordinatorId,
+						syncCoordinatorGroups: ["nerdworld"],
+						syncCoordinatorAdminSecret: "private-admin-secret",
+					}),
+					listGroups: async () => groups,
+					listDevices,
+				},
+			});
+
+			const response = await app.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			const summary = (await response.json()) as {
+				candidates: Array<{
+					candidateRef: string;
+					displayName: string;
+					deviceCount: number;
+					projectCount: number;
+				}>;
+			};
+			expect(summary.candidates.map((candidate) => candidate.displayName).toSorted()).toEqual([
+				"Nerdworld",
+				"SRE",
+			]);
+			expect(summary.candidates.some((candidate) => candidate.displayName === "Unrelated")).toBe(
+				false,
+			);
+			expect(summary.candidates.some((candidate) => candidate.displayName === "Managed only")).toBe(
+				false,
+			);
+			expect(
+				summary.candidates.some((candidate) => candidate.displayName === "Malformed coordinator"),
+			).toBe(false);
+			const sreCandidate = summary.candidates.find((candidate) => candidate.displayName === "SRE");
+			expect(sreCandidate?.candidateRef).toBe(legacyTeamCandidateId(rawCoordinatorId, "sre"));
+			expect(sreCandidate?.deviceCount).toBe(6);
+			expect(sreCandidate?.projectCount).toBe(1);
+			const sreDraft = getLegacyTeamSetupDraft(store.db, sreCandidate?.candidateRef ?? "");
+			expect(sreDraft?.devices).toHaveLength(6);
+			expect(sreDraft?.projects).toEqual([expect.objectContaining({ displayName: "sre-project" })]);
+			expect(sreDraft?.devices.every((device) => device.decision === "unresolved")).toBe(true);
+			expect(sreDraft?.devices.every((device) => device.targetIdentityId === null)).toBe(true);
+			expect(sreDraft?.devices.filter((device) => !device.enabled)).toHaveLength(1);
+			const detail = await app.request(
+				`/api/sync/team-setup/v1/${legacyTeamCandidateId(rawCoordinatorId, "sre")}`,
+			);
+			expect(detail.status).toBe(200);
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get()).toBe(
+				0,
+			);
+			expect(listDevices.mock.calls.map(([input]) => input.groupId).toSorted()).toEqual([
+				"nerdworld",
+				"sre",
+				"sre",
+			]);
+		} finally {
+			close();
+		}
+	});
+
+	it("prioritizes configured groups and deterministically truncates excess scope evidence", async () => {
+		const { store, close } = createRouteStore();
+		const coordinatorId = "http://localhost:8787";
+		const now = "2026-08-26T00:00:00.000Z";
+		try {
+			const insertScope = store.db.prepare(
+				`INSERT INTO replication_scopes(
+				 scope_id, label, kind, authority_type, coordinator_id, group_id,
+				 membership_epoch, status, created_at, updated_at
+				 ) VALUES (?, ?, 'team', 'coordinator', ?, ?, 1, 'active', ?, ?)`,
+			);
+			insertScope.run(
+				"scope-configured-overlap",
+				"Configured overlap",
+				coordinatorId,
+				"configured-00",
+				now,
+				now,
+			);
+			for (let index = 0; index < 40; index += 1) {
+				const suffix = index.toString().padStart(2, "0");
+				insertScope.run(
+					`scope-evidenced-${suffix}`,
+					`Evidenced ${index}`,
+					coordinatorId,
+					`evidenced-${suffix}`,
+					now,
+					now,
+				);
+			}
+			let configuredGroups = Array.from(
+				{ length: 13 },
+				(_, index) => `configured-${index.toString().padStart(2, "0")}`,
+			);
+			const config = {
+				...readCoordinatorSyncConfig({}),
+				syncCoordinatorUrl: coordinatorId,
+				get syncCoordinatorGroups() {
+					return configuredGroups;
+				},
+				syncCoordinatorAdminSecret: "private-admin-secret",
+			};
+			const evidencedGroups = Array.from({ length: 40 }, (_, index) => {
+				const suffix = index.toString().padStart(2, "0");
+				return `evidenced-${suffix}`;
+			});
+			const remoteGroups = [...configuredGroups, ...evidencedGroups].map((groupId) => ({
+				group_id: groupId,
+				display_name: groupId,
+				archived_at: null,
+				created_at: now,
+			}));
+			const dependencies = {
+				readConfig: () => config,
+				listGroups: vi.fn(async () => remoteGroups),
+				listDevices: vi.fn(async () => []),
+			};
+
+			const snapshots = await __teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith(
+				dependencies,
+				{},
+				() => store,
+			);
+			expect(snapshots.map((snapshot) => snapshot.groupId)).toEqual([
+				...configuredGroups,
+				...Array.from(
+					{ length: 12 },
+					(_, index) => `evidenced-${index.toString().padStart(2, "0")}`,
+				),
+			]);
+			configuredGroups = Array.from({ length: 26 }, (_, index) => `configured-${index}`);
+			await expect(
+				__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith(
+					dependencies,
+					{},
+					() => store,
+				),
+			).rejects.toThrow("team_setup_roster_unavailable");
+		} finally {
+			close();
+		}
+	});
+
+	it("finds equivalent coordinator evidence within the bounded distinct-coordinator lookup", async () => {
+		const { store, close } = createRouteStore();
+		const coordinatorId = "http://localhost:8787";
+		const now = "2026-08-26T00:00:00.000Z";
+		try {
+			const insertScope = store.db.prepare(
+				`INSERT INTO replication_scopes(
+				 scope_id, label, kind, authority_type, coordinator_id, group_id,
+				 membership_epoch, status, created_at, updated_at
+				 ) VALUES (?, ?, 'team', 'coordinator', ?, ?, 1, 'active', ?, ?)`,
+			);
+			for (let index = 0; index < 99; index += 1) {
+				insertScope.run(
+					`scope-foreign-${index}`,
+					`Foreign ${index}`,
+					`http://foreign-${index}.example.invalid`,
+					`foreign-${index}`,
+					now,
+					now,
+				);
+			}
+			for (let index = 0; index < 101; index += 1) {
+				insertScope.run(
+					`scope-blank-group-${index}`,
+					`Blank group ${index}`,
+					`http://blank-group-${index}.example.invalid`,
+					" ",
+					now,
+					now,
+				);
+			}
+			insertScope.run("scope-equivalent", "SRE", "LOCALHOST:8787/", "sre", now, now);
+			const dependencies = {
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: coordinatorId,
+					syncCoordinatorGroups: ["configured"],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+				listGroups: vi.fn(async () => [
+					{
+						group_id: "configured",
+						display_name: "Configured",
+						archived_at: null,
+						created_at: now,
+					},
+					{
+						group_id: "sre",
+						display_name: "SRE",
+						archived_at: null,
+						created_at: now,
+					},
+				]),
+				listDevices: vi.fn(async () => []),
+			};
+
+			const snapshots = await __teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith(
+				dependencies,
+				{},
+				() => store,
+			);
+			expect(snapshots.map((snapshot) => snapshot.groupId)).toEqual(["configured", "sre"]);
+			expect(snapshots[1]?.coordinatorId).toBe("LOCALHOST:8787/");
+			insertScope.run(
+				"scope-foreign-overflow",
+				"Foreign overflow",
+				"http://foreign-overflow.example.invalid",
+				"foreign-overflow",
+				now,
+				now,
+			);
+			await expect(
+				__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith(
+					dependencies,
+					{},
+					() => store,
+				),
+			).resolves.toEqual([
+				expect.objectContaining({
+					groupId: "configured",
+					coordinatorId,
+				}),
+			]);
+		} finally {
+			close();
+		}
+	});
+
+	it("omits an evidence-only group with ambiguous equivalent coordinator identities", async () => {
+		const { store, close } = createRouteStore();
+		const coordinatorId = "http://localhost:8787";
+		const now = "2026-08-26T00:00:00.000Z";
+		try {
+			const insertScope = store.db.prepare(
+				`INSERT INTO replication_scopes(
+				 scope_id, label, kind, authority_type, coordinator_id, group_id,
+				 membership_epoch, status, created_at, updated_at
+				 ) VALUES (?, 'SRE', 'team', 'coordinator', ?, 'sre', 1, 'active', ?, ?)`,
+			);
+			insertScope.run("scope-sre-raw", "localhost:8787/", now, now);
+			insertScope.run("scope-sre-canonical", coordinatorId, now, now);
+			const listDevices = vi.fn(async () => []);
+
+			const snapshots = await __teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith(
+				{
+					readConfig: () => ({
+						...readCoordinatorSyncConfig({}),
+						syncCoordinatorUrl: coordinatorId,
+						syncCoordinatorGroups: ["configured"],
+						syncCoordinatorAdminSecret: "private-admin-secret",
+					}),
+					listGroups: async () => [
+						{
+							group_id: "configured",
+							display_name: "Configured",
+							archived_at: null,
+							created_at: now,
+						},
+						{
+							group_id: "sre",
+							display_name: "SRE",
+							archived_at: null,
+							created_at: now,
+						},
+					],
+					listDevices,
+				},
+				{},
+				() => store,
+			);
+
+			expect(snapshots.map((snapshot) => snapshot.groupId)).toEqual(["configured"]);
+			expect(listDevices).toHaveBeenCalledTimes(1);
+		} finally {
+			close();
+		}
+	});
+
 	it.each([
 		"https://private.example.invalid/person",
 		"/Users/private/person",
@@ -227,6 +790,152 @@ describe("Team setup roster loading", () => {
 				{ candidateRef: legacyTeamCandidateId(coordinatorId, groupId) },
 			),
 		).rejects.toThrow("legacy_team_setup_roster_too_large");
+	});
+
+	it("keeps healthy summary candidates when another group roster is unavailable", async () => {
+		const publicKey = "public-key-healthy";
+		const listDevices = vi.fn(async ({ groupId }: { groupId: string }) => {
+			if (groupId === "group-unavailable") throw new Error("private coordinator failure");
+			return [
+				{
+					group_id: groupId,
+					device_id: "device-healthy",
+					public_key: publicKey,
+					fingerprint: fingerprintPublicKey(publicKey),
+					identity_id: null,
+					display_name: "Healthy laptop",
+					enabled: 1,
+					created_at: "2026-08-24T00:00:00.000Z",
+				},
+			];
+		});
+
+		const snapshots = await __teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
+			readConfig: () => ({
+				...readCoordinatorSyncConfig({}),
+				syncCoordinatorUrl: "http://localhost:8787",
+				syncCoordinatorGroups: ["group-healthy", "group-unavailable"],
+				syncCoordinatorAdminSecret: "private-admin-secret",
+			}),
+			listGroups: async () => [
+				{
+					group_id: "group-healthy",
+					display_name: "Healthy Team",
+					archived_at: null,
+					created_at: "2026-08-24T00:00:00.000Z",
+				},
+				{
+					group_id: "group-unavailable",
+					display_name: "Unavailable Team",
+					archived_at: null,
+					created_at: "2026-08-24T00:00:00.000Z",
+				},
+			],
+			listDevices,
+		});
+
+		expect(snapshots).toEqual([
+			expect.objectContaining({ groupId: "group-healthy", displayName: "Healthy Team" }),
+		]);
+		expect(listDevices).toHaveBeenCalledTimes(2);
+	});
+
+	it.each([
+		"archived",
+		"deleted",
+	])("treats a sole %s configured group as authoritative absence", async (state) => {
+		const { store, close } = createRouteStore();
+		const coordinatorId = "http://localhost:8787";
+		const groupId = "group-absent";
+		const listDevices = vi.fn(async () => []);
+		try {
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				snapshotLoaderDependencies: {
+					readConfig: () => ({
+						...readCoordinatorSyncConfig({}),
+						syncCoordinatorUrl: coordinatorId,
+						syncCoordinatorGroups: [groupId],
+						syncCoordinatorAdminSecret: "private-admin-secret",
+					}),
+					listGroups: async () =>
+						state === "archived"
+							? [
+									{
+										group_id: groupId,
+										display_name: "Archived Team",
+										archived_at: "2026-08-26T00:00:00.000Z",
+										created_at: "2026-08-24T00:00:00.000Z",
+									},
+								]
+							: [],
+					listDevices,
+				},
+			});
+			const summary = await app.request("/api/sync/team-setup/v1");
+			expect(summary.status).toBe(200);
+			expect(await summary.json()).toEqual({ version: 1, candidates: [] });
+			const detail = await app.request(
+				`/api/sync/team-setup/v1/${legacyTeamCandidateId(coordinatorId, groupId)}`,
+			);
+			expect(detail.status).toBe(404);
+			expect(await detail.json()).toEqual({ error: "team_setup_confirmation_stale" });
+			expect(listDevices).not.toHaveBeenCalled();
+		} finally {
+			close();
+		}
+	});
+
+	it("fails safely when the sole current group metadata is malformed", async () => {
+		await expect(
+			__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "http://localhost:8787",
+					syncCoordinatorGroups: ["group-malformed"],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+				listGroups: async () => [
+					{
+						group_id: "group-malformed",
+						display_name: 42 as unknown as string,
+						archived_at: null,
+						created_at: "2026-08-24T00:00:00.000Z",
+					},
+				],
+				listDevices: vi.fn(async () => []),
+			}),
+		).rejects.toThrow("team_setup_roster_unavailable");
+	});
+
+	it("fails closed when the requested candidate roster is unavailable", async () => {
+		const coordinatorId = "http://localhost:8787";
+		const groupId = "group-unavailable";
+
+		await expect(
+			__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith(
+				{
+					readConfig: () => ({
+						...readCoordinatorSyncConfig({}),
+						syncCoordinatorUrl: coordinatorId,
+						syncCoordinatorGroups: [groupId],
+						syncCoordinatorAdminSecret: "private-admin-secret",
+					}),
+					listGroups: async () => [
+						{
+							group_id: groupId,
+							display_name: "Unavailable Team",
+							archived_at: null,
+							created_at: "2026-08-24T00:00:00.000Z",
+						},
+					],
+					listDevices: async () => {
+						throw new Error("private coordinator failure");
+					},
+				},
+				{ candidateRef: legacyTeamCandidateId(coordinatorId, groupId) },
+			),
+		).rejects.toThrow("team_setup_roster_unavailable");
 	});
 
 	it("rejects mapping-choice responses that cannot include every opaque choice", () => {

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -37,6 +37,7 @@ import { type Context, Hono } from "hono";
 
 const TEAM_SETUP_VERSION = 1 as const;
 const MAX_CONFIGURED_GROUPS = 25;
+const MAX_SCOPE_EVIDENCE_COORDINATORS = 100;
 const MAX_DEVICES = 500;
 const MAX_PROJECTS = 500;
 const MAX_ACCESS_DELTA_ENTRIES = 10_000;
@@ -61,6 +62,11 @@ const VIEWER_ACCESS_DELTA_DIGEST_PATTERN = /^legacy-team-viewer-access-delta-v1:
 
 interface LegacyTeamConfiguredGroupSnapshotLoadOptions {
 	candidateRef?: string;
+}
+
+interface LegacyTeamCandidateGroupDescriptor {
+	groupId: string;
+	coordinatorId: string;
 }
 
 export type LegacyTeamConfiguredGroupSnapshotLoader = (
@@ -205,6 +211,7 @@ export interface LegacyTeamSetupFinishResponseV1 {
 interface TeamSetupRoutesOptions {
 	getStore: () => MemoryStore;
 	loadLegacyTeamConfiguredGroupSnapshots?: LegacyTeamConfiguredGroupSnapshotLoader;
+	snapshotLoaderDependencies?: LegacyTeamSnapshotLoaderDependencies;
 }
 
 interface LegacyTeamSnapshotLoaderDependencies {
@@ -233,9 +240,102 @@ function configuredGroupIds(groups: string[]): string[] {
 	return unique;
 }
 
+function normalizedCoordinatorId(value: string): string | null {
+	try {
+		const normalized = buildBaseUrl(value);
+		if (!normalized) return null;
+		const parsed = new URL(normalized);
+		if (
+			(parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+			!parsed.host ||
+			parsed.username ||
+			parsed.password
+		) {
+			return null;
+		}
+		const path = parsed.pathname === "/" ? "" : parsed.pathname;
+		return `${parsed.protocol}//${parsed.host}${path}${parsed.search}`;
+	} catch {
+		return null;
+	}
+}
+
+function scopeBackedGroupDescriptors(
+	store: MemoryStore,
+	normalizedConfiguredCoordinatorId: string,
+	limit: number,
+	excludedGroupIds: string[],
+): LegacyTeamCandidateGroupDescriptor[] {
+	if (limit <= 0) return [];
+	const textualCoordinatorIds = store.db
+		.prepare(
+			`SELECT DISTINCT coordinator_id FROM replication_scopes
+			 WHERE status = 'active' AND authority_type = 'coordinator'
+			   AND kind IN ('team', 'team_default', 'org', 'client')
+			   AND coordinator_id IS NOT NULL
+			   AND group_id IS NOT NULL AND TRIM(group_id) <> ''
+			 ORDER BY coordinator_id LIMIT ?`,
+		)
+		.pluck()
+		.all(MAX_SCOPE_EVIDENCE_COORDINATORS + 1) as string[];
+	if (textualCoordinatorIds.length > MAX_SCOPE_EVIDENCE_COORDINATORS) {
+		return [];
+	}
+	const matchingTextualIds = textualCoordinatorIds.filter(
+		(value) => normalizedCoordinatorId(value) === normalizedConfiguredCoordinatorId,
+	);
+	if (matchingTextualIds.length === 0) return [];
+	const coordinatorPlaceholders = matchingTextualIds.map(() => "?").join(", ");
+	const excludedGroupClause =
+		excludedGroupIds.length === 0
+			? ""
+			: `AND TRIM(group_id) NOT IN (${excludedGroupIds.map(() => "?").join(", ")})`;
+	const groupIds = store.db
+		.prepare(
+			`SELECT DISTINCT TRIM(group_id) AS group_id FROM replication_scopes
+			 WHERE status = 'active' AND authority_type = 'coordinator'
+			   AND kind IN ('team', 'team_default', 'org', 'client')
+			   AND coordinator_id IN (${coordinatorPlaceholders})
+			   AND group_id IS NOT NULL AND TRIM(group_id) <> ''
+			   ${excludedGroupClause}
+			 ORDER BY TRIM(group_id) LIMIT ?`,
+		)
+		.pluck()
+		.all(...matchingTextualIds, ...excludedGroupIds, limit) as string[];
+	if (groupIds.length === 0) return [];
+	const groupPlaceholders = groupIds.map(() => "?").join(", ");
+	const records = store.db
+		.prepare(
+			`SELECT DISTINCT TRIM(group_id) AS group_id, coordinator_id FROM replication_scopes
+			 WHERE status = 'active' AND authority_type = 'coordinator'
+			   AND kind IN ('team', 'team_default', 'org', 'client')
+			   AND coordinator_id IN (${coordinatorPlaceholders})
+			   AND TRIM(group_id) IN (${groupPlaceholders})
+			 ORDER BY TRIM(group_id), coordinator_id`,
+		)
+		.all(...matchingTextualIds, ...groupIds) as Array<{
+		group_id: string;
+		coordinator_id: string;
+	}>;
+	const coordinatorIdsByGroup = new Map<string, string[]>();
+	for (const record of records) {
+		const coordinatorIds = coordinatorIdsByGroup.get(record.group_id) ?? [];
+		coordinatorIds.push(record.coordinator_id);
+		coordinatorIdsByGroup.set(record.group_id, coordinatorIds);
+	}
+	return groupIds.flatMap((groupId) => {
+		const coordinatorIds = coordinatorIdsByGroup.get(groupId) ?? [];
+		// Equivalent textual coordinator IDs still represent distinct persisted
+		// candidate identities. Never merge their authorization evidence by label.
+		const coordinatorId = coordinatorIds[0];
+		return coordinatorIds.length === 1 && coordinatorId ? [{ groupId, coordinatorId }] : [];
+	});
+}
+
 async function loadConfiguredLegacyTeamGroupSnapshotsWith(
 	dependencies: LegacyTeamSnapshotLoaderDependencies,
 	options: LegacyTeamConfiguredGroupSnapshotLoadOptions = {},
+	getStore?: () => MemoryStore,
 ): Promise<LegacyTeamConfiguredGroupSnapshot[]> {
 	let config: ReturnType<typeof readCoordinatorSyncConfig>;
 	try {
@@ -243,21 +343,47 @@ async function loadConfiguredLegacyTeamGroupSnapshotsWith(
 	} catch {
 		throw safeCoordinatorError();
 	}
-	const groupIds = configuredGroupIds(config.syncCoordinatorGroups);
+	const configuredIds = configuredGroupIds(config.syncCoordinatorGroups);
 	const hasUrl = Boolean(config.syncCoordinatorUrl);
 	const hasSecret = Boolean(config.syncCoordinatorAdminSecret);
-	if (!hasUrl && !hasSecret && groupIds.length === 0) return [];
-	if (!hasUrl || !hasSecret || groupIds.length === 0) throw safeCoordinatorError();
+	if (!hasUrl && !hasSecret && configuredIds.length === 0) return [];
+	if (!hasUrl || !hasSecret) throw safeCoordinatorError();
 
 	try {
-		const remoteUrl = buildBaseUrl(config.syncCoordinatorUrl);
-		const coordinatorId = remoteUrl;
+		const configuredCoordinatorId = buildBaseUrl(config.syncCoordinatorUrl);
+		const normalizedConfiguredCoordinatorId = normalizedCoordinatorId(configuredCoordinatorId);
+		if (!configuredCoordinatorId || !normalizedConfiguredCoordinatorId) {
+			throw safeCoordinatorError();
+		}
+		const remoteUrl = configuredCoordinatorId;
+		const remainingEvidenceSlots = MAX_CONFIGURED_GROUPS - configuredIds.length;
+		let scopeBackedDescriptors: LegacyTeamCandidateGroupDescriptor[] = [];
+		if (getStore) {
+			try {
+				scopeBackedDescriptors = scopeBackedGroupDescriptors(
+					getStore(),
+					normalizedConfiguredCoordinatorId,
+					remainingEvidenceSlots,
+					configuredIds,
+				);
+			} catch {
+				// Scope discovery is additive. Preserve configured coordinator
+				// candidates when local evidence cannot be read.
+				scopeBackedDescriptors = [];
+			}
+		}
+		const groupDescriptors: LegacyTeamCandidateGroupDescriptor[] = [
+			...configuredIds.map((groupId) => ({ groupId, coordinatorId: configuredCoordinatorId })),
+			...scopeBackedDescriptors,
+		];
+		if (groupDescriptors.length === 0) throw safeCoordinatorError();
 		const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
-		const requestedGroupIds = options.candidateRef
-			? groupIds.filter(
-					(groupId) => legacyTeamCandidateId(coordinatorId, groupId) === options.candidateRef,
+		const requestedGroupDescriptors = options.candidateRef
+			? groupDescriptors.filter(
+					({ coordinatorId, groupId }) =>
+						legacyTeamCandidateId(coordinatorId, groupId) === options.candidateRef,
 				)
-			: groupIds;
+			: groupDescriptors;
 		const groups = await dependencies.listGroups({
 			remoteUrl,
 			adminSecret: config.syncCoordinatorAdminSecret,
@@ -265,16 +391,21 @@ async function loadConfiguredLegacyTeamGroupSnapshotsWith(
 			timeoutS,
 		});
 		const groupById = new Map(groups.map((group) => [group.group_id, group]));
-		const snapshots = await Promise.all(
-			requestedGroupIds.map(async (groupId) => {
+		const outcomes = await Promise.all(
+			requestedGroupDescriptors.map(async ({ coordinatorId, groupId }) => {
+				// Authoritative absence is stale state, while malformed or unavailable
+				// evidence stays fail-closed. Summary mode may isolate the latter only
+				// when another requested group remains healthy.
 				const group = groupById.get(groupId);
+				if (!group || group.archived_at != null) {
+					return { kind: "absent" as const };
+				}
 				if (
-					!group ||
 					group.group_id !== groupId ||
-					(group.display_name !== null && typeof group.display_name !== "string") ||
-					group.archived_at != null
+					(group.display_name !== null && typeof group.display_name !== "string")
 				) {
-					throw safeCoordinatorError();
+					if (options.candidateRef) throw safeCoordinatorError();
+					return { kind: "unavailable" as const };
 				}
 				let devices: Awaited<ReturnType<typeof coordinatorListDevicesAction>>;
 				try {
@@ -286,15 +417,15 @@ async function loadConfiguredLegacyTeamGroupSnapshotsWith(
 						timeoutS,
 					});
 				} catch (error) {
+					if (!options.candidateRef) return { kind: "unavailable" as const };
 					if (isCoordinatorRosterTooLargeError(error)) {
-						if (options.candidateRef) throw new Error("legacy_team_setup_roster_too_large");
-						return null;
+						throw new Error("legacy_team_setup_roster_too_large");
 					}
-					throw error;
+					throw safeCoordinatorError();
 				}
 				if (devices.length > MAX_DEVICES) {
 					if (options.candidateRef) throw new Error("legacy_team_setup_roster_too_large");
-					return null;
+					return { kind: "unavailable" as const };
 				}
 				if (
 					devices.some(
@@ -303,35 +434,39 @@ async function loadConfiguredLegacyTeamGroupSnapshotsWith(
 							(device.enabled !== 0 && device.enabled !== 1),
 					)
 				) {
-					throw safeCoordinatorError();
+					if (options.candidateRef) throw safeCoordinatorError();
+					return { kind: "unavailable" as const };
 				}
 				return {
-					coordinatorId,
-					groupId,
-					displayName: group.display_name ?? "Legacy Team",
-					devices: devices.map((device) => ({
-						deviceId: device.device_id,
-						fingerprint: device.fingerprint,
-						displayName: device.display_name ?? "Device",
-						enabled: device.enabled === 1,
-						labelRedactionIds: [device.identity_id ?? "", device.public_key].filter(Boolean),
-					})),
+					kind: "snapshot" as const,
+					snapshot: {
+						coordinatorId,
+						groupId,
+						displayName: group.display_name ?? "Legacy Team",
+						devices: devices.map((device) => ({
+							deviceId: device.device_id,
+							fingerprint: device.fingerprint,
+							displayName: device.display_name ?? "Device",
+							enabled: device.enabled === 1,
+							labelRedactionIds: [device.identity_id ?? "", device.public_key].filter(Boolean),
+						})),
+					},
 				};
 			}),
 		);
-		return snapshots.filter((snapshot) => snapshot !== null);
+		const validSnapshots = outcomes.flatMap((outcome) =>
+			outcome.kind === "snapshot" ? [outcome.snapshot] : [],
+		);
+		if (validSnapshots.length === 0 && outcomes.some((outcome) => outcome.kind === "unavailable")) {
+			throw safeCoordinatorError();
+		}
+		return validSnapshots;
 	} catch (error) {
 		if (error instanceof Error && error.message === "legacy_team_setup_roster_too_large") {
 			throw error;
 		}
 		throw safeCoordinatorError();
 	}
-}
-
-export async function loadConfiguredLegacyTeamGroupSnapshots(
-	options: LegacyTeamConfiguredGroupSnapshotLoadOptions = {},
-): Promise<LegacyTeamConfiguredGroupSnapshot[]> {
-	return loadConfiguredLegacyTeamGroupSnapshotsWith(defaultSnapshotLoaderDependencies, options);
 }
 
 function requireBoundedSnapshots(groups: LegacyTeamConfiguredGroupSnapshot[]): void {
@@ -687,6 +822,7 @@ function createCachedSnapshotLoader(
 export const __teamSetupTestHooks = {
 	createCachedSnapshotLoader,
 	loadConfiguredLegacyTeamGroupSnapshotsWith,
+	normalizedCoordinatorId,
 	requireCompleteMappingChoices,
 	disambiguateChoiceLabels,
 	safeChoiceLabel,
@@ -965,7 +1101,13 @@ function finishResponse(
 export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 	const app = new Hono();
 	const loadSnapshots =
-		options.loadLegacyTeamConfiguredGroupSnapshots ?? loadConfiguredLegacyTeamGroupSnapshots;
+		options.loadLegacyTeamConfiguredGroupSnapshots ??
+		((loadOptions?: LegacyTeamConfiguredGroupSnapshotLoadOptions) =>
+			loadConfiguredLegacyTeamGroupSnapshotsWith(
+				options.snapshotLoaderDependencies ?? defaultSnapshotLoaderDependencies,
+				loadOptions,
+				options.getStore,
+			));
 
 	async function loadedSnapshots(
 		candidateRef?: string,


### PR DESCRIPTION
## Description
Preserve valid legacy Team display names during migration and isolate roster refresh failures so one unavailable group does not hide healthy Teams. Exact-Team activation remains fail-closed.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced