### PR TITLE
feat(core): add canonical Team completion application

### DIFF
--- a/packages/core/src/legacy-team-setup-activation.test.ts
+++ b/packages/core/src/legacy-team-setup-activation.test.ts
@@ -2,7 +2,9 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { discoverLegacyTeamCandidates } from "./legacy-team-candidate.js";
 import {
+	applyCanonicalLegacyTeamSetupActivationInTransaction,
 	finishLegacyTeamSetupActivation,
+	inspectFreshLegacyTeamSetupActivation,
 	inspectLegacyTeamSetupActivation,
 	previewLegacyTeamSetupActivation,
 } from "./legacy-team-setup-activation.js";
@@ -356,6 +358,88 @@ describe("legacy Team setup activation", () => {
 
 		// Act / Assert
 		expect(preview(draft)).toMatchObject({ attemptId: draft.attemptId });
+	});
+
+	it("uses the canonical completion key instead of rotating the preview digest", () => {
+		// Arrange
+		const draft = readyDraft();
+		const completionKey = "legacy-team-activation-finish-v1:canonical";
+
+		// Act
+		const result = db
+			.transaction(() =>
+				applyCanonicalLegacyTeamSetupActivationInTransaction(db, {
+					candidateRef: draft.candidateRef,
+					attemptId: draft.attemptId,
+					policyRevision: "canonical-revision",
+					completedAt: NOW,
+					completionKey,
+				}),
+			)
+			.immediate();
+
+		// Assert
+		expect(result).toMatchObject({ status: "completed", completedAt: NOW });
+		expect(
+			db
+				.prepare("SELECT finish_digest FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId),
+		).toBe(completionKey);
+		expect(
+			db
+				.prepare("SELECT finish_digest FROM legacy_team_setup_completions WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId),
+		).toBe(completionKey);
+	});
+
+	it("replays a completed canonical application before revalidating the draft", () => {
+		// Arrange: the first application assigns a previously unassigned device,
+		// so the draft's stored `absent` expectation no longer matches live state.
+		const draft = readyDraft();
+		const completionKey = "legacy-team-activation-finish-v1:canonical";
+		const apply = () =>
+			db
+				.transaction(() =>
+					applyCanonicalLegacyTeamSetupActivationInTransaction(db, {
+						candidateRef: draft.candidateRef,
+						attemptId: draft.attemptId,
+						policyRevision: "canonical-revision",
+						completedAt: NOW,
+						completionKey,
+						allowCompletedDraft: true,
+					}),
+				)
+				.immediate();
+		const first = apply();
+		const changesAfterFirst = db.prepare("SELECT total_changes()").pluck().get();
+
+		// Act: a retry after a lost response or reconciliation re-run.
+		const retry = apply();
+
+		// Assert: the committed result replays without touching policy state.
+		expect(retry).toEqual(first);
+		expect(db.prepare("SELECT total_changes()").pluck().get()).toBe(changesAfterFirst);
+		expect(
+			db
+				.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId),
+		).toBe(1);
+
+		// A newer draft for the same candidate supersedes the completed attempt;
+		// a delayed retry for the old attempt must not report success.
+		db.prepare(
+			`INSERT INTO legacy_team_setup_drafts(
+			 attempt_id, candidate_id, coordinator_id, group_id, state, display_name,
+			 roster_fingerprint, projection_fingerprint, created_at, updated_at
+			 ) SELECT 'legacy-team-attempt:newer', candidate_id, coordinator_id, group_id,
+			          'needs_setup', display_name, roster_fingerprint, projection_fingerprint,
+			          ?, ?
+			   FROM legacy_team_setup_drafts WHERE attempt_id = ?`,
+		).run(NOW, NOW, draft.attemptId);
+		expect(apply).toThrow();
 	});
 
 	it("lists a shared canonical recipient addition once for merged Project resolutions", async () => {
@@ -910,6 +994,24 @@ describe("legacy Team setup activation", () => {
 				.pluck()
 				.get(draft.attemptId),
 		).toBe("stale");
+	});
+
+	it("persists stale state when fresh inspection detects changed evidence", () => {
+		const draft = readyDraft();
+
+		expect(() =>
+			inspectFreshLegacyTeamSetupActivation(db, {
+				candidateRef: draft.candidateRef,
+				attemptId: draft.attemptId,
+				freshRoster: [{ ...roster[0], fingerprint: "changed-key" }, roster[1]],
+				projectInventory: draftProjectInventory(draft.attemptId),
+			}),
+		).toThrow("team_setup_roster_changed");
+		expect(
+			db
+				.prepare("SELECT state, safe_error_code FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.get(draft.attemptId),
+		).toEqual({ state: "stale", safe_error_code: "team_setup_roster_changed" });
 	});
 
 	it("returns roster unavailable after a failed pre-lock fetch without canonical writes", async () => {
@@ -1888,6 +1990,36 @@ describe("legacy Team setup activation", () => {
 		expect(review.accessDelta.recipientChanges).not.toContainEqual(
 			expect.objectContaining({ canonicalProjectIdentity: PROJECT_A, change: "remove" }),
 		);
+	});
+
+	it("preserves a user-revoked recipient in both preview and activation", async () => {
+		const teamId = deterministicPolicyTeamId(CANDIDATE);
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, idempotency_key, created_at, updated_at
+			 ) VALUES (?, 'team', ?, 'revoked', 'user', 'user-r1', 'user_managed',
+			 'user-revoked-edge', ?, ?)`,
+		).run(PROJECT_A, teamId, NOW, NOW);
+		const draft = readyDraft();
+
+		const review = preview(draft);
+		expect(review.accessDelta.recipientChanges).not.toContainEqual(
+			expect.objectContaining({ canonicalProjectIdentity: PROJECT_A, change: "add" }),
+		);
+		expect(review.accessDelta.deviceAccessChanges).not.toContainEqual(
+			expect.objectContaining({ canonicalProjectIdentity: PROJECT_A, change: "add" }),
+		);
+		await finish(draft, review);
+
+		expect(
+			db
+				.prepare(
+					`SELECT status, provenance FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
+				)
+				.get(PROJECT_A, teamId),
+		).toEqual({ status: "revoked", provenance: "user" });
 	});
 
 	it("confirms and applies setup-owned mapping removal when repeat setup drops a Project", async () => {

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -16,6 +16,7 @@ import {
 import type { LegacyTeamSetupActivationErrorCode } from "./legacy-team-setup-errors.js";
 import {
 	LEGACY_TEAM_SETUP_MAX_DEVICES,
+	LEGACY_TEAM_SETUP_MAX_PROJECTS,
 	requireLegacyTeamSetupAccessDeltaTraversalWithinLimit,
 	requireLegacyTeamSetupSnapshotWithinLimits,
 } from "./legacy-team-setup-limits.js";
@@ -93,6 +94,10 @@ export interface FinishLegacyTeamSetupActivationInput
 	 * Implementations must be synchronous and read from the same database.
 	 */
 	validateLockedPreview: (preview: LegacyTeamSetupActivationPreviewV1) => boolean;
+	canonicalCompletion?: {
+		policyRevision: string;
+		completedAt: string;
+	};
 	now?: string;
 }
 
@@ -139,6 +144,7 @@ interface TeamRow {
 	display_name: string;
 	status: string;
 	device_eligibility_mode: string;
+	migration_state: string;
 	provenance: string;
 	source_fingerprint: string | null;
 }
@@ -241,6 +247,14 @@ interface ActivationModel {
 
 interface CompletionRow {
 	response_json: string;
+}
+
+interface AdditiveProjectRow {
+	project_ref: string;
+	source_project_identity: string;
+	source_fingerprint: string;
+	resolved_project_identity: string | null;
+	target_scope_id: string | null;
 }
 
 const SETUP_MEMBERSHIP_PROVENANCE = "reviewed_active";
@@ -413,7 +427,14 @@ function droppedSetupMappings(model: ActivationModel): MappingRow[] {
 	);
 }
 
-function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): ActivationModel {
+function loadModel(
+	db: Database,
+	input: PreviewLegacyTeamSetupActivationInput & {
+		allowCompletedDraft?: boolean;
+		allowInactiveCanonicalTeam?: boolean;
+		allowStaleDraft?: boolean;
+	},
+): ActivationModel {
 	const draft = db
 		.prepare(
 			`SELECT draft.attempt_id, draft.candidate_id, draft.coordinator_id, draft.group_id,
@@ -429,7 +450,13 @@ function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): 
 	if (!draft || draft.candidate_id !== input.candidateRef) {
 		activationError("team_setup_confirmation_stale");
 	}
-	if (draft.is_current === 0 || (draft.state !== "needs_setup" && draft.state !== "in_progress")) {
+	if (
+		draft.is_current === 0 ||
+		(draft.state !== "needs_setup" &&
+			draft.state !== "in_progress" &&
+			!(input.allowCompletedDraft && draft.state === "completed") &&
+			!(input.allowStaleDraft && draft.state === "stale"))
+	) {
 		activationError("team_setup_confirmation_stale");
 	}
 
@@ -517,7 +544,7 @@ function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): 
 		(db
 			.prepare(
 				`SELECT team_id, display_name, status, device_eligibility_mode,
-				        provenance, source_fingerprint
+				        migration_state, provenance, source_fingerprint
 				 FROM policy_teams WHERE team_id = ?`,
 			)
 			.get(teamId) as TeamRow | undefined) ?? null;
@@ -601,15 +628,23 @@ function loadModel(db: Database, input: PreviewLegacyTeamSetupActivationInput): 
 	};
 	requireAccessDeltaTraversalWithinLimit(model);
 	validateAssignmentExpectations(model);
-	validateCanonicalState(db, model);
+	validateCanonicalState(db, model, input.allowInactiveCanonicalTeam === true);
 	return model;
 }
 
-function validateCanonicalState(db: Database, model: ActivationModel): void {
+function validateCanonicalState(
+	db: Database,
+	model: ActivationModel,
+	allowInactiveCanonicalTeam: boolean,
+): void {
 	const { groupScopeIds, memberships, projects, recipients, scopeIds, team, teamId } = model;
 	if (team) {
 		const baseCompatible =
-			team.status === "active" && team.provenance === HISTORICAL_TEAM_PROVENANCE;
+			(team.status === "active" ||
+				(allowInactiveCanonicalTeam &&
+					team.status === "inactive" &&
+					team.migration_state === "needs_setup")) &&
+			team.provenance === HISTORICAL_TEAM_PROVENANCE;
 		const reviewedCompatible = team.device_eligibility_mode === "reviewed_allowlist";
 		const historicalCompatible = team.device_eligibility_mode === "person_all_devices";
 		if (!baseCompatible || (!reviewedCompatible && !historicalCompatible)) {
@@ -703,6 +738,40 @@ function targetScopeId(model: ActivationModel, project: DraftProjectRow): string
 		),
 	];
 	return matchingScopeIds.length === 1 ? (matchingScopeIds[0] ?? null) : null;
+}
+
+function requireSelectedProjectScopeMappings(
+	db: Database,
+	projects: readonly {
+		sourceProjectIdentity: string;
+		resolvedProjectIdentity: string;
+		targetScopeId: string;
+	}[],
+): void {
+	const sourcesByResolved = new Map<string, { sources: Set<string>; scopeIds: Set<string> }>();
+	for (const project of projects) {
+		const evidence = sourcesByResolved.get(project.resolvedProjectIdentity) ?? {
+			sources: new Set<string>(),
+			scopeIds: new Set<string>(),
+		};
+		evidence.sources.add(project.sourceProjectIdentity);
+		evidence.scopeIds.add(project.targetScopeId);
+		sourcesByResolved.set(project.resolvedProjectIdentity, evidence);
+	}
+	for (const [resolvedIdentity, evidence] of sourcesByResolved) {
+		const selected = selectedProjectScopeMapping(db, resolvedIdentity);
+		if (
+			evidence.scopeIds.size !== 1 ||
+			!selected ||
+			selected.workspaceIdentity == null ||
+			(normalizeLegacyProjectMappingIdentity(selected.workspaceIdentity) !==
+				normalizeLegacyProjectMappingIdentity(resolvedIdentity) &&
+				!evidence.sources.has(selected.projectPattern)) ||
+			selected.scopeId !== [...evidence.scopeIds][0]
+		) {
+			activationError("team_setup_conflict");
+		}
+	}
 }
 
 /**
@@ -817,6 +886,23 @@ interface DerivationRows {
 		status: string;
 		provenance: string;
 	}>;
+}
+
+const LEGACY_TEAM_SETUP_MAX_ACCESS_DELTA_ENTRIES = 10_000;
+
+export function requireLegacyTeamSetupAccessDeltaWithinLimit(
+	delta: LegacyTeamSetupAccessDeltaV1,
+): void {
+	const counts = [
+		delta.teamChanges.length,
+		delta.membershipChanges.length,
+		delta.projectChanges.length,
+		delta.recipientChanges.length,
+		delta.deviceAccessChanges.length,
+	];
+	if (counts.some((count) => count > LEGACY_TEAM_SETUP_MAX_ACCESS_DELTA_ENTRIES)) {
+		throw new Error("legacy_team_setup_roster_too_large");
+	}
 }
 
 function currentDerivationRows(model: ActivationModel): DerivationRows {
@@ -1000,8 +1086,9 @@ function simulatedDerivationRows(model: ActivationModel): DerivationRows {
 				row.recipientKind === "team" &&
 				row.recipientId === model.teamId,
 		);
-		if (existing) existing.status = "active";
-		else {
+		if (existing) {
+			if (existing.provenance === "reviewed_team_setup") existing.status = "active";
+		} else {
 			projectRecipients.push({
 				canonicalProjectIdentity: resolvedIdentity,
 				recipientKind: "team",
@@ -1147,7 +1234,7 @@ function buildAccessDelta(model: ActivationModel): LegacyTeamSetupAccessDeltaV1 
 				row.canonical_project_identity === resolvedIdentity &&
 				row.recipient_kind === "team" &&
 				row.recipient_id === model.teamId &&
-				row.status === "active",
+				(row.status === "active" || row.provenance !== "reviewed_team_setup"),
 		);
 		if (!recipient && !plannedRecipientIdentities.has(resolvedIdentity)) {
 			plannedRecipientIdentities.add(resolvedIdentity);
@@ -1320,9 +1407,19 @@ function exactReplay(
 ): LegacyTeamSetupActivationResultV1 | null {
 	const row = db
 		.prepare(
-			`SELECT response_json FROM legacy_team_setup_completions
-			 WHERE candidate_ref = ? AND attempt_id = ? AND finish_digest = ?
-			   AND confirmed_access_delta_digest = ?`,
+			`SELECT completion.response_json
+			 FROM legacy_team_setup_completions AS completion
+			 JOIN legacy_team_setup_drafts AS draft
+			   ON draft.attempt_id = completion.attempt_id
+			  AND draft.candidate_id = completion.candidate_ref
+			  AND draft.finish_digest = completion.finish_digest
+			 WHERE completion.candidate_ref = ? AND completion.attempt_id = ?
+			   AND completion.finish_digest = ?
+			   AND completion.confirmed_access_delta_digest = ?
+			   AND NOT EXISTS (
+			     SELECT 1 FROM legacy_team_setup_drafts AS newer
+			     WHERE newer.candidate_id = draft.candidate_id AND newer.rowid > draft.rowid
+			   )`,
 		)
 		.get(
 			input.candidateRef,
@@ -1331,6 +1428,16 @@ function exactReplay(
 			input.confirmedAccessDeltaDigest,
 		) as CompletionRow | undefined;
 	return row ? (JSON.parse(row.response_json) as LegacyTeamSetupActivationResultV1) : null;
+}
+
+export function replayLegacyTeamSetupActivation(
+	db: Database,
+	input: Pick<
+		FinishLegacyTeamSetupActivationInput,
+		"candidateRef" | "attemptId" | "finishDigest" | "confirmedAccessDeltaDigest"
+	>,
+): LegacyTeamSetupActivationResultV1 | null {
+	return exactReplay(db, input);
 }
 
 function validateFreshRoster(
@@ -1363,17 +1470,42 @@ function validateFreshRoster(
 	}
 }
 
+export function inspectFreshLegacyTeamSetupActivation(
+	db: Database,
+	input: PreviewLegacyTeamSetupActivationInput & {
+		freshRoster: Awaited<ReturnType<FinishLegacyTeamSetupActivationInput["loadFreshRoster"]>>;
+		projectInventory: LegacyTeamSetupProjectInput[];
+	},
+): LegacyTeamSetupActivationPreviewV1 {
+	try {
+		const model = loadModel(db, input);
+		validateFreshRoster(model, input.freshRoster);
+		if (
+			legacyTeamProjectionFingerprint(input.projectInventory) !== model.draft.projection_fingerprint
+		) {
+			activationError("team_setup_projection_changed");
+		}
+		return buildPreview(model);
+	} catch (error) {
+		const normalized = normalizedActivationError(error);
+		persistSafeError(db, input, normalized);
+		throw normalized;
+	}
+}
+
 function applyActivation(
 	db: Database,
 	model: ActivationModel,
 	preview: LegacyTeamSetupActivationPreviewV1,
 	freshRoster: Awaited<ReturnType<FinishLegacyTeamSetupActivationInput["loadFreshRoster"]>>,
 	now: string,
+	options: { revisionOverride?: string; completionKey?: string } = {},
 ): LegacyTeamSetupActivationResultV1 {
-	const revision = recipientPolicyDigest(
-		"legacy-team-activation-revision-v1",
-		preview.finishDigest,
-	);
+	const revision =
+		options.revisionOverride ??
+		recipientPolicyDigest("legacy-team-activation-revision-v1", preview.finishDigest);
+	const completionKey = options.completionKey ?? preview.finishDigest;
+	const allowExistingCompletion = options.completionKey !== undefined;
 	if (!model.team) {
 		db.prepare(
 			`INSERT INTO policy_teams(
@@ -1614,7 +1746,10 @@ function applyActivation(
 			 created_at, updated_at
 			 ) VALUES (?, 'team', ?, 'active', 'reviewed_team_setup', ?, 'completed', ?, ?, ?, ?)
 			 ON CONFLICT(canonical_project_identity, recipient_kind, recipient_id) DO UPDATE SET
-			 status = 'active',
+			 status = CASE
+			   WHEN project_recipients.provenance = 'reviewed_team_setup' THEN 'active'
+			   ELSE project_recipients.status
+			 END,
 			 provenance = CASE
 			   WHEN project_recipients.provenance = 'reviewed_team_setup' THEN excluded.provenance
 			   ELSE project_recipients.provenance
@@ -1686,36 +1821,14 @@ function applyActivation(
 	// mapping writes because merged resolutions map several confirmed source
 	// patterns onto one identity and selection can pick only one of them: the
 	// authoritative pattern is valid when it matches ANY confirmed source.
-	const confirmedSourcesByResolved = new Map<
-		string,
-		{ sources: Set<string>; targetScopeIds: Set<string> }
-	>();
-	for (const project of model.projects) {
-		const resolvedIdentity = project.resolved_project_identity as string;
-		const evidence = confirmedSourcesByResolved.get(resolvedIdentity) ?? {
-			sources: new Set<string>(),
-			targetScopeIds: new Set<string>(),
-		};
-		evidence.sources.add(project.source_project_identity);
-		const projectTargetScopeId = targetScopeId(model, project);
-		if (projectTargetScopeId) evidence.targetScopeIds.add(projectTargetScopeId);
-		confirmedSourcesByResolved.set(resolvedIdentity, evidence);
-	}
-	for (const [resolvedIdentity, evidence] of confirmedSourcesByResolved) {
-		const reviewedTargetScopeId = [...evidence.targetScopeIds][0];
-		const selected = selectedProjectScopeMapping(db, resolvedIdentity);
-		if (
-			evidence.targetScopeIds.size !== 1 ||
-			!selected ||
-			selected.workspaceIdentity == null ||
-			(normalizeLegacyProjectMappingIdentity(selected.workspaceIdentity) !==
-				normalizeLegacyProjectMappingIdentity(resolvedIdentity) &&
-				!evidence.sources.has(selected.projectPattern)) ||
-			selected.scopeId !== reviewedTargetScopeId
-		) {
-			activationError("team_setup_conflict");
-		}
-	}
+	requireSelectedProjectScopeMappings(
+		db,
+		model.projects.map((project) => ({
+			sourceProjectIdentity: project.source_project_identity,
+			resolvedProjectIdentity: project.resolved_project_identity as string,
+			targetScopeId: targetScopeId(model, project) as string,
+		})),
+	);
 
 	const result: LegacyTeamSetupActivationResultV1 = {
 		status: "completed",
@@ -1729,30 +1842,327 @@ function applyActivation(
 		 SET state = 'completed', finish_digest = ?, safe_error_code = NULL,
 		     roster_fingerprint = ?, completed_team_id = ?, completed_at = ?, updated_at = ?
 		 WHERE attempt_id = ?`,
-	).run(
-		preview.finishDigest,
-		postRosterFingerprint,
-		model.teamId,
-		now,
-		now,
+	).run(completionKey, postRosterFingerprint, model.teamId, now, now, model.draft.attempt_id);
+	const completionValues = [
 		model.draft.attempt_id,
-	);
-	db.prepare(
-		`INSERT INTO legacy_team_setup_completions(
-		 attempt_id, finish_digest, candidate_ref, confirmed_access_delta_digest,
-		 completed_team_id, response_json, completed_at, created_at
-		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-	).run(
-		model.draft.attempt_id,
-		preview.finishDigest,
+		completionKey,
 		model.draft.candidate_id,
 		preview.accessDeltaDigest,
 		model.teamId,
 		JSON.stringify(result),
 		now,
 		now,
-	);
+	] as const;
+	const insertedCompletion = db
+		.prepare(
+			`INSERT ${allowExistingCompletion ? "OR IGNORE " : ""}INTO legacy_team_setup_completions(
+		 attempt_id, finish_digest, candidate_ref, confirmed_access_delta_digest,
+		 completed_team_id, response_json, completed_at, created_at
+		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.run(...completionValues);
+	if (allowExistingCompletion && insertedCompletion.changes === 0) {
+		const existing = db
+			.prepare(
+				`SELECT candidate_ref, confirmed_access_delta_digest, completed_team_id,
+				        response_json, completed_at
+				 FROM legacy_team_setup_completions
+				 WHERE attempt_id = ? AND finish_digest = ?`,
+			)
+			.get(model.draft.attempt_id, completionKey) as
+			| {
+					candidate_ref: string;
+					confirmed_access_delta_digest: string;
+					completed_team_id: string;
+					response_json: string;
+					completed_at: string;
+			  }
+			| undefined;
+		if (
+			!existing ||
+			existing.candidate_ref !== model.draft.candidate_id ||
+			existing.confirmed_access_delta_digest !== preview.accessDeltaDigest ||
+			existing.completed_team_id !== model.teamId ||
+			existing.response_json !== JSON.stringify(result) ||
+			existing.completed_at !== now
+		) {
+			activationError("team_setup_completion_invalid");
+		}
+	}
 	return result;
+}
+
+function canonicalCompletionReplay(
+	db: Database,
+	input: { candidateRef: string; attemptId: string; completionKey: string },
+): LegacyTeamSetupActivationResultV1 | null {
+	const row = db
+		.prepare(
+			`SELECT completion.response_json
+			 FROM legacy_team_setup_completions AS completion
+			 JOIN legacy_team_setup_drafts AS draft
+			   ON draft.attempt_id = completion.attempt_id
+			  AND draft.candidate_id = completion.candidate_ref
+			  AND draft.finish_digest = completion.finish_digest
+			  AND draft.completed_team_id = completion.completed_team_id
+			 JOIN policy_teams AS team
+			   ON team.team_id = completion.completed_team_id AND team.status = 'active'
+			 WHERE completion.candidate_ref = ? AND completion.attempt_id = ?
+			   AND completion.finish_digest = ? AND draft.state = 'completed'
+			   AND NOT EXISTS (
+			     SELECT 1 FROM legacy_team_setup_drafts AS newer
+			     WHERE newer.candidate_id = draft.candidate_id AND newer.rowid > draft.rowid
+			   )`,
+		)
+		.get(input.candidateRef, input.attemptId, input.completionKey) as CompletionRow | undefined;
+	return row ? (JSON.parse(row.response_json) as LegacyTeamSetupActivationResultV1) : null;
+}
+
+/**
+ * Applies coordinator-owned completion facts after the caller has rewritten the
+ * current draft to match a validated manifest. The caller owns serialization
+ * and the surrounding immediate transaction.
+ */
+export function applyCanonicalLegacyTeamSetupActivationInTransaction(
+	db: Database,
+	input: PreviewLegacyTeamSetupActivationInput & {
+		policyRevision: string;
+		completedAt: string;
+		completionKey: string;
+		allowCompletedDraft?: boolean;
+		allowStaleDraft?: boolean;
+	},
+): LegacyTeamSetupActivationResultV1 {
+	try {
+		// A retry after a lost response or a reconciliation re-run must replay the
+		// committed application. Loading the completed draft first would validate
+		// pre-activation assignment expectations against post-activation state.
+		if (input.allowCompletedDraft) {
+			const replay = canonicalCompletionReplay(db, input);
+			if (replay) return replay;
+		}
+		const model = loadModel(db, { ...input, allowInactiveCanonicalTeam: true });
+		const inspected = buildPreview(model);
+		requireLegacyTeamSetupAccessDeltaWithinLimit(inspected.accessDelta);
+		const roster = model.devices
+			.filter((device) => device.decision !== "removed")
+			.map((device) => ({
+				deviceId: device.device_id,
+				fingerprint: device.key_fingerprint,
+				displayName: device.display_name,
+				enabled: device.enabled !== 0,
+			}));
+		return applyActivation(db, model, inspected, roster, input.completedAt, {
+			revisionOverride: input.policyRevision,
+			completionKey: input.completionKey,
+		});
+	} catch (error) {
+		throw normalizedActivationError(error);
+	}
+}
+
+/**
+ * Materializes only newly resolvable Projects for an already-completed Team.
+ * The caller owns serialization and the surrounding immediate transaction.
+ */
+export function applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(
+	db: Database,
+	input: {
+		candidateRef: string;
+		attemptId: string;
+		teamId: string;
+		projectRefs: readonly string[];
+		completedAt: string;
+	},
+): void {
+	try {
+		const projectRefs = [...new Set(input.projectRefs)].toSorted(compareText);
+		if (
+			projectRefs.length === 0 ||
+			projectRefs.length !== input.projectRefs.length ||
+			projectRefs.length > LEGACY_TEAM_SETUP_MAX_PROJECTS
+		) {
+			activationError("team_setup_completion_invalid");
+		}
+		const draft = db
+			.prepare(
+				`SELECT coordinator_id, group_id FROM legacy_team_setup_drafts AS draft
+				 WHERE attempt_id = ? AND candidate_id = ? AND state = 'completed'
+				   AND completed_team_id = ?
+				   AND NOT EXISTS (
+				     SELECT 1 FROM legacy_team_setup_drafts AS newer
+				     WHERE newer.candidate_id = draft.candidate_id AND newer.rowid > draft.rowid
+				   )`,
+			)
+			.get(input.attemptId, input.candidateRef, input.teamId) as
+			| { coordinator_id: string; group_id: string }
+			| undefined;
+		const team = db
+			.prepare(
+				`SELECT revision FROM policy_teams
+				 WHERE team_id = ? AND status = 'active' AND migration_state = 'completed'
+				   AND provenance = 'reviewed_team_candidate'
+				   AND device_eligibility_mode = 'reviewed_allowlist'`,
+			)
+			.get(input.teamId) as { revision: string } | undefined;
+		if (!draft || !team) activationError("team_setup_conflict");
+
+		const allProjects = db
+			.prepare(
+				`SELECT project_ref, source_project_identity, source_fingerprint,
+				        resolved_project_identity, target_scope_id
+				 FROM legacy_team_setup_draft_projects
+				 WHERE attempt_id = ?
+				 ORDER BY project_ref`,
+			)
+			.all(input.attemptId) as AdditiveProjectRow[];
+		const requestedProjectRefs = new Set(projectRefs);
+		const projects = allProjects.filter((project) => requestedProjectRefs.has(project.project_ref));
+		if (projects.length !== projectRefs.length) {
+			activationError("team_setup_completion_invalid");
+		}
+		const scopeIdsByResolved = new Map<string, Set<string>>();
+		for (const project of allProjects) {
+			if (!project.resolved_project_identity || !project.target_scope_id) continue;
+			const resolvedScopeIds =
+				scopeIdsByResolved.get(project.resolved_project_identity) ?? new Set();
+			resolvedScopeIds.add(project.target_scope_id);
+			scopeIdsByResolved.set(project.resolved_project_identity, resolvedScopeIds);
+		}
+		if ([...scopeIdsByResolved.values()].some((resolvedScopeIds) => resolvedScopeIds.size !== 1)) {
+			activationError("team_setup_conflict");
+		}
+		const scopeIds = db
+			.prepare(
+				`SELECT scope_id FROM replication_scopes
+				 WHERE coordinator_id = ? AND group_id = ? AND authority_type = 'coordinator'
+				   AND status = 'active' ORDER BY scope_id`,
+			)
+			.pluck()
+			.all(draft.coordinator_id, draft.group_id) as string[];
+		const groupScopeIds = db
+			.prepare(
+				`SELECT scope_id FROM replication_scopes
+				 WHERE coordinator_id = ? AND group_id = ? ORDER BY scope_id`,
+			)
+			.pluck()
+			.all(draft.coordinator_id, draft.group_id) as string[];
+		const mappings = db
+			.prepare(
+				`SELECT id, workspace_identity, project_pattern, scope_id, source
+				 FROM project_scope_mappings ORDER BY id`,
+			)
+			.all() as MappingRow[];
+		const recipients = db
+			.prepare(
+				`SELECT canonical_project_identity, recipient_kind, recipient_id, status, provenance
+				 FROM project_recipients ORDER BY canonical_project_identity, recipient_kind, recipient_id`,
+			)
+			.all() as RecipientRow[];
+		if (
+			!isLegacyTeamProjectCanonicalStateValid(
+				{
+					teamId: input.teamId,
+					scopeIds,
+					groupScopeIds,
+					projects: projects.map((project) => ({
+						sourceProjectIdentity: project.source_project_identity,
+						resolvedProjectIdentity: project.resolved_project_identity,
+						targetScopeId: project.target_scope_id,
+					})),
+					mappings: mappings.map((mapping) => ({
+						workspaceIdentity: mapping.workspace_identity,
+						projectPattern: mapping.project_pattern,
+						scopeId: mapping.scope_id,
+						source: mapping.source,
+					})),
+					recipients: recipients.map((recipient) => ({
+						canonicalProjectIdentity: recipient.canonical_project_identity,
+						recipientKind: recipient.recipient_kind,
+						recipientId: recipient.recipient_id,
+						status: recipient.status,
+					})),
+				},
+				db,
+			)
+		) {
+			activationError("team_setup_conflict");
+		}
+
+		for (const project of projects) {
+			const resolvedIdentity = project.resolved_project_identity as string;
+			const targetScopeId = project.target_scope_id as string;
+			const relatedMappings = mappings.filter(
+				(mapping) => mapping.project_pattern === project.source_project_identity,
+			);
+			const exactMapping = relatedMappings.some(
+				(mapping) =>
+					mapping.workspace_identity === resolvedIdentity && mapping.scope_id === targetScopeId,
+			);
+			if (
+				relatedMappings.some(
+					(mapping) =>
+						mapping.workspace_identity !== resolvedIdentity || mapping.scope_id !== targetScopeId,
+				)
+			) {
+				activationError("team_setup_conflict");
+			}
+			if (!exactMapping) {
+				db.prepare(
+					`INSERT INTO project_scope_mappings(
+					 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+					 ) VALUES (?, ?, ?, 1000, 'reviewed_team_setup', ?, ?)`,
+				).run(
+					resolvedIdentity,
+					project.source_project_identity,
+					targetScopeId,
+					input.completedAt,
+					input.completedAt,
+				);
+			}
+			// User revocation changes provenance to `user`; only a still setup-owned
+			// revoked edge can be safely reactivated for this newly converged Project.
+			db.prepare(
+				`INSERT INTO project_recipients(
+				 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+					 policy_revision, migration_state, source_fingerprint, idempotency_key,
+					 created_at, updated_at
+					 ) VALUES (?, 'team', ?, 'active', 'reviewed_team_setup', ?, 'completed', ?, ?, ?, ?)
+					 ON CONFLICT(canonical_project_identity, recipient_kind, recipient_id) DO UPDATE SET
+					   status = 'active', policy_revision = excluded.policy_revision,
+					   migration_state = 'completed', source_fingerprint = excluded.source_fingerprint,
+					   idempotency_key = excluded.idempotency_key, updated_at = excluded.updated_at
+					 WHERE project_recipients.provenance = 'reviewed_team_setup'`,
+			).run(
+				resolvedIdentity,
+				input.teamId,
+				team.revision,
+				project.source_fingerprint,
+				recipientPolicyDigest("legacy-team-project-recipient-v1", [resolvedIdentity, input.teamId]),
+				input.completedAt,
+				input.completedAt,
+			);
+			const recipientStatus = db
+				.prepare(
+					`SELECT status FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
+				)
+				.pluck()
+				.get(resolvedIdentity, input.teamId);
+			if (recipientStatus !== "active") activationError("team_setup_conflict");
+		}
+
+		requireSelectedProjectScopeMappings(
+			db,
+			projects.map((project) => ({
+				sourceProjectIdentity: project.source_project_identity,
+				resolvedProjectIdentity: project.resolved_project_identity as string,
+				targetScopeId: project.target_scope_id as string,
+			})),
+		);
+	} catch (error) {
+		throw normalizedActivationError(error);
+	}
 }
 
 async function finishLegacyTeamSetupActivationWithPublicationLock(
@@ -1839,7 +2249,14 @@ async function finishLegacyTeamSetupActivationWithPublicationLock(
 								if (!input.validateLockedPreview(lockedPreview)) {
 									activationError("team_setup_confirmation_stale");
 								}
-								return applyActivation(db, model, lockedPreview, freshRoster, now);
+								return applyActivation(
+									db,
+									model,
+									lockedPreview,
+									freshRoster,
+									input.canonicalCompletion?.completedAt ?? now,
+									{ revisionOverride: input.canonicalCompletion?.policyRevision },
+								);
 							})
 							.immediate();
 					} catch (error) {

--- a/packages/core/src/legacy-team-setup-errors.ts
+++ b/packages/core/src/legacy-team-setup-errors.ts
@@ -4,6 +4,9 @@ export type LegacyTeamSetupActivationErrorCode =
 	| "team_setup_projection_changed"
 	| "team_setup_assignment_changed"
 	| "team_setup_roster_unavailable"
+	| "team_setup_completion_unavailable"
+	| "team_setup_completion_conflict"
+	| "team_setup_completion_invalid"
 	| "team_setup_conflict"
 	| "team_setup_confirmation_stale"
 	| "team_setup_failed";
@@ -27,7 +30,11 @@ export type LegacyTeamSetupDraftErrorCode =
 
 export type LegacyTeamSetupCoreErrorCode =
 	| LegacyTeamSetupDraftErrorCode
-	| LegacyTeamSetupActivationErrorCode;
+	| LegacyTeamSetupActivationErrorCode
+	| "completion_conflict"
+	| "completion_manifest_invalid"
+	| "coordinator_completion_response_malformed"
+	| "coordinator_completion_group_mismatch";
 
 /**
  * Stable API compatibility boundary. Core keeps throwing its released strings;
@@ -54,9 +61,16 @@ export const LEGACY_TEAM_SETUP_API_ERROR_BY_CORE_ERROR = {
 	team_setup_projection_changed: "team_setup_projection_changed",
 	team_setup_assignment_changed: "team_setup_assignment_changed",
 	team_setup_roster_unavailable: "team_setup_roster_unavailable",
+	team_setup_completion_unavailable: "team_setup_completion_unavailable",
+	team_setup_completion_conflict: "team_setup_completion_conflict",
+	team_setup_completion_invalid: "team_setup_completion_invalid",
 	team_setup_conflict: "team_setup_conflict",
 	team_setup_confirmation_stale: "team_setup_confirmation_stale",
 	team_setup_failed: "team_setup_failed",
+	completion_conflict: "team_setup_completion_conflict",
+	completion_manifest_invalid: "team_setup_completion_invalid",
+	coordinator_completion_response_malformed: "team_setup_completion_invalid",
+	coordinator_completion_group_mismatch: "team_setup_completion_invalid",
 } as const satisfies Record<LegacyTeamSetupCoreErrorCode, LegacyTeamSetupActivationErrorCode>;
 
 export function legacyTeamSetupApiErrorCode(error: unknown): LegacyTeamSetupActivationErrorCode {


### PR DESCRIPTION
## Description
Add canonical and additive legacy Team completion application primitives. These transaction-scoped operations apply reviewed Team policy deterministically and expose typed completion errors for the manifest layer.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced