### PR TITLE
feat(viewer): return authoritative Team setup views

### DIFF
--- a/e2e/scenarios/legacy-team-migration.ts
+++ b/e2e/scenarios/legacy-team-migration.ts
@@ -89,11 +89,13 @@ interface TeamDetail {
 	version: 1;
 	candidate: CandidateSummary;
 	attemptId: string;
-	draftState: string;
+	state: "reviewing" | "ready_to_finish" | "unavailable" | "completed";
+	actions: {
+		refresh: { enabled: boolean; blockedReason: string | null };
+		finish: { enabled: boolean; blockedReason: string | null };
+	};
 	unresolvedDeviceCount: number;
 	unresolvedProjectCount: number;
-	canFinish: boolean;
-	conflictState: string | null;
 	finishDigest?: string;
 	accessDeltaDigest?: string;
 	viewerAccessDeltaDigest?: string;
@@ -322,7 +324,10 @@ function candidatePath(candidateRef: string): string {
 }
 
 function finishBody(detail: TeamDetail): Record<string, unknown> {
-	assert(detail.canFinish, `${detail.candidate.displayName} is not ready to finish`);
+	assert(
+		detail.state === "ready_to_finish" && detail.actions.finish.enabled,
+		`${detail.candidate.displayName} is not ready to finish`,
+	);
 	assert(detail.finishDigest, "finish digest missing");
 	assert(detail.accessDeltaDigest, "access delta digest missing");
 	assert(detail.viewerAccessDeltaDigest, "viewer access delta digest missing");
@@ -498,7 +503,9 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 	let alpha = await loadDetail(ctx, alphaCandidate.candidateRef, "11-alpha-unresolved-detail");
 	const betaInitial = await loadDetail(ctx, betaCandidate.candidateRef, "12-beta-initial-detail");
 	assert(
-		alpha.unresolvedProjectCount === 1 && !alpha.canFinish,
+		alpha.state === "reviewing" &&
+			alpha.unresolvedProjectCount === 1 &&
+			!alpha.actions.finish.enabled,
 		"explicit Project mapping did not block finish",
 	);
 	assert(
@@ -525,7 +532,12 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 	await assignDevice(ctx, alpha, "Optional Device", "Optional Person", "excluded", "15-alpha-optional");
 	await mapUnresolvedProjects(ctx, alpha, "16-alpha-map");
 	alpha = await loadDetail(ctx, alphaCandidate.candidateRef, "17-alpha-ready-detail");
-	assert(alpha.canFinish && alpha.unresolvedProjectCount === 0, "Alpha did not become finishable");
+	assert(
+		alpha.state === "ready_to_finish" &&
+			alpha.actions.finish.enabled &&
+			alpha.unresolvedProjectCount === 0,
+		"Alpha did not become finishable",
+	);
 	assert((alpha.accessDelta?.teamChanges.length ?? 0) === 1, "Alpha preview omitted the Team change");
 	assert((alpha.accessDelta?.recipientChanges.length ?? 0) === 2, "Alpha preview omitted Project recipients");
 
@@ -639,7 +651,10 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 		"33-beta-four",
 	);
 	beta = await loadDetail(ctx, betaCandidate.candidateRef, "34-beta-ready-detail");
-	assert(beta.canFinish, "Beta did not become finishable");
+	assert(
+		beta.state === "ready_to_finish" && beta.actions.finish.enabled,
+		"Beta did not become finishable",
+	);
 
 	// Negative: an external assignment appearing after review rejects the whole Beta transaction.
 	fixture(ctx, "conflict-beta-assignment", "35-conflict-beta-assignment");
@@ -789,8 +804,9 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 	);
 	assert(
 		recoveredBetaDetail.candidate.status === "ready" &&
-			recoveredBetaDetail.draftState === "completed" &&
-			!recoveredBetaDetail.canFinish,
+			recoveredBetaDetail.state === "completed" &&
+			!recoveredBetaDetail.actions.finish.enabled &&
+			!recoveredBetaDetail.actions.refresh.enabled,
 		"detail did not recover Beta as completed after the dropped finish response",
 	);
 	const afterLostResponse = fixture(ctx, "summary", "50-after-lost-beta-finish");

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -650,13 +650,15 @@ describe("viewer-server", () => {
 				expect(incomplete).toMatchObject({
 					version: 1,
 					candidate: { candidateRef },
-					draftState: "needs_setup",
-					conflictState: "team_setup_incomplete",
-					canFinish: false,
+					state: "reviewing",
+					actions: { finish: { enabled: false, blockedReason: "setup_incomplete" } },
 				});
 				expect(incomplete).not.toHaveProperty("finishDigest");
 				expect(incomplete).not.toHaveProperty("accessDeltaDigest");
 				expect(incomplete).not.toHaveProperty("accessDelta");
+				expect(incomplete).not.toHaveProperty("unavailableReason");
+				expect(incomplete).toHaveProperty("devices.0.actions");
+				expect(incomplete).toHaveProperty("projects.0.actions");
 				expect((await app.request(`/api/sync/team-setup/v1/${candidateRef}`)).status).toBe(200);
 				expect({
 					drafts: store.db.prepare("SELECT * FROM legacy_team_setup_drafts ORDER BY rowid").all(),
@@ -669,7 +671,6 @@ describe("viewer-server", () => {
 						)
 						.all(),
 				}).toEqual(beforeDetail);
-
 				const draft = core.getLegacyTeamSetupDraft(store.db, candidateRef);
 				expect(draft).not.toBeNull();
 				store.db
@@ -694,6 +695,15 @@ describe("viewer-server", () => {
 					"legacy-team-viewer-identity-ref-v1",
 					[candidateRef, replacementIdentityId],
 				);
+				const expectFullView = async (response: Response) => {
+					const payload = (await response.clone().json()) as Record<string, unknown>;
+					expect(payload).toMatchObject({ version: 1, candidate: { candidateRef } });
+					expect(payload).toHaveProperty("state");
+					expect(payload).toHaveProperty("actions");
+					expect(payload).toHaveProperty("devices");
+					expect(payload).toHaveProperty("projects");
+					expect(payload).toHaveProperty("identityChoices");
+				};
 				const assignmentResponse = await app.request(
 					`/api/sync/team-setup/v1/${candidateRef}/devices/${deviceRef}/assignment`,
 					{
@@ -707,6 +717,7 @@ describe("viewer-server", () => {
 					},
 				);
 				expect(assignmentResponse.status).toBe(200);
+				await expectFullView(assignmentResponse);
 				const replacementAssignmentResponse = await app.request(
 					`/api/sync/team-setup/v1/${candidateRef}/devices/${deviceRef}/assignment`,
 					{
@@ -720,6 +731,7 @@ describe("viewer-server", () => {
 					},
 				);
 				expect(replacementAssignmentResponse.status).toBe(200);
+				await expectFullView(replacementAssignmentResponse);
 				const staleDecisionResponse = await app.request(
 					`/api/sync/team-setup/v1/${candidateRef}/devices/${deviceRef}/decision`,
 					{
@@ -749,6 +761,7 @@ describe("viewer-server", () => {
 					},
 				);
 				expect(restoredAssignmentResponse.status).toBe(200);
+				await expectFullView(restoredAssignmentResponse);
 				const decisionResponse = await app.request(
 					`/api/sync/team-setup/v1/${candidateRef}/devices/${deviceRef}/decision`,
 					{
@@ -762,6 +775,7 @@ describe("viewer-server", () => {
 					},
 				);
 				expect(decisionResponse.status).toBe(200);
+				await expectFullView(decisionResponse);
 				const clearResponse = await app.request(
 					`/api/sync/team-setup/v1/${candidateRef}/devices/${deviceRef}/decision`,
 					{
@@ -771,8 +785,10 @@ describe("viewer-server", () => {
 					},
 				);
 				expect(clearResponse.status).toBe(200);
+				await expectFullView(clearResponse);
 				expect(await clearResponse.json()).toMatchObject({
-					canFinish: false,
+					state: "reviewing",
+					candidate: { candidateRef },
 					unresolvedDeviceCount: 1,
 				});
 				const restoredDecisionResponse = await app.request(
@@ -788,6 +804,7 @@ describe("viewer-server", () => {
 					},
 				);
 				expect(restoredDecisionResponse.status).toBe(200);
+				await expectFullView(restoredDecisionResponse);
 				const rawPreview = core.previewLegacyTeamSetupActivation(store.db, {
 					candidateRef,
 					attemptId: draft?.attemptId ?? "",
@@ -800,8 +817,8 @@ describe("viewer-server", () => {
 					version: 1,
 					attemptId: draft?.attemptId,
 					finishDigest: rawPreview.finishDigest,
-					canFinish: true,
-					conflictState: null,
+					state: "ready_to_finish",
+					actions: { finish: { enabled: true, blockedReason: null } },
 					accessDeltaDigest: rawPreview.accessDeltaDigest,
 				});
 				expect(JSON.stringify(detail)).not.toContain(coordinatorId);
@@ -1013,15 +1030,41 @@ describe("viewer-server", () => {
 				const ready = (await readyResponse.json()) as Record<string, unknown>;
 				expect(ready).toMatchObject({
 					candidate: { candidateRef, status: "ready" },
-					draftState: "completed",
-					canFinish: false,
-					conflictState: null,
+					state: "completed",
+					actions: {
+						refresh: { enabled: false, blockedReason: "setup_completed" },
+						finish: { enabled: false, blockedReason: "setup_completed" },
+					},
 				});
 				expect(ready).not.toHaveProperty("finishDigest");
 				expect(ready).not.toHaveProperty("accessDeltaDigest");
 				expect(ready).not.toHaveProperty("accessDelta");
 				expect(ready.identityChoices).toHaveLength(501);
 				expect(loadSnapshots).not.toHaveBeenCalled();
+				const completedMutation = await app.request(
+					`/api/sync/team-setup/v1/${candidateRef}/devices/${deviceRef}/decision`,
+					{
+						method: "PUT",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({ attemptId: draft?.attemptId, decision: "excluded" }),
+					},
+				);
+				expect(completedMutation.status).toBe(409);
+				expect(await completedMutation.json()).toEqual({
+					error: "team_setup_confirmation_stale",
+				});
+				const completedRefresh = await app.request(
+					`/api/sync/team-setup/v1/${candidateRef}/refresh`,
+					{
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: "{}",
+					},
+				);
+				expect(completedRefresh.status).toBe(409);
+				expect(await completedRefresh.json()).toEqual({
+					error: "team_setup_confirmation_stale",
+				});
 
 				store.db.prepare("DELETE FROM actors WHERE actor_id LIKE 'unrelated-%'").run();
 				store.db
@@ -1036,7 +1079,7 @@ describe("viewer-server", () => {
 				const reopened = (await reopenedResponse.json()) as Record<string, unknown>;
 				expect(reopened).toMatchObject({ candidate: { candidateRef } });
 				expect((reopened.candidate as { status: string }).status).not.toBe("ready");
-				expect(reopened.draftState).not.toBe("completed");
+				expect(reopened.state).not.toBe("completed");
 				expect(loadSnapshots).toHaveBeenCalledWith({ candidateRef });
 			} finally {
 				cleanup();
@@ -1441,8 +1484,9 @@ describe("viewer-server", () => {
 				expect(response.status).toBe(200);
 				const payload = await response.json();
 				expect(payload).toMatchObject({
-					candidateRef,
+					candidate: { candidateRef },
 					attemptId: draft.attemptId,
+					state: "reviewing",
 					unresolvedProjectCount: 0,
 				});
 				const saved = core.getLegacyTeamSetupDraft(store.db, candidateRef);
@@ -1803,6 +1847,11 @@ describe("viewer-server", () => {
 				resolveRefresh();
 				const refresh = await refreshPromise;
 				expect(refresh.status).toBe(200);
+				expect(await refresh.clone().json()).toMatchObject({
+					version: 1,
+					candidate: { candidateRef },
+					state: "reviewing",
+				});
 				const refreshedAttemptId = core.getLegacyTeamSetupDraft(
 					ensureStore().db,
 					candidateRef,

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -57,6 +57,8 @@ export {
 	reconcileRecipientPolicyProjects,
 } from "./routes/sync.js";
 export type {
+	LegacyTeamSetupActionBlockedReasonV1,
+	LegacyTeamSetupActionGateV1,
 	LegacyTeamSetupCandidateSummaryV1,
 	LegacyTeamSetupDetailResponseV1,
 	LegacyTeamSetupDeviceV1,
@@ -67,6 +69,7 @@ export type {
 	LegacyTeamSetupProjectV1,
 	LegacyTeamSetupSummaryResponseV1,
 	LegacyTeamSetupViewerAccessDeltaV1,
+	LegacyTeamSetupViewV1,
 } from "./routes/team-setup.js";
 
 export { VERSION };

--- a/packages/viewer-server/src/routes/team-setup-refresh.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-refresh.test.ts
@@ -1,0 +1,73 @@
+import {
+	getLegacyTeamSetupDraft,
+	type LegacyTeamConfiguredGroupSnapshot,
+	legacyTeamCandidateId,
+	MemoryStore,
+} from "@codemem/core";
+import { describe, expect, it, vi } from "vitest";
+import { teamSetupRoutes } from "./team-setup.js";
+
+describe("Team setup refresh snapshots", () => {
+	it("rejects snapshots when the attempt completes during loading", async () => {
+		const store = new MemoryStore(":memory:");
+		let resolveSnapshots!: (snapshots: LegacyTeamConfiguredGroupSnapshot[]) => void;
+		const coordinatorId = "https://coordinator.example.test";
+		const groupId = "group-alpha";
+		const candidateRef = legacyTeamCandidateId(coordinatorId, groupId);
+		const loadSnapshots = vi.fn(
+			() =>
+				new Promise<LegacyTeamConfiguredGroupSnapshot[]>((resolve) => {
+					resolveSnapshots = resolve;
+				}),
+		);
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+		});
+		try {
+			store.db
+				.prepare(
+					`INSERT INTO legacy_team_setup_drafts(
+					 attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
+					 roster_fingerprint, projection_fingerprint, created_at, updated_at
+					 ) VALUES ('attempt-alpha', ?, ?, ?,
+					 'in_progress', 'Alpha', 'roster-alpha', 'projection-alpha', ?, ?)`,
+				)
+				.run(
+					candidateRef,
+					coordinatorId,
+					groupId,
+					"2026-08-28T00:00:00.000Z",
+					"2026-08-28T00:00:00.000Z",
+				);
+			const refresh = app.request(`/api/sync/team-setup/v1/${candidateRef}/refresh`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: "{}",
+			});
+			await vi.waitFor(() => expect(loadSnapshots).toHaveBeenCalledOnce());
+			store.db
+				.prepare(
+					`UPDATE legacy_team_setup_drafts
+					 SET state = 'completed', completed_at = ?, updated_at = ?
+					 WHERE attempt_id = 'attempt-alpha'`,
+				)
+				.run("2026-08-28T00:01:00.000Z", "2026-08-28T00:01:00.000Z");
+			resolveSnapshots([
+				{
+					coordinatorId,
+					groupId,
+					displayName: "Alpha",
+					devices: [],
+				},
+			]);
+
+			const response = await refresh;
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_setup_confirmation_stale" });
+			expect(getLegacyTeamSetupDraft(store.db, candidateRef)?.state).toBe("completed");
+		} finally {
+			store.close();
+		}
+	});
+});

--- a/packages/viewer-server/src/routes/team-setup-view.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-view.test.ts
@@ -69,7 +69,12 @@ describe("legacy Team setup view projection", () => {
 	it("projects reviewing without confirmation evidence and typed action gates", () => {
 		const view = projectLegacyTeamSetupView(input());
 
-		expect(view.state).toBe("reviewing");
+		expect(view).toMatchObject({
+			state: "reviewing",
+			draftState: "in_progress",
+			canFinish: false,
+			conflictState: null,
+		});
 		expect(view).not.toHaveProperty("finishDigest");
 		expect(view).not.toHaveProperty("accessDelta");
 		expect(view.devices[0]?.actions).toEqual({
@@ -98,6 +103,9 @@ describe("legacy Team setup view projection", () => {
 
 		expect(view).toMatchObject({
 			state: "ready_to_finish",
+			draftState: "in_progress",
+			canFinish: true,
+			conflictState: null,
 			finishDigest: "finish-digest",
 			accessDeltaDigest: "access-digest",
 			viewerAccessDeltaDigest: "viewer-digest",
@@ -114,7 +122,12 @@ describe("legacy Team setup view projection", () => {
 			unavailableReason: "team_setup_roster_changed",
 		});
 
-		expect(view.state).toBe("unavailable");
+		expect(view).toMatchObject({
+			state: "unavailable",
+			draftState: "stale",
+			canFinish: false,
+			conflictState: "team_setup_roster_changed",
+		});
 		expect(
 			view.devices.every((device) =>
 				Object.values(device.actions).every(
@@ -131,13 +144,32 @@ describe("legacy Team setup view projection", () => {
 		expect(view).not.toHaveProperty("finishDigest");
 	});
 
+	it("preserves a null conflict alias for stale drafts without a reason", () => {
+		const view = projectLegacyTeamSetupView({
+			...input(),
+			draftState: "stale",
+		});
+
+		expect(view).toMatchObject({
+			state: "unavailable",
+			draftState: "stale",
+			unavailableReason: "team_setup_confirmation_stale",
+			conflictState: null,
+		});
+	});
+
 	it("projects completed with every mutation and refresh gate disabled", () => {
 		const view = projectLegacyTeamSetupView({
 			...input(),
 			draftState: "completed",
 		});
 
-		expect(view.state).toBe("completed");
+		expect(view).toMatchObject({
+			state: "completed",
+			draftState: "completed",
+			canFinish: false,
+			conflictState: null,
+		});
 		expect(view.actions).toEqual({
 			refresh: { enabled: false, blockedReason: "setup_completed" },
 			finish: { enabled: false, blockedReason: "setup_completed" },

--- a/packages/viewer-server/src/routes/team-setup-view.ts
+++ b/packages/viewer-server/src/routes/team-setup-view.ts
@@ -118,6 +118,10 @@ interface LegacyTeamSetupViewBaseV1 {
 	version: 1;
 	candidate: LegacyTeamSetupCandidateSummaryV1;
 	attemptId: string;
+	/** Transitional aliases retained until the viewer consumes state/actions. */
+	draftState: LegacyTeamSetupDraftView["state"];
+	canFinish: boolean;
+	conflictState: LegacyTeamSetupUnavailableReasonV1 | null;
 	unresolvedDeviceCount: number;
 	unresolvedProjectCount: number;
 	devices: LegacyTeamSetupDeviceV1[];
@@ -283,6 +287,9 @@ export function projectLegacyTeamSetupView(input: ProjectViewInput): LegacyTeamS
 		version: input.version,
 		candidate: input.candidate,
 		attemptId: input.attemptId,
+		draftState: input.draftState,
+		canFinish: state === "ready_to_finish",
+		conflictState: input.unavailableReason,
 		unresolvedDeviceCount: input.unresolvedDeviceCount,
 		unresolvedProjectCount: input.unresolvedProjectCount,
 		devices: input.devices.map((device) => ({

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -17,6 +17,29 @@ function createRouteStore(): { store: MemoryStore; close: () => void } {
 }
 
 describe("Team setup roster loading", () => {
+	it("rolls back a mutation when response projection fails", () => {
+		const { store, close } = createRouteStore();
+		try {
+			store.db.exec("CREATE TABLE projection_rollback_test(value TEXT NOT NULL)");
+
+			expect(() =>
+				__teamSetupTestHooks.projectMutationAtomically(
+					store,
+					() =>
+						store.db.prepare("INSERT INTO projection_rollback_test(value) VALUES (?)").run("saved"),
+					() => {
+						throw new Error("projection failed");
+					},
+				),
+			).toThrow("projection failed");
+			expect(store.db.prepare("SELECT COUNT(*) FROM projection_rollback_test").pluck().get()).toBe(
+				0,
+			);
+		} finally {
+			close();
+		}
+	});
+
 	it("reuses successful summary snapshots until the cache expires", async () => {
 		let now = 1_000;
 		const snapshots = [{ groupId: "group-alpha" }] as never;

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -35,6 +35,35 @@ import {
 	setLegacyTeamSetupProjectMapping,
 } from "@codemem/core";
 import { type Context, Hono } from "hono";
+import {
+	type LegacyTeamSetupCandidateSummaryV1,
+	type LegacyTeamSetupDetailResponseV1,
+	type LegacyTeamSetupDeviceV1,
+	type LegacyTeamSetupFinishResponseV1,
+	type LegacyTeamSetupIdentityChoiceV1,
+	type LegacyTeamSetupProjectV1,
+	type LegacyTeamSetupSummaryResponseV1,
+	type LegacyTeamSetupUnavailableReasonV1,
+	type LegacyTeamSetupViewerAccessDeltaV1,
+	projectLegacyTeamSetupView,
+} from "./team-setup-view.js";
+
+export type {
+	LegacyTeamSetupActionBlockedReasonV1,
+	LegacyTeamSetupActionGateV1,
+	LegacyTeamSetupCandidateSummaryV1,
+	LegacyTeamSetupDetailResponseV1,
+	LegacyTeamSetupDeviceV1,
+	LegacyTeamSetupErrorResponseV1,
+	LegacyTeamSetupFinishResponseV1,
+	LegacyTeamSetupIdentityChoiceV1,
+	LegacyTeamSetupMutationResponseV1,
+	LegacyTeamSetupProjectV1,
+	LegacyTeamSetupSummaryResponseV1,
+	LegacyTeamSetupUnavailableReasonV1,
+	LegacyTeamSetupViewerAccessDeltaV1,
+	LegacyTeamSetupViewV1,
+} from "./team-setup-view.js";
 
 const TEAM_SETUP_VERSION = 1 as const;
 const MAX_CONFIGURED_GROUPS = 25;
@@ -73,141 +102,6 @@ export interface LegacyTeamCandidateGroupDescriptor {
 export type LegacyTeamConfiguredGroupSnapshotLoader = (
 	options?: LegacyTeamConfiguredGroupSnapshotLoadOptions,
 ) => Promise<LegacyTeamConfiguredGroupSnapshot[]>;
-
-export interface LegacyTeamSetupCandidateSummaryV1 {
-	candidateRef: string;
-	displayName: string;
-	status: "needs_setup" | "in_progress" | "stale" | "ready";
-	deviceCount: number;
-	projectCount: number;
-	unresolvedDeviceCount: number;
-	unresolvedProjectCount: number;
-}
-
-export interface LegacyTeamSetupSummaryResponseV1 {
-	version: 1;
-	candidates: LegacyTeamSetupCandidateSummaryV1[];
-}
-
-export interface LegacyTeamSetupDeviceV1 {
-	deviceRef: string;
-	displayName: string;
-	enabled: boolean;
-	existingIdentityRef: string | null;
-	suggestedIdentityRef: string | null;
-	verifiedEvidenceKind: "active_assignment" | null;
-	decision: "unresolved" | "included" | "excluded" | "removed";
-	targetIdentityRef: string | null;
-	expectation:
-		| { kind: "absent" }
-		| { kind: "existing"; assignmentVersion: number; identityRef: string };
-}
-
-export interface LegacyTeamSetupProjectV1 {
-	projectRef: string;
-	displayName: string;
-	resolution: "unresolved" | "deterministic" | "explicit";
-	canonicalProjectRef: string | null;
-	resolvedProjectRef: string | null;
-	mappingChoices: Array<{ resolvedProjectRef: string; displayName: string }>;
-}
-
-export interface LegacyTeamSetupIdentityChoiceV1 {
-	identityRef: string;
-	displayName: string;
-}
-
-export interface LegacyTeamSetupViewerAccessDeltaV1 {
-	teamChanges: Array<{
-		teamRef: string;
-		teamDisplayName: string;
-		change: "add" | "update" | "remove";
-		fromDeviceEligibilityMode: "person_all_devices" | "reviewed_allowlist" | null;
-		toDeviceEligibilityMode: "reviewed_allowlist";
-	}>;
-	membershipChanges: Array<{
-		teamRef: string;
-		teamDisplayName: string;
-		identityRef: string;
-		identityDisplayName: string;
-		change: "add" | "update" | "remove";
-	}>;
-	projectChanges: Array<{
-		projectRef: string;
-		projectDisplayName: string;
-		fromResolvedProjectRef: string | null;
-		fromResolvedProjectDisplayName: string | null;
-		toResolvedProjectRef: string | null;
-		toResolvedProjectDisplayName: string | null;
-		change: "add" | "update" | "remove";
-	}>;
-	recipientChanges: Array<{
-		canonicalProjectRef: string;
-		canonicalProjectDisplayName: string;
-		recipientKind: "team";
-		recipientRef: string;
-		recipientDisplayName: string;
-		change: "add" | "update" | "remove";
-	}>;
-	deviceAccessChanges: Array<{
-		canonicalProjectRef: string;
-		canonicalProjectDisplayName: string;
-		deviceRef: string;
-		deviceDisplayName: string;
-		change: "add" | "remove";
-	}>;
-}
-
-interface LegacyTeamSetupDetailBaseV1 {
-	version: 1;
-	candidate: LegacyTeamSetupCandidateSummaryV1;
-	attemptId: string;
-	draftState: "needs_setup" | "in_progress" | "stale" | "completed";
-	unresolvedDeviceCount: number;
-	unresolvedProjectCount: number;
-	devices: LegacyTeamSetupDeviceV1[];
-	projects: LegacyTeamSetupProjectV1[];
-	identityChoices: LegacyTeamSetupIdentityChoiceV1[];
-}
-
-export type LegacyTeamSetupDetailResponseV1 = LegacyTeamSetupDetailBaseV1 &
-	(
-		| {
-				canFinish: true;
-				conflictState: null;
-				finishDigest: string;
-				accessDeltaDigest: string;
-				viewerAccessDeltaDigest: string;
-				accessDelta: LegacyTeamSetupViewerAccessDeltaV1;
-		  }
-		| {
-				canFinish: false;
-				conflictState: LegacyTeamSetupActivationErrorCode | null;
-		  }
-	);
-
-export interface LegacyTeamSetupErrorResponseV1 {
-	error: LegacyTeamSetupActivationErrorCode;
-}
-
-export interface LegacyTeamSetupMutationResponseV1 {
-	version: 1;
-	candidateRef: string;
-	attemptId: string;
-	draftState: LegacyTeamSetupDraftView["state"];
-	canFinish: boolean;
-	unresolvedDeviceCount: number;
-	unresolvedProjectCount: number;
-}
-
-export interface LegacyTeamSetupFinishResponseV1 {
-	version: 1;
-	status: "completed";
-	teamRef: string;
-	attemptId: string;
-	accessDeltaDigest: string;
-	completedAt: string;
-}
 
 export interface TeamSetupRoutesOptions {
 	getStore: () => MemoryStore;
@@ -535,11 +429,11 @@ function candidateSummaryForDraft(
 	};
 }
 
-function completedCandidateFromDraft(draft: LegacyTeamSetupDraftView): LegacyTeamCandidateView {
+function candidateFromDraft(draft: LegacyTeamSetupDraftView): LegacyTeamCandidateView {
 	return {
 		candidateRef: draft.candidateRef,
 		displayName: draft.displayName,
-		status: "ready",
+		status: draft.state === "completed" ? "ready" : draft.state,
 		deviceCount: draft.devices.length,
 		projectCount: draft.projects.length,
 		unresolvedDeviceCount: draft.unresolvedDeviceCount,
@@ -570,8 +464,8 @@ function viewerSafeAccessDelta(
 	delta: LegacyTeamSetupAccessDeltaV1,
 	labels?: {
 		teamDisplayName: string;
-		devices: LegacyTeamSetupDeviceV1[];
-		projects: LegacyTeamSetupProjectV1[];
+		devices: Array<Omit<LegacyTeamSetupDeviceV1, "actions">>;
+		projects: Array<Omit<LegacyTeamSetupProjectV1, "actions">>;
 		identityChoices: LegacyTeamSetupIdentityChoiceV1[];
 	},
 ): LegacyTeamSetupViewerAccessDeltaV1 {
@@ -840,10 +734,30 @@ function createCachedSnapshotLoader(
 	return cachedLoad;
 }
 
+async function loadMutableCandidateSnapshots(
+	store: MemoryStore,
+	candidateRef: string,
+	load: () => Promise<LegacyTeamConfiguredGroupSnapshot[]>,
+): Promise<LegacyTeamConfiguredGroupSnapshot[]> {
+	if (getLegacyTeamSetupDraft(store.db, candidateRef)?.state === "completed") {
+		throw new Error("team_setup_confirmation_stale");
+	}
+	return load();
+}
+
+function projectMutationAtomically<Mutation, Projection>(
+	store: MemoryStore,
+	mutate: () => Mutation,
+	project: (mutation: Mutation) => Projection,
+): Projection {
+	return store.db.transaction(() => project(mutate())).immediate();
+}
+
 export const __teamSetupTestHooks = {
 	createCachedSnapshotLoader,
 	loadConfiguredLegacyTeamGroupSnapshotsWith,
 	normalizedCoordinatorId,
+	projectMutationAtomically,
 	requireCompleteMappingChoices,
 	disambiguateChoiceLabels,
 	safeChoiceLabel,
@@ -953,14 +867,13 @@ function projectMappingChoices(store: MemoryStore): ProjectMappingChoiceInternal
 	}));
 }
 
-function viewerSafeDraft(
-	store: MemoryStore,
-	draft: LegacyTeamSetupDraftView,
-): {
-	devices: LegacyTeamSetupDeviceV1[];
-	projects: LegacyTeamSetupProjectV1[];
+interface ViewerSafeDraft {
+	devices: Array<Omit<LegacyTeamSetupDeviceV1, "actions">>;
+	projects: Array<Omit<LegacyTeamSetupProjectV1, "actions">>;
 	identityChoices: LegacyTeamSetupIdentityChoiceV1[];
-} {
+}
+
+function viewerSafeDraft(store: MemoryStore, draft: LegacyTeamSetupDraftView): ViewerSafeDraft {
 	if (draft.devices.length > MAX_DEVICES || draft.projects.length > MAX_PROJECTS) {
 		throw new Error("legacy_team_setup_roster_too_large");
 	}
@@ -1025,6 +938,23 @@ function viewerSafeDraft(
 			identityRef,
 			displayName,
 		})),
+	};
+}
+
+function viewerSafePreview(
+	draft: LegacyTeamSetupDraftView,
+	safeDraft: ViewerSafeDraft,
+	preview: ReturnType<typeof inspectLegacyTeamSetupActivation>,
+) {
+	const accessDelta = viewerSafeAccessDelta(draft.candidateRef, preview.accessDelta, {
+		teamDisplayName: draft.displayName,
+		...safeDraft,
+	});
+	return {
+		finishDigest: preview.finishDigest,
+		accessDeltaDigest: preview.accessDeltaDigest,
+		viewerAccessDeltaDigest: viewerAccessDeltaDigest(accessDelta),
+		accessDelta,
 	};
 }
 
@@ -1093,16 +1023,40 @@ function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): 
 	return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
 }
 
-function mutationResponse(draft: LegacyTeamSetupDraftView): LegacyTeamSetupMutationResponseV1 {
-	return {
+function detailResponse(
+	store: MemoryStore,
+	draft: LegacyTeamSetupDraftView,
+	candidate: LegacyTeamCandidateView = candidateFromDraft(draft),
+): LegacyTeamSetupDetailResponseV1 {
+	let unavailableReason: LegacyTeamSetupUnavailableReasonV1 | null = null;
+	let preview: ReturnType<typeof inspectLegacyTeamSetupActivation> | null = null;
+	if (draft.state !== "completed") {
+		try {
+			preview = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: draft.candidateRef,
+				attemptId: draft.attemptId,
+			});
+		} catch (error) {
+			const code = apiErrorCode(error);
+			if (code === "team_setup_failed") throw error;
+			if (code === "team_setup_projection_changed") unavailableReason = "team_setup_conflict";
+			else if (code !== "team_setup_incomplete") unavailableReason = code;
+		}
+	}
+	if (preview) requireBoundedAccessDelta(preview.accessDelta);
+	const safeDraft = viewerSafeDraft(store, draft);
+	const safePreview = preview ? viewerSafePreview(draft, safeDraft, preview) : null;
+	return projectLegacyTeamSetupView({
 		version: TEAM_SETUP_VERSION,
-		candidateRef: draft.candidateRef,
-		attemptId: draft.attemptId,
+		candidate: candidateSummaryForDraft(candidate, draft),
 		draftState: draft.state,
-		canFinish: draft.canFinish,
+		attemptId: draft.attemptId,
 		unresolvedDeviceCount: draft.unresolvedDeviceCount,
 		unresolvedProjectCount: draft.unresolvedProjectCount,
-	};
+		...safeDraft,
+		unavailableReason,
+		preview: safePreview,
+	});
 }
 
 function finishResponse(
@@ -1198,7 +1152,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 					),
 				})
 			) {
-				candidate = completedCandidateFromDraft(draft);
+				candidate = candidateFromDraft(draft);
 			} else {
 				const groups = await loadedCandidateSnapshots(candidateRef);
 				const candidateGroups = groups.filter(
@@ -1215,56 +1169,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			}
 			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 
-			let conflictState: LegacyTeamSetupActivationErrorCode | null = null;
-			let preview: ReturnType<typeof inspectLegacyTeamSetupActivation> | null = null;
-			if (draft.state !== "completed") {
-				try {
-					preview = inspectLegacyTeamSetupActivation(store.db, {
-						candidateRef,
-						attemptId: draft.attemptId,
-					});
-				} catch (error) {
-					const code = apiErrorCode(error);
-					if (code === "team_setup_failed") return c.json({ error: code }, 503);
-					preview = null;
-					conflictState = code;
-				}
-			}
-			if (preview) requireBoundedAccessDelta(preview.accessDelta);
-
-			const viewDraft = draft;
-			const safeDraft = viewerSafeDraft(store, viewDraft);
-			const responseBase = {
-				version: TEAM_SETUP_VERSION,
-				candidate: candidateSummaryForDraft(candidate, viewDraft),
-				attemptId: viewDraft.attemptId,
-				draftState: viewDraft.state,
-				unresolvedDeviceCount: viewDraft.unresolvedDeviceCount,
-				unresolvedProjectCount: viewDraft.unresolvedProjectCount,
-				...safeDraft,
-			};
-			if (!preview) {
-				const response = {
-					...responseBase,
-					canFinish: false,
-					conflictState,
-				} satisfies LegacyTeamSetupDetailResponseV1;
-				return c.json(response);
-			}
-			const accessDelta = viewerSafeAccessDelta(candidateRef, preview.accessDelta, {
-				teamDisplayName: viewDraft.displayName,
-				...safeDraft,
-			});
-			const response = {
-				...responseBase,
-				canFinish: true,
-				conflictState: null,
-				finishDigest: preview.finishDigest,
-				accessDeltaDigest: preview.accessDeltaDigest,
-				viewerAccessDeltaDigest: viewerAccessDeltaDigest(accessDelta),
-				accessDelta,
-			} satisfies LegacyTeamSetupDetailResponseV1;
-			return c.json(response);
+			return c.json(detailResponse(store, draft, candidate));
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1303,6 +1208,9 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			if (draft.attemptId !== attemptId) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
 			}
+			if (draft.state === "completed") {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
 			const device = draft.devices.find((item) => item.deviceRef === deviceRef);
 			if (!device) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 			const submittedExpectation = expectation as Record<string, unknown>;
@@ -1322,13 +1230,16 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			);
 			if (!target) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 			return c.json(
-				mutationResponse(
-					setLegacyTeamSetupDeviceAssignment(store.db, {
-						attemptId,
-						deviceRef,
-						targetIdentityId: target.identityId,
-						expectation: device.expectation,
-					}),
+				projectMutationAtomically(
+					store,
+					() =>
+						setLegacyTeamSetupDeviceAssignment(store.db, {
+							attemptId,
+							deviceRef,
+							targetIdentityId: target.identityId,
+							expectation: device.expectation,
+						}),
+					(draft) => detailResponse(store, draft),
 				),
 			);
 		} catch (error) {
@@ -1367,6 +1278,9 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			if (draft.attemptId !== attemptId) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
 			}
+			if (draft.state === "completed") {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
 			const device = draft.devices.find((item) => item.deviceRef === deviceRef);
 			if (!device) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
@@ -1379,12 +1293,15 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				return c.json({ error: "team_setup_assignment_changed" as const }, 409);
 			}
 			return c.json(
-				mutationResponse(
-					setLegacyTeamSetupDeviceDecision(store.db, {
-						attemptId,
-						deviceRef,
-						decision: decision as "included" | "excluded" | "removed",
-					}),
+				projectMutationAtomically(
+					store,
+					() =>
+						setLegacyTeamSetupDeviceDecision(store.db, {
+							attemptId,
+							deviceRef,
+							decision: decision as "included" | "excluded" | "removed",
+						}),
+					(draft) => detailResponse(store, draft),
 				),
 			);
 		} catch (error) {
@@ -1414,11 +1331,18 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			if (draft.attemptId !== attemptId) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
 			}
+			if (draft.state === "completed") {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
 			if (!draft.devices.some((item) => item.deviceRef === deviceRef)) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 			}
 			return c.json(
-				mutationResponse(clearLegacyTeamSetupDeviceDecision(store.db, { attemptId, deviceRef })),
+				projectMutationAtomically(
+					store,
+					() => clearLegacyTeamSetupDeviceDecision(store.db, { attemptId, deviceRef }),
+					(draft) => detailResponse(store, draft),
+				),
 			);
 		} catch (error) {
 			const code = apiErrorCode(error);
@@ -1452,6 +1376,9 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			if (draft.attemptId !== attemptId) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
 			}
+			if (draft.state === "completed") {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
 			const project = draft.projects.find((item) => item.projectRef === projectRef);
 			if (!project) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
@@ -1465,12 +1392,15 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			);
 			if (!target) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 			return c.json(
-				mutationResponse(
-					setLegacyTeamSetupProjectMapping(store.db, {
-						attemptId,
-						projectRef,
-						resolvedProjectIdentity: target.projectIdentity,
-					}),
+				projectMutationAtomically(
+					store,
+					() =>
+						setLegacyTeamSetupProjectMapping(store.db, {
+							attemptId,
+							projectRef,
+							resolvedProjectIdentity: target.projectIdentity,
+						}),
+					(draft) => detailResponse(store, draft),
 				),
 			);
 		} catch (error) {
@@ -1488,9 +1418,18 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		if (!parsed.ok || !hasExactKeys(parsed.value, [])) {
 			return c.json({ error: "team_setup_incomplete" as const }, 400);
 		}
+		let store: MemoryStore;
+		try {
+			store = options.getStore();
+		} catch (error) {
+			const code = apiErrorCode(error);
+			return c.json({ error: code }, errorStatus(code));
+		}
 		let groups: LegacyTeamConfiguredGroupSnapshot[];
 		try {
-			groups = await loadedCandidateSnapshots(candidateRef);
+			groups = await loadMutableCandidateSnapshots(store, candidateRef, () =>
+				loadedCandidateSnapshots(candidateRef),
+			);
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1503,14 +1442,20 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 		}
 		try {
-			const store = options.getStore();
 			return c.json(
-				mutationResponse(
-					refreshLegacyTeamCandidate(
-						store.db,
-						{ projection: projectionOptions(store), groups },
-						candidateRef,
-					),
+				projectMutationAtomically(
+					store,
+					() => {
+						if (getLegacyTeamSetupDraft(store.db, candidateRef)?.state === "completed") {
+							throw new Error("team_setup_confirmation_stale");
+						}
+						return refreshLegacyTeamCandidate(
+							store.db,
+							{ projection: projectionOptions(store), groups },
+							candidateRef,
+						);
+					},
+					(draft) => detailResponse(store, draft),
 				),
 			);
 		} catch (error) {


### PR DESCRIPTION
## Description
Adopts the closed Team setup view in Viewer routes. Detail and every mutation now return one complete authoritative view, completed attempts reject mutation, and route tests cover the full wire response.

Part 2 of codemem-752i.3.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Viewer route and integration tests
- [x] `pnpm run tsc`
- [x] `pnpm run lint`

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced