### PR TITLE
feat(core): validate canonical Team completion manifests

### DIFF
--- a/docs/plans/2026-09-04-additive-team-convergence-design.md
+++ b/docs/plans/2026-09-04-additive-team-convergence-design.md
@@ -1,0 +1,23 @@
+# Additive Team Convergence
+
+## Decision
+
+Completed Team setup reconciliation will materialize only canonical Projects that become locally resolvable after the initial completion. It will not replay device assignments, memberships, existing Project mappings, or cleanup during this additive pass.
+
+## Why
+
+A full activation is correct for the first canonical apply because the coordinator winner defines the reviewed policy. After completion, users can legitimately rebind devices and edit or delete Project mappings. Replaying the full activation when another canonical Project becomes resolvable would overwrite those later user actions.
+
+## Data flow
+
+Reconciliation compares the reconstructed completed manifest with the coordinator winner and resolves the winner's locally supported Projects. When the only difference is newly resolvable Projects, it rewrites the completed draft with those new Project rows and passes their refs to a project-only activation path. That path validates and writes only those mappings and Team recipients while intentionally preserving the original completion record.
+
+Initial completion, replacement-draft recovery, and divergent canonical policy continue through the existing full activation path.
+
+## Failure handling
+
+Project-only convergence remains transactional. Invalid scope evidence, conflicting selected mappings, or completion-history collisions roll back the new Project rows and writes without containing the already-valid completed Team policy.
+
+## Verification
+
+Regression coverage will start from a partial canonical completion, apply a post-completion device rebind and mapping deletion, make another canonical Project resolvable, and verify that only the new Project is materialized. Existing canonical replay and replacement-draft tests must continue to pass.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -500,6 +500,7 @@ export {
 } from "./legacy-recipient-policy-projection.js";
 export * from "./legacy-team-candidate.js";
 export * from "./legacy-team-setup-activation.js";
+export * from "./legacy-team-setup-completion-manifest.js";
 export * from "./legacy-team-setup-draft.js";
 export type {
 	LegacyTeamSetupCoreErrorCode,

--- a/packages/core/src/legacy-team-setup-activation.ts
+++ b/packages/core/src/legacy-team-setup-activation.ts
@@ -375,6 +375,17 @@ function requireAccessDeltaTraversalWithinLimit(
 	}
 }
 
+function requireCanonicalSnapshotWithinLimits(
+	devices: readonly unknown[],
+	projects: readonly unknown[],
+): void {
+	try {
+		requireLegacyTeamSetupSnapshotWithinLimits({ devices, projects });
+	} catch {
+		activationError("team_setup_completion_invalid");
+	}
+}
+
 function normalizedActivationError(error: unknown): LegacyTeamSetupActivationError {
 	if (error instanceof LegacyTeamSetupActivationError) return error;
 	if (
@@ -901,7 +912,7 @@ export function requireLegacyTeamSetupAccessDeltaWithinLimit(
 		delta.deviceAccessChanges.length,
 	];
 	if (counts.some((count) => count > LEGACY_TEAM_SETUP_MAX_ACCESS_DELTA_ENTRIES)) {
-		throw new Error("legacy_team_setup_roster_too_large");
+		activationError("team_setup_completion_invalid");
 	}
 }
 
@@ -1499,13 +1510,16 @@ function applyActivation(
 	preview: LegacyTeamSetupActivationPreviewV1,
 	freshRoster: Awaited<ReturnType<FinishLegacyTeamSetupActivationInput["loadFreshRoster"]>>,
 	now: string,
-	options: { revisionOverride?: string; completionKey?: string } = {},
+	options: {
+		revisionOverride?: string;
+		completionKey?: string;
+		allowExistingCompletion?: boolean;
+	} = {},
 ): LegacyTeamSetupActivationResultV1 {
 	const revision =
 		options.revisionOverride ??
 		recipientPolicyDigest("legacy-team-activation-revision-v1", preview.finishDigest);
 	const completionKey = options.completionKey ?? preview.finishDigest;
-	const allowExistingCompletion = options.completionKey !== undefined;
 	if (!model.team) {
 		db.prepare(
 			`INSERT INTO policy_teams(
@@ -1855,35 +1869,30 @@ function applyActivation(
 	] as const;
 	const insertedCompletion = db
 		.prepare(
-			`INSERT ${allowExistingCompletion ? "OR IGNORE " : ""}INTO legacy_team_setup_completions(
+			`INSERT ${options.allowExistingCompletion ? "OR IGNORE " : ""}INTO legacy_team_setup_completions(
 		 attempt_id, finish_digest, candidate_ref, confirmed_access_delta_digest,
 		 completed_team_id, response_json, completed_at, created_at
 		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		)
 		.run(...completionValues);
-	if (allowExistingCompletion && insertedCompletion.changes === 0) {
+	if (options.allowExistingCompletion && insertedCompletion.changes === 0) {
 		const existing = db
 			.prepare(
-				`SELECT candidate_ref, confirmed_access_delta_digest, completed_team_id,
-				        response_json, completed_at
+				`SELECT candidate_ref, completed_team_id, completed_at
 				 FROM legacy_team_setup_completions
 				 WHERE attempt_id = ? AND finish_digest = ?`,
 			)
 			.get(model.draft.attempt_id, completionKey) as
 			| {
 					candidate_ref: string;
-					confirmed_access_delta_digest: string;
 					completed_team_id: string;
-					response_json: string;
 					completed_at: string;
 			  }
 			| undefined;
 		if (
 			!existing ||
 			existing.candidate_ref !== model.draft.candidate_id ||
-			existing.confirmed_access_delta_digest !== preview.accessDeltaDigest ||
 			existing.completed_team_id !== model.teamId ||
-			existing.response_json !== JSON.stringify(result) ||
 			existing.completed_at !== now
 		) {
 			activationError("team_setup_completion_invalid");
@@ -1922,23 +1931,34 @@ function canonicalCompletionReplay(
  * Applies coordinator-owned completion facts after the caller has rewritten the
  * current draft to match a validated manifest. The caller owns serialization
  * and the surrounding immediate transaction.
+ *
+ * By default the completion is keyed by the derived preview digest so the
+ * originating device's confirmed replay token stays valid. Callers retrying an
+ * exact application against an already-completed draft pass `completionKey`
+ * to reuse the stored key; deriving a fresh preview from materialized policy
+ * would otherwise rotate the key on every retry.
  */
 export function applyCanonicalLegacyTeamSetupActivationInTransaction(
 	db: Database,
 	input: PreviewLegacyTeamSetupActivationInput & {
 		policyRevision: string;
 		completedAt: string;
-		completionKey: string;
+		completionKey?: string;
 		allowCompletedDraft?: boolean;
 		allowStaleDraft?: boolean;
 	},
 ): LegacyTeamSetupActivationResultV1 {
+	if (!db.inTransaction) activationError("team_setup_failed");
 	try {
 		// A retry after a lost response or a reconciliation re-run must replay the
 		// committed application. Loading the completed draft first would validate
 		// pre-activation assignment expectations against post-activation state.
-		if (input.allowCompletedDraft) {
-			const replay = canonicalCompletionReplay(db, input);
+		if (input.allowCompletedDraft && input.completionKey) {
+			const replay = canonicalCompletionReplay(db, {
+				candidateRef: input.candidateRef,
+				attemptId: input.attemptId,
+				completionKey: input.completionKey,
+			});
 			if (replay) return replay;
 		}
 		const model = loadModel(db, { ...input, allowInactiveCanonicalTeam: true });
@@ -1955,6 +1975,7 @@ export function applyCanonicalLegacyTeamSetupActivationInTransaction(
 		return applyActivation(db, model, inspected, roster, input.completedAt, {
 			revisionOverride: input.policyRevision,
 			completionKey: input.completionKey,
+			allowExistingCompletion: input.allowCompletedDraft,
 		});
 	} catch (error) {
 		throw normalizedActivationError(error);
@@ -1975,6 +1996,7 @@ export function applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(
 		completedAt: string;
 	},
 ): void {
+	if (!db.inTransaction) activationError("team_setup_failed");
 	try {
 		const projectRefs = [...new Set(input.projectRefs)].toSorted(compareText);
 		if (
@@ -2016,6 +2038,14 @@ export function applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(
 				 ORDER BY project_ref`,
 			)
 			.all(input.attemptId) as AdditiveProjectRow[];
+		const deviceIds = db
+			.prepare(
+				`SELECT device_id FROM legacy_team_setup_draft_devices
+				 WHERE attempt_id = ? ORDER BY device_id LIMIT ?`,
+			)
+			.pluck()
+			.all(input.attemptId, LEGACY_TEAM_SETUP_MAX_DEVICES + 1) as string[];
+		requireCanonicalSnapshotWithinLimits(deviceIds, allProjects);
 		const requestedProjectRefs = new Set(projectRefs);
 		const projects = allProjects.filter((project) => requestedProjectRefs.has(project.project_ref));
 		if (projects.length !== projectRefs.length) {

--- a/packages/core/src/legacy-team-setup-completion-manifest.test.ts
+++ b/packages/core/src/legacy-team-setup-completion-manifest.test.ts
@@ -1,0 +1,2122 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CoordinatorLegacyTeamCompletionManifestV1 } from "./coordinator-legacy-team-completion.js";
+import {
+	applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction,
+	applyCanonicalLegacyTeamSetupActivationInTransaction,
+	finishLegacyTeamSetupActivation,
+	inspectLegacyTeamSetupActivation,
+	requireLegacyTeamSetupAccessDeltaWithinLimit,
+} from "./legacy-team-setup-activation.js";
+import {
+	applyLegacyTeamSetupCompletionManifest,
+	areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible,
+	deriveLegacyTeamSetupCompletionManifest,
+	LegacyTeamSetupAdditiveConvergenceError,
+	reconstructLegacyTeamSetupCompletionManifest,
+	validateLegacyTeamSetupCompletionManifest,
+	validateLegacyTeamSetupCompletionManifestBinding,
+} from "./legacy-team-setup-completion-manifest.js";
+import {
+	legacyTeamResolvedProjectRef,
+	refreshLegacyTeamSetupDraft,
+	setLegacyTeamSetupDeviceAssignment,
+	setLegacyTeamSetupDeviceDecision,
+} from "./legacy-team-setup-draft.js";
+import {
+	legacyTeamCandidateId,
+	legacyTeamProjectRef,
+	recipientPolicyDigest,
+} from "./recipient-policy-identifiers.js";
+import { renameRecipientPolicyTeam } from "./recipient-policy-team-metadata.js";
+import { initTestSchema } from "./test-utils.js";
+
+const NOW = "2026-09-01T12:00:00.000Z";
+const COORDINATOR_ID = "coordinator-private";
+const GROUP_ID = "group-private";
+const CANDIDATE = legacyTeamCandidateId(COORDINATOR_ID, GROUP_ID);
+const PROJECT_A = "https://git.example.invalid/acme/api.git";
+const PROJECT_B = "https://git.example.invalid/acme/web.git";
+const PROJECT_C = "https://git.example.invalid/acme/new.git";
+const PROJECT_REF_A = legacyTeamProjectRef(CANDIDATE, PROJECT_A);
+const PROJECT_REF_C = legacyTeamProjectRef(CANDIDATE, PROJECT_C);
+const KEY_A = "a".repeat(64);
+const FRESH_ROSTER = [
+	{ deviceId: "device-a", fingerprint: KEY_A, displayName: "Laptop", enabled: true },
+];
+
+function rawDigest(domain: string, value: unknown): string {
+	return recipientPolicyDigest(domain, value).slice(domain.length + 1);
+}
+
+function refreshManifestDigests(
+	manifest: CoordinatorLegacyTeamCompletionManifestV1,
+): CoordinatorLegacyTeamCompletionManifestV1 {
+	const candidateDigest = rawDigest("legacy-team-completion-candidate-v1", {
+		coordinatorId: COORDINATOR_ID,
+		groupId: GROUP_ID,
+		candidateRef: manifest.candidate_ref,
+	});
+	const teamDigest = rawDigest("legacy-team-completion-team-v1", {
+		teamId: manifest.team_id,
+		displayName: manifest.team.display_name,
+		deviceEligibilityMode: manifest.team.device_eligibility_mode,
+	});
+	const sourceDigest = rawDigest("legacy-team-completion-source-v1", {
+		deviceDecisions: manifest.device_decisions,
+		projectMappings: manifest.project_mappings,
+	});
+	const accessDeltaDigest = rawDigest("legacy-team-completion-access-delta-v1", {
+		memberships: manifest.memberships,
+		projectRecipients: manifest.project_recipients,
+	});
+	const finishDigest = rawDigest("legacy-team-completion-finish-v1", {
+		candidateDigest,
+		teamDigest,
+		sourceDigest,
+		accessDeltaDigest,
+	});
+	return {
+		...manifest,
+		candidate_digest: candidateDigest,
+		team_digest: teamDigest,
+		source_digest: sourceDigest,
+		access_delta_digest: accessDeltaDigest,
+		finish_digest: finishDigest,
+		team: {
+			...manifest.team,
+			policy_revision: rawDigest("legacy-team-completion-policy-revision-v1", finishDigest),
+		},
+	};
+}
+
+describe("legacy Team setup completion manifests", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-a', 'Person A', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		db.prepare(
+			`INSERT INTO replication_scopes(
+			 scope_id, label, kind, authority_type, coordinator_id, group_id,
+			 membership_epoch, status, created_at, updated_at
+			 ) VALUES ('scope-engineering', 'Engineering', 'team', 'coordinator', ?, ?, 1,
+			 'active', ?, ?)`,
+		).run(COORDINATOR_ID, GROUP_ID, NOW, NOW);
+	});
+
+	afterEach(() => db.close());
+
+	function readyDraft() {
+		let draft = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [
+				{
+					deviceId: "device-a",
+					fingerprint: KEY_A,
+					displayName: "Laptop",
+					enabled: true,
+				},
+			],
+			projects: [],
+			now: NOW,
+		});
+		const device = draft.devices[0];
+		if (!device) throw new Error("missing test device");
+		draft = setLegacyTeamSetupDeviceAssignment(db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			targetIdentityId: "identity-a",
+			expectation: device.expectation,
+			now: NOW,
+		});
+		return setLegacyTeamSetupDeviceDecision(db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			decision: "included",
+			now: NOW,
+		});
+	}
+
+	it("accepts bounded access delta categories whose aggregate exceeds 10,000", () => {
+		expect(() =>
+			requireLegacyTeamSetupAccessDeltaWithinLimit({
+				teamChanges: [
+					{
+						teamId: "team-a",
+						change: "add",
+						fromDeviceEligibilityMode: null,
+						toDeviceEligibilityMode: "reviewed_allowlist",
+					},
+				],
+				membershipChanges: [],
+				projectChanges: [],
+				recipientChanges: [],
+				deviceAccessChanges: Array.from({ length: 10_000 }, (_, index) => ({
+					canonicalProjectIdentity: `project-${Math.floor(index / 500)}`,
+					deviceId: `device-${index % 500}`,
+					change: "add" as const,
+				})),
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects an oversized canonical activation delta", () => {
+		expect(() =>
+			requireLegacyTeamSetupAccessDeltaWithinLimit({
+				teamChanges: Array.from({ length: 10_001 }, (_, index) => ({
+					teamId: `team-${index}`,
+					change: "add",
+					fromDeviceEligibilityMode: null,
+					toDeviceEligibilityMode: "reviewed_allowlist",
+				})),
+				membershipChanges: [],
+				projectChanges: [],
+				recipientChanges: [],
+				deviceAccessChanges: [],
+			}),
+		).toThrow("team_setup_completion_invalid");
+	});
+
+	it("rejects a pre-limit completed attempt without reading past the device cap", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		// Simulate a historical completion persisted before the device cap.
+		const insertDevice = db.prepare(
+			`INSERT INTO legacy_team_setup_draft_devices(
+			 attempt_id, device_id, device_ref, key_fingerprint, display_name, enabled,
+			 existing_identity_id, existing_assignment_version, verified_evidence_kind,
+			 decision, target_identity_id, expected_assignment_kind,
+			 expected_assignment_version, updated_at
+			 ) VALUES (?, ?, ?, ?, ?, 1, NULL, NULL, NULL, 'excluded', NULL, 'absent', NULL, ?)`,
+		);
+		db.transaction(() => {
+			for (let index = 0; index < 600; index += 1) {
+				insertDevice.run(
+					draft.attemptId,
+					`device-legacy-${index.toString().padStart(4, "0")}`,
+					`device-ref-legacy-${index}`,
+					index.toString(16).padStart(64, "0"),
+					`Legacy ${index}`,
+					NOW,
+				);
+			}
+		})();
+		const originalPrepare = db.prepare.bind(db);
+		const materializedDeviceRows: number[] = [];
+		db.prepare = ((source: string) => {
+			const statement = originalPrepare(source);
+			if (!source.includes("FROM legacy_team_setup_draft_devices WHERE attempt_id = ?")) {
+				return statement;
+			}
+			const originalAll = statement.all.bind(statement);
+			statement.all = ((...args: unknown[]) => {
+				const rows = originalAll(...args);
+				materializedDeviceRows.push(rows.length);
+				return rows;
+			}) as typeof statement.all;
+			return statement;
+		}) as typeof db.prepare;
+
+		expect(() =>
+			reconstructLegacyTeamSetupCompletionManifest(db, { candidateRef: CANDIDATE }),
+		).toThrow("team_setup_completion_invalid");
+		expect(materializedDeviceRows).toEqual([501]);
+	});
+
+	it("rejects a pre-limit draft during full replacement without reading past the Project cap", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		const insertProject = db.prepare(
+			`INSERT INTO legacy_team_setup_draft_projects(
+			 attempt_id, project_ref, source_project_identity, display_name, source_fingerprint,
+			 resolution_kind, resolved_project_identity, target_scope_id, updated_at
+			 ) VALUES (?, ?, ?, ?, ?, 'explicit', ?, 'scope-a', ?)`,
+		);
+		db.transaction(() => {
+			for (let index = 0; index < 600; index += 1) {
+				const identity = `https://git.example.invalid/acme/legacy-${index.toString().padStart(4, "0")}.git`;
+				insertProject.run(
+					draft.attemptId,
+					legacyTeamProjectRef(CANDIDATE, identity),
+					identity,
+					`Legacy ${index}`,
+					`legacy-${index}`,
+					identity,
+					NOW,
+				);
+			}
+		})();
+		const originalPrepare = db.prepare.bind(db);
+		const materializedProjectRows: number[] = [];
+		db.prepare = ((source: string) => {
+			const statement = originalPrepare(source);
+			if (!source.includes("FROM legacy_team_setup_draft_projects WHERE attempt_id = ?")) {
+				return statement;
+			}
+			const originalAll = statement.all.bind(statement);
+			statement.all = ((...args: unknown[]) => {
+				const rows = originalAll(...args);
+				materializedProjectRows.push(rows.length);
+				return rows;
+			}) as typeof statement.all;
+			return statement;
+		}) as typeof db.prepare;
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		expect(materializedProjectRows.every((count) => count <= 501)).toBe(true);
+		expect(materializedProjectRows.length).toBeGreaterThan(0);
+	});
+
+	it("requires canonical activation helpers to run inside a transaction", () => {
+		const draft = readyDraft();
+
+		expect(() =>
+			applyCanonicalLegacyTeamSetupActivationInTransaction(db, {
+				candidateRef: draft.candidateRef,
+				attemptId: draft.attemptId,
+				policyRevision: "canonical-revision",
+				completedAt: NOW,
+				completionKey: "canonical-completion-key",
+			}),
+		).toThrow("team_setup_failed");
+		expect(() =>
+			applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(db, {
+				candidateRef: draft.candidateRef,
+				attemptId: draft.attemptId,
+				teamId: "policy-team-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				projectRefs: [],
+				completedAt: NOW,
+			}),
+		).toThrow("team_setup_failed");
+	});
+
+	it("derives and validates bounded canonical policy facts", () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+
+		expect(
+			validateLegacyTeamSetupCompletionManifest(manifest, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+			}),
+		).toEqual(manifest);
+		expect(manifest.memberships).toEqual([{ identity_id: "identity-a", role: "member" }]);
+		expect(manifest.finish_digest).toMatch(/^[0-9a-f]{64}$/u);
+		expect(manifest.access_delta_digest).toMatch(/^[0-9a-f]{64}$/u);
+		expect(manifest.device_decisions).toEqual([
+			{
+				device_id: "device-a",
+				key_fingerprint: KEY_A,
+				enabled: true,
+				identity_id: "identity-a",
+				decision: "included",
+			},
+		]);
+	});
+
+	it("rejects a validly digested manifest above the Project-device pair limit", () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		const deviceDecisions = Array.from({ length: 101 }, (_, index) => ({
+			device_id: `device-${index.toString().padStart(3, "0")}`,
+			key_fingerprint: index.toString(16).padStart(64, "0"),
+			enabled: true,
+			identity_id: "identity-a",
+			decision: "included" as const,
+		}));
+		const projectMappings = Array.from({ length: 100 }, (_, index) => {
+			const sourceIdentity = `https://git.example.invalid/acme/project-${index
+				.toString()
+				.padStart(3, "0")}.git`;
+			const projectRef = legacyTeamProjectRef(CANDIDATE, sourceIdentity);
+			return {
+				project_ref: projectRef,
+				resolved_project_ref: legacyTeamResolvedProjectRef(projectRef, sourceIdentity),
+				scope_id: "scope-a",
+			};
+		}).toSorted((left, right) => left.project_ref.localeCompare(right.project_ref));
+		const projectRecipients = projectMappings
+			.map((mapping) => ({
+				resolved_project_ref: mapping.resolved_project_ref,
+				team_id: manifest.team_id,
+			}))
+			.toSorted((left, right) =>
+				left.resolved_project_ref.localeCompare(right.resolved_project_ref),
+			);
+		const oversized = refreshManifestDigests({
+			...manifest,
+			device_decisions: deviceDecisions,
+			project_mappings: projectMappings,
+			project_recipients: projectRecipients,
+		});
+
+		expect(() =>
+			validateLegacyTeamSetupCompletionManifest(oversized, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+			}),
+		).toThrow("team_setup_completion_invalid");
+	});
+
+	it("rejects a digest or coordinator-group mismatch", () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+
+		expect(() =>
+			validateLegacyTeamSetupCompletionManifest(
+				{ ...manifest, source_digest: "0".repeat(64) },
+				{ coordinatorId: COORDINATOR_ID, groupId: GROUP_ID },
+			),
+		).toThrow("team_setup_completion_invalid");
+		expect(() =>
+			validateLegacyTeamSetupCompletionManifest(manifest, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: "other-group",
+			}),
+		).toThrow("team_setup_completion_invalid");
+	});
+
+	it("proves coordinator-group binding without requiring valid digests", () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		const digestInvalidManifest = { ...manifest, finish_digest: "0".repeat(64) };
+
+		expect(
+			validateLegacyTeamSetupCompletionManifestBinding(digestInvalidManifest, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+			}),
+		).toEqual(digestInvalidManifest);
+		expect(() =>
+			validateLegacyTeamSetupCompletionManifestBinding(manifest, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: "other-group",
+			}),
+		).toThrow("team_setup_completion_invalid");
+	});
+
+	it("rejects policy collections that do not match their canonical source facts", () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+
+		expect(() =>
+			validateLegacyTeamSetupCompletionManifest(
+				{ ...manifest, memberships: [] },
+				{ coordinatorId: COORDINATOR_ID, groupId: GROUP_ID },
+			),
+		).toThrow("team_setup_completion_invalid");
+		expect(() =>
+			validateLegacyTeamSetupCompletionManifest(
+				{
+					...manifest,
+					project_recipients: [
+						{ resolved_project_ref: "unexpected-project", team_id: manifest.team_id },
+					],
+				},
+				{ coordinatorId: COORDINATOR_ID, groupId: GROUP_ID },
+			),
+		).toThrow("team_setup_completion_invalid");
+	});
+
+	it("applies atomically and treats the same manifest as an exact replay", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		const localPreview = inspectLegacyTeamSetupActivation(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = ? WHERE attempt_id = ?").run(
+			"Stale local name",
+			draft.attemptId,
+		);
+
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const localCompletion = db
+			.prepare(
+				`SELECT finish_digest, confirmed_access_delta_digest
+				 FROM legacy_team_setup_completions WHERE attempt_id = ?`,
+			)
+			.get(draft.attemptId) as {
+			finish_digest: string;
+			confirmed_access_delta_digest: string;
+		};
+		expect(localCompletion).toEqual({
+			finish_digest: localPreview.finishDigest,
+			confirmed_access_delta_digest: localPreview.accessDeltaDigest,
+		});
+		expect(localCompletion.finish_digest).toMatch(
+			/^legacy-team-activation-finish-v1:[0-9a-f]{64}$/u,
+		);
+		expect(localCompletion.confirmed_access_delta_digest).toMatch(
+			/^legacy-team-access-delta:[0-9a-f]{64}$/u,
+		);
+		expect(localCompletion.finish_digest).not.toBe(manifest.finish_digest);
+		expect(localCompletion.confirmed_access_delta_digest).not.toBe(manifest.access_delta_digest);
+		expect(
+			db
+				.prepare("SELECT display_name FROM policy_teams WHERE team_id = ?")
+				.pluck()
+				.get(manifest.team_id),
+		).toBe(manifest.team.display_name);
+		expect(reconstructLegacyTeamSetupCompletionManifest(db, { candidateRef: CANDIDATE })).toEqual(
+			manifest,
+		);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(reconstructLegacyTeamSetupCompletionManifest(db, { candidateRef: CANDIDATE })).toEqual(
+			manifest,
+		);
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId),
+		).toBe("completed");
+	});
+
+	it("preserves inactive assignment evidence when applying an excluded device", async () => {
+		let draft = readyDraft();
+		const device = draft.devices[0];
+		if (!device) throw new Error("missing test device");
+		draft = setLegacyTeamSetupDeviceDecision(db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			decision: "excluded",
+			now: NOW,
+		});
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare(
+			`INSERT INTO identity_devices(
+			 identity_id, device_id, display_name, status, provenance, revision, migration_state,
+			 assignment_version, idempotency_key, created_at, updated_at
+			 ) VALUES ('identity-a', 'device-a', 'Laptop', 'revoked', 'reviewed_team_setup',
+			 'prior-revision', 'completed', 7, 'prior-device-assignment', ?, ?)`,
+		).run(NOW, NOW);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [],
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare(
+					`SELECT display_name, existing_identity_id, existing_assignment_version, verified_evidence_kind,
+					        expected_assignment_kind, expected_assignment_version
+					 FROM legacy_team_setup_draft_devices
+					 WHERE attempt_id = ? AND device_id = 'device-a'`,
+				)
+				.get(draft.attemptId),
+		).toEqual({
+			display_name: "Laptop",
+			existing_identity_id: "identity-a",
+			existing_assignment_version: 7,
+			verified_evidence_kind: null,
+			expected_assignment_kind: "existing",
+			expected_assignment_version: 7,
+		});
+		expect(
+			db
+				.prepare(
+					"SELECT decision FROM policy_team_device_decisions WHERE team_id = ? AND device_id = 'device-a'",
+				)
+				.pluck()
+				.get(manifest.team_id),
+		).toBe("excluded");
+	});
+
+	it("refreshes an existing draft device label from the live roster", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET display_name = ? WHERE attempt_id = ?",
+		).run("Stale laptop", draft.attemptId);
+
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: [
+				{
+					deviceId: "device-a",
+					fingerprint: KEY_A,
+					displayName: "  Renamed laptop  ",
+					enabled: true,
+				},
+			],
+			manifest,
+		});
+
+		expect(
+			db
+				.prepare(
+					"SELECT display_name FROM legacy_team_setup_draft_devices WHERE attempt_id = ? AND device_id = 'device-a'",
+				)
+				.pluck()
+				.get(draft.attemptId),
+		).toBe("Renamed laptop");
+		expect(
+			db
+				.prepare("SELECT display_name FROM identity_devices WHERE device_id = 'device-a'")
+				.pluck()
+				.get(),
+		).toBe("Renamed laptop");
+	});
+
+	it("applies a canonical completion over a stale local draft", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET state = 'stale' WHERE attempt_id = ?").run(
+			draft.attemptId,
+		);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId),
+		).toBe("completed");
+	});
+
+	it("materializes missing canonical devices and removes newer local membership grants", async () => {
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const source = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: source.candidateRef,
+			attemptId: source.attemptId,
+			completedAt: NOW,
+		});
+		let replacement = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [
+				{
+					deviceId: "device-new",
+					fingerprint: "key-new",
+					displayName: "New laptop",
+					enabled: true,
+				},
+			],
+			projects: [],
+			now: "2026-09-01T12:01:00.000Z",
+		});
+		const newDevice = replacement.devices.find((device) => device.displayName === "New laptop");
+		if (!newDevice) throw new Error("missing replacement device");
+		replacement = setLegacyTeamSetupDeviceAssignment(db, {
+			attemptId: replacement.attemptId,
+			deviceRef: newDevice.deviceRef,
+			targetIdentityId: "identity-b",
+			expectation: newDevice.expectation,
+			now: NOW,
+		});
+		replacement = setLegacyTeamSetupDeviceDecision(db, {
+			attemptId: replacement.attemptId,
+			deviceRef: newDevice.deviceRef,
+			decision: "included",
+			now: NOW,
+		});
+		db.prepare(
+			"DELETE FROM legacy_team_setup_draft_devices WHERE attempt_id = ? AND device_id = 'device-a'",
+		).run(replacement.attemptId);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare(
+					`SELECT identity_id, status FROM policy_team_memberships
+					 WHERE team_id = ? ORDER BY identity_id`,
+				)
+				.all(manifest.team_id),
+		).toEqual([{ identity_id: "identity-a", status: "reviewed_active" }]);
+		expect(
+			db
+				.prepare(
+					`SELECT device_id, decision FROM policy_team_device_decisions
+					 WHERE team_id = ? ORDER BY device_id`,
+				)
+				.all(manifest.team_id),
+		).toEqual([{ device_id: "device-a", decision: "included" }]);
+		expect(
+			db
+				.prepare(
+					`SELECT key_fingerprint, display_name, enabled FROM legacy_team_setup_draft_devices
+					 WHERE attempt_id = ? AND device_id = 'device-a'`,
+				)
+				.get(replacement.attemptId),
+		).toEqual({ key_fingerprint: KEY_A, display_name: "Laptop", enabled: 1 });
+		expect(
+			db
+				.prepare(
+					"SELECT device_id FROM legacy_team_setup_draft_devices WHERE attempt_id = ? ORDER BY device_id",
+				)
+				.pluck()
+				.all(replacement.attemptId),
+		).toEqual(["device-a"]);
+		expect(replacement.attemptId).not.toBe(source.attemptId);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(replacement.attemptId),
+		).toBe("completed");
+	});
+
+	it("adds newly resolvable Projects without replaying completed Team policy", async () => {
+		const projectRefB = legacyTeamProjectRef(CANDIDATE, PROJECT_B);
+		db.prepare(
+			`INSERT INTO replication_scopes(
+			 scope_id, label, kind, authority_type, coordinator_id, group_id,
+			 membership_epoch, status, created_at, updated_at
+			 ) VALUES ('scope-historical', 'Historical', 'team', 'coordinator', ?, ?, 1,
+			 'active', ?, ?)`,
+		).run(COORDINATOR_ID, GROUP_ID, NOW, NOW);
+		let source = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [{ deviceId: "device-a", fingerprint: KEY_A, displayName: "Laptop", enabled: true }],
+			projects: [
+				{
+					projectRef: PROJECT_REF_A,
+					sourceProjectIdentity: PROJECT_A,
+					displayName: "API",
+					sourceFingerprint: "source-a",
+					deterministicProjectIdentity: PROJECT_A,
+					targetScopeId: "scope-engineering",
+				},
+				{
+					projectRef: projectRefB,
+					sourceProjectIdentity: PROJECT_B,
+					displayName: "Web",
+					sourceFingerprint: "source-b",
+					deterministicProjectIdentity: PROJECT_B,
+					targetScopeId: "scope-historical",
+				},
+			],
+			now: NOW,
+		});
+		const sourceDevice = source.devices[0];
+		if (!sourceDevice) throw new Error("missing source device");
+		source = setLegacyTeamSetupDeviceAssignment(db, {
+			attemptId: source.attemptId,
+			deviceRef: sourceDevice.deviceRef,
+			targetIdentityId: "identity-a",
+			expectation: sourceDevice.expectation,
+			now: NOW,
+		});
+		source = setLegacyTeamSetupDeviceDecision(db, {
+			attemptId: source.attemptId,
+			deviceRef: sourceDevice.deviceRef,
+			decision: "included",
+			now: NOW,
+		});
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: source.candidateRef,
+			attemptId: source.attemptId,
+			completedAt: NOW,
+		});
+		const replacement = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [{ deviceId: "device-a", fingerprint: KEY_A, displayName: "Laptop", enabled: true }],
+			projects: [
+				{
+					projectRef: PROJECT_REF_A,
+					sourceProjectIdentity: PROJECT_A,
+					displayName: "API",
+					sourceFingerprint: "source-a",
+					deterministicProjectIdentity: PROJECT_A,
+					targetScopeId: "scope-engineering",
+				},
+				{
+					projectRef: PROJECT_REF_C,
+					sourceProjectIdentity: PROJECT_C,
+					displayName: "New Project",
+					sourceFingerprint: "source-c",
+					deterministicProjectIdentity: PROJECT_C,
+					targetScopeId: "scope-engineering",
+				},
+			],
+			now: "2026-09-01T12:01:00.000Z",
+		});
+		db.prepare("UPDATE replication_scopes SET status = 'inactive' WHERE scope_id = ?").run(
+			"scope-historical",
+		);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare(
+					`SELECT canonical_project_identity FROM project_recipients
+					 WHERE recipient_kind = 'team' AND recipient_id = ? AND status = 'active'
+					 ORDER BY canonical_project_identity`,
+				)
+				.pluck()
+				.all(manifest.team_id),
+		).toEqual([PROJECT_A]);
+		expect(
+			db
+				.prepare(
+					`SELECT project_pattern, workspace_identity FROM project_scope_mappings
+					 WHERE source = 'reviewed_team_setup' ORDER BY project_pattern`,
+				)
+				.all(),
+		).toEqual([{ project_pattern: PROJECT_A, workspace_identity: PROJECT_A }]);
+		expect(
+			db
+				.prepare(
+					"SELECT project_ref FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref",
+				)
+				.pluck()
+				.all(replacement.attemptId),
+		).toEqual([PROJECT_REF_A]);
+		expect(
+			areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible(
+				reconstructLegacyTeamSetupCompletionManifest(db, { candidateRef: CANDIDATE }),
+				manifest,
+			),
+		).toBe(true);
+		db.prepare(
+			`INSERT INTO legacy_team_setup_draft_projects(
+			 attempt_id, project_ref, source_project_identity, display_name, source_fingerprint,
+			 resolution_kind, resolved_project_identity, target_scope_id, updated_at
+			 ) VALUES (?, ?, ?, 'Cross-scope project', 'cross-scope-source', 'explicit', ?,
+			 'scope-historical', ?)`,
+		).run(replacement.attemptId, projectRefB, PROJECT_B, PROJECT_A, NOW);
+		const applyCrossScopeProject = db.transaction(() =>
+			applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(db, {
+				candidateRef: CANDIDATE,
+				attemptId: replacement.attemptId,
+				teamId: manifest.team_id,
+				projectRefs: [projectRefB],
+				completedAt: NOW,
+			}),
+		);
+		expect(() => applyCrossScopeProject.immediate()).toThrow("team_setup_conflict");
+		db.prepare(
+			"DELETE FROM legacy_team_setup_draft_projects WHERE attempt_id = ? AND project_ref = ?",
+		).run(replacement.attemptId, projectRefB);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		db.prepare(
+			`UPDATE project_recipients
+			 SET status = 'revoked', provenance = 'user', updated_at = ?
+			 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
+		).run("2026-09-01T12:01:30.000Z", PROJECT_A, manifest.team_id);
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		db.prepare(
+			`UPDATE identity_devices SET identity_id = 'identity-b', updated_at = ?
+			 WHERE device_id = 'device-a' AND status = 'active'`,
+		).run("2026-09-01T12:01:30.000Z");
+		db.prepare(
+			`DELETE FROM project_scope_mappings
+			 WHERE project_pattern = ? AND source = 'reviewed_team_setup'`,
+		).run(PROJECT_A);
+		db.prepare("UPDATE replication_scopes SET status = 'active' WHERE scope_id = ?").run(
+			"scope-historical",
+		);
+		db.prepare("INSERT INTO sessions(started_at, project, git_remote) VALUES (?, ?, ?)").run(
+			NOW,
+			"Web workspace",
+			PROJECT_B,
+		);
+		db.prepare(
+			`INSERT INTO project_scope_mappings(
+			 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, ?, 'scope-engineering', 1000, 'user', ?, ?)`,
+		).run(PROJECT_B, PROJECT_B, NOW, NOW);
+		const completionCountBeforeFailedConvergence = db
+			.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions")
+			.pluck()
+			.get();
+		let additiveFailure: unknown;
+		try {
+			await applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			});
+		} catch (error) {
+			additiveFailure = error;
+		}
+		expect(additiveFailure).toBeInstanceOf(LegacyTeamSetupAdditiveConvergenceError);
+		expect(additiveFailure).toMatchObject({ code: "team_setup_conflict" });
+		expect(
+			db.prepare("SELECT status FROM policy_teams WHERE team_id = ?").pluck().get(manifest.team_id),
+		).toBe("active");
+		expect(
+			db
+				.prepare(
+					"SELECT project_ref FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref",
+				)
+				.pluck()
+				.all(replacement.attemptId),
+		).toEqual([PROJECT_REF_A]);
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions").pluck().get()).toBe(
+			completionCountBeforeFailedConvergence,
+		);
+		db.prepare(
+			"DELETE FROM project_scope_mappings WHERE workspace_identity = ? AND source = 'user'",
+		).run(PROJECT_B);
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key,
+			 created_at, updated_at
+			 ) VALUES (?, 'team', ?, 'revoked', 'reviewed_team_setup', ?, 'completed', ?, ?, ?, ?)`,
+		).run(
+			PROJECT_B,
+			manifest.team_id,
+			manifest.team.policy_revision,
+			"source-b",
+			"revoked-before-convergence",
+			NOW,
+			NOW,
+		);
+		const insertNewerSession = db.prepare(
+			"INSERT INTO sessions(started_at, project, git_remote) VALUES (?, ?, ?)",
+		);
+		for (let index = 0; index < 500; index += 1) {
+			insertNewerSession.run(
+				new Date(Date.parse(NOW) + (index + 1) * 1000).toISOString(),
+				"API workspace",
+				PROJECT_A,
+			);
+		}
+		db.prepare(
+			"UPDATE policy_teams SET display_name = 'Platform', revision = 'rename-revision' WHERE team_id = ?",
+		).run(manifest.team_id);
+		db.prepare(
+			"UPDATE legacy_team_setup_drafts SET display_name = 'Platform' WHERE attempt_id = ?",
+		).run(replacement.attemptId);
+		const preservedTeam = db
+			.prepare("SELECT * FROM policy_teams WHERE team_id = ?")
+			.get(manifest.team_id);
+		const preservedDraft = db
+			.prepare("SELECT * FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+			.get(replacement.attemptId);
+		const preservedCompletions = db
+			.prepare(
+				`SELECT * FROM legacy_team_setup_completions
+				 WHERE candidate_ref = ? ORDER BY completed_at, finish_digest`,
+			)
+			.all(CANDIDATE);
+		const preservedMemberships = db
+			.prepare("SELECT * FROM policy_team_memberships WHERE team_id = ? ORDER BY identity_id")
+			.all(manifest.team_id);
+		const preservedDecisions = db
+			.prepare("SELECT * FROM policy_team_device_decisions WHERE team_id = ? ORDER BY device_id")
+			.all(manifest.team_id);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(
+			db
+				.prepare(
+					`SELECT canonical_project_identity FROM project_recipients
+					 WHERE recipient_kind = 'team' AND recipient_id = ? AND status = 'active'
+					 ORDER BY canonical_project_identity`,
+				)
+				.pluck()
+				.all(manifest.team_id),
+		).toEqual([PROJECT_B]);
+		expect(
+			db
+				.prepare(
+					`SELECT project_pattern, workspace_identity FROM project_scope_mappings
+					 WHERE source = 'reviewed_team_setup' ORDER BY project_pattern`,
+				)
+				.all(),
+		).toEqual([{ project_pattern: PROJECT_B, workspace_identity: PROJECT_B }]);
+		expect(
+			db
+				.prepare(
+					`SELECT status, provenance, policy_revision FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
+				)
+				.get(PROJECT_A, manifest.team_id),
+		).toEqual({
+			status: "revoked",
+			provenance: "user",
+			policy_revision: manifest.team.policy_revision,
+		});
+		expect(
+			db
+				.prepare(
+					`SELECT status, provenance, policy_revision FROM project_recipients
+					 WHERE canonical_project_identity = ? AND recipient_kind = 'team' AND recipient_id = ?`,
+				)
+				.get(PROJECT_B, manifest.team_id),
+		).toEqual({
+			status: "active",
+			provenance: "reviewed_team_setup",
+			policy_revision: "rename-revision",
+		});
+		expect(
+			db
+				.prepare(
+					"SELECT display_name FROM legacy_team_setup_draft_projects WHERE attempt_id = ? AND project_ref = ?",
+				)
+				.pluck()
+				.get(replacement.attemptId, projectRefB),
+		).toBe("Web workspace");
+		expect(
+			db
+				.prepare("SELECT display_name, revision FROM policy_teams WHERE team_id = ?")
+				.get(manifest.team_id),
+		).toEqual({ display_name: "Platform", revision: "rename-revision" });
+		expect(
+			db
+				.prepare("SELECT display_name FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(replacement.attemptId),
+		).toBe("Platform");
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(replacement.attemptId),
+		).toBe("completed");
+		expect(
+			db
+				.prepare(
+					"SELECT identity_id FROM identity_devices WHERE device_id = 'device-a' AND status = 'active'",
+				)
+				.pluck()
+				.get(),
+		).toBe("identity-b");
+		expect(
+			db.prepare("SELECT * FROM policy_teams WHERE team_id = ?").get(manifest.team_id),
+		).toEqual(preservedTeam);
+		expect(
+			db
+				.prepare("SELECT * FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.get(replacement.attemptId),
+		).toEqual(preservedDraft);
+		expect(
+			db
+				.prepare(
+					`SELECT * FROM legacy_team_setup_completions
+					 WHERE candidate_ref = ? ORDER BY completed_at, finish_digest`,
+				)
+				.all(CANDIDATE),
+		).toEqual(preservedCompletions);
+		expect(
+			db
+				.prepare("SELECT * FROM policy_team_memberships WHERE team_id = ? ORDER BY identity_id")
+				.all(manifest.team_id),
+		).toEqual(preservedMemberships);
+		expect(
+			db
+				.prepare("SELECT * FROM policy_team_device_decisions WHERE team_id = ? ORDER BY device_id")
+				.all(manifest.team_id),
+		).toEqual(preservedDecisions);
+
+		const additiveFacts = {
+			mappings: db.prepare("SELECT * FROM project_scope_mappings ORDER BY id").all(),
+			recipients: db
+				.prepare(
+					`SELECT * FROM project_recipients
+					 WHERE recipient_kind = 'team' AND recipient_id = ? ORDER BY canonical_project_identity`,
+				)
+				.all(manifest.team_id),
+			projects: db
+				.prepare(
+					"SELECT * FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref",
+				)
+				.all(replacement.attemptId),
+		};
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect({
+			mappings: db.prepare("SELECT * FROM project_scope_mappings ORDER BY id").all(),
+			recipients: db
+				.prepare(
+					`SELECT * FROM project_recipients
+					 WHERE recipient_kind = 'team' AND recipient_id = ? ORDER BY canonical_project_identity`,
+				)
+				.all(manifest.team_id),
+			projects: db
+				.prepare(
+					"SELECT * FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref",
+				)
+				.all(replacement.attemptId),
+		}).toEqual(additiveFacts);
+	});
+
+	it("preserves a supported linked Team rename when reconciling the original manifest", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		db.prepare(
+			"UPDATE policy_teams SET display_name = 'Platform', revision = 'rename-revision'",
+		).run();
+		db.prepare(
+			"UPDATE legacy_team_setup_drafts SET display_name = 'Platform' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(db.prepare("SELECT display_name, revision FROM policy_teams").get()).toEqual({
+			display_name: "Platform",
+			revision: "rename-revision",
+		});
+	});
+
+	it("keeps the completion key stable across exact re-applications of a completed draft", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		const localPreview = inspectLegacyTeamSetupActivation(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const completionKeys = () =>
+			db
+				.prepare(
+					`SELECT draft.finish_digest AS draft_key, completion.finish_digest AS completion_key
+					 FROM legacy_team_setup_drafts AS draft
+					 JOIN legacy_team_setup_completions AS completion
+					   ON completion.attempt_id = draft.attempt_id
+					 WHERE draft.attempt_id = ?`,
+				)
+				.all(draft.attemptId);
+		expect(completionKeys()).toEqual([
+			{ draft_key: localPreview.finishDigest, completion_key: localPreview.finishDigest },
+		]);
+
+		// Force the full re-apply path (reconstruction reports a rename conflict)
+		// twice: neither retry may rotate the key or append a completion row.
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			db.prepare("UPDATE policy_teams SET display_name = 'Platform'").run();
+			db.prepare(
+				"UPDATE legacy_team_setup_drafts SET display_name = 'Platform' WHERE attempt_id = ?",
+			).run(draft.attemptId);
+			await expect(
+				applyLegacyTeamSetupCompletionManifest(db, {
+					coordinatorId: COORDINATOR_ID,
+					groupId: GROUP_ID,
+					freshRoster: FRESH_ROSTER,
+					manifest,
+				}),
+			).resolves.toEqual(manifest);
+			expect(completionKeys()).toEqual([
+				{ draft_key: localPreview.finishDigest, completion_key: localPreview.finishDigest },
+			]);
+		}
+		await expect(
+			finishLegacyTeamSetupActivation(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+				finishDigest: localPreview.finishDigest,
+				confirmedAccessDeltaDigest: localPreview.accessDeltaDigest,
+				loadFreshRoster: async () => [],
+				loadProjectInventory: () => [],
+			}),
+		).resolves.toMatchObject({ status: "completed", teamId: manifest.team_id });
+	});
+
+	it("treats a changed completion timestamp as metadata-only during replay", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const restampedManifest = {
+			...manifest,
+			completed_at: "2026-09-01T12:01:00.000Z",
+		};
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: restampedManifest,
+			}),
+		).resolves.toEqual(restampedManifest);
+		expect(db.prepare("SELECT status FROM policy_teams").pluck().get()).toBe("active");
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions").pluck().get()).toBe(1);
+	});
+
+	it("preserves completed policy when local Project candidates exceed the apply limit", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const insertSession = db.prepare(
+			"INSERT INTO sessions(started_at, project, git_remote) VALUES (?, ?, ?)",
+		);
+		const insertCandidates = db.transaction(() => {
+			for (let index = 0; index <= 500; index += 1) {
+				insertSession.run(NOW, `Project ${index}`, `https://git.example.invalid/acme/${index}.git`);
+			}
+		});
+		insertCandidates();
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: { ...manifest, completed_at: "2026-09-01T12:01:00.000Z" },
+			}),
+		).rejects.toThrow("team_setup_roster_unavailable");
+		expect(db.prepare("SELECT status FROM policy_teams").pluck().get()).toBe("active");
+	});
+
+	it("preserves completed policy when the local Project scan exceeds its budget", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const insertSession = db.prepare(
+			"INSERT INTO sessions(started_at, project, git_remote) VALUES (?, ?, ?)",
+		);
+		const fillScanBudget = db.transaction(() => {
+			for (let index = 0; index <= 10_000; index += 1) {
+				insertSession.run(NOW, "Repeated project", PROJECT_A);
+			}
+		});
+		fillScanBudget();
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: { ...manifest, completed_at: "2026-09-01T12:01:00.000Z" },
+			}),
+		).rejects.toThrow("team_setup_roster_unavailable");
+		expect(db.prepare("SELECT status FROM policy_teams").pluck().get()).toBe("active");
+	});
+
+	it("preserves an active Team rename when applying the original manifest to a replacement draft", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const expandedRoster = [
+			...FRESH_ROSTER,
+			{
+				deviceId: "device-b",
+				fingerprint: "b".repeat(64),
+				displayName: "Tablet",
+				enabled: true,
+			},
+		];
+		const replacement = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Platform",
+			devices: expandedRoster,
+			projects: [],
+			now: "2026-09-01T12:01:00.000Z",
+		});
+		db.prepare(
+			"UPDATE policy_teams SET display_name = 'Platform', revision = 'rename-revision'",
+		).run();
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = 'Platform'").run();
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: expandedRoster,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		expect(db.prepare("SELECT display_name, revision FROM policy_teams").get()).toEqual({
+			display_name: "Platform",
+			revision: manifest.team.policy_revision,
+		});
+		expect(
+			db
+				.prepare("SELECT display_name, state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.get(replacement.attemptId),
+		).toEqual({ display_name: "Platform", state: "completed" });
+	});
+
+	it("validates fresh included-device evidence before completed replay", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [
+					{ deviceId: "device-a", fingerprint: "key-b", displayName: "Laptop", enabled: true },
+				],
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [
+					{ deviceId: "device-a", fingerprint: "key-b", displayName: "Laptop", enabled: true },
+				],
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).resolves.toEqual(manifest);
+		// Quarantine cleared the completion key, so recovery mints a new one; the
+		// second recovery then reuses it instead of rotating again.
+		expect(db.prepare("SELECT COUNT(*) FROM legacy_team_setup_completions").pluck().get()).toBe(2);
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [
+					{ deviceId: "device-a", fingerprint: "key-b", displayName: "Laptop", enabled: true },
+				],
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		db.prepare(
+			`UPDATE legacy_team_setup_completions SET completed_team_id = 'unexpected-team'
+			 WHERE rowid = (SELECT MAX(rowid) FROM legacy_team_setup_completions)`,
+		).run();
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		expect(
+			db.prepare("SELECT status FROM policy_teams WHERE team_id = ?").pluck().get(manifest.team_id),
+		).toBe("inactive");
+	});
+
+	it("rejects a canonical completion when an included device was re-keyed", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		const replacement = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [
+				{
+					deviceId: "device-a",
+					fingerprint: "key-b",
+					displayName: "Laptop",
+					enabled: true,
+				},
+			],
+			projects: [],
+			now: "2026-09-01T12:01:00.000Z",
+		});
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [
+					{ deviceId: "device-a", fingerprint: "key-b", displayName: "Laptop", enabled: true },
+				],
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		expect(
+			db
+				.prepare(
+					"SELECT state, key_fingerprint FROM legacy_team_setup_drafts JOIN legacy_team_setup_draft_devices USING (attempt_id) WHERE attempt_id = ?",
+				)
+				.get(replacement.attemptId),
+		).toEqual({ state: "needs_setup", key_fingerprint: "key-b" });
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+	});
+
+	it("rejects a canonical completion when an included device was disabled", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: [
+					{ deviceId: "device-a", fingerprint: KEY_A, displayName: "Laptop", enabled: false },
+				],
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+	});
+
+	it("contains active policy when canonical apply fails on a replacement draft", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const replacement = refreshLegacyTeamSetupDraft(db, {
+			candidateId: CANDIDATE,
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			displayName: "Engineering",
+			devices: [
+				{
+					deviceId: "device-a",
+					fingerprint: KEY_A,
+					displayName: "Laptop",
+					enabled: true,
+				},
+			],
+			projects: [],
+			now: "2026-09-01T12:01:00.000Z",
+		});
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key,
+			 created_at, updated_at
+			 ) VALUES ('project-private', 'team', ?, 'active', 'reviewed_team_setup',
+			 'local-revision', 'completed', 'local-source', 'local-key', ?, ?)`,
+		).run(manifest.team_id, NOW, NOW);
+		db.prepare("UPDATE actors SET status = 'inactive' WHERE actor_id = 'identity-a'").run();
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_conflict");
+		expect(
+			db.prepare("SELECT status FROM policy_teams WHERE team_id = ?").pluck().get(manifest.team_id),
+		).toBe("inactive");
+		expect(
+			db
+				.prepare(
+					`SELECT status FROM project_recipients
+					 WHERE canonical_project_identity = 'project-private'`,
+				)
+				.pluck()
+				.get(),
+		).toBe("revoked");
+		expect(replacement.state).toBe("needs_setup");
+	});
+
+	it("quarantines divergent local policy when Project resolution exceeds its budget", async () => {
+		const draft = readyDraft();
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const localManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-b' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		const canonicalManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-a' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest: localManifest,
+		});
+		expect(db.prepare("SELECT status FROM policy_teams").pluck().get()).toBe("active");
+		const insertSession = db.prepare(
+			"INSERT INTO sessions(started_at, project, git_remote) VALUES (?, ?, ?)",
+		);
+		db.transaction(() => {
+			for (let index = 0; index <= 10_000; index += 1) {
+				insertSession.run(NOW, "Repeated project", PROJECT_A);
+			}
+		})();
+
+		// The winner diverges from the active local policy and cannot be applied
+		// while the local inventory is over budget, so the superseded policy must
+		// not stay active across retries that keep failing the same way.
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: canonicalManifest,
+			}),
+		).rejects.toThrow("team_setup_roster_unavailable");
+		expect(db.prepare("SELECT status FROM policy_teams").pluck().get()).toBe("inactive");
+	});
+
+	it("preserves a proven rename when a divergent winner is re-applied over a completed draft", async () => {
+		const draft = readyDraft();
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const localManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-b' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		const divergentManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-a' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest: localManifest,
+		});
+		// The user renames the completed Team through the real rename path.
+		await renameRecipientPolicyTeam(db, {
+			teamId: localManifest.team_id,
+			displayName: "Platform",
+			expectedDisplayName: localManifest.team.display_name,
+			configuredCoordinatorGroups: [{ coordinatorId: COORDINATOR_ID, groupId: GROUP_ID }],
+			renameCoordinatorGroup: async () => true,
+			now: "2026-09-01T12:00:30.000Z",
+		});
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: divergentManifest,
+			}),
+		).resolves.toEqual(divergentManifest);
+		// Memberships converge on the winner while the proven rename survives.
+		expect(
+			db
+				.prepare("SELECT display_name, revision FROM policy_teams WHERE team_id = ?")
+				.get(divergentManifest.team_id),
+		).toEqual({ display_name: "Platform", revision: divergentManifest.team.policy_revision });
+		expect(
+			db
+				.prepare(
+					"SELECT identity_id FROM identity_devices WHERE device_id = 'device-a' AND status = 'active'",
+				)
+				.pluck()
+				.get(),
+		).toBe("identity-b");
+	});
+
+	it("supersedes a divergent pre-protocol local completion", async () => {
+		const draft = readyDraft();
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const localManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = ? WHERE attempt_id = ?").run(
+			"Platform",
+			draft.attemptId,
+		);
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-b' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		const canonicalManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = ? WHERE attempt_id = ?").run(
+			"Engineering",
+			draft.attemptId,
+		);
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-a' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest: localManifest,
+		});
+		const oldCompletion = db
+			.prepare(
+				`SELECT finish_digest, confirmed_access_delta_digest
+				 FROM legacy_team_setup_completions WHERE attempt_id = ?`,
+			)
+			.get(draft.attemptId) as {
+			finish_digest: string;
+			confirmed_access_delta_digest: string;
+		};
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: canonicalManifest,
+			}),
+		).resolves.toEqual(canonicalManifest);
+		expect(reconstructLegacyTeamSetupCompletionManifest(db, { candidateRef: CANDIDATE })).toEqual(
+			canonicalManifest,
+		);
+		expect(
+			db
+				.prepare("SELECT display_name FROM policy_teams WHERE team_id = ?")
+				.pluck()
+				.get(canonicalManifest.team_id),
+		).toBe("Platform");
+		expect(
+			db
+				.prepare(
+					"SELECT identity_id FROM identity_devices WHERE device_id = 'device-a' AND status = 'active'",
+				)
+				.pluck()
+				.get(),
+		).toBe("identity-b");
+		await expect(
+			finishLegacyTeamSetupActivation(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+				finishDigest: oldCompletion.finish_digest,
+				confirmedAccessDeltaDigest: oldCompletion.confirmed_access_delta_digest,
+				loadFreshRoster: async () => [],
+				loadProjectInventory: () => [],
+			}),
+		).rejects.toThrow("team_setup_confirmation_stale");
+	});
+
+	it("quarantines divergent local policy when the canonical winner cannot be applied", async () => {
+		const draft = readyDraft();
+		db.prepare(
+			`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+			 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+		).run(NOW, NOW);
+		const localManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = ? WHERE attempt_id = ?").run(
+			"Platform",
+			draft.attemptId,
+		);
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-b' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		const canonicalManifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE legacy_team_setup_drafts SET display_name = ? WHERE attempt_id = ?").run(
+			"Engineering",
+			draft.attemptId,
+		);
+		db.prepare(
+			"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-a' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest: localManifest,
+		});
+		const oldCompletion = db
+			.prepare(
+				`SELECT finish_digest, confirmed_access_delta_digest
+				 FROM legacy_team_setup_completions WHERE attempt_id = ?`,
+			)
+			.get(draft.attemptId) as {
+			finish_digest: string;
+			confirmed_access_delta_digest: string;
+		};
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key,
+			 created_at, updated_at
+			 ) VALUES ('project-private', 'team', ?, 'active', 'reviewed_team_setup',
+			 'local-revision', 'completed', 'local-source', 'local-key', ?, ?)`,
+		).run(canonicalManifest.team_id, NOW, NOW);
+		db.prepare("UPDATE actors SET status = 'inactive' WHERE actor_id = 'identity-b'").run();
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: canonicalManifest,
+			}),
+		).rejects.toThrow("team_setup_conflict");
+		expect(
+			db
+				.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+				.get(canonicalManifest.team_id),
+		).toEqual({ status: "inactive", migration_state: "needs_setup" });
+		expect(
+			db
+				.prepare(
+					`SELECT status, migration_state FROM project_recipients
+					 WHERE canonical_project_identity = 'project-private'`,
+				)
+				.get(),
+		).toEqual({ status: "revoked", migration_state: "needs_setup" });
+		db.prepare(
+			"UPDATE legacy_team_setup_drafts SET state = 'in_progress' WHERE attempt_id = ?",
+		).run(draft.attemptId);
+		const assignmentVersion = db
+			.prepare(
+				"SELECT assignment_version FROM identity_devices WHERE device_id = 'device-a' AND status = 'active'",
+			)
+			.pluck()
+			.get() as number;
+		db.prepare(
+			`UPDATE legacy_team_setup_draft_devices
+			 SET existing_identity_id = 'identity-a', existing_assignment_version = ?,
+			     verified_evidence_kind = 'active_assignment', expected_assignment_kind = 'existing',
+			     expected_assignment_version = ?
+			 WHERE attempt_id = ? AND device_id = 'device-a'`,
+		).run(assignmentVersion, assignmentVersion, draft.attemptId);
+		expect(() =>
+			inspectLegacyTeamSetupActivation(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+			}),
+		).toThrow("team_setup_conflict");
+		db.prepare("UPDATE legacy_team_setup_drafts SET state = 'completed' WHERE attempt_id = ?").run(
+			draft.attemptId,
+		);
+		await expect(
+			finishLegacyTeamSetupActivation(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+				finishDigest: oldCompletion.finish_digest,
+				confirmedAccessDeltaDigest: oldCompletion.confirmed_access_delta_digest,
+				loadFreshRoster: async () => [],
+				loadProjectInventory: () => [],
+			}),
+		).rejects.toThrow("team_setup_confirmation_stale");
+
+		db.prepare("UPDATE actors SET status = 'active' WHERE actor_id = 'identity-b'").run();
+		db.prepare("UPDATE policy_teams SET migration_state = 'completed' WHERE team_id = ?").run(
+			canonicalManifest.team_id,
+		);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: canonicalManifest,
+			}),
+		).rejects.toThrow("team_setup_conflict");
+		db.prepare("UPDATE policy_teams SET migration_state = 'needs_setup' WHERE team_id = ?").run(
+			canonicalManifest.team_id,
+		);
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: canonicalManifest,
+			}),
+		).resolves.toEqual(canonicalManifest);
+		expect(
+			db
+				.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+				.get(canonicalManifest.team_id),
+		).toEqual({ status: "active", migration_state: "completed" });
+	});
+
+	it("quarantines a bound completion whose digest validation fails", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const localRevision = db
+			.prepare("SELECT revision FROM policy_teams WHERE team_id = ?")
+			.pluck()
+			.get(manifest.team_id) as string;
+		db.prepare(
+			`INSERT INTO project_recipients(
+			 canonical_project_identity, recipient_kind, recipient_id, status, provenance,
+			 policy_revision, migration_state, source_fingerprint, idempotency_key,
+			 created_at, updated_at
+			 ) VALUES ('project-private', 'team', ?, 'active', 'reviewed_team_setup',
+			 'stale-revision', 'completed', 'local-source', 'local-key', ?, ?)`,
+		).run(manifest.team_id, NOW, NOW);
+		const invalidManifest = {
+			...manifest,
+			source_digest: "0".repeat(64),
+			team: { ...manifest.team, policy_revision: "1".repeat(64) },
+		};
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest: invalidManifest,
+			}),
+		).rejects.toThrow("team_setup_completion_invalid");
+		expect(
+			db
+				.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+				.get(manifest.team_id),
+		).toEqual({ status: "inactive", migration_state: "needs_setup" });
+		expect(
+			db
+				.prepare(
+					`SELECT status, policy_revision, migration_state FROM project_recipients
+				 WHERE canonical_project_identity = 'project-private'`,
+				)
+				.get(),
+		).toEqual({
+			status: "revoked",
+			policy_revision: localRevision,
+			migration_state: "needs_setup",
+		});
+		expect(
+			db
+				.prepare("SELECT finish_digest FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.get(draft.attemptId),
+		).toEqual({ finish_digest: null });
+	});
+
+	it.each([
+		["malformed", {}],
+		["bound to another coordinator", { coordinator_id: "coordinator-other" }],
+		[
+			"bound to another candidate",
+			{
+				candidate_ref: "legacy-team-candidate:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				team_id: "policy-team-v1:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			},
+		],
+	] as const)(
+		"does not quarantine active policy for an %s payload",
+		async (_label, replacement) => {
+			const draft = readyDraft();
+			const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+				candidateRef: draft.candidateRef,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			await applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			});
+			const finishDigest = db
+				.prepare("SELECT finish_digest FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId);
+			const payload =
+				Object.keys(replacement).length === 0 ? replacement : { ...manifest, ...replacement };
+
+			await expect(
+				applyLegacyTeamSetupCompletionManifest(db, {
+					coordinatorId: COORDINATOR_ID,
+					groupId: GROUP_ID,
+					freshRoster: FRESH_ROSTER,
+					manifest: payload,
+				}),
+			).rejects.toThrow("team_setup_completion_invalid");
+			expect(
+				db
+					.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+					.get(manifest.team_id),
+			).toEqual({ status: "active", migration_state: "completed" });
+			expect(
+				db
+					.prepare("SELECT finish_digest FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+					.pluck()
+					.get(draft.attemptId),
+			).toBe(finishDigest);
+		},
+	);
+
+	it("rolls back when canonical identity evidence is unavailable", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: draft.candidateRef,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		db.prepare("UPDATE actors SET status = 'inactive' WHERE actor_id = 'identity-a'").run();
+
+		await expect(
+			applyLegacyTeamSetupCompletionManifest(db, {
+				coordinatorId: COORDINATOR_ID,
+				groupId: GROUP_ID,
+				freshRoster: FRESH_ROSTER,
+				manifest,
+			}),
+		).rejects.toThrow("team_setup_conflict");
+		expect(
+			db
+				.prepare("SELECT state FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+				.pluck()
+				.get(draft.attemptId),
+		).not.toBe("completed");
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+	});
+});

--- a/packages/core/src/legacy-team-setup-completion-manifest.ts
+++ b/packages/core/src/legacy-team-setup-completion-manifest.ts
@@ -1,0 +1,1224 @@
+import {
+	type CoordinatorLegacyTeamCompletionManifestV1,
+	canonicalCoordinatorLegacyTeamCompletionManifestJson,
+	normalizeCoordinatorLegacyTeamCompletionManifest,
+} from "./coordinator-legacy-team-completion.js";
+import type { Database } from "./db.js";
+import {
+	isLegacyTeamCandidateSelectable,
+	type LegacyTeamRosterDeviceSnapshot,
+} from "./legacy-team-candidate.js";
+import {
+	applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction,
+	applyCanonicalLegacyTeamSetupActivationInTransaction,
+	inspectLegacyTeamSetupActivation,
+	LegacyTeamSetupActivationError,
+	type LegacyTeamSetupActivationErrorCode,
+} from "./legacy-team-setup-activation.js";
+import { legacyTeamResolvedProjectRef } from "./legacy-team-setup-draft.js";
+import { safeLabel, setupLabelForbiddenIds } from "./legacy-team-setup-label-policy.js";
+import {
+	LEGACY_TEAM_SETUP_MAX_DEVICES,
+	LEGACY_TEAM_SETUP_MAX_PROJECTS,
+	requireLegacyTeamSetupSnapshotWithinLimits,
+} from "./legacy-team-setup-limits.js";
+import { listProjectScopeCandidates } from "./project-scope-settings.js";
+import type { LegacyTeamSetupActivationResultV1 } from "./recipient-policy-contract.js";
+import {
+	compareCodepoints,
+	deterministicPolicyTeamId,
+	legacyTeamCandidateId,
+	legacyTeamDeviceRef,
+	legacyTeamProjectRef,
+	recipientPolicyDigest,
+} from "./recipient-policy-identifiers.js";
+import {
+	isRecipientPolicyTeamRenameRevision,
+	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyPublicationMutation,
+	serializeRecipientPolicyTeamMutation,
+} from "./recipient-policy-team-metadata.js";
+
+export type LegacyTeamSetupCompletionManifestErrorCode =
+	| "team_setup_completion_invalid"
+	| "team_setup_completion_conflict";
+
+export class LegacyTeamSetupCompletionManifestError extends Error {
+	readonly code: LegacyTeamSetupCompletionManifestErrorCode;
+
+	constructor(code: LegacyTeamSetupCompletionManifestErrorCode) {
+		super(code);
+		this.name = "LegacyTeamSetupCompletionManifestError";
+		this.code = code;
+	}
+}
+
+export class LegacyTeamSetupAdditiveConvergenceError extends Error {
+	readonly code: LegacyTeamSetupActivationErrorCode;
+
+	constructor(error: unknown) {
+		const code =
+			error instanceof LegacyTeamSetupActivationError ||
+			error instanceof LegacyTeamSetupCompletionManifestError
+				? error.code
+				: "team_setup_failed";
+		super(code, { cause: error });
+		this.name = "LegacyTeamSetupAdditiveConvergenceError";
+		this.code = code;
+	}
+}
+
+class LegacyTeamSetupConfirmationStaleError extends Error {
+	readonly code = "team_setup_confirmation_stale" as const;
+
+	constructor() {
+		super("team_setup_confirmation_stale");
+		this.name = "LegacyTeamSetupConfirmationStaleError";
+	}
+}
+
+class LegacyTeamSetupRosterCapacityError extends Error {
+	readonly code = "team_setup_roster_unavailable" as const;
+
+	constructor() {
+		super("team_setup_roster_unavailable");
+		this.name = "LegacyTeamSetupRosterCapacityError";
+	}
+}
+
+interface DraftRow {
+	attempt_id: string;
+	candidate_id: string;
+	coordinator_id: string;
+	group_id: string;
+	state: string;
+	display_name: string;
+	finish_digest: string | null;
+	completed_at: string | null;
+}
+
+interface DraftDeviceRow {
+	device_id: string;
+	key_fingerprint: string;
+	enabled: number;
+	decision: string;
+	target_identity_id: string | null;
+}
+
+interface ApplyCompletionManifestInput {
+	coordinatorId: string;
+	groupId: string;
+	manifest: unknown;
+	freshRoster: readonly LegacyTeamRosterDeviceSnapshot[];
+	expectedDraftManifest?: CoordinatorLegacyTeamCompletionManifestV1;
+	recipientPolicyLocksHeld?: {
+		publication: true;
+		team: true;
+		coordinatorGroup: true;
+	};
+}
+
+const LEGACY_TEAM_SETUP_MAX_PROJECT_CANDIDATE_SCAN_ROWS = 10_000;
+const LEGACY_TEAM_SETUP_MAX_PROJECT_CANDIDATE_METADATA_ROWS = 10_000;
+
+interface DraftProjectRow {
+	project_ref: string;
+	source_project_identity: string;
+	resolved_project_identity: string | null;
+	target_scope_id: string | null;
+}
+
+interface ResolvedManifestProject {
+	sourceIdentity: string;
+	resolvedIdentity: string;
+	displayName: string;
+}
+
+function fail(code: LegacyTeamSetupCompletionManifestErrorCode): never {
+	throw new LegacyTeamSetupCompletionManifestError(code);
+}
+
+function digest(domain: string, value: unknown): string {
+	const prefixedDigest = recipientPolicyDigest(domain, value);
+	const prefix = `${domain}:`;
+	if (!prefixedDigest.startsWith(prefix)) fail("team_setup_completion_invalid");
+	const rawDigest = prefixedDigest.slice(prefix.length);
+	if (!/^[0-9a-f]{64}$/u.test(rawDigest)) fail("team_setup_completion_invalid");
+	return rawDigest;
+}
+
+function manifestDigests(
+	coordinatorId: string,
+	groupId: string,
+	manifest: Omit<
+		CoordinatorLegacyTeamCompletionManifestV1,
+		| "candidate_digest"
+		| "team_digest"
+		| "source_digest"
+		| "finish_digest"
+		| "access_delta_digest"
+		| "completed_at"
+	> & { completed_at?: string },
+): Pick<
+	CoordinatorLegacyTeamCompletionManifestV1,
+	"candidate_digest" | "team_digest" | "source_digest" | "finish_digest" | "access_delta_digest"
+> {
+	const candidateDigest = digest("legacy-team-completion-candidate-v1", {
+		coordinatorId,
+		groupId,
+		candidateRef: manifest.candidate_ref,
+	});
+	const teamDigest = digest("legacy-team-completion-team-v1", {
+		teamId: manifest.team_id,
+		displayName: manifest.team.display_name,
+		deviceEligibilityMode: manifest.team.device_eligibility_mode,
+	});
+	const sourceDigest = digest("legacy-team-completion-source-v1", {
+		deviceDecisions: manifest.device_decisions,
+		projectMappings: manifest.project_mappings,
+	});
+	const accessDeltaDigest = digest("legacy-team-completion-access-delta-v1", {
+		memberships: manifest.memberships,
+		projectRecipients: manifest.project_recipients,
+	});
+	return {
+		candidate_digest: candidateDigest,
+		team_digest: teamDigest,
+		source_digest: sourceDigest,
+		access_delta_digest: accessDeltaDigest,
+		finish_digest: digest("legacy-team-completion-finish-v1", {
+			candidateDigest,
+			teamDigest,
+			sourceDigest,
+			accessDeltaDigest,
+		}),
+	};
+}
+
+function loadDraft(db: Database, candidateRef: string, attemptId?: string): DraftRow {
+	const row = attemptId
+		? (db
+				.prepare(
+					`SELECT attempt_id, candidate_id, coordinator_id, group_id, state, display_name, finish_digest, completed_at
+					 FROM legacy_team_setup_drafts WHERE attempt_id = ? AND candidate_id = ?`,
+				)
+				.get(attemptId, candidateRef) as DraftRow | undefined)
+		: (db
+				.prepare(
+					`SELECT attempt_id, candidate_id, coordinator_id, group_id, state, display_name, finish_digest, completed_at
+					 FROM legacy_team_setup_drafts WHERE candidate_id = ? ORDER BY rowid DESC LIMIT 1`,
+				)
+				.get(candidateRef) as DraftRow | undefined);
+	if (!row) fail("team_setup_completion_invalid");
+	return row;
+}
+
+function loadCompletedDraft(db: Database, candidateRef: string): DraftRow {
+	const row = db
+		.prepare(
+			`SELECT attempt_id, candidate_id, coordinator_id, group_id, state, display_name, finish_digest, completed_at
+			 FROM legacy_team_setup_drafts
+			 WHERE candidate_id = ? AND state = 'completed'
+			 ORDER BY rowid DESC LIMIT 1`,
+		)
+		.get(candidateRef) as DraftRow | undefined;
+	if (!row) fail("team_setup_completion_invalid");
+	return row;
+}
+
+function deriveFromDraft(
+	db: Database,
+	draft: DraftRow,
+	completedAt: string,
+): CoordinatorLegacyTeamCompletionManifestV1 {
+	// Fetch one row past each cap so a pre-limit historical attempt is rejected
+	// without materializing an unbounded draft first.
+	const devices = db
+		.prepare(
+			`SELECT device_id, key_fingerprint, enabled, decision, target_identity_id
+			 FROM legacy_team_setup_draft_devices WHERE attempt_id = ? ORDER BY device_id
+			 LIMIT ?`,
+		)
+		.all(draft.attempt_id, LEGACY_TEAM_SETUP_MAX_DEVICES + 1) as DraftDeviceRow[];
+	const projects = db
+		.prepare(
+			`SELECT project_ref, source_project_identity, resolved_project_identity, target_scope_id
+			 FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref
+			 LIMIT ?`,
+		)
+		.all(draft.attempt_id, LEGACY_TEAM_SETUP_MAX_PROJECTS + 1) as DraftProjectRow[];
+	requireCompletionSnapshotWithinLimits(devices, projects);
+	if (
+		devices.length === 0 ||
+		devices.some(
+			(device) =>
+				!["included", "excluded", "removed"].includes(device.decision) ||
+				(device.decision === "included" && !device.target_identity_id),
+		) ||
+		projects.some((project) => !project.resolved_project_identity)
+	) {
+		fail("team_setup_completion_invalid");
+	}
+	const teamId = deterministicPolicyTeamId(draft.candidate_id);
+	const memberships = [
+		...new Set(
+			devices.flatMap((device) =>
+				device.decision === "included" && device.target_identity_id
+					? [device.target_identity_id]
+					: [],
+			),
+		),
+	]
+		.toSorted(compareCodepoints)
+		.map((identityId) => ({ identity_id: identityId, role: "member" as const }));
+	const deviceDecisions = devices
+		.filter((device) => device.decision !== "removed")
+		.map((device) => ({
+			device_id: device.device_id,
+			key_fingerprint: device.key_fingerprint,
+			enabled: device.enabled !== 0,
+			identity_id: device.decision === "included" ? device.target_identity_id : null,
+			decision: device.decision === "included" ? ("included" as const) : ("excluded" as const),
+		}));
+	const projectMappings = projects.map((project) => {
+		const matchingScopeIds = project.target_scope_id
+			? [project.target_scope_id]
+			: (db
+					.prepare(
+						`SELECT DISTINCT mapping.scope_id FROM project_scope_mappings AS mapping
+						 JOIN replication_scopes AS scope ON scope.scope_id = mapping.scope_id
+						 WHERE mapping.project_pattern = ? AND mapping.workspace_identity = ?
+						   AND scope.coordinator_id = ? AND scope.group_id = ?
+						   AND scope.authority_type = 'coordinator' AND scope.status = 'active'
+						 ORDER BY mapping.scope_id`,
+					)
+					.pluck()
+					.all(
+						project.source_project_identity,
+						project.resolved_project_identity,
+						draft.coordinator_id,
+						draft.group_id,
+					) as string[]);
+		if (matchingScopeIds.length !== 1) fail("team_setup_completion_invalid");
+		return {
+			project_ref: project.project_ref,
+			resolved_project_ref: legacyTeamResolvedProjectRef(
+				project.project_ref,
+				project.resolved_project_identity as string,
+			),
+			scope_id: matchingScopeIds[0] as string,
+		};
+	});
+	const projectRecipients = [
+		...new Set(projectMappings.map((mapping) => mapping.resolved_project_ref)),
+	]
+		.toSorted(compareCodepoints)
+		.map((resolvedProjectRef) => ({ resolved_project_ref: resolvedProjectRef, team_id: teamId }));
+	const base = {
+		version: 1 as const,
+		coordinator_id: draft.coordinator_id,
+		candidate_ref: draft.candidate_id,
+		team_id: teamId,
+		team: {
+			display_name: draft.display_name,
+			policy_revision: "",
+			device_eligibility_mode: "reviewed_allowlist" as const,
+		},
+		memberships,
+		device_decisions: deviceDecisions,
+		project_mappings: projectMappings,
+		project_recipients: projectRecipients,
+	};
+	const digests = manifestDigests(draft.coordinator_id, draft.group_id, base);
+	const policyRevision = digest("legacy-team-completion-policy-revision-v1", digests.finish_digest);
+	return normalizeCoordinatorLegacyTeamCompletionManifest({
+		...base,
+		...digests,
+		team: { ...base.team, policy_revision: policyRevision },
+		completed_at: completedAt,
+	});
+}
+
+export function deriveLegacyTeamSetupCompletionManifest(
+	db: Database,
+	input: { candidateRef: string; attemptId: string; completedAt?: string },
+): CoordinatorLegacyTeamCompletionManifestV1 {
+	const draft = loadDraft(db, input.candidateRef, input.attemptId);
+	if (draft.state !== "needs_setup" && draft.state !== "in_progress") {
+		fail("team_setup_completion_invalid");
+	}
+	try {
+		inspectLegacyTeamSetupActivation(db, {
+			candidateRef: input.candidateRef,
+			attemptId: input.attemptId,
+		});
+	} catch {
+		fail("team_setup_completion_invalid");
+	}
+	return deriveFromDraft(db, draft, input.completedAt ?? new Date().toISOString());
+}
+
+export function reconstructLegacyTeamSetupCompletionManifest(
+	db: Database,
+	input: { candidateRef: string },
+): CoordinatorLegacyTeamCompletionManifestV1 {
+	const draft = loadCompletedDraft(db, input.candidateRef);
+	if (draft.state !== "completed" || !draft.completed_at) fail("team_setup_completion_invalid");
+	const manifest = deriveFromDraft(db, draft, draft.completed_at);
+	const team = db
+		.prepare("SELECT display_name FROM policy_teams WHERE team_id = ? AND status = 'active'")
+		.get(manifest.team_id) as { display_name: string } | undefined;
+	if (
+		!team ||
+		team.display_name !== manifest.team.display_name ||
+		!isLegacyTeamCandidateSelectable(db, input.candidateRef)
+	) {
+		fail("team_setup_completion_conflict");
+	}
+	return manifest;
+}
+
+export function validateLegacyTeamSetupCompletionManifest(
+	value: unknown,
+	input: { coordinatorId: string; groupId: string },
+): CoordinatorLegacyTeamCompletionManifestV1 {
+	const manifest = validateLegacyTeamSetupCompletionManifestBinding(value, input);
+	requireCompletionSnapshotWithinLimits(manifest.device_decisions, manifest.project_mappings);
+	const includedIdentityIds = [
+		...new Set(
+			manifest.device_decisions.flatMap((decision) =>
+				decision.identity_id ? [decision.identity_id] : [],
+			),
+		),
+	].toSorted(compareCodepoints);
+	const membershipIdentityIds = manifest.memberships.map((membership) => membership.identity_id);
+	const expectedRecipientRefs = [
+		...new Set(manifest.project_mappings.map((mapping) => mapping.resolved_project_ref)),
+	].toSorted(compareCodepoints);
+	const recipientRefs = manifest.project_recipients.map(
+		(recipient) => recipient.resolved_project_ref,
+	);
+	if (
+		JSON.stringify(membershipIdentityIds) !== JSON.stringify(includedIdentityIds) ||
+		JSON.stringify(recipientRefs) !== JSON.stringify(expectedRecipientRefs)
+	) {
+		fail("team_setup_completion_invalid");
+	}
+	const expected = manifestDigests(input.coordinatorId, input.groupId, manifest);
+	const expectedRevision = digest(
+		"legacy-team-completion-policy-revision-v1",
+		expected.finish_digest,
+	);
+	if (
+		manifest.candidate_digest !== expected.candidate_digest ||
+		manifest.team_digest !== expected.team_digest ||
+		manifest.source_digest !== expected.source_digest ||
+		manifest.finish_digest !== expected.finish_digest ||
+		manifest.access_delta_digest !== expected.access_delta_digest ||
+		manifest.team.policy_revision !== expectedRevision
+	) {
+		fail("team_setup_completion_invalid");
+	}
+	return manifest;
+}
+
+function requireCompletionSnapshotWithinLimits(
+	devices: readonly unknown[],
+	projects: readonly unknown[],
+): void {
+	try {
+		requireLegacyTeamSetupSnapshotWithinLimits({ devices, projects });
+	} catch {
+		fail("team_setup_completion_invalid");
+	}
+}
+
+export function validateLegacyTeamSetupCompletionManifestBinding(
+	value: unknown,
+	input: { coordinatorId: string; groupId: string },
+): CoordinatorLegacyTeamCompletionManifestV1 {
+	let manifest: CoordinatorLegacyTeamCompletionManifestV1;
+	try {
+		manifest = normalizeCoordinatorLegacyTeamCompletionManifest(value);
+	} catch {
+		fail("team_setup_completion_invalid");
+	}
+	if (
+		manifest.coordinator_id !== input.coordinatorId ||
+		manifest.candidate_ref !== legacyTeamCandidateId(input.coordinatorId, input.groupId) ||
+		manifest.team_id !== deterministicPolicyTeamId(manifest.candidate_ref)
+	) {
+		fail("team_setup_completion_invalid");
+	}
+	return manifest;
+}
+
+function resolveManifestProjects(
+	db: Database,
+	attemptId: string,
+	manifest: CoordinatorLegacyTeamCompletionManifestV1,
+): Map<string, ResolvedManifestProject> {
+	const projects = db
+		.prepare(
+			`SELECT project_ref, source_project_identity, resolved_project_identity
+			 FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref
+			 LIMIT ?`,
+		)
+		.all(attemptId, LEGACY_TEAM_SETUP_MAX_PROJECTS + 1) as DraftProjectRow[];
+	if (projects.length > LEGACY_TEAM_SETUP_MAX_PROJECTS) fail("team_setup_completion_invalid");
+	let localCandidates: ReturnType<typeof listProjectScopeCandidates>;
+	try {
+		localCandidates = listProjectScopeCandidates(db, {
+			limit: null,
+			maxScannedRows: LEGACY_TEAM_SETUP_MAX_PROJECT_CANDIDATE_SCAN_ROWS,
+			maxMetadataRows: LEGACY_TEAM_SETUP_MAX_PROJECT_CANDIDATE_METADATA_ROWS,
+			excludePeerReceived: true,
+		});
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			(error.message === "project_scope_candidate_scan_too_large" ||
+				error.message === "project_scope_candidate_metadata_too_large")
+		) {
+			throw new LegacyTeamSetupRosterCapacityError();
+		}
+		throw error;
+	}
+	if (localCandidates.length > LEGACY_TEAM_SETUP_MAX_PROJECTS) {
+		throw new LegacyTeamSetupRosterCapacityError();
+	}
+	const identities = [
+		...new Set([
+			...projects.flatMap((project) => [
+				project.source_project_identity,
+				...(project.resolved_project_identity ? [project.resolved_project_identity] : []),
+			]),
+			...localCandidates.map((candidate) => candidate.workspace_identity),
+		]),
+	].toSorted(compareCodepoints);
+	const displayNameByIdentity = new Map(
+		localCandidates.map((candidate) => [candidate.workspace_identity, candidate.display_project]),
+	);
+	const identityByResolvedRef = new Map<string, string>();
+	const identityByProjectRef = new Map(
+		projects.map((project) => [project.project_ref, project.source_project_identity]),
+	);
+	for (const identity of identities) {
+		for (const mapping of manifest.project_mappings) {
+			if (legacyTeamProjectRef(manifest.candidate_ref, identity) === mapping.project_ref) {
+				const existingSource = identityByProjectRef.get(mapping.project_ref);
+				if (existingSource && existingSource !== identity) fail("team_setup_completion_invalid");
+				identityByProjectRef.set(mapping.project_ref, identity);
+			}
+			if (
+				legacyTeamResolvedProjectRef(mapping.project_ref, identity) !== mapping.resolved_project_ref
+			) {
+				continue;
+			}
+			const existing = identityByResolvedRef.get(mapping.resolved_project_ref);
+			if (existing && existing !== identity) fail("team_setup_completion_invalid");
+			identityByResolvedRef.set(mapping.resolved_project_ref, identity);
+		}
+	}
+	const resolved = new Map<string, ResolvedManifestProject>();
+	for (const mapping of manifest.project_mappings) {
+		const sourceIdentity = identityByProjectRef.get(mapping.project_ref);
+		const resolvedIdentity = identityByResolvedRef.get(mapping.resolved_project_ref);
+		if (!sourceIdentity || !resolvedIdentity) continue;
+		resolved.set(mapping.project_ref, {
+			sourceIdentity,
+			resolvedIdentity,
+			displayName:
+				displayNameByIdentity.get(sourceIdentity) ??
+				displayNameByIdentity.get(resolvedIdentity) ??
+				"Canonical project",
+		});
+	}
+	return resolved;
+}
+
+function rewriteDraftFromManifest(
+	db: Database,
+	draft: DraftRow,
+	manifest: CoordinatorLegacyTeamCompletionManifestV1,
+	freshRoster: readonly LegacyTeamRosterDeviceSnapshot[],
+	preservedTeamDisplayName?: string,
+): void {
+	db.prepare(
+		"UPDATE legacy_team_setup_drafts SET display_name = ?, updated_at = ? WHERE attempt_id = ?",
+	).run(
+		preservedTeamDisplayName ?? manifest.team.display_name,
+		manifest.completed_at,
+		draft.attempt_id,
+	);
+	const draftDeviceIds = db
+		.prepare(
+			`SELECT device_id FROM legacy_team_setup_draft_devices
+			 WHERE attempt_id = ? ORDER BY device_id LIMIT ?`,
+		)
+		.pluck()
+		.all(draft.attempt_id, LEGACY_TEAM_SETUP_MAX_DEVICES + 1) as string[];
+	if (draftDeviceIds.length > LEGACY_TEAM_SETUP_MAX_DEVICES) {
+		fail("team_setup_completion_invalid");
+	}
+	const manifestDeviceIds = new Set(
+		manifest.device_decisions.map((decision) => decision.device_id),
+	);
+	const deleteDevice = db.prepare(
+		"DELETE FROM legacy_team_setup_draft_devices WHERE attempt_id = ? AND device_id = ?",
+	);
+	// Local roster additions postdate the winner and carry no canonical review.
+	// Removing their draft rows also lets activation revoke setup-owned members
+	// and decisions without growing the bounded draft to the union of rosters.
+	for (const deviceId of draftDeviceIds) {
+		if (!manifestDeviceIds.has(deviceId)) deleteDevice.run(draft.attempt_id, deviceId);
+	}
+	const updateDevice = db.prepare(
+		`UPDATE legacy_team_setup_draft_devices
+		 SET display_name = COALESCE(?, display_name), key_fingerprint = ?, enabled = ?, decision = ?, target_identity_id = ?, existing_identity_id = ?,
+		     existing_assignment_version = ?, verified_evidence_kind = ?,
+		     expected_assignment_kind = ?, expected_assignment_version = ?, updated_at = ?
+		 WHERE attempt_id = ? AND device_id = ?`,
+	);
+	const assignmentForDevice = db.prepare(
+		`SELECT identity_id, assignment_version, status FROM identity_devices
+		 WHERE device_id = ? LIMIT 1`,
+	);
+	const assignmentsByDeviceId = new Map(
+		manifest.device_decisions.map((decision) => [
+			decision.device_id,
+			assignmentForDevice.get(decision.device_id) as
+				| { identity_id: string; assignment_version: number; status: string }
+				| undefined,
+		]),
+	);
+	// Bounded read: a pre-limit draft must be rejected before its Project rows
+	// are materialized for label collection.
+	const persistedProjects = db
+		.prepare(
+			`SELECT source_project_identity, source_fingerprint,
+			        resolved_project_identity, target_scope_id
+			 FROM legacy_team_setup_draft_projects WHERE attempt_id = ? LIMIT ?`,
+		)
+		.all(draft.attempt_id, LEGACY_TEAM_SETUP_MAX_PROJECTS + 1) as Array<{
+		source_project_identity: string;
+		source_fingerprint: string;
+		resolved_project_identity: string | null;
+		target_scope_id: string | null;
+	}>;
+	if (persistedProjects.length > LEGACY_TEAM_SETUP_MAX_PROJECTS) {
+		fail("team_setup_completion_invalid");
+	}
+	const persistedProjectIds = persistedProjects.flatMap((project) => [
+		project.source_project_identity,
+		project.source_fingerprint,
+		project.resolved_project_identity ?? "",
+		project.target_scope_id ?? "",
+	]);
+	const insertDevice = db.prepare(
+		`INSERT INTO legacy_team_setup_draft_devices(
+		 attempt_id, device_id, device_ref, key_fingerprint, display_name, enabled,
+		 existing_identity_id, existing_assignment_version, verified_evidence_kind,
+		 decision, target_identity_id, expected_assignment_kind,
+		 expected_assignment_version, updated_at
+		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	);
+	const freshDeviceById = new Map(freshRoster.map((device) => [device.deviceId, device]));
+	const forbiddenLabelIds = setupLabelForbiddenIds(
+		[
+			draft.candidate_id,
+			draft.coordinator_id,
+			manifest.team_id,
+			...manifest.memberships.map((membership) => membership.identity_id),
+			...manifest.project_mappings.flatMap((mapping) => [
+				mapping.project_ref,
+				mapping.resolved_project_ref,
+				mapping.scope_id,
+			]),
+			...persistedProjectIds,
+		],
+		draft.group_id,
+		null,
+		freshRoster,
+		[],
+		manifest.device_decisions.map((decision) => ({
+			deviceId: decision.device_id,
+			fingerprint: decision.key_fingerprint,
+			existingIdentityId: assignmentsByDeviceId.get(decision.device_id)?.identity_id ?? null,
+			targetIdentityId: decision.identity_id,
+		})),
+		[],
+	);
+	for (const decision of manifest.device_decisions) {
+		const assignment = assignmentsByDeviceId.get(decision.device_id);
+		const freshDevice = freshDeviceById.get(decision.device_id);
+		const displayName = freshDevice
+			? safeLabel(freshDevice.displayName, "Canonical device", forbiddenLabelIds)
+			: null;
+		if (!draftDeviceIds.includes(decision.device_id)) {
+			insertDevice.run(
+				draft.attempt_id,
+				decision.device_id,
+				legacyTeamDeviceRef(draft.candidate_id, decision.device_id),
+				decision.key_fingerprint,
+				displayName ?? "Canonical device",
+				decision.enabled ? 1 : 0,
+				assignment?.identity_id ?? null,
+				assignment?.assignment_version ?? null,
+				assignment?.status === "active" ? "active_assignment" : null,
+				decision.decision,
+				decision.identity_id,
+				assignment ? "existing" : "absent",
+				assignment?.assignment_version ?? null,
+				manifest.completed_at,
+			);
+		}
+		// The coordinator winner is authoritative. Rebase the local CAS evidence
+		// onto the current assignment so applying that winner can converge a
+		// pre-protocol device rather than preserving its divergent binding.
+		updateDevice.run(
+			displayName,
+			decision.key_fingerprint,
+			decision.enabled ? 1 : 0,
+			decision.decision,
+			decision.identity_id,
+			assignment?.identity_id ?? null,
+			assignment?.assignment_version ?? null,
+			assignment?.status === "active" ? "active_assignment" : null,
+			assignment ? "existing" : "absent",
+			assignment?.assignment_version ?? null,
+			manifest.completed_at,
+			draft.attempt_id,
+			decision.device_id,
+		);
+	}
+	const resolvedProjects = resolveManifestProjects(db, draft.attempt_id, manifest);
+	const localProjectRefs = db
+		.prepare(
+			`SELECT project_ref FROM legacy_team_setup_draft_projects
+			 WHERE attempt_id = ? ORDER BY project_ref LIMIT ?`,
+		)
+		.pluck()
+		.all(draft.attempt_id, LEGACY_TEAM_SETUP_MAX_PROJECTS + 1) as string[];
+	if (localProjectRefs.length > LEGACY_TEAM_SETUP_MAX_PROJECTS) {
+		fail("team_setup_completion_invalid");
+	}
+	const deleteProject = db.prepare(
+		"DELETE FROM legacy_team_setup_draft_projects WHERE attempt_id = ? AND project_ref = ?",
+	);
+	// Activation grants every Project left in the draft. Retain only historical
+	// mappings supported by this installation's local Project evidence.
+	for (const projectRef of localProjectRefs) {
+		if (!resolvedProjects.has(projectRef)) deleteProject.run(draft.attempt_id, projectRef);
+	}
+	const updateProject = db.prepare(
+		`UPDATE legacy_team_setup_draft_projects
+		 SET resolution_kind = 'explicit', resolved_project_identity = ?, target_scope_id = ?, updated_at = ?
+		 WHERE attempt_id = ? AND project_ref = ?`,
+	);
+	const insertProject = db.prepare(
+		`INSERT INTO legacy_team_setup_draft_projects(
+		 attempt_id, project_ref, source_project_identity, display_name, source_fingerprint,
+		 resolution_kind, resolved_project_identity, target_scope_id, updated_at
+		 ) VALUES (?, ?, ?, ?, ?, 'explicit', ?, ?, ?)`,
+	);
+	for (const mapping of manifest.project_mappings) {
+		const resolvedProject = resolvedProjects.get(mapping.project_ref);
+		if (!resolvedProject) continue;
+		const scope = db
+			.prepare(
+				`SELECT 1 FROM replication_scopes
+				 WHERE scope_id = ? AND coordinator_id = ? AND group_id = ?
+				   AND authority_type = 'coordinator' AND status = 'active'`,
+			)
+			.get(mapping.scope_id, draft.coordinator_id, draft.group_id);
+		if (!scope) fail("team_setup_completion_invalid");
+		if (!localProjectRefs.includes(mapping.project_ref)) {
+			// The canonical manifest is durable evidence for this reconstructed row;
+			// no local discovery fingerprint exists when a peer first materializes it.
+			insertProject.run(
+				draft.attempt_id,
+				mapping.project_ref,
+				resolvedProject.sourceIdentity,
+				safeLabel(resolvedProject.displayName, "Canonical project", forbiddenLabelIds),
+				digest("legacy-team-canonical-project-source-v1", mapping),
+				resolvedProject.resolvedIdentity,
+				mapping.scope_id,
+				manifest.completed_at,
+			);
+		} else {
+			updateProject.run(
+				resolvedProject.resolvedIdentity,
+				mapping.scope_id,
+				manifest.completed_at,
+				draft.attempt_id,
+				mapping.project_ref,
+			);
+		}
+	}
+}
+
+function appendResolvedManifestProjects(
+	db: Database,
+	draft: DraftRow,
+	manifest: CoordinatorLegacyTeamCompletionManifestV1,
+	resolvedProjects: Map<string, ResolvedManifestProject>,
+	projectRefs: readonly string[],
+	freshRoster: readonly LegacyTeamRosterDeviceSnapshot[],
+): void {
+	const existingProjects = db
+		.prepare(
+			`SELECT project_ref, source_project_identity, source_fingerprint,
+			        resolved_project_identity, target_scope_id
+			 FROM legacy_team_setup_draft_projects WHERE attempt_id = ? ORDER BY project_ref`,
+		)
+		.all(draft.attempt_id) as Array<{
+		project_ref: string;
+		source_project_identity: string;
+		source_fingerprint: string;
+		resolved_project_identity: string | null;
+		target_scope_id: string | null;
+	}>;
+	const existingRefs = new Set(existingProjects.map((project) => project.project_ref));
+	if (
+		existingProjects.length + projectRefs.length > LEGACY_TEAM_SETUP_MAX_PROJECTS ||
+		projectRefs.some((projectRef) => existingRefs.has(projectRef))
+	) {
+		fail("team_setup_completion_invalid");
+	}
+	const mappingsByRef = new Map(
+		manifest.project_mappings.map((mapping) => [mapping.project_ref, mapping]),
+	);
+	const forbiddenLabelIds = setupLabelForbiddenIds(
+		[
+			draft.candidate_id,
+			draft.coordinator_id,
+			manifest.team_id,
+			...manifest.memberships.map((membership) => membership.identity_id),
+			...manifest.project_mappings.flatMap((mapping) => [
+				mapping.project_ref,
+				mapping.resolved_project_ref,
+				mapping.scope_id,
+			]),
+			...existingProjects.flatMap((project) => [
+				project.source_project_identity,
+				project.source_fingerprint,
+				project.resolved_project_identity ?? "",
+				project.target_scope_id ?? "",
+			]),
+		],
+		draft.group_id,
+		null,
+		freshRoster,
+		[],
+		[],
+		[],
+	);
+	const insert = db.prepare(
+		`INSERT INTO legacy_team_setup_draft_projects(
+		 attempt_id, project_ref, source_project_identity, display_name, source_fingerprint,
+		 resolution_kind, resolved_project_identity, target_scope_id, updated_at
+		 ) VALUES (?, ?, ?, ?, ?, 'explicit', ?, ?, ?)`,
+	);
+	for (const projectRef of projectRefs) {
+		const mapping = mappingsByRef.get(projectRef);
+		const resolved = resolvedProjects.get(projectRef);
+		if (!mapping || !resolved) fail("team_setup_completion_invalid");
+		const scope = db
+			.prepare(
+				`SELECT 1 FROM replication_scopes
+				 WHERE scope_id = ? AND coordinator_id = ? AND group_id = ?
+				   AND authority_type = 'coordinator' AND status = 'active'`,
+			)
+			.get(mapping.scope_id, draft.coordinator_id, draft.group_id);
+		if (!scope) fail("team_setup_completion_invalid");
+		insert.run(
+			draft.attempt_id,
+			projectRef,
+			resolved.sourceIdentity,
+			safeLabel(resolved.displayName, "Canonical project", forbiddenLabelIds),
+			digest("legacy-team-canonical-project-source-v1", mapping),
+			resolved.resolvedIdentity,
+			mapping.scope_id,
+			manifest.completed_at,
+		);
+	}
+}
+
+function requireIncludedDeviceEvidence(
+	manifest: CoordinatorLegacyTeamCompletionManifestV1,
+	freshRoster: readonly LegacyTeamRosterDeviceSnapshot[],
+): void {
+	if (freshRoster.length > LEGACY_TEAM_SETUP_MAX_DEVICES) fail("team_setup_completion_invalid");
+	const freshByDeviceId = new Map(freshRoster.map((device) => [device.deviceId, device]));
+	if (freshByDeviceId.size !== freshRoster.length) fail("team_setup_completion_invalid");
+	for (const decision of manifest.device_decisions) {
+		if (decision.decision !== "included") continue;
+		const fresh = freshByDeviceId.get(decision.device_id);
+		if (!decision.enabled || !fresh?.enabled || fresh.fingerprint !== decision.key_fingerprint) {
+			fail("team_setup_completion_invalid");
+		}
+	}
+}
+
+function quarantineDivergentCompletedPolicy(
+	db: Database,
+	binding: { candidateRef: string; teamId: string },
+): void {
+	db.transaction(() => {
+		const team = db
+			.prepare(
+				`SELECT revision FROM policy_teams
+				 WHERE team_id = ? AND status = 'active'
+				   AND provenance = 'reviewed_team_candidate'`,
+			)
+			.get(binding.teamId) as { revision: string } | undefined;
+		// Repeated containment is a no-op once the active setup-owned policy is gone.
+		if (!team) return;
+		const now = new Date().toISOString();
+		db.prepare(
+			`UPDATE policy_teams
+			 SET status = 'inactive', migration_state = 'needs_setup', updated_at = ?
+			 WHERE team_id = ? AND provenance = 'reviewed_team_candidate'`,
+		).run(now, binding.teamId);
+		db.prepare(
+			`UPDATE project_recipients
+			 SET status = 'revoked', policy_revision = ?, migration_state = 'needs_setup', updated_at = ?
+			 WHERE recipient_kind = 'team' AND recipient_id = ?
+			   AND provenance = 'reviewed_team_setup' AND status = 'active'`,
+		).run(team.revision, now, binding.teamId);
+		db.prepare(
+			`UPDATE legacy_team_setup_drafts SET finish_digest = NULL
+			 WHERE candidate_id = ? AND completed_team_id = ? AND state = 'completed'`,
+		).run(binding.candidateRef, binding.teamId);
+	}).immediate();
+}
+
+export async function containLegacyTeamSetupCompletionConflict(
+	db: Database,
+	input: { coordinatorId: string; groupId: string },
+): Promise<void> {
+	const candidateRef = legacyTeamCandidateId(input.coordinatorId, input.groupId);
+	const teamId = deterministicPolicyTeamId(candidateRef);
+	await serializeRecipientPolicyTeamMutation(db, teamId, () =>
+		serializeRecipientPolicyCoordinatorGroupMutation(db, input.groupId, () => {
+			quarantineDivergentCompletedPolicy(db, { candidateRef, teamId });
+			return Promise.resolve();
+		}),
+	);
+}
+
+function loadCompletedActivationResult(
+	db: Database,
+	draft: DraftRow,
+): LegacyTeamSetupActivationResultV1 {
+	if (!draft.finish_digest) fail("team_setup_completion_invalid");
+	const row = db
+		.prepare(
+			`SELECT response_json FROM legacy_team_setup_completions
+			 WHERE candidate_ref = ? AND attempt_id = ? AND finish_digest = ?`,
+		)
+		.get(draft.candidate_id, draft.attempt_id, draft.finish_digest) as
+		| { response_json: string }
+		| undefined;
+	if (!row) fail("team_setup_completion_invalid");
+	return JSON.parse(row.response_json) as LegacyTeamSetupActivationResultV1;
+}
+
+function equivalentCompletionPolicyFacts(
+	left: CoordinatorLegacyTeamCompletionManifestV1,
+	right: CoordinatorLegacyTeamCompletionManifestV1,
+	resolvableProjectRefs: ReadonlySet<string>,
+): boolean {
+	const applicationFacts = (manifest: CoordinatorLegacyTeamCompletionManifestV1) => ({
+		version: manifest.version,
+		candidate_ref: manifest.candidate_ref,
+		team_id: manifest.team_id,
+		candidate_digest: manifest.candidate_digest,
+		device_eligibility_mode: manifest.team.device_eligibility_mode,
+		device_decisions: manifest.device_decisions,
+		memberships: manifest.memberships,
+	});
+	if (JSON.stringify(applicationFacts(left)) !== JSON.stringify(applicationFacts(right))) {
+		return false;
+	}
+	const leftProjectRefs = new Set(left.project_mappings.map((mapping) => mapping.project_ref));
+	const rightMappings = new Map(
+		right.project_mappings.map((mapping) => [mapping.project_ref, mapping]),
+	);
+	const rightRecipients = new Map(
+		right.project_recipients.map((recipient) => [recipient.resolved_project_ref, recipient]),
+	);
+	return (
+		left.project_mappings.every(
+			(mapping) =>
+				JSON.stringify(rightMappings.get(mapping.project_ref)) === JSON.stringify(mapping),
+		) &&
+		left.project_recipients.every(
+			(recipient) =>
+				JSON.stringify(rightRecipients.get(recipient.resolved_project_ref)) ===
+				JSON.stringify(recipient),
+		) &&
+		right.project_mappings.every(
+			(mapping) =>
+				leftProjectRefs.has(mapping.project_ref) || !resolvableProjectRefs.has(mapping.project_ref),
+		)
+	);
+}
+
+/**
+ * A retry that re-applies the same policy facts onto an already-completed draft
+ * must keep that draft's completion key: deriving a fresh preview from the
+ * materialized policy would rotate the key on every retry and invalidate the
+ * originating device's exact-replay token. A divergent manifest gets a new key
+ * so stale tokens for the superseded policy fail closed.
+ */
+function retainedCompletionKeyForExactReapply(
+	db: Database,
+	draft: DraftRow,
+	manifest: CoordinatorLegacyTeamCompletionManifestV1,
+): string | undefined {
+	if (!draft.finish_digest) return undefined;
+	let current: CoordinatorLegacyTeamCompletionManifestV1;
+	try {
+		current = deriveFromDraft(db, draft, manifest.completed_at);
+	} catch {
+		return undefined;
+	}
+	const manifestProjectRefs = new Set(
+		manifest.project_mappings.map((mapping) => mapping.project_ref),
+	);
+	return equivalentCompletionPolicyFacts(current, manifest, manifestProjectRefs)
+		? draft.finish_digest
+		: undefined;
+}
+
+export function areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible(
+	local: CoordinatorLegacyTeamCompletionManifestV1,
+	canonical: CoordinatorLegacyTeamCompletionManifestV1,
+): boolean {
+	return equivalentCompletionPolicyFacts(local, canonical, new Set());
+}
+
+async function applyCompletionManifest(
+	db: Database,
+	input: ApplyCompletionManifestInput,
+): Promise<{
+	manifest: CoordinatorLegacyTeamCompletionManifestV1;
+	result: LegacyTeamSetupActivationResultV1;
+}> {
+	const boundManifest = validateLegacyTeamSetupCompletionManifestBinding(input.manifest, input);
+	const apply = async () => {
+		let additiveConvergenceOnly = false;
+		// Set while the local completion is additively compatible with the
+		// winner: a failure there must preserve the active policy, whereas a
+		// failed full replacement of divergent policy must quarantine it.
+		let compatibleLocalPolicy = false;
+		try {
+			const manifest = validateLegacyTeamSetupCompletionManifest(boundManifest, input);
+			return db
+				.transaction(() => {
+					let preservedTeamMetadata: { displayName: string; policyRevision: string } | null = null;
+					const draft = loadDraft(db, manifest.candidate_ref);
+					if (input.expectedDraftManifest) {
+						let currentManifest: CoordinatorLegacyTeamCompletionManifestV1;
+						try {
+							currentManifest = deriveFromDraft(
+								db,
+								draft,
+								input.expectedDraftManifest.completed_at,
+							);
+						} catch {
+							throw new LegacyTeamSetupConfirmationStaleError();
+						}
+						if (
+							canonicalCoordinatorLegacyTeamCompletionManifestJson(currentManifest) !==
+							canonicalCoordinatorLegacyTeamCompletionManifestJson(input.expectedDraftManifest)
+						) {
+							throw new LegacyTeamSetupConfirmationStaleError();
+						}
+					}
+					const hasCompletedDraft = draft.state === "completed";
+					requireIncludedDeviceEvidence(manifest, input.freshRoster);
+					if (hasCompletedDraft) {
+						try {
+							const local = reconstructLegacyTeamSetupCompletionManifest(db, {
+								candidateRef: manifest.candidate_ref,
+							});
+							if (
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(local) ===
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(manifest)
+							) {
+								return { manifest, result: loadCompletedActivationResult(db, draft) };
+							}
+							if (equivalentCompletionPolicyFacts(local, manifest, new Set())) {
+								compatibleLocalPolicy = true;
+								const additiveResolvedProjects = resolveManifestProjects(
+									db,
+									draft.attempt_id,
+									manifest,
+								);
+								if (
+									equivalentCompletionPolicyFacts(
+										local,
+										manifest,
+										new Set(additiveResolvedProjects.keys()),
+									)
+								) {
+									return { manifest, result: loadCompletedActivationResult(db, draft) };
+								}
+								additiveConvergenceOnly = true;
+								const localProjectRefs = new Set(
+									local.project_mappings.map((mapping) => mapping.project_ref),
+								);
+								const newProjectRefs = manifest.project_mappings
+									.map((mapping) => mapping.project_ref)
+									.filter(
+										(projectRef) =>
+											!localProjectRefs.has(projectRef) && additiveResolvedProjects.has(projectRef),
+									);
+								appendResolvedManifestProjects(
+									db,
+									draft,
+									manifest,
+									additiveResolvedProjects,
+									newProjectRefs,
+									input.freshRoster,
+								);
+								applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(db, {
+									candidateRef: manifest.candidate_ref,
+									attemptId: draft.attempt_id,
+									teamId: manifest.team_id,
+									projectRefs: newProjectRefs,
+									completedAt: manifest.completed_at,
+								});
+								return { manifest, result: loadCompletedActivationResult(db, draft) };
+							}
+						} catch (error) {
+							if (additiveConvergenceOnly) {
+								throw new LegacyTeamSetupAdditiveConvergenceError(error);
+							}
+							if (!(error instanceof LegacyTeamSetupCompletionManifestError)) throw error;
+							// Falling through replaces the local completion outright.
+							compatibleLocalPolicy = false;
+						}
+					}
+					if (
+						draft.coordinator_id !== input.coordinatorId ||
+						draft.group_id !== input.groupId ||
+						(!hasCompletedDraft &&
+							draft.state !== "needs_setup" &&
+							draft.state !== "in_progress" &&
+							draft.state !== "stale")
+					) {
+						fail("team_setup_completion_invalid");
+					}
+					{
+						// A proven Team/coordinator rename survives both a replacement draft
+						// and a divergent winner re-applied over the completed draft.
+						const team = db
+							.prepare(
+								"SELECT display_name, revision FROM policy_teams WHERE team_id = ? AND status = 'active'",
+							)
+							.get(manifest.team_id) as { display_name: string; revision: string } | undefined;
+						const hasRenamedCompletedLink = team
+							? Boolean(
+									db
+										.prepare(
+											`SELECT 1 FROM legacy_team_setup_drafts AS draft
+											 JOIN legacy_team_setup_completions AS completion
+											   ON completion.attempt_id = draft.attempt_id
+											  AND completion.finish_digest = draft.finish_digest
+											  AND completion.candidate_ref = draft.candidate_id
+											  AND completion.completed_team_id = draft.completed_team_id
+											 WHERE draft.candidate_id = ? AND draft.state = 'completed'
+											   AND draft.completed_team_id = ? AND draft.display_name = ? LIMIT 1`,
+										)
+										.pluck()
+										.get(manifest.candidate_ref, manifest.team_id, team.display_name),
+								)
+							: false;
+						// A completed draft always links to its own completion, so for the
+						// re-apply path the rename must additionally be proven by a
+						// rename-minted revision; a pre-protocol local name is superseded.
+						const renameProven = hasCompletedDraft
+							? Boolean(team && isRecipientPolicyTeamRenameRevision(team.revision))
+							: true;
+						if (
+							team &&
+							team.display_name !== manifest.team.display_name &&
+							hasRenamedCompletedLink &&
+							renameProven
+						) {
+							// Preserve the proven rename, but advance the revision because this
+							// replacement apply may change policy facts from the linked completion.
+							preservedTeamMetadata = {
+								displayName: team.display_name,
+								policyRevision: manifest.team.policy_revision,
+							};
+						}
+					}
+					const retainedCompletionKey = hasCompletedDraft
+						? retainedCompletionKeyForExactReapply(db, draft, manifest)
+						: undefined;
+					rewriteDraftFromManifest(
+						db,
+						draft,
+						manifest,
+						input.freshRoster,
+						preservedTeamMetadata?.displayName,
+					);
+					const result = applyCanonicalLegacyTeamSetupActivationInTransaction(db, {
+						candidateRef: manifest.candidate_ref,
+						attemptId: draft.attempt_id,
+						policyRevision: preservedTeamMetadata?.policyRevision ?? manifest.team.policy_revision,
+						completedAt: manifest.completed_at,
+						completionKey: retainedCompletionKey,
+						allowCompletedDraft: hasCompletedDraft,
+						allowStaleDraft: draft.state === "stale",
+					});
+					return { manifest, result };
+				})
+				.immediate();
+		} catch (error) {
+			// A failed canonical apply must contain any active setup-owned policy,
+			// including one left by a superseded completed draft. Resolution
+			// capacity failures count: retrying cannot converge divergent policy.
+			if (
+				!additiveConvergenceOnly &&
+				!compatibleLocalPolicy &&
+				(error instanceof LegacyTeamSetupCompletionManifestError ||
+					error instanceof LegacyTeamSetupActivationError ||
+					error instanceof LegacyTeamSetupRosterCapacityError)
+			) {
+				quarantineDivergentCompletedPolicy(db, {
+					candidateRef: boundManifest.candidate_ref,
+					teamId: boundManifest.team_id,
+				});
+			}
+			throw error;
+		}
+	};
+	if (input.recipientPolicyLocksHeld) return apply();
+	return serializeRecipientPolicyPublicationMutation(db, () =>
+		serializeRecipientPolicyTeamMutation(db, boundManifest.team_id, () =>
+			serializeRecipientPolicyCoordinatorGroupMutation(db, input.groupId, apply),
+		),
+	);
+}
+
+/** Applies a manifest obtained from an authenticated coordinator transport. */
+export async function applyLegacyTeamSetupCompletionManifest(
+	db: Database,
+	input: ApplyCompletionManifestInput,
+): Promise<CoordinatorLegacyTeamCompletionManifestV1> {
+	return (await applyCompletionManifest(db, input)).manifest;
+}
+
+/** Applies a manifest obtained from an authenticated coordinator transport. */
+export async function applyLegacyTeamSetupCompletionManifestAndReturnActivation(
+	db: Database,
+	input: ApplyCompletionManifestInput,
+): Promise<LegacyTeamSetupActivationResultV1> {
+	return (await applyCompletionManifest(db, input)).result;
+}

--- a/packages/core/src/recipient-policy-team-metadata.ts
+++ b/packages/core/src/recipient-policy-team-metadata.ts
@@ -190,6 +190,13 @@ async function renameLinkedCoordinatorGroup(
 	if (!renamed) fail("team_coordinator_rename_failed");
 }
 
+export const RECIPIENT_POLICY_TEAM_RENAME_REVISION_DOMAIN = "policy-team-metadata-rename-v1";
+
+/** A Team revision minted by `renameRecipientPolicyTeam` rather than by an activation. */
+export function isRecipientPolicyTeamRenameRevision(revision: string): boolean {
+	return revision.startsWith(`${RECIPIENT_POLICY_TEAM_RENAME_REVISION_DOMAIN}:`);
+}
+
 async function serializeMutation<T>(
 	queues: WeakMap<Database, Map<string, Promise<void>>>,
 	db: Database,
@@ -363,7 +370,7 @@ async function renameRecipientPolicyTeamOnce(
 	}
 
 	const now = input.now ?? new Date().toISOString();
-	const revision = recipientPolicyDigest("policy-team-metadata-rename-v1", [
+	const revision = recipientPolicyDigest(RECIPIENT_POLICY_TEAM_RENAME_REVISION_DOMAIN, [
 		team.team_id,
 		team.revision,
 		displayName,


### PR DESCRIPTION
## Description
Validate coordinator-owned legacy Team completion manifests and reconcile them into local policy. Adds bounded resolution, replay handling, additive convergence, containment, transaction guards, and completion-history preservation.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced