### PR TITLE
fix(plugin): preserve Linux ONNX install guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ after the CLI reports a fresh, validated npm release observed for at least 24 ho
 installation whose npm origin can be proven. Pinned, prerelease, downgrade,
 repository-development, stale, Docker, and unknown installs refuse execution. Set
 `CODEMEM_BACKEND_UPDATE_POLICY=off` to disable release checks.
+On Linux, plugin-owned auto-updates preserve the OpenCode environment and set
+`ONNXRUNTIME_NODE_INSTALL=skip` for the install to avoid the unused GPU-provider download.
 Docker guidance is always rebuild-and-restart guidance, never an in-container update.
 
 Pack rendering defaults to self-contained context. For token-constrained experiments, `codemem pack <context> --compact` renders an index plus top details. Near-related compression is controlled by `--compression-mode off|compact|ids` (or `CODEMEM_PACK_COMPRESSION`); MCP `memory_pack` exposes the same setting as `compression_mode`. Use `ids` only when the agent can follow up with `memory_get_observations`.

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -485,8 +485,11 @@ argv-based CLI runner. `notify` and `auto` show a best-effort toast at most once
 release in the current OpenCode process; `off` skips this release check. Under explicit `auto`, an
 eligible result executes a paired, version-pinned public-registry install for `codemem` and
 `@codemem/embeddings`, then verifies the active CLI version before a plugin-owned Viewer is
-restarted. Current, unavailable, malformed, ineligible, and timed-out results are ignored or shown
-as guidance without delaying plugin startup. The plugin-owned installer is best effort: it does not
+restarted. On Linux, both plugin-owned auto-update paths preserve the existing child environment
+and set `ONNXRUNTIME_NODE_INSTALL=skip` for the install; other platforms keep the existing
+environment behavior. Current, unavailable, malformed, ineligible, and timed-out results are
+ignored or shown as guidance without delaying plugin startup. The plugin-owned installer is best
+effort: it does not
 use the CLI install lock or Windows npm-shim handling, and plugin-owned auto-update is disabled on
 Windows. Avoid starting simultaneous automatic updates from multiple OpenCode sessions; use
 `codemem update install` when serialized installation is required.

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -265,7 +265,9 @@ describe("OpenCode startup release notifications", () => {
 
 	test("auto installs an eligible release through the paired package plan", async () => {
 		// Arrange
+		vi.spyOn(process, "platform", "get").mockReturnValue("linux");
 		process.env.CODEMEM_BACKEND_UPDATE_POLICY = "auto";
+		process.env.CODEMEM_UPDATE_ENV_SENTINEL = "preserved";
 		installSpawnResult({ ...availableStatus, auto_update_eligible: true });
 		const showToast = vi.fn().mockResolvedValue(undefined);
 
@@ -277,12 +279,31 @@ describe("OpenCode startup release notifications", () => {
 		const args = spawnMock.mock.calls.map((call) => call[1]);
 		expect(args.some((value) => value?.includes("update") && value?.includes("check"))).toBe(true);
 		expect(spawnMock.mock.calls.some(isPairedInstallCall)).toBe(true);
+		const installCall = spawnMock.mock.calls.find(isPairedInstallCall);
+		expect(installCall?.[2]?.env).toMatchObject({
+			CODEMEM_UPDATE_ENV_SENTINEL: "preserved",
+			ONNXRUNTIME_NODE_INSTALL: "skip",
+		});
 		expect(args.some((value) => value?.join(" ") === "update install --json")).toBe(false);
 		expect(showToast).toHaveBeenCalledTimes(1);
 		expect(showToast.mock.calls[0]?.[0]?.body).toMatchObject({
 			message: "Updated codemem to 0.41.0.",
 			variant: "success",
 		});
+	});
+
+	test("auto leaves the paired install environment unchanged off Linux", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+		process.env.CODEMEM_BACKEND_UPDATE_POLICY = "auto";
+		delete process.env.ONNXRUNTIME_NODE_INSTALL;
+		installSpawnResult({ ...availableStatus, auto_update_eligible: true });
+
+		await startPlugin();
+		await runStartupChecks();
+
+		const installCall = spawnMock.mock.calls.find(isPairedInstallCall);
+		expect(installCall?.[2]?.env).toBe(process.env);
+		expect(installCall?.[2]?.env).not.toHaveProperty("ONNXRUNTIME_NODE_INSTALL");
 	});
 
 	test("auto reports a verification failure instead of claiming update success", async () => {
@@ -440,7 +461,9 @@ describe("OpenCode startup release notifications", () => {
 
 	test("compatibility auto-update restarts the plugin-owned viewer after the refreshed CLI is compatible", async () => {
 		// Arrange
+		vi.spyOn(process, "platform", "get").mockReturnValue("linux");
 		process.env.CODEMEM_BACKEND_UPDATE_POLICY = "auto";
+		process.env.CODEMEM_UPDATE_ENV_SENTINEL = "preserved";
 		process.env.CODEMEM_MIN_VERSION = "0.41.0";
 		process.env.CODEMEM_VIEWER = "1";
 		process.env.CODEMEM_VIEWER_AUTO = "1";
@@ -488,7 +511,13 @@ describe("OpenCode startup release notifications", () => {
 				"codemem@0.41.0",
 				"@codemem/embeddings@0.41.0",
 			],
-			expect.objectContaining({ cwd: "/tmp/codemem" }),
+			expect.objectContaining({
+				cwd: "/tmp/codemem",
+				env: expect.objectContaining({
+					CODEMEM_UPDATE_ENV_SENTINEL: "preserved",
+					ONNXRUNTIME_NODE_INSTALL: "skip",
+				}),
+			}),
 		);
 		expect(
 			spawnMock.mock.calls.some((call) => call[1]?.join(" ") === "update install --json"),

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -388,6 +388,14 @@ const parseReleaseNotification = (result) => {
   }
 };
 
+const resolveAutoUpdateEnvironment = ({
+  platform = process.platform,
+  env = process.env,
+} = {}) => {
+  if (platform !== "linux") return env;
+  return { ...env, ONNXRUNTIME_NODE_INSTALL: "skip" };
+};
+
 const createLogLine = (logPath) => async (line) => {
   if (!logPath) {
     return;
@@ -2469,12 +2477,16 @@ export const CodememPlugin = async ({
   };
 
   const runCommand = async (cmd, options = {}) => {
-    const { stdinText = null, timeoutMs = commandTimeout } = options;
+    const {
+      env = process.env,
+      stdinText = null,
+      timeoutMs = commandTimeout,
+    } = options;
     const [command, ...args] = cmd;
     return new Promise((resolve) => {
       const proc = nodeSpawn(command, args, {
         cwd,
-        env: process.env,
+        env,
         stdio: ["pipe", "pipe", "pipe"],
       });
       let stdout = "";
@@ -2921,7 +2933,10 @@ export const CodememPlugin = async ({
         return;
       }
       await logLine(`compat.auto_update_start cmd=${autoPlan.commandText}`);
-      const updateResult = await runCommand(autoPlan.command, { timeoutMs: 480_000 });
+      const updateResult = await runCommand(autoPlan.command, {
+        env: resolveAutoUpdateEnvironment(),
+        timeoutMs: 480_000,
+      });
       if (updateResult?.exitCode === 0) {
         await logLine(
           `compat.auto_update_result exit=${updateResult?.exitCode ?? "unknown"} stderr=${redactLog(
@@ -3000,7 +3015,10 @@ export const CodememPlugin = async ({
       });
       if (autoPlan.allowed) {
         await logLine(`release.auto_update_start cmd=${autoPlan.commandText}`);
-        const installation = await runCommand(autoPlan.command, { timeoutMs: 480_000 });
+        const installation = await runCommand(autoPlan.command, {
+          env: resolveAutoUpdateEnvironment(),
+          timeoutMs: 480_000,
+        });
         if (installation?.exitCode === 0) {
           const verification = await runCli(["version"]);
           const installedVersion = (verification?.stdout || "").trim();


### PR DESCRIPTION
## Description

Preserves the Linux CPU-only ONNX install policy during plugin auto-updates by adding `ONNXRUNTIME_NODE_INSTALL=skip` without discarding the host environment. Non-Linux update behavior remains unchanged.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced