### PR TITLE
feat: mark coordinator administration as legacy

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -219,7 +219,7 @@ To rename an active Team, open **Sharing → Teams**, choose **Team settings**, 
 
 If a Team needs device setup, **Sharing** shows a notice and **Continue setup**. The Teams list shows **Needs setup**, **In progress**, or **Ready**.
 
-1. In **Review devices**, confirm a suggested person or choose an existing person. To add a missing person, open **Advanced → Manual device and identity controls**, choose **Create person**, then return to setup. Each confirmed assignment saves immediately and resumes if you leave or reload the page. A suggestion is never selected for you.
+1. In **Review devices**, confirm a suggested person or choose an existing person. To add a missing person, open **Advanced (legacy) → Manual device and identity controls**, choose **Create person**, then return to setup. Each confirmed assignment saves immediately and resumes if you leave or reload the page. A suggestion is never selected for you.
 2. Still in **Review devices**, include each device with its confirmed person, choose **Exclude**, or clear an earlier choice to review it again. An exclusion applies only to this Team; a confirmed person assignment can be reused by another Team.
 3. In **Review Projects**, check every Project. Codemem can recognize some Projects automatically; choose an explicit Project mapping for any it cannot. Unresolved Projects prevent finishing.
 4. In the final review, check the server-provided list of people, included and excluded devices, Project mappings, and every access change. Nothing changes while you are reviewing or saving choices.
@@ -290,13 +290,17 @@ The **Sharing** tab shows an attention notice while device setup, pairing, repai
 
 An offline device is a passive waiting state, not a failure or revocation. It keeps its current access and catches up after reconnecting. Retry only when codemem shows **Needs attention**; retry preserves completed setup work and resumes from the failed step.
 
-Disabling a device enrollment for one coordinator group revokes future delivery only for Projects in that group. The global identity device remains active, stays in **Devices**, and can retain access granted through other groups. Use **Advanced → Team administration** to review or re-enable the affected group enrollment. Re-enabling clears the disabled state; the next owner reconciliation pass then restores only the Projects currently authorized through the Identity's direct shares and Team policies for that group. Delivery resumes without a broader re-invite, and unrelated Projects remain absent. A separate global identity-device revocation removes the device from the active list; it is not restored through the group enrollment action. Neither revocation nor disabling can delete memories already copied to a recipient device.
+Disabling a device enrollment for one coordinator group revokes future delivery only for Projects in that group. The global identity device remains active, stays in **Devices**, and can retain access granted through other groups. Use **Advanced (legacy) → Coordinator administration (legacy)** only to review or re-enable that technical group enrollment. Re-enabling clears the disabled state; the next owner reconciliation pass then restores only the Projects currently authorized through the Identity's direct shares and Team policies for that group. Delivery resumes without a broader re-invite, and unrelated Projects remain absent. A separate global identity-device revocation removes the device from the active list; it is not restored through the group enrollment action. Neither revocation nor disabling can delete memories already copied to a recipient device.
 
 ## Advanced operator and compatibility guidance
 
-Use this section for same-person devices, existing integrations, diagnostics, or self-hosted coordination. These controls preserve internal compatibility; they are not required for the normal Projects → Sharing → Devices → Health workflow.
+**Sharing is the primary supported Team experience.** Use **Sharing → Teams** for Team membership, Team names, Identity relationships, and inherited Project access. Use **Projects** to choose exact Project recipients.
 
-Legacy `#sync` and `#sync/diagnostics` viewer links remain valid Advanced routes. Saved Sync views and coordinator administration remain available through **Advanced**.
+**Advanced (legacy)** is technical administration for compatibility, recovery, diagnostics, and self-hosted coordination. Its coordinator groups and Spaces are discovery and transport boundaries, not policy Teams. Creating, renaming, archiving, or restoring a coordinator group does not safely create, rename, archive, or change access for a Team in Sharing. Archiving a coordinator group stops its coordinator presence, peer discovery, Space grants, legacy invites, and joins, and removes that group from this device's local coordinator configuration. Restoring the remote group does not re-add that local configuration; configure this device separately before expecting presence or discovery here. Policy Team membership and Project access in Sharing remain separate and unchanged.
+
+Use this section for same-person devices, existing integrations, diagnostics, or self-hosted coordination. These controls preserve internal compatibility and recovery capability; they are not required for the normal Projects → Sharing → Devices → Health workflow.
+
+Legacy `#sync` and `#sync/diagnostics` viewer links remain valid Advanced routes. Saved Sync views and coordinator administration remain available through **Advanced (legacy)**.
 
 ### Sync runtime
 
@@ -308,7 +312,7 @@ Legacy `#sync` and `#sync/diagnostics` viewer links remain valid Advanced routes
 
 Use manual pairing for same-person devices, existing integrations, or compatibility—not normal teammate sharing.
 
-1. In **Advanced**, open the Sync panel and scan/copy the QR payload (recommended).
+1. In **Advanced (legacy)**, open the Sync panel and scan/copy the QR payload (recommended).
 2. Or run `codemem sync pair` and copy the payload.
 3. On the other device, run `codemem sync pair --accept '<payload>'`.
 
@@ -383,7 +387,7 @@ codemem maintenance status
 
 ### Same-person device recovery
 
-- In **Advanced → Sync**, ownership summaries come from active `identity_devices` bindings. Use the device card's **Set up Identity in Devices** or **Review or rebind in Devices** action to confirm or change ownership.
+- In **Advanced (legacy) → Sync**, ownership summaries come from active `identity_devices` bindings. Use the device card's **Set up Identity in Devices** or **Review or rebind in Devices** action to confirm or change ownership.
 - A legacy `sync_peers.actor_id` value may appear as a suggested Identity, but it is only a hint. It does not become ownership until you explicitly review and confirm the binding in Devices.
 - Identity setup preserves the distinction between ownership, provenance, pairing, and access. Private sync still requires membership in a personal Sharing domain; an Identity binding is not an access grant.
 - If a machine is replaced or re-paired, use `Claim old device as mine` to reconnect older synced history to your local actor.

--- a/packages/ui/src/app-devices.test.tsx
+++ b/packages/ui/src/app-devices.test.tsx
@@ -292,6 +292,28 @@ describe("Devices app integration", () => {
 		expect(document.activeElement).toBe(document.getElementById("tabBtn-sharing"));
 	});
 
+	it("opens Sharing from the legacy coordinator notice and moves focus to its navigation control", async () => {
+		act(() => document.getElementById("coordinatorAdminOpenSharing")?.click());
+		await Promise.resolve();
+
+		expect(window.location.hash).toBe("#sharing");
+		expect(document.getElementById("tab-sharing")?.hidden).toBe(false);
+		expect(document.activeElement).toBe(document.getElementById("tabBtn-sharing"));
+	});
+
+	it("focuses the legacy notice when switching into coordinator administration", async () => {
+		act(() => document.getElementById("tabBtn-advanced")?.click());
+		await Promise.resolve();
+		act(() => document.getElementById("advancedTeamsButton")?.click());
+		await Promise.resolve();
+
+		expect(window.location.hash).toBe("#advanced/teams");
+		expect(document.getElementById("advancedTeamsContent")?.hidden).toBe(false);
+		expect(document.activeElement).toBe(
+			document.getElementById("coordinatorAdminLegacyNoticeTitle"),
+		);
+	});
+
 	it("opens the global Team setup dialog from Projects without changing tabs", async () => {
 		const { initProjectsTab } = await import("./tabs/projects");
 		const { openLegacyTeamSetup } = await import("./tabs/legacy-team-setup-dialog");

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -440,7 +440,15 @@ function initTabs() {
 		);
 	});
 	$("advancedSyncButton")?.addEventListener("click", () => setAdvancedSection("sync", true));
-	$("advancedTeamsButton")?.addEventListener("click", () => setAdvancedSection("teams", true));
+	$("advancedTeamsButton")?.addEventListener("click", () => {
+		setAdvancedSection("teams", true);
+		renderAdvancedSection();
+		queueMicrotask(() => document.getElementById("coordinatorAdminLegacyNoticeTitle")?.focus());
+	});
+	$("coordinatorAdminOpenSharing")?.addEventListener("click", () => {
+		switchTab("sharing", { canonicalHash: true });
+		queueMicrotask(() => document.getElementById("tabBtn-sharing")?.focus());
+	});
 
 	// Listen for hash changes (back/forward navigation). Hashes may include a
 	// sub-view segment (e.g. `#sync/diagnostics`) — parse with the shared
@@ -450,6 +458,9 @@ function initTabs() {
 		if (top) {
 			const advancedSection = parseAdvancedSectionFromHash();
 			switchTab(top, advancedSection ? { advancedSection } : {});
+			if (top === "advanced" && advancedSection === "teams") {
+				queueMicrotask(() => document.getElementById("coordinatorAdminLegacyNoticeTitle")?.focus());
+			}
 		}
 	});
 

--- a/packages/ui/src/project-first-layout.test.ts
+++ b/packages/ui/src/project-first-layout.test.ts
@@ -3,6 +3,12 @@
 import { describe, expect, it } from "vitest";
 import html from "../static/index.html?raw";
 import appSource from "./app.ts?raw";
+import coordinatorGroupsSource from "./tabs/coordinator-admin/components/groups-panel.ts?raw";
+import syncPeersSource from "./tabs/sync/components/sync-peers.tsx?raw";
+import syncPeopleSource from "./tabs/sync/people.ts?raw";
+import invitePanelSource from "./tabs/sync/team-sync/helpers/invite-panel-dom.ts?raw";
+import renderTeamSyncSource from "./tabs/sync/team-sync/render/render-team-sync.ts?raw";
+import coordinatorApprovalSource from "./tabs/sync/view-model/coordinator-approval.ts?raw";
 
 describe("project-first navigation layout", () => {
 	it("includes the Projects share-flow mount used by row-level Share actions", () => {
@@ -16,12 +22,12 @@ describe("project-first navigation layout", () => {
 		expect(appSource.match(/onOpenTeamSetup: openLegacyTeamSetup/g)).toHaveLength(2);
 	});
 
-	it("orders the visible navigation as Feed, Projects, Sharing, Devices, Health, Advanced", () => {
+	it("orders the visible navigation with Sharing before Advanced (legacy)", () => {
 		const navigation = html.slice(
 			html.indexOf('<nav class="tab-bar"'),
 			html.indexOf("</nav>", html.indexOf('<nav class="tab-bar"')),
 		);
-		const labels = ["Feed", "Projects", "Sharing", "Devices", "Health", "Advanced"];
+		const labels = ["Feed", "Projects", "Sharing", "Devices", "Health", "Advanced (legacy)"];
 		let previous = -1;
 		for (const label of labels) {
 			const index = navigation.indexOf(`>${label}</button>`);
@@ -36,7 +42,7 @@ describe("project-first navigation layout", () => {
 		const advancedTab = html.indexOf('id="tabBtn-advanced"');
 		const sharingMount = html.indexOf('id="recipientPolicySharingMount"');
 		const devicesMount = html.indexOf('id="devicesMount"');
-		const advancedDisclosure = html.indexOf("Advanced Team administration");
+		const advancedDisclosure = html.indexOf("Advanced coordinator administration (legacy)");
 		const coordinatorMount = html.indexOf('id="coordinatorAdminMount"');
 
 		expect(sharingTab).toBeGreaterThan(-1);
@@ -48,7 +54,7 @@ describe("project-first navigation layout", () => {
 		expect(coordinatorMount).toBeGreaterThan(advancedDisclosure);
 	});
 
-	it("reuses Sync and Team administration DOM inside the Advanced panel", () => {
+	it("reuses Sync and coordinator administration DOM inside the legacy Advanced panel", () => {
 		const advancedStart = html.indexOf('id="tab-advanced"');
 		const advancedEnd = html.indexOf('<script src="/assets/app.js">', advancedStart);
 		const advanced = html.slice(advancedStart, advancedEnd);
@@ -60,6 +66,84 @@ describe("project-first navigation layout", () => {
 		expect(advanced).toContain('id="coordinatorAdminMount"');
 		expect(advanced).toContain('href="#advanced/sync/diagnostics"');
 		expect(advanced).toContain('href="#advanced/sync"');
+	});
+
+	it("bounds legacy coordinator administration and directs ordinary Team work to Sharing", () => {
+		const advancedStart = html.indexOf('id="advancedTeamsContent"');
+		const advancedEnd = html.indexOf("</details>", advancedStart);
+		const advanced = html.slice(advancedStart, advancedEnd);
+
+		expect(advanced).toContain('role="note"');
+		expect(advanced).toContain('aria-labelledby="coordinatorAdminLegacyNoticeTitle"');
+		expect(advanced).toContain("not policy Teams");
+		expect(advanced).toContain(
+			"do not safely manage Team membership, Project access, Identity, or Team names",
+		);
+		expect(advanced).toContain('id="coordinatorAdminOpenSharing"');
+		expect(advanced).toContain(">Open Sharing</button>");
+		expect(html).toContain('aria-label="Advanced sections" role="group"');
+		expect(advanced).toContain('id="coordinatorAdminLegacyNoticeTitle" tabindex="-1"');
+	});
+
+	it("keeps the legacy notice visible when technical controls are collapsed", () => {
+		const panelStart = html.indexOf('id="advancedTeamsContent"');
+		const disclosureStart = html.indexOf("<details", panelStart);
+		const noticeStart = html.indexOf('class="coordinator-admin-inline-warning', panelStart);
+		const noticeEnd = html.indexOf("</aside>", noticeStart);
+		const coordinatorMount = html.indexOf('id="coordinatorAdminMount"', disclosureStart);
+
+		expect(noticeStart).toBeGreaterThan(panelStart);
+		expect(noticeEnd).toBeLessThan(disclosureStart);
+		expect(coordinatorMount).toBeGreaterThan(disclosureStart);
+	});
+
+	it("keeps the legacy notice responsive without removing recovery controls", () => {
+		expect(html).toContain(".coordinator-admin-legacy-notice");
+		expect(html).toMatch(
+			/@media \(max-width: 720px\)[\s\S]*\.coordinator-admin-legacy-notice[\s\S]*flex-direction: column/,
+		);
+		expect(html).toContain("Keep using these controls for compatibility and recovery.");
+		expect(html).toContain('id="coordinatorAdminMount"');
+	});
+
+	it("does not present the legacy coordinator surface as ordinary Team administration", () => {
+		const advancedStart = html.indexOf('id="advancedTeamsContent"');
+		const advanced = html.slice(advancedStart);
+
+		expect(advanced).not.toContain("Advanced Team administration");
+		expect(advanced).not.toContain(">Teams</button>");
+		expect(advanced).not.toContain("Manage Team membership");
+	});
+
+	it("labels legacy coordinator destinations consistently across Advanced Sync", () => {
+		const advancedSyncSources = [
+			syncPeersSource,
+			syncPeopleSource,
+			invitePanelSource,
+			renderTeamSyncSource,
+			coordinatorApprovalSource,
+		].join("\n");
+
+		expect(advancedSyncSources).toContain("coordinator administration (legacy)");
+		for (const forbidden of [
+			"Manage Spaces in Teams",
+			"Review Space access for this device in Teams",
+			"Advanced admin tools now live in Teams",
+			"Finish Teams setup",
+			"Review the Team setup",
+		]) {
+			expect(advancedSyncSources).not.toContain(forbidden);
+		}
+	});
+
+	it("warns before creating a legacy coordinator group without relabeling it as a Team", () => {
+		expect(coordinatorGroupsSource).toContain(
+			"Creating a coordinator group changes legacy discovery and transport setup only.",
+		);
+		expect(coordinatorGroupsSource).toContain("does not create a policy Team");
+		expect(coordinatorGroupsSource).toContain('"Create coordinator group"');
+		expect(coordinatorGroupsSource).not.toContain('"Create Team"');
+		expect(coordinatorGroupsSource).not.toContain('"Manage Team"');
 	});
 
 	it("marks only the initial Feed control with aria-current", () => {

--- a/packages/ui/src/tabs/coordinator-admin/components/devices-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/devices-panel.ts
@@ -35,8 +35,8 @@ export function renderDevicesPanel(deps: DevicesPanelDeps) {
 			"p",
 			{ class: "peer-submeta" },
 			summary.readiness === "ready"
-				? "Rename, disable, re-enable, or remove Team devices here. Space access is granted from Spaces below; Team membership alone does not share memories."
-				: "Finish setup first. Device administration stays disabled until Teams is ready.",
+				? "Rename, disable, re-enable, or remove devices from the selected coordinator group. Space transport access is managed below; policy Team membership and Project access stay in Sharing."
+				: "Finish coordinator setup first. Device administration stays disabled until legacy administration is ready.",
 		),
 		!items.length
 			? h(

--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -18,6 +18,7 @@ import { coordinatorAdminState, type GroupPreferencesDraft } from "../data/state
 import type { CoordinatorAdminSummary } from "../data/summary";
 import {
 	availableCoordinatorGroups,
+	coordinatorGroupPresentationName,
 	currentAdminTargetGroup,
 	setAdminTargetGroup,
 } from "../data/target-group";
@@ -80,11 +81,11 @@ async function openGroupPreferences(groupId: string, renderShell: () => void): P
 			saving: false,
 			error: "",
 		});
-	} catch (error) {
+	} catch {
 		coordinatorAdminState.groupPreferencesDrafts.set(groupId, {
 			...draft,
 			loaded: true,
-			error: error instanceof Error ? error.message : "Failed to load preferences.",
+			error: "Legacy group defaults are unavailable. Check coordinator recovery status and retry.",
 		});
 	}
 	renderShell();
@@ -121,9 +122,11 @@ async function saveGroupPreferences(groupId: string, renderShell: () => void): P
 	renderShell();
 	try {
 		await api.saveCoordinatorGroupPreferences(groupId, payload);
-		showGlobalNotice("Team defaults saved. New devices use these filters and Space settings.");
+		showGlobalNotice(
+			"Legacy coordinator group defaults saved. Sharing policy and Project access are unchanged.",
+		);
 		closeGroupPreferences(groupId, renderShell);
-	} catch (error) {
+	} catch {
 		// Re-read the latest draft so any keystrokes landed during the save are
 		// preserved; only clobber saving + error fields.
 		const latest = coordinatorAdminState.groupPreferencesDrafts.get(groupId);
@@ -131,7 +134,8 @@ async function saveGroupPreferences(groupId: string, renderShell: () => void): P
 		coordinatorAdminState.groupPreferencesDrafts.set(groupId, {
 			...latest,
 			saving: false,
-			error: error instanceof Error ? error.message : "Failed to save preferences.",
+			error:
+				"Could not save legacy group defaults. Sharing policy is unchanged; retry after coordinator recovery.",
 		});
 		renderShell();
 	}
@@ -155,7 +159,7 @@ function renderGroupPreferencesEditor(
 	return h(
 		Fragment,
 		null,
-		h("h4", { class: "coordinator-admin-drawer-title" }, "Team defaults"),
+		h("h4", { class: "coordinator-admin-drawer-title" }, "Legacy group defaults"),
 		h(
 			"div",
 			{ class: "peer-submeta" },
@@ -194,7 +198,7 @@ function renderGroupPreferencesEditor(
 			h(
 				"span",
 				{ class: "section-meta", id: autoGrantLabelId },
-				"Auto-grant default Space on join",
+				"Auto-grant default Space on coordinator join",
 			),
 			h(RadixSwitch, {
 				"aria-labelledby": autoGrantLabelId,
@@ -293,7 +297,7 @@ function renderGroupPreferencesEditor(
 function renderTeamSetupGuide(renderShell: () => void): ReturnType<typeof h> {
 	const guide = coordinatorAdminState.teamSetupGuide;
 	if (!guide) return null;
-	const title = guide.displayName || guide.groupId;
+	const title = coordinatorGroupPresentationName(guide.groupId, guide.displayName);
 	const warningStepById: Record<string, string> = {
 		default_space: "default Space setup",
 		default_space_grant: "default Space access grant",
@@ -302,17 +306,17 @@ function renderTeamSetupGuide(renderShell: () => void): ReturnType<typeof h> {
 	return h(
 		"div",
 		{ class: "peer-meta coordinator-admin-empty-state" },
-		h("h4", { class: "coordinator-admin-drawer-title" }, `Set up ${title}`),
+		h("h4", { class: "coordinator-admin-drawer-title" }, `Set up legacy group ${title}`),
 		h(
 			"div",
 			{ class: "peer-submeta" },
-			"A Team organizes people and devices. The default Space is the memory boundary; Team membership only grants data access when default Space auto-grant is enabled.",
+			"This coordinator group organizes technical discovery and enrollment. It is not a policy Team; use Sharing to manage Team membership and Project access.",
 		),
 		guide.setupWarning
 			? h(
 					"div",
 					{ class: "peer-meta coordinator-admin-inline-warning" },
-					`Team created, but ${warningStep} failed. Automatic repair is not available yet; use Spaces to inspect or create access manually before inviting teammates.`,
+					`Legacy coordinator group created, but ${warningStep} failed. Automatic repair is not available yet; use Spaces to inspect or create transport access manually. Sharing policy is unchanged.`,
 				)
 			: h(
 					"div",
@@ -326,9 +330,9 @@ function renderTeamSetupGuide(renderShell: () => void): ReturnType<typeof h> {
 		h(
 			"ol",
 			{ class: "peer-submeta" },
-			h("li", null, "Review Team defaults and the auto-grant default Space setting."),
-			h("li", null, "Invite teammates or other devices."),
-			h("li", null, "Assign projects to Spaces from the Projects tab."),
+			h("li", null, "Review legacy group defaults and the auto-grant default Space setting."),
+			h("li", null, "Use legacy enrollment only when compatibility or recovery requires it."),
+			h("li", null, "Open Sharing for Team membership and Project access."),
 		),
 		h(
 			"div",
@@ -343,7 +347,7 @@ function renderTeamSetupGuide(renderShell: () => void): ReturnType<typeof h> {
 					},
 					type: "button",
 				},
-				"Review Team defaults",
+				"Review legacy defaults",
 			),
 			h(
 				"button",
@@ -367,7 +371,7 @@ function renderTeamSetupGuide(renderShell: () => void): ReturnType<typeof h> {
 					},
 					type: "button",
 				},
-				"Invite devices",
+				"Create legacy device invite",
 			),
 			h(
 				"button",
@@ -378,7 +382,7 @@ function renderTeamSetupGuide(renderShell: () => void): ReturnType<typeof h> {
 					},
 					type: "button",
 				},
-				"Assign projects",
+				"Open Projects",
 			),
 			h(
 				"button",
@@ -397,7 +401,7 @@ function renderTeamSetupGuide(renderShell: () => void): ReturnType<typeof h> {
 }
 
 function archiveButtonLabel(archived: boolean, pending: boolean): string {
-	if (pending) return archived ? "Restoring…" : "Archiving…";
+	if (pending) return archived ? "Unarchiving…" : "Archiving…";
 	return archived ? "Unarchive" : "Archive";
 }
 
@@ -429,22 +433,22 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 	return h(
 		RadixTabsContent,
 		{ className: "coordinator-admin-panel", value: "groups" },
-		h("h3", null, "Teams"),
+		h("h3", null, "Coordinator groups"),
 		h(
 			"p",
 			{ class: "peer-submeta" },
 			selectedGroup
-				? `Managing ${selectedGroup}${configuredGroup && configuredGroup !== selectedGroup ? ` · this node uses ${configuredGroup} for discovery` : ""}`
+				? `Managing the selected coordinator group${configuredGroup && configuredGroup !== selectedGroup ? " · this node uses a different group for discovery" : ""}`
 				: configuredGroup
-					? `This node uses ${configuredGroup} for discovery. Select a Team below to manage it.`
-					: "No Team selected yet. Create one or select an existing Team to manage.",
+					? `This node uses ${configuredGroup} for discovery. Select a coordinator group below to manage it.`
+					: "No coordinator group selected yet. Create one or select an existing group to manage.",
 		),
 		groups.length ? h("p", { class: "peer-submeta" }, countParts.join(" · ")) : null,
 		!targetExists && selectedGroup
 			? h(
 					"div",
 					{ class: "peer-meta coordinator-admin-inline-warning" },
-					`The selected Team (${selectedGroup}) is configured locally but does not exist in the coordinator yet. Create it below or switch to another Team once one exists.`,
+					"The selected legacy group is configured locally but does not exist in the coordinator yet. Create it below or switch to another coordinator group once one exists.",
 				)
 			: null,
 		renderTeamSetupGuide(renderShell),
@@ -463,11 +467,16 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 				},
 				h(
 					"div",
+					{ class: "peer-meta coordinator-admin-inline-warning", role: "note" },
+					"Creating a coordinator group changes legacy discovery and transport setup only. It does not create a policy Team or grant Project access in Sharing.",
+				),
+				h(
+					"div",
 					{ class: "coordinator-admin-form-grid" },
 					h(
 						"label",
 						{ class: "coordinator-admin-field" },
-						h("span", null, "New Team id"),
+						h("span", null, "New coordinator group ID"),
 						h(TextInput, {
 							class: "peer-scope-input",
 							disabled: createGroupDisabled,
@@ -476,7 +485,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 									(event.currentTarget as HTMLInputElement).value || "",
 								);
 							},
-							placeholder: "team-alpha",
+							placeholder: "group-alpha",
 							type: "text",
 							value: coordinatorAdminState.createGroupId,
 						}),
@@ -484,7 +493,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 					h(
 						"label",
 						{ class: "coordinator-admin-field" },
-						h("span", null, "Display name"),
+						h("span", null, "Legacy group display name"),
 						h(TextInput, {
 							class: "peer-scope-input",
 							disabled: createGroupDisabled,
@@ -493,7 +502,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 									(event.currentTarget as HTMLInputElement).value || "",
 								);
 							},
-							placeholder: "Team Alpha",
+							placeholder: "Legacy group Alpha",
 							type: "text",
 							value: coordinatorAdminState.createGroupDisplayName,
 						}),
@@ -514,7 +523,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 							},
 							coordinatorAdminState.groupActionPendingKind === "create"
 								? "Creating…"
-								: "Create Team",
+								: "Create coordinator group",
 						),
 					),
 					h(
@@ -550,9 +559,9 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 					{ class: "peer-meta coordinator-admin-empty-state" },
 					summary.readiness === "ready"
 						? coordinatorAdminState.showArchivedGroups
-							? "No Teams are available yet."
-							: "No active Teams yet. Create one to get started."
-						: "Team browsing will appear here once setup is complete.",
+							? "No coordinator groups are available yet."
+							: "No active coordinator groups yet. Create one only for legacy discovery or recovery."
+						: "Coordinator group browsing will appear here once setup is complete.",
 				)
 			: h(
 					"div",
@@ -564,7 +573,10 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 						const draftName =
 							coordinatorAdminState.groupRenameDrafts.get(group.group_id) ??
 							group.display_name ??
-							group.group_id;
+							"";
+						const presentationName =
+							draftName.trim() ||
+							coordinatorGroupPresentationName(group.group_id, group.display_name);
 						const scopeOpen = coordinatorAdminState.groupPreferencesOpen.has(group.group_id);
 						const domainsOpen = coordinatorAdminState.groupScopeManagementOpen.has(group.group_id);
 						const archiveActionKind = archived ? "unarchive" : "archive";
@@ -580,9 +592,13 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 						return h(
 							"div",
 							{ class: "peer-card peer-card--padded", key: group.group_id },
-							h("div", { class: "peer-title" }, h("strong", null, draftName)),
-							h("div", { class: "peer-submeta" }, archived ? "Archived Team" : "Active Team"),
-							h("div", { class: "peer-meta" }, `Advanced: Team ID ${group.group_id}`),
+							h("div", { class: "peer-title" }, h("strong", null, presentationName)),
+							h(
+								"div",
+								{ class: "peer-submeta" },
+								archived ? "Archived coordinator group" : "Active coordinator group",
+							),
+							h("div", { class: "peer-meta" }, `Advanced: Group ID ${group.group_id}`),
 							h(
 								"div",
 								{ class: "coordinator-admin-summary-grid" },
@@ -609,13 +625,13 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 								? h(
 										"div",
 										{ class: "peer-submeta" },
-										"This node uses this Team for coordinator-backed discovery.",
+										"This node uses this coordinator group for discovery.",
 									)
 								: null,
 							h(
 								"label",
 								{ class: "coordinator-admin-field" },
-								h("span", null, "Display name"),
+								h("span", null, "Legacy group display name"),
 								h(TextInput, {
 									class: "peer-scope-input",
 									disabled: summary.readiness !== "ready" || pending,
@@ -643,7 +659,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 										},
 										type: "button",
 									},
-									selected ? "Managing" : "Manage Team",
+									selected ? "Managing" : "Manage group",
 								),
 								h(
 									"button",
@@ -655,7 +671,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 									},
 									pending && coordinatorAdminState.groupActionPendingKind === "rename"
 										? "Renaming…"
-										: "Rename",
+										: "Rename group",
 								),
 								h(
 									"button",
@@ -674,7 +690,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 										},
 										type: "button",
 									},
-									h("span", null, "Team defaults"),
+									h("span", null, "Legacy group defaults"),
 									h(
 										"span",
 										{ "aria-hidden": "true", class: "device-row-chevron" },
@@ -733,7 +749,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 								h(
 									Collapsible.Content,
 									{
-										"aria-label": `Project defaults for ${draftName}`,
+										"aria-label": `Project defaults for ${presentationName}`,
 										class: "coordinator-admin-group-preferences",
 										id: `coord-admin-project-defaults-drawer-${group.group_id}`,
 									},
@@ -758,7 +774,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 								h(
 									Collapsible.Content,
 									{
-										"aria-label": `Spaces for ${draftName}`,
+										"aria-label": `Spaces for ${presentationName}`,
 										class:
 											"coordinator-admin-group-preferences coordinator-admin-domain-management",
 										id: `coord-admin-spaces-drawer-${group.group_id}`,

--- a/packages/ui/src/tabs/coordinator-admin/components/invites-panel.test.tsx
+++ b/packages/ui/src/tabs/coordinator-admin/components/invites-panel.test.tsx
@@ -4,7 +4,7 @@ import { state } from "../../../lib/state";
 import { coordinatorAdminState } from "../data/state";
 import { renderInvitesPanel } from "./invites-panel";
 
-describe("Teams invite panel", () => {
+describe("legacy coordinator invite panel", () => {
 	function textContent(value: ComponentChildren): string {
 		if (value == null || typeof value === "boolean") return "";
 		if (typeof value === "string" || typeof value === "number") return String(value);
@@ -55,8 +55,8 @@ describe("Teams invite panel", () => {
 			}),
 		);
 
-		expect(text).toContain("Legacy Team invites");
-		expect(text).toContain("do not grant project access");
+		expect(text).toContain("Legacy coordinator invites");
+		expect(text).toContain("do not add policy Team membership or grant Project access");
 		expect(text).toContain("Brian");
 		expect(text).toContain("codemem");
 		expect(text).toContain("Up to date");

--- a/packages/ui/src/tabs/coordinator-admin/components/invites-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/invites-panel.ts
@@ -34,13 +34,13 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 	return h(
 		RadixTabsContent,
 		{ className: "coordinator-admin-panel", value: "invites" },
-		h("h3", null, "Legacy Team invites"),
+		h("h3", null, "Legacy coordinator invites"),
 		h(
 			"p",
 			{ class: "peer-submeta" },
 			summary.readiness === "ready"
-				? "Legacy Team invites enroll a device in the selected Team. They do not grant project access; share projects from Projects instead."
-				: "Finish setup first. Invite creation stays disabled until the local Teams configuration is ready.",
+				? "Legacy coordinator invites enroll a device in the selected group for discovery. They do not add policy Team membership or grant Project access; use Sharing for both."
+				: "Finish coordinator setup first. Legacy invite creation stays disabled until the local configuration is ready.",
 		),
 		h(
 			"form",
@@ -58,7 +58,7 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 				h(
 					"label",
 					{ class: "coordinator-admin-field" },
-					h("span", null, "Team"),
+					h("span", null, "Coordinator group"),
 					h(TextInput, {
 						class: "peer-scope-input",
 						disabled: summary.readiness !== "ready",
@@ -68,7 +68,7 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 							);
 							renderShell();
 						},
-						placeholder: activeGroup || "team-alpha",
+						placeholder: activeGroup || "group-alpha",
 						type: "text",
 						value: coordinatorAdminState.inviteGroup,
 					}),
@@ -89,8 +89,8 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 							renderShell();
 						},
 						options: [
-							{ value: "auto_admit", label: "Auto-admit to Team" },
-							{ value: "approval_required", label: "Require approval to join Team" },
+							{ value: "auto_admit", label: "Auto-admit to coordinator group" },
+							{ value: "approval_required", label: "Require approval to join group" },
 						],
 						triggerClassName: "sync-radix-select-trigger sync-actor-select",
 						value: coordinatorAdminState.invitePolicy,
@@ -125,10 +125,10 @@ export function renderInvitesPanel(deps: InvitesPanelDeps) {
 						disabled: inviteDisabled,
 						type: "submit",
 					},
-					coordinatorAdminState.invitePending ? "Creating…" : "Create legacy Team invite",
+					coordinatorAdminState.invitePending ? "Creating…" : "Create legacy coordinator invite",
 				),
 				effectiveGroup
-					? h("span", { class: "peer-submeta" }, `Using Team ${effectiveGroup}`)
+					? h("span", { class: "peer-submeta" }, "Using the selected coordinator group")
 					: null,
 			),
 		),

--- a/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
@@ -27,8 +27,8 @@ export function renderJoinRequestsPanel(deps: JoinRequestsPanelDeps) {
 			"p",
 			{ class: "peer-submeta" },
 			summary.readiness === "ready"
-				? "Approve or deny devices that want to join this Team. Default Space access is handled by Team defaults and can be reviewed in Spaces."
-				: "Finish setup first. Join request review stays disabled until Teams is ready.",
+				? "Approve or deny devices that want to join this legacy coordinator group. Space transport access is handled by legacy group defaults and can be reviewed in Spaces; Sharing policy is separate."
+				: "Finish coordinator setup first. Join request review stays disabled until legacy administration is ready.",
 		),
 		!items.length
 			? h(

--- a/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { safeSpaceOperationError } from "./scope-management-panel";
+
+describe("legacy Space operation errors", () => {
+	it.each([
+		["Group is archived", "Restore this legacy coordinator group before changing Space access."],
+		[
+			"group_not_found: private-group-id",
+			"This legacy coordinator group no longer exists. Refresh Advanced administration.",
+		],
+		[
+			"scope_not_found: private-scope-id",
+			"This Space no longer exists. Refresh legacy Spaces before retrying.",
+		],
+		[
+			"device_not_enrolled_for_scope_group: private-device-id",
+			"This device is no longer enrolled in the legacy coordinator group. Refresh devices before retrying.",
+		],
+		["scope_not_active", "Restore this legacy Space before changing its access."],
+		[
+			"membership_not_found",
+			"This device no longer has access to the Space. Refresh legacy Spaces.",
+		],
+		[
+			"scopeId already exists.: private-scope-id",
+			"A Space already uses that ID. Choose a different Space ID or refresh legacy Spaces. Sharing policy is unchanged.",
+		],
+	] as const)("maps %s to safe actionable guidance", (message, expected) => {
+		expect(safeSpaceOperationError(new Error(message), "recovery fallback")).toBe(expected);
+		expect(safeSpaceOperationError(new Error(message), "recovery fallback")).not.toContain(
+			"private-",
+		);
+	});
+
+	it("keeps the recovery fallback for unknown failures", () => {
+		expect(
+			safeSpaceOperationError(new Error("private coordinator detail"), "recovery fallback"),
+		).toBe("recovery fallback");
+		expect(safeSpaceOperationError("group_archived", "recovery fallback")).toBe(
+			"recovery fallback",
+		);
+	});
+});

--- a/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/scope-management-panel.ts
@@ -63,6 +63,35 @@ function setDraft(groupId: string, draft: GroupScopeManagementDraft): void {
 	coordinatorAdminState.groupScopeManagementDrafts.set(groupId, draft);
 }
 
+export function safeSpaceOperationError(cause: unknown, fallback: string): string {
+	const message = cause instanceof Error ? cause.message : "";
+	if (message.includes("group_archived") || message.includes("Group is archived")) {
+		return "Restore this legacy coordinator group before changing Space access.";
+	}
+	if (message.includes("group_not_found") || message.includes("Group not found")) {
+		return "This legacy coordinator group no longer exists. Refresh Advanced administration.";
+	}
+	if (message.includes("scope_not_found") || message.includes("Scope not found")) {
+		return "This Space no longer exists. Refresh legacy Spaces before retrying.";
+	}
+	if (message.includes("scope_not_active") || message.includes("Scope is not active")) {
+		return "Restore this legacy Space before changing its access.";
+	}
+	if (message.includes("scopeId already exists")) {
+		return "A Space already uses that ID. Choose a different Space ID or refresh legacy Spaces. Sharing policy is unchanged.";
+	}
+	if (
+		message.includes("device_not_enrolled_for_scope_group") ||
+		message.includes("device must be enrolled")
+	) {
+		return "This device is no longer enrolled in the legacy coordinator group. Refresh devices before retrying.";
+	}
+	if (message.includes("membership_not_found")) {
+		return "This device no longer has access to the Space. Refresh legacy Spaces.";
+	}
+	return fallback;
+}
+
 async function loadGroupScopeManagement(
 	groupId: string,
 	renderShell: () => void,
@@ -99,12 +128,12 @@ async function loadGroupScopeManagement(
 			actionPendingKey: "",
 			actionPendingKind: "",
 		});
-	} catch (error) {
+	} catch {
 		setDraft(groupId, {
 			...draftFor(groupId),
 			loaded: true,
 			loading: false,
-			error: error instanceof Error ? error.message : "Failed to load Spaces.",
+			error: "Legacy Spaces are unavailable. Check coordinator recovery status and retry.",
 		});
 	}
 	renderShell();
@@ -157,12 +186,15 @@ async function createScope(groupId: string, renderShell: () => void): Promise<vo
 		});
 		showGlobalNotice("Space created. Grant devices explicitly before data can sync.");
 		await loadGroupScopeManagement(groupId, renderShell, latest.includeInactive);
-	} catch (error) {
+	} catch (cause) {
 		setDraft(groupId, {
 			...draftFor(groupId),
 			actionPendingKey: "",
 			actionPendingKind: "",
-			error: error instanceof Error ? error.message : "Failed to create Space.",
+			error: safeSpaceOperationError(
+				cause,
+				"Could not create the legacy Space. Sharing policy is unchanged; retry after coordinator recovery.",
+			),
 		});
 		renderShell();
 	}
@@ -186,12 +218,15 @@ async function grantMember(
 		});
 		showGlobalNotice("Device granted access to the Space.");
 		await loadGroupScopeManagement(groupId, renderShell, draft.includeInactive);
-	} catch (error) {
+	} catch (cause) {
 		setDraft(groupId, {
 			...draftFor(groupId),
 			actionPendingKey: "",
 			actionPendingKind: "",
-			error: error instanceof Error ? error.message : "Failed to grant Space access.",
+			error: safeSpaceOperationError(
+				cause,
+				"Could not grant legacy Space transport access. Sharing policy is unchanged; retry after coordinator recovery.",
+			),
 		});
 		renderShell();
 	}
@@ -224,12 +259,15 @@ async function revokeMember(
 		await api.revokeCoordinatorAdminScopeMember(groupId, scopeId, deviceId);
 		showGlobalNotice("Space access revoked. Future sync is blocked for that device.");
 		await loadGroupScopeManagement(groupId, renderShell, draft.includeInactive);
-	} catch (error) {
+	} catch (cause) {
 		setDraft(groupId, {
 			...draftFor(groupId),
 			actionPendingKey: "",
 			actionPendingKind: "",
-			error: error instanceof Error ? error.message : "Failed to revoke Space access.",
+			error: safeSpaceOperationError(
+				cause,
+				"Could not revoke legacy Space transport access. Sharing policy is unchanged; retry after coordinator recovery.",
+			),
 		});
 		renderShell();
 	}
@@ -254,7 +292,7 @@ function renderMembershipRows(
 		return h(
 			"div",
 			{ class: "peer-submeta coordinator-admin-empty-state" },
-			"No enrolled devices in this Team yet. Enroll a device before granting this Space.",
+			"No devices are enrolled in this coordinator group yet. Enroll a device before granting this Space.",
 		);
 	}
 	return h(
@@ -275,7 +313,7 @@ function renderMembershipRows(
 					h("strong", null, row.displayName),
 					h("span", null, copy.detail),
 					h("span", { class: "peer-meta" }, copy.advancedDetail),
-					row.enabled ? null : h("span", null, "Device is disabled in this Team."),
+					row.enabled ? null : h("span", null, "Device is disabled in this coordinator group."),
 				),
 				h(
 					"div",
@@ -332,7 +370,7 @@ function renderScopeCard(
 		h(
 			"div",
 			{ class: "peer-submeta" },
-			"Devices below are enrolled in the Team; only active Space members can sync this data boundary.",
+			"Devices below are enrolled in the coordinator group; only active Space members can sync this transport boundary.",
 		),
 		renderMembershipRows(groupId, scope, draft, ready, renderShell),
 	);
@@ -357,7 +395,7 @@ export function renderGroupScopeManagementPanel(deps: ScopeManagementPanelDeps) 
 		h(
 			"div",
 			{ class: "peer-submeta" },
-			"Teams discover and enroll devices. Spaces grant data access. Granting a device here is explicit; Team membership alone does not share memories.",
+			"Coordinator groups discover and enroll devices. Spaces are technical transport boundaries here. These controls do not manage policy Team membership or Project access in Sharing.",
 		),
 		h(
 			"label",
@@ -484,7 +522,7 @@ export function renderGroupScopeManagementPanel(deps: ScopeManagementPanelDeps) 
 			: h(
 					"div",
 					{ class: "peer-meta coordinator-admin-empty-state" },
-					"No Spaces are defined for this Team yet. Create a Space, then grant specific devices. Projects stay local-only until assigned to a Space.",
+					"No Spaces are defined for this coordinator group yet. Create a Space only for legacy transport or recovery, then grant specific devices. Sharing policy remains separate.",
 				),
 	);
 }

--- a/packages/ui/src/tabs/coordinator-admin/data/actions.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/actions.test.ts
@@ -6,15 +6,30 @@ import { coordinatorAdminState } from "./state";
 
 const mocks = vi.hoisted(() => ({
 	createCoordinatorAdminGroup: vi.fn(),
+	archiveCoordinatorAdminGroup: vi.fn(),
 	createCoordinatorInvite: vi.fn(),
+	disableCoordinatorAdminDevice: vi.fn(),
+	enableCoordinatorAdminDevice: vi.fn(),
+	openSyncConfirmDialog: vi.fn(),
+	renameCoordinatorAdminGroup: vi.fn(),
+	renameCoordinatorAdminDevice: vi.fn(),
+	removeCoordinatorAdminDevice: vi.fn(),
 	reviewCoordinatorAdminJoinRequest: vi.fn(),
 	showGlobalNotice: vi.fn(),
+	unarchiveCoordinatorAdminGroup: vi.fn(),
 }));
 
 vi.mock("../../../lib/api", () => ({
+	archiveCoordinatorAdminGroup: mocks.archiveCoordinatorAdminGroup,
 	createCoordinatorAdminGroup: mocks.createCoordinatorAdminGroup,
 	createCoordinatorInvite: mocks.createCoordinatorInvite,
+	disableCoordinatorAdminDevice: mocks.disableCoordinatorAdminDevice,
+	enableCoordinatorAdminDevice: mocks.enableCoordinatorAdminDevice,
+	renameCoordinatorAdminGroup: mocks.renameCoordinatorAdminGroup,
+	renameCoordinatorAdminDevice: mocks.renameCoordinatorAdminDevice,
+	removeCoordinatorAdminDevice: mocks.removeCoordinatorAdminDevice,
 	reviewCoordinatorAdminJoinRequest: mocks.reviewCoordinatorAdminJoinRequest,
+	unarchiveCoordinatorAdminGroup: mocks.unarchiveCoordinatorAdminGroup,
 }));
 
 vi.mock("../../../lib/notice", () => ({
@@ -22,27 +37,44 @@ vi.mock("../../../lib/notice", () => ({
 }));
 
 vi.mock("../../sync/sync-dialogs", () => ({
-	openSyncConfirmDialog: vi.fn(),
+	openSyncConfirmDialog: mocks.openSyncConfirmDialog,
 }));
 
 describe("coordinator admin actions", () => {
 	beforeEach(() => {
+		mocks.archiveCoordinatorAdminGroup.mockReset();
 		mocks.createCoordinatorAdminGroup.mockReset();
 		mocks.createCoordinatorInvite.mockReset();
+		mocks.disableCoordinatorAdminDevice.mockReset();
+		mocks.enableCoordinatorAdminDevice.mockReset();
+		mocks.openSyncConfirmDialog.mockReset();
+		mocks.openSyncConfirmDialog.mockResolvedValue(true);
+		mocks.renameCoordinatorAdminGroup.mockReset();
+		mocks.renameCoordinatorAdminDevice.mockReset();
+		mocks.removeCoordinatorAdminDevice.mockReset();
 		mocks.reviewCoordinatorAdminJoinRequest.mockReset();
 		mocks.showGlobalNotice.mockReset();
+		mocks.unarchiveCoordinatorAdminGroup.mockReset();
 		state.coordinatorAdminTargetGroup = "";
 		state.lastCoordinatorAdminStatus = {
 			coordinator_url: "https://coordinator.example",
 			readiness: "ready",
 		};
+		state.lastCoordinatorAdminGroups = [
+			{ group_id: "group-alpha", display_name: "Current Alpha", archived_at: null },
+		];
 		coordinatorAdminState.createGroupId = "";
 		coordinatorAdminState.createGroupDisplayName = "";
 		coordinatorAdminState.groupActionPendingKind = "";
+		coordinatorAdminState.groupActionPendingId = "";
+		coordinatorAdminState.groupPresentationAliases.clear();
 		coordinatorAdminState.inviteGroup = "";
 		coordinatorAdminState.invitePending = false;
 		coordinatorAdminState.invitePolicy = "auto_admit";
 		coordinatorAdminState.inviteTtlHours = "24";
+		coordinatorAdminState.deviceActionPendingId = "";
+		coordinatorAdminState.deviceActionPendingKind = "";
+		coordinatorAdminState.deviceRenameDrafts.clear();
 		coordinatorAdminState.teamSetupGuide = null;
 		localStorage.clear();
 	});
@@ -73,7 +105,7 @@ describe("coordinator admin actions", () => {
 			setupWarning: null,
 		});
 		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
-			"Team created with a default Space.",
+			"Legacy coordinator group created with a default Space. Sharing policy is unchanged.",
 			"success",
 		);
 		expect(reloadData).toHaveBeenCalledTimes(2);
@@ -98,7 +130,7 @@ describe("coordinator admin actions", () => {
 			error: "coordinator unavailable",
 		});
 		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
-			"Team created, but default Space setup needs repair.",
+			"Legacy coordinator group created, but default Space setup needs repair. Sharing policy is unchanged.",
 			"warning",
 		);
 	});
@@ -127,7 +159,26 @@ describe("coordinator admin actions", () => {
 		expect(state.coordinatorAdminTargetGroup).toBe("team-new");
 	});
 
-	it("points successful invite sharing copy at Teams", async () => {
+	it("keeps a new unnamed group ID out of presentation state", async () => {
+		mocks.createCoordinatorAdminGroup.mockResolvedValue({
+			group: { group_id: "group-private", display_name: null },
+			default_space: null,
+		});
+		coordinatorAdminState.createGroupId = "group-private";
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await actions.createGroupFromAdminPanel();
+
+		expect(coordinatorAdminState.teamSetupGuide).toMatchObject({
+			groupId: "group-private",
+			displayName: "",
+		});
+	});
+
+	it("states that a legacy coordinator invite does not grant Sharing access", async () => {
 		mocks.createCoordinatorInvite.mockResolvedValue({ token: "invite-token", warnings: [] });
 		coordinatorAdminState.inviteGroup = "team-alpha";
 		const actions = createCoordinatorAdminActions({
@@ -143,8 +194,255 @@ describe("coordinator admin actions", () => {
 			ttl_hours: 24,
 		});
 		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
-			"Invite created. Copy it from Teams and share it with your teammate.",
+			"Legacy coordinator invite created. It does not grant Sharing Project access.",
 			"success",
+		);
+	});
+
+	it.each([
+		[
+			"Group not found: private-group-id",
+			"This legacy coordinator group no longer exists. Choose an active group or refresh coordinator groups.",
+		],
+		[
+			"Remote coordinator request failed (404): group_not_found",
+			"This legacy coordinator group no longer exists. Choose an active group or refresh coordinator groups.",
+		],
+		[
+			"group_archived: private-group-id",
+			"This legacy coordinator group is archived. Choose an active group or refresh coordinator groups.",
+		],
+		[
+			"Group is archived: private-group-id",
+			"This legacy coordinator group is archived. Choose an active group or refresh coordinator groups.",
+		],
+		[
+			"Remote coordinator request failed (409): group_archived",
+			"This legacy coordinator group is archived. Choose an active group or refresh coordinator groups.",
+		],
+	] as const)("preserves actionable invite guidance for %s", async (message, expected) => {
+		mocks.createCoordinatorInvite.mockRejectedValue(new Error(message));
+		coordinatorAdminState.inviteGroup = "private-group-id";
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await actions.createInviteFromAdminPanel();
+
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(expected, "warning");
+		expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain("private-group-id");
+	});
+
+	it.each([
+		new Error("private coordinator detail"),
+		"group_archived",
+	])("keeps generic recovery guidance for an unknown invite failure (%o)", async (cause) => {
+		mocks.createCoordinatorInvite.mockRejectedValue(cause);
+		coordinatorAdminState.inviteGroup = "team-alpha";
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await actions.createInviteFromAdminPanel();
+
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+			"Could not create the legacy coordinator invite. Sharing policy is unchanged; check coordinator recovery status and retry.",
+			"warning",
+		);
+		expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain(
+			"private coordinator detail",
+		);
+	});
+
+	it.each([
+		["approve", "join request not found: private-request-id"],
+		["approve", "Remote coordinator request failed (404): request_not_found"],
+		["deny", "join request not found: private-request-id"],
+		["deny", "Remote coordinator request failed (404): request_not_found"],
+	] as const)("refreshes pending requests when %s reports a missing request (%s)", async (action, message) => {
+		mocks.reviewCoordinatorAdminJoinRequest.mockRejectedValue(new Error(message));
+		const reloadData = vi.fn().mockResolvedValue(undefined);
+		const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
+
+		await actions.reviewJoinRequestFromAdminPanel("private-request-id", action);
+
+		expect(reloadData).toHaveBeenCalledTimes(1);
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+			"This legacy coordinator join request no longer exists. Pending requests were refreshed.",
+			"warning",
+		);
+		expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain("private-request-id");
+	});
+
+	it.each([
+		new Error("private coordinator detail"),
+		"request_not_found",
+	])("keeps recovery guidance for an unknown join-review failure (%o)", async (cause) => {
+		mocks.reviewCoordinatorAdminJoinRequest.mockRejectedValue(cause);
+		const reloadData = vi.fn().mockResolvedValue(undefined);
+		const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
+
+		await actions.reviewJoinRequestFromAdminPanel("join-1", "approve");
+
+		expect(reloadData).not.toHaveBeenCalled();
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+			"Could not review the legacy coordinator join request. Sharing policy is unchanged; check coordinator recovery status and retry.",
+			"warning",
+		);
+		expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain(
+			"private coordinator detail",
+		);
+	});
+
+	it("confirms that renaming a coordinator group does not rename a Sharing Team", async () => {
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await actions.runGroupAction("group-alpha", "Legacy Alpha", "rename");
+
+		expect(mocks.openSyncConfirmDialog).toHaveBeenCalledWith(
+			expect.objectContaining({
+				description: expect.stringMatching(/Target: Current Alpha.*does not rename a policy Team/),
+				confirmLabel: "Rename coordinator group",
+				tone: "default",
+			}),
+		);
+		expect(mocks.renameCoordinatorAdminGroup).toHaveBeenCalledWith("group-alpha", "Legacy Alpha");
+	});
+
+	it("rejects an empty legacy group name before confirmation", async () => {
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await actions.runGroupAction("group-alpha", "   ", "rename");
+
+		expect(mocks.openSyncConfirmDialog).not.toHaveBeenCalled();
+		expect(mocks.renameCoordinatorAdminGroup).not.toHaveBeenCalled();
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+			"Enter a legacy group display name before renaming it.",
+			"warning",
+		);
+	});
+
+	it("uses a privacy-safe alias when an unnamed group is renamed", async () => {
+		state.lastCoordinatorAdminGroups = [
+			{ group_id: "group-alpha", display_name: null, archived_at: null },
+			{ group_id: "group-beta", display_name: null, archived_at: null },
+		];
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await actions.runGroupAction("group-alpha", "Legacy Alpha", "rename");
+
+		expect(mocks.openSyncConfirmDialog).toHaveBeenCalledWith(
+			expect.objectContaining({
+				description: expect.stringContaining(
+					"Target: Unnamed coordinator group 1. New name: Legacy Alpha.",
+				),
+			}),
+		);
+	});
+
+	it("warns that archiving a coordinator group leaves Sharing policy unchanged", async () => {
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await actions.runGroupAction("group-alpha", "Legacy Alpha", "archive");
+
+		expect(mocks.openSyncConfirmDialog).toHaveBeenCalledWith(
+			expect.objectContaining({
+				description: expect.stringMatching(
+					/Target: Current Alpha.*coordinator presence, peer discovery, Space grants, legacy invites, and joins stop.*removes this group from this device's local coordinator configuration.*Policy Team membership and Project access in Sharing are separate and unchanged/,
+				),
+				confirmLabel: "Archive coordinator group",
+				tone: "danger",
+			}),
+		);
+		expect(mocks.archiveCoordinatorAdminGroup).toHaveBeenCalledWith("group-alpha");
+	});
+
+	it("identifies the target when unarchiving a coordinator group", async () => {
+		state.lastCoordinatorAdminGroups = [
+			{
+				group_id: "group-alpha",
+				display_name: "Archived Alpha",
+				archived_at: "2026-08-27T00:00:00.000Z",
+			},
+		];
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await actions.runGroupAction("group-alpha", "Archived Alpha", "unarchive");
+
+		expect(mocks.openSyncConfirmDialog).toHaveBeenCalledWith(
+			expect.objectContaining({
+				description: expect.stringMatching(
+					/Target: Archived Alpha.*reactivates the remote coordinator group for devices still configured for it.*does not re-add this group to this device's local coordinator configuration.*restore that separately before expecting coordinator presence or peer discovery here/,
+				),
+				confirmLabel: "Unarchive coordinator group",
+				tone: "default",
+			}),
+		);
+		expect(mocks.unarchiveCoordinatorAdminGroup).toHaveBeenCalledWith("group-alpha");
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+			"Legacy coordinator group unarchived. This device's local coordinator configuration and Sharing policy are unchanged.",
+			"success",
+		);
+	});
+
+	it.each([
+		["rename", "group_not_found: private-group-id"],
+		["archive", "group_not_found_or_already_archived: private-group-id"],
+		["unarchive", "group_not_found_or_not_archived: private-group-id"],
+	] as const)("refreshes groups when %s finds stale coordinator state", async (kind, message) => {
+		const mutation =
+			kind === "rename"
+				? mocks.renameCoordinatorAdminGroup
+				: kind === "archive"
+					? mocks.archiveCoordinatorAdminGroup
+					: mocks.unarchiveCoordinatorAdminGroup;
+		mutation.mockRejectedValue(new Error(message));
+		const reloadData = vi.fn().mockResolvedValue(undefined);
+		const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
+
+		await actions.runGroupAction("private-group-id", "Legacy Alpha", kind);
+
+		expect(reloadData).toHaveBeenCalledTimes(1);
+		expect(mocks.showGlobalNotice).toHaveBeenLastCalledWith(
+			"This legacy coordinator group changed or no longer exists. Coordinator groups were refreshed.",
+			"warning",
+		);
+		expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain("private-group-id");
+	});
+
+	it("keeps stale-group guidance when refreshing groups fails", async () => {
+		mocks.archiveCoordinatorAdminGroup.mockRejectedValue(
+			new Error("group_not_found_or_already_archived"),
+		);
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockRejectedValue(new Error("refresh failed")),
+		});
+
+		await expect(
+			actions.runGroupAction("group-alpha", "Legacy Alpha", "archive"),
+		).resolves.toBeUndefined();
+
+		expect(mocks.showGlobalNotice).toHaveBeenLastCalledWith(
+			"This legacy coordinator group changed or no longer exists. Refresh coordinator groups before trying another action.",
+			"warning",
 		);
 	});
 
@@ -162,5 +460,87 @@ describe("coordinator admin actions", () => {
 			"warning",
 		);
 		expect(reloadData).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		["display_name_required", "Enter a device name before renaming it."],
+		["display_name_invalid", "Enter a valid device name and retry."],
+		["display_name_too_long", "The device name is too long. Use a shorter name and retry."],
+	])("shows a useful notice for the known device rename error %s", async (error, notice) => {
+		mocks.renameCoordinatorAdminDevice.mockRejectedValue(new Error(error));
+		coordinatorAdminState.deviceRenameDrafts.set("device-one", "New device name");
+		const reloadData = vi.fn().mockResolvedValue(undefined);
+		const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
+
+		await actions.runDeviceAction("device-one", "group-alpha", "Old device", "rename");
+
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(notice, "warning");
+		expect(reloadData).not.toHaveBeenCalled();
+	});
+
+	it("does not expose unknown coordinator details after a device rename failure", async () => {
+		mocks.renameCoordinatorAdminDevice.mockRejectedValue(new Error("private coordinator detail"));
+		coordinatorAdminState.deviceRenameDrafts.set("device-one", "New device name");
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await actions.runDeviceAction("device-one", "group-alpha", "Old device", "rename");
+
+		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+			"Could not rename the legacy coordinator device. Sharing policy is unchanged; check coordinator recovery status and retry.",
+			"warning",
+		);
+		expect(mocks.showGlobalNotice).not.toHaveBeenCalledWith(
+			expect.stringContaining("private coordinator detail"),
+			expect.anything(),
+		);
+	});
+
+	it.each([
+		"rename",
+		"disable",
+		"enable",
+		"remove",
+	] as const)("refreshes devices when %s finds a missing enrollment", async (kind) => {
+		const mutation =
+			kind === "rename"
+				? mocks.renameCoordinatorAdminDevice
+				: kind === "disable"
+					? mocks.disableCoordinatorAdminDevice
+					: kind === "enable"
+						? mocks.enableCoordinatorAdminDevice
+						: mocks.removeCoordinatorAdminDevice;
+		mutation.mockRejectedValue(new Error("device_not_found: private-device-id"));
+		coordinatorAdminState.deviceRenameDrafts.set("private-device-id", "New device name");
+		const reloadData = vi.fn().mockResolvedValue(undefined);
+		const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
+
+		await actions.runDeviceAction("private-device-id", "group-alpha", "Laptop", kind);
+
+		expect(reloadData).toHaveBeenCalledTimes(1);
+		expect(mocks.showGlobalNotice).toHaveBeenLastCalledWith(
+			"This legacy coordinator device no longer exists. Enrolled devices were refreshed.",
+			"warning",
+		);
+		expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain("private-device-id");
+	});
+
+	it("keeps missing-device guidance when refreshing devices fails", async () => {
+		mocks.removeCoordinatorAdminDevice.mockRejectedValue(new Error("device_not_found"));
+		const actions = createCoordinatorAdminActions({
+			renderShell: vi.fn(),
+			reloadData: vi.fn().mockRejectedValue(new Error("refresh failed")),
+		});
+
+		await expect(
+			actions.runDeviceAction("device-one", "group-alpha", "Laptop", "remove"),
+		).resolves.toBeUndefined();
+
+		expect(mocks.showGlobalNotice).toHaveBeenLastCalledWith(
+			"This legacy coordinator device no longer exists. Refresh enrolled devices before trying another action.",
+			"warning",
+		);
 	});
 });

--- a/packages/ui/src/tabs/coordinator-admin/data/actions.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/actions.ts
@@ -11,7 +11,47 @@ import { showGlobalNotice } from "../../../lib/notice";
 import { state } from "../../../lib/state";
 import { openSyncConfirmDialog } from "../../sync/sync-dialogs";
 import { coordinatorAdminState } from "./state";
-import { currentAdminTargetGroup, setAdminTargetGroup } from "./target-group";
+import {
+	coordinatorGroupPresentationName,
+	currentAdminTargetGroup,
+	setAdminTargetGroup,
+} from "./target-group";
+
+const DEVICE_RENAME_ERROR_MESSAGES = new Map([
+	["display_name_required", "Enter a device name before renaming it."],
+	["display_name_invalid", "Enter a valid device name and retry."],
+	["display_name_too_long", "The device name is too long. Use a shorter name and retry."],
+]);
+
+function safeInviteCreationError(cause: unknown): string {
+	const message = cause instanceof Error ? cause.message : "";
+	if (message.includes("group_archived") || message.includes("Group is archived")) {
+		return "This legacy coordinator group is archived. Choose an active group or refresh coordinator groups.";
+	}
+	if (message.includes("group_not_found") || message.includes("Group not found")) {
+		return "This legacy coordinator group no longer exists. Choose an active group or refresh coordinator groups.";
+	}
+	return "Could not create the legacy coordinator invite. Sharing policy is unchanged; check coordinator recovery status and retry.";
+}
+
+function isMissingJoinRequestError(cause: unknown): boolean {
+	if (!(cause instanceof Error)) return false;
+	return (
+		cause.message.includes("request_not_found") || cause.message.includes("join request not found")
+	);
+}
+
+function isStaleGroupMutationError(cause: unknown): boolean {
+	if (!(cause instanceof Error)) return false;
+	const message = cause.message.toLowerCase();
+	return message.includes("group_not_found") || message.includes("group not found");
+}
+
+function isMissingDeviceError(cause: unknown): boolean {
+	if (!(cause instanceof Error)) return false;
+	const message = cause.message.toLowerCase();
+	return message.includes("device_not_found") || message.includes("device not found");
+}
 
 export interface CoordinatorAdminActionDeps {
 	renderShell: () => void;
@@ -44,7 +84,7 @@ export function createCoordinatorAdminActions(
 		if (coordinatorAdminState.groupActionPendingKind) return;
 		const groupId = coordinatorAdminState.createGroupId.trim();
 		if (!groupId) {
-			showGlobalNotice("Enter a Team id before creating a Team.", "warning");
+			showGlobalNotice("Enter a coordinator group ID before creating a legacy group.", "warning");
 			return;
 		}
 		const requestedDisplayName = coordinatorAdminState.createGroupDisplayName.trim();
@@ -83,7 +123,7 @@ export function createCoordinatorAdminActions(
 			coordinatorAdminState.createGroupDisplayName = "";
 			coordinatorAdminState.teamSetupGuide = {
 				groupId,
-				displayName: String(result.group?.display_name || requestedDisplayName || groupId),
+				displayName: String(result.group?.display_name || requestedDisplayName || ""),
 				defaultSpaceScopeId,
 				defaultSpaceLabel: String(defaultSpace?.label || ""),
 				autoGrantDefaultSpaceOnJoin:
@@ -96,15 +136,24 @@ export function createCoordinatorAdminActions(
 			setAdminTargetGroup(groupId);
 			await reloadData();
 			if (result.setup_warning) {
-				showGlobalNotice("Team created, but default Space setup needs repair.", "warning");
+				showGlobalNotice(
+					"Legacy coordinator group created, but default Space setup needs repair. Sharing policy is unchanged.",
+					"warning",
+				);
 			} else if (defaultSpaceScopeId) {
-				showGlobalNotice("Team created with a default Space.", "success");
+				showGlobalNotice(
+					"Legacy coordinator group created with a default Space. Sharing policy is unchanged.",
+					"success",
+				);
 			} else {
-				showGlobalNotice("Team created, but default Space status is unknown.", "warning");
+				showGlobalNotice(
+					"Legacy coordinator group created, but default Space status is unknown. Sharing policy is unchanged.",
+					"warning",
+				);
 			}
-		} catch (error) {
+		} catch {
 			showGlobalNotice(
-				error instanceof Error ? error.message : "Failed to create Team.",
+				"Could not create the legacy coordinator group. No Sharing policy or Project access changed; check coordinator recovery status and retry.",
 				"warning",
 			);
 		} finally {
@@ -119,19 +168,41 @@ export function createCoordinatorAdminActions(
 		kind: "rename" | "archive" | "unarchive",
 	) {
 		if (!groupId || coordinatorAdminState.groupActionPendingId) return;
-		if (
-			(kind === "archive" || kind === "unarchive") &&
-			!(await openSyncConfirmDialog({
-				title: `${kind === "archive" ? "Archive" : "Unarchive"} ${displayName || groupId}?`,
-				description:
-					kind === "archive"
-						? "Archived Teams stay visible and restorable, but they stop being operational for new invites and joins."
-						: "This Team will become operational again for invites and coordinator-backed joins.",
-				confirmLabel: kind === "archive" ? "Archive Team" : "Unarchive Team",
-				cancelLabel: kind === "archive" ? "Keep Team active" : "Keep Team archived",
-				tone: "danger",
-			}))
-		) {
+		const requestedDisplayName = displayName.trim();
+		if (kind === "rename" && !requestedDisplayName) {
+			showGlobalNotice("Enter a legacy group display name before renaming it.", "warning");
+			return;
+		}
+		const currentGroup = state.lastCoordinatorAdminGroups.find(
+			(group) => group.group_id === groupId,
+		);
+		const target = coordinatorGroupPresentationName(groupId, currentGroup?.display_name);
+		const confirmed = await openSyncConfirmDialog({
+			title:
+				kind === "rename"
+					? "Rename legacy coordinator group?"
+					: `${kind === "archive" ? "Archive" : "Unarchive"} legacy coordinator group?`,
+			description:
+				kind === "rename"
+					? `Target: ${target}. New name: ${requestedDisplayName}. This renames the technical coordinator group only. It does not rename a policy Team or change membership or Project access in Sharing.`
+					: kind === "archive"
+						? `Target: ${target}. The group stays visible and restorable, but coordinator presence, peer discovery, Space grants, legacy invites, and joins stop. Archiving also removes this group from this device's local coordinator configuration. Policy Team membership and Project access in Sharing are separate and unchanged.`
+						: `Target: ${target}. This reactivates the remote coordinator group for devices still configured for it. It does not re-add this group to this device's local coordinator configuration; restore that separately before expecting coordinator presence or peer discovery here. It does not restore or change policy Team membership or Project access in Sharing.`,
+			confirmLabel:
+				kind === "rename"
+					? "Rename coordinator group"
+					: kind === "archive"
+						? "Archive coordinator group"
+						: "Unarchive coordinator group",
+			cancelLabel:
+				kind === "rename"
+					? "Keep current group name"
+					: kind === "archive"
+						? "Keep group active"
+						: "Keep group archived",
+			tone: kind === "archive" ? "danger" : "default",
+		});
+		if (!confirmed) {
 			return;
 		}
 		coordinatorAdminState.groupActionPendingId = groupId;
@@ -139,23 +210,47 @@ export function createCoordinatorAdminActions(
 		renderShell();
 		try {
 			if (kind === "rename") {
-				await api.renameCoordinatorAdminGroup(groupId, displayName);
-				showGlobalNotice("Team renamed.", "success");
+				await api.renameCoordinatorAdminGroup(groupId, requestedDisplayName);
+				showGlobalNotice(
+					"Legacy coordinator group renamed. Sharing Team names are unchanged.",
+					"success",
+				);
 			}
 			if (kind === "archive") {
 				await api.archiveCoordinatorAdminGroup(groupId);
-				showGlobalNotice("Team archived.", "success");
+				showGlobalNotice(
+					"Legacy coordinator group archived. Sharing policy is unchanged.",
+					"success",
+				);
 			}
 			if (kind === "unarchive") {
 				await api.unarchiveCoordinatorAdminGroup(groupId);
-				showGlobalNotice("Team unarchived.", "success");
+				showGlobalNotice(
+					"Legacy coordinator group unarchived. This device's local coordinator configuration and Sharing policy are unchanged.",
+					"success",
+				);
 			}
 			await reloadData();
-		} catch (error) {
-			showGlobalNotice(
-				error instanceof Error ? error.message : `Failed to ${kind} Team.`,
-				"warning",
-			);
+		} catch (cause) {
+			if (isStaleGroupMutationError(cause)) {
+				try {
+					await reloadData();
+					showGlobalNotice(
+						"This legacy coordinator group changed or no longer exists. Coordinator groups were refreshed.",
+						"warning",
+					);
+				} catch {
+					showGlobalNotice(
+						"This legacy coordinator group changed or no longer exists. Refresh coordinator groups before trying another action.",
+						"warning",
+					);
+				}
+			} else {
+				showGlobalNotice(
+					`Could not ${kind} the legacy coordinator group. Sharing policy is unchanged; check coordinator recovery status and retry.`,
+					"warning",
+				);
+			}
 		} finally {
 			coordinatorAdminState.groupActionPendingId = "";
 			coordinatorAdminState.groupActionPendingKind = "";
@@ -170,7 +265,7 @@ export function createCoordinatorAdminActions(
 		const groupId = coordinatorAdminState.inviteGroup.trim() || defaultGroup;
 		const ttlHours = Number(coordinatorAdminState.inviteTtlHours);
 		if (!groupId) {
-			showGlobalNotice("Choose a Team before creating an invite.", "warning");
+			showGlobalNotice("Choose a coordinator group before creating a legacy invite.", "warning");
 			return;
 		}
 		if (!Number.isFinite(ttlHours) || ttlHours < 1) {
@@ -191,12 +286,11 @@ export function createCoordinatorAdminActions(
 			showGlobalNotice(
 				warnings.length
 					? `Invite created. Review ${warnings.length === 1 ? "the warning" : `${warnings.length} warnings`} before sharing it.`
-					: "Invite created. Copy it from Teams and share it with your teammate.",
+					: "Legacy coordinator invite created. It does not grant Sharing Project access.",
 				warnings.length ? "warning" : "success",
 			);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "Failed to create invite.";
-			showGlobalNotice(message, "warning");
+		} catch (cause) {
+			showGlobalNotice(safeInviteCreationError(cause), "warning");
 		} finally {
 			coordinatorAdminState.invitePending = false;
 			renderShell();
@@ -224,9 +318,19 @@ export function createCoordinatorAdminActions(
 				);
 			}
 			await reloadData();
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "Failed to review join request.";
-			showGlobalNotice(message, "warning");
+		} catch (cause) {
+			if (isMissingJoinRequestError(cause)) {
+				await reloadData();
+				showGlobalNotice(
+					"This legacy coordinator join request no longer exists. Pending requests were refreshed.",
+					"warning",
+				);
+			} else {
+				showGlobalNotice(
+					"Could not review the legacy coordinator join request. Sharing policy is unchanged; check coordinator recovery status and retry.",
+					"warning",
+				);
+			}
 		} finally {
 			coordinatorAdminState.joinReviewPendingId = "";
 			coordinatorAdminState.joinReviewPendingAction = "";
@@ -285,8 +389,30 @@ export function createCoordinatorAdminActions(
 			}
 			await reloadData();
 		} catch (error) {
-			const message = error instanceof Error ? error.message : `Failed to ${kind} device.`;
-			showGlobalNotice(message, "warning");
+			const knownRenameError =
+				kind === "rename" && error instanceof Error
+					? DEVICE_RENAME_ERROR_MESSAGES.get(error.message.trim())
+					: undefined;
+			if (isMissingDeviceError(error)) {
+				try {
+					await reloadData();
+					showGlobalNotice(
+						"This legacy coordinator device no longer exists. Enrolled devices were refreshed.",
+						"warning",
+					);
+				} catch {
+					showGlobalNotice(
+						"This legacy coordinator device no longer exists. Refresh enrolled devices before trying another action.",
+						"warning",
+					);
+				}
+			} else {
+				showGlobalNotice(
+					knownRenameError ||
+						`Could not ${kind} the legacy coordinator device. Sharing policy is unchanged; check coordinator recovery status and retry.`,
+					"warning",
+				);
+			}
 		} finally {
 			coordinatorAdminState.deviceActionPendingId = "";
 			coordinatorAdminState.deviceActionPendingKind = "";

--- a/packages/ui/src/tabs/coordinator-admin/data/device-card.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/device-card.test.ts
@@ -3,27 +3,27 @@ import { describe, expect, it } from "vitest";
 import { coordinatorAdminDeviceCardCopy } from "./device-card";
 
 describe("coordinator admin device card copy", () => {
-	it("demotes raw device and Team ids to advanced copy", () => {
+	it("demotes raw device and coordinator group IDs to advanced copy", () => {
 		const copy = coordinatorAdminDeviceCardCopy(
 			{ device_id: "dev-a", display_name: "Alice laptop", enabled: true, group_id: "team-a" },
 			"fallback-team",
 		);
 
 		expect(copy.displayName).toBe("Alice laptop");
-		expect(copy.statusLabel).toBe("Enabled in this Team");
+		expect(copy.statusLabel).toBe("Enabled in this coordinator group");
 		expect(copy.statusLabel).not.toContain("dev-a");
-		expect(copy.advancedDetail).toBe("Advanced: Device ID dev-a · Team ID team-a");
+		expect(copy.advancedDetail).toBe("Advanced: Device ID dev-a · Group ID team-a");
 	});
 
-	it("uses the active Team as a fallback for older device payloads", () => {
+	it("uses the active coordinator group as a fallback for older device payloads", () => {
 		const copy = coordinatorAdminDeviceCardCopy(
 			{ device_id: "dev-b", display_name: "", enabled: false },
 			"active-team",
 		);
 
 		expect(copy.displayName).toBe("dev-b");
-		expect(copy.statusLabel).toBe("Disabled in this Team");
+		expect(copy.statusLabel).toBe("Disabled in this coordinator group");
 		expect(copy.teamId).toBe("active-team");
-		expect(copy.advancedDetail).toContain("Team ID active-team");
+		expect(copy.advancedDetail).toContain("Group ID active-team");
 	});
 });

--- a/packages/ui/src/tabs/coordinator-admin/data/device-card.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/device-card.ts
@@ -17,12 +17,14 @@ export function coordinatorAdminDeviceCardCopy(
 	const displayName = String(device.display_name || deviceId || "Unnamed device");
 	const enabled = device.enabled !== false && device.enabled !== 0;
 	const advancedParts = [`Device ID ${deviceId || "unknown"}`];
-	if (teamId) advancedParts.push(`Team ID ${teamId}`);
+	if (teamId) advancedParts.push(`Group ID ${teamId}`);
 	return {
 		advancedDetail: `Advanced: ${advancedParts.join(" · ")}`,
 		deviceId,
 		displayName,
-		statusLabel: enabled ? "Enabled in this Team" : "Disabled in this Team",
+		statusLabel: enabled
+			? "Enabled in this coordinator group"
+			: "Disabled in this coordinator group",
 		teamId,
 	};
 }

--- a/packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/scope-management.test.ts
@@ -15,7 +15,7 @@ describe("coordinator admin scope management view helpers", () => {
 		expect(
 			scopeManagementReadinessMessage({
 				readiness: "partial",
-				title: "Teams setup is incomplete",
+				title: "Legacy coordinator setup is incomplete",
 				detail: "Set a coordinator admin secret.",
 			}),
 		).toContain("admin secret");

--- a/packages/ui/src/tabs/coordinator-admin/data/scope-management.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/scope-management.ts
@@ -44,7 +44,7 @@ export interface SpaceAccessDeviceCopy {
 
 export function scopeManagementReadinessMessage(summary: CoordinatorAdminSummary): string | null {
 	if (summary.readiness === "ready") return null;
-	return "Space management needs the coordinator URL, target Team, and admin secret before it can list Spaces or change memberships.";
+	return "Legacy Space management needs the coordinator URL, target group, and admin secret before it can list Spaces or change transport memberships.";
 }
 
 export function scopeStatusLabel(status: string | null | undefined): string {

--- a/packages/ui/src/tabs/coordinator-admin/data/state.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/state.ts
@@ -69,6 +69,7 @@ export interface CoordinatorAdminState {
 	deviceActionPendingId: string;
 	deviceActionPendingKind: DeviceActionKind;
 	groupRenameDrafts: Map<string, string>;
+	groupPresentationAliases: Map<string, string>;
 	deviceRenameDrafts: Map<string, string>;
 	deviceRenameServerNames: Map<string, string>;
 	groupPreferencesOpen: Set<string>;
@@ -102,6 +103,7 @@ export const coordinatorAdminState: CoordinatorAdminState = {
 	deviceActionPendingId: "",
 	deviceActionPendingKind: "",
 	groupRenameDrafts: new Map<string, string>(),
+	groupPresentationAliases: new Map<string, string>(),
 	deviceRenameDrafts: new Map<string, string>(),
 	deviceRenameServerNames: new Map<string, string>(),
 	groupPreferencesOpen: new Set<string>(),

--- a/packages/ui/src/tabs/coordinator-admin/data/summary.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/summary.ts
@@ -17,32 +17,32 @@ export function coordinatorAdminSummary(): CoordinatorAdminSummary {
 	if (!status) {
 		return {
 			readiness: "partial",
-			title: "Checking Teams readiness…",
-			detail: "Loading local Teams configuration from the viewer server.",
+			title: "Checking legacy coordinator readiness…",
+			detail: "Loading local coordinator administration configuration from the viewer server.",
 		};
 	}
 	if (status.readiness === "ready") {
 		return {
 			readiness: "ready",
-			title: "Teams is ready",
+			title: "Legacy coordinator administration is ready",
 			detail:
-				"This viewer can use the local Teams admin configuration to manage invites, join requests, and enrolled devices without exposing the admin secret to the browser.",
+				"This viewer can manage legacy coordinator groups, invites, join requests, and enrolled devices without exposing the admin secret to the browser.",
 		};
 	}
 	if (status.readiness === "partial") {
 		return {
 			readiness: "partial",
-			title: "Teams setup is incomplete",
+			title: "Legacy coordinator setup is incomplete",
 			detail:
 				status.has_admin_secret === false
-					? "Set a coordinator admin secret for the viewer server before using Teams invite and device actions."
-					: "Finish configuring the coordinator target and Team before using Teams actions.",
+					? "Set a coordinator admin secret for the viewer server before using legacy invite and device actions."
+					: "Finish configuring the coordinator target and group before using legacy administration actions.",
 		};
 	}
 	return {
 		readiness: "not_configured",
-		title: "Teams is not configured",
+		title: "Legacy coordinator administration is not configured",
 		detail:
-			"Set a coordinator URL, Team, and admin secret locally to enable remote Teams administration from this viewer.",
+			"Set a coordinator URL, group, and admin secret locally to enable remote coordinator administration from this viewer.",
 	};
 }

--- a/packages/ui/src/tabs/coordinator-admin/data/target-group.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/target-group.test.ts
@@ -2,11 +2,18 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { state } from "../../../lib/state";
 import { coordinatorAdminState } from "./state";
-import { reconcileDeviceRenameDrafts } from "./target-group";
+import {
+	coordinatorGroupPresentationName,
+	reconcileDeviceRenameDrafts,
+	reconcileGroupRenameDrafts,
+} from "./target-group";
 
 describe("coordinator admin target group helpers", () => {
 	beforeEach(() => {
 		state.lastCoordinatorAdminDevices = [];
+		state.lastCoordinatorAdminGroups = [];
+		coordinatorAdminState.groupRenameDrafts.clear();
+		coordinatorAdminState.groupPresentationAliases.clear();
 		coordinatorAdminState.deviceRenameDrafts.clear();
 		coordinatorAdminState.deviceRenameServerNames.clear();
 	});
@@ -38,5 +45,82 @@ describe("coordinator admin target group helpers", () => {
 		reconcileDeviceRenameDrafts();
 
 		expect(coordinatorAdminState.deviceRenameDrafts.get("dev-1")).toBe("NAS seed peer");
+	});
+
+	it("assigns collision-free privacy-safe aliases to unnamed coordinator groups", () => {
+		state.lastCoordinatorAdminGroups = [
+			{ group_id: "group-zulu", display_name: null, archived_at: null },
+			{ group_id: "group-alpha", display_name: "", archived_at: null },
+			{ group_id: "group-named", display_name: "Named group", archived_at: null },
+			{
+				group_id: "group-reserved",
+				display_name: "Unnamed coordinator group 1",
+				archived_at: null,
+			},
+		];
+
+		expect(coordinatorGroupPresentationName("group-alpha", "")).toBe("Unnamed coordinator group 2");
+		expect(coordinatorGroupPresentationName("group-zulu", null)).toBe(
+			"Unnamed coordinator group 3",
+		);
+		expect(coordinatorGroupPresentationName("group-named", " Named group ")).toBe("Named group");
+	});
+
+	it("keeps aliases stable when the available group set changes", () => {
+		state.lastCoordinatorAdminGroups = [
+			{ group_id: "group-zulu", display_name: null, archived_at: null },
+		];
+		const originalAlias = coordinatorGroupPresentationName("group-zulu", null);
+
+		state.lastCoordinatorAdminGroups = [
+			{ group_id: "group-alpha", display_name: null, archived_at: null },
+			{ group_id: "group-zulu", display_name: null, archived_at: null },
+		];
+
+		expect(coordinatorGroupPresentationName("group-zulu", null)).toBe(originalAlias);
+		expect(coordinatorGroupPresentationName("group-alpha", null)).not.toBe(originalAlias);
+	});
+
+	it("reallocates an unnamed alias when a later explicit group name reserves it", () => {
+		state.lastCoordinatorAdminGroups = [
+			{ group_id: "group-unnamed", display_name: null, archived_at: null },
+		];
+		expect(coordinatorGroupPresentationName("group-unnamed", null)).toBe(
+			"Unnamed coordinator group 1",
+		);
+
+		state.lastCoordinatorAdminGroups = [
+			{ group_id: "group-unnamed", display_name: null, archived_at: null },
+			{
+				group_id: "group-named",
+				display_name: "Unnamed coordinator group 1",
+				archived_at: null,
+			},
+		];
+
+		expect(coordinatorGroupPresentationName("group-named", "Unnamed coordinator group 1")).toBe(
+			"Unnamed coordinator group 1",
+		);
+		expect(coordinatorGroupPresentationName("group-unnamed", null)).toBe(
+			"Unnamed coordinator group 2",
+		);
+		expect(coordinatorAdminState.groupPresentationAliases.has("group-named")).toBe(false);
+	});
+
+	it("assigns a distinct stable alias when the group is absent from the current snapshot", () => {
+		const alias = coordinatorGroupPresentationName("group-hidden", null);
+
+		expect(alias).toBe("Unnamed coordinator group 1");
+		expect(coordinatorGroupPresentationName("group-hidden", null)).toBe(alias);
+	});
+
+	it("keeps unnamed presentation aliases out of rename payload drafts", () => {
+		state.lastCoordinatorAdminGroups = [
+			{ group_id: "group-alpha", display_name: null, archived_at: null },
+		];
+
+		reconcileGroupRenameDrafts();
+
+		expect(coordinatorAdminState.groupRenameDrafts.get("group-alpha")).toBe("");
 	});
 });

--- a/packages/ui/src/tabs/coordinator-admin/data/target-group.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/target-group.ts
@@ -54,10 +54,41 @@ export function availableCoordinatorGroups(): Array<{
 		.filter((group) => group.group_id);
 }
 
+export function coordinatorGroupPresentationName(
+	groupId: string,
+	displayName: string | null | undefined,
+): string {
+	const explicitName = String(displayName || "").trim();
+	const groups = availableCoordinatorGroups();
+	const reservedNames = new Set(
+		groups.map((group) => String(group.display_name || "").trim()).filter(Boolean),
+	);
+	if (explicitName) reservedNames.add(explicitName);
+	for (const [aliasedGroupId, alias] of coordinatorAdminState.groupPresentationAliases) {
+		if (reservedNames.has(alias)) {
+			coordinatorAdminState.groupPresentationAliases.delete(aliasedGroupId);
+		}
+	}
+	if (explicitName) return explicitName;
+	const existingAlias = coordinatorAdminState.groupPresentationAliases.get(groupId);
+	if (existingAlias) return existingAlias;
+	for (const alias of coordinatorAdminState.groupPresentationAliases.values()) {
+		reservedNames.add(alias);
+	}
+	let suffix = 1;
+	let alias = `Unnamed coordinator group ${suffix}`;
+	while (reservedNames.has(alias)) {
+		suffix += 1;
+		alias = `Unnamed coordinator group ${suffix}`;
+	}
+	coordinatorAdminState.groupPresentationAliases.set(groupId, alias);
+	return alias;
+}
+
 export function reconcileGroupRenameDrafts() {
 	const next = new Map<string, string>();
 	for (const group of availableCoordinatorGroups()) {
-		next.set(group.group_id, group.display_name || group.group_id);
+		next.set(group.group_id, group.display_name || "");
 	}
 	coordinatorAdminState.groupRenameDrafts.clear();
 	for (const [groupId, name] of next.entries()) {

--- a/packages/ui/src/tabs/coordinator-admin/data/team-card.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/team-card.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { teamCardOverview } from "./team-card";
 
-describe("coordinator admin Team card helpers", () => {
+describe("coordinator admin legacy group card helpers", () => {
 	it("summarizes a newly created default Space without exposing raw IDs", () => {
 		expect(
 			teamCardOverview({
@@ -22,7 +22,7 @@ describe("coordinator admin Team card helpers", () => {
 		});
 	});
 
-	it("ignores setup guide state for a different Team", () => {
+	it("ignores setup guide state for a different coordinator group", () => {
 		expect(
 			teamCardOverview({
 				groupId: "team-beta",
@@ -36,12 +36,12 @@ describe("coordinator admin Team card helpers", () => {
 				},
 			}),
 		).toMatchObject({
-			autoGrant: "Open Team defaults to inspect",
-			defaultSpace: "Open Team defaults to inspect",
+			autoGrant: "Open legacy group defaults to inspect",
+			defaultSpace: "Open legacy group defaults to inspect",
 		});
 	});
 
-	it("shows conservative migrated Team defaults when preferences are loaded", () => {
+	it("shows conservative migrated group defaults when preferences are loaded", () => {
 		expect(
 			teamCardOverview({
 				groupId: "team-beta",

--- a/packages/ui/src/tabs/coordinator-admin/data/team-card.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/team-card.ts
@@ -26,7 +26,7 @@ function defaultSpaceSummary(
 	if (preferences?.loaded) return "Not configured";
 	if (setupGuide?.defaultSpaceLabel) return setupGuide.defaultSpaceLabel;
 	if (setupGuide?.defaultSpaceScopeId) return "Configured";
-	return "Open Team defaults to inspect";
+	return "Open legacy group defaults to inspect";
 }
 
 function autoGrantSummary(
@@ -40,7 +40,7 @@ function autoGrantSummary(
 	}
 	if (setupGuide?.autoGrantDefaultSpaceOnJoin === true) return "On for the default Space";
 	if (setupGuide?.autoGrantDefaultSpaceOnJoin === false) return "Off — Space access stays explicit";
-	return "Open Team defaults to inspect";
+	return "Open legacy group defaults to inspect";
 }
 
 function activeSpaceCount(scopeManagement: GroupScopeManagementDraft | undefined): number | null {

--- a/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
+++ b/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
@@ -65,7 +65,7 @@ function renderShell() {
 		summary.readiness !== "ready"
 			? summary.detail
 			: targetArchived
-				? "The selected Team is archived. Restore it or switch Teams before creating invites."
+				? "The selected coordinator group is archived. Restore it or switch groups before creating legacy invites."
 				: "";
 	if (
 		(coordinatorAdminState.activeSection === "invites" && !invitesEnabled) ||
@@ -83,26 +83,26 @@ function renderShell() {
 			h(
 				"div",
 				{ class: "card coordinator-admin-header" },
-				h("div", { class: "section-header" }, h("h2", null, "Teams")),
+				h("div", { class: "section-header" }, h("h2", null, "Legacy coordinator administration")),
 				h(
 					"div",
 					{ class: "coordinator-admin-summary-grid" },
 					h(
 						"div",
 						{ class: "coordinator-admin-summary-card" },
-						h("span", { class: "section-meta" }, "Team admin target"),
+						h("span", { class: "section-meta" }, "Coordinator group target"),
 						h("strong", null, targetGroup || "None selected"),
 					),
 					h(
 						"div",
 						{ class: "coordinator-admin-summary-card" },
-						h("span", { class: "section-meta" }, "Node discovery Team"),
+						h("span", { class: "section-meta" }, "Node discovery group"),
 						h("strong", null, activeGroup || "None"),
 					),
 					h(
 						"div",
 						{ class: "coordinator-admin-summary-card" },
-						h("span", { class: "section-meta" }, "Teams"),
+						h("span", { class: "section-meta" }, "Coordinator groups"),
 						h(
 							"strong",
 							null,
@@ -112,7 +112,7 @@ function renderShell() {
 					h(
 						"div",
 						{ class: "coordinator-admin-summary-card" },
-						h("span", { class: "section-meta" }, "Selected Team activity"),
+						h("span", { class: "section-meta" }, "Selected group activity"),
 						h("strong", null, `${joinRequestCount} join requests · ${deviceCount} devices`),
 					),
 				),
@@ -133,14 +133,14 @@ function renderShell() {
 				h(
 					RadixTabs,
 					{
-						ariaLabel: "Teams sections",
+						ariaLabel: "Legacy coordinator administration sections",
 						listClassName: "coordinator-admin-tabs-list",
 						onValueChange: (value) => {
 							coordinatorAdminState.activeSection = (value as AdminSection) || "groups";
 							renderShell();
 						},
 						tabs: [
-							{ value: "groups", label: "Teams", disabled: !groupsEnabled },
+							{ value: "groups", label: "Coordinator groups", disabled: !groupsEnabled },
 							{ value: "invites", label: "Invites", disabled: !invitesEnabled },
 							{ value: "join-requests", label: "Join requests", disabled: !joinRequestsEnabled },
 							{ value: "devices", label: "Devices", disabled: !devicesEnabled },
@@ -176,10 +176,10 @@ function renderShell() {
 					"div",
 					{ class: "section-meta coordinator-admin-context-line" },
 					targetArchived
-						? `Selected Team ${targetGroup || "—"} is archived. Switch or restore it to enable invite operations.`
+						? "The selected coordinator group is archived. Switch or restore it to enable legacy invite operations."
 						: targetGroup
-							? `Actions below apply to ${targetGroup}.`
-							: "Select a Team to start managing people, Spaces, and access.",
+							? "Actions below apply to the selected coordinator group."
+							: "Select a coordinator group to manage legacy enrollment and Spaces.",
 				),
 			),
 		),
@@ -211,7 +211,7 @@ export async function loadCoordinatorAdminData() {
 			const payload = await api.loadShareOperations();
 			state.lastShareOperations = Array.isArray(payload.items) ? payload.items : [];
 		} catch {
-			// Keep the previous read-only reflection; Teams administration remains usable.
+			// Keep the previous read-only reflection; legacy coordinator administration remains usable.
 		}
 		try {
 			const groupsPayload = (await api.loadCoordinatorAdminGroupsFiltered(

--- a/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
@@ -552,7 +552,7 @@ describe("recipient-policy invitations", () => {
 		expect(dialog.textContent).toContain("Viewer — 1 existing memory and future activity");
 		expect(dialog.textContent).toContain("does not join a Team");
 		expect(dialog.textContent).toContain("No other Projects are included");
-		expect(dialog.textContent).not.toContain("Use Advanced Team administration");
+		expect(dialog.textContent).not.toContain("Use Advanced coordinator administration (legacy)");
 		expect(document.querySelector("textarea")).toBeNull();
 
 		const recipientName = dialog.querySelector<HTMLInputElement>("#project-share-recipient-name");
@@ -1119,8 +1119,11 @@ describe("recipient-policy invitations", () => {
 		if (!dialog) throw new Error("dialog missing");
 		act(() => button("Review invitation", dialog).click());
 		await vi.waitFor(() =>
-			expect(dialog.textContent).toContain("Use Advanced Team administration to review and import"),
+			expect(dialog.textContent).toContain(
+				"Open Advanced (legacy), then Sync, to review and import",
+			),
 		);
+		expect(dialog.textContent).not.toContain("coordinator administration");
 		expect(api.importCoordinatorInvite).not.toHaveBeenCalled();
 	});
 });

--- a/packages/ui/src/tabs/recipient-policy-invitations.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.tsx
@@ -575,7 +575,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 						? "Review ready. Confirm before accepting."
 						: result.kind === "project_share_invite"
 							? "Review ready. Confirm the exact Projects before accepting."
-							: "Open Advanced Team administration to continue with this invitation.",
+							: "Open Advanced (legacy), then Sync, to review and import this invitation.",
 			);
 		} catch (cause) {
 			if (!isCurrentInspection()) return;
@@ -740,9 +740,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 				>
 					Review invitation
 				</button>
-				<p className="small">
-					Legacy invitation import remains under Advanced Team administration.
-				</p>
+				<p className="small">Legacy invitation import remains under Advanced (legacy), in Sync.</p>
 			</article>
 			{mode ? (
 				<RadixDialog
@@ -867,7 +865,7 @@ export function RecipientPolicyInvitations({ intent }: { intent: RecipientPolicy
 								</div>
 							) : null}
 							{inspected?.kind === "legacy_team_invite" ? (
-								<p>Use Advanced Team administration to review and import this invitation.</p>
+								<p>Open Advanced (legacy), then Sync, to review and import this invitation.</p>
 							) : null}
 							<p aria-live="polite" className="small" role="status">
 								{status}

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -240,7 +240,7 @@ describe("recipient-focused Sharing", () => {
 		expect(visiblePanel().textContent).toContain("Add a device");
 		expect(visiblePanel().textContent).toContain("Share exact Projects");
 		expect(visiblePanel().textContent).toContain(
-			"Legacy invitation import remains under Advanced Team administration",
+			"Legacy invitation import remains under Advanced (legacy), in Sync",
 		);
 	});
 

--- a/packages/ui/src/tabs/sync/components/sync-peers.test.ts
+++ b/packages/ui/src/tabs/sync/components/sync-peers.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { state } from "../../../lib/state";
 import {
 	advancedDeviceIdentityView,
-	canManageSpacesInTeams,
+	canManageLegacyCoordinatorSpaces,
 	openDeviceIdentitySetup,
 	renderSyncPeersList,
 } from "./sync-peers";
@@ -16,6 +16,7 @@ beforeEach(() => {
 	];
 	state.lastDeviceIdentityInventory = null;
 	state.deviceIdentityInventoryLoadError = false;
+	state.lastCoordinatorAdminStatus = null;
 	state.pendingDeviceIdentityFocus = undefined;
 	window.location.hash = "advanced/sync";
 });
@@ -26,15 +27,21 @@ afterEach(() => {
 	document.body.innerHTML = "";
 });
 
-describe("canManageSpacesInTeams", () => {
-	it("allows the Teams management action only for ready coordinator admin devices", () => {
-		expect(canManageSpacesInTeams({ has_admin_secret: true, readiness: "ready" })).toBe(true);
+describe("canManageLegacyCoordinatorSpaces", () => {
+	it("allows legacy coordinator administration only for ready admin devices", () => {
+		expect(canManageLegacyCoordinatorSpaces({ has_admin_secret: true, readiness: "ready" })).toBe(
+			true,
+		);
 	});
 
-	it("blocks the Teams management action when admin capability is absent", () => {
-		expect(canManageSpacesInTeams({ has_admin_secret: false, readiness: "ready" })).toBe(false);
-		expect(canManageSpacesInTeams({ has_admin_secret: true, readiness: "partial" })).toBe(false);
-		expect(canManageSpacesInTeams(null)).toBe(false);
+	it("blocks legacy coordinator administration when admin capability is absent", () => {
+		expect(canManageLegacyCoordinatorSpaces({ has_admin_secret: false, readiness: "ready" })).toBe(
+			false,
+		);
+		expect(canManageLegacyCoordinatorSpaces({ has_admin_secret: true, readiness: "partial" })).toBe(
+			false,
+		);
+		expect(canManageLegacyCoordinatorSpaces(null)).toBe(false);
 	});
 });
 
@@ -138,9 +145,9 @@ describe("Advanced device Identity ownership", () => {
 				onSync: vi.fn(),
 			}),
 		);
-		const disclosure = mount.querySelector<HTMLButtonElement>('[aria-expanded="false"]');
+		const disclosure = mount.querySelector<HTMLButtonElement>("[aria-expanded]");
 		if (!disclosure) throw new Error("peer disclosure missing");
-		act(() => disclosure.click());
+		if (disclosure.getAttribute("aria-expanded") === "false") act(() => disclosure.click());
 
 		expect(mount.textContent).toContain("Authoritative Identity ownership");
 		expect(mount.textContent).toContain("Set up Identity in Devices");
@@ -148,5 +155,32 @@ describe("Advanced device Identity ownership", () => {
 		expect(mount.textContent).toContain("Advanced sharing rules");
 		expect(mount.textContent).not.toContain("Save assignment");
 		expect(mount.querySelector('[aria-label^="Assigned person"]')).toBeNull();
+	});
+
+	it("routes legacy coordinator administration through the canonical Advanced hash", () => {
+		document.body.innerHTML = '<div id="mount"></div>';
+		state.lastCoordinatorAdminStatus = { has_admin_secret: true, readiness: "ready" };
+		const mount = document.getElementById("mount");
+		if (!mount) throw new Error("mount missing");
+		act(() =>
+			renderSyncPeersList(mount, {
+				peers: [{ peer_device_id: "peer-a", name: "Peer A", actor_id: "identity-hint" }],
+				onRemove: vi.fn(),
+				onRename: vi.fn(),
+				onSync: vi.fn(),
+			}),
+		);
+		const disclosure = mount.querySelector<HTMLButtonElement>("[aria-expanded]");
+		if (!disclosure) throw new Error("peer disclosure missing");
+		if (disclosure.getAttribute("aria-expanded") === "false") act(() => disclosure.click());
+		const adminButton = [...mount.querySelectorAll<HTMLButtonElement>("button")].find((button) =>
+			button.textContent?.includes("coordinator administration (legacy)"),
+		);
+		if (!adminButton) throw new Error("legacy coordinator administration action missing");
+
+		act(() => adminButton.click());
+
+		expect(window.location.hash).toBe("#advanced/teams");
+		expect(mount.textContent).not.toContain("Manage Spaces in Teams");
 	});
 });

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -228,11 +228,13 @@ function claimedLocalActorScopeMessage(
 	return "Private same-person sync is blocked until this device is granted an allowed personal Space.";
 }
 
-function openTeamsAccessManagement(): void {
-	window.location.hash = "coordinator-admin";
+function openLegacyCoordinatorAdministration(): void {
+	window.location.hash = "advanced/teams";
 }
 
-export function canManageSpacesInTeams(status = state.lastCoordinatorAdminStatus): boolean {
+export function canManageLegacyCoordinatorSpaces(
+	status = state.lastCoordinatorAdminStatus,
+): boolean {
 	return status?.readiness === "ready" && status.has_admin_secret === true;
 }
 
@@ -279,7 +281,7 @@ function SyncPeerCard({ peer, onRemove, onRename, onSync }: SyncPeerCardProps) {
 	const lastSyncAt = String(peerStatus.last_sync_at || peerStatus.last_sync_at_utc || "");
 	const lastPingAt = String(peerStatus.last_ping_at || peerStatus.last_ping_at_utc || "");
 	const discoverySummary = peer.discovered_via_group_id
-		? `Discovery: seen through Team ${peer.discovered_via_group_id}. Discovery helps find devices; Space access above decides data access.`
+		? `Discovery: seen through coordinator group ${peer.discovered_via_group_id}. Discovery helps find devices; Space access above decides data access.`
 		: peer.discovered_via_coordinator_id
 			? `Discovery: seen through coordinator ${peer.discovered_via_coordinator_id}. Discovery helps find devices; Space access above decides data access.`
 			: null;
@@ -352,14 +354,14 @@ function SyncPeerCard({ peer, onRemove, onRename, onSync }: SyncPeerCardProps) {
 
 	async function sync() {
 		if (pendingScopeReview) {
-			const canReviewInTeams = canManageSpacesInTeams();
+			const canReviewLegacySpaces = canManageLegacyCoordinatorSpaces();
 			const proceed = await openSyncConfirmDialog({
 				title: `Sync ${displayName} before advanced rule review?`,
-				description: canReviewInTeams
-					? "This manual sync will use the current Space access and advanced filters until you review them in Teams."
-					: "This manual sync will use the current Space access and advanced filters until a coordinator or manager reviews them in Teams.",
+				description: canReviewLegacySpaces
+					? "This manual sync will use the current Space access and advanced filters until you review them in coordinator administration (legacy)."
+					: "This manual sync will use the current Space access and advanced filters until a coordinator operator reviews them in coordinator administration (legacy).",
 				confirmLabel: "Sync anyway",
-				cancelLabel: canReviewInTeams ? "Review in Teams first" : "Cancel",
+				cancelLabel: canReviewLegacySpaces ? "Review legacy coordinator setup first" : "Cancel",
 			});
 			if (!proceed) return;
 		}
@@ -408,7 +410,7 @@ function SyncPeerCard({ peer, onRemove, onRename, onSync }: SyncPeerCardProps) {
 	// in SyncPeerStatusLike.
 	const presenceState: PresenceState = presenceForPeer(peer);
 	const syncMetaText = lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : "Sync: never";
-	const canManageSpaces = canManageSpacesInTeams();
+	const canManageSpaces = canManageLegacyCoordinatorSpaces();
 
 	const toggleLabel = `${isExpanded ? "Collapse" : "Expand"} device ${displayName}`;
 	// Read module-level state directly (not the stale closure value of
@@ -556,8 +558,8 @@ function SyncPeerCard({ peer, onRemove, onRename, onSync }: SyncPeerCardProps) {
 						{scopeReviewRequested ? (
 							<div className="peer-meta">
 								{canManageSpaces
-									? "Review this device's Space access and advanced rules in Teams if the defaults are too broad."
-									: "A coordinator or manager can review this device's Space access and advanced rules in Teams if the defaults are too broad."}
+									? "Review this device's Space access and advanced rules in coordinator administration (legacy) if the defaults are too broad."
+									: "A coordinator operator can review this device's Space access and advanced rules in coordinator administration (legacy) if the defaults are too broad."}
 							</div>
 						) : pendingScopeReview ? (
 							<div className="peer-meta">
@@ -675,14 +677,15 @@ function SyncPeerCard({ peer, onRemove, onRename, onSync }: SyncPeerCardProps) {
 								<button
 									type="button"
 									className="settings-button"
-									onClick={openTeamsAccessManagement}
+									onClick={openLegacyCoordinatorAdministration}
 								>
-									Manage Spaces in Teams
+									Open coordinator administration (legacy)
 								</button>
 							</div>
 						) : (
 							<div className="peer-meta">
-								Space access is managed in Teams by a coordinator or manager.
+								Legacy Space access is managed in coordinator administration (legacy) by a
+								coordinator operator.
 							</div>
 						)}
 						<SyncInlineFeedback feedback={feedback} />

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -10,7 +10,7 @@ import { renderSyncActorsList } from "./components/sync-actors";
 import { renderSyncEmptyState } from "./components/sync-diagnostics";
 import type { SyncActionFeedback } from "./components/sync-inline-feedback";
 import { renderLegacyClaimsSlice } from "./components/sync-legacy-claims";
-import { canManageSpacesInTeams, renderSyncPeersList } from "./components/sync-peers";
+import { canManageLegacyCoordinatorSpaces, renderSyncPeersList } from "./components/sync-peers";
 import { hideSkeleton, isPeerScopeReviewPending, shouldClearStalePeersFeedback } from "./helpers";
 import { openSyncConfirmDialog } from "./sync-dialogs";
 import {
@@ -164,9 +164,9 @@ export function renderSyncPeers() {
 					feedback = { message: summary.message, tone: "warning" };
 				} else if (peerId && isPeerScopeReviewPending(peerId)) {
 					const displayName = peer?.name || (peerId ? peerId.slice(0, 8) : "unknown");
-					const reviewGuidance = canManageSpacesInTeams()
-						? "Review Space access and advanced rules in Teams if this device needs tighter sharing."
-						: "A coordinator or manager can review Space access and advanced rules in Teams if this device needs tighter sharing.";
+					const reviewGuidance = canManageLegacyCoordinatorSpaces()
+						? "Review Space access and advanced rules in coordinator administration (legacy) if this device needs tighter sharing."
+						: "A coordinator operator can review Space access and advanced rules in coordinator administration (legacy) if this device needs tighter sharing.";
 					feedback = {
 						message: `Triggered sync for ${displayName}. ${reviewGuidance}`,
 						tone: "warning",

--- a/packages/ui/src/tabs/sync/team-sync/helpers/invite-panel-dom.ts
+++ b/packages/ui/src/tabs/sync/team-sync/helpers/invite-panel-dom.ts
@@ -27,19 +27,17 @@ export function applySyncInviteReadinessState() {
 	const hint = document.getElementById("syncInviteAdminHint") as HTMLParagraphElement | null;
 	if (!syncCreateInviteButton || !hint) return;
 	const readiness = state.lastCoordinatorAdminStatus?.readiness;
-	const activeGroup = String(state.lastCoordinatorAdminStatus?.active_group || "").trim();
 	if (readiness === "ready") {
 		syncCreateInviteButton.disabled = false;
 		hint.hidden = false;
-		hint.textContent = activeGroup
-			? `Teams is ready for ${activeGroup}. Advanced admin tools now live in Teams.`
-			: "Teams is ready. Advanced admin tools now live in Teams.";
+		hint.textContent =
+			"Legacy coordinator setup is ready. Technical controls are in coordinator administration (legacy).";
 		return;
 	}
 	const message =
 		readiness === "partial"
-			? "Finish Teams setup before creating remote invites. Use Teams to check what is missing."
-			: "Configure a coordinator URL, Team, and admin secret before creating remote invites. Use Teams to finish setup.";
+			? "Finish legacy coordinator setup before creating remote invites. Use coordinator administration (legacy) to check what is missing."
+			: "Configure a coordinator URL, group, and admin secret before creating remote invites. Use coordinator administration (legacy) to finish setup.";
 	syncCreateInviteButton.disabled = true;
 	hint.hidden = false;
 	hint.textContent = message;

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -380,11 +380,11 @@ export function renderTeamSync() {
 			mode = "setup-blocked";
 		} else if (hasAmbiguousCoordinatorGroup) {
 			actionMessage =
-				"This device appears in multiple coordinator groups. Review the Team setup before approving it here.";
+				"This device appears in multiple coordinator groups. Review legacy coordinator setup before approving it here.";
 			mode = "ambiguous";
 		} else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
 			actionMessage =
-				"Review this device's Space access and advanced rules in Teams before you sync it.";
+				"Review this device's Space access and advanced rules in coordinator administration (legacy) before you sync it.";
 			mode = "scope-pending";
 		} else if (pairedPeer?.last_error) {
 			noteParts.push(`error: ${String(pairedPeer.last_error)}`);

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -1064,7 +1064,7 @@ describe("summarizeSyncRunResult", () => {
 		});
 	});
 
-	it("routes scope_rejected failures to the Teams Space-access message", () => {
+	it("routes scope_rejected failures to the legacy coordinator Space-access message", () => {
 		expect(
 			summarizeSyncRunResult({
 				items: [
@@ -1082,12 +1082,12 @@ describe("summarizeSyncRunResult", () => {
 		).toEqual({
 			ok: false,
 			message:
-				"Sync ran, but the peer is not authorized for one or more Spaces. Review Space access for this device in Teams, then sync again.",
+				"Sync ran, but the peer is not authorized for one or more Spaces. Review legacy Space access for this device in coordinator administration (legacy), then sync again.",
 			warning: true,
 		});
 	});
 
-	it("routes scoped sync incomplete failures to the Teams Space-access message", () => {
+	it("routes scoped sync incomplete failures to the legacy coordinator Space-access message", () => {
 		expect(
 			summarizeSyncRunResult({
 				items: [
@@ -1104,7 +1104,7 @@ describe("summarizeSyncRunResult", () => {
 		).toEqual({
 			ok: false,
 			message:
-				"Sync ran, but the peer is not authorized for one or more Spaces. Review Space access for this device in Teams, then sync again.",
+				"Sync ran, but the peer is not authorized for one or more Spaces. Review legacy Space access for this device in coordinator administration (legacy), then sync again.",
 			warning: true,
 		});
 	});
@@ -1127,7 +1127,7 @@ describe("summarizeSyncRunResult", () => {
 		).toEqual({
 			ok: false,
 			message:
-				"Sync ran, but the peer is not authorized for one or more Spaces. Review Space access for this device in Teams, then sync again.",
+				"Sync ran, but the peer is not authorized for one or more Spaces. Review legacy Space access for this device in coordinator administration (legacy), then sync again.",
 			warning: true,
 		});
 	});
@@ -1150,7 +1150,7 @@ describe("summarizeSyncRunResult", () => {
 		).toEqual({
 			ok: false,
 			message:
-				"Sync ran, but the peer is not authorized for one or more Spaces. Review Space access for this device in Teams, then sync again.",
+				"Sync ran, but the peer is not authorized for one or more Spaces. Review legacy Space access for this device in coordinator administration (legacy), then sync again.",
 			warning: true,
 		});
 	});

--- a/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
+++ b/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
@@ -112,7 +112,7 @@ export function summarizeSyncRunResult(payload: UiSyncRunResponse): {
 		return {
 			ok: false,
 			message:
-				"Sync ran, but the peer is not authorized for one or more Spaces. Review Space access for this device in Teams, then sync again.",
+				"Sync ran, but the peer is not authorized for one or more Spaces. Review legacy Space access for this device in coordinator administration (legacy), then sync again.",
 			warning: true,
 		};
 	}

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -336,6 +336,44 @@
         padding: var(--sp-3);
       }
 
+      .coordinator-admin-legacy-notice {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--sp-4);
+        margin-bottom: var(--sp-4);
+      }
+
+      .coordinator-admin-legacy-notice-copy {
+        display: grid;
+        gap: var(--sp-2);
+        min-width: 0;
+      }
+
+      .coordinator-admin-legacy-notice-copy h3 {
+        margin: 0;
+      }
+
+      @media (max-width: 720px) {
+        .advanced-legacy-header {
+          align-items: stretch;
+          flex-direction: column;
+        }
+
+        .advanced-legacy-header .section-actions {
+          flex-wrap: wrap;
+        }
+
+        .coordinator-admin-legacy-notice {
+          align-items: stretch;
+          flex-direction: column;
+        }
+
+        .coordinator-admin-legacy-notice .settings-button {
+          width: 100%;
+        }
+      }
+
       .coordinator-admin-inline-meta {
         margin-top: -4px;
       }
@@ -3868,7 +3906,7 @@
       <button class="tab-btn" id="tabBtn-sharing">Sharing</button>
       <button class="tab-btn" id="tabBtn-devices">Devices</button>
       <button class="tab-btn" id="tabBtn-health">Health</button>
-      <button class="tab-btn" id="tabBtn-advanced">Advanced</button>
+      <button class="tab-btn" id="tabBtn-advanced">Advanced (legacy)</button>
     </nav>
     <div id="toastRoot"></div>
     <div id="recipientPolicyManagementMount"></div>
@@ -4222,14 +4260,14 @@
     <!-- ── Tab: Advanced ───────────────────────────────────── -->
     <div class="tab-panel" id="tab-advanced" hidden>
       <div class="card">
-        <div class="section-header">
+        <div class="section-header advanced-legacy-header">
           <div>
-            <h2>Advanced</h2>
-            <div class="section-meta">Compatibility tools for device sync and Team administration.</div>
+            <h2>Advanced (legacy)</h2>
+            <div class="section-meta">Compatibility and recovery tools for device sync and coordinator administration.</div>
           </div>
-          <div class="section-actions" aria-label="Advanced sections">
+          <div class="section-actions" aria-label="Advanced sections" role="group">
             <button class="settings-button" id="advancedSyncButton" type="button" aria-pressed="true">Sync</button>
-            <button class="settings-button" id="advancedTeamsButton" type="button" aria-pressed="false">Teams</button>
+            <button class="settings-button" id="advancedTeamsButton" type="button" aria-pressed="false">Coordinator administration (legacy)</button>
           </div>
         </div>
       </div>
@@ -4384,9 +4422,25 @@
 
       <div id="advancedTeamsContent" hidden>
         <div class="card">
+          <aside
+            aria-labelledby="coordinatorAdminLegacyNoticeTitle"
+            class="coordinator-admin-inline-warning coordinator-admin-legacy-notice"
+            role="note"
+          >
+            <div class="coordinator-admin-legacy-notice-copy">
+              <h3 id="coordinatorAdminLegacyNoticeTitle" tabindex="-1">Sharing is the supported Team experience</h3>
+              <div class="peer-submeta">
+                Coordinator groups and Spaces here are legacy technical discovery and transport boundaries, not policy Teams. Changes here do not safely manage Team membership, Project access, Identity, or Team names in Sharing.
+              </div>
+              <div class="peer-submeta">
+                Keep using these controls for compatibility and recovery. Use Sharing for ordinary Team and access administration.
+              </div>
+            </div>
+            <button class="settings-button" id="coordinatorAdminOpenSharing" type="button">Open Sharing</button>
+          </aside>
           <details class="advanced-administration-disclosure" open>
-            <summary>Advanced Team administration</summary>
-            <div class="section-meta">Manage legacy enrollment, Spaces, device administration, and coordinator settings.</div>
+            <summary>Advanced coordinator administration (legacy)</summary>
+            <div class="section-meta">Technical coordinator groups, Spaces, enrollment, and recovery controls.</div>
             <div id="coordinatorAdminMount"></div>
           </details>
         </div>


### PR DESCRIPTION
## Description
Mark Advanced coordinator Team and Space administration as legacy, route users toward Sharing, and clarify archive impact and technical-boundary terminology.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced