### PR TITLE
docs: note Intel Mac semantic fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ lexical-only recall until it restarts; restarting `codemem serve` alone does not
 restart that MCP child.
 
 The semantic runtime is pinned to CPU inference on every platform.
+ONNX Runtime 1.24.3 does not ship a macOS x64 binary, so Intel Macs continue
+with FTS5 keyword retrieval when semantic runtime initialization fails.
 
 OpenCode plugin and CLI are now split intentionally:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -508,8 +508,9 @@ Codemem runs semantic inference on the CPU. `ONNXRUNTIME_NODE_INSTALL=skip`
 prevents ONNX Runtime's Linux installer from downloading unused GPU provider
 libraries; the CPU binaries remain available. Apple silicon macOS and Windows
 users can omit the environment variable. Intel (x64) Macs have no ONNX Runtime
-1.24.3 artifact and stay on FTS5 keyword retrieval, so installing the runtime
-there does not enable semantic search.
+1.24.3 artifact, so Codemem reports the unavailable semantic runtime and stays on
+FTS5 keyword retrieval; installing the runtime there does not enable semantic
+search.
 
 The default `Xenova/bge-small-en-v1.5` model is pinned to a tested revision. If
 you set `CODEMEM_EMBEDDING_MODEL` to another repository, it must be a


### PR DESCRIPTION
## Description

Document the current semantic-runtime platform boundary: ONNX Runtime 1.24.3 supports Apple silicon macOS but does not publish a macOS x64 native binary. Intel Macs therefore keep the existing non-fatal FTS5 fallback instead of silently promising semantic inference.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`git diff --check`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced