### PR TITLE
docs: explain optional embedding runtime install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,49 @@ npx -y codemem db raw-events-status
 
 That's it. The plugin captures activity, builds memories, and injects context from here on.
 
-If you want `codemem` available directly on your `PATH` for manual commands and semantic retrieval, install the CLI and embedding runtime globally:
+If you want `codemem` available directly on your `PATH` for manual commands and semantic retrieval, install the CLI and embedding runtime globally. The command differs by platform:
+
+On Linux, skip the unused ONNX Runtime GPU provider download:
+
+```text
+env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings
+```
+
+On macOS and Windows:
 
 ```text
 npm install -g codemem @codemem/embeddings
 ```
 
+Installing only `codemem` keeps the CLI functional with FTS5 keyword retrieval
+and does not download the embedding runtime.
+
+Setup-managed `npx` launchers cannot set a platform-specific install variable.
+On Linux, either use the guarded global installation above or set
+`ONNXRUNTIME_NODE_INSTALL=skip` in the environment that launches OpenCode,
+Claude Code, or Codex before its first `npx` package resolution. This prevents
+the unused ONNX Runtime GPU-provider download while retaining CPU inference.
+
+After upgrading an existing installation, rerun `codemem setup` (or the
+app-specific `--opencode-only`, `--claude-only`, or `--codex-only` form).
+Setup replaces the old managed `npx -y codemem mcp` launcher and codemem MCP
+entries detected as UV/UVX-based so both packages share one runtime. Other
+custom MCP commands remain unchanged.
+
+Generated MCP configurations use the durable global `codemem` binary when it is
+available. Without a global install, setup-managed `npx` launchers request both
+packages in the same temporary environment. After changing the installation,
+restart the host whose config you updated — OpenCode, Claude Code, or Codex —
+plus any running `codemem serve` process. Each MCP process caches runtime
+availability for its lifetime, so a still-running Claude or Codex MCP host keeps
+lexical-only recall until it restarts; restarting `codemem serve` alone does not
+restart that MCP child.
+
 OpenCode plugin and CLI are now split intentionally:
 
 - `@codemem/opencode-plugin` — OpenCode plugin package
 - `codemem` — CLI and MCP commands
+- `@codemem/embeddings` — optional semantic embedding runtime
 
 ### Claude Code (marketplace install)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,7 @@ It does not currently gate sync or retrieval. See `docs/plans/2026-03-08-shared-
 
 ### Semantic search (sqlite-vec)
 
-When embeddings are available, `memory_vectors` (a `vec0` virtual table from sqlite-vec) stores 384-dimensional float vectors keyed by `memory_id`. Vectors are written automatically when memories are created, or backfilled with `codemem embed`.
+When the optional `@codemem/embeddings` runtime is installed, `memory_vectors` (a `vec0` virtual table from sqlite-vec) stores 384-dimensional float vectors keyed by `memory_id`. Vectors are written automatically when memories are created, or backfilled with `codemem embed`. Lexical-only installs omit Transformers and ONNX Runtime.
 
 Semantic search embeds the query text, then runs a nearest-neighbor lookup against `memory_vectors`. Distance is converted to a similarity score: `1.0 / (1.0 + distance)`.
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -185,7 +185,7 @@ codex plugin marketplace upgrade
 codex plugin remove codemem@codemem
 ```
 
-The plugin bundles `.mcp.json` (a paired `npx` launcher for `codemem` and `@codemem/embeddings`), `hooks/hooks.json`, and a dependency-free generated normalizer. Ingest wrappers use Viewer HTTP without child processes when healthy; `codemem` and pinned `npx` are fallback-only. Generated files come from the TypeScript normalizers in `packages/core/src/` via `node scripts/build-adapter-normalizers.mjs` and are protected by a byte-drift test. Validated targets: Codex CLI 0.135+ and current Desktop builds.
+The plugin bundles `.mcp.json`, `hooks/hooks.json`, and a dependency-free generated normalizer. Its MCP `npx` launcher requests both `codemem` and `@codemem/embeddings` in the same temporary environment so the optional runtime is resolvable. Ingest wrappers use Viewer HTTP without child processes when healthy; `codemem` and pinned `npx` are fallback-only. Generated files come from the TypeScript normalizers in `packages/core/src/` via `node scripts/build-adapter-normalizers.mjs` and are protected by a byte-drift test. Validated targets: Codex CLI 0.135+ and current Desktop builds.
 
 ### Plugin-free install (`codemem setup --codex-only`)
 
@@ -197,7 +197,7 @@ npx -y codemem setup --codex-only   # or, with a global install: codemem setup -
 
 What it does (idempotent; honors `CODEX_HOME`; backs up existing files; `--force` to refresh):
 
-- **MCP:** appends `[mcp_servers.codemem]` with an `npx` command that requests both `codemem` and `@codemem/embeddings` before launching `codemem mcp`. The file is never reparsed or reformatted — only appended — so comments and unrelated servers (including secrets) are preserved.
+- **MCP:** appends `[mcp_servers.codemem]` to `<CODEX_HOME>/config.toml` if not already present. It uses a durable global `codemem mcp` command when available; otherwise its `npx` command requests both `codemem` and `@codemem/embeddings` before launching `codemem mcp`. Setup upgrades the exact older managed `npx -y codemem mcp` table but leaves custom launchers untouched. The file is never reparsed or reformatted: setup either appends the table or replaces only the managed `command` and `args` lines, preserving comments and unrelated servers (including secrets).
 - **Hooks:** merges `SessionStart`, `UserPromptSubmit` (ingest + inject), `PostToolUse`, and `Stop` into `<CODEX_HOME>/hooks.json`, preserving any unrelated user hooks. Hook commands resolve to a direct `codemem codex-hook-*` call when `codemem` is on `PATH`; otherwise their `npx` fallback requests both packages before invoking the hook command. Prompt injection validates the loopback Viewer profile and retrieves with `POST /api/pack` first, using the local database only for classified compatibility fallback.
 
 Hooks loaded from the user config layer require a one-time trust approval in Codex (you'll be prompted on first run; MCP recall needs no trust). Codex setup also runs automatically in a plain `codemem setup` when a Codex home (`~/.codex` or `$CODEX_HOME`) is detected.
@@ -466,8 +466,8 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 
 When the plugin detects CLI/runtime version mismatch, it shows guidance based on runner mode:
 
-- `CODEMEM_RUNNER=codemem`: install matching `codemem` and `@codemem/embeddings` versions, then restart OpenCode
-- `CODEMEM_RUNNER=npx`: set `CODEMEM_RUNNER_FROM` to the desired `codemem@<version>` spec; the plugin pairs the matching `@codemem/embeddings` version automatically. Then restart OpenCode (or reinstall the plugin instead).
+- `CODEMEM_RUNNER=codemem`: run `npm install -g codemem @codemem/embeddings` (the optional runtime enables semantic recall), then restart OpenCode. On Linux, prefix with `ONNXRUNTIME_NODE_INSTALL=skip` to avoid downloading the unused GPU provider (see the semantic-runtime install notes).
+- `CODEMEM_RUNNER=npx`: the compatibility warning recommends moving to a global install. Install `codemem` and `@codemem/embeddings` globally, clear explicit `CODEMEM_RUNNER` and `CODEMEM_RUNNER_FROM` overrides so the plugin detects that install, then restart OpenCode. To keep using npx instead, update `CODEMEM_RUNNER_FROM` to the desired `codemem@<version>` spec; the plugin pairs the matching `@codemem/embeddings` version automatically. On Linux, see the CPU-only semantic-runtime install notes in the README.
 - `CODEMEM_RUNNER=node`: pull latest repo changes and run `pnpm build`, then restart OpenCode
 - custom/unknown runner: update the underlying `codemem` binary or package source, then restart OpenCode
 

--- a/docs/remote-mcp-oauth.md
+++ b/docs/remote-mcp-oauth.md
@@ -40,7 +40,10 @@ The viewer process and `codemem mcp http` process must run on different ports. O
 
 ## Prerequisites
 
-- Node.js 24.15+ and pnpm or both runtime packages installed globally (`npm install -g codemem @codemem/embeddings`). Omitting `@codemem/embeddings` intentionally limits retrieval to keyword search.
+- Node.js 24.15+ and pnpm.
+- On Linux, install both runtime packages with the CPU-only policy: `env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings`.
+- On macOS and Windows, install both runtime packages with `npm install -g codemem @codemem/embeddings`.
+- Omit `@codemem/embeddings` only when keyword-only retrieval is intentional.
 - The host already runs codemem as a peer with the user's memories synced locally.
 - An HTTPS-terminating public ingress such as Tailscale Funnel, Cloudflare Tunnel, or a reverse proxy that preserves the configured Host header.
 - An upstream OIDC provider the operator already uses (Google, GitHub via OIDC bridge, Anthropic SSO if available). The OIDC client must allow the `<MCP base URL>/oauth/callback` redirect URI.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -472,6 +472,37 @@ When selected history may already have replicated, all participating owner devic
 - Check `~/.codemem/plugin.log` for plugin errors.
 - Sync errors: `codemem sync status` shows the last error per peer.
 
+### Semantic runtime unavailable
+
+Codemem defaults to FTS5 keyword retrieval when the optional embedding runtime
+is absent. Install both packages globally to enable semantic recall. On Linux,
+set the CPU-only policy so the installer skips the unused GPU provider:
+
+```fish
+env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings
+```
+
+On macOS and Windows, install both packages normally:
+
+```text
+npm install -g codemem @codemem/embeddings
+```
+
+Rerun `codemem setup` after upgrading an existing installation. The scoped
+`--opencode-only`, `--claude-only`, and `--codex-only` forms work too. Setup
+replaces the old managed `npx -y codemem mcp` launcher and codemem MCP entries
+detected as UV/UVX-based so both packages resolve in one runtime. Other custom
+MCP commands remain unchanged.
+
+Generated MCP configurations use the durable global `codemem` binary when it is
+available, allowing it to resolve the globally installed sibling package.
+Setup-managed `npx` launchers instead request `codemem` and
+`@codemem/embeddings` together in one temporary environment. After installation,
+restart the host you configured — OpenCode, Claude Code, or Codex — plus any
+running `codemem serve` process. Each MCP process checks runtime availability
+once per lifetime, so a running Claude or Codex MCP host stays lexical-only until
+it restarts; restarting `codemem serve` alone does not restart that MCP child.
+
 ### sqlite-vec / `no such module: vec0`
 
 **Symptom:** API errors with `SqliteError: no such module: vec0`, or the viewer logs `sqlite-vec failed to load; retrying viewer startup with embeddings disabled` at startup.


### PR DESCRIPTION
## Description

Documents the lexical-only default install and the explicit `@codemem/embeddings` opt-in for semantic retrieval. Separates a missing runtime from sqlite-vec native-extension troubleshooting. Tracks `codemem-jnd6.8.3.7`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `git diff --check`
- [x] Documentation specialist review
- [x] Manually verified commands are fish-compatible

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced