### PR TITLE
refactor(ui): thin Team setup dialog shell

### DIFF
--- a/packages/ui/src/tabs/legacy-team-setup-devices.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-devices.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useState } from "preact/hooks";
 import type { LegacyTeamSetupDetailResponseV1, LegacyTeamSetupDeviceV1 } from "../lib/api";
+import { setupItemErrorId } from "./legacy-team-setup-dom";
 
 type DeviceDecision = "included" | "excluded" | "removed";
 
 export interface LegacyTeamSetupDevicesProps {
 	blocked: boolean;
+	blockedDeviceRefs?: ReadonlySet<string>;
 	blockedDescriptionId?: string;
-	busyDeviceRef: string | null;
+	busyDeviceRefs: ReadonlySet<string>;
 	detail: LegacyTeamSetupDetailResponseV1;
 	onAssign: (device: LegacyTeamSetupDeviceV1, identityRef: string) => void;
 	onClear: (device: LegacyTeamSetupDeviceV1) => void;
@@ -39,6 +41,7 @@ function initialIdentityRef(device: LegacyTeamSetupDeviceV1): string {
 function DeviceRow({
 	blocked,
 	blockedDescriptionId,
+	blockedDeviceRefs,
 	busy,
 	detail,
 	device,
@@ -63,7 +66,8 @@ function DeviceRow({
 	);
 	const existingName = identityName(detail, device.existingIdentityRef);
 	const suggestedName = identityName(detail, device.suggestedIdentityRef);
-	const controlsBlocked = blocked || busy;
+	const itemBlocked = blockedDeviceRefs?.has(device.deviceRef) ?? false;
+	const controlsBlocked = blocked || itemBlocked || busy;
 	const assignmentControlsBlocked = controlsBlocked || !device.actions.assignIdentity.enabled;
 	const assignmentEvidenceInactive =
 		device.actions.assignIdentity.blockedReason === "assignment_evidence_inactive";
@@ -81,7 +85,11 @@ function DeviceRow({
 		assignmentIdentityUnavailable ||
 		draftIdentityRef === savedIdentity;
 	const assignmentNeedsHelp = !device.enabled || includeNeedsHelp;
-	const globalBlockedDescription = blocked ? blockedDescriptionId : undefined;
+	const globalBlockedDescription = blocked
+		? blockedDescriptionId
+		: itemBlocked
+			? setupItemErrorId("device", device.deviceRef)
+			: undefined;
 	const assignmentDescription = [
 		evidenceId,
 		assignmentNeedsHelp ? assignmentHelpId : undefined,
@@ -242,7 +250,7 @@ export function LegacyTeamSetupDevices(props: LegacyTeamSetupDevicesProps) {
 				{props.detail.devices.map((device, index) => (
 					<DeviceRow
 						{...props}
-						busy={props.busyDeviceRef === device.deviceRef}
+						busy={props.busyDeviceRefs.has(device.deviceRef)}
 						device={device}
 						index={index}
 						key={device.deviceRef}

--- a/packages/ui/src/tabs/legacy-team-setup-dialog-view.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog-view.tsx
@@ -1,0 +1,366 @@
+import { DialogCloseButton } from "../components/primitives/dialog-close-button";
+import { RadixDialog, type RadixDialogProps } from "../components/primitives/radix-dialog";
+import type { LegacyTeamSetupDeviceV1, LegacyTeamSetupProjectV1 } from "../lib/api";
+import { LegacyTeamSetupDevices } from "./legacy-team-setup-devices";
+import { setupItemErrorId } from "./legacy-team-setup-dom";
+import { LegacyTeamSetupProjects } from "./legacy-team-setup-projects";
+import { LegacyTeamSetupReview } from "./legacy-team-setup-review";
+import {
+	globalError,
+	hasBlockingOperation,
+	hasGlobalOperation,
+	type InteractiveTeamSetupStep,
+	isEditable,
+	type OpenSetupSessionState,
+	type TeamSetupStep,
+} from "./legacy-team-setup-session";
+
+const EXPLICIT_LIST_ROLE = { role: "list" } as const;
+const EXPLICIT_LIST_ITEM_ROLE = { role: "listitem" } as const;
+
+export interface LegacyTeamSetupDialogViewProps {
+	session: OpenSetupSessionState;
+	onAssign: (device: LegacyTeamSetupDeviceV1, targetIdentityRef: string) => void;
+	onClear: (device: LegacyTeamSetupDeviceV1) => void;
+	onClose: () => void;
+	onCloseAutoFocus: NonNullable<RadixDialogProps["onCloseAutoFocus"]>;
+	onDecide: (
+		device: LegacyTeamSetupDeviceV1,
+		decision: "included" | "excluded" | "removed",
+		targetIdentityRef?: string,
+	) => void;
+	onFinish: () => void;
+	onMap: (project: LegacyTeamSetupProjectV1, resolvedProjectRef: string) => void;
+	onNavigate: (step: InteractiveTeamSetupStep) => void;
+	onOpenAutoFocus: NonNullable<RadixDialogProps["onOpenAutoFocus"]>;
+	onRefresh: () => void;
+	onRetry: () => void;
+}
+
+export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps) {
+	const session = props.session;
+	const view = session.view;
+	const error = globalError(session);
+	const loading = session.commands.some((command) => command.kind === "load");
+	const globalBusy = hasGlobalOperation(session) || hasBlockingOperation(session);
+	const recoveryRequired = view?.state === "unavailable" || error?.retry === "refresh";
+	const mutationsBlocked = !isEditable(view) || globalBusy || Boolean(error);
+	const mutationBlockDescriptionId = error
+		? "legacy-team-setup-error"
+		: globalBusy
+			? "legacy-team-setup-operation-status"
+			: view?.state === "unavailable"
+				? "legacy-team-setup-refresh"
+				: undefined;
+	const title = view ? `Set up ${view.candidate.displayName}` : "Set up Team";
+	const itemErrors = session.errors.filter(
+		(item) => item.scope.kind === "device" || item.scope.kind === "project",
+	);
+	const itemRecoveryRequired = itemErrors.length > 0;
+	const blockedDeviceRefs = new Set(
+		itemErrors.flatMap((item) => (item.scope.kind === "device" ? [item.scope.itemRef] : [])),
+	);
+	const blockedProjectRefs = new Set(
+		itemErrors.flatMap((item) => (item.scope.kind === "project" ? [item.scope.itemRef] : [])),
+	);
+	const busyDeviceRefs = new Set(
+		session.commands.flatMap((command) => ("deviceRef" in command ? [command.deviceRef] : [])),
+	);
+	const busyProjectRefs = new Set(
+		session.commands.flatMap((command) => ("projectRef" in command ? [command.projectRef] : [])),
+	);
+
+	return (
+		<RadixDialog
+			ariaDescribedby="legacy-team-setup-description"
+			ariaLabelledby="legacy-team-setup-title"
+			contentClassName="modal legacy-team-setup-dialog"
+			contentId="legacyTeamSetupDialog"
+			onCloseAutoFocus={props.onCloseAutoFocus}
+			onOpenAutoFocus={props.onOpenAutoFocus}
+			onOpenChange={(open) => {
+				if (!open) props.onClose();
+			}}
+			open
+			overlayClassName="modal-backdrop"
+			overlayId="legacyTeamSetupDialogBackdrop"
+		>
+			<div aria-busy={globalBusy ? "true" : "false"} className="modal-card legacy-team-setup-card">
+				<div className="modal-header">
+					<h2 id="legacy-team-setup-title" tabIndex={-1}>
+						{title}
+					</h2>
+					<DialogCloseButton
+						ariaDisabled={globalBusy}
+						ariaLabel={`Close ${title}`}
+						onClick={props.onClose}
+					/>
+				</div>
+				<div className="modal-body legacy-team-setup-body">
+					<p className="small" id="legacy-team-setup-description">
+						Review device ownership and Project access before this Team can be used for sharing.
+					</p>
+					{loading && !view ? <p role="status">Loading the latest Team setup details…</p> : null}
+					{error ? (
+						<div className="legacy-team-setup-error" id="legacy-team-setup-global-error">
+							<p aria-live="assertive" id="legacy-team-setup-error" role="alert">
+								{error.message}
+							</p>
+							{view?.state !== "unavailable" ? (
+								<button
+									aria-busy={globalBusy ? "true" : undefined}
+									aria-disabled={globalBusy ? "true" : undefined}
+									className="settings-button legacy-team-setup-target"
+									id="legacy-team-setup-retry"
+									onClick={() => {
+										if (!globalBusy) props.onRetry();
+									}}
+									type="button"
+								>
+									{loading ? "Retrying…" : "Retry"}
+								</button>
+							) : null}
+						</div>
+					) : null}
+					{itemRecoveryRequired ? (
+						<div className="legacy-team-setup-error" id="legacy-team-setup-item-errors">
+							{itemErrors.map((item) => (
+								<p
+									aria-live="assertive"
+									id={
+										"itemRef" in item.scope
+											? setupItemErrorId(item.scope.kind, item.scope.itemRef)
+											: undefined
+									}
+									key={
+										"itemRef" in item.scope
+											? `${item.scope.kind}:${item.scope.itemRef}`
+											: item.scope.kind
+									}
+									role="alert"
+								>
+									{item.message}
+								</p>
+							))}
+							<button
+								aria-busy={globalBusy ? "true" : undefined}
+								aria-disabled={globalBusy ? "true" : undefined}
+								className="settings-button legacy-team-setup-target"
+								id="legacy-team-setup-item-retry"
+								onClick={() => {
+									if (!globalBusy) props.onRetry();
+								}}
+								type="button"
+							>
+								{loading ? "Retrying…" : "Retry"}
+							</button>
+						</div>
+					) : null}
+					{view ? (
+						<>
+							{session.step !== "completed" ? (
+								<StepNavigation
+									onNavigate={props.onNavigate}
+									step={session.step}
+									unresolvedDeviceCount={view.unresolvedDeviceCount}
+									unresolvedProjectCount={view.unresolvedProjectCount}
+								/>
+							) : null}
+							{loading ? (
+								<p
+									aria-live="polite"
+									className="small"
+									id="legacy-team-setup-refresh-status"
+									role="status"
+								>
+									Refreshing Team setup details…
+								</p>
+							) : null}
+							<p
+								aria-live="polite"
+								className="small"
+								id="legacy-team-setup-operation-status"
+								role="status"
+							>
+								{session.message}
+							</p>
+							{view.state === "unavailable" ? (
+								<button
+									aria-busy={globalBusy ? "true" : undefined}
+									aria-disabled={globalBusy ? "true" : undefined}
+									className="settings-button legacy-team-setup-target"
+									id="legacy-team-setup-refresh"
+									onClick={() => {
+										if (!globalBusy) props.onRefresh();
+									}}
+									type="button"
+								>
+									Refresh Team setup
+								</button>
+							) : null}
+							{session.step === "devices" ? (
+								<LegacyTeamSetupDevices
+									blocked={mutationsBlocked}
+									blockedDescriptionId={mutationBlockDescriptionId}
+									blockedDeviceRefs={blockedDeviceRefs}
+									busyDeviceRefs={busyDeviceRefs}
+									detail={view}
+									onAssign={props.onAssign}
+									onClear={props.onClear}
+									onDecision={props.onDecide}
+								/>
+							) : session.step === "projects" ? (
+								<LegacyTeamSetupProjects
+									blocked={mutationsBlocked}
+									blockedDescriptionId={mutationBlockDescriptionId}
+									blockedProjectRefs={blockedProjectRefs}
+									busyProjectRefs={busyProjectRefs}
+									detail={view}
+									onContinue={() => props.onNavigate("review")}
+									onMap={props.onMap}
+								/>
+							) : session.step === "review" && view.state === "ready_to_finish" ? (
+								<LegacyTeamSetupReview
+									blocked={mutationsBlocked || itemRecoveryRequired}
+									blockedDescriptionId={
+										itemRecoveryRequired
+											? "legacy-team-setup-item-errors"
+											: mutationBlockDescriptionId
+									}
+									detail={view}
+									onFinish={props.onFinish}
+								/>
+							) : (
+								<FallbackStep
+									busy={globalBusy}
+									canFinish={view.state === "ready_to_finish"}
+									onRefresh={props.onRefresh}
+									recoveryRequired={recoveryRequired}
+									step={session.step}
+								/>
+							)}
+						</>
+					) : null}
+				</div>
+				<div className="modal-footer legacy-team-setup-actions">
+					<button
+						aria-disabled={globalBusy ? "true" : undefined}
+						className="settings-button legacy-team-setup-target"
+						onClick={props.onClose}
+						type="button"
+					>
+						Close
+					</button>
+				</div>
+			</div>
+		</RadixDialog>
+	);
+}
+
+function StepNavigation(props: {
+	step: TeamSetupStep;
+	unresolvedDeviceCount: number;
+	unresolvedProjectCount: number;
+	onNavigate: (step: InteractiveTeamSetupStep) => void;
+}) {
+	const devicesBlocked = props.unresolvedDeviceCount > 0;
+	const projectsBlocked = props.unresolvedProjectCount > 0;
+	const steps: Array<{ label: string; step: "devices" | "projects" | "review" }> = [
+		{ label: "Devices", step: "devices" },
+		{ label: "Projects", step: "projects" },
+		{ label: "Review", step: "review" },
+	];
+	return (
+		<>
+			<ol {...EXPLICIT_LIST_ROLE} aria-label="Team setup steps" className="legacy-team-setup-steps">
+				{steps.map((item, index) => {
+					const blocked =
+						item.step === "projects"
+							? devicesBlocked
+							: item.step === "review"
+								? devicesBlocked || projectsBlocked
+								: false;
+					const describedBy = blocked
+						? devicesBlocked
+							? "legacy-team-setup-block-devices"
+							: "legacy-team-setup-block-projects"
+						: undefined;
+					return (
+						<li {...EXPLICIT_LIST_ITEM_ROLE} className="legacy-team-setup-step" key={item.step}>
+							<span aria-hidden="true" className="legacy-team-setup-step-number">
+								{index + 1}
+							</span>
+							<button
+								aria-current={props.step === item.step ? "step" : undefined}
+								aria-describedby={describedBy}
+								aria-disabled={blocked ? "true" : undefined}
+								aria-label={`Step ${index + 1}: ${item.label}`}
+								className="settings-button legacy-team-setup-target"
+								onClick={() => props.onNavigate(item.step)}
+								type="button"
+							>
+								{item.label}
+							</button>
+						</li>
+					);
+				})}
+			</ol>
+			{devicesBlocked ? (
+				<p className="small" id="legacy-team-setup-block-devices">
+					Finish the device decisions before mapping Projects or reviewing access.
+				</p>
+			) : null}
+			{projectsBlocked ? (
+				<p className="small" id="legacy-team-setup-block-projects">
+					Finish the Project mappings before reviewing access.
+				</p>
+			) : null}
+		</>
+	);
+}
+
+function FallbackStep(props: {
+	busy: boolean;
+	canFinish: boolean;
+	onRefresh: () => void;
+	recoveryRequired: boolean;
+	step: TeamSetupStep;
+}) {
+	if (props.step === "completed") {
+		return (
+			<section aria-labelledby="legacy-team-setup-step-completed">
+				<h3 id="legacy-team-setup-step-completed" tabIndex={-1}>
+					Team setup complete
+				</h3>
+				<p>This Team is ready for Project sharing.</p>
+			</section>
+		);
+	}
+	if (props.step !== "review") return null;
+	return (
+		<section aria-labelledby="legacy-team-setup-step-review">
+			<h3 id="legacy-team-setup-step-review" tabIndex={-1}>
+				Review and finish
+			</h3>
+			<p>
+				{props.canFinish
+					? "The server has confirmed that this Team is ready for final review."
+					: "Final review is waiting for the latest setup details."}
+			</p>
+			<p className="small">Next setup action: review the access summary before finishing.</p>
+			{!props.canFinish && !props.recoveryRequired ? (
+				<button
+					aria-busy={props.busy ? "true" : undefined}
+					aria-disabled={props.busy ? "true" : undefined}
+					className="settings-button legacy-team-setup-target"
+					onClick={() => {
+						if (!props.busy) props.onRefresh();
+					}}
+					type="button"
+				>
+					Refresh Team setup
+				</button>
+			) : null}
+		</section>
+	);
+}

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -43,6 +43,12 @@ import {
 	mountLegacyTeamSetupDialog,
 	openLegacyTeamSetup,
 } from "./legacy-team-setup-dialog";
+import { LegacyTeamSetupDialogView } from "./legacy-team-setup-dialog-view";
+import {
+	createSetupSessionState,
+	type OpenSetupSessionState,
+	reduceSetupSession,
+} from "./legacy-team-setup-session";
 
 const identities: LegacyTeamSetupIdentityChoiceV1[] = [
 	{ identityRef: "identity-ref-alex", displayName: "Alex" },
@@ -273,6 +279,30 @@ function setup(
 	return { mount, trigger };
 }
 
+function busyViewSession(errors: OpenSetupSessionState["errors"]): OpenSetupSessionState {
+	let session = reduceSetupSession(createSetupSessionState(), {
+		type: "open",
+		candidateRef: "opaque-candidate",
+	});
+	if (session.status !== "open") throw new Error("expected open session");
+	const load = session.commands[0];
+	if (!load) throw new Error("expected load command");
+	session = reduceSetupSession(session, {
+		type: "effect_outcome",
+		outcome: {
+			status: "success",
+			generation: load.generation,
+			id: load.id,
+			kind: load.kind,
+			view: detail(),
+		},
+	});
+	if (session.status !== "open") throw new Error("expected loaded session");
+	session = reduceSetupSession(session, { type: "refresh" });
+	if (session.status !== "open") throw new Error("expected refreshing session");
+	return { ...session, errors };
+}
+
 function button(label: string): HTMLButtonElement {
 	const match = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
 		(candidate) => candidate.textContent === label,
@@ -292,6 +322,20 @@ afterEach(() => {
 });
 
 describe("legacy Team setup dialog", () => {
+	it("registers the opener before mount returns", () => {
+		document.body.innerHTML = '<div id="legacyTeamSetupMount"></div>';
+		const mount = document.getElementById("legacyTeamSetupMount");
+		if (!(mount instanceof HTMLElement)) throw new Error("Team setup mount missing");
+
+		let handled = false;
+		act(() => {
+			mountLegacyTeamSetupDialog(mount, { loadDetail: vi.fn().mockResolvedValue(detail()) });
+			handled = openLegacyTeamSetup("opaque-candidate");
+		});
+
+		expect(handled).toBe(true);
+	});
+
 	it("opens with loading state and selects Devices from authoritative detail", async () => {
 		const pending = deferred<LegacyTeamSetupDetailResponseV1>();
 		const loadDetail = vi.fn().mockReturnValue(pending.promise);
@@ -1009,6 +1053,12 @@ describe("legacy Team setup dialog", () => {
 		await vi.waitFor(() => {
 			expect(document.querySelector('[role="alert"]')?.textContent).toContain("could not be saved");
 		});
+		expect(
+			document.getElementById("legacy-team-setup-item-error-device-device-ref-one"),
+		).not.toBeNull();
+		expect(button("Include").getAttribute("aria-describedby")).toContain(
+			"legacy-team-setup-item-error-device-device-ref-one",
+		);
 		expect(document.body.textContent).not.toContain("private decision failure");
 		expect(saveAssignment).toHaveBeenCalledWith("opaque-candidate", "device-ref-one", {
 			attemptId: "attempt-before-assignment",
@@ -1028,7 +1078,7 @@ describe("legacy Team setup dialog", () => {
 			"identity-ref-sam",
 		);
 
-		act(() => document.getElementById("legacy-team-setup-retry")?.click());
+		act(() => document.getElementById("legacy-team-setup-item-retry")?.click());
 		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
 		act(() => button("Include").click());
 		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
@@ -1870,6 +1920,184 @@ describe("legacy Team setup dialog", () => {
 		await vi.waitFor(() => expect(document.body.textContent).toContain("Team setup complete"));
 		expect(document.activeElement?.id).toBe("legacy-team-setup-step-completed");
 		expect(onCompleted).toHaveBeenCalledTimes(1);
+	});
+
+	it("disables review controls after a finish failure until recovery", async () => {
+		const finish = vi.fn().mockRejectedValue(new Error("temporary failure"));
+		setup({
+			finish,
+			loadDetail: vi.fn().mockResolvedValue(detail({ canFinish: true })),
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Finish Team setup"));
+		const confirmation = document.querySelector<HTMLInputElement>(
+			".legacy-team-setup-confirmation input",
+		);
+		if (!confirmation) throw new Error("finish confirmation missing");
+		confirmation.checked = true;
+		act(() => {
+			confirmation.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+
+		const finishButton = button("Finish Team setup");
+		act(() => finishButton.click());
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain("Team setup could not be finished"),
+		);
+
+		expect(confirmation.getAttribute("aria-disabled")).toBe("true");
+		expect(finishButton.getAttribute("aria-disabled")).toBe("true");
+		act(() => finishButton.click());
+		expect(finish).toHaveBeenCalledTimes(1);
+	});
+
+	it("blocks final confirmation for an item error without blocking unrelated item edits", async () => {
+		const firstDevice = device({
+			deviceRef: "device-ref-one",
+			displayName: "First laptop",
+			decision: "excluded",
+		});
+		const secondDevice = device({
+			deviceRef: "device-ref-two",
+			displayName: "Second laptop",
+			decision: "excluded",
+		});
+		const saveDecision = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("temporary failure"))
+			.mockResolvedValueOnce(detail({ canFinish: true, devices: [firstDevice, secondDevice] }));
+		setup({
+			loadDetail: vi
+				.fn()
+				.mockResolvedValue(detail({ canFinish: true, devices: [firstDevice, secondDevice] })),
+			saveDecision,
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review and finish"));
+
+		act(() => button("Devices").click());
+		const excludeButtons = [...document.querySelectorAll<HTMLButtonElement>("button")].filter(
+			(candidate) => candidate.textContent === "Exclude",
+		);
+		act(() => excludeButtons[0]?.click());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("could not be saved"));
+
+		expect(excludeButtons[1]?.getAttribute("aria-disabled")).toBeNull();
+		act(() => excludeButtons[1]?.click());
+		await vi.waitFor(() => expect(saveDecision).toHaveBeenCalledTimes(2));
+		act(() => button("Review").click());
+		const confirmation = document.querySelector<HTMLInputElement>(
+			".legacy-team-setup-confirmation input",
+		);
+		if (!confirmation) throw new Error("finish confirmation missing");
+		expect(confirmation.getAttribute("aria-disabled")).toBe("true");
+		expect(confirmation.getAttribute("aria-describedby")).toContain(
+			"legacy-team-setup-item-errors",
+		);
+	});
+
+	it("marks fallback refresh busy and ignores duplicate requests", async () => {
+		const pendingRefresh = deferred<LegacyTeamSetupDetailResponseV1>();
+		const refreshCandidate = vi.fn().mockReturnValue(pendingRefresh.promise);
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(detail()),
+			refreshCandidate,
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Refresh Team setup"));
+
+		const refresh = button("Refresh Team setup");
+		act(() => {
+			refresh.click();
+			refresh.click();
+		});
+
+		expect(refreshCandidate).toHaveBeenCalledTimes(1);
+		expect(refresh.getAttribute("aria-busy")).toBe("true");
+		expect(refresh.getAttribute("aria-disabled")).toBe("true");
+	});
+
+	it("marks recovery refresh busy and ignores duplicate requests", async () => {
+		const pendingRefresh = deferred<LegacyTeamSetupDetailResponseV1>();
+		const refreshCandidate = vi.fn().mockReturnValue(pendingRefresh.promise);
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(detail({ draftState: "stale" })),
+			refreshCandidate,
+		});
+		await vi.waitFor(() =>
+			expect(document.getElementById("legacy-team-setup-refresh")).not.toBeNull(),
+		);
+
+		const refresh = document.getElementById("legacy-team-setup-refresh") as HTMLButtonElement;
+		act(() => {
+			refresh.click();
+			refresh.click();
+		});
+
+		expect(refreshCandidate).toHaveBeenCalledTimes(1);
+		expect(refresh.getAttribute("aria-busy")).toBe("true");
+		expect(refresh.getAttribute("aria-disabled")).toBe("true");
+	});
+
+	it("guards busy refresh and retry controls before dispatch", () => {
+		document.body.innerHTML = '<div id="legacyTeamSetupMount"></div>';
+		const mount = document.getElementById("legacyTeamSetupMount");
+		if (!(mount instanceof HTMLElement)) throw new Error("dialog mount missing");
+		const onRefresh = vi.fn();
+		const onRetry = vi.fn();
+		const session = busyViewSession([
+			{ scope: { kind: "global" }, message: "Reload required", retry: "load" },
+			{
+				scope: { kind: "device", itemRef: "device-ref-one" },
+				message: "Retry this device change",
+				retry: "load",
+			},
+		]);
+		act(() =>
+			render(
+				<LegacyTeamSetupDialogView
+					onAssign={vi.fn()}
+					onClear={vi.fn()}
+					onClose={vi.fn()}
+					onCloseAutoFocus={vi.fn()}
+					onDecide={vi.fn()}
+					onFinish={vi.fn()}
+					onMap={vi.fn()}
+					onNavigate={vi.fn()}
+					onOpenAutoFocus={vi.fn()}
+					onRefresh={onRefresh}
+					onRetry={onRetry}
+					session={session}
+				/>,
+				mount,
+			),
+		);
+
+		act(() => {
+			document.getElementById("legacy-team-setup-retry")?.click();
+			document.getElementById("legacy-team-setup-item-retry")?.click();
+			button("Refresh Team setup").click();
+		});
+
+		expect(onRetry).not.toHaveBeenCalled();
+		expect(onRefresh).not.toHaveBeenCalled();
+	});
+
+	it("describes unavailable item controls with the recovery action", async () => {
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(
+				detail({
+					conflictState: "team_setup_failed",
+					devices: [device()],
+					unresolvedDeviceCount: 1,
+				}),
+			),
+		});
+		await vi.waitFor(() =>
+			expect(document.getElementById("legacy-team-setup-refresh")).not.toBeNull(),
+		);
+
+		expect(button("Exclude").getAttribute("aria-disabled")).toBe("true");
+		expect(button("Exclude").getAttribute("aria-describedby")).toContain(
+			"legacy-team-setup-refresh",
+		);
 	});
 
 	it("ignores a completion refresh after closing and opening another Team", async () => {

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.tsx
@@ -1,36 +1,18 @@
 import { render } from "preact";
-import { useEffect, useRef, useState } from "preact/hooks";
-import { DialogCloseButton } from "../components/primitives/dialog-close-button";
-import { RadixDialog } from "../components/primitives/radix-dialog";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
+import type { RadixDialogProps } from "../components/primitives/radix-dialog";
 import * as api from "../lib/api";
-import { LegacyTeamSetupDevices } from "./legacy-team-setup-devices";
-import { LegacyTeamSetupProjects } from "./legacy-team-setup-projects";
-import { LegacyTeamSetupReview } from "./legacy-team-setup-review";
+import { LegacyTeamSetupDialogView } from "./legacy-team-setup-dialog-view";
+import { createSetupEffectRunner, type SetupEffectDependencies } from "./legacy-team-setup-effects";
+import {
+	createSetupSessionState,
+	hasBlockingOperation,
+	type InteractiveTeamSetupStep,
+	reduceSetupSession,
+	type SetupSessionEvent,
+} from "./legacy-team-setup-session";
 
-type TeamSetupStep = "devices" | "projects" | "review" | "completed";
-
-// Safari/VoiceOver can drop list semantics when CSS removes native markers.
-const EXPLICIT_LIST_ROLE = { role: "list" } as const;
-const EXPLICIT_LIST_ITEM_ROLE = { role: "listitem" } as const;
-const CHANGED_STATE_ERROR =
-	"Team setup changed since it was last reviewed. Reload the latest details to continue.";
-const RELOAD_ERROR_CODES = new Set<api.LegacyTeamSetupErrorCode>([
-	"team_setup_roster_changed",
-	"team_setup_assignment_changed",
-	"team_setup_conflict",
-	"team_setup_confirmation_stale",
-]);
-
-export interface LegacyTeamSetupDialogDependencies {
-	clearDecision: typeof api.clearLegacyTeamSetupDecision;
-	finish: typeof api.finishLegacyTeamSetup;
-	loadDetail: typeof api.loadLegacyTeamSetupDetail;
-	onCompleted: () => void | Promise<void>;
-	refreshCandidate: typeof api.refreshLegacyTeamSetupCandidate;
-	saveAssignment: typeof api.saveLegacyTeamSetupAssignment;
-	saveDecision: typeof api.saveLegacyTeamSetupDecision;
-	saveProjectMapping: typeof api.saveLegacyTeamSetupProjectMapping;
-}
+export type LegacyTeamSetupDialogDependencies = SetupEffectDependencies;
 
 const defaultDependencies: LegacyTeamSetupDialogDependencies = {
 	clearDecision: api.clearLegacyTeamSetupDecision,
@@ -43,16 +25,25 @@ const defaultDependencies: LegacyTeamSetupDialogDependencies = {
 	saveProjectMapping: api.saveLegacyTeamSetupProjectMapping,
 };
 
-let pendingCandidateRef: string | null = null;
-let requestOpen: ((candidateRef: string) => void) | null = null;
-let returnFocus: HTMLElement | null = null;
+const OPEN_TEAM_SETUP_EVENT = "codemem:open-legacy-team-setup";
+
+interface OpenTeamSetupEventDetail {
+	candidateRef: string;
+	handled: boolean;
+	returnFocus: HTMLElement | null;
+}
 
 export function openLegacyTeamSetup(candidateRef: string): boolean {
 	if (!candidateRef) return false;
-	returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-	if (requestOpen) requestOpen(candidateRef);
-	else pendingCandidateRef = candidateRef;
-	return true;
+	const detail: OpenTeamSetupEventDetail = {
+		candidateRef,
+		handled: false,
+		returnFocus: document.activeElement instanceof HTMLElement ? document.activeElement : null,
+	};
+	window.dispatchEvent(
+		new CustomEvent<OpenTeamSetupEventDetail>(OPEN_TEAM_SETUP_EVENT, { detail }),
+	);
+	return detail.handled;
 }
 
 function canRestoreFocus(element: HTMLElement | null): element is HTMLElement {
@@ -77,807 +68,127 @@ function canRestoreFocus(element: HTMLElement | null): element is HTMLElement {
 	return true;
 }
 
-function initialStep(
-	detail: api.LegacyTeamSetupDetailResponseV1,
-	projectsVisited = false,
-): TeamSetupStep {
-	if (detail.state === "completed") return "completed";
-	if (detail.unresolvedDeviceCount > 0) return "devices";
-	if (!projectsVisited && detail.projects.length > 0) return "projects";
-	if (detail.unresolvedProjectCount > 0) return "projects";
-	return "review";
-}
-
-function detailNeedsRecovery(detail: api.LegacyTeamSetupDetailResponseV1): boolean {
-	return (
-		detail.state === "unavailable" &&
-		(RELOAD_ERROR_CODES.has(detail.unavailableReason) ||
-			detail.unavailableReason === "team_setup_roster_unavailable")
-	);
-}
-
-function isReadyToFinish(
-	detail: api.LegacyTeamSetupDetailResponseV1,
-): detail is Extract<api.LegacyTeamSetupDetailResponseV1, { state: "ready_to_finish" }> {
-	return detail.state === "ready_to_finish";
-}
-
-const ROSTER_UNAVAILABLE_ERROR =
-	"Team device details are temporarily unavailable. Check the coordinator connection and settings, then retry.";
-
-function detailRecoveryError(detail: api.LegacyTeamSetupDetailResponseV1): string | null {
-	if (!detailNeedsRecovery(detail)) return null;
-	return detail.state === "unavailable" &&
-		detail.unavailableReason === "team_setup_roster_unavailable"
-		? ROSTER_UNAVAILABLE_ERROR
-		: CHANGED_STATE_ERROR;
-}
-
-function isRosterUnavailableError(cause: unknown): boolean {
-	return (
-		cause instanceof api.LegacyTeamSetupApiError &&
-		cause.errorCode === "team_setup_roster_unavailable"
-	);
-}
-
-function safeLoadError(cause: unknown): string {
-	if (isChangedStateError(cause)) {
-		return CHANGED_STATE_ERROR;
-	}
-	if (isRosterUnavailableError(cause)) return ROSTER_UNAVAILABLE_ERROR;
-	return "Team setup details are temporarily unavailable. Retry to load the latest details.";
-}
-
-function isChangedStateError(cause: unknown): boolean {
-	return cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode);
-}
-
-function safeMutationError(cause: unknown): string {
-	if (isChangedStateError(cause)) {
-		return CHANGED_STATE_ERROR;
-	}
-	if (isRosterUnavailableError(cause)) return ROSTER_UNAVAILABLE_ERROR;
-	return "This device change could not be saved. Reload the latest details before trying again.";
-}
-
-function safeProjectMutationError(cause: unknown): string {
-	if (cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode)) {
-		return CHANGED_STATE_ERROR;
-	}
-	if (isRosterUnavailableError(cause)) return ROSTER_UNAVAILABLE_ERROR;
-	return "This Project mapping could not be saved. Reload the latest details before trying again.";
-}
-
-function safeRefreshError(cause: unknown): string {
-	if (cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode)) {
-		return CHANGED_STATE_ERROR;
-	}
-	if (isRosterUnavailableError(cause)) return ROSTER_UNAVAILABLE_ERROR;
-	return "Team setup could not be refreshed. Retry to load the latest server details.";
-}
-
-function safeFinishError(cause: unknown): string {
-	if (cause instanceof api.LegacyTeamSetupApiError && RELOAD_ERROR_CODES.has(cause.errorCode)) {
-		return CHANGED_STATE_ERROR;
-	}
-	if (isRosterUnavailableError(cause)) return ROSTER_UNAVAILABLE_ERROR;
-	return "Team setup could not be finished. Reload the latest details before trying again.";
-}
-
-function StepContent({
-	detail,
-	step,
-}: {
-	detail: api.LegacyTeamSetupDetailResponseV1;
-	step: TeamSetupStep;
-}) {
-	if (step === "completed") {
-		return (
-			<section aria-labelledby="legacy-team-setup-step-completed">
-				<h3 id="legacy-team-setup-step-completed" tabIndex={-1}>
-					Team setup complete
-				</h3>
-				<p>This Team is ready for Project sharing.</p>
-			</section>
-		);
-	}
-	if (step === "devices") return null;
-	if (step === "projects") return null;
-	return (
-		<section aria-labelledby="legacy-team-setup-step-review">
-			<h3 id="legacy-team-setup-step-review" tabIndex={-1}>
-				Review and finish
-			</h3>
-			<p>
-				{isReadyToFinish(detail)
-					? "The server has confirmed that this Team is ready for final review."
-					: "Final review is waiting for the latest setup details."}
-			</p>
-			<p className="small">Next setup action: review the access summary before finishing.</p>
-		</section>
-	);
-}
-
 function LegacyTeamSetupDialogHost({
 	dependencies,
 }: {
 	dependencies: LegacyTeamSetupDialogDependencies;
 }) {
-	const [candidateRef, setCandidateRef] = useState<string | null>(null);
-	const [detail, setDetail] = useState<api.LegacyTeamSetupDetailResponseV1 | null>(null);
-	const [step, setStep] = useState<TeamSetupStep>("devices");
-	const [loading, setLoading] = useState(false);
-	const [error, setError] = useState<string | null>(null);
-	const [loadRevision, setLoadRevision] = useState(0);
-	const [busyDeviceRef, setBusyDeviceRef] = useState<string | null>(null);
-	const [busyProjectRef, setBusyProjectRef] = useState<string | null>(null);
-	const [operationStatus, setOperationStatus] = useState("");
-	const [isSubmitting, setIsSubmitting] = useState(false);
-	const focusAfterLoad = useRef(false);
-	const focusControlAfterRender = useRef<string | null>(null);
-	const focusStepAfterRender = useRef(false);
-	const refreshBeforeLoad = useRef(false);
-	const retryNeedsRefresh = useRef(false);
-	const projectsVisitedAttemptId = useRef<string | null>(null);
-	const submitting = useRef(false);
-	const dialogGeneration = useRef(0);
-	const completedSurfaceRefresh = useRef<{
-		attemptId: string;
-		candidateRef: string;
-		promise: Promise<void>;
-	} | null>(null);
-	const refreshCompletedSurfaces = (attemptId: string): Promise<void> => {
-		const currentRefresh = completedSurfaceRefresh.current;
-		if (currentRefresh?.attemptId === attemptId && currentRefresh.candidateRef === candidateRef) {
-			return currentRefresh.promise;
-		}
-		const refreshPromise = Promise.resolve().then(() => dependencies.onCompleted());
-		const forgetRefresh = () => {
-			if (completedSurfaceRefresh.current?.promise === trackedPromise) {
-				completedSurfaceRefresh.current = null;
-			}
-		};
-		const trackedPromise = refreshPromise.then(forgetRefresh, (cause: unknown) => {
-			forgetRefresh();
-			throw cause;
-		});
-		completedSurfaceRefresh.current = { attemptId, candidateRef, promise: trackedPromise };
-		return trackedPromise;
-	};
-	const reportCompletedRefresh = (attemptId: string, completionGeneration: number): void => {
-		setOperationStatus("Team setup complete. Sharing and Projects are refreshing.");
-		void refreshCompletedSurfaces(attemptId).then(
-			() => {
-				if (dialogGeneration.current !== completionGeneration) return;
-				setOperationStatus("Team setup complete. Sharing and Projects are up to date.");
-			},
-			() => {
-				if (dialogGeneration.current !== completionGeneration) return;
-				setOperationStatus(
-					"Team setup complete. Sharing or Projects could not be refreshed; use that view's Refresh control.",
-				);
-			},
-		);
+	const [session, setSession] = useState(createSetupSessionState);
+	const returnFocus = useRef<HTMLElement | null>(null);
+	const runner = useMemo(() => createSetupEffectRunner(dependencies), [dependencies]);
+	const dispatch = (event: SetupSessionEvent) => {
+		setSession((current) => reduceSetupSession(current, event));
 	};
 
-	useEffect(() => {
-		requestOpen = (nextCandidateRef) => {
-			if (submitting.current) {
-				setOperationStatus(
-					"Wait for the current Team setup change to finish before opening another Team.",
-				);
-				return;
-			}
-			dialogGeneration.current += 1;
-			refreshBeforeLoad.current = false;
-			retryNeedsRefresh.current = false;
-			projectsVisitedAttemptId.current = null;
-			setCandidateRef(nextCandidateRef);
-			setDetail(null);
-			setError(null);
-			setOperationStatus("");
-			setLoadRevision((current) => current + 1);
+	useLayoutEffect(() => {
+		const onOpen = (event: Event) => {
+			const request = event as CustomEvent<OpenTeamSetupEventDetail>;
+			request.detail.handled = true;
+			returnFocus.current = request.detail.returnFocus;
+			setSession((current) => {
+				if (current.status === "open" && hasBlockingOperation(current)) {
+					return reduceSetupSession(current, {
+						type: "open_blocked",
+						message:
+							"Wait for the current Team setup change to finish before opening another Team.",
+					});
+				}
+				return reduceSetupSession(current, {
+					type: "open",
+					candidateRef: request.detail.candidateRef,
+				});
+			});
 		};
-		if (pendingCandidateRef) {
-			const pending = pendingCandidateRef;
-			pendingCandidateRef = null;
-			requestOpen(pending);
-		}
+		window.addEventListener(OPEN_TEAM_SETUP_EVENT, onOpen);
 		return () => {
-			requestOpen = null;
+			window.removeEventListener(OPEN_TEAM_SETUP_EVENT, onOpen);
 		};
 	}, []);
 
 	useEffect(() => {
-		if (!candidateRef) return;
-		let current = true;
-		const shouldRefresh = refreshBeforeLoad.current;
-		refreshBeforeLoad.current = false;
-		setLoading(true);
-		const nextDetail = shouldRefresh
-			? dependencies.refreshCandidate(candidateRef)
-			: dependencies.loadDetail(candidateRef);
-		void nextDetail.then(
-			(nextDetail) => {
-				if (!current) return;
-				retryNeedsRefresh.current = detailNeedsRecovery(nextDetail);
-				setDetail(nextDetail);
-				const nextStep = initialStep(
-					nextDetail,
-					projectsVisitedAttemptId.current === nextDetail.attemptId,
-				);
-				if (nextStep === "projects") projectsVisitedAttemptId.current = nextDetail.attemptId;
-				setStep(nextStep);
-				setError(detailRecoveryError(nextDetail));
-				setLoading(false);
-				if (nextDetail.state === "completed") {
-					reportCompletedRefresh(nextDetail.attemptId, dialogGeneration.current);
-				}
-			},
-			(cause: unknown) => {
-				if (!current) return;
-				retryNeedsRefresh.current = shouldRefresh || isChangedStateError(cause);
-				setError(safeLoadError(cause));
-				setLoading(false);
-			},
-		);
-		return () => {
-			current = false;
-		};
-	}, [candidateRef, dependencies, loadRevision]);
+		if (session.status !== "open") return;
+		for (const command of session.commands.filter((item) => item.status === "pending")) {
+			dispatch({ type: "command_started", id: command.id });
+			void runner(command).then((outcome) => dispatch({ type: "effect_outcome", outcome }));
+		}
+	}, [runner, session]);
 
 	useEffect(() => {
-		if (focusControlAfterRender.current) {
-			const targetId = focusControlAfterRender.current;
-			focusControlAfterRender.current = null;
-			focusStepAfterRender.current = false;
-			document.getElementById(targetId)?.focus();
-			return;
-		}
-		if (!focusStepAfterRender.current) return;
-		focusStepAfterRender.current = false;
-		document.getElementById(`legacy-team-setup-step-${step}`)?.focus();
-	}, [step]);
+		if (session.status !== "open" || !session.focus) return;
+		const target =
+			document.getElementById(session.focus.targetId) ??
+			document.getElementById("legacy-team-setup-title");
+		if (!target) return;
+		target.focus();
+		dispatch({ type: "focus_applied", id: session.focus.id });
+	}, [session]);
 
-	useEffect(() => {
-		if (loading || !focusAfterLoad.current) return;
-		focusAfterLoad.current = false;
-		if (error) {
-			(
-				document.getElementById("legacy-team-setup-retry") ??
-				document.getElementById("legacy-team-setup-refresh")
-			)?.focus();
-			return;
-		}
-		document.getElementById(`legacy-team-setup-step-${step}`)?.focus();
-	}, [error, loading, step]);
-
-	if (!candidateRef) return null;
-	const title = detail ? `Set up ${detail.candidate.displayName}` : "Set up Team";
+	if (session.status === "closed") return null;
 	const close = () => {
-		if (submitting.current) {
-			setOperationStatus(
-				"Team setup will stay open while this change saves. Close it after saving finishes.",
-			);
-			return;
-		}
-		focusAfterLoad.current = false;
-		focusControlAfterRender.current = null;
-		focusStepAfterRender.current = false;
-		refreshBeforeLoad.current = false;
-		retryNeedsRefresh.current = false;
-		projectsVisitedAttemptId.current = null;
-		dialogGeneration.current += 1;
-		setCandidateRef(null);
-		setDetail(null);
-		setError(null);
-		setLoading(false);
-		setBusyDeviceRef(null);
-		setBusyProjectRef(null);
-		setOperationStatus("");
-		setStep("devices");
-	};
-	const navigate = (nextStep: TeamSetupStep) => {
-		if (nextStep === "projects" && detail) projectsVisitedAttemptId.current = detail.attemptId;
-		if (nextStep === step) {
-			document.getElementById(`legacy-team-setup-step-${nextStep}`)?.focus();
-			return;
-		}
-		focusStepAfterRender.current = true;
-		setStep(nextStep);
-	};
-	const explainBlockedStep = (blockedStep: "devices" | "projects", message: string) => {
-		setOperationStatus(message);
-		const unresolvedIndex =
-			blockedStep === "devices"
-				? detail?.devices.findIndex((device) => device.decision === "unresolved")
-				: detail?.projects.findIndex((project) => project.resolution === "unresolved");
-		const targetId =
-			unresolvedIndex !== undefined && unresolvedIndex >= 0
-				? blockedStep === "devices"
-					? `legacy-team-device-row-${unresolvedIndex}`
-					: `legacy-team-project-row-${unresolvedIndex}`
-				: null;
-		if (targetId && blockedStep === step) {
-			document.getElementById(targetId)?.focus();
-			return;
-		}
-		focusControlAfterRender.current = targetId;
-		navigate(blockedStep);
-	};
-	const devicesBlockProgress = detail ? detail.unresolvedDeviceCount > 0 : false;
-	const projectsBlockReview = detail ? detail.unresolvedProjectCount > 0 : false;
-	const recoveryRequired = detail ? detailNeedsRecovery(detail) : false;
-	const mutationsBlocked = loading || isSubmitting || Boolean(error);
-	const mutationBlockDescriptionId = error
-		? "legacy-team-setup-error"
-		: loading
-			? "legacy-team-setup-refresh-status"
-			: isSubmitting
-				? "legacy-team-setup-operation-status"
-				: undefined;
-	const applyAuthoritativeDetail = (
-		nextDetail: api.LegacyTeamSetupDetailResponseV1,
-		preserveDevicesStep: boolean,
-	) => {
-		retryNeedsRefresh.current = detailNeedsRecovery(nextDetail);
-		setDetail(nextDetail);
-		setStep((current) => {
-			const nextStep =
-				preserveDevicesStep &&
-				current === "devices" &&
-				nextDetail.state !== "completed" &&
-				nextDetail.unresolvedDeviceCount > 0
-					? "devices"
-					: initialStep(nextDetail, projectsVisitedAttemptId.current === nextDetail.attemptId);
-			if (nextStep === "projects") projectsVisitedAttemptId.current = nextDetail.attemptId;
-			if (nextStep !== current) focusStepAfterRender.current = true;
-			return nextStep;
-		});
-		setError(detailRecoveryError(nextDetail));
-	};
-	const recoverMutation = async (cause: unknown, getMessage = safeMutationError) => {
-		const message = getMessage(cause);
-		setOperationStatus("");
-		setError(message);
-		if (
-			!(cause instanceof api.LegacyTeamSetupApiError) ||
-			!RELOAD_ERROR_CODES.has(cause.errorCode)
-		) {
-			return;
-		}
-		try {
-			const nextDetail = await dependencies.loadDetail(candidateRef);
-			applyAuthoritativeDetail(nextDetail, true);
-			if (nextDetail.state === "completed") {
-				setError(null);
-				reportCompletedRefresh(nextDetail.attemptId, dialogGeneration.current);
-				return;
-			}
-			retryNeedsRefresh.current = true;
-		} catch {
-			retryNeedsRefresh.current = true;
-			// Keep the stable mutation error when the best-effort recovery reload also fails.
-		}
-		setError(message);
-	};
-	const runMutation = async (
-		itemRef: string,
-		status: string,
-		savedStatus: string,
-		setBusyRef: (value: string | null) => void,
-		getError: (cause: unknown) => string,
-		operation: () => Promise<api.LegacyTeamSetupDetailResponseV1>,
-	) => {
-		if (mutationsBlocked || submitting.current) return;
-		submitting.current = true;
-		setIsSubmitting(true);
-		setBusyRef(itemRef);
-		setOperationStatus(status);
-		setError(null);
-		try {
-			let nextDetail: api.LegacyTeamSetupDetailResponseV1;
-			try {
-				nextDetail = await operation();
-			} catch (cause) {
-				await recoverMutation(cause, getError);
-				return;
-			}
-			applyAuthoritativeDetail(nextDetail, true);
-			setOperationStatus(savedStatus);
-		} finally {
-			submitting.current = false;
-			setIsSubmitting(false);
-			setBusyRef(null);
-		}
-	};
-	const assignDevice = (device: api.LegacyTeamSetupDeviceV1, targetIdentityRef: string) => {
-		const currentDetail = detail;
-		if (!currentDetail) return;
-		void runMutation(
-			device.deviceRef,
-			`Saving the assignment for ${device.displayName}.`,
-			`${device.displayName} saved.`,
-			setBusyDeviceRef,
-			safeMutationError,
-			() =>
-				dependencies.saveAssignment(candidateRef, device.deviceRef, {
-					attemptId: currentDetail.attemptId,
-					targetIdentityRef,
-					expectation: device.expectation,
-				}),
-		);
-	};
-	const decideDevice = (
-		device: api.LegacyTeamSetupDeviceV1,
-		decision: "included" | "excluded" | "removed",
-		targetIdentityRef?: string,
-	) => {
-		const currentDetail = detail;
-		if (!currentDetail) return;
-		if (decision === "included" && !targetIdentityRef) {
-			setOperationStatus(`Save a person assignment before including ${device.displayName}.`);
-			return;
-		}
-		void runMutation(
-			device.deviceRef,
-			`Saving the decision for ${device.displayName}.`,
-			`${device.displayName} saved.`,
-			setBusyDeviceRef,
-			safeMutationError,
-			async () => {
-				if (decision === "included" && targetIdentityRef) {
-					return dependencies.saveDecision(candidateRef, device.deviceRef, {
-						attemptId: currentDetail.attemptId,
-						decision: "included",
-						expectedTargetIdentityRef: targetIdentityRef,
-					});
-				}
-				if (decision !== "included") {
-					return dependencies.saveDecision(candidateRef, device.deviceRef, {
-						attemptId: currentDetail.attemptId,
-						decision,
-					});
-				}
-				throw new Error("legacy_team_setup_identity_required");
-			},
-		);
-	};
-	const clearDevice = (device: api.LegacyTeamSetupDeviceV1) => {
-		const currentDetail = detail;
-		if (!currentDetail) return;
-		void runMutation(
-			device.deviceRef,
-			`Clearing the decision for ${device.displayName}.`,
-			`${device.displayName} saved.`,
-			setBusyDeviceRef,
-			safeMutationError,
-			() =>
-				dependencies.clearDecision(candidateRef, device.deviceRef, {
-					attemptId: currentDetail.attemptId,
-				}),
-		);
-	};
-	const mapProject = (project: api.LegacyTeamSetupProjectV1, resolvedProjectRef: string) => {
-		const currentDetail = detail;
-		if (!currentDetail) return;
-		void runMutation(
-			project.projectRef,
-			`Saving the mapping for ${project.displayName}.`,
-			`${project.displayName} saved.`,
-			setBusyProjectRef,
-			safeProjectMutationError,
-			() =>
-				dependencies.saveProjectMapping(candidateRef, project.projectRef, {
-					attemptId: currentDetail.attemptId,
-					resolvedProjectRef,
-				}),
-		);
-	};
-	const refreshSetup = () => {
-		if (loading || isSubmitting || submitting.current) return;
-		const completionGeneration = dialogGeneration.current;
-		submitting.current = true;
-		setIsSubmitting(true);
-		setOperationStatus("Refreshing Team setup from the latest server state.");
-		setError(null);
-		void dependencies
-			.refreshCandidate(candidateRef)
-			.then((nextDetail) => {
-				applyAuthoritativeDetail(nextDetail, true);
-				if (nextDetail.state === "completed") {
-					reportCompletedRefresh(nextDetail.attemptId, completionGeneration);
-					return;
-				}
-				setOperationStatus("Team setup refreshed.");
-			})
-			.catch((cause: unknown) => recoverMutation(cause, safeRefreshError))
-			.finally(() => {
-				submitting.current = false;
-				setIsSubmitting(false);
+		if (hasBlockingOperation(session)) {
+			dispatch({
+				type: "close_blocked",
+				message:
+					"Team setup will stay open while this change saves. Close it after saving finishes.",
 			});
+			return;
+		}
+		dispatch({ type: "close" });
 	};
-	const finishSetup = (
-		finishDetail: Extract<api.LegacyTeamSetupDetailResponseV1, { state: "ready_to_finish" }>,
-	) => {
-		if (mutationsBlocked || submitting.current) return;
-		const completionGeneration = dialogGeneration.current;
-		submitting.current = true;
-		setIsSubmitting(true);
-		setOperationStatus("Finishing Team setup.");
-		setError(null);
-		void dependencies
-			.finish(candidateRef, {
-				attemptId: finishDetail.attemptId,
-				finishDigest: finishDetail.finishDigest,
-				confirmedAccessDeltaDigest: finishDetail.accessDeltaDigest,
-				confirmedViewerAccessDeltaDigest: finishDetail.viewerAccessDeltaDigest,
-			})
-			.then(
-				() => {
-					focusStepAfterRender.current = true;
-					setStep("completed");
-					reportCompletedRefresh(finishDetail.attemptId, completionGeneration);
-				},
-				(cause: unknown) => recoverMutation(cause, safeFinishError),
-			)
-			.finally(() => {
-				submitting.current = false;
-				setIsSubmitting(false);
-			});
-	};
+	const navigate = (step: InteractiveTeamSetupStep) => dispatch({ type: "navigate", step });
 
 	return (
-		<RadixDialog
-			ariaDescribedby="legacy-team-setup-description"
-			ariaLabelledby="legacy-team-setup-title"
-			contentClassName="modal legacy-team-setup-dialog"
-			contentId="legacyTeamSetupDialog"
-			onCloseAutoFocus={(event) => {
-				event.preventDefault();
-				const activeTab = document.querySelector<HTMLElement>('.tab-btn[aria-current="page"]');
-				const target = canRestoreFocus(returnFocus) ? returnFocus : activeTab;
-				target?.focus();
-				returnFocus = null;
+		<LegacyTeamSetupDialogView
+			session={session}
+			onAssign={(device, targetIdentityRef) =>
+				dispatch({ type: "assign_device", deviceRef: device.deviceRef, targetIdentityRef })
+			}
+			onClear={(device) => dispatch({ type: "clear_device", deviceRef: device.deviceRef })}
+			onClose={close}
+			onCloseAutoFocus={(event) => restoreFocus(event, returnFocus)}
+			onDecide={(device, decision, targetIdentityRef) => {
+				if (decision === "included" && !targetIdentityRef) {
+					dispatch({
+						type: "open_blocked",
+						message: `Save a person assignment before including ${device.displayName}.`,
+					});
+					return;
+				}
+				dispatch({
+					type: "decide_device",
+					deviceRef: device.deviceRef,
+					decision,
+					...(targetIdentityRef ? { targetIdentityRef } : {}),
+				});
 			}}
-			onOpenAutoFocus={(event) => {
-				const heading = document.getElementById("legacy-team-setup-title");
-				if (!heading) return;
-				event.preventDefault();
-				heading.focus();
-			}}
-			onOpenChange={(open) => {
-				if (!open) close();
-			}}
-			open
-			overlayClassName="modal-backdrop"
-			overlayId="legacyTeamSetupDialogBackdrop"
-		>
-			<div
-				aria-busy={loading || isSubmitting ? "true" : "false"}
-				className="modal-card legacy-team-setup-card"
-			>
-				<div className="modal-header">
-					<h2 id="legacy-team-setup-title" tabIndex={-1}>
-						{title}
-					</h2>
-					<DialogCloseButton
-						ariaDisabled={isSubmitting}
-						ariaLabel={`Close ${title}`}
-						onClick={close}
-					/>
-				</div>
-				<div className="modal-body legacy-team-setup-body">
-					<p className="small" id="legacy-team-setup-description">
-						Review device ownership and Project access before this Team can be used for sharing.
-					</p>
-					{loading && !detail ? <p role="status">Loading the latest Team setup details…</p> : null}
-					{error ? (
-						<div className="legacy-team-setup-error">
-							<p aria-live="assertive" id="legacy-team-setup-error" role="alert">
-								{error}
-							</p>
-							{!detail || !recoveryRequired ? (
-								<button
-									aria-disabled={loading || isSubmitting ? "true" : undefined}
-									className="settings-button legacy-team-setup-target"
-									id="legacy-team-setup-retry"
-									onClick={() => {
-										if (loading || isSubmitting) return;
-										focusAfterLoad.current = true;
-										refreshBeforeLoad.current = retryNeedsRefresh.current;
-										setLoadRevision((current) => current + 1);
-									}}
-									type="button"
-								>
-									{loading ? "Retrying…" : "Retry"}
-								</button>
-							) : null}
-						</div>
-					) : null}
-					{detail ? (
-						<>
-							{step !== "completed" ? (
-								<>
-									<ol
-										{...EXPLICIT_LIST_ROLE}
-										aria-label="Team setup steps"
-										className="legacy-team-setup-steps"
-									>
-										<li {...EXPLICIT_LIST_ITEM_ROLE} className="legacy-team-setup-step">
-											<span aria-hidden="true" className="legacy-team-setup-step-number">
-												1
-											</span>
-											<button
-												aria-label="Step 1: Devices"
-												aria-current={step === "devices" ? "step" : undefined}
-												className="settings-button legacy-team-setup-target"
-												onClick={() => navigate("devices")}
-												type="button"
-											>
-												Devices
-											</button>
-										</li>
-										<li {...EXPLICIT_LIST_ITEM_ROLE} className="legacy-team-setup-step">
-											<span aria-hidden="true" className="legacy-team-setup-step-number">
-												2
-											</span>
-											<button
-												aria-label="Step 2: Projects"
-												aria-current={step === "projects" ? "step" : undefined}
-												aria-describedby={
-													devicesBlockProgress ? "legacy-team-setup-block-devices" : undefined
-												}
-												aria-disabled={devicesBlockProgress ? "true" : undefined}
-												className="settings-button legacy-team-setup-target"
-												onClick={() => {
-													if (devicesBlockProgress) {
-														explainBlockedStep(
-															"devices",
-															"Finish the device decisions before mapping Projects.",
-														);
-													} else navigate("projects");
-												}}
-												type="button"
-											>
-												Projects
-											</button>
-										</li>
-										<li {...EXPLICIT_LIST_ITEM_ROLE} className="legacy-team-setup-step">
-											<span aria-hidden="true" className="legacy-team-setup-step-number">
-												3
-											</span>
-											<button
-												aria-label="Step 3: Review"
-												aria-current={step === "review" ? "step" : undefined}
-												aria-describedby={
-													devicesBlockProgress
-														? "legacy-team-setup-block-devices"
-														: projectsBlockReview
-															? "legacy-team-setup-block-projects"
-															: undefined
-												}
-												aria-disabled={
-													devicesBlockProgress || projectsBlockReview ? "true" : undefined
-												}
-												className="settings-button legacy-team-setup-target"
-												onClick={() => {
-													if (devicesBlockProgress) {
-														explainBlockedStep(
-															"devices",
-															"Finish the device decisions before reviewing access.",
-														);
-													} else if (projectsBlockReview) {
-														explainBlockedStep(
-															"projects",
-															"Finish the Project mappings before reviewing access.",
-														);
-													} else navigate("review");
-												}}
-												type="button"
-											>
-												Review
-											</button>
-										</li>
-									</ol>
-									{devicesBlockProgress ? (
-										<p className="small" id="legacy-team-setup-block-devices">
-											Finish the device decisions before mapping Projects or reviewing access.
-										</p>
-									) : null}
-									{projectsBlockReview ? (
-										<p className="small" id="legacy-team-setup-block-projects">
-											Finish the Project mappings before reviewing access.
-										</p>
-									) : null}
-								</>
-							) : null}
-							{loading ? (
-								<p
-									aria-live="polite"
-									className="small"
-									id="legacy-team-setup-refresh-status"
-									role="status"
-								>
-									Refreshing Team setup details…
-								</p>
-							) : null}
-							<p
-								aria-live="polite"
-								className="small"
-								id="legacy-team-setup-operation-status"
-								role="status"
-							>
-								{operationStatus}
-							</p>
-							{recoveryRequired ? (
-								<button
-									aria-disabled={loading || isSubmitting ? "true" : undefined}
-									className="settings-button legacy-team-setup-target"
-									id="legacy-team-setup-refresh"
-									onClick={refreshSetup}
-									type="button"
-								>
-									Refresh Team setup
-								</button>
-							) : null}
-							{step === "devices" ? (
-								<LegacyTeamSetupDevices
-									blocked={mutationsBlocked}
-									blockedDescriptionId={mutationBlockDescriptionId}
-									busyDeviceRef={busyDeviceRef}
-									detail={detail}
-									onAssign={assignDevice}
-									onClear={clearDevice}
-									onDecision={decideDevice}
-								/>
-							) : step === "projects" ? (
-								<LegacyTeamSetupProjects
-									blocked={mutationsBlocked}
-									blockedDescriptionId={mutationBlockDescriptionId}
-									busyProjectRef={busyProjectRef}
-									detail={detail}
-									onContinue={() => navigate("review")}
-									onMap={mapProject}
-								/>
-							) : step === "review" && isReadyToFinish(detail) ? (
-								<LegacyTeamSetupReview
-									blocked={mutationsBlocked}
-									blockedDescriptionId={mutationBlockDescriptionId}
-									detail={detail}
-									onFinish={finishSetup}
-								/>
-							) : (
-								<>
-									<StepContent detail={detail} step={step} />
-									{step === "review" && !isReadyToFinish(detail) && !recoveryRequired ? (
-										<button
-											aria-disabled={loading || isSubmitting ? "true" : undefined}
-											className="settings-button legacy-team-setup-target"
-											onClick={refreshSetup}
-											type="button"
-										>
-											Refresh Team setup
-										</button>
-									) : null}
-								</>
-							)}
-						</>
-					) : null}
-				</div>
-				<div className="modal-footer legacy-team-setup-actions">
-					<button
-						aria-disabled={isSubmitting ? "true" : undefined}
-						className="settings-button legacy-team-setup-target"
-						onClick={close}
-						type="button"
-					>
-						Close
-					</button>
-				</div>
-			</div>
-		</RadixDialog>
+			onFinish={() => dispatch({ type: "finish" })}
+			onMap={(project, resolvedProjectRef) =>
+				dispatch({ type: "map_project", projectRef: project.projectRef, resolvedProjectRef })
+			}
+			onNavigate={navigate}
+			onOpenAutoFocus={focusTitle}
+			onRefresh={() => dispatch({ type: "refresh" })}
+			onRetry={() => dispatch({ type: "retry" })}
+		/>
 	);
+}
+
+const focusTitle: NonNullable<RadixDialogProps["onOpenAutoFocus"]> = (event) => {
+	const heading = document.getElementById("legacy-team-setup-title");
+	if (!heading) return;
+	event.preventDefault();
+	heading.focus();
+};
+
+function restoreFocus(
+	event: Parameters<NonNullable<RadixDialogProps["onCloseAutoFocus"]>>[0],
+	returnFocus: { current: HTMLElement | null },
+): void {
+	event.preventDefault();
+	const activeTab = document.querySelector<HTMLElement>('.tab-btn[aria-current="page"]');
+	const target = canRestoreFocus(returnFocus.current) ? returnFocus.current : activeTab;
+	target?.focus();
+	returnFocus.current = null;
 }
 
 export function mountLegacyTeamSetupDialog(

--- a/packages/ui/src/tabs/legacy-team-setup-dom.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-dom.ts
@@ -1,0 +1,3 @@
+export function setupItemErrorId(kind: "device" | "project", itemRef: string): string {
+	return `legacy-team-setup-item-error-${kind}-${itemRef}`;
+}

--- a/packages/ui/src/tabs/legacy-team-setup-projects.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-projects.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useId, useState } from "preact/hooks";
 import type { LegacyTeamSetupDetailResponseV1, LegacyTeamSetupProjectV1 } from "../lib/api";
 import { stableProjectPresentationLabels } from "../lib/project-identity-presentation";
+import { setupItemErrorId } from "./legacy-team-setup-dom";
 
 export interface LegacyTeamSetupProjectsProps {
 	blocked: boolean;
+	blockedProjectRefs?: ReadonlySet<string>;
 	blockedDescriptionId?: string;
-	busyProjectRef: string | null;
+	busyProjectRefs: ReadonlySet<string>;
 	detail: LegacyTeamSetupDetailResponseV1;
 	onContinue: () => void;
 	onMap: (project: LegacyTeamSetupProjectV1, resolvedProjectRef: string) => void;
@@ -22,11 +24,15 @@ function mappingName(
 function ProjectRow({
 	blocked,
 	blockedDescriptionId,
+	blockedProjectRefs,
 	busy,
 	index,
 	onMap,
 	project,
-}: Pick<LegacyTeamSetupProjectsProps, "blocked" | "blockedDescriptionId" | "onMap"> & {
+}: Pick<
+	LegacyTeamSetupProjectsProps,
+	"blocked" | "blockedDescriptionId" | "blockedProjectRefs" | "onMap"
+> & {
 	busy: boolean;
 	index: number;
 	project: LegacyTeamSetupProjectV1;
@@ -76,12 +82,17 @@ function ProjectRow({
 	const selectedMapping = choices.find(
 		(choice) => choice.token === draftMapping,
 	)?.resolvedProjectRef;
-	const controlsBlocked = blocked || busy || !project.actions.map.enabled;
+	const itemBlocked = blockedProjectRefs?.has(project.projectRef) ?? false;
+	const controlsBlocked = blocked || itemBlocked || busy || !project.actions.map.enabled;
 	const saveBlocked = controlsBlocked || !selectedMapping || selectedMapping === savedMapping;
 	const savedName = mappingName(project, labels);
 	const controlDescription = [
 		!draftMapping ? helpId : undefined,
-		blocked ? blockedDescriptionId : undefined,
+		blocked
+			? blockedDescriptionId
+			: itemBlocked
+				? setupItemErrorId("project", project.projectRef)
+				: undefined,
 	]
 		.filter(Boolean)
 		.join(" ");
@@ -168,7 +179,8 @@ export function LegacyTeamSetupProjects(props: LegacyTeamSetupProjectsProps) {
 					<ProjectRow
 						blocked={props.blocked}
 						blockedDescriptionId={props.blockedDescriptionId}
-						busy={props.busyProjectRef === project.projectRef}
+						blockedProjectRefs={props.blockedProjectRefs}
+						busy={props.busyProjectRefs.has(project.projectRef)}
 						index={index}
 						key={project.projectRef}
 						onMap={props.onMap}

--- a/packages/ui/src/tabs/legacy-team-setup-session.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.test.ts
@@ -170,6 +170,30 @@ describe("legacy Team setup session reducer", () => {
 		});
 	});
 
+	it("keeps navigation on Devices while device decisions remain unresolved", () => {
+		const state = loaded();
+
+		expect(reduceSetupSession(state, { type: "navigate", step: "projects" })).toMatchObject({
+			step: "devices",
+			message: "Finish the device decisions before mapping Projects.",
+			focus: { targetId: "legacy-team-device-row-0" },
+		});
+	});
+
+	it("keeps navigation on Projects while Project mappings remain unresolved", () => {
+		const current = view({
+			unresolvedDeviceCount: 0,
+			devices: view().devices.map((device) => ({ ...device, decision: "excluded" as const })),
+		});
+		const state = loaded(open(), current);
+
+		expect(reduceSetupSession(state, { type: "navigate", step: "review" })).toMatchObject({
+			step: "projects",
+			message: "Finish the Project mappings before reviewing access.",
+			focus: { targetId: "legacy-team-project-row-0" },
+		});
+	});
+
 	it("does not expose completed as an interactive navigation destination", () => {
 		const state = loaded();
 		const fabricated = { type: "navigate", step: "completed" } as unknown as SetupSessionEvent;
@@ -239,6 +263,48 @@ describe("legacy Team setup session reducer", () => {
 				decision: "excluded",
 			}),
 		).toMatchObject({ commands: [expect.objectContaining({ deviceRef: "device-b" })] });
+	});
+
+	it("focuses the next step when an unrelated item error remains", () => {
+		let state: SetupSessionState = {
+			...loaded(),
+			errors: [
+				{
+					scope: { kind: "device", itemRef: "device-a" },
+					message: "Retry this device change",
+					retry: "load",
+				},
+			],
+		};
+		state = reduceSetupSession(state, {
+			type: "decide_device",
+			deviceRef: "device-b",
+			decision: "excluded",
+		});
+		if (state.status !== "open") throw new Error("expected open mutation session");
+		const command = state.commands[0];
+		if (!command) throw new Error("expected mutation command");
+		const nextView = view({
+			unresolvedDeviceCount: 0,
+			devices: view().devices.map((device) => ({ ...device, decision: "excluded" as const })),
+		});
+
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "success",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				view: nextView,
+			},
+		});
+
+		expect(state).toMatchObject({
+			step: "projects",
+			focus: { targetId: "legacy-team-setup-step-projects" },
+			errors: [expect.objectContaining({ scope: { kind: "device", itemRef: "device-a" } })],
+		});
 	});
 
 	it("ignores device mutations while an authoritative refresh is running", () => {
@@ -632,6 +698,65 @@ describe("legacy Team setup session reducer", () => {
 		} as LegacyTeamSetupViewV1;
 
 		expect(isEditable(unavailable)).toBe(false);
+	});
+
+	it("enforces server action gates before enqueuing mutations", () => {
+		const state = loaded();
+
+		expect(
+			reduceSetupSession(state, {
+				type: "decide_device",
+				deviceRef: "device-a",
+				decision: "included",
+				targetIdentityRef: "identity-a",
+			}),
+		).toBe(state);
+		expect(
+			reduceSetupSession(state, {
+				type: "map_project",
+				projectRef: "project-a",
+				resolvedProjectRef: "resolved-a",
+			}),
+		).toBe(state);
+	});
+
+	it("prefers authoritative refresh when any accumulated error requires it", () => {
+		const state: OpenSetupSessionState = {
+			...loaded(),
+			errors: [
+				{
+					scope: { kind: "device", itemRef: "device-a" },
+					message: "Device failed",
+					retry: "load",
+				},
+				{ scope: { kind: "global" }, message: "State changed", retry: "refresh" },
+			],
+		};
+		const retried = reduceSetupSession(state, { type: "retry" });
+
+		expect(retried).toMatchObject({
+			commands: [expect.objectContaining({ kind: "load", refresh: true })],
+		});
+	});
+
+	it("does not queue retry while an item mutation is running", () => {
+		const state = reduceSetupSession(
+			{
+				...loaded(),
+				errors: [
+					{
+						scope: { kind: "project", itemRef: "project-a" },
+						message: "Project failed",
+						retry: "load",
+					},
+				],
+			},
+			{ type: "decide_device", deviceRef: "device-a", decision: "excluded" },
+		);
+		if (state.status !== "open") throw new Error("expected open session");
+
+		expect(state.commands).toEqual([expect.objectContaining({ kind: "decide_device" })]);
+		expect(reduceSetupSession(state, { type: "retry" })).toBe(state);
 	});
 
 	it("queues completion refresh exactly once after finish", () => {

--- a/packages/ui/src/tabs/legacy-team-setup-session.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.ts
@@ -13,7 +13,7 @@ import {
 } from "./legacy-team-setup-focus";
 
 export type TeamSetupStep = "devices" | "projects" | "review" | "completed";
-type InteractiveTeamSetupStep = Exclude<TeamSetupStep, "completed">;
+export type InteractiveTeamSetupStep = Exclude<TeamSetupStep, "completed">;
 export type SetupErrorScope =
 	| { kind: "load" }
 	| { kind: "global" }
@@ -152,6 +152,27 @@ function open(generation: number, candidateRef: string): OpenSetupSessionState {
 
 function navigate(state: SetupSessionState, step: TeamSetupStep): SetupSessionState {
 	if (state.status !== "open" || state.step === "completed" || step === "completed") return state;
+	if (step === "projects" && state.view?.unresolvedDeviceCount) {
+		return blockedNavigation(
+			state,
+			"devices",
+			"Finish the device decisions before mapping Projects.",
+		);
+	}
+	if (step === "review" && state.view?.unresolvedDeviceCount) {
+		return blockedNavigation(
+			state,
+			"devices",
+			"Finish the device decisions before reviewing access.",
+		);
+	}
+	if (step === "review" && state.view?.unresolvedProjectCount) {
+		return blockedNavigation(
+			state,
+			"projects",
+			"Finish the Project mappings before reviewing access.",
+		);
+	}
 	const projectsVisitedAttemptId =
 		step === "projects" && state.view ? state.view.attemptId : state.projectsVisitedAttemptId;
 	return {
@@ -470,7 +491,10 @@ function applyView(
 			? [
 					{
 						scope: { kind: "global" } as const,
-						message: CHANGED_STATE_ERROR,
+						message:
+							view.unavailableReason === "team_setup_roster_unavailable"
+								? ROSTER_UNAVAILABLE_ERROR
+								: CHANGED_STATE_ERROR,
 						retry: "refresh" as const,
 					},
 				]
@@ -498,11 +522,14 @@ function applyView(
 				? "Team setup complete. Sharing and Projects are refreshing."
 				: state.message,
 	};
+	const hasGlobalRetryTarget = unavailableError.some(
+		(error) => error.scope.kind === "global" || error.scope.kind === "load",
+	);
 	if (focusOnOutcome || step !== state.step) {
 		next = {
 			...next,
 			focus: planLoadFocus(next.nextFocusId, {
-				hasError: unavailableError.length > 0,
+				hasError: hasGlobalRetryTarget,
 				recovery: view.state === "unavailable",
 				step,
 			}),
@@ -613,7 +640,9 @@ function initialStep(view: LegacyTeamSetupViewV1, projectsVisited: boolean): Tea
 	return "review";
 }
 
-export function isEditable(view: LegacyTeamSetupViewV1 | null): boolean {
+export function isEditable(
+	view: LegacyTeamSetupViewV1 | null,
+): view is Extract<LegacyTeamSetupViewV1, { state: "reviewing" | "ready_to_finish" }> {
 	return view?.state === "reviewing" || view?.state === "ready_to_finish";
 }
 
@@ -665,7 +694,11 @@ export function globalError(state: OpenSetupSessionState): SetupSessionError | n
 }
 
 function needsRecovery(view: LegacyTeamSetupViewV1): boolean {
-	return view.state === "unavailable" && isChangedStateCode(view.unavailableReason);
+	return (
+		view.state === "unavailable" &&
+		(isChangedStateCode(view.unavailableReason) ||
+			view.unavailableReason === "team_setup_roster_unavailable")
+	);
 }
 
 function clearScope(state: OpenSetupSessionState, scope: SetupErrorScope): OpenSetupSessionState {


### PR DESCRIPTION
## Description
Replaces the legacy Team setup god component with a 232-line coordination shell and a presentational dialog view. The opener no longer uses mutable module globals; concurrent item work renders correctly; scoped errors have valid accessible references and unique retry controls.

Part 3 of codemem-752i.4.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] 79 focused reducer, effect, focus, dialog, and app tests
- [x] `pnpm run tsc`
- [x] `pnpm run lint`
- [x] `pnpm --filter @codemem/ui build`

## Checklist
- [x] Code follows project style
- [x] CodeReviewer and complexity review completed
- [x] No new warnings introduced