### PR TITLE
chore(tooling): upgrade Biome to 2.5

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -14,7 +14,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"complexity": {
 				"noUselessTernary": "error",
 				"noUselessTypeConstraint": "error",

--- a/packages/cli/src/commands/claude-user-prompt-hook.test.ts
+++ b/packages/cli/src/commands/claude-user-prompt-hook.test.ts
@@ -711,40 +711,43 @@ describe("dependency-free Claude user prompt hook", () => {
 	it.each([
 		["before", false, 1, ["/api/prompt-pack-profile"]],
 		["after", true, 0, ["/api/prompt-pack-profile", "/api/pack", "/api/prompt-pack-ledger"]],
-	] as const)("handles invalid_request %s a compatible profile", async (_label, compatibleProfile, expectedFallbackCalls, expectedRequestPaths) => {
-		// Arrange
-		const requestPaths: string[] = [];
-		let fallbackCalls = 0;
+	] as const)(
+		"handles invalid_request %s a compatible profile",
+		async (_label, compatibleProfile, expectedFallbackCalls, expectedRequestPaths) => {
+			// Arrange
+			const requestPaths: string[] = [];
+			let fallbackCalls = 0;
 
-		// Act
-		await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
-			env,
-			fetchImpl: async (input: string | URL) => {
-				const path = new URL(String(input)).pathname;
-				requestPaths.push(path);
-				if (compatibleProfile && path.endsWith("profile")) {
-					return jsonResponse({
-						service: "codemem-viewer",
-						protocol_version: 1,
-						min_supported_protocol_version: 1,
-						db_path: dbPath,
-						identity_target: identity,
-					});
-				}
-				return jsonResponse({ error: { code: "invalid_request" } }, 400);
-			},
-			writeOutput: () => {},
-			spawnIngestion: () => {},
-			runFallback: () => {
-				fallbackCalls += 1;
-				return { continue: true };
-			},
-		});
+			// Act
+			await hook.runClaudeUserPromptHook(JSON.stringify(payload), {
+				env,
+				fetchImpl: async (input: string | URL) => {
+					const path = new URL(String(input)).pathname;
+					requestPaths.push(path);
+					if (compatibleProfile && path.endsWith("profile")) {
+						return jsonResponse({
+							service: "codemem-viewer",
+							protocol_version: 1,
+							min_supported_protocol_version: 1,
+							db_path: dbPath,
+							identity_target: identity,
+						});
+					}
+					return jsonResponse({ error: { code: "invalid_request" } }, 400);
+				},
+				writeOutput: () => {},
+				spawnIngestion: () => {},
+				runFallback: () => {
+					fallbackCalls += 1;
+					return { continue: true };
+				},
+			});
 
-		// Assert
-		expect(requestPaths).toEqual(expectedRequestPaths);
-		expect(fallbackCalls).toBe(expectedFallbackCalls);
-	});
+			// Assert
+			expect(requestPaths).toEqual(expectedRequestPaths);
+			expect(fallbackCalls).toBe(expectedFallbackCalls);
+		},
+	);
 
 	it("records disabled injection without probing the pack profile", async () => {
 		env.CODEMEM_INJECT_CONTEXT = "0";

--- a/packages/cli/src/commands/codex-hook-inject.test.ts
+++ b/packages/cli/src/commands/codex-hook-inject.test.ts
@@ -348,41 +348,41 @@ describe("codex-hook-inject command", () => {
 		expect(localCalls).toBe(fallsBack ? 1 : 0);
 	});
 
-	it.each([
-		"db_path",
-		"identity_target",
-	] as const)("uses local fallback when the Viewer profile has a mismatched %s", async (field) => {
-		delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
-		process.env.CODEMEM_DB = join(tempDir, "mem.sqlite");
-		const identity = buildViewerIdentityTarget();
-		let localCalls = 0;
+	it.each(["db_path", "identity_target"] as const)(
+		"uses local fallback when the Viewer profile has a mismatched %s",
+		async (field) => {
+			delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;
+			process.env.CODEMEM_DB = join(tempDir, "mem.sqlite");
+			const identity = buildViewerIdentityTarget();
+			let localCalls = 0;
 
-		await buildCodexHookInjection(
-			{ hook_event_name: "UserPromptSubmit", prompt: "profile mismatch" },
-			{},
-			{
-				fetchImpl: async () =>
-					new Response(
-						JSON.stringify({
-							service: "codemem-viewer",
-							protocol_version: 1,
-							min_supported_protocol_version: 1,
-							db_path: field === "db_path" ? "/other.sqlite" : process.env.CODEMEM_DB,
-							identity_target:
-								field === "identity_target" ? { ...identity, workspace_id: "other" } : identity,
-						}),
-						{ status: 200 },
-					),
-				buildLocalPack: async () => {
-					localCalls += 1;
-					return pack("LOCAL_PACK");
+			await buildCodexHookInjection(
+				{ hook_event_name: "UserPromptSubmit", prompt: "profile mismatch" },
+				{},
+				{
+					fetchImpl: async () =>
+						new Response(
+							JSON.stringify({
+								service: "codemem-viewer",
+								protocol_version: 1,
+								min_supported_protocol_version: 1,
+								db_path: field === "db_path" ? "/other.sqlite" : process.env.CODEMEM_DB,
+								identity_target:
+									field === "identity_target" ? { ...identity, workspace_id: "other" } : identity,
+							}),
+							{ status: 200 },
+						),
+					buildLocalPack: async () => {
+						localCalls += 1;
+						return pack("LOCAL_PACK");
+					},
+					resolveDb: () => process.env.CODEMEM_DB as string,
 				},
-				resolveDb: () => process.env.CODEMEM_DB as string,
-			},
-		);
+			);
 
-		expect(localCalls).toBe(1);
-	});
+			expect(localCalls).toBe(1);
+		},
+	);
 
 	it("rejects non-loopback Viewer hosts without touching the network or local database", async () => {
 		delete process.env.CODEMEM_CODEX_LOCAL_PACK_ONLY;

--- a/packages/cli/src/commands/codex-user-prompt-hook.test.ts
+++ b/packages/cli/src/commands/codex-user-prompt-hook.test.ts
@@ -595,40 +595,43 @@ describe("dependency-free Codex user prompt hook", () => {
 	it.each([
 		["before", false, 1, ["/api/prompt-pack-profile"]],
 		["after", true, 0, ["/api/prompt-pack-profile", "/api/pack", "/api/prompt-pack-ledger"]],
-	] as const)("handles invalid_request %s a compatible profile", async (_label, compatibleProfile, expectedFallbackCalls, expectedRequestPaths) => {
-		// Arrange
-		const requestPaths: string[] = [];
-		let fallbackCalls = 0;
+	] as const)(
+		"handles invalid_request %s a compatible profile",
+		async (_label, compatibleProfile, expectedFallbackCalls, expectedRequestPaths) => {
+			// Arrange
+			const requestPaths: string[] = [];
+			let fallbackCalls = 0;
 
-		// Act
-		await hook.runCodexUserPromptHook(JSON.stringify(payload), {
-			env,
-			fetchImpl: async (input: string | URL) => {
-				const path = new URL(String(input)).pathname;
-				requestPaths.push(path);
-				if (compatibleProfile && path.endsWith("profile")) {
-					return jsonResponse({
-						service: "codemem-viewer",
-						protocol_version: 1,
-						min_supported_protocol_version: 1,
-						db_path: dbPath,
-						identity_target: identity,
-					});
-				}
-				return jsonResponse({ error: { code: "invalid_request" } }, 400);
-			},
-			writeOutput: () => {},
-			spawnIngestion: () => {},
-			runFallback: () => {
-				fallbackCalls += 1;
-				return { continue: true };
-			},
-		});
+			// Act
+			await hook.runCodexUserPromptHook(JSON.stringify(payload), {
+				env,
+				fetchImpl: async (input: string | URL) => {
+					const path = new URL(String(input)).pathname;
+					requestPaths.push(path);
+					if (compatibleProfile && path.endsWith("profile")) {
+						return jsonResponse({
+							service: "codemem-viewer",
+							protocol_version: 1,
+							min_supported_protocol_version: 1,
+							db_path: dbPath,
+							identity_target: identity,
+						});
+					}
+					return jsonResponse({ error: { code: "invalid_request" } }, 400);
+				},
+				writeOutput: () => {},
+				spawnIngestion: () => {},
+				runFallback: () => {
+					fallbackCalls += 1;
+					return { continue: true };
+				},
+			});
 
-		// Assert
-		expect(requestPaths).toEqual(expectedRequestPaths);
-		expect(fallbackCalls).toBe(expectedFallbackCalls);
-	});
+			// Assert
+			expect(requestPaths).toEqual(expectedRequestPaths);
+			expect(fallbackCalls).toBe(expectedFallbackCalls);
+		},
+	);
 
 	it("falls back once for a stale profile and fails closed for a compatible contract defect", async () => {
 		let fallbackCalls = 0;

--- a/packages/core/src/claude-hooks.test.ts
+++ b/packages/core/src/claude-hooks.test.ts
@@ -77,25 +77,25 @@ describe("extractHookTranscript", () => {
 		}
 	});
 
-	it.each([
-		"../outside.jsonl",
-		"../../outside.jsonl",
-	])("rejects relative traversal %s", (transcriptPath) => {
-		const parent = mkdtempSync(join(tmpdir(), "codemem-transcript-traversal-"));
-		const cwd = join(parent, "cwd");
-		mkdirSync(cwd);
-		writeFileSync(join(parent, "outside.jsonl"), '{"role":"assistant","content":"outside"}\n');
-		try {
-			expect(
-				extractHookTranscript(transcriptPath, {
-					policy: restrictedTranscriptPolicy(parent),
-					cwd,
-				}),
-			).toEqual([null, null]);
-		} finally {
-			rmSync(parent, { recursive: true, force: true });
-		}
-	});
+	it.each(["../outside.jsonl", "../../outside.jsonl"])(
+		"rejects relative traversal %s",
+		(transcriptPath) => {
+			const parent = mkdtempSync(join(tmpdir(), "codemem-transcript-traversal-"));
+			const cwd = join(parent, "cwd");
+			mkdirSync(cwd);
+			writeFileSync(join(parent, "outside.jsonl"), '{"role":"assistant","content":"outside"}\n');
+			try {
+				expect(
+					extractHookTranscript(transcriptPath, {
+						policy: restrictedTranscriptPolicy(parent),
+						cwd,
+					}),
+				).toEqual([null, null]);
+			} finally {
+				rmSync(parent, { recursive: true, force: true });
+			}
+		},
+	);
 
 	it("rejects an absolute path beneath a sibling with the same prefix", () => {
 		const parent = mkdtempSync(join(tmpdir(), "codemem-transcript-prefix-"));
@@ -352,7 +352,7 @@ describe("mapClaudeHookPayload", () => {
 			expect(event?.event_type).toBe("prompt");
 			expect(event?.payload.text).toBe("Run tests");
 			expect(event?.meta.hook_event_name).toBe("UserPromptSubmit");
-			expect((event?.meta.hook_fields as Record<string, unknown>).custom_field).toBe("keep-me");
+			expect(event?.meta.hook_fields).toMatchObject({ custom_field: "keep-me" });
 		});
 
 		it("returns null for empty prompt", () => {
@@ -499,7 +499,7 @@ describe("mapClaudeHookPayload", () => {
 			expect(event).not.toBeNull();
 			expect(event?.event_type).toBe("assistant");
 			expect(event?.payload.text).toBe("All done!");
-			expect((event?.payload.usage as Record<string, number>).input_tokens).toBe(100);
+			expect(event?.payload.usage).toMatchObject({ input_tokens: 100 });
 		});
 
 		it("returns null when no text and no transcript", () => {
@@ -815,9 +815,7 @@ describe("buildRawEventEnvelopeFromHook", () => {
 		expect(envelope?.event_type).toBe("claude.hook");
 		expect(envelope?.started_at).toBe("2026-03-04T01:00:00Z");
 		expect(envelope?.payload._adapter).toBeDefined();
-		expect((envelope?.payload._adapter as Record<string, unknown>).event_type).toBe(
-			"session_start",
-		);
+		expect(envelope?.payload._adapter).toMatchObject({ event_type: "session_start" });
 		// 2026-03-04T01:00:00Z in ms
 		expect(envelope?.ts_wall_ms).toBe(new Date("2026-03-04T01:00:00Z").getTime());
 	});
@@ -1043,7 +1041,7 @@ describe("buildIngestPayloadFromHook", () => {
 
 		const events = ingest?.events as Array<Record<string, unknown>>;
 		expect(events).toHaveLength(1);
-		expect((events[0]?._adapter as Record<string, unknown>).event_type).toBe("session_start");
+		expect(events[0]?._adapter).toMatchObject({ event_type: "session_start" });
 	});
 
 	it("sets cwd from hook payload", () => {

--- a/packages/core/src/codex-hooks.test.ts
+++ b/packages/core/src/codex-hooks.test.ts
@@ -95,7 +95,7 @@ describe("mapCodexHookPayload", () => {
 		expect(event?.payload.text).toBe("Run the tests");
 		expect(event?.meta.turn_id).toBe("turn-1");
 		expect(event?.meta.event_id_algo).toBe("codex/1");
-		expect((event?.meta.hook_fields as Record<string, unknown>).custom_field).toBe("preserve");
+		expect(event?.meta.hook_fields).toMatchObject({ custom_field: "preserve" });
 	});
 
 	it("skips empty prompts", () => {
@@ -295,7 +295,7 @@ describe("buildRawEventEnvelopeFromCodexHook", () => {
 		expect(envelope?.session_stream_id).toBe("codex-session");
 		expect(envelope?.started_at).toBe("2026-05-29T01:00:00Z");
 		expect(envelope?.payload.type).toBe("codex.hook");
-		expect((envelope?.payload._adapter as Record<string, unknown>).source).toBe("codex");
+		expect(envelope?.payload._adapter).toMatchObject({ source: "codex" });
 	});
 });
 
@@ -315,6 +315,6 @@ describe("buildIngestPayloadFromCodexHook", () => {
 			session_id: "codex-session",
 			opencode_session_id: "codex-session",
 		});
-		expect((payload?.events as Record<string, unknown>[])[0]?.type).toBe("codex.hook");
+		expect(payload?.events[0]).toMatchObject({ type: "codex.hook" });
 	});
 });

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -325,112 +325,108 @@ describe("coordinator local admin actions", () => {
 		expect(capturedBodies[2]).not.toHaveProperty("device_display_name");
 	});
 
-	it.each([
-		"operation",
-		"group",
-		"digest",
-		"tampered_project",
-	] as const)("rejects an accepted Project intent with a %s mismatch before projection persistence", async (mismatch) => {
-		const actionDbPath = join(tmpDir, `project-accepted-${mismatch}.sqlite`);
-		const keysDir = join(tmpDir, `project-accepted-${mismatch}-keys`);
-		const configPath = join(tmpDir, `project-accepted-${mismatch}-config.json`);
-		const operationId = `share_${"9".repeat(40)}`;
-		const project = {
-			canonical_identity: "https://git.example.invalid/acme/alpha.git",
-			display_name: "alpha",
-			existing_memory_count: 1,
-		};
-		const digest = shareProjectSetDigest([
-			{
-				canonicalIdentity: project.canonical_identity,
-				displayName: project.display_name,
-				identitySource: "git_remote",
-				existingMemoryCount: project.existing_memory_count,
-			},
-		]);
-		const acceptedProjectIntent = {
-			operation_id: mismatch === "operation" ? `share_${"8".repeat(40)}` : operationId,
-			reviewed_project_set_digest: mismatch === "digest" ? "7".repeat(64) : digest,
-			projects:
-				mismatch === "tampered_project" ? [{ ...project, existing_memory_count: 2 }] : [project],
-		};
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(
-				async () =>
-					new Response(
-						JSON.stringify({
-							status: "accepted",
-							group_id: mismatch === "group" ? "team-b" : "team-a",
-							operation_id: operationId,
-							trust_state: "pending_inviter_device",
-							bootstrap_grant_id: null,
-							inviter_device: null,
-							accepted_project_intent: acceptedProjectIntent,
+	it.each(["operation", "group", "digest", "tampered_project"] as const)(
+		"rejects an accepted Project intent with a %s mismatch before projection persistence",
+		async (mismatch) => {
+			const actionDbPath = join(tmpDir, `project-accepted-${mismatch}.sqlite`);
+			const keysDir = join(tmpDir, `project-accepted-${mismatch}-keys`);
+			const configPath = join(tmpDir, `project-accepted-${mismatch}-config.json`);
+			const operationId = `share_${"9".repeat(40)}`;
+			const project = {
+				canonical_identity: "https://git.example.invalid/acme/alpha.git",
+				display_name: "alpha",
+				existing_memory_count: 1,
+			};
+			const digest = shareProjectSetDigest([
+				{
+					canonicalIdentity: project.canonical_identity,
+					displayName: project.display_name,
+					identitySource: "git_remote",
+					existingMemoryCount: project.existing_memory_count,
+				},
+			]);
+			const acceptedProjectIntent = {
+				operation_id: mismatch === "operation" ? `share_${"8".repeat(40)}` : operationId,
+				reviewed_project_set_digest: mismatch === "digest" ? "7".repeat(64) : digest,
+				projects:
+					mismatch === "tampered_project" ? [{ ...project, existing_memory_count: 2 }] : [project],
+			};
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(
+					async () =>
+						new Response(
+							JSON.stringify({
+								status: "accepted",
+								group_id: mismatch === "group" ? "team-b" : "team-a",
+								operation_id: operationId,
+								trust_state: "pending_inviter_device",
+								bootstrap_grant_id: null,
+								inviter_device: null,
+								accepted_project_intent: acceptedProjectIntent,
+							}),
+							{ status: 200 },
+						),
+				),
+			);
+			const invite = encodeInvitePayload({
+				v: 1,
+				kind: "coordinator_team_invite",
+				coordinator_url: "https://coord.example.test",
+				group_id: "team-a",
+				policy: "auto_admit",
+				token: `project-${mismatch}-token`,
+				expires_at: "2099-01-01T00:00:00.000Z",
+				team_name: "Team A",
+				operation_id: operationId,
+			});
+
+			await expect(
+				coordinatorImportInviteAction({
+					inviteValue: invite,
+					dbPath: actionDbPath,
+					keysDir,
+					configPath,
+					recipientActorId: "identity-recipient",
+					recipientDisplayName: "Recipient",
+					deviceDisplayName: "Recipient laptop",
+				}),
+			).rejects.toThrow("accepted_project_intent");
+			const db = connect(actionDbPath);
+			try {
+				expect(
+					db.prepare("SELECT COUNT(*) FROM recipient_managed_project_projections").pluck().get(),
+				).toBe(0);
+				expect(db.prepare("SELECT COUNT(*) FROM actors").pluck().get()).toBe(0);
+			} finally {
+				db.close();
+			}
+		},
+	);
+
+	it.each([{}, { items: null }, { items: "not-a-list" }, { items: [null] }])(
+		"rejects malformed remote device lists: %j",
+		async (payload) => {
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(
+					async () =>
+						new Response(JSON.stringify(payload), {
+							status: 200,
+							headers: { "content-type": "application/json" },
 						}),
-						{ status: 200 },
-					),
-			),
-		);
-		const invite = encodeInvitePayload({
-			v: 1,
-			kind: "coordinator_team_invite",
-			coordinator_url: "https://coord.example.test",
-			group_id: "team-a",
-			policy: "auto_admit",
-			token: `project-${mismatch}-token`,
-			expires_at: "2099-01-01T00:00:00.000Z",
-			team_name: "Team A",
-			operation_id: operationId,
-		});
+				),
+			);
 
-		await expect(
-			coordinatorImportInviteAction({
-				inviteValue: invite,
-				dbPath: actionDbPath,
-				keysDir,
-				configPath,
-				recipientActorId: "identity-recipient",
-				recipientDisplayName: "Recipient",
-				deviceDisplayName: "Recipient laptop",
-			}),
-		).rejects.toThrow("accepted_project_intent");
-		const db = connect(actionDbPath);
-		try {
-			expect(
-				db.prepare("SELECT COUNT(*) FROM recipient_managed_project_projections").pluck().get(),
-			).toBe(0);
-			expect(db.prepare("SELECT COUNT(*) FROM actors").pluck().get()).toBe(0);
-		} finally {
-			db.close();
-		}
-	});
-
-	it.each([
-		{},
-		{ items: null },
-		{ items: "not-a-list" },
-		{ items: [null] },
-	])("rejects malformed remote device lists: %j", async (payload) => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(
-				async () =>
-					new Response(JSON.stringify(payload), {
-						status: 200,
-						headers: { "content-type": "application/json" },
-					}),
-			),
-		);
-
-		await expect(
-			coordinatorListDevicesAction({
-				groupId: "team-a",
-				remoteUrl: "https://coord.example.test",
-				adminSecret: "secret",
-			}),
-		).rejects.toThrow("coordinator_device_list_malformed");
-	});
+			await expect(
+				coordinatorListDevicesAction({
+					groupId: "team-a",
+					remoteUrl: "https://coord.example.test",
+					adminSecret: "secret",
+				}),
+			).rejects.toThrow("coordinator_device_list_malformed");
+		},
+	);
 
 	it("honors caller-provided remote list timeouts", async () => {
 		const timeoutSignal = new AbortController().signal;
@@ -584,42 +580,40 @@ describe("coordinator local admin actions", () => {
 		]);
 	});
 
-	it.each([
-		{ identity_id: "" },
-		{ identity_id: 0 },
-		{ display_name: 0 },
-		{ display_name: false },
-	])("rejects malformed non-null nullable remote device fields: %j", async (override) => {
-		const device = {
-			group_id: "team-a",
-			device_id: "device-1",
-			public_key: "pk-1",
-			fingerprint: "fp-1",
-			identity_id: null,
-			display_name: null,
-			enabled: 1,
-			created_at: "2026-07-26T00:00:00.000Z",
-			...override,
-		};
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(
-				async () =>
-					new Response(JSON.stringify({ items: [device] }), {
-						status: 200,
-						headers: { "content-type": "application/json" },
-					}),
-			),
-		);
+	it.each([{ identity_id: "" }, { identity_id: 0 }, { display_name: 0 }, { display_name: false }])(
+		"rejects malformed non-null nullable remote device fields: %j",
+		async (override) => {
+			const device = {
+				group_id: "team-a",
+				device_id: "device-1",
+				public_key: "pk-1",
+				fingerprint: "fp-1",
+				identity_id: null,
+				display_name: null,
+				enabled: 1,
+				created_at: "2026-07-26T00:00:00.000Z",
+				...override,
+			};
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(
+					async () =>
+						new Response(JSON.stringify({ items: [device] }), {
+							status: 200,
+							headers: { "content-type": "application/json" },
+						}),
+				),
+			);
 
-		await expect(
-			coordinatorListDevicesAction({
-				groupId: "team-a",
-				remoteUrl: "https://coord.example.test",
-				adminSecret: "secret",
-			}),
-		).rejects.toThrow("coordinator_device_list_malformed");
-	});
+			await expect(
+				coordinatorListDevicesAction({
+					groupId: "team-a",
+					remoteUrl: "https://coord.example.test",
+					adminSecret: "secret",
+				}),
+			).rejects.toThrow("coordinator_device_list_malformed");
+		},
+	);
 
 	it("lists only consumed Team invites without tokens", async () => {
 		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
@@ -865,40 +859,40 @@ describe("coordinator local admin actions", () => {
 		}
 	});
 
-	it.each([
-		"device_id",
-		"identity_id",
-	] as const)("rejects overlong remote device %s values", async (field) => {
-		const device = {
-			group_id: "team-a",
-			device_id: "device-1",
-			public_key: "pk-1",
-			fingerprint: "fp-1",
-			identity_id: "identity-1",
-			display_name: null,
-			enabled: 1,
-			created_at: "2026-07-26T00:00:00.000Z",
-			[field]: "x".repeat(257),
-		};
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(
-				async () =>
-					new Response(JSON.stringify({ items: [device] }), {
-						status: 200,
-						headers: { "content-type": "application/json" },
-					}),
-			),
-		);
+	it.each(["device_id", "identity_id"] as const)(
+		"rejects overlong remote device %s values",
+		async (field) => {
+			const device = {
+				group_id: "team-a",
+				device_id: "device-1",
+				public_key: "pk-1",
+				fingerprint: "fp-1",
+				identity_id: "identity-1",
+				display_name: null,
+				enabled: 1,
+				created_at: "2026-07-26T00:00:00.000Z",
+				[field]: "x".repeat(257),
+			};
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(
+					async () =>
+						new Response(JSON.stringify({ items: [device] }), {
+							status: 200,
+							headers: { "content-type": "application/json" },
+						}),
+				),
+			);
 
-		await expect(
-			coordinatorListDevicesAction({
-				groupId: "team-a",
-				remoteUrl: "https://coord.example.test",
-				adminSecret: "secret",
-			}),
-		).rejects.toThrow("coordinator_device_list_malformed");
-	});
+			await expect(
+				coordinatorListDevicesAction({
+					groupId: "team-a",
+					remoteUrl: "https://coord.example.test",
+					adminSecret: "secret",
+				}),
+			).rejects.toThrow("coordinator_device_list_malformed");
+		},
+	);
 
 	it("serializes only exact, well-formed remote device presence capability fields", async () => {
 		vi.stubGlobal(
@@ -2772,208 +2766,215 @@ describe("coordinator local admin actions", () => {
 			identityId: "identity-add-device",
 			targetId: "identity-add-device",
 		},
-	])("rejects stale $kind onboarding before consuming the invite or mutating local state", async (testCase) => {
-		const actionDbPath = join(tmpDir, `${testCase.kind}-stale-preflight.sqlite`);
-		const keysDir = join(tmpDir, `${testCase.kind}-stale-preflight-keys`);
-		const configPath = join(tmpDir, `${testCase.kind}-stale-preflight-config.json`);
-		const originalConfig = {
-			actor_id: testCase.identityId,
-			sync_coordinator_groups: ["existing-group"],
-		};
-		writeCodememConfigFile(originalConfig, configPath);
-		const reviewedIntent =
-			testCase.kind === "team_member"
-				? teamReviewedIntent(testCase.targetId)
-				: addDeviceReviewedIntent(testCase.targetId);
-		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
-		const validOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
-			dbPath: actionDbPath,
-			keysDir,
-			invitationId: `${testCase.kind}-stale-token`,
-			identityId: testCase.identityId,
-			deviceDisplayName: "Recipient laptop",
-			reviewedIntent,
-		});
-		const localSnapshot = () => {
-			const db = connect(actionDbPath);
-			try {
-				return JSON.stringify(
-					Object.fromEntries(
-						[
-							"actors",
-							"sync_device",
-							"identity_devices",
-							"policy_teams",
-							"policy_team_memberships",
-							"project_recipients",
-						].map((table) => [table, db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all()]),
-					),
-				);
-			} finally {
-				db.close();
-			}
-		};
-		const beforeDb = localSnapshot();
-		const requestedUrls: string[] = [];
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(async (url: string | URL) => {
-				const requestedUrl = String(url);
-				requestedUrls.push(requestedUrl);
-				if (!requestedUrl.endsWith("/v1/invites/inspect")) {
-					throw new Error(`unexpected request: ${requestedUrl}`);
-				}
-				return new Response(
-					JSON.stringify({
-						kind: testCase.kind,
-						policy_team_id: testCase.kind === "team_member" ? testCase.targetId : undefined,
-						assigned_identity_id: testCase.kind === "team_member" ? testCase.identityId : undefined,
-						target_identity_id: testCase.kind === "add_device" ? testCase.targetId : undefined,
-						reviewed_preview_digest: reviewedDigest,
-						reviewed_intent: reviewedIntent,
-						bound: false,
-					}),
-					{ status: 200 },
-				);
-			}),
-		);
-		const invite = encodeInvitePayload({
-			v: 1,
-			kind: testCase.kind,
-			coordinator_url: "https://coord.example.test",
-			group_id: "coordinator-a",
-			policy: "auto_admit",
-			token: `${testCase.kind}-stale-token`,
-			expires_at: "2099-01-01T00:00:00.000Z",
-			team_name: null,
-			...(testCase.kind === "team_member"
-				? {
-						policy_team_id: testCase.targetId,
-						assigned_identity_id: testCase.identityId,
-					}
-				: { target_identity_id: testCase.targetId }),
-			reviewed_preview_digest: reviewedDigest,
-		});
-
-		await expect(
-			coordinatorImportInviteAction({
-				inviteValue: invite,
+	])(
+		"rejects stale $kind onboarding before consuming the invite or mutating local state",
+		async (testCase) => {
+			const actionDbPath = join(tmpDir, `${testCase.kind}-stale-preflight.sqlite`);
+			const keysDir = join(tmpDir, `${testCase.kind}-stale-preflight-keys`);
+			const configPath = join(tmpDir, `${testCase.kind}-stale-preflight-config.json`);
+			const originalConfig = {
+				actor_id: testCase.identityId,
+				sync_coordinator_groups: ["existing-group"],
+			};
+			writeCodememConfigFile(originalConfig, configPath);
+			const reviewedIntent =
+				testCase.kind === "team_member"
+					? teamReviewedIntent(testCase.targetId)
+					: addDeviceReviewedIntent(testCase.targetId);
+			const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+			const validOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
 				dbPath: actionDbPath,
 				keysDir,
-				configPath,
-				recipientActorId: testCase.identityId,
+				invitationId: `${testCase.kind}-stale-token`,
+				identityId: testCase.identityId,
 				deviceDisplayName: "Recipient laptop",
-				reviewedOnboardingDigest: `${validOnboardingDigest}-stale`,
-			}),
-		).rejects.toThrow("reviewed_onboarding_stale");
-		expect(requestedUrls).toEqual(["https://coord.example.test/v1/invites/inspect"]);
-		expect(localSnapshot()).toBe(beforeDb);
-		expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
-	});
+				reviewedIntent,
+			});
+			const localSnapshot = () => {
+				const db = connect(actionDbPath);
+				try {
+					return JSON.stringify(
+						Object.fromEntries(
+							[
+								"actors",
+								"sync_device",
+								"identity_devices",
+								"policy_teams",
+								"policy_team_memberships",
+								"project_recipients",
+							].map((table) => [table, db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all()]),
+						),
+					);
+				} finally {
+					db.close();
+				}
+			};
+			const beforeDb = localSnapshot();
+			const requestedUrls: string[] = [];
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async (url: string | URL) => {
+					const requestedUrl = String(url);
+					requestedUrls.push(requestedUrl);
+					if (!requestedUrl.endsWith("/v1/invites/inspect")) {
+						throw new Error(`unexpected request: ${requestedUrl}`);
+					}
+					return new Response(
+						JSON.stringify({
+							kind: testCase.kind,
+							policy_team_id: testCase.kind === "team_member" ? testCase.targetId : undefined,
+							assigned_identity_id:
+								testCase.kind === "team_member" ? testCase.identityId : undefined,
+							target_identity_id: testCase.kind === "add_device" ? testCase.targetId : undefined,
+							reviewed_preview_digest: reviewedDigest,
+							reviewed_intent: reviewedIntent,
+							bound: false,
+						}),
+						{ status: 200 },
+					);
+				}),
+			);
+			const invite = encodeInvitePayload({
+				v: 1,
+				kind: testCase.kind,
+				coordinator_url: "https://coord.example.test",
+				group_id: "coordinator-a",
+				policy: "auto_admit",
+				token: `${testCase.kind}-stale-token`,
+				expires_at: "2099-01-01T00:00:00.000Z",
+				team_name: null,
+				...(testCase.kind === "team_member"
+					? {
+							policy_team_id: testCase.targetId,
+							assigned_identity_id: testCase.identityId,
+						}
+					: { target_identity_id: testCase.targetId }),
+				reviewed_preview_digest: reviewedDigest,
+			});
+
+			await expect(
+				coordinatorImportInviteAction({
+					inviteValue: invite,
+					dbPath: actionDbPath,
+					keysDir,
+					configPath,
+					recipientActorId: testCase.identityId,
+					deviceDisplayName: "Recipient laptop",
+					reviewedOnboardingDigest: `${validOnboardingDigest}-stale`,
+				}),
+			).rejects.toThrow("reviewed_onboarding_stale");
+			expect(requestedUrls).toEqual(["https://coord.example.test/v1/invites/inspect"]);
+			expect(localSnapshot()).toBe(beforeDb);
+			expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
+		},
+	);
 
 	it.each([
 		{ label: "kind", responseOverride: { kind: "add_device" } },
 		{ label: "target ID", responseOverride: { policy_team_id: "team-other" } },
 		{ label: "reviewed digest", responseOverride: { reviewed_preview_digest: "f".repeat(64) } },
-	])("rejects a mismatched $label returned by recipient invite inspection without local mutation", async (testCase) => {
-		// Arrange
-		const actionDbPath = join(
-			tmpDir,
-			`recipient-invite-${testCase.label.replaceAll(" ", "-")}.sqlite`,
-		);
-		const keysDir = join(tmpDir, `recipient-invite-${testCase.label.replaceAll(" ", "-")}-keys`);
-		const configPath = join(
-			tmpDir,
-			`recipient-invite-${testCase.label.replaceAll(" ", "-")}-config.json`,
-		);
-		const identityId = "identity-recipient";
-		const originalConfig = {
-			actor_id: identityId,
-			sync_coordinator_groups: ["existing-group"],
-		};
-		writeCodememConfigFile(originalConfig, configPath);
-		initDatabase(actionDbPath);
-		const setup = connect(actionDbPath);
-		try {
-			ensureDeviceIdentity(setup, { keysDir });
-		} finally {
-			setup.close();
-		}
-		const localSnapshot = () => {
-			const db = connect(actionDbPath);
+	])(
+		"rejects a mismatched $label returned by recipient invite inspection without local mutation",
+		async (testCase) => {
+			// Arrange
+			const actionDbPath = join(
+				tmpDir,
+				`recipient-invite-${testCase.label.replaceAll(" ", "-")}.sqlite`,
+			);
+			const keysDir = join(tmpDir, `recipient-invite-${testCase.label.replaceAll(" ", "-")}-keys`);
+			const configPath = join(
+				tmpDir,
+				`recipient-invite-${testCase.label.replaceAll(" ", "-")}-config.json`,
+			);
+			const identityId = "identity-recipient";
+			const originalConfig = {
+				actor_id: identityId,
+				sync_coordinator_groups: ["existing-group"],
+			};
+			writeCodememConfigFile(originalConfig, configPath);
+			initDatabase(actionDbPath);
+			const setup = connect(actionDbPath);
 			try {
-				return JSON.stringify(
-					Object.fromEntries(
-						[
-							"actors",
-							"sync_device",
-							"identity_devices",
-							"policy_teams",
-							"policy_team_memberships",
-							"project_recipients",
-						].map((table) => [table, db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all()]),
-					),
-				);
+				ensureDeviceIdentity(setup, { keysDir });
 			} finally {
-				db.close();
+				setup.close();
 			}
-		};
-		const beforeDb = localSnapshot();
-		const reviewedIntent = teamReviewedIntent("team-a");
-		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(
-				async () =>
-					new Response(
-						JSON.stringify({
-							ok: true,
-							status: "accepted",
-							kind: "team_member",
-							group_id: "coordinator-a",
-							identity_id: identityId,
-							policy_team_id: "team-a",
-							target_identity_id: null,
-							assigned_identity_id: identityId,
-							reviewed_preview_digest: reviewedDigest,
-							reviewed_intent: reviewedIntent,
-							...testCase.responseOverride,
-						}),
-						{ status: 200 },
-					),
-			),
-		);
-		const invite = encodeInvitePayload({
-			v: 1,
-			kind: "team_member",
-			coordinator_url: "https://coord.example.test",
-			group_id: "coordinator-a",
-			policy: "auto_admit",
-			token: `recipient-${testCase.label}-token`,
-			expires_at: "2099-01-01T00:00:00.000Z",
-			team_name: null,
-			policy_team_id: "team-a",
-			assigned_identity_id: identityId,
-			reviewed_preview_digest: reviewedDigest,
-		});
+			const localSnapshot = () => {
+				const db = connect(actionDbPath);
+				try {
+					return JSON.stringify(
+						Object.fromEntries(
+							[
+								"actors",
+								"sync_device",
+								"identity_devices",
+								"policy_teams",
+								"policy_team_memberships",
+								"project_recipients",
+							].map((table) => [table, db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all()]),
+						),
+					);
+				} finally {
+					db.close();
+				}
+			};
+			const beforeDb = localSnapshot();
+			const reviewedIntent = teamReviewedIntent("team-a");
+			const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(
+					async () =>
+						new Response(
+							JSON.stringify({
+								ok: true,
+								status: "accepted",
+								kind: "team_member",
+								group_id: "coordinator-a",
+								identity_id: identityId,
+								policy_team_id: "team-a",
+								target_identity_id: null,
+								assigned_identity_id: identityId,
+								reviewed_preview_digest: reviewedDigest,
+								reviewed_intent: reviewedIntent,
+								...testCase.responseOverride,
+							}),
+							{ status: 200 },
+						),
+				),
+			);
+			const invite = encodeInvitePayload({
+				v: 1,
+				kind: "team_member",
+				coordinator_url: "https://coord.example.test",
+				group_id: "coordinator-a",
+				policy: "auto_admit",
+				token: `recipient-${testCase.label}-token`,
+				expires_at: "2099-01-01T00:00:00.000Z",
+				team_name: null,
+				policy_team_id: "team-a",
+				assigned_identity_id: identityId,
+				reviewed_preview_digest: reviewedDigest,
+			});
 
-		// Act
-		const acceptance = coordinatorImportInviteAction({
-			inviteValue: invite,
-			dbPath: actionDbPath,
-			keysDir,
-			configPath,
-			recipientActorId: identityId,
-			recipientDisplayName: "Recipient",
-			deviceDisplayName: "Recipient laptop",
-			reviewedOnboardingDigest: `recipient-onboarding-preview-v1:${"a".repeat(64)}`,
-		});
+			// Act
+			const acceptance = coordinatorImportInviteAction({
+				inviteValue: invite,
+				dbPath: actionDbPath,
+				keysDir,
+				configPath,
+				recipientActorId: identityId,
+				recipientDisplayName: "Recipient",
+				deviceDisplayName: "Recipient laptop",
+				reviewedOnboardingDigest: `recipient-onboarding-preview-v1:${"a".repeat(64)}`,
+			});
 
-		// Assert
-		await expect(acceptance).rejects.toThrow("recipient_invite_intent_mismatch");
-		expect(localSnapshot()).toBe(beforeDb);
-		expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
-	});
+			// Assert
+			await expect(acceptance).rejects.toThrow("recipient_invite_intent_mismatch");
+			expect(localSnapshot()).toBe(beforeDb);
+			expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
+		},
+	);
 
 	it.each([
 		{
@@ -2986,101 +2987,104 @@ describe("coordinator local admin actions", () => {
 			targetId: "identity-recipient-device",
 			identityId: "identity-recipient-device",
 		},
-	])("rejects a conflicting $kind response Identity after valid inspection without local persistence", async (testCase) => {
-		const actionDbPath = join(tmpDir, `recipient-post-join-${testCase.kind}-mismatch.sqlite`);
-		const keysDir = join(tmpDir, `recipient-post-join-${testCase.kind}-mismatch-keys`);
-		const configPath = join(tmpDir, `recipient-post-join-${testCase.kind}-mismatch-config.json`);
-		const token = `recipient-post-join-${testCase.kind}-mismatch-token`;
-		const originalConfig = {
-			actor_id: testCase.identityId,
-			sync_coordinator_groups: ["existing-group"],
-		};
-		writeCodememConfigFile(originalConfig, configPath);
-		const reviewedIntent =
-			testCase.kind === "team_member"
-				? teamReviewedIntent(testCase.targetId)
-				: addDeviceReviewedIntent(testCase.targetId);
-		const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
-		const reviewedOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
-			dbPath: actionDbPath,
-			keysDir,
-			invitationId: token,
-			identityId: testCase.identityId,
-			deviceDisplayName: "Recipient laptop",
-			reviewedIntent,
-		});
-		const validResponse = {
-			ok: true,
-			status: "accepted",
-			kind: testCase.kind,
-			group_id: "coordinator-a",
-			identity_id: testCase.identityId,
-			policy_team_id: testCase.kind === "team_member" ? testCase.targetId : null,
-			target_identity_id: testCase.kind === "add_device" ? testCase.targetId : null,
-			assigned_identity_id: testCase.kind === "team_member" ? testCase.identityId : null,
-			reviewed_preview_digest: reviewedDigest,
-			reviewed_intent: reviewedIntent,
-		};
-		const requestedUrls: string[] = [];
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(async (url: string | URL) => {
-				const requestedUrl = String(url);
-				requestedUrls.push(requestedUrl);
-				return new Response(
-					JSON.stringify(
-						requestedUrl.endsWith("/v1/invites/inspect")
-							? validResponse
-							: { ...validResponse, identity_id: "identity-other" },
-					),
-					{ status: 200 },
-				);
-			}),
-		);
-		const invite = encodeInvitePayload({
-			v: 1,
-			kind: testCase.kind,
-			coordinator_url: "https://coord.example.test",
-			group_id: "coordinator-a",
-			policy: "auto_admit",
-			token,
-			expires_at: "2099-01-01T00:00:00.000Z",
-			team_name: null,
-			...(testCase.kind === "team_member"
-				? {
-						policy_team_id: testCase.targetId,
-						assigned_identity_id: testCase.identityId,
-					}
-				: { target_identity_id: testCase.targetId }),
-			reviewed_preview_digest: reviewedDigest,
-		});
-
-		await expect(
-			coordinatorImportInviteAction({
-				inviteValue: invite,
+	])(
+		"rejects a conflicting $kind response Identity after valid inspection without local persistence",
+		async (testCase) => {
+			const actionDbPath = join(tmpDir, `recipient-post-join-${testCase.kind}-mismatch.sqlite`);
+			const keysDir = join(tmpDir, `recipient-post-join-${testCase.kind}-mismatch-keys`);
+			const configPath = join(tmpDir, `recipient-post-join-${testCase.kind}-mismatch-config.json`);
+			const token = `recipient-post-join-${testCase.kind}-mismatch-token`;
+			const originalConfig = {
+				actor_id: testCase.identityId,
+				sync_coordinator_groups: ["existing-group"],
+			};
+			writeCodememConfigFile(originalConfig, configPath);
+			const reviewedIntent =
+				testCase.kind === "team_member"
+					? teamReviewedIntent(testCase.targetId)
+					: addDeviceReviewedIntent(testCase.targetId);
+			const reviewedDigest = await recipientReviewedIntentDigest(reviewedIntent);
+			const reviewedOnboardingDigest = reviewedOnboardingDigestForRecipientInvite({
 				dbPath: actionDbPath,
 				keysDir,
-				configPath,
-				recipientActorId: testCase.identityId,
-				recipientDisplayName: "Recipient",
+				invitationId: token,
+				identityId: testCase.identityId,
 				deviceDisplayName: "Recipient laptop",
-				reviewedOnboardingDigest,
-			}),
-		).rejects.toThrow("recipient_invite_intent_mismatch");
-		expect(requestedUrls).toEqual([
-			"https://coord.example.test/v1/invites/inspect",
-			"https://coord.example.test/v1/join",
-		]);
-		const db = connect(actionDbPath);
-		try {
-			expect(db.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
-			expect(db.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get()).toBe(0);
-			expect(db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(0);
-		} finally {
-			db.close();
-		}
-		expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
-	});
+				reviewedIntent,
+			});
+			const validResponse = {
+				ok: true,
+				status: "accepted",
+				kind: testCase.kind,
+				group_id: "coordinator-a",
+				identity_id: testCase.identityId,
+				policy_team_id: testCase.kind === "team_member" ? testCase.targetId : null,
+				target_identity_id: testCase.kind === "add_device" ? testCase.targetId : null,
+				assigned_identity_id: testCase.kind === "team_member" ? testCase.identityId : null,
+				reviewed_preview_digest: reviewedDigest,
+				reviewed_intent: reviewedIntent,
+			};
+			const requestedUrls: string[] = [];
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async (url: string | URL) => {
+					const requestedUrl = String(url);
+					requestedUrls.push(requestedUrl);
+					return new Response(
+						JSON.stringify(
+							requestedUrl.endsWith("/v1/invites/inspect")
+								? validResponse
+								: { ...validResponse, identity_id: "identity-other" },
+						),
+						{ status: 200 },
+					);
+				}),
+			);
+			const invite = encodeInvitePayload({
+				v: 1,
+				kind: testCase.kind,
+				coordinator_url: "https://coord.example.test",
+				group_id: "coordinator-a",
+				policy: "auto_admit",
+				token,
+				expires_at: "2099-01-01T00:00:00.000Z",
+				team_name: null,
+				...(testCase.kind === "team_member"
+					? {
+							policy_team_id: testCase.targetId,
+							assigned_identity_id: testCase.identityId,
+						}
+					: { target_identity_id: testCase.targetId }),
+				reviewed_preview_digest: reviewedDigest,
+			});
+
+			await expect(
+				coordinatorImportInviteAction({
+					inviteValue: invite,
+					dbPath: actionDbPath,
+					keysDir,
+					configPath,
+					recipientActorId: testCase.identityId,
+					recipientDisplayName: "Recipient",
+					deviceDisplayName: "Recipient laptop",
+					reviewedOnboardingDigest,
+				}),
+			).rejects.toThrow("recipient_invite_intent_mismatch");
+			expect(requestedUrls).toEqual([
+				"https://coord.example.test/v1/invites/inspect",
+				"https://coord.example.test/v1/join",
+			]);
+			const db = connect(actionDbPath);
+			try {
+				expect(db.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+				expect(db.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get()).toBe(0);
+				expect(db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get()).toBe(0);
+			} finally {
+				db.close();
+			}
+			expect(readCodememConfigFileAtPath(configPath)).toEqual(originalConfig);
+		},
+	);
 
 	it("warns when local invite coordinator URL uses private IPv6 space", async () => {
 		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -920,127 +920,133 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 			it.each([
 				{ kind: "team_member" as const, targetId: "policy-team-revoked" },
 				{ kind: "add_device" as const, targetId: "identity-revoked" },
-			])("rejects a revoked $kind invite before first inspection or acceptance", async (testCase) => {
-				await withContext(async ({ store, revokeInvite }) => {
-					// Arrange
-					await store.createGroup("g1", "Coordinator Alpha");
-					const reviewedIntent =
-						testCase.kind === "team_member"
-							? teamReviewedIntent(testCase.targetId)
-							: addDeviceReviewedIntent(testCase.targetId);
-					const invite = await store.createInvite({
-						groupId: "g1",
-						policy: "auto_admit",
-						expiresAt: "2099-01-01T00:00:00Z",
-						inviteKind: testCase.kind,
-						...(testCase.kind === "team_member"
-							? { policyTeamId: testCase.targetId }
-							: { targetIdentityId: testCase.targetId }),
-						reviewedPreviewDigest: await recipientReviewedIntentDigest(reviewedIntent),
-						reviewedIntent,
-					});
-					const acceptance = {
-						token: invite.token,
-						inviteKind: testCase.kind,
-						identityId:
+			])(
+				"rejects a revoked $kind invite before first inspection or acceptance",
+				async (testCase) => {
+					await withContext(async ({ store, revokeInvite }) => {
+						// Arrange
+						await store.createGroup("g1", "Coordinator Alpha");
+						const reviewedIntent =
 							testCase.kind === "team_member"
-								? String(invite.assigned_identity_id)
-								: testCase.targetId,
-						deviceId: "device-recipient",
-						publicKey: "recipient-public-key",
-						fingerprint: fingerprintPublicKey("recipient-public-key"),
-						now: "2026-07-23T00:00:00.000Z",
-					};
-					await revokeInvite(invite.invite_id, "2026-07-22T00:00:00.000Z");
+								? teamReviewedIntent(testCase.targetId)
+								: addDeviceReviewedIntent(testCase.targetId);
+						const invite = await store.createInvite({
+							groupId: "g1",
+							policy: "auto_admit",
+							expiresAt: "2099-01-01T00:00:00Z",
+							inviteKind: testCase.kind,
+							...(testCase.kind === "team_member"
+								? { policyTeamId: testCase.targetId }
+								: { targetIdentityId: testCase.targetId }),
+							reviewedPreviewDigest: await recipientReviewedIntentDigest(reviewedIntent),
+							reviewedIntent,
+						});
+						const acceptance = {
+							token: invite.token,
+							inviteKind: testCase.kind,
+							identityId:
+								testCase.kind === "team_member"
+									? String(invite.assigned_identity_id)
+									: testCase.targetId,
+							deviceId: "device-recipient",
+							publicKey: "recipient-public-key",
+							fingerprint: fingerprintPublicKey("recipient-public-key"),
+							now: "2026-07-23T00:00:00.000Z",
+						};
+						await revokeInvite(invite.invite_id, "2026-07-22T00:00:00.000Z");
 
-					// Act
-					const inspection = store.inspectRecipientInvite({
-						token: invite.token,
-						now: acceptance.now,
-					});
-					const consumption = store.consumeRecipientInvite(acceptance);
+						// Act
+						const inspection = store.inspectRecipientInvite({
+							token: invite.token,
+							now: acceptance.now,
+						});
+						const consumption = store.consumeRecipientInvite(acceptance);
 
-					// Assert
-					await Promise.all([
-						expect(inspection).rejects.toThrow("invite_invalid"),
-						expect(consumption).rejects.toThrow("invite_invalid"),
-					]);
-					expect(await store.getInviteByTokenForInspection(invite.token)).toMatchObject({
-						revoked_at: "2026-07-22T00:00:00.000Z",
-						consumed_at: null,
-						bound_device_id: null,
-						bound_public_key: null,
-						bound_fingerprint: null,
-						recipient_actor_id: null,
+						// Assert
+						await Promise.all([
+							expect(inspection).rejects.toThrow("invite_invalid"),
+							expect(consumption).rejects.toThrow("invite_invalid"),
+						]);
+						expect(await store.getInviteByTokenForInspection(invite.token)).toMatchObject({
+							revoked_at: "2026-07-22T00:00:00.000Z",
+							consumed_at: null,
+							bound_device_id: null,
+							bound_public_key: null,
+							bound_fingerprint: null,
+							recipient_actor_id: null,
+						});
 					});
-				});
-			});
+				},
+			);
 
 			it.each([
 				{ kind: "team_member" as const, targetId: "policy-team-replay" },
 				{ kind: "add_device" as const, targetId: "identity-replay" },
-			])("rejects a revoked $kind invite after an accepted replay without changing its binding", async (testCase) => {
-				await withContext(async ({ store, revokeInvite }) => {
-					// Arrange
-					await store.createGroup("g1", "Coordinator Alpha");
-					const reviewedIntent =
-						testCase.kind === "team_member"
-							? teamReviewedIntent(testCase.targetId)
-							: addDeviceReviewedIntent(testCase.targetId);
-					const invite = await store.createInvite({
-						groupId: "g1",
-						policy: "auto_admit",
-						expiresAt: "2099-01-01T00:00:00Z",
-						inviteKind: testCase.kind,
-						...(testCase.kind === "team_member"
-							? { policyTeamId: testCase.targetId }
-							: { targetIdentityId: testCase.targetId }),
-						reviewedPreviewDigest: await recipientReviewedIntentDigest(reviewedIntent),
-						reviewedIntent,
-					});
-					const acceptance = {
-						token: invite.token,
-						inviteKind: testCase.kind,
-						identityId:
+			])(
+				"rejects a revoked $kind invite after an accepted replay without changing its binding",
+				async (testCase) => {
+					await withContext(async ({ store, revokeInvite }) => {
+						// Arrange
+						await store.createGroup("g1", "Coordinator Alpha");
+						const reviewedIntent =
 							testCase.kind === "team_member"
-								? String(invite.assigned_identity_id)
-								: testCase.targetId,
-						deviceId: "device-recipient",
-						publicKey: "recipient-public-key",
-						fingerprint: fingerprintPublicKey("recipient-public-key"),
-						now: "2026-07-23T00:00:00.000Z",
-					};
-					expect((await store.consumeRecipientInvite(acceptance)).status).toBe("accepted");
-					expect((await store.consumeRecipientInvite(acceptance)).status).toBe("existing");
-					const boundBeforeRevocation = await store.getInviteByTokenForInspection(invite.token);
-					await revokeInvite(invite.invite_id, "2026-07-23T00:00:01.000Z");
+								? teamReviewedIntent(testCase.targetId)
+								: addDeviceReviewedIntent(testCase.targetId);
+						const invite = await store.createInvite({
+							groupId: "g1",
+							policy: "auto_admit",
+							expiresAt: "2099-01-01T00:00:00Z",
+							inviteKind: testCase.kind,
+							...(testCase.kind === "team_member"
+								? { policyTeamId: testCase.targetId }
+								: { targetIdentityId: testCase.targetId }),
+							reviewedPreviewDigest: await recipientReviewedIntentDigest(reviewedIntent),
+							reviewedIntent,
+						});
+						const acceptance = {
+							token: invite.token,
+							inviteKind: testCase.kind,
+							identityId:
+								testCase.kind === "team_member"
+									? String(invite.assigned_identity_id)
+									: testCase.targetId,
+							deviceId: "device-recipient",
+							publicKey: "recipient-public-key",
+							fingerprint: fingerprintPublicKey("recipient-public-key"),
+							now: "2026-07-23T00:00:00.000Z",
+						};
+						expect((await store.consumeRecipientInvite(acceptance)).status).toBe("accepted");
+						expect((await store.consumeRecipientInvite(acceptance)).status).toBe("existing");
+						const boundBeforeRevocation = await store.getInviteByTokenForInspection(invite.token);
+						await revokeInvite(invite.invite_id, "2026-07-23T00:00:01.000Z");
 
-					// Act
-					const inspection = store.inspectRecipientInvite({
-						token: invite.token,
-						now: "2026-07-23T00:00:02.000Z",
-					});
-					const replay = store.consumeRecipientInvite({
-						...acceptance,
-						now: "2026-07-23T00:00:02.000Z",
-					});
+						// Act
+						const inspection = store.inspectRecipientInvite({
+							token: invite.token,
+							now: "2026-07-23T00:00:02.000Z",
+						});
+						const replay = store.consumeRecipientInvite({
+							...acceptance,
+							now: "2026-07-23T00:00:02.000Z",
+						});
 
-					// Assert
-					await Promise.all([
-						expect(inspection).rejects.toThrow("invite_invalid"),
-						expect(replay).rejects.toThrow("invite_invalid"),
-					]);
-					const boundAfterRevocation = await store.getInviteByTokenForInspection(invite.token);
-					expect(boundAfterRevocation).toMatchObject({
-						revoked_at: "2026-07-23T00:00:01.000Z",
-						consumed_at: boundBeforeRevocation?.consumed_at,
-						bound_device_id: boundBeforeRevocation?.bound_device_id,
-						bound_public_key: boundBeforeRevocation?.bound_public_key,
-						bound_fingerprint: boundBeforeRevocation?.bound_fingerprint,
-						recipient_actor_id: boundBeforeRevocation?.recipient_actor_id,
+						// Assert
+						await Promise.all([
+							expect(inspection).rejects.toThrow("invite_invalid"),
+							expect(replay).rejects.toThrow("invite_invalid"),
+						]);
+						const boundAfterRevocation = await store.getInviteByTokenForInspection(invite.token);
+						expect(boundAfterRevocation).toMatchObject({
+							revoked_at: "2026-07-23T00:00:01.000Z",
+							consumed_at: boundBeforeRevocation?.consumed_at,
+							bound_device_id: boundBeforeRevocation?.bound_device_id,
+							bound_public_key: boundBeforeRevocation?.bound_public_key,
+							bound_fingerprint: boundBeforeRevocation?.bound_fingerprint,
+							recipient_actor_id: boundBeforeRevocation?.recipient_actor_id,
+						});
 					});
-				});
-			});
+				},
+			);
 
 			it("persists, enrolls, and single-use binds explicit Team and add-device invitations without scope membership", async () => {
 				await withContext(async ({ store }) => {

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -1727,15 +1727,15 @@ describe("ensureAdditiveSchemaCompatibility schema-compat gate", () => {
 			error:
 				"recipient_policy_device_eligibility_schema_incompatible:policy_team_device_decisions.assignment_version",
 		},
-	] as const)("surfaces a bounded compatibility error when $label repair is unavailable", ({
-		mutate,
-		error,
-	}) => {
-		ensureAdditiveSchemaCompatibility(db);
-		mutate(db);
+	] as const)(
+		"surfaces a bounded compatibility error when $label repair is unavailable",
+		({ mutate, error }) => {
+			ensureAdditiveSchemaCompatibility(db);
+			mutate(db);
 
-		expect(() => ensureAdditiveSchemaCompatibility(db)).toThrow(error);
-	});
+			expect(() => ensureAdditiveSchemaCompatibility(db)).toThrow(error);
+		},
+	);
 
 	it("replaces a raw additive-DDL failure with the bounded compatibility error", () => {
 		ensureAdditiveSchemaCompatibility(db);

--- a/packages/core/src/device-identity-binding.test.ts
+++ b/packages/core/src/device-identity-binding.test.ts
@@ -348,43 +348,47 @@ describe("device Identity binding", () => {
 	it.each([
 		{ status: "deactivated", mergedIntoIdentityId: null },
 		{ status: "merged", mergedIntoIdentityId: "identity-local" },
-	])("rejects an exact retry after its target identity becomes $status", ({
-		status,
-		mergedIntoIdentityId,
-	}) => {
-		const request = {
-			bindings: [
-				{
-					deviceId: "device-peer",
-					targetIdentityId: "identity-other",
-					confirmed: true,
-				},
-			],
-		};
-		const preview = previewDeviceIdentityBindings(db, inventoryInput, request);
-		const commit = { ...request, reviewedInventoryDigest: preview.reviewedInventoryDigest };
-		expect(commitDeviceIdentityBindings(db, context, inventoryInput, commit)).toMatchObject({
-			status: "applied",
-			writeCount: 1,
-			idempotent: false,
-		});
-		db.prepare(
-			"UPDATE actors SET status = ?, merged_into_actor_id = ? WHERE actor_id = 'identity-other'",
-		).run(status, mergedIntoIdentityId);
+	])(
+		"rejects an exact retry after its target identity becomes $status",
+		({ status, mergedIntoIdentityId }) => {
+			const request = {
+				bindings: [
+					{
+						deviceId: "device-peer",
+						targetIdentityId: "identity-other",
+						confirmed: true,
+					},
+				],
+			};
+			const preview = previewDeviceIdentityBindings(db, inventoryInput, request);
+			const commit = { ...request, reviewedInventoryDigest: preview.reviewedInventoryDigest };
+			expect(commitDeviceIdentityBindings(db, context, inventoryInput, commit)).toMatchObject({
+				status: "applied",
+				writeCount: 1,
+				idempotent: false,
+			});
+			db.prepare(
+				"UPDATE actors SET status = ?, merged_into_actor_id = ? WHERE actor_id = 'identity-other'",
+			).run(status, mergedIntoIdentityId);
 
-		expect(commitDeviceIdentityBindings(db, context, inventoryInput, commit)).toMatchObject({
-			status: "stale",
-			errorCode: "binding_retry_stale",
-			writeCount: 0,
-			idempotent: false,
-		});
-		expect(
-			db
-				.prepare("SELECT identity_id, status FROM identity_devices WHERE device_id = 'device-peer'")
-				.get(),
-		).toEqual({ identity_id: "identity-other", status: "active" });
-		expect(db.prepare("SELECT COUNT(*) FROM device_identity_binding_audit").pluck().get()).toBe(1);
-	});
+			expect(commitDeviceIdentityBindings(db, context, inventoryInput, commit)).toMatchObject({
+				status: "stale",
+				errorCode: "binding_retry_stale",
+				writeCount: 0,
+				idempotent: false,
+			});
+			expect(
+				db
+					.prepare(
+						"SELECT identity_id, status FROM identity_devices WHERE device_id = 'device-peer'",
+					)
+					.get(),
+			).toEqual({ identity_id: "identity-other", status: "active" });
+			expect(db.prepare("SELECT COUNT(*) FROM device_identity_binding_audit").pluck().get()).toBe(
+				1,
+			);
+		},
+	);
 
 	it("rejects an exact retry after device evidence becomes conflicted", () => {
 		const request = {

--- a/packages/core/src/embeddings.test.ts
+++ b/packages/core/src/embeddings.test.ts
@@ -81,14 +81,12 @@ describe("embeddingDataToFloat32", () => {
 		expect(() => embeddingDataToFloat32(new BigInt64Array([1n]))).toThrow(TypeError);
 	});
 
-	it.each([
-		Number.NaN,
-		Number.POSITIVE_INFINITY,
-		Number.NEGATIVE_INFINITY,
-		Number.MAX_VALUE,
-	])("rejects non-finite or unrepresentable data: %s", (value) => {
-		expect(() => embeddingDataToFloat32([value])).toThrow(TypeError);
-	});
+	it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.MAX_VALUE])(
+		"rejects non-finite or unrepresentable data: %s",
+		(value) => {
+			expect(() => embeddingDataToFloat32([value])).toThrow(TypeError);
+		},
+	);
 });
 
 describe("serializeFloat32", () => {

--- a/packages/core/src/extraction-eval.test.ts
+++ b/packages/core/src/extraction-eval.test.ts
@@ -45,56 +45,57 @@ describe("session extraction eval", () => {
 		);
 	});
 
-	it.each([
-		0, 1, 5,
-	])("does not fail rich-batch output solely because it has %i observations", (observationCount) => {
-		// Arrange
-		const scenario = getSessionExtractionEvalScenario("rich-batch-shape");
-		if (!scenario) throw new Error("scenario missing");
-		const observations = Array.from({ length: observationCount }, (_, index) => ({
-			id: index + 2,
-			kind: "decision",
-			title: `Durable decision ${index + 1}`,
-			bodyText: "A reusable decision that cleared the worthiness bar.",
-			active: true,
-			createdAt: "2026-04-07T06:13:46.000Z",
-			metadata: {},
-		}));
+	it.each([0, 1, 5])(
+		"does not fail rich-batch output solely because it has %i observations",
+		(observationCount) => {
+			// Arrange
+			const scenario = getSessionExtractionEvalScenario("rich-batch-shape");
+			if (!scenario) throw new Error("scenario missing");
+			const observations = Array.from({ length: observationCount }, (_, index) => ({
+				id: index + 2,
+				kind: "decision",
+				title: `Durable decision ${index + 1}`,
+				bodyText: "A reusable decision that cleared the worthiness bar.",
+				active: true,
+				createdAt: "2026-04-07T06:13:46.000Z",
+				metadata: {},
+			}));
 
-		// Act
-		const result = evaluateSessionExtractionItems(
-			{ type: "batch", sessionId: 166405, batchId: 18503 },
-			{
-				id: 166405,
-				project: "codemem",
-				cwd: "/tmp/repo",
-				startedAt: "2026-04-06T21:23:59.631Z",
-				endedAt: "2026-04-07T06:13:45.667Z",
-				sessionClass: "durable",
-				summaryDisposition: "stored",
-			},
-			[
+			// Act
+			const result = evaluateSessionExtractionItems(
+				{ type: "batch", sessionId: 166405, batchId: 18503 },
 				{
-					id: 1,
-					kind: "session_summary",
-					title: "Rich batch summary",
-					bodyText: "A broad, usable summary of the completed work.",
-					active: true,
-					createdAt: "2026-04-07T06:13:45.667Z",
-					metadata: {},
+					id: 166405,
+					project: "codemem",
+					cwd: "/tmp/repo",
+					startedAt: "2026-04-06T21:23:59.631Z",
+					endedAt: "2026-04-07T06:13:45.667Z",
+					sessionClass: "durable",
+					summaryDisposition: "stored",
 				},
-				...observations,
-			],
-			scenario,
-		);
+				[
+					{
+						id: 1,
+						kind: "session_summary",
+						title: "Rich batch summary",
+						bodyText: "A broad, usable summary of the completed work.",
+						active: true,
+						createdAt: "2026-04-07T06:13:45.667Z",
+						metadata: {},
+					},
+					...observations,
+				],
+				scenario,
+			);
 
-		// Assert
-		expect(result.pass).toBe(true);
-		expect(result.counts.observations).toBe(observationCount);
-		expect(result.failureReasons).not.toEqual(
-			expect.arrayContaining([expect.stringContaining("observation count")]),
-		);
-	});
+			// Assert
+			expect(result.pass).toBe(true);
+			expect(result.counts.observations).toBe(observationCount);
+			expect(result.failureReasons).not.toEqual(
+				expect.arrayContaining([expect.stringContaining("observation count")]),
+			);
+		},
+	);
 
 	it("still fails routine-batch output that emits an observation", () => {
 		// Arrange

--- a/packages/core/src/extraction-tier-routing.test.ts
+++ b/packages/core/src/extraction-tier-routing.test.ts
@@ -146,29 +146,32 @@ describe("extraction tier routing", () => {
 	it.each([
 		["simple", 12, 1, "gpt-5.4-mini"],
 		["rich", 153, 12, "gpt-5.4"],
-	] as const)("prefers configured legacy OpenAI models and reasoning over %s-tier defaults", (tier, eventSpan, toolCount, expectedModel) => {
-		const decision = decideExtractionReplayTier({
-			batchId: 19001,
-			sessionId: 200001,
-			eventSpan,
-			promptCount: tier === "rich" ? 4 : 1,
-			toolCount,
-			transcriptLength: tier === "rich" ? 2800 : 320,
-		});
-		const config = buildTieredObserverConfig(
-			baseConfig({
-				observerSimpleModel: "gpt-5.4-mini",
-				observerRichModel: "gpt-5.4",
-				observerReasoningEffort: "low",
-				observerReasoningSummary: "auto",
-			}),
-			decision,
-		);
+	] as const)(
+		"prefers configured legacy OpenAI models and reasoning over %s-tier defaults",
+		(tier, eventSpan, toolCount, expectedModel) => {
+			const decision = decideExtractionReplayTier({
+				batchId: 19001,
+				sessionId: 200001,
+				eventSpan,
+				promptCount: tier === "rich" ? 4 : 1,
+				toolCount,
+				transcriptLength: tier === "rich" ? 2800 : 320,
+			});
+			const config = buildTieredObserverConfig(
+				baseConfig({
+					observerSimpleModel: "gpt-5.4-mini",
+					observerRichModel: "gpt-5.4",
+					observerReasoningEffort: "low",
+					observerReasoningSummary: "auto",
+				}),
+				decision,
+			);
 
-		expect(config.observerModel).toBe(expectedModel);
-		expect(config.observerReasoningEffort).toBe("low");
-		expect(config.observerReasoningSummary).toBe("auto");
-	});
+			expect(config.observerModel).toBe(expectedModel);
+			expect(config.observerReasoningEffort).toBe("low");
+			expect(config.observerReasoningSummary).toBe("auto");
+		},
+	);
 
 	it("prefers the rich-tier reasoning override over the legacy base setting", () => {
 		const decision = decideExtractionReplayTier({
@@ -508,32 +511,35 @@ describe("extraction tier routing", () => {
 	it.each([
 		["simple", 12, 1],
 		["rich", 153, 12],
-	] as const)("uses chat completions without reasoning metadata for a custom OpenAI-compatible %s tier", (tier, eventSpan, toolCount) => {
-		const decision = decideExtractionReplayTier({
-			batchId: 19001,
-			sessionId: 200001,
-			eventSpan,
-			promptCount: tier === "rich" ? 4 : 1,
-			toolCount,
-			transcriptLength: tier === "rich" ? 2800 : 320,
-		});
-		const selection = buildTieredObserverSelection(
-			baseConfig({
-				observerBaseUrl: "https://gateway.example.test/v1",
-				observerOpenAIUseResponses: false,
-				observerReasoningEffort: "high",
-				observerReasoningSummary: "detailed",
-				observerRichReasoningEffort: "high",
-				observerRichReasoningSummary: "detailed",
-				observerExplicitConfigKeys: ["observerOpenAIUseResponses"],
-			}),
-			decision,
-		);
+	] as const)(
+		"uses chat completions without reasoning metadata for a custom OpenAI-compatible %s tier",
+		(tier, eventSpan, toolCount) => {
+			const decision = decideExtractionReplayTier({
+				batchId: 19001,
+				sessionId: 200001,
+				eventSpan,
+				promptCount: tier === "rich" ? 4 : 1,
+				toolCount,
+				transcriptLength: tier === "rich" ? 2800 : 320,
+			});
+			const selection = buildTieredObserverSelection(
+				baseConfig({
+					observerBaseUrl: "https://gateway.example.test/v1",
+					observerOpenAIUseResponses: false,
+					observerReasoningEffort: "high",
+					observerReasoningSummary: "detailed",
+					observerRichReasoningEffort: "high",
+					observerRichReasoningSummary: "detailed",
+					observerExplicitConfigKeys: ["observerOpenAIUseResponses"],
+				}),
+				decision,
+			);
 
-		expect(selection.observer.observerOpenAIUseResponses).toBe(false);
-		expect(selection.observer.observerReasoningEffort).toBeNull();
-		expect(selection.observer.observerReasoningSummary).toBeNull();
-	});
+			expect(selection.observer.observerOpenAIUseResponses).toBe(false);
+			expect(selection.observer.observerReasoningEffort).toBeNull();
+			expect(selection.observer.observerReasoningSummary).toBeNull();
+		},
+	);
 
 	it("does not record fallback on claude_sidecar when provider was not explicitly requested", () => {
 		const decision = decideExtractionReplayTier({

--- a/packages/core/src/legacy-recipient-policy-projection.test.ts
+++ b/packages/core/src/legacy-recipient-policy-projection.test.ts
@@ -175,23 +175,20 @@ describe("legacy recipient-policy projection", () => {
 
 	afterEach(() => db.close());
 
-	it.each([
-		"/",
-		"C:\\",
-		"//server/share",
-		"file://server/share",
-		"file:////server/share",
-	])("excludes filesystem-root Project %s from recipient review", (identity) => {
-		mapProject(db, identity, "local-default", "root-project");
+	it.each(["/", "C:\\", "//server/share", "file://server/share", "file:////server/share"])(
+		"excludes filesystem-root Project %s from recipient review",
+		(identity) => {
+			mapProject(db, identity, "local-default", "root-project");
 
-		expect(projections(db)).toEqual([]);
-		expect(
-			listLegacyTeamProjectEvidence(db, {
-				localActorId: LOCAL_ACTOR_ID,
-				localDeviceId: LOCAL_DEVICE_ID,
-			}),
-		).toEqual([]);
-	});
+			expect(projections(db)).toEqual([]);
+			expect(
+				listLegacyTeamProjectEvidence(db, {
+					localActorId: LOCAL_ACTOR_ID,
+					localDeviceId: LOCAL_DEVICE_ID,
+				}),
+			).toEqual([]);
+		},
+	);
 
 	it("projects one exact canonical Project from one active managed scope", () => {
 		const scopeId = "managed-project-one";

--- a/packages/core/src/legacy-team-candidate.test.ts
+++ b/packages/core/src/legacy-team-candidate.test.ts
@@ -1336,46 +1336,46 @@ describe("legacy Team candidate discovery", () => {
 		);
 	});
 
-	it.each([
-		"/",
-		null,
-	])("reconciles non-root edges without restoring a retired root resolved as %s", (rootResolution) => {
-		const completion = completeCandidate();
-		db.prepare(
-			"UPDATE policy_teams SET provenance = 'legacy_team_candidate' WHERE team_id = ?",
-		).run(completion.teamId);
-		db.prepare(
-			`INSERT INTO legacy_team_setup_draft_projects(
+	it.each(["/", null])(
+		"reconciles non-root edges without restoring a retired root resolved as %s",
+		(rootResolution) => {
+			const completion = completeCandidate();
+			db.prepare(
+				"UPDATE policy_teams SET provenance = 'legacy_team_candidate' WHERE team_id = ?",
+			).run(completion.teamId);
+			db.prepare(
+				`INSERT INTO legacy_team_setup_draft_projects(
 				 attempt_id, project_ref, source_project_identity, display_name,
 				 source_fingerprint, resolution_kind, resolved_project_identity,
 				 target_scope_id, updated_at
 				 ) VALUES (?, '000-root', '/', 'Filesystem root', 'root-source',
 				 'explicit', ?, 'scope-api', ?)`,
-		).run(completion.attemptId, rootResolution, NOW);
-		db.prepare(
-			"DELETE FROM project_recipients WHERE canonical_project_identity = ? AND recipient_id = ?",
-		).run(PROJECT_ID, completion.teamId);
+			).run(completion.attemptId, rootResolution, NOW);
+			db.prepare(
+				"DELETE FROM project_recipients WHERE canonical_project_identity = ? AND recipient_id = ?",
+			).run(PROJECT_ID, completion.teamId);
 
-		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
-		expect(
-			db
-				.prepare(
-					`SELECT COUNT(*) FROM project_recipients
+			expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
+			expect(
+				db
+					.prepare(
+						`SELECT COUNT(*) FROM project_recipients
 						 WHERE canonical_project_identity = ? AND recipient_id = ? AND status = 'active'`,
-				)
-				.pluck()
-				.get(PROJECT_ID, completion.teamId),
-		).toBe(1);
-		expect(
-			db
-				.prepare(
-					`SELECT COUNT(*) FROM project_recipients
+					)
+					.pluck()
+					.get(PROJECT_ID, completion.teamId),
+			).toBe(1);
+			expect(
+				db
+					.prepare(
+						`SELECT COUNT(*) FROM project_recipients
 						 WHERE canonical_project_identity = '/' AND recipient_id = ?`,
-				)
-				.pluck()
-				.get(completion.teamId),
-		).toBe(0);
-	});
+					)
+					.pluck()
+					.get(completion.teamId),
+			).toBe(0);
+		},
+	);
 
 	it("keeps validating a retired root source resolved to a non-root Project", () => {
 		const completion = completeCandidate();

--- a/packages/core/src/legacy-team-project-policy.test.ts
+++ b/packages/core/src/legacy-team-project-policy.test.ts
@@ -15,13 +15,12 @@ describe("isMigratableLegacyTeamProjectIdentity", () => {
 		expect(isMigratableLegacyTeamProjectIdentity(identity)).toBe(false);
 	});
 
-	it.each([
-		"shared:team",
-		"shared:workspace-only",
-		"https://example.invalid/project.git",
-	])("accepts canonical Project identity %s", (identity) => {
-		expect(isMigratableLegacyTeamProjectIdentity(identity)).toBe(true);
-	});
+	it.each(["shared:team", "shared:workspace-only", "https://example.invalid/project.git"])(
+		"accepts canonical Project identity %s",
+		(identity) => {
+			expect(isMigratableLegacyTeamProjectIdentity(identity)).toBe(true);
+		},
+	);
 
 	it("accepts peer-prefixed identities only when local inventory proves ownership", () => {
 		const db = new Database(":memory:");

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -498,47 +498,47 @@ describe("legacy Team setup activation", () => {
 		);
 	});
 
-	it.each([
-		"unresolved device",
-		"unresolved Project",
-	] as const)("rejects an incomplete draft with no canonical writes: %s", (label) => {
-		// Arrange
-		let draft = refreshLegacyTeamSetupDraft(db, snapshot());
-		if (label === "unresolved device") {
-			draft = setLegacyTeamSetupProjectMapping(db, {
-				attemptId: draft.attemptId,
-				projectRef: "project-ref-b",
-				resolvedProjectIdentity: PROJECT_B,
-				now: NOW,
-			});
-		} else {
-			for (const [index, identityId] of ["identity-a", "identity-b"].entries()) {
-				const device = draft.devices[index];
-				if (!device) throw new Error("invalid activation fixture");
-				draft = setLegacyTeamSetupDeviceAssignment(db, {
+	it.each(["unresolved device", "unresolved Project"] as const)(
+		"rejects an incomplete draft with no canonical writes: %s",
+		(label) => {
+			// Arrange
+			let draft = refreshLegacyTeamSetupDraft(db, snapshot());
+			if (label === "unresolved device") {
+				draft = setLegacyTeamSetupProjectMapping(db, {
 					attemptId: draft.attemptId,
-					deviceRef: device.deviceRef,
-					targetIdentityId: identityId,
-					expectation: device.expectation,
+					projectRef: "project-ref-b",
+					resolvedProjectIdentity: PROJECT_B,
 					now: NOW,
 				});
-				draft = setLegacyTeamSetupDeviceDecision(db, {
-					attemptId: draft.attemptId,
-					deviceRef: device.deviceRef,
-					decision: "included",
-					now: NOW,
-				});
+			} else {
+				for (const [index, identityId] of ["identity-a", "identity-b"].entries()) {
+					const device = draft.devices[index];
+					if (!device) throw new Error("invalid activation fixture");
+					draft = setLegacyTeamSetupDeviceAssignment(db, {
+						attemptId: draft.attemptId,
+						deviceRef: device.deviceRef,
+						targetIdentityId: identityId,
+						expectation: device.expectation,
+						now: NOW,
+					});
+					draft = setLegacyTeamSetupDeviceDecision(db, {
+						attemptId: draft.attemptId,
+						deviceRef: device.deviceRef,
+						decision: "included",
+						now: NOW,
+					});
+				}
 			}
-		}
 
-		// Act
-		const operation = () => preview(draft);
+			// Act
+			const operation = () => preview(draft);
 
-		// Assert
-		expect(operation).toThrow("team_setup_incomplete");
-		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
-		expect(db.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
-	});
+			// Assert
+			expect(operation).toThrow("team_setup_incomplete");
+			expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+			expect(db.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get()).toBe(0);
+		},
+	);
 
 	it("keeps read-only inspection from persisting activation errors", () => {
 		const draft = refreshLegacyTeamSetupDraft(db, snapshot());
@@ -1406,85 +1406,85 @@ describe("legacy Team setup activation", () => {
 		).toBe("scope-engineering-2");
 	});
 
-	it.each([
-		"unresolved",
-		"included",
-	] as const)("settles a %s invite decision to excluded when its device is removed", async (initialDecision) => {
-		// Arrange: a completed setup with an invite-owned decision for a roster
-		// device that later gets removed. The reviewed removal retires the
-		// device's access: `unresolved` would reopen setup forever and
-		// `included` would keep granting Project access to a removed device.
-		await finish(readyDraft());
-		const teamId = deterministicPolicyTeamId(CANDIDATE);
-		db.prepare(
-			`INSERT INTO policy_team_device_decisions(
+	it.each(["unresolved", "included"] as const)(
+		"settles a %s invite decision to excluded when its device is removed",
+		async (initialDecision) => {
+			// Arrange: a completed setup with an invite-owned decision for a roster
+			// device that later gets removed. The reviewed removal retires the
+			// device's access: `unresolved` would reopen setup forever and
+			// `included` would keep granting Project access to a removed device.
+			await finish(readyDraft());
+			const teamId = deterministicPolicyTeamId(CANDIDATE);
+			db.prepare(
+				`INSERT INTO policy_team_device_decisions(
 			 team_id, device_id, decision, assignment_version, provenance, revision,
 			 created_at, updated_at
 			 ) VALUES (?, 'device-b', ?, 0, 'coordinator_invite', 'invite-r1', ?, ?)
 			 ON CONFLICT(team_id, device_id) DO UPDATE SET
 			 decision = excluded.decision, provenance = 'coordinator_invite', revision = 'invite-r1'`,
-		).run(teamId, initialDecision, NOW, NOW);
-		let draft = refreshLegacyTeamSetupDraft(db, {
-			...snapshot(),
-			devices: [
-				{ deviceId: "device-a", fingerprint: "key-a", displayName: "Laptop", enabled: true },
-				{ deviceId: "device-b", fingerprint: "key-b", displayName: "Desktop", enabled: false },
-			],
-		});
-		for (const device of draft.devices) {
-			if (device.displayName === "Laptop") {
-				draft = setLegacyTeamSetupDeviceAssignment(db, {
-					attemptId: draft.attemptId,
-					deviceRef: device.deviceRef,
-					targetIdentityId: "identity-a",
-					expectation: device.expectation,
-					now: NOW,
-				});
-				draft = setLegacyTeamSetupDeviceDecision(db, {
-					attemptId: draft.attemptId,
-					deviceRef: device.deviceRef,
-					decision: "included",
-					now: NOW,
-				});
-			} else {
-				draft = setLegacyTeamSetupDeviceDecision(db, {
-					attemptId: draft.attemptId,
-					deviceRef: device.deviceRef,
-					decision: "removed",
-					now: NOW,
-				});
+			).run(teamId, initialDecision, NOW, NOW);
+			let draft = refreshLegacyTeamSetupDraft(db, {
+				...snapshot(),
+				devices: [
+					{ deviceId: "device-a", fingerprint: "key-a", displayName: "Laptop", enabled: true },
+					{ deviceId: "device-b", fingerprint: "key-b", displayName: "Desktop", enabled: false },
+				],
+			});
+			for (const device of draft.devices) {
+				if (device.displayName === "Laptop") {
+					draft = setLegacyTeamSetupDeviceAssignment(db, {
+						attemptId: draft.attemptId,
+						deviceRef: device.deviceRef,
+						targetIdentityId: "identity-a",
+						expectation: device.expectation,
+						now: NOW,
+					});
+					draft = setLegacyTeamSetupDeviceDecision(db, {
+						attemptId: draft.attemptId,
+						deviceRef: device.deviceRef,
+						decision: "included",
+						now: NOW,
+					});
+				} else {
+					draft = setLegacyTeamSetupDeviceDecision(db, {
+						attemptId: draft.attemptId,
+						deviceRef: device.deviceRef,
+						decision: "removed",
+						now: NOW,
+					});
+				}
 			}
-		}
-		draft = setLegacyTeamSetupProjectMapping(db, {
-			attemptId: draft.attemptId,
-			projectRef: "project-ref-b",
-			resolvedProjectIdentity: PROJECT_B,
-			now: NOW,
-		});
-		expect(draft.canFinish).toBe(true);
+			draft = setLegacyTeamSetupProjectMapping(db, {
+				attemptId: draft.attemptId,
+				projectRef: "project-ref-b",
+				resolvedProjectIdentity: PROJECT_B,
+				now: NOW,
+			});
+			expect(draft.canFinish).toBe(true);
 
-		// Act
-		const result = await finish(
-			draft,
-			preview(draft),
-			vi.fn(async () => [
-				{ deviceId: "device-a", fingerprint: "key-a", displayName: "Laptop", enabled: true },
-				{ deviceId: "device-b", fingerprint: "key-b", displayName: "Desktop", enabled: false },
-			]),
-		);
+			// Act
+			const result = await finish(
+				draft,
+				preview(draft),
+				vi.fn(async () => [
+					{ deviceId: "device-a", fingerprint: "key-a", displayName: "Laptop", enabled: true },
+					{ deviceId: "device-b", fingerprint: "key-b", displayName: "Desktop", enabled: false },
+				]),
+			);
 
-		// Assert: the invite decision settles to the non-granting resolved
-		// state instead of blocking Ready forever or being revoked outright.
-		expect(result).toMatchObject({ status: "completed" });
-		expect(
-			db
-				.prepare(
-					`SELECT decision, provenance FROM policy_team_device_decisions
+			// Assert: the invite decision settles to the non-granting resolved
+			// state instead of blocking Ready forever or being revoked outright.
+			expect(result).toMatchObject({ status: "completed" });
+			expect(
+				db
+					.prepare(
+						`SELECT decision, provenance FROM policy_team_device_decisions
 					 WHERE team_id = ? AND device_id = 'device-b'`,
-				)
-				.get(teamId),
-		).toEqual({ decision: "excluded", provenance: "coordinator_invite" });
-	});
+					)
+					.get(teamId),
+			).toEqual({ decision: "excluded", provenance: "coordinator_invite" });
+		},
+	);
 
 	it("settles an unresolved invite decision when its device drops out of the roster", async () => {
 		// Arrange: an invite-owned unresolved decision for a device the

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -297,89 +297,89 @@ describe("legacy Team setup drafts", () => {
 		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(2);
 	});
 
-	describe.each([
-		"needs_setup",
-		"in_progress",
-	] as const)("with an older non-current attempt manually left %s", (state) => {
-		it.each([
-			[
-				"device assignment",
-				(draft: ReturnType<typeof refreshLegacyTeamSetupDraft>) =>
-					setLegacyTeamSetupDeviceAssignment(db, {
-						attemptId: draft.attemptId,
-						deviceRef: draft.devices[0]?.deviceRef as string,
-						targetIdentityId: "identity-a",
-						expectation: { kind: "absent" },
-						now: NOW,
-					}),
-			],
-			[
-				"device decision",
-				(draft: ReturnType<typeof refreshLegacyTeamSetupDraft>) =>
-					setLegacyTeamSetupDeviceDecision(db, {
-						attemptId: draft.attemptId,
-						deviceRef: draft.devices[0]?.deviceRef as string,
-						decision: "excluded",
-						now: NOW,
-					}),
-			],
-			[
-				"Project mapping",
-				(draft: ReturnType<typeof refreshLegacyTeamSetupDraft>) =>
-					setLegacyTeamSetupProjectMapping(db, {
-						attemptId: draft.attemptId,
-						projectRef: "project-ref-b",
-						resolvedProjectIdentity: "https://example.invalid/repo-b.git",
-						now: NOW,
-					}),
-			],
-		] as const)("rejects %s mutations", (_label, mutate) => {
-			// Arrange
-			const older = refreshLegacyTeamSetupDraft(db, snapshot());
-			const current = refreshLegacyTeamSetupDraft(db, snapshot({ fingerprint: `key-${state}` }));
-			db.prepare("UPDATE legacy_team_setup_drafts SET state = ? WHERE attempt_id = ?").run(
-				state,
-				older.attemptId,
-			);
-			const before = {
-				device: db
-					.prepare(
-						`SELECT decision, target_identity_id FROM legacy_team_setup_draft_devices
+	describe.each(["needs_setup", "in_progress"] as const)(
+		"with an older non-current attempt manually left %s",
+		(state) => {
+			it.each([
+				[
+					"device assignment",
+					(draft: ReturnType<typeof refreshLegacyTeamSetupDraft>) =>
+						setLegacyTeamSetupDeviceAssignment(db, {
+							attemptId: draft.attemptId,
+							deviceRef: draft.devices[0]?.deviceRef as string,
+							targetIdentityId: "identity-a",
+							expectation: { kind: "absent" },
+							now: NOW,
+						}),
+				],
+				[
+					"device decision",
+					(draft: ReturnType<typeof refreshLegacyTeamSetupDraft>) =>
+						setLegacyTeamSetupDeviceDecision(db, {
+							attemptId: draft.attemptId,
+							deviceRef: draft.devices[0]?.deviceRef as string,
+							decision: "excluded",
+							now: NOW,
+						}),
+				],
+				[
+					"Project mapping",
+					(draft: ReturnType<typeof refreshLegacyTeamSetupDraft>) =>
+						setLegacyTeamSetupProjectMapping(db, {
+							attemptId: draft.attemptId,
+							projectRef: "project-ref-b",
+							resolvedProjectIdentity: "https://example.invalid/repo-b.git",
+							now: NOW,
+						}),
+				],
+			] as const)("rejects %s mutations", (_label, mutate) => {
+				// Arrange
+				const older = refreshLegacyTeamSetupDraft(db, snapshot());
+				const current = refreshLegacyTeamSetupDraft(db, snapshot({ fingerprint: `key-${state}` }));
+				db.prepare("UPDATE legacy_team_setup_drafts SET state = ? WHERE attempt_id = ?").run(
+					state,
+					older.attemptId,
+				);
+				const before = {
+					device: db
+						.prepare(
+							`SELECT decision, target_identity_id FROM legacy_team_setup_draft_devices
 						 WHERE attempt_id = ? AND device_ref = ?`,
-					)
-					.get(older.attemptId, older.devices[0]?.deviceRef),
-				project: db
-					.prepare(
-						`SELECT resolution_kind, resolved_project_identity
+						)
+						.get(older.attemptId, older.devices[0]?.deviceRef),
+					project: db
+						.prepare(
+							`SELECT resolution_kind, resolved_project_identity
 						 FROM legacy_team_setup_draft_projects
 						 WHERE attempt_id = ? AND project_ref = 'project-ref-b'`,
-					)
-					.get(older.attemptId),
-			};
+						)
+						.get(older.attemptId),
+				};
 
-			// Act
-			const act = () => mutate(older);
+				// Act
+				const act = () => mutate(older);
 
-			// Assert
-			expect(act).toThrow("legacy_team_setup_draft_stale");
-			expect(getLegacyTeamSetupDraft(db, CANDIDATE)?.attemptId).toBe(current.attemptId);
-			expect({
-				device: db
-					.prepare(
-						`SELECT decision, target_identity_id FROM legacy_team_setup_draft_devices
+				// Assert
+				expect(act).toThrow("legacy_team_setup_draft_stale");
+				expect(getLegacyTeamSetupDraft(db, CANDIDATE)?.attemptId).toBe(current.attemptId);
+				expect({
+					device: db
+						.prepare(
+							`SELECT decision, target_identity_id FROM legacy_team_setup_draft_devices
 						 WHERE attempt_id = ? AND device_ref = ?`,
-					)
-					.get(older.attemptId, older.devices[0]?.deviceRef),
-				project: db
-					.prepare(
-						`SELECT resolution_kind, resolved_project_identity
+						)
+						.get(older.attemptId, older.devices[0]?.deviceRef),
+					project: db
+						.prepare(
+							`SELECT resolution_kind, resolved_project_identity
 						 FROM legacy_team_setup_draft_projects
 						 WHERE attempt_id = ? AND project_ref = 'project-ref-b'`,
-					)
-					.get(older.attemptId),
-			}).toEqual(before);
-		});
-	});
+						)
+						.get(older.attemptId),
+				}).toEqual(before);
+			});
+		},
+	);
 
 	it.each([
 		// URLs, scp endpoints, key material
@@ -861,33 +861,33 @@ describe("legacy Team setup drafts", () => {
 		}
 	});
 
-	it.each([
-		"shared:team",
-		"shared:workspace-only",
-	])("accepts named shared Project resolution target %s", (target) => {
-		const draft = refreshLegacyTeamSetupDraft(db, snapshot());
-		const projectRef = draft.projects.find(
-			(project) => project.resolution === "unresolved",
-		)?.projectRef;
-		if (!projectRef) throw new Error("invalid test fixture");
+	it.each(["shared:team", "shared:workspace-only"])(
+		"accepts named shared Project resolution target %s",
+		(target) => {
+			const draft = refreshLegacyTeamSetupDraft(db, snapshot());
+			const projectRef = draft.projects.find(
+				(project) => project.resolution === "unresolved",
+			)?.projectRef;
+			if (!projectRef) throw new Error("invalid test fixture");
 
-		setLegacyTeamSetupProjectMapping(db, {
-			attemptId: draft.attemptId,
-			projectRef,
-			resolvedProjectIdentity: target,
-			now: NOW,
-		});
+			setLegacyTeamSetupProjectMapping(db, {
+				attemptId: draft.attemptId,
+				projectRef,
+				resolvedProjectIdentity: target,
+				now: NOW,
+			});
 
-		expect(
-			db
-				.prepare(
-					`SELECT resolved_project_identity FROM legacy_team_setup_draft_projects
+			expect(
+				db
+					.prepare(
+						`SELECT resolved_project_identity FROM legacy_team_setup_draft_projects
 						 WHERE attempt_id = ? AND project_ref = ?`,
-				)
-				.pluck()
-				.get(draft.attemptId, projectRef),
-		).toBe(target);
-	});
+					)
+					.pluck()
+					.get(draft.attemptId, projectRef),
+			).toBe(target);
+		},
+	);
 
 	it("rejects decisions outside the activation contract at runtime", () => {
 		const draft = refreshLegacyTeamSetupDraft(db, snapshot());
@@ -1577,63 +1577,66 @@ describe("legacy Team setup drafts", () => {
 		["fractional version", "existing", 1.5],
 		["unsafe version", "existing", Number.MAX_SAFE_INTEGER + 1],
 		["stale but well-formed version", "existing", 2],
-	] as const)("replaces an existing expectation with %s using normalized evidence", (_variant, expectedKind, expectedVersion) => {
-		// Arrange
-		db.prepare(
-			`INSERT INTO identity_devices(
+	] as const)(
+		"replaces an existing expectation with %s using normalized evidence",
+		(_variant, expectedKind, expectedVersion) => {
+			// Arrange
+			db.prepare(
+				`INSERT INTO identity_devices(
 				 device_id, identity_id, display_name, status, provenance, revision,
 				 migration_state, assignment_version, idempotency_key, created_at, updated_at
 				 ) VALUES ('device-a', 'identity-a', 'Laptop', 'active', 'test', 'r1',
 				 'complete', 3, 'device-a', ?, ?)`,
-		).run(NOW, NOW);
-		const current = readyDraft(db);
-		expect(current.canFinish).toBe(true);
-		const deviceRef = current.devices[0]?.deviceRef as string;
-		db.prepare(
-			`UPDATE legacy_team_setup_draft_devices
+			).run(NOW, NOW);
+			const current = readyDraft(db);
+			expect(current.canFinish).toBe(true);
+			const deviceRef = current.devices[0]?.deviceRef as string;
+			db.prepare(
+				`UPDATE legacy_team_setup_draft_devices
 			 SET expected_assignment_kind = ?, expected_assignment_version = ?
 			 WHERE attempt_id = ? AND device_ref = ?`,
-		).run(expectedKind, expectedVersion, current.attemptId, deviceRef);
+			).run(expectedKind, expectedVersion, current.attemptId, deviceRef);
 
-		// Act
-		const corrupt = getLegacyTeamSetupDraft(db, CANDIDATE);
-		const cannotFinish = () =>
-			previewLegacyTeamSetupActivation(db, {
-				candidateRef: current.candidateRef,
-				attemptId: current.attemptId,
+			// Act
+			const corrupt = getLegacyTeamSetupDraft(db, CANDIDATE);
+			const cannotFinish = () =>
+				previewLegacyTeamSetupActivation(db, {
+					candidateRef: current.candidateRef,
+					attemptId: current.attemptId,
+				});
+			expect(corrupt?.canFinish).toBe(false);
+			expect(cannotFinish).toThrow(/team_setup_(?:assignment_changed|incomplete)/u);
+			const replacement = refreshLegacyTeamSetupDraft(db, snapshot());
+
+			// Assert
+			expect(replacement).toMatchObject({
+				state: "needs_setup",
+				devices: [
+					{
+						decision: "unresolved",
+						targetIdentityId: null,
+						expectation: { kind: "existing", identityId: "identity-a", assignmentVersion: 3 },
+					},
+				],
 			});
-		expect(corrupt?.canFinish).toBe(false);
-		expect(cannotFinish).toThrow(/team_setup_(?:assignment_changed|incomplete)/u);
-		const replacement = refreshLegacyTeamSetupDraft(db, snapshot());
-
-		// Assert
-		expect(replacement).toMatchObject({
-			state: "needs_setup",
-			devices: [
-				{
-					decision: "unresolved",
-					targetIdentityId: null,
-					expectation: { kind: "existing", identityId: "identity-a", assignmentVersion: 3 },
-				},
-			],
-		});
-		expect(replacement.attemptId).not.toBe(current.attemptId);
-		expect(refreshLegacyTeamSetupDraft(db, snapshot()).attemptId).toBe(replacement.attemptId);
-		expect(
-			db
-				.prepare(
-					`SELECT draft.state, device.expected_assignment_kind, device.expected_assignment_version
+			expect(replacement.attemptId).not.toBe(current.attemptId);
+			expect(refreshLegacyTeamSetupDraft(db, snapshot()).attemptId).toBe(replacement.attemptId);
+			expect(
+				db
+					.prepare(
+						`SELECT draft.state, device.expected_assignment_kind, device.expected_assignment_version
 						 FROM legacy_team_setup_drafts AS draft
 						 JOIN legacy_team_setup_draft_devices AS device USING(attempt_id)
 						 WHERE draft.attempt_id = ? AND device.device_ref = ?`,
-				)
-				.get(current.attemptId, deviceRef),
-		).toEqual({
-			state: "stale",
-			expected_assignment_kind: expectedKind,
-			expected_assignment_version: expectedVersion,
-		});
-	});
+					)
+					.get(current.attemptId, deviceRef),
+			).toEqual({
+				state: "stale",
+				expected_assignment_kind: expectedKind,
+				expected_assignment_version: expectedVersion,
+			});
+		},
+	);
 
 	it("replaces a contradictory absent expectation with normalized evidence", () => {
 		// Arrange
@@ -1683,99 +1686,101 @@ describe("legacy Team setup drafts", () => {
 	it.each([
 		["excluded", true],
 		["removed", false],
-	] as const)("clears %s targets and produces a deterministic target-free finish digest", (decision, enabled) => {
-		// Arrange
-		db.prepare(
-			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+	] as const)(
+		"clears %s targets and produces a deterministic target-free finish digest",
+		(decision, enabled) => {
+			// Arrange
+			db.prepare(
+				`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
 			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
-		).run(NOW, NOW);
-		let draft = refreshLegacyTeamSetupDraft(db, snapshot());
-		const deviceRef = draft.devices[0]?.deviceRef as string;
-		draft = setLegacyTeamSetupDeviceAssignment(db, {
-			attemptId: draft.attemptId,
-			deviceRef,
-			targetIdentityId: "identity-a",
-			expectation: { kind: "absent" },
-			now: NOW,
-		});
-		db.prepare(
-			`UPDATE legacy_team_setup_draft_devices SET enabled = ?
+			).run(NOW, NOW);
+			let draft = refreshLegacyTeamSetupDraft(db, snapshot());
+			const deviceRef = draft.devices[0]?.deviceRef as string;
+			draft = setLegacyTeamSetupDeviceAssignment(db, {
+				attemptId: draft.attemptId,
+				deviceRef,
+				targetIdentityId: "identity-a",
+				expectation: { kind: "absent" },
+				now: NOW,
+			});
+			db.prepare(
+				`UPDATE legacy_team_setup_draft_devices SET enabled = ?
 			 WHERE attempt_id = ? AND device_ref = ?`,
-		).run(enabled ? 1 : 0, draft.attemptId, deviceRef);
+			).run(enabled ? 1 : 0, draft.attemptId, deviceRef);
 
-		// Act
-		const decisionAfterA = setLegacyTeamSetupDeviceDecision(db, {
-			attemptId: draft.attemptId,
-			deviceRef,
-			decision,
-			now: NOW,
-		});
-		db.prepare(
-			`UPDATE legacy_team_setup_draft_devices
+			// Act
+			const decisionAfterA = setLegacyTeamSetupDeviceDecision(db, {
+				attemptId: draft.attemptId,
+				deviceRef,
+				decision,
+				now: NOW,
+			});
+			db.prepare(
+				`UPDATE legacy_team_setup_draft_devices
 			 SET decision = 'unresolved', target_identity_id = 'identity-b'
 			 WHERE attempt_id = ? AND device_ref = ?`,
-		).run(draft.attemptId, deviceRef);
-		const decisionAfterB = setLegacyTeamSetupDeviceDecision(db, {
-			attemptId: draft.attemptId,
-			deviceRef,
-			decision,
-			now: NOW,
-		});
+			).run(draft.attemptId, deviceRef);
+			const decisionAfterB = setLegacyTeamSetupDeviceDecision(db, {
+				attemptId: draft.attemptId,
+				deviceRef,
+				decision,
+				now: NOW,
+			});
 
-		// Assert
-		expect(decisionAfterA.devices[0]).toMatchObject({
-			decision,
-			targetIdentityId: null,
-		});
-		expect(decisionAfterB.devices[0]).toMatchObject({
-			decision,
-			targetIdentityId: null,
-		});
-		expect(decisionAfterB.finishDigest).toBe(decisionAfterA.finishDigest);
-	});
+			// Assert
+			expect(decisionAfterA.devices[0]).toMatchObject({
+				decision,
+				targetIdentityId: null,
+			});
+			expect(decisionAfterB.devices[0]).toMatchObject({
+				decision,
+				targetIdentityId: null,
+			});
+			expect(decisionAfterB.finishDigest).toBe(decisionAfterA.finishDigest);
+		},
+	);
 
-	it.each([
-		-1,
-		1.5,
-		Number.MAX_SAFE_INTEGER + 1,
-	])("reports canFinish false for malformed assignment version %s", (assignmentVersion) => {
-		db.prepare(
-			`INSERT INTO identity_devices(
+	it.each([-1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+		"reports canFinish false for malformed assignment version %s",
+		(assignmentVersion) => {
+			db.prepare(
+				`INSERT INTO identity_devices(
 					device_id, identity_id, display_name, status, provenance, revision,
 					migration_state, assignment_version, idempotency_key, created_at, updated_at
 				 ) VALUES ('device-a', 'identity-a', 'Laptop', 'active', 'test', 'r1',
 					'complete', ?, 'device-a', ?, ?)`,
-		).run(assignmentVersion, NOW, NOW);
-		let draft = refreshLegacyTeamSetupDraft(db, snapshot());
-		const deviceRef = draft.devices[0]?.deviceRef as string;
-		draft = setLegacyTeamSetupDeviceAssignment(db, {
-			attemptId: draft.attemptId,
-			deviceRef,
-			targetIdentityId: "identity-a",
-			expectation: {
-				kind: "existing",
-				identityId: "identity-a",
-				assignmentVersion,
-			},
-			now: NOW,
-		});
-		draft = setLegacyTeamSetupDeviceDecision(db, {
-			attemptId: draft.attemptId,
-			deviceRef,
-			decision: "included",
-			now: NOW,
-		});
-		draft = setLegacyTeamSetupProjectMapping(db, {
-			attemptId: draft.attemptId,
-			projectRef: "project-ref-b",
-			resolvedProjectIdentity: "https://example.invalid/repo-b.git",
-			now: NOW,
-		});
+			).run(assignmentVersion, NOW, NOW);
+			let draft = refreshLegacyTeamSetupDraft(db, snapshot());
+			const deviceRef = draft.devices[0]?.deviceRef as string;
+			draft = setLegacyTeamSetupDeviceAssignment(db, {
+				attemptId: draft.attemptId,
+				deviceRef,
+				targetIdentityId: "identity-a",
+				expectation: {
+					kind: "existing",
+					identityId: "identity-a",
+					assignmentVersion,
+				},
+				now: NOW,
+			});
+			draft = setLegacyTeamSetupDeviceDecision(db, {
+				attemptId: draft.attemptId,
+				deviceRef,
+				decision: "included",
+				now: NOW,
+			});
+			draft = setLegacyTeamSetupProjectMapping(db, {
+				attemptId: draft.attemptId,
+				projectRef: "project-ref-b",
+				resolvedProjectIdentity: "https://example.invalid/repo-b.git",
+				now: NOW,
+			});
 
-		expect(draft.canFinish).toBe(false);
-		expect(refreshLegacyTeamSetupDraft(db, snapshot()).attemptId).toBe(draft.attemptId);
-		expect(refreshLegacyTeamSetupDraft(db, snapshot()).attemptId).toBe(draft.attemptId);
-	});
+			expect(draft.canFinish).toBe(false);
+			expect(refreshLegacyTeamSetupDraft(db, snapshot()).attemptId).toBe(draft.attemptId);
+			expect(refreshLegacyTeamSetupDraft(db, snapshot()).attemptId).toBe(draft.attemptId);
+		},
+	);
 
 	it("reports canFinish false when an included person is later deactivated", () => {
 		let draft = refreshLegacyTeamSetupDraft(db, snapshot());

--- a/packages/core/src/legacy-team-setup-label-policy.test.ts
+++ b/packages/core/src/legacy-team-setup-label-policy.test.ts
@@ -6,14 +6,12 @@ import {
 } from "./legacy-team-setup-label-policy.js";
 
 describe("legacy Team setup label policy", () => {
-	it.each([
-		"api.example.invalid",
-		"ssh-ed25519 secret",
-		"safe/name",
-		"api\u202E.example",
-	])("redacts unsafe label %s", (value) => {
-		expect(safeLabel(value, "Fallback", new Set())).toBe("Fallback");
-	});
+	it.each(["api.example.invalid", "ssh-ed25519 secret", "safe/name", "api\u202E.example"])(
+		"redacts unsafe label %s",
+		(value) => {
+			expect(safeLabel(value, "Fallback", new Set())).toBe("Fallback");
+		},
+	);
 
 	it("checks forbidden identifiers beyond the emitted label boundary", () => {
 		const value = `${"A".repeat(130)} private-id`;
@@ -27,11 +25,10 @@ describe("legacy Team setup label policy", () => {
 		expect(safeLabel("API laptop", "Device", forbidden)).toBe("API laptop");
 	});
 
-	it.each([
-		"a",
-		"group-1",
-		"thisgroupnameislongerthantwentyfour",
-	])("does not treat opaque group ID %s as a human alias", (groupId) => {
-		expect(humanGroupLabelAlias(groupId, groupId)).toBeNull();
-	});
+	it.each(["a", "group-1", "thisgroupnameislongerthantwentyfour"])(
+		"does not treat opaque group ID %s as a human alias",
+		(groupId) => {
+			expect(humanGroupLabelAlias(groupId, groupId)).toBeNull();
+		},
+	);
 });

--- a/packages/core/src/policy-team-device-eligibility.test.ts
+++ b/packages/core/src/policy-team-device-eligibility.test.ts
@@ -142,28 +142,24 @@ describe("Team device eligibility", () => {
 		});
 	});
 
-	it.each([
-		"",
-		" device-a",
-		"device-a ",
-		"device-a\n",
-		"device-\u200B-a",
-		"d".repeat(257),
-	])("blocks malformed reviewed decision device ID %j", (deviceId) => {
-		const result = derivePolicyTeamDeviceEligibility({
-			teamId: "team-a",
-			mode: "reviewed_allowlist",
-			identities,
-			memberships: [{ identityId: "identity-a", status: "reviewed_active" }],
-			devices,
-			decisions: [{ deviceId, decision: "included", assignmentVersion: 0 }],
-		});
+	it.each(["", " device-a", "device-a ", "device-a\n", "device-\u200B-a", "d".repeat(257)])(
+		"blocks malformed reviewed decision device ID %j",
+		(deviceId) => {
+			const result = derivePolicyTeamDeviceEligibility({
+				teamId: "team-a",
+				mode: "reviewed_allowlist",
+				identities,
+				memberships: [{ identityId: "identity-a", status: "reviewed_active" }],
+				devices,
+				decisions: [{ deviceId, decision: "included", assignmentVersion: 0 }],
+			});
 
-		expect(result).toEqual({
-			status: "blocked",
-			blocked: [{ code: "team_device_decision_invalid", referenceId: `team-a:${deviceId}` }],
-		});
-	});
+			expect(result).toEqual({
+				status: "blocked",
+				blocked: [{ code: "team_device_decision_invalid", referenceId: `team-a:${deviceId}` }],
+			});
+		},
+	);
 
 	it("accepts a canonical device ID at the 256 UTF-16-unit boundary", () => {
 		const deviceId = "d".repeat(256);
@@ -360,47 +356,43 @@ describe("Team device eligibility", () => {
 		expect(result.blocked).toEqual([{ code: "identity_device_invalid", referenceId: "device-a" }]);
 	});
 
-	it.each([
-		"",
-		" device-a",
-		"device-a ",
-		"device-a\n",
-	])("blocks malformed active device ID %j", (deviceId) => {
-		const result = derivePolicyTeamDeviceEligibility({
-			teamId: "team-a",
-			mode: "person_all_devices",
-			identities,
-			memberships: [{ identityId: "identity-a", status: "active" }],
-			devices: [{ identityId: "identity-a", deviceId, status: "active", assignmentVersion: 0 }],
-			decisions: [],
-		});
+	it.each(["", " device-a", "device-a ", "device-a\n"])(
+		"blocks malformed active device ID %j",
+		(deviceId) => {
+			const result = derivePolicyTeamDeviceEligibility({
+				teamId: "team-a",
+				mode: "person_all_devices",
+				identities,
+				memberships: [{ identityId: "identity-a", status: "active" }],
+				devices: [{ identityId: "identity-a", deviceId, status: "active", assignmentVersion: 0 }],
+				decisions: [],
+			});
 
-		expect(result.status).toBe("blocked");
-		expect(result).not.toHaveProperty("eligibleDeviceIds");
-		expect(result.blocked).toEqual([{ code: "identity_device_invalid", referenceId: deviceId }]);
-	});
+			expect(result.status).toBe("blocked");
+			expect(result).not.toHaveProperty("eligibleDeviceIds");
+			expect(result.blocked).toEqual([{ code: "identity_device_invalid", referenceId: deviceId }]);
+		},
+	);
 
-	it.each([
-		"",
-		" identity-a",
-		"identity-a ",
-		"identity-a\n",
-	])("blocks malformed inactive reviewed membership ID %j", (identityId) => {
-		const result = derivePolicyTeamDeviceEligibility({
-			teamId: "team-a",
-			mode: "reviewed_allowlist",
-			identities,
-			memberships: [{ identityId, status: "pending" }],
-			devices: [],
-			decisions: [],
-		});
+	it.each(["", " identity-a", "identity-a ", "identity-a\n"])(
+		"blocks malformed inactive reviewed membership ID %j",
+		(identityId) => {
+			const result = derivePolicyTeamDeviceEligibility({
+				teamId: "team-a",
+				mode: "reviewed_allowlist",
+				identities,
+				memberships: [{ identityId, status: "pending" }],
+				devices: [],
+				decisions: [],
+			});
 
-		expect(result.status).toBe("blocked");
-		expect(result).not.toHaveProperty("eligibleDeviceIds");
-		expect(result.blocked).toEqual([
-			{ code: "team_membership_invalid", referenceId: `team-a:${identityId}` },
-		]);
-	});
+			expect(result.status).toBe("blocked");
+			expect(result).not.toHaveProperty("eligibleDeviceIds");
+			expect(result.blocked).toEqual([
+				{ code: "team_membership_invalid", referenceId: `team-a:${identityId}` },
+			]);
+		},
+	);
 
 	it.each([
 		["missing", [], "team_member_identity_missing"],

--- a/packages/core/src/project-invite-identity.test.ts
+++ b/packages/core/src/project-invite-identity.test.ts
@@ -74,13 +74,14 @@ describe("project invite identity", () => {
 		);
 	});
 
-	it.each(
-		MACHINE_PRESENTATION_LABEL_FIXTURES,
-	)("keeps core and browser presentation classifiers aligned for %s", (value) => {
-		expect(isHumanPresentationName(value)).toBe(false);
-		expect(isMachinePresentationLabel(value)).toBe(true);
-		expect(humanPresentationLabel(value)).toBe("");
-	});
+	it.each(MACHINE_PRESENTATION_LABEL_FIXTURES)(
+		"keeps core and browser presentation classifiers aligned for %s",
+		(value) => {
+			expect(isHumanPresentationName(value)).toBe(false);
+			expect(isMachinePresentationLabel(value)).toBe(true);
+			expect(humanPresentationLabel(value)).toBe("");
+		},
+	);
 
 	it("normalizes human actor and device presentation names", () => {
 		expect(normalizeHumanPresentationName("  Brian   Example  ", "recipient_display_name")).toBe(

--- a/packages/core/src/prompt-transport.test.ts
+++ b/packages/core/src/prompt-transport.test.ts
@@ -56,36 +56,39 @@ describe("prompt transport failure classification", () => {
 		expect(classifyPromptTransportFailure({ kind })).toBe("fallback");
 	});
 
-	it.each([
-		"database_mismatch",
-		"runtime_identity_mismatch",
-	] as const)("classifies %s as one-shot local fallback", (kind) => {
-		expect(classifyPromptTransportFailure({ kind })).toBe("local_fallback");
-	});
+	it.each(["database_mismatch", "runtime_identity_mismatch"] as const)(
+		"classifies %s as one-shot local fallback",
+		(kind) => {
+			expect(classifyPromptTransportFailure({ kind })).toBe("local_fallback");
+		},
+	);
 
-	it.each([
-		"policy_failure",
-		"authorization_failure",
-	] as const)("classifies %s as terminal", (kind) => {
-		expect(classifyPromptTransportFailure({ kind })).toBe("terminal");
-	});
+	it.each(["policy_failure", "authorization_failure"] as const)(
+		"classifies %s as terminal",
+		(kind) => {
+			expect(classifyPromptTransportFailure({ kind })).toBe("terminal");
+		},
+	);
 
 	it.each([
 		[false, "fallback"],
 		[true, "terminal"],
-	] as const)("classifies invalid_request with compatibleProfile=%s as %s", (compatibleProfile, expected) => {
-		// Arrange
-		const failure = {
-			kind: "invalid_request",
-			compatibleProfile,
-		} as const;
+	] as const)(
+		"classifies invalid_request with compatibleProfile=%s as %s",
+		(compatibleProfile, expected) => {
+			// Arrange
+			const failure = {
+				kind: "invalid_request",
+				compatibleProfile,
+			} as const;
 
-		// Act
-		const disposition = classifyPromptTransportFailure(failure);
+			// Act
+			const disposition = classifyPromptTransportFailure(failure);
 
-		// Assert
-		expect(disposition).toBe(expected);
-	});
+			// Assert
+			expect(disposition).toBe(expected);
+		},
+	);
 
 	it("distinguishes contract skew before and after a compatible profile", () => {
 		expect(

--- a/packages/core/src/raw-event-ingest.test.ts
+++ b/packages/core/src/raw-event-ingest.test.ts
@@ -282,26 +282,25 @@ describe("ingestRawEvents", () => {
 		}
 	});
 
-	it.each([
-		"tool.execute.after",
-		"message.part.updated",
-		"session.idle",
-	])("accepts OpenCode wire event type %s", (eventType) => {
-		const store = createStore();
-		try {
-			expect(
-				ingestRawEvents(store, {
-					source: "opencode",
-					session_id: "session-opencode-wire-types",
-					event_id: `event-${eventType}`,
-					event_type: eventType,
-					payload: {},
-				}),
-			).toMatchObject({ inserted: 1, skipped: 0 });
-		} finally {
-			store.close();
-		}
-	});
+	it.each(["tool.execute.after", "message.part.updated", "session.idle"])(
+		"accepts OpenCode wire event type %s",
+		(eventType) => {
+			const store = createStore();
+			try {
+				expect(
+					ingestRawEvents(store, {
+						source: "opencode",
+						session_id: "session-opencode-wire-types",
+						event_id: `event-${eventType}`,
+						event_type: eventType,
+						payload: {},
+					}),
+				).toMatchObject({ inserted: 1, skipped: 0 });
+			} finally {
+				store.close();
+			}
+		},
+	);
 
 	it("accepts legacy signed and zero-padded integer sequences without trusting them", () => {
 		const store = createStore();

--- a/packages/core/src/recipient-policy-edges.test.ts
+++ b/packages/core/src/recipient-policy-edges.test.ts
@@ -648,99 +648,96 @@ describe("recipient-policy edge changes", () => {
 		["pending", "pending", null, "team_member_identity_not_active"],
 		["deactivated", "deactivated", null, "team_member_identity_not_active"],
 		["merged", "active", "identity-a", "team_member_identity_merged"],
-	] as const)("blocks $label Team members identically in preview and authoritative derivation", (_label, status, mergedIntoIdentityId, code) => {
-		const db = seedGraph();
-		insertProjectRecipient(db, PROJECT_A, "team-a", "team");
-		db.prepare(
-			`UPDATE actors SET status = ?, merged_into_actor_id = ?
+	] as const)(
+		"blocks $label Team members identically in preview and authoritative derivation",
+		(_label, status, mergedIntoIdentityId, code) => {
+			const db = seedGraph();
+			insertProjectRecipient(db, PROJECT_A, "team-a", "team");
+			db.prepare(
+				`UPDATE actors SET status = ?, merged_into_actor_id = ?
 				 WHERE actor_id = 'identity-b'`,
-		).run(status, mergedIntoIdentityId);
+			).run(status, mergedIntoIdentityId);
 
-		const authoritative = deriveRecipientPolicyEffectiveDevicesFromDatabase(db, PROJECT_A);
-		let previewError: unknown;
-		try {
-			previewRecipientPolicyEdges(db, {
-				version: 1,
-				changes: [teamChange(PROJECT_A, "team-a")],
+			const authoritative = deriveRecipientPolicyEffectiveDevicesFromDatabase(db, PROJECT_A);
+			let previewError: unknown;
+			try {
+				previewRecipientPolicyEdges(db, {
+					version: 1,
+					changes: [teamChange(PROJECT_A, "team-a")],
+				});
+			} catch (error) {
+				previewError = error;
+			}
+
+			expect(authoritative.status).toBe("blocked");
+			expect(authoritative.blocked[0]).toEqual({ code, referenceId: "identity-b" });
+			expect(previewError).toMatchObject({ status: "invalid", errorCode: code });
+		},
+	);
+
+	it.each(["", " device-a", "device-a ", "device-a\n"])(
+		"blocks malformed Team device ID %j identically in preview and authoritative derivation",
+		(deviceId) => {
+			const db = seedGraph();
+			insertProjectRecipient(db, PROJECT_A, "team-a", "team");
+			db.prepare("UPDATE identity_devices SET device_id = ? WHERE device_id = 'device-a'").run(
+				deviceId,
+			);
+
+			const authoritative = deriveRecipientPolicyEffectiveDevicesFromDatabase(db, PROJECT_A);
+			let previewError: unknown;
+			try {
+				previewRecipientPolicyEdges(db, {
+					version: 1,
+					changes: [teamChange(PROJECT_A, "team-a")],
+				});
+			} catch (error) {
+				previewError = error;
+			}
+
+			expect(authoritative.status).toBe("blocked");
+			expect(authoritative.blocked).toContainEqual({
+				code: "identity_device_invalid",
+				referenceId: deviceId,
 			});
-		} catch (error) {
-			previewError = error;
-		}
-
-		expect(authoritative.status).toBe("blocked");
-		expect(authoritative.blocked[0]).toEqual({ code, referenceId: "identity-b" });
-		expect(previewError).toMatchObject({ status: "invalid", errorCode: code });
-	});
-
-	it.each([
-		"",
-		" device-a",
-		"device-a ",
-		"device-a\n",
-	])("blocks malformed Team device ID %j identically in preview and authoritative derivation", (deviceId) => {
-		const db = seedGraph();
-		insertProjectRecipient(db, PROJECT_A, "team-a", "team");
-		db.prepare("UPDATE identity_devices SET device_id = ? WHERE device_id = 'device-a'").run(
-			deviceId,
-		);
-
-		const authoritative = deriveRecipientPolicyEffectiveDevicesFromDatabase(db, PROJECT_A);
-		let previewError: unknown;
-		try {
-			previewRecipientPolicyEdges(db, {
-				version: 1,
-				changes: [teamChange(PROJECT_A, "team-a")],
+			expect(previewError).toMatchObject({
+				status: "invalid",
+				errorCode: "identity_device_invalid",
 			});
-		} catch (error) {
-			previewError = error;
-		}
+		},
+	);
 
-		expect(authoritative.status).toBe("blocked");
-		expect(authoritative.blocked).toContainEqual({
-			code: "identity_device_invalid",
-			referenceId: deviceId,
-		});
-		expect(previewError).toMatchObject({
-			status: "invalid",
-			errorCode: "identity_device_invalid",
-		});
-	});
+	it.each(["", " device-a", "device-a ", "device-a\n", "device-\u200B-a", "a".repeat(257)])(
+		"blocks malformed direct-identity device ID %j identically in preview and authoritative derivation",
+		(deviceId) => {
+			const db = seedGraph();
+			insertProjectRecipient(db, PROJECT_A, "identity-a");
+			db.prepare("UPDATE identity_devices SET device_id = ? WHERE device_id = 'device-a'").run(
+				deviceId,
+			);
 
-	it.each([
-		"",
-		" device-a",
-		"device-a ",
-		"device-a\n",
-		"device-\u200B-a",
-		"a".repeat(257),
-	])("blocks malformed direct-identity device ID %j identically in preview and authoritative derivation", (deviceId) => {
-		const db = seedGraph();
-		insertProjectRecipient(db, PROJECT_A, "identity-a");
-		db.prepare("UPDATE identity_devices SET device_id = ? WHERE device_id = 'device-a'").run(
-			deviceId,
-		);
+			const authoritative = deriveRecipientPolicyEffectiveDevicesFromDatabase(db, PROJECT_A);
+			let previewError: unknown;
+			try {
+				previewRecipientPolicyEdges(db, {
+					version: 1,
+					changes: [identityChange(PROJECT_A, "identity-a")],
+				});
+			} catch (error) {
+				previewError = error;
+			}
 
-		const authoritative = deriveRecipientPolicyEffectiveDevicesFromDatabase(db, PROJECT_A);
-		let previewError: unknown;
-		try {
-			previewRecipientPolicyEdges(db, {
-				version: 1,
-				changes: [identityChange(PROJECT_A, "identity-a")],
+			expect(authoritative.status).toBe("blocked");
+			expect(authoritative.blocked).toContainEqual({
+				code: "identity_device_invalid",
+				referenceId: deviceId,
 			});
-		} catch (error) {
-			previewError = error;
-		}
-
-		expect(authoritative.status).toBe("blocked");
-		expect(authoritative.blocked).toContainEqual({
-			code: "identity_device_invalid",
-			referenceId: deviceId,
-		});
-		expect(previewError).toMatchObject({
-			status: "invalid",
-			errorCode: "identity_device_invalid",
-		});
-	});
+			expect(previewError).toMatchObject({
+				status: "invalid",
+				errorCode: "identity_device_invalid",
+			});
+		},
+	);
 
 	it("keeps indexed Team eligibility facts isolated across a large roster", () => {
 		const db = seedGraph();

--- a/packages/core/src/recipient-policy-identifiers.test.ts
+++ b/packages/core/src/recipient-policy-identifiers.test.ts
@@ -111,14 +111,12 @@ describe("recipient policy identifiers", () => {
 		expect(act).toThrow(TypeError);
 	});
 
-	it.each([
-		"\uD800",
-		"\uDC00",
-		"recipient\uD800policy",
-		"\uDC00\uD800",
-	])("rejects ill-formed UTF-16 in digest domain prefix %j", (prefix) => {
-		expect(() => recipientPolicyDigest(prefix, { value: true })).toThrow(TypeError);
-	});
+	it.each(["\uD800", "\uDC00", "recipient\uD800policy", "\uDC00\uD800"])(
+		"rejects ill-formed UTF-16 in digest domain prefix %j",
+		(prefix) => {
+			expect(() => recipientPolicyDigest(prefix, { value: true })).toThrow(TypeError);
+		},
+	);
 
 	it("keeps well-formed astral-plane digest prefixes stable", () => {
 		const prefix = "recipient-\u{1F600}-v1";

--- a/packages/core/src/recipient-policy-migration.test.ts
+++ b/packages/core/src/recipient-policy-migration.test.ts
@@ -1307,136 +1307,136 @@ describe("recipient policy intent migration", () => {
 		).toBe(1);
 	});
 
-	it.each([
-		"v1",
-		"v2",
-	] as const)("accepts a stored %s recipient edge authorized by a non-preferred current review", (metadataVersion) => {
-		// Arrange
-		const projectId = `https://git.example.invalid/acme/replay-${metadataVersion}.git`;
-		const scopeId = `scope-replay-${metadataVersion}`;
-		const recipientId = `identity-replay-${metadataVersion}`;
-		insertActor(db, recipientId, "Replay recipient");
-		insertProject(db, { projectId, displayName: `replay-${metadataVersion}`, scopeId });
-		insertScope(db, { scopeId, projectId });
-		assignDevice(db, {
-			scopeId,
-			deviceId: `device-replay-assigned-${metadataVersion}`,
-			actorId: recipientId,
-		});
-		for (const deviceId of [
-			`device-replay-${metadataVersion}-a`,
-			`device-replay-${metadataVersion}-b`,
-		]) {
-			db.prepare(
-				`INSERT INTO sync_peers(peer_device_id, name, actor_id, created_at)
-					 VALUES (?, ?, NULL, ?)`,
-			).run(deviceId, deviceId, NOW);
-			db.prepare(
-				`INSERT INTO scope_memberships(scope_id, device_id, status, membership_epoch, updated_at)
-					 VALUES (?, ?, 'active', 1, ?)`,
-			).run(scopeId, deviceId, NOW);
-		}
-		const items = listRecipientPolicyReview(db, context).reviewItems.filter((candidate) =>
-			candidate.options.some((option) => option.decision === "choose_recipients"),
-		);
-		expect(items).toHaveLength(2);
-		expect(new Set(items.map((item) => item.sourceFingerprint)).size).toBe(2);
-		for (const item of items) {
-			resolveRecipientPolicyReview(db, context, {
-				reviewItemId: item.reviewItemId,
-				sourceFingerprint: item.sourceFingerprint,
-				decision: "choose_recipients",
-				decisionInput: { recipientIds: [recipientId] },
+	it.each(["v1", "v2"] as const)(
+		"accepts a stored %s recipient edge authorized by a non-preferred current review",
+		(metadataVersion) => {
+			// Arrange
+			const projectId = `https://git.example.invalid/acme/replay-${metadataVersion}.git`;
+			const scopeId = `scope-replay-${metadataVersion}`;
+			const recipientId = `identity-replay-${metadataVersion}`;
+			insertActor(db, recipientId, "Replay recipient");
+			insertProject(db, { projectId, displayName: `replay-${metadataVersion}`, scopeId });
+			insertScope(db, { scopeId, projectId });
+			assignDevice(db, {
+				scopeId,
+				deviceId: `device-replay-assigned-${metadataVersion}`,
+				actorId: recipientId,
 			});
-		}
-		const [, storedFingerprint] = items
-			.map((item) => item.sourceFingerprint)
-			.toSorted(compareCodepoints);
-		if (!storedFingerprint) throw new Error("stored review fingerprint missing");
-		const identity = [projectId, "identity", recipientId];
-		const evidenceIdentity = {
-			identity,
-			provenance: "review_resolution",
-			sourceFingerprint: storedFingerprint,
-		};
-		const metadataIdentity = metadataVersion === "v1" ? identity : evidenceIdentity;
-		db.prepare(
-			`INSERT INTO project_recipients(
+			for (const deviceId of [
+				`device-replay-${metadataVersion}-a`,
+				`device-replay-${metadataVersion}-b`,
+			]) {
+				db.prepare(
+					`INSERT INTO sync_peers(peer_device_id, name, actor_id, created_at)
+					 VALUES (?, ?, NULL, ?)`,
+				).run(deviceId, deviceId, NOW);
+				db.prepare(
+					`INSERT INTO scope_memberships(scope_id, device_id, status, membership_epoch, updated_at)
+					 VALUES (?, ?, 'active', 1, ?)`,
+				).run(scopeId, deviceId, NOW);
+			}
+			const items = listRecipientPolicyReview(db, context).reviewItems.filter((candidate) =>
+				candidate.options.some((option) => option.decision === "choose_recipients"),
+			);
+			expect(items).toHaveLength(2);
+			expect(new Set(items.map((item) => item.sourceFingerprint)).size).toBe(2);
+			for (const item of items) {
+				resolveRecipientPolicyReview(db, context, {
+					reviewItemId: item.reviewItemId,
+					sourceFingerprint: item.sourceFingerprint,
+					decision: "choose_recipients",
+					decisionInput: { recipientIds: [recipientId] },
+				});
+			}
+			const [, storedFingerprint] = items
+				.map((item) => item.sourceFingerprint)
+				.toSorted(compareCodepoints);
+			if (!storedFingerprint) throw new Error("stored review fingerprint missing");
+			const identity = [projectId, "identity", recipientId];
+			const evidenceIdentity = {
+				identity,
+				provenance: "review_resolution",
+				sourceFingerprint: storedFingerprint,
+			};
+			const metadataIdentity = metadataVersion === "v1" ? identity : evidenceIdentity;
+			db.prepare(
+				`INSERT INTO project_recipients(
 				 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
 				 policy_revision, migration_state, source_fingerprint, idempotency_key, created_at, updated_at
 				 ) VALUES (?, 'identity', ?, 'active', 'review_resolution', ?, 'projected', ?, ?, ?, ?)`,
-		).run(
-			projectId,
-			recipientId,
-			legacyRecipientPolicyDigest(
-				`recipient-policy-project-recipient-revision-${metadataVersion}`,
-				metadataIdentity,
-			),
-			storedFingerprint,
-			legacyRecipientPolicyDigest(
-				`recipient-policy-project-recipient-idempotency-${metadataVersion}`,
-				metadataIdentity,
-			),
-			NOW,
-			NOW,
-		);
+			).run(
+				projectId,
+				recipientId,
+				legacyRecipientPolicyDigest(
+					`recipient-policy-project-recipient-revision-${metadataVersion}`,
+					metadataIdentity,
+				),
+				storedFingerprint,
+				legacyRecipientPolicyDigest(
+					`recipient-policy-project-recipient-idempotency-${metadataVersion}`,
+					metadataIdentity,
+				),
+				NOW,
+				NOW,
+			);
 
-		// Act
-		const result = migrateRecipientPolicyIntent(db, context);
-		const replay = migrateRecipientPolicyIntent(db, context);
+			// Act
+			const result = migrateRecipientPolicyIntent(db, context);
+			const replay = migrateRecipientPolicyIntent(db, context);
 
-		// Assert
-		expect(result.results).toContainEqual(
-			expect.objectContaining({
-				canonicalProjectIdentity: projectId,
-				status: "migrated",
-				errorCode: null,
-			}),
-		);
-		expect(replay.results).toContainEqual(
-			expect.objectContaining({
-				canonicalProjectIdentity: projectId,
-				status: "unchanged",
-				idempotent: true,
-			}),
-		);
-		expect(
-			db
-				.prepare(
-					`SELECT source_fingerprint FROM project_recipients
+			// Assert
+			expect(result.results).toContainEqual(
+				expect.objectContaining({
+					canonicalProjectIdentity: projectId,
+					status: "migrated",
+					errorCode: null,
+				}),
+			);
+			expect(replay.results).toContainEqual(
+				expect.objectContaining({
+					canonicalProjectIdentity: projectId,
+					status: "unchanged",
+					idempotent: true,
+				}),
+			);
+			expect(
+				db
+					.prepare(
+						`SELECT source_fingerprint FROM project_recipients
 						 WHERE canonical_project_identity = ? AND recipient_kind = 'identity'
 						   AND recipient_id = ?`,
-				)
-				.pluck()
-				.get(projectId, recipientId),
-		).toBe(storedFingerprint);
+					)
+					.pluck()
+					.get(projectId, recipientId),
+			).toBe(storedFingerprint);
 
-		db.prepare(
-			`UPDATE project_recipients SET source_fingerprint = 'not-a-current-review'
+			db.prepare(
+				`UPDATE project_recipients SET source_fingerprint = 'not-a-current-review'
 				 WHERE canonical_project_identity = ? AND recipient_kind = 'identity' AND recipient_id = ?`,
-		).run(projectId, recipientId);
-		const rejected = migrateRecipientPolicyIntent(db, context);
-		expect(rejected.results).toContainEqual(
-			expect.objectContaining({
-				canonicalProjectIdentity: projectId,
-				status: "blocked",
-				errorCode: "intent_conflict",
-			}),
-		);
+			).run(projectId, recipientId);
+			const rejected = migrateRecipientPolicyIntent(db, context);
+			expect(rejected.results).toContainEqual(
+				expect.objectContaining({
+					canonicalProjectIdentity: projectId,
+					status: "blocked",
+					errorCode: "intent_conflict",
+				}),
+			);
 
-		db.prepare(
-			`UPDATE project_recipients SET source_fingerprint = ?, policy_revision = 'tampered-revision'
+			db.prepare(
+				`UPDATE project_recipients SET source_fingerprint = ?, policy_revision = 'tampered-revision'
 			 WHERE canonical_project_identity = ? AND recipient_kind = 'identity' AND recipient_id = ?`,
-		).run(storedFingerprint, projectId, recipientId);
-		const metadataRejected = migrateRecipientPolicyIntent(db, context);
-		expect(metadataRejected.results).toContainEqual(
-			expect.objectContaining({
-				canonicalProjectIdentity: projectId,
-				status: "blocked",
-				errorCode: "intent_conflict",
-			}),
-		);
-	});
+			).run(storedFingerprint, projectId, recipientId);
+			const metadataRejected = migrateRecipientPolicyIntent(db, context);
+			expect(metadataRejected.results).toContainEqual(
+				expect.objectContaining({
+					canonicalProjectIdentity: projectId,
+					status: "blocked",
+					errorCode: "intent_conflict",
+				}),
+			);
+		},
+	);
 
 	it("keeps reviewed preserve-current Projects on legacy enforcement", () => {
 		const projectId = "https://git.example.invalid/acme/preserve-current.git";

--- a/packages/core/src/recipient-policy-onboarding.test.ts
+++ b/packages/core/src/recipient-policy-onboarding.test.ts
@@ -648,38 +648,45 @@ describe("recipient-policy onboarding", () => {
 	it.each([
 		["an actor assignment", "local:device-new", 0],
 		["a claimed-local assignment", null, 1],
-	] as const)("rejects add-device adoption when a sync peer has %s", (_name, peerActorId, claimed) => {
-		const fresh = new Database(":memory:");
-		initTestSchema(fresh);
-		insertActor(fresh, "local:device-new", "Ada", true);
-		fresh
-			.prepare(
-				`INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at)
+	] as const)(
+		"rejects add-device adoption when a sync peer has %s",
+		(_name, peerActorId, claimed) => {
+			const fresh = new Database(":memory:");
+			initTestSchema(fresh);
+			insertActor(fresh, "local:device-new", "Ada", true);
+			fresh
+				.prepare(
+					`INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at)
 				 VALUES (?, ?, ?, ?)`,
-			)
-			.run("peer-device", peerActorId, claimed, NOW);
-		try {
-			const request = reviewedIntentRequest({ identityId: "identity-existing" });
-			const intent = addDeviceReviewedIntent();
-			const preview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, request);
+				)
+				.run("peer-device", peerActorId, claimed, NOW);
+			try {
+				const request = reviewedIntentRequest({ identityId: "identity-existing" });
+				const intent = addDeviceReviewedIntent();
+				const preview = previewRecipientPolicyOnboardingFromReviewedIntent(intent, request);
 
-			expect(
-				commitRecipientPolicyOnboardingFromReviewedIntent(fresh, {
-					...request,
-					identityDisplayName: "Ada",
-					reviewedIntent: intent,
-					reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
-				}),
-			).toMatchObject({ status: "conflict", errorCode: "invite_identity_conflict", writeCount: 0 });
-			expect(
-				fresh
-					.prepare("SELECT is_local, status, merged_into_actor_id FROM actors WHERE actor_id = ?")
-					.get("local:device-new"),
-			).toEqual({ is_local: 1, status: "active", merged_into_actor_id: null });
-		} finally {
-			fresh.close();
-		}
-	});
+				expect(
+					commitRecipientPolicyOnboardingFromReviewedIntent(fresh, {
+						...request,
+						identityDisplayName: "Ada",
+						reviewedIntent: intent,
+						reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+					}),
+				).toMatchObject({
+					status: "conflict",
+					errorCode: "invite_identity_conflict",
+					writeCount: 0,
+				});
+				expect(
+					fresh
+						.prepare("SELECT is_local, status, merged_into_actor_id FROM actors WHERE actor_id = ?")
+						.get("local:device-new"),
+				).toEqual({ is_local: 1, status: "active", merged_into_actor_id: null });
+			} finally {
+				fresh.close();
+			}
+		},
+	);
 
 	it("rejects established-profile adoption without writes", () => {
 		const fresh = new Database(":memory:");
@@ -2244,40 +2251,40 @@ describe("recipient-policy onboarding", () => {
 		).toBe("reviewed-fingerprint");
 	});
 
-	it.each([
-		null,
-		"different-public-key",
-	])("rejects an exact-Project device transition without matching local key %s", (localPublicKey) => {
-		if (localPublicKey) {
-			db.prepare(
-				`INSERT INTO sync_device(device_id, public_key, fingerprint, created_at)
+	it.each([null, "different-public-key"])(
+		"rejects an exact-Project device transition without matching local key %s",
+		(localPublicKey) => {
+			if (localPublicKey) {
+				db.prepare(
+					`INSERT INTO sync_device(device_id, public_key, fingerprint, created_at)
 					 VALUES ('device-new', ?, ?, ?)`,
-			).run(localPublicKey, fingerprintPublicKey(localPublicKey), NOW);
-		}
-		db.prepare(
-			`INSERT INTO identity_devices(
+				).run(localPublicKey, fingerprintPublicKey(localPublicKey), NOW);
+			}
+			db.prepare(
+				`INSERT INTO identity_devices(
 				 identity_id, device_id, display_name, status, provenance, revision, migration_state,
 				 source_fingerprint, idempotency_key, created_at, updated_at
 				 ) VALUES ('identity-a', 'device-new', 'Original device', 'active',
 				 'exact_project_invite', 'exact-project-revision', 'user_managed',
 				 'exact-project-source', 'exact-project-idempotency', ?, ?)`,
-		).run(NOW, NOW);
-		const originalBinding = db
-			.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-new'")
-			.get();
-		const request = baseRequest({ invitationId: "invite-rejected-key-transition" });
-		const preview = previewRecipientPolicyOnboarding(db, request);
+			).run(NOW, NOW);
+			const originalBinding = db
+				.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-new'")
+				.get();
+			const request = baseRequest({ invitationId: "invite-rejected-key-transition" });
+			const preview = previewRecipientPolicyOnboarding(db, request);
 
-		expect(
-			commitRecipientPolicyOnboarding(db, {
-				...request,
-				reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
-			}),
-		).toMatchObject({ status: "conflict", errorCode: "device_binding_conflict", writeCount: 0 });
-		expect(
-			db.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-new'").get(),
-		).toEqual(originalBinding);
-	});
+			expect(
+				commitRecipientPolicyOnboarding(db, {
+					...request,
+					reviewedOnboardingDigest: preview.reviewedOnboardingDigest,
+				}),
+			).toMatchObject({ status: "conflict", errorCode: "device_binding_conflict", writeCount: 0 });
+			expect(
+				db.prepare("SELECT * FROM identity_devices WHERE device_id = 'device-new'").get(),
+			).toEqual(originalBinding);
+		},
+	);
 
 	it("commits add-device as the only intent write", () => {
 		const request = baseRequest();

--- a/packages/core/src/recipient-policy-reconciler.test.ts
+++ b/packages/core/src/recipient-policy-reconciler.test.ts
@@ -1222,43 +1222,43 @@ describe("recipient-policy reconciler executor", () => {
 		expect(effects.grant).not.toHaveBeenCalled();
 	});
 
-	it.each([
-		"unsupported",
-		"undetermined",
-	] as const)("bounds failed capability steps across repeated %s preflights", async (capability) => {
-		const { effects } = harness(["device-keep"]);
-		vi.mocked(effects.probeCapability).mockResolvedValue(capability);
-		const at = new Date(BASE_TIME).toISOString();
-		const insert = db.prepare(
-			`INSERT INTO recipient_policy_reconciliation_steps(
+	it.each(["unsupported", "undetermined"] as const)(
+		"bounds failed capability steps across repeated %s preflights",
+		async (capability) => {
+			const { effects } = harness(["device-keep"]);
+			vi.mocked(effects.probeCapability).mockResolvedValue(capability);
+			const at = new Date(BASE_TIME).toISOString();
+			const insert = db.prepare(
+				`INSERT INTO recipient_policy_reconciliation_steps(
 			 canonical_project_identity, generation, step_key, effect_id, payload_digest,
 			 status, created_at, updated_at
 			 ) VALUES (?, 1, ?, ?, 'payload', ?, ?, ?)`,
-		);
-		insert.run(PROJECT, "capability:stale:device-a", "stale-pending", "pending", at, at);
-		insert.run(PROJECT, "capability:stale:device-b", "stale-running", "running", at, at);
-
-		for (let pass = 1; pass <= 3; pass += 1) {
-			const outcome = await reconcileRecipientPolicyProject(
-				db,
-				{ canonicalProjectIdentity: PROJECT, leaseOwner: `worker-${pass}` },
-				effects,
 			);
+			insert.run(PROJECT, "capability:stale:device-a", "stale-pending", "pending", at, at);
+			insert.run(PROJECT, "capability:stale:device-b", "stale-running", "running", at, at);
 
-			expect(outcome.safeErrorCode).toBe(`recipient_policy_capability_${capability}`);
-			expect(
-				db
-					.prepare(
-						`SELECT COUNT(*) FROM recipient_policy_reconciliation_steps
+			for (let pass = 1; pass <= 3; pass += 1) {
+				const outcome = await reconcileRecipientPolicyProject(
+					db,
+					{ canonicalProjectIdentity: PROJECT, leaseOwner: `worker-${pass}` },
+					effects,
+				);
+
+				expect(outcome.safeErrorCode).toBe(`recipient_policy_capability_${capability}`);
+				expect(
+					db
+						.prepare(
+							`SELECT COUNT(*) FROM recipient_policy_reconciliation_steps
 							 WHERE canonical_project_identity = ?
 							 AND status IN ('pending', 'running', 'failed')
 							 AND step_key GLOB 'capability:*'`,
-					)
-					.pluck()
-					.get(PROJECT),
-			).toBe(2);
-		}
-	});
+						)
+						.pluck()
+						.get(PROJECT),
+				).toBe(2);
+			}
+		},
+	);
 
 	it("preserves active authority while capability evidence is undetermined", async () => {
 		const { effects } = harness(["device-keep"]);

--- a/packages/core/src/recipient-policy-reconciliation.test.ts
+++ b/packages/core/src/recipient-policy-reconciliation.test.ts
@@ -216,28 +216,31 @@ describe("strict recipient-policy effective-device derivation", () => {
 		["future_mode", "active", "included", "team_device_eligibility_mode_invalid"],
 		["person_all_devices", "reviewed_active", "included", "team_membership_mode_invalid"],
 		["reviewed_allowlist", "reviewed_active", "future_decision", "team_device_decision_invalid"],
-	] as const)("blocks invalid Team eligibility state (%s)", (mode, membershipStatus, decision, code) => {
-		const input = graph();
-		input.teams[0] = {
-			teamId: "team-a",
-			status: "active",
-			deviceEligibilityMode: mode,
-		};
-		input.teamMemberships[0] = {
-			teamId: "team-a",
-			identityId: "identity-b",
-			status: membershipStatus,
-		};
-		input.teamDeviceDecisions = [
-			{ teamId: "team-a", deviceId: "device-b", decision, assignmentVersion: 0 },
-		];
+	] as const)(
+		"blocks invalid Team eligibility state (%s)",
+		(mode, membershipStatus, decision, code) => {
+			const input = graph();
+			input.teams[0] = {
+				teamId: "team-a",
+				status: "active",
+				deviceEligibilityMode: mode,
+			};
+			input.teamMemberships[0] = {
+				teamId: "team-a",
+				identityId: "identity-b",
+				status: membershipStatus,
+			};
+			input.teamDeviceDecisions = [
+				{ teamId: "team-a", deviceId: "device-b", decision, assignmentVersion: 0 },
+			];
 
-		const result = deriveRecipientPolicyEffectiveDevices(input);
+			const result = deriveRecipientPolicyEffectiveDevices(input);
 
-		expect(result.status).toBe("blocked");
-		expect(result.devices).toEqual([]);
-		expect(result.blocked).toContainEqual(expect.objectContaining({ code }));
-	});
+			expect(result.status).toBe("blocked");
+			expect(result.devices).toEqual([]);
+			expect(result.blocked).toContainEqual(expect.objectContaining({ code }));
+		},
+	);
 
 	it("does not authorize a reviewed Team device with a stale assignment decision", () => {
 		const input = graph();

--- a/packages/core/src/recipient-policy-review.test.ts
+++ b/packages/core/src/recipient-policy-review.test.ts
@@ -383,31 +383,31 @@ describe("recipient policy review persistence", () => {
 		});
 	});
 
-	it.each([
-		"managed_project",
-		"future_project_boundary",
-	])("keeps a %s multi-project scope repairable", (kind) => {
-		configureUmbrellaScope(db, kind);
+	it.each(["managed_project", "future_project_boundary"])(
+		"keeps a %s multi-project scope repairable",
+		(kind) => {
+			configureUmbrellaScope(db, kind);
 
-		const result = listRecipientPolicyReview(db, context);
+			const result = listRecipientPolicyReview(db, context);
 
-		expect(result).toMatchObject({
-			blockedItems: [
-				{
-					ownerLabel: "Local administrator",
-					repairAction:
-						"Assign each Project to its own managed scope and move its memories out of the shared boundary.",
-				},
-				{
-					ownerLabel: "Local administrator",
-					repairAction:
-						"Assign each Project to its own managed scope and move its memories out of the shared boundary.",
-				},
-			],
-			continuity: null,
-			reviewItems: [],
-		});
-	});
+			expect(result).toMatchObject({
+				blockedItems: [
+					{
+						ownerLabel: "Local administrator",
+						repairAction:
+							"Assign each Project to its own managed scope and move its memories out of the shared boundary.",
+					},
+					{
+						ownerLabel: "Local administrator",
+						repairAction:
+							"Assign each Project to its own managed scope and move its memories out of the shared boundary.",
+					},
+				],
+				continuity: null,
+				reviewItems: [],
+			});
+		},
+	);
 
 	it("keeps a wildcard scope mapping as continuity without repair cards", () => {
 		const scopeId = "legacy-wildcard";
@@ -1133,28 +1133,31 @@ describe("recipient policy review persistence", () => {
 			'{"recipientIds":["actor-candidate"]}',
 		],
 		["remove_stale_device", { deviceId: "device-unassigned" }, '{"deviceId":"device-unassigned"}'],
-	] as const)("normalizes and stores %s decision input", (decision, decisionInput, expectedJson) => {
-		configureUnassignedDeviceReview(db);
-		const item = listRecipientPolicyReview(db, context).reviewItems.find((candidate) =>
-			candidate.options.some((option) => option.decision === decision),
-		);
-		if (!item) throw new Error("unassigned review item missing");
+	] as const)(
+		"normalizes and stores %s decision input",
+		(decision, decisionInput, expectedJson) => {
+			configureUnassignedDeviceReview(db);
+			const item = listRecipientPolicyReview(db, context).reviewItems.find((candidate) =>
+				candidate.options.some((option) => option.decision === decision),
+			);
+			if (!item) throw new Error("unassigned review item missing");
 
-		const result = resolveRecipientPolicyReview(db, context, {
-			reviewItemId: item.reviewItemId,
-			sourceFingerprint: item.sourceFingerprint,
-			decision,
-			decisionInput,
-		});
+			const result = resolveRecipientPolicyReview(db, context, {
+				reviewItemId: item.reviewItemId,
+				sourceFingerprint: item.sourceFingerprint,
+				decision,
+				decisionInput,
+			});
 
-		expect(result.status).toBe("applied");
-		expect(
-			db
-				.prepare("SELECT decision_input_json FROM recipient_policy_review_resolutions")
-				.pluck()
-				.get(),
-		).toBe(expectedJson);
-	});
+			expect(result.status).toBe("applied");
+			expect(
+				db
+					.prepare("SELECT decision_input_json FROM recipient_policy_review_resolutions")
+					.pluck()
+					.get(),
+			).toBe(expectedJson);
+		},
+	);
 
 	it("keeps unassigned-device resolutions durable and scoped to one device", () => {
 		configureUnassignedDeviceReview(db, ["device-unassigned-a", "device-unassigned-b"]);

--- a/packages/core/src/release-discovery.test.ts
+++ b/packages/core/src/release-discovery.test.ts
@@ -890,19 +890,20 @@ describe("installation guidance", () => {
 		["repo-dev", "git pull"],
 		["pinned", "pinned"],
 		["unknown", "installation method"],
-	] satisfies Array<
-		[InstallKind, string]
-	>)("returns %s-specific upgrade guidance", async (installKind, expectedGuidance) => {
-		// Arrange
-		const deps = dependencies();
+	] satisfies Array<[InstallKind, string]>)(
+		"returns %s-specific upgrade guidance",
+		async (installKind, expectedGuidance) => {
+			// Arrange
+			const deps = dependencies();
 
-		// Act
-		const status = await check(deps, { installKind });
+			// Act
+			const status = await check(deps, { installKind });
 
-		// Assert
-		expect(status).toMatchObject({ install_kind: installKind });
-		expect(status.recommended_action).toContain(expectedGuidance);
-	});
+			// Assert
+			expect(status).toMatchObject({ install_kind: installKind });
+			expect(status.recommended_action).toContain(expectedGuidance);
+		},
+	);
 
 	it("returns no-upgrade guidance when the installation is current", async () => {
 		// Arrange

--- a/packages/core/src/retrieval-ledger.test.ts
+++ b/packages/core/src/retrieval-ledger.test.ts
@@ -731,13 +731,12 @@ describe("retrieval attribution ledger", () => {
 		).toEqual(["experiment_id", "experiment_cell_id"]);
 	});
 
-	it.each([
-		"import_key",
-		"origin_device_id",
-	])("skips additive ledger DDL when a legacy memory schema lacks %s", (missingColumn) => {
-		const legacy = new Database(":memory:");
-		try {
-			legacy.exec(`
+	it.each(["import_key", "origin_device_id"])(
+		"skips additive ledger DDL when a legacy memory schema lacks %s",
+		(missingColumn) => {
+			const legacy = new Database(":memory:");
+			try {
+				legacy.exec(`
 					CREATE TABLE sessions (id INTEGER PRIMARY KEY);
 					CREATE TABLE memory_items (
 						id INTEGER PRIMARY KEY,
@@ -747,17 +746,18 @@ describe("retrieval attribution ledger", () => {
 					);
 				`);
 
-			expect(() => ensureRetrievalLedgerSchema(legacy)).not.toThrow();
-			expect(
-				legacy
-					.prepare("SELECT count(*) FROM sqlite_master WHERE name = 'retrieval_attempts'")
-					.pluck()
-					.get(),
-			).toBe(0);
-		} finally {
-			legacy.close();
-		}
-	});
+				expect(() => ensureRetrievalLedgerSchema(legacy)).not.toThrow();
+				expect(
+					legacy
+						.prepare("SELECT count(*) FROM sqlite_master WHERE name = 'retrieval_attempts'")
+						.pluck()
+						.get(),
+				).toBe(0);
+			} finally {
+				legacy.close();
+			}
+		},
+	);
 
 	it("adds nullable ledger columns to an existing ledger without rewriting rows", () => {
 		recordRetrievalAttempt(db, input());

--- a/packages/core/src/share-operation-lifecycle.test.ts
+++ b/packages/core/src/share-operation-lifecycle.test.ts
@@ -57,9 +57,12 @@ describe("projectShareLifecycle", () => {
 			"Invitation cancelled",
 			{ kind: "create_new_invite", label: "Create new invite" },
 		],
-	] as const)("projects %s with its required recovery action", (state, lifecycle, label, action) => {
-		expect(project(state)).toMatchObject({ lifecycle, label, primaryAction: action });
-	});
+	] as const)(
+		"projects %s with its required recovery action",
+		(state, lifecycle, label, action) => {
+			expect(project(state)).toMatchObject({ lifecycle, label, primaryAction: action });
+		},
+	);
 
 	it("offers Copy invite only when the safe link is available", () => {
 		expect(project("waiting_for_acceptance", [], "codemem://invite/encoded").primaryAction).toEqual(

--- a/packages/core/src/sync-bootstrap.test.ts
+++ b/packages/core/src/sync-bootstrap.test.ts
@@ -281,37 +281,37 @@ describe("applyBootstrapSnapshot", () => {
 				{ scopeCase: "non-string scope", payloadScopeId: 123 },
 			].map((scope) => ({ name, bootstrap, ...scope })),
 		),
-	)("$name rejects $scopeCase rows on default bootstrap before mutating local state", ({
-		bootstrap,
-		payloadScopeId,
-	}) => {
-		const now = "2026-01-01T00:00:00Z";
-		db.prepare(
-			`INSERT INTO memory_items(
+	)(
+		"$name rejects $scopeCase rows on default bootstrap before mutating local state",
+		({ bootstrap, payloadScopeId }) => {
+			const now = "2026-01-01T00:00:00Z";
+			db.prepare(
+				`INSERT INTO memory_items(
 				session_id, kind, title, body_text, created_at, updated_at, import_key, rev,
 				visibility, scope_id, metadata_json
 			 ) VALUES (?, 'discovery', 'existing', 'body', ?, ?, 'existing-key', 1, 'shared', NULL, ?)`,
-		).run(sessionId, now, now, toJson({ clock_device_id: "local" }));
-		const items = [
-			makeSnapshotItem("unauthorized-scoped-row", { payload: { scope_id: payloadScopeId } }),
-		];
+			).run(sessionId, now, now, toJson({ clock_device_id: "local" }));
+			const items = [
+				makeSnapshotItem("unauthorized-scoped-row", { payload: { scope_id: payloadScopeId } }),
+			];
 
-		expect(() => bootstrap(db, "peer-1", items, makeResetInfo({ scope_id: null }))).toThrow(
-			"scope_mismatch",
-		);
+			expect(() => bootstrap(db, "peer-1", items, makeResetInfo({ scope_id: null }))).toThrow(
+				"scope_mismatch",
+			);
 
-		expect(
-			db.prepare("SELECT title FROM memory_items WHERE import_key = ?").get("existing-key"),
-		).toEqual({ title: "existing" });
-		expect(
-			db
-				.prepare("SELECT COUNT(*) FROM memory_items WHERE import_key = ?")
-				.pluck()
-				.get("unauthorized-scoped-row"),
-		).toBe(0);
-		expect(getSyncResetState(db).snapshot_id).toBe("snap-1");
-		expect(getReplicationCursor(db, "peer-1")).toEqual([null, null]);
-	});
+			expect(
+				db.prepare("SELECT title FROM memory_items WHERE import_key = ?").get("existing-key"),
+			).toEqual({ title: "existing" });
+			expect(
+				db
+					.prepare("SELECT COUNT(*) FROM memory_items WHERE import_key = ?")
+					.pluck()
+					.get("unauthorized-scoped-row"),
+			).toBe(0);
+			expect(getSyncResetState(db).snapshot_id).toBe("snap-1");
+			expect(getReplicationCursor(db, "peer-1")).toEqual([null, null]);
+		},
+	);
 
 	it("uses the requested managed scope when payload scope_id is non-string", () => {
 		const items = [makeSnapshotItem("malformed-scope-key", { payload: { scope_id: 123 } })];

--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -397,7 +397,9 @@ describe("syncOnce", () => {
 			.mock.calls.filter(([method]) => method === "POST");
 		expect(pushCalls).toHaveLength(3);
 		expect(
-			pushCalls.map(([, , options]) => (options?.body as { ops: unknown[] }).ops.length),
+			pushCalls.map(
+				([, , options]) => (options?.body as { ops: unknown[] } | undefined)?.ops.length,
+			),
 		).toEqual([2, 1, 1]);
 		for (const [, , request] of pushCalls) {
 			expect(request?.headers).toMatchObject({
@@ -459,49 +461,58 @@ describe("syncOnce", () => {
 		["malformed", "not-a-version"],
 		["oversized", `1.2.3+${"a".repeat(129)}`],
 		["prerelease", "0.41.0-beta.1"],
-	])("clears peer runtime metadata when a matching status reports %s version data", async (_, value) => {
-		db.prepare(
-			`INSERT INTO sync_peers (
+	])(
+		"clears peer runtime metadata when a matching status reports %s version data",
+		async (_, value) => {
+			db.prepare(
+				`INSERT INTO sync_peers (
 				peer_device_id, pinned_fingerprint, runtime_version, runtime_version_observed_at, created_at
 			) VALUES (?, ?, ?, ?, ?)`,
-		).run("peer-version", "abc123", "0.40.1", "2026-08-01T00:00:00.000Z", new Date().toISOString());
-		db.prepare(
-			"INSERT INTO replication_cursors (peer_device_id, last_applied_cursor, updated_at) VALUES (?, ?, ?)",
-		).run("peer-version", "2025-12-31T00:00:00Z|local-op-0", new Date().toISOString());
-		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
-			"local-device-id",
-			"ed25519 AAAA",
-		]);
-		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
-		vi.spyOn(syncHttpClient, "requestJson")
-			.mockResolvedValueOnce([
-				200,
-				{
-					device_id: "peer-version",
-					fingerprint: "abc123",
-					protocol_version: "2",
-					...(value === undefined ? {} : { runtime_version: value }),
-					sync_capability: "legacy",
-					sync_reset: {
-						generation: 1,
-						snapshot_id: "snap-1",
-						baseline_cursor: null,
-						retained_floor_cursor: null,
+			).run(
+				"peer-version",
+				"abc123",
+				"0.40.1",
+				"2026-08-01T00:00:00.000Z",
+				new Date().toISOString(),
+			);
+			db.prepare(
+				"INSERT INTO replication_cursors (peer_device_id, last_applied_cursor, updated_at) VALUES (?, ?, ?)",
+			).run("peer-version", "2025-12-31T00:00:00Z|local-op-0", new Date().toISOString());
+			vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+				"local-device-id",
+				"ed25519 AAAA",
+			]);
+			vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+			vi.spyOn(syncHttpClient, "requestJson")
+				.mockResolvedValueOnce([
+					200,
+					{
+						device_id: "peer-version",
+						fingerprint: "abc123",
+						protocol_version: "2",
+						...(value === undefined ? {} : { runtime_version: value }),
+						sync_capability: "legacy",
+						sync_reset: {
+							generation: 1,
+							snapshot_id: "snap-1",
+							baseline_cursor: null,
+							retained_floor_cursor: null,
+						},
 					},
-				},
-			])
-			.mockResolvedValueOnce([500, { error: "stop_after_status" }]);
+				])
+				.mockResolvedValueOnce([500, { error: "stop_after_status" }]);
 
-		await syncOnce(db, "peer-version", ["http://127.0.0.1:9090"]);
+			await syncOnce(db, "peer-version", ["http://127.0.0.1:9090"]);
 
-		expect(
-			db
-				.prepare(
-					"SELECT runtime_version, runtime_version_observed_at FROM sync_peers WHERE peer_device_id = ?",
-				)
-				.get("peer-version"),
-		).toEqual({ runtime_version: null, runtime_version_observed_at: null });
-	});
+			expect(
+				db
+					.prepare(
+						"SELECT runtime_version, runtime_version_observed_at FROM sync_peers WHERE peer_device_id = ?",
+					)
+					.get("peer-version"),
+			).toEqual({ runtime_version: null, runtime_version_observed_at: null });
+		},
+	);
 
 	it("keeps trusted runtime metadata when status fingerprint verification fails", async () => {
 		db.prepare(
@@ -547,50 +558,59 @@ describe("syncOnce", () => {
 	it.each([
 		["wrong", "different-peer"],
 		["missing", undefined],
-	])("clears runtime metadata for a %s status device without creating a trust failure", async (_, statusDeviceId) => {
-		db.prepare(
-			`INSERT INTO sync_peers (
+	])(
+		"clears runtime metadata for a %s status device without creating a trust failure",
+		async (_, statusDeviceId) => {
+			db.prepare(
+				`INSERT INTO sync_peers (
 					peer_device_id, pinned_fingerprint, runtime_version, runtime_version_observed_at, created_at
 				) VALUES (?, ?, ?, ?, ?)`,
-		).run("peer-version", "abc123", "0.40.1", "2026-08-01T00:00:00.000Z", new Date().toISOString());
-		db.prepare(
-			"INSERT INTO replication_cursors (peer_device_id, last_applied_cursor, updated_at) VALUES (?, ?, ?)",
-		).run("peer-version", "2025-12-31T00:00:00Z|local-op-0", new Date().toISOString());
-		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
-			"local-device-id",
-			"ed25519 AAAA",
-		]);
-		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
-		vi.spyOn(syncHttpClient, "requestJson")
-			.mockResolvedValueOnce([
-				200,
-				{
-					...(statusDeviceId === undefined ? {} : { device_id: statusDeviceId }),
-					fingerprint: "abc123",
-					protocol_version: "2",
-					runtime_version: "0.40.2",
-					sync_capability: "legacy",
-					sync_reset: {
-						generation: 1,
-						snapshot_id: "snap-1",
-						baseline_cursor: null,
-						retained_floor_cursor: null,
+			).run(
+				"peer-version",
+				"abc123",
+				"0.40.1",
+				"2026-08-01T00:00:00.000Z",
+				new Date().toISOString(),
+			);
+			db.prepare(
+				"INSERT INTO replication_cursors (peer_device_id, last_applied_cursor, updated_at) VALUES (?, ?, ?)",
+			).run("peer-version", "2025-12-31T00:00:00Z|local-op-0", new Date().toISOString());
+			vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+				"local-device-id",
+				"ed25519 AAAA",
+			]);
+			vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+			vi.spyOn(syncHttpClient, "requestJson")
+				.mockResolvedValueOnce([
+					200,
+					{
+						...(statusDeviceId === undefined ? {} : { device_id: statusDeviceId }),
+						fingerprint: "abc123",
+						protocol_version: "2",
+						runtime_version: "0.40.2",
+						sync_capability: "legacy",
+						sync_reset: {
+							generation: 1,
+							snapshot_id: "snap-1",
+							baseline_cursor: null,
+							retained_floor_cursor: null,
+						},
 					},
-				},
-			])
-			.mockResolvedValueOnce([500, { error: "stop_after_status" }]);
+				])
+				.mockResolvedValueOnce([500, { error: "stop_after_status" }]);
 
-		const result = await syncOnce(db, "peer-version", ["http://127.0.0.1:9090"]);
+			const result = await syncOnce(db, "peer-version", ["http://127.0.0.1:9090"]);
 
-		expect(result.failureCategory).not.toBe("trust");
-		expect(
-			db
-				.prepare(
-					"SELECT runtime_version, runtime_version_observed_at FROM sync_peers WHERE peer_device_id = ?",
-				)
-				.get("peer-version"),
-		).toEqual({ runtime_version: null, runtime_version_observed_at: null });
-	});
+			expect(result.failureCategory).not.toBe("trust");
+			expect(
+				db
+					.prepare(
+						"SELECT runtime_version, runtime_version_observed_at FROM sync_peers WHERE peer_device_id = ?",
+					)
+					.get("peer-version"),
+			).toEqual({ runtime_version: null, runtime_version_observed_at: null });
+		},
+	);
 
 	it("queues durable vector catch-up after applying incremental inbound ops", async () => {
 		db.prepare(
@@ -1822,97 +1842,96 @@ describe("syncOnce", () => {
 		]);
 	});
 
-	it.each([
-		"missing_scope",
-		"stale_epoch",
-		"scope_inactive",
-	] as const)("keeps %s reset_required failures categorized as scope access", async (reason) => {
-		db.prepare(
-			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
-		).run(`peer-${reason}`, `fp-${reason}`, new Date().toISOString());
-		syncReplication.setReplicationCursor(db, `peer-${reason}`, {
-			lastApplied: "2025-12-31T00:00:00Z|default-baseline",
-		});
-		syncReplication.setReplicationCursor(
-			db,
-			`peer-${reason}`,
-			{ lastApplied: "2025-12-31T00:00:00Z|stale-acme" },
-			"acme-work",
-		);
-		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
-			"local-device-id",
-			"ed25519 AAAA",
-		]);
-		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
-		grantScopeForSyncPass(db, "acme-work", [`peer-${reason}`, "local-device-id"]);
+	it.each(["missing_scope", "stale_epoch", "scope_inactive"] as const)(
+		"keeps %s reset_required failures categorized as scope access",
+		async (reason) => {
+			db.prepare(
+				"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+			).run(`peer-${reason}`, `fp-${reason}`, new Date().toISOString());
+			syncReplication.setReplicationCursor(db, `peer-${reason}`, {
+				lastApplied: "2025-12-31T00:00:00Z|default-baseline",
+			});
+			syncReplication.setReplicationCursor(
+				db,
+				`peer-${reason}`,
+				{ lastApplied: "2025-12-31T00:00:00Z|stale-acme" },
+				"acme-work",
+			);
+			vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+				"local-device-id",
+				"ed25519 AAAA",
+			]);
+			vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+			grantScopeForSyncPass(db, "acme-work", [`peer-${reason}`, "local-device-id"]);
 
-		vi.spyOn(syncHttpClient, "requestJson")
-			.mockResolvedValueOnce([
-				200,
-				{
-					fingerprint: `fp-${reason}`,
-					protocol_version: "2",
-					sync_capability: "scoped",
-					sync_reset: {
+			vi.spyOn(syncHttpClient, "requestJson")
+				.mockResolvedValueOnce([
+					200,
+					{
+						fingerprint: `fp-${reason}`,
+						protocol_version: "2",
+						sync_capability: "scoped",
+						sync_reset: {
+							generation: 1,
+							snapshot_id: "snap-default",
+							baseline_cursor: null,
+							retained_floor_cursor: null,
+						},
+						authorized_scopes: [
+							{
+								scope_id: "acme-work",
+								label: "acme-work",
+								authority_type: "coordinator",
+								membership_epoch: 1,
+								sync_reset: {
+									scope_id: "acme-work",
+									generation: 2,
+									snapshot_id: "snap-acme-2",
+									baseline_cursor: null,
+									retained_floor_cursor: null,
+								},
+							},
+						],
+					},
+				])
+				.mockResolvedValueOnce([
+					200,
+					{
+						reset_required: false,
 						generation: 1,
 						snapshot_id: "snap-default",
 						baseline_cursor: null,
 						retained_floor_cursor: null,
+						ops: [],
+						next_cursor: null,
+						skipped: 0,
 					},
-					authorized_scopes: [
-						{
-							scope_id: "acme-work",
-							label: "acme-work",
-							authority_type: "coordinator",
-							membership_epoch: 1,
-							sync_reset: {
-								scope_id: "acme-work",
-								generation: 2,
-								snapshot_id: "snap-acme-2",
-								baseline_cursor: null,
-								retained_floor_cursor: null,
-							},
-						},
-					],
-				},
-			])
-			.mockResolvedValueOnce([
-				200,
-				{
-					reset_required: false,
-					generation: 1,
-					snapshot_id: "snap-default",
-					baseline_cursor: null,
-					retained_floor_cursor: null,
-					ops: [],
-					next_cursor: null,
-					skipped: 0,
-				},
-			])
-			.mockResolvedValueOnce([
-				409,
-				{
-					reset_required: true,
-					reason,
-					scope_id: "acme-work",
-					generation: 2,
-					snapshot_id: "snap-acme-2",
-					baseline_cursor: null,
-					retained_floor_cursor: null,
-				},
-			]);
+				])
+				.mockResolvedValueOnce([
+					409,
+					{
+						reset_required: true,
+						reason,
+						scope_id: "acme-work",
+						generation: 2,
+						snapshot_id: "snap-acme-2",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+				]);
 
-		const result = await syncOnce(db, `peer-${reason}`, ["http://127.0.0.1:9090"]);
+			const result = await syncOnce(db, `peer-${reason}`, ["http://127.0.0.1:9090"]);
 
-		expect(result.ok).toBe(false);
-		expect(result.perScopeResults?.[0]).toMatchObject({
-			scope_id: "acme-work",
-			ok: false,
-			error: `reset_required:${reason}`,
-			failureCategory: "scope",
-		});
-		expect(result.failureCategory).toBe("scope");
-	});
+			expect(result.ok).toBe(false);
+			expect(result.perScopeResults?.[0]).toMatchObject({
+				scope_id: "acme-work",
+				ok: false,
+				error: `reset_required:${reason}`,
+				failureCategory: "scope",
+			});
+			expect(result.failureCategory).toBe("scope");
+		},
+	);
 
 	it("keeps unsupported-scope reset_required failures categorized as protocol drift", async () => {
 		db.prepare(

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -2830,33 +2830,33 @@ describe("applyReplicationOps", () => {
 	it.each([
 		{ name: "null scope", scopeId: null, reason: "missing_scope" },
 		{ name: "local-default scope", scopeId: DEFAULT_SYNC_SCOPE_ID, reason: "scope_mismatch" },
-	] as const)("rejects regular inbound ops with $name when legacy scope validation is disabled", ({
-		scopeId,
-		reason,
-	}) => {
-		const op = makeReplicationOp({
-			op_id: `legacy-disabled-${reason}`,
-			scope_id: scopeId,
-			payload_json: toJson({
-				kind: "discovery",
-				title: "Blocked local-only memory",
-				body_text: "Remote body",
+	] as const)(
+		"rejects regular inbound ops with $name when legacy scope validation is disabled",
+		({ scopeId, reason }) => {
+			const op = makeReplicationOp({
+				op_id: `legacy-disabled-${reason}`,
 				scope_id: scopeId,
-			}),
-		});
+				payload_json: toJson({
+					kind: "discovery",
+					title: "Blocked local-only memory",
+					body_text: "Remote body",
+					scope_id: scopeId,
+				}),
+			});
 
-		const result = applyReplicationOps(db, [op], "dev-local", undefined, {
-			inboundScopeValidation: { peerDeviceId: "dev-remote", enabled: false },
-		});
+			const result = applyReplicationOps(db, [op], "dev-local", undefined, {
+				inboundScopeValidation: { peerDeviceId: "dev-remote", enabled: false },
+			});
 
-		expect(result.applied).toBe(0);
-		expect(result.rejected).toBe(1);
-		expect(result.rejections[0]).toMatchObject({ op_id: op.op_id, reason });
-		expect(memoryExists(op.entity_id)).toBe(false);
-		expect(
-			db.prepare("SELECT 1 FROM replication_ops WHERE op_id = ?").get(op.op_id),
-		).toBeUndefined();
-	});
+			expect(result.applied).toBe(0);
+			expect(result.rejected).toBe(1);
+			expect(result.rejections[0]).toMatchObject({ op_id: op.op_id, reason });
+			expect(memoryExists(op.entity_id)).toBe(false);
+			expect(
+				db.prepare("SELECT 1 FROM replication_ops WHERE op_id = ?").get(op.op_id),
+			).toBeUndefined();
+		},
+	);
 
 	function makeUnsupportedOldSideReassignment(importKey: string): ReplicationOp {
 		return makeReplicationOp({
@@ -2914,29 +2914,29 @@ describe("applyReplicationOps", () => {
 		{ name: "foreign", originDeviceId: "dev-other" },
 		{ name: "local", originDeviceId: "dev-local" },
 		{ name: "ambiguous", originDeviceId: null },
-	] as const)("rejects $name-origin old-side reassignment when strict validation is disabled", ({
-		name,
-		originDeviceId,
-	}) => {
-		const importKey = `key:unsupported-${name}-origin`;
-		insertReplicatedMemory({
-			importKey,
-			originDeviceId,
-			scopeId: DEFAULT_SYNC_SCOPE_ID,
-		});
-		const op = makeUnsupportedOldSideReassignment(importKey);
+	] as const)(
+		"rejects $name-origin old-side reassignment when strict validation is disabled",
+		({ name, originDeviceId }) => {
+			const importKey = `key:unsupported-${name}-origin`;
+			insertReplicatedMemory({
+				importKey,
+				originDeviceId,
+				scopeId: DEFAULT_SYNC_SCOPE_ID,
+			});
+			const op = makeUnsupportedOldSideReassignment(importKey);
 
-		const result = applyReplicationOps(db, [op], "dev-local", undefined, {
-			inboundScopeValidation: { peerDeviceId: "dev-remote", enabled: false },
-		});
+			const result = applyReplicationOps(db, [op], "dev-local", undefined, {
+				inboundScopeValidation: { peerDeviceId: "dev-remote", enabled: false },
+			});
 
-		expect(result.applied).toBe(0);
-		expect(result.rejected).toBe(1);
-		expect(result.rejections[0]).toMatchObject({ reason: "sender_not_member" });
-		expect(
-			db.prepare("SELECT active FROM memory_items WHERE import_key = ?").pluck().get(importKey),
-		).toBe(1);
-	});
+			expect(result.applied).toBe(0);
+			expect(result.rejected).toBe(1);
+			expect(result.rejections[0]).toMatchObject({ reason: "sender_not_member" });
+			expect(
+				db.prepare("SELECT active FROM memory_items WHERE import_key = ?").pluck().get(importKey),
+			).toBe(1);
+		},
+	);
 
 	it("allows sender-owned local-default cleanup for a prior recipient outside the destination", () => {
 		const importKey = "key:default-reassign";

--- a/packages/mcp-server/src/stdio-viewer.test.ts
+++ b/packages/mcp-server/src/stdio-viewer.test.ts
@@ -103,22 +103,22 @@ describe("MCP viewer ensure", () => {
 		expect(spawnMock).not.toHaveBeenCalled();
 	});
 
-	it.each([
-		"CODEMEM_VIEWER",
-		"CODEMEM_VIEWER_AUTO",
-	] as const)("respects the %s opt-out", async (variable) => {
-		const fetchMock = createFetchMock();
-		const { spawnMock } = createSpawnMock();
+	it.each(["CODEMEM_VIEWER", "CODEMEM_VIEWER_AUTO"] as const)(
+		"respects the %s opt-out",
+		async (variable) => {
+			const fetchMock = createFetchMock();
+			const { spawnMock } = createSpawnMock();
 
-		await ensureViewer({
-			env: { [variable]: "0" },
-			fetchImpl: fetchMock,
-			spawnImpl: spawnMock,
-		});
+			await ensureViewer({
+				env: { [variable]: "0" },
+				fetchImpl: fetchMock,
+				spawnImpl: spawnMock,
+			});
 
-		expect(fetchMock).not.toHaveBeenCalled();
-		expect(spawnMock).not.toHaveBeenCalled();
-	});
+			expect(fetchMock).not.toHaveBeenCalled();
+			expect(spawnMock).not.toHaveBeenCalled();
+		},
+	);
 
 	it("spawns detached with preserved arguments and polls five times", async () => {
 		const fetchMock = createFetchMock(...Array.from({ length: 6 }, () => new Error("offline")));

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -169,25 +169,27 @@ describe("recipient invitation API", () => {
 		});
 	});
 
-	it.each([
-		"team_member",
-		"add_device",
-	] as const)("does not classify %s failures as Project invitation failures", async (inviteKind) => {
-		globalThis.fetch = vi.fn(
-			async () =>
-				new Response(JSON.stringify({ error: "invite_identity_conflict" }), {
-					status: 409,
-				}),
-		) as typeof fetch;
+	it.each(["team_member", "add_device"] as const)(
+		"does not classify %s failures as Project invitation failures",
+		async (inviteKind) => {
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(JSON.stringify({ error: "invite_identity_conflict" }), {
+						status: 409,
+					}),
+			) as typeof fetch;
 
-		const failure = await importCoordinatorInvite("recipient-invite", undefined, inviteKind).catch(
-			(cause: unknown) => cause,
-		);
+			const failure = await importCoordinatorInvite(
+				"recipient-invite",
+				undefined,
+				inviteKind,
+			).catch((cause: unknown) => cause);
 
-		expect(failure).toBeInstanceOf(Error);
-		expect(failure).not.toBeInstanceOf(ProjectInviteAcceptanceError);
-		expect(failure).toMatchObject({ message: "invite_identity_conflict" });
-	});
+			expect(failure).toBeInstanceOf(Error);
+			expect(failure).not.toBeInstanceOf(ProjectInviteAcceptanceError);
+			expect(failure).toMatchObject({ message: "invite_identity_conflict" });
+		},
+	);
 
 	it("keeps unknown Project invitation errors untyped", async () => {
 		globalThis.fetch = vi.fn(
@@ -573,22 +575,20 @@ describe("legacy Team setup API", () => {
 		});
 	});
 
-	it.each([
-		"",
-		"not json",
-		"{}",
-		"[]",
-	])("rejects malformed successful Team setup payload %j", async (body) => {
-		globalThis.fetch = vi
-			.fn()
-			.mockResolvedValue(new Response(body, { status: 200 })) as typeof fetch;
+	it.each(["", "not json", "{}", "[]"])(
+		"rejects malformed successful Team setup payload %j",
+		async (body) => {
+			globalThis.fetch = vi
+				.fn()
+				.mockResolvedValue(new Response(body, { status: 200 })) as typeof fetch;
 
-		await expect(loadLegacyTeamSetupSummary()).rejects.toMatchObject({
-			statusCode: 200,
-			errorCode: "team_setup_failed",
-			message: "team_setup_failed",
-		});
-	});
+			await expect(loadLegacyTeamSetupSummary()).rejects.toMatchObject({
+				statusCode: 200,
+				errorCode: "team_setup_failed",
+				message: "team_setup_failed",
+			});
+		},
+	);
 
 	it("rejects finishable detail without viewer-bound confirmation evidence", async () => {
 		globalThis.fetch = vi.fn().mockResolvedValue(

--- a/packages/ui/src/lib/state.test.ts
+++ b/packages/ui/src/lib/state.test.ts
@@ -24,16 +24,12 @@ describe("Viewer tab routing", () => {
 		expect(ALL_TAB_IDS).toEqual(["feed", "projects", "sharing", "devices", "health", "advanced"]);
 	});
 
-	it.each([
-		"feed",
-		"projects",
-		"sharing",
-		"devices",
-		"health",
-		"advanced",
-	])("recognizes #%s as a canonical route", (tab) => {
-		expect(parseTabFromHash(`#${tab}`)).toBe(tab);
-	});
+	it.each(["feed", "projects", "sharing", "devices", "health", "advanced"])(
+		"recognizes #%s as a canonical route",
+		(tab) => {
+			expect(parseTabFromHash(`#${tab}`)).toBe(tab);
+		},
+	);
 
 	it.each([
 		["#sync", "sync"],

--- a/packages/ui/src/tabs/coordinator-admin/data/actions.test.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/actions.test.ts
@@ -280,27 +280,27 @@ describe("coordinator admin actions", () => {
 		expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain("private-group-id");
 	});
 
-	it.each([
-		new Error("private coordinator detail"),
-		"group_archived",
-	])("keeps generic recovery guidance for an unknown invite failure (%o)", async (cause) => {
-		mocks.createCoordinatorInvite.mockRejectedValue(cause);
-		coordinatorAdminState.inviteGroup = "team-alpha";
-		const actions = createCoordinatorAdminActions({
-			renderShell: vi.fn(),
-			reloadData: vi.fn().mockResolvedValue(undefined),
-		});
+	it.each([new Error("private coordinator detail"), "group_archived"])(
+		"keeps generic recovery guidance for an unknown invite failure (%o)",
+		async (cause) => {
+			mocks.createCoordinatorInvite.mockRejectedValue(cause);
+			coordinatorAdminState.inviteGroup = "team-alpha";
+			const actions = createCoordinatorAdminActions({
+				renderShell: vi.fn(),
+				reloadData: vi.fn().mockResolvedValue(undefined),
+			});
 
-		await actions.createInviteFromAdminPanel();
+			await actions.createInviteFromAdminPanel();
 
-		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
-			"Could not create the legacy coordinator invite. Sharing policy is unchanged; check coordinator recovery status and retry.",
-			"warning",
-		);
-		expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain(
-			"private coordinator detail",
-		);
-	});
+			expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+				"Could not create the legacy coordinator invite. Sharing policy is unchanged; check coordinator recovery status and retry.",
+				"warning",
+			);
+			expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain(
+				"private coordinator detail",
+			);
+		},
+	);
 
 	it("does not restore an invite returned after coordinator data is superseded", async () => {
 		const invite = deferred<{ token: string; warnings: string[] }>();
@@ -404,40 +404,45 @@ describe("coordinator admin actions", () => {
 		["approve", "Remote coordinator request failed (404): request_not_found"],
 		["deny", "join request not found: private-request-id"],
 		["deny", "Remote coordinator request failed (404): request_not_found"],
-	] as const)("refreshes pending requests when %s reports a missing request (%s)", async (action, message) => {
-		mocks.reviewCoordinatorAdminJoinRequest.mockRejectedValue(new Error(message));
-		const reloadData = vi.fn().mockResolvedValue(undefined);
-		const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
+	] as const)(
+		"refreshes pending requests when %s reports a missing request (%s)",
+		async (action, message) => {
+			mocks.reviewCoordinatorAdminJoinRequest.mockRejectedValue(new Error(message));
+			const reloadData = vi.fn().mockResolvedValue(undefined);
+			const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
 
-		await actions.reviewJoinRequestFromAdminPanel("private-request-id", action);
+			await actions.reviewJoinRequestFromAdminPanel("private-request-id", action);
 
-		expect(reloadData).toHaveBeenCalledTimes(1);
-		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
-			"This legacy coordinator join request no longer exists. Pending requests were refreshed.",
-			"warning",
-		);
-		expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain("private-request-id");
-	});
+			expect(reloadData).toHaveBeenCalledTimes(1);
+			expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+				"This legacy coordinator join request no longer exists. Pending requests were refreshed.",
+				"warning",
+			);
+			expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain(
+				"private-request-id",
+			);
+		},
+	);
 
-	it.each([
-		new Error("private coordinator detail"),
-		"request_not_found",
-	])("keeps recovery guidance for an unknown join-review failure (%o)", async (cause) => {
-		mocks.reviewCoordinatorAdminJoinRequest.mockRejectedValue(cause);
-		const reloadData = vi.fn().mockResolvedValue(undefined);
-		const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
+	it.each([new Error("private coordinator detail"), "request_not_found"])(
+		"keeps recovery guidance for an unknown join-review failure (%o)",
+		async (cause) => {
+			mocks.reviewCoordinatorAdminJoinRequest.mockRejectedValue(cause);
+			const reloadData = vi.fn().mockResolvedValue(undefined);
+			const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
 
-		await actions.reviewJoinRequestFromAdminPanel("join-1", "approve");
+			await actions.reviewJoinRequestFromAdminPanel("join-1", "approve");
 
-		expect(reloadData).not.toHaveBeenCalled();
-		expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
-			"Could not review the legacy coordinator join request. Sharing policy is unchanged; check coordinator recovery status and retry.",
-			"warning",
-		);
-		expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain(
-			"private coordinator detail",
-		);
-	});
+			expect(reloadData).not.toHaveBeenCalled();
+			expect(mocks.showGlobalNotice).toHaveBeenCalledWith(
+				"Could not review the legacy coordinator join request. Sharing policy is unchanged; check coordinator recovery status and retry.",
+				"warning",
+			);
+			expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain(
+				"private coordinator detail",
+			);
+		},
+	);
 
 	it("keeps missing-request guidance when refreshing the pending list fails", async () => {
 		mocks.reviewCoordinatorAdminJoinRequest.mockRejectedValue(new Error("join request not found"));
@@ -831,34 +836,32 @@ describe("coordinator admin actions", () => {
 		);
 	});
 
-	it.each([
-		"rename",
-		"disable",
-		"enable",
-		"remove",
-	] as const)("refreshes devices when %s finds a missing enrollment", async (kind) => {
-		const mutation =
-			kind === "rename"
-				? mocks.renameCoordinatorAdminDevice
-				: kind === "disable"
-					? mocks.disableCoordinatorAdminDevice
-					: kind === "enable"
-						? mocks.enableCoordinatorAdminDevice
-						: mocks.removeCoordinatorAdminDevice;
-		mutation.mockRejectedValue(new Error("device_not_found: private-device-id"));
-		coordinatorAdminState.deviceRenameDrafts.set("device-a", "New device name");
-		const reloadData = vi.fn().mockResolvedValue(undefined);
-		const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
+	it.each(["rename", "disable", "enable", "remove"] as const)(
+		"refreshes devices when %s finds a missing enrollment",
+		async (kind) => {
+			const mutation =
+				kind === "rename"
+					? mocks.renameCoordinatorAdminDevice
+					: kind === "disable"
+						? mocks.disableCoordinatorAdminDevice
+						: kind === "enable"
+							? mocks.enableCoordinatorAdminDevice
+							: mocks.removeCoordinatorAdminDevice;
+			mutation.mockRejectedValue(new Error("device_not_found: private-device-id"));
+			coordinatorAdminState.deviceRenameDrafts.set("device-a", "New device name");
+			const reloadData = vi.fn().mockResolvedValue(undefined);
+			const actions = createCoordinatorAdminActions({ renderShell: vi.fn(), reloadData });
 
-		await actions.runDeviceAction("device-a", "group-alpha", "Laptop", kind);
+			await actions.runDeviceAction("device-a", "group-alpha", "Laptop", kind);
 
-		expect(reloadData).toHaveBeenCalledTimes(1);
-		expect(mocks.showGlobalNotice).toHaveBeenLastCalledWith(
-			"This legacy coordinator device no longer exists. Enrolled devices were refreshed.",
-			"warning",
-		);
-		expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain("private-device-id");
-	});
+			expect(reloadData).toHaveBeenCalledTimes(1);
+			expect(mocks.showGlobalNotice).toHaveBeenLastCalledWith(
+				"This legacy coordinator device no longer exists. Enrolled devices were refreshed.",
+				"warning",
+			);
+			expect(mocks.showGlobalNotice.mock.calls.flat().join(" ")).not.toContain("private-device-id");
+		},
+	);
 
 	it("keeps missing-device guidance when refreshing devices fails", async () => {
 		mocks.removeCoordinatorAdminDevice.mockRejectedValue(new Error("device_not_found"));

--- a/packages/ui/src/tabs/coordinator-admin/lifecycle.test.tsx
+++ b/packages/ui/src/tabs/coordinator-admin/lifecycle.test.tsx
@@ -528,35 +528,35 @@ describe("coordinator administration recovery lifecycle", () => {
 		expect(coordinatorAdminState.groupScopeManagementOpen.has("group-a")).toBe(true);
 	});
 
-	it.each([
-		"partial",
-		"not_configured",
-	])("treats %s readiness as known setup state rather than downstream failure", async (readiness) => {
-		document.body.innerHTML = '<div id="coordinatorAdminMount"></div>';
-		initCoordinatorAdminTab();
-		mocks.loadCoordinatorAdminStatus.mockResolvedValue({
-			active_group: "",
-			coordinator_url: "https://coordinator.example",
-			readiness,
-		});
+	it.each(["partial", "not_configured"])(
+		"treats %s readiness as known setup state rather than downstream failure",
+		async (readiness) => {
+			document.body.innerHTML = '<div id="coordinatorAdminMount"></div>';
+			initCoordinatorAdminTab();
+			mocks.loadCoordinatorAdminStatus.mockResolvedValue({
+				active_group: "",
+				coordinator_url: "https://coordinator.example",
+				readiness,
+			});
 
-		await loadCoordinatorAdminData();
+			await loadCoordinatorAdminData();
 
-		expect(coordinatorAdminState.recovery.status.availability).toBe("fresh");
-		expect(coordinatorAdminState.recovery.groups.availability).toBe("not_applicable");
-		expect(coordinatorAdminState.recovery.joinRequests.availability).toBe("not_applicable");
-		expect(coordinatorAdminState.recovery.devices.availability).toBe("not_applicable");
-		expect(mocks.loadCoordinatorAdminGroupsFiltered).not.toHaveBeenCalled();
-		expect(document.body.textContent).toContain(
-			"Complete legacy coordinator setup before loading coordinator groups",
-		);
-		expect(document.body.textContent).toContain(
-			"Complete legacy coordinator setup to load join requests",
-		);
-		expect(document.body.textContent).toContain(
-			"Complete legacy coordinator setup to load enrolled devices",
-		);
-	});
+			expect(coordinatorAdminState.recovery.status.availability).toBe("fresh");
+			expect(coordinatorAdminState.recovery.groups.availability).toBe("not_applicable");
+			expect(coordinatorAdminState.recovery.joinRequests.availability).toBe("not_applicable");
+			expect(coordinatorAdminState.recovery.devices.availability).toBe("not_applicable");
+			expect(mocks.loadCoordinatorAdminGroupsFiltered).not.toHaveBeenCalled();
+			expect(document.body.textContent).toContain(
+				"Complete legacy coordinator setup before loading coordinator groups",
+			);
+			expect(document.body.textContent).toContain(
+				"Complete legacy coordinator setup to load join requests",
+			);
+			expect(document.body.textContent).toContain(
+				"Complete legacy coordinator setup to load enrolled devices",
+			);
+		},
+	);
 
 	it("keeps the recovery status node stable and focuses it after retry succeeds", async () => {
 		document.body.innerHTML = '<div id="coordinatorAdminMount"></div>';

--- a/packages/ui/src/tabs/devices.test.tsx
+++ b/packages/ui/src/tabs/devices.test.tsx
@@ -1651,115 +1651,118 @@ describe("read-only Devices", () => {
 			false,
 			"Identity reassignment completed, but refreshing Devices and Sharing failed. Refresh to see current state.",
 		],
-	])("uses the dedicated rebind flow and reports refresh result %s", async (refreshResult, expectedStatus) => {
-		const graph = intent({
-			identities: [
-				...intent().identities,
-				{ ...intent().identities[0], identityId: "identity-target", displayName: "Brian" },
-			],
-		});
-		const previewBindings = vi.fn().mockResolvedValue({
-			version: 1,
-			status: "ready",
-			reviewedInventoryDigest: "rebind-digest",
-			errorCode: null,
-			outcomes: [
-				{
-					deviceId: "device-address-fingerprint-secret",
-					displayName: "Work Laptop",
-					targetIdentityId: "identity-target",
-					previousIdentityId: "identity-scope-secret",
-					action: "rebind",
-					isLocal: false,
-				},
-			],
-			writeCount: 1,
-		});
-		const commitBindings = vi.fn().mockResolvedValue({ version: 1, status: "applied" });
-		const configuredItems = [
-			inventoryItem("device-address-fingerprint-secret", "Work Laptop", "configured"),
-			inventoryItem("fallback", "Fallback", "configured"),
-		];
-		const onCommitted = vi.fn(() => {
+	])(
+		"uses the dedicated rebind flow and reports refresh result %s",
+		async (refreshResult, expectedStatus) => {
+			const graph = intent({
+				identities: [
+					...intent().identities,
+					{ ...intent().identities[0], identityId: "identity-target", displayName: "Brian" },
+				],
+			});
+			const previewBindings = vi.fn().mockResolvedValue({
+				version: 1,
+				status: "ready",
+				reviewedInventoryDigest: "rebind-digest",
+				errorCode: null,
+				outcomes: [
+					{
+						deviceId: "device-address-fingerprint-secret",
+						displayName: "Work Laptop",
+						targetIdentityId: "identity-target",
+						previousIdentityId: "identity-scope-secret",
+						action: "rebind",
+						isLocal: false,
+					},
+				],
+				writeCount: 1,
+			});
+			const commitBindings = vi.fn().mockResolvedValue({ version: 1, status: "applied" });
+			const configuredItems = [
+				inventoryItem("device-address-fingerprint-secret", "Work Laptop", "configured"),
+				inventoryItem("fallback", "Fallback", "configured"),
+			];
+			const onCommitted = vi.fn(() => {
+				mount(graph, reconciliation(), {
+					inventory: inventory(configuredItems),
+					previewBindings,
+					commitBindings,
+					onCommitted,
+				});
+				return refreshResult;
+			});
 			mount(graph, reconciliation(), {
 				inventory: inventory(configuredItems),
 				previewBindings,
 				commitBindings,
 				onCommitted,
 			});
-			return refreshResult;
-		});
-		mount(graph, reconciliation(), {
-			inventory: inventory(configuredItems),
-			previewBindings,
-			commitBindings,
-			onCommitted,
-		});
-		const triggers = [...document.querySelectorAll<HTMLButtonElement>("button")].filter(
-			(button) => button.textContent === "Change Identity…",
-		);
-		expect(triggers).toHaveLength(2);
-		act(() => {
-			triggers[1]?.click();
-		});
-		const select = document.querySelector<HTMLSelectElement>(".device-identity-rebind select");
-		if (!select) throw new Error("rebind select missing");
-		select.value = "identity-target";
-		act(() => {
-			select.dispatchEvent(new Event("input", { bubbles: true }));
-		});
-		const confirmation = document.querySelector<HTMLInputElement>(
-			'.device-identity-rebind input[type="checkbox"]',
-		);
-		if (!confirmation) throw new Error("rebind confirmation missing");
-		confirmation.checked = true;
-		act(() => {
-			confirmation.dispatchEvent(new Event("input", { bubbles: true }));
-		});
-		await act(async () => {
-			(
-				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Review reassignment",
-				) as HTMLButtonElement
-			).click();
-		});
-		const finalConfirmation = [
-			...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-		].find((input) => input.parentElement?.textContent?.includes("I reviewed the previous"));
-		if (!finalConfirmation) throw new Error("final confirmation missing");
-		finalConfirmation.checked = true;
-		act(() => {
-			finalConfirmation.dispatchEvent(new Event("input", { bubbles: true }));
-		});
-		await act(async () => {
-			(
-				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Reassign Identity",
-				) as HTMLButtonElement
-			).click();
-			await Promise.resolve();
-			await Promise.resolve();
-		});
-		expect(commitBindings).toHaveBeenCalledWith({
-			bindings: [
-				{
-					deviceId: "device-address-fingerprint-secret",
-					targetIdentityId: "identity-target",
-					confirmed: true,
-					allowRebind: true,
-				},
-			],
-			reviewedInventoryDigest: "rebind-digest",
-		});
-		expect(onCommitted).toHaveBeenCalledOnce();
-		expect(
-			[...document.querySelectorAll('[role="status"]')].some(
-				(status) => status.textContent === expectedStatus,
-			),
-		).toBe(true);
-		expect(document.activeElement?.id).toBe(triggers[1]?.id);
-		expect(document.querySelector(".device-identity-rebind fieldset")).toBeNull();
-	});
+			const triggers = [...document.querySelectorAll<HTMLButtonElement>("button")].filter(
+				(button) => button.textContent === "Change Identity…",
+			);
+			expect(triggers).toHaveLength(2);
+			act(() => {
+				triggers[1]?.click();
+			});
+			const select = document.querySelector<HTMLSelectElement>(".device-identity-rebind select");
+			if (!select) throw new Error("rebind select missing");
+			select.value = "identity-target";
+			act(() => {
+				select.dispatchEvent(new Event("input", { bubbles: true }));
+			});
+			const confirmation = document.querySelector<HTMLInputElement>(
+				'.device-identity-rebind input[type="checkbox"]',
+			);
+			if (!confirmation) throw new Error("rebind confirmation missing");
+			confirmation.checked = true;
+			act(() => {
+				confirmation.dispatchEvent(new Event("input", { bubbles: true }));
+			});
+			await act(async () => {
+				(
+					[...document.querySelectorAll<HTMLButtonElement>("button")].find(
+						(button) => button.textContent === "Review reassignment",
+					) as HTMLButtonElement
+				).click();
+			});
+			const finalConfirmation = [
+				...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+			].find((input) => input.parentElement?.textContent?.includes("I reviewed the previous"));
+			if (!finalConfirmation) throw new Error("final confirmation missing");
+			finalConfirmation.checked = true;
+			act(() => {
+				finalConfirmation.dispatchEvent(new Event("input", { bubbles: true }));
+			});
+			await act(async () => {
+				(
+					[...document.querySelectorAll<HTMLButtonElement>("button")].find(
+						(button) => button.textContent === "Reassign Identity",
+					) as HTMLButtonElement
+				).click();
+				await Promise.resolve();
+				await Promise.resolve();
+			});
+			expect(commitBindings).toHaveBeenCalledWith({
+				bindings: [
+					{
+						deviceId: "device-address-fingerprint-secret",
+						targetIdentityId: "identity-target",
+						confirmed: true,
+						allowRebind: true,
+					},
+				],
+				reviewedInventoryDigest: "rebind-digest",
+			});
+			expect(onCommitted).toHaveBeenCalledOnce();
+			expect(
+				[...document.querySelectorAll('[role="status"]')].some(
+					(status) => status.textContent === expectedStatus,
+				),
+			).toBe(true);
+			expect(document.activeElement?.id).toBe(triggers[1]?.id);
+			expect(document.querySelector(".device-identity-rebind fieldset")).toBeNull();
+		},
+	);
 
 	it.each([
 		[true, "Identity setup completed. Devices and Sharing were refreshed."],
@@ -1767,94 +1770,97 @@ describe("read-only Devices", () => {
 			false,
 			"Identity setup completed, but refreshing Devices and Sharing failed. Refresh to see current state.",
 		],
-	])("commits setup after review and reports refresh result %s", async (refreshResult, expectedStatus) => {
-		const previewBindings = vi.fn().mockResolvedValue({
-			version: 1,
-			status: "ready",
-			reviewedInventoryDigest: "digest",
-			errorCode: null,
-			outcomes: [
-				{
-					deviceId: "one",
-					displayName: "One",
-					targetIdentityId: "identity-scope-secret",
-					previousIdentityId: null,
-					action: "bind",
-					isLocal: true,
-				},
-			],
-			writeCount: 1,
-		});
-		const commitBindings = vi.fn().mockResolvedValue({ version: 1, status: "applied" });
-		const onCommitted = vi.fn(() => {
+	])(
+		"commits setup after review and reports refresh result %s",
+		async (refreshResult, expectedStatus) => {
+			const previewBindings = vi.fn().mockResolvedValue({
+				version: 1,
+				status: "ready",
+				reviewedInventoryDigest: "digest",
+				errorCode: null,
+				outcomes: [
+					{
+						deviceId: "one",
+						displayName: "One",
+						targetIdentityId: "identity-scope-secret",
+						previousIdentityId: null,
+						action: "bind",
+						isLocal: true,
+					},
+				],
+				writeCount: 1,
+			});
+			const commitBindings = vi.fn().mockResolvedValue({ version: 1, status: "applied" });
+			const onCommitted = vi.fn(() => {
+				mount(intent(), reconciliation(), {
+					inventory: inventory([inventoryItem("one", "One", "configured")]),
+					previewBindings,
+					commitBindings,
+					onCommitted,
+				});
+				return refreshResult;
+			});
 			mount(intent(), reconciliation(), {
-				inventory: inventory([inventoryItem("one", "One", "configured")]),
+				inventory: inventory([inventoryItem("one", "One", "setup_required", { isLocal: true })]),
 				previewBindings,
 				commitBindings,
 				onCommitted,
 			});
-			return refreshResult;
-		});
-		mount(intent(), reconciliation(), {
-			inventory: inventory([inventoryItem("one", "One", "setup_required", { isLocal: true })]),
-			previewBindings,
-			commitBindings,
-			onCommitted,
-		});
-		const identitySelect = document.querySelector<HTMLSelectElement>(
-			".device-identity-setup-card select",
-		);
-		if (!identitySelect) throw new Error("Identity select missing");
-		identitySelect.value = "identity-scope-secret";
-		act(() => {
-			identitySelect.dispatchEvent(new Event("input", { bubbles: true }));
-		});
-		await act(async () =>
-			(
-				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-					(button) => button.textContent === "Review this device",
-				) as HTMLButtonElement
-			).click(),
-		);
-		expect(
-			[...document.querySelectorAll<HTMLButtonElement>("button")].find(
-				(button) => button.textContent === "Apply setup to 1 device",
-			),
-		).toBeTruthy();
-		const finalConfirmation = [
-			...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-		].find((input) => input.parentElement?.textContent?.includes("I reviewed every device"));
-		if (!finalConfirmation) throw new Error("final confirmation missing");
-		finalConfirmation.checked = true;
-		act(() => {
-			finalConfirmation.dispatchEvent(new Event("input", { bubbles: true }));
-		});
-		await act(async () => {
-			(
+			const identitySelect = document.querySelector<HTMLSelectElement>(
+				".device-identity-setup-card select",
+			);
+			if (!identitySelect) throw new Error("Identity select missing");
+			identitySelect.value = "identity-scope-secret";
+			act(() => {
+				identitySelect.dispatchEvent(new Event("input", { bubbles: true }));
+			});
+			await act(async () =>
+				(
+					[...document.querySelectorAll<HTMLButtonElement>("button")].find(
+						(button) => button.textContent === "Review this device",
+					) as HTMLButtonElement
+				).click(),
+			);
+			expect(
 				[...document.querySelectorAll<HTMLButtonElement>("button")].find(
 					(button) => button.textContent === "Apply setup to 1 device",
-				) as HTMLButtonElement
-			).click();
-			await Promise.resolve();
-			await Promise.resolve();
-		});
-		expect(commitBindings).toHaveBeenCalledWith({
-			bindings: [
-				{
-					deviceId: "one",
-					targetIdentityId: "identity-scope-secret",
-					confirmed: true,
-				},
-			],
-			reviewedInventoryDigest: "digest",
-		});
-		expect(onCommitted).toHaveBeenCalledOnce();
-		expect(
-			[...document.querySelectorAll('[role="status"]')].some(
-				(status) => status.textContent === expectedStatus,
-			),
-		).toBe(true);
-	});
+				),
+			).toBeTruthy();
+			const finalConfirmation = [
+				...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+			].find((input) => input.parentElement?.textContent?.includes("I reviewed every device"));
+			if (!finalConfirmation) throw new Error("final confirmation missing");
+			finalConfirmation.checked = true;
+			act(() => {
+				finalConfirmation.dispatchEvent(new Event("input", { bubbles: true }));
+			});
+			await act(async () => {
+				(
+					[...document.querySelectorAll<HTMLButtonElement>("button")].find(
+						(button) => button.textContent === "Apply setup to 1 device",
+					) as HTMLButtonElement
+				).click();
+				await Promise.resolve();
+				await Promise.resolve();
+			});
+			expect(commitBindings).toHaveBeenCalledWith({
+				bindings: [
+					{
+						deviceId: "one",
+						targetIdentityId: "identity-scope-secret",
+						confirmed: true,
+					},
+				],
+				reviewedInventoryDigest: "digest",
+			});
+			expect(onCommitted).toHaveBeenCalledOnce();
+			expect(
+				[...document.querySelectorAll('[role="status"]')].some(
+					(status) => status.textContent === expectedStatus,
+				),
+			).toBe(true);
+		},
+	);
 
 	it.each([
 		[503, "binding_preview_busy", "busy. Wait a moment"],

--- a/packages/ui/src/tabs/feed/data/helpers.test.ts
+++ b/packages/ui/src/tabs/feed/data/helpers.test.ts
@@ -46,16 +46,17 @@ describe("Feed identity labels", () => {
 		expect(deviceLabel(item)).toBe("Shared device");
 	});
 
-	it.each(
-		MACHINE_PRESENTATION_LABEL_FIXTURES,
-	)("never promotes machine-shaped label %s", (value) => {
-		expect(authorLabel({ actor_id: "remote-actor", resolved_actor_display_name: value })).toBe(
-			"Teammate",
-		);
-		expect(
-			deviceLabel({ origin_device_id: "remote-device", resolved_device_display_name: value }),
-		).toBe("Shared device");
-	});
+	it.each(MACHINE_PRESENTATION_LABEL_FIXTURES)(
+		"never promotes machine-shaped label %s",
+		(value) => {
+			expect(authorLabel({ actor_id: "remote-actor", resolved_actor_display_name: value })).toBe(
+				"Teammate",
+			);
+			expect(
+				deviceLabel({ origin_device_id: "remote-device", resolved_device_display_name: value }),
+			).toBe("Shared device");
+		},
+	);
 
 	it("uses unknown author when no actor provenance exists", () => {
 		expect(authorLabel({})).toBe("Unknown author");

--- a/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-invitations.test.tsx
@@ -681,34 +681,35 @@ describe("recipient-policy invitations", () => {
 	it.each([
 		["missing", undefined],
 		["empty", []],
-	] as Array<
-		[string, typeof projectShareInspection.projects | undefined]
-	>)("blocks Project acceptance when the inspected Project list is $0", async (_label, projects) => {
-		vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
-			...projectShareInspection,
-			projects,
-		});
-		mount();
-		act(() => button("Review invitation").click());
-		const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
-		const dialog = document.querySelector('[role="dialog"]');
-		if (!textarea || !dialog) throw new Error("acceptance dialog missing");
-		act(() => {
-			textarea.value = "project-without-details";
-			textarea.dispatchEvent(new Event("input", { bubbles: true }));
-		});
-		act(() => button("Review invitation", dialog).click());
+	] as Array<[string, typeof projectShareInspection.projects | undefined]>)(
+		"blocks Project acceptance when the inspected Project list is $0",
+		async (_label, projects) => {
+			vi.mocked(api.inspectCoordinatorInvite).mockResolvedValue({
+				...projectShareInspection,
+				projects,
+			});
+			mount();
+			act(() => button("Review invitation").click());
+			const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+			const dialog = document.querySelector('[role="dialog"]');
+			if (!textarea || !dialog) throw new Error("acceptance dialog missing");
+			act(() => {
+				textarea.value = "project-without-details";
+				textarea.dispatchEvent(new Event("input", { bubbles: true }));
+			});
+			act(() => button("Review invitation", dialog).click());
 
-		await vi.waitFor(() =>
-			expect(dialog.querySelector('[role="alert"]')?.textContent).toContain(
-				"Project details are unavailable",
-			),
-		);
-		const accept = button("Accept Project access", dialog);
-		expect(accept.disabled).toBe(true);
-		act(() => accept.click());
-		expect(api.importCoordinatorInvite).not.toHaveBeenCalled();
-	});
+			await vi.waitFor(() =>
+				expect(dialog.querySelector('[role="alert"]')?.textContent).toContain(
+					"Project details are unavailable",
+				),
+			);
+			const accept = button("Accept Project access", dialog);
+			expect(accept.disabled).toBe(true);
+			act(() => accept.click());
+			expect(api.importCoordinatorInvite).not.toHaveBeenCalled();
+		},
+	);
 
 	it("retries failed Project inspection with the preserved invite text", async () => {
 		vi.mocked(api.inspectCoordinatorInvite)

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -802,7 +802,9 @@ describe("recipient-focused Sharing", () => {
 		expect(attention?.textContent).toContain(
 			"does not grant Projects, Team membership, or sync access",
 		);
-		act(() => (attention?.querySelector("button") as HTMLButtonElement).click());
+		const reviewButton = attention?.querySelector<HTMLButtonElement>("button");
+		expect(reviewButton).toBeDefined();
+		act(() => reviewButton?.click());
 		expect(onReviewDevices).toHaveBeenCalledWith("device-setup");
 	});
 
@@ -820,7 +822,9 @@ describe("recipient-focused Sharing", () => {
 			"Coordinator groups are discovery boundaries, not policy Teams",
 		);
 		expect(attention?.textContent).not.toMatch(/fingerprint|group[_ -]?id|coordinator[_ -]?id/i);
-		act(() => (attention?.querySelector("button") as HTMLButtonElement).click());
+		const reviewButton = attention?.querySelector<HTMLButtonElement>("button");
+		expect(reviewButton).toBeDefined();
+		act(() => reviewButton?.click());
 		expect(onReviewDevices).toHaveBeenCalledOnce();
 	});
 

--- a/packages/ui/src/tabs/sync/components/project-share-operations.test.tsx
+++ b/packages/ui/src/tabs/sync/components/project-share-operations.test.tsx
@@ -91,22 +91,23 @@ describe("ProjectShareOperations", () => {
 		mount.remove();
 	});
 
-	it.each(
-		Object.keys(labels) as ShareOperationLifecycleState[],
-	)("renders %s with one lifecycle and at most one action", (state) => {
-		render(
-			<ProjectShareOperations
-				operations={[operation(state)]}
-				onAdvance={vi.fn()}
-				onReload={vi.fn()}
-			/>,
-			mount,
-		);
-		const card = mount.querySelector("article");
-		expect(card?.textContent).toContain(labels[state]);
-		expect(card?.querySelectorAll("button").length).toBeLessThanOrEqual(1);
-		expect(card?.querySelector('[role="alert"]') != null).toBe(state === "needs_attention");
-	});
+	it.each(Object.keys(labels) as ShareOperationLifecycleState[])(
+		"renders %s with one lifecycle and at most one action",
+		(state) => {
+			render(
+				<ProjectShareOperations
+					operations={[operation(state)]}
+					onAdvance={vi.fn()}
+					onReload={vi.fn()}
+				/>,
+				mount,
+			);
+			const card = mount.querySelector("article");
+			expect(card?.textContent).toContain(labels[state]);
+			expect(card?.querySelectorAll("button").length).toBeLessThanOrEqual(1);
+			expect(card?.querySelector('[role="alert"]') != null).toBe(state === "needs_attention");
+		},
+	);
 
 	it("groups strictly by actor identity and nests friendly devices and projects", () => {
 		render(
@@ -148,20 +149,23 @@ describe("ProjectShareOperations", () => {
 	it.each([
 		["revoked", "Previously shared"],
 		["cancelled", "Invitation cancelled"],
-	] as const)("describes %s operations as historical rather than current sharing", (state, label) => {
-		render(
-			<ProjectShareOperations
-				operations={[operation(state)]}
-				onAdvance={vi.fn()}
-				onReload={vi.fn()}
-			/>,
-			mount,
-		);
+	] as const)(
+		"describes %s operations as historical rather than current sharing",
+		(state, label) => {
+			render(
+				<ProjectShareOperations
+					operations={[operation(state)]}
+					onAdvance={vi.fn()}
+					onReload={vi.fn()}
+				/>,
+				mount,
+			);
 
-		const operationCard = mount.querySelector(".project-share-operation-card");
-		expect(operationCard?.textContent).toContain(label);
-		expect(operationCard?.querySelector(".peer-scope-summary")?.textContent).not.toBe("Sharing");
-	});
+			const operationCard = mount.querySelector(".project-share-operation-card");
+			expect(operationCard?.textContent).toContain(label);
+			expect(operationCard?.querySelector(".peer-scope-summary")?.textContent).not.toBe("Sharing");
+		},
+	);
 
 	it.each([
 		["revoked", "Share again"],

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -321,17 +321,20 @@ describe("deriveTeamSyncPrimaryStatus", () => {
 		["not enrolled", "not_enrolled", "not-enrolled", "Not enrolled"],
 		["coordinator error", "error", "unreachable", "Unreachable"],
 		["unknown coordinator presence", "unknown", "unreachable", "Unreachable"],
-	] as const)("prioritizes %s over peer-connectivity guidance", (_label, presenceStatus, expectedState, expectedBadge) => {
-		const view = deriveTeamSyncPrimaryStatus({
-			status: { enabled: true, daemon_state: "ok", daemon_running: true },
-			coordinator: { ...postedCoordinator, presence_status: presenceStatus },
-			peers: [{ peer_device_id: "peer-offline", status: { peer_state: "offline" } }],
-		});
+	] as const)(
+		"prioritizes %s over peer-connectivity guidance",
+		(_label, presenceStatus, expectedState, expectedBadge) => {
+			const view = deriveTeamSyncPrimaryStatus({
+				status: { enabled: true, daemon_state: "ok", daemon_running: true },
+				coordinator: { ...postedCoordinator, presence_status: presenceStatus },
+				peers: [{ peer_device_id: "peer-offline", status: { peer_state: "offline" } }],
+			});
 
-		expect(view).toMatchObject({ state: expectedState, badgeLabel: expectedBadge });
-		expect(view.nextAction).not.toBeNull();
-		expect(view.badgeLabel).not.toBe("Check devices");
-	});
+			expect(view).toMatchObject({ state: expectedState, badgeLabel: expectedBadge });
+			expect(view.nextAction).not.toBeNull();
+			expect(view.badgeLabel).not.toBe("Check devices");
+		},
+	);
 
 	it.each([
 		["fresh ping", { peer_state: "online", ping_status: "ok", fresh: true }],
@@ -385,24 +388,23 @@ describe("deriveTeamSyncPrimaryStatus", () => {
 		});
 	});
 
-	it.each([
-		"offline-peers",
-		"stale",
-		"degraded",
-	] as const)("directs users to check paired devices when daemon_state is %s", (daemonState) => {
-		const view = deriveTeamSyncPrimaryStatus({
-			status: { enabled: true, daemon_state: daemonState, daemon_running: true },
-			coordinator: postedCoordinator,
-			peers: [healthyPeer],
-		});
+	it.each(["offline-peers", "stale", "degraded"] as const)(
+		"directs users to check paired devices when daemon_state is %s",
+		(daemonState) => {
+			const view = deriveTeamSyncPrimaryStatus({
+				status: { enabled: true, daemon_state: daemonState, daemon_running: true },
+				coordinator: postedCoordinator,
+				peers: [healthyPeer],
+			});
 
-		expect(view).toMatchObject({
-			state: "reachable",
-			badgeLabel: "Check devices",
-			nextAction: expect.stringContaining("Bring the paired devices online"),
-		});
-		expect(view.nextAction).not.toContain("Pair and approve");
-	});
+			expect(view).toMatchObject({
+				state: "reachable",
+				badgeLabel: "Check devices",
+				nextAction: expect.stringContaining("Bring the paired devices online"),
+			});
+			expect(view.nextAction).not.toContain("Pair and approve");
+		},
+	);
 
 	it("directs users to check an offline peer before suggesting another pairing", () => {
 		const view = deriveTeamSyncPrimaryStatus({
@@ -528,11 +530,14 @@ describe("deriveTeamSyncPrimaryStatus", () => {
 			{ enabled: true, daemon_state: "ok" as const, daemon_running: true },
 			{ ...postedCoordinator, sync_enabled: undefined },
 		],
-	])("fails closed when %s despite daemon health and mutual trust", (_name, status, coordinator) => {
-		const view = deriveTeamSyncPrimaryStatus({ status, coordinator, peers: [healthyPeer] });
+	])(
+		"fails closed when %s despite daemon health and mutual trust",
+		(_name, status, coordinator) => {
+			const view = deriveTeamSyncPrimaryStatus({ status, coordinator, peers: [healthyPeer] });
 
-		expect(view).toMatchObject({ state: "reachable", badgeLabel: "Reachable" });
-	});
+			expect(view).toMatchObject({ state: "reachable", badgeLabel: "Reachable" });
+		},
+	);
 
 	const coordinatorCases: Array<
 		[
@@ -570,16 +575,17 @@ describe("deriveTeamSyncPrimaryStatus", () => {
 		],
 	];
 
-	it.each(
-		coordinatorCases,
-	)("models %s with one exact directive", (_name, coordinator, state, badgeLabel, meta, nextAction) => {
-		const view = deriveTeamSyncPrimaryStatus({
-			status: { enabled: true, daemon_state: "ok", daemon_running: true },
-			coordinator,
-		});
+	it.each(coordinatorCases)(
+		"models %s with one exact directive",
+		(_name, coordinator, state, badgeLabel, meta, nextAction) => {
+			const view = deriveTeamSyncPrimaryStatus({
+				status: { enabled: true, daemon_state: "ok", daemon_running: true },
+				coordinator,
+			});
 
-		expect(view).toEqual({ state, badgeLabel, meta, nextAction });
-	});
+			expect(view).toEqual({ state, badgeLabel, meta, nextAction });
+		},
+	);
 });
 
 describe("derivePeerUiStatus", () => {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1828,42 +1828,43 @@ describe("viewer-server", () => {
 			).rejects.toThrow("team_setup_roster_unavailable");
 		});
 
-		it.each([
-			2, -1,
-		])("fails closed on sole invalid coordinator enabled value %i", async (enabled) => {
-			const publicKey = "public-key-a";
-			const config = {
-				...core.readCoordinatorSyncConfig({}),
-				syncCoordinatorUrl: "http://localhost:8787",
-				syncCoordinatorGroups: [groupId],
-				syncCoordinatorAdminSecret: "private-admin-secret",
-			};
-			await expect(
-				__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
-					readConfig: () => config,
-					listGroups: async () => [
-						{
-							group_id: groupId,
-							display_name: "Migration Team",
-							archived_at: null,
-							created_at: "2026-08-24T00:00:00.000Z",
-						},
-					],
-					listDevices: async () => [
-						{
-							group_id: groupId,
-							device_id: "device-a",
-							public_key: publicKey,
-							fingerprint: fingerprintPublicKey(publicKey),
-							identity_id: null,
-							display_name: "Laptop",
-							enabled,
-							created_at: "2026-08-24T00:00:00.000Z",
-						},
-					],
-				}),
-			).rejects.toThrow("team_setup_roster_unavailable");
-		});
+		it.each([2, -1])(
+			"fails closed on sole invalid coordinator enabled value %i",
+			async (enabled) => {
+				const publicKey = "public-key-a";
+				const config = {
+					...core.readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "http://localhost:8787",
+					syncCoordinatorGroups: [groupId],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				};
+				await expect(
+					__teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
+						readConfig: () => config,
+						listGroups: async () => [
+							{
+								group_id: groupId,
+								display_name: "Migration Team",
+								archived_at: null,
+								created_at: "2026-08-24T00:00:00.000Z",
+							},
+						],
+						listDevices: async () => [
+							{
+								group_id: groupId,
+								device_id: "device-a",
+								public_key: publicKey,
+								fingerprint: fingerprintPublicKey(publicKey),
+								identity_id: null,
+								display_name: "Laptop",
+								enabled,
+								created_at: "2026-08-24T00:00:00.000Z",
+							},
+						],
+					}),
+				).rejects.toThrow("team_setup_roster_unavailable");
+			},
+		);
 
 		it("accepts matching roster keys and retains redaction-only coordinator identifiers", async () => {
 			const publicKey = "public-key-a";
@@ -2449,143 +2450,145 @@ describe("viewer-server", () => {
 			},
 		] as const;
 
-		it.each(
-			targetedIngestCases,
-		)("rejects database, identity, and contract mismatches before writes on $route", async ({
-			route,
-			payload,
-		}) => {
-			const { app, ensureStore, cleanup } = createTestApp();
-			try {
-				const store = ensureStore();
-				const profile = (await (await app.request("/api/prompt-pack-profile")).json()) as {
-					identity_target: Record<string, unknown>;
-				};
-				const diagnosticsBefore = (await (await app.request("/api/raw-events/status")).json()) as {
-					transcript_diagnostics: unknown;
-				};
-				const requests = [
-					{
-						db_path: `${store.dbPath}.other`,
-						identity_target: profile.identity_target,
-						expectedCode: "viewer_db_mismatch",
-					},
-					{
-						db_path: store.dbPath,
-						identity_target: { ...profile.identity_target, device_id: "other-device" },
-						expectedCode: "viewer_identity_mismatch",
-					},
-					{
-						db_path: store.dbPath,
-						identity_target: { ...profile.identity_target, future_field: "unsupported" },
-						expectedCode: "viewer_contract_unsupported",
-					},
-				];
-
-				for (const request of requests) {
-					const { expectedCode, ...target } = request;
-					const response = await postViewerJson(app, route, { ...payload, ...target });
-					expect(response.status).toBe(409);
-					expect(await response.json()).toMatchObject({
-						error: { code: expectedCode },
-					});
-					expect(rawEventState(store)).toEqual({ events: [], sessions: [] });
-					const diagnosticsAfter = (await (await app.request("/api/raw-events/status")).json()) as {
+		it.each(targetedIngestCases)(
+			"rejects database, identity, and contract mismatches before writes on $route",
+			async ({ route, payload }) => {
+				const { app, ensureStore, cleanup } = createTestApp();
+				try {
+					const store = ensureStore();
+					const profile = (await (await app.request("/api/prompt-pack-profile")).json()) as {
+						identity_target: Record<string, unknown>;
+					};
+					const diagnosticsBefore = (await (
+						await app.request("/api/raw-events/status")
+					).json()) as {
 						transcript_diagnostics: unknown;
 					};
-					expect(diagnosticsAfter.transcript_diagnostics).toEqual(
-						diagnosticsBefore.transcript_diagnostics,
-					);
+					const requests = [
+						{
+							db_path: `${store.dbPath}.other`,
+							identity_target: profile.identity_target,
+							expectedCode: "viewer_db_mismatch",
+						},
+						{
+							db_path: store.dbPath,
+							identity_target: { ...profile.identity_target, device_id: "other-device" },
+							expectedCode: "viewer_identity_mismatch",
+						},
+						{
+							db_path: store.dbPath,
+							identity_target: { ...profile.identity_target, future_field: "unsupported" },
+							expectedCode: "viewer_contract_unsupported",
+						},
+					];
+
+					for (const request of requests) {
+						const { expectedCode, ...target } = request;
+						const response = await postViewerJson(app, route, { ...payload, ...target });
+						expect(response.status).toBe(409);
+						expect(await response.json()).toMatchObject({
+							error: { code: expectedCode },
+						});
+						expect(rawEventState(store)).toEqual({ events: [], sessions: [] });
+						const diagnosticsAfter = (await (
+							await app.request("/api/raw-events/status")
+						).json()) as {
+							transcript_diagnostics: unknown;
+						};
+						expect(diagnosticsAfter.transcript_diagnostics).toEqual(
+							diagnosticsBefore.transcript_diagnostics,
+						);
+					}
+				} finally {
+					cleanup();
 				}
-			} finally {
-				cleanup();
-			}
-		});
+			},
+		);
 
-		it.each(targetedIngestCases)("rejects partial targeting on $route", async ({
-			route,
-			payload,
-		}) => {
-			const { app, ensureStore, cleanup } = createTestApp();
-			try {
-				const store = ensureStore();
-				const profile = (await (await app.request("/api/prompt-pack-profile")).json()) as {
-					identity_target: Record<string, unknown>;
-				};
-				for (const partialTarget of [
-					{ db_path: store.dbPath },
-					{ identity_target: profile.identity_target },
-				]) {
-					const response = await postViewerJson(app, route, { ...payload, ...partialTarget });
-					expect(response.status).toBe(400);
-					expect(await response.json()).toMatchObject({ error: { code: "invalid_request" } });
-					expect(rawEventState(store)).toEqual({ events: [], sessions: [] });
+		it.each(targetedIngestCases)(
+			"rejects partial targeting on $route",
+			async ({ route, payload }) => {
+				const { app, ensureStore, cleanup } = createTestApp();
+				try {
+					const store = ensureStore();
+					const profile = (await (await app.request("/api/prompt-pack-profile")).json()) as {
+						identity_target: Record<string, unknown>;
+					};
+					for (const partialTarget of [
+						{ db_path: store.dbPath },
+						{ identity_target: profile.identity_target },
+					]) {
+						const response = await postViewerJson(app, route, { ...payload, ...partialTarget });
+						expect(response.status).toBe(400);
+						expect(await response.json()).toMatchObject({ error: { code: "invalid_request" } });
+						expect(rawEventState(store)).toEqual({ events: [], sessions: [] });
+					}
+				} finally {
+					cleanup();
 				}
-			} finally {
-				cleanup();
-			}
-		});
+			},
+		);
 
-		it.each(targetedIngestCases)("rejects invalid target types on $route", async ({
-			route,
-			payload,
-		}) => {
-			const { app, ensureStore, cleanup } = createTestApp();
-			try {
-				const store = ensureStore();
-				const profile = (await (await app.request("/api/prompt-pack-profile")).json()) as {
-					identity_target: Record<string, unknown>;
-				};
-				for (const invalidTarget of [
-					{ db_path: 42, identity_target: profile.identity_target },
-					{ db_path: store.dbPath, identity_target: "wrong-type" },
-				]) {
-					const response = await postViewerJson(app, route, { ...payload, ...invalidTarget });
-					expect(response.status).toBe(400);
-					expect(await response.json()).toMatchObject({ error: { code: "invalid_request" } });
-					expect(rawEventState(store)).toEqual({ events: [], sessions: [] });
+		it.each(targetedIngestCases)(
+			"rejects invalid target types on $route",
+			async ({ route, payload }) => {
+				const { app, ensureStore, cleanup } = createTestApp();
+				try {
+					const store = ensureStore();
+					const profile = (await (await app.request("/api/prompt-pack-profile")).json()) as {
+						identity_target: Record<string, unknown>;
+					};
+					for (const invalidTarget of [
+						{ db_path: 42, identity_target: profile.identity_target },
+						{ db_path: store.dbPath, identity_target: "wrong-type" },
+					]) {
+						const response = await postViewerJson(app, route, { ...payload, ...invalidTarget });
+						expect(response.status).toBe(400);
+						expect(await response.json()).toMatchObject({ error: { code: "invalid_request" } });
+						expect(rawEventState(store)).toEqual({ events: [], sessions: [] });
+					}
+				} finally {
+					cleanup();
 				}
-			} finally {
-				cleanup();
-			}
-		});
+			},
+		);
 
-		it.each(targetedIngestCases)("accepts omitted targeting fields on $route", async ({
-			route,
-			payload,
-		}) => {
-			const { app, ensureStore, cleanup } = createTestApp();
-			try {
-				const response = await postViewerJson(app, route, payload);
-				expect(response.status).toBe(200);
-				expect(rawEventState(ensureStore()).events).toHaveLength(1);
-			} finally {
-				cleanup();
-			}
-		});
+		it.each(targetedIngestCases)(
+			"accepts omitted targeting fields on $route",
+			async ({ route, payload }) => {
+				const { app, ensureStore, cleanup } = createTestApp();
+				try {
+					const response = await postViewerJson(app, route, payload);
+					expect(response.status).toBe(200);
+					expect(rawEventState(ensureStore()).events).toHaveLength(1);
+				} finally {
+					cleanup();
+				}
+			},
+		);
 
-		it.each(targetedIngestCases)("accepts path-equivalent database targets on $route", async ({
-			route,
-			payload,
-		}) => {
-			const { app, ensureStore, cleanup } = createTestApp();
-			try {
-				const store = ensureStore();
-				const profile = (await (await app.request("/api/prompt-pack-profile")).json()) as {
-					identity_target: Record<string, unknown>;
-				};
-				const response = await postViewerJson(app, route, {
-					...payload,
-					db_path: `  ${dirname(store.dbPath)}/./${basename(store.dbPath)}  `,
-					identity_target: profile.identity_target,
-				});
+		it.each(targetedIngestCases)(
+			"accepts path-equivalent database targets on $route",
+			async ({ route, payload }) => {
+				const { app, ensureStore, cleanup } = createTestApp();
+				try {
+					const store = ensureStore();
+					const profile = (await (await app.request("/api/prompt-pack-profile")).json()) as {
+						identity_target: Record<string, unknown>;
+					};
+					const response = await postViewerJson(app, route, {
+						...payload,
+						db_path: `  ${dirname(store.dbPath)}/./${basename(store.dbPath)}  `,
+						identity_target: profile.identity_target,
+					});
 
-				expect(response.status).toBe(200);
-				expect(rawEventState(store).events).toHaveLength(1);
-			} finally {
-				cleanup();
-			}
-		});
+					expect(response.status).toBe(200);
+					expect(rawEventState(store).events).toHaveLength(1);
+				} finally {
+					cleanup();
+				}
+			},
+		);
 
 		it("defaults omitted source to opencode and returns exactly the canonical result fields", async () => {
 			const { app, ensureStore, cleanup } = createTestApp();
@@ -2881,27 +2884,27 @@ describe("viewer-server", () => {
 				error: "source must use 1-64 letters, digits, dots, underscores, or hyphens",
 			},
 			{ source: 42, error: "source must be string" },
-		])("rejects malformed source $source with a bounded error before writes", async ({
-			source,
-			error,
-		}) => {
-			const { app, ensureStore, cleanup } = createTestApp();
-			try {
-				const response = await postViewerJson(app, "/api/raw-events", {
-					source,
-					session_id: "session-invalid-source",
-					event_id: "event-invalid-source",
-					event_type: "prompt",
-					payload: {},
-				});
+		])(
+			"rejects malformed source $source with a bounded error before writes",
+			async ({ source, error }) => {
+				const { app, ensureStore, cleanup } = createTestApp();
+				try {
+					const response = await postViewerJson(app, "/api/raw-events", {
+						source,
+						session_id: "session-invalid-source",
+						event_id: "event-invalid-source",
+						event_type: "prompt",
+						payload: {},
+					});
 
-				expect(response.status).toBe(400);
-				expect(await response.json()).toEqual({ error });
-				expect(rawEventState(ensureStore())).toEqual({ events: [], sessions: [] });
-			} finally {
-				cleanup();
-			}
-		});
+					expect(response.status).toBe(400);
+					expect(await response.json()).toEqual({ error });
+					expect(rawEventState(ensureStore())).toEqual({ events: [], sessions: [] });
+				} finally {
+					cleanup();
+				}
+			},
+		);
 
 		it("rejects a conflicting per-event source for the whole batch before writes", async () => {
 			const { app, ensureStore, cleanup } = createTestApp();
@@ -2963,89 +2966,92 @@ describe("viewer-server", () => {
 				normalize: (payload: Record<string, unknown>) =>
 					core.buildRawEventEnvelopeFromCodexHook(payload, core.TRUSTED_HOOK_MAPPER_OPTIONS),
 			},
-		])("produces identical rows through canonical and named $label routes", async ({
-			route,
-			native,
-			normalize,
-		}) => {
-			const canonical = createTestApp();
-			const compatibility = createTestApp();
-			try {
-				const envelope = normalize(native);
-				expect(envelope).not.toBeNull();
+		])(
+			"produces identical rows through canonical and named $label routes",
+			async ({ route, native, normalize }) => {
+				const canonical = createTestApp();
+				const compatibility = createTestApp();
+				try {
+					const envelope = normalize(native);
+					expect(envelope).not.toBeNull();
 
-				const canonicalResponse = await postViewerJson(canonical.app, "/api/raw-events", envelope);
-				const compatibilityResponse = await postViewerJson(compatibility.app, route, native);
+					const canonicalResponse = await postViewerJson(
+						canonical.app,
+						"/api/raw-events",
+						envelope,
+					);
+					const compatibilityResponse = await postViewerJson(compatibility.app, route, native);
 
-				expect(await canonicalResponse.json()).toEqual({
-					inserted: 1,
-					skipped: 0,
-					received: 1,
-				});
-				const compatibilityBody = await compatibilityResponse.json();
-				expect(compatibilityBody).toEqual({ inserted: 1, skipped: 0 });
-				expect(compatibilityBody).not.toHaveProperty("received");
-				expect(rawEventState(canonical.ensureStore())).toEqual(
-					rawEventState(compatibility.ensureStore()),
-				);
-			} finally {
-				canonical.cleanup();
-				compatibility.cleanup();
-			}
-		});
+					expect(await canonicalResponse.json()).toEqual({
+						inserted: 1,
+						skipped: 0,
+						received: 1,
+					});
+					const compatibilityBody = await compatibilityResponse.json();
+					expect(compatibilityBody).toEqual({ inserted: 1, skipped: 0 });
+					expect(compatibilityBody).not.toHaveProperty("received");
+					expect(rawEventState(canonical.ensureStore())).toEqual(
+						rawEventState(compatibility.ensureStore()),
+					);
+				} finally {
+					canonical.cleanup();
+					compatibility.cleanup();
+				}
+			},
+		);
 
-		it.each([
-			"/api/claude-hooks",
-			"/api/codex-hooks",
-		])("returns bounded validation errors without writes on %s", async (route) => {
-			const { app, ensureStore, cleanup } = createTestApp();
-			try {
-				const response = await postViewerJson(app, route, {
-					hook_event_name: "UserPromptSubmit",
-					session_id: "msg_client-controlled",
-					prompt: "must not persist",
-					ts: "2026-08-15T12:00:00Z",
-				});
-				const body = await response.json();
+		it.each(["/api/claude-hooks", "/api/codex-hooks"])(
+			"returns bounded validation errors without writes on %s",
+			async (route) => {
+				const { app, ensureStore, cleanup } = createTestApp();
+				try {
+					const response = await postViewerJson(app, route, {
+						hook_event_name: "UserPromptSubmit",
+						session_id: "msg_client-controlled",
+						prompt: "must not persist",
+						ts: "2026-08-15T12:00:00Z",
+					});
+					const body = await response.json();
 
-				expect(response.status).toBe(400);
-				expect(body).toEqual({ error: "invalid session id" });
-				expect(body).not.toHaveProperty("received");
-				expect(rawEventState(ensureStore())).toEqual({ events: [], sessions: [] });
-			} finally {
-				cleanup();
-			}
-		});
+					expect(response.status).toBe(400);
+					expect(body).toEqual({ error: "invalid session id" });
+					expect(body).not.toHaveProperty("received");
+					expect(rawEventState(ensureStore())).toEqual({ events: [], sessions: [] });
+				} finally {
+					cleanup();
+				}
+			},
+		);
 
-		it.each([
-			"/api/claude-hooks",
-			"/api/codex-hooks",
-		])("keeps native parse and payload-limit errors bounded on %s", async (route) => {
-			const { app, cleanup } = createTestApp();
-			try {
-				const malformed = await app.request(route, {
-					method: "POST",
-					headers: {
-						"Content-Type": "application/json",
-						Origin: "http://127.0.0.1:38888",
-					},
-					body: "{",
-				});
-				expect(malformed.status).toBe(400);
-				expect(await malformed.json()).toEqual({ error: "invalid json" });
+		it.each(["/api/claude-hooks", "/api/codex-hooks"])(
+			"keeps native parse and payload-limit errors bounded on %s",
+			async (route) => {
+				const { app, cleanup } = createTestApp();
+				try {
+					const malformed = await app.request(route, {
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+							Origin: "http://127.0.0.1:38888",
+						},
+						body: "{",
+					});
+					expect(malformed.status).toBe(400);
+					expect(await malformed.json()).toEqual({ error: "invalid json" });
 
-				const oversized = await postViewerJson(app, route, {
-					payload: "x".repeat(1_048_576),
-				});
-				expect(oversized.status).toBe(413);
-				expect(await oversized.json()).toEqual({
-					error: "payload too large",
-					max_bytes: 1_048_576,
-				});
-			} finally {
-				cleanup();
-			}
-		});
+					const oversized = await postViewerJson(app, route, {
+						payload: "x".repeat(1_048_576),
+					});
+					expect(oversized.status).toBe(413);
+					expect(await oversized.json()).toEqual({
+						error: "payload too large",
+						max_bytes: 1_048_576,
+					});
+				} finally {
+					cleanup();
+				}
+			},
+		);
 	});
 
 	describe("GET /api/stats", () => {
@@ -15972,424 +15978,415 @@ describe("viewer-server", () => {
 			{ label: "kind", responseOverride: { kind: "add_device" } },
 			{ label: "target ID", responseOverride: { policy_team_id: "team-other" } },
 			{ label: "reviewed digest", responseOverride: { reviewed_preview_digest: "f".repeat(64) } },
-		])("rejects a mismatched inspect $label without mutating the recipient DB or config", async (testCase) => {
-			// Arrange
-			const testDir = mkdtempSync(join(tmpdir(), "codemem-recipient-inspect-mismatch-"));
-			const configPath = join(testDir, "config.json");
-			const keysDir = join(testDir, "keys");
-			const previousConfig = process.env.CODEMEM_CONFIG;
-			const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
-			const previousFetch = globalThis.fetch;
-			process.env.CODEMEM_CONFIG = configPath;
-			process.env.CODEMEM_KEYS_DIR = keysDir;
-			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Fresh Recipient" }));
-			const reviewedIntent: Extract<core.RecipientReviewedIntentV1, { journey: "team" }> = {
-				version: 1,
-				journey: "team",
-				team: {
-					teamId: "team-reviewed",
-					displayName: "Reviewed Team",
-					futureProjectsInherit: true,
-				},
-				projects: [],
-				excludedProjects: [],
-			};
-			const digest = await core.recipientReviewedIntentDigest(reviewedIntent);
-			const encoded = core.encodeInvitePayload({
-				v: 1,
-				kind: "team_member",
-				coordinator_url: "https://coord.example.test",
-				group_id: "coordinator-a",
-				policy: "auto_admit",
-				token: "token-reviewed",
-				expires_at: "2099-01-01T00:00:00.000Z",
-				team_name: null,
-				policy_team_id: "team-reviewed",
-				assigned_identity_id: "identity-assigned-team",
-				reviewed_preview_digest: digest,
-			});
-			globalThis.fetch = vi.fn(
-				async () =>
-					new Response(
-						JSON.stringify({
-							kind: "team_member",
-							policy_team_id: "team-reviewed",
-							assigned_identity_id: "identity-assigned-team",
-							reviewed_preview_digest: digest,
-							reviewed_intent: reviewedIntent,
-							bound: false,
-							...testCase.responseOverride,
-						}),
-						{ status: 200 },
-					),
-			) as typeof fetch;
-			const { app, ensureStore, cleanup } = createTestApp({ seedDevice: false });
-			try {
-				const store = ensureStore();
-				const [deviceId] = ensureDeviceIdentity(store.db, { keysDir });
-				store.adoptEnsuredDeviceIdentity(deviceId);
-				const snapshot = () =>
-					JSON.stringify(
-						Object.fromEntries(
-							[
-								"actors",
-								"sync_device",
-								"identity_devices",
-								"policy_teams",
-								"policy_team_memberships",
-								"project_recipients",
-							].map((table) => [
-								table,
-								store.db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all(),
-							]),
-						),
-					);
-				const beforeDb = snapshot();
-				const beforeConfig = readFileSync(configPath, "utf8");
-
-				// Act
-				const response = await app.request("/api/sync/invites/inspect", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ invite: encoded, device_name: "Recipient Laptop" }),
+		])(
+			"rejects a mismatched inspect $label without mutating the recipient DB or config",
+			async (testCase) => {
+				// Arrange
+				const testDir = mkdtempSync(join(tmpdir(), "codemem-recipient-inspect-mismatch-"));
+				const configPath = join(testDir, "config.json");
+				const keysDir = join(testDir, "keys");
+				const previousConfig = process.env.CODEMEM_CONFIG;
+				const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
+				const previousFetch = globalThis.fetch;
+				process.env.CODEMEM_CONFIG = configPath;
+				process.env.CODEMEM_KEYS_DIR = keysDir;
+				writeFileSync(configPath, JSON.stringify({ actor_display_name: "Fresh Recipient" }));
+				const reviewedIntent: Extract<core.RecipientReviewedIntentV1, { journey: "team" }> = {
+					version: 1,
+					journey: "team",
+					team: {
+						teamId: "team-reviewed",
+						displayName: "Reviewed Team",
+						futureProjectsInherit: true,
+					},
+					projects: [],
+					excludedProjects: [],
+				};
+				const digest = await core.recipientReviewedIntentDigest(reviewedIntent);
+				const encoded = core.encodeInvitePayload({
+					v: 1,
+					kind: "team_member",
+					coordinator_url: "https://coord.example.test",
+					group_id: "coordinator-a",
+					policy: "auto_admit",
+					token: "token-reviewed",
+					expires_at: "2099-01-01T00:00:00.000Z",
+					team_name: null,
+					policy_team_id: "team-reviewed",
+					assigned_identity_id: "identity-assigned-team",
+					reviewed_preview_digest: digest,
 				});
+				globalThis.fetch = vi.fn(
+					async () =>
+						new Response(
+							JSON.stringify({
+								kind: "team_member",
+								policy_team_id: "team-reviewed",
+								assigned_identity_id: "identity-assigned-team",
+								reviewed_preview_digest: digest,
+								reviewed_intent: reviewedIntent,
+								bound: false,
+								...testCase.responseOverride,
+							}),
+							{ status: 200 },
+						),
+				) as typeof fetch;
+				const { app, ensureStore, cleanup } = createTestApp({ seedDevice: false });
+				try {
+					const store = ensureStore();
+					const [deviceId] = ensureDeviceIdentity(store.db, { keysDir });
+					store.adoptEnsuredDeviceIdentity(deviceId);
+					const snapshot = () =>
+						JSON.stringify(
+							Object.fromEntries(
+								[
+									"actors",
+									"sync_device",
+									"identity_devices",
+									"policy_teams",
+									"policy_team_memberships",
+									"project_recipients",
+								].map((table) => [
+									table,
+									store.db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all(),
+								]),
+							),
+						);
+					const beforeDb = snapshot();
+					const beforeConfig = readFileSync(configPath, "utf8");
 
-				// Assert
-				expect(response.status).toBe(409);
-				expect(await response.json()).toEqual({ error: "recipient_invite_intent_mismatch" });
-				expect(snapshot()).toBe(beforeDb);
-				expect(readFileSync(configPath, "utf8")).toBe(beforeConfig);
-			} finally {
-				cleanup();
-				globalThis.fetch = previousFetch;
-				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
-				else process.env.CODEMEM_CONFIG = previousConfig;
-				if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
-				else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
-				rmSync(testDir, { recursive: true, force: true });
-			}
-		});
+					// Act
+					const response = await app.request("/api/sync/invites/inspect", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ invite: encoded, device_name: "Recipient Laptop" }),
+					});
+
+					// Assert
+					expect(response.status).toBe(409);
+					expect(await response.json()).toEqual({ error: "recipient_invite_intent_mismatch" });
+					expect(snapshot()).toBe(beforeDb);
+					expect(readFileSync(configPath, "utf8")).toBe(beforeConfig);
+				} finally {
+					cleanup();
+					globalThis.fetch = previousFetch;
+					if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+					else process.env.CODEMEM_CONFIG = previousConfig;
+					if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+					else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
+					rmSync(testDir, { recursive: true, force: true });
+				}
+			},
+		);
 
 		it.each([
 			{ label: "Team", kind: "team_member" as const },
 			{ label: "add-device", kind: "add_device" as const },
-		])("creates a $label invite through the owner viewer and accepts it in a separate fresh recipient", async (testCase) => {
-			// Arrange
-			const testDir = mkdtempSync(join(tmpdir(), `codemem-${testCase.kind}-coordinator-`));
-			const coordinatorDbPath = join(testDir, "coordinator.sqlite");
-			const ownerConfigPath = join(testDir, "owner-config.json");
-			const ownerKeysDir = join(testDir, "owner-keys");
-			const recipientConfigPath = join(testDir, "recipient-config.json");
-			const recipientKeysDir = join(testDir, "recipient-keys");
-			const previousConfig = process.env.CODEMEM_CONFIG;
-			const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
-			const previousAdminSecret = process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
-			const previousFetch = globalThis.fetch;
-			const setupCoordinator = new core.BetterSqliteCoordinatorStore(coordinatorDbPath);
-			await setupCoordinator.createGroup("coordinator-a", "Coordinator A");
-			await setupCoordinator.close();
-			const coordinatorApp = core.createCoordinatorApp({
-				storeFactory: () => new core.BetterSqliteCoordinatorStore(coordinatorDbPath),
-				runtime: {
-					adminSecret: () => "secret",
-					now: () => "2026-07-23T12:00:00.000Z",
-				},
-				requestVerifier: async () => true,
-			});
-			globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) =>
-				coordinatorApp.request(String(input), init),
-			) as typeof fetch;
-			process.env.CODEMEM_CONFIG = ownerConfigPath;
-			process.env.CODEMEM_KEYS_DIR = ownerKeysDir;
-			process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET = "secret";
-			writeFileSync(
-				ownerConfigPath,
-				JSON.stringify({
-					actor_display_name: "Owner Identity",
-					sync_coordinator_url: "https://coord.example.test",
-					sync_coordinator_group: "coordinator-a",
-					sync_coordinator_admin_secret: "secret",
-				}),
-			);
-			const owner = createTestApp({ seedDevice: false });
-			let recipient: ReturnType<typeof createTestApp> | null = null;
-			try {
-				const ownerStore = owner.ensureStore();
-				const [ownerDeviceId] = ensureDeviceIdentity(ownerStore.db, { keysDir: ownerKeysDir });
-				ownerStore.adoptEnsuredDeviceIdentity(ownerDeviceId);
-				const teamId = "policy-team-a";
-				const alphaProjectId = "https://git.example.invalid/acme/alpha.git";
-				const betaProjectId = "https://git.example.invalid/acme/beta.git";
-				const now = "2026-07-23T12:00:00.000Z";
-				for (const [projectId, displayName, count] of [
-					[alphaProjectId, "alpha", 2],
-					[betaProjectId, "beta", 1],
-				] as const) {
-					const sessionId = insertTestSession(ownerStore.db);
-					ownerStore.db
-						.prepare("UPDATE sessions SET cwd = ?, git_remote = ?, project = ? WHERE id = ?")
-						.run(`/workspace/${displayName}`, projectId, displayName, sessionId);
-					for (let index = 0; index < count; index += 1) {
-						insertTestMemory(ownerStore, {
-							sessionId,
-							kind: "discovery",
-							title: `${displayName}-${index}`,
-							originDeviceId: ownerDeviceId,
-						});
+		])(
+			"creates a $label invite through the owner viewer and accepts it in a separate fresh recipient",
+			async (testCase) => {
+				// Arrange
+				const testDir = mkdtempSync(join(tmpdir(), `codemem-${testCase.kind}-coordinator-`));
+				const coordinatorDbPath = join(testDir, "coordinator.sqlite");
+				const ownerConfigPath = join(testDir, "owner-config.json");
+				const ownerKeysDir = join(testDir, "owner-keys");
+				const recipientConfigPath = join(testDir, "recipient-config.json");
+				const recipientKeysDir = join(testDir, "recipient-keys");
+				const previousConfig = process.env.CODEMEM_CONFIG;
+				const previousKeysDir = process.env.CODEMEM_KEYS_DIR;
+				const previousAdminSecret = process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
+				const previousFetch = globalThis.fetch;
+				const setupCoordinator = new core.BetterSqliteCoordinatorStore(coordinatorDbPath);
+				await setupCoordinator.createGroup("coordinator-a", "Coordinator A");
+				await setupCoordinator.close();
+				const coordinatorApp = core.createCoordinatorApp({
+					storeFactory: () => new core.BetterSqliteCoordinatorStore(coordinatorDbPath),
+					runtime: {
+						adminSecret: () => "secret",
+						now: () => "2026-07-23T12:00:00.000Z",
+					},
+					requestVerifier: async () => true,
+				});
+				globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) =>
+					coordinatorApp.request(String(input), init),
+				) as typeof fetch;
+				process.env.CODEMEM_CONFIG = ownerConfigPath;
+				process.env.CODEMEM_KEYS_DIR = ownerKeysDir;
+				process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET = "secret";
+				writeFileSync(
+					ownerConfigPath,
+					JSON.stringify({
+						actor_display_name: "Owner Identity",
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "coordinator-a",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				const owner = createTestApp({ seedDevice: false });
+				let recipient: ReturnType<typeof createTestApp> | null = null;
+				try {
+					const ownerStore = owner.ensureStore();
+					const [ownerDeviceId] = ensureDeviceIdentity(ownerStore.db, { keysDir: ownerKeysDir });
+					ownerStore.adoptEnsuredDeviceIdentity(ownerDeviceId);
+					const teamId = "policy-team-a";
+					const alphaProjectId = "https://git.example.invalid/acme/alpha.git";
+					const betaProjectId = "https://git.example.invalid/acme/beta.git";
+					const now = "2026-07-23T12:00:00.000Z";
+					for (const [projectId, displayName, count] of [
+						[alphaProjectId, "alpha", 2],
+						[betaProjectId, "beta", 1],
+					] as const) {
+						const sessionId = insertTestSession(ownerStore.db);
+						ownerStore.db
+							.prepare("UPDATE sessions SET cwd = ?, git_remote = ?, project = ? WHERE id = ?")
+							.run(`/workspace/${displayName}`, projectId, displayName, sessionId);
+						for (let index = 0; index < count; index += 1) {
+							insertTestMemory(ownerStore, {
+								sessionId,
+								kind: "discovery",
+								title: `${displayName}-${index}`,
+								originDeviceId: ownerDeviceId,
+							});
+						}
 					}
-				}
-				ownerStore.db
-					.prepare(`INSERT INTO policy_teams(
+					ownerStore.db
+						.prepare(`INSERT INTO policy_teams(
 							team_id, display_name, status, provenance, revision, migration_state,
 							source_fingerprint, idempotency_key, created_at, updated_at
 						) VALUES (?, ?, 'active', 'user', 'r1', 'user_managed', NULL, 'team-a', ?, ?)`)
-					.run(teamId, "Policy Team A", now, now);
-				for (const [recipientKind, recipientId] of [
-					["team", teamId],
-					["identity", ownerStore.actorId],
-				] as const) {
-					ownerStore.db
-						.prepare(`INSERT INTO project_recipients(
+						.run(teamId, "Policy Team A", now, now);
+					for (const [recipientKind, recipientId] of [
+						["team", teamId],
+						["identity", ownerStore.actorId],
+					] as const) {
+						ownerStore.db
+							.prepare(`INSERT INTO project_recipients(
 								canonical_project_identity, recipient_kind, recipient_id, status, provenance,
 								policy_revision, migration_state, source_fingerprint, idempotency_key,
 								created_at, updated_at
 							) VALUES (?, ?, ?, 'active', 'user', ?, 'user_managed', NULL, ?, ?, ?)`)
-						.run(
-							alphaProjectId,
-							recipientKind,
-							recipientId,
-							`revision-${recipientKind}`,
-							`idempotency-${recipientKind}`,
-							now,
-							now,
-						);
-				}
-				const ownerRequest =
-					testCase.kind === "team_member"
-						? { kind: testCase.kind, policy_team_id: teamId }
-						: { kind: testCase.kind, target_identity_id: ownerStore.actorId };
-				const preview = (await (
-					await owner.app.request("/api/sync/recipient-policy/v1/invites/preview", {
-						method: "POST",
-						headers: { "Content-Type": "application/json" },
-						body: JSON.stringify(ownerRequest),
-					})
-				).json()) as { preview: { reviewedOnboardingDigest: string } };
-				const createResponse = await owner.app.request("/api/sync/recipient-policy/v1/invites", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({
-						...ownerRequest,
-						reviewed_onboarding_digest: preview.preview.reviewedOnboardingDigest,
-					}),
-				});
-				expect(createResponse.status, JSON.stringify(await createResponse.clone().json())).toBe(
-					200,
-				);
-				const created = (await createResponse.json()) as { invite: { encoded: string } };
-				const payload = core.decodeInvitePayload(created.invite.encoded);
-
-				process.env.CODEMEM_CONFIG = recipientConfigPath;
-				process.env.CODEMEM_KEYS_DIR = recipientKeysDir;
-				writeFileSync(
-					recipientConfigPath,
-					JSON.stringify(
-						testCase.kind === "team_member" ? { actor_display_name: "Fresh Recipient" } : {},
-					),
-				);
-				recipient = createTestApp({ seedDevice: false });
-				const recipientStore = recipient.ensureStore();
-				const bootstrapActorId = recipientStore.actorId;
-				expect(bootstrapActorId.length).toBeGreaterThan(0);
-				expect(recipientStore.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(
-					0,
-				);
-				expect(
-					recipientStore.db.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get(),
-				).toBe(0);
-				expect(
-					recipientStore.db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get(),
-				).toBe(0);
-
-				// Act
-				const inspectResponse = await recipient.app.request("/api/sync/invites/inspect", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ invite: created.invite.encoded, device_name: "Recipient Laptop" }),
-				});
-				expect(inspectResponse.status, JSON.stringify(await inspectResponse.clone().json())).toBe(
-					200,
-				);
-				const inspection = (await inspectResponse.json()) as {
-					recipient_name: string;
-					assigned_identity_id?: string;
-					onboarding: {
-						reviewedOnboardingDigest: string;
-						projects: unknown[];
-						excludedProjects: unknown[];
-					};
-				};
-
-				// Assert
-				if (testCase.kind === "team_member") {
-					expect(inspection.assigned_identity_id).toEqual(expect.any(String));
-					expect(inspection.assigned_identity_id?.trim()).toBe(inspection.assigned_identity_id);
-					expect(inspection.assigned_identity_id?.length).toBeGreaterThan(0);
-					expect(inspection.assigned_identity_id).not.toBe(bootstrapActorId);
-					expect(inspection.assigned_identity_id).not.toBe(ownerStore.actorId);
-				}
-				expect(inspection.onboarding.projects).toEqual([
-					{
-						canonicalProjectIdentity: alphaProjectId,
-						displayName: "alpha",
-						existingMemoryCount: 2,
-						futureMemoriesShared: true,
-						sources:
-							testCase.kind === "team_member"
-								? [{ kind: "team", teamId, displayName: "Policy Team A" }]
-								: [{ kind: "direct" }],
-					},
-				]);
-				expect(inspection.onboarding.excludedProjects).toEqual(
-					testCase.kind === "team_member"
-						? []
-						: [
-								{
-									canonicalProjectIdentity: betaProjectId,
-									displayName: "beta",
-									existingMemoryCount: 1,
-								},
-							],
-				);
-				if (testCase.kind === "team_member") {
-					expect(JSON.stringify(inspection)).not.toContain(betaProjectId);
-					expect(JSON.stringify(inspection)).not.toContain('"beta"');
-				}
-				const importBody = {
-					invite: created.invite.encoded,
-					recipient_name: inspection.recipient_name,
-					device_name: "Recipient Laptop",
-					reviewed_onboarding_digest: inspection.onboarding.reviewedOnboardingDigest,
-				};
-				if (testCase.kind === "team_member") {
-					const invalidName = await recipient.app.request("/api/sync/invites/import", {
+							.run(
+								alphaProjectId,
+								recipientKind,
+								recipientId,
+								`revision-${recipientKind}`,
+								`idempotency-${recipientKind}`,
+								now,
+								now,
+							);
+					}
+					const ownerRequest =
+						testCase.kind === "team_member"
+							? { kind: testCase.kind, policy_team_id: teamId }
+							: { kind: testCase.kind, target_identity_id: ownerStore.actorId };
+					const preview = (await (
+						await owner.app.request("/api/sync/recipient-policy/v1/invites/preview", {
+							method: "POST",
+							headers: { "Content-Type": "application/json" },
+							body: JSON.stringify(ownerRequest),
+						})
+					).json()) as { preview: { reviewedOnboardingDigest: string } };
+					const createResponse = await owner.app.request("/api/sync/recipient-policy/v1/invites", {
 						method: "POST",
 						headers: { "Content-Type": "application/json" },
 						body: JSON.stringify({
-							...importBody,
-							recipient_name: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
+							...ownerRequest,
+							reviewed_onboarding_digest: preview.preview.reviewedOnboardingDigest,
 						}),
 					});
-					expect(invalidName.status).toBe(400);
-					expect(await invalidName.json()).toEqual({ error: "recipient_display_name_invalid" });
-				}
-				const stale = await recipient.app.request("/api/sync/invites/import", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ ...importBody, device_name: "Renamed Recipient Laptop" }),
-				});
-				expect(stale.status).toBe(400);
-				expect(await stale.json()).toEqual({ error: "reviewed_onboarding_stale" });
-				expect(recipientStore.actorId).not.toBe(
-					testCase.kind === "team_member" ? inspection.assigned_identity_id : ownerStore.actorId,
-				);
+					expect(createResponse.status, JSON.stringify(await createResponse.clone().json())).toBe(
+						200,
+					);
+					const created = (await createResponse.json()) as { invite: { encoded: string } };
+					const payload = core.decodeInvitePayload(created.invite.encoded);
 
-				const accepted = await recipient.app.request("/api/sync/invites/import", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify(importBody),
-				});
-				expect(accepted.status, JSON.stringify(await accepted.clone().json())).toBe(200);
-				expect(await accepted.json()).toMatchObject({
-					status: "accepted",
-					type: "recipient_onboarding",
-				});
-				const expectedIdentityId =
-					testCase.kind === "team_member"
-						? String(inspection.assigned_identity_id)
-						: ownerStore.actorId;
-				expect(recipientStore.actorId).toBe(expectedIdentityId);
-				expect(recipientStore.actorId).not.toBe(bootstrapActorId);
-				if (testCase.kind === "add_device") {
-					expect(recipientStore.actorDisplayName).toBe("Owner Identity");
-				}
-				const recipientDeviceId = recipientStore.db
-					.prepare("SELECT device_id FROM sync_device LIMIT 1")
-					.pluck()
-					.get() as string;
-				expect(
-					recipientStore.db.prepare("SELECT identity_id, device_id FROM identity_devices").all(),
-				).toEqual([{ identity_id: expectedIdentityId, device_id: recipientDeviceId }]);
-				expect(
-					recipientStore.db
-						.prepare(
-							"SELECT actor_id, display_name, is_local, status FROM actors ORDER BY actor_id",
-						)
-						.all(),
-				).toEqual([
-					{
+					process.env.CODEMEM_CONFIG = recipientConfigPath;
+					process.env.CODEMEM_KEYS_DIR = recipientKeysDir;
+					writeFileSync(
+						recipientConfigPath,
+						JSON.stringify(
+							testCase.kind === "team_member" ? { actor_display_name: "Fresh Recipient" } : {},
+						),
+					);
+					recipient = createTestApp({ seedDevice: false });
+					const recipientStore = recipient.ensureStore();
+					const bootstrapActorId = recipientStore.actorId;
+					expect(bootstrapActorId.length).toBeGreaterThan(0);
+					expect(recipientStore.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(
+						0,
+					);
+					expect(
+						recipientStore.db.prepare("SELECT COUNT(*) FROM policy_team_memberships").pluck().get(),
+					).toBe(0);
+					expect(
+						recipientStore.db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get(),
+					).toBe(0);
+
+					// Act
+					const inspectResponse = await recipient.app.request("/api/sync/invites/inspect", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({
+							invite: created.invite.encoded,
+							device_name: "Recipient Laptop",
+						}),
+					});
+					expect(inspectResponse.status, JSON.stringify(await inspectResponse.clone().json())).toBe(
+						200,
+					);
+					const inspection = (await inspectResponse.json()) as {
+						recipient_name: string;
+						assigned_identity_id?: string;
+						onboarding: {
+							reviewedOnboardingDigest: string;
+							projects: unknown[];
+							excludedProjects: unknown[];
+						};
+					};
+
+					// Assert
+					if (testCase.kind === "team_member") {
+						expect(inspection.assigned_identity_id).toEqual(expect.any(String));
+						expect(inspection.assigned_identity_id?.trim()).toBe(inspection.assigned_identity_id);
+						expect(inspection.assigned_identity_id?.length).toBeGreaterThan(0);
+						expect(inspection.assigned_identity_id).not.toBe(bootstrapActorId);
+						expect(inspection.assigned_identity_id).not.toBe(ownerStore.actorId);
+					}
+					expect(inspection.onboarding.projects).toEqual([
+						{
+							canonicalProjectIdentity: alphaProjectId,
+							displayName: "alpha",
+							existingMemoryCount: 2,
+							futureMemoriesShared: true,
+							sources:
+								testCase.kind === "team_member"
+									? [{ kind: "team", teamId, displayName: "Policy Team A" }]
+									: [{ kind: "direct" }],
+						},
+					]);
+					expect(inspection.onboarding.excludedProjects).toEqual(
+						testCase.kind === "team_member"
+							? []
+							: [
+									{
+										canonicalProjectIdentity: betaProjectId,
+										displayName: "beta",
+										existingMemoryCount: 1,
+									},
+								],
+					);
+					if (testCase.kind === "team_member") {
+						expect(JSON.stringify(inspection)).not.toContain(betaProjectId);
+						expect(JSON.stringify(inspection)).not.toContain('"beta"');
+					}
+					const importBody = {
+						invite: created.invite.encoded,
+						recipient_name: inspection.recipient_name,
+						device_name: "Recipient Laptop",
+						reviewed_onboarding_digest: inspection.onboarding.reviewedOnboardingDigest,
+					};
+					if (testCase.kind === "team_member") {
+						const invalidName = await recipient.app.request("/api/sync/invites/import", {
+							method: "POST",
+							headers: { "Content-Type": "application/json" },
+							body: JSON.stringify({
+								...importBody,
+								recipient_name: "local:0ea043cc-c61c-427d-8b77-572331b9855c",
+							}),
+						});
+						expect(invalidName.status).toBe(400);
+						expect(await invalidName.json()).toEqual({ error: "recipient_display_name_invalid" });
+					}
+					const stale = await recipient.app.request("/api/sync/invites/import", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ ...importBody, device_name: "Renamed Recipient Laptop" }),
+					});
+					expect(stale.status).toBe(400);
+					expect(await stale.json()).toEqual({ error: "reviewed_onboarding_stale" });
+					expect(recipientStore.actorId).not.toBe(
+						testCase.kind === "team_member" ? inspection.assigned_identity_id : ownerStore.actorId,
+					);
+
+					const accepted = await recipient.app.request("/api/sync/invites/import", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify(importBody),
+					});
+					expect(accepted.status, JSON.stringify(await accepted.clone().json())).toBe(200);
+					expect(await accepted.json()).toMatchObject({
+						status: "accepted",
+						type: "recipient_onboarding",
+					});
+					const expectedIdentityId =
+						testCase.kind === "team_member"
+							? String(inspection.assigned_identity_id)
+							: ownerStore.actorId;
+					expect(recipientStore.actorId).toBe(expectedIdentityId);
+					expect(recipientStore.actorId).not.toBe(bootstrapActorId);
+					if (testCase.kind === "add_device") {
+						expect(recipientStore.actorDisplayName).toBe("Owner Identity");
+					}
+					const recipientDeviceId = recipientStore.db
+						.prepare("SELECT device_id FROM sync_device LIMIT 1")
+						.pluck()
+						.get() as string;
+					expect(
+						recipientStore.db.prepare("SELECT identity_id, device_id FROM identity_devices").all(),
+					).toEqual([{ identity_id: expectedIdentityId, device_id: recipientDeviceId }]);
+					expect(
+						recipientStore.db
+							.prepare(
+								"SELECT actor_id, display_name, is_local, status FROM actors ORDER BY actor_id",
+							)
+							.all(),
+					).toEqual([
+						{
+							actor_id: expectedIdentityId,
+							display_name: testCase.kind === "team_member" ? "Fresh Recipient" : "Owner Identity",
+							is_local: 1,
+							status: "active",
+						},
+					]);
+					expect(
+						recipientStore.db
+							.prepare("SELECT team_id, display_name, status FROM policy_teams")
+							.all(),
+					).toEqual(
+						testCase.kind === "team_member"
+							? [{ team_id: teamId, display_name: "Policy Team A", status: "active" }]
+							: [],
+					);
+					expect(
+						recipientStore.db
+							.prepare("SELECT team_id, identity_id, role, status FROM policy_team_memberships")
+							.all(),
+					).toEqual(
+						testCase.kind === "team_member"
+							? [
+									{
+										team_id: teamId,
+										identity_id: expectedIdentityId,
+										role: "member",
+										status: "active",
+									},
+								]
+							: [],
+					);
+					expect(
+						recipientStore.db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get(),
+					).toBe(0);
+					const persistedConfig = JSON.parse(readFileSync(recipientConfigPath, "utf8"));
+					expect(persistedConfig).toMatchObject({
 						actor_id: expectedIdentityId,
-						display_name: testCase.kind === "team_member" ? "Fresh Recipient" : "Owner Identity",
-						is_local: 1,
-						status: "active",
-					},
-				]);
-				expect(
-					recipientStore.db.prepare("SELECT team_id, display_name, status FROM policy_teams").all(),
-				).toEqual(
-					testCase.kind === "team_member"
-						? [{ team_id: teamId, display_name: "Policy Team A", status: "active" }]
-						: [],
-				);
-				expect(
-					recipientStore.db
-						.prepare("SELECT team_id, identity_id, role, status FROM policy_team_memberships")
-						.all(),
-				).toEqual(
-					testCase.kind === "team_member"
-						? [
-								{
-									team_id: teamId,
-									identity_id: expectedIdentityId,
-									role: "member",
-									status: "active",
-								},
-							]
-						: [],
-				);
-				expect(
-					recipientStore.db.prepare("SELECT COUNT(*) FROM project_recipients").pluck().get(),
-				).toBe(0);
-				const persistedConfig = JSON.parse(readFileSync(recipientConfigPath, "utf8"));
-				expect(persistedConfig).toMatchObject({
-					actor_id: expectedIdentityId,
-					actor_display_name:
-						testCase.kind === "team_member" ? "Fresh Recipient" : "Owner Identity",
-					sync_device_name: "Recipient Laptop",
-					sync_coordinator_url: "https://coord.example.test",
-					sync_coordinator_group: "coordinator-a",
-					sync_coordinator_groups: ["coordinator-a"],
-				});
-				const materializedState = JSON.stringify({
-					actors: recipientStore.db.prepare("SELECT * FROM actors ORDER BY actor_id").all(),
-					devices: recipientStore.db
-						.prepare("SELECT * FROM identity_devices ORDER BY identity_id")
-						.all(),
-					teams: recipientStore.db.prepare("SELECT * FROM policy_teams ORDER BY team_id").all(),
-					memberships: recipientStore.db
-						.prepare("SELECT * FROM policy_team_memberships ORDER BY team_id, identity_id")
-						.all(),
-				});
-				const persistedConfigText = readFileSync(recipientConfigPath, "utf8");
-				const replay = await recipient.app.request("/api/sync/invites/import", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify(importBody),
-				});
-				expect(replay.status).toBe(200);
-				expect(await replay.json()).toMatchObject({ status: "existing" });
-				expect(
-					JSON.stringify({
+						actor_display_name:
+							testCase.kind === "team_member" ? "Fresh Recipient" : "Owner Identity",
+						sync_device_name: "Recipient Laptop",
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "coordinator-a",
+						sync_coordinator_groups: ["coordinator-a"],
+					});
+					const materializedState = JSON.stringify({
 						actors: recipientStore.db.prepare("SELECT * FROM actors ORDER BY actor_id").all(),
 						devices: recipientStore.db
 							.prepare("SELECT * FROM identity_devices ORDER BY identity_id")
@@ -16398,41 +16395,61 @@ describe("viewer-server", () => {
 						memberships: recipientStore.db
 							.prepare("SELECT * FROM policy_team_memberships ORDER BY team_id, identity_id")
 							.all(),
-					}),
-				).toBe(materializedState);
-				expect(readFileSync(recipientConfigPath, "utf8")).toBe(persistedConfigText);
-				const coordinatorVerification = new core.BetterSqliteCoordinatorStore(coordinatorDbPath);
-				try {
-					expect(
-						await coordinatorVerification.getInviteByTokenForInspection(String(payload.token)),
-					).toMatchObject({
-						invite_kind: testCase.kind,
-						...(testCase.kind === "team_member"
-							? { assigned_identity_id: expectedIdentityId }
-							: { target_identity_id: expectedIdentityId }),
-						bound_device_id: recipientDeviceId,
-						recipient_actor_id: expectedIdentityId,
-						consumed_at: expect.any(String),
 					});
+					const persistedConfigText = readFileSync(recipientConfigPath, "utf8");
+					const replay = await recipient.app.request("/api/sync/invites/import", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify(importBody),
+					});
+					expect(replay.status).toBe(200);
+					expect(await replay.json()).toMatchObject({ status: "existing" });
+					expect(
+						JSON.stringify({
+							actors: recipientStore.db.prepare("SELECT * FROM actors ORDER BY actor_id").all(),
+							devices: recipientStore.db
+								.prepare("SELECT * FROM identity_devices ORDER BY identity_id")
+								.all(),
+							teams: recipientStore.db.prepare("SELECT * FROM policy_teams ORDER BY team_id").all(),
+							memberships: recipientStore.db
+								.prepare("SELECT * FROM policy_team_memberships ORDER BY team_id, identity_id")
+								.all(),
+						}),
+					).toBe(materializedState);
+					expect(readFileSync(recipientConfigPath, "utf8")).toBe(persistedConfigText);
+					const coordinatorVerification = new core.BetterSqliteCoordinatorStore(coordinatorDbPath);
+					try {
+						expect(
+							await coordinatorVerification.getInviteByTokenForInspection(String(payload.token)),
+						).toMatchObject({
+							invite_kind: testCase.kind,
+							...(testCase.kind === "team_member"
+								? { assigned_identity_id: expectedIdentityId }
+								: { target_identity_id: expectedIdentityId }),
+							bound_device_id: recipientDeviceId,
+							recipient_actor_id: expectedIdentityId,
+							consumed_at: expect.any(String),
+						});
+					} finally {
+						await coordinatorVerification.close();
+					}
 				} finally {
-					await coordinatorVerification.close();
+					recipient?.cleanup();
+					owner.cleanup();
+					globalThis.fetch = previousFetch;
+					if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
+					else process.env.CODEMEM_CONFIG = previousConfig;
+					if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+					else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
+					if (previousAdminSecret == null) {
+						delete process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
+					} else {
+						process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET = previousAdminSecret;
+					}
+					rmSync(testDir, { recursive: true, force: true });
 				}
-			} finally {
-				recipient?.cleanup();
-				owner.cleanup();
-				globalThis.fetch = previousFetch;
-				if (previousConfig == null) delete process.env.CODEMEM_CONFIG;
-				else process.env.CODEMEM_CONFIG = previousConfig;
-				if (previousKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
-				else process.env.CODEMEM_KEYS_DIR = previousKeysDir;
-				if (previousAdminSecret == null) {
-					delete process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
-				} else {
-					process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET = previousAdminSecret;
-				}
-				rmSync(testDir, { recursive: true, force: true });
-			}
-		});
+			},
+		);
 
 		it("reuses a reconciled Team identity for a later exact-Project share", async () => {
 			// Arrange

--- a/packages/viewer-server/src/routes/team-setup-terminal.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-terminal.test.ts
@@ -155,62 +155,65 @@ describe("Team setup terminal migration routing", () => {
 	it.each([
 		["serves the completed draft", true, 200],
 		["rejects the superseded draft", false, 404],
-	] as const)("rechecks a migration marker after detail roster loading and %s", async (_label, remainsCompleted, expectedStatus) => {
-		const store = new MemoryStore(":memory:");
-		let resolveCandidateLoad!: () => void;
-		const loadSnapshots = vi.fn((options?: { candidateRef?: string }) =>
-			options?.candidateRef
-				? new Promise<LegacyTeamConfiguredGroupSnapshot[]>((resolve) => {
-						resolveCandidateLoad = () => resolve(SNAPSHOTS);
-					})
-				: Promise.resolve(SNAPSHOTS),
-		);
-		const app = teamSetupRoutes({
-			getStore: () => store,
-			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
-		});
-		try {
-			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
-			const draft = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
-			if (!draft) throw new Error("initial Team setup draft missing");
-			completeDraft(store, draft, null);
-			const detailPromise = app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
-			await vi.waitFor(() => expect(loadSnapshots).toHaveBeenCalledTimes(2));
-			const teamId = insertTeam(store, draft, {
-				status: "active",
-				provenance: "reviewed_team_candidate",
+	] as const)(
+		"rechecks a migration marker after detail roster loading and %s",
+		async (_label, remainsCompleted, expectedStatus) => {
+			const store = new MemoryStore(":memory:");
+			let resolveCandidateLoad!: () => void;
+			const loadSnapshots = vi.fn((options?: { candidateRef?: string }) =>
+				options?.candidateRef
+					? new Promise<LegacyTeamConfiguredGroupSnapshot[]>((resolve) => {
+							resolveCandidateLoad = () => resolve(SNAPSHOTS);
+						})
+					: Promise.resolve(SNAPSHOTS),
+			);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
 			});
-			if (remainsCompleted) {
-				store.db
-					.prepare(
-						`UPDATE legacy_team_setup_drafts SET completed_team_id = ?
-							 WHERE attempt_id = ?`,
-					)
-					.run(teamId, draft.attemptId);
-			} else {
-				store.db
-					.prepare(
-						`UPDATE legacy_team_setup_drafts
-							 SET state = 'needs_setup', completed_at = NULL WHERE attempt_id = ?`,
-					)
-					.run(draft.attemptId);
-			}
-			resolveCandidateLoad();
-
-			const detail = await detailPromise;
-			expect(detail.status).toBe(expectedStatus);
-			if (remainsCompleted) {
-				expect(await detail.json()).toMatchObject({
-					candidate: { candidateRef: CANDIDATE_REF, status: "ready" },
-					state: "completed",
+			try {
+				expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+				const draft = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+				if (!draft) throw new Error("initial Team setup draft missing");
+				completeDraft(store, draft, null);
+				const detailPromise = app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+				await vi.waitFor(() => expect(loadSnapshots).toHaveBeenCalledTimes(2));
+				const teamId = insertTeam(store, draft, {
+					status: "active",
+					provenance: "reviewed_team_candidate",
 				});
-			} else {
-				expect(await detail.json()).toEqual({ error: "team_setup_confirmation_stale" });
+				if (remainsCompleted) {
+					store.db
+						.prepare(
+							`UPDATE legacy_team_setup_drafts SET completed_team_id = ?
+							 WHERE attempt_id = ?`,
+						)
+						.run(teamId, draft.attemptId);
+				} else {
+					store.db
+						.prepare(
+							`UPDATE legacy_team_setup_drafts
+							 SET state = 'needs_setup', completed_at = NULL WHERE attempt_id = ?`,
+						)
+						.run(draft.attemptId);
+				}
+				resolveCandidateLoad();
+
+				const detail = await detailPromise;
+				expect(detail.status).toBe(expectedStatus);
+				if (remainsCompleted) {
+					expect(await detail.json()).toMatchObject({
+						candidate: { candidateRef: CANDIDATE_REF, status: "ready" },
+						state: "completed",
+					});
+				} else {
+					expect(await detail.json()).toEqual({ error: "team_setup_confirmation_stale" });
+				}
+			} finally {
+				store.close();
 			}
-		} finally {
-			store.close();
-		}
-	});
+		},
+	);
 
 	it("does not treat an inactive migration marker as terminal", async () => {
 		const store = new MemoryStore(":memory:");

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -97,58 +97,58 @@ describe("Team setup roster loading", () => {
 	it.each([
 		{ configuredTimeoutS: 17, expectedTimeoutS: 17 },
 		{ configuredTimeoutS: 0, expectedTimeoutS: 1 },
-	])("uses normalized coordinator settings with timeout $expectedTimeoutS", async ({
-		configuredTimeoutS,
-		expectedTimeoutS,
-	}) => {
-		const publicKey = "public-key-a";
-		const listGroups = vi.fn(async () => [
-			{
-				group_id: "group-alpha",
-				display_name: "Migration Team",
-				archived_at: null,
-				created_at: "2026-08-24T00:00:00.000Z",
-			},
-		]);
-		const listDevices = vi.fn(async () => [
-			{
-				group_id: "group-alpha",
-				device_id: "device-a",
-				public_key: publicKey,
-				fingerprint: fingerprintPublicKey(publicKey),
-				identity_id: null,
-				display_name: "Laptop",
-				enabled: 1,
-				created_at: "2026-08-24T00:00:00.000Z",
-			},
-		]);
+	])(
+		"uses normalized coordinator settings with timeout $expectedTimeoutS",
+		async ({ configuredTimeoutS, expectedTimeoutS }) => {
+			const publicKey = "public-key-a";
+			const listGroups = vi.fn(async () => [
+				{
+					group_id: "group-alpha",
+					display_name: "Migration Team",
+					archived_at: null,
+					created_at: "2026-08-24T00:00:00.000Z",
+				},
+			]);
+			const listDevices = vi.fn(async () => [
+				{
+					group_id: "group-alpha",
+					device_id: "device-a",
+					public_key: publicKey,
+					fingerprint: fingerprintPublicKey(publicKey),
+					identity_id: null,
+					display_name: "Laptop",
+					enabled: 1,
+					created_at: "2026-08-24T00:00:00.000Z",
+				},
+			]);
 
-		const snapshots = await __teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
-			readConfig: () => ({
-				...readCoordinatorSyncConfig({}),
-				syncCoordinatorUrl: "localhost:8787/",
-				syncCoordinatorGroups: ["group-alpha"],
-				syncCoordinatorAdminSecret: "private-admin-secret",
-				syncCoordinatorTimeoutS: configuredTimeoutS,
-			}),
-			listGroups,
-			listDevices,
-		});
+			const snapshots = await __teamSetupTestHooks.loadConfiguredLegacyTeamGroupSnapshotsWith({
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: "localhost:8787/",
+					syncCoordinatorGroups: ["group-alpha"],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+					syncCoordinatorTimeoutS: configuredTimeoutS,
+				}),
+				listGroups,
+				listDevices,
+			});
 
-		expect(snapshots[0]?.coordinatorId).toBe("http://localhost:8787");
-		expect(listGroups).toHaveBeenCalledWith(
-			expect.objectContaining({
-				remoteUrl: "http://localhost:8787",
-				timeoutS: expectedTimeoutS,
-			}),
-		);
-		expect(listDevices).toHaveBeenCalledWith(
-			expect.objectContaining({
-				remoteUrl: "http://localhost:8787",
-				timeoutS: expectedTimeoutS,
-			}),
-		);
-	});
+			expect(snapshots[0]?.coordinatorId).toBe("http://localhost:8787");
+			expect(listGroups).toHaveBeenCalledWith(
+				expect.objectContaining({
+					remoteUrl: "http://localhost:8787",
+					timeoutS: expectedTimeoutS,
+				}),
+			);
+			expect(listDevices).toHaveBeenCalledWith(
+				expect.objectContaining({
+					remoteUrl: "http://localhost:8787",
+					timeoutS: expectedTimeoutS,
+				}),
+			);
+		},
+	);
 
 	it("retries transient coordinator timeouts while loading a candidate roster", async () => {
 		const publicKey = "public-key-a";
@@ -974,51 +974,51 @@ describe("Team setup roster loading", () => {
 		expect(listDevices).toHaveBeenCalledTimes(2);
 	});
 
-	it.each([
-		"archived",
-		"deleted",
-	])("treats a sole %s configured group as authoritative absence", async (state) => {
-		const { store, close } = createRouteStore();
-		const coordinatorId = "http://localhost:8787";
-		const groupId = "group-absent";
-		const listDevices = vi.fn(async () => []);
-		try {
-			const app = teamSetupRoutes({
-				getStore: () => store,
-				snapshotLoaderDependencies: {
-					readConfig: () => ({
-						...readCoordinatorSyncConfig({}),
-						syncCoordinatorUrl: coordinatorId,
-						syncCoordinatorGroups: [groupId],
-						syncCoordinatorAdminSecret: "private-admin-secret",
-					}),
-					listGroups: async () =>
-						state === "archived"
-							? [
-									{
-										group_id: groupId,
-										display_name: "Archived Team",
-										archived_at: "2026-08-26T00:00:00.000Z",
-										created_at: "2026-08-24T00:00:00.000Z",
-									},
-								]
-							: [],
-					listDevices,
-				},
-			});
-			const summary = await app.request("/api/sync/team-setup/v1");
-			expect(summary.status).toBe(200);
-			expect(await summary.json()).toEqual({ version: 1, candidates: [] });
-			const detail = await app.request(
-				`/api/sync/team-setup/v1/${legacyTeamCandidateId(coordinatorId, groupId)}`,
-			);
-			expect(detail.status).toBe(404);
-			expect(await detail.json()).toEqual({ error: "team_setup_confirmation_stale" });
-			expect(listDevices).not.toHaveBeenCalled();
-		} finally {
-			close();
-		}
-	});
+	it.each(["archived", "deleted"])(
+		"treats a sole %s configured group as authoritative absence",
+		async (state) => {
+			const { store, close } = createRouteStore();
+			const coordinatorId = "http://localhost:8787";
+			const groupId = "group-absent";
+			const listDevices = vi.fn(async () => []);
+			try {
+				const app = teamSetupRoutes({
+					getStore: () => store,
+					snapshotLoaderDependencies: {
+						readConfig: () => ({
+							...readCoordinatorSyncConfig({}),
+							syncCoordinatorUrl: coordinatorId,
+							syncCoordinatorGroups: [groupId],
+							syncCoordinatorAdminSecret: "private-admin-secret",
+						}),
+						listGroups: async () =>
+							state === "archived"
+								? [
+										{
+											group_id: groupId,
+											display_name: "Archived Team",
+											archived_at: "2026-08-26T00:00:00.000Z",
+											created_at: "2026-08-24T00:00:00.000Z",
+										},
+									]
+								: [],
+						listDevices,
+					},
+				});
+				const summary = await app.request("/api/sync/team-setup/v1");
+				expect(summary.status).toBe(200);
+				expect(await summary.json()).toEqual({ version: 1, candidates: [] });
+				const detail = await app.request(
+					`/api/sync/team-setup/v1/${legacyTeamCandidateId(coordinatorId, groupId)}`,
+				);
+				expect(detail.status).toBe(404);
+				expect(await detail.json()).toEqual({ error: "team_setup_confirmation_stale" });
+				expect(listDevices).not.toHaveBeenCalled();
+			} finally {
+				close();
+			}
+		},
+	);
 
 	it("fails safely when the sole current group metadata is malformed", async () => {
 		await expect(
@@ -1502,21 +1502,24 @@ describe("Team metadata route", () => {
 		["missing", "Old Team", "New Team", 404, "team_not_found"],
 		["team-local", "Stale Team", "New Team", 409, "team_rename_stale"],
 		["team-local", "Old Team", "actor:machine", 400, "team_name_invalid"],
-	])("returns safe errors for invalid or stale Team changes", async (teamId, expectedDisplayName, displayName, status, error) => {
-		const { store } = fixture();
-		try {
-			const app = syncRoutes(() => store, undefined, {
-				readCoordinatorConfig: () => readCoordinatorSyncConfig({}),
-			});
-			const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
-				method: "PATCH",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ displayName, expectedDisplayName }),
-			});
-			expect(response.status).toBe(status);
-			expect(await response.json()).toEqual({ error });
-		} finally {
-			store.close();
-		}
-	});
+	])(
+		"returns safe errors for invalid or stale Team changes",
+		async (teamId, expectedDisplayName, displayName, status, error) => {
+			const { store } = fixture();
+			try {
+				const app = syncRoutes(() => store, undefined, {
+					readCoordinatorConfig: () => readCoordinatorSyncConfig({}),
+				});
+				const response = await app.request(`/api/sync/recipient-policy/v1/teams/${teamId}`, {
+					method: "PATCH",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ displayName, expectedDisplayName }),
+				});
+				expect(response.status).toBe(status);
+				expect(await response.json()).toEqual({ error });
+			} finally {
+				store.close();
+			}
+		},
+	);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ settings:
 catalogs:
   default:
     '@biomejs/biome':
-      specifier: ^2.4.16
-      version: 2.4.16
+      specifier: ^2.5.11
+      version: 2.5.11
     '@hono/node-server':
       specifier: ^2.1.1
       version: 2.1.1
@@ -158,7 +158,7 @@ importers:
     devDependencies:
       '@biomejs/biome':
         specifier: 'catalog:'
-        version: 2.4.16
+        version: 2.5.11
       '@codemem/core':
         specifier: workspace:^
         version: link:packages/core
@@ -556,59 +556,59 @@ packages:
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.4.16':
-    resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
+  '@biomejs/biome@2.5.11':
+    resolution: {integrity: sha512-Tj0dnkLPdW0ASjHfj2D/ZkkvPU2wrFmnE1jWTD2xzV1ycapV1DutbYXk4NDnR3rYTi1ZCbNFD4G2gRMEY65WaA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.16':
-    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
+  '@biomejs/cli-darwin-arm64@2.5.11':
+    resolution: {integrity: sha512-6SGZxoKbXvUjMn1t6A98HqWISPnGNbYs0R/Rt2JarmXBSev+lva4QxUMWEBX9lX1Wo1XTJ78uk5xVDtG58SRZg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.16':
-    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
+  '@biomejs/cli-darwin-x64@2.5.11':
+    resolution: {integrity: sha512-nYkXY7tLBEgnGbYapDKAyKzgt44ZEyG+AKalvTXtCWKYgepI9dw327q+cVgedxm+Udi1ZzHKUyZrIusHi/KQbw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.16':
-    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
+  '@biomejs/cli-linux-arm64-musl@2.5.11':
+    resolution: {integrity: sha512-qhyZUMyCbWYFV2bAwRNVvfMVZ+hv7WYl6mossGrxC+uiQQXhvsuWWU8zz6jYX0mChZd9MgQZbm4vozTmG/5iGw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.16':
-    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
+  '@biomejs/cli-linux-arm64@2.5.11':
+    resolution: {integrity: sha512-3PVLSTD9RR73rvVPt5G3T1gc+ycggWEGfTD7RvzzbtcDPD27NxgxBbAFfpm7DXJKW6VLHWE1lLMGvFt2Qxjcow==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.16':
-    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
+  '@biomejs/cli-linux-x64-musl@2.5.11':
+    resolution: {integrity: sha512-oRRlrchG5EfrEL/EmtT1qUjSNHk3/5LGeZhQqADBBAJF1b1ET6964xEKe7aGlGARzDfza8H/seEsFJl7S6Ql9w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.16':
-    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
+  '@biomejs/cli-linux-x64@2.5.11':
+    resolution: {integrity: sha512-JOytptlsgM33B2MMFUg8iBrb4IKpbD5JnJrSeYiaFEeAj4vuXx0iQSQZ4qK7sqyMtfjZxxPdNdMZZVL4y/mFyA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.16':
-    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
+  '@biomejs/cli-win32-arm64@2.5.11':
+    resolution: {integrity: sha512-e49E6K9hzH/ohJNx8Y26mY8HaV4I4ZViIeoqhKsmoXLKHhQnMeBAVqCgsGf2Wa3lXlS7RkporDXMHHWkzvZzFw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.16':
-    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
+  '@biomejs/cli-win32-x64@2.5.11':
+    resolution: {integrity: sha512-QSQr/KjOgXA7OzXJUWS+oguKyAZ3Q0l/lnlDGbu397eKo83atuWUjBPJrsqbKNF6CARGw8XXJLGzpHC8Ryhd4Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -4010,39 +4010,39 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@biomejs/biome@2.4.16':
+  '@biomejs/biome@2.5.11':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.16
-      '@biomejs/cli-darwin-x64': 2.4.16
-      '@biomejs/cli-linux-arm64': 2.4.16
-      '@biomejs/cli-linux-arm64-musl': 2.4.16
-      '@biomejs/cli-linux-x64': 2.4.16
-      '@biomejs/cli-linux-x64-musl': 2.4.16
-      '@biomejs/cli-win32-arm64': 2.4.16
-      '@biomejs/cli-win32-x64': 2.4.16
+      '@biomejs/cli-darwin-arm64': 2.5.11
+      '@biomejs/cli-darwin-x64': 2.5.11
+      '@biomejs/cli-linux-arm64': 2.5.11
+      '@biomejs/cli-linux-arm64-musl': 2.5.11
+      '@biomejs/cli-linux-x64': 2.5.11
+      '@biomejs/cli-linux-x64-musl': 2.5.11
+      '@biomejs/cli-win32-arm64': 2.5.11
+      '@biomejs/cli-win32-x64': 2.5.11
 
-  '@biomejs/cli-darwin-arm64@2.4.16':
+  '@biomejs/cli-darwin-arm64@2.5.11':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.16':
+  '@biomejs/cli-darwin-x64@2.5.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.16':
+  '@biomejs/cli-linux-arm64-musl@2.5.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.16':
+  '@biomejs/cli-linux-arm64@2.5.11':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.16':
+  '@biomejs/cli-linux-x64-musl@2.5.11':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.16':
+  '@biomejs/cli-linux-x64@2.5.11':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.16':
+  '@biomejs/cli-win32-arm64@2.5.11':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.16':
+  '@biomejs/cli-win32-x64@2.5.11':
     optional: true
 
   '@clack/core@1.4.3':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ overrides:
   undici: '>=7.28.0 <8'
 
 catalog:
-  "@biomejs/biome": ^2.4.16
+  "@biomejs/biome": ^2.5.11
   "@hono/node-server": ^2.1.1
   "@types/better-sqlite3": ^7.6.13
   drizzle-orm: ^0.45.2


### PR DESCRIPTION
## Description

Upgrade Biome from 2.4.16 to 2.5.11 and migrate the recommended-rule configuration to the new preset syntax. Apply the required 2.5 formatter output and replace unsafe optional-chain assertions with failure-preserving matchers.

Closes codemem-jnd6.3.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional checks: full `pnpm run check` (5,740 tests), focused UI assertion test, and Snyk high-severity SCA scan.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed)
- [x] No new warnings introduced
