### PR TITLE
chore(release): publish embeddings before core

### DIFF
--- a/docs/trusted-publisher.md
+++ b/docs/trusted-publisher.md
@@ -13,12 +13,12 @@ Use npm trusted publishing for this GitHub repo:
 
 Trusted publishing must be configured for every package the workflow publishes:
 
+- `@codemem/embeddings`
 - `@codemem/core`
 - `@codemem/mcp`
 - `@codemem/server`
 - `codemem`
 - `@codemem/opencode-plugin`
-- `@codemem/embeddings`
 
 Before the first tagged release that includes a new npm package, publish a
 distinct bootstrap prerelease such as `0.0.0-alpha.0` with authenticated


### PR DESCRIPTION
## Description

Moves `@codemem/embeddings` ahead of `@codemem/core` in npm publication order now that core declares it as an optional peer. Keeps the trusted-publisher runbook order aligned and preserves the bootstrap-before-tag gate. Tracks `codemem-jnd6.8.3.6`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm run test:release-version` (11 tests, downstack behavior unchanged)
- [x] Manually verified workflow and runbook order match

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced

## Release gate

The documented npm bootstrap and trusted-publisher setup for `@codemem/embeddings` must complete before the first tagged release.