### PR TITLE
fix(core): regenerate test schema DDL and align Retry setup assertion

### DIFF
--- a/packages/core/src/test-schema.generated.test.ts
+++ b/packages/core/src/test-schema.generated.test.ts
@@ -44,6 +44,7 @@ describe("test schema generation", () => {
 		expect(TEST_SCHEMA_BASE_DDL).toContain("legacy_team_setup_drafts");
 		expect(TEST_SCHEMA_BASE_DDL).toContain("legacy_team_setup_draft_devices");
 		expect(TEST_SCHEMA_BASE_DDL).toContain("legacy_team_setup_draft_projects");
+		expect(TEST_SCHEMA_BASE_DDL).toContain("`target_scope_id` text");
 		expect(drizzleSchema.legacyTeamSetupDrafts.safe_error_code).toBeDefined();
 		expect(drizzleSchema.legacyTeamSetupDrafts.completed_team_id).toBeDefined();
 		expect(drizzleSchema.legacyTeamSetupDraftDevices.verified_evidence_kind).toBeDefined();


### PR DESCRIPTION
## Description

Fixes two test failures that were already red on this stack before any new work:

- `packages/core/src/test-schema.generated.ts` was stale and missing the `target_scope_id` column on `legacy_team_setup_draft_projects`, so the Drizzle snapshot test failed. Regenerated via `packages/core/scripts/generate-test-schema.ts`.
- `team-sync-panel.test.tsx` asserted the lowercase substring `"retry setup"` while the owner `needs_attention` next action renders `"Retry setup for <Project>."`. Aligned the assertion with the rendered casing.

Note: `pnpm --filter @codemem/core run generate:test-schema` currently fails because that package pins tsx 4.21.0 while 4.22.3 is installed. Run the script from the repo root instead. Not fixed here to keep this PR scoped.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Full suite green: 222 files, 5551 tests.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
