### PR TITLE
perf(sync): remove duplicate peer lookup and the scope-listing N+1

### DIFF
--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -2117,6 +2117,24 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 			.map((row) => rowToRecord<CoordinatorScopeMembership>(row));
 	}
 
+	async listDeviceScopeMemberships(
+		deviceId: string,
+		includeRevoked = false,
+	): Promise<CoordinatorScopeMembership[]> {
+		const normalizedDeviceId = clean(deviceId);
+		if (!normalizedDeviceId) throw new Error("deviceId is required.");
+		// Served by idx_coordinator_scope_memberships_device_status.
+		const statusWhere = includeRevoked ? "" : "AND status = 'active'";
+		return this.db
+			.prepare(`SELECT scope_id, device_id, role, status, membership_epoch, coordinator_id, group_id,
+					manifest_issuer_device_id, manifest_hash, signed_manifest_json, updated_at
+				 FROM coordinator_scope_memberships
+				 WHERE device_id = ? ${statusWhere}
+				 ORDER BY scope_id ASC`)
+			.all(normalizedDeviceId)
+			.map((row) => rowToRecord<CoordinatorScopeMembership>(row));
+	}
+
 	async listScopeMembershipAuditEvents(
 		opts: CoordinatorListScopeMembershipAuditInput,
 	): Promise<CoordinatorScopeMembershipAuditEvent[]> {

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -151,6 +151,9 @@ function createMockStore(
 		listScopeMemberships: vi.fn(
 			async (_: string, __?: boolean): Promise<CoordinatorScopeMembership[]> => [],
 		),
+		listDeviceScopeMemberships: vi.fn(
+			async (_: string, __?: boolean): Promise<CoordinatorScopeMembership[]> => [],
+		),
 		listScopeMembershipAuditEvents: vi.fn(
 			async (
 				_: CoordinatorListScopeMembershipAuditInput,
@@ -2802,6 +2805,11 @@ describe("createCoordinatorApp dependency injection", () => {
 			})),
 			listScopes: vi.fn(async () => scopes),
 			listScopeMemberships: vi.fn(async (scopeId: string) => memberships[scopeId] ?? []),
+			listDeviceScopeMemberships: vi.fn(async (deviceId: string) =>
+				Object.values(memberships)
+					.flat()
+					.filter((membership) => membership.device_id === deviceId),
+			),
 		});
 		const app = createCoordinatorApp({
 			storeFactory: () => store,

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -435,18 +435,6 @@ export function createCoordinatorApp(
 		return membership.status === "active" && membership.membership_epoch >= scope.membership_epoch;
 	}
 
-	async function requesterAuthorizedForScope(
-		store: CoordinatorStore,
-		scope: CoordinatorScope,
-		deviceId: string,
-	): Promise<boolean> {
-		const memberships = await store.listScopeMemberships(scope.scope_id, false);
-		return memberships.some(
-			(membership) =>
-				membership.device_id === deviceId && activeCurrentMembership(membership, scope),
-		);
-	}
-
 	// -----------------------------------------------------------------------
 	// POST /v1/presence — upsert device presence (authenticated)
 	// -----------------------------------------------------------------------
@@ -575,13 +563,21 @@ export function createCoordinatorApp(
 			if (response) return response;
 			if (!auth.enrollment) return c.json({ error: "unknown_device" }, 401);
 			const scopes = await store.listScopes({ groupId, includeInactive: false });
-			const items: CoordinatorScope[] = [];
-			for (const scope of scopes) {
-				if (scope.status !== "active") continue;
-				if (await requesterAuthorizedForScope(store, scope, String(auth.enrollment.device_id))) {
-					items.push(scope);
-				}
-			}
+			// One indexed lookup of the requester's own memberships, rather than
+			// reading every member of every scope to answer a question about one
+			// device. (scope_id, device_id) is unique, so the map is 1:1.
+			const memberships = await store.listDeviceScopeMemberships(
+				String(auth.enrollment.device_id),
+				false,
+			);
+			const membershipByScope = new Map(
+				memberships.map((membership) => [membership.scope_id, membership]),
+			);
+			const items: CoordinatorScope[] = scopes.filter((scope) => {
+				if (scope.status !== "active") return false;
+				const membership = membershipByScope.get(scope.scope_id);
+				return Boolean(membership && activeCurrentMembership(membership, scope));
+			});
 			return c.json({ items });
 		} finally {
 			await store.close();

--- a/packages/core/src/coordinator-runtime.test.ts
+++ b/packages/core/src/coordinator-runtime.test.ts
@@ -1253,6 +1253,35 @@ describe("coordinatorStatusSnapshot", () => {
 });
 
 describe("fetchCoordinatorStalePeers", () => {
+	it("derives the stale set from a supplied peer snapshot without a second lookup", async () => {
+		const db = new Database(":memory:");
+		const prevFetch = globalThis.fetch;
+		try {
+			initTestSchema(db);
+			// Any coordinator call would go through fetch; this asserts none happens.
+			globalThis.fetch = (async () => {
+				throw new Error("fetchCoordinatorStalePeers must not re-fetch a supplied snapshot");
+			}) as typeof fetch;
+
+			const stalePeers = await fetchCoordinatorStalePeers(db, ":memory:", undefined, {
+				peers: [
+					{ device_id: "peer-1", fingerprint: "old-fp", stale: true },
+					{ device_id: "peer-1", fingerprint: "new-fp", stale: false },
+					{ device_id: "peer-2", fingerprint: "fp-2", stale: true },
+				],
+			});
+
+			// Same semantics as the fetching path: device-wide staleness only when
+			// every entry is stale, plus the pinned key for a superseded fingerprint.
+			expect(stalePeers.has("peer-1")).toBe(false);
+			expect(stalePeers.has("peer-1:old-fp")).toBe(true);
+			expect(stalePeers.has("peer-2")).toBe(true);
+		} finally {
+			globalThis.fetch = prevFetch;
+			db.close();
+		}
+	});
+
 	it("returns a stale pinned peer key when the same device has a fresh replacement fingerprint", async () => {
 		const db = new Database(":memory:");
 		const keysDir = mkdtempSync(join(tmpdir(), "codemem-coordinator-runtime-keys-"));

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -782,45 +782,64 @@ export async function fetchCoordinatorStalePeers(
 	db: Database,
 	dbPath: string,
 	keysDir?: string,
+	options?: { peers?: Record<string, unknown>[] },
 ): Promise<Set<string>> {
+	// A caller that already looked peers up this tick passes that snapshot in.
+	// Its addresses have been stored by refreshAuthorizedCoordinatorPeerTrust
+	// already, so reusing it skips a second identical /v1/peers round trip and
+	// a duplicate refreshStoredCoordinatorPeerAddresses write. The snapshot is
+	// seconds old, which is well inside the tolerance of a best-effort offline
+	// preflight.
+	if (options?.peers) return coordinatorStalePeerKeys(options.peers);
 	const config = readCoordinatorSyncConfig();
 	if (!coordinatorEnabled(config)) return new Set();
 	try {
 		const peers = await lookupCoordinatorPeers({ db, dbPath }, config, { keysDir });
 		refreshStoredCoordinatorPeerAddresses(db, peers);
-		// A device may appear under multiple fingerprints (key rotation, multi-group).
-		// Skip device-wide only when all entries are stale, but also return pinned
-		// peer keys so an old trusted fingerprint stays fail-closed even when the
-		// same device id has a fresh replacement fingerprint.
-		const freshDevices = new Set<string>();
-		const staleDevices = new Set<string>();
-		const freshPinnedPeers = new Set<string>();
-		const stalePinnedPeers = new Set<string>();
-		for (const peer of peers) {
-			const deviceId = clean(peer.device_id);
-			if (!deviceId) continue;
-			const fingerprint = clean(peer.fingerprint);
-			const pinnedPeerKey = fingerprint ? `${deviceId}:${fingerprint}` : "";
-			if (peer.stale) {
-				staleDevices.add(deviceId);
-				if (pinnedPeerKey) stalePinnedPeers.add(pinnedPeerKey);
-			} else {
-				freshDevices.add(deviceId);
-				if (pinnedPeerKey) freshPinnedPeers.add(pinnedPeerKey);
-			}
-		}
-		// Remove any device that has at least one fresh entry
-		for (const deviceId of freshDevices) {
-			staleDevices.delete(deviceId);
-		}
-		for (const pinnedPeerKey of freshPinnedPeers) {
-			stalePinnedPeers.delete(pinnedPeerKey);
-		}
-		return new Set([...staleDevices, ...stalePinnedPeers]);
+		return coordinatorStalePeerKeys(peers);
 	} catch {
 		// Best-effort: if coordinator lookup fails, skip the optimization.
 		return new Set();
 	}
+}
+
+/**
+ * Reduce a coordinator peer listing to the device IDs and pinned peer keys
+ * whose presence has expired.
+ *
+ * Split out of fetchCoordinatorStalePeers so a caller holding a peer snapshot
+ * can derive the same set without repeating the lookup.
+ */
+export function coordinatorStalePeerKeys(peers: Record<string, unknown>[]): Set<string> {
+	// A device may appear under multiple fingerprints (key rotation, multi-group).
+	// Skip device-wide only when all entries are stale, but also return pinned
+	// peer keys so an old trusted fingerprint stays fail-closed even when the
+	// same device id has a fresh replacement fingerprint.
+	const freshDevices = new Set<string>();
+	const staleDevices = new Set<string>();
+	const freshPinnedPeers = new Set<string>();
+	const stalePinnedPeers = new Set<string>();
+	for (const peer of peers) {
+		const deviceId = clean(peer.device_id);
+		if (!deviceId) continue;
+		const fingerprint = clean(peer.fingerprint);
+		const pinnedPeerKey = fingerprint ? `${deviceId}:${fingerprint}` : "";
+		if (peer.stale) {
+			staleDevices.add(deviceId);
+			if (pinnedPeerKey) stalePinnedPeers.add(pinnedPeerKey);
+		} else {
+			freshDevices.add(deviceId);
+			if (pinnedPeerKey) freshPinnedPeers.add(pinnedPeerKey);
+		}
+	}
+	// Remove any device that has at least one fresh entry
+	for (const deviceId of freshDevices) {
+		staleDevices.delete(deviceId);
+	}
+	for (const pinnedPeerKey of freshPinnedPeers) {
+		stalePinnedPeers.delete(pinnedPeerKey);
+	}
+	return new Set([...staleDevices, ...stalePinnedPeers]);
 }
 
 export async function listCoordinatorReciprocalApprovals(

--- a/packages/core/src/coordinator-store-contract.ts
+++ b/packages/core/src/coordinator-store-contract.ts
@@ -514,6 +514,16 @@ export interface CoordinatorStore {
 		scopeId: string,
 		includeRevoked?: boolean,
 	): Promise<CoordinatorScopeMembership[]>;
+	/**
+	 * List one device's memberships across every scope, ordered by scope_id.
+	 *
+	 * Answers "which scopes is this device in" with a single indexed lookup,
+	 * rather than reading every member of every scope one scope at a time.
+	 */
+	listDeviceScopeMemberships(
+		deviceId: string,
+		includeRevoked?: boolean,
+	): Promise<CoordinatorScopeMembership[]>;
 	listScopeMembershipAuditEvents(
 		opts: CoordinatorListScopeMembershipAuditInput,
 	): Promise<CoordinatorScopeMembershipAuditEvent[]>;

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -229,6 +229,70 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 				});
 			});
 
+			it("lists one device's memberships across scopes without reading other members", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("group-a");
+					for (const deviceId of ["device-a", "device-b"]) {
+						await store.enrollDevice("group-a", {
+							deviceId,
+							fingerprint: `fp-${deviceId}`,
+							publicKey: `pk-${deviceId}`,
+						});
+					}
+					for (const scopeId of ["scope-acme", "scope-beta", "scope-gamma"]) {
+						await store.createScope({
+							scopeId,
+							label: scopeId,
+							coordinatorId: "coord-a",
+							groupId: "group-a",
+						});
+					}
+					// device-a is in acme and gamma; device-b only in beta.
+					await store.grantScopeMembership({
+						effectId: nextEffect("grant"),
+						scopeId: "scope-acme",
+						deviceId: "device-a",
+					});
+					await store.grantScopeMembership({
+						effectId: nextEffect("grant"),
+						scopeId: "scope-gamma",
+						deviceId: "device-a",
+					});
+					await store.grantScopeMembership({
+						effectId: nextEffect("grant"),
+						scopeId: "scope-beta",
+						deviceId: "device-b",
+					});
+
+					expect(await store.listDeviceScopeMemberships("device-a")).toEqual([
+						expect.objectContaining({ scope_id: "scope-acme", device_id: "device-a" }),
+						expect.objectContaining({ scope_id: "scope-gamma", device_id: "device-a" }),
+					]);
+					expect(await store.listDeviceScopeMemberships("device-b")).toEqual([
+						expect.objectContaining({ scope_id: "scope-beta", device_id: "device-b" }),
+					]);
+					expect(await store.listDeviceScopeMemberships("device-unknown")).toEqual([]);
+
+					// Revoked memberships drop out by default and return with includeRevoked.
+					await store.revokeScopeMembership({
+						effectId: nextEffect("revoke"),
+						scopeId: "scope-acme",
+						deviceId: "device-a",
+					});
+					expect(await store.listDeviceScopeMemberships("device-a")).toEqual([
+						expect.objectContaining({ scope_id: "scope-gamma", status: "active" }),
+					]);
+					expect(await store.listDeviceScopeMemberships("device-a", true)).toEqual([
+						expect.objectContaining({ scope_id: "scope-acme", status: "revoked" }),
+						expect.objectContaining({ scope_id: "scope-gamma", status: "active" }),
+					]);
+
+					await expect(store.listDeviceScopeMemberships("  ")).rejects.toThrow(
+						"deviceId is required.",
+					);
+				});
+			});
+
 			it("rejects scope grants with mismatched authority fields", async () => {
 				await withContext(async ({ store }) => {
 					await store.createScope({

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -2192,6 +2192,27 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		).map((row) => rowToRecord<CoordinatorScopeMembership>(row));
 	}
 
+	async listDeviceScopeMemberships(
+		deviceId: string,
+		includeRevoked = false,
+	): Promise<CoordinatorScopeMembership[]> {
+		const normalizedDeviceId = clean(deviceId);
+		if (!normalizedDeviceId) throw new Error("deviceId is required.");
+		// Served by idx_coordinator_scope_memberships_device_status.
+		const statusWhere = includeRevoked ? "" : "AND status = 'active'";
+		return (
+			await allRows<CoordinatorScopeMembership>(
+				this.db
+					.prepare(`SELECT scope_id, device_id, role, status, membership_epoch, coordinator_id, group_id,
+							manifest_issuer_device_id, manifest_hash, signed_manifest_json, updated_at
+						 FROM coordinator_scope_memberships
+						 WHERE device_id = ? ${statusWhere}
+						 ORDER BY scope_id ASC`)
+					.bind(normalizedDeviceId),
+			)
+		).map((row) => rowToRecord<CoordinatorScopeMembership>(row));
+	}
+
 	async listScopeMembershipAuditEvents(
 		opts: CoordinatorListScopeMembershipAuditInput,
 	): Promise<CoordinatorScopeMembershipAuditEvent[]> {

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -7,6 +7,7 @@ import { columnExists, connect } from "./db.js";
 import {
 	createSerializedDaemonTickRunner,
 	getSyncDaemonPhase,
+	refreshCoordinatorForDaemon,
 	refreshCoordinatorPresenceForDaemon,
 	resolveSyncDaemonKeysDir,
 	runSyncDaemon,
@@ -343,6 +344,34 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 		expect(await refreshCoordinatorPresenceForDaemon(db, ":memory:")).toBe(false);
 		expect(registerCoordinatorPresence).not.toHaveBeenCalled();
 		expect(refreshConfiguredScopeMembershipCache).not.toHaveBeenCalled();
+	});
+
+	it("returns the peer snapshot so the tick does not look peers up twice", async () => {
+		const { coordinatorEnabled, readCoordinatorSyncConfig, refreshAuthorizedCoordinatorPeerTrust } =
+			await import("./coordinator-runtime.js");
+		const peers = [{ device_id: "peer-1", fingerprint: "fp-1", stale: false }];
+		vi.mocked(coordinatorEnabled).mockReturnValue(true);
+		vi.mocked(readCoordinatorSyncConfig).mockReturnValue({
+			syncCoordinatorUrl: "http://coord",
+			syncCoordinatorGroups: ["team"],
+		} as never);
+		vi.mocked(refreshAuthorizedCoordinatorPeerTrust).mockResolvedValue({ peers, trusted: 1 });
+
+		expect(await refreshCoordinatorForDaemon(db, ":memory:", "/tmp/keys")).toEqual({
+			refreshed: true,
+			peers,
+		});
+		expect(refreshAuthorizedCoordinatorPeerTrust).toHaveBeenCalledTimes(1);
+	});
+
+	it("reports no peer snapshot when the coordinator is not configured", async () => {
+		const { coordinatorEnabled } = await import("./coordinator-runtime.js");
+		vi.mocked(coordinatorEnabled).mockReturnValue(false);
+
+		expect(await refreshCoordinatorForDaemon(db, ":memory:")).toEqual({
+			refreshed: false,
+			peers: null,
+		});
 	});
 
 	it("posts coordinator presence and refreshes scope membership cache when enabled", async () => {

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -160,17 +160,42 @@ export function setSyncDaemonPhase(db: Database, phase: SyncDaemonPhase): void {
 		.run();
 }
 
+export interface CoordinatorDaemonRefresh {
+	/** True when the coordinator is configured and the refresh ran. */
+	refreshed: boolean;
+	/**
+	 * The peer snapshot this refresh already fetched, or null when the
+	 * coordinator is not configured. Pass it to fetchCoordinatorStalePeers so
+	 * one tick performs one /v1/peers lookup instead of two.
+	 */
+	peers: Record<string, unknown>[] | null;
+}
+
+export async function refreshCoordinatorForDaemon(
+	db: Database,
+	dbPath: string,
+	keysDir?: string,
+): Promise<CoordinatorDaemonRefresh> {
+	const config = readCoordinatorSyncConfig();
+	if (!coordinatorEnabled(config)) return { refreshed: false, peers: null };
+	await registerCoordinatorPresence({ db, dbPath }, config, { keysDir });
+	await refreshConfiguredScopeMembershipCache(db, config, { keysDir, dbPath });
+	const { peers } = await refreshAuthorizedCoordinatorPeerTrust({ db, dbPath }, config, {
+		keysDir,
+	});
+	return { refreshed: true, peers };
+}
+
+/**
+ * Boolean-only form of refreshCoordinatorForDaemon, kept for callers that do
+ * not need the peer snapshot.
+ */
 export async function refreshCoordinatorPresenceForDaemon(
 	db: Database,
 	dbPath: string,
 	keysDir?: string,
 ): Promise<boolean> {
-	const config = readCoordinatorSyncConfig();
-	if (!coordinatorEnabled(config)) return false;
-	await registerCoordinatorPresence({ db, dbPath }, config, { keysDir });
-	await refreshConfiguredScopeMembershipCache(db, config, { keysDir, dbPath });
-	await refreshAuthorizedCoordinatorPeerTrust({ db, dbPath }, config, { keysDir });
-	return true;
+	return (await refreshCoordinatorForDaemon(db, dbPath, keysDir)).refreshed;
 }
 
 // ---------------------------------------------------------------------------
@@ -361,11 +386,13 @@ export async function runTickOnce(
 	try {
 		ensureAdditiveSchemaCompatibility(db);
 		ensureDeviceIdentity(db, { keysDir: resolvedKeysDir });
+		let coordinatorPeers: Record<string, unknown>[] | null = null;
 		try {
-			await refreshCoordinatorPresenceForDaemon(db, dbPath, resolvedKeysDir);
+			coordinatorPeers = (await refreshCoordinatorForDaemon(db, dbPath, resolvedKeysDir)).peers;
 		} catch {
 			// Coordinator discovery is a supplemental surface. Keep direct peer sync running
-			// even when heartbeat posting fails for this tick.
+			// even when heartbeat posting fails for this tick. Leaving coordinatorPeers null
+			// lets the stale-peer preflight below fall back to its own lookup.
 		}
 		let callbackFailed = false;
 		try {
@@ -378,7 +405,9 @@ export async function runTickOnce(
 		}
 		// Best-effort: skip peers the coordinator reports as offline.
 		// Returns empty set when coordinator is disabled or lookup fails.
-		const stalePeers = await fetchCoordinatorStalePeers(db, dbPath, resolvedKeysDir);
+		const stalePeers = await fetchCoordinatorStalePeers(db, dbPath, resolvedKeysDir, {
+			peers: coordinatorPeers ?? undefined,
+		});
 		const results = await syncDaemonTick(db, resolvedKeysDir, stalePeers, scanner, dbPath);
 		const needsAttention = results.some((r) => !r.ok && r.error?.includes("needs_attention"));
 		if (needsAttention) {


### PR DESCRIPTION
## Description

Follow-up to #1564 and #1565, which fixed `rows_read`. This one targets request volume, which is what `rows_written` is made of: every authenticated coordinator request writes two rows to `request_nonces` — one INSERT on the way in, one DELETE when it expires 600s later — so a redundant request costs writes no matter how little it reads.

Both changes are worth making on their own terms; neither is only a quota play.

**1. Duplicate `/v1/peers` per daemon tick.** `refreshCoordinatorPresenceForDaemon` called `refreshAuthorizedCoordinatorPeerTrust`, which fetches peers and stores their addresses — then discarded the peers it returned. Ten lines later `fetchCoordinatorStalePeers` re-read the config file, fetched the same `/v1/peers`, and repeated the same `refreshStoredCoordinatorPeerAddresses` write. Two identical round trips seconds apart, with the same side effect applied twice.

`refreshCoordinatorForDaemon` now returns the snapshot and the tick passes it through, so one tick makes one lookup. `fetchCoordinatorStalePeers` keeps its fetching path for callers without a snapshot — including the tick itself when the coordinator refresh threw, so a failed refresh still degrades to the old behaviour rather than silently skipping the preflight. The stale-set derivation moved into the exported `coordinatorStalePeerKeys` so both paths share one implementation. `refreshCoordinatorPresenceForDaemon` remains as a boolean-returning wrapper.

The snapshot is now taken before the `onAfterCoordinatorRefresh` callback rather than after it. For a best-effort offline preflight a few-seconds-old view is well inside tolerance.

**2. `GET /v1/scopes` N+1.** `requesterAuthorizedForScope` ran `listScopeMemberships(scope_id)` once per scope — reading every member of every scope to answer a question about one device. The endpoint now makes a single `listDeviceScopeMemberships` call, served by the already-present `idx_coordinator_scope_memberships_device_status` index, and matches scopes against that map. `(scope_id, device_id)` is the primary key so the mapping is 1:1, and the `membership_epoch >= scope.membership_epoch` check is unchanged. The helper had no other caller — `/v1/scopes/:scope_id/members` does its own check over memberships it already needs — so it is removed rather than left dead.

`listDeviceScopeMemberships` is added to the store contract and implemented in both the D1 and better-sqlite stores.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

`pnpm run tsc` and `pnpm run lint` clean. `pnpm run test` reports 5,736 passed — five more than before this change — with one unrelated environmental failure (`packages/mcp-server/src/http.test.ts` cannot bind `::1` in this container; it passes in CI). `pnpm --filter @codemem/cloudflare-coordinator-worker test:worker` passes, 6 tests.

New coverage:
- Shared store harness: one device's memberships across several scopes, isolation from other devices' grants, `includeRevoked` behaviour, and the empty-`deviceId` guard. Confirmed running against **both** store implementations.
- `fetchCoordinatorStalePeers` derives the same stale set from a supplied snapshot, with `globalThis.fetch` stubbed to throw so a second lookup would fail the test.
- `refreshCoordinatorForDaemon` returns the peer snapshot with exactly one `refreshAuthorizedCoordinatorPeerTrust` call, and reports `peers: null` when the coordinator is unconfigured.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq71RnJbURWvF9fmkKuDRc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lq71RnJbURWvF9fmkKuDRc)_