### PR TITLE
feat(viewer): reconcile legacy Team completion

### DIFF
--- a/docs/plans/2026-09-04-additive-team-convergence-design.md
+++ b/docs/plans/2026-09-04-additive-team-convergence-design.md
@@ -1,0 +1,23 @@
+# Additive Team Convergence
+
+## Decision
+
+Completed Team setup reconciliation will materialize only canonical Projects that become locally resolvable after the initial completion. It will not replay device assignments, memberships, existing Project mappings, or cleanup during this additive pass.
+
+## Why
+
+A full activation is correct for the first canonical apply because the coordinator winner defines the reviewed policy. After completion, users can legitimately rebind devices and edit or delete Project mappings. Replaying the full activation when another canonical Project becomes resolvable would overwrite those later user actions.
+
+## Data flow
+
+Reconciliation compares the reconstructed completed manifest with the coordinator winner and resolves the winner's locally supported Projects. When the only difference is newly resolvable Projects, it rewrites the completed draft with those new Project rows and passes their refs to a project-only activation path. That path validates and writes only those mappings and Team recipients, then updates completion bookkeeping without changing existing policy facts.
+
+Initial completion, replacement-draft recovery, and divergent canonical policy continue through the existing full activation path.
+
+## Failure handling
+
+Project-only convergence remains transactional. Invalid scope evidence, conflicting selected mappings, or completion-history collisions roll back the new Project rows and writes without containing the already-valid completed Team policy.
+
+## Verification
+
+Regression coverage will start from a partial canonical completion, apply a post-completion device rebind and mapping deletion, make another canonical Project resolvable, and verify that only the new Project is materialized. Existing canonical replay and replacement-draft tests must continue to pass.

--- a/docs/plans/2026-09-04-legacy-team-publication-barrier-design.md
+++ b/docs/plans/2026-09-04-legacy-team-publication-barrier-design.md
@@ -1,0 +1,32 @@
+# Legacy Team Publication Barrier
+
+## Decision
+
+Legacy Team completion publication will share one database-scoped mutation barrier with device-binding commits and Project-mapping writes. This prevents a successful local mutation from being overwritten by an immutable coordinator winner published concurrently.
+
+## Lock order
+
+Finish acquires locks in this order: candidate claim, publication barrier, sorted actor locks, Team lock, then coordinator-group lock. Device-binding and Project-mapping routes acquire only the publication barrier, so they cannot introduce a lock cycle.
+
+The barrier intentionally spans coordinator creation, conflict recovery, roster reload, and canonical local application. These operations are uncommon and correctness takes priority over cross-candidate write concurrency while publication is in flight.
+
+## Scope
+
+The barrier covers:
+
+- legacy Team finish publication;
+- device-binding commits;
+- single and bulk Project-mapping upserts;
+- Project-mapping deletion.
+
+Read-only previews and mapping reads remain concurrent.
+
+## Failure handling
+
+Every route releases the barrier in `finally`, including validation, SQLite, coordinator, and response-construction failures. Existing route-specific error responses remain unchanged.
+
+An interactive mutation can wait for the coordinator reconciliation budget of up to 60 seconds instead of reaching its SQLite-busy response while publication owns the barrier. This bounded availability cost is accepted to prevent a concurrent local write from being overwritten by the immutable coordinator winner.
+
+## Verification
+
+Route regressions will pause completion publication and assert that each affected mutation remains pending until publication finishes. Core tests will verify queue release after success and failure, and the full repository gate must pass before the existing PR stack is updated.

--- a/e2e/scenarios/legacy-team-migration.ts
+++ b/e2e/scenarios/legacy-team-migration.ts
@@ -193,6 +193,26 @@ function createCoordinatorRoster(ctx: ScenarioContext, roster: FixtureSummary["r
 	coordinatorCommand(ctx, ["group-create", GROUP_ALPHA, "--name", "Legacy Alpha"], "04-create-alpha");
 	coordinatorCommand(ctx, ["group-create", GROUP_BETA, "--name", "Legacy Beta"], "05-create-beta");
 	coordinatorCommand(ctx, ["group-create", GROUP_GAMMA, "--name", "Legacy Gamma"], "06-create-gamma");
+	for (const [groupId, scopeId, label] of [
+		[GROUP_ALPHA, "scope-legacy-alpha", "Legacy Alpha"],
+		[GROUP_BETA, "scope-legacy-beta", "Legacy Beta"],
+	] as const) {
+		coordinatorCommand(
+			ctx,
+			[
+				"create-scope",
+				groupId,
+				scopeId,
+				"--label",
+				label,
+				"--kind",
+				"team",
+				"--coordinator-id",
+				"http://coordinator:7347",
+			],
+			`06-create-scope-${groupId}`,
+		);
+	}
 	for (const [groupId, devices] of [
 		[GROUP_ALPHA, [roster.shared, roster.optional]],
 		[

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -488,6 +488,7 @@ export {
 } from "./legacy-recipient-policy-projection.js";
 export * from "./legacy-team-candidate.js";
 export * from "./legacy-team-setup-activation.js";
+export * from "./legacy-team-setup-completion-manifest.js";
 export * from "./legacy-team-setup-draft.js";
 export type {
 	LegacyTeamSetupCoreErrorCode,
@@ -894,8 +895,14 @@ export type {
 	RecipientPolicyTeamRenameResultV1,
 } from "./recipient-policy-team-metadata.js";
 export {
+	claimRecipientPolicyActorMutations,
+	claimRecipientPolicyPublicationMutation,
 	RecipientPolicyTeamRenameError,
 	renameRecipientPolicyTeam,
+	serializeRecipientPolicyActorMutations,
+	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyPublicationMutation,
+	serializeRecipientPolicyTeamMutation,
 } from "./recipient-policy-team-metadata.js";
 export type {
 	RecipientReviewedIntentExcludedProjectV1,

--- a/packages/core/src/legacy-team-candidate.ts
+++ b/packages/core/src/legacy-team-candidate.ts
@@ -859,6 +859,7 @@ function candidateAuthority(
 	requireLegacyTeamSetupEffectiveDevicesWithinLimit(
 		db,
 		rosterDevices,
+		projects,
 		authorityRow?.attempt_id ?? null,
 	);
 	const activeAssignmentIdentity = activeAssignmentIdentityLookup(db);

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { discoverLegacyTeamCandidates } from "./legacy-team-candidate.js";
 import {
 	finishLegacyTeamSetupActivation,
+	inspectFreshLegacyTeamSetupActivation,
 	inspectLegacyTeamSetupActivation,
 	previewLegacyTeamSetupActivation,
 } from "./legacy-team-setup-activation.js";
@@ -700,6 +701,24 @@ describe("legacy Team setup activation", () => {
 				.pluck()
 				.get(draft.attemptId),
 		).toBe("stale");
+	});
+
+	it("persists stale state when fresh inspection detects changed evidence", () => {
+		const draft = readyDraft();
+
+		expect(() =>
+			inspectFreshLegacyTeamSetupActivation(db, {
+				candidateRef: draft.candidateRef,
+				attemptId: draft.attemptId,
+				freshRoster: [{ ...roster[0], fingerprint: "changed-key" }, roster[1]],
+				projectInventory: draftProjectInventory(draft.attemptId),
+			}),
+		).toThrow("team_setup_roster_changed");
+		expect(
+			db
+				.prepare("SELECT state, safe_error_code FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.get(draft.attemptId),
+		).toEqual({ state: "stale", safe_error_code: "team_setup_roster_changed" });
 	});
 
 	it("returns roster unavailable after a failed pre-lock fetch without canonical writes", async () => {
@@ -1678,6 +1697,36 @@ describe("legacy Team setup activation", () => {
 		expect(review.accessDelta.recipientChanges).not.toContainEqual(
 			expect.objectContaining({ canonicalProjectIdentity: PROJECT_A, change: "remove" }),
 		);
+	});
+
+	it("preserves a user-revoked recipient in both preview and activation", async () => {
+		const teamId = deterministicPolicyTeamId(CANDIDATE);
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'team', ?, 'revoked', 'user', 'user-r1', 'user_managed',
+			 'user-revoked-edge', ?, ?)`,
+		).run(PROJECT_A, teamId, NOW, NOW);
+		const draft = readyDraft();
+
+		const review = preview(draft);
+		expect(review.accessDelta.recipientChanges).not.toContainEqual(
+			expect.objectContaining({ canonicalProjectIdentity: PROJECT_A, change: "add" }),
+		);
+		expect(review.accessDelta.deviceAccessChanges).not.toContainEqual(
+			expect.objectContaining({ canonicalProjectIdentity: PROJECT_A, change: "add" }),
+		);
+		await finish(draft, review);
+
+		expect(
+			db
+				.prepare(
+					`SELECT status, provenance FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
+				)
+				.get(PROJECT_A, teamId),
+		).toEqual({ status: "revoked", provenance: "user" });
 	});
 
 	it("confirms and applies setup-owned mapping removal when repeat setup drops a Project", async () => {

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -90,6 +90,10 @@ export interface FinishLegacyTeamSetupActivationInput
 	 * Implementations must be synchronous and read from the same database.
 	 */
 	validateLockedPreview: (preview: LegacyTeamSetupActivationPreviewV1) => boolean;
+	canonicalCompletion?: {
+		policyRevision: string;
+		completedAt: string;
+	};
 	now?: string;
 }
 
@@ -136,6 +140,7 @@ interface TeamRow {
 	display_name: string;
 	status: string;
 	device_eligibility_mode: string;
+	migration_state: string;
 	provenance: string;
 	source_fingerprint: string | null;
 }
@@ -238,6 +243,14 @@ interface ActivationModel {
 
 interface CompletionRow {
 	response_json: string;
+}
+
+interface AdditiveProjectRow {
+	project_ref: string;
+	source_project_identity: string;
+	source_fingerprint: string;
+	resolved_project_identity: string | null;
+	target_scope_id: string | null;
 }
 
 const SETUP_MEMBERSHIP_PROVENANCE = "reviewed_active";
@@ -369,7 +382,14 @@ function droppedSetupMappings(model: ActivationModel): MappingRow[] {
 	);
 }
 
-function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): ActivationModel {
+function loadModel(
+	db: Database,
+	input: PreviewLegacyTeamSetupActivationInput & {
+		allowCompletedDraft?: boolean;
+		allowInactiveCanonicalTeam?: boolean;
+		allowStaleDraft?: boolean;
+	},
+): ActivationModel {
 	const draft = db
 		.prepare(
 			`SELECT draft.attempt_id, draft.candidate_id, draft.coordinator_id, draft.group_id,
@@ -385,7 +405,13 @@ function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): 
 	if (!draft || draft.candidate_id !== input.candidateRef) {
 		activationError("team_setup_confirmation_stale");
 	}
-	if (draft.is_current === 0 || (draft.state !== "needs_setup" && draft.state !== "in_progress")) {
+	if (
+		draft.is_current === 0 ||
+		(draft.state !== "needs_setup" &&
+			draft.state !== "in_progress" &&
+			!(input.allowCompletedDraft && draft.state === "completed") &&
+			!(input.allowStaleDraft && draft.state === "stale"))
+	) {
 		activationError("team_setup_confirmation_stale");
 	}
 
@@ -474,7 +500,7 @@ function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): 
 		(db
 			.prepare(
 				`SELECT team_id, display_name, status, device_eligibility_mode,
-				        provenance, source_fingerprint
+				        migration_state, provenance, source_fingerprint
 				 FROM policy_teams WHERE team_id = ?`,
 			)
 			.get(teamId) as TeamRow | undefined) ?? null;
@@ -557,15 +583,23 @@ function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): 
 			.toSorted(compareText),
 	};
 	validateAssignmentExpectations(model);
-	validateCanonicalState(db, model);
+	validateCanonicalState(db, model, input.allowInactiveCanonicalTeam === true);
 	return model;
 }
 
-function validateCanonicalState(db: Database, model: ActivationModel): void {
+function validateCanonicalState(
+	db: Database,
+	model: ActivationModel,
+	allowInactiveCanonicalTeam: boolean,
+): void {
 	const { groupScopeIds, memberships, projects, recipients, scopeIds, team, teamId } = model;
 	if (team) {
 		const baseCompatible =
-			team.status === "active" && team.provenance === HISTORICAL_TEAM_PROVENANCE;
+			(team.status === "active" ||
+				(allowInactiveCanonicalTeam &&
+					team.status === "inactive" &&
+					team.migration_state === "needs_setup")) &&
+			team.provenance === HISTORICAL_TEAM_PROVENANCE;
 		const reviewedCompatible = team.device_eligibility_mode === "reviewed_allowlist";
 		const historicalCompatible = team.device_eligibility_mode === "person_all_devices";
 		if (!baseCompatible || (!reviewedCompatible && !historicalCompatible)) {
@@ -659,6 +693,40 @@ function targetScopeId(model: ActivationModel, project: DraftProjectRow): string
 		),
 	];
 	return matchingScopeIds.length === 1 ? (matchingScopeIds[0] ?? null) : null;
+}
+
+function requireSelectedProjectScopeMappings(
+	db: Database,
+	projects: readonly {
+		sourceProjectIdentity: string;
+		resolvedProjectIdentity: string;
+		targetScopeId: string;
+	}[],
+): void {
+	const sourcesByResolved = new Map<string, { sources: Set<string>; scopeIds: Set<string> }>();
+	for (const project of projects) {
+		const evidence = sourcesByResolved.get(project.resolvedProjectIdentity) ?? {
+			sources: new Set<string>(),
+			scopeIds: new Set<string>(),
+		};
+		evidence.sources.add(project.sourceProjectIdentity);
+		evidence.scopeIds.add(project.targetScopeId);
+		sourcesByResolved.set(project.resolvedProjectIdentity, evidence);
+	}
+	for (const [resolvedIdentity, evidence] of sourcesByResolved) {
+		const selected = selectedProjectScopeMapping(db, resolvedIdentity);
+		if (
+			evidence.scopeIds.size !== 1 ||
+			!selected ||
+			selected.workspaceIdentity == null ||
+			(normalizeLegacyProjectMappingIdentity(selected.workspaceIdentity) !==
+				normalizeLegacyProjectMappingIdentity(resolvedIdentity) &&
+				!evidence.sources.has(selected.projectPattern)) ||
+			selected.scopeId !== [...evidence.scopeIds][0]
+		) {
+			activationError("team_setup_conflict");
+		}
+	}
 }
 
 /**
@@ -773,6 +841,23 @@ interface DerivationRows {
 		status: string;
 		provenance: string;
 	}>;
+}
+
+const LEGACY_TEAM_SETUP_MAX_ACCESS_DELTA_ENTRIES = 10_000;
+
+export function requireLegacyTeamSetupAccessDeltaWithinLimit(
+	delta: LegacyTeamSetupAccessDeltaV1,
+): void {
+	const counts = [
+		delta.teamChanges.length,
+		delta.membershipChanges.length,
+		delta.projectChanges.length,
+		delta.recipientChanges.length,
+		delta.deviceAccessChanges.length,
+	];
+	if (counts.some((count) => count > LEGACY_TEAM_SETUP_MAX_ACCESS_DELTA_ENTRIES)) {
+		throw new Error("legacy_team_setup_roster_too_large");
+	}
 }
 
 function currentDerivationRows(model: ActivationModel): DerivationRows {
@@ -956,8 +1041,9 @@ function simulatedDerivationRows(model: ActivationModel): DerivationRows {
 				row.recipientKind === "team" &&
 				row.recipientId === model.teamId,
 		);
-		if (existing) existing.status = "active";
-		else {
+		if (existing) {
+			if (existing.provenance === "reviewed_team_setup") existing.status = "active";
+		} else {
 			projectRecipients.push({
 				canonicalProjectIdentity: resolvedIdentity,
 				recipientKind: "team",
@@ -1103,7 +1189,7 @@ function buildAccessDelta(model: ActivationModel): LegacyTeamSetupAccessDeltaV1 
 				row.canonical_project_identity === resolvedIdentity &&
 				row.recipient_kind === "team" &&
 				row.recipient_id === model.teamId &&
-				row.status === "active",
+				(row.status === "active" || row.provenance !== "reviewed_team_setup"),
 		);
 		if (!recipient && !plannedRecipientIdentities.has(resolvedIdentity)) {
 			plannedRecipientIdentities.add(resolvedIdentity);
@@ -1276,9 +1362,19 @@ function exactReplay(
 ): LegacyTeamSetupActivationResultV1 | null {
 	const row = db
 		.prepare(
-			`SELECT response_json FROM legacy_team_setup_completions
-			 WHERE candidate_ref = ? AND attempt_id = ? AND finish_digest = ?
-			   AND confirmed_access_delta_digest = ?`,
+			`SELECT completion.response_json
+			 FROM legacy_team_setup_completions AS completion
+			 JOIN legacy_team_setup_drafts AS draft
+			   ON draft.attempt_id = completion.attempt_id
+			  AND draft.candidate_id = completion.candidate_ref
+			  AND draft.finish_digest = completion.finish_digest
+			 WHERE completion.candidate_ref = ? AND completion.attempt_id = ?
+			   AND completion.finish_digest = ?
+			   AND completion.confirmed_access_delta_digest = ?
+			   AND NOT EXISTS (
+			     SELECT 1 FROM legacy_team_setup_drafts AS newer
+			     WHERE newer.candidate_id = draft.candidate_id AND newer.rowid > draft.rowid
+			   )`,
 		)
 		.get(
 			input.candidateRef,
@@ -1287,6 +1383,16 @@ function exactReplay(
 			input.confirmedAccessDeltaDigest,
 		) as CompletionRow | undefined;
 	return row ? (JSON.parse(row.response_json) as LegacyTeamSetupActivationResultV1) : null;
+}
+
+export function replayLegacyTeamSetupActivation(
+	db: Database,
+	input: Pick<
+		FinishLegacyTeamSetupActivationInput,
+		"candidateRef" | "attemptId" | "finishDigest" | "confirmedAccessDeltaDigest"
+	>,
+): LegacyTeamSetupActivationResultV1 | null {
+	return exactReplay(db, input);
 }
 
 function validateFreshRoster(
@@ -1319,17 +1425,41 @@ function validateFreshRoster(
 	}
 }
 
+export function inspectFreshLegacyTeamSetupActivation(
+	db: Database,
+	input: PreviewLegacyTeamSetupActivationInput & {
+		freshRoster: Awaited<ReturnType<FinishLegacyTeamSetupActivationInput["loadFreshRoster"]>>;
+		projectInventory: LegacyTeamSetupProjectInput[];
+	},
+): LegacyTeamSetupActivationPreviewV1 {
+	try {
+		const model = loadModel(db, input);
+		validateFreshRoster(model, input.freshRoster);
+		if (
+			legacyTeamProjectionFingerprint(input.projectInventory) !== model.draft.projection_fingerprint
+		) {
+			activationError("team_setup_projection_changed");
+		}
+		return buildPreview(model);
+	} catch (error) {
+		const normalized = normalizedActivationError(error);
+		persistSafeError(db, input, normalized);
+		throw normalized;
+	}
+}
+
 function applyActivation(
 	db: Database,
 	model: ActivationModel,
 	preview: LegacyTeamSetupActivationPreviewV1,
 	freshRoster: Awaited<ReturnType<FinishLegacyTeamSetupActivationInput["loadFreshRoster"]>>,
 	now: string,
+	revisionOverride?: string,
+	allowExistingCompletion = false,
 ): LegacyTeamSetupActivationResultV1 {
-	const revision = recipientPolicyDigest(
-		"legacy-team-activation-revision-v1",
-		preview.finishDigest,
-	);
+	const revision =
+		revisionOverride ??
+		recipientPolicyDigest("legacy-team-activation-revision-v1", preview.finishDigest);
 	if (!model.team) {
 		db.prepare(
 			`INSERT INTO policy_teams(
@@ -1570,7 +1700,10 @@ function applyActivation(
 			 created_at, updated_at
 			 ) VALUES (?, 'team', ?, 'active', 'reviewed_team_setup', ?, 'completed', ?, ?, ?, ?)
 			 ON CONFLICT(canonical_project_identity, recipient_kind, recipient_id) DO UPDATE SET
-			 status = 'active',
+			 status = CASE
+			   WHEN project_recipients.provenance = 'reviewed_team_setup' THEN 'active'
+			   ELSE project_recipients.status
+			 END,
 			 provenance = CASE
 			   WHEN project_recipients.provenance = 'reviewed_team_setup' THEN excluded.provenance
 			   ELSE project_recipients.provenance
@@ -1642,36 +1775,14 @@ function applyActivation(
 	// mapping writes because merged resolutions map several confirmed source
 	// patterns onto one identity and selection can pick only one of them: the
 	// authoritative pattern is valid when it matches ANY confirmed source.
-	const confirmedSourcesByResolved = new Map<
-		string,
-		{ sources: Set<string>; targetScopeIds: Set<string> }
-	>();
-	for (const project of model.projects) {
-		const resolvedIdentity = project.resolved_project_identity as string;
-		const evidence = confirmedSourcesByResolved.get(resolvedIdentity) ?? {
-			sources: new Set<string>(),
-			targetScopeIds: new Set<string>(),
-		};
-		evidence.sources.add(project.source_project_identity);
-		const projectTargetScopeId = targetScopeId(model, project);
-		if (projectTargetScopeId) evidence.targetScopeIds.add(projectTargetScopeId);
-		confirmedSourcesByResolved.set(resolvedIdentity, evidence);
-	}
-	for (const [resolvedIdentity, evidence] of confirmedSourcesByResolved) {
-		const reviewedTargetScopeId = [...evidence.targetScopeIds][0];
-		const selected = selectedProjectScopeMapping(db, resolvedIdentity);
-		if (
-			evidence.targetScopeIds.size !== 1 ||
-			!selected ||
-			selected.workspaceIdentity == null ||
-			(normalizeLegacyProjectMappingIdentity(selected.workspaceIdentity) !==
-				normalizeLegacyProjectMappingIdentity(resolvedIdentity) &&
-				!evidence.sources.has(selected.projectPattern)) ||
-			selected.scopeId !== reviewedTargetScopeId
-		) {
-			activationError("team_setup_conflict");
-		}
-	}
+	requireSelectedProjectScopeMappings(
+		db,
+		model.projects.map((project) => ({
+			sourceProjectIdentity: project.source_project_identity,
+			resolvedProjectIdentity: project.resolved_project_identity as string,
+			targetScopeId: targetScopeId(model, project) as string,
+		})),
+	);
 
 	const result: LegacyTeamSetupActivationResultV1 = {
 		status: "completed",
@@ -1693,12 +1804,7 @@ function applyActivation(
 		now,
 		model.draft.attempt_id,
 	);
-	db.prepare(
-		`INSERT INTO legacy_team_setup_completions(
-		 attempt_id, finish_digest, candidate_ref, confirmed_access_delta_digest,
-		 completed_team_id, response_json, completed_at, created_at
-		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-	).run(
+	const completionValues = [
 		model.draft.attempt_id,
 		preview.finishDigest,
 		model.draft.candidate_id,
@@ -1707,8 +1813,288 @@ function applyActivation(
 		JSON.stringify(result),
 		now,
 		now,
-	);
+	] as const;
+	const insertedCompletion = db
+		.prepare(
+			`INSERT ${allowExistingCompletion ? "OR IGNORE " : ""}INTO legacy_team_setup_completions(
+		 attempt_id, finish_digest, candidate_ref, confirmed_access_delta_digest,
+		 completed_team_id, response_json, completed_at, created_at
+		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.run(...completionValues);
+	if (allowExistingCompletion && insertedCompletion.changes === 0) {
+		const existing = db
+			.prepare(
+				`SELECT candidate_ref, confirmed_access_delta_digest, completed_team_id,
+				        response_json, completed_at
+				 FROM legacy_team_setup_completions
+				 WHERE attempt_id = ? AND finish_digest = ?`,
+			)
+			.get(model.draft.attempt_id, preview.finishDigest) as
+			| {
+					candidate_ref: string;
+					confirmed_access_delta_digest: string;
+					completed_team_id: string;
+					response_json: string;
+					completed_at: string;
+			  }
+			| undefined;
+		if (
+			!existing ||
+			existing.candidate_ref !== model.draft.candidate_id ||
+			existing.confirmed_access_delta_digest !== preview.accessDeltaDigest ||
+			existing.completed_team_id !== model.teamId ||
+			existing.response_json !== JSON.stringify(result) ||
+			existing.completed_at !== now
+		) {
+			activationError("team_setup_completion_invalid");
+		}
+	}
 	return result;
+}
+
+/**
+ * Applies coordinator-owned completion facts after the caller has rewritten the
+ * current draft to match a validated manifest. The caller owns serialization
+ * and the surrounding immediate transaction.
+ */
+export function applyCanonicalLegacyTeamSetupActivationInTransaction(
+	db: Database,
+	input: PreviewLegacyTeamSetupActivationInput & {
+		policyRevision: string;
+		completedAt: string;
+		allowCompletedDraft?: boolean;
+		allowStaleDraft?: boolean;
+	},
+): LegacyTeamSetupActivationResultV1 {
+	try {
+		const model = loadModel(db, { ...input, allowInactiveCanonicalTeam: true });
+		const inspected = buildPreview(model);
+		requireLegacyTeamSetupAccessDeltaWithinLimit(inspected.accessDelta);
+		const roster = model.devices
+			.filter((device) => device.decision !== "removed")
+			.map((device) => ({
+				deviceId: device.device_id,
+				fingerprint: device.key_fingerprint,
+				displayName: device.display_name,
+				enabled: device.enabled !== 0,
+			}));
+		return applyActivation(
+			db,
+			model,
+			inspected,
+			roster,
+			input.completedAt,
+			input.policyRevision,
+			true,
+		);
+	} catch (error) {
+		throw normalizedActivationError(error);
+	}
+}
+
+/**
+ * Materializes only newly resolvable Projects for an already-completed Team.
+ * The caller owns serialization and the surrounding immediate transaction.
+ */
+export function applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(
+	db: Database,
+	input: {
+		candidateRef: string;
+		attemptId: string;
+		teamId: string;
+		projectRefs: readonly string[];
+		completedAt: string;
+	},
+): void {
+	try {
+		const projectRefs = [...new Set(input.projectRefs)].toSorted(compareText);
+		if (
+			projectRefs.length === 0 ||
+			projectRefs.length !== input.projectRefs.length ||
+			projectRefs.length > LEGACY_TEAM_SETUP_MAX_PROJECTS
+		) {
+			activationError("team_setup_completion_invalid");
+		}
+		const draft = db
+			.prepare(
+				`SELECT coordinator_id, group_id FROM legacy_team_setup_drafts AS draft
+				 WHERE attempt_id = ? AND candidate_id = ? AND state = 'completed'
+				   AND completed_team_id = ?
+				   AND NOT EXISTS (
+				     SELECT 1 FROM legacy_team_setup_drafts AS newer
+				     WHERE newer.candidate_id = draft.candidate_id AND newer.rowid > draft.rowid
+				   )`,
+			)
+			.get(input.attemptId, input.candidateRef, input.teamId) as
+			| { coordinator_id: string; group_id: string }
+			| undefined;
+		const team = db
+			.prepare(
+				`SELECT revision FROM policy_teams
+				 WHERE team_id = ? AND status = 'active' AND migration_state = 'completed'
+				   AND provenance = 'reviewed_team_candidate'
+				   AND device_eligibility_mode = 'reviewed_allowlist'`,
+			)
+			.get(input.teamId) as { revision: string } | undefined;
+		if (!draft || !team) activationError("team_setup_conflict");
+
+		const allProjects = db
+			.prepare(
+				`SELECT project_ref, source_project_identity, source_fingerprint,
+				        resolved_project_identity, target_scope_id
+				 FROM legacy_team_setup_draft_projects
+				 WHERE attempt_id = ?
+				 ORDER BY project_ref`,
+			)
+			.all(input.attemptId) as AdditiveProjectRow[];
+		const requestedProjectRefs = new Set(projectRefs);
+		const projects = allProjects.filter((project) => requestedProjectRefs.has(project.project_ref));
+		if (projects.length !== projectRefs.length) {
+			activationError("team_setup_completion_invalid");
+		}
+		const scopeIdsByResolved = new Map<string, Set<string>>();
+		for (const project of allProjects) {
+			if (!project.resolved_project_identity || !project.target_scope_id) continue;
+			const resolvedScopeIds =
+				scopeIdsByResolved.get(project.resolved_project_identity) ?? new Set();
+			resolvedScopeIds.add(project.target_scope_id);
+			scopeIdsByResolved.set(project.resolved_project_identity, resolvedScopeIds);
+		}
+		if ([...scopeIdsByResolved.values()].some((resolvedScopeIds) => resolvedScopeIds.size !== 1)) {
+			activationError("team_setup_conflict");
+		}
+		const scopeIds = db
+			.prepare(
+				`SELECT scope_id FROM replication_scopes
+				 WHERE coordinator_id = ? AND group_id = ? AND authority_type = 'coordinator'
+				   AND status = 'active' ORDER BY scope_id`,
+			)
+			.pluck()
+			.all(draft.coordinator_id, draft.group_id) as string[];
+		const groupScopeIds = db
+			.prepare(
+				`SELECT scope_id FROM replication_scopes
+				 WHERE coordinator_id = ? AND group_id = ? ORDER BY scope_id`,
+			)
+			.pluck()
+			.all(draft.coordinator_id, draft.group_id) as string[];
+		const mappings = db
+			.prepare(
+				`SELECT id, workspace_identity, project_pattern, scope_id, source
+				 FROM project_scope_mappings ORDER BY id`,
+			)
+			.all() as MappingRow[];
+		const recipients = db
+			.prepare(
+				`SELECT canonical_project_identity, recipient_kind, recipient_id, status, provenance
+				 FROM project_recipients ORDER BY canonical_project_identity, recipient_kind, recipient_id`,
+			)
+			.all() as RecipientRow[];
+		if (
+			!isLegacyTeamProjectCanonicalStateValid(
+				{
+					teamId: input.teamId,
+					scopeIds,
+					groupScopeIds,
+					projects: projects.map((project) => ({
+						sourceProjectIdentity: project.source_project_identity,
+						resolvedProjectIdentity: project.resolved_project_identity,
+						targetScopeId: project.target_scope_id,
+					})),
+					mappings: mappings.map((mapping) => ({
+						workspaceIdentity: mapping.workspace_identity,
+						projectPattern: mapping.project_pattern,
+						scopeId: mapping.scope_id,
+						source: mapping.source,
+					})),
+					recipients: recipients.map((recipient) => ({
+						canonicalProjectIdentity: recipient.canonical_project_identity,
+						recipientKind: recipient.recipient_kind,
+						recipientId: recipient.recipient_id,
+						status: recipient.status,
+					})),
+				},
+				db,
+			)
+		) {
+			activationError("team_setup_conflict");
+		}
+
+		for (const project of projects) {
+			const resolvedIdentity = project.resolved_project_identity as string;
+			const targetScopeId = project.target_scope_id as string;
+			const relatedMappings = mappings.filter(
+				(mapping) => mapping.project_pattern === project.source_project_identity,
+			);
+			const exactMapping = relatedMappings.some(
+				(mapping) =>
+					mapping.workspace_identity === resolvedIdentity && mapping.scope_id === targetScopeId,
+			);
+			if (
+				relatedMappings.some(
+					(mapping) =>
+						mapping.workspace_identity !== resolvedIdentity || mapping.scope_id !== targetScopeId,
+				)
+			) {
+				activationError("team_setup_conflict");
+			}
+			if (!exactMapping) {
+				db.prepare(
+					`INSERT INTO project_scope_mappings(
+					 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+					 ) VALUES (?, ?, ?, 1000, 'reviewed_team_setup', ?, ?)`,
+				).run(
+					resolvedIdentity,
+					project.source_project_identity,
+					targetScopeId,
+					input.completedAt,
+					input.completedAt,
+				);
+			}
+			// User revocation changes provenance to `user`; only a still setup-owned
+			// revoked edge can be safely reactivated for this newly converged Project.
+			db.prepare(
+				`INSERT INTO project_recipients(
+				 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+					 policy_revision, migration_state, source_fingerprint, idempotency_key,
+					 created_at, updated_at
+					 ) VALUES (?, 'team', ?, 'active', 'reviewed_team_setup', ?, 'completed', ?, ?, ?, ?)
+					 ON CONFLICT(canonical_project_identity, recipient_kind, recipient_id) DO UPDATE SET
+					   status = 'active', policy_revision = excluded.policy_revision,
+					   migration_state = 'completed', source_fingerprint = excluded.source_fingerprint,
+					   idempotency_key = excluded.idempotency_key, updated_at = excluded.updated_at
+					 WHERE project_recipients.provenance = 'reviewed_team_setup'`,
+			).run(
+				resolvedIdentity,
+				input.teamId,
+				team.revision,
+				project.source_fingerprint,
+				recipientPolicyDigest("legacy-team-project-recipient-v1", [resolvedIdentity, input.teamId]),
+				input.completedAt,
+				input.completedAt,
+			);
+			const recipientStatus = db
+				.prepare(
+					`SELECT status FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
+				)
+				.pluck()
+				.get(resolvedIdentity, input.teamId);
+			if (recipientStatus !== "active") activationError("team_setup_conflict");
+		}
+
+		requireSelectedProjectScopeMappings(
+			db,
+			projects.map((project) => ({
+				sourceProjectIdentity: project.source_project_identity,
+				resolvedProjectIdentity: project.resolved_project_identity as string,
+				targetScopeId: project.target_scope_id as string,
+			})),
+		);
+	} catch (error) {
+		throw normalizedActivationError(error);
+	}
 }
 
 export async function finishLegacyTeamSetupActivation(
@@ -1788,7 +2174,14 @@ export async function finishLegacyTeamSetupActivation(
 						if (!input.validateLockedPreview(lockedPreview)) {
 							activationError("team_setup_confirmation_stale");
 						}
-						return applyActivation(db, model, lockedPreview, freshRoster, now);
+						return applyActivation(
+							db,
+							model,
+							lockedPreview,
+							freshRoster,
+							input.canonicalCompletion?.completedAt ?? now,
+							input.canonicalCompletion?.policyRevision,
+						);
 					})
 					.immediate();
 			} catch (error) {

--- a/packages/core/src/legacy-team-setup-completion-manifest.test.ts
+++ b/packages/core/src/legacy-team-setup-completion-manifest.test.ts
@@ -1,0 +1,1610 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction,
+	finishLegacyTeamSetupActivation,
+	inspectLegacyTeamSetupActivation,
+	requireLegacyTeamSetupAccessDeltaWithinLimit,
+} from "./legacy-team-setup-activation.js";
+import {
+	applyLegacyTeamSetupCompletionManifest,
+	areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible,
+	deriveLegacyTeamSetupCompletionManifest,
+	LegacyTeamSetupAdditiveConvergenceError,
+	reconstructLegacyTeamSetupCompletionManifest,
+	validateLegacyTeamSetupCompletionManifest,
+	validateLegacyTeamSetupCompletionManifestBinding,
+} from "./legacy-team-setup-completion-manifest.js";
+import {
+	refreshLegacyTeamSetupDraft,
+	setLegacyTeamSetupDeviceAssignment,
+	setLegacyTeamSetupDeviceDecision,
+} from "./legacy-team-setup-draft.js";
+import { legacyTeamCandidateId, legacyTeamProjectRef } from "./recipient-policy-identifiers.js";
+import { initTestSchema } from "./test-utils.js";
+
+const NOW = "2026-09-01T12:00:00.000Z";
+const COORDINATOR_ID = "coordinator-private";
+const GROUP_ID = "group-private";
+const CANDIDATE = legacyTeamCandidateId(COORDINATOR_ID, GROUP_ID);
+const PROJECT_A = "https://git.example.invalid/acme/api.git";
+const PROJECT_B = "https://git.example.invalid/acme/web.git";
+const PROJECT_C = "https://git.example.invalid/acme/new.git";
+const PROJECT_REF_A = legacyTeamProjectRef(CANDIDATE, PROJECT_A);
+const PROJECT_REF_C = legacyTeamProjectRef(CANDIDATE, PROJECT_C);
+const KEY_A = "a".repeat(64);
+const FRESH_ROSTER = [
+	{ deviceId: "device-a", fingerprint: KEY_A, displayName: "Laptop", enabled: true },
+];
+
+describe("legacy Team setup completion manifests", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-a', 'Person A', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		db.prepare(
+			`INSERT INTO replication_scopes(
+			 scope_id, label, kind, authority_type, coordinator_id, group_id,
+			 membership_epoch, status, created_at, updated_at
+			 ) VALUES ('scope-engineering', 'Engineering', 'team', 'coordinator', ?, ?, 1,
+			 'active', ?, ?)`,
+		).run(COORDINATOR_ID, GROUP_ID, NOW, NOW);
+	});
+
+	afterEach(() => db.close());
+
+	function readyDraft() {
+		let draft = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [
+				{
+					deviceId: "device-a",
+					fingerprint: KEY_A,
+					displayName: "Laptop",
+					enabled: true,
+				},
+			],
+			projects: [],
+			now: NOW,
+		});
+		const device = draft.devices[0];
+		if (!device) throw new Error("missing test device");
+		draft = setLegacyTeamSetupDeviceAssignment(db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			targetIdentityId: "identity-a",
+			expectation: device.expectation,
+			now: NOW,
+		});
+		return setLegacyTeamSetupDeviceDecision(db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			decision: "included",
+			now: NOW,
+		});
+	}
+
+	it("accepts bounded access delta categories whose aggregate exceeds 10,000", () => {
+		expect(() =>
+			requireLegacyTeamSetupAccessDeltaWithinLimit({
+				teamChanges: [
+					{
+						teamId: "team-a",
+						change: "add",
+						fromDeviceEligibilityMode: null,
+						toDeviceEligibilityMode: "reviewed_allowlist",
+					},
+				],
+				membershipChanges: [],
+				projectChanges: [],
+				recipientChanges: [],
+				deviceAccessChanges: Array.from({ length: 10_000 }, (_, index) => ({
+					canonicalProjectIdentity: `project-${Math.floor(index / 500)}`,
+					deviceId: `device-${index % 500}`,
+					change: "add" as const,
+				})),
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects an oversized canonical activation delta", () => {
+		expect(() =>
+			requireLegacyTeamSetupAccessDeltaWithinLimit({
+				teamChanges: Array.from({ length: 10_001 }, (_, index) => ({
+					teamId: `team-${index}`,
+					change: "add",
+					fromDeviceEligibilityMode: null,
+					toDeviceEligibilityMode: "reviewed_allowlist",
+				})),
+				membershipChanges: [],
+				projectChanges: [],
+				recipientChanges: [],
+				deviceAccessChanges: [],
+			}),
+		).toThrow("legacy_team_setup_roster_too_large");
+	});
+
+	it("derives and validates bounded canonical policy facts", () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+
+		expect(
+			validateLegacyTeamSetupCompletionManifest(manifest, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+			}),
+		).toEqual(manifest);
+		expect(manifest.memberships).toEqual([{ identity_id: "identity-a", role: "member" }]);
+		expect(manifest.finish_digest).toMatch(/^[0-9a-f]{64}$/u);
+		expect(manifest.access_delta_digest).toMatch(/^[0-9a-f]{64}$/u);
+		expect(manifest.device_decisions).toEqual([
+			{
+				device_id: "device-a",
+				key_fingerprint: KEY_A,
+				enabled: true,
+				identity_id: "identity-a",
+				decision: "included",
+			},
+		]);
+	});
+
+	it("rejects a digest or coordinator-group mismatch", () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+
+		expect(() =>
+			validateLegacyTeamSetupCompletionManifest(
+				{ ...manifest, source_digest: "0".repeat(64) },
+				{ coordinatorId: COORDINATOR_ID, groupId: GROUP_ID },
+			),
+		).toThrow("team_setup_completion_invalid");
+		expect(() =>
+			validateLegacyTeamSetupCompletionManifest(manifest, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: "other-group",
+			}),
+		).toThrow("team_setup_completion_invalid");
+	});
+
+	it("proves coordinator-group binding without requiring valid digests", () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		const digestInvalidManifest = { ...manifest, finish_digest: "0".repeat(64) };
+
+		expect(
+			validateLegacyTeamSetupCompletionManifestBinding(digestInvalidManifest, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+			}),
+		).toEqual(digestInvalidManifest);
+		expect(() =>
+			validateLegacyTeamSetupCompletionManifestBinding(manifest, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: "other-group",
+			}),
+		).toThrow("team_setup_completion_invalid");
+	});
+
+	it("rejects policy collections that do not match their canonical source facts", () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+
+		expect(() =>
+			validateLegacyTeamSetupCompletionManifest(
+				{ ...manifest, memberships: [] },
+				{ coordinatorId: COORDINATOR_ID, groupId: GROUP_ID },
+			),
+		).toThrow("team_setup_completion_invalid");
+		expect(() =>
+			validateLegacyTeamSetupCompletionManifest(
+				{
+					...manifest,
+					project_recipients: [
+						{ resolved_project_ref: "unexpected-project", team_id: manifest.team_id },
+					],
+				},
+				{ coordinatorId: COORDINATOR_ID, groupId: GROUP_ID },
+			),
+		).toThrow("team_setup_completion_invalid");
+	});
+
+	it("applies atomically and treats the same manifest as an exact replay", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		const localPreview = inspectLegacyTeamSetupActivation(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = ? WHERE attempt_id = ?").run(
+			"Stale local name",
+			draft.attemptId,
+		);
+
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const localCompletion = db
+			.prepare(
+				`SELECT finish_digest, confirmed_access_delta_digest
+				 FROM legacy_team_setup_completions WHERE attempt_id = ?`,
+			)
+			.get(draft.attemptId) as {
+			finish_digest: string;
+			confirmed_access_delta_digest: string;
+		};
+		expect(localCompletion).toEqual({
+			finish_digest: localPreview.finishDigest,
+			confirmed_access_delta_digest: localPreview.accessDeltaDigest,
+		});
+		expect(localCompletion.finish_digest).toMatch(
+			/^legacy-team-activation-finish-v1:[0-9a-f]{64}$/u,
+		);
+		expect(localCompletion.confirmed_access_delta_digest).toMatch(
+			/^legacy-team-access-delta:[0-9a-f]{64}$/u,
+		);
+		expect(localCompletion.finish_digest).not.toBe(manifest.finish_digest);
+		expect(localCompletion.confirmed_access_delta_digest).not.toBe(manifest.access_delta_digest);
+		expect(
+			db
+				.prepare("SELECT display_name FROM policy_teams WHERE team_id = ?")
+				.pluck()
+				.get(manifest.team_id),
+		).toBe(manifest.team.display_name);
+		expect(reconstructLegacyTeamSetupCompletionManifest(db, { candidateRef: CANDIDATE })).toEqual(
+			manifest,
+		);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(reconstructLegacyTeamSetupCompletionManifest(db, { candidateRef: CANDIDATE })).toEqual(
+			manifest,
+		);
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId),
+		).toBe("completed");
+	});
+
+	it("preserves inactive assignment evidence when applying an excluded device", async () => {
+		let draft = readyDraft();
+		const device = draft.devices[0];
+		if (!device) throw new Error("missing test device");
+		draft = setLegacyTeamSetupDeviceDecision(db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			decision: "excluded",
+			now: NOW,
+		});
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare(
+			`INSERT INTO identity_devices(
+			 identity_id, device_id, display_name, status, provenance, revision, migration_state,
+			 assignment_version, idempotency_key, created_at, updated_at
+			 ) VALUES ('identity-a', 'device-a', 'Laptop', 'revoked', 'reviewed_team_setup',
+			 'prior-revision', 'completed', 7, 'prior-device-assignment', ?, ?)`,
+		).run(NOW, NOW);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [],
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare(
+					`SELECT display_name, existing_identity_id, existing_assignment_version, verified_evidence_kind,
+					        expected_assignment_kind, expected_assignment_version
+					 FROM legacy_team_setup_draft_devices
+					 WHERE attempt_id = ? AND device_id = 'device-a'`,
+				)
+				.get(draft.attemptId),
+		).toEqual({
+			display_name: "Laptop",
+			existing_identity_id: "identity-a",
+			existing_assignment_version: 7,
+			verified_evidence_kind: null,
+			expected_assignment_kind: "existing",
+			expected_assignment_version: 7,
+		});
+		expect(
+			db
+				.prepare(
+					"SELECT decision FROM policy_team_device_decisions WHERE team_id = ? AND device_id = 'device-a'",
+				)
+				.pluck()
+				.get(manifest.team_id),
+		).toBe("excluded");
+	});
+
+	it("refreshes an existing draft device label from the live roster", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET display_name = ? WHERE attempt_id = ?",
+		).run("Stale laptop", draft.attemptId);
+
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: [
+				{
+					deviceId: "device-a",
+					fingerprint: KEY_A,
+					displayName: "  Renamed laptop  ",
+					enabled: true,
+				},
+			],
+			manifest,
+		});
+
+		expect(
+			db
+				.prepare(
+					"SELECT display_name FROM legacy_team_setup_draft_devices WHERE attempt_id = ? AND device_id = 'device-a'",
+				)
+				.pluck()
+				.get(draft.attemptId),
+		).toBe("Renamed laptop");
+		expect(
+			db
+				.prepare("SELECT display_name FROM identity_devices WHERE device_id = 'device-a'")
+				.pluck()
+				.get(),
+		).toBe("Renamed laptop");
+	});
+
+	it("applies a canonical completion over a stale local draft", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET state = 'stale' WHERE attempt_id = ?").run(
+			draft.attemptId,
+		);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId),
+		).toBe("completed");
+	});
+
+	it("materializes missing canonical devices and removes newer local membership grants", async () => {
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const source = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: source.candidateRef,
+			attemptId: source.attemptId,
+			completedAt: NOW,
+		});
+		let replacement = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [
+				{
+					deviceId: "device-new",
+					fingerprint: "key-new",
+					displayName: "New laptop",
+					enabled: true,
+				},
+			],
+			projects: [],
+			now: "2026-09-01T12:01:00.000Z",
+		});
+		const newDevice = replacement.devices.find((device) => device.displayName === "New laptop");
+		if (!newDevice) throw new Error("missing replacement device");
+		replacement = setLegacyTeamSetupDeviceAssignment(db, {
+			attemptId: replacement.attemptId,
+			deviceRef: newDevice.deviceRef,
+			targetIdentityId: "identity-b",
+			expectation: newDevice.expectation,
+			now: NOW,
+		});
+		replacement = setLegacyTeamSetupDeviceDecision(db, {
+			attemptId: replacement.attemptId,
+			deviceRef: newDevice.deviceRef,
+			decision: "included",
+			now: NOW,
+		});
+		db.prepare(
+			"DELETE FROM legacy_team_setup_draft_devices WHERE attempt_id = ? AND device_id = 'device-a'",
+		).run(replacement.attemptId);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare(
+					`SELECT identity_id, status FROM policy_team_memberships
+					 WHERE team_id = ? ORDER BY identity_id`,
+				)
+				.all(manifest.team_id),
+		).toEqual([{ identity_id: "identity-a", status: "reviewed_active" }]);
+		expect(
+			db
+				.prepare(
+					`SELECT device_id, decision FROM policy_team_device_decisions
+					 WHERE team_id = ? ORDER BY device_id`,
+				)
+				.all(manifest.team_id),
+		).toEqual([{ device_id: "device-a", decision: "included" }]);
+		expect(
+			db
+				.prepare(
+					`SELECT key_fingerprint, display_name, enabled FROM legacy_team_setup_draft_devices
+					 WHERE attempt_id = ? AND device_id = 'device-a'`,
+				)
+				.get(replacement.attemptId),
+		).toEqual({ key_fingerprint: KEY_A, display_name: "Laptop", enabled: 1 });
+		expect(
+			db
+				.prepare(
+					"SELECT device_id FROM legacy_team_setup_draft_devices WHERE attempt_id = ? ORDER BY device_id",
+				)
+				.pluck()
+				.all(replacement.attemptId),
+		).toEqual(["device-a"]);
+		expect(replacement.attemptId).not.toBe(source.attemptId);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(replacement.attemptId),
+		).toBe("completed");
+	});
+
+	it("adds newly resolvable Projects without replaying completed Team policy", async () => {
+		const projectRefB = legacyTeamProjectRef(CANDIDATE, PROJECT_B);
+		db.prepare(
+			`INSERT INTO replication_scopes(
+			 scope_id, label, kind, authority_type, coordinator_id, group_id,
+			 membership_epoch, status, created_at, updated_at
+			 ) VALUES ('scope-historical', 'Historical', 'team', 'coordinator', ?, ?, 1,
+			 'active', ?, ?)`,
+		).run(COORDINATOR_ID, GROUP_ID, NOW, NOW);
+		let source = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [{ deviceId: "device-a", fingerprint: KEY_A, displayName: "Laptop", enabled: true }],
+			projects: [
+				{
+					projectRef: PROJECT_REF_A,
+					sourceProjectIdentity: PROJECT_A,
+					displayName: "API",
+					sourceFingerprint: "source-a",
+					deterministicProjectIdentity: PROJECT_A,
+					targetScopeId: "scope-engineering",
+				},
+				{
+					projectRef: projectRefB,
+					sourceProjectIdentity: PROJECT_B,
+					displayName: "Web",
+					sourceFingerprint: "source-b",
+					deterministicProjectIdentity: PROJECT_B,
+					targetScopeId: "scope-historical",
+				},
+			],
+			now: NOW,
+		});
+		const sourceDevice = source.devices[0];
+		if (!sourceDevice) throw new Error("missing source device");
+		source = setLegacyTeamSetupDeviceAssignment(db, {
+			attemptId: source.attemptId,
+			deviceRef: sourceDevice.deviceRef,
+			targetIdentityId: "identity-a",
+			expectation: sourceDevice.expectation,
+			now: NOW,
+		});
+		source = setLegacyTeamSetupDeviceDecision(db, {
+			attemptId: source.attemptId,
+			deviceRef: sourceDevice.deviceRef,
+			decision: "included",
+			now: NOW,
+		});
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: source.candidateRef,
+			attemptId: source.attemptId,
+			completedAt: NOW,
+		});
+		const replacement = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [{ deviceId: "device-a", fingerprint: KEY_A, displayName: "Laptop", enabled: true }],
+			projects: [
+				{
+					projectRef: PROJECT_REF_A,
+					sourceProjectIdentity: PROJECT_A,
+					displayName: "API",
+					sourceFingerprint: "source-a",
+					deterministicProjectIdentity: PROJECT_A,
+					targetScopeId: "scope-engineering",
+				},
+				{
+					projectRef: PROJECT_REF_C,
+					sourceProjectIdentity: PROJECT_C,
+					displayName: "New Project",
+					sourceFingerprint: "source-c",
+					deterministicProjectIdentity: PROJECT_C,
+					targetScopeId: "scope-engineering",
+				},
+			],
+			now: "2026-09-01T12:01:00.000Z",
+		});
+		db.prepare("UPDATE replication_scopes SET status = 'inactive' WHERE scope_id = ?").run(
+			"scope-historical",
+		);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare(
+					`SELECT canonical_project_identity FROM project_recipients
+					 WHERE recipient_kind = 'team' AND recipient_id = ? AND status = 'active'
+					 ORDER BY canonical_project_identity`,
+				)
+				.pluck()
+				.all(manifest.team_id),
+		).toEqual([PROJECT_A]);
+		expect(
+			db
+				.prepare(
+					`SELECT project_pattern, workspace_identity FROM project_scope_mappings
+					 WHERE source = 'reviewed_team_setup' ORDER BY project_pattern`,
+				)
+				.all(),
+		).toEqual([{ project_pattern: PROJECT_A, workspace_identity: PROJECT_A }]);
+		expect(
+			db
+				.prepare(
+					"SELECT project_ref FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref",
+				)
+				.pluck()
+				.all(replacement.attemptId),
+		).toEqual([PROJECT_REF_A]);
+		expect(
+			areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible(
+				reconstructLegacyTeamSetupCompletionManifest(db, { candidateRef: CANDIDATE }),
+				manifest,
+			),
+		).toBe(true);
+		db.prepare(
+			`INSERT INTO legacy_team_setup_draft_projects(
+			 attempt_id, project_ref, source_project_identity, display_name, source_fingerprint,
+			 resolution_kind, resolved_project_identity, target_scope_id, updated_at
+			 ) VALUES (?, ?, ?, 'Cross-scope project', 'cross-scope-source', 'explicit', ?,
+			 'scope-historical', ?)`,
+		).run(replacement.attemptId, projectRefB, PROJECT_B, PROJECT_A, NOW);
+		expect(() =>
+			applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(db, {
+				candidateRef: CANDIDATE,
+				attemptId: replacement.attemptId,
+				teamId: manifest.team_id,
+				projectRefs: [projectRefB],
+				completedAt: NOW,
+			}),
+		).toThrow("team_setup_conflict");
+		db.prepare(
+			"DELETE FROM legacy_team_setup_draft_projects WHERE attempt_id = ? AND project_ref = ?",
+		).run(replacement.attemptId, projectRefB);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		db.prepare(
+			`UPDATE project_recipients
+			 SET status = 'revoked', provenance = 'user', updated_at = ?
+			 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
+		).run("2026-09-01T12:01:30.000Z", PROJECT_A, manifest.team_id);
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		db.prepare(
+			`UPDATE identity_devices SET identity_id = 'identity-b', updated_at = ?
+			 WHERE device_id = 'device-a' AND status = 'active'`,
+		).run("2026-09-01T12:01:30.000Z");
+		db.prepare(
+			`DELETE FROM project_scope_mappings
+			 WHERE project_pattern = ? AND source = 'reviewed_team_setup'`,
+		).run(PROJECT_A);
+		db.prepare("UPDATE replication_scopes SET status = 'active' WHERE scope_id = ?").run(
+			"scope-historical",
+		);
+		db.prepare("INSERT INTO sessions(started_at, project, git_remote) VALUES (?, ?, ?)").run(
+			NOW,
+			"Web workspace",
+			PROJECT_B,
+		);
+		db.prepare(
+			`INSERT INTO project_scope_mappings(
+			 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, ?, 'scope-engineering', 1000, 'user', ?, ?)`,
+		).run(PROJECT_B, PROJECT_B, NOW, NOW);
+		const completionCountBeforeFailedConvergence = db
+			.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions")
+			.pluck()
+			.get();
+		let additiveFailure: unknown;
+		try {
+			await applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			});
+		} catch (error) {
+			additiveFailure = error;
+		}
+		expect(additiveFailure).toBeInstanceOf(LegacyTeamSetupAdditiveConvergenceError);
+		expect(additiveFailure).toMatchObject({ code: "team_setup_conflict" });
+		expect(
+			db.prepare("SELECT status FROM policy_teams WHERE team_id = ?").pluck().get(manifest.team_id),
+		).toBe("active");
+		expect(
+			db
+				.prepare(
+					"SELECT project_ref FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref",
+				)
+				.pluck()
+				.all(replacement.attemptId),
+		).toEqual([PROJECT_REF_A]);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions").pluck().get()).toBe(
+			completionCountBeforeFailedConvergence,
+		);
+		db.prepare(
+			"DELETE FROM project_scope_mappings WHERE workspace_identity = ? AND source = 'user'",
+		).run(PROJECT_B);
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key,
+			 created_at, updated_at
+			 ) VALUES (?, 'team', ?, 'revoked', 'reviewed_team_setup', ?, 'completed', ?, ?, ?, ?)`,
+		).run(
+			PROJECT_B,
+			manifest.team_id,
+			manifest.team.policy_revision,
+			"source-b",
+			"revoked-before-convergence",
+			NOW,
+			NOW,
+		);
+		const insertNewerSession = db.prepare(
+			"INSERT INTO sessions(started_at, project, git_remote) VALUES (?, ?, ?)",
+		);
+		for (let index = 0; index < 500; index += 1) {
+			insertNewerSession.run(
+				new Date(Date.parse(NOW) + (index + 1) * 1000).toISOString(),
+				"API workspace",
+				PROJECT_A,
+			);
+		}
+		db.prepare(
+			"UPDATE policy_teams SET display_name = 'Platform', revision = 'rename-revision' WHERE team_id = ?",
+		).run(manifest.team_id);
+		db.prepare(
+			"UPDATE legacy_team_setup_drafts SET display_name = 'Platform' WHERE attempt_id = ?",
+		).run(replacement.attemptId);
+		const preservedTeam = db
+			.prepare("SELECT * FROM policy_teams WHERE team_id = ?")
+			.get(manifest.team_id);
+		const preservedDraft = db
+			.prepare("SELECT * FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+			.get(replacement.attemptId);
+		const preservedCompletions = db
+			.prepare(
+				`SELECT * FROM legacy_team_setup_completions
+				 WHERE candidate_ref = ? ORDER BY completed_at, finish_digest`,
+			)
+			.all(CANDIDATE);
+		const preservedMemberships = db
+			.prepare("SELECT * FROM policy_team_memberships WHERE team_id = ? ORDER BY identity_id")
+			.all(manifest.team_id);
+		const preservedDecisions = db
+			.prepare("SELECT * FROM policy_team_device_decisions WHERE team_id = ? ORDER BY device_id")
+			.all(manifest.team_id);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare(
+					`SELECT canonical_project_identity FROM project_recipients
+					 WHERE recipient_kind = 'team' AND recipient_id = ? AND status = 'active'
+					 ORDER BY canonical_project_identity`,
+				)
+				.pluck()
+				.all(manifest.team_id),
+		).toEqual([PROJECT_B]);
+		expect(
+			db
+				.prepare(
+					`SELECT project_pattern, workspace_identity FROM project_scope_mappings
+					 WHERE source = 'reviewed_team_setup' ORDER BY project_pattern`,
+				)
+				.all(),
+		).toEqual([{ project_pattern: PROJECT_B, workspace_identity: PROJECT_B }]);
+		expect(
+			db
+				.prepare(
+					`SELECT status, provenance, policy_revision FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
+				)
+				.get(PROJECT_A, manifest.team_id),
+		).toEqual({
+			status: "revoked",
+			provenance: "user",
+			policy_revision: manifest.team.policy_revision,
+		});
+		expect(
+			db
+				.prepare(
+					`SELECT status, provenance, policy_revision FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
+				)
+				.get(PROJECT_B, manifest.team_id),
+		).toEqual({
+			status: "active",
+			provenance: "reviewed_team_setup",
+			policy_revision: "rename-revision",
+		});
+		expect(
+			db
+				.prepare(
+					"SELECT display_name FROM legacy_team_setup_draft_projects WHERE attempt_id = ? AND project_ref = ?",
+				)
+				.pluck()
+				.get(replacement.attemptId, projectRefB),
+		).toBe("Web workspace");
+		expect(
+			db
+				.prepare("SELECT display_name, revision FROM policy_teams WHERE team_id = ?")
+				.get(manifest.team_id),
+		).toEqual({ display_name: "Platform", revision: "rename-revision" });
+		expect(
+			db
+				.prepare("SELECT display_name FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(replacement.attemptId),
+		).toBe("Platform");
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(replacement.attemptId),
+		).toBe("completed");
+		expect(
+			db
+				.prepare(
+					"SELECT identity_id FROM identity_devices WHERE device_id = 'device-a' AND status = 'active'",
+				)
+				.pluck()
+				.get(),
+		).toBe("identity-b");
+		expect(
+			db.prepare("SELECT * FROM policy_teams WHERE team_id = ?").get(manifest.team_id),
+		).toEqual(preservedTeam);
+		expect(
+			db
+				.prepare("SELECT * FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.get(replacement.attemptId),
+		).toEqual(preservedDraft);
+		expect(
+			db
+				.prepare(
+					`SELECT * FROM legacy_team_setup_completions
+					 WHERE candidate_ref = ? ORDER BY completed_at, finish_digest`,
+				)
+				.all(CANDIDATE),
+		).toEqual(preservedCompletions);
+		expect(
+			db
+				.prepare("SELECT * FROM policy_team_memberships WHERE team_id = ? ORDER BY identity_id")
+				.all(manifest.team_id),
+		).toEqual(preservedMemberships);
+		expect(
+			db
+				.prepare("SELECT * FROM policy_team_device_decisions WHERE team_id = ? ORDER BY device_id")
+				.all(manifest.team_id),
+		).toEqual(preservedDecisions);
+
+		const additiveFacts = {
+			mappings: db.prepare("SELECT * FROM project_scope_mappings ORDER BY id").all(),
+			recipients: db
+				.prepare(
+					`SELECT * FROM project_recipients
+					 WHERE recipient_kind = 'team' AND recipient_id = ? ORDER BY canonical_project_identity`,
+				)
+				.all(manifest.team_id),
+			projects: db
+				.prepare(
+					"SELECT * FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref",
+				)
+				.all(replacement.attemptId),
+		};
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect({
+			mappings: db.prepare("SELECT * FROM project_scope_mappings ORDER BY id").all(),
+			recipients: db
+				.prepare(
+					`SELECT * FROM project_recipients
+					 WHERE recipient_kind = 'team' AND recipient_id = ? ORDER BY canonical_project_identity`,
+				)
+				.all(manifest.team_id),
+			projects: db
+				.prepare(
+					"SELECT * FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref",
+				)
+				.all(replacement.attemptId),
+		}).toEqual(additiveFacts);
+	});
+
+	it("preserves a supported linked Team rename when reconciling the original manifest", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		db.prepare(
+			"UPDATE policy_teams SET display_name = 'Platform', revision = 'rename-revision'",
+		).run();
+		db.prepare(
+			"UPDATE legacy_team_setup_drafts SET display_name = 'Platform' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(db.prepare("SELECT display_name, revision FROM policy_teams").get()).toEqual({
+			display_name: "Platform",
+			revision: "rename-revision",
+		});
+	});
+
+	it("preserves an active Team rename when applying the original manifest to a replacement draft", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const expandedRoster = [
+			...FRESH_ROSTER,
+			{
+				deviceId: "device-b",
+				fingerprint: "b".repeat(64),
+				displayName: "Tablet",
+				enabled: true,
+			},
+		];
+		const replacement = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Platform",
+			devices: expandedRoster,
+			projects: [],
+			now: "2026-09-01T12:01:00.000Z",
+		});
+		db.prepare(
+			"UPDATE policy_teams SET display_name = 'Platform', revision = 'rename-revision'",
+		).run();
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = 'Platform'").run();
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: expandedRoster,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(db.prepare("SELECT display_name, revision FROM policy_teams").get()).toEqual({
+			display_name: "Platform",
+			revision: manifest.team.policy_revision,
+		});
+		expect(
+			db
+				.prepare("SELECT display_name, state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.get(replacement.attemptId),
+		).toEqual({ display_name: "Platform", state: "completed" });
+	});
+
+	it("validates fresh included-device evidence before completed replay", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [
+					{ deviceId: "device-a", fingerprint: "key-b", displayName: "Laptop", enabled: true },
+				],
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [
+					{ deviceId: "device-a", fingerprint: "key-b", displayName: "Laptop", enabled: true },
+				],
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions").pluck().get()).toBe(2);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [
+					{ deviceId: "device-a", fingerprint: "key-b", displayName: "Laptop", enabled: true },
+				],
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		db.prepare(
+			`UPDATE legacy_team_setup_completions SET completed_team_id = 'unexpected-team'
+			 WHERE rowid = (SELECT MAX(rowid) FROM legacy_team_setup_completions)`,
+		).run();
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		expect(
+			db.prepare("SELECT status FROM policy_teams WHERE team_id = ?").pluck().get(manifest.team_id),
+		).toBe("inactive");
+	});
+
+	it("rejects a canonical completion when an included device was re-keyed", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		const replacement = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [
+				{
+					deviceId: "device-a",
+					fingerprint: "key-b",
+					displayName: "Laptop",
+					enabled: true,
+				},
+			],
+			projects: [],
+			now: "2026-09-01T12:01:00.000Z",
+		});
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [
+					{ deviceId: "device-a", fingerprint: "key-b", displayName: "Laptop", enabled: true },
+				],
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		expect(
+			db
+				.prepare(
+					"SELECT state, key_fingerprint FROM legacy_team_setup_drafts JOIN legacy_team_setup_draft_devices USING (attempt_id) WHERE attempt_id = ?",
+				)
+				.get(replacement.attemptId),
+		).toEqual({ state: "needs_setup", key_fingerprint: "key-b" });
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+	});
+
+	it("rejects a canonical completion when an included device was disabled", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [
+					{ deviceId: "device-a", fingerprint: KEY_A, displayName: "Laptop", enabled: false },
+				],
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+	});
+
+	it("contains active policy when canonical apply fails on a replacement draft", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const replacement = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [
+				{
+					deviceId: "device-a",
+					fingerprint: KEY_A,
+					displayName: "Laptop",
+					enabled: true,
+				},
+			],
+			projects: [],
+			now: "2026-09-01T12:01:00.000Z",
+		});
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key,
+			 created_at, updated_at
+			 ) VALUES ('project-private', 'team', ?, 'active', 'reviewed_team_setup',
+			 'local-revision', 'completed', 'local-source', 'local-key', ?, ?)`,
+		).run(manifest.team_id, NOW, NOW);
+		db.prepare("UPDATE actors SET status = 'inactive' WHERE actor_id = 'identity-a'").run();
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_conflict");
+		expect(
+			db.prepare("SELECT status FROM policy_teams WHERE team_id = ?").pluck().get(manifest.team_id),
+		).toBe("inactive");
+		expect(
+			db
+				.prepare(
+					`SELECT status FROM project_recipients
+					 WHERE canonical_project_identity = 'project-private'`,
+				)
+				.pluck()
+				.get(),
+		).toBe("revoked");
+		expect(replacement.state).toBe("needs_setup");
+	});
+
+	it("supersedes a divergent pre-protocol local completion", async () => {
+		const draft = readyDraft();
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const localManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = ? WHERE attempt_id = ?").run(
+			"Platform",
+			draft.attemptId,
+		);
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-b' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		const canonicalManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = ? WHERE attempt_id = ?").run(
+			"Engineering",
+			draft.attemptId,
+		);
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-a' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest: localManifest,
+		});
+		const oldCompletion = db
+			.prepare(
+				`SELECT finish_digest, confirmed_access_delta_digest
+				 FROM legacy_team_setup_completions WHERE attempt_id = ?`,
+			)
+			.get(draft.attemptId) as {
+			finish_digest: string;
+			confirmed_access_delta_digest: string;
+		};
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: canonicalManifest,
+			}),
+		).resolves.toEqual(canonicalManifest);
+		expect(reconstructLegacyTeamSetupCompletionManifest(db, { candidateRef: CANDIDATE })).toEqual(
+			canonicalManifest,
+		);
+		expect(
+			db
+				.prepare("SELECT display_name FROM policy_teams WHERE team_id = ?")
+				.pluck()
+				.get(canonicalManifest.team_id),
+		).toBe("Platform");
+		expect(
+			db
+				.prepare(
+					"SELECT identity_id FROM identity_devices WHERE device_id = 'device-a' AND status = 'active'",
+				)
+				.pluck()
+				.get(),
+		).toBe("identity-b");
+		await expect(
+			finishLegacyTeamSetupActivation(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+				finishDigest: oldCompletion.finish_digest,
+				confirmedAccessDeltaDigest: oldCompletion.confirmed_access_delta_digest,
+				loadFreshRoster: async () => [],
+				loadProjectInventory: () => [],
+			}),
+		).rejects.toThrow("team_setup_confirmation_stale");
+	});
+
+	it("quarantines divergent local policy when the canonical winner cannot be applied", async () => {
+		const draft = readyDraft();
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const localManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = ? WHERE attempt_id = ?").run(
+			"Platform",
+			draft.attemptId,
+		);
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-b' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		const canonicalManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = ? WHERE attempt_id = ?").run(
+			"Engineering",
+			draft.attemptId,
+		);
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-a' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest: localManifest,
+		});
+		const oldCompletion = db
+			.prepare(
+				`SELECT finish_digest, confirmed_access_delta_digest
+				 FROM legacy_team_setup_completions WHERE attempt_id = ?`,
+			)
+			.get(draft.attemptId) as {
+			finish_digest: string;
+			confirmed_access_delta_digest: string;
+		};
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key,
+			 created_at, updated_at
+			 ) VALUES ('project-private', 'team', ?, 'active', 'reviewed_team_setup',
+			 'local-revision', 'completed', 'local-source', 'local-key', ?, ?)`,
+		).run(canonicalManifest.team_id, NOW, NOW);
+		db.prepare("UPDATE actors SET status = 'inactive' WHERE actor_id = 'identity-b'").run();
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: canonicalManifest,
+			}),
+		).rejects.toThrow("team_setup_conflict");
+		expect(
+			db
+				.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+				.get(canonicalManifest.team_id),
+		).toEqual({ status: "inactive", migration_state: "needs_setup" });
+		expect(
+			db
+				.prepare(
+					`SELECT status, migration_state FROM project_recipients
+					 WHERE canonical_project_identity = 'project-private'`,
+				)
+				.get(),
+		).toEqual({ status: "revoked", migration_state: "needs_setup" });
+		db.prepare(
+			"UPDATE legacy_team_setup_drafts SET state = 'in_progress' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		const assignmentVersion = db
+			.prepare(
+				"SELECT assignment_version FROM identity_devices WHERE device_id = 'device-a' AND status = 'active'",
+			)
+			.pluck()
+			.get() as number;
+		db.prepare(
+			`UPDATE legacy_team_setup_draft_devices
+			 SET existing_identity_id = 'identity-a', existing_assignment_version = ?,
+			     verified_evidence_kind = 'active_assignment', expected_assignment_kind = 'existing',
+			     expected_assignment_version = ?
+			 WHERE attempt_id = ? AND device_id = 'device-a'`,
+		).run(assignmentVersion, assignmentVersion, draft.attemptId);
+		expect(() =>
+			inspectLegacyTeamSetupActivation(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+			}),
+		).toThrow("team_setup_conflict");
+		db.prepare("UPDATE legacy_team_setup_drafts SET state = 'completed' WHERE attempt_id = ?").run(
+			draft.attemptId,
+		);
+		await expect(
+			finishLegacyTeamSetupActivation(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+				finishDigest: oldCompletion.finish_digest,
+				confirmedAccessDeltaDigest: oldCompletion.confirmed_access_delta_digest,
+				loadFreshRoster: async () => [],
+				loadProjectInventory: () => [],
+			}),
+		).rejects.toThrow("team_setup_confirmation_stale");
+
+		db.prepare("UPDATE actors SET status = 'active' WHERE actor_id = 'identity-b'").run();
+		db.prepare("UPDATE policy_teams SET migration_state = 'completed' WHERE team_id = ?").run(
+			canonicalManifest.team_id,
+		);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: canonicalManifest,
+			}),
+		).rejects.toThrow("team_setup_conflict");
+		db.prepare("UPDATE policy_teams SET migration_state = 'needs_setup' WHERE team_id = ?").run(
+			canonicalManifest.team_id,
+		);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: canonicalManifest,
+			}),
+		).resolves.toEqual(canonicalManifest);
+		expect(
+			db
+				.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+				.get(canonicalManifest.team_id),
+		).toEqual({ status: "active", migration_state: "completed" });
+	});
+
+	it("quarantines a bound completion whose digest validation fails", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const localRevision = db
+			.prepare("SELECT revision FROM policy_teams WHERE team_id = ?")
+			.pluck()
+			.get(manifest.team_id) as string;
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key,
+			 created_at, updated_at
+			 ) VALUES ('project-private', 'team', ?, 'active', 'reviewed_team_setup',
+			 'stale-revision', 'completed', 'local-source', 'local-key', ?, ?)`,
+		).run(manifest.team_id, NOW, NOW);
+		const invalidManifest = {
+			...manifest,
+			source_digest: "0".repeat(64),
+			team: { ...manifest.team, policy_revision: "1".repeat(64) },
+		};
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: invalidManifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		expect(
+			db
+				.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+				.get(manifest.team_id),
+		).toEqual({ status: "inactive", migration_state: "needs_setup" });
+		expect(
+			db
+				.prepare(
+					`SELECT status, policy_revision, migration_state FROM project_recipients
+				 WHERE canonical_project_identity = 'project-private'`,
+				)
+				.get(),
+		).toEqual({
+			status: "revoked",
+			policy_revision: localRevision,
+			migration_state: "needs_setup",
+		});
+		expect(
+			db
+				.prepare("SELECT finish_digest FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.get(draft.attemptId),
+		).toEqual({ finish_digest: null });
+	});
+
+	it.each([
+		["malformed", {}],
+		["bound to another coordinator", { coordinator_id: "coordinator-other" }],
+		[
+			"bound to another candidate",
+			{
+				candidate_ref: "legacy-team-candidate:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				team_id: "policy-team-v1:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			},
+		],
+	] as const)(
+		"does not quarantine active policy for an %s payload",
+		async (_label, replacement) => {
+			const draft = readyDraft();
+			const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+				candidateRef: draft.candidateRef,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			await applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			});
+			const finishDigest = db
+				.prepare("SELECT finish_digest FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId);
+			const payload =
+				Object.keys(replacement).length === 0 ? replacement : { ...manifest, ...replacement };
+
+			await expect(
+				applyLegacyTeamSetupCompletionManifest(db, {
+					coordinatorId: COORDINATOR_ID,
+					groupId: GROUP_ID,
+					freshRoster: FRESH_ROSTER,
+					manifest: payload,
+				}),
+			).rejects.toThrow("team_setup_completion_invalid");
+			expect(
+				db
+					.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+					.get(manifest.team_id),
+			).toEqual({ status: "active", migration_state: "completed" });
+			expect(
+				db
+					.prepare("SELECT finish_digest FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+					.pluck()
+					.get(draft.attemptId),
+			).toBe(finishDigest);
+		},
+	);
+
+	it("rolls back when canonical identity evidence is unavailable", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE actors SET status = 'inactive' WHERE actor_id = 'identity-a'").run();
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_conflict");
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId),
+		).not.toBe("completed");
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+	});
+});

--- a/packages/core/src/legacy-team-setup-completion-manifest.ts
+++ b/packages/core/src/legacy-team-setup-completion-manifest.ts
@@ -1,0 +1,1110 @@
+import {
+	type CoordinatorLegacyTeamCompletionManifestV1,
+	canonicalCoordinatorLegacyTeamCompletionManifestJson,
+	normalizeCoordinatorLegacyTeamCompletionManifest,
+} from "./coordinator-legacy-team-completion.js";
+import type { Database } from "./db.js";
+import {
+	isLegacyTeamCandidateSelectable,
+	type LegacyTeamRosterDeviceSnapshot,
+} from "./legacy-team-candidate.js";
+import {
+	applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction,
+	applyCanonicalLegacyTeamSetupActivationInTransaction,
+	inspectLegacyTeamSetupActivation,
+	LegacyTeamSetupActivationError,
+	type LegacyTeamSetupActivationErrorCode,
+} from "./legacy-team-setup-activation.js";
+import { legacyTeamResolvedProjectRef } from "./legacy-team-setup-draft.js";
+import { safeLabel, setupLabelForbiddenIds } from "./legacy-team-setup-label-policy.js";
+import {
+	LEGACY_TEAM_SETUP_MAX_DEVICES,
+	LEGACY_TEAM_SETUP_MAX_PROJECTS,
+} from "./legacy-team-setup-limits.js";
+import { listProjectScopeCandidates } from "./project-scope-settings.js";
+import type { LegacyTeamSetupActivationResultV1 } from "./recipient-policy-contract.js";
+import {
+	compareCodepoints,
+	deterministicPolicyTeamId,
+	legacyTeamCandidateId,
+	legacyTeamDeviceRef,
+	legacyTeamProjectRef,
+	recipientPolicyDigest,
+} from "./recipient-policy-identifiers.js";
+import {
+	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyPublicationMutation,
+	serializeRecipientPolicyTeamMutation,
+} from "./recipient-policy-team-metadata.js";
+
+export type LegacyTeamSetupCompletionManifestErrorCode =
+	| "team_setup_completion_invalid"
+	| "team_setup_completion_conflict";
+
+export class LegacyTeamSetupCompletionManifestError extends Error {
+	readonly code: LegacyTeamSetupCompletionManifestErrorCode;
+
+	constructor(code: LegacyTeamSetupCompletionManifestErrorCode) {
+		super(code);
+		this.name = "LegacyTeamSetupCompletionManifestError";
+		this.code = code;
+	}
+}
+
+export class LegacyTeamSetupAdditiveConvergenceError extends Error {
+	readonly code: LegacyTeamSetupActivationErrorCode;
+
+	constructor(error: unknown) {
+		const code =
+			error instanceof LegacyTeamSetupActivationError ||
+			error instanceof LegacyTeamSetupCompletionManifestError
+				? error.code
+				: "team_setup_conflict";
+		super(code, { cause: error });
+		this.name = "LegacyTeamSetupAdditiveConvergenceError";
+		this.code = code;
+	}
+}
+
+interface DraftRow {
+	attempt_id: string;
+	candidate_id: string;
+	coordinator_id: string;
+	group_id: string;
+	state: string;
+	display_name: string;
+	finish_digest: string | null;
+	completed_at: string | null;
+}
+
+interface DraftDeviceRow {
+	device_id: string;
+	key_fingerprint: string;
+	enabled: number;
+	decision: string;
+	target_identity_id: string | null;
+}
+
+interface ApplyCompletionManifestInput {
+	coordinatorId: string;
+	groupId: string;
+	manifest: unknown;
+	freshRoster: readonly LegacyTeamRosterDeviceSnapshot[];
+	expectedDraftManifest?: CoordinatorLegacyTeamCompletionManifestV1;
+	recipientPolicyMutationSerialized?: boolean;
+}
+
+interface DraftProjectRow {
+	project_ref: string;
+	source_project_identity: string;
+	resolved_project_identity: string | null;
+	target_scope_id: string | null;
+}
+
+interface ResolvedManifestProject {
+	sourceIdentity: string;
+	resolvedIdentity: string;
+	displayName: string;
+}
+
+function fail(code: LegacyTeamSetupCompletionManifestErrorCode): never {
+	throw new LegacyTeamSetupCompletionManifestError(code);
+}
+
+function digest(domain: string, value: unknown): string {
+	const prefixedDigest = recipientPolicyDigest(domain, value);
+	const prefix = `${domain}:`;
+	if (!prefixedDigest.startsWith(prefix)) fail("team_setup_completion_invalid");
+	const rawDigest = prefixedDigest.slice(prefix.length);
+	if (!/^[0-9a-f]{64}$/u.test(rawDigest)) fail("team_setup_completion_invalid");
+	return rawDigest;
+}
+
+function manifestDigests(
+	coordinatorId: string,
+	groupId: string,
+	manifest: Omit<
+		CoordinatorLegacyTeamCompletionManifestV1,
+		| "candidate_digest"
+		| "team_digest"
+		| "source_digest"
+		| "finish_digest"
+		| "access_delta_digest"
+		| "completed_at"
+	> & { completed_at?: string },
+): Pick<
+	CoordinatorLegacyTeamCompletionManifestV1,
+	"candidate_digest" | "team_digest" | "source_digest" | "finish_digest" | "access_delta_digest"
+> {
+	const candidateDigest = digest("legacy-team-completion-candidate-v1", {
+		coordinatorId,
+		groupId,
+		candidateRef: manifest.candidate_ref,
+	});
+	const teamDigest = digest("legacy-team-completion-team-v1", {
+		teamId: manifest.team_id,
+		displayName: manifest.team.display_name,
+		deviceEligibilityMode: manifest.team.device_eligibility_mode,
+	});
+	const sourceDigest = digest("legacy-team-completion-source-v1", {
+		deviceDecisions: manifest.device_decisions,
+		projectMappings: manifest.project_mappings,
+	});
+	const accessDeltaDigest = digest("legacy-team-completion-access-delta-v1", {
+		memberships: manifest.memberships,
+		projectRecipients: manifest.project_recipients,
+	});
+	return {
+		candidate_digest: candidateDigest,
+		team_digest: teamDigest,
+		source_digest: sourceDigest,
+		access_delta_digest: accessDeltaDigest,
+		finish_digest: digest("legacy-team-completion-finish-v1", {
+			candidateDigest,
+			teamDigest,
+			sourceDigest,
+			accessDeltaDigest,
+		}),
+	};
+}
+
+function loadDraft(db: Database, candidateRef: string, attemptId?: string): DraftRow {
+	const row = attemptId
+		? (db
+				.prepare(
+					`SELECT attempt_id, candidate_id, coordinator_id, group_id, state, display_name, finish_digest, completed_at
+					 FROM legacy_team_setup_drafts WHERE attempt_id = ? AND candidate_id = ?`,
+				)
+				.get(attemptId, candidateRef) as DraftRow | undefined)
+		: (db
+				.prepare(
+					`SELECT attempt_id, candidate_id, coordinator_id, group_id, state, display_name, finish_digest, completed_at
+					 FROM legacy_team_setup_drafts WHERE candidate_id = ? ORDER BY rowid DESC LIMIT 1`,
+				)
+				.get(candidateRef) as DraftRow | undefined);
+	if (!row) fail("team_setup_completion_invalid");
+	return row;
+}
+
+function loadCompletedDraft(db: Database, candidateRef: string): DraftRow {
+	const row = db
+		.prepare(
+			`SELECT attempt_id, candidate_id, coordinator_id, group_id, state, display_name, finish_digest, completed_at
+			 FROM legacy_team_setup_drafts
+			 WHERE candidate_id = ? AND state = 'completed'
+			 ORDER BY rowid DESC LIMIT 1`,
+		)
+		.get(candidateRef) as DraftRow | undefined;
+	if (!row) fail("team_setup_completion_invalid");
+	return row;
+}
+
+function deriveFromDraft(
+	db: Database,
+	draft: DraftRow,
+	completedAt: string,
+): CoordinatorLegacyTeamCompletionManifestV1 {
+	const devices = db
+		.prepare(
+			`SELECT device_id, key_fingerprint, enabled, decision, target_identity_id
+			 FROM legacy_team_setup_draft_devices WHERE attempt_id = ? ORDER BY device_id`,
+		)
+		.all(draft.attempt_id) as DraftDeviceRow[];
+	const projects = db
+		.prepare(
+			`SELECT project_ref, source_project_identity, resolved_project_identity, target_scope_id
+			 FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref`,
+		)
+		.all(draft.attempt_id) as DraftProjectRow[];
+	if (
+		devices.length === 0 ||
+		devices.length > LEGACY_TEAM_SETUP_MAX_DEVICES ||
+		projects.length > LEGACY_TEAM_SETUP_MAX_PROJECTS ||
+		devices.some(
+			(device) =>
+				!["included", "excluded", "removed"].includes(device.decision) ||
+				(device.decision === "included" && !device.target_identity_id),
+		) ||
+		projects.some((project) => !project.resolved_project_identity)
+	) {
+		fail("team_setup_completion_invalid");
+	}
+	const teamId = deterministicPolicyTeamId(draft.candidate_id);
+	const memberships = [
+		...new Set(
+			devices.flatMap((device) =>
+				device.decision === "included" && device.target_identity_id
+					? [device.target_identity_id]
+					: [],
+			),
+		),
+	]
+		.toSorted(compareCodepoints)
+		.map((identityId) => ({ identity_id: identityId, role: "member" as const }));
+	const deviceDecisions = devices
+		.filter((device) => device.decision !== "removed")
+		.map((device) => ({
+			device_id: device.device_id,
+			key_fingerprint: device.key_fingerprint,
+			enabled: device.enabled !== 0,
+			identity_id: device.decision === "included" ? device.target_identity_id : null,
+			decision: device.decision === "included" ? ("included" as const) : ("excluded" as const),
+		}));
+	const projectMappings = projects.map((project) => {
+		const matchingScopeIds = project.target_scope_id
+			? [project.target_scope_id]
+			: (db
+					.prepare(
+						`SELECT DISTINCT mapping.scope_id FROM project_scope_mappings AS mapping
+						 JOIN replication_scopes AS scope ON scope.scope_id = mapping.scope_id
+						 WHERE mapping.project_pattern = ? AND mapping.workspace_identity = ?
+						   AND scope.coordinator_id = ? AND scope.group_id = ?
+						   AND scope.authority_type = 'coordinator' AND scope.status = 'active'
+						 ORDER BY mapping.scope_id`,
+					)
+					.pluck()
+					.all(
+						project.source_project_identity,
+						project.resolved_project_identity,
+						draft.coordinator_id,
+						draft.group_id,
+					) as string[]);
+		if (matchingScopeIds.length !== 1) fail("team_setup_completion_invalid");
+		return {
+			project_ref: project.project_ref,
+			resolved_project_ref: legacyTeamResolvedProjectRef(
+				project.project_ref,
+				project.resolved_project_identity as string,
+			),
+			scope_id: matchingScopeIds[0] as string,
+		};
+	});
+	const projectRecipients = [
+		...new Set(projectMappings.map((mapping) => mapping.resolved_project_ref)),
+	]
+		.toSorted(compareCodepoints)
+		.map((resolvedProjectRef) => ({ resolved_project_ref: resolvedProjectRef, team_id: teamId }));
+	const base = {
+		version: 1 as const,
+		coordinator_id: draft.coordinator_id,
+		candidate_ref: draft.candidate_id,
+		team_id: teamId,
+		team: {
+			display_name: draft.display_name,
+			policy_revision: "",
+			device_eligibility_mode: "reviewed_allowlist" as const,
+		},
+		memberships,
+		device_decisions: deviceDecisions,
+		project_mappings: projectMappings,
+		project_recipients: projectRecipients,
+	};
+	const digests = manifestDigests(draft.coordinator_id, draft.group_id, base);
+	const policyRevision = digest("legacy-team-completion-policy-revision-v1", digests.finish_digest);
+	return normalizeCoordinatorLegacyTeamCompletionManifest({
+		...base,
+		...digests,
+		team: { ...base.team, policy_revision: policyRevision },
+		completed_at: completedAt,
+	});
+}
+
+export function deriveLegacyTeamSetupCompletionManifest(
+	db: Database,
+	input: { candidateRef: string; attemptId: string; completedAt?: string },
+): CoordinatorLegacyTeamCompletionManifestV1 {
+	const draft = loadDraft(db, input.candidateRef, input.attemptId);
+	if (draft.state !== "needs_setup" && draft.state !== "in_progress") {
+		fail("team_setup_completion_invalid");
+	}
+	try {
+		inspectLegacyTeamSetupActivation(db, {
+			candidateRef: input.candidateRef,
+			attemptId: input.attemptId,
+		});
+	} catch {
+		fail("team_setup_completion_invalid");
+	}
+	return deriveFromDraft(db, draft, input.completedAt ?? new Date().toISOString());
+}
+
+export function reconstructLegacyTeamSetupCompletionManifest(
+	db: Database,
+	input: { candidateRef: string },
+): CoordinatorLegacyTeamCompletionManifestV1 {
+	const draft = loadCompletedDraft(db, input.candidateRef);
+	if (draft.state !== "completed" || !draft.completed_at) fail("team_setup_completion_invalid");
+	const manifest = deriveFromDraft(db, draft, draft.completed_at);
+	const team = db
+		.prepare("SELECT display_name FROM policy_teams WHERE team_id = ? AND status = 'active'")
+		.get(manifest.team_id) as { display_name: string } | undefined;
+	if (
+		!team ||
+		team.display_name !== manifest.team.display_name ||
+		!isLegacyTeamCandidateSelectable(db, input.candidateRef)
+	) {
+		fail("team_setup_completion_conflict");
+	}
+	return manifest;
+}
+
+export function validateLegacyTeamSetupCompletionManifest(
+	value: unknown,
+	input: { coordinatorId: string; groupId: string },
+): CoordinatorLegacyTeamCompletionManifestV1 {
+	const manifest = validateLegacyTeamSetupCompletionManifestBinding(value, input);
+	const includedIdentityIds = [
+		...new Set(
+			manifest.device_decisions.flatMap((decision) =>
+				decision.identity_id ? [decision.identity_id] : [],
+			),
+		),
+	].toSorted(compareCodepoints);
+	const membershipIdentityIds = manifest.memberships.map((membership) => membership.identity_id);
+	const expectedRecipientRefs = [
+		...new Set(manifest.project_mappings.map((mapping) => mapping.resolved_project_ref)),
+	].toSorted(compareCodepoints);
+	const recipientRefs = manifest.project_recipients.map(
+		(recipient) => recipient.resolved_project_ref,
+	);
+	if (
+		JSON.stringify(membershipIdentityIds) !== JSON.stringify(includedIdentityIds) ||
+		JSON.stringify(recipientRefs) !== JSON.stringify(expectedRecipientRefs)
+	) {
+		fail("team_setup_completion_invalid");
+	}
+	const expected = manifestDigests(input.coordinatorId, input.groupId, manifest);
+	const expectedRevision = digest(
+		"legacy-team-completion-policy-revision-v1",
+		expected.finish_digest,
+	);
+	if (
+		manifest.candidate_digest !== expected.candidate_digest ||
+		manifest.team_digest !== expected.team_digest ||
+		manifest.source_digest !== expected.source_digest ||
+		manifest.finish_digest !== expected.finish_digest ||
+		manifest.access_delta_digest !== expected.access_delta_digest ||
+		manifest.team.policy_revision !== expectedRevision
+	) {
+		fail("team_setup_completion_invalid");
+	}
+	return manifest;
+}
+
+export function validateLegacyTeamSetupCompletionManifestBinding(
+	value: unknown,
+	input: { coordinatorId: string; groupId: string },
+): CoordinatorLegacyTeamCompletionManifestV1 {
+	let manifest: CoordinatorLegacyTeamCompletionManifestV1;
+	try {
+		manifest = normalizeCoordinatorLegacyTeamCompletionManifest(value);
+	} catch {
+		fail("team_setup_completion_invalid");
+	}
+	if (
+		manifest.coordinator_id !== input.coordinatorId ||
+		manifest.candidate_ref !== legacyTeamCandidateId(input.coordinatorId, input.groupId) ||
+		manifest.team_id !== deterministicPolicyTeamId(manifest.candidate_ref)
+	) {
+		fail("team_setup_completion_invalid");
+	}
+	return manifest;
+}
+
+function resolveManifestProjects(
+	db: Database,
+	attemptId: string,
+	manifest: CoordinatorLegacyTeamCompletionManifestV1,
+): Map<string, ResolvedManifestProject> {
+	const projects = db
+		.prepare(
+			`SELECT project_ref, source_project_identity, resolved_project_identity
+			 FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref
+			 LIMIT ?`,
+		)
+		.all(attemptId, LEGACY_TEAM_SETUP_MAX_PROJECTS + 1) as DraftProjectRow[];
+	if (projects.length > LEGACY_TEAM_SETUP_MAX_PROJECTS) fail("team_setup_completion_invalid");
+	const localCandidates = listProjectScopeCandidates(db, {
+		limit: null,
+		excludePeerReceived: true,
+	});
+	const identities = [
+		...new Set([
+			...projects.flatMap((project) => [
+				project.source_project_identity,
+				...(project.resolved_project_identity ? [project.resolved_project_identity] : []),
+			]),
+			...localCandidates.map((candidate) => candidate.workspace_identity),
+		]),
+	].toSorted(compareCodepoints);
+	const displayNameByIdentity = new Map(
+		localCandidates.map((candidate) => [candidate.workspace_identity, candidate.display_project]),
+	);
+	const identityByResolvedRef = new Map<string, string>();
+	const identityByProjectRef = new Map(
+		projects.map((project) => [project.project_ref, project.source_project_identity]),
+	);
+	for (const identity of identities) {
+		for (const mapping of manifest.project_mappings) {
+			if (legacyTeamProjectRef(manifest.candidate_ref, identity) === mapping.project_ref) {
+				const existingSource = identityByProjectRef.get(mapping.project_ref);
+				if (existingSource && existingSource !== identity) fail("team_setup_completion_invalid");
+				identityByProjectRef.set(mapping.project_ref, identity);
+			}
+			if (
+				legacyTeamResolvedProjectRef(mapping.project_ref, identity) !== mapping.resolved_project_ref
+			) {
+				continue;
+			}
+			const existing = identityByResolvedRef.get(mapping.resolved_project_ref);
+			if (existing && existing !== identity) fail("team_setup_completion_invalid");
+			identityByResolvedRef.set(mapping.resolved_project_ref, identity);
+		}
+	}
+	const resolved = new Map<string, ResolvedManifestProject>();
+	for (const mapping of manifest.project_mappings) {
+		const sourceIdentity = identityByProjectRef.get(mapping.project_ref);
+		const resolvedIdentity = identityByResolvedRef.get(mapping.resolved_project_ref);
+		if (!sourceIdentity || !resolvedIdentity) continue;
+		resolved.set(mapping.project_ref, {
+			sourceIdentity,
+			resolvedIdentity,
+			displayName:
+				displayNameByIdentity.get(sourceIdentity) ??
+				displayNameByIdentity.get(resolvedIdentity) ??
+				"Canonical project",
+		});
+	}
+	return resolved;
+}
+
+function rewriteDraftFromManifest(
+	db: Database,
+	draft: DraftRow,
+	manifest: CoordinatorLegacyTeamCompletionManifestV1,
+	freshRoster: readonly LegacyTeamRosterDeviceSnapshot[],
+	preservedTeamDisplayName?: string,
+): void {
+	db.prepare(
+		"UPDATE legacy_team_setup_drafts SET display_name = ?, updated_at = ? WHERE attempt_id = ?",
+	).run(
+		preservedTeamDisplayName ?? manifest.team.display_name,
+		manifest.completed_at,
+		draft.attempt_id,
+	);
+	const draftDeviceIds = db
+		.prepare(
+			`SELECT device_id FROM legacy_team_setup_draft_devices
+			 WHERE attempt_id = ? ORDER BY device_id LIMIT ?`,
+		)
+		.pluck()
+		.all(draft.attempt_id, LEGACY_TEAM_SETUP_MAX_DEVICES + 1) as string[];
+	if (draftDeviceIds.length > LEGACY_TEAM_SETUP_MAX_DEVICES) {
+		fail("team_setup_completion_invalid");
+	}
+	const manifestDeviceIds = new Set(
+		manifest.device_decisions.map((decision) => decision.device_id),
+	);
+	const deleteDevice = db.prepare(
+		"DELETE FROM legacy_team_setup_draft_devices WHERE attempt_id = ? AND device_id = ?",
+	);
+	// Local roster additions postdate the winner and carry no canonical review.
+	// Removing their draft rows also lets activation revoke setup-owned members
+	// and decisions without growing the bounded draft to the union of rosters.
+	for (const deviceId of draftDeviceIds) {
+		if (!manifestDeviceIds.has(deviceId)) deleteDevice.run(draft.attempt_id, deviceId);
+	}
+	const updateDevice = db.prepare(
+		`UPDATE legacy_team_setup_draft_devices
+		 SET display_name = COALESCE(?, display_name), key_fingerprint = ?, enabled = ?, decision = ?, target_identity_id = ?, existing_identity_id = ?,
+		     existing_assignment_version = ?, verified_evidence_kind = ?,
+		     expected_assignment_kind = ?, expected_assignment_version = ?, updated_at = ?
+		 WHERE attempt_id = ? AND device_id = ?`,
+	);
+	const assignmentForDevice = db.prepare(
+		`SELECT identity_id, assignment_version, status FROM identity_devices
+		 WHERE device_id = ? LIMIT 1`,
+	);
+	const assignmentsByDeviceId = new Map(
+		manifest.device_decisions.map((decision) => [
+			decision.device_id,
+			assignmentForDevice.get(decision.device_id) as
+				| { identity_id: string; assignment_version: number; status: string }
+				| undefined,
+		]),
+	);
+	const persistedProjectIds = (
+		db
+			.prepare(
+				`SELECT source_project_identity, source_fingerprint,
+				        resolved_project_identity, target_scope_id
+				 FROM legacy_team_setup_draft_projects WHERE attempt_id = ?`,
+			)
+			.all(draft.attempt_id) as Array<{
+			source_project_identity: string;
+			source_fingerprint: string;
+			resolved_project_identity: string | null;
+			target_scope_id: string | null;
+		}>
+	).flatMap((project) => [
+		project.source_project_identity,
+		project.source_fingerprint,
+		project.resolved_project_identity ?? "",
+		project.target_scope_id ?? "",
+	]);
+	const insertDevice = db.prepare(
+		`INSERT INTO legacy_team_setup_draft_devices(
+		 attempt_id, device_id, device_ref, key_fingerprint, display_name, enabled,
+		 existing_identity_id, existing_assignment_version, verified_evidence_kind,
+		 decision, target_identity_id, expected_assignment_kind,
+		 expected_assignment_version, updated_at
+		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	);
+	const freshDeviceById = new Map(freshRoster.map((device) => [device.deviceId, device]));
+	const forbiddenLabelIds = setupLabelForbiddenIds(
+		[
+			draft.candidate_id,
+			draft.coordinator_id,
+			manifest.team_id,
+			...manifest.memberships.map((membership) => membership.identity_id),
+			...manifest.project_mappings.flatMap((mapping) => [
+				mapping.project_ref,
+				mapping.resolved_project_ref,
+				mapping.scope_id,
+			]),
+			...persistedProjectIds,
+		],
+		draft.group_id,
+		null,
+		freshRoster,
+		[],
+		manifest.device_decisions.map((decision) => ({
+			deviceId: decision.device_id,
+			fingerprint: decision.key_fingerprint,
+			existingIdentityId: assignmentsByDeviceId.get(decision.device_id)?.identity_id ?? null,
+			targetIdentityId: decision.identity_id,
+		})),
+		[],
+	);
+	for (const decision of manifest.device_decisions) {
+		const assignment = assignmentsByDeviceId.get(decision.device_id);
+		const freshDevice = freshDeviceById.get(decision.device_id);
+		const displayName = freshDevice
+			? safeLabel(freshDevice.displayName, "Canonical device", forbiddenLabelIds)
+			: null;
+		if (!draftDeviceIds.includes(decision.device_id)) {
+			insertDevice.run(
+				draft.attempt_id,
+				decision.device_id,
+				legacyTeamDeviceRef(draft.candidate_id, decision.device_id),
+				decision.key_fingerprint,
+				displayName ?? "Canonical device",
+				decision.enabled ? 1 : 0,
+				assignment?.identity_id ?? null,
+				assignment?.assignment_version ?? null,
+				assignment?.status === "active" ? "active_assignment" : null,
+				decision.decision,
+				decision.identity_id,
+				assignment ? "existing" : "absent",
+				assignment?.assignment_version ?? null,
+				manifest.completed_at,
+			);
+		}
+		// The coordinator winner is authoritative. Rebase the local CAS evidence
+		// onto the current assignment so applying that winner can converge a
+		// pre-protocol device rather than preserving its divergent binding.
+		updateDevice.run(
+			displayName,
+			decision.key_fingerprint,
+			decision.enabled ? 1 : 0,
+			decision.decision,
+			decision.identity_id,
+			assignment?.identity_id ?? null,
+			assignment?.assignment_version ?? null,
+			assignment?.status === "active" ? "active_assignment" : null,
+			assignment ? "existing" : "absent",
+			assignment?.assignment_version ?? null,
+			manifest.completed_at,
+			draft.attempt_id,
+			decision.device_id,
+		);
+	}
+	const resolvedProjects = resolveManifestProjects(db, draft.attempt_id, manifest);
+	const localProjectRefs = db
+		.prepare(
+			`SELECT project_ref FROM legacy_team_setup_draft_projects
+			 WHERE attempt_id = ? ORDER BY project_ref LIMIT ?`,
+		)
+		.pluck()
+		.all(draft.attempt_id, LEGACY_TEAM_SETUP_MAX_PROJECTS + 1) as string[];
+	if (localProjectRefs.length > LEGACY_TEAM_SETUP_MAX_PROJECTS) {
+		fail("team_setup_completion_invalid");
+	}
+	const deleteProject = db.prepare(
+		"DELETE FROM legacy_team_setup_draft_projects WHERE attempt_id = ? AND project_ref = ?",
+	);
+	// Activation grants every Project left in the draft. Retain only historical
+	// mappings supported by this installation's local Project evidence.
+	for (const projectRef of localProjectRefs) {
+		if (!resolvedProjects.has(projectRef)) deleteProject.run(draft.attempt_id, projectRef);
+	}
+	const updateProject = db.prepare(
+		`UPDATE legacy_team_setup_draft_projects
+		 SET resolution_kind = 'explicit', resolved_project_identity = ?, target_scope_id = ?, updated_at = ?
+		 WHERE attempt_id = ? AND project_ref = ?`,
+	);
+	const insertProject = db.prepare(
+		`INSERT INTO legacy_team_setup_draft_projects(
+		 attempt_id, project_ref, source_project_identity, display_name, source_fingerprint,
+		 resolution_kind, resolved_project_identity, target_scope_id, updated_at
+		 ) VALUES (?, ?, ?, ?, ?, 'explicit', ?, ?, ?)`,
+	);
+	for (const mapping of manifest.project_mappings) {
+		const resolvedProject = resolvedProjects.get(mapping.project_ref);
+		if (!resolvedProject) continue;
+		const scope = db
+			.prepare(
+				`SELECT 1 FROM replication_scopes
+				 WHERE scope_id = ? AND coordinator_id = ? AND group_id = ?
+				   AND authority_type = 'coordinator' AND status = 'active'`,
+			)
+			.get(mapping.scope_id, draft.coordinator_id, draft.group_id);
+		if (!scope) fail("team_setup_completion_invalid");
+		if (!localProjectRefs.includes(mapping.project_ref)) {
+			// The canonical manifest is durable evidence for this reconstructed row;
+			// no local discovery fingerprint exists when a peer first materializes it.
+			insertProject.run(
+				draft.attempt_id,
+				mapping.project_ref,
+				resolvedProject.sourceIdentity,
+				safeLabel(resolvedProject.displayName, "Canonical project", forbiddenLabelIds),
+				digest("legacy-team-canonical-project-source-v1", mapping),
+				resolvedProject.resolvedIdentity,
+				mapping.scope_id,
+				manifest.completed_at,
+			);
+		} else {
+			updateProject.run(
+				resolvedProject.resolvedIdentity,
+				mapping.scope_id,
+				manifest.completed_at,
+				draft.attempt_id,
+				mapping.project_ref,
+			);
+		}
+	}
+}
+
+function appendResolvedManifestProjects(
+	db: Database,
+	draft: DraftRow,
+	manifest: CoordinatorLegacyTeamCompletionManifestV1,
+	resolvedProjects: Map<string, ResolvedManifestProject>,
+	projectRefs: readonly string[],
+	freshRoster: readonly LegacyTeamRosterDeviceSnapshot[],
+): void {
+	const existingProjects = db
+		.prepare(
+			`SELECT project_ref, source_project_identity, source_fingerprint,
+			        resolved_project_identity, target_scope_id
+			 FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref`,
+		)
+		.all(draft.attempt_id) as Array<{
+		project_ref: string;
+		source_project_identity: string;
+		source_fingerprint: string;
+		resolved_project_identity: string | null;
+		target_scope_id: string | null;
+	}>;
+	const existingRefs = new Set(existingProjects.map((project) => project.project_ref));
+	if (
+		existingProjects.length + projectRefs.length > LEGACY_TEAM_SETUP_MAX_PROJECTS ||
+		projectRefs.some((projectRef) => existingRefs.has(projectRef))
+	) {
+		fail("team_setup_completion_invalid");
+	}
+	const mappingsByRef = new Map(
+		manifest.project_mappings.map((mapping) => [mapping.project_ref, mapping]),
+	);
+	const forbiddenLabelIds = setupLabelForbiddenIds(
+		[
+			draft.candidate_id,
+			draft.coordinator_id,
+			manifest.team_id,
+			...manifest.memberships.map((membership) => membership.identity_id),
+			...manifest.project_mappings.flatMap((mapping) => [
+				mapping.project_ref,
+				mapping.resolved_project_ref,
+				mapping.scope_id,
+			]),
+			...existingProjects.flatMap((project) => [
+				project.source_project_identity,
+				project.source_fingerprint,
+				project.resolved_project_identity ?? "",
+				project.target_scope_id ?? "",
+			]),
+		],
+		draft.group_id,
+		null,
+		freshRoster,
+		[],
+		[],
+		[],
+	);
+	const insert = db.prepare(
+		`INSERT INTO legacy_team_setup_draft_projects(
+		 attempt_id, project_ref, source_project_identity, display_name, source_fingerprint,
+		 resolution_kind, resolved_project_identity, target_scope_id, updated_at
+		 ) VALUES (?, ?, ?, ?, ?, 'explicit', ?, ?, ?)`,
+	);
+	for (const projectRef of projectRefs) {
+		const mapping = mappingsByRef.get(projectRef);
+		const resolved = resolvedProjects.get(projectRef);
+		if (!mapping || !resolved) fail("team_setup_completion_invalid");
+		const scope = db
+			.prepare(
+				`SELECT 1 FROM replication_scopes
+				 WHERE scope_id = ? AND coordinator_id = ? AND group_id = ?
+				   AND authority_type = 'coordinator' AND status = 'active'`,
+			)
+			.get(mapping.scope_id, draft.coordinator_id, draft.group_id);
+		if (!scope) fail("team_setup_completion_invalid");
+		insert.run(
+			draft.attempt_id,
+			projectRef,
+			resolved.sourceIdentity,
+			safeLabel(resolved.displayName, "Canonical project", forbiddenLabelIds),
+			digest("legacy-team-canonical-project-source-v1", mapping),
+			resolved.resolvedIdentity,
+			mapping.scope_id,
+			manifest.completed_at,
+		);
+	}
+}
+
+function requireIncludedDeviceEvidence(
+	manifest: CoordinatorLegacyTeamCompletionManifestV1,
+	freshRoster: readonly LegacyTeamRosterDeviceSnapshot[],
+): void {
+	if (freshRoster.length > LEGACY_TEAM_SETUP_MAX_DEVICES) fail("team_setup_completion_invalid");
+	const freshByDeviceId = new Map(freshRoster.map((device) => [device.deviceId, device]));
+	if (freshByDeviceId.size !== freshRoster.length) fail("team_setup_completion_invalid");
+	for (const decision of manifest.device_decisions) {
+		if (decision.decision !== "included") continue;
+		const fresh = freshByDeviceId.get(decision.device_id);
+		if (!decision.enabled || !fresh?.enabled || fresh.fingerprint !== decision.key_fingerprint) {
+			fail("team_setup_completion_invalid");
+		}
+	}
+}
+
+function quarantineDivergentCompletedPolicy(
+	db: Database,
+	binding: { candidateRef: string; teamId: string },
+): void {
+	db.transaction(() => {
+		const team = db
+			.prepare(
+				`SELECT revision FROM policy_teams
+				 WHERE team_id = ? AND status = 'active'
+				   AND provenance = 'reviewed_team_candidate'`,
+			)
+			.get(binding.teamId) as { revision: string } | undefined;
+		// Repeated containment is a no-op once the active setup-owned policy is gone.
+		if (!team) return;
+		const now = new Date().toISOString();
+		db.prepare(
+			`UPDATE policy_teams
+			 SET status = 'inactive', migration_state = 'needs_setup', updated_at = ?
+			 WHERE team_id = ? AND provenance = 'reviewed_team_candidate'`,
+		).run(now, binding.teamId);
+		db.prepare(
+			`UPDATE project_recipients
+			 SET status = 'revoked', policy_revision = ?, migration_state = 'needs_setup', updated_at = ?
+			 WHERE recipient_kind = 'team' AND recipient_id = ?
+			   AND provenance = 'reviewed_team_setup' AND status = 'active'`,
+		).run(team.revision, now, binding.teamId);
+		db.prepare(
+			`UPDATE legacy_team_setup_drafts SET finish_digest = NULL
+			 WHERE candidate_id = ? AND completed_team_id = ? AND state = 'completed'`,
+		).run(binding.candidateRef, binding.teamId);
+	}).immediate();
+}
+
+export async function containLegacyTeamSetupCompletionConflict(
+	db: Database,
+	input: { coordinatorId: string; groupId: string },
+): Promise<void> {
+	const candidateRef = legacyTeamCandidateId(input.coordinatorId, input.groupId);
+	const teamId = deterministicPolicyTeamId(candidateRef);
+	await serializeRecipientPolicyTeamMutation(db, teamId, () =>
+		serializeRecipientPolicyCoordinatorGroupMutation(db, input.groupId, () => {
+			quarantineDivergentCompletedPolicy(db, { candidateRef, teamId });
+			return Promise.resolve();
+		}),
+	);
+}
+
+function loadCompletedActivationResult(
+	db: Database,
+	draft: DraftRow,
+): LegacyTeamSetupActivationResultV1 {
+	if (!draft.finish_digest) fail("team_setup_completion_invalid");
+	const row = db
+		.prepare(
+			`SELECT response_json FROM legacy_team_setup_completions
+			 WHERE candidate_ref = ? AND attempt_id = ? AND finish_digest = ?`,
+		)
+		.get(draft.candidate_id, draft.attempt_id, draft.finish_digest) as
+		| { response_json: string }
+		| undefined;
+	if (!row) fail("team_setup_completion_invalid");
+	return JSON.parse(row.response_json) as LegacyTeamSetupActivationResultV1;
+}
+
+function equivalentCompletionPolicyFacts(
+	left: CoordinatorLegacyTeamCompletionManifestV1,
+	right: CoordinatorLegacyTeamCompletionManifestV1,
+	resolvableProjectRefs: ReadonlySet<string>,
+): boolean {
+	const applicationFacts = (manifest: CoordinatorLegacyTeamCompletionManifestV1) => ({
+		version: manifest.version,
+		candidate_ref: manifest.candidate_ref,
+		team_id: manifest.team_id,
+		candidate_digest: manifest.candidate_digest,
+		device_eligibility_mode: manifest.team.device_eligibility_mode,
+		device_decisions: manifest.device_decisions,
+		memberships: manifest.memberships,
+		completed_at: manifest.completed_at,
+	});
+	if (JSON.stringify(applicationFacts(left)) !== JSON.stringify(applicationFacts(right))) {
+		return false;
+	}
+	const leftProjectRefs = new Set(left.project_mappings.map((mapping) => mapping.project_ref));
+	const rightMappings = new Map(
+		right.project_mappings.map((mapping) => [mapping.project_ref, mapping]),
+	);
+	const rightRecipients = new Map(
+		right.project_recipients.map((recipient) => [recipient.resolved_project_ref, recipient]),
+	);
+	return (
+		left.project_mappings.every(
+			(mapping) =>
+				JSON.stringify(rightMappings.get(mapping.project_ref)) === JSON.stringify(mapping),
+		) &&
+		left.project_recipients.every(
+			(recipient) =>
+				JSON.stringify(rightRecipients.get(recipient.resolved_project_ref)) ===
+				JSON.stringify(recipient),
+		) &&
+		right.project_mappings.every(
+			(mapping) =>
+				leftProjectRefs.has(mapping.project_ref) || !resolvableProjectRefs.has(mapping.project_ref),
+		)
+	);
+}
+
+export function areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible(
+	local: CoordinatorLegacyTeamCompletionManifestV1,
+	canonical: CoordinatorLegacyTeamCompletionManifestV1,
+): boolean {
+	return equivalentCompletionPolicyFacts(local, canonical, new Set());
+}
+
+async function applyCompletionManifest(
+	db: Database,
+	input: ApplyCompletionManifestInput,
+): Promise<{
+	manifest: CoordinatorLegacyTeamCompletionManifestV1;
+	result: LegacyTeamSetupActivationResultV1;
+}> {
+	const boundManifest = validateLegacyTeamSetupCompletionManifestBinding(input.manifest, input);
+	const apply = async () => {
+		let additiveConvergenceOnly = false;
+		try {
+			const manifest = validateLegacyTeamSetupCompletionManifest(boundManifest, input);
+			return db
+				.transaction(() => {
+					let preservedTeamMetadata: { displayName: string; policyRevision: string } | null = null;
+					const draft = loadDraft(db, manifest.candidate_ref);
+					if (input.expectedDraftManifest) {
+						let currentManifest: CoordinatorLegacyTeamCompletionManifestV1;
+						try {
+							currentManifest = deriveFromDraft(
+								db,
+								draft,
+								input.expectedDraftManifest.completed_at,
+							);
+						} catch {
+							throw new Error("team_setup_confirmation_stale");
+						}
+						if (
+							canonicalCoordinatorLegacyTeamCompletionManifestJson(currentManifest) !==
+							canonicalCoordinatorLegacyTeamCompletionManifestJson(input.expectedDraftManifest)
+						) {
+							throw new Error("team_setup_confirmation_stale");
+						}
+					}
+					const hasCompletedDraft = draft.state === "completed";
+					requireIncludedDeviceEvidence(manifest, input.freshRoster);
+					if (hasCompletedDraft) {
+						try {
+							const local = reconstructLegacyTeamSetupCompletionManifest(db, {
+								candidateRef: manifest.candidate_ref,
+							});
+							if (
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(local) ===
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(manifest)
+							) {
+								return { manifest, result: loadCompletedActivationResult(db, draft) };
+							}
+							if (equivalentCompletionPolicyFacts(local, manifest, new Set())) {
+								const additiveResolvedProjects = resolveManifestProjects(
+									db,
+									draft.attempt_id,
+									manifest,
+								);
+								if (
+									equivalentCompletionPolicyFacts(
+										local,
+										manifest,
+										new Set(additiveResolvedProjects.keys()),
+									)
+								) {
+									return { manifest, result: loadCompletedActivationResult(db, draft) };
+								}
+								additiveConvergenceOnly = true;
+								const localProjectRefs = new Set(
+									local.project_mappings.map((mapping) => mapping.project_ref),
+								);
+								const newProjectRefs = manifest.project_mappings
+									.map((mapping) => mapping.project_ref)
+									.filter(
+										(projectRef) =>
+											!localProjectRefs.has(projectRef) && additiveResolvedProjects.has(projectRef),
+									);
+								appendResolvedManifestProjects(
+									db,
+									draft,
+									manifest,
+									additiveResolvedProjects,
+									newProjectRefs,
+									input.freshRoster,
+								);
+								applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(db, {
+									candidateRef: manifest.candidate_ref,
+									attemptId: draft.attempt_id,
+									teamId: manifest.team_id,
+									projectRefs: newProjectRefs,
+									completedAt: manifest.completed_at,
+								});
+								return { manifest, result: loadCompletedActivationResult(db, draft) };
+							}
+						} catch (error) {
+							if (additiveConvergenceOnly) {
+								throw new LegacyTeamSetupAdditiveConvergenceError(error);
+							}
+							if (!(error instanceof LegacyTeamSetupCompletionManifestError)) throw error;
+						}
+					}
+					if (
+						draft.coordinator_id !== input.coordinatorId ||
+						draft.group_id !== input.groupId ||
+						(!hasCompletedDraft &&
+							draft.state !== "needs_setup" &&
+							draft.state !== "in_progress" &&
+							draft.state !== "stale")
+					) {
+						fail("team_setup_completion_invalid");
+					}
+					if (!hasCompletedDraft) {
+						const team = db
+							.prepare(
+								"SELECT display_name, revision FROM policy_teams WHERE team_id = ? AND status = 'active'",
+							)
+							.get(manifest.team_id) as { display_name: string; revision: string } | undefined;
+						const hasRenamedCompletedLink = team
+							? Boolean(
+									db
+										.prepare(
+											`SELECT 1 FROM legacy_team_setup_drafts AS draft
+											 JOIN legacy_team_setup_completions AS completion
+											   ON completion.attempt_id = draft.attempt_id
+											  AND completion.finish_digest = draft.finish_digest
+											  AND completion.candidate_ref = draft.candidate_id
+											  AND completion.completed_team_id = draft.completed_team_id
+											 WHERE draft.candidate_id = ? AND draft.state = 'completed'
+											   AND draft.completed_team_id = ? AND draft.display_name = ? LIMIT 1`,
+										)
+										.pluck()
+										.get(manifest.candidate_ref, manifest.team_id, team.display_name),
+								)
+							: false;
+						if (
+							team &&
+							team.display_name !== manifest.team.display_name &&
+							hasRenamedCompletedLink
+						) {
+							// Preserve the proven rename, but advance the revision because this
+							// replacement apply may change policy facts from the linked completion.
+							preservedTeamMetadata = {
+								displayName: team.display_name,
+								policyRevision: manifest.team.policy_revision,
+							};
+						}
+					}
+					rewriteDraftFromManifest(
+						db,
+						draft,
+						manifest,
+						input.freshRoster,
+						preservedTeamMetadata?.displayName,
+					);
+					const result = applyCanonicalLegacyTeamSetupActivationInTransaction(db, {
+						candidateRef: manifest.candidate_ref,
+						attemptId: draft.attempt_id,
+						policyRevision: preservedTeamMetadata?.policyRevision ?? manifest.team.policy_revision,
+						completedAt: manifest.completed_at,
+						allowCompletedDraft: hasCompletedDraft,
+						allowStaleDraft: draft.state === "stale",
+					});
+					return { manifest, result };
+				})
+				.immediate();
+		} catch (error) {
+			// A failed canonical apply must contain any active setup-owned policy,
+			// including one left by a superseded completed draft.
+			if (
+				!additiveConvergenceOnly &&
+				(error instanceof LegacyTeamSetupCompletionManifestError ||
+					error instanceof LegacyTeamSetupActivationError)
+			) {
+				quarantineDivergentCompletedPolicy(db, {
+					candidateRef: boundManifest.candidate_ref,
+					teamId: boundManifest.team_id,
+				});
+			}
+			throw error;
+		}
+	};
+	if (input.recipientPolicyMutationSerialized) return apply();
+	return serializeRecipientPolicyPublicationMutation(db, () =>
+		serializeRecipientPolicyTeamMutation(db, boundManifest.team_id, () =>
+			serializeRecipientPolicyCoordinatorGroupMutation(db, input.groupId, apply),
+		),
+	);
+}
+
+export async function applyLegacyTeamSetupCompletionManifest(
+	db: Database,
+	input: ApplyCompletionManifestInput,
+): Promise<CoordinatorLegacyTeamCompletionManifestV1> {
+	return (await applyCompletionManifest(db, input)).manifest;
+}
+
+export async function applyLegacyTeamSetupCompletionManifestAndReturnActivation(
+	db: Database,
+	input: ApplyCompletionManifestInput,
+): Promise<LegacyTeamSetupActivationResultV1> {
+	return (await applyCompletionManifest(db, input)).result;
+}

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -767,6 +767,48 @@ describe("legacy Team setup drafts", () => {
 		);
 	});
 
+	it("accepts exactly 10,000 Project-device pairs", () => {
+		const draft = refreshLegacyTeamSetupDraft(db, {
+			...snapshot(),
+			devices: devices(500),
+			projects: projects(20),
+		});
+
+		expect(draft.devices).toHaveLength(500);
+		expect(draft.projects).toHaveLength(20);
+	});
+
+	it("rejects more than 10,000 Project-device pairs without persisting", () => {
+		expect(() =>
+			refreshLegacyTeamSetupDraft(db, {
+				...snapshot(),
+				devices: devices(500),
+				projects: projects(21),
+			}),
+		).toThrow("legacy_team_setup_roster_too_large");
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(0);
+	});
+
+	it("counts carried Devices toward the Project-device pair limit", () => {
+		const current = refreshLegacyTeamSetupDraft(db, {
+			...snapshot(),
+			devices: devices(500),
+		});
+		db.prepare(
+			"UPDATE legacy_team_setup_drafts SET state = 'in_progress' WHERE attempt_id = ?",
+		).run(current.attemptId);
+		const before = getLegacyTeamSetupDraft(db, CANDIDATE);
+
+		expect(() =>
+			refreshLegacyTeamSetupDraft(db, {
+				...snapshot(),
+				devices: devices(476, 24),
+				projects: projects(21),
+			}),
+		).toThrow("legacy_team_setup_roster_too_large");
+		expect(getLegacyTeamSetupDraft(db, CANDIDATE)).toEqual(before);
+	});
+
 	it("rejects carried-device overflow and preserves the reviewed attempt", () => {
 		const current = refreshLegacyTeamSetupDraft(db, { ...snapshot(), devices: devices(500) });
 		db.prepare(

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -850,6 +850,7 @@ export function refreshLegacyTeamSetupDraft(
 		requireLegacyTeamSetupEffectiveDevicesWithinLimit(
 			db,
 			input.devices,
+			input.projects,
 			existing?.attempt_id ?? null,
 		);
 		const loadAssignment = assignmentLookup(db);

--- a/packages/core/src/legacy-team-setup-errors.ts
+++ b/packages/core/src/legacy-team-setup-errors.ts
@@ -4,6 +4,9 @@ export type LegacyTeamSetupActivationErrorCode =
 	| "team_setup_projection_changed"
 	| "team_setup_assignment_changed"
 	| "team_setup_roster_unavailable"
+	| "team_setup_completion_unavailable"
+	| "team_setup_completion_conflict"
+	| "team_setup_completion_invalid"
 	| "team_setup_conflict"
 	| "team_setup_confirmation_stale"
 	| "team_setup_failed";
@@ -27,7 +30,11 @@ export type LegacyTeamSetupDraftErrorCode =
 
 export type LegacyTeamSetupCoreErrorCode =
 	| LegacyTeamSetupDraftErrorCode
-	| LegacyTeamSetupActivationErrorCode;
+	| LegacyTeamSetupActivationErrorCode
+	| "completion_conflict"
+	| "completion_manifest_invalid"
+	| "coordinator_completion_response_malformed"
+	| "coordinator_completion_group_mismatch";
 
 /**
  * Stable API compatibility boundary. Core keeps throwing its released strings;
@@ -54,9 +61,16 @@ export const LEGACY_TEAM_SETUP_API_ERROR_BY_CORE_ERROR = {
 	team_setup_projection_changed: "team_setup_projection_changed",
 	team_setup_assignment_changed: "team_setup_assignment_changed",
 	team_setup_roster_unavailable: "team_setup_roster_unavailable",
+	team_setup_completion_unavailable: "team_setup_completion_unavailable",
+	team_setup_completion_conflict: "team_setup_completion_conflict",
+	team_setup_completion_invalid: "team_setup_completion_invalid",
 	team_setup_conflict: "team_setup_conflict",
 	team_setup_confirmation_stale: "team_setup_confirmation_stale",
 	team_setup_failed: "team_setup_failed",
+	completion_conflict: "team_setup_completion_conflict",
+	completion_manifest_invalid: "team_setup_completion_invalid",
+	coordinator_completion_response_malformed: "team_setup_completion_invalid",
+	coordinator_completion_group_mismatch: "team_setup_completion_invalid",
 } as const satisfies Record<LegacyTeamSetupCoreErrorCode, LegacyTeamSetupActivationErrorCode>;
 
 export function legacyTeamSetupApiErrorCode(error: unknown): LegacyTeamSetupActivationErrorCode {

--- a/packages/core/src/legacy-team-setup-limits.ts
+++ b/packages/core/src/legacy-team-setup-limits.ts
@@ -2,6 +2,7 @@ import type { Database } from "./db.js";
 
 export const LEGACY_TEAM_SETUP_MAX_DEVICES = 500;
 export const LEGACY_TEAM_SETUP_MAX_PROJECTS = 500;
+export const LEGACY_TEAM_SETUP_MAX_PROJECT_DEVICE_PAIRS = 10_000;
 
 export function requireLegacyTeamSetupSnapshotWithinLimits(input: {
 	devices: readonly unknown[];
@@ -9,7 +10,8 @@ export function requireLegacyTeamSetupSnapshotWithinLimits(input: {
 }): void {
 	if (
 		input.devices.length > LEGACY_TEAM_SETUP_MAX_DEVICES ||
-		input.projects.length > LEGACY_TEAM_SETUP_MAX_PROJECTS
+		input.projects.length > LEGACY_TEAM_SETUP_MAX_PROJECTS ||
+		input.devices.length * input.projects.length > LEGACY_TEAM_SETUP_MAX_PROJECT_DEVICE_PAIRS
 	) {
 		throw new Error("legacy_team_setup_roster_too_large");
 	}
@@ -18,6 +20,7 @@ export function requireLegacyTeamSetupSnapshotWithinLimits(input: {
 export function requireLegacyTeamSetupEffectiveDevicesWithinLimit(
 	db: Database,
 	devices: readonly { deviceId: string }[],
+	projects: readonly unknown[],
 	previousAttemptId: string | null,
 ): void {
 	if (!previousAttemptId) return;
@@ -33,7 +36,11 @@ export function requireLegacyTeamSetupEffectiveDevicesWithinLimit(
 			.pluck()
 			.get(previousAttemptId, ...currentDeviceIds) ?? 0,
 	);
-	if (devices.length + carriedDeviceCount > LEGACY_TEAM_SETUP_MAX_DEVICES) {
+	const effectiveDeviceCount = devices.length + carriedDeviceCount;
+	if (
+		effectiveDeviceCount > LEGACY_TEAM_SETUP_MAX_DEVICES ||
+		effectiveDeviceCount * projects.length > LEGACY_TEAM_SETUP_MAX_PROJECT_DEVICE_PAIRS
+	) {
 		throw new Error("legacy_team_setup_roster_too_large");
 	}
 }

--- a/packages/core/src/recipient-policy-team-metadata.test.ts
+++ b/packages/core/src/recipient-policy-team-metadata.test.ts
@@ -2,7 +2,12 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getLegacyTeamSetupDraft } from "./legacy-team-setup-draft.js";
 import { deterministicPolicyTeamId } from "./recipient-policy-identifiers.js";
-import { renameRecipientPolicyTeam } from "./recipient-policy-team-metadata.js";
+import {
+	claimRecipientPolicyActorMutations,
+	renameRecipientPolicyTeam,
+	serializeRecipientPolicyActorMutations,
+	serializeRecipientPolicyPublicationMutation,
+} from "./recipient-policy-team-metadata.js";
 import { initTestSchema } from "./test-utils.js";
 
 const NOW = "2026-08-26T12:00:00.000Z";
@@ -17,6 +22,65 @@ describe("recipient policy Team metadata", () => {
 	});
 
 	afterEach(() => db.close());
+
+	it("claims deduplicated actor locks in sorted order and releases them once", async () => {
+		let releaseActorB: () => void = () => undefined;
+		const actorBGate = new Promise<void>((resolve) => {
+			releaseActorB = resolve;
+		});
+		const heldActorB = serializeRecipientPolicyActorMutations(db, ["actor-b"], () => actorBGate);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		const releaseActorsPromise = claimRecipientPolicyActorMutations(db, [
+			"actor-b",
+			"actor-a",
+			"actor-a",
+		]);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		let actorAStarted = false;
+		let releaseActorA: () => void = () => undefined;
+		const actorAGate = new Promise<void>((resolve) => {
+			releaseActorA = resolve;
+		});
+		const heldActorA = serializeRecipientPolicyActorMutations(db, ["actor-a"], async () => {
+			actorAStarted = true;
+			await actorAGate;
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(actorAStarted).toBe(false);
+
+		releaseActorB();
+		const releaseActors = await releaseActorsPromise;
+		releaseActors();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(actorAStarted).toBe(true);
+
+		let trailingActorAStarted = false;
+		const trailingActorA = serializeRecipientPolicyActorMutations(db, ["actor-a"], async () => {
+			trailingActorAStarted = true;
+		});
+		releaseActors();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(trailingActorAStarted).toBe(false);
+
+		releaseActorA();
+		await Promise.all([heldActorA, heldActorB, trailingActorA]);
+		expect(trailingActorAStarted).toBe(true);
+	});
+
+	it("releases the publication barrier when an operation fails", async () => {
+		await expect(
+			serializeRecipientPolicyPublicationMutation(db, async () => {
+				throw new Error("publication failed");
+			}),
+		).rejects.toThrow("publication failed");
+
+		let nextOperationStarted = false;
+		await serializeRecipientPolicyPublicationMutation(db, async () => {
+			nextOperationStarted = true;
+		});
+		expect(nextOperationStarted).toBe(true);
+	});
 
 	function insertTeam(teamId = "team-local", displayName = "Old Team") {
 		db.prepare(

--- a/packages/core/src/recipient-policy-team-metadata.ts
+++ b/packages/core/src/recipient-policy-team-metadata.ts
@@ -67,6 +67,9 @@ interface ProvenCoordinatorLink {
 // equivalence is limited to historical-link evidence and never changes queue keys.
 const teamRenameQueues = new WeakMap<Database, Map<string, Promise<void>>>();
 const coordinatorGroupMutationQueues = new WeakMap<Database, Map<string, Promise<void>>>();
+const actorMutationQueues = new WeakMap<Database, Map<string, Promise<void>>>();
+const publicationMutationQueues = new WeakMap<Database, Map<string, Promise<void>>>();
+const PUBLICATION_MUTATION_KEY = "recipient-policy-publication";
 
 function fail(code: RecipientPolicyTeamRenameErrorCode): never {
 	throw new RecipientPolicyTeamRenameError(code);
@@ -193,6 +196,19 @@ async function serializeMutation<T>(
 	key: string,
 	operation: () => Promise<T>,
 ): Promise<T> {
+	const release = await claimMutation(queues, db, key);
+	try {
+		return await operation();
+	} finally {
+		release();
+	}
+}
+
+async function claimMutation(
+	queues: WeakMap<Database, Map<string, Promise<void>>>,
+	db: Database,
+	key: string,
+): Promise<() => void> {
 	let queue = queues.get(db);
 	if (!queue) {
 		queue = new Map();
@@ -206,12 +222,13 @@ async function serializeMutation<T>(
 	const queued = preceding.catch(() => undefined).then(() => turn);
 	queue.set(key, queued);
 	await preceding.catch(() => undefined);
-	try {
-		return await operation();
-	} finally {
+	let released = false;
+	return () => {
+		if (released) return;
+		released = true;
 		release();
 		if (queue.get(key) === queued) queue.delete(key);
-	}
+	};
 }
 
 export function serializeRecipientPolicyTeamMutation<T>(
@@ -220,6 +237,46 @@ export function serializeRecipientPolicyTeamMutation<T>(
 	operation: () => Promise<T>,
 ): Promise<T> {
 	return serializeMutation(teamRenameQueues, db, teamId, operation);
+}
+
+export function serializeRecipientPolicyActorMutations<T>(
+	db: Database,
+	actorIds: readonly string[],
+	operation: () => Promise<T>,
+): Promise<T> {
+	const orderedActorIds = [...new Set(actorIds)].toSorted();
+	const serializeNext = (index: number): Promise<T> => {
+		const actorId = orderedActorIds[index];
+		if (!actorId) return operation();
+		return serializeMutation(actorMutationQueues, db, actorId, () => serializeNext(index + 1));
+	};
+	return serializeNext(0);
+}
+
+export async function claimRecipientPolicyActorMutations(
+	db: Database,
+	actorIds: readonly string[],
+): Promise<() => void> {
+	const releases: Array<() => void> = [];
+	for (const actorId of [...new Set(actorIds)].toSorted()) {
+		releases.push(await claimMutation(actorMutationQueues, db, actorId));
+	}
+	return () => {
+		for (const release of releases.toReversed()) release();
+	};
+}
+
+// Lock order is candidate claim -> publication -> actor -> Team -> coordinator group.
+// Callers that need lower-level locks must acquire this barrier first.
+export function serializeRecipientPolicyPublicationMutation<T>(
+	db: Database,
+	operation: () => Promise<T>,
+): Promise<T> {
+	return serializeMutation(publicationMutationQueues, db, PUBLICATION_MUTATION_KEY, operation);
+}
+
+export function claimRecipientPolicyPublicationMutation(db: Database): Promise<() => void> {
+	return claimMutation(publicationMutationQueues, db, PUBLICATION_MUTATION_KEY);
 }
 
 // This deliberately uses the exact group ID as a coarse serialization key.

--- a/packages/viewer-server/src/device-identity-inventory.test.ts
+++ b/packages/viewer-server/src/device-identity-inventory.test.ts
@@ -6,6 +6,7 @@ import {
 	fingerprintPublicKey,
 	initTestSchema,
 	MemoryStore,
+	serializeRecipientPolicyPublicationMutation,
 } from "@codemem/core";
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
@@ -404,10 +405,37 @@ describe("device Identity binding routes", () => {
 				bindings,
 				reviewedInventoryDigest: preview.reviewedInventoryDigest,
 			};
-			const commitResponse = await app.request(
-				"/api/sync/recipient-policy/v1/device-bindings/commit",
-				{ method: "POST", body: JSON.stringify(commitBody) },
+			let releasePublication: () => void = () => undefined;
+			const publicationGate = new Promise<void>((resolve) => {
+				releasePublication = resolve;
+			});
+			let markPublicationStarted: () => void = () => undefined;
+			const publicationStarted = new Promise<void>((resolve) => {
+				markPublicationStarted = resolve;
+			});
+			const heldPublication = serializeRecipientPolicyPublicationMutation(
+				fixture.store.db,
+				async () => {
+					markPublicationStarted();
+					await publicationGate;
+				},
 			);
+			await publicationStarted;
+			let commitSettled = false;
+			const commitRequest = app
+				.request("/api/sync/recipient-policy/v1/device-bindings/commit", {
+					method: "POST",
+					body: JSON.stringify(commitBody),
+				})
+				.then((response) => {
+					commitSettled = true;
+					return response;
+				});
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(commitSettled).toBe(false);
+			releasePublication();
+			const commitResponse = await commitRequest;
+			await heldPublication;
 			const retryResponse = await app.request(
 				"/api/sync/recipient-policy/v1/device-bindings/commit",
 				{ method: "POST", body: JSON.stringify(commitBody) },

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -186,6 +186,7 @@ function createTestApp(opts?: {
 	sweeper?: unknown;
 	getUpdateStatus?: (options: core.GetUpdateStatusOptions) => Promise<core.UpdateStatus>;
 	loadLegacyTeamConfiguredGroupSnapshots?: LegacyTeamConfiguredGroupSnapshotLoader;
+	teamSetupCompletionDependencies?: AppOptions["teamSetupCompletionDependencies"];
 	readCoordinatorConfig?: AppOptions["readCoordinatorConfig"];
 	renameCoordinatorGroup?: AppOptions["renameCoordinatorGroup"];
 	syncRequestRateLimit?: {
@@ -217,6 +218,7 @@ function createTestApp(opts?: {
 		getUpdateStatus: opts?.getUpdateStatus,
 		getSyncRuntimeStatus: opts?.getSyncRuntimeStatus,
 		loadLegacyTeamConfiguredGroupSnapshots: opts?.loadLegacyTeamConfiguredGroupSnapshots,
+		teamSetupCompletionDependencies: opts?.teamSetupCompletionDependencies ?? null,
 		readCoordinatorConfig: opts?.readCoordinatorConfig,
 		renameCoordinatorGroup: opts?.renameCoordinatorGroup,
 	};
@@ -504,6 +506,7 @@ describe("viewer-server", () => {
 		const rawDeviceId = "device-secret-id";
 		const rawIdentityId = "identity-secret-id";
 		const rawProjectIdentity = "https://private.example.invalid/secret/repo.git";
+		const rawFingerprint = "a".repeat(64);
 		const candidateRef = core.legacyTeamCandidateId(coordinatorId, groupId);
 		const snapshots: core.LegacyTeamConfiguredGroupSnapshot[] = [
 			{
@@ -513,7 +516,7 @@ describe("viewer-server", () => {
 				devices: [
 					{
 						deviceId: rawDeviceId,
-						fingerprint: "fingerprint-secret",
+						fingerprint: rawFingerprint,
 						displayName: "Review Laptop",
 						enabled: true,
 					},
@@ -568,6 +571,15 @@ describe("viewer-server", () => {
 			const loadSnapshots = vi.fn(async () => snapshots);
 			const { app, ensureStore, cleanup } = createTestApp({
 				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				readCoordinatorConfig: () =>
+					core.readCoordinatorSyncConfig({
+						sync_coordinator_url: coordinatorId,
+						sync_coordinator_admin_secret: "test-secret",
+					}),
+				teamSetupCompletionDependencies: {
+					create: async ({ manifest }) => ({ status: "created", manifest }),
+					list: async () => [],
+				},
 			});
 			try {
 				const store = ensureStore();
@@ -825,7 +837,7 @@ describe("viewer-server", () => {
 				expect(JSON.stringify(detail)).not.toContain(groupId);
 				expect(JSON.stringify(detail)).not.toContain(rawDeviceId);
 				expect(JSON.stringify(detail)).not.toContain(rawIdentityId);
-				expect(JSON.stringify(detail)).not.toContain("fingerprint-secret");
+				expect(JSON.stringify(detail)).not.toContain(rawFingerprint);
 				expect(JSON.stringify(detail)).not.toContain(rawProjectIdentity);
 				expect(JSON.stringify(detail)).not.toContain(rawPreview.accessDelta.teamChanges[0]?.teamId);
 				expect(detail).toHaveProperty("accessDelta.teamChanges.0.teamRef");
@@ -927,8 +939,9 @@ describe("viewer-server", () => {
 					body: JSON.stringify(finishRequest),
 				});
 				expect(finishResponse.status).toBe(200);
-				expect(loadSnapshots).toHaveBeenCalledTimes(1);
-				expect(loadSnapshots).toHaveBeenCalledWith({ candidateRef });
+				expect(loadSnapshots).toHaveBeenCalledTimes(2);
+				expect(loadSnapshots).toHaveBeenNthCalledWith(1, { candidateRef });
+				expect(loadSnapshots).toHaveBeenNthCalledWith(2, { candidateRef });
 				const finished = await finishResponse.json();
 				expect(finished).toMatchObject({
 					version: 1,
@@ -12256,6 +12269,35 @@ describe("viewer-server", () => {
 				await app.request("/api/stats");
 				const store = getStore();
 				if (!store) throw new Error("store not initialized");
+				const requestBehindPublication = async (request: () => Promise<Response>) => {
+					let releasePublication: () => void = () => undefined;
+					const publicationGate = new Promise<void>((resolve) => {
+						releasePublication = resolve;
+					});
+					let markPublicationStarted: () => void = () => undefined;
+					const publicationStarted = new Promise<void>((resolve) => {
+						markPublicationStarted = resolve;
+					});
+					const heldPublication = core.serializeRecipientPolicyPublicationMutation(
+						store.db,
+						async () => {
+							markPublicationStarted();
+							await publicationGate;
+						},
+					);
+					await publicationStarted;
+					let requestSettled = false;
+					const pendingRequest = request().then((response) => {
+						requestSettled = true;
+						return response;
+					});
+					await new Promise((resolve) => setTimeout(resolve, 0));
+					expect(requestSettled).toBe(false);
+					releasePublication();
+					const response = await pendingRequest;
+					await heldPublication;
+					return response;
+				};
 				const sessionId = insertTestSession(store.db);
 				insertTestMemory(store, {
 					sessionId,
@@ -12363,15 +12405,18 @@ describe("viewer-server", () => {
 				});
 				expect(fractionalIdRes.status).toBe(400);
 
-				const saveRes = await app.request("/api/sync/sharing-domains/project-mappings", {
-					method: "PUT",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({
-						workspace_identity: project?.workspace_identity,
-						project_pattern: project?.display_project,
-						scope_id: "acme-work",
+				const mappingRequest = {
+					workspace_identity: project?.workspace_identity,
+					project_pattern: project?.display_project,
+					scope_id: "acme-work",
+				};
+				const saveRes = await requestBehindPublication(() =>
+					app.request("/api/sync/sharing-domains/project-mappings", {
+						method: "PUT",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify(mappingRequest),
 					}),
-				});
+				);
 				expect(saveRes.status).toBe(200);
 				const saveBody = (await saveRes.json()) as { mapping: { id: number; scope_id: string } };
 				expect(saveBody.mapping.scope_id).toBe("acme-work");
@@ -12396,10 +12441,19 @@ describe("viewer-server", () => {
 					n: number;
 				};
 				expect(memberships.n).toBe(0);
+				const bulkRes = await requestBehindPublication(() =>
+					app.request("/api/sync/sharing-domains/project-mappings/bulk", {
+						method: "PUT",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ mappings: [mappingRequest] }),
+					}),
+				);
+				expect(bulkRes.status).toBe(200);
 
-				const deleteRes = await app.request(
-					`/api/sync/sharing-domains/project-mappings/${saveBody.mapping.id}`,
-					{ method: "DELETE" },
+				const deleteRes = await requestBehindPublication(() =>
+					app.request(`/api/sync/sharing-domains/project-mappings/${saveBody.mapping.id}`, {
+						method: "DELETE",
+					}),
 				);
 				expect(deleteRes.status).toBe(200);
 			} finally {
@@ -13346,6 +13400,183 @@ describe("viewer-server", () => {
 				});
 				expect(missing.status).toBe(404);
 			} finally {
+				cleanup();
+			}
+		});
+
+		it("serializes Team recipient-edge commits behind Team publication", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			let releaseTeamMutation: () => void = () => undefined;
+			const teamMutationGate = new Promise<void>((resolve) => {
+				releaseTeamMutation = resolve;
+			});
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const teamId = "edge-serialization-team";
+				let markTeamMutationStarted: () => void = () => undefined;
+				const teamMutationStarted = new Promise<void>((resolve) => {
+					markTeamMutationStarted = resolve;
+				});
+				const teamMutation = core.serializeRecipientPolicyTeamMutation(
+					store.db,
+					teamId,
+					async () => {
+						markTeamMutationStarted();
+						await teamMutationGate;
+					},
+				);
+				await teamMutationStarted;
+
+				let commitSettled = false;
+				const commit = app
+					.request("/api/sync/recipient-policy/v1/edges/commit", {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({
+							version: 1,
+							changes: [
+								{
+									canonicalProjectIdentity: "https://git.example.invalid/acme/queued.git",
+									recipient: { recipientKind: "team", teamId },
+									action: "remove",
+								},
+							],
+							reviewedPolicyDigest: `edge-preview-v1:${"0".repeat(64)}`,
+						}),
+					})
+					.then((response) => {
+						commitSettled = true;
+						return response;
+					});
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				expect(commitSettled).toBe(false);
+
+				releaseTeamMutation();
+				expect((await commit).status).toBe(404);
+				await teamMutation;
+			} finally {
+				releaseTeamMutation();
+				cleanup();
+			}
+		});
+
+		it("does not queue identity-only recipient-edge commits behind Team publication", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			let releaseTeamMutation: () => void = () => undefined;
+			const teamMutationGate = new Promise<void>((resolve) => {
+				releaseTeamMutation = resolve;
+			});
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const identityId = "identity-only";
+				let markTeamMutationStarted: () => void = () => undefined;
+				const teamMutationStarted = new Promise<void>((resolve) => {
+					markTeamMutationStarted = resolve;
+				});
+				const teamMutation = core.serializeRecipientPolicyTeamMutation(
+					store.db,
+					identityId,
+					async () => {
+						markTeamMutationStarted();
+						await teamMutationGate;
+					},
+				);
+				await teamMutationStarted;
+
+				let commitSettled = false;
+				const commit = app
+					.request("/api/sync/recipient-policy/v1/edges/commit", {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({
+							version: 1,
+							changes: [
+								{
+									canonicalProjectIdentity: "https://git.example.invalid/acme/identity-only.git",
+									recipient: { recipientKind: "identity", identityId },
+									action: "remove",
+								},
+							],
+							reviewedPolicyDigest: `edge-preview-v1:${"0".repeat(64)}`,
+						}),
+					})
+					.then((response) => {
+						commitSettled = true;
+						return response;
+					});
+				await new Promise((resolve) => setTimeout(resolve, 0));
+
+				expect(commitSettled).toBe(true);
+				expect((await commit).status).toBe(404);
+				releaseTeamMutation();
+				await teamMutation;
+			} finally {
+				releaseTeamMutation();
+				cleanup();
+			}
+		});
+
+		it("acquires recipient-edge Team serializers in stable identity order", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			let releaseLastTeam: () => void = () => undefined;
+			const lastTeamGate = new Promise<void>((resolve) => {
+				releaseLastTeam = resolve;
+			});
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const firstTeamId = "edge-team-a";
+				const lastTeamId = "edge-team-z";
+				let markLastTeamStarted: () => void = () => undefined;
+				const lastTeamStarted = new Promise<void>((resolve) => {
+					markLastTeamStarted = resolve;
+				});
+				const lastTeamMutation = core.serializeRecipientPolicyTeamMutation(
+					store.db,
+					lastTeamId,
+					async () => {
+						markLastTeamStarted();
+						await lastTeamGate;
+					},
+				);
+				await lastTeamStarted;
+
+				const commit = app.request("/api/sync/recipient-policy/v1/edges/commit", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({
+						version: 1,
+						changes: [lastTeamId, firstTeamId].map((teamId, index) => ({
+							canonicalProjectIdentity: `https://git.example.invalid/acme/queued-${index}.git`,
+							recipient: { recipientKind: "team", teamId },
+							action: "remove",
+						})),
+						reviewedPolicyDigest: `edge-preview-v1:${"0".repeat(64)}`,
+					}),
+				});
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				let firstTeamMutationStarted = false;
+				const firstTeamMutation = core.serializeRecipientPolicyTeamMutation(
+					store.db,
+					firstTeamId,
+					async () => {
+						firstTeamMutationStarted = true;
+					},
+				);
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				expect(firstTeamMutationStarted).toBe(false);
+
+				releaseLastTeam();
+				expect((await commit).status).toBe(404);
+				await Promise.all([lastTeamMutation, firstTeamMutation]);
+				expect(firstTeamMutationStarted).toBe(true);
+			} finally {
+				releaseLastTeam();
 				cleanup();
 			}
 		});
@@ -14684,6 +14915,85 @@ describe("viewer-server", () => {
 				});
 				expect(res.status).toBe(409);
 				expect(await res.json()).toEqual({ error: "cannot merge this device's own local actor" });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("serializes actor merge and deactivation by affected actor identity", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				await app.request("/api/sync/actors");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const createActor = async (displayName: string): Promise<string> => {
+					const response = await app.request("/api/sync/actors", {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({ display_name: displayName }),
+					});
+					return ((await response.json()) as { actor_id: string }).actor_id;
+				};
+				const primaryActorId = await createActor("Primary actor");
+				const secondaryActorId = await createActor("Secondary actor");
+				let releaseMergeLock: () => void = () => undefined;
+				const mergeGate = new Promise<void>((resolve) => {
+					releaseMergeLock = resolve;
+				});
+				const heldMergeLock = core.serializeRecipientPolicyActorMutations(
+					store.db,
+					[secondaryActorId],
+					() => mergeGate,
+				);
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				let mergeSettled = false;
+				const merge = app
+					.request("/api/sync/actors/merge", {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({
+							primary_actor_id: primaryActorId,
+							secondary_actor_id: secondaryActorId,
+						}),
+					})
+					.then((response) => {
+						mergeSettled = true;
+						return response;
+					});
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				expect(mergeSettled).toBe(false);
+				releaseMergeLock();
+				expect((await merge).status).toBe(200);
+				await heldMergeLock;
+
+				const deactivatedActorId = await createActor("Deactivated actor");
+				let releaseDeactivateLock: () => void = () => undefined;
+				const deactivateGate = new Promise<void>((resolve) => {
+					releaseDeactivateLock = resolve;
+				});
+				const heldDeactivateLock = core.serializeRecipientPolicyActorMutations(
+					store.db,
+					[deactivatedActorId],
+					() => deactivateGate,
+				);
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				let deactivateSettled = false;
+				const deactivate = app
+					.request("/api/sync/actors/deactivate", {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({ actor_id: deactivatedActorId }),
+					})
+					.then((response) => {
+						deactivateSettled = true;
+						return response;
+					});
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				expect(deactivateSettled).toBe(false);
+				releaseDeactivateLock();
+				expect((await deactivate).status).toBe(200);
+				await heldDeactivateLock;
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -33,6 +33,7 @@ import { rawEventsRoutes } from "./routes/raw-events.js";
 import { statsRoutes } from "./routes/stats.js";
 import { type SyncRoutesOptions, syncProtocolRoutes, syncRoutes } from "./routes/sync.js";
 import {
+	type LegacyTeamCompletionDependencies,
 	type LegacyTeamConfiguredGroupSnapshotLoader,
 	TEAM_SETUP_ROUTE_PREFIX,
 	teamSetupRoutes,
@@ -103,6 +104,7 @@ export interface AppOptions {
 	getUpdateStatus?: (options: GetUpdateStatusOptions) => Promise<UpdateStatus>;
 	loadDeviceIdentityCoordinatorEvidence?: () => Promise<DeviceIdentityCoordinatorEvidence>;
 	loadLegacyTeamConfiguredGroupSnapshots?: LegacyTeamConfiguredGroupSnapshotLoader;
+	teamSetupCompletionDependencies?: LegacyTeamCompletionDependencies | null;
 	readCoordinatorConfig?: SyncRoutesOptions["readCoordinatorConfig"];
 	renameCoordinatorGroup?: SyncRoutesOptions["renameCoordinatorGroup"];
 	syncRequestRateLimit?: {
@@ -167,6 +169,8 @@ export function createApp(opts?: AppOptions) {
 		teamSetupRoutes({
 			getStore: storeFactory,
 			loadLegacyTeamConfiguredGroupSnapshots: opts?.loadLegacyTeamConfiguredGroupSnapshots,
+			completionDependencies: opts?.teamSetupCompletionDependencies,
+			readCoordinatorConfig: opts?.readCoordinatorConfig,
 			registerSummaryInvalidator: (invalidate) => {
 				invalidateTeamSetupSummary = invalidate;
 			},

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -45,6 +45,8 @@ import {
 	buildDirectPeerAuthHeaders,
 	CoordinatorReciprocalApprovalRequestChangedError,
 	canonicalWorkspaceIdentity,
+	claimRecipientPolicyActorMutations,
+	claimRecipientPolicyPublicationMutation,
 	cleanupNonces,
 	commitDeviceIdentityBindings,
 	commitRecipientPolicyEdges,
@@ -130,6 +132,7 @@ import {
 	normalizeTeammateName,
 	parseAcceptedProjectIntent,
 	parseReassignScopePayload,
+	parseRecipientPolicyEdgeCommitRequest,
 	parseSyncScopeRequest,
 	persistShareOperation,
 	personalScopeGrantStatusForPeer,
@@ -165,6 +168,7 @@ import {
 	SYNC_FEATURES_HEADER,
 	SYNC_SCOPE_QUERY_PARAM,
 	schema,
+	serializeRecipientPolicyTeamMutation,
 	summarizeInboundScopeRejections,
 	supportsSyncFeature,
 	syncScopeResetRequiredPayload,
@@ -5099,7 +5103,9 @@ export function syncRoutes(
 			return c.json({ error: "binding_request_invalid" }, 400);
 		}
 		const store = getStore();
+		let releasePublicationMutation: (() => void) | undefined;
 		try {
+			releasePublicationMutation = await claimRecipientPolicyPublicationMutation(store.db);
 			ensureStableStoreIdentity(store);
 			const result = commitDeviceIdentityBindings(
 				store.db,
@@ -5119,6 +5125,8 @@ export function syncRoutes(
 				return c.json({ error: "binding_commit_busy" }, 503);
 			}
 			return c.json({ error: "binding_commit_failed" }, 500);
+		} finally {
+			releasePublicationMutation?.();
 		}
 	});
 
@@ -5842,7 +5850,27 @@ export function syncRoutes(
 		const store = getStore();
 		const body = await parseViewerJsonBody(c);
 		try {
-			const result = commitRecipientPolicyEdges(store.db, body);
+			const request = parseRecipientPolicyEdgeCommitRequest(body);
+			// Acquire every affected Team queue in one stable order. Finish publication
+			// uses the same Team boundary, so its reviewed snapshot cannot race a
+			// successful user recipient commit.
+			const teamIds = request
+				? [
+						...new Set(
+							request.changes.flatMap((change) =>
+								change.recipient.recipientKind === "team" ? [change.recipient.teamId] : [],
+							),
+						),
+					].toSorted()
+				: [];
+			const commit = async (
+				index: number,
+			): Promise<ReturnType<typeof commitRecipientPolicyEdges>> => {
+				const teamId = teamIds[index];
+				if (!teamId) return commitRecipientPolicyEdges(store.db, request ?? body);
+				return serializeRecipientPolicyTeamMutation(store.db, teamId, () => commit(index + 1));
+			};
+			const result = await commit(0);
 			if (result.status === "invalid") return c.json(result, 400);
 			if (result.status === "not_found") return c.json(result, 404);
 			if (result.status === "stale" || result.status === "conflict") {
@@ -6432,9 +6460,11 @@ export function syncRoutes(
 		const store = getStore();
 		const body = await parseViewerJsonBody(c);
 		if (!body) return c.json({ error: "invalid json" }, 400);
+		let releasePublicationMutation: (() => void) | undefined;
 		try {
 			const confirmedGuardrailTokens = optionalViewerStringList(body, "confirmed_guardrail_tokens");
 			const mappingInput = parseViewerProjectMappingInput(body);
+			releasePublicationMutation = await claimRecipientPolicyPublicationMutation(store.db);
 			const analysis = analyzeProjectScopeMappingChangeGuardrails(store.db, mappingInput);
 			if (analysis.requested_workspace_identity?.startsWith("unmapped:")) {
 				return c.json(
@@ -6474,6 +6504,8 @@ export function syncRoutes(
 			return c.json({ ok: true, mapping, guardrail_warnings: analysis.warnings });
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+		} finally {
+			releasePublicationMutation?.();
 		}
 	});
 
@@ -6481,6 +6513,7 @@ export function syncRoutes(
 		const store = getStore();
 		const body = await parseViewerJsonBody(c);
 		if (!body) return c.json({ error: "invalid json" }, 400);
+		let releasePublicationMutation: (() => void) | undefined;
 		try {
 			const rawMappings = body.mappings;
 			if (!Array.isArray(rawMappings) || rawMappings.length === 0) {
@@ -6492,6 +6525,7 @@ export function syncRoutes(
 				}
 				return parseViewerProjectMappingInput(raw as Record<string, unknown>);
 			});
+			releasePublicationMutation = await claimRecipientPolicyPublicationMutation(store.db);
 			const analyses = mappingInputs.map((mappingInput) =>
 				analyzeProjectScopeMappingChangeGuardrails(store.db, mappingInput),
 			);
@@ -6540,17 +6574,23 @@ export function syncRoutes(
 			});
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+		} finally {
+			releasePublicationMutation?.();
 		}
 	});
 
-	app.delete("/api/sync/sharing-domains/project-mappings/:id", (c) => {
+	app.delete("/api/sync/sharing-domains/project-mappings/:id", async (c) => {
 		const store = getStore();
 		const id = Number(c.req.param("id"));
+		let releasePublicationMutation: (() => void) | undefined;
 		try {
+			releasePublicationMutation = await claimRecipientPolicyPublicationMutation(store.db);
 			const deleted = deleteProjectScopeSettingsMapping(store.db, id);
 			return c.json({ ok: true, deleted });
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+		} finally {
+			releasePublicationMutation?.();
 		}
 	});
 
@@ -6701,6 +6741,13 @@ export function syncRoutes(
 		if (!secondaryActorId) return c.json({ error: "secondary_actor_id required" }, 400);
 		if (primaryActorId === secondaryActorId) return c.json({ error: "actor ids must differ" }, 400);
 		const d = drizzle(store.db, { schema });
+		const releaseActorMutations = await claimRecipientPolicyActorMutations(store.db, [
+			primaryActorId,
+			secondaryActorId,
+		]);
+		// This transaction is synchronous. Deferring release prevents a thrown transaction
+		// from leaking the lock while keeping it held through every mutation below.
+		queueMicrotask(releaseActorMutations);
 		const now = new Date().toISOString();
 		const result = store.db
 			.transaction(() => {
@@ -7027,6 +7074,9 @@ export function syncRoutes(
 		if (actorId === store.actorId) {
 			return c.json({ error: "cannot deactivate this device's own local actor" }, 409);
 		}
+		const releaseActorMutations = await claimRecipientPolicyActorMutations(store.db, [actorId]);
+		// All following reads and writes are synchronous, so release after this turn.
+		queueMicrotask(releaseActorMutations);
 		const d = drizzle(store.db, { schema });
 		const actor = d.select().from(schema.actors).where(eq(schema.actors.actor_id, actorId)).get();
 		if (!actor) return c.json({ error: "actor not found" }, 404);

--- a/packages/viewer-server/src/routes/team-setup-refresh.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-refresh.test.ts
@@ -23,6 +23,7 @@ describe("Team setup refresh snapshots", () => {
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+			completionDependencies: null,
 		});
 		try {
 			store.db

--- a/packages/viewer-server/src/routes/team-setup-terminal.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-terminal.test.ts
@@ -1,4 +1,5 @@
 import {
+	deriveLegacyTeamSetupCompletionManifest,
 	deterministicPolicyTeamId,
 	finishLegacyTeamSetupActivation,
 	getLegacyTeamSetupDraft,
@@ -8,6 +9,10 @@ import {
 	legacyTeamCandidateProjectInventory,
 	MemoryStore,
 	readCoordinatorSyncConfig,
+	serializeRecipientPolicyActorMutations,
+	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyPublicationMutation,
+	serializeRecipientPolicyTeamMutation,
 	setLegacyTeamSetupDeviceAssignment,
 	setLegacyTeamSetupDeviceDecision,
 } from "@codemem/core";
@@ -18,6 +23,8 @@ const COORDINATOR_ID = "https://coordinator.example.test";
 const GROUP_ID = "group-alpha";
 const CANDIDATE_REF = legacyTeamCandidateId(COORDINATOR_ID, GROUP_ID);
 const NOW = "2026-08-26T00:00:00.000Z";
+const FINGERPRINT_A = "a".repeat(64);
+const FINGERPRINT_B = "b".repeat(64);
 const SNAPSHOTS: LegacyTeamConfiguredGroupSnapshot[] = [
 	{
 		coordinatorId: COORDINATOR_ID,
@@ -26,7 +33,7 @@ const SNAPSHOTS: LegacyTeamConfiguredGroupSnapshot[] = [
 		devices: [
 			{
 				deviceId: "device-a",
-				fingerprint: "fingerprint-a",
+				fingerprint: FINGERPRINT_A,
 				displayName: "Laptop",
 				enabled: true,
 			},
@@ -78,11 +85,1527 @@ function completeDraft(
 }
 
 describe("Team setup terminal migration routing", () => {
+	function completionConfig(timeoutS?: number) {
+		return {
+			readConfig: () => ({
+				...readCoordinatorSyncConfig({}),
+				syncCoordinatorUrl: COORDINATOR_ID,
+				syncCoordinatorGroups: [GROUP_ID],
+				syncCoordinatorAdminSecret: "private-admin-secret",
+				...(timeoutS == null ? {} : { syncCoordinatorTimeoutS: timeoutS }),
+			}),
+			listGroups: vi.fn(async () => []),
+			listDevices: vi.fn(async () => []),
+		};
+	}
+
+	async function readyDraftThroughSummary(
+		store: MemoryStore,
+		app: ReturnType<typeof teamSetupRoutes>,
+	) {
+		expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+		store.db
+			.prepare(
+				`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+				 VALUES ('identity-a', 'Person A', 0, 'active', ?, ?)`,
+			)
+			.run(NOW, NOW);
+		let draft = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+		if (!draft) throw new Error("Team setup draft missing");
+		const device = draft.devices[0];
+		if (!device) throw new Error("Team setup device missing");
+		draft = setLegacyTeamSetupDeviceAssignment(store.db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			targetIdentityId: "identity-a",
+			expectation: device.expectation,
+			now: NOW,
+		});
+		return setLegacyTeamSetupDeviceDecision(store.db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			decision: "included",
+			now: NOW,
+		});
+	}
+
+	it("publishes before activating the immutable winner", async () => {
+		const store = new MemoryStore(":memory:");
+		const loadSnapshots = vi.fn(async () => SNAPSHOTS);
+		const create = vi.fn(async ({ manifest }) => {
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+			return { status: "created" as const, manifest };
+		});
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: { create, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			const finishRequest = {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			};
+			const response = await app.request(
+				`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`,
+				finishRequest,
+			);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toMatchObject({
+				accessDeltaDigest: detail.accessDeltaDigest,
+			});
+			const completion = store.db
+				.prepare(
+					`SELECT finish_digest, confirmed_access_delta_digest
+					 FROM legacy_team_setup_completions WHERE attempt_id = ?`,
+				)
+				.get(draft.attemptId) as {
+				finish_digest: string;
+				confirmed_access_delta_digest: string;
+			};
+			expect(completion).toEqual({
+				finish_digest: detail.finishDigest,
+				confirmed_access_delta_digest: detail.accessDeltaDigest,
+			});
+			expect(completion.finish_digest).toMatch(/^legacy-team-activation-finish-v1:[0-9a-f]{64}$/u);
+			expect(completion.confirmed_access_delta_digest).toMatch(
+				/^legacy-team-access-delta:[0-9a-f]{64}$/u,
+			);
+			expect(create).toHaveBeenCalledTimes(1);
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(1);
+			expect(store.db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe(
+				"Migration Team",
+			);
+			loadSnapshots.mockRejectedValue(new Error("coordinator unavailable"));
+			const replay = await app.request(
+				`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`,
+				finishRequest,
+			);
+			expect(replay.status).toBe(200);
+			expect(await replay.json()).toMatchObject({ accessDeltaDigest: detail.accessDeltaDigest });
+			expect(create).toHaveBeenCalledTimes(1);
+			const staleReplay = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				...finishRequest,
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: `legacy-team-activation-finish-v1:${"0".repeat(64)}`,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+			expect(staleReplay.status).toBe(409);
+			expect(await staleReplay.json()).toEqual({ error: "team_setup_confirmation_stale" });
+			expect(create).toHaveBeenCalledTimes(1);
+			const staleAccessReplay = await app.request(
+				`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`,
+				{
+					...finishRequest,
+					body: JSON.stringify({
+						attemptId: draft.attemptId,
+						finishDigest: detail.finishDigest,
+						confirmedAccessDeltaDigest: `legacy-team-access-delta:${"1".repeat(64)}`,
+						confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+					}),
+				},
+			);
+			expect(staleAccessReplay.status).toBe(409);
+			expect(await staleAccessReplay.json()).toEqual({ error: "team_setup_confirmation_stale" });
+			expect(create).toHaveBeenCalledTimes(1);
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(1);
+			expect(
+				store.db
+					.prepare("SELECT state FROM legacy_team_setup_drafts WHERE candidate_id = ?")
+					.pluck()
+					.get(CANDIDATE_REF),
+			).toBe("completed");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("keeps local policy uncommitted when completion publication fails", async () => {
+		const store = new MemoryStore(":memory:");
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: {
+				create: async () => {
+					throw new Error("private upstream detail");
+				},
+				list: async () => [],
+			},
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+			expect(response.status).toBe(503);
+			expect(await response.json()).toEqual({ error: "team_setup_completion_unavailable" });
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("recovers a completion committed before its create response was lost", async () => {
+		const store = new MemoryStore(":memory:");
+		let published: ReturnType<typeof deriveLegacyTeamSetupCompletionManifest> | null = null;
+		const create = vi.fn(async ({ manifest }) => {
+			published = { ...manifest, completed_at: NOW };
+			throw new Error("completion_conflict");
+		});
+		const get = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Remote coordinator request failed (503): unavailable"))
+			.mockImplementation(async () => published);
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: { create, get, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toMatchObject({ completedAt: NOW });
+			expect(create).toHaveBeenCalledWith(
+				expect.objectContaining({ timeoutS: expect.any(Number) }),
+			);
+			expect(get).toHaveBeenCalledTimes(2);
+			expect(get).toHaveBeenCalledWith(
+				expect.objectContaining({
+					groupId: GROUP_ID,
+					candidateRef: CANDIDATE_REF,
+					timeoutS: expect.any(Number),
+				}),
+			);
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.state).toBe("completed");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("rejects a coordinator manifest that differs from the proposed completion", async () => {
+		const store = new MemoryStore(":memory:");
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: {
+				create: async ({ manifest }) => ({
+					status: "existing" as const,
+					manifest: { ...manifest, completed_at: "2026-08-30T00:00:01.000Z" },
+				}),
+				list: async () => [],
+			},
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_setup_completion_conflict" });
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("applies a remote completion before suppressing its candidate", async () => {
+		const source = new MemoryStore(":memory:");
+		const target = new MemoryStore(":memory:");
+		const sourceApp = teamSetupRoutes({
+			getStore: () => source,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const sourceDraft = await readyDraftThroughSummary(source, sourceApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(source.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: sourceDraft.attemptId,
+				completedAt: NOW,
+			});
+			const targetApp = teamSetupRoutes({
+				getStore: () => target,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: async ({ manifest }) => ({ status: "existing", manifest }),
+					list: async () => [
+						{
+							group_id: GROUP_ID,
+							manifest: {
+								...manifest,
+								candidate_ref: "legacy-team-candidate:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+							},
+						},
+						{ group_id: GROUP_ID, manifest },
+					],
+				},
+			});
+			target.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('identity-a', 'Person A', 0, 'active', ?, ?)`,
+				)
+				.run(NOW, NOW);
+			const response = await targetApp.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ version: 1, candidates: [] });
+			expect(target.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(1);
+		} finally {
+			source.close();
+			target.close();
+		}
+	});
+
+	it("isolates an invalid completion to its group during summary reconciliation", async () => {
+		const source = new MemoryStore(":memory:");
+		const target = new MemoryStore(":memory:");
+		const sourceApp = teamSetupRoutes({
+			getStore: () => source,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const sourceDraft = await readyDraftThroughSummary(source, sourceApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(source.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: sourceDraft.attemptId,
+				completedAt: NOW,
+			});
+			const secondGroup = {
+				...SNAPSHOTS[0],
+				groupId: "group-beta",
+				displayName: "Other Team",
+			} as LegacyTeamConfiguredGroupSnapshot;
+			const app = teamSetupRoutes({
+				getStore: () => target,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => [...SNAPSHOTS, secondGroup],
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: vi.fn(),
+					list: async () => [
+						{ group_id: GROUP_ID, manifest: { ...manifest, team_id: "team-invalid" } },
+					],
+				},
+			});
+
+			const response = await app.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			const body = (await response.json()) as { candidates: unknown[] };
+			expect(body.candidates).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ candidateRef: CANDIDATE_REF }),
+					expect.objectContaining({
+						candidateRef: legacyTeamCandidateId(COORDINATOR_ID, secondGroup.groupId),
+					}),
+				]),
+			);
+		} finally {
+			source.close();
+			target.close();
+		}
+	});
+
+	it("refreshes detail presentation after reconciling a completed draft", async () => {
+		const source = new MemoryStore(":memory:");
+		const target = new MemoryStore(":memory:");
+		const canonicalSnapshots = [
+			{
+				...SNAPSHOTS[0],
+				displayName: "Canonical Team",
+				devices: [
+					...(SNAPSHOTS[0]?.devices ?? []),
+					{
+						deviceId: "device-b",
+						displayName: "Spare laptop",
+						fingerprint: FINGERPRINT_B,
+						identityId: null,
+						enabled: true,
+					},
+				],
+			},
+		];
+		const sourceApp = teamSetupRoutes({
+			getStore: () => source,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => canonicalSnapshots,
+			completionDependencies: null,
+		});
+		const targetSetupApp = teamSetupRoutes({
+			getStore: () => target,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			let sourceDraft = await readyDraftThroughSummary(source, sourceApp);
+			const excludedDevice = sourceDraft.devices.find(
+				(device) => device.displayName === "Spare laptop",
+			);
+			if (!excludedDevice) throw new Error("canonical excluded device missing");
+			sourceDraft = setLegacyTeamSetupDeviceDecision(source.db, {
+				attemptId: sourceDraft.attemptId,
+				deviceRef: excludedDevice.deviceRef,
+				decision: "excluded",
+				now: NOW,
+			});
+			const manifest = deriveLegacyTeamSetupCompletionManifest(source.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: sourceDraft.attemptId,
+				completedAt: NOW,
+			});
+			const targetDraft = await readyDraftThroughSummary(target, targetSetupApp);
+			const review = inspectLegacyTeamSetupActivation(target.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: targetDraft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(target.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: targetDraft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			const app = teamSetupRoutes({
+				getStore: () => target,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => canonicalSnapshots,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: async ({ manifest: replay }) => ({ status: "existing", manifest: replay }),
+					list: async () => [{ group_id: GROUP_ID, manifest }],
+				},
+			});
+
+			let releasePublication: () => void = () => undefined;
+			const publicationGate = new Promise<void>((resolve) => {
+				releasePublication = resolve;
+			});
+			let markPublicationStarted: () => void = () => undefined;
+			const publicationStarted = new Promise<void>((resolve) => {
+				markPublicationStarted = resolve;
+			});
+			const heldPublication = serializeRecipientPolicyPublicationMutation(target.db, async () => {
+				markPublicationStarted();
+				await publicationGate;
+			});
+			await publicationStarted;
+			let detailSettled = false;
+			const detailRequest = app
+				.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+				.then((response) => {
+					detailSettled = true;
+					return response;
+				});
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(detailSettled).toBe(false);
+			releasePublication();
+			const response = await detailRequest;
+			await heldPublication;
+			expect(response.status).toBe(200);
+			expect(await response.json()).toMatchObject({
+				candidate: { displayName: "Canonical Team" },
+				state: "completed",
+			});
+		} finally {
+			source.close();
+			target.close();
+		}
+	});
+
+	it("does not republish an existing coordinator completion during loading", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			const create = vi.fn(async ({ manifest: replay }) => ({
+				status: "existing" as const,
+				manifest: replay,
+			}));
+			const list = vi.fn(async () => [{ group_id: GROUP_ID, manifest }]);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create,
+					list,
+				},
+			});
+			const response = await app.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ version: 1, candidates: [] });
+			expect(list).toHaveBeenCalledOnce();
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not block loading when existing-completion publication fails", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			let publicationMutationStarted = false;
+			let publicationMutation: Promise<void> | undefined;
+			let teamMutationStarted = false;
+			let teamMutation: Promise<void> | undefined;
+			let publicationStartedDuringCreate: boolean | undefined;
+			let teamStartedDuringCreate: boolean | undefined;
+			const create = vi.fn(async () => {
+				publicationMutation = serializeRecipientPolicyPublicationMutation(store.db, async () => {
+					publicationMutationStarted = true;
+				});
+				teamMutation = serializeRecipientPolicyTeamMutation(
+					store.db,
+					deterministicPolicyTeamId(CANDIDATE_REF),
+					async () => {
+						teamMutationStarted = true;
+					},
+				);
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				publicationStartedDuringCreate = publicationMutationStarted;
+				teamStartedDuringCreate = teamMutationStarted;
+				throw new Error("coordinator temporarily unavailable");
+			});
+			const list = vi.fn(async () => []);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: { create, list },
+			});
+
+			const response = await app.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ version: 1, candidates: [] });
+			expect(create).toHaveBeenCalledOnce();
+			expect(publicationStartedDuringCreate).toBe(false);
+			expect(teamStartedDuringCreate).toBe(false);
+			if (!publicationMutation) throw new Error("publication mutation was not queued");
+			if (!teamMutation) throw new Error("Team mutation was not queued");
+			await Promise.all([publicationMutation, teamMutation]);
+			expect(publicationMutationStarted).toBe(true);
+			expect(teamMutationStarted).toBe(true);
+			expect(list).toHaveBeenCalledOnce();
+			expect(
+				store.db
+					.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+					.get(deterministicPolicyTeamId(CANDIDATE_REF)),
+			).toEqual({ status: "active", migration_state: "completed" });
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.state).toBe("completed");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("applies the canonical winner when existing-completion publication conflicts", async () => {
+		const source = new MemoryStore(":memory:");
+		const target = new MemoryStore(":memory:");
+		const sourceApp = teamSetupRoutes({
+			getStore: () => source,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		const targetSetupApp = teamSetupRoutes({
+			getStore: () => target,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const sourceDraft = await readyDraftThroughSummary(source, sourceApp);
+			source.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+				)
+				.run(NOW, NOW);
+			source.db
+				.prepare(
+					"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-b' WHERE attempt_id = ?",
+				)
+				.run(sourceDraft.attemptId);
+			const canonicalManifest = deriveLegacyTeamSetupCompletionManifest(source.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: sourceDraft.attemptId,
+				completedAt: NOW,
+			});
+			const targetDraft = await readyDraftThroughSummary(target, targetSetupApp);
+			const review = inspectLegacyTeamSetupActivation(target.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: targetDraft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(target.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: targetDraft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			target.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+				)
+				.run(NOW, NOW);
+			const get = vi.fn(async () => canonicalManifest);
+			const app = teamSetupRoutes({
+				getStore: () => target,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: async () => {
+						throw new Error("completion_conflict");
+					},
+					get,
+					list: async () => [],
+				},
+			});
+
+			const response = await app.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ version: 1, candidates: [] });
+			expect(get).toHaveBeenCalledWith(
+				expect.objectContaining({
+					groupId: GROUP_ID,
+					candidateRef: CANDIDATE_REF,
+					timeoutS: expect.any(Number),
+				}),
+			);
+			expect(
+				target.db
+					.prepare(
+						"SELECT identity_id FROM policy_team_memberships WHERE team_id = ? AND status = 'reviewed_active'",
+					)
+					.pluck()
+					.get(deterministicPolicyTeamId(CANDIDATE_REF)),
+			).toBe("identity-b");
+		} finally {
+			source.close();
+			target.close();
+		}
+	});
+
+	it.each([
+		"roster-unavailable",
+		"additive-roster-unavailable",
+		"group-missing",
+		"digest-invalid",
+		"binding-mismatch",
+		"malformed",
+		"partial-roster-unavailable",
+	] as const)(
+		"handles a divergent local completion when a listed winner is %s",
+		async (failureMode) => {
+			const source = new MemoryStore(":memory:");
+			const target = new MemoryStore(":memory:");
+			const sourceApp = teamSetupRoutes({
+				getStore: () => source,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				completionDependencies: null,
+			});
+			const targetSetupApp = teamSetupRoutes({
+				getStore: () => target,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				completionDependencies: null,
+			});
+			try {
+				if (failureMode === "additive-roster-unavailable") {
+					const projectIdentity = "https://example.test/additive-project.git";
+					source.db
+						.prepare(
+							`INSERT INTO replication_scopes(
+							 scope_id, label, kind, authority_type, coordinator_id, group_id,
+							 membership_epoch, status, created_at, updated_at
+							 ) VALUES ('scope-additive', 'Additive', 'team', 'coordinator', ?, ?, 1,
+							 'active', ?, ?)`,
+						)
+						.run(COORDINATOR_ID, GROUP_ID, NOW, NOW);
+					const sessionId = Number(
+						source.db
+							.prepare(
+								`INSERT INTO sessions(started_at, project, git_remote)
+								 VALUES (?, 'additive-project', ?)`,
+							)
+							.run(NOW, projectIdentity).lastInsertRowid,
+					);
+					source.db
+						.prepare(
+							`INSERT INTO memory_items(
+							 session_id, kind, title, body_text, active, created_at, updated_at,
+							 visibility, project, scope_id
+							 ) VALUES (?, 'discovery', 'Additive Project', 'body', 1, ?, ?, 'shared',
+							 'additive-project', 'scope-additive')`,
+						)
+						.run(sessionId, NOW, NOW);
+					source.db
+						.prepare(
+							`INSERT INTO project_scope_mappings(
+							 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+							 ) VALUES (?, ?, 'scope-additive', 1000, 'reviewed_team_setup', ?, ?)`,
+						)
+						.run(projectIdentity, projectIdentity, NOW, NOW);
+				}
+				const sourceDraft = await readyDraftThroughSummary(source, sourceApp);
+				if (failureMode !== "additive-roster-unavailable") {
+					source.db
+						.prepare(
+							`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+						 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+						)
+						.run(NOW, NOW);
+					source.db
+						.prepare(
+							"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-b' WHERE attempt_id = ?",
+						)
+						.run(sourceDraft.attemptId);
+				}
+				const canonicalManifest = deriveLegacyTeamSetupCompletionManifest(source.db, {
+					candidateRef: CANDIDATE_REF,
+					attemptId: sourceDraft.attemptId,
+					completedAt: NOW,
+				});
+				const targetDraft = await readyDraftThroughSummary(target, targetSetupApp);
+				const review = inspectLegacyTeamSetupActivation(target.db, {
+					candidateRef: CANDIDATE_REF,
+					attemptId: targetDraft.attemptId,
+				});
+				await finishLegacyTeamSetupActivation(target.db, {
+					candidateRef: CANDIDATE_REF,
+					attemptId: targetDraft.attemptId,
+					finishDigest: review.finishDigest,
+					confirmedAccessDeltaDigest: review.accessDeltaDigest,
+					loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+					loadProjectInventory: () => [],
+					validateLockedPreview: () => true,
+					now: NOW,
+				});
+				let unscopedLoadCount = 0;
+				const primarySnapshot = SNAPSHOTS[0];
+				if (!primarySnapshot) throw new Error("missing primary test snapshot");
+				const secondSnapshot = { ...primarySnapshot, groupId: "other-group" };
+				const loadSnapshots = vi.fn(async (options?: { candidateRef?: string }) => {
+					if (failureMode === "partial-roster-unavailable") {
+						if (options?.candidateRef) throw new Error("team_setup_roster_unavailable");
+						unscopedLoadCount += 1;
+						return unscopedLoadCount === 1 ? [...SNAPSHOTS, secondSnapshot] : [secondSnapshot];
+					}
+					if (options?.candidateRef && failureMode === "group-missing") return [];
+					if (options?.candidateRef) throw new Error("team_setup_roster_unavailable");
+					return SNAPSHOTS;
+				});
+				const listedManifest = (() => {
+					if (failureMode === "digest-invalid") {
+						return { ...canonicalManifest, finish_digest: "0".repeat(64) };
+					}
+					if (failureMode === "binding-mismatch") {
+						return { ...canonicalManifest, coordinator_id: "other-coordinator" };
+					}
+					if (failureMode === "malformed") {
+						return null as unknown as typeof canonicalManifest;
+					}
+					return canonicalManifest;
+				})();
+				const snapshotDependencies = completionConfig();
+				if (failureMode === "partial-roster-unavailable") {
+					snapshotDependencies.readConfig = () => ({
+						...readCoordinatorSyncConfig({}),
+						syncCoordinatorUrl: COORDINATOR_ID,
+						syncCoordinatorGroups: [GROUP_ID, secondSnapshot.groupId],
+						syncCoordinatorAdminSecret: "private-admin-secret",
+					});
+				}
+				const app = teamSetupRoutes({
+					getStore: () => target,
+					loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+					snapshotLoaderDependencies: snapshotDependencies,
+					completionDependencies: {
+						create: vi.fn(),
+						list: async () => [{ group_id: GROUP_ID, manifest: listedManifest }],
+					},
+				});
+
+				const response = await app.request("/api/sync/team-setup/v1");
+
+				expect(response.status).toBe(200);
+				const shouldContain =
+					failureMode !== "additive-roster-unavailable" &&
+					failureMode !== "binding-mismatch" &&
+					failureMode !== "malformed" &&
+					failureMode !== "partial-roster-unavailable";
+				const body = await response.json();
+				if (shouldContain) {
+					expect(body).toMatchObject({
+						candidates: [expect.objectContaining({ candidateRef: CANDIDATE_REF })],
+					});
+				}
+				expect(
+					target.db
+						.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+						.get(deterministicPolicyTeamId(CANDIDATE_REF)),
+				).toEqual(
+					shouldContain
+						? { status: "inactive", migration_state: "needs_setup" }
+						: { status: "active", migration_state: "completed" },
+				);
+			} finally {
+				source.close();
+				target.close();
+			}
+		},
+	);
+
+	it("contains local completion when a fetched winner cannot load a fresh roster", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			const loadSnapshots = vi.fn(async (options?: { candidateRef?: string }) => {
+				if (options?.candidateRef) throw new Error("team_setup_roster_unavailable");
+				return SNAPSHOTS;
+			});
+			const get = vi.fn(async () => manifest);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: async () => {
+						throw new Error("completion_conflict");
+					},
+					get,
+					list: async () => [],
+				},
+			});
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(409);
+			expect(await detail.json()).toEqual({ error: "team_setup_completion_conflict" });
+			const summary = await app.request("/api/sync/team-setup/v1");
+			expect(summary.status).toBe(200);
+			expect(await summary.json()).toMatchObject({
+				candidates: [expect.objectContaining({ candidateRef: CANDIDATE_REF })],
+			});
+			expect(get).toHaveBeenCalledOnce();
+			expect(
+				store.db
+					.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+					.get(deterministicPolicyTeamId(CANDIDATE_REF)),
+			).toEqual({ status: "inactive", migration_state: "needs_setup" });
+		} finally {
+			store.close();
+		}
+	});
+
+	it("contains local completion when a publication conflict has no fetchable winner", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: async () => {
+						throw new Error("completion_conflict");
+					},
+					get: async () => null,
+					list: async () => [],
+				},
+			});
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(409);
+			expect(await detail.json()).toEqual({ error: "team_setup_completion_conflict" });
+			expect(
+				store.db
+					.prepare("SELECT finish_digest FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+					.pluck()
+					.get(draft.attemptId),
+			).toBeNull();
+			const summary = await app.request("/api/sync/team-setup/v1");
+			expect(summary.status).toBe(200);
+			expect(await summary.json()).toMatchObject({
+				candidates: [expect.objectContaining({ candidateRef: CANDIDATE_REF })],
+			});
+			expect(
+				store.db
+					.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+					.get(deterministicPolicyTeamId(CANDIDATE_REF)),
+			).toEqual({ status: "inactive", migration_state: "needs_setup" });
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not publish a persisted completion to a newly configured coordinator", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			const create = vi.fn();
+			const list = vi.fn(async () => []);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => [],
+				snapshotLoaderDependencies: {
+					...completionConfig(),
+					readConfig: () => ({
+						...readCoordinatorSyncConfig({}),
+						syncCoordinatorUrl: "https://other-coordinator.example.test",
+						syncCoordinatorGroups: [GROUP_ID],
+						syncCoordinatorAdminSecret: "other-private-admin-secret",
+					}),
+				},
+				completionDependencies: { create, list },
+			});
+
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toMatchObject({ state: "completed" });
+			expect(list).not.toHaveBeenCalled();
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not publish a persisted completion for a group removed from configuration", async () => {
+		const store = new MemoryStore(":memory:");
+		let configuredGroups = [GROUP_ID];
+		const create = vi.fn();
+		const list = vi.fn(async () => []);
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: {
+				...completionConfig(),
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: COORDINATOR_ID,
+					syncCoordinatorGroups: configuredGroups,
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+			},
+			completionDependencies: { create, list },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			configuredGroups = [];
+			create.mockClear();
+			list.mockClear();
+
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toMatchObject({ state: "completed" });
+			expect(list).not.toHaveBeenCalled();
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not publish finish data when the coordinator changes after roster loading", async () => {
+		const store = new MemoryStore(":memory:");
+		let changedConfig = false;
+		let changeAfterNextSnapshot = false;
+		const create = vi.fn();
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => {
+				if (changeAfterNextSnapshot) changedConfig = true;
+				return SNAPSHOTS;
+			},
+			snapshotLoaderDependencies: {
+				...completionConfig(),
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: changedConfig
+						? "https://other-coordinator.example.test"
+						: COORDINATOR_ID,
+					syncCoordinatorGroups: [GROUP_ID],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+			},
+			completionDependencies: { create, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			changeAfterNextSnapshot = true;
+
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_setup_completion_invalid" });
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not publish finish data when its group is removed during roster loading", async () => {
+		const store = new MemoryStore(":memory:");
+		let configuredGroups = [GROUP_ID];
+		let removeAfterNextSnapshot = false;
+		const create = vi.fn();
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => {
+				if (removeAfterNextSnapshot) configuredGroups = [];
+				return SNAPSHOTS;
+			},
+			snapshotLoaderDependencies: {
+				...completionConfig(),
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: COORDINATOR_ID,
+					syncCoordinatorGroups: configuredGroups,
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+			},
+			completionDependencies: { create, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			removeAfterNextSnapshot = true;
+
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_setup_completion_invalid" });
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("serializes a draft mutation behind completion publication", async () => {
+		const store = new MemoryStore(":memory:");
+		let groupMutationStarted = false;
+		let groupMutation: Promise<void> | undefined;
+		let policyMutationStarted = false;
+		let policyMutation: Promise<void> | undefined;
+		let actorMutationStarted = false;
+		let actorMutation: Promise<void> | undefined;
+		let publicationMutationStarted = false;
+		let publicationMutation: Promise<void> | undefined;
+		let releaseCreate: () => void = () => undefined;
+		const createGate = new Promise<void>((resolve) => {
+			releaseCreate = resolve;
+		});
+		let markCreateStarted: () => void = () => undefined;
+		const createStarted = new Promise<void>((resolve) => {
+			markCreateStarted = resolve;
+		});
+		let listedManifest: ReturnType<typeof deriveLegacyTeamSetupCompletionManifest> | null = null;
+		let listInvalidDigest = false;
+		const create = vi.fn(async ({ manifest }) => {
+			listedManifest = manifest;
+			groupMutation = serializeRecipientPolicyCoordinatorGroupMutation(
+				store.db,
+				GROUP_ID,
+				async () => {
+					groupMutationStarted = true;
+				},
+			);
+			policyMutation = serializeRecipientPolicyTeamMutation(
+				store.db,
+				deterministicPolicyTeamId(CANDIDATE_REF),
+				async () => {
+					policyMutationStarted = true;
+				},
+			);
+			const includedActorId = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.devices.find(
+				(device) => device.decision === "included",
+			)?.targetIdentityId;
+			if (!includedActorId) throw new Error("included actor was not assigned");
+			actorMutation = serializeRecipientPolicyActorMutations(
+				store.db,
+				[includedActorId],
+				async () => {
+					actorMutationStarted = true;
+				},
+			);
+			publicationMutation = serializeRecipientPolicyPublicationMutation(store.db, async () => {
+				publicationMutationStarted = true;
+			});
+			markCreateStarted();
+			await createGate;
+			return { status: "created" as const, manifest };
+		});
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: {
+				create,
+				list: async () => {
+					if (!listedManifest) return [];
+					return [
+						{
+							group_id: GROUP_ID,
+							manifest: listInvalidDigest
+								? { ...listedManifest, finish_digest: "0".repeat(64) }
+								: listedManifest,
+						},
+					];
+				},
+			},
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const deviceRef = draft.devices[0]?.deviceRef ?? "";
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+
+			const finishRequest = app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+			await createStarted;
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(groupMutationStarted).toBe(false);
+			expect(policyMutationStarted).toBe(false);
+			expect(actorMutationStarted).toBe(false);
+			expect(publicationMutationStarted).toBe(false);
+			const summaryResponse = await app.request("/api/sync/team-setup/v1");
+			expect(summaryResponse.status).toBe(200);
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+			listInvalidDigest = true;
+			const detailConflict = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detailConflict.status).toBe(409);
+			listInvalidDigest = false;
+			const mutationResponse = await app.request(
+				`/api/sync/team-setup/v1/${CANDIDATE_REF}/devices/${deviceRef}/decision`,
+				{
+					method: "DELETE",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ attemptId: draft.attemptId }),
+				},
+			);
+			expect(mutationResponse.status).toBe(409);
+			releaseCreate();
+
+			const response = await finishRequest;
+			expect(response.status).toBe(200);
+			if (!groupMutation) throw new Error("group mutation was not queued");
+			if (!policyMutation) throw new Error("policy mutation was not queued");
+			if (!actorMutation) throw new Error("actor mutation was not queued");
+			if (!publicationMutation) throw new Error("publication mutation was not queued");
+			await Promise.all([groupMutation, policyMutation, actorMutation, publicationMutation]);
+			expect(groupMutationStarted).toBe(true);
+			expect(policyMutationStarted).toBe(true);
+			expect(actorMutationStarted).toBe(true);
+			expect(publicationMutationStarted).toBe(true);
+			expect(create).toHaveBeenCalledOnce();
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.devices[0]?.decision).toBe(
+				"included",
+			);
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(1);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("keeps summary and detail reads available when an older coordinator lacks completion queries", async () => {
+		const store = new MemoryStore(":memory:");
+		const list = vi.fn(async () => {
+			throw new Error("Remote coordinator request failed (404): HTTP 404");
+		});
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: { create: vi.fn(), list },
+		});
+		try {
+			const summary = await app.request("/api/sync/team-setup/v1");
+			expect(summary.status).toBe(200);
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(200);
+			expect(list).toHaveBeenCalledTimes(2);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("reconciles an existing draft without a cold-cache roster read", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			expect((await setupApp.request("/api/sync/team-setup/v1")).status).toBe(200);
+			const loadSnapshots = vi.fn(async () => {
+				throw new Error("team_setup_roster_unavailable");
+			});
+			const list = vi.fn(async () => []);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: { create: vi.fn(), list },
+			});
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(200);
+			expect(loadSnapshots).not.toHaveBeenCalled();
+			expect(list).toHaveBeenCalledOnce();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("applies a canonical completion during a cold-cache detail read", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			const loadSnapshots = vi.fn(async () => SNAPSHOTS);
+			const list = vi.fn(async () => [{ group_id: GROUP_ID, manifest }]);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: { create: vi.fn(), list },
+			});
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(404);
+			expect(await detail.json()).toEqual({ error: "team_setup_confirmation_stale" });
+			expect(loadSnapshots).toHaveBeenCalledOnce();
+			expect(loadSnapshots).toHaveBeenCalledWith(
+				expect.objectContaining({
+					candidateRef: CANDIDATE_REF,
+					deadlineMs: expect.any(Number),
+				}),
+			);
+			expect(list).toHaveBeenCalledOnce();
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.state).toBe("completed");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("rejects a canonical completion after an included device is re-keyed", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			const originalSnapshot = SNAPSHOTS[0];
+			const originalDevice = originalSnapshot?.devices[0];
+			if (!originalSnapshot || !originalDevice) throw new Error("Team setup snapshot missing");
+			const rekeyedSnapshots: LegacyTeamConfiguredGroupSnapshot[] = [
+				{
+					...originalSnapshot,
+					devices: [{ ...originalDevice, fingerprint: FINGERPRINT_B }],
+				},
+			];
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => rekeyedSnapshots,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: vi.fn(),
+					list: vi.fn(async () => [{ group_id: GROUP_ID, manifest }]),
+				},
+			});
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(409);
+			expect(await detail.json()).toEqual({ error: "team_setup_completion_invalid" });
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+			expect(
+				store.db
+					.prepare(
+						"SELECT key_fingerprint FROM legacy_team_setup_draft_devices WHERE attempt_id = ?",
+					)
+					.pluck()
+					.get(draft.attemptId),
+			).toBe(FINGERPRINT_A);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("retries transient completion reads with the configured timeout", async () => {
+		const store = new MemoryStore(":memory:");
+		const list = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Remote coordinator request failed (503): unavailable"))
+			.mockResolvedValue([]);
+		const config = completionConfig(17);
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: config,
+			readCoordinatorConfig: config.readConfig,
+			completionDependencies: { create: vi.fn(), list },
+		});
+		try {
+			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+			expect(list).toHaveBeenCalledTimes(2);
+			expect(list).toHaveBeenCalledWith(expect.objectContaining({ timeoutS: 17 }));
+		} finally {
+			store.close();
+		}
+	});
+
 	it("revalidates pre-marker completions in detail and summary reads", async () => {
 		const store = new MemoryStore(":memory:");
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
 		});
 		try {
 			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
@@ -131,6 +1654,7 @@ describe("Team setup terminal migration routing", () => {
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+			completionDependencies: null,
 		});
 		try {
 			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
@@ -170,6 +1694,7 @@ describe("Team setup terminal migration routing", () => {
 			const app = teamSetupRoutes({
 				getStore: () => store,
 				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				completionDependencies: null,
 			});
 			try {
 				expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
@@ -220,6 +1745,7 @@ describe("Team setup terminal migration routing", () => {
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
 		});
 		try {
 			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
@@ -249,6 +1775,7 @@ describe("Team setup terminal migration routing", () => {
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
 		});
 		try {
 			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
@@ -283,6 +1810,7 @@ describe("Team setup terminal migration routing", () => {
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
 		});
 		try {
 			const projectIdentity = "https://example.test/terminal-project.git";

--- a/packages/viewer-server/src/routes/team-setup-timeout.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-timeout.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { remainingCoordinatorTimeoutS } from "./team-setup.js";
+
+describe("legacy Team completion coordinator timeout", () => {
+	it("caps each publication at the shared remaining budget", () => {
+		expect(remainingCoordinatorTimeoutS(30, 20_000, 10_000)).toBe(10);
+		expect(remainingCoordinatorTimeoutS(3, 20_000, 10_000)).toBe(3);
+		expect(remainingCoordinatorTimeoutS(3, 10_050, 10_000)).toBe(0.1);
+	});
+
+	it("stops publication after the shared deadline", () => {
+		expect(remainingCoordinatorTimeoutS(3, 10_000, 10_000)).toBeNull();
+		expect(remainingCoordinatorTimeoutS(3, 10_000, 10_001)).toBeNull();
+	});
+});

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -532,6 +532,10 @@ describe("Team setup roster loading", () => {
 			});
 			const app = teamSetupRoutes({
 				getStore: () => store,
+				completionDependencies: {
+					create: async ({ manifest }) => ({ status: "created", manifest }),
+					list: async () => [],
+				},
 				snapshotLoaderDependencies: {
 					readConfig: () => ({
 						...readCoordinatorSyncConfig({}),
@@ -984,6 +988,10 @@ describe("Team setup roster loading", () => {
 			try {
 				const app = teamSetupRoutes({
 					getStore: () => store,
+					completionDependencies: {
+						create: async ({ manifest }) => ({ status: "created", manifest }),
+						list: async () => [],
+					},
 					snapshotLoaderDependencies: {
 						readConfig: () => ({
 							...readCoordinatorSyncConfig({}),

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -8,18 +8,30 @@ import type {
 	MemoryStore,
 } from "@codemem/core";
 import {
+	applyLegacyTeamSetupCompletionManifest,
+	applyLegacyTeamSetupCompletionManifestAndReturnActivation,
+	areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible,
 	buildBaseUrl,
+	canonicalCoordinatorLegacyTeamCompletionManifestJson,
+	claimRecipientPolicyActorMutations,
+	claimRecipientPolicyPublicationMutation,
 	clearLegacyTeamSetupDeviceDecision,
+	containLegacyTeamSetupCompletionConflict,
+	coordinatorCreateLegacyTeamCompletionAction,
+	coordinatorGetLegacyTeamCompletionAction,
 	coordinatorListDevicesAction,
 	coordinatorListGroupsAction,
+	coordinatorListLegacyTeamCompletionsAction,
+	deriveLegacyTeamSetupCompletionManifest,
 	deterministicPolicyTeamId,
 	discoverLegacyTeamCandidates,
 	fingerprintPublicKey,
-	finishLegacyTeamSetupActivation,
 	getLegacyTeamSetupDraft,
+	inspectFreshLegacyTeamSetupActivation,
 	inspectLegacyTeamSetupActivation,
 	isLegacyTeamCandidateSelectable,
 	isLegacyTeamSetupProjectMappingIdentity,
+	LegacyTeamSetupAdditiveConvergenceError,
 	legacyTeamCandidateId,
 	legacyTeamCandidateProjectInventory,
 	legacyTeamCanonicalProjectRef,
@@ -30,10 +42,18 @@ import {
 	previewLegacyTeamSetupActivation,
 	readCoordinatorSyncConfig,
 	recipientPolicyDigest,
+	reconstructLegacyTeamSetupCompletionManifest,
 	refreshLegacyTeamCandidate,
+	replayLegacyTeamSetupActivation,
+	requireLegacyTeamSetupAccessDeltaWithinLimit,
+	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyPublicationMutation,
+	serializeRecipientPolicyTeamMutation,
 	setLegacyTeamSetupDeviceAssignment,
 	setLegacyTeamSetupDeviceDecision,
 	setLegacyTeamSetupProjectMapping,
+	validateLegacyTeamSetupCompletionManifest,
+	validateLegacyTeamSetupCompletionManifestBinding,
 } from "@codemem/core";
 import { type Context, Hono } from "hono";
 import {
@@ -73,7 +93,6 @@ const MAX_CONFIGURED_GROUPS = 25;
 const MAX_SCOPE_EVIDENCE_COORDINATORS = 100;
 const MAX_DEVICES = 500;
 const MAX_PROJECTS = 500;
-const MAX_ACCESS_DELTA_ENTRIES = 10_000;
 const MAX_IDENTITY_CHOICES = 500;
 const MAX_COMPLETED_IDENTITY_CHOICES = MAX_DEVICES * 4;
 const MAX_PROJECT_MAPPING_CHOICES = 500;
@@ -93,9 +112,42 @@ const ATTEMPT_ID_PATTERN = /^legacy-team-attempt:[0-9a-f-]{36}$/u;
 const FINISH_DIGEST_PATTERN = /^legacy-team-activation-finish-v1:[0-9a-f]{64}$/u;
 const ACCESS_DELTA_DIGEST_PATTERN = /^legacy-team-access-delta:[0-9a-f]{64}$/u;
 const VIEWER_ACCESS_DELTA_DIGEST_PATTERN = /^legacy-team-viewer-access-delta-v1:[0-9a-f]{64}$/u;
+const activeCandidateMutations = new WeakMap<MemoryStore["db"], Set<string>>();
+
+function claimCandidateMutation(db: MemoryStore["db"], candidateRef: string): (() => void) | null {
+	let active = activeCandidateMutations.get(db);
+	if (!active) {
+		active = new Set();
+		activeCandidateMutations.set(db, active);
+	}
+	if (active.has(candidateRef)) return null;
+	active.add(candidateRef);
+	let released = false;
+	return () => {
+		if (released) return;
+		released = true;
+		active?.delete(candidateRef);
+	};
+}
+
+async function runCandidateMutation<T>(
+	db: MemoryStore["db"],
+	candidateRef: string,
+	operation: () => Promise<T>,
+): Promise<boolean> {
+	const release = claimCandidateMutation(db, candidateRef);
+	if (!release) return false;
+	try {
+		await operation();
+		return true;
+	} finally {
+		release();
+	}
+}
 
 interface LegacyTeamConfiguredGroupSnapshotLoadOptions {
 	candidateRef?: string;
+	deadlineMs?: number;
 }
 
 export interface LegacyTeamCandidateGroupDescriptor {
@@ -111,8 +163,22 @@ export interface TeamSetupRoutesOptions {
 	getStore: () => MemoryStore;
 	loadLegacyTeamConfiguredGroupSnapshots?: LegacyTeamConfiguredGroupSnapshotLoader;
 	snapshotLoaderDependencies?: LegacyTeamSnapshotLoaderDependencies;
+	completionDependencies?: LegacyTeamCompletionDependencies | null;
+	readCoordinatorConfig?: typeof readCoordinatorSyncConfig;
 	registerSummaryInvalidator?: (invalidate: () => void) => void;
 }
+
+export interface LegacyTeamCompletionDependencies {
+	create: typeof coordinatorCreateLegacyTeamCompletionAction;
+	get?: typeof coordinatorGetLegacyTeamCompletionAction;
+	list: typeof coordinatorListLegacyTeamCompletionsAction;
+}
+
+const defaultCompletionDependencies: LegacyTeamCompletionDependencies = {
+	create: coordinatorCreateLegacyTeamCompletionAction,
+	get: coordinatorGetLegacyTeamCompletionAction,
+	list: coordinatorListLegacyTeamCompletionsAction,
+};
 
 interface LegacyTeamSnapshotLoaderDependencies {
 	readConfig: typeof readCoordinatorSyncConfig;
@@ -134,15 +200,26 @@ function isCoordinatorRosterTooLargeError(error: unknown): boolean {
 	return error instanceof Error && error.message === "coordinator_response_too_large";
 }
 
+function remoteCoordinatorHttpStatus(error: unknown): number | null {
+	if (!(error instanceof Error)) return null;
+	const status = /Remote coordinator request failed \((\d{3})\):/u.exec(error.message)?.[1];
+	return status ? Number(status) : null;
+}
+
 function isTransientCoordinatorReadError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
-	const remoteStatus = /Remote coordinator request failed \((\d{3})\):/u.exec(error.message)?.[1];
-	if (remoteStatus) return ["408", "429", "500", "502", "503", "504"].includes(remoteStatus);
+	const remoteStatus = remoteCoordinatorHttpStatus(error);
+	if (remoteStatus) return [408, 429, 500, 502, 503, 504].includes(remoteStatus);
 	return (
 		error.name === "TimeoutError" ||
 		error.name === "AbortError" ||
 		/request_timeout|fetch failed|timed out|timeout/iu.test(error.message)
 	);
+}
+
+function isUnsupportedCompletionQuery(error: unknown): boolean {
+	const status = remoteCoordinatorHttpStatus(error);
+	return status === 404 || status === 405;
 }
 
 async function retryTransientCoordinatorRead<T>(
@@ -165,6 +242,15 @@ async function retryTransientCoordinatorRead<T>(
 		}
 	}
 	throw lastError;
+}
+
+export function remainingCoordinatorTimeoutS(
+	configuredTimeoutS: number,
+	deadlineMs: number,
+	nowMs = Date.now(),
+): number | null {
+	const remainingMs = deadlineMs - nowMs;
+	return remainingMs <= 0 ? null : Math.max(0.1, Math.min(configuredTimeoutS, remainingMs / 1_000));
 }
 
 function configuredGroupIds(groups: string[]): string[] {
@@ -330,7 +416,7 @@ async function loadConfiguredLegacyTeamGroupSnapshotsWith(
 		);
 		if (groupDescriptors.length === 0) throw safeCoordinatorError();
 		const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
-		const deadlineMs = Date.now() + COORDINATOR_ROSTER_READ_BUDGET_MS;
+		const deadlineMs = options.deadlineMs ?? Date.now() + COORDINATOR_ROSTER_READ_BUDGET_MS;
 		const requestedGroupDescriptors = options.candidateRef
 			? groupDescriptors.filter(
 					({ coordinatorId, groupId }) =>
@@ -707,25 +793,6 @@ function viewerAccessDeltaDigest(delta: LegacyTeamSetupViewerAccessDeltaV1): str
 	return recipientPolicyDigest("legacy-team-viewer-access-delta-v1", delta);
 }
 
-function requireBoundedAccessDelta(delta: LegacyTeamSetupAccessDeltaV1): void {
-	const total =
-		delta.teamChanges.length +
-		delta.membershipChanges.length +
-		delta.projectChanges.length +
-		delta.recipientChanges.length +
-		delta.deviceAccessChanges.length;
-	if (
-		delta.teamChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
-		delta.membershipChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
-		delta.projectChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
-		delta.recipientChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
-		delta.deviceAccessChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
-		total > MAX_ACCESS_DELTA_ENTRIES
-	) {
-		throw new Error("legacy_team_setup_roster_too_large");
-	}
-}
-
 const SAFE_CHOICE_LABEL_PATTERN = /^[\p{L}\p{N} '&,.()_-]*$/u;
 
 // Keep this byte-for-byte equivalent in behavior to the core setup-label
@@ -1074,7 +1141,8 @@ function viewerSafePreview(
 }
 
 function errorStatus(code: LegacyTeamSetupActivationErrorCode): 400 | 409 | 503 {
-	if (code === "team_setup_roster_unavailable") return 503;
+	if (code === "team_setup_roster_unavailable" || code === "team_setup_completion_unavailable")
+		return 503;
 	if (code === "team_setup_failed") return 503;
 	if (code === "team_setup_incomplete") return 400;
 	return 409;
@@ -1083,6 +1151,11 @@ function errorStatus(code: LegacyTeamSetupActivationErrorCode): 400 | 409 | 503 
 function apiErrorCode(error: unknown): LegacyTeamSetupActivationErrorCode {
 	const code = legacyTeamSetupApiErrorCode(error);
 	return code === "team_setup_projection_changed" ? "team_setup_conflict" : code;
+}
+
+function completionApiError(error: unknown): LegacyTeamSetupActivationErrorCode {
+	const code = legacyTeamSetupApiErrorCode(error);
+	return code === "team_setup_failed" ? "team_setup_completion_unavailable" : code;
 }
 
 type BoundedJsonResult = { ok: true; value: Record<string, unknown> } | { ok: false };
@@ -1158,7 +1231,7 @@ function detailResponse(
 			else if (code !== "team_setup_incomplete") unavailableReason = code;
 		}
 	}
-	if (preview) requireBoundedAccessDelta(preview.accessDelta);
+	if (preview) requireLegacyTeamSetupAccessDeltaWithinLimit(preview.accessDelta);
 	const safeDraft = viewerSafeDraft(store, draft);
 	const safePreview = preview ? viewerSafePreview(draft, safeDraft, preview) : null;
 	return projectLegacyTeamSetupView({
@@ -1201,9 +1274,12 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 
 	async function loadedSnapshots(
 		candidateRef?: string,
+		deadlineMs?: number,
 	): Promise<LegacyTeamConfiguredGroupSnapshot[]> {
 		try {
-			return await loadSnapshots(candidateRef ? { candidateRef } : undefined);
+			return await loadSnapshots(
+				candidateRef || deadlineMs != null ? { candidateRef, deadlineMs } : undefined,
+			);
 		} catch (error) {
 			if (error instanceof Error && error.message === "legacy_team_setup_roster_too_large") {
 				throw error;
@@ -1216,6 +1292,394 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		SUMMARY_SNAPSHOT_CACHE_TTL_MS,
 	);
 	options.registerSummaryInvalidator?.(() => loadedSummarySnapshots.invalidate());
+	const completionDependencies =
+		options.completionDependencies === undefined
+			? defaultCompletionDependencies
+			: options.completionDependencies;
+
+	async function reconcileCompletions(
+		store: MemoryStore,
+		groups: LegacyTeamCandidateGroupDescriptor[],
+		reconciliationOptions: { isolateApplyFailures?: boolean } = {},
+	): Promise<void> {
+		if (!completionDependencies || groups.length === 0) return;
+		let config: ReturnType<typeof readCoordinatorSyncConfig>;
+		try {
+			config = (
+				options.readCoordinatorConfig ??
+				options.snapshotLoaderDependencies?.readConfig ??
+				readCoordinatorSyncConfig
+			)();
+		} catch (error) {
+			throw new Error(completionApiError(error));
+		}
+		const remoteUrl = buildBaseUrl(config.syncCoordinatorUrl);
+		if (!remoteUrl || !config.syncCoordinatorAdminSecret) {
+			return;
+		}
+		const configuredCoordinatorId = normalizedCoordinatorId(remoteUrl);
+		if (!configuredCoordinatorId) return;
+		let currentGroupIds: Set<string>;
+		try {
+			currentGroupIds = new Set(
+				legacyTeamCandidateGroupDescriptors(store, remoteUrl, config.syncCoordinatorGroups).map(
+					(group) => group.groupId,
+				),
+			);
+		} catch {
+			// If current authorization cannot be proven, skip completion I/O without
+			// failing an otherwise serviceable persisted detail read.
+			return;
+		}
+		// This is endpoint equivalence only. Candidate identity remains bound to
+		// the persisted coordinator string and must never be rewritten by config.
+		const scopedGroups = groups.filter(
+			(group) =>
+				currentGroupIds.has(group.groupId) &&
+				normalizedCoordinatorId(group.coordinatorId) === configuredCoordinatorId,
+		);
+		if (scopedGroups.length === 0) return;
+		const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
+		try {
+			const reconciliationDeadlineMs = Date.now() + COORDINATOR_ROSTER_READ_BUDGET_MS;
+			const groupById = new Map(scopedGroups.map((group) => [group.groupId, group]));
+			let records: Awaited<ReturnType<LegacyTeamCompletionDependencies["list"]>>;
+			try {
+				records = await retryTransientCoordinatorRead(
+					(attemptTimeoutS) =>
+						completionDependencies.list({
+							groupIds: [...new Set(scopedGroups.map((group) => group.groupId))],
+							remoteUrl,
+							adminSecret: config.syncCoordinatorAdminSecret,
+							timeoutS: attemptTimeoutS,
+						}),
+					timeoutS,
+					reconciliationDeadlineMs,
+				);
+			} catch (error) {
+				// Older coordinators do not expose completion reconciliation. Read routes
+				// remain usable, and best-effort publication below still lets upgraded
+				// peers observe a locally completed migration.
+				if (isUnsupportedCompletionQuery(error)) records = [];
+				else throw error;
+			}
+			const freshGroupByKey = new Map<string, LegacyTeamConfiguredGroupSnapshot>();
+			if (records.length > 0) {
+				try {
+					const onlyGroup = scopedGroups.length === 1 ? scopedGroups[0] : undefined;
+					const freshGroups = onlyGroup
+						? await loadedSnapshots(
+								legacyTeamCandidateId(onlyGroup.coordinatorId, onlyGroup.groupId),
+								reconciliationDeadlineMs,
+							)
+						: await loadedSnapshots(undefined, reconciliationDeadlineMs);
+					for (const freshGroup of freshGroups) {
+						const key = `${freshGroup.coordinatorId}\0${freshGroup.groupId}`;
+						if (freshGroupByKey.has(key)) throw new Error("team_setup_completion_invalid");
+						freshGroupByKey.set(key, freshGroup);
+					}
+				} catch (error) {
+					for (const record of records) {
+						const group = groupById.get(record.group_id);
+						if (!group) continue;
+						try {
+							validateLegacyTeamSetupCompletionManifestBinding(record.manifest, {
+								coordinatorId: group.coordinatorId,
+								groupId: group.groupId,
+							});
+						} catch (bindingError) {
+							if (!reconciliationOptions.isolateApplyFailures) throw bindingError;
+							continue;
+						}
+						let canonicalManifest: ReturnType<typeof validateLegacyTeamSetupCompletionManifest>;
+						try {
+							canonicalManifest = validateLegacyTeamSetupCompletionManifest(record.manifest, {
+								coordinatorId: group.coordinatorId,
+								groupId: group.groupId,
+							});
+						} catch (validationError) {
+							try {
+								const contained = await runCandidateMutation(
+									store.db,
+									legacyTeamCandidateId(group.coordinatorId, group.groupId),
+									() =>
+										containLegacyTeamSetupCompletionConflict(store.db, {
+											coordinatorId: group.coordinatorId,
+											groupId: group.groupId,
+										}),
+								);
+								if (!contained) {
+									if (!reconciliationOptions.isolateApplyFailures) throw validationError;
+									continue;
+								}
+							} catch (containmentError) {
+								if (!reconciliationOptions.isolateApplyFailures) throw containmentError;
+							}
+							if (!reconciliationOptions.isolateApplyFailures) throw validationError;
+							continue;
+						}
+						try {
+							const localManifest = reconstructLegacyTeamSetupCompletionManifest(store.db, {
+								candidateRef: canonicalManifest.candidate_ref,
+							});
+							if (
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(localManifest) ===
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(canonicalManifest)
+							) {
+								continue;
+							}
+							if (
+								areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible(
+									localManifest,
+									canonicalManifest,
+								)
+							) {
+								continue;
+							}
+						} catch {
+							// Missing or invalid local completion state must not remain active when
+							// a valid coordinator winner cannot be applied safely.
+						}
+						try {
+							await runCandidateMutation(store.db, canonicalManifest.candidate_ref, () =>
+								containLegacyTeamSetupCompletionConflict(store.db, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								}),
+							);
+						} catch (containmentError) {
+							if (!reconciliationOptions.isolateApplyFailures) throw containmentError;
+						}
+					}
+					if (!reconciliationOptions.isolateApplyFailures) throw error;
+					return;
+				}
+			}
+			const coordinatorCompletionGroupIds = new Set<string>();
+			for (const record of records) {
+				const group = groupById.get(record.group_id);
+				if (!group) throw new Error("team_setup_completion_invalid");
+				try {
+					validateLegacyTeamSetupCompletionManifestBinding(record.manifest, {
+						coordinatorId: group.coordinatorId,
+						groupId: group.groupId,
+					});
+				} catch (bindingError) {
+					if (!reconciliationOptions.isolateApplyFailures) throw bindingError;
+					continue;
+				}
+				let canonicalManifest: ReturnType<typeof validateLegacyTeamSetupCompletionManifest>;
+				try {
+					canonicalManifest = validateLegacyTeamSetupCompletionManifest(record.manifest, {
+						coordinatorId: group.coordinatorId,
+						groupId: group.groupId,
+					});
+				} catch (validationError) {
+					try {
+						await runCandidateMutation(
+							store.db,
+							legacyTeamCandidateId(group.coordinatorId, group.groupId),
+							() =>
+								containLegacyTeamSetupCompletionConflict(store.db, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								}),
+						);
+					} catch (containmentError) {
+						if (!reconciliationOptions.isolateApplyFailures) throw containmentError;
+					}
+					if (!reconciliationOptions.isolateApplyFailures) throw validationError;
+					continue;
+				}
+				coordinatorCompletionGroupIds.add(record.group_id);
+				try {
+					let freshGroup = freshGroupByKey.get(`${group.coordinatorId}\0${group.groupId}`);
+					if (!freshGroup && scopedGroups.length > 1) {
+						if (remainingCoordinatorTimeoutS(timeoutS, reconciliationDeadlineMs) == null) {
+							throw new Error("team_setup_roster_unavailable");
+						}
+						const candidateGroups = await loadedSnapshots(
+							legacyTeamCandidateId(group.coordinatorId, group.groupId),
+							reconciliationDeadlineMs,
+						);
+						freshGroup = candidateGroups.find(
+							(candidateGroup) =>
+								candidateGroup.coordinatorId === group.coordinatorId &&
+								candidateGroup.groupId === group.groupId,
+						);
+					}
+					if (!freshGroup) {
+						const contained = await runCandidateMutation(
+							store.db,
+							legacyTeamCandidateId(group.coordinatorId, group.groupId),
+							() =>
+								containLegacyTeamSetupCompletionConflict(store.db, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								}),
+						);
+						if (!contained) {
+							if (!reconciliationOptions.isolateApplyFailures) {
+								throw new Error("team_setup_completion_invalid");
+							}
+							continue;
+						}
+						throw new Error("team_setup_completion_invalid");
+					}
+					const applied = await runCandidateMutation(
+						store.db,
+						legacyTeamCandidateId(group.coordinatorId, group.groupId),
+						() =>
+							applyLegacyTeamSetupCompletionManifest(store.db, {
+								coordinatorId: group.coordinatorId,
+								groupId: group.groupId,
+								manifest: canonicalManifest,
+								freshRoster: freshGroup.devices,
+							}),
+					);
+					if (!applied) continue;
+				} catch (error) {
+					if (!reconciliationOptions.isolateApplyFailures) throw error;
+				}
+			}
+			for (const group of scopedGroups) {
+				if (coordinatorCompletionGroupIds.has(group.groupId)) continue;
+				const publicationTimeoutS = remainingCoordinatorTimeoutS(
+					timeoutS,
+					reconciliationDeadlineMs,
+				);
+				if (publicationTimeoutS == null) break;
+				if (
+					!hasCompletedLegacyTeamSetup(
+						store,
+						legacyTeamCandidateId(group.coordinatorId, group.groupId),
+					)
+				) {
+					continue;
+				}
+				const candidateRef = legacyTeamCandidateId(group.coordinatorId, group.groupId);
+				let reconstructionFailed = false;
+				try {
+					const published = await runCandidateMutation(store.db, candidateRef, () =>
+						serializeRecipientPolicyPublicationMutation(store.db, () =>
+							serializeRecipientPolicyTeamMutation(
+								store.db,
+								deterministicPolicyTeamId(candidateRef),
+								async () => {
+									let manifest: ReturnType<typeof reconstructLegacyTeamSetupCompletionManifest>;
+									try {
+										manifest = reconstructLegacyTeamSetupCompletionManifest(store.db, {
+											candidateRef,
+										});
+									} catch {
+										reconstructionFailed = true;
+										return;
+									}
+									await completionDependencies.create({
+										groupId: group.groupId,
+										manifest,
+										remoteUrl,
+										adminSecret: config.syncCoordinatorAdminSecret,
+										timeoutS: publicationTimeoutS,
+									});
+								},
+							),
+						),
+					);
+					if (!published || reconstructionFailed) continue;
+				} catch (error) {
+					// Publishing an existing local completion is best-effort. The bounded
+					// list/apply pass above remains authoritative and fail-closed.
+					if (completionApiError(error) !== "team_setup_completion_conflict") continue;
+					const getCompletion = completionDependencies.get;
+					let canonicalManifest: Awaited<ReturnType<NonNullable<typeof getCompletion>>> = null;
+					try {
+						if (!getCompletion) throw new Error("team_setup_completion_conflict");
+						canonicalManifest = await retryTransientCoordinatorRead(
+							(attemptTimeoutS) =>
+								getCompletion({
+									groupId: group.groupId,
+									candidateRef,
+									remoteUrl,
+									adminSecret: config.syncCoordinatorAdminSecret,
+									timeoutS: attemptTimeoutS,
+								}),
+							timeoutS,
+							reconciliationDeadlineMs,
+						);
+						if (!canonicalManifest) throw new Error("team_setup_completion_conflict");
+					} catch {
+						try {
+							const contained = await runCandidateMutation(store.db, candidateRef, () =>
+								containLegacyTeamSetupCompletionConflict(store.db, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								}),
+							);
+							if (!contained) {
+								if (!reconciliationOptions.isolateApplyFailures) {
+									throw new Error("team_setup_completion_conflict");
+								}
+								continue;
+							}
+						} catch (containmentError) {
+							if (!reconciliationOptions.isolateApplyFailures) throw containmentError;
+							continue;
+						}
+						if (!reconciliationOptions.isolateApplyFailures) {
+							throw new Error("team_setup_completion_conflict");
+						}
+						continue;
+					}
+					try {
+						const freshGroups = await loadedSnapshots(candidateRef, reconciliationDeadlineMs);
+						const freshMatches = freshGroups.filter(
+							(freshGroup) =>
+								freshGroup.coordinatorId === group.coordinatorId &&
+								freshGroup.groupId === group.groupId,
+						);
+						if (freshMatches.length !== 1) throw new Error("team_setup_roster_unavailable");
+						const applied = await runCandidateMutation(store.db, candidateRef, () =>
+							applyLegacyTeamSetupCompletionManifest(store.db, {
+								coordinatorId: group.coordinatorId,
+								groupId: group.groupId,
+								manifest: canonicalManifest,
+								freshRoster: freshMatches[0]?.devices ?? [],
+							}),
+						);
+						if (!applied) continue;
+					} catch (applyError) {
+						if (applyError instanceof LegacyTeamSetupAdditiveConvergenceError) {
+							if (!reconciliationOptions.isolateApplyFailures) throw applyError;
+							continue;
+						}
+						try {
+							const contained = await runCandidateMutation(store.db, candidateRef, () =>
+								containLegacyTeamSetupCompletionConflict(store.db, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								}),
+							);
+							if (!contained) {
+								if (!reconciliationOptions.isolateApplyFailures) {
+									throw new Error("team_setup_completion_conflict", { cause: applyError });
+								}
+								continue;
+							}
+						} catch (containmentError) {
+							if (!reconciliationOptions.isolateApplyFailures) throw containmentError;
+							continue;
+						}
+						if (!reconciliationOptions.isolateApplyFailures) {
+							throw new Error("team_setup_completion_conflict", { cause: applyError });
+						}
+					}
+				}
+			}
+		} catch (error) {
+			throw new Error(completionApiError(error));
+		}
+	}
 	async function loadedCandidateSnapshots(
 		candidateRef: string,
 		loadOptions: {
@@ -1242,6 +1706,21 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		}
 	}
 
+	function persistedCompletionGroup(
+		store: MemoryStore,
+		candidateRef: string,
+	): LegacyTeamCandidateGroupDescriptor | null {
+		const row = store.db
+			.prepare(
+				`SELECT coordinator_id, group_id FROM legacy_team_setup_drafts
+				 WHERE candidate_id = ? ORDER BY rowid DESC LIMIT 1`,
+			)
+			.get(candidateRef) as { coordinator_id: string; group_id: string } | undefined;
+		if (!row || legacyTeamCandidateId(row.coordinator_id, row.group_id) !== candidateRef)
+			return null;
+		return { coordinatorId: row.coordinator_id, groupId: row.group_id };
+	}
+
 	app.get("/api/sync/team-setup/v1", async (c) => {
 		let groups: LegacyTeamConfiguredGroupSnapshot[];
 		try {
@@ -1252,6 +1731,8 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		}
 		try {
 			const store = options.getStore();
+			readPureCandidateViews(store, groups);
+			await reconcileCompletions(store, groups, { isolateApplyFailures: true });
 			const response = {
 				version: TEAM_SETUP_VERSION,
 				candidates: readPureCandidateViews(store, groups)
@@ -1278,6 +1759,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			const store = options.getStore();
 			let draft = getLegacyTeamSetupDraft(store.db, candidateRef);
 			const terminal = hasCompletedLegacyTeamSetup(store, candidateRef);
+			let candidateGroupsForCompletion: LegacyTeamConfiguredGroupSnapshot[] | null = null;
 			if (terminal && draft?.state !== "completed") {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 			}
@@ -1295,6 +1777,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				const candidateGroups = groups.filter(
 					(group) => legacyTeamCandidateId(group.coordinatorId, group.groupId) === candidateRef,
 				);
+				candidateGroupsForCompletion = candidateGroups;
 				const postLoadDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
 				if (hasCompletedLegacyTeamSetup(store, candidateRef)) {
 					if (postLoadDraft?.state !== "completed") {
@@ -1314,6 +1797,28 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				}
 			}
 			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			const cachedCandidateGroups = loadedSummarySnapshots
+				.peek()
+				?.filter(
+					(group) => legacyTeamCandidateId(group.coordinatorId, group.groupId) === candidateRef,
+				);
+			let completionGroups: LegacyTeamCandidateGroupDescriptor[] | null =
+				candidateGroupsForCompletion ??
+				(cachedCandidateGroups?.length ? cachedCandidateGroups : null);
+			if (!completionGroups) {
+				const persistedGroup = persistedCompletionGroup(store, candidateRef);
+				completionGroups = persistedGroup ? [persistedGroup] : null;
+			}
+			const terminalBeforeReconciliation = hasCompletedLegacyTeamSetup(store, candidateRef);
+			if (completionGroups) await reconcileCompletions(store, completionGroups);
+			draft = getLegacyTeamSetupDraft(store.db, candidateRef);
+			if (
+				!draft ||
+				(!terminalBeforeReconciliation && hasCompletedLegacyTeamSetup(store, candidateRef))
+			) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			}
+			if (completionGroups) candidate = candidateFromDraft(draft);
 
 			return c.json(detailResponse(store, draft, candidate));
 		} catch (error) {
@@ -1378,19 +1883,27 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				(choice) => choice.identityRef === targetIdentityRef,
 			);
 			if (!target) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
-			return c.json(
-				projectMutationAtomically(
-					store,
-					() =>
-						setLegacyTeamSetupDeviceAssignment(store.db, {
-							attemptId,
-							deviceRef,
-							targetIdentityId: target.identityId,
-							expectation: device.expectation,
-						}),
-					(draft) => detailResponse(store, draft),
-				),
-			);
+			const releaseMutation = claimCandidateMutation(store.db, candidateRef);
+			if (!releaseMutation) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			try {
+				return c.json(
+					projectMutationAtomically(
+						store,
+						() =>
+							setLegacyTeamSetupDeviceAssignment(store.db, {
+								attemptId,
+								deviceRef,
+								targetIdentityId: target.identityId,
+								expectation: device.expectation,
+							}),
+						(draft) => detailResponse(store, draft),
+					),
+				);
+			} finally {
+				releaseMutation();
+			}
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1444,18 +1957,26 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			) {
 				return c.json({ error: "team_setup_assignment_changed" as const }, 409);
 			}
-			return c.json(
-				projectMutationAtomically(
-					store,
-					() =>
-						setLegacyTeamSetupDeviceDecision(store.db, {
-							attemptId,
-							deviceRef,
-							decision: decision as "included" | "excluded" | "removed",
-						}),
-					(draft) => detailResponse(store, draft),
-				),
-			);
+			const releaseMutation = claimCandidateMutation(store.db, candidateRef);
+			if (!releaseMutation) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			try {
+				return c.json(
+					projectMutationAtomically(
+						store,
+						() =>
+							setLegacyTeamSetupDeviceDecision(store.db, {
+								attemptId,
+								deviceRef,
+								decision: decision as "included" | "excluded" | "removed",
+							}),
+						(draft) => detailResponse(store, draft),
+					),
+				);
+			} finally {
+				releaseMutation();
+			}
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1492,13 +2013,21 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			if (!draft.devices.some((item) => item.deviceRef === deviceRef)) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 			}
-			return c.json(
-				projectMutationAtomically(
-					store,
-					() => clearLegacyTeamSetupDeviceDecision(store.db, { attemptId, deviceRef }),
-					(draft) => detailResponse(store, draft),
-				),
-			);
+			const releaseMutation = claimCandidateMutation(store.db, candidateRef);
+			if (!releaseMutation) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			try {
+				return c.json(
+					projectMutationAtomically(
+						store,
+						() => clearLegacyTeamSetupDeviceDecision(store.db, { attemptId, deviceRef }),
+						(draft) => detailResponse(store, draft),
+					),
+				);
+			} finally {
+				releaseMutation();
+			}
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1549,18 +2078,26 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 					legacyTeamResolvedProjectRef(projectRef, choice.projectIdentity) === resolvedProjectRef,
 			);
 			if (!target) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
-			return c.json(
-				projectMutationAtomically(
-					store,
-					() =>
-						setLegacyTeamSetupProjectMapping(store.db, {
-							attemptId,
-							projectRef,
-							resolvedProjectIdentity: target.projectIdentity,
-						}),
-					(draft) => detailResponse(store, draft),
-				),
-			);
+			const releaseMutation = claimCandidateMutation(store.db, candidateRef);
+			if (!releaseMutation) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			try {
+				return c.json(
+					projectMutationAtomically(
+						store,
+						() =>
+							setLegacyTeamSetupProjectMapping(store.db, {
+								attemptId,
+								projectRef,
+								resolvedProjectIdentity: target.projectIdentity,
+							}),
+						(draft) => detailResponse(store, draft),
+					),
+				);
+			} finally {
+				releaseMutation();
+			}
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1604,26 +2141,34 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 		}
 		try {
-			return c.json(
-				projectMutationAtomically(
-					store,
-					() => {
-						const currentDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
-						if (
-							currentDraft?.state === "completed" ||
-							hasCompletedLegacyTeamSetup(store, candidateRef)
-						) {
-							throw new Error("team_setup_confirmation_stale");
-						}
-						return refreshLegacyTeamCandidate(
-							store.db,
-							{ projection: projectionOptions(store), groups },
-							candidateRef,
-						);
-					},
-					(draft) => detailResponse(store, draft),
-				),
-			);
+			const releaseMutation = claimCandidateMutation(store.db, candidateRef);
+			if (!releaseMutation) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			try {
+				return c.json(
+					projectMutationAtomically(
+						store,
+						() => {
+							const currentDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
+							if (
+								currentDraft?.state === "completed" ||
+								hasCompletedLegacyTeamSetup(store, candidateRef)
+							) {
+								throw new Error("team_setup_confirmation_stale");
+							}
+							return refreshLegacyTeamCandidate(
+								store.db,
+								{ projection: projectionOptions(store), groups },
+								candidateRef,
+							);
+						},
+						(draft) => detailResponse(store, draft),
+					),
+				);
+			} finally {
+				releaseMutation();
+			}
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1670,6 +2215,9 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		) {
 			return c.json({ error: "team_setup_incomplete" as const }, 400);
 		}
+		let releaseMutation: (() => void) | undefined;
+		let releasePublicationMutation: (() => void) | undefined;
+		let releaseActorMutations: (() => void) | undefined;
 		try {
 			const store = options.getStore();
 			const draft = getLegacyTeamSetupDraft(store.db, candidateRef);
@@ -1680,57 +2228,225 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			if (draft.attemptId !== attemptId) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
 			}
-			if (draft.state !== "completed") {
-				const preview = previewLegacyTeamSetupActivation(store.db, {
-					candidateRef,
-					attemptId: draft.attemptId,
-				});
-				requireBoundedAccessDelta(preview.accessDelta);
-				const safeDraft = viewerSafeDraft(store, draft);
-				const currentViewerDigest = viewerAccessDeltaDigest(
-					viewerSafeAccessDelta(candidateRef, preview.accessDelta, {
-						teamDisplayName: draft.displayName,
-						...safeDraft,
-					}),
-				);
-				if (currentViewerDigest !== confirmedViewerAccessDeltaDigest) {
-					return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
-				}
-			}
-			const result = await finishLegacyTeamSetupActivation(store.db, {
+			const replay = replayLegacyTeamSetupActivation(store.db, {
 				candidateRef,
 				attemptId,
 				finishDigest,
 				confirmedAccessDeltaDigest,
-				loadFreshRoster: async () => {
-					const groups = await loadedCandidateSnapshots(candidateRef);
-					const matching = groups.filter(
-						(group) => legacyTeamCandidateId(group.coordinatorId, group.groupId) === candidateRef,
-					);
-					if (matching.length !== 1) throw safeCoordinatorError();
-					return matching[0]?.devices ?? [];
-				},
-				loadProjectInventory: () =>
-					legacyTeamCandidateProjectInventory(store.db, projectionOptions(store), candidateRef),
-				validateLockedPreview: (lockedPreview) => {
-					requireBoundedAccessDelta(lockedPreview.accessDelta);
-					const lockedDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
-					if (!lockedDraft || lockedDraft.attemptId !== attemptId) return false;
-					const safeDraft = viewerSafeDraft(store, lockedDraft);
-					return (
-						viewerAccessDeltaDigest(
-							viewerSafeAccessDelta(candidateRef, lockedPreview.accessDelta, {
-								teamDisplayName: lockedDraft.displayName,
-								...safeDraft,
-							}),
-						) === confirmedViewerAccessDeltaDigest
-					);
-				},
 			});
-			return c.json(finishResponse(candidateRef, result));
+			if (replay) return c.json(finishResponse(candidateRef, replay));
+			if (draft.state === "completed") {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			const preview = previewLegacyTeamSetupActivation(store.db, {
+				candidateRef,
+				attemptId: draft.attemptId,
+			});
+			requireLegacyTeamSetupAccessDeltaWithinLimit(preview.accessDelta);
+			const safeDraft = viewerSafeDraft(store, draft);
+			const currentViewerDigest = viewerAccessDeltaDigest(
+				viewerSafeAccessDelta(candidateRef, preview.accessDelta, {
+					teamDisplayName: draft.displayName,
+					...safeDraft,
+				}),
+			);
+			if (currentViewerDigest !== confirmedViewerAccessDeltaDigest) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			const freshGroups = await loadedCandidateSnapshots(candidateRef);
+			const matchingGroups = freshGroups.filter(
+				(group) => legacyTeamCandidateId(group.coordinatorId, group.groupId) === candidateRef,
+			);
+			if (matchingGroups.length !== 1) throw safeCoordinatorError();
+			const group = matchingGroups[0];
+			if (!group) throw safeCoordinatorError();
+			const freshRoster = group.devices;
+			releaseMutation = claimCandidateMutation(store.db, candidateRef) ?? undefined;
+			if (!releaseMutation) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			const claimedDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
+			if (!claimedDraft || claimedDraft.attemptId !== attemptId) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			releasePublicationMutation = await claimRecipientPolicyPublicationMutation(store.db);
+			// Included identities are part of the immutable publication winner, so these locks
+			// intentionally cover coordinator creation, conflict recovery, and local application.
+			releaseActorMutations = await claimRecipientPolicyActorMutations(
+				store.db,
+				claimedDraft.devices.flatMap((device) =>
+					device.decision === "included" && device.targetIdentityId
+						? [device.targetIdentityId]
+						: [],
+				),
+			);
+			const response = await serializeRecipientPolicyTeamMutation(
+				store.db,
+				deterministicPolicyTeamId(candidateRef),
+				() =>
+					serializeRecipientPolicyCoordinatorGroupMutation(store.db, group.groupId, async () => {
+						const projectInventory = legacyTeamCandidateProjectInventory(
+							store.db,
+							projectionOptions(store),
+							candidateRef,
+						);
+						const freshPreview = inspectFreshLegacyTeamSetupActivation(store.db, {
+							candidateRef,
+							attemptId,
+							freshRoster,
+							projectInventory,
+						});
+						if (
+							freshPreview.finishDigest !== finishDigest ||
+							freshPreview.accessDeltaDigest !== confirmedAccessDeltaDigest
+						) {
+							return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+						}
+						const freshDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
+						if (!freshDraft || freshDraft.attemptId !== attemptId) {
+							return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+						}
+						const safeFreshDraft = viewerSafeDraft(store, freshDraft);
+						if (
+							viewerAccessDeltaDigest(
+								viewerSafeAccessDelta(candidateRef, freshPreview.accessDelta, {
+									teamDisplayName: freshDraft.displayName,
+									...safeFreshDraft,
+								}),
+							) !== confirmedViewerAccessDeltaDigest
+						) {
+							return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+						}
+						const completedAt = new Date().toISOString();
+						const proposedManifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+							candidateRef,
+							attemptId,
+							completedAt,
+						});
+						let config: ReturnType<typeof readCoordinatorSyncConfig>;
+						try {
+							config = (
+								options.readCoordinatorConfig ??
+								options.snapshotLoaderDependencies?.readConfig ??
+								readCoordinatorSyncConfig
+							)();
+						} catch (error) {
+							throw new Error(completionApiError(error));
+						}
+						const remoteUrl = buildBaseUrl(config.syncCoordinatorUrl);
+						if (!completionDependencies || !remoteUrl || !config.syncCoordinatorAdminSecret) {
+							throw new Error("team_setup_completion_unavailable");
+						}
+						const configuredCoordinatorId = normalizedCoordinatorId(remoteUrl);
+						let currentGroupIds: Set<string>;
+						try {
+							currentGroupIds = new Set(
+								legacyTeamCandidateGroupDescriptors(
+									store,
+									remoteUrl,
+									config.syncCoordinatorGroups,
+								).map((currentGroup) => currentGroup.groupId),
+							);
+						} catch {
+							throw new Error("team_setup_completion_invalid");
+						}
+						if (
+							!configuredCoordinatorId ||
+							!currentGroupIds.has(group.groupId) ||
+							normalizedCoordinatorId(group.coordinatorId) !== configuredCoordinatorId
+						) {
+							throw new Error("team_setup_completion_invalid");
+						}
+						const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
+						let canonicalManifest: typeof proposedManifest;
+						try {
+							canonicalManifest = validateLegacyTeamSetupCompletionManifest(
+								(
+									await completionDependencies.create({
+										groupId: group.groupId,
+										manifest: proposedManifest,
+										remoteUrl,
+										adminSecret: config.syncCoordinatorAdminSecret,
+										timeoutS,
+									})
+								).manifest,
+								{ coordinatorId: group.coordinatorId, groupId: group.groupId },
+							);
+							if (
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(canonicalManifest) !==
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(proposedManifest)
+							) {
+								throw new Error("team_setup_completion_conflict");
+							}
+						} catch (error) {
+							const code = completionApiError(error);
+							const getCompletion = completionDependencies.get;
+							if (code !== "team_setup_completion_conflict" || !getCompletion) {
+								throw new Error(code);
+							}
+							try {
+								const existing = await retryTransientCoordinatorRead(
+									(attemptTimeoutS) =>
+										getCompletion({
+											groupId: group.groupId,
+											candidateRef,
+											remoteUrl,
+											adminSecret: config.syncCoordinatorAdminSecret,
+											timeoutS: attemptTimeoutS,
+										}),
+									timeoutS,
+									Date.now() + COORDINATOR_ROSTER_READ_BUDGET_MS,
+								);
+								if (!existing) throw new Error("team_setup_completion_conflict");
+								canonicalManifest = validateLegacyTeamSetupCompletionManifest(existing, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								});
+								// A conflict can mean an earlier request committed before its response was lost.
+								// The matching policy digest identifies that winner; its publication timestamp
+								// is coordinator-owned metadata and must be applied unchanged.
+								if (canonicalManifest.finish_digest !== proposedManifest.finish_digest) {
+									throw new Error("team_setup_completion_conflict");
+								}
+							} catch (recoveryError) {
+								throw new Error(completionApiError(recoveryError));
+							}
+						}
+						// Publication is the commit point. Apply its immutable winner after binding
+						// each included device to the current coordinator roster evidence.
+						// If this reload fails, reconciliation can apply the published winner later.
+						const postPublicationGroups = await loadedCandidateSnapshots(candidateRef);
+						const postPublicationMatches = postPublicationGroups.filter(
+							(candidate) =>
+								candidate.coordinatorId === group.coordinatorId &&
+								candidate.groupId === group.groupId &&
+								legacyTeamCandidateId(candidate.coordinatorId, candidate.groupId) === candidateRef,
+						);
+						if (postPublicationMatches.length !== 1) {
+							throw new Error("team_setup_roster_unavailable");
+						}
+						const result = await applyLegacyTeamSetupCompletionManifestAndReturnActivation(
+							store.db,
+							{
+								coordinatorId: group.coordinatorId,
+								groupId: group.groupId,
+								freshRoster: postPublicationMatches[0]?.devices ?? [],
+								manifest: canonicalManifest,
+								expectedDraftManifest: proposedManifest,
+								recipientPolicyMutationSerialized: true,
+							},
+						);
+						return c.json(finishResponse(candidateRef, result));
+					}),
+			);
+			return response;
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
+		} finally {
+			releaseActorMutations?.();
+			releasePublicationMutation?.();
+			releaseMutation?.();
 		}
 	});
 


### PR DESCRIPTION
## Description

Publishes validated Team setup before local activation, then reconciles coordinator-owned completion manifests during summary and detail loading. Remote application is atomic, exact replays are idempotent, conflicting or invalid evidence fails closed, and prior local completions publish opportunistically.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced