### PR TITLE
feat(ui): prioritize actionable Team setup work

### DIFF
--- a/packages/ui/src/tabs/legacy-team-setup-devices.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-devices.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useId, useState } from "preact/hooks";
 import type { LegacyTeamSetupDetailResponseV1, LegacyTeamSetupDeviceV1 } from "../lib/api";
 import { setupItemErrorId } from "./legacy-team-setup-dom";
+import { orderedSetupDevices } from "./legacy-team-setup-order";
 
 type DeviceDecision = "included" | "excluded" | "removed";
 
@@ -54,9 +55,10 @@ function DeviceRow({
 	device: LegacyTeamSetupDeviceV1;
 	index: number;
 }) {
-	const controlId = `legacy-team-device-identity-${index}`;
-	const evidenceId = `legacy-team-device-evidence-${index}`;
-	const assignmentHelpId = `legacy-team-device-assignment-help-${index}`;
+	const generatedId = useId();
+	const controlId = `${generatedId}-identity`;
+	const evidenceId = `${generatedId}-evidence`;
+	const assignmentHelpId = `${generatedId}-assignment-help`;
 	const initialIdentity = initialIdentityRef(device);
 	const savedIdentity = device.targetIdentityRef ?? "";
 	const [draftIdentityRef, setDraftIdentityRef] = useState(initialIdentity);
@@ -74,6 +76,7 @@ function DeviceRow({
 	const assignmentIdentityUnavailable = Boolean(draftIdentityRef) && !selectedChoiceExists;
 	const includeNeedsHelp =
 		!device.actions.include.enabled ||
+		assignmentEvidenceInactive ||
 		assignmentIdentityUnavailable ||
 		!savedIdentity ||
 		draftIdentityRef !== savedIdentity;
@@ -98,15 +101,17 @@ function DeviceRow({
 		.filter(Boolean)
 		.join(" ");
 	const actionDescription = [evidenceId, globalBlockedDescription].filter(Boolean).join(" ");
+	const needsAttention = device.decision === "unresolved";
 
 	return (
 		<fieldset
 			aria-busy={busy ? "true" : "false"}
-			className="legacy-team-device-row"
+			className={`legacy-team-device-row${needsAttention ? " legacy-team-setup-row-needs-attention" : ""}`}
 			id={`legacy-team-device-row-${index}`}
-			tabIndex={device.decision === "unresolved" ? -1 : undefined}
+			tabIndex={needsAttention ? -1 : undefined}
 		>
 			<legend>{device.displayName}</legend>
+			{needsAttention ? <span className="legacy-team-setup-status">Needs attention</span> : null}
 			<div className="small legacy-team-device-evidence" id={evidenceId}>
 				<span>
 					{device.enabled ? "Current Team device" : "Device no longer active on this Team"}
@@ -237,6 +242,7 @@ function DeviceRow({
 }
 
 export function LegacyTeamSetupDevices(props: LegacyTeamSetupDevicesProps) {
+	const devices = orderedSetupDevices(props.detail.devices);
 	return (
 		<section aria-labelledby="legacy-team-setup-step-devices">
 			<h3 id="legacy-team-setup-step-devices" tabIndex={-1}>
@@ -247,7 +253,7 @@ export function LegacyTeamSetupDevices(props: LegacyTeamSetupDevicesProps) {
 				{props.detail.candidate.deviceCount.toLocaleString()} Team devices still need a decision.
 			</p>
 			<div className="legacy-team-device-list">
-				{props.detail.devices.map((device, index) => (
+				{devices.map((device, index) => (
 					<DeviceRow
 						{...props}
 						busy={props.busyDeviceRefs.has(device.deviceRef)}

--- a/packages/ui/src/tabs/legacy-team-setup-dialog-view.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog-view.tsx
@@ -45,13 +45,14 @@ export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps)
 	const globalBusy = hasGlobalOperation(session) || hasBlockingOperation(session);
 	const recoveryRequired = view?.state === "unavailable" || error?.retry === "refresh";
 	const mutationsBlocked = !isEditable(view) || globalBusy || Boolean(error);
-	const mutationBlockDescriptionId = error
-		? "legacy-team-setup-error"
-		: globalBusy
-			? "legacy-team-setup-operation-status"
-			: view?.state === "unavailable"
-				? "legacy-team-setup-refresh"
-				: undefined;
+	const mutationBlockDescriptionId =
+		[
+			error ? "legacy-team-setup-error" : null,
+			globalBusy ? "legacy-team-setup-operation-status" : null,
+			view?.state === "unavailable" ? "legacy-team-setup-refresh" : null,
+		]
+			.filter(Boolean)
+			.join(" ") || undefined;
 	const title = view ? `Set up ${view.candidate.displayName}` : "Set up Team";
 	const itemErrors = session.errors.filter(
 		(item) => item.scope.kind === "device" || item.scope.kind === "project",

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -489,6 +489,12 @@ describe("legacy Team setup dialog", () => {
 		});
 		expect(document.body.textContent).toContain("Review Projects");
 		expect(document.body.textContent).not.toContain("Review and finish");
+		expect(button("Continue to Review").getAttribute("aria-describedby")).toContain(
+			"legacy-team-project-continue-help",
+		);
+		expect(document.getElementById("legacy-team-project-continue-help")?.textContent).toContain(
+			"exact people, devices, and Projects",
+		);
 		act(() => button("Continue to Review").click());
 		expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Review");
 		expect(document.body.textContent).toContain("Review and finish");
@@ -496,6 +502,115 @@ describe("legacy Team setup dialog", () => {
 			"Review device ownership and Project access before this Team can be used for sharing",
 		);
 		expect(document.body.textContent).not.toMatch(/confirmation evidence|server-provided work/i);
+	});
+
+	it("puts the one unresolved SRE device first and marks it as actionable", async () => {
+		const includedDevices = ["Air", "Mini", "NAS", "Pi", "Workstation"].map((displayName, index) =>
+			device({
+				deviceRef: `included-device-${index}`,
+				displayName,
+				decision: "included",
+				suggestedIdentityRef: null,
+				targetIdentityRef: "identity-ref-alex",
+			}),
+		);
+		const sarvar = device({
+			deviceRef: "sarvar-device",
+			displayName: "Sarvar",
+			suggestedIdentityRef: "identity-ref-sam",
+		});
+		setup(
+			vi.fn().mockResolvedValue(
+				detail({
+					devices: [...includedDevices, sarvar],
+					identityChoices: identities,
+					unresolvedDeviceCount: 1,
+				}),
+			),
+		);
+
+		const rows = await vi.waitFor(() => {
+			const matches = [...document.querySelectorAll<HTMLElement>(".legacy-team-device-row")];
+			if (matches.length !== 6) throw new Error("SRE device rows not ready");
+			return matches;
+		});
+		const highlighted = rows.filter((row) =>
+			row.classList.contains("legacy-team-setup-row-needs-attention"),
+		);
+
+		expect(rows[0]?.querySelector("legend")?.textContent).toBe("Sarvar");
+		expect(highlighted).toHaveLength(1);
+		expect(highlighted[0]?.textContent).toContain("Needs attention");
+		const exclude = [...(highlighted[0]?.querySelectorAll<HTMLButtonElement>("button") ?? [])].find(
+			(candidate) => candidate.textContent === "Exclude",
+		);
+		expect(exclude?.getAttribute("aria-disabled")).toBeNull();
+	});
+
+	it("explains unavailable setup states visibly and programmatically", async () => {
+		setup(
+			vi.fn().mockResolvedValue(
+				detail({
+					conflictState: "team_setup_roster_unavailable",
+					devices: [device()],
+					identityChoices: identities,
+					unresolvedDeviceCount: 1,
+				}),
+			),
+		);
+
+		const alert = await vi.waitFor(() => {
+			const match = document.getElementById("legacy-team-setup-error");
+			if (!match) throw new Error("unavailable explanation missing");
+			return match;
+		});
+		const select = document.querySelector<HTMLSelectElement>(".legacy-team-device-select");
+
+		expect(alert.textContent).toContain("temporarily unavailable");
+		expect(select?.getAttribute("aria-describedby")).toContain("legacy-team-setup-error");
+		expect(document.getElementById("legacy-team-setup-refresh")).not.toBeNull();
+	});
+
+	it("explains when an unresolved Project has no safe mapping action", async () => {
+		const unavailableProject: LegacyTeamSetupProjectV1 = {
+			...project(),
+			actions: { map: { enabled: false, blockedReason: "mapping_unavailable" } },
+		};
+		setup(
+			vi
+				.fn()
+				.mockResolvedValue(detail({ projects: [unavailableProject], unresolvedProjectCount: 1 })),
+		);
+
+		const select = await vi.waitFor(() => {
+			const match = document.querySelector<HTMLSelectElement>(".legacy-team-project-select");
+			if (!match) throw new Error("Project mapping control missing");
+			return match;
+		});
+		const descriptionIds = select.getAttribute("aria-describedby")?.split(" ") ?? [];
+
+		expect(select.disabled).toBe(true);
+		expect(descriptionIds).toHaveLength(1);
+		expect(document.getElementById(descriptionIds[0] ?? "")?.textContent).toContain(
+			"No safe Project mapping is available",
+		);
+	});
+
+	it("does not describe an unavailable setup as missing Project mappings", async () => {
+		setup(
+			vi.fn().mockResolvedValue(
+				detail({
+					conflictState: "team_setup_roster_unavailable",
+					projects: [project()],
+					unresolvedProjectCount: 1,
+				}),
+			),
+		);
+
+		await vi.waitFor(() =>
+			expect(document.getElementById("legacy-team-setup-error")).not.toBeNull(),
+		);
+		expect(document.body.textContent).not.toContain("No safe Project mapping is available");
 	});
 
 	it("returns a ready draft to Projects when the dialog is reopened", async () => {
@@ -624,7 +739,7 @@ describe("legacy Team setup dialog", () => {
 
 		await vi.waitFor(() => {
 			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
-				"Check the coordinator connection and settings, then retry.",
+				"Check the coordinator connection and settings, then refresh.",
 			);
 		});
 		expect(document.body.textContent).not.toContain("team_setup_roster_unavailable");
@@ -902,9 +1017,13 @@ describe("legacy Team setup dialog", () => {
 		expect(rows[1].textContent).toContain("This person is no longer available");
 		expect(save?.getAttribute("aria-disabled")).toBe("true");
 		expect(include?.getAttribute("aria-disabled")).toBe("true");
-		expect(rows[0].querySelector("select")?.getAttribute("aria-describedby")).toContain(
-			"legacy-team-device-assignment-help-0",
-		);
+		const descriptionIds =
+			rows[0].querySelector("select")?.getAttribute("aria-describedby")?.split(" ") ?? [];
+		expect(
+			descriptionIds.some((id) =>
+				document.getElementById(id)?.textContent?.includes("This person is no longer available"),
+			),
+		).toBe(true);
 		act(() => {
 			save?.click();
 			include?.click();

--- a/packages/ui/src/tabs/legacy-team-setup-order.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-order.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { LegacyTeamSetupDeviceV1, LegacyTeamSetupProjectV1 } from "../lib/api";
+import { orderedSetupDevices, orderedSetupProjects } from "./legacy-team-setup-order";
+
+describe("legacy Team setup ordering", () => {
+	it("puts unresolved devices first without mutating the server view", () => {
+		const included = { deviceRef: "included", displayName: "Alpha", decision: "included" };
+		const unresolved = { deviceRef: "unresolved", displayName: "Sarvar", decision: "unresolved" };
+		const devices = [included, unresolved] as LegacyTeamSetupDeviceV1[];
+
+		expect(orderedSetupDevices(devices).map((device) => device.deviceRef)).toEqual([
+			"unresolved",
+			"included",
+		]);
+		expect(devices.map((device) => device.deviceRef)).toEqual(["included", "unresolved"]);
+	});
+
+	it("puts unresolved Projects before automatic mappings", () => {
+		const automatic = {
+			projectRef: "automatic",
+			displayName: "Alpha",
+			resolution: "deterministic",
+		};
+		const unresolved = {
+			projectRef: "unresolved",
+			displayName: "Zulu",
+			resolution: "unresolved",
+		};
+
+		expect(
+			orderedSetupProjects([automatic, unresolved] as LegacyTeamSetupProjectV1[]).map(
+				(project) => project.projectRef,
+			),
+		).toEqual(["unresolved", "automatic"]);
+	});
+
+	it("preserves server order within unresolved and reviewed groups", () => {
+		const devices = [
+			{ deviceRef: "included-a", decision: "included" },
+			{ deviceRef: "unresolved-a", decision: "unresolved" },
+			{ deviceRef: "included-b", decision: "included" },
+			{ deviceRef: "unresolved-b", decision: "unresolved" },
+		] as LegacyTeamSetupDeviceV1[];
+
+		expect(orderedSetupDevices(devices).map((device) => device.deviceRef)).toEqual([
+			"unresolved-a",
+			"unresolved-b",
+			"included-a",
+			"included-b",
+		]);
+	});
+});

--- a/packages/ui/src/tabs/legacy-team-setup-order.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-order.ts
@@ -1,0 +1,19 @@
+import type { LegacyTeamSetupDeviceV1, LegacyTeamSetupProjectV1 } from "../lib/api";
+
+export function orderedSetupDevices(
+	devices: readonly LegacyTeamSetupDeviceV1[],
+): LegacyTeamSetupDeviceV1[] {
+	return [...devices].sort(
+		(left, right) =>
+			Number(right.decision === "unresolved") - Number(left.decision === "unresolved"),
+	);
+}
+
+export function orderedSetupProjects(
+	projects: readonly LegacyTeamSetupProjectV1[],
+): LegacyTeamSetupProjectV1[] {
+	return [...projects].sort(
+		(left, right) =>
+			Number(right.resolution === "unresolved") - Number(left.resolution === "unresolved"),
+	);
+}

--- a/packages/ui/src/tabs/legacy-team-setup-projects.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-projects.tsx
@@ -2,6 +2,7 @@ import { useEffect, useId, useState } from "preact/hooks";
 import type { LegacyTeamSetupDetailResponseV1, LegacyTeamSetupProjectV1 } from "../lib/api";
 import { stableProjectPresentationLabels } from "../lib/project-identity-presentation";
 import { setupItemErrorId } from "./legacy-team-setup-dom";
+import { orderedSetupProjects } from "./legacy-team-setup-order";
 
 export interface LegacyTeamSetupProjectsProps {
 	blocked: boolean;
@@ -83,11 +84,13 @@ function ProjectRow({
 		(choice) => choice.token === draftMapping,
 	)?.resolvedProjectRef;
 	const itemBlocked = blockedProjectRefs?.has(project.projectRef) ?? false;
+	const mappingUnavailable = project.actions.map.blockedReason === "mapping_unavailable";
+	const needsMappingSelection = project.actions.map.enabled && !draftMapping;
 	const controlsBlocked = blocked || itemBlocked || busy || !project.actions.map.enabled;
 	const saveBlocked = controlsBlocked || !selectedMapping || selectedMapping === savedMapping;
 	const savedName = mappingName(project, labels);
 	const controlDescription = [
-		!draftMapping ? helpId : undefined,
+		mappingUnavailable || needsMappingSelection ? helpId : undefined,
 		blocked
 			? blockedDescriptionId
 			: itemBlocked
@@ -96,16 +99,18 @@ function ProjectRow({
 	]
 		.filter(Boolean)
 		.join(" ");
+	const needsAttention = project.resolution === "unresolved";
 
 	return (
 		<fieldset
 			aria-busy={busy ? "true" : "false"}
-			className="legacy-team-project-row"
+			className={`legacy-team-project-row${needsAttention ? " legacy-team-setup-row-needs-attention" : ""}`}
 			id={`legacy-team-project-row-${index}`}
-			tabIndex={project.resolution === "unresolved" ? -1 : undefined}
+			tabIndex={needsAttention ? -1 : undefined}
 		>
 			<legend>{project.displayName}</legend>
 			<div className="legacy-team-project-row-content">
+				{needsAttention ? <span className="legacy-team-setup-status">Needs attention</span> : null}
 				{project.resolution === "deterministic" ? (
 					<p className="small">Mapped automatically from matching Project evidence.</p>
 				) : (
@@ -129,7 +134,11 @@ function ProjectRow({
 								</option>
 							))}
 						</select>
-						{!draftMapping ? (
+						{mappingUnavailable ? (
+							<p className="small" id={helpId}>
+								No safe Project mapping is available. Refresh after Project evidence changes.
+							</p>
+						) : needsMappingSelection ? (
 							<p className="small" id={helpId}>
 								Choose and save one of the server-provided Project mappings.
 							</p>
@@ -153,6 +162,7 @@ function ProjectRow({
 }
 
 export function LegacyTeamSetupProjects(props: LegacyTeamSetupProjectsProps) {
+	const projects = orderedSetupProjects(props.detail.projects);
 	const automaticallyMappedCount = props.detail.projects.filter(
 		(project) => project.resolution === "deterministic",
 	).length;
@@ -175,7 +185,7 @@ export function LegacyTeamSetupProjects(props: LegacyTeamSetupProjectsProps) {
 				<p className="small">Review the automatic mappings below before continuing.</p>
 			) : null}
 			<div className="legacy-team-project-list">
-				{props.detail.projects.map((project, index) => (
+				{projects.map((project, index) => (
 					<ProjectRow
 						blocked={props.blocked}
 						blockedDescriptionId={props.blockedDescriptionId}
@@ -189,17 +199,27 @@ export function LegacyTeamSetupProjects(props: LegacyTeamSetupProjectsProps) {
 				))}
 			</div>
 			{props.detail.unresolvedProjectCount === 0 ? (
-				<button
-					aria-describedby={props.blocked ? props.blockedDescriptionId : undefined}
-					aria-disabled={props.blocked ? "true" : undefined}
-					className="settings-button legacy-team-setup-target"
-					onClick={() => {
-						if (!props.blocked) props.onContinue();
-					}}
-					type="button"
-				>
-					Continue to Review
-				</button>
+				<div className="legacy-team-setup-next-action">
+					<p className="small" id="legacy-team-project-continue-help">
+						Continue to review the exact people, devices, and Projects that will receive access.
+					</p>
+					<button
+						aria-describedby={[
+							"legacy-team-project-continue-help",
+							props.blocked ? props.blockedDescriptionId : null,
+						]
+							.filter(Boolean)
+							.join(" ")}
+						aria-disabled={props.blocked ? "true" : undefined}
+						className="settings-button legacy-team-setup-target"
+						onClick={() => {
+							if (!props.blocked) props.onContinue();
+						}}
+						type="button"
+					>
+						Continue to Review
+					</button>
+				</div>
 			) : null}
 		</section>
 	);

--- a/packages/ui/src/tabs/legacy-team-setup-session.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.ts
@@ -1,4 +1,8 @@
-import { LegacyTeamSetupApiError, type LegacyTeamSetupViewV1 } from "../lib/api";
+import {
+	LegacyTeamSetupApiError,
+	type LegacyTeamSetupErrorCode,
+	type LegacyTeamSetupViewV1,
+} from "../lib/api";
 import type {
 	SetupEffect,
 	SetupEffectInput,
@@ -11,6 +15,7 @@ import {
 	planStepFocus,
 	type SetupFocusPlan,
 } from "./legacy-team-setup-focus";
+import { orderedSetupDevices, orderedSetupProjects } from "./legacy-team-setup-order";
 
 export type TeamSetupStep = "devices" | "projects" | "review" | "completed";
 export type InteractiveTeamSetupStep = Exclude<TeamSetupStep, "completed">;
@@ -74,7 +79,7 @@ export type SetupSessionEvent =
 const CHANGED_STATE_ERROR =
 	"Team setup changed since it was last reviewed. Reload the latest details to continue.";
 const ROSTER_UNAVAILABLE_ERROR =
-	"Team device details are temporarily unavailable. Check the coordinator connection and settings, then retry.";
+	"Team device details are temporarily unavailable. Check the coordinator connection and settings, then refresh.";
 
 export function createSetupSessionState(): SetupSessionState {
 	return { status: "closed", generation: 0 };
@@ -192,8 +197,12 @@ function blockedNavigation(
 	if (state.status !== "open" || state.step === "completed" || !state.view) return state;
 	const unresolvedIndex =
 		step === "devices"
-			? state.view.devices.findIndex((device) => device.decision === "unresolved")
-			: state.view.projects.findIndex((project) => project.resolution === "unresolved");
+			? orderedSetupDevices(state.view.devices).findIndex(
+					(device) => device.decision === "unresolved",
+				)
+			: orderedSetupProjects(state.view.projects).findIndex(
+					(project) => project.resolution === "unresolved",
+				);
 	return {
 		...state,
 		step,
@@ -487,14 +496,11 @@ function applyView(
 	const projectsVisitedAttemptId =
 		step === "projects" ? view.attemptId : state.projectsVisitedAttemptId;
 	const unavailableError: SetupSessionError[] =
-		view.state === "unavailable" && needsRecovery(view)
+		view.state === "unavailable"
 			? [
 					{
 						scope: { kind: "global" } as const,
-						message:
-							view.unavailableReason === "team_setup_roster_unavailable"
-								? ROSTER_UNAVAILABLE_ERROR
-								: CHANGED_STATE_ERROR,
+						message: unavailableMessage(view.unavailableReason),
 						retry: "refresh" as const,
 					},
 				]
@@ -693,12 +699,13 @@ export function globalError(state: OpenSetupSessionState): SetupSessionError | n
 	);
 }
 
-function needsRecovery(view: LegacyTeamSetupViewV1): boolean {
-	return (
-		view.state === "unavailable" &&
-		(isChangedStateCode(view.unavailableReason) ||
-			view.unavailableReason === "team_setup_roster_unavailable")
-	);
+function unavailableMessage(reason: LegacyTeamSetupErrorCode): string {
+	if (isChangedStateCode(reason)) return CHANGED_STATE_ERROR;
+	if (reason === "team_setup_roster_unavailable") return ROSTER_UNAVAILABLE_ERROR;
+	if (reason === "team_setup_incomplete") {
+		return "Team setup needs refreshed server details before review can continue.";
+	}
+	return "Team setup details are temporarily unavailable. Refresh to load the latest server state.";
 }
 
 function clearScope(state: OpenSetupSessionState, scope: SetupErrorScope): OpenSetupSessionState {

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1326,18 +1326,18 @@
         opacity: 0.55;
         cursor: not-allowed;
       }
-      .legacy-team-setup-body h3 { margin: var(--sp-2) 0; }
+      .legacy-team-setup-body h3 { margin: var(--sp-4) 0 var(--sp-2); }
       .legacy-team-setup-body p { overflow-wrap: anywhere; }
       .legacy-team-setup-error { display: grid; gap: var(--sp-2); justify-items: start; }
       .legacy-team-setup-actions { justify-content: flex-end; }
       .legacy-team-setup-target { min-width: 24px; min-height: 24px; }
-      .legacy-team-device-list { display: grid; gap: var(--sp-3); margin-top: var(--sp-3); }
+      .legacy-team-device-list { display: grid; gap: var(--sp-4); margin-top: var(--sp-4); }
       .legacy-team-device-row {
         display: grid;
         gap: var(--sp-2);
         min-width: 0;
         margin: 0;
-        padding: var(--sp-3);
+        padding: var(--sp-4);
         border: 1px solid var(--border);
         border-radius: var(--radius-md);
         background: var(--surface-2);
@@ -1355,9 +1355,9 @@
       .legacy-team-project-list {
         display: grid;
         grid-template-columns: minmax(0, 1fr);
-        gap: var(--sp-3);
+        gap: var(--sp-4);
         min-width: 0;
-        margin-top: var(--sp-3);
+        margin-top: var(--sp-4);
       }
       .legacy-team-project-row {
         box-sizing: border-box;
@@ -1365,7 +1365,7 @@
         min-width: 0;
         max-width: 100%;
         margin: 0;
-        padding: var(--sp-3);
+        padding: var(--sp-4);
         border: 1px solid var(--border);
         border-radius: var(--radius-md);
         background: var(--surface-2);
@@ -1387,6 +1387,31 @@
       .legacy-team-project-row label { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); }
       .legacy-team-project-select { box-sizing: border-box; width: 100%; min-width: 0; max-width: 100%; margin: 0; }
       .legacy-team-project-select:disabled { opacity: 0.55; cursor: not-allowed; }
+      .legacy-team-setup-row-needs-attention {
+        border-color: var(--accent);
+        background: var(--accent-subtle);
+        scroll-margin-block: var(--sp-4);
+      }
+      .legacy-team-setup-row-needs-attention:focus,
+      .legacy-team-setup-body h3:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      .legacy-team-setup-status {
+        width: fit-content;
+        padding: var(--sp-1) var(--sp-2);
+        border: 1px solid var(--accent);
+        border-radius: 999px;
+        color: var(--text-primary);
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-semibold);
+      }
+      .legacy-team-setup-row-needs-attention .legacy-team-device-actions button:not([aria-disabled="true"]),
+      .legacy-team-setup-row-needs-attention .legacy-team-project-row-content button:not([aria-disabled="true"]) {
+        border-color: var(--accent);
+      }
+      .legacy-team-setup-next-action { display: grid; gap: var(--sp-2); margin-top: var(--sp-4); justify-items: start; }
+      .legacy-team-setup-next-action p { margin: 0; }
       .legacy-team-setup-delta { display: grid; gap: var(--sp-3); }
       .legacy-team-setup-review-summary {
         display: grid;


### PR DESCRIPTION
## Description
Prioritizes actionable legacy Team setup work without disturbing server order. Unresolved devices and Projects render first with a visible Needs attention marker, focus planning uses the same ordering, automatic Project mappings remain reviewable, and every blocked or unavailable action has visible and programmatic recovery copy.

Tracks codemem-752i.5.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] 77 focused order, reducer, dialog, and app tests
- [x] SRE fixture: five included devices plus one unresolved Sarvar
- [x] `pnpm run tsc`
- [x] `pnpm run lint`
- [x] `pnpm --filter @codemem/ui build`

## Checklist
- [x] Code follows project style
- [x] Accessibility and CodeReviewer review completed
- [x] No new warnings introduced