### PR TITLE
fix(sync): serialize recipient policy publication

### DIFF
--- a/docs/plans/2026-09-04-legacy-team-publication-barrier-design.md
+++ b/docs/plans/2026-09-04-legacy-team-publication-barrier-design.md
@@ -1,0 +1,32 @@
+# Legacy Team Publication Barrier
+
+## Decision
+
+Legacy Team completion publication will share one database-scoped mutation barrier with device-binding commits and Project-mapping writes. This prevents a successful local mutation from being overwritten by an immutable coordinator winner published concurrently.
+
+## Lock order
+
+Finish acquires locks in this order: candidate claim, publication barrier, sorted actor locks, Team lock, then coordinator-group lock. Device-binding and Project-mapping routes acquire only the publication barrier, so they cannot introduce a lock cycle.
+
+The barrier intentionally spans coordinator creation, conflict recovery, roster reload, and canonical local application. These operations are uncommon and correctness takes priority over cross-candidate write concurrency while publication is in flight.
+
+## Scope
+
+The barrier covers:
+
+- legacy Team finish publication;
+- device-binding commits;
+- single and bulk Project-mapping upserts;
+- Project-mapping deletion.
+
+Read-only previews and mapping reads remain concurrent.
+
+## Failure handling
+
+Every route releases the barrier in `finally`, including validation, SQLite, coordinator, and response-construction failures. Existing route-specific error responses remain unchanged.
+
+An interactive mutation can wait for the coordinator reconciliation budget of up to 60 seconds instead of reaching its SQLite-busy response while publication owns the barrier. This bounded availability cost is accepted to prevent a concurrent local write from being overwritten by the immutable coordinator winner.
+
+## Verification
+
+Route regressions will pause completion publication and assert that each affected mutation remains pending until publication finishes. Core tests will verify queue release after success and failure, and the full repository gate must pass before the existing PR stack is updated.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -900,8 +900,14 @@ export type {
 	RecipientPolicyTeamRenameResultV1,
 } from "./recipient-policy-team-metadata.js";
 export {
+	claimRecipientPolicyActorMutations,
+	claimRecipientPolicyPublicationMutation,
 	RecipientPolicyTeamRenameError,
 	renameRecipientPolicyTeam,
+	serializeRecipientPolicyActorMutations,
+	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyPublicationMutation,
+	serializeRecipientPolicyTeamMutation,
 } from "./recipient-policy-team-metadata.js";
 export type {
 	RecipientReviewedIntentExcludedProjectV1,

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -21,6 +21,7 @@ import {
 } from "./recipient-policy-identifiers.js";
 import { deriveRecipientPolicyEffectiveDevicesFromDatabase } from "./recipient-policy-reconciliation.js";
 import {
+	serializeRecipientPolicyActorMutations,
 	serializeRecipientPolicyCoordinatorGroupMutation,
 	serializeRecipientPolicyTeamMutation,
 } from "./recipient-policy-team-metadata.js";
@@ -617,6 +618,31 @@ describe("legacy Team setup activation", () => {
 		releaseMutation();
 		await mutation;
 		await expect(activation).resolves.toMatchObject({ status: "completed", teamId });
+	});
+
+	it("serializes finish against actor mutations for the draft's identities", async () => {
+		const draft = readyDraft();
+		const review = preview(draft);
+		let releaseMutation = () => undefined;
+		const mutationPending = new Promise<void>((resolve) => {
+			releaseMutation = resolve;
+		});
+		let mutationStarted = false;
+		const mutation = serializeRecipientPolicyActorMutations(db, ["identity-a"], async () => {
+			mutationStarted = true;
+			await mutationPending;
+		});
+		await vi.waitFor(() => expect(mutationStarted).toBe(true));
+
+		// Finish must wait behind the in-flight actor mutation (a merge or
+		// deactivation) rather than commit assignments for an identity mid-change.
+		const activation = finish(draft, review);
+		await Promise.resolve();
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+
+		releaseMutation();
+		await mutation;
+		await expect(activation).resolves.toMatchObject({ status: "completed" });
 	});
 
 	it("waits for an in-flight coordinator group mutation before activating the Team", async () => {

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -35,6 +35,7 @@ import {
 } from "./recipient-policy-identifiers.js";
 import { deriveRecipientPolicyEffectiveDevices } from "./recipient-policy-reconciliation.js";
 import {
+	serializeRecipientPolicyActorMutations,
 	serializeRecipientPolicyCoordinatorGroupMutation,
 	serializeRecipientPolicyTeamMutation,
 } from "./recipient-policy-team-metadata.js";
@@ -1755,47 +1756,63 @@ export async function finishLegacyTeamSetupActivation(
 		throw error;
 	}
 
-	return serializeRecipientPolicyTeamMutation(db, initialModel.teamId, () =>
-		serializeRecipientPolicyCoordinatorGroupMutation(db, initialModel.draft.group_id, async () => {
-			const now = input.now ?? new Date().toISOString();
-			try {
-				return db
-					.transaction(() => {
-						const lockedReplay = exactReplay(db, input);
-						if (lockedReplay) return lockedReplay;
-						const model = loadModel(db, input);
-						validateFreshRoster(model, freshRoster);
-						// Displayed Project evidence that changed after preview would
-						// produce a confirmed digest for an inventory the user never
-						// saw. The inventory is derived inside this lock so ingestion
-						// between an earlier read and the transaction cannot slip a
-						// Project past the check; the roster, by contrast, is external
-						// coordinator evidence and is re-validated against the locked
-						// model above.
-						const liveProjectionFingerprint = legacyTeamProjectionFingerprint(
-							input.loadProjectInventory(),
-						);
-						if (liveProjectionFingerprint !== model.draft.projection_fingerprint) {
-							activationError("team_setup_projection_changed");
-						}
-						const lockedPreview = buildPreview(model);
-						if (
-							lockedPreview.finishDigest !== input.finishDigest ||
-							lockedPreview.accessDeltaDigest !== input.confirmedAccessDeltaDigest
-						) {
-							activationError("team_setup_confirmation_stale");
-						}
-						if (!input.validateLockedPreview(lockedPreview)) {
-							activationError("team_setup_confirmation_stale");
-						}
-						return applyActivation(db, model, lockedPreview, freshRoster, now);
-					})
-					.immediate();
-			} catch (error) {
-				const normalized = normalizedActivationError(error);
-				persistSafeError(db, input, normalized);
-				throw normalized;
-			}
-		}),
+	// Lock order: actor -> Team -> coordinator group. Actor queues cover every
+	// identity this activation reads or writes, so a merge or deactivation
+	// cannot interleave with the locked model load and commit below.
+	return serializeRecipientPolicyActorMutations(db, draftActorIds(initialModel), () =>
+		serializeRecipientPolicyTeamMutation(db, initialModel.teamId, () =>
+			serializeRecipientPolicyCoordinatorGroupMutation(
+				db,
+				initialModel.draft.group_id,
+				async () => {
+					const now = input.now ?? new Date().toISOString();
+					try {
+						return db
+							.transaction(() => {
+								const lockedReplay = exactReplay(db, input);
+								if (lockedReplay) return lockedReplay;
+								const model = loadModel(db, input);
+								validateFreshRoster(model, freshRoster);
+								// Displayed Project evidence that changed after preview would
+								// produce a confirmed digest for an inventory the user never
+								// saw. The inventory is derived inside this lock so ingestion
+								// between an earlier read and the transaction cannot slip a
+								// Project past the check; the roster, by contrast, is external
+								// coordinator evidence and is re-validated against the locked
+								// model above.
+								const liveProjectionFingerprint = legacyTeamProjectionFingerprint(
+									input.loadProjectInventory(),
+								);
+								if (liveProjectionFingerprint !== model.draft.projection_fingerprint) {
+									activationError("team_setup_projection_changed");
+								}
+								const lockedPreview = buildPreview(model);
+								if (
+									lockedPreview.finishDigest !== input.finishDigest ||
+									lockedPreview.accessDeltaDigest !== input.confirmedAccessDeltaDigest
+								) {
+									activationError("team_setup_confirmation_stale");
+								}
+								if (!input.validateLockedPreview(lockedPreview)) {
+									activationError("team_setup_confirmation_stale");
+								}
+								return applyActivation(db, model, lockedPreview, freshRoster, now);
+							})
+							.immediate();
+					} catch (error) {
+						const normalized = normalizedActivationError(error);
+						persistSafeError(db, input, normalized);
+						throw normalized;
+					}
+				},
+			),
+		),
 	);
+}
+
+function draftActorIds(model: ActivationModel): string[] {
+	return model.devices.flatMap((device) => [
+		...(device.target_identity_id ? [device.target_identity_id] : []),
+		...(device.existing_identity_id ? [device.existing_identity_id] : []),
+	]);
 }

--- a/packages/core/src/recipient-policy-team-metadata.test.ts
+++ b/packages/core/src/recipient-policy-team-metadata.test.ts
@@ -2,7 +2,12 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getLegacyTeamSetupDraft } from "./legacy-team-setup-draft.js";
 import { deterministicPolicyTeamId } from "./recipient-policy-identifiers.js";
-import { renameRecipientPolicyTeam } from "./recipient-policy-team-metadata.js";
+import {
+	claimRecipientPolicyActorMutations,
+	renameRecipientPolicyTeam,
+	serializeRecipientPolicyActorMutations,
+	serializeRecipientPolicyPublicationMutation,
+} from "./recipient-policy-team-metadata.js";
 import { initTestSchema } from "./test-utils.js";
 
 const NOW = "2026-08-26T12:00:00.000Z";
@@ -17,6 +22,65 @@ describe("recipient policy Team metadata", () => {
 	});
 
 	afterEach(() => db.close());
+
+	it("claims deduplicated actor locks in sorted order and releases them once", async () => {
+		let releaseActorB: () => void = () => undefined;
+		const actorBGate = new Promise<void>((resolve) => {
+			releaseActorB = resolve;
+		});
+		const heldActorB = serializeRecipientPolicyActorMutations(db, ["actor-b"], () => actorBGate);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		const releaseActorsPromise = claimRecipientPolicyActorMutations(db, [
+			"actor-b",
+			"actor-a",
+			"actor-a",
+		]);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		let actorAStarted = false;
+		let releaseActorA: () => void = () => undefined;
+		const actorAGate = new Promise<void>((resolve) => {
+			releaseActorA = resolve;
+		});
+		const heldActorA = serializeRecipientPolicyActorMutations(db, ["actor-a"], async () => {
+			actorAStarted = true;
+			await actorAGate;
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(actorAStarted).toBe(false);
+
+		releaseActorB();
+		const releaseActors = await releaseActorsPromise;
+		releaseActors();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(actorAStarted).toBe(true);
+
+		let trailingActorAStarted = false;
+		const trailingActorA = serializeRecipientPolicyActorMutations(db, ["actor-a"], async () => {
+			trailingActorAStarted = true;
+		});
+		releaseActors();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(trailingActorAStarted).toBe(false);
+
+		releaseActorA();
+		await Promise.all([heldActorA, heldActorB, trailingActorA]);
+		expect(trailingActorAStarted).toBe(true);
+	});
+
+	it("releases the publication barrier when an operation fails", async () => {
+		await expect(
+			serializeRecipientPolicyPublicationMutation(db, async () => {
+				throw new Error("publication failed");
+			}),
+		).rejects.toThrow("publication failed");
+
+		let nextOperationStarted = false;
+		await serializeRecipientPolicyPublicationMutation(db, async () => {
+			nextOperationStarted = true;
+		});
+		expect(nextOperationStarted).toBe(true);
+	});
 
 	function insertTeam(teamId = "team-local", displayName = "Old Team") {
 		db.prepare(

--- a/packages/core/src/recipient-policy-team-metadata.ts
+++ b/packages/core/src/recipient-policy-team-metadata.ts
@@ -67,6 +67,9 @@ interface ProvenCoordinatorLink {
 // equivalence is limited to historical-link evidence and never changes queue keys.
 const teamRenameQueues = new WeakMap<Database, Map<string, Promise<void>>>();
 const coordinatorGroupMutationQueues = new WeakMap<Database, Map<string, Promise<void>>>();
+const actorMutationQueues = new WeakMap<Database, Map<string, Promise<void>>>();
+const publicationMutationQueues = new WeakMap<Database, Map<string, Promise<void>>>();
+const PUBLICATION_MUTATION_KEY = "recipient-policy-publication";
 
 function fail(code: RecipientPolicyTeamRenameErrorCode): never {
 	throw new RecipientPolicyTeamRenameError(code);
@@ -193,6 +196,19 @@ async function serializeMutation<T>(
 	key: string,
 	operation: () => Promise<T>,
 ): Promise<T> {
+	const release = await claimMutation(queues, db, key);
+	try {
+		return await operation();
+	} finally {
+		release();
+	}
+}
+
+async function claimMutation(
+	queues: WeakMap<Database, Map<string, Promise<void>>>,
+	db: Database,
+	key: string,
+): Promise<() => void> {
 	let queue = queues.get(db);
 	if (!queue) {
 		queue = new Map();
@@ -206,12 +222,13 @@ async function serializeMutation<T>(
 	const queued = preceding.catch(() => undefined).then(() => turn);
 	queue.set(key, queued);
 	await preceding.catch(() => undefined);
-	try {
-		return await operation();
-	} finally {
+	let released = false;
+	return () => {
+		if (released) return;
+		released = true;
 		release();
 		if (queue.get(key) === queued) queue.delete(key);
-	}
+	};
 }
 
 export function serializeRecipientPolicyTeamMutation<T>(
@@ -220,6 +237,46 @@ export function serializeRecipientPolicyTeamMutation<T>(
 	operation: () => Promise<T>,
 ): Promise<T> {
 	return serializeMutation(teamRenameQueues, db, teamId, operation);
+}
+
+export function serializeRecipientPolicyActorMutations<T>(
+	db: Database,
+	actorIds: readonly string[],
+	operation: () => Promise<T>,
+): Promise<T> {
+	const orderedActorIds = [...new Set(actorIds)].toSorted();
+	const serializeNext = (index: number): Promise<T> => {
+		const actorId = orderedActorIds[index];
+		if (!actorId) return operation();
+		return serializeMutation(actorMutationQueues, db, actorId, () => serializeNext(index + 1));
+	};
+	return serializeNext(0);
+}
+
+export async function claimRecipientPolicyActorMutations(
+	db: Database,
+	actorIds: readonly string[],
+): Promise<() => void> {
+	const releases: Array<() => void> = [];
+	for (const actorId of [...new Set(actorIds)].toSorted()) {
+		releases.push(await claimMutation(actorMutationQueues, db, actorId));
+	}
+	return () => {
+		for (const release of releases.toReversed()) release();
+	};
+}
+
+// Lock order is candidate claim -> publication -> actor -> Team -> coordinator group.
+// Callers that need lower-level locks must acquire this barrier first.
+export function serializeRecipientPolicyPublicationMutation<T>(
+	db: Database,
+	operation: () => Promise<T>,
+): Promise<T> {
+	return serializeMutation(publicationMutationQueues, db, PUBLICATION_MUTATION_KEY, operation);
+}
+
+export function claimRecipientPolicyPublicationMutation(db: Database): Promise<() => void> {
+	return claimMutation(publicationMutationQueues, db, PUBLICATION_MUTATION_KEY);
 }
 
 // This deliberately uses the exact group ID as a coarse serialization key.

--- a/packages/viewer-server/src/device-identity-inventory.test.ts
+++ b/packages/viewer-server/src/device-identity-inventory.test.ts
@@ -6,6 +6,7 @@ import {
 	fingerprintPublicKey,
 	initTestSchema,
 	MemoryStore,
+	serializeRecipientPolicyPublicationMutation,
 } from "@codemem/core";
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
@@ -404,10 +405,37 @@ describe("device Identity binding routes", () => {
 				bindings,
 				reviewedInventoryDigest: preview.reviewedInventoryDigest,
 			};
-			const commitResponse = await app.request(
-				"/api/sync/recipient-policy/v1/device-bindings/commit",
-				{ method: "POST", body: JSON.stringify(commitBody) },
+			let releasePublication: () => void = () => undefined;
+			const publicationGate = new Promise<void>((resolve) => {
+				releasePublication = resolve;
+			});
+			let markPublicationStarted: () => void = () => undefined;
+			const publicationStarted = new Promise<void>((resolve) => {
+				markPublicationStarted = resolve;
+			});
+			const heldPublication = serializeRecipientPolicyPublicationMutation(
+				fixture.store.db,
+				async () => {
+					markPublicationStarted();
+					await publicationGate;
+				},
 			);
+			await publicationStarted;
+			let commitSettled = false;
+			const commitRequest = app
+				.request("/api/sync/recipient-policy/v1/device-bindings/commit", {
+					method: "POST",
+					body: JSON.stringify(commitBody),
+				})
+				.then((response) => {
+					commitSettled = true;
+					return response;
+				});
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(commitSettled).toBe(false);
+			releasePublication();
+			const commitResponse = await commitRequest;
+			await heldPublication;
 			const retryResponse = await app.request(
 				"/api/sync/recipient-policy/v1/device-bindings/commit",
 				{ method: "POST", body: JSON.stringify(commitBody) },

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -12256,6 +12256,35 @@ describe("viewer-server", () => {
 				await app.request("/api/stats");
 				const store = getStore();
 				if (!store) throw new Error("store not initialized");
+				const requestBehindPublication = async (request: () => Promise<Response>) => {
+					let releasePublication: () => void = () => undefined;
+					const publicationGate = new Promise<void>((resolve) => {
+						releasePublication = resolve;
+					});
+					let markPublicationStarted: () => void = () => undefined;
+					const publicationStarted = new Promise<void>((resolve) => {
+						markPublicationStarted = resolve;
+					});
+					const heldPublication = core.serializeRecipientPolicyPublicationMutation(
+						store.db,
+						async () => {
+							markPublicationStarted();
+							await publicationGate;
+						},
+					);
+					await publicationStarted;
+					let requestSettled = false;
+					const pendingRequest = request().then((response) => {
+						requestSettled = true;
+						return response;
+					});
+					await new Promise((resolve) => setTimeout(resolve, 0));
+					expect(requestSettled).toBe(false);
+					releasePublication();
+					const response = await pendingRequest;
+					await heldPublication;
+					return response;
+				};
 				const sessionId = insertTestSession(store.db);
 				insertTestMemory(store, {
 					sessionId,
@@ -12363,15 +12392,18 @@ describe("viewer-server", () => {
 				});
 				expect(fractionalIdRes.status).toBe(400);
 
-				const saveRes = await app.request("/api/sync/sharing-domains/project-mappings", {
-					method: "PUT",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({
-						workspace_identity: project?.workspace_identity,
-						project_pattern: project?.display_project,
-						scope_id: "acme-work",
+				const mappingRequest = {
+					workspace_identity: project?.workspace_identity,
+					project_pattern: project?.display_project,
+					scope_id: "acme-work",
+				};
+				const saveRes = await requestBehindPublication(() =>
+					app.request("/api/sync/sharing-domains/project-mappings", {
+						method: "PUT",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify(mappingRequest),
 					}),
-				});
+				);
 				expect(saveRes.status).toBe(200);
 				const saveBody = (await saveRes.json()) as { mapping: { id: number; scope_id: string } };
 				expect(saveBody.mapping.scope_id).toBe("acme-work");
@@ -12396,10 +12428,19 @@ describe("viewer-server", () => {
 					n: number;
 				};
 				expect(memberships.n).toBe(0);
+				const bulkRes = await requestBehindPublication(() =>
+					app.request("/api/sync/sharing-domains/project-mappings/bulk", {
+						method: "PUT",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ mappings: [mappingRequest] }),
+					}),
+				);
+				expect(bulkRes.status).toBe(200);
 
-				const deleteRes = await app.request(
-					`/api/sync/sharing-domains/project-mappings/${saveBody.mapping.id}`,
-					{ method: "DELETE" },
+				const deleteRes = await requestBehindPublication(() =>
+					app.request(`/api/sync/sharing-domains/project-mappings/${saveBody.mapping.id}`, {
+						method: "DELETE",
+					}),
 				);
 				expect(deleteRes.status).toBe(200);
 			} finally {
@@ -13346,6 +13387,183 @@ describe("viewer-server", () => {
 				});
 				expect(missing.status).toBe(404);
 			} finally {
+				cleanup();
+			}
+		});
+
+		it("serializes Team recipient-edge commits behind Team publication", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			let releaseTeamMutation: () => void = () => undefined;
+			const teamMutationGate = new Promise<void>((resolve) => {
+				releaseTeamMutation = resolve;
+			});
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const teamId = "edge-serialization-team";
+				let markTeamMutationStarted: () => void = () => undefined;
+				const teamMutationStarted = new Promise<void>((resolve) => {
+					markTeamMutationStarted = resolve;
+				});
+				const teamMutation = core.serializeRecipientPolicyTeamMutation(
+					store.db,
+					teamId,
+					async () => {
+						markTeamMutationStarted();
+						await teamMutationGate;
+					},
+				);
+				await teamMutationStarted;
+
+				let commitSettled = false;
+				const commit = app
+					.request("/api/sync/recipient-policy/v1/edges/commit", {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({
+							version: 1,
+							changes: [
+								{
+									canonicalProjectIdentity: "https://git.example.invalid/acme/queued.git",
+									recipient: { recipientKind: "team", teamId },
+									action: "remove",
+								},
+							],
+							reviewedPolicyDigest: `edge-preview-v1:${"0".repeat(64)}`,
+						}),
+					})
+					.then((response) => {
+						commitSettled = true;
+						return response;
+					});
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				expect(commitSettled).toBe(false);
+
+				releaseTeamMutation();
+				expect((await commit).status).toBe(404);
+				await teamMutation;
+			} finally {
+				releaseTeamMutation();
+				cleanup();
+			}
+		});
+
+		it("does not queue identity-only recipient-edge commits behind Team publication", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			let releaseTeamMutation: () => void = () => undefined;
+			const teamMutationGate = new Promise<void>((resolve) => {
+				releaseTeamMutation = resolve;
+			});
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const identityId = "identity-only";
+				let markTeamMutationStarted: () => void = () => undefined;
+				const teamMutationStarted = new Promise<void>((resolve) => {
+					markTeamMutationStarted = resolve;
+				});
+				const teamMutation = core.serializeRecipientPolicyTeamMutation(
+					store.db,
+					identityId,
+					async () => {
+						markTeamMutationStarted();
+						await teamMutationGate;
+					},
+				);
+				await teamMutationStarted;
+
+				let commitSettled = false;
+				const commit = app
+					.request("/api/sync/recipient-policy/v1/edges/commit", {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({
+							version: 1,
+							changes: [
+								{
+									canonicalProjectIdentity: "https://git.example.invalid/acme/identity-only.git",
+									recipient: { recipientKind: "identity", identityId },
+									action: "remove",
+								},
+							],
+							reviewedPolicyDigest: `edge-preview-v1:${"0".repeat(64)}`,
+						}),
+					})
+					.then((response) => {
+						commitSettled = true;
+						return response;
+					});
+				await new Promise((resolve) => setTimeout(resolve, 0));
+
+				expect(commitSettled).toBe(true);
+				expect((await commit).status).toBe(404);
+				releaseTeamMutation();
+				await teamMutation;
+			} finally {
+				releaseTeamMutation();
+				cleanup();
+			}
+		});
+
+		it("acquires recipient-edge Team serializers in stable identity order", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			let releaseLastTeam: () => void = () => undefined;
+			const lastTeamGate = new Promise<void>((resolve) => {
+				releaseLastTeam = resolve;
+			});
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const firstTeamId = "edge-team-a";
+				const lastTeamId = "edge-team-z";
+				let markLastTeamStarted: () => void = () => undefined;
+				const lastTeamStarted = new Promise<void>((resolve) => {
+					markLastTeamStarted = resolve;
+				});
+				const lastTeamMutation = core.serializeRecipientPolicyTeamMutation(
+					store.db,
+					lastTeamId,
+					async () => {
+						markLastTeamStarted();
+						await lastTeamGate;
+					},
+				);
+				await lastTeamStarted;
+
+				const commit = app.request("/api/sync/recipient-policy/v1/edges/commit", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({
+						version: 1,
+						changes: [lastTeamId, firstTeamId].map((teamId, index) => ({
+							canonicalProjectIdentity: `https://git.example.invalid/acme/queued-${index}.git`,
+							recipient: { recipientKind: "team", teamId },
+							action: "remove",
+						})),
+						reviewedPolicyDigest: `edge-preview-v1:${"0".repeat(64)}`,
+					}),
+				});
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				let firstTeamMutationStarted = false;
+				const firstTeamMutation = core.serializeRecipientPolicyTeamMutation(
+					store.db,
+					firstTeamId,
+					async () => {
+						firstTeamMutationStarted = true;
+					},
+				);
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				expect(firstTeamMutationStarted).toBe(false);
+
+				releaseLastTeam();
+				expect((await commit).status).toBe(404);
+				await Promise.all([lastTeamMutation, firstTeamMutation]);
+				expect(firstTeamMutationStarted).toBe(true);
+			} finally {
+				releaseLastTeam();
 				cleanup();
 			}
 		});
@@ -14684,6 +14902,85 @@ describe("viewer-server", () => {
 				});
 				expect(res.status).toBe(409);
 				expect(await res.json()).toEqual({ error: "cannot merge this device's own local actor" });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("serializes actor merge and deactivation by affected actor identity", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				await app.request("/api/sync/actors");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const createActor = async (displayName: string): Promise<string> => {
+					const response = await app.request("/api/sync/actors", {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({ display_name: displayName }),
+					});
+					return ((await response.json()) as { actor_id: string }).actor_id;
+				};
+				const primaryActorId = await createActor("Primary actor");
+				const secondaryActorId = await createActor("Secondary actor");
+				let releaseMergeLock: () => void = () => undefined;
+				const mergeGate = new Promise<void>((resolve) => {
+					releaseMergeLock = resolve;
+				});
+				const heldMergeLock = core.serializeRecipientPolicyActorMutations(
+					store.db,
+					[secondaryActorId],
+					() => mergeGate,
+				);
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				let mergeSettled = false;
+				const merge = app
+					.request("/api/sync/actors/merge", {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({
+							primary_actor_id: primaryActorId,
+							secondary_actor_id: secondaryActorId,
+						}),
+					})
+					.then((response) => {
+						mergeSettled = true;
+						return response;
+					});
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				expect(mergeSettled).toBe(false);
+				releaseMergeLock();
+				expect((await merge).status).toBe(200);
+				await heldMergeLock;
+
+				const deactivatedActorId = await createActor("Deactivated actor");
+				let releaseDeactivateLock: () => void = () => undefined;
+				const deactivateGate = new Promise<void>((resolve) => {
+					releaseDeactivateLock = resolve;
+				});
+				const heldDeactivateLock = core.serializeRecipientPolicyActorMutations(
+					store.db,
+					[deactivatedActorId],
+					() => deactivateGate,
+				);
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				let deactivateSettled = false;
+				const deactivate = app
+					.request("/api/sync/actors/deactivate", {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({ actor_id: deactivatedActorId }),
+					})
+					.then((response) => {
+						deactivateSettled = true;
+						return response;
+					});
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				expect(deactivateSettled).toBe(false);
+				releaseDeactivateLock();
+				expect((await deactivate).status).toBe(200);
+				await heldDeactivateLock;
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -45,6 +45,8 @@ import {
 	buildDirectPeerAuthHeaders,
 	CoordinatorReciprocalApprovalRequestChangedError,
 	canonicalWorkspaceIdentity,
+	claimRecipientPolicyActorMutations,
+	claimRecipientPolicyPublicationMutation,
 	cleanupNonces,
 	commitDeviceIdentityBindings,
 	commitRecipientPolicyEdges,
@@ -130,6 +132,7 @@ import {
 	normalizeTeammateName,
 	parseAcceptedProjectIntent,
 	parseReassignScopePayload,
+	parseRecipientPolicyEdgeCommitRequest,
 	parseSyncScopeRequest,
 	persistShareOperation,
 	personalScopeGrantStatusForPeer,
@@ -165,6 +168,7 @@ import {
 	SYNC_FEATURES_HEADER,
 	SYNC_SCOPE_QUERY_PARAM,
 	schema,
+	serializeRecipientPolicyTeamMutation,
 	summarizeInboundScopeRejections,
 	supportsSyncFeature,
 	syncScopeResetRequiredPayload,
@@ -5099,7 +5103,9 @@ export function syncRoutes(
 			return c.json({ error: "binding_request_invalid" }, 400);
 		}
 		const store = getStore();
+		let releasePublicationMutation: (() => void) | undefined;
 		try {
+			releasePublicationMutation = await claimRecipientPolicyPublicationMutation(store.db);
 			ensureStableStoreIdentity(store);
 			const result = commitDeviceIdentityBindings(
 				store.db,
@@ -5119,6 +5125,8 @@ export function syncRoutes(
 				return c.json({ error: "binding_commit_busy" }, 503);
 			}
 			return c.json({ error: "binding_commit_failed" }, 500);
+		} finally {
+			releasePublicationMutation?.();
 		}
 	});
 
@@ -5842,7 +5850,27 @@ export function syncRoutes(
 		const store = getStore();
 		const body = await parseViewerJsonBody(c);
 		try {
-			const result = commitRecipientPolicyEdges(store.db, body);
+			const request = parseRecipientPolicyEdgeCommitRequest(body);
+			// Acquire every affected Team queue in one stable order. Finish publication
+			// uses the same Team boundary, so its reviewed snapshot cannot race a
+			// successful user recipient commit.
+			const teamIds = request
+				? [
+						...new Set(
+							request.changes.flatMap((change) =>
+								change.recipient.recipientKind === "team" ? [change.recipient.teamId] : [],
+							),
+						),
+					].toSorted()
+				: [];
+			const commit = async (
+				index: number,
+			): Promise<ReturnType<typeof commitRecipientPolicyEdges>> => {
+				const teamId = teamIds[index];
+				if (!teamId) return commitRecipientPolicyEdges(store.db, request ?? body);
+				return serializeRecipientPolicyTeamMutation(store.db, teamId, () => commit(index + 1));
+			};
+			const result = await commit(0);
 			if (result.status === "invalid") return c.json(result, 400);
 			if (result.status === "not_found") return c.json(result, 404);
 			if (result.status === "stale" || result.status === "conflict") {
@@ -6432,9 +6460,11 @@ export function syncRoutes(
 		const store = getStore();
 		const body = await parseViewerJsonBody(c);
 		if (!body) return c.json({ error: "invalid json" }, 400);
+		let releasePublicationMutation: (() => void) | undefined;
 		try {
 			const confirmedGuardrailTokens = optionalViewerStringList(body, "confirmed_guardrail_tokens");
 			const mappingInput = parseViewerProjectMappingInput(body);
+			releasePublicationMutation = await claimRecipientPolicyPublicationMutation(store.db);
 			const analysis = analyzeProjectScopeMappingChangeGuardrails(store.db, mappingInput);
 			if (analysis.requested_workspace_identity?.startsWith("unmapped:")) {
 				return c.json(
@@ -6474,6 +6504,8 @@ export function syncRoutes(
 			return c.json({ ok: true, mapping, guardrail_warnings: analysis.warnings });
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+		} finally {
+			releasePublicationMutation?.();
 		}
 	});
 
@@ -6481,6 +6513,7 @@ export function syncRoutes(
 		const store = getStore();
 		const body = await parseViewerJsonBody(c);
 		if (!body) return c.json({ error: "invalid json" }, 400);
+		let releasePublicationMutation: (() => void) | undefined;
 		try {
 			const rawMappings = body.mappings;
 			if (!Array.isArray(rawMappings) || rawMappings.length === 0) {
@@ -6492,6 +6525,7 @@ export function syncRoutes(
 				}
 				return parseViewerProjectMappingInput(raw as Record<string, unknown>);
 			});
+			releasePublicationMutation = await claimRecipientPolicyPublicationMutation(store.db);
 			const analyses = mappingInputs.map((mappingInput) =>
 				analyzeProjectScopeMappingChangeGuardrails(store.db, mappingInput),
 			);
@@ -6540,17 +6574,23 @@ export function syncRoutes(
 			});
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+		} finally {
+			releasePublicationMutation?.();
 		}
 	});
 
-	app.delete("/api/sync/sharing-domains/project-mappings/:id", (c) => {
+	app.delete("/api/sync/sharing-domains/project-mappings/:id", async (c) => {
 		const store = getStore();
 		const id = Number(c.req.param("id"));
+		let releasePublicationMutation: (() => void) | undefined;
 		try {
+			releasePublicationMutation = await claimRecipientPolicyPublicationMutation(store.db);
 			const deleted = deleteProjectScopeSettingsMapping(store.db, id);
 			return c.json({ ok: true, deleted });
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+		} finally {
+			releasePublicationMutation?.();
 		}
 	});
 
@@ -6701,6 +6741,13 @@ export function syncRoutes(
 		if (!secondaryActorId) return c.json({ error: "secondary_actor_id required" }, 400);
 		if (primaryActorId === secondaryActorId) return c.json({ error: "actor ids must differ" }, 400);
 		const d = drizzle(store.db, { schema });
+		const releaseActorMutations = await claimRecipientPolicyActorMutations(store.db, [
+			primaryActorId,
+			secondaryActorId,
+		]);
+		// This transaction is synchronous. Deferring release prevents a thrown transaction
+		// from leaking the lock while keeping it held through every mutation below.
+		queueMicrotask(releaseActorMutations);
 		const now = new Date().toISOString();
 		const result = store.db
 			.transaction(() => {
@@ -7027,6 +7074,9 @@ export function syncRoutes(
 		if (actorId === store.actorId) {
 			return c.json({ error: "cannot deactivate this device's own local actor" }, 409);
 		}
+		const releaseActorMutations = await claimRecipientPolicyActorMutations(store.db, [actorId]);
+		// All following reads and writes are synchronous, so release after this turn.
+		queueMicrotask(releaseActorMutations);
 		const d = drizzle(store.db, { schema });
 		const actor = d.select().from(schema.actors).where(eq(schema.actors.actor_id, actorId)).get();
 		if (!actor) return c.json({ error: "actor not found" }, 404);


### PR DESCRIPTION
## Description
Serialize recipient-policy publication, Team mutation, and coordinator-group mutation so concurrent sync and completion paths cannot interleave policy writes. Adds focused lock and barrier regressions plus the publication hierarchy design note.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced