### PR TITLE
chore(deps): upgrade Commander to 15

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
 		"@codemem/mcp": "workspace:^",
 		"@codemem/server": "workspace:^",
 		"@hono/node-server": "catalog:",
-		"commander": "^14.0.3",
+		"commander": "^15.0.0",
 		"drizzle-orm": "catalog:",
 		"omelette": "^0.4.17"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,8 +207,8 @@ importers:
         specifier: 'catalog:'
         version: 2.1.1(hono@4.13.5)
       commander:
-        specifier: ^14.0.3
-        version: 14.0.3
+        specifier: ^15.0.0
+        version: 15.0.0
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
@@ -2381,6 +2381,10 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -5386,6 +5390,8 @@ snapshots:
   colorette@2.0.20: {}
 
   commander@14.0.3: {}
+
+  commander@15.0.0: {}
 
   content-disposition@1.1.0: {}
 


### PR DESCRIPTION
## Description

Upgrade the CLI runtime from Commander 14 to 15. The CLI already uses ESM and requires Node 24, so no command implementation changes were needed.

Tracks `codemem-jnd6.7.2`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation: CLI typecheck, 515 CLI tests, CLI production build, packed-artifact smoke, CLI help output, full `pnpm run check` (5,740 tests), and a high-severity Snyk scan with zero findings.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed; no user-facing behavior changed)
- [x] No new warnings introduced