### PR TITLE
chore(embeddings): enforce CPU-safe ONNX installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ On Linux, skip the unused ONNX Runtime GPU provider download:
 env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings
 ```
 
-On macOS and Windows:
+On Apple silicon macOS and Windows, install both packages normally:
 
 ```text
 npm install -g codemem @codemem/embeddings
@@ -83,6 +83,8 @@ plus any running `codemem serve` process. Each MCP process caches runtime
 availability for its lifetime, so a still-running Claude or Codex MCP host keeps
 lexical-only recall until it restarts; restarting `codemem serve` alone does not
 restart that MCP child.
+
+The semantic runtime is pinned to CPU inference on every platform.
 
 OpenCode plugin and CLI are now split intentionally:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -482,7 +482,8 @@ set the CPU-only policy so the installer skips the unused GPU provider:
 env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings
 ```
 
-On macOS and Windows, install both packages normally:
+On Apple silicon macOS and Windows, install both packages normally (no
+environment variable, which `env`/`cmd.exe`/PowerShell do not share):
 
 ```text
 npm install -g codemem @codemem/embeddings
@@ -502,6 +503,13 @@ restart the host you configured — OpenCode, Claude Code, or Codex — plus any
 running `codemem serve` process. Each MCP process checks runtime availability
 once per lifetime, so a running Claude or Codex MCP host stays lexical-only until
 it restarts; restarting `codemem serve` alone does not restart that MCP child.
+
+Codemem runs semantic inference on the CPU. `ONNXRUNTIME_NODE_INSTALL=skip`
+prevents ONNX Runtime's Linux installer from downloading unused GPU provider
+libraries; the CPU binaries remain available. Apple silicon macOS and Windows
+users can omit the environment variable. Intel (x64) Macs have no ONNX Runtime
+1.24.3 artifact and stay on FTS5 keyword retrieval, so installing the runtime
+there does not enable semantic search.
 
 The default `Xenova/bge-small-en-v1.5` model is pinned to a tested revision. If
 you set `CODEMEM_EMBEDDING_MODEL` to another repository, it must be a

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -11,12 +11,22 @@ This is the published npm package for the `codemem` CLI.
 covers macOS x64/arm64, Linux x64/arm64 (glibc 2.34+ or musl), and Windows x64.
 32-bit targets, including Linux armv7, are not supported.
 
+On Linux, skip the unused ONNX Runtime GPU provider download:
+
+```bash
+env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings
+```
+
+On Apple silicon macOS and Windows:
+
 ```bash
 npm install -g codemem @codemem/embeddings
 ```
 
 The embedding package enables semantic retrieval. Installing only `codemem` keeps
 the CLI functional with FTS5 keyword retrieval.
+
+Intel x64 Macs have no ONNX Runtime 1.24.3 artifact and remain on FTS5 retrieval.
 
 Or run without installing:
 

--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -30,11 +30,11 @@ function fail(message, result) {
 	throw new Error(message);
 }
 
-function run(command, args, cwd = packageRoot) {
+function run(command, args, cwd = packageRoot, env = process.env) {
 	const result = spawnSync(command, args, {
 		cwd,
 		encoding: "utf8",
-		env: process.env,
+		env,
 	});
 	if (result.status !== 0) {
 		fail(`Command failed: ${command} ${args.join(" ")}`, result);
@@ -46,6 +46,19 @@ function assert(condition, message) {
 	if (!condition) {
 		throw new Error(message);
 	}
+}
+
+function readInstallScriptPolicyEntries(result) {
+	let policy;
+	try {
+		policy = JSON.parse(result.stdout);
+	} catch {
+		fail("npm install-scripts returned invalid JSON", result);
+	}
+	if (!Array.isArray(policy?.allowScripts)) {
+		fail("npm install-scripts output schema changed", result);
+	}
+	return policy.allowScripts;
 }
 
 function runAsync(command, args, options, input) {
@@ -632,7 +645,16 @@ try {
 	}
 
 	const semanticInstallDir = join(tempDir, "semantic-install");
-	run("npm", ["install", "--prefix", semanticInstallDir, coreTarball, embeddingsTarball]);
+	mkdirSync(semanticInstallDir, { recursive: true });
+	writeFileSync(
+		join(semanticInstallDir, "package.json"),
+		JSON.stringify({ private: true }),
+		"utf8",
+	);
+	run("npm", ["install", "--prefix", semanticInstallDir, coreTarball, embeddingsTarball], packageRoot, {
+		...process.env,
+		ONNXRUNTIME_NODE_INSTALL: "skip",
+	});
 	const semanticCoreBundle = readFileSync(
 		join(semanticInstallDir, "node_modules", "@codemem", "core", "dist", "index.js"),
 		"utf8",
@@ -640,6 +662,74 @@ try {
 	assert(
 		/import\(["']@codemem\/embeddings["']\)/u.test(semanticCoreBundle),
 		"Packed core bundle does not preserve its external @codemem/embeddings import",
+	);
+	const installScriptsListing = spawnSync("npm", ["install-scripts", "ls", "--json"], {
+		cwd: semanticInstallDir,
+		encoding: "utf8",
+	});
+	const supportsInstallScripts = installScriptsListing.status === 0;
+	if (supportsInstallScripts) {
+		const blockedInstallScripts = readInstallScriptPolicyEntries(installScriptsListing);
+		const onnxInstallIsBlocked = blockedInstallScripts.some(
+			(entry) => entry?.name === "onnxruntime-node",
+		);
+		if (onnxInstallIsBlocked) {
+			run("npm", ["install-scripts", "approve", "onnxruntime-node"], semanticInstallDir);
+		} else {
+			process.stdout.write("ONNX Runtime install script was already permitted by npm\n");
+		}
+	} else {
+		const unsupportedCommandOutput = `${installScriptsListing.stdout ?? ""}\n${
+			installScriptsListing.stderr ?? ""
+		}`;
+		if (!/EUNKNOWNCOMMAND|Unknown command/i.test(unsupportedCommandOutput)) {
+			fail("Unable to inspect npm install-script policy", installScriptsListing);
+		}
+		process.stdout.write("npm does not support install-scripts; using rebuild compatibility path\n");
+	}
+	run("npm", ["rebuild", "onnxruntime-node"], semanticInstallDir, {
+		...process.env,
+		ONNXRUNTIME_NODE_INSTALL: "skip",
+	});
+	if (supportsInstallScripts) {
+		const remainingInstallScripts = readInstallScriptPolicyEntries(
+			run("npm", ["install-scripts", "ls", "--json"], semanticInstallDir),
+		);
+		assert(
+			!remainingInstallScripts.some((entry) => entry?.name === "onnxruntime-node"),
+			"Semantic install left ONNX Runtime's postinstall blocked after approval and rebuild",
+		);
+	}
+	const ortBinaryDir = join(
+		semanticInstallDir,
+		"node_modules",
+		"onnxruntime-node",
+		"bin",
+		"napi-v6",
+		process.platform,
+		process.arch,
+	);
+	const supportsOrtCpuBinary = !(process.platform === "darwin" && process.arch === "x64");
+	if (supportsOrtCpuBinary) {
+		assert(
+			existsSync(join(ortBinaryDir, "onnxruntime_binding.node")),
+			`Semantic install is missing ONNX Runtime CPU binaries for ${process.platform}/${process.arch}`,
+		);
+	}
+	assert(
+		!existsSync(
+			join(
+				semanticInstallDir,
+				"node_modules",
+				"onnxruntime-node",
+				"bin",
+				"napi-v6",
+				"linux",
+				"x64",
+				"libonnxruntime_providers_cuda.so",
+			),
+		),
+		"CPU-only semantic install unexpectedly contains the ONNX Runtime CUDA provider",
 	);
 	run(
 		process.execPath,

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -769,8 +769,12 @@ export function installCodex(force: boolean): boolean {
 	if (codememOnPath(true)) {
 		p.log.info("Codex hooks will call `codemem` directly (found on PATH).");
 	} else {
+		const globalInstallCommand =
+			process.platform === "linux"
+				? "env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings"
+				: "npm install -g codemem @codemem/embeddings";
 		p.log.info(
-			"`codemem` is not on PATH, so Codex hooks will run through a paired `npx` launcher (works without a global install). For lower hook latency: npm install -g codemem @codemem/embeddings",
+			`\`codemem\` is not on PATH, so Codex hooks will run via \`npx -y --package codemem --package @codemem/embeddings codemem\` (works without a global install). For lower hook latency: ${globalInstallCommand}`,
 		);
 	}
 

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -274,6 +274,7 @@ describe("update install command", () => {
 	});
 
 	it("installs the exact validated release without a shell and verifies it", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
 		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
 		spawn
 			.mockImplementationOnce(() => commandProcess())
@@ -293,7 +294,7 @@ describe("update install command", () => {
 				"codemem@0.41.0",
 				"@codemem/embeddings@0.41.0",
 			],
-			expect.objectContaining({ shell: false }),
+			expect.objectContaining({ env: undefined, shell: false }),
 		);
 		expect(spawn).toHaveBeenNthCalledWith(
 			2,
@@ -317,6 +318,30 @@ describe("update install command", () => {
 
 		expect(getUpdateStatus).not.toHaveBeenCalled();
 		expect(spawn).not.toHaveBeenCalled();
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("preserves the CPU-only ONNX install policy on Linux", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
+		spawn
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn).toHaveBeenNthCalledWith(
+			1,
+			"npm",
+			expect.arrayContaining(["codemem@0.41.0", "@codemem/embeddings@0.41.0"]),
+			expect.objectContaining({
+				env: expect.objectContaining({
+					ONNXRUNTIME_NODE_INSTALL: "skip",
+					PATH: process.env.PATH,
+				}),
+			}),
+		);
 		expect(process.exitCode).toBeUndefined();
 	});
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -82,12 +82,13 @@ function runCommand(
 	command: string,
 	args: string[],
 	timeoutMs: number,
-	options: { cwd?: string; windowsVerbatimArguments?: boolean } = {},
+	options: { cwd?: string; env?: NodeJS.ProcessEnv; windowsVerbatimArguments?: boolean } = {},
 ): Promise<CommandResult> {
 	return new Promise((resolve, reject) => {
 		const child = spawn(command, args, {
 			cwd: options.cwd,
 			detached: process.platform !== "win32",
+			env: options.env,
 			shell: false,
 			stdio: ["ignore", "pipe", "pipe"],
 			windowsVerbatimArguments: options.windowsVerbatimArguments,
@@ -313,7 +314,14 @@ async function installUpdate(options: UpdateInstallOptions): Promise<void> {
 						`@codemem/embeddings@${targetVersion}`,
 					],
 			INSTALL_TIMEOUT_MS,
-			{ cwd: npm.cwd, windowsVerbatimArguments: process.platform === "win32" },
+			{
+				cwd: npm.cwd,
+				env:
+					process.platform === "linux"
+						? { ...process.env, ONNXRUNTIME_NODE_INSTALL: "skip" }
+						: undefined,
+				windowsVerbatimArguments: process.platform === "win32",
+			},
 		);
 		if (installation.exitCode !== 0) {
 			failInstall(

--- a/packages/core/src/release-discovery.test.ts
+++ b/packages/core/src/release-discovery.test.ts
@@ -905,6 +905,28 @@ describe("installation guidance", () => {
 		},
 	);
 
+	it("includes the CPU-only ONNX policy in Linux npm-global guidance", async () => {
+		const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+		const status = await check(dependencies(), { installKind: "npm-global" }).finally(() =>
+			platform.mockRestore(),
+		);
+
+		expect(status.recommended_action).toBe(
+			"env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem@0.41.0 @codemem/embeddings@0.41.0",
+		);
+	});
+
+	it("keeps npm-global guidance unprefixed off Linux", async () => {
+		const platform = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+		const status = await check(dependencies(), { installKind: "npm-global" }).finally(() =>
+			platform.mockRestore(),
+		);
+
+		expect(status.recommended_action).toBe(
+			"npm install -g codemem@0.41.0 @codemem/embeddings@0.41.0",
+		);
+	});
+
 	it("returns no-upgrade guidance when the installation is current", async () => {
 		// Arrange
 		const deps = dependencies({ payload: { version: "0.40.2" } });

--- a/packages/core/src/release-discovery.ts
+++ b/packages/core/src/release-discovery.ts
@@ -235,7 +235,7 @@ function recommendedAction(
 	if (!updateAvailable) return "No action required; codemem is up to date.";
 	switch (installKind) {
 		case "npm-global":
-			return `npm install -g codemem@${latestVersion} @codemem/embeddings@${latestVersion}`;
+			return `${process.platform === "linux" ? "env ONNXRUNTIME_NODE_INSTALL=skip " : ""}npm install -g codemem@${latestVersion} @codemem/embeddings@${latestVersion}`;
 		case "npx":
 			return `Update your launcher to request codemem@${latestVersion} and @codemem/embeddings@${latestVersion} together.`;
 		case "docker":


### PR DESCRIPTION
## Description

Document and enforce CPU-safe installation of the optional embedding runtime. Linux npm installs now skip ONNX Runtime GPU provider downloads, while packed-consumer validation proves the host CPU binary remains available and the Linux CUDA provider is absent.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, packed-artifact smoke)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced