### PR TITLE
fix(core): bound legacy Team setup size

### DIFF
--- a/packages/core/src/legacy-team-candidate.test.ts
+++ b/packages/core/src/legacy-team-candidate.test.ts
@@ -955,6 +955,75 @@ describe("legacy Team candidate discovery", () => {
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("needs_setup");
 	});
 
+	it("bounds the assignment fan-out re-derived for a completed candidate", () => {
+		// A one-device roster with one completed Project still re-derives
+		// effective devices across every persisted assignment row, so a large
+		// assignment table must trip the pair bound before that derivation runs.
+		const { candidateId } = completeCandidate();
+		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");
+		const insertAssignment = db.prepare(
+			`INSERT INTO identity_devices(
+				device_id, identity_id, display_name, status, provenance, revision,
+				migration_state, assignment_version, idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'identity-member', ?, 'revoked', 'test', 'r1', 'user_managed', 1, ?, ?, ?)`,
+		);
+		db.transaction(() => {
+			for (let index = 0; index < 10_000; index += 1) {
+				insertAssignment.run(
+					`device-historical-${index}`,
+					`Old ${index}`,
+					`hist-${index}`,
+					NOW,
+					NOW,
+				);
+			}
+		})();
+		const derive = vi.spyOn(db, "prepare");
+		try {
+			expect(discoverLegacyTeamCandidates(db, options())).toEqual([]);
+			expect(
+				derive.mock.calls.some(([sql]) => String(sql).includes("FROM policy_team_memberships")),
+			).toBe(false);
+		} finally {
+			derive.mockRestore();
+		}
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE candidate_id = ?")
+				.pluck()
+				.get(candidateId),
+		).toBe("completed");
+	});
+
+	it("still discovers a small new candidate alongside many unrelated assignments", () => {
+		// The readiness fan-out bound only applies once a completed candidate's
+		// compatibility derivation will run; a fresh candidate must not be
+		// hidden by historical assignment rows it never traverses.
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-historical', 'Historical', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const insertAssignment = db.prepare(
+			`INSERT INTO identity_devices(
+				device_id, identity_id, display_name, status, provenance, revision,
+				migration_state, assignment_version, idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'identity-historical', ?, 'revoked', 'test', 'r1', 'user_managed', 1, ?, ?, ?)`,
+		);
+		db.transaction(() => {
+			for (let index = 0; index < 10_000; index += 1) {
+				insertAssignment.run(
+					`device-historical-${index}`,
+					`Old ${index}`,
+					`hist-${index}`,
+					NOW,
+					NOW,
+				);
+			}
+		})();
+
+		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("needs_setup");
+	});
+
 	it("keeps a completed Team selectable when merged resolutions share one mapping", () => {
 		const { teamId, attemptId, candidateId } = completeCandidate();
 		expect(discoverLegacyTeamCandidates(db, options())[0]?.status).toBe("ready");

--- a/packages/core/src/legacy-team-candidate.ts
+++ b/packages/core/src/legacy-team-candidate.ts
@@ -20,6 +20,7 @@ import {
 } from "./legacy-team-setup-draft.js";
 import {
 	requireLegacyTeamSetupEffectiveDevicesWithinLimit,
+	requireLegacyTeamSetupReachableDevicesWithinLimit,
 	requireLegacyTeamSetupSnapshotWithinLimits,
 } from "./legacy-team-setup-limits.js";
 import { derivePolicyTeamDeviceEligibility } from "./policy-team-device-eligibility.js";
@@ -859,6 +860,7 @@ function candidateAuthority(
 	requireLegacyTeamSetupEffectiveDevicesWithinLimit(
 		db,
 		rosterDevices,
+		projects,
 		authorityRow?.attempt_id ?? null,
 	);
 	const activeAssignmentIdentity = activeAssignmentIdentityLookup(db);
@@ -875,6 +877,11 @@ function candidateAuthority(
 		completedRow !== null &&
 		completedRow.roster_fingerprint === rosterFingerprint &&
 		completedInventoryCompatible(db, completedRow.attempt_id, projects);
+	// Only the completed-candidate compatibility derivation fans out across
+	// every assignment row; a fresh or in-progress candidate never runs it.
+	if (completionEvidenceMatches) {
+		requireLegacyTeamSetupReachableDevicesWithinLimit(db, rosterDevices, projects);
+	}
 	let ready =
 		completionEvidenceMatches &&
 		isCompatibleReadyTeam(db, candidateId, completedRow, rosterFingerprint);

--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -23,6 +23,7 @@ import { deriveRecipientPolicyEffectiveDevicesFromDatabase } from "./recipient-p
 import {
 	serializeRecipientPolicyActorMutations,
 	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyPublicationMutation,
 	serializeRecipientPolicyTeamMutation,
 } from "./recipient-policy-team-metadata.js";
 import { initTestSchema } from "./test-utils.js";
@@ -230,6 +231,131 @@ describe("legacy Team setup activation", () => {
 		expect(review.accessDeltaDigest).toMatch(/^legacy-team-access-delta:/u);
 		expect(db.prepare("SELECT total_changes()").pluck().get()).toBe(before);
 		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+	});
+
+	it("rejects persisted drafts above the Project-device pair limit before preview", () => {
+		// Arrange
+		const draft = readyDraft();
+		const insertDevice = db.prepare(
+			`INSERT INTO legacy_team_setup_draft_devices(
+			 attempt_id, device_id, device_ref, key_fingerprint, display_name, enabled,
+			 existing_identity_id, existing_assignment_version, verified_evidence_kind,
+			 decision, target_identity_id, expected_assignment_kind,
+			 expected_assignment_version, updated_at
+			 ) VALUES (?, ?, ?, ?, ?, 1, 'identity-a', 0, 'active_assignment',
+			 'included', 'identity-a', 'existing', 0, ?)`,
+		);
+		const insertProject = db.prepare(
+			`INSERT INTO legacy_team_setup_draft_projects(
+			 attempt_id, project_ref, source_project_identity, display_name, source_fingerprint,
+			 resolution_kind, resolved_project_identity, target_scope_id, updated_at
+			 ) VALUES (?, ?, ?, ?, ?, 'deterministic', ?, 'scope-engineering', ?)`,
+		);
+		for (let index = 2; index < 500; index += 1) {
+			insertDevice.run(
+				draft.attemptId,
+				`device-${index}`,
+				`device-ref-${index}`,
+				`key-${index}`,
+				`Device ${index}`,
+				NOW,
+			);
+		}
+		for (let index = 2; index < 21; index += 1) {
+			const project = `https://git.example.invalid/acme/project-${index}.git`;
+			insertProject.run(
+				draft.attemptId,
+				`project-ref-${index}`,
+				project,
+				`Project ${index}`,
+				`source-${index}`,
+				project,
+				NOW,
+			);
+		}
+
+		// Act / Assert
+		expect(() => preview(draft)).toThrow("team_setup_roster_unavailable");
+	});
+
+	it("rejects a small draft whose access-delta traversal exceeds the pair limit", () => {
+		// Arrange: a 1-device/1-Project draft in an installation that already
+		// holds many active recipient Projects and assigned devices. The delta
+		// derivation walks every one of them, so the bound must cover that
+		// traversal rather than only the two persisted draft arrays.
+		const draft = readyDraft();
+		const insertRecipient = db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'identity', 'identity-b', 'active', 'user', 'r1', 'completed', ?, ?, ?)`,
+		);
+		const insertAssignment = db.prepare(
+			`INSERT INTO identity_devices(
+			 identity_id, device_id, display_name, status, provenance, revision, migration_state,
+			 assignment_version, idempotency_key, created_at, updated_at
+			 ) VALUES ('identity-b', ?, ?, 'active', 'invitation', 'r1', 'completed', 0, ?, ?, ?)`,
+		);
+		for (let index = 0; index < 120; index += 1) {
+			insertRecipient.run(
+				`https://git.example.invalid/acme/existing-${index}.git`,
+				`recipient-${index}`,
+				NOW,
+				NOW,
+			);
+			insertAssignment.run(
+				`device-existing-${index}`,
+				`Device ${index}`,
+				`assign-${index}`,
+				NOW,
+				NOW,
+			);
+		}
+
+		// Act / Assert
+		expect(() => preview(draft)).toThrow("team_setup_roster_unavailable");
+	});
+
+	it("ignores removed draft devices when bounding the access-delta traversal", () => {
+		// Arrange: 500 carried removed devices and 21 active recipient Projects.
+		// Removed devices never reach a derivation row, so the empty assignment
+		// graph must not be counted as 500 x 21 traversed pairs.
+		const draft = readyDraft();
+		const insertDevice = db.prepare(
+			`INSERT INTO legacy_team_setup_draft_devices(
+			 attempt_id, device_id, device_ref, key_fingerprint, display_name, enabled,
+			 existing_identity_id, existing_assignment_version, verified_evidence_kind,
+			 decision, target_identity_id, expected_assignment_kind,
+			 expected_assignment_version, updated_at
+			 ) VALUES (?, ?, ?, ?, ?, 1, NULL, NULL, NULL, 'removed', NULL, 'absent', NULL, ?)`,
+		);
+		const insertRecipient = db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'identity', 'identity-b', 'active', 'user', 'r1', 'completed', ?, ?, ?)`,
+		);
+		for (let index = 0; index < 498; index += 1) {
+			insertDevice.run(
+				draft.attemptId,
+				`device-removed-${index}`,
+				`device-ref-removed-${index}`,
+				`key-removed-${index}`,
+				`Removed ${index}`,
+				NOW,
+			);
+		}
+		for (let index = 0; index < 21; index += 1) {
+			insertRecipient.run(
+				`https://git.example.invalid/acme/existing-${index}.git`,
+				`recipient-${index}`,
+				NOW,
+				NOW,
+			);
+		}
+
+		// Act / Assert
+		expect(preview(draft)).toMatchObject({ attemptId: draft.attemptId });
 	});
 
 	it("lists a shared canonical recipient addition once for merged Project resolutions", async () => {
@@ -643,6 +769,64 @@ describe("legacy Team setup activation", () => {
 		releaseMutation();
 		await mutation;
 		await expect(activation).resolves.toMatchObject({ status: "completed" });
+	});
+
+	it("waits for an in-flight publication mutation before activating the Team", async () => {
+		const draft = readyDraft();
+		const review = preview(draft);
+		let releaseMutation = () => undefined;
+		const mutationPending = new Promise<void>((resolve) => {
+			releaseMutation = resolve;
+		});
+		let mutationStarted = false;
+		const mutation = serializeRecipientPolicyPublicationMutation(db, async () => {
+			mutationStarted = true;
+			await mutationPending;
+		});
+		await vi.waitFor(() => expect(mutationStarted).toBe(true));
+
+		const loadFreshRoster = vi.fn(async () => roster);
+		const activation = finish(draft, review, loadFreshRoster);
+		const activationState = await Promise.race([
+			activation.then(() => "completed" as const),
+			new Promise<"blocked">((resolve) => setTimeout(() => resolve("blocked"), 25)),
+		]);
+		expect(activationState).toBe("blocked");
+		expect(loadFreshRoster).not.toHaveBeenCalled();
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+
+		releaseMutation();
+		await mutation;
+		await expect(activation).resolves.toMatchObject({ status: "completed" });
+	});
+
+	it("replays a committed activation without waiting for the publication barrier", async () => {
+		const draft = readyDraft();
+		const review = preview(draft);
+		const committed = await finish(draft, review);
+		let releaseMutation = () => undefined;
+		const mutationPending = new Promise<void>((resolve) => {
+			releaseMutation = resolve;
+		});
+		let mutationStarted = false;
+		const mutation = serializeRecipientPolicyPublicationMutation(db, async () => {
+			mutationStarted = true;
+			await mutationPending;
+		});
+		await vi.waitFor(() => expect(mutationStarted).toBe(true));
+
+		// The immutable response is already persisted; an exact retry must not
+		// queue behind an unrelated publication holding the barrier.
+		const replayState = await Promise.race([
+			finish(draft, review).then((result) => ({ kind: "replayed" as const, result })),
+			new Promise<{ kind: "blocked" }>((resolve) =>
+				setTimeout(() => resolve({ kind: "blocked" }), 25),
+			),
+		]);
+		expect(replayState).toEqual({ kind: "replayed", result: committed });
+
+		releaseMutation();
+		await mutation;
 	});
 
 	it("waits for an in-flight coordinator group mutation before activating the Team", async () => {

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -16,7 +16,8 @@ import {
 import type { LegacyTeamSetupActivationErrorCode } from "./legacy-team-setup-errors.js";
 import {
 	LEGACY_TEAM_SETUP_MAX_DEVICES,
-	LEGACY_TEAM_SETUP_MAX_PROJECTS,
+	requireLegacyTeamSetupAccessDeltaTraversalWithinLimit,
+	requireLegacyTeamSetupSnapshotWithinLimits,
 } from "./legacy-team-setup-limits.js";
 import {
 	activeUnmergedActorIds,
@@ -37,6 +38,7 @@ import { deriveRecipientPolicyEffectiveDevices } from "./recipient-policy-reconc
 import {
 	serializeRecipientPolicyActorMutations,
 	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyPublicationMutation,
 	serializeRecipientPolicyTeamMutation,
 } from "./recipient-policy-team-metadata.js";
 import {
@@ -318,6 +320,47 @@ function activationError(code: LegacyTeamSetupActivationErrorCode): never {
 	throw new LegacyTeamSetupActivationError(code);
 }
 
+function requireActivationModelWithinLimits(
+	devices: readonly DraftDeviceRow[],
+	projects: readonly DraftProjectRow[],
+): void {
+	try {
+		requireLegacyTeamSetupSnapshotWithinLimits({ devices, projects });
+	} catch {
+		activationError("team_setup_roster_unavailable");
+	}
+}
+
+function requireAccessDeltaTraversalWithinLimit(
+	model: Pick<ActivationModel, "projects" | "recipients" | "assignments" | "devices">,
+): void {
+	const projectIdentities = new Set([
+		...model.projects.flatMap((project) =>
+			project.resolved_project_identity ? [project.resolved_project_identity] : [],
+		),
+		...model.recipients
+			.filter((row) => row.status === "active")
+			.map((row) => row.canonical_project_identity),
+	]);
+	// Every persisted assignment row is fed into each Project derivation
+	// regardless of status, so all of them count. Of the draft devices, only
+	// included ones can add a row; excluded or removed devices never do.
+	const deviceIds = new Set([
+		...model.assignments.map((row) => row.device_id),
+		...model.devices
+			.filter((device) => device.decision === "included" && device.target_identity_id)
+			.map((device) => device.device_id),
+	]);
+	try {
+		requireLegacyTeamSetupAccessDeltaTraversalWithinLimit({
+			projectIdentities,
+			deviceCount: deviceIds.size,
+		});
+	} catch {
+		activationError("team_setup_roster_unavailable");
+	}
+}
+
 function normalizedActivationError(error: unknown): LegacyTeamSetupActivationError {
 	if (error instanceof LegacyTeamSetupActivationError) return error;
 	if (
@@ -406,12 +449,11 @@ function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): 
 			 FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref`,
 		)
 		.all(input.attemptId) as DraftProjectRow[];
+	requireActivationModelWithinLimits(devices, projects);
 	if (
 		devices.length === 0 ||
-		devices.length > LEGACY_TEAM_SETUP_MAX_DEVICES ||
 		// A configured group without displayed Projects is a valid setup: the
 		// reviewed Team becomes ready for future sharing with no mappings yet.
-		projects.length > LEGACY_TEAM_SETUP_MAX_PROJECTS ||
 		devices.some(
 			(device) =>
 				device.decision === "unresolved" ||
@@ -557,6 +599,7 @@ function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): 
 			.map((device) => device.device_id)
 			.toSorted(compareText),
 	};
+	requireAccessDeltaTraversalWithinLimit(model);
 	validateAssignmentExpectations(model);
 	validateCanonicalState(db, model);
 	return model;
@@ -1712,7 +1755,7 @@ function applyActivation(
 	return result;
 }
 
-export async function finishLegacyTeamSetupActivation(
+async function finishLegacyTeamSetupActivationWithPublicationLock(
 	db: Database,
 	input: FinishLegacyTeamSetupActivationInput,
 ): Promise<LegacyTeamSetupActivationResultV1> {
@@ -1815,4 +1858,18 @@ function draftActorIds(model: ActivationModel): string[] {
 		...(device.target_identity_id ? [device.target_identity_id] : []),
 		...(device.existing_identity_id ? [device.existing_identity_id] : []),
 	]);
+}
+
+export async function finishLegacyTeamSetupActivation(
+	db: Database,
+	input: FinishLegacyTeamSetupActivationInput,
+): Promise<LegacyTeamSetupActivationResultV1> {
+	// An exact retry of a committed activation must not queue behind unrelated
+	// publications; its immutable response is already persisted. The locked
+	// path repeats the lookup for finishes that overlap the commit.
+	const replay = exactReplay(db, input);
+	if (replay) return replay;
+	return serializeRecipientPolicyPublicationMutation(db, () =>
+		finishLegacyTeamSetupActivationWithPublicationLock(db, input),
+	);
 }

--- a/packages/core/src/legacy-team-setup-draft.test.ts
+++ b/packages/core/src/legacy-team-setup-draft.test.ts
@@ -767,6 +767,48 @@ describe("legacy Team setup drafts", () => {
 		);
 	});
 
+	it("accepts exactly 10,000 Project-device pairs", () => {
+		const draft = refreshLegacyTeamSetupDraft(db, {
+			...snapshot(),
+			devices: devices(500),
+			projects: projects(20),
+		});
+
+		expect(draft.devices).toHaveLength(500);
+		expect(draft.projects).toHaveLength(20);
+	});
+
+	it("rejects more than 10,000 Project-device pairs without persisting", () => {
+		expect(() =>
+			refreshLegacyTeamSetupDraft(db, {
+				...snapshot(),
+				devices: devices(500),
+				projects: projects(21),
+			}),
+		).toThrow("legacy_team_setup_roster_too_large");
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_drafts").pluck().get()).toBe(0);
+	});
+
+	it("counts carried Devices toward the Project-device pair limit", () => {
+		const current = refreshLegacyTeamSetupDraft(db, {
+			...snapshot(),
+			devices: devices(500),
+		});
+		db.prepare(
+			"UPDATE legacy_team_setup_drafts SET state = 'in_progress' WHERE attempt_id = ?",
+		).run(current.attemptId);
+		const before = getLegacyTeamSetupDraft(db, CANDIDATE);
+
+		expect(() =>
+			refreshLegacyTeamSetupDraft(db, {
+				...snapshot(),
+				devices: devices(476, 24),
+				projects: projects(21),
+			}),
+		).toThrow("legacy_team_setup_roster_too_large");
+		expect(getLegacyTeamSetupDraft(db, CANDIDATE)).toEqual(before);
+	});
+
 	it("rejects carried-device overflow and preserves the reviewed attempt", () => {
 		const current = refreshLegacyTeamSetupDraft(db, { ...snapshot(), devices: devices(500) });
 		db.prepare(

--- a/packages/core/src/legacy-team-setup-draft.ts
+++ b/packages/core/src/legacy-team-setup-draft.ts
@@ -850,6 +850,7 @@ export function refreshLegacyTeamSetupDraft(
 		requireLegacyTeamSetupEffectiveDevicesWithinLimit(
 			db,
 			input.devices,
+			input.projects,
 			existing?.attempt_id ?? null,
 		);
 		const loadAssignment = assignmentLookup(db);

--- a/packages/core/src/legacy-team-setup-limits.ts
+++ b/packages/core/src/legacy-team-setup-limits.ts
@@ -2,6 +2,7 @@ import type { Database } from "./db.js";
 
 export const LEGACY_TEAM_SETUP_MAX_DEVICES = 500;
 export const LEGACY_TEAM_SETUP_MAX_PROJECTS = 500;
+export const LEGACY_TEAM_SETUP_MAX_PROJECT_DEVICE_PAIRS = 10_000;
 
 export function requireLegacyTeamSetupSnapshotWithinLimits(input: {
 	devices: readonly unknown[];
@@ -9,7 +10,49 @@ export function requireLegacyTeamSetupSnapshotWithinLimits(input: {
 }): void {
 	if (
 		input.devices.length > LEGACY_TEAM_SETUP_MAX_DEVICES ||
-		input.projects.length > LEGACY_TEAM_SETUP_MAX_PROJECTS
+		input.projects.length > LEGACY_TEAM_SETUP_MAX_PROJECTS ||
+		input.devices.length * input.projects.length > LEGACY_TEAM_SETUP_MAX_PROJECT_DEVICE_PAIRS
+	) {
+		throw new Error("legacy_team_setup_roster_too_large");
+	}
+}
+
+/**
+ * Bounds the access-delta derivation itself. Activation recomputes effective
+ * devices for every Project the Team touches plus every Project with an
+ * active recipient edge, across every assigned device, so a tiny draft can
+ * still fan out past the pair budget when the installation already holds many
+ * recipients or assignments.
+ */
+export function requireLegacyTeamSetupAccessDeltaTraversalWithinLimit(input: {
+	projectIdentities: ReadonlySet<string>;
+	deviceCount: number;
+}): void {
+	if (
+		input.projectIdentities.size * input.deviceCount >
+		LEGACY_TEAM_SETUP_MAX_PROJECT_DEVICE_PAIRS
+	) {
+		throw new Error("legacy_team_setup_roster_too_large");
+	}
+}
+
+/**
+ * Readiness checks re-derive effective devices for every completed Project,
+ * and that derivation walks every persisted assignment row. Bound that fan-out
+ * so a small roster cannot hide an unbounded Project-by-assignment traversal.
+ */
+export function requireLegacyTeamSetupReachableDevicesWithinLimit(
+	db: Database,
+	devices: readonly unknown[],
+	projects: readonly unknown[],
+): void {
+	if (projects.length === 0) return;
+	const assignmentRows = Number(
+		db.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get() ?? 0,
+	);
+	if (
+		(devices.length + assignmentRows) * projects.length >
+		LEGACY_TEAM_SETUP_MAX_PROJECT_DEVICE_PAIRS
 	) {
 		throw new Error("legacy_team_setup_roster_too_large");
 	}
@@ -18,6 +61,7 @@ export function requireLegacyTeamSetupSnapshotWithinLimits(input: {
 export function requireLegacyTeamSetupEffectiveDevicesWithinLimit(
 	db: Database,
 	devices: readonly { deviceId: string }[],
+	projects: readonly unknown[],
 	previousAttemptId: string | null,
 ): void {
 	if (!previousAttemptId) return;
@@ -33,7 +77,11 @@ export function requireLegacyTeamSetupEffectiveDevicesWithinLimit(
 			.pluck()
 			.get(previousAttemptId, ...currentDeviceIds) ?? 0,
 	);
-	if (devices.length + carriedDeviceCount > LEGACY_TEAM_SETUP_MAX_DEVICES) {
+	const effectiveDeviceCount = devices.length + carriedDeviceCount;
+	if (
+		effectiveDeviceCount > LEGACY_TEAM_SETUP_MAX_DEVICES ||
+		effectiveDeviceCount * projects.length > LEGACY_TEAM_SETUP_MAX_PROJECT_DEVICE_PAIRS
+	) {
 		throw new Error("legacy_team_setup_roster_too_large");
 	}
 }

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -1072,6 +1072,37 @@ describe("Team setup roster loading", () => {
 		).rejects.toThrow("team_setup_roster_unavailable");
 	});
 
+	it("accepts a maximal device access delta alongside the mandatory Team entry", () => {
+		// 500 devices x 20 Projects fills the device category exactly; the Team
+		// addition must not tip the preview into a roster-too-large failure.
+		const deviceAccessChanges = Array.from({ length: 10_000 }, (_, index) => ({
+			canonicalProjectIdentity: `https://git.example.invalid/acme/project-${index % 20}.git`,
+			deviceId: `device-${Math.floor(index / 20)}`,
+			change: "add" as const,
+		}));
+		const delta = {
+			teamChanges: [
+				{
+					teamId: "policy-team-v1:team",
+					change: "add" as const,
+					fromDeviceEligibilityMode: null,
+					toDeviceEligibilityMode: "reviewed_allowlist" as const,
+				},
+			],
+			membershipChanges: [],
+			projectChanges: [],
+			recipientChanges: [],
+			deviceAccessChanges,
+		};
+		expect(() => __teamSetupTestHooks.requireBoundedAccessDelta(delta)).not.toThrow();
+		expect(() =>
+			__teamSetupTestHooks.requireBoundedAccessDelta({
+				...delta,
+				deviceAccessChanges: [...deviceAccessChanges, deviceAccessChanges[0]],
+			}),
+		).toThrow("legacy_team_setup_roster_too_large");
+	});
+
 	it("rejects mapping-choice responses that cannot include every opaque choice", () => {
 		expect(() => __teamSetupTestHooks.requireCompleteMappingChoices(21, 500)).toThrow(
 			"legacy_team_setup_roster_too_large",

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -707,20 +707,16 @@ function viewerAccessDeltaDigest(delta: LegacyTeamSetupViewerAccessDeltaV1): str
 	return recipientPolicyDigest("legacy-team-viewer-access-delta-v1", delta);
 }
 
+// Each category is capped independently, matching core's activation limit:
+// a maximal 500-device/20-Project activation fills the device category exactly,
+// and the mandatory Team and membership entries must still fit alongside it.
 function requireBoundedAccessDelta(delta: LegacyTeamSetupAccessDeltaV1): void {
-	const total =
-		delta.teamChanges.length +
-		delta.membershipChanges.length +
-		delta.projectChanges.length +
-		delta.recipientChanges.length +
-		delta.deviceAccessChanges.length;
 	if (
 		delta.teamChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
 		delta.membershipChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
 		delta.projectChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
 		delta.recipientChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
-		delta.deviceAccessChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
-		total > MAX_ACCESS_DELTA_ENTRIES
+		delta.deviceAccessChanges.length > MAX_ACCESS_DELTA_ENTRIES
 	) {
 		throw new Error("legacy_team_setup_roster_too_large");
 	}
@@ -873,6 +869,7 @@ export const __teamSetupTestHooks = {
 	loadConfiguredLegacyTeamGroupSnapshotsWith,
 	normalizedCoordinatorId,
 	projectMutationAtomically,
+	requireBoundedAccessDelta,
 	requireCompleteMappingChoices,
 	disambiguateChoiceLabels,
 	safeChoiceLabel,


### PR DESCRIPTION
## Description
Bound legacy Team setup candidate and draft construction by device, Project, and Project-device pair counts. This prevents oversized legacy inventories from creating unbounded setup work while preserving the existing failure contract.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced