### PR TITLE
feat: manage Team names from Sharing

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -213,6 +213,8 @@ The normal flow is **Projects → Sharing → Devices → Health**, not manual p
 
 Team membership organizes people and devices, but it is not permission to every Project—only Projects explicitly assigned to that Team. Project access remains explicit and uses canonical Project identity.
 
+To rename an active Team, open **Sharing → Teams**, choose **Team settings**, and save a human-readable Team name. For Teams completed through legacy setup and still linked to the configured coordinator group, this one action updates both names; local Teams update only their policy metadata. If that exact Team and coordinator group has repeated completed setup records, all of those historical summaries receive the new name while remaining completed. Renaming never changes Team membership, device decisions, or Project access. If the connected service cannot be updated, the local name remains unchanged; retry the same name after the connection recovers.
+
 ### Set up an existing Team
 
 If a Team needs device setup, **Sharing** shows a notice and **Continue setup**. The Teams list shows **Needs setup**, **In progress**, or **Ready**.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -862,6 +862,15 @@ export {
 	resolveRecipientPolicyReviewBulk,
 } from "./recipient-policy-review.js";
 export type {
+	ConfiguredCoordinatorGroupV1,
+	RecipientPolicyTeamRenameErrorCode,
+	RecipientPolicyTeamRenameResultV1,
+} from "./recipient-policy-team-metadata.js";
+export {
+	RecipientPolicyTeamRenameError,
+	renameRecipientPolicyTeam,
+} from "./recipient-policy-team-metadata.js";
+export type {
 	RecipientReviewedIntentExcludedProjectV1,
 	RecipientReviewedIntentProjectSourceV1,
 	RecipientReviewedIntentProjectV1,

--- a/packages/core/src/legacy-team-candidate.test.ts
+++ b/packages/core/src/legacy-team-candidate.test.ts
@@ -1378,6 +1378,38 @@ describe("legacy Team candidate discovery", () => {
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
 	});
 
+	it("keeps the active Team name when stale coordinator evidence creates a replacement draft", () => {
+		const [initial] = discoverLegacyTeamCandidates(db, options());
+		const draft = db
+			.prepare(
+				`SELECT attempt_id, candidate_id, roster_fingerprint
+				 FROM legacy_team_setup_drafts WHERE candidate_id = ?`,
+			)
+			.get(initial?.candidateRef) as {
+			attempt_id: string;
+			candidate_id: string;
+			roster_fingerprint: string;
+		};
+		const teamId = deterministicPolicyTeamId(draft.candidate_id);
+		db.prepare(
+			`INSERT INTO policy_teams(
+			 team_id, display_name, status, device_eligibility_mode, provenance,
+			 revision, migration_state, source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'Renamed Engineering', 'active', 'reviewed_allowlist',
+			 'reviewed_team_candidate', 'revision-1', 'completed', ?, 'team-setup-test', ?, ?)`,
+		).run(teamId, draft.roster_fingerprint, NOW, NOW);
+		db.prepare(
+			`UPDATE legacy_team_setup_drafts
+			 SET state = 'completed', completed_team_id = ?, completed_at = ?, updated_at = ?
+			 WHERE attempt_id = ?`,
+		).run(teamId, NOW, NOW, draft.attempt_id);
+
+		const refreshed = refreshLegacyTeamCandidate(db, options("changed-key"), draft.candidate_id);
+
+		expect(refreshed.attemptId).not.toBe(draft.attempt_id);
+		expect(refreshed.displayName).toBe("Renamed Engineering");
+	});
+
 	it("serializes a competing refresh before reading candidate authority", () => {
 		// Arrange
 		const directory = mkdtempSync(join(tmpdir(), "codemem-legacy-team-authority-"));

--- a/packages/core/src/legacy-team-candidate.ts
+++ b/packages/core/src/legacy-team-candidate.ts
@@ -620,6 +620,13 @@ function candidateAuthority(
 	return { row, rosterFingerprint, ready };
 }
 
+function candidateDisplayName(db: Database, candidateId: string, fallback: string): string {
+	const team = db
+		.prepare("SELECT display_name FROM policy_teams WHERE team_id = ? AND status = 'active'")
+		.get(deterministicPolicyTeamId(candidateId)) as { display_name: string } | undefined;
+	return team?.display_name ?? fallback;
+}
+
 function resolveDiscoveredCandidate(
 	db: Database,
 	group: EffectiveGroupSnapshot,
@@ -635,6 +642,7 @@ function resolveDiscoveredCandidate(
 			rosterDevices,
 			projects,
 		);
+		const displayName = candidateDisplayName(db, candidateId, group.displayName);
 		let draft: LegacyTeamSetupDraftView;
 		const expectedProjectionFingerprint = legacyTeamProjectionFingerprint(projects);
 		if (!row || (row.state === "completed" && !ready)) {
@@ -642,21 +650,21 @@ function resolveDiscoveredCandidate(
 				candidateId,
 				coordinatorId,
 				groupId,
-				displayName: group.displayName,
+				displayName,
 				devices: rosterDevices,
 				projects,
 				now,
 			});
 		} else if (row.state === "completed") {
 			draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
-				displayName: group.displayName,
+				displayName,
 				devices: rosterDevices,
 				projects,
 				now,
 			});
 		} else if (row.state === "stale") {
 			draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
-				displayName: group.displayName,
+				displayName,
 				devices: rosterDevices,
 				projects,
 				now,
@@ -672,7 +680,7 @@ function resolveDiscoveredCandidate(
 				).run(now, row.attempt_id);
 			}
 			draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
-				displayName: group.displayName,
+				displayName,
 				devices: rosterDevices,
 				projects,
 				now,
@@ -682,7 +690,7 @@ function resolveDiscoveredCandidate(
 				candidateId,
 				coordinatorId,
 				groupId,
-				displayName: group.displayName,
+				displayName,
 				devices: rosterDevices,
 				projects,
 				now,
@@ -766,12 +774,13 @@ export function refreshLegacyTeamCandidate(
 		const refresh = db.transaction(() => {
 			const projects = legacyTeamCandidateProjectInventory(db, options.projection, candidateId);
 			const { row, ready } = candidateAuthority(db, candidateId, rosterDevices, projects);
+			const displayName = candidateDisplayName(db, candidateId, group.displayName);
 			// A compatible Ready completion with unchanged evidence survives an
 			// explicit refresh: only labels update. Creating a replacement attempt
 			// here would immediately drop Ready and force a redundant review cycle.
 			if (row?.state === "completed" && ready) {
 				return refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
-					displayName: group.displayName,
+					displayName,
 					devices: rosterDevices,
 					projects,
 					now: options.now,
@@ -781,7 +790,7 @@ export function refreshLegacyTeamCandidate(
 				candidateId,
 				coordinatorId,
 				groupId,
-				displayName: group.displayName,
+				displayName,
 				devices: rosterDevices,
 				projects,
 				now: options.now,

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -19,6 +19,10 @@ import {
 	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
 import { deriveRecipientPolicyEffectiveDevicesFromDatabase } from "./recipient-policy-reconciliation.js";
+import {
+	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyTeamMutation,
+} from "./recipient-policy-team-metadata.js";
 import { initTestSchema } from "./test-utils.js";
 
 const NOW = "2026-08-21T12:00:00.000Z";
@@ -565,6 +569,60 @@ describe("legacy Team setup activation", () => {
 				.get(draft.attemptId),
 		).not.toBe("stale");
 		await expect(finish(draft, review)).resolves.toMatchObject({ status: "completed" });
+	});
+
+	it("waits for an in-flight Team metadata mutation before writing the activation revision", async () => {
+		const draft = readyDraft();
+		const review = preview(draft);
+		const teamId = deterministicPolicyTeamId(CANDIDATE);
+		let releaseMutation = () => undefined;
+		const mutationPending = new Promise<void>((resolve) => {
+			releaseMutation = resolve;
+		});
+		let mutationStarted = false;
+		const mutation = serializeRecipientPolicyTeamMutation(db, teamId, async () => {
+			mutationStarted = true;
+			await mutationPending;
+		});
+		await vi.waitFor(() => expect(mutationStarted).toBe(true));
+
+		const activation = finish(draft, review);
+		await Promise.resolve();
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+
+		releaseMutation();
+		await mutation;
+		await expect(activation).resolves.toMatchObject({ status: "completed", teamId });
+	});
+
+	it("waits for an in-flight coordinator group mutation before activating the Team", async () => {
+		const draft = readyDraft();
+		const review = preview(draft);
+		let releaseMutation = () => undefined;
+		const mutationPending = new Promise<void>((resolve) => {
+			releaseMutation = resolve;
+		});
+		let mutationStarted = false;
+		const mutation = serializeRecipientPolicyCoordinatorGroupMutation(
+			db,
+			"group-private",
+			async () => {
+				mutationStarted = true;
+				await mutationPending;
+			},
+		);
+		await vi.waitFor(() => expect(mutationStarted).toBe(true));
+
+		const activation = finish(draft, review);
+		await Promise.resolve();
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+
+		releaseMutation();
+		await mutation;
+		await expect(activation).resolves.toMatchObject({
+			status: "completed",
+			teamId: deterministicPolicyTeamId(CANDIDATE),
+		});
 	});
 
 	it("rejects preview and finish for a mutable attempt superseded by a newer row", async () => {

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -32,6 +32,10 @@ import {
 } from "./recipient-policy-identifiers.js";
 import { deriveRecipientPolicyEffectiveDevices } from "./recipient-policy-reconciliation.js";
 import {
+	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyTeamMutation,
+} from "./recipient-policy-team-metadata.js";
+import {
 	classifyTeamPolicyOwnership,
 	planSetupDeviceDecisionTransition,
 	planSetupMembershipTransition,
@@ -1697,43 +1701,47 @@ export async function finishLegacyTeamSetupActivation(
 		throw error;
 	}
 
-	const now = input.now ?? new Date().toISOString();
-	try {
-		return db
-			.transaction(() => {
-				const lockedReplay = exactReplay(db, input);
-				if (lockedReplay) return lockedReplay;
-				const model = loadModel(db, input);
-				validateFreshRoster(model, freshRoster);
-				// Displayed Project evidence that changed after preview would
-				// produce a confirmed digest for an inventory the user never
-				// saw. The inventory is derived inside this lock so ingestion
-				// between an earlier read and the transaction cannot slip a
-				// Project past the check; the roster, by contrast, is external
-				// coordinator evidence and is re-validated against the locked
-				// model above.
-				const liveProjectionFingerprint = legacyTeamProjectionFingerprint(
-					input.loadProjectInventory(),
-				);
-				if (liveProjectionFingerprint !== model.draft.projection_fingerprint) {
-					activationError("team_setup_projection_changed");
-				}
-				const lockedPreview = buildPreview(model);
-				if (
-					lockedPreview.finishDigest !== input.finishDigest ||
-					lockedPreview.accessDeltaDigest !== input.confirmedAccessDeltaDigest
-				) {
-					activationError("team_setup_confirmation_stale");
-				}
-				if (!input.validateLockedPreview(lockedPreview)) {
-					activationError("team_setup_confirmation_stale");
-				}
-				return applyActivation(db, model, lockedPreview, freshRoster, now);
-			})
-			.immediate();
-	} catch (error) {
-		const normalized = normalizedActivationError(error);
-		persistSafeError(db, input, normalized);
-		throw normalized;
-	}
+	return serializeRecipientPolicyTeamMutation(db, initialModel.teamId, () =>
+		serializeRecipientPolicyCoordinatorGroupMutation(db, initialModel.draft.group_id, async () => {
+			const now = input.now ?? new Date().toISOString();
+			try {
+				return db
+					.transaction(() => {
+						const lockedReplay = exactReplay(db, input);
+						if (lockedReplay) return lockedReplay;
+						const model = loadModel(db, input);
+						validateFreshRoster(model, freshRoster);
+						// Displayed Project evidence that changed after preview would
+						// produce a confirmed digest for an inventory the user never
+						// saw. The inventory is derived inside this lock so ingestion
+						// between an earlier read and the transaction cannot slip a
+						// Project past the check; the roster, by contrast, is external
+						// coordinator evidence and is re-validated against the locked
+						// model above.
+						const liveProjectionFingerprint = legacyTeamProjectionFingerprint(
+							input.loadProjectInventory(),
+						);
+						if (liveProjectionFingerprint !== model.draft.projection_fingerprint) {
+							activationError("team_setup_projection_changed");
+						}
+						const lockedPreview = buildPreview(model);
+						if (
+							lockedPreview.finishDigest !== input.finishDigest ||
+							lockedPreview.accessDeltaDigest !== input.confirmedAccessDeltaDigest
+						) {
+							activationError("team_setup_confirmation_stale");
+						}
+						if (!input.validateLockedPreview(lockedPreview)) {
+							activationError("team_setup_confirmation_stale");
+						}
+						return applyActivation(db, model, lockedPreview, freshRoster, now);
+					})
+					.immediate();
+			} catch (error) {
+				const normalized = normalizedActivationError(error);
+				persistSafeError(db, input, normalized);
+				throw normalized;
+			}
+		}),
+	);
 }

--- a/packages/core/src/recipient-policy-team-metadata.test.ts
+++ b/packages/core/src/recipient-policy-team-metadata.test.ts
@@ -1,0 +1,699 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getLegacyTeamSetupDraft } from "./legacy-team-setup-draft.js";
+import { deterministicPolicyTeamId } from "./recipient-policy-identifiers.js";
+import { renameRecipientPolicyTeam } from "./recipient-policy-team-metadata.js";
+import { initTestSchema } from "./test-utils.js";
+
+const NOW = "2026-08-26T12:00:00.000Z";
+const LATER = "2026-08-26T13:00:00.000Z";
+
+describe("recipient policy Team metadata", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => db.close());
+
+	function insertTeam(teamId = "team-local", displayName = "Old Team") {
+		db.prepare(
+			`INSERT INTO policy_teams(
+			 team_id, display_name, status, provenance, revision, migration_state,
+			 source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES (?, ?, 'active', 'user', 'revision-1', 'user_managed',
+			 'roster-fingerprint', ?, ?, ?)`,
+		).run(teamId, displayName, `team-key-${teamId}`, NOW, NOW);
+	}
+
+	function linkCompletedSetup(
+		teamId: string,
+		options: {
+			attemptId?: string;
+			candidateId?: string;
+			coordinatorId?: string;
+			groupId?: string;
+		} = {},
+	) {
+		const candidateId =
+			options.candidateId ?? "legacy-team-candidate:11111111111111111111111111111111";
+		const attemptId = options.attemptId ?? "attempt-1";
+		const coordinatorId = options.coordinatorId ?? "https://coordinator.example.test";
+		const groupId = options.groupId ?? "group-one";
+		expect(deterministicPolicyTeamId(candidateId)).toBe(teamId);
+		db.prepare(
+			`INSERT INTO legacy_team_setup_drafts(
+			 attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
+			 roster_fingerprint, projection_fingerprint, finish_digest, completed_team_id,
+			 created_at, updated_at, completed_at
+			 ) VALUES (?, ?, ?, ?,
+			 'completed', 'Old Team', 'roster', 'projection', 'finish', ?, ?, ?, ?)`,
+		).run(attemptId, candidateId, coordinatorId, groupId, teamId, NOW, NOW, NOW);
+		db.prepare(
+			`INSERT INTO legacy_team_setup_completions(
+			 attempt_id, finish_digest, candidate_ref, confirmed_access_delta_digest,
+			 completed_team_id, response_json, completed_at, created_at
+			 ) VALUES (?, 'finish', ?, 'access', ?, '{}', ?, ?)`,
+		).run(attemptId, candidateId, teamId, NOW, NOW);
+	}
+
+	it("renames local metadata without touching coordinator linkage fields", async () => {
+		insertTeam();
+		const renameCoordinatorGroup = vi.fn();
+
+		const result = await renameRecipientPolicyTeam(db, {
+			teamId: "team-local",
+			displayName: "  New   Team  ",
+			expectedDisplayName: "Old Team",
+			configuredCoordinatorGroups: [],
+			renameCoordinatorGroup,
+			now: LATER,
+		});
+
+		expect(result).toMatchObject({ displayName: "New Team", linkedCoordinatorGroupRenamed: false });
+		expect(renameCoordinatorGroup).not.toHaveBeenCalled();
+		expect(
+			db
+				.prepare(
+					"SELECT display_name, revision, source_fingerprint, idempotency_key, updated_at FROM policy_teams",
+				)
+				.get(),
+		).toEqual({
+			display_name: "New Team",
+			revision: result.revision,
+			source_fingerprint: "roster-fingerprint",
+			idempotency_key: "team-key-team-local",
+			updated_at: LATER,
+		});
+		expect(result.revision).not.toBe("revision-1");
+	});
+
+	it("renames a proven configured coordinator group before local policy metadata", async () => {
+		const candidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const teamId = deterministicPolicyTeamId(candidateId);
+		insertTeam(teamId);
+		linkCompletedSetup(teamId);
+		db.prepare(
+			`INSERT INTO legacy_team_setup_drafts(
+			 attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
+			 roster_fingerprint, projection_fingerprint, created_at, updated_at
+			 ) VALUES (?, ?, ?, ?, 'in_progress', 'Old Team', 'repeat-roster', 'repeat-projection', ?, ?)`,
+		).run("attempt-repeat", candidateId, "https://coordinator.example.test", "group-one", NOW, NOW);
+		const renameCoordinatorGroup = vi.fn().mockResolvedValue(true);
+
+		const result = await renameRecipientPolicyTeam(db, {
+			teamId,
+			displayName: "Linked Team",
+			expectedDisplayName: "Old Team",
+			configuredCoordinatorGroups: [
+				{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+			],
+			renameCoordinatorGroup,
+			now: LATER,
+		});
+
+		expect(renameCoordinatorGroup).toHaveBeenCalledWith(
+			{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+			"Linked Team",
+		);
+		expect(result.linkedCoordinatorGroupRenamed).toBe(true);
+		expect(db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe("Linked Team");
+		expect(
+			db
+				.prepare(
+					"SELECT attempt_id, display_name FROM legacy_team_setup_drafts ORDER BY attempt_id",
+				)
+				.all(),
+		).toEqual([
+			{ attempt_id: "attempt-1", display_name: "Linked Team" },
+			{ attempt_id: "attempt-repeat", display_name: "Linked Team" },
+		]);
+	});
+
+	it("preserves a proven historical link when coordinator text is equivalent", async () => {
+		const candidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const teamId = deterministicPolicyTeamId(candidateId);
+		insertTeam(teamId);
+		linkCompletedSetup(teamId, { coordinatorId: "https://COORDINATOR.example.test/" });
+		linkCompletedSetup(teamId, {
+			attemptId: "attempt-2",
+			coordinatorId: "https://coordinator.example.test",
+		});
+		const renameCoordinatorGroup = vi.fn().mockResolvedValue(true);
+
+		await expect(
+			renameRecipientPolicyTeam(db, {
+				teamId,
+				displayName: "Equivalent Team",
+				expectedDisplayName: "Old Team",
+				configuredCoordinatorGroups: [
+					{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+				],
+				coordinatorIdsEquivalent: (left, right) =>
+					left.toLowerCase().replace(/\/$/u, "") === right.toLowerCase().replace(/\/$/u, ""),
+				renameCoordinatorGroup,
+				now: LATER,
+			}),
+		).resolves.toMatchObject({ linkedCoordinatorGroupRenamed: true });
+		expect(renameCoordinatorGroup).toHaveBeenCalledWith(
+			{ coordinatorId: "https://COORDINATOR.example.test/", groupId: "group-one" },
+			"Equivalent Team",
+		);
+		expect(
+			db
+				.prepare("SELECT DISTINCT display_name FROM legacy_team_setup_drafts ORDER BY display_name")
+				.pluck()
+				.all(),
+		).toEqual(["Equivalent Team"]);
+	});
+
+	it("fails closed when coordinator equivalence does not prove the historical link", async () => {
+		const candidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const teamId = deterministicPolicyTeamId(candidateId);
+		insertTeam(teamId);
+		linkCompletedSetup(teamId, { coordinatorId: "https://historical.example.test" });
+		const renameCoordinatorGroup = vi.fn();
+
+		await expect(
+			renameRecipientPolicyTeam(db, {
+				teamId,
+				displayName: "Unproven Team",
+				expectedDisplayName: "Old Team",
+				configuredCoordinatorGroups: [
+					{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+				],
+				coordinatorIdsEquivalent: (left, right) => left === right,
+				renameCoordinatorGroup,
+			}),
+		).rejects.toMatchObject({ code: "team_link_stale" });
+		expect(renameCoordinatorGroup).not.toHaveBeenCalled();
+	});
+
+	it("keeps local metadata unchanged when the coordinator rename fails and retries safely", async () => {
+		const candidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const teamId = deterministicPolicyTeamId(candidateId);
+		insertTeam(teamId);
+		linkCompletedSetup(teamId);
+		const renameCoordinatorGroup = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("private coordinator detail"))
+			.mockResolvedValue(true);
+		const input = {
+			teamId,
+			displayName: "Retry Team",
+			expectedDisplayName: "Old Team",
+			configuredCoordinatorGroups: [
+				{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+			],
+			renameCoordinatorGroup,
+			now: LATER,
+		};
+
+		await expect(renameRecipientPolicyTeam(db, input)).rejects.toMatchObject({
+			code: "team_coordinator_rename_failed",
+		});
+		expect(db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe("Old Team");
+		await expect(renameRecipientPolicyTeam(db, input)).resolves.toMatchObject({
+			displayName: "Retry Team",
+		});
+		await expect(renameRecipientPolicyTeam(db, input)).resolves.toMatchObject({
+			displayName: "Retry Team",
+		});
+		expect(renameCoordinatorGroup).toHaveBeenCalledTimes(3);
+	});
+
+	it("verifies same-name linked retries with the coordinator while local retries stay cheap", async () => {
+		const candidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const teamId = deterministicPolicyTeamId(candidateId);
+		insertTeam(teamId, "Current Team");
+		linkCompletedSetup(teamId);
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = 'Current Team'").run();
+		const linkedRename = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+		const linkedInput = {
+			teamId,
+			displayName: "Current Team",
+			expectedDisplayName: "Old Team",
+			configuredCoordinatorGroups: [
+				{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+			],
+			renameCoordinatorGroup: linkedRename,
+		};
+
+		await expect(renameRecipientPolicyTeam(db, linkedInput)).resolves.toMatchObject({
+			linkedCoordinatorGroupRenamed: true,
+		});
+		await expect(renameRecipientPolicyTeam(db, linkedInput)).rejects.toMatchObject({
+			code: "team_coordinator_rename_failed",
+		});
+		expect(linkedRename).toHaveBeenCalledTimes(2);
+
+		insertTeam("team-local-same", "Current Team");
+		const localRename = vi.fn();
+		await expect(
+			renameRecipientPolicyTeam(db, {
+				teamId: "team-local-same",
+				displayName: "Current Team",
+				expectedDisplayName: "Old Team",
+				configuredCoordinatorGroups: [],
+				renameCoordinatorGroup: localRename,
+			}),
+		).resolves.toMatchObject({ linkedCoordinatorGroupRenamed: false });
+		expect(localRename).not.toHaveBeenCalled();
+	});
+
+	it("reports a pending local rename after coordinator success and completes on retry", async () => {
+		const candidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const teamId = deterministicPolicyTeamId(candidateId);
+		insertTeam(teamId);
+		linkCompletedSetup(teamId);
+		db.exec(`CREATE TRIGGER reject_team_rename BEFORE UPDATE ON policy_teams
+			BEGIN SELECT RAISE(FAIL, 'local write failed'); END;`);
+		const renameCoordinatorGroup = vi.fn().mockResolvedValue(true);
+		const input = {
+			teamId,
+			displayName: "Recovered Team",
+			expectedDisplayName: "Old Team",
+			configuredCoordinatorGroups: [
+				{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+			],
+			renameCoordinatorGroup,
+			now: LATER,
+		};
+
+		await expect(renameRecipientPolicyTeam(db, input)).rejects.toMatchObject({
+			code: "team_local_rename_pending",
+		});
+		expect(db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe("Old Team");
+		db.exec("DROP TRIGGER reject_team_rename");
+		await expect(renameRecipientPolicyTeam(db, input)).resolves.toMatchObject({
+			displayName: "Recovered Team",
+		});
+		expect(renameCoordinatorGroup).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not infer a migrated coordinator link from a matching label", async () => {
+		const candidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const teamId = deterministicPolicyTeamId(candidateId);
+		insertTeam(teamId, "Same Label");
+		linkCompletedSetup(teamId);
+		const renameCoordinatorGroup = vi.fn();
+
+		await expect(
+			renameRecipientPolicyTeam(db, {
+				teamId,
+				displayName: "New Team",
+				expectedDisplayName: "Same Label",
+				configuredCoordinatorGroups: [
+					{ coordinatorId: "https://other.example.test", groupId: "Same Label" },
+				],
+				renameCoordinatorGroup,
+			}),
+		).rejects.toMatchObject({ code: "team_link_stale" });
+		expect(renameCoordinatorGroup).not.toHaveBeenCalled();
+		expect(db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe("Same Label");
+	});
+
+	it("fails closed when completed history proves more than one configured link", async () => {
+		const candidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const teamId = deterministicPolicyTeamId(candidateId);
+		insertTeam(teamId);
+		linkCompletedSetup(teamId);
+		linkCompletedSetup(teamId, {
+			attemptId: "attempt-2",
+			coordinatorId: "https://other.example.test",
+			groupId: "group-two",
+		});
+		const renameCoordinatorGroup = vi.fn();
+
+		await expect(
+			renameRecipientPolicyTeam(db, {
+				teamId,
+				displayName: "New Team",
+				expectedDisplayName: "Old Team",
+				configuredCoordinatorGroups: [
+					{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+					{ coordinatorId: "https://other.example.test", groupId: "group-two" },
+				],
+				renameCoordinatorGroup,
+			}),
+		).rejects.toMatchObject({ code: "team_link_ambiguous" });
+		expect(renameCoordinatorGroup).not.toHaveBeenCalled();
+		expect(db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe("Old Team");
+	});
+
+	it("rejects active Teams that alias the same coordinator group", async () => {
+		const firstCandidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const secondCandidateId = "legacy-team-candidate:22222222222222222222222222222222";
+		const firstTeamId = deterministicPolicyTeamId(firstCandidateId);
+		const secondTeamId = deterministicPolicyTeamId(secondCandidateId);
+		insertTeam(firstTeamId, "First Team");
+		insertTeam(secondTeamId, "Second Team");
+		linkCompletedSetup(firstTeamId, {
+			candidateId: firstCandidateId,
+			coordinatorId: "https://COORDINATOR.example.test/",
+		});
+		linkCompletedSetup(secondTeamId, {
+			attemptId: "attempt-2",
+			candidateId: secondCandidateId,
+			coordinatorId: "https://coordinator.example.test",
+		});
+		const renameCoordinatorGroup = vi.fn();
+		const coordinatorIdsEquivalent = (left: string, right: string) =>
+			left.toLowerCase().replace(/\/$/u, "") === right.toLowerCase().replace(/\/$/u, "");
+		const configuredCoordinatorGroups = [
+			{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+		];
+
+		for (const [teamId, expectedDisplayName] of [
+			[firstTeamId, "First Team"],
+			[secondTeamId, "Second Team"],
+		] as const) {
+			await expect(
+				renameRecipientPolicyTeam(db, {
+					teamId,
+					displayName: "Renamed Team",
+					expectedDisplayName,
+					configuredCoordinatorGroups,
+					coordinatorIdsEquivalent,
+					renameCoordinatorGroup,
+				}),
+			).rejects.toMatchObject({ code: "team_link_ambiguous" });
+		}
+		expect(renameCoordinatorGroup).not.toHaveBeenCalled();
+		expect(
+			db.prepare("SELECT display_name FROM policy_teams ORDER BY display_name").pluck().all(),
+		).toEqual(["First Team", "Second Team"]);
+	});
+
+	it("ignores an inactive Team with an equivalent historical coordinator link", async () => {
+		const activeCandidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const inactiveCandidateId = "legacy-team-candidate:22222222222222222222222222222222";
+		const activeTeamId = deterministicPolicyTeamId(activeCandidateId);
+		const inactiveTeamId = deterministicPolicyTeamId(inactiveCandidateId);
+		insertTeam(activeTeamId, "Active Team");
+		insertTeam(inactiveTeamId, "Archived Team");
+		db.prepare("UPDATE policy_teams SET status = 'archived' WHERE team_id = ?").run(inactiveTeamId);
+		linkCompletedSetup(activeTeamId, { candidateId: activeCandidateId });
+		linkCompletedSetup(inactiveTeamId, {
+			attemptId: "attempt-2",
+			candidateId: inactiveCandidateId,
+			coordinatorId: "https://COORDINATOR.example.test/",
+		});
+		const renameCoordinatorGroup = vi.fn().mockResolvedValue(true);
+
+		await expect(
+			renameRecipientPolicyTeam(db, {
+				teamId: activeTeamId,
+				displayName: "Renamed Team",
+				expectedDisplayName: "Active Team",
+				configuredCoordinatorGroups: [
+					{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+				],
+				coordinatorIdsEquivalent: (left, right) =>
+					left.toLowerCase().replace(/\/$/u, "") === right.toLowerCase().replace(/\/$/u, ""),
+				renameCoordinatorGroup,
+			}),
+		).resolves.toMatchObject({ displayName: "Renamed Team" });
+		expect(renameCoordinatorGroup).toHaveBeenCalledOnce();
+	});
+
+	it("rejects a possible active Team link when coordinator comparison fails", async () => {
+		const firstCandidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const secondCandidateId = "legacy-team-candidate:22222222222222222222222222222222";
+		const firstTeamId = deterministicPolicyTeamId(firstCandidateId);
+		const secondTeamId = deterministicPolicyTeamId(secondCandidateId);
+		insertTeam(firstTeamId, "First Team");
+		insertTeam(secondTeamId, "Second Team");
+		linkCompletedSetup(firstTeamId, {
+			candidateId: firstCandidateId,
+			coordinatorId: "https://coordinator-one.example.test",
+		});
+		linkCompletedSetup(secondTeamId, {
+			attemptId: "attempt-2",
+			candidateId: secondCandidateId,
+			coordinatorId: "https://coordinator-two.example.test",
+		});
+		const renameCoordinatorGroup = vi.fn();
+
+		await expect(
+			renameRecipientPolicyTeam(db, {
+				teamId: firstTeamId,
+				displayName: "Renamed Team",
+				expectedDisplayName: "First Team",
+				configuredCoordinatorGroups: [
+					{ coordinatorId: "https://coordinator-one.example.test", groupId: "group-one" },
+				],
+				coordinatorIdsEquivalent: () => {
+					throw new Error("comparison unavailable");
+				},
+				renameCoordinatorGroup,
+			}),
+		).rejects.toMatchObject({ code: "team_link_ambiguous" });
+		expect(renameCoordinatorGroup).not.toHaveBeenCalled();
+		expect(
+			db
+				.prepare("SELECT display_name FROM policy_teams WHERE team_id = ?")
+				.pluck()
+				.get(firstTeamId),
+		).toBe("First Team");
+	});
+
+	it("rejects a rename when a conflicting Team link appears during the remote mutation", async () => {
+		const firstCandidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const secondCandidateId = "legacy-team-candidate:22222222222222222222222222222222";
+		const firstTeamId = deterministicPolicyTeamId(firstCandidateId);
+		const secondTeamId = deterministicPolicyTeamId(secondCandidateId);
+		insertTeam(firstTeamId, "First Team");
+		linkCompletedSetup(firstTeamId, {
+			candidateId: firstCandidateId,
+			coordinatorId: "https://COORDINATOR.example.test/",
+		});
+		const renameCoordinatorGroup = vi.fn().mockImplementation(async () => {
+			insertTeam(secondTeamId, "Second Team");
+			linkCompletedSetup(secondTeamId, {
+				attemptId: "attempt-2",
+				candidateId: secondCandidateId,
+				coordinatorId: "https://coordinator.example.test",
+			});
+			return true;
+		});
+
+		await expect(
+			renameRecipientPolicyTeam(db, {
+				teamId: firstTeamId,
+				displayName: "Renamed Team",
+				expectedDisplayName: "First Team",
+				configuredCoordinatorGroups: [
+					{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+				],
+				coordinatorIdsEquivalent: (left, right) =>
+					left.toLowerCase().replace(/\/$/u, "") === right.toLowerCase().replace(/\/$/u, ""),
+				renameCoordinatorGroup,
+			}),
+		).rejects.toMatchObject({ code: "team_link_ambiguous" });
+		expect(
+			db
+				.prepare("SELECT display_name FROM policy_teams WHERE team_id = ?")
+				.pluck()
+				.get(firstTeamId),
+		).toBe("First Team");
+	});
+
+	it("preserves post-coordinator CAS conflicts as stale", async () => {
+		const candidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const teamId = deterministicPolicyTeamId(candidateId);
+		insertTeam(teamId);
+		linkCompletedSetup(teamId);
+		const renameCoordinatorGroup = vi.fn().mockImplementation(async () => {
+			db.prepare("UPDATE policy_teams SET revision = 'concurrent-revision' WHERE team_id = ?").run(
+				teamId,
+			);
+			return true;
+		});
+
+		await expect(
+			renameRecipientPolicyTeam(db, {
+				teamId,
+				displayName: "New Team",
+				expectedDisplayName: "Old Team",
+				configuredCoordinatorGroups: [
+					{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+				],
+				renameCoordinatorGroup,
+			}),
+		).rejects.toMatchObject({ code: "team_rename_stale" });
+		expect(db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe("Old Team");
+	});
+
+	it("serializes concurrent linked renames before changing the coordinator", async () => {
+		const candidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const teamId = deterministicPolicyTeamId(candidateId);
+		insertTeam(teamId);
+		linkCompletedSetup(teamId);
+		let finishFirstRename = () => undefined;
+		const firstRenamePending = new Promise<void>((resolve) => {
+			finishFirstRename = resolve;
+		});
+		const renameCoordinatorGroup = vi
+			.fn()
+			.mockImplementationOnce(async () => {
+				await firstRenamePending;
+				return true;
+			})
+			.mockResolvedValue(true);
+		const base = {
+			teamId,
+			expectedDisplayName: "Old Team",
+			configuredCoordinatorGroups: [
+				{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+			],
+			renameCoordinatorGroup,
+			now: LATER,
+		};
+
+		const first = renameRecipientPolicyTeam(db, { ...base, displayName: "First Team" });
+		await vi.waitFor(() => expect(renameCoordinatorGroup).toHaveBeenCalledTimes(1));
+		const second = renameRecipientPolicyTeam(db, { ...base, displayName: "Second Team" });
+		await Promise.resolve();
+		expect(renameCoordinatorGroup).toHaveBeenCalledTimes(1);
+		finishFirstRename();
+
+		await expect(first).resolves.toMatchObject({ displayName: "First Team" });
+		await expect(second).rejects.toMatchObject({ code: "team_rename_stale" });
+		expect(renameCoordinatorGroup).toHaveBeenCalledTimes(1);
+		expect(db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe("First Team");
+	});
+
+	it("does not serialize independent Team renames through a global lock", async () => {
+		const firstCandidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const secondCandidateId = "legacy-team-candidate:22222222222222222222222222222222";
+		const firstTeamId = deterministicPolicyTeamId(firstCandidateId);
+		const secondTeamId = deterministicPolicyTeamId(secondCandidateId);
+		insertTeam(firstTeamId);
+		insertTeam(secondTeamId);
+		linkCompletedSetup(firstTeamId, { candidateId: firstCandidateId });
+		linkCompletedSetup(secondTeamId, {
+			attemptId: "attempt-2",
+			candidateId: secondCandidateId,
+			groupId: "group-two",
+		});
+		let finishFirstRename = () => undefined;
+		const firstRenamePending = new Promise<void>((resolve) => {
+			finishFirstRename = resolve;
+		});
+		const firstCoordinatorRename = vi.fn(async () => {
+			await firstRenamePending;
+			return true;
+		});
+		const secondCoordinatorRename = vi.fn().mockResolvedValue(true);
+
+		const first = renameRecipientPolicyTeam(db, {
+			teamId: firstTeamId,
+			displayName: "First Team",
+			expectedDisplayName: "Old Team",
+			configuredCoordinatorGroups: [
+				{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+			],
+			renameCoordinatorGroup: firstCoordinatorRename,
+		});
+		await vi.waitFor(() => expect(firstCoordinatorRename).toHaveBeenCalledOnce());
+		const second = renameRecipientPolicyTeam(db, {
+			teamId: secondTeamId,
+			displayName: "Second Team",
+			expectedDisplayName: "Old Team",
+			configuredCoordinatorGroups: [
+				{ coordinatorId: "https://coordinator.example.test", groupId: "group-two" },
+			],
+			renameCoordinatorGroup: secondCoordinatorRename,
+		});
+
+		await vi.waitFor(() => expect(secondCoordinatorRename).toHaveBeenCalledOnce());
+		finishFirstRename();
+		await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+	});
+
+	it("updates every repeated completed draft for the exact proven historical link", async () => {
+		const candidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const teamId = deterministicPolicyTeamId(candidateId);
+		insertTeam(teamId);
+		linkCompletedSetup(teamId);
+		linkCompletedSetup(teamId, { attemptId: "attempt-2" });
+
+		await renameRecipientPolicyTeam(db, {
+			teamId,
+			displayName: "Historical Team",
+			expectedDisplayName: "Old Team",
+			configuredCoordinatorGroups: [
+				{ coordinatorId: "https://coordinator.example.test", groupId: "group-one" },
+			],
+			renameCoordinatorGroup: vi.fn().mockResolvedValue(true),
+			now: LATER,
+		});
+
+		expect(
+			db
+				.prepare(
+					`SELECT attempt_id, display_name, state, roster_fingerprint,
+					 projection_fingerprint, finish_digest FROM legacy_team_setup_drafts
+					 ORDER BY attempt_id`,
+				)
+				.all(),
+		).toEqual([
+			{
+				attempt_id: "attempt-1",
+				display_name: "Historical Team",
+				state: "completed",
+				roster_fingerprint: "roster",
+				projection_fingerprint: "projection",
+				finish_digest: "finish",
+			},
+			{
+				attempt_id: "attempt-2",
+				display_name: "Historical Team",
+				state: "completed",
+				roster_fingerprint: "roster",
+				projection_fingerprint: "projection",
+				finish_digest: "finish",
+			},
+		]);
+		expect(getLegacyTeamSetupDraft(db, candidateId)).toMatchObject({
+			displayName: "Historical Team",
+			state: "completed",
+		});
+	});
+
+	it.each([
+		["", "team_name_invalid"],
+		["actor:machine", "team_name_invalid"],
+	])("rejects invalid presentation name %j", async (displayName, code) => {
+		insertTeam();
+		await expect(
+			renameRecipientPolicyTeam(db, {
+				teamId: "team-local",
+				displayName,
+				expectedDisplayName: "Old Team",
+				configuredCoordinatorGroups: [],
+				renameCoordinatorGroup: vi.fn(),
+			}),
+		).rejects.toMatchObject({ code });
+	});
+
+	it("fails unknown and stale Teams without mutation", async () => {
+		insertTeam();
+		const base = {
+			displayName: "New Team",
+			expectedDisplayName: "Stale Team",
+			configuredCoordinatorGroups: [],
+			renameCoordinatorGroup: vi.fn(),
+		};
+		await expect(
+			renameRecipientPolicyTeam(db, { ...base, teamId: "missing" }),
+		).rejects.toMatchObject({ code: "team_not_found" });
+		await expect(
+			renameRecipientPolicyTeam(db, { ...base, teamId: "team-local" }),
+		).rejects.toMatchObject({ code: "team_rename_stale" });
+		expect(db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe("Old Team");
+	});
+});

--- a/packages/core/src/recipient-policy-team-metadata.ts
+++ b/packages/core/src/recipient-policy-team-metadata.ts
@@ -1,0 +1,374 @@
+import type { Database } from "./db.js";
+import { normalizeHumanPresentationName } from "./project-invite-identity.js";
+import {
+	deterministicPolicyTeamId,
+	recipientPolicyDigest,
+} from "./recipient-policy-identifiers.js";
+
+export type RecipientPolicyTeamRenameErrorCode =
+	| "team_name_invalid"
+	| "team_not_found"
+	| "team_rename_stale"
+	| "team_link_stale"
+	| "team_link_ambiguous"
+	| "team_coordinator_rename_failed"
+	| "team_local_rename_pending"
+	| "team_rename_failed";
+
+export class RecipientPolicyTeamRenameError extends Error {
+	constructor(readonly code: RecipientPolicyTeamRenameErrorCode) {
+		super(code);
+		this.name = "RecipientPolicyTeamRenameError";
+	}
+}
+
+export interface ConfiguredCoordinatorGroupV1 {
+	coordinatorId: string;
+	groupId: string;
+}
+
+export interface RecipientPolicyTeamRenameResultV1 {
+	version: 1;
+	teamId: string;
+	displayName: string;
+	revision: string;
+	linkedCoordinatorGroupRenamed: boolean;
+}
+
+interface TeamRow {
+	team_id: string;
+	display_name: string;
+	status: string;
+	revision: string;
+}
+
+interface LinkRow {
+	attempt_id: string;
+	candidate_id: string;
+	coordinator_id: string;
+	group_id: string;
+}
+
+interface ActiveTeamLinkRow extends LinkRow {
+	completed_team_id: string;
+}
+
+interface ProvenCoordinatorLink {
+	group: ConfiguredCoordinatorGroupV1;
+	attempts: Array<{
+		attemptId: string;
+		candidateId: string;
+		coordinatorId: string;
+		groupId: string;
+	}>;
+}
+
+// Keep exact Team identities as the serialization boundary. Coordinator URL
+// equivalence is limited to historical-link evidence and never changes queue keys.
+const teamRenameQueues = new WeakMap<Database, Map<string, Promise<void>>>();
+const coordinatorGroupMutationQueues = new WeakMap<Database, Map<string, Promise<void>>>();
+
+function fail(code: RecipientPolicyTeamRenameErrorCode): never {
+	throw new RecipientPolicyTeamRenameError(code);
+}
+
+function name(value: string): string {
+	try {
+		return normalizeHumanPresentationName(value, "display_name");
+	} catch {
+		return fail("team_name_invalid");
+	}
+}
+
+function linkedGroup(
+	db: Database,
+	teamId: string,
+	configured: readonly ConfiguredCoordinatorGroupV1[],
+	coordinatorIdsEquivalent?: (left: string, right: string) => boolean,
+): ProvenCoordinatorLink | null {
+	const rows = db
+		.prepare(
+			`SELECT DISTINCT draft.attempt_id, draft.candidate_id, draft.coordinator_id, draft.group_id
+			 FROM legacy_team_setup_drafts AS draft
+			 JOIN legacy_team_setup_completions AS completion
+			   ON completion.attempt_id = draft.attempt_id
+			  AND completion.finish_digest = draft.finish_digest
+			  AND completion.candidate_ref = draft.candidate_id
+			  AND completion.completed_team_id = draft.completed_team_id
+			 WHERE draft.state = 'completed' AND draft.completed_team_id = ?
+			 ORDER BY draft.attempt_id`,
+		)
+		.all(teamId) as LinkRow[];
+	const completedLinks = rows.filter(
+		(row) => deterministicPolicyTeamId(row.candidate_id) === teamId,
+	);
+	const first = completedLinks[0];
+	if (!first) return null;
+	const equivalent = (left: string, right: string): boolean => {
+		if (left === right) return true;
+		try {
+			return coordinatorIdsEquivalent?.(left, right) === true;
+		} catch {
+			return false;
+		}
+	};
+	const equivalentOrConflict = (left: string, right: string): boolean => {
+		if (left === right) return true;
+		if (!coordinatorIdsEquivalent) return false;
+		try {
+			return coordinatorIdsEquivalent(left, right);
+		} catch {
+			return true;
+		}
+	};
+	if (
+		completedLinks.some(
+			(row) =>
+				row.group_id !== first.group_id || !equivalent(row.coordinator_id, first.coordinator_id),
+		)
+	) {
+		fail("team_link_ambiguous");
+	}
+	const matchesConfiguredGroup = configured.some(
+		(item) =>
+			item.groupId === first.group_id && equivalent(item.coordinatorId, first.coordinator_id),
+	);
+	if (!matchesConfiguredGroup) fail("team_link_stale");
+	const conflictingLinks = db
+		.prepare(
+			`SELECT DISTINCT draft.attempt_id, draft.candidate_id, draft.coordinator_id,
+			        draft.group_id, draft.completed_team_id
+			 FROM legacy_team_setup_drafts AS draft
+			 JOIN legacy_team_setup_completions AS completion
+			   ON completion.attempt_id = draft.attempt_id
+			  AND completion.finish_digest = draft.finish_digest
+			  AND completion.candidate_ref = draft.candidate_id
+			  AND completion.completed_team_id = draft.completed_team_id
+			 JOIN policy_teams AS team
+			   ON team.team_id = draft.completed_team_id
+			  AND team.status = 'active'
+			 WHERE draft.state = 'completed'
+			   AND draft.completed_team_id <> ?
+			   AND draft.group_id = ?
+			 ORDER BY draft.completed_team_id, draft.attempt_id`,
+		)
+		.all(teamId, first.group_id) as ActiveTeamLinkRow[];
+	if (
+		conflictingLinks.some(
+			(row) =>
+				deterministicPolicyTeamId(row.candidate_id) === row.completed_team_id &&
+				equivalentOrConflict(row.coordinator_id, first.coordinator_id),
+		)
+	) {
+		fail("team_link_ambiguous");
+	}
+	return {
+		group: { coordinatorId: first.coordinator_id, groupId: first.group_id },
+		attempts: completedLinks.map((row) => ({
+			attemptId: row.attempt_id,
+			candidateId: row.candidate_id,
+			coordinatorId: row.coordinator_id,
+			groupId: row.group_id,
+		})),
+	};
+}
+
+async function renameLinkedCoordinatorGroup(
+	rename: (group: ConfiguredCoordinatorGroupV1, displayName: string) => Promise<boolean>,
+	link: ConfiguredCoordinatorGroupV1,
+	displayName: string,
+): Promise<void> {
+	let renamed = false;
+	try {
+		renamed = await rename(link, displayName);
+	} catch {
+		fail("team_coordinator_rename_failed");
+	}
+	if (!renamed) fail("team_coordinator_rename_failed");
+}
+
+async function serializeMutation<T>(
+	queues: WeakMap<Database, Map<string, Promise<void>>>,
+	db: Database,
+	key: string,
+	operation: () => Promise<T>,
+): Promise<T> {
+	let queue = queues.get(db);
+	if (!queue) {
+		queue = new Map();
+		queues.set(db, queue);
+	}
+	const preceding = queue.get(key) ?? Promise.resolve();
+	let release: () => void = () => undefined;
+	const turn = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const queued = preceding.catch(() => undefined).then(() => turn);
+	queue.set(key, queued);
+	await preceding.catch(() => undefined);
+	try {
+		return await operation();
+	} finally {
+		release();
+		if (queue.get(key) === queued) queue.delete(key);
+	}
+}
+
+export function serializeRecipientPolicyTeamMutation<T>(
+	db: Database,
+	teamId: string,
+	operation: () => Promise<T>,
+): Promise<T> {
+	return serializeMutation(teamRenameQueues, db, teamId, operation);
+}
+
+// This deliberately uses the exact group ID as a coarse serialization key.
+// Coordinator URL equivalence remains matching-only, while equivalent URL
+// spellings for the same group cannot activate during a linked Team rename.
+export function serializeRecipientPolicyCoordinatorGroupMutation<T>(
+	db: Database,
+	groupId: string,
+	operation: () => Promise<T>,
+): Promise<T> {
+	return serializeMutation(coordinatorGroupMutationQueues, db, groupId, operation);
+}
+
+async function renameRecipientPolicyTeamOnce(
+	db: Database,
+	input: {
+		teamId: string;
+		displayName: string;
+		expectedDisplayName: string;
+		configuredCoordinatorGroups: readonly ConfiguredCoordinatorGroupV1[];
+		coordinatorIdsEquivalent?: (left: string, right: string) => boolean;
+		renameCoordinatorGroup: (
+			group: ConfiguredCoordinatorGroupV1,
+			displayName: string,
+		) => Promise<boolean>;
+		now?: string;
+	},
+	coordinatorGroupSerialized = false,
+): Promise<RecipientPolicyTeamRenameResultV1> {
+	const displayName = name(input.displayName);
+	const team = db
+		.prepare("SELECT team_id, display_name, status, revision FROM policy_teams WHERE team_id = ?")
+		.get(input.teamId) as TeamRow | undefined;
+	if (team?.status !== "active") fail("team_not_found");
+	const link = linkedGroup(
+		db,
+		team.team_id,
+		input.configuredCoordinatorGroups,
+		input.coordinatorIdsEquivalent,
+	);
+	if (link && !coordinatorGroupSerialized) {
+		return serializeRecipientPolicyCoordinatorGroupMutation(db, link.group.groupId, () =>
+			renameRecipientPolicyTeamOnce(db, input, true),
+		);
+	}
+	if (team.display_name === displayName) {
+		if (link) {
+			await renameLinkedCoordinatorGroup(input.renameCoordinatorGroup, link.group, displayName);
+			if (
+				!linkedGroup(
+					db,
+					team.team_id,
+					input.configuredCoordinatorGroups,
+					input.coordinatorIdsEquivalent,
+				)
+			) {
+				fail("team_link_stale");
+			}
+		}
+		return {
+			version: 1,
+			teamId: team.team_id,
+			displayName,
+			revision: team.revision,
+			linkedCoordinatorGroupRenamed: link !== null,
+		};
+	}
+	if (team.display_name !== input.expectedDisplayName) fail("team_rename_stale");
+
+	let currentLink = link;
+	if (currentLink) {
+		await renameLinkedCoordinatorGroup(
+			input.renameCoordinatorGroup,
+			currentLink.group,
+			displayName,
+		);
+		currentLink = linkedGroup(
+			db,
+			team.team_id,
+			input.configuredCoordinatorGroups,
+			input.coordinatorIdsEquivalent,
+		);
+		if (!currentLink) fail("team_link_stale");
+	}
+
+	const now = input.now ?? new Date().toISOString();
+	const revision = recipientPolicyDigest("policy-team-metadata-rename-v1", [
+		team.team_id,
+		team.revision,
+		displayName,
+	]);
+	const update = db.transaction(() => {
+		const changed = db
+			.prepare(
+				`UPDATE policy_teams SET display_name = ?, revision = ?, updated_at = ?
+				 WHERE team_id = ? AND status = 'active' AND revision = ? AND display_name = ?`,
+			)
+			.run(displayName, revision, now, team.team_id, team.revision, team.display_name);
+		if (changed.changes !== 1) fail("team_rename_stale");
+		if (currentLink) {
+			// Every completed attempt for this proven Team/coordinator/group represents
+			// the same historical setup label. Preserve its exact stored coordinator ID.
+			const updateDraft = db.prepare(
+				`UPDATE legacy_team_setup_drafts SET display_name = ?, updated_at = ?
+				 WHERE attempt_id = ? AND state = 'completed' AND completed_team_id = ?
+				   AND coordinator_id = ? AND group_id = ?`,
+			);
+			for (const attempt of currentLink.attempts) {
+				const changedDraft = updateDraft.run(
+					displayName,
+					now,
+					attempt.attemptId,
+					team.team_id,
+					attempt.coordinatorId,
+					attempt.groupId,
+				);
+				if (changedDraft.changes !== 1) fail("team_rename_stale");
+			}
+			const updateUnfinishedDrafts = db.prepare(
+				`UPDATE legacy_team_setup_drafts SET display_name = ?, updated_at = ?
+				 WHERE candidate_id = ? AND state IN ('needs_setup', 'in_progress')`,
+			);
+			for (const candidateId of new Set(
+				currentLink.attempts.map((attempt) => attempt.candidateId),
+			)) {
+				updateUnfinishedDrafts.run(displayName, now, candidateId);
+			}
+		}
+	});
+	try {
+		update();
+	} catch (error) {
+		if (error instanceof RecipientPolicyTeamRenameError) throw error;
+		fail(currentLink ? "team_local_rename_pending" : "team_rename_failed");
+	}
+	return {
+		version: 1,
+		teamId: team.team_id,
+		displayName,
+		revision,
+		linkedCoordinatorGroupRenamed: link !== null,
+	};
+}
+
+export function renameRecipientPolicyTeam(
+	db: Database,
+	input: Parameters<typeof renameRecipientPolicyTeamOnce>[1],
+): Promise<RecipientPolicyTeamRenameResultV1> {
+	return serializeRecipientPolicyTeamMutation(db, input.teamId, () =>
+		renameRecipientPolicyTeamOnce(db, input),
+	);
+}

--- a/packages/ui/src/app-sharing.test.tsx
+++ b/packages/ui/src/app-sharing.test.tsx
@@ -83,6 +83,65 @@ afterEach(() => {
 });
 
 describe("Sharing app data refresh", () => {
+	it("refreshes Sharing and setup names after a Team rename", async () => {
+		document.body.innerHTML = '<div id="recipientPolicySharingMount"></div>';
+		const oldIntent = {
+			...intent,
+			teams: [
+				{
+					version: 1 as const,
+					teamId: "team-one",
+					displayName: "Old Team",
+					status: "active" as const,
+				},
+			],
+		};
+		const newIntent = {
+			...oldIntent,
+			teams: [{ ...oldIntent.teams[0], displayName: "New Team" }],
+		};
+		const oldSummary: LegacyTeamSetupSummaryResponseV1 = {
+			version: 1,
+			candidates: [
+				{
+					candidateRef: "candidate-one",
+					displayName: "Old Team",
+					status: "ready",
+					deviceCount: 1,
+					projectCount: 1,
+					unresolvedDeviceCount: 0,
+					unresolvedProjectCount: 0,
+				},
+			],
+		};
+		const newSummary = {
+			...oldSummary,
+			candidates: [{ ...oldSummary.candidates[0], displayName: "New Team" }],
+		};
+		const mountSharing = vi.fn();
+		const load = createRecipientPolicySharingLoader({
+			loadDeviceInventory: vi.fn().mockResolvedValue({ version: 1, items: [], truncated: false }),
+			loadIntent: vi.fn().mockResolvedValueOnce(oldIntent).mockResolvedValueOnce(newIntent),
+			loadProjects: vi.fn().mockResolvedValue({ manageable: projects, received: [] }),
+			loadTeamSetupSummary: vi
+				.fn()
+				.mockResolvedValueOnce(oldSummary)
+				.mockResolvedValueOnce(newSummary),
+			mountSharing,
+		});
+
+		await load();
+		const onTeamRenamed = mountSharing.mock.calls.at(-1)?.[3]?.onTeamRenamed;
+		await onTeamRenamed?.();
+
+		expect(mountSharing).toHaveBeenLastCalledWith(
+			document.getElementById("recipientPolicySharingMount"),
+			projects,
+			newIntent,
+			expect.objectContaining({ teamSetupSummary: newSummary }),
+		);
+	});
+
 	it("keeps stale Sharing cards after a refresh failure and restores fresh state after recovery", async () => {
 		document.body.innerHTML =
 			'<div id="recipientPolicySharingMount"></div><div id="recipientPolicyManagementMount"></div>';

--- a/packages/ui/src/app-sharing.ts
+++ b/packages/ui/src/app-sharing.ts
@@ -125,6 +125,8 @@ export function createRecipientPolicySharingLoader(
 							deviceInventoryUnavailable: lastDeviceInventoryUnavailable,
 							onOpenTeamSetup: options.onOpenTeamSetup,
 							onReviewDevices: options.onReviewDevices,
+							onTeamRenamed: () =>
+								loadRecipientPolicySharingData({ requireTeamSetupSummary: true }),
 							received: cached.inventory.received,
 							...(lastRequiredRefreshError ? { refreshError: true } : {}),
 							teamSetupSummary,
@@ -200,6 +202,7 @@ export function createRecipientPolicySharingLoader(
 				deviceInventoryUnavailable,
 				onOpenTeamSetup: options.onOpenTeamSetup,
 				onReviewDevices: options.onReviewDevices,
+				onTeamRenamed: () => loadRecipientPolicySharingData({ requireTeamSetupSummary: true }),
 				received: inventory.received,
 			};
 			if (managementMount) {
@@ -219,6 +222,7 @@ export function createRecipientPolicySharingLoader(
 				deviceInventoryUnavailable,
 				onOpenTeamSetup: options.onOpenTeamSetup,
 				onReviewDevices: options.onReviewDevices,
+				onTeamRenamed: () => loadRecipientPolicySharingData({ requireTeamSetupSummary: true }),
 				received: cached.inventory.received,
 				refreshError: true,
 			};

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -100,6 +100,8 @@ export type {
 	RecipientPolicyReviewResolveResultV1,
 	RecipientPolicyReviewResolveStatusV1,
 	RecipientPolicyTeamMembershipV1,
+	RecipientPolicyTeamRenameErrorCode,
+	RecipientPolicyTeamRenameResultV1,
 	RecipientPolicyTeamV1,
 } from "./api/sync";
 export {
@@ -146,11 +148,13 @@ export {
 	previewRecipientPolicyEdges,
 	RecipientPolicyEdgesStaleError,
 	RecipientPolicyReviewStaleError,
+	RecipientPolicyTeamRenameApiError,
 	reassignLegacySharedReviewGroup,
 	reassignProjectInventoryProject,
 	refreshLegacyTeamSetupCandidate,
 	renameActor,
 	renamePeer,
+	renameRecipientPolicyTeam,
 	resolveRecipientPolicyReview,
 	resolveRecipientPolicyReviewBulk,
 	SharingDomainGuardrailConfirmationError,

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -26,6 +26,7 @@ import {
 	type RecipientPolicyReviewListV1,
 	RecipientPolicyReviewStaleError,
 	refreshLegacyTeamSetupCandidate,
+	renameRecipientPolicyTeam,
 	resolveRecipientPolicyReview,
 	resolveRecipientPolicyReviewBulk,
 	saveLegacyTeamSetupAssignment,
@@ -95,6 +96,51 @@ const originalFetch = globalThis.fetch;
 afterEach(() => {
 	globalThis.fetch = originalFetch;
 	vi.restoreAllMocks();
+});
+
+describe("recipient policy Team metadata API", () => {
+	it("sends the bounded rename contract and validates the response", async () => {
+		const result = {
+			version: 1 as const,
+			teamId: "team-one",
+			displayName: "New Team",
+			revision: "revision-two",
+			linkedCoordinatorGroupRenamed: true,
+		};
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(new Response(JSON.stringify(result), { status: 200 }));
+		globalThis.fetch = fetchMock as typeof fetch;
+
+		await expect(
+			renameRecipientPolicyTeam({
+				teamId: "team/one",
+				displayName: "New Team",
+				expectedDisplayName: "Old Team",
+			}),
+		).resolves.toEqual(result);
+		expect(fetchMock).toHaveBeenCalledWith("/api/sync/recipient-policy/v1/teams/team%2Fone", {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ displayName: "New Team", expectedDisplayName: "Old Team" }),
+		});
+	});
+
+	it("maps unknown server failures to a safe typed error", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify({ error: "private_remote_detail" }), { status: 503 }),
+			) as typeof fetch;
+
+		await expect(
+			renameRecipientPolicyTeam({
+				teamId: "team-one",
+				displayName: "New Team",
+				expectedDisplayName: "Old Team",
+			}),
+		).rejects.toMatchObject({ statusCode: 503, errorCode: "team_rename_failed" });
+	});
 });
 
 describe("recipient invitation API", () => {

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -68,6 +68,89 @@ export interface RecipientInvitePreviewResult {
 	preview: RecipientOnboardingPreviewV1;
 }
 
+export type RecipientPolicyTeamRenameErrorCode =
+	| "team_name_invalid"
+	| "team_not_found"
+	| "team_rename_stale"
+	| "team_link_stale"
+	| "team_link_ambiguous"
+	| "team_coordinator_rename_failed"
+	| "team_local_rename_pending"
+	| "team_rename_failed";
+
+export interface RecipientPolicyTeamRenameResultV1 {
+	version: 1;
+	teamId: string;
+	displayName: string;
+	revision: string;
+	linkedCoordinatorGroupRenamed: boolean;
+}
+
+export class RecipientPolicyTeamRenameApiError extends Error {
+	constructor(
+		readonly statusCode: number,
+		readonly errorCode: RecipientPolicyTeamRenameErrorCode,
+	) {
+		super(errorCode);
+		this.name = "RecipientPolicyTeamRenameApiError";
+	}
+}
+
+const TEAM_RENAME_ERROR_CODES = new Set<RecipientPolicyTeamRenameErrorCode>([
+	"team_name_invalid",
+	"team_not_found",
+	"team_rename_stale",
+	"team_link_stale",
+	"team_link_ambiguous",
+	"team_coordinator_rename_failed",
+	"team_local_rename_pending",
+	"team_rename_failed",
+]);
+
+export async function renameRecipientPolicyTeam(input: {
+	teamId: string;
+	displayName: string;
+	expectedDisplayName: string;
+}): Promise<RecipientPolicyTeamRenameResultV1> {
+	let response: Response;
+	try {
+		response = await fetch(
+			`/api/sync/recipient-policy/v1/teams/${encodeURIComponent(input.teamId)}`,
+			{
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					displayName: input.displayName,
+					expectedDisplayName: input.expectedDisplayName,
+				}),
+			},
+		);
+	} catch {
+		throw new RecipientPolicyTeamRenameApiError(0, "team_rename_failed");
+	}
+	const { payload } = await readJsonPayload<RecipientPolicyTeamRenameResultV1>(response);
+	if (!response.ok) {
+		const code =
+			payload && typeof payload === "object" && "error" in payload ? String(payload.error) : "";
+		throw new RecipientPolicyTeamRenameApiError(
+			response.status,
+			TEAM_RENAME_ERROR_CODES.has(code as RecipientPolicyTeamRenameErrorCode)
+				? (code as RecipientPolicyTeamRenameErrorCode)
+				: "team_rename_failed",
+		);
+	}
+	if (
+		payload?.version !== 1 ||
+		typeof payload.teamId !== "string" ||
+		typeof payload.displayName !== "string" ||
+		typeof payload.revision !== "string" ||
+		typeof payload.linkedCoordinatorGroupRenamed !== "boolean"
+	) {
+		throw new RecipientPolicyTeamRenameApiError(response.status, "team_rename_failed");
+	}
+	return payload;
+}
+
 export interface CreatedRecipientInvite extends RecipientInvitePreviewResult {
 	ok: true;
 	invite: {

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -1,8 +1,50 @@
-import { render } from "preact";
+import { type ComponentChildren, render } from "preact";
+import { useEffect, useRef } from "preact/hooks";
 import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const openManagement = vi.hoisted(() => vi.fn());
+
+vi.mock("../components/primitives/radix-dialog", () => ({
+	RadixDialog: ({
+		ariaDescribedby,
+		ariaLabelledby,
+		children,
+		contentClassName,
+		contentId,
+		onCloseAutoFocus,
+		onOpenAutoFocus,
+		open,
+	}: {
+		ariaDescribedby?: string;
+		ariaLabelledby?: string;
+		children?: ComponentChildren;
+		contentClassName?: string;
+		contentId: string;
+		onCloseAutoFocus?: (event: { preventDefault: () => void }) => void;
+		onOpenAutoFocus?: (event: { preventDefault: () => void }) => void;
+		open: boolean;
+	}) => {
+		const wasOpen = useRef(false);
+		useEffect(() => {
+			const event = { preventDefault: () => undefined };
+			if (open && !wasOpen.current) onOpenAutoFocus?.(event);
+			if (!open && wasOpen.current) onCloseAutoFocus?.(event);
+			wasOpen.current = open;
+		}, [onCloseAutoFocus, onOpenAutoFocus, open]);
+		return open ? (
+			<div
+				aria-describedby={ariaDescribedby}
+				aria-labelledby={ariaLabelledby}
+				className={contentClassName}
+				id={contentId}
+				role="dialog"
+			>
+				{children}
+			</div>
+		) : null;
+	},
+}));
 
 vi.mock("./recipient-policy-management", async (importOriginal) => {
 	const original = await importOriginal<typeof import("./recipient-policy-management")>();
@@ -13,6 +55,7 @@ import type {
 	LegacyTeamSetupSummaryResponseV1,
 	RecipientPolicyIntentGraphV1,
 } from "../lib/api/sync";
+import { RecipientPolicyTeamRenameApiError } from "../lib/api/sync";
 import type { RecipientPolicyManagementProject } from "./recipient-policy-management";
 import { mountRecipientPolicySharing } from "./recipient-policy-sharing";
 
@@ -439,7 +482,7 @@ describe("recipient-focused Sharing", () => {
 	it("opens exact recipient management requests from both action labels", () => {
 		mount();
 		for (const button of visiblePanel().querySelectorAll<HTMLButtonElement>("button")) {
-			act(() => button.click());
+			if (button.textContent !== "Team settings") act(() => button.click());
 		}
 		clickTab("Identities");
 		const adamCard = document.querySelector<HTMLElement>(".recipient-policy-sharing-identity-card");
@@ -477,6 +520,154 @@ describe("recipient-focused Sharing", () => {
 		expect(document.body.textContent).toContain(
 			"Add projects only adds the selected Projects after you preview the exact changes",
 		);
+	});
+
+	it("opens a narrow focused Team settings dialog with the current name and restores focus", async () => {
+		const renameTeam = vi.fn().mockResolvedValue({
+			version: 1,
+			teamId: "team-example",
+			displayName: "Renamed Team",
+			revision: "revision-two",
+			linkedCoordinatorGroupRenamed: false,
+		});
+		const onTeamRenamed = vi.fn();
+		mount(intent(), { onTeamRenamed, renameTeam });
+		const trigger = [...visiblePanel().querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => button.textContent === "Team settings",
+		);
+		if (!trigger) throw new Error("Team settings trigger missing");
+
+		act(() => trigger.click());
+		const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
+		const input = document.getElementById(
+			"recipient-policy-team-settings-name",
+		) as HTMLInputElement;
+		expect(dialog?.classList.contains("recipient-policy-team-settings-dialog")).toBe(true);
+		expect(dialog?.getAttribute("aria-labelledby")).toBe("recipient-policy-team-settings-title");
+		expect(input.value).toBe("ExampleCo");
+		await vi.waitFor(() => expect(document.activeElement).toBe(input));
+
+		act(() => {
+			input.value = "Renamed Team";
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		const save = [...(dialog?.querySelectorAll<HTMLButtonElement>("button") ?? [])].find(
+			(button) => button.textContent === "Save",
+		);
+		await act(async () => save?.click());
+		expect(renameTeam).toHaveBeenCalledWith({
+			teamId: "team-example",
+			displayName: "Renamed Team",
+			expectedDisplayName: "ExampleCo",
+		});
+		expect(onTeamRenamed).toHaveBeenCalledOnce();
+		await vi.waitFor(() =>
+			expect(document.querySelector('[role="status"]')?.textContent).toContain(
+				"Team renamed to Renamed Team",
+			),
+		);
+		const done = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => button.textContent === "Done",
+		);
+		await vi.waitFor(() => expect(document.activeElement).toBe(done));
+		act(() => done?.click());
+		await vi.waitFor(() => expect(document.activeElement).toBe(trigger));
+	});
+
+	it("validates Team names before save without exposing identifiers", () => {
+		const renameTeam = vi.fn();
+		mount(intent(), { renameTeam });
+		const trigger = [...visiblePanel().querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => button.textContent === "Team settings",
+		);
+		act(() => trigger?.click());
+		const input = document.getElementById(
+			"recipient-policy-team-settings-name",
+		) as HTMLInputElement;
+		act(() => {
+			input.value = "actor:machine";
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		const save = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => button.textContent === "Save",
+		);
+		act(() => save?.click());
+
+		expect(renameTeam).not.toHaveBeenCalled();
+		expect(document.querySelector('[role="alert"]')?.textContent).toBe(
+			"Enter a human-readable Team name.",
+		);
+		expect(document.body.textContent).not.toContain("team-example");
+	});
+
+	it("keeps coordinator failure visible and retries the same explicit rename", async () => {
+		const renameTeam = vi
+			.fn()
+			.mockRejectedValueOnce(
+				new RecipientPolicyTeamRenameApiError(503, "team_coordinator_rename_failed"),
+			)
+			.mockResolvedValueOnce({
+				version: 1,
+				teamId: "team-example",
+				displayName: "Retry Team",
+				revision: "revision-two",
+				linkedCoordinatorGroupRenamed: true,
+			});
+		mount(intent(), { renameTeam });
+		const trigger = [...visiblePanel().querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => button.textContent === "Team settings",
+		);
+		act(() => trigger?.click());
+		const input = document.getElementById(
+			"recipient-policy-team-settings-name",
+		) as HTMLInputElement;
+		act(() => {
+			input.value = "Retry Team";
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		const click = async (label: string) => {
+			const target = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+				(button) => button.textContent === label,
+			);
+			await act(async () => target?.click());
+		};
+
+		await click("Save");
+		expect(document.querySelector('[role="alert"]')?.textContent).toBe(
+			"The connected Team service could not be updated. Nothing changed locally. Try again.",
+		);
+		expect(document.body.textContent).not.toContain("team_coordinator_rename_failed");
+		await click("Try again");
+		expect(renameTeam).toHaveBeenCalledTimes(2);
+		expect(document.body.textContent).toContain("Team renamed to Retry Team");
+	});
+
+	it("shows a bounded fail-closed message for ambiguous connected Team history", async () => {
+		const renameTeam = vi
+			.fn()
+			.mockRejectedValue(new RecipientPolicyTeamRenameApiError(409, "team_link_ambiguous"));
+		mount(intent(), { renameTeam });
+		const trigger = [...visiblePanel().querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => button.textContent === "Team settings",
+		);
+		act(() => trigger?.click());
+		const input = document.getElementById(
+			"recipient-policy-team-settings-name",
+		) as HTMLInputElement;
+		act(() => {
+			input.value = "Ambiguous Team";
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+		const save = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => button.textContent === "Save",
+		);
+
+		await act(async () => save?.click());
+
+		expect(document.querySelector('[role="alert"]')?.textContent).toBe(
+			"This Team has conflicting connected setup records. Nothing was changed. Review the Team setup before retrying.",
+		);
+		expect(document.body.textContent).not.toContain("team_link_ambiguous");
 	});
 
 	it("renders loading, error, and empty states with live-region semantics", () => {
@@ -527,7 +718,7 @@ describe("recipient-focused Sharing", () => {
 		const mutationButtons = visiblePanel().querySelectorAll<HTMLButtonElement>(
 			".recipient-policy-sharing-actions button",
 		);
-		expect(mutationButtons).toHaveLength(2);
+		expect(mutationButtons).toHaveLength(3);
 		for (const button of mutationButtons) {
 			expect(button.disabled).toBe(true);
 		}

--- a/packages/ui/src/tabs/recipient-policy-sharing.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.tsx
@@ -19,6 +19,7 @@ import {
 	type RecipientPolicyManagementProject,
 } from "./recipient-policy-management";
 import type { ReceivedProjectShare } from "./recipient-policy-projects";
+import { RecipientPolicyTeamSettings } from "./recipient-policy-team-settings";
 
 export interface RecipientPolicySharingOptions {
 	loading?: boolean;
@@ -29,6 +30,8 @@ export interface RecipientPolicySharingOptions {
 	deviceInventory?: DeviceIdentityInventoryV1;
 	onOpenTeamSetup?: (candidateRef: string) => void;
 	onReviewDevices?: (deviceId?: string) => void;
+	onTeamRenamed?: () => Promise<unknown> | unknown;
+	renameTeam?: typeof import("../lib/api/sync").renameRecipientPolicyTeam;
 	coordinatorEnrollmentIssueCount?: number;
 	teamSetupSummary?: LegacyTeamSetupSummaryResponseV1;
 	teamSetupLoading?: boolean;
@@ -316,11 +319,15 @@ function RecipientActions({
 function TeamsView({
 	disableMutations,
 	intent,
+	onTeamRenamed,
 	projects,
+	renameTeam,
 }: {
 	disableMutations: boolean;
 	intent: RecipientPolicyIntentGraphV1;
+	onTeamRenamed?: () => Promise<unknown> | unknown;
 	projects: RecipientPolicyManagementProject[];
+	renameTeam?: typeof import("../lib/api/sync").renameRecipientPolicyTeam;
 }) {
 	const activeTeams = intent.teams.filter((team) => team.status === "active");
 	const activeIdentitiesById = new Map(
@@ -419,6 +426,15 @@ function TeamsView({
 							displayName={team.displayName}
 							recipient={{ recipientKind: "team", teamId: team.teamId }}
 						/>
+						<div className="peer-actions recipient-policy-sharing-actions recipient-policy-sharing-responsive-actions">
+							<RecipientPolicyTeamSettings
+								disabled={disableMutations}
+								displayName={team.displayName}
+								onRenamed={onTeamRenamed}
+								renameTeam={renameTeam}
+								teamId={team.teamId}
+							/>
+						</div>
 					</article>
 				);
 			})}
@@ -777,7 +793,9 @@ function RecipientPolicySharing({
 						<TeamsView
 							disableMutations={options.refreshError === true}
 							intent={intent}
+							onTeamRenamed={options.onTeamRenamed}
 							projects={projects}
+							renameTeam={options.renameTeam}
 						/>
 					) : tab.id === "identities" ? (
 						<IdentitiesView

--- a/packages/ui/src/tabs/recipient-policy-team-settings.tsx
+++ b/packages/ui/src/tabs/recipient-policy-team-settings.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+import { DialogCloseButton } from "../components/primitives/dialog-close-button";
+import { RadixDialog } from "../components/primitives/radix-dialog";
+import * as api from "../lib/api";
+import { isMachinePresentationLabel } from "../lib/identity-presentation";
+
+function validation(value: string): string {
+	const reviewed = value.trim();
+	if (!reviewed) return "Team name is required.";
+	if ([...reviewed].length > 120) return "Team name must use 120 characters or fewer.";
+	if ([...reviewed].some((character) => /[\p{Cc}\p{Cf}]/u.test(character))) {
+		return "Team name cannot include control or format characters.";
+	}
+	if (isMachinePresentationLabel(reviewed)) return "Enter a human-readable Team name.";
+	return "";
+}
+
+function safeError(cause: unknown): string {
+	if (!(cause instanceof api.RecipientPolicyTeamRenameApiError)) {
+		return "The Team could not be renamed. Try again.";
+	}
+	if (cause.errorCode === "team_name_invalid") return "Enter a valid human-readable Team name.";
+	if (cause.errorCode === "team_not_found") {
+		return "This Team is no longer available. Refresh Sharing and try again.";
+	}
+	if (cause.errorCode === "team_rename_stale") {
+		return "This Team changed since you opened settings. Refresh Sharing and try again.";
+	}
+	if (cause.errorCode === "team_link_stale") {
+		return "This Team’s connected setup is no longer configured. Refresh Sharing before renaming it.";
+	}
+	if (cause.errorCode === "team_link_ambiguous") {
+		return "This Team has conflicting connected setup records. Nothing was changed. Review the Team setup before retrying.";
+	}
+	if (cause.errorCode === "team_coordinator_rename_failed") {
+		return "The connected Team service could not be updated. Nothing changed locally. Try again.";
+	}
+	if (cause.errorCode === "team_local_rename_pending") {
+		return "The connected Team service was updated, but Sharing could not save the name locally. Try again to finish.";
+	}
+	return "The Team could not be renamed safely. Try again.";
+}
+
+export function RecipientPolicyTeamSettings({
+	disabled,
+	displayName,
+	onRenamed,
+	renameTeam = api.renameRecipientPolicyTeam,
+	teamId,
+}: {
+	disabled: boolean;
+	displayName: string;
+	onRenamed?: () => Promise<unknown> | unknown;
+	renameTeam?: typeof api.renameRecipientPolicyTeam;
+	teamId: string;
+}) {
+	const [open, setOpen] = useState(false);
+	const [draft, setDraft] = useState(displayName);
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState("");
+	const [success, setSuccess] = useState("");
+	const trigger = useRef<HTMLButtonElement>(null);
+	const input = useRef<HTMLInputElement>(null);
+	const done = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		if (success && !busy) done.current?.focus();
+	}, [busy, success]);
+
+	const close = () => {
+		if (busy) return;
+		setOpen(false);
+		setError("");
+		setSuccess("");
+	};
+	const save = async () => {
+		const invalid = validation(draft);
+		if (invalid) {
+			setError(invalid);
+			return;
+		}
+		if (busy) return;
+		setBusy(true);
+		setError("");
+		setSuccess("");
+		try {
+			const result = await renameTeam({
+				teamId,
+				displayName: draft,
+				expectedDisplayName: displayName,
+			});
+			setDraft(result.displayName);
+			setSuccess(`Team renamed to ${result.displayName}.`);
+			try {
+				const refreshed = await onRenamed?.();
+				if (refreshed === false) {
+					setSuccess(`Team renamed to ${result.displayName}, but Sharing could not refresh.`);
+				}
+			} catch {
+				setSuccess(`Team renamed to ${result.displayName}, but Sharing could not refresh.`);
+			}
+		} catch (cause) {
+			setError(safeError(cause));
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	return (
+		<>
+			<button
+				aria-label={`Team settings for ${displayName}`}
+				className="settings-button recipient-policy-sharing-target recipient-policy-sharing-target-24"
+				disabled={disabled}
+				onClick={() => {
+					setDraft(displayName);
+					setError("");
+					setSuccess("");
+					setOpen(true);
+				}}
+				ref={trigger}
+				type="button"
+			>
+				Team settings
+			</button>
+			<RadixDialog
+				ariaDescribedby="recipient-policy-team-settings-description"
+				ariaLabelledby="recipient-policy-team-settings-title"
+				contentClassName="modal recipient-policy-team-settings-dialog"
+				contentId="recipientPolicyTeamSettingsDialog"
+				onCloseAutoFocus={(event) => {
+					event.preventDefault();
+					trigger.current?.focus();
+				}}
+				onEscapeKeyDown={(event) => {
+					if (busy) event.preventDefault();
+				}}
+				onInteractOutside={(event) => {
+					if (busy) event.preventDefault();
+				}}
+				onOpenAutoFocus={(event) => {
+					event.preventDefault();
+					input.current?.focus();
+					input.current?.select();
+				}}
+				onOpenChange={(nextOpen) => {
+					if (!nextOpen) close();
+				}}
+				open={open}
+				overlayClassName="modal-backdrop"
+				overlayId="recipientPolicyTeamSettingsDialogBackdrop"
+			>
+				<div aria-busy={busy ? "true" : "false"} className="modal-card sync-dialog-card">
+					<div className="modal-header">
+						<h2 id="recipient-policy-team-settings-title">Team settings</h2>
+						<DialogCloseButton ariaLabel="Close Team settings" disabled={busy} onClick={close} />
+					</div>
+					<div className="modal-body">
+						<p className="small" id="recipient-policy-team-settings-description">
+							Change the name shown for this Team in Sharing.
+						</p>
+						<label className="form-field" htmlFor="recipient-policy-team-settings-name">
+							<span>Team name</span>
+							<input
+								disabled={busy || Boolean(success)}
+								id="recipient-policy-team-settings-name"
+								maxLength={120}
+								onInput={(event) => {
+									setDraft(event.currentTarget.value);
+									setError("");
+								}}
+								ref={input}
+								value={draft}
+							/>
+						</label>
+						{busy ? (
+							<p aria-live="polite" role="status">
+								Saving Team name…
+							</p>
+						) : null}
+						{error ? (
+							<p aria-live="assertive" role="alert">
+								{error}
+							</p>
+						) : null}
+						{success ? (
+							<p aria-live="polite" role="status">
+								{success}
+							</p>
+						) : null}
+					</div>
+					<div className="modal-footer recipient-policy-team-settings-actions">
+						<button
+							className="settings-button"
+							disabled={busy}
+							onClick={close}
+							ref={done}
+							type="button"
+						>
+							{success ? "Done" : "Cancel"}
+						</button>
+						{success ? null : (
+							<button
+								className="settings-button sync-dialog-confirm"
+								disabled={busy || !draft.trim() || draft.trim() === displayName}
+								onClick={() => void save()}
+								type="button"
+							>
+								{busy ? "Saving…" : error ? "Try again" : "Save"}
+							</button>
+						)}
+					</div>
+				</div>
+			</RadixDialog>
+		</>
+	);
+}

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1203,6 +1203,11 @@
         font-weight: var(--font-weight-semibold);
       }
       .recipient-policy-management-dialog .modal-card { width: min(720px, calc(100vw - 32px)); }
+      .recipient-policy-team-settings-dialog .modal-card { width: min(440px, calc(100vw - 32px)); }
+      .recipient-policy-team-settings-dialog .form-field { display: grid; gap: var(--sp-2); margin-top: var(--sp-4); }
+      .recipient-policy-team-settings-dialog .form-field span { font-weight: var(--font-weight-semibold); }
+      .recipient-policy-team-settings-dialog input { width: 100%; }
+      .recipient-policy-team-settings-actions { justify-content: flex-end; flex-wrap: wrap; }
       .legacy-team-setup-dialog .modal-card { width: min(680px, calc(100vw - 32px)); }
       .legacy-team-setup-steps {
         display: grid;
@@ -1365,6 +1370,9 @@
       }
       .recipient-policy-sharing-details dt { color: var(--text-secondary); }
       .recipient-policy-sharing-details dd { margin: 0; color: var(--text-primary); }
+      .recipient-policy-sharing-team-card > .recipient-policy-sharing-actions + .recipient-policy-sharing-actions {
+        margin-top: var(--sp-2);
+      }
 
       .loading-card-list { display: grid; gap: var(--sp-3); }
       .loading-card {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -28,7 +28,7 @@ import {
 import { serve } from "@hono/node-server";
 import Database from "better-sqlite3";
 import { describe, expect, it, vi } from "vitest";
-import { createApp, createSyncApp } from "./index.js";
+import { type AppOptions, createApp, createSyncApp } from "./index.js";
 import { __usageCacheTestHooks } from "./routes/stats.js";
 import { reconcileConfiguredCoordinatorEnrollment } from "./routes/sync.js";
 import {
@@ -186,6 +186,8 @@ function createTestApp(opts?: {
 	sweeper?: unknown;
 	getUpdateStatus?: (options: core.GetUpdateStatusOptions) => Promise<core.UpdateStatus>;
 	loadLegacyTeamConfiguredGroupSnapshots?: LegacyTeamConfiguredGroupSnapshotLoader;
+	readCoordinatorConfig?: AppOptions["readCoordinatorConfig"];
+	renameCoordinatorGroup?: AppOptions["renameCoordinatorGroup"];
 	syncRequestRateLimit?: {
 		readLimit?: number;
 		mutationLimit?: number;
@@ -215,6 +217,8 @@ function createTestApp(opts?: {
 		getUpdateStatus: opts?.getUpdateStatus,
 		getSyncRuntimeStatus: opts?.getSyncRuntimeStatus,
 		loadLegacyTeamConfiguredGroupSnapshots: opts?.loadLegacyTeamConfiguredGroupSnapshots,
+		readCoordinatorConfig: opts?.readCoordinatorConfig,
+		renameCoordinatorGroup: opts?.renameCoordinatorGroup,
 	};
 	const app = createApp(appOptions);
 
@@ -449,15 +453,21 @@ describe("viewer-server", () => {
 	it("sync UI api routes all exist in the viewer sync router", () => {
 		const root = join(import.meta.dirname, "../../..");
 		const apiSource = readFileSync(join(root, "packages/ui/src/lib/api.ts"), "utf8");
-		const routeSource = ["sync.ts", "team-setup.ts"]
-			.map((file) => readFileSync(join(root, "packages/viewer-server/src/routes", file), "utf8"))
-			.join("\n");
+		const syncRouteSource = readFileSync(
+			join(root, "packages/viewer-server/src/routes/sync.ts"),
+			"utf8",
+		);
+		const teamSetupRouteSource = readFileSync(
+			join(root, "packages/viewer-server/src/routes/team-setup.ts"),
+			"utf8",
+		);
+		const routeSource = `${syncRouteSource}\n${teamSetupRouteSource}`;
 		const uiRoutes = [
 			...apiSource.matchAll(/fetch\('(\/api\/sync\/[^']+)'/g),
 			...apiSource.matchAll(/fetchJson\('(\/api\/sync\/[^']+)'/g),
 		].map((match) => match[1]);
 		const concreteServerRoutes = [
-			...routeSource.matchAll(/app\.(?:get|post|put|delete)\("(\/api\/sync\/[^"]+)"/g),
+			...routeSource.matchAll(/app\.(?:get|post|put|patch|delete)\("(\/api\/sync\/[^"]+)"/g),
 		].map((match) => match[1]);
 		const normalizedServerRoutes = new Set(
 			concreteServerRoutes.map((route) => route.replace(/:\w+/g, "__param__")),
@@ -470,6 +480,8 @@ describe("viewer-server", () => {
 		).toBe(true);
 		expect(concreteServerRoutes).toContain("/api/sync/team-setup/v1");
 		expect(concreteServerRoutes).toContain("/api/sync/team-setup/v1/:candidateRef");
+		expect(syncRouteSource).toContain('app.patch("/api/sync/recipient-policy/v1/teams/:teamId"');
+		expect(teamSetupRouteSource).not.toContain("/api/sync/recipient-policy/");
 		expect(concreteServerRoutes).toEqual(
 			expect.arrayContaining([
 				"/api/sync/team-setup/v1/:candidateRef/devices/:deviceRef/assignment",
@@ -508,6 +520,49 @@ describe("viewer-server", () => {
 				],
 			},
 		];
+
+		it("invalidates the cached Team setup summary after a recipient-policy rename", async () => {
+			const loadSnapshots = vi.fn(async () => []);
+			const { app, ensureStore, cleanup } = createTestApp({
+				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				readCoordinatorConfig: () => core.readCoordinatorSyncConfig({}),
+			});
+			try {
+				const store = ensureStore();
+				store.db
+					.prepare(
+						`INSERT INTO policy_teams(
+					 team_id, display_name, status, provenance, revision, migration_state,
+					 idempotency_key, created_at, updated_at
+					 ) VALUES ('team-local', 'Old Team', 'active', 'user', 'revision-1',
+					 'user_managed', 'team-key', '2026-08-26T00:00:00.000Z',
+					 '2026-08-26T00:00:00.000Z')`,
+					)
+					.run();
+
+				await app.request("/api/sync/team-setup/v1");
+				await app.request("/api/sync/team-setup/v1");
+				expect(loadSnapshots).toHaveBeenCalledTimes(1);
+
+				const renamed = await app.request("/api/sync/recipient-policy/v1/teams/team-local", {
+					method: "PATCH",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({
+						displayName: "New Team",
+						expectedDisplayName: "Old Team",
+					}),
+				});
+				expect(renamed.status).toBe(200);
+
+				await app.request("/api/sync/team-setup/v1");
+				expect(loadSnapshots).toHaveBeenCalledTimes(2);
+			} finally {
+				cleanup();
+			}
+		});
 
 		it("returns versioned summaries and a redacted detail with preview only when finishable", async () => {
 			const loadSnapshots = vi.fn(async () => snapshots);

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -31,7 +31,7 @@ import { observerStatusRoutes } from "./routes/observer-status.js";
 import { packTransportRoutes } from "./routes/pack.js";
 import { rawEventsRoutes } from "./routes/raw-events.js";
 import { statsRoutes } from "./routes/stats.js";
-import { syncProtocolRoutes, syncRoutes } from "./routes/sync.js";
+import { type SyncRoutesOptions, syncProtocolRoutes, syncRoutes } from "./routes/sync.js";
 import {
 	type LegacyTeamConfiguredGroupSnapshotLoader,
 	TEAM_SETUP_ROUTE_PREFIX,
@@ -99,6 +99,8 @@ export interface AppOptions {
 	getUpdateStatus?: (options: GetUpdateStatusOptions) => Promise<UpdateStatus>;
 	loadDeviceIdentityCoordinatorEvidence?: () => Promise<DeviceIdentityCoordinatorEvidence>;
 	loadLegacyTeamConfiguredGroupSnapshots?: LegacyTeamConfiguredGroupSnapshotLoader;
+	readCoordinatorConfig?: SyncRoutesOptions["readCoordinatorConfig"];
+	renameCoordinatorGroup?: SyncRoutesOptions["renameCoordinatorGroup"];
 	syncRequestRateLimit?: {
 		limiter?: InMemoryRequestRateLimiter;
 		readLimit?: number;
@@ -125,6 +127,7 @@ export function createApp(opts?: AppOptions) {
 	const sweeper = opts?.sweeper ?? null;
 	const observer = opts?.observer ?? null;
 	const getSyncRuntimeStatus = opts?.getSyncRuntimeStatus ?? (() => null);
+	let invalidateTeamSetupSummary = () => {};
 	const app = new Hono();
 
 	// CORS / origin guard
@@ -150,6 +153,9 @@ export function createApp(opts?: AppOptions) {
 		"/",
 		syncRoutes(storeFactory, getSyncRuntimeStatus, {
 			loadDeviceIdentityCoordinatorEvidence: opts?.loadDeviceIdentityCoordinatorEvidence,
+			onRecipientPolicyTeamRenamed: () => invalidateTeamSetupSummary(),
+			readCoordinatorConfig: opts?.readCoordinatorConfig,
+			renameCoordinatorGroup: opts?.renameCoordinatorGroup,
 		}),
 	);
 	app.route(
@@ -157,6 +163,9 @@ export function createApp(opts?: AppOptions) {
 		teamSetupRoutes({
 			getStore: storeFactory,
 			loadLegacyTeamConfiguredGroupSnapshots: opts?.loadLegacyTeamConfiguredGroupSnapshots,
+			registerSummaryInvalidator: (invalidate) => {
+				invalidateTeamSetupSummary = invalidate;
+			},
 		}),
 	);
 	app.route("/", updateStatusRoutes({ getUpdateStatus: opts?.getUpdateStatus }));

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -140,6 +140,7 @@ import {
 	previewRecipientPolicyOnboardingFromReviewedIntent,
 	projectShareLifecycle,
 	RecipientPolicyEdgeRequestError,
+	RecipientPolicyTeamRenameError,
 	readCodememConfigFile,
 	readCoordinatorSyncConfig,
 	reassignProjectScopeInventoryProject,
@@ -153,6 +154,7 @@ import {
 	refreshAuthorizedCoordinatorPeerTrust,
 	refreshConfiguredScopeMembershipCache,
 	rejectInboundScopeFailures,
+	renameRecipientPolicyTeam,
 	requestJson,
 	resolveRecipientPolicyReview,
 	resolveRecipientPolicyReviewBulk,
@@ -180,10 +182,17 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import { type Context, Hono } from "hono";
 import { queryBool, queryInt, safeJsonList } from "../helpers.js";
 import type { InMemoryRequestRateLimiter } from "../request-rate-limit.js";
+import { legacyTeamCandidateGroupDescriptors, normalizedCoordinatorId } from "./team-setup.js";
 
 type StoreFactory = () => MemoryStore;
 export type DeviceIdentityCoordinatorEvidenceLoader =
 	() => Promise<DeviceIdentityCoordinatorEvidence>;
+export interface SyncRoutesOptions {
+	loadDeviceIdentityCoordinatorEvidence?: DeviceIdentityCoordinatorEvidenceLoader;
+	onRecipientPolicyTeamRenamed?: () => void;
+	readCoordinatorConfig?: typeof readCoordinatorSyncConfig;
+	renameCoordinatorGroup?: typeof coordinatorRenameGroupAction;
+}
 type SyncRuntimeStatus = {
 	phase:
 		| "starting"
@@ -4876,9 +4885,11 @@ async function loadConfiguredDeviceIdentityCoordinatorEvidence(): Promise<Device
 export function syncRoutes(
 	getStore: StoreFactory,
 	getSyncRuntimeStatus?: () => SyncRuntimeStatus | null,
-	options: { loadDeviceIdentityCoordinatorEvidence?: DeviceIdentityCoordinatorEvidenceLoader } = {},
+	options: SyncRoutesOptions = {},
 ) {
 	const app = new Hono();
+	const readCoordinatorConfig = options.readCoordinatorConfig ?? readCoordinatorSyncConfig;
+	const renameCoordinatorGroup = options.renameCoordinatorGroup ?? coordinatorRenameGroupAction;
 	const loadCoordinatorEvidence =
 		options.loadDeviceIdentityCoordinatorEvidence ??
 		loadConfiguredDeviceIdentityCoordinatorEvidence;
@@ -4915,6 +4926,109 @@ export function syncRoutes(
 		const store = getStore();
 		ensureStableStoreIdentity(store);
 		return c.json(listDeviceIdentityInventory(store.db, await localInventoryInput(store)));
+	});
+
+	app.patch("/api/sync/recipient-policy/v1/teams/:teamId", async (c) => {
+		const raw = await readBoundedRequestBytes(c.req.raw, 8_192);
+		if (!raw) return c.json({ error: "team_name_invalid" as const }, 400);
+		let body: Record<string, unknown>;
+		try {
+			const parsed = JSON.parse(raw.toString("utf8")) as unknown;
+			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+				return c.json({ error: "team_name_invalid" as const }, 400);
+			}
+			body = parsed as Record<string, unknown>;
+		} catch {
+			return c.json({ error: "team_name_invalid" as const }, 400);
+		}
+		if (
+			Object.keys(body).length !== 2 ||
+			!Object.hasOwn(body, "displayName") ||
+			!Object.hasOwn(body, "expectedDisplayName") ||
+			typeof body.displayName !== "string" ||
+			typeof body.expectedDisplayName !== "string"
+		) {
+			return c.json({ error: "team_name_invalid" as const }, 400);
+		}
+		try {
+			const store = getStore();
+			const config = readCoordinatorConfig();
+			const coordinatorId = config.syncCoordinatorUrl
+				? buildBaseUrl(config.syncCoordinatorUrl)
+				: null;
+			const normalizedConfiguredCoordinatorId = coordinatorId
+				? normalizedCoordinatorId(coordinatorId)
+				: null;
+			let configuredCoordinatorGroups: ReturnType<typeof legacyTeamCandidateGroupDescriptors> = [];
+			if (coordinatorId) {
+				try {
+					// Scope-backed descriptors widen rename eligibility only when
+					// linkedGroup() also proves exact completed-setup history.
+					configuredCoordinatorGroups = legacyTeamCandidateGroupDescriptors(
+						store,
+						config.syncCoordinatorUrl,
+						config.syncCoordinatorGroups,
+					);
+				} catch {
+					// Bad coordinator evidence must not block a local-only rename.
+					// Proven linked Teams still fail closed as team_link_stale.
+					configuredCoordinatorGroups = [];
+				}
+			}
+			const result = await renameRecipientPolicyTeam(store.db, {
+				teamId: c.req.param("teamId"),
+				displayName: body.displayName,
+				expectedDisplayName: body.expectedDisplayName,
+				configuredCoordinatorGroups,
+				coordinatorIdsEquivalent: (left, right) => {
+					const normalizedLeft = normalizedCoordinatorId(left);
+					const normalizedRight = normalizedCoordinatorId(right);
+					return normalizedLeft !== null && normalizedLeft === normalizedRight;
+				},
+				renameCoordinatorGroup: async (group, normalizedDisplayName) => {
+					const normalizedLinkedCoordinatorId = normalizedCoordinatorId(group.coordinatorId);
+					if (
+						!config.syncCoordinatorUrl ||
+						!config.syncCoordinatorAdminSecret ||
+						!normalizedConfiguredCoordinatorId ||
+						!normalizedLinkedCoordinatorId ||
+						normalizedLinkedCoordinatorId !== normalizedConfiguredCoordinatorId
+					) {
+						return false;
+					}
+					const renamed = await renameCoordinatorGroup({
+						groupId: group.groupId,
+						displayName: normalizedDisplayName,
+						remoteUrl: config.syncCoordinatorUrl,
+						adminSecret: config.syncCoordinatorAdminSecret,
+					});
+					return (
+						renamed?.group_id === group.groupId && renamed.display_name === normalizedDisplayName
+					);
+				},
+			});
+			try {
+				options.onRecipientPolicyTeamRenamed?.();
+			} catch {
+				// Cache invalidation is best-effort after the authoritative rename commits.
+			}
+			return c.json(result);
+		} catch (error) {
+			if (!(error instanceof RecipientPolicyTeamRenameError)) {
+				return c.json({ error: "team_rename_failed" as const }, 503);
+			}
+			const status =
+				error.code === "team_name_invalid"
+					? 400
+					: error.code === "team_not_found"
+						? 404
+						: error.code === "team_coordinator_rename_failed" ||
+								error.code === "team_local_rename_pending" ||
+								error.code === "team_rename_failed"
+							? 503
+							: 409;
+			return c.json({ error: error.code }, status);
+		}
 	});
 
 	const parseDeviceBindingRequest = (

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -1,5 +1,6 @@
 import {
 	canonicalWorkspaceIdentity,
+	deterministicPolicyTeamId,
 	fingerprintPublicKey,
 	getLegacyTeamSetupDraft,
 	legacyTeamCandidateId,
@@ -7,6 +8,7 @@ import {
 	readCoordinatorSyncConfig,
 } from "@codemem/core";
 import { describe, expect, it, vi } from "vitest";
+import { syncRoutes } from "./sync.js";
 import { __teamSetupTestHooks, teamSetupRoutes } from "./team-setup.js";
 
 function createRouteStore(): { store: MemoryStore; close: () => void } {
@@ -983,5 +985,406 @@ describe("Team setup roster loading", () => {
 		]);
 		expect(listDevices).toHaveBeenCalledTimes(1);
 		expect(listDevices).toHaveBeenCalledWith(expect.objectContaining({ groupId: targetGroupId }));
+	});
+});
+
+describe("Team metadata route", () => {
+	function fixture(linked = false) {
+		const store = new MemoryStore(":memory:");
+		const candidateId = "legacy-team-candidate:22222222222222222222222222222222";
+		const teamId = linked ? deterministicPolicyTeamId(candidateId) : "team-local";
+		store.db
+			.prepare(
+				`INSERT INTO policy_teams(
+				 team_id, display_name, status, provenance, revision, migration_state,
+				 idempotency_key, created_at, updated_at
+				 ) VALUES (?, 'Old Team', 'active', 'user', 'revision-1', 'user_managed',
+				 'team-key', '2026-08-26T00:00:00.000Z', '2026-08-26T00:00:00.000Z')`,
+			)
+			.run(teamId);
+		if (linked) {
+			store.db
+				.prepare(
+					`INSERT INTO legacy_team_setup_drafts(
+					 attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
+					 roster_fingerprint, projection_fingerprint, finish_digest, completed_team_id,
+					 created_at, updated_at, completed_at
+					 ) VALUES ('attempt-route', ?, 'https://coordinator.example.test', 'group-one',
+					 'completed', 'Old Team', 'roster', 'projection', 'finish', ?,
+					 '2026-08-26T00:00:00.000Z', '2026-08-26T00:00:00.000Z',
+					 '2026-08-26T00:00:00.000Z')`,
+				)
+				.run(candidateId, teamId);
+			store.db
+				.prepare(
+					`INSERT INTO legacy_team_setup_completions(
+					 attempt_id, finish_digest, candidate_ref, confirmed_access_delta_digest,
+					 completed_team_id, response_json, completed_at, created_at
+					 ) VALUES ('attempt-route', 'finish', ?, 'access', ?, '{}',
+					 '2026-08-26T00:00:00.000Z', '2026-08-26T00:00:00.000Z')`,
+				)
+				.run(candidateId, teamId);
+		}
+		return { store, teamId };
+	}
+
+	it("renames a local Team and returns only bounded metadata", async () => {
+		const { store, teamId } = fixture();
+		const onRecipientPolicyTeamRenamed = vi.fn();
+		try {
+			const app = syncRoutes(() => store, undefined, {
+				onRecipientPolicyTeamRenamed,
+				readCoordinatorConfig: () => readCoordinatorSyncConfig({}),
+			});
+			const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ displayName: "New Team", expectedDisplayName: "Old Team" }),
+			});
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual(
+				expect.objectContaining({
+					version: 1,
+					teamId,
+					displayName: "New Team",
+					linkedCoordinatorGroupRenamed: false,
+				}),
+			);
+			expect(onRecipientPolicyTeamRenamed).toHaveBeenCalledOnce();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("uses a safe coordinator failure and leaves linked local metadata unchanged", async () => {
+		const { store, teamId } = fixture(true);
+		try {
+			const app = syncRoutes(() => store, undefined, {
+				readCoordinatorConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "https://coordinator.example.test",
+					syncCoordinatorGroups: ["group-one"],
+					syncCoordinatorAdminSecret: "test-secret",
+				}),
+				renameCoordinatorGroup: vi.fn().mockRejectedValue(new Error("raw remote failure")),
+			});
+			const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ displayName: "New Team", expectedDisplayName: "Old Team" }),
+			});
+
+			expect(response.status).toBe(503);
+			expect(await response.json()).toEqual({ error: "team_coordinator_rename_failed" });
+			expect(store.db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe(
+				"Old Team",
+			);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("keeps linked policy and completed setup names consistent after coordinator success", async () => {
+		const { store, teamId } = fixture(true);
+		const renameCoordinatorGroup = vi.fn().mockResolvedValue({
+			group_id: "group-one",
+			display_name: "New Team",
+			archived_at: null,
+			created_at: "2026-08-26T00:00:00.000Z",
+		});
+		try {
+			const app = syncRoutes(() => store, undefined, {
+				readCoordinatorConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "https://coordinator.example.test",
+					syncCoordinatorGroups: ["group-one"],
+					syncCoordinatorAdminSecret: "test-secret",
+				}),
+				renameCoordinatorGroup,
+			});
+			const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ displayName: "New Team", expectedDisplayName: "Old Team" }),
+			});
+
+			expect(response.status).toBe(200);
+			expect(renameCoordinatorGroup).toHaveBeenCalledWith(
+				expect.objectContaining({ groupId: "group-one", displayName: "New Team" }),
+			);
+			expect(store.db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe(
+				"New Team",
+			);
+			expect(
+				store.db.prepare("SELECT display_name FROM legacy_team_setup_drafts").pluck().get(),
+			).toBe("New Team");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("renames a Team linked through equivalent scope-backed coordinator evidence", async () => {
+		const { store, teamId } = fixture(true);
+		const scopeCoordinatorId = "https://COORDINATOR.example.test/";
+		store.db
+			.prepare("UPDATE legacy_team_setup_drafts SET coordinator_id = ?")
+			.run(scopeCoordinatorId);
+		store.db
+			.prepare(
+				`INSERT INTO replication_scopes(
+				 scope_id, label, kind, authority_type, coordinator_id, group_id,
+				 membership_epoch, status, created_at, updated_at
+				 ) VALUES ('scope-linked', 'Old Team', 'team', 'coordinator', ?, 'group-one',
+				 1, 'active', '2026-08-26T00:00:00.000Z', '2026-08-26T00:00:00.000Z')`,
+			)
+			.run(scopeCoordinatorId);
+		const renameCoordinatorGroup = vi.fn().mockResolvedValue({
+			group_id: "group-one",
+			display_name: "Scope Team",
+			archived_at: null,
+			created_at: "2026-08-26T00:00:00.000Z",
+		});
+		try {
+			const app = syncRoutes(() => store, undefined, {
+				readCoordinatorConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "https://coordinator.example.test",
+					syncCoordinatorGroups: [],
+					syncCoordinatorAdminSecret: "test-secret",
+				}),
+				renameCoordinatorGroup,
+			});
+			const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ displayName: "Scope Team", expectedDisplayName: "Old Team" }),
+			});
+
+			expect(response.status).toBe(200);
+			expect(renameCoordinatorGroup).toHaveBeenCalledWith(
+				expect.objectContaining({ groupId: "group-one", displayName: "Scope Team" }),
+			);
+			expect(store.db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe(
+				"Scope Team",
+			);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("renames a zero-Project Team through an equivalent configured coordinator URL", async () => {
+		const { store, teamId } = fixture(true);
+		store.db
+			.prepare("UPDATE legacy_team_setup_drafts SET coordinator_id = ?")
+			.run("https://COORDINATOR.example.test/");
+		const renameCoordinatorGroup = vi.fn().mockResolvedValue({
+			group_id: "group-one",
+			display_name: "Equivalent Team",
+			archived_at: null,
+			created_at: "2026-08-26T00:00:00.000Z",
+		});
+		try {
+			const app = syncRoutes(() => store, undefined, {
+				readCoordinatorConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "https://coordinator.example.test",
+					syncCoordinatorGroups: ["group-one"],
+					syncCoordinatorAdminSecret: "test-secret",
+				}),
+				renameCoordinatorGroup,
+			});
+			const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ displayName: "Equivalent Team", expectedDisplayName: "Old Team" }),
+			});
+
+			expect(response.status).toBe(200);
+			expect(renameCoordinatorGroup).toHaveBeenCalledWith(
+				expect.objectContaining({ groupId: "group-one", displayName: "Equivalent Team" }),
+			);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("rejects active Teams linked to the same normalized coordinator group", async () => {
+		const { store, teamId } = fixture(true);
+		const aliasCandidateId = "legacy-team-candidate:11111111111111111111111111111111";
+		const aliasTeamId = deterministicPolicyTeamId(aliasCandidateId);
+		store.db
+			.prepare(
+				`INSERT INTO policy_teams(
+				 team_id, display_name, status, provenance, revision, migration_state,
+				 idempotency_key, created_at, updated_at
+				 ) VALUES (?, 'Alias Team', 'active', 'user', 'revision-alias', 'user_managed',
+				 'team-key-alias', '2026-08-26T00:00:00.000Z', '2026-08-26T00:00:00.000Z')`,
+			)
+			.run(aliasTeamId);
+		store.db
+			.prepare(
+				`INSERT INTO legacy_team_setup_drafts(
+				 attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
+				 roster_fingerprint, projection_fingerprint, finish_digest, completed_team_id,
+				 created_at, updated_at, completed_at
+				 ) VALUES ('attempt-route-alias', ?, 'HTTPS://COORDINATOR.example.test/', 'group-one',
+				 'completed', 'Alias Team', 'roster-alias', 'projection-alias', 'finish-alias', ?,
+				 '2026-08-26T00:00:00.000Z', '2026-08-26T00:00:00.000Z',
+				 '2026-08-26T00:00:00.000Z')`,
+			)
+			.run(aliasCandidateId, aliasTeamId);
+		store.db
+			.prepare(
+				`INSERT INTO legacy_team_setup_completions(
+				 attempt_id, finish_digest, candidate_ref, confirmed_access_delta_digest,
+				 completed_team_id, response_json, completed_at, created_at
+				 ) VALUES ('attempt-route-alias', 'finish-alias', ?, 'access-alias', ?, '{}',
+				 '2026-08-26T00:00:00.000Z', '2026-08-26T00:00:00.000Z')`,
+			)
+			.run(aliasCandidateId, aliasTeamId);
+		const renameCoordinatorGroup = vi.fn();
+		try {
+			const app = syncRoutes(() => store, undefined, {
+				readCoordinatorConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "https://coordinator.example.test",
+					syncCoordinatorGroups: ["group-one"],
+					syncCoordinatorAdminSecret: "test-secret",
+				}),
+				renameCoordinatorGroup,
+			});
+			const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ displayName: "New Team", expectedDisplayName: "Old Team" }),
+			});
+
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_link_ambiguous" });
+			expect(renameCoordinatorGroup).not.toHaveBeenCalled();
+			expect(
+				store.db
+					.prepare("SELECT display_name FROM policy_teams WHERE team_id = ?")
+					.pluck()
+					.get(teamId),
+			).toBe("Old Team");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not infer a coordinator rename from scope evidence without completed setup proof", async () => {
+		const { store, teamId } = fixture();
+		store.db
+			.prepare(
+				`INSERT INTO replication_scopes(
+				 scope_id, label, kind, authority_type, coordinator_id, group_id,
+				 membership_epoch, status, created_at, updated_at
+				 ) VALUES ('scope-unproven', 'Unproven', 'team', 'coordinator',
+				 'https://coordinator.example.test', 'group-one', 1, 'active',
+				 '2026-08-26T00:00:00.000Z', '2026-08-26T00:00:00.000Z')`,
+			)
+			.run();
+		const renameCoordinatorGroup = vi.fn();
+		try {
+			const app = syncRoutes(() => store, undefined, {
+				readCoordinatorConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "https://coordinator.example.test",
+					syncCoordinatorGroups: [],
+					syncCoordinatorAdminSecret: "test-secret",
+				}),
+				renameCoordinatorGroup,
+			});
+			const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ displayName: "Local Team", expectedDisplayName: "Old Team" }),
+			});
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual(
+				expect.objectContaining({ linkedCoordinatorGroupRenamed: false }),
+			);
+			expect(renameCoordinatorGroup).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("keeps local Team renames available when coordinator evidence is invalid", async () => {
+		const { store, teamId } = fixture();
+		const renameCoordinatorGroup = vi.fn();
+		try {
+			const app = syncRoutes(() => store, undefined, {
+				readCoordinatorConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "https://coordinator.example.test",
+					syncCoordinatorGroups: Array.from({ length: 26 }, (_, index) => `group-${index}`),
+					syncCoordinatorAdminSecret: "test-secret",
+				}),
+				renameCoordinatorGroup,
+			});
+			const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ displayName: "Local Team", expectedDisplayName: "Old Team" }),
+			});
+
+			expect(response.status).toBe(200);
+			expect(renameCoordinatorGroup).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("fails closed for a linked Team when coordinator evidence is invalid", async () => {
+		const { store, teamId } = fixture(true);
+		const renameCoordinatorGroup = vi.fn();
+		try {
+			const app = syncRoutes(() => store, undefined, {
+				readCoordinatorConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "https://coordinator.example.test",
+					syncCoordinatorGroups: Array.from({ length: 26 }, (_, index) => `group-${index}`),
+					syncCoordinatorAdminSecret: "test-secret",
+				}),
+				renameCoordinatorGroup,
+			});
+			const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ displayName: "Blocked Team", expectedDisplayName: "Old Team" }),
+			});
+
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_link_stale" });
+			expect(renameCoordinatorGroup).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it.each([
+		["missing", "Old Team", "New Team", 404, "team_not_found"],
+		["team-local", "Stale Team", "New Team", 409, "team_rename_stale"],
+		["team-local", "Old Team", "actor:machine", 400, "team_name_invalid"],
+	])("returns safe errors for invalid or stale Team changes", async (teamId, expectedDisplayName, displayName, status, error) => {
+		const { store } = fixture();
+		try {
+			const app = syncRoutes(() => store, undefined, {
+				readCoordinatorConfig: () => readCoordinatorSyncConfig({}),
+			});
+			const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ displayName, expectedDisplayName }),
+			});
+			expect(response.status).toBe(status);
+			expect(await response.json()).toEqual({ error });
+		} finally {
+			store.close();
+		}
 	});
 });

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -64,7 +64,7 @@ interface LegacyTeamConfiguredGroupSnapshotLoadOptions {
 	candidateRef?: string;
 }
 
-interface LegacyTeamCandidateGroupDescriptor {
+export interface LegacyTeamCandidateGroupDescriptor {
 	groupId: string;
 	coordinatorId: string;
 }
@@ -208,10 +208,11 @@ export interface LegacyTeamSetupFinishResponseV1 {
 	completedAt: string;
 }
 
-interface TeamSetupRoutesOptions {
+export interface TeamSetupRoutesOptions {
 	getStore: () => MemoryStore;
 	loadLegacyTeamConfiguredGroupSnapshots?: LegacyTeamConfiguredGroupSnapshotLoader;
 	snapshotLoaderDependencies?: LegacyTeamSnapshotLoaderDependencies;
+	registerSummaryInvalidator?: (invalidate: () => void) => void;
 }
 
 interface LegacyTeamSnapshotLoaderDependencies {
@@ -240,7 +241,7 @@ function configuredGroupIds(groups: string[]): string[] {
 	return unique;
 }
 
-function normalizedCoordinatorId(value: string): string | null {
+export function normalizedCoordinatorId(value: string): string | null {
 	try {
 		const normalized = buildBaseUrl(value);
 		if (!normalized) return null;
@@ -258,6 +259,36 @@ function normalizedCoordinatorId(value: string): string | null {
 	} catch {
 		return null;
 	}
+}
+
+export function legacyTeamCandidateGroupDescriptors(
+	store: MemoryStore | undefined,
+	coordinatorUrl: string,
+	groups: string[],
+): LegacyTeamCandidateGroupDescriptor[] {
+	const configuredIds = configuredGroupIds(groups);
+	const configuredCoordinatorId = buildBaseUrl(coordinatorUrl);
+	const normalizedConfiguredCoordinatorId = normalizedCoordinatorId(configuredCoordinatorId);
+	if (!configuredCoordinatorId || !normalizedConfiguredCoordinatorId) throw safeCoordinatorError();
+	let scopeBackedDescriptors: LegacyTeamCandidateGroupDescriptor[] = [];
+	if (store) {
+		try {
+			scopeBackedDescriptors = scopeBackedGroupDescriptors(
+				store,
+				normalizedConfiguredCoordinatorId,
+				MAX_CONFIGURED_GROUPS - configuredIds.length,
+				configuredIds,
+			);
+		} catch {
+			// Scope discovery is additive. Preserve configured coordinator candidates
+			// when local evidence cannot be read.
+			scopeBackedDescriptors = [];
+		}
+	}
+	return [
+		...configuredIds.map((groupId) => ({ groupId, coordinatorId: configuredCoordinatorId })),
+		...scopeBackedDescriptors,
+	];
 }
 
 function scopeBackedGroupDescriptors(
@@ -343,39 +374,28 @@ async function loadConfiguredLegacyTeamGroupSnapshotsWith(
 	} catch {
 		throw safeCoordinatorError();
 	}
-	const configuredIds = configuredGroupIds(config.syncCoordinatorGroups);
 	const hasUrl = Boolean(config.syncCoordinatorUrl);
 	const hasSecret = Boolean(config.syncCoordinatorAdminSecret);
-	if (!hasUrl && !hasSecret && configuredIds.length === 0) return [];
+	if (!hasUrl && !hasSecret && config.syncCoordinatorGroups.length === 0) return [];
 	if (!hasUrl || !hasSecret) throw safeCoordinatorError();
 
 	try {
 		const configuredCoordinatorId = buildBaseUrl(config.syncCoordinatorUrl);
-		const normalizedConfiguredCoordinatorId = normalizedCoordinatorId(configuredCoordinatorId);
-		if (!configuredCoordinatorId || !normalizedConfiguredCoordinatorId) {
-			throw safeCoordinatorError();
-		}
+		if (!configuredCoordinatorId) throw safeCoordinatorError();
 		const remoteUrl = configuredCoordinatorId;
-		const remainingEvidenceSlots = MAX_CONFIGURED_GROUPS - configuredIds.length;
-		let scopeBackedDescriptors: LegacyTeamCandidateGroupDescriptor[] = [];
-		if (getStore) {
-			try {
-				scopeBackedDescriptors = scopeBackedGroupDescriptors(
-					getStore(),
-					normalizedConfiguredCoordinatorId,
-					remainingEvidenceSlots,
-					configuredIds,
-				);
-			} catch {
-				// Scope discovery is additive. Preserve configured coordinator
-				// candidates when local evidence cannot be read.
-				scopeBackedDescriptors = [];
-			}
+		let store: MemoryStore | undefined;
+		try {
+			store = getStore?.();
+		} catch {
+			// Scope discovery is additive. Preserve configured coordinator candidates
+			// when local evidence cannot be read.
+			store = undefined;
 		}
-		const groupDescriptors: LegacyTeamCandidateGroupDescriptor[] = [
-			...configuredIds.map((groupId) => ({ groupId, coordinatorId: configuredCoordinatorId })),
-			...scopeBackedDescriptors,
-		];
+		const groupDescriptors = legacyTeamCandidateGroupDescriptors(
+			store,
+			config.syncCoordinatorUrl,
+			config.syncCoordinatorGroups,
+		);
 		if (groupDescriptors.length === 0) throw safeCoordinatorError();
 		const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
 		const requestedGroupDescriptors = options.candidateRef
@@ -1125,6 +1145,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		() => loadedSnapshots(),
 		SUMMARY_SNAPSHOT_CACHE_TTL_MS,
 	);
+	options.registerSummaryInvalidator?.(() => loadedSummarySnapshots.invalidate());
 	async function loadedCandidateSnapshots(
 		candidateRef: string,
 	): Promise<LegacyTeamConfiguredGroupSnapshot[]> {


### PR DESCRIPTION
## Description
Add Team-name management to Sharing for local and proven coordinator-linked Teams. Rename operations use exact setup metadata, deterministic identity, safe errors, and concurrency protection.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced