### PR TITLE
chore(deps): upgrade better-sqlite3 to 13

### DIFF
--- a/docs/plans/2026-03-15-install-matrix.md
+++ b/docs/plans/2026-03-15-install-matrix.md
@@ -10,23 +10,21 @@ what each package requires per platform, what users need installed, and what bre
 
 | Platform | better-sqlite3 | sqlite-vec | onnxruntime-node |
 |---|---|---|---|
-| macOS arm64 | ⚠️ Compile from source¹ | ✅ Prebuild (.dylib) | ✅ Prebuild |
+| macOS arm64 | ✅ Bundled prebuild | ✅ Prebuild (.dylib) | ✅ Prebuild |
 | macOS x64 | ✅ Prebuild available | ✅ Prebuild (.dylib) | ✅ Prebuild |
 | Linux x64 | ✅ Prebuild available | ✅ Prebuild (.so) | ✅ Prebuild |
-| Linux arm64 | ⚠️ Compile from source¹ | ✅ Prebuild (.so) | ✅ Prebuild |
+| Linux arm64 | ✅ Bundled prebuild | ✅ Prebuild (.so) | ✅ Prebuild |
 | Windows x64 | ✅ Prebuild available | ✅ Prebuild (.dll) | ✅ Prebuild |
 
-¹ No prebuild for Node 24 + arm64 confirmed in spike. better-sqlite3 publishes
-prebuilds via `prebuild-install` (143 release assets for v12.8.0 covering many
-Node × platform combos), but coverage for newer Node versions on arm64 lags.
-Prebuilds for Node 20/22 on arm64 are typically available. **This is the primary
-install friction point.**
+better-sqlite3 13 bundles Node-API binaries for x64 and arm64 on macOS, Windows,
+glibc Linux, and musl Linux. Node 24 therefore uses a bundled binary on every
+platform in the supported matrix.
 
 ### How each package ships native code
 
 | Package | Native strategy | Build system | Fallback |
 |---|---|---|---|
-| better-sqlite3 | `prebuild-install`, falls back to `node-gyp rebuild` | node-gyp (C++ addon, compiles SQLite amalgamation) | Source compilation |
+| better-sqlite3 | Bundled platform binaries | node-gyp validates the bundled binary during install | Source compilation on unsupported targets |
 | sqlite-vec | `optionalDependencies` per-platform packages | None — prebuilt binaries only | Fatal error if platform unsupported |
 | onnxruntime-node | Single package, postinstall downloads platform binary | N-API addon, prebuilt | Fatal error if platform unsupported |
 
@@ -46,7 +44,7 @@ matching one. No compilation step.
 
 ## SQLite Version Compatibility
 
-**better-sqlite3 bundles its own SQLite** (currently v3.51.3) compiled from the
+**better-sqlite3 bundles its own SQLite** (currently v3.53.3) compiled from the
 amalgamation source. It does NOT use a system SQLite.
 
 **sqlite-vec does not conflict.** The sqlite-vec .dylib/.so is loaded via
@@ -58,32 +56,34 @@ collision.
 The only requirement is that the host SQLite version supports the extension's
 required APIs. sqlite-vec uses virtual tables and standard extension entry
 points, which have been stable since SQLite 3.9.0 (2015). better-sqlite3's
-bundled 3.51.3 is well above this.
+bundled 3.53.3 is well above this.
 
 ## Install Size Budget
 
 | Package | Unpacked size | Notes |
 |---|---|---|
-| better-sqlite3 | ~10 MB | Includes SQLite amalgamation source + prebuilt .node |
+| better-sqlite3 | ~27 MB | Includes SQLite amalgamation source + eight platform prebuilds |
 | sqlite-vec (per-platform) | ~160 KB | Only the matching platform package is installed |
 | onnxruntime-node | **~220 MB** | Ships all platform binaries in one package |
-| **Total (with onnxruntime)** | **~230 MB** | Dominated by onnxruntime |
-| **Total (without onnxruntime)** | **~10 MB** | Core functionality only |
+| **Total (with onnxruntime)** | **~247 MB** | Dominated by onnxruntime |
+| **Total (without onnxruntime)** | **~27 MB** | Core functionality only |
 
-onnxruntime-node is 95% of the install weight. This is the strongest argument
+onnxruntime-node still dominates the install weight. This is the strongest argument
 for making it optional (see §Optional Dependencies below).
 
 ## Build Tool Requirements
 
-### When prebuilds are available (most users)
+### Supported platforms
 
-No build tools required. `npm install` downloads prebuilt binaries for all three
-packages.
+better-sqlite3 13 ships its supported binaries inside the npm package. Its
+install step still invokes node-gyp to select the bundled binary, so Python and
+the platform build runner must be available even though no C++ compilation is
+expected on supported targets.
 
 ### When better-sqlite3 must compile from source
 
-This applies to: Node 24 on arm64 (macOS and Linux), and any future
-Node version before prebuilds are published.
+This applies to unsupported operating systems or CPU architectures, or when a
+bundled binary cannot load.
 
 | Platform | Required tools |
 |---|---|
@@ -91,19 +91,10 @@ Node version before prebuilds are published.
 | Linux arm64 | `build-essential` (gcc/g++, make), `python3` |
 | Linux x64 | `build-essential`, `python3` (only if prebuild missing) |
 
-node-gyp requires: Python 3, a C++ compiler supporting C++20, and make.
+Source compilation requires Python 3, a C++ compiler supporting C++20, and make.
 These are standard on developer machines but **not** on minimal CI images or
-Docker containers. The install script (`prebuild-install || node-gyp rebuild`)
-handles the fallback automatically.
-
-### Mitigation: ship our own prebuilds
-
-If Node 24 arm64 becomes a common target before upstream publishes prebuilds:
-1. Fork/rebuild with `prebuild` targeting Node 24 arm64
-2. Host prebuilds on GitHub Releases
-3. Configure `prebuild-install --download` to check our mirror first
-
-This is a contingency, not a first step.
+Docker containers. better-sqlite3's node-gyp configuration selects a bundled
+binary when the current platform and architecture are supported.
 
 ## CI Matrix
 
@@ -112,7 +103,7 @@ This is a contingency, not a first step.
 | Runner | Node | Arch | Purpose |
 |---|---|---|---|
 | `macos-14` (M1) | 22 | arm64 | Primary dev platform, prebuild test |
-| `macos-14` (M1) | 24 | arm64 | Source compilation test |
+| `macos-14` (M1) | 24 | arm64 | Bundled prebuild test |
 | `ubuntu-24.04` | 22 | x64 | Standard Linux, prebuild test |
 | `ubuntu-24.04` | 24 | x64 | Latest Node on Linux |
 | `ubuntu-24.04-arm` | 22 | arm64 | Linux arm64 prebuild test |
@@ -123,7 +114,7 @@ This is a contingency, not a first step.
 |---|---|---|---|
 | `macos-13` | 22 | x64 | Intel Mac support |
 | `windows-latest` | 22 | x64 | Windows baseline (if we support it) |
-| `ubuntu-24.04-arm` | 24 | arm64 | Linux arm64 source compilation |
+| `ubuntu-24.04-arm` | 24 | arm64 | Linux arm64 bundled prebuild test |
 
 ### What each CI job validates
 
@@ -141,13 +132,13 @@ This is a contingency, not a first step.
 installs optional dependencies unless the user explicitly passes
 `--omit=optional`. Instead, split into two packages:
 
-- **`codemem`** — core package, no onnxruntime (~10 MB). FTS search works, semantic search is unavailable.
+- **`codemem`** — core package, no onnxruntime (~27 MB). FTS search works, semantic search is unavailable.
 - **`codemem-embeddings`** (or `@codemem/embeddings`) — adds `onnxruntime-node` + `@huggingface/transformers` (~220 MB). Enables semantic search.
 
 Users install what they need:
 ```bash
-npm install codemem                    # Core only (~10 MB)
-npm install codemem codemem-embeddings # Full with semantic search (~230 MB)
+npm install codemem                    # Core only (~27 MB)
+npm install codemem codemem-embeddings # Full with semantic search (~247 MB)
 ```
 
 The core package detects `codemem-embeddings` at runtime via dynamic import:
@@ -191,10 +182,10 @@ Embeddings require onnxruntime-node. Install it with:
 #### Install instructions in README
 
 ```bash
-# Core install (~10 MB)
+# Core install (~27 MB)
 npm install codemem
 
-# With embedding support (~230 MB)
+# With embedding support (~247 MB)
 npm install codemem onnxruntime-node
 ```
 
@@ -233,5 +224,5 @@ covers the vast majority of Node.js deployments.
 **Risk:** onnxruntime-node is 220 MB. Embedding models (e.g., all-MiniLM-L6-v2
 ONNX) add another 20-80 MB. Total install weight for a user wanting embeddings
 could hit 300+ MB.
-**Mitigation:** Optional dependency strategy keeps the default install at ~10 MB.
+**Mitigation:** Optional dependency strategy keeps the default install at ~27 MB.
 Model files should be downloaded on first use, not at install time.

--- a/packages/cloudflare-coordinator-worker/package.json
+++ b/packages/cloudflare-coordinator-worker/package.json
@@ -18,7 +18,7 @@
 		"@cloudflare/vitest-pool-workers": "^0.22.0",
 		"@cloudflare/workers-types": "^5.20260901.1",
 		"@types/better-sqlite3": "catalog:",
-		"better-sqlite3": "12.8.0",
+		"better-sqlite3": "13.0.0",
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@xenova/transformers": "^2.17.2",
-		"better-sqlite3": "12.8.0",
+		"better-sqlite3": "13.0.0",
 		"bonjour-service": "^1.4.4",
 		"drizzle-orm": "catalog:",
 		"hono": "catalog:",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -29,7 +29,7 @@
 	"devDependencies": {
 		"@types/better-sqlite3": "catalog:",
 		"@types/node": "^24.12.4",
-		"better-sqlite3": "12.8.0",
+		"better-sqlite3": "13.0.0",
 		"sqlite-vec": "0.1.9",
 		"typescript": "catalog:",
 		"vite": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ catalogs:
       specifier: ^2.1.1
       version: 2.1.1
     '@types/better-sqlite3':
-      specifier: ^7.6.13
-      version: 7.6.13
+      specifier: ^9.6.0
+      version: 9.6.0
     drizzle-orm:
       specifier: ^0.45.2
       version: 0.45.2
@@ -139,7 +139,7 @@ catalogs:
       version: 4.1.11
 
 overrides:
-  better-sqlite3: 12.8.0
+  better-sqlite3: 13.0.0
   fast-uri: 3.1.5
   '@modelcontextprotocol/sdk>@hono/node-server': 1.19.17
   '@modelcontextprotocol/sdk>hono': 4.13.5
@@ -209,7 +209,7 @@ importers:
         version: 15.0.0
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.0)
       omelette:
         specifier: ^0.4.17
         version: 0.4.17
@@ -247,10 +247,10 @@ importers:
         version: 5.20260901.1
       '@types/better-sqlite3':
         specifier: 'catalog:'
-        version: 7.6.13
+        version: 9.6.0
       better-sqlite3:
-        specifier: 12.8.0
-        version: 12.8.0
+        specifier: 13.0.0
+        version: 13.0.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -270,14 +270,14 @@ importers:
         specifier: ^2.17.2
         version: 2.17.2
       better-sqlite3:
-        specifier: 12.8.0
-        version: 12.8.0
+        specifier: 13.0.0
+        version: 13.0.0
       bonjour-service:
         specifier: ^1.4.4
         version: 1.4.4
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@13.0.0)
       hono:
         specifier: 'catalog:'
         version: 4.13.5
@@ -290,7 +290,7 @@ importers:
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
-        version: 7.6.13
+        version: 9.6.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -415,7 +415,7 @@ importers:
         version: 2.1.1(hono@4.13.5)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@13.0.0)
       hono:
         specifier: 'catalog:'
         version: 4.13.5
@@ -425,13 +425,13 @@ importers:
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
-        version: 7.6.13
+        version: 9.6.0
       '@types/node':
         specifier: ^24.12.4
         version: 24.13.3
       better-sqlite3:
-        specifier: 12.8.0
-        version: 12.8.0
+        specifier: 13.0.0
+        version: 13.0.0
       sqlite-vec:
         specifier: 0.1.9
         version: 0.1.9
@@ -2127,6 +2127,9 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
+  '@types/better-sqlite3@9.6.0':
+    resolution: {integrity: sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -2308,15 +2311,12 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  better-sqlite3@12.8.0:
-    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  better-sqlite3@13.0.0:
+    resolution: {integrity: sha512-EV1zoFJkJyZ6XziOyrL+yjs6WsvFbkG1U9SZ6489WBZ+I73YewvZUwHa7//qDueS8aY1LDp7i2j1SeZH3r0boA==}
+    engines: {node: '>=22'}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -2536,7 +2536,7 @@ packages:
       '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
-      better-sqlite3: 12.8.0
+      better-sqlite3: 13.0.0
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
       gel: '>=2'
@@ -2755,9 +2755,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -3143,6 +3140,10 @@ packages:
 
   node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
+
+  node-addon-api@8.9.2:
+    resolution: {integrity: sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
@@ -5174,6 +5175,11 @@ snapshots:
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 24.13.3
+    optional: true
+
+  '@types/better-sqlite3@9.6.0':
+    dependencies:
+      '@types/node': 24.13.3
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -5362,18 +5368,13 @@ snapshots:
 
   baseline-browser-mapping@2.11.14: {}
 
-  better-sqlite3@12.8.0:
+  better-sqlite3@13.0.0:
     dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
+      node-addon-api: 8.9.2
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
 
   bl@4.1.0:
     dependencies:
@@ -5584,11 +5585,17 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.13
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.0):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260529.1
       '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 12.8.0
+      better-sqlite3: 13.0.0
+
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@13.0.0):
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260529.1
+      '@types/better-sqlite3': 9.6.0
+      better-sqlite3: 13.0.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -5816,8 +5823,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
       picomatch: 4.0.7
-
-  file-uri-to-path@1.0.0: {}
 
   finalhandler@2.1.1(supports-color@10.2.2):
     dependencies:
@@ -6199,6 +6204,8 @@ snapshots:
       semver: 7.8.5
 
   node-addon-api@6.1.0: {}
+
+  node-addon-api@8.9.2: {}
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ allowBuilds:
   workerd: true
 
 overrides:
-  better-sqlite3: 12.8.0
+  better-sqlite3: 13.0.0
   fast-uri: 3.1.5
   '@modelcontextprotocol/sdk>@hono/node-server': 1.19.17
   '@modelcontextprotocol/sdk>hono': 4.13.5
@@ -26,7 +26,7 @@ overrides:
 catalog:
   "@biomejs/biome": ^2.5.11
   "@hono/node-server": ^2.1.1
-  "@types/better-sqlite3": ^7.6.13
+  "@types/better-sqlite3": ^9.6.0
   drizzle-orm: ^0.45.2
   hono: ^4.13.5
   limiter: ^3.0.0


### PR DESCRIPTION
## Description

Upgrade better-sqlite3 from 12.8.0 to 13.0.0 and align `@types/better-sqlite3` at 9.6.0 across the workspace. Update the native-install decision document for v13 bundled prebuilds, SQLite 3.53.3, and the larger package footprint.

Tracks `codemem-jnd6.7.3`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation: Node 24.20.0 arm64 install and bundled-prebuild detection; in-memory database query using SQLite 3.53.3; 3,525 core tests; 473 viewer-server tests; Worker node and integration tests; package builds; Worker bundle dry-run; full `pnpm run check` (5,740 tests); and high-severity Snyk scan with zero findings. Code review returned GO.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced