### PR TITLE
feat(core): add pi event adapter for 0.41 ingest

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -674,6 +674,15 @@ export {
 	buildMemoryPackWithTraceAsync,
 	estimateTokens,
 } from "./pack.js";
+export type { PiFlushSignal, PiHookAdapterEvent, PiHookRawEventEnvelope } from "./pi-hooks.js";
+export {
+	buildIngestPayloadFromPiEvent,
+	buildPiFlushSignalFromEvent,
+	buildRawEventEnvelopeFromPiEvent,
+	MAPPABLE_PI_EVENTS,
+	mapPiEventPayload,
+	PI_FLUSH_ONLY_EVENTS,
+} from "./pi-hooks.js";
 export type {
 	BlockedPolicyTeamDeviceEligibilityResult,
 	DerivePolicyTeamDeviceEligibilityInput,

--- a/packages/core/src/pi-hooks.test.ts
+++ b/packages/core/src/pi-hooks.test.ts
@@ -1,0 +1,776 @@
+/**
+ * Tests for pi-hooks.ts — AdapterEvent v1 mapping for pi extension events.
+ *
+ * Covers:
+ *  - mapPiEventPayload: all mappable event types, skip cases, deterministic ids,
+ *    tool_result isError, fork → new stream identity
+ *  - buildPiFlushSignalFromEvent: session_before_compact flush-only contract
+ *  - buildRawEventEnvelopeFromPiEvent: envelope shape + source "pi"
+ *  - buildIngestPayloadFromPiEvent: session context fields
+ *  - store attribution: pi-ingested rows carry source = "pi" (no opencode rows)
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import {
+	buildIngestPayloadFromPiEvent,
+	buildPiFlushSignalFromEvent,
+	buildRawEventEnvelopeFromPiEvent,
+	MAPPABLE_PI_EVENTS,
+	mapPiEventPayload,
+} from "./pi-hooks.js";
+import { ingestRawEvents } from "./raw-event-ingest.js";
+import { MemoryStore } from "./store.js";
+import { initTestSchema } from "./test-utils.js";
+
+function requireEnvelope(envelope: ReturnType<typeof buildRawEventEnvelopeFromPiEvent>) {
+	if (envelope === null) {
+		throw new Error("expected pi envelope");
+	}
+	return envelope;
+}
+
+// ---------------------------------------------------------------------------
+// mapPiEventPayload — event type mapping
+// ---------------------------------------------------------------------------
+
+describe("mapPiEventPayload", () => {
+	describe("session_start → session_start", () => {
+		it("maps session start with deterministic id", () => {
+			const event = mapPiEventPayload({
+				piEvent: "session_start",
+				sessionId: "pi-sess-1",
+				cwd: "/tmp/repo",
+				ts: "2026-06-01T12:00:00Z",
+			});
+
+			expect(event).not.toBeNull();
+			expect(event?.schema_version).toBe("1.0");
+			expect(event?.source).toBe("pi");
+			expect(event?.event_type).toBe("session_start");
+			expect(event?.session_id).toBe("pi-sess-1");
+			expect(event?.event_id).toBe("pi:pi-sess-1:session_start");
+			expect(event?.cwd).toBe("/tmp/repo");
+			expect(event?.ts).toBe("2026-06-01T12:00:00Z");
+		});
+
+		it("prefers entryId for the event id suffix when present", () => {
+			const event = mapPiEventPayload({
+				piEvent: "session_start",
+				sessionId: "pi-sess-1",
+				entryId: "entry-start-1",
+				ts: "2026-06-01T12:00:00Z",
+			});
+			expect(event?.event_id).toBe("pi:pi-sess-1:entry-start-1");
+		});
+	});
+
+	describe("session_shutdown → session_end", () => {
+		it("maps reason field", () => {
+			const event = mapPiEventPayload({
+				piEvent: "session_shutdown",
+				sessionId: "pi-sess-end",
+				reason: "user_exit",
+				ts: "2026-06-01T13:00:00Z",
+			});
+
+			expect(event).not.toBeNull();
+			expect(event?.event_type).toBe("session_end");
+			expect(event?.payload.reason).toBe("user_exit");
+			expect(event?.event_id).toBe("pi:pi-sess-end:session_end");
+			expect(event?.source).toBe("pi");
+		});
+	});
+
+	describe("message_end role=user → prompt", () => {
+		it("maps prompt text and meta", () => {
+			const event = mapPiEventPayload({
+				piEvent: "message_end",
+				sessionId: "pi-sess-msg",
+				entryId: "entry-u1",
+				role: "user",
+				text: "Run tests",
+				cwd: "/tmp/repo",
+				custom_field: "keep-me",
+				ts: "2026-06-01T12:01:00Z",
+			});
+
+			expect(event).not.toBeNull();
+			expect(event?.source).toBe("pi");
+			expect(event?.event_type).toBe("prompt");
+			expect(event?.payload.text).toBe("Run tests");
+			expect(event?.event_id).toBe("pi:pi-sess-msg:entry-u1");
+			expect(event?.meta.pi_event).toBe("message_end");
+			expect(event?.meta.entry_id).toBe("entry-u1");
+			expect((event?.meta.pi_fields as Record<string, unknown>).custom_field).toBe("keep-me");
+		});
+
+		it("returns null for empty text", () => {
+			expect(
+				mapPiEventPayload({
+					piEvent: "message_end",
+					sessionId: "pi-sess-msg",
+					entryId: "entry-u1",
+					role: "user",
+					text: "  ",
+				}),
+			).toBeNull();
+		});
+
+		it("returns null without entryId", () => {
+			expect(
+				mapPiEventPayload({
+					piEvent: "message_end",
+					sessionId: "pi-sess-msg",
+					role: "user",
+					text: "hello",
+				}),
+			).toBeNull();
+		});
+	});
+
+	describe("message_end role=assistant → assistant", () => {
+		it("maps assistant text", () => {
+			const event = mapPiEventPayload({
+				piEvent: "message_end",
+				sessionId: "pi-sess-msg",
+				entryId: "entry-a1",
+				role: "assistant",
+				text: "All done",
+				ts: "2026-06-01T12:02:00Z",
+			});
+
+			expect(event).not.toBeNull();
+			expect(event?.event_type).toBe("assistant");
+			expect(event?.payload.text).toBe("All done");
+			expect(event?.event_id).toBe("pi:pi-sess-msg:entry-a1");
+		});
+	});
+
+	describe("turn_end → assistant", () => {
+		it("maps turn_end text", () => {
+			const event = mapPiEventPayload({
+				piEvent: "turn_end",
+				sessionId: "pi-sess-turn",
+				entryId: "entry-t1",
+				text: "Turn complete",
+				ts: "2026-06-01T12:03:00Z",
+			});
+			expect(event?.event_type).toBe("assistant");
+			expect(event?.payload.text).toBe("Turn complete");
+			expect(event?.event_id).toBe("pi:pi-sess-turn:entry-t1");
+		});
+
+		it("does not map agent_end (D2: extension emits message_end only)", () => {
+			expect(MAPPABLE_PI_EVENTS.has("agent_end")).toBe(false);
+			expect(
+				mapPiEventPayload({
+					piEvent: "agent_end",
+					sessionId: "pi-sess-agent",
+					entryId: "entry-ag1",
+					text: "Agent finished",
+					ts: "2026-06-01T12:04:00Z",
+				}),
+			).toBeNull();
+		});
+	});
+
+	describe("tool_call → tool_call", () => {
+		it("maps tool name, input, and toolCallId", () => {
+			const event = mapPiEventPayload({
+				piEvent: "tool_call",
+				sessionId: "pi-sess-tool",
+				toolCallId: "tc-1",
+				toolName: "bash",
+				toolInput: { command: "pnpm test" },
+				ts: "2026-06-01T12:05:00Z",
+			});
+
+			expect(event).not.toBeNull();
+			expect(event?.event_type).toBe("tool_call");
+			expect(event?.payload.tool_name).toBe("bash");
+			expect(event?.payload.tool_input).toEqual({ command: "pnpm test" });
+			expect(event?.event_id).toBe("pi:pi-sess-tool:tc-1");
+			expect(event?.meta.tool_call_id).toBe("tc-1");
+		});
+
+		it("defaults tool_input to {} when missing", () => {
+			const event = mapPiEventPayload({
+				piEvent: "tool_call",
+				sessionId: "pi-sess-tool",
+				toolCallId: "tc-2",
+				toolName: "read",
+				ts: "2026-06-01T12:05:00Z",
+			});
+			expect(event?.payload.tool_input).toEqual({});
+		});
+
+		it("returns null for missing toolName", () => {
+			expect(
+				mapPiEventPayload({
+					piEvent: "tool_call",
+					sessionId: "pi-sess-tool",
+					toolCallId: "tc-3",
+				}),
+			).toBeNull();
+		});
+
+		it("returns null without toolCallId or entryId", () => {
+			expect(
+				mapPiEventPayload({
+					piEvent: "tool_call",
+					sessionId: "pi-sess-tool",
+					toolName: "bash",
+				}),
+			).toBeNull();
+		});
+	});
+
+	describe("tool_result → tool_result (isError)", () => {
+		it("maps ok result", () => {
+			const event = mapPiEventPayload({
+				piEvent: "tool_result",
+				sessionId: "pi-sess-tool",
+				toolCallId: "tc-1",
+				toolName: "bash",
+				toolOutput: { exit_code: 0 },
+				isError: false,
+				ts: "2026-06-01T12:06:00Z",
+			});
+
+			expect(event).not.toBeNull();
+			expect(event?.event_type).toBe("tool_result");
+			expect(event?.payload.status).toBe("ok");
+			expect(event?.payload.tool_output).toEqual({ exit_code: 0 });
+			expect(event?.payload.tool_error).toBeNull();
+			expect(event?.event_id).toBe("pi:pi-sess-tool:tc-1:result");
+		});
+
+		it("maps isError result", () => {
+			const event = mapPiEventPayload({
+				piEvent: "tool_result",
+				sessionId: "pi-sess-tool",
+				toolCallId: "tc-err",
+				toolName: "bash",
+				isError: true,
+				error: { message: "1 failed" },
+				ts: "2026-06-01T12:07:00Z",
+			});
+
+			expect(event).not.toBeNull();
+			expect(event?.event_type).toBe("tool_result");
+			expect(event?.payload.status).toBe("error");
+			expect(event?.payload.tool_output).toBeNull();
+			expect(event?.payload.error).toEqual({ message: "1 failed" });
+			expect(event?.payload.tool_error).toEqual({ message: "1 failed" });
+			expect(event?.event_id).toBe("pi:pi-sess-tool:tc-err:result");
+		});
+	});
+
+	describe("skip cases", () => {
+		it("returns null for unsupported event type", () => {
+			expect(
+				mapPiEventPayload({
+					piEvent: "before_agent_start",
+					sessionId: "pi-sess-1",
+				}),
+			).toBeNull();
+		});
+
+		it("returns null for missing sessionId", () => {
+			expect(
+				mapPiEventPayload({
+					piEvent: "session_start",
+				}),
+			).toBeNull();
+		});
+
+		it("returns null for empty sessionId", () => {
+			expect(
+				mapPiEventPayload({
+					piEvent: "session_start",
+					sessionId: "   ",
+				}),
+			).toBeNull();
+		});
+
+		it("returns null for session_before_compact (flush-only, not transcript)", () => {
+			expect(
+				mapPiEventPayload({
+					piEvent: "session_before_compact",
+					sessionId: "pi-sess-1",
+					ts: "2026-06-01T12:00:00Z",
+				}),
+			).toBeNull();
+		});
+
+		it("returns null for unknown role on message_end", () => {
+			expect(
+				mapPiEventPayload({
+					piEvent: "message_end",
+					sessionId: "pi-sess-1",
+					entryId: "e1",
+					role: "system",
+					text: "nope",
+				}),
+			).toBeNull();
+		});
+	});
+
+	describe("deterministic event ids", () => {
+		it("produces identical ids for identical payloads", () => {
+			const payload = {
+				piEvent: "message_end",
+				sessionId: "pi-sess-stable",
+				entryId: "entry-stable-1",
+				role: "user",
+				text: "hello",
+				ts: "2026-06-01T12:00:00Z",
+			};
+			const first = mapPiEventPayload(payload);
+			const second = mapPiEventPayload(payload);
+			expect(first?.event_id).toBe(second?.event_id);
+			expect(first?.event_id).toBe("pi:pi-sess-stable:entry-stable-1");
+		});
+
+		it("event_id is invariant to ts (different or absent)", () => {
+			// Dedup key must not incorporate wall-clock ts — retries with a fresh
+			// clock or missing ts must collapse to the same raw-event identity.
+			const base = {
+				piEvent: "message_end",
+				sessionId: "pi-sess-ts-invariant",
+				entryId: "entry-ts-1",
+				role: "assistant",
+				text: "same logical message",
+			};
+			const withTsA = mapPiEventPayload({ ...base, ts: "2026-01-01T00:00:00Z" });
+			const withTsB = mapPiEventPayload({ ...base, ts: "2026-12-31T23:59:59Z" });
+			const withoutTs = mapPiEventPayload({ ...base });
+			expect(withTsA?.event_id).toBe("pi:pi-sess-ts-invariant:entry-ts-1");
+			expect(withTsB?.event_id).toBe(withTsA?.event_id);
+			expect(withoutTs?.event_id).toBe(withTsA?.event_id);
+			// ts itself may differ; only event_id must be stable.
+			expect(withTsA?.ts).not.toBe(withTsB?.ts);
+		});
+
+		it("uses the pi:<sessionId>:<id> format", () => {
+			const event = mapPiEventPayload({
+				piEvent: "tool_call",
+				sessionId: "S",
+				toolCallId: "T",
+				toolName: "read",
+				ts: "2026-06-01T12:00:00Z",
+			});
+			expect(event?.event_id).toMatch(/^pi:[^:]+:.+$/);
+			expect(event?.event_id).toBe("pi:S:T");
+		});
+	});
+
+	describe("fork id change → new stream identity", () => {
+		it("different sessionId yields different event_id and session_id", () => {
+			const base = {
+				piEvent: "message_end" as const,
+				entryId: "entry-same",
+				role: "user",
+				text: "same text",
+				ts: "2026-06-01T12:00:00Z",
+			};
+			const parent = mapPiEventPayload({ ...base, sessionId: "sess-parent" });
+			const fork = mapPiEventPayload({ ...base, sessionId: "sess-fork" });
+
+			expect(parent?.session_id).toBe("sess-parent");
+			expect(fork?.session_id).toBe("sess-fork");
+			expect(parent?.event_id).toBe("pi:sess-parent:entry-same");
+			expect(fork?.event_id).toBe("pi:sess-fork:entry-same");
+			expect(parent?.event_id).not.toBe(fork?.event_id);
+		});
+
+		it("envelope stream identity follows the forked session id", () => {
+			const parentEnv = buildRawEventEnvelopeFromPiEvent({
+				piEvent: "session_start",
+				sessionId: "sess-parent",
+				ts: "2026-06-01T12:00:00Z",
+			});
+			const forkEnv = buildRawEventEnvelopeFromPiEvent({
+				piEvent: "session_start",
+				sessionId: "sess-fork",
+				ts: "2026-06-01T12:00:00Z",
+			});
+
+			expect(parentEnv?.session_stream_id).toBe("sess-parent");
+			expect(forkEnv?.session_stream_id).toBe("sess-fork");
+			expect(parentEnv?.session_stream_id).not.toBe(forkEnv?.session_stream_id);
+			expect(parentEnv?.source).toBe("pi");
+			expect(forkEnv?.source).toBe("pi");
+		});
+	});
+
+	describe("snake_case field aliases", () => {
+		it("accepts session_id / pi_event / entry_id aliases", () => {
+			const event = mapPiEventPayload({
+				pi_event: "message_end",
+				session_id: "pi-snake",
+				entry_id: "e-snake",
+				role: "user",
+				text: "aliased",
+				ts: "2026-06-01T12:00:00Z",
+			});
+			expect(event?.session_id).toBe("pi-snake");
+			expect(event?.event_id).toBe("pi:pi-snake:e-snake");
+			expect(event?.source).toBe("pi");
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildPiFlushSignalFromEvent
+// ---------------------------------------------------------------------------
+
+describe("buildPiFlushSignalFromEvent", () => {
+	it("returns a flush signal for session_before_compact", () => {
+		const signal = buildPiFlushSignalFromEvent({
+			piEvent: "session_before_compact",
+			sessionId: "pi-sess-compact",
+			cwd: "/tmp/repo",
+			project: "repo",
+			ts: "2026-06-01T14:00:00Z",
+		});
+
+		expect(signal).not.toBeNull();
+		expect(signal?.kind).toBe("flush");
+		expect(signal?.reason).toBe("session_before_compact");
+		expect(signal?.source).toBe("pi");
+		expect(signal?.session_id).toBe("pi-sess-compact");
+		expect(signal?.ts).toBe("2026-06-01T14:00:00Z");
+		// Must never look like a compaction object for pi to apply.
+		expect(signal && "compaction" in signal).toBe(false);
+	});
+
+	it("returns null for transcript events", () => {
+		expect(
+			buildPiFlushSignalFromEvent({
+				piEvent: "session_start",
+				sessionId: "pi-sess-1",
+			}),
+		).toBeNull();
+	});
+
+	it("returns null without sessionId", () => {
+		expect(
+			buildPiFlushSignalFromEvent({
+				piEvent: "session_before_compact",
+			}),
+		).toBeNull();
+	});
+
+	it("does not produce a raw envelope or ingest payload for compaction", () => {
+		const payload = {
+			piEvent: "session_before_compact",
+			sessionId: "pi-sess-compact",
+			ts: "2026-06-01T14:00:00Z",
+		};
+		expect(mapPiEventPayload(payload)).toBeNull();
+		expect(buildRawEventEnvelopeFromPiEvent(payload)).toBeNull();
+		expect(buildIngestPayloadFromPiEvent(payload)).toBeNull();
+		expect(buildPiFlushSignalFromEvent(payload)).not.toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildRawEventEnvelopeFromPiEvent
+// ---------------------------------------------------------------------------
+
+describe("buildRawEventEnvelopeFromPiEvent", () => {
+	it("returns null for unsupported event", () => {
+		expect(
+			buildRawEventEnvelopeFromPiEvent({
+				piEvent: "before_agent_start",
+				sessionId: "pi-sess-1",
+			}),
+		).toBeNull();
+	});
+
+	it("wraps adapter events for raw-event ingestion with source pi", () => {
+		const envelope = buildRawEventEnvelopeFromPiEvent({
+			piEvent: "session_start",
+			sessionId: "pi-sess-env",
+			ts: "2026-06-01T12:00:00Z",
+			cwd: "/tmp/repo",
+			project: "repo",
+		});
+
+		expect(envelope).not.toBeNull();
+		expect(envelope?.source).toBe("pi");
+		expect(envelope?.event_type).toBe("pi.hook");
+		expect(envelope?.session_stream_id).toBe("pi-sess-env");
+		expect(envelope?.session_id).toBe("pi-sess-env");
+		expect(envelope?.opencode_session_id).toBe("pi-sess-env");
+		expect(envelope?.started_at).toBe("2026-06-01T12:00:00Z");
+		expect(envelope?.event_id).toBe("pi:pi-sess-env:session_start");
+		expect(envelope?.payload.type).toBe("pi.hook");
+		expect((envelope?.payload._adapter as Record<string, unknown>).source).toBe("pi");
+		expect((envelope?.payload._adapter as Record<string, unknown>).schema_version).toBe("1.0");
+		expect((envelope?.payload._adapter as Record<string, unknown>).event_type).toBe(
+			"session_start",
+		);
+	});
+
+	it("sets started_at only for session_start", () => {
+		const envelope = buildRawEventEnvelopeFromPiEvent({
+			piEvent: "message_end",
+			sessionId: "pi-sess-env",
+			entryId: "e1",
+			role: "user",
+			text: "hi",
+			ts: "2026-06-01T12:01:00Z",
+		});
+		expect(envelope?.started_at).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildIngestPayloadFromPiEvent
+// ---------------------------------------------------------------------------
+
+describe("buildIngestPayloadFromPiEvent", () => {
+	it("returns null for unsupported event", () => {
+		expect(
+			buildIngestPayloadFromPiEvent({
+				piEvent: "unknown",
+				sessionId: "pi-sess-1",
+			}),
+		).toBeNull();
+	});
+
+	it("wraps adapter event in session_context with source pi and all aliases", () => {
+		const ingest = buildIngestPayloadFromPiEvent({
+			piEvent: "session_start",
+			sessionId: "pi-sess-xyz",
+			cwd: "/tmp/repo",
+			ts: "2026-06-01T12:00:00Z",
+		});
+
+		expect(ingest).not.toBeNull();
+		const ctx = ingest?.session_context as Record<string, unknown>;
+		expect(ctx.source).toBe("pi");
+		expect(ctx.stream_id).toBe("pi-sess-xyz");
+		expect(ctx.session_stream_id).toBe("pi-sess-xyz");
+		expect(ctx.session_id).toBe("pi-sess-xyz");
+		expect(ctx.opencode_session_id).toBe("pi-sess-xyz");
+
+		const events = ingest?.events as Array<Record<string, unknown>>;
+		expect(events).toHaveLength(1);
+		expect(events[0]?.type).toBe("pi.hook");
+		expect((events[0]?._adapter as Record<string, unknown>).source).toBe("pi");
+		expect((events[0]?._adapter as Record<string, unknown>).event_type).toBe("session_start");
+	});
+
+	it("sets cwd from pi payload", () => {
+		const ingest = buildIngestPayloadFromPiEvent({
+			piEvent: "message_end",
+			sessionId: "pi-sess-cwd",
+			entryId: "e-cwd",
+			role: "user",
+			text: "hello",
+			cwd: "/home/user/myrepo",
+			ts: "2026-06-01T12:00:00Z",
+		});
+		expect(ingest?.cwd).toBe("/home/user/myrepo");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Attribution: pi-ingested rows carry source = "pi"
+// ---------------------------------------------------------------------------
+
+describe("pi source attribution via recordRawEvent", () => {
+	let tmpDir: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-pi-hooks-test-"));
+		const dbPath = join(tmpDir, "test.sqlite");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("stores raw events with source=pi and creates no opencode rows", () => {
+		const envelope = requireEnvelope(
+			buildRawEventEnvelopeFromPiEvent({
+				piEvent: "message_end",
+				sessionId: "pi-attr-sess",
+				entryId: "entry-attr-1",
+				role: "user",
+				text: "attribute me to pi",
+				ts: "2026-06-01T15:00:00Z",
+				cwd: tmpDir,
+				project: "codemem",
+			}),
+		);
+		// Explicit source from envelope — never rely on recordRawEvent default.
+		expect(envelope.source).toBe("pi");
+
+		const inserted = store.recordRawEvent({
+			opencodeSessionId: envelope.session_stream_id,
+			source: envelope.source,
+			eventId: envelope.event_id,
+			eventType: envelope.event_type,
+			payload: envelope.payload,
+			tsWallMs: envelope.ts_wall_ms,
+		});
+		expect(inserted).toBe(true);
+
+		const piRows = store.db
+			.prepare(`SELECT source, stream_id, event_id, event_type FROM raw_events WHERE source = ?`)
+			.all("pi") as Array<{
+			source: string;
+			stream_id: string;
+			event_id: string;
+			event_type: string;
+		}>;
+		expect(piRows).toHaveLength(1);
+		expect(piRows[0]?.source).toBe("pi");
+		expect(piRows[0]?.stream_id).toBe("pi-attr-sess");
+		expect(piRows[0]?.event_id).toBe("pi:pi-attr-sess:entry-attr-1");
+		expect(piRows[0]?.event_type).toBe("pi.hook");
+
+		const opencodeRows = store.db
+			.prepare(`SELECT COUNT(*) AS n FROM raw_events WHERE source = ?`)
+			.get("opencode") as { n: number };
+		expect(Number(opencodeRows.n)).toBe(0);
+
+		const sessionRows = store.db
+			.prepare(`SELECT source, stream_id FROM raw_event_sessions`)
+			.all() as Array<{ source: string; stream_id: string }>;
+		expect(sessionRows).toHaveLength(1);
+		expect(sessionRows[0]?.source).toBe("pi");
+		expect(sessionRows[0]?.stream_id).toBe("pi-attr-sess");
+	});
+
+	it("dedupes retries by (source, stream, event_id) for pi", () => {
+		const envelope = requireEnvelope(
+			buildRawEventEnvelopeFromPiEvent({
+				piEvent: "tool_call",
+				sessionId: "pi-dedupe-sess",
+				toolCallId: "tc-dedupe",
+				toolName: "read",
+				toolInput: { path: "README.md" },
+				ts: "2026-06-01T15:01:00Z",
+			}),
+		);
+
+		const write = () =>
+			store.recordRawEvent({
+				opencodeSessionId: envelope.session_stream_id,
+				source: envelope.source,
+				eventId: envelope.event_id,
+				eventType: envelope.event_type,
+				payload: envelope.payload,
+				tsWallMs: envelope.ts_wall_ms,
+			});
+		expect(write()).toBe(true);
+		expect(write()).toBe(false);
+
+		const count = store.db
+			.prepare(`SELECT COUNT(*) AS n FROM raw_events WHERE source = ? AND stream_id = ?`)
+			.get("pi", "pi-dedupe-sess") as { n: number };
+		expect(Number(count.n)).toBe(1);
+	});
+
+	it("forked session id creates a separate pi stream partition", () => {
+		for (const sessionId of ["sess-parent", "sess-fork"]) {
+			const envelope = requireEnvelope(
+				buildRawEventEnvelopeFromPiEvent({
+					piEvent: "message_end",
+					sessionId,
+					entryId: "entry-shared-logical",
+					role: "user",
+					text: "fork test",
+					ts: "2026-06-01T15:02:00Z",
+				}),
+			);
+			store.recordRawEvent({
+				opencodeSessionId: envelope.session_stream_id,
+				source: envelope.source,
+				eventId: envelope.event_id,
+				eventType: envelope.event_type,
+				payload: envelope.payload,
+				tsWallMs: envelope.ts_wall_ms,
+			});
+		}
+
+		const rows = store.db
+			.prepare(
+				`SELECT source, stream_id, event_id FROM raw_events WHERE source = ? ORDER BY stream_id`,
+			)
+			.all("pi") as Array<{ source: string; stream_id: string; event_id: string }>;
+		expect(rows).toHaveLength(2);
+		expect(rows.map((r) => r.stream_id).sort()).toEqual(["sess-fork", "sess-parent"]);
+		expect(rows.every((r) => r.source === "pi")).toBe(true);
+		expect(new Set(rows.map((r) => r.event_id)).size).toBe(2);
+
+		const opencodeCount = store.db
+			.prepare(`SELECT COUNT(*) AS n FROM raw_events WHERE source = ?`)
+			.get("opencode") as { n: number };
+		expect(Number(opencodeCount.n)).toBe(0);
+	});
+});
+
+describe("ingestRawEvents accepts pi envelopes", () => {
+	let tmpDir: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-pi-hooks-ingest-"));
+		const dbPath = join(tmpDir, "test.sqlite");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("persists source pi with no opencode rows", () => {
+		const envelope = requireEnvelope(
+			buildRawEventEnvelopeFromPiEvent({
+				piEvent: "message_end",
+				sessionId: "pi-canonical-1",
+				entryId: "entry-1",
+				role: "user",
+				text: "hello",
+				ts: "2026-06-01T16:00:00Z",
+			}),
+		);
+		const result = ingestRawEvents(store, envelope);
+		expect(result.inserted).toBe(1);
+		expect(result.skipped).toBe(0);
+
+		const row = store.db.prepare(`SELECT source, stream_id, event_id FROM raw_events`).get() as {
+			source: string;
+			stream_id: string;
+			event_id: string;
+		};
+		expect(row.source).toBe("pi");
+		expect(row.stream_id).toBe("pi-canonical-1");
+		expect(row.event_id).toBe(envelope.event_id);
+
+		const opencodeCount = store.db
+			.prepare(`SELECT COUNT(*) AS n FROM raw_events WHERE source = ?`)
+			.get("opencode") as { n: number };
+		expect(Number(opencodeCount.n)).toBe(0);
+	});
+});

--- a/packages/core/src/pi-hooks.test.ts
+++ b/packages/core/src/pi-hooks.test.ts
@@ -110,7 +110,9 @@ describe("mapPiEventPayload", () => {
 			expect(event?.event_id).toMatch(PI_EVENT_ID);
 			expect(event?.meta.pi_event).toBe("message_end");
 			expect(event?.meta.entry_id).toBe("entry-u1");
-			expect((event?.meta.pi_fields as Record<string, unknown>).custom_field).toBe("keep-me");
+			expect((event?.meta.pi_fields as Record<string, unknown> | undefined)?.custom_field).toBe(
+				"keep-me",
+			);
 		});
 
 		it("returns null for empty text", () => {
@@ -515,11 +517,10 @@ describe("buildRawEventEnvelopeFromPiEvent", () => {
 		expect(envelope?.started_at).toBe("2026-06-01T12:00:00Z");
 		expect(envelope?.event_id).toMatch(PI_EVENT_ID);
 		expect(envelope?.payload.type).toBe("pi.hook");
-		expect((envelope?.payload._adapter as Record<string, unknown>).source).toBe("pi");
-		expect((envelope?.payload._adapter as Record<string, unknown>).schema_version).toBe("1.0");
-		expect((envelope?.payload._adapter as Record<string, unknown>).event_type).toBe(
-			"session_start",
-		);
+		const adapter = envelope?.payload._adapter as Record<string, unknown> | undefined;
+		expect(adapter?.source).toBe("pi");
+		expect(adapter?.schema_version).toBe("1.0");
+		expect(adapter?.event_type).toBe("session_start");
 	});
 
 	it("sets started_at only for session_start", () => {
@@ -568,8 +569,9 @@ describe("buildIngestPayloadFromPiEvent", () => {
 		const events = ingest?.events as Array<Record<string, unknown>>;
 		expect(events).toHaveLength(1);
 		expect(events[0]?.type).toBe("pi.hook");
-		expect((events[0]?._adapter as Record<string, unknown>).source).toBe("pi");
-		expect((events[0]?._adapter as Record<string, unknown>).event_type).toBe("session_start");
+		const adapter = events[0]?._adapter as Record<string, unknown> | undefined;
+		expect(adapter?.source).toBe("pi");
+		expect(adapter?.event_type).toBe("session_start");
 	});
 
 	it("sets cwd from pi payload", () => {

--- a/packages/core/src/pi-hooks.test.ts
+++ b/packages/core/src/pi-hooks.test.ts
@@ -33,6 +33,8 @@ function requireEnvelope(envelope: ReturnType<typeof buildRawEventEnvelopeFromPi
 	return envelope;
 }
 
+const PI_EVENT_ID = /^pi_evt_[0-9a-f]{24}$/;
+
 // ---------------------------------------------------------------------------
 // mapPiEventPayload — event type mapping
 // ---------------------------------------------------------------------------
@@ -52,7 +54,7 @@ describe("mapPiEventPayload", () => {
 			expect(event?.source).toBe("pi");
 			expect(event?.event_type).toBe("session_start");
 			expect(event?.session_id).toBe("pi-sess-1");
-			expect(event?.event_id).toBe("pi:pi-sess-1:session_start");
+			expect(event?.event_id).toMatch(PI_EVENT_ID);
 			expect(event?.cwd).toBe("/tmp/repo");
 			expect(event?.ts).toBe("2026-06-01T12:00:00Z");
 		});
@@ -64,7 +66,7 @@ describe("mapPiEventPayload", () => {
 				entryId: "entry-start-1",
 				ts: "2026-06-01T12:00:00Z",
 			});
-			expect(event?.event_id).toBe("pi:pi-sess-1:entry-start-1");
+			expect(event?.event_id).toMatch(PI_EVENT_ID);
 		});
 	});
 
@@ -80,7 +82,7 @@ describe("mapPiEventPayload", () => {
 			expect(event).not.toBeNull();
 			expect(event?.event_type).toBe("session_end");
 			expect(event?.payload.reason).toBe("user_exit");
-			expect(event?.event_id).toBe("pi:pi-sess-end:session_end");
+			expect(event?.event_id).toMatch(PI_EVENT_ID);
 			expect(event?.source).toBe("pi");
 		});
 	});
@@ -102,7 +104,7 @@ describe("mapPiEventPayload", () => {
 			expect(event?.source).toBe("pi");
 			expect(event?.event_type).toBe("prompt");
 			expect(event?.payload.text).toBe("Run tests");
-			expect(event?.event_id).toBe("pi:pi-sess-msg:entry-u1");
+			expect(event?.event_id).toMatch(PI_EVENT_ID);
 			expect(event?.meta.pi_event).toBe("message_end");
 			expect(event?.meta.entry_id).toBe("entry-u1");
 			expect((event?.meta.pi_fields as Record<string, unknown>).custom_field).toBe("keep-me");
@@ -146,7 +148,7 @@ describe("mapPiEventPayload", () => {
 			expect(event).not.toBeNull();
 			expect(event?.event_type).toBe("assistant");
 			expect(event?.payload.text).toBe("All done");
-			expect(event?.event_id).toBe("pi:pi-sess-msg:entry-a1");
+			expect(event?.event_id).toMatch(PI_EVENT_ID);
 		});
 	});
 
@@ -161,7 +163,7 @@ describe("mapPiEventPayload", () => {
 			});
 			expect(event?.event_type).toBe("assistant");
 			expect(event?.payload.text).toBe("Turn complete");
-			expect(event?.event_id).toBe("pi:pi-sess-turn:entry-t1");
+			expect(event?.event_id).toMatch(PI_EVENT_ID);
 		});
 
 		it("does not map agent_end (D2: extension emits message_end only)", () => {
@@ -193,7 +195,7 @@ describe("mapPiEventPayload", () => {
 			expect(event?.event_type).toBe("tool_call");
 			expect(event?.payload.tool_name).toBe("bash");
 			expect(event?.payload.tool_input).toEqual({ command: "pnpm test" });
-			expect(event?.event_id).toBe("pi:pi-sess-tool:tc-1");
+			expect(event?.event_id).toMatch(PI_EVENT_ID);
 			expect(event?.meta.tool_call_id).toBe("tc-1");
 		});
 
@@ -246,7 +248,7 @@ describe("mapPiEventPayload", () => {
 			expect(event?.payload.status).toBe("ok");
 			expect(event?.payload.tool_output).toEqual({ exit_code: 0 });
 			expect(event?.payload.tool_error).toBeNull();
-			expect(event?.event_id).toBe("pi:pi-sess-tool:tc-1:result");
+			expect(event?.event_id).toMatch(PI_EVENT_ID);
 		});
 
 		it("maps isError result", () => {
@@ -266,7 +268,7 @@ describe("mapPiEventPayload", () => {
 			expect(event?.payload.tool_output).toBeNull();
 			expect(event?.payload.error).toEqual({ message: "1 failed" });
 			expect(event?.payload.tool_error).toEqual({ message: "1 failed" });
-			expect(event?.event_id).toBe("pi:pi-sess-tool:tc-err:result");
+			expect(event?.event_id).toMatch(PI_EVENT_ID);
 		});
 	});
 
@@ -333,7 +335,7 @@ describe("mapPiEventPayload", () => {
 			const first = mapPiEventPayload(payload);
 			const second = mapPiEventPayload(payload);
 			expect(first?.event_id).toBe(second?.event_id);
-			expect(first?.event_id).toBe("pi:pi-sess-stable:entry-stable-1");
+			expect(first?.event_id).toMatch(PI_EVENT_ID);
 		});
 
 		it("event_id is invariant to ts (different or absent)", () => {
@@ -349,14 +351,14 @@ describe("mapPiEventPayload", () => {
 			const withTsA = mapPiEventPayload({ ...base, ts: "2026-01-01T00:00:00Z" });
 			const withTsB = mapPiEventPayload({ ...base, ts: "2026-12-31T23:59:59Z" });
 			const withoutTs = mapPiEventPayload({ ...base });
-			expect(withTsA?.event_id).toBe("pi:pi-sess-ts-invariant:entry-ts-1");
+			expect(withTsA?.event_id).toMatch(PI_EVENT_ID);
 			expect(withTsB?.event_id).toBe(withTsA?.event_id);
 			expect(withoutTs?.event_id).toBe(withTsA?.event_id);
 			// ts itself may differ; only event_id must be stable.
 			expect(withTsA?.ts).not.toBe(withTsB?.ts);
 		});
 
-		it("uses the pi:<sessionId>:<id> format", () => {
+		it("uses the pi_evt_ hashed format", () => {
 			const event = mapPiEventPayload({
 				piEvent: "tool_call",
 				sessionId: "S",
@@ -364,8 +366,7 @@ describe("mapPiEventPayload", () => {
 				toolName: "read",
 				ts: "2026-06-01T12:00:00Z",
 			});
-			expect(event?.event_id).toMatch(/^pi:[^:]+:.+$/);
-			expect(event?.event_id).toBe("pi:S:T");
+			expect(event?.event_id).toMatch(PI_EVENT_ID);
 		});
 	});
 
@@ -383,8 +384,8 @@ describe("mapPiEventPayload", () => {
 
 			expect(parent?.session_id).toBe("sess-parent");
 			expect(fork?.session_id).toBe("sess-fork");
-			expect(parent?.event_id).toBe("pi:sess-parent:entry-same");
-			expect(fork?.event_id).toBe("pi:sess-fork:entry-same");
+			expect(parent?.event_id).toMatch(PI_EVENT_ID);
+			expect(fork?.event_id).toMatch(PI_EVENT_ID);
 			expect(parent?.event_id).not.toBe(fork?.event_id);
 		});
 
@@ -419,7 +420,7 @@ describe("mapPiEventPayload", () => {
 				ts: "2026-06-01T12:00:00Z",
 			});
 			expect(event?.session_id).toBe("pi-snake");
-			expect(event?.event_id).toBe("pi:pi-snake:e-snake");
+			expect(event?.event_id).toMatch(PI_EVENT_ID);
 			expect(event?.source).toBe("pi");
 		});
 	});
@@ -509,7 +510,7 @@ describe("buildRawEventEnvelopeFromPiEvent", () => {
 		expect(envelope?.session_id).toBe("pi-sess-env");
 		expect(envelope?.opencode_session_id).toBe("pi-sess-env");
 		expect(envelope?.started_at).toBe("2026-06-01T12:00:00Z");
-		expect(envelope?.event_id).toBe("pi:pi-sess-env:session_start");
+		expect(envelope?.event_id).toMatch(PI_EVENT_ID);
 		expect(envelope?.payload.type).toBe("pi.hook");
 		expect((envelope?.payload._adapter as Record<string, unknown>).source).toBe("pi");
 		expect((envelope?.payload._adapter as Record<string, unknown>).schema_version).toBe("1.0");
@@ -641,7 +642,7 @@ describe("pi source attribution via recordRawEvent", () => {
 		expect(piRows).toHaveLength(1);
 		expect(piRows[0]?.source).toBe("pi");
 		expect(piRows[0]?.stream_id).toBe("pi-attr-sess");
-		expect(piRows[0]?.event_id).toBe("pi:pi-attr-sess:entry-attr-1");
+		expect(piRows[0]?.event_id).toMatch(PI_EVENT_ID);
 		expect(piRows[0]?.event_type).toBe("pi.hook");
 
 		const opencodeRows = store.db
@@ -772,5 +773,52 @@ describe("ingestRawEvents accepts pi envelopes", () => {
 			.prepare(`SELECT COUNT(*) AS n FROM raw_events WHERE source = ?`)
 			.get("opencode") as { n: number };
 		expect(Number(opencodeCount.n)).toBe(0);
+	});
+
+	it.each([
+		{ sessionId: "session/with/slash", entryId: "entry+1" },
+		{ sessionId: "s".repeat(80), entryId: "e+".repeat(40) },
+	])("hashes unconstrained identity into an ingest-safe event_id", ({ sessionId, entryId }) => {
+		const envelope = requireEnvelope(
+			buildRawEventEnvelopeFromPiEvent({
+				piEvent: "message_end",
+				sessionId,
+				entryId,
+				role: "user",
+				text: "hello",
+				ts: "2026-06-01T16:00:00Z",
+			}),
+		);
+		expect(envelope.event_id).toMatch(/^[A-Za-z0-9._:-]+$/);
+		expect(envelope.event_id.length).toBeLessThanOrEqual(128);
+		const result = ingestRawEvents(store, envelope);
+		expect(result.inserted).toBe(1);
+		expect(result.skipped).toBe(0);
+	});
+
+	it("persists reload then exit as distinct session_end events", () => {
+		const sessionId = "pi-reload-exit";
+		const reload = requireEnvelope(
+			buildRawEventEnvelopeFromPiEvent({
+				piEvent: "session_shutdown",
+				sessionId,
+				entryId: "session_end",
+				reason: "reload",
+				ts: "2026-06-01T16:00:00Z",
+			}),
+		);
+		const exit = requireEnvelope(
+			buildRawEventEnvelopeFromPiEvent({
+				piEvent: "session_shutdown",
+				sessionId,
+				entryId: "session_end",
+				reason: "quit",
+				ts: "2026-06-01T16:01:00Z",
+			}),
+		);
+		expect(reload.event_id).not.toBe(exit.event_id);
+		expect(ingestRawEvents(store, reload)).toMatchObject({ inserted: 1, skipped: 0 });
+		expect(ingestRawEvents(store, exit)).toMatchObject({ inserted: 1, skipped: 0 });
+		expect(ingestRawEvents(store, exit)).toMatchObject({ inserted: 0, skipped: 1 });
 	});
 });

--- a/packages/core/src/pi-hooks.test.ts
+++ b/packages/core/src/pi-hooks.test.ts
@@ -21,6 +21,7 @@ import {
 	buildRawEventEnvelopeFromPiEvent,
 	MAPPABLE_PI_EVENTS,
 	mapPiEventPayload,
+	PI_EVENT_ID_ALGO,
 } from "./pi-hooks.js";
 import { ingestRawEvents } from "./raw-event-ingest.js";
 import { MemoryStore } from "./store.js";
@@ -84,6 +85,8 @@ describe("mapPiEventPayload", () => {
 			expect(event?.payload.reason).toBe("user_exit");
 			expect(event?.event_id).toMatch(PI_EVENT_ID);
 			expect(event?.source).toBe("pi");
+			expect(event?.meta.event_id_algo).toBe(PI_EVENT_ID_ALGO);
+			expect(PI_EVENT_ID_ALGO).toBe("pi/1");
 		});
 	});
 
@@ -820,5 +823,32 @@ describe("ingestRawEvents accepts pi envelopes", () => {
 		expect(ingestRawEvents(store, reload)).toMatchObject({ inserted: 1, skipped: 0 });
 		expect(ingestRawEvents(store, exit)).toMatchObject({ inserted: 1, skipped: 0 });
 		expect(ingestRawEvents(store, exit)).toMatchObject({ inserted: 0, skipped: 1 });
+	});
+
+	it("persists reload then reload as distinct session_end events", () => {
+		const sessionId = "pi-reload-reload";
+		const first = requireEnvelope(
+			buildRawEventEnvelopeFromPiEvent({
+				piEvent: "session_shutdown",
+				sessionId,
+				entryId: "session_end",
+				reason: "reload",
+				ts: "2026-06-01T16:00:00Z",
+			}),
+		);
+		const second = requireEnvelope(
+			buildRawEventEnvelopeFromPiEvent({
+				piEvent: "session_shutdown",
+				sessionId,
+				entryId: "session_end",
+				reason: "reload",
+				ts: "2026-06-01T16:01:00Z",
+			}),
+		);
+		expect(first.event_id).not.toBe(second.event_id);
+		expect(ingestRawEvents(store, first)).toMatchObject({ inserted: 1, skipped: 0 });
+		expect(ingestRawEvents(store, second)).toMatchObject({ inserted: 1, skipped: 0 });
+		expect(ingestRawEvents(store, first)).toMatchObject({ inserted: 0, skipped: 1 });
+		expect(ingestRawEvents(store, second)).toMatchObject({ inserted: 0, skipped: 1 });
 	});
 });

--- a/packages/core/src/pi-hooks.test.ts
+++ b/packages/core/src/pi-hooks.test.ts
@@ -13,7 +13,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { connect } from "./db.js";
 import {
 	buildIngestPayloadFromPiEvent,
@@ -852,5 +852,34 @@ describe("ingestRawEvents accepts pi envelopes", () => {
 		expect(ingestRawEvents(store, second)).toMatchObject({ inserted: 1, skipped: 0 });
 		expect(ingestRawEvents(store, first)).toMatchObject({ inserted: 0, skipped: 1 });
 		expect(ingestRawEvents(store, second)).toMatchObject({ inserted: 0, skipped: 1 });
+	});
+
+	it("distinguishes ts-less same-reason shutdowns by generated time", () => {
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date("2026-06-01T17:00:00Z"));
+			const first = requireEnvelope(
+				buildRawEventEnvelopeFromPiEvent({
+					piEvent: "session_shutdown",
+					sessionId: "pi-no-ts-reload",
+					entryId: "session_end",
+					reason: "reload",
+				}),
+			);
+			vi.setSystemTime(new Date("2026-06-01T17:00:01Z"));
+			const second = requireEnvelope(
+				buildRawEventEnvelopeFromPiEvent({
+					piEvent: "session_shutdown",
+					sessionId: "pi-no-ts-reload",
+					entryId: "session_end",
+					reason: "reload",
+				}),
+			);
+			expect(first.event_id).not.toBe(second.event_id);
+			expect(ingestRawEvents(store, first)).toMatchObject({ inserted: 1, skipped: 0 });
+			expect(ingestRawEvents(store, second)).toMatchObject({ inserted: 1, skipped: 0 });
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/packages/core/src/pi-hooks.ts
+++ b/packages/core/src/pi-hooks.ts
@@ -1,0 +1,450 @@
+/**
+ * Pi extension event payload mapping.
+ *
+ * Normalizes pi coding-agent extension events into AdapterEvent v1 envelopes
+ * for the shared raw-event sweeper pipeline. Mirrors claude-hooks.ts /
+ * codex-hooks.ts structure with source hard-coded to "pi".
+ *
+ * Entry points:
+ *   mapPiEventPayload(payload)              → adapter event or null
+ *   buildRawEventEnvelopeFromPiEvent(...)   → raw event envelope or null
+ *   buildIngestPayloadFromPiEvent(...)      → ingest payload or null
+ *   buildPiFlushSignalFromEvent(...)        → flush signal (compaction only)
+ *
+ * session_before_compact is observe-only: it never becomes a transcript event
+ * and never returns a compaction object for pi to apply.
+ */
+
+import { normalizeProjectLabel, resolveHookProject } from "./claude-hooks.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Pi extension events that map to AdapterEvent v1 transcript types. */
+export const MAPPABLE_PI_EVENTS = new Set([
+	"session_start",
+	"session_shutdown",
+	"message_end",
+	"turn_end",
+	"tool_call",
+	"tool_result",
+]);
+
+/** Events that only signal a boundary flush (never stored as transcript). */
+export const PI_FLUSH_ONLY_EVENTS = new Set(["session_before_compact"]);
+
+// ---------------------------------------------------------------------------
+// Timestamp helpers
+// ---------------------------------------------------------------------------
+
+function nowIso(): string {
+	return new Date().toISOString().replace(/\.(\d{3})\d*Z$/, ".$1Z");
+}
+
+function normalizeIsoTs(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const text = value.trim();
+	if (!text) return null;
+	const hasTimezone =
+		/[Zz]$/.test(text) || /[+-]\d{2}:\d{2}$/.test(text) || /[+-]\d{4}$/.test(text);
+	const parsed = new Date(hasTimezone ? text : `${text}Z`);
+	if (Number.isNaN(parsed.getTime())) return null;
+	const hasFractional = /\.\d+([Zz+-]|$)/.test(text);
+	return hasFractional
+		? parsed.toISOString().replace(/\.(\d{3})Z$/, ".$1000Z")
+		: parsed.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function isoToWallMs(value: string): number {
+	return new Date(value).getTime();
+}
+
+// ---------------------------------------------------------------------------
+// Coercion helpers
+// ---------------------------------------------------------------------------
+
+function coerceString(value: unknown): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+/** Read the first defined field among camelCase / snake_case aliases. */
+function field(payload: Record<string, unknown>, ...keys: string[]): unknown {
+	for (const key of keys) {
+		if (Object.hasOwn(payload, key) && payload[key] !== undefined) return payload[key];
+	}
+	return undefined;
+}
+
+function coerceSessionId(payload: Record<string, unknown>): string | null {
+	const value = coerceString(field(payload, "sessionId", "session_id"));
+	return value || null;
+}
+
+function coercePiEventName(payload: Record<string, unknown>): string {
+	return coerceString(field(payload, "piEvent", "pi_event", "event", "type"));
+}
+
+function objectOrEmpty(value: unknown): Record<string, unknown> {
+	return value != null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+function coerceBool(value: unknown): boolean {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "number") return value !== 0;
+	if (typeof value === "string") {
+		const t = value.trim().toLowerCase();
+		return t === "true" || t === "1" || t === "yes";
+	}
+	return false;
+}
+
+/**
+ * Deterministic event id: `pi:<sessionId>:<entryId|toolCallId|stable-suffix>`.
+ * Same logical event must yield the same id across HTTP/CLI retries.
+ */
+function buildPiEventId(sessionId: string, stablePart: string): string {
+	const part = stablePart.trim();
+	if (!part) throw new Error("pi event id stable part is required");
+	return `pi:${sessionId}:${part}`;
+}
+
+// ---------------------------------------------------------------------------
+// mapPiEventPayload
+// ---------------------------------------------------------------------------
+
+export interface PiHookAdapterEvent {
+	schema_version: "1.0";
+	source: "pi";
+	session_id: string;
+	event_id: string;
+	event_type: string;
+	ts: string;
+	ordering_confidence: "low";
+	cwd: string | null;
+	payload: Record<string, unknown>;
+	meta: Record<string, unknown>;
+}
+
+/**
+ * Map a pi extension event payload to a normalized AdapterEvent v1.
+ * Returns null if the event type is unsupported, flush-only, or required
+ * fields are missing.
+ */
+export function mapPiEventPayload(payload: Record<string, unknown>): PiHookAdapterEvent | null {
+	const piEvent = coercePiEventName(payload);
+	if (!piEvent) return null;
+
+	// Compaction is observe-only — never a transcript AdapterEvent.
+	if (PI_FLUSH_ONLY_EVENTS.has(piEvent)) return null;
+	if (!MAPPABLE_PI_EVENTS.has(piEvent)) return null;
+
+	const sessionId = coerceSessionId(payload);
+	if (!sessionId) return null;
+
+	const normalizedRawTs = normalizeIsoTs(field(payload, "ts", "timestamp"));
+	const ts = normalizedRawTs ?? nowIso();
+
+	const entryId = coerceString(field(payload, "entryId", "entry_id"));
+	const toolCallId = coerceString(field(payload, "toolCallId", "tool_call_id"));
+	const cwdRaw = field(payload, "cwd");
+	const cwd = typeof cwdRaw === "string" ? cwdRaw : null;
+
+	const consumed = new Set([
+		"piEvent",
+		"pi_event",
+		"event",
+		"type",
+		"sessionId",
+		"session_id",
+		"entryId",
+		"entry_id",
+		"toolCallId",
+		"tool_call_id",
+		"cwd",
+		"ts",
+		"timestamp",
+		"project",
+	]);
+
+	let eventType: string;
+	let eventPayload: Record<string, unknown>;
+	let idPart: string | null = null;
+
+	if (piEvent === "session_start") {
+		eventType = "session_start";
+		eventPayload = {};
+		idPart = entryId || "session_start";
+	} else if (piEvent === "session_shutdown") {
+		const reason = field(payload, "reason");
+		eventType = "session_end";
+		eventPayload = { reason: reason ?? null };
+		idPart = entryId || "session_end";
+		consumed.add("reason");
+	} else if (piEvent === "message_end") {
+		const role = coerceString(field(payload, "role")).toLowerCase();
+		const text = coerceString(field(payload, "text", "content", "prompt"));
+		if (!text) return null;
+		if (!entryId) return null;
+		if (role === "user") {
+			eventType = "prompt";
+			eventPayload = { text };
+		} else if (role === "assistant") {
+			eventType = "assistant";
+			eventPayload = { text };
+		} else {
+			return null;
+		}
+		idPart = entryId;
+		consumed.add("role");
+		consumed.add("text");
+		consumed.add("content");
+		consumed.add("prompt");
+	} else if (piEvent === "turn_end") {
+		// Design D2: turn_end → assistant. Extension emits message_end for completed
+		// assistant turns; agent_end is intentionally not in the mappable set.
+		const text = coerceString(field(payload, "text", "content"));
+		if (!text) return null;
+		if (!entryId && !toolCallId) return null;
+		eventType = "assistant";
+		eventPayload = { text };
+		idPart = entryId || toolCallId;
+		consumed.add("role");
+		consumed.add("text");
+		consumed.add("content");
+	} else if (piEvent === "tool_call") {
+		const toolName = coerceString(field(payload, "toolName", "tool_name", "name"));
+		if (!toolName) return null;
+		if (!toolCallId && !entryId) return null;
+		const toolInput = objectOrEmpty(field(payload, "toolInput", "tool_input", "args", "input"));
+		eventType = "tool_call";
+		eventPayload = { tool_name: toolName, tool_input: toolInput };
+		idPart = toolCallId || entryId;
+		consumed.add("toolName");
+		consumed.add("tool_name");
+		consumed.add("name");
+		consumed.add("toolInput");
+		consumed.add("tool_input");
+		consumed.add("args");
+		consumed.add("input");
+	} else if (piEvent === "tool_result") {
+		const toolName = coerceString(field(payload, "toolName", "tool_name", "name"));
+		if (!toolName) return null;
+		if (!toolCallId && !entryId) return null;
+		const toolInput = objectOrEmpty(field(payload, "toolInput", "tool_input", "args", "input"));
+		const isError = coerceBool(field(payload, "isError", "is_error"));
+		const toolOutput = field(payload, "toolOutput", "tool_output", "output", "result") ?? null;
+		const error = field(payload, "error", "tool_error") ?? null;
+		eventType = "tool_result";
+		if (isError) {
+			eventPayload = {
+				tool_name: toolName,
+				status: "error",
+				tool_input: toolInput,
+				tool_output: null,
+				tool_error: error ?? true,
+				error: error ?? true,
+			};
+		} else {
+			eventPayload = {
+				tool_name: toolName,
+				status: "ok",
+				tool_input: toolInput,
+				tool_output: toolOutput,
+				tool_error: null,
+			};
+		}
+		// tool_result ids prefer toolCallId so call/result pair on the same id root.
+		idPart = toolCallId ? `${toolCallId}:result` : `${entryId}:result`;
+		consumed.add("toolName");
+		consumed.add("tool_name");
+		consumed.add("name");
+		consumed.add("toolInput");
+		consumed.add("tool_input");
+		consumed.add("args");
+		consumed.add("input");
+		consumed.add("toolOutput");
+		consumed.add("tool_output");
+		consumed.add("output");
+		consumed.add("result");
+		consumed.add("isError");
+		consumed.add("is_error");
+		consumed.add("error");
+		consumed.add("tool_error");
+	} else {
+		return null;
+	}
+
+	if (!idPart) return null;
+
+	const meta: Record<string, unknown> = {
+		pi_event: piEvent,
+		ordering_confidence: "low",
+	};
+	if (entryId) meta.entry_id = entryId;
+	if (toolCallId) meta.tool_call_id = toolCallId;
+	if (normalizedRawTs === null) meta.ts_normalized = "generated";
+
+	const unknown: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(payload)) {
+		if (!consumed.has(key)) unknown[key] = value;
+	}
+	if (Object.keys(unknown).length > 0) meta.pi_fields = unknown;
+
+	return {
+		schema_version: "1.0",
+		source: "pi",
+		session_id: sessionId,
+		event_id: buildPiEventId(sessionId, idPart),
+		event_type: eventType,
+		ts,
+		ordering_confidence: "low",
+		cwd,
+		payload: eventPayload,
+		meta,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Flush signal (session_before_compact — observe only)
+// ---------------------------------------------------------------------------
+
+export interface PiFlushSignal {
+	kind: "flush";
+	reason: "session_before_compact";
+	source: "pi";
+	session_id: string;
+	ts: string;
+	cwd: string | null;
+	project: string | null;
+}
+
+/**
+ * Build a flush signal for pi compaction boundaries.
+ * Returns null unless the payload is a session_before_compact event with a
+ * session id. Never produces a compaction object for pi to apply.
+ */
+export function buildPiFlushSignalFromEvent(
+	payload: Record<string, unknown>,
+): PiFlushSignal | null {
+	const piEvent = coercePiEventName(payload);
+	if (!PI_FLUSH_ONLY_EVENTS.has(piEvent)) return null;
+
+	const sessionId = coerceSessionId(payload);
+	if (!sessionId) return null;
+
+	const normalizedRawTs = normalizeIsoTs(field(payload, "ts", "timestamp"));
+	const ts = normalizedRawTs ?? nowIso();
+	const cwdRaw = field(payload, "cwd");
+	const cwd = typeof cwdRaw === "string" ? cwdRaw : null;
+	const project =
+		resolveHookProject(cwd, field(payload, "project")) ??
+		normalizeProjectLabel(field(payload, "project"));
+
+	return {
+		kind: "flush",
+		reason: "session_before_compact",
+		source: "pi",
+		session_id: sessionId,
+		ts,
+		cwd,
+		project,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// buildRawEventEnvelopeFromPiEvent
+// ---------------------------------------------------------------------------
+
+export interface PiHookRawEventEnvelope {
+	session_stream_id: string;
+	session_id: string;
+	opencode_session_id: string;
+	source: "pi";
+	event_id: string;
+	event_type: "pi.hook";
+	payload: Record<string, unknown>;
+	ts_wall_ms: number;
+	cwd: string | null;
+	project: string | null;
+	started_at: string | null;
+}
+
+/**
+ * Build a raw event envelope from a pi extension event payload.
+ * Returns null if the payload is unsupported, flush-only, or missing fields.
+ * Source is always the literal "pi" — never falls through to a default.
+ */
+export function buildRawEventEnvelopeFromPiEvent(
+	piPayload: Record<string, unknown>,
+): PiHookRawEventEnvelope | null {
+	const adapterEvent = mapPiEventPayload(piPayload);
+	if (adapterEvent === null) return null;
+
+	const sessionId = adapterEvent.session_id.trim();
+	if (!sessionId) return null;
+	const ts = adapterEvent.ts.trim();
+	if (!ts) return null;
+
+	const cwdRaw = field(piPayload, "cwd");
+	const cwd = typeof cwdRaw === "string" ? cwdRaw : null;
+	const project =
+		resolveHookProject(cwd, field(piPayload, "project")) ??
+		normalizeProjectLabel(field(piPayload, "project"));
+	const piEvent = coercePiEventName(piPayload);
+
+	return {
+		session_stream_id: sessionId,
+		session_id: sessionId,
+		opencode_session_id: sessionId,
+		source: "pi",
+		event_id: adapterEvent.event_id,
+		event_type: "pi.hook",
+		payload: {
+			type: "pi.hook",
+			timestamp: ts,
+			_adapter: adapterEvent,
+		},
+		ts_wall_ms: isoToWallMs(ts),
+		cwd,
+		project,
+		started_at: piEvent === "session_start" ? ts : null,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// buildIngestPayloadFromPiEvent
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an ingest pipeline payload from a pi extension event.
+ * Used by the direct-ingest path. Source is always the literal "pi".
+ * Returns null if the payload is unsupported or flush-only.
+ */
+export function buildIngestPayloadFromPiEvent(
+	piPayload: Record<string, unknown>,
+): Record<string, unknown> | null {
+	const adapterEvent = mapPiEventPayload(piPayload);
+	if (adapterEvent === null) return null;
+
+	const sessionId = adapterEvent.session_id;
+	return {
+		cwd: field(piPayload, "cwd") ?? null,
+		events: [
+			{
+				type: "pi.hook",
+				timestamp: adapterEvent.ts,
+				_adapter: adapterEvent,
+			},
+		],
+		session_context: {
+			source: "pi",
+			stream_id: sessionId,
+			session_stream_id: sessionId,
+			session_id: sessionId,
+			opencode_session_id: sessionId,
+		},
+	};
+}

--- a/packages/core/src/pi-hooks.ts
+++ b/packages/core/src/pi-hooks.ts
@@ -15,6 +15,7 @@
  * and never returns a compaction object for pi to apply.
  */
 
+import { createHash } from "node:crypto";
 import { normalizeProjectLabel, resolveHookProject } from "./claude-hooks.js";
 
 // ---------------------------------------------------------------------------
@@ -102,13 +103,12 @@ function coerceBool(value: unknown): boolean {
 }
 
 /**
- * Deterministic event id: `pi:<sessionId>:<entryId|toolCallId|stable-suffix>`.
+ * Deterministic event id: `pi_evt_` + sha256(identity).hex.slice(0, 24).
  * Same logical event must yield the same id across HTTP/CLI retries.
  */
-function buildPiEventId(sessionId: string, stablePart: string): string {
-	const part = stablePart.trim();
-	if (!part) throw new Error("pi event id stable part is required");
-	return `pi:${sessionId}:${part}`;
+function buildPiEventId(...parts: string[]): string {
+	const digest = createHash("sha256").update(parts.join("|"), "utf-8").digest("hex").slice(0, 24);
+	return `pi_evt_${digest}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -181,7 +181,7 @@ export function mapPiEventPayload(payload: Record<string, unknown>): PiHookAdapt
 		const reason = field(payload, "reason");
 		eventType = "session_end";
 		eventPayload = { reason: reason ?? null };
-		idPart = entryId || "session_end";
+		idPart = entryId && entryId !== "session_end" ? entryId : `session_end:${coerceString(reason)}`;
 		consumed.add("reason");
 	} else if (piEvent === "message_end") {
 		const role = coerceString(field(payload, "role")).toLowerCase();
@@ -297,7 +297,7 @@ export function mapPiEventPayload(payload: Record<string, unknown>): PiHookAdapt
 		schema_version: "1.0",
 		source: "pi",
 		session_id: sessionId,
-		event_id: buildPiEventId(sessionId, idPart),
+		event_id: buildPiEventId(sessionId, piEvent, idPart),
 		event_type: eventType,
 		ts,
 		ordering_confidence: "low",

--- a/packages/core/src/pi-hooks.ts
+++ b/packages/core/src/pi-hooks.ts
@@ -35,6 +35,8 @@ export const MAPPABLE_PI_EVENTS = new Set([
 /** Events that only signal a boundary flush (never stored as transcript). */
 export const PI_FLUSH_ONLY_EVENTS = new Set(["session_before_compact"]);
 
+/** Frozen discriminator for Pi's derived event identity contract. */
+export const PI_EVENT_ID_ALGO = "pi/1";
 // ---------------------------------------------------------------------------
 // Timestamp helpers
 // ---------------------------------------------------------------------------
@@ -181,7 +183,10 @@ export function mapPiEventPayload(payload: Record<string, unknown>): PiHookAdapt
 		const reason = field(payload, "reason");
 		eventType = "session_end";
 		eventPayload = { reason: reason ?? null };
-		idPart = entryId && entryId !== "session_end" ? entryId : `session_end:${coerceString(reason)}`;
+		idPart =
+			entryId && entryId !== "session_end"
+				? entryId
+				: `session_end:${coerceString(reason)}:${normalizedRawTs ?? ""}`;
 		consumed.add("reason");
 	} else if (piEvent === "message_end") {
 		const role = coerceString(field(payload, "role")).toLowerCase();
@@ -280,6 +285,7 @@ export function mapPiEventPayload(payload: Record<string, unknown>): PiHookAdapt
 	if (!idPart) return null;
 
 	const meta: Record<string, unknown> = {
+		event_id_algo: PI_EVENT_ID_ALGO,
 		pi_event: piEvent,
 		ordering_confidence: "low",
 	};

--- a/packages/core/src/pi-hooks.ts
+++ b/packages/core/src/pi-hooks.ts
@@ -183,10 +183,10 @@ export function mapPiEventPayload(payload: Record<string, unknown>): PiHookAdapt
 		const reason = field(payload, "reason");
 		eventType = "session_end";
 		eventPayload = { reason: reason ?? null };
+		// Payload ts keeps retries stable; a generated ts falls back so ts-less
+		// same-reason shutdowns stay distinct (mirrors claude-hooks eventIdTsSeed).
 		idPart =
-			entryId && entryId !== "session_end"
-				? entryId
-				: `session_end:${coerceString(reason)}:${normalizedRawTs ?? ""}`;
+			entryId && entryId !== "session_end" ? entryId : `session_end:${coerceString(reason)}:${ts}`;
 		consumed.add("reason");
 	} else if (piEvent === "message_end") {
 		const role = coerceString(field(payload, "role")).toLowerCase();


### PR DESCRIPTION
Second PR in the pi integration stack — context and overall design in #1430. Builds on #1473 (merged); the diff here is the pi adapter only.

## Why

Pi events need a core adapter that produces the same envelope shape `ingestRawEvents` already accepts, with `source: "pi"` explicit and deterministic ids so HTTP/CLI retries do not duplicate rows.

## What

- `packages/core/src/pi-hooks.ts`: map session/prompt/tool events; compaction is flush-only
- Envelope fields include `session_stream_id` / `session_id` aliases required by 0.41 ingest
- Test: `ingestRawEvents` persists source `pi` and creates zero opencode rows

## Test plan

- `vitest run packages/core/src/pi-hooks.test.ts` — 40/40 passed
- Gates `lint`, `tsc`, `build` green locally; `test` passes except local-sandbox env failures unrelated to this change (sqlite-vec native ext unavailable in this dev sandbox)

@kunickiaj layer 2 of the stack is ready for review whenever you have a moment. Layers 3–8 will follow one at a time as each predecessor merges, same as this one.

Related: #1430, #1429, #1473
