### PR TITLE
fix(viewer): keep completed Team migration terminal

### DIFF
--- a/packages/core/src/sync-http-client.test.ts
+++ b/packages/core/src/sync-http-client.test.ts
@@ -123,6 +123,18 @@ describe("requestJson", () => {
 		expect(call[1].headers.Authorization).toBe("Bearer tok");
 	});
 
+	it("rounds fractional timeout seconds to integer milliseconds", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			status: 200,
+			text: () => Promise.resolve("{}"),
+		});
+		const timeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(new AbortController().signal);
+
+		await requestJson("GET", "http://localhost:8080/info", { timeoutS: 1.001 });
+
+		expect(timeout).toHaveBeenCalledWith(1_001);
+	});
+
 	it("rejects a declared response larger than the configured limit", async () => {
 		globalThis.fetch = vi.fn().mockResolvedValue(
 			new Response("{}", {

--- a/packages/core/src/sync-http-client.ts
+++ b/packages/core/src/sync-http-client.ts
@@ -88,7 +88,7 @@ export async function requestJson(
 		method,
 		headers: requestHeaders,
 		body: requestBody,
-		signal: AbortSignal.timeout(timeoutS * 1000),
+		signal: AbortSignal.timeout(Math.round(timeoutS * 1_000)),
 	});
 
 	let raw: string;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -943,6 +943,27 @@ describe("viewer-server", () => {
 				const pendingAfterFinish = await app.request("/api/sync/team-setup/v1");
 				expect(pendingAfterFinish.status).toBe(200);
 				expect(await pendingAfterFinish.json()).toEqual({ version: 1, candidates: [] });
+				store.db
+					.prepare(
+						`DELETE FROM project_recipients
+						 WHERE recipient_kind = 'team' AND recipient_id = ?
+						   AND provenance = 'reviewed_team_setup'`,
+					)
+					.run(core.deterministicPolicyTeamId(candidateRef));
+				expect(store.db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(0);
+				const reconciledSummary = await app.request("/api/sync/team-setup/v1");
+				expect(reconciledSummary.status).toBe(200);
+				expect(await reconciledSummary.json()).toEqual({ version: 1, candidates: [] });
+				expect(store.db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(1);
+				expect(
+					store.db
+						.prepare(
+							`SELECT attempt_id FROM legacy_team_setup_drafts
+							 WHERE candidate_id = ? ORDER BY rowid DESC LIMIT 1`,
+						)
+						.pluck()
+						.get(candidateRef),
+				).toBe(draft?.attemptId);
 				const canonicalSnapshot = () => ({
 					teams: store.db.prepare("SELECT * FROM policy_teams ORDER BY team_id").all(),
 					memberships: store.db
@@ -1106,6 +1127,56 @@ describe("viewer-server", () => {
 				expect(reopened).toMatchObject({ candidate: { candidateRef } });
 				expect((reopened.candidate as { status: string }).status).toBe("ready");
 				expect(reopened.state).toBe("completed");
+				expect(loadSnapshots).not.toHaveBeenCalled();
+
+				const supersedingAttemptId = "legacy-team-attempt:00000000-0000-4000-8000-000000000099";
+				store.db
+					.prepare(
+						`INSERT INTO legacy_team_setup_drafts(
+						 attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
+						 roster_fingerprint, projection_fingerprint, created_at, updated_at
+						 ) VALUES (?, ?, ?, ?, 'needs_setup', 'Migration Team', 'new-roster',
+						 'new-projection', ?, ?)`,
+					)
+					.run(supersedingAttemptId, candidateRef, coordinatorId, groupId, now, now);
+				loadSnapshots.mockClear();
+				const terminalSummaryResponse = await app.request("/api/sync/team-setup/v1");
+				expect(terminalSummaryResponse.status).toBe(200);
+				const terminalSummary = (await terminalSummaryResponse.json()) as {
+					candidates: Array<{ candidateRef: string }>;
+				};
+				expect(terminalSummary.candidates).not.toContainEqual(
+					expect.objectContaining({ candidateRef }),
+				);
+				const staleSupersedingDetail = await app.request(`/api/sync/team-setup/v1/${candidateRef}`);
+				expect(staleSupersedingDetail.status).toBe(404);
+				expect(await staleSupersedingDetail.json()).toEqual({
+					error: "team_setup_confirmation_stale",
+				});
+				const staleSupersedingDecision = await app.request(
+					`/api/sync/team-setup/v1/${candidateRef}/devices/${deviceRef}/decision`,
+					{
+						method: "PUT",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({ attemptId: supersedingAttemptId, decision: "excluded" }),
+					},
+				);
+				expect(staleSupersedingDecision.status).toBe(409);
+				expect(await staleSupersedingDecision.json()).toEqual({
+					error: "team_setup_confirmation_stale",
+				});
+				const staleSupersedingRefresh = await app.request(
+					`/api/sync/team-setup/v1/${candidateRef}/refresh`,
+					{
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: "{}",
+					},
+				);
+				expect(staleSupersedingRefresh.status).toBe(409);
+				expect(await staleSupersedingRefresh.json()).toEqual({
+					error: "team_setup_confirmation_stale",
+				});
 				expect(loadSnapshots).not.toHaveBeenCalled();
 			} finally {
 				cleanup();
@@ -1923,7 +1994,118 @@ describe("viewer-server", () => {
 				expect(core.getLegacyTeamSetupDraft(ensureStore().db, candidateRef)?.attemptId).toBe(
 					refreshedAttemptId,
 				);
+				// Explicit refresh invalidates the summary before and after its fresh
+				// roster load; read-only detail loads retain the display cache instead.
 				expect(loadSnapshots).toHaveBeenCalledTimes(4);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects a refresh when migration completes during the roster load", async () => {
+			let resolveRefresh!: () => void;
+			const loadSnapshots = vi.fn((options?: { candidateRef?: string }) =>
+				options?.candidateRef
+					? new Promise<core.LegacyTeamConfiguredGroupSnapshot[]>((resolve) => {
+							resolveRefresh = () =>
+								resolve([
+									{
+										...snapshots[0],
+										devices: snapshots[0].devices.map((device) => ({
+											...device,
+											fingerprint: "refreshed-fingerprint",
+										})),
+									},
+								]);
+						})
+					: Promise.resolve(snapshots),
+			);
+			const { app, ensureStore, cleanup } = createTestApp({
+				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+			});
+			try {
+				expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+				const store = ensureStore();
+				const initialAttemptId = core.getLegacyTeamSetupDraft(store.db, candidateRef)?.attemptId;
+				const refreshPromise = app.request(`/api/sync/team-setup/v1/${candidateRef}/refresh`, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: "{}",
+				});
+				await vi.waitFor(() => expect(loadSnapshots).toHaveBeenCalledTimes(2));
+				store.db
+					.prepare(
+						`INSERT INTO policy_teams(
+						 team_id, display_name, status, device_eligibility_mode, provenance,
+						 revision, migration_state, source_fingerprint, idempotency_key, created_at, updated_at
+						 ) VALUES (?, 'Migration Team', 'active', 'reviewed_allowlist',
+						 'reviewed_team_candidate', 'revision-1', 'completed', 'roster', 'team-key', ?, ?)`,
+					)
+					.run(
+						core.deterministicPolicyTeamId(candidateRef),
+						"2026-08-26T00:00:00.000Z",
+						"2026-08-26T00:00:00.000Z",
+					);
+				resolveRefresh();
+
+				const refresh = await refreshPromise;
+				expect(refresh.status).toBe(409);
+				expect(await refresh.json()).toEqual({ error: "team_setup_confirmation_stale" });
+				expect(
+					store.db
+						.prepare(
+							`SELECT attempt_id FROM legacy_team_setup_drafts
+							 WHERE candidate_id = ? ORDER BY rowid DESC LIMIT 1`,
+						)
+						.pluck()
+						.get(candidateRef),
+				).toBe(initialAttemptId);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("keeps an active review attempt stable across read-only summary and detail loads", async () => {
+			let currentSnapshots = snapshots;
+			const loadSnapshots = vi.fn(async () => currentSnapshots);
+			const { app, ensureStore, cleanup } = createTestApp({
+				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+			});
+			try {
+				expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+				const initialAttemptId = core.getLegacyTeamSetupDraft(
+					ensureStore().db,
+					candidateRef,
+				)?.attemptId;
+				expect(initialAttemptId).toBeTruthy();
+				currentSnapshots = [
+					{
+						...snapshots[0],
+						devices: snapshots[0].devices.map((device) => ({
+							...device,
+							fingerprint: "new-fingerprint",
+						})),
+					},
+				];
+				loadSnapshots.mockClear();
+
+				expect((await app.request(`/api/sync/team-setup/v1/${candidateRef}`)).status).toBe(200);
+				expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+				expect(core.getLegacyTeamSetupDraft(ensureStore().db, candidateRef)?.attemptId).toBe(
+					initialAttemptId,
+				);
+				expect(loadSnapshots).not.toHaveBeenCalledWith({ candidateRef });
+
+				const refreshed = await app.request(`/api/sync/team-setup/v1/${candidateRef}/refresh`, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: "{}",
+				});
+				expect(refreshed.status).toBe(200);
+				expect(core.getLegacyTeamSetupDraft(ensureStore().db, candidateRef)?.attemptId).not.toBe(
+					initialAttemptId,
+				);
+				expect(loadSnapshots).toHaveBeenCalledWith({ candidateRef });
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/team-setup-terminal.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-terminal.test.ts
@@ -1,0 +1,463 @@
+import {
+	deterministicPolicyTeamId,
+	finishLegacyTeamSetupActivation,
+	getLegacyTeamSetupDraft,
+	inspectLegacyTeamSetupActivation,
+	type LegacyTeamConfiguredGroupSnapshot,
+	legacyTeamCandidateId,
+	legacyTeamCandidateProjectInventory,
+	MemoryStore,
+	readCoordinatorSyncConfig,
+	setLegacyTeamSetupDeviceAssignment,
+	setLegacyTeamSetupDeviceDecision,
+} from "@codemem/core";
+import { describe, expect, it, vi } from "vitest";
+import { __teamSetupTestHooks, teamSetupRoutes } from "./team-setup.js";
+
+const COORDINATOR_ID = "https://coordinator.example.test";
+const GROUP_ID = "group-alpha";
+const CANDIDATE_REF = legacyTeamCandidateId(COORDINATOR_ID, GROUP_ID);
+const NOW = "2026-08-26T00:00:00.000Z";
+const SNAPSHOTS: LegacyTeamConfiguredGroupSnapshot[] = [
+	{
+		coordinatorId: COORDINATOR_ID,
+		groupId: GROUP_ID,
+		displayName: "Migration Team",
+		devices: [
+			{
+				deviceId: "device-a",
+				fingerprint: "fingerprint-a",
+				displayName: "Laptop",
+				enabled: true,
+			},
+		],
+	},
+];
+
+function insertTeam(
+	store: MemoryStore,
+	draft: NonNullable<ReturnType<typeof getLegacyTeamSetupDraft>>,
+	options: {
+		status: "active" | "inactive";
+		provenance: "legacy_team_candidate" | "reviewed_team_candidate";
+		sourceFingerprint?: string;
+	},
+): string {
+	const teamId = deterministicPolicyTeamId(CANDIDATE_REF);
+	store.db
+		.prepare(
+			`INSERT INTO policy_teams(
+			 team_id, display_name, status, device_eligibility_mode, provenance,
+			 revision, migration_state, source_fingerprint, idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'Migration Team', ?, 'reviewed_allowlist', ?, 'revision-1',
+			 'completed', ?, 'team-key', ?, ?)`,
+		)
+		.run(
+			teamId,
+			options.status,
+			options.provenance,
+			options.sourceFingerprint ?? draft.rosterFingerprint,
+			NOW,
+			NOW,
+		);
+	return teamId;
+}
+
+function completeDraft(
+	store: MemoryStore,
+	draft: NonNullable<ReturnType<typeof getLegacyTeamSetupDraft>>,
+	teamId: string | null,
+): void {
+	store.db
+		.prepare(
+			`UPDATE legacy_team_setup_drafts
+			 SET state = 'completed', completed_team_id = ?, completed_at = ?, updated_at = ?
+			 WHERE attempt_id = ?`,
+		)
+		.run(teamId, NOW, NOW, draft.attemptId);
+}
+
+describe("Team setup terminal migration routing", () => {
+	it("revalidates pre-marker completions in detail and summary reads", async () => {
+		const store = new MemoryStore(":memory:");
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+		});
+		try {
+			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+			const first = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+			if (!first) throw new Error("initial Team setup draft missing");
+			const teamId = insertTeam(store, first, {
+				status: "active",
+				provenance: "legacy_team_candidate",
+				sourceFingerprint: "drifted-roster",
+			});
+			completeDraft(store, first, teamId);
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(200);
+			expect(await detail.json()).toMatchObject({
+				candidate: { candidateRef: CANDIDATE_REF, status: "needs_setup" },
+				state: "reviewing",
+			});
+			const second = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+			expect(second?.attemptId).not.toBe(first.attemptId);
+
+			if (!second) throw new Error("replacement Team setup draft missing");
+			completeDraft(store, second, teamId);
+			const summary = await app.request("/api/sync/team-setup/v1");
+			expect(summary.status).toBe(200);
+			expect(await summary.json()).toMatchObject({
+				version: 1,
+				candidates: [
+					expect.objectContaining({ candidateRef: CANDIDATE_REF, status: "needs_setup" }),
+				],
+			});
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.attemptId).not.toBe(
+				second.attemptId,
+			);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("preserves a pre-marker completion when fresh detail evidence is unavailable", async () => {
+		const store = new MemoryStore(":memory:");
+		const loadSnapshots = vi.fn(async (options?: { candidateRef?: string }) => {
+			if (options?.candidateRef) throw new Error("team_setup_roster_unavailable");
+			return SNAPSHOTS;
+		});
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+		});
+		try {
+			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+			const draft = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+			if (!draft) throw new Error("initial Team setup draft missing");
+			completeDraft(store, draft, null);
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(503);
+			expect(await detail.json()).toEqual({ error: "team_setup_roster_unavailable" });
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)).toMatchObject({
+				attemptId: draft.attemptId,
+				state: "completed",
+			});
+			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+			expect(loadSnapshots).toHaveBeenCalledTimes(2);
+		} finally {
+			store.close();
+		}
+	});
+
+	it.each([
+		["serves the completed draft", true, 200],
+		["rejects the superseded draft", false, 404],
+	] as const)("rechecks a migration marker after detail roster loading and %s", async (_label, remainsCompleted, expectedStatus) => {
+		const store = new MemoryStore(":memory:");
+		let resolveCandidateLoad!: () => void;
+		const loadSnapshots = vi.fn((options?: { candidateRef?: string }) =>
+			options?.candidateRef
+				? new Promise<LegacyTeamConfiguredGroupSnapshot[]>((resolve) => {
+						resolveCandidateLoad = () => resolve(SNAPSHOTS);
+					})
+				: Promise.resolve(SNAPSHOTS),
+		);
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+		});
+		try {
+			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+			const draft = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+			if (!draft) throw new Error("initial Team setup draft missing");
+			completeDraft(store, draft, null);
+			const detailPromise = app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			await vi.waitFor(() => expect(loadSnapshots).toHaveBeenCalledTimes(2));
+			const teamId = insertTeam(store, draft, {
+				status: "active",
+				provenance: "reviewed_team_candidate",
+			});
+			if (remainsCompleted) {
+				store.db
+					.prepare(
+						`UPDATE legacy_team_setup_drafts SET completed_team_id = ?
+							 WHERE attempt_id = ?`,
+					)
+					.run(teamId, draft.attemptId);
+			} else {
+				store.db
+					.prepare(
+						`UPDATE legacy_team_setup_drafts
+							 SET state = 'needs_setup', completed_at = NULL WHERE attempt_id = ?`,
+					)
+					.run(draft.attemptId);
+			}
+			resolveCandidateLoad();
+
+			const detail = await detailPromise;
+			expect(detail.status).toBe(expectedStatus);
+			if (remainsCompleted) {
+				expect(await detail.json()).toMatchObject({
+					candidate: { candidateRef: CANDIDATE_REF, status: "ready" },
+					state: "completed",
+				});
+			} else {
+				expect(await detail.json()).toEqual({ error: "team_setup_confirmation_stale" });
+			}
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not treat an inactive migration marker as terminal", async () => {
+		const store = new MemoryStore(":memory:");
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+		});
+		try {
+			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+			const draft = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+			if (!draft) throw new Error("initial Team setup draft missing");
+			const teamId = insertTeam(store, draft, {
+				status: "inactive",
+				provenance: "reviewed_team_candidate",
+			});
+			completeDraft(store, draft, teamId);
+
+			const summary = await app.request("/api/sync/team-setup/v1");
+			expect(summary.status).toBe(200);
+			expect(await summary.json()).toMatchObject({
+				candidates: [
+					expect.objectContaining({ candidateRef: CANDIDATE_REF, status: "needs_setup" }),
+				],
+			});
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.attemptId).not.toBe(draft.attemptId);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not churn a draft when a migration marker lacks a canonical completion", async () => {
+		const store = new MemoryStore(":memory:");
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+		});
+		try {
+			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+			const draft = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+			if (!draft) throw new Error("initial Team setup draft missing");
+			insertTeam(store, draft, {
+				status: "active",
+				provenance: "reviewed_team_candidate",
+			});
+			const attemptCount = store.db
+				.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts WHERE candidate_id = ?")
+				.pluck()
+				.get(CANDIDATE_REF);
+
+			const summary = await app.request("/api/sync/team-setup/v1");
+			expect(summary.status).toBe(200);
+			expect(await summary.json()).toEqual({ version: 1, candidates: [] });
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.attemptId).toBe(draft.attemptId);
+			expect(
+				store.db
+					.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts WHERE candidate_id = ?")
+					.pluck()
+					.get(CANDIDATE_REF),
+			).toBe(attemptCount);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("keeps a newer attempt stable when a terminal migration marker exists", async () => {
+		const store = new MemoryStore(":memory:");
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+		});
+		try {
+			const projectIdentity = "https://example.test/terminal-project.git";
+			store.db
+				.prepare(
+					`INSERT INTO replication_scopes(
+					 scope_id, label, kind, authority_type, coordinator_id, group_id,
+					 membership_epoch, status, created_at, updated_at
+					 ) VALUES ('scope-terminal', 'Terminal', 'team', 'coordinator', ?, ?, 1,
+					 'active', ?, ?)`,
+				)
+				.run(COORDINATOR_ID, GROUP_ID, NOW, NOW);
+			const sessionId = Number(
+				store.db
+					.prepare(
+						`INSERT INTO sessions(started_at, project, git_remote)
+						 VALUES (?, 'terminal-project', ?)`,
+					)
+					.run(NOW, projectIdentity).lastInsertRowid,
+			);
+			store.db
+				.prepare(
+					`INSERT INTO memory_items(
+					 session_id, kind, title, body_text, active, created_at, updated_at,
+					 visibility, project, scope_id
+					 ) VALUES (?, 'discovery', 'Terminal Project', 'body', 1, ?, ?, 'shared',
+					 'terminal-project', 'scope-terminal')`,
+				)
+				.run(sessionId, NOW, NOW);
+			store.db
+				.prepare(
+					`INSERT INTO project_scope_mappings(
+					 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+					 ) VALUES (?, ?, 'scope-terminal', 1000, 'reviewed_team_setup', ?, ?)`,
+				)
+				.run(projectIdentity, projectIdentity, NOW, NOW);
+			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+			let completed = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+			if (!completed) throw new Error("initial Team setup draft missing");
+			expect(
+				store.db
+					.prepare(
+						`SELECT source_project_identity, resolved_project_identity, target_scope_id
+						 FROM legacy_team_setup_draft_projects WHERE attempt_id = ?`,
+					)
+					.get(completed.attemptId),
+			).toEqual({
+				source_project_identity: projectIdentity,
+				resolved_project_identity: projectIdentity,
+				target_scope_id: "scope-terminal",
+			});
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('identity-a', 'Person A', 0, 'active', ?, ?)`,
+				)
+				.run(NOW, NOW);
+			const device = completed.devices[0];
+			if (!device) throw new Error("initial Team setup device missing");
+			completed = setLegacyTeamSetupDeviceAssignment(store.db, {
+				attemptId: completed.attemptId,
+				deviceRef: device.deviceRef,
+				targetIdentityId: "identity-a",
+				expectation: device.expectation,
+				now: NOW,
+			});
+			completed = setLegacyTeamSetupDeviceDecision(store.db, {
+				attemptId: completed.attemptId,
+				deviceRef: device.deviceRef,
+				decision: "included",
+				now: NOW,
+			});
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: completed.attemptId,
+			});
+			const completion = await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: completed.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () =>
+					legacyTeamCandidateProjectInventory(
+						store.db,
+						{ localActorId: store.actorId, localDeviceId: store.deviceId },
+						CANDIDATE_REF,
+					),
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			const teamId = completion.teamId;
+			store.db
+				.prepare(
+					`DELETE FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
+				)
+				.run(projectIdentity, teamId);
+			const newerAttemptId = "legacy-team-attempt:00000000-0000-4000-8000-000000000099";
+			store.db
+				.prepare(
+					`INSERT INTO legacy_team_setup_drafts(
+					 attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
+					 roster_fingerprint, projection_fingerprint, created_at, updated_at
+					 ) VALUES (?, ?, ?, ?, 'needs_setup', 'Migration Team', 'new-roster',
+					 'new-projection', ?, ?)`,
+				)
+				.run(newerAttemptId, CANDIDATE_REF, COORDINATOR_ID, GROUP_ID, NOW, NOW);
+
+			const summary = await app.request("/api/sync/team-setup/v1");
+			expect(summary.status).toBe(200);
+			expect(await summary.json()).toEqual({ version: 1, candidates: [] });
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.attemptId).toBe(newerAttemptId);
+			expect(
+				store.db
+					.prepare(
+						`SELECT status, provenance FROM project_recipients
+						 WHERE canonical_project_identity = ? AND recipient_kind = 'team'
+						   AND recipient_id = ?`,
+					)
+					.get(projectIdentity, teamId),
+			).toEqual({ status: "active", provenance: "reviewed_team_setup" });
+		} finally {
+			store.close();
+		}
+	});
+});
+
+describe("Team setup coordinator retry classification", () => {
+	it.each([408, 429, 503])("retries transient coordinator HTTP %i errors", async (status) => {
+		const listGroups = vi
+			.fn()
+			.mockRejectedValueOnce(
+				new Error(`Remote coordinator request failed (${status}): unavailable`),
+			)
+			.mockResolvedValue([
+				{
+					group_id: GROUP_ID,
+					display_name: "Migration Team",
+					archived_at: null,
+					created_at: NOW,
+				},
+			]);
+
+		await expect(
+			__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: COORDINATOR_ID,
+					syncCoordinatorGroups: [GROUP_ID],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+				listGroups,
+				listDevices: vi.fn(async () => []),
+			}),
+		).resolves.toEqual([expect.objectContaining({ groupId: GROUP_ID })]);
+		expect(listGroups).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not let timeout-like response text override a permanent HTTP status", async () => {
+		const listGroups = vi
+			.fn()
+			.mockRejectedValue(
+				new Error("Remote coordinator request failed (403): upstream request_timeout"),
+			);
+
+		await expect(
+			__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: COORDINATOR_ID,
+					syncCoordinatorGroups: [GROUP_ID],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+				listGroups,
+				listDevices: vi.fn(async () => []),
+			}),
+		).rejects.toThrow("team_setup_roster_unavailable");
+		expect(listGroups).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -150,6 +150,116 @@ describe("Team setup roster loading", () => {
 		);
 	});
 
+	it("retries transient coordinator timeouts while loading a candidate roster", async () => {
+		const publicKey = "public-key-a";
+		const timeoutError = Object.assign(new Error("The operation was aborted due to timeout"), {
+			name: "TimeoutError",
+		});
+		const listGroups = vi
+			.fn()
+			.mockRejectedValueOnce(timeoutError)
+			.mockRejectedValueOnce(timeoutError)
+			.mockRejectedValueOnce(timeoutError)
+			.mockRejectedValueOnce(timeoutError)
+			.mockResolvedValue([
+				{
+					group_id: "group-alpha",
+					display_name: "Migration Team",
+					archived_at: null,
+					created_at: "2026-08-24T00:00:00.000Z",
+				},
+			]);
+		const listDevices = vi
+			.fn()
+			.mockRejectedValueOnce(timeoutError)
+			.mockRejectedValueOnce(timeoutError)
+			.mockRejectedValueOnce(timeoutError)
+			.mockRejectedValueOnce(timeoutError)
+			.mockResolvedValue([
+				{
+					group_id: "group-alpha",
+					device_id: "device-a",
+					public_key: publicKey,
+					fingerprint: fingerprintPublicKey(publicKey),
+					identity_id: null,
+					display_name: "Laptop",
+					enabled: 1,
+					created_at: "2026-08-24T00:00:00.000Z",
+				},
+			]);
+
+		await expect(
+			__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "http://localhost:8787",
+					syncCoordinatorGroups: ["group-alpha"],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+				listGroups,
+				listDevices,
+			}),
+		).resolves.toEqual([
+			expect.objectContaining({ groupId: "group-alpha", displayName: "Migration Team" }),
+		]);
+		expect(listGroups).toHaveBeenCalledTimes(5);
+		expect(listDevices).toHaveBeenCalledTimes(5);
+	});
+
+	it("retries transient coordinator server errors", async () => {
+		const listGroups = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Remote coordinator request failed (503): unavailable"))
+			.mockResolvedValue([
+				{
+					group_id: "group-alpha",
+					display_name: "Migration Team",
+					archived_at: null,
+					created_at: "2026-08-24T00:00:00.000Z",
+				},
+			]);
+		const listDevices = vi.fn(async () => []);
+
+		await expect(
+			__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "http://localhost:8787",
+					syncCoordinatorGroups: ["group-alpha"],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+				listGroups,
+				listDevices,
+			}),
+		).resolves.toEqual([
+			expect.objectContaining({ groupId: "group-alpha", displayName: "Migration Team" }),
+		]);
+		expect(listGroups).toHaveBeenCalledTimes(2);
+		expect(listDevices).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not retry permanent coordinator failures", async () => {
+		const listGroups = vi
+			.fn()
+			.mockRejectedValue(new Error("Remote coordinator request failed (403): forbidden"));
+		const listDevices = vi.fn(async () => []);
+
+		await expect(
+			__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "http://localhost:8787",
+					syncCoordinatorGroups: ["group-alpha"],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+				listGroups,
+				listDevices,
+			}),
+		).rejects.toThrow("team_setup_roster_unavailable");
+		expect(listGroups).toHaveBeenCalledTimes(1);
+		expect(listDevices).not.toHaveBeenCalled();
+	});
+
 	it("canonicalizes equivalent coordinator URLs while preserving non-root paths", () => {
 		expect(__teamSetupTestHooks.normalizedCoordinatorId("HTTP://LOCALHOST:80/")).toBe(
 			"http://localhost",
@@ -476,7 +586,6 @@ describe("Team setup roster loading", () => {
 			);
 			expect(listDevices.mock.calls.map(([input]) => input.groupId).toSorted()).toEqual([
 				"nerdworld",
-				"sre",
 				"sre",
 			]);
 		} finally {

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -12,6 +12,7 @@ import {
 	clearLegacyTeamSetupDeviceDecision,
 	coordinatorListDevicesAction,
 	coordinatorListGroupsAction,
+	deterministicPolicyTeamId,
 	discoverLegacyTeamCandidates,
 	fingerprintPublicKey,
 	finishLegacyTeamSetupActivation,
@@ -81,6 +82,7 @@ const MAX_PROJECT_MAPPING_SCAN_ROWS = 10_000;
 const MAX_PROJECT_MAPPING_METADATA_ROWS = 10_000;
 const MAX_MUTATION_BODY_BYTES = 8_192;
 const SUMMARY_SNAPSHOT_CACHE_TTL_MS = 30_000;
+const COORDINATOR_ROSTER_READ_BUDGET_MS = 60_000;
 export const TEAM_SETUP_ROUTE_PREFIX = "/api/sync/team-setup/v1";
 const CANDIDATE_REF_PATTERN = /^legacy-team-candidate:[0-9a-f]{32}$/u;
 const DEVICE_REF_PATTERN = /^legacy-team-device-ref-v1:[0-9a-f]{64}$/u;
@@ -130,6 +132,39 @@ function safeCoordinatorError(): Error {
 
 function isCoordinatorRosterTooLargeError(error: unknown): boolean {
 	return error instanceof Error && error.message === "coordinator_response_too_large";
+}
+
+function isTransientCoordinatorReadError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const remoteStatus = /Remote coordinator request failed \((\d{3})\):/u.exec(error.message)?.[1];
+	if (remoteStatus) return ["408", "429", "500", "502", "503", "504"].includes(remoteStatus);
+	return (
+		error.name === "TimeoutError" ||
+		error.name === "AbortError" ||
+		/request_timeout|fetch failed|timed out|timeout/iu.test(error.message)
+	);
+}
+
+async function retryTransientCoordinatorRead<T>(
+	read: (timeoutS: number) => Promise<T>,
+	configuredTimeoutS: number,
+	deadlineMs: number,
+): Promise<T> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 8; attempt += 1) {
+		const remainingMs = deadlineMs - Date.now();
+		if (remainingMs <= 0) throw lastError ?? safeCoordinatorError();
+		try {
+			return await read(Math.max(0.1, Math.min(configuredTimeoutS, remainingMs / 1_000)));
+		} catch (error) {
+			lastError = error;
+			if (!isTransientCoordinatorReadError(error) || attempt === 7) throw error;
+			const delayMs = Math.min(100 * 2 ** attempt, 2_000, deadlineMs - Date.now());
+			if (delayMs <= 0) throw error;
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+		}
+	}
+	throw lastError;
 }
 
 function configuredGroupIds(groups: string[]): string[] {
@@ -295,18 +330,24 @@ async function loadConfiguredLegacyTeamGroupSnapshotsWith(
 		);
 		if (groupDescriptors.length === 0) throw safeCoordinatorError();
 		const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
+		const deadlineMs = Date.now() + COORDINATOR_ROSTER_READ_BUDGET_MS;
 		const requestedGroupDescriptors = options.candidateRef
 			? groupDescriptors.filter(
 					({ coordinatorId, groupId }) =>
 						legacyTeamCandidateId(coordinatorId, groupId) === options.candidateRef,
 				)
 			: groupDescriptors;
-		const groups = await dependencies.listGroups({
-			remoteUrl,
-			adminSecret: config.syncCoordinatorAdminSecret,
-			includeArchived: false,
+		const groups = await retryTransientCoordinatorRead(
+			(attemptTimeoutS) =>
+				dependencies.listGroups({
+					remoteUrl,
+					adminSecret: config.syncCoordinatorAdminSecret,
+					includeArchived: false,
+					timeoutS: attemptTimeoutS,
+				}),
 			timeoutS,
-		});
+			deadlineMs,
+		);
 		const groupById = new Map(groups.map((group) => [group.group_id, group]));
 		const outcomes = await Promise.all(
 			requestedGroupDescriptors.map(async ({ coordinatorId, groupId }) => {
@@ -326,13 +367,18 @@ async function loadConfiguredLegacyTeamGroupSnapshotsWith(
 				}
 				let devices: Awaited<ReturnType<typeof coordinatorListDevicesAction>>;
 				try {
-					devices = await dependencies.listDevices({
-						groupId,
-						includeDisabled: true,
-						remoteUrl,
-						adminSecret: config.syncCoordinatorAdminSecret,
+					devices = await retryTransientCoordinatorRead(
+						(attemptTimeoutS) =>
+							dependencies.listDevices({
+								groupId,
+								includeDisabled: true,
+								remoteUrl,
+								adminSecret: config.syncCoordinatorAdminSecret,
+								timeoutS: attemptTimeoutS,
+							}),
 						timeoutS,
-					});
+						deadlineMs,
+					);
 				} catch (error) {
 					if (!options.candidateRef) return { kind: "unavailable" as const };
 					if (isCoordinatorRosterTooLargeError(error)) {
@@ -441,6 +487,48 @@ function candidateFromDraft(draft: LegacyTeamSetupDraftView): LegacyTeamCandidat
 		unresolvedDeviceCount: draft.unresolvedDeviceCount,
 		unresolvedProjectCount: draft.unresolvedProjectCount,
 	};
+}
+
+function readPureCandidateViews(
+	store: MemoryStore,
+	groups: LegacyTeamConfiguredGroupSnapshot[],
+): LegacyTeamCandidateView[] {
+	const existing: LegacyTeamCandidateView[] = [];
+	const discoverable: LegacyTeamConfiguredGroupSnapshot[] = [];
+	for (const group of groups) {
+		const candidateRef = legacyTeamCandidateId(group.coordinatorId, group.groupId);
+		const draft = getLegacyTeamSetupDraft(store.db, candidateRef);
+		if (hasCompletedLegacyTeamSetup(store, candidateRef)) {
+			// Only canonical terminal completions pass through discovery: they can
+			// reconcile missing setup recipient edges while preserving newer drafts.
+			if (isLegacyTeamCandidateSelectable(store.db, candidateRef)) discoverable.push(group);
+			continue;
+		}
+		if (!draft || draft.state === "completed") {
+			discoverable.push(group);
+			continue;
+		}
+		existing.push(candidateFromDraft(draft));
+	}
+	return [...existing, ...discoverCandidates(store, discoverable)]
+		.filter((candidate) => !hasCompletedLegacyTeamSetup(store, candidate.candidateRef))
+		.toSorted((left, right) =>
+			left.candidateRef < right.candidateRef ? -1 : left.candidateRef > right.candidateRef ? 1 : 0,
+		);
+}
+
+function hasCompletedLegacyTeamSetup(store: MemoryStore, candidateRef: string): boolean {
+	return Boolean(
+		store.db
+			.prepare(
+				`SELECT 1 FROM policy_teams
+				 WHERE team_id = ? AND status = 'active'
+				   AND provenance = 'reviewed_team_candidate'
+				   AND migration_state = 'completed' LIMIT 1`,
+			)
+			.pluck()
+			.get(deterministicPolicyTeamId(candidateRef)),
+	);
 }
 
 function identityRef(candidateRef: string, identityId: string | null): string | null {
@@ -728,7 +816,10 @@ function createCachedSnapshotLoader(
 	load: () => Promise<LegacyTeamConfiguredGroupSnapshot[]>,
 	ttlMs: number,
 	now: () => number = Date.now,
-): (() => Promise<LegacyTeamConfiguredGroupSnapshot[]>) & { invalidate: () => void } {
+): (() => Promise<LegacyTeamConfiguredGroupSnapshot[]>) & {
+	invalidate: () => void;
+	peek: () => LegacyTeamConfiguredGroupSnapshot[] | null;
+} {
 	let cached: { expiresAt: number; snapshots: LegacyTeamConfiguredGroupSnapshot[] } | null = null;
 	let inFlight: Promise<LegacyTeamConfiguredGroupSnapshot[]> | null = null;
 	let generation = 0;
@@ -754,6 +845,7 @@ function createCachedSnapshotLoader(
 		cached = null;
 		inFlight = null;
 	};
+	cachedLoad.peek = () => (cached && now() < cached.expiresAt ? cached.snapshots : null);
 	return cachedLoad;
 }
 
@@ -1126,12 +1218,27 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 	options.registerSummaryInvalidator?.(() => loadedSummarySnapshots.invalidate());
 	async function loadedCandidateSnapshots(
 		candidateRef: string,
+		loadOptions: {
+			allowCachedSummaryFallback?: boolean;
+			invalidateSummaryCache?: boolean;
+		} = {},
 	): Promise<LegacyTeamConfiguredGroupSnapshot[]> {
-		loadedSummarySnapshots.invalidate();
+		const allowCachedSummaryFallback = loadOptions.allowCachedSummaryFallback ?? false;
+		const invalidateSummaryCache = loadOptions.invalidateSummaryCache ?? true;
+		if (invalidateSummaryCache) loadedSummarySnapshots.invalidate();
 		try {
 			return await loadedSnapshots(candidateRef);
+		} catch (error) {
+			if (!allowCachedSummaryFallback) throw error;
+			const cachedGroups = loadedSummarySnapshots.peek();
+			if (!cachedGroups) throw error;
+			const matching = cachedGroups.filter(
+				(group) => legacyTeamCandidateId(group.coordinatorId, group.groupId) === candidateRef,
+			);
+			if (matching.length !== 1) throw error;
+			return matching;
 		} finally {
-			loadedSummarySnapshots.invalidate();
+			if (invalidateSummaryCache) loadedSummarySnapshots.invalidate();
 		}
 	}
 
@@ -1144,9 +1251,10 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			return c.json({ error: code }, errorStatus(code));
 		}
 		try {
+			const store = options.getStore();
 			const response = {
 				version: TEAM_SETUP_VERSION,
-				candidates: discoverCandidates(options.getStore(), groups)
+				candidates: readPureCandidateViews(store, groups)
 					.map(candidateSummary)
 					.filter(
 						(candidate): candidate is LegacyTeamSetupPendingCandidateSummaryV1 =>
@@ -1169,31 +1277,41 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		try {
 			const store = options.getStore();
 			let draft = getLegacyTeamSetupDraft(store.db, candidateRef);
+			const terminal = hasCompletedLegacyTeamSetup(store, candidateRef);
+			if (terminal && draft?.state !== "completed") {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			}
 			let candidate: LegacyTeamCandidateView;
-			if (
-				draft?.state === "completed" &&
-				isLegacyTeamCandidateSelectable(store.db, candidateRef, {
-					projects: legacyTeamCandidateProjectInventory(
-						store.db,
-						projectionOptions(store),
-						candidateRef,
-					),
-				})
-			) {
+			if (draft && (draft.state !== "completed" || terminal)) {
 				candidate = candidateFromDraft(draft);
 			} else {
-				const groups = await loadedCandidateSnapshots(candidateRef);
+				// Revalidation may replace a completed draft, so it must never decide
+				// against a stale summary-cache roster. Cache fallback remains safe for
+				// candidates that have no persisted attempt yet.
+				const groups = await loadedCandidateSnapshots(candidateRef, {
+					allowCachedSummaryFallback: draft == null,
+					invalidateSummaryCache: false,
+				});
 				const candidateGroups = groups.filter(
 					(group) => legacyTeamCandidateId(group.coordinatorId, group.groupId) === candidateRef,
 				);
-				const discoveredCandidate = discoverCandidates(store, candidateGroups).find(
-					(item) => item.candidateRef === candidateRef,
-				);
-				if (!discoveredCandidate) {
-					return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+				const postLoadDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
+				if (hasCompletedLegacyTeamSetup(store, candidateRef)) {
+					if (postLoadDraft?.state !== "completed") {
+						return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+					}
+					draft = postLoadDraft;
+					candidate = candidateFromDraft(postLoadDraft);
+				} else {
+					const discoveredCandidate = discoverCandidates(store, candidateGroups).find(
+						(item) => item.candidateRef === candidateRef,
+					);
+					if (!discoveredCandidate) {
+						return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+					}
+					candidate = discoveredCandidate;
+					draft = getLegacyTeamSetupDraft(store.db, candidateRef);
 				}
-				candidate = discoveredCandidate;
-				draft = getLegacyTeamSetupDraft(store.db, candidateRef);
 			}
 			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 
@@ -1233,6 +1351,9 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			const store = options.getStore();
 			const draft = getLegacyTeamSetupDraft(store.db, candidateRef);
 			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			if (draft.state !== "completed" && hasCompletedLegacyTeamSetup(store, candidateRef)) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
 			if (draft.attemptId !== attemptId) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
 			}
@@ -1303,6 +1424,9 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			const store = options.getStore();
 			const draft = getLegacyTeamSetupDraft(store.db, candidateRef);
 			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			if (draft.state !== "completed" && hasCompletedLegacyTeamSetup(store, candidateRef)) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
 			if (draft.attemptId !== attemptId) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
 			}
@@ -1356,6 +1480,9 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			const store = options.getStore();
 			const draft = getLegacyTeamSetupDraft(store.db, candidateRef);
 			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			if (draft.state !== "completed" && hasCompletedLegacyTeamSetup(store, candidateRef)) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
 			if (draft.attemptId !== attemptId) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
 			}
@@ -1401,6 +1528,9 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			const store = options.getStore();
 			const draft = getLegacyTeamSetupDraft(store.db, candidateRef);
 			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			if (draft.state !== "completed" && hasCompletedLegacyTeamSetup(store, candidateRef)) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
 			if (draft.attemptId !== attemptId) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
 			}
@@ -1449,6 +1579,10 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		let store: MemoryStore;
 		try {
 			store = options.getStore();
+			const currentDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
+			if (currentDraft?.state === "completed" || hasCompletedLegacyTeamSetup(store, candidateRef)) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1474,7 +1608,11 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				projectMutationAtomically(
 					store,
 					() => {
-						if (getLegacyTeamSetupDraft(store.db, candidateRef)?.state === "completed") {
+						const currentDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
+						if (
+							currentDraft?.state === "completed" ||
+							hasCompletedLegacyTeamSetup(store, candidateRef)
+						) {
 							throw new Error("team_setup_confirmation_stale");
 						}
 						return refreshLegacyTeamCandidate(
@@ -1536,6 +1674,9 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			const store = options.getStore();
 			const draft = getLegacyTeamSetupDraft(store.db, candidateRef);
 			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			if (draft.state !== "completed" && hasCompletedLegacyTeamSetup(store, candidateRef)) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
 			if (draft.attemptId !== attemptId) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
 			}


### PR DESCRIPTION
## Description

Make completed legacy Team migration terminal in Viewer routes. Canonical completed Teams suppress superseding legacy drafts, stale direct reads return 404, and every mutation/refresh path fails closed. Coordinator roster reads also use bounded retry and cached fallback behavior.

Live verification confirmed the completed SRE Team is absent from the migration summary and its stale detail URL returns 404.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced