### PR TITLE
feat(viewer): ship pending-only Team setup gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ packages/ui/index.html
 
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
+.beads.gate.lock

--- a/e2e/scenarios/legacy-team-migration.ts
+++ b/e2e/scenarios/legacy-team-migration.ts
@@ -794,8 +794,8 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 		(candidate) => candidate.candidateRef === betaCandidate.candidateRef,
 	);
 	assert(
-		recoveredSummary.status === 200 && recoveredBetaSummary?.status === "ready",
-		"summary did not recover Beta as ready after the dropped finish response",
+		recoveredSummary.status === 200 && !recoveredBetaSummary,
+		"summary resurfaced Beta after the dropped finish response",
 	);
 	const recoveredBetaDetail = await loadDetail(
 		ctx,

--- a/packages/ui/src/app-sharing.test.tsx
+++ b/packages/ui/src/app-sharing.test.tsx
@@ -106,7 +106,7 @@ describe("Sharing app data refresh", () => {
 				{
 					candidateRef: "candidate-one",
 					displayName: "Old Team",
-					status: "ready",
+					status: "in_progress",
 					deviceCount: 1,
 					projectCount: 1,
 					unresolvedDeviceCount: 0,

--- a/packages/ui/src/components/primitives/primitives.test.tsx
+++ b/packages/ui/src/components/primitives/primitives.test.tsx
@@ -109,7 +109,7 @@ vi.mock("@radix-ui/react-switch", () => ({
 }));
 
 import { DialogCloseButton } from "./dialog-close-button";
-import { RadixDialog } from "./radix-dialog";
+import { RadixDialog, RadixDialogTitle } from "./radix-dialog";
 import { RadixRadioGroup } from "./radix-radio-group";
 import { RadixSelect } from "./radix-select";
 import { RadixSwitch } from "./radix-switch";
@@ -199,7 +199,9 @@ describe("RadixDialog", () => {
 						open={open}
 						overlayId="radix-dialog-overlay"
 					>
-						<h2 id="radix-dialog-title">Primitive dialog</h2>
+						<div id="radix-dialog-title">
+							<RadixDialogTitle>Primitive dialog</RadixDialogTitle>
+						</div>
 						<button type="button">Inside</button>
 					</RadixDialog>
 				</>

--- a/packages/ui/src/components/primitives/radix-dialog.tsx
+++ b/packages/ui/src/components/primitives/radix-dialog.tsx
@@ -3,6 +3,7 @@ import type { ComponentChildren, ComponentProps } from "preact";
 import { render } from "preact";
 
 type DialogContentProps = ComponentProps<typeof Dialog.Content>;
+type DialogTitleProps = ComponentProps<typeof Dialog.Title>;
 
 export type RadixDialogProps = {
 	ariaDescribedby?: string;
@@ -84,6 +85,10 @@ export function RadixDialog({
 			) : null}
 		</Dialog.Root>
 	);
+}
+
+export function RadixDialogTitle(props: DialogTitleProps) {
+	return <Dialog.Title {...props} />;
 }
 
 export function renderRadixDialog(mount: HTMLElement, props: RadixDialogProps) {

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -63,6 +63,7 @@ export type {
 	LegacyTeamSetupFinishResponseV1,
 	LegacyTeamSetupIdentityChoiceV1,
 	LegacyTeamSetupMutationResponseV1,
+	LegacyTeamSetupPendingCandidateSummaryV1,
 	LegacyTeamSetupProjectV1,
 	LegacyTeamSetupStatusV1,
 	LegacyTeamSetupSummaryResponseV1,

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -498,6 +498,33 @@ describe("legacy Team setup API", () => {
 		]);
 	});
 
+	it("rejects completed candidates in the pending-only summary contract", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					version: 1,
+					candidates: [
+						{
+							candidateRef: "completed-candidate",
+							displayName: "Completed Team",
+							status: "ready",
+							deviceCount: 1,
+							projectCount: 1,
+							unresolvedDeviceCount: 0,
+							unresolvedProjectCount: 0,
+						},
+					],
+				}),
+				{ status: 200 },
+			),
+		) as typeof fetch;
+
+		await expect(loadLegacyTeamSetupSummary()).rejects.toMatchObject({
+			statusCode: 200,
+			errorCode: "team_setup_failed",
+		});
+	});
+
 	it("preserves only stable bounded error codes and never exposes raw response text", async () => {
 		globalThis.fetch = vi
 			.fn()

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -914,9 +914,16 @@ export interface LegacyTeamSetupCandidateSummaryV1 {
 	unresolvedProjectCount: number;
 }
 
+export type LegacyTeamSetupPendingCandidateSummaryV1 = Omit<
+	LegacyTeamSetupCandidateSummaryV1,
+	"status"
+> & {
+	status: Exclude<LegacyTeamSetupStatusV1, "ready">;
+};
+
 export interface LegacyTeamSetupSummaryResponseV1 {
 	version: 1;
-	candidates: LegacyTeamSetupCandidateSummaryV1[];
+	candidates: LegacyTeamSetupPendingCandidateSummaryV1[];
 }
 
 export type LegacyTeamSetupAssignmentExpectationV1 =
@@ -1162,7 +1169,11 @@ function isLegacyTeamSetupSummary(value: unknown): value is LegacyTeamSetupSumma
 	return (
 		isJsonRecord(value) &&
 		value.version === LEGACY_TEAM_SETUP_VERSION &&
-		isArrayOf(value.candidates, isLegacyTeamSetupCandidateSummary)
+		isArrayOf(
+			value.candidates,
+			(candidate): candidate is LegacyTeamSetupPendingCandidateSummaryV1 =>
+				isLegacyTeamSetupCandidateSummary(candidate) && candidate.status !== "ready",
+		)
 	);
 }
 

--- a/packages/ui/src/project-first-layout.test.ts
+++ b/packages/ui/src/project-first-layout.test.ts
@@ -124,6 +124,18 @@ describe("project-first navigation layout", () => {
 		expect(styles).toContain("overflow-wrap: anywhere");
 	});
 
+	it("bounds Team setup device selectors at narrow and 200% zoom widths", () => {
+		const rule = html.match(/\.legacy-team-device-select \{([^}]*)\}/)?.[1] ?? "";
+		const cascadeOverride =
+			html.match(/\.feed-search\.legacy-team-device-select,[^{]*\{([^}]*)\}/)?.[1] ?? "";
+
+		expect(rule).toContain("width: 100%");
+		expect(rule).toContain("min-width: 0");
+		expect(rule).toContain("max-width: 100%");
+		expect(cascadeOverride).toContain("min-width: 0");
+		expect(cascadeOverride).toContain("max-width: 100%");
+	});
+
 	it("does not present the legacy coordinator surface as ordinary Team administration", () => {
 		const advancedStart = html.indexOf('id="advancedTeamsContent"');
 		const advanced = html.slice(advancedStart);

--- a/packages/ui/src/tabs/legacy-team-setup-dialog-view.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog-view.tsx
@@ -1,5 +1,9 @@
 import { DialogCloseButton } from "../components/primitives/dialog-close-button";
-import { RadixDialog, type RadixDialogProps } from "../components/primitives/radix-dialog";
+import {
+	RadixDialog,
+	type RadixDialogProps,
+	RadixDialogTitle,
+} from "../components/primitives/radix-dialog";
 import type { LegacyTeamSetupDeviceV1, LegacyTeamSetupProjectV1 } from "../lib/api";
 import { LegacyTeamSetupDevices } from "./legacy-team-setup-devices";
 import { setupItemErrorId } from "./legacy-team-setup-dom";
@@ -88,9 +92,9 @@ export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps)
 		>
 			<div aria-busy={globalBusy ? "true" : "false"} className="modal-card legacy-team-setup-card">
 				<div className="modal-header">
-					<h2 id="legacy-team-setup-title" tabIndex={-1}>
-						{title}
-					</h2>
+					<div id="legacy-team-setup-title" tabIndex={-1}>
+						<RadixDialogTitle>{title}</RadixDialogTitle>
+					</div>
 					<DialogCloseButton
 						ariaDisabled={globalBusy}
 						ariaLabel={`Close ${title}`}

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -36,6 +36,9 @@ vi.mock("../components/primitives/radix-dialog", () => ({
 			</div>
 		) : null;
 	},
+	RadixDialogTitle: (props: { children?: ComponentChildren; id?: string; tabIndex?: number }) => (
+		<h2 {...props}>{props.children}</h2>
+	),
 }));
 
 import {

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -612,14 +612,100 @@ describe("Projects tab", () => {
 		resolveFirst({ version: 1, candidates: [] });
 	});
 
-	it("fails a strict refresh while a Project domain selection is active", async () => {
+	it("removes completed setup cards without disturbing an active Project domain selection", async () => {
+		const select = document.createElement("select");
+		select.className = "project-domain-select";
+		document.body.appendChild(select);
+		select.focus();
+		const mount = document.getElementById("recipientPolicyReviewMount");
+		if (!mount) throw new Error("review mount missing");
+		const card = document.createElement("section");
+		card.className = "project-team-setup-entry";
+		mount.appendChild(card);
+		vi.mocked(api.loadLegacyTeamSetupSummary).mockResolvedValueOnce({
+			version: 1,
+			candidates: [],
+		});
+
+		await expect(loadProjectsData({ requireTeamSetupSummary: true })).resolves.toBe(true);
+		expect(api.loadLegacyTeamSetupSummary).toHaveBeenCalledOnce();
+		expect(document.querySelector(".project-team-setup-entry")).toBeNull();
+		expect(document.activeElement).toBe(select);
+	});
+
+	it("ignores an older focused-select Team setup summary", async () => {
+		let resolveOlder!: (value: LegacyTeamSetupSummaryResponseV1) => void;
+		let resolveNewer!: (value: LegacyTeamSetupSummaryResponseV1) => void;
+		vi.mocked(api.loadLegacyTeamSetupSummary)
+			.mockImplementationOnce(() => new Promise((resolve) => (resolveOlder = resolve)))
+			.mockImplementationOnce(() => new Promise((resolve) => (resolveNewer = resolve)));
 		const select = document.createElement("select");
 		select.className = "project-domain-select";
 		document.body.appendChild(select);
 		select.focus();
 
-		await expect(loadProjectsData({ requireTeamSetupSummary: true })).resolves.toBe(false);
-		expect(api.loadLegacyTeamSetupSummary).not.toHaveBeenCalled();
+		const olderRefresh = loadProjectsData({ requireTeamSetupSummary: true });
+		await vi.waitFor(() => expect(api.loadLegacyTeamSetupSummary).toHaveBeenCalledOnce());
+		select.remove();
+		const newerRefresh = loadProjectsData({ requireTeamSetupSummary: true });
+		await vi.waitFor(() => expect(api.loadLegacyTeamSetupSummary).toHaveBeenCalledTimes(2));
+
+		resolveNewer({ version: 1, candidates: [] });
+		await expect(newerRefresh).resolves.toBe(true);
+		resolveOlder({
+			version: 1,
+			candidates: [
+				{
+					candidateRef: "opaque-candidate-ref",
+					deviceCount: 1,
+					displayName: "Stale Team",
+					projectCount: 1,
+					status: "needs_setup",
+					unresolvedDeviceCount: 1,
+					unresolvedProjectCount: 0,
+				},
+			],
+		});
+		await expect(olderRefresh).resolves.toBe(false);
+		expect(document.querySelector(".project-team-setup-entry")).toBeNull();
+	});
+
+	it("does not cancel an inventory load when a focused-select summary starts", async () => {
+		let resolveInventory!: (
+			value: Awaited<ReturnType<typeof api.loadProjectScopeInventory>>,
+		) => void;
+		let resolveBackgroundSummary!: (value: LegacyTeamSetupSummaryResponseV1) => void;
+		vi.mocked(api.loadProjectScopeInventory).mockImplementationOnce(
+			() => new Promise((resolve) => (resolveInventory = resolve)),
+		);
+		vi.mocked(api.loadLegacyTeamSetupSummary)
+			.mockImplementationOnce(() => new Promise((resolve) => (resolveBackgroundSummary = resolve)))
+			.mockResolvedValueOnce({ version: 1, candidates: [] });
+
+		const inventoryLoad = loadProjectsData();
+		await vi.waitFor(() =>
+			expect(document.getElementById("projectsInventoryMeta")?.textContent).toBe(
+				"Loading project inventory…",
+			),
+		);
+		const select = document.createElement("select");
+		select.className = "project-domain-select";
+		document.body.appendChild(select);
+		select.focus();
+
+		await expect(loadProjectsData({ requireTeamSetupSummary: true })).resolves.toBe(true);
+		resolveInventory({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		});
+		await expect(inventoryLoad).resolves.toBe(true);
+		expect(document.getElementById("projectsInventoryMeta")?.textContent).toContain(
+			"1 project identity found",
+		);
+		resolveBackgroundSummary({ version: 1, candidates: [] });
 	});
 
 	it("reuses slow Team setup discovery across polling generations", async () => {

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -56,6 +56,7 @@ let skippedProjectRefreshForActiveSelect = false;
 let coordinatorGroupNamesCurrent = false;
 let projectShareInventoryReady = false;
 let projectsLoadGeneration = 0;
+let teamSetupEntryLoadGeneration = 0;
 type TeamSetupSummaryResult =
 	| { ok: true; summary: LegacyTeamSetupSummaryResponseV1 }
 	| { ok: false };
@@ -1277,7 +1278,7 @@ function renderProjectTeamSetupEntry(
 	mount: HTMLElement,
 	summary: LegacyTeamSetupSummaryResponseV1 | undefined,
 ) {
-	const candidates = summary?.candidates.filter((candidate) => candidate.status !== "ready") ?? [];
+	const candidates = summary?.candidates ?? [];
 	const existingEntry = mount.querySelector<HTMLElement>(":scope > .project-team-setup-entry");
 	existingEntry?.querySelector(".project-team-setup-status")?.remove();
 	const focusedCandidateRef = existingEntry?.contains(document.activeElement)
@@ -1385,7 +1386,18 @@ export async function loadProjectsData(options: ProjectsDataLoadOptions = {}) {
 	if (isProjectSpaceSelectActive()) {
 		skippedProjectRefreshForActiveSelect = true;
 		if (!options.requireTeamSetupSummary) return true;
-		return false;
+		const entryLoadGeneration = ++teamSetupEntryLoadGeneration;
+		// Completion refresh must remove the setup card without replacing the
+		// focused Space select or moving the user's cursor in Project inventory.
+		const teamSetupSummary = await loadTeamSetupSummaryOnce(true);
+		if (entryLoadGeneration !== teamSetupEntryLoadGeneration) return false;
+		const reviewMount = el<HTMLDivElement>("recipientPolicyReviewMount");
+		if (!teamSetupSummary.ok) {
+			if (reviewMount) markProjectTeamSetupEntryUnavailable(reviewMount);
+			return false;
+		}
+		if (reviewMount) renderProjectTeamSetupEntry(reviewMount, teamSetupSummary.summary);
+		return true;
 	}
 	skippedProjectRefreshForActiveSelect = false;
 	const loadGeneration = ++projectsLoadGeneration;
@@ -1394,6 +1406,7 @@ export async function loadProjectsData(options: ProjectsDataLoadOptions = {}) {
 	updateSelectionControls();
 	meta.textContent = "Loading project inventory…";
 	try {
+		const entryLoadGeneration = ++teamSetupEntryLoadGeneration;
 		const teamSetupSummaryPromise = loadTeamSetupSummaryOnce(
 			options.requireTeamSetupSummary === true,
 		);
@@ -1461,8 +1474,14 @@ export async function loadProjectsData(options: ProjectsDataLoadOptions = {}) {
 		);
 		renderProjectInventory(result);
 		refreshProjectCoordinatorGroupNamesInBackground(result, loadGeneration);
+		// Register the DOM update before the strict await below: callers use the
+		// resolved promise as proof that a completed setup card has disappeared.
 		void teamSetupSummaryPromise.then((teamSetupSummary) => {
-			if (loadGeneration !== projectsLoadGeneration) return;
+			if (
+				loadGeneration !== projectsLoadGeneration ||
+				entryLoadGeneration !== teamSetupEntryLoadGeneration
+			)
+				return;
 			const currentReviewMount = el<HTMLDivElement>("recipientPolicyReviewMount");
 			if (!currentReviewMount) return;
 			if (!teamSetupSummary.ok) {
@@ -1475,7 +1494,11 @@ export async function loadProjectsData(options: ProjectsDataLoadOptions = {}) {
 			shareInventory.ok && "review" in recipientPolicyReview && intentResult.ok;
 		if (!options.requireTeamSetupSummary) return requiredLoadSucceeded;
 		const teamSetupSummary = await teamSetupSummaryPromise;
-		if (loadGeneration !== projectsLoadGeneration) return false;
+		if (
+			loadGeneration !== projectsLoadGeneration ||
+			entryLoadGeneration !== teamSetupEntryLoadGeneration
+		)
+			return false;
 		return requiredLoadSucceeded && teamSetupSummary.ok;
 	} catch (error) {
 		if (loadGeneration !== projectsLoadGeneration) return false;

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -850,15 +850,6 @@ describe("recipient-focused Sharing", () => {
 						unresolvedDeviceCount: 0,
 						unresolvedProjectCount: 0,
 					},
-					{
-						candidateRef: "candidate-ready",
-						displayName: "Ready Team",
-						status: "ready",
-						deviceCount: 0,
-						projectCount: 0,
-						unresolvedDeviceCount: 5,
-						unresolvedProjectCount: 5,
-					},
 				],
 			},
 		});
@@ -1074,21 +1065,11 @@ describe("recipient-focused Sharing", () => {
 		expect(onOpenTeamSetup).toHaveBeenCalledWith("opaque-scope-backed-candidate");
 	});
 
-	it("hides migration work after every legacy candidate is migrated", () => {
+	it("hides migration work when the pending summary is empty", () => {
 		mount(intent(), {
 			teamSetupSummary: {
 				version: 1,
-				candidates: [
-					{
-						candidateRef: "completed-candidate",
-						displayName: "Migrated Team",
-						status: "ready",
-						deviceCount: 2,
-						projectCount: 1,
-						unresolvedDeviceCount: 0,
-						unresolvedProjectCount: 0,
-					},
-				],
+				candidates: [],
 			},
 		});
 

--- a/packages/ui/src/tabs/recipient-policy-sharing.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.tsx
@@ -4,8 +4,7 @@ import { useEffect, useRef, useState } from "preact/hooks";
 import { LoadingCardList } from "../components/LoadingCardList";
 import type {
 	DeviceIdentityInventoryV1,
-	LegacyTeamSetupCandidateSummaryV1,
-	LegacyTeamSetupStatusV1,
+	LegacyTeamSetupPendingCandidateSummaryV1,
 	LegacyTeamSetupSummaryResponseV1,
 	RecipientPolicyIntentGraphV1,
 } from "../lib/api/sync";
@@ -39,18 +38,18 @@ export interface RecipientPolicySharingOptions {
 	teamSetupUnavailable?: boolean;
 }
 
-const TEAM_SETUP_STATUS_LABELS: Record<LegacyTeamSetupStatusV1, string> = {
+type PendingTeamSetupStatus = LegacyTeamSetupPendingCandidateSummaryV1["status"];
+
+const TEAM_SETUP_STATUS_LABELS: Record<PendingTeamSetupStatus, string> = {
 	needs_setup: "Ready to review",
 	in_progress: "Migration in progress",
 	stale: "Migration review needs update",
-	ready: "Migrated",
 };
 
-const TEAM_SETUP_STATUS_CLASSES: Record<LegacyTeamSetupStatusV1, string> = {
+const TEAM_SETUP_STATUS_CLASSES: Record<PendingTeamSetupStatus, string> = {
 	needs_setup: "needs_attention",
 	in_progress: "suggested",
 	stale: "needs_attention",
-	ready: "",
 };
 
 // Safari/VoiceOver can drop list semantics when CSS removes native markers.
@@ -59,23 +58,23 @@ const EXPLICIT_LIST_ITEM_ROLE = { role: "listitem" } as const;
 
 function teamSetupStatusLabel(status: unknown): string {
 	return typeof status === "string" && Object.hasOwn(TEAM_SETUP_STATUS_LABELS, status)
-		? TEAM_SETUP_STATUS_LABELS[status as LegacyTeamSetupStatusV1]
+		? TEAM_SETUP_STATUS_LABELS[status as PendingTeamSetupStatus]
 		: "Ready to review";
 }
 
 function teamSetupStatusClass(status: unknown): string {
 	return typeof status === "string" && Object.hasOwn(TEAM_SETUP_STATUS_CLASSES, status)
-		? TEAM_SETUP_STATUS_CLASSES[status as LegacyTeamSetupStatusV1]
+		? TEAM_SETUP_STATUS_CLASSES[status as PendingTeamSetupStatus]
 		: "needs_attention";
 }
 
 interface TeamSetupCandidateGroup {
 	displayName: string;
-	candidates: LegacyTeamSetupCandidateSummaryV1[];
+	candidates: LegacyTeamSetupPendingCandidateSummaryV1[];
 }
 
 function teamSetupCandidateGroups(
-	candidates: LegacyTeamSetupCandidateSummaryV1[],
+	candidates: LegacyTeamSetupPendingCandidateSummaryV1[],
 ): TeamSetupCandidateGroup[] {
 	const groups = new Map<string, TeamSetupCandidateGroup>();
 	for (const candidate of candidates) {
@@ -96,13 +95,11 @@ function TeamSetupOverview({
 	candidates,
 	onOpenTeamSetup,
 }: {
-	candidates: LegacyTeamSetupCandidateSummaryV1[];
+	candidates: LegacyTeamSetupPendingCandidateSummaryV1[];
 	onOpenTeamSetup?: (candidateRef: string) => void;
 }) {
 	if (candidates.length === 0) return null;
-	const pending = candidates.filter((candidate) => candidate.status !== "ready");
-	if (pending.length === 0) return null;
-	const groups = teamSetupCandidateGroups(pending);
+	const groups = teamSetupCandidateGroups(candidates);
 	return (
 		<aside
 			aria-labelledby="sharing-team-setup-heading"
@@ -170,7 +167,7 @@ function TeamSetupOverview({
 											</span>
 										</span>
 										<span className="recipient-policy-sharing-team-setup-action">
-											{candidate.status !== "ready" && onOpenTeamSetup ? (
+											{onOpenTeamSetup ? (
 												<button
 													aria-label={actionLabel}
 													className="settings-button recipient-policy-sharing-target-24"

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1349,7 +1349,7 @@
       }
       .legacy-team-device-row label { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); }
       .legacy-team-device-evidence { display: grid; gap: var(--sp-1); }
-      .legacy-team-device-select { width: 100%; margin: 0; }
+      .legacy-team-device-select { box-sizing: border-box; width: 100%; min-width: 0; max-width: 100%; margin: 0; }
       .legacy-team-device-select:disabled { opacity: 0.55; cursor: not-allowed; }
       .legacy-team-device-actions { display: flex; flex-wrap: wrap; gap: var(--sp-2); }
       .legacy-team-project-list {
@@ -1799,6 +1799,13 @@
       }
       .feed-search::placeholder { color: var(--text-tertiary); }
       .feed-search:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--focus-ring); }
+      .feed-search.legacy-team-device-select,
+      .feed-search.legacy-team-project-select {
+        box-sizing: border-box;
+        width: 100%;
+        min-width: 0;
+        max-width: 100%;
+      }
 
       .feed-inspector-files {
         width: 100%;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -940,6 +940,31 @@ describe("viewer-server", () => {
 				expect(JSON.stringify(finished)).not.toContain(
 					rawPreview.accessDelta.teamChanges[0]?.teamId,
 				);
+				const pendingAfterFinish = await app.request("/api/sync/team-setup/v1");
+				expect(pendingAfterFinish.status).toBe(200);
+				expect(await pendingAfterFinish.json()).toEqual({ version: 1, candidates: [] });
+				const canonicalSnapshot = () => ({
+					teams: store.db.prepare("SELECT * FROM policy_teams ORDER BY team_id").all(),
+					memberships: store.db
+						.prepare("SELECT * FROM policy_team_memberships ORDER BY team_id, identity_id")
+						.all(),
+					decisions: store.db
+						.prepare("SELECT * FROM policy_team_device_decisions ORDER BY team_id, device_id")
+						.all(),
+					assignments: store.db.prepare("SELECT * FROM identity_devices ORDER BY device_id").all(),
+					mappings: store.db.prepare("SELECT * FROM project_scope_mappings ORDER BY id").all(),
+					recipients: store.db
+						.prepare(
+							`SELECT * FROM project_recipients
+							 ORDER BY canonical_project_identity, recipient_kind, recipient_id`,
+						)
+						.all(),
+					drafts: store.db.prepare("SELECT * FROM legacy_team_setup_drafts ORDER BY rowid").all(),
+					completions: store.db
+						.prepare("SELECT * FROM legacy_team_setup_completions ORDER BY rowid")
+						.all(),
+				});
+				const beforeReplay = canonicalSnapshot();
 				const replayResponse = await app.request(`/api/sync/team-setup/v1/${candidateRef}/finish`, {
 					method: "POST",
 					headers: { "content-type": "application/json" },
@@ -947,6 +972,7 @@ describe("viewer-server", () => {
 				});
 				expect(replayResponse.status).toBe(200);
 				expect(await replayResponse.json()).toEqual(finished);
+				expect(canonicalSnapshot()).toEqual(beforeReplay);
 				const missingConfirmation = await app.request(
 					`/api/sync/team-setup/v1/${candidateRef}/finish`,
 					{

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -66,6 +66,7 @@ export type {
 	LegacyTeamSetupFinishResponseV1,
 	LegacyTeamSetupIdentityChoiceV1,
 	LegacyTeamSetupMutationResponseV1,
+	LegacyTeamSetupPendingCandidateSummaryV1,
 	LegacyTeamSetupProjectV1,
 	LegacyTeamSetupSummaryResponseV1,
 	LegacyTeamSetupViewerAccessDeltaV1,

--- a/packages/viewer-server/src/routes/team-setup-view.ts
+++ b/packages/viewer-server/src/routes/team-setup-view.ts
@@ -10,9 +10,16 @@ export interface LegacyTeamSetupCandidateSummaryV1 {
 	unresolvedProjectCount: number;
 }
 
+export type LegacyTeamSetupPendingCandidateSummaryV1 = Omit<
+	LegacyTeamSetupCandidateSummaryV1,
+	"status"
+> & {
+	status: Exclude<LegacyTeamSetupCandidateSummaryV1["status"], "ready">;
+};
+
 export interface LegacyTeamSetupSummaryResponseV1 {
 	version: 1;
-	candidates: LegacyTeamSetupCandidateSummaryV1[];
+	candidates: LegacyTeamSetupPendingCandidateSummaryV1[];
 }
 
 export type LegacyTeamSetupActionBlockedReasonV1 =

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -41,6 +41,7 @@ import {
 	type LegacyTeamSetupDeviceV1,
 	type LegacyTeamSetupFinishResponseV1,
 	type LegacyTeamSetupIdentityChoiceV1,
+	type LegacyTeamSetupPendingCandidateSummaryV1,
 	type LegacyTeamSetupProjectV1,
 	type LegacyTeamSetupSummaryResponseV1,
 	type LegacyTeamSetupUnavailableReasonV1,
@@ -58,6 +59,7 @@ export type {
 	LegacyTeamSetupFinishResponseV1,
 	LegacyTeamSetupIdentityChoiceV1,
 	LegacyTeamSetupMutationResponseV1,
+	LegacyTeamSetupPendingCandidateSummaryV1,
 	LegacyTeamSetupProjectV1,
 	LegacyTeamSetupSummaryResponseV1,
 	LegacyTeamSetupUnavailableReasonV1,
@@ -1123,7 +1125,12 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		try {
 			const response = {
 				version: TEAM_SETUP_VERSION,
-				candidates: discoverCandidates(options.getStore(), groups).map(candidateSummary),
+				candidates: discoverCandidates(options.getStore(), groups)
+					.map(candidateSummary)
+					.filter(
+						(candidate): candidate is LegacyTeamSetupPendingCandidateSummaryV1 =>
+							candidate.status !== "ready",
+					),
 			} satisfies LegacyTeamSetupSummaryResponseV1;
 			return c.json(response);
 		} catch (error) {


### PR DESCRIPTION
## Description
Makes the server the sole owner of the pending-only Team setup summary and removes duplicate client filtering. Completed cards disappear after authoritative refresh without disrupting an active Project select. The wire validator rejects completed entries, exact finish replay is proven write-free, Radix title semantics remove browser accessibility errors, and Team setup controls remain usable at narrow/200%-zoom widths.

Tracks codemem-752i.7.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Full `pnpm run check`: 230 files, 5601 tests passed, 3 todo
- [x] Full `pnpm run build`
- [x] cmux browser dogfood for SRE and Nerdworld
- [x] No browser or console errors
- [x] SRE Sarvar ordering/focus and Nerdworld automatic Project review
- [x] Effective 200%-zoom dialog width has no horizontal overflow

## Checklist
- [x] Code follows project style
- [x] Final CodeReviewer approval
- [x] No new warnings introduced
- [ ] Live finish intentionally not executed pending approval because it mutates Team authorization state