### PR TITLE
fix(core): stop vec0 full scans starving the viewer under write lock

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -692,6 +692,12 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	if (invocation.dbPath) process.env.CODEMEM_DB = invocation.dbPath;
 	if (invocation.configPath) process.env.CODEMEM_CONFIG = invocation.configPath;
 	warnIfViewerExposed(invocation.host, invocation.port);
+	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
+	if (!(await terminateTrustedMaintenanceWorker(dbPath, { gracefulMs: 1000, forceMs: 5000 }))) {
+		p.log.warn(
+			"Existing maintenance worker is not trusted or did not stop; starting viewer anyway",
+		);
+	}
 	const preparedDb = prepareViewerDatabase(invocation.dbPath);
 
 	const observer = new ObserverClient();
@@ -725,12 +731,6 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		: readCodememConfigFile();
 	const syncConfig = readCoordinatorSyncConfig(config);
 	const syncEnabled = syncConfig.syncEnabled;
-	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
-	if (!(await terminateTrustedMaintenanceWorker(dbPath, { gracefulMs: 1000, forceMs: 5000 }))) {
-		p.log.warn(
-			"Existing maintenance worker is not trusted or did not stop; starting viewer anyway",
-		);
-	}
 	const syncRuntimeStatus: {
 		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
 		detail: string | null;

--- a/packages/cli/src/maintenance-worker-runtime.test.ts
+++ b/packages/cli/src/maintenance-worker-runtime.test.ts
@@ -68,7 +68,7 @@ describe("maintenance worker runtime", () => {
 		);
 	});
 
-	it("constructs vector migration with the smaller worker-specific batch size", async () => {
+	it("constructs vector migration with bounded batches and the default idle cadence", async () => {
 		// Arrange
 		vi.stubEnv("CODEMEM_EMBEDDING_DISABLED", "0");
 		let vectorRunner: VectorModelMigrationRunner | null = null;
@@ -90,6 +90,9 @@ describe("maintenance worker runtime", () => {
 		// Assert
 		const configuredBatchSize = (vectorRunner as unknown as { batchSize: number } | null)
 			?.batchSize;
+		const configuredIdleInterval = (vectorRunner as unknown as { idleIntervalMs: number } | null)
+			?.idleIntervalMs;
 		expect(configuredBatchSize).toBe(10);
+		expect(configuredIdleInterval).toBeGreaterThanOrEqual(60_000);
 	});
 });

--- a/packages/cli/src/maintenance-worker-runtime.ts
+++ b/packages/cli/src/maintenance-worker-runtime.ts
@@ -186,9 +186,12 @@ export function startMaintenanceWorkerRuntime(
 				dbPath,
 				signal: options.signal,
 				// This worker cannot receive the viewer process's in-memory wake signal,
-				// so retain the short poll while bounding each pass with a smaller batch.
+				// so work queued just after an idle tick waits up to one idle interval
+				// before being noticed. Once a tick sees running/pending work it stays on
+				// the normal interval; only genuinely idle polling slows. This trades
+				// bounded latency for not hammering a quiet DB every 5 seconds.
 				batchSize: 10,
-				idleIntervalMs: 5000,
+				idleIntervalMs: 60_000,
 			}),
 		);
 	}

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -681,6 +681,90 @@ describe("createSerializedDaemonTickRunner", () => {
 		expect(run()).toBe(true);
 		expect(tick).toHaveBeenCalledTimes(2);
 	});
+
+	it("consumes a rejected tick and permits the next scheduled tick", async () => {
+		const failure = new Error("database connection failed before tick setup");
+		const tick = vi.fn().mockRejectedValueOnce(failure).mockResolvedValue(undefined);
+		const firstCompleted = vi.fn();
+		const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		const run = createSerializedDaemonTickRunner(tick, firstCompleted);
+
+		try {
+			expect(run()).toBe(true);
+			await vi.waitFor(() => expect(firstCompleted).toHaveBeenCalledOnce());
+			await vi.waitFor(() =>
+				expect(errorLog).toHaveBeenCalledWith(
+					"[codemem] scheduled sync daemon tick failed:",
+					failure,
+				),
+			);
+
+			expect(run()).toBe(true);
+			await vi.waitFor(() => expect(tick).toHaveBeenCalledTimes(2));
+		} finally {
+			errorLog.mockRestore();
+		}
+	});
+
+	it("contains a locked diagnostic write and recovers on a later tick", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "codemem-sync-daemon-locked-diagnostic-"));
+		const dbPath = join(tempDir, "mem.sqlite");
+		const keysDir = join(tempDir, "keys");
+		const setupDb = new Database(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		const lockDb = new Database(dbPath);
+		const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		const unhandledRejections: unknown[] = [];
+		const onUnhandledRejection = (error: unknown) => unhandledRejections.push(error);
+		process.on("unhandledRejection", onUnhandledRejection);
+		let lockOnCallback = true;
+		const firstCompleted = vi.fn();
+		const tick = vi.fn(() =>
+			runTickOnce(dbPath, keysDir, undefined, ({ db }) => {
+				if (!lockOnCallback) return;
+				lockOnCallback = false;
+				db.pragma("busy_timeout = 1");
+				lockDb.exec("BEGIN EXCLUSIVE");
+				throw new Error("maintenance callback failed while database is locked");
+			}),
+		);
+		const run = createSerializedDaemonTickRunner(tick, firstCompleted);
+
+		try {
+			expect(run()).toBe(true);
+			await vi.waitFor(() => expect(firstCompleted).toHaveBeenCalledOnce());
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(unhandledRejections).toEqual([]);
+			expect(errorLog).toHaveBeenCalledWith(
+				expect.stringContaining("could not persist its diagnostic"),
+				expect.any(Error),
+				expect.objectContaining({ code: "SQLITE_BUSY" }),
+			);
+
+			lockDb.exec("ROLLBACK");
+			expect(run()).toBe(true);
+			await vi.waitFor(() => expect(tick).toHaveBeenCalledTimes(2));
+			await vi.waitFor(() => {
+				const verified = new Database(dbPath);
+				try {
+					const lastOkAt = verified
+						.prepare("SELECT last_ok_at FROM sync_daemon_state WHERE id = 1")
+						.pluck()
+						.get();
+					expect(lastOkAt).toBeTruthy();
+				} finally {
+					verified.close();
+				}
+			});
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+			if (lockDb.inTransaction) lockDb.exec("ROLLBACK");
+			lockDb.close();
+			errorLog.mockRestore();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -127,6 +127,42 @@ export function setSyncDaemonError(db: Database, error: string, traceback?: stri
 		.run();
 }
 
+function logSyncDaemonFailure(details: {
+	message: string;
+	error: unknown;
+	reportingError?: unknown;
+}): void {
+	try {
+		if (details.reportingError === undefined) {
+			console.error(details.message, details.error);
+			return;
+		}
+		console.error(details.message, details.error, details.reportingError);
+	} catch {
+		// Diagnostics must never replace or rethrow the daemon failure being contained.
+	}
+}
+
+function reportSyncDaemonError(
+	db: Database,
+	error: unknown,
+	options?: { prefix?: string; phase?: Exclude<SyncDaemonPhase, null> },
+): void {
+	const message = error instanceof Error ? error.message : String(error);
+	const stack = error instanceof Error ? (error.stack ?? "") : "";
+	const reportedMessage = options?.prefix ? `${options.prefix}: ${message}` : message;
+	try {
+		setSyncDaemonError(db, reportedMessage, stack);
+		if (options?.phase) setSyncDaemonPhase(db, options.phase);
+	} catch (reportingError) {
+		logSyncDaemonFailure({
+			message: `[codemem] sync daemon failed and could not persist its diagnostic: ${reportedMessage}`,
+			error,
+			reportingError,
+		});
+	}
+}
+
 /** Valid sync daemon phases for the rebootstrap safety gate. */
 export type SyncDaemonPhase = "identity_error" | "needs_attention" | null;
 
@@ -359,13 +395,20 @@ export function createSerializedDaemonTickRunner(
 	return () => {
 		if (tickRunning) return false;
 		tickRunning = true;
-		void runTick().finally(() => {
-			tickRunning = false;
-			if (!firstTickCompleted) {
-				firstTickCompleted = true;
-				onFirstCompleted?.();
-			}
-		});
+		void runTick()
+			.finally(() => {
+				tickRunning = false;
+				if (!firstTickCompleted) {
+					firstTickCompleted = true;
+					onFirstCompleted?.();
+				}
+			})
+			.catch((error) => {
+				logSyncDaemonFailure({
+					message: "[codemem] scheduled sync daemon tick failed:",
+					error,
+				});
+			});
 		return true;
 	};
 }
@@ -399,9 +442,7 @@ export async function runTickOnce(
 			await onAfterCoordinatorRefresh?.({ db, dbPath, keysDir: resolvedKeysDir });
 		} catch (error) {
 			callbackFailed = true;
-			const message = error instanceof Error ? error.message : String(error);
-			const stack = error instanceof Error ? (error.stack ?? "") : "";
-			setSyncDaemonError(db, `daemon tick callback failed: ${message}`, stack);
+			reportSyncDaemonError(db, error, { prefix: "daemon tick callback failed" });
 		}
 		// Best-effort: skip peers the coordinator reports as offline.
 		// Returns empty set when coordinator is disabled or lookup fails.
@@ -416,13 +457,10 @@ export async function runTickOnce(
 			// Clear any prior needs_attention phase — all peers are healthy.
 			setSyncDaemonOk(db);
 		}
-	} catch (err: unknown) {
-		const message = err instanceof Error ? err.message : String(err);
-		const stack = err instanceof Error ? (err.stack ?? "") : "";
-		setSyncDaemonError(db, message, stack);
-		if (err instanceof DeviceIdentityError) {
-			setSyncDaemonPhase(db, "identity_error");
-		}
+	} catch (error: unknown) {
+		reportSyncDaemonError(db, error, {
+			phase: error instanceof DeviceIdentityError ? "identity_error" : undefined,
+		});
 	} finally {
 		db.close();
 	}

--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -1790,6 +1790,46 @@ describe("vector migration", () => {
 		});
 	});
 
+	it("persists exhaustion for pre-flag completed jobs after one clean compatibility scan", async () => {
+		// Simulate a database upgraded from a build that predates
+		// stale_scan_exhausted: the job is completed with only target vectors and
+		// no watermark. The first tick must scan once and persist; the second
+		// must not touch memory_vectors at all.
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "One", "Body one");
+		seedVector(db, 1, "test-model");
+		startMaintenanceJob(db, {
+			kind: VECTOR_MODEL_MIGRATION_JOB,
+			title: "Re-indexing memories",
+			metadata: { target_model: "test-model", cleanup_pending: false },
+		});
+		completeMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)?.metadata).not.toHaveProperty(
+			"stale_scan_exhausted",
+		);
+
+		const countVectorStatements = async (): Promise<number> => {
+			let count = 0;
+			const spy = vi.spyOn(db, "prepare").mockImplementation((sql: string) => {
+				if (sql.includes("FROM memory_vectors WHERE")) count++;
+				return Database.prototype.prepare.call(db, sql);
+			});
+			try {
+				await runVectorMigrationPass(db, { batchSize: 10 });
+			} finally {
+				spy.mockRestore();
+			}
+			return count;
+		};
+
+		expect(await countVectorStatements()).toBeGreaterThan(0);
+		const persisted = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)?.metadata;
+		expect(persisted).toMatchObject({ stale_scan_exhausted: true });
+		expect(typeof persisted?.stale_scan_exhausted_max_rowid).toBe("number");
+
+		expect(await countVectorStatements()).toBe(0);
+	});
+
 	it("short-circuits exhausted completed cleanup without reading memory_vectors", async () => {
 		startMaintenanceJob(db, {
 			kind: VECTOR_MODEL_MIGRATION_JOB,

--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -1262,7 +1262,7 @@ describe("vector migration", () => {
 		let coverageScanPreparations = 0;
 		const prepareSpy = vi.spyOn(db, "prepare");
 		prepareSpy.mockImplementation((sql: string) => {
-			if (sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")) {
+			if (sql.includes("vector-stale-scan-rowids")) {
 				staleBatchSelections++;
 			}
 			if (
@@ -1304,7 +1304,7 @@ describe("vector migration", () => {
 		const prepareSpy = vi.spyOn(db, "prepare");
 		prepareSpy.mockImplementation((sql: string) => {
 			const statement = Database.prototype.prepare.call(db, sql);
-			if (sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")) {
+			if (sql.includes("vector-stale-scan-rowids")) {
 				const all = statement.all.bind(statement);
 				statement.all = ((...params: unknown[]) => {
 					const rows = all(...params);
@@ -1348,7 +1348,7 @@ describe("vector migration", () => {
 		const prepareSpy = vi.spyOn(db, "prepare");
 		prepareSpy.mockImplementation((sql: string) => {
 			const statement = Database.prototype.prepare.call(db, sql);
-			if (sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")) {
+			if (sql.includes("vector-stale-scan-rowids")) {
 				staleBatchSelections++;
 				if (staleBatchSelections === 1) {
 					setImmediate(() => {
@@ -1384,10 +1384,7 @@ describe("vector migration", () => {
 		const prepareSpy = vi.spyOn(db, "prepare");
 		prepareSpy.mockImplementation((sql: string) => {
 			const statement = Database.prototype.prepare.call(db, sql);
-			if (
-				!scheduledMutation &&
-				sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")
-			) {
+			if (!scheduledMutation && sql.includes("vector-stale-scan-rowids")) {
 				const all = statement.all.bind(statement);
 				statement.all = ((...params: unknown[]) => {
 					const rows = all(...params);
@@ -1436,7 +1433,7 @@ describe("vector migration", () => {
 			const prepareSpy = vi.spyOn(firstDb, "prepare");
 			prepareSpy.mockImplementation((sql: string) => {
 				const statement = Database.prototype.prepare.call(firstDb, sql);
-				if (sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")) {
+				if (sql.includes("vector-stale-scan-rowids")) {
 					staleBatchSelections++;
 					if (staleBatchSelections === 1) {
 						setImmediate(() => {
@@ -1528,7 +1525,7 @@ describe("vector migration", () => {
 			const prepareSpy = vi.spyOn(fileDb, "prepare");
 			prepareSpy.mockImplementation((sql: string) => {
 				const statement = Database.prototype.prepare.call(fileDb, sql);
-				if (sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")) {
+				if (sql.includes("vector-stale-scan-rowids")) {
 					const all = statement.all.bind(statement);
 					statement.all = ((...params: unknown[]) => {
 						const rows = all(...params);
@@ -1607,7 +1604,7 @@ describe("vector migration", () => {
 			const prepareSpy = vi.spyOn(fileDb, "prepare");
 			prepareSpy.mockImplementation((sql: string) => {
 				const statement = Database.prototype.prepare.call(fileDb, sql);
-				if (sql.startsWith("SELECT rowid FROM memory_vectors WHERE model != ?")) {
+				if (sql.includes("vector-stale-scan-rowids")) {
 					const all = statement.all.bind(statement);
 					statement.all = ((...params: unknown[]) => {
 						const rows = all(...params);
@@ -1681,7 +1678,7 @@ describe("vector migration", () => {
 		const prepareSpy = vi.spyOn(db, "prepare");
 		prepareSpy.mockImplementation((sql: string) => {
 			const statement = Database.prototype.prepare.call(db, sql);
-			if (sql.includes("SELECT mv.rowid AS rowid")) {
+			if (sql.includes("vector-target-prune-rowids")) {
 				const all = statement.all.bind(statement);
 				statement.all = ((...params: unknown[]) => {
 					const rows = all(...params);
@@ -1793,6 +1790,33 @@ describe("vector migration", () => {
 		});
 	});
 
+	it("short-circuits exhausted completed cleanup without reading memory_vectors", async () => {
+		startMaintenanceJob(db, {
+			kind: VECTOR_MODEL_MIGRATION_JOB,
+			title: "Re-indexing memories",
+			metadata: {
+				target_model: "test-model",
+				cleanup_pending: false,
+				stale_scan_exhausted: true,
+				stale_scan_exhausted_max_rowid: 0,
+			},
+		});
+		completeMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		const vectorStatements: string[] = [];
+		const prepareSpy = vi.spyOn(db, "prepare");
+		prepareSpy.mockImplementation((sql: string) => {
+			if (sql.includes("FROM memory_vectors WHERE")) vectorStatements.push(sql);
+			return Database.prototype.prepare.call(db, sql);
+		});
+
+		try {
+			await runVectorMigrationPass(db, { batchSize: 10 });
+		} finally {
+			prepareSpy.mockRestore();
+		}
+		expect(vectorStatements).toEqual([]);
+	});
+
 	it("removes stale old-model rows when queued work has zero embeddable memories", async () => {
 		const sessionId = insertTestSession(db);
 		seedMemory(db, 1, sessionId, "", "");
@@ -1814,6 +1838,57 @@ describe("vector migration", () => {
 			.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
 			.all() as Array<{ model: string; c: number }>;
 		expect(models).toEqual([]);
+	});
+
+	it("watermarks the zero-embeddable cleanup at the last scanned rowid, not MAX(rowid)", async () => {
+		// A legacy row written by a concurrent process AFTER the stale scan ends
+		// but BEFORE metadata is persisted must land above the watermark so the
+		// next pass re-examines it. Reading MAX(rowid) post-hoc would hide it.
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "", "");
+		seedVector(db, 1, "old-model");
+		const originalPrepare = db.prepare.bind(db);
+		let injected = false;
+		const prepareSpy = vi.spyOn(db, "prepare").mockImplementation((sql: string) => {
+			const stmt = originalPrepare(sql);
+			// The delete transaction is the last thing deleteStaleModelVectors does
+			// before returning; inject a fresh legacy row right after it fires.
+			if (!injected && sql === "DELETE FROM memory_vectors WHERE rowid = ?") {
+				const run = stmt.run.bind(stmt);
+				stmt.run = ((...args: unknown[]) => {
+					const result = run(...args);
+					if (!injected) {
+						injected = true;
+						seedVector(db, 2, "old-model");
+					}
+					return result;
+				}) as typeof stmt.run;
+			}
+			return stmt;
+		});
+
+		try {
+			await runVectorMigrationPass(db, { batchSize: 10 });
+		} finally {
+			prepareSpy.mockRestore();
+		}
+		expect(injected).toBe(true);
+
+		const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		const watermark = Number(job?.metadata?.stale_scan_exhausted_max_rowid ?? Number.NaN);
+		const survivingLegacyRowId = db
+			.prepare("SELECT rowid FROM memory_vectors WHERE model = 'old-model'")
+			.pluck()
+			.get() as number | undefined;
+		expect(survivingLegacyRowId).toBeDefined();
+		// The injected row must sit strictly above the persisted watermark.
+		expect(watermark).toBeLessThan(survivingLegacyRowId as number);
+
+		// And the next pass must actually find and remove it.
+		await runVectorMigrationPass(db, { batchSize: 10 });
+		expect(
+			db.prepare("SELECT COUNT(*) FROM memory_vectors WHERE model = 'old-model'").pluck().get(),
+		).toBe(0);
 	});
 
 	it("backfills memories that have no vectors at all (no source model)", async () => {

--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -9,6 +9,7 @@ import {
 	completeMaintenanceJob,
 	getMaintenanceJob,
 	startMaintenanceJob,
+	updateMaintenanceJob,
 } from "./maintenance-jobs.js";
 import { applyBootstrapSnapshot } from "./sync-bootstrap.js";
 import { setSyncResetState } from "./sync-replication.js";
@@ -17,6 +18,7 @@ import {
 	queueVectorBackfillForIncrementalSync,
 	runVectorMigrationPass,
 	VECTOR_MODEL_MIGRATION_JOB,
+	VectorModelMigrationRunner,
 } from "./vector-migration.js";
 import { resolveSemanticSearchModel } from "./vectors.js";
 
@@ -1828,6 +1830,30 @@ describe("vector migration", () => {
 		expect(typeof persisted?.stale_scan_exhausted_max_rowid).toBe("number");
 
 		expect(await countVectorStatements()).toBe(0);
+	});
+
+	it("keeps completed jobs with cleanup_pending on the active cadence", () => {
+		// computeIdle decides whether the runner backs off to idleIntervalMs.
+		// A completed job that still owes cleanup (bounded stale batch not
+		// exhausted, or a deferred pass) is known work and must not wait a full
+		// idle interval between attempts.
+		const runner = new VectorModelMigrationRunner({ dbPath: ":memory:" });
+		const computeIdle = (
+			runner as unknown as { computeIdle: (db: Database.Database) => boolean }
+		).computeIdle.bind(runner);
+
+		startMaintenanceJob(db, {
+			kind: VECTOR_MODEL_MIGRATION_JOB,
+			title: "Re-indexing memories",
+			metadata: { target_model: "test-model", cleanup_pending: true },
+		});
+		completeMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(computeIdle(db)).toBe(false);
+
+		updateMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
+			metadata: { target_model: "test-model", cleanup_pending: false },
+		});
+		expect(computeIdle(db)).toBe(true);
 	});
 
 	it("short-circuits exhausted completed cleanup without reading memory_vectors", async () => {

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -1542,6 +1542,10 @@ export class VectorModelMigrationRunner {
 				metadataMemoryIds(meta.pending_upsert_memory_ids).length +
 				metadataMemoryIds(meta.pending_delete_memory_ids).length;
 			if (queued > 0) return false;
+			// A completed job with cleanup still owed (bounded stale batch not yet
+			// exhausted, or a deferred cleanup pass) is known work, not a quiet
+			// database. Keep it on the active cadence so it finishes promptly.
+			if (meta.cleanup_pending) return false;
 			return true;
 		}
 		// No job row yet. Peek coverage directly to tell whether the first

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -417,15 +417,22 @@ function vectorModels(db: SqliteDatabase): Array<{ model: string; rows: number }
 		.all() as Array<{ model: string; rows: number }>;
 }
 
-function hasSourceModelVectorsAfter(
+type SourceModelScanResult = {
+	found: boolean;
+	/** Last rowid the scan examined, or null when the legacy full-scan path ran. */
+	scannedMaxRowId: number | null;
+};
+
+function scanForSourceModelVectorsAfter(
 	db: SqliteDatabase,
 	targetModel: string,
 	afterRowId: number,
-): boolean {
+): SourceModelScanResult {
 	if (!hasMemoryVectorRowidsShadowTable(db)) {
-		return Boolean(
+		const found = Boolean(
 			db.prepare("SELECT 1 FROM memory_vectors WHERE model != ? LIMIT 1").pluck().get(targetModel),
 		);
+		return { found, scannedMaxRowId: null };
 	}
 	const selectRowIds = db.prepare(
 		"SELECT rowid FROM memory_vectors_rowids WHERE rowid > ? ORDER BY rowid ASC LIMIT ? /* vector-source-scan-rowids */",
@@ -436,13 +443,23 @@ function hasSourceModelVectorsAfter(
 	let cursor = afterRowId;
 	while (true) {
 		const rows = selectRowIds.all(cursor, 250) as Array<{ rowid: number }>;
-		if (rows.length === 0) return false;
+		if (rows.length === 0) return { found: false, scannedMaxRowId: cursor };
 		for (const row of rows) {
 			const metadata = selectMetadata.get(row.rowid) as { model: string } | undefined;
-			if (metadata && metadata.model !== targetModel) return true;
+			if (metadata && metadata.model !== targetModel) {
+				return { found: true, scannedMaxRowId: null };
+			}
 		}
 		cursor = rows.at(-1)?.rowid ?? cursor;
 	}
+}
+
+function hasSourceModelVectorsAfter(
+	db: SqliteDatabase,
+	targetModel: string,
+	afterRowId: number,
+): boolean {
+	return scanForSourceModelVectorsAfter(db, targetModel, afterRowId).found;
 }
 
 function hasSourceModelVectors(db: SqliteDatabase, targetModel: string): boolean {
@@ -469,7 +486,19 @@ function checkCompletedStaleScan(
 ): { canReturn: boolean; metadata: MigrationMetadata } {
 	if (metadata.cleanup_pending) return { canReturn: false, metadata };
 	if (!metadata.stale_scan_exhausted) {
-		return { canReturn: !hasSourceModelVectors(db, targetModel), metadata };
+		// Jobs completed before the flag existed have no watermark. One clean
+		// compatibility scan is unavoidable, but persist its result so upgraded
+		// databases don't repeat it on every idle tick.
+		const scan = scanForSourceModelVectorsAfter(db, targetModel, 0);
+		if (scan.found) return { canReturn: false, metadata };
+		if (scan.scannedMaxRowId == null) return { canReturn: true, metadata };
+		const persisted = {
+			...metadata,
+			stale_scan_exhausted: true,
+			stale_scan_exhausted_max_rowid: scan.scannedMaxRowId,
+		};
+		updateMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, { metadata: persisted });
+		return { canReturn: true, metadata: persisted };
 	}
 	const exhaustedMaxRowId = metadata.stale_scan_exhausted_max_rowid;
 	const currentMaxRowId = readMaxMemoryVectorRowId(db);

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -20,6 +20,7 @@ import {
 	countIncompleteActiveMemoryVectorCoverage,
 	findMemoryIdsWithCompleteActiveVectorCoverage,
 	pruneObsoleteTargetModelVectors,
+	pruneObsoleteTargetModelVectorsWithCoverage,
 	pruneStaleCurrentModelVectors,
 } from "./vectors.js";
 
@@ -59,6 +60,8 @@ type MigrationMetadata = {
 	removed_stale_rows?: number;
 	uncovered_target_memories?: number;
 	cleanup_pending?: boolean;
+	stale_scan_exhausted?: boolean;
+	stale_scan_exhausted_max_rowid?: number;
 	reconciliation_target_coverage_complete?: boolean;
 	cutover_retry_count?: number;
 	trigger?: string | null;
@@ -414,10 +417,85 @@ function vectorModels(db: SqliteDatabase): Array<{ model: string; rows: number }
 		.all() as Array<{ model: string; rows: number }>;
 }
 
-function hasSourceModelVectors(db: SqliteDatabase, targetModel: string): boolean {
-	return Boolean(
-		db.prepare("SELECT 1 FROM memory_vectors WHERE model != ? LIMIT 1").pluck().get(targetModel),
+function hasSourceModelVectorsAfter(
+	db: SqliteDatabase,
+	targetModel: string,
+	afterRowId: number,
+): boolean {
+	if (!hasMemoryVectorRowidsShadowTable(db)) {
+		return Boolean(
+			db.prepare("SELECT 1 FROM memory_vectors WHERE model != ? LIMIT 1").pluck().get(targetModel),
+		);
+	}
+	const selectRowIds = db.prepare(
+		"SELECT rowid FROM memory_vectors_rowids WHERE rowid > ? ORDER BY rowid ASC LIMIT ? /* vector-source-scan-rowids */",
 	);
+	const selectMetadata = db.prepare(
+		"SELECT memory_id, content_hash, model FROM memory_vectors WHERE rowid = ?",
+	);
+	let cursor = afterRowId;
+	while (true) {
+		const rows = selectRowIds.all(cursor, 250) as Array<{ rowid: number }>;
+		if (rows.length === 0) return false;
+		for (const row of rows) {
+			const metadata = selectMetadata.get(row.rowid) as { model: string } | undefined;
+			if (metadata && metadata.model !== targetModel) return true;
+		}
+		cursor = rows.at(-1)?.rowid ?? cursor;
+	}
+}
+
+function hasSourceModelVectors(db: SqliteDatabase, targetModel: string): boolean {
+	return hasSourceModelVectorsAfter(db, targetModel, 0);
+}
+
+function hasMemoryVectorRowidsShadowTable(db: SqliteDatabase): boolean {
+	const tables = db.prepare("PRAGMA table_list").all() as Array<{ name: string }>;
+	return tables.some((table) => table.name === "memory_vectors_rowids");
+}
+
+function readMaxMemoryVectorRowId(db: SqliteDatabase): number | null {
+	if (!hasMemoryVectorRowidsShadowTable(db)) return null;
+	const row = db.prepare("SELECT MAX(rowid) AS max_rowid FROM memory_vectors_rowids").get() as
+		| { max_rowid: number | null }
+		| undefined;
+	return Number(row?.max_rowid ?? 0);
+}
+
+function checkCompletedStaleScan(
+	db: SqliteDatabase,
+	targetModel: string,
+	metadata: MigrationMetadata,
+): { canReturn: boolean; metadata: MigrationMetadata } {
+	if (metadata.cleanup_pending) return { canReturn: false, metadata };
+	if (!metadata.stale_scan_exhausted) {
+		return { canReturn: !hasSourceModelVectors(db, targetModel), metadata };
+	}
+	const exhaustedMaxRowId = metadata.stale_scan_exhausted_max_rowid;
+	const currentMaxRowId = readMaxMemoryVectorRowId(db);
+	if (
+		typeof exhaustedMaxRowId === "number" &&
+		currentMaxRowId != null &&
+		currentMaxRowId <= exhaustedMaxRowId
+	) {
+		return { canReturn: true, metadata };
+	}
+	if (
+		typeof exhaustedMaxRowId === "number" &&
+		currentMaxRowId != null &&
+		!hasSourceModelVectorsAfter(db, targetModel, exhaustedMaxRowId)
+	) {
+		const refreshed = { ...metadata, stale_scan_exhausted_max_rowid: currentMaxRowId };
+		updateMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, { metadata: refreshed });
+		return { canReturn: true, metadata: refreshed };
+	}
+	const invalidated = {
+		...metadata,
+		stale_scan_exhausted: undefined,
+		stale_scan_exhausted_max_rowid: undefined,
+	};
+	updateMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, { metadata: invalidated });
+	return { canReturn: false, metadata: invalidated };
 }
 
 function countEmbeddableActiveMemories(db: SqliteDatabase): number {
@@ -513,29 +591,65 @@ function deleteStaleModelVectors(
 	db: SqliteDatabase,
 	targetModel: string,
 	signal?: AbortSignal,
-): { deleted: number; exhausted: boolean } {
+): { deleted: number; exhausted: boolean; scannedMaxRowId: number | null } {
 	const batchSize = 250;
 	let deleted = 0;
-	const selectStmt = db.prepare(
-		"SELECT rowid FROM memory_vectors WHERE model != ? ORDER BY rowid ASC LIMIT ?",
-	);
 	const deleteStmt = db.prepare("DELETE FROM memory_vectors WHERE rowid = ?");
-	if (signal?.aborted) return { deleted, exhausted: false };
-	const rows = selectStmt.all(targetModel, batchSize) as Array<{ rowid: number }>;
-	if (rows.length === 0) return { deleted, exhausted: true };
-	if (signal?.aborted) return { deleted, exhausted: false };
+	if (signal?.aborted) return { deleted, exhausted: false, scannedMaxRowId: null };
+	if (!hasMemoryVectorRowidsShadowTable(db)) {
+		const rows = db
+			.prepare("SELECT rowid FROM memory_vectors WHERE model != ? ORDER BY rowid ASC LIMIT ?")
+			.all(targetModel, batchSize) as Array<{ rowid: number }>;
+		if (rows.length === 0) return { deleted, exhausted: true, scannedMaxRowId: null };
+		if (signal?.aborted) return { deleted, exhausted: false, scannedMaxRowId: null };
+		db.transaction(() => {
+			for (const row of rows) deleted += deleteStmt.run(row.rowid).changes;
+		})();
+		return { deleted, exhausted: rows.length < batchSize, scannedMaxRowId: null };
+	}
+
+	const selectRowIds = db.prepare(
+		"SELECT rowid FROM memory_vectors_rowids WHERE rowid > ? ORDER BY rowid ASC LIMIT ? /* vector-stale-scan-rowids */",
+	);
+	const selectMetadata = db.prepare(
+		"SELECT memory_id, content_hash, model FROM memory_vectors WHERE rowid = ?",
+	);
+	const staleRowIds: number[] = [];
+	let afterRowId = 0;
+	let exhausted = false;
+	while (staleRowIds.length < batchSize && !signal?.aborted) {
+		const rows = selectRowIds.all(afterRowId, batchSize) as Array<{ rowid: number }>;
+		if (rows.length === 0) {
+			exhausted = true;
+			break;
+		}
+		for (const row of rows) {
+			const metadata = selectMetadata.get(row.rowid) as { model: string } | undefined;
+			if (metadata && metadata.model !== targetModel) staleRowIds.push(row.rowid);
+			afterRowId = row.rowid;
+			if (staleRowIds.length === batchSize) break;
+		}
+		const lastRowId = rows.at(-1)?.rowid;
+		if (rows.length < batchSize && afterRowId === lastRowId) exhausted = true;
+	}
+	// The watermark is the last rowid this scan actually examined. Rows inserted
+	// above it by a concurrent writer were never inspected and must be re-checked
+	// on the next pass, so it must not be read from MAX(rowid) after the fact.
+	const scannedMaxRowId = exhausted ? afterRowId : null;
+	if (signal?.aborted) return { deleted, exhausted: false, scannedMaxRowId: null };
+	if (staleRowIds.length === 0) return { deleted, exhausted, scannedMaxRowId };
 	// Stop after one bounded batch so the event loop can deliver shutdown before
 	// the next migration pass. Deleted rows are the durable cleanup cursor.
 	db.transaction(() => {
-		for (const row of rows) deleted += deleteStmt.run(row.rowid).changes;
+		for (const rowid of staleRowIds) deleted += deleteStmt.run(rowid).changes;
 	})();
-	return { deleted, exhausted: rows.length < batchSize };
+	return { deleted, exhausted, scannedMaxRowId };
 }
 
 function cleanupStaleModels(
 	db: SqliteDatabase,
 	targetModel: string,
-): { removed: number; exhausted: boolean } {
+): { removed: number; exhausted: boolean; scannedMaxRowId: number | null } {
 	const cleanup = deleteStaleModelVectors(db, targetModel);
 	// Also prune obsolete rows within the target model: coverage is a subset
 	// check, so a memory can be "covered" while retaining target rows for content
@@ -543,7 +657,11 @@ function cleanupStaleModels(
 	// vector maintenance). Leaving them lets MIN-distance recall surface stale
 	// content after the migration reports success.
 	const prunedObsolete = pruneObsoleteTargetModelVectors(db, targetModel);
-	return { removed: cleanup.deleted + prunedObsolete, exhausted: cleanup.exhausted };
+	return {
+		removed: cleanup.deleted + prunedObsolete,
+		exhausted: cleanup.exhausted,
+		scannedMaxRowId: cleanup.scannedMaxRowId,
+	};
 }
 
 type DatabaseMutationSnapshot = {
@@ -675,6 +793,8 @@ async function finalizeMigrationCutover(
 			metadata: {
 				...progressMetadata,
 				cleanup_pending: true,
+				stale_scan_exhausted: undefined,
+				stale_scan_exhausted_max_rowid: undefined,
 				cutover_retry_count: 0,
 				uncovered_target_memories: undefined,
 			},
@@ -721,6 +841,8 @@ function deferCompletedCleanup(
 				...latestMetadata,
 				removed_stale_rows: mergedRemovedRows(latestMetadata, previouslyRemoved, prunedTargetRows),
 				cleanup_pending: true,
+				stale_scan_exhausted: undefined,
+				stale_scan_exhausted_max_rowid: undefined,
 				reconciliation_target_coverage_complete: undefined,
 			},
 		});
@@ -744,6 +866,8 @@ function restartMigrationForIncompleteCoverage(
 			metadata: {
 				...latestMetadata,
 				cleanup_pending: false,
+				stale_scan_exhausted: undefined,
+				stale_scan_exhausted_max_rowid: undefined,
 				reconciliation_target_coverage_complete: undefined,
 				source_model: null,
 				last_cursor_id: 0,
@@ -776,6 +900,7 @@ function recordResumedCleanupResult(
 			: 0;
 		const removed = mergedRemovedRows(latestMetadata, options.previouslyRemoved, newlyRemoved);
 		cleanupCompleted = options.cleanup.exhausted && cleanupWasIsolated;
+		const exhaustedMaxRowId = cleanupCompleted ? readMaxMemoryVectorRowId(db) : null;
 		let message = "Finished re-indexing; removing stale vectors";
 		if (!cleanupWasIsolated) message = "Memory changes arrived during cleanup; retrying";
 		if (cleanupCompleted) {
@@ -791,6 +916,8 @@ function recordResumedCleanupResult(
 				...latestMetadata,
 				removed_stale_rows: removed,
 				cleanup_pending: !cleanupCompleted,
+				stale_scan_exhausted: cleanupCompleted || undefined,
+				stale_scan_exhausted_max_rowid: exhaustedMaxRowId ?? undefined,
 				reconciliation_target_coverage_complete: undefined,
 			},
 		});
@@ -874,7 +1001,8 @@ async function drainStaleModelVectors(
 type CompletedCleanupPassResult = {
 	continueMigration: boolean;
 	restartFromBeginning: boolean;
-	reconciliationTargetPruningComplete: boolean;
+	staleScanExhausted: boolean;
+	validatedTargetCoverageComplete: boolean;
 };
 
 async function finishCompletedCleanupPass(
@@ -887,17 +1015,20 @@ async function finishCompletedCleanupPass(
 	const stop: CompletedCleanupPassResult = {
 		continueMigration: false,
 		restartFromBeginning: false,
-		reconciliationTargetPruningComplete: false,
+		staleScanExhausted: false,
+		validatedTargetCoverageComplete: false,
 	};
 	if (signal?.aborted) return stop;
 
 	const previouslyRemoved = Number(metadata.removed_stale_rows ?? 0);
 	const pruneSnapshot = readDatabaseMutationSnapshot(db, "cleanup-prune-start");
-	const prunedTargetRows = pruneObsoleteTargetModelVectors(db, targetModel, { signal });
+	const pruneResult = pruneObsoleteTargetModelVectorsWithCoverage(db, targetModel, { signal });
+	const prunedTargetRows = pruneResult.deleted;
 	const validationSnapshot = readDatabaseMutationSnapshot(db, "cleanup-prune-end");
 	const uncovered = signal?.aborted
 		? 0
-		: countIncompleteActiveMemoryVectorCoverage(db, targetModel);
+		: (pruneResult.incompleteActiveCoverage ??
+			countIncompleteActiveMemoryVectorCoverage(db, targetModel));
 	const pruningWasIsolated = sameDatabaseDataVersion(pruneSnapshot, validationSnapshot);
 	if (
 		signal?.aborted ||
@@ -914,14 +1045,16 @@ async function finishCompletedCleanupPass(
 		return {
 			continueMigration: true,
 			restartFromBeginning: false,
-			reconciliationTargetPruningComplete: false,
+			staleScanExhausted: false,
+			validatedTargetCoverageComplete: false,
 		};
 	}
 	if (!metadata.cleanup_pending) {
 		return {
 			continueMigration: true,
 			restartFromBeginning: true,
-			reconciliationTargetPruningComplete: true,
+			staleScanExhausted: metadata.stale_scan_exhausted === true,
+			validatedTargetCoverageComplete: false,
 		};
 	}
 
@@ -936,7 +1069,8 @@ async function finishCompletedCleanupPass(
 	return {
 		continueMigration: true,
 		restartFromBeginning: true,
-		reconciliationTargetPruningComplete: true,
+		staleScanExhausted: true,
+		validatedTargetCoverageComplete: prunedTargetRows === 0,
 	};
 }
 
@@ -1008,30 +1142,32 @@ export async function runVectorMigrationPass(
 		metadataMemoryIds(existingMetadata.pending_delete_memory_ids).length;
 	let restartCompletedMigration = false;
 	let reconciliationTargetCoverageComplete = false;
+	let completedMetadata = existingMetadata;
 	if (
 		existingJob?.status === "completed" &&
-		existingMetadata.target_model === targetModel &&
+		completedMetadata.target_model === targetModel &&
 		queuedSyncWorkCount === 0
 	) {
-		if (!existingMetadata.cleanup_pending && !hasSourceModelVectors(db, targetModel)) return;
+		const staleScan = checkCompletedStaleScan(db, targetModel, completedMetadata);
+		if (staleScan.canReturn) return;
+		completedMetadata = staleScan.metadata;
 		const cleanupResult = await finishCompletedCleanupPass(
 			db,
 			targetModel,
-			existingMetadata,
+			completedMetadata,
 			options.signal,
 			options.shouldStop,
 		);
 		if (
 			!cleanupResult.continueMigration ||
 			options.signal?.aborted ||
-			(cleanupResult.restartFromBeginning && !hasSourceModelVectors(db, targetModel))
+			(cleanupResult.restartFromBeginning &&
+				(cleanupResult.staleScanExhausted || !hasSourceModelVectors(db, targetModel)))
 		) {
 			return;
 		}
 		restartCompletedMigration = cleanupResult.restartFromBeginning;
-		reconciliationTargetCoverageComplete =
-			cleanupResult.reconciliationTargetPruningComplete &&
-			countIncompleteActiveMemoryVectorCoverage(db, targetModel) === 0;
+		reconciliationTargetCoverageComplete = cleanupResult.validatedTargetCoverageComplete;
 		existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
 	}
 	if (existingJob) {
@@ -1129,6 +1265,20 @@ export async function runVectorMigrationPass(
 	}
 	if (sourceModel && embeddableTotal <= 0) {
 		const cleanup = cleanupStaleModels(db, targetModel);
+		// Only claim exhaustion when the scan itself walked the shadow table;
+		// the legacy full-scan path has no examined-rowid watermark to persist.
+		const staleScanExhausted = cleanup.exhausted && cleanup.scannedMaxRowId != null;
+		const cleanupMetadata = {
+			...requestMetadata,
+			source_model: sourceModel,
+			target_model: targetModel,
+			removed_stale_rows: cleanup.removed,
+			cleanup_pending: !cleanup.exhausted,
+			stale_scan_exhausted: staleScanExhausted || undefined,
+			stale_scan_exhausted_max_rowid: staleScanExhausted
+				? (cleanup.scannedMaxRowId ?? undefined)
+				: undefined,
+		};
 		startMaintenanceJob(db, {
 			kind: VECTOR_MODEL_MIGRATION_JOB,
 			title: "Re-indexing memories",
@@ -1137,24 +1287,12 @@ export async function runVectorMigrationPass(
 					? `Removed ${cleanup.removed} stale vector rows`
 					: "No embeddable memories to re-index",
 			progressTotal: 0,
-			metadata: {
-				...requestMetadata,
-				source_model: sourceModel,
-				target_model: targetModel,
-				removed_stale_rows: cleanup.removed,
-				cleanup_pending: !cleanup.exhausted,
-			},
+			metadata: cleanupMetadata,
 		});
 		completeMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
 			progressCurrent: 0,
 			progressTotal: 0,
-			metadata: {
-				...requestMetadata,
-				source_model: sourceModel,
-				target_model: targetModel,
-				removed_stale_rows: cleanup.removed,
-				cleanup_pending: !cleanup.exhausted,
-			},
+			metadata: cleanupMetadata,
 		});
 		return;
 	}

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -16,6 +16,7 @@ import {
 	countIncompleteActiveMemoryVectorCoverage,
 	getSemanticIndexDiagnostics,
 	pruneObsoleteTargetModelVectors,
+	pruneObsoleteTargetModelVectorsWithCoverage,
 	resolveSemanticSearchModel,
 	semanticSearch,
 	storeVectors,
@@ -333,6 +334,7 @@ describe("vectors", () => {
 			insertTestVector(memoryId, 0, `obsolete-${index}`);
 		}
 		const controller = new AbortController();
+		let scanPageReads = 0;
 		const prepareSpy = vi.spyOn(db, "prepare");
 		prepareSpy.mockImplementation((sql: string) => {
 			const statement = Database.prototype.prepare.call(db, sql);
@@ -340,7 +342,8 @@ describe("vectors", () => {
 				const all = statement.all.bind(statement);
 				statement.all = ((...params: unknown[]) => {
 					const result = all(...params);
-					controller.abort();
+					scanPageReads++;
+					if (scanPageReads === 2) controller.abort();
 					return result;
 				}) as typeof statement.all;
 			}
@@ -357,6 +360,9 @@ describe("vectors", () => {
 		expect(
 			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE model = ?").get("test-model"),
 		).toMatchObject({ c: 252 });
+		expect(
+			db.prepare("SELECT name FROM temp.sqlite_schema WHERE name = 'vector_prune_scan'").get(),
+		).toBeUndefined();
 	});
 
 	it("pages stably and queries existing hashes once per page", async () => {
@@ -574,6 +580,143 @@ describe("vectors", () => {
 		).toMatchObject({ c: 1 });
 	});
 
+	it("bounds pruning query results and drops the spill table", () => {
+		const sessionId = insertTestSession(db);
+		const now = "2026-09-01T00:00:00.000Z";
+		const insertMemory = db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+			 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+			 VALUES (?, 'feature', ?, 'body', 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+		);
+		db.transaction(() => {
+			for (let index = 1; index <= 1_000; index++) {
+				const title = `Memory ${index}`;
+				const memoryId = Number(insertMemory.run(sessionId, title, now, now).lastInsertRowid);
+				insertTestVector(memoryId, 0, embeddings.hashText(`${title}\nbody`));
+				insertTestVector(memoryId, 0, `obsolete-a-${index}`);
+				insertTestVector(memoryId, 0, `obsolete-b-${index}`);
+			}
+		})();
+		const allResultSizes: number[] = [];
+		const prepareSpy = vi.spyOn(db, "prepare");
+		prepareSpy.mockImplementation((sql: string) => {
+			const statement = Database.prototype.prepare.call(db, sql);
+			const all = statement.all.bind(statement);
+			statement.all = ((...params: unknown[]) => {
+				const rows = all(...params);
+				allResultSizes.push(rows.length);
+				return rows;
+			}) as typeof statement.all;
+			return statement;
+		});
+
+		try {
+			expect(pruneObsoleteTargetModelVectors(db, "test-model")).toBe(2_000);
+		} finally {
+			prepareSpy.mockRestore();
+		}
+		expect(Math.max(...allResultSizes)).toBeLessThanOrEqual(250);
+		expect(
+			db.prepare("SELECT name FROM temp.sqlite_schema WHERE name = 'vector_prune_scan'").get(),
+		).toBeUndefined();
+	});
+
+	it("spills the prune scan to disk and restores temp_store afterwards", () => {
+		// The connection defaults to temp_store=MEMORY (db.ts read tuning). If the
+		// prune left that in place the spill would live in SQLite's heap and peak
+		// memory would still be O(total vectors), which is the OOM Codex flagged.
+		// temp_store values: 0=DEFAULT, 1=FILE, 2=MEMORY.
+		db.pragma("temp_store = MEMORY");
+		expect(db.pragma("temp_store", { simple: true })).toBe(2);
+		const sessionId = insertTestSession(db);
+		const memoryId = insertBackfillMemory(sessionId, "Spill", "2026-09-01T00:00:00.000Z");
+		// A covering row keeps the memory "complete" so the obsolete sibling is
+		// actually eligible for pruning; an incomplete memory is left untouched.
+		insertTestVector(memoryId, 0, embeddings.hashText("Spill\nBackfill body"));
+		insertTestVector(memoryId, 0, "obsolete");
+
+		let tempStoreDuringSpill: number | null = null;
+		const prepareSpy = vi.spyOn(db, "prepare").mockImplementation((sql: string) => {
+			const statement = Database.prototype.prepare.call(db, sql);
+			if (sql.startsWith("INSERT INTO temp.vector_prune_scan")) {
+				const run = statement.run.bind(statement);
+				statement.run = ((...params: unknown[]) => {
+					tempStoreDuringSpill ??= db.pragma("temp_store", { simple: true }) as number;
+					return run(...params);
+				}) as typeof statement.run;
+			}
+			return statement;
+		});
+		try {
+			expect(pruneObsoleteTargetModelVectors(db, "test-model")).toBe(1);
+		} finally {
+			prepareSpy.mockRestore();
+		}
+		expect(tempStoreDuringSpill).toBe(1);
+		expect(db.pragma("temp_store", { simple: true })).toBe(2);
+	});
+
+	it("deletes target rows for inactive and missing memories", () => {
+		const sessionId = insertTestSession(db);
+		const inactiveId = insertBackfillMemory(sessionId, "Inactive", "2026-09-01T00:00:00.000Z");
+		db.prepare("UPDATE memory_items SET active = 0 WHERE id = ?").run(inactiveId);
+		insertTestVector(inactiveId, 0, "inactive-hash");
+		insertTestVector(999_999, 0, "missing-hash");
+
+		expect(pruneObsoleteTargetModelVectors(db, "test-model")).toBe(2);
+		expect(db.prepare("SELECT COUNT(*) AS c FROM memory_vectors").get()).toMatchObject({ c: 0 });
+	});
+
+	it("does not lock main-database writers while spilling a scan page", () => {
+		db.close();
+		const directory = mkdtempSync(join(tmpdir(), "codemem-vector-prune-lock-"));
+		const dbPath = join(directory, "mem.sqlite");
+		db = dbModule.connect(dbPath);
+		const otherDb = dbModule.connect(dbPath);
+		otherDb.pragma("busy_timeout = 0");
+		const sessionId = insertTestSession(db);
+		const memoryId = insertBackfillMemory(sessionId, "Current", "2026-09-01T00:00:00.000Z", "body");
+		insertTestVector(memoryId, 0, embeddings.hashText("Current\nbody"));
+		const now = "2026-09-01T00:00:00.000Z";
+		const concurrentInsert = otherDb.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+			 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+			 VALUES (?, 'feature', 'Concurrent', 'write', 0.5, '', 0, ?, ?, '{}', 1, 'shared')`,
+		);
+		let concurrentMemoryId: number | null = null;
+		const prepareSpy = vi.spyOn(db, "prepare");
+		prepareSpy.mockImplementation((sql: string) => {
+			const statement = Database.prototype.prepare.call(db, sql);
+			if (sql.startsWith("INSERT INTO temp.vector_prune_scan")) {
+				const run = statement.run.bind(statement);
+				statement.run = ((...params: unknown[]) => {
+					const result = run(...params);
+					if (concurrentMemoryId == null) {
+						concurrentMemoryId = Number(concurrentInsert.run(sessionId, now, now).lastInsertRowid);
+					}
+					return result;
+				}) as typeof statement.run;
+			}
+			return statement;
+		});
+
+		try {
+			expect(pruneObsoleteTargetModelVectors(db, "test-model")).toBe(0);
+			expect(concurrentMemoryId).not.toBeNull();
+			expect(
+				db.prepare("SELECT id FROM memory_items WHERE id = ?").get(concurrentMemoryId),
+			).toEqual({
+				id: concurrentMemoryId,
+			});
+		} finally {
+			prepareSpy.mockRestore();
+			otherDb.close();
+			db.close();
+			db = new Database(":memory:");
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
 	it("keeps vec0 metadata scans outside delete transactions", () => {
 		const sessionId = insertTestSession(db);
 		const memoryId = insertBackfillMemory(sessionId, "Current", "2026-09-01T00:00:00.000Z", "body");
@@ -633,7 +776,10 @@ describe("vectors", () => {
 		insertTestVector(memoryId, 0, embeddings.hashText(firstChunk));
 		insertTestVector(memoryId, 0, "obsolete-target-hash");
 
-		expect(pruneObsoleteTargetModelVectors(db, "test-model")).toBe(0);
+		expect(pruneObsoleteTargetModelVectorsWithCoverage(db, "test-model")).toEqual({
+			deleted: 0,
+			incompleteActiveCoverage: 1,
+		});
 		expect(
 			db.prepare("SELECT content_hash FROM memory_vectors WHERE memory_id = ?").all(memoryId),
 		).toEqual(

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -336,7 +336,7 @@ describe("vectors", () => {
 		const prepareSpy = vi.spyOn(db, "prepare");
 		prepareSpy.mockImplementation((sql: string) => {
 			const statement = Database.prototype.prepare.call(db, sql);
-			if (sql.includes("SELECT mv.rowid AS rowid")) {
+			if (sql.includes("vector-target-prune-rowids")) {
 				const all = statement.all.bind(statement);
 				statement.all = ((...params: unknown[]) => {
 					const result = all(...params);
@@ -349,14 +349,14 @@ describe("vectors", () => {
 
 		try {
 			expect(pruneObsoleteTargetModelVectors(db, "test-model", { signal: controller.signal })).toBe(
-				249,
+				0,
 			);
 		} finally {
 			prepareSpy.mockRestore();
 		}
 		expect(
 			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE model = ?").get("test-model"),
-		).toMatchObject({ c: 3 });
+		).toMatchObject({ c: 252 });
 	});
 
 	it("pages stably and queries existing hashes once per page", async () => {
@@ -572,6 +572,49 @@ describe("vectors", () => {
 		expect(
 			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE model = ?").get("test-model"),
 		).toMatchObject({ c: 1 });
+	});
+
+	it("keeps vec0 metadata scans outside delete transactions", () => {
+		const sessionId = insertTestSession(db);
+		const memoryId = insertBackfillMemory(sessionId, "Current", "2026-09-01T00:00:00.000Z", "body");
+		insertTestVector(memoryId, 0, embeddings.hashText("Current\nbody"));
+		for (let index = 0; index < 999; index++) {
+			insertTestVector(memoryId, 0, `obsolete-plan-${index}`);
+		}
+		const pointLookupPlans = (
+			db
+				.prepare(
+					"EXPLAIN QUERY PLAN SELECT memory_id, content_hash, model FROM memory_vectors WHERE rowid = ?",
+				)
+				.all(1) as Array<{ detail: string }>
+		).map(({ detail }) => detail);
+		let metadataReadsInTransaction = 0;
+		const prepareSpy = vi.spyOn(db, "prepare");
+		prepareSpy.mockImplementation((sql: string) => {
+			const statement = Database.prototype.prepare.call(db, sql);
+			if (sql === "SELECT memory_id, content_hash, model FROM memory_vectors WHERE rowid = ?") {
+				const get = statement.get.bind(statement);
+				statement.get = ((...params: unknown[]) => {
+					if (db.inTransaction) metadataReadsInTransaction++;
+					return get(...params);
+				}) as typeof statement.get;
+			}
+			return statement;
+		});
+
+		try {
+			expect(pruneObsoleteTargetModelVectors(db, "test-model")).toBe(999);
+		} finally {
+			prepareSpy.mockRestore();
+		}
+		expect(metadataReadsInTransaction).toBe(0);
+		expect(pointLookupPlans.length).toBeGreaterThan(0);
+		expect(pointLookupPlans.some((detail) => detail.includes("VIRTUAL TABLE"))).toBe(true);
+		expect(
+			pointLookupPlans.every(
+				(detail) => !detail.includes("INDEX 0") && !detail.toLowerCase().includes("fullscan"),
+			),
+		).toBe(true);
 	});
 
 	it("retains obsolete target rows while current target coverage is incomplete", () => {

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -382,37 +382,206 @@ type TargetVectorRow = {
 	content_hash: string | null;
 };
 
+type TargetVectorCoverageState = {
+	expectedHashes: string[];
+	expected: Set<string>;
+	existing: Set<string>;
+};
+
 function collectTargetVectorRows(
 	db: Database,
 	model: string,
 	batchSize: number,
 	signal?: AbortSignal,
-): { rowsByMemory: Map<number, TargetVectorRow[]>; exhausted: boolean } {
-	const rowsByMemory = new Map<number, TargetVectorRow[]>();
+): boolean {
 	const selectRowIds = db.prepare(
 		"SELECT rowid FROM memory_vectors_rowids WHERE rowid > ? ORDER BY rowid ASC LIMIT ? /* vector-target-prune-rowids */",
 	);
 	const selectMetadata = db.prepare(
 		"SELECT memory_id, content_hash, model FROM memory_vectors WHERE rowid = ?",
 	);
+	const insertScanRow = db.prepare(
+		"INSERT INTO temp.vector_prune_scan(rowid, memory_id, content_hash) VALUES (?, ?, ?) /* vector-target-prune-spill */",
+	);
+	const insertScanPage = db.transaction((rows: TargetVectorRow[]) => {
+		for (const row of rows) insertScanRow.run(row.rowid, row.memory_id, row.content_hash);
+	});
 	let afterRowId = 0;
 	while (!signal?.aborted) {
 		const rowIds = selectRowIds.all(afterRowId, batchSize) as Array<{ rowid: number }>;
-		if (rowIds.length === 0) return { rowsByMemory, exhausted: true };
+		if (signal?.aborted) return false;
+		if (rowIds.length === 0) return true;
+		const targetRows: TargetVectorRow[] = [];
 		for (const { rowid } of rowIds) {
-			if (signal?.aborted) return { rowsByMemory, exhausted: false };
+			if (signal?.aborted) return false;
 			const metadata = selectMetadata.get(rowid) as
 				| { memory_id: number; content_hash: string | null; model: string }
 				| undefined;
 			if (!metadata || metadata.model !== model) continue;
-			const rows = rowsByMemory.get(metadata.memory_id) ?? [];
-			rows.push({ rowid, memory_id: metadata.memory_id, content_hash: metadata.content_hash });
-			rowsByMemory.set(metadata.memory_id, rows);
+			targetRows.push({
+				rowid,
+				memory_id: metadata.memory_id,
+				content_hash: metadata.content_hash,
+			});
 		}
+		if (signal?.aborted) return false;
+		insertScanPage.deferred(targetRows);
 		afterRowId = rowIds.at(-1)?.rowid ?? afterRowId;
-		if (rowIds.length < batchSize) return { rowsByMemory, exhausted: true };
+		if (rowIds.length < batchSize) return true;
 	}
-	return { rowsByMemory, exhausted: false };
+	return false;
+}
+
+function visitTargetVectorRowsForMemories(
+	db: Database,
+	memoryIds: number[],
+	batchSize: number,
+	visit: (rows: TargetVectorRow[]) => void,
+	signal?: AbortSignal,
+): boolean {
+	if (memoryIds.length === 0) return true;
+	const placeholders = memoryIds.map(() => "?").join(", ");
+	const selectRows = db.prepare(
+		`SELECT rowid, memory_id, content_hash FROM temp.vector_prune_scan
+		 WHERE memory_id IN (${placeholders}) AND rowid > ?
+		 ORDER BY rowid ASC LIMIT ? /* vector-target-prune-spill-page */`,
+	);
+	let afterRowId = 0;
+	while (!signal?.aborted) {
+		const rows = selectRows.all(...memoryIds, afterRowId, batchSize) as TargetVectorRow[];
+		if (signal?.aborted) return false;
+		if (rows.length === 0) return true;
+		visit(rows);
+		afterRowId = rows.at(-1)?.rowid ?? afterRowId;
+		if (rows.length < batchSize) return true;
+	}
+	return false;
+}
+
+function deleteVectorRows(db: Database, rowIds: number[]): number {
+	const deleteStmt = db.prepare("DELETE FROM memory_vectors WHERE rowid = ?");
+	return db
+		.transaction(() => rowIds.reduce((count, rowid) => count + deleteStmt.run(rowid).changes, 0))
+		.immediate();
+}
+
+function createTargetVectorCoverageStates(
+	memories: MemoryTextRow[],
+): Map<number, TargetVectorCoverageState> {
+	return new Map(
+		memories.map((memory): [number, TargetVectorCoverageState] => {
+			const expectedHashes = chunkHashes(memoryText(memory.title, memory.body_text));
+			return [
+				memory.id,
+				{ expectedHashes, expected: new Set(expectedHashes), existing: new Set<string>() },
+			];
+		}),
+	);
+}
+
+function summarizeTargetVectorCoverage(states: Map<number, TargetVectorCoverageState>): {
+	coveredMemoryIds: number[];
+	incomplete: number;
+} {
+	const coveredMemoryIds: number[] = [];
+	let incomplete = 0;
+	for (const [memoryId, state] of states) {
+		if (!expectedHashSetContains(state.expectedHashes, state.existing)) incomplete++;
+		else coveredMemoryIds.push(memoryId);
+	}
+	return { coveredMemoryIds, incomplete };
+}
+
+function pruneCoveredTargetVectorRows(
+	db: Database,
+	states: Map<number, TargetVectorCoverageState>,
+	memoryIds: number[],
+	batchSize: number,
+	signal?: AbortSignal,
+): { completed: boolean; deleted: number } {
+	let deleted = 0;
+	const completed = visitTargetVectorRowsForMemories(
+		db,
+		memoryIds,
+		batchSize,
+		(rows) => {
+			const obsolete = rows
+				.filter((row) => {
+					const expected = states.get(row.memory_id)?.expected;
+					return row.content_hash == null || !expected?.has(row.content_hash);
+				})
+				.map((row) => row.rowid);
+			if (obsolete.length > 0) deleted += deleteVectorRows(db, obsolete);
+		},
+		signal,
+	);
+	return { completed, deleted };
+}
+
+function pruneActiveMemoryPage(
+	db: Database,
+	memories: MemoryTextRow[],
+	batchSize: number,
+	signal?: AbortSignal,
+): { completed: boolean; deleted: number; incomplete: number } {
+	const states = createTargetVectorCoverageStates(memories);
+	const memoryIds = memories.map((memory) => memory.id);
+	const covered = visitTargetVectorRowsForMemories(
+		db,
+		memoryIds,
+		batchSize,
+		(rows) => {
+			for (const row of rows) {
+				const state = states.get(row.memory_id);
+				if (row.content_hash != null && state?.expected.has(row.content_hash)) {
+					state.existing.add(row.content_hash);
+				}
+			}
+		},
+		signal,
+	);
+	if (!covered) return { completed: false, deleted: 0, incomplete: 0 };
+	const coverage = summarizeTargetVectorCoverage(states);
+	const pruned = pruneCoveredTargetVectorRows(
+		db,
+		states,
+		coverage.coveredMemoryIds,
+		batchSize,
+		signal,
+	);
+	if (!pruned.completed) {
+		return { completed: false, deleted: pruned.deleted, incomplete: coverage.incomplete };
+	}
+	const placeholders = memoryIds.map(() => "?").join(", ");
+	db.prepare(`DELETE FROM temp.vector_prune_scan WHERE memory_id IN (${placeholders})`).run(
+		...memoryIds,
+	);
+	return { completed: true, deleted: pruned.deleted, incomplete: coverage.incomplete };
+}
+
+function pruneRemainingTargetVectorRows(
+	db: Database,
+	batchSize: number,
+	signal?: AbortSignal,
+): { completed: boolean; deleted: number } {
+	const selectRows = db.prepare(
+		`SELECT rowid, memory_id, content_hash FROM temp.vector_prune_scan
+		 WHERE rowid > ? ORDER BY rowid ASC LIMIT ? /* vector-target-prune-spill-remainder */`,
+	);
+	let afterRowId = 0;
+	let deleted = 0;
+	while (!signal?.aborted) {
+		const rows = selectRows.all(afterRowId, batchSize) as TargetVectorRow[];
+		if (signal?.aborted) return { completed: false, deleted };
+		if (rows.length === 0) return { completed: true, deleted };
+		deleted += deleteVectorRows(
+			db,
+			rows.map((row) => row.rowid),
+		);
+		afterRowId = rows.at(-1)?.rowid ?? afterRowId;
+		if (rows.length < batchSize) return { completed: true, deleted };
+	}
+	return { completed: false, deleted };
 }
 
 function pruneTargetVectorRowsFromShadowTable(
@@ -421,55 +590,71 @@ function pruneTargetVectorRowsFromShadowTable(
 	options: { signal?: AbortSignal },
 ): { deleted: number; incompleteActiveCoverage: number | null } {
 	const batchSize = 250;
-	const collected = collectTargetVectorRows(db, model, batchSize, options.signal);
-	if (!collected.exhausted) return { deleted: 0, incompleteActiveCoverage: null };
+	// The connection defaults to temp_store=MEMORY, which would keep the spill
+	// resident in SQLite's heap and leave peak memory O(total vectors). Force it
+	// to disk for the prune so the bound is genuinely one page. temp_store cannot
+	// change while temp tables exist, so this must bracket the CREATE/DROP.
+	const previousTempStore = readTempStore(db);
+	db.pragma("temp_store = FILE");
+	try {
+		return pruneTargetVectorRowsWithSpill(db, model, batchSize, options.signal);
+	} finally {
+		db.pragma(`temp_store = ${previousTempStore}`);
+	}
+}
 
-	const selectMemories = db.prepare(
-		`SELECT id, title, body_text FROM memory_items
-		 WHERE active = 1 AND id > ?
-		 ORDER BY id ASC
-		 LIMIT ?`,
-	);
-	const activeMemoryIds = new Set<number>();
-	const obsoleteRowIds: number[] = [];
-	let afterMemoryId = 0;
-	let incompleteActiveCoverage = 0;
-	while (!options.signal?.aborted) {
-		const memories = selectMemories.all(afterMemoryId, batchSize) as MemoryTextRow[];
-		if (memories.length === 0) break;
-		for (const memory of memories) {
-			activeMemoryIds.add(memory.id);
-			const rows = collected.rowsByMemory.get(memory.id) ?? [];
-			const expectedHashes = chunkHashes(memoryText(memory.title, memory.body_text));
-			const existingRows = rows.map((row) => ({ content_hash: row.content_hash }));
-			if (!expectedHashesExist(expectedHashes, existingRows)) {
-				incompleteActiveCoverage++;
-				continue;
-			}
-			const expected = new Set(expectedHashes);
-			for (const row of rows) {
-				if (row.content_hash == null || !expected.has(row.content_hash)) {
-					obsoleteRowIds.push(row.rowid);
-				}
-			}
+function readTempStore(db: Database): number {
+	const value = db.pragma("temp_store", { simple: true });
+	return typeof value === "number" ? value : 0;
+}
+
+function pruneTargetVectorRowsWithSpill(
+	db: Database,
+	model: string,
+	batchSize: number,
+	signal: AbortSignal | undefined,
+): { deleted: number; incompleteActiveCoverage: number | null } {
+	const options = { signal };
+	db.exec(`CREATE TEMP TABLE IF NOT EXISTS vector_prune_scan (
+		rowid INTEGER PRIMARY KEY,
+		memory_id INTEGER NOT NULL,
+		content_hash TEXT
+	)`);
+	try {
+		db.exec(
+			"CREATE INDEX IF NOT EXISTS temp.vector_prune_scan_memory_id_idx ON vector_prune_scan(memory_id)",
+		);
+		db.exec("DELETE FROM temp.vector_prune_scan");
+		if (!collectTargetVectorRows(db, model, batchSize, options.signal)) {
+			return { deleted: 0, incompleteActiveCoverage: null };
 		}
-		afterMemoryId = memories.at(-1)?.id ?? afterMemoryId;
+		const selectMemories = db.prepare(
+			`SELECT id, title, body_text FROM memory_items
+			 WHERE active = 1 AND id > ?
+			 ORDER BY id ASC LIMIT ?`,
+		);
+		let afterMemoryId = 0;
+		let deleted = 0;
+		let incompleteActiveCoverage = 0;
+		while (!options.signal?.aborted) {
+			const memories = selectMemories.all(afterMemoryId, batchSize) as MemoryTextRow[];
+			if (memories.length === 0) break;
+			const result = pruneActiveMemoryPage(db, memories, batchSize, options.signal);
+			deleted += result.deleted;
+			if (!result.completed) return { deleted, incompleteActiveCoverage: null };
+			incompleteActiveCoverage += result.incomplete;
+			afterMemoryId = memories.at(-1)?.id ?? afterMemoryId;
+		}
+		if (options.signal?.aborted) return { deleted, incompleteActiveCoverage: null };
+		const remaining = pruneRemainingTargetVectorRows(db, batchSize, options.signal);
+		deleted += remaining.deleted;
+		return {
+			deleted,
+			incompleteActiveCoverage: remaining.completed ? incompleteActiveCoverage : null,
+		};
+	} finally {
+		db.exec("DROP TABLE IF EXISTS temp.vector_prune_scan");
 	}
-	if (options.signal?.aborted) return { deleted: 0, incompleteActiveCoverage: null };
-	for (const [memoryId, rows] of collected.rowsByMemory) {
-		if (!activeMemoryIds.has(memoryId)) obsoleteRowIds.push(...rows.map((row) => row.rowid));
-	}
-
-	const deleteStmt = db.prepare("DELETE FROM memory_vectors WHERE rowid = ?");
-	let deleted = 0;
-	for (let offset = 0; offset < obsoleteRowIds.length; offset += batchSize) {
-		if (options.signal?.aborted) break;
-		const batch = obsoleteRowIds.slice(offset, offset + batchSize);
-		deleted += db
-			.transaction(() => batch.reduce((count, rowid) => count + deleteStmt.run(rowid).changes, 0))
-			.immediate();
-	}
-	return { deleted, incompleteActiveCoverage };
 }
 
 function pruneTargetVectorRowsWithLegacyScan(

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -371,6 +371,166 @@ export function countIncompleteActiveMemoryVectorCoverage(db: Database, model: s
 	return incomplete;
 }
 
+function hasMemoryVectorRowidsShadowTable(db: Database): boolean {
+	const tables = db.prepare("PRAGMA table_list").all() as Array<{ name: string }>;
+	return tables.some((table) => table.name === "memory_vectors_rowids");
+}
+
+type TargetVectorRow = {
+	rowid: number;
+	memory_id: number;
+	content_hash: string | null;
+};
+
+function collectTargetVectorRows(
+	db: Database,
+	model: string,
+	batchSize: number,
+	signal?: AbortSignal,
+): { rowsByMemory: Map<number, TargetVectorRow[]>; exhausted: boolean } {
+	const rowsByMemory = new Map<number, TargetVectorRow[]>();
+	const selectRowIds = db.prepare(
+		"SELECT rowid FROM memory_vectors_rowids WHERE rowid > ? ORDER BY rowid ASC LIMIT ? /* vector-target-prune-rowids */",
+	);
+	const selectMetadata = db.prepare(
+		"SELECT memory_id, content_hash, model FROM memory_vectors WHERE rowid = ?",
+	);
+	let afterRowId = 0;
+	while (!signal?.aborted) {
+		const rowIds = selectRowIds.all(afterRowId, batchSize) as Array<{ rowid: number }>;
+		if (rowIds.length === 0) return { rowsByMemory, exhausted: true };
+		for (const { rowid } of rowIds) {
+			if (signal?.aborted) return { rowsByMemory, exhausted: false };
+			const metadata = selectMetadata.get(rowid) as
+				| { memory_id: number; content_hash: string | null; model: string }
+				| undefined;
+			if (!metadata || metadata.model !== model) continue;
+			const rows = rowsByMemory.get(metadata.memory_id) ?? [];
+			rows.push({ rowid, memory_id: metadata.memory_id, content_hash: metadata.content_hash });
+			rowsByMemory.set(metadata.memory_id, rows);
+		}
+		afterRowId = rowIds.at(-1)?.rowid ?? afterRowId;
+		if (rowIds.length < batchSize) return { rowsByMemory, exhausted: true };
+	}
+	return { rowsByMemory, exhausted: false };
+}
+
+function pruneTargetVectorRowsFromShadowTable(
+	db: Database,
+	model: string,
+	options: { signal?: AbortSignal },
+): { deleted: number; incompleteActiveCoverage: number | null } {
+	const batchSize = 250;
+	const collected = collectTargetVectorRows(db, model, batchSize, options.signal);
+	if (!collected.exhausted) return { deleted: 0, incompleteActiveCoverage: null };
+
+	const selectMemories = db.prepare(
+		`SELECT id, title, body_text FROM memory_items
+		 WHERE active = 1 AND id > ?
+		 ORDER BY id ASC
+		 LIMIT ?`,
+	);
+	const activeMemoryIds = new Set<number>();
+	const obsoleteRowIds: number[] = [];
+	let afterMemoryId = 0;
+	let incompleteActiveCoverage = 0;
+	while (!options.signal?.aborted) {
+		const memories = selectMemories.all(afterMemoryId, batchSize) as MemoryTextRow[];
+		if (memories.length === 0) break;
+		for (const memory of memories) {
+			activeMemoryIds.add(memory.id);
+			const rows = collected.rowsByMemory.get(memory.id) ?? [];
+			const expectedHashes = chunkHashes(memoryText(memory.title, memory.body_text));
+			const existingRows = rows.map((row) => ({ content_hash: row.content_hash }));
+			if (!expectedHashesExist(expectedHashes, existingRows)) {
+				incompleteActiveCoverage++;
+				continue;
+			}
+			const expected = new Set(expectedHashes);
+			for (const row of rows) {
+				if (row.content_hash == null || !expected.has(row.content_hash)) {
+					obsoleteRowIds.push(row.rowid);
+				}
+			}
+		}
+		afterMemoryId = memories.at(-1)?.id ?? afterMemoryId;
+	}
+	if (options.signal?.aborted) return { deleted: 0, incompleteActiveCoverage: null };
+	for (const [memoryId, rows] of collected.rowsByMemory) {
+		if (!activeMemoryIds.has(memoryId)) obsoleteRowIds.push(...rows.map((row) => row.rowid));
+	}
+
+	const deleteStmt = db.prepare("DELETE FROM memory_vectors WHERE rowid = ?");
+	let deleted = 0;
+	for (let offset = 0; offset < obsoleteRowIds.length; offset += batchSize) {
+		if (options.signal?.aborted) break;
+		const batch = obsoleteRowIds.slice(offset, offset + batchSize);
+		deleted += db
+			.transaction(() => batch.reduce((count, rowid) => count + deleteStmt.run(rowid).changes, 0))
+			.immediate();
+	}
+	return { deleted, incompleteActiveCoverage };
+}
+
+function pruneTargetVectorRowsWithLegacyScan(
+	db: Database,
+	model: string,
+	options: { signal?: AbortSignal },
+): number {
+	const batchSize = 250;
+	let afterRowId = 0;
+	let deleted = 0;
+	const selectBatch = db.prepare(
+		`SELECT mv.rowid AS rowid, mv.memory_id AS memory_id, mv.content_hash AS content_hash,
+		        mi.title AS title, mi.body_text AS body_text, mi.active AS active
+		 FROM memory_vectors mv
+		 LEFT JOIN memory_items mi ON mi.id = mv.memory_id
+		 WHERE mv.model = ? AND mv.rowid > ?
+		 ORDER BY mv.rowid ASC
+		 LIMIT ?`,
+	);
+	const deleteStmt = db.prepare("DELETE FROM memory_vectors WHERE rowid = ?");
+	while (!options.signal?.aborted) {
+		const rows = selectBatch.all(model, afterRowId, batchSize) as Array<
+			TargetVectorRow & { title: string | null; body_text: string | null; active: number | null }
+		>;
+		if (rows.length === 0) break;
+		const obsoleteRowIds: number[] = [];
+		const expectedByMemory = new Map<number, Set<string>>();
+		const coverageByMemory = new Map<number, boolean>();
+		for (const row of rows) {
+			if (row.active == null || row.active === 0) {
+				obsoleteRowIds.push(row.rowid);
+				continue;
+			}
+			let covered = coverageByMemory.get(row.memory_id);
+			if (covered === undefined) {
+				covered = memoryHasCompleteVectorCoverage(
+					db,
+					{ id: row.memory_id, title: row.title, body_text: row.body_text },
+					model,
+				);
+				coverageByMemory.set(row.memory_id, covered);
+			}
+			if (!covered) continue;
+			const expected =
+				expectedByMemory.get(row.memory_id) ??
+				new Set(chunkHashes(memoryText(row.title, row.body_text)));
+			expectedByMemory.set(row.memory_id, expected);
+			if (row.content_hash == null || !expected.has(row.content_hash)) {
+				obsoleteRowIds.push(row.rowid);
+			}
+		}
+		deleted += db
+			.transaction(() =>
+				obsoleteRowIds.reduce((count, rowid) => count + deleteStmt.run(rowid).changes, 0),
+			)
+			.immediate();
+		afterRowId = rows.at(-1)?.rowid ?? afterRowId;
+	}
+	return deleted;
+}
+
 /**
  * Delete target-model vector rows whose content_hash is not part of their
  * memory's current chunk set. Coverage is a subset check, so a memory can be
@@ -387,70 +547,21 @@ export function pruneObsoleteTargetModelVectors(
 	model: string,
 	options: { signal?: AbortSignal } = {},
 ): number {
-	const batchSize = 250;
-	let afterRowId = 0;
-	let deleted = 0;
-	const selectBatch = db.prepare(
-		`SELECT mv.rowid AS rowid, mv.memory_id AS memory_id, mv.content_hash AS content_hash,
-		        mi.title AS title, mi.body_text AS body_text, mi.active AS active
-		 FROM memory_vectors mv
-		 LEFT JOIN memory_items mi ON mi.id = mv.memory_id
-		 WHERE mv.model = ? AND mv.rowid > ?
-		 ORDER BY mv.rowid ASC
-		 LIMIT ?`,
-	);
-	const deleteStmt = db.prepare("DELETE FROM memory_vectors WHERE rowid = ?");
-	const processBatch = db.transaction((cursor: number) => {
-		const rows = selectBatch.all(model, cursor, batchSize) as Array<{
-			rowid: number;
-			memory_id: number;
-			content_hash: string | null;
-			title: string | null;
-			body_text: string | null;
-			active: number | null;
-		}>;
-		const expectedByMemory = new Map<number, Set<string>>();
-		const coverageByMemory = new Map<number, boolean>();
-		const obsoleteRowIds: number[] = [];
-		for (const row of rows) {
-			if (row.active == null || row.active === 0) {
-				obsoleteRowIds.push(row.rowid);
-				continue;
-			}
-			let hasCompleteCoverage = coverageByMemory.get(row.memory_id);
-			if (hasCompleteCoverage === undefined) {
-				hasCompleteCoverage = memoryHasCompleteVectorCoverage(
-					db,
-					{ id: row.memory_id, title: row.title, body_text: row.body_text },
-					model,
-				);
-				coverageByMemory.set(row.memory_id, hasCompleteCoverage);
-			}
-			if (!hasCompleteCoverage) continue;
-			let expected = expectedByMemory.get(row.memory_id);
-			if (!expected) {
-				expected = new Set(chunkHashes(memoryText(row.title, row.body_text)));
-				expectedByMemory.set(row.memory_id, expected);
-			}
-			if (row.content_hash == null || !expected.has(row.content_hash)) {
-				obsoleteRowIds.push(row.rowid);
-			}
-		}
-		let deletedInBatch = 0;
-		for (const id of obsoleteRowIds) deletedInBatch += deleteStmt.run(id).changes;
+	return pruneObsoleteTargetModelVectorsWithCoverage(db, model, options).deleted;
+}
+
+export function pruneObsoleteTargetModelVectorsWithCoverage(
+	db: Database,
+	model: string,
+	options: { signal?: AbortSignal } = {},
+): { deleted: number; incompleteActiveCoverage: number | null } {
+	if (!hasMemoryVectorRowidsShadowTable(db)) {
 		return {
-			deleted: deletedInBatch,
-			nextCursor: rows.at(-1)?.rowid ?? cursor,
-			exhausted: rows.length === 0,
+			deleted: pruneTargetVectorRowsWithLegacyScan(db, model, options),
+			incompleteActiveCoverage: null,
 		};
-	}).immediate;
-	while (!options.signal?.aborted) {
-		const batch = processBatch(afterRowId);
-		deleted += batch.deleted;
-		if (batch.exhausted) break;
-		afterRowId = batch.nextCursor;
 	}
-	return deleted;
+	return pruneTargetVectorRowsFromShadowTable(db, model, options);
 }
 
 function toSqlStringLiteral(value: string): string {


### PR DESCRIPTION
## Description
Root-causes the Viewer instability seen during v0.44.0-alpha.1 dogfooding. Two independent defects compounded:

**1. sqlite-vec `vec0` full scans under the write lock (the actual cause).** `vec0` indexes only `rowid = ?`; every metadata predicate (`model = ?`, `memory_id IN (...)`, `rowid > ?` range) is a full scan that materialises metadata for every row. Vector-migration cleanup ran N/250 such scans per pass **inside `IMMEDIATE` transactions**, then deferred on any concurrent write and retried every 5s. On the live 140k-row DB the cleanup had looped for 12 hours, pinning a core and holding the write lock so the Viewer got `SQLITE_BUSY` and died.

Fix: walk the `memory_vectors_rowids` shadow table (a real AUTOINCREMENT b-tree) for cursors, read metadata via indexed `rowid = ?` point lookups, hold the write lock only for deletes. Persist `stale_scan_exhausted` with a watermark taken from the scan's own last-examined rowid (not post-hoc `MAX(rowid)`, which can hide rows inserted during the prune). Rows above the watermark are re-checked; a legacy row invalidates the flag. Falls back to the old path when the shadow table is absent. Idle poll raised 5s → 60s.

**2. Sync-daemon crash on error-write.** When a tick failed and the error-state write *also* threw `SQLITE_BUSY`, the rejection escaped the timer as unhandled and killed the process, orphaning the maintenance worker. That orphan then blocked the next startup because worker cleanup ran *after* database init. Fix: error-state persistence is best-effort with console fallback, timer rejections are consumed, and trusted-worker termination now precedes `prepareViewerDatabase`.

## Live validation
Cleanup that had looped since 11:24 UTC completed in ~60s on the fixed build: `cleanup_pending: 0`, `stale_scan_exhausted: 1`, removed 102,721 stale rows. Worker dropped to 0% CPU; Viewer stayed HTTP 200 throughout.

## Type of Change
- [x] 🐛 Bug fix
- [ ] 🚀 Feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance
- [ ] 🧪 Testing

## Testing
- [x] 191 targeted tests pass (`vectors`, `vector-migration`, `vector-migration-queue-coverage`, `maintenance-worker-runtime`, `sync-daemon`, `serve`)
- [x] `pnpm run tsc`
- [x] Targeted Biome (pre-existing warnings only), `git diff --check`
- [x] New regressions: zero `SCAN memory_vectors` inside delete txns; exhausted flag short-circuits with zero vector statements; watermark race (verified to fail against `MAX(rowid)` code); `SQLITE_BUSY` on error-write does not crash and next tick recovers; `idleIntervalMs >= 60000`
- [ ] Full workspace suite not rerun for this PR

## Checklist
- [x] Self-review
- [x] Independent CodeReviewer approved (one blocker found and fixed: watermark race)
- [x] No new warnings introduced

Tracking: codemem-1m48 (P0), codemem-29vi. AUTOINCREMENT rowid non-reuse verified empirically against vec0 0.1.9 including post-VACUUM.