### PR TITLE
chore(deps): upgrade better-sqlite3 to 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Persistent memory for [OpenCode](https://opencode.ai) and [Claude Code](https://
 
 ## Quick start
 
-**Prerequisites:** Node.js 24.15+ and npm (or pnpm)
+**Prerequisites:** Node.js 24.15+ and npm (or pnpm). Native database support
+covers macOS x64/arm64, Linux x64/arm64 (glibc 2.34+ or musl), and Windows x64.
+32-bit targets, including Linux armv7, are not supported.
 
 codemem keeps one minimum Node.js version across published packages and workspace tooling.
 

--- a/docs/plans/2026-03-15-install-matrix.md
+++ b/docs/plans/2026-03-15-install-matrix.md
@@ -10,23 +10,42 @@ what each package requires per platform, what users need installed, and what bre
 
 | Platform | better-sqlite3 | sqlite-vec | onnxruntime-node |
 |---|---|---|---|
-| macOS arm64 | ⚠️ Compile from source¹ | ✅ Prebuild (.dylib) | ✅ Prebuild |
-| macOS x64 | ✅ Prebuild available | ✅ Prebuild (.dylib) | ✅ Prebuild |
-| Linux x64 | ✅ Prebuild available | ✅ Prebuild (.so) | ✅ Prebuild |
-| Linux arm64 | ⚠️ Compile from source¹ | ✅ Prebuild (.so) | ✅ Prebuild |
-| Windows x64 | ✅ Prebuild available | ✅ Prebuild (.dll) | ✅ Prebuild |
+| macOS arm64 | ✅ Bundled binary | ✅ Prebuild (.dylib) | ✅ Prebuild |
+| macOS x64 | ✅ Bundled binary | ✅ Prebuild (.dylib) | ✅ Prebuild |
+| Linux x64 | ✅ Bundled glibc/musl binaries | ✅ Prebuild (.so) | ✅ Prebuild |
+| Linux arm64 | ✅ Bundled glibc/musl binaries | ✅ Prebuild (.so) | ✅ Prebuild |
+| Windows x64 | ✅ Bundled binary | ✅ Prebuild (.dll) | ✅ Prebuild |
 
-¹ No prebuild for Node 24 + arm64 confirmed in spike. better-sqlite3 publishes
-prebuilds via `prebuild-install` (143 release assets for v12.8.0 covering many
-Node × platform combos), but coverage for newer Node versions on arm64 lags.
-Prebuilds for Node 20/22 on arm64 are typically available. **This is the primary
-install friction point.**
+better-sqlite3 13.0.3 bundles N-API prebuilds for macOS, Linux glibc, Linux
+musl, and Windows on x64 and arm64. Version 13.0.0's Linux arm64 binary required
+newer glibc and libstdc++ symbols than Debian Bookworm provides; upstream rebuilt
+it on Ubuntu 22.04 for 13.0.3.
+
+### Why upgrade from better-sqlite3 12.8.0
+
+The upgrade primarily improves native-module compatibility and maintenance; codemem
+does not need the two new query-inspection APIs yet.
+
+| Area | 12.8.0 | 13.0.3 | Effect on codemem |
+|---|---|---|---|
+| Native API | V8-version-specific addon | Node-API v10 addon | One bundled binary works across supported Node releases |
+| Prebuild delivery | Downloaded by an install script | 8 binaries bundled in the package | Removes better-sqlite3's install-time network lookup and works when npm lifecycle scripts are disabled |
+| Bundled SQLite | 3.51.3 | 3.53.4 | Gains SQLite 3.53 features and subsequent fixes |
+| Query diagnostics | Prepared `EXPLAIN` statements | Adds `db.explain()` and `Statement#toString()` | Available at runtime for future diagnostics; `@types/better-sqlite3` does not declare them yet |
+| Runtime fixes | Baseline | Cross-realm errors and bindings, table-parameter validation, and worker-termination abort fixes | Lower risk in tests, workers, and multi-realm runtimes |
+| Unpacked package size | 10.3 MB | 27.3 MB | Adds 17.0 MB because every supported binary ships together |
+
+Version 13 drops Windows x86, Linux armv7, Electron before v35, and Node before
+v22. codemem already requires Node 24.15+ and supports x64/arm64, so those removals
+do not narrow its documented support. The N-API migration also removes
+better-sqlite3's `prebuild-install` dependency, although codemem still receives
+that package transitively through Transformers.js and Sharp.
 
 ### How each package ships native code
 
 | Package | Native strategy | Build system | Fallback |
 |---|---|---|---|
-| better-sqlite3 | `prebuild-install`, falls back to `node-gyp rebuild` | node-gyp (C++ addon, compiles SQLite amalgamation) | Source compilation |
+| better-sqlite3 | Bundled N-API binaries selected at runtime | node-gyp (explicit `build-release` only) | Runtime load error at first `new Database()` if the platform has no bundled binary; install still succeeds |
 | sqlite-vec | `optionalDependencies` per-platform packages | None — prebuilt binaries only | Fatal error if platform unsupported |
 | onnxruntime-node | Single package, postinstall downloads platform binary | N-API addon, prebuilt | Fatal error if platform unsupported |
 
@@ -46,7 +65,7 @@ matching one. No compilation step.
 
 ## SQLite Version Compatibility
 
-**better-sqlite3 bundles its own SQLite** (currently v3.51.3) compiled from the
+**better-sqlite3 bundles its own SQLite** (currently v3.53.4) compiled from the
 amalgamation source. It does NOT use a system SQLite.
 
 **sqlite-vec does not conflict.** The sqlite-vec .dylib/.so is loaded via
@@ -58,17 +77,17 @@ collision.
 The only requirement is that the host SQLite version supports the extension's
 required APIs. sqlite-vec uses virtual tables and standard extension entry
 points, which have been stable since SQLite 3.9.0 (2015). better-sqlite3's
-bundled 3.51.3 is well above this.
+bundled 3.53.4 is well above this.
 
 ## Install Size Budget
 
 | Package | Unpacked size | Notes |
 |---|---|---|
-| better-sqlite3 | ~10 MB | Includes SQLite amalgamation source + prebuilt .node |
+| better-sqlite3 | ~27 MB | Includes SQLite amalgamation source + bundled binaries for supported platforms |
 | sqlite-vec (per-platform) | ~160 KB | Only the matching platform package is installed |
 | onnxruntime-node | **~220 MB** | Ships all platform binaries in one package |
-| **Total (with onnxruntime)** | **~230 MB** | Dominated by onnxruntime |
-| **Total (without onnxruntime)** | **~10 MB** | Core functionality only |
+| **Total (with onnxruntime)** | **~247 MB** | Dominated by onnxruntime |
+| **Total (without onnxruntime)** | **~27 MB** | Core functionality only |
 
 onnxruntime-node is 95% of the install weight. This is the strongest argument
 for making it optional (see §Optional Dependencies below).
@@ -77,57 +96,48 @@ for making it optional (see §Optional Dependencies below).
 
 ### When prebuilds are available (most users)
 
-No build tools required. `npm install` downloads prebuilt binaries for all three
-packages.
+No build tools required. `npm install` uses the bundled better-sqlite3 binary and
+obtains prebuilt binaries for the other native packages.
 
-### When better-sqlite3 must compile from source
+### Why the better-sqlite3 build is denied
 
-This applies to: Node 24 on arm64 (macOS and Linux), and any future
-Node version before prebuilds are published.
+better-sqlite3 13 includes `binding.gyp` but has no install script. pnpm 12.2.1
+therefore synthesizes `node-gyp rebuild` even though `gypfile` is false and a
+matching bundled binary exists. node-gyp checks for Python before the package's
+GYP condition can detect the prebuild, so minimal Docker images fail during
+installation unnecessarily.
 
-| Platform | Required tools |
-|---|---|
-| macOS arm64 | Xcode Command Line Tools (`xcode-select --install`) — provides clang++, make, python3 |
-| Linux arm64 | `build-essential` (gcc/g++, make), `python3` |
-| Linux x64 | `build-essential`, `python3` (only if prebuild missing) |
-
-node-gyp requires: Python 3, a C++ compiler supporting C++20, and make.
-These are standard on developer machines but **not** on minimal CI images or
-Docker containers. The install script (`prebuild-install || node-gyp rebuild`)
-handles the fallback automatically.
-
-### Mitigation: ship our own prebuilds
-
-If Node 24 arm64 becomes a common target before upstream publishes prebuilds:
-1. Fork/rebuild with `prebuild` targeting Node 24 arm64
-2. Host prebuilds on GitHub Releases
-3. Configure `prebuild-install --download` to check our mirror first
-
-This is a contingency, not a first step.
+The workspace sets `allowBuilds.better-sqlite3: false` to skip that implicit
+lifecycle. This is narrower than disabling all install scripts and ensures the
+bundled binary is used. Unsupported operating-system and architecture pairs are
+not covered by this policy because they would require a deliberate source-build
+toolchain and separate validation.
 
 ## CI Matrix
 
-### Minimum test matrix
+### Proposed minimum test matrix
+
+The repository CI currently covers Linux x64 on Node 24. The other rows are the
+target support matrix and require release-gate coverage before their results can
+be treated as continuous guarantees.
 
 | Runner | Node | Arch | Purpose |
 |---|---|---|---|
-| `macos-14` (M1) | 22 | arm64 | Primary dev platform, prebuild test |
-| `macos-14` (M1) | 24 | arm64 | Source compilation test |
-| `ubuntu-24.04` | 22 | x64 | Standard Linux, prebuild test |
-| `ubuntu-24.04` | 24 | x64 | Latest Node on Linux |
-| `ubuntu-24.04-arm` | 22 | arm64 | Linux arm64 prebuild test |
+| `macos-14` (M1) | 24 | arm64 | Primary dev platform and bundled-binary test |
+| `ubuntu-24.04` | 24 | x64 | Linux glibc bundled-binary test |
+| `ubuntu-24.04-arm` | 24 | arm64 | Linux arm64 bundled-binary test |
 
 ### Extended matrix (lower priority)
 
 | Runner | Node | Arch | Purpose |
 |---|---|---|---|
-| `macos-13` | 22 | x64 | Intel Mac support |
-| `windows-latest` | 22 | x64 | Windows baseline (if we support it) |
-| `ubuntu-24.04-arm` | 24 | arm64 | Linux arm64 source compilation |
+| `macos-13` | 24 | x64 | Intel Mac bundled-binary test |
+| `windows-latest` | 24 | x64 | Windows bundled-binary test (if supported) |
+| Alpine container | 24 | x64 + arm64 | Linux musl bundled-binary test |
 
 ### What each CI job validates
 
-1. `npm install` succeeds (prebuilds download or compilation works)
+1. `npm install` succeeds without compiling better-sqlite3
 2. `better-sqlite3` opens a database and runs queries
 3. `sqlite-vec` extension loads via `db.loadExtension()`
 4. `onnxruntime-node` loads a model and produces embeddings (optional dep jobs only)
@@ -141,13 +151,13 @@ This is a contingency, not a first step.
 installs optional dependencies unless the user explicitly passes
 `--omit=optional`. Instead, split into two packages:
 
-- **`codemem`** — core package, no onnxruntime (~10 MB). FTS search works, semantic search is unavailable.
+- **`codemem`** — core package, no onnxruntime (~27 MB). FTS search works, semantic search is unavailable.
 - **`codemem-embeddings`** (or `@codemem/embeddings`) — adds `onnxruntime-node` + `@huggingface/transformers` (~220 MB). Enables semantic search.
 
 Users install what they need:
 ```bash
-npm install codemem                    # Core only (~10 MB)
-npm install codemem codemem-embeddings # Full with semantic search (~230 MB)
+npm install codemem                    # Core only (~27 MB)
+npm install codemem codemem-embeddings # Full with semantic search (~247 MB)
 ```
 
 The core package detects `codemem-embeddings` at runtime via dynamic import:
@@ -191,21 +201,22 @@ Embeddings require onnxruntime-node. Install it with:
 #### Install instructions in README
 
 ```bash
-# Core install (~10 MB)
+# Core install (~27 MB)
 npm install codemem
 
-# With embedding support (~230 MB)
+# With embedding support (~247 MB)
 npm install codemem onnxruntime-node
 ```
 
 ## Open Risks
 
-### 1. better-sqlite3 prebuild lag on new Node versions
-**Risk:** Every major Node release has a window where prebuilds aren't published
-yet for all platforms. Users on bleeding-edge Node hit a compilation requirement.
-**Mitigation:** Pin `engines` to Node versions with confirmed prebuilds. Document
-build tool requirements clearly. Consider self-hosting prebuilds if the window
-is long.
+### 1. better-sqlite3 unsupported native targets
+**Risk:** The bundled binaries cover x64 and arm64 on macOS, Windows, Linux glibc,
+and Linux musl. Other targets need source compilation, which codemem's denied
+better-sqlite3 lifecycle does not permit.
+**Mitigation:** Keep the documented platform set aligned with tested bundled
+binaries. Treat any new operating-system or architecture pair as a separate
+support decision with a native-build test.
 
 ### 2. onnxruntime-node postinstall fragility
 **Risk:** onnxruntime-node's `postinstall` script downloads binaries at install
@@ -223,15 +234,16 @@ the extension itself is pre-1.0.
 prepared to vendor the .dylib/.so if the npm package becomes unmaintained.
 
 ### 4. glibc minimum on Linux
-**Risk:** Prebuilt binaries (sqlite-vec, onnxruntime-node, better-sqlite3
-prebuilds) are compiled against a specific glibc version. Old distros
-(CentOS 7, Amazon Linux 2) may not have a new enough glibc.
-**Mitigation:** Document minimum Linux versions. Test on Ubuntu 22.04+ which
-covers the vast majority of Node.js deployments.
+**Risk:** better-sqlite3 13.0.3's Linux binaries require GLIBC 2.34,
+GLIBCXX 3.4.29, and CXXABI 1.3.9. Other native dependencies may impose a higher
+floor. Old distributions such as CentOS 7 and Amazon Linux 2 do not satisfy the
+better-sqlite3 floor.
+**Mitigation:** Use a glibc 2.34+ distribution and test the oldest supported
+image. Debian Bookworm's glibc 2.36 and libstdc++ 3.4.30 pass the runtime probe.
 
 ### 5. Total install weight with onnxruntime + model files
 **Risk:** onnxruntime-node is 220 MB. Embedding models (e.g., all-MiniLM-L6-v2
 ONNX) add another 20-80 MB. Total install weight for a user wanting embeddings
 could hit 300+ MB.
-**Mitigation:** Optional dependency strategy keeps the default install at ~10 MB.
+**Mitigation:** Optional dependency strategy keeps the default install at ~27 MB.
 Model files should be downloaded on first use, not at install time.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -502,7 +502,10 @@ Fixes, in order of preference:
            (npm root -g)/codemem/node_modules/sqlite-vec-linux-arm64
    # then restart the viewer
    ```
-   Substitute the right platform: `sqlite-vec-linux-arm` for 32-bit Pi OS (`uname -m` reports `armv7l`), `sqlite-vec-linux-x64` for x86_64 Linux.
+   Substitute `sqlite-vec-linux-x64` for x86_64 Linux. A 32-bit Pi OS
+   installation (`uname -m` reports `armv7l`) is not supported because
+   better-sqlite3 13 does not ship a Linux armv7 binary; use a 64-bit OS on
+   arm64 hardware instead.
 
 3. **Run with embeddings disabled.** Codemem degrades gracefully: keyword search via FTS5 keeps working, the viewer keeps loading, and the only feature you lose is semantic recall via vector similarity:
    ```fish

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,6 +7,10 @@ This is the published npm package for the `codemem` CLI.
 
 ## Install
 
+**Prerequisites:** Node.js 24.15+ and npm (or pnpm). Native database support
+covers macOS x64/arm64, Linux x64/arm64 (glibc 2.34+ or musl), and Windows x64.
+32-bit targets, including Linux armv7, are not supported.
+
 ```bash
 npm install -g codemem
 ```

--- a/packages/cloudflare-coordinator-worker/package.json
+++ b/packages/cloudflare-coordinator-worker/package.json
@@ -18,7 +18,7 @@
 		"@cloudflare/vitest-pool-workers": "^0.22.0",
 		"@cloudflare/workers-types": "^5.20260901.1",
 		"@types/better-sqlite3": "catalog:",
-		"better-sqlite3": "12.8.0",
+		"better-sqlite3": "13.0.3",
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@xenova/transformers": "^2.17.2",
-		"better-sqlite3": "12.8.0",
+		"better-sqlite3": "13.0.3",
 		"bonjour-service": "^1.4.4",
 		"drizzle-orm": "catalog:",
 		"hono": "catalog:",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -29,7 +29,7 @@
 	"devDependencies": {
 		"@types/better-sqlite3": "catalog:",
 		"@types/node": "^24.12.4",
-		"better-sqlite3": "12.8.0",
+		"better-sqlite3": "13.0.3",
 		"sqlite-vec": "0.1.9",
 		"typescript": "catalog:",
 		"vite": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ catalogs:
       specifier: ^2.1.1
       version: 2.1.1
     '@types/better-sqlite3':
-      specifier: ^7.6.13
-      version: 7.6.13
+      specifier: ^9.6.0
+      version: 9.6.0
     drizzle-orm:
       specifier: ^0.45.2
       version: 0.45.2
@@ -139,7 +139,7 @@ catalogs:
       version: 4.1.11
 
 overrides:
-  better-sqlite3: 12.8.0
+  better-sqlite3: 13.0.3
   fast-uri: 3.1.5
   '@modelcontextprotocol/sdk>@hono/node-server': 1.19.17
   '@modelcontextprotocol/sdk>hono': 4.13.5
@@ -211,14 +211,14 @@ importers:
         version: 15.0.0
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@13.0.3)
       omelette:
         specifier: ^0.4.17
         version: 0.4.17
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
-        version: 7.6.13
+        version: 9.6.0
       '@types/node':
         specifier: ^24.12.4
         version: 24.13.3
@@ -252,10 +252,10 @@ importers:
         version: 5.20260901.1
       '@types/better-sqlite3':
         specifier: 'catalog:'
-        version: 7.6.13
+        version: 9.6.0
       better-sqlite3:
-        specifier: 12.8.0
-        version: 12.8.0
+        specifier: 13.0.3
+        version: 13.0.3
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -275,14 +275,14 @@ importers:
         specifier: ^2.17.2
         version: 2.17.2
       better-sqlite3:
-        specifier: 12.8.0
-        version: 12.8.0
+        specifier: 13.0.3
+        version: 13.0.3
       bonjour-service:
         specifier: ^1.4.4
         version: 1.4.4
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@13.0.3)
       hono:
         specifier: 'catalog:'
         version: 4.13.5
@@ -295,7 +295,7 @@ importers:
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
-        version: 7.6.13
+        version: 9.6.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -417,7 +417,7 @@ importers:
         version: 2.1.1(hono@4.13.5)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@13.0.3)
       hono:
         specifier: 'catalog:'
         version: 4.13.5
@@ -427,13 +427,13 @@ importers:
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
-        version: 7.6.13
+        version: 9.6.0
       '@types/node':
         specifier: ^24.12.4
         version: 24.13.3
       better-sqlite3:
-        specifier: 12.8.0
-        version: 12.8.0
+        specifier: 13.0.3
+        version: 13.0.3
       sqlite-vec:
         specifier: 0.1.9
         version: 0.1.9
@@ -2114,8 +2114,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@types/better-sqlite3@7.6.13':
-    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+  '@types/better-sqlite3@9.6.0':
+    resolution: {integrity: sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -2414,15 +2414,12 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  better-sqlite3@12.8.0:
-    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  better-sqlite3@13.0.3:
+    resolution: {integrity: sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==}
+    engines: {node: '>=22'}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -2634,7 +2631,7 @@ packages:
       '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
-      better-sqlite3: 12.8.0
+      better-sqlite3: 13.0.3
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
       gel: '>=2'
@@ -2853,9 +2850,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -3224,6 +3218,10 @@ packages:
 
   node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
+
+  node-addon-api@8.9.2:
+    resolution: {integrity: sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
@@ -5220,7 +5218,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@types/better-sqlite3@7.6.13':
+  '@types/better-sqlite3@9.6.0':
     dependencies:
       '@types/node': 24.13.3
 
@@ -5468,18 +5466,13 @@ snapshots:
 
   baseline-browser-mapping@2.11.14: {}
 
-  better-sqlite3@12.8.0:
+  better-sqlite3@13.0.3:
     dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
+      node-addon-api: 8.9.2
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
 
   bl@4.1.0:
     dependencies:
@@ -5676,11 +5669,11 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.13
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260529.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@13.0.3):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260529.1
-      '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 12.8.0
+      '@types/better-sqlite3': 9.6.0
+      better-sqlite3: 13.0.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -5908,8 +5901,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
       picomatch: 4.0.7
-
-  file-uri-to-path@1.0.0: {}
 
   finalhandler@2.1.1(supports-color@10.2.2):
     dependencies:
@@ -6246,6 +6237,8 @@ snapshots:
       semver: 7.8.5
 
   node-addon-api@6.1.0: {}
+
+  node-addon-api@8.9.2: {}
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - packages/*
 
 allowBuilds:
-  better-sqlite3: true
+  better-sqlite3: false
   esbuild: true
   msgpackr-extract: true
   protobufjs: false
@@ -10,7 +10,7 @@ allowBuilds:
   workerd: true
 
 overrides:
-  better-sqlite3: 12.8.0
+  better-sqlite3: 13.0.3
   fast-uri: 3.1.5
   '@modelcontextprotocol/sdk>@hono/node-server': 1.19.17
   '@modelcontextprotocol/sdk>hono': 4.13.5
@@ -25,7 +25,7 @@ overrides:
 catalog:
   "@biomejs/biome": ^2.5.11
   "@hono/node-server": ^2.1.1
-  "@types/better-sqlite3": ^7.6.13
+  "@types/better-sqlite3": ^9.6.0
   drizzle-orm: ^0.45.2
   hono: ^4.13.5
   limiter: ^3.0.0


### PR DESCRIPTION
## Description

Upgrade better-sqlite3 from 12.8.0 to 13.0.3 and align @types/better-sqlite3 at 9.6.0 across every Drizzle consumer.

Version 13 moves to Node-API and bundles eight platform binaries instead of downloading a Node-version-specific prebuild during installation. pnpm 12.2.1 incorrectly synthesizes node-gyp rebuild despite the package declaring gypfile=false, so this change explicitly denies that unnecessary lifecycle and relies on the bundled binary for the documented x64/arm64 platform set.

The install matrix records the concrete gains, compatibility limits, package-size increase, glibc floor, and runtime-failure behavior for unsupported targets.

Supersedes #1578.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation:

- `pnpm run check` — 235 files, 5,745 tests passed; 3 todo
- `pnpm run build`
- `pnpm install --frozen-lockfile`
- Cloudflare Worker node, integration, bundle, and dry-run checks
- SQLite 3.53.4 runtime probes on Darwin arm64
- Clean Debian Bookworm glibc 2.36 installs and runtime probes on Linux x64 and arm64
- Alpine musl runtime probes with install scripts disabled on Linux x64 and arm64
- One Drizzle 0.45.2 instance and one @types/better-sqlite3 9.6.0 instance confirmed
- Independent CodeReviewer: GO

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced