### PR TITLE
perf(core): avoid repeated vector cleanup validation

### DIFF
--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSqliteVec } from "./db.js";
 import * as embeddings from "./embeddings.js";
 import {
 	completeMaintenanceJob,
@@ -1251,26 +1252,74 @@ describe("vector migration", () => {
 		expect(completedAfterDisable).toMatchObject({ status: "completed" });
 	});
 
-	it("bounds stale-model cleanup to one resumable batch and honors abort before resuming", async () => {
+	it("drains bounded stale-model batches without repeating full-corpus validation", async () => {
+		const sessionId = insertTestSession(db);
+		for (let id = 1; id <= 501; id++) {
+			seedMemory(db, id, sessionId, `Memory ${id}`, `Body ${id}`);
+			seedVector(db, id, "old-model");
+		}
+		let staleBatchSelections = 0;
+		let coverageScanPreparations = 0;
+		const prepareSpy = vi.spyOn(db, "prepare");
+		prepareSpy.mockImplementation((sql: string) => {
+			if (sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")) {
+				staleBatchSelections++;
+			}
+			if (
+				sql.includes("SELECT id, title, body_text FROM memory_items") &&
+				sql.includes("AND TRIM(COALESCE(title, '') || COALESCE(body_text, '')) != ''") &&
+				sql.includes("AND id > ?")
+			) {
+				coverageScanPreparations++;
+			}
+			return Database.prototype.prepare.call(db, sql);
+		});
+
+		try {
+			await runVectorMigrationPass(db, { batchSize: 1000 });
+		} finally {
+			prepareSpy.mockRestore();
+		}
+
+		expect(
+			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE model = 'old-model'").get(),
+		).toMatchObject({ c: 0 });
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
+			status: "completed",
+			metadata: { cleanup_pending: false, removed_stale_rows: 501 },
+		});
+		expect(staleBatchSelections).toBe(3);
+		expect(coverageScanPreparations).toBe(1);
+	});
+
+	it("pauses bounded stale-model cleanup on abort and resumes safely", async () => {
 		const sessionId = insertTestSession(db);
 		for (let id = 1; id <= 251; id++) {
 			seedMemory(db, id, sessionId, `Memory ${id}`, `Body ${id}`);
 			seedVector(db, id, "old-model");
 		}
 
-		await runVectorMigrationPass(db, { batchSize: 500 });
-
-		expect(
-			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE model = 'old-model'").get(),
-		).toMatchObject({ c: 1 });
-		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
-			status: "completed",
-			metadata: { cleanup_pending: true, removed_stale_rows: 250 },
-		});
-
 		const controller = new AbortController();
-		controller.abort();
-		await runVectorMigrationPass(db, { batchSize: 500, signal: controller.signal });
+		let staleBatchSelections = 0;
+		const prepareSpy = vi.spyOn(db, "prepare");
+		prepareSpy.mockImplementation((sql: string) => {
+			const statement = Database.prototype.prepare.call(db, sql);
+			if (sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")) {
+				const all = statement.all.bind(statement);
+				statement.all = ((...params: unknown[]) => {
+					const rows = all(...params);
+					staleBatchSelections++;
+					if (staleBatchSelections === 2) controller.abort();
+					return rows;
+				}) as typeof statement.all;
+			}
+			return statement;
+		});
+		try {
+			await runVectorMigrationPass(db, { batchSize: 500, signal: controller.signal });
+		} finally {
+			prepareSpy.mockRestore();
+		}
 		expect(
 			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE model = 'old-model'").get(),
 		).toMatchObject({ c: 1 });
@@ -1286,6 +1335,150 @@ describe("vector migration", () => {
 			status: "completed",
 			metadata: { cleanup_pending: false, removed_stale_rows: 251 },
 		});
+	});
+
+	it("pauses bounded cleanup when its runner stops without an abort signal", async () => {
+		const sessionId = insertTestSession(db);
+		for (let id = 1; id <= 251; id++) {
+			seedMemory(db, id, sessionId, `Memory ${id}`, `Body ${id}`);
+			seedVector(db, id, "old-model");
+		}
+		let stopRequested = false;
+		let staleBatchSelections = 0;
+		const prepareSpy = vi.spyOn(db, "prepare");
+		prepareSpy.mockImplementation((sql: string) => {
+			const statement = Database.prototype.prepare.call(db, sql);
+			if (sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")) {
+				staleBatchSelections++;
+				if (staleBatchSelections === 1) {
+					setImmediate(() => {
+						stopRequested = true;
+					});
+				}
+			}
+			return statement;
+		});
+
+		try {
+			await runVectorMigrationPass(db, { batchSize: 500, shouldStop: () => stopRequested });
+		} finally {
+			prepareSpy.mockRestore();
+		}
+
+		expect(
+			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE model = 'old-model'").get(),
+		).toMatchObject({ c: 1 });
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
+			status: "completed",
+			metadata: { cleanup_pending: true, removed_stale_rows: 250 },
+		});
+	});
+
+	it("stops cleanup when the same connection mutates memory between batches", async () => {
+		const sessionId = insertTestSession(db);
+		for (let id = 1; id <= 251; id++) {
+			seedMemory(db, id, sessionId, `Memory ${id}`, `Body ${id}`);
+			seedVector(db, id, "old-model");
+		}
+		let scheduledMutation = false;
+		const prepareSpy = vi.spyOn(db, "prepare");
+		prepareSpy.mockImplementation((sql: string) => {
+			const statement = Database.prototype.prepare.call(db, sql);
+			if (
+				!scheduledMutation &&
+				sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")
+			) {
+				const all = statement.all.bind(statement);
+				statement.all = ((...params: unknown[]) => {
+					const rows = all(...params);
+					scheduledMutation = true;
+					setImmediate(() => {
+						db.prepare("UPDATE memory_items SET body_text = ? WHERE id = 1").run("Changed body");
+					});
+					return rows;
+				}) as typeof statement.all;
+			}
+			return statement;
+		});
+
+		try {
+			await runVectorMigrationPass(db, { batchSize: 500 });
+		} finally {
+			prepareSpy.mockRestore();
+		}
+
+		expect(scheduledMutation).toBe(true);
+		expect(
+			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE model = 'old-model'").get(),
+		).toMatchObject({ c: 1 });
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
+			status: "completed",
+			message: "Memory changes arrived during cleanup; retrying",
+			metadata: { cleanup_pending: true, removed_stale_rows: 250 },
+		});
+	});
+
+	it("revalidates target coverage after cleanup resumes on a new connection", async () => {
+		const dbDir = mkdtempSync(join(tmpdir(), "codemem-vector-cleanup-reconnect-"));
+		const dbPath = join(dbDir, "cleanup-reconnect.sqlite");
+		let firstDb: Database | null = null;
+		let resumedDb: Database | null = null;
+		try {
+			firstDb = new Database(dbPath);
+			initTestSchema(firstDb);
+			const sessionId = insertTestSession(firstDb);
+			for (let id = 1; id <= 251; id++) {
+				seedMemory(firstDb, id, sessionId, `Memory ${id}`, `Body ${id}`);
+				seedVector(firstDb, id, "old-model");
+			}
+			let stopRequested = false;
+			let staleBatchSelections = 0;
+			const prepareSpy = vi.spyOn(firstDb, "prepare");
+			prepareSpy.mockImplementation((sql: string) => {
+				const statement = Database.prototype.prepare.call(firstDb, sql);
+				if (sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")) {
+					staleBatchSelections++;
+					if (staleBatchSelections === 1) {
+						setImmediate(() => {
+							stopRequested = true;
+						});
+					}
+				}
+				return statement;
+			});
+			try {
+				await runVectorMigrationPass(firstDb, {
+					batchSize: 500,
+					shouldStop: () => stopRequested,
+				});
+			} finally {
+				prepareSpy.mockRestore();
+			}
+			firstDb.close();
+			firstDb = null;
+
+			const writerDb = new Database(dbPath);
+			writerDb.prepare("UPDATE memory_items SET body_text = ? WHERE id = 1").run("Changed body");
+			writerDb.close();
+			resumedDb = new Database(dbPath);
+			loadSqliteVec(resumedDb);
+			await runVectorMigrationPass(resumedDb, { batchSize: 500 });
+
+			expect(
+				resumedDb
+					.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE model != ?")
+					.get("test-model"),
+			).toMatchObject({ c: 0 });
+			expect(
+				resumedDb
+					.prepare("SELECT content_hash FROM memory_vectors WHERE memory_id = ? AND model = ?")
+					.all(1, "test-model"),
+			).toEqual([{ content_hash: embeddings.hashText("Memory 1\nChanged body") }]);
+		} finally {
+			resumedDb?.close();
+			firstDb?.close();
+			rmSync(dbDir, { recursive: true, force: true });
+		}
 	});
 
 	it("resumes stale-model cleanup after cutover completion", async () => {

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -589,7 +589,7 @@ function sameDatabaseMutationSnapshot(
 	);
 }
 
-function finalizeMigrationCutover(
+async function finalizeMigrationCutover(
 	db: SqliteDatabase,
 	targetModel: string,
 	metadata: MigrationMetadata,
@@ -597,7 +597,8 @@ function finalizeMigrationCutover(
 	processedEmbeddable: number,
 	embeddableTotal: number,
 	signal?: AbortSignal,
-): void {
+	shouldStop?: () => boolean,
+): Promise<void> {
 	const previouslyRemoved = Number(metadata.removed_stale_rows ?? 0);
 	const pruneSnapshot = readDatabaseMutationSnapshot(db, "prune-start");
 	const prunedTargetRows = pruneObsoleteTargetModelVectors(db, targetModel, { signal });
@@ -682,12 +683,12 @@ function finalizeMigrationCutover(
 	}).immediate();
 
 	if (!readyForLegacyCleanup) return;
-	const cleanup = deleteStaleModelVectors(db, targetModel, signal);
-	recordResumedCleanupResult(db, {
-		cleanup,
+	await drainStaleModelVectors(db, targetModel, {
 		validationSnapshot,
 		previouslyRemoved: removedBeforeCleanup,
 		prunedTargetRows: 0,
+		signal,
+		shouldStop,
 	});
 }
 
@@ -797,18 +798,92 @@ function recordResumedCleanupResult(
 	return cleanupCompleted;
 }
 
+async function yieldToCleanupInterrupts(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function cleanupShouldPause(options: {
+	signal?: AbortSignal;
+	shouldStop?: () => boolean;
+}): boolean {
+	if (options.signal?.aborted) return true;
+	return options.shouldStop?.() === true;
+}
+
+async function drainStaleModelVectors(
+	db: SqliteDatabase,
+	targetModel: string,
+	options: {
+		validationSnapshot: DatabaseMutationSnapshot;
+		previouslyRemoved: number;
+		prunedTargetRows: number;
+		signal?: AbortSignal;
+		shouldStop?: () => boolean;
+	},
+): Promise<boolean> {
+	let prunedTargetRows = options.prunedTargetRows;
+	let cleanupFence = readDatabaseMutationSnapshot(db, "validation");
+	if (!sameDatabaseDataVersion(options.validationSnapshot, cleanupFence)) {
+		deferCompletedCleanup(
+			db,
+			options.previouslyRemoved,
+			prunedTargetRows,
+			"Memory changes arrived during cleanup; retrying",
+		);
+		return false;
+	}
+	while (true) {
+		if (cleanupShouldPause(options)) {
+			deferCompletedCleanup(
+				db,
+				options.previouslyRemoved,
+				prunedTargetRows,
+				"Cleanup paused during shutdown; retrying",
+			);
+			return false;
+		}
+		if (!sameDatabaseMutationSnapshot(db, cleanupFence)) {
+			deferCompletedCleanup(
+				db,
+				options.previouslyRemoved,
+				prunedTargetRows,
+				"Memory changes arrived during cleanup; retrying",
+			);
+			return false;
+		}
+
+		const cleanup = deleteStaleModelVectors(db, targetModel, options.signal);
+		const cleanupCompleted = recordResumedCleanupResult(db, {
+			cleanup,
+			validationSnapshot: options.validationSnapshot,
+			previouslyRemoved: options.previouslyRemoved,
+			prunedTargetRows,
+		});
+		if (cleanupCompleted) return true;
+		if (cleanupShouldPause(options)) return false;
+		if (cleanup.deleted === 0) return false;
+		const cleanupSnapshot = readDatabaseMutationSnapshot(db, "validation");
+		if (!sameDatabaseDataVersion(options.validationSnapshot, cleanupSnapshot)) return false;
+
+		prunedTargetRows = 0;
+		cleanupFence = cleanupSnapshot;
+		await yieldToCleanupInterrupts();
+	}
+}
+
 type CompletedCleanupPassResult = {
 	continueMigration: boolean;
 	restartFromBeginning: boolean;
 	reconciliationTargetPruningComplete: boolean;
 };
 
-function finishCompletedCleanupPass(
+async function finishCompletedCleanupPass(
 	db: SqliteDatabase,
 	targetModel: string,
 	metadata: MigrationMetadata,
 	signal?: AbortSignal,
-): CompletedCleanupPassResult {
+	shouldStop?: () => boolean,
+): Promise<CompletedCleanupPassResult> {
 	const stop: CompletedCleanupPassResult = {
 		continueMigration: false,
 		restartFromBeginning: false,
@@ -850,12 +925,12 @@ function finishCompletedCleanupPass(
 		};
 	}
 
-	const cleanup = deleteStaleModelVectors(db, targetModel, signal);
-	const cleanupCompleted = recordResumedCleanupResult(db, {
-		cleanup,
+	const cleanupCompleted = await drainStaleModelVectors(db, targetModel, {
 		validationSnapshot,
 		previouslyRemoved,
 		prunedTargetRows,
+		signal,
+		shouldStop,
 	});
 	if (!cleanupCompleted) return stop;
 	return {
@@ -884,7 +959,7 @@ function resolveMigrationStartMessage(
 
 export async function runVectorMigrationPass(
 	db: SqliteDatabase,
-	options: { batchSize?: number; signal?: AbortSignal } = {},
+	options: { batchSize?: number; signal?: AbortSignal; shouldStop?: () => boolean } = {},
 ): Promise<void> {
 	let existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
 	const isInFlightJob = existingJob?.status === "running" || existingJob?.status === "pending";
@@ -939,11 +1014,12 @@ export async function runVectorMigrationPass(
 		queuedSyncWorkCount === 0
 	) {
 		if (!existingMetadata.cleanup_pending && !hasSourceModelVectors(db, targetModel)) return;
-		const cleanupResult = finishCompletedCleanupPass(
+		const cleanupResult = await finishCompletedCleanupPass(
 			db,
 			targetModel,
 			existingMetadata,
 			options.signal,
+			options.shouldStop,
 		);
 		if (
 			!cleanupResult.continueMigration ||
@@ -1129,7 +1205,7 @@ export async function runVectorMigrationPass(
 			removed_stale_rows: Number(metadata.removed_stale_rows ?? 0) + prunedCoveredRows,
 		};
 		if (batchRows.length < effectiveBatchSize) {
-			finalizeMigrationCutover(
+			await finalizeMigrationCutover(
 				db,
 				targetModel,
 				metadataAfterPrune,
@@ -1137,6 +1213,7 @@ export async function runVectorMigrationPass(
 				processedEmbeddable,
 				embeddableTotal,
 				options.signal,
+				options.shouldStop,
 			);
 			return;
 		}
@@ -1163,7 +1240,7 @@ export async function runVectorMigrationPass(
 	}
 
 	if (metadata.last_cursor_id && metadata.last_cursor_id > 0) {
-		finalizeMigrationCutover(
+		await finalizeMigrationCutover(
 			db,
 			targetModel,
 			metadata,
@@ -1171,6 +1248,7 @@ export async function runVectorMigrationPass(
 			embeddableTotal,
 			embeddableTotal,
 			options.signal,
+			options.shouldStop,
 		);
 	}
 }
@@ -1254,6 +1332,7 @@ export class VectorModelMigrationRunner {
 			await runVectorMigrationPass(db, {
 				batchSize: this.batchSize,
 				signal: this.signal,
+				shouldStop: () => !this.active,
 			});
 			this.lastTickWasIdle = this.computeIdle(db);
 		} catch (error) {


### PR DESCRIPTION
## Description

Drains bounded stale-vector cleanup batches after one full-corpus validation instead of repeating that scan after every 250 rows. The loop yields between batches and preserves abort, runner-stop, mutation-fence, restart, and zero-progress safety.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced