### PR TITLE
release: prepare v0.44.0-alpha.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.43.2"
+    "version": "0.44.0-alpha.1"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.43.2",
+      "version": "0.44.0-alpha.1",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.43.2";
+const PINNED_BACKEND_VERSION = "0.44.0-alpha.1";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.43.2",
+	"version": "0.44.0-alpha.1",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/cli/src/commands/codex-user-prompt-hook.test.ts
+++ b/packages/cli/src/commands/codex-user-prompt-hook.test.ts
@@ -369,9 +369,9 @@ describe("dependency-free Codex user prompt hook", () => {
 				args: [
 					"-y",
 					"--package",
-					expect.stringMatching(/^codemem@\d+\.\d+\.\d+$/),
+					expect.stringMatching(/^codemem@\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\.\d+)?$/),
 					"--package",
-					expect.stringMatching(/^@codemem\/embeddings@\d+\.\d+\.\d+$/),
+					expect.stringMatching(/^@codemem\/embeddings@\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\.\d+)?$/),
 					"codemem",
 					"codex-hook-inject",
 				],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.43.2",
+	"version": "0.44.0-alpha.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.43.2");
+		expect(VERSION).toBe("0.44.0-alpha.1");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.43.2";
+export const VERSION = "0.44.0-alpha.1";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/embeddings",
-	"version": "0.43.2",
+	"version": "0.44.0-alpha.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.43.2",
+	"version": "0.44.0-alpha.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -16,7 +16,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.43.2";
+const PINNED_BACKEND_VERSION = "0.44.0-alpha.1";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 const MAX_UPDATE_STATUS_BYTES = 16 * 1024;

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.43.2",
+	"version": "0.44.0-alpha.1",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.43.2",
+	"version": "0.44.0-alpha.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.43.2",
+  "version": "0.44.0-alpha.1",
   "author": {
     "name": "Adam Kunicki"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codemem",
-  "version": "0.43.2",
+  "version": "0.44.0-alpha.1",
   "description": "Persistent memory for Codex. Capture work across sessions and recall relevant context.",
   "author": {
     "name": "Adam Kunicki"


### PR DESCRIPTION
## Description

Prepare the managed packages and plugin manifests for v0.44.0-alpha.1. The release is intended for controlled dogfood of the broad integration delta since v0.43.2.

This also updates the Codex fallback-launcher assertion so supported alpha, beta, and rc pins remain covered by the exact-version contract.

Alpha install with semantic search:

```sh
npm install -g codemem@alpha @codemem/embeddings@alpha
```

Known alpha risks: the OpenCode stream can report a restart-time CLI queue fallback that remains under investigation; update checks intentionally ignore prerelease versions; WebGPU remains out of scope until beta measurement.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional validation: `pnpm run check`, `pnpm run build`, both packed-artifact smoke tests, and local Project Sharing E2E passed. Main CI run 34007255108 passed after rerunning its transient failures.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced