### PR TITLE
fix(ui): explain Team setup net access changes

### DIFF
--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -999,8 +999,10 @@ export interface LegacyTeamSetupAccessDeltaV1 {
 	projectChanges: Array<{
 		projectRef: string;
 		projectDisplayName: string;
+		fromCanonicalProjectRef: string | null;
 		fromResolvedProjectRef: string | null;
 		fromResolvedProjectDisplayName: string | null;
+		toCanonicalProjectRef: string | null;
 		toResolvedProjectRef: string | null;
 		toResolvedProjectDisplayName: string | null;
 		change: "add" | "update" | "remove";
@@ -1008,6 +1010,7 @@ export interface LegacyTeamSetupAccessDeltaV1 {
 	recipientChanges: Array<{
 		canonicalProjectRef: string;
 		canonicalProjectDisplayName: string;
+		canonicalProjectKind: "project" | "legacy_default_sharing";
 		recipientKind: "team";
 		recipientRef: string;
 		recipientDisplayName: string;
@@ -1016,6 +1019,7 @@ export interface LegacyTeamSetupAccessDeltaV1 {
 	deviceAccessChanges: Array<{
 		canonicalProjectRef: string;
 		canonicalProjectDisplayName: string;
+		canonicalProjectKind: "project" | "legacy_default_sharing";
 		deviceRef: string;
 		deviceDisplayName: string;
 		change: "add" | "remove";
@@ -1291,8 +1295,10 @@ function isLegacyTeamSetupAccessDelta(value: unknown): value is LegacyTeamSetupA
 				isJsonRecord(item) &&
 				typeof item.projectRef === "string" &&
 				typeof item.projectDisplayName === "string" &&
+				isStringOrNull(item.fromCanonicalProjectRef) &&
 				isStringOrNull(item.fromResolvedProjectRef) &&
 				isStringOrNull(item.fromResolvedProjectDisplayName) &&
+				isStringOrNull(item.toCanonicalProjectRef) &&
 				isStringOrNull(item.toResolvedProjectRef) &&
 				isStringOrNull(item.toResolvedProjectDisplayName) &&
 				validChange(item.change),
@@ -1303,6 +1309,8 @@ function isLegacyTeamSetupAccessDelta(value: unknown): value is LegacyTeamSetupA
 				isJsonRecord(item) &&
 				typeof item.canonicalProjectRef === "string" &&
 				typeof item.canonicalProjectDisplayName === "string" &&
+				(item.canonicalProjectKind === "project" ||
+					item.canonicalProjectKind === "legacy_default_sharing") &&
 				item.recipientKind === "team" &&
 				typeof item.recipientRef === "string" &&
 				typeof item.recipientDisplayName === "string" &&
@@ -1314,6 +1322,8 @@ function isLegacyTeamSetupAccessDelta(value: unknown): value is LegacyTeamSetupA
 				isJsonRecord(item) &&
 				typeof item.canonicalProjectRef === "string" &&
 				typeof item.canonicalProjectDisplayName === "string" &&
+				(item.canonicalProjectKind === "project" ||
+					item.canonicalProjectKind === "legacy_default_sharing") &&
 				typeof item.deviceRef === "string" &&
 				typeof item.deviceDisplayName === "string" &&
 				typeof item.change === "string" &&

--- a/packages/ui/src/lib/project-identity-presentation.ts
+++ b/packages/ui/src/lib/project-identity-presentation.ts
@@ -15,7 +15,7 @@ function compareCanonicalId(
 	return left.canonicalId < right.canonicalId ? -1 : left.canonicalId > right.canonicalId ? 1 : 0;
 }
 
-function displayNameKey(displayName: string): string {
+export function projectDisplayNameKey(displayName: string): string {
 	return displayName
 		.normalize("NFKC")
 		.replace(/\u200B/gu, "")
@@ -41,7 +41,7 @@ export function stableProjectPresentationLabels(
 ): ReadonlyMap<string, string> {
 	const groups = new Map<string, ProjectIdentityPresentationItem[]>();
 	for (const item of distinctSortedItems(items)) {
-		const key = displayNameKey(item.displayName);
+		const key = projectDisplayNameKey(item.displayName);
 		const group = groups.get(key);
 		if (group) group.push(item);
 		else groups.set(key, [item]);
@@ -69,7 +69,7 @@ export function projectIdentitySummaryGroups(
 		{ displayName: string; canonicalIds: string[]; firstCanonicalId: string }
 	>();
 	for (const item of distinctSortedItems(items)) {
-		const key = displayNameKey(item.displayName);
+		const key = projectDisplayNameKey(item.displayName);
 		const group = groups.get(key);
 		if (group) group.canonicalIds.push(item.canonicalId);
 		else {
@@ -82,8 +82,8 @@ export function projectIdentitySummaryGroups(
 	}
 	return [...groups.values()]
 		.sort((left, right) => {
-			const nameOrder = displayNameKey(left.displayName).localeCompare(
-				displayNameKey(right.displayName),
+			const nameOrder = projectDisplayNameKey(left.displayName).localeCompare(
+				projectDisplayNameKey(right.displayName),
 			);
 			if (nameOrder !== 0) return nameOrder;
 			return left.firstCanonicalId < right.firstCanonicalId

--- a/packages/ui/src/tabs/legacy-team-setup-dialog-view.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog-view.tsx
@@ -47,6 +47,7 @@ export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps)
 	const error = globalError(session);
 	const loading = session.commands.some((command) => command.kind === "load");
 	const globalBusy = hasGlobalOperation(session) || hasBlockingOperation(session);
+	const finishing = session.commands.some((command) => command.kind === "finish");
 	const recoveryRequired = view?.state === "unavailable" || error?.retry === "refresh";
 	const mutationsBlocked = !isEditable(view) || globalBusy || Boolean(error);
 	const mutationBlockDescriptionId =
@@ -62,6 +63,7 @@ export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps)
 		(item) => item.scope.kind === "device" || item.scope.kind === "project",
 	);
 	const itemRecoveryRequired = itemErrors.length > 0;
+	const itemRefreshRecovery = itemErrors.some((item) => item.retry === "refresh");
 	const blockedDeviceRefs = new Set(
 		itemErrors.flatMap((item) => (item.scope.kind === "device" ? [item.scope.itemRef] : [])),
 	);
@@ -122,7 +124,13 @@ export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps)
 									}}
 									type="button"
 								>
-									{loading ? "Retrying…" : "Retry"}
+									{loading
+										? error.retry === "refresh"
+											? "Refreshing…"
+											: "Retrying…"
+										: error.retry === "refresh"
+											? "Refresh Team setup"
+											: "Retry"}
 								</button>
 							) : null}
 						</div>
@@ -157,7 +165,13 @@ export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps)
 								}}
 								type="button"
 							>
-								{loading ? "Retrying…" : "Retry"}
+								{loading
+									? itemRefreshRecovery
+										? "Refreshing…"
+										: "Retrying…"
+									: itemRefreshRecovery
+										? "Refresh Team setup"
+										: "Retry"}
 							</button>
 						</div>
 					) : null}
@@ -233,6 +247,7 @@ export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps)
 											: mutationBlockDescriptionId
 									}
 									detail={view}
+									finishing={finishing}
 									onFinish={props.onFinish}
 								/>
 							) : (

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -745,6 +745,9 @@ describe("legacy Team setup dialog", () => {
 				"Check the coordinator connection and settings, then refresh.",
 			);
 		});
+		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+			"temporarily unavailable",
+		);
 		expect(document.body.textContent).not.toContain("team_setup_roster_unavailable");
 	});
 
@@ -1723,8 +1726,10 @@ describe("legacy Team setup dialog", () => {
 						{
 							projectRef: "project-ref-one",
 							projectDisplayName: "Legacy Project",
+							fromCanonicalProjectRef: "canonical-project-old",
 							fromResolvedProjectRef: "resolved-project-old",
 							fromResolvedProjectDisplayName: "Previous Project",
+							toCanonicalProjectRef: "canonical-project-ref",
 							toResolvedProjectRef: "resolved-project-beta",
 							toResolvedProjectDisplayName: "Project Beta",
 							change: "update",
@@ -1734,6 +1739,7 @@ describe("legacy Team setup dialog", () => {
 						{
 							canonicalProjectRef: "canonical-project-ref",
 							canonicalProjectDisplayName: "Legacy Project",
+							canonicalProjectKind: "project",
 							recipientKind: "team",
 							recipientRef: "opaque-team-ref",
 							recipientDisplayName: "Example Team",
@@ -1744,6 +1750,7 @@ describe("legacy Team setup dialog", () => {
 						{
 							canonicalProjectRef: "canonical-project-ref",
 							canonicalProjectDisplayName: "Legacy Project",
+							canonicalProjectKind: "project",
 							deviceRef: "device-ref-one",
 							deviceDisplayName: "Work laptop",
 							change: "add",
@@ -1751,6 +1758,7 @@ describe("legacy Team setup dialog", () => {
 						{
 							canonicalProjectRef: "external-canonical-project-ref",
 							canonicalProjectDisplayName: "External Project",
+							canonicalProjectKind: "project",
 							deviceRef: "external-device-ref",
 							deviceDisplayName: "External laptop",
 							change: "remove",
@@ -1778,6 +1786,197 @@ describe("legacy Team setup dialog", () => {
 		expect(text).not.toContain("resolved-project-old");
 		expect(document.querySelectorAll(".legacy-team-setup-exact-list li")).toHaveLength(6);
 		expect(document.querySelectorAll(".legacy-team-setup-delta details")).toHaveLength(0);
+	});
+
+	it("disambiguates changed Projects against the full reviewed Project set", async () => {
+		const projects = [
+			project({
+				projectRef: "project-ref-a",
+				displayName: "Shared name",
+				resolution: "deterministic",
+				mappingChoices: [],
+			}),
+			project({
+				projectRef: "project-ref-b",
+				displayName: "Shared name",
+				resolution: "deterministic",
+				mappingChoices: [],
+			}),
+		];
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(
+				detail({
+					canFinish: true,
+					projects,
+					accessDelta: {
+						teamChanges: [],
+						membershipChanges: [],
+						projectChanges: [
+							{
+								projectRef: "project-ref-b",
+								projectDisplayName: "Shared name",
+								fromCanonicalProjectRef: null,
+								fromResolvedProjectRef: null,
+								fromResolvedProjectDisplayName: null,
+								toCanonicalProjectRef: "canonical-project-b",
+								toResolvedProjectRef: "resolved-project-b",
+								toResolvedProjectDisplayName: "Project B",
+								change: "add",
+							},
+						],
+						recipientChanges: [],
+						deviceAccessChanges: [],
+					},
+				}),
+			),
+		});
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		act(() => button("Review").click());
+		const changedProjectText = [
+			...document.querySelectorAll<HTMLLIElement>(".legacy-team-setup-exact-list li"),
+		].find((item) => item.textContent?.startsWith("Add Shared name —"))?.textContent;
+		expect(changedProjectText).toContain("2 of 2: no Project to Project B.");
+	});
+
+	it("presents one canonical destination once when multiple sources map to it", async () => {
+		const projects = [
+			project({
+				projectRef: "project-ref-a",
+				displayName: "Source A",
+				resolution: "deterministic",
+				canonicalProjectRef: "canonical-project-shared",
+				resolvedProjectRef: "resolved-project-a",
+				mappingChoices: [],
+			}),
+			project({
+				projectRef: "project-ref-b",
+				displayName: "Source B",
+				resolution: "deterministic",
+				canonicalProjectRef: "canonical-project-shared",
+				resolvedProjectRef: "resolved-project-b",
+				mappingChoices: [],
+			}),
+		];
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(
+				detail({
+					canFinish: true,
+					projects,
+					accessDelta: {
+						teamChanges: [],
+						membershipChanges: [],
+						projectChanges: projects.map((entry) => ({
+							projectRef: entry.projectRef,
+							projectDisplayName: entry.displayName,
+							fromCanonicalProjectRef: null,
+							fromResolvedProjectRef: null,
+							fromResolvedProjectDisplayName: null,
+							toCanonicalProjectRef: entry.canonicalProjectRef,
+							toResolvedProjectRef: entry.resolvedProjectRef,
+							toResolvedProjectDisplayName: "Shared destination",
+							change: "add" as const,
+						})),
+						recipientChanges: [],
+						deviceAccessChanges: [],
+					},
+				}),
+			),
+		});
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		act(() => button("Review").click());
+		expect(document.body.textContent).toContain("Add Source A: no Project to Shared destination.");
+		expect(document.body.textContent).toContain("Add Source B: no Project to Shared destination.");
+		expect(document.body.textContent).not.toContain("Shared destination — duplicate name");
+	});
+
+	it("presents one prior canonical destination once when multiple sources leave it", async () => {
+		const projects = [
+			project({ projectRef: "project-ref-a", displayName: "Source A" }),
+			project({ projectRef: "project-ref-b", displayName: "Source B" }),
+		];
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(
+				detail({
+					canFinish: true,
+					projects,
+					accessDelta: {
+						teamChanges: [],
+						membershipChanges: [],
+						projectChanges: projects.map((entry, index) => ({
+							projectRef: entry.projectRef,
+							projectDisplayName: entry.displayName,
+							fromCanonicalProjectRef: "canonical-project-shared",
+							fromResolvedProjectRef: `resolved-project-old-${index}`,
+							fromResolvedProjectDisplayName: "Shared destination",
+							toCanonicalProjectRef: `canonical-project-new-${index}`,
+							toResolvedProjectRef: `resolved-project-new-${index}`,
+							toResolvedProjectDisplayName: `New destination ${index + 1}`,
+							change: "update" as const,
+						})),
+						recipientChanges: [],
+						deviceAccessChanges: [],
+					},
+				}),
+			),
+		});
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		act(() => button("Review").click());
+		expect(document.body.textContent).toContain(
+			"Update Source A: Shared destination to New destination 1.",
+		);
+		expect(document.body.textContent).toContain(
+			"Update Source B: Shared destination to New destination 2.",
+		);
+		expect(document.body.textContent).not.toContain("Shared destination — Project");
+	});
+
+	it("disambiguates changed canonical Projects against unchanged reviewed Projects", async () => {
+		const projects = [
+			project({
+				projectRef: "project-ref-a",
+				displayName: "Shared name",
+				canonicalProjectRef: "canonical-project-a",
+			}),
+			project({
+				projectRef: "project-ref-b",
+				displayName: "Shared name",
+				canonicalProjectRef: "canonical-project-b",
+			}),
+		];
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(
+				detail({
+					canFinish: true,
+					projects,
+					accessDelta: {
+						teamChanges: [],
+						membershipChanges: [],
+						projectChanges: [],
+						recipientChanges: [
+							{
+								canonicalProjectRef: "canonical-project-a",
+								canonicalProjectDisplayName: "Shared name",
+								canonicalProjectKind: "project",
+								recipientKind: "team",
+								recipientRef: "team-ref",
+								recipientDisplayName: "Example Team",
+								change: "add",
+							},
+						],
+						deviceAccessChanges: [],
+					},
+				}),
+			),
+		});
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		act(() => button("Review").click());
+		expect(document.body.textContent).toContain(
+			"Add Example Team as a recipient for Shared name — Project 1 of 2.",
+		);
 	});
 
 	it("summarizes a 63 Project by 6 device migration while preserving all 509 exact rows", async () => {
@@ -1822,8 +2021,10 @@ describe("legacy Team setup dialog", () => {
 			projectChanges: projects.map((entry) => ({
 				projectRef: entry.projectRef,
 				projectDisplayName: entry.displayName,
+				fromCanonicalProjectRef: null,
 				fromResolvedProjectRef: null,
 				fromResolvedProjectDisplayName: null,
+				toCanonicalProjectRef: entry.canonicalProjectRef,
 				toResolvedProjectRef: entry.resolvedProjectRef,
 				toResolvedProjectDisplayName: entry.displayName,
 				change: "add" as const,
@@ -1831,6 +2032,7 @@ describe("legacy Team setup dialog", () => {
 			recipientChanges: projects.map((entry) => ({
 				canonicalProjectRef: entry.canonicalProjectRef ?? "",
 				canonicalProjectDisplayName: entry.displayName,
+				canonicalProjectKind: "project" as const,
 				recipientKind: "team" as const,
 				recipientRef: "internal-team-ref",
 				recipientDisplayName: "Example Team",
@@ -1840,6 +2042,7 @@ describe("legacy Team setup dialog", () => {
 				devices.map((entryDevice) => ({
 					canonicalProjectRef: entry.canonicalProjectRef ?? "",
 					canonicalProjectDisplayName: entry.displayName,
+					canonicalProjectKind: "project" as const,
 					deviceRef: entryDevice.deviceRef,
 					deviceDisplayName: entryDevice.displayName,
 					change: "add" as const,
@@ -1858,6 +2061,8 @@ describe("legacy Team setup dialog", () => {
 		});
 
 		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		expect(document.body.textContent).toContain("greenroom — Project 1 of 34");
+		expect(document.body.textContent).toContain("greenroom — Project 34 of 34");
 		act(() => button("Review").click());
 		const review = document.querySelector<HTMLElement>(
 			'[aria-labelledby="legacy-team-setup-step-review"]',
@@ -1882,13 +2087,13 @@ describe("legacy Team setup dialog", () => {
 		expect(review.textContent).toContain("6 included devices");
 		expect(review.textContent).toContain("378 device-access changes");
 		expect(section("Projects").textContent).toContain(
-			"greenroom — 34 Projects with this name, 34 Project changes",
+			"greenroom — 34 reviewed Projects, 34 Project changes",
 		);
 		expect(section("Recipients").textContent).toContain(
-			"greenroom — 34 Projects with this name, 34 recipient changes",
+			"greenroom — 34 canonical Projects, 34 recipient changes",
 		);
 		expect(section("Device access").textContent).toContain(
-			"greenroom — 34 Projects with this name, 204 device-access changes",
+			"greenroom — 34 canonical Projects, 204 device-access changes",
 		);
 		expect(review.textContent).not.toContain("internal-");
 
@@ -1916,14 +2121,127 @@ describe("legacy Team setup dialog", () => {
 		expect([...review.querySelectorAll("details")].every((details) => !details.open)).toBe(true);
 		expect(
 			[...section("Projects").querySelectorAll(".legacy-team-setup-exact-list > li")].filter(
-				(row) => row.textContent === "Add greenroom: no Project to greenroom.",
+				(row) => row.textContent?.startsWith("Add greenroom — Project "),
 			),
 		).toHaveLength(34);
 		expect(
 			[...section("Device access").querySelectorAll(".legacy-team-setup-exact-list > li")].filter(
-				(row) => row.textContent === "Add Work laptop access to greenroom.",
+				(row) => row.textContent?.startsWith("Add Work laptop access to greenroom — Project "),
 			),
 		).toHaveLength(68);
+	});
+
+	it("explains legacy default-sharing cleanup as a net effect rather than an unknown Project", async () => {
+		const devices = ["Dustin Airbnb", "Sarvar"].map((displayName, index) =>
+			device({
+				deviceRef: `cleanup-device-${index + 1}`,
+				displayName,
+				decision: "included",
+				targetIdentityRef: `cleanup-identity-${index + 1}`,
+			}),
+		);
+		const projects = [
+			project(),
+			project({ projectRef: "project-ref-two", displayName: "greenroom" }),
+		];
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(
+				detail({
+					canFinish: true,
+					devices,
+					projects,
+					accessDelta: {
+						teamChanges: [],
+						membershipChanges: [],
+						projectChanges: [],
+						recipientChanges: [
+							{
+								canonicalProjectRef: "legacy-default-ref",
+								canonicalProjectDisplayName: "Legacy default sharing",
+								canonicalProjectKind: "legacy_default_sharing",
+								recipientKind: "team",
+								recipientRef: "team-ref",
+								recipientDisplayName: "SRE",
+								change: "remove",
+							},
+						],
+						deviceAccessChanges: devices.map((entry) => ({
+							canonicalProjectRef: "legacy-default-ref",
+							canonicalProjectDisplayName: "Legacy default sharing",
+							canonicalProjectKind: "legacy_default_sharing" as const,
+							deviceRef: entry.deviceRef,
+							deviceDisplayName: entry.displayName,
+							change: "remove" as const,
+						})),
+					},
+				}),
+			),
+		});
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		act(() => button("Review").click());
+		const text = document.body.textContent ?? "";
+
+		expect(text).toContain("No new access will be added");
+		expect(text).toContain("removes legacy default sharing for Example Team");
+		expect(text).toContain(
+			"2 devices will stop receiving memories shared only through that default",
+		);
+		expect(text).toContain("Project-scoped access is unchanged across 2 reviewed Projects");
+		expect(text).toContain("Stop using legacy default sharing for SRE");
+		expect(text).toContain("Dustin Airbnb stops inheriting legacy default sharing");
+		expect(text).not.toContain("Project with this name");
+		expect(text).not.toContain("Project outside this setup");
+	});
+
+	it("distinguishes the legacy default scope from a Project with the same name", async () => {
+		const changes = Array.from({ length: 11 }, (_, index) => ({
+			deviceRef: `device-ref-${index}`,
+			deviceDisplayName: `Device ${index + 1}`,
+			change: "remove" as const,
+		}));
+		setup({
+			loadDetail: vi.fn().mockResolvedValue(
+				detail({
+					canFinish: true,
+					projects: [
+						project({
+							canonicalProjectRef: "canonical-project-ref",
+							displayName: "Legacy default sharing",
+						}),
+					],
+					accessDelta: {
+						teamChanges: [],
+						membershipChanges: [],
+						projectChanges: [],
+						recipientChanges: [],
+						deviceAccessChanges: [
+							...changes.map((change) => ({
+								...change,
+								canonicalProjectRef: "canonical-project-ref",
+								canonicalProjectDisplayName: "Legacy default sharing",
+								canonicalProjectKind: "project" as const,
+							})),
+							...changes.map((change) => ({
+								...change,
+								canonicalProjectRef: "legacy-default-ref",
+								canonicalProjectDisplayName: "Legacy default sharing",
+								canonicalProjectKind: "legacy_default_sharing" as const,
+							})),
+						],
+					},
+				}),
+			),
+		});
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
+		act(() => button("Review").click());
+
+		const summaries = [...document.querySelectorAll(".legacy-team-setup-delta-summary li")].map(
+			(item) => item.textContent,
+		);
+		expect(summaries).toContain("Legacy default sharing, 11 device-access changes");
+		expect(summaries).toContain("Legacy default sharing — default scope, 11 device-access changes");
 	});
 
 	it("keeps a large exact section visible when its labels cannot be usefully grouped", async () => {
@@ -1933,8 +2251,10 @@ describe("legacy Team setup dialog", () => {
 			projectChanges: Array.from({ length: 11 }, (_, index) => ({
 				projectRef: `opaque-project-${index}`,
 				projectDisplayName: `Project ${index + 1}`,
+				fromCanonicalProjectRef: null,
 				fromResolvedProjectRef: null,
 				fromResolvedProjectDisplayName: null,
+				toCanonicalProjectRef: `canonical-project-${index}`,
 				toResolvedProjectRef: `opaque-resolved-project-${index}`,
 				toResolvedProjectDisplayName: `Project ${index + 1}`,
 				change: "add" as const,
@@ -1974,8 +2294,10 @@ describe("legacy Team setup dialog", () => {
 			projectChanges: Array.from({ length: 11 }, (_, index) => ({
 				projectRef: "opaque-project-ref",
 				projectDisplayName: "Legacy Project",
+				fromCanonicalProjectRef: null,
 				fromResolvedProjectRef: null,
 				fromResolvedProjectDisplayName: null,
+				toCanonicalProjectRef: "canonical-project-ref",
 				toResolvedProjectRef: "opaque-resolved-project-ref",
 				toResolvedProjectDisplayName: "Canonical Project",
 				change: index % 2 === 0 ? ("add" as const) : ("remove" as const),
@@ -1996,9 +2318,7 @@ describe("legacy Team setup dialog", () => {
 		expect(finish).not.toHaveBeenCalled();
 		const summaries = [...document.querySelectorAll<HTMLElement>("details > summary")];
 		expect(summaries).toHaveLength(1);
-		expect(document.body.textContent).toContain(
-			"Legacy Project — 1 Project with this name, 11 Project changes",
-		);
+		expect(document.body.textContent).toContain("Legacy Project, 11 Project changes");
 		for (const summary of summaries) act(() => summary.click());
 		expect(finishButton.getAttribute("aria-disabled")).toBe("true");
 		const confirmation = document.querySelector<HTMLInputElement>(
@@ -2019,6 +2339,16 @@ describe("legacy Team setup dialog", () => {
 			finishButton.click();
 			finishButton.click();
 		});
+		expect(finishButton.textContent).toBe("Finishing Team setup…");
+		expect(document.body.textContent).toContain(
+			"Checking the latest Team roster and applying all reviewed changes atomically",
+		);
+		expect(document.body.textContent).toContain(
+			"No partial changes will be kept if this cannot finish",
+		);
+		expect(document.querySelector(".legacy-team-setup-card")?.getAttribute("aria-busy")).toBe(
+			"true",
+		);
 		expect(finish).toHaveBeenCalledTimes(1);
 		expect(finish).toHaveBeenCalledWith("opaque-candidate", {
 			attemptId: "opaque-attempt",
@@ -2478,6 +2808,33 @@ describe("legacy Team setup dialog", () => {
 		});
 		expect(document.body.textContent).not.toContain("private refresh response");
 		expect(document.body.textContent).not.toContain("device change could not be saved");
+	});
+
+	it("states that a roster failure during Finish applied no changes", async () => {
+		setup({
+			finish: vi
+				.fn()
+				.mockRejectedValue(new LegacyTeamSetupApiError(503, "team_setup_roster_unavailable")),
+			loadDetail: vi.fn().mockResolvedValue(detail({ canFinish: true })),
+		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Finish Team setup"));
+		const confirmation = document.querySelector<HTMLInputElement>(
+			".legacy-team-setup-confirmation input",
+		);
+		if (!confirmation) throw new Error("finish confirmation missing");
+		confirmation.checked = true;
+		act(() => {
+			confirmation.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		act(() => button("Finish Team setup").click());
+
+		await vi.waitFor(() =>
+			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+				"setup was not finished and no changes were applied",
+			),
+		);
+		expect(document.body.textContent).toContain("Refresh");
+		expect(document.body.textContent).not.toContain("team_setup_roster_unavailable");
 	});
 
 	it("fails closed and resets confirmation when finish evidence becomes stale", async () => {

--- a/packages/ui/src/tabs/legacy-team-setup-projects.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-projects.tsx
@@ -29,6 +29,7 @@ function ProjectRow({
 	busy,
 	index,
 	onMap,
+	presentationName,
 	project,
 }: Pick<
 	LegacyTeamSetupProjectsProps,
@@ -36,6 +37,7 @@ function ProjectRow({
 > & {
 	busy: boolean;
 	index: number;
+	presentationName: string;
 	project: LegacyTeamSetupProjectV1;
 }) {
 	const generatedId = useId();
@@ -108,7 +110,7 @@ function ProjectRow({
 			id={`legacy-team-project-row-${index}`}
 			tabIndex={needsAttention ? -1 : undefined}
 		>
-			<legend>{project.displayName}</legend>
+			<legend>{presentationName}</legend>
 			<div className="legacy-team-project-row-content">
 				{needsAttention ? <span className="legacy-team-setup-status">Needs attention</span> : null}
 				{project.resolution === "deterministic" ? (
@@ -163,6 +165,12 @@ function ProjectRow({
 
 export function LegacyTeamSetupProjects(props: LegacyTeamSetupProjectsProps) {
 	const projects = orderedSetupProjects(props.detail.projects);
+	const presentationNames = stableProjectPresentationLabels(
+		projects.map((project) => ({
+			canonicalId: project.projectRef,
+			displayName: project.displayName,
+		})),
+	);
 	const automaticallyMappedCount = props.detail.projects.filter(
 		(project) => project.resolution === "deterministic",
 	).length;
@@ -194,6 +202,7 @@ export function LegacyTeamSetupProjects(props: LegacyTeamSetupProjectsProps) {
 						index={index}
 						key={project.projectRef}
 						onMap={props.onMap}
+						presentationName={presentationNames.get(project.projectRef) ?? project.displayName}
 						project={project}
 					/>
 				))}

--- a/packages/ui/src/tabs/legacy-team-setup-review.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-review.tsx
@@ -1,5 +1,9 @@
 import { useState } from "preact/hooks";
 import type { LegacyTeamSetupDetailResponseV1 } from "../lib/api";
+import {
+	projectDisplayNameKey,
+	stableProjectPresentationLabels,
+} from "../lib/project-identity-presentation";
 
 type FinishableDetail = Extract<LegacyTeamSetupDetailResponseV1, { state: "ready_to_finish" }>;
 
@@ -7,6 +11,7 @@ export interface LegacyTeamSetupReviewProps {
 	blocked: boolean;
 	blockedDescriptionId?: string;
 	detail: FinishableDetail;
+	finishing: boolean;
 	onFinish: (detail: FinishableDetail) => void;
 }
 
@@ -19,6 +24,7 @@ function countLabel(count: number, singular: string, plural = `${singular}s`): s
 
 interface ProjectIdentityGroup {
 	displayName: string;
+	kind: "project" | "legacy_default_sharing";
 	projectRefs: Set<string>;
 	changeCount: number;
 }
@@ -27,14 +33,17 @@ function groupProjectIdentities<T>(
 	items: T[],
 	displayName: (item: T) => string,
 	projectRef: (item: T) => string,
+	kind: (item: T) => ProjectIdentityGroup["kind"],
 ): ProjectIdentityGroup[] {
 	const groups = new Map<string, ProjectIdentityGroup>();
 	for (const item of items) {
 		const name = displayName(item);
-		const key = name.trim().toLowerCase();
+		const itemKind = kind(item);
+		const key = `${itemKind}:${projectDisplayNameKey(name)}`;
 		const ref = projectRef(item);
 		const group = groups.get(key) ?? {
 			displayName: name,
+			kind: itemKind,
 			projectRefs: new Set<string>(),
 			changeCount: 0,
 		};
@@ -45,12 +54,11 @@ function groupProjectIdentities<T>(
 	return [...groups.values()];
 }
 
-function projectGroupSummary(group: ProjectIdentityGroup): string {
-	return `${group.displayName} — ${countLabel(
-		group.projectRefs.size,
-		"Project with this name",
-		"Projects with this name",
-	)}`;
+function projectGroupSummary(group: ProjectIdentityGroup, noun: string): string {
+	if (group.kind === "legacy_default_sharing") return `${group.displayName} — default scope`;
+	return group.projectRefs.size > 1
+		? `${group.displayName} — ${countLabel(group.projectRefs.size, noun)}`
+		: group.displayName;
 }
 
 function DeltaSection({
@@ -110,6 +118,7 @@ export function LegacyTeamSetupReview({
 	blocked,
 	blockedDescriptionId,
 	detail,
+	finishing,
 	onFinish,
 }: LegacyTeamSetupReviewProps) {
 	const delta = detail.accessDelta;
@@ -143,23 +152,101 @@ export function LegacyTeamSetupReview({
 				change.change === "remove" ? "from" : "to"
 			} ${change.teamDisplayName}.`,
 	);
+	const projectLabels = stableProjectPresentationLabels([
+		...detail.projects.map((project) => ({
+			canonicalId: project.projectRef,
+			displayName: project.displayName,
+		})),
+		...delta.projectChanges.map((change) => ({
+			canonicalId: change.projectRef,
+			displayName: change.projectDisplayName,
+		})),
+	]);
+	const resolvedProjectItems = delta.projectChanges.flatMap((change) => [
+		...(change.fromResolvedProjectRef && change.fromResolvedProjectDisplayName
+			? [
+					{
+						canonicalProjectRef: change.fromCanonicalProjectRef,
+						resolvedProjectRef: change.fromResolvedProjectRef,
+						displayName: change.fromResolvedProjectDisplayName,
+					},
+				]
+			: []),
+		...(change.toResolvedProjectRef && change.toResolvedProjectDisplayName
+			? [
+					{
+						canonicalProjectRef: change.toCanonicalProjectRef,
+						resolvedProjectRef: change.toResolvedProjectRef,
+						displayName: change.toResolvedProjectDisplayName,
+					},
+				]
+			: []),
+	]);
+	const canonicalResolvedProjectLabels = stableProjectPresentationLabels(
+		resolvedProjectItems.map((item) => ({
+			canonicalId: item.canonicalProjectRef ?? item.resolvedProjectRef,
+			displayName: item.displayName,
+		})),
+	);
+	const resolvedProjectLabels = new Map(
+		resolvedProjectItems.map((item) => [
+			item.resolvedProjectRef,
+			canonicalResolvedProjectLabels.get(item.canonicalProjectRef ?? item.resolvedProjectRef) ??
+				item.displayName,
+		]),
+	);
+	const canonicalProjectLabels = stableProjectPresentationLabels([
+		...detail.projects.flatMap((project) =>
+			project.canonicalProjectRef
+				? [{ canonicalId: project.canonicalProjectRef, displayName: project.displayName }]
+				: [],
+		),
+		...[...delta.recipientChanges, ...delta.deviceAccessChanges]
+			.filter((change) => change.canonicalProjectKind === "project")
+			.map((change) => ({
+				canonicalId: change.canonicalProjectRef,
+				displayName: change.canonicalProjectDisplayName,
+			})),
+	]);
 	const projectItems = delta.projectChanges.map(
 		(change) =>
-			`${CHANGE_VERBS[change.change]} ${change.projectDisplayName}: ${
-				change.fromResolvedProjectDisplayName ?? "no Project"
-			} to ${change.toResolvedProjectDisplayName ?? "no Project"}.`,
+			`${CHANGE_VERBS[change.change]} ${
+				projectLabels.get(change.projectRef) ?? change.projectDisplayName
+			}: ${
+				change.fromResolvedProjectRef
+					? (resolvedProjectLabels.get(change.fromResolvedProjectRef) ??
+						change.fromResolvedProjectDisplayName ??
+						"no Project")
+					: "no Project"
+			} to ${
+				change.toResolvedProjectRef
+					? (resolvedProjectLabels.get(change.toResolvedProjectRef) ??
+						change.toResolvedProjectDisplayName ??
+						"no Project")
+					: "no Project"
+			}.`,
 	);
-	const recipientItems = delta.recipientChanges.map(
-		(change) =>
-			`${CHANGE_VERBS[change.change]} ${change.recipientDisplayName} ${
-				change.change === "remove" ? "from" : "as"
-			} a recipient for ${change.canonicalProjectDisplayName}.`,
+	const recipientItems = delta.recipientChanges.map((change) =>
+		change.canonicalProjectKind === "legacy_default_sharing"
+			? `${change.change === "remove" ? "Stop" : "Start"} using legacy default sharing for ${change.recipientDisplayName}.`
+			: `${CHANGE_VERBS[change.change]} ${change.recipientDisplayName} ${
+					change.change === "remove" ? "from" : "as"
+				} a recipient for ${
+					canonicalProjectLabels.get(change.canonicalProjectRef) ??
+					change.canonicalProjectDisplayName
+				}.`,
 	);
-	const deviceItems = delta.deviceAccessChanges.map(
-		(change) =>
-			`${CHANGE_VERBS[change.change]} ${change.deviceDisplayName} access ${
-				change.change === "remove" ? "from" : "to"
-			} ${change.canonicalProjectDisplayName}.`,
+	const deviceItems = delta.deviceAccessChanges.map((change) =>
+		change.canonicalProjectKind === "legacy_default_sharing"
+			? `${change.deviceDisplayName} ${
+					change.change === "remove" ? "stops" : "starts"
+				} inheriting legacy default sharing.`
+			: `${CHANGE_VERBS[change.change]} ${change.deviceDisplayName} access ${
+					change.change === "remove" ? "from" : "to"
+				} ${
+					canonicalProjectLabels.get(change.canonicalProjectRef) ??
+					change.canonicalProjectDisplayName
+				}.`,
 	);
 	const accessChangeCount =
 		delta.teamChanges.length +
@@ -171,16 +258,19 @@ export function LegacyTeamSetupReview({
 		delta.projectChanges,
 		(change) => change.projectDisplayName,
 		(change) => change.projectRef,
+		() => "project",
 	);
 	const recipientGroups = groupProjectIdentities(
 		delta.recipientChanges,
 		(change) => change.canonicalProjectDisplayName,
 		(change) => change.canonicalProjectRef,
+		(change) => change.canonicalProjectKind,
 	);
 	const deviceAccessGroups = groupProjectIdentities(
 		delta.deviceAccessChanges,
 		(change) => change.canonicalProjectDisplayName,
 		(change) => change.canonicalProjectRef,
+		(change) => change.canonicalProjectKind,
 	);
 	const includedDeviceCount = detail.devices.filter(
 		(device) => device.decision === "included",
@@ -196,6 +286,40 @@ export function LegacyTeamSetupReview({
 		includedDeviceCount,
 		"included device",
 	)}.`;
+	const reviewedProjectCount = Math.max(detail.candidate.projectCount, detail.projects.length);
+	const legacyCleanupDeviceCount = new Set(
+		delta.deviceAccessChanges.map((change) => change.deviceRef),
+	).size;
+	const removalCount = [
+		...delta.teamChanges,
+		...delta.membershipChanges,
+		...delta.projectChanges,
+		...delta.recipientChanges,
+		...delta.deviceAccessChanges,
+	].filter((change) => change.change === "remove").length;
+	const onlyLegacyDefaultCleanup =
+		delta.teamChanges.length === 0 &&
+		delta.membershipChanges.length === 0 &&
+		delta.projectChanges.length === 0 &&
+		delta.recipientChanges.length > 0 &&
+		delta.recipientChanges.every(
+			(change) =>
+				change.change === "remove" && change.canonicalProjectKind === "legacy_default_sharing",
+		) &&
+		delta.deviceAccessChanges.every(
+			(change) =>
+				change.change === "remove" && change.canonicalProjectKind === "legacy_default_sharing",
+		);
+	const netEffect = onlyLegacyDefaultCleanup
+		? `No new access will be added. This removes legacy default sharing for ${detail.candidate.displayName}.${
+				legacyCleanupDeviceCount > 0
+					? ` ${countLabel(legacyCleanupDeviceCount, "device")} will stop receiving memories shared only through that default.`
+					: ""
+			} Project-scoped access is unchanged across ${countLabel(reviewedProjectCount, "reviewed Project")}.`
+		: `${countLabel(accessChangeCount, "server-confirmed access change")} will be applied atomically; ${countLabel(
+				removalCount,
+				"removal",
+			)} ${removalCount === 1 ? "is" : "are"} included.`;
 
 	return (
 		<section aria-labelledby="legacy-team-setup-step-review">
@@ -204,6 +328,9 @@ export function LegacyTeamSetupReview({
 			</h3>
 			<p>Review every server-confirmed access change before activating this Team.</p>
 			<section aria-label="Access review summary" className="legacy-team-setup-review-summary">
+				<p className="legacy-team-setup-net-effect">
+					<strong>Net effect:</strong> {netEffect}
+				</p>
 				<p>
 					<strong>{countLabel(accessChangeCount, "exact access change")}</strong> to review.
 				</p>
@@ -233,7 +360,7 @@ export function LegacyTeamSetupReview({
 					exactItems={projectItems}
 					summaryItems={projectGroups.map(
 						(group) =>
-							`${projectGroupSummary(group)}, ${countLabel(group.changeCount, "Project change")}`,
+							`${projectGroupSummary(group, "reviewed Project")}, ${countLabel(group.changeCount, "Project change")}`,
 					)}
 					title="Projects"
 				/>
@@ -243,7 +370,7 @@ export function LegacyTeamSetupReview({
 					exactItems={recipientItems}
 					summaryItems={recipientGroups.map(
 						(group) =>
-							`${projectGroupSummary(group)}, ${countLabel(group.changeCount, "recipient change")}`,
+							`${projectGroupSummary(group, "canonical Project")}, ${countLabel(group.changeCount, "recipient change")}`,
 					)}
 					title="Recipients"
 				/>
@@ -253,7 +380,7 @@ export function LegacyTeamSetupReview({
 					exactItems={deviceItems}
 					summaryItems={deviceAccessGroups.map(
 						(group) =>
-							`${projectGroupSummary(group)}, ${countLabel(group.changeCount, "device-access change")}`,
+							`${projectGroupSummary(group, "canonical Project")}, ${countLabel(group.changeCount, "device-access change")}`,
 					)}
 					title="Device access"
 				/>
@@ -277,6 +404,13 @@ export function LegacyTeamSetupReview({
 				/>
 				<span>I reviewed every access change above and approve activating this Team.</span>
 			</label>
+			{finishing ? (
+				<p aria-live="polite" className="legacy-team-setup-finish-progress" role="status">
+					<span aria-hidden="true" className="legacy-team-setup-spinner" />
+					Checking the latest Team roster and applying all reviewed changes atomically. No partial
+					changes will be kept if this cannot finish.
+				</p>
+			) : null}
 			<button
 				aria-describedby={finishBlockedDescription || undefined}
 				aria-disabled={finishBlocked ? "true" : undefined}
@@ -286,7 +420,7 @@ export function LegacyTeamSetupReview({
 				}}
 				type="button"
 			>
-				Finish Team setup
+				{finishing ? "Finishing Team setup…" : "Finish Team setup"}
 			</button>
 		</section>
 	);

--- a/packages/ui/src/tabs/legacy-team-setup-session.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.ts
@@ -80,6 +80,8 @@ const CHANGED_STATE_ERROR =
 	"Team setup changed since it was last reviewed. Reload the latest details to continue.";
 const ROSTER_UNAVAILABLE_ERROR =
 	"Team device details are temporarily unavailable. Check the coordinator connection and settings, then refresh.";
+const ROSTER_UNAVAILABLE_AFTER_FINISH_ERROR =
+	"Team device details were unavailable, so setup was not finished and no changes were applied. Check the coordinator connection and settings, then refresh.";
 
 export function createSetupSessionState(): SetupSessionState {
 	return { status: "closed", generation: 0 };
@@ -577,17 +579,17 @@ function errorFor(command: SetupEffect, cause: unknown): SetupSessionError {
 	const message = changed
 		? CHANGED_STATE_ERROR
 		: rosterUnavailable
-			? ROSTER_UNAVAILABLE_ERROR
+			? command.kind === "finish"
+				? ROSTER_UNAVAILABLE_AFTER_FINISH_ERROR
+				: ROSTER_UNAVAILABLE_ERROR
 			: safeError(command.kind);
-	const retry = changed
-		? ("refresh" as const)
-		: command.kind === "refresh"
+	const retry =
+		changed ||
+		rosterUnavailable ||
+		command.kind === "refresh" ||
+		(command.kind === "load" && command.refresh)
 			? ("refresh" as const)
-			: command.kind === "load"
-				? command.refresh
-					? ("refresh" as const)
-					: ("load" as const)
-				: ("load" as const);
+			: ("load" as const);
 	if (
 		command.kind === "assign_device" ||
 		command.kind === "decide_device" ||

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1424,6 +1424,13 @@
       }
       .legacy-team-setup-review-summary p,
       .legacy-team-setup-review-summary ul { margin: 0; }
+      .legacy-team-setup-net-effect {
+        padding: var(--sp-3);
+        border-inline-start: 4px solid var(--accent);
+        border-radius: var(--radius-sm);
+        background: var(--accent-subtle);
+        line-height: 1.5;
+      }
       .legacy-team-setup-delta section { padding-block: var(--sp-2); border-bottom: 1px solid var(--border); }
       .legacy-team-setup-delta h4 { margin: 0 0 var(--sp-2); }
       .legacy-team-setup-delta ul { display: grid; gap: var(--sp-1); margin: 0; padding-inline-start: var(--sp-5); }
@@ -1437,6 +1444,30 @@
       }
       .legacy-team-setup-confirmation { display: flex; gap: var(--sp-2); align-items: flex-start; margin-block: var(--sp-4); }
       .legacy-team-setup-confirmation input { flex: 0 0 auto; margin-top: 0.2em; min-width: 24px; min-height: 24px; }
+      .legacy-team-setup-finish-progress {
+        display: flex;
+        gap: var(--sp-2);
+        align-items: flex-start;
+        margin-block: var(--sp-3);
+        padding: var(--sp-3);
+        border: 1px solid var(--accent);
+        border-radius: var(--radius-sm);
+        background: var(--accent-subtle);
+      }
+      .legacy-team-setup-spinner {
+        width: 1rem;
+        height: 1rem;
+        flex: 0 0 auto;
+        margin-top: 0.15em;
+        border: 2px solid var(--border);
+        border-top-color: var(--accent);
+        border-radius: 50%;
+        animation: legacy-team-setup-spin 0.8s linear infinite;
+      }
+      @keyframes legacy-team-setup-spin { to { transform: rotate(360deg); } }
+      @media (prefers-reduced-motion: reduce) {
+        .legacy-team-setup-spinner { animation: none; }
+      }
       .recipient-policy-management-selection fieldset { border: 0; padding: 0; margin: var(--sp-4) 0 0; }
       .recipient-policy-management-selection legend { font-weight: var(--font-weight-semibold); }
       .recipient-policy-management-review section + section { margin-top: var(--sp-4); }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1137,8 +1137,10 @@ describe("viewer-server", () => {
 			expect(safe.projectChanges[0]).toEqual({
 				projectRef,
 				projectDisplayName: "Project outside this setup (1)",
+				fromCanonicalProjectRef: core.legacyTeamCanonicalProjectRef(candidateRef, fromIdentity),
 				fromResolvedProjectRef: fromRef,
 				fromResolvedProjectDisplayName: "Project outside this setup (2)",
+				toCanonicalProjectRef: core.legacyTeamCanonicalProjectRef(candidateRef, toIdentity),
 				toResolvedProjectRef: toRef,
 				toResolvedProjectDisplayName: "Project outside this setup (3)",
 				change: "update",
@@ -1205,6 +1207,39 @@ describe("viewer-server", () => {
 			]);
 			expect(JSON.stringify(safe)).not.toContain("external-device");
 			expect(JSON.stringify(safe)).not.toContain("file:///private");
+		});
+
+		it("labels synthetic default-sharing cleanup without pretending it is a Project", () => {
+			const safe = __teamSetupTestHooks.viewerSafeAccessDelta(candidateRef, {
+				teamChanges: [],
+				membershipChanges: [],
+				projectChanges: [],
+				recipientChanges: [
+					{
+						canonicalProjectIdentity: "shared:default",
+						recipientKind: "team",
+						recipientId: "team-id",
+						change: "remove",
+					},
+				],
+				deviceAccessChanges: [
+					{
+						canonicalProjectIdentity: "shared:default",
+						deviceId: "device-id",
+						change: "remove",
+					},
+				],
+			});
+
+			expect(safe.recipientChanges[0]).toMatchObject({
+				canonicalProjectDisplayName: "Legacy default sharing",
+				canonicalProjectKind: "legacy_default_sharing",
+			});
+			expect(safe.deviceAccessChanges[0]).toMatchObject({
+				canonicalProjectDisplayName: "Legacy default sharing",
+				canonicalProjectKind: "legacy_default_sharing",
+			});
+			expect(JSON.stringify(safe)).not.toContain("shared:default");
 		});
 
 		it("fails closed when active identity choices exceed their response cap", async () => {

--- a/packages/viewer-server/src/routes/team-setup-view.ts
+++ b/packages/viewer-server/src/routes/team-setup-view.ts
@@ -98,8 +98,10 @@ export interface LegacyTeamSetupViewerAccessDeltaV1 {
 	projectChanges: Array<{
 		projectRef: string;
 		projectDisplayName: string;
+		fromCanonicalProjectRef: string | null;
 		fromResolvedProjectRef: string | null;
 		fromResolvedProjectDisplayName: string | null;
+		toCanonicalProjectRef: string | null;
 		toResolvedProjectRef: string | null;
 		toResolvedProjectDisplayName: string | null;
 		change: "add" | "update" | "remove";
@@ -107,6 +109,7 @@ export interface LegacyTeamSetupViewerAccessDeltaV1 {
 	recipientChanges: Array<{
 		canonicalProjectRef: string;
 		canonicalProjectDisplayName: string;
+		canonicalProjectKind: "project" | "legacy_default_sharing";
 		recipientKind: "team";
 		recipientRef: string;
 		recipientDisplayName: string;
@@ -115,6 +118,7 @@ export interface LegacyTeamSetupViewerAccessDeltaV1 {
 	deviceAccessChanges: Array<{
 		canonicalProjectRef: string;
 		canonicalProjectDisplayName: string;
+		canonicalProjectKind: "project" | "legacy_default_sharing";
 		deviceRef: string;
 		deviceDisplayName: string;
 		change: "add" | "remove";

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -511,6 +511,15 @@ function viewerSafeAccessDelta(
 		labels?.identityChoices.map((identity) => [identity.identityRef, identity]),
 	);
 	const devicesByRef = new Map(labels?.devices.map((device) => [device.deviceRef, device]));
+	const canonicalProjectPresentation = (identity: string, ref: string) => {
+		if (identity === "shared:default") {
+			return { displayName: "Legacy default sharing", kind: "legacy_default_sharing" as const };
+		}
+		return {
+			displayName: projectsByCanonicalRef.get(ref)?.displayName ?? fallbackLabel("Project", ref),
+			kind: "project" as const,
+		};
+	};
 	const resolvedDisplayName = (projectRef: string, ref: string | null): string | null => {
 		if (!ref) return null;
 		const project = projectsByRef.get(projectRef);
@@ -550,8 +559,14 @@ function viewerSafeAccessDelta(
 				projectDisplayName:
 					projectsByRef.get(change.projectRef)?.displayName ??
 					fallbackLabel("Project", change.projectRef),
+				fromCanonicalProjectRef: change.fromProjectIdentity
+					? legacyTeamCanonicalProjectRef(candidateRef, change.fromProjectIdentity)
+					: null,
 				fromResolvedProjectRef: fromRef,
 				fromResolvedProjectDisplayName: resolvedDisplayName(change.projectRef, fromRef),
+				toCanonicalProjectRef: change.toProjectIdentity
+					? legacyTeamCanonicalProjectRef(candidateRef, change.toProjectIdentity)
+					: null,
 				toResolvedProjectRef: toRef,
 				toResolvedProjectDisplayName: resolvedDisplayName(change.projectRef, toRef),
 				change: change.change,
@@ -563,11 +578,14 @@ function viewerSafeAccessDelta(
 				change.canonicalProjectIdentity,
 			);
 			const recipientRef = teamRef(candidateRef, change.recipientId);
+			const projectPresentation = canonicalProjectPresentation(
+				change.canonicalProjectIdentity,
+				canonicalProjectRef,
+			);
 			return {
 				canonicalProjectRef,
-				canonicalProjectDisplayName:
-					projectsByCanonicalRef.get(canonicalProjectRef)?.displayName ??
-					fallbackLabel("Project", canonicalProjectRef),
+				canonicalProjectDisplayName: projectPresentation.displayName,
+				canonicalProjectKind: projectPresentation.kind,
 				recipientKind: change.recipientKind,
 				recipientRef,
 				recipientDisplayName: labels?.teamDisplayName ?? fallbackLabel("Team", recipientRef),
@@ -580,11 +598,14 @@ function viewerSafeAccessDelta(
 				change.canonicalProjectIdentity,
 			);
 			const deviceRef = legacyTeamDeviceRef(candidateRef, change.deviceId);
+			const projectPresentation = canonicalProjectPresentation(
+				change.canonicalProjectIdentity,
+				canonicalProjectRef,
+			);
 			return {
 				canonicalProjectRef,
-				canonicalProjectDisplayName:
-					projectsByCanonicalRef.get(canonicalProjectRef)?.displayName ??
-					fallbackLabel("Project", canonicalProjectRef),
+				canonicalProjectDisplayName: projectPresentation.displayName,
+				canonicalProjectKind: projectPresentation.kind,
 				deviceRef,
 				deviceDisplayName:
 					devicesByRef.get(deviceRef)?.displayName ?? fallbackLabel("Device", deviceRef),


### PR DESCRIPTION
## Description
Fixes live dogfood confusion in the legacy Team final review. Synthetic `shared:default` cleanup is presented as **Legacy default sharing**, the review opens with a concrete net-effect statement, repeated Project names use stable privacy-safe Project N-of-M labels on both Projects and Review, and grouping distinguishes reviewed rows from canonical Projects. Long Finish requests now show a prominent atomic-progress state; roster failure after Finish explicitly says setup did not finish and no changes were applied.

Tracks codemem-752i.11 and blocks codemem-752i.7.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Full `pnpm run check`: 230 files, 5604 tests passed, 3 todo
- [x] Full `pnpm run build`
- [x] 511 focused server/UI migration tests
- [x] Net-effect, duplicate-label, Finish progress, no-partial-change error, privacy, and reduced-motion coverage

## Checklist
- [x] Code follows project style
- [x] CodeReviewer approval
- [x] No opaque identifiers rendered
- [x] No new warnings introduced