### PR TITLE
test(ui): trace conflicting access and device states

### DIFF
--- a/docs/plans/2026-09-07-conflicting-access-device-review-state-investigation.md
+++ b/docs/plans/2026-09-07-conflicting-access-device-review-state-investigation.md
@@ -1,0 +1,68 @@
+# Conflicting access and device-review state investigation
+
+The reported contradictions are presentation defects over valid, intentionally separate backend states; neither case indicates corrupt access data or an unsafe pairing path.
+
+## Decision
+
+This investigation changes no policy or copy because the follow-up information-architecture work must decide how to present these state distinctions.
+
+- Treat active Team intent separately from per-Project enforcement convergence.
+- Treat an expired coordinator presence as offline and ineligible for review.
+- Preserve the existing fail-closed checks for stale device pairing.
+- Use the focused UI fixtures below as characterization tests until replacement copy and state ownership are approved.
+
+## Evidence matrix
+
+The matrix maps each visible message to the state that produces it and the operation it actually describes.
+
+| Visible message | Endpoint and source field | Backend derivation | Freshness rule | Affected operation | Finding |
+|---|---|---|---|---|---|
+| Advanced: “Team access needs review before it can continue.” | `GET /api/sync/status`; `recipient_policy_reconciliation.items[].state` | `listRecipientPolicyReconciliationStatus()` maps a non-waiting safe error or rolled-back authority to `needs_attention` for one canonical Project. | No age threshold; this is persisted Project authority state. | Per-Project recipient-policy reconciliation and authority cutover. | Presentation defect: valid Project enforcement failure is summarized as broad Team access state. |
+| Advanced: “Open Sharing, review Project access, then sync again.” | Same reconciliation item and derived primary status. | `deriveTeamSyncPrimaryStatus()` routes reconciliation-only failures to Sharing without exposing the affected Project or safe reason. | No freshness rule. | Review the failed Project access update. | Presentation defect: Sharing does not render reconciliation state, so the destination cannot explain the warning. |
+| Sharing: active members, registered devices, and shared Project identities | `GET /api/sync/recipient-policy/v1/intent`; active `teams`, `teamMemberships`, `identityDevices`, and `projectRecipients` rows | `listRecipientPolicyIntent()` projects the intent graph; the Team renderer filters and counts active rows independently of enforcement authority. | No presence threshold; a failed refresh can retain the last successful intent with stale-data disclosure. | Manage declared Team membership and Project-recipient intent. | Intentional state distinction presented without enough context. Active intent can coexist with failed Project enforcement. |
+| Attention: “{device} is available to review.” | `GET /api/sync/status`; unpaired `coordinator.discovered_devices[]` with `stale: true` | `deriveSyncViewModel()` creates a generic `review-team-device` attention item for a stale unpaired discovery. | A discovery is stale when expiry is missing, invalid, or not later than the current time. | The action only focuses the device row. | Presentation defect: the generic title claims review is available when the row rejects review. |
+| Device row: “Offline”, “No fresh addresses”, and fresh-presence recovery guidance | Same discovered device; `stale`, `addresses`, `address_count`, and `expires_at` | Coordinator projections retain enrolled offline devices, strip stale addresses, and the UI sets the row to stale mode without a pairing button. | Presence defaults to a 180-second lifetime. Status caching does not extend a fresh record beyond its expiry. | `POST /api/sync/peers/accept-discovered`. | Correct stale-state handling. Enrollment remains visible, but pairing is unavailable. |
+| Pairing error: `discovered_peer_stale` | `POST /api/sync/peers/accept-discovered`; current coordinator peer record | The handler reloads coordinator state and rejects stale or expired presence before inserting a peer or reciprocal approval. | Revalidated against the operation-time clock. | Trust and pair the discovered device. | Correct fail-closed behavior. |
+
+## Trace: active Team intent with failed Project enforcement
+
+The contradiction combines two valid projections but labels the narrower failure too broadly.
+
+1. `packages/viewer-server/src/routes/sync.ts` exposes recipient-policy reconciliation through `GET /api/sync/status` and canonical intent through `GET /api/sync/recipient-policy/v1/intent`.
+2. `packages/core/src/recipient-policy-intent.ts` projects the full Team, membership, device-registration, and Project-recipient intent graph.
+3. `packages/ui/src/tabs/recipient-policy-sharing.tsx` filters that graph to active rows and counts them for the Sharing Team card.
+4. `packages/ui/src/tabs/sync/view-model/primary-status.ts` converts a reconciliation `needs_attention` item into broad Team-level warning copy after higher-priority setup and operation blockers are ruled out.
+5. `packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts` renders that status in Advanced.
+
+The architecture allows this combination: `docs/adr/0001-project-recipient-policy-boundaries.md` separates user intent, derived effective recipients, and current scope enforcement, and requires authority cutover per Project.
+
+## Trace: stale unpaired device shown as reviewable
+
+The contradiction is entirely inside the viewer because backend and row-level guards consistently reject stale review.
+
+1. `packages/core/src/better-sqlite-coordinator-store.ts` and `packages/core/src/d1-coordinator-store.ts` retain enrolled devices after presence expiry but return no stale addresses.
+2. `packages/core/src/coordinator-runtime.ts` merges sightings, excludes stale addresses, and exposes `stale` and `expires_at` in status.
+3. `packages/ui/src/tabs/sync/view-model/sync-view-model.ts` creates the “available to review” attention item for an unpaired stale discovery.
+4. `packages/ui/src/tabs/sync/view-model/coordinator-approval.ts` returns false from `shouldShowCoordinatorReviewAction()` for the same stale device.
+5. `packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts` renders the device as offline with no review button.
+6. `packages/viewer-server/src/routes/sync.ts` rechecks freshness and returns `discovered_peer_stale` if a caller attempts pairing anyway.
+
+## Characterization fixtures
+
+The focused fixtures preserve evidence of the current contradictions without approving the current wording as the target design.
+
+- `packages/ui/src/tabs/recipient-policy-sharing.test.tsx` renders active Team intent and derives the Advanced reconciliation warning for the same Project fixture.
+- `packages/ui/src/tabs/sync/team-sync/render/render-team-sync.test.ts` renders one stale, addressless, unpaired discovery and verifies that its attention item claims review availability while its device row is offline and has no pairing button.
+
+Existing core and server tests cover rollback without granting, stale-address removal, and operation-time stale pairing rejection. The UI fixtures cover only the contradictory presentation that those lower-level tests cannot observe.
+
+## Follow-up boundary
+
+The next design task should assign canonical ownership and replacement copy rather than alter authorization, reconciliation, expiry, or pairing semantics.
+
+Decisions still required:
+
+- whether Advanced names the affected Project and safe failure reason;
+- whether Sharing owns reconciliation status or Advanced links to a focused repair surface;
+- whether stale devices remain in Attention with an explicitly non-actionable title or appear only in the device inventory;
+- how compatibility deep links preserve access to the chosen owner.

--- a/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
+++ b/packages/ui/src/tabs/recipient-policy-sharing.test.tsx
@@ -58,6 +58,7 @@ import type {
 import { RecipientPolicyTeamRenameApiError } from "../lib/api/sync";
 import type { RecipientPolicyManagementProject } from "./recipient-policy-management";
 import { mountRecipientPolicySharing } from "./recipient-policy-sharing";
+import { deriveTeamSyncPrimaryStatus } from "./sync/view-model";
 
 const projects: RecipientPolicyManagementProject[] = [
 	{ canonicalProjectIdentity: "project-codemem", displayName: "Codemem", existingMemoryCount: 40 },
@@ -412,6 +413,44 @@ describe("recipient-focused Sharing", () => {
 		expect(text).toContain("1 active shared Project identity — Codemem");
 		expect(text).toContain("Yes — future Team members inherit the Team’s shared Projects");
 		expect(text).not.toContain("Old Team");
+	});
+
+	it("keeps active Team intent visible while Project enforcement needs attention", () => {
+		const graph = intent();
+		const sharedProject = graph.projectRecipients.find(
+			(recipient) => recipient.recipientKind === "team" && recipient.status === "active",
+		);
+		if (!sharedProject) throw new Error("active Team Project recipient missing");
+		mount(graph);
+		const sharingText = visiblePanel().textContent ?? "";
+		const advancedStatus = deriveTeamSyncPrimaryStatus({
+			status: { enabled: true, daemon_state: "ok", daemon_running: true },
+			coordinator: {
+				configured: true,
+				groups: ["ExampleCo"],
+				presence_status: "posted",
+			},
+			reconciliation: {
+				items: [
+					{
+						canonicalProjectIdentity: sharedProject.canonicalProjectIdentity,
+						state: "needs_attention",
+					},
+				],
+			},
+		});
+
+		expect(sharingText).toContain("2 active members — Adam, Brian");
+		expect(sharingText).toContain("2 active registered devices");
+		expect(sharingText).toContain("1 active shared Project identity — Codemem");
+		expect(sharingText).not.toContain("needs review");
+		expect(sharingText).not.toContain("Project access");
+		expect(advancedStatus).toMatchObject({
+			state: "needs-attention",
+			meta: "Team: ExampleCo. Team access needs review before it can continue.",
+			nextAction: "Open Sharing, review Project access, then sync again.",
+		});
+		expect(advancedStatus.meta).not.toContain(sharedProject.canonicalProjectIdentity);
 	});
 
 	it("bounds long member lists behind an accessible disclosure", () => {

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.test.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.test.ts
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "../../../../lib/api";
 import { state } from "../../../../lib/state";
 import type { TeamSyncDiscoveredRow } from "../../components/team-sync-panel";
-import { deriveTeamSyncPrimaryStatus, type UiTeamSyncPrimaryStatus } from "../../view-model";
+import {
+	deriveSyncViewModel,
+	deriveTeamSyncPrimaryStatus,
+	type UiTeamSyncPrimaryStatus,
+} from "../../view-model";
 import { teamSyncState } from "../data/state";
 import {
 	needsCoordinatorGroupReview,
@@ -259,7 +263,56 @@ describe("submitDiscoveredDeviceReview", () => {
 	});
 });
 
-describe("renderTeamSync pending coordinator approval", () => {
+describe("renderTeamSync discovered-device state", () => {
+	it("presents a stale unpaired device as attention-visible but not reviewable", () => {
+		document.body.innerHTML = `
+			<div id="syncTeamMeta"></div>
+			<div id="syncSetupPanel"></div>
+			<div id="syncTeamActions"></div>
+			<div id="syncCoordinatorDiscovered"></div>
+			<div id="syncCoordinatorDiscoveredMeta"></div>
+			<div id="syncCoordinatorDiscoveredList"></div>
+		`;
+		state.lastSyncStatus = { enabled: true, daemon_state: "ok", daemon_running: true };
+		state.lastSyncPeers = [];
+		state.lastSyncCoordinator = {
+			configured: true,
+			coordinator_url: "https://coord.example.test",
+			sync_enabled: true,
+			groups: ["Acme"],
+			presence_status: "posted",
+			discovered_devices: [
+				{
+					device_id: "device-stale",
+					display_name: "Desk Mini",
+					fingerprint: "fingerprint-stale",
+					groups: ["Acme"],
+					addresses: [],
+					address_count: 0,
+					stale: true,
+				},
+			],
+		};
+		state.lastSyncViewModel = deriveSyncViewModel({
+			coordinator: state.lastSyncCoordinator,
+			peers: state.lastSyncPeers,
+			status: state.lastSyncStatus,
+		});
+
+		act(() => renderTeamSync());
+
+		const actions = document.getElementById("syncTeamActions") as HTMLElement;
+		const discovered = document.getElementById("syncCoordinatorDiscoveredList") as HTMLElement;
+		expect(actions.textContent).toContain("Desk Mini is available to review");
+		expect(actions.textContent).toContain("Open device");
+		expect(discovered.textContent).toContain("Offline");
+		expect(discovered.textContent).toContain("No fresh addresses");
+		expect(discovered.textContent).toContain(
+			"Wait for a fresh coordinator presence update, then review this device again here.",
+		);
+		expect(discovered.querySelector("button")).toBeNull();
+	});
+
 	it("keeps a stale authoritative approval row visible without counting it as actionable", () => {
 		document.body.innerHTML = `
 			<div id="syncTeamMeta"></div>


### PR DESCRIPTION
## Description

Document why active Team intent can coexist with failed per-Project enforcement and why a stale discovered device can appear in Attention while pairing remains unavailable. Add focused UI characterization fixtures without changing access policy, sync semantics, runtime copy, or live state.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused UI tests passed: 49 tests. Full suite passed: 249 files, 6,217 tests with 3 existing todos. CodeReviewer verdict: SHIP.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (evidence matrix added)
- [x] No new warnings introduced