### PR TITLE
fix(core): persist inline vector identity mapping

### DIFF
--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -397,6 +397,18 @@ describe("memory command scope safety", () => {
 		vi.mocked(embeddings.getEmbeddingClient).mockResolvedValue({
 			model: "test-model",
 			dimensions: 384,
+			identity: {
+				package: "@huggingface/transformers",
+				version: "4.2.0",
+				model: "test-model",
+				revision: "0123456789abcdef0123456789abcdef01234567",
+				requestedRevision: "test-revision",
+				dtype: "fp32",
+				device: "cpu",
+				pooling: "mean",
+				normalization: "l2",
+				dimensions: 384,
+			},
 			embed: vi.fn(),
 		});
 		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);

--- a/packages/core/src/vectors-inline-identity.test.ts
+++ b/packages/core/src/vectors-inline-identity.test.ts
@@ -1,0 +1,158 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadDistillVectorFeatures } from "./distill.js";
+import {
+	_resetEmbeddingClient,
+	_resetEmbeddingRuntimeFactory,
+	_setEmbeddingRuntimeFactory,
+	resolveEmbeddingVectorIdentityLabel,
+} from "./embeddings.js";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
+import { ensureVectorSchema } from "./schema-bootstrap.js";
+import { MemoryStore } from "./store.js";
+import { storeVectors } from "./vectors.js";
+
+const REQUESTED_MODEL = "example/custom-embedding-model";
+const REQUESTED_REVISION = "mutable-release";
+const CANONICAL_REVISION = "0123456789abcdef0123456789abcdef01234567";
+const EXPECTED_VECTOR = new Float32Array(384).fill(0.25);
+
+describe("inline vector identity persistence", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+	let previousDisabled: string | undefined;
+	let previousModel: string | undefined;
+	let previousRevision: string | undefined;
+	let runtimeLoads: number;
+
+	beforeEach(() => {
+		previousDisabled = process.env.CODEMEM_EMBEDDING_DISABLED;
+		previousModel = process.env.CODEMEM_EMBEDDING_MODEL;
+		previousRevision = process.env.CODEMEM_EMBEDDING_REVISION;
+		process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+		process.env.CODEMEM_EMBEDDING_MODEL = REQUESTED_MODEL;
+		process.env.CODEMEM_EMBEDDING_REVISION = REQUESTED_REVISION;
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-inline-vector-identity-"));
+		dbPath = join(tmpDir, "test.sqlite");
+		store = new MemoryStore(dbPath);
+		runtimeLoads = 0;
+		_setEmbeddingRuntimeFactory(async () => {
+			runtimeLoads++;
+			return {
+				model: REQUESTED_MODEL,
+				dimensions: 384,
+				identity: {
+					package: "@huggingface/transformers",
+					version: "4.2.0",
+					model: REQUESTED_MODEL,
+					revision: CANONICAL_REVISION,
+					requestedRevision: REQUESTED_REVISION,
+					dtype: "fp32",
+					device: "cpu",
+					pooling: "mean",
+					normalization: "l2",
+					dimensions: 384,
+				},
+				embed: async (texts) => texts.map(() => EXPECTED_VECTOR.slice()),
+			};
+		});
+	});
+
+	afterEach(() => {
+		store.close();
+		_resetEmbeddingRuntimeFactory();
+		if (previousDisabled === undefined) delete process.env.CODEMEM_EMBEDDING_DISABLED;
+		else process.env.CODEMEM_EMBEDDING_DISABLED = previousDisabled;
+		if (previousModel === undefined) delete process.env.CODEMEM_EMBEDDING_MODEL;
+		else process.env.CODEMEM_EMBEDDING_MODEL = previousModel;
+		if (previousRevision === undefined) delete process.env.CODEMEM_EMBEDDING_REVISION;
+		else process.env.CODEMEM_EMBEDDING_REVISION = previousRevision;
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	async function writeInlineVector(): Promise<number> {
+		const sessionId = store.startSession({ project: "codemem" });
+		const memoryId = store.remember(sessionId, "decision", "Canonical inline identity", "Body");
+		await store.flushPendingVectorWrites();
+		delete process.env.CODEMEM_EMBEDDING_DISABLED;
+		ensureVectorSchema(store.db);
+		await storeVectors(store.db, memoryId, "Canonical inline identity", "Body");
+		return memoryId;
+	}
+
+	it("maps a mutable request to the canonical vector label and maintenance identity", async () => {
+		const memoryId = await writeInlineVector();
+		const targetModel = resolveEmbeddingVectorIdentityLabel(REQUESTED_MODEL, CANONICAL_REVISION);
+		const row = store.db
+			.prepare("SELECT model FROM memory_vectors WHERE memory_id = ?")
+			.get(memoryId);
+
+		expect({
+			row,
+			metadata: getMaintenanceJob(store.db, "vector_model_identity")?.metadata,
+		}).toEqual({
+			row: { model: targetModel },
+			metadata: {
+				target_model: targetModel,
+				requested_model: REQUESTED_MODEL,
+				requested_revision: REQUESTED_REVISION,
+			},
+		});
+	});
+
+	it("keeps inline vectors discoverable after runtime client state is reset", async () => {
+		const memoryId = await writeInlineVector();
+		_resetEmbeddingClient();
+		store.close();
+		store = new MemoryStore(dbPath);
+		const item = store.get(memoryId);
+		if (!item) throw new Error("expected inline-vector memory");
+
+		const [feature] = loadDistillVectorFeatures(store, [item]);
+
+		expect(feature?.vector).toEqual(EXPECTED_VECTOR);
+		expect(runtimeLoads).toBe(1);
+	});
+
+	it("does not rewrite an unchanged completed identity job", async () => {
+		const memoryId = await writeInlineVector();
+		store.db
+			.prepare("UPDATE maintenance_jobs SET updated_at = ? WHERE kind = 'vector_model_identity'")
+			.run("2000-01-01T00:00:00.000Z");
+
+		await storeVectors(store.db, memoryId, "Canonical inline identity", "Body");
+
+		expect(getMaintenanceJob(store.db, "vector_model_identity")?.updated_at).toBe(
+			"2000-01-01T00:00:00.000Z",
+		);
+	});
+
+	it("rolls back inline vectors when identity persistence fails", async () => {
+		const sessionId = store.startSession({ project: "codemem" });
+		const memoryId = store.remember(sessionId, "decision", "Atomic inline identity", "Body");
+		await store.flushPendingVectorWrites();
+		delete process.env.CODEMEM_EMBEDDING_DISABLED;
+		ensureVectorSchema(store.db);
+		getMaintenanceJob(store.db, "vector_model_identity");
+		store.db.exec(`
+			CREATE TRIGGER fail_vector_identity_insert
+			BEFORE INSERT ON maintenance_jobs
+			WHEN NEW.kind = 'vector_model_identity'
+			BEGIN
+				SELECT RAISE(ABORT, 'identity write failed');
+			END;
+		`);
+
+		await expect(
+			storeVectors(store.db, memoryId, "Atomic inline identity", "Body"),
+		).rejects.toThrow("identity write failed");
+
+		const vectorCount = store.db
+			.prepare("SELECT COUNT(*) AS count FROM memory_vectors WHERE memory_id = ?")
+			.get(memoryId) as { count: number };
+		expect(vectorCount.count).toBe(0);
+	});
+});

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -1584,11 +1584,7 @@ describe("memory_vectors bootstrap on fresh databases", () => {
 		prevCodememConfig = process.env.CODEMEM_CONFIG;
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-vec-bootstrap-test-"));
 		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
-		vi.mocked(embeddings.getEmbeddingClient).mockResolvedValue({
-			model: "test-model",
-			dimensions: 384,
-			embed: vi.fn(async () => [new Float32Array(384)]),
-		});
+		vi.mocked(embeddings.getEmbeddingClient).mockResolvedValue(injectedBackfillClient());
 		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
 	});
 

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -165,23 +165,28 @@ function tryResolveConfiguredVectorIdentityLabel(db: Database): string | null {
 	return null;
 }
 
-function persistBackfillVectorIdentity(
-	db: Database,
-	client: EmbeddingClient,
-	targetModel: string,
-): void {
+function persistVectorIdentity(db: Database, client: EmbeddingClient, targetModel: string): void {
 	if (!client.identity) {
-		throw new TypeError("Embedding runtime identity is required to persist backfill metadata");
+		throw new TypeError("Embedding runtime identity is required to persist vector metadata");
 	}
 	const metadata = {
 		target_model: targetModel,
 		requested_model: client.model,
 		requested_revision: client.identity.requestedRevision ?? client.identity.revision,
 	};
+	const existing = getMaintenanceJob(db, VECTOR_MODEL_IDENTITY_JOB);
+	if (
+		existing?.status === "completed" &&
+		existing.metadata?.target_model === metadata.target_model &&
+		existing.metadata.requested_model === metadata.requested_model &&
+		existing.metadata.requested_revision === metadata.requested_revision
+	) {
+		return;
+	}
 	startMaintenanceJob(db, {
 		kind: VECTOR_MODEL_IDENTITY_JOB,
 		title: "Embedding vector identity",
-		message: "Recorded the canonical embedding identity used by vector backfill",
+		message: "Recorded the canonical embedding identity used by vector writes",
 		progressTotal: 1,
 		metadata,
 	});
@@ -279,6 +284,30 @@ export function memoryHasCompleteVectorCoverage(
 		.prepare("SELECT content_hash FROM memory_vectors WHERE memory_id = ? AND model = ?")
 		.all(memory.id, model) as Array<{ content_hash: string | null }>;
 	return expectedHashesExist(expectedHashes, existingRows);
+}
+
+export function findMemoryIdsWithCompleteActiveVectorCoverage(
+	db: Database,
+	memoryIds: number[],
+	model: string,
+): number[] {
+	const ids = uniqueMemoryIds(memoryIds);
+	if (ids.length === 0) return [];
+	const placeholders = ids.map(() => "?").join(", ");
+	const memories = db
+		.prepare(
+			`SELECT id, title, body_text FROM memory_items
+			 WHERE active = 1 AND id IN (${placeholders})`,
+		)
+		.all(...ids) as MemoryTextRow[];
+	const incompleteIds = new Set(
+		memories
+			.filter((memory) => !memoryHasCompleteVectorCoverage(db, memory, model))
+			.map((memory) => memory.id),
+	);
+	// Missing or inactive memories have no active coverage work and must not
+	// remain queued forever. Their deletion work is tracked separately.
+	return ids.filter((memoryId) => !incompleteIds.has(memoryId));
 }
 
 function expectedHashesExist(
@@ -961,6 +990,7 @@ export async function storeVectors(
 ): Promise<void> {
 	const client = await getEmbeddingClient();
 	if (!client) return;
+	assertEmbeddingClientIdentity(client);
 
 	const text = `${title}\n${bodyText}`.trim();
 	const chunks = chunkText(text);
@@ -970,11 +1000,12 @@ export async function storeVectors(
 	if (embeddings.length === 0) return;
 
 	const model = resolveEmbeddingClientVectorIdentityLabel(client);
-	const insertVectors = db.transaction(
+	const persistVectors = db.transaction(
 		(entries: Array<{ vector: Float32Array; chunkIndex: number; contentHash: string }>) => {
 			for (const entry of entries) {
 				insertMemoryVector(db, entry.vector, memoryId, entry.chunkIndex, entry.contentHash, model);
 			}
+			persistVectorIdentity(db, client, model);
 		},
 	);
 	const entries: Array<{ vector: Float32Array; chunkIndex: number; contentHash: string }> = [];
@@ -986,7 +1017,8 @@ export async function storeVectors(
 		if (!chunk) continue;
 		entries.push({ vector, chunkIndex: i, contentHash: hashText(chunk) });
 	}
-	if (entries.length > 0) insertVectors(entries);
+	if (entries.length === 0) return;
+	persistVectors.immediate(entries);
 }
 
 // ---------------------------------------------------------------------------
@@ -1196,7 +1228,7 @@ export async function backfillVectors(
 	}
 
 	if (!dryRun && (inserted > 0 || skipped > 0)) {
-		persistBackfillVectorIdentity(db, client, model);
+		persistVectorIdentity(db, client, model);
 	}
 	return { checked, embedded, inserted, skipped };
 }


### PR DESCRIPTION
## Description

Persists the requested-to-canonical embedding identity mapping after inline vector writes. Vector rows and identity metadata now commit atomically, invalid clients fail before inference, and identical completed identity jobs remain untouched.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced