### PR TITLE
fix(viewer): keep Team setup detail reads pure

### DIFF
--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { discoverLegacyTeamCandidates } from "./legacy-team-candidate.js";
 import {
 	finishLegacyTeamSetupActivation,
+	inspectLegacyTeamSetupActivation,
 	previewLegacyTeamSetupActivation,
 } from "./legacy-team-setup-activation.js";
 import { latestLegacyTeamSetupAttempt } from "./legacy-team-setup-attempt.js";
@@ -537,6 +538,25 @@ describe("legacy Team setup activation", () => {
 		expect(operation).toThrow("team_setup_incomplete");
 		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
 		expect(db.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+	});
+
+	it("keeps read-only inspection from persisting activation errors", () => {
+		const draft = refreshLegacyTeamSetupDraft(db, snapshot());
+		const input = { candidateRef: draft.candidateRef, attemptId: draft.attemptId };
+
+		expect(() => inspectLegacyTeamSetupActivation(db, input)).toThrow("team_setup_incomplete");
+		expect(
+			db
+				.prepare("SELECT state, safe_error_code FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.get(draft.attemptId),
+		).toEqual({ state: "needs_setup", safe_error_code: null });
+
+		expect(() => previewLegacyTeamSetupActivation(db, input)).toThrow("team_setup_incomplete");
+		expect(
+			db
+				.prepare("SELECT state, safe_error_code FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.get(draft.attemptId),
+		).toEqual({ state: "needs_setup", safe_error_code: "team_setup_incomplete" });
 	});
 
 	it.each([

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -1237,12 +1237,23 @@ function buildPreview(model: ActivationModel): LegacyTeamSetupActivationPreviewV
 	};
 }
 
-export function previewLegacyTeamSetupActivation(
+export function inspectLegacyTeamSetupActivation(
 	db: Database,
 	input: PreviewLegacyTeamSetupActivationInput,
 ): LegacyTeamSetupActivationPreviewV1 {
 	try {
 		return buildPreview(loadModel(db, input));
+	} catch (error) {
+		throw normalizedActivationError(error);
+	}
+}
+
+export function previewLegacyTeamSetupActivation(
+	db: Database,
+	input: PreviewLegacyTeamSetupActivationInput,
+): LegacyTeamSetupActivationPreviewV1 {
+	try {
+		return inspectLegacyTeamSetupActivation(db, input);
 	} catch (error) {
 		const normalized = normalizedActivationError(error);
 		persistSafeError(db, input, normalized);

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -986,30 +986,25 @@ export function refreshLegacyTeamSetupDraftLabels(
 				targetScopeId: project.target_scope_id,
 			})),
 		);
-		const result = db
-			.prepare(
-				"UPDATE legacy_team_setup_drafts SET display_name = ?, updated_at = ? WHERE attempt_id = ?",
-			)
-			.run(safeLabel(input.displayName, "Legacy Team", forbiddenIds), now, attemptId);
-		if (result.changes !== 1) throw new Error("legacy_team_setup_draft_not_found");
+		const teamDisplayName = safeLabel(input.displayName, "Legacy Team", forbiddenIds);
+		db.prepare(
+			`UPDATE legacy_team_setup_drafts SET display_name = ?, updated_at = ?
+				 WHERE attempt_id = ? AND display_name <> ?`,
+		).run(teamDisplayName, now, attemptId, teamDisplayName);
 		const updateDevice = db.prepare(
 			`UPDATE legacy_team_setup_draft_devices SET display_name = ?, updated_at = ?
-			 WHERE attempt_id = ? AND device_id = ?`,
+			 WHERE attempt_id = ? AND device_id = ? AND display_name <> ?`,
 		);
 		const inputDeviceById = new Map(input.devices.map((device) => [device.deviceId, device]));
 		for (const persistedDevice of persistedDevices) {
 			const displayName =
 				inputDeviceById.get(persistedDevice.device_id)?.displayName ?? persistedDevice.display_name;
-			updateDevice.run(
-				safeLabel(displayName, "Device", forbiddenIds),
-				now,
-				attemptId,
-				persistedDevice.device_id,
-			);
+			const safeDisplayName = safeLabel(displayName, "Device", forbiddenIds);
+			updateDevice.run(safeDisplayName, now, attemptId, persistedDevice.device_id, safeDisplayName);
 		}
 		const updateProject = db.prepare(
 			`UPDATE legacy_team_setup_draft_projects SET display_name = ?, updated_at = ?
-			 WHERE attempt_id = ? AND project_ref = ?`,
+			 WHERE attempt_id = ? AND project_ref = ? AND display_name <> ?`,
 		);
 		const inputProjectByRef = new Map(
 			input.projects.map((project) => [project.projectRef, project]),
@@ -1018,11 +1013,13 @@ export function refreshLegacyTeamSetupDraftLabels(
 			const displayName =
 				inputProjectByRef.get(persistedProject.project_ref)?.displayName ??
 				persistedProject.display_name;
+			const safeDisplayName = safeLabel(displayName, "Project", forbiddenIds);
 			updateProject.run(
-				safeLabel(displayName, "Project", forbiddenIds),
+				safeDisplayName,
 				now,
 				attemptId,
 				persistedProject.project_ref,
+				safeDisplayName,
 			);
 		}
 		return loadDraftView(db, attemptId);

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -632,6 +632,17 @@ describe("viewer-server", () => {
 					unresolvedDeviceCount: 1,
 					unresolvedProjectCount: 0,
 				});
+				const beforeDetail = {
+					drafts: store.db.prepare("SELECT * FROM legacy_team_setup_drafts ORDER BY rowid").all(),
+					devices: store.db
+						.prepare("SELECT * FROM legacy_team_setup_draft_devices ORDER BY attempt_id, device_id")
+						.all(),
+					projects: store.db
+						.prepare(
+							"SELECT * FROM legacy_team_setup_draft_projects ORDER BY attempt_id, project_ref",
+						)
+						.all(),
+				};
 
 				const incompleteResponse = await app.request(`/api/sync/team-setup/v1/${candidateRef}`);
 				expect(incompleteResponse.status).toBe(200);
@@ -646,6 +657,18 @@ describe("viewer-server", () => {
 				expect(incomplete).not.toHaveProperty("finishDigest");
 				expect(incomplete).not.toHaveProperty("accessDeltaDigest");
 				expect(incomplete).not.toHaveProperty("accessDelta");
+				expect((await app.request(`/api/sync/team-setup/v1/${candidateRef}`)).status).toBe(200);
+				expect({
+					drafts: store.db.prepare("SELECT * FROM legacy_team_setup_drafts ORDER BY rowid").all(),
+					devices: store.db
+						.prepare("SELECT * FROM legacy_team_setup_draft_devices ORDER BY attempt_id, device_id")
+						.all(),
+					projects: store.db
+						.prepare(
+							"SELECT * FROM legacy_team_setup_draft_projects ORDER BY attempt_id, project_ref",
+						)
+						.all(),
+				}).toEqual(beforeDetail);
 
 				const draft = core.getLegacyTeamSetupDraft(store.db, candidateRef);
 				expect(draft).not.toBeNull();

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -16,6 +16,7 @@ import {
 	fingerprintPublicKey,
 	finishLegacyTeamSetupActivation,
 	getLegacyTeamSetupDraft,
+	inspectLegacyTeamSetupActivation,
 	isLegacyTeamCandidateSelectable,
 	isLegacyTeamSetupProjectMappingIdentity,
 	legacyTeamCandidateId,
@@ -1215,10 +1216,10 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 
 			let conflictState: LegacyTeamSetupActivationErrorCode | null = null;
-			let preview: ReturnType<typeof previewLegacyTeamSetupActivation> | null = null;
+			let preview: ReturnType<typeof inspectLegacyTeamSetupActivation> | null = null;
 			if (draft.state !== "completed") {
 				try {
-					preview = previewLegacyTeamSetupActivation(store.db, {
+					preview = inspectLegacyTeamSetupActivation(store.db, {
 						candidateRef,
 						attemptId: draft.attemptId,
 					});
@@ -1231,9 +1232,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			}
 			if (preview) requireBoundedAccessDelta(preview.accessDelta);
 
-			const viewDraft = conflictState
-				? (getLegacyTeamSetupDraft(store.db, candidateRef) ?? draft)
-				: draft;
+			const viewDraft = draft;
 			const safeDraft = viewerSafeDraft(store, viewDraft);
 			const responseBase = {
 				version: TEAM_SETUP_VERSION,


### PR DESCRIPTION
## Description
Makes Team setup detail reads side-effect free for unchanged evidence. Read-only activation inspection no longer persists safe errors, unchanged labels no longer bump database timestamps, and write previews retain their existing error persistence.

Tracks codemem-752i.2.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm run tsc`
- [x] `pnpm run lint`
- [x] 604 focused core and Viewer tests
- [x] Added database snapshot coverage across repeated detail GETs

## Checklist

- [x] Code follows project style
- [x] Self-review and CodeReviewer review completed
- [x] Documentation not needed for this internal behavior fix
- [x] No new warnings introduced