### PR TITLE
perf(core): batch v2 embedding extractor calls

### DIFF
--- a/packages/core/src/embeddings.test.ts
+++ b/packages/core/src/embeddings.test.ts
@@ -6,8 +6,15 @@
  * in a separate test file gated on CODEMEM_EMBEDDING_DISABLED.
  */
 
-import { describe, expect, it } from "vitest";
-import { chunkText, embeddingDataToFloat32, hashText, serializeFloat32 } from "./embeddings.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+	chunkText,
+	embeddingDataToFloat32,
+	embeddingTensorToFloat32Rows,
+	embedTextBatches,
+	hashText,
+	serializeFloat32,
+} from "./embeddings.js";
 
 describe("hashText", () => {
 	it("returns a 64-char hex SHA-256 digest", () => {
@@ -87,6 +94,47 @@ describe("embeddingDataToFloat32", () => {
 			expect(() => embeddingDataToFloat32([value])).toThrow(TypeError);
 		},
 	);
+});
+
+describe("bounded embedding batches", () => {
+	it("runs stable array inference batches and returns owned rows", async () => {
+		const outputs: Float32Array[] = [];
+		const extractor = vi.fn(async (texts: string[]) => {
+			const data = new Float32Array(texts.flatMap((text) => [Number(text), Number(text) + 0.5]));
+			outputs.push(data);
+			return { data, dims: [texts.length, 2] };
+		});
+
+		const vectors = await embedTextBatches(extractor, ["1", "2", "3", "4", "5"], 2, 2);
+
+		expect(extractor.mock.calls.map(([texts]) => texts)).toEqual([["1", "2"], ["3", "4"], ["5"]]);
+		expect(vectors).toEqual([
+			new Float32Array([1, 1.5]),
+			new Float32Array([2, 2.5]),
+			new Float32Array([3, 3.5]),
+			new Float32Array([4, 4.5]),
+			new Float32Array([5, 5.5]),
+		]);
+		expect(
+			vectors.every((vector) => outputs.every((output) => vector.buffer !== output.buffer)),
+		).toBe(true);
+		expect(new Set(vectors.map((vector) => vector.buffer)).size).toBe(vectors.length);
+	});
+
+	it("does not invoke the extractor for empty input", async () => {
+		const extractor = vi.fn();
+
+		await expect(embedTextBatches(extractor, [], 384)).resolves.toEqual([]);
+		expect(extractor).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		[{ data: new Float32Array(4), dims: [1, 2] }, "shape"],
+		[{ data: new Float32Array(3), dims: [2, 2] }, "values"],
+		[{ data: new Float32Array([1, 2, Number.NaN, 4]), dims: [2, 2] }, "non-finite"],
+	])("rejects invalid batched tensor %s", (output, expectedMessage) => {
+		expect(() => embeddingTensorToFloat32Rows(output, 2, 2)).toThrow(expectedMessage);
+	});
 });
 
 describe("serializeFloat32", () => {

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -24,6 +24,18 @@ export interface EmbeddingClient {
 	embed(texts: string[]): Promise<Float32Array[]>;
 }
 
+interface EmbeddingTensor {
+	data: ArrayLike<number | bigint>;
+	dims?: number[];
+}
+
+type FeatureExtractor = (
+	texts: string[],
+	options: { pooling: "mean"; normalize: true },
+) => Promise<EmbeddingTensor>;
+
+const EMBEDDING_BATCH_SIZE = 32;
+
 /** Copy validated embedding model data into owned Float32 storage. */
 export function embeddingDataToFloat32(data: ArrayLike<number | bigint>): Float32Array {
 	const vector = new Float32Array(data.length);
@@ -38,6 +50,72 @@ export function embeddingDataToFloat32(data: ArrayLike<number | bigint>): Float3
 		vector[index] = float32Value;
 	}
 	return vector;
+}
+
+/** Split one validated row-major tensor into independently owned vectors. */
+export function embeddingTensorToFloat32Rows(
+	output: EmbeddingTensor,
+	expectedRows: number,
+	dimensions: number,
+): Float32Array[] {
+	if (
+		!Number.isInteger(expectedRows) ||
+		expectedRows <= 0 ||
+		!Number.isInteger(dimensions) ||
+		dimensions <= 0
+	) {
+		throw new TypeError("Embedding tensor shape expectations must be positive integers");
+	}
+	if (
+		output.dims?.length !== 2 ||
+		output.dims[0] !== expectedRows ||
+		output.dims[1] !== dimensions
+	) {
+		throw new TypeError(
+			`Embedding model returned shape [${output.dims?.join(", ") ?? "unknown"}], expected [${expectedRows}, ${dimensions}]`,
+		);
+	}
+	if (output.data.length !== expectedRows * dimensions) {
+		throw new TypeError(
+			`Embedding model returned ${output.data.length} values, expected ${expectedRows * dimensions}`,
+		);
+	}
+
+	const rows = Array.from({ length: expectedRows }, () => new Float32Array(dimensions));
+	for (let flatIndex = 0; flatIndex < output.data.length; flatIndex++) {
+		const value = output.data[flatIndex];
+		const float32Value = typeof value === "number" ? Math.fround(value) : Number.NaN;
+		if (!Number.isFinite(float32Value)) {
+			throw new TypeError(
+				`Embedding model returned non-finite, non-numeric, or unrepresentable tensor data at index ${flatIndex}`,
+			);
+		}
+		const row = rows[Math.floor(flatIndex / dimensions)];
+		if (!row) throw new TypeError("Embedding tensor row calculation failed");
+		row[flatIndex % dimensions] = float32Value;
+	}
+	return rows;
+}
+
+/** Run array inference in bounded batches while preserving input order. */
+export async function embedTextBatches(
+	extractor: FeatureExtractor,
+	texts: string[],
+	dimensions: number,
+	batchSize = EMBEDDING_BATCH_SIZE,
+): Promise<Float32Array[]> {
+	if (texts.length === 0) return [];
+	if (!Number.isInteger(batchSize) || batchSize <= 0) {
+		throw new TypeError("Embedding batch size must be a positive integer");
+	}
+
+	const vectors: Float32Array[] = [];
+	for (let offset = 0; offset < texts.length; offset += batchSize) {
+		const batch = texts.slice(offset, offset + batchSize);
+		const output = await extractor(batch, { pooling: "mean", normalize: true });
+		vectors.push(...embeddingTensorToFloat32Rows(output, batch.length, dimensions));
+	}
+	return vectors;
 }
 
 // ---------------------------------------------------------------------------
@@ -174,20 +252,15 @@ async function createTransformersClient(model: string): Promise<EmbeddingClient>
 	});
 
 	// Infer dimensions from a probe embedding
-	const probe = await extractor("probe", { pooling: "mean", normalize: true });
+	const probe = await extractor(["probe"], { pooling: "mean", normalize: true });
 	const dims = probe.dims?.at(-1) ?? 384;
+	embeddingTensorToFloat32Rows(probe, 1, dims);
 
 	return {
 		model,
 		dimensions: dims,
 		async embed(texts: string[]): Promise<Float32Array[]> {
-			const results: Float32Array[] = [];
-			for (const text of texts) {
-				const output = await extractor(text, { pooling: "mean", normalize: true });
-				// output.data is a Float32Array of shape [1, dims]
-				results.push(embeddingDataToFloat32(output.data));
-			}
-			return results;
+			return embedTextBatches(extractor, texts, dims);
 		},
 	};
 }

--- a/packages/core/src/xenova-transformers.d.ts
+++ b/packages/core/src/xenova-transformers.d.ts
@@ -12,7 +12,7 @@ declare module "@xenova/transformers" {
 	}
 
 	type FeatureExtractionPipeline = (
-		text: string,
+		text: string | string[],
 		options?: { pooling?: string; normalize?: boolean },
 	) => Promise<PipelineOutput>;
 


### PR DESCRIPTION
## Description

Replaces one-at-a-time Xenova feature extraction with bounded 32-text tensor batches while preserving the current fp32 BGE model, ordering, dimensions, pooling, normalization, and public embedding API. Validates the complete tensor before returning independently owned vectors. Tracks `codemem-jnd6.8.2`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm exec vitest run packages/core/src/embeddings.test.ts` (23 tests)
- [x] `pnpm --filter @codemem/core typecheck`
- [x] `pnpm exec biome check packages/core/src/embeddings.ts packages/core/src/embeddings.test.ts packages/core/src/xenova-transformers.d.ts`
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated in the downstack design PR
- [x] No new warnings introduced