### PR TITLE
test(e2e): verify cross-device Team completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ For ongoing collaboration:
 
 Team onboarding links Identities and devices. The invitation does not assign Projects to the Team, but a new member inherits every current and future Project assigned to it. Review the Team's Projects before sending or accepting the invitation. Use **Share exact Projects** to send a separate direct Project invitation to one Identity. Team sharing must already be configured, but accepting the direct invitation does not add the recipient to the Team.
 
+For a legacy Team that needs setup, finish the reviewed setup on any upgraded device. The first valid finish becomes the Team's shared result; other upgraded devices apply it locally and stop showing that setup task. See [Set up an existing Team](docs/user-guide.md#set-up-an-existing-team) for recovery and compatibility details.
+
 For a direct share, choose **Create an invitation → Share exact Projects**:
 
 1. Choose or enter the teammate's **Identity display name**.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -225,11 +225,15 @@ If a Team needs device setup, **Sharing** shows a notice and **Continue setup**.
 2. Still in **Review devices**, include each device with its confirmed person, choose **Exclude**, or clear an earlier choice to review it again. An exclusion applies only to this Team; a confirmed person assignment can be reused by another Team.
 3. In **Review Projects**, check every Project. Codemem can recognize some Projects automatically; choose an explicit Project mapping for any it cannot. Unresolved Projects prevent finishing.
 4. In the final review, check the server-provided list of people, included and excluded devices, Project mappings, and every access change. Nothing changes while you are reviewing or saving choices.
-5. Choose **Finish Team setup** only when the review is correct. Codemem applies the confirmed Team, device decisions, Project mappings, and access changes together. If it cannot complete every change, it applies none.
+5. Choose **Finish Team setup** only when the review is correct. The first valid finish becomes the shared result for that Team. Codemem applies the confirmed Team, device decisions, Project mappings, and access changes together. If it cannot complete every change, it applies none.
 
 Setup can become stale when devices, Project mappings, or access change while you are reviewing. Refresh the Team, review the updates, and finish again; new or changed devices need a fresh decision. Your unchanged saved choices remain available for review.
 
-If the page closes or the finish response is lost, refresh **Sharing** and open the Team again. A completed Team appears **Ready**; retrying the same finish request returns the completed result instead of applying access changes again.
+When another upgraded device opens **Sharing**, it automatically applies a completed Team's reviewed policy locally before removing the setup task. The Team then appears normally under **Sharing → Teams**, so you do not need to repeat setup on each device.
+
+If the page closes or the finish response is lost, refresh **Sharing** and open the Team again. Retrying the same finish safely returns the completed result instead of applying access changes again. If setup cannot reach the shared completion service or cannot apply the completed result locally, the task stays visible and offers retry; it never hides an incomplete setup.
+
+Every device that finishes or recovers setup must use a coordinator that supports cross-device Team completion. With an older coordinator, Codemem keeps the setup unfinished rather than creating a local-only result; update the coordinator, then retry. A device upgraded after a prior local completion makes that result available when it reconnects, after which other upgraded devices recover it automatically.
 
 ### Share exact Projects
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -131,8 +131,9 @@ This scenario proves that reviewed Team setup:
 - persists device choices, supports shared assignments across Teams, and keeps a Team-specific exclusion scoped to that Team;
 - blocks incomplete, stale, conflicting, or unmapped Project reviews without changing access;
 - applies confirmed device decisions, Project mappings, and access changes together at finish;
-- keeps a later unreviewed device ineligible; and
-- returns the same completed result when a finish response is lost and retried.
+- keeps a later unreviewed device ineligible;
+- returns the same completed result when a finish response is lost and retried; and
+- makes the first valid completion authoritative across upgraded devices: another device applies the same policy locally and no longer shows the setup task.
 
 ## Run the sharing-domain scenario
 

--- a/e2e/scenarios/legacy-team-migration.ts
+++ b/e2e/scenarios/legacy-team-migration.ts
@@ -145,9 +145,14 @@ interface StoredCompletionResponse {
 	completedAt: string;
 }
 
-function fixture(ctx: ScenarioContext, action: string, artifact: string): FixtureSummary {
+function fixture(
+	ctx: ScenarioContext,
+	action: string,
+	artifact: string,
+	service = "peer-a",
+): FixtureSummary {
 	const result = ctx.compose.exec(
-		"peer-a",
+		service,
 		[
 			"env",
 			"CODEMEM_EMBEDDING_DISABLED=1",
@@ -262,21 +267,26 @@ function createCoordinatorRoster(ctx: ScenarioContext, roster: FixtureSummary["r
 	);
 }
 
-function startServer(ctx: ScenarioContext): void {
+function startServer(
+	ctx: ScenarioContext,
+	service = "peer-a",
+	staticArtifact = "07-viewer-static",
+	serverArtifact = "08-start-viewer",
+): void {
 	const staticResult = ctx.compose.exec(
-		"peer-a",
+		service,
 		[
 			"node",
 			"--input-type=module",
 			"-e",
 			"import { mkdirSync, writeFileSync } from 'node:fs'; mkdirSync('/tmp/viewer-static', { recursive: true }); writeFileSync('/tmp/viewer-static/index.html', '<!doctype html><title>e2e</title>');",
 		],
-		"07-viewer-static",
+		staticArtifact,
 		30_000,
 	);
 	assertStatus(staticResult.status, 0, "viewer static preparation failed");
 	const result = ctx.compose.execDetached(
-		"peer-a",
+		service,
 		[
 			"env",
 			"CODEMEM_VIEWER_STATIC_DIR=/tmp/viewer-static",
@@ -291,7 +301,7 @@ function startServer(ctx: ScenarioContext): void {
 			"--port",
 			"38888",
 		],
-		"08-start-viewer",
+		serverArtifact,
 	);
 	assertStatus(result.status, 0, "viewer server failed to start");
 }
@@ -302,6 +312,7 @@ async function request<T>(
 	path: string,
 	artifact: string,
 	body?: Record<string, unknown>,
+	service = "peer-a",
 ): Promise<{ status: number; body: T }> {
 	const init =
 		method === "GET"
@@ -313,7 +324,7 @@ async function request<T>(
 				};
 	const script = `const response = await fetch(${JSON.stringify(`http://127.0.0.1:38888${path}`)}, ${JSON.stringify(init)}); const text = await response.text(); console.log(JSON.stringify({ status: response.status, body: text ? JSON.parse(text) : null }));`;
 	const result = ctx.compose.exec(
-		"peer-a",
+		service,
 		["node", "--input-type=module", "-e", script],
 		artifact,
 		60_000,
@@ -459,15 +470,34 @@ function assertExactRows<T>(actual: T[], expected: T[], message: string): void {
 	);
 }
 
+function assertExactPolicies(
+	actual: FixtureSummary["policies"],
+	expected: FixtureSummary["policies"],
+	message: string,
+): void {
+	assertExactRows(actual.teams, expected.teams, `${message}: Teams differ`);
+	assertExactRows(actual.memberships, expected.memberships, `${message}: memberships differ`);
+	assertExactRows(actual.devices, expected.devices, `${message}: device assignments differ`);
+	assertExactRows(actual.decisions, expected.decisions, `${message}: device decisions differ`);
+	assertExactRows(actual.recipients, expected.recipients, `${message}: Project recipients differ`);
+	assertExactRows(
+		actual.reviewedMappings,
+		expected.reviewedMappings,
+		`${message}: reviewed Project mappings differ`,
+	);
+}
+
 export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Promise<void> {
 	ctx.recordNote(
 		"scenario.txt",
-		"Legacy Team migration: review two overlapping coordinator groups through the real viewer API; prove explicit mapping, stale and conflicting evidence rejection, atomic activation, reviewed device eligibility, and immutable retry.",
+		"Legacy Team migration: review two overlapping coordinator groups through real viewer APIs; prove cross-device canonical completion, explicit mapping, stale and conflicting evidence rejection, atomic activation, reviewed device eligibility, and immutable retry.",
 	);
 	ctx.compose.down("00-compose-down-pre", true);
-	ctx.compose.up(["coordinator", "peer-a"], "01-compose-up");
+	ctx.compose.up(["coordinator", "peer-a", "peer-b"], "01-compose-up");
 	seedPeer(ctx.compose, ctx.artifactsDir, "peer-a", "empty", "02-seed-empty");
+	seedPeer(ctx.compose, ctx.artifactsDir, "peer-b", "empty", "02-peer-b-seed-empty");
 	const seeded = fixture(ctx, "seed", "03-seed-legacy-team-fixture");
+	fixture(ctx, "seed", "03-peer-b-seed-legacy-team-fixture", "peer-b");
 	createCoordinatorRoster(ctx, seeded.roster);
 	writePeerConfig(
 		ctx,
@@ -480,7 +510,24 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 		},
 		"07-write-config",
 	);
+	writePeerConfig(
+		ctx,
+		"peer-b",
+		{
+			sync_coordinator_url: "http://coordinator:7347",
+			sync_coordinator_admin_secret: ADMIN_SECRET,
+			sync_coordinator_groups: [GROUP_ALPHA],
+			sync_coordinator_timeout_s: 10,
+		},
+		"07-peer-b-write-config",
+	);
 	startServer(ctx);
+	startServer(
+		ctx,
+		"peer-b",
+		"07-peer-b-viewer-static",
+		"08-peer-b-start-viewer",
+	);
 	await waitFor(
 		async () => {
 			const response = await request<Record<string, unknown>>(
@@ -492,6 +539,20 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 			assert(response.status === 200, "viewer is not ready");
 		},
 		{ description: "legacy Team viewer readiness", timeoutMs: 120_000, intervalMs: 2_000 },
+	);
+	await waitFor(
+		async () => {
+			const response = await request<Record<string, unknown>>(
+				ctx,
+				"GET",
+				"/api/stats",
+				"09-peer-b-wait-viewer",
+				undefined,
+				"peer-b",
+			);
+			assert(response.status === 200, "peer-b viewer is not ready");
+		},
+		{ description: "peer-b legacy Team viewer readiness", timeoutMs: 120_000, intervalMs: 2_000 },
 	);
 
 	// Arrange: Alpha is configured while active coordinator-backed scope evidence discovers Beta.
@@ -519,6 +580,24 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 	assert(
 		alphaCandidate.deviceCount === 2 && betaCandidate.deviceCount === 6,
 		"configured Alpha and scope-backed Beta did not expose the exact current rosters",
+	);
+	const peerBBeforeCompletion = await request<{
+		version: 1;
+		candidates: CandidateSummary[];
+	}>(ctx, "GET", API, "10-peer-b-candidate-summary", undefined, "peer-b");
+	assert(peerBBeforeCompletion.status === 200, "peer-b initial Team setup load failed");
+	assert(
+		peerBBeforeCompletion.body.candidates.some(
+			(candidate) => candidate.candidateRef === alphaCandidate.candidateRef,
+		) &&
+			peerBBeforeCompletion.body.candidates.some(
+				(candidate) => candidate.candidateRef === betaCandidate.candidateRef,
+			),
+		"peer-b did not expose Alpha and unrelated Beta before coordinator completion",
+	);
+	assertNoPolicyWrites(
+		fixture(ctx, "summary", "10-peer-b-before-completion-policy", "peer-b"),
+		"peer-b candidate discovery",
 	);
 	let alpha = await loadDetail(ctx, alphaCandidate.candidateRef, "11-alpha-unresolved-detail");
 	const betaInitial = await loadDetail(ctx, betaCandidate.candidateRef, "12-beta-initial-detail");
@@ -619,6 +698,38 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 	assert(
 		afterAlpha.policies.reviewedMappings.length === 1,
 		"explicit Project repair was not committed with Alpha",
+	);
+
+	// Positive: a second viewer applies Alpha's coordinator-owned completion before hiding it.
+	const peerBSummary = await request<{ version: 1; candidates: CandidateSummary[] }>(
+		ctx,
+		"GET",
+		API,
+		"25-peer-b-summary-after-alpha",
+		undefined,
+		"peer-b",
+	);
+	assert(peerBSummary.status === 200, "peer-b legacy Team summary failed");
+	assert(
+		!peerBSummary.body.candidates.some(
+			(candidate) => candidate.candidateRef === alphaCandidate.candidateRef,
+		) &&
+			peerBSummary.body.candidates.some(
+				(candidate) => candidate.candidateRef === betaCandidate.candidateRef,
+			),
+		"peer-b resurfaced Alpha or lost unrelated Beta after applying the canonical completion",
+	);
+	const peerBAfterAlpha = fixture(ctx, "summary", "25-peer-b-policy-after-alpha", "peer-b");
+	assertExactPolicies(
+		peerBAfterAlpha.policies,
+		afterAlpha.policies,
+		"peer-b canonical policy differs from peer-a",
+	);
+	assert(
+		peerBAfterAlpha.completions.some(
+			(completion) => completion.candidate_ref === alphaCandidate.candidateRef,
+		),
+		"peer-b did not record Alpha's canonical completion locally",
 	);
 
 	// Arrange: refresh Beta after Alpha so the included shared assignment is verified and reusable.
@@ -1108,6 +1219,11 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 		"peer-a:/data/mem.sqlite",
 		`${ctx.artifactsDir}/db/peer-a-legacy-team-migration.sqlite`,
 		"55-copy-peer-db",
+	);
+	ctx.compose.copyFromContainer(
+		"peer-b:/data/mem.sqlite",
+		`${ctx.artifactsDir}/db/peer-b-legacy-team-migration.sqlite`,
+		"55-copy-peer-b-db",
 	);
 	ctx.compose.copyFromContainer(
 		"coordinator:/data/coordinator.sqlite",

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -356,7 +356,7 @@ describe("recipient invitation API", () => {
 });
 
 describe("legacy Team setup API", () => {
-	it("preserves exactly the seven stable design error codes", async () => {
+	it("preserves exactly the ten stable design error codes", async () => {
 		const errorCodes = [
 			"team_setup_incomplete",
 			"team_setup_roster_changed",
@@ -364,6 +364,9 @@ describe("legacy Team setup API", () => {
 			"team_setup_roster_unavailable",
 			"team_setup_conflict",
 			"team_setup_confirmation_stale",
+			"team_setup_completion_unavailable",
+			"team_setup_completion_conflict",
+			"team_setup_completion_invalid",
 			"team_setup_failed",
 		] as const;
 		const responses = [...errorCodes];

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -1096,6 +1096,9 @@ export type LegacyTeamSetupErrorCode =
 	| "team_setup_roster_unavailable"
 	| "team_setup_conflict"
 	| "team_setup_confirmation_stale"
+	| "team_setup_completion_unavailable"
+	| "team_setup_completion_conflict"
+	| "team_setup_completion_invalid"
 	| "team_setup_failed";
 
 const LEGACY_TEAM_SETUP_VERSION = 1;
@@ -1106,6 +1109,9 @@ const LEGACY_TEAM_SETUP_ERROR_CODES = new Set<LegacyTeamSetupErrorCode>([
 	"team_setup_roster_unavailable",
 	"team_setup_conflict",
 	"team_setup_confirmation_stale",
+	"team_setup_completion_unavailable",
+	"team_setup_completion_conflict",
+	"team_setup_completion_invalid",
 	"team_setup_failed",
 ]);
 const LEGACY_TEAM_SETUP_STATUSES = new Set<LegacyTeamSetupStatusV1>([

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -751,6 +751,36 @@ describe("legacy Team setup dialog", () => {
 		expect(document.body.textContent).not.toContain("team_setup_roster_unavailable");
 	});
 
+	it.each([
+		[
+			"team_setup_completion_unavailable",
+			"Team setup completion could not be checked",
+			"Check the coordinator connection and settings, then refresh",
+		],
+		[
+			"team_setup_completion_conflict",
+			"Another device completed this Team with different reviewed details",
+			"Refresh to apply the completed setup",
+		],
+		[
+			"team_setup_completion_invalid",
+			"The completed Team setup could not be verified",
+			"check the coordinator connection and settings if the problem continues",
+		],
+	] as const)("shows recovery copy without exposing %s", async (errorCode, summary, recovery) => {
+		// Arrange
+		setup(vi.fn().mockResolvedValue(detail({ conflictState: errorCode })));
+
+		// Act
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).not.toBeNull());
+
+		// Assert
+		const text = document.querySelector('[role="alert"]')?.textContent ?? "";
+		expect(text).toContain(summary);
+		expect(text).toContain(recovery);
+		expect(document.body.textContent).not.toContain(errorCode);
+	});
+
 	it("uses changed-state copy for stale API errors and stale detail", async () => {
 		const loadDetail = vi
 			.fn()
@@ -1579,7 +1609,7 @@ describe("legacy Team setup dialog", () => {
 		expect(document.body.outerHTML).not.toContain(privateRemote);
 	});
 
-	it("reloads stale Project mapping evidence and keeps safe recovery copy", async () => {
+	it("reloads stale Project mapping evidence and retries with a plain detail load", async () => {
 		const initialProject = project();
 		const refreshedProject = project({
 			mappingChoices: [
@@ -1630,11 +1660,13 @@ describe("legacy Team setup dialog", () => {
 			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
 				"changed since it was last reviewed",
 			);
-			expect(document.body.textContent).toContain("Current setup details are unavailable");
+			expect(document.body.textContent).toContain("Project Gamma");
 		});
 		expect(document.body.textContent).not.toContain("team_setup_confirmation_stale");
 		expect(loadDetail).toHaveBeenCalledTimes(2);
-		expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")).toBeNull();
+		expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")?.value).toBe(
+			"",
+		);
 
 		act(() => document.getElementById("legacy-team-setup-retry")?.click());
 		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
@@ -1642,8 +1674,8 @@ describe("legacy Team setup dialog", () => {
 			"",
 		);
 		expect(button("Save mapping").getAttribute("aria-disabled")).toBe("true");
-		expect(loadDetail).toHaveBeenCalledTimes(2);
-		expect(refreshCandidate).toHaveBeenCalledWith("opaque-candidate");
+		expect(loadDetail).toHaveBeenCalledTimes(3);
+		expect(refreshCandidate).not.toHaveBeenCalled();
 	});
 
 	it("does not reload after an authoritative Project mapping response", async () => {
@@ -2880,11 +2912,13 @@ describe("legacy Team setup dialog", () => {
 			confirmedAccessDeltaDigest: "opaque-access-digest",
 			confirmedViewerAccessDeltaDigest: "opaque-viewer-access-digest",
 		});
-		expect(
-			document.querySelector<HTMLInputElement>(".legacy-team-setup-confirmation input"),
-		).toBeNull();
-		expect(document.body.textContent).not.toContain("Add Sam to Example Team.");
-		expect(document.body.textContent).toContain("Retry loading current setup");
+		const refreshedConfirmation = document.querySelector<HTMLInputElement>(
+			".legacy-team-setup-confirmation input",
+		);
+		expect(refreshedConfirmation?.checked).toBe(false);
+		expect(refreshedConfirmation?.getAttribute("aria-disabled")).toBe("true");
+		expect(document.body.textContent).toContain("Add Sam to Example Team.");
+		expect(button("Retry")).toBeTruthy();
 	});
 
 	it("treats a stale finish recovery that is already completed as success", async () => {

--- a/packages/ui/src/tabs/legacy-team-setup-effects.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-effects.test.ts
@@ -63,6 +63,55 @@ describe("legacy Team setup effect runner", () => {
 		expect(outcome).toMatchObject({ status: "failure", cause, recoveredView: view });
 	});
 
+	it("reloads once when detail reconciliation makes the prior confirmation stale", async () => {
+		const cause = new LegacyTeamSetupApiError(409, "team_setup_confirmation_stale");
+		const completedView = { state: "completed" } as LegacyTeamSetupViewV1;
+		const loadDetail = vi.fn().mockRejectedValueOnce(cause).mockResolvedValueOnce(completedView);
+		const outcome = await createSetupEffectRunner(dependencies({ loadDetail }))(
+			effect({ kind: "load", refresh: false, focusOnOutcome: true }),
+		);
+
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+		expect(outcome).toMatchObject({ status: "failure", cause, recoveredView: completedView });
+	});
+
+	it("preserves a failure from the one-shot detail recovery", async () => {
+		const stale = new LegacyTeamSetupApiError(409, "team_setup_confirmation_stale");
+		const unavailable = new LegacyTeamSetupApiError(503, "team_setup_completion_unavailable");
+		const loadDetail = vi.fn().mockRejectedValueOnce(stale).mockRejectedValueOnce(unavailable);
+		const outcome = await createSetupEffectRunner(dependencies({ loadDetail }))(
+			effect({ kind: "load", refresh: false, focusOnOutcome: true }),
+		);
+
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+		expect(outcome).toMatchObject({ status: "failure", cause: stale, recoveryCause: unavailable });
+		expect(outcome).not.toHaveProperty("recoveredView");
+	});
+
+	it("does not reload a confirmation-stale refresh request", async () => {
+		const cause = new LegacyTeamSetupApiError(409, "team_setup_confirmation_stale");
+		const loadDetail = vi.fn();
+		const refreshCandidate = vi.fn().mockRejectedValue(cause);
+		const outcome = await createSetupEffectRunner(dependencies({ loadDetail, refreshCandidate }))(
+			effect({ kind: "load", refresh: true, focusOnOutcome: true }),
+		);
+
+		expect(refreshCandidate).toHaveBeenCalledOnce();
+		expect(loadDetail).not.toHaveBeenCalled();
+		expect(outcome).not.toHaveProperty("recoveredView");
+	});
+
+	it("does not reload detail for unrelated changed-state errors", async () => {
+		const cause = new LegacyTeamSetupApiError(409, "team_setup_roster_changed");
+		const loadDetail = vi.fn().mockRejectedValue(cause);
+		const outcome = await createSetupEffectRunner(dependencies({ loadDetail }))(
+			effect({ kind: "load", refresh: false, focusOnOutcome: true }),
+		);
+
+		expect(loadDetail).toHaveBeenCalledOnce();
+		expect(outcome).not.toHaveProperty("recoveredView");
+	});
+
 	it("does not recover ordinary item failures by reloading", async () => {
 		const cause = new Error("safe test failure");
 		const deps = dependencies({ saveDecision: vi.fn().mockRejectedValue(cause) });

--- a/packages/ui/src/tabs/legacy-team-setup-effects.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-effects.ts
@@ -86,6 +86,7 @@ export type SetupEffectOutcome =
 			id: string;
 			kind: SetupEffect["kind"];
 			cause: unknown;
+			recoveryCause?: unknown;
 			recoveredView?: LegacyTeamSetupViewV1;
 	  };
 
@@ -116,13 +117,20 @@ export function createSetupEffectRunner(dependencies: SetupEffectDependencies): 
 				view,
 			};
 		} catch (cause) {
-			const recoveredView = await recover(effect, dependencies, cause);
+			let recoveredView: LegacyTeamSetupViewV1 | undefined;
+			let recoveryCause: unknown;
+			try {
+				recoveredView = await recover(effect, dependencies, cause);
+			} catch (recoveryError) {
+				recoveryCause = recoveryError;
+			}
 			return {
 				status: "failure",
 				generation: effect.generation,
 				id: effect.id,
 				kind: effect.kind,
 				cause,
+				...(recoveryCause ? { recoveryCause } : {}),
 				...(recoveredView ? { recoveredView } : {}),
 			};
 		}
@@ -190,11 +198,17 @@ async function recover(
 	dependencies: SetupEffectDependencies,
 	cause: unknown,
 ): Promise<LegacyTeamSetupViewV1 | undefined> {
-	if (effect.kind === "load" || effect.kind === "completion_refresh") return undefined;
+	if (effect.kind === "completion_refresh") return undefined;
 	if (!(cause instanceof LegacyTeamSetupApiError) || !isChangedStateCode(cause.errorCode)) {
 		return undefined;
 	}
-	return dependencies.loadDetail(effect.candidateRef).catch(() => undefined);
+	if (
+		effect.kind === "load" &&
+		(effect.refresh || cause.errorCode !== "team_setup_confirmation_stale")
+	) {
+		return undefined;
+	}
+	return dependencies.loadDetail(effect.candidateRef);
 }
 
 export function isChangedStateCode(code: LegacyTeamSetupErrorCode): boolean {

--- a/packages/ui/src/tabs/legacy-team-setup-session.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.test.ts
@@ -443,6 +443,47 @@ describe("legacy Team setup session reducer", () => {
 		).toBe(state);
 	});
 
+	it.each([
+		["team_setup_completion_unavailable", "Team setup completion could not be checked"],
+		[
+			"team_setup_completion_conflict",
+			"Another device completed this Team with different reviewed details",
+		],
+		["team_setup_completion_invalid", "The completed Team setup could not be verified"],
+	] as const)("treats %s as a global reload recovery error", (errorCode, expectedMessage) => {
+		// Arrange
+		let state: SetupSessionState = reduceSetupSession(loaded(), {
+			type: "decide_device",
+			deviceRef: "device-a",
+			decision: "excluded",
+		});
+		if (state.status !== "open") throw new Error("expected open mutation session");
+		const command = state.commands[0];
+		if (!command) throw new Error("expected mutation command");
+
+		// Act
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new LegacyTeamSetupApiError(409, errorCode),
+			},
+		});
+
+		// Assert
+		if (state.status !== "open") throw new Error("expected open failed session");
+		expect(globalError(state)).toMatchObject({
+			scope: { kind: "global" },
+			message: expect.stringContaining(expectedMessage),
+			retry: "load",
+		});
+		expect(globalError(state)?.message).not.toContain(errorCode);
+		expect(errorForItem(state, "device", "device-a")).toBeNull();
+	});
+
 	it("prioritizes global refresh recovery and preserves it after a transient failure", () => {
 		let state: OpenSetupSessionState = {
 			...loaded(),
@@ -614,6 +655,153 @@ describe("legacy Team setup session reducer", () => {
 
 		expect(globalError(state)).not.toBeNull();
 		expect(reduceSetupSession(state, { type: "finish" })).toBe(state);
+	});
+
+	it("reloads completion state after finish publication is unavailable", () => {
+		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
+		if (state.status !== "open") throw new Error("expected finish session");
+		const command = state.commands[0];
+		if (command?.kind !== "finish") throw new Error("expected finish command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new LegacyTeamSetupApiError(503, "team_setup_completion_unavailable"),
+			},
+		});
+		if (state.status !== "open") throw new Error("expected failed finish session");
+
+		expect(globalError(state)).toMatchObject({
+			message: expect.stringContaining("no local changes were applied"),
+			retry: "load",
+		});
+		expect(globalError(state)?.message).not.toContain("setup was not finished");
+		state = reduceSetupSession(state, { type: "retry" });
+		expect(state).toMatchObject({
+			commands: [expect.objectContaining({ kind: "load", refresh: false })],
+		});
+	});
+
+	it("uses a plain detail retry when confirmation-stale recovery also fails", () => {
+		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
+		if (state.status !== "open") throw new Error("expected finish session");
+		const command = state.commands[0];
+		if (command?.kind !== "finish") throw new Error("expected finish command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new LegacyTeamSetupApiError(409, "team_setup_confirmation_stale"),
+				recoveryCause: new LegacyTeamSetupApiError(503, "team_setup_completion_unavailable"),
+			},
+		});
+		if (state.status !== "open") throw new Error("expected failed finish session");
+
+		expect(globalError(state)).toMatchObject({
+			message: expect.stringContaining("changed since it was last reviewed"),
+			retry: "load",
+		});
+		expect(globalError(state)?.message).not.toContain("no local changes were applied");
+		state = reduceSetupSession(state, { type: "retry" });
+		expect(state).toMatchObject({
+			commands: [expect.objectContaining({ kind: "load", refresh: false })],
+		});
+	});
+
+	it("preserves refresh retry when roster-change recovery also fails", () => {
+		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
+		if (state.status !== "open") throw new Error("expected finish session");
+		const command = state.commands[0];
+		if (command?.kind !== "finish") throw new Error("expected finish command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new LegacyTeamSetupApiError(409, "team_setup_roster_changed"),
+				recoveryCause: new LegacyTeamSetupApiError(503, "team_setup_completion_unavailable"),
+			},
+		});
+		if (state.status !== "open") throw new Error("expected failed finish session");
+
+		expect(globalError(state)).toMatchObject({
+			message: expect.stringContaining("changed since it was last reviewed"),
+			retry: "refresh",
+		});
+		state = reduceSetupSession(state, { type: "retry" });
+		expect(state).toMatchObject({
+			commands: [expect.objectContaining({ kind: "load", refresh: true })],
+		});
+	});
+
+	it.each([
+		["team_setup_completion_conflict", "different reviewed details"],
+		["team_setup_completion_invalid", "could not be verified"],
+	] as const)(
+		"surfaces terminal recovery error %s with a detail retry",
+		(errorCode, expectedMessage) => {
+			let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
+			if (state.status !== "open") throw new Error("expected finish session");
+			const command = state.commands[0];
+			if (command?.kind !== "finish") throw new Error("expected finish command");
+			state = reduceSetupSession(state, {
+				type: "effect_outcome",
+				outcome: {
+					status: "failure",
+					generation: command.generation,
+					id: command.id,
+					kind: command.kind,
+					cause: new LegacyTeamSetupApiError(409, "team_setup_roster_changed"),
+					recoveryCause: new LegacyTeamSetupApiError(409, errorCode),
+				},
+			});
+			if (state.status !== "open") throw new Error("expected failed finish session");
+
+			expect(globalError(state)).toMatchObject({
+				message: expect.stringContaining(expectedMessage),
+				retry: "load",
+			});
+			state = reduceSetupSession(state, { type: "retry" });
+			expect(state).toMatchObject({
+				commands: [expect.objectContaining({ kind: "load", refresh: false })],
+			});
+		},
+	);
+
+	it("uses a plain detail retry when roster-change recovery finds a completed draft", () => {
+		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
+		if (state.status !== "open") throw new Error("expected finish session");
+		const command = state.commands[0];
+		if (command?.kind !== "finish") throw new Error("expected finish command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new LegacyTeamSetupApiError(409, "team_setup_roster_changed"),
+				recoveryCause: new LegacyTeamSetupApiError(409, "team_setup_confirmation_stale"),
+			},
+		});
+		if (state.status !== "open") throw new Error("expected failed finish session");
+
+		expect(globalError(state)).toMatchObject({
+			message: expect.stringContaining("changed since it was last reviewed"),
+			retry: "load",
+		});
+		state = reduceSetupSession(state, { type: "retry" });
+		expect(state).toMatchObject({
+			commands: [expect.objectContaining({ kind: "load", refresh: false })],
+		});
 	});
 
 	it.each([

--- a/packages/ui/src/tabs/legacy-team-setup-session.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.ts
@@ -82,6 +82,14 @@ const ROSTER_UNAVAILABLE_ERROR =
 	"Team device details are temporarily unavailable. Check the coordinator connection and settings, then refresh.";
 const ROSTER_UNAVAILABLE_AFTER_FINISH_ERROR =
 	"Team device details were unavailable, so setup was not finished and no changes were applied. Check the coordinator connection and settings, then refresh.";
+const COMPLETION_UNAVAILABLE_ERROR =
+	"Team setup completion could not be checked. Check the coordinator connection and settings, then refresh.";
+const COMPLETION_UNAVAILABLE_AFTER_FINISH_ERROR =
+	"Team setup could not be confirmed, and no local changes were applied. Refresh to check whether setup completed, then retry if needed.";
+const COMPLETION_CONFLICT_ERROR =
+	"Another device completed this Team with different reviewed details. Refresh to apply the completed setup.";
+const COMPLETION_INVALID_ERROR =
+	"The completed Team setup could not be verified. Refresh to try again, then check the coordinator connection and settings if the problem continues.";
 
 export function createSetupSessionState(): SetupSessionState {
 	return { status: "closed", generation: 0 };
@@ -471,7 +479,7 @@ function failed(
 	}
 	const recovered = result.recoveredView ? applyView(state, result.recoveredView, false) : state;
 	if (result.recoveredView?.state === "completed") return recovered;
-	const error = errorFor(command, result.cause);
+	const error = errorFor(command, result.cause, result.recoveryCause);
 	const next = {
 		...recovered,
 		errors: [...clearScope(recovered, error.scope).errors, error],
@@ -572,24 +580,56 @@ function completed(state: OpenSetupSessionState, attemptId: string): OpenSetupSe
 	return next;
 }
 
-function errorFor(command: SetupEffect, cause: unknown): SetupSessionError {
+function errorFor(
+	command: SetupEffect,
+	cause: unknown,
+	recoveryCause?: unknown,
+): SetupSessionError {
 	const changed = cause instanceof LegacyTeamSetupApiError && isChangedStateCode(cause.errorCode);
 	const rosterUnavailable =
 		cause instanceof LegacyTeamSetupApiError && cause.errorCode === "team_setup_roster_unavailable";
-	const message = changed
-		? CHANGED_STATE_ERROR
-		: rosterUnavailable
-			? command.kind === "finish"
-				? ROSTER_UNAVAILABLE_AFTER_FINISH_ERROR
-				: ROSTER_UNAVAILABLE_ERROR
-			: safeError(command.kind);
-	const retry =
-		changed ||
-		rosterUnavailable ||
-		command.kind === "refresh" ||
-		(command.kind === "load" && command.refresh)
-			? ("refresh" as const)
-			: ("load" as const);
+	const causeCompletionCode =
+		cause instanceof LegacyTeamSetupApiError ? completionErrorCode(cause.errorCode) : null;
+	const recoveryCompletionCode =
+		recoveryCause instanceof LegacyTeamSetupApiError
+			? completionErrorCode(recoveryCause.errorCode)
+			: null;
+	const terminalRecoveryCode =
+		recoveryCompletionCode === "team_setup_completion_conflict" ||
+		recoveryCompletionCode === "team_setup_completion_invalid"
+			? recoveryCompletionCode
+			: null;
+	const completionCode = terminalRecoveryCode ?? causeCompletionCode;
+	const completionError =
+		completionCode === "team_setup_completion_unavailable" && command.kind === "finish"
+			? COMPLETION_UNAVAILABLE_AFTER_FINISH_ERROR
+			: completionMessage(completionCode);
+	let message = completionError ?? safeError(command.kind);
+	if (!terminalRecoveryCode) {
+		if (changed) message = CHANGED_STATE_ERROR;
+		else if (rosterUnavailable) {
+			message =
+				command.kind === "finish"
+					? ROSTER_UNAVAILABLE_AFTER_FINISH_ERROR
+					: ROSTER_UNAVAILABLE_ERROR;
+		}
+	}
+	const confirmationStale =
+		(cause instanceof LegacyTeamSetupApiError &&
+			cause.errorCode === "team_setup_confirmation_stale") ||
+		(recoveryCause instanceof LegacyTeamSetupApiError &&
+			recoveryCause.errorCode === "team_setup_confirmation_stale");
+	let retry: SetupSessionError["retry"] = "load";
+	if (
+		!confirmationStale &&
+		!terminalRecoveryCode &&
+		(changed ||
+			rosterUnavailable ||
+			command.kind === "refresh" ||
+			(command.kind === "load" && command.refresh))
+	) {
+		retry = "refresh";
+	}
 	if (
 		command.kind === "assign_device" ||
 		command.kind === "decide_device" ||
@@ -597,7 +637,7 @@ function errorFor(command: SetupEffect, cause: unknown): SetupSessionError {
 	) {
 		return {
 			scope:
-				changed || rosterUnavailable
+				changed || rosterUnavailable || completionCode !== null
 					? { kind: "global" }
 					: { kind: "device", itemRef: command.deviceRef },
 			message,
@@ -607,7 +647,7 @@ function errorFor(command: SetupEffect, cause: unknown): SetupSessionError {
 	if (command.kind === "map_project") {
 		return {
 			scope:
-				changed || rosterUnavailable
+				changed || rosterUnavailable || completionCode !== null
 					? { kind: "global" }
 					: { kind: "project", itemRef: command.projectRef },
 			message,
@@ -704,10 +744,36 @@ export function globalError(state: OpenSetupSessionState): SetupSessionError | n
 function unavailableMessage(reason: LegacyTeamSetupErrorCode): string {
 	if (isChangedStateCode(reason)) return CHANGED_STATE_ERROR;
 	if (reason === "team_setup_roster_unavailable") return ROSTER_UNAVAILABLE_ERROR;
+	const completion = completionMessage(completionErrorCode(reason));
+	if (completion) return completion;
 	if (reason === "team_setup_incomplete") {
 		return "Team setup needs refreshed server details before review can continue.";
 	}
 	return "Team setup details are temporarily unavailable. Refresh to load the latest server state.";
+}
+
+function completionErrorCode(
+	reason: LegacyTeamSetupErrorCode,
+):
+	| "team_setup_completion_unavailable"
+	| "team_setup_completion_conflict"
+	| "team_setup_completion_invalid"
+	| null {
+	if (
+		reason === "team_setup_completion_unavailable" ||
+		reason === "team_setup_completion_conflict" ||
+		reason === "team_setup_completion_invalid"
+	) {
+		return reason;
+	}
+	return null;
+}
+
+function completionMessage(reason: ReturnType<typeof completionErrorCode>): string | null {
+	if (reason === "team_setup_completion_unavailable") return COMPLETION_UNAVAILABLE_ERROR;
+	if (reason === "team_setup_completion_conflict") return COMPLETION_CONFLICT_ERROR;
+	if (reason === "team_setup_completion_invalid") return COMPLETION_INVALID_ERROR;
+	return null;
 }
 
 function clearScope(state: OpenSetupSessionState, scope: SetupErrorScope): OpenSetupSessionState {


### PR DESCRIPTION
## Description

Proves cross-device Team completion through two independent viewer databases and the real coordinator path. It also accepts the three stable completion error categories, provides recovery-oriented UI copy without exposing raw codes, and documents first-valid-finish-wins behavior.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation: `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1 pnpm run e2e:legacy-team-migration -- --json`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced