### PR TITLE
perf(coordinator): index invite lookups and backfill the nonce index locally

### DIFF
--- a/packages/cloudflare-coordinator-worker/migrations/0015_add_coordinator_invites_group_created_index.sql
+++ b/packages/cloudflare-coordinator-worker/migrations/0015_add_coordinator_invites_group_created_index.sql
@@ -1,0 +1,7 @@
+-- `listInvites` runs `SELECT ... FROM coordinator_invites WHERE group_id = ?
+-- ORDER BY created_at DESC`, which scanned the whole table and then sorted it
+-- through a temp b-tree. Invites are never pruned, so that scan grows with
+-- every invite ever issued. Ordering the index by created_at DESC lets one
+-- index seek satisfy both the filter and the ordering.
+CREATE INDEX IF NOT EXISTS idx_coordinator_invites_group_created
+ON coordinator_invites(group_id, created_at DESC);

--- a/packages/cloudflare-coordinator-worker/schema.sql
+++ b/packages/cloudflare-coordinator-worker/schema.sql
@@ -81,6 +81,11 @@ ON coordinator_invites(operation_id) WHERE operation_id IS NOT NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_coordinator_invites_token_digest
 ON coordinator_invites(token_digest) WHERE token_digest IS NOT NULL;
 
+-- Serves listInvites' group filter and created_at ordering from one seek; see
+-- migration 0015_add_coordinator_invites_group_created_index.sql.
+CREATE INDEX IF NOT EXISTS idx_coordinator_invites_group_created
+ON coordinator_invites(group_id, created_at DESC);
+
 CREATE TABLE IF NOT EXISTS coordinator_join_requests (
   request_id TEXT PRIMARY KEY,
   group_id TEXT NOT NULL,

--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -643,6 +643,9 @@ function initializeSchema(db: DatabaseType): void {
 			PRIMARY KEY (device_id, nonce)
 		);
 
+		CREATE INDEX IF NOT EXISTS idx_request_nonces_created_at
+			ON request_nonces(created_at);
+
 		CREATE TABLE IF NOT EXISTS coordinator_invites (
 			invite_id TEXT PRIMARY KEY,
 			group_id TEXT NOT NULL,
@@ -856,6 +859,8 @@ function initializeSchema(db: DatabaseType): void {
 			ON coordinator_invites(operation_id) WHERE operation_id IS NOT NULL;
 		 CREATE UNIQUE INDEX IF NOT EXISTS idx_coordinator_invites_token_digest
 			ON coordinator_invites(token_digest) WHERE token_digest IS NOT NULL;
+		 CREATE INDEX IF NOT EXISTS idx_coordinator_invites_group_created
+			ON coordinator_invites(group_id, created_at DESC);
 		 UPDATE coordinator_invites
 			SET invite_kind = CASE WHEN operation_id IS NOT NULL THEN 'project_share' ELSE 'legacy_enrollment' END
 			WHERE invite_kind IS NULL;`,


### PR DESCRIPTION
## Description

Follow-up to #1564, which landed migration 0014 while this work was still in progress.

**1. Invite lookups.** `listInvites` (`packages/core/src/d1-coordinator-store.ts:1493`) runs `SELECT ... FROM coordinator_invites WHERE group_id = ? ORDER BY created_at DESC`, which scanned the whole table and then sorted it through a temp b-tree. Measured against production: 32 rows read to return 2, and 69,213 rows/day across 1,507 runs. `coordinator_invites` is never pruned, so that scan grows with every invite ever issued.

Ordering the index `created_at DESC` lets one seek satisfy both the filter and the ordering. Verified against production after applying:

```
SEARCH coordinator_invites USING INDEX idx_coordinator_invites_group_created (group_id=?)
```

with no `USE TEMP B-TREE FOR ORDER BY` line — the sort is eliminated, not just the scan.

**2. better-sqlite parity.** The better-sqlite coordinator store shares `authorizeRequest`, so the self-hosted coordinator had the same per-request full-scan nonce sweep that #1564 fixed for D1 — only the D1 schema had been updated. This adds `idx_request_nonces_created_at` to that store's `CREATE TABLE` block, and puts `idx_coordinator_invites_group_created` in its existing invite-index migration step so established local databases are upgraded in place rather than only fresh ones.

Both indexes are additive and need no Worker redeploy. The invite index is already applied to the production D1 database; this PR is what keeps the migration chain honest for every other environment.

For context on where the budget stands: daily reads went from 4,855,507 to a projected ~590k, about 12% of the 5,000,000 cap. The remaining top consumers (`listGroupPeers`, `listScopeMemberships`) are already index-served at 7–12 rows per call — reducing those means cutting request volume, not adding indexes.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

`pnpm run tsc` and `pnpm run lint` clean. The schema-parity suites that load `schema.sql` directly — `packages/core/src/d1-coordinator-store.test.ts` and `packages/cloudflare-coordinator-worker/src/index.test.ts` — pass, 101 tests. The full `pnpm run test` run on this change before rebasing reported 5,731 passed, with one unrelated environmental failure (`packages/mcp-server/src/http.test.ts` cannot bind `::1` in this container).

Query plans were checked by loading the committed `schema.sql` into SQLite with and without each index, then confirmed against the production database.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq71RnJbURWvF9fmkKuDRc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lq71RnJbURWvF9fmkKuDRc)_