### PR TITLE
fix(core): complete benign raw-event microbatches

### DIFF
--- a/docs/plans/2026-09-05-raw-event-microbatch-terminal-state-design.md
+++ b/docs/plans/2026-09-05-raw-event-microbatch-terminal-state-design.md
@@ -1,0 +1,17 @@
+# Raw-event microbatch terminal-state fix
+
+## Decision
+
+Exhausted raw-event microbatches should complete as no-ops only when they contain at most two events, contain no assistant output, and had no processable input before any observer call. Empty, malformed, or lossy observer responses remain failures.
+
+## Why
+
+Long-running sessions can end with one or two prompt or tool events after the last useful assistant response. Retrying those fragments cannot add missing context, but marking them `gave_up` makes `codemem status` report a global ingestion failure. Provider, authentication, timeout, parse, and lossy-repair failures must remain failures.
+
+## Data flow
+
+The ingest pipeline carries the selected tier observer's status with every observer call failure and assigns stable reasons to output-validation failures. A `no_processable_input` result occurs before an observer call, so it discards any stale `lastError` retained by the observer while preserving provider and model identity. Current generic observer-call failures receive their own stable error type. The flush layer records that status and reason on each failed attempt. At retry exhaustion, the flush layer accepts only `no_processable_input`; empty, malformed, unstorable, and lossy observer output remains `gave_up`. An exhausted assistant-free microbatch carrying the legacy generic `Error` type receives exactly one re-diagnosis attempt regardless of its historical retry count or stale observer diagnostics. A repeated generic failure is persisted with a stable error type, preventing another attempt. Both terminal paths advance the stream cursor as they do today.
+
+## Validation
+
+Focused tests cover assistant-free two-event completion, diagnosed tier-observer failure, substantive or assistant-backed failure, and existing retry behavior. The core TypeScript and lint checks guard the changed interfaces.

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -281,6 +281,45 @@ export interface IngestOptions {
 	storeTyped?: boolean;
 }
 
+export type RawEventObserverOutputFailureReason =
+	| "no_processable_input"
+	| "empty_observer_output"
+	| "lossy_repair"
+	| "unstorable_observer_output";
+
+const observerFailureStatuses = new WeakMap<object, ReturnType<ObserverClient["getStatus"]>>();
+
+export class RawEventObserverOutputError extends Error {
+	readonly observerStatus: ReturnType<ObserverClient["getStatus"]>;
+	readonly reason: RawEventObserverOutputFailureReason;
+
+	constructor(
+		message: string,
+		reason: RawEventObserverOutputFailureReason,
+		observer: ObserverClient,
+		options: { includeObserverError?: boolean } = {},
+	) {
+		super(message);
+		this.name = "RawEventObserverOutputError";
+		this.reason = reason;
+		const observerStatus = observer.getStatus();
+		if (options.includeObserverError === false) {
+			const { lastError: _lastError, ...statusWithoutError } = observerStatus;
+			this.observerStatus = statusWithoutError;
+			return;
+		}
+		this.observerStatus = observerStatus;
+	}
+}
+
+export function rawEventObserverStatusFromError(
+	error: unknown,
+): ReturnType<ObserverClient["getStatus"]> | null {
+	if (error instanceof RawEventObserverOutputError) return error.observerStatus;
+	if ((typeof error !== "object" && typeof error !== "function") || error === null) return null;
+	return observerFailureStatuses.get(error) ?? null;
+}
+
 async function observeStructuredOutput(
 	observer: ObserverClient,
 	system: string,
@@ -333,6 +372,21 @@ async function observeStructuredOutput(
 		provider: repaired.provider,
 		model: repaired.model,
 	};
+}
+
+async function observeRawEventOutput(
+	observer: ObserverClient,
+	system: string,
+	user: string,
+): Promise<Awaited<ReturnType<typeof observeStructuredOutput>>> {
+	try {
+		return await observeStructuredOutput(observer, system, user);
+	} catch (error) {
+		if ((typeof error === "object" || typeof error === "function") && error !== null) {
+			observerFailureStatuses.set(error, observer.getStatus());
+		}
+		throw error;
+	}
 }
 
 /**
@@ -443,7 +497,12 @@ export async function ingest(
 
 		if (!shouldProcess) {
 			if (sessionContext?.flusher === "raw_events") {
-				throw new Error("observer produced no storable output for raw-event flush");
+				throw new RawEventObserverOutputError(
+					"observer produced no storable output for raw-event flush",
+					"no_processable_input",
+					options.observer,
+					{ includeObserverError: false },
+				);
 			}
 			endSession(store, sessionId, events.length, sessionContext);
 			return;
@@ -540,13 +599,17 @@ export async function ingest(
 		// ------------------------------------------------------------------
 		// Call observer LLM
 		// ------------------------------------------------------------------
-		const response = await observeStructuredOutput(selectedObserver, system, user);
+		const response = await observeRawEventOutput(selectedObserver, system, user);
 
 		if (!response.raw) {
 			// Raw-event flushes must be lossless: if the observer returns no output,
 			// fail the flush so we do NOT advance last_flushed_event_seq.
 			if (sessionContext?.flusher === "raw_events") {
-				throw new Error("observer failed during raw-event flush");
+				throw new RawEventObserverOutputError(
+					"observer failed during raw-event flush",
+					"empty_observer_output",
+					selectedObserver,
+				);
 			}
 
 			// Surface the failure for normal ingest paths.
@@ -571,7 +634,11 @@ export async function ingest(
 				parsed.skipSummaryReason !== null) &&
 			shouldRepairObserverResponse(rawText, parsed)
 		) {
-			throw new Error("observer repair remained lossy during raw-event flush");
+			throw new RawEventObserverOutputError(
+				"observer repair remained lossy during raw-event flush",
+				"lossy_repair",
+				selectedObserver,
+			);
 		}
 		const observerStatus = selectedObserver.getStatus();
 
@@ -718,7 +785,11 @@ export async function ingest(
 					});
 					return;
 				}
-				throw new Error("observer produced no storable output for raw-event flush");
+				throw new RawEventObserverOutputError(
+					"observer produced no storable output for raw-event flush",
+					"unstorable_observer_output",
+					selectedObserver,
+				);
 			}
 		}
 

--- a/packages/core/src/raw-event-flush.test.ts
+++ b/packages/core/src/raw-event-flush.test.ts
@@ -85,10 +85,16 @@ describe("flushRawEvents max retry", () => {
 		}),
 	};
 
-	it("gives up after max attempts and advances flush cursor", async () => {
+	it("completes an exhausted assistant-free microbatch as a no-op", async () => {
 		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "3";
 		const sessionId = "ses_max_retry_test";
-		seedEvents(sessionId);
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-1",
+			eventType: "user_prompt",
+			payload: { type: "user_prompt", prompt_text: "ok" },
+			tsWallMs: 100,
+		});
 
 		const ingestOpts = { observer: nullObserver } as unknown as IngestOptions;
 		const flushOpts = {
@@ -103,27 +109,387 @@ describe("flushRawEvents max retry", () => {
 		// Fail 3 times — each attempt claims the batch and increments attempt_count
 		for (let i = 0; i < 3; i++) {
 			await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toThrow(
-				"observer failed during raw-event flush",
+				"observer produced no storable output for raw-event flush",
 			);
 		}
 
-		// 4th attempt should give up instead of retrying
+		// 4th attempt should complete the terminal fragment instead of reporting an outage
 		const result = await flushRawEvents(store, ingestOpts, flushOpts);
 		expect(result.updatedState).toBe(1);
-		expect(result.flushed).toBe(0);
+		expect(result.flushed).toBe(1);
 
-		// Batch should be marked gave_up
+		// Batch should be marked completed
 		const batch = store.db
 			.prepare(
 				"SELECT status, attempt_count FROM raw_event_flush_batches WHERE opencode_session_id = ?",
 			)
 			.get(sessionId) as { status: string; attempt_count: number };
-		expect(batch.status).toBe("gave_up");
+		expect(batch.status).toBe("completed");
 		expect(batch.attempt_count).toBe(3);
 
 		// Flush state should be advanced so the session isn't retried
 		const flushState = store.rawEventFlushState(sessionId, "opencode");
 		expect(flushState).toBeGreaterThanOrEqual(0);
+	});
+
+	it("ignores stale observer diagnostics for an assistant-free no-op", async () => {
+		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "1";
+		const sessionId = "ses_stale_observer_diagnostics";
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-1",
+			eventType: "user_prompt",
+			payload: { type: "user_prompt", prompt_text: "ok" },
+			tsWallMs: 100,
+		});
+		const observerWithStaleError = {
+			...nullObserver,
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+				lastError: { code: "rate_limited", message: "Stale failure" },
+			}),
+		};
+		const ingestOpts = { observer: observerWithStaleError } as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: null,
+			maxEvents: null,
+		};
+
+		await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toThrow(
+			"observer produced no storable output for raw-event flush",
+		);
+		await flushRawEvents(store, ingestOpts, flushOpts);
+
+		const batch = store.db
+			.prepare(
+				"SELECT status, observer_error_code, observer_error_message FROM raw_event_flush_batches WHERE opencode_session_id = ?",
+			)
+			.get(sessionId) as {
+			status: string;
+			observer_error_code: string | null;
+			observer_error_message: string | null;
+		};
+		expect(batch).toEqual({
+			status: "completed",
+			observer_error_code: null,
+			observer_error_message: null,
+		});
+	});
+
+	it("re-diagnoses a legacy exhausted assistant-free microbatch once", async () => {
+		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "1";
+		const sessionId = "ses_legacy_no_input_failure";
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-1",
+			eventType: "user_prompt",
+			payload: { type: "user_prompt", prompt_text: "ok" },
+			tsWallMs: 100,
+		});
+		const event = store.db
+			.prepare("SELECT event_seq FROM raw_events WHERE opencode_session_id = ?")
+			.get(sessionId) as { event_seq: number };
+		const batch = store.getOrCreateRawEventFlushBatch(
+			sessionId,
+			"opencode",
+			event.event_seq,
+			event.event_seq,
+			"raw_events_v1",
+		);
+		store.db
+			.prepare(
+				"UPDATE raw_event_flush_batches SET status = 'failed', attempt_count = 3, error_type = 'Error', observer_error_code = 'rate_limited', observer_error_message = 'Stale failure' WHERE id = ?",
+			)
+			.run(batch.batchId);
+		const ingestOpts = { observer: nullObserver } as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: null,
+			maxEvents: null,
+		};
+
+		await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toThrow(
+			"observer produced no storable output for raw-event flush",
+		);
+		const rediagnosed = store.db
+			.prepare("SELECT status, attempt_count, error_type FROM raw_event_flush_batches WHERE id = ?")
+			.get(batch.batchId) as { status: string; attempt_count: number; error_type: string };
+		expect(rediagnosed).toEqual({
+			status: "failed",
+			attempt_count: 4,
+			error_type: "RawEventObserverOutputError:no_processable_input",
+		});
+
+		await flushRawEvents(store, ingestOpts, flushOpts);
+		const completed = store.db
+			.prepare("SELECT status, attempt_count FROM raw_event_flush_batches WHERE id = ?")
+			.get(batch.batchId) as { status: string; attempt_count: number };
+		expect(completed).toEqual({ status: "completed", attempt_count: 4 });
+	});
+
+	it("does not repeatedly re-diagnose a legacy generic failure", async () => {
+		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "1";
+		const sessionId = "ses_legacy_generic_failure";
+		seedEvents(sessionId);
+		const range = store.db
+			.prepare(
+				"SELECT MIN(event_seq) AS start_seq, MAX(event_seq) AS end_seq FROM raw_events WHERE opencode_session_id = ?",
+			)
+			.get(sessionId) as { start_seq: number; end_seq: number };
+		const batch = store.getOrCreateRawEventFlushBatch(
+			sessionId,
+			"opencode",
+			range.start_seq,
+			range.end_seq,
+			"raw_events_v1",
+		);
+		store.db
+			.prepare(
+				"UPDATE raw_event_flush_batches SET status = 'failed', attempt_count = 3, error_type = 'Error', observer_error_code = 'rate_limited' WHERE id = ?",
+			)
+			.run(batch.batchId);
+		let observeCalls = 0;
+		const failingObserver = {
+			...nullObserver,
+			observe: async () => {
+				observeCalls++;
+				throw "provider unavailable";
+			},
+		};
+		const ingestOpts = { observer: failingObserver } as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: null,
+			maxEvents: null,
+		};
+
+		await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toBe("provider unavailable");
+		await flushRawEvents(store, ingestOpts, flushOpts);
+
+		const terminal = store.db
+			.prepare("SELECT status, attempt_count, error_type FROM raw_event_flush_batches WHERE id = ?")
+			.get(batch.batchId) as { status: string; attempt_count: number; error_type: string };
+		expect(terminal).toEqual({
+			status: "gave_up",
+			attempt_count: 4,
+			error_type: "RawEventObserverCallError",
+		});
+		expect(observeCalls).toBe(1);
+	});
+
+	it("marks a generic legacy re-diagnosis failure with a stable terminal type", async () => {
+		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "1";
+		const sessionId = "ses_legacy_rediagnosis_failure";
+		seedEvents(sessionId);
+		const range = store.db
+			.prepare(
+				"SELECT MIN(event_seq) AS start_seq, MAX(event_seq) AS end_seq FROM raw_events WHERE opencode_session_id = ?",
+			)
+			.get(sessionId) as { start_seq: number; end_seq: number };
+		const batch = store.getOrCreateRawEventFlushBatch(
+			sessionId,
+			"opencode",
+			range.start_seq,
+			range.end_seq,
+			"raw_events_v1",
+		);
+		store.db
+			.prepare(
+				"UPDATE raw_event_flush_batches SET status = 'failed', attempt_count = 3, error_type = 'Error' WHERE id = ?",
+			)
+			.run(batch.batchId);
+		store.getOrCreateSessionForOpencodeSession = () => {
+			throw new Error("session insert failed");
+		};
+
+		await expect(
+			flushRawEvents(store, { observer: nullObserver } as unknown as IngestOptions, {
+				opencodeSessionId: sessionId,
+				source: "opencode",
+				cwd: null,
+				project: null,
+				startedAt: null,
+				maxEvents: null,
+			}),
+		).rejects.toThrow("session insert failed");
+
+		const rediagnosed = store.db
+			.prepare("SELECT status, error_type FROM raw_event_flush_batches WHERE id = ?")
+			.get(batch.batchId) as { status: string; error_type: string };
+		expect(rediagnosed).toEqual({
+			status: "failed",
+			error_type: "RawEventLegacyFailure:rediagnosis_failed",
+		});
+	});
+
+	it("preserves selected observer status for a plain-object rejection", async () => {
+		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "1";
+		const sessionId = "ses_plain_object_observer_failure";
+		seedEvents(sessionId);
+		let observeCalls = 0;
+		const rejection = { message: "provider unavailable" };
+		const selectedObserver = {
+			...nullObserver,
+			observe: async () => {
+				observeCalls++;
+				throw rejection;
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "selected-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+				lastError: { code: "rate_limited", message: "Try again later" },
+			}),
+		};
+		const routingObserver = {
+			...nullObserver,
+			tierRoutingEnabled: true,
+			toConfig: () => ({}),
+		};
+		const ingestOpts = {
+			observer: routingObserver,
+			createTierObserver: () => selectedObserver,
+		} as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: null,
+			maxEvents: null,
+		};
+
+		await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toBe(rejection);
+		await flushRawEvents(store, ingestOpts, flushOpts);
+
+		const batch = store.db
+			.prepare(
+				"SELECT status, error_type, observer_model, observer_error_code FROM raw_event_flush_batches WHERE opencode_session_id = ?",
+			)
+			.get(sessionId) as {
+			status: string;
+			error_type: string;
+			observer_model: string | null;
+			observer_error_code: string | null;
+		};
+		expect(batch).toEqual({
+			status: "gave_up",
+			error_type: "RawEventObserverCallError",
+			observer_model: "selected-model",
+			observer_error_code: "rate_limited",
+		});
+		expect(observeCalls).toBe(1);
+	});
+
+	it("keeps a diagnosed tier-observer failure as gave_up", async () => {
+		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "1";
+		const sessionId = "ses_diagnosed_tier_failure";
+		seedEvents(sessionId);
+		const selectedObserver = {
+			...nullObserver,
+			observe: async () => {
+				throw new Error("provider unavailable");
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "selected-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+				lastError: { code: "rate_limited", message: "Try again later" },
+			}),
+		};
+		const routingObserver = {
+			...nullObserver,
+			tierRoutingEnabled: true,
+			toConfig: () => ({}),
+		};
+		const ingestOpts = {
+			observer: routingObserver,
+			createTierObserver: () => selectedObserver,
+		} as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: null,
+			maxEvents: null,
+		};
+
+		await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toThrow(
+			"provider unavailable",
+		);
+		await flushRawEvents(store, ingestOpts, flushOpts);
+
+		const batch = store.db
+			.prepare(
+				"SELECT status, error_type, observer_model, observer_error_code FROM raw_event_flush_batches WHERE opencode_session_id = ?",
+			)
+			.get(sessionId) as {
+			status: string;
+			error_type: string;
+			observer_model: string | null;
+			observer_error_code: string | null;
+		};
+		expect(batch).toEqual({
+			status: "gave_up",
+			error_type: "RawEventObserverCallError",
+			observer_model: "selected-model",
+			observer_error_code: "rate_limited",
+		});
+	});
+
+	it("keeps repeated unparseable microbatch output as gave_up", async () => {
+		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "1";
+		const sessionId = "ses_unparseable_microbatch";
+		seedEvents(sessionId);
+		const observer = {
+			...nullObserver,
+			observe: async () => ({
+				raw: "I can summarize this session in plain English.",
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+		};
+		const ingestOpts = { observer } as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: null,
+			maxEvents: null,
+		};
+
+		await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toThrow(
+			"observer produced no storable output for raw-event flush",
+		);
+		await flushRawEvents(store, ingestOpts, flushOpts);
+
+		const batch = store.db
+			.prepare(
+				"SELECT status, error_type FROM raw_event_flush_batches WHERE opencode_session_id = ?",
+			)
+			.get(sessionId) as { status: string; error_type: string };
+		expect(batch).toEqual({
+			status: "gave_up",
+			error_type: "RawEventObserverOutputError:unstorable_observer_output",
+		});
 	});
 
 	it("does not give up when under the max attempts", async () => {
@@ -263,6 +629,13 @@ describe("flushRawEvents max retry", () => {
 		delete process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS;
 		const sessionId = "ses_default_max";
 		seedEvents(sessionId);
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-3",
+			eventType: "assistant_message",
+			payload: { type: "assistant_message", assistant_text: "Unable to finish." },
+			tsWallMs: 300,
+		});
 
 		const ingestOpts = { observer: nullObserver } as unknown as IngestOptions;
 		const flushOpts = {
@@ -295,6 +668,13 @@ describe("flushRawEvents max retry", () => {
 		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "1";
 		const sessionId = "ses_no_resurrect";
 		seedEvents(sessionId);
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-3",
+			eventType: "assistant_message",
+			payload: { type: "assistant_message", assistant_text: "Unable to finish." },
+			tsWallMs: 300,
+		});
 
 		const ingestOpts = { observer: nullObserver } as unknown as IngestOptions;
 		const flushOpts = {

--- a/packages/core/src/raw-event-flush.ts
+++ b/packages/core/src/raw-event-flush.ts
@@ -10,8 +10,17 @@
 
 import { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";
 import { extractAdapterEvent, projectAdapterToolEvent } from "./ingest-events.js";
-import { type IngestOptions, ingest } from "./ingest-pipeline.js";
-import { normalizeAdapterEvents, normalizeEventsForSessionContext } from "./ingest-transcript.js";
+import {
+	type IngestOptions,
+	ingest,
+	RawEventObserverOutputError,
+	rawEventObserverStatusFromError,
+} from "./ingest-pipeline.js";
+import {
+	extractAssistantMessages,
+	normalizeAdapterEvents,
+	normalizeEventsForSessionContext,
+} from "./ingest-transcript.js";
 import type { IngestPayload, SessionContext } from "./ingest-types.js";
 import { ObserverAuthError } from "./observer-client.js";
 import type { MemoryStore } from "./store.js";
@@ -21,6 +30,9 @@ const EXTRACTOR_VERSION = "raw_events_v1";
 /** Max flush attempts before a batch is permanently abandoned.
  *  Override via CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS. */
 const DEFAULT_MAX_FLUSH_ATTEMPTS = 5;
+const TERMINAL_NO_OUTPUT_MICROBATCH_MAX_EVENTS = 2;
+const LEGACY_REDIAGNOSIS_FAILED_ERROR_TYPE = "RawEventLegacyFailure:rediagnosis_failed";
+const OBSERVER_CALL_ERROR_TYPE = "RawEventObserverCallError";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -65,6 +77,37 @@ function summarizeFlushFailure(exc: Error, provider: string | null | undefined):
 		return `${providerTitle} response could not be processed.`;
 	}
 	return `${providerTitle} processing failed during raw-event ingestion.`;
+}
+
+function flushFailureErrorType(error: Error): string {
+	if (error instanceof ObserverAuthError) return "ObserverAuthError";
+	if (error instanceof RawEventObserverOutputError) return `${error.name}:${error.reason}`;
+	return error.name;
+}
+
+function isTerminalNoOutputMicrobatch(
+	events: Record<string, unknown>[],
+	failure: {
+		errorType: string | null;
+		observerErrorCode: string | null;
+		observerErrorMessage: string | null;
+	},
+): boolean {
+	if (events.length > TERMINAL_NO_OUTPUT_MICROBATCH_MAX_EVENTS) return false;
+	if (failure.observerErrorCode || failure.observerErrorMessage) return false;
+	if (failure.errorType !== "RawEventObserverOutputError:no_processable_input") {
+		return false;
+	}
+	return extractAssistantMessages(normalizeAdapterEvents(events)).length === 0;
+}
+
+function shouldRediagnoseLegacyNoOutputMicrobatch(
+	events: Record<string, unknown>[],
+	errorType: string | null,
+): boolean {
+	if (events.length > TERMINAL_NO_OUTPUT_MICROBATCH_MAX_EVENTS) return false;
+	if (errorType !== "Error") return false;
+	return extractAssistantMessages(normalizeAdapterEvents(events)).length === 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -288,13 +331,14 @@ export async function flushRawEvents(
 	}
 
 	// Get or create flush batch (idempotency guard)
-	const { batchId, status, attemptCount } = store.getOrCreateRawEventFlushBatch(
-		opencodeSessionId,
-		source,
-		startEventSeq,
-		lastEventSeq,
-		EXTRACTOR_VERSION,
-	);
+	const { batchId, status, attemptCount, errorType, observerErrorCode, observerErrorMessage } =
+		store.getOrCreateRawEventFlushBatch(
+			opencodeSessionId,
+			source,
+			startEventSeq,
+			lastEventSeq,
+			EXTRACTOR_VERSION,
+		);
 
 	// If already completed, just advance flush state
 	if (status === "completed") {
@@ -309,10 +353,25 @@ export async function flushRawEvents(
 	const maxAttempts = Number.parseInt(process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS ?? "", 10);
 	const effectiveMax =
 		Number.isFinite(maxAttempts) && maxAttempts > 0 ? maxAttempts : DEFAULT_MAX_FLUSH_ATTEMPTS;
+	let isLegacyRediagnosis = false;
 	if (attemptCount >= effectiveMax && (status === "failed" || status === "error")) {
-		store.updateRawEventFlushBatchStatus(batchId, "gave_up");
-		store.updateRawEventFlushState(opencodeSessionId, lastEventSeq, source);
-		return { flushed: 0, updatedState: 1 };
+		const shouldRediagnoseLegacyFailure = shouldRediagnoseLegacyNoOutputMicrobatch(
+			events,
+			errorType,
+		);
+		if (!shouldRediagnoseLegacyFailure) {
+			const completedNoOp = isTerminalNoOutputMicrobatch(events, {
+				errorType,
+				observerErrorCode,
+				observerErrorMessage,
+			});
+			store.updateRawEventFlushBatchStatus(batchId, completedNoOp ? "completed" : "gave_up");
+			store.updateRawEventFlushState(opencodeSessionId, lastEventSeq, source);
+			return { flushed: completedNoOp ? events.length : 0, updatedState: 1 };
+		}
+		// Legacy builds stored this pre-observer outcome as a generic Error. Fall
+		// through exactly once to replace it with the stable reason used below.
+		isLegacyRediagnosis = true;
 	}
 
 	// Claim the batch (atomic lock)
@@ -356,13 +415,24 @@ export async function flushRawEvents(
 		await ingest(payload, store, ingestOpts);
 	} catch (exc) {
 		// Record failure details on the batch
+		const observerFailureStatus = rawEventObserverStatusFromError(exc);
+		const isNonErrorRejection = !(exc instanceof Error);
 		const err = exc instanceof Error ? exc : new Error(String(exc));
-		const status = ingestOpts.observer?.getStatus?.();
+		const status = observerFailureStatus ?? ingestOpts.observer?.getStatus?.();
 		const provider = status?.provider as string | undefined;
 		const message = truncateErrorMessage(summarizeFlushFailure(err, provider));
+		const reportedErrorType = flushFailureErrorType(err);
+		const currentErrorType =
+			reportedErrorType === "Error" && (observerFailureStatus || isNonErrorRejection)
+				? OBSERVER_CALL_ERROR_TYPE
+				: reportedErrorType;
+		const errorType =
+			isLegacyRediagnosis && currentErrorType === "Error"
+				? LEGACY_REDIAGNOSIS_FAILED_ERROR_TYPE
+				: currentErrorType;
 		store.recordRawEventFlushBatchFailure(batchId, {
 			message,
-			errorType: err instanceof ObserverAuthError ? "ObserverAuthError" : err.name,
+			errorType,
 			observerProvider: provider ?? null,
 			observerModel: status?.model ?? null,
 			observerRuntime: status?.runtime ?? null,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -2072,7 +2072,14 @@ export class MemoryStore {
 		startEventSeq: number,
 		endEventSeq: number,
 		extractorVersion: string,
-	): { batchId: number; status: string; attemptCount: number } {
+	): {
+		batchId: number;
+		status: string;
+		attemptCount: number;
+		errorType: string | null;
+		observerErrorCode: string | null;
+		observerErrorMessage: string | null;
+	} {
 		const [s, sid] = this.normalizeStreamIdentity(source, opencodeSessionId);
 		const now = new Date().toISOString();
 
@@ -2103,7 +2110,14 @@ export class MemoryStore {
 					END`,
 				},
 			})
-			.returning({ id: t.id, status: t.status, attempt_count: t.attempt_count })
+			.returning({
+				id: t.id,
+				status: t.status,
+				attempt_count: t.attempt_count,
+				error_type: t.error_type,
+				observer_error_code: t.observer_error_code,
+				observer_error_message: t.observer_error_message,
+			})
 			.get();
 
 		if (!row) throw new Error("Failed to create flush batch");
@@ -2121,6 +2135,9 @@ export class MemoryStore {
 			batchId: Number(row.id),
 			status: canonicalStatus,
 			attemptCount: Number(row.attempt_count ?? 0),
+			errorType: row.error_type,
+			observerErrorCode: row.observer_error_code,
+			observerErrorMessage: row.observer_error_message,
 		};
 	}
 


### PR DESCRIPTION
## Description

Treat exhausted assistant-free raw-event microbatches with a diagnosed `no_processable_input` outcome as completed no-ops. Preserve retry exhaustion for malformed, lossy, observer, provider, and assistant-backed failures, and propagate stable observer diagnostics for classification.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced