### PR TITLE
feat(core): define observer output envelope

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -615,6 +615,7 @@ export type {
 	ObserverTokenUsage,
 } from "./observer-client.js";
 export { loadObserverConfig, ObserverAuthError, ObserverClient } from "./observer-client.js";
+export * from "./observer-concepts.js";
 export type {
 	ConfigPathResolution,
 	ConfigPathSource,
@@ -652,6 +653,7 @@ export {
 	writeCodememConfigFile,
 	writeWorkspaceCodememConfigFile,
 } from "./observer-config.js";
+export * from "./observer-output-schema.js";
 export * from "./operational-status.js";
 export * from "./outcome-evidence.js";
 export type { PackArtifacts } from "./pack.js";

--- a/packages/core/src/ingest-prompts.ts
+++ b/packages/core/src/ingest-prompts.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ObserverContext, ToolEvent } from "./ingest-types.js";
+import { OBSERVER_CONCEPTS } from "./observer-concepts.js";
 
 // ---------------------------------------------------------------------------
 // Constants — prompt fragments matching Python's observer_prompts.py
@@ -134,7 +135,7 @@ const OBSERVATION_SCHEMA = `<observation>
     Aim for 100-500 words - enough to be useful, not overwhelming.
   ]</narrative>
   <concepts>
-    <concept>[how-it-works, why-it-exists, what-changed, problem-solution, gotcha, pattern, trade-off]</concept>
+    <concept>[${OBSERVER_CONCEPTS.join(", ")}]</concept>
   </concepts>
   <!-- concepts: 2-5 knowledge categories from the list above -->
   <files_read>

--- a/packages/core/src/ingest-xml-parser.ts
+++ b/packages/core/src/ingest-xml-parser.ts
@@ -11,6 +11,7 @@
 import { isLowSignalObservation } from "./ingest-filters.js";
 import type { ParsedObservation, ParsedOutput, ParsedSummary } from "./ingest-types.js";
 import { REMEMBER_MEMORY_KINDS } from "./memory-kinds.js";
+import { OBSERVER_CONCEPT_SET } from "./observer-concepts.js";
 
 // ---------------------------------------------------------------------------
 // Regex patterns
@@ -32,16 +33,6 @@ const SUMMARY_FIELDS = new Set([
 	"notes",
 	"files_read",
 	"files_modified",
-]);
-
-const OBSERVATION_CONCEPTS = new Set([
-	"how-it-works",
-	"why-it-exists",
-	"what-changed",
-	"problem-solution",
-	"gotcha",
-	"pattern",
-	"trade-off",
 ]);
 
 export const SUPPORTED_OBSERVATION_KINDS = new Set<string>(REMEMBER_MEMORY_KINDS);
@@ -1076,7 +1067,7 @@ function addedObservationFieldsAreGrounded(
 			extractRecoverableChildTexts(fragment, "concepts", "concept"),
 			observation.concepts,
 			source,
-			(value) => OBSERVATION_CONCEPTS.has(value.trim().toLowerCase()),
+			(value) => OBSERVER_CONCEPT_SET.has(value.trim().toLowerCase()),
 		) &&
 		addedItemsAreGrounded(
 			extractRecoverableChildTexts(fragment, "files_read", "file"),
@@ -1311,7 +1302,7 @@ function observationsAreGroundedInPlainProse(
 		(!hasVisibleText(observation.subtitle ?? "") ||
 			isGroundedProsePhrase(observation.subtitle as string, prose)) &&
 		observation.facts.every((value) => isGroundedProsePhrase(value, prose)) &&
-		observation.concepts.every((value) => OBSERVATION_CONCEPTS.has(value.trim().toLowerCase())) &&
+		observation.concepts.every((value) => OBSERVER_CONCEPT_SET.has(value.trim().toLowerCase())) &&
 		[...observation.filesRead, ...observation.filesModified].every((value) =>
 			isGroundedProsePath(value, prose),
 		)

--- a/packages/core/src/maintenance/ai-structured.ts
+++ b/packages/core/src/maintenance/ai-structured.ts
@@ -9,6 +9,7 @@ import {
 	updateMaintenanceJob,
 } from "../maintenance-jobs.js";
 import { loadObserverConfig, ObserverClient } from "../observer-client.js";
+import { OBSERVER_CONCEPT_SET, OBSERVER_CONCEPTS } from "../observer-concepts.js";
 import { SecretScanner } from "../secret-scanner.js";
 import { isSummaryLikeMemory } from "../summary-memory.js";
 
@@ -22,17 +23,6 @@ const AI_BACKFILL_KINDS = [
 	"refactor",
 ] as const;
 
-const AI_BACKFILL_CONCEPTS = [
-	"how-it-works",
-	"why-it-exists",
-	"what-changed",
-	"problem-solution",
-	"gotcha",
-	"pattern",
-	"trade-off",
-] as const;
-const AI_BACKFILL_CONCEPT_SET = new Set<string>(AI_BACKFILL_CONCEPTS);
-
 const AI_BACKFILL_JOB_KIND = "ai_structured_backfill";
 const AI_BACKFILL_SCHEMA_NAME = "codemem_structured_memory_backfill";
 const AI_BACKFILL_SCHEMA: Record<string, unknown> = {
@@ -41,7 +31,7 @@ const AI_BACKFILL_SCHEMA: Record<string, unknown> = {
 	properties: {
 		narrative: { type: ["string", "null"] },
 		facts: { type: "array", items: { type: "string" } },
-		concepts: { type: "array", items: { type: "string", enum: [...AI_BACKFILL_CONCEPTS] } },
+		concepts: { type: "array", items: { type: "string", enum: [...OBSERVER_CONCEPTS] } },
 	},
 	required: ["narrative", "facts", "concepts"],
 };
@@ -157,7 +147,7 @@ function buildStructuredBackfillPrompt(row: {
 - narrative must end cleanly on a full sentence. Do not output a truncated clause.
 - facts: 2-8 source-grounded, self-contained statements. Prefer concrete details over generic purpose statements.
 - concepts: 2-5 values from this exact list only:
-  ["how-it-works", "why-it-exists", "what-changed", "problem-solution", "gotcha", "pattern", "trade-off"]
+  ${JSON.stringify([...OBSERVER_CONCEPTS])}
 </field_rules>
 
 <grounding_rules>
@@ -257,7 +247,7 @@ function parseStructuredBackfillResponse(raw: string | null): ParsedStructuredBa
 					(item): item is string =>
 						typeof item === "string" &&
 						item.trim().length > 0 &&
-						AI_BACKFILL_CONCEPT_SET.has(item.trim().toLowerCase()),
+						OBSERVER_CONCEPT_SET.has(item.trim().toLowerCase()),
 				)
 				.map((item) => item.trim().toLowerCase())
 		: [];

--- a/packages/core/src/observer-concepts.ts
+++ b/packages/core/src/observer-concepts.ts
@@ -1,0 +1,14 @@
+/** Canonical concept taxonomy shared by observer extraction surfaces. */
+export const OBSERVER_CONCEPTS = [
+	"how-it-works",
+	"why-it-exists",
+	"what-changed",
+	"problem-solution",
+	"gotcha",
+	"pattern",
+	"trade-off",
+] as const;
+
+export type ObserverConcept = (typeof OBSERVER_CONCEPTS)[number];
+
+export const OBSERVER_CONCEPT_SET = new Set<string>(OBSERVER_CONCEPTS);

--- a/packages/core/src/observer-output-schema.test.ts
+++ b/packages/core/src/observer-output-schema.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it } from "vitest";
+import {
+	normalizeObserverEnvelopeV1,
+	OBSERVER_ENVELOPE_JSON_SCHEMA,
+	OBSERVER_OUTPUT_LIMITS,
+	parseObserverEnvelopeV1,
+	validateObserverEnvelopeV1,
+} from "./observer-output-schema.js";
+
+function validCapture() {
+	return {
+		schema_version: 1,
+		status: "captured",
+		observations: [
+			{
+				kind: "decision",
+				title: "Use a versioned envelope",
+				narrative: "The observer now emits constrained JSON.",
+				subtitle: null,
+				facts: ["The envelope is validated locally."],
+				concepts: ["what-changed"],
+				files_read: ["packages/core/src/observer-client.ts"],
+				files_modified: [],
+			},
+		],
+		summary: null,
+		skip_reason: null,
+	};
+}
+
+describe("observer envelope v1", () => {
+	it("publishes a closed provider schema", () => {
+		expect(OBSERVER_ENVELOPE_JSON_SCHEMA).toMatchInlineSnapshot(`
+			{
+			  "additionalProperties": false,
+			  "properties": {
+			    "observations": {
+			      "items": {
+			        "additionalProperties": false,
+			        "properties": {
+			          "concepts": {
+			            "items": {
+			              "enum": [
+			                "how-it-works",
+			                "why-it-exists",
+			                "what-changed",
+			                "problem-solution",
+			                "gotcha",
+			                "pattern",
+			                "trade-off",
+			              ],
+			              "type": "string",
+			            },
+			            "type": "array",
+			          },
+			          "facts": {
+			            "items": {
+			              "type": "string",
+			            },
+			            "type": "array",
+			          },
+			          "files_modified": {
+			            "items": {
+			              "type": "string",
+			            },
+			            "type": "array",
+			          },
+			          "files_read": {
+			            "items": {
+			              "type": "string",
+			            },
+			            "type": "array",
+			          },
+			          "kind": {
+			            "enum": [
+			              "discovery",
+			              "change",
+			              "feature",
+			              "bugfix",
+			              "refactor",
+			              "decision",
+			              "exploration",
+			            ],
+			            "type": "string",
+			          },
+			          "narrative": {
+			            "type": "string",
+			          },
+			          "subtitle": {
+			            "type": [
+			              "string",
+			              "null",
+			            ],
+			          },
+			          "title": {
+			            "type": "string",
+			          },
+			        },
+			        "required": [
+			          "kind",
+			          "title",
+			          "narrative",
+			          "subtitle",
+			          "facts",
+			          "concepts",
+			          "files_read",
+			          "files_modified",
+			        ],
+			        "type": "object",
+			      },
+			      "type": "array",
+			    },
+			    "schema_version": {
+			      "enum": [
+			        1,
+			      ],
+			      "type": "integer",
+			    },
+			    "skip_reason": {
+			      "type": [
+			        "string",
+			        "null",
+			      ],
+			    },
+			    "status": {
+			      "enum": [
+			        "captured",
+			        "skipped",
+			      ],
+			      "type": "string",
+			    },
+			    "summary": {
+			      "anyOf": [
+			        {
+			          "additionalProperties": false,
+			          "properties": {
+			            "completed": {
+			              "type": "string",
+			            },
+			            "files_modified": {
+			              "items": {
+			                "type": "string",
+			              },
+			              "type": "array",
+			            },
+			            "files_read": {
+			              "items": {
+			                "type": "string",
+			              },
+			              "type": "array",
+			            },
+			            "investigated": {
+			              "type": "string",
+			            },
+			            "learned": {
+			              "type": "string",
+			            },
+			            "next_steps": {
+			              "type": "string",
+			            },
+			            "notes": {
+			              "type": "string",
+			            },
+			            "request": {
+			              "type": "string",
+			            },
+			          },
+			          "required": [
+			            "request",
+			            "investigated",
+			            "learned",
+			            "completed",
+			            "next_steps",
+			            "notes",
+			            "files_read",
+			            "files_modified",
+			          ],
+			          "type": "object",
+			        },
+			        {
+			          "type": "null",
+			        },
+			      ],
+			    },
+			  },
+			  "required": [
+			    "schema_version",
+			    "status",
+			    "observations",
+			    "summary",
+			    "skip_reason",
+			  ],
+			  "type": "object",
+			}
+		`);
+	});
+});
+
+describe("observer envelope validation", () => {
+	it("validates and normalizes captured observations", () => {
+		const result = validateObserverEnvelopeV1(validCapture());
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(normalizeObserverEnvelopeV1(result.envelope)).toEqual({
+			observations: [
+				{
+					kind: "decision",
+					title: "Use a versioned envelope",
+					narrative: "The observer now emits constrained JSON.",
+					subtitle: null,
+					facts: ["The envelope is validated locally."],
+					concepts: ["what-changed"],
+					filesRead: ["packages/core/src/observer-client.ts"],
+					filesModified: [],
+				},
+			],
+			summary: null,
+			skipSummaryReason: null,
+		});
+	});
+
+	it("accepts a summary-only capture", () => {
+		const value = validCapture();
+		value.observations = [];
+		value.summary = {
+			request: "Replace XML",
+			investigated: "Observer transports",
+			learned: "Direct APIs support schemas",
+			completed: "Defined the contract",
+			next_steps: "Wire ingestion",
+			notes: "",
+			files_read: [],
+			files_modified: [],
+		};
+		expect(validateObserverEnvelopeV1(value).ok).toBe(true);
+	});
+
+	it("keeps an intentional skip distinct", () => {
+		const result = validateObserverEnvelopeV1({
+			schema_version: 1,
+			status: "skipped",
+			observations: [],
+			summary: null,
+			skip_reason: "low-signal",
+		});
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(normalizeObserverEnvelopeV1(result.envelope).skipSummaryReason).toBe("low-signal");
+	});
+});
+
+describe("observer envelope failures", () => {
+	it.each([
+		["non-object root", []],
+		["unsupported version", { ...validCapture(), schema_version: 2 }],
+		["unknown envelope property", { ...validCapture(), extra: true }],
+		[
+			"unsupported kind",
+			{ ...validCapture(), observations: [{ ...validCapture().observations[0], kind: "note" }] },
+		],
+		[
+			"missing required array",
+			{
+				...validCapture(),
+				observations: [{ ...validCapture().observations[0], facts: undefined }],
+			},
+		],
+		["captured skip reason", { ...validCapture(), skip_reason: "low-signal" }],
+		["empty capture", { ...validCapture(), observations: [] }],
+		["skipped observation", { ...validCapture(), status: "skipped", skip_reason: "low-signal" }],
+		[
+			"skipped summary",
+			{
+				...validCapture(),
+				status: "skipped",
+				observations: [],
+				summary: {
+					request: "request",
+					investigated: "",
+					learned: "",
+					completed: "",
+					next_steps: "",
+					notes: "",
+					files_read: [],
+					files_modified: [],
+				},
+				skip_reason: "low-signal",
+			},
+		],
+		[
+			"non-string fact",
+			{
+				...validCapture(),
+				observations: [{ ...validCapture().observations[0], facts: [1] }],
+			},
+		],
+		[
+			"non-canonical concept",
+			{
+				...validCapture(),
+				observations: [{ ...validCapture().observations[0], concepts: ["Gotcha"] }],
+			},
+		],
+		[
+			"too many concepts",
+			{
+				...validCapture(),
+				observations: [
+					{
+						...validCapture().observations[0],
+						concepts: Array.from({ length: OBSERVER_OUTPUT_LIMITS.concepts + 1 }, () => "gotcha"),
+					},
+				],
+			},
+		],
+		[
+			"empty skip reason",
+			{ ...validCapture(), status: "skipped", observations: [], skip_reason: " " },
+		],
+	])("rejects %s", (_name, value) => {
+		expect(validateObserverEnvelopeV1(value).ok).toBe(false);
+	});
+
+	it("rejects oversized strings and arrays", () => {
+		const value = validCapture();
+		value.observations[0].title = "x".repeat(OBSERVER_OUTPUT_LIMITS.textCharacters + 1);
+		value.observations[0].facts = Array.from(
+			{ length: OBSERVER_OUTPUT_LIMITS.listItems + 1 },
+			() => "fact",
+		);
+		const result = validateObserverEnvelopeV1(value);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.issues).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining("title exceeds"),
+				expect.stringContaining("facts exceeds"),
+			]),
+		);
+	});
+
+	it("classifies invalid JSON separately from schema failures", () => {
+		expect(parseObserverEnvelopeV1("not json")).toEqual({
+			ok: false,
+			reason: "structured_output_invalid_json",
+			issues: ["observer output is not valid JSON"],
+		});
+		expect(parseObserverEnvelopeV1("{}")).toMatchObject({
+			ok: false,
+			reason: "structured_output_schema_invalid",
+		});
+	});
+});

--- a/packages/core/src/observer-output-schema.ts
+++ b/packages/core/src/observer-output-schema.ts
@@ -1,0 +1,362 @@
+import type { ParsedOutput } from "./ingest-types.js";
+import { REMEMBER_MEMORY_KINDS, type RememberMemoryKind } from "./memory-kinds.js";
+import { OBSERVER_CONCEPTS } from "./observer-concepts.js";
+
+export const OBSERVER_ENVELOPE_SCHEMA_VERSION = 1 as const;
+export const OBSERVER_ENVELOPE_SCHEMA_NAME = "codemem_observer_envelope_v1";
+
+export const OBSERVER_OUTPUT_LIMITS = {
+	observations: 50,
+	listItems: 100,
+	concepts: OBSERVER_CONCEPTS.length,
+	textCharacters: 16_384,
+} as const;
+
+export interface ObserverObservationV1 {
+	kind: RememberMemoryKind;
+	title: string;
+	narrative: string;
+	subtitle: string | null;
+	facts: string[];
+	concepts: string[];
+	files_read: string[];
+	files_modified: string[];
+}
+
+export interface ObserverSummaryV1 {
+	request: string;
+	investigated: string;
+	learned: string;
+	completed: string;
+	next_steps: string;
+	notes: string;
+	files_read: string[];
+	files_modified: string[];
+}
+
+export interface ObserverEnvelopeV1 {
+	schema_version: typeof OBSERVER_ENVELOPE_SCHEMA_VERSION;
+	status: "captured" | "skipped";
+	observations: ObserverObservationV1[];
+	summary: ObserverSummaryV1 | null;
+	skip_reason: string | null;
+}
+
+export type ObserverEnvelopeFailureReason =
+	| "structured_output_refused"
+	| "structured_output_truncated"
+	| "structured_output_missing"
+	| "structured_output_invalid_json"
+	| "structured_output_schema_invalid"
+	| "forced_tool_missing"
+	| "forced_tool_multiple_calls"
+	| "forced_tool_input_invalid"
+	| "legacy_xml_lossy";
+
+export type ObserverEnvelopeParseResult =
+	| { ok: true; envelope: ObserverEnvelopeV1 }
+	| { ok: false; reason: ObserverEnvelopeFailureReason; issues: string[] };
+
+const boundedStringSchema = {
+	type: "string",
+} as const;
+
+const boundedStringArraySchema = {
+	type: "array",
+	items: boundedStringSchema,
+} as const;
+
+const observationSchema = {
+	type: "object",
+	additionalProperties: false,
+	properties: {
+		kind: { type: "string", enum: [...REMEMBER_MEMORY_KINDS] },
+		title: boundedStringSchema,
+		narrative: boundedStringSchema,
+		subtitle: { type: ["string", "null"] },
+		facts: boundedStringArraySchema,
+		concepts: {
+			type: "array",
+			items: { ...boundedStringSchema, enum: [...OBSERVER_CONCEPTS] },
+		},
+		files_read: boundedStringArraySchema,
+		files_modified: boundedStringArraySchema,
+	},
+	required: [
+		"kind",
+		"title",
+		"narrative",
+		"subtitle",
+		"facts",
+		"concepts",
+		"files_read",
+		"files_modified",
+	],
+} as const;
+
+const summarySchema = {
+	type: "object",
+	additionalProperties: false,
+	properties: {
+		request: boundedStringSchema,
+		investigated: boundedStringSchema,
+		learned: boundedStringSchema,
+		completed: boundedStringSchema,
+		next_steps: boundedStringSchema,
+		notes: boundedStringSchema,
+		files_read: boundedStringArraySchema,
+		files_modified: boundedStringArraySchema,
+	},
+	required: [
+		"request",
+		"investigated",
+		"learned",
+		"completed",
+		"next_steps",
+		"notes",
+		"files_read",
+		"files_modified",
+	],
+} as const;
+
+/** Conservative provider-neutral JSON Schema accepted by supported direct APIs. */
+export const OBSERVER_ENVELOPE_JSON_SCHEMA: Record<string, unknown> = {
+	type: "object",
+	additionalProperties: false,
+	properties: {
+		schema_version: { type: "integer", enum: [OBSERVER_ENVELOPE_SCHEMA_VERSION] },
+		status: { type: "string", enum: ["captured", "skipped"] },
+		observations: {
+			type: "array",
+			items: observationSchema,
+		},
+		summary: { anyOf: [summarySchema, { type: "null" }] },
+		skip_reason: { type: ["string", "null"] },
+	},
+	required: ["schema_version", "status", "observations", "summary", "skip_reason"],
+};
+
+const ENVELOPE_KEYS = [
+	"schema_version",
+	"status",
+	"observations",
+	"summary",
+	"skip_reason",
+] as const;
+const OBSERVATION_KEYS = [
+	"kind",
+	"title",
+	"narrative",
+	"subtitle",
+	"facts",
+	"concepts",
+	"files_read",
+	"files_modified",
+] as const;
+const SUMMARY_KEYS = [
+	"request",
+	"investigated",
+	"learned",
+	"completed",
+	"next_steps",
+	"notes",
+	"files_read",
+	"files_modified",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateExactKeys(
+	value: Record<string, unknown>,
+	keys: readonly string[],
+	path: string,
+	issues: string[],
+): void {
+	for (const key of keys) {
+		if (!Object.hasOwn(value, key)) issues.push(`${path}.${key} is required`);
+	}
+	const unexpectedCount = Object.keys(value).filter((key) => !keys.includes(key)).length;
+	if (unexpectedCount > 0) issues.push(`${path} has ${unexpectedCount} unexpected properties`);
+}
+
+function validateString(value: unknown, path: string, issues: string[]): value is string {
+	if (typeof value !== "string") {
+		issues.push(`${path} must be a string`);
+		return false;
+	}
+	if (value.length > OBSERVER_OUTPUT_LIMITS.textCharacters) {
+		issues.push(`${path} exceeds ${OBSERVER_OUTPUT_LIMITS.textCharacters} characters`);
+		return false;
+	}
+	return true;
+}
+
+function validateStringArray(
+	value: unknown,
+	path: string,
+	issues: string[],
+	options: { maxItems?: number; allowed?: ReadonlySet<string> } = {},
+): void {
+	if (!Array.isArray(value)) {
+		issues.push(`${path} must be an array`);
+		return;
+	}
+	const maxItems = options.maxItems ?? OBSERVER_OUTPUT_LIMITS.listItems;
+	if (value.length > maxItems) issues.push(`${path} exceeds ${maxItems} items`);
+	for (const [index, item] of value.entries()) {
+		if (!validateString(item, `${path}[${index}]`, issues)) continue;
+		if (options.allowed && !options.allowed.has(item)) {
+			issues.push(`${path}[${index}] is not allowed`);
+		}
+	}
+}
+
+function validateObservation(value: unknown, index: number, issues: string[]): void {
+	const path = `$.observations[${index}]`;
+	if (!isRecord(value)) {
+		issues.push(`${path} must be an object`);
+		return;
+	}
+	validateExactKeys(value, OBSERVATION_KEYS, path, issues);
+	if (
+		typeof value.kind !== "string" ||
+		!REMEMBER_MEMORY_KINDS.includes(value.kind as RememberMemoryKind)
+	) {
+		issues.push(`${path}.kind is not supported`);
+	}
+	validateString(value.title, `${path}.title`, issues);
+	validateString(value.narrative, `${path}.narrative`, issues);
+	if (value.subtitle !== null) validateString(value.subtitle, `${path}.subtitle`, issues);
+	validateStringArray(value.facts, `${path}.facts`, issues);
+	validateStringArray(value.concepts, `${path}.concepts`, issues, {
+		maxItems: OBSERVER_OUTPUT_LIMITS.concepts,
+		allowed: new Set(OBSERVER_CONCEPTS),
+	});
+	validateStringArray(value.files_read, `${path}.files_read`, issues);
+	validateStringArray(value.files_modified, `${path}.files_modified`, issues);
+}
+
+function validateSummary(value: unknown, issues: string[]): void {
+	if (!isRecord(value)) {
+		issues.push("$.summary must be an object or null");
+		return;
+	}
+	validateExactKeys(value, SUMMARY_KEYS, "$.summary", issues);
+	for (const key of SUMMARY_KEYS) {
+		if (key === "files_read" || key === "files_modified") {
+			validateStringArray(value[key], `$.summary.${key}`, issues);
+			continue;
+		}
+		validateString(value[key], `$.summary.${key}`, issues);
+	}
+}
+
+function validateEnvelopeFields(value: Record<string, unknown>, issues: string[]): void {
+	validateExactKeys(value, ENVELOPE_KEYS, "$", issues);
+	if (value.schema_version !== OBSERVER_ENVELOPE_SCHEMA_VERSION) {
+		issues.push(`$.schema_version must equal ${OBSERVER_ENVELOPE_SCHEMA_VERSION}`);
+	}
+	if (value.status !== "captured" && value.status !== "skipped") {
+		issues.push('$.status must equal "captured" or "skipped"');
+	}
+	if (!Array.isArray(value.observations)) {
+		issues.push("$.observations must be an array");
+	} else {
+		if (value.observations.length > OBSERVER_OUTPUT_LIMITS.observations) {
+			issues.push(`$.observations exceeds ${OBSERVER_OUTPUT_LIMITS.observations} items`);
+		}
+		value.observations.forEach((observation, index) => {
+			validateObservation(observation, index, issues);
+		});
+	}
+	if (value.summary !== null) validateSummary(value.summary, issues);
+	if (value.skip_reason !== null) validateString(value.skip_reason, "$.skip_reason", issues);
+}
+
+function validateEnvelopeState(value: Record<string, unknown>, issues: string[]): void {
+	if (value.status === "captured") {
+		if (value.skip_reason !== null) {
+			issues.push("$.skip_reason must be null when status is captured");
+		}
+		if (
+			Array.isArray(value.observations) &&
+			value.observations.length === 0 &&
+			value.summary === null
+		) {
+			issues.push("captured output must contain observations or a summary");
+		}
+		return;
+	}
+	if (value.status !== "skipped") return;
+	if (Array.isArray(value.observations) && value.observations.length > 0) {
+		issues.push("$.observations must be empty when status is skipped");
+	}
+	if (value.summary !== null) issues.push("$.summary must be null when status is skipped");
+	if (typeof value.skip_reason !== "string" || value.skip_reason.trim().length === 0) {
+		issues.push("$.skip_reason must be non-empty when status is skipped");
+	}
+}
+
+export function validateObserverEnvelopeV1(value: unknown): ObserverEnvelopeParseResult {
+	const issues: string[] = [];
+	if (!isRecord(value)) {
+		return {
+			ok: false,
+			reason: "structured_output_schema_invalid",
+			issues: ["$ must be an object"],
+		};
+	}
+
+	validateEnvelopeFields(value, issues);
+	validateEnvelopeState(value, issues);
+
+	if (issues.length > 0) {
+		return { ok: false, reason: "structured_output_schema_invalid", issues };
+	}
+	return { ok: true, envelope: value as unknown as ObserverEnvelopeV1 };
+}
+
+export function parseObserverEnvelopeV1(raw: string): ObserverEnvelopeParseResult {
+	// Do not salvage fences or prose: constrained transports must honor the declared contract.
+	let value: unknown;
+	try {
+		value = JSON.parse(raw);
+	} catch {
+		return {
+			ok: false,
+			reason: "structured_output_invalid_json",
+			issues: ["observer output is not valid JSON"],
+		};
+	}
+	return validateObserverEnvelopeV1(value);
+}
+
+export function normalizeObserverEnvelopeV1(envelope: ObserverEnvelopeV1): ParsedOutput {
+	return {
+		observations: envelope.observations.map((observation) => ({
+			kind: observation.kind,
+			title: observation.title,
+			narrative: observation.narrative,
+			subtitle: observation.subtitle,
+			facts: [...observation.facts],
+			concepts: [...new Set(observation.concepts)],
+			filesRead: [...observation.files_read],
+			filesModified: [...observation.files_modified],
+		})),
+		summary: envelope.summary
+			? {
+					request: envelope.summary.request,
+					investigated: envelope.summary.investigated,
+					learned: envelope.summary.learned,
+					completed: envelope.summary.completed,
+					nextSteps: envelope.summary.next_steps,
+					notes: envelope.summary.notes,
+					filesRead: [...envelope.summary.files_read],
+					filesModified: [...envelope.summary.files_modified],
+				}
+			: null,
+		skipSummaryReason: envelope.status === "skipped" ? envelope.skip_reason : null,
+	};
+}


### PR DESCRIPTION
## Description

Defines the versioned observer output envelope, shared JSON Schema, strict validation, normalization, stable failure reasons, and canonical concept handling. This gives later transport routing a fail-closed contract that cannot fall back to reparsing invalid constrained output as XML.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced