### PR TITLE
fix: clarify repeated Project identities

### DIFF
--- a/packages/ui/src/lib/project-identity-presentation.test.ts
+++ b/packages/ui/src/lib/project-identity-presentation.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+	projectIdentitySummaryGroups,
+	stableProjectPresentationLabels,
+} from "./project-identity-presentation";
+
+describe("Project identity presentation", () => {
+	it("assigns privacy-safe same-label ordinals by canonical identity regardless of input order", () => {
+		const privatePath = "/private/worktrees/codemem";
+		const privateRemote = "ssh://git@private.example.test/codemem.git";
+		const items = [
+			{ canonicalId: privateRemote, displayName: "codemem" },
+			{ canonicalId: privatePath, displayName: "codemem" },
+		];
+
+		const forward = stableProjectPresentationLabels(items);
+		const reversed = stableProjectPresentationLabels([...items].reverse());
+
+		expect([...forward]).toEqual([...reversed]);
+		expect(forward.get(privatePath)).toBe("codemem — Project 1 of 2");
+		expect(forward.get(privateRemote)).toBe("codemem — Project 2 of 2");
+		expect(JSON.stringify([...forward.values()])).not.toContain(privatePath);
+		expect(JSON.stringify([...forward.values()])).not.toContain(privateRemote);
+	});
+
+	it("labels large same-name groups without changing deterministic ordinals", () => {
+		const itemCount = 10_000;
+		const items = Array.from({ length: itemCount }, (_, index) => ({
+			canonicalId: `project-${index.toString().padStart(5, "0")}`,
+			displayName: "codemem",
+		}));
+
+		const labels = stableProjectPresentationLabels(items);
+
+		expect(labels.size).toBe(itemCount);
+		expect(labels.get("project-00000")).toBe(`codemem — Project 1 of ${itemCount}`);
+		expect(labels.get("project-05000")).toBe(`codemem — Project 5001 of ${itemCount}`);
+		expect(labels.get("project-09999")).toBe(`codemem — Project 10000 of ${itemCount}`);
+	});
+
+	it("groups distinct canonical identities without merging their exact count", () => {
+		expect(
+			projectIdentitySummaryGroups([
+				{ canonicalId: "project-c", displayName: "codemem" },
+				{ canonicalId: "project-a", displayName: "codemem" },
+				{ canonicalId: "project-b", displayName: "API" },
+			]),
+		).toEqual([
+			{ displayName: "API", identityCount: 1 },
+			{ displayName: "codemem", identityCount: 2 },
+		]);
+	});
+
+	it("groups visually equivalent Unicode labels while preserving exact identities", () => {
+		const labels = stableProjectPresentationLabels([
+			{ canonicalId: "project-a", displayName: "codemem" },
+			{ canonicalId: "project-b", displayName: "code\u200Bmem" },
+		]);
+
+		expect(labels.get("project-a")).toBe("codemem — Project 1 of 2");
+		expect(labels.get("project-b")).toBe("code\u200Bmem — Project 2 of 2");
+	});
+
+	it("keeps emoji ZWJ sequences distinct from adjacent emoji", () => {
+		const labels = stableProjectPresentationLabels([
+			{ canonicalId: "project-a", displayName: "👩‍💻" },
+			{ canonicalId: "project-b", displayName: "👩💻" },
+		]);
+
+		expect(labels.get("project-a")).toBe("👩‍💻");
+		expect(labels.get("project-b")).toBe("👩💻");
+	});
+
+	it("keeps ZWNJ-shaped labels distinct from their joined spelling", () => {
+		const labels = stableProjectPresentationLabels([
+			{ canonicalId: "project-a", displayName: "می‌روم" },
+			{ canonicalId: "project-b", displayName: "میروم" },
+		]);
+
+		expect(labels.get("project-a")).toBe("می‌روم");
+		expect(labels.get("project-b")).toBe("میروم");
+	});
+});

--- a/packages/ui/src/lib/project-identity-presentation.ts
+++ b/packages/ui/src/lib/project-identity-presentation.ts
@@ -1,0 +1,99 @@
+export interface ProjectIdentityPresentationItem {
+	canonicalId: string;
+	displayName: string;
+}
+
+export interface ProjectIdentitySummaryGroup {
+	displayName: string;
+	identityCount: number;
+}
+
+function compareCanonicalId(
+	left: ProjectIdentityPresentationItem,
+	right: ProjectIdentityPresentationItem,
+): number {
+	return left.canonicalId < right.canonicalId ? -1 : left.canonicalId > right.canonicalId ? 1 : 0;
+}
+
+function displayNameKey(displayName: string): string {
+	return displayName
+		.normalize("NFKC")
+		.replace(/\u200B/gu, "")
+		.replace(/\s+/gu, " ")
+		.trim()
+		.toLowerCase();
+}
+
+function distinctSortedItems(
+	items: ProjectIdentityPresentationItem[],
+): ProjectIdentityPresentationItem[] {
+	const byCanonicalId = new Map<string, ProjectIdentityPresentationItem>();
+	for (const item of items) {
+		const current = byCanonicalId.get(item.canonicalId);
+		if (!current || item.displayName < current.displayName)
+			byCanonicalId.set(item.canonicalId, item);
+	}
+	return [...byCanonicalId.values()].sort(compareCanonicalId);
+}
+
+export function stableProjectPresentationLabels(
+	items: ProjectIdentityPresentationItem[],
+): ReadonlyMap<string, string> {
+	const groups = new Map<string, ProjectIdentityPresentationItem[]>();
+	for (const item of distinctSortedItems(items)) {
+		const key = displayNameKey(item.displayName);
+		const group = groups.get(key);
+		if (group) group.push(item);
+		else groups.set(key, [item]);
+	}
+
+	const labels = new Map<string, string>();
+	for (const group of groups.values()) {
+		for (const [index, item] of group.entries()) {
+			labels.set(
+				item.canonicalId,
+				group.length > 1
+					? `${item.displayName} — Project ${index + 1} of ${group.length}`
+					: item.displayName,
+			);
+		}
+	}
+	return labels;
+}
+
+export function projectIdentitySummaryGroups(
+	items: ProjectIdentityPresentationItem[],
+): ProjectIdentitySummaryGroup[] {
+	const groups = new Map<
+		string,
+		{ displayName: string; canonicalIds: string[]; firstCanonicalId: string }
+	>();
+	for (const item of distinctSortedItems(items)) {
+		const key = displayNameKey(item.displayName);
+		const group = groups.get(key);
+		if (group) group.canonicalIds.push(item.canonicalId);
+		else {
+			groups.set(key, {
+				displayName: item.displayName,
+				canonicalIds: [item.canonicalId],
+				firstCanonicalId: item.canonicalId,
+			});
+		}
+	}
+	return [...groups.values()]
+		.sort((left, right) => {
+			const nameOrder = displayNameKey(left.displayName).localeCompare(
+				displayNameKey(right.displayName),
+			);
+			if (nameOrder !== 0) return nameOrder;
+			return left.firstCanonicalId < right.firstCanonicalId
+				? -1
+				: left.firstCanonicalId > right.firstCanonicalId
+					? 1
+					: 0;
+		})
+		.map((group) => ({
+			displayName: group.displayName,
+			identityCount: group.canonicalIds.length,
+		}));
+}

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -1228,7 +1228,7 @@ describe("legacy Team setup dialog", () => {
 			"Project Alpha",
 			"Project Beta",
 		]);
-		select.value = "resolved-project-beta";
+		select.value = "project-choice-2";
 		act(() => {
 			select.dispatchEvent(new Event("change", { bubbles: true }));
 		});
@@ -1246,6 +1246,59 @@ describe("legacy Team setup dialog", () => {
 		await vi.waitFor(() => expect(document.body.textContent).toContain("Review and finish"));
 		expect(document.activeElement?.id).toBe("legacy-team-setup-step-review");
 		expect(loadDetail).toHaveBeenCalledTimes(2);
+	});
+
+	it("gives reversed same-label mapping choices stable private labels and saves the exact choice", async () => {
+		const privatePath = "/private/worktrees/codemem";
+		const privateRemote = "ssh://git@private.example.test/codemem.git";
+		const mappingChoices = [
+			{ resolvedProjectRef: privateRemote, displayName: "codemem" },
+			{ resolvedProjectRef: privatePath, displayName: "codemem" },
+		];
+		const initialProject = project({ mappingChoices });
+		const mappedProject = project({
+			mappingChoices,
+			resolution: "explicit",
+			resolvedProjectRef: privatePath,
+		});
+		const loadDetail = vi
+			.fn()
+			.mockResolvedValueOnce(detail({ projects: [initialProject], unresolvedProjectCount: 1 }))
+			.mockResolvedValueOnce(detail({ projects: [mappedProject] }));
+		const saveProjectMapping = vi.fn().mockResolvedValue(mutationResult());
+		setup({ loadDetail, saveProjectMapping });
+
+		const select = await vi.waitFor(() => {
+			const match = document.querySelector<HTMLSelectElement>(".legacy-team-project-select");
+			if (!match) throw new Error("Project mapping select missing");
+			return match;
+		});
+		expect([...select.options].map((option) => option.textContent)).toEqual([
+			"Choose a Project",
+			"codemem — Project 2 of 2",
+			"codemem — Project 1 of 2",
+		]);
+		expect([...select.options].map((option) => option.value)).toEqual([
+			"",
+			"project-choice-2",
+			"project-choice-1",
+		]);
+		expect(document.body.outerHTML).not.toContain(privatePath);
+		expect(document.body.outerHTML).not.toContain(privateRemote);
+
+		select.value = "project-choice-1";
+		act(() => {
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		act(() => button("Save mapping").click());
+
+		expect(saveProjectMapping).toHaveBeenCalledWith("opaque-candidate", "project-ref-one", {
+			attemptId: "opaque-attempt",
+			resolvedProjectRef: privatePath,
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review and finish"));
+		expect(document.body.outerHTML).not.toContain(privatePath);
+		expect(document.body.outerHTML).not.toContain(privateRemote);
 	});
 
 	it("reloads stale Project mapping evidence and keeps safe recovery copy", async () => {
@@ -1283,7 +1336,7 @@ describe("legacy Team setup dialog", () => {
 			if (!match) throw new Error("Project mapping select missing");
 			return match;
 		});
-		select.value = "resolved-project-alpha";
+		select.value = "project-choice-1";
 		act(() => {
 			select.dispatchEvent(new Event("change", { bubbles: true }));
 		});
@@ -1328,7 +1381,7 @@ describe("legacy Team setup dialog", () => {
 			if (!match) throw new Error("Project mapping select missing");
 			return match;
 		});
-		select.value = "resolved-project-alpha";
+		select.value = "project-choice-1";
 		act(() => {
 			select.dispatchEvent(new Event("change", { bubbles: true }));
 		});

--- a/packages/ui/src/tabs/legacy-team-setup-projects.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-projects.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useState } from "preact/hooks";
 import type { LegacyTeamSetupDetailResponseV1, LegacyTeamSetupProjectV1 } from "../lib/api";
+import { stableProjectPresentationLabels } from "../lib/project-identity-presentation";
 
 export interface LegacyTeamSetupProjectsProps {
 	blocked: boolean;
@@ -10,13 +11,12 @@ export interface LegacyTeamSetupProjectsProps {
 	onMap: (project: LegacyTeamSetupProjectV1, resolvedProjectRef: string) => void;
 }
 
-function mappingName(project: LegacyTeamSetupProjectV1): string | null {
+function mappingName(
+	project: LegacyTeamSetupProjectV1,
+	labels: ReadonlyMap<string, string>,
+): string | null {
 	if (!project.resolvedProjectRef) return null;
-	return (
-		project.mappingChoices.find(
-			(choice) => choice.resolvedProjectRef === project.resolvedProjectRef,
-		)?.displayName ?? "Unavailable Project"
-	);
+	return labels.get(project.resolvedProjectRef) ?? "Unavailable Project";
 }
 
 function ProjectRow({
@@ -35,19 +35,50 @@ function ProjectRow({
 	const controlId = `${generatedId}-mapping`;
 	const helpId = `${generatedId}-help`;
 	const savedMapping = project.resolvedProjectRef ?? "";
-	const availableSavedMapping = project.mappingChoices.some(
-		(choice) => choice.resolvedProjectRef === savedMapping,
-	)
-		? savedMapping
-		: "";
-	const choiceKey = JSON.stringify(
-		project.mappingChoices.map((choice) => choice.resolvedProjectRef),
+	const labels = stableProjectPresentationLabels(
+		project.mappingChoices.map((choice) => ({
+			canonicalId: choice.resolvedProjectRef,
+			displayName: choice.displayName,
+		})),
 	);
+	const choiceRefs = [
+		...new Set(project.mappingChoices.map((choice) => choice.resolvedProjectRef)),
+	];
+	const sortedChoiceRefs = [...choiceRefs].sort((left, right) =>
+		left < right ? -1 : left > right ? 1 : 0,
+	);
+	const choiceTokens = new Map(
+		sortedChoiceRefs.map((resolvedProjectRef, index) => [
+			resolvedProjectRef,
+			`project-choice-${index + 1}`,
+		]),
+	);
+	const choiceByRef = new Map(
+		project.mappingChoices.map((choice) => [choice.resolvedProjectRef, choice]),
+	);
+	const choices = choiceRefs.flatMap((resolvedProjectRef) => {
+		const choice = choiceByRef.get(resolvedProjectRef);
+		return choice
+			? [
+					{
+						...choice,
+						label: labels.get(resolvedProjectRef) ?? choice.displayName,
+						token: choiceTokens.get(resolvedProjectRef) ?? "",
+					},
+				]
+			: [];
+	});
+	const availableSavedMapping =
+		choices.find((choice) => choice.resolvedProjectRef === savedMapping)?.token ?? "";
+	const choiceKey = JSON.stringify(sortedChoiceRefs);
 	const [draftMapping, setDraftMapping] = useState(availableSavedMapping);
 	useEffect(() => setDraftMapping(availableSavedMapping), [availableSavedMapping, choiceKey]);
+	const selectedMapping = choices.find(
+		(choice) => choice.token === draftMapping,
+	)?.resolvedProjectRef;
 	const controlsBlocked = blocked || busy;
-	const saveBlocked = controlsBlocked || !draftMapping || draftMapping === savedMapping;
-	const savedName = mappingName(project);
+	const saveBlocked = controlsBlocked || !selectedMapping || selectedMapping === savedMapping;
+	const savedName = mappingName(project, labels);
 	const controlDescription = [
 		!draftMapping ? helpId : undefined,
 		blocked ? blockedDescriptionId : undefined,
@@ -80,9 +111,9 @@ function ProjectRow({
 						value={draftMapping}
 					>
 						<option value="">Choose a Project</option>
-						{project.mappingChoices.map((choice) => (
-							<option key={choice.resolvedProjectRef} value={choice.resolvedProjectRef}>
-								{choice.displayName}
+						{choices.map((choice) => (
+							<option key={choice.resolvedProjectRef} value={choice.token}>
+								{choice.label}
 							</option>
 						))}
 					</select>
@@ -96,7 +127,7 @@ function ProjectRow({
 						aria-disabled={saveBlocked ? "true" : undefined}
 						className="settings-button legacy-team-setup-target"
 						onClick={() => {
-							if (!saveBlocked) onMap(project, draftMapping);
+							if (!saveBlocked && selectedMapping) onMap(project, selectedMapping);
 						}}
 						type="button"
 					>

--- a/packages/ui/src/tabs/recipient-policy-management.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-management.test.tsx
@@ -512,6 +512,58 @@ describe("recipient policy management dialog", () => {
 		});
 	});
 
+	it("keeps same-label Project choices separate, stable, and private while selecting exact identities", async () => {
+		const privatePath = "/private/worktrees/codemem";
+		const privateRemote = "ssh://git@private.example.test/codemem.git";
+		vi.mocked(api.previewRecipientPolicyEdges).mockImplementationOnce(async (request) => ({
+			...preview(request.changes),
+			projects: [
+				{
+					canonicalProjectIdentity: privatePath,
+					displayName: "codemem",
+					existingMemoryCount: 1,
+					futureMemoriesShared: true,
+				},
+			],
+		}));
+		mount(intent({ projectRecipients: [] }), {}, [
+			{ canonicalProjectIdentity: privateRemote, displayName: "codemem", existingMemoryCount: 2 },
+			{ canonicalProjectIdentity: privatePath, displayName: "codemem", existingMemoryCount: 1 },
+		]);
+		act(() => {
+			openRecipientPolicyManagement({
+				mode: "recipient-add",
+				recipient: { recipientKind: "identity", identityId: "identity-adam" },
+			});
+		});
+
+		const labels = [...document.querySelectorAll(".recipient-policy-management-name")].map(
+			(label) => label.textContent,
+		);
+		expect(labels).toEqual(["codemem — Project 2 of 2", "codemem — Project 1 of 2"]);
+		expect(document.body.outerHTML).not.toContain(privatePath);
+		expect(document.body.outerHTML).not.toContain(privateRemote);
+
+		act(() => checkbox("codemem — Project 1 of 2").click());
+		await reviewSelection();
+
+		expect(api.previewRecipientPolicyEdges).toHaveBeenCalledWith({
+			version: 1,
+			changes: [
+				{
+					canonicalProjectIdentity: privatePath,
+					recipient: { recipientKind: "identity", identityId: "identity-adam" },
+					action: "add",
+				},
+			],
+		});
+		expect(document.body.textContent).toContain(
+			"codemem — Project 1 of 2 — Access changes affect 1 existing memories",
+		);
+		expect(document.body.outerHTML).not.toContain(privatePath);
+		expect(document.body.outerHTML).not.toContain(privateRemote);
+	});
+
 	it("labels one recipient with mixed changes across selected Projects", async () => {
 		vi.mocked(api.previewRecipientPolicyEdges).mockImplementationOnce(async (request) => ({
 			...preview(request.changes),
@@ -982,6 +1034,7 @@ describe("recipient policy management dialog", () => {
 
 	it("marks long Project, Team, Identity, member, and device names as wrappable", async () => {
 		const longProject = "Project-with-a-very-long-unbroken-name-that-must-wrap";
+		const longProjectLabel = `${longProject} — Project 1 of 2`;
 		const longTeam = "Team-with-a-very-long-unbroken-name-that-must-wrap";
 		const longIdentity = "Identity-with-a-very-long-unbroken-name-that-must-wrap";
 		const longMember = "Member-with-a-very-long-unbroken-name-that-must-wrap";
@@ -1025,6 +1078,19 @@ describe("recipient policy management dialog", () => {
 					displayName: index === 0 ? longMember : longIdentity,
 				})),
 			}),
+			{},
+			[
+				{
+					canonicalProjectIdentity: "git:codemem",
+					displayName: longProject,
+					existingMemoryCount: 436,
+				},
+				{
+					canonicalProjectIdentity: "git:duplicate-long-project",
+					displayName: longProject,
+					existingMemoryCount: 1,
+				},
+			],
 		);
 		act(() => {
 			openRecipientPolicyManagement({ mode: "project-add", projectIds: ["git:codemem"] });
@@ -1037,7 +1103,7 @@ describe("recipient policy management dialog", () => {
 		act(() => checkbox("ExampleCo").click());
 		await reviewSelection();
 
-		for (const name of [longProject, longTeam, longIdentity, longDevice]) {
+		for (const name of [longProjectLabel, longTeam, longIdentity, longDevice]) {
 			const node = [...document.querySelectorAll(".recipient-policy-management-name")].find(
 				(candidate) => candidate.textContent === name,
 			);

--- a/packages/ui/src/tabs/recipient-policy-management.tsx
+++ b/packages/ui/src/tabs/recipient-policy-management.tsx
@@ -11,6 +11,7 @@ import type {
 	RecipientPolicyEdgeRecipientRefV1,
 	RecipientPolicyIntentGraphV1,
 } from "../lib/api/sync";
+import { stableProjectPresentationLabels } from "../lib/project-identity-presentation";
 
 export interface RecipientPolicyManagementProject {
 	canonicalProjectIdentity: string;
@@ -253,12 +254,19 @@ function projectChoices(
 	initial: string[],
 	unavailableLabels: ReadonlyMap<string, string>,
 ): Array<RecipientPolicyManagementProject & { description: string }> {
+	const presentationLabels = stableProjectPresentationLabels(
+		projects.map((project) => ({
+			canonicalId: project.canonicalProjectIdentity,
+			displayName: project.displayName,
+		})),
+	);
 	const visibleProjects =
 		request.mode === "recipient-add"
 			? projects.filter((project) => !initial.includes(project.canonicalProjectIdentity))
 			: projects;
 	const choices = visibleProjects.map((project) => ({
 		...project,
+		displayName: presentationLabels.get(project.canonicalProjectIdentity) ?? project.displayName,
 		description: `${project.existingMemoryCount.toLocaleString()} existing memories`,
 	}));
 	if (request.mode !== "recipient-manage") return choices;
@@ -650,11 +658,19 @@ function RecipientPolicyManagementHost({ intent, options, projects }: Management
 		() => unavailableProjectLabels(projects, request, initial),
 		[initial, projects, request],
 	);
-	const projectLabels = useMemo(() => new Map(unavailableProjects), [unavailableProjects]);
 	const projectIds = useMemo(
 		() => new Set(projects.map((project) => project.canonicalProjectIdentity)),
 		[projects],
 	);
+	const projectLabels = useMemo(() => {
+		const labels = stableProjectPresentationLabels(
+			projects.map((project) => ({
+				canonicalId: project.canonicalProjectIdentity,
+				displayName: project.displayName,
+			})),
+		);
+		return new Map([...labels, ...unavailableProjects]);
+	}, [projects, unavailableProjects]);
 
 	useEffect(() => {
 		requestOpen = (nextRequest) => {

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -132,10 +132,14 @@ function intent(
 	};
 }
 
-function mount(graph = intent(), options: Parameters<typeof mountRecipientPolicySharing>[3] = {}) {
+function mount(
+	graph = intent(),
+	options: Parameters<typeof mountRecipientPolicySharing>[3] = {},
+	projectInventory = projects,
+) {
 	const element = document.getElementById("mount");
 	if (!element) throw new Error("mount missing");
-	act(() => mountRecipientPolicySharing(element, projects, graph, options));
+	act(() => mountRecipientPolicySharing(element, projectInventory, graph, options));
 }
 
 function tab(label: string): HTMLButtonElement {
@@ -362,7 +366,7 @@ describe("recipient-focused Sharing", () => {
 		expect(text).toContain("ExampleCo");
 		expect(text).toContain("2 active members — Adam, Brian");
 		expect(text).toContain("2 active registered devices");
-		expect(text).toContain("1 active shared Project — Codemem");
+		expect(text).toContain("1 active shared Project identity — Codemem");
 		expect(text).toContain("Yes — future Team members inherit the Team’s shared Projects");
 		expect(text).not.toContain("Old Team");
 	});
@@ -376,12 +380,60 @@ describe("recipient-focused Sharing", () => {
 		expect(text).toContain("Local identity");
 		expect(text).toContain("1 active registered device — Adam’s Mac");
 		expect(text).toContain("1 active Team membership — ExampleCo");
-		expect(text).toContain("1 directly shared active Project — API");
+		expect(text).toContain("1 directly shared active Project identity — API");
 		expect(text).toContain("Team Projects are shown on Team cards");
 		expect(text).toContain("per-device eligibility cannot be inferred");
 		expect(text).not.toContain("Team-inherited Project");
 		expect(text).not.toContain("Codemem");
 		expect(text).not.toContain("directly shared active Project — Codemem");
+	});
+
+	it("groups exact same-label Project identities with a bounded accessible preview", () => {
+		const privatePath = "/private/worktrees/codemem";
+		const privateRemote = "ssh://git@private.example.test/codemem.git";
+		const repeatedProjects: RecipientPolicyManagementProject[] = [
+			{ canonicalProjectIdentity: privateRemote, displayName: "Codemem", existingMemoryCount: 2 },
+			{ canonicalProjectIdentity: "git:docs", displayName: "Docs", existingMemoryCount: 3 },
+			{ canonicalProjectIdentity: privatePath, displayName: "Codemem", existingMemoryCount: 1 },
+			{ canonicalProjectIdentity: "git:api", displayName: "API", existingMemoryCount: 4 },
+			{ canonicalProjectIdentity: "git:tools", displayName: "Tools", existingMemoryCount: 5 },
+		];
+		const teamEdges = repeatedProjects.map((project, index) => ({
+			version: 1 as const,
+			canonicalProjectIdentity: project.canonicalProjectIdentity,
+			recipientKind: "team" as const,
+			teamId: "team-example",
+			intentSource: "user" as const,
+			policyRevision: `team-${index}`,
+			status: "active" as const,
+		}));
+		const identityEdges = repeatedProjects.map((project, index) => ({
+			version: 1 as const,
+			canonicalProjectIdentity: project.canonicalProjectIdentity,
+			recipientKind: "identity" as const,
+			identityId: "identity-adam",
+			intentSource: "user" as const,
+			policyRevision: `identity-${index}`,
+			status: "active" as const,
+		}));
+
+		mount(intent({ projectRecipients: [...teamEdges, ...identityEdges] }), {}, repeatedProjects);
+
+		expect(visiblePanel().textContent).toContain("5 active shared Project identities");
+		expect(visiblePanel().textContent).toContain("Codemem (2 identities)");
+		const disclosure = visiblePanel().querySelector<HTMLDetailsElement>(
+			".recipient-policy-sharing-project-details",
+		);
+		expect(disclosure?.open).toBe(false);
+		expect(disclosure?.querySelector("summary")?.textContent).toBe(
+			"View all 4 Project name groups",
+		);
+		expect(disclosure?.querySelector("ul")?.getAttribute("role")).toBe("list");
+		clickTab("Identities");
+		expect(visiblePanel().textContent).toContain("5 directly shared active Project identities");
+		expect(visiblePanel().textContent).toContain("Codemem (2 identities)");
+		expect(document.body.outerHTML).not.toContain(privatePath);
+		expect(document.body.outerHTML).not.toContain(privateRemote);
 	});
 
 	it("opens exact recipient management requests from both action labels", () => {

--- a/packages/ui/src/tabs/recipient-policy-sharing.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.tsx
@@ -9,6 +9,10 @@ import type {
 	RecipientPolicyIntentGraphV1,
 } from "../lib/api/sync";
 import { deviceIdentityAttentionItems } from "../lib/device-identity-inventory";
+import {
+	type ProjectIdentityPresentationItem,
+	projectIdentitySummaryGroups,
+} from "../lib/project-identity-presentation";
 import { RecipientPolicyInvitations } from "./recipient-policy-invitations";
 import {
 	openRecipientPolicyManagement,
@@ -200,14 +204,62 @@ function namesLabel(names: string[], empty: string): string {
 	return names.length ? names.join(", ") : empty;
 }
 
-function activeProjectNames(
+function activeProjectIdentities(
 	projectIds: Iterable<string>,
 	projectsById: Map<string, RecipientPolicyManagementProject>,
-): string[] {
-	return [...new Set(projectIds)].flatMap((projectId) => {
+): ProjectIdentityPresentationItem[] {
+	return [...new Set(projectIds)].map((projectId) => {
 		const project = projectsById.get(projectId);
-		return project ? [project.displayName] : [];
+		return {
+			canonicalId: projectId,
+			displayName: project?.displayName ?? "Unavailable Project",
+		};
 	});
+}
+
+const PROJECT_GROUP_PREVIEW_LIMIT = 3;
+
+function ProjectIdentitySummary({
+	empty,
+	identities,
+	qualifier,
+}: {
+	empty: string;
+	identities: ProjectIdentityPresentationItem[];
+	qualifier: string;
+}) {
+	if (identities.length === 0) return <>{empty}</>;
+	const groups = projectIdentitySummaryGroups(identities);
+	const groupLabel = (group: (typeof groups)[number]) =>
+		group.identityCount > 1
+			? `${group.displayName} (${countLabel(group.identityCount, "identity", "identities")})`
+			: group.displayName;
+	const preview = groups.slice(0, PROJECT_GROUP_PREVIEW_LIMIT);
+	return (
+		<>
+			{countLabel(
+				identities.length,
+				`${qualifier} Project identity`,
+				`${qualifier} Project identities`,
+			)}{" "}
+			— {preview.map(groupLabel).join(", ")}
+			{groups.length > PROJECT_GROUP_PREVIEW_LIMIT ? (
+				<>
+					<span aria-hidden="true">, …</span>
+					<details className="recipient-policy-sharing-project-details">
+						<summary>View all {countLabel(groups.length, "Project name group")}</summary>
+						<ul {...EXPLICIT_LIST_ROLE} aria-label={`All ${qualifier} Project identity groups`}>
+							{groups.map((group) => (
+								<li {...EXPLICIT_LIST_ITEM_ROLE} key={group.displayName}>
+									{groupLabel(group)}
+								</li>
+							))}
+						</ul>
+					</details>
+				</>
+			) : null}
+		</>
+	);
 }
 
 function RecipientActions({
@@ -311,7 +363,7 @@ function TeamsView({
 						.filter((device) => device.status === "active" && memberIds.includes(device.identityId))
 						.map((device) => device.deviceId),
 				).size;
-				const projectNames = activeProjectNames(
+				const projectIdentities = activeProjectIdentities(
 					intent.projectRecipients
 						.filter(
 							(edge) =>
@@ -349,8 +401,11 @@ function TeamsView({
 							<div>
 								<dt>Shared Projects</dt>
 								<dd>
-									{countLabel(projectNames.length, "active shared Project")} —{` `}
-									{namesLabel(projectNames, "No Projects shared")}
+									<ProjectIdentitySummary
+										empty="No Projects shared"
+										identities={projectIdentities}
+										qualifier="active shared"
+									/>
 								</dd>
 							</div>
 							<div>
@@ -415,7 +470,7 @@ function IdentitiesView({
 					),
 				];
 				const teamNames = teamIds.map((teamId) => activeTeamsById.get(teamId)?.displayName ?? "");
-				const directProjectNames = activeProjectNames(
+				const directProjectIdentities = activeProjectIdentities(
 					intent.projectRecipients
 						.filter(
 							(edge) =>
@@ -463,8 +518,11 @@ function IdentitiesView({
 							<div>
 								<dt>Directly shared Projects</dt>
 								<dd>
-									{countLabel(directProjectNames.length, "directly shared active Project")} —{` `}
-									{namesLabel(directProjectNames, "No Projects shared directly")}
+									<ProjectIdentitySummary
+										empty="No Projects shared directly"
+										identities={directProjectIdentities}
+										qualifier="directly shared active"
+									/>
 								</dd>
 							</div>
 						</dl>


### PR DESCRIPTION
## Description
Clarify repeated Project display names without merging canonical identities. Summaries use stable grouped labels while management retains exact authorization edges and privacy-safe distinctions.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced