### PR TITLE
docs: record Transformers.js v4 audit decision

### DIFF
--- a/docs/plans/2026-09-02-transformers-v4-migration-design.md
+++ b/docs/plans/2026-09-02-transformers-v4-migration-design.md
@@ -75,6 +75,30 @@ Setting `ONNXRUNTIME_NODE_INSTALL=skip` skips the CUDA download while retaining 
 
 The package boundary therefore needs an explicit install contract. Lexical-only users must not receive ONNX Runtime, while embedding users must get CPU-safe installation guidance and validation.
 
+### Release decision
+
+Ship the v4 CPU baseline with the remaining downstream advisories documented.
+Compared with v2, the clean consumer audit removes one critical finding while
+retaining four high findings. That is an improvement in severity, not an
+audit-clean result.
+
+Repository overrides protect contributors and CI, but npm consumers do not
+inherit them. The text embedding path does not use Sharp, while `adm-zip` is in
+ONNX Runtime's installer; Linux users are instructed to skip the unused GPU
+provider download. We accept that residual exposure for this baseline and will
+revisit it when Transformers.js permits patched Sharp and ONNX Runtime versions.
+
+Setup-managed `npx` launchers and the OpenCode plugin's `npx` viewer runner do
+not set `ONNXRUNTIME_NODE_INSTALL=skip`. On Linux with a package manager that
+executes dependency scripts, the first resolution through those launchers can
+still download the roughly 205 MB GPU provider. We accept that exposure for the
+no-global-install path rather than injecting environment policy across three MCP
+config formats; the README directs Linux users to install both packages globally
+with the CPU-only policy or set the variable persistently.
+
+ONNX Runtime 1.24.3 also omits a macOS x64 binary. Intel Macs retain non-fatal
+FTS fallback rather than semantic inference.
+
 ## Stack Design
 
 ### PR 1: Bounded batching on v2


### PR DESCRIPTION
## Description

Record the release decision to accept the remaining downstream npm advisories in the Transformers.js v4 CPU baseline. The decision compares v2 and v4 severity, distinguishes repository overrides from consumer resolution, bounds the affected code paths, and records the Intel Mac fallback.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`git diff --check`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced