### PR TITLE
feat(cli): install semantic runtime by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,24 @@ npx -y codemem db raw-events-status
 
 That's it. The plugin captures activity, builds memories, and injects context from here on.
 
-If you want `codemem` available directly on your `PATH` for manual commands and semantic retrieval, install the CLI and embedding runtime globally. The command differs by platform:
+If you want `codemem` available directly on your `PATH` for manual commands and semantic retrieval, install the CLI globally. The CLI installs its matching embedding runtime by default. The command differs by platform:
 
 On Linux, skip the unused ONNX Runtime GPU provider download:
 
 ```text
-env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings
+env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem
 ```
 
-On Apple silicon macOS and Windows, install both packages normally:
+On Apple silicon macOS and Windows, install normally:
 
 ```text
-npm install -g codemem @codemem/embeddings
+npm install -g codemem
 ```
 
-Installing only `codemem` keeps the CLI functional with FTS5 keyword retrieval
-and does not download the embedding runtime.
+For a smaller keyword-only install, use `npm install -g codemem --omit=optional`
+and set `CODEMEM_EMBEDDING_DISABLED=1` in every Codemem process. The flag is
+required because npm also omits sqlite-vec's optional platform package; the CLI
+then remains functional with FTS5.
 
 Setup-managed `npx` launchers cannot set a platform-specific install variable.
 On Linux, either use the guarded global installation above or set
@@ -92,7 +94,7 @@ OpenCode plugin and CLI are now split intentionally:
 
 - `@codemem/opencode-plugin` — OpenCode plugin package
 - `codemem` — CLI and MCP commands
-- `@codemem/embeddings` — optional semantic embedding runtime
+- `@codemem/embeddings` — optional semantic embedding runtime installed by the CLI
 
 ### Claude Code (marketplace install)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,7 @@ It does not currently gate sync or retrieval. See `docs/plans/2026-03-08-shared-
 
 ### Semantic search (sqlite-vec)
 
-When the optional `@codemem/embeddings` runtime is installed, `memory_vectors` (a `vec0` virtual table from sqlite-vec) stores 384-dimensional float vectors keyed by `memory_id`. Vectors are written automatically when memories are created, or backfilled with `codemem embed`. Lexical-only installs omit Transformers and ONNX Runtime.
+The `codemem` package installs its matching optional `@codemem/embeddings` runtime by default. When available, `memory_vectors` (a `vec0` virtual table from sqlite-vec) stores 384-dimensional float vectors keyed by `memory_id`. Vectors are written automatically when memories are created, or backfilled with `codemem embed`. Processes started with `CODEMEM_EMBEDDING_DISABLED=1` use lexical retrieval without loading Transformers or ONNX Runtime. An install made with `--omit=optional` also omits sqlite-vec's platform package and therefore requires this flag.
 
 Each vector row carries a canonical identity for model repository, revision,
 runtime generation, fp32 dtype, mean pooling, L2 normalization, and dimensions.

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -466,8 +466,8 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 
 When the plugin detects CLI/runtime version mismatch, it shows guidance based on runner mode:
 
-- `CODEMEM_RUNNER=codemem`: run `npm install -g codemem @codemem/embeddings` (the optional runtime enables semantic recall), then restart OpenCode. On Linux, prefix with `ONNXRUNTIME_NODE_INSTALL=skip` to avoid downloading the unused GPU provider (see the semantic-runtime install notes).
-- `CODEMEM_RUNNER=npx`: the compatibility warning recommends moving to a global install. Install `codemem` and `@codemem/embeddings` globally, clear explicit `CODEMEM_RUNNER` and `CODEMEM_RUNNER_FROM` overrides so the plugin detects that install, then restart OpenCode. To keep using npx instead, update `CODEMEM_RUNNER_FROM` to the desired `codemem@<version>` spec; the plugin pairs the matching `@codemem/embeddings` version automatically. On Linux, see the CPU-only semantic-runtime install notes in the README.
+- `CODEMEM_RUNNER=codemem`: run `npm install -g codemem` (the CLI installs its optional semantic runtime), then restart OpenCode. On Linux, prefix with `ONNXRUNTIME_NODE_INSTALL=skip` to avoid downloading the unused GPU provider (see the semantic-runtime install notes).
+- `CODEMEM_RUNNER=npx`: the compatibility warning recommends moving to a global `codemem` install, which includes its optional semantic runtime. Clear explicit `CODEMEM_RUNNER` and `CODEMEM_RUNNER_FROM` overrides so the plugin detects that install, then restart OpenCode. To keep using npx instead, update `CODEMEM_RUNNER_FROM` to the desired `codemem@<version>` spec; the plugin pairs the matching `@codemem/embeddings` version automatically. On Linux, see the CPU-only semantic-runtime install notes in the README.
 - `CODEMEM_RUNNER=node`: pull latest repo changes and run `pnpm build`, then restart OpenCode
 - custom/unknown runner: update the underlying `codemem` binary or package source, then restart OpenCode
 

--- a/docs/remote-mcp-oauth.md
+++ b/docs/remote-mcp-oauth.md
@@ -41,9 +41,9 @@ The viewer process and `codemem mcp http` process must run on different ports. O
 ## Prerequisites
 
 - Node.js 24.15+ and pnpm.
-- On Linux, install both runtime packages with the CPU-only policy: `env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings`.
-- On macOS and Windows, install both runtime packages with `npm install -g codemem @codemem/embeddings`.
-- Omit `@codemem/embeddings` only when keyword-only retrieval is intentional.
+- On Linux, install with the CPU-only policy: `env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem`.
+- On macOS and Windows, install with `npm install -g codemem`.
+- For a smaller keyword-only install, use `npm install -g codemem --omit=optional` and set `CODEMEM_EMBEDDING_DISABLED=1` in every Codemem process; npm also omits sqlite-vec's optional platform package.
 - The host already runs codemem as a peer with the user's memories synced locally.
 - An HTTPS-terminating public ingress such as Tailscale Funnel, Cloudflare Tunnel, or a reverse proxy that preserves the configured Host header.
 - An upstream OIDC provider the operator already uses (Google, GitHub via OIDC bridge, Anthropic SSO if available). The OIDC client must allow the `<MCP base URL>/oauth/callback` redirect URI.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -478,19 +478,19 @@ When selected history may already have replicated, all participating owner devic
 
 ### Semantic runtime unavailable
 
-Codemem defaults to FTS5 keyword retrieval when the optional embedding runtime
-is absent. Install both packages globally to enable semantic recall. On Linux,
-set the CPU-only policy so the installer skips the unused GPU provider:
+Codemem installs its matching optional embedding runtime by default and falls
+back to FTS5 keyword retrieval when that runtime is absent. On Linux, set the
+CPU-only policy so the installer skips the unused GPU provider:
 
 ```fish
-env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings
+env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem
 ```
 
-On Apple silicon macOS and Windows, install both packages normally (no
+On Apple silicon macOS and Windows, install normally (no
 environment variable, which `env`/`cmd.exe`/PowerShell do not share):
 
 ```text
-npm install -g codemem @codemem/embeddings
+npm install -g codemem
 ```
 
 Rerun `codemem setup` after upgrading an existing installation. The scoped
@@ -498,6 +498,10 @@ Rerun `codemem setup` after upgrading an existing installation. The scoped
 replaces the old managed `npx -y codemem mcp` launcher and codemem MCP entries
 detected as UV/UVX-based so both packages resolve in one runtime. Other custom
 MCP commands remain unchanged.
+
+For a smaller keyword-only install, use `npm install -g codemem --omit=optional`
+and set `CODEMEM_EMBEDDING_DISABLED=1` in every Codemem process. The flag is
+required because npm also omits sqlite-vec's optional platform package.
 
 Generated MCP configurations use the durable global `codemem` binary when it is
 available, allowing it to resolve the globally installed sibling package.

--- a/packages/cli/.opencode/lib/compat.js
+++ b/packages/cli/.opencode/lib/compat.js
@@ -31,7 +31,7 @@ export const resolveUpgradeGuidance = ({ runner, runnerFrom }) => {
     return {
       mode: "global",
       action:
-        "Run `npm install -g codemem @codemem/embeddings` to update both the CLI and the optional semantic runtime, then restart OpenCode. On Linux, prefix with `ONNXRUNTIME_NODE_INSTALL=skip` to avoid the unused GPU provider download.",
+        "Run `npm install -g codemem` to update the CLI and its optional semantic runtime, then restart OpenCode. On Linux, prefix with `ONNXRUNTIME_NODE_INSTALL=skip` to avoid the unused GPU provider download.",
       note: "detected global codemem runner mode",
     };
   }
@@ -40,7 +40,7 @@ export const resolveUpgradeGuidance = ({ runner, runnerFrom }) => {
     return {
       mode: "npx",
       action:
-        "Run `npm install -g codemem @codemem/embeddings` to update the CLI and optional semantic runtime, then restart OpenCode. On Linux, prefix with `ONNXRUNTIME_NODE_INSTALL=skip` to avoid the unused GPU provider download.",
+        "Run `npm install -g codemem` to update the CLI and its optional semantic runtime, then restart OpenCode. On Linux, prefix with `ONNXRUNTIME_NODE_INSTALL=skip` to avoid the unused GPU provider download.",
       note: "detected npx runner mode",
     };
   }

--- a/packages/cli/.opencode/tests/compat.test.js
+++ b/packages/cli/.opencode/tests/compat.test.js
@@ -69,17 +69,19 @@ describe("resolveUpgradeGuidance", () => {
     expect(guidance.action).toContain("normal install method");
   });
 
-  test("tells the global codemem runner to install the embedding runtime too", () => {
+  test("tells the global codemem runner that the CLI installs its embedding runtime", () => {
     const guidance = resolveUpgradeGuidance({ runner: "codemem", runnerFrom: "" });
     expect(guidance.mode).toBe("global");
-    expect(guidance.action).toContain("npm install -g codemem @codemem/embeddings");
+    expect(guidance.action).toContain("npm install -g codemem");
+    expect(guidance.action).not.toContain("npm install -g codemem @codemem/embeddings");
     expect(guidance.action).toContain("ONNXRUNTIME_NODE_INSTALL=skip");
   });
 
-  test("tells the npx runner to install both packages", () => {
+  test("tells the npx runner to install the CLI and its embedding runtime", () => {
     const guidance = resolveUpgradeGuidance({ runner: "npx", runnerFrom: "codemem@latest" });
     expect(guidance.mode).toBe("npx");
-    expect(guidance.action).toContain("npm install -g codemem @codemem/embeddings");
+    expect(guidance.action).toContain("npm install -g codemem");
+    expect(guidance.action).not.toContain("npm install -g codemem @codemem/embeddings");
   });
 });
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,24 +7,27 @@ This is the published npm package for the `codemem` CLI.
 
 ## Install
 
-**Prerequisites:** Node.js 24.15+ and npm (or pnpm). Native database support
+**Prerequisites:** Node.js 24.15+ and npm. Native database support
 covers macOS x64/arm64, Linux x64/arm64 (glibc 2.34+ or musl), and Windows x64.
 32-bit targets, including Linux armv7, are not supported.
 
 On Linux, skip the unused ONNX Runtime GPU provider download:
 
 ```bash
-env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings
+env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem
 ```
 
 On Apple silicon macOS and Windows:
 
 ```bash
-npm install -g codemem @codemem/embeddings
+npm install -g codemem
 ```
 
-The embedding package enables semantic retrieval. Installing only `codemem` keeps
-the CLI functional with FTS5 keyword retrieval.
+The CLI installs its matching embedding runtime by default. For a smaller
+keyword-only install, use `npm install -g codemem --omit=optional` and set
+`CODEMEM_EMBEDDING_DISABLED=1` in every Codemem process. The flag is required
+because npm also omits sqlite-vec's optional platform package; the CLI then
+remains functional with FTS5.
 
 Intel x64 Macs have no ONNX Runtime 1.24.3 artifact and remain on FTS5 retrieval.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,9 @@
 		"drizzle-orm": "catalog:",
 		"omelette": "^0.4.17"
 	},
+	"optionalDependencies": {
+		"@codemem/embeddings": "workspace:*"
+	},
 	"devDependencies": {
 		"@types/better-sqlite3": "catalog:",
 		"@types/node": "^24.12.4",

--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -642,18 +642,32 @@ try {
 		embeddingsTarListing.includes("package/dist/index.js"),
 		"Packed embeddings artifact is missing dist/index.js",
 	);
+	const packedPackageJson = JSON.parse(
+		run("tar", ["-xOf", packedTarball, "package/package.json"]).stdout,
+	);
+	assert(
+		packedPackageJson.optionalDependencies?.["@codemem/embeddings"] === packageVersion,
+		"Packed CLI must declare the matching @codemem/embeddings runtime as optional",
+	);
 
 	const installDir = join(tempDir, "install");
 	run(
 		"npm",
-		["install", "--prefix", installDir, coreTarball, mcpTarball, serverTarball, packedTarball],
+		[
+			"install",
+			"--omit=optional",
+			"--prefix",
+			installDir,
+			coreTarball,
+			mcpTarball,
+			serverTarball,
+			packedTarball,
+		],
 		packageRoot,
 		{ ...process.env, npm_config_install_strategy: "hoisted" },
 	);
 	const lexicalLockPath = join(installDir, "package-lock.json");
 	assert(existsSync(lexicalLockPath), "Lexical install did not produce a package-lock.json");
-	const lexicalLock = JSON.parse(readFileSync(lexicalLockPath, "utf8"));
-	const lexicalPackages = Object.keys(lexicalLock.packages ?? {});
 	for (const packageName of [
 		"@codemem/embeddings",
 		"@huggingface/transformers",
@@ -664,8 +678,7 @@ try {
 		"sharp",
 	]) {
 		assert(
-			// npm lockfile package keys use `/` and may be relative to a parent directory.
-			!lexicalPackages.some((path) => path.endsWith(`node_modules/${packageName}`)),
+			!existsSync(join(installDir, "node_modules", ...packageName.split("/"))),
 			`Lexical-only install unexpectedly contains ${packageName}`,
 		);
 	}
@@ -677,11 +690,25 @@ try {
 		JSON.stringify({ private: true }),
 		"utf8",
 	);
-	run("npm", ["install", "--prefix", semanticInstallDir, coreTarball, embeddingsTarball], packageRoot, {
-		...process.env,
-		ONNXRUNTIME_NODE_INSTALL: "skip",
-		npm_config_install_strategy: "hoisted",
-	});
+	run(
+		"npm",
+		[
+			"install",
+			"--prefix",
+			semanticInstallDir,
+			coreTarball,
+			embeddingsTarball,
+			mcpTarball,
+			serverTarball,
+			packedTarball,
+		],
+		packageRoot,
+		{
+			...process.env,
+			ONNXRUNTIME_NODE_INSTALL: "skip",
+			npm_config_install_strategy: "hoisted",
+		},
+	);
 	const semanticCoreBundle = readFileSync(
 		join(semanticInstallDir, "node_modules", "@codemem", "core", "dist", "index.js"),
 		"utf8",
@@ -734,7 +761,21 @@ try {
 	const semanticPackages = Object.keys(semanticLock.packages ?? {});
 	assert(
 		semanticPackages.some((path) => path.endsWith("node_modules/@huggingface/transformers")),
-		"Semantic install is missing the @huggingface/transformers runtime",
+		"Semantic CLI fixture is missing the @huggingface/transformers runtime",
+	);
+	const embeddingsPackageDir = join(
+		semanticInstallDir,
+		"node_modules",
+		"@codemem",
+		"embeddings",
+	);
+	assert(existsSync(embeddingsPackageDir), "Semantic CLI fixture is missing @codemem/embeddings");
+	const installedEmbeddingsPackage = JSON.parse(
+		readFileSync(join(embeddingsPackageDir, "package.json"), "utf8"),
+	);
+	assert(
+		installedEmbeddingsPackage.version === packageVersion,
+		`Semantic CLI fixture installed @codemem/embeddings ${installedEmbeddingsPackage.version}, expected ${packageVersion}`,
 	);
 	const ortPackageDir = resolveInstalledPackageDir(semanticInstallDir, "onnxruntime-node");
 	const ortBinaryDir = join(ortPackageDir, "bin", "napi-v6", process.platform, process.arch);
@@ -804,6 +845,13 @@ try {
 
 	const versionOutput = run(cliBin, ["version"]).stdout.trim();
 	assert(versionOutput === packageVersion, `Installed CLI reported ${versionOutput}, expected ${packageVersion}`);
+	const optionalFreeDbPath = join(tempDir, "optional-free.sqlite");
+	run(cliBin, ["stats"], installDir, {
+		...process.env,
+		CODEMEM_DB: optionalFreeDbPath,
+		CODEMEM_EMBEDDING_DISABLED: "1",
+	});
+	assert(existsSync(optionalFreeDbPath), "Optional-free CLI smoke did not create its isolated database");
 
 	const isolatedAdapters = join(tempDir, "isolated-adapters");
 	await buildAdapterNormalizers(isolatedAdapters);

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -771,8 +771,8 @@ export function installCodex(force: boolean): boolean {
 	} else {
 		const globalInstallCommand =
 			process.platform === "linux"
-				? "env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem @codemem/embeddings"
-				: "npm install -g codemem @codemem/embeddings";
+				? "env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem"
+				: "npm install -g codemem";
 		p.log.info(
 			`\`codemem\` is not on PATH, so Codex hooks will run via \`npx -y --package codemem --package @codemem/embeddings codemem\` (works without a global install). For lower hook latency: ${globalInstallCommand}`,
 		);

--- a/packages/core/src/release-discovery.test.ts
+++ b/packages/core/src/release-discovery.test.ts
@@ -884,7 +884,7 @@ describe("installation-kind detection", () => {
 
 describe("installation guidance", () => {
 	it.each([
-		["npm-global", "npm install -g codemem@0.41.0 @codemem/embeddings@0.41.0"],
+		["npm-global", "npm install -g codemem@0.41.0"],
 		["npx", "codemem@0.41.0 and @codemem/embeddings@0.41.0"],
 		["docker", "CODEMEM_VERSION=0.41.0 docker compose build --pull"],
 		["repo-dev", "git pull"],
@@ -912,7 +912,7 @@ describe("installation guidance", () => {
 		);
 
 		expect(status.recommended_action).toBe(
-			"env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem@0.41.0 @codemem/embeddings@0.41.0",
+			"env ONNXRUNTIME_NODE_INSTALL=skip npm install -g codemem@0.41.0",
 		);
 	});
 
@@ -922,9 +922,7 @@ describe("installation guidance", () => {
 			platform.mockRestore(),
 		);
 
-		expect(status.recommended_action).toBe(
-			"npm install -g codemem@0.41.0 @codemem/embeddings@0.41.0",
-		);
+		expect(status.recommended_action).toBe("npm install -g codemem@0.41.0");
 	});
 
 	it("returns no-upgrade guidance when the installation is current", async () => {

--- a/packages/core/src/release-discovery.ts
+++ b/packages/core/src/release-discovery.ts
@@ -235,7 +235,7 @@ function recommendedAction(
 	if (!updateAvailable) return "No action required; codemem is up to date.";
 	switch (installKind) {
 		case "npm-global":
-			return `${process.platform === "linux" ? "env ONNXRUNTIME_NODE_INSTALL=skip " : ""}npm install -g codemem@${latestVersion} @codemem/embeddings@${latestVersion}`;
+			return `${process.platform === "linux" ? "env ONNXRUNTIME_NODE_INSTALL=skip " : ""}npm install -g codemem@${latestVersion}`;
 		case "npx":
 			return `Update your launcher to request codemem@${latestVersion} and @codemem/embeddings@${latestVersion} together.`;
 		case "docker":

--- a/packages/opencode-plugin/.opencode/lib/compat.js
+++ b/packages/opencode-plugin/.opencode/lib/compat.js
@@ -31,7 +31,7 @@ export const resolveUpgradeGuidance = ({ runner, runnerFrom }) => {
     return {
       mode: "global",
       action:
-        "Run `npm install -g codemem @codemem/embeddings` to update both the CLI and the optional semantic runtime, then restart OpenCode. On Linux, prefix with `ONNXRUNTIME_NODE_INSTALL=skip` to avoid the unused GPU provider download.",
+        "Run `npm install -g codemem` to update the CLI and its optional semantic runtime, then restart OpenCode. On Linux, prefix with `ONNXRUNTIME_NODE_INSTALL=skip` to avoid the unused GPU provider download.",
       note: "detected global codemem runner mode",
     };
   }
@@ -40,7 +40,7 @@ export const resolveUpgradeGuidance = ({ runner, runnerFrom }) => {
     return {
       mode: "npx",
       action:
-        "Run `npm install -g codemem @codemem/embeddings` to update the CLI and optional semantic runtime, then restart OpenCode. On Linux, prefix with `ONNXRUNTIME_NODE_INSTALL=skip` to avoid the unused GPU provider download.",
+        "Run `npm install -g codemem` to update the CLI and its optional semantic runtime, then restart OpenCode. On Linux, prefix with `ONNXRUNTIME_NODE_INSTALL=skip` to avoid the unused GPU provider download.",
       note: "detected npx runner mode",
     };
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,10 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.11(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.13)(yaml@2.9.0))
+    optionalDependencies:
+      '@codemem/embeddings':
+        specifier: workspace:*
+        version: link:../embeddings
 
   packages/cloudflare-coordinator-worker:
     dependencies:


### PR DESCRIPTION
## Description
Install the semantic runtime with the CLI by default so alpha users receive the runtime needed for semantic features without a second manual install.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced