### PR TITLE
fix(cli): detect missing native bindings at startup

### DIFF
--- a/docs/plans/2026-03-15-install-matrix.md
+++ b/docs/plans/2026-03-15-install-matrix.md
@@ -46,7 +46,7 @@ that package transitively through Transformers.js and Sharp.
 | Package | Native strategy | Build system | Fallback |
 |---|---|---|---|
 | better-sqlite3 | Bundled N-API binaries selected at runtime | node-gyp (explicit `build-release` only) | Runtime load error at first `new Database()` if the platform has no bundled binary; install still succeeds |
-| sqlite-vec | `optionalDependencies` per-platform packages | None — prebuilt binaries only | Fatal error if platform unsupported |
+| sqlite-vec | `optionalDependencies` per-platform packages | None — prebuilt binaries only | Viewer startup disables semantic search and keeps FTS5; other commands require `CODEMEM_EMBEDDING_DISABLED=1` |
 | onnxruntime-node | Single package, postinstall downloads platform binary | N-API addon, prebuilt | Fatal error if platform unsupported |
 
 ### sqlite-vec platform packages

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -549,6 +549,24 @@ hardware; the rebuild runs outside the viewer process in bounded batches.
 ONNX Runtime 1.24.3 has no macOS x64 artifact, so Intel Macs continue using
 FTS5 keyword retrieval instead of semantic inference.
 
+### Required SQLite native binding
+
+`better-sqlite3` is required for every codemem storage mode. Viewer startup now
+checks its native binding before preparing a database or detaching a background
+process; restart checks before stopping a healthy viewer. If the check fails,
+copy the exact-version `npm install -g codemem@<version>` repair command from the
+diagnostic. Use Node 24.15+ on a supported 64-bit target listed in the [native
+install matrix](plans/2026-03-15-install-matrix.md).
+
+`better-sqlite3` 13.0.3 bundles its N-API prebuilds and has no package install
+script, so a failed binding check does not by itself mean npm blocked lifecycle
+scripts. Semantic installs still carry upstream runtime requirements including
+Sharp, ONNX Runtime, protobufjs, and global-agent; ONNX Runtime's postinstall and
+roughly 220 MB unpacked weight remain upstream requirements. `sqlite-vec` stays
+optional: viewer startup catches its load failure, disables semantic search, and
+preserves FTS5 lexical search. Other commands require
+`CODEMEM_EMBEDDING_DISABLED=1` when sqlite-vec is unavailable.
+
 ### sqlite-vec / `no such module: vec0`
 
 **Symptom:** API errors with `SqliteError: no such module: vec0`, or the viewer logs `sqlite-vec failed to load; retrying viewer startup with embeddings disabled` at startup.

--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -7,6 +7,7 @@ import {
 	mkdtempSync,
 	readFileSync,
 	readdirSync,
+	renameSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -68,8 +69,21 @@ function resolveInstalledPackageDir(installDir, packageName) {
 		.split(/\r?\n/u)
 		.map((line) => line.trim())
 		.find((line) => line.endsWith(expectedSuffix));
-	assert(packageDir, `Semantic install is missing ${packageName}`);
+	assert(packageDir, `Installed fixture is missing ${packageName}`);
 	return packageDir;
+}
+
+function collectFiles(directory, predicate) {
+	const matches = [];
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		const entryPath = join(directory, entry.name);
+		if (entry.isDirectory()) {
+			matches.push(...collectFiles(entryPath, predicate));
+		} else if (predicate(entryPath)) {
+			matches.push(entryPath);
+		}
+	}
+	return matches;
 }
 
 function runAsync(command, args, options, input) {
@@ -672,9 +686,11 @@ try {
 		"@codemem/embeddings",
 		"@huggingface/transformers",
 		"@xenova/transformers",
+		"global-agent",
 		"onnxruntime-common",
 		"onnxruntime-node",
 		"onnxruntime-web",
+		"protobufjs",
 		"sharp",
 	]) {
 		assert(
@@ -759,10 +775,19 @@ try {
 	assert(existsSync(semanticLockPath), "Semantic install did not produce a package-lock.json");
 	const semanticLock = JSON.parse(readFileSync(semanticLockPath, "utf8"));
 	const semanticPackages = Object.keys(semanticLock.packages ?? {});
-	assert(
-		semanticPackages.some((path) => path.endsWith("node_modules/@huggingface/transformers")),
-		"Semantic CLI fixture is missing the @huggingface/transformers runtime",
-	);
+	for (const packageName of [
+		"@huggingface/transformers",
+		"onnxruntime-node",
+		"sharp",
+		"protobufjs",
+		"global-agent",
+	]) {
+		const expectedSuffix = `node_modules/${packageName}`;
+		assert(
+			semanticPackages.some((path) => path.endsWith(expectedSuffix)),
+			`Semantic CLI fixture is missing required upstream dependency ${packageName}`,
+		);
+	}
 	const embeddingsPackageDir = join(
 		semanticInstallDir,
 		"node_modules",
@@ -852,6 +877,58 @@ try {
 		CODEMEM_EMBEDDING_DISABLED: "1",
 	});
 	assert(existsSync(optionalFreeDbPath), "Optional-free CLI smoke did not create its isolated database");
+
+	const betterSqlitePackageDir = resolveInstalledPackageDir(installDir, "better-sqlite3");
+	const nativeBindings = collectFiles(betterSqlitePackageDir, (path) => path.endsWith(".node"));
+	assert(nativeBindings.length > 0, "Packed install is missing better-sqlite3 native binaries");
+	const hiddenBindings = nativeBindings.map((path) => `${path}.codemem-smoke-hidden`);
+	try {
+		for (let index = 0; index < nativeBindings.length; index += 1) {
+			renameSync(nativeBindings[index], hiddenBindings[index]);
+		}
+		const failedStart = spawnSync(
+			process.execPath,
+			[
+				join(installedPackageRoot, "dist", "index.js"),
+				"serve",
+				"restart",
+				"--port",
+				"38889",
+				"--db-path",
+				join(tempDir, "missing-native.sqlite"),
+			],
+			{
+				cwd: installDir,
+				encoding: "utf8",
+				env: { ...process.env, CODEMEM_EMBEDDING_DISABLED: "1" },
+			},
+		);
+		const output = `${failedStart.stdout ?? ""}\n${failedStart.stderr ?? ""}`;
+		assert(
+			failedStart.status !== 0,
+			`Background serve succeeded without a SQLite native binding: ${output}`,
+		);
+		assert(
+			output.includes("Required SQLite native binding is unavailable"),
+			`Background serve omitted required SQLite diagnostic: ${output}`,
+		);
+		assert(
+			output.includes(`Node ${process.version} on ${process.platform}/${process.arch}`),
+			"Background serve omitted runtime platform details",
+		);
+		assert(
+			output.includes(`npm install -g codemem@${packageVersion}`),
+			"Background serve omitted exact-version repair command",
+		);
+		assert(
+			!output.includes("Viewer started in background"),
+			"Background serve falsely claimed it started",
+		);
+	} finally {
+		for (let index = 0; index < nativeBindings.length; index += 1) {
+			if (existsSync(hiddenBindings[index])) renameSync(hiddenBindings[index], nativeBindings[index]);
+		}
+	}
 
 	const isolatedAdapters = join(tempDir, "isolated-adapters");
 	await buildAdapterNormalizers(isolatedAdapters);

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -15,9 +15,12 @@ import {
 	isSqliteVecLoadFailure,
 	maintenanceWorkerPidFilePath,
 	pickViewerPidCandidate,
+	preflightServeNativeRuntime,
 	prepareViewerDatabase,
+	requiredNativeRuntimeFailureDiagnostics,
 	respondsLikeCodememViewer,
 	runServeCoordinatorMaintenance,
+	runServeInvocation,
 	sqliteVecFailureDiagnostics,
 	terminateTrustedMaintenanceWorker,
 	terminateTrustedViewerPid,
@@ -304,6 +307,111 @@ describe("serve command option resolution", () => {
 		expect(lines.some((line) => line.startsWith("node="))).toBe(true);
 		expect(lines.some((line) => line.startsWith("exec="))).toBe(true);
 		expect(lines.some((line) => line.startsWith("error=vec0 load failed"))).toBe(true);
+	});
+
+	it("formats required SQLite binding failures with exact-version repair guidance", () => {
+		const lines = requiredNativeRuntimeFailureDiagnostics(new Error("binding missing"), {
+			version: "1.2.3-alpha.4",
+			nodeVersion: "v24.15.0",
+			platform: "linux",
+			arch: "arm64",
+		});
+		expect(lines).toContain("Required SQLite native binding is unavailable.");
+		expect(lines).toContain("Runtime: Node v24.15.0 on linux/arm64.");
+		expect(lines).toContain("Details: binding missing");
+		expect(lines).toContain(
+			"Reinstall this exact codemem version: npm install -g codemem@1.2.3-alpha.4",
+		);
+		expect(lines.some((line) => line.includes("optional sqlite-vec"))).toBe(true);
+	});
+
+	it("checks an ordinary start port before probing the native runtime", async () => {
+		const calls: string[] = [];
+		const result = await preflightServeNativeRuntime(
+			resolveStartServeInvocation({ host: "127.0.0.1", port: "38888" }),
+			{
+				isPortOpen: vi.fn(async () => {
+					calls.push("port");
+					return true;
+				}),
+				probe: vi.fn(() => calls.push("probe")),
+			},
+		);
+
+		expect(result).toEqual({ state: "already_running" });
+		expect(calls).toEqual(["port"]);
+	});
+
+	it("probes exactly once after an ordinary start finds an available port", async () => {
+		const calls: string[] = [];
+		const probe = vi.fn(() => {
+			calls.push("probe");
+		});
+		const result = await preflightServeNativeRuntime(
+			resolveStartServeInvocation({ host: "127.0.0.1", port: "38888" }),
+			{
+				isPortOpen: vi.fn(async () => {
+					calls.push("port");
+					return false;
+				}),
+				probe,
+			},
+		);
+
+		expect(result).toEqual({ state: "ready" });
+		expect(calls).toEqual(["port", "probe"]);
+		expect(probe).toHaveBeenCalledOnce();
+	});
+
+	it("fails an ordinary start when the native runtime probe fails", async () => {
+		const result = await preflightServeNativeRuntime(
+			resolveStartServeInvocation({ host: "127.0.0.1", port: "38888" }),
+			{
+				isPortOpen: vi.fn(async () => false),
+				probe: vi.fn(() => {
+					throw new Error("binding missing");
+				}),
+			},
+		);
+
+		expect(result.state).toBe("unavailable");
+	});
+
+	it("probes a restart before lifecycle code can stop the existing viewer", async () => {
+		const calls: string[] = [];
+		const result = await preflightServeNativeRuntime(
+			resolveStopRestartInvocation("restart", { host: "127.0.0.1", port: "38888" }),
+			{
+				isPortOpen: vi.fn(async () => {
+					calls.push("port");
+					return true;
+				}),
+				probe: vi.fn(() => {
+					calls.push("probe");
+					throw new Error("binding missing");
+				}),
+			},
+		);
+
+		expect(result.state).toBe("unavailable");
+		expect(calls).toEqual(["probe"]);
+	});
+
+	it("does not stop an existing viewer when restart native-runtime preflight fails", async () => {
+		const stopExistingViewer = vi.fn(async () => ({ stopped: true, pid: 1234 }));
+		await runServeInvocation(
+			resolveStopRestartInvocation("restart", {
+				dbPath: join(tmpdir(), `codemem-restart-${process.pid}.sqlite`),
+				host: "127.0.0.1",
+				port: "38888",
+			}),
+			{
+				nativeRuntimeAllowsServeStart: vi.fn(async () => false),
+				stopExistingViewer,
+			},
+		);
+
+		expect(stopExistingViewer).not.toHaveBeenCalled();
 	});
 
 	it("extracts viewer_pid from stats payload", () => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -8,12 +8,14 @@ import {
 	isEmbeddingDisabled,
 	type MemoryStore,
 	ObserverClient,
+	probeRequiredNativeRuntime,
 	RawEventSweeper,
 	readCodememConfigFile,
 	readCodememConfigFileAtPath,
 	readCoordinatorSyncConfig,
 	resolveDbPath,
 	runSyncDaemon,
+	VERSION,
 } from "@codemem/core";
 import type { ReconcileConfiguredCoordinatorEnrollmentResult } from "@codemem/server";
 import { Command, Option } from "commander";
@@ -494,6 +496,82 @@ export function sqliteVecFailureDiagnostics(error: unknown, dbPath: string): str
 	];
 }
 
+export interface RequiredNativeRuntimeDiagnosticContext {
+	version: string;
+	nodeVersion: string;
+	platform: NodeJS.Platform;
+	arch: string;
+}
+
+export function requiredNativeRuntimeFailureDiagnostics(
+	error: unknown,
+	context: RequiredNativeRuntimeDiagnosticContext = {
+		version: VERSION,
+		nodeVersion: process.version,
+		platform: process.platform,
+		arch: process.arch,
+	},
+): string[] {
+	const detail = error instanceof Error ? error.message : String(error);
+	return [
+		"Required SQLite native binding is unavailable.",
+		`Runtime: Node ${context.nodeVersion} on ${context.platform}/${context.arch}.`,
+		`Details: ${detail}`,
+		`Reinstall this exact codemem version: npm install -g codemem@${context.version}`,
+		"Use Node 24.15+ on a supported 64-bit macOS, Linux, or Windows target; see the native install matrix for current platform coverage.",
+		"This required better-sqlite3 failure is separate from optional sqlite-vec loading, which can fall back to lexical search.",
+	];
+}
+
+export type ServeNativeRuntimePreflightResult =
+	| { state: "ready" }
+	| { state: "already_running" }
+	| { state: "unavailable"; diagnostics: string[] };
+
+export async function preflightServeNativeRuntime(
+	invocation: ResolvedServeInvocation,
+	dependencies: {
+		isPortOpen: (host: string, port: number) => Promise<boolean>;
+		probe: () => void;
+	} = {
+		isPortOpen,
+		probe: probeRequiredNativeRuntime,
+	},
+): Promise<ServeNativeRuntimePreflightResult> {
+	if (
+		invocation.mode === "start" &&
+		(await dependencies.isPortOpen(invocation.host, invocation.port))
+	) {
+		return { state: "already_running" };
+	}
+
+	try {
+		dependencies.probe();
+		return { state: "ready" };
+	} catch (error) {
+		return { state: "unavailable", diagnostics: requiredNativeRuntimeFailureDiagnostics(error) };
+	}
+}
+
+async function nativeRuntimeAllowsServeStart(
+	invocation: ResolvedServeInvocation,
+): Promise<boolean> {
+	if (invocation.mode !== "start" && invocation.mode !== "restart") return true;
+
+	const preflight = await preflightServeNativeRuntime(invocation);
+	if (preflight.state === "already_running") {
+		p.log.warn(`Viewer already running at http://${invocation.host}:${invocation.port}`);
+		if (!invocation.background) process.exitCode = 1;
+		return false;
+	}
+	if (preflight.state === "ready") return true;
+
+	p.intro("codemem viewer");
+	for (const line of preflight.diagnostics) p.log.error(line);
+	process.exitCode = 1;
+	return false;
+}
+
 export interface ServeCoordinatorMaintenanceResult {
 	projectShares: { processed: number; failed: number };
 	coordinatorEnrollment: {
@@ -614,11 +692,6 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	if (invocation.dbPath) process.env.CODEMEM_DB = invocation.dbPath;
 	if (invocation.configPath) process.env.CODEMEM_CONFIG = invocation.configPath;
 	warnIfViewerExposed(invocation.host, invocation.port);
-	if (await isPortOpen(invocation.host, invocation.port)) {
-		p.log.warn(`Viewer already running at http://${invocation.host}:${invocation.port}`);
-		process.exitCode = 1;
-		return;
-	}
 	const preparedDb = prepareViewerDatabase(invocation.dbPath);
 
 	const observer = new ObserverClient();
@@ -839,7 +912,16 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	});
 }
 
-async function runServeInvocation(invocation: ResolvedServeInvocation): Promise<void> {
+export async function runServeInvocation(
+	invocation: ResolvedServeInvocation,
+	dependencies: {
+		nativeRuntimeAllowsServeStart: (invocation: ResolvedServeInvocation) => Promise<boolean>;
+		stopExistingViewer: typeof stopExistingViewer;
+	} = {
+		nativeRuntimeAllowsServeStart,
+		stopExistingViewer,
+	},
+): Promise<void> {
 	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
 	const runtimeConflict = await findRuntimeViewerConflict(dbPath, {
 		host: invocation.host,
@@ -856,8 +938,9 @@ async function runServeInvocation(invocation: ResolvedServeInvocation): Promise<
 		process.exitCode = 1;
 		return;
 	}
+	if (!(await dependencies.nativeRuntimeAllowsServeStart(invocation))) return;
 	if (invocation.mode === "stop" || invocation.mode === "restart") {
-		const result = await stopExistingViewer(dbPath, {
+		const result = await dependencies.stopExistingViewer(dbPath, {
 			host: invocation.host,
 			port: invocation.port,
 		});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -588,6 +588,7 @@ export {
 	isDerivedFactRow,
 	readArtifactClass,
 } from "./memory-quality.js";
+export { probeRequiredNativeRuntime } from "./native-runtime.js";
 export type { ObserverAuthMaterial } from "./observer-auth.js";
 export {
 	buildCodexHeaders,

--- a/packages/core/src/native-runtime.test.ts
+++ b/packages/core/src/native-runtime.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { probeRequiredNativeRuntime } from "./native-runtime.js";
+
+describe("probeRequiredNativeRuntime", () => {
+	it("opens and closes an in-memory better-sqlite3 database", () => {
+		expect(() => probeRequiredNativeRuntime()).not.toThrow();
+	});
+
+	it("propagates native binding load failures", () => {
+		expect(() =>
+			probeRequiredNativeRuntime(() => {
+				throw new Error("binding missing");
+			}),
+		).toThrow("binding missing");
+	});
+});

--- a/packages/core/src/native-runtime.ts
+++ b/packages/core/src/native-runtime.ts
@@ -1,0 +1,16 @@
+import Database from "better-sqlite3";
+
+type RequiredNativeDatabaseFactory = () => { close(): void };
+
+/**
+ * Verify that codemem's required SQLite native binding loads in this runtime.
+ *
+ * This intentionally avoids sqlite-vec and user database paths so callers can
+ * run it before starting or replacing a long-lived process.
+ */
+export function probeRequiredNativeRuntime(
+	createDatabase: RequiredNativeDatabaseFactory = () => new Database(":memory:"),
+): void {
+	const db = createDatabase();
+	db.close();
+}


### PR DESCRIPTION
## Description
Detect unavailable native bindings during CLI startup and return actionable diagnostics instead of failing later with an opaque module error.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced