### PR TITLE
fix(ui): separate sharing review categories

### DIFF
--- a/docs/superpowers/specs/2026-08-10-recipient-policy-multi-project-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-10-recipient-policy-multi-project-diagnostics-design.md
@@ -3,6 +3,7 @@
 **Date:** 2026-08-10
 **Target:** 0.40.2
 **Status:** Approved
+**Amended:** 2026-09-06 to separate review, continuity, and repair presentation
 
 ## Problem
 
@@ -18,19 +19,21 @@ Treat `wildcard_scope_mapping` the same way: a deliberate catch-all mapping can 
 
 This changes presentation only. It does not create recipient intent, change current access, promote recipient-policy authority, resolve migration findings, or weaken scope enforcement.
 
+The amended Projects surface presents actionable review decisions, preserved legacy continuity, and blocked source repairs as separate categories under the neutral title `Sharing review`. Each category scopes its access and action guidance to its own findings, so preserved continuity cannot make a mixed response look repaired or blocked. The V1 response adds `categoryCounts`; `continuity.findingCount` remains the compatible aggregate for older clients.
+
 ## Implementation
 
 - Add an exhaustive, typed presentation classification for every `LegacyRecipientPolicyConditionCodeV1`: actionable, repairable blocked, or preserved continuity. Adding a future condition code must fail compilation until its presentation is selected explicitly.
 - Classify `ambiguous_multi_project_scope` as preserved continuity only for legacy umbrella scope kinds, and keep a `managed_project` collision repairable. Classify `wildcard_scope_mapping` as preserved continuity; classify noncanonical identities, conflicting mappings, and inactive boundaries as repairable blocked conditions.
-- Count suppressed diagnostics in the existing `continuity.findingCount` alongside unresolved deferred review items.
+- Count suppressed diagnostics in `categoryCounts.preservedContinuity`; retain the existing aggregate `continuity.findingCount` for older clients.
 - Preserve the existing `hasDiagnostic` gate so ambiguous Projects remain fail-closed and do not gain actionable review options.
-- When continuity and genuine blocked items coexist, title the surface `Sharing needs repair` and retain the deferred-finding count. Suppress the continuity-only `No action is required` introduction in this mixed state so the copy does not contradict the repair cards.
+- Render separate `Review decisions`, `Preserved legacy continuity`, and `Blocked source repairs` sections with independent counts, and preserve repair controls only in the blocked section.
 - Add regression coverage proving that a multi-Project umbrella scope remains ambiguous in projection, contributes to continuity, and does not become a blocked repair card.
 - Cover mixed intentional and repairable diagnostics, retained blocked-item ID stability, and migration remaining skipped without authoritative evidence.
-- Preserve blocked-card coverage for a genuinely noncanonical Project identity and UI coverage for continuity-only and mixed states. The mixed-state test must intentionally replace its previous `Existing sharing kept as-is` and `No action is required` expectations.
+- Preserve blocked-card coverage for a genuinely noncanonical Project identity and UI coverage for continuity-only and mixed states. Mixed-state tests must prove continuity findings do not appear as repair blockers.
 - Cover the exhaustive presentation classification so a newly added condition code cannot silently disappear from review.
 
-The review response shape and contract version remain unchanged. The legacy projection condition shape is additively extended with optional `scopeKinds` evidence. `continuity` is already an additive V1 field; this patch only corrects which legacy findings contribute to it versus `blockedItems`.
+The contract version remains unchanged. The response additively includes `categoryCounts`, and the legacy projection condition shape retains optional `scopeKinds` evidence. Older clients can continue reading `continuity` and `blockedItems`.
 
 ## Validation
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -889,6 +889,7 @@ export type {
 	RecipientPolicyDerivedReviewState,
 	RecipientPolicyReviewActionOptionV1,
 	RecipientPolicyReviewBulkResultV1,
+	RecipientPolicyReviewCategoryCountsV1,
 	RecipientPolicyReviewContext,
 	RecipientPolicyReviewListV1,
 	RecipientPolicyReviewResolveRequestV1,

--- a/packages/core/src/recipient-policy-review.test.ts
+++ b/packages/core/src/recipient-policy-review.test.ts
@@ -206,6 +206,12 @@ function protectedSnapshot(db: InstanceType<typeof Database>): string {
 		"replication_scopes",
 		"project_scope_mappings",
 		"scope_memberships",
+		"policy_teams",
+		"policy_team_memberships",
+		"policy_team_device_decisions",
+		"project_recipients",
+		"recipient_policy_authority_states",
+		"recipient_policy_deny_overlays",
 		"memory_items",
 		"replication_ops",
 		"replication_cursors",
@@ -292,6 +298,11 @@ describe("recipient policy review persistence", () => {
 			findingCount: 1,
 			state: "legacy_access_preserved",
 		});
+		expect(result.categoryCounts).toEqual({
+			actionableReview: 1,
+			preservedContinuity: 0,
+			blockedRepair: 0,
+		});
 		expect(result.reviewItems).toHaveLength(1);
 		const item = result.reviewItems[0];
 		expect(new Set(item?.options.map((option) => option.decision)).size).toBe(item?.options.length);
@@ -329,6 +340,11 @@ describe("recipient policy review persistence", () => {
 		const result = listRecipientPolicyReview(db, context);
 
 		expect(result.continuity).toBeNull();
+		expect(result.categoryCounts).toEqual({
+			actionableReview: 0,
+			preservedContinuity: 0,
+			blockedRepair: 1,
+		});
 		expect(result.blockedItems[0]).toMatchObject({
 			ownerLabel: "Project owner",
 			repairAction: expect.any(String),
@@ -378,6 +394,11 @@ describe("recipient policy review persistence", () => {
 		).toBe(true);
 		expect(result).toMatchObject({
 			blockedItems: [],
+			categoryCounts: {
+				actionableReview: 0,
+				preservedContinuity: 2,
+				blockedRepair: 0,
+			},
 			continuity: { findingCount: 2, state: "legacy_access_preserved" },
 			reviewItems: [],
 		});
@@ -427,6 +448,61 @@ describe("recipient policy review persistence", () => {
 			continuity: { findingCount: 1, state: "legacy_access_preserved" },
 			reviewItems: [],
 		});
+	});
+
+	it("reports separate counts for mixed decisions, continuity, and blocked repairs", () => {
+		insertLegacyScope(db, "personal-review", "personal");
+		db.prepare("UPDATE memory_items SET scope_id = 'personal-review'").run();
+		mapProject(db, PROJECT_ID, PROJECT_ID, "personal-review");
+		insertLegacyScope(db, "legacy-wildcard");
+		mapProject(db, null, "*", "legacy-wildcard");
+		const continuityProjectId = "https://git.example.invalid/acme/continuity.git";
+		const continuitySessionId = Number(
+			db
+				.prepare(
+					`INSERT INTO sessions(started_at, project, git_remote, git_branch)
+					 VALUES (?, 'continuity', ?, 'main')`,
+				)
+				.run(NOW, continuityProjectId).lastInsertRowid,
+		);
+		db.prepare(
+			`INSERT INTO memory_items(
+			 session_id, kind, title, body_text, active, created_at, updated_at,
+			 visibility, project, scope_id
+			 ) VALUES (?, 'discovery', 'Continuity fixture', 'body', 1, ?, ?, 'shared',
+			 'continuity', 'legacy-wildcard')`,
+		).run(continuitySessionId, NOW, NOW);
+		const blockedSessionId = Number(
+			db.prepare("INSERT INTO sessions(started_at, project) VALUES (?, 'display-only')").run(NOW)
+				.lastInsertRowid,
+		);
+		insertLegacyScope(db, "blocked-managed", "managed_project");
+		db.prepare(
+			`INSERT INTO memory_items(
+			 session_id, kind, title, body_text, active, created_at, updated_at,
+			 visibility, project, scope_id
+			 ) VALUES (?, 'discovery', 'Blocked fixture', 'body', 1, ?, ?, 'private',
+			 'display-only', 'blocked-managed')`,
+		).run(blockedSessionId, NOW, NOW);
+		const blockedProjectId = listLegacyRecipientPolicyProjections(db, context).find(
+			(item) => item.project.displayName === "display-only",
+		)?.project.canonicalIdentity;
+		if (!blockedProjectId) throw new Error("blocked Project fixture missing");
+		mapProject(db, blockedProjectId, blockedProjectId, "blocked-managed");
+
+		const result = listRecipientPolicyReview(db, context);
+
+		expect(result.categoryCounts).toEqual({
+			actionableReview: 1,
+			preservedContinuity: 1,
+			blockedRepair: 1,
+		});
+		expect(result.continuity).toEqual({
+			findingCount: 2,
+			state: "legacy_access_preserved",
+		});
+		expect(result.reviewItems).toHaveLength(1);
+		expect(result.blockedItems).toHaveLength(1);
 	});
 
 	it("emits only repairable cards for mixed diagnostics and keeps blocked IDs stable", () => {
@@ -490,6 +566,35 @@ describe("recipient policy review persistence", () => {
 		]);
 	});
 
+	it("keeps actionable options suppressed when the same Project has a continuity diagnostic", () => {
+		const mixed = projection();
+		mixed.conditions = [
+			{
+				version: 1,
+				code: "wildcard_scope_mapping",
+				kind: "diagnostic",
+				message: "Legacy wildcard access remains preserved.",
+			},
+			{
+				version: 1,
+				code: "suggest_local_identity",
+				kind: "actionable",
+				message: "A local Identity candidate exists.",
+			},
+		];
+
+		const state = deriveRecipientPolicyReviewState(db, context, [mixed]);
+
+		expect(state.allReviewItems).toEqual([]);
+		expect(state.blockedItems).toEqual([]);
+		expect(state.preservedDiagnosticFindings).toEqual([
+			{
+				canonicalProjectIdentity: PROJECT_ID,
+				conditionCode: "wildcard_scope_mapping",
+			},
+		]);
+	});
+
 	it("records only the immutable resolution with server-derived attribution", () => {
 		const item = listRecipientPolicyReview(db, context).reviewItems[0];
 		if (!item) throw new Error("review item missing");
@@ -522,6 +627,11 @@ describe("recipient policy review persistence", () => {
 		const resolvedReview = listRecipientPolicyReview(db, context);
 		expect(resolvedReview.reviewItems).toEqual([]);
 		expect(resolvedReview.continuity).toBeNull();
+		expect(resolvedReview.categoryCounts).toEqual({
+			actionableReview: 0,
+			preservedContinuity: 0,
+			blockedRepair: 0,
+		});
 	});
 
 	it("rejects stale fingerprints without writing", () => {

--- a/packages/core/src/recipient-policy-review.ts
+++ b/packages/core/src/recipient-policy-review.ts
@@ -47,6 +47,12 @@ export interface RecipientPolicyReviewContinuityV1 {
 	findingCount: number;
 }
 
+export interface RecipientPolicyReviewCategoryCountsV1 {
+	actionableReview: number;
+	preservedContinuity: number;
+	blockedRepair: number;
+}
+
 // Patch-level additive wire hint: existing v1 clients ignore the new field,
 // while current clients require it so absence cannot silently change UX mode.
 export interface RecipientPolicyReviewListV1 {
@@ -54,6 +60,7 @@ export interface RecipientPolicyReviewListV1 {
 	reviewItems: RecipientPolicyActionableReviewItemV1[];
 	blockedItems: RecipientPolicyBlockedItemV1[];
 	continuity: RecipientPolicyReviewContinuityV1 | null;
+	categoryCounts: RecipientPolicyReviewCategoryCountsV1;
 }
 
 export interface RecipientPolicyReviewResolveRequestV1 {
@@ -545,6 +552,11 @@ export function listRecipientPolicyReview(
 		version: RECIPIENT_POLICY_CONTRACT_VERSION,
 		reviewItems,
 		blockedItems: state.blockedItems,
+		categoryCounts: {
+			actionableReview: reviewItems.length,
+			preservedContinuity: state.preservedDiagnosticFindings.length,
+			blockedRepair: state.blockedItems.length,
+		},
 		continuity:
 			findingCount > 0
 				? {

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -93,6 +93,7 @@ export type {
 	RecipientPolicyReconciliationReadState,
 	RecipientPolicyReconciliationStatusV1,
 	RecipientPolicyReviewBulkResultV1,
+	RecipientPolicyReviewCategoryCountsV1,
 	RecipientPolicyReviewDecisionV1,
 	RecipientPolicyReviewItemV1,
 	RecipientPolicyReviewListV1,

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -972,6 +972,11 @@ describe("recipient policy review API", () => {
 			version: 1,
 			reviewItems: [],
 			blockedItems: [],
+			categoryCounts: {
+				actionableReview: 0,
+				preservedContinuity: 0,
+				blockedRepair: 0,
+			},
 			continuity: null,
 		};
 		const applied = {
@@ -1008,7 +1013,32 @@ describe("recipient policy review API", () => {
 		);
 	});
 
-	it("keeps legacy review items visible when continuity is absent", async () => {
+	it("uses review arrays when explicit category counts disagree", async () => {
+		const review = {
+			version: 1,
+			reviewItems: [{ reviewItemId: "review-visible" }],
+			blockedItems: [{ blockedItemId: "repair-visible" }],
+			categoryCounts: {
+				actionableReview: 0,
+				preservedContinuity: 2,
+				blockedRepair: 0,
+			},
+			continuity: { findingCount: 3, state: "legacy_access_preserved" },
+		};
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(new Response(JSON.stringify(review), { status: 200 })) as typeof fetch;
+
+		await expect(loadRecipientPolicyReview()).resolves.toMatchObject({
+			categoryCounts: {
+				actionableReview: 1,
+				preservedContinuity: 2,
+				blockedRepair: 1,
+			},
+		});
+	});
+
+	it("keeps legacy review items actionable when continuity is absent", async () => {
 		const legacyReview = {
 			version: 1,
 			reviewItems: [{ reviewItemId: "legacy-review" }],
@@ -1022,7 +1052,57 @@ describe("recipient policy review API", () => {
 
 		await expect(loadRecipientPolicyReview()).resolves.toEqual({
 			...legacyReview,
-			continuity: { findingCount: 1, state: "legacy_access_preserved" },
+			categoryCounts: {
+				actionableReview: 1,
+				preservedContinuity: 0,
+				blockedRepair: 0,
+			},
+			continuity: null,
+		});
+	});
+
+	it("separates review, continuity, and repair counts in an old aggregate payload", async () => {
+		const aggregateReview = {
+			version: 1,
+			reviewItems: [{ reviewItemId: "legacy-review" }],
+			blockedItems: [{ blockedItemId: "legacy-blocked" }],
+			continuity: { findingCount: 3, state: "legacy_access_preserved" },
+		};
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify(aggregateReview), { status: 200 }),
+			) as typeof fetch;
+
+		await expect(loadRecipientPolicyReview()).resolves.toEqual({
+			...aggregateReview,
+			categoryCounts: {
+				actionableReview: 1,
+				preservedContinuity: 2,
+				blockedRepair: 1,
+			},
+		});
+	});
+
+	it("clamps old preserved continuity counts at zero", async () => {
+		const aggregateReview = {
+			version: 1,
+			reviewItems: [{ reviewItemId: "legacy-review" }],
+			blockedItems: [],
+			continuity: { findingCount: 0, state: "legacy_access_preserved" },
+		};
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify(aggregateReview), { status: 200 }),
+			) as typeof fetch;
+
+		await expect(loadRecipientPolicyReview()).resolves.toMatchObject({
+			categoryCounts: {
+				actionableReview: 1,
+				preservedContinuity: 0,
+				blockedRepair: 0,
+			},
 		});
 	});
 

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -722,10 +722,17 @@ export interface RecipientPolicyBlockedItemV1 {
 	};
 }
 
+export interface RecipientPolicyReviewCategoryCountsV1 {
+	actionableReview: number;
+	preservedContinuity: number;
+	blockedRepair: number;
+}
+
 export interface RecipientPolicyReviewListV1 {
 	version: 1;
 	reviewItems: RecipientPolicyReviewItemV1[];
 	blockedItems: RecipientPolicyBlockedItemV1[];
+	categoryCounts: RecipientPolicyReviewCategoryCountsV1;
 	continuity: {
 		state: "legacy_access_preserved";
 		findingCount: number;
@@ -1854,17 +1861,35 @@ export function createRecipientInvite(
 
 export async function loadRecipientPolicyReview(): Promise<RecipientPolicyReviewListV1> {
 	const review = await fetchJson<
-		Omit<RecipientPolicyReviewListV1, "continuity"> & {
+		Omit<RecipientPolicyReviewListV1, "categoryCounts" | "continuity"> & {
+			categoryCounts?: RecipientPolicyReviewListV1["categoryCounts"];
 			continuity?: RecipientPolicyReviewListV1["continuity"];
 		}
 	>("/api/sync/recipient-policy/v1/review");
-	if (review.continuity !== undefined) return { ...review, continuity: review.continuity };
+	const continuity = review.continuity ?? null;
+	if (review.categoryCounts) {
+		return {
+			...review,
+			continuity,
+			categoryCounts: {
+				actionableReview: review.reviewItems.length,
+				preservedContinuity: Math.max(0, review.categoryCounts.preservedContinuity),
+				blockedRepair: review.blockedItems.length,
+			},
+		};
+	}
+	const preservedContinuity = Math.max(
+		0,
+		(continuity?.findingCount ?? 0) - review.reviewItems.length,
+	);
 	return {
 		...review,
-		continuity:
-			review.reviewItems.length > 0
-				? { state: "legacy_access_preserved", findingCount: review.reviewItems.length }
-				: null,
+		continuity,
+		categoryCounts: {
+			actionableReview: review.reviewItems.length,
+			preservedContinuity,
+			blockedRepair: review.blockedItems.length,
+		},
 	};
 }
 

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -180,12 +180,23 @@ function reviewItem(
 function recipientReview(
 	overrides: Partial<RecipientPolicyReviewListV1> = {},
 ): RecipientPolicyReviewListV1 {
+	const reviewItems = overrides.reviewItems ?? [reviewItem()];
+	const blockedItems = overrides.blockedItems ?? [];
+	const continuity =
+		overrides.continuity === undefined
+			? { findingCount: 1 as const, state: "legacy_access_preserved" as const }
+			: overrides.continuity;
+	const categoryCounts = overrides.categoryCounts ?? {
+		actionableReview: reviewItems.length,
+		preservedContinuity: Math.max(0, (continuity?.findingCount ?? 0) - reviewItems.length),
+		blockedRepair: blockedItems.length,
+	};
 	return {
-		blockedItems: [],
-		continuity: { findingCount: 1, state: "legacy_access_preserved" },
-		reviewItems: [reviewItem()],
-		version: 1,
-		...overrides,
+		blockedItems,
+		categoryCounts,
+		continuity,
+		reviewItems,
+		version: overrides.version ?? 1,
 	};
 }
 
@@ -280,6 +291,11 @@ describe("Projects tab", () => {
 		});
 		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue({
 			blockedItems: [],
+			categoryCounts: {
+				actionableReview: 0,
+				preservedContinuity: 0,
+				blockedRepair: 0,
+			},
 			continuity: null,
 			reviewItems: [],
 			version: 1,
@@ -396,23 +412,31 @@ describe("Projects tab", () => {
 					version: 1,
 				},
 			],
+			categoryCounts: {
+				actionableReview: 1,
+				preservedContinuity: 36,
+				blockedRepair: 1,
+			},
 			continuity: { findingCount: 37, state: "legacy_access_preserved" },
 		});
 
 		await loadProjectsData();
 
 		const surface = document.querySelector(".recipient-policy-review");
-		expect(surface?.textContent).toContain("Sharing needs repair");
-		expect(surface?.textContent).not.toContain("Existing sharing kept as-is");
-		expect(surface?.textContent).not.toContain("No action is required for this update");
-		expect(surface?.textContent).toContain("37 older sharing findings were not changed");
-		expect(surface?.textContent).toContain("current availability cannot be confirmed");
-		expect(surface?.textContent).not.toContain("Current access remains in place");
-		expect(surface?.textContent).not.toContain("will continue using");
+		expect(surface?.textContent).toContain("Sharing review");
+		expect(surface?.textContent).toContain("Review decisions (1)");
+		expect(surface?.textContent).toContain("Preserved legacy continuity (36)");
+		expect(surface?.textContent).toContain("Blocked source repairs (1)");
+		expect(surface?.textContent).toContain("36 preserved legacy findings");
+		expect(surface?.textContent).toContain("These preserved findings require no action");
+		expect(surface?.textContent).toContain("Action is required");
 		expect(surface?.textContent).toContain("Assign a stable canonical Project identity");
 		expect(surface?.textContent).toContain("Owner: Project owner");
+		expect(surface?.querySelectorAll("button")).toHaveLength(1);
 		expect(surface?.querySelector("button")?.textContent).toBe("Repair Project identity…");
-		expect(document.querySelectorAll(".recipient-policy-review-item")).toHaveLength(0);
+		expect(document.querySelectorAll(".recipient-policy-review-item")).toHaveLength(1);
+		expect(document.querySelector(".recipient-policy-review-decisions button")).toBeNull();
+		expect(document.querySelector(".recipient-policy-review-continuity button")).toBeNull();
 	});
 
 	it("routes an unfinished server Team candidate into guided setup without resolving recipient review", async () => {
@@ -754,7 +778,7 @@ describe("Projects tab", () => {
 		);
 	});
 
-	it("preserves the continuity surface across an unchanged refresh", async () => {
+	it("preserves the review surface across an unchanged refresh", async () => {
 		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
 			has_more: false,
 			limit: 250,
@@ -766,15 +790,15 @@ describe("Projects tab", () => {
 
 		await loadProjectsData();
 		const firstSurface = document.querySelector(".recipient-policy-review");
-		expect(firstSurface?.textContent).toContain("Existing sharing kept as-is");
-		expect(firstSurface?.textContent).toContain("No action is required for this update");
+		expect(firstSurface?.textContent).toContain("Review decisions (1)");
+		expect(firstSurface?.textContent).toContain("Action is required");
 
 		await loadProjectsData();
 
 		expect(document.querySelector(".recipient-policy-review")).toBe(firstSurface);
 	});
 
-	it("rerenders the continuity surface when the deferred finding count changes", async () => {
+	it("rerenders the continuity surface when the preserved finding count changes", async () => {
 		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
 			has_more: false,
 			limit: 250,
@@ -783,10 +807,25 @@ describe("Projects tab", () => {
 			total: 0,
 		});
 		vi.mocked(api.loadRecipientPolicyReview)
-			.mockResolvedValueOnce(recipientReview())
 			.mockResolvedValueOnce(
 				recipientReview({
+					categoryCounts: {
+						actionableReview: 0,
+						preservedContinuity: 1,
+						blockedRepair: 0,
+					},
+					reviewItems: [],
+				}),
+			)
+			.mockResolvedValueOnce(
+				recipientReview({
+					categoryCounts: {
+						actionableReview: 0,
+						preservedContinuity: 2,
+						blockedRepair: 0,
+					},
 					continuity: { findingCount: 2, state: "legacy_access_preserved" },
+					reviewItems: [],
 				}),
 			);
 
@@ -796,7 +835,8 @@ describe("Projects tab", () => {
 		await loadProjectsData();
 
 		expect(document.querySelector(".recipient-policy-review")).not.toBe(firstSurface);
-		expect(document.body.textContent).toContain("2 older sharing findings were not changed");
+		expect(document.body.textContent).toContain("Preserved legacy continuity (2)");
+		expect(document.body.textContent).toContain("2 preserved legacy findings");
 	});
 
 	it("does not offer an unusable repair action for an unmapped Project", async () => {

--- a/packages/ui/src/tabs/recipient-policy-review.ts
+++ b/packages/ui/src/tabs/recipient-policy-review.ts
@@ -1,4 +1,8 @@
-import type { RecipientPolicyBlockedItemV1, RecipientPolicyReviewListV1 } from "../lib/api/sync";
+import type {
+	RecipientPolicyBlockedItemV1,
+	RecipientPolicyReviewItemV1,
+	RecipientPolicyReviewListV1,
+} from "../lib/api/sync";
 
 const renderedReviewSignatures = new WeakMap<HTMLElement, string>();
 
@@ -12,6 +16,74 @@ function paragraph(text: string, className = ""): HTMLParagraphElement {
 export interface RecipientPolicyReviewRenderOptions {
 	isRepairAvailable?: (repair: RecipientPolicyBlockedItemV1["repair"]) => boolean;
 	onRepair?: (repair: RecipientPolicyBlockedItemV1["repair"]) => Promise<void> | void;
+}
+
+function sectionHeading(label: string, count: number): HTMLHeadingElement {
+	const heading = document.createElement("h3");
+	heading.className = "recipient-policy-review-heading";
+	heading.textContent = `${label} (${count.toLocaleString()})`;
+	return heading;
+}
+
+function renderReviewItem(item: RecipientPolicyReviewItemV1): HTMLElement {
+	const card = document.createElement("article");
+	card.className = "project-inventory-row recipient-policy-review-item";
+	const finding = document.createElement("h4");
+	finding.className = "project-inventory-title";
+	finding.textContent = item.finding;
+	card.append(finding, paragraph(item.reason, "project-inventory-meta"));
+	return card;
+}
+
+function renderReviewDecisionSection(review: RecipientPolicyReviewListV1): HTMLElement {
+	const section = document.createElement("section");
+	section.className = "recipient-policy-review-section recipient-policy-review-decisions";
+	section.append(
+		sectionHeading("Review decisions", review.reviewItems.length),
+		paragraph(
+			"Access has not changed. Action is required. Next step: review these findings, then use the existing sharing controls below if you choose to change access.",
+			"section-meta",
+		),
+	);
+	const list = document.createElement("div");
+	list.className = "project-inventory-list recipient-policy-review-list";
+	for (const item of review.reviewItems) list.appendChild(renderReviewItem(item));
+	section.appendChild(list);
+	return section;
+}
+
+function renderContinuitySection(review: RecipientPolicyReviewListV1): HTMLElement {
+	const count = review.categoryCounts.preservedContinuity;
+	const section = document.createElement("section");
+	section.className = "recipient-policy-review-section recipient-policy-review-continuity";
+	const detail = paragraph(
+		`${count.toLocaleString()} preserved legacy finding${count === 1 ? "" : "s"}. Access has not changed. These preserved findings require no action. Next step: none for this category; Codemem will keep this legacy sharing state as-is.`,
+		"settings-note",
+	);
+	detail.setAttribute("role", "status");
+	detail.setAttribute("aria-live", "polite");
+	section.append(sectionHeading("Preserved legacy continuity", count), detail);
+	return section;
+}
+
+function renderBlockedSection(
+	review: RecipientPolicyReviewListV1,
+	options: RecipientPolicyReviewRenderOptions,
+): HTMLElement {
+	const section = document.createElement("section");
+	section.className = "recipient-policy-review-section recipient-policy-review-blocked";
+	section.append(
+		sectionHeading("Blocked source repairs", review.blockedItems.length),
+		paragraph(
+			"Access has not changed. Action is required before Codemem can safely interpret these records. Next step: repair each source record below.",
+			"section-meta project-attention-note",
+		),
+	);
+	const list = document.createElement("div");
+	list.className = "project-inventory-list recipient-policy-review-list";
+	for (const item of review.blockedItems) list.appendChild(renderBlockedItem(item, options));
+	section.appendChild(list);
+	return section;
 }
 
 function renderBlockedItem(
@@ -68,7 +140,12 @@ export function renderRecipientPolicyReview(
 	);
 	const signature = `review:${repairAvailability.join("")}:${JSON.stringify(review)}`;
 	if (renderedReviewSignatures.get(mount) === signature) return;
-	if (!review.continuity && review.blockedItems.length === 0) {
+	const { preservedContinuity } = review.categoryCounts;
+	if (
+		review.reviewItems.length === 0 &&
+		preservedContinuity === 0 &&
+		review.blockedItems.length === 0
+	) {
 		mount.replaceChildren();
 		mount.hidden = true;
 		renderedReviewSignatures.set(mount, signature);
@@ -81,42 +158,12 @@ export function renderRecipientPolicyReview(
 	surface.setAttribute("aria-labelledby", "recipientPolicyReviewTitle");
 	const title = document.createElement("h2");
 	title.id = "recipientPolicyReviewTitle";
-	title.textContent =
-		review.blockedItems.length > 0 ? "Sharing needs repair" : "Existing sharing kept as-is";
+	title.textContent = "Sharing review";
 	surface.appendChild(title);
 
-	if (review.continuity) {
-		const findingCount = review.continuity.findingCount;
-		const detail = paragraph(
-			`${findingCount.toLocaleString()} older sharing finding${findingCount === 1 ? " was" : "s were"} not changed because Codemem could not safely translate ${findingCount === 1 ? "it" : "them"} automatically.`,
-			"settings-note",
-		);
-		detail.setAttribute("role", "status");
-		detail.setAttribute("aria-live", "polite");
-		if (review.blockedItems.length === 0) {
-			surface.appendChild(
-				paragraph(
-					"No action is required for this update. Codemem did not change your existing Team or local sharing configuration.",
-					"section-meta",
-				),
-			);
-		}
-		surface.appendChild(detail);
-	}
-
-	if (review.blockedItems.length > 0) {
-		const intro = paragraph(
-			"Codemem did not change access for these items, but their current availability cannot be confirmed until these source-state problems are repaired.",
-			"section-meta project-attention-note",
-		);
-		const heading = document.createElement("h3");
-		heading.className = "recipient-policy-blocked-heading";
-		heading.textContent = "Needs repair";
-		const list = document.createElement("div");
-		list.className = "project-inventory-list recipient-policy-review-list";
-		for (const item of review.blockedItems) list.appendChild(renderBlockedItem(item, options));
-		surface.append(intro, heading, list);
-	}
+	if (review.reviewItems.length > 0) surface.appendChild(renderReviewDecisionSection(review));
+	if (preservedContinuity > 0) surface.appendChild(renderContinuitySection(review));
+	if (review.blockedItems.length > 0) surface.appendChild(renderBlockedSection(review, options));
 
 	mount.replaceChildren(surface);
 	renderedReviewSignatures.set(mount, signature);

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1224,7 +1224,8 @@
         margin-top: var(--sp-2);
       }
       .projects-pagination { margin-top: var(--sp-4); }
-      .recipient-policy-review > h3 { margin-top: var(--sp-4); }
+      .recipient-policy-review-section + .recipient-policy-review-section { margin-top: var(--sp-5); }
+      .recipient-policy-review-heading { margin-bottom: var(--sp-2); }
       .recipient-policy-review-status:empty { display: none; }
       .recipient-policy-review-list { margin-top: var(--sp-3); }
       .recipient-policy-review-item .project-inventory-actions label {
@@ -1240,7 +1241,6 @@
         margin-top: var(--sp-1);
         padding-left: var(--sp-5);
       }
-      .recipient-policy-blocked-heading { margin-top: var(--sp-5) !important; }
       .project-selection-actions,
       .recipient-policy-management-actions,
       .recipient-policy-sharing-actions {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -12850,6 +12850,12 @@ describe("viewer-server", () => {
 					"replication_scopes",
 					"project_scope_mappings",
 					"scope_memberships",
+					"policy_teams",
+					"policy_team_memberships",
+					"policy_team_device_decisions",
+					"project_recipients",
+					"recipient_policy_authority_states",
+					"recipient_policy_deny_overlays",
 					"memory_items",
 					"replication_ops",
 					"replication_cursors",
@@ -12870,6 +12876,11 @@ describe("viewer-server", () => {
 				).toBeUndefined();
 				const reviewResponse = await app.request("/api/sync/recipient-policy/v1/review");
 				const review = (await reviewResponse.json()) as {
+					categoryCounts: {
+						actionableReview: number;
+						preservedContinuity: number;
+						blockedRepair: number;
+					};
 					continuity: { findingCount: number; state: string } | null;
 					reviewItems: Array<{
 						reviewItemId: string;
@@ -12885,6 +12896,11 @@ describe("viewer-server", () => {
 				expect(review.continuity).toEqual({
 					findingCount: 1,
 					state: "legacy_access_preserved",
+				});
+				expect(review.categoryCounts).toEqual({
+					actionableReview: 1,
+					preservedContinuity: 0,
+					blockedRepair: 0,
 				});
 				expect(
 					store.db
@@ -13016,6 +13032,11 @@ describe("viewer-server", () => {
 				expect(completedReviewResponse.status).toBe(200);
 				expect(completedReview.continuity).toBeNull();
 				expect(completedReview).toHaveProperty("continuity");
+				expect(completedReview.categoryCounts).toEqual({
+					actionableReview: 0,
+					preservedContinuity: 0,
+					blockedRepair: 0,
+				});
 			} finally {
 				getStore()?.db.pragma("query_only = OFF");
 				cleanup();


### PR DESCRIPTION
## Description
Separate actionable sharing decisions, preserved legacy continuity, and blocked source repairs in the Projects UI. Add compatible category counts, normalize legacy payloads, scope no-action copy to continuity findings, and keep repair controls exclusive to blocked items.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced