### PR TITLE
refactor(ui): model Team setup as reducer state

### DIFF
--- a/packages/ui/src/tabs/legacy-team-setup-session.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.test.ts
@@ -1,0 +1,681 @@
+import { describe, expect, it } from "vitest";
+import { LegacyTeamSetupApiError, type LegacyTeamSetupViewV1 } from "../lib/api";
+import {
+	createSetupSessionState,
+	errorForItem,
+	globalError,
+	isEditable,
+	type OpenSetupSessionState,
+	reduceSetupSession,
+	type SetupSessionEvent,
+	type SetupSessionState,
+} from "./legacy-team-setup-session";
+
+function view(
+	overrides: Partial<Extract<LegacyTeamSetupViewV1, { state: "reviewing" }>> = {},
+): LegacyTeamSetupViewV1 {
+	return {
+		version: 1,
+		state: "reviewing",
+		candidate: {
+			candidateRef: "candidate-a",
+			displayName: "Example Team",
+			status: "in_progress",
+			deviceCount: 2,
+			projectCount: 1,
+			unresolvedDeviceCount: 1,
+			unresolvedProjectCount: 1,
+		},
+		attemptId: "attempt-a",
+		unresolvedDeviceCount: 1,
+		unresolvedProjectCount: 1,
+		devices: ["device-a", "device-b"].map((deviceRef) => ({
+			deviceRef,
+			displayName: deviceRef,
+			enabled: true,
+			existingIdentityRef: null,
+			suggestedIdentityRef: null,
+			verifiedEvidenceKind: null,
+			decision: "unresolved" as const,
+			targetIdentityRef: null,
+			expectation: { kind: "absent" as const },
+			actions: {
+				assignIdentity: { enabled: true, blockedReason: null },
+				include: { enabled: false, blockedReason: "assignment_required" },
+				exclude: { enabled: true, blockedReason: null },
+				remove: { enabled: false, blockedReason: "device_active" },
+				clearDecision: { enabled: false, blockedReason: "decision_unresolved" },
+			},
+		})),
+		projects: [
+			{
+				projectRef: "project-a",
+				displayName: "Project A",
+				resolution: "unresolved",
+				canonicalProjectRef: null,
+				resolvedProjectRef: null,
+				mappingChoices: [],
+				actions: { map: { enabled: false, blockedReason: "mapping_unavailable" } },
+			},
+		],
+		identityChoices: [],
+		actions: {
+			refresh: { enabled: true, blockedReason: null },
+			finish: { enabled: false, blockedReason: "setup_incomplete" },
+		},
+		...overrides,
+	};
+}
+
+function open(): OpenSetupSessionState {
+	const state = reduceSetupSession(createSetupSessionState(), {
+		type: "open",
+		candidateRef: "candidate-a",
+	});
+	if (state.status !== "open") throw new Error("expected open session");
+	return state;
+}
+
+function readyView(): LegacyTeamSetupViewV1 {
+	return {
+		...view({ unresolvedDeviceCount: 0, unresolvedProjectCount: 0 }),
+		state: "ready_to_finish",
+		finishDigest: "finish",
+		accessDeltaDigest: "access",
+		viewerAccessDeltaDigest: "viewer",
+		accessDelta: {
+			teamChanges: [],
+			membershipChanges: [],
+			projectChanges: [],
+			recipientChanges: [],
+			deviceAccessChanges: [],
+		},
+		actions: {
+			refresh: { enabled: true, blockedReason: null },
+			finish: { enabled: true, blockedReason: null },
+		},
+	} as LegacyTeamSetupViewV1;
+}
+
+function loaded(current = open(), nextView = view()): OpenSetupSessionState {
+	const command = current.commands[0];
+	if (!command) throw new Error("expected load command");
+	const state = reduceSetupSession(current, {
+		type: "effect_outcome",
+		outcome: {
+			status: "success",
+			generation: command.generation,
+			id: command.id,
+			kind: command.kind,
+			view: nextView,
+		},
+	});
+	if (state.status !== "open") throw new Error("expected open loaded session");
+	return state;
+}
+
+describe("legacy Team setup session reducer", () => {
+	it("opens with a generation-bound load command", () => {
+		const state = open();
+
+		expect(state.generation).toBe(1);
+		expect(state.commands).toEqual([
+			expect.objectContaining({
+				kind: "load",
+				candidateRef: "candidate-a",
+				generation: 1,
+				status: "pending",
+			}),
+		]);
+	});
+
+	it("discards an outcome from an older dialog generation", () => {
+		const first = open();
+		const oldCommand = first.commands[0];
+		if (!oldCommand) throw new Error("expected old command");
+		const second = reduceSetupSession(first, { type: "open", candidateRef: "candidate-b" });
+		const result = reduceSetupSession(second, {
+			type: "effect_outcome",
+			outcome: {
+				status: "success",
+				generation: oldCommand.generation,
+				id: oldCommand.id,
+				kind: oldCommand.kind,
+				view: view(),
+			},
+		});
+
+		expect(result).toBe(second);
+	});
+
+	it("applies authoritative load state and plans the unresolved step", () => {
+		const state = loaded();
+
+		expect(state.view?.state).toBe("reviewing");
+		expect(state.step).toBe("devices");
+		expect(state.commands).toEqual([]);
+	});
+
+	it("records Projects as visited when blocked navigation redirects there", () => {
+		const state = loaded();
+		const redirected = reduceSetupSession(state, {
+			type: "blocked_navigation",
+			step: "projects",
+			message: "Resolve Projects first.",
+		});
+
+		expect(redirected).toMatchObject({
+			step: "projects",
+			projectsVisitedAttemptId: "attempt-a",
+		});
+	});
+
+	it("does not expose completed as an interactive navigation destination", () => {
+		const state = loaded();
+		const fabricated = { type: "navigate", step: "completed" } as unknown as SetupSessionEvent;
+
+		expect(reduceSetupSession(state, fabricated)).toBe(state);
+	});
+
+	it("preserves the open session while a mutation is active", () => {
+		const mutation = reduceSetupSession(loaded(), {
+			type: "decide_device",
+			deviceRef: "device-a",
+			decision: "excluded",
+		});
+
+		expect(reduceSetupSession(mutation, { type: "close" })).toBe(mutation);
+		expect(reduceSetupSession(mutation, { type: "open", candidateRef: "candidate-b" })).toBe(
+			mutation,
+		);
+	});
+
+	it("preserves the open session while an authoritative refresh is active", () => {
+		const refresh = reduceSetupSession(loaded(), { type: "refresh" });
+
+		expect(reduceSetupSession(refresh, { type: "close" })).toBe(refresh);
+		expect(reduceSetupSession(refresh, { type: "open", candidateRef: "candidate-b" })).toBe(
+			refresh,
+		);
+	});
+
+	it("replaces the session while an ordinary read-only load is pending", () => {
+		const loading = open();
+
+		expect(reduceSetupSession(loading, { type: "close" })).toMatchObject({
+			status: "closed",
+		});
+	});
+
+	it("scopes an ordinary mutation failure to one device", () => {
+		let state: SetupSessionState = loaded();
+		state = reduceSetupSession(state, {
+			type: "decide_device",
+			deviceRef: "device-a",
+			decision: "excluded",
+		});
+		if (state.status !== "open") throw new Error("expected open mutation session");
+		expect(state.message).toBe("Saving the decision for device-a.");
+		const command = state.commands[0];
+		if (!command) throw new Error("expected mutation command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new Error("private failure"),
+			},
+		});
+		if (state.status !== "open") throw new Error("expected open failed session");
+
+		expect(errorForItem(state, "device", "device-a")?.message).toContain("could not be saved");
+		expect(errorForItem(state, "device", "device-b")).toBeNull();
+		expect(
+			reduceSetupSession(state, {
+				type: "decide_device",
+				deviceRef: "device-b",
+				decision: "excluded",
+			}),
+		).toMatchObject({ commands: [expect.objectContaining({ deviceRef: "device-b" })] });
+	});
+
+	it("ignores device mutations while an authoritative refresh is running", () => {
+		const refreshing = reduceSetupSession(loaded(), { type: "refresh" });
+		if (refreshing.status !== "open") throw new Error("expected open refresh session");
+
+		expect(refreshing.commands).toEqual([expect.objectContaining({ kind: "refresh" })]);
+		expect(
+			reduceSetupSession(refreshing, {
+				type: "decide_device",
+				deviceRef: "device-a",
+				decision: "excluded",
+			}),
+		).toBe(refreshing);
+	});
+
+	it("ignores Project mutations while an authoritative refresh is running", () => {
+		const current = view();
+		const project = current.projects[0];
+		if (!project) throw new Error("expected project");
+		const state = loaded(open(), {
+			...current,
+			projects: [
+				{
+					...project,
+					mappingChoices: [{ resolvedProjectRef: "resolved-project-a", displayName: "Project A" }],
+					actions: { map: { enabled: true, blockedReason: null } },
+				},
+			],
+		});
+		const refreshing = reduceSetupSession(state, { type: "refresh" });
+		if (refreshing.status !== "open") throw new Error("expected open refresh session");
+
+		expect(
+			reduceSetupSession(refreshing, {
+				type: "map_project",
+				projectRef: "project-a",
+				resolvedProjectRef: "resolved-project-a",
+			}),
+		).toBe(refreshing);
+	});
+
+	it("announces a Project mapping while it is being saved", () => {
+		const current = view();
+		const project = current.projects[0];
+		if (!project) throw new Error("expected project");
+		const state = loaded(open(), {
+			...current,
+			projects: [
+				{
+					...project,
+					mappingChoices: [{ resolvedProjectRef: "resolved-project-a", displayName: "Project A" }],
+					actions: { map: { enabled: true, blockedReason: null } },
+				},
+			],
+		});
+		const saving = reduceSetupSession(state, {
+			type: "map_project",
+			projectRef: "project-a",
+			resolvedProjectRef: "resolved-project-a",
+		});
+
+		expect(saving).toMatchObject({ message: "Saving the mapping for Project A." });
+	});
+
+	it("ignores refresh when the authoritative action gate is disabled", () => {
+		const current = view();
+		const completed = loaded(open(), {
+			...current,
+			state: "completed",
+			actions: {
+				...current.actions,
+				refresh: { enabled: false, blockedReason: "setup_completed" },
+			},
+		} as LegacyTeamSetupViewV1);
+
+		expect(reduceSetupSession(completed, { type: "refresh" })).toBe(completed);
+	});
+
+	it("ignores refresh while an item mutation is running", () => {
+		const mutation = reduceSetupSession(loaded(), {
+			type: "decide_device",
+			deviceRef: "device-a",
+			decision: "excluded",
+		});
+
+		expect(reduceSetupSession(mutation, { type: "refresh" })).toBe(mutation);
+	});
+
+	it("ignores retry and a second item mutation while an item mutation is active", () => {
+		const mutation = reduceSetupSession(loaded(), {
+			type: "decide_device",
+			deviceRef: "device-a",
+			decision: "excluded",
+		});
+
+		expect(reduceSetupSession(mutation, { type: "retry" })).toBe(mutation);
+		expect(
+			reduceSetupSession(mutation, {
+				type: "decide_device",
+				deviceRef: "device-b",
+				decision: "excluded",
+			}),
+		).toBe(mutation);
+	});
+
+	it("treats roster outages from item mutations as global recovery errors", () => {
+		let state: SetupSessionState = reduceSetupSession(loaded(), {
+			type: "decide_device",
+			deviceRef: "device-a",
+			decision: "excluded",
+		});
+		if (state.status !== "open") throw new Error("expected open mutation session");
+		const command = state.commands[0];
+		if (!command) throw new Error("expected mutation command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new LegacyTeamSetupApiError(503, "team_setup_roster_unavailable"),
+			},
+		});
+		if (state.status !== "open") throw new Error("expected open failed session");
+
+		expect(globalError(state)).toMatchObject({ scope: { kind: "global" } });
+		expect(errorForItem(state, "device", "device-a")).toBeNull();
+		expect(
+			reduceSetupSession(state, {
+				type: "decide_device",
+				deviceRef: "device-b",
+				decision: "excluded",
+			}),
+		).toBe(state);
+	});
+
+	it("prioritizes global refresh recovery and preserves it after a transient failure", () => {
+		let state: OpenSetupSessionState = {
+			...loaded(),
+			errors: [
+				{ scope: { kind: "device", itemRef: "device-a" }, message: "item", retry: "load" },
+				{ scope: { kind: "global" }, message: "global", retry: "refresh" },
+			],
+		};
+		state = reduceSetupSession(state, { type: "retry" }) as OpenSetupSessionState;
+		const command = state.commands[0];
+		if (command?.kind !== "load") throw new Error("expected recovery load");
+		expect(command.refresh).toBe(true);
+
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new Error("temporary failure"),
+			},
+		}) as OpenSetupSessionState;
+		expect(globalError(state)?.retry).toBe("refresh");
+	});
+
+	it("preserves refresh recovery after an explicit refresh fails", () => {
+		let state = reduceSetupSession(loaded(), { type: "refresh" });
+		if (state.status !== "open") throw new Error("expected refresh session");
+		const command = state.commands[0];
+		if (command?.kind !== "refresh") throw new Error("expected refresh command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new Error("temporary failure"),
+			},
+		});
+		if (state.status !== "open") throw new Error("expected failed refresh session");
+
+		expect(globalError(state)?.retry).toBe("refresh");
+	});
+
+	it("restores failed unavailable recovery focus to the refresh control", () => {
+		const unavailable = {
+			...view(),
+			state: "unavailable",
+			unavailableReason: "team_setup_roster_changed",
+			actions: {
+				refresh: { enabled: true, blockedReason: null },
+				finish: { enabled: false, blockedReason: "setup_unavailable" },
+			},
+		} as LegacyTeamSetupViewV1;
+		let state: SetupSessionState = reduceSetupSession(loaded(open(), unavailable), {
+			type: "retry",
+		});
+		if (state.status !== "open") throw new Error("expected recovery session");
+		const command = state.commands[0];
+		if (command?.kind !== "load") throw new Error("expected recovery load");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new Error("temporary failure"),
+			},
+		});
+
+		expect(state).toMatchObject({
+			focus: { targetId: "legacy-team-setup-refresh" },
+		});
+	});
+
+	it("preserves the session while unavailable recovery refresh is active", () => {
+		const unavailable = {
+			...view(),
+			state: "unavailable",
+			unavailableReason: "team_setup_roster_changed",
+			actions: {
+				refresh: { enabled: true, blockedReason: null },
+				finish: { enabled: false, blockedReason: "setup_unavailable" },
+			},
+		} as LegacyTeamSetupViewV1;
+		const recovery = reduceSetupSession(loaded(open(), unavailable), { type: "retry" });
+
+		expect(reduceSetupSession(recovery, { type: "close" })).toBe(recovery);
+		expect(reduceSetupSession(recovery, { type: "open", candidateRef: "candidate-b" })).toBe(
+			recovery,
+		);
+	});
+
+	it("blocks finish while global recovery is unresolved", () => {
+		const state: OpenSetupSessionState = {
+			...loaded(open(), readyView()),
+			errors: [{ scope: { kind: "global" }, message: "Reload required", retry: "load" }],
+		};
+
+		expect(reduceSetupSession(state, { type: "finish" })).toBe(state);
+	});
+
+	it("blocks finish while an item save error is unresolved", () => {
+		const state: OpenSetupSessionState = {
+			...loaded(open(), readyView()),
+			errors: [
+				{
+					scope: { kind: "device", itemRef: "device-a" },
+					message: "The device decision could not be saved.",
+					retry: "load",
+				},
+			],
+		};
+
+		expect(reduceSetupSession(state, { type: "finish" })).toBe(state);
+	});
+
+	it("unblocks finish after an authoritative refresh clears an item error", () => {
+		let state: SetupSessionState = {
+			...loaded(),
+			errors: [
+				{
+					scope: { kind: "device", itemRef: "device-a" },
+					message: "The device decision could not be saved.",
+					retry: "load",
+				},
+			],
+		};
+		state = reduceSetupSession(state, { type: "refresh" });
+		if (state.status !== "open") throw new Error("expected refresh session");
+		const command = state.commands[0];
+		if (command?.kind !== "refresh") throw new Error("expected refresh command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "success",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				view: readyView(),
+			},
+		});
+
+		expect(state).toMatchObject({ errors: [] });
+		expect(reduceSetupSession(state, { type: "finish" })).toMatchObject({
+			commands: [expect.objectContaining({ kind: "finish" })],
+		});
+	});
+
+	it("blocks finish resubmission after an ordinary finish failure", () => {
+		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
+		if (state.status !== "open") throw new Error("expected finish session");
+		const command = state.commands[0];
+		if (command?.kind !== "finish") throw new Error("expected finish command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new Error("temporary failure"),
+			},
+		});
+		if (state.status !== "open") throw new Error("expected failed finish session");
+
+		expect(globalError(state)).not.toBeNull();
+		expect(reduceSetupSession(state, { type: "finish" })).toBe(state);
+	});
+
+	it.each([
+		{ type: "decide_device", deviceRef: "device-a", decision: "included" },
+		{ type: "decide_device", deviceRef: "device-a", decision: "removed" },
+		{ type: "clear_device", deviceRef: "device-a" },
+	] as const)("ignores disabled device action $type", (event) => {
+		const state = loaded();
+
+		expect(reduceSetupSession(state, event)).toBe(state);
+	});
+
+	it("ignores a disabled device assignment", () => {
+		const current = view();
+		const firstDevice = current.devices[0];
+		if (!firstDevice) throw new Error("expected device");
+		const state = loaded(open(), {
+			...current,
+			devices: [
+				{
+					...firstDevice,
+					actions: {
+						...firstDevice.actions,
+						assignIdentity: { enabled: false, blockedReason: "assignment_unavailable" },
+					},
+				},
+				...current.devices.slice(1),
+			],
+		});
+
+		expect(
+			reduceSetupSession(state, {
+				type: "assign_device",
+				deviceRef: "device-a",
+				targetIdentityRef: "identity-a",
+			}),
+		).toBe(state);
+	});
+
+	it.each([
+		{ projectRef: "missing-project", resolvedProjectRef: "resolved-project-a" },
+		{ projectRef: "project-a", resolvedProjectRef: "resolved-project-a" },
+	] as const)("ignores unavailable Project mapping for $projectRef", (event) => {
+		const state = loaded();
+
+		expect(reduceSetupSession(state, { type: "map_project", ...event })).toBe(state);
+	});
+
+	it("ignores a Project mapping choice absent from the authoritative view", () => {
+		const current = view();
+		const project = current.projects[0];
+		if (!project) throw new Error("expected project");
+		const state = loaded(open(), {
+			...current,
+			projects: [
+				{
+					...project,
+					mappingChoices: [{ resolvedProjectRef: "resolved-project-a", displayName: "Project A" }],
+					actions: { map: { enabled: true, blockedReason: null } },
+				},
+			],
+		});
+
+		expect(
+			reduceSetupSession(state, {
+				type: "map_project",
+				projectRef: "project-a",
+				resolvedProjectRef: "resolved-project-b",
+			}),
+		).toBe(state);
+	});
+
+	it("never treats unavailable views as editable", () => {
+		const unavailable = {
+			...view(),
+			state: "unavailable",
+			unavailableReason: "team_setup_conflict",
+			actions: {
+				refresh: { enabled: true, blockedReason: null },
+				finish: { enabled: false, blockedReason: "setup_unavailable" },
+			},
+		} as LegacyTeamSetupViewV1;
+
+		expect(isEditable(unavailable)).toBe(false);
+	});
+
+	it("queues completion refresh exactly once after finish", () => {
+		let state: SetupSessionState = loaded(open(), readyView());
+		state = reduceSetupSession(state, { type: "finish" });
+		if (state.status !== "open") throw new Error("expected finish session");
+		const finish = state.commands[0];
+		if (!finish) throw new Error("expected finish command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "success",
+				generation: finish.generation,
+				id: finish.id,
+				kind: finish.kind,
+			},
+		});
+		if (state.status !== "open") throw new Error("expected completed session");
+
+		expect(state.step).toBe("completed");
+		const completionRefresh = state.commands.find(
+			(command) => command.kind === "completion_refresh",
+		);
+		if (!completionRefresh) throw new Error("expected completion refresh command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "success",
+				generation: completionRefresh.generation,
+				id: completionRefresh.id,
+				kind: completionRefresh.kind,
+			},
+		});
+		if (state.status !== "open") throw new Error("expected settled completed session");
+		expect(state.commands).toEqual([]);
+		expect(reduceSetupSession(state, { type: "navigate", step: "devices" })).toBe(state);
+		expect(reduceSetupSession(state, { type: "retry" })).toBe(state);
+		expect(reduceSetupSession(state, { type: "finish" })).toBe(state);
+		expect(
+			reduceSetupSession(state, {
+				type: "decide_device",
+				deviceRef: "device-a",
+				decision: "excluded",
+			}),
+		).toBe(state);
+	});
+});

--- a/packages/ui/src/tabs/legacy-team-setup-session.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.ts
@@ -1,0 +1,716 @@
+import { LegacyTeamSetupApiError, type LegacyTeamSetupViewV1 } from "../lib/api";
+import type {
+	SetupEffect,
+	SetupEffectInput,
+	SetupEffectOutcome,
+} from "./legacy-team-setup-effects";
+import { isChangedStateCode } from "./legacy-team-setup-effects";
+import {
+	planBlockedFocus,
+	planLoadFocus,
+	planStepFocus,
+	type SetupFocusPlan,
+} from "./legacy-team-setup-focus";
+
+export type TeamSetupStep = "devices" | "projects" | "review" | "completed";
+type InteractiveTeamSetupStep = Exclude<TeamSetupStep, "completed">;
+export type SetupErrorScope =
+	| { kind: "load" }
+	| { kind: "global" }
+	| { kind: "device"; itemRef: string }
+	| { kind: "project"; itemRef: string };
+
+export interface SetupSessionError {
+	message: string;
+	retry: "load" | "refresh" | null;
+	scope: SetupErrorScope;
+}
+
+interface ClosedSetupSessionState {
+	status: "closed";
+	generation: number;
+}
+
+export interface OpenSetupSessionState {
+	status: "open";
+	generation: number;
+	candidateRef: string;
+	view: LegacyTeamSetupViewV1 | null;
+	step: TeamSetupStep;
+	projectsVisitedAttemptId: string | null;
+	commands: SetupEffect[];
+	nextCommandId: number;
+	errors: SetupSessionError[];
+	message: string;
+	focus: SetupFocusPlan | null;
+	nextFocusId: number;
+}
+
+export type SetupSessionState = ClosedSetupSessionState | OpenSetupSessionState;
+
+export type SetupSessionEvent =
+	| { type: "open"; candidateRef: string }
+	| { type: "close" }
+	| { type: "close_blocked"; message: string }
+	| { type: "open_blocked"; message: string }
+	| { type: "navigate"; step: InteractiveTeamSetupStep }
+	| { type: "blocked_navigation"; step: "devices" | "projects"; message: string }
+	| { type: "retry" }
+	| { type: "refresh" }
+	| { type: "assign_device"; deviceRef: string; targetIdentityRef: string }
+	| {
+			type: "decide_device";
+			deviceRef: string;
+			decision: "included" | "excluded" | "removed";
+			targetIdentityRef?: string;
+	  }
+	| { type: "clear_device"; deviceRef: string }
+	| { type: "map_project"; projectRef: string; resolvedProjectRef: string }
+	| { type: "finish" }
+	| { type: "command_started"; id: string }
+	| { type: "effect_outcome"; outcome: SetupEffectOutcome }
+	| { type: "focus_applied"; id: number };
+
+const CHANGED_STATE_ERROR =
+	"Team setup changed since it was last reviewed. Reload the latest details to continue.";
+const ROSTER_UNAVAILABLE_ERROR =
+	"Team device details are temporarily unavailable. Check the coordinator connection and settings, then retry.";
+
+export function createSetupSessionState(): SetupSessionState {
+	return { status: "closed", generation: 0 };
+}
+
+export function reduceSetupSession(
+	state: SetupSessionState,
+	event: SetupSessionEvent,
+): SetupSessionState {
+	switch (event.type) {
+		case "open":
+			if (state.status === "open" && hasBlockingOperation(state)) return state;
+			return open(state.generation + 1, event.candidateRef);
+		case "close":
+			if (state.status === "open" && hasBlockingOperation(state)) return state;
+			return { status: "closed", generation: state.generation + 1 };
+		case "close_blocked":
+		case "open_blocked":
+			return state.status === "open" ? { ...state, message: event.message } : state;
+		case "navigate":
+			return navigate(state, event.step);
+		case "blocked_navigation":
+			return blockedNavigation(state, event.step, event.message);
+		case "retry":
+			return retry(state);
+		case "refresh":
+			return enqueueGlobal(state, "refresh", "Refreshing Team setup from the latest server state.");
+		case "assign_device":
+			return enqueueDevice(state, event, "assign_device");
+		case "decide_device":
+			return enqueueDevice(state, event, "decide_device");
+		case "clear_device":
+			return enqueueDevice(state, event, "clear_device");
+		case "map_project":
+			return enqueueProject(state, event);
+		case "finish":
+			return enqueueFinish(state);
+		case "command_started":
+			return mapCommand(state, event.id, (command) => ({ ...command, status: "running" }));
+		case "effect_outcome":
+			return outcome(state, event.outcome);
+		case "focus_applied":
+			return state.status === "open" && state.focus?.id === event.id
+				? { ...state, focus: null }
+				: state;
+		default: {
+			const exhaustive: never = event;
+			return exhaustive;
+		}
+	}
+}
+
+function open(generation: number, candidateRef: string): OpenSetupSessionState {
+	const state: OpenSetupSessionState = {
+		status: "open",
+		generation,
+		candidateRef,
+		view: null,
+		step: "devices",
+		projectsVisitedAttemptId: null,
+		commands: [],
+		nextCommandId: 1,
+		errors: [],
+		message: "",
+		focus: null,
+		nextFocusId: 1,
+	};
+	return append(state, {
+		kind: "load",
+		candidateRef,
+		refresh: false,
+		focusOnOutcome: false,
+	});
+}
+
+function navigate(state: SetupSessionState, step: TeamSetupStep): SetupSessionState {
+	if (state.status !== "open" || state.step === "completed" || step === "completed") return state;
+	const projectsVisitedAttemptId =
+		step === "projects" && state.view ? state.view.attemptId : state.projectsVisitedAttemptId;
+	return {
+		...state,
+		step,
+		projectsVisitedAttemptId,
+		focus: planStepFocus(state.nextFocusId, step),
+		nextFocusId: state.nextFocusId + 1,
+	};
+}
+
+function blockedNavigation(
+	state: SetupSessionState,
+	step: "devices" | "projects",
+	message: string,
+): SetupSessionState {
+	if (state.status !== "open" || state.step === "completed" || !state.view) return state;
+	const unresolvedIndex =
+		step === "devices"
+			? state.view.devices.findIndex((device) => device.decision === "unresolved")
+			: state.view.projects.findIndex((project) => project.resolution === "unresolved");
+	return {
+		...state,
+		step,
+		projectsVisitedAttemptId:
+			step === "projects" ? state.view.attemptId : state.projectsVisitedAttemptId,
+		message,
+		focus: planBlockedFocus(state.nextFocusId, step, unresolvedIndex),
+		nextFocusId: state.nextFocusId + 1,
+	};
+}
+
+function retry(state: SetupSessionState): SetupSessionState {
+	if (
+		state.status !== "open" ||
+		state.step === "completed" ||
+		hasGlobalOperation(state) ||
+		hasBlockingOperation(state)
+	)
+		return state;
+	const retryMode =
+		globalError(state)?.retry ?? state.errors.find((error) => error.retry)?.retry ?? "load";
+	return append(state, {
+		kind: "load",
+		candidateRef: state.candidateRef,
+		refresh: retryMode === "refresh",
+		focusOnOutcome: true,
+	});
+}
+
+function enqueueDevice(
+	state: SetupSessionState,
+	event: Extract<SetupSessionEvent, { type: "assign_device" | "decide_device" | "clear_device" }>,
+	kind: "assign_device" | "decide_device" | "clear_device",
+): SetupSessionState {
+	if (
+		state.status !== "open" ||
+		state.step === "completed" ||
+		!isEditable(state.view) ||
+		globalError(state) ||
+		hasGlobalOperation(state) ||
+		hasBlockingOperation(state)
+	) {
+		return state;
+	}
+	const device = state.view.devices.find((item) => item.deviceRef === event.deviceRef);
+	if (!device) return state;
+	const action =
+		event.type === "assign_device"
+			? device.actions.assignIdentity
+			: event.type === "clear_device"
+				? device.actions.clearDecision
+				: event.decision === "included"
+					? device.actions.include
+					: event.decision === "excluded"
+						? device.actions.exclude
+						: device.actions.remove;
+	if (!action.enabled) return state;
+	const base = { candidateRef: state.candidateRef, deviceRef: event.deviceRef };
+	const command =
+		kind === "assign_device" && event.type === "assign_device"
+			? {
+					kind,
+					...base,
+					input: {
+						attemptId: state.view.attemptId,
+						targetIdentityRef: event.targetIdentityRef,
+						expectation: device.expectation,
+					},
+				}
+			: kind === "clear_device" && event.type === "clear_device"
+				? { kind, ...base, input: { attemptId: state.view.attemptId } }
+				: event.type === "decide_device"
+					? {
+							kind: "decide_device" as const,
+							...base,
+							input:
+								event.decision === "included" && event.targetIdentityRef
+									? {
+											attemptId: state.view.attemptId,
+											decision: "included" as const,
+											expectedTargetIdentityRef: event.targetIdentityRef,
+										}
+									: {
+											attemptId: state.view.attemptId,
+											decision: event.decision as "excluded" | "removed",
+										},
+						}
+					: null;
+	if (!command) return state;
+	if (event.type === "decide_device" && event.decision === "included" && !event.targetIdentityRef) {
+		return state;
+	}
+	const pendingMessage =
+		event.type === "assign_device"
+			? `Saving the assignment for ${device.displayName}.`
+			: event.type === "clear_device"
+				? `Clearing the decision for ${device.displayName}.`
+				: `Saving the decision for ${device.displayName}.`;
+	return append(
+		clearScope(state, { kind: "device", itemRef: event.deviceRef }),
+		command,
+		pendingMessage,
+	);
+}
+
+function enqueueProject(
+	state: SetupSessionState,
+	event: Extract<SetupSessionEvent, { type: "map_project" }>,
+): SetupSessionState {
+	if (
+		state.status !== "open" ||
+		state.step === "completed" ||
+		!isEditable(state.view) ||
+		globalError(state) ||
+		hasGlobalOperation(state) ||
+		hasBlockingOperation(state)
+	) {
+		return state;
+	}
+	const project = state.view.projects.find((item) => item.projectRef === event.projectRef);
+	if (
+		!project?.actions.map.enabled ||
+		!project.mappingChoices.some((choice) => choice.resolvedProjectRef === event.resolvedProjectRef)
+	) {
+		return state;
+	}
+	return append(
+		clearScope(state, { kind: "project", itemRef: event.projectRef }),
+		{
+			kind: "map_project",
+			candidateRef: state.candidateRef,
+			projectRef: event.projectRef,
+			input: {
+				attemptId: state.view.attemptId,
+				resolvedProjectRef: event.resolvedProjectRef,
+			},
+		},
+		`Saving the mapping for ${project.displayName}.`,
+	);
+}
+
+function enqueueGlobal(
+	state: SetupSessionState,
+	kind: "refresh",
+	message: string,
+): SetupSessionState {
+	if (
+		state.status !== "open" ||
+		state.step === "completed" ||
+		!state.view?.actions.refresh.enabled ||
+		hasGlobalOperation(state) ||
+		hasBlockingOperation(state)
+	) {
+		return state;
+	}
+	return append(
+		clearScope(state, { kind: "global" }),
+		{
+			kind,
+			candidateRef: state.candidateRef,
+		},
+		message,
+	);
+}
+
+function enqueueFinish(state: SetupSessionState): SetupSessionState {
+	if (
+		state.status !== "open" ||
+		state.step === "completed" ||
+		state.view?.state !== "ready_to_finish" ||
+		state.commands.length ||
+		state.errors.length > 0
+	) {
+		return state;
+	}
+	return append(
+		clearScope(state, { kind: "global" }),
+		{
+			kind: "finish",
+			candidateRef: state.candidateRef,
+			attemptId: state.view.attemptId,
+			input: {
+				attemptId: state.view.attemptId,
+				finishDigest: state.view.finishDigest,
+				confirmedAccessDeltaDigest: state.view.accessDeltaDigest,
+				confirmedViewerAccessDeltaDigest: state.view.viewerAccessDeltaDigest,
+			},
+		},
+		"Finishing Team setup.",
+	);
+}
+
+function append(
+	state: OpenSetupSessionState,
+	command: SetupEffectInput,
+	message = state.message,
+): OpenSetupSessionState {
+	const id = `${state.generation}:${state.nextCommandId}`;
+	return {
+		...state,
+		commands: [
+			...state.commands,
+			{ ...command, generation: state.generation, id, status: "pending" } as SetupEffect,
+		],
+		nextCommandId: state.nextCommandId + 1,
+		message,
+	};
+}
+
+function outcome(state: SetupSessionState, result: SetupEffectOutcome): SetupSessionState {
+	if (state.status !== "open" || state.generation !== result.generation) return state;
+	const command = state.commands.find((item) => item.id === result.id);
+	if (!command) return state;
+	const withoutCommand = {
+		...state,
+		commands: state.commands.filter((item) => item.id !== result.id),
+	};
+	if (result.status === "failure") return failed(withoutCommand, command, result);
+	if (command.kind === "completion_refresh") {
+		return {
+			...withoutCommand,
+			message: "Team setup complete. Sharing and Projects are up to date.",
+		};
+	}
+	if (command.kind === "finish") return completed(withoutCommand, command.attemptId);
+	if (!result.view) return withoutCommand;
+	const cleared = clearCommandError(withoutCommand, command);
+	return applyView(
+		{ ...cleared, message: successMessage(command, state.view) },
+		result.view,
+		command.kind === "load" && command.focusOnOutcome,
+	);
+}
+
+function successMessage(command: SetupEffect, view: LegacyTeamSetupViewV1 | null): string {
+	if (command.kind === "refresh") return "Team setup refreshed.";
+	if (command.kind === "load") return "";
+	if ("deviceRef" in command) {
+		const name = view?.devices.find(
+			(device) => device.deviceRef === command.deviceRef,
+		)?.displayName;
+		return name ? `${name} saved.` : "Device saved.";
+	}
+	if ("projectRef" in command) {
+		const name = view?.projects.find(
+			(project) => project.projectRef === command.projectRef,
+		)?.displayName;
+		return name ? `${name} saved.` : "Project mapping saved.";
+	}
+	return "";
+}
+
+function failed(
+	state: OpenSetupSessionState,
+	command: SetupEffect,
+	result: Extract<SetupEffectOutcome, { status: "failure" }>,
+): OpenSetupSessionState {
+	if (command.kind === "completion_refresh") {
+		return {
+			...state,
+			message:
+				"Team setup complete. Sharing or Projects could not be refreshed; use that view's Refresh control.",
+		};
+	}
+	const recovered = result.recoveredView ? applyView(state, result.recoveredView, false) : state;
+	if (result.recoveredView?.state === "completed") return recovered;
+	const error = errorFor(command, result.cause);
+	const next = {
+		...recovered,
+		errors: [...clearScope(recovered, error.scope).errors, error],
+		message: "",
+	};
+	if (command.kind !== "load" || !command.focusOnOutcome) return next;
+	return {
+		...next,
+		focus: planLoadFocus(next.nextFocusId, {
+			hasError: true,
+			recovery: next.view?.state === "unavailable",
+			step: next.step,
+		}),
+		nextFocusId: next.nextFocusId + 1,
+	};
+}
+
+function applyView(
+	state: OpenSetupSessionState,
+	view: LegacyTeamSetupViewV1,
+	focusOnOutcome: boolean,
+): OpenSetupSessionState {
+	const step = initialStep(view, state.projectsVisitedAttemptId === view.attemptId);
+	const projectsVisitedAttemptId =
+		step === "projects" ? view.attemptId : state.projectsVisitedAttemptId;
+	const unavailableError: SetupSessionError[] =
+		view.state === "unavailable" && needsRecovery(view)
+			? [
+					{
+						scope: { kind: "global" } as const,
+						message: CHANGED_STATE_ERROR,
+						retry: "refresh" as const,
+					},
+				]
+			: view.state === "completed"
+				? []
+				: state.errors.filter((error) => {
+						if (error.scope.kind === "device") {
+							const itemRef = error.scope.itemRef;
+							return view.devices.some((device) => device.deviceRef === itemRef);
+						}
+						if (error.scope.kind === "project") {
+							const itemRef = error.scope.itemRef;
+							return view.projects.some((project) => project.projectRef === itemRef);
+						}
+						return false;
+					});
+	let next: OpenSetupSessionState = {
+		...state,
+		view,
+		step,
+		projectsVisitedAttemptId,
+		errors: unavailableError,
+		message:
+			view.state === "completed"
+				? "Team setup complete. Sharing and Projects are refreshing."
+				: state.message,
+	};
+	if (focusOnOutcome || step !== state.step) {
+		next = {
+			...next,
+			focus: planLoadFocus(next.nextFocusId, {
+				hasError: unavailableError.length > 0,
+				recovery: view.state === "unavailable",
+				step,
+			}),
+			nextFocusId: next.nextFocusId + 1,
+		};
+	}
+	if (view.state === "completed" && !hasCompletionRefresh(next, view.attemptId)) {
+		next = append(next, {
+			kind: "completion_refresh",
+			candidateRef: next.candidateRef,
+			attemptId: view.attemptId,
+		});
+	}
+	return next;
+}
+
+function completed(state: OpenSetupSessionState, attemptId: string): OpenSetupSessionState {
+	let next: OpenSetupSessionState = {
+		...state,
+		step: "completed" as const,
+		message: "Team setup complete. Sharing and Projects are refreshing.",
+		focus: planStepFocus(state.nextFocusId, "completed"),
+		nextFocusId: state.nextFocusId + 1,
+	};
+	if (!hasCompletionRefresh(next, attemptId)) {
+		next = append(next, {
+			kind: "completion_refresh",
+			candidateRef: next.candidateRef,
+			attemptId,
+		});
+	}
+	return next;
+}
+
+function errorFor(command: SetupEffect, cause: unknown): SetupSessionError {
+	const changed = cause instanceof LegacyTeamSetupApiError && isChangedStateCode(cause.errorCode);
+	const rosterUnavailable =
+		cause instanceof LegacyTeamSetupApiError && cause.errorCode === "team_setup_roster_unavailable";
+	const message = changed
+		? CHANGED_STATE_ERROR
+		: rosterUnavailable
+			? ROSTER_UNAVAILABLE_ERROR
+			: safeError(command.kind);
+	const retry = changed
+		? ("refresh" as const)
+		: command.kind === "refresh"
+			? ("refresh" as const)
+			: command.kind === "load"
+				? command.refresh
+					? ("refresh" as const)
+					: ("load" as const)
+				: ("load" as const);
+	if (
+		command.kind === "assign_device" ||
+		command.kind === "decide_device" ||
+		command.kind === "clear_device"
+	) {
+		return {
+			scope:
+				changed || rosterUnavailable
+					? { kind: "global" }
+					: { kind: "device", itemRef: command.deviceRef },
+			message,
+			retry,
+		};
+	}
+	if (command.kind === "map_project") {
+		return {
+			scope:
+				changed || rosterUnavailable
+					? { kind: "global" }
+					: { kind: "project", itemRef: command.projectRef },
+			message,
+			retry,
+		};
+	}
+	return { scope: command.kind === "load" ? { kind: "load" } : { kind: "global" }, message, retry };
+}
+
+function safeError(kind: SetupEffect["kind"]): string {
+	switch (kind) {
+		case "load":
+			return "Team setup details are temporarily unavailable. Retry to load the latest details.";
+		case "assign_device":
+		case "decide_device":
+		case "clear_device":
+			return "This device change could not be saved. Reload the latest details before trying again.";
+		case "map_project":
+			return "This Project mapping could not be saved. Reload the latest details before trying again.";
+		case "refresh":
+			return "Team setup could not be refreshed. Retry to load the latest server details.";
+		case "finish":
+			return "Team setup could not be finished. Reload the latest details before trying again.";
+		case "completion_refresh":
+			return "Team setup completed, but dependent views could not be refreshed.";
+		default: {
+			const exhaustive: never = kind;
+			return exhaustive;
+		}
+	}
+}
+
+function initialStep(view: LegacyTeamSetupViewV1, projectsVisited: boolean): TeamSetupStep {
+	if (view.state === "completed") return "completed";
+	if (view.unresolvedDeviceCount > 0) return "devices";
+	if (!projectsVisited && view.projects.length > 0) return "projects";
+	if (view.unresolvedProjectCount > 0) return "projects";
+	return "review";
+}
+
+export function isEditable(view: LegacyTeamSetupViewV1 | null): boolean {
+	return view?.state === "reviewing" || view?.state === "ready_to_finish";
+}
+
+export function isItemBusy(state: OpenSetupSessionState, itemRef: string): boolean {
+	return state.commands.some(
+		(command) =>
+			("deviceRef" in command && command.deviceRef === itemRef) ||
+			("projectRef" in command && command.projectRef === itemRef),
+	);
+}
+
+export function hasBlockingOperation(state: OpenSetupSessionState): boolean {
+	return state.commands.some(
+		(command) =>
+			(command.kind === "load" && command.refresh) ||
+			[
+				"refresh",
+				"assign_device",
+				"decide_device",
+				"clear_device",
+				"map_project",
+				"finish",
+			].includes(command.kind),
+	);
+}
+
+export function hasGlobalOperation(state: OpenSetupSessionState): boolean {
+	return state.commands.some((command) => ["load", "refresh", "finish"].includes(command.kind));
+}
+
+export function errorForItem(
+	state: OpenSetupSessionState,
+	kind: "device" | "project",
+	itemRef: string,
+): SetupSessionError | null {
+	return (
+		state.errors.find(
+			(error) =>
+				error.scope.kind === kind && "itemRef" in error.scope && error.scope.itemRef === itemRef,
+		) ?? null
+	);
+}
+
+export function globalError(state: OpenSetupSessionState): SetupSessionError | null {
+	return (
+		state.errors.find((error) => error.scope.kind === "global" || error.scope.kind === "load") ??
+		null
+	);
+}
+
+function needsRecovery(view: LegacyTeamSetupViewV1): boolean {
+	return view.state === "unavailable" && isChangedStateCode(view.unavailableReason);
+}
+
+function clearScope(state: OpenSetupSessionState, scope: SetupErrorScope): OpenSetupSessionState {
+	return {
+		...state,
+		errors: state.errors.filter((error) => {
+			if (error.scope.kind !== scope.kind) return true;
+			if (!("itemRef" in scope) || !("itemRef" in error.scope)) return false;
+			return error.scope.itemRef !== scope.itemRef;
+		}),
+	};
+}
+
+function clearCommandError(
+	state: OpenSetupSessionState,
+	command: SetupEffect,
+): OpenSetupSessionState {
+	if (
+		command.kind === "assign_device" ||
+		command.kind === "decide_device" ||
+		command.kind === "clear_device"
+	) {
+		return clearScope(state, { kind: "device", itemRef: command.deviceRef });
+	}
+	if (command.kind === "map_project") {
+		return clearScope(state, { kind: "project", itemRef: command.projectRef });
+	}
+	return { ...state, errors: [] };
+}
+
+function mapCommand(
+	state: SetupSessionState,
+	id: string,
+	map: (command: SetupEffect) => SetupEffect,
+): SetupSessionState {
+	return state.status === "open"
+		? {
+				...state,
+				commands: state.commands.map((command) => (command.id === id ? map(command) : command)),
+			}
+		: state;
+}
+
+function hasCompletionRefresh(state: OpenSetupSessionState, attemptId: string): boolean {
+	return state.commands.some(
+		(command) => command.kind === "completion_refresh" && command.attemptId === attemptId,
+	);
+}


### PR DESCRIPTION
## Description
Introduces one discriminated `SetupSessionState` and exhaustive reducer for Team setup lifecycle, commands, scoped errors, navigation, and completion. Stale async outcomes are discarded by generation and server action gates are enforced before effects are queued.

Part 2 of codemem-752i.4.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Direct reducer transition, stale-generation, gate, retry, and completion tests
- [x] `pnpm run tsc`
- [x] `pnpm run lint`

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced