### PR TITLE
ci: bind gate authorization to merge target

### DIFF
--- a/.github/scripts/ci-gate.mjs
+++ b/.github/scripts/ci-gate.mjs
@@ -15,22 +15,35 @@ function isSuccessfulFullJob(job, result, eventName) {
 	);
 }
 
-export function findCiGateFailures(needs, { eventName } = {}) {
+function findAuthorizationFailures({ eventName, baseRef, defaultBranch }) {
+	if (eventName !== "pull_request") return [];
+	if (!baseRef || !defaultBranch) return ["authorization=target-unknown"];
+	return baseRef === defaultBranch ? [] : ["authorization=stacked-pr"];
+}
+
+export function findCiGateFailures(needs, { eventName, baseRef, defaultBranch } = {}) {
 	const classify = needs?.classify;
 	const jobResults = resultEntries(needs).filter(([job]) => job !== "classify");
 	if (jobResults.length === 0) return ["required-jobs=missing"];
+	const authorizationFailures = findAuthorizationFailures({
+		eventName,
+		baseRef,
+		defaultBranch,
+	});
 	if (classify?.result !== "success") {
-		return jobResults
+		const jobFailures = jobResults
 			.filter(([job, result]) => !isSuccessfulFullJob(job, result, eventName))
 			.map(([job, result]) => `${job}=${result}`);
+		return [...authorizationFailures, ...jobFailures];
 	}
 
 	const runFull = classify.outputs?.run_full;
 	const reason = classify.outputs?.reason;
 	if (runFull === "true") {
-		return jobResults
+		const jobFailures = jobResults
 			.filter(([job, result]) => !isSuccessfulFullJob(job, result, eventName))
 			.map(([job, result]) => `${job}=${result}`);
+		return [...authorizationFailures, ...jobFailures];
 	}
 
 	if (runFull !== "false" || !REDUCED_REASONS.has(reason)) {
@@ -40,14 +53,17 @@ export function findCiGateFailures(needs, { eventName } = {}) {
 	const unexpectedJobs = jobResults
 		.filter(([, result]) => result !== "skipped")
 		.map(([job, result]) => `${job}=${result}`);
-	if (reason === "stacked-pr") return ["authorization=stacked-pr", ...unexpectedJobs];
-	return unexpectedJobs;
+	return [...authorizationFailures, ...unexpectedJobs];
 }
 
 function main() {
 	try {
 		const needs = JSON.parse(process.env.CI_NEEDS);
-		const failures = findCiGateFailures(needs, { eventName: process.env.CI_EVENT_NAME });
+		const failures = findCiGateFailures(needs, {
+			eventName: process.env.CI_EVENT_NAME,
+			baseRef: process.env.CI_BASE_REF,
+			defaultBranch: process.env.CI_DEFAULT_BRANCH,
+		});
 		if (failures.length === 0) return;
 
 		console.error(`Required CI jobs did not complete as expected: ${failures.join(", ")}`);

--- a/.github/scripts/ci-gate.test.mjs
+++ b/.github/scripts/ci-gate.test.mjs
@@ -8,6 +8,13 @@ const successfulNeeds = {
 	"ts-test": { result: "success", outputs: {} },
 };
 
+const mainPullRequest = { eventName: "pull_request", baseRef: "main", defaultBranch: "main" };
+const stackedPullRequest = {
+	eventName: "pull_request",
+	baseRef: "stack-parent",
+	defaultBranch: "main",
+};
+
 test("accepts successful required jobs", () => {
 	assert.deepEqual(findCiGateFailures(successfulNeeds), []);
 });
@@ -17,7 +24,7 @@ test("accepts the Windows smoke skip only on pull requests", () => {
 		...successfulNeeds,
 		"windows-embedding-runtime-smoke": { result: "skipped", outputs: {} },
 	};
-	assert.deepEqual(findCiGateFailures(needs, { eventName: "pull_request" }), []);
+	assert.deepEqual(findCiGateFailures(needs, mainPullRequest), []);
 	assert.deepEqual(findCiGateFailures(needs, { eventName: "push" }), [
 		"windows-embedding-runtime-smoke=skipped",
 	]);
@@ -32,7 +39,7 @@ test("rejects failed, cancelled, skipped, and missing jobs", () => {
 
 test("rejects non-Windows skipped jobs on pull requests", () => {
 	const needs = { ...successfulNeeds, "ts-test": { result: "skipped", outputs: {} } };
-	assert.deepEqual(findCiGateFailures(needs, { eventName: "pull_request" }), ["ts-test=skipped"]);
+	assert.deepEqual(findCiGateFailures(needs, mainPullRequest), ["ts-test=skipped"]);
 });
 
 test("rejects malformed or empty needs metadata", () => {
@@ -40,12 +47,24 @@ test("rejects malformed or empty needs metadata", () => {
 	assert.deepEqual(findCiGateFailures({}), ["required-jobs=missing"]);
 });
 
+test("blocks stacked pull requests before conditional CI is enabled", () => {
+	assert.deepEqual(findCiGateFailures(successfulNeeds, stackedPullRequest), [
+		"authorization=stacked-pr",
+	]);
+	assert.deepEqual(findCiGateFailures(successfulNeeds, { eventName: "pull_request" }), [
+		"authorization=target-unknown",
+	]);
+});
+
 test("supports successful full classifications before conditional CI is enabled", () => {
 	const needs = {
-		classify: { result: "success", outputs: { run_full: "true", reason: "bottom" } },
+		classify: {
+			result: "success",
+			outputs: { run_full: "true", reason: "bottom" },
+		},
 		...successfulNeeds,
 	};
-	assert.deepEqual(findCiGateFailures(needs), []);
+	assert.deepEqual(findCiGateFailures(needs, mainPullRequest), []);
 });
 
 test("accepts docs-only skips but blocks stacked merge authorization", () => {
@@ -54,23 +73,56 @@ test("accepts docs-only skips but blocks stacked merge authorization", () => {
 		"ts-test": { result: "skipped", outputs: {} },
 	};
 	assert.deepEqual(
-		findCiGateFailures({
-			classify: { result: "success", outputs: { run_full: "false", reason: "docs-only" } },
-			...reducedJobs,
-		}),
+		findCiGateFailures(
+			{
+				classify: {
+					result: "success",
+					outputs: { run_full: "false", reason: "docs-only" },
+				},
+				...reducedJobs,
+			},
+			mainPullRequest,
+		),
 		[],
 	);
 	assert.deepEqual(
-		findCiGateFailures({
-			classify: { result: "success", outputs: { run_full: "false", reason: "stacked-pr" } },
-			...reducedJobs,
-		}),
+		findCiGateFailures(
+			{
+				classify: {
+					result: "success",
+					outputs: { run_full: "false", reason: "stacked-pr" },
+				},
+				...reducedJobs,
+			},
+			stackedPullRequest,
+		),
 		["authorization=stacked-pr"],
 	);
 });
 
+test("blocks a full run while the pull request still targets a stack branch", () => {
+	const needs = {
+		classify: {
+			result: "success",
+			outputs: { run_full: "true", reason: "ci:full" },
+		},
+		...successfulNeeds,
+	};
+	assert.deepEqual(findCiGateFailures(needs, stackedPullRequest), ["authorization=stacked-pr"]);
+});
+
+test("blocks a stacked pull request when classification fails", () => {
+	const needs = {
+		classify: { result: "failure", outputs: {} },
+		...successfulNeeds,
+	};
+	assert.deepEqual(findCiGateFailures(needs, stackedPullRequest), ["authorization=stacked-pr"]);
+	assert.deepEqual(findCiGateFailures(needs, mainPullRequest), []);
+});
+
 test("depends on every other workflow job", async () => {
 	const workflow = await readFile(new URL("../workflows/ci.yml", import.meta.url), "utf8");
+	assert.match(workflow, /^ {4}types: \[[^\]\n]*\bedited\b[^\]\n]*]$/m);
 	const jobs = workflow.slice(workflow.indexOf("\njobs:\n") + "\njobs:\n".length);
 	const jobIds = [...jobs.matchAll(/^ {2}([a-z0-9-]+):\s*$/gm)].map((match) => match[1]);
 	const gateBlock = jobs.slice(jobs.indexOf("  ci-gate:\n"));
@@ -81,4 +133,11 @@ test("depends on every other workflow job", async () => {
 		gateNeeds,
 		jobIds.filter((job) => job !== "ci-gate"),
 	);
+	const baseRefEnv = ["CI_BASE_REF: $", "{{ github.event.pull_request.base.ref }}"].join("");
+	const defaultBranchEnv = [
+		"CI_DEFAULT_BRANCH: $",
+		"{{ github.event.repository.default_branch }}",
+	].join("");
+	assert.equal(gateBlock.includes(baseRefEnv), true);
+	assert.equal(gateBlock.includes(defaultBranchEnv), true);
 });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
   workflow_call:
 
@@ -259,5 +260,7 @@ jobs:
       - name: Require successful CI jobs
         run: node .github/scripts/ci-gate.mjs
         env:
+          CI_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          CI_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           CI_EVENT_NAME: ${{ github.event_name }}
           CI_NEEDS: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Description

Bind CI Gate authorization directly to the pull request merge target.

- Read the pull request base and repository default branch from the GitHub event.
- Keep stacked pull requests blocked even when `ci:full` runs every job.
- Fail closed when merge-target metadata is missing or the classifier fails.
- Preserve the merged unconditional gate behavior when no classifier job exists.

This closes the authorization gap where a classifier failure or forced full run could leave a successful required gate on a commit that still targeted another stack branch.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation: `pnpm run check` passes with 242 test files and 6,073 tests; 11 focused gate tests, touched-file Biome checks, and `git diff --check` pass. Independent review found no correctness blockers.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated in the dependent PR
- [x] No new warnings introduced