### PR TITLE
fix(plugin): dedupe collectors and drain backlogs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -373,7 +373,7 @@ behavior and `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1` opt-in for `Stop` remain unch
 ### OpenCode stream reliability
 - Preflight check: `GET /api/raw-events/status` with periodic re-checks (`CODEMEM_RAW_EVENTS_STATUS_CHECK_MS`), bounded by a 5-second timeout
 - Backoff on failure: configurable via `CODEMEM_RAW_EVENTS_BACKOFF_MS`; on stream failure the plugin can fall back to CLI enqueue for durable persistence
-- Once events are accepted by the viewer/store queue, flush workers handle retries
+- Once events are accepted by the viewer/store queue, each periodic sweep drains bounded work from active or idle sessions and retries failed batches
 
 ### Claude hook flush boundaries
 - `SessionEnd` immediately flushes by default; `CODEMEM_CLAUDE_HOOK_FLUSH=0` disables the attempt

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -14,6 +14,8 @@ This page covers advanced plugin behavior, environment variables, and stream rel
 4. Use `codemem stats` and `codemem recent` to confirm ingestion.
 5. Browse the viewer at the printed URL.
 
+OpenCode loads configured npm plugins and project-local `.opencode/plugins/` files as separate sources. If both resolve to Codemem for the same project, the first registration remains active and later registrations skip all hooks with a warning. Remove the configured npm entry when testing checkout-local plugin changes so the local copy initializes first.
+
 ### Repository-only lint feedback
 
 When OpenCode runs from a codemem source checkout, the root `opencode.jsonc` loads `packages/opencode-plugin/src/lint-feedback.ts`; that repository-owned entrypoint runs the installed Biome launcher through Node without a shell. The hook checks JavaScript and TypeScript paths included by `biome.json` when handled by `edit`, `write`, or `apply_patch`, including move destinations; paths outside that configured Biome scope are ignored. It appends at most 10 new or worsened diagnostics and leaves the edit intact when Biome fails or exceeds its 10-second timeout. Existing diagnostics are a warning-level ratchet rather than a cleanup mandate.
@@ -343,12 +345,12 @@ Stream contract:
 Suggested settings:
 
 ```bash
-export CODEMEM_RAW_EVENTS_AUTO_FLUSH=1
-export CODEMEM_RAW_EVENTS_DEBOUNCE_MS=60000
 export CODEMEM_RAW_EVENTS_SWEEPER=1
-export CODEMEM_RAW_EVENTS_SWEEPER_IDLE_MS=120000
 export CODEMEM_RAW_EVENTS_SWEEPER_LIMIT=25
 export CODEMEM_RAW_EVENTS_STUCK_BATCH_MS=300000
+# optional quiet-period flush before the next periodic sweep
+# export CODEMEM_RAW_EVENTS_AUTO_FLUSH=1
+# export CODEMEM_RAW_EVENTS_DEBOUNCE_MS=10000
 # optional retention
 # export CODEMEM_RAW_EVENTS_RETENTION_MS=$((7*24*60*60*1000))
 ```
@@ -383,7 +385,7 @@ Force-flush thresholds (immediate flush):
 Failure semantics:
 - Stream POST failures are backoff-gated in plugin runtime (`CODEMEM_RAW_EVENTS_BACKOFF_MS`).
 - Availability checks are rate-limited (`CODEMEM_RAW_EVENTS_STATUS_CHECK_MS`).
-- Accepted raw-event batches are retried by viewer/store queue workers (`codemem db raw-events-retry`).
+- Each periodic viewer sweep drains a bounded batch from accepted sessions, including sessions that remain active; failed batches are retried by viewer/store queue workers (`codemem db raw-events-retry`).
 
 ## Project label normalization
 
@@ -454,12 +456,11 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_RAW_EVENT_SPOOL_DRAIN_LIMIT` | Max valid saved envelopes attempted per spool drain; corrupt entries do not consume this limit (default `20`). |
 | `CODEMEM_RAW_EVENT_SPOOL_MAX_ENTRIES` | Max `.json` entries in the OpenCode raw-event spool (default `2000`). A full spool rejects new event IDs without evicting existing entries; the failed write remains only in the bounded in-memory queue. |
 | `CODEMEM_RAW_EVENTS_AUTO_FLUSH` | Set to `1` to enable viewer-side debounced flush of streamed raw events (default off). |
-| `CODEMEM_RAW_EVENTS_DEBOUNCE_MS` | Debounce delay before auto-flush per session (default `60000`). |
-| `CODEMEM_RAW_EVENTS_SWEEPER` | Set to `1` to enable periodic sweeper flush for idle sessions (default on). |
+| `CODEMEM_RAW_EVENTS_DEBOUNCE_MS` | Debounce delay before auto-flush per session (default `60000`); the periodic sweeper may drain the session sooner. |
+| `CODEMEM_RAW_EVENTS_SWEEPER` | Set to `1` to enable periodic sweeper flush for sessions with unflushed events (default on). |
 | `CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS` | Sweeper tick interval (default `30000`). |
 | `CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S` | Config/env interval in seconds used by Settings UI (default `30`; overridden by `CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS` when set). |
-| `CODEMEM_RAW_EVENTS_SWEEPER_IDLE_MS` | Consider session idle if no events since this many ms (default `120000`). |
-| `CODEMEM_RAW_EVENTS_SWEEPER_LIMIT` | Max idle sessions to flush per sweeper tick (default `25`). |
+| `CODEMEM_RAW_EVENTS_SWEEPER_LIMIT` | Max sessions with unflushed events to process per sweeper tick (default `25`). |
 | `CODEMEM_RAW_EVENTS_STUCK_BATCH_MS` | Mark flush batches older than this many ms as error (default `300000`). |
 | `CODEMEM_RAW_EVENTS_RETENTION_MS` | If >0, delete raw events older than this many ms (default `0`, keep forever). |
 | `CODEMEM_CLAUDE_HOOK_FLUSH` | Set to `0` to disable immediate `SessionEnd` boundary flush (default on for `SessionEnd`; `Stop` still requires `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1`). |

--- a/packages/cli/.opencode/tests/plugin-transform-hook.test.js
+++ b/packages/cli/.opencode/tests/plugin-transform-hook.test.js
@@ -26,6 +26,7 @@ import {
 
 const spawnMock = vi.fn();
 const execSyncMock = vi.fn(() => "test-version");
+const pluginRegistrationsKey = Symbol.for("codemem.opencode-plugin.registrations");
 
 vi.mock("node:child_process", () => ({
 	spawn: (...args) => spawnMock(...args),
@@ -297,6 +298,7 @@ describe("OpenCode transform-time injection", () => {
 		// cover transform-time injection, so keep that background timer inert.
 		vi.useFakeTimers();
 		vi.resetModules();
+		Reflect.deleteProperty(globalThis, pluginRegistrationsKey);
 		spawnMock.mockReset();
 		execSyncMock.mockClear();
 		process.env = {
@@ -333,6 +335,104 @@ describe("OpenCode transform-time injection", () => {
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
 		process.env = originalEnv;
+		Reflect.deleteProperty(globalThis, pluginRegistrationsKey);
+	});
+
+	test("loads separate plugin copies once for the same project", async () => {
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "0";
+		process.env.CODEMEM_RAW_EVENTS = "1";
+		process.env.CODEMEM_PLUGIN_LOG = join(process.env.HOME, "plugin.log");
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+			if (String(url).includes("/api/raw-events/status")) {
+				return jsonResponse(200, { ingest: { available: true } });
+			}
+			return jsonResponse(200, { ok: true });
+		});
+		const firstAppLog = vi.fn().mockResolvedValue(undefined);
+		const secondAppLog = vi.fn().mockResolvedValue(undefined);
+		const { OpencodeMemPlugin: firstPlugin } = await import("../plugins/codemem.js");
+		vi.resetModules();
+		const { OpencodeMemPlugin: secondPlugin } = await import("../plugins/codemem.js");
+		expect(secondPlugin).not.toBe(firstPlugin);
+
+		const pluginContext = {
+			project: { name: "greenroom" },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		};
+		const firstHooks = await firstPlugin({
+			...pluginContext,
+			client: { app: { log: firstAppLog }, tui: {} },
+		});
+		const secondHooks = await secondPlugin({
+			...pluginContext,
+			client: { app: { log: secondAppLog }, tui: {} },
+		});
+
+		for (const hooks of [firstHooks, secondHooks]) {
+			await hooks["tool.execute.after"]?.(
+				{ tool: "read", args: { filePath: "src/raw-event.ts" }, sessionID: "sess-duplicate" },
+				{},
+			);
+		}
+		await vi.waitFor(() =>
+			expect(fetchPostCalls(fetchMock).filter(([url]) => String(url).endsWith("/api/raw-events")))
+				.toHaveLength(1),
+		);
+
+		expect(secondHooks).toEqual({});
+		expect(secondAppLog).toHaveBeenCalledWith(expect.objectContaining({
+			level: "warn",
+			message: "codemem duplicate plugin registration skipped",
+		}));
+		const captureLines = readFileSync(process.env.CODEMEM_PLUGIN_LOG, "utf8")
+			.split("\n")
+			.filter((line) => line.includes("tool.execute.after read queued=1"));
+		expect(captureLines).toHaveLength(1);
+	});
+
+	test("keeps separate projects active in one process", async () => {
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		const { OpencodeMemPlugin: firstPlugin } = await import("../plugins/codemem.js");
+		vi.resetModules();
+		const { OpencodeMemPlugin: secondPlugin } = await import("../plugins/codemem.js");
+		const client = { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} };
+
+		const firstHooks = await firstPlugin({
+			project: { name: "first" },
+			client,
+			directory: "/tmp/first",
+			worktree: "/tmp/first",
+		});
+		const secondHooks = await secondPlugin({
+			project: { name: "second" },
+			client,
+			directory: "/tmp/second",
+			worktree: "/tmp/second",
+		});
+
+		expect(firstHooks["tool.execute.after"]).toBeTypeOf("function");
+		expect(secondHooks["tool.execute.after"]).toBeTypeOf("function");
+	});
+
+	test("releases a project registration when the plugin is disposed", async () => {
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		const { OpencodeMemPlugin: firstPlugin } = await import("../plugins/codemem.js");
+		vi.resetModules();
+		const { OpencodeMemPlugin: secondPlugin } = await import("../plugins/codemem.js");
+		const pluginContext = {
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		};
+		const firstHooks = await firstPlugin(pluginContext);
+
+		firstHooks.dispose();
+		const replacementHooks = await secondPlugin(pluginContext);
+
+		expect(replacementHooks["tool.execute.after"]).toBeTypeOf("function");
 	});
 
 	test("appends built memory pack to the latest user message by default", async () => {
@@ -982,6 +1082,7 @@ describe("OpenCode transform-time injection", () => {
 		});
 
 		const buildPlugin = async () => {
+			Reflect.deleteProperty(globalThis, pluginRegistrationsKey);
 			vi.resetModules();
 			const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
 			return OpencodeMemPlugin({
@@ -2462,6 +2563,7 @@ describe("OpenCode transform-time injection", () => {
 		expect(readdirSync(spoolDirectory).filter((name) => name.endsWith(".json"))).toHaveLength(1);
 
 		fallbackSucceeds = true;
+		Reflect.deleteProperty(globalThis, pluginRegistrationsKey);
 		vi.resetModules();
 		({ OpencodeMemPlugin } = await import("../plugins/codemem.js"));
 		await OpencodeMemPlugin({

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -100,6 +100,7 @@ function isPairedInstallCall(call) {
 }
 
 async function startPlugin(showToast = vi.fn().mockResolvedValue(undefined)) {
+	Reflect.deleteProperty(globalThis, Symbol.for("codemem.opencode-plugin.registrations"));
 	const { CodememPlugin } = await import("../plugins/codemem.js");
 	const hooks = await CodememPlugin({
 		project: { name: "codemem" },

--- a/packages/cli/.opencode/tests/setup.js
+++ b/packages/cli/.opencode/tests/setup.js
@@ -1,4 +1,10 @@
-import { vi } from "vitest";
+import { beforeEach, vi } from "vitest";
+
+const pluginRegistrationsKey = Symbol.for("codemem.opencode-plugin.registrations");
+
+beforeEach(() => {
+	Reflect.deleteProperty(globalThis, pluginRegistrationsKey);
+});
 
 const schemaBuilder = () => ({
 	optional: () => schemaBuilder(),

--- a/packages/core/src/raw-event-sweeper-active.test.ts
+++ b/packages/core/src/raw-event-sweeper-active.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { connect } from "./db.js";
+import type { IngestOptions } from "./ingest-pipeline.js";
+import { RawEventSweeper } from "./raw-event-sweeper.js";
+import { MemoryStore } from "./store.js";
+import { initTestSchema } from "./test-utils.js";
+
+const activeSessionObservation = async () => ({
+	raw: `<observation>
+		<type>discovery</type><title>Active events drained</title>
+		<narrative>The periodic worker processed accepted events while the session remained active.</narrative>
+	</observation>`,
+	parsed: null,
+	provider: "test",
+	model: "test",
+});
+
+function seedActiveSession(
+	store: MemoryStore,
+	tmpDir: string,
+	sessionId: string,
+	eventCount: number,
+) {
+	const now = Date.now();
+	for (let index = 0; index < eventCount; index += 1) {
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: `evt-${index}`,
+			eventType: "user_prompt",
+			payload: { type: "user_prompt", prompt_text: `Active prompt ${index}` },
+			tsWallMs: now + index,
+		});
+	}
+	store.updateRawEventSessionMeta({
+		opencodeSessionId: sessionId,
+		cwd: tmpDir,
+		project: "codemem",
+		startedAt: "2026-01-01T00:00:00Z",
+		lastSeenTsWallMs: now + eventCount - 1,
+	});
+}
+
+function createSweeper(store: MemoryStore, observe: ReturnType<typeof vi.fn>) {
+	return new RawEventSweeper(store, {
+		observer: {
+			observe,
+			getStatus: () => ({
+				provider: "test",
+				model: "test",
+				runtime: "api_http",
+				auth: { source: "test", type: "api_direct", hasToken: true },
+			}),
+		} as never,
+	} satisfies IngestOptions);
+}
+
+describe("RawEventSweeper active session draining", () => {
+	let tmpDir: string;
+	let store: MemoryStore;
+	let previousAutoFlush: string | undefined;
+	let previousWorkerMaxEvents: string | undefined;
+
+	beforeEach(() => {
+		previousAutoFlush = process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH;
+		previousWorkerMaxEvents = process.env.CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS;
+		delete process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH;
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-active-sweeper-test-"));
+		const dbPath = join(tmpDir, "test.sqlite");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store.close();
+		if (previousAutoFlush == null) delete process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH;
+		else process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = previousAutoFlush;
+		if (previousWorkerMaxEvents == null) delete process.env.CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS;
+		else process.env.CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS = previousWorkerMaxEvents;
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("drains a recently active session when auto flush is disabled", async () => {
+		seedActiveSession(store, tmpDir, "sess-active-periodic", 2);
+		const observe = vi.fn(activeSessionObservation);
+		const sweeper = createSweeper(store, observe);
+
+		await sweeper.tick();
+
+		expect(observe).toHaveBeenCalledTimes(1);
+		expect(store.rawEventFlushState("sess-active-periodic")).toBe(1);
+	});
+
+	it("drains a backlog in capped non-overlapping periodic batches", async () => {
+		process.env.CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS = "2";
+		seedActiveSession(store, tmpDir, "sess-active-backlog", 5);
+		const observe = vi.fn(activeSessionObservation);
+		const sweeper = createSweeper(store, observe);
+
+		for (const expectedCursor of [1, 3, 4]) {
+			await sweeper.tick();
+			expect(store.rawEventFlushState("sess-active-backlog")).toBe(expectedCursor);
+		}
+		await sweeper.tick();
+
+		expect(observe).toHaveBeenCalledTimes(3);
+	});
+});

--- a/packages/core/src/raw-event-sweeper.test.ts
+++ b/packages/core/src/raw-event-sweeper.test.ts
@@ -174,7 +174,6 @@ describe("RawEventSweeper auto flush", () => {
 			}),
 		} as never,
 	};
-
 	it("suppresses auto flush during auth backoff after an auth failure", async () => {
 		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
 		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";

--- a/packages/core/src/raw-event-sweeper.ts
+++ b/packages/core/src/raw-event-sweeper.ts
@@ -12,7 +12,7 @@
  * 3. Purge old events (if retention configured)
  * 4. Mark stuck batches as error
  * 5. Flush sessions with pending queue entries
- * 6. Flush idle sessions with unflushed events
+ * 6. Flush sessions with unflushed events
  * 7. Handle auth errors by setting backoff
  */
 
@@ -96,10 +96,6 @@ export class RawEventSweeper {
 			return Math.max(1000, configSeconds * 1000);
 		}
 		return 30_000;
-	}
-
-	private idleMs(): number {
-		return envInt("CODEMEM_RAW_EVENTS_SWEEPER_IDLE_MS", 120_000);
 	}
 
 	private limit(): number {
@@ -465,7 +461,7 @@ export class RawEventSweeper {
 	 * 2. Purge old events
 	 * 3. Mark stuck batches
 	 * 4. Flush pending queue sessions
-	 * 5. Flush idle sessions
+	 * 5. Flush sessions with unflushed events
 	 */
 	async tick(): Promise<void> {
 		if (!this.enabled()) return;
@@ -480,7 +476,6 @@ export class RawEventSweeper {
 		}
 
 		const nowMs = Date.now();
-		const idleBefore = nowMs - this.idleMs();
 
 		// Purge old events if retention configured
 		const retentionMs = this.retentionMs();
@@ -532,9 +527,9 @@ export class RawEventSweeper {
 			}
 		}
 
-		// Phase 2: Flush idle sessions with unflushed events
-		const idleSessions = this.store.rawEventSessionsPendingIdleFlush(idleBefore, sessionLimit);
-		for (const item of idleSessions) {
+		// Phase 2: Flush accepted events even while their session remains active.
+		const pendingSessions = this.store.rawEventSessionsPendingFlush(sessionLimit);
+		for (const item of pendingSessions) {
 			const { source, streamId } = item;
 			if (!streamId) continue;
 			if (drained.has(`${source}:${streamId}`)) continue;

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1732,11 +1732,22 @@ export class MemoryStore {
 
 	/**
 	 * Find sessions that have unflushed events and have been idle long enough.
-	 * Port of raw_event_sessions_pending_idle_flush().
 	 */
 	rawEventSessionsPendingIdleFlush(
 		idleBeforeTsWallMs: number,
 		limit = 25,
+	): { source: string; streamId: string }[] {
+		return this.rawEventSessionsPendingFlushQuery(limit, idleBeforeTsWallMs);
+	}
+
+	/** Find sessions that have unflushed events, oldest activity first. */
+	rawEventSessionsPendingFlush(limit = 25): { source: string; streamId: string }[] {
+		return this.rawEventSessionsPendingFlushQuery(limit);
+	}
+
+	private rawEventSessionsPendingFlushQuery(
+		limit: number,
+		idleBeforeTsWallMs?: number,
 	): { source: string; streamId: string }[] {
 		const maxEvents = this.d
 			.select({
@@ -1764,7 +1775,9 @@ export class MemoryStore {
 			.where(
 				and(
 					isNotNull(schema.rawEventSessions.last_seen_ts_wall_ms),
-					lte(schema.rawEventSessions.last_seen_ts_wall_ms, idleBeforeTsWallMs),
+					idleBeforeTsWallMs == null
+						? undefined
+						: lte(schema.rawEventSessions.last_seen_ts_wall_ms, idleBeforeTsWallMs),
 					gt(maxEvents.max_seq, schema.rawEventSessions.last_flushed_event_seq),
 				),
 			)

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -45,9 +45,27 @@ const VIEWER_HEALTH_RESTART_COOLDOWN_MS = 5 * 60_000;
 const RAW_EVENTS_STATUS_TIMEOUT_MS = 5_000;
 const DEFAULT_EMBEDDING_MODEL = "Xenova/bge-small-en-v1.5";
 const DEFAULT_EMBEDDING_REVISION = "ea104dacec62c0de699686887e3f920caeb4f3e3";
+const PLUGIN_REGISTRATIONS_KEY = Symbol.for("codemem.opencode-plugin.registrations");
 
 let compatCheckCache = null;
 const notifiedReleaseVersions = new Set();
+
+const claimPluginRegistration = (cwd) => {
+  let registrations = globalThis[PLUGIN_REGISTRATIONS_KEY];
+  if (!(registrations instanceof Map)) {
+    registrations = new Map();
+    globalThis[PLUGIN_REGISTRATIONS_KEY] = registrations;
+  }
+  const projectPath = resolve(cwd);
+  if (registrations.has(projectPath)) return null;
+  const registration = Symbol(projectPath);
+  registrations.set(projectPath, registration);
+  return () => {
+    if (registrations.get(projectPath) === registration) {
+      registrations.delete(projectPath);
+    }
+  };
+};
 const rawEventSpoolDrainsInFlight = new Map();
 
 // Release an unread response body without surfacing cancellation failures.
@@ -1906,6 +1924,13 @@ export const CodememPlugin = async ({
     TRUTHY_VALUES
   );
   if (pluginIgnored) {
+    return {};
+  }
+  const releasePluginRegistration = claimPluginRegistration(cwd);
+  if (!releasePluginRegistration) {
+    await log("warn", "codemem duplicate plugin registration skipped", {
+      next_action: "remove either the configured npm plugin or the project-local Codemem plugin",
+    });
     return {};
   }
 
@@ -3846,6 +3871,11 @@ export const CodememPlugin = async ({
   void drainRawEventSpool();
 
   return {
+    dispose: () => {
+      clearTimeout(updateCheckTimer);
+      stopHealthCheck();
+      releasePluginRegistration();
+    },
     "experimental.session.compacting": async (input) => {
       const sessionID = extractHookSessionID(input) || activeSessionID;
       markCompactionInjectionSkip(compactionInjectionSkips, sessionID);


### PR DESCRIPTION
## Description
Deduplicate plugin collectors per process and Project, release registrations on disposal, and drain bounded pending active or idle sessions. This prevents duplicate capture while allowing deferred backlogs to recover.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced