### PR TITLE
feat(core): route observer output by capability

### DIFF
--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -10,6 +10,7 @@ import {
 	compareMemoryRoleReports,
 	type ExtractionBenchmarkScore,
 	type ExtractionModelCostEstimate,
+	type ExtractionReplayResult,
 	type ExtractionStructuralDiagnostics,
 	estimateExtractionModelCost,
 	getExtractionBenchmarkProfile,
@@ -1013,6 +1014,50 @@ export function summarizeBenchmarkReasoning(
 	};
 }
 
+function benchmarkSecondAttemptValue<T>(attempted: boolean, value: T | null): T | null {
+	return attempted ? value : null;
+}
+
+function benchmarkSecondAttemptList<T>(attempted: boolean, value: T[]): T[] {
+	return attempted ? value : [];
+}
+
+function buildBenchmarkSecondAttempt(
+	result: ExtractionReplayResult,
+	input: { attempted: boolean; reason: string | null; quality: ExtractionBenchmarkScore | null },
+) {
+	return {
+		attempted: input.attempted,
+		reason: input.reason,
+		raw: benchmarkSecondAttemptValue(input.attempted, result.observer.repairedRaw),
+		status: benchmarkSecondAttemptValue(
+			input.attempted,
+			result.repairedClassification?.status ?? null,
+		),
+		resultReason: benchmarkSecondAttemptValue(
+			input.attempted,
+			result.repairedClassification?.reason ?? null,
+		),
+		pass: benchmarkSecondAttemptValue(input.attempted, result.repairedEvaluation?.pass ?? null),
+		failureReasons: benchmarkSecondAttemptList(
+			input.attempted,
+			result.repairedEvaluation?.failureReasons ?? [],
+		),
+		summaries: benchmarkSecondAttemptValue(
+			input.attempted,
+			result.repairedEvaluation?.counts.summaries ?? null,
+		),
+		observations: benchmarkSecondAttemptValue(
+			input.attempted,
+			result.repairedEvaluation?.counts.observations ?? null,
+		),
+		diagnostics: benchmarkSecondAttemptValue(input.attempted, result.observer.repairedDiagnostics),
+		elapsedMs: benchmarkSecondAttemptValue(input.attempted, result.observer.repairedElapsedMs),
+		usage: benchmarkSecondAttemptValue(input.attempted, result.observer.repairedUsage),
+		quality: benchmarkSecondAttemptValue(input.attempted, input.quality),
+	};
+}
+
 function createMemoryExtractionBenchmarkCommand(): Command {
 	const cmd = new Command("extraction-benchmark")
 		.configureHelp(helpStyle)
@@ -1173,6 +1218,8 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					summaries: number;
 					observations: number;
 					repairApplied: boolean;
+					retryAttempted: boolean;
+					retryReason: string | null;
 					initial: {
 						raw: string | null;
 						status: "pass" | "shape_fail" | "observer_no_output";
@@ -1200,6 +1247,21 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						usage: ObserverTokenUsage | null;
 						quality: ExtractionBenchmarkScore | null;
 					};
+					retry: {
+						attempted: boolean;
+						reason: string | null;
+						raw: string | null;
+						status: "pass" | "shape_fail" | "observer_no_output" | null;
+						resultReason: string | null;
+						pass: boolean | null;
+						failureReasons: string[];
+						summaries: number | null;
+						observations: number | null;
+						diagnostics: ExtractionStructuralDiagnostics | null;
+						elapsedMs: number | null;
+						usage: ObserverTokenUsage | null;
+						quality: ExtractionBenchmarkScore | null;
+					};
 					telemetry: {
 						totalElapsedMs: number | null;
 						totalUsage: ObserverTokenUsage | null;
@@ -1208,6 +1270,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					cost: {
 						initial: ExtractionModelCostEstimate | null;
 						repair: ExtractionModelCostEstimate | null;
+						retry: ExtractionModelCostEstimate | null;
 						total: ExtractionModelCostEstimate | null;
 						unavailableReason:
 							| "missing_usage"
@@ -1242,9 +1305,17 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						const initialCost = costModel
 							? estimateExtractionModelCost(costModel, result.observer.initialUsage)
 							: null;
-						const repairCost = costModel
+						const secondAttemptCost = costModel
 							? estimateExtractionModelCost(costModel, result.observer.repairedUsage)
 							: null;
+						const repairCost = benchmarkSecondAttemptValue(
+							result.observer.repairAttempted,
+							secondAttemptCost,
+						);
+						const retryCost = benchmarkSecondAttemptValue(
+							result.observer.retryAttempted,
+							secondAttemptCost,
+						);
 						const totalCost = costModel
 							? estimateExtractionModelCost(costModel, result.observer.totalUsage)
 							: null;
@@ -1268,7 +1339,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 									expectedSummaryDisposition: batch.expectedSummaryDisposition,
 								})
 							: null;
-						const repairQuality =
+						const secondAttemptQuality =
 							result.observer.repairedParsed && result.observer.repairedDiagnostics
 								? scoreExtractionBenchmarkOutput({
 										parsed: result.observer.repairedParsed,
@@ -1277,7 +1348,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 											status: "unreviewed",
 											reviewerNotes: "No durable-fact review has been recorded for this batch.",
 										},
-										estimatedCostUsd: repairCost?.totalCostUsd ?? null,
+										estimatedCostUsd: secondAttemptCost?.totalCostUsd ?? null,
 										expectedSummaryDisposition: batch.expectedSummaryDisposition,
 									})
 								: null;
@@ -1299,6 +1370,16 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 							finalFailureReasons: result.evaluation.failureReasons,
 							initialQuality,
 							finalQuality,
+						});
+						const repairAttempt = buildBenchmarkSecondAttempt(result, {
+							attempted: result.observer.repairAttempted,
+							reason: null,
+							quality: secondAttemptQuality,
+						});
+						const retryAttempt = buildBenchmarkSecondAttempt(result, {
+							attempted: result.observer.retryAttempted,
+							reason: result.observer.retryReason,
+							quality: secondAttemptQuality,
 						});
 						runs.push({
 							iteration,
@@ -1334,6 +1415,8 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 							summaries: result.evaluation.counts.summaries,
 							observations: result.evaluation.counts.observations,
 							repairApplied: result.observer.repairApplied,
+							retryAttempted: result.observer.retryAttempted,
+							retryReason: result.observer.retryReason,
 							initial: {
 								raw: result.observer.initialRaw,
 								status: result.initialClassification.status,
@@ -1349,18 +1432,19 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 							},
 							repair: {
 								applied: result.observer.repairApplied,
-								raw: result.observer.repairedRaw,
-								status: result.repairedClassification?.status ?? null,
-								reason: result.repairedClassification?.reason ?? null,
-								pass: result.repairedEvaluation?.pass ?? null,
-								failureReasons: result.repairedEvaluation?.failureReasons ?? [],
-								summaries: result.repairedEvaluation?.counts.summaries ?? null,
-								observations: result.repairedEvaluation?.counts.observations ?? null,
-								diagnostics: result.observer.repairedDiagnostics,
-								elapsedMs: result.observer.repairedElapsedMs,
-								usage: result.observer.repairedUsage,
-								quality: repairQuality,
+								raw: repairAttempt.raw,
+								status: repairAttempt.status,
+								reason: repairAttempt.resultReason,
+								pass: repairAttempt.pass,
+								failureReasons: repairAttempt.failureReasons,
+								summaries: repairAttempt.summaries,
+								observations: repairAttempt.observations,
+								diagnostics: repairAttempt.diagnostics,
+								elapsedMs: repairAttempt.elapsedMs,
+								usage: repairAttempt.usage,
+								quality: repairAttempt.quality,
 							},
+							retry: retryAttempt,
 							telemetry: {
 								totalElapsedMs: result.observer.totalElapsedMs,
 								totalUsage: result.observer.totalUsage,
@@ -1369,6 +1453,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 							cost: {
 								initial: initialCost,
 								repair: repairCost,
+								retry: retryCost,
 								total: totalCost,
 								unavailableReason: costUnavailableReason,
 							},
@@ -1528,7 +1613,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						run.telemetry.totalElapsedMs == null ? "n/a" : `${run.telemetry.totalElapsedMs}ms`;
 					const missingRequired = run.quality?.requiredRecall.missingLabelIds.join(",") || "none";
 					p.log.message(
-						`  [${run.batchId}#${run.iteration}] ${run.status.padEnd(18)} ${run.complexity.padEnd(10)} tier=${run.tier.padEnd(6)} expected=${(run.expectedTier ?? "n/a").padEnd(6)} disposition=${run.quality?.summaryDisposition.actual ?? "n/a"}/${run.expectedSummaryDisposition} span=${String(run.analysis.eventSpan).padEnd(3)} prompts=${run.analysis.promptCount} tools=${String(run.analysis.toolCount).padEnd(2)} transcript=${run.analysis.transcriptLength} ${run.provider}/${run.model} [${run.transport}] initial=${run.initial.summaries}s/${run.initial.observations}o final=${run.summaries}s/${run.observations}o quality=${qualityLabel} coverage=${run.quality?.weightedQualityCoverage?.toFixed(3) ?? "n/a"} required_missing=${missingRequired} cost=${costLabel} latency=${latencyLabel} schema_loss=${run.initial.diagnostics?.dataLoss === true ? "yes" : "no"} fallback=${run.modelFallbackApplied ? "yes" : "no"} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
+						`  [${run.batchId}#${run.iteration}] ${run.status.padEnd(18)} ${run.complexity.padEnd(10)} tier=${run.tier.padEnd(6)} expected=${(run.expectedTier ?? "n/a").padEnd(6)} disposition=${run.quality?.summaryDisposition.actual ?? "n/a"}/${run.expectedSummaryDisposition} span=${String(run.analysis.eventSpan).padEnd(3)} prompts=${run.analysis.promptCount} tools=${String(run.analysis.toolCount).padEnd(2)} transcript=${run.analysis.transcriptLength} ${run.provider}/${run.model} [${run.transport}] initial=${run.initial.summaries}s/${run.initial.observations}o final=${run.summaries}s/${run.observations}o quality=${qualityLabel} coverage=${run.quality?.weightedQualityCoverage?.toFixed(3) ?? "n/a"} required_missing=${missingRequired} cost=${costLabel} latency=${latencyLabel} schema_loss=${run.initial.diagnostics?.dataLoss === true ? "yes" : "no"} fallback=${run.modelFallbackApplied ? "yes" : "no"} repair=${run.repairApplied ? "yes" : "no"} retry=${run.retryAttempted ? (run.retryReason ?? "yes") : "no"} — ${run.label}`,
 					);
 				}
 				p.outro("done");

--- a/packages/core/src/extraction-replay.test.ts
+++ b/packages/core/src/extraction-replay.test.ts
@@ -18,6 +18,27 @@ function createDbPath(name: string): string {
 	);
 }
 
+function createSingleEventReplayFixture(name: string, batchId: number): string {
+	const dbPath = createDbPath(name);
+	const db = new Database(dbPath);
+	try {
+		initTestSchema(db);
+		db.exec(`
+			INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+			  (400001, '2026-09-07T20:00:00Z', '2026-09-07T20:01:00Z', '/tmp/repo', 'codemem', 'test', 'test', '{}');
+			INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+			  ('opencode', 'structured-retry', 'structured-retry', 400001, '2026-09-07T20:00:00Z');
+			INSERT INTO raw_event_flush_batches(id, source, stream_id, opencode_session_id, start_event_seq, end_event_seq, extractor_version, status, attempt_count, created_at, updated_at) VALUES
+			  (${batchId}, 'opencode', 'structured-retry', 'structured-retry', 1, 1, 'raw_events_v1', 'completed', 1, '2026-09-07T20:00:00Z', '2026-09-07T20:01:00Z');
+			INSERT INTO raw_events(source, stream_id, opencode_session_id, event_id, event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, created_at) VALUES
+			  ('opencode', 'structured-retry', 'structured-retry', 'evt-structured-retry', 1, 'user_prompt', 1000, 1, '{"type":"user_prompt","prompt_text":"Capture durable output"}', '2026-09-07T20:00:00Z');
+		`);
+	} finally {
+		db.close();
+	}
+	return dbPath;
+}
+
 function replayObserverConfig(overrides: Partial<ObserverConfig> = {}): ObserverConfig {
 	return {
 		observerProvider: "openai",
@@ -46,6 +67,60 @@ function replayObserverConfig(overrides: Partial<ObserverConfig> = {}): Observer
 }
 
 describe("extraction replay", () => {
+	it("does not classify a transport-only structured retry as schema loss", async () => {
+		const batchId = 40001;
+		const dbPath = createSingleEventReplayFixture("structured-transport-retry", batchId);
+		let callCount = 0;
+		const observer = {
+			provider: "openai",
+			model: "test-model",
+			requestedModel: "test-model",
+			runtime: "api_http",
+			openaiUseResponses: true,
+			outputMode: "auto",
+			hasCustomBaseUrl: false,
+			maxChars: 12_000,
+			observeStructuredJson: async () => {
+				callCount += 1;
+				return {
+					raw:
+						callCount === 1
+							? null
+							: JSON.stringify({
+									schema_version: 1,
+									status: "skipped",
+									observations: [],
+									summary: null,
+									skip_reason: "low-signal",
+								}),
+					parsed: null,
+					provider: "openai",
+					model: "test-model",
+					elapsedMs: 2,
+					usage: null,
+					usedStructuredOutputs: true,
+					failureReason: null,
+					transportFailureCode: callCount === 1 ? "rate_limited" : null,
+				};
+			},
+			getStatus: () => ({
+				provider: "openai",
+				model: "test-model",
+				runtime: "api_http",
+				auth: { source: "test", type: "api_direct", hasToken: true },
+			}),
+		} as unknown as ObserverClient;
+
+		const result = await replayBatchExtraction(dbPath, observer, {
+			batchId,
+			scenarioId: "simple-batch-shape",
+		});
+
+		expect(callCount).toBe(2);
+		expect(result.observer.retryReason).toBe("rate_limited");
+		expect(result.observer.initialDiagnostics?.dataLoss).toBe(false);
+	});
+
 	it.each([
 		{ tier: "simple", eventSpan: 12, toolCount: 1, expectedModel: "gpt-5.6-luna" },
 		{ tier: "rich", eventSpan: 153, toolCount: 12, expectedModel: "gpt-5.6-terra" },
@@ -264,6 +339,12 @@ describe("extraction replay", () => {
 		expect(result.observer.temperature).toBeNull();
 		expect(result.observer.modelFallbackApplied).toBe(false);
 		expect(result.observer.repairApplied).toBe(true);
+		expect(result.observer.requestedOutputMode).toBe("legacy_xml");
+		expect(result.observer.actualOutputMode).toBe("legacy_xml");
+		expect(result.observer.outputSchemaVersion).toBeNull();
+		expect(result.observer.outputCapabilityReason).toBe("client_capability_unspecified");
+		expect(result.observer.outputValidation).toBe("not_applicable");
+		expect(result.observer.repairAttempted).toBe(true);
 		expect(result.observer.initialRaw).toContain(
 			"<observation><type>decision</type><title>Track 3 reframed",
 		);

--- a/packages/core/src/extraction-replay.ts
+++ b/packages/core/src/extraction-replay.ts
@@ -17,11 +17,7 @@ import {
 	projectAdapterToolEvent,
 } from "./ingest-events.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
-import {
-	buildObserverPrompt,
-	buildObserverRepairPrompt,
-	truncateObserverTranscript,
-} from "./ingest-prompts.js";
+import { buildObserverPrompt, truncateObserverTranscript } from "./ingest-prompts.js";
 import {
 	buildTranscript,
 	deriveRequest,
@@ -39,19 +35,20 @@ import type {
 	SessionContext,
 	ToolEvent,
 } from "./ingest-types.js";
-import {
-	parseObserverResponse,
-	SUPPORTED_OBSERVATION_KINDS,
-	shouldPreferRepairedObserverResponse,
-	shouldRepairObserverResponse,
-} from "./ingest-xml-parser.js";
+import { SUPPORTED_OBSERVATION_KINDS } from "./ingest-xml-parser.js";
 import {
 	type ObserverClient,
 	ObserverClient as ObserverClientImpl,
 	type ObserverConfig,
-	type ObserverStatus,
 	type ObserverTokenUsage,
 } from "./observer-client.js";
+import {
+	type ObserverOutputCapabilityReason,
+	type ObserverOutputMode,
+	type ObserverOutputValidation,
+	observeAndNormalizeObserverOutput,
+	resolveObserverOutputCapability,
+} from "./observer-output.js";
 import { resolveProject } from "./project.js";
 import { buildSessionContext } from "./raw-event-flush.js";
 
@@ -67,15 +64,6 @@ function normalizePath(path: string, repoRoot: string | null): string {
 
 function normalizePaths(paths: string[], repoRoot: string | null): string[] {
 	return paths.map((p) => normalizePath(p, repoRoot)).filter(Boolean);
-}
-
-function snapshotObserverStatus(observer: ObserverClient): ObserverStatus {
-	const status = observer.getStatus();
-	return {
-		...status,
-		auth: { ...status.auth },
-		...(status.lastError ? { lastError: { ...status.lastError } } : {}),
-	};
 }
 
 function summaryBody(summary: ParsedSummary): string {
@@ -116,76 +104,6 @@ function normalizeEventsForToolExtraction(
 	return toolEvents;
 }
 
-async function observeStructuredOutput(
-	observer: ObserverClient,
-	system: string,
-	user: string,
-): Promise<{
-	initial: {
-		raw: string | null;
-		parsed: ParsedOutput;
-		provider: string;
-		model: string;
-		elapsedMs: number | null;
-		usage: ObserverTokenUsage | null;
-		status: ObserverStatus;
-	};
-	repaired: {
-		raw: string | null;
-		parsed: ParsedOutput;
-		provider: string;
-		model: string;
-		elapsedMs: number | null;
-		usage: ObserverTokenUsage | null;
-		status: ObserverStatus;
-	} | null;
-}> {
-	const first = await observer.observe(system, user);
-	const firstParsed = first.raw
-		? parseObserverResponse(first.raw)
-		: { observations: [], summary: null, skipSummaryReason: null };
-	const initial = {
-		raw: first.raw,
-		parsed: firstParsed,
-		provider: first.provider,
-		model: first.model,
-		elapsedMs: first.elapsedMs ?? null,
-		usage: first.usage ?? null,
-		status: snapshotObserverStatus(observer),
-	};
-	if (!shouldRepairObserverResponse(first.raw, firstParsed)) {
-		return { initial, repaired: null };
-	}
-
-	const repairPrompt = buildObserverRepairPrompt(
-		system,
-		user,
-		first.raw as string,
-		observer.maxChars,
-	);
-	let repaired: Awaited<ReturnType<ObserverClient["observe"]>>;
-	try {
-		repaired = await observer.observe(repairPrompt.system, repairPrompt.user);
-	} catch {
-		return { initial, repaired: null };
-	}
-	const repairedParsed = repaired.raw
-		? parseObserverResponse(repaired.raw)
-		: { observations: [], summary: null, skipSummaryReason: null };
-	return {
-		initial,
-		repaired: {
-			raw: repaired.raw,
-			parsed: repairedParsed,
-			provider: repaired.provider,
-			model: repaired.model,
-			elapsedMs: repaired.elapsedMs ?? null,
-			usage: repaired.usage ?? null,
-			status: snapshotObserverStatus(observer),
-		},
-	};
-}
-
 function sumObserverUsage(
 	initial: ObserverTokenUsage | null,
 	repaired: ObserverTokenUsage | null,
@@ -212,6 +130,46 @@ function sumObserverUsage(
 		...(totalTokens != null ? { totalTokens } : {}),
 		...(cacheReadInputTokens != null ? { cacheReadInputTokens } : {}),
 		...(cacheCreationInputTokens != null ? { cacheCreationInputTokens } : {}),
+	};
+}
+
+function validatedEnvelopeDiagnostics(
+	parsed: ParsedOutput,
+): ReturnType<typeof evaluateExtractionStructure> {
+	const observationCount = parsed.observations.length;
+	const summaryCount = parsed.summary ? 1 : 0;
+	return {
+		recognizedOutput: true,
+		observationBlocks: observationCount,
+		retainedObservations: observationCount,
+		summaryBlocks: summaryCount,
+		retainedSummaries: summaryCount,
+		illegalObservationNestingInSummary: 0,
+		unknownSummaryFields: [],
+		unsupportedObservationKinds: [],
+		missingObservationKinds: 0,
+		discardedObservationBlocks: 0,
+		discardedSummaryBlocks: 0,
+		dataLoss: false,
+	};
+}
+
+function failedStructuredAttemptDiagnostics(options: {
+	dataLoss: boolean;
+}): ReturnType<typeof evaluateExtractionStructure> {
+	return {
+		recognizedOutput: false,
+		observationBlocks: 0,
+		retainedObservations: 0,
+		summaryBlocks: 0,
+		retainedSummaries: 0,
+		illegalObservationNestingInSummary: 0,
+		unknownSummaryFields: [],
+		unsupportedObservationKinds: [],
+		missingObservationKinds: 0,
+		discardedObservationBlocks: 0,
+		discardedSummaryBlocks: 0,
+		dataLoss: options.dataLoss,
 	};
 }
 
@@ -248,6 +206,17 @@ export interface ExtractionReplayResult {
 		maxOutputTokens: number | null;
 		temperature: number | null;
 		repairApplied: boolean;
+		requestedOutputMode: ObserverOutputMode;
+		actualOutputMode: Exclude<ObserverOutputMode, "forced_tool">;
+		outputSchemaVersion: number | null;
+		outputCapabilityReason: ObserverOutputCapabilityReason;
+		outputFallbackApplied: boolean;
+		outputFallbackReason: ObserverOutputCapabilityReason | null;
+		outputValidation: ObserverOutputValidation;
+		outputFailureReason: string | null;
+		repairAttempted: boolean;
+		retryAttempted: boolean;
+		retryReason: string | null;
 		initialRaw: string | null;
 		initialElapsedMs: number | null;
 		initialUsage: ObserverTokenUsage | null;
@@ -305,8 +274,6 @@ interface PreparedReplayBatch {
 	};
 	sessionContext: SessionContext;
 	observerContext: ObserverContext;
-	system: string;
-	user: string;
 	sessionPost: Record<string, unknown>;
 	analysis: ReplayBatchAnalysis;
 }
@@ -589,7 +556,6 @@ async function prepareReplayBatch(
 			diffSummary: "",
 			recentFiles: "",
 		};
-		const { system, user } = buildObserverPrompt(observerContext);
 		const sessionMeta = (() => {
 			try {
 				return batch.metadata_json
@@ -611,8 +577,6 @@ async function prepareReplayBatch(
 			},
 			sessionContext,
 			observerContext,
-			system,
-			user,
 			sessionPost: post,
 			analysis: {
 				batchId: batch.id,
@@ -638,7 +602,16 @@ async function replayPreparedBatch(
 	tierReasons: string[],
 ): Promise<ExtractionReplayResult> {
 	const configuredModel = observer.requestedModel ?? observer.model;
-	const response = await observeStructuredOutput(observer, prepared.system, prepared.user);
+	const outputCapability = resolveObserverOutputCapability(observer);
+	const prompt = buildObserverPrompt(prepared.observerContext, {
+		outputMode: outputCapability.actualMode,
+	});
+	const response = await observeAndNormalizeObserverOutput(
+		observer,
+		prompt.system,
+		prompt.user,
+		outputCapability,
+	);
 	const requestedModel = configuredModel || response.initial.model;
 	const session = {
 		id: prepared.batch.session_id,
@@ -668,17 +641,8 @@ async function replayPreparedBatch(
 				prepared.scenario,
 			)
 		: null;
-	const preferRepaired = response.repaired
-		? shouldPreferRepairedObserverResponse(
-				response.initial.parsed,
-				response.repaired.raw,
-				response.repaired.parsed,
-				response.initial.raw,
-			)
-		: false;
-	const finalResponse = preferRepaired
-		? (response.repaired as NonNullable<typeof response.repaired>)
-		: response.initial;
+	const preferRepaired = response.repairApplied || response.retryApplied;
+	const finalResponse = response.final;
 	const observerStatus = finalResponse.status;
 	const modelFallbackApplied = observerStatus.modelFallbackApplied === true;
 	const resolvedModel = modelFallbackApplied
@@ -697,22 +661,36 @@ async function replayPreparedBatch(
 				evaluation: repairedEvaluation ?? initialEvaluation,
 			})
 		: null;
-	const initialDiagnostics = evaluateExtractionStructure(
-		response.initial.raw ?? "",
-		response.initial.parsed,
-	);
-	const repairedDiagnostics = response.repaired
-		? evaluateExtractionStructure(response.repaired.raw ?? "", response.repaired.parsed)
-		: null;
-	const repairAttempted = response.repaired !== null;
+	let initialDiagnostics: ReturnType<typeof evaluateExtractionStructure>;
+	if (response.diagnostics.actualMode === "legacy_xml") {
+		initialDiagnostics = evaluateExtractionStructure(
+			response.initial.raw ?? "",
+			response.initial.parsed,
+		);
+	} else if (response.retryApplied) {
+		initialDiagnostics = failedStructuredAttemptDiagnostics({
+			dataLoss: response.initial.raw != null,
+		});
+	} else {
+		initialDiagnostics = validatedEnvelopeDiagnostics(response.initial.parsed);
+	}
+	let repairedDiagnostics: ReturnType<typeof evaluateExtractionStructure> | null = null;
+	if (response.repaired) {
+		repairedDiagnostics =
+			response.diagnostics.actualMode === "legacy_xml"
+				? evaluateExtractionStructure(response.repaired.raw ?? "", response.repaired.parsed)
+				: validatedEnvelopeDiagnostics(response.repaired.parsed);
+	}
+	const repairAttempted = response.diagnostics.repairAttempted;
+	const secondAttempted = repairAttempted || response.diagnostics.retryAttempted;
 	const totalElapsedMs =
-		response.initial.elapsedMs != null && (!repairAttempted || response.repaired?.elapsedMs != null)
+		response.initial.elapsedMs != null && (!secondAttempted || response.repaired?.elapsedMs != null)
 			? response.initial.elapsedMs + (response.repaired?.elapsedMs ?? 0)
 			: null;
 	const totalUsage = sumObserverUsage(
 		response.initial.usage,
 		response.repaired?.usage ?? null,
-		repairAttempted,
+		secondAttempted,
 	);
 	const transport =
 		observerStatus.auth.type === "codex_consumer" ||
@@ -750,7 +728,18 @@ async function replayPreparedBatch(
 			reasoningSummary: reportsReasoning ? observer.reasoningSummary : null,
 			maxOutputTokens: reportsRequestLimits ? observer.maxOutputTokens : null,
 			temperature: reportsRequestLimits ? observer.temperature : null,
-			repairApplied: preferRepaired,
+			repairApplied: response.repairApplied,
+			requestedOutputMode: response.diagnostics.requestedMode,
+			actualOutputMode: response.diagnostics.actualMode,
+			outputSchemaVersion: response.diagnostics.schemaVersion,
+			outputCapabilityReason: response.diagnostics.capabilityReason,
+			outputFallbackApplied: response.diagnostics.fallbackApplied,
+			outputFallbackReason: response.diagnostics.fallbackReason,
+			outputValidation: response.diagnostics.validation,
+			outputFailureReason: response.diagnostics.failureReason,
+			repairAttempted,
+			retryAttempted: response.diagnostics.retryAttempted,
+			retryReason: response.diagnostics.retryReason,
 			initialRaw: response.initial.raw,
 			initialElapsedMs: response.initial.elapsedMs,
 			initialUsage: response.initial.usage,
@@ -765,9 +754,7 @@ async function replayPreparedBatch(
 			totalElapsedMs,
 			totalUsage,
 			parsed: finalResponse.parsed,
-			diagnostics: preferRepaired
-				? (repairedDiagnostics as NonNullable<typeof repairedDiagnostics>)
-				: initialDiagnostics,
+			diagnostics: preferRepaired ? repairedDiagnostics : initialDiagnostics,
 		},
 		observerContext: prepared.observerContext,
 		initialClassification,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -653,6 +653,7 @@ export {
 	writeCodememConfigFile,
 	writeWorkspaceCodememConfigFile,
 } from "./observer-config.js";
+export * from "./observer-output.js";
 export * from "./observer-output-schema.js";
 export * from "./operational-status.js";
 export * from "./outcome-evidence.js";

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -2109,6 +2109,77 @@ describe("ingest() integration", { timeout: 15_000 }, () => {
 		expect(summaryMetadata.learned).toBe("Race condition in handler");
 	});
 
+	it("persists normalized JSON Schema output and content-free mode metadata", async () => {
+		const structuredObserver = {
+			provider: "openai",
+			model: "gpt-test",
+			runtime: "api_http",
+			openaiUseResponses: true,
+			outputMode: "auto",
+			hasCustomBaseUrl: false,
+			tierRoutingEnabled: false,
+			maxChars: 12_000,
+			observe: async () => {
+				throw new Error("legacy XML path must not run");
+			},
+			observeStructuredJson: async () => ({
+				raw: JSON.stringify({
+					schema_version: 1,
+					status: "captured",
+					observations: [
+						{
+							kind: "discovery",
+							title: "Schema output reached ingest",
+							narrative: "The shared boundary normalized provider JSON.",
+							subtitle: null,
+							facts: ["The persisted path did not parse XML."],
+							concepts: ["problem-solution"],
+							files_read: [],
+							files_modified: ["packages/core/src/ingest-pipeline.ts"],
+						},
+					],
+					summary: null,
+					skip_reason: null,
+				}),
+				parsed: null,
+				provider: "openai",
+				model: "gpt-test",
+				elapsedMs: 7,
+				usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+				usedStructuredOutputs: true,
+				failureReason: null,
+			}),
+			getStatus: () => ({
+				provider: "openai",
+				model: "gpt-test",
+				runtime: "api_http",
+				auth: { source: "test", type: "api_direct", hasToken: true },
+			}),
+		};
+
+		await ingest(buildPayload(), store, {
+			observer: structuredObserver,
+			storeSummary: false,
+		} as unknown as IngestOptions);
+
+		const metadata = observerMemoryMetadata("Schema output reached ingest");
+		expect(metadata).toEqual(
+			expect.objectContaining({
+				observer_requested_output_mode: "json_schema",
+				observer_output_mode: "json_schema",
+				observer_output_schema_version: 1,
+				observer_output_validation: "valid",
+				observer_output_repair_attempted: false,
+				observer_output_initial_elapsed_ms: 7,
+			}),
+		);
+		expect(metadata.observer_output_initial_usage).toEqual({
+			inputTokens: 10,
+			outputTokens: 20,
+			totalTokens: 30,
+		});
+	});
+
 	it("repairs a structured response when parsing would discard an observation", async () => {
 		const calls: Array<{ system: string; user: string }> = [];
 		const lossy = `<summary>

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -35,11 +35,7 @@ import {
 	projectAdapterToolEvent,
 } from "./ingest-events.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
-import {
-	buildObserverPrompt,
-	buildObserverRepairPrompt,
-	truncateObserverTranscript,
-} from "./ingest-prompts.js";
+import { buildObserverPrompt, truncateObserverTranscript } from "./ingest-prompts.js";
 import { type CaptureRoutedObservation, routeObservationsForCapture } from "./ingest-routing.js";
 import {
 	buildTranscript,
@@ -54,19 +50,18 @@ import {
 import type {
 	IngestPayload,
 	ObserverContext,
-	ParsedOutput,
 	ParsedSummary,
 	SessionContext,
 	ToolEvent,
 } from "./ingest-types.js";
-import {
-	hasMeaningfulObservation,
-	parseObserverResponse,
-	shouldPreferRepairedObserverResponse,
-	shouldRepairObserverResponse,
-} from "./ingest-xml-parser.js";
+import { hasMeaningfulObservation } from "./ingest-xml-parser.js";
 import { REMEMBER_MEMORY_KINDS } from "./memory-kinds.js";
 import { type ObserverClient, ObserverClient as ObserverClientImpl } from "./observer-client.js";
+import {
+	observeAndNormalizeObserverOutput,
+	observerOutputMetadata,
+	resolveObserverOutputCapability,
+} from "./observer-output.js";
 import { resolveProject } from "./project.js";
 import * as schema from "./schema.js";
 import { classifySessionForInjection, shouldSuppressSummaryOnlyOutput } from "./session-policy.js";
@@ -320,67 +315,14 @@ export function rawEventObserverStatusFromError(
 	return observerFailureStatuses.get(error) ?? null;
 }
 
-async function observeStructuredOutput(
-	observer: ObserverClient,
-	system: string,
-	user: string,
-): Promise<{ raw: string | null; parsed: ParsedOutput; provider: string; model: string }> {
-	const first = await observer.observe(system, user);
-	const firstParsed = first.raw
-		? parseObserverResponse(first.raw)
-		: { observations: [], summary: null, skipSummaryReason: null };
-	if (!shouldRepairObserverResponse(first.raw, firstParsed)) {
-		return {
-			raw: first.raw,
-			parsed: firstParsed,
-			provider: first.provider,
-			model: first.model,
-		};
-	}
-
-	const repairPrompt = buildObserverRepairPrompt(
-		system,
-		user,
-		first.raw as string,
-		observer.maxChars,
-	);
-	let repaired: Awaited<ReturnType<ObserverClient["observe"]>>;
-	try {
-		repaired = await observer.observe(repairPrompt.system, repairPrompt.user);
-	} catch {
-		return {
-			raw: first.raw,
-			parsed: firstParsed,
-			provider: first.provider,
-			model: first.model,
-		};
-	}
-	const repairedParsed = repaired.raw
-		? parseObserverResponse(repaired.raw)
-		: { observations: [], summary: null, skipSummaryReason: null };
-	if (!shouldPreferRepairedObserverResponse(firstParsed, repaired.raw, repairedParsed, first.raw)) {
-		return {
-			raw: first.raw,
-			parsed: firstParsed,
-			provider: first.provider,
-			model: first.model,
-		};
-	}
-	return {
-		raw: repaired.raw,
-		parsed: repairedParsed,
-		provider: repaired.provider,
-		model: repaired.model,
-	};
-}
-
 async function observeRawEventOutput(
 	observer: ObserverClient,
 	system: string,
 	user: string,
-): Promise<Awaited<ReturnType<typeof observeStructuredOutput>>> {
+	capability: ReturnType<typeof resolveObserverOutputCapability>,
+): Promise<Awaited<ReturnType<typeof observeAndNormalizeObserverOutput>>> {
 	try {
-		return await observeStructuredOutput(observer, system, user);
+		return await observeAndNormalizeObserverOutput(observer, system, user, capability);
 	} catch (error) {
 		if ((typeof error === "object" || typeof error === "function") && error !== null) {
 			observerFailureStatuses.set(error, observer.getStatus());
@@ -594,12 +536,17 @@ export async function ingest(
 				: new ObserverClientImpl(tierConfig);
 		}
 
-		const { system, user } = buildObserverPrompt(observerContext);
+		const outputCapability = resolveObserverOutputCapability(selectedObserver);
+		const { system, user } = buildObserverPrompt(observerContext, {
+			outputMode: outputCapability.actualMode,
+		});
 
 		// ------------------------------------------------------------------
 		// Call observer LLM
 		// ------------------------------------------------------------------
-		const response = await observeRawEventOutput(selectedObserver, system, user);
+		const output = await observeRawEventOutput(selectedObserver, system, user, outputCapability);
+		const response = output.final;
+		const outputMetadata = observerOutputMetadata(output);
 
 		if (!response.raw) {
 			// Raw-event flushes must be lossless: if the observer returns no output,
@@ -629,10 +576,10 @@ export async function ingest(
 		const parsed = response.parsed;
 		if (
 			sessionContext?.flusher === "raw_events" &&
+			output.diagnostics.failureReason === "legacy_xml_lossy" &&
 			(parsed.observations.length > 0 ||
 				parsed.summary !== null ||
-				parsed.skipSummaryReason !== null) &&
-			shouldRepairObserverResponse(rawText, parsed)
+				parsed.skipSummaryReason !== null)
 		) {
 			throw new RawEventObserverOutputError(
 				"observer repair remained lossy during raw-event flush",
@@ -845,6 +792,7 @@ export async function ingest(
 					observer_openai_responses: selectedObserver.openaiUseResponses,
 					observer_fallback_applied: observerFallbackApplied,
 					observer_fallback_reason: observerFallbackReason,
+					...outputMetadata,
 					flush_batch: flushBatchMetadata,
 				});
 				vectorWriteInputs.push({ memoryId, title: memoryTitle, bodyText });
@@ -898,6 +846,7 @@ export async function ingest(
 						observer_openai_responses: selectedObserver.openaiUseResponses,
 						observer_fallback_applied: observerFallbackApplied,
 						observer_fallback_reason: observerFallbackReason,
+						...outputMetadata,
 						files_read: summary.filesRead,
 						files_modified: summary.filesModified,
 						source: "observer_summary",
@@ -949,6 +898,7 @@ export async function ingest(
 						openai_responses: selectedObserver.openaiUseResponses,
 						fallback_applied: observerFallbackApplied,
 						fallback_reason: observerFallbackReason,
+						...outputMetadata,
 						session_usage_tokens: usageTokenTotal,
 					}),
 				})
@@ -982,6 +932,7 @@ export async function ingest(
 			observer_openai_responses: selectedObserver.openaiUseResponses,
 			observer_fallback_applied: observerFallbackApplied,
 			observer_fallback_reason: observerFallbackReason,
+			...outputMetadata,
 		});
 	} catch (err) {
 		// End session even on error

--- a/packages/core/src/ingest-prompts.test.ts
+++ b/packages/core/src/ingest-prompts.test.ts
@@ -6,6 +6,36 @@ import {
 } from "./ingest-prompts.js";
 
 describe("buildObserverPrompt", () => {
+	it("requests only the supplied JSON Schema contract in json_schema mode", () => {
+		const { system } = buildObserverPrompt(
+			{
+				project: "codemem",
+				userPrompt: "capture this",
+				promptNumber: 1,
+				transcript: "",
+				toolEvents: [],
+				lastAssistantMessage: null,
+				includeSummary: true,
+				diffSummary: "",
+				recentFiles: "",
+			},
+			{ outputMode: "json_schema" },
+		);
+
+		expect(system).toContain("conforms exactly to the supplied JSON Schema");
+		expect(system).not.toContain("Observation XML schema");
+		expect(system).not.toContain("Summary XML schema");
+		expect(system).not.toContain("<observation>");
+		expect(system).not.toContain("<summary>");
+		expect(system).not.toContain("<skip_summary");
+		expect(system).not.toContain("Before writing XML");
+		expect(system).not.toContain("Output only XML");
+		expect(system).not.toMatch(/<\/?[a-z_]+(?:\s|\/?>)/i);
+		expect(system).toContain("Emit a summary unless status is skipped");
+		expect(system).toContain("Only summarize what is evidenced in the session context");
+		expect(system).toContain("aim for ~150-450 words");
+	});
+
 	it("includes the Python parity examples and schema guidance", () => {
 		const { system } = buildObserverPrompt({
 			project: "codemem",

--- a/packages/core/src/ingest-prompts.ts
+++ b/packages/core/src/ingest-prompts.ts
@@ -83,6 +83,26 @@ const RICH_SESSION_GUIDANCE = `When the session contains MULTIPLE meaningful thr
 - Choose subthreads that future sessions would most want for rediscovery reduction: important decisions, durable learnings, shipped changes, closed investigations, or troubleshooting outcomes.
 - If one thread clearly dominates and the rest are trivial, keep a single observation. Do not invent diversity where none exists.`;
 
+function jsonOutputGuidance(guidance: string): string {
+	return guidance
+		.replace(
+			"Output only XML. Do not include commentary outside XML.",
+			"Return only the supplied JSON object.",
+		)
+		.replace("Output no <observation> blocks", "Return no observations")
+		.replace(
+			'Output <skip_summary reason="low-signal"/> instead of a <summary> block.',
+			'Set status to skipped with skip_reason "low-signal" and summary to null.',
+		)
+		.replaceAll("an <observation>", "an observation")
+		.replaceAll("in <summary>", "in the summary")
+		.replace("Before writing XML", "Before producing output")
+		.replaceAll("the <summary>", "the summary")
+		.replaceAll("<observation> blocks", "observations")
+		.replaceAll("<observation>", "observation")
+		.replaceAll("a <summary>", "a summary");
+}
+
 const OUTPUT_GUIDANCE =
 	"Output only XML. Do not include commentary outside XML.\n\n" +
 	"Emit <observation> blocks only for content that passes the observation worthiness bar. " +
@@ -187,6 +207,18 @@ For rich sessions, make the summary broad enough that a future reader can see th
 
 This summary helps future sessions understand where this work left off.`;
 
+const SUMMARY_GUIDANCE = `Summary fields describe the current state of the primary work, not the observation process:
+- request: what the user requested and the goal of the session.
+- investigated: files, systems, logs, questions, and approaches examined.
+- learned: durable discoveries about the codebase, architecture, or domain.
+- completed: shipped work and concrete outcomes, including specific files and behavior changes.
+- next_steps: remaining work, blockers, dependencies, and the next useful action.
+- notes: relevant decisions, trade-offs, alternatives, or warnings not covered above.
+
+If the user prompt is a short approval or acknowledgement ("yes", "ok", "approved"), infer the request from the observed work and the completed or learned fields instead.
+Only summarize what is evidenced in the session context. Do not infer or fabricate file edits, behaviors, or outcomes that are not explicitly observed.
+Keep summaries concise (aim for ~150-450 words total across all fields). For rich sessions, cover the major subthreads so a future reader does not need every observation.`;
+
 // ---------------------------------------------------------------------------
 // XML escaping
 // ---------------------------------------------------------------------------
@@ -259,6 +291,47 @@ function truncateMiddle(text: string, limit: number): string {
 // Public API
 // ---------------------------------------------------------------------------
 
+function observerGuidance(outputMode: "json_schema" | "legacy_xml", guidance: string): string {
+	return outputMode === "json_schema" ? jsonOutputGuidance(guidance) : guidance;
+}
+
+function buildObserverSystemPrompt(
+	context: ObserverContext,
+	outputMode: "json_schema" | "legacy_xml",
+): string {
+	const systemBlocks: string[] = [
+		SYSTEM_IDENTITY,
+		"",
+		RECORDING_FOCUS,
+		"",
+		observerGuidance(outputMode, SKIP_GUIDANCE),
+		"",
+		observerGuidance(outputMode, WORTHINESS_GUIDANCE),
+		"",
+		NARRATIVE_GUIDANCE,
+		"",
+		observerGuidance(outputMode, RICH_SESSION_GUIDANCE),
+	];
+	if (outputMode === "json_schema") {
+		systemBlocks.push(
+			"",
+			jsonOutputGuidance(OUTPUT_GUIDANCE),
+			"",
+			'Return one JSON object that conforms exactly to the supplied JSON Schema. Do not emit XML, Markdown, or prose outside the object. When nothing should be captured, set status to skipped, observations to [], summary to null, and skip_reason to exactly "low-signal".',
+		);
+	} else {
+		systemBlocks.push("", OUTPUT_GUIDANCE, "", "Observation XML schema:", OBSERVATION_SCHEMA);
+	}
+	if (context.includeSummary && outputMode === "legacy_xml") {
+		systemBlocks.push("", "Summary XML schema:", SUMMARY_SCHEMA);
+	} else if (context.includeSummary) {
+		systemBlocks.push("", SUMMARY_GUIDANCE, "", "Emit a summary unless status is skipped.");
+	} else if (outputMode === "json_schema") {
+		systemBlocks.push("", "No summary was requested. Set summary to null.");
+	}
+	return systemBlocks.join("\n\n").trim();
+}
+
 /**
  * Build the observer prompt from session context.
  *
@@ -269,33 +342,15 @@ function truncateMiddle(text: string, limit: number): string {
  * the user message. We split system/user for cleaner API mapping, but the
  * content is equivalent.
  */
-export function buildObserverPrompt(context: ObserverContext): {
+export function buildObserverPrompt(
+	context: ObserverContext,
+	options: { outputMode?: "json_schema" | "legacy_xml" } = {},
+): {
 	system: string;
 	user: string;
 } {
-	// System prompt: identity + guidance + schemas
-	const systemBlocks: string[] = [
-		SYSTEM_IDENTITY,
-		"",
-		RECORDING_FOCUS,
-		"",
-		SKIP_GUIDANCE,
-		"",
-		WORTHINESS_GUIDANCE,
-		"",
-		NARRATIVE_GUIDANCE,
-		"",
-		RICH_SESSION_GUIDANCE,
-		"",
-		OUTPUT_GUIDANCE,
-		"",
-		"Observation XML schema:",
-		OBSERVATION_SCHEMA,
-	];
-	if (context.includeSummary) {
-		systemBlocks.push("", "Summary XML schema:", SUMMARY_SCHEMA);
-	}
-	const system = systemBlocks.join("\n\n").trim();
+	const outputMode = options.outputMode ?? "legacy_xml";
+	const system = buildObserverSystemPrompt(context, outputMode);
 
 	// User prompt: observed session context
 	const userBlocks: string[] = ["Observed session context:"];

--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -42,6 +42,7 @@ describe("loadObserverConfig", () => {
 		"CODEMEM_OBSERVER_RICH_REASONING_SUMMARY",
 		"CODEMEM_OBSERVER_RICH_MAX_OUTPUT_TOKENS",
 		"CODEMEM_OBSERVER_OPENAI_USE_RESPONSES",
+		"CODEMEM_OBSERVER_OUTPUT_MODE",
 		"CODEMEM_OBSERVER_REASONING_EFFORT",
 		"CODEMEM_OBSERVER_REASONING_SUMMARY",
 		"CODEMEM_OBSERVER_MAX_OUTPUT_TOKENS",
@@ -246,6 +247,23 @@ describe("loadObserverConfig", () => {
 		expect(cfg.observerExplicitConfigKeys).toEqual(
 			expect.arrayContaining(["observerOpenAIUseResponses"]),
 		);
+	});
+
+	it("loads the observer output-mode rollback switch from config and env", () => {
+		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-config-test-"));
+		const configPath = join(tmpDir, "config.json");
+		writeFileSync(configPath, JSON.stringify({ observer_output_mode: "json_schema" }));
+		try {
+			process.env.CODEMEM_CONFIG = configPath;
+			expect(loadObserverConfig().observerOutputMode).toBe("json_schema");
+
+			process.env.CODEMEM_OBSERVER_OUTPUT_MODE = "legacy_xml";
+			const cfg = loadObserverConfig();
+			expect(cfg.observerOutputMode).toBe("legacy_xml");
+			expect(cfg.observerExplicitConfigKeys).toContain("observerOutputMode");
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
 	});
 });
 
@@ -1903,6 +1921,219 @@ describe("ObserverClient.observe()", () => {
 		expect(status.modelFallbackReason).toBe(
 			"configured sidecar tier model unavailable; retried with default Claude model",
 		);
+	});
+});
+
+describe("ObserverClient.observeStructuredJson() failures", () => {
+	function directClient(provider: "openai" | "anthropic"): ObserverClient {
+		return new ObserverClient({
+			observerProvider: provider,
+			observerModel: provider === "openai" ? "gpt-test" : "claude-test",
+			observerRuntime: "api_http",
+			observerApiKey: fixtureToken(`structured-${provider}`),
+			observerBaseUrl: null,
+			observerMaxChars: 12_000,
+			observerMaxTokens: 4_000,
+			observerHeaders: {},
+			observerAuthSource: "auto",
+			observerAuthFile: null,
+			observerAuthCommand: [],
+			observerAuthTimeoutMs: 1500,
+			observerAuthCacheTtlS: 300,
+		});
+	}
+
+	it("classifies an OpenAI refusal without exposing refusal content", async () => {
+		const previousFetch = globalThis.fetch;
+		let payload: Record<string, unknown> | null = null;
+		globalThis.fetch = (async (_input, init) => {
+			payload = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return new Response(
+				JSON.stringify({
+					status: "completed",
+					output: [
+						{
+							type: "message",
+							content: [{ type: "refusal", refusal: "sensitive provider text" }],
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof globalThis.fetch;
+		try {
+			const client = directClient("openai");
+			const result = await client.observeStructuredJson("system", "user", "test_schema", {
+				type: "object",
+			});
+			expect(result.failureReason).toBe("structured_output_refused");
+			expect(result.raw).toBeNull();
+			expect(client.getStatus().lastError).toEqual({
+				code: "structured_output_refused",
+				message: "OpenAI structured observer output failed (structured_output_refused).",
+			});
+			expect(payload?.text).toEqual({
+				format: {
+					type: "json_schema",
+					name: "test_schema",
+					schema: { type: "object" },
+					strict: true,
+				},
+			});
+		} finally {
+			globalThis.fetch = previousFetch;
+		}
+	});
+
+	it("classifies Anthropic max_tokens as truncation even when partial text exists", async () => {
+		const previousFetch = globalThis.fetch;
+		let anthropicBeta: string | null = null;
+		let payload: Record<string, unknown> | null = null;
+		globalThis.fetch = (async (input, init) => {
+			anthropicBeta = new Request(input, init).headers.get("anthropic-beta");
+			payload = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return new Response(
+				JSON.stringify({
+					stop_reason: "max_tokens",
+					content: [{ type: "text", text: '{"schema_version":1' }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof globalThis.fetch;
+		try {
+			const client = directClient("anthropic");
+			const result = await client.observeStructuredJson("system", "user", "test_schema", {
+				type: "object",
+			});
+			expect(result.failureReason).toBe("structured_output_truncated");
+			expect(result.raw).toBe('{"schema_version":1');
+			expect(client.getStatus().lastError).toEqual({
+				code: "structured_output_truncated",
+				message: "Anthropic structured observer output failed (structured_output_truncated).",
+			});
+			expect(anthropicBeta).toBeNull();
+			expect(payload?.output_config).toEqual({
+				format: { type: "json_schema", schema: { type: "object" } },
+			});
+		} finally {
+			globalThis.fetch = previousFetch;
+		}
+	});
+
+	it("sends structured Anthropic requests to the explicit Anthropic endpoint", async () => {
+		const previousFetch = globalThis.fetch;
+		const previousEndpoint = process.env.CODEMEM_ANTHROPIC_ENDPOINT;
+		let requestedUrl = "";
+		process.env.CODEMEM_ANTHROPIC_ENDPOINT = "https://anthropic-gateway.example.test/messages";
+		globalThis.fetch = (async (input) => {
+			requestedUrl = String(input);
+			return new Response(
+				JSON.stringify({
+					stop_reason: "end_turn",
+					content: [{ type: "text", text: '{"ok":true}' }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof globalThis.fetch;
+		try {
+			const client = directClient("anthropic");
+			expect(client.hasCustomAnthropicEndpoint).toBe(true);
+			await client.observeStructuredJson("system", "user", "test_schema", { type: "object" });
+			expect(requestedUrl).toBe("https://anthropic-gateway.example.test/messages");
+		} finally {
+			globalThis.fetch = previousFetch;
+			if (previousEndpoint === undefined) delete process.env.CODEMEM_ANTHROPIC_ENDPOINT;
+			else process.env.CODEMEM_ANTHROPIC_ENDPOINT = previousEndpoint;
+		}
+	});
+
+	it("refreshes authentication and retries a structured request once", async () => {
+		const previousFetch = globalThis.fetch;
+		let callCount = 0;
+		globalThis.fetch = (async () => {
+			callCount += 1;
+			if (callCount === 1) return new Response("Unauthorized", { status: 401 });
+			return new Response(JSON.stringify({ status: "completed", output_text: '{"ok":true}' }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as typeof globalThis.fetch;
+		try {
+			const result = await directClient("openai").observeStructuredJson(
+				"system",
+				"user",
+				"test_schema",
+				{ type: "object" },
+			);
+			expect(callCount).toBe(2);
+			expect(result.raw).toBe('{"ok":true}');
+		} finally {
+			globalThis.fetch = previousFetch;
+		}
+	});
+
+	it("preserves transport failure classification for non-success responses", async () => {
+		const previousFetch = globalThis.fetch;
+		globalThis.fetch = (async () =>
+			new Response("limited", { status: 429 })) as typeof globalThis.fetch;
+		try {
+			const client = directClient("openai");
+			const result = await client.observeStructuredJson("system", "user", "test_schema", {
+				type: "object",
+			});
+			expect(result.failureReason).toBeNull();
+			expect(result.transportFailureCode).toBe("rate_limited");
+		} finally {
+			globalThis.fetch = previousFetch;
+		}
+	});
+
+	it("classifies structured response processing failures locally", async () => {
+		const previousFetch = globalThis.fetch;
+		globalThis.fetch = (async () =>
+			new Response("not-json", {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			})) as typeof globalThis.fetch;
+		try {
+			const result = await directClient("openai").observeStructuredJson(
+				"system",
+				"user",
+				"test_schema",
+				{ type: "object" },
+			);
+			expect(result.failureReason).toBeNull();
+			expect(result.transportFailureCode).toBe("observer_call_failed");
+		} finally {
+			globalThis.fetch = previousFetch;
+		}
+	});
+
+	it("applies the configured prompt cap to structured requests", async () => {
+		const previousFetch = globalThis.fetch;
+		let payload: Record<string, unknown> | null = null;
+		globalThis.fetch = (async (_input, init) => {
+			payload = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return new Response(
+				JSON.stringify({
+					status: "completed",
+					output_text: '{"ok":true}',
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof globalThis.fetch;
+		try {
+			const client = directClient("openai");
+			await client.observeStructuredJson("s".repeat(10_000), "u".repeat(10_000), "test_schema", {
+				type: "object",
+			});
+
+			const input = payload?.input as Array<{ content: Array<{ text: string }> }>;
+			const promptLength = input.reduce((sum, message) => sum + message.content[0].text.length, 0);
+			expect(promptLength).toBe(client.maxChars);
+		} finally {
+			globalThis.fetch = previousFetch;
+		}
 	});
 });
 

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -43,6 +43,7 @@ import {
 	stripJsonComments,
 	stripTrailingCommas,
 } from "./observer-config.js";
+import type { ObserverEnvelopeFailureReason } from "./observer-output-schema.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -121,6 +122,7 @@ export interface ObserverConfig {
 	observerRichReasoningSummary?: string | null;
 	observerRichMaxOutputTokens?: number | null;
 	observerOpenAIUseResponses?: boolean;
+	observerOutputMode?: "auto" | "json_schema" | "legacy_xml";
 	observerReasoningEffort?: string | null;
 	observerReasoningSummary?: string | null;
 	observerMaxOutputTokens?: number | null;
@@ -158,6 +160,10 @@ export interface ObserverTokenUsage {
 
 export interface ObserverStructuredJsonResponse extends ObserverResponse {
 	usedStructuredOutputs: boolean;
+	failureReason: ObserverEnvelopeFailureReason | null;
+	transportFailureCode: string | null;
+	/** HTTP status for provider request failures; null for non-HTTP failures. */
+	httpStatus?: number | null;
 }
 
 export interface ObserverStatus {
@@ -243,6 +249,11 @@ const OBSERVER_CONFIG_KEY_MAPPINGS: ObserverConfigKeyMapping[] = [
 		fileKey: "observer_openai_use_responses",
 		envKey: "CODEMEM_OBSERVER_OPENAI_USE_RESPONSES",
 		normalizedKey: "observerOpenAIUseResponses",
+	},
+	{
+		fileKey: "observer_output_mode",
+		envKey: "CODEMEM_OBSERVER_OUTPUT_MODE",
+		normalizedKey: "observerOutputMode",
 	},
 	{
 		fileKey: "observer_reasoning_effort",
@@ -443,6 +454,7 @@ export function loadObserverConfig(): ObserverConfig {
 		observerRichReasoningSummary: null,
 		observerRichMaxOutputTokens: null,
 		observerOpenAIUseResponses: undefined,
+		observerOutputMode: "legacy_xml",
 		observerReasoningEffort: null,
 		observerReasoningSummary: null,
 		observerMaxOutputTokens: null,
@@ -531,6 +543,13 @@ export function loadObserverConfig(): ObserverConfig {
 	if (data.observer_openai_use_responses != null) {
 		cfg.observerOpenAIUseResponses = data.observer_openai_use_responses === true;
 	}
+	if (
+		data.observer_output_mode === "auto" ||
+		data.observer_output_mode === "json_schema" ||
+		data.observer_output_mode === "legacy_xml"
+	) {
+		cfg.observerOutputMode = data.observer_output_mode;
+	}
 	if (typeof data.observer_reasoning_effort === "string") {
 		cfg.observerReasoningEffort = data.observer_reasoning_effort;
 	}
@@ -609,6 +628,10 @@ export function loadObserverConfig(): ObserverConfig {
 		cfg.observerOpenAIUseResponses =
 			process.env.CODEMEM_OBSERVER_OPENAI_USE_RESPONSES === "1" ||
 			process.env.CODEMEM_OBSERVER_OPENAI_USE_RESPONSES === "true";
+	}
+	const outputMode = process.env.CODEMEM_OBSERVER_OUTPUT_MODE;
+	if (outputMode === "auto" || outputMode === "json_schema" || outputMode === "legacy_xml") {
+		cfg.observerOutputMode = outputMode;
 	}
 	cfg.observerReasoningEffort =
 		process.env.CODEMEM_OBSERVER_REASONING_EFFORT ?? cfg.observerReasoningEffort;
@@ -922,6 +945,9 @@ function parseAnthropicResponse(body: Record<string, unknown>): string | null {
 interface ObserverCallResult {
 	raw: string | null;
 	usage: ObserverTokenUsage | null;
+	failureReason?: ObserverEnvelopeFailureReason | null;
+	transportFailureCode?: string | null;
+	httpStatus?: number | null;
 }
 
 function tokenCount(value: unknown): number | null {
@@ -955,7 +981,51 @@ function normalizeObserverUsage(body: Record<string, unknown>): ObserverTokenUsa
 }
 
 function emptyCallResult(raw: string | null): ObserverCallResult {
-	return { raw, usage: null };
+	return { raw, usage: null, failureReason: null, transportFailureCode: null };
+}
+
+function classifyOpenAIResponsesStructuredFailure(
+	body: Record<string, unknown>,
+): ObserverEnvelopeFailureReason | null {
+	if (body.status === "incomplete") {
+		const details = body.incomplete_details;
+		if (
+			typeof details === "object" &&
+			details != null &&
+			(details as Record<string, unknown>).reason === "content_filter"
+		) {
+			return "structured_output_refused";
+		}
+		return "structured_output_truncated";
+	}
+	const output = body.output;
+	if (!Array.isArray(output)) return null;
+	for (const item of output) {
+		if (typeof item !== "object" || item == null) continue;
+		const content = (item as Record<string, unknown>).content;
+		if (!Array.isArray(content)) continue;
+		if (
+			content.some(
+				(block) =>
+					typeof block === "object" &&
+					block != null &&
+					(block as Record<string, unknown>).type === "refusal",
+			)
+		) {
+			return "structured_output_refused";
+		}
+	}
+	return null;
+}
+
+function classifyAnthropicStructuredFailure(
+	body: Record<string, unknown>,
+): ObserverEnvelopeFailureReason | null {
+	if (body.stop_reason === "refusal") return "structured_output_refused";
+	if (body.stop_reason === "max_tokens" || body.stop_reason === "model_context_window_exceeded") {
+		return "structured_output_truncated";
+	}
+	return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -1230,6 +1300,23 @@ function nowMs(): number {
 	return Date.now();
 }
 
+function clipObserverPrompts(
+	systemPrompt: string,
+	userPrompt: string,
+	maxChars: number,
+): { system: string; user: string } {
+	const minUserBudget = Math.floor(maxChars * 0.25);
+	const systemBudget = Math.max(0, maxChars - minUserBudget);
+	const system = (
+		systemPrompt.length > systemBudget ? systemPrompt.slice(0, systemBudget) : systemPrompt
+	).toWellFormed();
+	const userBudget = Math.max(minUserBudget, maxChars - system.length);
+	const user = (
+		userPrompt.length > userBudget ? userPrompt.slice(0, userBudget) : userPrompt
+	).toWellFormed();
+	return { system, user };
+}
+
 // ---------------------------------------------------------------------------
 // ObserverClient
 // ---------------------------------------------------------------------------
@@ -1258,6 +1345,9 @@ export class ObserverClient {
 	readonly richReasoningSummary: string | null;
 	readonly richMaxOutputTokens: number | null;
 	readonly openaiUseResponses: boolean;
+	readonly outputMode: "auto" | "json_schema" | "legacy_xml";
+	readonly hasCustomBaseUrl: boolean;
+	readonly hasCustomAnthropicEndpoint: boolean;
 	readonly reasoningEffort: string | null;
 	readonly reasoningSummary: string | null;
 	readonly maxChars: number;
@@ -1387,8 +1477,14 @@ export class ObserverClient {
 			typeof cfg.observerTemperature === "number" && Number.isFinite(cfg.observerTemperature)
 				? cfg.observerTemperature
 				: 0.2;
-		const hasCustomBaseUrl =
+		const hasConfiguredBaseUrl =
 			typeof cfg.observerBaseUrl === "string" && cfg.observerBaseUrl.trim().length > 0;
+		const hasCustomAnthropicEndpoint =
+			this.provider === "anthropic" &&
+			typeof process.env.CODEMEM_ANTHROPIC_ENDPOINT === "string" &&
+			process.env.CODEMEM_ANTHROPIC_ENDPOINT.trim().length > 0;
+		const hasCustomBaseUrl = hasConfiguredBaseUrl || hasCustomAnthropicEndpoint;
+		this.hasCustomAnthropicEndpoint = hasCustomAnthropicEndpoint;
 		this.tierRoutingEnabled = explicitConfigKeys.has("observerTierRoutingEnabled")
 			? cfg.observerTierRoutingEnabled === true
 			: supportsDefaultTierRouting(this.provider, this.runtime, hasCustomBaseUrl);
@@ -1439,6 +1535,8 @@ export class ObserverClient {
 			this.provider === "openai" && this.runtime === "api_http" && !hasCustomBaseUrl
 				? true
 				: configuredOpenAIUseResponses;
+		this.outputMode = cfg.observerOutputMode ?? "legacy_xml";
+		this.hasCustomBaseUrl = hasCustomBaseUrl;
 		const usesCustomOpenAIChatCompletions =
 			this.provider === "openai" &&
 			this.runtime === "api_http" &&
@@ -1533,6 +1631,7 @@ export class ObserverClient {
 			observerRichReasoningSummary: this.richReasoningSummary,
 			observerRichMaxOutputTokens: this.richMaxOutputTokens,
 			observerOpenAIUseResponses: this.openaiUseResponses,
+			observerOutputMode: this.outputMode,
 			observerReasoningEffort: this.reasoningEffort,
 			observerReasoningSummary: this.reasoningSummary,
 			observerMaxOutputTokens: this.maxOutputTokens,
@@ -1619,47 +1718,34 @@ export class ObserverClient {
 	async observe(systemPrompt: string, userPrompt: string): Promise<ObserverResponse> {
 		const startedAt = nowMs();
 		// Enforce configured prompt-length cap (matches Python behavior)
-		const maxChars = this.maxChars;
-		const minUserBudget = Math.floor(maxChars * 0.25);
-		const systemBudget = Math.max(0, maxChars - minUserBudget);
-		const clippedSystem = (
-			systemPrompt.length > systemBudget ? systemPrompt.slice(0, systemBudget) : systemPrompt
-		).toWellFormed();
-		const userBudget = Math.max(minUserBudget, maxChars - clippedSystem.length);
-		const clippedUser = (
-			userPrompt.length > userBudget ? userPrompt.slice(0, userBudget) : userPrompt
-		).toWellFormed();
+		const clipped = clipObserverPrompts(systemPrompt, userPrompt, this.maxChars);
 
+		if (this.runtime === "claude_sidecar") {
+			this._lastResolvedModel = this._sidecarModel;
+			this._sidecarModelFallbackApplied = false;
+			this._sidecarModelFallbackReason = null;
+		} else if (this.runtime === "codex_sidecar") {
+			this._lastResolvedModel = this._codexSidecarModel;
+			this._codexSidecarModelFallbackApplied = false;
+			this._codexSidecarModelFallbackReason = null;
+		}
+		const call = await this._callWithAuthRetry(() => this._callOnce(clipped.system, clipped.user));
+		if (call.raw) this._clearLastError();
+		return this._buildResponse(call, startedAt);
+	}
+
+	private async _callWithAuthRetry<T>(call: () => Promise<T>): Promise<T> {
 		try {
-			if (this.runtime === "claude_sidecar") {
-				this._lastResolvedModel = this._sidecarModel;
-				this._sidecarModelFallbackApplied = false;
-				this._sidecarModelFallbackReason = null;
-			} else if (this.runtime === "codex_sidecar") {
-				this._lastResolvedModel = this._codexSidecarModel;
-				this._codexSidecarModelFallbackApplied = false;
-				this._codexSidecarModelFallbackReason = null;
+			return await call();
+		} catch (error) {
+			if (!(error instanceof ObserverAuthError)) throw error;
+			this.refreshAuth();
+			if (!this.auth.token) throw error;
+			try {
+				return await call();
+			} catch {
+				throw error;
 			}
-			const call = await this._callOnce(clippedSystem, clippedUser);
-			if (call.raw) this._clearLastError();
-			return this._buildResponse(call, startedAt);
-		} catch (err) {
-			if (err instanceof ObserverAuthError) {
-				// Attempt one auth refresh + retry. Note: for sidecar runtimes
-				// (claude_sidecar / codex_sidecar) auth is delegated to the local CLI
-				// and this.auth.token is always null, so this retry is intentionally a
-				// no-op — the error propagates and the caller backs off.
-				this.refreshAuth();
-				if (!this.auth.token) throw err;
-				try {
-					const call = await this._callOnce(clippedSystem, clippedUser);
-					if (call.raw) this._clearLastError();
-					return this._buildResponse(call, startedAt);
-				} catch {
-					throw err; // re-throw original
-				}
-			}
-			throw err;
 		}
 	}
 
@@ -1693,10 +1779,15 @@ export class ObserverClient {
 		schema: Record<string, unknown>,
 	): Promise<ObserverStructuredJsonResponse> {
 		const startedAt = nowMs();
+		const clipped = clipObserverPrompts(systemPrompt, userPrompt, this.maxChars);
 		if (this.provider === "openai" && this.openaiUseResponses && !this._codexAccess) {
 			if (!this.auth.token && !this.canCallOpenAIDirectWithoutAuth()) {
 				this._initProvider(true);
 				if (!this.auth.token && !this.canCallOpenAIDirectWithoutAuth()) {
+					this._setLastError(
+						"OpenAI observer authentication is not configured.",
+						"observer_auth_missing",
+					);
 					return {
 						raw: null,
 						parsed: null,
@@ -1705,6 +1796,8 @@ export class ObserverClient {
 						elapsedMs: Math.max(0, nowMs() - startedAt),
 						usage: null,
 						usedStructuredOutputs: true,
+						failureReason: null,
+						transportFailureCode: "observer_auth_missing",
 					};
 				}
 			}
@@ -1715,15 +1808,10 @@ export class ObserverClient {
 			} else {
 				url = "https://api.openai.com/v1/responses";
 			}
-			const headers = buildOpenAIHeaders(this.auth.token);
-			const mergedHeaders = mergeHeadersCaseInsensitive(
-				headers,
-				renderObserverHeaders(this._observerHeaders, this.auth),
-			);
 			const payload = buildOpenAIResponsesStructuredPayload(
 				this.model,
-				systemPrompt,
-				userPrompt,
+				clipped.system,
+				clipped.user,
 				this.maxOutputTokens,
 				this.reasoningEffort,
 				this.reasoningSummary,
@@ -1731,10 +1819,19 @@ export class ObserverClient {
 				schemaName,
 				schema,
 			);
-			const call = await this._fetchJSON(url, mergedHeaders, payload, {
-				parseResponse: parseOpenAIResponsesResponse,
-				providerLabel: "OpenAI",
+			const call = await this._callWithAuthRetry(() => {
+				const headers = buildOpenAIHeaders(this.auth.token);
+				const mergedHeaders = mergeHeadersCaseInsensitive(
+					headers,
+					renderObserverHeaders(this._observerHeaders, this.auth),
+				);
+				return this._fetchJSON(url, mergedHeaders, payload, {
+					parseResponse: parseOpenAIResponsesResponse,
+					providerLabel: "OpenAI",
+					classifyStructuredFailure: classifyOpenAIResponsesStructuredFailure,
+				});
 			});
+			if (call.raw && !call.failureReason && !call.transportFailureCode) this._clearLastError();
 			return {
 				raw: call.raw,
 				parsed: call.raw ? tryParseJSON(call.raw) : null,
@@ -1743,6 +1840,11 @@ export class ObserverClient {
 				elapsedMs: Math.max(0, nowMs() - startedAt),
 				usage: call.usage,
 				usedStructuredOutputs: true,
+				failureReason:
+					call.failureReason ??
+					(call.raw || call.transportFailureCode ? null : "structured_output_missing"),
+				transportFailureCode: call.transportFailureCode ?? null,
+				httpStatus: call.httpStatus ?? null,
 			};
 		}
 
@@ -1755,23 +1857,28 @@ export class ObserverClient {
 					this._initProvider(true);
 				}
 				if (this.auth.token) {
-					const headers = buildAnthropicHeaders(this.auth.token, false);
-					const mergedHeaders = mergeHeadersCaseInsensitive(
-						headers,
-						renderObserverHeaders(this._observerHeaders, this.auth),
+					const payload = buildAnthropicStructuredPayload(
+						this.model,
+						clipped.system,
+						clipped.user,
+						this.maxTokens,
+						schema,
 					);
-					const call = await this._fetchJSON(
-						resolveAnthropicEndpoint(),
-						mergedHeaders,
-						buildAnthropicStructuredPayload(
-							this.model,
-							systemPrompt,
-							userPrompt,
-							this.maxTokens,
-							schema,
-						),
-						{ parseResponse: parseAnthropicResponse, providerLabel: "Anthropic" },
-					);
+					const call = await this._callWithAuthRetry(() => {
+						const headers = buildAnthropicHeaders(this.auth.token ?? "", false);
+						const mergedHeaders = mergeHeadersCaseInsensitive(
+							headers,
+							renderObserverHeaders(this._observerHeaders, this.auth),
+						);
+						return this._fetchJSON(resolveAnthropicEndpoint(), mergedHeaders, payload, {
+							parseResponse: parseAnthropicResponse,
+							providerLabel: "Anthropic",
+							classifyStructuredFailure: classifyAnthropicStructuredFailure,
+						});
+					});
+					if (call.raw && !call.failureReason && !call.transportFailureCode) {
+						this._clearLastError();
+					}
 					return {
 						raw: call.raw,
 						parsed: call.raw ? tryParseJSON(call.raw) : null,
@@ -1780,8 +1887,28 @@ export class ObserverClient {
 						elapsedMs: Math.max(0, nowMs() - startedAt),
 						usage: call.usage,
 						usedStructuredOutputs: true,
+						failureReason:
+							call.failureReason ??
+							(call.raw || call.transportFailureCode ? null : "structured_output_missing"),
+						transportFailureCode: call.transportFailureCode ?? null,
+						httpStatus: call.httpStatus ?? null,
 					};
 				}
+				this._setLastError(
+					"Anthropic observer authentication is not configured.",
+					"observer_auth_missing",
+				);
+				return {
+					raw: null,
+					parsed: null,
+					provider: this.provider,
+					model: this.model,
+					elapsedMs: Math.max(0, nowMs() - startedAt),
+					usage: null,
+					usedStructuredOutputs: true,
+					failureReason: null,
+					transportFailureCode: "observer_auth_missing",
+				};
 			}
 			// OAuth or no token — fall through to observe() fallback below
 		}
@@ -1795,6 +1922,8 @@ export class ObserverClient {
 			elapsedMs: Math.max(0, nowMs() - startedAt),
 			usage: fallback.usage,
 			usedStructuredOutputs: false,
+			failureReason: null,
+			transportFailureCode: null,
 		};
 	}
 
@@ -2507,6 +2636,9 @@ export class ObserverClient {
 		opts: {
 			parseResponse: (body: Record<string, unknown>) => string | null;
 			providerLabel: string;
+			classifyStructuredFailure?: (
+				body: Record<string, unknown>,
+			) => ObserverEnvelopeFailureReason | null;
 		},
 	): Promise<ObserverCallResult> {
 		try {
@@ -2519,26 +2651,53 @@ export class ObserverClient {
 
 			if (!response.ok) {
 				const errorText = await response.text().catch(() => "");
-				this._handleHttpError(response.status, errorText, opts.providerLabel);
-				return emptyCallResult(null);
+				const transportFailureCode = this._handleHttpError(
+					response.status,
+					errorText,
+					opts.providerLabel,
+				);
+				return {
+					...emptyCallResult(null),
+					transportFailureCode,
+					httpStatus: response.status,
+				};
 			}
 
 			const body = (await response.json()) as Record<string, unknown>;
+			const failureReason = opts.classifyStructuredFailure?.(body) ?? null;
 			const result = opts.parseResponse(body);
-			if (result === null) {
+			if (failureReason) {
 				this._setLastError(
-					`${opts.providerLabel} returned 200 but response contained no extractable text.`,
-					"empty_response",
+					`${opts.providerLabel} structured observer output failed (${failureReason}).`,
+					failureReason,
+				);
+			} else if (result === null) {
+				const structured = opts.classifyStructuredFailure != null;
+				this._setLastError(
+					structured
+						? `${opts.providerLabel} structured observer output was missing.`
+						: `${opts.providerLabel} returned 200 but response contained no extractable text.`,
+					structured ? "structured_output_missing" : "empty_response",
 				);
 			}
-			return { raw: result, usage: normalizeObserverUsage(body) };
+			return {
+				raw: result,
+				usage: normalizeObserverUsage(body),
+				failureReason,
+				transportFailureCode: null,
+				httpStatus: null,
+			};
 		} catch (err) {
 			if (err instanceof ObserverAuthError) throw err;
 			this._setLastError(
 				`${opts.providerLabel} processing failed during observer inference.`,
 				"observer_call_failed",
 			);
-			return emptyCallResult(null);
+			return {
+				...emptyCallResult(null),
+				transportFailureCode: "observer_call_failed",
+				httpStatus: null,
+			};
 		}
 	}
 
@@ -2593,7 +2752,7 @@ export class ObserverClient {
 	// Error handling
 	// -----------------------------------------------------------------------
 
-	private _handleHttpError(status: number, errorText: string, providerLabel: string): void {
+	private _handleHttpError(status: number, errorText: string, providerLabel: string): string {
 		const summary = redactText(errorText);
 
 		if (isAuthStatus(status)) {
@@ -2606,7 +2765,7 @@ export class ObserverClient {
 
 		if (status === 429) {
 			this._setLastError(`${providerLabel} rate limited. Retry later.`, "rate_limited");
-			return;
+			return "rate_limited";
 		}
 
 		// Check for model-not-found in Anthropic error responses
@@ -2622,7 +2781,7 @@ export class ObserverClient {
 							`${providerLabel} model ID not found: ${message.split(":")[1]?.trim() ?? this.model}.`,
 							"invalid_model_id",
 						);
-						return;
+						return "invalid_model_id";
 					}
 				}
 			} catch {
@@ -2631,6 +2790,7 @@ export class ObserverClient {
 		}
 
 		this._setLastError(`${providerLabel} request failed (${status}).`, "provider_request_failed");
+		return "provider_request_failed";
 	}
 
 	private _setLastError(message: string, code?: string): void {

--- a/packages/core/src/observer-config.ts
+++ b/packages/core/src/observer-config.ts
@@ -199,6 +199,7 @@ export const CODEMEM_CONFIG_ENV_OVERRIDES: Record<string, string> = {
 	observer_rich_reasoning_effort: "CODEMEM_OBSERVER_RICH_REASONING_EFFORT",
 	observer_rich_reasoning_summary: "CODEMEM_OBSERVER_RICH_REASONING_SUMMARY",
 	observer_rich_max_output_tokens: "CODEMEM_OBSERVER_RICH_MAX_OUTPUT_TOKENS",
+	observer_output_mode: "CODEMEM_OBSERVER_OUTPUT_MODE",
 	observer_base_url: "CODEMEM_OBSERVER_BASE_URL",
 	observer_runtime: "CODEMEM_OBSERVER_RUNTIME",
 	observer_auth_source: "CODEMEM_OBSERVER_AUTH_SOURCE",

--- a/packages/core/src/observer-output-schema.test.ts
+++ b/packages/core/src/observer-output-schema.test.ts
@@ -135,6 +135,7 @@ describe("observer envelope v1", () => {
 			          "additionalProperties": false,
 			          "properties": {
 			            "completed": {
+			              "description": "Work completed and concrete outcomes.",
 			              "type": "string",
 			            },
 			            "files_modified": {
@@ -150,18 +151,23 @@ describe("observer envelope v1", () => {
 			              "type": "array",
 			            },
 			            "investigated": {
+			              "description": "What was examined or attempted.",
 			              "type": "string",
 			            },
 			            "learned": {
+			              "description": "Durable discoveries from the session.",
 			              "type": "string",
 			            },
 			            "next_steps": {
+			              "description": "Remaining work, blockers, and next actions.",
 			              "type": "string",
 			            },
 			            "notes": {
+			              "description": "Relevant decisions, trade-offs, or warnings.",
 			              "type": "string",
 			            },
 			            "request": {
+			              "description": "The user's request and session goal.",
 			              "type": "string",
 			            },
 			          },
@@ -302,26 +308,18 @@ describe("observer envelope failures", () => {
 			},
 		],
 		[
-			"too many concepts",
-			{
-				...validCapture(),
-				observations: [
-					{
-						...validCapture().observations[0],
-						concepts: Array.from({ length: OBSERVER_OUTPUT_LIMITS.concepts + 1 }, () => "gotcha"),
-					},
-				],
-			},
-		],
-		[
 			"empty skip reason",
 			{ ...validCapture(), status: "skipped", observations: [], skip_reason: " " },
+		],
+		[
+			"unsupported skip reason",
+			{ ...validCapture(), status: "skipped", observations: [], skip_reason: "other" },
 		],
 	])("rejects %s", (_name, value) => {
 		expect(validateObserverEnvelopeV1(value).ok).toBe(false);
 	});
 
-	it("rejects oversized strings and arrays", () => {
+	it("rejects provider-valid output with local size overages", () => {
 		const value = validCapture();
 		value.observations[0].title = "x".repeat(OBSERVER_OUTPUT_LIMITS.textCharacters + 1);
 		value.observations[0].facts = Array.from(
@@ -329,14 +327,64 @@ describe("observer envelope failures", () => {
 			() => "fact",
 		);
 		const result = validateObserverEnvelopeV1(value);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.issues).toEqual(
-			expect.arrayContaining([
-				expect.stringContaining("title exceeds"),
-				expect.stringContaining("facts exceeds"),
-			]),
+		expect(result).toMatchObject({
+			ok: false,
+			reason: "structured_output_schema_invalid",
+		});
+	});
+
+	it("rejects observation-count overages before normalization", () => {
+		const value = validCapture();
+		value.observations = Array.from(
+			{ length: OBSERVER_OUTPUT_LIMITS.observations + 1 },
+			(_, index) => ({
+				...validCapture().observations[0],
+				title: `${index}${"x".repeat(OBSERVER_OUTPUT_LIMITS.textCharacters)}`,
+				facts: Array.from({ length: OBSERVER_OUTPUT_LIMITS.listItems + 1 }, () => "fact"),
+				concepts: Array.from({ length: OBSERVER_OUTPUT_LIMITS.concepts + 1 }, () => "gotcha"),
+			}),
 		);
+		const result = validateObserverEnvelopeV1(value);
+		expect(result).toMatchObject({
+			ok: false,
+			reason: "structured_output_schema_invalid",
+		});
+	});
+
+	it("keeps clipped text well-formed at a surrogate-pair boundary", () => {
+		const value = validCapture();
+		value.observations[0].title = `${"x".repeat(OBSERVER_OUTPUT_LIMITS.textCharacters - 1)}💾`;
+		const title = normalizeObserverEnvelopeV1(value).observations[0]?.title;
+		expect(title).toBe(`${"x".repeat(OBSERVER_OUTPUT_LIMITS.textCharacters - 1)}�`);
+		expect(title?.isWellFormed()).toBe(true);
+	});
+});
+
+describe("observer envelope persistability", () => {
+	it("rejects captured output with no persistable content", () => {
+		const emptySummary = {
+			request: "",
+			investigated: "",
+			learned: "",
+			completed: "",
+			next_steps: "",
+			notes: "",
+			files_read: [],
+			files_modified: [],
+		};
+		const emptyObservation = {
+			...validCapture().observations[0],
+			title: "",
+			narrative: "",
+		};
+
+		expect(
+			validateObserverEnvelopeV1({
+				...validCapture(),
+				observations: [emptyObservation],
+				summary: emptySummary,
+			}),
+		).toMatchObject({ ok: false, reason: "structured_output_schema_invalid" });
 	});
 
 	it("classifies invalid JSON separately from schema failures", () => {

--- a/packages/core/src/observer-output-schema.ts
+++ b/packages/core/src/observer-output-schema.ts
@@ -57,13 +57,13 @@ export type ObserverEnvelopeParseResult =
 	| { ok: true; envelope: ObserverEnvelopeV1 }
 	| { ok: false; reason: ObserverEnvelopeFailureReason; issues: string[] };
 
-const boundedStringSchema = {
+const stringSchema = {
 	type: "string",
 } as const;
 
-const boundedStringArraySchema = {
+const stringArraySchema = {
 	type: "array",
-	items: boundedStringSchema,
+	items: stringSchema,
 } as const;
 
 const observationSchema = {
@@ -71,16 +71,16 @@ const observationSchema = {
 	additionalProperties: false,
 	properties: {
 		kind: { type: "string", enum: [...REMEMBER_MEMORY_KINDS] },
-		title: boundedStringSchema,
-		narrative: boundedStringSchema,
+		title: stringSchema,
+		narrative: stringSchema,
 		subtitle: { type: ["string", "null"] },
-		facts: boundedStringArraySchema,
+		facts: stringArraySchema,
 		concepts: {
 			type: "array",
-			items: { ...boundedStringSchema, enum: [...OBSERVER_CONCEPTS] },
+			items: { ...stringSchema, enum: [...OBSERVER_CONCEPTS] },
 		},
-		files_read: boundedStringArraySchema,
-		files_modified: boundedStringArraySchema,
+		files_read: stringArraySchema,
+		files_modified: stringArraySchema,
 	},
 	required: [
 		"kind",
@@ -98,14 +98,17 @@ const summarySchema = {
 	type: "object",
 	additionalProperties: false,
 	properties: {
-		request: boundedStringSchema,
-		investigated: boundedStringSchema,
-		learned: boundedStringSchema,
-		completed: boundedStringSchema,
-		next_steps: boundedStringSchema,
-		notes: boundedStringSchema,
-		files_read: boundedStringArraySchema,
-		files_modified: boundedStringArraySchema,
+		request: { ...stringSchema, description: "The user's request and session goal." },
+		investigated: { ...stringSchema, description: "What was examined or attempted." },
+		learned: { ...stringSchema, description: "Durable discoveries from the session." },
+		completed: { ...stringSchema, description: "Work completed and concrete outcomes." },
+		next_steps: {
+			...stringSchema,
+			description: "Remaining work, blockers, and next actions.",
+		},
+		notes: { ...stringSchema, description: "Relevant decisions, trade-offs, or warnings." },
+		files_read: stringArraySchema,
+		files_modified: stringArraySchema,
 	},
 	required: [
 		"request",
@@ -187,8 +190,7 @@ function validateString(value: unknown, path: string, issues: string[]): value i
 		return false;
 	}
 	if (value.length > OBSERVER_OUTPUT_LIMITS.textCharacters) {
-		issues.push(`${path} exceeds ${OBSERVER_OUTPUT_LIMITS.textCharacters} characters`);
-		return false;
+		issues.push(`${path} must contain at most ${OBSERVER_OUTPUT_LIMITS.textCharacters} characters`);
 	}
 	return true;
 }
@@ -197,14 +199,16 @@ function validateStringArray(
 	value: unknown,
 	path: string,
 	issues: string[],
-	options: { maxItems?: number; allowed?: ReadonlySet<string> } = {},
+	options: { allowed?: ReadonlySet<string>; maxItems?: number } = {},
 ): void {
 	if (!Array.isArray(value)) {
 		issues.push(`${path} must be an array`);
 		return;
 	}
 	const maxItems = options.maxItems ?? OBSERVER_OUTPUT_LIMITS.listItems;
-	if (value.length > maxItems) issues.push(`${path} exceeds ${maxItems} items`);
+	if (value.length > maxItems) {
+		issues.push(`${path} must contain at most ${maxItems} items`);
+	}
 	for (const [index, item] of value.entries()) {
 		if (!validateString(item, `${path}[${index}]`, issues)) continue;
 		if (options.allowed && !options.allowed.has(item)) {
@@ -231,8 +235,8 @@ function validateObservation(value: unknown, index: number, issues: string[]): v
 	if (value.subtitle !== null) validateString(value.subtitle, `${path}.subtitle`, issues);
 	validateStringArray(value.facts, `${path}.facts`, issues);
 	validateStringArray(value.concepts, `${path}.concepts`, issues, {
-		maxItems: OBSERVER_OUTPUT_LIMITS.concepts,
 		allowed: new Set(OBSERVER_CONCEPTS),
+		maxItems: OBSERVER_OUTPUT_LIMITS.concepts,
 	});
 	validateStringArray(value.files_read, `${path}.files_read`, issues);
 	validateStringArray(value.files_modified, `${path}.files_modified`, issues);
@@ -265,7 +269,9 @@ function validateEnvelopeFields(value: Record<string, unknown>, issues: string[]
 		issues.push("$.observations must be an array");
 	} else {
 		if (value.observations.length > OBSERVER_OUTPUT_LIMITS.observations) {
-			issues.push(`$.observations exceeds ${OBSERVER_OUTPUT_LIMITS.observations} items`);
+			issues.push(
+				`$.observations must contain at most ${OBSERVER_OUTPUT_LIMITS.observations} items`,
+			);
 		}
 		value.observations.forEach((observation, index) => {
 			validateObservation(observation, index, issues);
@@ -280,11 +286,22 @@ function validateEnvelopeState(value: Record<string, unknown>, issues: string[])
 		if (value.skip_reason !== null) {
 			issues.push("$.skip_reason must be null when status is captured");
 		}
-		if (
+		const hasPersistableObservation =
 			Array.isArray(value.observations) &&
-			value.observations.length === 0 &&
-			value.summary === null
-		) {
+			value.observations.some(
+				(observation) =>
+					isRecord(observation) &&
+					((typeof observation.title === "string" && observation.title.trim().length > 0) ||
+						(typeof observation.narrative === "string" && observation.narrative.trim().length > 0)),
+			);
+		const summary = isRecord(value.summary) ? value.summary : null;
+		const hasPersistableSummary =
+			summary !== null &&
+			["request", "investigated", "learned", "completed", "next_steps", "notes"].some((key) => {
+				const text = summary[key];
+				return typeof text === "string" && text.trim().length > 0;
+			});
+		if (!hasPersistableObservation && !hasPersistableSummary) {
 			issues.push("captured output must contain observations or a summary");
 		}
 		return;
@@ -294,8 +311,8 @@ function validateEnvelopeState(value: Record<string, unknown>, issues: string[])
 		issues.push("$.observations must be empty when status is skipped");
 	}
 	if (value.summary !== null) issues.push("$.summary must be null when status is skipped");
-	if (typeof value.skip_reason !== "string" || value.skip_reason.trim().length === 0) {
-		issues.push("$.skip_reason must be non-empty when status is skipped");
+	if (value.skip_reason !== "low-signal") {
+		issues.push('$.skip_reason must equal "low-signal" when status is skipped');
 	}
 }
 
@@ -333,28 +350,41 @@ export function parseObserverEnvelopeV1(raw: string): ObserverEnvelopeParseResul
 	return validateObserverEnvelopeV1(value);
 }
 
+function clampText(value: string): string {
+	return value.slice(0, OBSERVER_OUTPUT_LIMITS.textCharacters).toWellFormed();
+}
+
+function clampList(
+	values: string[],
+	maxItems: number = OBSERVER_OUTPUT_LIMITS.listItems,
+): string[] {
+	return values.slice(0, maxItems).map(clampText);
+}
+
 export function normalizeObserverEnvelopeV1(envelope: ObserverEnvelopeV1): ParsedOutput {
 	return {
-		observations: envelope.observations.map((observation) => ({
-			kind: observation.kind,
-			title: observation.title,
-			narrative: observation.narrative,
-			subtitle: observation.subtitle,
-			facts: [...observation.facts],
-			concepts: [...new Set(observation.concepts)],
-			filesRead: [...observation.files_read],
-			filesModified: [...observation.files_modified],
-		})),
+		observations: envelope.observations
+			.slice(0, OBSERVER_OUTPUT_LIMITS.observations)
+			.map((observation) => ({
+				kind: observation.kind,
+				title: clampText(observation.title),
+				narrative: clampText(observation.narrative),
+				subtitle: observation.subtitle === null ? null : clampText(observation.subtitle),
+				facts: clampList(observation.facts),
+				concepts: clampList([...new Set(observation.concepts)], OBSERVER_OUTPUT_LIMITS.concepts),
+				filesRead: clampList(observation.files_read),
+				filesModified: clampList(observation.files_modified),
+			})),
 		summary: envelope.summary
 			? {
-					request: envelope.summary.request,
-					investigated: envelope.summary.investigated,
-					learned: envelope.summary.learned,
-					completed: envelope.summary.completed,
-					nextSteps: envelope.summary.next_steps,
-					notes: envelope.summary.notes,
-					filesRead: [...envelope.summary.files_read],
-					filesModified: [...envelope.summary.files_modified],
+					request: clampText(envelope.summary.request),
+					investigated: clampText(envelope.summary.investigated),
+					learned: clampText(envelope.summary.learned),
+					completed: clampText(envelope.summary.completed),
+					nextSteps: clampText(envelope.summary.next_steps),
+					notes: clampText(envelope.summary.notes),
+					filesRead: clampList(envelope.summary.files_read),
+					filesModified: clampList(envelope.summary.files_modified),
 				}
 			: null,
 		skipSummaryReason: envelope.status === "skipped" ? envelope.skip_reason : null,

--- a/packages/core/src/observer-output.test.ts
+++ b/packages/core/src/observer-output.test.ts
@@ -1,0 +1,471 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ObserverClient, ObserverStatus } from "./observer-client.js";
+import {
+	type ObserverOutputError,
+	observeAndNormalizeObserverOutput,
+	observerOutputMetadata,
+	resolveObserverOutputCapability,
+} from "./observer-output.js";
+
+const status = (overrides: Partial<ObserverStatus> = {}): ObserverStatus => ({
+	provider: "openai",
+	model: "test-model",
+	runtime: "api_http",
+	auth: { source: "test", type: "api_direct", hasToken: true },
+	...overrides,
+});
+
+function fakeObserver(
+	overrides: Partial<ObserverClient> & {
+		status?: ObserverStatus;
+		structuredRaw?: string | null;
+		structuredFailure?: ObserverOutputError["reason"] | null;
+		transportFailureCode?: string | null;
+		httpStatus?: number | null;
+	} = {},
+): ObserverClient {
+	const observerStatus = overrides.status ?? status();
+	return {
+		provider: observerStatus.provider,
+		model: observerStatus.model,
+		runtime: observerStatus.runtime,
+		openaiUseResponses: true,
+		outputMode: "auto",
+		hasCustomBaseUrl: false,
+		maxChars: 12_000,
+		getStatus: () => observerStatus,
+		observe: vi.fn(async () => ({
+			raw: null,
+			parsed: null,
+			provider: observerStatus.provider,
+			model: observerStatus.model,
+			elapsedMs: 2,
+			usage: null,
+		})),
+		observeStructuredJson: vi.fn(async () => ({
+			raw: overrides.structuredRaw ?? null,
+			parsed: null,
+			provider: observerStatus.provider,
+			model: observerStatus.model,
+			elapsedMs: 3,
+			usage: null,
+			usedStructuredOutputs: true,
+			failureReason: overrides.structuredFailure ?? null,
+			transportFailureCode: overrides.transportFailureCode ?? null,
+			httpStatus: overrides.httpStatus ?? null,
+		})),
+		...overrides,
+	} as unknown as ObserverClient;
+}
+
+const capturedEnvelope = JSON.stringify({
+	schema_version: 1,
+	status: "captured",
+	observations: [
+		{
+			kind: "decision",
+			title: "Use schema output",
+			narrative: "The observer now uses a versioned envelope.",
+			subtitle: null,
+			facts: ["The schema version is one."],
+			concepts: ["what-changed"],
+			files_read: [],
+			files_modified: ["packages/core/src/observer-output.ts"],
+		},
+	],
+	summary: null,
+	skip_reason: null,
+});
+
+describe("resolveObserverOutputCapability", () => {
+	it("selects native JSON Schema only for proven direct API paths", () => {
+		expect(resolveObserverOutputCapability(fakeObserver()).actualMode).toBe("json_schema");
+
+		const anthropic = fakeObserver({
+			provider: "anthropic",
+			openaiUseResponses: false,
+			status: status({
+				provider: "anthropic",
+				auth: { source: "test", type: "api_direct", hasToken: true },
+			}),
+		});
+		expect(resolveObserverOutputCapability(anthropic)).toEqual(
+			expect.objectContaining({
+				actualMode: "json_schema",
+				capabilityReason: "anthropic_api_key_direct",
+			}),
+		);
+	});
+
+	it("preselects XML for OAuth, sidecars, and unknown custom gateways", () => {
+		const oauth = fakeObserver({
+			status: status({
+				auth: { source: "oauth", type: "codex_consumer", hasToken: true },
+			}),
+		});
+		const sidecar = fakeObserver({
+			runtime: "claude_sidecar",
+			status: status({
+				runtime: "claude_sidecar",
+				auth: { source: "none", type: "claude_sidecar", hasToken: false },
+			}),
+		});
+		const custom = fakeObserver({ hasCustomBaseUrl: true, openaiUseResponses: false });
+
+		expect(resolveObserverOutputCapability(oauth).actualMode).toBe("legacy_xml");
+		expect(resolveObserverOutputCapability(sidecar).actualMode).toBe("legacy_xml");
+		expect(resolveObserverOutputCapability(custom)).toEqual(
+			expect.objectContaining({
+				actualMode: "legacy_xml",
+				fallbackApplied: true,
+				fallbackReason: "unsupported_custom_gateway",
+			}),
+		);
+	});
+
+	it("allows an explicitly Responses-enabled custom gateway to use JSON Schema", () => {
+		const observer = fakeObserver({
+			hasCustomBaseUrl: true,
+			openaiUseResponses: true,
+			outputMode: "json_schema",
+		});
+		expect(resolveObserverOutputCapability(observer)).toEqual(
+			expect.objectContaining({
+				actualMode: "json_schema",
+				fallbackApplied: false,
+				capabilityReason: "configured_custom_gateway_json_schema",
+			}),
+		);
+	});
+
+	it("preselects XML for an Anthropic custom gateway unless JSON Schema is explicit", () => {
+		const observer = fakeObserver({
+			provider: "anthropic",
+			openaiUseResponses: false,
+			hasCustomBaseUrl: true,
+			status: status({
+				provider: "anthropic",
+				auth: { source: "test", type: "api_direct", hasToken: true },
+			}),
+		});
+
+		expect(resolveObserverOutputCapability(observer)).toEqual(
+			expect.objectContaining({
+				actualMode: "legacy_xml",
+				fallbackReason: "unsupported_custom_gateway",
+			}),
+		);
+
+		const explicitObserver = fakeObserver({
+			provider: "anthropic",
+			openaiUseResponses: false,
+			hasCustomBaseUrl: true,
+			hasCustomAnthropicEndpoint: true,
+			outputMode: "json_schema",
+			status: status({
+				provider: "anthropic",
+				auth: { source: "test", type: "api_direct", hasToken: true },
+			}),
+		});
+		expect(resolveObserverOutputCapability(explicitObserver)).toEqual(
+			expect.objectContaining({
+				actualMode: "json_schema",
+				fallbackApplied: false,
+				capabilityReason: "configured_custom_gateway_json_schema",
+			}),
+		);
+	});
+
+	it("supports a configuration-only rollback to legacy XML", () => {
+		const observer = fakeObserver({ outputMode: "legacy_xml" });
+		expect(resolveObserverOutputCapability(observer)).toEqual({
+			requestedMode: "legacy_xml",
+			actualMode: "legacy_xml",
+			capabilityReason: "configured_legacy_xml",
+			fallbackApplied: false,
+			fallbackReason: null,
+		});
+	});
+});
+
+describe("observeAndNormalizeObserverOutput", () => {
+	it("normalizes a valid constrained envelope without XML repair", async () => {
+		const observer = fakeObserver({ structuredRaw: capturedEnvelope });
+		const output = await observeAndNormalizeObserverOutput(observer, "system", "user");
+
+		expect(output.final.parsed.observations).toEqual([
+			expect.objectContaining({
+				kind: "decision",
+				title: "Use schema output",
+				filesModified: ["packages/core/src/observer-output.ts"],
+			}),
+		]);
+		expect(output.diagnostics).toEqual(
+			expect.objectContaining({
+				actualMode: "json_schema",
+				schemaVersion: 1,
+				validation: "valid",
+				repairAttempted: false,
+			}),
+		);
+		expect(observer.observe).not.toHaveBeenCalled();
+	});
+});
+
+describe("observeAndNormalizeObserverOutput failures and compatibility", () => {
+	it.each([
+		"structured_output_refused",
+		"structured_output_truncated",
+		"structured_output_missing",
+	] as const)("fails closed for %s", async (reason) => {
+		const observer = fakeObserver({ structuredFailure: reason });
+		const promise = observeAndNormalizeObserverOutput(observer, "system", "user");
+		await expect(promise).rejects.toMatchObject({
+			name: "ObserverOutputError",
+			reason,
+			diagnostics: { failureReason: reason, validation: "invalid" },
+		});
+		expect(observer.observe).not.toHaveBeenCalled();
+	});
+
+	it("retries a transient transport failure before reporting it", async () => {
+		const observer = fakeObserver({ transportFailureCode: "rate_limited" });
+		const promise = observeAndNormalizeObserverOutput(observer, "system", "user");
+
+		await expect(promise).rejects.toMatchObject({
+			name: "ObserverOutputTransportError",
+			code: "rate_limited",
+		});
+		expect(observer.observeStructuredJson).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not retry deterministic provider request failures", async () => {
+		const observer = fakeObserver({
+			transportFailureCode: "provider_request_failed",
+			httpStatus: 400,
+		});
+
+		await expect(
+			observeAndNormalizeObserverOutput(observer, "system", "user"),
+		).rejects.toMatchObject({
+			name: "ObserverOutputTransportError",
+			code: "provider_request_failed",
+			diagnostics: { retryAttempted: false },
+		});
+		expect(observer.observeStructuredJson).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries transient provider server failures", async () => {
+		const observer = fakeObserver({
+			transportFailureCode: "provider_request_failed",
+			httpStatus: 503,
+		});
+
+		await expect(
+			observeAndNormalizeObserverOutput(observer, "system", "user"),
+		).rejects.toMatchObject({
+			name: "ObserverOutputTransportError",
+			code: "provider_request_failed",
+			diagnostics: {
+				retryAttempted: true,
+				retryReason: "provider_request_failed",
+			},
+		});
+		expect(observer.observeStructuredJson).toHaveBeenCalledTimes(2);
+	});
+
+	it("records a successful transport retry separately from XML repair", async () => {
+		const observeStructuredJson = vi
+			.fn()
+			.mockResolvedValueOnce({
+				raw: null,
+				parsed: null,
+				provider: "openai",
+				model: "test-model",
+				elapsedMs: 2,
+				usage: null,
+				usedStructuredOutputs: true,
+				failureReason: null,
+				transportFailureCode: "rate_limited",
+			})
+			.mockResolvedValueOnce({
+				raw: capturedEnvelope,
+				parsed: null,
+				provider: "openai",
+				model: "test-model",
+				elapsedMs: 3,
+				usage: null,
+				usedStructuredOutputs: true,
+				failureReason: null,
+				transportFailureCode: null,
+			});
+		const output = await observeAndNormalizeObserverOutput(
+			fakeObserver({ observeStructuredJson }),
+			"system",
+			"user",
+		);
+
+		expect(output.repairApplied).toBe(false);
+		expect(output.retryApplied).toBe(true);
+		expect(output.diagnostics).toEqual(
+			expect.objectContaining({
+				repairAttempted: false,
+				retryAttempted: true,
+				retryReason: "rate_limited",
+			}),
+		);
+		expect(observerOutputMetadata(output)).toEqual(
+			expect.objectContaining({
+				observer_output_repair_elapsed_ms: null,
+				observer_output_repair_usage: null,
+				observer_output_retry_elapsed_ms: 3,
+				observer_output_retry_usage: null,
+			}),
+		);
+	});
+
+	it("preserves retry diagnostics and telemetry when the retry output is invalid", async () => {
+		const observeStructuredJson = vi
+			.fn()
+			.mockResolvedValueOnce({
+				raw: null,
+				parsed: null,
+				provider: "openai",
+				model: "test-model",
+				elapsedMs: 2,
+				usage: { inputTokens: 10, outputTokens: 2, totalTokens: 12 },
+				usedStructuredOutputs: true,
+				failureReason: "structured_output_truncated",
+				transportFailureCode: null,
+			})
+			.mockResolvedValueOnce({
+				raw: null,
+				parsed: null,
+				provider: "openai",
+				model: "test-model",
+				elapsedMs: 3,
+				usage: { inputTokens: 8, outputTokens: 1, totalTokens: 9 },
+				usedStructuredOutputs: true,
+				failureReason: "structured_output_refused",
+				transportFailureCode: null,
+			});
+
+		await expect(
+			observeAndNormalizeObserverOutput(fakeObserver({ observeStructuredJson }), "system", "user"),
+		).rejects.toMatchObject({
+			reason: "structured_output_refused",
+			diagnostics: {
+				retryAttempted: true,
+				retryReason: "structured_output_truncated",
+			},
+			telemetry: {
+				totalElapsedMs: 5,
+				totalUsage: { inputTokens: 18, outputTokens: 3, totalTokens: 21 },
+			},
+		});
+	});
+
+	it("classifies invalid JSON without reparsing it as XML", async () => {
+		const observer = fakeObserver({ structuredRaw: "<observation>not json</observation>" });
+		await expect(
+			observeAndNormalizeObserverOutput(observer, "system", "user"),
+		).rejects.toMatchObject({ reason: "structured_output_invalid_json" });
+		expect(observer.observe).not.toHaveBeenCalled();
+	});
+
+	it("classifies schema-invalid JSON without invoking XML repair", async () => {
+		const observer = fakeObserver({
+			structuredRaw: JSON.stringify({ schema_version: 1, status: "captured" }),
+		});
+		await expect(
+			observeAndNormalizeObserverOutput(observer, "system", "user"),
+		).rejects.toMatchObject({ reason: "structured_output_schema_invalid" });
+		expect(observer.observe).not.toHaveBeenCalled();
+	});
+
+	it("keeps legacy XML parsing and repair on the preselected XML path", async () => {
+		const observe = vi
+			.fn()
+			.mockResolvedValueOnce({
+				raw: "<observation><type>note</type><title>Use XML</title></observation>",
+				parsed: null,
+				provider: "openai",
+				model: "test-model",
+				elapsedMs: 2,
+				usage: null,
+			})
+			.mockResolvedValueOnce({
+				raw: "<observation><type>decision</type><title>Use XML</title></observation>",
+				parsed: null,
+				provider: "openai",
+				model: "test-model",
+				elapsedMs: 2,
+				usage: null,
+			});
+		const observer = fakeObserver({ outputMode: "legacy_xml", observe });
+		const output = await observeAndNormalizeObserverOutput(observer, "system", "user");
+
+		expect(observe).toHaveBeenCalledTimes(2);
+		expect(output.repairApplied).toBe(true);
+		expect(output.diagnostics.repairAttempted).toBe(true);
+		expect(output.final.parsed.observations[0]?.title).toBe("Use XML");
+		expect(observerOutputMetadata(output)).toEqual(
+			expect.objectContaining({
+				observer_output_repair_elapsed_ms: 2,
+				observer_output_repair_usage: null,
+				observer_output_retry_elapsed_ms: null,
+				observer_output_retry_usage: null,
+			}),
+		);
+	});
+
+	it("classifies a failed legacy repair without including observer content", async () => {
+		const sensitive = "private observer wording";
+		const observe = vi
+			.fn()
+			.mockResolvedValueOnce({
+				raw: `${sensitive}<observation><type>decision</type><title>Incomplete`,
+				parsed: null,
+				provider: "openai",
+				model: "test-model",
+			})
+			.mockRejectedValueOnce(new Error("repair failed"));
+		const output = await observeAndNormalizeObserverOutput(
+			fakeObserver({ outputMode: "legacy_xml", observe }),
+			"system",
+			"user",
+		);
+
+		expect(output.diagnostics.failureReason).toBe("legacy_xml_lossy");
+		expect(JSON.stringify(observerOutputMetadata(output))).not.toContain(sensitive);
+	});
+
+	it("normalizes equivalent JSON and XML fixtures to the same domain shape", async () => {
+		const jsonOutput = await observeAndNormalizeObserverOutput(
+			fakeObserver({ structuredRaw: capturedEnvelope }),
+			"system",
+			"user",
+		);
+		const xml = `<observation>
+			<type>decision</type>
+			<title>Use schema output</title>
+			<narrative>The observer now uses a versioned envelope.</narrative>
+			<facts><fact>The schema version is one.</fact></facts>
+			<concepts><concept>what-changed</concept></concepts>
+			<files_read></files_read>
+			<files_modified><file>packages/core/src/observer-output.ts</file></files_modified>
+		</observation>`;
+		const xmlObserver = fakeObserver({
+			outputMode: "legacy_xml",
+			observe: vi.fn(async () => ({
+				raw: xml,
+				parsed: null,
+				provider: "openai",
+				model: "test-model",
+			})),
+		});
+		const xmlOutput = await observeAndNormalizeObserverOutput(xmlObserver, "system", "user");
+
+		expect(xmlOutput.final.parsed).toEqual(jsonOutput.final.parsed);
+	});
+});

--- a/packages/core/src/observer-output.ts
+++ b/packages/core/src/observer-output.ts
@@ -1,0 +1,507 @@
+import { buildObserverRepairPrompt } from "./ingest-prompts.js";
+import type { ParsedOutput } from "./ingest-types.js";
+import {
+	parseObserverResponse,
+	shouldPreferRepairedObserverResponse,
+	shouldRepairObserverResponse,
+} from "./ingest-xml-parser.js";
+import type {
+	ObserverClient,
+	ObserverResponse,
+	ObserverStatus,
+	ObserverStructuredJsonResponse,
+	ObserverTokenUsage,
+} from "./observer-client.js";
+import {
+	normalizeObserverEnvelopeV1,
+	OBSERVER_ENVELOPE_JSON_SCHEMA,
+	OBSERVER_ENVELOPE_SCHEMA_NAME,
+	OBSERVER_ENVELOPE_SCHEMA_VERSION,
+	type ObserverEnvelopeFailureReason,
+	parseObserverEnvelopeV1,
+} from "./observer-output-schema.js";
+
+export type ObserverOutputMode = "json_schema" | "forced_tool" | "legacy_xml";
+export type ObserverOutputValidation = "valid" | "invalid" | "not_applicable";
+export type ObserverOutputRetryReason =
+	| "structured_output_truncated"
+	| "rate_limited"
+	| "provider_request_failed"
+	| "observer_call_failed";
+
+export type ObserverOutputCapabilityReason =
+	| "openai_responses_api_direct"
+	| "anthropic_api_key_direct"
+	| "configured_custom_gateway_json_schema"
+	| "configured_legacy_xml"
+	| "client_capability_unspecified"
+	| "unsupported_auth_path"
+	| "unsupported_custom_gateway"
+	| "unsupported_provider"
+	| "unsupported_runtime"
+	| "openai_responses_disabled";
+
+export interface ObserverOutputCapability {
+	requestedMode: ObserverOutputMode;
+	actualMode: Exclude<ObserverOutputMode, "forced_tool">;
+	capabilityReason: ObserverOutputCapabilityReason;
+	fallbackApplied: boolean;
+	fallbackReason: ObserverOutputCapabilityReason | null;
+}
+
+export interface ObserverOutputDiagnostics extends ObserverOutputCapability {
+	schemaVersion: number | null;
+	validation: ObserverOutputValidation;
+	failureReason: ObserverEnvelopeFailureReason | null;
+	repairAttempted: boolean;
+	retryAttempted: boolean;
+	retryReason: ObserverOutputRetryReason | null;
+}
+
+export interface ObserverOutputAttempt {
+	raw: string | null;
+	parsed: ParsedOutput;
+	provider: string;
+	model: string;
+	elapsedMs: number | null;
+	usage: ObserverTokenUsage | null;
+	status: ObserverStatus;
+}
+
+export interface NormalizedObserverOutput {
+	initial: ObserverOutputAttempt;
+	repaired: ObserverOutputAttempt | null;
+	final: ObserverOutputAttempt;
+	repairApplied: boolean;
+	retryApplied: boolean;
+	diagnostics: ObserverOutputDiagnostics;
+}
+
+export interface ObserverOutputFailureTelemetry {
+	totalElapsedMs: number | null;
+	totalUsage: ObserverTokenUsage | null;
+}
+
+export class ObserverOutputError extends Error {
+	readonly reason: ObserverEnvelopeFailureReason;
+	readonly diagnostics: ObserverOutputDiagnostics;
+	readonly telemetry: ObserverOutputFailureTelemetry;
+
+	constructor(
+		reason: ObserverEnvelopeFailureReason,
+		diagnostics: ObserverOutputDiagnostics,
+		telemetry: ObserverOutputFailureTelemetry,
+	) {
+		super(`observer output failed validation (${reason})`);
+		this.name = "ObserverOutputError";
+		this.reason = reason;
+		this.diagnostics = diagnostics;
+		this.telemetry = telemetry;
+	}
+}
+
+export class ObserverOutputTransportError extends Error {
+	readonly code: string;
+	readonly diagnostics: ObserverOutputDiagnostics;
+	readonly telemetry: ObserverOutputFailureTelemetry;
+
+	constructor(
+		code: string,
+		diagnostics: ObserverOutputDiagnostics,
+		telemetry: ObserverOutputFailureTelemetry,
+	) {
+		super(`observer request failed (${code})`);
+		this.name = "ObserverOutputTransportError";
+		this.code = code;
+		this.diagnostics = diagnostics;
+		this.telemetry = telemetry;
+	}
+}
+
+function snapshotObserverStatus(observer: ObserverClient): ObserverStatus {
+	const status = observer.getStatus();
+	return {
+		...status,
+		auth: { ...status.auth },
+		...(status.lastError ? { lastError: { ...status.lastError } } : {}),
+	};
+}
+
+function isDirectOpenAIResponses(observer: ObserverClient, status: ObserverStatus): boolean {
+	if (observer.provider !== "openai" || !observer.openaiUseResponses) return false;
+	if (observer.runtime !== "api_http") return false;
+	if (status.auth.type === "codex_consumer") return false;
+	if (observer.hasCustomBaseUrl) return observer.outputMode === "json_schema";
+	return status.auth.type === "api_direct";
+}
+
+function unsupportedCapabilityReason(
+	observer: ObserverClient,
+	status: ObserverStatus,
+): ObserverOutputCapabilityReason {
+	if (observer.runtime !== "api_http") return "unsupported_runtime";
+	if (status.auth.type === "codex_consumer" || status.auth.type === "anthropic_consumer") {
+		return "unsupported_auth_path";
+	}
+	if (observer.provider !== "openai" && observer.provider !== "anthropic") {
+		return "unsupported_provider";
+	}
+	if (observer.hasCustomBaseUrl && observer.outputMode !== "json_schema") {
+		return "unsupported_custom_gateway";
+	}
+	if (observer.provider === "openai" && !observer.openaiUseResponses) {
+		return "openai_responses_disabled";
+	}
+	return "unsupported_auth_path";
+}
+
+export function resolveObserverOutputCapability(
+	observer: ObserverClient,
+): ObserverOutputCapability {
+	if (observer.outputMode == null) {
+		return {
+			requestedMode: "legacy_xml",
+			actualMode: "legacy_xml",
+			capabilityReason: "client_capability_unspecified",
+			fallbackApplied: false,
+			fallbackReason: null,
+		};
+	}
+	if (observer.outputMode === "legacy_xml") {
+		return {
+			requestedMode: "legacy_xml",
+			actualMode: "legacy_xml",
+			capabilityReason: "configured_legacy_xml",
+			fallbackApplied: false,
+			fallbackReason: null,
+		};
+	}
+
+	const status = observer.getStatus();
+	if (isDirectOpenAIResponses(observer, status)) {
+		const capabilityReason = observer.hasCustomBaseUrl
+			? "configured_custom_gateway_json_schema"
+			: "openai_responses_api_direct";
+		return {
+			requestedMode: "json_schema",
+			actualMode: "json_schema",
+			capabilityReason,
+			fallbackApplied: false,
+			fallbackReason: null,
+		};
+	}
+	if (
+		observer.provider === "anthropic" &&
+		observer.runtime === "api_http" &&
+		status.auth.type === "api_direct" &&
+		(!observer.hasCustomBaseUrl ||
+			(observer.hasCustomAnthropicEndpoint && observer.outputMode === "json_schema"))
+	) {
+		return {
+			requestedMode: "json_schema",
+			actualMode: "json_schema",
+			capabilityReason: observer.hasCustomBaseUrl
+				? "configured_custom_gateway_json_schema"
+				: "anthropic_api_key_direct",
+			fallbackApplied: false,
+			fallbackReason: null,
+		};
+	}
+
+	const reason = unsupportedCapabilityReason(observer, status);
+	return {
+		requestedMode: "json_schema",
+		actualMode: "legacy_xml",
+		capabilityReason: reason,
+		fallbackApplied: true,
+		fallbackReason: reason,
+	};
+}
+
+function emptyParsedOutput(): ParsedOutput {
+	return { observations: [], summary: null, skipSummaryReason: null };
+}
+
+function toAttempt(
+	observer: ObserverClient,
+	response: ObserverResponse,
+	parsed: ParsedOutput,
+): ObserverOutputAttempt {
+	return {
+		raw: response.raw,
+		parsed,
+		provider: response.provider,
+		model: response.model,
+		elapsedMs: response.elapsedMs ?? null,
+		usage: response.usage ?? null,
+		status: snapshotObserverStatus(observer),
+	};
+}
+
+function buildDiagnostics(
+	capability: ObserverOutputCapability,
+	overrides: Partial<
+		Pick<
+			ObserverOutputDiagnostics,
+			"validation" | "failureReason" | "repairAttempted" | "retryAttempted" | "retryReason"
+		>
+	>,
+): ObserverOutputDiagnostics {
+	return {
+		...capability,
+		schemaVersion:
+			capability.actualMode === "json_schema" ? OBSERVER_ENVELOPE_SCHEMA_VERSION : null,
+		validation: overrides.validation ?? "not_applicable",
+		failureReason: overrides.failureReason ?? null,
+		repairAttempted: overrides.repairAttempted ?? false,
+		retryAttempted: overrides.retryAttempted ?? false,
+		retryReason: overrides.retryReason ?? null,
+	};
+}
+
+function observerOutputRetryReason(
+	response: ObserverStructuredJsonResponse,
+): ObserverOutputRetryReason | null {
+	if (response.failureReason === "structured_output_truncated") {
+		return "structured_output_truncated";
+	}
+	if (
+		response.transportFailureCode === "rate_limited" ||
+		response.transportFailureCode === "observer_call_failed"
+	) {
+		return response.transportFailureCode;
+	}
+	if (
+		response.transportFailureCode === "provider_request_failed" &&
+		response.httpStatus != null &&
+		(response.httpStatus === 408 || response.httpStatus === 425 || response.httpStatus >= 500)
+	) {
+		return "provider_request_failed";
+	}
+	return null;
+}
+
+function sumObserverUsage(
+	first: ObserverTokenUsage | null | undefined,
+	second: ObserverTokenUsage | null | undefined,
+): ObserverTokenUsage | null {
+	if (first == null || second === null) return null;
+	if (second === undefined) return { ...first };
+	return {
+		inputTokens: first.inputTokens + second.inputTokens,
+		outputTokens: first.outputTokens + second.outputTokens,
+		totalTokens:
+			(first.totalTokens ?? first.inputTokens + first.outputTokens) +
+			(second.totalTokens ?? second.inputTokens + second.outputTokens),
+		cacheReadInputTokens: (first.cacheReadInputTokens ?? 0) + (second.cacheReadInputTokens ?? 0),
+		cacheCreationInputTokens:
+			(first.cacheCreationInputTokens ?? 0) + (second.cacheCreationInputTokens ?? 0),
+	};
+}
+
+function failureTelemetry(
+	first: ObserverStructuredJsonResponse,
+	second: ObserverStructuredJsonResponse | null,
+): ObserverOutputFailureTelemetry {
+	const secondAttempted = second != null;
+	const totalElapsedMs =
+		first.elapsedMs != null && (!secondAttempted || second.elapsedMs != null)
+			? first.elapsedMs + (second?.elapsedMs ?? 0)
+			: null;
+	return {
+		totalElapsedMs,
+		totalUsage: sumObserverUsage(first.usage, second === null ? undefined : second.usage),
+	};
+}
+
+async function observeJsonSchema(
+	observer: ObserverClient,
+	system: string,
+	user: string,
+	capability: ObserverOutputCapability,
+): Promise<NormalizedObserverOutput> {
+	const invoke = () =>
+		observer.observeStructuredJson(
+			system,
+			user,
+			OBSERVER_ENVELOPE_SCHEMA_NAME,
+			OBSERVER_ENVELOPE_JSON_SCHEMA,
+		);
+	const firstResponse = await invoke();
+	const retryReason = observerOutputRetryReason(firstResponse);
+	const retryResponse = retryReason ? await invoke() : null;
+	const response = retryResponse ?? firstResponse;
+	const retryDiagnostics = {
+		retryAttempted: retryReason != null,
+		retryReason,
+	};
+	const telemetry = failureTelemetry(firstResponse, retryResponse);
+	if (response.transportFailureCode) {
+		throw new ObserverOutputTransportError(
+			response.transportFailureCode,
+			buildDiagnostics(capability, {
+				validation: "invalid",
+				...retryDiagnostics,
+			}),
+			telemetry,
+		);
+	}
+	if (response.failureReason) {
+		throw new ObserverOutputError(
+			response.failureReason,
+			buildDiagnostics(capability, {
+				validation: "invalid",
+				failureReason: response.failureReason,
+				...retryDiagnostics,
+			}),
+			telemetry,
+		);
+	}
+	if (!response.usedStructuredOutputs || response.raw == null) {
+		throw new ObserverOutputError(
+			"structured_output_missing",
+			buildDiagnostics(capability, {
+				validation: "invalid",
+				failureReason: "structured_output_missing",
+				...retryDiagnostics,
+			}),
+			telemetry,
+		);
+	}
+
+	const parsedEnvelope = parseObserverEnvelopeV1(response.raw);
+	if (!parsedEnvelope.ok) {
+		throw new ObserverOutputError(
+			parsedEnvelope.reason,
+			buildDiagnostics(capability, {
+				validation: "invalid",
+				failureReason: parsedEnvelope.reason,
+				...retryDiagnostics,
+			}),
+			telemetry,
+		);
+	}
+
+	const finalAttempt = toAttempt(
+		observer,
+		response,
+		normalizeObserverEnvelopeV1(parsedEnvelope.envelope),
+	);
+	return {
+		initial: retryReason ? toAttempt(observer, firstResponse, emptyParsedOutput()) : finalAttempt,
+		repaired: retryReason ? finalAttempt : null,
+		final: finalAttempt,
+		repairApplied: false,
+		retryApplied: retryReason != null,
+		diagnostics: buildDiagnostics(capability, {
+			validation: "valid",
+			retryAttempted: retryReason != null,
+			retryReason,
+		}),
+	};
+}
+
+async function observeLegacyXml(
+	observer: ObserverClient,
+	system: string,
+	user: string,
+	capability: ObserverOutputCapability,
+): Promise<NormalizedObserverOutput> {
+	const firstResponse = await observer.observe(system, user);
+	const firstParsed = firstResponse.raw
+		? parseObserverResponse(firstResponse.raw)
+		: emptyParsedOutput();
+	const initial = toAttempt(observer, firstResponse, firstParsed);
+	if (!shouldRepairObserverResponse(firstResponse.raw, firstParsed)) {
+		return {
+			initial,
+			repaired: null,
+			final: initial,
+			repairApplied: false,
+			retryApplied: false,
+			diagnostics: buildDiagnostics(capability, {}),
+		};
+	}
+
+	const repairPrompt = buildObserverRepairPrompt(
+		system,
+		user,
+		firstResponse.raw as string,
+		observer.maxChars,
+	);
+	let repairResponse: ObserverResponse;
+	try {
+		repairResponse = await observer.observe(repairPrompt.system, repairPrompt.user);
+	} catch {
+		return {
+			initial,
+			repaired: null,
+			final: initial,
+			repairApplied: false,
+			retryApplied: false,
+			diagnostics: buildDiagnostics(capability, {
+				repairAttempted: true,
+				failureReason: "legacy_xml_lossy",
+			}),
+		};
+	}
+	const repairedParsed = repairResponse.raw
+		? parseObserverResponse(repairResponse.raw)
+		: emptyParsedOutput();
+	const repaired = toAttempt(observer, repairResponse, repairedParsed);
+	const repairApplied = shouldPreferRepairedObserverResponse(
+		firstParsed,
+		repairResponse.raw,
+		repairedParsed,
+		firstResponse.raw,
+	);
+	const final = repairApplied ? repaired : initial;
+	const failureReason = shouldRepairObserverResponse(final.raw, final.parsed)
+		? "legacy_xml_lossy"
+		: null;
+	return {
+		initial,
+		repaired,
+		final,
+		repairApplied,
+		retryApplied: false,
+		diagnostics: buildDiagnostics(capability, { repairAttempted: true, failureReason }),
+	};
+}
+
+export async function observeAndNormalizeObserverOutput(
+	observer: ObserverClient,
+	system: string,
+	user: string,
+	capability = resolveObserverOutputCapability(observer),
+): Promise<NormalizedObserverOutput> {
+	if (capability.actualMode === "json_schema") {
+		return observeJsonSchema(observer, system, user, capability);
+	}
+	return observeLegacyXml(observer, system, user, capability);
+}
+
+export function observerOutputMetadata(output: NormalizedObserverOutput): Record<string, unknown> {
+	const { diagnostics } = output;
+	const repairAttempt = diagnostics.repairAttempted ? output.repaired : null;
+	const retryAttempt = diagnostics.retryAttempted ? output.repaired : null;
+	return {
+		observer_requested_output_mode: diagnostics.requestedMode,
+		observer_output_mode: diagnostics.actualMode,
+		observer_output_schema_version: diagnostics.schemaVersion,
+		observer_output_capability_reason: diagnostics.capabilityReason,
+		observer_output_fallback_applied: diagnostics.fallbackApplied,
+		observer_output_fallback_reason: diagnostics.fallbackReason,
+		observer_output_validation: diagnostics.validation,
+		observer_output_failure_reason: diagnostics.failureReason,
+		observer_output_repair_attempted: diagnostics.repairAttempted,
+		observer_output_retry_attempted: diagnostics.retryAttempted,
+		observer_output_retry_reason: diagnostics.retryReason,
+		observer_output_initial_elapsed_ms: output.initial.elapsedMs,
+		observer_output_initial_usage: output.initial.usage,
+		observer_output_repair_elapsed_ms: repairAttempt?.elapsedMs ?? null,
+		observer_output_repair_usage: repairAttempt?.usage ?? null,
+		observer_output_retry_elapsed_ms: retryAttempt?.elapsedMs ?? null,
+		observer_output_retry_usage: retryAttempt?.usage ?? null,
+	};
+}

--- a/packages/core/src/raw-event-flush.test.ts
+++ b/packages/core/src/raw-event-flush.test.ts
@@ -453,6 +453,63 @@ describe("flushRawEvents max retry", () => {
 		});
 	});
 
+	it("classifies structured transport failures without advancing the cursor", async () => {
+		const sessionId = "ses_structured_transport_failure";
+		seedEvents(sessionId);
+		const structuredObserver = {
+			provider: "openai",
+			runtime: "api_http",
+			openaiUseResponses: true,
+			hasCustomBaseUrl: false,
+			outputMode: "json_schema",
+			maxChars: 12_000,
+			observeStructuredJson: async () => ({
+				raw: null,
+				parsed: null,
+				provider: "openai",
+				model: "test-model",
+				usedStructuredOutputs: true,
+				failureReason: null,
+				transportFailureCode: "rate_limited",
+			}),
+			getStatus: () => ({
+				provider: "openai",
+				model: "test-model",
+				runtime: "api_http",
+				auth: { source: "env", type: "api_direct", hasToken: true },
+				lastError: { code: "rate_limited", message: "Try again later" },
+			}),
+		};
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: null,
+			maxEvents: null,
+		};
+
+		await expect(
+			flushRawEvents(
+				store,
+				{ observer: structuredObserver } as unknown as IngestOptions,
+				flushOpts,
+			),
+		).rejects.toThrow("observer request failed (rate_limited)");
+
+		const batch = store.db
+			.prepare(
+				"SELECT status, error_type, error_message FROM raw_event_flush_batches WHERE opencode_session_id = ?",
+			)
+			.get(sessionId) as { status: string; error_type: string; error_message: string };
+		expect(batch).toEqual({
+			status: "failed",
+			error_type: "ObserverOutputTransportError:rate_limited",
+			error_message: "OpenAI request was rate limited during raw-event processing.",
+		});
+		expect(store.rawEventFlushState(sessionId)).toBe(-1);
+	});
+
 	it("keeps repeated unparseable microbatch output as gave_up", async () => {
 		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "1";
 		const sessionId = "ses_unparseable_microbatch";

--- a/packages/core/src/raw-event-flush.ts
+++ b/packages/core/src/raw-event-flush.ts
@@ -23,6 +23,7 @@ import {
 } from "./ingest-transcript.js";
 import type { IngestPayload, SessionContext } from "./ingest-types.js";
 import { ObserverAuthError } from "./observer-client.js";
+import { ObserverOutputError, ObserverOutputTransportError } from "./observer-output.js";
 import type { MemoryStore } from "./store.js";
 
 const EXTRACTOR_VERSION = "raw_events_v1";
@@ -52,6 +53,26 @@ function providerDisplayName(provider: string | null | undefined): string {
 	return "Observer";
 }
 
+function summarizeObserverOutputFailure(exc: Error, providerTitle: string): string | null {
+	if (exc instanceof ObserverOutputTransportError) {
+		if (exc.code === "rate_limited") {
+			return `${providerTitle} request was rate limited during raw-event processing.`;
+		}
+		if (exc.code === "observer_auth_missing") {
+			return `${providerTitle} authentication is not configured for raw-event processing.`;
+		}
+		return `${providerTitle} request failed during raw-event processing.`;
+	}
+	if (!(exc instanceof ObserverOutputError)) return null;
+	if (exc.reason === "structured_output_refused") {
+		return `${providerTitle} refused the structured raw-event request.`;
+	}
+	if (exc.reason === "structured_output_truncated") {
+		return `${providerTitle} truncated its structured raw-event response.`;
+	}
+	return `${providerTitle} structured response could not be processed.`;
+}
+
 function summarizeFlushFailure(exc: Error, provider: string | null | undefined): string {
 	const providerTitle = providerDisplayName(provider);
 	const rawMessage = String(exc.message ?? "")
@@ -61,6 +82,8 @@ function summarizeFlushFailure(exc: Error, provider: string | null | undefined):
 	if (exc instanceof ObserverAuthError) {
 		return `${providerTitle} authentication failed. Refresh credentials and retry.`;
 	}
+	const observerOutputSummary = summarizeObserverOutputFailure(exc, providerTitle);
+	if (observerOutputSummary) return observerOutputSummary;
 	if (exc.name === "TimeoutError" || rawMessage.includes("timeout")) {
 		return `${providerTitle} request timed out during raw-event processing.`;
 	}
@@ -82,6 +105,8 @@ function summarizeFlushFailure(exc: Error, provider: string | null | undefined):
 function flushFailureErrorType(error: Error): string {
 	if (error instanceof ObserverAuthError) return "ObserverAuthError";
 	if (error instanceof RawEventObserverOutputError) return `${error.name}:${error.reason}`;
+	if (error instanceof ObserverOutputTransportError) return `${error.name}:${error.code}`;
+	if (error instanceof ObserverOutputError) return `${error.name}:${error.reason}`;
 	return error.name;
 }
 


### PR DESCRIPTION
## Description

Routes observer output by proven provider capability, integrates JSON Schema and legacy XML paths into ingest and replay, classifies structured refusals and transport failures, and records safe diagnostics and retry telemetry. Constrained output retries once for truncation or transient transport errors and never falls back to XML after selection.

Operator documentation is included in the next PR in this stack.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced