### PR TITLE
test(cli): validate packed optional embedding installs

### DIFF
--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -569,6 +569,15 @@ try {
 		.map((line) => line.trim())
 		.filter(Boolean)
 		.at(-1);
+	const embeddingsTarball = run(
+		"pnpm",
+		["pack", "--pack-destination", tempDir],
+		resolve(workspaceRoot, "packages/embeddings"),
+	)
+		.stdout.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.at(-1);
 	const mcpTarball = run("pnpm", ["pack", "--pack-destination", tempDir], resolve(workspaceRoot, "packages/mcp-server"))
 		.stdout.split(/\r?\n/)
 		.map((line) => line.trim())
@@ -587,10 +596,12 @@ try {
 		.at(-1);
 
 	assert(Boolean(coreTarball), "pnpm pack did not report a core tarball path");
+	assert(Boolean(embeddingsTarball), "pnpm pack did not report an embeddings tarball path");
 	assert(Boolean(mcpTarball), "pnpm pack did not report an mcp tarball path");
 	assert(Boolean(serverTarball), "pnpm pack did not report a server tarball path");
 	assert(Boolean(packedTarball), "pnpm pack did not report a tarball path");
 	assert(existsSync(coreTarball), `Packed core tarball not found: ${coreTarball}`);
+	assert(existsSync(embeddingsTarball), `Packed embeddings tarball not found: ${embeddingsTarball}`);
 	assert(existsSync(mcpTarball), `Packed mcp tarball not found: ${mcpTarball}`);
 	assert(existsSync(serverTarball), `Packed server tarball not found: ${serverTarball}`);
 	assert(existsSync(packedTarball), `Packed tarball not found: ${packedTarball}`);
@@ -598,9 +609,45 @@ try {
 	const tarListing = run("tar", ["-tf", packedTarball]).stdout;
 	assert(tarListing.includes("package/dist/index.js"), "Packed artifact is missing dist/index.js");
 	assert(tarListing.includes("package/README.md"), "Packed artifact is missing README.md");
+	const embeddingsTarListing = run("tar", ["-tf", embeddingsTarball]).stdout;
+	assert(
+		embeddingsTarListing.includes("package/dist/index.js"),
+		"Packed embeddings artifact is missing dist/index.js",
+	);
 
 	const installDir = join(tempDir, "install");
 	run("npm", ["install", "--prefix", installDir, coreTarball, mcpTarball, serverTarball, packedTarball]);
+	const lexicalLockPath = join(installDir, "package-lock.json");
+	assert(existsSync(lexicalLockPath), "Lexical install did not produce a package-lock.json");
+	const lexicalLock = JSON.parse(readFileSync(lexicalLockPath, "utf8"));
+	const lexicalPackages = Object.keys(lexicalLock.packages ?? {});
+	for (const packageName of ["@codemem/embeddings", "@xenova/transformers", "onnxruntime-node"]) {
+		assert(
+			// npm lockfile package keys use `/` and may be relative to a parent directory.
+			!lexicalPackages.some((path) => path.endsWith(`node_modules/${packageName}`)),
+			`Lexical-only install unexpectedly contains ${packageName}`,
+		);
+	}
+
+	const semanticInstallDir = join(tempDir, "semantic-install");
+	run("npm", ["install", "--prefix", semanticInstallDir, coreTarball, embeddingsTarball]);
+	const semanticCoreBundle = readFileSync(
+		join(semanticInstallDir, "node_modules", "@codemem", "core", "dist", "index.js"),
+		"utf8",
+	);
+	assert(
+		/import\(["']@codemem\/embeddings["']\)/u.test(semanticCoreBundle),
+		"Packed core bundle does not preserve its external @codemem/embeddings import",
+	);
+	run(
+		process.execPath,
+		[
+			"--input-type=module",
+			"--eval",
+			"const runtime = await import('@codemem/embeddings'); if (typeof runtime.createEmbeddingRuntime !== 'function') process.exit(1);",
+		],
+		semanticInstallDir,
+	);
 
 	const installedPackageRoot = join(installDir, "node_modules", "codemem");
 	const cliBin = join(installDir, "node_modules", ".bin", process.platform === "win32" ? "codemem.cmd" : "codemem");


### PR DESCRIPTION
## Description

Extends the packed CLI smoke to prove lexical-only consumers do not install `@codemem/embeddings`, Xenova, or ONNX Runtime. A second packed consumer installs core plus the runtime package and resolves its factory without invoking model inference. Tracks `codemem-jnd6.8.3.8`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm --filter codemem test:packed-artifact`
- [x] `node --check packages/cli/scripts/packed-artifact-smoke.mjs`
- [x] Added/updated tests for changes
- [x] Manually verified the semantic install imports without downloading a model

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated downstack
- [x] No new warnings introduced