### PR TITLE
test: guard Transformers.js v4 isolation

### DIFF
--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -61,6 +61,17 @@ function readInstallScriptPolicyEntries(result) {
 	return policy.allowScripts;
 }
 
+function resolveInstalledPackageDir(installDir, packageName) {
+	const result = run("npm", ["ls", packageName, "--parseable", "--all"], installDir);
+	const expectedSuffix = join("node_modules", ...packageName.split("/"));
+	const packageDir = result.stdout
+		.split(/\r?\n/u)
+		.map((line) => line.trim())
+		.find((line) => line.endsWith(expectedSuffix));
+	assert(packageDir, `Semantic install is missing ${packageName}`);
+	return packageDir;
+}
+
 function runAsync(command, args, options, input) {
 	return new Promise((resolvePromise, reject) => {
 		const child = spawn(command, args, options);
@@ -631,12 +642,25 @@ try {
 	);
 
 	const installDir = join(tempDir, "install");
-	run("npm", ["install", "--prefix", installDir, coreTarball, mcpTarball, serverTarball, packedTarball]);
+	run(
+		"npm",
+		["install", "--prefix", installDir, coreTarball, mcpTarball, serverTarball, packedTarball],
+		packageRoot,
+		{ ...process.env, npm_config_install_strategy: "hoisted" },
+	);
 	const lexicalLockPath = join(installDir, "package-lock.json");
 	assert(existsSync(lexicalLockPath), "Lexical install did not produce a package-lock.json");
 	const lexicalLock = JSON.parse(readFileSync(lexicalLockPath, "utf8"));
 	const lexicalPackages = Object.keys(lexicalLock.packages ?? {});
-	for (const packageName of ["@codemem/embeddings", "@xenova/transformers", "onnxruntime-node"]) {
+	for (const packageName of [
+		"@codemem/embeddings",
+		"@huggingface/transformers",
+		"@xenova/transformers",
+		"onnxruntime-common",
+		"onnxruntime-node",
+		"onnxruntime-web",
+		"sharp",
+	]) {
 		assert(
 			// npm lockfile package keys use `/` and may be relative to a parent directory.
 			!lexicalPackages.some((path) => path.endsWith(`node_modules/${packageName}`)),
@@ -654,6 +678,7 @@ try {
 	run("npm", ["install", "--prefix", semanticInstallDir, coreTarball, embeddingsTarball], packageRoot, {
 		...process.env,
 		ONNXRUNTIME_NODE_INSTALL: "skip",
+		npm_config_install_strategy: "hoisted",
 	});
 	const semanticCoreBundle = readFileSync(
 		join(semanticInstallDir, "node_modules", "@codemem", "core", "dist", "index.js"),
@@ -690,6 +715,7 @@ try {
 	run("npm", ["rebuild", "onnxruntime-node"], semanticInstallDir, {
 		...process.env,
 		ONNXRUNTIME_NODE_INSTALL: "skip",
+		npm_config_install_strategy: "hoisted",
 	});
 	if (supportsInstallScripts) {
 		const remainingInstallScripts = readInstallScriptPolicyEntries(
@@ -700,15 +726,16 @@ try {
 			"Semantic install left ONNX Runtime's postinstall blocked after approval and rebuild",
 		);
 	}
-	const ortBinaryDir = join(
-		semanticInstallDir,
-		"node_modules",
-		"onnxruntime-node",
-		"bin",
-		"napi-v6",
-		process.platform,
-		process.arch,
+	const semanticLockPath = join(semanticInstallDir, "package-lock.json");
+	assert(existsSync(semanticLockPath), "Semantic install did not produce a package-lock.json");
+	const semanticLock = JSON.parse(readFileSync(semanticLockPath, "utf8"));
+	const semanticPackages = Object.keys(semanticLock.packages ?? {});
+	assert(
+		semanticPackages.some((path) => path.endsWith("node_modules/@huggingface/transformers")),
+		"Semantic install is missing the @huggingface/transformers runtime",
 	);
+	const ortPackageDir = resolveInstalledPackageDir(semanticInstallDir, "onnxruntime-node");
+	const ortBinaryDir = join(ortPackageDir, "bin", "napi-v6", process.platform, process.arch);
 	const supportsOrtCpuBinary = !(process.platform === "darwin" && process.arch === "x64");
 	if (supportsOrtCpuBinary) {
 		assert(
@@ -719,9 +746,7 @@ try {
 	assert(
 		!existsSync(
 			join(
-				semanticInstallDir,
-				"node_modules",
-				"onnxruntime-node",
+				ortPackageDir,
 				"bin",
 				"napi-v6",
 				"linux",
@@ -731,6 +756,10 @@ try {
 		),
 		"CPU-only semantic install unexpectedly contains the ONNX Runtime CUDA provider",
 	);
+	// Importing the @codemem/embeddings wrapper is always safe: it loads
+	// Transformers.js (and thus onnxruntime-node) lazily inside
+	// createEmbeddingRuntime, so this verifies the packed export exists even on
+	// Intel macOS where the ORT CPU binary is unavailable.
 	run(
 		process.execPath,
 		[
@@ -740,6 +769,23 @@ try {
 		],
 		semanticInstallDir,
 	);
+	// Only evaluate the direct Transformers.js runtime where ORT has a CPU binary;
+	// on darwin/x64 that import cannot load onnxruntime-node.
+	if (supportsOrtCpuBinary) {
+		const transformersPackageDir = resolveInstalledPackageDir(
+			semanticInstallDir,
+			"@huggingface/transformers",
+		);
+		run(
+			process.execPath,
+			[
+				"--input-type=module",
+				"--eval",
+				"const transformers = await import('@huggingface/transformers'); if (typeof transformers.pipeline !== 'function') process.exit(1);",
+			],
+			transformersPackageDir,
+		);
+	}
 
 	const installedPackageRoot = join(installDir, "node_modules", "codemem");
 	const cliBin = join(installDir, "node_modules", ".bin", process.platform === "win32" ? "codemem.cmd" : "codemem");

--- a/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.mjs
+++ b/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.mjs
@@ -12,9 +12,14 @@ const FORBIDDEN_IMPORTS = [
 	// Bundled npm packages are listed as intent and are also caught by the
 	// default-deny node:* rule when they pull unsupported builtins into the Worker.
 	"@codemem/embeddings",
+	"@huggingface/transformers",
 	"@xenova/transformers",
 	"better-sqlite3",
 	"bonjour-service",
+	"onnxruntime-common",
+	"onnxruntime-node",
+	"onnxruntime-web",
+	"sharp",
 	"sqlite-vec",
 ];
 // Add every forbidden package that is linked from this workspace rather than node_modules.
@@ -94,22 +99,39 @@ export async function assertWorkerBundleClean(bundlePath) {
 	}
 }
 
-async function listJavaScriptFiles(path) {
+// Binary asset extensions that indicate a native/WASM runtime was bundled. When
+// a package like onnxruntime-web is inlined, its `import "...onnxruntime-web..."`
+// specifier disappears from the emitted JS, but it emits these assets — which the
+// JS-only import scan cannot see. Reject them so the bundle stays lexical/pure JS.
+const FORBIDDEN_ASSET_EXTENSIONS = [".wasm", ".node"];
+
+async function listBundleFiles(path) {
 	const entry = await stat(path);
-	if (entry.isFile()) return path.endsWith(".js") ? [path] : [];
+	if (entry.isFile()) return [path];
 	const files = [];
 	for (const child of await readdir(path, { withFileTypes: true })) {
 		const childPath = join(path, child.name);
-		if (child.isDirectory()) files.push(...(await listJavaScriptFiles(childPath)));
-		else if (child.isFile() && child.name.endsWith(".js")) files.push(childPath);
+		if (child.isDirectory()) files.push(...(await listBundleFiles(childPath)));
+		else if (child.isFile()) files.push(childPath);
 	}
 	return files.toSorted();
 }
 
 export async function assertWorkerBundleOutputClean(bundlePath) {
-	const files = await listJavaScriptFiles(bundlePath);
-	if (files.length === 0) throw new Error(`Worker bundle contains no JavaScript files: ${bundlePath}`);
-	for (const file of files) await assertWorkerBundleClean(file);
+	const files = await listBundleFiles(bundlePath);
+	const javaScriptFiles = files.filter((file) => file.endsWith(".js"));
+	if (javaScriptFiles.length === 0) {
+		throw new Error(`Worker bundle contains no JavaScript files: ${bundlePath}`);
+	}
+	const forbiddenAssets = files.filter((file) =>
+		FORBIDDEN_ASSET_EXTENSIONS.some((extension) => file.endsWith(extension)),
+	);
+	if (forbiddenAssets.length > 0) {
+		throw new Error(
+			`Worker bundle contains forbidden native/WASM assets: ${forbiddenAssets.join(", ")}`,
+		);
+	}
+	for (const file of javaScriptFiles) await assertWorkerBundleClean(file);
 }
 
 export async function assertWorkerBundleMetafileClean(metafilePath) {

--- a/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.test.mjs
+++ b/packages/cloudflare-coordinator-worker/scripts/assert-worker-bundle-clean.test.mjs
@@ -19,9 +19,15 @@ test("rejects static, dynamic, and generated require imports of forbidden module
 	const source = [
 		'import { createRequire } from "node:module";',
 		'import "@codemem/embeddings";',
+		'import "@huggingface/transformers";',
+		'import "@huggingface/transformers/env";',
 		'import "@xenova/transformers";',
 		'await import("bonjour-service");',
 		'const Database = require("better-sqlite3");',
+		'const ortCommon = require("onnxruntime-common");',
+		'const ort = require("onnxruntime-node");',
+		'import "onnxruntime-web/webgpu";',
+		'import "sharp";',
 		'const fs = __require("node:fs");',
 		'const os = __require2("node:os");',
 		'const bareFs = require("fs");',
@@ -29,6 +35,8 @@ test("rejects static, dynamic, and generated require imports of forbidden module
 	].join("\n");
 	assert.deepEqual(findForbiddenWorkerImports(source), [
 		"@codemem/embeddings",
+		"@huggingface/transformers",
+		"@huggingface/transformers/env",
 		"@xenova/transformers",
 		"better-sqlite3",
 		"bonjour-service",
@@ -36,7 +44,11 @@ test("rejects static, dynamic, and generated require imports of forbidden module
 		"node:fs",
 		"node:module",
 		"node:os",
+		"onnxruntime-common",
+		"onnxruntime-node",
+		"onnxruntime-web/webgpu",
 		"os",
+		"sharp",
 	]);
 });
 
@@ -132,6 +144,22 @@ test("rejects a bundle output with no JavaScript", async () => {
 		await assert.rejects(
 			assertWorkerBundleOutputClean(directory),
 			/Worker bundle contains no JavaScript files:/u,
+		);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("rejects bundled native/WASM assets even when the JS imports look clean", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "codemem-worker-bundle-wasm-"));
+	try {
+		// An inlined package like onnxruntime-web drops its import specifier from
+		// the emitted JS but still emits a .wasm asset the JS-only scan misses.
+		await writeFile(join(directory, "index.js"), 'import { createHash } from "node:crypto";');
+		await writeFile(join(directory, "ort-wasm-simd.wasm"), "\0asm");
+		await assert.rejects(
+			assertWorkerBundleOutputClean(directory),
+			/Worker bundle contains forbidden native\/WASM assets: .*ort-wasm-simd\.wasm/u,
 		);
 	} finally {
 		await rm(directory, { recursive: true, force: true });


### PR DESCRIPTION
## Description

Update Worker and packed-install isolation guards for Transformers.js v4. The Worker denylist now rejects the v4 runtime, its subpaths, ONNX Runtime, and Sharp; packed tests prove lexical installs omit the runtime while semantic installs contain it.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (Worker bundle/integration checks and packed-artifact smoke)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced