### PR TITLE
fix(viewer): restrict Team completion to configured groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ For ongoing collaboration:
 
 Team onboarding links Identities and devices. The invitation does not assign Projects to the Team, but a new member inherits every current and future Project assigned to it. Review the Team's Projects before sending or accepting the invitation. Use **Share exact Projects** to send a separate direct Project invitation to one Identity. Team sharing must already be configured, but accepting the direct invitation does not add the recipient to the Team.
 
-For a legacy Team that needs setup, finish the reviewed setup on any upgraded device. The first valid finish becomes the Team's shared result; other upgraded devices apply it locally and stop showing that setup task. See [Set up an existing Team](docs/user-guide.md#set-up-an-existing-team) for recovery and compatibility details.
+For a legacy Team that needs setup, finish the reviewed setup on any upgraded device. The first valid finish becomes the Team's shared result; other upgraded devices apply it locally and stop showing that setup task. To finish setup, the device must list the Team's coordinator group in `sync_coordinator_groups`; scope-backed discovery can show a Team for review but cannot complete its setup. See [Set up an existing Team](docs/user-guide.md#set-up-an-existing-team) for recovery and compatibility details.
 
 For a direct share, choose **Create an invitation → Share exact Projects**:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -235,7 +235,7 @@ When another upgraded device opens **Sharing**, it automatically applies a compl
 
 If the page closes or the finish response is lost, refresh **Sharing** and open the Team again. Retrying the same finish safely returns the completed result instead of applying access changes again. If setup cannot reach the shared completion service or cannot apply the completed result locally, the task stays visible and offers retry; it never hides an incomplete setup.
 
-Every device that finishes or recovers setup must use a coordinator that supports cross-device Team completion. With an older coordinator, Codemem keeps the setup unfinished rather than creating a local-only result; update the coordinator, then retry. A device upgraded after a prior local completion makes that result available when it reconnects, after which other upgraded devices recover it automatically.
+Every device that finishes or recovers setup must use a coordinator that supports cross-device Team completion. The device must also list the Team's coordinator group in `sync_coordinator_groups`; scope-backed discovery can show a Team for review but cannot complete its setup. With an older coordinator, Codemem keeps the setup unfinished rather than creating a local-only result; update the coordinator, then retry. A device upgraded after a prior local completion makes that result available when it reconnects, after which other upgraded devices recover it automatically.
 
 ### Share exact Projects
 

--- a/e2e/scenarios/legacy-team-migration.ts
+++ b/e2e/scenarios/legacy-team-migration.ts
@@ -642,7 +642,7 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 		{
 			sync_coordinator_url: "http://coordinator:7347",
 			sync_coordinator_admin_secret: ADMIN_SECRET,
-			sync_coordinator_groups: [GROUP_ALPHA],
+			sync_coordinator_groups: [GROUP_ALPHA, GROUP_BETA],
 			sync_coordinator_timeout_s: 10,
 		},
 		"07-write-config",
@@ -653,7 +653,7 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 		{
 			sync_coordinator_url: "http://coordinator:7347",
 			sync_coordinator_admin_secret: ADMIN_SECRET,
-			sync_coordinator_groups: [GROUP_ALPHA],
+			sync_coordinator_groups: [GROUP_ALPHA, GROUP_BETA],
 			sync_coordinator_timeout_s: 10,
 		},
 		"07-peer-b-write-config",
@@ -692,7 +692,7 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 		{ description: "peer-b legacy Team viewer readiness", timeoutMs: 120_000, intervalMs: 2_000 },
 	);
 
-	// Arrange: Alpha is configured while active coordinator-backed scope evidence discovers Beta.
+	// Arrange: Alpha and Beta are configured; Gamma remains unrelated.
 	const summaryResponse = await request<{ version: 1; candidates: CandidateSummary[] }>(
 		ctx,
 		"GET",
@@ -712,11 +712,11 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 	);
 	assert(
 		alphaCandidate && betaCandidate && !gammaCandidate,
-		"expected configured Alpha and scope-backed Beta, but not unrelated Gamma",
+		"expected configured Alpha and Beta, but not unrelated Gamma",
 	);
 	assert(
 		alphaCandidate.deviceCount === 2 && betaCandidate.deviceCount === 6,
-		"configured Alpha and scope-backed Beta did not expose the exact current rosters",
+		"configured Alpha and Beta did not expose the exact current rosters",
 	);
 	const peerBBeforeCompletion = await request<{
 		version: 1;
@@ -730,7 +730,7 @@ export async function runLegacyTeamMigrationScenario(ctx: ScenarioContext): Prom
 			peerBBeforeCompletion.body.candidates.some(
 				(candidate) => candidate.candidateRef === betaCandidate.candidateRef,
 			),
-		"peer-b did not expose Alpha and unrelated Beta before coordinator completion",
+		"peer-b did not expose configured Alpha and Beta before coordinator completion",
 	);
 	assertNoPolicyWrites(
 		fixture(ctx, "summary", "10-peer-b-before-completion-policy", "peer-b"),

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -574,6 +574,7 @@ describe("viewer-server", () => {
 				readCoordinatorConfig: () =>
 					core.readCoordinatorSyncConfig({
 						sync_coordinator_url: coordinatorId,
+						sync_coordinator_groups: [groupId],
 						sync_coordinator_admin_secret: "test-secret",
 					}),
 				teamSetupCompletionDependencies: {

--- a/packages/viewer-server/src/routes/team-setup-terminal.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-terminal.test.ts
@@ -102,6 +102,7 @@ describe("Team setup terminal migration routing", () => {
 	async function readyDraftThroughSummary(
 		store: MemoryStore,
 		app: ReturnType<typeof teamSetupRoutes>,
+		candidateRef = CANDIDATE_REF,
 	) {
 		expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
 		store.db
@@ -110,7 +111,7 @@ describe("Team setup terminal migration routing", () => {
 				 VALUES ('identity-a', 'Person A', 0, 'active', ?, ?)`,
 			)
 			.run(NOW, NOW);
-		let draft = getLegacyTeamSetupDraft(store.db, CANDIDATE_REF);
+		let draft = getLegacyTeamSetupDraft(store.db, candidateRef);
 		if (!draft) throw new Error("Team setup draft missing");
 		const device = draft.devices[0];
 		if (!device) throw new Error("Team setup device missing");
@@ -1794,6 +1795,119 @@ describe("Team setup terminal migration routing", () => {
 			await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`);
 			expect(getLegacyTeamSetupDraft(store.db, CANDIDATE_REF)?.state).not.toBe("completed");
 			expect(store.db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("discovers scope-backed groups without authorizing completion reconciliation", async () => {
+		const store = new MemoryStore(":memory:");
+		const scopeBackedGroupId = "group-beta";
+		const scopeBackedCandidateRef = legacyTeamCandidateId(COORDINATOR_ID, scopeBackedGroupId);
+		const scopeBackedSnapshot: LegacyTeamConfiguredGroupSnapshot = {
+			...SNAPSHOTS[0],
+			groupId: scopeBackedGroupId,
+			displayName: "Scope-backed Team",
+			devices: [
+				{
+					deviceId: "device-beta",
+					fingerprint: FINGERPRINT_B,
+					displayName: "Beta laptop",
+					enabled: true,
+				},
+			],
+		};
+		store.db
+			.prepare(
+				`INSERT INTO replication_scopes(
+				 scope_id, label, kind, authority_type, coordinator_id, group_id,
+				 membership_epoch, status, created_at, updated_at
+				 ) VALUES ('scope-beta', 'Beta', 'team', 'coordinator', ?, ?, 1, 'active', ?, ?)`,
+			)
+			.run(COORDINATOR_ID, scopeBackedGroupId, NOW, NOW);
+		const list = vi.fn(async () => []);
+		const create = vi.fn();
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => [...SNAPSHOTS, scopeBackedSnapshot],
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: { create, list },
+		});
+		try {
+			const response = await app.request("/api/sync/team-setup/v1");
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toMatchObject({
+				candidates: expect.arrayContaining([
+					expect.objectContaining({ candidateRef: CANDIDATE_REF }),
+					expect.objectContaining({ candidateRef: scopeBackedCandidateRef }),
+				]),
+			});
+			expect(list).toHaveBeenCalledWith(expect.objectContaining({ groupIds: [GROUP_ID] }));
+			expect(create).not.toHaveBeenCalled();
+			expect(
+				store.db
+					.prepare("SELECT COUNT(*) FROM policy_teams WHERE team_id = ?")
+					.pluck()
+					.get(deterministicPolicyTeamId(scopeBackedCandidateRef)),
+			).toBe(0);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("rejects finish publication for a scope-backed group absent from configuration", async () => {
+		const store = new MemoryStore(":memory:");
+		const scopeBackedGroupId = "group-beta";
+		const scopeBackedCandidateRef = legacyTeamCandidateId(COORDINATOR_ID, scopeBackedGroupId);
+		const snapshot = SNAPSHOTS[0];
+		if (!snapshot) throw new Error("missing test snapshot");
+		const scopeBackedSnapshot = {
+			...snapshot,
+			groupId: scopeBackedGroupId,
+			displayName: "Scope-backed Team",
+		};
+		store.db
+			.prepare(
+				`INSERT INTO replication_scopes(
+				 scope_id, label, kind, authority_type, coordinator_id, group_id,
+				 membership_epoch, status, created_at, updated_at
+				 ) VALUES ('scope-beta', 'Beta', 'team', 'coordinator', ?, ?, 1, 'active', ?, ?)`,
+			)
+			.run(COORDINATOR_ID, scopeBackedGroupId, NOW, NOW);
+		const create = vi.fn();
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: async () => [scopeBackedSnapshot],
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: { create, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app, scopeBackedCandidateRef);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${scopeBackedCandidateRef}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			const response = await app.request(
+				`/api/sync/team-setup/v1/${scopeBackedCandidateRef}/finish`,
+				{
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({
+						attemptId: draft.attemptId,
+						finishDigest: detail.finishDigest,
+						confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+						confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+					}),
+				},
+			);
+
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_setup_completion_invalid" });
+			expect(create).not.toHaveBeenCalled();
 		} finally {
 			store.close();
 		}

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -1351,7 +1351,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 	 * authorizes. Returns null when completion I/O is not configured or current
 	 * authorization cannot be proven.
 	 */
-	function currentCompletionAuthorization(store: MemoryStore): CompletionAuthorization | null {
+	function currentCompletionAuthorization(): CompletionAuthorization | null {
 		const config = (
 			options.readCoordinatorConfig ??
 			options.snapshotLoaderDependencies?.readConfig ??
@@ -1363,11 +1363,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		if (!configuredCoordinatorId) return null;
 		let currentGroupIds: Set<string>;
 		try {
-			currentGroupIds = new Set(
-				legacyTeamCandidateGroupDescriptors(store, remoteUrl, config.syncCoordinatorGroups).map(
-					(group) => group.groupId,
-				),
-			);
+			currentGroupIds = new Set(configuredGroupIds(config.syncCoordinatorGroups));
 		} catch {
 			return null;
 		}
@@ -1392,13 +1388,12 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 	 * before applying canonical policy, as the finish publication path does.
 	 */
 	function stillAuthorizesGroup(
-		store: MemoryStore,
 		initial: CompletionAuthorization,
 		group: LegacyTeamCandidateGroupDescriptor,
 	): boolean {
 		let current: CompletionAuthorization | null;
 		try {
-			current = currentCompletionAuthorization(store);
+			current = currentCompletionAuthorization();
 		} catch {
 			return false;
 		}
@@ -1492,7 +1487,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				serializeRecipientPolicyPublicationMutation(store.db, () =>
 					serializeRecipientPolicyTeamMutation(store.db, manifest.team_id, () =>
 						serializeRecipientPolicyCoordinatorGroupMutation(store.db, group.groupId, async () => {
-							if (!stillAuthorizesGroup(store, authorization, group)) return;
+							if (!stillAuthorizesGroup(authorization, group)) return;
 							await applyLegacyTeamSetupCompletionManifest(store.db, {
 								coordinatorId: group.coordinatorId,
 								groupId: group.groupId,
@@ -1516,7 +1511,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		if (!completionDependencies || groups.length === 0) return;
 		let authorization: CompletionAuthorization | null;
 		try {
-			authorization = currentCompletionAuthorization(store);
+			authorization = currentCompletionAuthorization();
 		} catch (error) {
 			throw new Error(completionApiError(error));
 		}
@@ -1766,7 +1761,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 									}
 									// Publication sends identity and policy data to the coordinator;
 									// re-prove the destination is still the configured one.
-									if (!stillAuthorizesGroup(store, authorization, group)) {
+									if (!stillAuthorizesGroup(authorization, group)) {
 										reconstructionFailed = true;
 										return;
 									}
@@ -2540,40 +2535,19 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 							attemptId,
 							completedAt,
 						});
-						let config: ReturnType<typeof readCoordinatorSyncConfig>;
+						let authorization: CompletionAuthorization | null;
 						try {
-							config = (
-								options.readCoordinatorConfig ??
-								options.snapshotLoaderDependencies?.readConfig ??
-								readCoordinatorSyncConfig
-							)();
+							authorization = currentCompletionAuthorization();
 						} catch (error) {
 							throw new Error(completionApiError(error));
 						}
-						const remoteUrl = buildBaseUrl(config.syncCoordinatorUrl);
-						if (!completionDependencies || !remoteUrl || !config.syncCoordinatorAdminSecret) {
+						if (!completionDependencies || !authorization) {
 							throw new Error("team_setup_completion_unavailable");
 						}
-						const configuredCoordinatorId = normalizedCoordinatorId(remoteUrl);
-						let currentGroupIds: Set<string>;
-						try {
-							currentGroupIds = new Set(
-								legacyTeamCandidateGroupDescriptors(
-									store,
-									remoteUrl,
-									config.syncCoordinatorGroups,
-								).map((currentGroup) => currentGroup.groupId),
-							);
-						} catch {
+						if (!authorizesGroup(authorization, group)) {
 							throw new Error("team_setup_completion_invalid");
 						}
-						if (
-							!configuredCoordinatorId ||
-							!currentGroupIds.has(group.groupId) ||
-							normalizedCoordinatorId(group.coordinatorId) !== configuredCoordinatorId
-						) {
-							throw new Error("team_setup_completion_invalid");
-						}
+						const { config, remoteUrl } = authorization;
 						const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
 						const publicationTimeoutS = remainingCoordinatorTimeoutS(
 							timeoutS,


### PR DESCRIPTION
## Description

Restrict legacy Team setup completion and reconciliation to groups explicitly listed in `sync_coordinator_groups`. Scope-backed group descriptors remain available for discovery but no longer authorize publication. Update the migration scenario and user documentation to reflect the configured-group requirement.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated at the stack tip with `pnpm run check` and `CODEMEM_E2E_BUILD=1 pnpm run e2e:legacy-team-migration`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced