### PR TITLE
fix(viewer): surface why Team setup finish failed

### DIFF
--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -132,7 +132,7 @@ function coordinatorRemoteTarget(config = readCodememConfigFile()): {
 	return { remoteUrl, adminSecret };
 }
 
-class RemoteCoordinatorRequestError extends Error {
+export class RemoteCoordinatorRequestError extends Error {
 	constructor(
 		readonly status: number,
 		readonly code: string,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,7 @@ export {
 	coordinatorUnarchiveGroupAction,
 	coordinatorUpdateScopeAction,
 	isPeerTrustBindingCompatible,
+	RemoteCoordinatorRequestError,
 } from "./coordinator-actions.js";
 export type {
 	CoordinatorRequestVerifier,
@@ -505,9 +506,11 @@ export * from "./legacy-team-setup-draft.js";
 export type {
 	LegacyTeamSetupCoreErrorCode,
 	LegacyTeamSetupDraftErrorCode,
+	LegacyTeamSetupErrorReason,
 } from "./legacy-team-setup-errors.js";
 export {
 	LEGACY_TEAM_SETUP_API_ERROR_BY_CORE_ERROR,
+	LEGACY_TEAM_SETUP_ERROR_REASONS,
 	legacyTeamSetupApiErrorCode,
 } from "./legacy-team-setup-errors.js";
 export type {

--- a/packages/core/src/legacy-team-setup-completion-manifest.ts
+++ b/packages/core/src/legacy-team-setup-completion-manifest.ts
@@ -77,7 +77,7 @@ class LegacyTeamSetupConfirmationStaleError extends Error {
 	}
 }
 
-class LegacyTeamSetupRosterCapacityError extends Error {
+export class LegacyTeamSetupRosterCapacityError extends Error {
 	readonly code = "team_setup_roster_unavailable" as const;
 
 	constructor() {

--- a/packages/core/src/legacy-team-setup-errors.test.ts
+++ b/packages/core/src/legacy-team-setup-errors.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { LEGACY_TEAM_SETUP_ERROR_REASONS } from "./legacy-team-setup-errors.js";
+
+describe("legacy Team setup diagnostic reasons", () => {
+	it("keeps the exported reason vocabulary stable", () => {
+		expect(LEGACY_TEAM_SETUP_ERROR_REASONS).toEqual([
+			"coordinator_route_missing",
+			"coordinator_rejected_manifest",
+			"coordinator_unreachable",
+			"local_candidate_scan_budget_exceeded",
+			"coordinator_roster_unavailable",
+		]);
+	});
+
+	it("matches the UI client's hand-maintained copy of the vocabulary", () => {
+		// packages/ui cannot import @codemem/core, so it restates this set. Read
+		// the UI source here (Node side) so adding a reason in core without
+		// mirroring it in the client fails the build instead of degrading the
+		// client's parse to `undefined`.
+		const uiSource = readFileSync(new URL("../../ui/src/lib/api/sync.ts", import.meta.url), "utf8");
+		const setLiteral =
+			/export const LEGACY_TEAM_SETUP_ERROR_REASONS = new Set<LegacyTeamSetupErrorReason>\(\[([\s\S]*?)\]\);/u.exec(
+				uiSource,
+			)?.[1];
+		if (!setLiteral) throw new Error("UI Team setup reason vocabulary missing");
+		const uiReasons = [...setLiteral.matchAll(/"([^"]+)"/gu)].map((match) => match[1]);
+
+		expect(uiReasons).toEqual([...LEGACY_TEAM_SETUP_ERROR_REASONS]);
+	});
+});

--- a/packages/core/src/legacy-team-setup-errors.ts
+++ b/packages/core/src/legacy-team-setup-errors.ts
@@ -36,6 +36,16 @@ export type LegacyTeamSetupCoreErrorCode =
 	| "coordinator_completion_response_malformed"
 	| "coordinator_completion_group_mismatch";
 
+export const LEGACY_TEAM_SETUP_ERROR_REASONS = [
+	"coordinator_route_missing",
+	"coordinator_rejected_manifest",
+	"coordinator_unreachable",
+	"local_candidate_scan_budget_exceeded",
+	"coordinator_roster_unavailable",
+] as const;
+
+export type LegacyTeamSetupErrorReason = (typeof LEGACY_TEAM_SETUP_ERROR_REASONS)[number];
+
 /**
  * Stable API compatibility boundary. Core keeps throwing its released strings;
  * API callers translate them through this frozen, bounded vocabulary.

--- a/packages/ui/src/lib/api/sync.test.ts
+++ b/packages/ui/src/lib/api/sync.test.ts
@@ -534,9 +534,14 @@ describe("legacy Team setup API", () => {
 		globalThis.fetch = vi
 			.fn()
 			.mockResolvedValueOnce(
-				new Response(JSON.stringify({ error: "team_setup_roster_changed", detail: "secret" }), {
-					status: 409,
-				}),
+				new Response(
+					JSON.stringify({
+						error: "team_setup_roster_changed",
+						reason: "coordinator_roster_unavailable",
+						detail: "secret",
+					}),
+					{ status: 409 },
+				),
 			)
 			.mockResolvedValueOnce(new Response("private coordinator failure", { status: 500 }))
 			.mockResolvedValueOnce(
@@ -554,6 +559,7 @@ describe("legacy Team setup API", () => {
 		await expect(stable).rejects.toMatchObject({
 			statusCode: 409,
 			errorCode: "team_setup_roster_changed",
+			reason: "coordinator_roster_unavailable",
 			message: "team_setup_roster_changed",
 		});
 		await expect(stable).rejects.toBeInstanceOf(LegacyTeamSetupApiError);

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -1108,6 +1108,13 @@ export type LegacyTeamSetupErrorCode =
 	| "team_setup_completion_invalid"
 	| "team_setup_failed";
 
+export type LegacyTeamSetupErrorReason =
+	| "coordinator_route_missing"
+	| "coordinator_rejected_manifest"
+	| "coordinator_unreachable"
+	| "local_candidate_scan_budget_exceeded"
+	| "coordinator_roster_unavailable";
+
 const LEGACY_TEAM_SETUP_VERSION = 1;
 const LEGACY_TEAM_SETUP_ERROR_CODES = new Set<LegacyTeamSetupErrorCode>([
 	"team_setup_incomplete",
@@ -1120,6 +1127,13 @@ const LEGACY_TEAM_SETUP_ERROR_CODES = new Set<LegacyTeamSetupErrorCode>([
 	"team_setup_completion_conflict",
 	"team_setup_completion_invalid",
 	"team_setup_failed",
+]);
+export const LEGACY_TEAM_SETUP_ERROR_REASONS = new Set<LegacyTeamSetupErrorReason>([
+	"coordinator_route_missing",
+	"coordinator_rejected_manifest",
+	"coordinator_unreachable",
+	"local_candidate_scan_budget_exceeded",
+	"coordinator_roster_unavailable",
 ]);
 const LEGACY_TEAM_SETUP_STATUSES = new Set<LegacyTeamSetupStatusV1>([
 	"needs_setup",
@@ -1473,6 +1487,7 @@ export class LegacyTeamSetupApiError extends Error {
 	constructor(
 		readonly statusCode: number,
 		readonly errorCode: LegacyTeamSetupErrorCode,
+		readonly reason?: LegacyTeamSetupErrorReason,
 	) {
 		super(errorCode);
 		this.name = "LegacyTeamSetupApiError";
@@ -1515,7 +1530,19 @@ async function legacyTeamSetupRequest<T>(
 		const errorCode = LEGACY_TEAM_SETUP_ERROR_CODES.has(submittedCode as LegacyTeamSetupErrorCode)
 			? (submittedCode as LegacyTeamSetupErrorCode)
 			: "team_setup_failed";
-		throw new LegacyTeamSetupApiError(response.status, errorCode);
+		const submittedReason =
+			payload &&
+			typeof payload === "object" &&
+			"reason" in payload &&
+			typeof payload.reason === "string"
+				? payload.reason
+				: "";
+		const reason = LEGACY_TEAM_SETUP_ERROR_REASONS.has(
+			submittedReason as LegacyTeamSetupErrorReason,
+		)
+			? (submittedReason as LegacyTeamSetupErrorReason)
+			: undefined;
+		throw new LegacyTeamSetupApiError(response.status, errorCode, reason);
 	}
 	if (!isPayload(payload)) {
 		throw new LegacyTeamSetupApiError(response.status, "team_setup_failed");

--- a/packages/ui/src/tabs/legacy-team-setup-session.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.test.ts
@@ -729,6 +729,59 @@ describe("legacy Team setup session reducer", () => {
 		});
 	});
 
+	it("describes a local candidate scan budget failure without coordinator guidance", () => {
+		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
+		if (state.status !== "open") throw new Error("expected finish session");
+		const command = state.commands[0];
+		if (command?.kind !== "finish") throw new Error("expected finish command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new LegacyTeamSetupApiError(
+					503,
+					"team_setup_roster_unavailable",
+					"local_candidate_scan_budget_exceeded",
+				),
+			},
+		});
+		if (state.status !== "open") throw new Error("expected failed finish session");
+
+		expect(globalError(state)?.message).toContain(
+			"Retry from a device with less history, or contact support.",
+		);
+		expect(globalError(state)?.message).not.toContain("coordinator connection");
+	});
+
+	it("identifies an older coordinator when the finish route is missing", () => {
+		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
+		if (state.status !== "open") throw new Error("expected finish session");
+		const command = state.commands[0];
+		if (command?.kind !== "finish") throw new Error("expected finish command");
+		state = reduceSetupSession(state, {
+			type: "effect_outcome",
+			outcome: {
+				status: "failure",
+				generation: command.generation,
+				id: command.id,
+				kind: command.kind,
+				cause: new LegacyTeamSetupApiError(
+					503,
+					"team_setup_completion_unavailable",
+					"coordinator_route_missing",
+				),
+			},
+		});
+		if (state.status !== "open") throw new Error("expected failed finish session");
+
+		expect(globalError(state)?.message).toContain(
+			"The coordinator may be running an older version.",
+		);
+	});
+
 	it("uses a plain detail retry when confirmation-stale recovery also fails", () => {
 		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
 		if (state.status !== "open") throw new Error("expected finish session");

--- a/packages/ui/src/tabs/legacy-team-setup-session.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.ts
@@ -82,6 +82,8 @@ const ROSTER_UNAVAILABLE_ERROR =
 	"Team device details are temporarily unavailable. Check the coordinator connection and settings, then refresh.";
 const ROSTER_UNAVAILABLE_AFTER_FINISH_ERROR =
 	"Team device details were unavailable, so setup was not finished and no changes were applied. Check the coordinator connection and settings, then refresh.";
+const LOCAL_SCAN_BUDGET_AFTER_FINISH_ERROR =
+	"This device's Project history is too large to finish setup here, so no changes were applied. Retry from a device with less history, or contact support.";
 const COMPLETION_UNAVAILABLE_ERROR =
 	"Team setup completion could not be checked. Check the coordinator connection and settings, then retry.";
 const COMPLETION_UNAVAILABLE_AFTER_FINISH_ERROR =
@@ -656,7 +658,7 @@ function completionOrChangedMessage(options: {
 	const completionCode = terminalRecoveryCode ?? causeCompletionCode;
 	const completionError =
 		completionCode === "team_setup_completion_unavailable" && command.kind === "finish"
-			? COMPLETION_UNAVAILABLE_AFTER_FINISH_ERROR
+			? completionUnavailableAfterFinishMessage(cause)
 			: completionMessage(completionCode);
 	if (terminalRecoveryCode) {
 		return {
@@ -667,8 +669,14 @@ function completionOrChangedMessage(options: {
 	}
 	if (changed) return { completionCode, message: CHANGED_STATE_ERROR, terminalRecoveryCode };
 	if (rosterUnavailable) {
-		const message =
-			command.kind === "finish" ? ROSTER_UNAVAILABLE_AFTER_FINISH_ERROR : ROSTER_UNAVAILABLE_ERROR;
+		let message = ROSTER_UNAVAILABLE_ERROR;
+		if (command.kind === "finish") {
+			message =
+				cause instanceof LegacyTeamSetupApiError &&
+				cause.reason === "local_candidate_scan_budget_exceeded"
+					? LOCAL_SCAN_BUDGET_AFTER_FINISH_ERROR
+					: ROSTER_UNAVAILABLE_AFTER_FINISH_ERROR;
+		}
 		return { completionCode, message, terminalRecoveryCode };
 	}
 	return {
@@ -676,6 +684,13 @@ function completionOrChangedMessage(options: {
 		message: completionError ?? safeError(command.kind),
 		terminalRecoveryCode,
 	};
+}
+
+function completionUnavailableAfterFinishMessage(cause: unknown): string {
+	if (cause instanceof LegacyTeamSetupApiError && cause.reason === "coordinator_route_missing") {
+		return `${COMPLETION_UNAVAILABLE_AFTER_FINISH_ERROR} The coordinator may be running an older version.`;
+	}
+	return COMPLETION_UNAVAILABLE_AFTER_FINISH_ERROR;
 }
 
 function terminalCompletionCode(

--- a/packages/viewer-server/src/routes/team-setup-view.ts
+++ b/packages/viewer-server/src/routes/team-setup-view.ts
@@ -1,4 +1,8 @@
-import type { LegacyTeamSetupActivationErrorCode, LegacyTeamSetupDraftView } from "@codemem/core";
+import type {
+	LegacyTeamSetupActivationErrorCode,
+	LegacyTeamSetupDraftView,
+	LegacyTeamSetupErrorReason,
+} from "@codemem/core";
 
 export interface LegacyTeamSetupCandidateSummaryV1 {
 	candidateRef: string;
@@ -176,6 +180,7 @@ export type LegacyTeamSetupMutationResponseV1 = LegacyTeamSetupViewV1;
 
 export interface LegacyTeamSetupErrorResponseV1 {
 	error: LegacyTeamSetupActivationErrorCode;
+	reason?: LegacyTeamSetupErrorReason;
 }
 
 export interface LegacyTeamSetupFinishResponseV1 {

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -277,12 +277,44 @@ describe("Team setup finish diagnostics", () => {
 		expect(result.warning).not.toContain("Internal Server Error");
 	});
 
-	it("keeps identifier-shaped remote error codes verbatim", async () => {
+	it("echoes only allowlisted remote error codes verbatim", async () => {
 		const result = await failedFinishResponse({
 			createError: new RemoteCoordinatorRequestError(409, "group_archived"),
 		});
 
 		expect(result.warning).toContain("code=group_archived");
+	});
+
+	it("classifies an identifier-shaped but unknown remote code instead of echoing it", async () => {
+		// A shape check is not an allowlist: a coordinator or proxy that puts a
+		// credential in the JSON `error` field would pass /^[a-z0-9_]+$/ and
+		// land in the log. Only known coordinator codes are echoed.
+		const smuggled = "supersecrettoken";
+		const result = await failedFinishResponse({
+			createError: new RemoteCoordinatorRequestError(403, smuggled),
+		});
+
+		expect(result.warning).toContain("code=unclassified_remote_error");
+		expect(result.warning).not.toContain(smuggled);
+	});
+
+	it("does not label a coordinator roster-size limit as a local scan failure", () => {
+		// Ten sites throw the shared `legacy_team_setup_roster_too_large`
+		// string. Only the typed local scan-budget error means "this device's
+		// history is too large"; the coordinator roster exceeding MAX_DEVICES
+		// throws the same string and must NOT get the local reason, or the UI
+		// tells the user to try another device for a server-side limit.
+		const rosterLimit = new Error("legacy_team_setup_roster_too_large");
+		const localScan = __teamSetupTestHooks.localProjectScanBudgetError();
+
+		expect(__teamSetupTestHooks.finishFailureDetails(rosterLimit)).toEqual({
+			cause: "legacy_team_setup_roster_too_large",
+		});
+		expect(__teamSetupTestHooks.finishFailureDetails(localScan)).toMatchObject({
+			reason: "local_candidate_scan_budget_exceeded",
+		});
+		// Same message, different type: the string alone is not the signal.
+		expect(localScan.message).toBe(rosterLimit.message);
 	});
 
 	it("classifies a missing fresh coordinator roster without changing the API error", async () => {

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -3,9 +3,14 @@ import {
 	deterministicPolicyTeamId,
 	fingerprintPublicKey,
 	getLegacyTeamSetupDraft,
+	type LegacyTeamConfiguredGroupSnapshot,
+	LegacyTeamSetupRosterCapacityError,
 	legacyTeamCandidateId,
 	MemoryStore,
+	RemoteCoordinatorRequestError,
 	readCoordinatorSyncConfig,
+	setLegacyTeamSetupDeviceAssignment,
+	setLegacyTeamSetupDeviceDecision,
 } from "@codemem/core";
 import { describe, expect, it, vi } from "vitest";
 import { syncRoutes } from "./sync.js";
@@ -15,6 +20,241 @@ function createRouteStore(): { store: MemoryStore; close: () => void } {
 	const store = new MemoryStore(":memory:");
 	return { store, close: () => store.close() };
 }
+
+const FINISH_COORDINATOR_ID = "https://coordinator.example.test";
+const FINISH_GROUP_ID = "group-finish-diagnostics";
+const FINISH_CANDIDATE_REF = legacyTeamCandidateId(FINISH_COORDINATOR_ID, FINISH_GROUP_ID);
+const FINISH_ADMIN_SECRET = "finish-diagnostics-admin-secret";
+const FINISH_SNAPSHOTS: LegacyTeamConfiguredGroupSnapshot[] = [
+	{
+		coordinatorId: FINISH_COORDINATOR_ID,
+		groupId: FINISH_GROUP_ID,
+		displayName: "Migration Team",
+		devices: [
+			{
+				deviceId: "device-a",
+				fingerprint: "a".repeat(64),
+				displayName: "Laptop",
+				enabled: true,
+			},
+		],
+	},
+];
+
+async function failedFinishResponse(options: {
+	beforeFinish?: (store: MemoryStore) => void;
+	createError?: Error;
+	freshRosterUnavailable?: boolean;
+	getError?: Error;
+}): Promise<{ status: number; payload: unknown; warning: string }> {
+	const store = new MemoryStore(":memory:");
+	const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+	const app = teamSetupRoutes({
+		getStore: () => store,
+		loadLegacyTeamConfiguredGroupSnapshots: async (loadOptions) =>
+			options.freshRosterUnavailable && loadOptions?.deadlineMs ? [] : FINISH_SNAPSHOTS,
+		snapshotLoaderDependencies: {
+			readConfig: () => ({
+				...readCoordinatorSyncConfig({}),
+				syncCoordinatorUrl: FINISH_COORDINATOR_ID,
+				syncCoordinatorGroups: [FINISH_GROUP_ID],
+				syncCoordinatorAdminSecret: FINISH_ADMIN_SECRET,
+			}),
+			listGroups: vi.fn(async () => []),
+			listDevices: vi.fn(async () => []),
+		},
+		completionDependencies: {
+			create: async ({ manifest }) => {
+				if (options.createError) throw options.createError;
+				return { status: "created", manifest };
+			},
+			...(options.getError
+				? {
+						get: async () => {
+							throw options.getError;
+						},
+					}
+				: {}),
+			list: async () => [],
+		},
+	});
+	try {
+		expect((await app.request("/api/sync/team-setup/v1")).status).toBe(200);
+		store.db
+			.prepare(
+				`INSERT INTO actors(actor_id, display_name, is_local, status, created_at, updated_at)
+				 VALUES ('identity-a', 'Person A', 0, 'active', ?, ?)`,
+			)
+			.run("2026-09-06T00:00:00.000Z", "2026-09-06T00:00:00.000Z");
+		let draft = getLegacyTeamSetupDraft(store.db, FINISH_CANDIDATE_REF);
+		if (!draft) throw new Error("Team setup draft missing");
+		const device = draft.devices[0];
+		if (!device) throw new Error("Team setup device missing");
+		draft = setLegacyTeamSetupDeviceAssignment(store.db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			targetIdentityId: "identity-a",
+			expectation: device.expectation,
+			now: "2026-09-06T00:00:00.000Z",
+		});
+		draft = setLegacyTeamSetupDeviceDecision(store.db, {
+			attemptId: draft.attemptId,
+			deviceRef: device.deviceRef,
+			decision: "included",
+			now: "2026-09-06T00:00:00.000Z",
+		});
+		const detail = (await (
+			await app.request(`/api/sync/team-setup/v1/${FINISH_CANDIDATE_REF}`)
+		).json()) as {
+			finishDigest: string;
+			accessDeltaDigest: string;
+			viewerAccessDeltaDigest: string;
+		};
+		warn.mockClear();
+		options.beforeFinish?.(store);
+		const response = await app.request(`/api/sync/team-setup/v1/${FINISH_CANDIDATE_REF}/finish`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				attemptId: draft.attemptId,
+				finishDigest: detail.finishDigest,
+				confirmedAccessDeltaDigest: detail.accessDeltaDigest,
+				confirmedViewerAccessDeltaDigest: detail.viewerAccessDeltaDigest,
+			}),
+		});
+		expect(warn).toHaveBeenCalledTimes(1);
+		return {
+			status: response.status,
+			payload: await response.json(),
+			warning: String(warn.mock.calls[0]?.[0]),
+		};
+	} finally {
+		warn.mockRestore();
+		store.close();
+	}
+}
+
+describe("Team setup finish diagnostics", () => {
+	it.each([
+		{
+			name: "missing coordinator route",
+			error: new RemoteCoordinatorRequestError(404, "non_json_response: Not Found"),
+			status: 503,
+			apiError: "team_setup_completion_unavailable",
+			reason: "coordinator_route_missing",
+			cause: "remote coordinator request failed",
+		},
+		{
+			name: "rejected completion manifest",
+			error: new RemoteCoordinatorRequestError(400, "completion_manifest_invalid"),
+			status: 409,
+			apiError: "team_setup_completion_invalid",
+			reason: "coordinator_rejected_manifest",
+			cause: "remote coordinator request failed",
+		},
+		{
+			name: "unreachable coordinator",
+			error: new TypeError(`fetch failed ${FINISH_ADMIN_SECRET}`),
+			status: 503,
+			apiError: "team_setup_completion_unavailable",
+			reason: "coordinator_unreachable",
+			cause: "fetch failed",
+		},
+		{
+			name: "local candidate scan budget",
+			error: new LegacyTeamSetupRosterCapacityError(),
+			status: 503,
+			apiError: "team_setup_roster_unavailable",
+			reason: "local_candidate_scan_budget_exceeded",
+			cause: "local project candidate scan exceeded budget",
+		},
+	])("returns a stable diagnostic reason for $name", async (testCase) => {
+		const result = await failedFinishResponse({ createError: testCase.error });
+
+		expect(result.status).toBe(testCase.status);
+		expect(result.payload).toEqual({ error: testCase.apiError, reason: testCase.reason });
+		expect(result.warning).toContain(FINISH_CANDIDATE_REF);
+		expect(result.warning).toContain("attemptId=legacy-team-attempt:");
+		expect(result.warning).toContain(testCase.cause);
+		expect(result.warning).toContain(`reason=${testCase.reason}`);
+		expect(result.warning).not.toMatch(/[\r\n]/u);
+		if (testCase.error instanceof RemoteCoordinatorRequestError) {
+			expect(result.warning).toContain(`status=${testCase.error.status}`);
+			expect(result.warning).toContain(`code=${testCase.error.code}`);
+		}
+		expect(result.warning).not.toContain(FINISH_ADMIN_SECRET);
+	});
+
+	it("does not classify a coordinator resource 404 as a missing route", async () => {
+		const result = await failedFinishResponse({
+			createError: new RemoteCoordinatorRequestError(404, "group_not_found"),
+		});
+
+		expect(result.status).toBe(503);
+		expect(result.payload).toEqual({ error: "team_setup_completion_unavailable" });
+		expect(result.warning).toContain("status=404");
+		expect(result.warning).toContain("code=group_not_found");
+		expect(result.warning).not.toContain("reason=coordinator_route_missing");
+	});
+
+	it("classifies an oversized local project-mapping choice list during finish", async () => {
+		const result = await failedFinishResponse({
+			beforeFinish: (store) => {
+				const insert = store.db.prepare(
+					"INSERT INTO sessions(started_at, project, git_remote) VALUES (?, ?, ?)",
+				);
+				store.db.transaction(() => {
+					for (let index = 0; index <= 500; index += 1) {
+						insert.run(
+							new Date(Date.UTC(2026, 8, 6) + index).toISOString(),
+							`project-${index}`,
+							`https://git.example.test/acme/project-${index}.git`,
+						);
+					}
+				})();
+			},
+		});
+
+		expect(result.status).toBe(503);
+		expect(result.payload).toEqual({
+			error: "team_setup_roster_unavailable",
+			reason: "local_candidate_scan_budget_exceeded",
+		});
+		expect(result.warning).toContain("cause=local project candidate scan exceeded budget");
+		expect(result.warning).not.toContain(FINISH_ADMIN_SECRET);
+	});
+
+	it("redacts the admin secret when completion conflict recovery fails", async () => {
+		const result = await failedFinishResponse({
+			createError: new Error("completion_conflict"),
+			getError: new Error(
+				`recovery failed ${FINISH_ADMIN_SECRET} at https://coordinator.example.test/completions?token=private-token`,
+			),
+		});
+
+		expect(result.status).toBe(503);
+		expect(result.payload).toEqual({ error: "team_setup_completion_unavailable" });
+		expect(result.warning).toContain(
+			"cause=recovery failed [redacted] at https://coordinator.example.test",
+		);
+		expect(result.warning).not.toContain(FINISH_ADMIN_SECRET);
+		expect(result.warning).not.toContain("private-token");
+		expect(result.warning).not.toContain("/completions");
+	});
+
+	it("classifies a missing fresh coordinator roster without changing the API error", async () => {
+		const result = await failedFinishResponse({ freshRosterUnavailable: true });
+
+		expect(result.status).toBe(503);
+		expect(result.payload).toEqual({
+			error: "team_setup_roster_unavailable",
+			reason: "coordinator_roster_unavailable",
+		});
+		expect(result.warning).toContain(FINISH_CANDIDATE_REF);
+		expect(result.warning).toContain("reason=coordinator_roster_unavailable");
+		expect(result.warning).not.toContain(FINISH_ADMIN_SECRET);
+	});
+});
 
 describe("Team setup roster loading", () => {
 	it("rolls back a mutation when response projection fails", () => {

--- a/packages/viewer-server/src/routes/team-setup.test.ts
+++ b/packages/viewer-server/src/routes/team-setup.test.ts
@@ -143,6 +143,7 @@ describe("Team setup finish diagnostics", () => {
 			apiError: "team_setup_completion_unavailable",
 			reason: "coordinator_route_missing",
 			cause: "remote coordinator request failed",
+			loggedCode: "non_json_response",
 		},
 		{
 			name: "rejected completion manifest",
@@ -151,6 +152,7 @@ describe("Team setup finish diagnostics", () => {
 			apiError: "team_setup_completion_invalid",
 			reason: "coordinator_rejected_manifest",
 			cause: "remote coordinator request failed",
+			loggedCode: "completion_manifest_invalid",
 		},
 		{
 			name: "unreachable coordinator",
@@ -158,7 +160,7 @@ describe("Team setup finish diagnostics", () => {
 			status: 503,
 			apiError: "team_setup_completion_unavailable",
 			reason: "coordinator_unreachable",
-			cause: "fetch failed",
+			cause: "fetch_failed",
 		},
 		{
 			name: "local candidate scan budget",
@@ -180,7 +182,7 @@ describe("Team setup finish diagnostics", () => {
 		expect(result.warning).not.toMatch(/[\r\n]/u);
 		if (testCase.error instanceof RemoteCoordinatorRequestError) {
 			expect(result.warning).toContain(`status=${testCase.error.status}`);
-			expect(result.warning).toContain(`code=${testCase.error.code}`);
+			expect(result.warning).toContain(`code=${testCase.loggedCode}`);
 		}
 		expect(result.warning).not.toContain(FINISH_ADMIN_SECRET);
 	});
@@ -234,12 +236,53 @@ describe("Team setup finish diagnostics", () => {
 
 		expect(result.status).toBe(503);
 		expect(result.payload).toEqual({ error: "team_setup_completion_unavailable" });
-		expect(result.warning).toContain(
-			"cause=recovery failed [redacted] at https://coordinator.example.test",
-		);
+		// Free-form error text is never echoed; it is reduced to a classification.
+		expect(result.warning).toContain("cause=unclassified_error:Error");
+		expect(result.warning).not.toContain("recovery failed");
 		expect(result.warning).not.toContain(FINISH_ADMIN_SECRET);
 		expect(result.warning).not.toContain("private-token");
-		expect(result.warning).not.toContain("/completions");
+		expect(result.warning).not.toContain("coordinator.example.test");
+	});
+
+	it("never logs a raw non-JSON coordinator response body", async () => {
+		// The HTTP client folds the first bytes of a non-JSON body into
+		// RemoteCoordinatorRequestError.code. A proxy error page or stack trace
+		// must not reach the log; only a fixed classification may.
+		const hostileBody = `non_json_response: <html><body>Error at /srv/internal/app.js:42 token=${FINISH_ADMIN_SECRET}-leak host=db.internal.corp</body></html>`;
+		const result = await failedFinishResponse({
+			createError: new RemoteCoordinatorRequestError(502, hostileBody),
+		});
+
+		expect(result.status).toBe(503);
+		expect(result.payload).toEqual({ error: "team_setup_completion_unavailable" });
+		expect(result.warning).toContain("status=502");
+		expect(result.warning).toContain("code=non_json_response");
+		expect(result.warning).not.toContain("<html>");
+		expect(result.warning).not.toContain("/srv/internal");
+		expect(result.warning).not.toContain("db.internal.corp");
+		expect(result.warning).not.toContain(FINISH_ADMIN_SECRET);
+		expect(result.warning).not.toContain("-leak");
+	});
+
+	it("reduces a non-identifier remote error code to a fixed classification", async () => {
+		const result = await failedFinishResponse({
+			createError: new RemoteCoordinatorRequestError(
+				500,
+				"Internal Server Error: see /var/log/coordinator.log",
+			),
+		});
+
+		expect(result.warning).toContain("code=unclassified_remote_error");
+		expect(result.warning).not.toContain("/var/log");
+		expect(result.warning).not.toContain("Internal Server Error");
+	});
+
+	it("keeps identifier-shaped remote error codes verbatim", async () => {
+		const result = await failedFinishResponse({
+			createError: new RemoteCoordinatorRequestError(409, "group_archived"),
+		});
+
+		expect(result.warning).toContain("code=group_archived");
 	});
 
 	it("classifies a missing fresh coordinator roster without changing the API error", async () => {

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -7,6 +7,7 @@ import type {
 	LegacyTeamSetupActivationErrorCode,
 	LegacyTeamSetupActivationResultV1,
 	LegacyTeamSetupDraftView,
+	LegacyTeamSetupErrorReason,
 	MemoryStore,
 } from "@codemem/core";
 import {
@@ -34,6 +35,7 @@ import {
 	isLegacyTeamCandidateSelectable,
 	isLegacyTeamSetupProjectMappingIdentity,
 	LegacyTeamSetupAdditiveConvergenceError,
+	LegacyTeamSetupRosterCapacityError,
 	legacyTeamCandidateId,
 	legacyTeamCandidateProjectInventory,
 	legacyTeamCanonicalProjectRef,
@@ -42,6 +44,7 @@ import {
 	legacyTeamSetupApiErrorCode,
 	listProjectScopeCandidates,
 	previewLegacyTeamSetupActivation,
+	RemoteCoordinatorRequestError,
 	readCoordinatorSyncConfig,
 	recipientPolicyDigest,
 	reconstructLegacyTeamSetupCompletionManifest,
@@ -1198,6 +1201,145 @@ function apiErrorCode(error: unknown): LegacyTeamSetupActivationErrorCode {
 function completionApiError(error: unknown): LegacyTeamSetupActivationErrorCode {
 	const code = legacyTeamSetupApiErrorCode(error);
 	return code === "team_setup_failed" ? "team_setup_completion_unavailable" : code;
+}
+
+class TeamSetupFinishError extends Error {
+	constructor(
+		code: LegacyTeamSetupActivationErrorCode,
+		readonly reason: LegacyTeamSetupErrorReason | undefined,
+		readonly alreadyLogged: boolean,
+		cause?: unknown,
+	) {
+		super(code, cause === undefined ? undefined : { cause });
+		this.name = "TeamSetupFinishError";
+	}
+}
+
+interface TeamSetupFinishFailureDetails {
+	reason?: LegacyTeamSetupErrorReason;
+	cause: string;
+	status?: number;
+	code?: string;
+}
+
+const LOCAL_CANDIDATE_SCAN_BUDGET_ERRORS = new Set([
+	"legacy_team_setup_roster_too_large",
+	"project_scope_candidate_scan_too_large",
+	"project_scope_candidate_metadata_too_large",
+]);
+
+function errorChain(error: unknown): unknown[] {
+	const chain: unknown[] = [];
+	let current = error;
+	while (current && !chain.includes(current)) {
+		chain.push(current);
+		current = current instanceof Error ? current.cause : undefined;
+	}
+	return chain;
+}
+
+function teamSetupFinishFailureDetails(error: unknown): TeamSetupFinishFailureDetails {
+	const chain = errorChain(error);
+	const wrapper = chain.find(
+		(item): item is TeamSetupFinishError => item instanceof TeamSetupFinishError,
+	);
+	const remote = chain.find(
+		(item): item is RemoteCoordinatorRequestError => item instanceof RemoteCoordinatorRequestError,
+	);
+	if (remote) {
+		let reason = wrapper?.reason;
+		if (
+			remote.status === 404 &&
+			(remote.code === "not_found" || remote.code.startsWith("non_json"))
+		) {
+			reason = "coordinator_route_missing";
+		}
+		if (remote.status === 400 && remote.code === "completion_manifest_invalid") {
+			reason = "coordinator_rejected_manifest";
+		}
+		return {
+			...(reason ? { reason } : {}),
+			cause: "remote coordinator request failed",
+			status: remote.status,
+			code: remote.code,
+		};
+	}
+	if (
+		chain.some(
+			(item) =>
+				item instanceof LegacyTeamSetupRosterCapacityError ||
+				(item instanceof Error && LOCAL_CANDIDATE_SCAN_BUDGET_ERRORS.has(item.message)),
+		)
+	) {
+		return {
+			reason: "local_candidate_scan_budget_exceeded",
+			cause: "local project candidate scan exceeded budget",
+		};
+	}
+	const errorCause = chain.find(
+		(item): item is Error => item instanceof Error && !(item instanceof TeamSetupFinishError),
+	);
+	if (wrapper?.reason) {
+		return { reason: wrapper.reason, cause: errorCause?.message ?? String(error) };
+	}
+	if (
+		errorCause &&
+		(errorCause.name === "AbortError" ||
+			errorCause.name === "TimeoutError" ||
+			/fetch failed|timed out|timeout/iu.test(errorCause.message))
+	) {
+		return { reason: "coordinator_unreachable", cause: errorCause.message };
+	}
+	return { cause: errorCause?.message ?? String(error) };
+}
+
+function warnTeamSetupFinishFailure(
+	error: unknown,
+	details: TeamSetupFinishFailureDetails,
+	context: {
+		candidateRef: string;
+		attemptId: string;
+		apiCode: LegacyTeamSetupActivationErrorCode;
+		redactValues?: readonly string[];
+	},
+): void {
+	if (
+		errorChain(error).some((item) => item instanceof TeamSetupFinishError && item.alreadyLogged)
+	) {
+		return;
+	}
+	const safe = (value: string | number): string => {
+		let sanitized = String(value).replace(/[\r\n\t]+/gu, " ");
+		for (const secret of context.redactValues ?? []) {
+			if (secret) sanitized = sanitized.replaceAll(secret, "[redacted]");
+		}
+		return sanitized.replace(/https?:\/\/[^\s]+/giu, (value) => {
+			try {
+				const url = new URL(value);
+				return `${url.protocol}//${url.host}`;
+			} catch {
+				return "[redacted-url]";
+			}
+		});
+	};
+	const fields = [
+		`candidateRef=${safe(context.candidateRef)}`,
+		`attemptId=${safe(context.attemptId)}`,
+		`apiCode=${safe(context.apiCode)}`,
+		`cause=${safe(details.cause)}`,
+		...(details.reason ? [`reason=${safe(details.reason)}`] : []),
+		...(details.status == null ? [] : [`status=${safe(details.status)}`]),
+		...(details.code == null ? [] : [`code=${safe(details.code)}`]),
+	];
+	console.warn(`[team-setup finish] ${fields.join(" ")}`);
+}
+
+function finishErrorResponse(
+	code: LegacyTeamSetupActivationErrorCode,
+	details: TeamSetupFinishFailureDetails,
+): { error: LegacyTeamSetupActivationErrorCode; reason?: LegacyTeamSetupErrorReason } {
+	const reason = details.reason;
+	return reason ? { error: code, reason } : { error: code };
 }
 
 type BoundedJsonResult = { ok: true; value: Record<string, unknown> } | { ok: false };
@@ -2409,6 +2551,7 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 		let releaseMutation: (() => void) | undefined;
 		let releasePublicationMutation: (() => void) | undefined;
 		let releaseActorMutations: (() => void) | undefined;
+		let finishLogRedactValues: readonly string[] = [];
 		try {
 			const store = options.getStore();
 			const draft = getLegacyTeamSetupDraft(store.db, candidateRef);
@@ -2511,12 +2654,20 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 							throw new Error("team_setup_completion_invalid");
 						}
 						const { config, remoteUrl } = authorization;
+						finishLogRedactValues = [config.syncCoordinatorAdminSecret];
 						const freshGroup = await loadFreshGroupSnapshot(
 							group,
 							remoteUrl,
 							publicationDeadlineMs,
 						);
-						if (!freshGroup) throw new Error("team_setup_roster_unavailable");
+						if (!freshGroup) {
+							throw new TeamSetupFinishError(
+								"team_setup_roster_unavailable",
+								"coordinator_roster_unavailable",
+								false,
+								new Error("coordinator roster unavailable"),
+							);
+						}
 						if (!stillAuthorizesGroup(authorization, group)) {
 							throw new Error("team_setup_completion_invalid");
 						}
@@ -2588,9 +2739,16 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 							}
 						} catch (error) {
 							const code = completionApiError(error);
+							const details = teamSetupFinishFailureDetails(error);
 							const getCompletion = completionDependencies.get;
 							if (code !== "team_setup_completion_conflict" || !getCompletion) {
-								throw new Error(code);
+								warnTeamSetupFinishFailure(error, details, {
+									candidateRef,
+									attemptId,
+									apiCode: code,
+									redactValues: finishLogRedactValues,
+								});
+								throw new TeamSetupFinishError(code, details.reason, true, error);
 							}
 							try {
 								const existing = await retryTransientCoordinatorRead(
@@ -2617,7 +2775,12 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 									throw new Error("team_setup_completion_conflict");
 								}
 							} catch (recoveryError) {
-								throw new Error(completionApiError(recoveryError));
+								throw new TeamSetupFinishError(
+									completionApiError(recoveryError),
+									teamSetupFinishFailureDetails(recoveryError).reason,
+									false,
+									recoveryError,
+								);
 							}
 						}
 						// Publication is the commit point. Apply its immutable winner after binding
@@ -2632,11 +2795,23 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 							);
 						} catch (error) {
 							if (legacyTeamSetupApiErrorCode(error) === "team_setup_completion_invalid") {
-								throw new Error("team_setup_roster_unavailable");
+								throw new TeamSetupFinishError(
+									"team_setup_roster_unavailable",
+									"coordinator_roster_unavailable",
+									false,
+									error,
+								);
 							}
 							throw error;
 						}
-						if (!postPublicationGroup) throw new Error("team_setup_roster_unavailable");
+						if (!postPublicationGroup) {
+							throw new TeamSetupFinishError(
+								"team_setup_roster_unavailable",
+								"coordinator_roster_unavailable",
+								false,
+								new Error("coordinator roster unavailable"),
+							);
+						}
 						const result = await applyLegacyTeamSetupCompletionManifestAndReturnActivation(
 							store.db,
 							{
@@ -2658,7 +2833,14 @@ export function teamSetupRoutes(options: TeamSetupRoutesOptions): Hono {
 			return response;
 		} catch (error) {
 			const code = apiErrorCode(error);
-			return c.json({ error: code }, errorStatus(code));
+			const details = teamSetupFinishFailureDetails(error);
+			warnTeamSetupFinishFailure(error, details, {
+				candidateRef,
+				attemptId,
+				apiCode: code,
+				redactValues: finishLogRedactValues,
+			});
+			return c.json(finishErrorResponse(code, details), errorStatus(code));
 		} finally {
 			releaseActorMutations?.();
 			releasePublicationMutation?.();

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -1228,6 +1228,35 @@ const LOCAL_CANDIDATE_SCAN_BUDGET_ERRORS = new Set([
 	"project_scope_candidate_metadata_too_large",
 ]);
 
+/**
+ * Only identifier-shaped remote error codes are safe to log verbatim. A
+ * coordinator that returns a non-JSON body (error page, proxy interstitial)
+ * has its first response bytes folded into `RemoteCoordinatorRequestError.code`
+ * by the HTTP client, and those bytes can carry anything: stack traces,
+ * internal hostnames, tokens. Anything that is not a bare snake_case token is
+ * reduced to a fixed classification.
+ */
+const SAFE_REMOTE_ERROR_CODE = /^[a-z][a-z0-9_]{0,63}$/u;
+
+function loggableRemoteCode(code: string): string {
+	if (SAFE_REMOTE_ERROR_CODE.test(code)) return code;
+	if (code.startsWith("non_json_response")) return "non_json_response";
+	return "unclassified_remote_error";
+}
+
+/**
+ * Local error messages are code-controlled identifiers except for transport
+ * failures, whose messages come from undici/fetch and can embed the target
+ * URL or system detail. Keep identifiers; classify everything else.
+ */
+function loggableLocalCause(error: Error): string {
+	if (SAFE_REMOTE_ERROR_CODE.test(error.message)) return error.message;
+	if (error.name === "AbortError" || error.name === "TimeoutError") return error.name;
+	if (/fetch failed/iu.test(error.message)) return "fetch_failed";
+	if (/timed out|timeout/iu.test(error.message)) return "timed_out";
+	return `unclassified_error:${error.name || "Error"}`;
+}
+
 function errorChain(error: unknown): unknown[] {
 	const chain: unknown[] = [];
 	let current = error;
@@ -1236,6 +1265,22 @@ function errorChain(error: unknown): unknown[] {
 		current = current instanceof Error ? current.cause : undefined;
 	}
 	return chain;
+}
+
+function remoteFailureReason(
+	remote: RemoteCoordinatorRequestError,
+	fallback: LegacyTeamSetupErrorReason | undefined,
+): LegacyTeamSetupErrorReason | undefined {
+	if (
+		remote.status === 404 &&
+		(remote.code === "not_found" || remote.code.startsWith("non_json"))
+	) {
+		return "coordinator_route_missing";
+	}
+	if (remote.status === 400 && remote.code === "completion_manifest_invalid") {
+		return "coordinator_rejected_manifest";
+	}
+	return fallback;
 }
 
 function teamSetupFinishFailureDetails(error: unknown): TeamSetupFinishFailureDetails {
@@ -1247,21 +1292,12 @@ function teamSetupFinishFailureDetails(error: unknown): TeamSetupFinishFailureDe
 		(item): item is RemoteCoordinatorRequestError => item instanceof RemoteCoordinatorRequestError,
 	);
 	if (remote) {
-		let reason = wrapper?.reason;
-		if (
-			remote.status === 404 &&
-			(remote.code === "not_found" || remote.code.startsWith("non_json"))
-		) {
-			reason = "coordinator_route_missing";
-		}
-		if (remote.status === 400 && remote.code === "completion_manifest_invalid") {
-			reason = "coordinator_rejected_manifest";
-		}
+		const reason = remoteFailureReason(remote, wrapper?.reason);
 		return {
 			...(reason ? { reason } : {}),
 			cause: "remote coordinator request failed",
 			status: remote.status,
-			code: remote.code,
+			code: loggableRemoteCode(remote.code),
 		};
 	}
 	if (
@@ -1279,18 +1315,17 @@ function teamSetupFinishFailureDetails(error: unknown): TeamSetupFinishFailureDe
 	const errorCause = chain.find(
 		(item): item is Error => item instanceof Error && !(item instanceof TeamSetupFinishError),
 	);
-	if (wrapper?.reason) {
-		return { reason: wrapper.reason, cause: errorCause?.message ?? String(error) };
-	}
+	const cause = errorCause ? loggableLocalCause(errorCause) : "unclassified_non_error";
+	if (wrapper?.reason) return { reason: wrapper.reason, cause };
 	if (
 		errorCause &&
 		(errorCause.name === "AbortError" ||
 			errorCause.name === "TimeoutError" ||
 			/fetch failed|timed out|timeout/iu.test(errorCause.message))
 	) {
-		return { reason: "coordinator_unreachable", cause: errorCause.message };
+		return { reason: "coordinator_unreachable", cause };
 	}
-	return { cause: errorCause?.message ?? String(error) };
+	return { cause };
 }
 
 function warnTeamSetupFinishFailure(

--- a/packages/viewer-server/src/routes/team-setup.ts
+++ b/packages/viewer-server/src/routes/team-setup.ts
@@ -989,6 +989,9 @@ export const __teamSetupTestHooks = {
 	disambiguateChoiceLabels,
 	safeChoiceLabel,
 	viewerSafeAccessDelta,
+	// Lazy: the classifier and its typed error are declared below this object.
+	finishFailureDetails: (error: unknown) => teamSetupFinishFailureDetails(error),
+	localProjectScanBudgetError: (cause?: unknown) => new LocalProjectScanBudgetError(cause),
 };
 
 interface IdentityChoiceInternal extends LegacyTeamSetupIdentityChoiceV1 {
@@ -1081,12 +1084,12 @@ function projectMappingChoices(store: MemoryStore): ProjectMappingChoiceInternal
 			(error.message === "project_scope_candidate_scan_too_large" ||
 				error.message === "project_scope_candidate_metadata_too_large")
 		) {
-			throw new Error("legacy_team_setup_roster_too_large");
+			throw new LocalProjectScanBudgetError(error);
 		}
 		throw error;
 	}
 	if (candidates.length > MAX_PROJECT_MAPPING_CHOICES) {
-		throw new Error("legacy_team_setup_roster_too_large");
+		throw new LocalProjectScanBudgetError();
 	}
 	return candidates.map((candidate) => ({
 		projectIdentity: candidate.workspace_identity,
@@ -1222,35 +1225,70 @@ interface TeamSetupFinishFailureDetails {
 	code?: string;
 }
 
-const LOCAL_CANDIDATE_SCAN_BUDGET_ERRORS = new Set([
-	"legacy_team_setup_roster_too_large",
-	"project_scope_candidate_scan_too_large",
-	"project_scope_candidate_metadata_too_large",
-]);
+/**
+ * The generic `legacy_team_setup_roster_too_large` string is thrown by ten
+ * sites for unrelated limits (coordinator roster size, draft device count,
+ * local project choices). Only the local project-candidate scan is a
+ * "this device's history is too large" condition, so it carries a distinct
+ * type. The message is kept identical so the frozen API-code mapping and every
+ * existing caller that matches on it are unchanged.
+ */
+class LocalProjectScanBudgetError extends Error {
+	constructor(cause?: unknown) {
+		super("legacy_team_setup_roster_too_large", cause === undefined ? undefined : { cause });
+		this.name = "LocalProjectScanBudgetError";
+	}
+}
 
 /**
- * Only identifier-shaped remote error codes are safe to log verbatim. A
- * coordinator that returns a non-JSON body (error page, proxy interstitial)
- * has its first response bytes folded into `RemoteCoordinatorRequestError.code`
- * by the HTTP client, and those bytes can carry anything: stack traces,
- * internal hostnames, tokens. Anything that is not a bare snake_case token is
- * reduced to a fixed classification.
+ * Remote error codes the finish path can legitimately receive from the
+ * coordinator. Anything else — including identifier-shaped values, which a
+ * hostile or misconfigured upstream could use to smuggle a credential through
+ * a JSON `error` field — is reduced to a fixed classification before logging.
+ * A shape check is not an allowlist; only this set is echoed verbatim.
  */
-const SAFE_REMOTE_ERROR_CODE = /^[a-z][a-z0-9_]{0,63}$/u;
+const LOGGABLE_REMOTE_ERROR_CODES = new Set([
+	"body_too_large",
+	"completion_manifest_invalid",
+	"completion_manifest_unavailable",
+	"completion_not_found",
+	"completion_query_invalid",
+	"group_archived",
+	"group_id_and_candidate_ref_required",
+	"group_not_found",
+	"invalid_json",
+	"missing_admin_header",
+	"not_found",
+	"rate_limited",
+	"response_too_large",
+	"unauthorized",
+]);
 
 function loggableRemoteCode(code: string): string {
-	if (SAFE_REMOTE_ERROR_CODE.test(code)) return code;
+	if (LOGGABLE_REMOTE_ERROR_CODES.has(code)) return code;
 	if (code.startsWith("non_json_response")) return "non_json_response";
 	return "unclassified_remote_error";
 }
 
 /**
- * Local error messages are code-controlled identifiers except for transport
- * failures, whose messages come from undici/fetch and can embed the target
- * URL or system detail. Keep identifiers; classify everything else.
+ * Local causes the finish path can produce. Same allowlist discipline as
+ * remote codes: everything else, including transport messages that embed the
+ * target URL, is classified rather than echoed.
  */
+const LOGGABLE_LOCAL_CAUSES = new Set([
+	"completion_conflict",
+	"legacy_team_setup_roster_too_large",
+	"project_scope_candidate_metadata_too_large",
+	"project_scope_candidate_scan_too_large",
+	"team_setup_completion_conflict",
+	"team_setup_completion_invalid",
+	"team_setup_completion_unavailable",
+	"team_setup_confirmation_stale",
+	"team_setup_roster_unavailable",
+]);
+
 function loggableLocalCause(error: Error): string {
-	if (SAFE_REMOTE_ERROR_CODE.test(error.message)) return error.message;
+	if (LOGGABLE_LOCAL_CAUSES.has(error.message)) return error.message;
 	if (error.name === "AbortError" || error.name === "TimeoutError") return error.name;
 	if (/fetch failed/iu.test(error.message)) return "fetch_failed";
 	if (/timed out|timeout/iu.test(error.message)) return "timed_out";
@@ -1300,11 +1338,14 @@ function teamSetupFinishFailureDetails(error: unknown): TeamSetupFinishFailureDe
 			code: loggableRemoteCode(remote.code),
 		};
 	}
+	// Only typed scan-budget errors mean "this device's history is too large".
+	// The shared roster_too_large string also fires for coordinator roster size
+	// and draft device count, which are not local conditions.
 	if (
 		chain.some(
 			(item) =>
 				item instanceof LegacyTeamSetupRosterCapacityError ||
-				(item instanceof Error && LOCAL_CANDIDATE_SCAN_BUDGET_ERRORS.has(item.message)),
+				item instanceof LocalProjectScanBudgetError,
 		)
 	) {
 		return {


### PR DESCRIPTION
## Description
Closes codemem-g90j. Stacked on #1638.

During v0.44 alpha dogfood, three unrelated defects (stale coordinator deploy → bare 404; NULL `coordinator_id` → remote 400; local scan-cap throw) all surfaced as the same "Team setup could not be confirmed" message. The finish route discarded the cause at two catch sites with no logging. Diagnosis required instrumenting source three times.

**What changes:**
- **Server log at both catch sites.** One `console.warn("[team-setup finish] …")` per failure with candidateRef, attemptId, API code, and a cause classification. Deduplicated: the inner catch marks `alreadyLogged` so the outer does not double-log. Admin secret, tokens, and URL query/userinfo are redacted; the redaction list is hoisted to handler scope so the recovery and roster paths are covered too.
- **Additive `reason` field on error JSON** from a closed vocabulary in `legacy-team-setup-errors.ts`: `coordinator_route_missing`, `coordinator_rejected_manifest`, `coordinator_unreachable`, `local_candidate_scan_budget_exceeded`, `coordinator_roster_unavailable`. Omitted when unclassified. The frozen `error` vocabulary and status codes are unchanged; existing clients ignore `reason`.
- **Cause preserved through the inner catch** via `TeamSetupFinishError` with `.cause`, so `RemoteCoordinatorRequestError.status/.code` reach the classifier. `coordinator_route_missing` requires 404 **and** `non_json_response` (what an unregistered Hono route returns); domain 404s like `group_not_found` stay unclassified rather than mislabeled as a stale deploy.
- **UI copy.** `local_candidate_scan_budget_exceeded` no longer says "Check the coordinator connection" — it is local. `coordinator_route_missing` appends "The coordinator may be running an older version."
- **Vocabulary parity test** in core reads the UI's hand-maintained `Set` literal (UI cannot import core) and fails the build if they drift.

## Type of Change
- [x] 🐛 Bug fix
- [ ] 🚀 Feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance
- [ ] 🧪 Testing

## Testing
- [x] 152 tests across team-setup routes, legacy-team-setup-session, legacy-team-setup-errors, ui sync API
- [x] `pnpm run tsc`, `pnpm --filter @codemem/ui build`, Biome (organizeImports clean; pre-existing warnings only), `git diff --check`
- [x] Regressions: each reason reachable by exactly one path; same `error` code as before for each input; `reason` omitted (not null) when unclassified; scan-cap via `projectMappingChoices` reaches the finish catch; recovery-path failure with embedded secret logs `[redacted]` through the OUTER catch; `warn` called exactly once per failure; parity test fails on a bogus UI reason
- [ ] Full workspace suite not rerun for this PR
- [ ] Docs: neither plugin-reference nor user-guide documents this response shape; skipped

## Checklist
- [x] Self-review
- [x] Independent CodeReviewer: 3 blockers + 2 fixes found and addressed (unclassified local scan path; unredacted outer catch; 404 mislabel; organizeImports; UI/core vocabulary drift)
- [x] No new warnings introduced