### PR TITLE
fix(ui): keep split-pane navigation visible

### DIFF
--- a/packages/ui/src/app-devices.test.tsx
+++ b/packages/ui/src/app-devices.test.tsx
@@ -530,6 +530,7 @@ describe("Devices app integration", () => {
 			"Device ownership information is temporarily unavailable",
 		);
 		expect(document.getElementById("refreshStatus")?.textContent).toBe("refresh failed");
+		expect(document.getElementById("refreshStatus")?.dataset.refreshState).toBe("error");
 		expect(document.getElementById("refreshAnnouncer")?.textContent).toBe("Refresh failed.");
 		expect(document.getElementById("refreshStatus")?.textContent).not.toContain("updated");
 	});

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -29,6 +29,7 @@ import {
 	state,
 	type TabId,
 } from "./lib/state";
+import { createTabVisibilityTracker } from "./lib/tab-visibility";
 import { getTheme, initThemeToggle, setTheme } from "./lib/theme";
 
 import { initCoordinatorAdminTab, loadCoordinatorAdminData } from "./tabs/coordinator-admin";
@@ -313,6 +314,7 @@ function setRefreshStatus(rs: RefreshState, detail?: string) {
 	state.refreshState = rs;
 	const el = $("refreshStatus");
 	if (!el) return;
+	el.dataset.refreshState = rs;
 
 	const announce = (msg: string) => {
 		const announcer = $("refreshAnnouncer");
@@ -395,6 +397,8 @@ function renderAdvancedSection() {
 	});
 }
 
+const revealChangedTab = createTabVisibilityTracker();
+
 function renderTabs(activeTab: TabId) {
 	const visibleTabs = new Set(getVisibleTabs(state.lastCoordinatorAdminStatus));
 	ALL_TAB_IDS.forEach((id) => {
@@ -411,6 +415,8 @@ function renderTabs(activeTab: TabId) {
 		if (active) btn.setAttribute("aria-current", "page");
 		else btn.removeAttribute("aria-current");
 	});
+	const activeButton = $(`tabBtn-${activeTab}`);
+	if (activeButton) revealChangedTab(activeButton);
 	renderAdvancedSection();
 }
 

--- a/packages/ui/src/lib/tab-visibility.test.ts
+++ b/packages/ui/src/lib/tab-visibility.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTabVisibilityTracker, ensureTabIsVisible } from "./tab-visibility";
+
+function bounds(left: number, right: number): DOMRect {
+	return {
+		bottom: 40,
+		height: 40,
+		left,
+		right,
+		toJSON: () => ({}),
+		top: 0,
+		width: right - left,
+		x: left,
+		y: 0,
+	};
+}
+
+describe("ensureTabIsVisible", () => {
+	let button: HTMLButtonElement;
+	let navigation: HTMLElement;
+
+	beforeEach(() => {
+		document.body.innerHTML = '<nav class="tab-bar"><button>Advanced</button></nav>';
+		navigation = document.querySelector("nav") as HTMLElement;
+		button = document.querySelector("button") as HTMLButtonElement;
+		button.scrollIntoView = vi.fn();
+		navigation.getBoundingClientRect = vi.fn(() => bounds(20, 500));
+	});
+
+	it("leaves a fully visible active tab in place", () => {
+		button.getBoundingClientRect = vi.fn(() => bounds(360, 460));
+
+		ensureTabIsVisible(button);
+
+		expect(button.scrollIntoView).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["left", 0, 100],
+		["right", 460, 540],
+	])("brings a tab clipped on the %s edge into view", (_edge, left, right) => {
+		button.getBoundingClientRect = vi.fn(() => bounds(left, right));
+
+		ensureTabIsVisible(button);
+
+		expect(button.scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });
+	});
+
+	it("ignores buttons outside the navigation or hidden from it", () => {
+		const detached = document.createElement("button");
+		detached.scrollIntoView = vi.fn();
+		ensureTabIsVisible(detached);
+		button.hidden = true;
+		ensureTabIsVisible(button);
+
+		expect(detached.scrollIntoView).not.toHaveBeenCalled();
+		expect(button.scrollIntoView).not.toHaveBeenCalled();
+	});
+
+	it("does not pull the tab bar back during unchanged refreshes", () => {
+		button.getBoundingClientRect = vi.fn(() => bounds(460, 540));
+		const revealChangedTab = createTabVisibilityTracker();
+
+		revealChangedTab(button);
+		revealChangedTab(button);
+
+		expect(button.scrollIntoView).toHaveBeenCalledTimes(1);
+	});
+
+	it("rechecks the active tab after the navigation bounds change", () => {
+		let navigationRight = 500;
+		navigation.getBoundingClientRect = vi.fn(() => bounds(20, navigationRight));
+		button.getBoundingClientRect = vi.fn(() => bounds(430, 490));
+		const revealChangedTab = createTabVisibilityTracker();
+
+		revealChangedTab(button);
+		navigationRight = 450;
+		revealChangedTab(button);
+
+		expect(button.scrollIntoView).toHaveBeenCalledOnce();
+	});
+
+	it("rechecks the active tab after its bounds change", () => {
+		let buttonLeft = 430;
+		button.getBoundingClientRect = vi.fn(() => bounds(buttonLeft, buttonLeft + 60));
+		const revealChangedTab = createTabVisibilityTracker();
+
+		revealChangedTab(button);
+		buttonLeft = 460;
+		revealChangedTab(button);
+
+		expect(button.scrollIntoView).toHaveBeenCalledOnce();
+	});
+
+	it("preserves manual tab-bar scrolling during refreshes", () => {
+		let buttonLeft = 430;
+		button.getBoundingClientRect = vi.fn(() => bounds(buttonLeft, buttonLeft + 60));
+		const revealChangedTab = createTabVisibilityTracker();
+
+		revealChangedTab(button);
+		navigation.scrollLeft = 430;
+		buttonLeft = 0;
+		revealChangedTab(button);
+
+		expect(button.scrollIntoView).not.toHaveBeenCalled();
+	});
+});

--- a/packages/ui/src/lib/tab-visibility.ts
+++ b/packages/ui/src/lib/tab-visibility.ts
@@ -1,0 +1,49 @@
+function revealTabWithinBounds(
+	button: HTMLElement,
+	buttonBounds: DOMRect,
+	navigationBounds: DOMRect,
+): void {
+	const isVisible =
+		buttonBounds.left >= navigationBounds.left && buttonBounds.right <= navigationBounds.right;
+	if (isVisible) return;
+	button.scrollIntoView({ block: "nearest", inline: "nearest" });
+}
+
+export function ensureTabIsVisible(button: HTMLElement): void {
+	if (button.hidden) return;
+	const navigation = button.closest<HTMLElement>(".tab-bar");
+	if (!navigation) return;
+	revealTabWithinBounds(button, button.getBoundingClientRect(), navigation.getBoundingClientRect());
+}
+
+export function createTabVisibilityTracker(): (button: HTMLElement) => void {
+	let lastButton: HTMLElement | null = null;
+	let lastButtonContentLeft: number | null = null;
+	let lastButtonContentRight: number | null = null;
+	let lastNavigationLeft: number | null = null;
+	let lastNavigationRight: number | null = null;
+	return (button) => {
+		if (button.hidden) return;
+		const navigation = button.closest<HTMLElement>(".tab-bar");
+		if (!navigation) return;
+		const buttonBounds = button.getBoundingClientRect();
+		const navigationBounds = navigation.getBoundingClientRect();
+		const buttonContentLeft = buttonBounds.left + navigation.scrollLeft;
+		const buttonContentRight = buttonBounds.right + navigation.scrollLeft;
+		if (
+			button === lastButton &&
+			buttonContentLeft === lastButtonContentLeft &&
+			buttonContentRight === lastButtonContentRight &&
+			navigationBounds.left === lastNavigationLeft &&
+			navigationBounds.right === lastNavigationRight
+		) {
+			return;
+		}
+		lastButton = button;
+		lastButtonContentLeft = buttonContentLeft;
+		lastButtonContentRight = buttonContentRight;
+		lastNavigationLeft = navigationBounds.left;
+		lastNavigationRight = navigationBounds.right;
+		revealTabWithinBounds(button, buttonBounds, navigationBounds);
+	};
+}

--- a/packages/ui/src/project-first-layout.test.ts
+++ b/packages/ui/src/project-first-layout.test.ts
@@ -259,3 +259,31 @@ describe("project-first navigation layout", () => {
 		);
 	});
 });
+
+describe("split-pane shell layout", () => {
+	it("keeps controls bounded across responsive breakpoints", () => {
+		const normalized = html.replace(/\s+/g, " ");
+		const responsiveStart = normalized.indexOf("/* ── Responsive");
+		const desktopStart = normalized.indexOf("@media (max-width: 900px)", responsiveStart);
+		const narrowStart = normalized.indexOf("@media (max-width: 720px)", desktopStart);
+		const compactStart = normalized.indexOf("@media (max-width: 520px)", narrowStart);
+		const responsiveEnd = normalized.indexOf("/* ──", compactStart);
+		const desktopSplit = normalized.slice(desktopStart, narrowStart);
+		const narrowSplit = normalized.slice(narrowStart, compactStart);
+		const compact = normalized.slice(compactStart, responsiveEnd);
+
+		expect(desktopSplit).toContain(".header-row { flex-wrap: nowrap; }");
+		expect(desktopSplit).toContain(".header-tertiary { display: none; }");
+		expect(desktopSplit).toContain(
+			".header-right .project-filter { flex: 1 1 140px; min-width: 96px;",
+		);
+		expect(desktopSplit).toContain(".tab-bar { overflow-x: auto;");
+		expect(narrowSplit).toContain(".header-title { font-size: var(--font-size-xl); }");
+		expect(compact).toContain("header { padding: var(--sp-3) var(--sp-4);");
+		expect(compact).toContain("body { --header-sticky-offset: 117px; }");
+		expect(compact).toContain(".header-row { flex-wrap: wrap; }");
+		expect(compact).toContain(".header-left, .header-right { flex-basis: 100%; }");
+		expect(compact).toContain('.refresh-status[data-refresh-state="idle"] { display: none; }');
+		expect(compact).not.toContain(".refresh-status { display: none; }");
+	});
+});

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -445,7 +445,10 @@ describe("Projects tab", () => {
 
 	it("preserves a focused repair when only hidden continuity data changes", async () => {
 		const initialReviewItem = reviewItem();
-		const refreshedReviewItem = reviewItem({ sourceFingerprint: "fingerprint-2" });
+		const refreshedReviewItem = reviewItem({
+			reviewItemId: "review-2",
+			sourceFingerprint: "fingerprint-2",
+		});
 		const blockedItem = {
 			blockedItemId: "blocked-1",
 			finding: "Project identity is unstable.",

--- a/packages/ui/src/tabs/recipient-policy-review.ts
+++ b/packages/ui/src/tabs/recipient-policy-review.ts
@@ -136,7 +136,6 @@ export function renderRecipientPolicyReview(
 		reviewItems: review.reviewItems.map((item) => ({
 			finding: item.finding,
 			reason: item.reason,
-			reviewItemId: item.reviewItemId,
 		})),
 	};
 	const signature = `review:${repairAvailability.join("")}:${JSON.stringify(renderedReview)}`;

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -43,6 +43,7 @@
       *, *::before, *::after { box-sizing: border-box; margin: 0; }
 
       body {
+        --header-sticky-offset: 73px;
         font-family: var(--font-sans);
         font-size: var(--font-size-base);
         line-height: 1.55;
@@ -108,6 +109,8 @@
         display: flex;
         align-items: center;
         gap: var(--sp-3);
+        min-width: 0;
+        overflow: hidden;
       }
 
       .logo {
@@ -127,7 +130,10 @@
         font-size: var(--font-size-2xl);
         font-weight: var(--font-weight-semibold);
         letter-spacing: -0.01em;
+        min-width: 0;
         white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .health-dot {
@@ -144,6 +150,7 @@
         display: flex;
         align-items: center;
         gap: var(--sp-2);
+        min-width: 0;
       }
 
       /* Diagnostic metadata cluster: runtime version + database path. Grouped
@@ -194,7 +201,7 @@
         -webkit-backdrop-filter: blur(10px) saturate(1.2);
         border-bottom: 1px solid var(--border);
         position: sticky;
-        top: 73px; /* header height */
+        top: var(--header-sticky-offset);
         z-index: 9;
       }
 
@@ -229,7 +236,7 @@
       .tab-btn.active::after {
         content: "";
         position: absolute;
-        bottom: -1px;
+        bottom: 0;
         left: var(--sp-4);
         right: var(--sp-4);
         height: 2px;
@@ -3954,6 +3961,24 @@
       /* ── Responsive ────────────────────────────────────────── */
 
       @media (max-width: 900px) {
+        .header-row { flex-wrap: nowrap; }
+        .header-right { flex: 1 1 auto; justify-content: flex-end; }
+        /* Diagnostic metadata yields before project scope or controls clip. */
+        .header-tertiary { display: none; }
+        .header-right .project-filter {
+          flex: 1 1 140px;
+          min-width: 96px;
+          max-width: 240px;
+        }
+        /* Keep navigation to one compact row while preserving every destination. */
+        .tab-bar {
+          overflow-x: auto;
+          overscroll-behavior-inline: contain;
+          -webkit-overflow-scrolling: touch;
+          scrollbar-width: none;
+        }
+        .tab-bar::-webkit-scrollbar { display: none; }
+        .tab-btn { flex-shrink: 0; }
         .tab-panel { padding: var(--sp-4); }
         .summary-row { grid-template-columns: 1fr; }
         .feed-card-header { flex-wrap: wrap; }
@@ -3971,23 +3996,15 @@
       }
 
       @media (max-width: 720px) {
-        /* Hide diagnostic metadata (runtime version + database path) when the
-           header would otherwise wrap. Keeps brand + project filter + theme
-           + settings on a single row at common split-window widths. */
-        .header-tertiary { display: none; }
-        /* Allow the tab bar to scroll horizontally rather than wrap into two
-           rows. Scrollbar is hidden to keep the sticky chrome compact. */
-        .tab-bar {
-          overflow-x: auto;
-          -webkit-overflow-scrolling: touch;
-          scrollbar-width: none;
-        }
-        .tab-bar::-webkit-scrollbar { display: none; }
-        .tab-btn { flex-shrink: 0; }
+        .header-title { font-size: var(--font-size-xl); }
       }
 
       @media (max-width: 520px) {
+        body { --header-sticky-offset: 117px; }
         header { padding: var(--sp-3) var(--sp-4); }
+        .header-row { flex-wrap: wrap; }
+        .header-left, .header-right { flex-basis: 100%; }
+        .refresh-status[data-refresh-state="idle"] { display: none; }
         .tab-bar { padding: 0 var(--sp-4); }
         .modal { padding: var(--sp-3); }
         .modal-card { padding: var(--sp-4); border-radius: var(--radius-lg); }
@@ -4051,7 +4068,7 @@
             <span class="header-title">codemem</span>
             <span class="health-dot status-healthy" id="healthDot" title="Healthy"></span>
           </div>
-          <span class="refresh-status" id="refreshStatus">refreshing…</span>
+          <span class="refresh-status" id="refreshStatus" data-refresh-state="refreshing">refreshing…</span>
           <span class="sr-only" id="refreshAnnouncer" aria-live="polite"></span>
         </div>
         <div class="header-right">


### PR DESCRIPTION
## Description

Keep viewer navigation usable at narrow split-pane widths. The header metadata now yields space, tabs remain horizontally reachable, and active-tab visibility updates do not reset user scrolling during polling.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused UI tests passed: 34 tests. Production UI build passed. Full suite passed: 249 files, 6,213 tests. Live cmux validation is deferred because cmux was unavailable in this session.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed; no public workflow changed)
- [x] No new warnings introduced