### PR TITLE
refactor(core): centralize legacy Team migration policy

### DIFF
--- a/packages/core/src/legacy-team-attempt-lifecycle.test.ts
+++ b/packages/core/src/legacy-team-attempt-lifecycle.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { planLegacyTeamAttempt } from "./legacy-team-attempt-lifecycle.js";
+
+describe("planLegacyTeamAttempt", () => {
+	it.each([
+		[{ state: null, evidenceMatches: false, completionReady: false }, "create"],
+		[{ state: null, evidenceMatches: true, completionReady: true }, "create"],
+		[{ state: "needs_setup", evidenceMatches: true, completionReady: false }, "reuse"],
+		[{ state: "needs_setup", evidenceMatches: false, completionReady: false }, "replace"],
+		[{ state: "needs_setup", evidenceMatches: true, completionReady: true }, "reuse"],
+		[{ state: "needs_setup", evidenceMatches: false, completionReady: true }, "replace"],
+		[{ state: "in_progress", evidenceMatches: true, completionReady: false }, "reuse"],
+		[{ state: "in_progress", evidenceMatches: false, completionReady: false }, "replace"],
+		[{ state: "in_progress", evidenceMatches: true, completionReady: true }, "reuse"],
+		[{ state: "in_progress", evidenceMatches: false, completionReady: true }, "replace"],
+		[{ state: "stale", evidenceMatches: true, completionReady: false }, "replace"],
+		[{ state: "stale", evidenceMatches: false, completionReady: false }, "replace"],
+		[{ state: "stale", evidenceMatches: true, completionReady: true }, "replace"],
+		[{ state: "stale", evidenceMatches: false, completionReady: true }, "replace"],
+		[{ state: "completed", evidenceMatches: true, completionReady: true }, "preserve_completion"],
+		[{ state: "completed", evidenceMatches: false, completionReady: true }, "preserve_completion"],
+		[{ state: "completed", evidenceMatches: true, completionReady: false }, "replace"],
+		[{ state: "completed", evidenceMatches: false, completionReady: false }, "replace"],
+	] as const)("plans %s as %s", (input, expected) => {
+		expect(planLegacyTeamAttempt(input).kind).toBe(expected);
+	});
+});

--- a/packages/core/src/legacy-team-attempt-lifecycle.ts
+++ b/packages/core/src/legacy-team-attempt-lifecycle.ts
@@ -1,0 +1,28 @@
+export type LegacyTeamAttemptState = "needs_setup" | "in_progress" | "stale" | "completed";
+
+export type LegacyTeamAttemptPlan =
+	| { kind: "create" }
+	| { kind: "replace" }
+	| { kind: "reuse" }
+	| { kind: "preserve_completion" };
+
+export function planLegacyTeamAttempt(input: {
+	state: LegacyTeamAttemptState | null;
+	evidenceMatches: boolean;
+	completionReady: boolean;
+}): LegacyTeamAttemptPlan {
+	if (input.state == null) return { kind: "create" };
+	switch (input.state) {
+		case "completed":
+			return input.completionReady ? { kind: "preserve_completion" } : { kind: "replace" };
+		case "stale":
+			return { kind: "replace" };
+		case "needs_setup":
+		case "in_progress":
+			return input.evidenceMatches ? { kind: "reuse" } : { kind: "replace" };
+		default: {
+			const exhaustive: never = input.state;
+			throw new Error(`unknown legacy Team attempt state: ${exhaustive}`);
+		}
+	}
+}

--- a/packages/core/src/legacy-team-candidate.test.ts
+++ b/packages/core/src/legacy-team-candidate.test.ts
@@ -470,19 +470,17 @@ describe("legacy Team candidate discovery", () => {
 		);
 	});
 
-	it("marks changed roster evidence stale until explicit refresh", () => {
+	it("replaces changed roster evidence during discovery", () => {
 		const [first] = discoverLegacyTeamCandidates(db, options());
 		const firstAttempt = latestLegacyTeamSetupAttempt(db, first?.candidateRef as string);
 		expect(firstAttempt).not.toBeNull();
 		if (!firstAttempt) throw new Error("initial refresh attempt missing");
-		const [stale] = discoverLegacyTeamCandidates(db, options("key-b"));
+		const [refreshedCandidate] = discoverLegacyTeamCandidates(db, options("key-b"));
 
-		expect(stale?.status).toBe("stale");
-		const refreshed = refreshLegacyTeamCandidate(
-			db,
-			options("key-b"),
-			first?.candidateRef as string,
-		);
+		expect(refreshedCandidate?.status).toBe("needs_setup");
+		const refreshed = getLegacyTeamSetupDraft(db, first?.candidateRef as string);
+		expect(refreshed).not.toBeNull();
+		if (!refreshed) throw new Error("replacement attempt missing");
 		expect(refreshed.state).toBe("needs_setup");
 		expect(latestLegacyTeamSetupAttempt(db, first?.candidateRef as string)?.attemptId).toBe(
 			refreshed.attemptId,
@@ -496,10 +494,29 @@ describe("legacy Team candidate discovery", () => {
 		).toBe(firstAttempt.attemptId);
 	});
 
+	it("replaces an activation-staled attempt during discovery", () => {
+		const [candidate] = discoverLegacyTeamCandidates(db, options());
+		const firstAttempt = latestLegacyTeamSetupAttempt(db, candidate?.candidateRef as string);
+		if (!firstAttempt) throw new Error("initial attempt missing");
+		db.prepare("UPDATE legacy_team_setup_drafts SET state = 'stale' WHERE attempt_id = ?").run(
+			firstAttempt.attemptId,
+		);
+
+		const [rediscovered] = discoverLegacyTeamCandidates(db, options());
+		const replacement = latestLegacyTeamSetupAttempt(db, candidate?.candidateRef as string);
+		const historical = db
+			.prepare("SELECT state, superseded_at FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+			.get(firstAttempt.attemptId);
+
+		expect(rediscovered?.status).toBe("needs_setup");
+		expect(replacement?.attemptId).not.toBe(firstAttempt.attemptId);
+		expect(historical).toEqual({ state: "stale", superseded_at: NOW });
+	});
+
 	it.each([
-		["newly stale", false],
-		["already stale", true],
-	] as const)("re-sanitizes persisted labels for a %s attempt", (_label, staleFirst) => {
+		["first replacement", false],
+		["subsequent replacement", true],
+	] as const)("sanitizes labels for a %s", (_label, replaceFirst) => {
 		const initialOptions = options("key-a", "api");
 		const initialGroup = initialOptions.groups[0];
 		if (!initialGroup) throw new Error("invalid test fixture");
@@ -513,15 +530,15 @@ describe("legacy Team candidate discovery", () => {
 			projects: [{ displayName: "api" }],
 		});
 
-		if (staleFirst) {
-			const staleOptions = options("key-b", "api");
-			const staleGroup = staleOptions.groups[0];
-			if (!staleGroup) throw new Error("invalid test fixture");
-			staleGroup.displayName = "api";
-			expect(discoverLegacyTeamCandidates(db, staleOptions)[0]?.status).toBe("stale");
+		if (replaceFirst) {
+			const replacementOptions = options("key-b", "api");
+			const replacementGroup = replacementOptions.groups[0];
+			if (!replacementGroup) throw new Error("invalid test fixture");
+			replacementGroup.displayName = "api";
+			expect(discoverLegacyTeamCandidates(db, replacementOptions)[0]?.status).toBe("needs_setup");
 		}
 
-		const changedOptions = options(staleFirst ? "key-b" : "key-a", "api");
+		const changedOptions = options(replaceFirst ? "key-b" : "key-a", "api");
 		const changedGroup = changedOptions.groups[0];
 		if (!changedGroup) throw new Error("invalid test fixture");
 		changedGroup.displayName = "api";
@@ -532,35 +549,36 @@ describe("legacy Team candidate discovery", () => {
 		db.prepare("DELETE FROM sessions").run();
 		db.prepare("DELETE FROM project_scope_mappings").run();
 
-		const [stale] = discoverLegacyTeamCandidates(db, changedOptions);
-		const staleDraft = getLegacyTeamSetupDraft(db, initial?.candidateRef as string);
+		const [replacement] = discoverLegacyTeamCandidates(db, changedOptions);
+		const replacementDraft = getLegacyTeamSetupDraft(db, initial?.candidateRef as string);
 
-		expect(stale).toMatchObject({ displayName: "Legacy Team", status: "stale" });
-		expect(staleDraft).toMatchObject({
-			attemptId,
-			state: "stale",
+		expect(replacement).toMatchObject({ displayName: "Legacy Team", status: "needs_setup" });
+		expect(replacementDraft).toMatchObject({
+			state: "needs_setup",
 			displayName: "Legacy Team",
-			devices: [{ displayName: "Device" }],
-			projects: [{ displayName: "Project" }],
+			projects: [],
 		});
-		expect(latestLegacyTeamSetupAttempt(db, stale?.candidateRef as string)?.attemptId).toBe(
-			attemptId,
-		);
+		expect(replacementDraft?.devices.map((device) => device.displayName)).toEqual([
+			"New Device",
+			"Removed device",
+		]);
+		expect(replacementDraft?.attemptId).not.toBe(attemptId);
 	});
 
-	it("keeps a stale attempt blocked if roster evidence reverts", () => {
+	it("creates a fresh attempt if roster evidence reverts", () => {
 		const [first] = discoverLegacyTeamCandidates(db, options());
 		const firstAttempt = latestLegacyTeamSetupAttempt(db, first?.candidateRef as string);
 		expect(firstAttempt).not.toBeNull();
 		if (!firstAttempt) throw new Error("initial stale-reversion attempt missing");
 		discoverLegacyTeamCandidates(db, options("key-b"));
+		const changedAttempt = latestLegacyTeamSetupAttempt(db, first?.candidateRef as string);
 
 		const [reverted] = discoverLegacyTeamCandidates(db, options("key-a"));
 
-		expect(reverted?.status).toBe("stale");
-		expect(latestLegacyTeamSetupAttempt(db, reverted?.candidateRef as string)?.attemptId).toBe(
-			firstAttempt.attemptId,
-		);
+		expect(reverted?.status).toBe("needs_setup");
+		const revertedAttempt = latestLegacyTeamSetupAttempt(db, reverted?.candidateRef as string);
+		expect(revertedAttempt?.attemptId).not.toBe(firstAttempt.attemptId);
+		expect(revertedAttempt?.attemptId).not.toBe(changedAttempt?.attemptId);
 	});
 
 	it("derives ready only from a current completed draft and compatible canonical Team", () => {

--- a/packages/core/src/legacy-team-candidate.ts
+++ b/packages/core/src/legacy-team-candidate.ts
@@ -4,7 +4,10 @@ import {
 	listLegacyTeamProjectEvidence,
 	selectedProjectScopeMappings,
 } from "./legacy-recipient-policy-projection.js";
+import { planLegacyTeamAttempt } from "./legacy-team-attempt-lifecycle.js";
+import { isMigratableLegacyTeamProjectIdentity } from "./legacy-team-project-policy.js";
 import {
+	type LegacyTeamSetupDraftState,
 	type LegacyTeamSetupDraftView,
 	type LegacyTeamSetupProjectInput,
 	legacyTeamProjectionFingerprint,
@@ -67,7 +70,7 @@ interface DraftFreshnessRow {
 	attempt_id: string;
 	coordinator_id: string;
 	group_id: string;
-	state: "needs_setup" | "in_progress" | "stale" | "completed";
+	state: LegacyTeamSetupDraftState;
 	roster_fingerprint: string;
 	projection_fingerprint: string;
 	completed_team_id: string | null;
@@ -223,7 +226,7 @@ function projectInventory(
 	return evidence
 		.filter(
 			(project) =>
-				project.project.canonicalIdentity !== "shared:default" &&
+				isMigratableLegacyTeamProjectIdentity(project.project.canonicalIdentity) &&
 				project.teamCandidateIds.includes(candidateId),
 		)
 		.map((project) => {
@@ -679,59 +682,31 @@ function resolveDiscoveredCandidate(
 			projects,
 		);
 		const displayName = candidateDisplayName(db, candidateId, group.displayName);
-		let draft: LegacyTeamSetupDraftView;
 		const expectedProjectionFingerprint = legacyTeamProjectionFingerprint(projects);
-		if (!row || (row.state === "completed" && !ready)) {
-			draft = refreshLegacyTeamSetupDraft(db, {
-				candidateId,
-				coordinatorId,
-				groupId,
-				displayName,
-				devices: rosterDevices,
-				projects,
-				now,
-			});
-		} else if (row.state === "completed") {
-			draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
-				displayName,
-				devices: rosterDevices,
-				projects,
-				now,
-			});
-		} else if (row.state === "stale") {
-			draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
-				displayName,
-				devices: rosterDevices,
-				projects,
-				now,
-			});
-		} else if (
-			row.roster_fingerprint !== rosterFingerprint ||
-			row.projection_fingerprint !== expectedProjectionFingerprint
-		) {
-			if (row.state === "needs_setup" || row.state === "in_progress") {
-				db.prepare(
-					`UPDATE legacy_team_setup_drafts SET state = 'stale', updated_at = ?
-					 WHERE attempt_id = ?`,
-				).run(now, row.attempt_id);
-			}
-			draft = refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
-				displayName,
-				devices: rosterDevices,
-				projects,
-				now,
-			});
-		} else {
-			draft = refreshLegacyTeamSetupDraft(db, {
-				candidateId,
-				coordinatorId,
-				groupId,
-				displayName,
-				devices: rosterDevices,
-				projects,
-				now,
-			});
-		}
+		const plan = planLegacyTeamAttempt({
+			state: row?.state ?? null,
+			evidenceMatches:
+				row?.roster_fingerprint === rosterFingerprint &&
+				row.projection_fingerprint === expectedProjectionFingerprint,
+			completionReady: ready,
+		});
+		const draft =
+			plan.kind === "preserve_completion" && row
+				? refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
+						displayName,
+						devices: rosterDevices,
+						projects,
+						now,
+					})
+				: refreshLegacyTeamSetupDraft(db, {
+						candidateId,
+						coordinatorId,
+						groupId,
+						displayName,
+						devices: rosterDevices,
+						projects,
+						now,
+					});
 		return { draft, ready, projectCount: projects.length };
 	});
 	return discover.immediate();

--- a/packages/core/src/legacy-team-project-canonical-preflight.test.ts
+++ b/packages/core/src/legacy-team-project-canonical-preflight.test.ts
@@ -49,6 +49,19 @@ describe("legacy Team Project canonical preflight", () => {
 			expected: false,
 		},
 		{
+			name: "rejects a synthetic workspace identity defensively",
+			overrides: {
+				projects: [
+					{
+						sourceProjectIdentity: SOURCE,
+						resolvedProjectIdentity: "personal:actor-a",
+						targetScopeId: "scope-active",
+					},
+				],
+			},
+			expected: false,
+		},
+		{
 			name: "accepts multiple active scopes when Project evidence selects one",
 			overrides: {
 				scopeIds: ["scope-active", "scope-active-2"],

--- a/packages/core/src/legacy-team-project-canonical-preflight.ts
+++ b/packages/core/src/legacy-team-project-canonical-preflight.ts
@@ -1,3 +1,5 @@
+import { isMigratableLegacyTeamProjectIdentity } from "./legacy-team-project-policy.js";
+
 export interface LegacyTeamProjectCanonicalPreflightInput {
 	teamId: string;
 	scopeIds: readonly string[];
@@ -40,6 +42,7 @@ export function isLegacyTeamProjectCanonicalStateValid(
 	for (const project of input.projects) {
 		const resolvedIdentity = project.resolvedProjectIdentity;
 		if (!resolvedIdentity || resolvedIdentity.startsWith("unmapped:")) return false;
+		if (!isMigratableLegacyTeamProjectIdentity(resolvedIdentity)) return false;
 		if (!project.targetScopeId || !input.scopeIds.includes(project.targetScopeId)) return false;
 
 		const relatedMappings = input.mappings.filter(

--- a/packages/core/src/legacy-team-project-policy.test.ts
+++ b/packages/core/src/legacy-team-project-policy.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isMigratableLegacyTeamProjectIdentity } from "./legacy-team-project-policy.js";
+
+describe("isMigratableLegacyTeamProjectIdentity", () => {
+	it.each([
+		"shared",
+		"shared:default",
+		"shared:legacy",
+		"personal:actor-1",
+	])("rejects synthetic workspace identity %s", (identity) => {
+		expect(isMigratableLegacyTeamProjectIdentity(identity)).toBe(false);
+	});
+
+	it.each([
+		"shared:team",
+		"shared:workspace-only",
+		"https://example.invalid/project.git",
+	])("accepts canonical Project identity %s", (identity) => {
+		expect(isMigratableLegacyTeamProjectIdentity(identity)).toBe(true);
+	});
+});

--- a/packages/core/src/legacy-team-project-policy.ts
+++ b/packages/core/src/legacy-team-project-policy.ts
@@ -1,0 +1,9 @@
+export function isMigratableLegacyTeamProjectIdentity(identity: string): boolean {
+	const normalized = identity.trim();
+	return (
+		normalized !== "shared" &&
+		normalized !== "shared:default" &&
+		normalized !== "shared:legacy" &&
+		!normalized.startsWith("personal:")
+	);
+}

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -823,6 +823,10 @@ describe("legacy Team setup drafts", () => {
 		const projectRef = draft.projects.find((p) => p.resolution === "unresolved")?.projectRef;
 		if (!projectRef) throw new Error("invalid test fixture");
 		for (const target of [
+			"shared",
+			"shared:default",
+			"shared:legacy",
+			"personal:actor-local",
 			"C:\\repos\\acme",
 			"https://git.example.invalid/acme/web.git/",
 			"https://git.example.invalid/acme/web\u200b.git",
@@ -855,6 +859,34 @@ describe("legacy Team setup drafts", () => {
 				}),
 			).toThrow("legacy_team_setup_project_mapping_invalid");
 		}
+	});
+
+	it.each([
+		"shared:team",
+		"shared:workspace-only",
+	])("accepts named shared Project resolution target %s", (target) => {
+		const draft = refreshLegacyTeamSetupDraft(db, snapshot());
+		const projectRef = draft.projects.find(
+			(project) => project.resolution === "unresolved",
+		)?.projectRef;
+		if (!projectRef) throw new Error("invalid test fixture");
+
+		setLegacyTeamSetupProjectMapping(db, {
+			attemptId: draft.attemptId,
+			projectRef,
+			resolvedProjectIdentity: target,
+			now: NOW,
+		});
+
+		expect(
+			db
+				.prepare(
+					`SELECT resolved_project_identity FROM legacy_team_setup_draft_projects
+						 WHERE attempt_id = ? AND project_ref = ?`,
+				)
+				.pluck()
+				.get(draft.attemptId, projectRef),
+		).toBe(target);
 	});
 
 	it("rejects decisions outside the activation contract at runtime", () => {

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -5,11 +5,21 @@ import {
 	isValidLegacyTeamAssignmentVersion,
 	type StoredLegacyTeamAssignmentExpectation,
 } from "./legacy-team-assignment-expectation.js";
+import {
+	type LegacyTeamAttemptState,
+	planLegacyTeamAttempt,
+} from "./legacy-team-attempt-lifecycle.js";
 import { isLegacyTeamProjectCanonicalStateValid } from "./legacy-team-project-canonical-preflight.js";
+import { isMigratableLegacyTeamProjectIdentity } from "./legacy-team-project-policy.js";
 import {
 	latestLegacyTeamSetupAttempt,
 	legacyTeamSetupAttemptCurrentness,
 } from "./legacy-team-setup-attempt.js";
+import {
+	humanGroupLabelAlias,
+	safeLabel,
+	setupLabelForbiddenIds,
+} from "./legacy-team-setup-label-policy.js";
 import {
 	requireLegacyTeamSetupEffectiveDevicesWithinLimit,
 	requireLegacyTeamSetupSnapshotWithinLimits,
@@ -29,7 +39,7 @@ import {
 } from "./recipient-policy-identifiers.js";
 import { canonicalWorkspaceIdentity } from "./scope-resolution.js";
 
-export type LegacyTeamSetupDraftState = "needs_setup" | "in_progress" | "stale" | "completed";
+export type LegacyTeamSetupDraftState = LegacyTeamAttemptState;
 export type LegacyTeamDeviceDecision = "unresolved" | "included" | "excluded" | "removed";
 export type LegacyTeamProjectResolution = "unresolved" | "deterministic" | "explicit";
 export type LegacyTeamAssignmentExpectation =
@@ -249,135 +259,6 @@ function projectCanonicalStateValid(
 			status: recipient.status,
 		})),
 	});
-}
-
-/**
- * Characters a display label may contain: letters, numbers, spaces, and a
- * small set of name punctuation. Everything else — separators (`/ \ : @ ~ $
- * %`), brackets, quotes — is what paths, URLs, endpoints, and hostnames are
- * made of, so their absence removes the entire leak surface at once.
- */
-const SAFE_LABEL_PATTERN = /^[\p{L}\p{N} '&,.()_-]*$/u;
-
-function normalizeLabelText(value: string): string {
-	return (
-		value
-			.normalize("NFKC")
-			// Format characters (zero-width joiners, bidi controls) are removed
-			// entirely so they cannot split an address or identifier into innocent
-			// halves; control characters become word separators.
-			.replace(/\p{Cf}/gu, "")
-			.replace(/\p{Cc}/gu, " ")
-			.replace(/\s+/gu, " ")
-			.trim()
-	);
-}
-
-function labelComparisonForm(value: string): string {
-	return normalizeLabelText(value).toLowerCase();
-}
-
-// A coordinator display name is affirmative evidence that a compact alphabetic
-// group slug is a human label alias. Separators, digits, long values, or a
-// mismatched display name remain opaque and stay in the redaction set.
-function humanGroupLabelAlias(groupId: string, displayName: string): string | null {
-	const comparableGroupId = labelComparisonForm(groupId);
-	if (!/^[a-z]{2,24}$/u.test(comparableGroupId)) return null;
-	return labelComparisonForm(displayName) === comparableGroupId ? comparableGroupId : null;
-}
-
-/**
- * Coordinator-supplied display labels are sanitized with an allowlist, not a
- * denylist: multiple review rounds each found one more denylisted shape (bare
- * IPs, `host:port`, dot-relative paths, rooted backslash paths), and forms
- * like `home/alice/projects` vs `50/50` or a dotless internal hostname vs a
- * product name are not separable by any pattern. Labels are display-only and
- * the fallbacks are meaningful, so the cheap failure mode is showing the
- * generic name — never exporting private topology. Anything that does not
- * match a conservative name grammar falls back:
- *
- * - NFKC-normalize first so full-width or compatibility lookalikes cannot
- *   smuggle separators past the grammar; strip every control and format
- *   character (zero-width joiners, bidi overrides) rather than only C0.
- * - Reject any character outside letters/numbers/space and `' & , . ( ) _ -`.
- * - Reject `.` squeezed between letters/numbers on both sides: that single
- *   rule removes hostnames, IPs, and dotted file names while keeping ordinary
- *   sentence punctuation like `v2 release.` intact.
- * - Reject labels embedding opaque lookup identifiers (coordinator, device,
- *   project, and non-display group references).
- */
-function safeLabel(value: string, fallback: string, forbiddenIds: ReadonlySet<string>): string {
-	const boundedValue = value.slice(0, 512);
-	const normalized = normalizeLabelText(boundedValue);
-	const sanitized = normalized.slice(0, 120).trim();
-	if (!sanitized) return fallback;
-	if (!SAFE_LABEL_PATTERN.test(sanitized)) return fallback;
-	if (/[\p{L}\p{N}]\.[\p{L}\p{N}]/u.test(sanitized)) return fallback;
-	// Key-material markers are pure letters/hyphens, so the grammar alone
-	// would keep surrounding text; fail closed on the markers themselves.
-	if (/-----|\b(?:ssh|ecdsa|sk)-[\p{L}\p{N}-]+ /iu.test(sanitized)) return fallback;
-	// Compare the complete bounded input before display truncation so an
-	// identifier cannot be hidden just past the visible label boundary.
-	const comparable = normalized.toLowerCase();
-	for (const forbiddenId of forbiddenIds) {
-		if (comparable.includes(forbiddenId)) return fallback;
-	}
-	return sanitized;
-}
-
-function setupLabelForbiddenIds(
-	contextIds: ReadonlyArray<string>,
-	groupId: string,
-	humanGroupAlias: string | null,
-	devices: ReadonlyArray<LegacyTeamSetupRosterDeviceInput>,
-	projects: ReadonlyArray<LegacyTeamSetupProjectInput>,
-	persistedDevices: ReadonlyArray<{
-		deviceId: string;
-		fingerprint: string;
-		existingIdentityId: string | null;
-		targetIdentityId: string | null;
-	}>,
-	persistedProjects: ReadonlyArray<{
-		projectRef: string;
-		sourceProjectIdentity: string;
-		sourceFingerprint: string;
-		resolvedProjectIdentity: string | null;
-		targetScopeId: string | null;
-	}>,
-): ReadonlySet<string> {
-	return new Set(
-		[
-			...contextIds,
-			...(humanGroupAlias ? [] : [groupId]),
-			...devices.flatMap((device) => [
-				device.deviceId,
-				device.fingerprint,
-				...(device.labelRedactionIds ?? []),
-			]),
-			...persistedDevices.flatMap((device) => [
-				device.deviceId,
-				device.fingerprint,
-				device.existingIdentityId ?? "",
-				device.targetIdentityId ?? "",
-			]),
-			...projects.flatMap((project) => [
-				project.projectRef,
-				project.sourceProjectIdentity,
-				project.sourceFingerprint,
-				project.deterministicProjectIdentity ?? "",
-				project.targetScopeId ?? "",
-			]),
-			...persistedProjects.flatMap((project) => [
-				project.projectRef,
-				project.sourceProjectIdentity,
-				project.sourceFingerprint,
-				project.resolvedProjectIdentity ?? "",
-				project.targetScopeId ?? "",
-			]),
-		]
-			.map(labelComparisonForm)
-			.filter(Boolean),
-	);
 }
 
 interface DeviceAssignmentSnapshot {
@@ -983,16 +864,20 @@ export function refreshLegacyTeamSetupDraft(
 		}));
 		const rosterFingerprint = legacyTeamRosterFingerprint(assignments);
 		const projectFingerprint = legacyTeamProjectionFingerprint(normalizedInput.projects);
-		if (
-			existing &&
-			(existing.state === "needs_setup" || existing.state === "in_progress") &&
+		const evidenceMatches =
+			existing != null &&
 			existing.roster_fingerprint === rosterFingerprint &&
 			existing.projection_fingerprint === projectFingerprint &&
-			storedAssignmentEvidenceMatches(db, existing.attempt_id, assignmentSnapshots)
-		) {
+			storedAssignmentEvidenceMatches(db, existing.attempt_id, assignmentSnapshots);
+		const plan = planLegacyTeamAttempt({
+			state: existing?.state ?? null,
+			evidenceMatches,
+			completionReady: false,
+		});
+		if (plan.kind === "reuse" && existing) {
 			return refreshLegacyTeamSetupDraftLabels(db, existing.attempt_id, normalizedInput);
 		}
-		if (existing && (existing.state === "needs_setup" || existing.state === "in_progress")) {
+		if (existing && existing.state !== "completed") {
 			db.prepare(
 				`UPDATE legacy_team_setup_drafts
 				 SET state = 'stale', superseded_at = ?, updated_at = ?
@@ -1374,6 +1259,7 @@ export function isLegacyTeamSetupProjectMappingIdentity(value: string): boolean 
 	return !(
 		!isStrictRecipientPolicyProjectIdentity(identity) ||
 		identity.startsWith("unmapped:") ||
+		!isMigratableLegacyTeamProjectIdentity(identity) ||
 		/\s/u.test(identity) ||
 		(/[/\\]/u.test(identity) && !isRemoteForm) ||
 		/^(?:[~.$%]|[A-Za-z]:[\\/])/.test(identity) ||

--- a/packages/core/src/legacy-team-setup-label-policy.test.ts
+++ b/packages/core/src/legacy-team-setup-label-policy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+	humanGroupLabelAlias,
+	safeLabel,
+	setupLabelForbiddenIds,
+} from "./legacy-team-setup-label-policy.js";
+
+describe("legacy Team setup label policy", () => {
+	it.each([
+		"api.example.invalid",
+		"ssh-ed25519 secret",
+		"safe/name",
+		"api\u202E.example",
+	])("redacts unsafe label %s", (value) => {
+		expect(safeLabel(value, "Fallback", new Set())).toBe("Fallback");
+	});
+
+	it("checks forbidden identifiers beyond the emitted label boundary", () => {
+		const value = `${"A".repeat(130)} private-id`;
+		expect(safeLabel(value, "Fallback", new Set(["private-id"]))).toBe("Fallback");
+	});
+
+	it("allows a proven human group alias in presentation labels", () => {
+		const alias = humanGroupLabelAlias("api", "API");
+		const forbidden = setupLabelForbiddenIds([], "api", alias, [], [], [], []);
+		expect(safeLabel("API", "Legacy Team", forbidden)).toBe("API");
+		expect(safeLabel("API laptop", "Device", forbidden)).toBe("API laptop");
+	});
+
+	it.each([
+		"a",
+		"group-1",
+		"thisgroupnameislongerthantwentyfour",
+	])("does not treat opaque group ID %s as a human alias", (groupId) => {
+		expect(humanGroupLabelAlias(groupId, groupId)).toBeNull();
+	});
+});

--- a/packages/core/src/legacy-team-setup-label-policy.ts
+++ b/packages/core/src/legacy-team-setup-label-policy.ts
@@ -1,0 +1,110 @@
+interface LabelDeviceInput {
+	deviceId: string;
+	fingerprint: string;
+	labelRedactionIds?: readonly string[];
+}
+
+interface LabelProjectInput {
+	projectRef: string;
+	sourceProjectIdentity: string;
+	sourceFingerprint: string;
+	deterministicProjectIdentity: string | null;
+	targetScopeId?: string | null;
+}
+
+interface PersistedLabelDevice {
+	deviceId: string;
+	fingerprint: string;
+	existingIdentityId: string | null;
+	targetIdentityId: string | null;
+}
+
+interface PersistedLabelProject {
+	projectRef: string;
+	sourceProjectIdentity: string;
+	sourceFingerprint: string;
+	resolvedProjectIdentity: string | null;
+	targetScopeId: string | null;
+}
+
+const SAFE_LABEL_PATTERN = /^[\p{L}\p{N} '&,.()_-]*$/u;
+
+function normalize(value: string): string {
+	return value
+		.normalize("NFKC")
+		.replace(/\p{Cf}/gu, "")
+		.replace(/\p{Cc}/gu, " ")
+		.replace(/\s+/gu, " ")
+		.trim();
+}
+
+function comparable(value: string): string {
+	return normalize(value).toLowerCase();
+}
+
+export function humanGroupLabelAlias(groupId: string, displayName: string): string | null {
+	const comparableGroupId = comparable(groupId);
+	if (!/^[a-z]{2,24}$/u.test(comparableGroupId)) return null;
+	return comparable(displayName) === comparableGroupId ? comparableGroupId : null;
+}
+
+export function safeLabel(
+	value: string,
+	fallback: string,
+	forbiddenIds: ReadonlySet<string>,
+): string {
+	const normalized = normalize(value.slice(0, 512));
+	const sanitized = normalized.slice(0, 120).trim();
+	if (!sanitized || !SAFE_LABEL_PATTERN.test(sanitized)) return fallback;
+	if (/[\p{L}\p{N}]\.[\p{L}\p{N}]/u.test(sanitized)) return fallback;
+	if (/-----|\b(?:ssh|ecdsa|sk)-[\p{L}\p{N}-]+ /iu.test(sanitized)) return fallback;
+	const comparison = normalized.toLowerCase();
+	for (const forbiddenId of forbiddenIds) {
+		if (comparison.includes(forbiddenId)) return fallback;
+	}
+	return sanitized;
+}
+
+export function setupLabelForbiddenIds(
+	contextIds: ReadonlyArray<string>,
+	groupId: string,
+	humanGroupAlias: string | null,
+	devices: ReadonlyArray<LabelDeviceInput>,
+	projects: ReadonlyArray<LabelProjectInput>,
+	persistedDevices: ReadonlyArray<PersistedLabelDevice>,
+	persistedProjects: ReadonlyArray<PersistedLabelProject>,
+): ReadonlySet<string> {
+	return new Set(
+		[
+			...contextIds,
+			...(humanGroupAlias ? [] : [groupId]),
+			...devices.flatMap((device) => [
+				device.deviceId,
+				device.fingerprint,
+				...(device.labelRedactionIds ?? []),
+			]),
+			...persistedDevices.flatMap((device) => [
+				device.deviceId,
+				device.fingerprint,
+				device.existingIdentityId ?? "",
+				device.targetIdentityId ?? "",
+			]),
+			...projects.flatMap((project) => [
+				project.projectRef,
+				project.sourceProjectIdentity,
+				project.sourceFingerprint,
+				project.deterministicProjectIdentity ?? "",
+				project.targetScopeId ?? "",
+			]),
+			...persistedProjects.flatMap((project) => [
+				project.projectRef,
+				project.sourceProjectIdentity,
+				project.sourceFingerprint,
+				project.resolvedProjectIdentity ?? "",
+				project.targetScopeId ?? "",
+			]),
+		]
+			.map(comparable)
+			.filter(Boolean),
+	);
+}


### PR DESCRIPTION
## Description
Centralizes legacy Team migration label policy, Project eligibility, and attempt lifecycle planning. Synthetic shared and personal workspace identities now fail closed at discovery, review, and activation preflight boundaries. Drifted attempts are replaced atomically instead of remaining stale and editable.

Tracks codemem-752i.1.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm run tsc`
- [x] `pnpm run lint`
- [x] 274 focused legacy Team tests
- [x] Added/updated tests for lifecycle, labels, Project policy, discovery, draft, and activation preflight

## Checklist

- [x] Code follows project style
- [x] Self-review and CodeReviewer review completed
- [x] Documentation not needed for this internal behavior refactor
- [x] No new warnings introduced