### PR TITLE
fix(ui): improve Team setup recovery

### DIFF
--- a/packages/ui/scripts/stage-viewer-static.mjs
+++ b/packages/ui/scripts/stage-viewer-static.mjs
@@ -7,6 +7,7 @@ import {
 	rmSync,
 	writeFileSync,
 } from "node:fs";
+import { createHash } from "node:crypto";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { brotliCompressSync, constants as zlibConstants, gzipSync } from "node:zlib";
@@ -27,6 +28,17 @@ for (const entry of readdirSync(sourceStaticDir, { withFileTypes: true })) {
 	if (entry.name === "app.js") continue;
 	if (extname(entry.name) === ".map") continue;
 	cpSync(join(sourceStaticDir, entry.name), join(viewerStaticDir, entry.name));
+}
+
+const stagedAppPath = join(viewerStaticDir, "app.js");
+const stagedIndexPath = join(viewerStaticDir, "index.html");
+if (existsSync(stagedAppPath) && existsSync(stagedIndexPath)) {
+	const appVersion = createHash("sha256").update(readFileSync(stagedAppPath)).digest("hex").slice(0, 12);
+	const indexHtml = readFileSync(stagedIndexPath, "utf8").replace(
+		/\/assets\/app\.js(?:\?v=[^"']*)?/u,
+		`/assets/app.js?v=${appVersion}`,
+	);
+	writeFileSync(stagedIndexPath, indexHtml);
 }
 
 // Precompress text assets so the viewer server (serveStatic precompressed:true)

--- a/packages/ui/src/lib/project-identity-presentation.test.ts
+++ b/packages/ui/src/lib/project-identity-presentation.test.ts
@@ -17,8 +17,8 @@ describe("Project identity presentation", () => {
 		const reversed = stableProjectPresentationLabels([...items].reverse());
 
 		expect([...forward]).toEqual([...reversed]);
-		expect(forward.get(privatePath)).toBe("codemem — Project 1 of 2");
-		expect(forward.get(privateRemote)).toBe("codemem — Project 2 of 2");
+		expect(forward.get(privatePath)).toBe("codemem — duplicate name 1 of 2");
+		expect(forward.get(privateRemote)).toBe("codemem — duplicate name 2 of 2");
 		expect(JSON.stringify([...forward.values()])).not.toContain(privatePath);
 		expect(JSON.stringify([...forward.values()])).not.toContain(privateRemote);
 	});
@@ -33,9 +33,9 @@ describe("Project identity presentation", () => {
 		const labels = stableProjectPresentationLabels(items);
 
 		expect(labels.size).toBe(itemCount);
-		expect(labels.get("project-00000")).toBe(`codemem — Project 1 of ${itemCount}`);
-		expect(labels.get("project-05000")).toBe(`codemem — Project 5001 of ${itemCount}`);
-		expect(labels.get("project-09999")).toBe(`codemem — Project 10000 of ${itemCount}`);
+		expect(labels.get("project-00000")).toBe(`codemem — duplicate name 1 of ${itemCount}`);
+		expect(labels.get("project-05000")).toBe(`codemem — duplicate name 5001 of ${itemCount}`);
+		expect(labels.get("project-09999")).toBe(`codemem — duplicate name 10000 of ${itemCount}`);
 	});
 
 	it("groups distinct canonical identities without merging their exact count", () => {
@@ -57,8 +57,8 @@ describe("Project identity presentation", () => {
 			{ canonicalId: "project-b", displayName: "code\u200Bmem" },
 		]);
 
-		expect(labels.get("project-a")).toBe("codemem — Project 1 of 2");
-		expect(labels.get("project-b")).toBe("code\u200Bmem — Project 2 of 2");
+		expect(labels.get("project-a")).toBe("codemem — duplicate name 1 of 2");
+		expect(labels.get("project-b")).toBe("code\u200Bmem — duplicate name 2 of 2");
 	});
 
 	it("keeps emoji ZWJ sequences distinct from adjacent emoji", () => {

--- a/packages/ui/src/lib/project-identity-presentation.ts
+++ b/packages/ui/src/lib/project-identity-presentation.ts
@@ -53,7 +53,7 @@ export function stableProjectPresentationLabels(
 			labels.set(
 				item.canonicalId,
 				group.length > 1
-					? `${item.displayName} — Project ${index + 1} of ${group.length}`
+					? `${item.displayName} — duplicate name ${index + 1} of ${group.length}`
 					: item.displayName,
 			);
 		}

--- a/packages/ui/src/native-control-styles.test.ts
+++ b/packages/ui/src/native-control-styles.test.ts
@@ -85,4 +85,9 @@ describe("native control styles", () => {
 			expect(stagingScript).toContain(`"${filename}"`);
 		}
 	});
+
+	it("cache-busts the staged viewer bundle from its content hash", () => {
+		expect(stagingScript).toContain('createHash("sha256")');
+		expect(stagingScript).toContain(`/assets/app.js?v=\${appVersion}`);
+	});
 });

--- a/packages/ui/src/tabs/legacy-team-setup-dialog-view.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog-view.tsx
@@ -49,6 +49,7 @@ export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps)
 	const globalBusy = hasGlobalOperation(session) || hasBlockingOperation(session);
 	const finishing = session.commands.some((command) => command.kind === "finish");
 	const recoveryRequired = view?.state === "unavailable" || error?.retry === "refresh";
+	const recoveryMode = error != null && (!view || recoveryRequired);
 	const mutationsBlocked = !isEditable(view) || globalBusy || Boolean(error);
 	const mutationBlockDescriptionId =
 		[
@@ -109,30 +110,32 @@ export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps)
 					</p>
 					{loading && !view ? <p role="status">Loading the latest Team setup details…</p> : null}
 					{error ? (
-						<div className="legacy-team-setup-error" id="legacy-team-setup-global-error">
+						<div
+							className="legacy-team-setup-error legacy-team-setup-recovery"
+							id="legacy-team-setup-global-error"
+						>
+							{recoveryMode ? <strong>Current setup details are unavailable</strong> : null}
 							<p aria-live="assertive" id="legacy-team-setup-error" role="alert">
 								{error.message}
 							</p>
-							{view?.state !== "unavailable" ? (
-								<button
-									aria-busy={globalBusy ? "true" : undefined}
-									aria-disabled={globalBusy ? "true" : undefined}
-									className="settings-button legacy-team-setup-target"
-									id="legacy-team-setup-retry"
-									onClick={() => {
-										if (!globalBusy) props.onRetry();
-									}}
-									type="button"
-								>
-									{loading
-										? error.retry === "refresh"
-											? "Refreshing…"
-											: "Retrying…"
-										: error.retry === "refresh"
-											? "Refresh Team setup"
-											: "Retry"}
-								</button>
-							) : null}
+							<button
+								aria-busy={globalBusy ? "true" : undefined}
+								aria-disabled={globalBusy ? "true" : undefined}
+								className="settings-button legacy-team-setup-target"
+								id="legacy-team-setup-retry"
+								onClick={() => {
+									if (!globalBusy) props.onRetry();
+								}}
+								type="button"
+							>
+								{loading
+									? error.retry === "refresh"
+										? "Refreshing…"
+										: "Retrying…"
+									: error.retry === "refresh"
+										? "Retry loading current setup"
+										: "Retry"}
+							</button>
 						</div>
 					) : null}
 					{itemRecoveryRequired ? (
@@ -177,7 +180,7 @@ export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps)
 					) : null}
 					{view ? (
 						<>
-							{session.step !== "completed" ? (
+							{session.step !== "completed" && !recoveryMode ? (
 								<StepNavigation
 									onNavigate={props.onNavigate}
 									step={session.step}
@@ -203,21 +206,7 @@ export function LegacyTeamSetupDialogView(props: LegacyTeamSetupDialogViewProps)
 							>
 								{session.message}
 							</p>
-							{view.state === "unavailable" ? (
-								<button
-									aria-busy={globalBusy ? "true" : undefined}
-									aria-disabled={globalBusy ? "true" : undefined}
-									className="settings-button legacy-team-setup-target"
-									id="legacy-team-setup-refresh"
-									onClick={() => {
-										if (!globalBusy) props.onRefresh();
-									}}
-									type="button"
-								>
-									Refresh Team setup
-								</button>
-							) : null}
-							{session.step === "devices" ? (
+							{recoveryMode ? null : session.step === "devices" ? (
 								<LegacyTeamSetupDevices
 									blocked={mutationsBlocked}
 									blockedDescriptionId={mutationBlockDescriptionId}

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -570,8 +570,10 @@ describe("legacy Team setup dialog", () => {
 		const select = document.querySelector<HTMLSelectElement>(".legacy-team-device-select");
 
 		expect(alert.textContent).toContain("temporarily unavailable");
-		expect(select?.getAttribute("aria-describedby")).toContain("legacy-team-setup-error");
-		expect(document.getElementById("legacy-team-setup-refresh")).not.toBeNull();
+		expect(select).toBeNull();
+		expect(document.getElementById("legacy-team-setup-retry")?.textContent).toContain(
+			"Retry loading current setup",
+		);
 	});
 
 	it("explains when an unresolved Project has no safe mapping action", async () => {
@@ -728,9 +730,7 @@ describe("legacy Team setup dialog", () => {
 			"temporarily unavailable",
 		);
 		retry.resolve(detail({ unresolvedProjectCount: 1 }));
-		await vi.waitFor(() => {
-			expect(document.body.textContent).toContain("Review Projects");
-		});
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
 		expect(document.activeElement?.id).toBe("legacy-team-setup-step-projects");
 		expect(loadDetail).toHaveBeenCalledTimes(2);
 	});
@@ -768,22 +768,23 @@ describe("legacy Team setup dialog", () => {
 		act(() => {
 			document.getElementById("legacy-team-setup-retry")?.click();
 		});
-		await vi.waitFor(() => {
-			expect(document.body.textContent).toContain("Review Projects");
-		});
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain("Current setup details are unavailable"),
+		);
 		expect(refreshCandidate).toHaveBeenCalledTimes(1);
 		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
 			"changed since it was last reviewed",
 		);
-		expect(document.getElementById("legacy-team-setup-retry")).toBeNull();
-		expect(document.activeElement?.id).toBe("legacy-team-setup-refresh");
+		expect(document.getElementById("legacy-team-setup-retry")).not.toBeNull();
+		await vi.waitFor(() =>
+			expect(
+				document.getElementById("legacy-team-setup-retry")?.getAttribute("aria-disabled"),
+			).toBeNull(),
+		);
 		act(() => {
-			button("Refresh Team setup").click();
+			document.getElementById("legacy-team-setup-retry")?.click();
 		});
-		await vi.waitFor(() => {
-			expect(document.querySelector('[role="alert"]')).toBeNull();
-		});
-		expect(refreshCandidate).toHaveBeenCalledTimes(2);
+		await vi.waitFor(() => expect(refreshCandidate).toHaveBeenCalledTimes(2));
 		expect(loadDetail).toHaveBeenCalledTimes(1);
 	});
 
@@ -1334,19 +1335,14 @@ describe("legacy Team setup dialog", () => {
 		await vi.waitFor(() => expect(document.body.textContent).toContain("Work laptop"));
 
 		act(() => button("Exclude").click());
-		await vi.waitFor(() => {
-			expect(document.body.textContent).toContain("changed since it was last reviewed");
-			expect(document.body.textContent).toContain("Current assignment: Sam");
-		});
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain("changed since it was last reviewed"),
+		);
 		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
 			"changed since it was last reviewed",
 		);
 		expect(loadDetail).toHaveBeenCalledTimes(2);
-		const exclude = button("Exclude");
-		expect(exclude.disabled).toBe(false);
-		expect(exclude.getAttribute("aria-disabled")).toBe("true");
-		exclude.focus();
-		expect(document.activeElement).toBe(exclude);
+		expect(document.body.textContent).not.toContain("Current assignment: Sam");
 
 		act(() => document.getElementById("legacy-team-setup-retry")?.click());
 		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
@@ -1386,7 +1382,7 @@ describe("legacy Team setup dialog", () => {
 				"changed since it was last reviewed",
 			),
 		);
-		act(() => document.getElementById("legacy-team-setup-refresh")?.click());
+		act(() => document.getElementById("legacy-team-setup-retry")?.click());
 
 		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
 		expect(refreshCandidate).toHaveBeenCalledWith("opaque-candidate");
@@ -1557,8 +1553,8 @@ describe("legacy Team setup dialog", () => {
 		});
 		expect([...select.options].map((option) => option.textContent)).toEqual([
 			"Choose a Project",
-			"codemem — Project 2 of 2",
-			"codemem — Project 1 of 2",
+			"codemem — duplicate name 2 of 2",
+			"codemem — duplicate name 1 of 2",
 		]);
 		expect([...select.options].map((option) => option.value)).toEqual([
 			"",
@@ -1634,17 +1630,11 @@ describe("legacy Team setup dialog", () => {
 			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
 				"changed since it was last reviewed",
 			);
-			expect(document.body.textContent).toContain("Project Gamma");
-			expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")?.value).toBe(
-				"",
-			);
+			expect(document.body.textContent).toContain("Current setup details are unavailable");
 		});
 		expect(document.body.textContent).not.toContain("team_setup_confirmation_stale");
 		expect(loadDetail).toHaveBeenCalledTimes(2);
-		expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")?.disabled).toBe(
-			true,
-		);
-		expect(button("Save mapping").getAttribute("aria-disabled")).toBe("true");
+		expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")).toBeNull();
 
 		act(() => document.getElementById("legacy-team-setup-retry")?.click());
 		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
@@ -1975,7 +1965,7 @@ describe("legacy Team setup dialog", () => {
 		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
 		act(() => button("Review").click());
 		expect(document.body.textContent).toContain(
-			"Add Example Team as a recipient for Shared name — Project 1 of 2.",
+			"Add Example Team as a recipient for Shared name — duplicate name 1 of 2.",
 		);
 	});
 
@@ -2061,8 +2051,8 @@ describe("legacy Team setup dialog", () => {
 		});
 
 		await vi.waitFor(() => expect(document.body.textContent).toContain("Review Projects"));
-		expect(document.body.textContent).toContain("greenroom — Project 1 of 34");
-		expect(document.body.textContent).toContain("greenroom — Project 34 of 34");
+		expect(document.body.textContent).toContain("greenroom — duplicate name 1 of 34");
+		expect(document.body.textContent).toContain("greenroom — duplicate name 34 of 34");
 		act(() => button("Review").click());
 		const review = document.querySelector<HTMLElement>(
 			'[aria-labelledby="legacy-team-setup-step-review"]',
@@ -2121,12 +2111,13 @@ describe("legacy Team setup dialog", () => {
 		expect([...review.querySelectorAll("details")].every((details) => !details.open)).toBe(true);
 		expect(
 			[...section("Projects").querySelectorAll(".legacy-team-setup-exact-list > li")].filter(
-				(row) => row.textContent?.startsWith("Add greenroom — Project "),
+				(row) => row.textContent?.startsWith("Add greenroom — duplicate name "),
 			),
 		).toHaveLength(34);
 		expect(
 			[...section("Device access").querySelectorAll(".legacy-team-setup-exact-list > li")].filter(
-				(row) => row.textContent?.startsWith("Add Work laptop access to greenroom — Project "),
+				(row) =>
+					row.textContent?.startsWith("Add Work laptop access to greenroom — duplicate name "),
 			),
 		).toHaveLength(68);
 	});
@@ -2466,7 +2457,7 @@ describe("legacy Team setup dialog", () => {
 		expect(refresh.getAttribute("aria-disabled")).toBe("true");
 	});
 
-	it("marks recovery refresh busy and ignores duplicate requests", async () => {
+	it("marks recovery retry busy and ignores duplicate requests", async () => {
 		const pendingRefresh = deferred<LegacyTeamSetupDetailResponseV1>();
 		const refreshCandidate = vi.fn().mockReturnValue(pendingRefresh.promise);
 		setup({
@@ -2474,10 +2465,10 @@ describe("legacy Team setup dialog", () => {
 			refreshCandidate,
 		});
 		await vi.waitFor(() =>
-			expect(document.getElementById("legacy-team-setup-refresh")).not.toBeNull(),
+			expect(document.getElementById("legacy-team-setup-retry")).not.toBeNull(),
 		);
 
-		const refresh = document.getElementById("legacy-team-setup-refresh") as HTMLButtonElement;
+		const refresh = document.getElementById("legacy-team-setup-retry") as HTMLButtonElement;
 		act(() => {
 			refresh.click();
 			refresh.click();
@@ -2532,7 +2523,7 @@ describe("legacy Team setup dialog", () => {
 		expect(onRefresh).not.toHaveBeenCalled();
 	});
 
-	it("describes unavailable item controls with the recovery action", async () => {
+	it("hides unavailable item controls behind the recovery action", async () => {
 		setup({
 			loadDetail: vi.fn().mockResolvedValue(
 				detail({
@@ -2543,13 +2534,10 @@ describe("legacy Team setup dialog", () => {
 			),
 		});
 		await vi.waitFor(() =>
-			expect(document.getElementById("legacy-team-setup-refresh")).not.toBeNull(),
+			expect(document.getElementById("legacy-team-setup-retry")).not.toBeNull(),
 		);
 
-		expect(button("Exclude").getAttribute("aria-disabled")).toBe("true");
-		expect(button("Exclude").getAttribute("aria-describedby")).toContain(
-			"legacy-team-setup-refresh",
-		);
+		expect(document.querySelector(".legacy-team-device-row")).toBeNull();
 	});
 
 	it("ignores a completion refresh after closing and opening another Team", async () => {
@@ -2719,16 +2707,18 @@ describe("legacy Team setup dialog", () => {
 			);
 		setup({ loadDetail, refreshCandidate });
 
-		await vi.waitFor(() => expect(document.body.textContent).toContain("Refresh Team setup"));
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain("Retry loading current setup"),
+		);
 		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
 			"changed since it was last reviewed",
 		);
-		expect(document.getElementById("legacy-team-setup-retry")).toBeNull();
-		expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Devices");
+		expect(document.getElementById("legacy-team-setup-retry")).not.toBeNull();
+		expect(document.querySelector('button[aria-current="step"]')).toBeNull();
 
-		act(() => button("Refresh Team setup").click());
+		act(() => document.getElementById("legacy-team-setup-retry")?.click());
 
-		await vi.waitFor(() => expect(document.body.textContent).toContain("Team setup refreshed."));
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Review devices"));
 		expect(refreshCandidate).toHaveBeenCalledWith("opaque-candidate");
 		expect(loadDetail).toHaveBeenCalledTimes(1);
 		expect(document.querySelector('[role="alert"]')).toBeNull();
@@ -2749,13 +2739,15 @@ describe("legacy Team setup dialog", () => {
 		);
 		setup({ loadDetail: vi.fn().mockResolvedValue(unavailable), refreshCandidate });
 
-		await vi.waitFor(() => expect(document.body.textContent).toContain("Refresh Team setup"));
-		expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Devices");
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain("Retry loading current setup"),
+		);
+		expect(document.querySelector('button[aria-current="step"]')).toBeNull();
 		expect(document.querySelector('[role="alert"]')?.textContent).toContain(
 			"Team device details are temporarily unavailable",
 		);
 
-		act(() => button("Refresh Team setup").click());
+		act(() => document.getElementById("legacy-team-setup-retry")?.click());
 
 		await vi.waitFor(() => expect(refreshCandidate).toHaveBeenCalledWith("opaque-candidate"));
 	});
@@ -2786,8 +2778,8 @@ describe("legacy Team setup dialog", () => {
 		);
 		setup({ loadDetail, refreshCandidate });
 
-		await vi.waitFor(() => expect(document.body.textContent).toContain("Old automatic Project"));
-		act(() => button("Refresh Team setup").click());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Current setup details"));
+		act(() => document.getElementById("legacy-team-setup-retry")?.click());
 
 		await vi.waitFor(() => expect(document.body.textContent).toContain("New automatic Project"));
 		expect(document.querySelector('button[aria-current="step"]')?.textContent).toBe("Projects");
@@ -2833,7 +2825,7 @@ describe("legacy Team setup dialog", () => {
 				"setup was not finished and no changes were applied",
 			),
 		);
-		expect(document.body.textContent).toContain("Refresh");
+		expect(document.body.textContent).toContain("Retry loading current setup");
 		expect(document.body.textContent).not.toContain("team_setup_roster_unavailable");
 	});
 
@@ -2889,10 +2881,10 @@ describe("legacy Team setup dialog", () => {
 			confirmedViewerAccessDeltaDigest: "opaque-viewer-access-digest",
 		});
 		expect(
-			document.querySelector<HTMLInputElement>(".legacy-team-setup-confirmation input")?.checked,
-		).toBe(false);
-		expect(document.body.textContent).toContain("Add Sam to Example Team.");
-		expect(button("Finish Team setup").getAttribute("aria-disabled")).toBe("true");
+			document.querySelector<HTMLInputElement>(".legacy-team-setup-confirmation input"),
+		).toBeNull();
+		expect(document.body.textContent).not.toContain("Add Sam to Example Team.");
+		expect(document.body.textContent).toContain("Retry loading current setup");
 	});
 
 	it("treats a stale finish recovery that is already completed as success", async () => {

--- a/packages/ui/src/tabs/legacy-team-setup-focus.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-focus.test.ts
@@ -26,7 +26,7 @@ describe("legacy Team setup focus planning", () => {
 	it("targets the visible recovery control", () => {
 		expect(planLoadFocus(3, { hasError: true, recovery: true, step: "devices" })).toEqual({
 			id: 3,
-			targetId: "legacy-team-setup-refresh",
+			targetId: "legacy-team-setup-retry",
 		});
 		expect(planLoadFocus(4, { hasError: true, step: "devices" })).toEqual({
 			id: 4,

--- a/packages/ui/src/tabs/legacy-team-setup-focus.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-focus.ts
@@ -26,7 +26,7 @@ export function planLoadFocus(
 	return planTargetFocus(
 		id,
 		input.recovery
-			? "legacy-team-setup-refresh"
+			? "legacy-team-setup-retry"
 			: input.hasError
 				? "legacy-team-setup-retry"
 				: `legacy-team-setup-step-${input.step}`,

--- a/packages/ui/src/tabs/legacy-team-setup-session.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.test.ts
@@ -489,7 +489,7 @@ describe("legacy Team setup session reducer", () => {
 		expect(globalError(state)?.retry).toBe("refresh");
 	});
 
-	it("restores failed unavailable recovery focus to the refresh control", () => {
+	it("restores failed unavailable recovery focus to the recovery retry", () => {
 		const unavailable = {
 			...view(),
 			state: "unavailable",
@@ -517,7 +517,7 @@ describe("legacy Team setup session reducer", () => {
 		});
 
 		expect(state).toMatchObject({
-			focus: { targetId: "legacy-team-setup-refresh" },
+			focus: { targetId: "legacy-team-setup-retry" },
 		});
 	});
 

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -76,6 +76,7 @@ import type {
 	RecipientPolicyReviewItemV1,
 	RecipientPolicyReviewListV1,
 } from "../lib/api/sync";
+import { showGlobalNotice } from "../lib/notice";
 import { state } from "../lib/state";
 import * as projectSharing from "./project-sharing";
 import { initProjectsTab, loadProjectsData } from "./projects";
@@ -389,8 +390,8 @@ describe("Projects tab", () => {
 					repairAction: "Assign a stable canonical Project identity.",
 					repair: {
 						kind: "reassign_project",
-						projectIdentity: "unstable-project",
-						label: "Assign Project",
+						projectIdentity: "/workspace/unstable",
+						label: "Repair Project identity…",
 					},
 					version: 1,
 				},
@@ -409,7 +410,8 @@ describe("Projects tab", () => {
 		expect(surface?.textContent).not.toContain("Current access remains in place");
 		expect(surface?.textContent).not.toContain("will continue using");
 		expect(surface?.textContent).toContain("Assign a stable canonical Project identity");
-		expect(surface?.querySelector("button, select")).toBeNull();
+		expect(surface?.textContent).toContain("Owner: Project owner");
+		expect(surface?.querySelector("button")?.textContent).toBe("Repair Project identity…");
 		expect(document.querySelectorAll(".recipient-policy-review-item")).toHaveLength(0);
 	});
 
@@ -797,13 +799,17 @@ describe("Projects tab", () => {
 		expect(document.body.textContent).toContain("2 older sharing findings were not changed");
 	});
 
-	it("renders blocked repair ownership without decision controls", async () => {
+	it("does not offer an unusable repair action for an unmapped Project", async () => {
+		const repairProject = project({
+			identity_source: "unmapped",
+			workspace_identity: "unmapped:unstable",
+		});
 		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
 			has_more: false,
 			limit: 250,
 			offset: 0,
-			projects: [],
-			total: 0,
+			projects: [repairProject],
+			total: 1,
 		});
 		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
 			recipientReview({
@@ -815,9 +821,9 @@ describe("Projects tab", () => {
 						reason: "Codemem requires source-state repair.",
 						repairAction: "Assign a stable canonical Project identity.",
 						repair: {
-							kind: "reassign_project",
-							projectIdentity: "unstable-project",
-							label: "Assign Project",
+							kind: "open_project_administration",
+							projectIdentity: "unmapped:unstable",
+							label: "Open Project administration",
 						},
 						version: 1,
 					},
@@ -831,9 +837,768 @@ describe("Projects tab", () => {
 
 		const blocked = document.querySelector(".recipient-policy-blocked-item");
 		expect(blocked?.textContent).toContain("Blocked");
+		expect(blocked?.textContent).toContain("Assign a stable canonical Project identity.");
 		expect(blocked?.textContent).toContain("Owner: Project owner");
-		expect(blocked?.textContent).toContain("Repair: Assign a stable canonical Project identity.");
-		expect(blocked?.querySelector("button, select")).toBeNull();
+		expect(blocked?.querySelector("button")).toBeNull();
+	});
+
+	it("clears an active status filter before opening a filtered repair target", async () => {
+		const repairProject = project({
+			cwd: "/workspace/filtered-project",
+			display_project: "filtered-project",
+			identity_source: "cwd",
+			project: "filtered-project",
+			workspace_identity: "cwd:/workspace/filtered-project",
+		});
+		const status = document.getElementById("projectsStatusFilter") as HTMLSelectElement;
+		status.append(new Option("Needs attention", "needs_attention"));
+		status.value = "needs_attention";
+		vi.mocked(api.loadProjectScopeInventory).mockImplementation(async (input = {}) => ({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: input.status || input.q !== repairProject.workspace_identity ? [] : [repairProject],
+			total: input.status || input.q !== repairProject.workspace_identity ? 0 : 1,
+		}));
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: [
+					{
+						blockedItemId: "blocked-filtered",
+						finding: "Project identity is unstable.",
+						ownerLabel: "Project owner",
+						reason: "Codemem requires source-state repair.",
+						repairAction: "Assign a stable canonical Project identity.",
+						repair: {
+							kind: "open_project_administration",
+							projectIdentity: repairProject.workspace_identity,
+							label: "Open Project administration",
+						},
+						version: 1,
+					},
+				],
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		document.querySelector<HTMLButtonElement>(".recipient-policy-blocked-item button")?.click();
+
+		await vi.waitFor(() => expect(status.value).toBe(""));
+		expect(document.getElementById("projectsSearch")).toHaveProperty(
+			"value",
+			repairProject.workspace_identity,
+		);
+		expect(
+			document
+				.querySelector<HTMLElement>(
+					`[data-project-workspace-identity="${repairProject.workspace_identity}"]`,
+				)
+				?.querySelector<HTMLDetailsElement>(".project-inventory-details")?.open,
+		).toBe(true);
+	});
+
+	it("queues a second blocked-item repair while navigation is active", async () => {
+		let resolveFirstLookup!: (value: ProjectScopeInventoryResult) => void;
+		const firstLookup = new Promise<ProjectScopeInventoryResult>((resolve) => {
+			resolveFirstLookup = resolve;
+		});
+		vi.mocked(api.loadProjectScopeInventory).mockImplementation((input = {}) => {
+			if (!input.q) {
+				return Promise.resolve({
+					has_more: false,
+					limit: 250,
+					offset: 0,
+					projects: [],
+					total: 0,
+				});
+			}
+			if (input.q === "/workspace/first") return firstLookup;
+			return Promise.resolve({
+				has_more: false,
+				limit: 250,
+				offset: 0,
+				projects: [],
+				total: 0,
+			});
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: ["first", "second"].map((name) => ({
+					blockedItemId: `blocked-${name}`,
+					finding: `Project ${name} identity is unstable.`,
+					ownerLabel: "Project owner",
+					reason: "Codemem requires source-state repair.",
+					repairAction: "Open Project administration.",
+					repair: {
+						kind: "open_project_administration" as const,
+						projectIdentity: `/workspace/${name}`,
+						label: "Open Project administration",
+					},
+					version: 1 as const,
+				})),
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		const repairs = [
+			...document.querySelectorAll<HTMLButtonElement>(".recipient-policy-blocked-item button"),
+		];
+		repairs[0]?.click();
+		repairs[1]?.click();
+		await Promise.resolve();
+
+		expect(
+			vi
+				.mocked(api.loadProjectScopeInventory)
+				.mock.calls.flatMap(([input]) => (input?.q ? [input.q] : [])),
+		).toEqual(["/workspace/first"]);
+
+		resolveFirstLookup({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [],
+			total: 0,
+		});
+		await vi.waitFor(() =>
+			expect(
+				vi
+					.mocked(api.loadProjectScopeInventory)
+					.mock.calls.flatMap(([input]) => (input?.q ? [input.q] : [])),
+			).toEqual(["/workspace/first", "/workspace/second"]),
+		);
+		await flushAsyncWork();
+	});
+
+	it("drops queued repairs superseded by later user navigation", async () => {
+		let resolveFirstLookup!: (value: ProjectScopeInventoryResult) => void;
+		const firstLookup = new Promise<ProjectScopeInventoryResult>((resolve) => {
+			resolveFirstLookup = resolve;
+		});
+		const repairQueries: string[] = [];
+		vi.mocked(api.loadProjectScopeInventory).mockImplementation((input = {}) => {
+			if (input.q?.startsWith("/workspace/")) repairQueries.push(input.q);
+			if (input.q === "/workspace/first") return firstLookup;
+			return Promise.resolve({
+				has_more: false,
+				limit: 250,
+				offset: 0,
+				projects: [],
+				total: 0,
+			});
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: ["first", "second"].map((name) => ({
+					blockedItemId: `blocked-${name}`,
+					finding: `Project ${name} identity is unstable.`,
+					ownerLabel: "Project owner",
+					reason: "Codemem requires source-state repair.",
+					repairAction: "Open Project administration.",
+					repair: {
+						kind: "open_project_administration" as const,
+						projectIdentity: `/workspace/${name}`,
+						label: "Open Project administration",
+					},
+					version: 1 as const,
+				})),
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		initProjectsTab(() => {
+			void loadProjectsData();
+		});
+		const repairs = [
+			...document.querySelectorAll<HTMLButtonElement>(".recipient-policy-blocked-item button"),
+		];
+		repairs[0]?.click();
+		repairs[1]?.click();
+		await vi.waitFor(() => expect(repairQueries).toEqual(["/workspace/first"]));
+
+		const search = document.getElementById("projectsSearch") as HTMLInputElement;
+		search.value = "user-query";
+		search.dispatchEvent(new Event("input"));
+		resolveFirstLookup({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [],
+			total: 0,
+		});
+		await flushAsyncWork();
+
+		expect(repairQueries).toEqual(["/workspace/first"]);
+		expect(search.value).toBe("user-query");
+	});
+
+	it("defers repair while a Space assignment control is active", async () => {
+		const repairProject = project({ workspace_identity: "/workspace/repair-target" });
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [repairProject],
+			total: 1,
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: [
+					{
+						blockedItemId: "blocked-active-space",
+						finding: "Project identity is unstable.",
+						ownerLabel: "Project owner",
+						reason: "Codemem requires source-state repair.",
+						repairAction: "Open Project administration.",
+						repair: {
+							kind: "open_project_administration",
+							projectIdentity: repairProject.workspace_identity,
+							label: "Open Project administration",
+						},
+						version: 1,
+					},
+				],
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		const activeSelect = document.createElement("select");
+		activeSelect.className = "project-domain-select";
+		document.body.appendChild(activeSelect);
+		activeSelect.focus();
+		document.querySelector<HTMLButtonElement>(".recipient-policy-blocked-item button")?.click();
+
+		await vi.waitFor(() =>
+			expect(showGlobalNotice).toHaveBeenCalledWith(
+				"Finish the open Space assignment, then try Repair again.",
+				"warning",
+			),
+		);
+	});
+
+	it("preserves newer filter edits when repair navigation is superseded", async () => {
+		const projectIdentity = "/workspace/repair-target";
+		const repairProject = project({ workspace_identity: projectIdentity });
+		let resolveRepairLoad!: (value: ProjectScopeInventoryResult) => void;
+		const repairLoad = new Promise<ProjectScopeInventoryResult>((resolve) => {
+			resolveRepairLoad = resolve;
+		});
+		let repairQueryCount = 0;
+		vi.mocked(api.loadProjectScopeInventory).mockImplementation((input = {}) => {
+			if (input.q === projectIdentity) {
+				repairQueryCount += 1;
+				if (repairQueryCount === 1) {
+					return Promise.resolve({
+						has_more: false,
+						limit: 250,
+						offset: 0,
+						projects: [repairProject],
+						total: 1,
+					});
+				}
+				return repairLoad;
+			}
+			return Promise.resolve({
+				has_more: false,
+				limit: 250,
+				offset: 0,
+				projects: [],
+				total: 0,
+			});
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: [
+					{
+						blockedItemId: "blocked-superseded-navigation",
+						finding: "Project identity is unstable.",
+						ownerLabel: "Project owner",
+						reason: "Codemem requires source-state repair.",
+						repairAction: "Open Project administration.",
+						repair: {
+							kind: "open_project_administration",
+							projectIdentity,
+							label: "Open Project administration",
+						},
+						version: 1,
+					},
+				],
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		document.querySelector<HTMLButtonElement>(".recipient-policy-blocked-item button")?.click();
+		await vi.waitFor(() => expect(repairQueryCount).toBe(2));
+
+		const search = document.getElementById("projectsSearch") as HTMLInputElement;
+		search.value = "user-query";
+		await loadProjectsData();
+		resolveRepairLoad({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [repairProject],
+			total: 1,
+		});
+		await flushAsyncWork();
+
+		expect(search.value).toBe("user-query");
+	});
+
+	it("preserves newer filter edits made during repair target lookup", async () => {
+		const projectIdentity = "/workspace/slow-repair-target";
+		const repairProject = project({ workspace_identity: projectIdentity });
+		let resolveLookup!: (value: ProjectScopeInventoryResult) => void;
+		const lookup = new Promise<ProjectScopeInventoryResult>((resolve) => {
+			resolveLookup = resolve;
+		});
+		let repairQueryCount = 0;
+		vi.mocked(api.loadProjectScopeInventory).mockImplementation((input = {}) => {
+			if (input.q === projectIdentity) {
+				repairQueryCount += 1;
+				if (repairQueryCount === 1) return lookup;
+			}
+			return Promise.resolve({
+				has_more: false,
+				limit: 250,
+				offset: 0,
+				projects: input.q === projectIdentity ? [repairProject] : [],
+				total: input.q === projectIdentity ? 1 : 0,
+			});
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: [
+					{
+						blockedItemId: "blocked-slow-lookup",
+						finding: "Project identity is unstable.",
+						ownerLabel: "Project owner",
+						reason: "Codemem requires source-state repair.",
+						repairAction: "Open Project administration.",
+						repair: {
+							kind: "open_project_administration",
+							projectIdentity,
+							label: "Open Project administration",
+						},
+						version: 1,
+					},
+				],
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		document.querySelector<HTMLButtonElement>(".recipient-policy-blocked-item button")?.click();
+		await vi.waitFor(() => expect(repairQueryCount).toBe(1));
+
+		const search = document.getElementById("projectsSearch") as HTMLInputElement;
+		search.value = "user-query";
+		await loadProjectsData();
+		resolveLookup({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [repairProject],
+			total: 1,
+		});
+		await flushAsyncWork();
+
+		expect(search.value).toBe("user-query");
+		expect(repairQueryCount).toBe(1);
+	});
+
+	it("continues repair target lookup across a background inventory refresh", async () => {
+		const projectIdentity = "/workspace/background-refresh-target";
+		const repairProject = project({ workspace_identity: projectIdentity });
+		let resolveLookup!: (value: ProjectScopeInventoryResult) => void;
+		const lookup = new Promise<ProjectScopeInventoryResult>((resolve) => {
+			resolveLookup = resolve;
+		});
+		let repairQueryCount = 0;
+		vi.mocked(api.loadProjectScopeInventory).mockImplementation((input = {}) => {
+			if (input.q === projectIdentity) {
+				repairQueryCount += 1;
+				if (repairQueryCount === 1) return lookup;
+				return Promise.resolve({
+					has_more: false,
+					limit: 250,
+					offset: 0,
+					projects: [repairProject],
+					total: 1,
+				});
+			}
+			return Promise.resolve({
+				has_more: false,
+				limit: 250,
+				offset: 0,
+				projects: [],
+				total: 0,
+			});
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: [
+					{
+						blockedItemId: "blocked-background-refresh",
+						finding: "Project identity is unstable.",
+						ownerLabel: "Project owner",
+						reason: "Codemem requires source-state repair.",
+						repairAction: "Open Project administration.",
+						repair: {
+							kind: "open_project_administration",
+							projectIdentity,
+							label: "Open Project administration",
+						},
+						version: 1,
+					},
+				],
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		document.querySelector<HTMLButtonElement>(".recipient-policy-blocked-item button")?.click();
+		await vi.waitFor(() => expect(repairQueryCount).toBe(1));
+		await loadProjectsData();
+		resolveLookup({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [repairProject],
+			total: 1,
+		});
+
+		await vi.waitFor(() => expect(repairQueryCount).toBe(2));
+		await vi.waitFor(() =>
+			expect(
+				document
+					.querySelector<HTMLElement>(`[data-project-workspace-identity="${projectIdentity}"]`)
+					?.querySelector<HTMLDetailsElement>(".project-inventory-details")?.open,
+			).toBe(true),
+		);
+	});
+
+	it("pages identity search until it renders the exact repair target", async () => {
+		const repairProject = project({
+			display_project: "app",
+			project: "app",
+			workspace_identity: "/workspace/app",
+		});
+		const prefixMatch = project({
+			display_project: "nested-app",
+			project: "nested-app",
+			workspace_identity: "/workspace/app/nested",
+		});
+		const peerExactMatch = project({
+			read_only: true,
+			read_only_reason: "peer_received",
+			session_count: 0,
+			workspace_identity: repairProject.workspace_identity,
+		});
+		vi.mocked(api.loadProjectScopeInventory).mockImplementation(async (input = {}) => {
+			if (!input.q) {
+				return {
+					has_more: false,
+					limit: 250,
+					offset: 0,
+					projects: [peerExactMatch],
+					total: 1,
+				};
+			}
+			if ((input.offset ?? 0) === 0) {
+				return {
+					has_more: true,
+					limit: 250,
+					offset: 0,
+					projects: [prefixMatch, peerExactMatch],
+					total: 250,
+				};
+			}
+			return {
+				has_more: false,
+				limit: 250,
+				offset: 250,
+				projects: [repairProject],
+				total: 250,
+			};
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: [
+					{
+						blockedItemId: "blocked-paginated",
+						finding: "Project identity is unstable.",
+						ownerLabel: "Project owner",
+						reason: "Codemem requires source-state repair.",
+						repairAction: "Assign a stable canonical Project identity.",
+						repair: {
+							kind: "open_project_administration",
+							projectIdentity: repairProject.workspace_identity,
+							label: "Open Project administration",
+						},
+						version: 1,
+					},
+				],
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		document.querySelector<HTMLButtonElement>(".recipient-policy-blocked-item button")?.click();
+
+		await vi.waitFor(() =>
+			expect(
+				document
+					.querySelector<HTMLElement>(
+						`[data-project-workspace-identity="${repairProject.workspace_identity}"]`,
+					)
+					?.querySelector<HTMLDetailsElement>(".project-inventory-details")?.open,
+			).toBe(true),
+		);
+		expect(api.loadProjectScopeInventory).toHaveBeenCalledWith({
+			limit: 250,
+			offset: 0,
+			q: repairProject.workspace_identity,
+		});
+		expect(api.loadProjectScopeInventory).toHaveBeenCalledWith(
+			expect.objectContaining({ offset: 250, q: repairProject.workspace_identity }),
+		);
+	});
+
+	it("stops repair lookup when paginated search does not advance", async () => {
+		const projectIdentity = "/workspace/app";
+		vi.mocked(api.loadProjectScopeInventory).mockImplementation(async (input = {}) => {
+			if (!input.q) {
+				return { has_more: false, limit: 250, offset: 0, projects: [], total: 0 };
+			}
+			return {
+				has_more: true,
+				limit: 250,
+				offset: 0,
+				projects:
+					(input.offset ?? 0) === 0
+						? [project({ workspace_identity: `${projectIdentity}/nested` })]
+						: [],
+				total: 500,
+			};
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: [
+					{
+						blockedItemId: "blocked-stalled-pagination",
+						finding: "Project identity is unstable.",
+						ownerLabel: "Project owner",
+						reason: "Codemem requires source-state repair.",
+						repairAction: "Assign a stable canonical Project identity.",
+						repair: {
+							kind: "open_project_administration",
+							projectIdentity,
+							label: "Open Project administration",
+						},
+						version: 1,
+					},
+				],
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		document.querySelector<HTMLButtonElement>(".recipient-policy-blocked-item button")?.click();
+
+		await vi.waitFor(() =>
+			expect(showGlobalNotice).toHaveBeenCalledWith(
+				"This Project is not visible in the current inventory. Refresh Projects, then try Repair again.",
+				"warning",
+			),
+		);
+		expect(
+			vi
+				.mocked(api.loadProjectScopeInventory)
+				.mock.calls.map(([input]) => input)
+				.filter((input) => input?.q === projectIdentity),
+		).toEqual([
+			{ limit: 250, offset: 0, q: projectIdentity },
+			{ limit: 250, offset: 250, q: projectIdentity },
+		]);
+	});
+
+	it("opens the local repairable row when a peer row shares its reserved identity", async () => {
+		const workspaceIdentity = "peer-received:collision";
+		const localProject = project({ workspace_identity: workspaceIdentity });
+		const peerProject = project({
+			read_only: true,
+			read_only_reason: "peer_received",
+			session_count: 0,
+			workspace_identity: workspaceIdentity,
+		});
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [localProject, peerProject],
+			total: 2,
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: [
+					{
+						blockedItemId: "blocked-collision",
+						finding: "Project administration needs attention.",
+						ownerLabel: "Project owner",
+						reason: "Codemem requires source-state repair.",
+						repairAction: "Open the local Project administration controls.",
+						repair: {
+							kind: "open_project_administration",
+							projectIdentity: workspaceIdentity,
+							label: "Open Project administration",
+						},
+						version: 1,
+					},
+				],
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		document.querySelector<HTMLButtonElement>(".recipient-policy-blocked-item button")?.click();
+
+		const currentRows = () => [
+			...document.querySelectorAll<HTMLElement>(
+				`[data-project-workspace-identity="${workspaceIdentity}"]`,
+			),
+		];
+		expect(currentRows()).toHaveLength(2);
+		await vi.waitFor(() => {
+			const rows = currentRows();
+			expect(
+				rows.find((row) => row.dataset.projectRepairable === "true")?.querySelector("details")
+					?.open,
+			).toBe(true);
+			expect(
+				rows
+					.find((row) => row.dataset.projectRepairable === "true")
+					?.contains(document.activeElement),
+			).toBe(true);
+		});
+		expect(
+			currentRows()
+				.find((row) => row.dataset.projectRepairable === "false")
+				?.querySelector("details")?.open,
+		).toBe(false);
+
+		await loadProjectsData();
+
+		expect(
+			currentRows()
+				.find((row) => row.dataset.projectRepairable === "true")
+				?.contains(document.activeElement),
+		).toBe(true);
+	});
+
+	it("opens the containing cluster before focusing a duplicate-name repair target", async () => {
+		const repairProject = project({
+			cwd: "/workspace/repair-target",
+			display_project: "duplicate-repair",
+			git_remote: "https://git.example.invalid/exampleco/duplicate-repair.git",
+			project: "duplicate-repair",
+			workspace_identity: "cwd:/workspace/repair-target",
+		});
+		const duplicateNameProject = project({
+			cwd: "/workspace/duplicate-name",
+			display_project: "duplicate-repair",
+			git_remote: "https://git.example.invalid/exampleco/duplicate-repair.git",
+			project: "duplicate-repair",
+			workspace_identity: "git:https://git.example.invalid/exampleco/duplicate-name.git",
+		});
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [repairProject, duplicateNameProject],
+			total: 2,
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: [
+					{
+						blockedItemId: "blocked-clustered",
+						finding: "Project identity is unstable.",
+						ownerLabel: "Project owner",
+						reason: "Codemem requires source-state repair.",
+						repairAction: "Assign a stable canonical Project identity.",
+						repair: {
+							kind: "open_project_administration",
+							projectIdentity: repairProject.workspace_identity,
+							label: "Open Project administration",
+						},
+						version: 1,
+					},
+				],
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		const clusterDetails = document.querySelector<HTMLDetailsElement>(
+			".project-inventory-cluster > .project-inventory-details",
+		);
+		expect(clusterDetails?.open).toBe(false);
+
+		document.querySelector<HTMLButtonElement>(".recipient-policy-blocked-item button")?.click();
+
+		await vi.waitFor(() =>
+			expect(
+				document.querySelector<HTMLDetailsElement>(
+					".project-inventory-cluster > .project-inventory-details",
+				)?.open,
+			).toBe(true),
+		);
+		const repairRow = document.querySelector<HTMLElement>(
+			`[data-project-workspace-identity="${repairProject.workspace_identity}"]`,
+		);
+		expect(repairRow?.querySelector<HTMLDetailsElement>(".project-inventory-details")?.open).toBe(
+			true,
+		);
+		expect(repairRow?.contains(document.activeElement)).toBe(true);
+		expect(
+			document
+				.querySelector<HTMLElement>(
+					`[data-project-workspace-identity="${duplicateNameProject.workspace_identity}"]`,
+				)
+				?.querySelector<HTMLDetailsElement>(".project-inventory-details")?.open,
+		).toBe(false);
+
+		await loadProjectsData();
+
+		const rerenderedRepairRow = document.querySelector<HTMLElement>(
+			`[data-project-workspace-identity="${repairProject.workspace_identity}"]`,
+		);
+		expect(
+			document.querySelector<HTMLDetailsElement>(
+				".project-inventory-cluster > .project-inventory-details",
+			)?.open,
+		).toBe(true);
+		expect(
+			rerenderedRepairRow?.querySelector<HTMLDetailsElement>(".project-inventory-details")?.open,
+		).toBe(true);
+		expect(rerenderedRepairRow?.contains(document.activeElement)).toBe(true);
 	});
 
 	it("opens row sharing with exactly the selected canonical project", async () => {
@@ -1073,6 +1838,61 @@ describe("Projects tab", () => {
 			document.getElementById("projectShareFlowMount"),
 			[],
 			{ inventoryError: true },
+		);
+	});
+
+	it("does not reuse cached repair targets after an inventory load fails", async () => {
+		const repairProject = project({ workspace_identity: "/workspace/stale-repair-target" });
+		let failNextPrimaryLoad = false;
+		vi.mocked(api.loadProjectScopeInventory).mockImplementation(async (input = {}) => {
+			if (failNextPrimaryLoad && !input.q) {
+				failNextPrimaryLoad = false;
+				throw new Error("inventory unavailable");
+			}
+			return {
+				has_more: false,
+				limit: 250,
+				offset: 0,
+				projects: input.q ? [] : [repairProject],
+				total: input.q ? 0 : 1,
+			};
+		});
+		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue(
+			recipientReview({
+				blockedItems: [
+					{
+						blockedItemId: "blocked-stale-cache",
+						finding: "Project identity is unstable.",
+						ownerLabel: "Project owner",
+						reason: "Codemem requires source-state repair.",
+						repairAction: "Open Project administration.",
+						repair: {
+							kind: "open_project_administration",
+							projectIdentity: repairProject.workspace_identity,
+							label: "Open Project administration",
+						},
+						version: 1,
+					},
+				],
+				continuity: null,
+				reviewItems: [],
+			}),
+		);
+
+		await loadProjectsData();
+		failNextPrimaryLoad = true;
+		await loadProjectsData();
+		document.querySelector<HTMLButtonElement>(".recipient-policy-blocked-item button")?.click();
+
+		await vi.waitFor(() =>
+			expect(showGlobalNotice).toHaveBeenCalledWith(
+				"This Project is not visible in the current inventory. Refresh Projects, then try Repair again.",
+				"warning",
+			),
+		);
+		expect(showGlobalNotice).not.toHaveBeenCalledWith(
+			"Project administration could not be opened. Refresh Projects and try again.",
+			"warning",
 		);
 	});
 

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -3,6 +3,7 @@ import type {
 	LegacyTeamSetupSummaryResponseV1,
 	ProjectScopeGuardrailWarning,
 	ProjectScopeInventoryProject,
+	RecipientPolicyBlockedItemV1,
 	RecipientPolicyIntentGraphV1,
 	SharingDomainScope,
 } from "../lib/api/sync";
@@ -39,6 +40,7 @@ const STATUS_OPTIONS = [
 let refreshProjects: RefreshFn | null = null;
 let currentOffset = 0;
 const lastLimit = 250;
+const maxRepairLookupPages = 100;
 let scopes: SharingDomainScope[] = [];
 const openProjectDetails = new Set<string>();
 const openProjectClusters = new Set<string>();
@@ -53,10 +55,13 @@ const pendingForgetConfirmations = new Map<
 	{ confirmationToken: string; localOwnedMemoryCount: number; peerOwnedMemoryCount: number }
 >();
 let skippedProjectRefreshForActiveSelect = false;
+const projectInventoryByIdentity = new Map<string, ProjectScopeInventoryProject>();
 let coordinatorGroupNamesCurrent = false;
 let projectShareInventoryReady = false;
 let projectsLoadGeneration = 0;
+let projectsUserNavigationGeneration = 0;
 let teamSetupEntryLoadGeneration = 0;
+let recipientPolicyRepairInFlight: Promise<void> | null = null;
 type TeamSetupSummaryResult =
 	| { ok: true; summary: LegacyTeamSetupSummaryResponseV1 }
 	| { ok: false };
@@ -115,6 +120,13 @@ function isPeerReceivedProject(project: ProjectScopeInventoryProject): boolean {
 
 function isLocallyAssignableProject(project: ProjectScopeInventoryProject): boolean {
 	return project.identity_source !== "unmapped" && !isPeerReceivedProject(project);
+}
+
+function cacheProjectInventoryProject(project: ProjectScopeInventoryProject): void {
+	const existing = projectInventoryByIdentity.get(project.workspace_identity);
+	if (!existing || (isPeerReceivedProject(existing) && !isPeerReceivedProject(project))) {
+		projectInventoryByIdentity.set(project.workspace_identity, project);
+	}
 }
 
 function projectDomainLabel(project: ProjectScopeInventoryProject): string {
@@ -677,6 +689,166 @@ async function reassignProject(project: ProjectScopeInventoryProject) {
 	}
 }
 
+async function projectForRepair(
+	projectIdentity: string,
+): Promise<{ offset: number; project: ProjectScopeInventoryProject } | null> {
+	const cached = projectInventoryByIdentity.get(projectIdentity);
+	if (cached && !isPeerReceivedProject(cached)) return { offset: currentOffset, project: cached };
+	try {
+		let offset = 0;
+		let pagesScanned = 0;
+		while (true) {
+			const result = await api.loadProjectScopeInventory({
+				limit: lastLimit,
+				offset,
+				q: projectIdentity,
+			});
+			pagesScanned += 1;
+			const project = result.projects.find(
+				(candidate) =>
+					candidate.workspace_identity === projectIdentity && !isPeerReceivedProject(candidate),
+			);
+			if (project) return { offset: result.offset, project };
+			if (!result.has_more || result.limit <= 0) return null;
+			const nextOffset = result.offset + result.limit;
+			if (nextOffset <= offset || pagesScanned >= maxRepairLookupPages) return null;
+			offset = nextOffset;
+		}
+	} catch {
+		return null;
+	}
+}
+
+function focusProjectAdministration(projectIdentity: string): boolean {
+	const row = [...document.querySelectorAll<HTMLElement>("[data-project-workspace-identity]")].find(
+		(candidate) =>
+			candidate.dataset.projectWorkspaceIdentity === projectIdentity &&
+			candidate.dataset.projectRepairable === "true",
+	);
+	if (!row) return false;
+	const details = row.querySelector<HTMLDetailsElement>(".project-inventory-details");
+	if (!details) return false;
+	const cluster = row.closest<HTMLElement>(".project-inventory-cluster");
+	const clusterDetails = cluster?.querySelector<HTMLDetailsElement>(
+		":scope > .project-inventory-details",
+	);
+	if (clusterDetails) {
+		clusterDetails.open = true;
+		const clusterKey = cluster?.dataset.projectClusterKey;
+		if (clusterKey) openProjectClusters.add(clusterKey);
+	}
+	details.open = true;
+	openProjectDetails.add(`${row.dataset.projectRepairable}:${projectIdentity}`);
+	details.scrollIntoView?.({ block: "center", behavior: "smooth" });
+	details.querySelector<HTMLElement>("summary")?.focus();
+	return true;
+}
+
+async function performRecipientPolicyRepair(
+	repair: RecipientPolicyBlockedItemV1["repair"],
+): Promise<void> {
+	if (isProjectSpaceSelectActive()) {
+		showGlobalNotice("Finish the open Space assignment, then try Repair again.", "warning");
+		return;
+	}
+	const lookupUserNavigationGeneration = projectsUserNavigationGeneration;
+	const lookupSearch = el<HTMLInputElement>("projectsSearch")?.value ?? "";
+	const lookupStatus = el<HTMLSelectElement>("projectsStatusFilter")?.value ?? "";
+	const lookupOffset = currentOffset;
+	const target = await projectForRepair(repair.projectIdentity);
+	if (
+		projectsUserNavigationGeneration !== lookupUserNavigationGeneration ||
+		(el<HTMLInputElement>("projectsSearch")?.value ?? "") !== lookupSearch ||
+		(el<HTMLSelectElement>("projectsStatusFilter")?.value ?? "") !== lookupStatus ||
+		currentOffset !== lookupOffset
+	) {
+		return;
+	}
+	if (isProjectSpaceSelectActive()) {
+		showGlobalNotice("Finish the open Space assignment, then try Repair again.", "warning");
+		return;
+	}
+	if (!target) {
+		showGlobalNotice(
+			"This Project is not visible in the current inventory. Refresh Projects, then try Repair again.",
+			"warning",
+		);
+		return;
+	}
+	const { project } = target;
+	if (repair.kind === "reassign_project") {
+		if (project.identity_source === "unmapped" || project.session_count === 0) {
+			showGlobalNotice(
+				"This Project cannot be reassigned yet because it has no local sessions with stable source evidence.",
+				"warning",
+			);
+			return;
+		}
+		await reassignProject(project);
+		return;
+	}
+	if (!focusProjectAdministration(project.workspace_identity)) {
+		const search = el<HTMLInputElement>("projectsSearch");
+		const previousSearch = search?.value ?? "";
+		const repairSearch = project.workspace_identity;
+		if (search) search.value = repairSearch;
+		const status = el<HTMLSelectElement>("projectsStatusFilter");
+		const previousStatus = status?.value ?? "";
+		const repairStatus = "";
+		if (status) status.value = repairStatus;
+		const previousOffset = currentOffset;
+		currentOffset = target.offset;
+		const repairUserNavigationGeneration = projectsUserNavigationGeneration;
+		const repairLoad = loadProjectsData();
+		await repairLoad;
+		if (!focusProjectAdministration(project.workspace_identity)) {
+			if (
+				projectsUserNavigationGeneration !== repairUserNavigationGeneration ||
+				(search && search.value !== repairSearch) ||
+				(status && status.value !== repairStatus) ||
+				currentOffset !== target.offset
+			) {
+				return;
+			}
+			if (search) search.value = previousSearch;
+			if (status) status.value = previousStatus;
+			currentOffset = previousOffset;
+			await loadProjectsData();
+			showGlobalNotice(
+				"Project administration could not be opened. Refresh Projects and try again.",
+				"warning",
+			);
+		}
+	}
+}
+
+function repairRecipientPolicyItem(repair: RecipientPolicyBlockedItemV1["repair"]): Promise<void> {
+	const requestedNavigationGeneration = projectsUserNavigationGeneration;
+	const operation = (
+		recipientPolicyRepairInFlight?.catch(() => undefined) ?? Promise.resolve()
+	).then(async () => {
+		if (projectsUserNavigationGeneration !== requestedNavigationGeneration) return;
+		try {
+			await performRecipientPolicyRepair(repair);
+		} catch (error) {
+			showGlobalNotice(
+				error instanceof Error ? error.message : "Unable to repair this Project.",
+				"warning",
+			);
+		}
+	});
+	recipientPolicyRepairInFlight = operation;
+	operation.then(
+		() => {
+			if (recipientPolicyRepairInFlight === operation) recipientPolicyRepairInFlight = null;
+		},
+		() => {
+			if (recipientPolicyRepairInFlight === operation) recipientPolicyRepairInFlight = null;
+		},
+	);
+	return operation;
+}
+
 function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElement {
 	const actions = document.createElement("div");
 	actions.className = "project-inventory-actions";
@@ -864,6 +1036,8 @@ function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElemen
 function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 	const row = document.createElement("article");
 	row.className = "project-inventory-row";
+	row.dataset.projectWorkspaceIdentity = project.workspace_identity;
+	row.dataset.projectRepairable = String(isLocallyAssignableProject(project));
 	const titleId = `project-title-${project.workspace_identity.replace(/[^a-z0-9_-]/gi, "-")}`;
 	row.setAttribute("aria-labelledby", titleId);
 	const header = document.createElement("div");
@@ -969,12 +1143,14 @@ function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 
 	const detail = document.createElement("details");
 	detail.className = "project-inventory-details";
-	detail.open = openProjectDetails.has(project.workspace_identity);
+	const detailKey = `${row.dataset.projectRepairable}:${project.workspace_identity}`;
+	detail.open = openProjectDetails.has(detailKey);
 	detail.addEventListener("toggle", () => {
-		if (detail.open) openProjectDetails.add(project.workspace_identity);
-		else openProjectDetails.delete(project.workspace_identity);
+		if (detail.open) openProjectDetails.add(detailKey);
+		else openProjectDetails.delete(detailKey);
 	});
 	const summary = document.createElement("summary");
+	summary.dataset.projectFocusKey = `admin:${row.dataset.projectRepairable}:${project.workspace_identity}`;
 	summary.textContent =
 		warnings.length > 0
 			? `Advanced Project administration — ${warnings.length.toLocaleString()} item${warnings.length === 1 ? "" : "s"} need attention`
@@ -1025,6 +1201,7 @@ function renderProjectCluster(projects: ProjectScopeInventoryProject[]): HTMLEle
 	const projectIds = uniqueProjectIds(manageableProjects);
 	const row = document.createElement("article");
 	row.className = "project-inventory-row project-inventory-cluster";
+	row.dataset.projectClusterKey = clusterKey;
 	const clusterLabel = projectClusterLabel(projects[0]);
 	const titleId = `project-cluster-title-${clusterKey.replace(/[^a-z0-9_-]/gi, "-")}`;
 	row.setAttribute("aria-labelledby", titleId);
@@ -1205,6 +1382,10 @@ function renderProjectInventory(result: {
 			? document.activeElement.dataset.projectFocusKey
 			: undefined;
 	hideProjectInventorySkeleton();
+	projectInventoryByIdentity.clear();
+	for (const project of result.projects) {
+		cacheProjectInventoryProject(project);
+	}
 	list.textContent = "";
 	if (result.projects.length === 0) {
 		renderEmpty("No projects match those filters.");
@@ -1460,7 +1641,10 @@ export async function loadProjectsData(options: ProjectsDataLoadOptions = {}) {
 		if (reviewMount) {
 			const reviewContent = recipientPolicyReviewContentMount(reviewMount);
 			if ("review" in recipientPolicyReview) {
-				renderRecipientPolicyReview(reviewContent, recipientPolicyReview.review);
+				renderRecipientPolicyReview(reviewContent, recipientPolicyReview.review, {
+					isRepairAvailable: (repair) => !repair.projectIdentity.startsWith("unmapped:"),
+					onRepair: repairRecipientPolicyItem,
+				});
 			} else {
 				renderRecipientPolicyReviewLoadError(reviewContent, recipientPolicyReview.error);
 			}
@@ -1502,6 +1686,7 @@ export async function loadProjectsData(options: ProjectsDataLoadOptions = {}) {
 		return requiredLoadSucceeded && teamSetupSummary.ok;
 	} catch (error) {
 		if (loadGeneration !== projectsLoadGeneration) return false;
+		projectInventoryByIdentity.clear();
 		projectShareInventoryReady = false;
 		recipientPolicyIntentReady = false;
 		recipientPolicyIntent = emptyRecipientPolicyIntent;
@@ -1533,16 +1718,19 @@ export function initProjectsTab(
 		}
 	}
 	const requestRefresh = () => {
+		projectsUserNavigationGeneration += 1;
 		currentOffset = 0;
 		refreshProjects?.();
 	};
 	el<HTMLInputElement>("projectsSearch")?.addEventListener("input", requestRefresh);
 	status?.addEventListener("change", requestRefresh);
 	el<HTMLButtonElement>("projectsPrevPage")?.addEventListener("click", () => {
+		projectsUserNavigationGeneration += 1;
 		currentOffset = Math.max(0, currentOffset - lastLimit);
 		refreshProjects?.();
 	});
 	el<HTMLButtonElement>("projectsNextPage")?.addEventListener("click", () => {
+		projectsUserNavigationGeneration += 1;
 		currentOffset += lastLimit;
 		refreshProjects?.();
 	});

--- a/packages/ui/src/tabs/recipient-policy-management.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-management.test.tsx
@@ -540,11 +540,11 @@ describe("recipient policy management dialog", () => {
 		const labels = [...document.querySelectorAll(".recipient-policy-management-name")].map(
 			(label) => label.textContent,
 		);
-		expect(labels).toEqual(["codemem — Project 2 of 2", "codemem — Project 1 of 2"]);
+		expect(labels).toEqual(["codemem — duplicate name 2 of 2", "codemem — duplicate name 1 of 2"]);
 		expect(document.body.outerHTML).not.toContain(privatePath);
 		expect(document.body.outerHTML).not.toContain(privateRemote);
 
-		act(() => checkbox("codemem — Project 1 of 2").click());
+		act(() => checkbox("codemem — duplicate name 1 of 2").click());
 		await reviewSelection();
 
 		expect(api.previewRecipientPolicyEdges).toHaveBeenCalledWith({
@@ -558,7 +558,7 @@ describe("recipient policy management dialog", () => {
 			],
 		});
 		expect(document.body.textContent).toContain(
-			"codemem — Project 1 of 2 — Access changes affect 1 existing memories",
+			"codemem — duplicate name 1 of 2 — Access changes affect 1 existing memories",
 		);
 		expect(document.body.outerHTML).not.toContain(privatePath);
 		expect(document.body.outerHTML).not.toContain(privateRemote);
@@ -1034,7 +1034,7 @@ describe("recipient policy management dialog", () => {
 
 	it("marks long Project, Team, Identity, member, and device names as wrappable", async () => {
 		const longProject = "Project-with-a-very-long-unbroken-name-that-must-wrap";
-		const longProjectLabel = `${longProject} — Project 1 of 2`;
+		const longProjectLabel = `${longProject} — duplicate name 1 of 2`;
 		const longTeam = "Team-with-a-very-long-unbroken-name-that-must-wrap";
 		const longIdentity = "Identity-with-a-very-long-unbroken-name-that-must-wrap";
 		const longMember = "Member-with-a-very-long-unbroken-name-that-must-wrap";

--- a/packages/ui/src/tabs/recipient-policy-review.ts
+++ b/packages/ui/src/tabs/recipient-policy-review.ts
@@ -9,7 +9,15 @@ function paragraph(text: string, className = ""): HTMLParagraphElement {
 	return node;
 }
 
-function renderBlockedItem(item: RecipientPolicyBlockedItemV1): HTMLElement {
+export interface RecipientPolicyReviewRenderOptions {
+	isRepairAvailable?: (repair: RecipientPolicyBlockedItemV1["repair"]) => boolean;
+	onRepair?: (repair: RecipientPolicyBlockedItemV1["repair"]) => Promise<void> | void;
+}
+
+function renderBlockedItem(
+	item: RecipientPolicyBlockedItemV1,
+	options: RecipientPolicyReviewRenderOptions,
+): HTMLElement {
 	const card = document.createElement("article");
 	card.className = "project-inventory-row recipient-policy-blocked-item";
 	const heading = document.createElement("div");
@@ -21,20 +29,44 @@ function renderBlockedItem(item: RecipientPolicyBlockedItemV1): HTMLElement {
 	badge.className = "project-status-badge needs_attention";
 	badge.textContent = "Blocked";
 	heading.append(finding, badge);
+	const repairHelp = paragraph(item.repairAction, "settings-note");
+	repairHelp.id = `recipient-policy-repair-help-${item.blockedItemId}`;
 	card.append(
 		heading,
 		paragraph(item.reason, "project-inventory-meta"),
+		repairHelp,
 		paragraph(`Owner: ${item.ownerLabel}`, "settings-note"),
-		paragraph(`Repair: ${item.repairAction}`, "settings-note"),
 	);
+	if (options.onRepair && (options.isRepairAvailable?.(item.repair) ?? true)) {
+		const repair = document.createElement("button");
+		repair.className = "settings-button";
+		repair.type = "button";
+		repair.textContent = item.repair.label;
+		repair.setAttribute("aria-describedby", repairHelp.id);
+		repair.addEventListener("click", async () => {
+			repair.disabled = true;
+			try {
+				await options.onRepair?.(item.repair);
+			} finally {
+				repair.disabled = false;
+			}
+		});
+		card.appendChild(repair);
+	} else {
+		card.appendChild(paragraph("Open Projects to repair this item.", "settings-note"));
+	}
 	return card;
 }
 
 export function renderRecipientPolicyReview(
 	mount: HTMLElement,
 	review: RecipientPolicyReviewListV1,
+	options: RecipientPolicyReviewRenderOptions = {},
 ): void {
-	const signature = `review:${JSON.stringify(review)}`;
+	const repairAvailability = review.blockedItems.map((item) =>
+		options.onRepair && (options.isRepairAvailable?.(item.repair) ?? true) ? "1" : "0",
+	);
+	const signature = `review:${repairAvailability.join("")}:${JSON.stringify(review)}`;
 	if (renderedReviewSignatures.get(mount) === signature) return;
 	if (!review.continuity && review.blockedItems.length === 0) {
 		mount.replaceChildren();
@@ -82,7 +114,7 @@ export function renderRecipientPolicyReview(
 		heading.textContent = "Needs repair";
 		const list = document.createElement("div");
 		list.className = "project-inventory-list recipient-policy-review-list";
-		for (const item of review.blockedItems) list.appendChild(renderBlockedItem(item));
+		for (const item of review.blockedItems) list.appendChild(renderBlockedItem(item, options));
 		surface.append(intro, heading, list);
 	}
 

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -974,18 +974,14 @@ describe("recipient-focused Sharing", () => {
 		expect(document.querySelector(".project-status-badge")).toBeNull();
 	});
 
-	it("labels cached Team setup status as previous while refreshing", () => {
+	it("keeps cached Team setup visible without a transient refresh banner", () => {
 		mount(intent(), {
 			teamSetupLoading: true,
 			teamSetupSummary: { version: 1, candidates: [] },
 		});
 
-		const status = [...document.querySelectorAll<HTMLElement>('[role="status"]')].find(
-			(item) =>
-				item.textContent ===
-				"Team setup status is being refreshed. The previous Team setup status is being shown.",
-		);
-		expect(status?.getAttribute("aria-live")).toBe("polite");
+		expect(document.body.textContent).not.toContain("Team setup status is being refreshed");
+		expect(document.body.textContent).not.toContain("previous Team setup status");
 	});
 
 	it("labels first-load Team setup discovery as loading without claiming stale status", () => {

--- a/packages/ui/src/tabs/recipient-policy-sharing.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.tsx
@@ -698,11 +698,9 @@ function RecipientPolicySharing({
 				candidates={options.teamSetupSummary?.candidates ?? []}
 				onOpenTeamSetup={options.onOpenTeamSetup}
 			/>
-			{options.teamSetupLoading ? (
+			{options.teamSetupLoading && !options.teamSetupSummary ? (
 				<p aria-live="polite" className="small recipient-policy-sharing-empty" role="status">
-					{options.teamSetupSummary
-						? "Team setup status is being refreshed. The previous Team setup status is being shown."
-						: "Team setup status is loading."}
+					Team setup status is loading.
 				</p>
 			) : null}
 			{options.teamSetupUnavailable ? (

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1329,6 +1329,15 @@
       .legacy-team-setup-body h3 { margin: var(--sp-4) 0 var(--sp-2); }
       .legacy-team-setup-body p { overflow-wrap: anywhere; }
       .legacy-team-setup-error { display: grid; gap: var(--sp-2); justify-items: start; }
+      .legacy-team-setup-recovery {
+        max-width: 44rem;
+        margin-block: var(--sp-4);
+        padding: var(--sp-4);
+        border: 1px solid var(--accent-warm);
+        border-radius: var(--radius-sm);
+        background: var(--accent-warm-subtle);
+      }
+      .legacy-team-setup-recovery p { margin: 0; }
       .legacy-team-setup-actions { justify-content: flex-end; }
       .legacy-team-setup-target { min-width: 24px; min-height: 24px; }
       .legacy-team-device-list { display: grid; gap: var(--sp-4); margin-top: var(--sp-4); }


### PR DESCRIPTION
## Description

Improve Team setup recovery and Project repair UX: keep stale states fail-closed, route actionable repair work to Projects, preserve useful labels, remove transient layout shifts, and content-hash the staged Viewer bundle URL.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced