### PR TITLE
chore(release): bump version to 0.44.0-beta.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.44.0-alpha.1"
+    "version": "0.44.0-beta.1"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.44.0-alpha.1",
+      "version": "0.44.0-beta.1",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.44.0-alpha.1";
+const PINNED_BACKEND_VERSION = "0.44.0-beta.1";
 
 export {
 	default,

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -9,25 +9,50 @@ vi.mock("node:child_process", () => ({
 	execSync: (...args) => execSyncMock(...args),
 }));
 
+const { __testUtils } = await import("../plugins/codemem.js");
+const PINNED = __testUtils.PINNED_BACKEND_VERSION;
+
+/** Bump the prerelease counter of a version like x.y.z-beta.1 by `delta`. */
+function bumpPrerelease(version, delta) {
+	const match = /^(\d+\.\d+\.\d+-(?:alpha|beta|rc)\.)(\d+)$/u.exec(version);
+	if (!match) throw new Error(`not a prerelease: ${version}`);
+	return `${match[1]}${Number(match[2]) + delta}`;
+}
+
+/** Same version number on a different prerelease channel. */
+function onChannel(version, channel) {
+	return version.replace(/-(?:alpha|beta|rc)\./u, `-${channel}.`);
+}
+
+const CURRENT = PINNED;
+const NEWER = bumpPrerelease(PINNED, 1);
+const NEWEST = bumpPrerelease(PINNED, 2);
+const OLDER = bumpPrerelease(PINNED, -1);
+const CURRENT_CHANNEL = /-(alpha|beta|rc)\./u.exec(PINNED)[1];
+const CROSS_CHANNEL = onChannel(
+	bumpPrerelease(PINNED, 1),
+	CURRENT_CHANNEL === "alpha" ? "beta" : "alpha",
+);
+
 const currentStatus = {
-	current_version: "0.44.0-alpha.1",
-	channel: "alpha",
-	latest_version: "0.44.0-alpha.1",
+	current_version: CURRENT,
+	channel: CURRENT_CHANNEL,
+	latest_version: CURRENT,
 	update_available: false,
 	first_seen_at: "2026-08-10T12:00:00.000Z",
 	checked_at: "2026-08-10T12:00:00.000Z",
 	stale: false,
 	install_kind: "npm-global",
 	auto_update_eligible: false,
-	recommended_action: "No action required; codemem is on the latest alpha release.",
+	recommended_action: `No action required; codemem is on the latest ${CURRENT_CHANNEL} release.`,
 	error: null,
 };
 
 const availableStatus = {
 	...currentStatus,
-	latest_version: "0.44.0-alpha.2",
+	latest_version: NEWER,
 	update_available: true,
-	recommended_action: "npm install -g codemem@0.44.0-alpha.2",
+	recommended_action: `npm install -g codemem@${NEWER}`,
 };
 
 function makeProcess(
@@ -141,13 +166,13 @@ describe("@codemem/opencode-plugin exports", () => {
 	});
 
 	test("keeps a newer same-channel prerelease on the global runner", async () => {
-		execSyncMock.mockReturnValueOnce("0.44.0-alpha.2");
+		execSyncMock.mockReturnValueOnce(NEWER);
 		const { __testUtils } = await import("../plugins/codemem.js");
 
 		expect(__testUtils.detectRunner({ cwd: "/tmp/codemem", envRunner: "" })).toBe("codemem");
 	});
 
-	test.each(["0.44.0-alpha.0", "0.44.0-beta.2"])(
+	test.each([OLDER, CROSS_CHANNEL])(
 		"rejects an older or cross-channel global runner at %s",
 		async (version) => {
 			execSyncMock.mockReturnValueOnce(version);
@@ -248,15 +273,15 @@ describe("OpenCode startup release notifications", () => {
 		await runStartupChecks();
 		status = {
 			...availableStatus,
-			latest_version: "0.44.0-alpha.3",
-			recommended_action: "npm install -g codemem@0.44.0-alpha.3",
+			latest_version: NEWEST,
+			recommended_action: `npm install -g codemem@${NEWEST}`,
 		};
 		await startPlugin(showToast);
 		await runStartupChecks();
 
 		// Assert
 		expect(showToast).toHaveBeenCalledTimes(2);
-		expect(showToast.mock.calls[1]?.[0]?.body?.message).toMatch(/0\.44\.0-alpha\.3/);
+		expect(showToast.mock.calls[1]?.[0]?.body?.message).toContain(NEWEST);
 	});
 
 	test.each([
@@ -277,7 +302,7 @@ describe("OpenCode startup release notifications", () => {
 			label: "guidance for another version",
 			status: {
 				...availableStatus,
-				recommended_action: "npm install -g codemem@0.44.0-alpha.3",
+				recommended_action: `npm install -g codemem@${NEWEST}`,
 			},
 		},
 	])("ignores $label", async ({ status }) => {

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -24,12 +24,24 @@ function onChannel(version, channel) {
 	return version.replace(/-(?:alpha|beta|rc)\./u, `-${channel}.`);
 }
 
+function previousCoreVersion(version) {
+	const match = /^(\d+)\.(\d+)\.(\d+)-/u.exec(version);
+	if (!match) throw new Error(`not a prerelease: ${version}`);
+	const major = Number(match[1]);
+	const minor = Number(match[2]);
+	const patch = Number(match[3]);
+	if (patch > 0) return `${major}.${minor}.${patch - 1}`;
+	if (minor > 0) return `${major}.${minor - 1}.0`;
+	if (major > 0) return `${major - 1}.0.0`;
+	return "0.0.0-0";
+}
+
 const CURRENT = PINNED;
 function updateFixtureVersions(version) {
 	const channel = /-(alpha|beta|rc)\.(\d+)$/u.exec(version);
 	if (channel) {
 		let older = bumpPrerelease(version, -1);
-		if (Number(channel[2]) === 0) older = version.replace(/\.0$/u, ".0-0");
+		if (Number(channel[2]) === 0) older = previousCoreVersion(version);
 		return {
 			channel: channel[1],
 			newer: bumpPrerelease(version, 1),
@@ -66,6 +78,10 @@ test("update fixtures support stable pins", () => {
 		older: "0.44.0-rc.0",
 		crossChannel: "0.44.1-alpha.1",
 	});
+});
+
+test("update fixtures use an older core version for prerelease zero pins", () => {
+	expect(updateFixtureVersions("0.44.0-beta.0").older).toBe("0.43.0");
 });
 
 const currentStatus = {

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -25,14 +25,48 @@ function onChannel(version, channel) {
 }
 
 const CURRENT = PINNED;
-const NEWER = bumpPrerelease(PINNED, 1);
-const NEWEST = bumpPrerelease(PINNED, 2);
-const OLDER = bumpPrerelease(PINNED, -1);
-const CURRENT_CHANNEL = /-(alpha|beta|rc)\./u.exec(PINNED)[1];
-const CROSS_CHANNEL = onChannel(
-	bumpPrerelease(PINNED, 1),
-	CURRENT_CHANNEL === "alpha" ? "beta" : "alpha",
-);
+function updateFixtureVersions(version) {
+	const channel = /-(alpha|beta|rc)\.(\d+)$/u.exec(version);
+	if (channel) {
+		let older = bumpPrerelease(version, -1);
+		if (Number(channel[2]) === 0) older = version.replace(/\.0$/u, ".0-0");
+		return {
+			channel: channel[1],
+			newer: bumpPrerelease(version, 1),
+			newest: bumpPrerelease(version, 2),
+			older,
+			crossChannel: onChannel(bumpPrerelease(version, 1), channel[1] === "alpha" ? "beta" : "alpha"),
+		};
+	}
+	const stable = /^(\d+)\.(\d+)\.(\d+)$/u.exec(version);
+	if (!stable) throw new Error(`Unsupported fixture version: ${version}`);
+	const base = `${stable[1]}.${stable[2]}`;
+	return {
+		channel: "latest",
+		newer: `${base}.${Number(stable[3]) + 1}`,
+		newest: `${base}.${Number(stable[3]) + 2}`,
+		older: `${version}-rc.0`,
+		crossChannel: `${base}.${Number(stable[3]) + 1}-alpha.1`,
+	};
+}
+
+const {
+	newer: NEWER,
+	newest: NEWEST,
+	older: OLDER,
+	channel: CURRENT_CHANNEL,
+	crossChannel: CROSS_CHANNEL,
+} = updateFixtureVersions(PINNED);
+
+test("update fixtures support stable pins", () => {
+	expect(updateFixtureVersions("0.44.0")).toEqual({
+		channel: "latest",
+		newer: "0.44.1",
+		newest: "0.44.2",
+		older: "0.44.0-rc.0",
+		crossChannel: "0.44.1-alpha.1",
+	});
+});
 
 const currentStatus = {
 	current_version: CURRENT,
@@ -290,12 +324,12 @@ describe("OpenCode startup release notifications", () => {
 			status: { ...availableStatus, channel: undefined },
 		},
 		{
-			label: "stable status on an alpha plugin",
+			label: "status from another channel",
 			status: {
 				...availableStatus,
-				channel: "latest",
-				latest_version: "0.44.0",
-				recommended_action: "npm install -g codemem@0.44.0",
+				channel: CURRENT_CHANNEL === "alpha" ? "beta" : "alpha",
+				latest_version: CROSS_CHANNEL,
+				recommended_action: `npm install -g codemem@${CROSS_CHANNEL}`,
 			},
 		},
 		{
@@ -372,7 +406,7 @@ describe("OpenCode startup release notifications", () => {
 		await runStartupChecks();
 
 		const installCall = spawnMock.mock.calls.find(isPairedInstallCall);
-		expect(installCall?.[2]?.env).toBe(process.env);
+		expect(installCall?.[2]?.env === process.env).toBe(true);
 		expect(installCall?.[2]?.env).not.toHaveProperty("ONNXRUNTIME_NODE_INSTALL");
 	});
 

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -33,7 +33,7 @@ function previousCoreVersion(version) {
 	if (patch > 0) return `${major}.${minor}.${patch - 1}`;
 	if (minor > 0) return `${major}.${minor - 1}.0`;
 	if (major > 0) return `${major - 1}.0.0`;
-	return "0.0.0-0";
+	throw new Error(`no earlier core version: ${version}`);
 }
 
 const CURRENT = PINNED;
@@ -41,7 +41,9 @@ function updateFixtureVersions(version) {
 	const channel = /-(alpha|beta|rc)\.(\d+)$/u.exec(version);
 	if (channel) {
 		let older = bumpPrerelease(version, -1);
-		if (Number(channel[2]) === 0) older = previousCoreVersion(version);
+		if (Number(channel[2]) === 0) {
+			older = `${previousCoreVersion(version)}-${channel[1]}.0`;
+		}
 		return {
 			channel: channel[1],
 			newer: bumpPrerelease(version, 1),
@@ -81,7 +83,7 @@ test("update fixtures support stable pins", () => {
 });
 
 test("update fixtures use an older core version for prerelease zero pins", () => {
-	expect(updateFixtureVersions("0.44.0-beta.0").older).toBe("0.43.0");
+	expect(updateFixtureVersions("0.44.0-beta.0").older).toBe("0.43.0-beta.0");
 });
 
 const currentStatus = {

--- a/packages/cli/.opencode/tests/plugin-update-notification.test.js
+++ b/packages/cli/.opencode/tests/plugin-update-notification.test.js
@@ -25,8 +25,8 @@ function onChannel(version, channel) {
 }
 
 function previousCoreVersion(version) {
-	const match = /^(\d+)\.(\d+)\.(\d+)-/u.exec(version);
-	if (!match) throw new Error(`not a prerelease: ${version}`);
+	const match = /^(\d+)\.(\d+)\.(\d+)/u.exec(version);
+	if (!match) throw new Error(`not a semantic version: ${version}`);
 	const major = Number(match[1]);
 	const minor = Number(match[2]);
 	const patch = Number(match[3]);
@@ -57,7 +57,7 @@ function updateFixtureVersions(version) {
 		channel: "latest",
 		newer: `${base}.${Number(stable[3]) + 1}`,
 		newest: `${base}.${Number(stable[3]) + 2}`,
-		older: `${version}-rc.0`,
+		older: previousCoreVersion(version),
 		crossChannel: `${base}.${Number(stable[3]) + 1}-alpha.1`,
 	};
 }
@@ -75,7 +75,7 @@ test("update fixtures support stable pins", () => {
 		channel: "latest",
 		newer: "0.44.1",
 		newest: "0.44.2",
-		older: "0.44.0-rc.0",
+		older: "0.43.0",
 		crossChannel: "0.44.1-alpha.1",
 	});
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.44.0-alpha.1",
+	"version": "0.44.0-beta.1",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.44.0-alpha.1",
+	"version": "0.44.0-beta.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.44.0-alpha.1");
+		expect(VERSION).toBe("0.44.0-beta.1");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.44.0-alpha.1";
+export const VERSION = "0.44.0-beta.1";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/embeddings",
-	"version": "0.44.0-alpha.1",
+	"version": "0.44.0-beta.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.44.0-alpha.1",
+	"version": "0.44.0-beta.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -25,7 +25,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.44.0-alpha.1";
+const PINNED_BACKEND_VERSION = "0.44.0-beta.1";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 const MAX_UPDATE_STATUS_BYTES = 16 * 1024;

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.44.0-alpha.1",
+	"version": "0.44.0-beta.1",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.44.0-alpha.1",
+	"version": "0.44.0-beta.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.44.0-alpha.1",
+  "version": "0.44.0-beta.1",
   "author": {
     "name": "Adam Kunicki"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codemem",
-  "version": "0.44.0-alpha.1",
+  "version": "0.44.0-beta.1",
   "description": "Persistent memory for Codex. Capture work across sessions and recall relevant context.",
   "author": {
     "name": "Adam Kunicki"


### PR DESCRIPTION
## Description
Align all managed versions from `0.44.0-alpha.1` to `0.44.0-beta.1` via `scripts/release-version.mjs`. Stacked on #1640.

**What beta.1 publishes that alpha.1 did not:** the eleven alpha-dogfood fixes merged today (#1629–#1639), including `codemem` depending on `@codemem/embeddings` so `npm install -g codemem@beta` installs the semantic runtime with one command.

**Beta acceptance, per the release train:**
- Alpha dogfood findings resolved — yes, all eleven merged.
- OpenCode restart has no persistent fallback and no event loss — yes (#1632, #1633).
- Linked Team blockers closed with regressions — yes (#1634, #1638, #1639; Nerdworld completed end-to-end).
- Batched final hash rechecks and WebGPU vs CPU backfill comparison — **explicitly deferred.** Not measured; the CPU path is unchanged from alpha.1 and no WebGPU path is present. Tracked for a later prerelease.

Tag creation is a separate, approval-gated step after this merges: `v0.44.0-beta.1` on the merged main commit only.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] 🚀 Feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance (release)
- [ ] 🧪 Testing

## Testing
- [x] `pnpm run release:version -- check` — aligned at 0.44.0-beta.1
- [x] `pnpm run check` — tsc, lint, 36 release + 4 normalizer + 9 CI-workflow script tests, 248 files / 6,209 tests + 3 todo
- [x] `pnpm run build` — all 8 packages
- [x] `pnpm install` — lockfile unchanged (workspace protocol)
- [x] `git diff --check`
- [ ] E2E scenarios and packed supported-platform installs run on the tagged commit in CI, not here

## Checklist
- [x] Self-review
- [x] Scripted bump only; no hand edits
- [x] No new warnings introduced