### PR TITLE
feat(embeddings): add isolated Xenova runtime package

### DIFF
--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@codemem/embeddings",
+	"version": "0.43.2",
+	"private": true,
+	"type": "module",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist/"
+	],
+	"scripts": {
+		"clean": "rm -rf dist tsconfig.tsbuildinfo",
+		"build": "pnpm exec vite build && pnpm exec tsc --build --force",
+		"typecheck": "pnpm exec tsc --noEmit",
+		"test": "pnpm exec vitest run"
+	},
+	"dependencies": {
+		"@xenova/transformers": "^2.17.2"
+	},
+	"devDependencies": {
+		"typescript": "catalog:",
+		"vite": "catalog:",
+		"vitest": "catalog:"
+	}
+}

--- a/packages/embeddings/src/index.test.ts
+++ b/packages/embeddings/src/index.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const pipelineMock = vi.hoisted(() => vi.fn());
+vi.mock("@xenova/transformers", () => ({ pipeline: pipelineMock }));
+
+import { createEmbeddingRuntime } from "./index.js";
+
+const tensor = (
+	rows: number[][],
+	dims: number[] | undefined = [rows.length, rows[0]?.length ?? 0],
+) => ({ data: new Float64Array(rows.flat()), dims });
+
+describe("createEmbeddingRuntime", () => {
+	beforeEach(() => pipelineMock.mockReset());
+
+	it("uses full-precision feature extraction and probes dimensions", async () => {
+		const extractor = vi.fn().mockResolvedValue(tensor([[1, 2, 3]]));
+		pipelineMock.mockResolvedValueOnce(extractor);
+		const runtime = await createEmbeddingRuntime({ model: "test/model" });
+		expect(runtime.dimensions).toBe(3);
+		expect(extractor).toHaveBeenCalledWith(["probe"], {
+			pooling: "mean",
+			normalize: true,
+		});
+		expect(pipelineMock).toHaveBeenCalledWith("feature-extraction", "test/model", {
+			quantized: false,
+		});
+	});
+
+	it("batches at 32 while preserving order and returning owned fp32 rows", async () => {
+		const calls: string[][] = [];
+		const outputs: Float64Array[] = [];
+		const extractor = vi.fn(async (texts: string[]) => {
+			calls.push(texts);
+			const output =
+				texts[0] === "probe"
+					? tensor([[0, 0]])
+					: tensor(texts.map((text) => [Number(text), Number(text) + 0.5]));
+			outputs.push(output.data);
+			return output;
+		});
+		pipelineMock.mockResolvedValue(extractor);
+		const runtime = await createEmbeddingRuntime({ model: "test/model" });
+		const vectors = await runtime.embed(Array.from({ length: 65 }, (_, index) => String(index)));
+
+		expect(calls.slice(1).map((call) => call.length)).toEqual([32, 32, 1]);
+		expect(vectors.map((row) => [...row])).toEqual(
+			Array.from({ length: 65 }, (_, index) => [index, index + 0.5]),
+		);
+		const firstBuffer = vectors[0]?.buffer;
+		expect(vectors.every((row, index) => index === 0 || row.buffer !== firstBuffer)).toBe(true);
+		expect(vectors.every((row) => outputs.every((output) => row.buffer !== output.buffer))).toBe(
+			true,
+		);
+	});
+
+	it("does not invoke inference for empty input", async () => {
+		const extractor = vi.fn().mockResolvedValue(tensor([[0, 0]]));
+		pipelineMock.mockResolvedValue(extractor);
+		const runtime = await createEmbeddingRuntime({ model: "test/model" });
+		extractor.mockClear();
+
+		await expect(runtime.embed([])).resolves.toEqual([]);
+		expect(extractor).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ data: new Float32Array([1, 2]), dims: [2, 1] },
+		{ data: new Float32Array([1]), dims: [1, 2] },
+		{ data: new Float32Array(384), dims: undefined },
+		{ data: new Float32Array([1, Number.NaN]), dims: [1, 2] },
+	])("rejects malformed tensors", async (probe) => {
+		pipelineMock.mockResolvedValue(vi.fn().mockResolvedValue(probe));
+		await expect(createEmbeddingRuntime({ model: "bad/model" })).rejects.toThrow(TypeError);
+	});
+
+	it.each([
+		{ data: new Float32Array([1]), dims: [1, 1] },
+		{ data: new Float32Array([1, 2]), dims: undefined },
+		{ data: new Float32Array([1, Number.NaN]), dims: [1, 2] },
+	])("rejects malformed inference tensors", async (output) => {
+		const extractor = vi
+			.fn()
+			.mockResolvedValueOnce(tensor([[0, 0]]))
+			.mockResolvedValueOnce(output);
+		pipelineMock.mockResolvedValue(extractor);
+		const runtime = await createEmbeddingRuntime({ model: "bad/model" });
+
+		await expect(runtime.embed(["text"])).rejects.toThrow(TypeError);
+	});
+});

--- a/packages/embeddings/src/index.ts
+++ b/packages/embeddings/src/index.ts
@@ -1,0 +1,75 @@
+export interface EmbeddingRuntimeRequest {
+	model: string;
+}
+
+export interface EmbeddingClient {
+	readonly model: string;
+	readonly dimensions: number;
+	embed(texts: string[]): Promise<Float32Array[]>;
+}
+
+export type EmbeddingRuntimeFactory = (
+	request: EmbeddingRuntimeRequest,
+) => Promise<EmbeddingClient | null>;
+
+interface Tensor {
+	data: ArrayLike<number | bigint>;
+	dims?: number[];
+}
+
+type Extractor = (
+	texts: string[],
+	options: { pooling: "mean"; normalize: true },
+) => Promise<Tensor>;
+
+function rows(output: Tensor, count: number, dimensions: number): Float32Array[] {
+	if (
+		output.dims?.length !== 2 ||
+		(output.dims?.length === 2 && (output.dims[0] !== count || output.dims[1] !== dimensions)) ||
+		output.data.length !== count * dimensions
+	) {
+		throw new TypeError("Embedding model returned an invalid tensor shape or value count");
+	}
+	const result = Array.from({ length: count }, () => new Float32Array(dimensions));
+	for (let index = 0; index < output.data.length; index++) {
+		const value = output.data[index];
+		const number = typeof value === "number" ? Math.fround(value) : Number.NaN;
+		if (!Number.isFinite(number)) {
+			throw new TypeError(`Embedding model returned non-finite data at index ${index}`);
+		}
+		const row = result[Math.floor(index / dimensions)];
+		if (!row) throw new TypeError("Embedding model returned an invalid tensor row");
+		row[index % dimensions] = number;
+	}
+	return result;
+}
+
+export async function createEmbeddingRuntime({
+	model,
+}: EmbeddingRuntimeRequest): Promise<EmbeddingClient> {
+	const { pipeline } = await import("@xenova/transformers");
+	// Runtime validation below guards the structural boundary hidden by upstream's broad pipeline type.
+	const extractor = (await pipeline("feature-extraction", model, {
+		quantized: false,
+	})) as unknown as Extractor;
+	const options = { pooling: "mean", normalize: true } as const;
+	const probe = await extractor(["probe"], options);
+	const dimensions = probe.dims?.at(-1);
+	if (typeof dimensions !== "number" || !Number.isInteger(dimensions) || dimensions <= 0) {
+		throw new TypeError("Embedding model returned invalid dimensions");
+	}
+	rows(probe, 1, dimensions);
+
+	return {
+		model,
+		dimensions,
+		async embed(texts) {
+			const result: Float32Array[] = [];
+			for (let offset = 0; offset < texts.length; offset += 32) {
+				const batch = texts.slice(offset, offset + 32);
+				result.push(...rows(await extractor(batch, options), batch.length, dimensions));
+			}
+			return result;
+		},
+	};
+}

--- a/packages/embeddings/tsconfig.json
+++ b/packages/embeddings/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"declaration": true,
+		"emitDeclarationOnly": true
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/packages/embeddings/vite.config.ts
+++ b/packages/embeddings/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	build: {
+		lib: { entry: "src/index.ts", formats: ["es"], fileName: "index" },
+		rollupOptions: { external: ["@xenova/transformers", /^node:/] },
+		outDir: "dist",
+		sourcemap: true,
+		emptyOutDir: true,
+	},
+	test: { name: "embeddings", include: ["src/**/*.test.ts"] },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,22 @@ importers:
         specifier: 'catalog:'
         version: 4.1.11(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.13)(yaml@2.9.0))
 
+  packages/embeddings:
+    dependencies:
+      '@xenova/transformers':
+        specifier: ^2.17.2
+        version: 2.17.2
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: 'catalog:'
+        version: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.13)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.11(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.13)(yaml@2.9.0))
+
   packages/mcp-server:
     dependencies:
       '@codemem/core':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"files": [],
 	"references": [
 		{ "path": "packages/core" },
+		{ "path": "packages/embeddings" },
 		{ "path": "packages/cloudflare-coordinator-worker" },
 		{ "path": "packages/mcp-server" },
 		{ "path": "packages/opencode-plugin" },


### PR DESCRIPTION
## Description

Adds a private `@codemem/embeddings` workspace package that owns the Xenova runtime and implements the structural factory contract without depending on another Codemem package. It preserves fp32 BGE extraction, validates tensor output, and limits extractor calls to 32 texts. Core consumption and publishing remain separate PRs. Tracks `codemem-jnd6.8.3.2`.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @codemem/embeddings test` (9 tests)
- [x] `pnpm --filter @codemem/embeddings typecheck`
- [x] `pnpm --filter @codemem/embeddings build`
- [x] `pnpm run tsc`
- [x] Biome check for all touched source/config files
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated in the design PR
- [x] No new warnings introduced