### PR TITLE
ci(release): verify npm latest never points at a prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,20 @@ jobs:
           publish_if_missing "codemem" "packages/cli"
           publish_if_missing "@codemem/opencode-plugin" "packages/opencode-plugin"
 
+      - name: Verify latest dist-tag is absent or stable
+        # npm assigns `latest` to a package's first-ever version regardless of
+        # --tag, so a brand-new package whose debut is a prerelease exposes that
+        # prerelease to untagged installs. OIDC trusted publishing only grants
+        # publish, not dist-tag mutation, so this step cannot fix it; it
+        # reports. The manual fix is in docs/versioning.md under "First
+        # publication of a new package". Warning-only until every published
+        # package is clean, then flip continue-on-error to false.
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          node scripts/release-latest-guard.mjs \
+            @codemem/embeddings @codemem/core @codemem/mcp @codemem/server codemem @codemem/opencode-plugin
+
   release:
     name: Create GitHub Release
     needs: [publish-npm]

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -45,6 +45,18 @@ Keep `.opencode/.npmrc` pinned to the public npm registry:
 
 - `registry=https://registry.npmjs.org/`
 
+### First publication of a new package
+
+npm sets `latest` on a package's first-ever version regardless of `--tag`. A new package whose debut is a prerelease therefore exposes that prerelease to untagged installs (`npm install <pkg>`).
+
+The release workflow cannot fix this automatically: OIDC trusted publishing grants `publish` only, not dist-tag mutation. Instead, a post-publish step runs `scripts/release-latest-guard.mjs` in verify mode and reports any package whose `latest` points at a prerelease. Fix it once, by hand, from a machine with an npm login:
+
+```fish
+node scripts/release-latest-guard.mjs --apply <package>
+```
+
+The guard only removes; it never adds or moves `latest`, so an established package's stable `latest` is untouched. Until a package's first stable release, untagged installs of it correctly fail with "no matching version". The verify step is `continue-on-error` while any package is still dirty; flip it to a hard gate once the guard reports clean.
+
 ## Release tag preflight
 
 Before creating or pushing a release tag, run:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "pnpm exec vitest run",
     "test:watch": "pnpm exec vitest",
     "test:ci-workflow": "node --test scripts/ci-workflow.test.mjs",
-    "test:release": "node --test scripts/release-version.test.mjs scripts/release-tag-preflight.test.mjs scripts/release-workflow.test.mjs",
+    "test:release": "node --test scripts/release-version.test.mjs scripts/release-tag-preflight.test.mjs scripts/release-workflow.test.mjs scripts/release-latest-guard.test.mjs",
     "test:adapter-normalizers": "node --test scripts/build-adapter-normalizers.test.mjs",
     "test:release-version": "node --test scripts/release-version.test.mjs",
     "test:release-tag-preflight": "node --test scripts/release-tag-preflight.test.mjs",

--- a/packages/cloudflare-coordinator-worker/package.json
+++ b/packages/cloudflare-coordinator-worker/package.json
@@ -5,8 +5,9 @@
 	"type": "module",
 	"scripts": {
 		"clean": "rm -rf dist tsconfig.tsbuildinfo",
-		"build": "pnpm exec vite build && pnpm run check:bundle && pnpm exec tsc --build",
-		"check:bundle": "pnpm --filter @codemem/core build && node --test scripts/assert-worker-bundle-clean.test.mjs && rm -rf ../../.tmp/cloudflare-coordinator-worker-bundle && pnpm exec wrangler deploy --dry-run --config wrangler.jsonc --outdir ../../.tmp/cloudflare-coordinator-worker-bundle --metafile ../../.tmp/cloudflare-coordinator-worker-bundle/meta.json && node scripts/assert-worker-bundle-clean.mjs ../../.tmp/cloudflare-coordinator-worker-bundle ../../.tmp/cloudflare-coordinator-worker-bundle/meta.json",
+		"build": "pnpm exec vite build && pnpm run check:bundle:prepared && pnpm exec tsc --build",
+		"check:bundle": "pnpm --filter @codemem/core build && pnpm run check:bundle:prepared",
+		"check:bundle:prepared": "node --test scripts/assert-worker-bundle-clean.test.mjs && rm -rf ../../.tmp/cloudflare-coordinator-worker-bundle && pnpm exec wrangler deploy --dry-run --config wrangler.jsonc --outdir ../../.tmp/cloudflare-coordinator-worker-bundle --metafile ../../.tmp/cloudflare-coordinator-worker-bundle/meta.json && node scripts/assert-worker-bundle-clean.mjs ../../.tmp/cloudflare-coordinator-worker-bundle ../../.tmp/cloudflare-coordinator-worker-bundle/meta.json",
 		"typecheck": "pnpm exec tsc --build",
 		"test:node": "pnpm exec vitest run --config vitest.node.config.ts src/index.test.ts",
 		"test:worker": "pnpm run check:bundle && pnpm run test:node && pnpm exec vitest run --config vitest.config.ts test/worker.integration.test.ts"

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -7,6 +7,12 @@ const fullE2eWorkflow = readFileSync(
 	new URL("../.github/workflows/e2e-full.yml", import.meta.url),
 	"utf8",
 );
+const workerPackage = JSON.parse(
+	readFileSync(
+		new URL("../packages/cloudflare-coordinator-worker/package.json", import.meta.url),
+		"utf8",
+	),
+);
 const githubExpressionOpen = ["$", "{", "{"].join("");
 
 function getTopLevelBlock(workflow, key) {
@@ -57,6 +63,12 @@ const specializedScenarios = [
 ];
 
 describe("normal CI workflow source contract", () => {
+	it("does not rebuild workspace dependencies from the Worker build", () => {
+		assert.match(workerPackage.scripts.build, /pnpm run check:bundle:prepared/u);
+		assert.doesNotMatch(workerPackage.scripts.build, /pnpm run check:bundle(?:\s|$)/u);
+		assert.match(workerPackage.scripts["check:bundle"], /pnpm --filter @codemem\/core build/u);
+	});
+
 	it("contains only main push, default pull request, and workflow call triggers", () => {
 		assert.equal(
 			getTopLevelBlock(ciWorkflow, "on"),

--- a/scripts/release-latest-guard.mjs
+++ b/scripts/release-latest-guard.mjs
@@ -1,0 +1,118 @@
+/**
+ * Guard the npm `latest` dist-tag against prerelease leakage.
+ *
+ * npm assigns `latest` to the first-ever version of a package regardless of
+ * `--tag`. A new package whose first publication is a prerelease therefore
+ * exposes that prerelease to `npm install <pkg>` with no tag. This script
+ * inspects a package's live dist-tags and reports whether `latest` must be
+ * removed. It only ever removes; it never adds or moves `latest`.
+ */
+import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PRERELEASE_VERSION = /^\d+\.\d+\.\d+-[0-9A-Za-z.+-]+$/;
+
+export function isPrereleaseVersion(version) {
+	return PRERELEASE_VERSION.test(version);
+}
+
+/**
+ * Decide what to do about a package's `latest` dist-tag.
+ *
+ * Returns `remove` only when `latest` points at a prerelease — the exact
+ * shape npm's first-publish behavior produces. A stable `latest` is never
+ * touched even during a prerelease publish, and an absent `latest` is fine.
+ */
+export function latestGuardAction(distTags) {
+	const latest = distTags?.latest;
+	if (latest == null || latest === "") return { action: "none", reason: "latest absent" };
+	if (!isPrereleaseVersion(latest)) {
+		return { action: "none", reason: `latest is stable ${latest}` };
+	}
+	return { action: "remove", reason: `latest points at prerelease ${latest}` };
+}
+
+/**
+ * Read a package's live dist-tags. An unpublished package (E404) has no
+ * `latest` and therefore nothing to guard; it reads as `{}` rather than an
+ * error so the guard can run before a new package's first publish.
+ */
+export function readDistTags(packageName, { spawn = spawnSync } = {}) {
+	const result = spawn("npm", ["view", packageName, "dist-tags", "--json"], {
+		encoding: "utf8",
+	});
+	if (result.status !== 0) {
+		if (/E404|404 Not Found/u.test(result.stderr ?? "")) return {};
+		throw new Error(`npm view ${packageName} dist-tags failed: ${(result.stderr ?? "").trim()}`);
+	}
+	const parsed = JSON.parse(result.stdout);
+	// npm returns an array when the spec resolves to multiple versions; a
+	// bare package name resolves to one object.
+	return Array.isArray(parsed) ? (parsed[0] ?? {}) : parsed;
+}
+
+export function removeLatest(packageName, { spawn = spawnSync } = {}) {
+	const result = spawn("npm", ["dist-tag", "rm", packageName, "latest"], {
+		encoding: "utf8",
+		stdio: ["ignore", "inherit", "inherit"],
+	});
+	if (result.status !== 0) throw new Error(`npm dist-tag rm ${packageName} latest failed`);
+}
+
+/**
+ * Inspect every package and, with `apply`, remove a prerelease `latest`.
+ *
+ * Every package is inspected even if an earlier one fails, so the operator
+ * sees the full picture from one run; failures are collected and thrown
+ * together at the end. Returns how many packages needed action, whether or
+ * not it was applied, so a dry run can fail a verify step without touching
+ * the registry.
+ */
+export function guardPackages(packageNames, { apply, log = console.log, spawn = spawnSync } = {}) {
+	let needingAction = 0;
+	const failures = [];
+	for (const packageName of packageNames) {
+		try {
+			const distTags = readDistTags(packageName, { spawn });
+			const decision = latestGuardAction(distTags);
+			log(`${packageName}: ${decision.action} (${decision.reason})`);
+			if (decision.action !== "remove") continue;
+			needingAction += 1;
+			if (apply) removeLatest(packageName, { spawn });
+		} catch (error) {
+			failures.push(`${packageName}: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+	if (failures.length > 0) throw new Error(`latest-tag guard failures:\n${failures.join("\n")}`);
+	return needingAction;
+}
+
+if (
+	process.argv[1] &&
+	realpathSync(fileURLToPath(import.meta.url)) === realpathSync(resolve(process.argv[1]))
+) {
+	const args = process.argv.slice(2);
+	const flags = args.filter((arg) => arg.startsWith("--"));
+	const unknownFlags = flags.filter((flag) => flag !== "--apply");
+	const apply = flags.includes("--apply");
+	const packageNames = args.filter((arg) => !arg.startsWith("--"));
+	if (unknownFlags.length > 0 || packageNames.length === 0) {
+		// Reject typos like --aply: a human runs apply mode, and a silent
+		// fallback to dry-run would report success while fixing nothing.
+		if (unknownFlags.length > 0) process.stderr.write(`unknown flag: ${unknownFlags.join(" ")}\n`);
+		process.stderr.write("usage: release-latest-guard.mjs [--apply] <package>...\n");
+		process.exitCode = 2;
+	} else {
+		try {
+			const needingAction = guardPackages(packageNames, { apply });
+			// Dry run (verify mode) fails when any package still needs action;
+			// apply mode has fixed them, so it succeeds.
+			if (!apply && needingAction > 0) process.exitCode = 1;
+		} catch (error) {
+			process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+			process.exitCode = 1;
+		}
+	}
+}

--- a/scripts/release-latest-guard.mjs
+++ b/scripts/release-latest-guard.mjs
@@ -40,17 +40,22 @@ export function latestGuardAction(distTags) {
  * error so the guard can run before a new package's first publish.
  */
 export function readDistTags(packageName, { spawn = spawnSync } = {}) {
-	const result = spawn("npm", ["view", packageName, "dist-tags", "--json"], {
+	const result = spawn("npm", ["dist-tag", "ls", packageName], {
 		encoding: "utf8",
 	});
 	if (result.status !== 0) {
 		if (/E404|404 Not Found/u.test(result.stderr ?? "")) return {};
 		throw new Error(`npm view ${packageName} dist-tags failed: ${(result.stderr ?? "").trim()}`);
 	}
-	const parsed = JSON.parse(result.stdout);
-	// npm returns an array when the spec resolves to multiple versions; a
-	// bare package name resolves to one object.
-	return Array.isArray(parsed) ? (parsed[0] ?? {}) : parsed;
+	// Unlike npm view, this reads package tags without resolving through latest.
+	const tags = {};
+	for (const line of result.stdout.trim().split(/\r?\n/u)) {
+		if (!line) continue;
+		const match = /^([^\s:]+):\s+(\S+)$/u.exec(line);
+		if (!match) throw new Error(`Malformed dist-tag listing for ${packageName}`);
+		tags[match[1]] = match[2];
+	}
+	return tags;
 }
 
 export function removeLatest(packageName, { spawn = spawnSync } = {}) {

--- a/scripts/release-latest-guard.test.mjs
+++ b/scripts/release-latest-guard.test.mjs
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import {
+	guardPackages,
+	isPrereleaseVersion,
+	latestGuardAction,
+	readDistTags,
+} from "./release-latest-guard.mjs";
+
+const releaseWorkflow = readFileSync(
+	new URL("../.github/workflows/release.yml", import.meta.url),
+	"utf8",
+);
+
+const PUBLISHED_PACKAGES = [
+	"@codemem/embeddings",
+	"@codemem/core",
+	"@codemem/mcp",
+	"@codemem/server",
+	"codemem",
+	"@codemem/opencode-plugin",
+];
+
+/** Build a fake `spawnSync` that answers `npm view <pkg> dist-tags --json`. */
+function fakeNpm(distTagsByPackage, { failView = new Set(), failRm = new Set() } = {}) {
+	const calls = [];
+	const spawn = (command, args) => {
+		calls.push([command, ...args]);
+		const [subcommand, ...rest] = args;
+		if (subcommand === "view") {
+			const packageName = rest[0];
+			if (failView.has(packageName)) {
+				return { status: 1, stdout: "", stderr: `npm error 500 for ${packageName}` };
+			}
+			const distTags = distTagsByPackage[packageName];
+			if (distTags === undefined) {
+				return { status: 1, stdout: "", stderr: `npm error code E404\nnpm error 404 Not Found - GET ${packageName}` };
+			}
+			return { status: 0, stdout: JSON.stringify(distTags), stderr: "" };
+		}
+		if (subcommand === "dist-tag") {
+			const packageName = rest[1];
+			return failRm.has(packageName) ? { status: 1 } : { status: 0 };
+		}
+		throw new Error(`unexpected npm invocation: ${args.join(" ")}`);
+	};
+	return { spawn, calls };
+}
+
+describe("release latest-tag guard: classification", () => {
+	it("classifies prerelease versions", () => {
+		assert.equal(isPrereleaseVersion("0.44.0-alpha.1"), true);
+		assert.equal(isPrereleaseVersion("0.44.0-beta.2"), true);
+		assert.equal(isPrereleaseVersion("1.0.0-rc.0"), true);
+		assert.equal(isPrereleaseVersion("0.43.2"), false);
+		assert.equal(isPrereleaseVersion("1.0.0"), false);
+	});
+
+	it("removes latest only when it points at a prerelease", () => {
+		// npm's first-publish behavior: a brand-new package published with
+		// --tag alpha still gets latest set to that alpha.
+		assert.deepEqual(latestGuardAction({ alpha: "0.44.0-alpha.1", latest: "0.44.0-alpha.1" }), {
+			action: "remove",
+			reason: "latest points at prerelease 0.44.0-alpha.1",
+		});
+	});
+
+	it("never touches a stable latest, even during a prerelease publish", () => {
+		assert.deepEqual(latestGuardAction({ alpha: "0.44.0-alpha.1", latest: "0.43.2" }), {
+			action: "none",
+			reason: "latest is stable 0.43.2",
+		});
+	});
+
+	it("treats an absent latest as already correct", () => {
+		assert.deepEqual(latestGuardAction({ alpha: "0.44.0-alpha.1" }), {
+			action: "none",
+			reason: "latest absent",
+		});
+		assert.deepEqual(latestGuardAction({}), { action: "none", reason: "latest absent" });
+		assert.deepEqual(latestGuardAction(undefined), { action: "none", reason: "latest absent" });
+		assert.deepEqual(latestGuardAction({ latest: "" }), { action: "none", reason: "latest absent" });
+	});
+});
+
+describe("release latest-tag guard: registry reads", () => {
+	it("unwraps the array shape npm returns for range specs", () => {
+		const { spawn } = fakeNpm({});
+		const arrayShaped = (command, args) => {
+			if (args[0] === "view") {
+				return { status: 0, stdout: JSON.stringify([{ latest: "0.43.2" }, { latest: "0.43.2" }]), stderr: "" };
+			}
+			return spawn(command, args);
+		};
+		assert.deepEqual(readDistTags("@codemem/core", { spawn: arrayShaped }), { latest: "0.43.2" });
+	});
+
+	it("treats an unpublished package as having no dist-tags", () => {
+		// The guard must be runnable before a new package's first publish.
+		const { spawn } = fakeNpm({});
+		assert.deepEqual(readDistTags("@codemem/not-yet", { spawn }), {});
+	});
+
+	it("propagates non-404 registry failures", () => {
+		const { spawn } = fakeNpm({}, { failView: new Set(["@codemem/core"]) });
+		assert.throws(() => readDistTags("@codemem/core", { spawn }), /npm error 500/u);
+	});
+});
+
+describe("release latest-tag guard: guardPackages", () => {
+	it("counts packages needing action without mutating in dry-run mode", () => {
+		const { spawn, calls } = fakeNpm({
+			"@codemem/embeddings": { alpha: "0.44.0-alpha.1", latest: "0.44.0-alpha.1" },
+			"@codemem/core": { alpha: "0.44.0-alpha.1", latest: "0.43.2" },
+		});
+		const needing = guardPackages(["@codemem/embeddings", "@codemem/core"], {
+			apply: false,
+			log: () => {},
+			spawn,
+		});
+		assert.equal(needing, 1);
+		assert.ok(calls.every(([, sub]) => sub === "view"), "dry run must not call dist-tag");
+	});
+
+	it("removes latest only for the flagged package in apply mode", () => {
+		const { spawn, calls } = fakeNpm({
+			"@codemem/embeddings": { alpha: "0.44.0-alpha.1", latest: "0.44.0-alpha.1" },
+			"@codemem/core": { alpha: "0.44.0-alpha.1", latest: "0.43.2" },
+		});
+		guardPackages(["@codemem/embeddings", "@codemem/core"], { apply: true, log: () => {}, spawn });
+		const removals = calls.filter(([, sub]) => sub === "dist-tag");
+		assert.deepEqual(removals, [["npm", "dist-tag", "rm", "@codemem/embeddings", "latest"]]);
+	});
+
+	it("inspects every package even when an earlier one fails, then reports all failures", () => {
+		// A transient failure on package 2 must not leave packages 3-6 unseen.
+		const { spawn, calls } = fakeNpm(
+			{
+				"@codemem/embeddings": { latest: "0.43.2" },
+				"@codemem/core": { latest: "0.43.2" },
+				"@codemem/mcp": { latest: "0.43.2" },
+			},
+			{ failView: new Set(["@codemem/core"]) },
+		);
+		assert.throws(
+			() => guardPackages(["@codemem/embeddings", "@codemem/core", "@codemem/mcp"], { log: () => {}, spawn }),
+			/latest-tag guard failures:\n@codemem\/core: /u,
+		);
+		const viewed = calls.filter(([, sub]) => sub === "view").map(([, , name]) => name);
+		assert.deepEqual(viewed, ["@codemem/embeddings", "@codemem/core", "@codemem/mcp"]);
+	});
+
+	it("is idempotent: a second run after removal is a no-op", () => {
+		const { spawn, calls } = fakeNpm({ "@codemem/embeddings": { alpha: "0.44.0-alpha.1" } });
+		const needing = guardPackages(["@codemem/embeddings"], { apply: true, log: () => {}, spawn });
+		assert.equal(needing, 0);
+		assert.ok(calls.every(([, sub]) => sub === "view"));
+	});
+});
+
+describe("release latest-tag guard: workflow wiring", () => {
+	it("runs verify-only after publishing, covering every published package on one step", () => {
+		// OIDC trusted publishing grants `publish` only, not `dist-tag`, so the
+		// workflow must not attempt --apply: it would 401 after packages are
+		// already published. Verify-only, with the fix documented for a human.
+		const stepStart = releaseWorkflow.indexOf("- name: Verify latest dist-tag is absent or stable");
+		assert.ok(stepStart >= 0, "verify step missing");
+		const nextStep = releaseWorkflow.indexOf("\n      - name:", stepStart + 1);
+		const nextJob = releaseWorkflow.indexOf("\n  release:", stepStart);
+		const stepEnd = [nextStep, nextJob].filter((i) => i > 0).reduce((a, b) => Math.min(a, b));
+		const step = releaseWorkflow.slice(stepStart, stepEnd);
+
+		assert.match(step, /node scripts\/release-latest-guard\.mjs/u);
+		assert.doesNotMatch(step, /--apply/u, "workflow must never run the guard in apply mode");
+		assert.doesNotMatch(step, /NODE_AUTH_TOKEN/u, "verify is unauthenticated");
+		for (const packageName of PUBLISHED_PACKAGES) {
+			assert.ok(step.includes(packageName), `verify step must cover ${packageName}`);
+		}
+		assert.ok(
+			releaseWorkflow.indexOf('publish_if_missing "@codemem/opencode-plugin"') < stepStart,
+			"verify must run after the last publish",
+		);
+	});
+
+	it("points at the documented manual fix and stays warning-only until clean", () => {
+		// The workflow must not itself contain a dist-tag mutation command
+		// (release-workflow.test.mjs enforces that); it points at the doc.
+		assert.match(releaseWorkflow, /docs\/versioning\.md/u);
+		assert.match(releaseWorkflow, /continue-on-error: true/u);
+	});
+});

--- a/scripts/release-latest-guard.test.mjs
+++ b/scripts/release-latest-guard.test.mjs
@@ -28,8 +28,8 @@ function fakeNpm(distTagsByPackage, { failView = new Set(), failRm = new Set() }
 	const spawn = (command, args) => {
 		calls.push([command, ...args]);
 		const [subcommand, ...rest] = args;
-		if (subcommand === "view") {
-			const packageName = rest[0];
+		if (subcommand === "dist-tag" && rest[0] === "ls") {
+			const packageName = rest[1];
 			if (failView.has(packageName)) {
 				return { status: 1, stdout: "", stderr: `npm error 500 for ${packageName}` };
 			}
@@ -37,7 +37,7 @@ function fakeNpm(distTagsByPackage, { failView = new Set(), failRm = new Set() }
 			if (distTags === undefined) {
 				return { status: 1, stdout: "", stderr: `npm error code E404\nnpm error 404 Not Found - GET ${packageName}` };
 			}
-			return { status: 0, stdout: JSON.stringify(distTags), stderr: "" };
+			return { status: 0, stdout: Object.entries(distTags).map(([tag, version]) => `${tag}: ${version}`).join("\n"), stderr: "" };
 		}
 		if (subcommand === "dist-tag") {
 			const packageName = rest[1];
@@ -85,15 +85,10 @@ describe("release latest-tag guard: classification", () => {
 });
 
 describe("release latest-tag guard: registry reads", () => {
-	it("unwraps the array shape npm returns for range specs", () => {
-		const { spawn } = fakeNpm({});
-		const arrayShaped = (command, args) => {
-			if (args[0] === "view") {
-				return { status: 0, stdout: JSON.stringify([{ latest: "0.43.2" }, { latest: "0.43.2" }]), stderr: "" };
-			}
-			return spawn(command, args);
-		};
-		assert.deepEqual(readDistTags("@codemem/core", { spawn: arrayShaped }), { latest: "0.43.2" });
+	it("reads package tags without needing latest to exist", () => {
+		const { spawn, calls } = fakeNpm({ "@codemem/core": { beta: "0.44.0-beta.1" } });
+		assert.deepEqual(readDistTags("@codemem/core", { spawn }), { beta: "0.44.0-beta.1" });
+		assert.deepEqual(calls, [["npm", "dist-tag", "ls", "@codemem/core"]]);
 	});
 
 	it("treats an unpublished package as having no dist-tags", () => {
@@ -120,7 +115,7 @@ describe("release latest-tag guard: guardPackages", () => {
 			spawn,
 		});
 		assert.equal(needing, 1);
-		assert.ok(calls.every(([, sub]) => sub === "view"), "dry run must not call dist-tag");
+		assert.ok(calls.every(([, sub, action]) => sub === "dist-tag" && action === "ls"), "dry run must only list tags");
 	});
 
 	it("removes latest only for the flagged package in apply mode", () => {
@@ -129,7 +124,7 @@ describe("release latest-tag guard: guardPackages", () => {
 			"@codemem/core": { alpha: "0.44.0-alpha.1", latest: "0.43.2" },
 		});
 		guardPackages(["@codemem/embeddings", "@codemem/core"], { apply: true, log: () => {}, spawn });
-		const removals = calls.filter(([, sub]) => sub === "dist-tag");
+		const removals = calls.filter(([, sub, action]) => sub === "dist-tag" && action === "rm");
 		assert.deepEqual(removals, [["npm", "dist-tag", "rm", "@codemem/embeddings", "latest"]]);
 	});
 
@@ -147,7 +142,7 @@ describe("release latest-tag guard: guardPackages", () => {
 			() => guardPackages(["@codemem/embeddings", "@codemem/core", "@codemem/mcp"], { log: () => {}, spawn }),
 			/latest-tag guard failures:\n@codemem\/core: /u,
 		);
-		const viewed = calls.filter(([, sub]) => sub === "view").map(([, , name]) => name);
+		const viewed = calls.filter(([, sub, action]) => sub === "dist-tag" && action === "ls").map(([, , , name]) => name);
 		assert.deepEqual(viewed, ["@codemem/embeddings", "@codemem/core", "@codemem/mcp"]);
 	});
 
@@ -155,7 +150,7 @@ describe("release latest-tag guard: guardPackages", () => {
 		const { spawn, calls } = fakeNpm({ "@codemem/embeddings": { alpha: "0.44.0-alpha.1" } });
 		const needing = guardPackages(["@codemem/embeddings"], { apply: true, log: () => {}, spawn });
 		assert.equal(needing, 0);
-		assert.ok(calls.every(([, sub]) => sub === "view"));
+		assert.ok(calls.every(([, sub, action]) => sub === "dist-tag" && action === "ls"));
 	});
 });
 


### PR DESCRIPTION
## Description
Part of the v0.44 release train.

npm sets `latest` on a package's first-ever version regardless of `--tag`. `@codemem/embeddings` debuted as `0.44.0-alpha.1`, so `npm install @codemem/embeddings` with no tag resolves to a prerelease. Every other package correctly has `latest → 0.43.2`.

**What this adds:**
- `scripts/release-latest-guard.mjs` — inspects live dist-tags and flags any package whose `latest` is a prerelease. Pure decision logic exported and unit-tested. Only ever *removes* a bad `latest`; never adds or moves one, so a stable `latest` is untouched during a prerelease publish. Treats E404 (unpublished) as clean so it can run before a new package's debut. Inspects every package even if one fails, then reports all failures together.
- A **verify-only** post-publish step in `release.yml`. It does not attempt to fix: OIDC trusted publishing grants `publish` only, not dist-tag mutation (verified from npm 12 source — `oidc.js` is required solely by `publish.js`; `dist-tag.js` goes straight to `_authToken`, and the repo has zero secrets). An `--apply` step would 401 *after* packages are already published. Marked `continue-on-error` until the one dirty package is fixed by hand, then flip to a hard gate.
- `docs/versioning.md` — the npm behavior, why CI can't fix it, and the one manual command.

**Not in this PR:** the actual `latest` removal on `@codemem/embeddings`. That needs an npm login; the doc gives the command. Live dry-run confirms the guard flags only that package.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] 🚀 Feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance (CI / release)
- [ ] 🧪 Testing

## Testing
- [x] `pnpm run test:release` — 36 pass (12 new: classification, array-shape unwrap, E404→{}, 500 propagates, dry-run never mutates, apply removes only flagged, failure on pkg 2 still inspects pkg 3, idempotent, workflow-shape slice)
- [x] Live dry-run against the registry: flags `@codemem/embeddings` only, exit 1; unpublished package reads clean, exit 0
- [x] Reviewer mutation-tested the workflow assertions: 6/6 mutations caught (add `--apply`, drop a package, add `NODE_AUTH_TOKEN`, reorder before publish, flip `continue-on-error`, delete the step)
- [x] `git diff --check`
- [ ] Full workspace suite not rerun; scripts/ is outside Biome's include set

## Checklist
- [x] Self-review
- [x] Independent CodeReviewer: 4 blockers found on v1 (OIDC auth gap; hard gate that could never clear; fail-fast on pkg 2; E404 fatal) — all addressed by switching to verify-only
- [x] No new warnings introduced