### PR TITLE
fix(core): reject command failures as project identity

### DIFF
--- a/packages/core/src/export-import.test.ts
+++ b/packages/core/src/export-import.test.ts
@@ -278,6 +278,32 @@ describe("export/import", () => {
 		}
 	});
 
+	it("does not import command failures as session identity metadata", () => {
+		const payload = minimalPayload("local-default");
+		const session = payload.sessions[0];
+		if (!session) throw new Error("expected fixture session");
+		session.cwd = "Command failed: git rev-parse --show-toplevel";
+		session.project = "error: failed to discover project";
+		session.git_remote = "fatal: not a git repository";
+		session.git_branch = "fatal: ambiguous argument HEAD";
+		const destination = createDbPath("malformed-identity-import");
+		const setupDb = new Database(destination);
+		initTestSchema(setupDb);
+		setupDb.close();
+
+		importMemories(payload, { dbPath: destination });
+
+		const checkDb = new Database(destination, { readonly: true });
+		try {
+			const imported = checkDb
+				.prepare("SELECT cwd, project, git_remote, git_branch FROM sessions LIMIT 1")
+				.get();
+			expect(imported).toEqual({ cwd: null, project: null, git_remote: null, git_branch: null });
+		} finally {
+			checkDb.close();
+		}
+	});
+
 	it("preserves imported source scopes only when locally authorized", () => {
 		const authorizedDestPath = createDbPath("authorized-import-scope");
 		const authorizedDb = new Database(authorizedDestPath);

--- a/packages/core/src/export-import.ts
+++ b/packages/core/src/export-import.ts
@@ -12,6 +12,7 @@ import {
 import { buildFilterClausesWithContext } from "./filters.js";
 import { expandUserPath } from "./observer-config.js";
 import { projectColumnClause, resolveProject as resolveProjectName } from "./project.js";
+import { cleanProjectIdentity } from "./project-identity.js";
 import * as schema from "./schema.js";
 import { LOCAL_DEFAULT_SCOPE_ID } from "./scope-resolution.js";
 import { resolveSessionScopeId } from "./scope-stamping.js";
@@ -411,10 +412,10 @@ function insertSession(d: DrizzleDb, row: JsonObject): number {
 		.values({
 			started_at: typeof row.started_at === "string" ? row.started_at : nowIso(),
 			ended_at: typeof row.ended_at === "string" ? row.ended_at : null,
-			cwd: String(row.cwd ?? process.cwd()),
-			project: row.project == null ? null : String(row.project),
-			git_remote: row.git_remote == null ? null : String(row.git_remote),
-			git_branch: row.git_branch == null ? null : String(row.git_branch),
+			cwd: row.cwd == null ? process.cwd() : cleanProjectIdentity(String(row.cwd)),
+			project: row.project == null ? null : cleanProjectIdentity(String(row.project)),
+			git_remote: row.git_remote == null ? null : cleanProjectIdentity(String(row.git_remote)),
+			git_branch: row.git_branch == null ? null : cleanProjectIdentity(String(row.git_branch)),
 			user: String(row.user ?? nextUserName()),
 			tool_version: String(row.tool_version ?? "import"),
 			metadata_json: toJson(row.metadata_json ?? null),

--- a/packages/core/src/legacy-recipient-policy-projection.test.ts
+++ b/packages/core/src/legacy-recipient-policy-projection.test.ts
@@ -190,6 +190,25 @@ describe("legacy recipient-policy projection", () => {
 		},
 	);
 
+	it("reports malformed legacy metadata as noncanonical without changing recipient policy", () => {
+		insertProject(db, {
+			cwd: "Command failed: git rev-parse --show-toplevel",
+			project: "error: failed to discover project",
+			remote: "fatal: not a git repository (or any of the parent directories): .git",
+		});
+		const recipientsBefore = db.prepare("SELECT * FROM project_recipients ORDER BY rowid").all();
+
+		const [projection] = projections(db);
+
+		expect(projection).toMatchObject({
+			conditions: [expect.objectContaining({ code: "noncanonical_project_identity" })],
+			enforcement: { safeErrorCode: "noncanonical_project_identity", state: "ambiguous" },
+		});
+		expect(db.prepare("SELECT * FROM project_recipients ORDER BY rowid").all()).toEqual(
+			recipientsBefore,
+		);
+	});
+
 	it("projects one exact canonical Project from one active managed scope", () => {
 		const scopeId = "managed-project-one";
 		const projectId = insertProject(db, { project: "api", scopeId });

--- a/packages/core/src/project-identity.test.ts
+++ b/packages/core/src/project-identity.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { cleanProjectIdentity, isMalformedProjectIdentity } from "./project-identity.js";
+
+describe("project identity metadata", () => {
+	it.each([
+		"Command failed: git rev-parse --show-toplevel",
+		"error: failed to discover project",
+		"fatal: not a git repository",
+		"git: 'workspace-id' is not a git command",
+		"valid-project\nfatal: leaked stderr",
+	])("rejects command failure output: %s", (value) => {
+		expect(isMalformedProjectIdentity(value)).toBe(true);
+		expect(cleanProjectIdentity(value)).toBeNull();
+	});
+
+	it.each(["fatal-error-handler", "/tmp/error: logs", "git:alpha", "project name"])(
+		"preserves valid identity text: %s",
+		(value) => {
+			expect(cleanProjectIdentity(` ${value} `)).toBe(value);
+		},
+	);
+});

--- a/packages/core/src/project-identity.ts
+++ b/packages/core/src/project-identity.ts
@@ -1,0 +1,17 @@
+const COMMAND_FAILURE_PREFIX = /^(?:command failed(?:\s|:)|error:\s|fatal:\s|git:\s)/iu;
+const GIT_FAILURE_TEXT = /\b(?:not a git repository|unknown revision or path|no such remote)\b/iu;
+
+/** Return true when a discovery failure was supplied where Project identity was expected. */
+export function isMalformedProjectIdentity(value: unknown): boolean {
+	if (typeof value !== "string") return false;
+	const cleaned = value.trim();
+	if (!cleaned) return false;
+	if (cleaned.includes("\n") || cleaned.includes("\r")) return true;
+	return COMMAND_FAILURE_PREFIX.test(cleaned) || GIT_FAILURE_TEXT.test(cleaned);
+}
+
+export function cleanProjectIdentity(value: string | null | undefined): string | null {
+	const cleaned = value?.trim();
+	if (!cleaned || isMalformedProjectIdentity(cleaned)) return null;
+	return cleaned;
+}

--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -138,6 +138,48 @@ describe("project scope settings", () => {
 		]);
 	});
 
+	it("surfaces a legacy malformed identity as unmapped for repair", () => {
+		const sessionId = insertSession(db, {
+			cwd: "Command failed: git rev-parse --show-toplevel",
+			gitRemote: "fatal: not a git repository (or any of the parent directories): .git",
+			project: "error: failed to discover project",
+		});
+		insertMemory(db, sessionId, { workspaceId: null });
+
+		expect(listProjectScopeInventory(db).projects).toEqual([
+			expect.objectContaining({
+				cwd: null,
+				display_project: expect.stringMatching(/^unmapped:/),
+				git_remote: null,
+				identity_source: "unmapped",
+				project: null,
+				resolved_scope_id: LOCAL_DEFAULT_SCOPE_ID,
+				statuses: expect.arrayContaining(["local_only", "unmapped"]),
+				workspace_identity: expect.stringMatching(/^unmapped:/),
+			}),
+		]);
+	});
+
+	it("keeps distinct malformed legacy sessions as separate repair candidates", () => {
+		for (const [index, failure] of [
+			"fatal: not a git repository",
+			"Command failed: git remote get-url origin",
+		].entries()) {
+			const sessionId = insertSession(db, {
+				cwd: failure,
+				gitRemote: failure,
+				project: `error: failed project ${index}`,
+			});
+			insertMemory(db, sessionId, { workspaceId: null });
+		}
+
+		const projects = listProjectScopeInventory(db).projects;
+
+		expect(projects).toHaveLength(2);
+		expect(new Set(projects.map((project) => project.workspace_identity)).size).toBe(2);
+		expect(projects.every((project) => project.identity_source === "unmapped")).toBe(true);
+	});
+
 	it("fails closed when a bounded candidate scan exceeds its row budget", () => {
 		insertSession(db, { cwd: "/workspace/one", gitRemote: null, project: "one" });
 		insertSession(db, { cwd: "/workspace/two", gitRemote: null, project: "two" });

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { type Database, fromJson, toJson } from "./db.js";
 import { hasLocalInventoryIdentity } from "./local-project-inventory.js";
+import { cleanProjectIdentity } from "./project-identity.js";
 import { ensureScopeBackfillScopes, LEGACY_SHARED_REVIEW_SCOPE_ID } from "./scope-backfill.js";
 import {
 	canonicalWorkspaceIdentity,
@@ -458,6 +459,10 @@ function buildProjectScopeCandidate(
 	mappings: ProjectScopeSettingsMapping[],
 	scopes: SharingDomainSettingsScope[],
 ): ProjectScopeCandidate {
+	const project = cleanProjectIdentity(row.project);
+	const cwd = cleanProjectIdentity(row.cwd);
+	const gitRemote = cleanProjectIdentity(row.git_remote);
+	const gitBranch = cleanProjectIdentity(row.git_branch);
 	const identity = canonicalWorkspaceIdentity({
 		gitRemote: row.git_remote,
 		gitBranch: row.git_branch,
@@ -476,12 +481,11 @@ function buildProjectScopeCandidate(
 	const baseCandidate = {
 		workspace_identity: identity.value,
 		identity_source: identity.source,
-		display_project:
-			identity.displayProject ?? clean(row.project) ?? clean(row.cwd) ?? identity.value,
-		project: clean(row.project),
-		cwd: clean(row.cwd),
-		git_remote: clean(row.git_remote),
-		git_branch: clean(row.git_branch),
+		display_project: identity.displayProject ?? project ?? cwd ?? identity.value,
+		project,
+		cwd,
+		git_remote: gitRemote,
+		git_branch: gitBranch,
 		latest_session_at: row.started_at,
 		resolved_scope_id: resolution.scopeId,
 		resolution_reason: resolution.reason,

--- a/packages/core/src/raw-event-ingest.test.ts
+++ b/packages/core/src/raw-event-ingest.test.ts
@@ -371,6 +371,38 @@ describe("ingestRawEvents", () => {
 		}
 	});
 
+	it("discards failed Git discovery output and preserves valid fallback metadata", () => {
+		const store = createStore();
+		try {
+			ingestRawEvents(store, {
+				source: "opencode",
+				session_id: "session-failed-discovery",
+				cwd: "/workspace/valid",
+				project: "valid-project",
+				events: [
+					{
+						event_id: "event-failed-discovery",
+						event_type: "prompt",
+						payload: {},
+						cwd: "fatal: not a git repository (or any of the parent directories): .git",
+						project: "Command failed: git rev-parse --show-toplevel",
+					},
+				],
+			});
+
+			store.updateRawEventSessionMeta({
+				opencodeSessionId: "session-failed-discovery",
+				cwd: "fatal: not a git repository (or any of the parent directories): .git",
+				project: "error: failed to discover project",
+			});
+
+			const session = store.db.prepare("SELECT cwd, project FROM raw_event_sessions").get();
+			expect(session).toEqual({ cwd: "/workspace/valid", project: "valid-project" });
+		} finally {
+			store.close();
+		}
+	});
+
 	it.each(["claude", "codex"])("starts a fresh %s stream at sequence zero", (source) => {
 		const store = createStore();
 		try {

--- a/packages/core/src/raw-event-ingest.ts
+++ b/packages/core/src/raw-event-ingest.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { Database } from "./db.js";
 import { stripPrivateObj } from "./ingest-sanitize.js";
+import { cleanProjectIdentity } from "./project-identity.js";
 
 const SESSION_ID_KEYS = [
 	"session_stream_id",
@@ -94,6 +95,14 @@ function optionalString(value: Record<string, unknown>, key: string): string | n
 	if (raw == null) return null;
 	if (typeof raw !== "string") validationError(`${key} must be string`);
 	return raw || null;
+}
+
+function optionalProjectIdentity(
+	value: Record<string, unknown>,
+	key: "cwd" | "project",
+): string | null {
+	const identity = optionalString(value, key);
+	return cleanProjectIdentity(identity);
 }
 
 function optionalNumber(value: Record<string, unknown>, key: string): number | null {
@@ -213,8 +222,8 @@ function normalizeEvent(
 		payload,
 		tsWallMs,
 		tsMonoMs,
-		cwd: optionalString(item, "cwd"),
-		project: optionalString(item, "project"),
+		cwd: optionalProjectIdentity(item, "cwd"),
+		project: optionalProjectIdentity(item, "project"),
 		startedAt: optionalString(item, "started_at"),
 	};
 }
@@ -237,8 +246,8 @@ function normalizeRequest(request: Record<string, unknown>): NormalizedRequest {
 		events,
 		received: rawEvents.length,
 		requestMeta: {
-			cwd: optionalString(request, "cwd"),
-			project: optionalString(request, "project"),
+			cwd: optionalProjectIdentity(request, "cwd"),
+			project: optionalProjectIdentity(request, "project"),
 			startedAt: optionalString(request, "started_at"),
 		},
 	};

--- a/packages/core/src/scope-resolution.test.ts
+++ b/packages/core/src/scope-resolution.test.ts
@@ -42,6 +42,32 @@ describe("canonicalWorkspaceIdentity", () => {
 			}).value,
 		).toBe("https://github.com/kunickiaj/codemem.git:feature/scope");
 	});
+
+	it("falls through malformed higher-priority identity to a valid cwd", () => {
+		expect(
+			canonicalWorkspaceIdentity({
+				cwd: "/work/acme/service",
+				gitRemote: "fatal: not a git repository (or any of the parent directories): .git",
+				project: "service",
+			}),
+		).toEqual({
+			displayProject: "service",
+			source: "cwd",
+			value: "/work/acme/service",
+		});
+	});
+
+	it("quarantines malformed legacy identity fields as unmapped", () => {
+		const identity = canonicalWorkspaceIdentity({
+			cwd: "Command failed: git rev-parse --show-toplevel",
+			gitRemote: "fatal: not a git repository (or any of the parent directories): .git",
+			project: "error: failed to discover project",
+			workspaceId: "git: 'workspace-id' is not a git command",
+		});
+
+		expect(identity).toMatchObject({ displayProject: null, source: "unmapped" });
+		expect(identity.value).toMatch(/^unmapped:[a-f0-9]{64}$/);
+	});
 });
 
 describe("resolveProjectScope", () => {

--- a/packages/core/src/scope-resolution.ts
+++ b/packages/core/src/scope-resolution.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import type { Database } from "better-sqlite3";
+import { cleanProjectIdentity } from "./project-identity.js";
 
 export const LOCAL_DEFAULT_SCOPE_ID = "local-default";
 
@@ -101,23 +102,25 @@ function normalizeMappingIdentity(value: string | null | undefined): string | nu
 }
 
 function unmappedIdentity(input: WorkspaceIdentityInput): string {
-	const seed = [input.cwd, input.project, input.workspaceId]
-		.map((value) => clean(value))
+	const validSeed = [input.cwd, input.project, input.workspaceId]
+		.map((value) => cleanProjectIdentity(value))
 		.find((value): value is string => value != null);
-	const digest = createHash("sha256")
-		.update(seed ?? "unknown", "utf8")
-		.digest("hex");
+	const rawSeed = [input.gitRemote, input.gitBranch, input.cwd, input.project, input.workspaceId]
+		.map((value) => (typeof value === "string" ? value.trim() : ""))
+		.find(Boolean);
+	const seed = validSeed ?? rawSeed ?? "unknown";
+	const digest = createHash("sha256").update(seed, "utf8").digest("hex");
 	return `unmapped:${digest}`;
 }
 
 export function canonicalWorkspaceIdentity(
 	input: WorkspaceIdentityInput,
 ): CanonicalWorkspaceIdentity {
-	const gitRemote = clean(input.gitRemote);
-	const gitBranch = clean(input.gitBranch);
-	const cwd = clean(input.cwd);
-	const workspaceId = clean(input.workspaceId);
-	const project = clean(input.project);
+	const gitRemote = cleanProjectIdentity(input.gitRemote);
+	const gitBranch = cleanProjectIdentity(input.gitBranch);
+	const cwd = cleanProjectIdentity(input.cwd);
+	const workspaceId = cleanProjectIdentity(input.workspaceId);
+	const project = cleanProjectIdentity(input.project);
 
 	if (gitRemote) {
 		const normalizedRemote = normalizeSlash(gitRemote);

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -105,6 +105,21 @@ describe("MemoryStore", () => {
 		return Number(info.lastInsertRowid);
 	}
 
+	it("does not persist command failures as session identity metadata", () => {
+		const sessionId = store.startSession({
+			cwd: "Command failed: git rev-parse --show-toplevel",
+			project: "error: failed to discover project",
+			gitRemote: "fatal: not a git repository (or any parent): .git",
+			gitBranch: "fatal: ambiguous argument HEAD",
+		});
+
+		const session = store.db
+			.prepare("SELECT cwd, project, git_remote, git_branch FROM sessions WHERE id = ?")
+			.get(sessionId);
+
+		expect(session).toEqual({ cwd: null, project: null, git_remote: null, git_branch: null });
+	});
+
 	// -- get ----------------------------------------------------------------
 
 	describe("get", () => {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -42,6 +42,7 @@ import {
 	buildMemoryPackWithTrace,
 	buildMemoryPackWithTraceAsync,
 } from "./pack.js";
+import { cleanProjectIdentity } from "./project-identity.js";
 import { populateMemoryRefs } from "./ref-populate.js";
 import type { RefQueryOptions, RefQueryResult } from "./ref-queries.js";
 import { findByConcept as findByConceptFn, findByFile as findByFileFn } from "./ref-queries.js";
@@ -598,14 +599,15 @@ export class MemoryStore {
 		metadata?: Record<string, unknown>;
 	}): number {
 		const now = nowIso();
+		const cwd = opts.cwd == null ? process.cwd() : cleanProjectIdentity(opts.cwd);
 		const rows = this.d
 			.insert(schema.sessions)
 			.values({
 				started_at: now,
-				cwd: opts.cwd ?? process.cwd(),
-				project: opts.project ?? null,
-				git_remote: opts.gitRemote ?? null,
-				git_branch: opts.gitBranch ?? null,
+				cwd,
+				project: cleanProjectIdentity(opts.project),
+				git_remote: cleanProjectIdentity(opts.gitRemote),
+				git_branch: cleanProjectIdentity(opts.gitBranch),
 				user: opts.user ?? process.env.USER ?? "unknown",
 				tool_version: opts.toolVersion ?? "manual",
 				metadata_json: toJson(opts.metadata ?? {}),
@@ -646,12 +648,14 @@ export class MemoryStore {
 		}
 
 		const startedAt = opts.startedAt ?? nowIso();
+		const cwd = opts.cwd == null ? process.cwd() : cleanProjectIdentity(opts.cwd);
+		const project = cleanProjectIdentity(opts.project);
 		const sessionRows = this.d
 			.insert(schema.sessions)
 			.values({
 				started_at: startedAt,
-				cwd: opts.cwd ?? process.cwd(),
-				project: opts.project ?? null,
+				cwd,
+				project,
 				git_remote: null,
 				git_branch: null,
 				user: opts.user ?? process.env.USER ?? "unknown",
@@ -2616,6 +2620,8 @@ export class MemoryStore {
 			opts.opencodeSessionId,
 		);
 		const now = nowIso();
+		const cwd = cleanProjectIdentity(opts.cwd);
+		const project = cleanProjectIdentity(opts.project);
 		const t = schema.rawEventSessions;
 		this.d
 			.insert(t)
@@ -2623,8 +2629,8 @@ export class MemoryStore {
 				opencode_session_id: streamId,
 				source,
 				stream_id: streamId,
-				cwd: opts.cwd ?? null,
-				project: opts.project ?? null,
+				cwd,
+				project,
 				started_at: opts.startedAt ?? null,
 				last_seen_ts_wall_ms: opts.lastSeenTsWallMs ?? null,
 				updated_at: now,


### PR DESCRIPTION
## Description
Reject command output and failure text as Project identities at raw-event, store, and import boundaries. Legacy malformed values now fall through safely or enter distinct unmapped quarantine findings without changing sharing policy.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced