### PR TITLE
fix(core): retain stale queued vector upserts

### DIFF
--- a/packages/core/src/vector-migration-queue-coverage.test.ts
+++ b/packages/core/src/vector-migration-queue-coverage.test.ts
@@ -1,0 +1,250 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as embeddings from "./embeddings.js";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+import {
+	queueVectorBackfillForIncrementalSync,
+	runVectorMigrationPass,
+	VECTOR_MODEL_MIGRATION_JOB,
+} from "./vector-migration.js";
+import * as vectors from "./vectors.js";
+
+vi.mock("./embeddings.js", async () => {
+	const actual = await vi.importActual<typeof import("./embeddings.js")>("./embeddings.js");
+	return {
+		...actual,
+		getEmbeddingClient: vi.fn(),
+		embedTexts: vi.fn(),
+		resolveEmbeddingClientVectorIdentityLabel: vi.fn(() => "test-model"),
+		tryResolveEmbeddingVectorIdentityLabel: vi.fn(() => "test-model"),
+	};
+});
+
+vi.mock("./vectors.js", async () => {
+	const actual = await vi.importActual<typeof import("./vectors.js")>("./vectors.js");
+	return {
+		...actual,
+		pruneStaleCurrentModelVectors: vi.fn(actual.pruneStaleCurrentModelVectors),
+	};
+});
+
+function seedMemory(db: Database, id: number, sessionId: number, body: string): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO memory_items(id, session_id, kind, title, body_text, confidence,
+		 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+		 VALUES (?, ?, 'feature', ?, ?, 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+	).run(id, sessionId, `Memory ${id}`, body, now, now);
+}
+
+let db: Database;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	db = new Database(":memory:");
+	initTestSchema(db);
+	vi.mocked(embeddings.getEmbeddingClient).mockResolvedValue({
+		model: "test-model",
+		dimensions: 384,
+		identity: {
+			package: "@huggingface/transformers",
+			version: "4.2.0",
+			model: "test-model",
+			revision: "0123456789abcdef0123456789abcdef01234567",
+			requestedRevision: "test-revision",
+			dtype: "fp32",
+			device: "cpu",
+			pooling: "mean",
+			normalization: "l2",
+			dimensions: 384,
+		},
+		embed: vi.fn(),
+	});
+	vi.mocked(embeddings.embedTexts).mockImplementation(async (texts) =>
+		texts.map(() => new Float32Array(384)),
+	);
+});
+
+afterEach(() => {
+	db.close();
+});
+
+describe("queued vector coverage reconciliation", () => {
+	it("retains an in-flight upsert when content changes before inference returns", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "Original body");
+		queueVectorBackfillForIncrementalSync(db, {
+			upsertMemoryIds: [1],
+			deleteMemoryIds: [],
+		});
+		vi.mocked(embeddings.embedTexts).mockImplementationOnce(async (texts) => {
+			db.prepare("UPDATE memory_items SET body_text = ? WHERE id = ?").run("Updated body", 1);
+			return texts.map(() => new Float32Array(384));
+		});
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
+			status: "running",
+			metadata: { pending_upsert_memory_ids: [1] },
+		});
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		expect(
+			db
+				.prepare("SELECT content_hash FROM memory_vectors WHERE memory_id = ? AND model = ?")
+				.all(1, "test-model"),
+		).toEqual([{ content_hash: embeddings.hashText("Memory 1\nUpdated body") }]);
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
+			status: "completed",
+			metadata: { pending_upsert_memory_ids: [] },
+		});
+	});
+
+	it("dequeues covered IDs while retaining redacted and concurrently queued IDs", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "Stable body");
+		seedMemory(db, 2, sessionId, "Sensitive body");
+		seedMemory(db, 3, sessionId, "Arrived concurrently");
+		queueVectorBackfillForIncrementalSync(db, {
+			upsertMemoryIds: [1, 2],
+			deleteMemoryIds: [],
+		});
+		vi.mocked(embeddings.embedTexts).mockImplementationOnce(async (texts) => {
+			db.prepare("UPDATE memory_items SET body_text = ? WHERE id = ?").run("[REDACTED]", 2);
+			queueVectorBackfillForIncrementalSync(db, {
+				upsertMemoryIds: [3],
+				deleteMemoryIds: [],
+			});
+			return texts.map(() => new Float32Array(384));
+		});
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
+			status: "running",
+			metadata: { pending_upsert_memory_ids: [2, 3] },
+		});
+	});
+});
+
+describe("queued vector finalization pruning", () => {
+	it("re-prunes final content before discarding a newly covered requeue", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "Initial body");
+		const insertVector = db.prepare(
+			"INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model) VALUES (?, ?, ?, ?, ?)",
+		);
+		insertVector.run(
+			Buffer.alloc(384 * Float32Array.BYTES_PER_ELEMENT),
+			1n,
+			1n,
+			embeddings.hashText("Memory 1\nStale body"),
+			"test-model",
+		);
+		insertVector.run(
+			Buffer.alloc(384 * Float32Array.BYTES_PER_ELEMENT),
+			1n,
+			0n,
+			embeddings.hashText("Memory 1\nFinal body"),
+			"test-model",
+		);
+		queueVectorBackfillForIncrementalSync(db, {
+			upsertMemoryIds: [1],
+			deleteMemoryIds: [],
+		});
+		vi.mocked(embeddings.embedTexts).mockImplementationOnce(async (texts) => {
+			db.prepare("UPDATE memory_items SET body_text = ? WHERE id = ?").run("Intermediate body", 1);
+			return texts.map(() => new Float32Array(384));
+		});
+		const actualVectors = await vi.importActual<typeof import("./vectors.js")>("./vectors.js");
+		vi.mocked(vectors.pruneStaleCurrentModelVectors).mockImplementationOnce(
+			(database, memoryIds, model) => {
+				const deleted = actualVectors.pruneStaleCurrentModelVectors(database, memoryIds, model);
+				database.prepare("UPDATE memory_items SET body_text = ? WHERE id = ?").run("Final body", 1);
+				queueVectorBackfillForIncrementalSync(database, {
+					upsertMemoryIds: [1],
+					deleteMemoryIds: [],
+				});
+				return deleted;
+			},
+		);
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		expect(
+			db
+				.prepare("SELECT content_hash FROM memory_vectors WHERE memory_id = ? AND model = ?")
+				.all(1, "test-model"),
+		).toEqual([{ content_hash: embeddings.hashText("Memory 1\nFinal body") }]);
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
+			status: "completed",
+			metadata: { pending_upsert_memory_ids: [] },
+		});
+	});
+});
+
+describe("queued vector concurrency reconciliation", () => {
+	it("merges changes queued through another connection during inference", async () => {
+		const dbDir = mkdtempSync(join(tmpdir(), "codemem-vector-queue-"));
+		const dbPath = join(dbDir, "queue.sqlite");
+		const fileDb = new Database(dbPath);
+		const writerDb = new Database(dbPath);
+		try {
+			initTestSchema(fileDb);
+			const sessionId = insertTestSession(fileDb);
+			seedMemory(fileDb, 1, sessionId, "Original body");
+			seedMemory(fileDb, 2, sessionId, "Arrived concurrently");
+			queueVectorBackfillForIncrementalSync(fileDb, {
+				upsertMemoryIds: [1],
+				deleteMemoryIds: [],
+			});
+			vi.mocked(embeddings.embedTexts).mockImplementationOnce(async (texts) => {
+				writerDb
+					.prepare("UPDATE memory_items SET body_text = ? WHERE id = ?")
+					.run("Updated body", 1);
+				queueVectorBackfillForIncrementalSync(writerDb, {
+					upsertMemoryIds: [1, 2],
+					deleteMemoryIds: [],
+				});
+				return texts.map(() => new Float32Array(384));
+			});
+
+			await runVectorMigrationPass(fileDb, { batchSize: 10 });
+
+			expect(getMaintenanceJob(fileDb, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
+				status: "running",
+				metadata: { pending_upsert_memory_ids: [1, 2], queue_revision: 2 },
+			});
+		} finally {
+			writerDb.close();
+			fileDb.close();
+			rmSync(dbDir, { recursive: true, force: true });
+		}
+	});
+
+	it("dequeues an in-flight memory that becomes inactive", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "Original body");
+		queueVectorBackfillForIncrementalSync(db, {
+			upsertMemoryIds: [1],
+			deleteMemoryIds: [],
+		});
+		vi.mocked(embeddings.embedTexts).mockImplementationOnce(async (texts) => {
+			db.prepare("UPDATE memory_items SET active = 0 WHERE id = ?").run(1);
+			return texts.map(() => new Float32Array(384));
+		});
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
+			status: "completed",
+			metadata: { pending_upsert_memory_ids: [] },
+		});
+	});
+});

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -18,6 +18,7 @@ import type { ReplicationVectorWork } from "./sync-replication.js";
 import {
 	backfillVectors,
 	countIncompleteActiveMemoryVectorCoverage,
+	findMemoryIdsWithCompleteActiveVectorCoverage,
 	pruneObsoleteTargetModelVectors,
 	pruneStaleCurrentModelVectors,
 } from "./vectors.js";
@@ -115,6 +116,159 @@ function sameQueuedSyncWork(a: MigrationMetadata, b: MigrationMetadata): boolean
 	);
 }
 
+function buildDrainedQueuedSyncMetadata(options: {
+	metadata: MigrationMetadata;
+	pendingUpsertMemoryIds: number[];
+	batchUpsertMemoryIds: number[];
+	coveredBatchUpsertMemoryIds: Set<number>;
+	client: EmbeddingClient;
+	targetModel: string;
+	prunedRows: number;
+}): MigrationMetadata {
+	const targetChanged =
+		options.metadata.target_model != null && options.metadata.target_model !== options.targetModel;
+	const retainedMetadata: MigrationMetadata = targetChanged
+		? {
+				trigger: options.metadata.trigger,
+				pending_delete_memory_ids: options.metadata.pending_delete_memory_ids,
+				pending_upsert_memory_ids: options.metadata.pending_upsert_memory_ids,
+				source_model: null,
+				last_cursor_id: 0,
+				processed_embeddable: 0,
+			}
+		: options.metadata;
+	const retainedBatchUpserts = options.batchUpsertMemoryIds.filter(
+		(memoryId) => !options.coveredBatchUpsertMemoryIds.has(memoryId),
+	);
+	return {
+		...retainedMetadata,
+		target_model: options.targetModel,
+		requested_model: options.client.model,
+		requested_revision:
+			options.client.identity?.requestedRevision ?? options.client.identity?.revision ?? null,
+		removed_stale_rows: Number(options.metadata.removed_stale_rows ?? 0) + options.prunedRows,
+		pending_delete_memory_ids: [],
+		pending_upsert_memory_ids: [
+			...retainedBatchUpserts,
+			...options.pendingUpsertMemoryIds.slice(options.batchUpsertMemoryIds.length),
+		],
+	};
+}
+
+function pendingQueuedSyncCount(metadata: MigrationMetadata): number {
+	return (
+		metadataMemoryIds(metadata.pending_delete_memory_ids).length +
+		metadataMemoryIds(metadata.pending_upsert_memory_ids).length
+	);
+}
+
+function shouldCompleteIncrementalSync(
+	db: SqliteDatabase,
+	metadata: MigrationMetadata,
+	targetModel: string,
+): boolean {
+	if (pendingQueuedSyncCount(metadata) > 0) return false;
+	if (hasSourceModelVectors(db, targetModel)) return false;
+	return (
+		(metadata.trigger ?? SYNC_INCREMENTAL_TRIGGER) === SYNC_INCREMENTAL_TRIGGER &&
+		!metadata.source_model &&
+		!metadata.last_cursor_id &&
+		metadata.embeddable_total == null
+	);
+}
+
+function writeQueuedSyncResult(
+	db: SqliteDatabase,
+	job: NonNullable<ReturnType<typeof getMaintenanceJob>>,
+	metadata: MigrationMetadata,
+	targetModel: string,
+): { completed: boolean; metadata: MigrationMetadata } {
+	const remainingWorkCount = pendingQueuedSyncCount(metadata);
+	if (shouldCompleteIncrementalSync(db, metadata, targetModel)) {
+		completeMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
+			message: "Finished vector catch-up for incremental sync data",
+			progressCurrent: 0,
+			progressTotal: null,
+			metadata,
+		});
+		return { completed: true, metadata };
+	}
+
+	updateMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
+		status: remainingWorkCount > 0 ? "running" : job.status,
+		message:
+			remainingWorkCount > 0
+				? `Queued vector catch-up has ${remainingWorkCount} memory change(s) remaining`
+				: job.message,
+		progressCurrent: 0,
+		progressTotal: null,
+		metadata,
+	});
+	return { completed: false, metadata };
+}
+
+function finalizeQueuedSyncVectorWork(
+	db: SqliteDatabase,
+	options: {
+		job: NonNullable<ReturnType<typeof getMaintenanceJob>>;
+		metadata: MigrationMetadata;
+		pendingUpsertMemoryIds: number[];
+		batchUpsertMemoryIds: number[];
+		client: EmbeddingClient;
+		targetModel: string;
+		prunedRows: number;
+	},
+): { completed: boolean; metadata: MigrationMetadata } {
+	return db
+		.transaction(() => {
+			const coveredBatchUpsertMemoryIds = new Set(
+				findMemoryIdsWithCompleteActiveVectorCoverage(
+					db,
+					options.batchUpsertMemoryIds,
+					options.targetModel,
+				),
+			);
+			const latestJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+			const latestMetadata = (latestJob?.metadata ?? {}) as MigrationMetadata;
+			const queuedWorkChanged = !sameQueuedSyncWork(latestMetadata, options.metadata);
+			let prunedRows = options.prunedRows;
+			if (queuedWorkChanged) {
+				const coveredRequeuedMemoryIds = metadataMemoryIds(
+					latestMetadata.pending_upsert_memory_ids,
+				).filter((memoryId) => coveredBatchUpsertMemoryIds.has(memoryId));
+				prunedRows += pruneStaleCurrentModelVectors(
+					db,
+					coveredRequeuedMemoryIds,
+					options.targetModel,
+				);
+			}
+			const drainedMetadata = buildDrainedQueuedSyncMetadata({
+				...options,
+				coveredBatchUpsertMemoryIds,
+				prunedRows,
+			});
+			let nextMetadata = drainedMetadata;
+			if (queuedWorkChanged) {
+				const latestPendingUpserts = metadataMemoryIds(
+					latestMetadata.pending_upsert_memory_ids,
+				).filter((memoryId) => !coveredBatchUpsertMemoryIds.has(memoryId));
+				nextMetadata = {
+					...drainedMetadata,
+					...mergeQueuedSyncMemoryIds(
+						{ ...latestMetadata, pending_upsert_memory_ids: latestPendingUpserts },
+						{
+							upsertMemoryIds: metadataMemoryIds(drainedMetadata.pending_upsert_memory_ids),
+							deleteMemoryIds: metadataMemoryIds(drainedMetadata.pending_delete_memory_ids),
+						},
+					),
+					queue_revision: latestMetadata.queue_revision,
+				};
+			}
+			return writeQueuedSyncResult(db, options.job, nextMetadata, options.targetModel);
+		})
+		.immediate();
+}
+
 export function wakeActiveVectorMigrationRunner(): void {
 	activeRunner?.wake();
 }
@@ -131,54 +285,55 @@ export function queueVectorBackfillForIncrementalSync(
 		return;
 	}
 
-	const existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
-	const jobMetadata = (existingJob?.metadata ?? {}) as MigrationMetadata;
-	let existingMetadata: MigrationMetadata = {};
-	if (existingJob && existingJob.status !== "completed" && existingJob.status !== "cancelled") {
-		existingMetadata = jobMetadata;
-	} else if (jobMetadata.cleanup_pending) {
-		existingMetadata = {
-			cleanup_pending: true,
-			target_model: jobMetadata.target_model,
-			requested_model: jobMetadata.requested_model,
-			requested_revision: jobMetadata.requested_revision,
-			removed_stale_rows: jobMetadata.removed_stale_rows,
-			queue_revision: jobMetadata.queue_revision,
+	db.transaction(() => {
+		const existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		const jobMetadata = (existingJob?.metadata ?? {}) as MigrationMetadata;
+		let existingMetadata: MigrationMetadata = {};
+		if (existingJob && existingJob.status !== "completed" && existingJob.status !== "cancelled") {
+			existingMetadata = jobMetadata;
+		} else if (jobMetadata.cleanup_pending) {
+			existingMetadata = {
+				cleanup_pending: true,
+				target_model: jobMetadata.target_model,
+				requested_model: jobMetadata.requested_model,
+				requested_revision: jobMetadata.requested_revision,
+				removed_stale_rows: jobMetadata.removed_stale_rows,
+				queue_revision: jobMetadata.queue_revision,
+			};
+		}
+		const metadata: MigrationMetadata = {
+			...existingMetadata,
+			...mergeQueuedSyncMemoryIds(existingMetadata, work),
+			queue_revision: Number(existingMetadata.queue_revision ?? 0) + 1,
+			trigger: existingMetadata.trigger ?? SYNC_INCREMENTAL_TRIGGER,
 		};
-	}
-	const metadata: MigrationMetadata = {
-		...existingMetadata,
-		...mergeQueuedSyncMemoryIds(existingMetadata, work),
-		queue_revision: Number(existingMetadata.queue_revision ?? 0) + 1,
-		trigger: existingMetadata.trigger ?? SYNC_INCREMENTAL_TRIGGER,
-	};
-	const pendingWorkCount =
-		metadataMemoryIds(metadata.pending_upsert_memory_ids).length +
-		metadataMemoryIds(metadata.pending_delete_memory_ids).length;
+		const pendingWorkCount =
+			metadataMemoryIds(metadata.pending_upsert_memory_ids).length +
+			metadataMemoryIds(metadata.pending_delete_memory_ids).length;
 
-	if (!existingJob || existingJob.status === "completed" || existingJob.status === "cancelled") {
-		startMaintenanceJob(db, {
-			kind: VECTOR_MODEL_MIGRATION_JOB,
-			title: "Re-indexing memories",
+		if (!existingJob || existingJob.status === "completed" || existingJob.status === "cancelled") {
+			startMaintenanceJob(db, {
+				kind: VECTOR_MODEL_MIGRATION_JOB,
+				title: "Re-indexing memories",
+				status: "pending",
+				message: "Queued vector catch-up for incremental sync data",
+				progressTotal: null,
+				metadata,
+			});
+			return;
+		}
+
+		updateMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
 			status: "pending",
 			message: "Queued vector catch-up for incremental sync data",
-			progressTotal: null,
+			progressCurrent:
+				existingJob.status === "failed"
+					? 0
+					: Math.min(existingJob.progress.current, pendingWorkCount),
+			progressTotal: existingJob.progress.total,
 			metadata,
 		});
-		wakeActiveVectorMigrationRunner();
-		return;
-	}
-
-	updateMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
-		status: "pending",
-		message: "Queued vector catch-up for incremental sync data",
-		progressCurrent:
-			existingJob.status === "failed"
-				? 0
-				: Math.min(existingJob.progress.current, pendingWorkCount),
-		progressTotal: existingJob.progress.total,
-		metadata,
-	});
+	}).immediate();
 	wakeActiveVectorMigrationRunner();
 }
 
@@ -213,72 +368,15 @@ async function runQueuedSyncVectorWork(
 		}
 		prunedRows = pruneStaleCurrentModelVectors(db, batchUpsertMemoryIds, targetModel);
 	}
-
-	const targetChanged = metadata.target_model != null && metadata.target_model !== targetModel;
-	const retainedMetadata: MigrationMetadata = targetChanged
-		? {
-				trigger: metadata.trigger,
-				pending_delete_memory_ids: metadata.pending_delete_memory_ids,
-				pending_upsert_memory_ids: metadata.pending_upsert_memory_ids,
-				source_model: null,
-				last_cursor_id: 0,
-				processed_embeddable: 0,
-			}
-		: metadata;
-	const drainedMetadata: MigrationMetadata = {
-		...retainedMetadata,
-		target_model: targetModel,
-		requested_model: client.model,
-		requested_revision: client.identity?.requestedRevision ?? client.identity?.revision ?? null,
-		removed_stale_rows: Number(metadata.removed_stale_rows ?? 0) + prunedRows,
-		pending_delete_memory_ids: [],
-		pending_upsert_memory_ids: pendingUpsertMemoryIds.slice(batchUpsertMemoryIds.length),
-	};
-	const latestJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
-	const latestMetadata = (latestJob?.metadata ?? {}) as MigrationMetadata;
-	const nextMetadata = sameQueuedSyncWork(latestMetadata, metadata)
-		? drainedMetadata
-		: {
-				...drainedMetadata,
-				...mergeQueuedSyncMemoryIds(latestMetadata, {
-					upsertMemoryIds: metadataMemoryIds(drainedMetadata.pending_upsert_memory_ids),
-					deleteMemoryIds: metadataMemoryIds(drainedMetadata.pending_delete_memory_ids),
-				}),
-				queue_revision: latestMetadata.queue_revision,
-			};
-	const remainingWorkCount =
-		metadataMemoryIds(nextMetadata.pending_delete_memory_ids).length +
-		metadataMemoryIds(nextMetadata.pending_upsert_memory_ids).length;
-	const requiresLegacyRebuild =
-		remainingWorkCount === 0 && detectSourceModel(db, targetModel) != null;
-	const incrementalOnly =
-		(nextMetadata.trigger ?? SYNC_INCREMENTAL_TRIGGER) === SYNC_INCREMENTAL_TRIGGER &&
-		!nextMetadata.source_model &&
-		!nextMetadata.last_cursor_id &&
-		nextMetadata.embeddable_total == null &&
-		!requiresLegacyRebuild;
-
-	if (remainingWorkCount === 0 && incrementalOnly) {
-		completeMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
-			message: "Finished vector catch-up for incremental sync data",
-			progressCurrent: 0,
-			progressTotal: null,
-			metadata: nextMetadata,
-		});
-		return { completed: true, metadata: nextMetadata };
-	}
-
-	updateMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
-		status: remainingWorkCount > 0 ? "running" : job.status,
-		message:
-			remainingWorkCount > 0
-				? `Queued vector catch-up has ${remainingWorkCount} memory change(s) remaining`
-				: job.message,
-		progressCurrent: 0,
-		progressTotal: null,
-		metadata: nextMetadata,
+	return finalizeQueuedSyncVectorWork(db, {
+		job,
+		metadata,
+		pendingUpsertMemoryIds,
+		batchUpsertMemoryIds,
+		client,
+		targetModel,
+		prunedRows,
 	});
-	return { completed: false, metadata: nextMetadata };
 }
 
 export function queueVectorBackfillForSyncBootstrap(


### PR DESCRIPTION
## Description

Revalidates queued vector coverage before removing completed backfill entries. Concurrent mutation or redaction now retains stale work for retry instead of silently losing required vector updates.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced