### PR TITLE
refactor(ui): isolate Team setup effects and focus

### DIFF
--- a/packages/ui/src/tabs/legacy-team-setup-effects.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-effects.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { LegacyTeamSetupApiError, type LegacyTeamSetupViewV1 } from "../lib/api";
+import {
+	createSetupEffectRunner,
+	type SetupEffect,
+	type SetupEffectDependencies,
+} from "./legacy-team-setup-effects";
+
+const view = { state: "reviewing" } as LegacyTeamSetupViewV1;
+
+function dependencies(overrides: Partial<SetupEffectDependencies> = {}): SetupEffectDependencies {
+	return {
+		clearDecision: vi.fn(),
+		finish: vi.fn(),
+		loadDetail: vi.fn().mockResolvedValue(view),
+		onCompleted: vi.fn(),
+		refreshCandidate: vi.fn().mockResolvedValue(view),
+		saveAssignment: vi.fn(),
+		saveDecision: vi.fn(),
+		saveProjectMapping: vi.fn(),
+		...overrides,
+	} as SetupEffectDependencies;
+}
+
+function effect(input: Partial<SetupEffect> & Pick<SetupEffect, "kind">): SetupEffect {
+	return {
+		candidateRef: "candidate",
+		generation: 7,
+		id: `7:${input.kind}`,
+		status: "running",
+		...input,
+	} as SetupEffect;
+}
+
+describe("legacy Team setup effect runner", () => {
+	it("returns authoritative load outcomes with the originating generation", async () => {
+		const deps = dependencies();
+		const outcome = await createSetupEffectRunner(deps)(
+			effect({ kind: "load", refresh: false, focusOnOutcome: true }),
+		);
+
+		expect(deps.loadDetail).toHaveBeenCalledWith("candidate");
+		expect(outcome).toMatchObject({
+			status: "success",
+			generation: 7,
+			kind: "load",
+			view,
+		});
+	});
+
+	it("recovers changed mutation failures with a fresh authoritative view", async () => {
+		const cause = new LegacyTeamSetupApiError(409, "team_setup_assignment_changed");
+		const deps = dependencies({ saveDecision: vi.fn().mockRejectedValue(cause) });
+		const outcome = await createSetupEffectRunner(deps)(
+			effect({
+				kind: "decide_device",
+				deviceRef: "device",
+				input: { attemptId: "attempt", decision: "excluded" },
+			}),
+		);
+
+		expect(deps.loadDetail).toHaveBeenCalledWith("candidate");
+		expect(outcome).toMatchObject({ status: "failure", cause, recoveredView: view });
+	});
+
+	it("does not recover ordinary item failures by reloading", async () => {
+		const cause = new Error("safe test failure");
+		const deps = dependencies({ saveDecision: vi.fn().mockRejectedValue(cause) });
+		const outcome = await createSetupEffectRunner(deps)(
+			effect({
+				kind: "decide_device",
+				deviceRef: "device",
+				input: { attemptId: "attempt", decision: "excluded" },
+			}),
+		);
+
+		expect(deps.loadDetail).not.toHaveBeenCalled();
+		expect(outcome).toMatchObject({ status: "failure", cause });
+		expect(outcome).not.toHaveProperty("recoveredView");
+	});
+
+	it("coalesces concurrent completion refreshes for one attempt", async () => {
+		let release = () => undefined;
+		const pending = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const deps = dependencies({ onCompleted: vi.fn(() => pending) });
+		const run = createSetupEffectRunner(deps);
+		const first = run(effect({ kind: "completion_refresh", id: "7:first", attemptId: "attempt" }));
+		const second = run(
+			effect({ kind: "completion_refresh", id: "7:second", attemptId: "attempt" }),
+		);
+		await Promise.resolve();
+
+		expect(deps.onCompleted).toHaveBeenCalledOnce();
+		release();
+		await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+	});
+});

--- a/packages/ui/src/tabs/legacy-team-setup-effects.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-effects.ts
@@ -1,0 +1,207 @@
+import type * as api from "../lib/api";
+import {
+	LegacyTeamSetupApiError,
+	type LegacyTeamSetupErrorCode,
+	type LegacyTeamSetupViewV1,
+} from "../lib/api";
+
+export interface SetupEffectDependencies {
+	clearDecision: typeof api.clearLegacyTeamSetupDecision;
+	finish: typeof api.finishLegacyTeamSetup;
+	loadDetail: typeof api.loadLegacyTeamSetupDetail;
+	onCompleted: () => void | Promise<void>;
+	refreshCandidate: typeof api.refreshLegacyTeamSetupCandidate;
+	saveAssignment: typeof api.saveLegacyTeamSetupAssignment;
+	saveDecision: typeof api.saveLegacyTeamSetupDecision;
+	saveProjectMapping: typeof api.saveLegacyTeamSetupProjectMapping;
+}
+
+interface SetupEffectBase {
+	generation: number;
+	id: string;
+	status: "pending" | "running";
+}
+
+export type SetupEffect =
+	| (SetupEffectBase & {
+			kind: "load";
+			candidateRef: string;
+			refresh: boolean;
+			focusOnOutcome: boolean;
+	  })
+	| (SetupEffectBase & {
+			kind: "assign_device";
+			candidateRef: string;
+			deviceRef: string;
+			input: Parameters<typeof api.saveLegacyTeamSetupAssignment>[2];
+	  })
+	| (SetupEffectBase & {
+			kind: "decide_device";
+			candidateRef: string;
+			deviceRef: string;
+			input: Parameters<typeof api.saveLegacyTeamSetupDecision>[2];
+	  })
+	| (SetupEffectBase & {
+			kind: "clear_device";
+			candidateRef: string;
+			deviceRef: string;
+			input: Parameters<typeof api.clearLegacyTeamSetupDecision>[2];
+	  })
+	| (SetupEffectBase & {
+			kind: "map_project";
+			candidateRef: string;
+			projectRef: string;
+			input: Parameters<typeof api.saveLegacyTeamSetupProjectMapping>[2];
+	  })
+	| (SetupEffectBase & { kind: "refresh"; candidateRef: string })
+	| (SetupEffectBase & {
+			kind: "finish";
+			candidateRef: string;
+			attemptId: string;
+			input: Parameters<typeof api.finishLegacyTeamSetup>[1];
+	  })
+	| (SetupEffectBase & {
+			kind: "completion_refresh";
+			candidateRef: string;
+			attemptId: string;
+	  });
+
+export type SetupEffectInput = SetupEffect extends infer Effect
+	? Effect extends SetupEffect
+		? Omit<Effect, "generation" | "id" | "status">
+		: never
+	: never;
+
+export type SetupEffectOutcome =
+	| {
+			status: "success";
+			generation: number;
+			id: string;
+			kind: SetupEffect["kind"];
+			view?: LegacyTeamSetupViewV1;
+	  }
+	| {
+			status: "failure";
+			generation: number;
+			id: string;
+			kind: SetupEffect["kind"];
+			cause: unknown;
+			recoveredView?: LegacyTeamSetupViewV1;
+	  };
+
+export type SetupEffectRunner = (effect: SetupEffect) => Promise<SetupEffectOutcome>;
+
+export function createSetupEffectRunner(dependencies: SetupEffectDependencies): SetupEffectRunner {
+	let completedRefresh: {
+		attemptId: string;
+		candidateRef: string;
+		promise: Promise<void>;
+	} | null = null;
+
+	return async (effect) => {
+		try {
+			const view = await execute(
+				effect,
+				dependencies,
+				() => completedRefresh,
+				(next) => {
+					completedRefresh = next;
+				},
+			);
+			return {
+				status: "success",
+				generation: effect.generation,
+				id: effect.id,
+				kind: effect.kind,
+				view,
+			};
+		} catch (cause) {
+			const recoveredView = await recover(effect, dependencies, cause);
+			return {
+				status: "failure",
+				generation: effect.generation,
+				id: effect.id,
+				kind: effect.kind,
+				cause,
+				...(recoveredView ? { recoveredView } : {}),
+			};
+		}
+	};
+}
+
+async function execute(
+	effect: SetupEffect,
+	dependencies: SetupEffectDependencies,
+	getCompletedRefresh: () => {
+		attemptId: string;
+		candidateRef: string;
+		promise: Promise<void>;
+	} | null,
+	setCompletedRefresh: (
+		value: { attemptId: string; candidateRef: string; promise: Promise<void> } | null,
+	) => void,
+): Promise<LegacyTeamSetupViewV1 | undefined> {
+	switch (effect.kind) {
+		case "load":
+			return effect.refresh
+				? dependencies.refreshCandidate(effect.candidateRef)
+				: dependencies.loadDetail(effect.candidateRef);
+		case "assign_device":
+			return dependencies.saveAssignment(effect.candidateRef, effect.deviceRef, effect.input);
+		case "decide_device":
+			return dependencies.saveDecision(effect.candidateRef, effect.deviceRef, effect.input);
+		case "clear_device":
+			return dependencies.clearDecision(effect.candidateRef, effect.deviceRef, effect.input);
+		case "map_project":
+			return dependencies.saveProjectMapping(effect.candidateRef, effect.projectRef, effect.input);
+		case "refresh":
+			return dependencies.refreshCandidate(effect.candidateRef);
+		case "finish":
+			await dependencies.finish(effect.candidateRef, effect.input);
+			return undefined;
+		case "completion_refresh": {
+			const current = getCompletedRefresh();
+			if (current?.attemptId === effect.attemptId && current.candidateRef === effect.candidateRef) {
+				await current.promise;
+				return undefined;
+			}
+			const promise = Promise.resolve().then(() => dependencies.onCompleted());
+			setCompletedRefresh({
+				attemptId: effect.attemptId,
+				candidateRef: effect.candidateRef,
+				promise,
+			});
+			try {
+				await promise;
+			} finally {
+				if (getCompletedRefresh()?.promise === promise) setCompletedRefresh(null);
+			}
+			return undefined;
+		}
+		default: {
+			const exhaustive: never = effect;
+			throw new Error(`Unhandled Team setup effect: ${String(exhaustive)}`);
+		}
+	}
+}
+
+async function recover(
+	effect: SetupEffect,
+	dependencies: SetupEffectDependencies,
+	cause: unknown,
+): Promise<LegacyTeamSetupViewV1 | undefined> {
+	if (effect.kind === "load" || effect.kind === "completion_refresh") return undefined;
+	if (!(cause instanceof LegacyTeamSetupApiError) || !isChangedStateCode(cause.errorCode)) {
+		return undefined;
+	}
+	return dependencies.loadDetail(effect.candidateRef).catch(() => undefined);
+}
+
+export function isChangedStateCode(code: LegacyTeamSetupErrorCode): boolean {
+	return [
+		"team_setup_roster_changed",
+		"team_setup_assignment_changed",
+		"team_setup_conflict",
+		"team_setup_confirmation_stale",
+	].includes(code);
+}

--- a/packages/ui/src/tabs/legacy-team-setup-focus.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-focus.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { planBlockedFocus, planLoadFocus, planStepFocus } from "./legacy-team-setup-focus";
+
+describe("legacy Team setup focus planning", () => {
+	it("targets step headings for explicit navigation", () => {
+		expect(planStepFocus(1, "projects")).toEqual({
+			id: 1,
+			targetId: "legacy-team-setup-step-projects",
+		});
+	});
+
+	it("targets the first unresolved row when navigation is blocked", () => {
+		expect(planBlockedFocus(2, "devices", 3)).toEqual({
+			id: 2,
+			targetId: "legacy-team-device-row-3",
+		});
+	});
+
+	it("falls back to the blocked step heading when no unresolved row is found", () => {
+		expect(planBlockedFocus(3, "projects", -1)).toEqual({
+			id: 3,
+			targetId: "legacy-team-setup-step-projects",
+		});
+	});
+
+	it("targets the visible recovery control", () => {
+		expect(planLoadFocus(3, { hasError: true, recovery: true, step: "devices" })).toEqual({
+			id: 3,
+			targetId: "legacy-team-setup-refresh",
+		});
+		expect(planLoadFocus(4, { hasError: true, step: "devices" })).toEqual({
+			id: 4,
+			targetId: "legacy-team-setup-retry",
+		});
+	});
+});

--- a/packages/ui/src/tabs/legacy-team-setup-focus.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-focus.ts
@@ -1,0 +1,38 @@
+export interface SetupFocusPlan {
+	id: number;
+	targetId: string;
+}
+
+export function planStepFocus(id: number, step: string): SetupFocusPlan {
+	return { id, targetId: `legacy-team-setup-step-${step}` };
+}
+
+export function planBlockedFocus(
+	id: number,
+	step: "devices" | "projects",
+	unresolvedIndex: number,
+): SetupFocusPlan {
+	const row = step === "devices" ? "legacy-team-device-row" : "legacy-team-project-row";
+	return planTargetFocus(
+		id,
+		unresolvedIndex >= 0 ? `${row}-${unresolvedIndex}` : `legacy-team-setup-step-${step}`,
+	);
+}
+
+export function planLoadFocus(
+	id: number,
+	input: { hasError: boolean; recovery?: boolean; step: string },
+): SetupFocusPlan {
+	return planTargetFocus(
+		id,
+		input.recovery
+			? "legacy-team-setup-refresh"
+			: input.hasError
+				? "legacy-team-setup-retry"
+				: `legacy-team-setup-step-${input.step}`,
+	);
+}
+
+function planTargetFocus(id: number, targetId: string): SetupFocusPlan {
+	return { id, targetId };
+}


### PR DESCRIPTION
## Description
Extracts generation-bound Team setup effect execution and pure focus planning from the dialog. Changed-state mutation failures recover through authoritative detail, concurrent completion refreshes coalesce, and focus targets are deterministic.

Part 1 of codemem-752i.4.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Direct effect and focus tests
- [x] `pnpm run tsc`
- [x] `pnpm run lint`

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced