### PR TITLE
fix: address bounded alpha review feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ OpenCode plugin and CLI are now split intentionally:
 - `codemem` — CLI and MCP commands
 - `@codemem/embeddings` — optional semantic embedding runtime installed by the CLI
 
+OpenCode treats configured npm plugins and checkout-local `.opencode/plugins/` files as separate
+sources. If both load Codemem for one Project, the first registration wins and later copies skip
+their hooks with a warning. Remove the configured npm entry when testing a source checkout so the
+checkout-local plugin loads first; otherwise your edits may appear to do nothing.
+
 ### Claude Code (marketplace install)
 
 1. Install codemem's Claude MCP config:
@@ -217,8 +222,8 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | | `codemem sync once` | Run one immediate sync pass |
 | | `codemem sync doctor` | Diagnose sync configuration issues |
 | | `codemem sync bootstrap` | Bootstrap sync from a peer snapshot |
-| **Updates** | `codemem update install` | Install an eligible stable release from npm |
-| | `codemem update check` | Check the npm registry for a newer stable release (`--json` and `--refresh` supported) |
+| **Updates** | `codemem update install` | Install an eligible release from the installed channel |
+| | `codemem update check` | Check npm for a newer release on the installed channel (`--json` and `--refresh` supported) |
 | **Coordinator** | `codemem coordinator` | Self-hosted coordinator admin (groups, devices, invites) |
 | **Database** | `codemem db prune-memories` | Deactivate low-signal memories (`--dry-run` to preview) |
 | | `codemem db prune-observations` | Deactivate low-signal observations |
@@ -239,18 +244,19 @@ for the stable machine-readable report. `codemem stats` remains the inventory an
 usage command; use `sync status`/`sync doctor`, `maintenance status`, and
 `db raw-events-status` for subsystem detail.
 
-`codemem update check` is read-only: it reports the latest validated stable release and
+`codemem update check` is read-only: it derives `alpha`, `beta`, `rc`, or `latest` from the
+installed version and reports the latest validated release on that same channel with
 installation-specific guidance. Results are cached for six hours;
-pass `--refresh` to force a registry request or `--json` for one stable status object.
+pass `--refresh` to force a registry request or `--json` for one channel-aware status object.
 The Viewer Health page reads the same status from `/api/update-status`. The OpenCode plugin
 checks it after startup and shows at most one best-effort notification for each newly discovered
-release. `notify` is the default. `codemem update install` performs the explicit, fail-closed
+same-channel release. `notify` is the default. `codemem update install` performs the explicit, fail-closed
 installation; bare `codemem update` remains non-mutating. Explicit plugin
 `auto` policy may run a paired, version-pinned public-registry install of `codemem` and
 `@codemem/embeddings` only
-after the CLI reports a fresh, validated npm release observed for at least 24 hours and an
-installation whose npm origin can be proven. Pinned, prerelease, downgrade,
-repository-development, stale, Docker, and unknown installs refuse execution. Set
+after the CLI reports a fresh, validated same-channel npm release observed for at least 24 hours
+and an installation whose npm origin can be proven. Pinned, cross-channel, unsupported-channel,
+downgrade, repository-development, stale, Docker, and unknown installs refuse execution. Set
 `CODEMEM_BACKEND_UPDATE_POLICY=off` to disable release checks.
 On Linux, plugin-owned auto-updates preserve the OpenCode environment and set
 `ONNXRUNTIME_NODE_INSTALL=skip` for the install to avoid the unused GPU-provider download.

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -338,7 +338,8 @@ Stream contract:
 - Raw-event batches accepted by the viewer are retried by the sweeper flush workers.
 - After Viewer delivery fails, OpenCode writes the exact normalized envelope to `~/.codemem/opencode-raw-event-spool` before invoking the direct CLI fallback. A successful fallback removes the entry; missing runtimes, locks, timeouts, version skew, and validation failures remain on disk and retry at bounded startup or session boundaries with the same event ID.
 - Viewer mismatch notices expose only a fixed category and next action: restart Viewer from the same workspace/config for `database`, restart Codemem and OpenCode with the same environment for `identity`, update Codemem on the installed channel and restart OpenCode for `contract`, or check/restart Viewer for `connection`. Payloads, target values, subprocess output, paths, and addresses are omitted.
-- Corrupt spool entries are retained for recovery. The spool accepts at most `CODEMEM_RAW_EVENT_SPOOL_MAX_ENTRIES` `.json` entries and rejects a new event when full without evicting existing entries; an existing event ID remains idempotent. If a private spool write fails or the spool is full, OpenCode warns that the event remains only in the bounded in-memory queue rather than claiming durable preservation. For a full spool, repair the CLI or Viewer mismatch and restart OpenCode so retained entries drain. If specific entries remain rejected, stop OpenCode and move `~/.codemem/opencode-raw-event-spool` to a backup location for manual recovery; do not delete it until the events are delivered or intentionally discarded.
+- Corrupt spool entries are retained for recovery. The spool accepts at most `CODEMEM_RAW_EVENT_SPOOL_MAX_ENTRIES` `.json` entries and rejects a new event when full without evicting existing entries; an existing event ID remains idempotent. If a private spool write fails or the spool is full, OpenCode warns that the event remains only in the bounded in-memory queue rather than claiming durable preservation. OpenCode drains retained entries through the installed CLI, so repair or update that CLI and restart OpenCode; restarting Viewer alone does not recover this spool. If specific entries remain rejected, stop OpenCode and move `~/.codemem/opencode-raw-event-spool` to a backup location for manual recovery; do not delete it until the events are delivered or intentionally discarded.
+- `CODEMEM_RAW_EVENTS=0` pauses capture and every OpenCode spool drain. Existing spool files remain untouched until raw events are enabled again.
 
 `GET /api/raw-events/status` also includes `transcript_diagnostics`, a per-Viewer-process, per-router-instance counter block scoped explicitly to `legacy_compatibility_routes`. It counts Claude and Codex compatibility-route transcript reads by the fixed outcomes `ok`, `not_provided`, `path_rejected`, `unreadable`, `no_complete_record`, and `no_assistant_record`. These counters are not persisted, do not include paths or transcript content, and do not describe the normal generated-adapter path through `POST /api/raw-events`. A skipped legacy `Stop` response keeps `skip_reason: "transcript_unavailable"` and may include one of the non-`ok` outcomes as `skip_detail`; other mapping skips remain `skip_reason: "unsupported_hook"`.
 
@@ -479,15 +480,16 @@ When the plugin detects CLI/runtime version mismatch, it shows guidance based on
 Update policy:
 
 - `CODEMEM_BACKEND_UPDATE_POLICY=notify` (default): show warning toast with suggested action
-- `CODEMEM_BACKEND_UPDATE_POLICY=auto`: try a best-effort auto-update for eligible compatibility-floor mismatches and fresh stable releases observed for at least 24 hours, then warn if still outdated
+- `CODEMEM_BACKEND_UPDATE_POLICY=auto`: try a best-effort auto-update for eligible compatibility-floor mismatches and fresh same-channel releases observed for at least 24 hours, then warn if still outdated
 	- skipped for `node` dev-mode runners
 	- skipped when `CODEMEM_RUNNER_FROM` is pinned to a fixed package/version
-	- skipped for Docker, unknown, stale, prerelease, or downgrade states
+	- skipped for Docker, unknown, stale, unsupported-channel, cross-channel, or downgrade states
 - `CODEMEM_BACKEND_UPDATE_POLICY=off`: no compatibility toast (logging still records mismatch)
 
 After its startup delay, the plugin also runs `codemem update check --json` through the same
-argv-based CLI runner. `notify` and `auto` show a best-effort toast at most once per latest stable
-release in the current OpenCode process; `off` skips this release check. Under explicit `auto`, an
+argv-based CLI runner. The CLI derives `alpha`, `beta`, `rc`, or `latest` from the installed version.
+`notify` and `auto` show a best-effort toast at most once per newly discovered release on that
+channel in the current OpenCode process; `off` skips this release check. Under explicit `auto`, an
 eligible result executes a paired, version-pinned public-registry install for `codemem` and
 `@codemem/embeddings`, then verifies the active CLI version before a plugin-owned Viewer is
 restarted. On Linux, both plugin-owned auto-update paths preserve the existing child environment

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,7 +2,8 @@
 
 ## Check for updates
 
-Use the read-only release check to compare the running CLI with the latest stable npm release:
+Use the read-only release check to compare the running CLI with the latest npm release on its
+installed channel. Stable versions use `latest`; prereleases use `alpha`, `beta`, or `rc`:
 
 ```fish
 codemem update check
@@ -11,16 +12,16 @@ codemem update check --json
 ```
 
 - Results are cached locally for six hours; `--refresh` bypasses a fresh cache.
-- `--json` prints one stable status object and uses a non-zero exit code when no validated fresh
+- `--json` prints one channel-aware status object and uses a non-zero exit code when no validated fresh
   or stale status is available.
 - Stale validated cache data remains clearly labeled and may provide guidance when the registry is
   unavailable.
 - This command never installs or executes an update. Release installation remains outside this
   read-only check. `codemem update install` is the separate, fail-closed installer: it refreshes
-  release status, requires a proven global npm installation and a stable release observed for at
+  release status, requires a proven global npm installation and a same-channel release observed for at
   least 24 hours, installs exact matching `codemem` and `@codemem/embeddings` versions from the
   public npm registry, and verifies the active `codemem` command. It refuses npx, Docker, pinned,
-  development, stale, prerelease, downgrade, and unknown installations. Bare `codemem update`
+  development, stale, cross-channel, downgrade, unsupported-channel, and unknown installations. Bare `codemem update`
   remains non-mutating. As with a
   manual npm install, npm runs the packages' installation scripts for native CPU dependencies.
 

--- a/packages/cli/.opencode/tests/plugin-transform-hook.test.js
+++ b/packages/cli/.opencode/tests/plugin-transform-hook.test.js
@@ -2580,6 +2580,47 @@ describe("OpenCode transform-time injection", () => {
 		expect(new Set(enqueueBytes).size).toBe(1);
 	});
 
+	test("preserves the retry spool across every drain trigger when raw events are disabled", async () => {
+		const home = mkdtempSync(join(tmpdir(), "codemem-opencode-disabled-spool-"));
+		tmpDirs.push(home);
+		process.env.HOME = home;
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		await writeRawEventSpoolEntry({
+			envelope: { event_id: "event-retained-disabled", event_type: "tool" },
+			homeDir: home,
+		});
+		const enqueueBytes = [];
+		spawnMock.mockImplementation((_command, args) => {
+			const proc = makeProcess({ exitCode: 0 });
+			if (Array.isArray(args) && args.includes("enqueue-raw-event")) {
+				proc.stdin.write = vi.fn((value) => enqueueBytes.push(String(value)));
+			}
+			return proc;
+		});
+
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+		await hooks["tool.execute.after"](
+			{ tool: "read", args: {}, sessionID: "sess-disabled-spool" },
+			{},
+		);
+		await hooks.event({
+			event: { type: "session.idle", properties: { sessionID: "sess-disabled-spool" } },
+		});
+
+		const spoolDirectory = join(home, ".codemem", "opencode-raw-event-spool");
+		expect(enqueueBytes).toEqual([]);
+		expect(readdirSync(spoolDirectory).filter((name) => name.endsWith(".json"))).toHaveLength(1);
+		expect(readFileSync(join(spoolDirectory, readdirSync(spoolDirectory)[0]), "utf8")).toContain(
+			"event-retained-disabled",
+		);
+	});
+
 	test("continues draining after a poisoned oldest spool entry", async () => {
 		const home = mkdtempSync(join(tmpdir(), "codemem-opencode-poisoned-spool-"));
 		tmpDirs.push(home);

--- a/packages/core/src/project-identity.test.ts
+++ b/packages/core/src/project-identity.test.ts
@@ -7,16 +7,22 @@ describe("project identity metadata", () => {
 		"error: failed to discover project",
 		"fatal: not a git repository",
 		"git: 'workspace-id' is not a git command",
+		"GitError: fatal: not a git repository",
+		"Git command failed: no such remote 'upstream'",
 		"valid-project\nfatal: leaked stderr",
 	])("rejects command failure output: %s", (value) => {
 		expect(isMalformedProjectIdentity(value)).toBe(true);
 		expect(cleanProjectIdentity(value)).toBeNull();
 	});
 
-	it.each(["fatal-error-handler", "/tmp/error: logs", "git:alpha", "project name"])(
-		"preserves valid identity text: %s",
-		(value) => {
-			expect(cleanProjectIdentity(` ${value} `)).toBe(value);
-		},
-	);
+	it.each([
+		"fatal-error-handler",
+		"/tmp/error: logs",
+		"git:alpha",
+		"project name",
+		"/work/not a git repository/demo",
+		"no such remote",
+	])("preserves valid identity text: %s", (value) => {
+		expect(cleanProjectIdentity(` ${value} `)).toBe(value);
+	});
 });

--- a/packages/core/src/project-identity.test.ts
+++ b/packages/core/src/project-identity.test.ts
@@ -8,6 +8,7 @@ describe("project identity metadata", () => {
 		"fatal: not a git repository",
 		"git: 'workspace-id' is not a git command",
 		"GitError: fatal: not a git repository",
+		"GitError: fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree",
 		"Git command failed: no such remote 'upstream'",
 		"valid-project\nfatal: leaked stderr",
 	])("rejects command failure output: %s", (value) => {
@@ -21,6 +22,7 @@ describe("project identity metadata", () => {
 		"git:alpha",
 		"project name",
 		"/work/not a git repository/demo",
+		"/work/unknown revision or path/demo",
 		"no such remote",
 	])("preserves valid identity text: %s", (value) => {
 		expect(cleanProjectIdentity(` ${value} `)).toBe(value);

--- a/packages/core/src/project-identity.ts
+++ b/packages/core/src/project-identity.ts
@@ -1,6 +1,6 @@
 const COMMAND_FAILURE_PREFIX = /^(?:command failed(?:\s|:)|error:\s|fatal:\s|git:\s)/iu;
 const WRAPPED_GIT_FAILURE =
-	/^(?:giterror|git error|git command failed):\s*(?:fatal:\s*)?(?:not a git repository|unknown revision or path|no such remote)\b/iu;
+	/^(?:giterror|git error|git command failed):[^\r\n]*(?:not a git repository|unknown revision or path|no such remote)\b/iu;
 
 /** Return true when a discovery failure was supplied where Project identity was expected. */
 export function isMalformedProjectIdentity(value: unknown): boolean {

--- a/packages/core/src/project-identity.ts
+++ b/packages/core/src/project-identity.ts
@@ -1,5 +1,6 @@
 const COMMAND_FAILURE_PREFIX = /^(?:command failed(?:\s|:)|error:\s|fatal:\s|git:\s)/iu;
-const GIT_FAILURE_TEXT = /\b(?:not a git repository|unknown revision or path|no such remote)\b/iu;
+const WRAPPED_GIT_FAILURE =
+	/^(?:giterror|git error|git command failed):\s*(?:fatal:\s*)?(?:not a git repository|unknown revision or path|no such remote)\b/iu;
 
 /** Return true when a discovery failure was supplied where Project identity was expected. */
 export function isMalformedProjectIdentity(value: unknown): boolean {
@@ -7,7 +8,7 @@ export function isMalformedProjectIdentity(value: unknown): boolean {
 	const cleaned = value.trim();
 	if (!cleaned) return false;
 	if (cleaned.includes("\n") || cleaned.includes("\r")) return true;
-	return COMMAND_FAILURE_PREFIX.test(cleaned) || GIT_FAILURE_TEXT.test(cleaned);
+	return COMMAND_FAILURE_PREFIX.test(cleaned) || WRAPPED_GIT_FAILURE.test(cleaned);
 }
 
 export function cleanProjectIdentity(value: string | null | undefined): string | null {

--- a/packages/core/src/scope-resolution.test.ts
+++ b/packages/core/src/scope-resolution.test.ts
@@ -69,6 +69,18 @@ describe("canonicalWorkspaceIdentity", () => {
 		expect(identity.value).toMatch(/^unmapped:[a-f0-9]{64}$/);
 	});
 
+	it("preserves the project-only unmapped hash", () => {
+		expect(canonicalWorkspaceIdentity({ project: "codemem" }).value).toBe(
+			"unmapped:34170381a2e99d876e3036c84ecdfcbbf0ef62cf9c89208236e7f8d528ed7720",
+		);
+	});
+
+	it("preserves the unknown hash for an empty identity", () => {
+		expect(canonicalWorkspaceIdentity({}).value).toBe(
+			"unmapped:b23a6a8439c0dde5515893e7c90c1e3233b8616e634470f20dc4928bcf3609bc",
+		);
+	});
+
 	it("keeps distinct malformed identity tuples in separate quarantines", () => {
 		const sharedFields = {
 			gitRemote: "fatal: not a git repository (or any of the parent directories): .git",

--- a/packages/core/src/scope-resolution.test.ts
+++ b/packages/core/src/scope-resolution.test.ts
@@ -68,6 +68,27 @@ describe("canonicalWorkspaceIdentity", () => {
 		expect(identity).toMatchObject({ displayProject: null, source: "unmapped" });
 		expect(identity.value).toMatch(/^unmapped:[a-f0-9]{64}$/);
 	});
+
+	it("keeps distinct malformed identity tuples in separate quarantines", () => {
+		const sharedFields = {
+			gitRemote: "fatal: not a git repository (or any of the parent directories): .git",
+			project: "error: failed to discover project",
+		};
+		const first = canonicalWorkspaceIdentity({
+			...sharedFields,
+			cwd: "Command failed: git rev-parse --show-toplevel",
+			workspaceId: "git: 'first-workspace' is not a git command",
+		});
+		const second = canonicalWorkspaceIdentity({
+			...sharedFields,
+			cwd: "Command failed: git rev-parse --show-prefix",
+			workspaceId: "git: 'second-workspace' is not a git command",
+		});
+
+		expect(first).toMatchObject({ source: "unmapped" });
+		expect(second).toMatchObject({ source: "unmapped" });
+		expect(first.value).not.toBe(second.value);
+	});
 });
 
 describe("resolveProjectScope", () => {

--- a/packages/core/src/scope-resolution.ts
+++ b/packages/core/src/scope-resolution.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import type { Database } from "better-sqlite3";
-import { cleanProjectIdentity } from "./project-identity.js";
+import { cleanProjectIdentity, isMalformedProjectIdentity } from "./project-identity.js";
 
 export const LOCAL_DEFAULT_SCOPE_ID = "local-default";
 
@@ -102,11 +102,20 @@ function normalizeMappingIdentity(value: string | null | undefined): string | nu
 }
 
 function unmappedIdentity(input: WorkspaceIdentityInput): string {
-	const seed = JSON.stringify(
-		[input.gitRemote, input.gitBranch, input.cwd, input.project, input.workspaceId].map((value) =>
-			typeof value === "string" ? value.trim() : null,
-		),
-	);
+	const validSeed = [input.cwd, input.project, input.workspaceId]
+		.map((value) => cleanProjectIdentity(value))
+		.find((value) => value !== null);
+	const identityTuple = [
+		input.gitRemote,
+		input.gitBranch,
+		input.cwd,
+		input.project,
+		input.workspaceId,
+	].map((value) => (typeof value === "string" ? value.trim() : null));
+	let seed = validSeed ?? "unknown";
+	if (!validSeed && identityTuple.some(isMalformedProjectIdentity)) {
+		seed = JSON.stringify(identityTuple);
+	}
 	const digest = createHash("sha256").update(seed, "utf8").digest("hex");
 	return `unmapped:${digest}`;
 }

--- a/packages/core/src/scope-resolution.ts
+++ b/packages/core/src/scope-resolution.ts
@@ -102,13 +102,11 @@ function normalizeMappingIdentity(value: string | null | undefined): string | nu
 }
 
 function unmappedIdentity(input: WorkspaceIdentityInput): string {
-	const validSeed = [input.cwd, input.project, input.workspaceId]
-		.map((value) => cleanProjectIdentity(value))
-		.find((value): value is string => value != null);
-	const rawSeed = [input.gitRemote, input.gitBranch, input.cwd, input.project, input.workspaceId]
-		.map((value) => (typeof value === "string" ? value.trim() : ""))
-		.find(Boolean);
-	const seed = validSeed ?? rawSeed ?? "unknown";
+	const seed = JSON.stringify(
+		[input.gitRemote, input.gitBranch, input.cwd, input.project, input.workspaceId].map((value) =>
+			typeof value === "string" ? value.trim() : null,
+		),
+	);
 	const digest = createHash("sha256").update(seed, "utf8").digest("hex");
 	return `unmapped:${digest}`;
 }

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -2193,6 +2193,9 @@ export const CodememPlugin = async ({
   };
 
   const drainRawEventSpool = () => {
+    if (!rawEventsEnabled) {
+      return Promise.resolve();
+    }
     const existingDrain = rawEventSpoolDrainsInFlight.get(rawEventSpoolDirectory);
     if (existingDrain) {
       return existingDrain;

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -424,12 +424,17 @@ describe("Projects tab", () => {
 
 		const surface = document.querySelector(".recipient-policy-review");
 		expect(surface?.textContent).toContain("Sharing review");
-		expect(surface?.textContent).toContain("Review decisions (1)");
+		expect(surface?.textContent).toContain("Review findings (1)");
 		expect(surface?.textContent).toContain("Preserved legacy continuity (36)");
 		expect(surface?.textContent).toContain("Blocked source repairs (1)");
 		expect(surface?.textContent).toContain("36 preserved legacy findings");
 		expect(surface?.textContent).toContain("These preserved findings require no action");
 		expect(surface?.textContent).toContain("Action is required");
+		const reviewCopy = surface?.querySelector(".recipient-policy-review-decisions")?.textContent;
+		expect(reviewCopy).toContain("These findings are informational");
+		expect(reviewCopy).toContain("this view has no decision controls");
+		expect(reviewCopy).toContain("those changes do not record a review decision");
+		expect(reviewCopy).not.toContain("Action is required");
 		expect(surface?.textContent).toContain("Assign a stable canonical Project identity");
 		expect(surface?.textContent).toContain("Owner: Project owner");
 		expect(surface?.querySelectorAll("button")).toHaveLength(1);
@@ -790,8 +795,9 @@ describe("Projects tab", () => {
 
 		await loadProjectsData();
 		const firstSurface = document.querySelector(".recipient-policy-review");
-		expect(firstSurface?.textContent).toContain("Review decisions (1)");
-		expect(firstSurface?.textContent).toContain("Action is required");
+		expect(firstSurface?.textContent).toContain("Review findings (1)");
+		expect(firstSurface?.textContent).toContain("These findings are informational");
+		expect(firstSurface?.textContent).not.toContain("Action is required");
 
 		await loadProjectsData();
 

--- a/packages/ui/src/tabs/recipient-policy-review.ts
+++ b/packages/ui/src/tabs/recipient-policy-review.ts
@@ -39,9 +39,9 @@ function renderReviewDecisionSection(review: RecipientPolicyReviewListV1): HTMLE
 	const section = document.createElement("section");
 	section.className = "recipient-policy-review-section recipient-policy-review-decisions";
 	section.append(
-		sectionHeading("Review decisions", review.reviewItems.length),
+		sectionHeading("Review findings", review.reviewItems.length),
 		paragraph(
-			"Access has not changed. Action is required. Next step: review these findings, then use the existing sharing controls below if you choose to change access.",
+			"Access has not changed. These findings are informational because this view has no decision controls. You may use the existing sharing controls below to change access, but those changes do not record a review decision.",
 			"section-meta",
 		),
 	);


### PR DESCRIPTION
## Description
One bounded follow-up to #1629–#1635; no downstack rewrites.

- Pause spool draining when raw events are disabled, retaining saved envelopes.
- Distinguish malformed identity tuples and preserve legitimate names containing Git error phrases.
- Correct same-channel update and CLI-only spool recovery docs; explain duplicate-plugin precedence.
- Present review findings as informational rather than requiring unavailable decisions. Actual blocked repair controls are unchanged.

Deferred by agreement: per-channel cache history (codemem-po0z), Viewer spool retry (codemem-zr2w), and full review decision controls (codemem-i331). The last two receive truthful current-limit documentation/copy, not new workflows. Live Projects records and sharing mappings are untouched.

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Documentation-only
- [ ] Maintenance
- [ ] Testing-only

## Testing
- [x] Targeted regressions: 95 core/UI tests and 84 plugin tests passed
- [x] pnpm run tsc
- [x] Targeted Biome check and git diff --check
- [ ] Full workspace suite rerun for this follow-up
- [ ] Manual browser verification

Plugin tests use the dedicated CLI .opencode Vitest config; initial incorrect harness attempts failed before tests ran. Two existing function-length warnings remain.

## Checklist
- [x] Self-review completed
- [x] One independent scoped review approved
- [x] Documentation updated
- [ ] No warnings introduced: the existing Projects test-suite length warning grows with regression assertions

Tracking: codemem-2ccx. Stop after this bounded patch unless a concrete correctness or data-handling defect appears.