### PR TITLE
perf(worker): index request_nonces(created_at) to stop full-scan sweeps

### DIFF
--- a/packages/cloudflare-coordinator-worker/migrations/0014_add_request_nonces_created_at_index.sql
+++ b/packages/cloudflare-coordinator-worker/migrations/0014_add_request_nonces_created_at_index.sql
@@ -1,0 +1,8 @@
+-- Replay-protection nonces are pruned by `DELETE FROM request_nonces WHERE
+-- created_at < ?`, which runs on every authenticated request. Without an index
+-- on created_at that DELETE scans the whole table, so each request reads the
+-- entire live nonce window to delete the roughly one row that has expired.
+-- On D1 those scanned rows are billed as rows_read, making daily reads grow
+-- with the square of request volume.
+CREATE INDEX IF NOT EXISTS idx_request_nonces_created_at
+ON request_nonces(created_at);

--- a/packages/cloudflare-coordinator-worker/schema.sql
+++ b/packages/cloudflare-coordinator-worker/schema.sql
@@ -34,6 +34,11 @@ CREATE TABLE IF NOT EXISTS request_nonces (
   PRIMARY KEY (device_id, nonce)
 );
 
+-- Keeps the per-request expiry sweep off a full table scan; see migration
+-- 0014_add_request_nonces_created_at_index.sql.
+CREATE INDEX IF NOT EXISTS idx_request_nonces_created_at
+ON request_nonces(created_at);
+
 CREATE TABLE IF NOT EXISTS coordinator_invites (
   invite_id TEXT PRIMARY KEY,
   group_id TEXT NOT NULL,


### PR DESCRIPTION
## Description

`authorizeRequest` prunes replay-protection nonces on every authenticated request via `DELETE FROM request_nonces WHERE created_at < ?` (`packages/core/src/coordinator-api.ts:202`). There was no index on `created_at` — the primary key is `(device_id, nonce)` — so that DELETE scanned the entire live nonce window to remove the roughly one row that had expired. D1 bills scanned rows as `rows_read`.

Because the table's steady-state size is itself proportional to request volume (600s retention, `DEFAULT_TIME_WINDOW_S * 2`), daily reads grew with the **square** of traffic. That is why the 30-second status cache from #1512 did not deliver the reduction its design predicted: it lowered request volume, but the per-request cost kept rising with the volume that remained.

Production `wrangler d1 insights`, top query by reads:

| Query | Runs | Avg rows read | Total rows read | Share |
|---|---|---|---|---|
| `DELETE FROM request_nonces WHERE created_at < ?` | 24,909 | 179 | 4,462,989 | 92% |
| `listGroupPeers` | 10,721 | 12 | 128,652 | 2.6% |
| `listScopeMemberships` | 13,984 | 8 | 124,391 | 2.6% |
| `listScopes` | 9,450 | 7 | 70,262 | 1.4% |
| `listInvites` | 1,507 | 45 | 69,213 | 1.4% |

That single query is ~89% of the 5,000,000-row daily free-tier cap, and it read 4.46M rows to delete 26,250. Cloudflare scores its `queryEfficiency` as 0.

This adds one index. `EXPLAIN QUERY PLAN` against the real schema goes from:

```
SCAN request_nonces
```

to:

```
SEARCH request_nonces USING INDEX idx_request_nonces_created_at (created_at<?)
```

so the sweep touches only already-expired rows instead of the whole window.

The migration is additive and backward-compatible. The deployed Worker keeps serving against the upgraded schema with no code change and no redeploy, the same way the 0.40.2 migrations were applied.

Deliberately out of scope: the daemon's duplicate `/v1/peers` lookup per tick, and the `GET /v1/scopes` N+1 through `requesterAuthorizedForScope`. Both are real, both are worth fixing, and neither is a quota problem — the insights data puts every non-nonce query combined at ~8% of reads. `coordinator_reciprocal_approvals` holds 17 rows and never reached the top five.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

`pnpm run tsc` and `pnpm run lint` are clean. `pnpm run test` reports 5,731 passed with one unrelated environmental failure: `packages/mcp-server/src/http.test.ts` cannot bind `::1` in this container. The schema-parity suites that load `schema.sql` directly — `packages/core/src/d1-coordinator-store.test.ts` (89 tests) and `packages/cloudflare-coordinator-worker/src/index.test.ts` (12 tests) — both pass.

Query plans were verified by loading the committed `schema.sql` into SQLite with and without the new index, seeded with 179 nonces spread across the 600-second retention window to match production.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq71RnJbURWvF9fmkKuDRc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lq71RnJbURWvF9fmkKuDRc)_