### PR TITLE
fix(embeddings): allow offline commit-pinned models

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ For cross-network setups where peer addresses change frequently or mDNS does not
 
 ## Semantic recall
 
-Embeddings are stored in sqlite-vec and written automatically when memories are created. Use `codemem embed` to backfill existing memories. A custom `CODEMEM_EMBEDDING_MODEL` requires `CODEMEM_EMBEDDING_REVISION`; mutable branches and tags resolve to their canonical commit before vectors are labeled, while an explicit 40-character commit works offline. Changing either value triggers a background rebuild and uses keyword search until incompatible migrations finish. If sqlite-vec cannot load, keyword search still works.
+Embeddings are stored in sqlite-vec and written automatically when memories are created. Use `codemem embed` to backfill existing memories. A custom `CODEMEM_EMBEDDING_MODEL` requires `CODEMEM_EMBEDDING_REVISION`; mutable branches and tags resolve to their canonical commit before vectors are labeled. Set `CODEMEM_EMBEDDING_OFFLINE=1` with an explicit 40-character commit to load only cached model files without a Hub request. Changing the model or revision triggers a background rebuild and uses keyword search until incompatible migrations finish. If sqlite-vec cannot load, keyword search still works.
 
 ## Alternative install methods
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,6 +133,9 @@ cutover. Custom model repositories require an explicit
 `CODEMEM_EMBEDDING_REVISION`. The runtime resolves mutable Hub refs to a
 canonical 40-character commit before it embeds or labels vectors; offline and
 local-model configurations must provide that canonical identity directly.
+`CODEMEM_EMBEDDING_OFFLINE=1` maps Codemem's offline mode to Transformers.js'
+`allowRemoteModels=false`, preventing both canonicalization and model-download
+requests while allowing cached commit-pinned models to load.
 Synchronous FTS-only paths do not perform network resolution and remain pending
 until runtime-resolved identity metadata is available.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -525,7 +525,12 @@ branch, tag, or full 40-character commit SHA. The runtime resolves mutable refs
 to their canonical Hugging Face commit before labeling vectors, preventing old
 and new embedding spaces from sharing an identity. A custom model without a
 revision is rejected; offline or local-model use requires the full commit-style
-identity because Codemem cannot resolve a mutable ref without the Hub.
+identity because Codemem cannot resolve a mutable ref without the Hub. Set
+`CODEMEM_EMBEDDING_OFFLINE=1` to disable remote model requests and load that
+commit only from the Transformers.js cache. Clear the variable before using a
+mutable branch or tag so Codemem can resolve it to a canonical commit.
+Viewer and OpenCode profile checks include this setting, so clients do not send
+prompt content to an already-running viewer configured for online model access.
 `CODEMEM_EMBEDDING_REVISION` can also override the default model revision when
 an intentional rebuild is required.
 

--- a/packages/cli/.opencode/tests/plugin-transform-hook.test.js
+++ b/packages/cli/.opencode/tests/plugin-transform-hook.test.js
@@ -61,11 +61,15 @@ test("OpenCode identity targeting matches the core contract for absolute paths",
 		CODEMEM_WORKSPACE_ID: "workspace-1",
 		CODEMEM_PACK_COMPRESSION: "ids",
 		CODEMEM_EMBEDDING_DISABLED: "yes",
+		CODEMEM_EMBEDDING_OFFLINE: "YES",
 		CODEMEM_EMBEDDING_MODEL: "model-1",
 		CODEMEM_EMBEDDING_REVISION: "revision-1",
 	};
 	const { __testUtils } = await import("../plugins/codemem.js");
 	expect(__testUtils.buildViewerIdentityTarget(env, root)).toEqual(buildViewerIdentityTarget(env));
+	expect(__testUtils.buildViewerIdentityTarget(env, root)).toMatchObject({
+		embedding_offline: true,
+	});
 });
 
 test("OpenCode identity targeting preserves a missing custom-model revision as null", async () => {
@@ -141,6 +145,9 @@ const viewerProfileResponse = (overrides = {}) => {
 			pack_compression: process.env.CODEMEM_PACK_COMPRESSION?.trim() || null,
 			embedding_disabled: ["1", "true", "yes"].includes(
 				String(process.env.CODEMEM_EMBEDDING_DISABLED || "").toLowerCase(),
+			),
+			embedding_offline: ["1", "true", "yes"].includes(
+				String(process.env.CODEMEM_EMBEDDING_OFFLINE || "").toLowerCase(),
 			),
 			embedding_model: embeddingModel,
 			embedding_revision: embeddingRevision,
@@ -299,6 +306,7 @@ describe("OpenCode transform-time injection", () => {
 			"CODEMEM_WORKSPACE_ID",
 			"CODEMEM_PACK_COMPRESSION",
 			"CODEMEM_EMBEDDING_DISABLED",
+			"CODEMEM_EMBEDDING_OFFLINE",
 			"CODEMEM_EMBEDDING_MODEL",
 			"CODEMEM_EMBEDDING_REVISION",
 		]) {
@@ -1840,6 +1848,7 @@ describe("OpenCode transform-time injection", () => {
 				home_dir: resolve(process.env.HOME?.trim() || homedir()),
 				pack_compression: null,
 				embedding_disabled: false,
+				embedding_offline: false,
 				embedding_model: "Xenova/bge-small-en-v1.5",
 				embedding_revision: "ea104dacec62c0de699686887e3f920caeb4f3e3",
 			},

--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -215,6 +215,7 @@ async function smokeClaudePromptWrapper(isolatedRoot) {
 		home_dir: home,
 		pack_compression: null,
 		embedding_disabled: false,
+		embedding_offline: false,
 		embedding_model: "Xenova/bge-small-en-v1.5",
 		embedding_revision: "ea104dacec62c0de699686887e3f920caeb4f3e3",
 	};
@@ -330,6 +331,7 @@ async function smokeCodexPromptWrapper(isolatedRoot) {
 		home_dir: home,
 		pack_compression: null,
 		embedding_disabled: false,
+		embedding_offline: false,
 		embedding_model: "Xenova/bge-small-en-v1.5",
 		embedding_revision: "ea104dacec62c0de699686887e3f920caeb4f3e3",
 	};

--- a/packages/cli/src/commands/claude-user-prompt-hook.test.ts
+++ b/packages/cli/src/commands/claude-user-prompt-hook.test.ts
@@ -50,6 +50,7 @@ describe("dependency-free Claude user prompt hook", () => {
 			home_dir: root,
 			pack_compression: null,
 			embedding_disabled: false,
+			embedding_offline: false,
 			embedding_model: "Xenova/bge-small-en-v1.5",
 			embedding_revision: "ea104dacec62c0de699686887e3f920caeb4f3e3",
 		};
@@ -91,6 +92,7 @@ describe("dependency-free Claude user prompt hook", () => {
 			CODEMEM_WORKSPACE_ID: "workspace-1",
 			CODEMEM_PACK_COMPRESSION: "ids",
 			CODEMEM_EMBEDDING_DISABLED: "true",
+			CODEMEM_EMBEDDING_OFFLINE: "YeS",
 			CODEMEM_EMBEDDING_MODEL: "model-1",
 			CODEMEM_EMBEDDING_REVISION: "abcdef1234567890abcdef1234567890abcdef12",
 		};

--- a/packages/cli/src/commands/codex-user-prompt-hook.test.ts
+++ b/packages/cli/src/commands/codex-user-prompt-hook.test.ts
@@ -55,6 +55,7 @@ describe("dependency-free Codex user prompt hook", () => {
 			home_dir: root,
 			pack_compression: null,
 			embedding_disabled: false,
+			embedding_offline: false,
 			embedding_model: "Xenova/bge-small-en-v1.5",
 			embedding_revision: "ea104dacec62c0de699686887e3f920caeb4f3e3",
 		};
@@ -81,6 +82,7 @@ describe("dependency-free Codex user prompt hook", () => {
 			CODEMEM_WORKSPACE_ID: "workspace-1",
 			CODEMEM_PACK_COMPRESSION: "ids",
 			CODEMEM_EMBEDDING_DISABLED: "true",
+			CODEMEM_EMBEDDING_OFFLINE: "YeS",
 			CODEMEM_EMBEDDING_MODEL: "model-1",
 			CODEMEM_EMBEDDING_REVISION: "abcdef1234567890abcdef1234567890abcdef12",
 		};

--- a/packages/core/src/identity-target.ts
+++ b/packages/core/src/identity-target.ts
@@ -15,6 +15,7 @@ export const VIEWER_IDENTITY_TARGET_KEYS = [
 	"home_dir",
 	"pack_compression",
 	"embedding_disabled",
+	"embedding_offline",
 	"embedding_model",
 	"embedding_revision",
 ] as const;
@@ -31,6 +32,7 @@ export interface ViewerIdentityTarget {
 	home_dir: string | null;
 	pack_compression: string | null;
 	embedding_disabled: boolean;
+	embedding_offline: boolean;
 	embedding_model: string;
 	embedding_revision: string | null;
 }
@@ -56,6 +58,9 @@ export function buildViewerIdentityTarget(
 		pack_compression: env.CODEMEM_PACK_COMPRESSION?.trim() || null,
 		embedding_disabled: ["1", "true", "yes"].includes(
 			String(env.CODEMEM_EMBEDDING_DISABLED || "").toLowerCase(),
+		),
+		embedding_offline: ["1", "true", "yes"].includes(
+			String(env.CODEMEM_EMBEDDING_OFFLINE || "").toLowerCase(),
 		),
 		embedding_model: embeddingModel,
 		embedding_revision: tryResolveEmbeddingRevision(embeddingModel, env),

--- a/packages/embeddings/src/index.test.ts
+++ b/packages/embeddings/src/index.test.ts
@@ -22,7 +22,7 @@ const tensor = (
 ) => ({ data: new Float64Array(rows.flat()), dims });
 
 const CANONICAL_REVISION = "0123456789abcdef0123456789abcdef01234567";
-const HEX_NAMED_MUTABLE_REF = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const HEX_NAMED_MUTABLE_REF = "89abcdef0123456789abcdef0123456789abcdef";
 
 describe("cached default embedding runtime", () => {
 	it("loads an explicit built-in pin without a network lookup", async () => {
@@ -193,7 +193,7 @@ describe("createEmbeddingRuntime", () => {
 		);
 	});
 
-	it("resolves a 40-hex named ref before publishing runtime identity", async () => {
+	it("resolves a lowercase 40-character hex ref before publishing runtime identity", async () => {
 		pipelineMock.mockResolvedValue(vi.fn().mockResolvedValue(tensor([[1, 2]])));
 
 		const runtime = await createEmbeddingRuntime({
@@ -216,6 +216,29 @@ describe("createEmbeddingRuntime", () => {
 		});
 	});
 
+	it("canonicalizes an explicit custom-model commit when remote access is enabled", async () => {
+		pipelineMock.mockResolvedValue(vi.fn().mockResolvedValue(tensor([[1, 2]])));
+
+		const runtime = await createEmbeddingRuntime({
+			model: "test/model",
+			revision: CANONICAL_REVISION,
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			`https://huggingface.co/test/model/resolve/${CANONICAL_REVISION}/config.json`,
+			expect.objectContaining({ method: "HEAD", redirect: "follow" }),
+		);
+		expect(runtime.identity).toMatchObject({
+			revision: CANONICAL_REVISION,
+			requestedRevision: CANONICAL_REVISION,
+		});
+		expect(pipelineMock).toHaveBeenCalledWith(
+			"feature-extraction",
+			"test/model",
+			expect.objectContaining({ revision: CANONICAL_REVISION }),
+		);
+	});
+
 	it("rejects mutable revisions when remote models are disabled", async () => {
 		transformersEnv.allowRemoteModels = false;
 
@@ -232,15 +255,56 @@ describe("createEmbeddingRuntime", () => {
 
 		const runtime = await createEmbeddingRuntime({
 			model: "test/model",
-			revision: HEX_NAMED_MUTABLE_REF,
+			revision: CANONICAL_REVISION,
 		});
 
 		expect(fetchMock).not.toHaveBeenCalled();
-		expect(runtime.identity.revision).toBe(HEX_NAMED_MUTABLE_REF);
+		expect(runtime.identity.revision).toBe(CANONICAL_REVISION);
 		expect(pipelineMock).toHaveBeenCalledWith(
 			"feature-extraction",
 			"test/model",
-			expect.objectContaining({ revision: HEX_NAMED_MUTABLE_REF }),
+			expect.objectContaining({ revision: CANONICAL_REVISION }),
+		);
+	});
+
+	it("uses Codemem offline mode to load a cached commit without a network lookup", async () => {
+		vi.stubEnv("CODEMEM_EMBEDDING_OFFLINE", "1");
+		pipelineMock.mockResolvedValue(vi.fn().mockResolvedValue(tensor([[1, 2]])));
+
+		const runtime = await createEmbeddingRuntime({
+			model: "test/model",
+			revision: CANONICAL_REVISION,
+		});
+
+		expect(transformersEnv.allowRemoteModels).toBe(false);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(runtime.identity.revision).toBe(CANONICAL_REVISION);
+		expect(pipelineMock).toHaveBeenCalledWith(
+			"feature-extraction",
+			"test/model",
+			expect.objectContaining({ revision: CANONICAL_REVISION }),
+		);
+	});
+
+	it("restores remote revision resolution after Codemem offline mode is disabled", async () => {
+		vi.stubEnv("CODEMEM_EMBEDDING_OFFLINE", "1");
+		pipelineMock.mockResolvedValue(vi.fn().mockResolvedValue(tensor([[1, 2]])));
+		await createEmbeddingRuntime({
+			model: "test/model",
+			revision: CANONICAL_REVISION,
+		});
+
+		fetchMock.mockClear();
+		vi.stubEnv("CODEMEM_EMBEDDING_OFFLINE", "");
+		await createEmbeddingRuntime({
+			model: "test/model",
+			revision: HEX_NAMED_MUTABLE_REF,
+		});
+
+		expect(transformersEnv.allowRemoteModels).toBe(true);
+		expect(fetchMock).toHaveBeenCalledWith(
+			`https://huggingface.co/test/model/resolve/${HEX_NAMED_MUTABLE_REF}/config.json`,
+			expect.objectContaining({ method: "HEAD", redirect: "follow" }),
 		);
 	});
 

--- a/packages/embeddings/src/index.ts
+++ b/packages/embeddings/src/index.ts
@@ -40,6 +40,23 @@ type Extractor = (
 const DEFAULT_MODEL = "Xenova/bge-small-en-v1.5";
 const DEFAULT_REVISION = "ea104dacec62c0de699686887e3f920caeb4f3e3";
 const CANONICAL_REVISION_PATTERN = /^[0-9a-f]{40}$/;
+let allowRemoteModelsBeforeOffline: boolean | undefined;
+
+function isEmbeddingOffline(): boolean {
+	const value = process.env.CODEMEM_EMBEDDING_OFFLINE?.toLowerCase();
+	return value === "1" || value === "true" || value === "yes";
+}
+
+function configureRemoteModelAccess(env: HubEnvironment): void {
+	if (isEmbeddingOffline()) {
+		allowRemoteModelsBeforeOffline ??= env.allowRemoteModels;
+		env.allowRemoteModels = false;
+		return;
+	}
+	if (allowRemoteModelsBeforeOffline === undefined) return;
+	env.allowRemoteModels = allowRemoteModelsBeforeOffline;
+	allowRemoteModelsBeforeOffline = undefined;
+}
 
 interface HubEnvironment {
 	remoteHost: string;
@@ -62,8 +79,16 @@ function isLocalModelPath(model: string): boolean {
 function configuredRevisionToResolve(
 	model: string,
 	configuredRevision: string | undefined,
+	allowRemoteModels: boolean,
 ): string | undefined {
 	if (model === DEFAULT_MODEL && configuredRevision === DEFAULT_REVISION) return undefined;
+	if (
+		configuredRevision &&
+		CANONICAL_REVISION_PATTERN.test(configuredRevision) &&
+		(isLocalModelPath(model) || !allowRemoteModels)
+	) {
+		return undefined;
+	}
 	return configuredRevision;
 }
 
@@ -133,22 +158,21 @@ export async function createEmbeddingRuntime({
 		throw new TypeError("A revision is required when creating a runtime for a custom model");
 	}
 	const { env, pipeline } = await import("@huggingface/transformers");
+	configureRemoteModelAccess(env);
 	const requestedRevision = configuredRevision || DEFAULT_REVISION;
 	let revision = requestedRevision;
-	const revisionToResolve = configuredRevisionToResolve(model, configuredRevision);
+	const revisionToResolve = configuredRevisionToResolve(
+		model,
+		configuredRevision,
+		env.allowRemoteModels,
+	);
 	if (revisionToResolve) {
 		if (isLocalModelPath(model)) {
-			if (!CANONICAL_REVISION_PATTERN.test(revisionToResolve)) {
-				throw new TypeError("Local embedding models require a 40-character revision identity");
-			}
+			throw new TypeError("Local embedding models require a 40-character revision identity");
 		} else if (!env.allowRemoteModels) {
-			if (CANONICAL_REVISION_PATTERN.test(revisionToResolve)) {
-				revision = revisionToResolve;
-			} else {
-				throw new TypeError(
-					`Cannot resolve mutable embedding revision ${revisionToResolve} while remote models are disabled`,
-				);
-			}
+			throw new TypeError(
+				`Cannot resolve mutable embedding revision ${revisionToResolve} while remote models are disabled`,
+			);
 		} else {
 			revision = await resolveCanonicalRevision(model, revisionToResolve, env);
 		}

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -665,6 +665,9 @@ const buildViewerIdentityTarget = (env = process.env, cwd = process.cwd()) => {
     embedding_disabled: ["1", "true", "yes"].includes(
       String(env.CODEMEM_EMBEDDING_DISABLED || "").toLowerCase(),
     ),
+    embedding_offline: ["1", "true", "yes"].includes(
+      String(env.CODEMEM_EMBEDDING_OFFLINE || "").toLowerCase(),
+    ),
     embedding_model: embeddingModel,
     embedding_revision: embeddingRevision,
   };

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -5668,6 +5668,7 @@ describe("viewer-server", () => {
 					home_dir: resolve(process.env.HOME || homedir()),
 					pack_compression: null,
 					embedding_disabled: false,
+					embedding_offline: false,
 					embedding_model: "Xenova/bge-small-en-v1.5",
 					embedding_revision: "ea104dacec62c0de699686887e3f920caeb4f3e3",
 				};
@@ -5710,6 +5711,13 @@ describe("viewer-server", () => {
 				});
 				expect(embeddingMismatch.status).toBe(409);
 
+				const embeddingOfflineMismatch = await postViewerJson(app, "/api/pack", {
+					context: "viewer identity",
+					db_path: ensureStore().dbPath,
+					identity_target: { ...viewerIdentityTarget, embedding_offline: true },
+				});
+				expect(embeddingOfflineMismatch.status).toBe(409);
+
 				const embeddingRevisionMismatch = await postViewerJson(app, "/api/pack", {
 					context: "viewer identity",
 					db_path: ensureStore().dbPath,
@@ -5745,6 +5753,7 @@ describe("viewer-server", () => {
 				"CODEMEM_WORKSPACE_ID",
 				"CODEMEM_PACK_COMPRESSION",
 				"CODEMEM_EMBEDDING_DISABLED",
+				"CODEMEM_EMBEDDING_OFFLINE",
 				"CODEMEM_EMBEDDING_MODEL",
 				"CODEMEM_EMBEDDING_REVISION",
 			] as const;
@@ -5770,6 +5779,7 @@ describe("viewer-server", () => {
 						home_dir: resolve(process.env.HOME || homedir()),
 						pack_compression: null,
 						embedding_disabled: false,
+						embedding_offline: false,
 						embedding_model: "Xenova/bge-small-en-v1.5",
 						embedding_revision: "ea104dacec62c0de699686887e3f920caeb4f3e3",
 					},

--- a/packages/viewer-server/src/routes/target-validation.ts
+++ b/packages/viewer-server/src/routes/target-validation.ts
@@ -7,7 +7,11 @@ import {
 } from "@codemem/core";
 
 const IDENTITY_TARGET_KEYS = new Set<string>(VIEWER_IDENTITY_TARGET_KEYS);
-const BOOLEAN_IDENTITY_TARGET_KEYS = new Set(["actor_id_present", "embedding_disabled"]);
+const BOOLEAN_IDENTITY_TARGET_KEYS = new Set([
+	"actor_id_present",
+	"embedding_disabled",
+	"embedding_offline",
+]);
 
 export type ViewerTargetValidation =
 	| { ok: true }

--- a/plugins/claude/scripts/user-prompt-hook.mjs
+++ b/plugins/claude/scripts/user-prompt-hook.mjs
@@ -103,6 +103,9 @@ export function identityTarget(cwd, env) {
 		embedding_disabled: ["1", "true", "yes"].includes(
 			String(env.CODEMEM_EMBEDDING_DISABLED ?? "").toLowerCase(),
 		),
+		embedding_offline: ["1", "true", "yes"].includes(
+			String(env.CODEMEM_EMBEDDING_OFFLINE ?? "").toLowerCase(),
+		),
 		embedding_model: embeddingModel,
 		embedding_revision: embeddingRevision,
 	};

--- a/plugins/codex/scripts/user-prompt-hook.mjs
+++ b/plugins/codex/scripts/user-prompt-hook.mjs
@@ -113,6 +113,9 @@ export function identityTarget(cwd, env) {
 		embedding_disabled: ["1", "true", "yes"].includes(
 			String(env.CODEMEM_EMBEDDING_DISABLED ?? "").toLowerCase(),
 		),
+		embedding_offline: ["1", "true", "yes"].includes(
+			String(env.CODEMEM_EMBEDDING_OFFLINE ?? "").toLowerCase(),
+		),
 		embedding_model: embeddingModel,
 		embedding_revision: embeddingRevision,
 	};


### PR DESCRIPTION
## Description

Allows cached custom models pinned to lowercase 40-character commit identities to start when remote access is disabled. When remote access is enabled, every custom Hub revision is canonicalized because a movable branch or tag can also have a 40-hex name.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced