### PR TITLE
fix(release): keep updates on installed channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,18 +122,16 @@ jobs:
 
       - name: Determine npm dist-tag
         id: dist-tag
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
           set -euo pipefail
-          TAG="${{ env.RELEASE_TAG }}"
-          if [[ "$TAG" == *"-alpha"* ]]; then
-            echo "tag=alpha" >> "$GITHUB_OUTPUT"
-          elif [[ "$TAG" == *"-beta"* ]]; then
-            echo "tag=beta" >> "$GITHUB_OUTPUT"
-          elif [[ "$TAG" == *"-rc"* ]]; then
-            echo "tag=rc" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          TAG_OUTPUT="$(node scripts/release-dist-tag.mjs "$RELEASE_TAG")"
+          if [[ ! "$TAG_OUTPUT" =~ ^tag=(alpha|beta|rc|latest)$ ]]; then
+            echo "Invalid or empty npm dist-tag output: $TAG_OUTPUT" >&2
+            exit 1
           fi
+          printf '%s\n' "$TAG_OUTPUT" >> "$GITHUB_OUTPUT"
 
       - name: Publish packages
         env:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -62,19 +62,28 @@ Tag only after the release PR has merged to `main` and you have verified that `H
 
 ## Release discovery
 
-`codemem update check` queries the fixed public npm registry endpoint for the latest stable
-`codemem` release. Results are cached locally for six hours; use `--refresh` to bypass a fresh
-cache and `--json` for the stable automation contract. If a refresh fails, a previously validated
-cache may be returned as stale guidance. A running process backs off failed registry checks for 15
-minutes, while `--refresh` bypasses that backoff. `codemem update check` remains informational.
+`codemem update check` derives the release channel from the installed version and queries the fixed
+public npm registry endpoint for the matching dist-tag: alpha uses `alpha`, beta uses `beta`, release
+candidates use `rc`, and a stable version uses `latest`. Registry responses, status output, guidance,
+and cache records must
+match that channel. Results are cached locally for six hours; use `--refresh` to bypass a fresh cache
+and `--json` for the additive automation contract. Existing stable-only cache records remain valid
+for stable installations, but no cache or in-process result is reused across channels. If a refresh
+fails, a previously validated same-channel cache may be returned as stale guidance. A running process
+backs off failed registry checks for 15 minutes, while `--refresh` bypasses that backoff.
+`codemem update check` remains informational.
 `codemem update install` separately requires fresh validated status, a 24-hour first-seen delay,
 and a proven eligible npm installation before it installs exact matching `codemem` and
 `@codemem/embeddings` versions with an argv-only npm command and verifies the active CLI version.
-Bare `codemem update` remains non-mutating. Installation refuses pinned, prerelease, downgrade,
-development, stale, Docker, and unknown states. The npm operation runs the packages' installation
-scripts for native CPU dependencies, just as a manual global install does.
+Bare `codemem update` remains non-mutating. Installing an alpha, beta, or release candidate is
+explicit opt-in, so the
+existing auto-update policy may install a delayed eligible update within that installed channel.
+Installation refuses pinned, cross-channel, unsupported-prerelease, downgrade, development, stale,
+Docker, and unknown states. Updater internals always install exact matching `codemem` and
+`@codemem/embeddings` versions. The npm operation runs the packages' installation scripts for native
+CPU dependencies, just as a manual global install does.
 
-Release discovery compares the running product version with the latest published stable release.
+Release discovery compares the running product version with the latest release on its channel.
 It is separate from the compatibility-floor check below: discovering a newer release does not
 change whether the current CLI satisfies the plugin's minimum supported version.
 
@@ -86,7 +95,7 @@ The OpenCode plugin performs a runtime CLI version check and warns if the local 
 The compatibility reaction is controlled by `CODEMEM_BACKEND_UPDATE_POLICY`:
 
 - `notify` (default): warn with an upgrade hint
-- `auto`: attempt a best-effort update for eligible npm runners and delayed stable releases, then re-check
+- `auto`: attempt a best-effort same-channel update for eligible npm runners and delayed releases, then re-check
 - `off`: suppress compatibility toasts
 
 This check enforces a minimum supported CLI version. It does not query the npm registry or report

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "pnpm exec vitest run",
     "test:watch": "pnpm exec vitest",
     "test:ci-workflow": "node --test scripts/ci-workflow.test.mjs",
-    "test:release": "node --test scripts/release-version.test.mjs scripts/release-tag-preflight.test.mjs",
+    "test:release": "node --test scripts/release-version.test.mjs scripts/release-tag-preflight.test.mjs scripts/release-workflow.test.mjs",
     "test:adapter-normalizers": "node --test scripts/build-adapter-normalizers.test.mjs",
     "test:release-version": "node --test scripts/release-version.test.mjs",
     "test:release-tag-preflight": "node --test scripts/release-tag-preflight.test.mjs",

--- a/packages/cli/.opencode/lib/compat.js
+++ b/packages/cli/.opencode/lib/compat.js
@@ -117,6 +117,8 @@ const isPinnedGitSource = (runnerFrom) => {
 };
 
 const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org/";
+const UPDATE_TARGET_VERSION =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:alpha|beta|rc)(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 const createNpmUpdatePlan = (targetVersion) => {
 	const command = [
@@ -136,7 +138,7 @@ export const resolveAutoUpdatePlan = ({
 	runner,
 	runnerFrom,
 	runnerFromExplicit = false,
-	targetVersion = "latest",
+	targetVersion,
 	platform = process.platform,
 }) => {
 	const normalizedRunner = String(runner || "").trim();
@@ -144,9 +146,6 @@ export const resolveAutoUpdatePlan = ({
 	const normalizedTargetVersion = String(targetVersion || "").trim();
 	if (platform === "win32") {
 		return { allowed: false, reason: "unsupported-platform", command: null, commandText: null };
-	}
-	if (normalizedTargetVersion !== "latest" && !/^\d+\.\d+\.\d+$/.test(normalizedTargetVersion)) {
-		return { allowed: false, reason: "invalid-version", command: null, commandText: null };
 	}
 	if (isPinnedGitSource(source) || /^codemem@(?!latest$|next$|\*$)[^\s]+$/i.test(source)) {
 		return {
@@ -175,6 +174,9 @@ export const resolveAutoUpdatePlan = ({
 				commandText: null,
 			};
 		}
+		if (!UPDATE_TARGET_VERSION.test(normalizedTargetVersion)) {
+			return { allowed: false, reason: "invalid-version", command: null, commandText: null };
+		}
 		return createNpmUpdatePlan(normalizedTargetVersion);
   }
 
@@ -197,6 +199,9 @@ export const resolveAutoUpdatePlan = ({
   }
 
 	if (normalizedRunner === "codemem") {
+		if (!UPDATE_TARGET_VERSION.test(normalizedTargetVersion)) {
+			return { allowed: false, reason: "invalid-version", command: null, commandText: null };
+		}
 		return createNpmUpdatePlan(normalizedTargetVersion);
 	}
 

--- a/packages/cli/.opencode/tests/compat.test.js
+++ b/packages/cli/.opencode/tests/compat.test.js
@@ -107,7 +107,11 @@ describe("parseBackendUpdatePolicy", () => {
 
 describe("resolveAutoUpdatePlan", () => {
 	test("allows the known global npm runner and updates both packages", () => {
-		const plan = resolveAutoUpdatePlan({ runner: "codemem", runnerFrom: "/tmp/project" });
+		const plan = resolveAutoUpdatePlan({
+			runner: "codemem",
+			runnerFrom: "/tmp/project",
+			targetVersion: "0.41.0",
+		});
 		expect(plan.allowed).toBe(true);
 		expect(plan.command).toEqual([
 			"npm",
@@ -116,8 +120,8 @@ describe("resolveAutoUpdatePlan", () => {
 			"--registry",
 			"https://registry.npmjs.org/",
 			"--@codemem:registry=https://registry.npmjs.org/",
-			"codemem@latest",
-			"@codemem/embeddings@latest",
+			"codemem@0.41.0",
+			"@codemem/embeddings@0.41.0",
 		]);
 	});
 
@@ -137,6 +141,75 @@ describe("resolveAutoUpdatePlan", () => {
 			"codemem@0.41.0",
 			"@codemem/embeddings@0.41.0",
 		]);
+	});
+
+	test("pins both packages to an opted-in prerelease target", () => {
+		const targetVersion = "0.44.0-alpha.2";
+		const plan = resolveAutoUpdatePlan({
+			runner: "codemem",
+			runnerFrom: "/tmp/project",
+			targetVersion,
+		});
+
+		expect(plan.command).toEqual([
+			"npm",
+			"install",
+			"-g",
+			"--registry",
+			"https://registry.npmjs.org/",
+			"--@codemem:registry=https://registry.npmjs.org/",
+			`codemem@${targetVersion}`,
+			`@codemem/embeddings@${targetVersion}`,
+		]);
+	});
+
+	test("pins both packages to an rc target", () => {
+		const plan = resolveAutoUpdatePlan({
+			runner: "codemem",
+			runnerFrom: "/tmp/project",
+			targetVersion: "0.44.0-rc.1",
+		});
+
+		expect(plan.command).toEqual([
+			"npm",
+			"install",
+			"-g",
+			"--registry",
+			"https://registry.npmjs.org/",
+			"--@codemem:registry=https://registry.npmjs.org/",
+			"codemem@0.44.0-rc.1",
+			"@codemem/embeddings@0.44.0-rc.1",
+		]);
+	});
+
+	test("rejects a missing target version", () => {
+		expect(
+			resolveAutoUpdatePlan({ runner: "codemem", runnerFrom: "/tmp/project" }),
+		).toMatchObject({ allowed: false, reason: "invalid-version" });
+	});
+
+	test("rejects a dist-tag target", () => {
+		expect(
+			resolveAutoUpdatePlan({
+				runner: "codemem",
+				runnerFrom: "/tmp/project",
+				targetVersion: "latest",
+			}),
+		).toMatchObject({ allowed: false, reason: "invalid-version" });
+	});
+
+	test("accepts an exact target with build metadata", () => {
+		const targetVersion = "0.41.0+build.7";
+		const plan = resolveAutoUpdatePlan({
+			runner: "codemem",
+			runnerFrom: "/tmp/project",
+			targetVersion,
+		});
+
+		expect(plan.command).toEqual(expect.arrayContaining([
+			`codemem@${targetVersion}`,
+			`@codemem/embeddings@${targetVersion}`,
+		]));
 	});
 
 	test("blocks plugin-owned auto-update on Windows", () => {
@@ -172,6 +245,7 @@ describe("resolveAutoUpdatePlan", () => {
 				runner: "npx",
 				runnerFrom: "codemem@latest",
 				runnerFromExplicit: true,
+				targetVersion: "0.41.0",
 			}),
 		).toMatchObject({ allowed: true });
 		expect(resolveAutoUpdatePlan({ runner: "npx", runnerFrom: "codemem@latest" })).toMatchObject({

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -10,29 +10,24 @@ vi.mock("node:child_process", () => ({
 }));
 
 const currentStatus = {
-	current_version: "0.40.2",
-	latest_version: "0.40.2",
+	current_version: "0.44.0-alpha.1",
+	channel: "alpha",
+	latest_version: "0.44.0-alpha.1",
 	update_available: false,
 	first_seen_at: "2026-08-10T12:00:00.000Z",
 	checked_at: "2026-08-10T12:00:00.000Z",
 	stale: false,
 	install_kind: "npm-global",
 	auto_update_eligible: false,
-	recommended_action: "No action required; codemem is up to date.",
+	recommended_action: "No action required; codemem is on the latest alpha release.",
 	error: null,
-};
-
-const compatibleStatus = {
-	...currentStatus,
-	current_version: "0.41.0",
-	latest_version: "0.41.0",
 };
 
 const availableStatus = {
 	...currentStatus,
-	latest_version: "0.41.0",
+	latest_version: "0.44.0-alpha.2",
 	update_available: true,
-	recommended_action: "npm install -g codemem@0.41.0",
+	recommended_action: "npm install -g codemem@0.44.0-alpha.2",
 };
 
 function makeProcess(
@@ -83,7 +78,7 @@ function installCompatibilityAutoUpdateSpawnResult({ startViewer = false } = {})
 		if (args?.includes("version")) {
 			versionCallCount += 1;
 			return makeProcess({
-				stdout: versionCallCount === 1 ? "0.40.2\n" : "0.41.0\n",
+				stdout: versionCallCount === 1 ? "0.40.2\n" : `${availableStatus.latest_version}\n`,
 			});
 		}
 		if (args?.includes("update") && args?.includes("check")) {
@@ -100,7 +95,7 @@ function isPairedInstallCall(call) {
 	return (
 		call[0] === "npm" &&
 		call[1]?.join(" ") ===
-			"install -g --registry https://registry.npmjs.org/ --@codemem:registry=https://registry.npmjs.org/ codemem@0.41.0 @codemem/embeddings@0.41.0"
+			`install -g --registry https://registry.npmjs.org/ --@codemem:registry=https://registry.npmjs.org/ codemem@${availableStatus.latest_version} @codemem/embeddings@${availableStatus.latest_version}`
 	);
 }
 
@@ -143,6 +138,23 @@ describe("@codemem/opencode-plugin exports", () => {
 		expect(plugin.default).toBe(plugin.CodememPlugin);
 		expect(plugin.OpencodeMemPlugin).toBe(plugin.CodememPlugin);
 	});
+
+	test("keeps a newer same-channel prerelease on the global runner", async () => {
+		execSyncMock.mockReturnValueOnce("0.44.0-alpha.2");
+		const { __testUtils } = await import("../plugins/codemem.js");
+
+		expect(__testUtils.detectRunner({ cwd: "/tmp/codemem", envRunner: "" })).toBe("codemem");
+	});
+
+	test.each(["0.44.0-alpha.0", "0.44.0-beta.2"])(
+		"rejects an older or cross-channel global runner at %s",
+		async (version) => {
+			execSyncMock.mockReturnValueOnce(version);
+			const { __testUtils } = await import("../plugins/codemem.js");
+
+			expect(__testUtils.detectRunner({ cwd: "/tmp/codemem", envRunner: "" })).toBe("npx");
+		},
+	);
 });
 
 describe("OpenCode startup release notifications", () => {
@@ -213,7 +225,7 @@ describe("OpenCode startup release notifications", () => {
 		expect(showToast).toHaveBeenCalledTimes(1);
 		expect(showToast).toHaveBeenCalledWith({
 			body: expect.objectContaining({
-				message: expect.stringMatching(/0\.41\.0.*npm install -g codemem@0\.41\.0/i),
+				message: expect.stringContaining(availableStatus.recommended_action),
 			}),
 		});
 	});
@@ -225,7 +237,7 @@ describe("OpenCode startup release notifications", () => {
 			if (args?.includes("update") && args?.includes("check")) {
 				return makeProcess({ stdout: JSON.stringify(status) });
 			}
-			if (args?.includes("version")) return makeProcess({ stdout: "0.40.2\n" });
+			if (args?.includes("version")) return makeProcess({ stdout: `${currentStatus.current_version}\n` });
 			return makeProcess();
 		});
 		const showToast = vi.fn().mockResolvedValue(undefined);
@@ -235,15 +247,47 @@ describe("OpenCode startup release notifications", () => {
 		await runStartupChecks();
 		status = {
 			...availableStatus,
-			latest_version: "0.42.0",
-			recommended_action: "npm install -g codemem@0.42.0",
+			latest_version: "0.44.0-alpha.3",
+			recommended_action: "npm install -g codemem@0.44.0-alpha.3",
 		};
 		await startPlugin(showToast);
 		await runStartupChecks();
 
 		// Assert
 		expect(showToast).toHaveBeenCalledTimes(2);
-		expect(showToast.mock.calls[1]?.[0]?.body?.message).toMatch(/0\.42\.0/);
+		expect(showToast.mock.calls[1]?.[0]?.body?.message).toMatch(/0\.44\.0-alpha\.3/);
+	});
+
+	test.each([
+		{
+			label: "missing channel identity",
+			status: { ...availableStatus, channel: undefined },
+		},
+		{
+			label: "stable status on an alpha plugin",
+			status: {
+				...availableStatus,
+				channel: "latest",
+				latest_version: "0.44.0",
+				recommended_action: "npm install -g codemem@0.44.0",
+			},
+		},
+		{
+			label: "guidance for another version",
+			status: {
+				...availableStatus,
+				recommended_action: "npm install -g codemem@0.44.0-alpha.3",
+			},
+		},
+	])("ignores $label", async ({ status }) => {
+		installSpawnResult(status);
+		const showToast = vi.fn().mockResolvedValue(undefined);
+
+		await startPlugin(showToast);
+		await runStartupChecks();
+
+		expect(showToast).not.toHaveBeenCalled();
+		expect(spawnMock.mock.calls.some((call) => call[1]?.includes("install"))).toBe(false);
 	});
 
 	test("off skips release discovery and notification without disabling compatibility checks", async () => {
@@ -287,7 +331,7 @@ describe("OpenCode startup release notifications", () => {
 		expect(args.some((value) => value?.join(" ") === "update install --json")).toBe(false);
 		expect(showToast).toHaveBeenCalledTimes(1);
 		expect(showToast.mock.calls[0]?.[0]?.body).toMatchObject({
-			message: "Updated codemem to 0.41.0.",
+			message: `Updated codemem to ${availableStatus.latest_version}.`,
 			variant: "success",
 		});
 	});
@@ -314,7 +358,7 @@ describe("OpenCode startup release notifications", () => {
 					stdout: JSON.stringify({ ...availableStatus, auto_update_eligible: true }),
 				});
 			}
-			if (args?.includes("version")) return makeProcess({ stdout: "0.40.2\n" });
+			if (args?.includes("version")) return makeProcess({ stdout: `${currentStatus.current_version}\n` });
 			return makeProcess();
 		});
 		const showToast = vi.fn().mockResolvedValue(undefined);
@@ -360,7 +404,9 @@ describe("OpenCode startup release notifications", () => {
 				});
 			}
 			if (args?.includes("version")) {
-				return makeProcess({ stdout: `${installed ? "0.41.0" : "0.40.2"}\n` });
+				return makeProcess({
+					stdout: `${installed ? availableStatus.latest_version : currentStatus.current_version}\n`,
+				});
 			}
 			return makeProcess();
 		});
@@ -508,8 +554,8 @@ describe("OpenCode startup release notifications", () => {
 				"--registry",
 				"https://registry.npmjs.org/",
 				"--@codemem:registry=https://registry.npmjs.org/",
-				"codemem@0.41.0",
-				"@codemem/embeddings@0.41.0",
+				`codemem@${availableStatus.latest_version}`,
+				`@codemem/embeddings@${availableStatus.latest_version}`,
 			],
 			expect.objectContaining({
 				cwd: "/tmp/codemem",
@@ -539,7 +585,7 @@ describe("OpenCode startup release notifications", () => {
 		).toHaveLength(1);
 		expect(showToast).toHaveBeenCalledWith({
 			body: {
-				message: "Updated codemem backend from 0.40.2 to 0.41.0.",
+				message: `Updated codemem backend from 0.40.2 to ${availableStatus.latest_version}.`,
 				variant: "success",
 			},
 		});
@@ -582,7 +628,7 @@ describe("OpenCode startup release notifications", () => {
 				(call) =>
 					call[0] === "npm" &&
 					call[1]?.join(" ") ===
-						"install -g --registry https://registry.npmjs.org/ --@codemem:registry=https://registry.npmjs.org/ codemem@0.41.0 @codemem/embeddings@0.41.0",
+						`install -g --registry https://registry.npmjs.org/ --@codemem:registry=https://registry.npmjs.org/ codemem@${availableStatus.latest_version} @codemem/embeddings@${availableStatus.latest_version}`,
 			),
 		).toBe(true);
 		expect(
@@ -597,7 +643,7 @@ describe("OpenCode startup release notifications", () => {
 		).toBe(false);
 		expect(showToast).toHaveBeenCalledWith({
 			body: {
-				message: "Updated codemem backend from 0.40.2 to 0.41.0.",
+				message: `Updated codemem backend from 0.40.2 to ${availableStatus.latest_version}.`,
 				variant: "success",
 			},
 		});
@@ -605,7 +651,7 @@ describe("OpenCode startup release notifications", () => {
 
 	test("compatibility auto-update skips a release that is not eligible", async () => {
 		process.env.CODEMEM_BACKEND_UPDATE_POLICY = "auto";
-		process.env.CODEMEM_MIN_VERSION = "0.41.0";
+		process.env.CODEMEM_MIN_VERSION = "0.45.0";
 		installSpawnResult({ ...availableStatus, auto_update_eligible: false });
 		const showToast = vi.fn().mockResolvedValue(undefined);
 
@@ -636,7 +682,9 @@ describe("OpenCode startup release notifications", () => {
 		await runStartupChecks();
 
 		expect(spawnMock.mock.calls.some((call) => call[1]?.includes("install"))).toBe(false);
-		expect(showToast.mock.calls[0]?.[0]?.body?.message).toMatch(/0\.41\.0.*npm install/i);
+		expect(showToast.mock.calls[0]?.[0]?.body?.message).toContain(
+			availableStatus.recommended_action,
+		);
 	});
 
 	test("auto does not invoke installation when runner provenance is pinned", async () => {
@@ -650,7 +698,9 @@ describe("OpenCode startup release notifications", () => {
 		await runStartupChecks();
 
 		expect(spawnMock.mock.calls.some((call) => call[1]?.includes("install"))).toBe(false);
-		expect(showToast.mock.calls.at(-1)?.[0]?.body?.message).toMatch(/0\.41\.0/);
+		expect(showToast.mock.calls.at(-1)?.[0]?.body?.message).toContain(
+			availableStatus.latest_version,
+		);
 	});
 
 	test.each([
@@ -666,7 +716,7 @@ describe("OpenCode startup release notifications", () => {
 					exitCode,
 				});
 			}
-			if (args?.includes("version")) return makeProcess({ stdout: "0.40.2\n" });
+			if (args?.includes("version")) return makeProcess({ stdout: `${currentStatus.current_version}\n` });
 			return makeProcess();
 		});
 		const showToast = vi.fn().mockResolvedValue(undefined);
@@ -688,7 +738,7 @@ describe("OpenCode startup release notifications", () => {
 		// Arrange
 		spawnMock.mockImplementation((_command, args) => {
 			if (args?.includes("update") && args?.includes("check")) return makeProcess({ settle: false });
-			if (args?.includes("version")) return makeProcess({ stdout: "0.40.2\n" });
+			if (args?.includes("version")) return makeProcess({ stdout: `${currentStatus.current_version}\n` });
 			return makeProcess();
 		});
 
@@ -711,8 +761,7 @@ describe("OpenCode startup release notifications", () => {
 		installSpawnResult({
 			...availableStatus,
 			install_kind: "docker",
-			recommended_action:
-				"Set CODEMEM_VERSION=0.41.0, then run CODEMEM_VERSION=0.41.0 docker compose build --pull and docker compose up -d.",
+			recommended_action: `Set CODEMEM_VERSION=${availableStatus.latest_version}, then run CODEMEM_VERSION=${availableStatus.latest_version} docker compose build --pull and docker compose up -d.`,
 		});
 		const showToast = vi.fn().mockResolvedValue(undefined);
 

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -28,6 +28,7 @@ let testHome = "";
 
 const availableStatus = {
 	current_version: "0.40.2",
+	channel: "latest",
 	latest_version: "0.41.0",
 	update_available: true,
 	first_seen_at: "2026-08-10T12:00:00.000Z",
@@ -178,7 +179,7 @@ describe("update check command", () => {
 		expect(process.exitCode).toBeUndefined();
 	});
 
-	it("emits exactly one stable status object in JSON mode", async () => {
+	it("emits exactly one channel-aware status object in JSON mode", async () => {
 		// Arrange
 		getUpdateStatus.mockResolvedValue(availableStatus);
 		const log = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -307,6 +308,31 @@ describe("update install command", () => {
 			previous_version: "0.40.2",
 			installed_version: "0.41.0",
 		});
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("installs an eligible prerelease within the reported channel with exact package pairing", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+		getUpdateStatus.mockResolvedValue({
+			...availableStatus,
+			current_version: "0.44.0-alpha.1",
+			channel: "alpha",
+			latest_version: "0.44.0-alpha.2",
+			auto_update_eligible: true,
+		});
+		spawn
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.44.0-alpha.2\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn).toHaveBeenNthCalledWith(
+			1,
+			"npm",
+			expect.arrayContaining(["codemem@0.44.0-alpha.2", "@codemem/embeddings@0.44.0-alpha.2"]),
+			expect.objectContaining({ shell: false }),
+		);
 		expect(process.exitCode).toBeUndefined();
 	});
 });

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -2,7 +2,12 @@ import { spawn, spawnSync } from "node:child_process";
 import { mkdir, open, readFile, stat, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
-import { detectInstallKind, getUpdateStatus, isStableReleaseVersion, VERSION } from "@codemem/core";
+import {
+	detectInstallKind,
+	getUpdateStatus,
+	isReleaseVersionForChannel,
+	VERSION,
+} from "@codemem/core";
 import { Command, Option } from "commander";
 import { helpStyle } from "../help-style.js";
 import { addJsonOption, emitJsonError, type JsonOpts } from "../shared-options.js";
@@ -217,14 +222,14 @@ function renderHumanStatus(status: Awaited<ReturnType<typeof getUpdateStatus>>):
 	if (status.update_available) {
 		return `Update available${cacheQualifier(status.stale)}: ${status.current_version} → ${status.latest_version}. ${status.recommended_action}${warning}`;
 	}
-	if (!isStableReleaseVersion(status.current_version)) {
+	if (!status.channel || !isReleaseVersionForChannel(status.current_version, status.channel)) {
 		return `Unable to compare current version ${status.current_version} with ${status.latest_version}. ${status.recommended_action}${warning}`;
 	}
 	return `${status.current_version} is up to date${cacheQualifier(status.stale)}.${warning}`;
 }
 
 const checkCommand = addJsonOption(
-	new Command("check").description("Check for a newer stable codemem release"),
+	new Command("check").description("Check for a newer codemem release on the installed channel"),
 )
 	.addOption(new Option("-r, --refresh", "bypass the six-hour release cache"))
 	.configureHelp(helpStyle)
@@ -295,11 +300,11 @@ async function installUpdate(options: UpdateInstallOptions): Promise<void> {
 		}
 
 		const targetVersion = status.latest_version;
-		if (!isStableReleaseVersion(targetVersion)) {
+		if (!status.channel || !isReleaseVersionForChannel(targetVersion, status.channel)) {
 			failInstall(
 				options,
 				"update_install_refused",
-				"release version is not a stable semantic version",
+				"release version does not match the installed channel",
 			);
 			return;
 		}
@@ -356,7 +361,7 @@ async function installUpdate(options: UpdateInstallOptions): Promise<void> {
 }
 
 const installCommand = addJsonOption(
-	new Command("install").description("Install an eligible stable codemem update"),
+	new Command("install").description("Install an eligible codemem update on the installed channel"),
 )
 	.configureHelp(helpStyle)
 	.action(installUpdate);

--- a/packages/core/src/release-discovery.test.ts
+++ b/packages/core/src/release-discovery.test.ts
@@ -8,14 +8,16 @@ import {
 	detectInstallKind,
 	type InstallDetectionInput,
 	type InstallKind,
+	type ReleaseChannel,
 	type ReleaseDiscoveryDependencies,
 } from "./release-discovery.js";
 
 const NOW = new Date("2026-08-10T12:00:00.000Z");
-const REGISTRY_URL = "https://registry.npmjs.org/codemem/latest";
+const registryUrl = (channel: ReleaseChannel) => `https://registry.npmjs.org/codemem/${channel}`;
 
 type CacheRecord = {
 	schema_version: number;
+	channel?: ReleaseChannel;
 	latest_version: string;
 	checked_at: string;
 	first_seen_at: string;
@@ -137,6 +139,7 @@ describe("release discovery registry contract", () => {
 		// Assert
 		expect(status).toMatchObject({
 			current_version: "0.40.2",
+			channel: "latest",
 			latest_version: "0.40.2",
 			update_available: false,
 			stale: false,
@@ -160,6 +163,50 @@ describe("release discovery registry contract", () => {
 			stale: false,
 		});
 	});
+
+	it.each([
+		{ channel: "alpha", currentVersion: "0.44.0-alpha.1", latestVersion: "0.44.0-alpha.2" },
+		{ channel: "beta", currentVersion: "0.44.0-beta.1", latestVersion: "0.44.0-beta.2" },
+		{ channel: "rc", currentVersion: "0.44.0-rc.1", latestVersion: "0.44.0-rc.2" },
+		{ channel: "latest", currentVersion: "0.43.0", latestVersion: "0.44.0" },
+	] satisfies Array<{
+		channel: ReleaseChannel;
+		currentVersion: string;
+		latestVersion: string;
+	}>)(
+		"queries npm's $channel tag for an installed $channel release",
+		async ({ channel, currentVersion, latestVersion }) => {
+			const deps = dependencies({ payload: { version: latestVersion } });
+
+			const status = await check(deps, { currentVersion });
+
+			expect(status).toMatchObject({
+				channel,
+				latest_version: latestVersion,
+				update_available: true,
+			});
+			expect(deps.fetch).toHaveBeenCalledWith(
+				registryUrl(channel),
+				expect.objectContaining({ redirect: "error" }),
+			);
+		},
+	);
+
+	it.each([
+		{ currentVersion: "0.44.0-alpha.1", registryVersion: "0.44.0-beta.1" },
+		{ currentVersion: "0.44.0-beta.1", registryVersion: "0.44.0-alpha.2" },
+		{ currentVersion: "0.43.0", registryVersion: "0.44.0-alpha.2" },
+	])(
+		"rejects registry version $registryVersion outside the installed channel",
+		async ({ currentVersion, registryVersion }) => {
+			const status = await check(dependencies({ payload: { version: registryVersion } }), {
+				currentVersion,
+			});
+
+			expect(status).toMatchObject({ latest_version: null, update_available: false });
+			expect(status.error).toMatch(/invalid registry version/i);
+		},
+	);
 
 	it("accepts stable semantic versions with build metadata", async () => {
 		// Arrange
@@ -204,6 +251,27 @@ describe("release discovery registry contract", () => {
 		const status = await check(deps, { installKind: "npm-global" });
 
 		expect(status.auto_update_eligible).toBe(true);
+	});
+
+	it("allows an opted-in alpha installation to auto-update within alpha", async () => {
+		const deps = dependencies({
+			cache: JSON.stringify(
+				cacheRecord({
+					schema_version: 2,
+					channel: "alpha",
+					latest_version: "0.44.0-alpha.2",
+					first_seen_at: "2026-08-09T12:00:00.000Z",
+					checked_at: NOW.toISOString(),
+				}),
+			),
+		});
+
+		const status = await check(deps, {
+			currentVersion: "0.44.0-alpha.1",
+			installKind: "npm-global",
+		});
+
+		expect(status).toMatchObject({ channel: "alpha", auto_update_eligible: true });
 	});
 
 	it("refuses a release observed for less than 24 hours", async () => {
@@ -284,7 +352,7 @@ describe("release discovery registry contract", () => {
 		// Assert
 		expect(deps.timeoutSignal).toHaveBeenCalledWith(2_000);
 		expect(deps.fetch).toHaveBeenCalledWith(
-			REGISTRY_URL,
+			registryUrl("latest"),
 			expect.objectContaining({ redirect: "error", signal: expect.any(AbortSignal) }),
 		);
 	});
@@ -358,7 +426,7 @@ describe("release discovery registry contract", () => {
 		// Arrange
 		const deps = dependencies();
 		const chunks = Array.from({ length: 20 }, () => "x".repeat(4_096));
-		const streamed = streamingResponse({ chunks, contentLength, url: REGISTRY_URL });
+		const streamed = streamingResponse({ chunks, contentLength, url: registryUrl("latest") });
 		deps.fetch.mockResolvedValue(streamed.response);
 
 		// Act
@@ -375,7 +443,7 @@ describe("release discovery registry contract", () => {
 		const deps = dependencies();
 		const streamed = streamingResponse({
 			chunks: ["é".repeat(9_000)],
-			url: REGISTRY_URL,
+			url: registryUrl("latest"),
 		});
 		deps.fetch.mockResolvedValue(streamed.response);
 
@@ -396,6 +464,24 @@ describe("release discovery registry contract", () => {
 		// Assert
 		expect(status.update_available).toBe(false);
 		expect(status.recommended_action).not.toMatch(/up to date|no action required/i);
+		expect(deps.fetch).not.toHaveBeenCalled();
+	});
+
+	it("routes an rc installation through the rc channel", async () => {
+		const deps = dependencies({ payload: { version: "0.44.0-rc.2" } });
+
+		const status = await check(deps, { currentVersion: "0.44.0-rc.1" });
+
+		expect(status).toMatchObject({
+			channel: "rc",
+			latest_version: "0.44.0-rc.2",
+			update_available: true,
+		});
+		expect(status.recommended_action).toContain("codemem@0.44.0-rc.2");
+		expect(deps.fetch).toHaveBeenCalledWith(
+			registryUrl("rc"),
+			expect.objectContaining({ redirect: "error", signal: expect.any(AbortSignal) }),
+		);
 	});
 });
 
@@ -439,8 +525,51 @@ describe("release discovery cache contract", () => {
 
 		// Assert
 		const contents = String(deps.writeCacheAtomic.mock.calls[0]?.[0]);
-		expect(JSON.parse(contents)).toMatchObject({ schema_version: 1 });
+		expect(JSON.parse(contents)).toMatchObject({ schema_version: 2, channel: "latest" });
 	});
+
+	it("preserves a valid legacy stable cache without registry access", async () => {
+		const cached = cacheRecord({ checked_at: "2026-08-10T11:00:00.000Z" });
+		const deps = dependencies({ cache: JSON.stringify(cached) });
+
+		const status = await check(deps);
+
+		expect(status).toMatchObject({ channel: "latest", latest_version: "0.41.0" });
+		expect(deps.fetch).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{
+			label: "alpha installation with stable legacy cache",
+			currentVersion: "0.44.0-alpha.1",
+			cache: cacheRecord({ checked_at: "2026-08-10T11:00:00.000Z" }),
+			registryVersion: "0.44.0-alpha.2",
+		},
+		{
+			label: "stable installation with alpha cache",
+			currentVersion: "0.43.0",
+			cache: cacheRecord({
+				schema_version: 2,
+				channel: "alpha",
+				latest_version: "0.44.0-alpha.2",
+				checked_at: "2026-08-10T11:00:00.000Z",
+			}),
+			registryVersion: "0.44.0",
+		},
+	])(
+		"never reuses a cache across channels: $label",
+		async ({ currentVersion, cache, registryVersion }) => {
+			const deps = dependencies({
+				cache: JSON.stringify(cache),
+				payload: { version: registryVersion },
+			});
+
+			const status = await check(deps, { currentVersion });
+
+			expect(status.latest_version).toBe(registryVersion);
+			expect(deps.fetch).toHaveBeenCalledTimes(1);
+		},
+	);
 
 	it("preserves first-seen time while the same latest release remains current", async () => {
 		// Arrange
@@ -541,7 +670,7 @@ describe("release discovery cache contract", () => {
 		{
 			label: "unsupported schema version",
 			cache: cacheRecord({
-				schema_version: 2,
+				schema_version: 3,
 				checked_at: "2026-08-10T11:00:00.000Z",
 				first_seen_at: "2026-08-10T10:00:00.000Z",
 			}),
@@ -625,6 +754,24 @@ describe("release discovery cache contract", () => {
 		// Assert
 		expect(deps.fetch).toHaveBeenCalledTimes(1);
 		expect(second).toEqual(first);
+	});
+
+	it("does not reuse an in-memory result across channels", async () => {
+		const deps = dependencies();
+		deps.fetch.mockImplementation(async (url: string) =>
+			response({ version: url.endsWith("/alpha") ? "0.44.0-alpha.2" : "0.44.0" }),
+		);
+		const discovery = createReleaseDiscovery(deps);
+
+		const alpha = await discovery.check({
+			currentVersion: "0.44.0-alpha.1",
+			installKind: "npm-global",
+		});
+		const stable = await discovery.check({ currentVersion: "0.43.0", installKind: "npm-global" });
+
+		expect(alpha.latest_version).toBe("0.44.0-alpha.2");
+		expect(stable.latest_version).toBe("0.44.0");
+		expect(deps.fetch).toHaveBeenCalledTimes(2);
 	});
 
 	it("backs off sequential registry failures when no cache exists", async () => {
@@ -883,6 +1030,20 @@ describe("installation-kind detection", () => {
 });
 
 describe("installation guidance", () => {
+	it.each([
+		{ channel: "alpha", currentVersion: "0.44.0-alpha.1", latestVersion: "0.44.0-alpha.2" },
+		{ channel: "beta", currentVersion: "0.44.0-beta.1", latestVersion: "0.44.0-beta.2" },
+	] as const)(
+		"keeps $channel guidance on the installed channel",
+		async ({ currentVersion, latestVersion }) => {
+			const status = await check(dependencies({ payload: { version: latestVersion } }), {
+				currentVersion,
+			});
+
+			expect(status.recommended_action).toContain(`codemem@${latestVersion}`);
+		},
+	);
+
 	it.each([
 		["npm-global", "npm install -g codemem@0.41.0"],
 		["npx", "codemem@0.41.0 and @codemem/embeddings@0.41.0"],

--- a/packages/core/src/release-discovery.ts
+++ b/packages/core/src/release-discovery.ts
@@ -4,22 +4,24 @@ import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { codememHomeDir } from "./home.js";
 
-const REGISTRY_URL = "https://registry.npmjs.org/codemem/latest";
+const REGISTRY_URL_PREFIX = "https://registry.npmjs.org/codemem/";
 const REQUEST_TIMEOUT_MS = 2_000;
 const CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1_000;
 const FAILURE_RETRY_DELAY_MS = 15 * 60 * 1_000;
 const MAX_RESPONSE_BYTES = 16 * 1_024;
 const MAX_VERSION_LENGTH = 128;
 const MAX_RUNNER_SOURCE_LENGTH = 4_096;
-const RELEASE_CACHE_SCHEMA_VERSION = 1;
+const RELEASE_CACHE_SCHEMA_VERSION = 2;
 const AUTO_UPDATE_DELAY_MS = 24 * 60 * 60 * 1_000;
-const STABLE_SEMVER =
-	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const SEMVER =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 export type InstallKind = "npm-global" | "npx" | "docker" | "repo-dev" | "pinned" | "unknown";
+export type ReleaseChannel = "alpha" | "beta" | "rc" | "latest";
 
 export interface UpdateStatus {
 	current_version: string;
+	channel: ReleaseChannel | null;
 	latest_version: string | null;
 	update_available: boolean;
 	first_seen_at: string | null;
@@ -33,6 +35,7 @@ export interface UpdateStatus {
 
 interface ReleaseCacheRecord {
 	schema_version: typeof RELEASE_CACHE_SCHEMA_VERSION;
+	channel: ReleaseChannel;
 	latest_version: string;
 	checked_at: string;
 	first_seen_at: string;
@@ -72,29 +75,82 @@ interface ReleaseResolution {
 	error: string | null;
 }
 
-function parseStableSemver(value: unknown): [number, number, number] | null {
+interface ParsedSemver {
+	core: [number, number, number];
+	prerelease: string[];
+}
+
+interface ReleaseDiscoveryState {
+	inFlight: Map<ReleaseChannel, Promise<ReleaseResolution>>;
+	memoryResolutions: Map<ReleaseChannel, { resolution: ReleaseResolution; resolvedAtMs: number }>;
+}
+
+function parseSemver(value: unknown): ParsedSemver | null {
 	if (typeof value !== "string" || value.length === 0 || value.length > MAX_VERSION_LENGTH) {
 		return null;
 	}
-	const match = STABLE_SEMVER.exec(value);
+	const match = SEMVER.exec(value);
 	if (!match) return null;
 	const parts = match.slice(1, 4).map(Number);
-	return parts.every(Number.isSafeInteger) ? (parts as [number, number, number]) : null;
+	if (!parts.every(Number.isSafeInteger)) return null;
+	const prerelease = match[4]?.split(".") ?? [];
+	if (prerelease.some((identifier) => /^\d+$/.test(identifier) && /^0\d/.test(identifier))) {
+		return null;
+	}
+	return { core: parts as [number, number, number], prerelease };
+}
+
+export function releaseChannelForVersion(value: unknown): ReleaseChannel | null {
+	const parsed = parseSemver(value);
+	if (!parsed) return null;
+	if (parsed.prerelease.length === 0) return "latest";
+	const channel = parsed.prerelease[0];
+	return channel === "alpha" || channel === "beta" || channel === "rc" ? channel : null;
+}
+
+export function isReleaseVersionForChannel(
+	value: unknown,
+	channel: ReleaseChannel,
+): value is string {
+	return releaseChannelForVersion(value) === channel;
 }
 
 export function isStableReleaseVersion(value: unknown): value is string {
-	return parseStableSemver(value) !== null;
+	return releaseChannelForVersion(value) === "latest";
 }
 
-function compareStableSemver(left: string, right: string): number | null {
-	const leftParts = parseStableSemver(left);
-	const rightParts = parseStableSemver(right);
-	if (!leftParts || !rightParts) return null;
-	for (const index of [0, 1, 2] as const) {
-		const difference = leftParts[index] - rightParts[index];
-		if (difference !== 0) return Math.sign(difference);
+function comparePrereleaseIdentifier(left: string | undefined, right: string | undefined): number {
+	if (left === undefined) return right === undefined ? 0 : -1;
+	if (right === undefined) return 1;
+	if (left === right) return 0;
+	const leftNumeric = /^\d+$/.test(left);
+	const rightNumeric = /^\d+$/.test(right);
+	if (leftNumeric && rightNumeric && left.length !== right.length) {
+		return Math.sign(left.length - right.length);
+	}
+	if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+	return left < right ? -1 : 1;
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+	if (left.length === 0) return right.length === 0 ? 0 : 1;
+	if (right.length === 0) return -1;
+	for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+		const comparison = comparePrereleaseIdentifier(left[index], right[index]);
+		if (comparison !== 0) return comparison;
 	}
 	return 0;
+}
+
+function compareSemver(left: string, right: string): number | null {
+	const leftVersion = parseSemver(left);
+	const rightVersion = parseSemver(right);
+	if (!leftVersion || !rightVersion) return null;
+	for (const index of [0, 1, 2] as const) {
+		const difference = leftVersion.core[index] - rightVersion.core[index];
+		if (difference !== 0) return Math.sign(difference);
+	}
+	return comparePrerelease(leftVersion.prerelease, rightVersion.prerelease);
 }
 
 function parseIsoTimestamp(value: unknown): string | null {
@@ -103,15 +159,24 @@ function parseIsoTimestamp(value: unknown): string | null {
 	return Number.isFinite(timestamp.getTime()) && timestamp.toISOString() === value ? value : null;
 }
 
-function parseCache(contents: string | null, now: Date): ReleaseCacheRecord | null {
+function parseCache(
+	contents: string | null,
+	now: Date,
+	channel: ReleaseChannel,
+): ReleaseCacheRecord | null {
 	if (contents === null) return null;
 	try {
 		const value: unknown = JSON.parse(contents);
 		if (!value || typeof value !== "object" || Array.isArray(value)) return null;
 		const candidate = value as Record<string, unknown>;
-		if (candidate.schema_version !== RELEASE_CACHE_SCHEMA_VERSION) return null;
+		const isLegacyStableCache = candidate.schema_version === 1 && channel === "latest";
+		if (!isLegacyStableCache && candidate.schema_version !== RELEASE_CACHE_SCHEMA_VERSION)
+			return null;
+		const cachedChannel = isLegacyStableCache ? "latest" : candidate.channel;
+		if (cachedChannel !== channel) return null;
 		const latestVersion =
-			typeof candidate.latest_version === "string" && parseStableSemver(candidate.latest_version)
+			typeof candidate.latest_version === "string" &&
+			isReleaseVersionForChannel(candidate.latest_version, channel)
 				? candidate.latest_version
 				: null;
 		const checkedAt = parseIsoTimestamp(candidate.checked_at);
@@ -122,6 +187,7 @@ function parseCache(contents: string | null, now: Date): ReleaseCacheRecord | nu
 		if (checkedTime > now.getTime() || firstSeenTime > checkedTime) return null;
 		return {
 			schema_version: RELEASE_CACHE_SCHEMA_VERSION,
+			channel,
 			latest_version: latestVersion,
 			checked_at: checkedAt,
 			first_seen_at: firstSeenAt,
@@ -188,8 +254,12 @@ async function readBoundedResponseBody(response: Response): Promise<string> {
 	}
 }
 
-async function fetchLatestVersion(deps: ReleaseDiscoveryDependencies): Promise<string> {
-	const response = await deps.fetch(REGISTRY_URL, {
+async function fetchLatestVersion(
+	deps: ReleaseDiscoveryDependencies,
+	channel: ReleaseChannel,
+): Promise<string> {
+	const registryUrl = `${REGISTRY_URL_PREFIX}${channel}`;
+	const response = await deps.fetch(registryUrl, {
 		headers: { accept: "application/json" },
 		redirect: "error",
 		signal: deps.timeoutSignal(REQUEST_TIMEOUT_MS),
@@ -200,7 +270,7 @@ async function fetchLatestVersion(deps: ReleaseDiscoveryDependencies): Promise<s
 	}
 	if (response.url) {
 		const finalUrl = new URL(response.url);
-		if (finalUrl.href !== REGISTRY_URL) {
+		if (finalUrl.href !== registryUrl) {
 			await response.body?.cancel();
 			throw new Error("invalid registry response URL");
 		}
@@ -216,7 +286,7 @@ async function fetchLatestVersion(deps: ReleaseDiscoveryDependencies): Promise<s
 		throw new Error("invalid registry response payload");
 	}
 	const version = (payload as Record<string, unknown>).version;
-	if (typeof version !== "string" || !parseStableSemver(version)) {
+	if (typeof version !== "string" || !isReleaseVersionForChannel(version, channel)) {
 		throw new Error("invalid registry version");
 	}
 	return version;
@@ -227,12 +297,16 @@ function recommendedAction(
 	currentVersion: string,
 	latestVersion: string | null,
 	updateAvailable: boolean,
+	channel: ReleaseChannel | null,
 ): string {
-	if (!latestVersion) return "Check network access and try again.";
-	if (!parseStableSemver(currentVersion)) {
+	if (!channel || !isReleaseVersionForChannel(currentVersion, channel)) {
 		return "Verify the current codemem version and try again.";
 	}
-	if (!updateAvailable) return "No action required; codemem is up to date.";
+	if (!latestVersion) return "Check network access and try again.";
+	if (!updateAvailable) {
+		const releaseLabel = channel === "latest" ? "stable" : channel;
+		return `No action required; codemem is on the latest ${releaseLabel} release.`;
+	}
 	switch (installKind) {
 		case "npm-global":
 			return `${process.platform === "linux" ? "env ONNXRUNTIME_NODE_INSTALL=skip " : ""}npm install -g codemem@${latestVersion}`;
@@ -249,14 +323,17 @@ function recommendedAction(
 	}
 }
 
-function toStatus(resolution: ReleaseResolution, options: ReleaseCheckOptions): UpdateStatus {
+function toStatus(
+	resolution: ReleaseResolution,
+	options: ReleaseCheckOptions,
+	channel: ReleaseChannel | null,
+): UpdateStatus {
 	const latestVersion = resolution.record?.latest_version ?? null;
-	const comparison = latestVersion
-		? compareStableSemver(latestVersion, options.currentVersion)
-		: null;
+	const comparison = latestVersion ? compareSemver(latestVersion, options.currentVersion) : null;
 	const updateAvailable = comparison !== null && comparison > 0;
 	return {
 		current_version: options.currentVersion,
+		channel,
 		latest_version: latestVersion,
 		update_available: updateAvailable,
 		first_seen_at: resolution.record?.first_seen_at ?? null,
@@ -276,83 +353,113 @@ function toStatus(resolution: ReleaseResolution, options: ReleaseCheckOptions): 
 			options.currentVersion,
 			latestVersion,
 			updateAvailable,
+			channel,
 		),
 		error: resolution.error,
 	};
 }
 
-export function createReleaseDiscovery(deps: ReleaseDiscoveryDependencies): ReleaseDiscovery {
-	let inFlight: Promise<ReleaseResolution> | null = null;
-	let memoryResolution: { resolution: ReleaseResolution; resolvedAtMs: number } | null = null;
+function canReuseMemoryResolution(
+	state: ReleaseDiscoveryState,
+	channel: ReleaseChannel,
+	now: Date,
+): boolean {
+	const memoryResolution = state.memoryResolutions.get(channel);
+	if (!memoryResolution) return false;
+	const ageMs = Math.max(0, now.getTime() - memoryResolution.resolvedAtMs);
+	const { resolution } = memoryResolution;
+	if (resolution.record && !resolution.stale && isFresh(resolution.record, now)) return true;
+	return resolution.error !== null && ageMs < FAILURE_RETRY_DELAY_MS;
+}
 
-	function canReuseMemoryResolution(now: Date): boolean {
-		if (!memoryResolution) return false;
-		const ageMs = Math.max(0, now.getTime() - memoryResolution.resolvedAtMs);
-		const { resolution } = memoryResolution;
-		if (resolution.record && !resolution.stale && isFresh(resolution.record, now)) return true;
-		return resolution.error !== null && ageMs < FAILURE_RETRY_DELAY_MS;
-	}
-
-	async function refresh(cached: ReleaseCacheRecord | null, now: Date): Promise<ReleaseResolution> {
+async function refreshRelease(
+	deps: ReleaseDiscoveryDependencies,
+	cached: ReleaseCacheRecord | null,
+	now: Date,
+	channel: ReleaseChannel,
+): Promise<ReleaseResolution> {
+	try {
+		const latestVersion = await fetchLatestVersion(deps, channel);
+		const timestamp = now.toISOString();
+		const record: ReleaseCacheRecord = {
+			schema_version: RELEASE_CACHE_SCHEMA_VERSION,
+			channel,
+			latest_version: latestVersion,
+			checked_at: timestamp,
+			first_seen_at: cached?.latest_version === latestVersion ? cached.first_seen_at : timestamp,
+		};
 		try {
-			const latestVersion = await fetchLatestVersion(deps);
-			const timestamp = now.toISOString();
-			const record: ReleaseCacheRecord = {
-				schema_version: RELEASE_CACHE_SCHEMA_VERSION,
-				latest_version: latestVersion,
-				checked_at: timestamp,
-				first_seen_at: cached?.latest_version === latestVersion ? cached.first_seen_at : timestamp,
-			};
-			try {
-				await deps.writeCacheAtomic(JSON.stringify(record));
-				return { record, stale: false, error: null };
-			} catch (error) {
-				return {
-					record,
-					stale: false,
-					error: `cache write failed: ${errorMessage(error)}`,
-				};
-			}
+			await deps.writeCacheAtomic(JSON.stringify(record));
+			return { record, stale: false, error: null };
 		} catch (error) {
-			return { record: cached, stale: cached !== null, error: errorMessage(error) };
+			return { record, stale: false, error: `cache write failed: ${errorMessage(error)}` };
 		}
+	} catch (error) {
+		return { record: cached, stale: cached !== null, error: errorMessage(error) };
 	}
+}
 
-	return {
-		async check(options): Promise<UpdateStatus> {
-			const now = deps.now();
-			let cached: ReleaseCacheRecord | null = null;
-			let cacheReadError: string | null = null;
-			try {
-				cached = parseCache(await deps.readCache(), now);
-			} catch (error) {
-				cacheReadError = `cache read failed: ${errorMessage(error)}`;
-			}
-			if (!options.refresh && cached && isFresh(cached, now)) {
-				return toStatus({ record: cached, stale: false, error: null }, options);
-			}
-			if (!options.refresh && canReuseMemoryResolution(now) && memoryResolution) {
-				const resolution = memoryResolution.resolution;
-				return toStatus(
-					cacheReadError && !resolution.error
-						? { ...resolution, error: cacheReadError }
-						: resolution,
-					options,
-				);
-			}
-			if (!inFlight) {
-				inFlight = refresh(cached, now).finally(() => {
-					inFlight = null;
-				});
-			}
-			const resolution = await inFlight;
-			memoryResolution = { resolution, resolvedAtMs: deps.now().getTime() };
-			return toStatus(
-				cacheReadError && !resolution.error ? { ...resolution, error: cacheReadError } : resolution,
-				options,
-			);
-		},
+function withCacheReadError(
+	resolution: ReleaseResolution,
+	cacheReadError: string | null,
+): ReleaseResolution {
+	return cacheReadError && !resolution.error
+		? { ...resolution, error: cacheReadError }
+		: resolution;
+}
+
+async function readReleaseCache(
+	deps: ReleaseDiscoveryDependencies,
+	now: Date,
+	channel: ReleaseChannel,
+): Promise<{ cached: ReleaseCacheRecord | null; error: string | null }> {
+	try {
+		return { cached: parseCache(await deps.readCache(), now, channel), error: null };
+	} catch (error) {
+		return { cached: null, error: `cache read failed: ${errorMessage(error)}` };
+	}
+}
+
+async function checkRelease(
+	deps: ReleaseDiscoveryDependencies,
+	state: ReleaseDiscoveryState,
+	options: ReleaseCheckOptions,
+): Promise<UpdateStatus> {
+	const now = deps.now();
+	const channel = releaseChannelForVersion(options.currentVersion);
+	if (!channel) {
+		return toStatus(
+			{ record: null, stale: false, error: "unsupported installed release channel" },
+			options,
+			null,
+		);
+	}
+	const cache = await readReleaseCache(deps, now, channel);
+	if (!options.refresh && cache.cached && isFresh(cache.cached, now)) {
+		return toStatus({ record: cache.cached, stale: false, error: null }, options, channel);
+	}
+	const memoryResolution = state.memoryResolutions.get(channel);
+	if (!options.refresh && memoryResolution && canReuseMemoryResolution(state, channel, now)) {
+		return toStatus(withCacheReadError(memoryResolution.resolution, cache.error), options, channel);
+	}
+	let request = state.inFlight.get(channel);
+	if (!request) {
+		request = refreshRelease(deps, cache.cached, now, channel).finally(() => {
+			state.inFlight.delete(channel);
+		});
+		state.inFlight.set(channel, request);
+	}
+	const resolution = await request;
+	state.memoryResolutions.set(channel, { resolution, resolvedAtMs: deps.now().getTime() });
+	return toStatus(withCacheReadError(resolution, cache.error), options, channel);
+}
+
+export function createReleaseDiscovery(deps: ReleaseDiscoveryDependencies): ReleaseDiscovery {
+	const state: ReleaseDiscoveryState = {
+		inFlight: new Map(),
+		memoryResolutions: new Map(),
 	};
+	return { check: (options) => checkRelease(deps, state, options) };
 }
 
 function defaultCachePath(): string {

--- a/packages/opencode-plugin/.opencode/lib/compat.js
+++ b/packages/opencode-plugin/.opencode/lib/compat.js
@@ -117,6 +117,8 @@ const isPinnedGitSource = (runnerFrom) => {
 };
 
 const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org/";
+const UPDATE_TARGET_VERSION =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:alpha|beta|rc)(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 const createNpmUpdatePlan = (targetVersion) => {
 	const command = [
@@ -136,7 +138,7 @@ export const resolveAutoUpdatePlan = ({
 	runner,
 	runnerFrom,
 	runnerFromExplicit = false,
-	targetVersion = "latest",
+	targetVersion,
 	platform = process.platform,
 }) => {
 	const normalizedRunner = String(runner || "").trim();
@@ -144,9 +146,6 @@ export const resolveAutoUpdatePlan = ({
 	const normalizedTargetVersion = String(targetVersion || "").trim();
 	if (platform === "win32") {
 		return { allowed: false, reason: "unsupported-platform", command: null, commandText: null };
-	}
-	if (normalizedTargetVersion !== "latest" && !/^\d+\.\d+\.\d+$/.test(normalizedTargetVersion)) {
-		return { allowed: false, reason: "invalid-version", command: null, commandText: null };
 	}
 	if (isPinnedGitSource(source) || /^codemem@(?!latest$|next$|\*$)[^\s]+$/i.test(source)) {
 		return {
@@ -175,6 +174,9 @@ export const resolveAutoUpdatePlan = ({
 				commandText: null,
 			};
 		}
+		if (!UPDATE_TARGET_VERSION.test(normalizedTargetVersion)) {
+			return { allowed: false, reason: "invalid-version", command: null, commandText: null };
+		}
 		return createNpmUpdatePlan(normalizedTargetVersion);
   }
 
@@ -197,6 +199,9 @@ export const resolveAutoUpdatePlan = ({
   }
 
 	if (normalizedRunner === "codemem") {
+		if (!UPDATE_TARGET_VERSION.test(normalizedTargetVersion)) {
+			return { allowed: false, reason: "invalid-version", command: null, commandText: null };
+		}
 		return createNpmUpdatePlan(normalizedTargetVersion);
 	}
 

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -22,8 +22,8 @@ const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 const MAX_UPDATE_STATUS_BYTES = 16 * 1024;
 const MAX_UPDATE_ACTION_CHARS = 1000;
 const MAX_UPDATE_VERSION_CHARS = 128;
-const STABLE_RELEASE_VERSION =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const RELEASE_VERSION =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const CODEMEM_CONTEXT_PART_ID_PREFIX = "codemem-context-";
 const MAX_MESSAGE_INJECTION_CACHE_SESSIONS = 20;
 const MAX_MESSAGE_INJECTION_CACHE_MESSAGES = 100;
@@ -354,10 +354,74 @@ const clearCompatCheckCache = () => {
   compatCheckCache = null;
 };
 
-const isStableReleaseVersion = (value) => {
-  if (typeof value !== "string" || value.length > MAX_UPDATE_VERSION_CHARS) return false;
-  const match = STABLE_RELEASE_VERSION.exec(value);
-  return Boolean(match && match.slice(1, 4).map(Number).every(Number.isSafeInteger));
+const parseReleaseVersion = (value) => {
+  if (typeof value !== "string" || value.length > MAX_UPDATE_VERSION_CHARS) return null;
+  const match = RELEASE_VERSION.exec(value);
+  if (!match || !match.slice(1, 4).map(Number).every(Number.isSafeInteger)) return null;
+  const prerelease = match[4]?.split(".") || [];
+  if (prerelease.some((identifier) => /^0\d+$/.test(identifier))) return null;
+  return { core: match.slice(1, 4).map(Number), prerelease };
+};
+
+const releaseChannelForVersion = (value) => {
+  const parsed = parseReleaseVersion(value);
+  if (!parsed) return null;
+  if (parsed.prerelease.length === 0) return "latest";
+  const channel = parsed.prerelease[0];
+  return channel === "alpha" || channel === "beta" || channel === "rc" ? channel : null;
+};
+
+const comparePrereleaseIdentifier = (left, right) => {
+  if (left === undefined) return right === undefined ? 0 : -1;
+  if (right === undefined) return 1;
+  if (left === right) return 0;
+  const leftNumeric = /^\d+$/.test(left);
+  const rightNumeric = /^\d+$/.test(right);
+  if (leftNumeric && rightNumeric && left.length !== right.length) {
+    return Math.sign(left.length - right.length);
+  }
+  if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+  return left < right ? -1 : 1;
+};
+
+const compareReleaseVersions = (left, right) => {
+  const leftVersion = parseReleaseVersion(left);
+  const rightVersion = parseReleaseVersion(right);
+  if (!leftVersion || !rightVersion) return null;
+  for (let index = 0; index < leftVersion.core.length; index += 1) {
+    const difference = leftVersion.core[index] - rightVersion.core[index];
+    if (difference !== 0) return Math.sign(difference);
+  }
+  if (leftVersion.prerelease.length === 0) {
+    return rightVersion.prerelease.length === 0 ? 0 : 1;
+  }
+  if (rightVersion.prerelease.length === 0) return -1;
+  const length = Math.max(leftVersion.prerelease.length, rightVersion.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const comparison = comparePrereleaseIdentifier(
+      leftVersion.prerelease[index],
+      rightVersion.prerelease[index],
+    );
+    if (comparison !== 0) return comparison;
+  }
+  return 0;
+};
+
+const isSameChannelVersionAtLeast = (currentVersion, minimumVersion) => {
+  const currentChannel = releaseChannelForVersion(currentVersion);
+  if (!currentChannel || currentChannel !== releaseChannelForVersion(minimumVersion)) return false;
+  const comparison = compareReleaseVersions(currentVersion, minimumVersion);
+  return comparison !== null && comparison >= 0;
+};
+
+const PINNED_RELEASE_CHANNEL = releaseChannelForVersion(PINNED_BACKEND_VERSION);
+
+const guidanceMatchesRelease = (guidance, latestVersion) => {
+  const versions =
+    String(guidance || "").match(
+      /\b\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?/g,
+    ) || [];
+  return versions.length === 0 || versions.every((version) => version === latestVersion);
 };
 
 const parseReleaseNotification = (result) => {
@@ -368,18 +432,24 @@ const parseReleaseNotification = (result) => {
     const status = JSON.parse(stdout);
     if (!status || typeof status !== "object" || Array.isArray(status)) return null;
     if (status.update_available !== true) return null;
-    if (!isStableReleaseVersion(status.latest_version)) {
+    if (
+      !PINNED_RELEASE_CHANNEL
+      || status.channel !== PINNED_RELEASE_CHANNEL
+      || releaseChannelForVersion(status.latest_version) !== PINNED_RELEASE_CHANNEL
+    ) {
       return null;
     }
     if (
       typeof status.recommended_action !== "string"
       || !status.recommended_action.trim()
       || status.recommended_action.length > MAX_UPDATE_ACTION_CHARS
+      || !guidanceMatchesRelease(status.recommended_action, status.latest_version)
     ) {
       return null;
     }
     return {
       latestVersion: status.latest_version,
+      channel: PINNED_RELEASE_CHANNEL,
       recommendedAction: status.recommended_action.trim(),
       autoUpdateEligible: status.auto_update_eligible === true,
     };
@@ -1693,22 +1763,10 @@ const detectRunner = ({ cwd, envRunner }) => {
       // terminal on every OpenCode startup for npx-only installs.
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-    // Accept any global codemem at or above the pinned backend version, so a
-    // newer global install is used instead of silently downgrading to
-    // `npx codemem@<pin>` (the old check only matched the exact pin or the
-    // long-obsolete 0.2x series).
-    // Accept a global codemem only when it is the EXACT pinned version, or a
-    // clean (non-prerelease) release at least as new as the pin. isVersionAtLeast
-    // ignores prerelease suffixes, so without this a prerelease like
-    // "0.36.1-alpha.0" would wrongly compare >= the "0.36.1" release even though
-    // SemVer orders it below. Requiring an exact match for prereleases also
-    // handles a prerelease PIN correctly (the release script can set one): only
-    // the identical prerelease is trusted, never an older/different one.
-    const isPrerelease = versionOutput.includes("-");
-    const matchesOrCleanNewer =
-      versionOutput === PINNED_BACKEND_VERSION ||
-      (!isPrerelease && isVersionAtLeast(versionOutput, PINNED_BACKEND_VERSION));
-    if (matchesOrCleanNewer) {
+    // Use a newer global CLI only when it remains on the plugin's release
+    // channel. This prevents both channel crossing and fallback to an older pin
+    // immediately after a successful prerelease auto-update.
+    if (isSameChannelVersionAtLeast(versionOutput, PINNED_BACKEND_VERSION)) {
       return "codemem";
     }
   } catch {
@@ -4130,6 +4188,7 @@ export const __testUtils = {
   redactPackCommand,
   rejectsInternalLedgerFlag,
   classifyFallbackCommandResult,
+  detectRunner,
   PROMPT_TRANSPORT_PROTOCOL_RANGE,
   normalizePromptTransportProtocolRange,
   arePromptTransportProtocolRangesCompatible,

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -58,6 +58,7 @@ export interface RuntimeInfo {
 /** Browser-side mirror of the additive /api/update-status wire contract. */
 export interface UpdateStatus {
 	current_version: string;
+	channel: "alpha" | "beta" | "rc" | "latest" | null;
 	latest_version: string | null;
 	update_available: boolean;
 	first_seen_at: string | null;

--- a/packages/ui/src/lib/api/update-status.ts
+++ b/packages/ui/src/lib/api/update-status.ts
@@ -8,6 +8,7 @@ export async function loadUpdateStatus(): Promise<UpdateStatus> {
 export function unavailableUpdateStatus(error: unknown): UpdateStatus {
 	return {
 		current_version: "unknown",
+		channel: null,
 		latest_version: null,
 		update_available: false,
 		first_seen_at: null,

--- a/packages/ui/src/tabs/health.test.ts
+++ b/packages/ui/src/tabs/health.test.ts
@@ -14,6 +14,7 @@ vi.mock("../components/primitives/tooltip", () => ({
 
 const availableStatus: UpdateStatus = {
 	current_version: "0.40.2",
+	channel: "latest",
 	latest_version: "0.41.0",
 	update_available: true,
 	first_seen_at: "2026-08-10T12:00:00.000Z",
@@ -107,22 +108,57 @@ describe("Health update banner", () => {
 		);
 	});
 
-	it("does not present an unparseable installed version as current", () => {
+	it("shows unavailable status for an unsupported installed version", () => {
 		// Arrange
 		setUpdateStatus({
 			...availableStatus,
 			current_version: "0.41.0-rc.1",
+			channel: null,
+			latest_version: null,
 			update_available: false,
 			recommended_action: "Verify the current codemem version and try again.",
+			error: "unsupported installed release channel",
 		});
 
 		// Act
 		renderOverview();
 
 		// Assert
-		expect(updateBannerText()).toMatch(/unable to compare/i);
+		expect(updateBannerText()).toMatch(/update check unavailable/i);
 		expect(updateBannerText()).toContain("Verify the current codemem version and try again.");
 		expect(updateBannerText()).not.toMatch(/up to date|latest stable release/i);
+	});
+
+	it("identifies an up-to-date rc installation as rc", () => {
+		setUpdateStatus({
+			...availableStatus,
+			current_version: "0.44.0-rc.2",
+			channel: "rc",
+			latest_version: "0.44.0-rc.2",
+			update_available: false,
+			recommended_action: "No action required; codemem is on the latest rc release.",
+		});
+
+		renderOverview();
+
+		expect(updateBannerText()).toMatch(/latest rc release/i);
+		expect(updateBannerText()).not.toMatch(/latest stable release/i);
+	});
+
+	it("identifies an up-to-date alpha installation as alpha", () => {
+		setUpdateStatus({
+			...availableStatus,
+			current_version: "0.44.0-alpha.2",
+			channel: "alpha",
+			latest_version: "0.44.0-alpha.2",
+			update_available: false,
+			recommended_action: "No action required; codemem is on the latest alpha release.",
+		});
+
+		renderOverview();
+
+		expect(updateBannerText()).toMatch(/latest alpha release/i);
+		expect(updateBannerText()).not.toMatch(/latest stable release/i);
 	});
 
 	it("shows an available release with npm-global installation guidance", () => {

--- a/packages/ui/src/tabs/health/components.ts
+++ b/packages/ui/src/tabs/health/components.ts
@@ -17,12 +17,9 @@ import type {
 	StatItem,
 } from "./types";
 
-const STABLE_RELEASE_VERSION =
-	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
-
-function isStableReleaseVersion(value: string): boolean {
-	const match = STABLE_RELEASE_VERSION.exec(value);
-	return Boolean(match?.slice(1, 4).map(Number).every(Number.isSafeInteger));
+function releaseChannelLabel(status: UpdateStatus): string | null {
+	if (status.channel === "latest") return "stable";
+	return status.channel;
 }
 
 export function buildHealthCard(input: HealthCardInput): HealthCardInput {
@@ -60,17 +57,18 @@ function updateBannerCopy(status: UpdateStatus) {
 		};
 	}
 
-	if (!isStableReleaseVersion(status.current_version)) {
+	const channelLabel = releaseChannelLabel(status);
+	if (!channelLabel) {
 		return {
 			title: `Unable to compare Codemem ${status.current_version} with ${status.latest_version}`,
-			detail: "The installed version is not a stable semantic version.",
+			detail: "The installed version is not on a supported release channel.",
 			tone: "unavailable",
 		};
 	}
 
 	return {
 		title: `Codemem ${status.current_version} is up to date`,
-		detail: "You are running the latest stable release.",
+		detail: `You are running the latest ${channelLabel} release.`,
 		tone: "current",
 	};
 }
@@ -78,10 +76,7 @@ function updateBannerCopy(status: UpdateStatus) {
 function UpdateBanner({ status }: { status: UpdateStatus }) {
 	const copy = updateBannerCopy(status);
 	const showGuidance =
-		status.update_available ||
-		status.stale ||
-		!status.latest_version ||
-		!isStableReleaseVersion(status.current_version);
+		status.update_available || status.stale || !status.latest_version || !status.channel;
 	return h(
 		"section",
 		{

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -3200,6 +3200,7 @@ describe("viewer-server", () => {
 	describe("GET /api/update-status", () => {
 		const availableStatus: core.UpdateStatus = {
 			current_version: "0.40.2",
+			channel: "latest",
 			latest_version: "0.41.0",
 			update_available: true,
 			first_seen_at: "2026-08-10T12:00:00.000Z",

--- a/scripts/release-dist-tag.mjs
+++ b/scripts/release-dist-tag.mjs
@@ -1,0 +1,25 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function npmDistTagForReleaseTag(releaseTag) {
+	if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.+-]+)?$/.test(releaseTag)) {
+		throw new Error(`Invalid release tag: ${releaseTag}`);
+	}
+	const prereleaseChannel = /^v\d+\.\d+\.\d+-([0-9A-Za-z-]+)/.exec(releaseTag)?.[1];
+	if (!prereleaseChannel) return "latest";
+	if (["alpha", "beta", "rc"].includes(prereleaseChannel)) return prereleaseChannel;
+	throw new Error(`Unsupported release channel: ${prereleaseChannel}`);
+}
+
+if (
+	process.argv[1] &&
+	realpathSync(fileURLToPath(import.meta.url)) === realpathSync(resolve(process.argv[1]))
+) {
+	try {
+		process.stdout.write(`tag=${npmDistTagForReleaseTag(process.argv[2] ?? "")}\n`);
+	} catch (error) {
+		process.stderr.write(`${error instanceof Error ? error.message : "Invalid release tag"}\n`);
+		process.exitCode = 1;
+	}
+}

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { copyFileSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { npmDistTagForReleaseTag } from "./release-dist-tag.mjs";
+
+const releaseWorkflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+const publishedPackages = [
+	["@codemem/embeddings", "packages/embeddings"],
+	["@codemem/core", "packages/core"],
+	["@codemem/mcp", "packages/mcp-server"],
+	["@codemem/server", "packages/viewer-server"],
+	["codemem", "packages/cli"],
+	["@codemem/opencode-plugin", "packages/opencode-plugin"],
+];
+
+describe("release npm dist-tag routing", () => {
+	for (const [releaseTag, expectedTag] of [
+		["v0.44.0-alpha.2", "alpha"],
+		["v0.44.0-beta.2", "beta"],
+		["v0.44.0-rc.2", "rc"],
+		["v0.44.0", "latest"],
+	]) {
+		it(`routes ${releaseTag} to npm ${expectedTag} for every published package`, () => {
+			const routes = publishedPackages.map(([packageName]) => ({
+				packageName,
+				distTag: npmDistTagForReleaseTag(releaseTag),
+			}));
+
+			assert.equal(routes.length, publishedPackages.length);
+			assert.ok(routes.every(({ distTag }) => distTag === expectedTag));
+		});
+	}
+
+	it("keeps every published package on the shared computed dist-tag", () => {
+		assert.match(releaseWorkflow, /TAG_OUTPUT="\$\(node scripts\/release-dist-tag\.mjs "\$RELEASE_TAG"\)"/);
+		assert.match(releaseWorkflow, /\^tag=\(alpha\|beta\|rc\|latest\)\$/);
+		assert.match(releaseWorkflow, /printf '%s\\n' "\$TAG_OUTPUT" >> "\$GITHUB_OUTPUT"/);
+		assert.match(releaseWorkflow, /publish --tag "\$\{DIST_TAG\}"/);
+		for (const [packageName, packageDirectory] of publishedPackages) {
+			assert.match(
+				releaseWorkflow,
+				new RegExp(
+					`publish_if_missing "${packageName.replaceAll("/", "\\/")}" "${packageDirectory.replaceAll("/", "\\/")}"`,
+				),
+			);
+		}
+		assert.doesNotMatch(releaseWorkflow, /npm dist-tag (?:add|rm)/);
+	});
+
+	it("emits a dist-tag when executed from a path containing spaces", () => {
+		const directory = mkdtempSync(join(tmpdir(), "codemem release tag "));
+		const scriptPath = join(directory, "release dist tag.mjs");
+		try {
+			copyFileSync(fileURLToPath(new URL("./release-dist-tag.mjs", import.meta.url)), scriptPath);
+			const result = spawnSync(process.execPath, [scriptPath, "v0.44.0-alpha.2"], {
+				encoding: "utf8",
+			});
+
+			assert.equal(result.status, 0);
+			assert.equal(result.stdout, "tag=alpha\n");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Description
Keep update checks and installs on the channel of the currently installed codemem version. Alpha users no longer get offered an ineligible stable or differently tagged release.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced