### PR TITLE
perf(core): batch backfill chunks across memories

### DIFF
--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -68,7 +68,9 @@ describe("vector migration", () => {
 			dimensions: 384,
 			embed: vi.fn(),
 		});
-		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+		vi.mocked(embeddings.embedTexts).mockImplementation(async (texts) =>
+			texts.map(() => new Float32Array(384)),
+		);
 	});
 
 	afterEach(() => {
@@ -199,7 +201,9 @@ describe("vector migration", () => {
 		}
 
 		// Restore normal behavior and resume — should pick up from cursor
-		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+		vi.mocked(embeddings.embedTexts).mockImplementation(async (texts) =>
+			texts.map(() => new Float32Array(384)),
+		);
 		await runVectorMigrationPass(db, { batchSize: 10 });
 
 		const afterResume = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
@@ -212,40 +216,45 @@ describe("vector migration", () => {
 		expect(models).toEqual([{ model: "test-model", c: 3 }]);
 	});
 
-	it("bails out of a large batch when the AbortSignal fires", async () => {
+	it("preserves the migration cursor when an inference batch is aborted", async () => {
 		// Cooperative shutdown (codemem-u5yn): with an aborted signal, the
-		// per-memory loop inside backfillVectors should break early rather
-		// than embed all queued rows. Critically, the cursor must NOT
-		// advance — the next post-restart tick needs to re-process this
-		// batch to cover the rows the abort skipped.
+		// in-flight inference batch finishes, but the migration cursor must NOT
+		// advance. The next tick rechecks the batch before completing cutover.
 		const sessionId = insertTestSession(db);
 		for (let i = 1; i <= 10; i++) {
 			seedMemory(db, i, sessionId, `Title ${i}`, `Body for memory ${i}`);
 			seedVector(db, i, "old-model");
 		}
 		const controller = new AbortController();
-		// Abort on the first embed call. backfillVectors processes memory 1
-		// and then breaks on the abort check before memory 2.
-		const embedSpy = vi.mocked(embeddings.embedTexts).mockImplementation(async () => {
+		const embedSpy = vi.mocked(embeddings.embedTexts).mockImplementation(async (texts) => {
 			controller.abort();
-			return [new Float32Array(384)];
+			return texts.map(() => new Float32Array(384));
 		});
 
 		await runVectorMigrationPass(db, { batchSize: 10, signal: controller.signal });
 
 		expect(embedSpy.mock.calls.length).toBe(1);
-		// Behavioral: only memory 1 got a target-model row; the other 9
-		// stayed on old-model.
 		const coverage = db
 			.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
 			.all() as Array<{ model: string; c: number }>;
 		expect(coverage).toEqual([
 			{ model: "old-model", c: 10 },
-			{ model: "test-model", c: 1 },
+			{ model: "test-model", c: 10 },
 		]);
 		// Cursor must not advance — retry on next tick.
 		const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
 		expect(job?.status).not.toBe("completed");
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)?.status).toBe("running");
+
+		// An exact-size batch needs one empty cursor pass to prove the migration is drained.
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)?.status).toBe("completed");
+		expect(
+			db.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model").all(),
+		).toEqual([{ model: "test-model", c: 10 }]);
 	});
 
 	it("completes an in-flight running job without re-embedding when corpus is already covered", async () => {

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -24,6 +24,7 @@ vi.mock("./embeddings.js", async () => {
 		...actual,
 		getEmbeddingClient: vi.fn(),
 		embedTexts: vi.fn(),
+		chunkText: vi.fn(actual.chunkText),
 		resolveEmbeddingModel: vi.fn(() => "test-model"),
 	};
 });
@@ -184,7 +185,7 @@ describe("vectors", () => {
 		let insertedBehindCursorId: number | null = null;
 		let insertedAheadOfHighWaterId: number | null = null;
 		let pagingPlan: Array<{ detail: string }> = [];
-		const embedSpy = vi.mocked(embeddings.embedTexts).mockImplementation(async () => {
+		const embedSpy = vi.mocked(embeddings.embedTexts).mockImplementation(async (texts) => {
 			if (insertedBehindCursorId == null) {
 				const pageSql = prepareSpy.mock.calls.find(([sql]) =>
 					String(sql).includes("candidates.seq AS snapshot_seq"),
@@ -204,7 +205,7 @@ describe("vectors", () => {
 					"2026-09-03T00:00:00.000Z",
 				);
 			}
-			return [new Float32Array(384)];
+			return texts.map(() => new Float32Array(384));
 		});
 		const prepareSpy = vi.spyOn(db, "prepare");
 
@@ -212,8 +213,7 @@ describe("vectors", () => {
 			const result = await backfillVectors(db);
 
 			expect(result).toEqual({ checked: 51, embedded: 50, inserted: 50, skipped: 1 });
-			expect(embedSpy).toHaveBeenCalledTimes(50);
-			expect(embedSpy.mock.calls.every(([texts]) => texts.length === 1)).toBe(true);
+			expect(embedSpy.mock.calls.map(([texts]) => texts.length)).toEqual([32, 17, 1]);
 			expect(
 				pagingPlan.some(({ detail }) =>
 					detail.startsWith("SEARCH candidates USING INTEGER PRIMARY KEY"),
@@ -370,7 +370,7 @@ describe("vectors", () => {
 			insertBackfillMemory(sessionId, `Limited ${index}`, createdAt);
 		}
 		let snapshottedRows: number | null = null;
-		const embedSpy = vi.mocked(embeddings.embedTexts).mockImplementation(async () => {
+		const embedSpy = vi.mocked(embeddings.embedTexts).mockImplementation(async (texts) => {
 			if (snapshottedRows == null) {
 				const snapshot = db
 					.prepare(
@@ -385,14 +385,14 @@ describe("vectors", () => {
 				};
 				snapshottedRows = count.c;
 			}
-			return [new Float32Array(384)];
+			return texts.map(() => new Float32Array(384));
 		});
 
 		const result = await backfillVectors(db, { limit: 7 });
 
 		expect(result).toEqual({ checked: 7, embedded: 7, inserted: 7, skipped: 0 });
 		expect(snapshottedRows).toBe(7);
-		expect(embedSpy).toHaveBeenCalledTimes(7);
+		expect(embedSpy.mock.calls.map(([texts]) => texts.length)).toEqual([7]);
 		expect(
 			db
 				.prepare(
@@ -403,19 +403,39 @@ describe("vectors", () => {
 		).toMatchObject({ c: 0 });
 	});
 
+	it("prepares page chunks incrementally instead of retaining the full page", async () => {
+		const sessionId = insertTestSession(db);
+		const createdAt = new Date().toISOString();
+		for (let index = 1; index <= 50; index++) {
+			insertBackfillMemory(sessionId, `Incremental ${index}`, createdAt);
+		}
+		let chunkCallsAtFirstInference: number | null = null;
+		const embedSpy = vi.mocked(embeddings.embedTexts).mockImplementation(async (texts) => {
+			chunkCallsAtFirstInference ??= vi.mocked(embeddings.chunkText).mock.calls.length;
+			return texts.map(() => new Float32Array(384));
+		});
+
+		const result = await backfillVectors(db);
+
+		expect(result).toEqual({ checked: 50, embedded: 50, inserted: 50, skipped: 0 });
+		expect(embedSpy.mock.calls.map(([texts]) => texts.length)).toEqual([32, 18]);
+		expect(chunkCallsAtFirstInference).toBe(32);
+	});
+
 	it("preserves dry-run counts without storing vectors", async () => {
 		const sessionId = insertTestSession(db);
 		const createdAt = new Date().toISOString();
 		for (let index = 1; index <= 3; index++) {
 			insertBackfillMemory(sessionId, `Dry run ${index}`, createdAt);
 		}
-		vi.mocked(embeddings.embedTexts).mockImplementation(async (texts) =>
-			texts.map(() => new Float32Array(384)),
-		);
+		const embedSpy = vi
+			.mocked(embeddings.embedTexts)
+			.mockImplementation(async (texts) => texts.map(() => new Float32Array(384)));
 
 		const result = await backfillVectors(db, { dryRun: true });
 
 		expect(result).toEqual({ checked: 3, embedded: 3, inserted: 3, skipped: 0 });
+		expect(embedSpy.mock.calls.map(([texts]) => texts.length)).toEqual([3]);
 		expect(db.prepare("SELECT COUNT(*) AS c FROM memory_vectors").get()).toMatchObject({ c: 0 });
 	});
 
@@ -426,7 +446,7 @@ describe("vectors", () => {
 		let nestedResult: Awaited<ReturnType<typeof backfillVectors>> | null = null;
 		let nested = false;
 		let maximumSnapshotCount = 0;
-		vi.mocked(embeddings.embedTexts).mockImplementation(async () => {
+		vi.mocked(embeddings.embedTexts).mockImplementation(async (texts) => {
 			const snapshotCount = db
 				.prepare(
 					`SELECT COUNT(*) AS c FROM sqlite_temp_master
@@ -438,7 +458,7 @@ describe("vectors", () => {
 				nested = true;
 				nestedResult = await backfillVectors(db, { memoryIds: [secondId] });
 			}
-			return [new Float32Array(384)];
+			return texts.map(() => new Float32Array(384));
 		});
 
 		const outerResult = await backfillVectors(db, { memoryIds: [firstId] });
@@ -454,6 +474,48 @@ describe("vectors", () => {
 				)
 				.get(),
 		).toMatchObject({ c: 0 });
+	});
+
+	it("keeps a memory atomic when aborting across the 32-chunk boundary", async () => {
+		const sessionId = insertTestSession(db);
+		const createdAt = new Date().toISOString();
+		const shortId = insertBackfillMemory(sessionId, "Short memory", createdAt);
+		const longBody = "x".repeat(1200 * 40);
+		const longId = insertBackfillMemory(sessionId, "Long memory", createdAt, longBody);
+		const longChunkCount = embeddings.chunkText(`Long memory\n${longBody}`).length;
+		expect(longChunkCount).toBeGreaterThan(32);
+		const controller = new AbortController();
+		const firstPassEmbed = vi.mocked(embeddings.embedTexts).mockImplementation(async (texts) => {
+			controller.abort();
+			return texts.map(() => new Float32Array(384));
+		});
+
+		const aborted = await backfillVectors(db, { signal: controller.signal });
+
+		expect(firstPassEmbed.mock.calls.map(([texts]) => texts.length)).toEqual([32]);
+		expect(aborted).toEqual({ checked: 2, embedded: 32, inserted: 1, skipped: 0 });
+		expect(
+			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE memory_id = ?").get(shortId),
+		).toMatchObject({ c: 1 });
+		expect(
+			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE memory_id = ?").get(longId),
+		).toMatchObject({ c: 0 });
+
+		const retryEmbed = vi.mocked(embeddings.embedTexts);
+		retryEmbed.mockClear();
+		retryEmbed.mockImplementation(async (texts) => texts.map(() => new Float32Array(384)));
+		const retried = await backfillVectors(db);
+
+		expect(retryEmbed.mock.calls.map(([texts]) => texts.length)).toEqual([32, longChunkCount - 32]);
+		expect(retried).toEqual({
+			checked: 2,
+			embedded: longChunkCount,
+			inserted: longChunkCount,
+			skipped: 1,
+		});
+		expect(
+			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE memory_id = ?").get(longId),
+		).toMatchObject({ c: longChunkCount });
 	});
 
 	it.each(["zero", "dimension", "non-finite"] as const)(

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -28,6 +28,7 @@ import type { MemoryFilters } from "./types.js";
 
 const VECTOR_MODEL_MIGRATION_JOB = "vector_model_migration";
 const BACKFILL_MEMORY_PAGE_SIZE = 50;
+const BACKFILL_INFERENCE_BATCH_SIZE = 32;
 const BACKFILL_CANDIDATE_TABLE_PREFIX = "codemem_backfill_vector_candidates";
 
 type VectorModelCount = { model: string; rows: number };
@@ -37,6 +38,12 @@ type MemoryTextRow = {
 	title: string | null;
 	body_text: string | null;
 	created_at?: string;
+};
+type PendingChunk = { text: string; chunkIndex: number; contentHash: string };
+type PendingMemory = {
+	memoryId: number;
+	chunks: PendingChunk[];
+	vectors: Float32Array[];
 };
 
 type BackfillMemoryRow = MemoryTextRow & { snapshot_seq: number };
@@ -222,9 +229,9 @@ export interface BackfillVectorsOptions {
 	dryRun?: boolean;
 	memoryIds?: number[] | null;
 	/**
-	 * When provided, the per-memory loop bails after the current memory
-	 * finishes if the signal has fired. Used by the viewer serve shutdown
-	 * sequence so SIGTERM does not block on an entire 50-memory batch.
+	 * When provided, backfill stops between inference batches. The in-flight
+	 * batch finishes, and any memory with only partial output remains unwritten.
+	 * Used by the viewer serve shutdown sequence to bound SIGTERM latency.
 	 */
 	signal?: AbortSignal;
 }
@@ -675,33 +682,18 @@ export async function backfillVectors(
 				existingHashesByMemory.set(existing.memory_id, hashes);
 			}
 
-			for (const row of rows) {
-				if (signal?.aborted) break;
-				checked++;
-				const chunks = chunkText(memoryText(row.title, row.body_text));
-				const existingHashes = existingHashesByMemory.get(row.id) ?? new Set<string>();
-				const pendingChunks: string[] = [];
-				const pendingHashes: string[] = [];
-				const pendingChunkIndexes: number[] = [];
-				for (const [chunkIndex, text] of chunks.entries()) {
-					const contentHash = hashText(text);
-					if (existingHashes.has(contentHash)) {
-						skipped++;
-						continue;
-					}
-					pendingChunks.push(text);
-					pendingHashes.push(contentHash);
-					pendingChunkIndexes.push(chunkIndex);
-				}
-				if (pendingChunks.length === 0) continue;
-
-				const embeddings = await embedTexts(pendingChunks);
-				if (embeddings.length !== pendingChunks.length) {
+			let batch: Array<{ memory: PendingMemory; chunk: PendingChunk }> = [];
+			const flushBatch = async (): Promise<void> => {
+				if (batch.length === 0) return;
+				const currentBatch = batch;
+				batch = [];
+				const embeddings = await embedTexts(currentBatch.map(({ chunk }) => chunk.text));
+				if (embeddings.length !== currentBatch.length) {
 					throw new TypeError(
-						`Embedding client returned ${embeddings.length} vectors for ${pendingChunks.length} texts`,
+						`Embedding client returned ${embeddings.length} vectors for ${currentBatch.length} texts`,
 					);
 				}
-				const entries = embeddings.map((vector, index) => {
+				for (const vector of embeddings) {
 					if (vector.length !== client.dimensions) {
 						throw new TypeError(
 							`Embedding client returned vector dimension ${vector.length}, expected ${client.dimensions}`,
@@ -712,55 +704,96 @@ export async function backfillVectors(
 							throw new TypeError("Embedding client returned a non-finite vector value");
 						}
 					}
-					return {
-						vector,
-						chunkIndex: pendingChunkIndexes[index] as number,
-						contentHash: pendingHashes[index] as string,
-					};
-				});
-				embedded += entries.length;
-				if (dryRun) {
-					inserted += entries.length;
-					continue;
 				}
-				// The page-wide existing-hash snapshot can go stale between that query
-				// and this insert when a concurrent writer (e.g. a vector migration
-				// worker running alongside `codemem embed`) vectors the same memory.
-				// memory_vectors is a vec0 table with no uniqueness constraint, so
-				// re-read this memory's current hashes inside an immediate transaction
-				// and skip any that now exist, preventing permanent duplicate rows.
-				const insertVectors = db.transaction(
-					(items: Array<{ vector: Float32Array; chunkIndex: number; contentHash: string }>) => {
-						const currentHashes = new Set(
-							(
-								db
-									.prepare(
-										"SELECT content_hash FROM memory_vectors WHERE memory_id = ? AND model = ?",
-									)
-									.all(row.id, model) as Array<{ content_hash: string | null }>
-							)
-								.map((existing) => existing.content_hash)
-								.filter((hash): hash is string => hash != null),
-						);
-						let insertedInTx = 0;
-						for (const entry of items) {
-							if (currentHashes.has(entry.contentHash)) continue;
-							insertMemoryVector(
-								db,
-								entry.vector,
-								row.id,
-								entry.chunkIndex,
-								entry.contentHash,
-								model,
+				embedded += embeddings.length;
+				const completed = new Set<PendingMemory>();
+				for (const [index, { memory }] of currentBatch.entries()) {
+					const vector = embeddings[index];
+					if (!vector) throw new TypeError("Embedding client omitted a validated vector");
+					memory.vectors.push(vector);
+					if (memory.vectors.length === memory.chunks.length) completed.add(memory);
+				}
+				for (const memory of completed) {
+					const entries = memory.chunks.map((chunk, index) => ({
+						...chunk,
+						vector: memory.vectors[index] as Float32Array,
+					}));
+					if (!dryRun) {
+						// The page-wide existing-hash snapshot can go stale between that
+						// query and this insert when a concurrent writer (e.g. a vector
+						// migration worker running alongside `codemem embed`) vectors the
+						// same memory. memory_vectors is a vec0 table with no uniqueness
+						// constraint, so re-read this memory's current hashes inside an
+						// immediate transaction and skip any that now exist, preventing
+						// permanent duplicate rows.
+						const insertVectors = db.transaction(() => {
+							// Only skip hashes a concurrent writer already persisted for this
+							// memory (observed since the page-wide snapshot). Do not dedup
+							// within this batch: distinct chunk_index rows may legitimately
+							// share content, matching the pre-existing insert semantics.
+							const persistedHashes = new Set(
+								(
+									db
+										.prepare(
+											"SELECT content_hash FROM memory_vectors WHERE memory_id = ? AND model = ?",
+										)
+										.all(memory.memoryId, model) as Array<{ content_hash: string | null }>
+								)
+									.map((existing) => existing.content_hash)
+									.filter((hash): hash is string => hash != null),
 							);
-							currentHashes.add(entry.contentHash);
-							insertedInTx++;
-						}
-						return insertedInTx;
-					},
-				);
-				inserted += insertVectors.immediate(entries);
+							let insertedInTx = 0;
+							for (const entry of entries) {
+								if (persistedHashes.has(entry.contentHash)) continue;
+								insertMemoryVector(
+									db,
+									entry.vector,
+									memory.memoryId,
+									entry.chunkIndex,
+									entry.contentHash,
+									model,
+								);
+								insertedInTx++;
+							}
+							return insertedInTx;
+						});
+						inserted += insertVectors.immediate();
+					} else {
+						inserted += entries.length;
+					}
+					memory.vectors.length = 0;
+					memory.chunks.length = 0;
+				}
+			};
+
+			for (const row of rows) {
+				if (signal?.aborted) return { checked, embedded, inserted, skipped };
+				checked++;
+				const chunks = chunkText(memoryText(row.title, row.body_text));
+				const existingHashes = existingHashesByMemory.get(row.id) ?? new Set<string>();
+				const pendingChunks: PendingChunk[] = [];
+				for (const [chunkIndex, text] of chunks.entries()) {
+					const contentHash = hashText(text);
+					if (existingHashes.has(contentHash)) {
+						skipped++;
+						continue;
+					}
+					pendingChunks.push({ text, chunkIndex, contentHash });
+				}
+				if (pendingChunks.length === 0) continue;
+				const memory: PendingMemory = { memoryId: row.id, chunks: pendingChunks, vectors: [] };
+				for (const chunk of pendingChunks) {
+					batch.push({ memory, chunk });
+					if (batch.length < BACKFILL_INFERENCE_BATCH_SIZE) continue;
+					await flushBatch();
+					if (!signal?.aborted) continue;
+					// `embedded` includes valid inference discarded for an incomplete memory;
+					// `inserted` counts only memories completed by this batch (also for dry-run).
+					return { checked, embedded, inserted, skipped };
+				}
 			}
+			await flushBatch();
+			if (signal?.aborted) return { checked, embedded, inserted, skipped };
 		}
 	} finally {
 		deleteBackfillCandidateSnapshot(db, candidateTable);


### PR DESCRIPTION
## Description

Batches pending backfill chunks across memories in inference groups of at most 32 while keeping writes atomic per memory. Abort completes the active inference group, writes only memories with complete output, and leaves partial memories unwritten for retry. `embedded` can exceed `inserted + skipped` after abort because it includes valid vectors discarded for an incomplete memory. Completes `codemem-jnd6.8.5`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm exec vitest run packages/core/src/vectors.test.ts packages/core/src/vector-migration.test.ts` (46 tests)
- [x] `pnpm --filter @codemem/core typecheck`
- [x] `pnpm exec biome check packages/core/src/vectors.ts packages/core/src/vectors.test.ts packages/core/src/vector-migration.test.ts`
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated in the design PR
- [x] No new warnings introduced