### PR TITLE
fix(core): harden legacy Team recovery policy

### DIFF
--- a/e2e/scenarios/legacy-team-migration.ts
+++ b/e2e/scenarios/legacy-team-migration.ts
@@ -806,6 +806,7 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 		recoveredBetaDetail.candidate.status === "ready" &&
 			recoveredBetaDetail.state === "completed" &&
 			!recoveredBetaDetail.actions.finish.enabled &&
+			recoveredBetaDetail.actions.finish.blockedReason === "setup_completed" &&
 			!recoveredBetaDetail.actions.refresh.enabled,
 		"detail did not recover Beta as completed after the dropped finish response",
 	);

--- a/packages/core/src/identity-device-assignment.ts
+++ b/packages/core/src/identity-device-assignment.ts
@@ -209,8 +209,8 @@ export function assignIdentityDeviceInTransaction(
 		.run(now, input.deviceId);
 
 	for (const team of affectedTeams) {
-		// Candidate readiness requires a matching source fingerprint. Clearing it
-		// makes the completed draft non-ready so refresh creates a new setup attempt.
+		// Clear the stale completion fingerprint so compatibility diagnostics and
+		// older non-terminal migration records fail closed after reassignment.
 		db.prepare(
 			`UPDATE policy_teams
 			 SET source_fingerprint = NULL, updated_at = ?

--- a/packages/core/src/legacy-recipient-policy-projection.test.ts
+++ b/packages/core/src/legacy-recipient-policy-projection.test.ts
@@ -1,6 +1,9 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { listLegacyRecipientPolicyProjections } from "./legacy-recipient-policy-projection.js";
+import {
+	listLegacyRecipientPolicyProjections,
+	listLegacyTeamProjectEvidence,
+} from "./legacy-recipient-policy-projection.js";
 import { shareProjectSetDigest } from "./share-operation.js";
 import { initTestSchema } from "./test-utils.js";
 
@@ -171,6 +174,24 @@ describe("legacy recipient-policy projection", () => {
 	});
 
 	afterEach(() => db.close());
+
+	it.each([
+		"/",
+		"C:\\",
+		"//server/share",
+		"file://server/share",
+		"file:////server/share",
+	])("excludes filesystem-root Project %s from recipient review", (identity) => {
+		mapProject(db, identity, "local-default", "root-project");
+
+		expect(projections(db)).toEqual([]);
+		expect(
+			listLegacyTeamProjectEvidence(db, {
+				localActorId: LOCAL_ACTOR_ID,
+				localDeviceId: LOCAL_DEVICE_ID,
+			}),
+		).toEqual([]);
+	});
 
 	it("projects one exact canonical Project from one active managed scope", () => {
 		const scopeId = "managed-project-one";

--- a/packages/core/src/legacy-recipient-policy-projection.ts
+++ b/packages/core/src/legacy-recipient-policy-projection.ts
@@ -1,4 +1,5 @@
 import type { Database } from "./db.js";
+import { isFilesystemRootProjectIdentity } from "./legacy-team-project-policy.js";
 import { preferredActiveUnmergedLocalActorId } from "./recipient-policy-actor-eligibility.js";
 import {
 	RECIPIENT_POLICY_CONTRACT_VERSION,
@@ -208,6 +209,10 @@ function hasWildcard(value: string): boolean {
 
 function normalizedIdentity(value: string): string {
 	return value.trim().replaceAll("\\", "/").replace(/\/+$/u, "");
+}
+
+export function normalizeLegacyProjectMappingIdentity(value: string): string {
+	return normalizedIdentity(value);
 }
 
 function wildcardMatches(identity: string, pattern: string): boolean {
@@ -670,8 +675,13 @@ export function projectLegacyRecipientPolicyProjections(
 	options: ListLegacyRecipientPolicyProjectionsOptions,
 ): LegacyRecipientPolicyProjectionV1[] {
 	const scopes = new Map(snapshot.scopes.map((scope) => [scope.scopeId, scope]));
-	const projectsByScope = scopeProjectIndex(snapshot);
-	return snapshot.projects
+	const projects = snapshot.projects.filter(
+		(project) =>
+			project.canonicalIdentity !== "" &&
+			!isFilesystemRootProjectIdentity(project.canonicalIdentity),
+	);
+	const projectsByScope = scopeProjectIndex({ ...snapshot, projects });
+	return projects
 		.map((project): LegacyRecipientPolicyProjectionV1 => {
 			const projectShareOperations = snapshot.shareOperations.filter(
 				(operation) => operation.canonicalProjectIdentity === project.canonicalIdentity,
@@ -850,6 +860,7 @@ function loadSnapshot(
 				AND mi.active = 1 AND mi.deleted_at IS NULL
 			 WHERE (COALESCE(TRIM(s.git_remote), TRIM(s.cwd), TRIM(s.project), TRIM(mi.workspace_id), '') <> '')
 			   AND (s.cwd IS NULL OR substr(s.cwd, 1, length(?)) <> ?)
+			   AND COALESCE(s.tool_version, '') <> 'sync_replication'
 			 ORDER BY s.id, mi.id`,
 		)
 		.all(SYNC_BOOTSTRAP_CWD_PREFIX, SYNC_BOOTSTRAP_CWD_PREFIX) as Array<{

--- a/packages/core/src/legacy-team-candidate.test.ts
+++ b/packages/core/src/legacy-team-candidate.test.ts
@@ -11,6 +11,35 @@ import {
 	legacyTeamCandidateProjectInventory,
 	refreshLegacyTeamCandidate,
 } from "./legacy-team-candidate.js";
+import { isFilesystemRootProjectIdentity } from "./legacy-team-project-policy.js";
+
+describe("filesystem-root Project identities", () => {
+	it.each([
+		"/",
+		"C:\\",
+		"D:/",
+		"//server/share",
+		"file:///",
+		"file:///C:/",
+		"file://server/share",
+		"file://server/share/",
+		"file:////server/share",
+	])("rejects %s", (identity) => {
+		expect(isFilesystemRootProjectIdentity(identity)).toBe(true);
+	});
+
+	it.each([
+		"/workspace/repo",
+		"C:\\workspace\\repo",
+		"//server/share/repo",
+		"file://server/share/repo",
+		"file:///C:/workspace/repo",
+		"codemem",
+	])("keeps %s", (identity) => {
+		expect(isFilesystemRootProjectIdentity(identity)).toBe(false);
+	});
+});
+
 import { latestLegacyTeamSetupAttempt } from "./legacy-team-setup-attempt.js";
 import { getLegacyTeamSetupDraft } from "./legacy-team-setup-draft.js";
 import {
@@ -639,9 +668,31 @@ describe("legacy Team candidate discovery", () => {
 		// Older completions may predate Project edge materialization. A setup-owned
 		// missing edge is restored once, without reopening an otherwise compatible Team.
 		db.prepare("DELETE FROM project_recipients WHERE recipient_id = ?").run(completedTeamId);
+		const supersedingAttemptId = "legacy-team-attempt:00000000-0000-4000-8000-000000000099";
+		db.prepare(
+			`INSERT INTO legacy_team_setup_drafts(
+			 attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
+			 roster_fingerprint, projection_fingerprint, created_at, updated_at
+			 ) SELECT ?, candidate_id, coordinator_id, group_id, 'needs_setup', display_name,
+			 'superseding-roster', 'superseding-projection', ?, ?
+			 FROM legacy_team_setup_drafts WHERE attempt_id = ?`,
+		).run(supersedingAttemptId, NOW, NOW, draft.attempt_id);
 		const firstReconciliation = options();
 		firstReconciliation.now = "2026-08-21T12:01:00.000Z";
 		expect(discoverLegacyTeamCandidates(db, firstReconciliation)[0]?.status).toBe("ready");
+		expect(
+			db
+				.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts WHERE candidate_id = ?")
+				.pluck()
+				.get(draft.candidate_id),
+		).toBe(2);
+		expect(
+			db
+				.prepare(
+					"SELECT state, completed_team_id FROM legacy_team_setup_drafts WHERE attempt_id = ?",
+				)
+				.get(supersedingAttemptId),
+		).toEqual({ state: "needs_setup", completed_team_id: null });
 		expect(
 			db
 				.prepare(
@@ -768,7 +819,8 @@ describe("legacy Team candidate discovery", () => {
 		});
 		expect(latestLegacyTeamSetupAttempt(db, draft.candidate_id)?.attemptId).toBe(draft.attempt_id);
 
-		// A genuinely new Project still reopens setup for review.
+		// A genuinely new Project drops the legacy Ready diagnostic without
+		// superseding the terminal completion.
 		const newSession = Number(
 			db.prepare(`INSERT INTO sessions(started_at, project) VALUES (?, 'brand-new')`).run(NOW)
 				.lastInsertRowid,
@@ -848,6 +900,17 @@ describe("legacy Team candidate discovery", () => {
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("needs_setup");
 	});
 
+	it("keeps Ready for a higher-priority exact mapping to the reviewed scope", () => {
+		completeCandidate();
+		db.prepare(
+			`INSERT INTO project_scope_mappings(
+				workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, 'older-exact-pattern', 'scope-api', 9000, 'test', ?, ?)`,
+		).run(PROJECT_ID, NOW, NOW);
+
+		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
+	});
+
 	it("drops Ready for malformed inactive membership identities", () => {
 		const { teamId } = completeCandidate();
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
@@ -892,9 +955,14 @@ describe("legacy Team candidate discovery", () => {
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("needs_setup");
 	});
 
-	it("keeps Ready when merged resolutions share one selected mapping", () => {
-		const { attemptId, candidateId } = completeCandidate();
+	it("keeps a completed Team selectable when merged resolutions share one mapping", () => {
+		const { teamId, attemptId, candidateId } = completeCandidate();
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
+		// Exercise the full compatibility path used by completions created before
+		// terminal migration provenance was introduced.
+		db.prepare(
+			"UPDATE policy_teams SET provenance = 'legacy_team_candidate' WHERE team_id = ?",
+		).run(teamId);
 		db.prepare(
 			`INSERT INTO replication_scopes(
 				scope_id, label, kind, authority_type, coordinator_id, group_id,
@@ -910,28 +978,15 @@ describe("legacy Team candidate discovery", () => {
 			`INSERT INTO legacy_team_setup_draft_projects(
 				attempt_id, project_ref, source_project_identity, display_name,
 				source_fingerprint, resolution_kind, resolved_project_identity, target_scope_id, updated_at
-				 ) VALUES (?, 'project-ref-mirror', 'unmapped:mirror', 'Mirror', 'source-mirror',
+			 ) VALUES (?, 'project-ref-mirror', 'unmapped:mirror', 'Mirror', 'source-mirror',
 			 'explicit', ?, 'scope-api', ?)`,
 		).run(attemptId, PROJECT_ID, NOW);
-		const prepareSpy = vi.spyOn(db, "prepare");
-		try {
-			expect(isLegacyTeamCandidateSelectable(db, candidateId)).toBe(true);
-			expect(
-				prepareSpy.mock.calls.filter(([sql]) => /FROM actors ORDER BY actor_id/.test(String(sql))),
-			).toHaveLength(1);
-			expect(
-				prepareSpy.mock.calls.filter(([sql]) =>
-					/SELECT 1 FROM project_recipients\s+WHERE canonical_project_identity/u.test(String(sql)),
-				),
-			).toHaveLength(1);
-			expect(
-				prepareSpy.mock.calls.filter(([sql]) =>
-					/FROM project_scope_mappings\s+ORDER BY priority DESC/u.test(String(sql)),
-				),
-			).toHaveLength(1);
-		} finally {
-			prepareSpy.mockRestore();
-		}
+		db.prepare(
+			`INSERT INTO project_scope_mappings(
+				workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, 'unmapped:mirror', 'scope-api', 1000, 'reviewed_team_setup', ?, ?)`,
+		).run(PROJECT_ID, NOW, NOW);
+		expect(isLegacyTeamCandidateSelectable(db, candidateId)).toBe(true);
 
 		// The other merged source targets scope-api-second, but that cannot
 		// authorize moving the selected primary source away from scope-api.
@@ -985,14 +1040,16 @@ describe("legacy Team candidate discovery", () => {
 						sql.includes("FROM legacy_team_setup_drafts") && sql.includes("completed_team_id"),
 				);
 			expect(authorityReads).toHaveLength(1);
-			expect(authorityReads[0]).toMatch(/WHERE candidate_id = \?\s+ORDER BY rowid DESC LIMIT 1/u);
+			expect(authorityReads[0]).toMatch(
+				/WHERE draft\.candidate_id = \?.*ORDER BY draft\.rowid DESC LIMIT 1/su,
+			);
 			expect(authorityReads[0]).not.toMatch(/WHERE attempt_id = \?/u);
 		} finally {
 			prepare.mockRestore();
 		}
 	});
 
-	it("bounds active assignment statement preparation across completion-bound devices", () => {
+	it("does not revalidate completion-bound devices after migration", () => {
 		const { teamId, attemptId, candidateId } = completeCandidate();
 		const insertActor = db.prepare(
 			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
@@ -1055,7 +1112,7 @@ describe("legacy Team candidate discovery", () => {
 						String(sql),
 					),
 				),
-			).toHaveLength(1);
+			).toHaveLength(0);
 		} finally {
 			prepare.mockRestore();
 		}
@@ -1204,8 +1261,8 @@ describe("legacy Team candidate discovery", () => {
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.projectCount).toBe(3);
 	});
 
-	it("blocks selection when current evidence drifted from the completion", () => {
-		completeCandidate();
+	it("keeps a completed Team selectable when current evidence drifts", () => {
+		const completion = completeCandidate();
 		const [candidate] = discoverLegacyTeamCandidates(db, options());
 		expect(candidate?.status).toBe("ready");
 		const candidateId = candidate?.candidateRef as string;
@@ -1217,18 +1274,149 @@ describe("legacy Team candidate discovery", () => {
 			true,
 		);
 
-		// Roster drift the next discovery would reopen setup for must also
-		// block selection when the caller holds a current snapshot.
+		// Roster and Project drift belong to normal Team management after the
+		// one-time migration completes; they must not revoke that completion.
 		expect(
 			isLegacyTeamCandidateSelectable(db, candidateId, {
 				rosterFingerprint: "drifted-roster",
 				projects: liveInventory,
 			}),
-		).toBe(false);
+		).toBe(true);
 
-		// Inventory drift — a reviewed Project vanished or a new one appeared —
-		// blocks selection the same way.
-		expect(isLegacyTeamCandidateSelectable(db, candidateId, { projects: [] })).toBe(false);
+		expect(isLegacyTeamCandidateSelectable(db, candidateId, { projects: [] })).toBe(true);
+
+		const driftedRoster = options("key-b");
+		expect(discoverLegacyTeamCandidates(db, driftedRoster)[0]?.status).toBe("needs_setup");
+		expect(latestLegacyTeamSetupAttempt(db, candidateId)?.attemptId).toBe(completion.attemptId);
+		expect(getLegacyTeamSetupDraft(db, candidateId)?.state).toBe("completed");
+		expect(isLegacyTeamCandidateSelectable(db, candidateId)).toBe(true);
+	});
+
+	it("validates normalized current Project evidence for pre-marker completions", () => {
+		const completion = completeCandidate();
+		db.prepare(
+			"UPDATE policy_teams SET provenance = 'legacy_team_candidate' WHERE team_id = ?",
+		).run(completion.teamId);
+		const liveInventory = legacyTeamCandidateProjectInventory(
+			db,
+			options().projection,
+			completion.candidateId,
+		);
+		db.prepare("UPDATE project_scope_mappings SET workspace_identity = ?").run(`${PROJECT_ID}/`);
+
+		expect(
+			isLegacyTeamCandidateSelectable(db, completion.candidateId, {
+				projects: liveInventory.map((project) => ({
+					...project,
+					sourceProjectIdentity: `${project.sourceProjectIdentity}/`,
+				})),
+			}),
+		).toBe(true);
+		expect(isLegacyTeamCandidateSelectable(db, completion.candidateId, { projects: [] })).toBe(
+			false,
+		);
+	});
+
+	it("keeps pre-marker completions selectable after root Projects are retired", () => {
+		const completion = completeCandidate();
+		db.prepare(
+			"UPDATE policy_teams SET provenance = 'legacy_team_candidate' WHERE team_id = ?",
+		).run(completion.teamId);
+		db.prepare(
+			`UPDATE legacy_team_setup_draft_projects
+			 SET source_project_identity = '/', resolved_project_identity = '/'
+			 WHERE attempt_id = ?`,
+		).run(completion.attemptId);
+		db.prepare("DELETE FROM memory_items").run();
+		db.prepare("DELETE FROM sessions").run();
+		db.prepare("DELETE FROM project_scope_mappings").run();
+
+		expect(isLegacyTeamCandidateSelectable(db, completion.candidateId, { projects: [] })).toBe(
+			true,
+		);
+	});
+
+	it.each([
+		"/",
+		null,
+	])("reconciles non-root edges without restoring a retired root resolved as %s", (rootResolution) => {
+		const completion = completeCandidate();
+		db.prepare(
+			"UPDATE policy_teams SET provenance = 'legacy_team_candidate' WHERE team_id = ?",
+		).run(completion.teamId);
+		db.prepare(
+			`INSERT INTO legacy_team_setup_draft_projects(
+				 attempt_id, project_ref, source_project_identity, display_name,
+				 source_fingerprint, resolution_kind, resolved_project_identity,
+				 target_scope_id, updated_at
+				 ) VALUES (?, '000-root', '/', 'Filesystem root', 'root-source',
+				 'explicit', ?, 'scope-api', ?)`,
+		).run(completion.attemptId, rootResolution, NOW);
+		db.prepare(
+			"DELETE FROM project_recipients WHERE canonical_project_identity = ? AND recipient_id = ?",
+		).run(PROJECT_ID, completion.teamId);
+
+		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
+		expect(
+			db
+				.prepare(
+					`SELECT COUNT(*) FROM project_recipients
+						 WHERE canonical_project_identity = ? AND recipient_id = ? AND status = 'active'`,
+				)
+				.pluck()
+				.get(PROJECT_ID, completion.teamId),
+		).toBe(1);
+		expect(
+			db
+				.prepare(
+					`SELECT COUNT(*) FROM project_recipients
+						 WHERE canonical_project_identity = '/' AND recipient_id = ?`,
+				)
+				.pluck()
+				.get(completion.teamId),
+		).toBe(0);
+	});
+
+	it("keeps validating a retired root source resolved to a non-root Project", () => {
+		const completion = completeCandidate();
+		db.prepare(
+			"UPDATE policy_teams SET provenance = 'legacy_team_candidate' WHERE team_id = ?",
+		).run(completion.teamId);
+		db.prepare(
+			`UPDATE legacy_team_setup_draft_projects
+			 SET source_project_identity = '/'
+			 WHERE attempt_id = ?`,
+		).run(completion.attemptId);
+		db.prepare(
+			"DELETE FROM project_recipients WHERE canonical_project_identity = ? AND recipient_id = ?",
+		).run(PROJECT_ID, completion.teamId);
+
+		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
+		expect(
+			db
+				.prepare(
+					`SELECT COUNT(*) FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_id = ? AND status = 'active'`,
+				)
+				.pluck()
+				.get(PROJECT_ID, completion.teamId),
+		).toBe(1);
+	});
+
+	it("reopens an incompatible completion that predates terminal migration markers", () => {
+		const completion = completeCandidate();
+		db.prepare(
+			`UPDATE policy_teams
+			 SET provenance = 'legacy_team_candidate', source_fingerprint = 'drifted-roster'
+			 WHERE team_id = ?`,
+		).run(completion.teamId);
+
+		expect(isLegacyTeamCandidateSelectable(db, completion.candidateId)).toBe(false);
+		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("needs_setup");
+		expect(latestLegacyTeamSetupAttempt(db, completion.candidateId)?.attemptId).not.toBe(
+			completion.attemptId,
+		);
+		expect(getLegacyTeamSetupDraft(db, completion.candidateId)?.state).toBe("needs_setup");
 	});
 
 	it("rejects rosters with conflicting duplicate device rows", () => {
@@ -1560,7 +1748,7 @@ describe("legacy Team candidate discovery", () => {
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
 	});
 
-	it("keeps the active Team name when stale coordinator evidence creates a replacement draft", () => {
+	it("keeps the active Team name and completion when coordinator evidence changes", () => {
 		const [initial] = discoverLegacyTeamCandidates(db, options());
 		const draft = db
 			.prepare(
@@ -1588,8 +1776,29 @@ describe("legacy Team candidate discovery", () => {
 
 		const refreshed = refreshLegacyTeamCandidate(db, options("changed-key"), draft.candidate_id);
 
-		expect(refreshed.attemptId).not.toBe(draft.attempt_id);
+		expect(refreshed.attemptId).toBe(draft.attempt_id);
+		expect(refreshed.state).toBe("completed");
 		expect(refreshed.displayName).toBe("Renamed Engineering");
+	});
+
+	it("keeps the last reviewed Team name when coordinator labels temporarily fall back", () => {
+		const namedOptions = options();
+		const namedGroup = namedOptions.groups[0];
+		if (!namedGroup) throw new Error("group fixture missing");
+		namedGroup.displayName = "Nerdworld";
+		const [initial] = discoverLegacyTeamCandidates(db, namedOptions);
+		expect(initial?.displayName).toBe("Nerdworld");
+
+		const fallbackOptions = options("changed-key");
+		const fallbackGroup = fallbackOptions.groups[0];
+		if (!fallbackGroup) throw new Error("group fixture missing");
+		fallbackGroup.displayName = "Legacy Team";
+		const [refreshed] = discoverLegacyTeamCandidates(db, fallbackOptions);
+
+		expect(refreshed?.displayName).toBe("Nerdworld");
+		expect(getLegacyTeamSetupDraft(db, refreshed?.candidateRef as string)?.displayName).toBe(
+			"Nerdworld",
+		);
 	});
 
 	it("serializes a competing refresh before reading candidate authority", () => {
@@ -1968,7 +2177,7 @@ describe("legacy Team candidate discovery", () => {
 					.run(teamId, NOW, NOW);
 			},
 		],
-	] as const)("drops Ready for an included-device completion when %s", (_label, mutate) => {
+	] as const)("preserves terminal completion when %s", (_label, mutate) => {
 		db.prepare(
 			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
 			 VALUES ('identity-a', 'Person A', 0, 'active', ?, ?)`,
@@ -2034,9 +2243,12 @@ describe("legacy Team candidate discovery", () => {
 
 		mutate(db, teamId);
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("needs_setup");
+		expect(latestLegacyTeamSetupAttempt(db, draft.candidate_id)?.attemptId).toBe(draft.attempt_id);
+		expect(getLegacyTeamSetupDraft(db, draft.candidate_id)?.state).toBe("completed");
+		expect(isLegacyTeamCandidateSelectable(db, draft.candidate_id)).toBe(true);
 	});
 
-	it("reopens a completed candidate when its Project inventory fingerprint is stale", () => {
+	it("replaces a malformed completion without a terminal Team", () => {
 		const [initial] = discoverLegacyTeamCandidates(db, options());
 		if (!initial) throw new Error("initial candidate missing");
 		const initialAttempt = latestLegacyTeamSetupAttempt(db, initial.candidateRef);
@@ -2047,18 +2259,16 @@ describe("legacy Team candidate discovery", () => {
 			 WHERE candidate_id = ?`,
 		).run(NOW, initial.candidateRef);
 
-		const [reopened] = discoverLegacyTeamCandidates(db, options());
-		if (!reopened) throw new Error("reopened candidate missing");
-		const reopenedAttempt = latestLegacyTeamSetupAttempt(db, reopened.candidateRef);
+		const [rediscovered] = discoverLegacyTeamCandidates(db, options());
+		if (!rediscovered) throw new Error("rediscovered candidate missing");
+		const rediscoveredAttempt = latestLegacyTeamSetupAttempt(db, rediscovered.candidateRef);
 
-		expect(reopened.status).toBe("needs_setup");
-		expect(reopenedAttempt).toMatchObject({ candidateId: initial.candidateRef, isCurrent: true });
-		expect(reopenedAttempt?.attemptId).not.toBe(initialAttempt.attemptId);
-		expect(
-			db
-				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
-				.pluck()
-				.get(initialAttempt.attemptId),
-		).toBe("completed");
+		expect(rediscovered.status).toBe("needs_setup");
+		expect(rediscoveredAttempt).toMatchObject({
+			candidateId: initial.candidateRef,
+			isCurrent: true,
+		});
+		expect(rediscoveredAttempt?.attemptId).not.toBe(initialAttempt.attemptId);
+		expect(getLegacyTeamSetupDraft(db, initial.candidateRef)?.state).toBe("needs_setup");
 	});
 });

--- a/packages/core/src/legacy-team-candidate.ts
+++ b/packages/core/src/legacy-team-candidate.ts
@@ -2,10 +2,14 @@ import type { Database } from "./db.js";
 import {
 	type ListLegacyRecipientPolicyProjectionsOptions,
 	listLegacyTeamProjectEvidence,
+	normalizeLegacyProjectMappingIdentity,
 	selectedProjectScopeMappings,
 } from "./legacy-recipient-policy-projection.js";
 import { planLegacyTeamAttempt } from "./legacy-team-attempt-lifecycle.js";
-import { isMigratableLegacyTeamProjectIdentity } from "./legacy-team-project-policy.js";
+import {
+	isFilesystemRootProjectIdentity,
+	isMigratableLegacyTeamProjectIdentity,
+} from "./legacy-team-project-policy.js";
 import {
 	type LegacyTeamSetupDraftState,
 	type LegacyTeamSetupDraftView,
@@ -227,7 +231,7 @@ function projectInventory(
 	return evidence
 		.filter(
 			(project) =>
-				isMigratableLegacyTeamProjectIdentity(project.project.canonicalIdentity) &&
+				isMigratableLegacyTeamProjectIdentity(project.project.canonicalIdentity, db) &&
 				project.teamCandidateIds.includes(candidateId),
 		)
 		.map((project) => {
@@ -257,11 +261,20 @@ function projectInventory(
  * `unmapped:` source mapped to its reviewed target), which legitimately
  * changes the recomputed evidence without changing what the user authorized.
  * A current Project is accounted for when it matches a completion-bound row's
- * source or resolved identity; anything else — a new Project, or a reviewed
- * Project that disappeared — reopens setup. Canonical row integrity (teams,
- * decisions, memberships, mappings, recipients) is separately enforced by
- * `isCompatibleReadyTeam`.
+ * source or resolved identity. Other inventory changes make the completion
+ * incompatible for legacy reconciliation diagnostics, but never reopen the
+ * terminal migration. Canonical row integrity is separately checked by
+ * `isCompatibleReadyTeam` while deciding whether reconciliation is safe.
  */
+function isRetiredFilesystemRootProjectRow(row: {
+	source_project_identity: string;
+	resolved_project_identity: string | null;
+}): boolean {
+	return isFilesystemRootProjectIdentity(
+		row.resolved_project_identity ?? row.source_project_identity,
+	);
+}
+
 function completedInventoryCompatible(
 	db: Database,
 	attemptId: string,
@@ -276,21 +289,26 @@ function completedInventoryCompatible(
 		source_project_identity: string;
 		resolved_project_identity: string | null;
 	}>;
+	const reviewableRows = rows.filter((row) => !isRetiredFilesystemRootProjectRow(row));
 	const reviewedIdentities = new Set<string>();
-	for (const row of rows) {
-		reviewedIdentities.add(row.source_project_identity);
-		if (row.resolved_project_identity) reviewedIdentities.add(row.resolved_project_identity);
+	for (const row of reviewableRows) {
+		reviewedIdentities.add(normalizeLegacyProjectMappingIdentity(row.source_project_identity));
+		if (row.resolved_project_identity) {
+			reviewedIdentities.add(normalizeLegacyProjectMappingIdentity(row.resolved_project_identity));
+		}
 	}
-	const currentIdentities = new Set(projects.map((project) => project.sourceProjectIdentity));
+	const currentIdentities = new Set(
+		projects.map((project) => normalizeLegacyProjectMappingIdentity(project.sourceProjectIdentity)),
+	);
 	for (const identity of currentIdentities) {
 		if (!reviewedIdentities.has(identity)) return false;
 	}
-	for (const row of rows) {
-		const materialized = row.resolved_project_identity ?? row.source_project_identity;
-		if (
-			!currentIdentities.has(materialized) &&
-			!currentIdentities.has(row.source_project_identity)
-		) {
+	for (const row of reviewableRows) {
+		const sourceIdentity = normalizeLegacyProjectMappingIdentity(row.source_project_identity);
+		const materialized = normalizeLegacyProjectMappingIdentity(
+			row.resolved_project_identity ?? row.source_project_identity,
+		);
+		if (!currentIdentities.has(materialized) && !currentIdentities.has(sourceIdentity)) {
 			return false;
 		}
 	}
@@ -308,6 +326,26 @@ function currentDraftRow(db: Database, candidateId: string): DraftFreshnessRow |
 				 ORDER BY rowid DESC LIMIT 1`,
 			)
 			.get(candidateId) as DraftFreshnessRow | undefined) ?? null
+	);
+}
+
+function canonicalCompletedDraftRow(db: Database, candidateId: string): DraftFreshnessRow | null {
+	return (
+		(db
+			.prepare(
+				`SELECT draft.attempt_id, draft.coordinator_id, draft.group_id, draft.state,
+				        draft.roster_fingerprint, draft.projection_fingerprint,
+				        draft.completed_team_id
+				 FROM legacy_team_setup_drafts AS draft
+				 JOIN policy_teams AS team ON team.team_id = draft.completed_team_id
+				 WHERE draft.candidate_id = ? AND draft.state = 'completed'
+				   AND draft.completed_team_id = ? AND team.status = 'active'
+				   AND team.provenance = 'reviewed_team_candidate'
+				   AND team.migration_state = 'completed'
+				 ORDER BY draft.rowid DESC LIMIT 1`,
+			)
+			.get(candidateId, deterministicPolicyTeamId(candidateId)) as DraftFreshnessRow | undefined) ??
+		null
 	);
 }
 
@@ -334,16 +372,18 @@ function isCompatibleReadyTeam(
 	// only required when the completed draft has Project rows to validate: a
 	// configured group with no displayed Projects has no mapping whose scope
 	// could drift, so its completion stays Ready without a local scope row.
-	const completionProjectRows = db
-		.prepare(
-			`SELECT source_project_identity, resolved_project_identity, target_scope_id
-			 FROM legacy_team_setup_draft_projects WHERE attempt_id = ?`,
-		)
-		.all(attemptId) as Array<{
-		source_project_identity: string;
-		resolved_project_identity: string | null;
-		target_scope_id: string | null;
-	}>;
+	const completionProjectRows = (
+		db
+			.prepare(
+				`SELECT source_project_identity, resolved_project_identity, target_scope_id
+				 FROM legacy_team_setup_draft_projects WHERE attempt_id = ?`,
+			)
+			.all(attemptId) as Array<{
+			source_project_identity: string;
+			resolved_project_identity: string | null;
+			target_scope_id: string | null;
+		}>
+	).filter((row) => !isRetiredFilesystemRootProjectRow(row));
 	const setupScopeIds = db
 		.prepare(
 			`SELECT scope_id FROM replication_scopes
@@ -573,14 +613,37 @@ function isCompatibleReadyTeam(
 		// is not evidence that the completion still governs the Project.
 		const selected = selectedMappings.get(resolvedIdentity);
 		const confirmedSources = confirmedProjectsByResolved.get(resolvedIdentity);
-		const confirmedTargetScopeId =
-			selected && confirmedSources?.has(selected.projectPattern)
-				? (confirmedSources.get(selected.projectPattern) ?? selected.scopeId)
+		const normalizedSelectedPattern = selected
+			? normalizeLegacyProjectMappingIdentity(selected.projectPattern)
+			: null;
+		const confirmedSourceTargetScopeIds = new Set(
+			[...(confirmedSources?.entries() ?? [])]
+				.filter(
+					([sourceIdentity]) =>
+						normalizedSelectedPattern !== null &&
+						normalizeLegacyProjectMappingIdentity(sourceIdentity) === normalizedSelectedPattern,
+				)
+				.map(([, scopeId]) => scopeId),
+		);
+		if (confirmedSourceTargetScopeIds.size > 1) return false;
+		const hasConfirmedSource = confirmedSourceTargetScopeIds.size === 1;
+		const confirmedSourceTargetScopeId = [...confirmedSourceTargetScopeIds][0];
+		const confirmedTargetScopeIds = new Set(
+			[...(confirmedSources?.values() ?? [])].filter((scopeId): scopeId is string =>
+				Boolean(scopeId),
+			),
+		);
+		const confirmedTargetScopeId = hasConfirmedSource
+			? (confirmedSourceTargetScopeId ?? selected?.scopeId)
+			: selected?.workspaceIdentity &&
+					normalizeLegacyProjectMappingIdentity(selected.workspaceIdentity) ===
+						normalizeLegacyProjectMappingIdentity(resolvedIdentity) &&
+					confirmedTargetScopeIds.size === 1
+				? [...confirmedTargetScopeIds][0]
 				: undefined;
 		if (
 			!selected ||
 			selected.workspaceIdentity == null ||
-			!confirmedSources?.has(selected.projectPattern) ||
 			!confirmedTargetScopeId ||
 			selected.scopeId !== confirmedTargetScopeId ||
 			!setupScopeIds.includes(confirmedTargetScopeId)
@@ -593,6 +656,7 @@ function isCompatibleReadyTeam(
 
 interface CompletionProjectRecipientRow {
 	project_ref: string;
+	source_project_identity: string;
 	resolved_project_identity: string | null;
 	source_fingerprint: string;
 }
@@ -624,12 +688,15 @@ function reconcileMissingCompletedProjectRecipients(
 		.prepare("SELECT revision FROM policy_teams WHERE team_id = ? AND status = 'active'")
 		.get(draftRow.completed_team_id) as { revision: string } | undefined;
 	if (!team) return 0;
-	const completionProjects = db
-		.prepare(
-			`SELECT project_ref, resolved_project_identity, source_fingerprint
-			 FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref`,
-		)
-		.all(draftRow.attempt_id) as CompletionProjectRecipientRow[];
+	const completionProjects = (
+		db
+			.prepare(
+				`SELECT project_ref, source_project_identity, resolved_project_identity,
+				        source_fingerprint
+				 FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref`,
+			)
+			.all(draftRow.attempt_id) as CompletionProjectRecipientRow[]
+	).filter((row) => !isRetiredFilesystemRootProjectRow(row));
 	const existingRecipient = db.prepare(
 		`SELECT status, provenance FROM project_recipients
 		 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
@@ -637,7 +704,7 @@ function reconcileMissingCompletedProjectRecipients(
 	const planned = new Map<string, { mode: "insert" | "reactivate"; sourceFingerprint: string }>();
 	for (const project of completionProjects) {
 		const resolvedIdentity = project.resolved_project_identity;
-		if (!resolvedIdentity || !isMigratableLegacyTeamProjectIdentity(resolvedIdentity)) return 0;
+		if (!resolvedIdentity || !isMigratableLegacyTeamProjectIdentity(resolvedIdentity, db)) return 0;
 		const existing = existingRecipient.get(resolvedIdentity, draftRow.completed_team_id) as
 			| ExistingProjectRecipientRow
 			| undefined;
@@ -691,19 +758,28 @@ function reconcileMissingCompletedProjectRecipients(
 	return writeCount;
 }
 
-/**
- * A completed guided setup is selectable (for example by `choose_recipients`)
- * only while its full completion-bound canonical state is intact. Production
- * writers such as `commitDeviceIdentityBindings` can invalidate decisions
- * without clearing the Team fingerprint, so a header-only check is not enough.
- *
- * The stored draft cannot prove freshness against evidence it does not hold:
- * callers that can compute the current Project inventory or a current
- * coordinator roster fingerprint must pass them so that drift the next
- * discovery would reopen setup for also blocks selection. When a caller has
- * no coordinator snapshot (review/migration contexts run without coordinator
- * connectivity), roster drift admits no unreviewed grants — new devices have
- * no canonical decisions — and discovery reopens setup on its next pass.
+function hasTerminalLegacyTeamCompletion(
+	db: Database,
+	candidateId: string,
+	completedTeamId: string,
+): boolean {
+	if (completedTeamId !== deterministicPolicyTeamId(candidateId)) return false;
+	return Boolean(
+		db
+			.prepare(
+				`SELECT 1 FROM policy_teams
+				 WHERE team_id = ? AND status = 'active'
+				   AND provenance = 'reviewed_team_candidate'
+				   AND migration_state = 'completed' LIMIT 1`,
+			)
+			.pluck()
+			.get(completedTeamId),
+	);
+}
+
+/** A completed guided migration stays selectable as an active canonical Team.
+ * Later roster, Project, and policy changes belong to normal Team management;
+ * they must not reopen or revoke the one-time migration completion.
  */
 export function isLegacyTeamCandidateSelectable(
 	db: Database,
@@ -713,15 +789,23 @@ export function isLegacyTeamCandidateSelectable(
 		projects?: LegacyTeamSetupProjectInput[];
 	},
 ): boolean {
+	const canonicalCompletedRow = canonicalCompletedDraftRow(db, candidateId);
+	if (
+		canonicalCompletedRow?.completed_team_id &&
+		hasTerminalLegacyTeamCompletion(db, candidateId, canonicalCompletedRow.completed_team_id)
+	) {
+		return true;
+	}
 	const row = currentDraftRow(db, candidateId);
 	if (row?.state !== "completed" || !row.completed_team_id) return false;
-	if (current?.rosterFingerprint != null && current.rosterFingerprint !== row.roster_fingerprint) {
-		return false;
-	}
-	if (current?.projects && !completedInventoryCompatible(db, row.attempt_id, current.projects)) {
-		return false;
-	}
-	return isCompatibleReadyTeam(db, candidateId, row, row.roster_fingerprint);
+	// Keep compatibility with older canonical completions that predate the
+	// terminal provenance markers; their full completion evidence remains the gate.
+	const rosterFingerprint = current?.rosterFingerprint ?? row.roster_fingerprint;
+	return (
+		(current?.projects === undefined ||
+			completedInventoryCompatible(db, row.attempt_id, current.projects)) &&
+		isCompatibleReadyTeam(db, candidateId, row, rosterFingerprint)
+	);
 }
 
 function candidateStatus(
@@ -758,10 +842,25 @@ function candidateAuthority(
 	rosterDevices: LegacyTeamRosterDeviceSnapshot[],
 	projects: LegacyTeamSetupProjectInput[],
 	now: string,
-): { row: DraftFreshnessRow | null; rosterFingerprint: string; ready: boolean } {
+): {
+	row: DraftFreshnessRow | null;
+	rosterFingerprint: string;
+	ready: boolean;
+	terminal: boolean;
+} {
 	const row = currentDraftRow(db, candidateId);
+	const canonicalCompletedRow = canonicalCompletedDraftRow(db, candidateId);
+	const terminal = Boolean(
+		canonicalCompletedRow?.completed_team_id &&
+			hasTerminalLegacyTeamCompletion(db, candidateId, canonicalCompletedRow.completed_team_id),
+	);
+	const authorityRow = terminal ? canonicalCompletedRow : row;
 	requireLegacyTeamSetupSnapshotWithinLimits({ devices: rosterDevices, projects });
-	requireLegacyTeamSetupEffectiveDevicesWithinLimit(db, rosterDevices, row?.attempt_id ?? null);
+	requireLegacyTeamSetupEffectiveDevicesWithinLimit(
+		db,
+		rosterDevices,
+		authorityRow?.attempt_id ?? null,
+	);
 	const activeAssignmentIdentity = activeAssignmentIdentityLookup(db);
 	const rosterFingerprint = legacyTeamRosterFingerprint(
 		rosterDevices.map((device) => ({
@@ -771,7 +870,7 @@ function candidateAuthority(
 			identityId: activeAssignmentIdentity(device.deviceId),
 		})),
 	);
-	const completedRow = row?.state === "completed" ? row : null;
+	const completedRow = authorityRow?.state === "completed" ? authorityRow : canonicalCompletedRow;
 	const completionEvidenceMatches =
 		completedRow !== null &&
 		completedRow.roster_fingerprint === rosterFingerprint &&
@@ -794,14 +893,22 @@ function candidateAuthority(
 		ready = isCompatibleReadyTeam(db, candidateId, completedRow, rosterFingerprint);
 		if (!ready) throw new Error("legacy_team_completion_reconciliation_invalid");
 	}
-	return { row, rosterFingerprint, ready };
+	return { row: authorityRow, rosterFingerprint, ready, terminal };
 }
 
 function candidateDisplayName(db: Database, candidateId: string, fallback: string): string {
 	const team = db
 		.prepare("SELECT display_name FROM policy_teams WHERE team_id = ? AND status = 'active'")
 		.get(deterministicPolicyTeamId(candidateId)) as { display_name: string } | undefined;
-	return team?.display_name ?? fallback;
+	if (team?.display_name) return team.display_name;
+	const historical = db
+		.prepare(
+			`SELECT display_name FROM legacy_team_setup_drafts
+			 WHERE candidate_id = ? AND display_name <> 'Legacy Team'
+			 ORDER BY rowid DESC LIMIT 1`,
+		)
+		.get(candidateId) as { display_name: string } | undefined;
+	return historical?.display_name ?? fallback;
 }
 
 function resolveDiscoveredCandidate(
@@ -813,7 +920,7 @@ function resolveDiscoveredCandidate(
 	const discover = db.transaction(() => {
 		const { candidateId, coordinatorId, groupId, devices: rosterDevices } = group;
 		const projects = legacyTeamCandidateProjectInventory(db, projection, candidateId);
-		const { row, rosterFingerprint, ready } = candidateAuthority(
+		const { row, rosterFingerprint, ready, terminal } = candidateAuthority(
 			db,
 			candidateId,
 			rosterDevices,
@@ -827,7 +934,7 @@ function resolveDiscoveredCandidate(
 			evidenceMatches:
 				row?.roster_fingerprint === rosterFingerprint &&
 				row.projection_fingerprint === expectedProjectionFingerprint,
-			completionReady: ready,
+			completionReady: ready || terminal,
 		});
 		const draft =
 			plan.kind === "preserve_completion" && row
@@ -922,7 +1029,7 @@ export function refreshLegacyTeamCandidate(
 		if (candidateId !== candidateRef) continue;
 		const refresh = db.transaction(() => {
 			const projects = legacyTeamCandidateProjectInventory(db, options.projection, candidateId);
-			const { row, ready } = candidateAuthority(
+			const { row } = candidateAuthority(
 				db,
 				candidateId,
 				rosterDevices,
@@ -930,10 +1037,9 @@ export function refreshLegacyTeamCandidate(
 				validatedNow(options.now),
 			);
 			const displayName = candidateDisplayName(db, candidateId, group.displayName);
-			// A compatible Ready completion with unchanged evidence survives an
-			// explicit refresh: only labels update. Creating a replacement attempt
-			// here would immediately drop Ready and force a redundant review cycle.
-			if (row?.state === "completed" && ready) {
+			// Completion is terminal. Explicit refresh may reconcile compatible
+			// setup-owned edges and labels, but later drift never creates a new attempt.
+			if (row?.state === "completed") {
 				return refreshLegacyTeamSetupDraftLabels(db, row.attempt_id, {
 					displayName,
 					devices: rosterDevices,

--- a/packages/core/src/legacy-team-project-canonical-preflight.ts
+++ b/packages/core/src/legacy-team-project-canonical-preflight.ts
@@ -1,3 +1,4 @@
+import type { Database } from "./db.js";
 import { isMigratableLegacyTeamProjectIdentity } from "./legacy-team-project-policy.js";
 
 export interface LegacyTeamProjectCanonicalPreflightInput {
@@ -38,11 +39,12 @@ export interface LegacyTeamProjectCanonicalPreflightInput {
  */
 export function isLegacyTeamProjectCanonicalStateValid(
 	input: LegacyTeamProjectCanonicalPreflightInput,
+	db?: Database,
 ): boolean {
 	for (const project of input.projects) {
 		const resolvedIdentity = project.resolvedProjectIdentity;
 		if (!resolvedIdentity || resolvedIdentity.startsWith("unmapped:")) return false;
-		if (!isMigratableLegacyTeamProjectIdentity(resolvedIdentity)) return false;
+		if (!isMigratableLegacyTeamProjectIdentity(resolvedIdentity, db)) return false;
 		if (!project.targetScopeId || !input.scopeIds.includes(project.targetScopeId)) return false;
 
 		const relatedMappings = input.mappings.filter(

--- a/packages/core/src/legacy-team-project-policy.test.ts
+++ b/packages/core/src/legacy-team-project-policy.test.ts
@@ -1,5 +1,8 @@
+import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import { isMigratableLegacyTeamProjectIdentity } from "./legacy-team-project-policy.js";
+import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap-constants.js";
+import { initTestSchema } from "./test-utils.js";
 
 describe("isMigratableLegacyTeamProjectIdentity", () => {
 	it.each([
@@ -7,6 +10,7 @@ describe("isMigratableLegacyTeamProjectIdentity", () => {
 		"shared:default",
 		"shared:legacy",
 		"personal:actor-1",
+		"peer-received:peer-a:project:codemem",
 	])("rejects synthetic workspace identity %s", (identity) => {
 		expect(isMigratableLegacyTeamProjectIdentity(identity)).toBe(false);
 	});
@@ -17,5 +21,81 @@ describe("isMigratableLegacyTeamProjectIdentity", () => {
 		"https://example.invalid/project.git",
 	])("accepts canonical Project identity %s", (identity) => {
 		expect(isMigratableLegacyTeamProjectIdentity(identity)).toBe(true);
+	});
+
+	it("accepts peer-prefixed identities only when local inventory proves ownership", () => {
+		const db = new Database(":memory:");
+		initTestSchema(db);
+		try {
+			const localIdentity = "peer-received:local-workspace";
+			const replicatedIdentity = "peer-received:replicated-workspace";
+			const incrementallyReplicatedIdentity = "peer-received:incremental-workspace";
+			const inactiveReplicatedIdentity = "peer-received:inactive-replicated-workspace";
+			const inactiveIdentity = "peer-received:inactive-workspace";
+			const insertSession = db.prepare(
+				"INSERT INTO sessions(started_at, cwd, tool_version) VALUES (?, ?, ?)",
+			);
+			const insertMemory = db.prepare(
+				`INSERT INTO memory_items(
+				 session_id, kind, title, body_text, active, created_at, updated_at, workspace_id
+				 ) VALUES (?, 'discovery', 'title', 'body', ?, ?, ?, ?)`,
+			);
+			const localSessionId = Number(
+				insertSession.run("2026-08-31T00:00:00.000Z", null, null).lastInsertRowid,
+			);
+			insertMemory.run(
+				localSessionId,
+				1,
+				"2026-08-31T00:00:00.000Z",
+				"2026-08-31T00:00:00.000Z",
+				`${localIdentity}/`,
+			);
+			const replicatedSessionId = Number(
+				insertSession.run("2026-08-31T00:00:00.000Z", `${SYNC_BOOTSTRAP_CWD_PREFIX}:peer`, null)
+					.lastInsertRowid,
+			);
+			insertMemory.run(
+				replicatedSessionId,
+				1,
+				"2026-08-31T00:00:00.000Z",
+				"2026-08-31T00:00:00.000Z",
+				replicatedIdentity,
+			);
+			const incrementalSessionId = Number(
+				insertSession.run("2026-08-31T00:00:00.000Z", null, "sync_replication").lastInsertRowid,
+			);
+			insertMemory.run(
+				incrementalSessionId,
+				1,
+				"2026-08-31T00:00:00.000Z",
+				"2026-08-31T00:00:00.000Z",
+				incrementallyReplicatedIdentity,
+			);
+			insertMemory.run(
+				incrementalSessionId,
+				0,
+				"2026-08-31T00:00:00.000Z",
+				"2026-08-31T00:00:00.000Z",
+				inactiveReplicatedIdentity,
+			);
+			insertMemory.run(
+				localSessionId,
+				0,
+				"2026-08-31T00:00:00.000Z",
+				"2026-08-31T00:00:00.000Z",
+				inactiveIdentity,
+			);
+
+			expect(isMigratableLegacyTeamProjectIdentity(localIdentity, db)).toBe(true);
+			expect(isMigratableLegacyTeamProjectIdentity(replicatedIdentity, db)).toBe(false);
+			expect(isMigratableLegacyTeamProjectIdentity(incrementallyReplicatedIdentity, db)).toBe(
+				false,
+			);
+			expect(isMigratableLegacyTeamProjectIdentity(inactiveReplicatedIdentity, db)).toBe(false);
+			expect(isMigratableLegacyTeamProjectIdentity(inactiveIdentity, db)).toBe(true);
+			expect(isMigratableLegacyTeamProjectIdentity(localIdentity)).toBe(false);
+		} finally {
+			db.close();
+		}
 	});
 });

--- a/packages/core/src/legacy-team-project-policy.ts
+++ b/packages/core/src/legacy-team-project-policy.ts
@@ -1,9 +1,30 @@
-export function isMigratableLegacyTeamProjectIdentity(identity: string): boolean {
+import type { Database } from "./db.js";
+import { hasLocalInventoryIdentity } from "./local-project-inventory.js";
+
+export function isFilesystemRootProjectIdentity(value: string): boolean {
+	const normalized = value.trim().replaceAll("\\", "/");
+	if (normalized === "/" || /^[A-Za-z]:\/?$/u.test(normalized)) return true;
+	if (/^\/\/[^/]+\/[^/]+\/?$/u.test(normalized)) return true;
+	try {
+		const parsed = new URL(normalized);
+		if (parsed.protocol !== "file:") return false;
+		if (parsed.pathname === "/" || parsed.pathname === "") return true;
+		if (parsed.hostname === "" && /^\/[A-Za-z]:\/?$/u.test(parsed.pathname)) return true;
+		if (parsed.hostname === "" && /^\/\/[^/]+\/[^/]+\/?$/u.test(parsed.pathname)) return true;
+		return parsed.hostname !== "" && parsed.pathname.split("/").filter(Boolean).length === 1;
+	} catch {
+		return false;
+	}
+}
+
+export function isMigratableLegacyTeamProjectIdentity(identity: string, db?: Database): boolean {
 	const normalized = identity.trim();
 	return (
 		normalized !== "shared" &&
 		normalized !== "shared:default" &&
 		normalized !== "shared:legacy" &&
-		!normalized.startsWith("personal:")
+		!normalized.startsWith("personal:") &&
+		(!normalized.startsWith("peer-received:") ||
+			Boolean(db && hasLocalInventoryIdentity(db, normalized)))
 	);
 }

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -1939,6 +1939,26 @@ describe("legacy Team setup activation", () => {
 		).toBe(0);
 	});
 
+	it("accepts a normalized exact mapping already targeting the reviewed scope", async () => {
+		db.prepare(
+			`INSERT INTO project_scope_mappings(
+			 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, ?, 'scope-engineering', 5000, 'test', ?, ?)`,
+		).run(`${PROJECT_B}/`, "older-exact-pattern", NOW, NOW);
+		const draft = readyDraft();
+
+		await expect(finish(draft)).resolves.toMatchObject({ status: "completed" });
+		expect(
+			db
+				.prepare(
+					`SELECT COUNT(*) FROM project_recipients
+					 WHERE canonical_project_identity = ? AND status = 'active'`,
+				)
+				.pluck()
+				.get(PROJECT_B),
+		).toBe(1);
+	});
+
 	it("reads as Ready in candidate discovery after activation completes", async () => {
 		// Arrange: the full seam — activation writes assignments, mappings
 		// (including an explicit unmapped resolution), recipients, and the

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -3,7 +3,10 @@ import {
 	assignIdentityDeviceInTransaction,
 	IdentityDeviceAssignmentError,
 } from "./identity-device-assignment.js";
-import { selectedProjectScopeMapping } from "./legacy-recipient-policy-projection.js";
+import {
+	normalizeLegacyProjectMappingIdentity,
+	selectedProjectScopeMapping,
+} from "./legacy-recipient-policy-projection.js";
 import { isStoredLegacyTeamAssignmentExpectationWellFormed } from "./legacy-team-assignment-expectation.js";
 import { isLegacyTeamProjectCanonicalStateValid } from "./legacy-team-project-canonical-preflight.js";
 import {
@@ -554,11 +557,11 @@ function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): 
 			.toSorted(compareText),
 	};
 	validateAssignmentExpectations(model);
-	validateCanonicalState(model);
+	validateCanonicalState(db, model);
 	return model;
 }
 
-function validateCanonicalState(model: ActivationModel): void {
+function validateCanonicalState(db: Database, model: ActivationModel): void {
 	const { groupScopeIds, memberships, projects, recipients, scopeIds, team, teamId } = model;
 	if (team) {
 		const baseCompatible =
@@ -609,28 +612,31 @@ function validateCanonicalState(model: ActivationModel): void {
 	}
 
 	if (
-		!isLegacyTeamProjectCanonicalStateValid({
-			teamId,
-			scopeIds,
-			groupScopeIds,
-			projects: projects.map((project) => ({
-				sourceProjectIdentity: project.source_project_identity,
-				resolvedProjectIdentity: project.resolved_project_identity,
-				targetScopeId: targetScopeId(model, project),
-			})),
-			mappings: model.mappings.map((mapping) => ({
-				workspaceIdentity: mapping.workspace_identity,
-				projectPattern: mapping.project_pattern,
-				scopeId: mapping.scope_id,
-				source: mapping.source,
-			})),
-			recipients: recipients.map((recipient) => ({
-				canonicalProjectIdentity: recipient.canonical_project_identity,
-				recipientKind: recipient.recipient_kind,
-				recipientId: recipient.recipient_id,
-				status: recipient.status,
-			})),
-		})
+		!isLegacyTeamProjectCanonicalStateValid(
+			{
+				teamId,
+				scopeIds,
+				groupScopeIds,
+				projects: projects.map((project) => ({
+					sourceProjectIdentity: project.source_project_identity,
+					resolvedProjectIdentity: project.resolved_project_identity,
+					targetScopeId: targetScopeId(model, project),
+				})),
+				mappings: model.mappings.map((mapping) => ({
+					workspaceIdentity: mapping.workspace_identity,
+					projectPattern: mapping.project_pattern,
+					scopeId: mapping.scope_id,
+					source: mapping.source,
+				})),
+				recipients: recipients.map((recipient) => ({
+					canonicalProjectIdentity: recipient.canonical_project_identity,
+					recipientKind: recipient.recipient_kind,
+					recipientId: recipient.recipient_id,
+					status: recipient.status,
+				})),
+			},
+			db,
+		)
 	) {
 		activationError("team_setup_conflict");
 	}
@@ -1658,7 +1664,9 @@ function applyActivation(
 			evidence.targetScopeIds.size !== 1 ||
 			!selected ||
 			selected.workspaceIdentity == null ||
-			!evidence.sources.has(selected.projectPattern) ||
+			(normalizeLegacyProjectMappingIdentity(selected.workspaceIdentity) !==
+				normalizeLegacyProjectMappingIdentity(resolvedIdentity) &&
+				!evidence.sources.has(selected.projectPattern)) ||
 			selected.scopeId !== reviewedTargetScopeId
 		) {
 			activationError("team_setup_conflict");

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -237,28 +237,31 @@ function projectCanonicalStateValid(
 					status: string;
 				}>);
 
-	return isLegacyTeamProjectCanonicalStateValid({
-		teamId: deterministicPolicyTeamId(draft.candidate_id),
-		scopeIds,
-		groupScopeIds,
-		projects: projects.map((project) => ({
-			sourceProjectIdentity: project.source_project_identity,
-			resolvedProjectIdentity: project.resolved_project_identity,
-			targetScopeId: targetScopeIdFor(project),
-		})),
-		mappings: mappings.map((mapping) => ({
-			workspaceIdentity: mapping.workspace_identity,
-			projectPattern: mapping.project_pattern,
-			scopeId: mapping.scope_id,
-			source: mapping.source,
-		})),
-		recipients: recipients.map((recipient) => ({
-			canonicalProjectIdentity: recipient.canonical_project_identity,
-			recipientKind: recipient.recipient_kind,
-			recipientId: recipient.recipient_id,
-			status: recipient.status,
-		})),
-	});
+	return isLegacyTeamProjectCanonicalStateValid(
+		{
+			teamId: deterministicPolicyTeamId(draft.candidate_id),
+			scopeIds,
+			groupScopeIds,
+			projects: projects.map((project) => ({
+				sourceProjectIdentity: project.source_project_identity,
+				resolvedProjectIdentity: project.resolved_project_identity,
+				targetScopeId: targetScopeIdFor(project),
+			})),
+			mappings: mappings.map((mapping) => ({
+				workspaceIdentity: mapping.workspace_identity,
+				projectPattern: mapping.project_pattern,
+				scopeId: mapping.scope_id,
+				source: mapping.source,
+			})),
+			recipients: recipients.map((recipient) => ({
+				canonicalProjectIdentity: recipient.canonical_project_identity,
+				recipientKind: recipient.recipient_kind,
+				recipientId: recipient.recipient_id,
+				status: recipient.status,
+			})),
+		},
+		db,
+	);
 }
 
 interface DeviceAssignmentSnapshot {
@@ -1230,7 +1233,7 @@ export function clearLegacyTeamSetupDeviceDecision(
 	return clearDecision.immediate();
 }
 
-export function isLegacyTeamSetupProjectMappingIdentity(value: string): boolean {
+export function isLegacyTeamSetupProjectMappingIdentity(value: string, db?: Database): boolean {
 	const identity = value.trim();
 	// The repair target becomes a mapping workspace identity and an active
 	// recipient edge at activation; anything that is not itself a shareable
@@ -1256,7 +1259,7 @@ export function isLegacyTeamSetupProjectMappingIdentity(value: string): boolean 
 	return !(
 		!isStrictRecipientPolicyProjectIdentity(identity) ||
 		identity.startsWith("unmapped:") ||
-		!isMigratableLegacyTeamProjectIdentity(identity) ||
+		!isMigratableLegacyTeamProjectIdentity(identity, db) ||
 		/\s/u.test(identity) ||
 		(/[/\\]/u.test(identity) && !isRemoteForm) ||
 		/^(?:[~.$%]|[A-Za-z]:[\\/])/.test(identity) ||
@@ -1274,7 +1277,7 @@ export function setLegacyTeamSetupProjectMapping(
 	},
 ): LegacyTeamSetupDraftView {
 	const identity = input.resolvedProjectIdentity.trim();
-	if (!isLegacyTeamSetupProjectMappingIdentity(identity)) {
+	if (!isLegacyTeamSetupProjectMappingIdentity(identity, db)) {
 		throw new Error("legacy_team_setup_project_mapping_invalid");
 	}
 	const now = validatedNow(input.now);

--- a/packages/core/src/local-project-inventory.ts
+++ b/packages/core/src/local-project-inventory.ts
@@ -1,0 +1,24 @@
+import type { Database } from "./db.js";
+import { normalizeLegacyProjectMappingIdentity } from "./legacy-recipient-policy-projection.js";
+import { SYNC_BOOTSTRAP_CWD_PREFIX } from "./sync-bootstrap-constants.js";
+
+export function hasLocalInventoryIdentity(db: Database, workspaceIdentity: string): boolean {
+	const row = db
+		.prepare(
+			`SELECT 1 AS one
+			 FROM sessions s
+			 JOIN memory_items mi ON mi.session_id = s.id
+			 WHERE (s.cwd IS NULL OR substr(s.cwd, 1, length(?)) <> ?)
+			   AND COALESCE(s.tool_version, '') <> 'sync_replication'
+			   AND COALESCE(TRIM(s.git_remote), TRIM(s.cwd), '') = ''
+			   AND mi.workspace_id IS NOT NULL
+			   AND RTRIM(REPLACE(TRIM(mi.workspace_id), CHAR(92), '/'), '/') = ?
+			 LIMIT 1`,
+		)
+		.get(
+			SYNC_BOOTSTRAP_CWD_PREFIX,
+			SYNC_BOOTSTRAP_CWD_PREFIX,
+			normalizeLegacyProjectMappingIdentity(workspaceIdentity),
+		) as { one: number } | undefined;
+	return Boolean(row);
+}

--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -48,6 +48,7 @@ function insertMemory(
 	db: InstanceType<typeof Database>,
 	sessionId: number,
 	input: {
+		active?: boolean;
 		importKey?: string | null;
 		originDeviceId?: string | null;
 		project?: string | null;
@@ -1466,7 +1467,7 @@ describe("project scope settings", () => {
 		).toThrow(/peer-received projects cannot be assigned/);
 	});
 
-	it("allows assignment of reserved-prefix identities when a real local row owns them", () => {
+	it("keeps reserved-prefix identities editable after local memories become inactive", () => {
 		insertScope(db, { scopeId: "exampleco-work", label: "ExampleCo Work" });
 		const localSession = insertSession(db, {
 			cwd: null,
@@ -1474,6 +1475,7 @@ describe("project scope settings", () => {
 			project: "codemem",
 		});
 		insertMemory(db, localSession, {
+			active: false,
 			project: "codemem",
 			workspaceId: "peer-received:peer-a:project:codemem",
 		});

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { type Database, fromJson, toJson } from "./db.js";
+import { hasLocalInventoryIdentity } from "./local-project-inventory.js";
 import { ensureScopeBackfillScopes, LEGACY_SHARED_REVIEW_SCOPE_ID } from "./scope-backfill.js";
 import {
 	canonicalWorkspaceIdentity,
@@ -170,24 +171,6 @@ function inventoryMergeKey(
 	candidate: ProjectScopeCandidate,
 ): string {
 	return `${row.inventory_source === "peer_received" ? "peer_received" : "local"}:${candidate.workspace_identity}`;
-}
-
-function hasLocalInventoryIdentity(db: Database, workspaceIdentity: string): boolean {
-	const row = db
-		.prepare(
-			`SELECT 1 AS one
-			 FROM sessions s
-			 JOIN memory_items mi ON mi.session_id = s.id
-			 WHERE (s.cwd IS NULL OR substr(s.cwd, 1, length(?)) <> ?)
-			   AND COALESCE(TRIM(s.git_remote), TRIM(s.cwd), '') = ''
-			   AND mi.workspace_id IS NOT NULL
-			   AND TRIM(mi.workspace_id) = ?
-			 LIMIT 1`,
-		)
-		.get(SYNC_BOOTSTRAP_CWD_PREFIX, SYNC_BOOTSTRAP_CWD_PREFIX, workspaceIdentity) as
-		| { one: number }
-		| undefined;
-	return Boolean(row);
 }
 
 function normalizeWorkspaceIdentity(value: string | null | undefined): string | null {

--- a/packages/core/src/recipient-policy-contract.ts
+++ b/packages/core/src/recipient-policy-contract.ts
@@ -184,6 +184,11 @@ export interface RecipientPolicyBlockedItemV1 {
 	reason: string;
 	ownerLabel: string;
 	repairAction: string;
+	repair: {
+		kind: "reassign_project" | "open_project_administration";
+		projectIdentity: string;
+		label: string;
+	};
 }
 
 export interface RecipientPolicyProjectionV1 {

--- a/packages/core/src/recipient-policy-migration.ts
+++ b/packages/core/src/recipient-policy-migration.ts
@@ -386,7 +386,6 @@ function addReviewDecision(
 	projection: LegacyRecipientPolicyProjectionV1,
 	currentItem: RecipientPolicyActionableReviewItemV1,
 	resolution: StoredResolution,
-	context: RecipientPolicyReviewContext,
 	now: string,
 ): string | null {
 	plan.hadApplicableEvidence = true;
@@ -433,12 +432,7 @@ function addReviewDecision(
 		) {
 			return "review_decision_input_invalid";
 		}
-		const selectableRecipients = deriveSelectableRecipientIds(db, projection, {
-			localIdentity: {
-				localActorId: context.localActorId,
-				localDeviceId: context.localDeviceId,
-			},
-		});
+		const selectableRecipients = deriveSelectableRecipientIds(db, projection);
 		for (const recipientId of recipientIds as string[]) {
 			if (selectableRecipients.identities.has(recipientId)) {
 				plan.rows.push(
@@ -588,15 +582,7 @@ function collectCompatibleDeviceEvidence(input: {
 				if (
 					!resolution ||
 					!currentItem?.options.some((option) => option.decision === resolution.decision) ||
-					addReviewDecision(
-						input.db,
-						plan,
-						projection,
-						currentItem,
-						resolution,
-						input.context,
-						input.now,
-					) !== null
+					addReviewDecision(input.db, plan, projection, currentItem, resolution, input.now) !== null
 				) {
 					reviewEvidenceValid = false;
 					break;
@@ -1058,15 +1044,7 @@ function migrateProjectInTransaction(input: {
 		if (!currentItem.options.some((option) => option.decision === resolution.decision)) {
 			throw new Error("review_decision_unsupported");
 		}
-		const reviewError = addReviewDecision(
-			db,
-			plan,
-			projection,
-			currentItem,
-			resolution,
-			context,
-			now,
-		);
+		const reviewError = addReviewDecision(db, plan, projection, currentItem, resolution, now);
 		if (reviewError !== "review_preserves_legacy_access") {
 			throw new Error(reviewError ?? "review_decision_unsupported");
 		}
@@ -1094,15 +1072,7 @@ function migrateProjectInTransaction(input: {
 		if (!currentItem?.options.some((option) => option.decision === resolution.decision)) {
 			throw new Error("review_decision_unsupported");
 		}
-		const reviewError = addReviewDecision(
-			db,
-			plan,
-			projection,
-			currentItem,
-			resolution,
-			context,
-			now,
-		);
+		const reviewError = addReviewDecision(db, plan, projection, currentItem, resolution, now);
 		if (reviewError) throw new Error(reviewError);
 	}
 	plan = deduplicatePlan(plan);

--- a/packages/core/src/recipient-policy-review.test.ts
+++ b/packages/core/src/recipient-policy-review.test.ts
@@ -332,8 +332,34 @@ describe("recipient policy review persistence", () => {
 		expect(result.blockedItems[0]).toMatchObject({
 			ownerLabel: "Project owner",
 			repairAction: expect.any(String),
+			repair: {
+				kind: "open_project_administration",
+				label: "Open Project administration",
+			},
 		});
 		expect(result.blockedItems[0]).not.toHaveProperty("options");
+	});
+
+	it("does not offer local recipient-policy repair for peer-received Projects", () => {
+		const sessionId = Number(
+			db
+				.prepare(
+					`INSERT INTO sessions(started_at, project, tool_version)
+					 VALUES (?, 'peer-only', 'sync_replication')`,
+				)
+				.run(NOW).lastInsertRowid,
+		);
+		db.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, body_text, active, created_at, updated_at,
+				visibility, project, scope_id
+			 ) VALUES (?, 'discovery', 'Peer fixture', 'body', 1, ?, ?, 'shared', 'peer-only', 'local-default')`,
+		).run(sessionId, NOW, NOW);
+
+		const projections = listLegacyRecipientPolicyProjections(db, context);
+
+		expect(projections).toHaveLength(1);
+		expect(projections[0]?.project.canonicalIdentity).toBe(PROJECT_ID);
 	});
 
 	it("keeps an ambiguous umbrella scope as continuity without repair cards", () => {
@@ -439,6 +465,29 @@ describe("recipient policy review persistence", () => {
 		expect(mixedState.blockedItems[0]?.blockedItemId).toBe(
 			repairableState.blockedItems[0]?.blockedItemId,
 		);
+	});
+
+	it("keeps synthetic shared compatibility identities out of repair targets", () => {
+		const shared = projection();
+		shared.project = { version: 1, canonicalIdentity: "shared:default", displayName: "Shared" };
+		shared.conditions = [
+			{
+				version: 1,
+				code: "ambiguous_scope_mapping",
+				kind: "diagnostic",
+				message: "Legacy shared scope remains in compatibility mode.",
+			},
+		];
+
+		const state = deriveRecipientPolicyReviewState(db, context, [shared]);
+
+		expect(state.blockedItems).toEqual([]);
+		expect(state.preservedDiagnosticFindings).toEqual([
+			{
+				canonicalProjectIdentity: "shared:default",
+				conditionCode: "ambiguous_scope_mapping",
+			},
+		]);
 	});
 
 	it("records only the immutable resolution with server-derived attribution", () => {

--- a/packages/core/src/recipient-policy-review.ts
+++ b/packages/core/src/recipient-policy-review.ts
@@ -7,10 +7,8 @@ import {
 	listLegacyRecipientPolicyProjections,
 	resolveLegacyRecipientPolicyLocalIdentity,
 } from "./legacy-recipient-policy-projection.js";
-import {
-	isLegacyTeamCandidateSelectable,
-	legacyTeamCandidateProjectInventory,
-} from "./legacy-team-candidate.js";
+import { isLegacyTeamCandidateSelectable } from "./legacy-team-candidate.js";
+import { isMigratableLegacyTeamProjectIdentity } from "./legacy-team-project-policy.js";
 import { isActiveUnmergedLocalActor } from "./recipient-policy-actor-eligibility.js";
 import {
 	isRecipientPolicyNoOpDecision,
@@ -345,28 +343,38 @@ function reviewOptions(
 function blockedOwner(code: LegacyRecipientPolicyConditionCodeV1): {
 	ownerLabel: string;
 	repairAction: string;
+	repairKind: RecipientPolicyBlockedItemV1["repair"]["kind"];
+	repairLabel: string;
 } {
 	switch (code) {
 		case "noncanonical_project_identity":
 			return {
 				ownerLabel: "Project owner",
 				repairAction: "Assign a stable canonical Project identity.",
+				repairKind: "open_project_administration",
+				repairLabel: "Open Project administration",
 			};
 		case "inactive_scope_boundary":
 			return {
 				ownerLabel: "Scope owner",
 				repairAction: "Restore or replace the inactive enforcement boundary.",
+				repairKind: "open_project_administration",
+				repairLabel: "Open Project administration",
 			};
 		case "ambiguous_multi_project_scope":
 			return {
 				ownerLabel: "Local administrator",
 				repairAction:
 					"Assign each Project to its own managed scope and move its memories out of the shared boundary.",
+				repairKind: "open_project_administration",
+				repairLabel: "Open Project administration",
 			};
 		case "ambiguous_scope_mapping":
 			return {
 				ownerLabel: "Local administrator",
 				repairAction: "Repair the ambiguous legacy Project-to-scope mapping in Advanced settings.",
+				repairKind: "open_project_administration",
+				repairLabel: "Open Project administration",
 			};
 		case "suggest_local_identity":
 		case "suggest_team_candidate":
@@ -401,6 +409,14 @@ export function deriveRecipientPolicyReviewState(
 				continue;
 			}
 			if (presentation === "repairable_blocked") {
+				if (!isMigratableLegacyTeamProjectIdentity(projection.project.canonicalIdentity, db)) {
+					preservedDiagnosticFindings.push({
+						canonicalProjectIdentity: projection.project.canonicalIdentity,
+						conditionCode: condition.code,
+					});
+					continue;
+				}
+				const owner = blockedOwner(condition.code);
 				blockedItems.push({
 					version: RECIPIENT_POLICY_CONTRACT_VERSION,
 					blockedItemId: digest("recipient-policy-blocked-v1", [
@@ -409,7 +425,13 @@ export function deriveRecipientPolicyReviewState(
 					]),
 					finding: condition.message,
 					reason: `Project ${projection.project.displayName} requires source-state repair.`,
-					...blockedOwner(condition.code),
+					ownerLabel: owner.ownerLabel,
+					repairAction: owner.repairAction,
+					repair: {
+						kind: owner.repairKind,
+						projectIdentity: projection.project.canonicalIdentity,
+						label: owner.repairLabel,
+					},
 				});
 				continue;
 			}
@@ -551,11 +573,8 @@ function normalizeDecisionInput(
 	projection: LegacyRecipientPolicyProjectionV1,
 	request: RecipientPolicyReviewResolveRequestV1,
 	decisionDeviceIds: ReadonlySet<string>,
-	context: RecipientPolicyReviewContext,
 ): { ok: true; json: string } | { ok: false; errorCode: string } {
-	const candidates = deriveSelectableRecipientIds(db, projection, {
-		localIdentity: { localActorId: context.localActorId, localDeviceId: context.localDeviceId },
-	});
+	const candidates = deriveSelectableRecipientIds(db, projection);
 	const unassignedDeviceIds = new Set(
 		projection.effectiveDevices
 			.filter(
@@ -634,16 +653,6 @@ function normalizeDecisionInput(
 export function deriveSelectableRecipientIds(
 	db: Database,
 	projection: LegacyRecipientPolicyProjectionV1,
-	freshness?: {
-		/**
-		 * Local identity used to recompute each candidate's current Project
-		 * inventory; inventory drift the next discovery would reopen setup
-		 * for must also block selection.
-		 */
-		localIdentity?: { localActorId: string; localDeviceId: string };
-		/** Current coordinator roster fingerprints by candidate ID, when the caller holds a snapshot. */
-		rosterFingerprints?: ReadonlyMap<string, string>;
-	},
 ): {
 	all: Set<string>;
 	identities: Set<string>;
@@ -670,20 +679,9 @@ export function deriveSelectableRecipientIds(
 	for (const candidate of projection.teamCandidates) {
 		const expectedTeamId = deterministicPolicyTeamId(candidate.teamCandidateId);
 		teams.delete(expectedTeamId);
-		// The full completion-bound compatibility check guards against stale
-		// completed Teams whose canonical decisions, memberships, mappings, or
-		// recipient edges drifted without clearing the header fingerprint.
-		const current = {
-			rosterFingerprint: freshness?.rosterFingerprints?.get(candidate.teamCandidateId),
-			projects: freshness?.localIdentity
-				? legacyTeamCandidateProjectInventory(
-						db,
-						freshness.localIdentity,
-						candidate.teamCandidateId,
-					)
-				: undefined,
-		};
-		if (isLegacyTeamCandidateSelectable(db, candidate.teamCandidateId, current)) {
+		// Terminal migrations remain normal active Teams after later policy,
+		// roster, or Project drift; older completions retain strict compatibility.
+		if (isLegacyTeamCandidateSelectable(db, candidate.teamCandidateId)) {
 			teams.add(expectedTeamId);
 		}
 	}
@@ -751,7 +749,6 @@ function resolveInTransaction(
 		projection,
 		request,
 		new Set(selectedOption.preview.effectiveDevices.map((device) => device.deviceId)),
-		context,
 	);
 	if (!normalizedInput.ok) return invalid(request, normalizedInput.errorCode);
 	const key = resolutionKey(item.reviewItemId, item.sourceFingerprint);

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -715,6 +715,11 @@ export interface RecipientPolicyBlockedItemV1 {
 	reason: string;
 	ownerLabel: string;
 	repairAction: string;
+	repair: {
+		kind: "reassign_project" | "open_project_administration";
+		projectIdentity: string;
+		label: string;
+	};
 }
 
 export interface RecipientPolicyReviewListV1 {

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -387,6 +387,11 @@ describe("Projects tab", () => {
 					ownerLabel: "Project owner",
 					reason: "Codemem requires source-state repair.",
 					repairAction: "Assign a stable canonical Project identity.",
+					repair: {
+						kind: "reassign_project",
+						projectIdentity: "unstable-project",
+						label: "Assign Project",
+					},
 					version: 1,
 				},
 			],
@@ -809,6 +814,11 @@ describe("Projects tab", () => {
 						ownerLabel: "Project owner",
 						reason: "Codemem requires source-state repair.",
 						repairAction: "Assign a stable canonical Project identity.",
+						repair: {
+							kind: "reassign_project",
+							projectIdentity: "unstable-project",
+							label: "Assign Project",
+						},
 						version: 1,
 					},
 				],

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1104,9 +1104,9 @@ describe("viewer-server", () => {
 				expect(reopenedResponse.status).toBe(200);
 				const reopened = (await reopenedResponse.json()) as Record<string, unknown>;
 				expect(reopened).toMatchObject({ candidate: { candidateRef } });
-				expect((reopened.candidate as { status: string }).status).not.toBe("ready");
-				expect(reopened.state).not.toBe("completed");
-				expect(loadSnapshots).toHaveBeenCalledWith({ candidateRef });
+				expect((reopened.candidate as { status: string }).status).toBe("ready");
+				expect(reopened.state).toBe("completed");
+				expect(loadSnapshots).not.toHaveBeenCalled();
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -869,7 +869,7 @@ function projectMappingChoices(store: MemoryStore): ProjectMappingChoiceInternal
 		}).filter(
 			(candidate) =>
 				!candidate.read_only &&
-				isLegacyTeamSetupProjectMappingIdentity(candidate.workspace_identity),
+				isLegacyTeamSetupProjectMappingIdentity(candidate.workspace_identity, store.db),
 		);
 	} catch (error) {
 		if (


### PR DESCRIPTION
## Description

Harden legacy Team recovery policy by excluding invalid local Project identities, preserving reviewed canonical mappings, and surfacing actionable repair metadata without treating peer-received state as local repair work.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced