### PR TITLE
fix(cli): pin codemem scope during updates

### DIFF
--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -273,7 +273,7 @@ describe("update install command", () => {
 		expect(process.exitCode).toBe(1);
 	});
 
-	it("installs the exact validated release without a shell and verifies it", async () => {
+	it("pins the public default and scoped registries in the POSIX install command", async () => {
 		vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
 		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
 		spawn
@@ -291,6 +291,7 @@ describe("update install command", () => {
 				"-g",
 				"--registry",
 				"https://registry.npmjs.org/",
+				"--@codemem:registry=https://registry.npmjs.org/",
 				"codemem@0.41.0",
 				"@codemem/embeddings@0.41.0",
 			],
@@ -308,7 +309,48 @@ describe("update install command", () => {
 		});
 		expect(process.exitCode).toBeUndefined();
 	});
+});
 
+describe("update install command on Windows", () => {
+	it("pins the public default and scoped registries in the Windows install command", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+		const originalSystemRoot = process.env.SystemRoot;
+		const systemRoot = join(tmpdir(), "Windows");
+		const system32 = join(systemRoot, "System32");
+		const npmShim = join(system32, "npm.cmd");
+		const codememShim = join(system32, "codemem.cmd");
+		process.env.SystemRoot = systemRoot;
+		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${npmShim}\n` }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: `${codememShim}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await parseUpdateCommand(["install", "--json"]);
+		} finally {
+			if (originalSystemRoot === undefined) delete process.env.SystemRoot;
+			else process.env.SystemRoot = originalSystemRoot;
+		}
+
+		expect(spawn).toHaveBeenNthCalledWith(
+			2,
+			join(system32, "cmd.exe"),
+			[
+				"/d",
+				"/s",
+				"/c",
+				`""${npmShim}" install -g --registry https://registry.npmjs.org/ --@codemem:registry=https://registry.npmjs.org/ codemem@0.41.0 @codemem/embeddings@0.41.0"`,
+			],
+			expect.objectContaining({ shell: false, windowsVerbatimArguments: true }),
+		);
+		expect(process.exitCode).toBeUndefined();
+	});
+});
+
+describe("update install command behavior", () => {
 	it("keeps the bare update command non-mutating", async () => {
 		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -263,6 +263,20 @@ const checkCommand = addJsonOption(
 		}
 	});
 
+function updateInstallArgs(npmArgs: string[], targetVersion: string): string[] {
+	const installArgs = [
+		"install",
+		"-g",
+		"--registry",
+		PUBLIC_NPM_REGISTRY,
+		`--@codemem:registry=${PUBLIC_NPM_REGISTRY}`,
+		`codemem@${targetVersion}`,
+		`@codemem/embeddings@${targetVersion}`,
+	];
+	if (process.platform !== "win32") return installArgs;
+	return [...npmArgs.slice(0, 3), windowsCommandLine(npmArgs[3] ?? "", installArgs)];
+}
+
 async function installUpdate(options: UpdateInstallOptions): Promise<void> {
 	let releaseInstallLock: (() => Promise<void>) | null = null;
 	try {
@@ -293,26 +307,7 @@ async function installUpdate(options: UpdateInstallOptions): Promise<void> {
 		const npm = await resolveInstallCommand();
 		const installation = await runCommand(
 			npm.command,
-			process.platform === "win32"
-				? [
-						...npm.args.slice(0, 3),
-						windowsCommandLine(npm.args[3] ?? "", [
-							"install",
-							"-g",
-							"--registry",
-							PUBLIC_NPM_REGISTRY,
-							`codemem@${targetVersion}`,
-							`@codemem/embeddings@${targetVersion}`,
-						]),
-					]
-				: [
-						"install",
-						"-g",
-						"--registry",
-						PUBLIC_NPM_REGISTRY,
-						`codemem@${targetVersion}`,
-						`@codemem/embeddings@${targetVersion}`,
-					],
+			updateInstallArgs(npm.args, targetVersion),
 			INSTALL_TIMEOUT_MS,
 			{
 				cwd: npm.cwd,


### PR DESCRIPTION
## Description

Pins both the npm registry and the `@codemem` scope registry during CLI updates. User-level npm scope mappings can no longer redirect paired codemem packages away from the public registry.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced