### PR TITLE
chore(release): publish embedding runtime package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,12 +163,13 @@ jobs:
             pnpm --filter "${filter}" publish --tag "${DIST_TAG}" --provenance --access public --no-git-checks
           }
           # pnpm publish resolves workspace:^ to actual version ranges.
-          # Publish in dependency order: core → mcp, server → cli → opencode-plugin.
+          # Publish existing dependency order first; embeddings has no consumers yet.
           publish_if_missing "@codemem/core" "packages/core"
           publish_if_missing "@codemem/mcp" "packages/mcp-server"
           publish_if_missing "@codemem/server" "packages/viewer-server"
           publish_if_missing "codemem" "packages/cli"
           publish_if_missing "@codemem/opencode-plugin" "packages/opencode-plugin"
+          publish_if_missing "@codemem/embeddings" "packages/embeddings"
 
   release:
     name: Create GitHub Release

--- a/docs/trusted-publisher.md
+++ b/docs/trusted-publisher.md
@@ -18,6 +18,14 @@ Trusted publishing must be configured for every package the workflow publishes:
 - `@codemem/server`
 - `codemem`
 - `@codemem/opencode-plugin`
+- `@codemem/embeddings`
+
+Before the first tagged release that includes a new npm package, publish a
+distinct bootstrap prerelease such as `0.0.0-alpha.0` with authenticated
+maintainer credentials and a non-latest dist-tag such as `bootstrap`. Do not use
+the intended release version for this bootstrap. Then configure the trusted
+publisher above; npm requires the package to exist first. Do not use a release
+tag until this setup is complete.
 
 ## GitHub workflow behavior
 
@@ -36,6 +44,7 @@ dependency order:
 3. `@codemem/server`
 4. `codemem`
 5. `@codemem/opencode-plugin`
+6. `@codemem/embeddings`
 
 Publish command shape:
 
@@ -72,7 +81,7 @@ on one package), use the `workflow_dispatch` path instead of retagging:
 ## Verification checklist
 
 - Tag push `vX.Y.Z` runs `Release` and `publish-npm` succeeds
-- All five package versions on npm match the release tag
+- All six package versions on npm match the release tag
 - npm provenance attestation is present for published artifacts
 - For recovery: `workflow_dispatch` rerun completes with `skip:` lines for
   packages already at the tag's version and `publish:` lines for any that

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -18,6 +18,7 @@ CodeMem uses one shared semantic version stream across its npm packages.
 Version bumps are prepared on a release branch and touch these files:
 
 - `packages/core/package.json` (`version`)
+- `packages/embeddings/package.json` (`version`)
 - `packages/cli/package.json` (`version`)
 - `packages/opencode-plugin/package.json` (`version`)
 - `packages/mcp-server/package.json` (`version`)

--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@codemem/embeddings",
 	"version": "0.43.2",
-	"private": true,
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {
@@ -27,5 +26,17 @@
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kunickiaj/codemem.git",
+		"directory": "packages/embeddings"
+	},
+	"engines": {
+		"node": ">=24.15.0"
+	},
+	"license": "MIT",
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -12,6 +12,7 @@ const CORE_TEST_VERSION_RE = /^(\s*expect\(VERSION\)\.toBe\(")([^"]+)("\);\s*)$/
 const PLUGIN_PIN_RE = /^(const\s+PINNED_BACKEND_VERSION\s*=\s*")([^"]+)(";\s*)$/m;
 const REQUIRED_REPO_MARKERS = [
 	"packages/core/package.json",
+	"packages/embeddings/package.json",
 	"packages/cli/package.json",
 	"packages/opencode-plugin/package.json",
 	"packages/mcp-server/package.json",
@@ -166,6 +167,7 @@ export function readVersions(root) {
 
 	return {
 		core_package: extractPackageVersion(repoRoot, "packages/core/package.json"),
+		embeddings_package: extractPackageVersion(repoRoot, "packages/embeddings/package.json"),
 		cli_package: extractPackageVersion(repoRoot, "packages/cli/package.json"),
 		opencode_plugin_package: extractPackageVersion(repoRoot, "packages/opencode-plugin/package.json"),
 		mcp_server_package: extractPackageVersion(repoRoot, "packages/mcp-server/package.json"),
@@ -229,6 +231,7 @@ export function setVersion(root, version, { dryRun = false } = {}) {
 	const writes = new Map();
 
 	setPackageVersion(repoRoot, "packages/core/package.json", version, writes, changed);
+	setPackageVersion(repoRoot, "packages/embeddings/package.json", version, writes, changed);
 	setPackageVersion(repoRoot, "packages/cli/package.json", version, writes, changed);
 	setPackageVersion(repoRoot, "packages/opencode-plugin/package.json", version, writes, changed);
 	setPackageVersion(repoRoot, "packages/mcp-server/package.json", version, writes, changed);

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -20,6 +20,10 @@ function makeRepo(version = "0.16.0") {
 \t"version": "${version}"
 }
 `);
+	write(join(root, "packages/embeddings/package.json"), `{
+	"version": "${version}"
+}
+`);
 	write(join(root, "packages/cli/package.json"), `{
 \t"version": "${version}"
 }
@@ -137,6 +141,7 @@ describe("release-version script", () => {
 			"packages/core/package.json",
 			"packages/core/src/index.test.ts",
 			"packages/core/src/index.ts",
+			"packages/embeddings/package.json",
 			"packages/mcp-server/package.json",
 			"packages/opencode-plugin/.opencode/plugins/codemem.js",
 			"packages/opencode-plugin/package.json",
@@ -150,7 +155,7 @@ describe("release-version script", () => {
 	it("supports dry run without writing", () => {
 		const root = makeRepo("1.0.0");
 		const changed = setVersion(root, "1.0.1", { dryRun: true });
-		assert.equal(changed.length, 12);
+		assert.equal(changed.length, 13);
 		assert.deepEqual(new Set(Object.values(readVersions(root))), new Set(["1.0.0"]));
 	});
 


### PR DESCRIPTION
## Description

Makes `@codemem/embeddings` publishable, adds it to release-version alignment, and publishes it after the five existing packages while it has no consumers. The trusted-publisher runbook now requires a distinct bootstrap prerelease before the first tagged release. Tracks `codemem-jnd6.8.3.3`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm run test:release-version` (11 tests)
- [x] `pnpm run release:version -- check`
- [x] `pnpm install --frozen-lockfile`
- [x] Biome check for the package manifest
- [x] Added/updated tests for changes
- [x] Manually verified workflow order and packed package contents

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced

## Release gate

Before the first tagged release, publish a distinct bootstrap prerelease under a non-latest dist-tag and configure npm trusted publishing for `@codemem/embeddings` as documented in `docs/trusted-publisher.md`.