### PR TITLE
feat(viewer): reconcile canonical Team completion

### DIFF
--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -356,7 +356,7 @@ describe("recipient invitation API", () => {
 });
 
 describe("legacy Team setup API", () => {
-	it("preserves exactly the seven stable design error codes", async () => {
+	it("preserves exactly the ten stable design error codes", async () => {
 		const errorCodes = [
 			"team_setup_incomplete",
 			"team_setup_roster_changed",
@@ -364,6 +364,9 @@ describe("legacy Team setup API", () => {
 			"team_setup_roster_unavailable",
 			"team_setup_conflict",
 			"team_setup_confirmation_stale",
+			"team_setup_completion_unavailable",
+			"team_setup_completion_conflict",
+			"team_setup_completion_invalid",
 			"team_setup_failed",
 		] as const;
 		const responses = [...errorCodes];

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -1096,6 +1096,9 @@ export type LegacyTeamSetupErrorCode =
 	| "team_setup_roster_unavailable"
 	| "team_setup_conflict"
 	| "team_setup_confirmation_stale"
+	| "team_setup_completion_unavailable"
+	| "team_setup_completion_conflict"
+	| "team_setup_completion_invalid"
 	| "team_setup_failed";
 
 const LEGACY_TEAM_SETUP_VERSION = 1;
@@ -1106,6 +1109,9 @@ const LEGACY_TEAM_SETUP_ERROR_CODES = new Set<LegacyTeamSetupErrorCode>([
 	"team_setup_roster_unavailable",
 	"team_setup_conflict",
 	"team_setup_confirmation_stale",
+	"team_setup_completion_unavailable",
+	"team_setup_completion_conflict",
+	"team_setup_completion_invalid",
 	"team_setup_failed",
 ]);
 const LEGACY_TEAM_SETUP_STATUSES = new Set<LegacyTeamSetupStatusV1>([

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -186,6 +186,7 @@ function createTestApp(opts?: {
 	sweeper?: unknown;
 	getUpdateStatus?: (options: core.GetUpdateStatusOptions) => Promise<core.UpdateStatus>;
 	loadLegacyTeamConfiguredGroupSnapshots?: LegacyTeamConfiguredGroupSnapshotLoader;
+	teamSetupCompletionDependencies?: AppOptions["teamSetupCompletionDependencies"];
 	readCoordinatorConfig?: AppOptions["readCoordinatorConfig"];
 	renameCoordinatorGroup?: AppOptions["renameCoordinatorGroup"];
 	syncRequestRateLimit?: {
@@ -217,6 +218,7 @@ function createTestApp(opts?: {
 		getUpdateStatus: opts?.getUpdateStatus,
 		getSyncRuntimeStatus: opts?.getSyncRuntimeStatus,
 		loadLegacyTeamConfiguredGroupSnapshots: opts?.loadLegacyTeamConfiguredGroupSnapshots,
+		teamSetupCompletionDependencies: opts?.teamSetupCompletionDependencies ?? null,
 		readCoordinatorConfig: opts?.readCoordinatorConfig,
 		renameCoordinatorGroup: opts?.renameCoordinatorGroup,
 	};
@@ -504,6 +506,7 @@ describe("viewer-server", () => {
 		const rawDeviceId = "device-secret-id";
 		const rawIdentityId = "identity-secret-id";
 		const rawProjectIdentity = "https://private.example.invalid/secret/repo.git";
+		const rawFingerprint = "a".repeat(64);
 		const candidateRef = core.legacyTeamCandidateId(coordinatorId, groupId);
 		const snapshots: core.LegacyTeamConfiguredGroupSnapshot[] = [
 			{
@@ -513,7 +516,7 @@ describe("viewer-server", () => {
 				devices: [
 					{
 						deviceId: rawDeviceId,
-						fingerprint: "fingerprint-secret",
+						fingerprint: rawFingerprint,
 						displayName: "Review Laptop",
 						enabled: true,
 					},
@@ -568,6 +571,15 @@ describe("viewer-server", () => {
 			const loadSnapshots = vi.fn(async () => snapshots);
 			const { app, ensureStore, cleanup } = createTestApp({
 				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				readCoordinatorConfig: () =>
+					core.readCoordinatorSyncConfig({
+						sync_coordinator_url: coordinatorId,
+						sync_coordinator_admin_secret: "test-secret",
+					}),
+				teamSetupCompletionDependencies: {
+					create: async ({ manifest }) => ({ status: "created", manifest }),
+					list: async () => [],
+				},
 			});
 			try {
 				const store = ensureStore();
@@ -825,7 +837,7 @@ describe("viewer-server", () => {
 				expect(JSON.stringify(detail)).not.toContain(groupId);
 				expect(JSON.stringify(detail)).not.toContain(rawDeviceId);
 				expect(JSON.stringify(detail)).not.toContain(rawIdentityId);
-				expect(JSON.stringify(detail)).not.toContain("fingerprint-secret");
+				expect(JSON.stringify(detail)).not.toContain(rawFingerprint);
 				expect(JSON.stringify(detail)).not.toContain(rawProjectIdentity);
 				expect(JSON.stringify(detail)).not.toContain(rawPreview.accessDelta.teamChanges[0]?.teamId);
 				expect(detail).toHaveProperty("accessDelta.teamChanges.0.teamRef");
@@ -927,8 +939,12 @@ describe("viewer-server", () => {
 					body: JSON.stringify(finishRequest),
 				});
 				expect(finishResponse.status).toBe(200);
-				expect(loadSnapshots).toHaveBeenCalledTimes(1);
-				expect(loadSnapshots).toHaveBeenCalledWith({ candidateRef });
+				expect(loadSnapshots).toHaveBeenCalledTimes(2);
+				expect(loadSnapshots).toHaveBeenNthCalledWith(1, { candidateRef });
+				expect(loadSnapshots).toHaveBeenNthCalledWith(
+					2,
+					expect.objectContaining({ candidateRef, deadlineMs: expect.any(Number) }),
+				);
 				const finished = await finishResponse.json();
 				expect(finished).toMatchObject({
 					version: 1,

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -33,6 +33,7 @@ import { rawEventsRoutes } from "./routes/raw-events.js";
 import { statsRoutes } from "./routes/stats.js";
 import { type SyncRoutesOptions, syncProtocolRoutes, syncRoutes } from "./routes/sync.js";
 import {
+	type LegacyTeamCompletionDependencies,
 	type LegacyTeamConfiguredGroupSnapshotLoader,
 	TEAM_SETUP_ROUTE_PREFIX,
 	teamSetupRoutes,
@@ -103,6 +104,7 @@ export interface AppOptions {
 	getUpdateStatus?: (options: GetUpdateStatusOptions) => Promise<UpdateStatus>;
 	loadDeviceIdentityCoordinatorEvidence?: () => Promise<DeviceIdentityCoordinatorEvidence>;
 	loadLegacyTeamConfiguredGroupSnapshots?: LegacyTeamConfiguredGroupSnapshotLoader;
+	teamSetupCompletionDependencies?: LegacyTeamCompletionDependencies | null;
 	readCoordinatorConfig?: SyncRoutesOptions["readCoordinatorConfig"];
 	renameCoordinatorGroup?: SyncRoutesOptions["renameCoordinatorGroup"];
 	syncRequestRateLimit?: {
@@ -167,6 +169,8 @@ export function createApp(opts?: AppOptions) {
 		teamSetupRoutes({
 			getStore: storeFactory,
 			loadLegacyTeamConfiguredGroupSnapshots: opts?.loadLegacyTeamConfiguredGroupSnapshots,
+			completionDependencies: opts?.teamSetupCompletionDependencies,
+			readCoordinatorConfig: opts?.readCoordinatorConfig,
 			registerSummaryInvalidator: (invalidate) => {
 				invalidateTeamSetupSummary = invalidate;
 			},

--- a/packages/viewer-server/src/routes/team-setup-refresh.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-refresh.test.ts
@@ -23,6 +23,7 @@ describe("Team setup refresh snapshots", () => {
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+			completionDependencies: null,
 		});
 		try {
 			store.db

--- a/packages/viewer-server/src/routes/team-setup-terminal.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-terminal.test.ts
@@ -1,4 +1,5 @@
 import {
+	deriveLegacyTeamSetupCompletionManifest,
 	deterministicPolicyTeamId,
 	finishLegacyTeamSetupActivation,
 	getLegacyTeamSetupDraft,
@@ -8,6 +9,10 @@ import {
 	legacyTeamCandidateProjectInventory,
 	MemoryStore,
 	readCoordinatorSyncConfig,
+	serializeRecipientPolicyActorMutations,
+	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyPublicationMutation,
+	serializeRecipientPolicyTeamMutation,
 	setLegacyTeamSetupDeviceAssignment,
 	setLegacyTeamSetupDeviceDecision,
 } from "@codemem/core";
@@ -18,6 +23,8 @@ const COORDINATOR_ID = "https://coordinator.example.test";
 const GROUP_ID = "group-alpha";
 const CANDIDATE_REF = legacyTeamCandidateId(COORDINATOR_ID, GROUP_ID);
 const NOW = "2026-08-26T00:00:00.000Z";
+const FINGERPRINT_A = "a".repeat(64);
+const FINGERPRINT_B = "b".repeat(64);
 const SNAPSHOTS: LegacyTeamConfiguredGroupSnapshot[] = [
 	{
 		coordinatorId: COORDINATOR_ID,
@@ -26,7 +33,7 @@ const SNAPSHOTS: LegacyTeamConfiguredGroupSnapshot[] = [
 		devices: [
 			{
 				deviceId: "device-a",
-				fingerprint: "fingerprint-a",
+				fingerprint: FINGERPRINT_A,
 				displayName: "Laptop",
 				enabled: true,
 			},
@@ -78,11 +85,2015 @@ function completeDraft(
 }
 
 describe("Team setup terminal migration routing", () => {
+	function completionConfig(timeoutS?: number) {
+		return {
+			readConfig: () => ({
+				...readCoordinatorSyncConfig({}),
+				syncCoordinatorUrl: COORDINATOR_ID,
+				syncCoordinatorGroups: [GROUP_ID],
+				syncCoordinatorAdminSecret: "private-admin-secret",
+				...(timeoutS == null ? {} : { syncCoordinatorTimeoutS: timeoutS }),
+			}),
+			listGroups: vi.fn(async () => []),
+			listDevices: vi.fn(async () => []),
+		};
+	}
+
+	async function readyDraftThroughSummary(
+		store: MemoryStore,
+		app: ReturnType<typeof teamSetupRoutes>,
+	) {
+		expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+		store.db
+			.prepare(
+				`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+				 VALUES ('identity-a', 'Person A', 0, 'active', ?, ?)`,
+			)
+			.run(NOW, NOW);
+		let draft = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+		if (!draft) throw new Error("Team setup draft missing");
+		const device = draft.devices[0];
+		if (!device) throw new Error("Team setup device missing");
+		draft = setLegacyTeamSetupDeviceAssignment(store.db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			targetIdentityId: "identity-a",
+			expectation: device.expectation,
+			now: NOW,
+		});
+		return setLegacyTeamSetupDeviceDecision(store.db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			decision: "included",
+			now: NOW,
+		});
+	}
+
+	it("publishes before activating the immutable winner", async () => {
+		const store = new MemoryStore(":memory:");
+		const loadSnapshots = vi.fn(async () => SNAPSHOTS);
+		const create = vi.fn(async ({ manifest }) => {
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+			return { status: "created" as const, manifest };
+		});
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: { create, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			const finishRequest = {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			};
+			const response = await app.request(
+				`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`,
+				finishRequest,
+			);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toMatchObject({
+				accessDeltaDigest: detail.accessDeltaDigest,
+			});
+			const completion = store.db
+				.prepare(
+					`SELECT finish_digest, confirmed_access_delta_digest
+					 FROM legacy_team_setup_completions WHERE attempt_id = ?`,
+				)
+				.get(draft.attemptId) as {
+				finish_digest: string;
+				confirmed_access_delta_digest: string;
+			};
+			expect(completion).toEqual({
+				finish_digest: detail.finishDigest,
+				confirmed_access_delta_digest: detail.accessDeltaDigest,
+			});
+			expect(completion.finish_digest).toMatch(/^legacy-team-activation-finish-v1:[0-9a-f]{64}$/u);
+			expect(completion.confirmed_access_delta_digest).toMatch(
+				/^legacy-team-access-delta:[0-9a-f]{64}$/u,
+			);
+			expect(create).toHaveBeenCalledTimes(1);
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(1);
+			expect(store.db.prepare("SELECT display_name FROM policy_teams").pluck().get()).toBe(
+				"Migration Team",
+			);
+			loadSnapshots.mockRejectedValue(new Error("coordinator unavailable"));
+			const replay = await app.request(
+				`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`,
+				finishRequest,
+			);
+			expect(replay.status).toBe(200);
+			expect(await replay.json()).toMatchObject({ accessDeltaDigest: detail.accessDeltaDigest });
+			expect(create).toHaveBeenCalledTimes(1);
+			const staleReplay = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				...finishRequest,
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: `legacy-team-activation-finish-v1:${"0".repeat(64)}`,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+			expect(staleReplay.status).toBe(409);
+			expect(await staleReplay.json()).toEqual({ error: "team_setup_confirmation_stale" });
+			expect(create).toHaveBeenCalledTimes(1);
+			const staleAccessReplay = await app.request(
+				`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`,
+				{
+					...finishRequest,
+					body: JSON.stringify({
+						attemptId: draft.attemptId,
+						finishDigest: detail.finishDigest,
+						confirmedAccessDeltaDigest: `legacy-team-access-delta:${"1".repeat(64)}`,
+						confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+					}),
+				},
+			);
+			expect(staleAccessReplay.status).toBe(409);
+			expect(await staleAccessReplay.json()).toEqual({ error: "team_setup_confirmation_stale" });
+			expect(create).toHaveBeenCalledTimes(1);
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(1);
+			expect(
+				store.db
+					.prepare("SELECT state FROM legacy_team_setup_drafts WHERE candidate_id = ?")
+					.pluck()
+					.get(CANDIDATE_REF),
+			).toBe("completed");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("keeps local policy uncommitted when completion publication fails", async () => {
+		const store = new MemoryStore(":memory:");
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: {
+				create: async () => {
+					throw new Error("private upstream detail");
+				},
+				list: async () => [],
+			},
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+			expect(response.status).toBe(503);
+			expect(await response.json()).toEqual({ error: "team_setup_completion_unavailable" });
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+			await Promise.all([
+				serializeRecipientPolicyPublicationMutation(store.db, async () => undefined),
+				serializeRecipientPolicyActorMutations(store.db, ["identity-a"], async () => undefined),
+			]);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("recovers a completion committed before its create response was lost", async () => {
+		const store = new MemoryStore(":memory:");
+		let published: ReturnType<typeof deriveLegacyTeamSetupCompletionManifest> | null = null;
+		const create = vi.fn(async ({ manifest }) => {
+			published = { ...manifest, completed_at: NOW };
+			throw new Error("completion_conflict");
+		});
+		const get = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Remote coordinator request failed (503): unavailable"))
+			.mockImplementation(async () => published);
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: { create, get, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toMatchObject({ completedAt: NOW });
+			expect(create).toHaveBeenCalledWith(
+				expect.objectContaining({ timeoutS: expect.any(Number) }),
+			);
+			expect(get).toHaveBeenCalledTimes(2);
+			expect(get).toHaveBeenCalledWith(
+				expect.objectContaining({
+					groupId: GROUP_ID,
+					candidateRef: CANDIDATE_REF,
+					timeoutS: expect.any(Number),
+				}),
+			);
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.state).toBe("completed");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("rejects a coordinator manifest that differs from the proposed completion", async () => {
+		const store = new MemoryStore(":memory:");
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: {
+				create: async ({ manifest }) => ({
+					status: "existing" as const,
+					manifest: { ...manifest, completed_at: "2026-08-30T00:00:01.000Z" },
+				}),
+				list: async () => [],
+			},
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_setup_completion_conflict" });
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("applies a remote completion before suppressing its candidate", async () => {
+		const source = new MemoryStore(":memory:");
+		const target = new MemoryStore(":memory:");
+		const sourceApp = teamSetupRoutes({
+			getStore: () => source,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const sourceDraft = await readyDraftThroughSummary(source, sourceApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(source.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: sourceDraft.attemptId,
+				completedAt: NOW,
+			});
+			const targetApp = teamSetupRoutes({
+				getStore: () => target,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: async ({ manifest }) => ({ status: "existing", manifest }),
+					list: async () => [
+						{
+							group_id: GROUP_ID,
+							manifest: {
+								...manifest,
+								candidate_ref: "legacy-team-candidate:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+							},
+						},
+						{ group_id: GROUP_ID, manifest },
+					],
+				},
+			});
+			target.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('identity-a', 'Person A', 0, 'active', ?, ?)`,
+				)
+				.run(NOW, NOW);
+			const response = await targetApp.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ version: 1, candidates: [] });
+			expect(target.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(1);
+		} finally {
+			source.close();
+			target.close();
+		}
+	});
+
+	it("isolates an invalid completion to its group during summary reconciliation", async () => {
+		const source = new MemoryStore(":memory:");
+		const target = new MemoryStore(":memory:");
+		const sourceApp = teamSetupRoutes({
+			getStore: () => source,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const sourceDraft = await readyDraftThroughSummary(source, sourceApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(source.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: sourceDraft.attemptId,
+				completedAt: NOW,
+			});
+			const secondGroup = {
+				...SNAPSHOTS[0],
+				groupId: "group-beta",
+				displayName: "Other Team",
+			} as LegacyTeamConfiguredGroupSnapshot;
+			const app = teamSetupRoutes({
+				getStore: () => target,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => [...SNAPSHOTS, secondGroup],
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: vi.fn(),
+					list: async () => [
+						{ group_id: GROUP_ID, manifest: { ...manifest, team_id: "team-invalid" } },
+					],
+				},
+			});
+
+			const response = await app.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			const body = (await response.json()) as { candidates: unknown[] };
+			expect(body.candidates).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ candidateRef: CANDIDATE_REF }),
+					expect.objectContaining({
+						candidateRef: legacyTeamCandidateId(COORDINATOR_ID, secondGroup.groupId),
+					}),
+				]),
+			);
+		} finally {
+			source.close();
+			target.close();
+		}
+	});
+
+	it("isolates an undecodable batch record to its group during summary reconciliation", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			const secondGroup = {
+				...SNAPSHOTS[0],
+				groupId: "group-beta",
+				displayName: "Other Team",
+			} as LegacyTeamConfiguredGroupSnapshot;
+			// The production batch action rejects the whole payload when any one
+			// record fails decoding, so the route must re-query per group.
+			const list = vi.fn(async (input: { groupIds: string[] }) => {
+				if (input.groupIds.length === 1 && input.groupIds[0] === GROUP_ID) {
+					return [{ group_id: GROUP_ID, manifest }];
+				}
+				throw new Error("coordinator_completion_response_malformed");
+			});
+			const twoGroupConfig = completionConfig();
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => [...SNAPSHOTS, secondGroup],
+				snapshotLoaderDependencies: {
+					...twoGroupConfig,
+					readConfig: () => ({
+						...twoGroupConfig.readConfig(),
+						syncCoordinatorGroups: [GROUP_ID, secondGroup.groupId],
+					}),
+				},
+				completionDependencies: { create: vi.fn(), list },
+			});
+
+			const response = await app.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			const body = (await response.json()) as { candidates: unknown[] };
+			// The decodable group's completion applied (so it no longer needs setup)
+			// while the undecodable group still surfaces its own setup state.
+			expect(body.candidates).toEqual([
+				expect.objectContaining({
+					candidateRef: legacyTeamCandidateId(COORDINATOR_ID, secondGroup.groupId),
+					status: "needs_setup",
+				}),
+			]);
+			expect(list.mock.calls.map(([input]) => input.groupIds)).toEqual([
+				[GROUP_ID, secondGroup.groupId],
+				[GROUP_ID],
+				[secondGroup.groupId],
+			]);
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.state).toBe("completed");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("refreshes detail presentation after reconciling a completed draft", async () => {
+		const source = new MemoryStore(":memory:");
+		const target = new MemoryStore(":memory:");
+		const canonicalSnapshots = [
+			{
+				...SNAPSHOTS[0],
+				displayName: "Canonical Team",
+				devices: [
+					...(SNAPSHOTS[0]?.devices ?? []),
+					{
+						deviceId: "device-b",
+						displayName: "Spare laptop",
+						fingerprint: FINGERPRINT_B,
+						identityId: null,
+						enabled: true,
+					},
+				],
+			},
+		];
+		const sourceApp = teamSetupRoutes({
+			getStore: () => source,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => canonicalSnapshots,
+			completionDependencies: null,
+		});
+		const targetSetupApp = teamSetupRoutes({
+			getStore: () => target,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			let sourceDraft = await readyDraftThroughSummary(source, sourceApp);
+			const excludedDevice = sourceDraft.devices.find(
+				(device) => device.displayName === "Spare laptop",
+			);
+			if (!excludedDevice) throw new Error("canonical excluded device missing");
+			sourceDraft = setLegacyTeamSetupDeviceDecision(source.db, {
+				attemptId: sourceDraft.attemptId,
+				deviceRef: excludedDevice.deviceRef,
+				decision: "excluded",
+				now: NOW,
+			});
+			const manifest = deriveLegacyTeamSetupCompletionManifest(source.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: sourceDraft.attemptId,
+				completedAt: NOW,
+			});
+			const targetDraft = await readyDraftThroughSummary(target, targetSetupApp);
+			const review = inspectLegacyTeamSetupActivation(target.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: targetDraft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(target.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: targetDraft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			const app = teamSetupRoutes({
+				getStore: () => target,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => canonicalSnapshots,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: async ({ manifest: replay }) => ({ status: "existing", manifest: replay }),
+					list: async () => [{ group_id: GROUP_ID, manifest }],
+				},
+			});
+
+			let releasePublication: () => void = () => undefined;
+			const publicationGate = new Promise<void>((resolve) => {
+				releasePublication = resolve;
+			});
+			let markPublicationStarted: () => void = () => undefined;
+			const publicationStarted = new Promise<void>((resolve) => {
+				markPublicationStarted = resolve;
+			});
+			const heldPublication = serializeRecipientPolicyPublicationMutation(target.db, async () => {
+				markPublicationStarted();
+				await publicationGate;
+			});
+			await publicationStarted;
+			let detailSettled = false;
+			const detailRequest = app
+				.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+				.then((response) => {
+					detailSettled = true;
+					return response;
+				});
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(detailSettled).toBe(false);
+			releasePublication();
+			const response = await detailRequest;
+			await heldPublication;
+			expect(response.status).toBe(200);
+			expect(await response.json()).toMatchObject({
+				candidate: { displayName: "Canonical Team" },
+				state: "completed",
+			});
+		} finally {
+			source.close();
+			target.close();
+		}
+	});
+
+	it("does not republish an existing coordinator completion during loading", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			const create = vi.fn(async ({ manifest: replay }) => ({
+				status: "existing" as const,
+				manifest: replay,
+			}));
+			const list = vi.fn(async () => [{ group_id: GROUP_ID, manifest }]);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create,
+					list,
+				},
+			});
+			const response = await app.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ version: 1, candidates: [] });
+			expect(list).toHaveBeenCalledOnce();
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not block loading when existing-completion publication fails", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			let publicationMutationStarted = false;
+			let publicationMutation: Promise<void> | undefined;
+			let teamMutationStarted = false;
+			let teamMutation: Promise<void> | undefined;
+			let publicationStartedDuringCreate: boolean | undefined;
+			let teamStartedDuringCreate: boolean | undefined;
+			const create = vi.fn(async () => {
+				publicationMutation = serializeRecipientPolicyPublicationMutation(store.db, async () => {
+					publicationMutationStarted = true;
+				});
+				teamMutation = serializeRecipientPolicyTeamMutation(
+					store.db,
+					deterministicPolicyTeamId(CANDIDATE_REF),
+					async () => {
+						teamMutationStarted = true;
+					},
+				);
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				publicationStartedDuringCreate = publicationMutationStarted;
+				teamStartedDuringCreate = teamMutationStarted;
+				throw new Error("coordinator temporarily unavailable");
+			});
+			const list = vi.fn(async () => []);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: { create, list },
+			});
+
+			const response = await app.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ version: 1, candidates: [] });
+			expect(create).toHaveBeenCalledOnce();
+			expect(publicationStartedDuringCreate).toBe(false);
+			expect(teamStartedDuringCreate).toBe(false);
+			if (!publicationMutation) throw new Error("publication mutation was not queued");
+			if (!teamMutation) throw new Error("Team mutation was not queued");
+			await Promise.all([publicationMutation, teamMutation]);
+			expect(publicationMutationStarted).toBe(true);
+			expect(teamMutationStarted).toBe(true);
+			expect(list).toHaveBeenCalledOnce();
+			expect(
+				store.db
+					.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+					.get(deterministicPolicyTeamId(CANDIDATE_REF)),
+			).toEqual({ status: "active", migration_state: "completed" });
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.state).toBe("completed");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("applies the canonical winner when existing-completion publication conflicts", async () => {
+		const source = new MemoryStore(":memory:");
+		const target = new MemoryStore(":memory:");
+		const sourceApp = teamSetupRoutes({
+			getStore: () => source,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		const targetSetupApp = teamSetupRoutes({
+			getStore: () => target,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const sourceDraft = await readyDraftThroughSummary(source, sourceApp);
+			source.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+				)
+				.run(NOW, NOW);
+			source.db
+				.prepare(
+					"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-b' WHERE attempt_id = ?",
+				)
+				.run(sourceDraft.attemptId);
+			const canonicalManifest = deriveLegacyTeamSetupCompletionManifest(source.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: sourceDraft.attemptId,
+				completedAt: NOW,
+			});
+			const targetDraft = await readyDraftThroughSummary(target, targetSetupApp);
+			const review = inspectLegacyTeamSetupActivation(target.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: targetDraft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(target.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: targetDraft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			target.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+				)
+				.run(NOW, NOW);
+			const get = vi.fn(async () => canonicalManifest);
+			const app = teamSetupRoutes({
+				getStore: () => target,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: async () => {
+						throw new Error("completion_conflict");
+					},
+					get,
+					list: async () => [],
+				},
+			});
+
+			const response = await app.request("/api/sync/team-setup/v1");
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ version: 1, candidates: [] });
+			expect(get).toHaveBeenCalledWith(
+				expect.objectContaining({
+					groupId: GROUP_ID,
+					candidateRef: CANDIDATE_REF,
+					timeoutS: expect.any(Number),
+				}),
+			);
+			expect(
+				target.db
+					.prepare(
+						"SELECT identity_id FROM policy_team_memberships WHERE team_id = ? AND status = 'reviewed_active'",
+					)
+					.pluck()
+					.get(deterministicPolicyTeamId(CANDIDATE_REF)),
+			).toBe("identity-b");
+		} finally {
+			source.close();
+			target.close();
+		}
+	});
+
+	it.each([
+		"roster-unavailable",
+		"additive-roster-unavailable",
+		"group-missing",
+		"digest-invalid",
+		"binding-mismatch",
+		"malformed",
+		"partial-roster-unavailable",
+	] as const)(
+		"handles a divergent local completion when a listed winner is %s",
+		async (failureMode) => {
+			const source = new MemoryStore(":memory:");
+			const target = new MemoryStore(":memory:");
+			const sourceApp = teamSetupRoutes({
+				getStore: () => source,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				completionDependencies: null,
+			});
+			const targetSetupApp = teamSetupRoutes({
+				getStore: () => target,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				completionDependencies: null,
+			});
+			try {
+				if (failureMode === "additive-roster-unavailable") {
+					const projectIdentity = "https://example.test/additive-project.git";
+					source.db
+						.prepare(
+							`INSERT INTO replication_scopes(
+							 scope_id, label, kind, authority_type, coordinator_id, group_id,
+							 membership_epoch, status, created_at, updated_at
+							 ) VALUES ('scope-additive', 'Additive', 'team', 'coordinator', ?, ?, 1,
+							 'active', ?, ?)`,
+						)
+						.run(COORDINATOR_ID, GROUP_ID, NOW, NOW);
+					const sessionId = Number(
+						source.db
+							.prepare(
+								`INSERT INTO sessions(started_at, project, git_remote)
+								 VALUES (?, 'additive-project', ?)`,
+							)
+							.run(NOW, projectIdentity).lastInsertRowid,
+					);
+					source.db
+						.prepare(
+							`INSERT INTO memory_items(
+							 session_id, kind, title, body_text, active, created_at, updated_at,
+							 visibility, project, scope_id
+							 ) VALUES (?, 'discovery', 'Additive Project', 'body', 1, ?, ?, 'shared',
+							 'additive-project', 'scope-additive')`,
+						)
+						.run(sessionId, NOW, NOW);
+					source.db
+						.prepare(
+							`INSERT INTO project_scope_mappings(
+							 workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+							 ) VALUES (?, ?, 'scope-additive', 1000, 'reviewed_team_setup', ?, ?)`,
+						)
+						.run(projectIdentity, projectIdentity, NOW, NOW);
+				}
+				const sourceDraft = await readyDraftThroughSummary(source, sourceApp);
+				if (failureMode !== "additive-roster-unavailable") {
+					source.db
+						.prepare(
+							`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+						 VALUES ('identity-b', 'Person B', 0, 'active', ?, ?)`,
+						)
+						.run(NOW, NOW);
+					source.db
+						.prepare(
+							"UPDATE legacy_team_setup_draft_devices SET target_identity_id = 'identity-b' WHERE attempt_id = ?",
+						)
+						.run(sourceDraft.attemptId);
+				}
+				const canonicalManifest = deriveLegacyTeamSetupCompletionManifest(source.db, {
+					candidateRef: CANDIDATE_REF,
+					attemptId: sourceDraft.attemptId,
+					completedAt: NOW,
+				});
+				const targetDraft = await readyDraftThroughSummary(target, targetSetupApp);
+				const review = inspectLegacyTeamSetupActivation(target.db, {
+					candidateRef: CANDIDATE_REF,
+					attemptId: targetDraft.attemptId,
+				});
+				await finishLegacyTeamSetupActivation(target.db, {
+					candidateRef: CANDIDATE_REF,
+					attemptId: targetDraft.attemptId,
+					finishDigest: review.finishDigest,
+					confirmedAccessDeltaDigest: review.accessDeltaDigest,
+					loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+					loadProjectInventory: () => [],
+					validateLockedPreview: () => true,
+					now: NOW,
+				});
+				let unscopedLoadCount = 0;
+				const primarySnapshot = SNAPSHOTS[0];
+				if (!primarySnapshot) throw new Error("missing primary test snapshot");
+				const secondSnapshot = { ...primarySnapshot, groupId: "other-group" };
+				const loadSnapshots = vi.fn(async (options?: { candidateRef?: string }) => {
+					if (failureMode === "partial-roster-unavailable") {
+						if (options?.candidateRef) throw new Error("team_setup_roster_unavailable");
+						unscopedLoadCount += 1;
+						return unscopedLoadCount === 1 ? [...SNAPSHOTS, secondSnapshot] : [secondSnapshot];
+					}
+					if (options?.candidateRef && failureMode === "group-missing") return [];
+					if (options?.candidateRef) throw new Error("team_setup_roster_unavailable");
+					return SNAPSHOTS;
+				});
+				const listedManifest = (() => {
+					if (failureMode === "digest-invalid") {
+						return { ...canonicalManifest, finish_digest: "0".repeat(64) };
+					}
+					if (failureMode === "binding-mismatch") {
+						return { ...canonicalManifest, coordinator_id: "other-coordinator" };
+					}
+					if (failureMode === "malformed") {
+						return null as unknown as typeof canonicalManifest;
+					}
+					return canonicalManifest;
+				})();
+				const snapshotDependencies = completionConfig();
+				if (failureMode === "partial-roster-unavailable") {
+					snapshotDependencies.readConfig = () => ({
+						...readCoordinatorSyncConfig({}),
+						syncCoordinatorUrl: COORDINATOR_ID,
+						syncCoordinatorGroups: [GROUP_ID, secondSnapshot.groupId],
+						syncCoordinatorAdminSecret: "private-admin-secret",
+					});
+				}
+				const app = teamSetupRoutes({
+					getStore: () => target,
+					loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+					snapshotLoaderDependencies: snapshotDependencies,
+					completionDependencies: {
+						create: vi.fn(),
+						list: async () => [{ group_id: GROUP_ID, manifest: listedManifest }],
+					},
+				});
+
+				const response = await app.request("/api/sync/team-setup/v1");
+
+				expect(response.status).toBe(200);
+				const shouldContain =
+					failureMode !== "additive-roster-unavailable" &&
+					failureMode !== "binding-mismatch" &&
+					failureMode !== "malformed" &&
+					failureMode !== "partial-roster-unavailable";
+				const body = await response.json();
+				if (shouldContain) {
+					expect(body).toMatchObject({
+						candidates: [expect.objectContaining({ candidateRef: CANDIDATE_REF })],
+					});
+				}
+				expect(
+					target.db
+						.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+						.get(deterministicPolicyTeamId(CANDIDATE_REF)),
+				).toEqual(
+					shouldContain
+						? { status: "inactive", migration_state: "needs_setup" }
+						: { status: "active", migration_state: "completed" },
+				);
+			} finally {
+				source.close();
+				target.close();
+			}
+		},
+	);
+
+	it("contains local completion when a fetched winner cannot load a fresh roster", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			const loadSnapshots = vi.fn(async (options?: { candidateRef?: string }) => {
+				if (options?.candidateRef) throw new Error("team_setup_roster_unavailable");
+				return SNAPSHOTS;
+			});
+			const get = vi.fn(async () => manifest);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: async () => {
+						throw new Error("completion_conflict");
+					},
+					get,
+					list: async () => [],
+				},
+			});
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(409);
+			expect(await detail.json()).toEqual({ error: "team_setup_completion_conflict" });
+			const summary = await app.request("/api/sync/team-setup/v1");
+			expect(summary.status).toBe(200);
+			expect(await summary.json()).toMatchObject({
+				candidates: [expect.objectContaining({ candidateRef: CANDIDATE_REF })],
+			});
+			expect(get).toHaveBeenCalledOnce();
+			expect(
+				store.db
+					.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+					.get(deterministicPolicyTeamId(CANDIDATE_REF)),
+			).toEqual({ status: "inactive", migration_state: "needs_setup" });
+		} finally {
+			store.close();
+		}
+	});
+
+	it("contains local completion when a publication conflict has no fetchable winner", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: async () => {
+						throw new Error("completion_conflict");
+					},
+					get: async () => null,
+					list: async () => [],
+				},
+			});
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(409);
+			expect(await detail.json()).toEqual({ error: "team_setup_completion_conflict" });
+			expect(
+				store.db
+					.prepare("SELECT finish_digest FROM legacy_team_setup_drafts WHERE attempt_id = ?")
+					.pluck()
+					.get(draft.attemptId),
+			).toBeNull();
+			const summary = await app.request("/api/sync/team-setup/v1");
+			expect(summary.status).toBe(200);
+			expect(await summary.json()).toMatchObject({
+				candidates: [expect.objectContaining({ candidateRef: CANDIDATE_REF })],
+			});
+			expect(
+				store.db
+					.prepare("SELECT status, migration_state FROM policy_teams WHERE team_id = ?")
+					.get(deterministicPolicyTeamId(CANDIDATE_REF)),
+			).toEqual({ status: "inactive", migration_state: "needs_setup" });
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not publish a persisted completion to a newly configured coordinator", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			const create = vi.fn();
+			const list = vi.fn(async () => []);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => [],
+				snapshotLoaderDependencies: {
+					...completionConfig(),
+					readConfig: () => ({
+						...readCoordinatorSyncConfig({}),
+						syncCoordinatorUrl: "https://other-coordinator.example.test",
+						syncCoordinatorGroups: [GROUP_ID],
+						syncCoordinatorAdminSecret: "other-private-admin-secret",
+					}),
+				},
+				completionDependencies: { create, list },
+			});
+
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toMatchObject({ state: "completed" });
+			expect(list).not.toHaveBeenCalled();
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not publish a persisted completion for a group removed from configuration", async () => {
+		const store = new MemoryStore(":memory:");
+		let configuredGroups = [GROUP_ID];
+		const create = vi.fn();
+		const list = vi.fn(async () => []);
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: {
+				...completionConfig(),
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: COORDINATOR_ID,
+					syncCoordinatorGroups: configuredGroups,
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+			},
+			completionDependencies: { create, list },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			configuredGroups = [];
+			create.mockClear();
+			list.mockClear();
+
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toMatchObject({ state: "completed" });
+			expect(list).not.toHaveBeenCalled();
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not publish finish data when the coordinator changes after roster loading", async () => {
+		const store = new MemoryStore(":memory:");
+		let changedConfig = false;
+		let changeAfterNextSnapshot = false;
+		const create = vi.fn();
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => {
+				if (changeAfterNextSnapshot) changedConfig = true;
+				return SNAPSHOTS;
+			},
+			snapshotLoaderDependencies: {
+				...completionConfig(),
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: changedConfig
+						? "https://other-coordinator.example.test"
+						: COORDINATOR_ID,
+					syncCoordinatorGroups: [GROUP_ID],
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+			},
+			completionDependencies: { create, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			changeAfterNextSnapshot = true;
+
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_setup_completion_invalid" });
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not publish finish data when its group is removed during roster loading", async () => {
+		const store = new MemoryStore(":memory:");
+		let configuredGroups = [GROUP_ID];
+		let removeAfterNextSnapshot = false;
+		const create = vi.fn();
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => {
+				if (removeAfterNextSnapshot) configuredGroups = [];
+				return SNAPSHOTS;
+			},
+			snapshotLoaderDependencies: {
+				...completionConfig(),
+				readConfig: () => ({
+					...readCoordinatorSyncConfig({}),
+					syncCoordinatorUrl: COORDINATOR_ID,
+					syncCoordinatorGroups: configuredGroups,
+					syncCoordinatorAdminSecret: "private-admin-secret",
+				}),
+			},
+			completionDependencies: { create, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			removeAfterNextSnapshot = true;
+
+			const response = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_setup_completion_invalid" });
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("locks an excluded device's existing identity through completion publication", async () => {
+		const store = new MemoryStore(":memory:");
+		let releaseCreate: () => void = () => undefined;
+		const createGate = new Promise<void>((resolve) => {
+			releaseCreate = resolve;
+		});
+		let markCreateStarted: () => void = () => undefined;
+		const createStarted = new Promise<void>((resolve) => {
+			markCreateStarted = resolve;
+		});
+		let existingActorMutationStarted = false;
+		let existingActorMutation: Promise<void> | undefined;
+		const create = vi.fn(async ({ manifest }) => {
+			// The reviewed device belongs to identity-existing and is excluded; a
+			// merge or deactivation of that identity must wait for publication.
+			existingActorMutation = serializeRecipientPolicyActorMutations(
+				store.db,
+				["identity-existing"],
+				async () => {
+					existingActorMutationStarted = true;
+				},
+			);
+			markCreateStarted();
+			await createGate;
+			return { status: "created" as const, manifest };
+		});
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: { create, list: async () => [] },
+		});
+		try {
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('identity-existing', 'Existing Person', 0, 'active', ?, ?)`,
+				)
+				.run(NOW, NOW);
+			store.db
+				.prepare(
+					`INSERT INTO identity_devices(
+					 device_id, identity_id, display_name, status, provenance, revision, migration_state,
+					 assignment_version, idempotency_key, created_at, updated_at
+					 ) VALUES ('device-a', 'identity-existing', 'Laptop', 'active', 'invitation', 'r1',
+					 'completed', 0, 'existing-a', ?, ?)`,
+				)
+				.run(NOW, NOW);
+			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+			let draft = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+			if (!draft) throw new Error("Team setup draft missing");
+			const device = draft.devices[0];
+			if (!device) throw new Error("Team setup device missing");
+			expect(device.existingIdentityId).toBe("identity-existing");
+			draft = setLegacyTeamSetupDeviceDecision(store.db, {
+				attemptId: draft.attemptId,
+				deviceRef: device.deviceRef,
+				decision: "excluded",
+				now: NOW,
+			});
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			const finishRequest = app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+			await createStarted;
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(existingActorMutationStarted).toBe(false);
+			releaseCreate();
+			const response = await finishRequest;
+			expect(response.status).toBe(200);
+			if (!existingActorMutation) throw new Error("actor mutation was not queued");
+			await existingActorMutation;
+			expect(existingActorMutationStarted).toBe(true);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("serializes a draft mutation behind completion publication", async () => {
+		const store = new MemoryStore(":memory:");
+		let groupMutationStarted = false;
+		let groupMutation: Promise<void> | undefined;
+		let policyMutationStarted = false;
+		let policyMutation: Promise<void> | undefined;
+		let actorMutationStarted = false;
+		let actorMutation: Promise<void> | undefined;
+		let publicationMutationStarted = false;
+		let publicationMutation: Promise<void> | undefined;
+		let releaseCreate: () => void = () => undefined;
+		const createGate = new Promise<void>((resolve) => {
+			releaseCreate = resolve;
+		});
+		let markCreateStarted: () => void = () => undefined;
+		const createStarted = new Promise<void>((resolve) => {
+			markCreateStarted = resolve;
+		});
+		let listedManifest: ReturnType<typeof deriveLegacyTeamSetupCompletionManifest> | null = null;
+		let listInvalidDigest = false;
+		const create = vi.fn(async ({ manifest }) => {
+			listedManifest = manifest;
+			groupMutation = serializeRecipientPolicyCoordinatorGroupMutation(
+				store.db,
+				GROUP_ID,
+				async () => {
+					groupMutationStarted = true;
+				},
+			);
+			policyMutation = serializeRecipientPolicyTeamMutation(
+				store.db,
+				deterministicPolicyTeamId(CANDIDATE_REF),
+				async () => {
+					policyMutationStarted = true;
+				},
+			);
+			const includedActorId = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.devices.find(
+				(device) => device.decision === "included",
+			)?.targetIdentityId;
+			if (!includedActorId) throw new Error("included actor was not assigned");
+			actorMutation = serializeRecipientPolicyActorMutations(
+				store.db,
+				[includedActorId],
+				async () => {
+					actorMutationStarted = true;
+				},
+			);
+			publicationMutation = serializeRecipientPolicyPublicationMutation(store.db, async () => {
+				publicationMutationStarted = true;
+			});
+			markCreateStarted();
+			await createGate;
+			return { status: "created" as const, manifest };
+		});
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: {
+				create,
+				list: async () => {
+					if (!listedManifest) return [];
+					return [
+						{
+							group_id: GROUP_ID,
+							manifest: listInvalidDigest
+								? { ...listedManifest, finish_digest: "0".repeat(64) }
+								: listedManifest,
+						},
+					];
+				},
+			},
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const deviceRef = draft.devices[0]?.deviceRef ?? "";
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+
+			const finishRequest = app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+			await createStarted;
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(groupMutationStarted).toBe(false);
+			expect(policyMutationStarted).toBe(false);
+			expect(actorMutationStarted).toBe(false);
+			expect(publicationMutationStarted).toBe(false);
+			const summaryResponse = await app.request("/api/sync/team-setup/v1");
+			expect(summaryResponse.status).toBe(200);
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+			listInvalidDigest = true;
+			const detailConflict = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detailConflict.status).toBe(409);
+			listInvalidDigest = false;
+			const mutationResponse = await app.request(
+				`/api/sync/team-setup/v1/${CANDIDATE_REF}/devices/${deviceRef}/decision`,
+				{
+					method: "DELETE",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ attemptId: draft.attemptId }),
+				},
+			);
+			expect(mutationResponse.status).toBe(409);
+			releaseCreate();
+
+			const response = await finishRequest;
+			expect(response.status).toBe(200);
+			if (!groupMutation) throw new Error("group mutation was not queued");
+			if (!policyMutation) throw new Error("policy mutation was not queued");
+			if (!actorMutation) throw new Error("actor mutation was not queued");
+			if (!publicationMutation) throw new Error("publication mutation was not queued");
+			await Promise.all([groupMutation, policyMutation, actorMutation, publicationMutation]);
+			expect(groupMutationStarted).toBe(true);
+			expect(policyMutationStarted).toBe(true);
+			expect(actorMutationStarted).toBe(true);
+			expect(publicationMutationStarted).toBe(true);
+			expect(create).toHaveBeenCalledOnce();
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.devices[0]?.decision).toBe(
+				"included",
+			);
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(1);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("keeps summary and detail reads available when an older coordinator lacks completion queries", async () => {
+		const store = new MemoryStore(":memory:");
+		const list = vi.fn(async () => {
+			throw new Error("Remote coordinator request failed (404): HTTP 404");
+		});
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: { create: vi.fn(), list },
+		});
+		try {
+			const summary = await app.request("/api/sync/team-setup/v1");
+			expect(summary.status).toBe(200);
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(200);
+			expect(list).toHaveBeenCalledTimes(2);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("reconciles an existing draft without a cold-cache roster read", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			expect((await setupApp.request("/api/sync/team-setup/v1")).status).toBe(200);
+			const loadSnapshots = vi.fn(async () => {
+				throw new Error("team_setup_roster_unavailable");
+			});
+			const list = vi.fn(async () => []);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: { create: vi.fn(), list },
+			});
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(200);
+			expect(loadSnapshots).not.toHaveBeenCalled();
+			expect(list).toHaveBeenCalledOnce();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("ignores completion records for other candidate identities of the same group", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			// The coordinator lists every candidate the group ever completed,
+			// including one recorded under an earlier coordinator address.
+			const historicalRecord = {
+				group_id: GROUP_ID,
+				manifest: {
+					...manifest,
+					candidate_ref: legacyTeamCandidateId("https://old.coordinator.example.test", GROUP_ID),
+				},
+			};
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: vi.fn(),
+					list: vi.fn(async () => [historicalRecord, { group_id: GROUP_ID, manifest }]),
+				},
+			});
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(404);
+			expect(await detail.json()).toEqual({ error: "team_setup_confirmation_stale" });
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.state).toBe("completed");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("loads the fresh roster for an equivalently spelled persisted coordinator", async () => {
+		const store = new MemoryStore(":memory:");
+		const spelledCoordinatorId = "HTTPS://COORDINATOR.EXAMPLE.TEST";
+		const spelledCandidateRef = legacyTeamCandidateId(spelledCoordinatorId, GROUP_ID);
+		const spelledSnapshots = SNAPSHOTS.map((snapshot) => ({
+			...snapshot,
+			coordinatorId: spelledCoordinatorId,
+		}));
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => spelledSnapshots,
+			completionDependencies: null,
+		});
+		try {
+			expect((await setupApp.request("/api/sync/team-setup/v1")).status).toBe(200);
+			store.db
+				.prepare(
+					`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+					 VALUES ('identity-a', 'Person A', 0, 'active', ?, ?)`,
+				)
+				.run(NOW, NOW);
+			let draft = getLegacyTeamSetupDraft(store.db, spelledCandidateRef);
+			if (!draft) throw new Error("Team setup draft missing");
+			const device = draft.devices[0];
+			if (!device) throw new Error("Team setup device missing");
+			draft = setLegacyTeamSetupDeviceAssignment(store.db, {
+				attemptId: draft.attemptId,
+				deviceRef: device.deviceRef,
+				targetIdentityId: "identity-a",
+				expectation: device.expectation,
+				now: NOW,
+			});
+			draft = setLegacyTeamSetupDeviceDecision(store.db, {
+				attemptId: draft.attemptId,
+				deviceRef: device.deviceRef,
+				decision: "included",
+				now: NOW,
+			});
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: spelledCandidateRef,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			// Configuration now uses the canonical spelling; the production loader
+			// keys its snapshots by that spelling, not the persisted one.
+			const loadSnapshots = vi.fn(async (input?: { candidateRef?: string }) =>
+				input?.candidateRef && input.candidateRef !== CANDIDATE_REF ? [] : SNAPSHOTS,
+			);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: vi.fn(),
+					list: vi.fn(async () => [{ group_id: GROUP_ID, manifest }]),
+				},
+			});
+
+			await app.request(`/api/sync/team-setup/v1/${spelledCandidateRef}`);
+			expect(getLegacyTeamSetupDraft(store.db, spelledCandidateRef)?.state).toBe("completed");
+			expect(
+				store.db
+					.prepare("SELECT status FROM policy_teams WHERE team_id = ?")
+					.pluck()
+					.get(manifest.team_id),
+			).toBe("active");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not apply a completion after coordinator authorization changes mid-flight", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			// The user removes the group while the completion list is in flight.
+			let configuredGroups = [GROUP_ID];
+			const config = completionConfig();
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: {
+					...config,
+					readConfig: () => ({ ...config.readConfig(), syncCoordinatorGroups: configuredGroups }),
+				},
+				completionDependencies: {
+					create: vi.fn(),
+					list: vi.fn(async () => {
+						configuredGroups = [];
+						return [{ group_id: GROUP_ID, manifest }];
+					}),
+				},
+			});
+
+			await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.state).not.toBe("completed");
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not apply a completion when authorization is revoked while the Team lock is held", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			let configuredGroups = [GROUP_ID];
+			const config = completionConfig();
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: {
+					...config,
+					readConfig: () => ({ ...config.readConfig(), syncCoordinatorGroups: configuredGroups }),
+				},
+				completionDependencies: {
+					create: vi.fn(),
+					list: vi.fn(async () => [{ group_id: GROUP_ID, manifest }]),
+				},
+			});
+			// Another policy mutation holds the Team lock while reconciliation
+			// waits; the user removes the group before that lock is released.
+			let releaseTeamLock = () => undefined;
+			const teamLockPending = new Promise<void>((resolve) => {
+				releaseTeamLock = resolve;
+			});
+			let teamLockHeld = false;
+			const teamMutation = serializeRecipientPolicyTeamMutation(
+				store.db,
+				manifest.team_id,
+				async () => {
+					teamLockHeld = true;
+					await teamLockPending;
+				},
+			);
+			await vi.waitFor(() => expect(teamLockHeld).toBe(true));
+			const detail = app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+			configuredGroups = [];
+			releaseTeamLock();
+			await teamMutation;
+			await detail;
+
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.state).not.toBe("completed");
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not republish a local completion after authorization is revoked under the lock", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const review = inspectLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+			});
+			await finishLegacyTeamSetupActivation(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				finishDigest: review.finishDigest,
+				confirmedAccessDeltaDigest: review.accessDeltaDigest,
+				loadFreshRoster: async () => SNAPSHOTS[0]?.devices ?? [],
+				loadProjectInventory: () => [],
+				validateLockedPreview: () => true,
+				now: NOW,
+			});
+			let configuredGroups = [GROUP_ID];
+			const config = completionConfig();
+			const create = vi.fn(async ({ manifest }) => ({ status: "created" as const, manifest }));
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+				snapshotLoaderDependencies: {
+					...config,
+					readConfig: () => ({ ...config.readConfig(), syncCoordinatorGroups: configuredGroups }),
+				},
+				completionDependencies: { create, list: vi.fn(async () => []) },
+			});
+			const teamId = deterministicPolicyTeamId(CANDIDATE_REF);
+			let releaseTeamLock = () => undefined;
+			const teamLockPending = new Promise<void>((resolve) => {
+				releaseTeamLock = resolve;
+			});
+			let teamLockHeld = false;
+			const teamMutation = serializeRecipientPolicyTeamMutation(store.db, teamId, async () => {
+				teamLockHeld = true;
+				await teamLockPending;
+			});
+			await vi.waitFor(() => expect(teamLockHeld).toBe(true));
+			const summary = app.request("/api/sync/team-setup/v1");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect(create).not.toHaveBeenCalled();
+			configuredGroups = [];
+			releaseTeamLock();
+			await teamMutation;
+			expect((await summary).status).toBe(200);
+
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("returns the committed result to an identical finish that overlapped the commit", async () => {
+		const store = new MemoryStore(":memory:");
+		let releaseCreate = () => undefined;
+		const createPending = new Promise<void>((resolve) => {
+			releaseCreate = resolve;
+		});
+		let createStarted = () => undefined;
+		const createStartedPromise = new Promise<void>((resolve) => {
+			createStarted = resolve;
+		});
+		const create = vi.fn(async ({ manifest }) => {
+			createStarted();
+			await createPending;
+			return { status: "created" as const, manifest };
+		});
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: { create, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			const finishRequest = {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			};
+			const first = app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, finishRequest);
+			await createStartedPromise;
+			// The retry arrives while the first request is publishing.
+			const retry = app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, finishRequest);
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			releaseCreate();
+
+			const [firstResponse, retryResponse] = await Promise.all([first, retry]);
+			expect(firstResponse.status).toBe(200);
+			expect(retryResponse.status).toBe(200);
+			expect(await retryResponse.json()).toEqual(await firstResponse.json());
+			expect(create).toHaveBeenCalledOnce();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("applies a canonical completion during a cold-cache detail read", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			const loadSnapshots = vi.fn(async () => SNAPSHOTS);
+			const list = vi.fn(async () => [{ group_id: GROUP_ID, manifest }]);
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: { create: vi.fn(), list },
+			});
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(404);
+			expect(await detail.json()).toEqual({ error: "team_setup_confirmation_stale" });
+			expect(loadSnapshots).toHaveBeenCalledOnce();
+			expect(loadSnapshots).toHaveBeenCalledWith(
+				expect.objectContaining({
+					candidateRef: CANDIDATE_REF,
+					deadlineMs: expect.any(Number),
+				}),
+			);
+			expect(list).toHaveBeenCalledOnce();
+			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.state).toBe("completed");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("rejects a canonical completion after an included device is re-keyed", async () => {
+		const store = new MemoryStore(":memory:");
+		const setupApp = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, setupApp);
+			const manifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+				candidateRef: CANDIDATE_REF,
+				attemptId: draft.attemptId,
+				completedAt: NOW,
+			});
+			const originalSnapshot = SNAPSHOTS[0];
+			const originalDevice = originalSnapshot?.devices[0];
+			if (!originalSnapshot || !originalDevice) throw new Error("Team setup snapshot missing");
+			const rekeyedSnapshots: LegacyTeamConfiguredGroupSnapshot[] = [
+				{
+					...originalSnapshot,
+					devices: [{ ...originalDevice, fingerprint: FINGERPRINT_B }],
+				},
+			];
+			const app = teamSetupRoutes({
+				getStore: () => store,
+				loadLegacyTeamConfiguredGroupSnapshots: async () => rekeyedSnapshots,
+				snapshotLoaderDependencies: completionConfig(),
+				completionDependencies: {
+					create: vi.fn(),
+					list: vi.fn(async () => [{ group_id: GROUP_ID, manifest }]),
+				},
+			});
+
+			const detail = await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
+			expect(detail.status).toBe(409);
+			expect(await detail.json()).toEqual({ error: "team_setup_completion_invalid" });
+			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+			expect(
+				store.db
+					.prepare(
+						"SELECT key_fingerprint FROM legacy_team_setup_draft_devices WHERE attempt_id = ?",
+					)
+					.pluck()
+					.get(draft.attemptId),
+			).toBe(FINGERPRINT_A);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("retries transient completion reads with the configured timeout", async () => {
+		const store = new MemoryStore(":memory:");
+		const list = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Remote coordinator request failed (503): unavailable"))
+			.mockResolvedValue([]);
+		const config = completionConfig(17);
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			snapshotLoaderDependencies: config,
+			readCoordinatorConfig: config.readConfig,
+			completionDependencies: { create: vi.fn(), list },
+		});
+		try {
+			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+			expect(list).toHaveBeenCalledTimes(2);
+			expect(list).toHaveBeenCalledWith(expect.objectContaining({ timeoutS: 17 }));
+		} finally {
+			store.close();
+		}
+	});
+
 	it("revalidates pre-marker completions in detail and summary reads", async () => {
 		const store = new MemoryStore(":memory:");
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
 		});
 		try {
 			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
@@ -131,6 +2142,7 @@ describe("Team setup terminal migration routing", () => {
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+			completionDependencies: null,
 		});
 		try {
 			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
@@ -170,6 +2182,7 @@ describe("Team setup terminal migration routing", () => {
 			const app = teamSetupRoutes({
 				getStore: () => store,
 				loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+				completionDependencies: null,
 			});
 			try {
 				expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
@@ -220,6 +2233,7 @@ describe("Team setup terminal migration routing", () => {
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
 		});
 		try {
 			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
@@ -249,6 +2263,7 @@ describe("Team setup terminal migration routing", () => {
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
 		});
 		try {
 			expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
@@ -283,6 +2298,7 @@ describe("Team setup terminal migration routing", () => {
 		const app = teamSetupRoutes({
 			getStore: () => store,
 			loadLegacyTeamConfiguredGroupSnapshots: async () => SNAPSHOTS,
+			completionDependencies: null,
 		});
 		try {
 			const projectIdentity = "https://example.test/terminal-project.git";

--- a/packages/viewer-server/src/routes/team-setup-timeout.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-timeout.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { remainingCoordinatorTimeoutS } from "./team-setup.js";
+
+describe("legacy Team completion coordinator timeout", () => {
+	it("caps each publication at the shared remaining budget", () => {
+		expect(remainingCoordinatorTimeoutS(30, 20_000, 10_000)).toBe(10);
+		expect(remainingCoordinatorTimeoutS(3, 20_000, 10_000)).toBe(3);
+		expect(remainingCoordinatorTimeoutS(3, 10_050, 10_000)).toBe(0.1);
+	});
+
+	it("stops publication after the shared deadline", () => {
+		expect(remainingCoordinatorTimeoutS(3, 10_000, 10_000)).toBeNull();
+		expect(remainingCoordinatorTimeoutS(3, 10_000, 10_001)).toBeNull();
+	});
+});

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -532,6 +532,10 @@ describe("Team setup roster loading", () => {
 			});
 			const app = teamSetupRoutes({
 				getStore: () => store,
+				completionDependencies: {
+					create: async ({ manifest }) => ({ status: "created", manifest }),
+					list: async () => [],
+				},
 				snapshotLoaderDependencies: {
 					readConfig: () => ({
 						...readCoordinatorSyncConfig({}),
@@ -984,6 +988,10 @@ describe("Team setup roster loading", () => {
 			try {
 				const app = teamSetupRoutes({
 					getStore: () => store,
+					completionDependencies: {
+						create: async ({ manifest }) => ({ status: "created", manifest }),
+						list: async () => [],
+					},
 					snapshotLoaderDependencies: {
 						readConfig: () => ({
 							...readCoordinatorSyncConfig({}),
@@ -1100,7 +1108,7 @@ describe("Team setup roster loading", () => {
 				...delta,
 				deviceAccessChanges: [...deviceAccessChanges, deviceAccessChanges[0]],
 			}),
-		).toThrow("legacy_team_setup_roster_too_large");
+		).toThrow("team_setup_completion_invalid");
 	});
 
 	it("rejects mapping-choice responses that cannot include every opaque choice", () => {

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -1,4 +1,6 @@
 import type {
+	CoordinatorLegacyTeamCompletionManifestV1,
+	CoordinatorLegacyTeamCompletionRecord,
 	LegacyTeamCandidateView,
 	LegacyTeamConfiguredGroupSnapshot,
 	LegacyTeamSetupAccessDeltaV1,
@@ -8,18 +10,30 @@ import type {
 	MemoryStore,
 } from "@codemem/core";
 import {
+	applyLegacyTeamSetupCompletionManifest,
+	applyLegacyTeamSetupCompletionManifestAndReturnActivation,
+	areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible,
 	buildBaseUrl,
+	canonicalCoordinatorLegacyTeamCompletionManifestJson,
+	claimRecipientPolicyActorMutations,
+	claimRecipientPolicyPublicationMutation,
 	clearLegacyTeamSetupDeviceDecision,
+	containLegacyTeamSetupCompletionConflict,
+	coordinatorCreateLegacyTeamCompletionAction,
+	coordinatorGetLegacyTeamCompletionAction,
 	coordinatorListDevicesAction,
 	coordinatorListGroupsAction,
+	coordinatorListLegacyTeamCompletionsAction,
+	deriveLegacyTeamSetupCompletionManifest,
 	deterministicPolicyTeamId,
 	discoverLegacyTeamCandidates,
 	fingerprintPublicKey,
-	finishLegacyTeamSetupActivation,
 	getLegacyTeamSetupDraft,
+	inspectFreshLegacyTeamSetupActivation,
 	inspectLegacyTeamSetupActivation,
 	isLegacyTeamCandidateSelectable,
 	isLegacyTeamSetupProjectMappingIdentity,
+	LegacyTeamSetupAdditiveConvergenceError,
 	legacyTeamCandidateId,
 	legacyTeamCandidateProjectInventory,
 	legacyTeamCanonicalProjectRef,
@@ -30,10 +44,18 @@ import {
 	previewLegacyTeamSetupActivation,
 	readCoordinatorSyncConfig,
 	recipientPolicyDigest,
+	reconstructLegacyTeamSetupCompletionManifest,
 	refreshLegacyTeamCandidate,
+	replayLegacyTeamSetupActivation,
+	requireLegacyTeamSetupAccessDeltaWithinLimit,
+	serializeRecipientPolicyCoordinatorGroupMutation,
+	serializeRecipientPolicyPublicationMutation,
+	serializeRecipientPolicyTeamMutation,
 	setLegacyTeamSetupDeviceAssignment,
 	setLegacyTeamSetupDeviceDecision,
 	setLegacyTeamSetupProjectMapping,
+	validateLegacyTeamSetupCompletionManifest,
+	validateLegacyTeamSetupCompletionManifestBinding,
 } from "@codemem/core";
 import { type Context, Hono } from "hono";
 import {
@@ -73,7 +95,6 @@ const MAX_CONFIGURED_GROUPS = 25;
 const MAX_SCOPE_EVIDENCE_COORDINATORS = 100;
 const MAX_DEVICES = 500;
 const MAX_PROJECTS = 500;
-const MAX_ACCESS_DELTA_ENTRIES = 10_000;
 const MAX_IDENTITY_CHOICES = 500;
 const MAX_COMPLETED_IDENTITY_CHOICES = MAX_DEVICES * 4;
 const MAX_PROJECT_MAPPING_CHOICES = 500;
@@ -93,9 +114,52 @@ const ATTEMPT_ID_PATTERN = /^legacy-team-attempt:[0-9a-f-]{36}$/u;
 const FINISH_DIGEST_PATTERN = /^legacy-team-activation-finish-v1:[0-9a-f]{64}$/u;
 const ACCESS_DELTA_DIGEST_PATTERN = /^legacy-team-access-delta:[0-9a-f]{64}$/u;
 const VIEWER_ACCESS_DELTA_DIGEST_PATTERN = /^legacy-team-viewer-access-delta-v1:[0-9a-f]{64}$/u;
+const activeCandidateMutations = new WeakMap<MemoryStore["db"], Map<string, Promise<void>>>();
+
+function claimCandidateMutation(db: MemoryStore["db"], candidateRef: string): (() => void) | null {
+	let active = activeCandidateMutations.get(db);
+	if (!active) {
+		active = new Map();
+		activeCandidateMutations.set(db, active);
+	}
+	if (active.has(candidateRef)) return null;
+	let settle: () => void = () => undefined;
+	const settled = new Promise<void>((resolve) => {
+		settle = resolve;
+	});
+	active.set(candidateRef, settled);
+	let released = false;
+	return () => {
+		if (released) return;
+		released = true;
+		active?.delete(candidateRef);
+		settle();
+	};
+}
+
+/** Resolves once the current holder of the candidate claim (if any) releases it. */
+function candidateMutationSettled(db: MemoryStore["db"], candidateRef: string): Promise<void> {
+	return activeCandidateMutations.get(db)?.get(candidateRef) ?? Promise.resolve();
+}
+
+async function runCandidateMutation<T>(
+	db: MemoryStore["db"],
+	candidateRef: string,
+	operation: () => Promise<T>,
+): Promise<boolean> {
+	const release = claimCandidateMutation(db, candidateRef);
+	if (!release) return false;
+	try {
+		await operation();
+		return true;
+	} finally {
+		release();
+	}
+}
 
 interface LegacyTeamConfiguredGroupSnapshotLoadOptions {
 	candidateRef?: string;
+	deadlineMs?: number;
 }
 
 export interface LegacyTeamCandidateGroupDescriptor {
@@ -111,8 +175,22 @@ export interface TeamSetupRoutesOptions {
 	getStore: () => MemoryStore;
 	loadLegacyTeamConfiguredGroupSnapshots?: LegacyTeamConfiguredGroupSnapshotLoader;
 	snapshotLoaderDependencies?: LegacyTeamSnapshotLoaderDependencies;
+	completionDependencies?: LegacyTeamCompletionDependencies | null;
+	readCoordinatorConfig?: typeof readCoordinatorSyncConfig;
 	registerSummaryInvalidator?: (invalidate: () => void) => void;
 }
+
+export interface LegacyTeamCompletionDependencies {
+	create: typeof coordinatorCreateLegacyTeamCompletionAction;
+	get?: typeof coordinatorGetLegacyTeamCompletionAction;
+	list: typeof coordinatorListLegacyTeamCompletionsAction;
+}
+
+const defaultCompletionDependencies: LegacyTeamCompletionDependencies = {
+	create: coordinatorCreateLegacyTeamCompletionAction,
+	get: coordinatorGetLegacyTeamCompletionAction,
+	list: coordinatorListLegacyTeamCompletionsAction,
+};
 
 interface LegacyTeamSnapshotLoaderDependencies {
 	readConfig: typeof readCoordinatorSyncConfig;
@@ -134,15 +212,55 @@ function isCoordinatorRosterTooLargeError(error: unknown): boolean {
 	return error instanceof Error && error.message === "coordinator_response_too_large";
 }
 
+function remoteCoordinatorHttpStatus(error: unknown): number | null {
+	if (!(error instanceof Error)) return null;
+	const status = /Remote coordinator request failed \((\d{3})\):/u.exec(error.message)?.[1];
+	return status ? Number(status) : null;
+}
+
 function isTransientCoordinatorReadError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
-	const remoteStatus = /Remote coordinator request failed \((\d{3})\):/u.exec(error.message)?.[1];
-	if (remoteStatus) return ["408", "429", "500", "502", "503", "504"].includes(remoteStatus);
+	const remoteStatus = remoteCoordinatorHttpStatus(error);
+	if (remoteStatus) return [408, 429, 500, 502, 503, 504].includes(remoteStatus);
 	return (
 		error.name === "TimeoutError" ||
 		error.name === "AbortError" ||
 		/request_timeout|fetch failed|timed out|timeout/iu.test(error.message)
 	);
+}
+
+function isUnsupportedCompletionQuery(error: unknown): boolean {
+	const status = remoteCoordinatorHttpStatus(error);
+	return status === 404 || status === 405;
+}
+
+/**
+ * Batch completion decoding rejects the whole payload when any one record is
+ * malformed or misattributed, so the failure cannot be pinned to a group.
+ */
+function isUnattributableCompletionBatchError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		(error.message === "coordinator_completion_response_malformed" ||
+			error.message === "coordinator_completion_group_mismatch")
+	);
+}
+
+async function listCompletionRecordsPerGroup(
+	groupIds: readonly string[],
+	list: (groupIds: string[]) => Promise<CoordinatorLegacyTeamCompletionRecord[]>,
+): Promise<CoordinatorLegacyTeamCompletionRecord[]> {
+	// A single group re-query would repeat the same undecodable payload.
+	if (groupIds.length < 2) return [];
+	const records: CoordinatorLegacyTeamCompletionRecord[] = [];
+	for (const groupId of groupIds) {
+		try {
+			records.push(...(await list([groupId])));
+		} catch (error) {
+			if (!isUnattributableCompletionBatchError(error)) throw error;
+		}
+	}
+	return records;
 }
 
 async function retryTransientCoordinatorRead<T>(
@@ -165,6 +283,15 @@ async function retryTransientCoordinatorRead<T>(
 		}
 	}
 	throw lastError;
+}
+
+export function remainingCoordinatorTimeoutS(
+	configuredTimeoutS: number,
+	deadlineMs: number,
+	nowMs = Date.now(),
+): number | null {
+	const remainingMs = deadlineMs - nowMs;
+	return remainingMs <= 0 ? null : Math.max(0.1, Math.min(configuredTimeoutS, remainingMs / 1_000));
 }
 
 function configuredGroupIds(groups: string[]): string[] {
@@ -330,7 +457,7 @@ async function loadConfiguredLegacyTeamGroupSnapshotsWith(
 		);
 		if (groupDescriptors.length === 0) throw safeCoordinatorError();
 		const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
-		const deadlineMs = Date.now() + COORDINATOR_ROSTER_READ_BUDGET_MS;
+		const deadlineMs = options.deadlineMs ?? Date.now() + COORDINATOR_ROSTER_READ_BUDGET_MS;
 		const requestedGroupDescriptors = options.candidateRef
 			? groupDescriptors.filter(
 					({ coordinatorId, groupId }) =>
@@ -707,21 +834,6 @@ function viewerAccessDeltaDigest(delta: LegacyTeamSetupViewerAccessDeltaV1): str
 	return recipientPolicyDigest("legacy-team-viewer-access-delta-v1", delta);
 }
 
-// Each category is capped independently, matching core's activation limit:
-// a maximal 500-device/20-Project activation fills the device category exactly,
-// and the mandatory Team and membership entries must still fit alongside it.
-function requireBoundedAccessDelta(delta: LegacyTeamSetupAccessDeltaV1): void {
-	if (
-		delta.teamChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
-		delta.membershipChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
-		delta.projectChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
-		delta.recipientChanges.length > MAX_ACCESS_DELTA_ENTRIES ||
-		delta.deviceAccessChanges.length > MAX_ACCESS_DELTA_ENTRIES
-	) {
-		throw new Error("legacy_team_setup_roster_too_large");
-	}
-}
-
 const SAFE_CHOICE_LABEL_PATTERN = /^[\p{L}\p{N} '&,.()_-]*$/u;
 
 // Keep this byte-for-byte equivalent in behavior to the core setup-label
@@ -869,7 +981,7 @@ export const __teamSetupTestHooks = {
 	loadConfiguredLegacyTeamGroupSnapshotsWith,
 	normalizedCoordinatorId,
 	projectMutationAtomically,
-	requireBoundedAccessDelta,
+	requireBoundedAccessDelta: requireLegacyTeamSetupAccessDeltaWithinLimit,
 	requireCompleteMappingChoices,
 	disambiguateChoiceLabels,
 	safeChoiceLabel,
@@ -1071,7 +1183,8 @@ function viewerSafePreview(
 }
 
 function errorStatus(code: LegacyTeamSetupActivationErrorCode): 400 | 409 | 503 {
-	if (code === "team_setup_roster_unavailable") return 503;
+	if (code === "team_setup_roster_unavailable" || code === "team_setup_completion_unavailable")
+		return 503;
 	if (code === "team_setup_failed") return 503;
 	if (code === "team_setup_incomplete") return 400;
 	return 409;
@@ -1080,6 +1193,11 @@ function errorStatus(code: LegacyTeamSetupActivationErrorCode): 400 | 409 | 503 
 function apiErrorCode(error: unknown): LegacyTeamSetupActivationErrorCode {
 	const code = legacyTeamSetupApiErrorCode(error);
 	return code === "team_setup_projection_changed" ? "team_setup_conflict" : code;
+}
+
+function completionApiError(error: unknown): LegacyTeamSetupActivationErrorCode {
+	const code = legacyTeamSetupApiErrorCode(error);
+	return code === "team_setup_failed" ? "team_setup_completion_unavailable" : code;
 }
 
 type BoundedJsonResult = { ok: true; value: Record<string, unknown> } | { ok: false };
@@ -1155,7 +1273,7 @@ function detailResponse(
 			else if (code !== "team_setup_incomplete") unavailableReason = code;
 		}
 	}
-	if (preview) requireBoundedAccessDelta(preview.accessDelta);
+	if (preview) requireLegacyTeamSetupAccessDeltaWithinLimit(preview.accessDelta);
 	const safeDraft = viewerSafeDraft(store, draft);
 	const safePreview = preview ? viewerSafePreview(draft, safeDraft, preview) : null;
 	return projectLegacyTeamSetupView({
@@ -1198,9 +1316,12 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 
 	async function loadedSnapshots(
 		candidateRef?: string,
+		deadlineMs?: number,
 	): Promise<LegacyTeamConfiguredGroupSnapshot[]> {
 		try {
-			return await loadSnapshots(candidateRef ? { candidateRef } : undefined);
+			return await loadSnapshots(
+				candidateRef || deadlineMs != null ? { candidateRef, deadlineMs } : undefined,
+			);
 		} catch (error) {
 			if (error instanceof Error && error.message === "legacy_team_setup_roster_too_large") {
 				throw error;
@@ -1213,10 +1334,550 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		SUMMARY_SNAPSHOT_CACHE_TTL_MS,
 	);
 	options.registerSummaryInvalidator?.(() => loadedSummarySnapshots.invalidate());
+	const completionDependencies =
+		options.completionDependencies === undefined
+			? defaultCompletionDependencies
+			: options.completionDependencies;
+
+	interface CompletionAuthorization {
+		config: ReturnType<typeof readCoordinatorSyncConfig>;
+		remoteUrl: string;
+		configuredCoordinatorId: string;
+		currentGroupIds: Set<string>;
+	}
+
+	/**
+	 * Reads the live coordinator configuration and the groups it currently
+	 * authorizes. Returns null when completion I/O is not configured or current
+	 * authorization cannot be proven.
+	 */
+	function currentCompletionAuthorization(store: MemoryStore): CompletionAuthorization | null {
+		const config = (
+			options.readCoordinatorConfig ??
+			options.snapshotLoaderDependencies?.readConfig ??
+			readCoordinatorSyncConfig
+		)();
+		const remoteUrl = buildBaseUrl(config.syncCoordinatorUrl);
+		if (!remoteUrl || !config.syncCoordinatorAdminSecret) return null;
+		const configuredCoordinatorId = normalizedCoordinatorId(remoteUrl);
+		if (!configuredCoordinatorId) return null;
+		let currentGroupIds: Set<string>;
+		try {
+			currentGroupIds = new Set(
+				legacyTeamCandidateGroupDescriptors(store, remoteUrl, config.syncCoordinatorGroups).map(
+					(group) => group.groupId,
+				),
+			);
+		} catch {
+			return null;
+		}
+		return { config, remoteUrl, configuredCoordinatorId, currentGroupIds };
+	}
+
+	// Endpoint equivalence only: candidate identity stays bound to the persisted
+	// coordinator string and is never rewritten from configuration.
+	function authorizesGroup(
+		authorization: CompletionAuthorization,
+		group: LegacyTeamCandidateGroupDescriptor,
+	): boolean {
+		return (
+			authorization.currentGroupIds.has(group.groupId) &&
+			normalizedCoordinatorId(group.coordinatorId) === authorization.configuredCoordinatorId
+		);
+	}
+
+	/**
+	 * Configuration may change while completion-list or roster requests are in
+	 * flight. Re-prove authorization for the exact coordinator and group right
+	 * before applying canonical policy, as the finish publication path does.
+	 */
+	function stillAuthorizesGroup(
+		store: MemoryStore,
+		initial: CompletionAuthorization,
+		group: LegacyTeamCandidateGroupDescriptor,
+	): boolean {
+		let current: CompletionAuthorization | null;
+		try {
+			current = currentCompletionAuthorization(store);
+		} catch {
+			return false;
+		}
+		return (
+			current !== null &&
+			current.configuredCoordinatorId === initial.configuredCoordinatorId &&
+			authorizesGroup(current, group)
+		);
+	}
+
+	function matchesGroupSnapshot(
+		snapshot: LegacyTeamConfiguredGroupSnapshot,
+		group: LegacyTeamCandidateGroupDescriptor,
+	): boolean {
+		return (
+			snapshot.groupId === group.groupId &&
+			normalizedCoordinatorId(snapshot.coordinatorId) ===
+				normalizedCoordinatorId(group.coordinatorId)
+		);
+	}
+
+	function freshGroupKey(group: { coordinatorId: string; groupId: string }): string {
+		return `${normalizedCoordinatorId(group.coordinatorId) ?? group.coordinatorId}\0${group.groupId}`;
+	}
+
+	/**
+	 * The snapshot loader keys candidates by the configured coordinator spelling,
+	 * while a persisted group may carry an equivalent but different spelling.
+	 * Ask for the roster under each spelling and match on normalized identity,
+	 * preserving the persisted candidate identity for everything else.
+	 */
+	async function loadFreshGroupSnapshot(
+		group: LegacyTeamCandidateGroupDescriptor,
+		remoteUrl: string,
+		deadlineMs: number,
+	): Promise<LegacyTeamConfiguredGroupSnapshot | undefined> {
+		const candidateRefs = [
+			...new Set([
+				legacyTeamCandidateId(remoteUrl, group.groupId),
+				legacyTeamCandidateId(group.coordinatorId, group.groupId),
+			]),
+		];
+		for (const candidateRef of candidateRefs) {
+			const snapshots = await loadedSnapshots(candidateRef, deadlineMs);
+			const matches = snapshots.filter((snapshot) => matchesGroupSnapshot(snapshot, group));
+			if (matches.length > 1) throw new Error("team_setup_completion_invalid");
+			if (matches[0]) return matches[0];
+		}
+		return undefined;
+	}
+
+	function completionRecordCandidateRef(record: { manifest: unknown }): string | null {
+		const manifest = record.manifest;
+		if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return null;
+		const candidateRef = (manifest as { candidate_ref?: unknown }).candidate_ref;
+		return typeof candidateRef === "string" ? candidateRef : null;
+	}
+
+	// The coordinator lists every candidate a group has ever completed. A record
+	// for a different candidate identity (an earlier coordinator address) is
+	// historical context, not evidence about this candidate.
+	function belongsToGroupCandidate(
+		record: { manifest: unknown },
+		group: LegacyTeamCandidateGroupDescriptor,
+	): boolean {
+		const candidateRef = completionRecordCandidateRef(record);
+		return (
+			candidateRef === null ||
+			candidateRef === legacyTeamCandidateId(group.coordinatorId, group.groupId)
+		);
+	}
+
+	/**
+	 * Applies a canonical manifest with authorization re-proven inside the same
+	 * serialized section that guards the apply. Checking before the locks would
+	 * let a group removed while reconciliation waited on another policy
+	 * mutation still be applied once the queues open.
+	 */
+	async function applyCanonicalManifestIfStillAuthorized(
+		store: MemoryStore,
+		authorization: CompletionAuthorization,
+		group: LegacyTeamCandidateGroupDescriptor,
+		manifest: CoordinatorLegacyTeamCompletionManifestV1,
+		freshRoster: LegacyTeamConfiguredGroupSnapshot["devices"],
+	): Promise<"applied" | "unauthorized" | "claimed"> {
+		let outcome: "applied" | "unauthorized" = "unauthorized";
+		const ran = await runCandidateMutation(
+			store.db,
+			legacyTeamCandidateId(group.coordinatorId, group.groupId),
+			() =>
+				serializeRecipientPolicyPublicationMutation(store.db, () =>
+					serializeRecipientPolicyTeamMutation(store.db, manifest.team_id, () =>
+						serializeRecipientPolicyCoordinatorGroupMutation(store.db, group.groupId, async () => {
+							if (!stillAuthorizesGroup(store, authorization, group)) return;
+							await applyLegacyTeamSetupCompletionManifest(store.db, {
+								coordinatorId: group.coordinatorId,
+								groupId: group.groupId,
+								manifest,
+								freshRoster,
+								recipientPolicyLocksHeld: { publication: true, team: true, coordinatorGroup: true },
+							});
+							outcome = "applied";
+						}),
+					),
+				),
+		);
+		return ran ? outcome : "claimed";
+	}
+
+	async function reconcileCompletions(
+		store: MemoryStore,
+		groups: LegacyTeamCandidateGroupDescriptor[],
+		reconciliationOptions: { isolateApplyFailures?: boolean } = {},
+	): Promise<void> {
+		if (!completionDependencies || groups.length === 0) return;
+		let authorization: CompletionAuthorization | null;
+		try {
+			authorization = currentCompletionAuthorization(store);
+		} catch (error) {
+			throw new Error(completionApiError(error));
+		}
+		// If current authorization cannot be proven, skip completion I/O without
+		// failing an otherwise serviceable persisted detail read.
+		if (!authorization) return;
+		const { config, remoteUrl } = authorization;
+		const scopedGroups = groups.filter((group) => authorizesGroup(authorization, group));
+		if (scopedGroups.length === 0) return;
+		const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
+		try {
+			const reconciliationDeadlineMs = Date.now() + COORDINATOR_ROSTER_READ_BUDGET_MS;
+			const groupById = new Map(scopedGroups.map((group) => [group.groupId, group]));
+			const listCompletionRecords = (groupIds: string[]) =>
+				retryTransientCoordinatorRead(
+					(attemptTimeoutS) =>
+						completionDependencies.list({
+							groupIds,
+							remoteUrl,
+							adminSecret: config.syncCoordinatorAdminSecret,
+							timeoutS: attemptTimeoutS,
+						}),
+					timeoutS,
+					reconciliationDeadlineMs,
+				);
+			const scopedGroupIds = [...new Set(scopedGroups.map((group) => group.groupId))];
+			let records: Awaited<ReturnType<LegacyTeamCompletionDependencies["list"]>>;
+			try {
+				records = await listCompletionRecords(scopedGroupIds);
+			} catch (error) {
+				// Older coordinators do not expose completion reconciliation. Read routes
+				// remain usable, and best-effort publication below still lets upgraded
+				// peers observe a locally completed migration.
+				if (isUnsupportedCompletionQuery(error)) {
+					records = [];
+				} else if (
+					reconciliationOptions.isolateApplyFailures &&
+					isUnattributableCompletionBatchError(error)
+				) {
+					// One corrupt or mixed-version record must not hide every healthy
+					// group's setup state. Re-query per group so the decode failure
+					// stays attributable; a group whose own record cannot be decoded is
+					// skipped, matching the unprovable-binding path below.
+					records = await listCompletionRecordsPerGroup(scopedGroupIds, listCompletionRecords);
+				} else {
+					throw error;
+				}
+			}
+			const freshGroupByKey = new Map<string, LegacyTeamConfiguredGroupSnapshot>();
+			if (records.length > 0) {
+				try {
+					const onlyGroup = scopedGroups.length === 1 ? scopedGroups[0] : undefined;
+					const freshGroups = onlyGroup
+						? [await loadFreshGroupSnapshot(onlyGroup, remoteUrl, reconciliationDeadlineMs)]
+						: await loadedSnapshots(undefined, reconciliationDeadlineMs);
+					for (const freshGroup of freshGroups) {
+						if (!freshGroup) continue;
+						const key = freshGroupKey(freshGroup);
+						if (freshGroupByKey.has(key)) throw new Error("team_setup_completion_invalid");
+						freshGroupByKey.set(key, freshGroup);
+					}
+				} catch (error) {
+					for (const record of records) {
+						const group = groupById.get(record.group_id);
+						if (!group || !belongsToGroupCandidate(record, group)) continue;
+						try {
+							validateLegacyTeamSetupCompletionManifestBinding(record.manifest, {
+								coordinatorId: group.coordinatorId,
+								groupId: group.groupId,
+							});
+						} catch (bindingError) {
+							if (!reconciliationOptions.isolateApplyFailures) throw bindingError;
+							continue;
+						}
+						let canonicalManifest: ReturnType<typeof validateLegacyTeamSetupCompletionManifest>;
+						try {
+							canonicalManifest = validateLegacyTeamSetupCompletionManifest(record.manifest, {
+								coordinatorId: group.coordinatorId,
+								groupId: group.groupId,
+							});
+						} catch (validationError) {
+							try {
+								const contained = await runCandidateMutation(
+									store.db,
+									legacyTeamCandidateId(group.coordinatorId, group.groupId),
+									() =>
+										containLegacyTeamSetupCompletionConflict(store.db, {
+											coordinatorId: group.coordinatorId,
+											groupId: group.groupId,
+										}),
+								);
+								if (!contained) {
+									if (!reconciliationOptions.isolateApplyFailures) throw validationError;
+									continue;
+								}
+							} catch (containmentError) {
+								if (!reconciliationOptions.isolateApplyFailures) throw containmentError;
+							}
+							if (!reconciliationOptions.isolateApplyFailures) throw validationError;
+							continue;
+						}
+						try {
+							const localManifest = reconstructLegacyTeamSetupCompletionManifest(store.db, {
+								candidateRef: canonicalManifest.candidate_ref,
+							});
+							if (
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(localManifest) ===
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(canonicalManifest)
+							) {
+								continue;
+							}
+							if (
+								areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible(
+									localManifest,
+									canonicalManifest,
+								)
+							) {
+								continue;
+							}
+						} catch {
+							// Missing or invalid local completion state must not remain active when
+							// a valid coordinator winner cannot be applied safely.
+						}
+						try {
+							await runCandidateMutation(store.db, canonicalManifest.candidate_ref, () =>
+								containLegacyTeamSetupCompletionConflict(store.db, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								}),
+							);
+						} catch (containmentError) {
+							if (!reconciliationOptions.isolateApplyFailures) throw containmentError;
+						}
+					}
+					if (!reconciliationOptions.isolateApplyFailures) throw error;
+					return;
+				}
+			}
+			const coordinatorCompletionGroupIds = new Set<string>();
+			for (const record of records) {
+				const group = groupById.get(record.group_id);
+				if (!group) throw new Error("team_setup_completion_invalid");
+				if (!belongsToGroupCandidate(record, group)) continue;
+				try {
+					validateLegacyTeamSetupCompletionManifestBinding(record.manifest, {
+						coordinatorId: group.coordinatorId,
+						groupId: group.groupId,
+					});
+				} catch (bindingError) {
+					if (!reconciliationOptions.isolateApplyFailures) throw bindingError;
+					continue;
+				}
+				let canonicalManifest: ReturnType<typeof validateLegacyTeamSetupCompletionManifest>;
+				try {
+					canonicalManifest = validateLegacyTeamSetupCompletionManifest(record.manifest, {
+						coordinatorId: group.coordinatorId,
+						groupId: group.groupId,
+					});
+				} catch (validationError) {
+					try {
+						await runCandidateMutation(
+							store.db,
+							legacyTeamCandidateId(group.coordinatorId, group.groupId),
+							() =>
+								containLegacyTeamSetupCompletionConflict(store.db, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								}),
+						);
+					} catch (containmentError) {
+						if (!reconciliationOptions.isolateApplyFailures) throw containmentError;
+					}
+					if (!reconciliationOptions.isolateApplyFailures) throw validationError;
+					continue;
+				}
+				coordinatorCompletionGroupIds.add(record.group_id);
+				try {
+					let freshGroup = freshGroupByKey.get(freshGroupKey(group));
+					if (!freshGroup && scopedGroups.length > 1) {
+						if (remainingCoordinatorTimeoutS(timeoutS, reconciliationDeadlineMs) == null) {
+							throw new Error("team_setup_roster_unavailable");
+						}
+						freshGroup = await loadFreshGroupSnapshot(group, remoteUrl, reconciliationDeadlineMs);
+					}
+					if (!freshGroup) {
+						const contained = await runCandidateMutation(
+							store.db,
+							legacyTeamCandidateId(group.coordinatorId, group.groupId),
+							() =>
+								containLegacyTeamSetupCompletionConflict(store.db, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								}),
+						);
+						if (!contained) {
+							if (!reconciliationOptions.isolateApplyFailures) {
+								throw new Error("team_setup_completion_invalid");
+							}
+							continue;
+						}
+						throw new Error("team_setup_completion_invalid");
+					}
+					const applied = await applyCanonicalManifestIfStillAuthorized(
+						store,
+						authorization,
+						group,
+						canonicalManifest,
+						freshGroup.devices,
+					);
+					if (applied !== "applied") continue;
+				} catch (error) {
+					if (!reconciliationOptions.isolateApplyFailures) throw error;
+				}
+			}
+			for (const group of scopedGroups) {
+				if (coordinatorCompletionGroupIds.has(group.groupId)) continue;
+				const publicationTimeoutS = remainingCoordinatorTimeoutS(
+					timeoutS,
+					reconciliationDeadlineMs,
+				);
+				if (publicationTimeoutS == null) break;
+				if (
+					!hasCompletedLegacyTeamSetup(
+						store,
+						legacyTeamCandidateId(group.coordinatorId, group.groupId),
+					)
+				) {
+					continue;
+				}
+				const candidateRef = legacyTeamCandidateId(group.coordinatorId, group.groupId);
+				let reconstructionFailed = false;
+				try {
+					const published = await runCandidateMutation(store.db, candidateRef, () =>
+						serializeRecipientPolicyPublicationMutation(store.db, () =>
+							serializeRecipientPolicyTeamMutation(
+								store.db,
+								deterministicPolicyTeamId(candidateRef),
+								async () => {
+									let manifest: ReturnType<typeof reconstructLegacyTeamSetupCompletionManifest>;
+									try {
+										manifest = reconstructLegacyTeamSetupCompletionManifest(store.db, {
+											candidateRef,
+										});
+									} catch {
+										reconstructionFailed = true;
+										return;
+									}
+									// Publication sends identity and policy data to the coordinator;
+									// re-prove the destination is still the configured one.
+									if (!stillAuthorizesGroup(store, authorization, group)) {
+										reconstructionFailed = true;
+										return;
+									}
+									await completionDependencies.create({
+										groupId: group.groupId,
+										manifest,
+										remoteUrl,
+										adminSecret: config.syncCoordinatorAdminSecret,
+										timeoutS: publicationTimeoutS,
+									});
+								},
+							),
+						),
+					);
+					if (!published || reconstructionFailed) continue;
+				} catch (error) {
+					// Publishing an existing local completion is best-effort. The bounded
+					// list/apply pass above remains authoritative and fail-closed.
+					if (completionApiError(error) !== "team_setup_completion_conflict") continue;
+					const getCompletion = completionDependencies.get;
+					let canonicalManifest: Awaited<ReturnType<NonNullable<typeof getCompletion>>> = null;
+					try {
+						if (!getCompletion) throw new Error("team_setup_completion_conflict");
+						canonicalManifest = await retryTransientCoordinatorRead(
+							(attemptTimeoutS) =>
+								getCompletion({
+									groupId: group.groupId,
+									candidateRef,
+									remoteUrl,
+									adminSecret: config.syncCoordinatorAdminSecret,
+									timeoutS: attemptTimeoutS,
+								}),
+							timeoutS,
+							reconciliationDeadlineMs,
+						);
+						if (!canonicalManifest) throw new Error("team_setup_completion_conflict");
+					} catch {
+						try {
+							const contained = await runCandidateMutation(store.db, candidateRef, () =>
+								containLegacyTeamSetupCompletionConflict(store.db, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								}),
+							);
+							if (!contained) {
+								if (!reconciliationOptions.isolateApplyFailures) {
+									throw new Error("team_setup_completion_conflict");
+								}
+								continue;
+							}
+						} catch (containmentError) {
+							if (!reconciliationOptions.isolateApplyFailures) throw containmentError;
+							continue;
+						}
+						if (!reconciliationOptions.isolateApplyFailures) {
+							throw new Error("team_setup_completion_conflict");
+						}
+						continue;
+					}
+					try {
+						const freshGroup = await loadFreshGroupSnapshot(
+							group,
+							remoteUrl,
+							reconciliationDeadlineMs,
+						);
+						if (!freshGroup) throw new Error("team_setup_roster_unavailable");
+						const applied = await applyCanonicalManifestIfStillAuthorized(
+							store,
+							authorization,
+							group,
+							canonicalManifest,
+							freshGroup.devices,
+						);
+						if (applied !== "applied") continue;
+					} catch (applyError) {
+						if (applyError instanceof LegacyTeamSetupAdditiveConvergenceError) {
+							if (!reconciliationOptions.isolateApplyFailures) throw applyError;
+							continue;
+						}
+						try {
+							const contained = await runCandidateMutation(store.db, candidateRef, () =>
+								containLegacyTeamSetupCompletionConflict(store.db, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								}),
+							);
+							if (!contained) {
+								if (!reconciliationOptions.isolateApplyFailures) {
+									throw new Error("team_setup_completion_conflict", { cause: applyError });
+								}
+								continue;
+							}
+						} catch (containmentError) {
+							if (!reconciliationOptions.isolateApplyFailures) throw containmentError;
+							continue;
+						}
+						if (!reconciliationOptions.isolateApplyFailures) {
+							throw new Error("team_setup_completion_conflict", { cause: applyError });
+						}
+					}
+				}
+			}
+		} catch (error) {
+			throw new Error(completionApiError(error));
+		}
+	}
 	async function loadedCandidateSnapshots(
 		candidateRef: string,
 		loadOptions: {
 			allowCachedSummaryFallback?: boolean;
+			deadlineMs?: number;
 			invalidateSummaryCache?: boolean;
 		} = {},
 	): Promise<LegacyTeamConfiguredGroupSnapshot[]> {
@@ -1224,7 +1885,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		const invalidateSummaryCache = loadOptions.invalidateSummaryCache ?? true;
 		if (invalidateSummaryCache) loadedSummarySnapshots.invalidate();
 		try {
-			return await loadedSnapshots(candidateRef);
+			return await loadedSnapshots(candidateRef, loadOptions.deadlineMs);
 		} catch (error) {
 			if (!allowCachedSummaryFallback) throw error;
 			const cachedGroups = loadedSummarySnapshots.peek();
@@ -1239,6 +1900,21 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		}
 	}
 
+	function persistedCompletionGroup(
+		store: MemoryStore,
+		candidateRef: string,
+	): LegacyTeamCandidateGroupDescriptor | null {
+		const row = store.db
+			.prepare(
+				`SELECT coordinator_id, group_id FROM legacy_team_setup_drafts
+				 WHERE candidate_id = ? ORDER BY rowid DESC LIMIT 1`,
+			)
+			.get(candidateRef) as { coordinator_id: string; group_id: string } | undefined;
+		if (!row || legacyTeamCandidateId(row.coordinator_id, row.group_id) !== candidateRef)
+			return null;
+		return { coordinatorId: row.coordinator_id, groupId: row.group_id };
+	}
+
 	app.get("/api/sync/team-setup/v1", async (c) => {
 		let groups: LegacyTeamConfiguredGroupSnapshot[];
 		try {
@@ -1249,6 +1925,8 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		}
 		try {
 			const store = options.getStore();
+			readPureCandidateViews(store, groups);
+			await reconcileCompletions(store, groups, { isolateApplyFailures: true });
 			const response = {
 				version: TEAM_SETUP_VERSION,
 				candidates: readPureCandidateViews(store, groups)
@@ -1275,6 +1953,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			const store = options.getStore();
 			let draft = getLegacyTeamSetupDraft(store.db, candidateRef);
 			const terminal = hasCompletedLegacyTeamSetup(store, candidateRef);
+			let candidateGroupsForCompletion: LegacyTeamConfiguredGroupSnapshot[] | null = null;
 			if (terminal && draft?.state !== "completed") {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 			}
@@ -1292,6 +1971,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				const candidateGroups = groups.filter(
 					(group) => legacyTeamCandidateId(group.coordinatorId, group.groupId) === candidateRef,
 				);
+				candidateGroupsForCompletion = candidateGroups;
 				const postLoadDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
 				if (hasCompletedLegacyTeamSetup(store, candidateRef)) {
 					if (postLoadDraft?.state !== "completed") {
@@ -1311,6 +1991,28 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				}
 			}
 			if (!draft) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			const cachedCandidateGroups = loadedSummarySnapshots
+				.peek()
+				?.filter(
+					(group) => legacyTeamCandidateId(group.coordinatorId, group.groupId) === candidateRef,
+				);
+			let completionGroups: LegacyTeamCandidateGroupDescriptor[] | null =
+				candidateGroupsForCompletion ??
+				(cachedCandidateGroups?.length ? cachedCandidateGroups : null);
+			if (!completionGroups) {
+				const persistedGroup = persistedCompletionGroup(store, candidateRef);
+				completionGroups = persistedGroup ? [persistedGroup] : null;
+			}
+			const terminalBeforeReconciliation = hasCompletedLegacyTeamSetup(store, candidateRef);
+			if (completionGroups) await reconcileCompletions(store, completionGroups);
+			draft = getLegacyTeamSetupDraft(store.db, candidateRef);
+			if (
+				!draft ||
+				(!terminalBeforeReconciliation && hasCompletedLegacyTeamSetup(store, candidateRef))
+			) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
+			}
+			if (completionGroups) candidate = candidateFromDraft(draft);
 
 			return c.json(detailResponse(store, draft, candidate));
 		} catch (error) {
@@ -1375,19 +2077,27 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				(choice) => choice.identityRef === targetIdentityRef,
 			);
 			if (!target) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
-			return c.json(
-				projectMutationAtomically(
-					store,
-					() =>
-						setLegacyTeamSetupDeviceAssignment(store.db, {
-							attemptId,
-							deviceRef,
-							targetIdentityId: target.identityId,
-							expectation: device.expectation,
-						}),
-					(draft) => detailResponse(store, draft),
-				),
-			);
+			const releaseMutation = claimCandidateMutation(store.db, candidateRef);
+			if (!releaseMutation) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			try {
+				return c.json(
+					projectMutationAtomically(
+						store,
+						() =>
+							setLegacyTeamSetupDeviceAssignment(store.db, {
+								attemptId,
+								deviceRef,
+								targetIdentityId: target.identityId,
+								expectation: device.expectation,
+							}),
+						(draft) => detailResponse(store, draft),
+					),
+				);
+			} finally {
+				releaseMutation();
+			}
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1441,18 +2151,26 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			) {
 				return c.json({ error: "team_setup_assignment_changed" as const }, 409);
 			}
-			return c.json(
-				projectMutationAtomically(
-					store,
-					() =>
-						setLegacyTeamSetupDeviceDecision(store.db, {
-							attemptId,
-							deviceRef,
-							decision: decision as "included" | "excluded" | "removed",
-						}),
-					(draft) => detailResponse(store, draft),
-				),
-			);
+			const releaseMutation = claimCandidateMutation(store.db, candidateRef);
+			if (!releaseMutation) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			try {
+				return c.json(
+					projectMutationAtomically(
+						store,
+						() =>
+							setLegacyTeamSetupDeviceDecision(store.db, {
+								attemptId,
+								deviceRef,
+								decision: decision as "included" | "excluded" | "removed",
+							}),
+						(draft) => detailResponse(store, draft),
+					),
+				);
+			} finally {
+				releaseMutation();
+			}
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1489,13 +2207,21 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			if (!draft.devices.some((item) => item.deviceRef === deviceRef)) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 			}
-			return c.json(
-				projectMutationAtomically(
-					store,
-					() => clearLegacyTeamSetupDeviceDecision(store.db, { attemptId, deviceRef }),
-					(draft) => detailResponse(store, draft),
-				),
-			);
+			const releaseMutation = claimCandidateMutation(store.db, candidateRef);
+			if (!releaseMutation) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			try {
+				return c.json(
+					projectMutationAtomically(
+						store,
+						() => clearLegacyTeamSetupDeviceDecision(store.db, { attemptId, deviceRef }),
+						(draft) => detailResponse(store, draft),
+					),
+				);
+			} finally {
+				releaseMutation();
+			}
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1546,18 +2272,26 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 					legacyTeamResolvedProjectRef(projectRef, choice.projectIdentity) === resolvedProjectRef,
 			);
 			if (!target) return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
-			return c.json(
-				projectMutationAtomically(
-					store,
-					() =>
-						setLegacyTeamSetupProjectMapping(store.db, {
-							attemptId,
-							projectRef,
-							resolvedProjectIdentity: target.projectIdentity,
-						}),
-					(draft) => detailResponse(store, draft),
-				),
-			);
+			const releaseMutation = claimCandidateMutation(store.db, candidateRef);
+			if (!releaseMutation) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			try {
+				return c.json(
+					projectMutationAtomically(
+						store,
+						() =>
+							setLegacyTeamSetupProjectMapping(store.db, {
+								attemptId,
+								projectRef,
+								resolvedProjectIdentity: target.projectIdentity,
+							}),
+						(draft) => detailResponse(store, draft),
+					),
+				);
+			} finally {
+				releaseMutation();
+			}
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1601,26 +2335,34 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			return c.json({ error: "team_setup_confirmation_stale" as const }, 404);
 		}
 		try {
-			return c.json(
-				projectMutationAtomically(
-					store,
-					() => {
-						const currentDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
-						if (
-							currentDraft?.state === "completed" ||
-							hasCompletedLegacyTeamSetup(store, candidateRef)
-						) {
-							throw new Error("team_setup_confirmation_stale");
-						}
-						return refreshLegacyTeamCandidate(
-							store.db,
-							{ projection: projectionOptions(store), groups },
-							candidateRef,
-						);
-					},
-					(draft) => detailResponse(store, draft),
-				),
-			);
+			const releaseMutation = claimCandidateMutation(store.db, candidateRef);
+			if (!releaseMutation) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			try {
+				return c.json(
+					projectMutationAtomically(
+						store,
+						() => {
+							const currentDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
+							if (
+								currentDraft?.state === "completed" ||
+								hasCompletedLegacyTeamSetup(store, candidateRef)
+							) {
+								throw new Error("team_setup_confirmation_stale");
+							}
+							return refreshLegacyTeamCandidate(
+								store.db,
+								{ projection: projectionOptions(store), groups },
+								candidateRef,
+							);
+						},
+						(draft) => detailResponse(store, draft),
+					),
+				);
+			} finally {
+				releaseMutation();
+			}
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
@@ -1667,6 +2409,9 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		) {
 			return c.json({ error: "team_setup_incomplete" as const }, 400);
 		}
+		let releaseMutation: (() => void) | undefined;
+		let releasePublicationMutation: (() => void) | undefined;
+		let releaseActorMutations: (() => void) | undefined;
 		try {
 			const store = options.getStore();
 			const draft = getLegacyTeamSetupDraft(store.db, candidateRef);
@@ -1677,57 +2422,261 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			if (draft.attemptId !== attemptId) {
 				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
 			}
-			if (draft.state !== "completed") {
-				const preview = previewLegacyTeamSetupActivation(store.db, {
-					candidateRef,
-					attemptId: draft.attemptId,
-				});
-				requireBoundedAccessDelta(preview.accessDelta);
-				const safeDraft = viewerSafeDraft(store, draft);
-				const currentViewerDigest = viewerAccessDeltaDigest(
-					viewerSafeAccessDelta(candidateRef, preview.accessDelta, {
-						teamDisplayName: draft.displayName,
-						...safeDraft,
-					}),
-				);
-				if (currentViewerDigest !== confirmedViewerAccessDeltaDigest) {
-					return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
-				}
-			}
-			const result = await finishLegacyTeamSetupActivation(store.db, {
+			const replay = replayLegacyTeamSetupActivation(store.db, {
 				candidateRef,
 				attemptId,
 				finishDigest,
 				confirmedAccessDeltaDigest,
-				loadFreshRoster: async () => {
-					const groups = await loadedCandidateSnapshots(candidateRef);
-					const matching = groups.filter(
-						(group) => legacyTeamCandidateId(group.coordinatorId, group.groupId) === candidateRef,
-					);
-					if (matching.length !== 1) throw safeCoordinatorError();
-					return matching[0]?.devices ?? [];
-				},
-				loadProjectInventory: () =>
-					legacyTeamCandidateProjectInventory(store.db, projectionOptions(store), candidateRef),
-				validateLockedPreview: (lockedPreview) => {
-					requireBoundedAccessDelta(lockedPreview.accessDelta);
-					const lockedDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
-					if (!lockedDraft || lockedDraft.attemptId !== attemptId) return false;
-					const safeDraft = viewerSafeDraft(store, lockedDraft);
-					return (
-						viewerAccessDeltaDigest(
-							viewerSafeAccessDelta(candidateRef, lockedPreview.accessDelta, {
-								teamDisplayName: lockedDraft.displayName,
-								...safeDraft,
-							}),
-						) === confirmedViewerAccessDeltaDigest
-					);
-				},
 			});
-			return c.json(finishResponse(candidateRef, result));
+			if (replay) return c.json(finishResponse(candidateRef, replay));
+			if (draft.state === "completed") {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			const preview = previewLegacyTeamSetupActivation(store.db, {
+				candidateRef,
+				attemptId: draft.attemptId,
+			});
+			requireLegacyTeamSetupAccessDeltaWithinLimit(preview.accessDelta);
+			const safeDraft = viewerSafeDraft(store, draft);
+			const currentViewerDigest = viewerAccessDeltaDigest(
+				viewerSafeAccessDelta(candidateRef, preview.accessDelta, {
+					teamDisplayName: draft.displayName,
+					...safeDraft,
+				}),
+			);
+			if (currentViewerDigest !== confirmedViewerAccessDeltaDigest) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			const freshGroups = await loadedCandidateSnapshots(candidateRef);
+			const matchingGroups = freshGroups.filter(
+				(group) => legacyTeamCandidateId(group.coordinatorId, group.groupId) === candidateRef,
+			);
+			if (matchingGroups.length !== 1) throw safeCoordinatorError();
+			const group = matchingGroups[0];
+			if (!group) throw safeCoordinatorError();
+			const freshRoster = group.devices;
+			releaseMutation = claimCandidateMutation(store.db, candidateRef) ?? undefined;
+			if (!releaseMutation) {
+				// An identical request may be committing right now. Wait for it and
+				// return its immutable result instead of a stale-confirmation error.
+				await candidateMutationSettled(store.db, candidateRef);
+				const overlappingReplay = replayLegacyTeamSetupActivation(store.db, {
+					candidateRef,
+					attemptId,
+					finishDigest,
+					confirmedAccessDeltaDigest,
+				});
+				if (overlappingReplay) return c.json(finishResponse(candidateRef, overlappingReplay));
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			// The pre-claim replay lookup raced an in-flight commit; recheck under the claim.
+			const claimedReplay = replayLegacyTeamSetupActivation(store.db, {
+				candidateRef,
+				attemptId,
+				finishDigest,
+				confirmedAccessDeltaDigest,
+			});
+			if (claimedReplay) return c.json(finishResponse(candidateRef, claimedReplay));
+			const claimedDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
+			if (!claimedDraft || claimedDraft.attemptId !== attemptId) {
+				return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+			}
+			const publicationDeadlineMs = Date.now() + COORDINATOR_ROSTER_READ_BUDGET_MS;
+			releasePublicationMutation = await claimRecipientPolicyPublicationMutation(store.db);
+			// Every identity the activation reads or writes is part of the immutable
+			// publication winner: the target of each included device and the existing
+			// assignment of every reviewed device (including excluded or removed ones,
+			// whose current assignment the access delta depends on). These locks cover
+			// coordinator creation, conflict recovery, and local application.
+			releaseActorMutations = await claimRecipientPolicyActorMutations(
+				store.db,
+				claimedDraft.devices.flatMap((device) => [
+					...(device.decision === "included" && device.targetIdentityId
+						? [device.targetIdentityId]
+						: []),
+					...(device.existingIdentityId ? [device.existingIdentityId] : []),
+				]),
+			);
+			const response = await serializeRecipientPolicyTeamMutation(
+				store.db,
+				deterministicPolicyTeamId(candidateRef),
+				() =>
+					serializeRecipientPolicyCoordinatorGroupMutation(store.db, group.groupId, async () => {
+						const projectInventory = legacyTeamCandidateProjectInventory(
+							store.db,
+							projectionOptions(store),
+							candidateRef,
+						);
+						const freshPreview = inspectFreshLegacyTeamSetupActivation(store.db, {
+							candidateRef,
+							attemptId,
+							freshRoster,
+							projectInventory,
+						});
+						if (
+							freshPreview.finishDigest !== finishDigest ||
+							freshPreview.accessDeltaDigest !== confirmedAccessDeltaDigest
+						) {
+							return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+						}
+						const freshDraft = getLegacyTeamSetupDraft(store.db, candidateRef);
+						if (!freshDraft || freshDraft.attemptId !== attemptId) {
+							return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+						}
+						const safeFreshDraft = viewerSafeDraft(store, freshDraft);
+						if (
+							viewerAccessDeltaDigest(
+								viewerSafeAccessDelta(candidateRef, freshPreview.accessDelta, {
+									teamDisplayName: freshDraft.displayName,
+									...safeFreshDraft,
+								}),
+							) !== confirmedViewerAccessDeltaDigest
+						) {
+							return c.json({ error: "team_setup_confirmation_stale" as const }, 409);
+						}
+						const completedAt = new Date().toISOString();
+						const proposedManifest = deriveLegacyTeamSetupCompletionManifest(store.db, {
+							candidateRef,
+							attemptId,
+							completedAt,
+						});
+						let config: ReturnType<typeof readCoordinatorSyncConfig>;
+						try {
+							config = (
+								options.readCoordinatorConfig ??
+								options.snapshotLoaderDependencies?.readConfig ??
+								readCoordinatorSyncConfig
+							)();
+						} catch (error) {
+							throw new Error(completionApiError(error));
+						}
+						const remoteUrl = buildBaseUrl(config.syncCoordinatorUrl);
+						if (!completionDependencies || !remoteUrl || !config.syncCoordinatorAdminSecret) {
+							throw new Error("team_setup_completion_unavailable");
+						}
+						const configuredCoordinatorId = normalizedCoordinatorId(remoteUrl);
+						let currentGroupIds: Set<string>;
+						try {
+							currentGroupIds = new Set(
+								legacyTeamCandidateGroupDescriptors(
+									store,
+									remoteUrl,
+									config.syncCoordinatorGroups,
+								).map((currentGroup) => currentGroup.groupId),
+							);
+						} catch {
+							throw new Error("team_setup_completion_invalid");
+						}
+						if (
+							!configuredCoordinatorId ||
+							!currentGroupIds.has(group.groupId) ||
+							normalizedCoordinatorId(group.coordinatorId) !== configuredCoordinatorId
+						) {
+							throw new Error("team_setup_completion_invalid");
+						}
+						const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
+						const publicationTimeoutS = remainingCoordinatorTimeoutS(
+							timeoutS,
+							publicationDeadlineMs,
+						);
+						if (publicationTimeoutS == null) {
+							throw new Error("team_setup_completion_unavailable");
+						}
+						let canonicalManifest: typeof proposedManifest;
+						try {
+							canonicalManifest = validateLegacyTeamSetupCompletionManifest(
+								(
+									await completionDependencies.create({
+										groupId: group.groupId,
+										manifest: proposedManifest,
+										remoteUrl,
+										adminSecret: config.syncCoordinatorAdminSecret,
+										timeoutS: publicationTimeoutS,
+									})
+								).manifest,
+								{ coordinatorId: group.coordinatorId, groupId: group.groupId },
+							);
+							if (
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(canonicalManifest) !==
+								canonicalCoordinatorLegacyTeamCompletionManifestJson(proposedManifest)
+							) {
+								throw new Error("team_setup_completion_conflict");
+							}
+						} catch (error) {
+							const code = completionApiError(error);
+							const getCompletion = completionDependencies.get;
+							if (code !== "team_setup_completion_conflict" || !getCompletion) {
+								throw new Error(code);
+							}
+							try {
+								const existing = await retryTransientCoordinatorRead(
+									(attemptTimeoutS) =>
+										getCompletion({
+											groupId: group.groupId,
+											candidateRef,
+											remoteUrl,
+											adminSecret: config.syncCoordinatorAdminSecret,
+											timeoutS: attemptTimeoutS,
+										}),
+									timeoutS,
+									publicationDeadlineMs,
+								);
+								if (!existing) throw new Error("team_setup_completion_conflict");
+								canonicalManifest = validateLegacyTeamSetupCompletionManifest(existing, {
+									coordinatorId: group.coordinatorId,
+									groupId: group.groupId,
+								});
+								// A conflict can mean an earlier request committed before its response was lost.
+								// The matching policy digest identifies that winner; its publication timestamp
+								// is coordinator-owned metadata and must be applied unchanged.
+								if (canonicalManifest.finish_digest !== proposedManifest.finish_digest) {
+									throw new Error("team_setup_completion_conflict");
+								}
+							} catch (recoveryError) {
+								throw new Error(completionApiError(recoveryError));
+							}
+						}
+						// Publication is the commit point. Apply its immutable winner after binding
+						// each included device to the current coordinator roster evidence.
+						// If this reload fails, reconciliation can apply the published winner later.
+						const postPublicationGroups = await loadedCandidateSnapshots(candidateRef, {
+							deadlineMs: publicationDeadlineMs,
+						});
+						const postPublicationMatches = postPublicationGroups.filter(
+							(candidate) =>
+								candidate.coordinatorId === group.coordinatorId &&
+								candidate.groupId === group.groupId &&
+								legacyTeamCandidateId(candidate.coordinatorId, candidate.groupId) === candidateRef,
+						);
+						if (postPublicationMatches.length !== 1) {
+							throw new Error("team_setup_roster_unavailable");
+						}
+						const result = await applyLegacyTeamSetupCompletionManifestAndReturnActivation(
+							store.db,
+							{
+								coordinatorId: group.coordinatorId,
+								groupId: group.groupId,
+								freshRoster: postPublicationMatches[0]?.devices ?? [],
+								manifest: canonicalManifest,
+								expectedDraftManifest: proposedManifest,
+								recipientPolicyLocksHeld: {
+									publication: true,
+									team: true,
+									coordinatorGroup: true,
+								},
+							},
+						);
+						return c.json(finishResponse(candidateRef, result));
+					}),
+			);
+			return response;
 		} catch (error) {
 			const code = apiErrorCode(error);
 			return c.json({ error: code }, errorStatus(code));
+		} finally {
+			releaseActorMutations?.();
+			releasePublicationMutation?.();
+			releaseMutation?.();
 		}
 	});
 


### PR DESCRIPTION
## Description
Reconcile canonical legacy Team completions through the viewer API before completed setup disappears locally. Uses publication, Team, and coordinator-group lock ordering plus one shared coordinator deadline, with regressions for timeout and lock release.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced