### PR TITLE
test(worker): guard embedding runtime imports

### DIFF
--- a/packages/cloudflare-coordinator-worker/package.json
+++ b/packages/cloudflare-coordinator-worker/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"clean": "rm -rf dist tsconfig.tsbuildinfo",
 		"build": "pnpm exec vite build && pnpm run check:bundle && pnpm exec tsc --build",
-		"check:bundle": "pnpm --filter @codemem/core build && node --test scripts/assert-worker-bundle-clean.test.mjs && rm -rf ../../.tmp/cloudflare-coordinator-worker-bundle && pnpm exec wrangler deploy --dry-run --config wrangler.jsonc --outdir ../../.tmp/cloudflare-coordinator-worker-bundle && node scripts/assert-worker-bundle-clean.mjs ../../.tmp/cloudflare-coordinator-worker-bundle",
+		"check:bundle": "pnpm --filter @codemem/core build && node --test scripts/assert-worker-bundle-clean.test.mjs && rm -rf ../../.tmp/cloudflare-coordinator-worker-bundle && pnpm exec wrangler deploy --dry-run --config wrangler.jsonc --outdir ../../.tmp/cloudflare-coordinator-worker-bundle --metafile ../../.tmp/cloudflare-coordinator-worker-bundle/meta.json && node scripts/assert-worker-bundle-clean.mjs ../../.tmp/cloudflare-coordinator-worker-bundle ../../.tmp/cloudflare-coordinator-worker-bundle/meta.json",
 		"typecheck": "pnpm exec tsc --build",
 		"test:node": "pnpm exec vitest run --config vitest.node.config.ts src/index.test.ts",
 		"test:worker": "pnpm run check:bundle && pnpm run test:node && pnpm exec vitest run --config vitest.config.ts test/worker.integration.test.ts"

--- a/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.mjs
+++ b/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.mjs
@@ -11,11 +11,16 @@ const BARE_NODE_IMPORTS = new Set(
 const FORBIDDEN_IMPORTS = [
 	// Bundled npm packages are listed as intent and are also caught by the
 	// default-deny node:* rule when they pull unsupported builtins into the Worker.
+	"@codemem/embeddings",
 	"@xenova/transformers",
 	"better-sqlite3",
 	"bonjour-service",
 	"sqlite-vec",
 ];
+// Add every forbidden package that is linked from this workspace rather than node_modules.
+const FORBIDDEN_WORKSPACE_PATHS = new Map([
+	["@codemem/embeddings", ["/../embeddings/", "/packages/embeddings/"]],
+]);
 
 function isForbiddenImport(specifier) {
 	const normalizedNodeImport = specifier.startsWith("node:")
@@ -45,6 +50,42 @@ export function findForbiddenWorkerImports(source) {
 	return [...specifiers].filter(isForbiddenImport).toSorted();
 }
 
+function packageNameFromModulePath(modulePath) {
+	const normalizedPath = `/${modulePath.replaceAll("\\", "/")}`;
+	return FORBIDDEN_IMPORTS.find(
+		(forbidden) =>
+			normalizedPath.includes(`/node_modules/${forbidden}/`) ||
+			normalizedPath.endsWith(`/node_modules/${forbidden}`) ||
+			FORBIDDEN_WORKSPACE_PATHS.get(forbidden)?.some((workspacePath) =>
+				normalizedPath.includes(workspacePath),
+			),
+	);
+}
+
+export function findForbiddenWorkerMetafileModules(metafile) {
+	const forbiddenModules = new Set();
+	for (const [modulePath, metadata] of Object.entries(metafile?.inputs ?? {})) {
+		const packageName = packageNameFromModulePath(modulePath);
+		if (packageName) forbiddenModules.add(packageName);
+		if (!metadata || typeof metadata !== "object") {
+			throw new TypeError(`Worker bundle metafile has invalid entry for: ${modulePath}`);
+		}
+		if (!Array.isArray(metadata.imports)) {
+			throw new TypeError(`Worker bundle metafile has invalid imports for: ${modulePath}`);
+		}
+		for (const imported of metadata.imports) {
+			if (!imported || typeof imported !== "object") continue;
+			for (const specifier of [imported.original, imported.path]) {
+				if (typeof specifier !== "string") continue;
+				const importedPackage = packageNameFromModulePath(specifier);
+				if (importedPackage) forbiddenModules.add(importedPackage);
+				else if (isForbiddenImport(specifier)) forbiddenModules.add(specifier);
+			}
+		}
+	}
+	return [...forbiddenModules].toSorted();
+}
+
 export async function assertWorkerBundleClean(bundlePath) {
 	const source = await readFile(bundlePath, "utf8");
 	const forbiddenImports = findForbiddenWorkerImports(source);
@@ -71,9 +112,33 @@ export async function assertWorkerBundleOutputClean(bundlePath) {
 	for (const file of files) await assertWorkerBundleClean(file);
 }
 
+export async function assertWorkerBundleMetafileClean(metafilePath) {
+	const metafile = JSON.parse(await readFile(metafilePath, "utf8"));
+	if (
+		!metafile?.inputs ||
+		typeof metafile.inputs !== "object" ||
+		Array.isArray(metafile.inputs) ||
+		Object.keys(metafile.inputs).length === 0
+	) {
+		throw new Error(`Worker bundle metafile has no inputs: ${metafilePath}`);
+	}
+	const forbiddenModules = findForbiddenWorkerMetafileModules(metafile);
+	if (forbiddenModules.length > 0) {
+		throw new Error(
+			`Worker bundle graph contains forbidden modules: ${forbiddenModules.join(", ")}`,
+		);
+	}
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
 	const bundlePath = process.argv[2];
-	if (!bundlePath) throw new Error("Usage: node assert-worker-bundle-clean.mjs <bundle-path>");
+	const metafilePath = process.argv[3];
+	if (!bundlePath || !metafilePath) {
+		throw new Error(
+			"Usage: node assert-worker-bundle-clean.mjs <bundle-path> <metafile-path>",
+		);
+	}
 	await assertWorkerBundleOutputClean(bundlePath);
+	await assertWorkerBundleMetafileClean(metafilePath);
 	console.log(`Worker bundle import check passed: ${bundlePath}`);
 }

--- a/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.test.mjs
+++ b/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.test.mjs
@@ -4,8 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+	assertWorkerBundleMetafileClean,
 	assertWorkerBundleOutputClean,
 	findForbiddenWorkerImports,
+	findForbiddenWorkerMetafileModules,
 } from "./assert-worker-bundle-clean.mjs";
 
 test("allows Worker-compatible imports", () => {
@@ -16,6 +18,8 @@ test("allows Worker-compatible imports", () => {
 test("rejects static, dynamic, and generated require imports of forbidden modules", () => {
 	const source = [
 		'import { createRequire } from "node:module";',
+		'import "@codemem/embeddings";',
+		'import "@xenova/transformers";',
 		'await import("bonjour-service");',
 		'const Database = require("better-sqlite3");',
 		'const fs = __require("node:fs");',
@@ -24,6 +28,8 @@ test("rejects static, dynamic, and generated require imports of forbidden module
 		'import "os";',
 	].join("\n");
 	assert.deepEqual(findForbiddenWorkerImports(source), [
+		"@codemem/embeddings",
+		"@xenova/transformers",
 		"better-sqlite3",
 		"bonjour-service",
 		"fs",
@@ -42,6 +48,67 @@ test("allows only the Node imports used by the Worker bundle", () => {
 		'import "path";',
 	].join("\n");
 	assert.deepEqual(findForbiddenWorkerImports(source), []);
+});
+
+test("rejects forbidden packages after the bundler resolves their import specifiers", () => {
+	const metafile = {
+		inputs: {
+			"../embeddings/src/index.ts": {
+				bytes: 100,
+				imports: [],
+			},
+			"../core/src/embeddings.ts": {
+				bytes: 100,
+				imports: [
+					{
+						path: "../../node_modules/.pnpm/@xenova+transformers@2.17.2/node_modules/@xenova/transformers/src/transformers.js",
+						original: "@xenova/transformers",
+					},
+				],
+			},
+			"node_modules/@xenova/transformers/src/env.js": {
+				bytes: 100,
+				imports: [],
+			},
+		},
+	};
+	assert.deepEqual(findForbiddenWorkerMetafileModules(metafile), [
+		"@codemem/embeddings",
+		"@xenova/transformers",
+	]);
+});
+
+test("allows a clean metafile", () => {
+	const metafile = {
+		inputs: {
+			"../core/src/index.ts": { bytes: 100, imports: [] },
+		},
+	};
+	assert.deepEqual(findForbiddenWorkerMetafileModules(metafile), []);
+});
+
+test("rejects an empty bundle metafile", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "codemem-worker-metafile-empty-"));
+	try {
+		const metafilePath = join(directory, "meta.json");
+		await writeFile(metafilePath, "{}");
+		await assert.rejects(
+			assertWorkerBundleMetafileClean(metafilePath),
+			/Worker bundle metafile has no inputs:/u,
+		);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("rejects malformed bundle metafile imports", () => {
+	assert.throws(
+		() =>
+			findForbiddenWorkerMetafileModules({
+				inputs: { "../core/src/index.ts": { imports: {} } },
+			}),
+		/Worker bundle metafile has invalid imports for: \.\.\/core\/src\/index\.ts/u,
+	);
 });
 
 test("checks every JavaScript chunk in the bundle output", async () => {


### PR DESCRIPTION
## Description

Extends the Cloudflare Worker bundle deny check to reject the new `@codemem/embeddings` boundary while retaining the transitive Xenova guard. Tracks `codemem-jnd6.8.3.5`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm --filter @codemem/cloudflare-coordinator-worker test:worker`
- [x] Worker dry-run bundle import check
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated in the stack design
- [x] No new warnings introduced