### PR TITLE
fix: make Sharing fallbacks privacy-safe

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -139,6 +139,7 @@ export {
 	loadSyncStatus,
 	mergeActor,
 	ProjectForgetConfirmationError,
+	ProjectInviteAcceptanceError,
 	previewDeviceIdentityBindings,
 	previewProjectInvite,
 	previewRecipientInvite,

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -18,6 +18,7 @@ import {
 	loadRecipientPolicyReview,
 	loadShareOperation,
 	loadShareOperations,
+	ProjectInviteAcceptanceError,
 	previewDeviceIdentityBindings,
 	previewRecipientInvite,
 	previewRecipientPolicyEdges,
@@ -97,6 +98,67 @@ afterEach(() => {
 });
 
 describe("recipient invitation API", () => {
+	it("preserves allowlisted Project invitation error codes without changing safe detail", async () => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						detail: "This invitation expired. Ask the owner to create a new invitation.",
+						error: "invite_expired",
+					}),
+					{ status: 400 },
+				),
+		) as typeof fetch;
+
+		const failure = await importCoordinatorInvite(
+			"expired-project-invite",
+			undefined,
+			"project_share_invite",
+		).catch((cause: unknown) => cause);
+
+		expect(failure).toBeInstanceOf(ProjectInviteAcceptanceError);
+		expect(failure).toMatchObject({
+			errorCode: "invite_expired",
+			message: "This invitation expired. Ask the owner to create a new invitation.",
+		});
+	});
+
+	it.each([
+		"team_member",
+		"add_device",
+	] as const)("does not classify %s failures as Project invitation failures", async (inviteKind) => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ error: "invite_identity_conflict" }), {
+					status: 409,
+				}),
+		) as typeof fetch;
+
+		const failure = await importCoordinatorInvite("recipient-invite", undefined, inviteKind).catch(
+			(cause: unknown) => cause,
+		);
+
+		expect(failure).toBeInstanceOf(Error);
+		expect(failure).not.toBeInstanceOf(ProjectInviteAcceptanceError);
+		expect(failure).toMatchObject({ message: "invite_identity_conflict" });
+	});
+
+	it("keeps unknown Project invitation errors untyped", async () => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ detail: "private backend detail", error: "private_code" }), {
+					status: 400,
+				}),
+		) as typeof fetch;
+
+		const failure = await importCoordinatorInvite("unknown-project-invite").catch(
+			(cause: unknown) => cause,
+		);
+
+		expect(failure).toBeInstanceOf(Error);
+		expect(failure).not.toBeInstanceOf(ProjectInviteAcceptanceError);
+	});
+
 	it("prefers actionable invite-import detail over an opaque error code", async () => {
 		globalThis.fetch = vi.fn(
 			async () =>

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -89,6 +89,35 @@ type CoordinatorInviteIdentity =
 			reviewed_onboarding_digest: string;
 	  };
 
+const PROJECT_INVITE_ACCEPTANCE_ERROR_CODES = new Set([
+	"device_display_name_invalid",
+	"device_display_name_required",
+	"device_display_name_too_long",
+	"invite_already_bound",
+	"invite_expired",
+	"invite_identity_conflict",
+	"invite_invalid",
+	"inviter_identity_invalid",
+	"project_invite_acceptance_failed",
+	"project_invite_bootstrap_incomplete",
+	"project_invite_self_acceptance_forbidden",
+	"project_invite_trust_state_invalid",
+	"project_sync_enablement_failed",
+	"recipient_display_name_invalid",
+	"recipient_display_name_required",
+	"recipient_display_name_too_long",
+]);
+
+export class ProjectInviteAcceptanceError extends Error {
+	constructor(
+		message: string,
+		readonly errorCode: string,
+	) {
+		super(message);
+		this.name = "ProjectInviteAcceptanceError";
+	}
+}
+
 type TriggerSyncTarget = {
 	address?: string;
 	peerDeviceId?: string;
@@ -110,6 +139,7 @@ export async function loadSyncStatus(
 export async function importCoordinatorInvite(
 	invite: string,
 	identity?: CoordinatorInviteIdentity,
+	inviteKind?: InspectInviteResult["kind"],
 ): Promise<ImportInviteResult> {
 	const resp = await fetch("/api/sync/invites/import", {
 		method: "POST",
@@ -119,7 +149,16 @@ export async function importCoordinatorInvite(
 	const { text, payload: data } = await readJsonPayload<ImportInviteResult>(resp);
 	if (!resp.ok) {
 		const detail = typeof data?.detail === "string" ? data.detail.trim() : "";
-		throw new Error(detail || payloadError(data) || text || "request failed");
+		const errorCode = payloadError(data);
+		const message = detail || errorCode || text || "request failed";
+		if (
+			inviteKind === "project_share_invite" &&
+			errorCode &&
+			PROJECT_INVITE_ACCEPTANCE_ERROR_CODES.has(errorCode)
+		) {
+			throw new ProjectInviteAcceptanceError(message, errorCode);
+		}
+		throw new Error(message);
 	}
 	return data;
 }

--- a/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
@@ -4,6 +4,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const dialogSpy = vi.hoisted(() => vi.fn());
 const openProjectShare = vi.hoisted(() => vi.fn());
+const MockProjectInviteAcceptanceError = vi.hoisted(
+	() =>
+		class ProjectInviteAcceptanceError extends Error {
+			constructor(
+				message: string,
+				readonly errorCode: string,
+			) {
+				super(message);
+			}
+		},
+);
 
 vi.mock("../components/primitives/radix-dialog", () => ({
 	RadixDialog: (props: {
@@ -30,10 +41,12 @@ vi.mock("../components/primitives/radix-dialog", () => ({
 	},
 }));
 
-vi.mock("../lib/api", () => ({
+vi.mock("../lib/api", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/api")>()),
 	createRecipientInvite: vi.fn(),
 	importCoordinatorInvite: vi.fn(),
 	inspectCoordinatorInvite: vi.fn(),
+	ProjectInviteAcceptanceError: MockProjectInviteAcceptanceError,
 	previewRecipientInvite: vi.fn(),
 }));
 
@@ -231,10 +244,14 @@ describe("recipient-policy invitations", () => {
 
 		act(() => button("Accept invitation", dialog).click());
 		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
-		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("recipient-invite", {
-			device_name: "Travel Laptop",
-			reviewed_onboarding_digest: addDevicePreview.reviewedOnboardingDigest,
-		});
+		expect(api.importCoordinatorInvite).toHaveBeenCalledWith(
+			"recipient-invite",
+			{
+				device_name: "Travel Laptop",
+				reviewed_onboarding_digest: addDevicePreview.reviewedOnboardingDigest,
+			},
+			"add_device",
+		);
 		await vi.waitFor(() => expect(dialog.textContent).toContain("Device added"));
 		expect(dialog.textContent).toContain(
 			"Existing shared Projects do not sync to this device until",
@@ -311,11 +328,15 @@ describe("recipient-policy invitations", () => {
 		});
 
 		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
-		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("team-member-invite", {
-			recipient_name: "Local Identity",
-			device_name: "Work Laptop",
-			reviewed_onboarding_digest: teamPreview.reviewedOnboardingDigest,
-		});
+		expect(api.importCoordinatorInvite).toHaveBeenCalledWith(
+			"team-member-invite",
+			{
+				recipient_name: "Local Identity",
+				device_name: "Work Laptop",
+				reviewed_onboarding_digest: teamPreview.reviewedOnboardingDigest,
+			},
+			"team_member",
+		);
 		await vi.waitFor(() => expect(dialog.textContent).toContain("Team invitation accepted"));
 		expect(dialog.textContent).not.toContain("Project setup is pending");
 		const result = dialog.querySelector("#recipient-invitation-result");
@@ -372,11 +393,15 @@ describe("recipient-policy invitations", () => {
 		expect(button("Accept invitation", dialog).disabled).toBe(false);
 		act(() => button("Accept invitation", dialog).click());
 		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
-		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("team-member-invite", {
-			recipient_name: "Fresh Recipient",
-			device_name: "Work Laptop",
-			reviewed_onboarding_digest: teamPreview.reviewedOnboardingDigest,
-		});
+		expect(api.importCoordinatorInvite).toHaveBeenCalledWith(
+			"team-member-invite",
+			{
+				recipient_name: "Fresh Recipient",
+				device_name: "Work Laptop",
+				reviewed_onboarding_digest: teamPreview.reviewedOnboardingDigest,
+			},
+			"team_member",
+		);
 	});
 
 	it("surfaces restart guidance when Team acceptance enables sync", async () => {
@@ -391,7 +416,7 @@ describe("recipient-policy invitations", () => {
 			setup_state: "restart_required",
 			restart_required: true,
 			sync_enabled: true,
-			detail: "Restart codemem to start receiving the reviewed Projects.",
+			detail: "Restart after checking /Users/private-user/secret-project.",
 		});
 		mount();
 		act(() => button("Review invitation").click());
@@ -407,10 +432,9 @@ describe("recipient-policy invitations", () => {
 		act(() => button("Accept invitation", dialog).click());
 
 		await vi.waitFor(() =>
-			expect(dialog.textContent).toContain(
-				"Restart codemem to start receiving the reviewed Projects.",
-			),
+			expect(dialog.textContent).toContain("Restart codemem to finish joining this Team."),
 		);
+		expect(dialog.outerHTML).not.toContain("/Users/private-user/secret-project");
 		const result = dialog.querySelector<HTMLElement>("#recipient-invitation-result");
 		if (!result) throw new Error("Team restart completion missing");
 		expect(result.classList.contains("recipient-policy-invitation-result")).toBe(true);
@@ -548,10 +572,14 @@ describe("recipient-policy invitations", () => {
 		accept.focus();
 		act(() => accept.click());
 		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
-		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("project-invite-payload", {
-			recipient_name: "Reviewed Brian",
-			device_name: "Reviewed Mac",
-		});
+		expect(api.importCoordinatorInvite).toHaveBeenCalledWith(
+			"project-invite-payload",
+			{
+				recipient_name: "Reviewed Brian",
+				device_name: "Reviewed Mac",
+			},
+			"project_share_invite",
+		);
 		await vi.waitFor(() =>
 			expect(document.activeElement).toBe(
 				document.getElementById("project-share-invitation-result"),
@@ -817,7 +845,7 @@ describe("recipient-policy invitations", () => {
 			type: "recipient_onboarding",
 			setup_state: "restart_required",
 			restart_required: true,
-			detail: "Restart codemem before continuing with the adopted Identity.",
+			detail: "Restart after contacting private.example.test.",
 		});
 		mount();
 		act(() => button("Review invitation").click());
@@ -833,10 +861,9 @@ describe("recipient-policy invitations", () => {
 		act(() => button("Accept invitation", dialog).click());
 
 		await vi.waitFor(() =>
-			expect(dialog.textContent).toContain(
-				"Restart codemem before continuing with the adopted Identity.",
-			),
+			expect(dialog.textContent).toContain("Restart codemem to finish adding this device."),
 		);
+		expect(dialog.outerHTML).not.toContain("private.example.test");
 		expect(dialog.textContent).not.toContain("Device added.");
 		expect(dialog.querySelector("#recipient-invitation-result")).toBe(document.activeElement);
 		expect(() => button("Accept invitation", dialog)).toThrow("button missing");
@@ -878,10 +905,14 @@ describe("recipient-policy invitations", () => {
 		act(() => button("Accept Project access", dialog).click());
 
 		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
-		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("project-without-names", {
-			recipient_name: "Reviewed recipient",
-			device_name: "Reviewed device",
-		});
+		expect(api.importCoordinatorInvite).toHaveBeenCalledWith(
+			"project-without-names",
+			{
+				recipient_name: "Reviewed recipient",
+				device_name: "Reviewed device",
+			},
+			"project_share_invite",
+		);
 		await vi.waitFor(() =>
 			expect(dialog.textContent).toContain("Project setup status could not be confirmed"),
 		);
@@ -889,9 +920,11 @@ describe("recipient-policy invitations", () => {
 	});
 
 	it("keeps the reviewed Project payload available for retry after an acceptance error", async () => {
+		const hostileError =
+			'Backend failure at /Users/private-user/work/secret-client for ssh://git@private.example.test/secret/client.git (identity_opaque_private_52de04) <img src=x onerror="alert(1)">';
 		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue(projectShareInspection);
 		vi.mocked(api.importCoordinatorInvite)
-			.mockRejectedValueOnce(new Error("Ask the owner for a new invitation, then try again."))
+			.mockRejectedValueOnce(new Error(hostileError))
 			.mockResolvedValueOnce({
 				status: "pending_setup",
 				setup_state: "pending_inviter",
@@ -912,17 +945,66 @@ describe("recipient-policy invitations", () => {
 		act(() => button("Accept Project access", dialog).click());
 		await vi.waitFor(() =>
 			expect(dialog.querySelector('[role="alert"]')?.textContent).toContain(
-				"Ask the owner for a new invitation, then try again.",
+				"Unable to accept this Project invitation. Ask the owner to create a new invitation, then try again.",
 			),
 		);
+		expect(dialog.textContent).not.toContain(hostileError);
+		expect(dialog.outerHTML).not.toContain("/Users/private-user/work/secret-client");
+		expect(dialog.outerHTML).not.toContain("private.example.test");
+		expect(dialog.outerHTML).not.toContain("identity_opaque_private_52de04");
+		expect(dialog.querySelector("img")).toBeNull();
 		expect(dialog.textContent).toContain("Codemem — 41 existing memories");
 		expect(button("Accept Project access", dialog).disabled).toBe(false);
 		act(() => button("Accept Project access", dialog).click());
 		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledTimes(2));
-		expect(api.importCoordinatorInvite).toHaveBeenNthCalledWith(2, "retry-project-invite", {
-			recipient_name: "Brian",
-			device_name: "Brian’s Mac",
+		expect(api.importCoordinatorInvite).toHaveBeenNthCalledWith(
+			2,
+			"retry-project-invite",
+			{
+				recipient_name: "Brian",
+				device_name: "Brian’s Mac",
+			},
+			"project_share_invite",
+		);
+	});
+
+	it.each([
+		["invite_expired", "This invitation expired. Ask the owner to create a new invitation."],
+		[
+			"project_invite_self_acceptance_forbidden",
+			"The owner cannot accept this recipient invitation on the owner's device.",
+		],
+		[
+			"device_display_name_invalid",
+			"Enter a human-readable device name instead of an internal identifier.",
+		],
+		[
+			"project_sync_enablement_failed",
+			"The invitation was accepted, but Project setup could not be enabled because the codemem config is not writable. Make the config writable, then check Sync to finish setup.",
+		],
+	] as const)("shows safe Project invitation guidance for %s", async (code, guidance) => {
+		const hostileError = `private backend detail for ${code}`;
+		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue(projectShareInspection);
+		vi.mocked(api.importCoordinatorInvite).mockRejectedValue(
+			new api.ProjectInviteAcceptanceError(hostileError, code),
+		);
+		mount();
+		act(() => button("Review invitation").click());
+		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+		const dialog = document.querySelector('[role="dialog"]');
+		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+		act(() => {
+			textarea.value = "project-invite";
+			textarea.dispatchEvent(new Event("input", { bubbles: true }));
 		});
+		act(() => button("Review invitation", dialog).click());
+		await vi.waitFor(() => expect(dialog.textContent).toContain("Exact Projects shared directly"));
+		act(() => button("Accept Project access", dialog).click());
+
+		await vi.waitFor(() =>
+			expect(dialog.querySelector('[role="alert"]')?.textContent).toContain(guidance),
+		);
+		expect(dialog.textContent).not.toContain(hostileError);
 	});
 
 	it("shows loading, error, and empty states without exposing internal language", async () => {

--- a/packages/ui/src/tabs/recipient-policy-invitations.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.tsx
@@ -68,6 +68,38 @@ function normalizeProjectShareAcceptance(result: ImportInviteResult): ProjectSha
 
 function errorMessage(cause: unknown, fallback: string): string {
 	if (!(cause instanceof Error)) return fallback;
+	if (cause instanceof api.ProjectInviteAcceptanceError) {
+		const guidance: Record<string, string> = {
+			device_display_name_invalid:
+				"Enter a human-readable device name instead of an internal identifier.",
+			device_display_name_required: "Enter a device display name.",
+			device_display_name_too_long: "Use a device display name with 120 characters or fewer.",
+			invite_already_bound:
+				"This invitation was accepted by another device. Ask the owner to create a new invitation.",
+			invite_expired: "This invitation expired. Ask the owner to create a new invitation.",
+			invite_identity_conflict:
+				"This invitation does not match this Identity. Ask the owner to create a new invitation for this recipient.",
+			invite_invalid:
+				"This invitation is no longer valid. Ask the owner to create a new invitation.",
+			inviter_identity_invalid:
+				"The owner's device identity could not be verified. Ask the owner to review the share and create a new invitation.",
+			project_invite_acceptance_failed:
+				"The invitation could not be accepted safely. Retry once, then ask the owner to review the share.",
+			project_invite_bootstrap_incomplete:
+				"The owner's device is not ready to establish trust yet. Retry once, then ask the owner to review the share.",
+			project_invite_self_acceptance_forbidden:
+				"The owner cannot accept this recipient invitation on the owner's device.",
+			project_invite_trust_state_invalid:
+				"The owner's trust setup could not be verified. Ask the owner to review the share.",
+			project_sync_enablement_failed:
+				"The invitation was accepted, but Project setup could not be enabled because the codemem config is not writable. Make the config writable, then check Sync to finish setup.",
+			recipient_display_name_invalid:
+				"Enter a human-readable Identity name instead of an internal identifier.",
+			recipient_display_name_required: "Enter an Identity display name.",
+			recipient_display_name_too_long: "Use an Identity display name with 120 characters or fewer.",
+		};
+		return guidance[cause.errorCode] ?? fallback;
+	}
 	if (cause.message === "reviewed_onboarding_stale") {
 		return "Invitation details changed. Review them again before creating it.";
 	}
@@ -577,15 +609,25 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 		try {
 			const result =
 				inspected.kind === "project_share_invite"
-					? await api.importCoordinatorInvite(invite.trim(), {
-							recipient_name: projectRecipientName.trim(),
-							device_name: projectDeviceName.trim(),
-						})
-					: await api.importCoordinatorInvite(invite.trim(), {
-							...(inspected.kind === "team_member" ? { recipient_name: recipientName.trim() } : {}),
-							device_name: inspected.device_name,
-							reviewed_onboarding_digest: inspected.onboarding.reviewedOnboardingDigest,
-						});
+					? await api.importCoordinatorInvite(
+							invite.trim(),
+							{
+								recipient_name: projectRecipientName.trim(),
+								device_name: projectDeviceName.trim(),
+							},
+							inspected.kind,
+						)
+					: await api.importCoordinatorInvite(
+							invite.trim(),
+							{
+								...(inspected.kind === "team_member"
+									? { recipient_name: recipientName.trim() }
+									: {}),
+								device_name: inspected.device_name,
+								reviewed_onboarding_digest: inspected.onboarding.reviewedOnboardingDigest,
+							},
+							inspected.kind,
+						);
 			if (inspected.kind === "project_share_invite") {
 				setProjectAcceptance(normalizeProjectShareAcceptance(result));
 				setStatus("");
@@ -593,11 +635,13 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 				const acceptedKind = inspected.kind;
 				const restartRequired =
 					result.restart_required === true || result.setup_state === "restart_required";
-				const detail = typeof result.detail === "string" ? result.detail.trim() : "";
 				setRecipientAcceptance({
 					kind: acceptedKind,
 					restartRequired,
-					detail: detail || "Restart codemem before continuing.",
+					detail:
+						acceptedKind === "team_member"
+							? "Restart codemem to finish joining this Team."
+							: "Restart codemem to finish adding this device.",
 					deliveryPending:
 						acceptedKind === "add_device" && (inspected.onboarding?.projects?.length ?? 0) > 0,
 				});
@@ -605,10 +649,9 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 			}
 		} catch (cause) {
 			accepting.current = false;
-			const detail = cause instanceof Error ? cause.message.trim() : "";
 			const fallback =
-				inspected.kind === "project_share_invite" && detail
-					? detail
+				inspected.kind === "project_share_invite"
+					? "Unable to accept this Project invitation. Ask the owner to create a new invitation, then try again."
 					: "Unable to accept this invitation.";
 			setError(errorMessage(cause, fallback));
 			setStatus("");

--- a/packages/ui/src/tabs/recipient-policy-management.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-management.test.tsx
@@ -447,8 +447,9 @@ describe("recipient policy management dialog", () => {
 		expect(document.body.textContent).toContain("Archived Team — Removing access · Team");
 		expect(document.body.textContent).toContain("Merged recipient — Removing access · Identity");
 		expect(document.body.textContent).toContain(
-			"identity-deactivated — Removing access · Identity",
+			"Unavailable Identity — Removing access · Identity",
 		);
+		expect(document.body.outerHTML).not.toContain("identity-deactivated");
 
 		expect(api.previewRecipientPolicyEdges).toHaveBeenCalledWith({
 			version: 1,
@@ -539,22 +540,75 @@ describe("recipient policy management dialog", () => {
 		expect(document.body.textContent).toContain("Adam — Mixed changes · Identity");
 	});
 
-	it("recipient-manage exposes stale active Projects only so they can be removed", async () => {
+	it("keeps unavailable private Projects generic while allowing their access to be removed", async () => {
+		const privatePath = "/Users/private-user/work/secret-client";
+		const privateRemote = "ssh://git@private.example.test/secret/client.git";
+		vi.mocked(api.previewRecipientPolicyEdges).mockImplementationOnce(async (request) => ({
+			...preview(request.changes),
+			projects: [privatePath, privateRemote].map((canonicalProjectIdentity) => ({
+				canonicalProjectIdentity,
+				displayName: canonicalProjectIdentity,
+				existingMemoryCount: 0,
+				futureMemoriesShared: true as const,
+			})),
+			selectedRecipients: [
+				{
+					recipientKind: "identity" as const,
+					identityId: "identity-adam",
+					displayName: "Adam",
+					verification: "local" as const,
+				},
+			],
+		}));
+		vi.mocked(api.commitRecipientPolicyEdges).mockImplementationOnce(async (request) => ({
+			version: 1,
+			status: "applied",
+			reviewedPolicyDigest: request.reviewedPolicyDigest,
+			errorCode: null,
+			outcomes: request.changes.map((change) => ({ change, outcome: "removed" as const })),
+			writeCount: request.changes.length,
+			idempotent: false,
+		}));
+		const onCommitted = vi.fn(async () => {
+			mount(intent(), { onCommitted }, [
+				...projects,
+				{
+					canonicalProjectIdentity: privatePath,
+					displayName: "Recovered Project A",
+					existingMemoryCount: 0,
+				},
+				{
+					canonicalProjectIdentity: privateRemote,
+					displayName: "Recovered Project B",
+					existingMemoryCount: 0,
+				},
+			]);
+		});
 		mount(
 			intent({
 				projectRecipients: [
 					...intent().projectRecipients,
 					{
 						version: 1,
-						canonicalProjectIdentity: "git:removed",
+						canonicalProjectIdentity: privatePath,
 						recipientKind: "identity",
 						identityId: "identity-adam",
 						intentSource: "user",
-						policyRevision: "revision-stale-project",
+						policyRevision: "revision-stale-path",
+						status: "active",
+					},
+					{
+						version: 1,
+						canonicalProjectIdentity: privateRemote,
+						recipientKind: "identity",
+						identityId: "identity-adam",
+						intentSource: "user",
+						policyRevision: "revision-stale-remote",
 						status: "active",
 					},
 				],
 			}),
+			{ onCommitted },
 		);
 		act(() => {
 			openRecipientPolicyManagement({
@@ -563,22 +617,50 @@ describe("recipient policy management dialog", () => {
 			});
 		});
 
-		expect(checkbox("git:removed").checked).toBe(true);
-		expect(document.body.textContent).toContain(
-			"Unavailable Project · existing access can only be removed",
+		const unavailableProjects = [...document.querySelectorAll<HTMLLabelElement>("label")].filter(
+			(label) => label.querySelector("strong")?.textContent?.startsWith("Unavailable Project"),
 		);
-		act(() => checkbox("git:removed").click());
+		expect(unavailableProjects).toHaveLength(2);
+		expect(unavailableProjects.map((label) => label.querySelector("strong")?.textContent)).toEqual([
+			"Unavailable Project 1 of 2",
+			"Unavailable Project 2 of 2",
+		]);
+		expect(document.body.textContent).toContain(
+			"Unavailable Project 1 of 2 · existing access can only be removed",
+		);
+		expect(document.body.outerHTML).not.toContain(privatePath);
+		expect(document.body.outerHTML).not.toContain(privateRemote);
+		act(() => {
+			for (const label of unavailableProjects) {
+				label.querySelector<HTMLInputElement>('input[type="checkbox"]')?.click();
+			}
+		});
 		await reviewSelection();
+		expect(document.body.textContent).toContain("Unavailable Project 1 of 2");
+		expect(document.body.textContent).toContain("Unavailable Project 2 of 2");
+		expect(document.body.outerHTML).not.toContain(privatePath);
+		expect(document.body.outerHTML).not.toContain(privateRemote);
 		expect(api.previewRecipientPolicyEdges).toHaveBeenCalledWith({
 			version: 1,
 			changes: [
 				{
-					canonicalProjectIdentity: "git:removed",
+					canonicalProjectIdentity: privatePath,
+					recipient: { recipientKind: "identity", identityId: "identity-adam" },
+					action: "remove",
+				},
+				{
+					canonicalProjectIdentity: privateRemote,
 					recipient: { recipientKind: "identity", identityId: "identity-adam" },
 					action: "remove",
 				},
 			],
 		});
+		await confirmChanges();
+		expect(onCommitted).toHaveBeenCalledOnce();
+		expect(document.body.textContent).toContain("Unavailable Project 1 of 2");
+		expect(document.body.textContent).toContain("Unavailable Project 2 of 2");
+		expect(document.body.outerHTML).not.toContain(privatePath);
+		expect(document.body.outerHTML).not.toContain(privateRemote);
 
 		act(() => {
 			openRecipientPolicyManagement({
@@ -586,7 +668,86 @@ describe("recipient policy management dialog", () => {
 				recipient: { recipientKind: "identity", identityId: "identity-adam" },
 			});
 		});
-		expect(document.body.textContent).not.toContain("git:removed");
+		expect(document.body.outerHTML).not.toContain(privatePath);
+		expect(document.body.outerHTML).not.toContain(privateRemote);
+	});
+
+	it("keeps reviewed aliases after committed recipients disappear from refreshed intent", async () => {
+		const opaqueTeamIds = ["team_opaque_private_7ca891", "team_opaque_private_8db902"];
+		const opaqueIdentityIds = ["identity_opaque_private_52de04", "identity_opaque_private_63ef15"];
+		const base = intent();
+		const graph = intent({
+			projectRecipients: [
+				...base.projectRecipients,
+				...opaqueTeamIds.map((teamId, index) => ({
+					version: 1 as const,
+					canonicalProjectIdentity: "git:codemem",
+					recipientKind: "team" as const,
+					teamId,
+					intentSource: "user" as const,
+					policyRevision: `revision-opaque-team-${index}`,
+					status: "active" as const,
+				})),
+				...opaqueIdentityIds.map((identityId, index) => ({
+					version: 1 as const,
+					canonicalProjectIdentity: "git:codemem",
+					recipientKind: "identity" as const,
+					identityId,
+					intentSource: "user" as const,
+					policyRevision: `revision-opaque-identity-${index}`,
+					status: "active" as const,
+				})),
+			],
+		});
+		vi.mocked(api.commitRecipientPolicyEdges).mockImplementationOnce(async (request) => ({
+			version: 1,
+			status: "applied",
+			reviewedPolicyDigest: request.reviewedPolicyDigest,
+			errorCode: null,
+			outcomes: request.changes.map((change) => ({ change, outcome: "removed" as const })),
+			writeCount: request.changes.length,
+			idempotent: false,
+		}));
+		const onCommitted = vi.fn(async () => {
+			mount(base, { onCommitted });
+		});
+		mount(graph, { onCommitted });
+		act(() => {
+			openRecipientPolicyManagement({ mode: "project-manage", projectId: "git:codemem" });
+		});
+		act(() => {
+			checkbox("Unavailable Team 1 of 2").click();
+			checkbox("Unavailable Team 2 of 2").click();
+			checkbox("Unavailable Identity 1 of 2").click();
+			checkbox("Unavailable Identity 2 of 2").click();
+		});
+		await reviewSelection();
+
+		for (const label of [
+			"Unavailable Team 1 of 2",
+			"Unavailable Team 2 of 2",
+			"Unavailable Identity 1 of 2",
+			"Unavailable Identity 2 of 2",
+		]) {
+			expect(document.body.textContent).toContain(`${label} — Removing access`);
+		}
+		for (const opaqueId of [...opaqueTeamIds, ...opaqueIdentityIds]) {
+			expect(document.body.outerHTML).not.toContain(opaqueId);
+		}
+
+		await confirmChanges();
+		expect(onCommitted).toHaveBeenCalledOnce();
+		for (const label of [
+			"Unavailable Team 1 of 2",
+			"Unavailable Team 2 of 2",
+			"Unavailable Identity 1 of 2",
+			"Unavailable Identity 2 of 2",
+		]) {
+			expect(document.body.textContent).toContain(`Remove ${label} from Codemem: removed`);
+		}
+		for (const opaqueId of [...opaqueTeamIds, ...opaqueIdentityIds]) {
+			expect(document.body.outerHTML).not.toContain(opaqueId);
+		}
 	});
 
 	it("recipient-add offers only additional Projects and cannot emit removals", async () => {

--- a/packages/ui/src/tabs/recipient-policy-management.tsx
+++ b/packages/ui/src/tabs/recipient-policy-management.tsx
@@ -82,6 +82,55 @@ function sameRecipient(
 	return edgeRecipientKey(edge) === recipientKey(recipient);
 }
 
+function ordinalLabels(keys: readonly string[], label: string): ReadonlyMap<string, string> {
+	const sorted = [...new Set(keys)].sort((left, right) =>
+		left < right ? -1 : left > right ? 1 : 0,
+	);
+	return new Map(
+		sorted.map((key, index) => [
+			key,
+			sorted.length === 1 ? label : `${label} ${index + 1} of ${sorted.length}`,
+		]),
+	);
+}
+
+function unavailableRecipientLabels(
+	intent: RecipientPolicyIntentGraphV1,
+	request: RecipientPolicyManagementRequest | null,
+): ReadonlyMap<string, string> {
+	if (request?.mode !== "project-manage") return new Map();
+	const knownTeamIds = new Set(intent.teams.map((team) => team.teamId));
+	const knownIdentityIds = new Set(intent.identities.map((identity) => identity.identityId));
+	const activeEdges = intent.projectRecipients.filter(
+		(edge) => edge.status === "active" && edge.canonicalProjectIdentity === request.projectId,
+	);
+	const missingTeams = activeEdges.flatMap((edge) =>
+		edge.recipientKind === "team" && !knownTeamIds.has(edge.teamId) ? [edgeRecipientKey(edge)] : [],
+	);
+	const missingIdentities = activeEdges.flatMap((edge) =>
+		edge.recipientKind === "identity" && !knownIdentityIds.has(edge.identityId)
+			? [edgeRecipientKey(edge)]
+			: [],
+	);
+	return new Map([
+		...ordinalLabels(missingTeams, "Unavailable Team"),
+		...ordinalLabels(missingIdentities, "Unavailable Identity"),
+	]);
+}
+
+function unavailableProjectLabels(
+	projects: readonly RecipientPolicyManagementProject[],
+	request: RecipientPolicyManagementRequest | null,
+	initial: readonly string[],
+): ReadonlyMap<string, string> {
+	if (request?.mode !== "recipient-manage") return new Map();
+	const visibleProjectIds = new Set(projects.map((project) => project.canonicalProjectIdentity));
+	return ordinalLabels(
+		initial.filter((canonicalProjectIdentity) => !visibleProjectIds.has(canonicalProjectIdentity)),
+		"Unavailable Project",
+	);
+}
+
 function safeError(cause: unknown, fallback: string): string {
 	if (cause instanceof api.RecipientPolicyEdgesStaleError) {
 		return "Recipient access changed after this review. Review the refreshed changes before trying again.";
@@ -120,6 +169,7 @@ function Choice({
 function recipientChoices(
 	intent: RecipientPolicyIntentGraphV1,
 	request: RecipientPolicyManagementRequest | null,
+	unavailableLabels: ReadonlyMap<string, string>,
 ) {
 	const activeMemberships = intent.teamMemberships.filter((item) => item.status === "active");
 	const identitiesById = new Map(
@@ -155,17 +205,19 @@ function recipientChoices(
 		if (choiceKeys.has(key)) continue;
 		if (edge.recipientKind === "team") {
 			const team = intent.teams.find((candidate) => candidate.teamId === edge.teamId);
+			const unavailableLabel = unavailableLabels.get(key) ?? "Unavailable Team";
 			choices.push({
 				key,
-				label: team?.displayName ?? "Unavailable Team",
-				description: `${team?.status === "archived" ? "Archived Team" : "Unavailable Team"} · existing access can only be removed`,
+				label: team?.displayName ?? unavailableLabel,
+				description: `${team?.status === "archived" ? "Archived Team" : unavailableLabel} · existing access can only be removed`,
 			});
 		} else {
 			const identity = identitiesById.get(edge.identityId);
+			const unavailableLabel = unavailableLabels.get(key) ?? "Unavailable Identity";
 			choices.push({
 				key,
-				label: identity?.displayName ?? "Unavailable Identity",
-				description: `${identity?.status === "merged" ? "Merged Identity" : "Unavailable Identity"} · existing access can only be removed`,
+				label: identity?.displayName ?? unavailableLabel,
+				description: `${identity?.status === "merged" ? "Merged Identity" : unavailableLabel} · existing access can only be removed`,
 			});
 		}
 		choiceKeys.add(key);
@@ -199,6 +251,7 @@ function projectChoices(
 	projects: RecipientPolicyManagementProject[],
 	request: RecipientPolicyManagementRequest,
 	initial: string[],
+	unavailableLabels: ReadonlyMap<string, string>,
 ): Array<RecipientPolicyManagementProject & { description: string }> {
 	const visibleProjects =
 		request.mode === "recipient-add"
@@ -212,13 +265,16 @@ function projectChoices(
 	const visibleProjectIds = new Set(
 		visibleProjects.map((project) => project.canonicalProjectIdentity),
 	);
-	for (const canonicalProjectIdentity of initial) {
-		if (visibleProjectIds.has(canonicalProjectIdentity)) continue;
+	const unavailableProjectIds = initial.filter(
+		(canonicalProjectIdentity) => !visibleProjectIds.has(canonicalProjectIdentity),
+	);
+	for (const canonicalProjectIdentity of unavailableProjectIds) {
+		const label = unavailableLabels.get(canonicalProjectIdentity) ?? "Unavailable Project";
 		choices.push({
 			canonicalProjectIdentity,
-			displayName: canonicalProjectIdentity,
+			displayName: label,
 			existingMemoryCount: 0,
-			description: "Unavailable Project · existing access can only be removed",
+			description: `${label} · existing access can only be removed`,
 		});
 	}
 	return choices;
@@ -358,11 +414,24 @@ function deduplicateEffectiveDevices(
 	});
 }
 
+function previewProjectLabel(
+	project: RecipientPolicyEdgePreviewResponseV1["projects"][number],
+	projectLabels: ReadonlyMap<string, string>,
+): string {
+	const localLabel = projectLabels.get(project.canonicalProjectIdentity);
+	if (localLabel) return localLabel;
+	return project.displayName !== project.canonicalProjectIdentity
+		? project.displayName
+		: "Unavailable Project";
+}
+
 function Review({
 	preview,
+	projectLabels,
 	recipientLabels,
 }: {
 	preview: RecipientPolicyEdgePreviewResponseV1;
+	projectLabels: ReadonlyMap<string, string>;
 	recipientLabels: ReadonlyMap<string, string>;
 }) {
 	const effectiveDevices = deduplicateEffectiveDevices(preview.effectiveDevices);
@@ -374,7 +443,9 @@ function Review({
 				<ul>
 					{preview.projects.map((project) => (
 						<li key={project.canonicalProjectIdentity}>
-							<strong className="recipient-policy-management-name">{project.displayName}</strong>
+							<strong className="recipient-policy-management-name">
+								{previewProjectLabel(project, projectLabels)}
+							</strong>
 							<span>
 								{" "}
 								— Access changes affect {project.existingMemoryCount.toLocaleString()} existing
@@ -418,7 +489,9 @@ function Review({
 						<li key={recipientKey(recipient)}>
 							<strong className="recipient-policy-management-name">
 								{recipientLabels.get(recipientKey(recipient)) ??
-									(recipient.recipientKind === "team" ? recipient.teamId : recipient.identityId)}
+									(recipient.recipientKind === "team"
+										? "Unavailable Team"
+										: "Unavailable Identity")}
 							</strong>{" "}
 							<span>
 								— {recipientActionLabel(preview.outcomes, recipient)} ·{" "}
@@ -472,7 +545,7 @@ function Review({
 									className="recipient-policy-management-name"
 									key={project.canonicalProjectIdentity}
 								>
-									{project.displayName}
+									{previewProjectLabel(project, projectLabels)}
 								</li>
 							))}
 						</ul>
@@ -485,9 +558,13 @@ function Review({
 
 function CommitResult({
 	preview,
+	projectLabels,
+	recipientLabels,
 	result,
 }: {
 	preview: RecipientPolicyEdgePreviewResponseV1;
+	projectLabels: ReadonlyMap<string, string>;
+	recipientLabels: ReadonlyMap<string, string>;
 	result: RecipientPolicyEdgeCommitResultV1;
 }) {
 	const technicalStatus =
@@ -507,15 +584,19 @@ function CommitResult({
 				{result.outcomes.length ? (
 					<ul>
 						{result.outcomes.map((item) => {
-							const projectName =
-								preview.projects.find(
-									(project) =>
-										project.canonicalProjectIdentity === item.change.canonicalProjectIdentity,
-								)?.displayName ?? "Selected Project";
+							const previewProject = preview.projects.find(
+								(project) =>
+									project.canonicalProjectIdentity === item.change.canonicalProjectIdentity,
+							);
+							const projectName = previewProject
+								? previewProjectLabel(previewProject, projectLabels)
+								: (projectLabels.get(item.change.canonicalProjectIdentity) ??
+									"Unavailable Project");
 							const recipientName =
 								preview.selectedRecipients.find(
 									(recipient) => recipientKey(recipient) === recipientKey(item.change.recipient),
 								)?.displayName ??
+								recipientLabels.get(recipientKey(item.change.recipient)) ??
 								(item.change.recipient.recipientKind === "team" ? "Team" : "Identity");
 							return (
 								<li
@@ -544,7 +625,16 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 	const [status, setStatus] = useState("");
 	const [busy, setBusy] = useState(false);
 	const submitting = useRef(false);
-	const choices = useMemo(() => recipientChoices(intent, request), [intent, request]);
+	const reviewedRecipientLabels = useRef<ReadonlyMap<string, string>>(new Map());
+	const reviewedProjectLabels = useRef<ReadonlyMap<string, string>>(new Map());
+	const unavailableRecipients = useMemo(
+		() => unavailableRecipientLabels(intent, request),
+		[intent, request],
+	);
+	const choices = useMemo(
+		() => recipientChoices(intent, request, unavailableRecipients),
+		[intent, request, unavailableRecipients],
+	);
 	const recipientLabels = useMemo(
 		() =>
 			new Map([
@@ -552,9 +642,15 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 				...intent.identities.map(
 					(identity) => [`identity:${identity.identityId}`, identity.displayName] as const,
 				),
+				...unavailableRecipients,
 			]),
-		[intent],
+		[intent, unavailableRecipients],
 	);
+	const unavailableProjects = useMemo(
+		() => unavailableProjectLabels(projects, request, initial),
+		[initial, projects, request],
+	);
+	const projectLabels = useMemo(() => new Map(unavailableProjects), [unavailableProjects]);
 	const projectIds = useMemo(
 		() => new Set(projects.map((project) => project.canonicalProjectIdentity)),
 		[projects],
@@ -569,6 +665,8 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 			setSelected(nextRequest.mode === "recipient-add" ? [] : nextInitial);
 			setPreview(null);
 			setResult(null);
+			reviewedRecipientLabels.current = new Map();
+			reviewedProjectLabels.current = new Map();
 			setError(null);
 			setStatus("");
 			setBusy(false);
@@ -608,7 +706,7 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 		(request.mode === "project-add" || request.mode === "recipient-add") && selected.length === 0;
 	const noChanges =
 		request.mode !== "project-add" && request.mode !== "recipient-add" && changes.length === 0;
-	const availableProjects = projectChoices(projects, request, initial);
+	const availableProjects = projectChoices(projects, request, initial, unavailableProjects);
 	const resultApplied = result?.status === "applied";
 	const title = result
 		? resultApplied
@@ -630,6 +728,8 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 		setRequest(null);
 		setPreview(null);
 		setResult(null);
+		reviewedRecipientLabels.current = new Map();
+		reviewedProjectLabels.current = new Map();
 		setError(null);
 		setStatus("");
 	};
@@ -655,7 +755,10 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 		setError(null);
 		setStatus("Reviewing exact recipient access changes.");
 		try {
-			setPreview(await api.previewRecipientPolicyEdges({ version: 1, changes }));
+			const reviewed = await api.previewRecipientPolicyEdges({ version: 1, changes });
+			reviewedRecipientLabels.current = new Map(recipientLabels);
+			reviewedProjectLabels.current = new Map(projectLabels);
+			setPreview(reviewed);
 			setStatus("Review ready. Confirm the exact changes.");
 		} catch (cause) {
 			setError(safeError(cause, "Unable to review recipient access changes."));
@@ -687,6 +790,8 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 		} catch (cause) {
 			if (cause instanceof api.RecipientPolicyEdgesStaleError) {
 				setPreview(null);
+				reviewedRecipientLabels.current = new Map();
+				reviewedProjectLabels.current = new Map();
 				setStatus("");
 			}
 			setError(safeError(cause, "Unable to save recipient access changes."));
@@ -759,9 +864,18 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 							{unavailableMessage}
 						</p>
 					) : result && preview ? (
-						<CommitResult preview={preview} result={result} />
+						<CommitResult
+							preview={preview}
+							projectLabels={reviewedProjectLabels.current}
+							recipientLabels={reviewedRecipientLabels.current}
+							result={result}
+						/>
 					) : preview ? (
-						<Review preview={preview} recipientLabels={recipientLabels} />
+						<Review
+							preview={preview}
+							projectLabels={reviewedProjectLabels.current}
+							recipientLabels={reviewedRecipientLabels.current}
+						/>
 					) : request.mode === "recipient-add" || request.mode === "recipient-manage" ? (
 						<fieldset className="sync-dialog-radio-list" disabled={busy}>
 							<legend>{copy.legend}</legend>
@@ -835,6 +949,8 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 							preview && !result
 								? () => {
 										setPreview(null);
+										reviewedRecipientLabels.current = new Map();
+										reviewedProjectLabels.current = new Map();
 										setStatus("");
 									}
 								: close

--- a/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.test.ts
+++ b/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.test.ts
@@ -214,7 +214,11 @@ describe("project invite review events", () => {
 
 		button.click();
 		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
-		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("legacy-invite", undefined);
+		expect(api.importCoordinatorInvite).toHaveBeenCalledWith(
+			"legacy-invite",
+			undefined,
+			"legacy_team_invite",
+		);
 		expect(invite.value).toBe("");
 		await vi.waitFor(() => expect(button.textContent).toBe("Review invite"));
 	});
@@ -233,10 +237,14 @@ describe("project invite review events", () => {
 
 		button.click();
 		await vi.waitFor(() => expect(api.importCoordinatorInvite).toHaveBeenCalledOnce());
-		expect(api.importCoordinatorInvite).toHaveBeenCalledWith("project-invite", {
-			device_name: "Brian's Mac",
-			recipient_name: "Brian Updated",
-		});
+		expect(api.importCoordinatorInvite).toHaveBeenCalledWith(
+			"project-invite",
+			{
+				device_name: "Brian's Mac",
+				recipient_name: "Brian Updated",
+			},
+			"project_share_invite",
+		);
 		await vi.waitFor(() => expect(button.textContent).toBe("Review invite"));
 	});
 

--- a/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
+++ b/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
@@ -53,6 +53,7 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 		"syncRecipientDeviceName",
 	) as HTMLInputElement | null;
 	let inspectedInviteValue = "";
+	let inspectedInviteKind: api.InspectInviteResult["kind"] | undefined;
 	let inviteInputRevision = 0;
 
 	syncShareProjectsButton?.addEventListener("click", () => {
@@ -73,6 +74,7 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 		if (inputRevision !== inviteInputRevision || syncJoinInvite?.value.trim() !== inviteValue) {
 			return "stale";
 		}
+		inspectedInviteKind = inspected.kind;
 		if (inspected.kind !== "project_share_invite") return "other";
 		const projectNames = (inspected.projects ?? [])
 			.map(
@@ -96,6 +98,7 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 		inviteInputRevision += 1;
 		if (syncJoinInvite.value.trim() === inspectedInviteValue) return;
 		inspectedInviteValue = "";
+		inspectedInviteKind = undefined;
 		if (projectInviteReview) projectInviteReview.hidden = true;
 		if (syncJoinButton) syncJoinButton.textContent = "Review invite";
 	});
@@ -219,7 +222,7 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 		syncJoinButton.disabled = true;
 		syncJoinButton.textContent = "Accepting\u2026";
 		try {
-			const result = await api.importCoordinatorInvite(inviteValue, identity);
+			const result = await api.importCoordinatorInvite(inviteValue, identity, inspectedInviteKind);
 			state.lastTeamJoin = result;
 			const resultFields = result as {
 				detail?: unknown;


### PR DESCRIPTION
## Description
Replace Sharing fallback labels and errors that could expose private Project identities, Team IDs, Identity IDs, paths, remotes, or backend messages with stable privacy-safe presentation.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced