### PR TITLE
fix(viewer): revalidate Team roster under publication locks

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -940,11 +940,21 @@ describe("viewer-server", () => {
 					body: JSON.stringify(finishRequest),
 				});
 				expect(finishResponse.status).toBe(200);
-				expect(loadSnapshots).toHaveBeenCalledTimes(2);
+				expect(loadSnapshots).toHaveBeenCalledTimes(3);
 				expect(loadSnapshots).toHaveBeenNthCalledWith(1, { candidateRef });
 				expect(loadSnapshots).toHaveBeenNthCalledWith(
 					2,
-					expect.objectContaining({ candidateRef, deadlineMs: expect.any(Number) }),
+					expect.objectContaining({
+						candidateRef: expect.any(String),
+						deadlineMs: expect.any(Number),
+					}),
+				);
+				expect(loadSnapshots).toHaveBeenNthCalledWith(
+					3,
+					expect.objectContaining({
+						candidateRef: expect.any(String),
+						deadlineMs: expect.any(Number),
+					}),
 				);
 				const finished = await finishResponse.json();
 				expect(finished).toMatchObject({

--- a/packages/viewer-server/src/routes/team-setup-terminal.test.ts
+++ b/packages/viewer-server/src/routes/team-setup-terminal.test.ts
@@ -239,6 +239,136 @@ describe("Team setup terminal migration routing", () => {
 		}
 	});
 
+	it("rejects a roster change that occurs while finish waits for publication locks", async () => {
+		const store = new MemoryStore(":memory:");
+		let currentSnapshots = SNAPSHOTS;
+		const loadSnapshots = vi.fn(async () => currentSnapshots);
+		const create = vi.fn(async ({ manifest }) => ({ status: "created" as const, manifest }));
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+			snapshotLoaderDependencies: completionConfig(),
+			completionDependencies: { create, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			let releasePublicationLock = () => undefined;
+			const publicationLockPending = new Promise<void>((resolve) => {
+				releasePublicationLock = resolve;
+			});
+			let publicationLockHeld = false;
+			const publicationMutation = serializeRecipientPolicyPublicationMutation(
+				store.db,
+				async () => {
+					publicationLockHeld = true;
+					await publicationLockPending;
+				},
+			);
+			await vi.waitFor(() => expect(publicationLockHeld).toBe(true));
+			const loadCountBeforeFinish = loadSnapshots.mock.calls.length;
+			const finish = app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+			await vi.waitFor(() =>
+				expect(loadSnapshots.mock.calls.length).toBeGreaterThan(loadCountBeforeFinish),
+			);
+			const snapshot = SNAPSHOTS[0];
+			if (!snapshot) throw new Error("missing test snapshot");
+			currentSnapshots = [
+				{
+					...snapshot,
+					devices: snapshot.devices.map((device) => ({ ...device, enabled: false })),
+				},
+			];
+			releasePublicationLock();
+			await publicationMutation;
+
+			const response = await finish;
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_setup_roster_changed" });
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("rejects finish when authorization is revoked during the locked roster reload", async () => {
+		const store = new MemoryStore(":memory:");
+		let configuredGroups = [GROUP_ID];
+		let trackFinishLoads = false;
+		let finishLoadCount = 0;
+		let releaseLockedRosterReload = () => undefined;
+		const lockedRosterReloadPending = new Promise<void>((resolve) => {
+			releaseLockedRosterReload = resolve;
+		});
+		let lockedRosterReloadStarted = false;
+		const loadSnapshots = vi.fn(async () => {
+			if (!trackFinishLoads) return SNAPSHOTS;
+			finishLoadCount += 1;
+			if (finishLoadCount === 2) {
+				lockedRosterReloadStarted = true;
+				await lockedRosterReloadPending;
+			}
+			return SNAPSHOTS;
+		});
+		const config = completionConfig();
+		const create = vi.fn(async ({ manifest }) => ({ status: "created" as const, manifest }));
+		const app = teamSetupRoutes({
+			getStore: () => store,
+			loadLegacyTeamConfiguredGroupSnapshots: loadSnapshots,
+			snapshotLoaderDependencies: {
+				...config,
+				readConfig: () => ({ ...config.readConfig(), syncCoordinatorGroups: configuredGroups }),
+			},
+			completionDependencies: { create, list: async () => [] },
+		});
+		try {
+			const draft = await readyDraftThroughSummary(store, app);
+			const detail = (await (
+				await app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}`)
+			).json()) as {
+				finishDigest: string;
+				accessDeltaDigest: string;
+				viewerAccessDeltaDigest: string;
+			};
+			trackFinishLoads = true;
+			const finish = app.request(`/api/sync/team-setup/v1/${CANDIDATE_REF}/finish`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					attemptId: draft.attemptId,
+					finishDigest: detail.finishDigest,
+					confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+					confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+				}),
+			});
+			await vi.waitFor(() => expect(lockedRosterReloadStarted).toBe(true));
+			configuredGroups = [];
+			releaseLockedRosterReload();
+
+			const response = await finish;
+			expect(response.status).toBe(409);
+			expect(await response.json()).toEqual({ error: "team_setup_completion_invalid" });
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			store.close();
+		}
+	});
+
 	it("keeps local policy uncommitted when completion publication fails", async () => {
 		const store = new MemoryStore(":memory:");
 		const app = teamSetupRoutes({

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -1400,6 +1400,8 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		return (
 			current !== null &&
 			current.configuredCoordinatorId === initial.configuredCoordinatorId &&
+			current.remoteUrl === initial.remoteUrl &&
+			current.config.syncCoordinatorAdminSecret === initial.config.syncCoordinatorAdminSecret &&
 			authorizesGroup(current, group)
 		);
 	}
@@ -2449,7 +2451,6 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			if (matchingGroups.length !== 1) throw safeCoordinatorError();
 			const group = matchingGroups[0];
 			if (!group) throw safeCoordinatorError();
-			const freshRoster = group.devices;
 			releaseMutation = claimCandidateMutation(store.db, candidateRef) ?? undefined;
 			if (!releaseMutation) {
 				// An identical request may be committing right now. Wait for it and
@@ -2497,6 +2498,28 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 				deterministicPolicyTeamId(candidateRef),
 				() =>
 					serializeRecipientPolicyCoordinatorGroupMutation(store.db, group.groupId, async () => {
+						let authorization: CompletionAuthorization | null;
+						try {
+							authorization = currentCompletionAuthorization();
+						} catch (error) {
+							throw new Error(completionApiError(error));
+						}
+						if (!completionDependencies || !authorization) {
+							throw new Error("team_setup_completion_unavailable");
+						}
+						if (!authorizesGroup(authorization, group)) {
+							throw new Error("team_setup_completion_invalid");
+						}
+						const { config, remoteUrl } = authorization;
+						const freshGroup = await loadFreshGroupSnapshot(
+							group,
+							remoteUrl,
+							publicationDeadlineMs,
+						);
+						if (!freshGroup) throw new Error("team_setup_roster_unavailable");
+						if (!stillAuthorizesGroup(authorization, group)) {
+							throw new Error("team_setup_completion_invalid");
+						}
 						const projectInventory = legacyTeamCandidateProjectInventory(
 							store.db,
 							projectionOptions(store),
@@ -2505,7 +2528,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 						const freshPreview = inspectFreshLegacyTeamSetupActivation(store.db, {
 							candidateRef,
 							attemptId,
-							freshRoster,
+							freshRoster: freshGroup.devices,
 							projectInventory,
 						});
 						if (
@@ -2535,19 +2558,6 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 							attemptId,
 							completedAt,
 						});
-						let authorization: CompletionAuthorization | null;
-						try {
-							authorization = currentCompletionAuthorization();
-						} catch (error) {
-							throw new Error(completionApiError(error));
-						}
-						if (!completionDependencies || !authorization) {
-							throw new Error("team_setup_completion_unavailable");
-						}
-						if (!authorizesGroup(authorization, group)) {
-							throw new Error("team_setup_completion_invalid");
-						}
-						const { config, remoteUrl } = authorization;
 						const timeoutS = Math.max(1, config.syncCoordinatorTimeoutS);
 						const publicationTimeoutS = remainingCoordinatorTimeoutS(
 							timeoutS,
@@ -2613,24 +2623,26 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 						// Publication is the commit point. Apply its immutable winner after binding
 						// each included device to the current coordinator roster evidence.
 						// If this reload fails, reconciliation can apply the published winner later.
-						const postPublicationGroups = await loadedCandidateSnapshots(candidateRef, {
-							deadlineMs: publicationDeadlineMs,
-						});
-						const postPublicationMatches = postPublicationGroups.filter(
-							(candidate) =>
-								candidate.coordinatorId === group.coordinatorId &&
-								candidate.groupId === group.groupId &&
-								legacyTeamCandidateId(candidate.coordinatorId, candidate.groupId) === candidateRef,
-						);
-						if (postPublicationMatches.length !== 1) {
-							throw new Error("team_setup_roster_unavailable");
+						let postPublicationGroup: LegacyTeamConfiguredGroupSnapshot | undefined;
+						try {
+							postPublicationGroup = await loadFreshGroupSnapshot(
+								group,
+								remoteUrl,
+								publicationDeadlineMs,
+							);
+						} catch (error) {
+							if (legacyTeamSetupApiErrorCode(error) === "team_setup_completion_invalid") {
+								throw new Error("team_setup_roster_unavailable");
+							}
+							throw error;
 						}
+						if (!postPublicationGroup) throw new Error("team_setup_roster_unavailable");
 						const result = await applyLegacyTeamSetupCompletionManifestAndReturnActivation(
 							store.db,
 							{
 								coordinatorId: group.coordinatorId,
 								groupId: group.groupId,
-								freshRoster: postPublicationMatches[0]?.devices ?? [],
+								freshRoster: postPublicationGroup.devices,
 								manifest: canonicalManifest,
 								expectedDraftManifest: proposedManifest,
 								recipientPolicyLocksHeld: {


### PR DESCRIPTION
## Description

Reload and validate the legacy Team roster after acquiring publication and recipient-policy locks, immediately before publishing completion. Use normalized coordinator lookup for the post-publication reload and preserve the specific `team_setup_roster_changed` API error when concurrent roster changes invalidate the operation.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated at the stack tip with `pnpm run check` and `CODEMEM_E2E_BUILD=1 pnpm run e2e:legacy-team-migration`. The focused publication-lock roster-race regression also passes.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced