### PR TITLE
refactor(core): add embedding runtime factory contract

### DIFF
--- a/packages/core/src/embeddings.test.ts
+++ b/packages/core/src/embeddings.test.ts
@@ -6,15 +6,133 @@
  * in a separate test file gated on CODEMEM_EMBEDDING_DISABLED.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	_resetEmbeddingRuntimeFactory,
+	_setEmbeddingRuntimeFactory,
 	chunkText,
 	embeddingDataToFloat32,
 	embeddingTensorToFloat32Rows,
 	embedTextBatches,
+	getEmbeddingClient,
 	hashText,
+	resolveEmbeddingModel,
 	serializeFloat32,
 } from "./embeddings.js";
+
+function fakeClient(model = "test/model") {
+	return { model, dimensions: 384, embed: vi.fn(async () => []) };
+}
+
+describe("embedding runtime factory", () => {
+	const originalEmbeddingDisabled = process.env.CODEMEM_EMBEDDING_DISABLED;
+
+	beforeEach(() => {
+		delete process.env.CODEMEM_EMBEDDING_DISABLED;
+	});
+
+	afterEach(() => {
+		_resetEmbeddingRuntimeFactory();
+		if (originalEmbeddingDisabled === undefined) delete process.env.CODEMEM_EMBEDDING_DISABLED;
+		else process.env.CODEMEM_EMBEDDING_DISABLED = originalEmbeddingDisabled;
+	});
+
+	it("receives the resolved model request", async () => {
+		const client = fakeClient(resolveEmbeddingModel());
+		const factory = vi.fn(async () => client);
+		_setEmbeddingRuntimeFactory(factory);
+
+		await expect(getEmbeddingClient()).resolves.toBe(client);
+		expect(factory).toHaveBeenCalledWith({ model: resolveEmbeddingModel() });
+	});
+
+	it("reuses the singleton client", async () => {
+		const client = fakeClient();
+		const factory = vi.fn(async () => client);
+		_setEmbeddingRuntimeFactory(factory);
+
+		expect(await getEmbeddingClient()).toBe(client);
+		expect(await getEmbeddingClient()).toBe(client);
+		expect(factory).toHaveBeenCalledTimes(1);
+	});
+
+	it("resolves in-flight waiters through the current client after a factory swap", async () => {
+		let resolveFirst: ((client: ReturnType<typeof fakeClient>) => void) | undefined;
+		const firstFactory = vi.fn(
+			() =>
+				new Promise<ReturnType<typeof fakeClient>>((resolve) => {
+					resolveFirst = resolve;
+				}),
+		);
+		_setEmbeddingRuntimeFactory(firstFactory);
+		const first = getEmbeddingClient();
+		const shared = getEmbeddingClient();
+		expect(firstFactory).toHaveBeenCalledTimes(1);
+
+		// Use the resolved default identity so the upstack v4 runtime-identity
+		// assertion accepts the replacement client after this branch merges.
+		const replacementClient = fakeClient(resolveEmbeddingModel());
+		_setEmbeddingRuntimeFactory(vi.fn(async () => replacementClient));
+		expect(await getEmbeddingClient()).toBe(replacementClient);
+		// The stale creation completing must not hand its now-superseded client
+		// to earlier waiters; they resolve through the current generation.
+		resolveFirst?.(fakeClient("stale"));
+		await expect(first).resolves.toBe(replacementClient);
+		await expect(shared).resolves.toBe(replacementClient);
+		await expect(getEmbeddingClient()).resolves.toBe(replacementClient);
+	});
+
+	it("resolves stale waiters through the current client when a swapped-out creation fails", async () => {
+		let rejectFirst: ((error: Error) => void) | undefined;
+		_setEmbeddingRuntimeFactory(
+			vi.fn(
+				() =>
+					new Promise<ReturnType<typeof fakeClient>>((_resolve, reject) => {
+						rejectFirst = reject;
+					}),
+			),
+		);
+		const first = getEmbeddingClient();
+
+		// Use the resolved default identity so the upstack v4 runtime-identity
+		// assertion accepts the replacement client after this branch merges.
+		const replacementClient = fakeClient(resolveEmbeddingModel());
+		_setEmbeddingRuntimeFactory(vi.fn(async () => replacementClient));
+		expect(await getEmbeddingClient()).toBe(replacementClient);
+		rejectFirst?.(new Error("stale runtime unavailable"));
+		await expect(first).resolves.toBe(replacementClient);
+	});
+
+	it("returns null when the factory fails", async () => {
+		const factory = vi.fn(async () => {
+			throw new Error("runtime unavailable");
+		});
+		_setEmbeddingRuntimeFactory(factory);
+
+		await expect(getEmbeddingClient()).resolves.toBeNull();
+	});
+
+	it("does not call the factory when embeddings are disabled", async () => {
+		process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+		const factory = vi.fn(async () => fakeClient());
+		_setEmbeddingRuntimeFactory(factory);
+
+		await expect(getEmbeddingClient()).resolves.toBeNull();
+		expect(factory).not.toHaveBeenCalled();
+	});
+
+	it("clears the cached client when the runtime factory resets", async () => {
+		_setEmbeddingRuntimeFactory(vi.fn(async () => fakeClient("first")));
+		expect((await getEmbeddingClient())?.model).toBe("first");
+
+		_resetEmbeddingRuntimeFactory();
+		const replacement = vi.fn(async () => fakeClient("second"));
+		_setEmbeddingRuntimeFactory(replacement);
+
+		expect((await getEmbeddingClient())?.model).toBe("second");
+		expect(replacement).toHaveBeenCalledTimes(1);
+	});
+});
 
 describe("hashText", () => {
 	it("returns a 64-char hex SHA-256 digest", () => {

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -24,6 +24,14 @@ export interface EmbeddingClient {
 	embed(texts: string[]): Promise<Float32Array[]>;
 }
 
+export interface EmbeddingRuntimeRequest {
+	model: string;
+}
+
+export type EmbeddingRuntimeFactory = (
+	request: EmbeddingRuntimeRequest,
+) => Promise<EmbeddingClient | null>;
+
 interface EmbeddingTensor {
 	data: ArrayLike<number | bigint>;
 	dims?: number[];
@@ -200,10 +208,30 @@ export function chunkText(text: string, maxChars = 1200): string[] {
 // ---------------------------------------------------------------------------
 
 let _client: EmbeddingClient | null | undefined;
+let _clientPromise: Promise<EmbeddingClient | null> | undefined;
+let _clientGeneration = 0;
+
+const defaultEmbeddingRuntimeFactory: EmbeddingRuntimeFactory = ({ model }) =>
+	createTransformersClient(model);
+let embeddingRuntimeFactory = defaultEmbeddingRuntimeFactory;
 
 /** Reset the singleton (for tests). */
 export function _resetEmbeddingClient(): void {
 	_client = undefined;
+	_clientPromise = undefined;
+	_clientGeneration++;
+}
+
+/** Override the embedding runtime factory (for tests). */
+export function _setEmbeddingRuntimeFactory(factory: EmbeddingRuntimeFactory): void {
+	embeddingRuntimeFactory = factory;
+	_resetEmbeddingClient();
+}
+
+/** Restore the default embedding runtime factory (for tests). */
+export function _resetEmbeddingRuntimeFactory(): void {
+	embeddingRuntimeFactory = defaultEmbeddingRuntimeFactory;
+	_resetEmbeddingClient();
 }
 
 /** Return the configured embedding model label without loading the client. */
@@ -217,17 +245,39 @@ export function resolveEmbeddingModel(): string {
  */
 export async function getEmbeddingClient(): Promise<EmbeddingClient | null> {
 	if (_client !== undefined) return _client;
+	if (_clientPromise) return _clientPromise;
 	if (isEmbeddingDisabled()) {
 		_client = null;
 		return null;
 	}
 	const model = resolveEmbeddingModel();
-	try {
-		_client = await createTransformersClient(model);
-	} catch {
-		_client = null;
-	}
-	return _client;
+	const generation = _clientGeneration;
+	_clientPromise = (async () => {
+		try {
+			const client = await embeddingRuntimeFactory({ model });
+			if (generation === _clientGeneration) {
+				_client = client;
+				return client;
+			}
+			// The factory was swapped/reset while this creation was in flight.
+			// Returning this now-stale client would let waiters capture its
+			// model/dimensions while embedTexts() embeds through the replacement
+			// singleton — storing vectors under a stale label or failing the
+			// dimension guard. Resolve waiters through the current generation.
+			return getEmbeddingClient();
+		} catch {
+			if (generation === _clientGeneration) {
+				_client = null;
+				return null;
+			}
+			// A stale creation failed after a swap; defer to the live generation
+			// rather than forcing current waiters to a null result.
+			return getEmbeddingClient();
+		} finally {
+			if (generation === _clientGeneration) _clientPromise = undefined;
+		}
+	})();
+	return _clientPromise;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -316,9 +316,15 @@ export {
 	judgeDistillReport,
 	parseJudgeVerdict,
 } from "./distill-judge.js";
-export type { EmbeddingClient } from "./embeddings.js";
+export type {
+	EmbeddingClient,
+	EmbeddingRuntimeFactory,
+	EmbeddingRuntimeRequest,
+} from "./embeddings.js";
 export {
 	_resetEmbeddingClient,
+	_resetEmbeddingRuntimeFactory,
+	_setEmbeddingRuntimeFactory,
 	chunkText,
 	embedTexts,
 	getEmbeddingClient,


### PR DESCRIPTION
## Description

Adds a runtime-neutral embedding factory contract while retaining the current Xenova backend as the default. Factory changes clear cached and in-flight client state; concurrent callers share model creation, and stale factory completion cannot replace a newer cached client. Tracks `codemem-jnd6.8.3.1`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm exec vitest run packages/core/src/embeddings.test.ts` (29 tests)
- [x] `pnpm --filter @codemem/core typecheck`
- [x] `pnpm exec biome check packages/core/src/embeddings.ts packages/core/src/embeddings.test.ts packages/core/src/index.ts`
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated in the design PR
- [x] No new warnings introduced